### PR TITLE
Plan 02: graph file-IO primitives, paths & IPC bindings

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -23,6 +23,7 @@
     "@reflect/db": "workspace:*",
     "@reflect/design-system": "workspace:*",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-opener": "^2",
     "clsx": "^2.1.1",
     "lucide-react": "^1.17.0",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2262,6 +2262,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2736,12 +2737,14 @@ dependencies = [
 name = "reflect-open"
 version = "0.1.0"
 dependencies = [
+ "dirs",
  "rusqlite",
  "serde",
  "serde_json",
  "sqlite-vec",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tempfile",
  "trash",
@@ -2808,6 +2811,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3537,6 +3564,48 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -4729,6 +4798,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4760,11 +4838,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4798,6 +4893,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4808,6 +4909,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4822,10 +4929,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4840,6 +4959,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4850,6 +4975,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4864,6 +4995,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4874,6 +5011,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2743,6 +2743,8 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tempfile",
+ "trash",
 ]
 
 [[package]]
@@ -3385,7 +3387,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -3456,7 +3458,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3555,7 +3557,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -3581,7 +3583,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3606,7 +3608,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -4002,6 +4004,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "trash"
+version = "5.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7602e0c7d66ec2d92a8c917219fbc7894039efa2063b9064260110828a356f46"
+dependencies = [
+ "chrono",
+ "libc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "once_cell",
+ "percent-encoding",
+ "scopeguard",
+ "urlencoding",
+ "windows 0.56.0",
+]
+
+[[package]]
 name = "tray-icon"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4123,6 +4143,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"
@@ -4417,10 +4443,10 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -4441,7 +4467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -4493,6 +4519,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
+dependencies = [
+ "windows-core 0.56.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -4515,12 +4551,24 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+dependencies = [
+ "windows-implement 0.56.0",
+ "windows-interface 0.56.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -4532,8 +4580,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -4552,9 +4600,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4592,6 +4662,15 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4968,7 +5047,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -24,4 +24,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = { version = "0.40.1", features = ["bundled"] }
 sqlite-vec = "0.1.9"
+tempfile = "3.27.0"
+trash = "5.2.6"
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -26,4 +26,6 @@ rusqlite = { version = "0.40.1", features = ["bundled"] }
 sqlite-vec = "0.1.9"
 tempfile = "3.27.0"
 trash = "5.2.6"
+dirs = "6.0.0"
+tauri-plugin-dialog = "2.7.1"
 

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default"
+    "opener:default",
+    "dialog:default"
   ]
 }

--- a/apps/desktop/src-tauri/src/error.rs
+++ b/apps/desktop/src-tauri/src/error.rs
@@ -1,0 +1,71 @@
+//! The shared error contract returned by every `#[tauri::command]`.
+//!
+//! Serializes to `{ "kind": "...", "message": "..." }` — matching the zod
+//! `AppError` discriminated union in `@reflect/core`, so the frontend can branch
+//! on `kind` with a type guard instead of inspecting opaque strings.
+
+use serde::Serialize;
+
+// The enum mirrors the full TS `AppError` contract. Some variants (`Parse`,
+// `Unknown`) are only produced on the TypeScript boundary, so Rust never
+// constructs them — keep them for contract parity.
+#[allow(dead_code)]
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum AppError {
+    /// Filesystem / IO failure.
+    Io { message: String },
+    /// A requested note or file does not exist.
+    NotFound { message: String },
+    /// A path escaped the graph root (security guard).
+    Traversal { message: String },
+    /// An operation needs an open graph but none is set.
+    NoGraph { message: String },
+    /// Parse / validation failure.
+    Parse { message: String },
+    /// Anything not covered above.
+    Unknown { message: String },
+}
+
+impl AppError {
+    pub fn io(message: impl Into<String>) -> Self {
+        Self::Io {
+            message: message.into(),
+        }
+    }
+
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::NotFound {
+            message: message.into(),
+        }
+    }
+
+    pub fn traversal(message: impl Into<String>) -> Self {
+        Self::Traversal {
+            message: message.into(),
+        }
+    }
+
+    pub fn no_graph() -> Self {
+        Self::NoGraph {
+            message: "No graph is open".into(),
+        }
+    }
+}
+
+impl From<std::io::Error> for AppError {
+    fn from(err: std::io::Error) -> Self {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            Self::NotFound {
+                message: err.to_string(),
+            }
+        } else {
+            Self::Io {
+                message: err.to_string(),
+            }
+        }
+    }
+}
+
+/// Result alias for command and helper functions.
+pub type AppResult<T> = Result<T, AppError>;

--- a/apps/desktop/src-tauri/src/fs.rs
+++ b/apps/desktop/src-tauri/src/fs.rs
@@ -54,13 +54,16 @@ pub struct FileMeta {
 
 // ---- internal helpers (unit-tested directly) -------------------------------
 
-/// Reject a relative path that is absolute or contains `..`/root components.
-/// This is the primary path-traversal guard.
+/// Reject a relative path that is absolute, contains `..`/root components, or is
+/// empty/dot-only (which would target the graph root itself). Requires at least
+/// one real path segment. The primary, lexical path-traversal guard.
 fn ensure_relative(rel: &str) -> AppResult<PathBuf> {
     let path = Path::new(rel);
+    let mut has_segment = false;
     for component in path.components() {
         match component {
-            Component::Normal(_) | Component::CurDir => {}
+            Component::Normal(_) => has_segment = true,
+            Component::CurDir => {}
             _ => {
                 return Err(AppError::traversal(format!(
                     "path escapes the graph root: {rel}"
@@ -68,12 +71,43 @@ fn ensure_relative(rel: &str) -> AppResult<PathBuf> {
             }
         }
     }
+    if !has_segment {
+        return Err(AppError::traversal(format!(
+            "path must point to a file inside the graph, got: {rel:?}"
+        )));
+    }
     Ok(path.to_path_buf())
 }
 
-/// Resolve a graph-relative path to an absolute path inside `root`.
+/// The deepest existing ancestor of `path` (the path itself if it exists).
+fn existing_ancestor(path: &Path) -> PathBuf {
+    let mut current = path;
+    loop {
+        if current.exists() {
+            return current.to_path_buf();
+        }
+        match current.parent() {
+            Some(parent) if !parent.as_os_str().is_empty() => current = parent,
+            _ => return path.to_path_buf(),
+        }
+    }
+}
+
+/// Resolve a graph-relative path to an absolute path **inside** `root`. Beyond
+/// the lexical guard, this canonicalizes the deepest existing ancestor and
+/// verifies it stays under the canonicalized root, so a symlink inside the graph
+/// can't redirect reads/writes outside it.
 fn resolve(root: &Path, rel: &str) -> AppResult<PathBuf> {
-    Ok(root.join(ensure_relative(rel)?))
+    let rel = ensure_relative(rel)?;
+    let joined = root.join(&rel);
+    let canonical_root = root.canonicalize()?;
+    let anchor = existing_ancestor(&joined).canonicalize()?;
+    if !anchor.starts_with(&canonical_root) {
+        return Err(AppError::traversal(format!(
+            "path resolves outside the graph: {rel:?}"
+        )));
+    }
+    Ok(joined)
 }
 
 /// Create the standard graph layout + ignore/meta files (idempotent).
@@ -130,20 +164,25 @@ fn collect_markdown(root: &Path, dir: &str, out: &mut Vec<FileMeta>) -> AppResul
     while let Some(current) = stack.pop() {
         for entry in fs::read_dir(&current)? {
             let entry = entry?;
+            // Don't follow symlinks — they can point outside the graph.
+            let file_type = entry.file_type()?;
+            if file_type.is_symlink() {
+                continue;
+            }
             let path = entry.path();
-            if path.is_dir() {
+            if file_type.is_dir() {
                 stack.push(path);
                 continue;
             }
-            if path.extension().and_then(|ext| ext.to_str()) == Some("md") {
+            if file_type.is_file() && path.extension().and_then(|ext| ext.to_str()) == Some("md") {
+                // Skip anything that isn't actually under the root rather than
+                // leaking an absolute path.
+                let Ok(rel) = path.strip_prefix(root) else {
+                    continue;
+                };
                 let meta = entry.metadata()?;
-                let rel = path
-                    .strip_prefix(root)
-                    .unwrap_or(&path)
-                    .to_string_lossy()
-                    .replace('\\', "/");
                 out.push(FileMeta {
-                    path: rel,
+                    path: rel.to_string_lossy().replace('\\', "/"),
                     size: meta.len(),
                     modified_ms: modified_ms(&meta),
                 });
@@ -270,6 +309,33 @@ mod tests {
         assert!(ensure_relative("notes/../../escape.md").is_err());
         assert!(ensure_relative("notes/ok.md").is_ok());
         assert!(ensure_relative("./daily/2026-06-09.md").is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_and_dot_only_paths() {
+        // These would otherwise resolve to the graph root itself.
+        assert!(ensure_relative("").is_err());
+        assert!(ensure_relative(".").is_err());
+        assert!(ensure_relative("./.").is_err());
+    }
+
+    #[test]
+    fn resolve_accepts_in_graph_path() {
+        let dir = tempdir().unwrap();
+        bootstrap(dir.path()).unwrap();
+        assert!(resolve(dir.path(), "notes/ok.md").is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_rejects_symlink_escape() {
+        use std::os::unix::fs::symlink;
+        let outside = tempdir().unwrap();
+        let graph = tempdir().unwrap();
+        bootstrap(graph.path()).unwrap();
+        // A symlink inside the graph pointing out of it.
+        symlink(outside.path(), graph.path().join("notes/escape")).unwrap();
+        assert!(resolve(graph.path(), "notes/escape/evil.md").is_err());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/fs.rs
+++ b/apps/desktop/src-tauri/src/fs.rs
@@ -206,9 +206,14 @@ fn graph_info(root: &Path) -> GraphInfo {
 
 /// Set the active root, record it in recents, and return its info.
 fn activate(state: &State<GraphState>, root: &Path) -> AppResult<GraphInfo> {
-    set_root(state, root)?;
     let info = graph_info(root);
-    crate::recents::record(root, &info.name)?;
+    set_root(state, root)?;
+    // Recents is a convenience cache: a failure to persist it must not fail the
+    // open (which would leave Rust treating the graph as open while the command
+    // returns an error, out of sync with the UI). Best-effort, log and move on.
+    if let Err(err) = crate::recents::record(root, &info.name) {
+        eprintln!("reflect: failed to record recent graph: {err:?}");
+    }
     Ok(info)
 }
 

--- a/apps/desktop/src-tauri/src/fs.rs
+++ b/apps/desktop/src-tauri/src/fs.rs
@@ -1,0 +1,301 @@
+//! Graph file-IO primitives (Plan 02).
+//!
+//! Markdown files are the durable source of truth; this module moves bytes and
+//! paths, not meaning. All paths are **graph-relative** — the graph root lives
+//! in Rust state and the frontend can never address files outside it
+//! (path-traversal guard). Writes are atomic (temp file + rename) and deletes go
+//! to the OS trash. Parsing/indexing live in later plans.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
+use std::sync::Mutex;
+use std::time::UNIX_EPOCH;
+
+use serde::Serialize;
+use tauri::State;
+
+use crate::error::{AppError, AppResult};
+
+const REFLECT_DIR: &str = ".reflect";
+const META_SCHEMA_VERSION: u32 = 1;
+const TOP_LEVEL_DIRS: [&str; 4] = ["daily", "notes", "assets", REFLECT_DIR];
+/// Directories scanned by `list_files` for markdown notes.
+const NOTE_DIRS: [&str; 2] = ["daily", "notes"];
+
+/// Tauri-managed state holding the currently open graph root (absolute path).
+#[derive(Default)]
+pub struct GraphState(pub Mutex<Option<PathBuf>>);
+
+/// Identity of an open graph, returned to the frontend.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphInfo {
+    /// Absolute path of the graph root.
+    pub root: String,
+    /// Display name (the root folder name).
+    pub name: String,
+}
+
+/// Metadata for a file inside the graph.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileMeta {
+    /// Graph-relative path, forward-slashed.
+    pub path: String,
+    pub size: u64,
+    /// Last-modified time in epoch milliseconds.
+    pub modified_ms: u64,
+}
+
+// ---- internal helpers (unit-tested directly) -------------------------------
+
+/// Reject a relative path that is absolute or contains `..`/root components.
+/// This is the primary path-traversal guard.
+fn ensure_relative(rel: &str) -> AppResult<PathBuf> {
+    let path = Path::new(rel);
+    for component in path.components() {
+        match component {
+            Component::Normal(_) | Component::CurDir => {}
+            _ => {
+                return Err(AppError::traversal(format!(
+                    "path escapes the graph root: {rel}"
+                )))
+            }
+        }
+    }
+    Ok(path.to_path_buf())
+}
+
+/// Resolve a graph-relative path to an absolute path inside `root`.
+fn resolve(root: &Path, rel: &str) -> AppResult<PathBuf> {
+    Ok(root.join(ensure_relative(rel)?))
+}
+
+/// Create the standard graph layout + ignore/meta files (idempotent).
+fn bootstrap(root: &Path) -> AppResult<()> {
+    for dir in TOP_LEVEL_DIRS {
+        fs::create_dir_all(root.join(dir))?;
+    }
+    let gitignore = root.join(".gitignore");
+    if !gitignore.exists() {
+        fs::write(
+            &gitignore,
+            "# Reflect local index + caches (rebuildable; never committed)\n/.reflect/\n",
+        )?;
+    }
+    let meta = root.join(REFLECT_DIR).join("meta.json");
+    if !meta.exists() {
+        fs::write(
+            &meta,
+            format!("{{\n  \"schemaVersion\": {META_SCHEMA_VERSION}\n}}\n"),
+        )?;
+    }
+    Ok(())
+}
+
+/// Atomically write `contents` to `target` (temp file in the same dir + rename).
+fn atomic_write(target: &Path, contents: &str) -> AppResult<()> {
+    let dir = target
+        .parent()
+        .ok_or_else(|| AppError::io(format!("no parent directory for {}", target.display())))?;
+    fs::create_dir_all(dir)?;
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
+    tmp.write_all(contents.as_bytes())?;
+    tmp.as_file().sync_all()?;
+    tmp.persist(target)
+        .map_err(|err| AppError::io(err.to_string()))?;
+    Ok(())
+}
+
+fn modified_ms(meta: &fs::Metadata) -> u64 {
+    meta.modified()
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|dur| dur.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Collect markdown files under `root/dir` into `out` (recursive).
+fn collect_markdown(root: &Path, dir: &str, out: &mut Vec<FileMeta>) -> AppResult<()> {
+    let base = root.join(dir);
+    if !base.is_dir() {
+        return Ok(());
+    }
+    let mut stack = vec![base];
+    while let Some(current) = stack.pop() {
+        for entry in fs::read_dir(&current)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().and_then(|ext| ext.to_str()) == Some("md") {
+                let meta = entry.metadata()?;
+                let rel = path
+                    .strip_prefix(root)
+                    .unwrap_or(&path)
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                out.push(FileMeta {
+                    path: rel,
+                    size: meta.len(),
+                    modified_ms: modified_ms(&meta),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn graph_info(root: &Path) -> AppResult<GraphInfo> {
+    let name = root
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    Ok(GraphInfo {
+        root: root.to_string_lossy().into_owned(),
+        name,
+    })
+}
+
+fn current_root(state: &State<GraphState>) -> AppResult<PathBuf> {
+    state
+        .0
+        .lock()
+        .map_err(|_| AppError::io("graph state lock poisoned"))?
+        .clone()
+        .ok_or_else(AppError::no_graph)
+}
+
+fn set_root(state: &State<GraphState>, root: &Path) -> AppResult<()> {
+    let mut guard = state
+        .0
+        .lock()
+        .map_err(|_| AppError::io("graph state lock poisoned"))?;
+    *guard = Some(root.to_path_buf());
+    Ok(())
+}
+
+// ---- commands --------------------------------------------------------------
+
+/// Create a new graph at `path` (scaffolds the layout) and open it.
+#[tauri::command]
+pub fn graph_create(path: String, state: State<GraphState>) -> AppResult<GraphInfo> {
+    let root = PathBuf::from(&path);
+    fs::create_dir_all(&root)?;
+    bootstrap(&root)?;
+    set_root(&state, &root)?;
+    graph_info(&root)
+}
+
+/// Open an existing graph at `path`, ensuring the standard layout exists.
+#[tauri::command]
+pub fn graph_open(path: String, state: State<GraphState>) -> AppResult<GraphInfo> {
+    let root = PathBuf::from(&path);
+    if !root.is_dir() {
+        return Err(AppError::not_found(format!("not a directory: {path}")));
+    }
+    bootstrap(&root)?;
+    set_root(&state, &root)?;
+    graph_info(&root)
+}
+
+/// Read a note's markdown by graph-relative path.
+#[tauri::command]
+pub fn note_read(path: String, state: State<GraphState>) -> AppResult<String> {
+    let root = current_root(&state)?;
+    Ok(fs::read_to_string(resolve(&root, &path)?)?)
+}
+
+/// Atomically write a note's markdown by graph-relative path.
+#[tauri::command]
+pub fn note_write(path: String, contents: String, state: State<GraphState>) -> AppResult<()> {
+    let root = current_root(&state)?;
+    atomic_write(&resolve(&root, &path)?, &contents)
+}
+
+/// Move/rename a note within the graph.
+#[tauri::command]
+pub fn note_move(from: String, to: String, state: State<GraphState>) -> AppResult<()> {
+    let root = current_root(&state)?;
+    let to_abs = resolve(&root, &to)?;
+    if let Some(parent) = to_abs.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::rename(resolve(&root, &from)?, to_abs)?;
+    Ok(())
+}
+
+/// Send a note to the OS trash (recoverable), not a hard delete.
+#[tauri::command]
+pub fn note_delete(path: String, state: State<GraphState>) -> AppResult<()> {
+    let root = current_root(&state)?;
+    trash::delete(resolve(&root, &path)?).map_err(|err| AppError::io(err.to_string()))?;
+    Ok(())
+}
+
+/// List markdown notes under `daily/` and `notes/`.
+#[tauri::command]
+pub fn list_files(state: State<GraphState>) -> AppResult<Vec<FileMeta>> {
+    let root = current_root(&state)?;
+    let mut out = Vec::new();
+    for dir in NOTE_DIRS {
+        collect_markdown(&root, dir, &mut out)?;
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn rejects_path_traversal() {
+        assert!(ensure_relative("../secret").is_err());
+        assert!(ensure_relative("/etc/passwd").is_err());
+        assert!(ensure_relative("notes/../../escape.md").is_err());
+        assert!(ensure_relative("notes/ok.md").is_ok());
+        assert!(ensure_relative("./daily/2026-06-09.md").is_ok());
+    }
+
+    #[test]
+    fn bootstrap_creates_layout() {
+        let dir = tempdir().unwrap();
+        bootstrap(dir.path()).unwrap();
+        for sub in TOP_LEVEL_DIRS {
+            assert!(dir.path().join(sub).is_dir(), "missing dir {sub}");
+        }
+        assert!(dir.path().join(".gitignore").exists());
+        assert!(dir.path().join(".reflect/meta.json").exists());
+    }
+
+    #[test]
+    fn atomic_write_round_trips() {
+        let dir = tempdir().unwrap();
+        bootstrap(dir.path()).unwrap();
+        let target = dir.path().join("notes/hello.md");
+        atomic_write(&target, "# Hello\n\nworld\n").unwrap();
+        assert_eq!(fs::read_to_string(&target).unwrap(), "# Hello\n\nworld\n");
+    }
+
+    #[test]
+    fn list_finds_only_markdown_under_note_dirs() {
+        let dir = tempdir().unwrap();
+        bootstrap(dir.path()).unwrap();
+        atomic_write(&dir.path().join("notes/a.md"), "a").unwrap();
+        atomic_write(&dir.path().join("daily/2026-06-09.md"), "b").unwrap();
+        atomic_write(&dir.path().join("notes/skip.txt"), "c").unwrap();
+
+        let mut out = Vec::new();
+        for d in NOTE_DIRS {
+            collect_markdown(dir.path(), d, &mut out).unwrap();
+        }
+        let paths: Vec<&str> = out.iter().map(|f| f.path.as_str()).collect();
+        assert!(paths.contains(&"notes/a.md"));
+        assert!(paths.contains(&"daily/2026-06-09.md"));
+        assert!(!paths.iter().any(|p| p.ends_with(".txt")));
+    }
+}

--- a/apps/desktop/src-tauri/src/fs.rs
+++ b/apps/desktop/src-tauri/src/fs.rs
@@ -35,6 +35,10 @@ pub struct GraphInfo {
     pub root: String,
     /// Display name (the root folder name).
     pub name: String,
+    /// File-sync provider this graph appears to live inside (e.g. `"icloud"`),
+    /// or `None`. A `Some(_)` means the UI should warn — Reflect syncs via
+    /// GitHub only and a cloud-synced graph risks index corruption (Plan 12/04).
+    pub cloud_sync: Option<String>,
 }
 
 /// Metadata for a file inside the graph.
@@ -149,15 +153,24 @@ fn collect_markdown(root: &Path, dir: &str, out: &mut Vec<FileMeta>) -> AppResul
     Ok(())
 }
 
-fn graph_info(root: &Path) -> AppResult<GraphInfo> {
+fn graph_info(root: &Path) -> GraphInfo {
     let name = root
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_default();
-    Ok(GraphInfo {
+    GraphInfo {
         root: root.to_string_lossy().into_owned(),
         name,
-    })
+        cloud_sync: crate::recents::detect_cloud_sync(root).map(str::to_string),
+    }
+}
+
+/// Set the active root, record it in recents, and return its info.
+fn activate(state: &State<GraphState>, root: &Path) -> AppResult<GraphInfo> {
+    set_root(state, root)?;
+    let info = graph_info(root);
+    crate::recents::record(root, &info.name)?;
+    Ok(info)
 }
 
 fn current_root(state: &State<GraphState>) -> AppResult<PathBuf> {
@@ -186,8 +199,7 @@ pub fn graph_create(path: String, state: State<GraphState>) -> AppResult<GraphIn
     let root = PathBuf::from(&path);
     fs::create_dir_all(&root)?;
     bootstrap(&root)?;
-    set_root(&state, &root)?;
-    graph_info(&root)
+    activate(&state, &root)
 }
 
 /// Open an existing graph at `path`, ensuring the standard layout exists.
@@ -198,8 +210,7 @@ pub fn graph_open(path: String, state: State<GraphState>) -> AppResult<GraphInfo
         return Err(AppError::not_found(format!("not a directory: {path}")));
     }
     bootstrap(&root)?;
-    set_root(&state, &root)?;
-    graph_info(&root)
+    activate(&state, &root)
 }
 
 /// Read a note's markdown by graph-relative path.

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod db;
 mod error;
 mod fs;
+mod recents;
 
 /// Returns the desktop application version from Cargo metadata.
 ///
@@ -15,6 +16,7 @@ fn app_version() -> String {
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_dialog::init())
         .manage(fs::GraphState::default())
         .invoke_handler(tauri::generate_handler![
             app_version,
@@ -25,6 +27,8 @@ pub fn run() {
             fs::note_move,
             fs::note_delete,
             fs::list_files,
+            recents::recent_graphs,
+            recents::forget_recent,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,4 +1,6 @@
 mod db;
+mod error;
+mod fs;
 
 /// Returns the desktop application version from Cargo metadata.
 ///
@@ -13,7 +15,17 @@ fn app_version() -> String {
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![app_version])
+        .manage(fs::GraphState::default())
+        .invoke_handler(tauri::generate_handler![
+            app_version,
+            fs::graph_open,
+            fs::graph_create,
+            fs::note_read,
+            fs::note_write,
+            fs::note_move,
+            fs::note_delete,
+            fs::list_files,
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/apps/desktop/src-tauri/src/recents.rs
+++ b/apps/desktop/src-tauri/src/recents.rs
@@ -8,7 +8,7 @@
 
 use std::fs;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
@@ -116,23 +116,32 @@ pub fn forget_recent(root: String) -> AppResult<()> {
 /// Heuristic: which file-sync provider, if any, is `path` inside? Pure
 /// (unit-tested). A `Some(_)` result means the UI should warn (Plan 12 / Plan 04).
 pub fn detect_cloud_sync(path: &Path) -> Option<&'static str> {
-    let lower = path.to_string_lossy();
-    if lower.contains("Mobile Documents")
-        || lower.contains("com~apple~CloudDocs")
-        || lower.contains("iCloud Drive")
-    {
+    // Match whole path *components*, not raw substrings, so look-alike folder
+    // names (e.g. "My Driveway", "Dropbox Backups") don't false-positive.
+    let parts: Vec<&str> = path
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(os) => os.to_str(),
+            _ => None,
+        })
+        .collect();
+    let has = |name: &str| parts.contains(&name);
+
+    if has("Mobile Documents") || has("com~apple~CloudDocs") || has("iCloud Drive") {
         Some("icloud")
-    } else if lower.contains("/Dropbox/")
-        || lower.ends_with("/Dropbox")
-        || lower.contains("\\Dropbox\\")
-    {
+    } else if has("Dropbox") {
         Some("dropbox")
-    } else if lower.contains("Google Drive")
-        || lower.contains("GoogleDrive")
-        || lower.contains("My Drive")
+    } else if has("My Drive")
+        || has("Google Drive")
+        || parts.iter().any(|part| part.starts_with("GoogleDrive-"))
     {
+        // macOS CloudStorage uses a `GoogleDrive-<account>` component.
         Some("googleDrive")
-    } else if lower.contains("OneDrive") {
+    } else if parts
+        .iter()
+        .any(|part| *part == "OneDrive" || part.starts_with("OneDrive -"))
+    {
+        // Business OneDrive uses `OneDrive - <Org>`.
         Some("oneDrive")
     } else {
         None
@@ -212,6 +221,19 @@ mod tests {
             )),
             Some("googleDrive")
         );
+        assert_eq!(
+            detect_cloud_sync(Path::new("/Users/x/OneDrive - Acme/Graph")),
+            Some("oneDrive")
+        );
         assert_eq!(detect_cloud_sync(Path::new("/Users/x/Notes/Graph")), None);
+        // Substring look-alikes must NOT be misclassified.
+        assert_eq!(
+            detect_cloud_sync(Path::new("/Users/x/My Driveway/Graph")),
+            None
+        );
+        assert_eq!(
+            detect_cloud_sync(Path::new("/Users/x/Dropbox Backups/Graph")),
+            None
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/recents.rs
+++ b/apps/desktop/src-tauri/src/recents.rs
@@ -1,0 +1,192 @@
+//! Recent-graphs list + cloud-sync detection (Plan 02).
+//!
+//! The recents list lives in the OS config dir — **never** inside any one
+//! graph's `.reflect/` — so it survives graph deletion and isn't synced as note
+//! content. Cloud-sync detection flags graphs placed inside iCloud/Dropbox/Drive
+//! folders, which are unsupported for sync (Reflect syncs via GitHub only,
+//! Plan 12) and risk corrupting the in-graph index.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{AppError, AppResult};
+
+const MAX_RECENTS: usize = 12;
+
+/// A previously-opened graph, newest first in the stored list.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecentGraph {
+    pub root: String,
+    pub name: String,
+    pub opened_ms: u64,
+}
+
+fn store_path() -> AppResult<PathBuf> {
+    let base = dirs::config_dir().ok_or_else(|| AppError::io("no OS config dir"))?;
+    Ok(base.join("reflect-open").join("recent-graphs.json"))
+}
+
+fn load_from(path: &Path) -> Vec<RecentGraph> {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default()
+}
+
+fn save_to(path: &Path, recents: &[RecentGraph]) -> AppResult<()> {
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir)?;
+    }
+    let json =
+        serde_json::to_string_pretty(recents).map_err(|err| AppError::io(err.to_string()))?;
+    fs::write(path, json)?;
+    Ok(())
+}
+
+/// Prepend `entry`, dedupe by `root`, and cap the list. Pure (unit-tested).
+fn with_entry(mut recents: Vec<RecentGraph>, entry: RecentGraph) -> Vec<RecentGraph> {
+    recents.retain(|r| r.root != entry.root);
+    recents.insert(0, entry);
+    recents.truncate(MAX_RECENTS);
+    recents
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|dur| dur.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Record a graph as most-recently-opened.
+pub fn record(root: &Path, name: &str) -> AppResult<()> {
+    let path = store_path()?;
+    let entry = RecentGraph {
+        root: root.to_string_lossy().into_owned(),
+        name: name.to_string(),
+        opened_ms: now_ms(),
+    };
+    save_to(&path, &with_entry(load_from(&path), entry))
+}
+
+/// The recent-graphs list, newest first.
+pub fn list() -> AppResult<Vec<RecentGraph>> {
+    Ok(load_from(&store_path()?))
+}
+
+/// Drop a graph from the recents list (by root path).
+pub fn forget(root: &str) -> AppResult<()> {
+    let path = store_path()?;
+    let mut recents = load_from(&path);
+    recents.retain(|r| r.root != root);
+    save_to(&path, &recents)
+}
+
+/// Command: the recent-graphs list, newest first.
+#[tauri::command]
+pub fn recent_graphs() -> AppResult<Vec<RecentGraph>> {
+    list()
+}
+
+/// Command: drop a graph from recents (by root path).
+#[tauri::command]
+pub fn forget_recent(root: String) -> AppResult<()> {
+    forget(&root)
+}
+
+/// Heuristic: which file-sync provider, if any, is `path` inside? Pure
+/// (unit-tested). A `Some(_)` result means the UI should warn (Plan 12 / Plan 04).
+pub fn detect_cloud_sync(path: &Path) -> Option<&'static str> {
+    let lower = path.to_string_lossy();
+    if lower.contains("Mobile Documents")
+        || lower.contains("com~apple~CloudDocs")
+        || lower.contains("iCloud Drive")
+    {
+        Some("icloud")
+    } else if lower.contains("/Dropbox/")
+        || lower.ends_with("/Dropbox")
+        || lower.contains("\\Dropbox\\")
+    {
+        Some("dropbox")
+    } else if lower.contains("Google Drive")
+        || lower.contains("GoogleDrive")
+        || lower.contains("My Drive")
+    {
+        Some("googleDrive")
+    } else if lower.contains("OneDrive") {
+        Some("oneDrive")
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn entry(root: &str, opened_ms: u64) -> RecentGraph {
+        RecentGraph {
+            root: root.to_string(),
+            name: root.rsplit('/').next().unwrap_or(root).to_string(),
+            opened_ms,
+        }
+    }
+
+    #[test]
+    fn prepends_dedupes_and_caps() {
+        let mut list = Vec::new();
+        for i in 0..15 {
+            list = with_entry(list, entry(&format!("/g/{i}"), i));
+        }
+        assert_eq!(list.len(), MAX_RECENTS);
+        assert_eq!(list[0].root, "/g/14"); // newest first
+
+        // Re-opening an existing root moves it to front without duplicating.
+        let list = with_entry(list, entry("/g/10", 99));
+        assert_eq!(list[0].root, "/g/10");
+        assert_eq!(list.iter().filter(|r| r.root == "/g/10").count(), 1);
+        assert_eq!(list.len(), MAX_RECENTS);
+    }
+
+    #[test]
+    fn save_load_round_trip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("recent-graphs.json");
+        let recents = vec![entry("/a", 1), entry("/b", 2)];
+        save_to(&path, &recents).unwrap();
+        assert_eq!(load_from(&path), recents);
+    }
+
+    #[test]
+    fn missing_store_loads_empty() {
+        let dir = tempdir().unwrap();
+        assert!(load_from(&dir.path().join("nope.json")).is_empty());
+    }
+
+    #[test]
+    fn detects_cloud_providers() {
+        use std::path::Path;
+        assert_eq!(
+            detect_cloud_sync(Path::new(
+                "/Users/x/Library/Mobile Documents/com~apple~CloudDocs/Graph"
+            )),
+            Some("icloud")
+        );
+        assert_eq!(
+            detect_cloud_sync(Path::new("/Users/x/Dropbox/Graph")),
+            Some("dropbox")
+        );
+        assert_eq!(
+            detect_cloud_sync(Path::new(
+                "/Users/x/Library/CloudStorage/GoogleDrive-a/My Drive/Graph"
+            )),
+            Some("googleDrive")
+        );
+        assert_eq!(detect_cloud_sync(Path::new("/Users/x/Notes/Graph")), None);
+    }
+}

--- a/apps/desktop/src-tauri/src/recents.rs
+++ b/apps/desktop/src-tauri/src/recents.rs
@@ -7,10 +7,12 @@
 //! Plan 12) and risk corrupting the in-graph index.
 
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
+use tempfile::NamedTempFile;
 
 use crate::error::{AppError, AppResult};
 
@@ -30,20 +32,33 @@ fn store_path() -> AppResult<PathBuf> {
     Ok(base.join("reflect-open").join("recent-graphs.json"))
 }
 
-fn load_from(path: &Path) -> Vec<RecentGraph> {
-    fs::read_to_string(path)
-        .ok()
-        .and_then(|raw| serde_json::from_str(&raw).ok())
-        .unwrap_or_default()
+/// Load the stored list. A missing store is an empty list, but a real IO error
+/// or malformed JSON is propagated — we must **not** silently treat a corrupt or
+/// unreadable store as empty, or the next mutation would persist that emptiness
+/// and wipe every saved entry.
+fn load_from(path: &Path) -> AppResult<Vec<RecentGraph>> {
+    let raw = match fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(AppError::io(err.to_string())),
+    };
+    serde_json::from_str(&raw).map_err(|err| AppError::io(err.to_string()))
 }
 
 fn save_to(path: &Path, recents: &[RecentGraph]) -> AppResult<()> {
-    if let Some(dir) = path.parent() {
-        fs::create_dir_all(dir)?;
-    }
+    let dir = path
+        .parent()
+        .ok_or_else(|| AppError::io("recents store path has no parent directory"))?;
+    fs::create_dir_all(dir)?;
     let json =
         serde_json::to_string_pretty(recents).map_err(|err| AppError::io(err.to_string()))?;
-    fs::write(path, json)?;
+    // Write to a temp file in the same dir, then atomically rename over the
+    // target so a crash mid-write can't truncate the existing store.
+    let mut tmp = NamedTempFile::new_in(dir)?;
+    tmp.write_all(json.as_bytes())?;
+    tmp.flush()?;
+    tmp.persist(path)
+        .map_err(|err| AppError::io(err.to_string()))?;
     Ok(())
 }
 
@@ -70,18 +85,18 @@ pub fn record(root: &Path, name: &str) -> AppResult<()> {
         name: name.to_string(),
         opened_ms: now_ms(),
     };
-    save_to(&path, &with_entry(load_from(&path), entry))
+    save_to(&path, &with_entry(load_from(&path)?, entry))
 }
 
 /// The recent-graphs list, newest first.
 pub fn list() -> AppResult<Vec<RecentGraph>> {
-    Ok(load_from(&store_path()?))
+    load_from(&store_path()?)
 }
 
 /// Drop a graph from the recents list (by root path).
 pub fn forget(root: &str) -> AppResult<()> {
     let path = store_path()?;
-    let mut recents = load_from(&path);
+    let mut recents = load_from(&path)?;
     recents.retain(|r| r.root != root);
     save_to(&path, &recents)
 }
@@ -159,13 +174,23 @@ mod tests {
         let path = dir.path().join("recent-graphs.json");
         let recents = vec![entry("/a", 1), entry("/b", 2)];
         save_to(&path, &recents).unwrap();
-        assert_eq!(load_from(&path), recents);
+        assert_eq!(load_from(&path).unwrap(), recents);
     }
 
     #[test]
     fn missing_store_loads_empty() {
         let dir = tempdir().unwrap();
-        assert!(load_from(&dir.path().join("nope.json")).is_empty());
+        assert!(load_from(&dir.path().join("nope.json")).unwrap().is_empty());
+    }
+
+    #[test]
+    fn corrupt_store_errors_instead_of_wiping() {
+        // A malformed store must surface an error, not silently read as empty
+        // (which a later save would persist, destroying the real entries).
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("recent-graphs.json");
+        fs::write(&path, b"{ this is not json").unwrap();
+        assert!(load_from(&path).is_err());
     }
 
     #[test]

--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -1,90 +1,27 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { getAppVersion } from '@reflect/core'
-import { AppShell } from '@/components/app-shell'
-import { NoteEditor } from '@/editor/note-editor'
-import { useTheme } from '@/providers/theme-provider'
-
-/** Sample note for the Plan 05 editor spike — exercises headings, marks, a list,
- * a quote, and `[[wiki links]]` (which render as plain text until Plan 07). */
-const SAMPLE_NOTE = `# Welcome to Reflect
-
-This is the **meowdown** editor — markdown you can _see_, backed by plain files.
-
-Daily notes link to people and ideas with [[Wiki Links]], and to dates like [[2026-06-09]].
-
-- capture first
-- organize later
-
-> Backlinks are the organizing primitive.
-`
+import { GraphChooser } from '@/components/graph-chooser'
+import { GraphWorkspace } from '@/components/graph-workspace'
+import { useGraph } from '@/providers/graph-provider'
 
 /**
- * Root application component. Renders the three-region shell, exercises the IPC
- * boundary via the `app_version` round-trip, and mounts the meowdown editor
- * (Plan 05 spike). Real daily-note wiring + persistence arrive in Plans 02/06.
+ * Root component — the Plan 02 loading gate. Routes between the graph chooser
+ * and the workspace based on whether a graph is open. Real product surfaces
+ * (daily notes, search, AI) hang off the workspace in later plans.
  */
 export function App() {
-  const { resolvedTheme, setTheme } = useTheme()
-  const [version, setVersion] = useState<string | null>(null)
-  const markdownRef = useRef(SAMPLE_NOTE)
+  const { status, graph } = useGraph()
 
-  useEffect(() => {
-    let active = true
-    void (async () => {
-      try {
-        const result = await getAppVersion()
-        if (active) {
-          setVersion(result)
-        }
-      } catch {
-        // `app_version` only resolves inside the Tauri shell; ignore in browser dev.
-        if (active) {
-          setVersion(null)
-        }
-      }
-    })()
-    return () => {
-      active = false
-    }
-  }, [])
+  if (status === 'ready' && graph) {
+    return <GraphWorkspace graph={graph} />
+  }
 
-  const toggleTheme = useCallback((): void => {
-    setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')
-  }, [resolvedTheme, setTheme])
+  if (status === 'choosing') {
+    return <GraphChooser />
+  }
 
-  const handleEditorChange = useCallback((markdown: string): void => {
-    // Persistence lands in Plan 02/05; for the spike we just hold the latest value.
-    markdownRef.current = markdown
-  }, [])
-
+  // 'loading' | 'opening'
   return (
-    <AppShell
-      rail={
-        <span className="text-xs font-semibold text-[color:var(--text-secondary)]">R</span>
-      }
-      sidebar={
-        <div className="p-4 text-sm text-[color:var(--text-secondary)]">Context</div>
-      }
-    >
-      <div className="flex h-full flex-col">
-        <header className="flex items-center justify-between gap-4 border-b border-black/10 px-6 py-3 dark:border-white/10">
-          <h1 className="text-sm font-semibold">Reflect</h1>
-          <div className="flex items-center gap-3">
-            <span className="text-xs text-[color:var(--text-muted)]">v{version ?? '—'}</span>
-            <button
-              type="button"
-              onClick={toggleTheme}
-              className="rounded-md border border-black/10 px-2.5 py-1 text-xs font-medium dark:border-white/10"
-            >
-              {resolvedTheme === 'dark' ? 'Light' : 'Dark'} mode
-            </button>
-          </div>
-        </header>
-
-        <div className="mx-auto w-full max-w-2xl flex-1 overflow-auto px-6 py-8">
-          <NoteEditor initialContent={SAMPLE_NOTE} onChange={handleEditorChange} />
-        </div>
-      </div>
-    </AppShell>
+    <div className="flex h-screen w-screen items-center justify-center text-sm text-[color:var(--text-muted)]">
+      Loading…
+    </div>
   )
 }

--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -1,3 +1,4 @@
+import { type ReactElement } from 'react'
 import { GraphChooser } from '@/components/graph-chooser'
 import { GraphWorkspace } from '@/components/graph-workspace'
 import { useGraph } from '@/providers/graph-provider'
@@ -7,7 +8,7 @@ import { useGraph } from '@/providers/graph-provider'
  * and the workspace based on whether a graph is open. Real product surfaces
  * (daily notes, search, AI) hang off the workspace in later plans.
  */
-export function App() {
+export function App(): ReactElement {
   const { status, graph } = useGraph()
 
   if (status === 'ready' && graph) {

--- a/apps/desktop/src/components/graph-chooser.tsx
+++ b/apps/desktop/src/components/graph-chooser.tsx
@@ -1,10 +1,11 @@
+import { type ReactElement } from 'react'
 import { useGraph } from '@/providers/graph-provider'
 
 /**
  * First-run / no-graph screen: open a folder as a graph, or reopen a recent one.
  * Shown by `App` whenever no graph is active (Plan 02 loading gate).
  */
-export function GraphChooser() {
+export function GraphChooser(): ReactElement {
   const { recents, error, pickAndOpen, openRecent, forget } = useGraph()
 
   return (
@@ -25,7 +26,11 @@ export function GraphChooser() {
           Open graph…
         </button>
 
-        {error ? <p className="text-center text-sm text-red-500">{error}</p> : null}
+        {error ? (
+          <p role="alert" className="text-center text-sm text-red-500">
+            {error}
+          </p>
+        ) : null}
 
         {recents.length > 0 ? (
           <div className="space-y-2">
@@ -52,7 +57,7 @@ export function GraphChooser() {
                     type="button"
                     onClick={() => void forget(recent.root)}
                     aria-label={`Forget ${recent.name}`}
-                    className="shrink-0 text-xs text-[color:var(--text-muted)] opacity-0 group-hover:opacity-100"
+                    className="shrink-0 text-xs text-[color:var(--text-muted)] opacity-0 group-hover:opacity-100 focus-visible:opacity-100 group-focus-within:opacity-100"
                   >
                     Forget
                   </button>

--- a/apps/desktop/src/components/graph-chooser.tsx
+++ b/apps/desktop/src/components/graph-chooser.tsx
@@ -1,0 +1,67 @@
+import { useGraph } from '@/providers/graph-provider'
+
+/**
+ * First-run / no-graph screen: open a folder as a graph, or reopen a recent one.
+ * Shown by `App` whenever no graph is active (Plan 02 loading gate).
+ */
+export function GraphChooser() {
+  const { recents, error, pickAndOpen, openRecent, forget } = useGraph()
+
+  return (
+    <div className="flex h-screen w-screen items-center justify-center p-8">
+      <div className="w-full max-w-sm space-y-6">
+        <div className="space-y-1 text-center">
+          <h1 className="text-xl font-semibold">Open a graph</h1>
+          <p className="text-sm text-[color:var(--text-secondary)]">
+            Pick a folder for your notes — Reflect stores them as plain markdown.
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => void pickAndOpen()}
+          className="w-full rounded-md bg-[var(--accent)] px-3 py-2 text-sm font-medium text-[var(--text-on-brand,#fff)]"
+        >
+          Open graph…
+        </button>
+
+        {error ? <p className="text-center text-sm text-red-500">{error}</p> : null}
+
+        {recents.length > 0 ? (
+          <div className="space-y-2">
+            <p className="text-xs font-medium tracking-wide text-[color:var(--text-muted)] uppercase">
+              Recent
+            </p>
+            <ul className="space-y-1">
+              {recents.map((recent) => (
+                <li
+                  key={recent.root}
+                  className="group flex items-center justify-between gap-2 rounded-md px-2 py-1.5 hover:bg-black/5 dark:hover:bg-white/5"
+                >
+                  <button
+                    type="button"
+                    onClick={() => void openRecent(recent.root)}
+                    className="min-w-0 flex-1 text-left"
+                  >
+                    <span className="block truncate text-sm font-medium">{recent.name}</span>
+                    <span className="block truncate text-xs text-[color:var(--text-muted)]">
+                      {recent.root}
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void forget(recent.root)}
+                    aria-label={`Forget ${recent.name}`}
+                    className="shrink-0 text-xs text-[color:var(--text-muted)] opacity-0 group-hover:opacity-100"
+                  >
+                    Forget
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/components/graph-workspace.tsx
+++ b/apps/desktop/src/components/graph-workspace.tsx
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { getAppVersion, type GraphInfo } from '@reflect/core'
+import { AppShell } from '@/components/app-shell'
+import { NoteEditor } from '@/editor/note-editor'
+import { useTheme } from '@/providers/theme-provider'
+
+/** Sample note for the Plan 05 editor spike (persistence arrives in Plan 06). */
+const SAMPLE_NOTE = `# Welcome to Reflect
+
+This is the **meowdown** editor — markdown you can _see_, backed by plain files.
+
+Daily notes link to people and ideas with [[Wiki Links]], and to dates like [[2026-06-09]].
+
+- capture first
+- organize later
+
+> Backlinks are the organizing primitive.
+`
+
+const CLOUD_LABELS: Record<string, string> = {
+  icloud: 'iCloud Drive',
+  dropbox: 'Dropbox',
+  googleDrive: 'Google Drive',
+  oneDrive: 'OneDrive',
+}
+
+interface GraphWorkspaceProps {
+  graph: GraphInfo
+}
+
+/**
+ * The main surface once a graph is open: the three-region shell with a header
+ * (graph name, a cloud-sync warning when relevant, version, theme toggle) and
+ * the editor. Daily-note wiring + persistence land in Plan 06.
+ */
+export function GraphWorkspace({ graph }: GraphWorkspaceProps) {
+  const { resolvedTheme, setTheme } = useTheme()
+  const [version, setVersion] = useState<string | null>(null)
+  const markdownRef = useRef(SAMPLE_NOTE)
+
+  useEffect(() => {
+    let active = true
+    void (async () => {
+      try {
+        const result = await getAppVersion()
+        if (active) {
+          setVersion(result)
+        }
+      } catch {
+        if (active) {
+          setVersion(null)
+        }
+      }
+    })()
+    return () => {
+      active = false
+    }
+  }, [])
+
+  const toggleTheme = useCallback((): void => {
+    setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')
+  }, [resolvedTheme, setTheme])
+
+  const handleEditorChange = useCallback((markdown: string): void => {
+    markdownRef.current = markdown
+  }, [])
+
+  const cloudLabel = graph.cloudSync ? (CLOUD_LABELS[graph.cloudSync] ?? graph.cloudSync) : null
+
+  return (
+    <AppShell
+      rail={
+        <span className="text-xs font-semibold text-[color:var(--text-secondary)]">R</span>
+      }
+      sidebar={
+        <div className="p-4 text-sm text-[color:var(--text-secondary)]">Context</div>
+      }
+    >
+      <div className="flex h-full flex-col">
+        <header className="flex items-center justify-between gap-4 border-b border-black/10 px-6 py-3 dark:border-white/10">
+          <h1 className="truncate text-sm font-semibold" title={graph.root}>
+            {graph.name}
+          </h1>
+          <div className="flex items-center gap-3">
+            <span className="text-xs text-[color:var(--text-muted)]">v{version ?? '—'}</span>
+            <button
+              type="button"
+              onClick={toggleTheme}
+              className="rounded-md border border-black/10 px-2.5 py-1 text-xs font-medium dark:border-white/10"
+            >
+              {resolvedTheme === 'dark' ? 'Light' : 'Dark'} mode
+            </button>
+          </div>
+        </header>
+
+        {cloudLabel ? (
+          <div className="border-b border-amber-500/30 bg-amber-500/10 px-6 py-2 text-xs text-amber-700 dark:text-amber-300">
+            This graph is inside {cloudLabel}. Reflect syncs via GitHub — a cloud-synced
+            folder is unsupported and can corrupt the local index. Consider moving it to a
+            non-synced location.
+          </div>
+        ) : null}
+
+        <div className="mx-auto w-full max-w-2xl flex-1 overflow-auto px-6 py-8">
+          <NoteEditor initialContent={SAMPLE_NOTE} onChange={handleEditorChange} />
+        </div>
+      </div>
+    </AppShell>
+  )
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { App } from '@/app'
+import { GraphProvider } from '@/providers/graph-provider'
 import { ThemeProvider } from '@/providers/theme-provider'
 import '@/styles/index.css'
 
@@ -12,7 +13,9 @@ if (!rootElement) {
 createRoot(rootElement).render(
   <StrictMode>
     <ThemeProvider>
-      <App />
+      <GraphProvider>
+        <App />
+      </GraphProvider>
     </ThemeProvider>
   </StrictMode>,
 )

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -8,6 +8,7 @@ import {
   useState,
   type ReactNode,
 } from 'react'
+import { isTauri } from '@tauri-apps/api/core'
 import { open } from '@tauri-apps/plugin-dialog'
 import {
   forgetRecent,
@@ -56,38 +57,57 @@ export function GraphProvider({ children }: { children: ReactNode }) {
   // so overlapping opens (double-click, StrictMode remount) can't finish out of
   // order and leave us on a graph the user didn't pick last.
   const openSeq = useRef(0)
+  // Serializes backend opens (see `openRecent`).
+  const openChain = useRef<Promise<unknown>>(Promise.resolve())
 
   const loadRecents = useCallback(async (): Promise<RecentGraph[]> => {
+    if (!isTauri()) {
+      return [] // browser dev — there's no backend store to read.
+    }
     try {
       const list = await recentGraphs()
       setRecents(list)
       return list
-    } catch {
-      // Not running inside Tauri (e.g. browser dev), or no store yet.
+    } catch (err) {
+      // A real failure (e.g. a corrupt recent-graphs.json, which Rust reports as
+      // an error rather than an empty list) should surface, not vanish.
+      setError(messageOf(err))
       return []
     }
   }, [])
 
   const openRecent = useCallback(
-    async (root: string): Promise<void> => {
+    (root: string): Promise<void> => {
       const seq = ++openSeq.current
       setStatus('opening')
       setError(null)
-      try {
-        const info = await openGraph(root)
-        if (seq !== openSeq.current) {
-          return // superseded by a newer open
+      const run = async (): Promise<void> => {
+        try {
+          const info = await openGraph(root)
+          if (seq !== openSeq.current) {
+            return // superseded by a newer open
+          }
+          setGraph(info)
+          setStatus('ready')
+        } catch (err) {
+          if (seq !== openSeq.current) {
+            return
+          }
+          setError(messageOf(err))
+          setStatus('choosing')
         }
-        setGraph(info)
-        setStatus('ready')
-      } catch (err) {
-        if (seq !== openSeq.current) {
-          return
+        if (seq === openSeq.current) {
+          await loadRecents()
         }
-        setError(messageOf(err))
-        setStatus('choosing')
       }
-      await loadRecents()
+      // `graph_open` mutates Rust's GraphState (`set_root`), so overlapping opens
+      // could otherwise have a slow older call land *after* a newer one and leave
+      // the backend on a different graph than the UI. Serialize them: running
+      // one-at-a-time in request order makes the last-requested open the last to
+      // touch GraphState, matching the `openSeq`-pinned UI.
+      const next = openChain.current.then(run, run)
+      openChain.current = next
+      return next
     },
     [loadRecents],
   )

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -4,15 +4,16 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from 'react'
 import { open } from '@tauri-apps/plugin-dialog'
 import {
   forgetRecent,
-  isAppError,
   openGraph,
   recentGraphs,
+  toAppError,
   type GraphInfo,
   type RecentGraph,
 } from '@reflect/core'
@@ -36,7 +37,9 @@ interface GraphContextValue {
 const GraphContext = createContext<GraphContextValue | null>(null)
 
 function messageOf(error: unknown): string {
-  return isAppError(error) ? error.message : String(error)
+  // `toAppError` already normalizes Errors/strings/objects safely, so unknown
+  // throws never render as `[object Object]`.
+  return toAppError(error).message
 }
 
 /**
@@ -49,6 +52,10 @@ export function GraphProvider({ children }: { children: ReactNode }) {
   const [graph, setGraph] = useState<GraphInfo | null>(null)
   const [recents, setRecents] = useState<RecentGraph[]>([])
   const [error, setError] = useState<string | null>(null)
+  // Monotonic open token: only the most recent open may commit `graph`/`status`,
+  // so overlapping opens (double-click, StrictMode remount) can't finish out of
+  // order and leave us on a graph the user didn't pick last.
+  const openSeq = useRef(0)
 
   const loadRecents = useCallback(async (): Promise<RecentGraph[]> => {
     try {
@@ -63,12 +70,20 @@ export function GraphProvider({ children }: { children: ReactNode }) {
 
   const openRecent = useCallback(
     async (root: string): Promise<void> => {
+      const seq = ++openSeq.current
       setStatus('opening')
       setError(null)
       try {
-        setGraph(await openGraph(root))
+        const info = await openGraph(root)
+        if (seq !== openSeq.current) {
+          return // superseded by a newer open
+        }
+        setGraph(info)
         setStatus('ready')
       } catch (err) {
+        if (seq !== openSeq.current) {
+          return
+        }
         setError(messageOf(err))
         setStatus('choosing')
       }

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -60,21 +60,28 @@ export function GraphProvider({ children }: { children: ReactNode }) {
   // Serializes backend opens (see `openRecent`).
   const openChain = useRef<Promise<unknown>>(Promise.resolve())
 
-  const loadRecents = useCallback(async (): Promise<RecentGraph[]> => {
-    if (!isTauri()) {
-      return [] // browser dev — there's no backend store to read.
-    }
-    try {
-      const list = await recentGraphs()
-      setRecents(list)
-      return list
-    } catch (err) {
-      // A real failure (e.g. a corrupt recent-graphs.json, which Rust reports as
-      // an error rather than an empty list) should surface, not vanish.
-      setError(messageOf(err))
-      return []
-    }
-  }, [])
+  const loadRecents = useCallback(
+    async (options?: { surfaceErrors?: boolean }): Promise<RecentGraph[]> => {
+      if (!isTauri()) {
+        return [] // browser dev — there's no backend store to read.
+      }
+      try {
+        const list = await recentGraphs()
+        setRecents(list)
+        return list
+      } catch (err) {
+        // Surface a real failure (e.g. a corrupt recent-graphs.json, which Rust
+        // reports as an error rather than an empty list) only when this is the
+        // primary load. As a post-open refresh it must not clobber an open error
+        // or set one on a screen (the workspace) that never shows it.
+        if (options?.surfaceErrors) {
+          setError(messageOf(err))
+        }
+        return []
+      }
+    },
+    [],
+  )
 
   const openRecent = useCallback(
     (root: string): Promise<void> => {
@@ -115,7 +122,7 @@ export function GraphProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     let active = true
     void (async () => {
-      const list = await loadRecents()
+      const list = await loadRecents({ surfaceErrors: true })
       if (!active) {
         return
       }

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -1,0 +1,143 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+import { open } from '@tauri-apps/plugin-dialog'
+import {
+  forgetRecent,
+  isAppError,
+  openGraph,
+  recentGraphs,
+  type GraphInfo,
+  type RecentGraph,
+} from '@reflect/core'
+
+/** Lifecycle of the active graph (Plan 02 loading gate). */
+export type GraphStatus = 'loading' | 'choosing' | 'opening' | 'ready'
+
+interface GraphContextValue {
+  status: GraphStatus
+  graph: GraphInfo | null
+  recents: RecentGraph[]
+  error: string | null
+  /** Show the OS folder picker, then open (and bootstrap) the chosen graph. */
+  pickAndOpen: () => Promise<void>
+  /** Open a previously-used graph by its root path. */
+  openRecent: (root: string) => Promise<void>
+  /** Drop a graph from the recents list. */
+  forget: (root: string) => Promise<void>
+}
+
+const GraphContext = createContext<GraphContextValue | null>(null)
+
+function messageOf(error: unknown): string {
+  return isAppError(error) ? error.message : String(error)
+}
+
+/**
+ * Owns the active graph and the open/choose flow. On mount it auto-opens the
+ * most-recent graph (so the app reopens where you left off) and otherwise shows
+ * the chooser. All durable file access goes through `@reflect/core` commands.
+ */
+export function GraphProvider({ children }: { children: ReactNode }) {
+  const [status, setStatus] = useState<GraphStatus>('loading')
+  const [graph, setGraph] = useState<GraphInfo | null>(null)
+  const [recents, setRecents] = useState<RecentGraph[]>([])
+  const [error, setError] = useState<string | null>(null)
+
+  const loadRecents = useCallback(async (): Promise<RecentGraph[]> => {
+    try {
+      const list = await recentGraphs()
+      setRecents(list)
+      return list
+    } catch {
+      // Not running inside Tauri (e.g. browser dev), or no store yet.
+      return []
+    }
+  }, [])
+
+  const openRecent = useCallback(
+    async (root: string): Promise<void> => {
+      setStatus('opening')
+      setError(null)
+      try {
+        setGraph(await openGraph(root))
+        setStatus('ready')
+      } catch (err) {
+        setError(messageOf(err))
+        setStatus('choosing')
+      }
+      await loadRecents()
+    },
+    [loadRecents],
+  )
+
+  useEffect(() => {
+    let active = true
+    void (async () => {
+      const list = await loadRecents()
+      if (!active) {
+        return
+      }
+      if (list.length > 0) {
+        await openRecent(list[0].root)
+      } else {
+        setStatus('choosing')
+      }
+    })()
+    return () => {
+      active = false
+    }
+  }, [loadRecents, openRecent])
+
+  const pickAndOpen = useCallback(async (): Promise<void> => {
+    let selected: string | null = null
+    try {
+      const result = await open({
+        directory: true,
+        multiple: false,
+        title: 'Choose a graph folder',
+      })
+      selected = typeof result === 'string' ? result : null
+    } catch (err) {
+      setError(messageOf(err))
+      return
+    }
+    if (selected) {
+      await openRecent(selected)
+    }
+  }, [openRecent])
+
+  const forget = useCallback(
+    async (root: string): Promise<void> => {
+      try {
+        await forgetRecent(root)
+        await loadRecents()
+      } catch {
+        // best-effort
+      }
+    },
+    [loadRecents],
+  )
+
+  const value = useMemo<GraphContextValue>(
+    () => ({ status, graph, recents, error, pickAndOpen, openRecent, forget }),
+    [status, graph, recents, error, pickAndOpen, openRecent, forget],
+  )
+
+  return <GraphContext.Provider value={value}>{children}</GraphContext.Provider>
+}
+
+/** Access the active graph + open/choose actions. Use within a GraphProvider. */
+export function useGraph(): GraphContextValue {
+  const context = useContext(GraphContext)
+  if (!context) {
+    throw new Error('useGraph must be used within a GraphProvider')
+  }
+  return context
+}

--- a/docs/plans/03-markdown-document-model.md
+++ b/docs/plans/03-markdown-document-model.md
@@ -46,14 +46,14 @@ Markdown is the source of truth, so the parser is load-bearing. Two hard require
    "no frontmatter" + a non-fatal warning, never an unreadable note.
 
    ```ts
-   // src/lib/markdown/frontmatter.ts
+   // packages/core/src/markdown/frontmatter.ts
    import { z } from 'zod'
 
    export const frontmatterSchema = z.object({
-     id: z.string().optional(),
+     id: z.string().optional(), // reserved; not auto-written in the first wave (see step 5)
      aliases: z.array(z.string()).default([]),
      private: z.boolean().default(false),
-   }).passthrough() // preserve unknown keys
+   }).passthrough() // preserve unknown keys (incl. a user's `tags:`)
    export type Frontmatter = z.infer<typeof frontmatterSchema>
    ```
 
@@ -61,8 +61,8 @@ Markdown is the source of truth, so the parser is load-bearing. Two hard require
    - `title` (frontmatter, else first H1, else filename).
    - Outgoing `[[wiki links]]` with target + optional `|alias` + source position.
    - Standard markdown links (href, text) and their domains.
-   - Tags (`#tag` in body and/or frontmatter — decide one canonical source; first wave:
-     body `#tag` + optional frontmatter `tags`).
+   - Tags: **body `#tag` only** (decided 2026-06-09). A frontmatter `tags:` key, if present,
+     is preserved via passthrough but is **not** a tag source in the first wave.
    - Headings (for section anchors + chunking in Plan 09).
    - Asset references (relative links into `assets/`).
    - Plain text (for FTS + AI context).
@@ -75,8 +75,14 @@ Markdown is the source of truth, so the parser is load-bearing. Two hard require
 
 5. **Wiki-link resolution model.** Define resolution rules used everywhere:
    case-insensitive title match, alias match, and `[[YYYY-MM-DD]]` → daily note. Return
-   a typed result: `resolved(noteId)` | `unresolved(text)` so the editor (Plan 05/07)
-   can offer "create note."
+   a typed result: `resolved(ref)` | `unresolved(text)` so the editor (Plan 05/07) can
+   offer "create note." **Note identity = the file path/title in the first wave** (decided
+   2026-06-09): `ref` is the note's path, resolution **prefers a frontmatter `id` when one
+   is present** but we don't auto-write ids yet. This keeps files clean and externally
+   editable; rename-stable ids (the V1 model) are reserved in the schema and revisited when
+   sync (Plan 12) makes them matter. The lookup itself is **injected** (DI per conventions
+   §3) — `resolve.ts` owns only the pure normalization + the `Resolution` type; the
+   index-backed resolver lands in Plan 04/07.
 
 6. **Tests.** Golden round-trip corpus (Reflect notes, Obsidian notes, GFM edge cases,
    broken frontmatter, mixed line endings). Property test: `serialize(parse(x))` is
@@ -109,6 +115,10 @@ the canonical model. (Even that can be done from the Lezer tree if we prefer zer
   string. (Answers the indexing-doc open question; supersedes the remark recommendation.)
 - **Unknown frontmatter is preserved, never dropped.** zod `.passthrough()` at the
   boundary; only the known subset is typed.
+- **Note identity = path/title in the first wave** (decided 2026-06-09). `id` is reserved
+  in the schema and resolution prefers it when present, but ids aren't auto-written yet.
+- **Tags = body `#tag` only** (decided 2026-06-09). A frontmatter `tags:` key passes through
+  untouched but isn't a tag source this wave.
 - **Edits are minimal-diff** to keep sync quiet.
 - **The extraction output is a stable, versioned interface** — Plan 04 depends on it.
 

--- a/docs/plans/architecture-conventions.md
+++ b/docs/plans/architecture-conventions.md
@@ -132,6 +132,32 @@ the analog of picardo's `TRPCError`.
 - Timestamps surface as numbers/ISO strings deliberately (SQLite has no `Date`); document
   the choice in `packages/db`.
 
+## 5. State management (frontend)
+
+State is split **by kind**, not funneled through one global store. Match the tool to the
+shape of the data:
+
+- **Projection / IPC data** (notes, backlinks, search results, file lists, recents) →
+  **TanStack Query** (`@tanstack/react-query`). The `queryFn` is a `@reflect/core` getter;
+  the file-watcher event (Plans 03/04) drives **targeted `queryClient.invalidateQueries`**,
+  and setters (markdown writes) do optimistic update + invalidate. SQLite stays the single
+  source of truth — **the frontend caches the projection, it never holds a second copy of it.**
+- **Editor / document state** → owned by **meowdown/ProseMirror**; the `<Editor>` is
+  uncontrolled, so this is never mirrored into a store.
+- **Shared UI / session state** (theme, active graph, route model, command palette,
+  sidebar + AI-context toggles, sync status) → **Zustand**, one small store per concern.
+  Keep a React **provider** only where context semantics genuinely apply (e.g. the graph
+  lifecycle / open flow); reach for Zustand for new cross-cutting UI slices from the start.
+- **Strictly-local ephemeral state** → plain React (`useState` / `useReducer`).
+
+This composes with the actions pattern (§3): getters back query functions, setters invalidate.
+
+**Non-goal:** a global observable domain model (MobX / MobX-Keystone style) that mirrors the
+graph and notes in memory. V1 did this; in V2 the domain model lives in files → SQLite, so an
+in-memory mirror only duplicates the projection and reintroduces watcher-sync complexity for
+no benefit. MobX's fine-grained reactivity pays off over a rich client-owned model — which we
+deliberately don't have.
+
 ## Consequences for specific plans
 
 - **Plan 01** restructures the scaffold into `apps/desktop` + `packages/core` +

--- a/docs/plans/architecture-conventions.md
+++ b/docs/plans/architecture-conventions.md
@@ -145,9 +145,11 @@ shape of the data:
 - **Editor / document state** → owned by **meowdown/ProseMirror**; the `<Editor>` is
   uncontrolled, so this is never mirrored into a store.
 - **Shared UI / session state** (theme, active graph, route model, command palette,
-  sidebar + AI-context toggles, sync status) → **Zustand**, one small store per concern.
-  Keep a React **provider** only where context semantics genuinely apply (e.g. the graph
-  lifecycle / open flow); reach for Zustand for new cross-cutting UI slices from the start.
+  sidebar + AI-context toggles, sync status) → **React context + hooks by default**
+  (what `ThemeProvider`/`GraphProvider` already are). **Zustand** is in the toolbox for when
+  a slice outgrows context — frequent updates that re-render too widely, or state needed far
+  from where it's provided — but that's a per-slice judgement call, not a mandate. Reach for
+  it when it earns its place; otherwise context suffices. Tradeoffs, as always.
 - **Strictly-local ephemeral state** → plain React (`useState` / `useReducer`).
 
 This composes with the actions pattern (§3): getters back query functions, setters invalidate.

--- a/docs/plans/libraries.md
+++ b/docs/plans/libraries.md
@@ -21,6 +21,8 @@ first-party (owned by the team) and MIT-licensed, so there is no copyleft constr
 
 | Need | Library | Plan |
 | --- | --- | --- |
+| Projection/IPC data cache + invalidation (server-state) | `@tanstack/react-query` | 04 |
+| Shared UI / session state (theme, route, palette, sync) | `zustand` | 06 / 08 |
 | Frontmatter YAML (tolerant, round-trippable) | `yaml` (eemeli) | 03 |
 | Note IDs (ULID) | `ulidx` | 02 |
 | Routing (typed product routes + history) | **custom, no dependency** | 06 |

--- a/docs/plans/libraries.md
+++ b/docs/plans/libraries.md
@@ -22,7 +22,7 @@ first-party (owned by the team) and MIT-licensed, so there is no copyleft constr
 | Need | Library | Plan |
 | --- | --- | --- |
 | Projection/IPC data cache + invalidation (server-state) | `@tanstack/react-query` | 04 |
-| Shared UI / session state (theme, route, palette, sync) | `zustand` | 06 / 08 |
+| Shared UI / session state (theme, route, palette, sync) | React context + hooks; `zustand` *available if a slice earns it* | 06 / 08 |
 | Frontmatter YAML (tolerant, round-trippable) | `yaml` (eemeli) | 03 |
 | Note IDs (ULID) | `ulidx` | 02 |
 | Routing (typed product routes + history) | **custom, no dependency** | 06 |

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -5,12 +5,14 @@ import { z } from 'zod'
  *
  * Rust commands return `Result<T, AppError>`; the serialized error is validated
  * here so the UI can branch on `kind` with a type guard instead of inspecting
- * opaque strings.
+ * opaque strings. Kinds mirror the Rust `AppError` enum (camelCase via serde).
  */
 export const appErrorSchema = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('io'), message: z.string() }),
-  z.object({ kind: z.literal('parse'), message: z.string() }),
   z.object({ kind: z.literal('notFound'), message: z.string() }),
+  z.object({ kind: z.literal('traversal'), message: z.string() }),
+  z.object({ kind: z.literal('noGraph'), message: z.string() }),
+  z.object({ kind: z.literal('parse'), message: z.string() }),
   z.object({ kind: z.literal('unknown'), message: z.string() }),
 ])
 
@@ -19,4 +21,22 @@ export type AppError = z.infer<typeof appErrorSchema>
 /** Type guard: is this value a well-formed {@link AppError}? */
 export function isAppError(value: unknown): value is AppError {
   return appErrorSchema.safeParse(value).success
+}
+
+/**
+ * Coerce any thrown/rejected value into an {@link AppError}. A well-formed
+ * command error passes through; anything else becomes `unknown`.
+ */
+export function toAppError(value: unknown): AppError {
+  const parsed = appErrorSchema.safeParse(value)
+  if (parsed.success) {
+    return parsed.data
+  }
+  const message =
+    value instanceof Error
+      ? value.message
+      : typeof value === 'string'
+        ? value
+        : JSON.stringify(value)
+  return { kind: 'unknown', message }
 }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -32,11 +32,19 @@ export function toAppError(value: unknown): AppError {
   if (parsed.success) {
     return parsed.data
   }
-  const message =
-    value instanceof Error
-      ? value.message
-      : typeof value === 'string'
-        ? value
-        : JSON.stringify(value)
+  let message: string
+  if (value instanceof Error) {
+    message = value.message
+  } else if (typeof value === 'string') {
+    message = value
+  } else {
+    try {
+      // `JSON.stringify` can throw (BigInt, circular refs); never let the error
+      // path itself throw.
+      message = JSON.stringify(value)
+    } catch {
+      message = String(value)
+    }
+  }
   return { kind: 'unknown', message }
 }

--- a/packages/core/src/graph/commands.ts
+++ b/packages/core/src/graph/commands.ts
@@ -1,6 +1,13 @@
 import { z } from 'zod'
 import { call } from '../ipc/invoke'
-import { fileMetaSchema, graphInfoSchema, type FileMeta, type GraphInfo } from './schemas'
+import {
+  fileMetaSchema,
+  graphInfoSchema,
+  recentGraphSchema,
+  type FileMeta,
+  type GraphInfo,
+  type RecentGraph,
+} from './schemas'
 
 /** Commands that return `()` from Rust serialize as `null` over IPC. */
 const voidSchema = z.unknown()
@@ -38,4 +45,14 @@ export async function deleteNote(path: string): Promise<void> {
 /** List markdown notes under `daily/` and `notes/`. */
 export async function listFiles(): Promise<FileMeta[]> {
   return call('list_files', {}, z.array(fileMetaSchema))
+}
+
+/** The recently-opened graphs, newest first. */
+export async function recentGraphs(): Promise<RecentGraph[]> {
+  return call('recent_graphs', {}, z.array(recentGraphSchema))
+}
+
+/** Drop a graph from the recents list (by root path). */
+export async function forgetRecent(root: string): Promise<void> {
+  await call('forget_recent', { root }, voidSchema)
 }

--- a/packages/core/src/graph/commands.ts
+++ b/packages/core/src/graph/commands.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod'
+import { call } from '../ipc/invoke'
+import { fileMetaSchema, graphInfoSchema, type FileMeta, type GraphInfo } from './schemas'
+
+/** Commands that return `()` from Rust serialize as `null` over IPC. */
+const voidSchema = z.unknown()
+
+/** Open an existing graph at `path` (ensures the standard layout exists). */
+export async function openGraph(path: string): Promise<GraphInfo> {
+  return call('graph_open', { path }, graphInfoSchema)
+}
+
+/** Create a new graph at `path` and open it. */
+export async function createGraph(path: string): Promise<GraphInfo> {
+  return call('graph_create', { path }, graphInfoSchema)
+}
+
+/** Read a note's markdown by graph-relative path. */
+export async function readNote(path: string): Promise<string> {
+  return call('note_read', { path }, z.string())
+}
+
+/** Atomically write a note's markdown by graph-relative path. */
+export async function writeNote(path: string, contents: string): Promise<void> {
+  await call('note_write', { path, contents }, voidSchema)
+}
+
+/** Move/rename a note within the graph. */
+export async function moveNote(from: string, to: string): Promise<void> {
+  await call('note_move', { from, to }, voidSchema)
+}
+
+/** Send a note to the OS trash (recoverable). */
+export async function deleteNote(path: string): Promise<void> {
+  await call('note_delete', { path }, voidSchema)
+}
+
+/** List markdown notes under `daily/` and `notes/`. */
+export async function listFiles(): Promise<FileMeta[]> {
+  return call('list_files', {}, z.array(fileMetaSchema))
+}

--- a/packages/core/src/graph/commands.ts
+++ b/packages/core/src/graph/commands.ts
@@ -10,7 +10,7 @@ import {
 } from './schemas'
 
 /** Commands that return `()` from Rust serialize as `null` over IPC. */
-const voidSchema = z.unknown()
+const voidSchema = z.null()
 
 /** Open an existing graph at `path` (ensures the standard layout exists). */
 export async function openGraph(path: string): Promise<GraphInfo> {

--- a/packages/core/src/graph/paths.test.ts
+++ b/packages/core/src/graph/paths.test.ts
@@ -17,6 +17,11 @@ describe('graph paths', () => {
     expect(() => dailyPath('2026-6-9')).toThrow()
   })
 
+  it('rejects well-formatted but invalid calendar dates', () => {
+    expect(() => dailyPath('2026-13-01')).toThrow()
+    expect(() => dailyPath('2026-02-31')).toThrow()
+  })
+
   it('builds note and asset paths', () => {
     expect(notePath('charlotte-maccaw')).toBe('notes/charlotte-maccaw.md')
     expect(assetPath('screenshot.png')).toBe('assets/screenshot.png')

--- a/packages/core/src/graph/paths.test.ts
+++ b/packages/core/src/graph/paths.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assetPath,
+  dailyPath,
+  dateFromDailyPath,
+  isDaily,
+  notePath,
+} from './paths'
+
+describe('graph paths', () => {
+  it('builds daily-note paths from ISO dates', () => {
+    expect(dailyPath('2026-06-09')).toBe('daily/2026-06-09.md')
+  })
+
+  it('rejects non-ISO daily dates', () => {
+    expect(() => dailyPath('June 9 2026')).toThrow()
+    expect(() => dailyPath('2026-6-9')).toThrow()
+  })
+
+  it('builds note and asset paths', () => {
+    expect(notePath('charlotte-maccaw')).toBe('notes/charlotte-maccaw.md')
+    expect(assetPath('screenshot.png')).toBe('assets/screenshot.png')
+  })
+
+  it('recognizes daily-note paths', () => {
+    expect(isDaily('daily/2026-06-09.md')).toBe(true)
+    expect(isDaily('notes/foo.md')).toBe(false)
+    expect(isDaily('daily/not-a-date.md')).toBe(false)
+  })
+
+  it('extracts the date from a daily path, else null', () => {
+    expect(dateFromDailyPath('daily/2026-06-09.md')).toBe('2026-06-09')
+    expect(dateFromDailyPath('notes/foo.md')).toBeNull()
+  })
+})

--- a/packages/core/src/graph/paths.ts
+++ b/packages/core/src/graph/paths.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure helpers for the graph's on-disk path conventions (Plan 02). These build
+ * and recognize **graph-relative** paths; the Rust layer owns the root and the
+ * traversal guard. Shared by every later phase (daily notes, backlinks, CLI).
+ */
+
+export const DAILY_DIR = 'daily'
+export const NOTES_DIR = 'notes'
+export const ASSETS_DIR = 'assets'
+
+/** Matches a daily-note path and captures its ISO date. */
+const DAILY_PATH_RE = /^daily\/(\d{4}-\d{2}-\d{2})\.md$/
+/** A bare ISO date (`YYYY-MM-DD`). */
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+/** Graph-relative path to a daily note for an ISO `YYYY-MM-DD` date. */
+export function dailyPath(date: string): string {
+  if (!ISO_DATE_RE.test(date)) {
+    throw new Error(`dailyPath expects an ISO YYYY-MM-DD date, got: ${date}`)
+  }
+  return `${DAILY_DIR}/${date}.md`
+}
+
+/** Graph-relative path to a regular note for a filename slug (without `.md`). */
+export function notePath(slug: string): string {
+  return `${NOTES_DIR}/${slug}.md`
+}
+
+/** Graph-relative path to an attachment under `assets/`. */
+export function assetPath(name: string): string {
+  return `${ASSETS_DIR}/${name}`
+}
+
+/** Is this graph-relative path a daily note (`daily/YYYY-MM-DD.md`)? */
+export function isDaily(path: string): boolean {
+  return DAILY_PATH_RE.test(path)
+}
+
+/** Extract the ISO date from a daily-note path, or `null` if it isn't one. */
+export function dateFromDailyPath(path: string): string | null {
+  return DAILY_PATH_RE.exec(path)?.[1] ?? null
+}

--- a/packages/core/src/graph/paths.ts
+++ b/packages/core/src/graph/paths.ts
@@ -18,6 +18,17 @@ export function dailyPath(date: string): string {
   if (!ISO_DATE_RE.test(date)) {
     throw new Error(`dailyPath expects an ISO YYYY-MM-DD date, got: ${date}`)
   }
+  // Reject well-formatted but invalid dates (e.g. 2026-13-99, 2026-02-31) by
+  // round-tripping through UTC and comparing the components.
+  const [year, month, day] = date.split('-').map(Number)
+  const utc = new Date(Date.UTC(year, month - 1, day))
+  if (
+    utc.getUTCFullYear() !== year ||
+    utc.getUTCMonth() !== month - 1 ||
+    utc.getUTCDate() !== day
+  ) {
+    throw new Error(`dailyPath expects a valid calendar date, got: ${date}`)
+  }
   return `${DAILY_DIR}/${date}.md`
 }
 

--- a/packages/core/src/graph/schemas.ts
+++ b/packages/core/src/graph/schemas.ts
@@ -6,8 +6,23 @@ export const graphInfoSchema = z.object({
   root: z.string(),
   /** Display name (the root folder name). */
   name: z.string(),
+  /**
+   * File-sync provider this graph appears to live inside (e.g. `"icloud"`,
+   * `"dropbox"`), or `null`. A non-null value means the UI should warn — Reflect
+   * syncs via GitHub only and a cloud-synced graph risks index corruption.
+   */
+  cloudSync: z.string().nullable(),
 })
 export type GraphInfo = z.infer<typeof graphInfoSchema>
+
+/** A previously-opened graph (mirrors the Rust `RecentGraph`). */
+export const recentGraphSchema = z.object({
+  root: z.string(),
+  name: z.string(),
+  /** When it was last opened, epoch milliseconds. */
+  openedMs: z.number(),
+})
+export type RecentGraph = z.infer<typeof recentGraphSchema>
 
 /** Metadata for a file inside the graph (mirrors the Rust `FileMeta`). */
 export const fileMetaSchema = z.object({

--- a/packages/core/src/graph/schemas.ts
+++ b/packages/core/src/graph/schemas.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+
+/** Identity of an open graph (mirrors the Rust `GraphInfo`). */
+export const graphInfoSchema = z.object({
+  /** Absolute path of the graph root. */
+  root: z.string(),
+  /** Display name (the root folder name). */
+  name: z.string(),
+})
+export type GraphInfo = z.infer<typeof graphInfoSchema>
+
+/** Metadata for a file inside the graph (mirrors the Rust `FileMeta`). */
+export const fileMetaSchema = z.object({
+  /** Graph-relative path, forward-slashed. */
+  path: z.string(),
+  size: z.number(),
+  /** Last-modified time in epoch milliseconds. */
+  modifiedMs: z.number(),
+})
+export type FileMeta = z.infer<typeof fileMetaSchema>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,9 +3,37 @@
  *
  * Per the architecture conventions, all reads, orchestration, AI/provider
  * calls, and privacy guards live here; the Rust shell provides only native
- * primitives. The per-domain `actions/` modules land in later plans; this entry
- * point currently exposes the IPC boundary and the shared error contract.
+ * primitives. The per-domain `actions/` modules grow over the plans; this entry
+ * point exposes the IPC boundary, the shared error contract, and the graph
+ * file-storage layer (Plan 02).
  */
 export { call } from './ipc/invoke'
 export { getAppVersion } from './ipc/commands'
-export { appErrorSchema, isAppError, type AppError } from './errors'
+export { appErrorSchema, isAppError, toAppError, type AppError } from './errors'
+
+// Graph & file storage (Plan 02)
+export {
+  DAILY_DIR,
+  NOTES_DIR,
+  ASSETS_DIR,
+  dailyPath,
+  notePath,
+  assetPath,
+  isDaily,
+  dateFromDailyPath,
+} from './graph/paths'
+export {
+  graphInfoSchema,
+  fileMetaSchema,
+  type GraphInfo,
+  type FileMeta,
+} from './graph/schemas'
+export {
+  openGraph,
+  createGraph,
+  readNote,
+  writeNote,
+  moveNote,
+  deleteNote,
+  listFiles,
+} from './graph/commands'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,8 +24,10 @@ export {
 } from './graph/paths'
 export {
   graphInfoSchema,
+  recentGraphSchema,
   fileMetaSchema,
   type GraphInfo,
+  type RecentGraph,
   type FileMeta,
 } from './graph/schemas'
 export {
@@ -36,4 +38,6 @@ export {
   moveNote,
   deleteNote,
   listFiles,
+  recentGraphs,
+  forgetRecent,
 } from './graph/commands'

--- a/packages/core/src/ipc/invoke.ts
+++ b/packages/core/src/ipc/invoke.ts
@@ -1,14 +1,19 @@
 import { invoke } from '@tauri-apps/api/core'
 import type { ZodType } from 'zod'
+import { toAppError, type AppError } from '../errors'
 
 /**
  * The single boundary where an untyped Tauri IPC response becomes a typed,
  * validated domain value.
  *
  * Components and hooks must never call `invoke` from `@tauri-apps/api`
- * directly — they call a typed binding (see `commands.ts`) that funnels through
- * here. Every response is validated with a zod schema; Rust is responsible for
- * emitting camelCase keys so the parsed value needs no further normalization.
+ * directly — they call a typed binding (see the per-domain command modules)
+ * that funnels through here. Every response is validated with a zod schema;
+ * Rust emits camelCase keys so the parsed value needs no further normalization.
+ *
+ * On failure this always throws an {@link AppError}: a rejected command is
+ * coerced via {@link toAppError}; a response that doesn't match `schema` becomes
+ * a `parse` error. Callers can branch on `error.kind`.
  *
  * @param command  The `#[tauri::command]` name (snake_case).
  * @param args     Arguments passed to the command.
@@ -20,6 +25,20 @@ export async function call<TOutput>(
   args: Record<string, unknown>,
   schema: ZodType<TOutput>,
 ): Promise<TOutput> {
-  const raw = await invoke(command, args)
-  return schema.parse(raw)
+  let raw: unknown
+  try {
+    raw = await invoke(command, args)
+  } catch (error) {
+    throw toAppError(error)
+  }
+
+  const result = schema.safeParse(raw)
+  if (!result.success) {
+    const appError: AppError = {
+      kind: 'parse',
+      message: `unexpected response shape from "${command}": ${result.error.message}`,
+    }
+    throw appError
+  }
+  return result.data
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.11.0
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2.7.1
+        version: 2.7.1
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.4
@@ -1035,6 +1038,9 @@ packages:
     resolution: {integrity: sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-dialog@2.7.1':
+    resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
 
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
@@ -2786,6 +2792,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.2
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.2
       '@tauri-apps/cli-win32-x64-msvc': 2.11.2
+
+  '@tauri-apps/plugin-dialog@2.7.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-opener@2.5.4':
     dependencies:


### PR DESCRIPTION
First increment of [Plan 02 — Graph & File Storage](docs/plans/02-graph-and-file-storage.md): the durable file layer that markdown notes live on. Headlessly verifiable; the GUI bits (folder picker, recents) follow.

## Rust (`apps/desktop/src-tauri`)
- **`error.rs`** — `AppError` enum serialized as `{kind, message}` via serde `rename_all = "camelCase"`, matching the `@reflect/core` zod contract. This is the real error **producer** the IPC boundary was missing.
- **`fs.rs`** — graph-relative file IO behind a **path-traversal guard**, with the graph root held in Tauri state. Commands: `graph_open`/`graph_create` (bootstrap `daily/ notes/ assets/ .reflect/` + `.gitignore` + `meta.json`), `note_read`, `note_write` (**atomic** temp-file + rename), `note_move`, `note_delete` (**OS trash**), `list_files`. Adds `tempfile` + `trash`. Unit tests cover the guard, bootstrap, atomic write, and listing.

## TypeScript (`@reflect/core`)
- **`graph/paths.ts`** — pure `dailyPath`/`notePath`/`assetPath`/`isDaily`/`dateFromDailyPath` (+ tests).
- **`graph/schemas.ts`** — zod `GraphInfo`/`FileMeta`. **`graph/commands.ts`** — typed IPC bindings.
- **`call()`** now always throws a typed `AppError` (catches the IPC rejection; a response-shape mismatch becomes a `parse` error). Casing is handled by Rust serde camelCase.

This **closes 3 of the 4 deferred PR #1 review threads** (IPC casing, `AppError` wiring, IPC error handling) by implementing them properly here. The theme FOUC remains deferred to a polish pass.

## Deferred to a follow-up (needs GUI/native)
GraphProvider + dialog folder picker, recent-graphs config (OS app-config), and the macOS security-scoped-bookmark / cloud-folder detection.

## Verification
`cargo fmt`/`clippy -D warnings`/`cargo test` (6) and `pnpm lint`/`typecheck`/`test` (desktop 10 + core 5)/`build` — all green locally; CI runs the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New filesystem and IPC surface with path-traversal guards and tests, but mistakes could still affect user note data or graph roots; UI open races are mitigated with serialization.
> 
> **Overview**
> **Plan 02** adds the graph file layer end-to-end: Rust owns graph-relative IO behind a traversal guard; `@reflect/core` exposes typed IPC; the desktop app gates on open/choose graph.
> 
> The Tauri backend introduces a shared **`AppError`** contract (`io`, `notFound`, `traversal`, `noGraph`, …) and **`fs`** commands to create/open graphs (bootstrap `daily/`, `notes/`, `assets/`, `.reflect/`), read/write notes with **atomic writes**, move/rename, **trash** deletes, and list markdown under note dirs. Paths are resolved only inside the active graph root, with lexical checks and canonicalization against symlink escape. **`recents`** persists recent graphs in the OS config dir (atomic JSON) and **`detect_cloud_sync`** feeds a warning in **`GraphInfo`**.
> 
> **`@reflect/core`** adds graph **path helpers**, **zod schemas**, **command bindings**, expanded **`AppError`** + **`toAppError`**, and **`call()`** that always throws typed errors (IPC rejections and response-shape mismatches). The desktop shell wraps **`GraphProvider`** (folder dialog, auto-reopen latest recent, serialized opens), **`GraphChooser`**, and **`GraphWorkspace`** (cloud-sync banner); **`App`** routes loading / chooser / workspace instead of the editor-only spike.
> 
> Docs record frontend **state-management** guidance (TanStack Query later, context for session) and Plan 03 decisions on note identity and tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9102776826186705cb559225757269410aef9c03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graph workspace management: create/open workspaces with scaffolded layout, cloud-sync detection/warning, and persisted recents
  * Note operations: read, atomic write, move/rename, delete (to OS trash) and markdown file discovery
  * UI: Graph chooser, graph workspace, provider-driven loading flow, theme toggle and app version display

* **Bug Fixes / Reliability**
  * Expanded shared error handling and stricter IPC parsing
  * Safe path traversal and symlink-escape protections; more robust write/delete semantics

* **Tests**
  * Added tests for path utilities, filesystem traversal/safety, and recents persistence

* **Documentation**
  * Frontend state management and library recommendations added

* **Chores**
  * Desktop now permits native dialog access for opening directories
<!-- end of auto-generated comment: release notes by coderabbit.ai -->