### PR TITLE
Settings: routed screen, config-dir persistence, editor mark-mode setting

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -5,13 +5,15 @@
 //! composition* — a command here never encodes product rules beyond the
 //! primitive it exposes. Each module wires one capability:
 //! [`fs`] (graph file IO), [`db`] (SQLite index), [`watcher`] (file events),
-//! [`recents`] (recent-graphs store), [`error`] (the shared error contract).
+//! [`recents`] (recent-graphs store), [`settings`] (user settings store),
+//! [`error`] (the shared error contract).
 
 mod db;
 mod error;
 mod fs;
 mod quit;
 mod recents;
+mod settings;
 mod watcher;
 
 use tauri::{Emitter, Manager};
@@ -55,6 +57,8 @@ pub fn run() {
             fs::list_files,
             recents::recent_graphs,
             recents::forget_recent,
+            settings::settings_load,
+            settings::settings_save,
             db::index_open,
             db::index_apply,
             db::index_apply_batch,

--- a/apps/desktop/src-tauri/src/settings.rs
+++ b/apps/desktop/src-tauri/src/settings.rs
@@ -1,0 +1,124 @@
+//! User settings store: one JSON document in the OS config dir.
+//!
+//! Settings live next to the recents store — **never** inside any one graph's
+//! `.reflect/` — because they are per-user preferences that must follow the
+//! user across graphs and survive graph deletion. Rust treats the document as
+//! an opaque JSON object (a capability, per the architecture conventions);
+//! the schema, defaults, and validation are policy and live in
+//! `@reflect/core`'s zod layer.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde_json::{Map, Value};
+use tempfile::NamedTempFile;
+
+use crate::error::{AppError, AppResult};
+
+/// The settings document: a JSON object keyed by setting name. `Map` (not
+/// `Value`) so a non-object payload is rejected at deserialization.
+pub type SettingsDoc = Map<String, Value>;
+
+fn store_path() -> AppResult<PathBuf> {
+    let base = dirs::config_dir().ok_or_else(|| AppError::io("no OS config dir"))?;
+    Ok(base.join("reflect-open").join("settings.json"))
+}
+
+/// Load the stored document. A missing store is an empty object, but a real IO
+/// error or malformed JSON is propagated — silently treating a corrupt store as
+/// empty would let the next save persist that emptiness and wipe every setting.
+fn load_from(path: &Path) -> AppResult<SettingsDoc> {
+    let raw = match fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(SettingsDoc::new()),
+        Err(err) => return Err(AppError::io(err.to_string())),
+    };
+    serde_json::from_str(&raw).map_err(|err| AppError::io(err.to_string()))
+}
+
+fn save_to(path: &Path, settings: &SettingsDoc) -> AppResult<()> {
+    let dir = path
+        .parent()
+        .ok_or_else(|| AppError::io("settings store path has no parent directory"))?;
+    fs::create_dir_all(dir)?;
+    let json =
+        serde_json::to_string_pretty(settings).map_err(|err| AppError::io(err.to_string()))?;
+    // Write to a temp file in the same dir, then atomically rename over the
+    // target so a crash mid-write can't truncate the existing store.
+    let mut tmp = NamedTempFile::new_in(dir)?;
+    tmp.write_all(json.as_bytes())?;
+    tmp.flush()?;
+    tmp.persist(path)
+        .map_err(|err| AppError::io(err.to_string()))?;
+    Ok(())
+}
+
+/// Command: the persisted settings document (an empty object on first run).
+#[tauri::command]
+pub fn settings_load() -> AppResult<SettingsDoc> {
+    load_from(&store_path()?)
+}
+
+/// Command: atomically replace the persisted settings document.
+#[tauri::command]
+pub fn settings_save(settings: SettingsDoc) -> AppResult<()> {
+    save_to(&store_path()?, &settings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    fn doc(entries: &[(&str, Value)]) -> SettingsDoc {
+        entries
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn save_load_round_trip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        let settings = doc(&[("editorMarkMode", json!("show"))]);
+        save_to(&path, &settings).unwrap();
+        assert_eq!(load_from(&path).unwrap(), settings);
+    }
+
+    #[test]
+    fn missing_store_loads_empty() {
+        let dir = tempdir().unwrap();
+        assert!(load_from(&dir.path().join("nope.json")).unwrap().is_empty());
+    }
+
+    #[test]
+    fn corrupt_store_errors_instead_of_wiping() {
+        // A malformed store must surface an error, not silently read as empty
+        // (which a later save would persist, destroying the real settings).
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        fs::write(&path, b"{ this is not json").unwrap();
+        assert!(load_from(&path).is_err());
+    }
+
+    #[test]
+    fn non_object_store_errors() {
+        // The document contract is a JSON object; a stray array/string must not
+        // load (and then round-trip) as if it were settings.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        fs::write(&path, b"[1, 2, 3]").unwrap();
+        assert!(load_from(&path).is_err());
+    }
+
+    #[test]
+    fn save_creates_parent_directories() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nested").join("settings.json");
+        save_to(&path, &doc(&[("theme", json!("dark"))])).unwrap();
+        assert_eq!(load_from(&path).unwrap(), doc(&[("theme", json!("dark"))]));
+    }
+}

--- a/apps/desktop/src-tauri/src/settings.rs
+++ b/apps/desktop/src-tauri/src/settings.rs
@@ -83,7 +83,7 @@ mod tests {
     fn save_load_round_trip() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("settings.json");
-        let settings = doc(&[("editorMarkMode", json!("show"))]);
+        let settings = doc(&[("editorMarkdownSyntax", json!("show"))]);
         save_to(&path, &settings).unwrap();
         assert_eq!(load_from(&path).unwrap(), settings);
     }

--- a/apps/desktop/src/components/graph-workspace.tsx
+++ b/apps/desktop/src/components/graph-workspace.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, type ReactElement } from 'react'
 import type { GraphInfo } from '@reflect/core'
+import { Settings } from 'lucide-react'
 import { AppShell } from '@/components/app-shell'
 import { CommandPalette } from '@/components/command-palette/command-palette'
 import { PaletteProvider, usePalette } from '@/components/command-palette/palette-provider'
 import { DailyStream } from '@/components/daily-stream'
 import { NotePane } from '@/components/note-pane'
+import { SettingsScreen } from '@/components/settings-screen'
 import { useAppVersion } from '@/hooks/use-app-version'
 import { isIsoDate } from '@/lib/dates'
 import { useToday } from '@/lib/use-today'
@@ -45,6 +47,7 @@ export function GraphWorkspace({ graph }: GraphWorkspaceProps): ReactElement {
 function WorkspaceContent({ graph }: GraphWorkspaceProps): ReactElement {
   const { resolvedTheme, setTheme } = useTheme()
   const { indexing } = useGraph()
+  const { navigate } = useRouter()
   const version = useAppVersion()
   const commandContext = useAppShortcuts()
 
@@ -84,6 +87,15 @@ function WorkspaceContent({ graph }: GraphWorkspaceProps): ReactElement {
               className="rounded-md border border-black/10 px-2.5 py-1 text-xs font-medium dark:border-white/10"
             >
               {resolvedTheme === 'dark' ? 'Light' : 'Dark'} mode
+            </button>
+            <button
+              type="button"
+              aria-label="Open settings"
+              title="Settings (⌘,)"
+              onClick={() => navigate({ kind: 'settings' })}
+              className="rounded-md border border-black/10 p-1.5 text-[color:var(--text-secondary)] dark:border-white/10"
+            >
+              <Settings aria-hidden className="size-3.5" />
             </button>
           </div>
         </header>
@@ -145,5 +157,13 @@ function RouteContent(): ReactElement {
       )
     case 'search':
       return <SearchRoute query={route.query} today={today} />
+    case 'settings':
+      return (
+        <ScrollRestored className="h-full overflow-auto px-6 py-8">
+          <div className="mx-auto w-full max-w-2xl">
+            <SettingsScreen />
+          </div>
+        </ScrollRestored>
+      )
   }
 }

--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -8,6 +8,7 @@ import { WikiAutocomplete } from '@/editor/wiki-autocomplete'
 import { createNoteWithTitle } from '@/lib/create-note'
 import { isIsoDate } from '@/lib/dates'
 import { useGraph } from '@/providers/graph-provider'
+import { useSettings } from '@/providers/settings-provider'
 import { useRouter } from '@/routing/router'
 import { routeForPath } from '@/routing/route'
 
@@ -38,6 +39,7 @@ export function NotePane({
 }: NotePaneProps): ReactElement {
   const { graph } = useGraph()
   const { navigate } = useRouter()
+  const { settings } = useSettings()
   const graphRoot = graph?.root ?? null
   const generation = graph?.generation ?? null
   const document = useNoteDocument(path, generation, {
@@ -206,6 +208,7 @@ export function NotePane({
         key={path}
         initialContent={document.initialContent}
         onChange={document.onEditorChange}
+        markMode={settings.editorMarkMode}
         images={images}
         onWikiLinkClick={onWikiLinkClick}
         handleRef={handleRef}

--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -208,7 +208,7 @@ export function NotePane({
         key={path}
         initialContent={document.initialContent}
         onChange={document.onEditorChange}
-        markMode={settings.editorMarkMode}
+        markMode={settings.editorMarkdownSyntax}
         images={images}
         onWikiLinkClick={onWikiLinkClick}
         handleRef={handleRef}

--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -62,7 +62,7 @@ afterEach(() => {
 
 describe('SettingsScreen', () => {
   it('reflects the persisted markdown syntax mode', async () => {
-    stored = { editorMarkMode: 'show' }
+    stored = { editorMarkdownSyntax: 'show' }
     renderScreen()
     await waitFor(() => expect(radio(/^show/i).checked).toBe(true))
     expect(radio(/^focus/i).checked).toBe(false)
@@ -74,7 +74,7 @@ describe('SettingsScreen', () => {
 
     fireEvent.click(radio(/^show/i))
 
-    await waitFor(() => expect(saved).toEqual([{ editorMarkMode: 'show' }]))
+    await waitFor(() => expect(saved).toEqual([{ editorMarkdownSyntax: 'show' }]))
     expect(radio(/^show/i).checked).toBe(true)
     expect(radio(/^focus/i).checked).toBe(false)
   })

--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -1,0 +1,81 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { setBridge } from '@reflect/core'
+import { SettingsProvider } from '@/providers/settings-provider'
+import { SettingsScreen } from './settings-screen'
+
+let stored: Record<string, unknown>
+let saved: unknown[]
+
+function installFakeBridge(): void {
+  saved = []
+  setBridge({
+    invoke: async (command, args) => {
+      switch (command) {
+        case 'settings_load':
+          return stored
+        case 'settings_save':
+          saved.push(args.settings)
+          return null
+        default:
+          return null
+      }
+    },
+    listen: async () => () => {},
+  })
+}
+
+let queryClient: QueryClient
+
+function renderScreen(): void {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <SettingsProvider>
+        <SettingsScreen />
+      </SettingsProvider>
+    </QueryClientProvider>,
+  )
+}
+
+function radio(name: RegExp): HTMLInputElement {
+  const element = screen.getByRole('radio', { name })
+  if (!(element instanceof HTMLInputElement)) {
+    throw new Error('expected an <input type="radio">')
+  }
+  return element
+}
+
+beforeEach(() => {
+  stored = {}
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  })
+  installFakeBridge()
+})
+
+afterEach(() => {
+  cleanup() // `globals: false` disables testing-library's automatic cleanup
+  setBridge(null)
+  queryClient.clear()
+})
+
+describe('SettingsScreen', () => {
+  it('reflects the persisted markdown syntax mode', async () => {
+    stored = { editorMarkMode: 'show' }
+    renderScreen()
+    await waitFor(() => expect(radio(/^show/i).checked).toBe(true))
+    expect(radio(/^focus/i).checked).toBe(false)
+  })
+
+  it('selecting Show applies instantly and persists', async () => {
+    renderScreen()
+    await waitFor(() => expect(radio(/^focus/i).checked).toBe(true))
+
+    fireEvent.click(radio(/^show/i))
+
+    await waitFor(() => expect(saved).toEqual([{ editorMarkMode: 'show' }]))
+    expect(radio(/^show/i).checked).toBe(true)
+    expect(radio(/^focus/i).checked).toBe(false)
+  })
+})

--- a/apps/desktop/src/components/settings-screen.tsx
+++ b/apps/desktop/src/components/settings-screen.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react'
-import type { EditorMarkMode } from '@reflect/core'
+import type { EditorMarkdownSyntax } from '@reflect/core'
 import { useSettings } from '@/providers/settings-provider'
 
 /**
@@ -8,13 +8,13 @@ import { useSettings } from '@/providers/settings-provider'
  * {@link useSettings}; there is no save button.
  */
 
-interface MarkModeOption {
-  value: EditorMarkMode
+interface MarkdownSyntaxOption {
+  value: EditorMarkdownSyntax
   label: string
   description: string
 }
 
-const MARK_MODE_OPTIONS: MarkModeOption[] = [
+const MARKDOWN_SYNTAX_OPTIONS: MarkdownSyntaxOption[] = [
   {
     value: 'focus',
     label: 'Focus',
@@ -45,8 +45,8 @@ export function SettingsScreen(): ReactElement {
             How literal markdown characters (#, **, [[ ]]) are displayed while editing.
           </p>
           <div className="mt-3 flex flex-col gap-2">
-            {MARK_MODE_OPTIONS.map((option) => {
-              const selected = settings.editorMarkMode === option.value
+            {MARKDOWN_SYNTAX_OPTIONS.map((option) => {
+              const selected = settings.editorMarkdownSyntax === option.value
               return (
                 <label
                   key={option.value}
@@ -58,10 +58,10 @@ export function SettingsScreen(): ReactElement {
                 >
                   <input
                     type="radio"
-                    name="editor-mark-mode"
+                    name="editor-markdown-syntax"
                     value={option.value}
                     checked={selected}
-                    onChange={() => updateSettings({ editorMarkMode: option.value })}
+                    onChange={() => updateSettings({ editorMarkdownSyntax: option.value })}
                     className="mt-0.5 accent-[var(--accent)]"
                   />
                   <span>

--- a/apps/desktop/src/components/settings-screen.tsx
+++ b/apps/desktop/src/components/settings-screen.tsx
@@ -1,0 +1,81 @@
+import type { ReactElement } from 'react'
+import type { EditorMarkMode } from '@reflect/core'
+import { useSettings } from '@/providers/settings-provider'
+
+/**
+ * The settings screen (a routed view, like notes — reached via ⌘, or the
+ * palette's "Open settings"). Every control applies instantly through
+ * {@link useSettings}; there is no save button.
+ */
+
+interface MarkModeOption {
+  value: EditorMarkMode
+  label: string
+  description: string
+}
+
+const MARK_MODE_OPTIONS: MarkModeOption[] = [
+  {
+    value: 'focus',
+    label: 'Focus',
+    description: 'Markdown syntax stays hidden and is revealed around your cursor as you edit.',
+  },
+  {
+    value: 'show',
+    label: 'Show',
+    description: 'Markdown syntax characters are always visible.',
+  },
+]
+
+export function SettingsScreen(): ReactElement {
+  const { settings, updateSettings } = useSettings()
+
+  return (
+    <div aria-label="Settings">
+      <h1 className="text-lg font-semibold">Settings</h1>
+
+      <section className="mt-8">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-[color:var(--text-secondary)]">
+          Editor
+        </h2>
+
+        <fieldset className="mt-4">
+          <legend className="text-sm font-medium">Markdown syntax</legend>
+          <p className="mt-1 text-xs text-[color:var(--text-muted)]">
+            How literal markdown characters (#, **, [[ ]]) are displayed while editing.
+          </p>
+          <div className="mt-3 flex flex-col gap-2">
+            {MARK_MODE_OPTIONS.map((option) => {
+              const selected = settings.editorMarkMode === option.value
+              return (
+                <label
+                  key={option.value}
+                  className={`flex cursor-pointer items-start gap-3 rounded-md border px-3 py-2.5 ${
+                    selected
+                      ? 'border-[var(--accent)] bg-[var(--accent-soft,rgb(99_102_241/0.08))]'
+                      : 'border-black/10 dark:border-white/10'
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="editor-mark-mode"
+                    value={option.value}
+                    checked={selected}
+                    onChange={() => updateSettings({ editorMarkMode: option.value })}
+                    className="mt-0.5 accent-[var(--accent)]"
+                  />
+                  <span>
+                    <span className="block text-sm font-medium">{option.label}</span>
+                    <span className="mt-0.5 block text-xs text-[color:var(--text-muted)]">
+                      {option.description}
+                    </span>
+                  </span>
+                </label>
+              )
+            })}
+          </div>
+        </fieldset>
+      </section>
+    </div>
+  )
+}

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -51,6 +51,12 @@ describe('app commands', () => {
     expect(context.toggleTheme).toHaveBeenCalled()
   })
 
+  it('settings.open navigates to the settings screen', async () => {
+    const { context, navigated } = fakeContext()
+    await command('settings.open').run(context)
+    expect(navigated).toEqual([{ kind: 'settings' }])
+  })
+
   it('note.new navigates to a fresh lazy ULID note path', async () => {
     const { context, navigated } = fakeContext()
     await command('note.new').run(context)

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -64,6 +64,13 @@ const APP_COMMANDS: AppCommand[] = [
     run: (context) => context.toggleTheme(),
   },
   {
+    id: 'settings.open',
+    title: 'Open settings',
+    keywords: ['preferences', 'config', 'options'],
+    keybinding: 'Mod-,',
+    run: (context) => context.navigate({ kind: 'settings' }),
+  },
+  {
     id: 'index.rebuild',
     title: 'Rebuild search index',
     keywords: ['reindex', 'refresh'],

--- a/apps/desktop/src/lib/quit-flush.ts
+++ b/apps/desktop/src/lib/quit-flush.ts
@@ -1,10 +1,12 @@
 import { getCurrentWindow } from '@tauri-apps/api/window'
 import { confirmQuit, hasBridge, subscribeQuitRequested } from '@reflect/core'
 import { flushOpenDocuments } from '@/editor/open-documents'
+import { flushSettings } from '@/lib/settings-flush'
 
 /**
  * Quit-time persistence: the webview never dies with dirty note buffers still
- * inside their save debounce. Three exits, three hooks:
+ * inside their save debounce — or with settings writes still in their queue.
+ * Three exits, three hooks:
  *
  * - **Window close** (red button, ⌘W): registering a JS `onCloseRequested`
  *   listener defers the close until the handler returns, so the flush is
@@ -36,18 +38,19 @@ export function installQuitFlush(): () => void {
 
   void getCurrentWindow()
     .onCloseRequested(async () => {
-      await flushOpenDocuments()
+      await Promise.all([flushOpenDocuments(), flushSettings()])
     })
     .then(track)
 
   void subscribeQuitRequested(() => {
-    void flushOpenDocuments().finally(() => {
+    void Promise.allSettled([flushOpenDocuments(), flushSettings()]).then(() => {
       void confirmQuit()
     })
   }).then(track)
 
   const onBeforeUnload = (): void => {
     void flushOpenDocuments()
+    void flushSettings()
   }
   window.addEventListener('beforeunload', onBeforeUnload)
   track(() => window.removeEventListener('beforeunload', onBeforeUnload))

--- a/apps/desktop/src/lib/settings-flush.ts
+++ b/apps/desktop/src/lib/settings-flush.ts
@@ -1,0 +1,24 @@
+/**
+ * Quit-time flush hook for settings. The persist queue lives inside the
+ * settings provider, but quit flushing is installed at module level (see
+ * `installQuitFlush`), so the provider registers its flusher in this slot —
+ * the same session-owned shape as the open-documents service.
+ */
+
+type SettingsFlush = () => Promise<void>
+
+let flusher: SettingsFlush | null = null
+
+/** Register (or clear, with `null`) the mounted provider's flusher. */
+export function setSettingsFlusher(flush: SettingsFlush | null): void {
+  flusher = flush
+}
+
+/**
+ * Persist any unconfirmed settings and drain the write queue. Resolves (never
+ * rejects) once pending writes have settled; a no-op when no provider is
+ * mounted or nothing changed.
+ */
+export function flushSettings(): Promise<void> {
+  return flusher?.() ?? Promise.resolve()
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -6,6 +6,7 @@ import { queryClient } from '@/lib/query-client'
 import { registerAppCommands } from '@/lib/commands/app-commands'
 import { installTauriBridge } from '@/lib/tauri-bridge'
 import { GraphProvider } from '@/providers/graph-provider'
+import { SettingsProvider } from '@/providers/settings-provider'
 import { ThemeProvider } from '@/providers/theme-provider'
 import '@/styles/index.css'
 
@@ -21,9 +22,11 @@ createRoot(rootElement).render(
   <StrictMode>
     <ThemeProvider>
       <QueryClientProvider client={queryClient}>
-        <GraphProvider>
-          <App />
-        </GraphProvider>
+        <SettingsProvider>
+          <GraphProvider>
+            <App />
+          </GraphProvider>
+        </SettingsProvider>
       </QueryClientProvider>
     </ThemeProvider>
   </StrictMode>,

--- a/apps/desktop/src/providers/settings-provider.test.tsx
+++ b/apps/desktop/src/providers/settings-provider.test.tsx
@@ -127,6 +127,33 @@ describe('SettingsProvider', () => {
     await waitFor(() => expect(result.current.settings.editorMarkMode).toBe('show'))
   })
 
+  it('compounding updates racing the initial load settle on the last one', async () => {
+    // Two updates while settings_load is in flight: their cancellation
+    // callbacks settle in *reverse* order (the second cancel finds nothing in
+    // flight), so an unguarded stale re-apply would resurrect the first value.
+    stored = { editorMarkMode: 'focus' }
+    gateLoad = true
+    const { result } = renderHook(() => useSettings(), { wrapper })
+
+    act(() => {
+      result.current.updateSettings({ editorMarkMode: 'show' })
+      result.current.updateSettings({ editorMarkMode: 'focus' })
+    })
+    act(() => {
+      releaseLoad()
+    })
+    await waitFor(() =>
+      expect(saved).toEqual([{ editorMarkMode: 'show' }, { editorMarkMode: 'focus' }]),
+    )
+    await waitFor(() => expect(result.current.settings.editorMarkMode).toBe('focus'))
+    // Let every queued cancellation callback drain, then re-check: a stale
+    // re-apply would flip the value back to 'show' here.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(result.current.settings.editorMarkMode).toBe('focus')
+  })
+
   it('keeps the applied value when the save fails', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     try {

--- a/apps/desktop/src/providers/settings-provider.test.tsx
+++ b/apps/desktop/src/providers/settings-provider.test.tsx
@@ -1,0 +1,148 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import { setBridge } from '@reflect/core'
+import { SettingsProvider, useSettings } from './settings-provider'
+
+/**
+ * Exercises the instant-apply contract: defaults while the load is in flight,
+ * updates winning over a racing initial load, full-document persistence
+ * (unknown keys included), and a failed save leaving the applied value alone.
+ */
+
+let stored: Record<string, unknown>
+let saved: unknown[]
+let failSaves: boolean
+/** When set, `settings_load` blocks until {@link releaseLoad} is called. */
+let pendingLoad: (() => void) | null
+let gateLoad: boolean
+
+function releaseLoad(): void {
+  pendingLoad?.()
+  pendingLoad = null
+}
+
+function installFakeBridge(): void {
+  saved = []
+  failSaves = false
+  gateLoad = false
+  pendingLoad = null
+  setBridge({
+    invoke: async (command, args) => {
+      switch (command) {
+        case 'settings_load':
+          if (gateLoad) {
+            await new Promise<void>((resolve) => {
+              pendingLoad = resolve
+            })
+          }
+          return stored
+        case 'settings_save':
+          if (failSaves) {
+            throw { kind: 'io', message: 'disk full' }
+          }
+          saved.push(args.settings)
+          return null
+        default:
+          return null
+      }
+    },
+    listen: async () => () => {},
+  })
+}
+
+let queryClient: QueryClient
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>
+    <SettingsProvider>{children}</SettingsProvider>
+  </QueryClientProvider>
+)
+
+beforeEach(() => {
+  stored = {}
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  })
+  installFakeBridge()
+})
+
+afterEach(() => {
+  cleanup() // `globals: false` disables testing-library's automatic cleanup
+  setBridge(null)
+  queryClient.clear()
+})
+
+describe('SettingsProvider', () => {
+  it('serves defaults immediately, then the persisted document', async () => {
+    stored = { editorMarkMode: 'show' }
+    const { result } = renderHook(() => useSettings(), { wrapper })
+    // Defaults are usable before the IPC load settles — no loading gate.
+    expect(result.current.settings.editorMarkMode).toBe('focus')
+    await waitFor(() => expect(result.current.settings.editorMarkMode).toBe('show'))
+  })
+
+  it('normalizes an invalid persisted value to its default', async () => {
+    stored = { editorMarkMode: 'sideways' }
+    const { result } = renderHook(() => useSettings(), { wrapper })
+    await waitFor(() =>
+      expect(queryClient.getQueryData(['settings'])).toBeDefined(),
+    )
+    expect(result.current.settings.editorMarkMode).toBe('focus')
+  })
+
+  it('applies an update and persists the full document, unknown keys included', async () => {
+    stored = { editorMarkMode: 'focus', futureKey: true }
+    const { result } = renderHook(() => useSettings(), { wrapper })
+    await waitFor(() => expect(result.current.settings).toMatchObject({ futureKey: true }))
+
+    act(() => {
+      result.current.updateSettings({ editorMarkMode: 'show' })
+    })
+    // Applied without waiting for any IO — the cache is written synchronously
+    // (consumers re-render on the next notification tick).
+    expect(queryClient.getQueryData(['settings'])).toMatchObject({ editorMarkMode: 'show' })
+    await waitFor(() => expect(result.current.settings.editorMarkMode).toBe('show'))
+    // The persisted document keeps unknown keys (newer-version settings survive).
+    await waitFor(() =>
+      expect(saved).toEqual([{ editorMarkMode: 'show', futureKey: true }]),
+    )
+  })
+
+  it('an update racing the initial load wins over the load result', async () => {
+    stored = { editorMarkMode: 'focus' }
+    gateLoad = true
+    const { result } = renderHook(() => useSettings(), { wrapper })
+
+    // Update while settings_load is still in flight…
+    act(() => {
+      result.current.updateSettings({ editorMarkMode: 'show' })
+    })
+    // …then let the (now stale) load finish. It must not clobber the update.
+    act(() => {
+      releaseLoad()
+    })
+    await waitFor(() => expect(saved).toEqual([{ editorMarkMode: 'show' }]))
+    await waitFor(() => expect(result.current.settings.editorMarkMode).toBe('show'))
+  })
+
+  it('keeps the applied value when the save fails', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const { result } = renderHook(() => useSettings(), { wrapper })
+      await waitFor(() =>
+        expect(queryClient.getQueryData(['settings'])).toBeDefined(),
+      )
+
+      failSaves = true
+      act(() => {
+        result.current.updateSettings({ editorMarkMode: 'show' })
+      })
+      await waitFor(() => expect(errorSpy).toHaveBeenCalled())
+      expect(result.current.settings.editorMarkMode).toBe('show')
+    } finally {
+      errorSpy.mockRestore()
+    }
+  })
+})

--- a/apps/desktop/src/providers/settings-provider.test.tsx
+++ b/apps/desktop/src/providers/settings-provider.test.tsx
@@ -3,12 +3,13 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
 import { setBridge } from '@reflect/core'
-import { SettingsProvider, useSettings } from './settings-provider'
+import { SETTINGS_QUERY_KEY, SettingsProvider, useSettings } from './settings-provider'
 
 /**
- * Exercises the instant-apply contract: defaults while the load is in flight,
- * updates winning over a racing initial load, full-document persistence
- * (unknown keys included), and a failed save leaving the applied value alone.
+ * Exercises the hydration + overrides contract: defaults while the load is in
+ * flight, updates winning over a racing initial load, persistence deferred
+ * until hydration (an early save must not drop passthrough keys on disk), and
+ * a failed save leaving the applied value alone.
  */
 
 let stored: Record<string, unknown>
@@ -60,6 +61,11 @@ const wrapper = ({ children }: { children: ReactNode }) => (
   </QueryClientProvider>
 )
 
+/** Resolves once the initial settings_load has populated the query cache. */
+async function loadSettled(): Promise<void> {
+  await waitFor(() => expect(queryClient.getQueryData(SETTINGS_QUERY_KEY)).toBeDefined())
+}
+
 beforeEach(() => {
   stored = {}
   queryClient = new QueryClient({
@@ -81,37 +87,35 @@ describe('SettingsProvider', () => {
     // Defaults are usable before the IPC load settles — no loading gate.
     expect(result.current.settings.editorMarkMode).toBe('focus')
     await waitFor(() => expect(result.current.settings.editorMarkMode).toBe('show'))
+    // Hydration alone must not write the store back.
+    expect(saved).toEqual([])
   })
 
   it('normalizes an invalid persisted value to its default', async () => {
     stored = { editorMarkMode: 'sideways' }
     const { result } = renderHook(() => useSettings(), { wrapper })
-    await waitFor(() =>
-      expect(queryClient.getQueryData(['settings'])).toBeDefined(),
-    )
+    await loadSettled()
     expect(result.current.settings.editorMarkMode).toBe('focus')
   })
 
-  it('applies an update and persists the full document, unknown keys included', async () => {
+  it('applies an update instantly and persists the full document', async () => {
     stored = { editorMarkMode: 'focus', futureKey: true }
     const { result } = renderHook(() => useSettings(), { wrapper })
-    await waitFor(() => expect(result.current.settings).toMatchObject({ futureKey: true }))
+    await loadSettled()
 
     act(() => {
       result.current.updateSettings({ editorMarkMode: 'show' })
     })
-    // Applied without waiting for any IO — the cache is written synchronously
-    // (consumers re-render on the next notification tick).
-    expect(queryClient.getQueryData(['settings'])).toMatchObject({ editorMarkMode: 'show' })
-    await waitFor(() => expect(result.current.settings.editorMarkMode).toBe('show'))
+    // Applied synchronously — plain React state, no IO in the way.
+    expect(result.current.settings.editorMarkMode).toBe('show')
     // The persisted document keeps unknown keys (newer-version settings survive).
     await waitFor(() =>
       expect(saved).toEqual([{ editorMarkMode: 'show', futureKey: true }]),
     )
   })
 
-  it('an update racing the initial load wins over the load result', async () => {
-    stored = { editorMarkMode: 'focus' }
+  it('an update racing the initial load wins and keeps passthrough keys', async () => {
+    stored = { editorMarkMode: 'focus', futureKey: true }
     gateLoad = true
     const { result } = renderHook(() => useSettings(), { wrapper })
 
@@ -119,19 +123,24 @@ describe('SettingsProvider', () => {
     act(() => {
       result.current.updateSettings({ editorMarkMode: 'show' })
     })
-    // …then let the (now stale) load finish. It must not clobber the update.
+    expect(result.current.settings.editorMarkMode).toBe('show')
+    // …and nothing may hit the disk before the disk has been read: a save
+    // built from defaults would drop `futureKey` permanently.
+    expect(saved).toEqual([])
+
     act(() => {
       releaseLoad()
     })
-    await waitFor(() => expect(saved).toEqual([{ editorMarkMode: 'show' }]))
-    await waitFor(() => expect(result.current.settings.editorMarkMode).toBe('show'))
+    // The load result must not clobber the update, and the deferred flush
+    // persists the update merged over the *loaded* document.
+    await waitFor(() =>
+      expect(saved).toEqual([{ editorMarkMode: 'show', futureKey: true }]),
+    )
+    expect(result.current.settings.editorMarkMode).toBe('show')
   })
 
-  it('compounding updates racing the initial load settle on the last one', async () => {
-    // Two updates while settings_load is in flight: their cancellation
-    // callbacks settle in *reverse* order (the second cancel finds nothing in
-    // flight), so an unguarded stale re-apply would resurrect the first value.
-    stored = { editorMarkMode: 'focus' }
+  it('compounding updates racing the initial load flush as one document', async () => {
+    stored = { editorMarkMode: 'show' }
     gateLoad = true
     const { result } = renderHook(() => useSettings(), { wrapper })
 
@@ -142,15 +151,7 @@ describe('SettingsProvider', () => {
     act(() => {
       releaseLoad()
     })
-    await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkMode: 'show' }, { editorMarkMode: 'focus' }]),
-    )
-    await waitFor(() => expect(result.current.settings.editorMarkMode).toBe('focus'))
-    // Let every queued cancellation callback drain, then re-check: a stale
-    // re-apply would flip the value back to 'show' here.
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0))
-    })
+    await waitFor(() => expect(saved).toEqual([{ editorMarkMode: 'focus' }]))
     expect(result.current.settings.editorMarkMode).toBe('focus')
   })
 
@@ -158,9 +159,7 @@ describe('SettingsProvider', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     try {
       const { result } = renderHook(() => useSettings(), { wrapper })
-      await waitFor(() =>
-        expect(queryClient.getQueryData(['settings'])).toBeDefined(),
-      )
+      await loadSettled()
 
       failSaves = true
       act(() => {

--- a/apps/desktop/src/providers/settings-provider.test.tsx
+++ b/apps/desktop/src/providers/settings-provider.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { ReactNode } from 'react'
 import { setBridge } from '@reflect/core'
 import { resetOperations, useOperations } from '@/lib/operations'
+import { flushSettings } from '@/lib/settings-flush'
 import { SETTINGS_QUERY_KEY, SettingsProvider, useSettings } from './settings-provider'
 
 /**
@@ -16,6 +17,7 @@ import { SETTINGS_QUERY_KEY, SettingsProvider, useSettings } from './settings-pr
 let stored: Record<string, unknown>
 let saved: unknown[]
 let failSaves: boolean
+let failLoad: boolean
 /** When set, `settings_load` blocks until {@link releaseLoad} is called. */
 let pendingLoad: (() => void) | null
 let gateLoad: boolean
@@ -28,12 +30,16 @@ function releaseLoad(): void {
 function installFakeBridge(): void {
   saved = []
   failSaves = false
+  failLoad = false
   gateLoad = false
   pendingLoad = null
   setBridge({
     invoke: async (command, args) => {
       switch (command) {
         case 'settings_load':
+          if (failLoad) {
+            throw { kind: 'io', message: 'corrupt store' }
+          }
           if (gateLoad) {
             await new Promise<void>((resolve) => {
               pendingLoad = resolve
@@ -174,5 +180,73 @@ describe('SettingsProvider', () => {
       ]),
     )
     expect(result.current.settings.editorMarkdownSyntax).toBe('show')
+  })
+
+  it('retries an unconfirmed save on the next update, even to the same value', async () => {
+    const { result } = renderHook(
+      () => ({ ...useSettings(), operations: useOperations() }),
+      { wrapper },
+    )
+    await loadSettled()
+
+    failSaves = true
+    act(() => {
+      result.current.updateSettings({ editorMarkdownSyntax: 'show' })
+    })
+    await waitFor(() => expect(result.current.operations).toHaveLength(1))
+    expect(saved).toEqual([])
+
+    // Disk recovered; re-applying the same value must re-attempt the write —
+    // `lastPersisted` only advances on a *confirmed* save.
+    failSaves = false
+    act(() => {
+      result.current.updateSettings({ editorMarkdownSyntax: 'show' })
+    })
+    await waitFor(() => expect(saved).toEqual([{ editorMarkdownSyntax: 'show' }]))
+  })
+
+  it('the quit flush persists changes a failed save left unconfirmed', async () => {
+    const { result } = renderHook(
+      () => ({ ...useSettings(), operations: useOperations() }),
+      { wrapper },
+    )
+    await loadSettled()
+
+    failSaves = true
+    act(() => {
+      result.current.updateSettings({ editorMarkdownSyntax: 'show' })
+    })
+    await waitFor(() => expect(result.current.operations).toHaveLength(1))
+    expect(saved).toEqual([])
+
+    failSaves = false
+    await act(async () => {
+      await flushSettings()
+    })
+    expect(saved).toEqual([{ editorMarkdownSyntax: 'show' }])
+  })
+
+  it('surfaces a failed load and keeps changes session-only', async () => {
+    failLoad = true
+    const { result } = renderHook(
+      () => ({ ...useSettings(), operations: useOperations() }),
+      { wrapper },
+    )
+    await waitFor(() =>
+      expect(result.current.operations).toMatchObject([
+        { label: 'Loading settings', status: 'failed', error: 'corrupt store' },
+      ]),
+    )
+
+    // Changes still apply for the session, but nothing may be written over a
+    // store that couldn't be read — a defaults-built save could wipe it.
+    act(() => {
+      result.current.updateSettings({ editorMarkdownSyntax: 'show' })
+    })
+    expect(result.current.settings.editorMarkdownSyntax).toBe('show')
+    await act(async () => {
+      await flushSettings()
+    })
+    expect(saved).toEqual([])
   })
 })

--- a/apps/desktop/src/providers/settings-provider.test.tsx
+++ b/apps/desktop/src/providers/settings-provider.test.tsx
@@ -1,8 +1,9 @@
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { ReactNode } from 'react'
 import { setBridge } from '@reflect/core'
+import { resetOperations, useOperations } from '@/lib/operations'
 import { SETTINGS_QUERY_KEY, SettingsProvider, useSettings } from './settings-provider'
 
 /**
@@ -78,52 +79,53 @@ afterEach(() => {
   cleanup() // `globals: false` disables testing-library's automatic cleanup
   setBridge(null)
   queryClient.clear()
+  resetOperations() // failed-save entries linger on a timer otherwise
 })
 
 describe('SettingsProvider', () => {
   it('serves defaults immediately, then the persisted document', async () => {
-    stored = { editorMarkMode: 'show' }
+    stored = { editorMarkdownSyntax: 'show' }
     const { result } = renderHook(() => useSettings(), { wrapper })
     // Defaults are usable before the IPC load settles — no loading gate.
-    expect(result.current.settings.editorMarkMode).toBe('focus')
-    await waitFor(() => expect(result.current.settings.editorMarkMode).toBe('show'))
+    expect(result.current.settings.editorMarkdownSyntax).toBe('focus')
+    await waitFor(() => expect(result.current.settings.editorMarkdownSyntax).toBe('show'))
     // Hydration alone must not write the store back.
     expect(saved).toEqual([])
   })
 
   it('normalizes an invalid persisted value to its default', async () => {
-    stored = { editorMarkMode: 'sideways' }
+    stored = { editorMarkdownSyntax: 'sideways' }
     const { result } = renderHook(() => useSettings(), { wrapper })
     await loadSettled()
-    expect(result.current.settings.editorMarkMode).toBe('focus')
+    expect(result.current.settings.editorMarkdownSyntax).toBe('focus')
   })
 
   it('applies an update instantly and persists the full document', async () => {
-    stored = { editorMarkMode: 'focus', futureKey: true }
+    stored = { editorMarkdownSyntax: 'focus', futureKey: true }
     const { result } = renderHook(() => useSettings(), { wrapper })
     await loadSettled()
 
     act(() => {
-      result.current.updateSettings({ editorMarkMode: 'show' })
+      result.current.updateSettings({ editorMarkdownSyntax: 'show' })
     })
     // Applied synchronously — plain React state, no IO in the way.
-    expect(result.current.settings.editorMarkMode).toBe('show')
+    expect(result.current.settings.editorMarkdownSyntax).toBe('show')
     // The persisted document keeps unknown keys (newer-version settings survive).
     await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkMode: 'show', futureKey: true }]),
+      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', futureKey: true }]),
     )
   })
 
   it('an update racing the initial load wins and keeps passthrough keys', async () => {
-    stored = { editorMarkMode: 'focus', futureKey: true }
+    stored = { editorMarkdownSyntax: 'focus', futureKey: true }
     gateLoad = true
     const { result } = renderHook(() => useSettings(), { wrapper })
 
     // Update while settings_load is still in flight…
     act(() => {
-      result.current.updateSettings({ editorMarkMode: 'show' })
+      result.current.updateSettings({ editorMarkdownSyntax: 'show' })
     })
-    expect(result.current.settings.editorMarkMode).toBe('show')
+    expect(result.current.settings.editorMarkdownSyntax).toBe('show')
     // …and nothing may hit the disk before the disk has been read: a save
     // built from defaults would drop `futureKey` permanently.
     expect(saved).toEqual([])
@@ -134,41 +136,43 @@ describe('SettingsProvider', () => {
     // The load result must not clobber the update, and the deferred flush
     // persists the update merged over the *loaded* document.
     await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkMode: 'show', futureKey: true }]),
+      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', futureKey: true }]),
     )
-    expect(result.current.settings.editorMarkMode).toBe('show')
+    expect(result.current.settings.editorMarkdownSyntax).toBe('show')
   })
 
   it('compounding updates racing the initial load flush as one document', async () => {
-    stored = { editorMarkMode: 'show' }
+    stored = { editorMarkdownSyntax: 'show' }
     gateLoad = true
     const { result } = renderHook(() => useSettings(), { wrapper })
 
     act(() => {
-      result.current.updateSettings({ editorMarkMode: 'show' })
-      result.current.updateSettings({ editorMarkMode: 'focus' })
+      result.current.updateSettings({ editorMarkdownSyntax: 'show' })
+      result.current.updateSettings({ editorMarkdownSyntax: 'focus' })
     })
     act(() => {
       releaseLoad()
     })
-    await waitFor(() => expect(saved).toEqual([{ editorMarkMode: 'focus' }]))
-    expect(result.current.settings.editorMarkMode).toBe('focus')
+    await waitFor(() => expect(saved).toEqual([{ editorMarkdownSyntax: 'focus' }]))
+    expect(result.current.settings.editorMarkdownSyntax).toBe('focus')
   })
 
-  it('keeps the applied value when the save fails', async () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    try {
-      const { result } = renderHook(() => useSettings(), { wrapper })
-      await loadSettled()
+  it('keeps the applied value and surfaces a failed save as an operation', async () => {
+    const { result } = renderHook(
+      () => ({ ...useSettings(), operations: useOperations() }),
+      { wrapper },
+    )
+    await loadSettled()
 
-      failSaves = true
-      act(() => {
-        result.current.updateSettings({ editorMarkMode: 'show' })
-      })
-      await waitFor(() => expect(errorSpy).toHaveBeenCalled())
-      expect(result.current.settings.editorMarkMode).toBe('show')
-    } finally {
-      errorSpy.mockRestore()
-    }
+    failSaves = true
+    act(() => {
+      result.current.updateSettings({ editorMarkdownSyntax: 'show' })
+    })
+    await waitFor(() =>
+      expect(result.current.operations).toMatchObject([
+        { label: 'Saving settings', status: 'failed', error: 'disk full' },
+      ]),
+    )
+    expect(result.current.settings.editorMarkdownSyntax).toBe('show')
   })
 })

--- a/apps/desktop/src/providers/settings-provider.tsx
+++ b/apps/desktop/src/providers/settings-provider.tsx
@@ -55,18 +55,27 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
   // updates in one tick must compound, not overwrite) and re-synced on render.
   const settingsRef = useRef(settings)
   settingsRef.current = settings
+  // Monotonic update counter, so a stale re-apply (below) can recognize itself.
+  const updateSeq = useRef(0)
 
   const updateSettings = useCallback(
     (patch: Partial<Settings>) => {
+      const seq = ++updateSeq.current
       const next: Settings = { ...settingsRef.current, ...patch }
       settingsRef.current = next
       queryClient.setQueryData(SETTINGS_QUERY_KEY, next)
       // An update racing the initial load must win. Cancelling reverts the
       // in-flight fetch *asynchronously* — which would clobber the value just
-      // applied — so it is re-applied once the cancellation has settled.
-      void queryClient
-        .cancelQueries({ queryKey: SETTINGS_QUERY_KEY })
-        .then(() => queryClient.setQueryData(SETTINGS_QUERY_KEY, next))
+      // applied — so it is re-applied once the cancellation has settled. Only
+      // the latest update may re-apply: cancellation promises aren't
+      // guaranteed to settle in call order (a later cancel can find nothing
+      // in flight and resolve sooner), so an unguarded older callback could
+      // overwrite a newer value.
+      void queryClient.cancelQueries({ queryKey: SETTINGS_QUERY_KEY }).then(() => {
+        if (updateSeq.current === seq) {
+          queryClient.setQueryData(SETTINGS_QUERY_KEY, next)
+        }
+      })
       persistQueue.current = persistQueue.current
         .then(() => saveSettings(next))
         .catch((error: unknown) => {

--- a/apps/desktop/src/providers/settings-provider.tsx
+++ b/apps/desktop/src/providers/settings-provider.tsx
@@ -2,12 +2,14 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useRef,
+  useState,
   type ReactElement,
   type ReactNode,
 } from 'react'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import {
   DEFAULT_SETTINGS,
   hasBridge,
@@ -17,11 +19,13 @@ import {
 } from '@reflect/core'
 
 /**
- * App-wide user settings (config-dir JSON, not graph state): loaded once
- * through TanStack Query and updated with **instant apply** — `updateSettings`
- * writes the cache synchronously (every consumer re-renders immediately) and
- * persists in the background. Defaults are served while the load is in flight
- * so consumers never wait on disk.
+ * App-wide user settings (config-dir JSON, not graph state), applied instantly.
+ *
+ * The design is hydration + overrides: the query reads the disk document once
+ * and is never written afterwards; session updates accumulate in local state
+ * and win over whatever the load returns **by construction**. There is no
+ * optimistic cache write to defend, so an update racing the initial load needs
+ * no cancellation or re-apply — the merge order is the whole story.
  */
 
 export const SETTINGS_QUERY_KEY = ['settings'] as const
@@ -34,58 +38,61 @@ interface SettingsContextValue {
 
 const SettingsContext = createContext<SettingsContextValue | null>(null)
 
+/** Shallow own-key equality — settings documents are flat JSON objects. */
+function sameDocument(a: Settings, b: Settings): boolean {
+  const aKeys = Object.keys(a)
+  const bKeys = Object.keys(b)
+  return aKeys.length === bKeys.length && aKeys.every((key) => Object.is(a[key], b[key]))
+}
+
 interface SettingsProviderProps {
   children: ReactNode
 }
 
 export function SettingsProvider({ children }: SettingsProviderProps): ReactElement {
-  const queryClient = useQueryClient()
-  const { data } = useQuery({
+  const { data: loaded } = useQuery({
     queryKey: SETTINGS_QUERY_KEY,
     queryFn: loadSettings,
     enabled: hasBridge(),
     staleTime: Infinity,
   })
-  const settings = data ?? DEFAULT_SETTINGS
+  const [overrides, setOverrides] = useState<Partial<Settings>>({})
 
-  // Persists are chained so rapid toggles can't interleave writes out of
-  // order — the last applied patch is always the last document on disk.
-  const persistQueue = useRef<Promise<void>>(Promise.resolve())
-  // Tracks the latest applied document. Written synchronously on update (two
-  // updates in one tick must compound, not overwrite) and re-synced on render.
-  const settingsRef = useRef(settings)
-  settingsRef.current = settings
-  // Monotonic update counter, so a stale re-apply (below) can recognize itself.
-  const updateSeq = useRef(0)
-
-  const updateSettings = useCallback(
-    (patch: Partial<Settings>) => {
-      const seq = ++updateSeq.current
-      const next: Settings = { ...settingsRef.current, ...patch }
-      settingsRef.current = next
-      queryClient.setQueryData(SETTINGS_QUERY_KEY, next)
-      // An update racing the initial load must win. Cancelling reverts the
-      // in-flight fetch *asynchronously* — which would clobber the value just
-      // applied — so it is re-applied once the cancellation has settled. Only
-      // the latest update may re-apply: cancellation promises aren't
-      // guaranteed to settle in call order (a later cancel can find nothing
-      // in flight and resolve sooner), so an unguarded older callback could
-      // overwrite a newer value.
-      void queryClient.cancelQueries({ queryKey: SETTINGS_QUERY_KEY }).then(() => {
-        if (updateSeq.current === seq) {
-          queryClient.setQueryData(SETTINGS_QUERY_KEY, next)
-        }
-      })
-      persistQueue.current = persistQueue.current
-        .then(() => saveSettings(next))
-        .catch((error: unknown) => {
-          // The in-memory value stays applied; the next successful save (or
-          // relaunch) reconciles. Settings are low-stakes enough not to block.
-          console.error('saving settings failed:', error)
-        })
-    },
-    [queryClient],
+  // Defaults are usable before the IPC load settles — no loading gate.
+  const settings = useMemo<Settings>(
+    () => ({ ...DEFAULT_SETTINGS, ...loaded, ...overrides }),
+    [loaded, overrides],
   )
+
+  const updateSettings = useCallback((patch: Partial<Settings>) => {
+    setOverrides((current) => ({ ...current, ...patch }))
+  }, [])
+
+  // Persistence trails hydration. Nothing is written before the disk document
+  // has been read — a save built from defaults would drop passthrough keys a
+  // newer app version wrote — and the full merged document is saved so those
+  // keys survive. An update made mid-load is simply flushed when the load
+  // lands. Writes are chained so they reach disk in apply order.
+  const persistQueue = useRef<Promise<void>>(Promise.resolve())
+  const lastPersisted = useRef<Settings | null>(null)
+  useEffect(() => {
+    if (loaded === undefined) {
+      return
+    }
+    const onDisk = lastPersisted.current ?? loaded
+    if (sameDocument(settings, onDisk)) {
+      lastPersisted.current = onDisk
+      return
+    }
+    lastPersisted.current = settings
+    persistQueue.current = persistQueue.current
+      .then(() => saveSettings(settings))
+      .catch((error: unknown) => {
+        // The in-memory value stays applied; the next successful save (or
+        // relaunch) reconciles. Settings are low-stakes enough not to block.
+        console.error('saving settings failed:', error)
+      })
+  }, [loaded, settings])
 
   const value = useMemo<SettingsContextValue>(
     () => ({ settings, updateSettings }),

--- a/apps/desktop/src/providers/settings-provider.tsx
+++ b/apps/desktop/src/providers/settings-provider.tsx
@@ -15,8 +15,10 @@ import {
   hasBridge,
   loadSettings,
   saveSettings,
+  toAppError,
   type Settings,
 } from '@reflect/core'
+import { startOperation } from '@/lib/operations'
 
 /**
  * App-wide user settings (config-dir JSON, not graph state), applied instantly.
@@ -89,8 +91,9 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
       .then(() => saveSettings(settings))
       .catch((error: unknown) => {
         // The in-memory value stays applied; the next successful save (or
-        // relaunch) reconciles. Settings are low-stakes enough not to block.
-        console.error('saving settings failed:', error)
+        // relaunch) reconciles. The failure is product status, not console
+        // noise — surface it where backgrounded errors live.
+        startOperation('Saving settings').fail(toAppError(error).message)
       })
   }, [loaded, settings])
 

--- a/apps/desktop/src/providers/settings-provider.tsx
+++ b/apps/desktop/src/providers/settings-provider.tsx
@@ -1,0 +1,96 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  type ReactElement,
+  type ReactNode,
+} from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  DEFAULT_SETTINGS,
+  hasBridge,
+  loadSettings,
+  saveSettings,
+  type Settings,
+} from '@reflect/core'
+
+/**
+ * App-wide user settings (config-dir JSON, not graph state): loaded once
+ * through TanStack Query and updated with **instant apply** — `updateSettings`
+ * writes the cache synchronously (every consumer re-renders immediately) and
+ * persists in the background. Defaults are served while the load is in flight
+ * so consumers never wait on disk.
+ */
+
+export const SETTINGS_QUERY_KEY = ['settings'] as const
+
+interface SettingsContextValue {
+  settings: Settings
+  /** Merge `patch` into the settings: applied immediately, persisted async. */
+  updateSettings: (patch: Partial<Settings>) => void
+}
+
+const SettingsContext = createContext<SettingsContextValue | null>(null)
+
+interface SettingsProviderProps {
+  children: ReactNode
+}
+
+export function SettingsProvider({ children }: SettingsProviderProps): ReactElement {
+  const queryClient = useQueryClient()
+  const { data } = useQuery({
+    queryKey: SETTINGS_QUERY_KEY,
+    queryFn: loadSettings,
+    enabled: hasBridge(),
+    staleTime: Infinity,
+  })
+  const settings = data ?? DEFAULT_SETTINGS
+
+  // Persists are chained so rapid toggles can't interleave writes out of
+  // order — the last applied patch is always the last document on disk.
+  const persistQueue = useRef<Promise<void>>(Promise.resolve())
+  // Tracks the latest applied document. Written synchronously on update (two
+  // updates in one tick must compound, not overwrite) and re-synced on render.
+  const settingsRef = useRef(settings)
+  settingsRef.current = settings
+
+  const updateSettings = useCallback(
+    (patch: Partial<Settings>) => {
+      const next: Settings = { ...settingsRef.current, ...patch }
+      settingsRef.current = next
+      queryClient.setQueryData(SETTINGS_QUERY_KEY, next)
+      // An update racing the initial load must win. Cancelling reverts the
+      // in-flight fetch *asynchronously* — which would clobber the value just
+      // applied — so it is re-applied once the cancellation has settled.
+      void queryClient
+        .cancelQueries({ queryKey: SETTINGS_QUERY_KEY })
+        .then(() => queryClient.setQueryData(SETTINGS_QUERY_KEY, next))
+      persistQueue.current = persistQueue.current
+        .then(() => saveSettings(next))
+        .catch((error: unknown) => {
+          // The in-memory value stays applied; the next successful save (or
+          // relaunch) reconciles. Settings are low-stakes enough not to block.
+          console.error('saving settings failed:', error)
+        })
+    },
+    [queryClient],
+  )
+
+  const value = useMemo<SettingsContextValue>(
+    () => ({ settings, updateSettings }),
+    [settings, updateSettings],
+  )
+
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>
+}
+
+/** Access the current settings and the updater. Use within a SettingsProvider. */
+export function useSettings(): SettingsContextValue {
+  const context = useContext(SettingsContext)
+  if (!context) {
+    throw new Error('useSettings must be used within a SettingsProvider')
+  }
+  return context
+}

--- a/apps/desktop/src/providers/settings-provider.tsx
+++ b/apps/desktop/src/providers/settings-provider.tsx
@@ -19,6 +19,7 @@ import {
   type Settings,
 } from '@reflect/core'
 import { startOperation } from '@/lib/operations'
+import { setSettingsFlusher } from '@/lib/settings-flush'
 
 /**
  * App-wide user settings (config-dir JSON, not graph state), applied instantly.
@@ -52,7 +53,7 @@ interface SettingsProviderProps {
 }
 
 export function SettingsProvider({ children }: SettingsProviderProps): ReactElement {
-  const { data: loaded } = useQuery({
+  const { data: loaded, error: loadError } = useQuery({
     queryKey: SETTINGS_QUERY_KEY,
     queryFn: loadSettings,
     enabled: hasBridge(),
@@ -70,32 +71,66 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
     setOverrides((current) => ({ ...current, ...patch }))
   }, [])
 
+  // A corrupt store fails the load *by design* (Rust errors rather than
+  // reading empty, so a later save can't wipe the real document). Changes
+  // then apply for the session only — surface that state, don't hide it.
+  const loadErrorSurfaced = useRef(false)
+  useEffect(() => {
+    if (loadError && !loadErrorSurfaced.current) {
+      loadErrorSurfaced.current = true
+      startOperation('Loading settings').fail(toAppError(loadError).message)
+    }
+  }, [loadError])
+
   // Persistence trails hydration. Nothing is written before the disk document
   // has been read — a save built from defaults would drop passthrough keys a
   // newer app version wrote — and the full merged document is saved so those
-  // keys survive. An update made mid-load is simply flushed when the load
-  // lands. Writes are chained so they reach disk in apply order.
+  // keys survive. `lastPersisted` is the last document *confirmed* on disk
+  // (hydration, or a successful save): a failed write leaves it untouched, so
+  // the next change or the quit flush retries the difference. Writes are
+  // chained so they reach disk in apply order.
   const persistQueue = useRef<Promise<void>>(Promise.resolve())
   const lastPersisted = useRef<Settings | null>(null)
-  useEffect(() => {
-    if (loaded === undefined) {
-      return
+  const settingsRef = useRef(settings)
+  settingsRef.current = settings
+  const loadedRef = useRef(loaded)
+  loadedRef.current = loaded
+
+  const persistIfChanged = useCallback((): Promise<void> => {
+    const disk = loadedRef.current
+    if (disk === undefined) {
+      return persistQueue.current // never write over an unread store
     }
-    const onDisk = lastPersisted.current ?? loaded
-    if (sameDocument(settings, onDisk)) {
-      lastPersisted.current = onDisk
-      return
+    const target = settingsRef.current
+    const confirmed = lastPersisted.current ?? disk
+    if (sameDocument(target, confirmed)) {
+      lastPersisted.current = confirmed
+      return persistQueue.current
     }
-    lastPersisted.current = settings
     persistQueue.current = persistQueue.current
-      .then(() => saveSettings(settings))
+      .then(() => saveSettings(target))
+      .then(() => {
+        lastPersisted.current = target
+      })
       .catch((error: unknown) => {
-        // The in-memory value stays applied; the next successful save (or
-        // relaunch) reconciles. The failure is product status, not console
-        // noise — surface it where backgrounded errors live.
+        // The in-memory value stays applied and `lastPersisted` still points
+        // at the confirmed disk document, so the difference is retried later.
+        // The failure is product status, not console noise.
         startOperation('Saving settings').fail(toAppError(error).message)
       })
-  }, [loaded, settings])
+    return persistQueue.current
+  }, [])
+
+  useEffect(() => {
+    void persistIfChanged()
+  }, [loaded, settings, persistIfChanged])
+
+  // Quit-time persistence (window close, ⌘Q, reload): installQuitFlush drains
+  // this provider's queue — and retries anything unconfirmed — before exit.
+  useEffect(() => {
+    setSettingsFlusher(persistIfChanged)
+    return () => setSettingsFlusher(null)
+  }, [persistIfChanged])
 
   const value = useMemo<SettingsContextValue>(
     () => ({ settings, updateSettings }),

--- a/apps/desktop/src/routing/route.ts
+++ b/apps/desktop/src/routing/route.ts
@@ -15,6 +15,7 @@ export type Route =
   | { kind: 'daily'; date: string }
   | { kind: 'note'; path: string }
   | { kind: 'search'; query: string }
+  | { kind: 'settings' }
 
 /** Structural route equality (used to avoid pushing no-op history entries). */
 export function routesEqual(a: Route, b: Route): boolean {
@@ -23,6 +24,7 @@ export function routesEqual(a: Route, b: Route): boolean {
   }
   switch (a.kind) {
     case 'today':
+    case 'settings':
       return true
     case 'daily':
       return a.date === (b as Extract<Route, { kind: 'daily' }>).date

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,10 +52,10 @@ export {
 // User settings (config-dir JSON document; Rust persists, this layer validates)
 export {
   settingsSchema,
-  editorMarkModeSchema,
+  editorMarkdownSyntaxSchema,
   DEFAULT_SETTINGS,
   type Settings,
-  type EditorMarkMode,
+  type EditorMarkdownSyntax,
 } from './settings/schema'
 export { loadSettings, saveSettings } from './settings/commands'
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,6 +49,16 @@ export {
   forgetRecent,
 } from './graph/commands'
 
+// User settings (config-dir JSON document; Rust persists, this layer validates)
+export {
+  settingsSchema,
+  editorMarkModeSchema,
+  DEFAULT_SETTINGS,
+  type Settings,
+  type EditorMarkMode,
+} from './settings/schema'
+export { loadSettings, saveSettings } from './settings/commands'
+
 // Markdown document model (Plan 03)
 export {
   frontmatterSchema,

--- a/packages/core/src/ipc/invoke.ts
+++ b/packages/core/src/ipc/invoke.ts
@@ -1,4 +1,4 @@
-import type { ZodType } from 'zod'
+import type { ZodType, ZodTypeDef } from 'zod'
 import { toAppError, type AppError } from '../errors'
 import { getBridge } from './bridge'
 
@@ -23,7 +23,10 @@ import { getBridge } from './bridge'
 export async function call<TOutput>(
   command: string,
   args: Record<string, unknown>,
-  schema: ZodType<TOutput>,
+  // Input is `unknown`, not `TOutput`: schemas that normalize (`.catch`,
+  // `.default`) have a wider input type than output, and a validator's job is
+  // to consume untyped IPC data anyway.
+  schema: ZodType<TOutput, ZodTypeDef, unknown>,
 ): Promise<TOutput> {
   const bridge = getBridge()
   let raw: unknown

--- a/packages/core/src/settings/commands.ts
+++ b/packages/core/src/settings/commands.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod'
+import { call } from '../ipc/invoke'
+import { settingsSchema, type Settings } from './schema'
+
+/** Commands that return `()` from Rust serialize as `null` over IPC. */
+const voidSchema = z.null()
+
+/**
+ * Load the persisted user settings, normalized through the schema: a fresh
+ * install (empty document) and a document with missing or invalid values both
+ * come back fully defaulted, never as an error.
+ */
+export async function loadSettings(): Promise<Settings> {
+  return call('settings_load', {}, settingsSchema)
+}
+
+/**
+ * Atomically replace the persisted settings document. Callers pass the full
+ * document (typically the loaded settings plus the changed key) so unknown
+ * keys from newer app versions survive the round trip.
+ */
+export async function saveSettings(settings: Settings): Promise<void> {
+  await call('settings_save', { settings }, voidSchema)
+}

--- a/packages/core/src/settings/schema.test.ts
+++ b/packages/core/src/settings/schema.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_SETTINGS, settingsSchema } from './schema'
+
+describe('settingsSchema', () => {
+  it('defaults every key on an empty document (fresh install)', () => {
+    expect(settingsSchema.parse({})).toEqual({ editorMarkMode: 'focus' })
+    expect(DEFAULT_SETTINGS.editorMarkMode).toBe('focus')
+  })
+
+  it('accepts valid values', () => {
+    expect(settingsSchema.parse({ editorMarkMode: 'show' }).editorMarkMode).toBe('show')
+    expect(settingsSchema.parse({ editorMarkMode: 'focus' }).editorMarkMode).toBe('focus')
+  })
+
+  it('degrades an invalid value to its default instead of failing the load', () => {
+    expect(settingsSchema.parse({ editorMarkMode: 'sideways' }).editorMarkMode).toBe('focus')
+    expect(settingsSchema.parse({ editorMarkMode: 42 }).editorMarkMode).toBe('focus')
+  })
+
+  it('preserves unknown keys so newer-version settings survive a round trip', () => {
+    const parsed = settingsSchema.parse({ editorMarkMode: 'show', futureKey: true })
+    expect(parsed).toEqual({ editorMarkMode: 'show', futureKey: true })
+  })
+})

--- a/packages/core/src/settings/schema.test.ts
+++ b/packages/core/src/settings/schema.test.ts
@@ -3,22 +3,22 @@ import { DEFAULT_SETTINGS, settingsSchema } from './schema'
 
 describe('settingsSchema', () => {
   it('defaults every key on an empty document (fresh install)', () => {
-    expect(settingsSchema.parse({})).toEqual({ editorMarkMode: 'focus' })
-    expect(DEFAULT_SETTINGS.editorMarkMode).toBe('focus')
+    expect(settingsSchema.parse({})).toEqual({ editorMarkdownSyntax: 'focus' })
+    expect(DEFAULT_SETTINGS.editorMarkdownSyntax).toBe('focus')
   })
 
   it('accepts valid values', () => {
-    expect(settingsSchema.parse({ editorMarkMode: 'show' }).editorMarkMode).toBe('show')
-    expect(settingsSchema.parse({ editorMarkMode: 'focus' }).editorMarkMode).toBe('focus')
+    expect(settingsSchema.parse({ editorMarkdownSyntax: 'show' }).editorMarkdownSyntax).toBe('show')
+    expect(settingsSchema.parse({ editorMarkdownSyntax: 'focus' }).editorMarkdownSyntax).toBe('focus')
   })
 
   it('degrades an invalid value to its default instead of failing the load', () => {
-    expect(settingsSchema.parse({ editorMarkMode: 'sideways' }).editorMarkMode).toBe('focus')
-    expect(settingsSchema.parse({ editorMarkMode: 42 }).editorMarkMode).toBe('focus')
+    expect(settingsSchema.parse({ editorMarkdownSyntax: 'sideways' }).editorMarkdownSyntax).toBe('focus')
+    expect(settingsSchema.parse({ editorMarkdownSyntax: 42 }).editorMarkdownSyntax).toBe('focus')
   })
 
   it('preserves unknown keys so newer-version settings survive a round trip', () => {
-    const parsed = settingsSchema.parse({ editorMarkMode: 'show', futureKey: true })
-    expect(parsed).toEqual({ editorMarkMode: 'show', futureKey: true })
+    const parsed = settingsSchema.parse({ editorMarkdownSyntax: 'show', futureKey: true })
+    expect(parsed).toEqual({ editorMarkdownSyntax: 'show', futureKey: true })
   })
 })

--- a/packages/core/src/settings/schema.ts
+++ b/packages/core/src/settings/schema.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod'
+
+/**
+ * The user-settings schema — the policy half of the settings store. Rust
+ * persists an opaque JSON object in the OS config dir; this schema owns the
+ * known keys, their defaults, and their validation.
+ *
+ * Resilience contract (mirrors the frontmatter schema): a missing or invalid
+ * value degrades to its default (`.catch`) instead of failing the whole load,
+ * and unknown keys are preserved (`.passthrough`) so a document written by a
+ * newer app version round-trips through an older one without losing fields.
+ */
+
+/**
+ * How the editor renders markdown syntax characters. `focus` (the default)
+ * hides them except near the caret; `show` always displays them.
+ */
+export const editorMarkModeSchema = z.enum(['focus', 'show']).catch('focus')
+
+export type EditorMarkMode = z.infer<typeof editorMarkModeSchema>
+
+export const settingsSchema = z
+  .object({
+    editorMarkMode: editorMarkModeSchema,
+  })
+  .passthrough()
+
+export type Settings = z.infer<typeof settingsSchema>
+
+/** The settings a fresh install starts from (every key at its default). */
+export const DEFAULT_SETTINGS: Settings = settingsSchema.parse({})

--- a/packages/core/src/settings/schema.ts
+++ b/packages/core/src/settings/schema.ts
@@ -14,14 +14,18 @@ import { z } from 'zod'
 /**
  * How the editor renders markdown syntax characters. `focus` (the default)
  * hides them except near the caret; `show` always displays them.
+ *
+ * The persisted name is implementation-neutral on purpose — it maps to
+ * meowdown's "mark mode" at the editor boundary, but the settings document
+ * must outlive any one editor library.
  */
-export const editorMarkModeSchema = z.enum(['focus', 'show']).catch('focus')
+export const editorMarkdownSyntaxSchema = z.enum(['focus', 'show']).catch('focus')
 
-export type EditorMarkMode = z.infer<typeof editorMarkModeSchema>
+export type EditorMarkdownSyntax = z.infer<typeof editorMarkdownSyntaxSchema>
 
 export const settingsSchema = z
   .object({
-    editorMarkMode: editorMarkModeSchema,
+    editorMarkdownSyntax: editorMarkdownSyntaxSchema,
   })
   .passthrough()
 


### PR DESCRIPTION
## What

First user-settings surface: a routed settings screen with persisted, instantly-applied settings — starting with the editor's markdown syntax mode (meowdown `focus`/`show`).

- **Rust store** (`settings.rs`): one JSON document at `<config-dir>/reflect-open/settings.json`, atomic temp-file-and-rename writes, mirroring the recents store. Rust treats the document as an opaque JSON object — the store is a *capability*; the schema is *policy* and lives in TypeScript. A corrupt store errors instead of silently loading empty, so a later save can't wipe real settings.
- **Schema in `@reflect/core`** (`settings/schema.ts`): `editorMarkMode: 'focus' | 'show'`, default `focus`. Follows the frontmatter idiom — invalid values degrade to their default (`.catch`), unknown keys pass through, so documents written by a newer app version survive a round trip through an older one.
- **`SettingsProvider`** (instant apply): TanStack Query load, defaults served while the read is in flight, `updateSettings` writes the cache synchronously and persists in the background. Persists are chained (rapid toggles can't land out of order) and an update racing the initial load cancels the fetch *and re-applies after cancellation settles* — TanStack's revert lands asynchronously and would otherwise clobber the update (covered by a deterministic gated-load test).
- **UI**: new `{ kind: 'settings' }` route, screen with an Editor → "Markdown syntax" radio group. Reachable via ⌘, , the palette's "Open settings" (`settings.open`), and a header gear button. `NotePane` feeds the setting into meowdown's reactive `defineMarkMode` extension, so open editors flip live.

## Why

Per-user preferences need a home that follows the user across graphs and survives graph deletion — the OS config dir, not `.reflect/`. The screen is a routed view (back/forward works, room to grow) rather than a modal, and changes apply instantly with no save button.

## Reviewer notes

- One core API change: `call` in `ipc/invoke.ts` now types its schema input as `unknown` (`ZodType<TOutput, ZodTypeDef, unknown>`). Normalizing schemas (`.catch`/`.default`) have a wider input than output and didn't satisfy the old `ZodType<TOutput>` signature. All existing schemas remain assignable.
- meowdown also has a third `MarkMode`, `'hide'` — intentionally left out of the enum for now; adding it later is one enum value + one option entry.
- Rust: 5 new unit tests on the store; TS: schema, provider (incl. race + failed-save), screen, and command tests. Full desktop suite + typecheck pass after rebasing onto `master` (84fb81a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New persistence path and quit-time flush behavior; corrupt-store handling blocks writes until load succeeds, which is intentional but affects recovery UX.
> 
> **Overview**
> Adds **per-user settings** persisted in the OS config dir (`reflect-open/settings.json`), not inside any graph. Rust exposes `settings_load` / `settings_save` with atomic writes; corrupt or non-object JSON **errors** on load so a bad read cannot be overwritten by a defaults-based save. `@reflect/core` owns the zod schema (`editorMarkdownSyntax`: `focus` | `show`, passthrough unknown keys) and typed IPC helpers; `call()` now types schema input as `unknown` for normalizing schemas.
> 
> The desktop app wraps the tree in **`SettingsProvider`**: defaults while loading, session **overrides** that win over a racing initial load, chained async saves after hydration, failed-save retry and **quit flush** alongside open documents. A new **`{ kind: 'settings' }`** route renders **SettingsScreen** (Editor → markdown syntax radios, instant apply); entry via **⌘,**, palette `settings.open`, and a header gear. **`NotePane`** passes the setting into the editor as **`markMode`** so open notes update live.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e55d1c9ba971ce0392bc17bb2b462b242463f9e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a settings screen to manage user preferences with keyboard shortcut (Mod-,)
  * Markdown display mode is now configurable and automatically persisted

<!-- end of auto-generated comment: release notes by coderabbit.ai -->