### PR TITLE
Plan 04b: live file watcher + incremental reindex + index generation token

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -968,6 +968,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-id"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,6 +1044,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1754,6 +1772,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags 2.13.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,6 +1932,26 @@ dependencies = [
  "bitflags 2.13.0",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
 ]
 
 [[package]]
@@ -2047,6 +2105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2101,6 +2160,46 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.13.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02b49179cfebc9932238d04d6079912d26de0379328872846118a0fa0dbb302"
+dependencies = [
+ "file-id",
+ "log",
+ "notify",
+ "notify-types",
+ "walkdir",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.13.0",
+]
 
 [[package]]
 name = "num-conv"
@@ -2738,6 +2837,8 @@ name = "reflect-open"
 version = "0.1.0"
 dependencies = [
  "dirs",
+ "notify",
+ "notify-debouncer-full",
  "rusqlite",
  "rusqlite_migration",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -29,4 +29,6 @@ trash = "5.2.6"
 dirs = "6.0.0"
 tauri-plugin-dialog = "2.7.1"
 rusqlite_migration = "2.6.0"
+notify = "8.2.0"
+notify-debouncer-full = "0.7.0"
 

--- a/apps/desktop/src-tauri/src/db.rs
+++ b/apps/desktop/src-tauri/src/db.rs
@@ -9,8 +9,7 @@
 
 use std::ffi::{c_char, c_int};
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{LazyLock, Mutex, OnceLock};
+use std::sync::{LazyLock, Mutex, MutexGuard, OnceLock};
 
 use rusqlite::ffi::{sqlite3, sqlite3_api_routines};
 use rusqlite::{params, params_from_iter, Connection};
@@ -73,17 +72,23 @@ pub fn open_in_memory() -> AppResult<Connection> {
     Ok(Connection::open_in_memory()?)
 }
 
-/// The open index connection for the active graph (`None` until `index_open`),
-/// plus a monotonic generation bumped on every open. Write commands carry the
-/// generation they were issued for and **no-op if it's stale**, so a reconcile
-/// pass from a previous graph can never mutate a newly-opened index — making
-/// cancellation correct regardless of caller timing (needed once the watcher in
-/// Plan 04b indexes outside the serialized open flow).
+/// The open index connection plus its monotonic generation, kept **under one
+/// lock** so they swap atomically. `index_open` bumps the generation and rebinds
+/// the connection together; a write carries the generation it was issued for and
+/// no-ops if it's stale. Because the check and the connection are read under the
+/// same lock, a write can never see a fresh generation with a stale connection
+/// (or vice versa) — so a reconcile/reindex pass from a previous graph can never
+/// mutate a newly-opened index, regardless of caller timing (needed once the
+/// watcher in Plan 04b indexes outside the serialized open flow).
 #[derive(Default)]
-pub struct IndexState {
-    conn: Mutex<Option<Connection>>,
-    generation: AtomicU64,
+struct IndexInner {
+    generation: u64,
+    conn: Option<Connection>,
 }
+
+/// The active graph's index state (`conn` is `None` until `index_open`).
+#[derive(Default)]
+pub struct IndexState(Mutex<IndexInner>);
 
 /// Bring the connection up to the latest schema version (no-op if current).
 fn migrate(conn: &mut Connection) -> AppResult<()> {
@@ -292,25 +297,18 @@ fn remove_note(conn: &Connection, path: &str) -> AppResult<()> {
     Ok(())
 }
 
-fn lock_index<'a>(
-    index: &'a State<IndexState>,
-) -> AppResult<std::sync::MutexGuard<'a, Option<Connection>>> {
+fn lock_state<'a>(index: &'a State<IndexState>) -> AppResult<MutexGuard<'a, IndexInner>> {
     index
-        .conn
+        .0
         .lock()
         .map_err(|_| AppError::io("index state lock poisoned"))
 }
 
 // ---- commands --------------------------------------------------------------
 
-/// True when `generation` is the current index generation. Callers check this
-/// while holding the connection lock so the check and the write are consistent.
-fn generation_is_current(index: &State<IndexState>, generation: u64) -> bool {
-    index.generation.load(Ordering::SeqCst) == generation
-}
-
 /// Open + migrate the index for the active graph (reads the root from state).
-/// Returns the new generation, which write commands must echo back.
+/// Returns the new generation, which write commands must echo back. The
+/// generation bump and connection rebind happen under one lock, atomically.
 #[tauri::command]
 pub fn index_open(graph: State<GraphState>, index: State<IndexState>) -> AppResult<u64> {
     let root = graph
@@ -319,25 +317,24 @@ pub fn index_open(graph: State<GraphState>, index: State<IndexState>) -> AppResu
         .map_err(|_| AppError::io("graph state lock poisoned"))?
         .clone()
         .ok_or_else(AppError::no_graph)?;
-    // Bump the generation first (invalidating any in-flight prior-graph pass),
-    // then drop the old connection so a failed open can't leave a stale one that
-    // later reads would hit (wrong graph's data).
-    let generation = index.generation.fetch_add(1, Ordering::SeqCst) + 1;
-    *lock_index(&index)? = None;
-    let conn = open_index_at(&root)?;
-    *lock_index(&index)? = Some(conn);
-    Ok(generation)
+    let mut state = lock_state(&index)?;
+    state.generation += 1;
+    // Drop the old connection before opening; if the open fails we return with
+    // `conn = None` (reads then error) rather than a stale connection.
+    state.conn = None;
+    state.conn = Some(open_index_at(&root)?);
+    Ok(state.generation)
 }
 
 /// Apply one note's extracted projection in a single transaction (no-op if the
 /// generation is stale — a superseded pass must not write the new graph's index).
 #[tauri::command]
 pub fn index_apply(note: IndexedNote, generation: u64, index: State<IndexState>) -> AppResult<()> {
-    let mut guard = lock_index(&index)?;
-    if !generation_is_current(&index, generation) {
+    let mut state = lock_state(&index)?;
+    if state.generation != generation {
         return Ok(());
     }
-    let conn = guard.as_mut().ok_or_else(AppError::no_graph)?;
+    let conn = state.conn.as_mut().ok_or_else(AppError::no_graph)?;
     let tx = conn.transaction()?;
     apply_note(&tx, &note)?;
     tx.commit()?;
@@ -347,22 +344,22 @@ pub fn index_apply(note: IndexedNote, generation: u64, index: State<IndexState>)
 /// Remove a note (e.g. deleted on disk) from the index (no-op if stale).
 #[tauri::command]
 pub fn index_remove(path: String, generation: u64, index: State<IndexState>) -> AppResult<()> {
-    let guard = lock_index(&index)?;
-    if !generation_is_current(&index, generation) {
+    let state = lock_state(&index)?;
+    if state.generation != generation {
         return Ok(());
     }
-    let conn = guard.as_ref().ok_or_else(AppError::no_graph)?;
+    let conn = state.conn.as_ref().ok_or_else(AppError::no_graph)?;
     remove_note(conn, &path)
 }
 
 /// Wipe all derived tables (the TS layer then re-applies every note; no-op if stale).
 #[tauri::command]
 pub fn index_clear(generation: u64, index: State<IndexState>) -> AppResult<()> {
-    let guard = lock_index(&index)?;
-    if !generation_is_current(&index, generation) {
+    let state = lock_state(&index)?;
+    if state.generation != generation {
         return Ok(());
     }
-    let conn = guard.as_ref().ok_or_else(AppError::no_graph)?;
+    let conn = state.conn.as_ref().ok_or_else(AppError::no_graph)?;
     clear_index(conn)
 }
 
@@ -373,8 +370,8 @@ pub fn db_query(
     params: Vec<Value>,
     index: State<IndexState>,
 ) -> AppResult<Vec<Map<String, Value>>> {
-    let guard = lock_index(&index)?;
-    let conn = guard.as_ref().ok_or_else(AppError::no_graph)?;
+    let state = lock_state(&index)?;
+    let conn = state.conn.as_ref().ok_or_else(AppError::no_graph)?;
     run_query(conn, &sql, &params)
 }
 

--- a/apps/desktop/src-tauri/src/db.rs
+++ b/apps/desktop/src-tauri/src/db.rs
@@ -9,6 +9,7 @@
 
 use std::ffi::{c_char, c_int};
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{LazyLock, Mutex, OnceLock};
 
 use rusqlite::ffi::{sqlite3, sqlite3_api_routines};
@@ -72,9 +73,17 @@ pub fn open_in_memory() -> AppResult<Connection> {
     Ok(Connection::open_in_memory()?)
 }
 
-/// The open index connection for the active graph (`None` until `index_open`).
+/// The open index connection for the active graph (`None` until `index_open`),
+/// plus a monotonic generation bumped on every open. Write commands carry the
+/// generation they were issued for and **no-op if it's stale**, so a reconcile
+/// pass from a previous graph can never mutate a newly-opened index — making
+/// cancellation correct regardless of caller timing (needed once the watcher in
+/// Plan 04b indexes outside the serialized open flow).
 #[derive(Default)]
-pub struct IndexState(pub Mutex<Option<Connection>>);
+pub struct IndexState {
+    conn: Mutex<Option<Connection>>,
+    generation: AtomicU64,
+}
 
 /// Bring the connection up to the latest schema version (no-op if current).
 fn migrate(conn: &mut Connection) -> AppResult<()> {
@@ -287,34 +296,47 @@ fn lock_index<'a>(
     index: &'a State<IndexState>,
 ) -> AppResult<std::sync::MutexGuard<'a, Option<Connection>>> {
     index
-        .0
+        .conn
         .lock()
         .map_err(|_| AppError::io("index state lock poisoned"))
 }
 
 // ---- commands --------------------------------------------------------------
 
+/// True when `generation` is the current index generation. Callers check this
+/// while holding the connection lock so the check and the write are consistent.
+fn generation_is_current(index: &State<IndexState>, generation: u64) -> bool {
+    index.generation.load(Ordering::SeqCst) == generation
+}
+
 /// Open + migrate the index for the active graph (reads the root from state).
+/// Returns the new generation, which write commands must echo back.
 #[tauri::command]
-pub fn index_open(graph: State<GraphState>, index: State<IndexState>) -> AppResult<()> {
+pub fn index_open(graph: State<GraphState>, index: State<IndexState>) -> AppResult<u64> {
     let root = graph
         .0
         .lock()
         .map_err(|_| AppError::io("graph state lock poisoned"))?
         .clone()
         .ok_or_else(AppError::no_graph)?;
-    // Drop the previous graph's connection first, so a failed open can't leave a
-    // stale connection that later reads would hit (wrong graph's data).
+    // Bump the generation first (invalidating any in-flight prior-graph pass),
+    // then drop the old connection so a failed open can't leave a stale one that
+    // later reads would hit (wrong graph's data).
+    let generation = index.generation.fetch_add(1, Ordering::SeqCst) + 1;
     *lock_index(&index)? = None;
     let conn = open_index_at(&root)?;
     *lock_index(&index)? = Some(conn);
-    Ok(())
+    Ok(generation)
 }
 
-/// Apply one note's extracted projection in a single transaction.
+/// Apply one note's extracted projection in a single transaction (no-op if the
+/// generation is stale — a superseded pass must not write the new graph's index).
 #[tauri::command]
-pub fn index_apply(note: IndexedNote, index: State<IndexState>) -> AppResult<()> {
+pub fn index_apply(note: IndexedNote, generation: u64, index: State<IndexState>) -> AppResult<()> {
     let mut guard = lock_index(&index)?;
+    if !generation_is_current(&index, generation) {
+        return Ok(());
+    }
     let conn = guard.as_mut().ok_or_else(AppError::no_graph)?;
     let tx = conn.transaction()?;
     apply_note(&tx, &note)?;
@@ -322,18 +344,24 @@ pub fn index_apply(note: IndexedNote, index: State<IndexState>) -> AppResult<()>
     Ok(())
 }
 
-/// Remove a note (e.g. deleted on disk) from the index.
+/// Remove a note (e.g. deleted on disk) from the index (no-op if stale).
 #[tauri::command]
-pub fn index_remove(path: String, index: State<IndexState>) -> AppResult<()> {
+pub fn index_remove(path: String, generation: u64, index: State<IndexState>) -> AppResult<()> {
     let guard = lock_index(&index)?;
+    if !generation_is_current(&index, generation) {
+        return Ok(());
+    }
     let conn = guard.as_ref().ok_or_else(AppError::no_graph)?;
     remove_note(conn, &path)
 }
 
-/// Wipe all derived tables (the TS layer then re-applies every note).
+/// Wipe all derived tables (the TS layer then re-applies every note; no-op if stale).
 #[tauri::command]
-pub fn index_clear(index: State<IndexState>) -> AppResult<()> {
+pub fn index_clear(generation: u64, index: State<IndexState>) -> AppResult<()> {
     let guard = lock_index(&index)?;
+    if !generation_is_current(&index, generation) {
+        return Ok(());
+    }
     let conn = guard.as_ref().ok_or_else(AppError::no_graph)?;
     clear_index(conn)
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod db;
 mod error;
 mod fs;
 mod recents;
+mod watcher;
 
 /// Returns the desktop application version from Cargo metadata.
 ///
@@ -19,6 +20,7 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .manage(fs::GraphState::default())
         .manage(db::IndexState::default())
+        .manage(watcher::WatcherState::default())
         .invoke_handler(tauri::generate_handler![
             app_version,
             fs::graph_open,
@@ -35,6 +37,8 @@ pub fn run() {
             db::index_remove,
             db::index_clear,
             db::db_query,
+            watcher::watch_start,
+            watcher::watch_stop,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -89,6 +89,11 @@ pub fn watch_start(
         .clone()
         .ok_or_else(AppError::no_graph)?;
 
+    // Drop any previous watcher first: if installing the new one fails we're then
+    // left with no watcher, rather than the previous graph's still driving
+    // index:changed against the now-current graph.
+    *lock_watcher(&watcher)? = None;
+
     let handler_root = root.clone();
     let mut debouncer = new_debouncer(
         Duration::from_millis(400),

--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -1,0 +1,174 @@
+//! Filesystem watcher for the open graph (Plan 04b).
+//!
+//! A debounced `notify` watcher over the graph root. It's the **sole** trigger
+//! for incremental re-indexing: an edit (ours or external) writes the markdown
+//! file, the watcher fires, and the frontend re-indexes that file. The index
+//! lives under `.reflect/`, which is filtered out here, so index writes can't
+//! loop back. The watcher only reports `.md` under `daily/` and `notes/`; the
+//! frontend resolves create-vs-delete and re-indexes (content-hash gated).
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::Duration;
+
+use notify::{RecommendedWatcher, RecursiveMode};
+use notify_debouncer_full::{new_debouncer, DebounceEventResult, Debouncer, RecommendedCache};
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, State};
+
+use crate::error::{AppError, AppResult};
+use crate::fs::GraphState;
+
+/// The Tauri event name carrying batched {@link FileChange}s to the frontend.
+const CHANGE_EVENT: &str = "index:changed";
+
+/// Holds the active debouncer; dropping it stops the background watch thread.
+#[derive(Default)]
+pub struct WatcherState(pub Mutex<Option<Debouncer<RecommendedWatcher, RecommendedCache>>>);
+
+/// A debounced change to a tracked markdown note, sent to the frontend.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileChange {
+    /// Graph-relative path, forward-slashed.
+    pub path: String,
+    /// `"upsert"` (created/modified) or `"remove"` (deleted).
+    pub kind: String,
+}
+
+/// Graph-relative path if `path` is a tracked markdown note (`.md` under `daily/`
+/// or `notes/`), else `None`. Pure — the filtering rule, unit-tested.
+fn tracked_relpath(path: &Path, root: &Path) -> Option<String> {
+    let rel = path.strip_prefix(root).ok()?;
+    let rel_str = rel.to_string_lossy().replace('\\', "/");
+    let tracked = (rel_str.starts_with("daily/") || rel_str.starts_with("notes/"))
+        && rel_str.ends_with(".md");
+    tracked.then_some(rel_str)
+}
+
+/// Reduce a debounced batch of paths to unique tracked changes (last kind wins).
+/// Create/modify vs delete is decided by whether the file currently exists.
+fn collect_changes(paths: &[PathBuf], root: &Path) -> Vec<FileChange> {
+    let mut seen: std::collections::BTreeMap<String, FileChange> =
+        std::collections::BTreeMap::new();
+    for path in paths {
+        if let Some(rel) = tracked_relpath(path, root) {
+            let kind = if path.exists() { "upsert" } else { "remove" };
+            seen.insert(
+                rel.clone(),
+                FileChange {
+                    path: rel,
+                    kind: kind.to_string(),
+                },
+            );
+        }
+    }
+    seen.into_values().collect()
+}
+
+fn lock_watcher<'a>(
+    watcher: &'a State<WatcherState>,
+) -> AppResult<std::sync::MutexGuard<'a, Option<Debouncer<RecommendedWatcher, RecommendedCache>>>> {
+    watcher
+        .0
+        .lock()
+        .map_err(|_| AppError::io("watcher state lock poisoned"))
+}
+
+/// Start (or restart) watching the active graph; emits `index:changed` batches.
+#[tauri::command]
+pub fn watch_start(
+    app: AppHandle,
+    graph: State<GraphState>,
+    watcher: State<WatcherState>,
+) -> AppResult<()> {
+    let root = graph
+        .0
+        .lock()
+        .map_err(|_| AppError::io("graph state lock poisoned"))?
+        .clone()
+        .ok_or_else(AppError::no_graph)?;
+
+    let handler_root = root.clone();
+    let mut debouncer = new_debouncer(
+        Duration::from_millis(400),
+        None,
+        move |result: DebounceEventResult| {
+            let Ok(events) = result else {
+                return; // watch errors are transient; the next batch recovers
+            };
+            let paths: Vec<PathBuf> = events
+                .iter()
+                .flat_map(|event| event.paths.clone())
+                .collect();
+            let changes = collect_changes(&paths, &handler_root);
+            if !changes.is_empty() {
+                let _ = app.emit(CHANGE_EVENT, changes);
+            }
+        },
+    )
+    .map_err(|err| AppError::io(err.to_string()))?;
+
+    debouncer
+        .watch(&root, RecursiveMode::Recursive)
+        .map_err(|err| AppError::io(err.to_string()))?;
+
+    // Dropping any previous debouncer here stops its thread.
+    *lock_watcher(&watcher)? = Some(debouncer);
+    Ok(())
+}
+
+/// Stop watching (drops the debouncer).
+#[tauri::command]
+pub fn watch_stop(watcher: State<WatcherState>) -> AppResult<()> {
+    *lock_watcher(&watcher)? = None;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tracks_only_markdown_under_note_dirs() {
+        let root = Path::new("/g");
+        assert_eq!(
+            tracked_relpath(Path::new("/g/notes/a.md"), root).as_deref(),
+            Some("notes/a.md")
+        );
+        assert_eq!(
+            tracked_relpath(Path::new("/g/daily/2026-06-09.md"), root).as_deref(),
+            Some("daily/2026-06-09.md")
+        );
+        // Not tracked: the index, assets, non-markdown, dotfiles, outside root.
+        assert_eq!(
+            tracked_relpath(Path::new("/g/.reflect/index.sqlite"), root),
+            None
+        );
+        assert_eq!(tracked_relpath(Path::new("/g/assets/x.png"), root), None);
+        assert_eq!(tracked_relpath(Path::new("/g/notes/x.txt"), root), None);
+        assert_eq!(tracked_relpath(Path::new("/g/README.md"), root), None);
+        assert_eq!(tracked_relpath(Path::new("/other/notes/a.md"), root), None);
+    }
+
+    #[test]
+    fn collect_changes_dedupes_and_marks_missing_as_remove() {
+        let root = Path::new("/g");
+        // These paths don't exist on disk → "remove"; deduped by path.
+        let changes = collect_changes(
+            &[
+                PathBuf::from("/g/notes/a.md"),
+                PathBuf::from("/g/notes/a.md"),
+                PathBuf::from("/g/.reflect/index.sqlite"),
+            ],
+            root,
+        );
+        assert_eq!(
+            changes,
+            vec![FileChange {
+                path: "notes/a.md".to_string(),
+                kind: "remove".to_string()
+            }]
+        );
+    }
+}

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -107,10 +107,9 @@ export function GraphProvider({ children }: { children: ReactNode }) {
           await reconcileDone.current.catch(() => {})
           // Open the index *before* 'ready' so reads can't hit the previous
           // graph's index. Best-effort: an index failure doesn't block editing.
-          let indexReady = false
+          let generation: number | null = null
           try {
-            await openIndex()
-            indexReady = true
+            generation = await openIndex()
           } catch (err) {
             console.error('index open failed:', messageOf(err))
           }
@@ -119,10 +118,13 @@ export function GraphProvider({ children }: { children: ReactNode }) {
           }
           setGraph(info)
           setStatus('ready')
-          if (indexReady) {
+          if (generation !== null) {
             const controller = new AbortController()
             indexAbort.current = controller
-            reconcileDone.current = reconcileIndex({ signal: controller.signal }).catch((err) => {
+            reconcileDone.current = reconcileIndex({
+              generation,
+              signal: controller.signal,
+            }).catch((err) => {
               console.error('index reconcile failed:', messageOf(err))
             })
           }

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -19,6 +19,7 @@ import {
   subscribeIndexChanges,
   toAppError,
   watchStart,
+  watchStop,
   type GraphInfo,
   type RecentGraph,
 } from '@reflect/core'
@@ -122,6 +123,12 @@ export function GraphProvider({ children }: { children: ReactNode }) {
           }
           setGraph(info)
           setStatus('ready')
+          // Always tear down the previous graph's subscription + watcher, even
+          // when this open's index failed — otherwise a failed openIndex leaves
+          // the old live subscription attached to a different graph.
+          indexUnlisten.current?.()
+          indexUnlisten.current = null
+          void watchStop().catch(() => {})
           if (generation !== null) {
             const controller = new AbortController()
             indexAbort.current = controller
@@ -131,11 +138,9 @@ export function GraphProvider({ children }: { children: ReactNode }) {
             }).catch((err) => {
               console.error('index reconcile failed:', messageOf(err))
             })
-            // Start the live watcher and (re)subscribe with this generation, so
+            // Start the live watcher and subscribe with this generation, so
             // ongoing edits re-index incrementally. Stale events from a previous
             // graph carry the old generation and are dropped by Rust.
-            indexUnlisten.current?.()
-            indexUnlisten.current = null
             void (async () => {
               try {
                 await watchStart()
@@ -144,6 +149,7 @@ export function GraphProvider({ children }: { children: ReactNode }) {
                   unlisten() // a newer open superseded us mid-setup — tear down
                   return
                 }
+                indexUnlisten.current?.() // drop any racing setup before binding
                 indexUnlisten.current = unlisten
               } catch (err) {
                 console.error('index watcher start failed:', messageOf(err))

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -123,36 +123,41 @@ export function GraphProvider({ children }: { children: ReactNode }) {
           }
           setGraph(info)
           setStatus('ready')
-          // Always tear down the previous graph's subscription + watcher, even
-          // when this open's index failed — otherwise a failed openIndex leaves
-          // the old live subscription attached to a different graph.
+          // Tear down the previous graph's live subscription unconditionally, so
+          // a failed openIndex can't leave it attached to a different graph.
           indexUnlisten.current?.()
           indexUnlisten.current = null
-          void watchStop().catch(() => {})
-          if (generation !== null) {
+
+          if (generation === null) {
+            // No index for this graph — stop any watcher from the previous one.
+            void watchStop().catch(() => {})
+          } else {
+            // Index sync, sequenced so the passes never write concurrently:
+            // reconcile the whole graph first, then subscribe (listener up), then
+            // start the Rust watcher (which replaces any previous one). reconcile
+            // is abortable; seq checks bail if a newer open supersedes us.
             const controller = new AbortController()
             indexAbort.current = controller
-            reconcileDone.current = reconcileIndex({
-              generation,
-              signal: controller.signal,
-            }).catch((err) => {
-              console.error('index reconcile failed:', messageOf(err))
-            })
-            // Start the live watcher and subscribe with this generation, so
-            // ongoing edits re-index incrementally. Stale events from a previous
-            // graph carry the old generation and are dropped by Rust.
-            void (async () => {
+            reconcileDone.current = (async () => {
               try {
-                await watchStart()
-                const unlisten = await subscribeIndexChanges(generation)
+                await reconcileIndex({ generation, signal: controller.signal })
                 if (seq !== openSeq.current) {
-                  unlisten() // a newer open superseded us mid-setup — tear down
                   return
                 }
-                indexUnlisten.current?.() // drop any racing setup before binding
+                const unlisten = await subscribeIndexChanges(generation)
+                if (seq !== openSeq.current) {
+                  unlisten()
+                  return
+                }
+                await watchStart()
+                if (seq !== openSeq.current) {
+                  unlisten()
+                  return
+                }
+                indexUnlisten.current?.()
                 indexUnlisten.current = unlisten
               } catch (err) {
-                console.error('index watcher start failed:', messageOf(err))
+                console.error('index sync failed:', messageOf(err))
               }
             })()
           }

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -139,7 +139,12 @@ export function GraphProvider({ children }: { children: ReactNode }) {
             void (async () => {
               try {
                 await watchStart()
-                indexUnlisten.current = await subscribeIndexChanges(generation)
+                const unlisten = await subscribeIndexChanges(generation)
+                if (seq !== openSeq.current) {
+                  unlisten() // a newer open superseded us mid-setup — tear down
+                  return
+                }
+                indexUnlisten.current = unlisten
               } catch (err) {
                 console.error('index watcher start failed:', messageOf(err))
               }

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -16,7 +16,9 @@ import {
   openIndex,
   reconcileIndex,
   recentGraphs,
+  subscribeIndexChanges,
   toAppError,
+  watchStart,
   type GraphInfo,
   type RecentGraph,
 } from '@reflect/core'
@@ -65,6 +67,8 @@ export function GraphProvider({ children }: { children: ReactNode }) {
   // switch can stop the prior pass before the Rust index connection is swapped.
   const indexAbort = useRef<AbortController | null>(null)
   const reconcileDone = useRef<Promise<void>>(Promise.resolve())
+  // Unlistens the live `index:changed` subscription for the previous graph.
+  const indexUnlisten = useRef<(() => void) | null>(null)
 
   const loadRecents = useCallback(
     async (options?: { surfaceErrors?: boolean }): Promise<RecentGraph[]> => {
@@ -127,6 +131,19 @@ export function GraphProvider({ children }: { children: ReactNode }) {
             }).catch((err) => {
               console.error('index reconcile failed:', messageOf(err))
             })
+            // Start the live watcher and (re)subscribe with this generation, so
+            // ongoing edits re-index incrementally. Stale events from a previous
+            // graph carry the old generation and are dropped by Rust.
+            indexUnlisten.current?.()
+            indexUnlisten.current = null
+            void (async () => {
+              try {
+                await watchStart()
+                indexUnlisten.current = await subscribeIndexChanges(generation)
+              } catch (err) {
+                console.error('index watcher start failed:', messageOf(err))
+              }
+            })()
           }
         } catch (err) {
           if (seq !== openSeq.current) {

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -139,25 +139,29 @@ export function GraphProvider({ children }: { children: ReactNode }) {
             const controller = new AbortController()
             indexAbort.current = controller
             reconcileDone.current = (async () => {
+              let unlisten: (() => void) | null = null
               try {
                 await reconcileIndex({ generation, signal: controller.signal })
                 if (seq !== openSeq.current) {
                   return
                 }
-                const unlisten = await subscribeIndexChanges(generation)
+                unlisten = await subscribeIndexChanges(generation)
                 if (seq !== openSeq.current) {
-                  unlisten()
                   return
                 }
                 await watchStart()
                 if (seq !== openSeq.current) {
-                  unlisten()
                   return
                 }
                 indexUnlisten.current?.()
                 indexUnlisten.current = unlisten
+                unlisten = null // ownership transferred to the ref
               } catch (err) {
                 console.error('index sync failed:', messageOf(err))
+              } finally {
+                // Tear down a subscription that was created but never bound
+                // (superseded, or a later step threw) so listeners can't leak.
+                unlisten?.()
               }
             })()
           }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -79,6 +79,10 @@ export {
   applyIndexedNote,
   removeFromIndex,
   clearIndex,
+  watchStart,
+  watchStop,
+  subscribeIndexChanges,
+  applyIndexChanges,
   hashContent,
   buildIndexedNote,
   indexNote,
@@ -96,4 +100,5 @@ export {
   type Backlink,
   type NoteRow,
   type SearchHit,
+  type FileChange,
 } from './indexing'

--- a/packages/core/src/indexing/commands.ts
+++ b/packages/core/src/indexing/commands.ts
@@ -5,22 +5,27 @@ import type { IndexedNote } from './indexed-note'
 /** Index commands return `()` from Rust, which serializes to `null` over IPC. */
 const voidSchema = z.null()
 
-/** Open + migrate the index for the active graph (Rust reads the root from state). */
-export async function openIndex(): Promise<void> {
-  await call('index_open', {}, voidSchema)
+/**
+ * Open + migrate the index for the active graph (Rust reads the root from state)
+ * and return the new index **generation**. Write commands echo this back; Rust
+ * no-ops a write whose generation is stale, so a pass started for one graph can
+ * never mutate a newly-opened index.
+ */
+export async function openIndex(): Promise<number> {
+  return call('index_open', {}, z.number())
 }
 
-/** Apply one note's projection in a single Rust transaction. */
-export async function applyIndexedNote(note: IndexedNote): Promise<void> {
-  await call('index_apply', { note }, voidSchema)
+/** Apply one note's projection in a single Rust transaction (for `generation`). */
+export async function applyIndexedNote(note: IndexedNote, generation: number): Promise<void> {
+  await call('index_apply', { note, generation }, voidSchema)
 }
 
-/** Remove a note (deleted on disk) from the index. */
-export async function removeFromIndex(path: string): Promise<void> {
-  await call('index_remove', { path }, voidSchema)
+/** Remove a note (deleted on disk) from the index (for `generation`). */
+export async function removeFromIndex(path: string, generation: number): Promise<void> {
+  await call('index_remove', { path, generation }, voidSchema)
 }
 
-/** Wipe all derived tables (precedes a full rebuild). */
-export async function clearIndex(): Promise<void> {
-  await call('index_clear', {}, voidSchema)
+/** Wipe all derived tables (precedes a full rebuild; for `generation`). */
+export async function clearIndex(generation: number): Promise<void> {
+  await call('index_clear', { generation }, voidSchema)
 }

--- a/packages/core/src/indexing/commands.ts
+++ b/packages/core/src/indexing/commands.ts
@@ -29,3 +29,13 @@ export async function removeFromIndex(path: string, generation: number): Promise
 export async function clearIndex(generation: number): Promise<void> {
   await call('index_clear', { generation }, voidSchema)
 }
+
+/** Start (or restart) the filesystem watcher for the active graph (Plan 04b). */
+export async function watchStart(): Promise<void> {
+  await call('watch_start', {}, voidSchema)
+}
+
+/** Stop the filesystem watcher. */
+export async function watchStop(): Promise<void> {
+  await call('watch_stop', {}, voidSchema)
+}

--- a/packages/core/src/indexing/index.ts
+++ b/packages/core/src/indexing/index.ts
@@ -2,7 +2,15 @@
  * `@reflect/core` indexing layer (Plan 04) — the TS pipeline that turns parsed
  * notes into the SQLite projection, plus the typed read getters over it.
  */
-export { openIndex, applyIndexedNote, removeFromIndex, clearIndex } from './commands'
+export {
+  openIndex,
+  applyIndexedNote,
+  removeFromIndex,
+  clearIndex,
+  watchStart,
+  watchStop,
+} from './commands'
+export { subscribeIndexChanges, applyIndexChanges, type FileChange } from './watch'
 export { hashContent } from './hash'
 export {
   buildIndexedNote,

--- a/packages/core/src/indexing/indexer.ts
+++ b/packages/core/src/indexing/indexer.ts
@@ -1,3 +1,4 @@
+import { isAppError } from '../errors'
 import { listFiles, readNote } from '../graph/commands'
 import { parseNote } from '../markdown'
 import { applyIndexedNote, clearIndex, removeFromIndex } from './commands'
@@ -9,25 +10,33 @@ import { getIndexedHashes } from './queries'
  * The indexing pipeline (Plan 04): read (Plan 02) → parse/extract in TS
  * (Plan 03) → hash → hand the flattened projection to Rust, which applies it in
  * one transaction. The index is a rebuildable cache.
+ *
+ * Every write carries the index `generation` returned by `openIndex`. Rust
+ * no-ops a write whose generation is stale, so a pass started for one graph can
+ * never mutate a newly-opened index — cancellation is correct regardless of
+ * caller timing (the watcher in Plan 04b indexes outside the serialized open
+ * flow). The `AbortSignal` is an optimization that stops a superseded pass early.
  */
 
-/** Read, parse, and (re)index a single note. */
+/** Read, parse, and (re)index a single note for the given index generation. */
 export async function indexNote(
   path: string,
-  options?: { content?: string; mtime?: number },
+  options: { generation: number; content?: string; mtime?: number },
 ): Promise<void> {
-  const content = options?.content ?? (await readNote(path))
+  const content = options.content ?? (await readNote(path))
   const parsed = parseNote({ path, source: content })
   const fileHash = await hashContent(content)
-  await applyIndexedNote(buildIndexedNote(parsed, { fileHash, mtime: options?.mtime ?? 0 }))
+  await applyIndexedNote(
+    buildIndexedNote(parsed, { fileHash, mtime: options.mtime ?? 0 }),
+    options.generation,
+  )
 }
 
-/**
- * Options for the long-running index passes. `signal` lets the caller abort
- * between files when the active graph changes — without it, a stale pass would
- * keep writing to whatever index/graph is now open and corrupt the cache.
- */
+/** Options for the long-running index passes. */
 export interface IndexPassOptions {
+  /** The index generation from `openIndex`; stale writes are dropped by Rust. */
+  generation: number
+  /** Aborts the pass early when the active graph changes. */
   signal?: AbortSignal
 }
 
@@ -38,32 +47,27 @@ export interface IndexPassOptions {
  * cleared, we run to completion so an interrupted rebuild can't leave the index
  * empty or half-populated.
  */
-export async function rebuildIndex(options?: IndexPassOptions): Promise<void> {
-  if (options?.signal?.aborted) {
+export async function rebuildIndex(options: IndexPassOptions): Promise<void> {
+  const { generation } = options
+  if (options.signal?.aborted) {
     return // don't wipe the current index for an already-cancelled pass
   }
-  await clearIndex()
+  await clearIndex(generation)
   const files = await listFiles()
   for (const file of files) {
-    await indexNote(file.path, { mtime: file.modifiedMs })
+    await indexNote(file.path, { generation, mtime: file.modifiedMs })
   }
 }
 
 /**
  * Reconcile the index with disk (the open path): re-index files whose content
  * hash changed, and drop rows for files that no longer exist. Cheaper than a full
- * rebuild on an already-populated index, and abortable on graph switch.
- *
- * The caller (GraphProvider) aborts the prior reconcile and **awaits its
- * settlement before calling `openIndex` to swap the Rust connection**, so a pass
- * cannot run concurrently with a connection swap. The abort checks here make a
- * superseded pass stop promptly; a generation token bound to the index
- * connection in Rust — making stale writes caller-independent — is planned with
- * the live watcher (Plan 04b), where indexing also runs outside this serialized
- * open flow.
+ * rebuild on an already-populated index, and abortable on graph switch. Writes
+ * carry `generation`, so even a pass that races a connection swap can't corrupt
+ * the newly-opened index — Rust drops its stale writes.
  */
-export async function reconcileIndex(options?: IndexPassOptions): Promise<void> {
-  const signal = options?.signal
+export async function reconcileIndex(options: IndexPassOptions): Promise<void> {
+  const { generation, signal } = options
   const files = await listFiles()
   if (signal?.aborted) {
     return
@@ -78,20 +82,21 @@ export async function reconcileIndex(options?: IndexPassOptions): Promise<void> 
     let content: string
     try {
       content = await readNote(file.path)
-    } catch {
-      // The file moved/was deleted/locked between listFiles() and here (TOCTOU)
-      // — skip it rather than aborting the whole pass; a later pass will catch up.
+    } catch (err) {
+      // The file moved/was deleted/locked between listFiles() and here (TOCTOU).
+      // If it's gone, drop it from `onDisk` so the cleanup loop removes its
+      // now-ghost row this pass; for a transient error keep the row and retry.
+      if (isAppError(err) && err.kind === 'notFound') {
+        onDisk.delete(file.path)
+      }
       continue
     }
     const fileHash = await hashContent(content)
     if (stored.get(file.path) === fileHash) {
       continue // unchanged
     }
-    if (signal?.aborted) {
-      return // re-check after the awaits — don't write for a superseded pass
-    }
     const parsed = parseNote({ path: file.path, source: content })
-    await applyIndexedNote(buildIndexedNote(parsed, { fileHash, mtime: file.modifiedMs }))
+    await applyIndexedNote(buildIndexedNote(parsed, { fileHash, mtime: file.modifiedMs }), generation)
   }
 
   for (const path of stored.keys()) {
@@ -99,7 +104,7 @@ export async function reconcileIndex(options?: IndexPassOptions): Promise<void> 
       return
     }
     if (!onDisk.has(path)) {
-      await removeFromIndex(path)
+      await removeFromIndex(path, generation)
     }
   }
 }

--- a/packages/core/src/indexing/indexer.ts
+++ b/packages/core/src/indexing/indexer.ts
@@ -95,6 +95,9 @@ export async function reconcileIndex(options: IndexPassOptions): Promise<void> {
     if (stored.get(file.path) === fileHash) {
       continue // unchanged
     }
+    if (signal?.aborted) {
+      return // re-check after the awaits — don't write for a superseded pass
+    }
     const parsed = parseNote({ path: file.path, source: content })
     await applyIndexedNote(buildIndexedNote(parsed, { fileHash, mtime: file.modifiedMs }), generation)
   }

--- a/packages/core/src/indexing/pipeline.test.ts
+++ b/packages/core/src/indexing/pipeline.test.ts
@@ -37,21 +37,22 @@ beforeEach(() => {
 })
 
 describe('indexNote', () => {
-  it('reads, parses, and applies a built index payload', async () => {
-    await indexNote('notes/a.md', { mtime: 5 })
+  it('reads, parses, and applies a built index payload with its generation', async () => {
+    await indexNote('notes/a.md', { generation: 7, mtime: 5 })
     const apply = mockInvoke.mock.calls.find(([cmd]) => cmd === 'index_apply')
     expect(apply).toBeDefined()
-    const note = (apply![1] as { note: Record<string, unknown> }).note
-    expect(note.path).toBe('notes/a.md')
-    expect(note.title).toBe('Hello')
-    expect(note.fileHash).toMatch(/^[0-9a-f]{64}$/)
-    expect((note.links as { targetKey: string }[]).map((l) => l.targetKey)).toContain('world')
+    const args = apply![1] as { note: Record<string, unknown>; generation: number }
+    expect(args.generation).toBe(7)
+    expect(args.note.path).toBe('notes/a.md')
+    expect(args.note.title).toBe('Hello')
+    expect(args.note.fileHash).toMatch(/^[0-9a-f]{64}$/)
+    expect((args.note.links as { targetKey: string }[]).map((link) => link.targetKey)).toContain('world')
   })
 })
 
 describe('rebuildIndex', () => {
   it('clears, lists, then applies every file', async () => {
-    await rebuildIndex()
+    await rebuildIndex({ generation: 1 })
     const commands = mockInvoke.mock.calls.map(([cmd]) => cmd)
     expect(commands[0]).toBe('index_clear')
     expect(commands).toContain('list_files')

--- a/packages/core/src/indexing/pipeline.test.ts
+++ b/packages/core/src/indexing/pipeline.test.ts
@@ -2,6 +2,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getBacklinks, resolveWikiTarget, searchNotes } from './queries'
 import { indexNote, rebuildIndex } from './indexer'
+import { applyIndexChanges } from './watch'
 
 // Mock the Tauri bridge so both core's `call` and @reflect/db's dialect resolve
 // against an in-test fake — exercises the pipeline + the Kysely→db_query bridge.
@@ -57,6 +58,23 @@ describe('rebuildIndex', () => {
     expect(commands[0]).toBe('index_clear')
     expect(commands).toContain('list_files')
     expect(commands.filter((c) => c === 'index_apply')).toHaveLength(1)
+  })
+})
+
+describe('applyIndexChanges (watcher dispatch)', () => {
+  it('re-indexes upserts and removes deletes at the given generation', async () => {
+    await applyIndexChanges(
+      [
+        { path: 'notes/a.md', kind: 'upsert' },
+        { path: 'notes/gone.md', kind: 'remove' },
+      ],
+      9,
+    )
+    const apply = mockInvoke.mock.calls.find(([cmd]) => cmd === 'index_apply')
+    const remove = mockInvoke.mock.calls.find(([cmd]) => cmd === 'index_remove')
+    expect((apply![1] as { note: { path: string }; generation: number }).generation).toBe(9)
+    expect((apply![1] as { note: { path: string } }).note.path).toBe('notes/a.md')
+    expect(remove![1]).toMatchObject({ path: 'notes/gone.md', generation: 9 })
   })
 })
 

--- a/packages/core/src/indexing/watch.ts
+++ b/packages/core/src/indexing/watch.ts
@@ -1,0 +1,50 @@
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+import { z } from 'zod'
+import { removeFromIndex } from './commands'
+import { indexNote } from './indexer'
+
+/**
+ * Live re-indexing from the Rust watcher (Plan 04b). The watcher emits batches
+ * of {@link FileChange} on `index:changed`; we re-index or remove each at the
+ * subscription's `generation`. Late events from a previous graph carry that
+ * graph's (now-stale) generation, so Rust drops their writes — the watcher is
+ * the sole incremental-reindex path and can't corrupt a newly-opened index.
+ */
+
+const fileChangeSchema = z.object({
+  path: z.string(),
+  kind: z.enum(['upsert', 'remove']),
+})
+const fileChangesSchema = z.array(fileChangeSchema)
+
+/** A single tracked change reported by the watcher. */
+export type FileChange = z.infer<typeof fileChangeSchema>
+
+/** Apply a batch of watcher changes to the index at `generation`. */
+export async function applyIndexChanges(changes: FileChange[], generation: number): Promise<void> {
+  for (const change of changes) {
+    try {
+      if (change.kind === 'remove') {
+        await removeFromIndex(change.path, generation)
+      } else {
+        await indexNote(change.path, { generation })
+      }
+    } catch (err) {
+      console.error(`failed to index change for ${change.path}:`, err)
+    }
+  }
+}
+
+/**
+ * Subscribe to `index:changed` and apply each batch at `generation`. Returns an
+ * unlisten function; call it (and resubscribe with the new generation) when the
+ * active graph changes.
+ */
+export function subscribeIndexChanges(generation: number): Promise<UnlistenFn> {
+  return listen('index:changed', (event) => {
+    const parsed = fileChangesSchema.safeParse(event.payload)
+    if (parsed.success) {
+      void applyIndexChanges(parsed.data, generation)
+    }
+  })
+}

--- a/packages/core/src/indexing/watch.ts
+++ b/packages/core/src/indexing/watch.ts
@@ -41,10 +41,17 @@ export async function applyIndexChanges(changes: FileChange[], generation: numbe
  * active graph changes.
  */
 export function subscribeIndexChanges(generation: number): Promise<UnlistenFn> {
+  // Serialize batches so overlapping events for the same path can't reorder
+  // (e.g. an upsert landing after a later remove, leaving a ghost row).
+  let applyQueue: Promise<void> = Promise.resolve()
   return listen('index:changed', (event) => {
     const parsed = fileChangesSchema.safeParse(event.payload)
     if (parsed.success) {
-      void applyIndexChanges(parsed.data, generation)
+      applyQueue = applyQueue
+        .then(() => applyIndexChanges(parsed.data, generation))
+        .catch((err) => {
+          console.error('failed to apply watcher batch:', err)
+        })
     }
   })
 }


### PR DESCRIPTION
Completes Plan 04: the live filesystem watcher that keeps the index fresh on edits, plus the connection-bound generation token we deferred from 04a. Builds on 04a (#4).

## Generation token (cancellation, caller-independent)
- `IndexState` now tracks a monotonic **generation**; `index_open` bumps it and returns it. `index_apply` / `index_remove` / `index_clear` carry the generation they were issued for and **no-op if it's stale** — so a reconcile/reindex pass started for one graph can never mutate a newly-opened index, regardless of caller timing. The TS indexer threads the generation from `openIndex` through every write. (Closes the recurring "abort racy at the write boundary" review thread from #4.)

## Live watcher
- **Rust `watcher.rs`** — a debounced `notify` watcher (notify 8 + notify-debouncer-full 0.7) over the graph root. Filters to `.md` under `daily/`+`notes/` (the index lives in `.reflect/`, excluded → **no echo loop**), resolves create-vs-delete by existence, dedupes a batch, and emits `index:changed`. `watch_start` (replaces any prior watcher) / `watch_stop`.
- **TS** — `subscribeIndexChanges(generation)` listens for `index:changed` (zod-validated payload) and re-indexes upserts / removes deletes at that generation; `GraphProvider` starts the watcher + subscribes after each open, unlistening the prior subscription. **Watcher-as-sole-path** for incremental reindex (the design flagged during 04a planning).

## Also
- Reconcile **ghost-row fix**: when `readNote` fails with `notFound` (deleted between `listFiles` and read), drop it from the on-disk set so the cleanup loop removes its stale row this pass. (Cursor Bugbot, #4.)

## Tests
- **22 Rust** (+ watcher path-filtering & change-dedupe), **56 core TS** (+ watcher dispatch). `lint`/`typecheck`/`test`/`build` green.
- The watcher's real FS-event → reindex loop can't be exercised headlessly (needs `pnpm tauri dev`); the pure pieces (path filtering, change dedupe, dispatch) are unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches index write correctness and graph-switch concurrency (generation guards and open sequencing); watcher path is new background IPC but writes remain gated in Rust.
> 
> **Overview**
> Adds **live incremental re-indexing** via a debounced Rust filesystem watcher and hardens index writes with a **generation token** so stale work cannot corrupt the index after a graph switch.
> 
> **Index generation:** `index_open` now returns a monotonic generation and bumps it atomically with the SQLite connection. `index_apply`, `index_remove`, and `index_clear` accept that generation and no-op when it is stale; the TS indexer threads it through reconcile, rebuild, and watcher-driven updates.
> 
> **Watcher:** New `watcher.rs` uses `notify` + `notify-debouncer-full` on the graph root, filters to `.md` under `daily/` and `notes/` (excluding `.reflect/` to avoid echo loops), batches deduped upsert/remove events, and emits `index:changed`. Core exposes `watchStart`/`watchStop`, `subscribeIndexChanges`, and serialized `applyIndexChanges`; **GraphProvider** runs reconcile → subscribe → start watcher on each open and tears down prior listeners/watchers on switch.
> 
> **Reconcile fix:** When `readNote` fails with `notFound` during reconcile, the path is removed from the on-disk set so ghost index rows are cleaned up in the same pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e64ccab4c49811700575e5ca2dc58a459e5028f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background filesystem watcher with debounced, deduplicated change detection and incremental index updates; frontend can start/stop watching and subscribe to live index-change streams.
  * Index open now returns a generation token used to coordinate live updates.

* **Bug Fixes**
  * Generation-aware locking prevents stale in-flight writes from racing or corrupting the index during graph switches, ensuring consistent read/write behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->