### PR TITLE
ci: bump checkout/pnpm/setup-node off deprecated Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,15 @@ jobs:
     name: Lint · typecheck · test · build (Node)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
       - name: Install Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: pnpm
@@ -61,7 +61,7 @@ jobs:
       run:
         working-directory: apps/desktop/src-tauri
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## Why

GitHub is force-migrating Actions to the Node.js 24 runtime on **2026-06-16**. Our CI currently pins three actions that still run on the **deprecated Node 20** runtime (the deprecation warning is visible in CI logs):

| Action | Before | After | Runtime |
|---|---|---|---|
| `actions/checkout` (node + rust jobs) | `34e1148` `# v4` | `08c6903` `# v5` | node20 → **node24** |
| `pnpm/action-setup` | `b906aff` `# v4` | `0e279bb` `# v6` | node20 → **node24** |
| `actions/setup-node` | `49933ea` `# v4` | `48b55a0` `# v6` | node20 → **node24** |

All remain **SHA-pinned** with a version comment. `persist-credentials: false` is preserved on both `checkout` steps.

## Checked but not changed

- **`Swatinem/rust-cache`** — the pinned SHA (`e18b497`) already runs on **node24**; no warning, left as-is.
- **`dtolnay/rust-toolchain`** — a **composite** action (no Node runtime); cannot emit the Node 20 warning, left as-is.

## Notes

- `pnpm/action-setup` jumps v4 → v6, but the step passes no `version` input and the action reads `packageManager: "pnpm@10.33.0"` from `package.json` natively in v6, so behavior is unchanged.
- `actions/checkout` is pinned to **v5** as requested. v6 is now also available (also node24) if a further bump is preferred later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only dependency pin updates with no application or auth logic changes; main risk is transient CI breakage if an action release misbehaves.
> 
> **Overview**
> Updates **CI** to use GitHub Actions builds on the **Node 24** runner runtime ahead of GitHub’s Node 20 deprecation, without changing job steps or commands.
> 
> In **`.github/workflows/ci.yml`**, the **node** and **rust** jobs now pin **`actions/checkout`** to **v5**, **`pnpm/action-setup`** to **v6**, and **`actions/setup-node`** to **v6** (SHA-pinned with version comments). **`persist-credentials: false`** on checkout is unchanged; Node 22 and pnpm cache behavior stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95eebd70d5af9e81ed02dd60b7b75bd0c2e7ef32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration dependencies to newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->