### PR TITLE
refactor(index): decouple Plan 04a index layer — cascade, async resolver, extracted lifecycle

### DIFF
--- a/apps/desktop/src-tauri/migrations/0001_initial.sql
+++ b/apps/desktop/src-tauri/migrations/0001_initial.sql
@@ -25,7 +25,7 @@ CREATE TABLE note_text (
 
 CREATE TABLE links (
   source_path TEXT NOT NULL REFERENCES notes(path) ON DELETE CASCADE,
-  kind TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('wiki', 'md')),
   target_raw TEXT NOT NULL,
   target_key TEXT NOT NULL,
   alias TEXT,
@@ -55,6 +55,8 @@ CREATE TABLE assets (
 );
 CREATE INDEX assets_note ON assets(note_path);
 
+-- Reserved key/value bookkeeping (e.g. last-rebuild marker). Not written yet;
+-- preserved across `index_clear` so it can hold values that outlive a rebuild.
 CREATE TABLE index_meta (key TEXT PRIMARY KEY NOT NULL, value TEXT NOT NULL);
 
 CREATE VIRTUAL TABLE search_fts USING fts5(path UNINDEXED, title, body);

--- a/apps/desktop/src-tauri/src/db.rs
+++ b/apps/desktop/src-tauri/src/db.rs
@@ -73,6 +73,11 @@ pub fn open_in_memory() -> AppResult<Connection> {
 }
 
 /// The open index connection for the active graph (`None` until `index_open`).
+///
+/// A single connection behind a `Mutex`, so reads (`db_query`) and writes
+/// (`index_*`) are serialized — a long FTS scan briefly blocks an apply and vice
+/// versa. That's acceptable at first-wave scale; a read-pool / WAL reader split
+/// can come later if contention shows up.
 #[derive(Default)]
 pub struct IndexState(pub Mutex<Option<Connection>>);
 
@@ -147,7 +152,11 @@ fn run_query(conn: &Connection, sql: &str, params: &[Value]) -> AppResult<Vec<Ma
 
 // ---- write path ------------------------------------------------------------
 
-/// A note's extracted projection, built in TS (Plan 03) and applied as one row-set.
+/// A note's extracted projection, built in TS (Plan 03) and applied as one
+/// row-set. Mirrors the `indexedNoteSchema` zod contract in
+/// `packages/core/src/indexing/indexed-note.ts` field-for-field (serde
+/// `rename_all = "camelCase"` matches the camelCase payload); a change on either
+/// side must be mirrored on the other.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IndexedNote {
@@ -184,54 +193,40 @@ struct IndexedAlias {
     alias_key: String,
 }
 
-/// Replace all derived rows for `note.path` and upsert its `notes` row. Caller
-/// wraps this in a transaction.
+/// Replace all rows for `note.path` with its current projection. Caller wraps
+/// this in a transaction; statements are cached so a batch rebuild reuses them.
+///
+/// We clear the note via `remove_note` (which deletes the `notes` row and lets
+/// `ON DELETE CASCADE` clear every child table) and then insert fresh rows.
+/// The schema's foreign keys — not a hand-maintained `DELETE` list here — are the
+/// single source of truth for what belongs to a note, so new child tables (Plan
+/// 09 embeddings, etc.) need no change to this function.
 fn apply_note(conn: &Connection, note: &IndexedNote) -> AppResult<()> {
-    conn.execute(
-        "DELETE FROM links WHERE source_path = ?1",
-        params![note.path],
-    )?;
-    conn.execute("DELETE FROM tags WHERE note_path = ?1", params![note.path])?;
-    conn.execute(
-        "DELETE FROM aliases WHERE note_path = ?1",
-        params![note.path],
-    )?;
-    conn.execute(
-        "DELETE FROM assets WHERE note_path = ?1",
-        params![note.path],
-    )?;
-    conn.execute(
-        "DELETE FROM note_text WHERE note_path = ?1",
-        params![note.path],
-    )?;
-    conn.execute("DELETE FROM search_fts WHERE path = ?1", params![note.path])?;
+    remove_note(conn, &note.path)?;
 
-    conn.execute(
+    conn.prepare_cached(
         "INSERT INTO notes(path, id, title, title_key, daily_date, is_private, file_hash, mtime, updated_at)
-         VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?8)
-         ON CONFLICT(path) DO UPDATE SET
-           id = ?2, title = ?3, title_key = ?4, daily_date = ?5,
-           is_private = ?6, file_hash = ?7, mtime = ?8, updated_at = ?8",
-        params![
-            note.path,
-            note.id,
-            note.title,
-            note.title_key,
-            note.daily_date,
-            i64::from(note.is_private),
-            note.file_hash,
-            note.mtime,
-        ],
-    )?;
-    conn.execute(
-        "INSERT INTO note_text(note_path, text) VALUES(?1, ?2)",
-        params![note.path, note.text],
-    )?;
-    for link in &note.links {
-        conn.execute(
+         VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?8)",
+    )?
+    .execute(params![
+        note.path,
+        note.id,
+        note.title,
+        note.title_key,
+        note.daily_date,
+        i64::from(note.is_private),
+        note.file_hash,
+        note.mtime,
+    ])?;
+    conn.prepare_cached("INSERT INTO note_text(note_path, text) VALUES(?1, ?2)")?
+        .execute(params![note.path, note.text])?;
+    {
+        let mut stmt = conn.prepare_cached(
             "INSERT INTO links(source_path, kind, target_raw, target_key, alias, pos_from, pos_to)
              VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-            params![
+        )?;
+        for link in &note.links {
+            stmt.execute(params![
                 note.path,
                 link.kind,
                 link.target_raw,
@@ -239,47 +234,49 @@ fn apply_note(conn: &Connection, note: &IndexedNote) -> AppResult<()> {
                 link.alias,
                 link.pos_from,
                 link.pos_to
-            ],
-        )?;
+            ])?;
+        }
     }
-    for tag in &note.tags {
-        conn.execute(
-            "INSERT INTO tags(note_path, tag) VALUES(?1, ?2)",
-            params![note.path, tag],
-        )?;
+    {
+        let mut stmt = conn.prepare_cached("INSERT INTO tags(note_path, tag) VALUES(?1, ?2)")?;
+        for tag in &note.tags {
+            stmt.execute(params![note.path, tag])?;
+        }
     }
-    for alias in &note.aliases {
-        conn.execute(
+    {
+        let mut stmt = conn.prepare_cached(
             "INSERT INTO aliases(note_path, alias, alias_key) VALUES(?1, ?2, ?3)",
-            params![note.path, alias.alias, alias.alias_key],
         )?;
+        for alias in &note.aliases {
+            stmt.execute(params![note.path, alias.alias, alias.alias_key])?;
+        }
     }
-    for asset in &note.assets {
-        conn.execute(
-            "INSERT INTO assets(note_path, asset_path) VALUES(?1, ?2)",
-            params![note.path, asset],
-        )?;
+    {
+        let mut stmt =
+            conn.prepare_cached("INSERT INTO assets(note_path, asset_path) VALUES(?1, ?2)")?;
+        for asset in &note.assets {
+            stmt.execute(params![note.path, asset])?;
+        }
     }
-    conn.execute(
-        "INSERT INTO search_fts(path, title, body) VALUES(?1, ?2, ?3)",
-        params![note.path, note.title, note.text],
-    )?;
+    conn.prepare_cached("INSERT INTO search_fts(path, title, body) VALUES(?1, ?2, ?3)")?
+        .execute(params![note.path, note.title, note.text])?;
     Ok(())
 }
 
-/// Wipe every derived table (for a full rebuild driven by TS).
+/// Wipe every derived table (for a full rebuild driven by TS). Deleting `notes`
+/// cascades to every child table; `search_fts` (a virtual table, no FK) is
+/// cleared explicitly. `index_meta` is intentionally preserved across a rebuild.
 fn clear_index(conn: &Connection) -> AppResult<()> {
-    conn.execute_batch(
-        "DELETE FROM notes; DELETE FROM note_text; DELETE FROM links; DELETE FROM tags;
-         DELETE FROM aliases; DELETE FROM assets; DELETE FROM search_fts;",
-    )?;
+    conn.execute_batch("DELETE FROM notes; DELETE FROM search_fts;")?;
     Ok(())
 }
 
 fn remove_note(conn: &Connection, path: &str) -> AppResult<()> {
     // notes cascades to child tables; search_fts is standalone.
-    conn.execute("DELETE FROM notes WHERE path = ?1", params![path])?;
-    conn.execute("DELETE FROM search_fts WHERE path = ?1", params![path])?;
+    conn.prepare_cached("DELETE FROM notes WHERE path = ?1")?
+        .execute(params![path])?;
+    conn.prepare_cached("DELETE FROM search_fts WHERE path = ?1")?
+        .execute(params![path])?;
     Ok(())
 }
 
@@ -311,15 +308,30 @@ pub fn index_open(graph: State<GraphState>, index: State<IndexState>) -> AppResu
     Ok(())
 }
 
+/// Apply a batch of note projections in a single transaction (shared by the
+/// one-note and batch commands). One transaction + cached statements keeps a
+/// full rebuild cheap; an empty batch commits a no-op transaction.
+fn apply_in_txn(index: &State<IndexState>, notes: &[IndexedNote]) -> AppResult<()> {
+    let mut guard = lock_index(index)?;
+    let conn = guard.as_mut().ok_or_else(AppError::no_graph)?;
+    let tx = conn.transaction()?;
+    for note in notes {
+        apply_note(&tx, note)?;
+    }
+    tx.commit()?;
+    Ok(())
+}
+
 /// Apply one note's extracted projection in a single transaction.
 #[tauri::command]
 pub fn index_apply(note: IndexedNote, index: State<IndexState>) -> AppResult<()> {
-    let mut guard = lock_index(&index)?;
-    let conn = guard.as_mut().ok_or_else(AppError::no_graph)?;
-    let tx = conn.transaction()?;
-    apply_note(&tx, &note)?;
-    tx.commit()?;
-    Ok(())
+    apply_in_txn(&index, std::slice::from_ref(&note))
+}
+
+/// Apply many notes' projections in one transaction (the full-rebuild path).
+#[tauri::command]
+pub fn index_apply_batch(notes: Vec<IndexedNote>, index: State<IndexState>) -> AppResult<()> {
+    apply_in_txn(&index, &notes)
 }
 
 /// Remove a note (e.g. deleted on disk) from the index.
@@ -458,12 +470,76 @@ mod tests {
     }
 
     #[test]
-    fn clear_empties_derived_tables() {
+    fn clear_cascades_to_child_tables() {
         let conn = migrated();
         apply_note(&conn, &note("notes/a.md", "A", vec![wiki("X")])).unwrap();
         clear_index(&conn).unwrap();
-        let rows = run_query(&conn, "SELECT count(*) AS n FROM notes", &[]).unwrap();
+        // Deleting notes cascades to children; search_fts is cleared explicitly.
+        for table in [
+            "notes",
+            "note_text",
+            "links",
+            "tags",
+            "aliases",
+            "assets",
+            "search_fts",
+        ] {
+            let rows =
+                run_query(&conn, &format!("SELECT count(*) AS n FROM {table}"), &[]).unwrap();
+            assert_eq!(rows[0]["n"], Value::from(0), "{table} should be empty");
+        }
+    }
+
+    #[test]
+    fn reapplying_a_note_cascades_away_stale_children() {
+        let conn = migrated();
+        apply_note(&conn, &note("notes/a.md", "A", vec![wiki("X"), wiki("Y")])).unwrap();
+        // Re-applying clears the note (cascade) before reinserting, so the old
+        // tags/links don't linger even though apply_note lists no explicit deletes.
+        apply_note(&conn, &note("notes/a.md", "A", vec![])).unwrap();
+        let rows = run_query(&conn, "SELECT count(*) AS n FROM links", &[]).unwrap();
         assert_eq!(rows[0]["n"], Value::from(0));
+    }
+
+    #[test]
+    fn link_kind_check_rejects_unknown_kinds() {
+        let conn = migrated();
+        apply_note(&conn, &note("notes/a.md", "A", vec![])).unwrap();
+        let bogus = conn.execute(
+            "INSERT INTO links(source_path, kind, target_raw, target_key, pos_from, pos_to)
+             VALUES('notes/a.md', 'bogus', 'X', 'x', 0, 0)",
+            [],
+        );
+        assert!(
+            bogus.is_err(),
+            "CHECK should reject kinds other than wiki/md"
+        );
+    }
+
+    #[test]
+    fn open_index_at_creates_migrates_and_reopens() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+
+        let conn = open_index_at(root).expect("first open");
+        assert!(root.join(".reflect/index.sqlite").exists());
+        let version: i64 = conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(version, 1);
+        let journal: String = conn
+            .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(journal, "wal");
+        drop(conn);
+
+        // Reopening an existing index is a no-op migration and preserves data.
+        let conn = open_index_at(root).expect("first open");
+        apply_note(&conn, &note("notes/a.md", "A", vec![])).unwrap();
+        drop(conn);
+        let conn = open_index_at(root).expect("reopen");
+        let rows = run_query(&conn, "SELECT count(*) AS n FROM notes", &[]).unwrap();
+        assert_eq!(rows[0]["n"], Value::from(1));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -32,6 +32,7 @@ pub fn run() {
             recents::forget_recent,
             db::index_open,
             db::index_apply,
+            db::index_apply_batch,
             db::index_remove,
             db::index_clear,
             db::db_query,

--- a/apps/desktop/src/providers/graph-index.test.ts
+++ b/apps/desktop/src/providers/graph-index.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@reflect/core', () => ({
+  openIndex: vi.fn(),
+  reconcileIndex: vi.fn(),
+}))
+
+import { openIndex, reconcileIndex } from '@reflect/core'
+import { createGraphIndex } from './graph-index'
+
+const mockOpen = vi.mocked(openIndex)
+const mockReconcile = vi.mocked(reconcileIndex)
+
+beforeEach(() => {
+  mockOpen.mockReset()
+  mockReconcile.mockReset()
+})
+
+describe('createGraphIndex', () => {
+  it('open() returns true when the index opens', async () => {
+    mockOpen.mockResolvedValue(undefined)
+    expect(await createGraphIndex().open()).toBe(true)
+  })
+
+  it('open() returns false and reports the failure (editing is never blocked)', async () => {
+    const onError = vi.fn()
+    mockOpen.mockRejectedValue(new Error('boom'))
+    expect(await createGraphIndex({ onError }).open()).toBe(false)
+    expect(onError).toHaveBeenCalledWith('open', expect.any(Error))
+  })
+
+  it('reconcile() passes an abort signal, and stop() aborts it then waits to settle', async () => {
+    let captured: AbortSignal | undefined
+    let settle: () => void = () => {}
+    mockReconcile.mockImplementation((options) => {
+      captured = options?.signal
+      return new Promise<void>((resolve) => {
+        settle = resolve
+      })
+    })
+
+    const index = createGraphIndex()
+    index.reconcile()
+    expect(captured).toBeInstanceOf(AbortSignal)
+    expect(captured?.aborted).toBe(false)
+
+    const stopped = index.stop()
+    expect(captured?.aborted).toBe(true) // aborted synchronously
+
+    let resolved = false
+    void stopped.then(() => {
+      resolved = true
+    })
+    await Promise.resolve()
+    expect(resolved).toBe(false) // stop() is still awaiting the reconcile
+
+    settle()
+    await stopped
+  })
+
+  it('stop() before any reconcile resolves immediately', async () => {
+    await expect(createGraphIndex().stop()).resolves.toBeUndefined()
+  })
+
+  it('reports a reconcile failure yet stop() still settles', async () => {
+    const onError = vi.fn()
+    mockReconcile.mockRejectedValue(new Error('reconcile boom'))
+    const index = createGraphIndex({ onError })
+    index.reconcile()
+    await index.stop()
+    expect(onError).toHaveBeenCalledWith('reconcile', expect.any(Error))
+  })
+})

--- a/apps/desktop/src/providers/graph-index.ts
+++ b/apps/desktop/src/providers/graph-index.ts
@@ -1,0 +1,79 @@
+import { openIndex, reconcileIndex } from '@reflect/core'
+
+/**
+ * The active graph's index lifecycle, factored out of `GraphProvider` so the
+ * abort/await/open/reconcile dance is testable on its own and the provider is
+ * left to own graph state and the open-ordering guards.
+ *
+ * Usage on a graph switch (the caller still gates on its own open token):
+ *
+ * ```ts
+ * await index.stop()              // halt the previous graph's reconcile
+ * const ready = await index.open() // open the new graph's index
+ * if (stale) return
+ * if (ready) index.reconcile()    // kick a background reconcile pass
+ * ```
+ */
+export interface GraphIndex {
+  /**
+   * Abort the in-flight reconcile (if any) and wait for it to fully settle, so a
+   * stale pass can't write into the next graph's index after the Rust connection
+   * is swapped.
+   */
+  stop: () => Promise<void>
+  /**
+   * Open + migrate the index for the now-active graph. Best-effort: returns
+   * `false` (and reports via `onError`) if the open fails, so a broken index
+   * never blocks editing.
+   */
+  open: () => Promise<boolean>
+  /**
+   * Start a background reconcile pass for the active graph. Call only after a
+   * successful {@link GraphIndex.open}; a later {@link GraphIndex.stop} aborts it.
+   */
+  reconcile: () => void
+}
+
+/** Stage of the index lifecycle that failed, for `onError` reporting. */
+export type GraphIndexStage = 'open' | 'reconcile'
+
+export interface GraphIndexOptions {
+  /** Called when a stage fails. The lifecycle itself never throws. */
+  onError?: (stage: GraphIndexStage, error: unknown) => void
+}
+
+/**
+ * Create a {@link GraphIndex}. Holds the in-flight reconcile's `AbortController`
+ * and settlement promise internally; the caller keeps one instance (e.g. in a
+ * ref) across graph switches.
+ */
+export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
+  const { onError } = options
+  let abort: AbortController | null = null
+  let done: Promise<void> = Promise.resolve()
+
+  async function stop(): Promise<void> {
+    abort?.abort()
+    await done.catch(() => {})
+  }
+
+  async function open(): Promise<boolean> {
+    try {
+      await openIndex()
+      return true
+    } catch (error) {
+      onError?.('open', error)
+      return false
+    }
+  }
+
+  function reconcile(): void {
+    const controller = new AbortController()
+    abort = controller
+    done = reconcileIndex({ signal: controller.signal }).catch((error) => {
+      onError?.('reconcile', error)
+    })
+  }
+
+  return { stop, open, reconcile }
+}

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -13,13 +13,12 @@ import { open } from '@tauri-apps/plugin-dialog'
 import {
   forgetRecent,
   openGraph,
-  openIndex,
-  reconcileIndex,
   recentGraphs,
   toAppError,
   type GraphInfo,
   type RecentGraph,
 } from '@reflect/core'
+import { createGraphIndex } from './graph-index'
 
 /** Lifecycle of the active graph (Plan 02 loading gate). */
 export type GraphStatus = 'loading' | 'choosing' | 'opening' | 'ready'
@@ -61,10 +60,13 @@ export function GraphProvider({ children }: { children: ReactNode }) {
   const openSeq = useRef(0)
   // Serializes backend opens (see `openRecent`).
   const openChain = useRef<Promise<unknown>>(Promise.resolve())
-  // The active graph's background index reconcile + its abort handle, so a graph
+  // The active graph's index lifecycle (open + background reconcile), so a graph
   // switch can stop the prior pass before the Rust index connection is swapped.
-  const indexAbort = useRef<AbortController | null>(null)
-  const reconcileDone = useRef<Promise<void>>(Promise.resolve())
+  const indexRef = useRef(
+    createGraphIndex({
+      onError: (stage, err) => console.error(`index ${stage} failed:`, messageOf(err)),
+    }),
+  )
 
   const loadRecents = useCallback(
     async (options?: { surfaceErrors?: boolean }): Promise<RecentGraph[]> => {
@@ -100,31 +102,21 @@ export function GraphProvider({ children }: { children: ReactNode }) {
           if (seq !== openSeq.current) {
             return // superseded by a newer open
           }
+          const index = indexRef.current
           // Stop any prior reconcile and wait for it to fully settle before the
           // Rust index connection is swapped, so a stale pass can't write into
           // this graph's index.
-          indexAbort.current?.abort()
-          await reconcileDone.current.catch(() => {})
+          await index.stop()
           // Open the index *before* 'ready' so reads can't hit the previous
           // graph's index. Best-effort: an index failure doesn't block editing.
-          let indexReady = false
-          try {
-            await openIndex()
-            indexReady = true
-          } catch (err) {
-            console.error('index open failed:', messageOf(err))
-          }
+          const indexReady = await index.open()
           if (seq !== openSeq.current) {
             return
           }
           setGraph(info)
           setStatus('ready')
           if (indexReady) {
-            const controller = new AbortController()
-            indexAbort.current = controller
-            reconcileDone.current = reconcileIndex({ signal: controller.signal }).catch((err) => {
-              console.error('index reconcile failed:', messageOf(err))
-            })
+            index.reconcile()
           }
         } catch (err) {
           if (seq !== openSeq.current) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,9 +55,11 @@ export {
   parseNote,
   appendUnderHeading,
   renameWikiLink,
+  foldKey,
   normalizeWikiTarget,
   resolved,
   resolveWikiLink,
+  resolveWikiLinkAsync,
   unresolved,
   type Frontmatter,
   type Span,
@@ -71,16 +73,21 @@ export {
   type NormalizedTarget,
   type Resolution,
   type WikiLookup,
+  type AsyncWikiLookup,
 } from './markdown'
 
 // Local index (Plan 04)
 export {
   openIndex,
   applyIndexedNote,
+  applyIndexedNotes,
   removeFromIndex,
   clearIndex,
   hashContent,
   buildIndexedNote,
+  indexedNoteSchema,
+  indexedLinkSchema,
+  indexedAliasSchema,
   indexNote,
   rebuildIndex,
   reconcileIndex,

--- a/packages/core/src/indexing/commands.ts
+++ b/packages/core/src/indexing/commands.ts
@@ -15,6 +15,18 @@ export async function applyIndexedNote(note: IndexedNote): Promise<void> {
   await call('index_apply', { note }, voidSchema)
 }
 
+/**
+ * Apply many notes' projections in one Rust transaction. Used by the full
+ * rebuild, where a transaction (and prepared-statement reuse) per note would be
+ * needless overhead. A no-op for an empty batch — it never touches the backend.
+ */
+export async function applyIndexedNotes(notes: IndexedNote[]): Promise<void> {
+  if (notes.length === 0) {
+    return
+  }
+  await call('index_apply_batch', { notes }, voidSchema)
+}
+
 /** Remove a note (deleted on disk) from the index. */
 export async function removeFromIndex(path: string): Promise<void> {
   await call('index_remove', { path }, voidSchema)

--- a/packages/core/src/indexing/index.ts
+++ b/packages/core/src/indexing/index.ts
@@ -2,10 +2,19 @@
  * `@reflect/core` indexing layer (Plan 04) — the TS pipeline that turns parsed
  * notes into the SQLite projection, plus the typed read getters over it.
  */
-export { openIndex, applyIndexedNote, removeFromIndex, clearIndex } from './commands'
+export {
+  openIndex,
+  applyIndexedNote,
+  applyIndexedNotes,
+  removeFromIndex,
+  clearIndex,
+} from './commands'
 export { hashContent } from './hash'
 export {
   buildIndexedNote,
+  indexedNoteSchema,
+  indexedLinkSchema,
+  indexedAliasSchema,
   type IndexedNote,
   type IndexedLink,
   type IndexedAlias,

--- a/packages/core/src/indexing/indexed-note.test.ts
+++ b/packages/core/src/indexing/indexed-note.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { parseNote } from '../markdown'
-import { buildIndexedNote } from './indexed-note'
+import { buildIndexedNote, indexedNoteSchema } from './indexed-note'
 
 describe('buildIndexedNote', () => {
   it('flattens a parsed note into the index payload', () => {
@@ -48,5 +48,17 @@ describe('buildIndexedNote', () => {
     expect(indexed.title).toBe('2026-06-09')
     expect(indexed.id).toBeNull()
     expect(indexed.isPrivate).toBe(false)
+  })
+
+  it('produces a payload that satisfies the cross-language contract schema', () => {
+    // Guards the TS half of the TS↔Rust `IndexedNote` contract: if a field is
+    // dropped or mistyped here, the schema parse fails before it can desync from
+    // the serde struct in db.rs.
+    const source = '---\naliases: [Alt]\n---\n# Title\n\n[[Link]] #tag [x](http://x)'
+    const indexed = buildIndexedNote(parseNote({ path: 'notes/n.md', source }), {
+      fileHash: 'h',
+      mtime: 1,
+    })
+    expect(() => indexedNoteSchema.parse(indexed)).not.toThrow()
   })
 })

--- a/packages/core/src/indexing/indexed-note.ts
+++ b/packages/core/src/indexing/indexed-note.ts
@@ -1,43 +1,52 @@
+import { z } from 'zod'
 import { dateFromDailyPath, isDaily } from '../graph/paths'
-import { normalizeWikiTarget, type ParsedNote } from '../markdown'
+import { foldKey, normalizeWikiTarget, type ParsedNote } from '../markdown'
 
 /**
  * The index write payload (Plan 04): a {@link ParsedNote} (Plan 03) flattened into
  * the row-set the Rust `index_apply` command upserts. Pure — no IO — so it's the
- * unit-testable heart of the pipeline. Shape mirrors the Rust `IndexedNote`
- * (camelCase ↔ serde camelCase).
+ * unit-testable heart of the pipeline.
+ *
+ * The zod schemas below are the single source of truth for the payload shape —
+ * the TS types are inferred from them. They mirror the serde `IndexedNote` struct
+ * in `apps/desktop/src-tauri/src/db.rs` field-for-field (camelCase ↔ serde
+ * `rename_all = "camelCase"`); a change on either side must be mirrored on the
+ * other, and {@link indexedNoteSchema} is the contract a drift test can assert.
  */
 
-export interface IndexedLink {
-  kind: 'wiki' | 'md'
-  targetRaw: string
-  /** Normalized match key: case-folded wiki target, or the href for md links. */
-  targetKey: string
-  alias: string | null
-  posFrom: number
-  posTo: number
-}
+export const indexedLinkSchema = z.object({
+  kind: z.enum(['wiki', 'md']),
+  targetRaw: z.string(),
+  /** Normalized match key: case-folded wiki target, or the lowercased href for md links. */
+  targetKey: z.string(),
+  alias: z.string().nullable(),
+  posFrom: z.number(),
+  posTo: z.number(),
+})
+export type IndexedLink = z.infer<typeof indexedLinkSchema>
 
-export interface IndexedAlias {
-  alias: string
-  aliasKey: string
-}
+export const indexedAliasSchema = z.object({
+  alias: z.string(),
+  aliasKey: z.string(),
+})
+export type IndexedAlias = z.infer<typeof indexedAliasSchema>
 
-export interface IndexedNote {
-  path: string
-  id: string | null
-  title: string
-  titleKey: string
-  dailyDate: string | null
-  isPrivate: boolean
-  fileHash: string
-  mtime: number
-  text: string
-  links: IndexedLink[]
-  tags: string[]
-  aliases: IndexedAlias[]
-  assets: string[]
-}
+export const indexedNoteSchema = z.object({
+  path: z.string(),
+  id: z.string().nullable(),
+  title: z.string(),
+  titleKey: z.string(),
+  dailyDate: z.string().nullable(),
+  isPrivate: z.boolean(),
+  fileHash: z.string(),
+  mtime: z.number(),
+  text: z.string(),
+  links: z.array(indexedLinkSchema),
+  tags: z.array(z.string()),
+  aliases: z.array(indexedAliasSchema),
+  assets: z.array(z.string()),
+})
+export type IndexedNote = z.infer<typeof indexedNoteSchema>
 
 /** Flatten a parsed note into the index payload. */
 export function buildIndexedNote(
@@ -65,7 +74,7 @@ export function buildIndexedNote(
     path: parsed.path,
     id: parsed.id ?? null,
     title: parsed.title,
-    titleKey: parsed.title.trim().toLowerCase(),
+    titleKey: foldKey(parsed.title),
     dailyDate: isDaily(parsed.path) ? dateFromDailyPath(parsed.path) : null,
     isPrivate: parsed.frontmatter.private,
     fileHash: meta.fileHash,
@@ -75,7 +84,7 @@ export function buildIndexedNote(
     tags: parsed.tags,
     aliases: parsed.frontmatter.aliases.map((alias) => ({
       alias,
-      aliasKey: alias.trim().toLowerCase(),
+      aliasKey: foldKey(alias),
     })),
     assets: parsed.assets.map((asset) => asset.path),
   }

--- a/packages/core/src/indexing/indexer.ts
+++ b/packages/core/src/indexing/indexer.ts
@@ -1,8 +1,8 @@
 import { listFiles, readNote } from '../graph/commands'
 import { parseNote } from '../markdown'
-import { applyIndexedNote, clearIndex, removeFromIndex } from './commands'
+import { applyIndexedNote, applyIndexedNotes, clearIndex, removeFromIndex } from './commands'
 import { hashContent } from './hash'
-import { buildIndexedNote } from './indexed-note'
+import { buildIndexedNote, type IndexedNote } from './indexed-note'
 import { getIndexedHashes } from './queries'
 
 /**
@@ -10,6 +10,13 @@ import { getIndexedHashes } from './queries'
  * (Plan 03) → hash → hand the flattened projection to Rust, which applies it in
  * one transaction. The index is a rebuildable cache.
  */
+
+/**
+ * Notes per `index_apply_batch` transaction during a full rebuild. Bounds the
+ * IPC payload and transaction size on large graphs while keeping the
+ * transaction/round-trip count far below one-per-note.
+ */
+const REBUILD_BATCH_SIZE = 256
 
 /** Read, parse, and (re)index a single note. */
 export async function indexNote(
@@ -44,9 +51,18 @@ export async function rebuildIndex(options?: IndexPassOptions): Promise<void> {
   }
   await clearIndex()
   const files = await listFiles()
+  let batch: IndexedNote[] = []
   for (const file of files) {
-    await indexNote(file.path, { mtime: file.modifiedMs })
+    const content = await readNote(file.path)
+    const parsed = parseNote({ path: file.path, source: content })
+    const fileHash = await hashContent(content)
+    batch.push(buildIndexedNote(parsed, { fileHash, mtime: file.modifiedMs }))
+    if (batch.length >= REBUILD_BATCH_SIZE) {
+      await applyIndexedNotes(batch)
+      batch = []
+    }
   }
+  await applyIndexedNotes(batch)
 }
 
 /**

--- a/packages/core/src/indexing/pipeline.test.ts
+++ b/packages/core/src/indexing/pipeline.test.ts
@@ -18,6 +18,7 @@ beforeEach(() => {
       case 'list_files':
         return [{ path: 'notes/a.md', size: 1, modifiedMs: 5 }]
       case 'index_apply':
+      case 'index_apply_batch':
       case 'index_clear':
       case 'index_remove':
         return null
@@ -50,12 +51,16 @@ describe('indexNote', () => {
 })
 
 describe('rebuildIndex', () => {
-  it('clears, lists, then applies every file', async () => {
+  it('clears, lists, then applies every file in one batch', async () => {
     await rebuildIndex()
     const commands = mockInvoke.mock.calls.map(([cmd]) => cmd)
     expect(commands[0]).toBe('index_clear')
     expect(commands).toContain('list_files')
-    expect(commands.filter((c) => c === 'index_apply')).toHaveLength(1)
+    const batch = mockInvoke.mock.calls.find(([cmd]) => cmd === 'index_apply_batch')
+    expect(batch).toBeDefined()
+    const notes = (batch![1] as { notes: { path: string }[] }).notes
+    expect(notes.map((note) => note.path)).toEqual(['notes/a.md'])
+    expect(commands).not.toContain('index_apply') // batched, not one-by-one
   })
 })
 

--- a/packages/core/src/indexing/queries.ts
+++ b/packages/core/src/indexing/queries.ts
@@ -1,11 +1,7 @@
 import { db, type Database } from '@reflect/db'
 import { sql, type Selectable } from 'kysely'
-import {
-  normalizeWikiTarget,
-  resolved,
-  unresolved,
-  type Resolution,
-} from '../markdown'
+import { resolveWikiLinkAsync, type Resolution } from '../markdown'
+import { buildFtsMatch } from './search-query'
 
 /**
  * Index read getters (Plan 04). Queries are built with Kysely and execute over
@@ -28,19 +24,28 @@ export function getBacklinks(path: string): Promise<Backlink[]> {
     .execute()
 }
 
-/** Core columns of one note row: identity path, title, daily date, privacy flag. */
-export type NoteRow = Pick<
-  Selectable<Database['notes']>,
-  'path' | 'title' | 'dailyDate' | 'isPrivate'
->
+/** Core fields of one note row: identity path, title, daily date, privacy flag. */
+export interface NoteRow {
+  path: string
+  title: string
+  dailyDate: string | null
+  /**
+   * The `private: true` frontmatter flag — a hard block on sending content to
+   * external services. SQLite stores it as `0|1`; this getter maps it to a real
+   * boolean at the read boundary so privacy checks can't be tripped up by a
+   * truthy number.
+   */
+  isPrivate: boolean
+}
 
 /** Fetch a single note's row by graph-relative path, or `undefined` if absent. */
-export function getNote(path: string): Promise<NoteRow | undefined> {
-  return db
+export async function getNote(path: string): Promise<NoteRow | undefined> {
+  const row = await db
     .selectFrom('notes')
     .where('path', '=', path)
     .select(['path', 'title', 'dailyDate', 'isPrivate'])
     .executeTakeFirst()
+  return row ? { ...row, isPrivate: row.isPrivate !== 0 } : undefined
 }
 
 /** Graph-relative paths of every note carrying `tag`, ordered by path. */
@@ -59,13 +64,10 @@ export type SearchHit = Pick<Selectable<Database['searchFts']>, 'path' | 'title'
 
 /** Full-text search over title + body (FTS5 `MATCH`, ranked). */
 export async function searchNotes(query: string, limit = 50): Promise<SearchHit[]> {
-  const terms = query.trim().split(/\s+/).filter(Boolean)
-  if (terms.length === 0) {
-    return [] // FTS5 errors on an empty MATCH; nothing to search anyway.
+  const match = buildFtsMatch(query)
+  if (match === null) {
+    return [] // nothing to search (FTS5 also errors on an empty MATCH).
   }
-  // Quote each term so FTS5 operators in user input (e.g. `(`, `AND`, `*`) are
-  // treated as literal text instead of throwing a query-syntax error.
-  const match = terms.map((term) => `"${term.replace(/"/g, '""')}"`).join(' ')
   return db
     .selectFrom('searchFts')
     .select(['path', 'title'])
@@ -75,53 +77,53 @@ export async function searchNotes(query: string, limit = 50): Promise<SearchHit[
     .execute()
 }
 
-/** Stored `path → fileHash` map, for content-hash reconciliation on open. */
+/**
+ * Stored `path → fileHash` map, for content-hash reconciliation on open. Loads
+ * every note's hash into memory — fine at first-wave graph sizes; revisit with a
+ * streamed/keyset scan if graphs grow large (tracked with the Plan 04b watcher).
+ */
 export async function getIndexedHashes(): Promise<Map<string, string>> {
   const rows = await db.selectFrom('notes').select(['path', 'fileHash']).execute()
   return new Map(rows.map((row) => [row.path, row.fileHash]))
 }
 
 /**
- * Resolve a `[[target]]` against the index (prefer daily-date, then title, then
- * alias), returning the note ref (its path). The DB-backed counterpart to the
- * pure {@link normalizeWikiTarget} rules in `markdown/resolve.ts`.
+ * Resolve a `[[target]]` against the index, returning the note ref (its path).
+ * The resolution *policy* (prefer daily-date, then title, then alias) lives once
+ * in {@link resolveWikiLinkAsync}; this is only the DB-backed data access.
+ *
+ * Each lookup `orderBy`s before taking the first row so a title/alias/date
+ * collision resolves to the same note every time (otherwise the row order is
+ * undefined).
  */
-export async function resolveWikiTarget(target: string): Promise<Resolution> {
-  const { raw, key, date } = normalizeWikiTarget(target)
-
-  // `orderBy` before `executeTakeFirst` so a title/alias/date collision resolves
-  // to the same note every time (otherwise the row order is undefined).
-  if (date) {
-    const daily = await db
-      .selectFrom('notes')
-      .where('dailyDate', '=', date)
-      .select('path')
-      .orderBy('path')
-      .executeTakeFirst()
-    if (daily) {
-      return resolved(daily.path)
-    }
-  }
-
-  const byTitle = await db
-    .selectFrom('notes')
-    .where('titleKey', '=', key)
-    .select('path')
-    .orderBy('path')
-    .executeTakeFirst()
-  if (byTitle) {
-    return resolved(byTitle.path)
-  }
-
-  const byAlias = await db
-    .selectFrom('aliases')
-    .where('aliasKey', '=', key)
-    .select('notePath')
-    .orderBy('notePath')
-    .executeTakeFirst()
-  if (byAlias) {
-    return resolved(byAlias.notePath)
-  }
-
-  return unresolved(raw)
+export function resolveWikiTarget(target: string): Promise<Resolution> {
+  return resolveWikiLinkAsync(target, {
+    byDate: async (date) =>
+      (
+        await db
+          .selectFrom('notes')
+          .where('dailyDate', '=', date)
+          .select('path')
+          .orderBy('path')
+          .executeTakeFirst()
+      )?.path,
+    byTitle: async (key) =>
+      (
+        await db
+          .selectFrom('notes')
+          .where('titleKey', '=', key)
+          .select('path')
+          .orderBy('path')
+          .executeTakeFirst()
+      )?.path,
+    byAlias: async (key) =>
+      (
+        await db
+          .selectFrom('aliases')
+          .where('aliasKey', '=', key)
+          .select('notePath')
+          .orderBy('notePath')
+          .executeTakeFirst()
+      )?.notePath,
+  })
 }

--- a/packages/core/src/indexing/search-query.test.ts
+++ b/packages/core/src/indexing/search-query.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { buildFtsMatch } from './search-query'
+
+describe('buildFtsMatch', () => {
+  it('returns null for an empty or whitespace-only query', () => {
+    expect(buildFtsMatch('')).toBeNull()
+    expect(buildFtsMatch('   \t \n ')).toBeNull()
+  })
+
+  it('quotes a single term as a literal phrase', () => {
+    expect(buildFtsMatch('hello')).toBe('"hello"')
+  })
+
+  it('quotes each term so FTS5 operators are treated as literal text', () => {
+    expect(buildFtsMatch('cats AND (dogs*)')).toBe('"cats" "AND" "(dogs*)"')
+  })
+
+  it('doubles embedded double-quotes (FTS5 escaping)', () => {
+    expect(buildFtsMatch('say "hi"')).toBe('"say" """hi"""')
+  })
+
+  it('collapses runs of whitespace between terms', () => {
+    expect(buildFtsMatch('  alpha   beta ')).toBe('"alpha" "beta"')
+  })
+})

--- a/packages/core/src/indexing/search-query.ts
+++ b/packages/core/src/indexing/search-query.ts
@@ -1,0 +1,23 @@
+/**
+ * FTS5 query construction (Plan 04).
+ *
+ * FTS5 interprets a raw `MATCH` argument as query syntax, so operators in user
+ * input (`AND`, `OR`, `NOT`, `*`, `(`, `"`) would either change the meaning of
+ * the search or raise a syntax error. {@link buildFtsMatch} defends that boundary:
+ * it splits the query on whitespace and wraps every term in a double-quoted
+ * string (doubling any embedded quote, FTS5's own escape), so each term is
+ * matched as a literal — the search is robust to whatever the user types.
+ */
+
+/**
+ * Build an FTS5 `MATCH` expression from a free-text query, or `null` when there
+ * is nothing to search. FTS5 errors on an empty `MATCH`, so callers should treat
+ * `null` as an empty result set rather than passing it to the database.
+ */
+export function buildFtsMatch(query: string): string | null {
+  const terms = query.trim().split(/\s+/).filter(Boolean)
+  if (terms.length === 0) {
+    return null
+  }
+  return terms.map((term) => `"${term.replace(/"/g, '""')}"`).join(' ')
+}

--- a/packages/core/src/markdown/index.ts
+++ b/packages/core/src/markdown/index.ts
@@ -24,12 +24,15 @@ export {
 export { parseBody, reflectMarkdownParser, wikiLinkExtension } from './grammar'
 export { parseNote } from './extract'
 export { appendUnderHeading, renameWikiLink } from './edit'
+export { foldKey } from './keys'
 export {
   normalizeWikiTarget,
   resolved,
   resolveWikiLink,
+  resolveWikiLinkAsync,
   unresolved,
   type NormalizedTarget,
   type Resolution,
   type WikiLookup,
+  type AsyncWikiLookup,
 } from './resolve'

--- a/packages/core/src/markdown/keys.test.ts
+++ b/packages/core/src/markdown/keys.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { foldKey } from './keys'
+
+describe('foldKey', () => {
+  it('trims and lowercases', () => {
+    expect(foldKey('  Project X  ')).toBe('project x')
+  })
+
+  it('is idempotent', () => {
+    const once = foldKey('  Charlotte ')
+    expect(foldKey(once)).toBe(once)
+  })
+
+  it('leaves an already-folded key unchanged', () => {
+    expect(foldKey('charlotte')).toBe('charlotte')
+  })
+})

--- a/packages/core/src/markdown/keys.ts
+++ b/packages/core/src/markdown/keys.ts
@@ -1,0 +1,14 @@
+/**
+ * Match-key folding (Plan 03/04).
+ *
+ * Note identity matching — wiki-link targets, note titles, and aliases — is
+ * insensitive to case and surrounding whitespace. {@link foldKey} is the single
+ * definition of that normalization, shared by the index write path
+ * (`buildIndexedNote`) and the resolver (`normalizeWikiTarget`) so the keys
+ * written to the index can never drift from the keys looked up against it.
+ */
+
+/** Trim surrounding whitespace and case-fold `value` to its match key. */
+export function foldKey(value: string): string {
+  return value.trim().toLowerCase()
+}

--- a/packages/core/src/markdown/resolve.test.ts
+++ b/packages/core/src/markdown/resolve.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest'
-import { normalizeWikiTarget, resolveWikiLink, type WikiLookup } from './resolve'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  normalizeWikiTarget,
+  resolveWikiLink,
+  resolveWikiLinkAsync,
+  type AsyncWikiLookup,
+  type WikiLookup,
+} from './resolve'
 
 describe('normalizeWikiTarget', () => {
   it('trims and case-folds, flagging daily-date targets', () => {
@@ -27,5 +33,59 @@ describe('resolveWikiLink', () => {
 
   it('returns the original text when unresolved', () => {
     expect(resolveWikiLink('Unknown Page', lookup)).toEqual({ kind: 'unresolved', text: 'Unknown Page' })
+  })
+})
+
+describe('resolveWikiLinkAsync', () => {
+  it('applies the same date → title → alias precedence', async () => {
+    const lookup: AsyncWikiLookup = {
+      byDate: async (date) => (date === '2026-06-09' ? 'daily/2026-06-09.md' : undefined),
+      byTitle: async (key) => (key === 'project x' ? 'notes/project-x.md' : undefined),
+      byAlias: async (key) => (key === 'pjx' ? 'notes/project-x.md' : undefined),
+    }
+    expect(await resolveWikiLinkAsync('2026-06-09', lookup)).toEqual({
+      kind: 'resolved',
+      ref: 'daily/2026-06-09.md',
+    })
+    expect(await resolveWikiLinkAsync('Project X', lookup)).toEqual({
+      kind: 'resolved',
+      ref: 'notes/project-x.md',
+    })
+    expect(await resolveWikiLinkAsync('pjx', lookup)).toEqual({
+      kind: 'resolved',
+      ref: 'notes/project-x.md',
+    })
+    expect(await resolveWikiLinkAsync('Unknown', lookup)).toEqual({
+      kind: 'unresolved',
+      text: 'Unknown',
+    })
+  })
+
+  it('short-circuits: a title hit never queries the alias lookup', async () => {
+    const byAlias = vi.fn(async () => undefined)
+    const lookup: AsyncWikiLookup = {
+      byDate: async () => undefined,
+      byTitle: async () => 'notes/hit.md',
+      byAlias,
+    }
+    expect(await resolveWikiLinkAsync('Anything', lookup)).toEqual({
+      kind: 'resolved',
+      ref: 'notes/hit.md',
+    })
+    expect(byAlias).not.toHaveBeenCalled()
+  })
+
+  it('skips the date lookup for a non-date target', async () => {
+    const byDate = vi.fn(async () => 'daily/should-not-be-used.md')
+    const lookup: AsyncWikiLookup = {
+      byDate,
+      byTitle: async () => undefined,
+      byAlias: async () => 'notes/alias.md',
+    }
+    expect(await resolveWikiLinkAsync('Some Title', lookup)).toEqual({
+      kind: 'resolved',
+      ref: 'notes/alias.md',
+    })
+    expect(byDate).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/markdown/resolve.ts
+++ b/packages/core/src/markdown/resolve.ts
@@ -9,6 +9,8 @@
  * id when present" is honoured at the lookup layer.
  */
 
+import { foldKey } from './keys'
+
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 
 /** A wiki-link target normalized for matching. */
@@ -24,7 +26,7 @@ export interface NormalizedTarget {
 /** Trim, case-fold, and detect a `YYYY-MM-DD` daily-note target. */
 export function normalizeWikiTarget(target: string): NormalizedTarget {
   const raw = target.trim()
-  const normalized: NormalizedTarget = { raw, key: raw.toLowerCase() }
+  const normalized: NormalizedTarget = { raw, key: foldKey(raw) }
   if (ISO_DATE_RE.test(raw)) {
     normalized.date = raw
   }
@@ -65,5 +67,35 @@ export function resolveWikiLink(target: string, lookup: WikiLookup): Resolution 
     (normalized.date ? lookup.byDate(normalized.date) : undefined) ??
     lookup.byTitle(normalized.key) ??
     lookup.byAlias(normalized.key)
+  return ref ? resolved(ref) : unresolved(normalized.raw)
+}
+
+/**
+ * Async counterpart of {@link WikiLookup} for lookups that hit the database. The
+ * index-backed resolver (Plan 04) queries SQLite over IPC, so its lookups are
+ * inherently asynchronous; the resolution rules are otherwise identical.
+ */
+export interface AsyncWikiLookup {
+  byDate(date: string): Promise<string | undefined>
+  byTitle(key: string): Promise<string | undefined>
+  byAlias(key: string): Promise<string | undefined>
+}
+
+/**
+ * Resolve a `[[target]]` against an async (DB-backed) lookup, with the same
+ * precedence as {@link resolveWikiLink}: explicit daily-date, then title, then
+ * alias. The `??` chain short-circuits, so a title hit means the alias lookup is
+ * never queried. This keeps the resolution *policy* in one place — the
+ * index-backed `resolveWikiTarget` supplies only the data access.
+ */
+export async function resolveWikiLinkAsync(
+  target: string,
+  lookup: AsyncWikiLookup,
+): Promise<Resolution> {
+  const normalized = normalizeWikiTarget(target)
+  const ref =
+    (normalized.date ? await lookup.byDate(normalized.date) : undefined) ??
+    (await lookup.byTitle(normalized.key)) ??
+    (await lookup.byAlias(normalized.key))
   return ref ? resolved(ref) : unresolved(normalized.raw)
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -9,6 +9,7 @@
   "types": "./src/index.ts",
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
     "db:codegen": "node scripts/generate-schema.mjs"
   },
   "dependencies": {
@@ -19,6 +20,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "better-sqlite3": "^12.10.0",
     "kysely-codegen": "^0.20.0",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "vitest": "^3"
   }
 }

--- a/packages/db/src/dialect.test.ts
+++ b/packages/db/src/dialect.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+
+import { invoke } from '@tauri-apps/api/core'
+import { createDb } from './db'
+
+const mockInvoke = vi.mocked(invoke)
+
+beforeEach(() => {
+  mockInvoke.mockReset()
+})
+
+describe('IpcDialect (Kysely → db_query bridge)', () => {
+  it('compiles to snake_case SQL and ships it over db_query with params', async () => {
+    mockInvoke.mockResolvedValue([])
+    const db = createDb()
+    await db
+      .selectFrom('notes')
+      .select(['path', 'fileHash'])
+      .where('titleKey', '=', 'project x')
+      .execute()
+
+    expect(mockInvoke).toHaveBeenCalledTimes(1)
+    const [command, args] = mockInvoke.mock.calls[0]
+    expect(command).toBe('db_query')
+    const { sql, params } = args as { sql: string; params: unknown[] }
+    expect(sql).toContain('"file_hash"')
+    expect(sql).toContain('"title_key"')
+    expect(params).toEqual(['project x'])
+  })
+
+  it('maps snake_case result columns back to camelCase', async () => {
+    mockInvoke.mockResolvedValue([{ path: 'notes/a.md', file_hash: 'abc' }])
+    const db = createDb()
+    const rows = await db.selectFrom('notes').select(['path', 'fileHash']).execute()
+    expect(rows).toEqual([{ path: 'notes/a.md', fileHash: 'abc' }])
+  })
+
+  it('fails fast when the backend returns a non-array payload', async () => {
+    mockInvoke.mockResolvedValue({ not: 'an array' } as unknown)
+    const db = createDb()
+    await expect(db.selectFrom('notes').selectAll().execute()).rejects.toThrow(/row array/)
+  })
+
+  it('rejects transactions — writes go through the index_* commands', async () => {
+    mockInvoke.mockResolvedValue([])
+    const db = createDb()
+    await expect(db.transaction().execute(async () => undefined)).rejects.toThrow(
+      /transactions run in Rust/,
+    )
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^3
+        version: 3.2.6(@types/node@25.9.2)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)(yaml@2.9.0)
 
 packages:
 


### PR DESCRIPTION
## Overview

Polish of the most recent landed work — **Plan 04a (#4): local SQLite index + Kysely-over-IPC bridge** — toward best-in-class open source. The goal is fewer single-sources-of-truth to keep in sync, logic extracted into tested units, and a hardened read boundary. **No change to the indexing contract** — behavior is preserved and covered by new tests.

## What changed

### Decoupling / single source of truth
- **`db.rs` leans on `ON DELETE CASCADE`.** `apply_note`/`clear_index` previously enumerated the derived-table set in three hand-maintained `DELETE` lists. Now deleting the `notes` row cascades to every child table, so the schema is the single source of truth and new tables (Plan 09 embeddings, etc.) need no edits here. Inserts use `prepare_cached`.
- **Wiki resolution policy lives in one place.** Added `resolveWikiLinkAsync` + `AsyncWikiLookup` to `markdown/resolve.ts` (the DI seam the file was designed for). `queries.ts::resolveWikiTarget` now supplies only data access; the date→title→alias ordering is no longer duplicated.
- **Index lifecycle extracted from the provider.** The abort → settle → open → reconcile dance moves out of `GraphProvider` into `createGraphIndex` (`graph-index.ts`), now unit-tested in isolation.

### Extracted logic + tests
- `buildFtsMatch` (`search-query.ts`) and `foldKey` (`markdown/keys.ts`), each with focused tests; `searchNotes` / `normalizeWikiTarget` / `buildIndexedNote` consume them.
- New Rust test for the **production** `open_index_at` path (dir creation, WAL, idempotent reopen) and a direct `IpcDialect` test suite (added vitest to `@reflect/db`).

### Performance
- `index_apply_batch` command + `applyIndexedNotes` binding; `rebuildIndex` now applies in 256-note transactions instead of one transaction/IPC round-trip per note.

### Hardening
- `getNote` maps `isPrivate` `0|1 → boolean` at the read boundary (the `private:` hard block).
- `IndexedNote` is now zod-schema-sourced (single source via `z.infer`, mirrors the Rust struct, with a contract test). Migration adds `CHECK (kind IN ('wiki','md'))` and an `index_meta` reserved-table comment.

## Reviewer notes
- The `0001_initial.sql` edit (CHECK constraint + comment) is safe because the schema is **unreleased** — there are no shipped v1 DBs to migrate. Schema codegen confirms **no drift** in `schema.gen.ts`.
- `resolveWikiTarget` and `getNote` had **no consumers yet** (only re-exported), so the API improvements (boolean `isPrivate`, delegated resolution) land at zero blast radius.

## Verification
- `pnpm typecheck` (4 packages) ✅
- TS tests ✅ 86 — core 67, **db 4 (new)**, desktop 15 (incl. **5 new**)
- `cargo test db::` ✅ 11 (incl. **3 new**)
- `oxlint`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` ✅
- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core index write/read paths and graph-switch lifecycle; behavior is intended to be preserved but batching and CASCADE refactor warrant regression checks on rebuild and re-apply.
> 
> **Overview**
> Refactors the Plan 04 local index layer for clearer ownership, faster rebuilds, and safer reads—without changing the overall indexing contract.
> 
> **Rust / SQLite:** Note upserts and full clears rely on **`ON DELETE CASCADE`** from `notes` instead of per-table `DELETE` lists; inserts use **`prepare_cached`**. New **`index_apply_batch`** applies many notes in one transaction (shared with single-note **`index_apply`**). Migration adds **`CHECK (kind IN ('wiki','md'))`** and documents **`index_meta`** surviving **`index_clear`**.
> 
> **TypeScript pipeline:** **`rebuildIndex`** sends notes in batches of 256 via **`applyIndexedNotes`**. **`IndexedNote`** is defined with **zod schemas** (mirroring Rust serde). Shared **`foldKey`** and **`buildFtsMatch`** centralize match keys and FTS quoting; **`resolveWikiLinkAsync`** owns wiki resolution policy while **`resolveWikiTarget`** only runs DB lookups. **`getNote`** maps **`isPrivate`** to a boolean at the read boundary.
> 
> **Desktop:** Graph open/sync logic moves into testable **`createGraphIndex`** (`open` → reconcile → subscribe → watch), with **`GraphProvider`** delegating to it.
> 
> **Tests:** New coverage for graph index lifecycle, FTS match building, IPC dialect, cascade/clear behavior, and **`open_index_at`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ca0c812fb8e43d20d4a826a252ada3cd3625ece. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batched note indexing for faster rebuilds
  * Async wiki-link resolution using DB lookups
  * Safer full‑text search match construction

* **Improvements**
  * Stricter validation of link kinds in the index schema
  * More robust graph-index lifecycle and background sync
  * Index clearing now preserves bookkeeping metadata and supports batch apply

* **Tests**
  * Expanded coverage for indexing, search, and graph workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->