### PR TITLE
fix(editor): flush dirty note buffers on app quit

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -10,8 +10,11 @@
 mod db;
 mod error;
 mod fs;
+mod quit;
 mod recents;
 mod watcher;
+
+use tauri::{Emitter, Manager};
 
 /// Returns the desktop application version from Cargo metadata.
 ///
@@ -39,6 +42,7 @@ pub fn run() {
         .manage(fs::GraphState::default())
         .manage(db::IndexState::default())
         .manage(watcher::WatcherState::default())
+        .manage(quit::QuitState::default())
         .invoke_handler(tauri::generate_handler![
             app_version,
             fs::graph_open,
@@ -59,7 +63,22 @@ pub fn run() {
             db::db_query,
             watcher::watch_start,
             watcher::watch_stop,
+            quit::quit_confirm,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app, event| {
+            if let tauri::RunEvent::ExitRequested { code, api, .. } = &event {
+                // A user/OS-initiated quit (⌘Q — no exit code) with a live
+                // webview defers once so the frontend can flush dirty note
+                // buffers (`app:quit-requested` → `quit_confirm`). An exit
+                // carrying a code is the confirm itself; with no webview left
+                // the window-close path has already flushed.
+                let quit = app.state::<quit::QuitState>();
+                if code.is_none() && !quit.flushed() && !app.webview_windows().is_empty() {
+                    api.prevent_exit();
+                    let _ = app.emit("app:quit-requested", ());
+                }
+            }
+        });
 }

--- a/apps/desktop/src-tauri/src/quit.rs
+++ b/apps/desktop/src-tauri/src/quit.rs
@@ -1,0 +1,41 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tauri::{AppHandle, State};
+
+/// Quit-time flush handshake (the save pipeline's last line of defense).
+///
+/// macOS ⌘Q requests app termination without closing the window first, so the
+/// frontend's close-requested flush never runs and a debounced note save still
+/// inside its window would be lost. The run loop (lib.rs) defers that exit
+/// once and emits `app:quit-requested`; the frontend flushes dirty buffers and
+/// calls `quit_confirm`, which marks the flush done and exits for real.
+#[derive(Default)]
+pub struct QuitState {
+    flushed: AtomicBool,
+}
+
+impl QuitState {
+    pub fn flushed(&self) -> bool {
+        self.flushed.load(Ordering::SeqCst)
+    }
+}
+
+/// Confirm a deferred quit: the frontend has flushed, exit immediately.
+#[tauri::command]
+pub fn quit_confirm(app: AppHandle, state: State<'_, QuitState>) {
+    state.flushed.store(true, Ordering::SeqCst);
+    app.exit(0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn starts_unflushed_and_latches() {
+        let state = QuitState::default();
+        assert!(!state.flushed());
+        state.flushed.store(true, Ordering::SeqCst);
+        assert!(state.flushed());
+    }
+}

--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -14,7 +14,10 @@ export function App(): ReactElement {
 
   // Quit-time persistence: flush dirty note buffers before the webview dies
   // (window close, ⌘Q, reload) — unmount effects don't run on those paths.
-  useEffect(() => installQuitFlush(), [])
+  // installQuitFlush returns its teardown, which the effect returns as cleanup.
+  useEffect(() => {
+    return installQuitFlush()
+  }, [])
 
   if (status === 'ready' && graph) {
     return <GraphWorkspace graph={graph} />

--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -1,6 +1,7 @@
-import { type ReactElement } from 'react'
+import { useEffect, type ReactElement } from 'react'
 import { GraphChooser } from '@/components/graph-chooser'
 import { GraphWorkspace } from '@/components/graph-workspace'
+import { installQuitFlush } from '@/lib/quit-flush'
 import { useGraph } from '@/providers/graph-provider'
 
 /**
@@ -10,6 +11,10 @@ import { useGraph } from '@/providers/graph-provider'
  */
 export function App(): ReactElement {
   const { status, graph } = useGraph()
+
+  // Quit-time persistence: flush dirty note buffers before the webview dies
+  // (window close, ⌘Q, reload) — unmount effects don't run on those paths.
+  useEffect(() => installQuitFlush(), [])
 
   if (status === 'ready' && graph) {
     return <GraphWorkspace graph={graph} />

--- a/apps/desktop/src/editor/flush-registry.test.ts
+++ b/apps/desktop/src/editor/flush-registry.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { flushAllNotes, registerFlush } from './flush-registry'
+
+describe('flush registry', () => {
+  it('flushes every registered buffer and awaits completion', async () => {
+    const flushed: string[] = []
+    const unregisterA = registerFlush(async () => {
+      await Promise.resolve() // lands a microtask later, like a real write
+      flushed.push('a')
+    })
+    const unregisterB = registerFlush(async () => {
+      flushed.push('b')
+    })
+    try {
+      await flushAllNotes()
+      expect(flushed.sort()).toEqual(['a', 'b'])
+    } finally {
+      unregisterA()
+      unregisterB()
+    }
+  })
+
+  it('does not call an unregistered flush', async () => {
+    const flushed: string[] = []
+    registerFlush(async () => {
+      flushed.push('gone')
+    })()
+    await flushAllNotes()
+    expect(flushed).toEqual([])
+  })
+
+  it('a failing flush neither blocks the others nor rejects', async () => {
+    const flushed: string[] = []
+    const unregisterA = registerFlush(() => Promise.reject(new Error('disk full')))
+    const unregisterB = registerFlush(async () => {
+      flushed.push('b')
+    })
+    try {
+      await expect(flushAllNotes()).resolves.toBeUndefined()
+      expect(flushed).toEqual(['b'])
+    } finally {
+      unregisterA()
+      unregisterB()
+    }
+  })
+
+  it('resolves with nothing registered', async () => {
+    await expect(flushAllNotes()).resolves.toBeUndefined()
+  })
+})

--- a/apps/desktop/src/editor/flush-registry.ts
+++ b/apps/desktop/src/editor/flush-registry.ts
@@ -1,0 +1,28 @@
+/**
+ * App-global registry of the open notes' flush functions. Quit-time teardown
+ * (window close, ⌘Q, webview unload) must persist every dirty buffer before
+ * the webview dies, and React unmount effects don't run on quit — so each
+ * mounted note document registers an awaitable flush here instead.
+ */
+
+type Flush = () => Promise<void>
+
+const flushes = new Set<Flush>()
+
+/** Register a note buffer's flush; returns its unregister. */
+export function registerFlush(flush: Flush): () => void {
+  flushes.add(flush)
+  return () => {
+    flushes.delete(flush)
+  }
+}
+
+/**
+ * Flush every registered buffer and settle once all writes have. A failing
+ * flush is already surfaced per-note by the save pipeline, and teardown must
+ * proceed past it to the other buffers — so rejections are absorbed, never
+ * re-thrown.
+ */
+export async function flushAllNotes(): Promise<void> {
+  await Promise.allSettled(Array.from(flushes, (flush) => flush()))
+}

--- a/apps/desktop/src/editor/note-session.ts
+++ b/apps/desktop/src/editor/note-session.ts
@@ -98,8 +98,12 @@ export interface NoteSession {
   editorChanged: (markdown: string) => void
   /** The watcher reported an on-disk change to this note; reconcile. */
   externalChanged: () => void
-  /** Persist pending edits now (e.g. on window blur). */
-  flush: () => void
+  /**
+   * Persist pending edits now (e.g. on window blur). Resolves once the
+   * flushed write has settled — quit-time teardown awaits this so the webview
+   * can't die before the bytes land.
+   */
+  flush: () => Promise<void>
   /** Resolve a conflict by keeping the buffer (rewrites the file). */
   keepMine: () => void
   /** Resolve a conflict by loading the external content (discards the buffer). */
@@ -227,9 +231,12 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
     }
   }
 
-  function flush(): void {
+  function flush(): Promise<void> {
     cancelScheduledSave()
     save()
+    // save() extended the chain synchronously (or left it settled when there
+    // was nothing to do) — the chain as of now is exactly this flush's write.
+    return saveChain
   }
 
   function editorChanged(markdown: string): void {
@@ -395,7 +402,7 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
   function dispose(): void {
     // Flush first: the queued save step reads the (now frozen) buffer, so
     // pending edits persist to this session's path even after the UI moves on.
-    flush()
+    void flush()
     disposed = true
   }
 

--- a/apps/desktop/src/editor/use-note-document.test.tsx
+++ b/apps/desktop/src/editor/use-note-document.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { setBridge } from '@reflect/core'
+import { flushAllNotes } from './flush-registry'
 import type { NoteEditorHandle } from './note-editor'
 import { useNoteDocument } from './use-note-document'
 
@@ -82,6 +83,37 @@ describe('useNoteDocument', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('flushAllNotes persists a pending edit without waiting out the debounce (quit path)', async () => {
+    vi.useFakeTimers()
+    try {
+      const hook = renderHook(() => useNoteDocument('notes/a.md', 1))
+      await act(() => vi.advanceTimersByTimeAsync(0))
+      expect(hook.result.current.status).toBe('ready')
+
+      act(() => hook.result.current.onEditorChange('# Quitting\n'))
+      expect(writes).toEqual([]) // still inside the 800ms debounce window
+
+      // The quit path: the registry flush settles only once the write has
+      // landed — no timer advance, the way a ⌘Q teardown would run it.
+      await act(() => flushAllNotes())
+      expect(writes).toEqual(['# Quitting\n'])
+      expect(hook.result.current.dirty).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('unmounting unregisters the buffer from the quit-flush registry', async () => {
+    const hook = await readyHook()
+    act(() => hook.result.current.onEditorChange('# Edited\n'))
+    hook.unmount() // unmount itself flushes once (the existing final-flush path)
+    await act(async () => {})
+    const writesAfterUnmount = writes.length
+
+    await flushAllNotes() // the unmounted buffer must no longer be registered
+    expect(writes.length).toBe(writesAfterUnmount)
   })
 
   it('ignores the watcher echo of its own save', async () => {

--- a/apps/desktop/src/editor/use-note-document.ts
+++ b/apps/desktop/src/editor/use-note-document.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { hasBridge, readNote, subscribeFileChanges, writeNote } from '@reflect/core'
+import { registerFlush } from './flush-registry'
 import type { NoteEditorHandle } from './note-editor'
 import {
   createNoteSession,
@@ -124,14 +125,21 @@ export function useNoteDocument(
     }
   }, [path])
 
-  // Flush pending edits when the window loses focus.
+  // Flush pending edits when the window loses focus, and register with the
+  // app-global registry so quit-time teardown (window close, ⌘Q — paths where
+  // unmount effects never run) can flush this buffer too. The session's flush
+  // resolves once the write has landed, which is what makes quit wait.
   useEffect(() => {
     if (!path) {
       return
     }
-    const flush = (): void => sessionRef.current?.flush()
+    const flush = (): void => void sessionRef.current?.flush()
+    const unregister = registerFlush(async () => {
+      await sessionRef.current?.flush()
+    })
     window.addEventListener('blur', flush)
     return () => {
+      unregister()
       window.removeEventListener('blur', flush)
     }
   }, [path])

--- a/apps/desktop/src/lib/quit-flush.ts
+++ b/apps/desktop/src/lib/quit-flush.ts
@@ -1,0 +1,62 @@
+import { getCurrentWindow } from '@tauri-apps/api/window'
+import { confirmQuit, hasBridge, subscribeQuitRequested } from '@reflect/core'
+import { flushAllNotes } from '@/editor/flush-registry'
+
+/**
+ * Quit-time persistence: the webview never dies with dirty note buffers still
+ * inside their save debounce. Three exits, three hooks:
+ *
+ * - **Window close** (red button, ⌘W): registering a JS `onCloseRequested`
+ *   listener defers the close until the handler returns, so the flush is
+ *   awaited before the window is destroyed.
+ * - **App quit** (⌘Q): never reaches close-requested — the Rust shell defers
+ *   `ExitRequested` once and emits `app:quit-requested`; we flush, then
+ *   `confirmQuit()` exits for real (even if a flush failed: its error is
+ *   already surfaced per-note, and refusing to quit would trap the user).
+ * - **Webview unload** (dev reloads): `beforeunload` can't await, but writes
+ *   dispatched before teardown still reach the Rust process — a belt.
+ */
+export function installQuitFlush(): () => void {
+  // No bridge → no native shell (plain-browser dev): nothing can quit-flush.
+  // getCurrentWindow below is safe to reach only inside a Tauri webview.
+  if (!hasBridge()) {
+    return () => {}
+  }
+
+  let disposed = false
+  const disposers: Array<() => void> = []
+  const track = (dispose: () => void): void => {
+    // A subscription can resolve after teardown (StrictMode's probe mount).
+    if (disposed) {
+      dispose()
+    } else {
+      disposers.push(dispose)
+    }
+  }
+
+  void getCurrentWindow()
+    .onCloseRequested(async () => {
+      await flushAllNotes()
+    })
+    .then(track)
+
+  void subscribeQuitRequested(() => {
+    void flushAllNotes().finally(() => {
+      void confirmQuit()
+    })
+  }).then(track)
+
+  const onBeforeUnload = (): void => {
+    void flushAllNotes()
+  }
+  window.addEventListener('beforeunload', onBeforeUnload)
+  track(() => window.removeEventListener('beforeunload', onBeforeUnload))
+
+  return () => {
+    disposed = true
+    for (const dispose of disposers) {
+      dispose()
+    }
+    disposers.length = 0
+  }
+}

--- a/packages/core/src/app/quit.ts
+++ b/packages/core/src/app/quit.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod'
+import { getBridge, type Unlisten } from '../ipc/bridge'
+import { call } from '../ipc/invoke'
+
+/**
+ * The quit-time flush handshake. macOS ⌘Q requests app exit without closing
+ * the window first, so the window's close-requested flush never runs; the Rust
+ * shell defers that exit once and emits {@link QUIT_REQUESTED_EVENT}, the
+ * frontend flushes dirty note buffers, then confirms — and the confirm exits
+ * for real.
+ */
+
+/** Event name the Rust shell emits when it deferred an exit for flushing. */
+export const QUIT_REQUESTED_EVENT = 'app:quit-requested'
+
+/** Subscribe to the shell's deferred-quit notification. */
+export function subscribeQuitRequested(handler: () => void): Promise<Unlisten> {
+  return getBridge().listen(QUIT_REQUESTED_EVENT, () => {
+    handler()
+  })
+}
+
+/**
+ * Confirm a deferred quit after flushing. The app exits inside this call, so
+ * the returned promise may never settle — fire and forget.
+ */
+export function confirmQuit(): Promise<void> {
+  return call('quit_confirm', {}, z.null()).then(() => undefined)
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@
 export { setBridge, hasBridge, type IpcBridge, type Unlisten } from './ipc/bridge'
 export { call } from './ipc/invoke'
 export { getAppVersion } from './ipc/commands'
+export { confirmQuit, subscribeQuitRequested } from './app/quit'
 export { appErrorSchema, isAppError, toAppError, type AppError } from './errors'
 
 // Graph & file storage (Plan 02)


### PR DESCRIPTION
## Problem

The save pipeline debounces writes by 800ms and flushes on window blur and component unmount — but nothing flushed on app quit. `⌘Q` (or closing the window) inside the debounce window silently lost the user's last keystrokes: Tauri destroys the webview without unmount effects or a blur reliably firing. Data-loss class, flagged in the Plan 06 retrospective.

## Approach

**App-global flush registry** ([flush-registry.ts](../blob/claude/quit-flush/apps/desktop/src/editor/flush-registry.ts)): each mounted `useNoteDocument` registers an awaitable flush (`flush(); await saveChain.current` — flush only enqueues; awaiting the chain it just extended is what makes quit wait for the write to actually land) and unregisters on unmount.

**Three exits, three hooks** ([quit-flush.ts](../blob/claude/quit-flush/apps/desktop/src/lib/quit-flush.ts), installed once in `App`):
- **Window close** (red button, `⌘W`): registering a JS `onCloseRequested` listener makes Tauri defer the close until the handler returns — the flush is awaited, then the window is destroyed.
- **App quit** (`⌘Q`): never reaches close-requested on macOS. The Rust run loop defers `ExitRequested` once (only when there's no exit code, the flush hasn't been confirmed, and a webview is still alive), emits `app:quit-requested`; the frontend flushes and calls `quit_confirm`, which latches `QuitState` and exits for real. The no-webview guard keeps the window-close path (whose flush already ran) from deadlocking a headless app.
- **Webview unload** (dev reloads): `beforeunload` can't await, but writes dispatched before teardown still reach the Rust process — a belt.

**Invariants hold by construction**: flushes go through the existing serialized save chain, carry the graph generation token (a flush racing a graph switch is rejected loudly in Rust, never cross-written), and a parked conflict still pauses saves — quit never force-writes a conflicted note.

## Tests

- Registry: flush-all awaits completion, unregister excludes, a failing flush neither blocks others nor rejects, empty registry resolves.
- Pipeline: `flushAllNotes()` persists a pending edit with no timer advance (the ⌘Q path); unmount unregisters the buffer.
- Rust: `QuitState` latch; fmt/clippy/test green.

`pnpm lint` · `pnpm typecheck` · 74 core + 84 desktop + 4 db TS tests · 26 Rust tests — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the note save path and app lifecycle at exit; incorrect timing could still lose edits or block quit, but changes reuse the existing save chain and still confirm quit after flush failures.
> 
> **Overview**
> Fixes **data loss on quit** when note saves are still inside the 800ms debounce: React unmount and blur are unreliable on `⌘Q`, window close, and webview teardown.
> 
> Adds an **app-global flush registry** so each open note registers an awaitable flush; `flushAllNotes()` runs all of them with `Promise.allSettled` (failures don’t block quit). **`NoteSession.flush()`** now returns a `Promise` that settles when the serialized save chain finishes, so teardown can wait for bytes on disk.
> 
> **`installQuitFlush()`** (wired once in `App`) covers three exits: **window close** awaits flush in `onCloseRequested`; **⌘Q** uses a new Rust **`ExitRequested`** handler that defers exit once, emits `app:quit-requested`, then **`quit_confirm`** after flush; **`beforeunload`** fires a best-effort flush for dev reloads. **`@reflect/core`** exports `subscribeQuitRequested` and `confirmQuit` for the IPC handshake.
> 
> Tests cover the registry, quit-path flush without advancing debounce timers, and unmount unregistering buffers; Rust tests the `QuitState` latch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f23e3a5e55856e9f4be6bfa95c6a2c8e1e98077. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deferred quit flow with frontend confirmation to avoid accidental exits
  * Global flush-on-exit that ensures pending note edits are written on quit, window close, or reload
  * App lifecycle hookup to reliably trigger and clean up flush handlers

* **Tests**
  * Added tests covering flush registry, hook integration, and quit confirmation behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->