### PR TITLE
ci: cache ort's ONNX Runtime download, save cargo cache on failed runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,28 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: apps/desktop/src-tauri
+          # A failed clippy/test run still compiled the dependency tree; save it
+          # so the next push doesn't pay the cold-build cost again.
+          cache-on-failure: true
+
+      # ort-sys (fastembed → ort) downloads prebuilt ONNX Runtime binaries at
+      # build time and extracts them to ~/.cache/ort.pyke.io — outside target/,
+      # so rust-cache never captures them and every run re-downloads. The build
+      # script skips the download when the extracted dir is already present.
+      # Entries are content-addressed (dfbin/<target>/<hash>), so restoring a
+      # stale cache after an ort upgrade is safe — it just downloads anew.
+      - name: Cache ONNX Runtime binaries
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.cache/ort.pyke.io
+          key: ort-bin-${{ runner.os }}-${{ hashFiles('apps/desktop/src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ort-bin-${{ runner.os }}-
+
+      # Without this, actions/cache warns at save time on builds that never
+      # trigger the ort download (the path wouldn't exist).
+      - name: Ensure ort cache dir exists
+        run: mkdir -p ~/.cache/ort.pyke.io
 
       - name: Format check
         run: cargo fmt --all -- --check


### PR DESCRIPTION
## Why

The Rust CI job tripled from ~1m40s to ~5m40s on #18, which adds `fastembed` → `ort`. Two findings from digging into the run timings:

- `Swatinem/rust-cache@v2` was already in the workflow (since #1) and is working — #18's second run was 3m18s with a full cache hit. The 5m40s was the unavoidable cold build for the new `Cargo.lock`.
- What rust-cache *doesn't* capture: `ort-sys`'s build script downloads prebuilt ONNX Runtime binaries and extracts them to `~/.cache/ort.pyke.io` — outside `target/` — so **every** run re-downloads them (visible as the ~8s gap before `Compiling reflect-open` in warm runs, plus a network dependency on `parcel.pyke.io` that can flake).

## What

- Cache `~/.cache/ort.pyke.io` with `actions/cache`, keyed on `apps/desktop/src-tauri/Cargo.lock`. The extract dir is content-addressed (`dfbin/<target>/<hash>`) and the build script skips the download when it exists, so stale restores after an ort upgrade are safe.
- `cache-on-failure: true` on rust-cache, so a red clippy/test run still saves the compiled dependency tree for the next push.
- `mkdir -p` the ort cache dir so `actions/cache` doesn't warn at save time on builds that never trigger the download (master until #18 lands).

The job's commands (fmt, clippy `--all-targets`, test) are unchanged.

## Verification

Timing comparison on a throwaway draft PR that combines this change with #18's branch — numbers to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only caching changes; no application code, auth, or runtime behavior is modified.
> 
> **Overview**
> Speeds up the Rust CI job by caching artifacts that were missing from `Swatinem/rust-cache`.
> 
> **`cache-on-failure: true`** is enabled on the existing cargo cache so a failed `fmt` / clippy / test run still saves the compiled dependency tree for the next push.
> 
> A new **`actions/cache`** step caches `~/.cache/ort.pyke.io` (ONNX Runtime binaries pulled by `ort-sys` during build, outside `target/`). The cache key is tied to `apps/desktop/src-tauri/Cargo.lock`, with OS-scoped restore keys. A **`mkdir -p`** step ensures the cache path exists so saves do not warn when ort never downloads.
> 
> Rust job commands are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aea6a649c3f61da4371aac6e9a6b9075f5d3abe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->