### PR TITLE
[DO NOT MERGE] test: CI cache timing (#20 + #18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,28 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: apps/desktop/src-tauri
+          # A failed clippy/test run still compiled the dependency tree; save it
+          # so the next push doesn't pay the cold-build cost again.
+          cache-on-failure: true
+
+      # ort-sys (fastembed → ort) downloads prebuilt ONNX Runtime binaries at
+      # build time and extracts them to ~/.cache/ort.pyke.io — outside target/,
+      # so rust-cache never captures them and every run re-downloads. The build
+      # script skips the download when the extracted dir is already present.
+      # Entries are content-addressed (dfbin/<target>/<hash>), so restoring a
+      # stale cache after an ort upgrade is safe — it just downloads anew.
+      - name: Cache ONNX Runtime binaries
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.cache/ort.pyke.io
+          key: ort-bin-${{ runner.os }}-${{ hashFiles('apps/desktop/src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ort-bin-${{ runner.os }}-
+
+      # Without this, actions/cache warns at save time on builds that never
+      # trigger the ort download (the path wouldn't exist).
+      - name: Ensure ort cache dir exists
+        run: mkdir -p ~/.cache/ort.pyke.io
 
       - name: Format check
         run: cargo fmt --all -- --check

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -9,12 +9,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
 ]
 
 [[package]]
@@ -33,6 +65,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +84,38 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "async-broadcast"
@@ -214,6 +284,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +343,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -241,6 +366,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +384,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
 ]
 
 [[package]]
@@ -317,6 +457,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +479,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -411,12 +563,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -466,6 +629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +642,21 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -485,13 +669,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -517,9 +742,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -530,7 +755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -562,10 +787,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -618,12 +868,36 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -641,13 +915,33 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -662,6 +956,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +973,37 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -770,6 +1105,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dom_query"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,6 +1180,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,6 +1204,21 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endi"
@@ -876,6 +1241,26 @@ name = "enumflags2_derive"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -910,6 +1295,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,6 +1322,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,10 +1349,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fastembed"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add59222e7bc3787285f993744b244cd454d78571845623606bdc45b22b23a4e"
+dependencies = [
+ "anyhow",
+ "hf-hub",
+ "image",
+ "ndarray",
+ "ort",
+ "safetensors",
+ "serde",
+ "serde_json",
+ "tokenizers",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1012,12 +1441,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1030,6 +1468,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1285,6 +1729,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,6 +1887,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,7 +1937,11 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1497,6 +1985,33 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hf-hub"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
+dependencies = [
+ "dirs",
+ "http",
+ "indicatif",
+ "libc",
+ "log",
+ "native-tls",
+ "rand",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "ureq",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "html5ever"
@@ -1563,6 +2078,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1571,6 +2087,37 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1591,9 +2138,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1746,6 +2295,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,6 +2355,19 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
 ]
 
 [[package]]
@@ -1798,6 +2400,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,6 +2433,15 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1893,6 +2515,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -1973,6 +2605,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,6 +2647,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
  "pkg-config",
+]
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
+dependencies = [
+ "arbitrary",
+ "cc",
 ]
 
 [[package]]
@@ -2054,6 +2702,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,6 +2721,37 @@ name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
+name = "lzma-rust2"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
+
+[[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
 name = "markup5ever"
@@ -2086,6 +2771,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
 ]
 
 [[package]]
@@ -2110,6 +2815,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2132,6 +2843,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,6 +2893,38 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
 ]
 
 [[package]]
@@ -2181,6 +2956,40 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "notify"
@@ -2232,10 +3041,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2471,6 +3330,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "open"
 version = "5.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2480,6 +3361,49 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2496,6 +3420,30 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+dependencies = [
+ "ndarray",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+ "ureq",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+dependencies = [
+ "hmac-sha256",
+ "lzma-rust2",
+ "ureq",
 ]
 
 [[package]]
@@ -2553,10 +3501,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2694,6 +3663,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2707,6 +3691,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "precomputed-hash"
@@ -2787,6 +3780,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2817,10 +3850,126 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand",
+ "rand_chacha",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools",
+ "rayon",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -2868,6 +4017,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "dirs",
+ "fastembed",
  "notify",
  "notify-debouncer-full",
  "rusqlite",
@@ -2916,6 +4066,49 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -2944,7 +4137,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -2970,6 +4163,26 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3036,10 +4249,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safetensors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+dependencies = [
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "same-file"
@@ -3048,6 +4313,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3106,6 +4380,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3232,6 +4529,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3257,7 +4566,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3337,6 +4646,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3362,6 +4680,17 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3413,6 +4742,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom 7.1.3",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "sqlite-vec"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3438,6 +4779,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -3468,6 +4815,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -3522,6 +4875,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3542,7 +4916,7 @@ checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -3622,7 +4996,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3958,6 +5332,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4014,6 +5402,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4025,6 +5446,26 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4383,16 +5824,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "cookie_store",
+ "der",
+ "flate2",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
 
 [[package]]
 name = "url"
@@ -4432,6 +5942,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4446,6 +5962,17 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
  "wasm-bindgen",
 ]
 
@@ -4615,6 +6142,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -4643,6 +6183,16 @@ name = "web-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4705,6 +6255,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4739,6 +6307,12 @@ dependencies = [
  "windows 0.61.3",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -4934,6 +6508,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4985,6 +6570,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5418,6 +7012,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5502,6 +7102,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5521,6 +7141,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
@@ -5560,6 +7186,30 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -34,6 +34,7 @@ notify-debouncer-full = "0.7.0"
 base64 = "0.22.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+fastembed = "5"
 
 [dev-dependencies]
 tauri = { version = "2", features = ["test"] }

--- a/apps/desktop/src-tauri/migrations/0002_embeddings.sql
+++ b/apps/desktop/src-tauri/migrations/0002_embeddings.sql
@@ -1,0 +1,20 @@
+-- Plan 09: chunk-level embeddings. `embedding_chunks` deliberately has NO
+-- foreign key to `notes`: apply_note re-creates the note row on every index
+-- pass (delete + insert), and a cascade would wipe the chunks each save —
+-- destroying the hash-skip that makes re-embedding incremental. Chunk
+-- lifecycle is owned by the embedding pipeline (embed_apply / embed_remove);
+-- vectors live in the vec0 table keyed by the chunk's rowid.
+
+CREATE TABLE embedding_chunks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  note_path TEXT NOT NULL,
+  heading TEXT,
+  pos_from INTEGER NOT NULL,
+  pos_to INTEGER NOT NULL,
+  text TEXT NOT NULL,
+  content_hash TEXT NOT NULL,
+  model_id TEXT NOT NULL
+);
+CREATE INDEX embedding_chunks_note ON embedding_chunks(note_path);
+
+CREATE VIRTUAL TABLE embedding_vectors USING vec0(embedding float[384]);

--- a/apps/desktop/src-tauri/src/db/embed_write.rs
+++ b/apps/desktop/src-tauri/src/db/embed_write.rs
@@ -1,0 +1,131 @@
+//! Embedding-table writes (Plan 09): chunk rows + their vec0 vectors, applied
+//! per note as one diff. Plain functions over a [`Connection`] — the command
+//! layer ([`super`]) owns transactions and generation gating, mirroring
+//! `write.rs`.
+
+use rusqlite::{params, Connection};
+use serde::Deserialize;
+
+use crate::error::{AppError, AppResult};
+
+/// One chunk of a note, built in TS (`@reflect/core` chunker). `vector` is
+/// present only for new/changed chunks — `None` means "this chunk's hash
+/// already has a row; keep its vector, refresh its metadata" (positions and
+/// headings shift when text moves above an unchanged chunk).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EmbeddedChunk {
+    pub(super) heading: Option<String>,
+    pub(super) pos_from: i64,
+    pub(super) pos_to: i64,
+    pub(super) text: String,
+    pub(super) content_hash: String,
+    pub(super) model_id: String,
+    pub(super) vector: Option<Vec<f32>>,
+}
+
+fn vector_json(vector: &[f32]) -> String {
+    let mut out = String::with_capacity(vector.len() * 10 + 2);
+    out.push('[');
+    for (i, value) in vector.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push_str(&value.to_string());
+    }
+    out.push(']');
+    out
+}
+
+/// Apply `chunks` as the note's complete new chunk set: rows whose hash isn't
+/// in the set are dropped (vectors included), kept rows get fresh metadata,
+/// and chunks carrying a vector are inserted. A "new" chunk without a vector
+/// is a pipeline bug — fail loudly rather than store an unsearchable row.
+pub(super) fn apply_chunks(
+    conn: &Connection,
+    note_path: &str,
+    chunks: &[EmbeddedChunk],
+) -> AppResult<()> {
+    // Existing rows by content hash (a note rarely has duplicate-hash chunks;
+    // if it does, rows pair up by position order — both forms are identical).
+    let mut existing: Vec<(i64, String)> = conn
+        .prepare_cached(
+            "SELECT id, content_hash FROM embedding_chunks WHERE note_path = ?1 ORDER BY pos_from",
+        )?
+        .query_map(params![note_path], |row| Ok((row.get(0)?, row.get(1)?)))?
+        .collect::<Result<_, _>>()?;
+
+    let mut kept: Vec<i64> = Vec::new();
+    for chunk in chunks {
+        match chunk.vector.as_ref() {
+            None => {
+                let at = existing
+                    .iter()
+                    .position(|(_, hash)| *hash == chunk.content_hash)
+                    .ok_or_else(|| {
+                        AppError::parse(format!(
+                            "unchanged chunk has no stored row (hash {})",
+                            chunk.content_hash
+                        ))
+                    })?;
+                let (id, _) = existing.remove(at);
+                conn.prepare_cached(
+                    "UPDATE embedding_chunks
+                     SET heading = ?2, pos_from = ?3, pos_to = ?4, model_id = ?5
+                     WHERE id = ?1",
+                )?
+                .execute(params![
+                    id,
+                    chunk.heading,
+                    chunk.pos_from,
+                    chunk.pos_to,
+                    chunk.model_id
+                ])?;
+                kept.push(id);
+            }
+            Some(vector) => {
+                conn.prepare_cached(
+                    "INSERT INTO embedding_chunks
+                       (note_path, heading, pos_from, pos_to, text, content_hash, model_id)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                )?
+                .execute(params![
+                    note_path,
+                    chunk.heading,
+                    chunk.pos_from,
+                    chunk.pos_to,
+                    chunk.text,
+                    chunk.content_hash,
+                    chunk.model_id
+                ])?;
+                let id = conn.last_insert_rowid();
+                conn.prepare_cached(
+                    "INSERT INTO embedding_vectors(rowid, embedding) VALUES (?1, ?2)",
+                )?
+                .execute(params![id, vector_json(vector)])?;
+                kept.push(id);
+            }
+        }
+    }
+
+    // Whatever wasn't kept is stale: drop vector + row.
+    for (id, _) in existing {
+        conn.prepare_cached("DELETE FROM embedding_vectors WHERE rowid = ?1")?
+            .execute(params![id])?;
+        conn.prepare_cached("DELETE FROM embedding_chunks WHERE id = ?1")?
+            .execute(params![id])?;
+    }
+    Ok(())
+}
+
+/// Drop every chunk + vector belonging to `note_path` (note deletion).
+pub(super) fn remove_chunks(conn: &Connection, note_path: &str) -> AppResult<()> {
+    conn.prepare_cached(
+        "DELETE FROM embedding_vectors WHERE rowid IN
+           (SELECT id FROM embedding_chunks WHERE note_path = ?1)",
+    )?
+    .execute(params![note_path])?;
+    conn.prepare_cached("DELETE FROM embedding_chunks WHERE note_path = ?1")?
+        .execute(params![note_path])?;
+    Ok(())
+}

--- a/apps/desktop/src-tauri/src/db/migrations.rs
+++ b/apps/desktop/src-tauri/src/db/migrations.rs
@@ -17,9 +17,10 @@ use crate::error::{AppError, AppResult};
 
 /// Ordered schema migrations, loaded from `migrations/*.sql`.
 static MIGRATIONS: LazyLock<Migrations<'static>> = LazyLock::new(|| {
-    Migrations::new(vec![M::up(include_str!(
-        "../../migrations/0001_initial.sql"
-    ))])
+    Migrations::new(vec![
+        M::up(include_str!("../../migrations/0001_initial.sql")),
+        M::up(include_str!("../../migrations/0002_embeddings.sql")),
+    ])
 });
 
 /// Result of the one-time sqlite-vec registration; the error message is cached so
@@ -85,6 +86,12 @@ pub(super) fn open_index_at(root: &Path) -> AppResult<Connection> {
 }
 
 #[cfg(test)]
-pub(super) fn validate_migrations() -> Result<(), rusqlite_migration::Error> {
-    MIGRATIONS.validate()
+pub(super) fn validate_migrations() -> AppResult<()> {
+    // Validation replays the migrations on its own connection; vec0 must be
+    // registered first (the auto-extension is process-global but not innate —
+    // without this the test is order-dependent on whoever registers first).
+    register_sqlite_vec()?;
+    MIGRATIONS
+        .validate()
+        .map_err(|err| AppError::io(format!("invalid migration set: {err}")))
 }

--- a/apps/desktop/src-tauri/src/db/mod.rs
+++ b/apps/desktop/src-tauri/src/db/mod.rs
@@ -124,6 +124,9 @@ pub fn index_apply_batch(
 }
 
 /// Remove a note (e.g. deleted on disk) from the index (no-op if stale).
+/// This is the *genuine deletion* entry point, so embedding rows go too —
+/// `apply_note`'s internal remove must NOT do this (it runs on every upsert
+/// and would destroy the chunk hash-skip).
 #[tauri::command]
 pub fn index_remove(path: String, generation: u64, index: State<IndexState>) -> AppResult<()> {
     let state = lock_state(&index)?;
@@ -131,7 +134,8 @@ pub fn index_remove(path: String, generation: u64, index: State<IndexState>) -> 
         return Ok(());
     }
     let conn = state.conn.as_ref().ok_or_else(AppError::no_graph)?;
-    write::remove_note(conn, &path)
+    write::remove_note(conn, &path)?;
+    embed_write::remove_chunks(conn, &path)
 }
 
 /// Wipe all derived tables (the TS layer then re-applies every note; no-op if stale).

--- a/apps/desktop/src-tauri/src/db/mod.rs
+++ b/apps/desktop/src-tauri/src/db/mod.rs
@@ -129,13 +129,19 @@ pub fn index_apply_batch(
 /// and would destroy the chunk hash-skip).
 #[tauri::command]
 pub fn index_remove(path: String, generation: u64, index: State<IndexState>) -> AppResult<()> {
-    let state = lock_state(&index)?;
+    let mut state = lock_state(&index)?;
     if state.generation != generation {
         return Ok(());
     }
-    let conn = state.conn.as_ref().ok_or_else(AppError::no_graph)?;
-    write::remove_note(conn, &path)?;
-    embed_write::remove_chunks(conn, &path)
+    let conn = state.conn.as_mut().ok_or_else(AppError::no_graph)?;
+    // One transaction: a half-removed note (row gone, chunks left) would let
+    // a later note at the same path surface stale chunk text in semantic
+    // search until a re-embed.
+    let tx = conn.transaction()?;
+    write::remove_note(&tx, &path)?;
+    embed_write::remove_chunks(&tx, &path)?;
+    tx.commit()?;
+    Ok(())
 }
 
 /// Wipe all derived tables (the TS layer then re-applies every note; no-op if stale).
@@ -172,12 +178,16 @@ pub fn embed_apply(
 /// Drop a deleted note's chunks + vectors (no-op if stale).
 #[tauri::command]
 pub fn embed_remove(path: String, generation: u64, index: State<IndexState>) -> AppResult<()> {
-    let state = lock_state(&index)?;
+    let mut state = lock_state(&index)?;
     if state.generation != generation {
         return Ok(());
     }
-    let conn = state.conn.as_ref().ok_or_else(AppError::no_graph)?;
-    embed_write::remove_chunks(conn, &path)
+    let conn = state.conn.as_mut().ok_or_else(AppError::no_graph)?;
+    // Two DELETEs (vectors, then rows): atomic, mirroring embed_apply.
+    let tx = conn.transaction()?;
+    embed_write::remove_chunks(&tx, &path)?;
+    tx.commit()?;
+    Ok(())
 }
 
 /// Execute a read query (compiled by Kysely on the frontend) and return rows.

--- a/apps/desktop/src-tauri/src/db/mod.rs
+++ b/apps/desktop/src-tauri/src/db/mod.rs
@@ -9,6 +9,7 @@
 //! ([`query`]) that executes the SQL the frontend builds with Kysely. The DB is
 //! a cache: deleting it loses nothing durable.
 
+mod embed_write;
 mod migrations;
 mod query;
 #[cfg(test)]
@@ -24,6 +25,7 @@ use tauri::State;
 use crate::error::{AppError, AppResult};
 use crate::fs::GraphState;
 
+pub use embed_write::EmbeddedChunk;
 pub use write::IndexedNote;
 
 /// The open index connection plus its monotonic generation, kept **under one
@@ -141,6 +143,37 @@ pub fn index_clear(generation: u64, index: State<IndexState>) -> AppResult<()> {
     }
     let conn = state.conn.as_ref().ok_or_else(AppError::no_graph)?;
     write::clear_index(conn)
+}
+
+/// Replace a note's embedding chunk set (diff applied in one transaction;
+/// no-op if stale). Unchanged chunks keep their vectors — the hash-skip.
+#[tauri::command]
+pub fn embed_apply(
+    path: String,
+    chunks: Vec<EmbeddedChunk>,
+    generation: u64,
+    index: State<IndexState>,
+) -> AppResult<()> {
+    let mut state = lock_state(&index)?;
+    if state.generation != generation {
+        return Ok(());
+    }
+    let conn = state.conn.as_mut().ok_or_else(AppError::no_graph)?;
+    let tx = conn.transaction()?;
+    embed_write::apply_chunks(&tx, &path, &chunks)?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// Drop a deleted note's chunks + vectors (no-op if stale).
+#[tauri::command]
+pub fn embed_remove(path: String, generation: u64, index: State<IndexState>) -> AppResult<()> {
+    let state = lock_state(&index)?;
+    if state.generation != generation {
+        return Ok(());
+    }
+    let conn = state.conn.as_ref().ok_or_else(AppError::no_graph)?;
+    embed_write::remove_chunks(conn, &path)
 }
 
 /// Execute a read query (compiled by Kysely on the frontend) and return rows.

--- a/apps/desktop/src-tauri/src/db/tests.rs
+++ b/apps/desktop/src-tauri/src/db/tests.rs
@@ -5,12 +5,15 @@
 use rusqlite::Connection;
 use serde_json::Value;
 
+use super::embed_write::{apply_chunks, remove_chunks, EmbeddedChunk};
 use super::migrations::{migrate, open_in_memory, open_index_at, validate_migrations};
 use super::query::run_query;
 use super::write::{apply_note, clear_index, IndexedLink, IndexedNote};
 
 fn migrated() -> Connection {
-    let mut conn = Connection::open_in_memory().expect("open");
+    // Registers sqlite-vec before migrating — the 0002 migration creates a
+    // vec0 table, so a raw rusqlite open would fail with "no such module".
+    let mut conn = open_in_memory().expect("open");
     conn.execute_batch("PRAGMA foreign_keys=ON;").expect("fk");
     migrate(&mut conn).expect("migrate");
     conn
@@ -53,7 +56,7 @@ fn migrations_are_valid_and_idempotent() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 1); // one applied migration
+    assert_eq!(version, 2); // applied migrations (0001 + 0002)
     migrate(&mut conn).expect("re-running to_latest is a no-op");
 }
 
@@ -168,7 +171,7 @@ fn open_index_at_creates_migrates_and_reopens() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 1);
+    assert_eq!(version, 2);
     let journal: String = conn
         .query_row("PRAGMA journal_mode", [], |row| row.get(0))
         .unwrap();
@@ -277,4 +280,151 @@ fn sqlite_vec_loads_and_runs_knn() {
         )
         .expect("vec0 knn");
     assert_eq!(nearest, 1);
+}
+
+// ---- embeddings (Plan 09) ---------------------------------------------------
+
+fn chunk(hash: &str, vector: Option<Vec<f32>>) -> EmbeddedChunk {
+    EmbeddedChunk {
+        heading: None,
+        pos_from: 0,
+        pos_to: 10,
+        text: format!("text {hash}"),
+        content_hash: hash.to_string(),
+        model_id: "all-MiniLM-L6-v2".to_string(),
+        vector,
+    }
+}
+
+fn vec384(fill: f32) -> Vec<f32> {
+    vec![fill; 384]
+}
+
+fn chunk_rows(conn: &Connection) -> Vec<(String, String)> {
+    conn.prepare("SELECT note_path, content_hash FROM embedding_chunks ORDER BY id")
+        .unwrap()
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap()
+}
+
+fn vector_count(conn: &Connection) -> i64 {
+    conn.query_row("SELECT count(*) FROM embedding_vectors", [], |row| {
+        row.get(0)
+    })
+    .unwrap()
+}
+
+#[test]
+fn apply_chunks_inserts_new_and_drops_stale_with_their_vectors() {
+    let conn = migrated();
+    apply_chunks(
+        &conn,
+        "notes/a.md",
+        &[
+            chunk("h1", Some(vec384(0.1))),
+            chunk("h2", Some(vec384(0.2))),
+        ],
+    )
+    .unwrap();
+    assert_eq!(vector_count(&conn), 2);
+
+    // h2 survives unembedded (hash-skip); h3 is new; h1 is gone.
+    apply_chunks(
+        &conn,
+        "notes/a.md",
+        &[chunk("h2", None), chunk("h3", Some(vec384(0.3)))],
+    )
+    .unwrap();
+    assert_eq!(
+        chunk_rows(&conn),
+        vec![
+            ("notes/a.md".to_string(), "h2".to_string()),
+            ("notes/a.md".to_string(), "h3".to_string()),
+        ]
+    );
+    assert_eq!(vector_count(&conn), 2);
+}
+
+#[test]
+fn unchanged_chunks_keep_vectors_but_refresh_positions() {
+    let conn = migrated();
+    apply_chunks(&conn, "notes/a.md", &[chunk("h1", Some(vec384(0.5)))]).unwrap();
+    let mut moved = chunk("h1", None);
+    moved.pos_from = 100;
+    moved.pos_to = 140;
+    apply_chunks(&conn, "notes/a.md", &[moved]).unwrap();
+    let (from, to): (i64, i64) = conn
+        .query_row(
+            "SELECT pos_from, pos_to FROM embedding_chunks WHERE content_hash = 'h1'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!((from, to), (100, 140));
+    assert_eq!(vector_count(&conn), 1);
+}
+
+#[test]
+fn an_unchanged_chunk_without_a_stored_row_is_a_loud_error() {
+    let conn = migrated();
+    let result = apply_chunks(&conn, "notes/a.md", &[chunk("missing", None)]);
+    assert!(result.is_err());
+}
+
+#[test]
+fn remove_chunks_drops_rows_and_vectors_for_one_note_only() {
+    let conn = migrated();
+    apply_chunks(&conn, "notes/a.md", &[chunk("a1", Some(vec384(0.1)))]).unwrap();
+    apply_chunks(&conn, "notes/b.md", &[chunk("b1", Some(vec384(0.2)))]).unwrap();
+    remove_chunks(&conn, "notes/a.md").unwrap();
+    assert_eq!(
+        chunk_rows(&conn),
+        vec![("notes/b.md".to_string(), "b1".to_string())]
+    );
+    assert_eq!(vector_count(&conn), 1);
+}
+
+#[test]
+fn clear_index_wipes_embeddings_too() {
+    let conn = migrated();
+    apply_chunks(&conn, "notes/a.md", &[chunk("a1", Some(vec384(0.1)))]).unwrap();
+    clear_index(&conn).unwrap();
+    assert_eq!(chunk_rows(&conn), vec![]);
+    assert_eq!(vector_count(&conn), 0);
+}
+
+#[test]
+fn knn_query_returns_nearest_chunk_first() {
+    let conn = migrated();
+    let mut near = vec384(0.0);
+    near[0] = 1.0;
+    let mut far = vec384(0.0);
+    far[1] = 1.0;
+    apply_chunks(&conn, "notes/near.md", &[chunk("n", Some(near))]).unwrap();
+    apply_chunks(&conn, "notes/far.md", &[chunk("f", Some(far))]).unwrap();
+
+    let mut probe = vec![0.0f32; 384];
+    probe[0] = 0.9;
+    let probe_json = format!(
+        "[{}]",
+        probe
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    // The same shape the frontend uses through read-only db_query.
+    let rows = run_query(
+        &conn,
+        "SELECT c.note_path FROM embedding_vectors v
+         JOIN embedding_chunks c ON c.id = v.rowid
+         WHERE v.embedding MATCH ?1 AND k = 2
+         ORDER BY v.distance",
+        &[Value::String(probe_json)],
+    )
+    .unwrap();
+    let first = rows[0].get("note_path").unwrap().as_str().unwrap();
+    assert_eq!(first, "notes/near.md");
 }

--- a/apps/desktop/src-tauri/src/db/tests.rs
+++ b/apps/desktop/src-tauri/src/db/tests.rs
@@ -449,3 +449,34 @@ fn reindexing_a_note_keeps_its_chunks_but_true_deletion_drops_them() {
     assert_eq!(chunk_rows(&conn), vec![]);
     assert_eq!(vector_count(&conn), 0);
 }
+
+#[test]
+fn stored_vectors_round_trip_through_vec_to_json() {
+    // relatedNotes (TS) seeds KNN with `vec_to_json(embedding)` via db_query;
+    // pin the function name + shape against the real extension.
+    let conn = migrated();
+    apply_chunks(&conn, "notes/a.md", &[chunk("a1", Some(vec384(0.25)))]).unwrap();
+    let rows = run_query(
+        &conn,
+        "SELECT vec_to_json(v.embedding) AS vec
+         FROM embedding_chunks c JOIN embedding_vectors v ON v.rowid = c.id
+         WHERE c.note_path = ?1 ORDER BY c.pos_from LIMIT 1",
+        &[Value::String("notes/a.md".to_string())],
+    )
+    .unwrap();
+    let vec = rows[0].get("vec").unwrap().as_str().unwrap();
+    assert!(vec.starts_with('['));
+    // And the JSON form is MATCH-able right back (the second relatedNotes query).
+    let knn = run_query(
+        &conn,
+        "SELECT c.note_path FROM embedding_vectors v
+         JOIN embedding_chunks c ON c.id = v.rowid
+         WHERE v.embedding MATCH ?1 AND k = 1 ORDER BY v.distance",
+        &[Value::String(vec.to_string())],
+    )
+    .unwrap();
+    assert_eq!(
+        knn[0].get("note_path").unwrap().as_str().unwrap(),
+        "notes/a.md"
+    );
+}

--- a/apps/desktop/src-tauri/src/db/tests.rs
+++ b/apps/desktop/src-tauri/src/db/tests.rs
@@ -428,3 +428,24 @@ fn knn_query_returns_nearest_chunk_first() {
     let first = rows[0].get("note_path").unwrap().as_str().unwrap();
     assert_eq!(first, "notes/near.md");
 }
+
+#[test]
+fn reindexing_a_note_keeps_its_chunks_but_true_deletion_drops_them() {
+    let mut conn = migrated();
+    apply_note(&conn, &note("notes/a.md", "Alpha", vec![])).unwrap();
+    apply_chunks(&conn, "notes/a.md", &[chunk("a1", Some(vec384(0.1)))]).unwrap();
+
+    // Upsert path: apply_note re-creates the note row — chunks must survive
+    // (the hash-skip depends on it).
+    apply_note(&conn, &note("notes/a.md", "Alpha edited", vec![])).unwrap();
+    assert_eq!(chunk_rows(&conn).len(), 1);
+    assert_eq!(vector_count(&conn), 1);
+
+    // Genuine deletion (the index_remove command shape): everything goes.
+    let tx = conn.transaction().unwrap();
+    super::write::remove_note(&tx, "notes/a.md").unwrap();
+    super::embed_write::remove_chunks(&tx, "notes/a.md").unwrap();
+    tx.commit().unwrap();
+    assert_eq!(chunk_rows(&conn), vec![]);
+    assert_eq!(vector_count(&conn), 0);
+}

--- a/apps/desktop/src-tauri/src/db/write.rs
+++ b/apps/desktop/src-tauri/src/db/write.rs
@@ -124,7 +124,10 @@ pub(super) fn apply_note(conn: &Connection, note: &IndexedNote) -> AppResult<()>
 /// cascades to every child table; `search_fts` (a virtual table, no FK) is
 /// cleared explicitly. `index_meta` is intentionally preserved across a rebuild.
 pub(super) fn clear_index(conn: &Connection) -> AppResult<()> {
-    conn.execute_batch("DELETE FROM notes; DELETE FROM search_fts;")?;
+    conn.execute_batch(
+        "DELETE FROM notes; DELETE FROM search_fts;
+         DELETE FROM embedding_vectors; DELETE FROM embedding_chunks;",
+    )?;
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/embed.rs
+++ b/apps/desktop/src-tauri/src/embed.rs
@@ -1,0 +1,151 @@
+//! The local embedding runtime (Plan 09): fastembed (ONNX) in-process, off the
+//! UI thread. The model (all-MiniLM-L6-v2, 384-dim) is downloaded on demand
+//! into app data — never bundled — and every failure degrades to a reported
+//! "unavailable" state (the same recoverable contract as sqlite-vec): semantic
+//! search is strictly additive, so nothing here may ever take the app down.
+
+use std::sync::{Arc, Mutex};
+
+use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager, State};
+
+use crate::error::{AppError, AppResult};
+
+/// Identifier recorded per vector; changing the model bumps this and triggers
+/// an embedding rebuild (`index_meta.embeddingModel` comparison in TS).
+pub const MODEL_ID: &str = "all-MiniLM-L6-v2";
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase", tag = "status")]
+pub enum EmbedStatus {
+    /// No model loaded yet; `embed_ensure` will download/load it.
+    Uninitialized,
+    /// Download/load in progress (first run downloads ~90MB).
+    Loading,
+    /// `embed_texts` is ready; `model` is recorded per vector (rebuild key).
+    Ready { model: String },
+    /// Load failed; semantic search is unavailable (lexical still works).
+    Failed { message: String },
+}
+
+#[derive(Default)]
+enum Runtime {
+    #[default]
+    Uninitialized,
+    Loading,
+    // fastembed's `embed` takes `&mut self`, so the model sits behind its own
+    // Mutex — embed calls serialize, which batching makes irrelevant.
+    Ready(Arc<Mutex<TextEmbedding>>),
+    Failed(String),
+}
+
+/// Process-wide embedding runtime state.
+#[derive(Default)]
+pub struct EmbedState(Mutex<Runtime>);
+
+fn lock_state<'a>(
+    state: &'a State<'a, EmbedState>,
+) -> AppResult<std::sync::MutexGuard<'a, Runtime>> {
+    state.0.lock().map_err(|err| {
+        tracing::error!(?err, "embed state lock poisoned by an earlier panic");
+        AppError::io("embed state lock poisoned")
+    })
+}
+
+fn status_of(runtime: &Runtime) -> EmbedStatus {
+    match runtime {
+        Runtime::Uninitialized => EmbedStatus::Uninitialized,
+        Runtime::Loading => EmbedStatus::Loading,
+        Runtime::Ready(_) => EmbedStatus::Ready {
+            model: MODEL_ID.to_string(),
+        },
+        Runtime::Failed(message) => EmbedStatus::Failed {
+            message: message.clone(),
+        },
+    }
+}
+
+fn emit_status(app: &AppHandle, status: &EmbedStatus) {
+    let _ = app.emit("embed:status", status);
+}
+
+/// Current runtime status (poll on startup; live changes arrive on
+/// `embed:status` events).
+#[tauri::command]
+pub fn embed_status(state: State<EmbedState>) -> AppResult<EmbedStatus> {
+    Ok(status_of(&*lock_state(&state)?))
+}
+
+/// Ensure the model is loaded, downloading it on first use. Idempotent: a
+/// concurrent call while loading returns immediately (the event stream carries
+/// the outcome). Runs the load on a blocking thread — model init is seconds
+/// even when cached, and the first run downloads.
+#[tauri::command]
+pub async fn embed_ensure(app: AppHandle, state: State<'_, EmbedState>) -> AppResult<EmbedStatus> {
+    {
+        let mut runtime = lock_state(&state)?;
+        match &*runtime {
+            Runtime::Ready(_) | Runtime::Loading => return Ok(status_of(&runtime)),
+            Runtime::Uninitialized | Runtime::Failed(_) => {
+                *runtime = Runtime::Loading;
+            }
+        }
+    }
+    emit_status(&app, &EmbedStatus::Loading);
+
+    let cache_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|err| AppError::io(format!("no app data dir: {err}")))?
+        .join("models");
+
+    let loaded = tauri::async_runtime::spawn_blocking(move || {
+        TextEmbedding::try_new(
+            InitOptions::new(EmbeddingModel::AllMiniLML6V2).with_cache_dir(cache_dir),
+        )
+        .map_err(|err| err.to_string())
+    })
+    .await
+    .map_err(|err| AppError::io(format!("embedding load task panicked: {err}")))?;
+
+    let status = {
+        let mut runtime = lock_state(&state)?;
+        *runtime = match loaded {
+            Ok(model) => Runtime::Ready(Arc::new(Mutex::new(model))),
+            Err(message) => {
+                tracing::error!(message, "embedding model load failed");
+                Runtime::Failed(message)
+            }
+        };
+        status_of(&runtime)
+    };
+    emit_status(&app, &status);
+    Ok(status)
+}
+
+/// Embed a batch of texts → 384-dim vectors, off the UI thread. Errors if the
+/// model isn't `Ready` (callers gate on `embed_status`/`embed_ensure`).
+#[tauri::command]
+pub async fn embed_texts(
+    texts: Vec<String>,
+    state: State<'_, EmbedState>,
+) -> AppResult<Vec<Vec<f32>>> {
+    let model = {
+        let runtime = lock_state(&state)?;
+        match &*runtime {
+            Runtime::Ready(model) => Arc::clone(model),
+            _ => return Err(AppError::io("embedding model is not loaded")),
+        }
+    };
+    tauri::async_runtime::spawn_blocking(move || {
+        let mut model = model
+            .lock()
+            .map_err(|_| AppError::io("embedding model lock poisoned"))?;
+        model
+            .embed(texts, None)
+            .map_err(|err| AppError::io(format!("embedding failed: {err}")))
+    })
+    .await
+    .map_err(|err| AppError::io(format!("embedding task panicked: {err}")))?
+}

--- a/apps/desktop/src-tauri/src/embed.rs
+++ b/apps/desktop/src-tauri/src/embed.rs
@@ -83,6 +83,14 @@ pub fn embed_status(state: State<EmbedState>) -> AppResult<EmbedStatus> {
 /// even when cached, and the first run downloads.
 #[tauri::command]
 pub async fn embed_ensure(app: AppHandle, state: State<'_, EmbedState>) -> AppResult<EmbedStatus> {
+    // Resolve the cache dir BEFORE flipping to Loading: it's the only step
+    // here that may fail without a guaranteed state transition afterwards.
+    let cache_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|err| AppError::io(format!("no app data dir: {err}")))?
+        .join("models");
+
     {
         let mut runtime = lock_state(&state)?;
         match &*runtime {
@@ -94,20 +102,21 @@ pub async fn embed_ensure(app: AppHandle, state: State<'_, EmbedState>) -> AppRe
     }
     emit_status(&app, &EmbedStatus::Loading);
 
-    let cache_dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|err| AppError::io(format!("no app data dir: {err}")))?
-        .join("models");
-
-    let loaded = tauri::async_runtime::spawn_blocking(move || {
-        TextEmbedding::try_new(
-            InitOptions::new(EmbeddingModel::AllMiniLML6V2).with_cache_dir(cache_dir),
-        )
-        .map_err(|err| err.to_string())
-    })
-    .await
-    .map_err(|err| AppError::io(format!("embedding load task panicked: {err}")))?;
+    // From here every path — success, load failure, even a panicked blocking
+    // task — must land the state in Ready or Failed: an early `?` would wedge
+    // the runtime in Loading forever (later ensures return early on Loading).
+    let loaded: Result<TextEmbedding, String> =
+        match tauri::async_runtime::spawn_blocking(move || {
+            TextEmbedding::try_new(
+                InitOptions::new(EmbeddingModel::AllMiniLML6V2).with_cache_dir(cache_dir),
+            )
+            .map_err(|err| err.to_string())
+        })
+        .await
+        {
+            Ok(result) => result,
+            Err(err) => Err(format!("embedding load task panicked: {err}")),
+        };
 
     let status = {
         let mut runtime = lock_state(&state)?;

--- a/apps/desktop/src-tauri/src/error.rs
+++ b/apps/desktop/src-tauri/src/error.rs
@@ -46,6 +46,12 @@ impl AppError {
         }
     }
 
+    pub fn parse(message: impl Into<String>) -> Self {
+        Self::Parse {
+            message: message.into(),
+        }
+    }
+
     pub fn no_graph() -> Self {
         Self::NoGraph {
             message: "No graph is open".into(),

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@
 //! [`recents`] (recent-graphs store), [`error`] (the shared error contract).
 
 mod db;
+mod embed;
 mod error;
 mod fs;
 mod quit;
@@ -43,6 +44,7 @@ pub fn run() {
         .manage(db::IndexState::default())
         .manage(watcher::WatcherState::default())
         .manage(quit::QuitState::default())
+        .manage(embed::EmbedState::default())
         .invoke_handler(tauri::generate_handler![
             app_version,
             fs::graph_open,
@@ -61,6 +63,11 @@ pub fn run() {
             db::index_remove,
             db::index_clear,
             db::db_query,
+            db::embed_apply,
+            db::embed_remove,
+            embed::embed_status,
+            embed::embed_ensure,
+            embed::embed_texts,
             watcher::watch_start,
             watcher::watch_stop,
             quit::quit_confirm,

--- a/apps/desktop/src/components/command-palette/command-palette.test.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.test.tsx
@@ -15,6 +15,11 @@ vi.mock('@reflect/core', async (importOriginal) => ({
   suggestWikiTargets,
   searchNotesRanked,
 }))
+vi.mock('@/lib/use-embed-status', () => ({
+  // The model is absent in these tests: the palette is exactly the lexical
+  // surface it was before Plan 09 (hybrid mode is additive).
+  useEmbedStatus: () => ({ status: 'uninitialized' }),
+}))
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({ graph: { root: '/g', name: 'g', cloudSync: null, generation: 1 } }),
 }))

--- a/apps/desktop/src/components/command-palette/command-palette.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 import {
   hasBridge,
   parseHighlights,
+  retrieve,
   searchNotesRanked,
   suggestWikiTargets,
 } from '@reflect/core'
@@ -11,6 +12,7 @@ import { listCommands, runCommand } from '@/lib/commands/registry'
 import type { CommandContext } from '@/lib/commands/types'
 import { formatDayLabel } from '@/lib/dates'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
+import { useEmbedStatus } from '@/lib/use-embed-status'
 import { useGraph } from '@/providers/graph-provider'
 import { routeForPath } from '@/routing/route'
 import { buildPaletteSections, type NoteEntry } from './entries'
@@ -47,6 +49,11 @@ function Snippet({ snippet }: { snippet: string }): ReactElement {
 export function CommandPalette({ context }: CommandPaletteProps): ReactElement | null {
   const { open, query, setQuery, closePalette } = usePalette()
   const { graph } = useGraph()
+  // Hybrid by default once the model is ready (decided): semantic results
+  // blend in via RRF with no toggle; without the model this is exactly the
+  // lexical search it was before.
+  const embed = useEmbedStatus()
+  const hybrid = embed.status === 'ready'
 
   // Defer the query the index sees: fast typing coalesces (the plan's
   // debounce) while the input itself stays perfectly responsive.
@@ -62,8 +69,14 @@ export function CommandPalette({ context }: CommandPaletteProps): ReactElement |
     enabled: searching,
   })
   const { data: hits, isLoading: hitsLoading, isError: hitsError } = useQuery({
-    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'palette-search', trimmed],
-    queryFn: () => searchNotesRanked(trimmed),
+    queryKey: [
+      INDEX_QUERY_SCOPE,
+      graph?.root,
+      'palette-search',
+      hybrid ? 'hybrid' : 'lexical',
+      trimmed,
+    ],
+    queryFn: () => (hybrid ? retrieve(trimmed, { mode: 'hybrid' }) : searchNotesRanked(trimmed)),
     enabled: searching && trimmed !== '',
   })
   // "No results" must mean the index answered **the live query**: both

--- a/apps/desktop/src/components/embeddings-sync.tsx
+++ b/apps/desktop/src/components/embeddings-sync.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useRef } from 'react'
+import { embedNote, embedRemove, subscribeFileChanges } from '@reflect/core'
+import { backfillEmbeddingsVisibly, ensureEmbeddingsVisibly, semanticEnabled } from '@/lib/semantic'
+import { useEmbedStatus } from '@/lib/use-embed-status'
+import { useGraph } from '@/providers/graph-provider'
+
+/**
+ * Keeps embeddings in sync with the graph (Plan 09). Renders nothing; mounted
+ * once per workspace. Three jobs, all gated on the runtime being `ready`:
+ *
+ * - auto-load the model on launch when semantic search was previously enabled
+ *   (the cache makes this instant; the first download only ever happens via
+ *   the explicit `semantic.enable` command);
+ * - run one incremental backfill per graph-open once `ready` (hash-skip makes
+ *   this cheap when nothing changed);
+ * - follow the watcher: changed notes re-embed, deleted notes drop vectors.
+ *   Work is serialized on one queue so passes can't interleave.
+ */
+export function EmbeddingsSync(): null {
+  const { graph } = useGraph()
+  const status = useEmbedStatus()
+  const queue = useRef<Promise<void>>(Promise.resolve())
+
+  const generation = graph?.generation ?? null
+  const root = graph?.root ?? null
+  const ready = status.status === 'ready'
+  const modelId = status.status === 'ready' ? status.model : null
+
+  // Auto-load on launch for users who opted in earlier.
+  useEffect(() => {
+    if (status.status === 'uninitialized' && semanticEnabled()) {
+      void ensureEmbeddingsVisibly()
+    }
+  }, [status.status])
+
+  // One backfill per (graph, model) once ready, then live watcher follow-up.
+  useEffect(() => {
+    if (!ready || generation === null || root === null || modelId === null) {
+      return
+    }
+    let active = true
+    let unlisten: (() => void) | null = null
+
+    queue.current = queue.current.then(() =>
+      backfillEmbeddingsVisibly({ generation, modelId, isStale: () => !active }),
+    )
+
+    void subscribeFileChanges((changes) => {
+      if (!active) {
+        return
+      }
+      for (const change of changes) {
+        queue.current = queue.current
+          .then(() => {
+            if (!active) {
+              return
+            }
+            return change.kind === 'remove'
+              ? embedRemove(change.path, generation)
+              : embedNote({ path: change.path, generation, modelId }).then(() => {})
+          })
+          .catch((cause) => {
+            console.error(`embedding sync failed for ${change.path}:`, cause)
+          })
+      }
+    }).then((fn) => {
+      if (active) {
+        unlisten = fn
+      } else {
+        fn()
+      }
+    })
+
+    return () => {
+      active = false
+      unlisten?.()
+    }
+  }, [ready, generation, root, modelId])
+
+  return null
+}

--- a/apps/desktop/src/components/embeddings-sync.tsx
+++ b/apps/desktop/src/components/embeddings-sync.tsx
@@ -41,9 +41,20 @@ export function EmbeddingsSync(): null {
     let active = true
     let unlisten: (() => void) | null = null
 
-    queue.current = queue.current.then(() =>
-      backfillEmbeddingsVisibly({ generation, modelId, isStale: () => !active }),
-    )
+    queue.current = queue.current
+      .then(() => {
+        if (!active) {
+          return
+        }
+        return backfillEmbeddingsVisibly({ generation, modelId, isStale: () => !active }).then(
+          () => {},
+        )
+      })
+      .catch((cause) => {
+        // A rejection here must not poison the queue (later watcher items
+        // chain off this promise) nor masquerade as a per-change failure.
+        console.error('embedding backfill failed:', cause)
+      })
 
     void subscribeFileChanges((changes) => {
       if (!active) {

--- a/apps/desktop/src/components/graph-workspace.tsx
+++ b/apps/desktop/src/components/graph-workspace.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, type ReactElement } from 'react'
 import type { GraphInfo } from '@reflect/core'
 import { AppShell } from '@/components/app-shell'
 import { CommandPalette } from '@/components/command-palette/command-palette'
+import { EmbeddingsSync } from '@/components/embeddings-sync'
 import { PaletteProvider, usePalette } from '@/components/command-palette/palette-provider'
 import { DailyStream } from '@/components/daily-stream'
 import { NotePane } from '@/components/note-pane'
@@ -102,6 +103,7 @@ function WorkspaceContent({ graph }: GraphWorkspaceProps): ReactElement {
 
         <OperationsStatus />
         <CommandPalette context={commandContext} />
+        <EmbeddingsSync />
       </div>
     </AppShell>
   )

--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -215,7 +215,7 @@ export function NotePane({
       </NoteEditor>
 
       <BacklinksPanel path={path} />
-      <RelatedNotes path={path} seed={document.initialContent} />
+      <RelatedNotes path={path} />
     </div>
   )
 }

--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, type ReactElement } from 'react'
 import { isDaily, resolveWikiTarget } from '@reflect/core'
 import { BacklinksPanel } from '@/components/backlinks-panel'
+import { RelatedNotes } from '@/components/related-notes'
 import { NoteEditor, type NoteEditorHandle } from '@/editor/note-editor'
 import { useImagePersistence } from '@/editor/use-image-persistence'
 import { useNoteDocument } from '@/editor/use-note-document'
@@ -214,6 +215,7 @@ export function NotePane({
       </NoteEditor>
 
       <BacklinksPanel path={path} />
+      <RelatedNotes path={path} seed={document.initialContent} />
     </div>
   )
 }

--- a/apps/desktop/src/components/related-notes.test.tsx
+++ b/apps/desktop/src/components/related-notes.test.tsx
@@ -1,0 +1,74 @@
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import { RouterProvider, useRouter } from '@/routing/router'
+import { RelatedNotes } from './related-notes'
+
+const retrieve = vi.hoisted(() => vi.fn())
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  hasBridge: () => true,
+  retrieve,
+}))
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({ graph: { root: '/g', name: 'g', cloudSync: null, generation: 1 } }),
+}))
+const embedStatus = vi.hoisted(() => ({ current: { status: 'ready', model: 'm' } }))
+vi.mock('@/lib/use-embed-status', () => ({
+  useEmbedStatus: () => embedStatus.current,
+}))
+
+function RouteProbe(): ReactNode {
+  const { route } = useRouter()
+  return <output data-testid="route">{JSON.stringify(route)}</output>
+}
+
+function renderRelated(path: string, seed: string) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <RouterProvider>
+        <RelatedNotes path={path} seed={seed} />
+        <RouteProbe />
+      </RouterProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('RelatedNotes', () => {
+  it('lists semantic neighbors, excluding the note itself, and navigates', async () => {
+    retrieve.mockResolvedValue([
+      { path: 'notes/self.md', title: 'Self', score: 1, snippet: 'me', heading: null, isPrivate: false },
+      { path: 'notes/kin.md', title: 'Kindred', score: 0.8, snippet: 'close by', heading: null, isPrivate: false },
+    ])
+    const view = renderRelated('notes/self.md', 'seed content about things')
+    await view.findByText('Kindred')
+    expect(view.queryByText('Self')).toBeNull() // self-excluded
+
+    await userEvent.click(view.getByText('Kindred'))
+    expect(view.getByTestId('route').textContent).toContain('notes/kin.md')
+    view.unmount()
+  })
+
+  it('renders nothing when the model is not ready', async () => {
+    embedStatus.current = { status: 'uninitialized' } as never
+    try {
+      retrieve.mockClear()
+      const view = renderRelated('notes/a.md', 'seed')
+      await waitFor(() => expect(view.queryByText('Related')).toBeNull())
+      expect(retrieve).not.toHaveBeenCalled()
+      view.unmount()
+    } finally {
+      embedStatus.current = { status: 'ready', model: 'm' } as never
+    }
+  })
+
+  it('renders nothing for an empty seed or empty results', async () => {
+    retrieve.mockResolvedValue([])
+    const view = renderRelated('notes/a.md', '   ')
+    await waitFor(() => expect(view.queryByText('Related')).toBeNull())
+    view.unmount()
+  })
+})

--- a/apps/desktop/src/components/related-notes.test.tsx
+++ b/apps/desktop/src/components/related-notes.test.tsx
@@ -6,18 +6,14 @@ import type { ReactNode } from 'react'
 import { RouterProvider, useRouter } from '@/routing/router'
 import { RelatedNotes } from './related-notes'
 
-const retrieve = vi.hoisted(() => vi.fn())
+const relatedNotes = vi.hoisted(() => vi.fn())
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   hasBridge: () => true,
-  retrieve,
+  relatedNotes,
 }))
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({ graph: { root: '/g', name: 'g', cloudSync: null, generation: 1 } }),
-}))
-const embedStatus = vi.hoisted(() => ({ current: { status: 'ready', model: 'm' } }))
-vi.mock('@/lib/use-embed-status', () => ({
-  useEmbedStatus: () => embedStatus.current,
 }))
 
 function RouteProbe(): ReactNode {
@@ -25,12 +21,12 @@ function RouteProbe(): ReactNode {
   return <output data-testid="route">{JSON.stringify(route)}</output>
 }
 
-function renderRelated(path: string, seed: string) {
+function renderRelated(path: string) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <QueryClientProvider client={client}>
       <RouterProvider>
-        <RelatedNotes path={path} seed={seed} />
+        <RelatedNotes path={path} />
         <RouteProbe />
       </RouterProvider>
     </QueryClientProvider>,
@@ -38,36 +34,21 @@ function renderRelated(path: string, seed: string) {
 }
 
 describe('RelatedNotes', () => {
-  it('lists semantic neighbors, excluding the note itself, and navigates', async () => {
-    retrieve.mockResolvedValue([
-      { path: 'notes/self.md', title: 'Self', score: 1, snippet: 'me', heading: null, isPrivate: false },
+  it('lists semantic neighbors and navigates on click', async () => {
+    relatedNotes.mockResolvedValue([
       { path: 'notes/kin.md', title: 'Kindred', score: 0.8, snippet: 'close by', heading: null, isPrivate: false },
     ])
-    const view = renderRelated('notes/self.md', 'seed content about things')
+    const view = renderRelated('notes/self.md')
     await view.findByText('Kindred')
-    expect(view.queryByText('Self')).toBeNull() // self-excluded
 
     await userEvent.click(view.getByText('Kindred'))
     expect(view.getByTestId('route').textContent).toContain('notes/kin.md')
     view.unmount()
   })
 
-  it('renders nothing when the model is not ready', async () => {
-    embedStatus.current = { status: 'uninitialized' } as never
-    try {
-      retrieve.mockClear()
-      const view = renderRelated('notes/a.md', 'seed')
-      await waitFor(() => expect(view.queryByText('Related')).toBeNull())
-      expect(retrieve).not.toHaveBeenCalled()
-      view.unmount()
-    } finally {
-      embedStatus.current = { status: 'ready', model: 'm' } as never
-    }
-  })
-
-  it('renders nothing for an empty seed or empty results', async () => {
-    retrieve.mockResolvedValue([])
-    const view = renderRelated('notes/a.md', '   ')
+  it('renders nothing when the note has no vectors (or nothing relates)', async () => {
+    relatedNotes.mockResolvedValue([]) // model never enabled / not yet embedded
+    const view = renderRelated('notes/a.md')
     await waitFor(() => expect(view.queryByText('Related')).toBeNull())
     view.unmount()
   })

--- a/apps/desktop/src/components/related-notes.tsx
+++ b/apps/desktop/src/components/related-notes.tsx
@@ -1,8 +1,7 @@
 import type { ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { hasBridge, retrieve } from '@reflect/core'
+import { hasBridge, relatedNotes } from '@reflect/core'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
-import { useEmbedStatus } from '@/lib/use-embed-status'
 import { useGraph } from '@/providers/graph-provider'
 import { routeForPath } from '@/routing/route'
 import { useRouter } from '@/routing/router'
@@ -10,34 +9,27 @@ import { useRouter } from '@/routing/router'
 interface RelatedNotesProps {
   /** The open note (excluded from its own results). */
   path: string
-  /** Seed content (the note body; the first ~1k chars are plenty). */
-  seed: string
 }
-
-const SEED_CHARS = 1200
 
 /**
  * Semantic neighbors of the open note (Plan 09 — the "suggested backlinks"
- * deferred from Plan 07): the payoff surface for local embeddings. Renders
- * nothing until the model is ready, when the note is empty, or when nothing
- * relates — strictly additive, like the rest of semantic search.
+ * deferred from Plan 07): the payoff surface for local embeddings. Seeded by
+ * the note's own **stored** chunk vectors, so freshness rides the embedding
+ * sync + index invalidation (saves re-embed → scope invalidates → refetch) —
+ * no pane-provided seed text to go stale. Renders nothing when the note has
+ * no vectors yet (model never enabled, not yet embedded) or nothing relates.
  */
-export function RelatedNotes({ path, seed }: RelatedNotesProps): ReactElement | null {
+export function RelatedNotes({ path }: RelatedNotesProps): ReactElement | null {
   const { navigate } = useRouter()
   const { graph } = useGraph()
-  const status = useEmbedStatus()
-  const ready = status.status === 'ready'
-  const trimmedSeed = seed.trim().slice(0, SEED_CHARS)
 
   const { data } = useQuery({
-    // The seed is part of the key: the same path re-seeded (reload, save,
-    // external sync) must not serve neighbors computed from the old body.
-    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'related', path, trimmedSeed],
-    queryFn: () => retrieve(trimmedSeed, { mode: 'semantic', limit: 7 }),
-    enabled: ready && hasBridge() && graph !== null && trimmedSeed !== '',
+    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'related', path],
+    queryFn: () => relatedNotes(path),
+    enabled: hasBridge() && graph !== null,
   })
 
-  const related = (data ?? []).filter((hit) => hit.path !== path).slice(0, 6)
+  const related = data ?? []
   if (related.length === 0) {
     return null
   }

--- a/apps/desktop/src/components/related-notes.tsx
+++ b/apps/desktop/src/components/related-notes.tsx
@@ -1,0 +1,71 @@
+import type { ReactElement } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { hasBridge, retrieve } from '@reflect/core'
+import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
+import { useEmbedStatus } from '@/lib/use-embed-status'
+import { useGraph } from '@/providers/graph-provider'
+import { routeForPath } from '@/routing/route'
+import { useRouter } from '@/routing/router'
+
+interface RelatedNotesProps {
+  /** The open note (excluded from its own results). */
+  path: string
+  /** Seed content (the note body; the first ~1k chars are plenty). */
+  seed: string
+}
+
+const SEED_CHARS = 1200
+
+/**
+ * Semantic neighbors of the open note (Plan 09 — the "suggested backlinks"
+ * deferred from Plan 07): the payoff surface for local embeddings. Renders
+ * nothing until the model is ready, when the note is empty, or when nothing
+ * relates — strictly additive, like the rest of semantic search.
+ */
+export function RelatedNotes({ path, seed }: RelatedNotesProps): ReactElement | null {
+  const { navigate } = useRouter()
+  const { graph } = useGraph()
+  const status = useEmbedStatus()
+  const ready = status.status === 'ready'
+  const trimmedSeed = seed.trim().slice(0, SEED_CHARS)
+
+  const { data } = useQuery({
+    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'related', path],
+    queryFn: () => retrieve(trimmedSeed, { mode: 'semantic', limit: 7 }),
+    enabled: ready && hasBridge() && graph !== null && trimmedSeed !== '',
+  })
+
+  const related = (data ?? []).filter((hit) => hit.path !== path).slice(0, 6)
+  if (related.length === 0) {
+    return null
+  }
+
+  return (
+    <section
+      aria-label="Related notes"
+      className="mt-6 border-t border-black/5 pt-3 dark:border-white/5"
+    >
+      <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-[color:var(--text-muted)]">
+        Related
+      </h3>
+      <ul className="space-y-0.5">
+        {related.map((hit) => (
+          <li key={hit.path}>
+            <button
+              type="button"
+              onClick={() => navigate(routeForPath(hit.path))}
+              className="w-full rounded px-2 py-1 text-left hover:bg-black/5 dark:hover:bg-white/5"
+            >
+              <span className="block truncate text-sm font-medium">{hit.title}</span>
+              {hit.snippet !== '' ? (
+                <span className="block truncate text-xs text-[color:var(--text-muted)]">
+                  {hit.snippet}
+                </span>
+              ) : null}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/apps/desktop/src/components/related-notes.tsx
+++ b/apps/desktop/src/components/related-notes.tsx
@@ -30,7 +30,9 @@ export function RelatedNotes({ path, seed }: RelatedNotesProps): ReactElement | 
   const trimmedSeed = seed.trim().slice(0, SEED_CHARS)
 
   const { data } = useQuery({
-    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'related', path],
+    // The seed is part of the key: the same path re-seeded (reload, save,
+    // external sync) must not serve neighbors computed from the old body.
+    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'related', path, trimmedSeed],
     queryFn: () => retrieve(trimmedSeed, { mode: 'semantic', limit: 7 }),
     enabled: ready && hasBridge() && graph !== null && trimmedSeed !== '',
   })

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -5,6 +5,13 @@ import type { CommandContext } from './types'
 
 const randomNotePath = vi.hoisted(() => vi.fn())
 const rebuildIndex = vi.hoisted(() => vi.fn())
+const ensureEmbeddingsVisibly = vi.hoisted(() => vi.fn(async () => ({ status: 'ready', model: 'm' })))
+const setSemanticEnabled = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/semantic', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/semantic')>()),
+  ensureEmbeddingsVisibly,
+  setSemanticEnabled,
+}))
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   randomNotePath,
@@ -69,6 +76,13 @@ describe('app commands', () => {
     randomNotePath.mockResolvedValueOnce(null)
     await command('note.random').run(context)
     expect(navigated).toHaveLength(1) // unchanged
+  })
+
+  it('semantic.enable persists the opt-in and loads the model visibly', async () => {
+    const { context } = fakeContext()
+    await command('semantic.enable').run(context)
+    expect(setSemanticEnabled).toHaveBeenCalledWith(true)
+    expect(ensureEmbeddingsVisibly).toHaveBeenCalled()
   })
 
   it('index.rebuild runs at the open generation and reports as an operation', async () => {

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -1,6 +1,7 @@
 import { notePath, randomNotePath, rebuildIndex } from '@reflect/core'
 import { ulid } from 'ulidx'
 import { startOperation } from '@/lib/operations'
+import { ensureEmbeddingsVisibly, setSemanticEnabled } from '@/lib/semantic'
 import { registerCommands } from './registry'
 import type { AppCommand } from './types'
 
@@ -62,6 +63,19 @@ const APP_COMMANDS: AppCommand[] = [
     title: 'Toggle theme',
     keywords: ['dark', 'light', 'appearance'],
     run: (context) => context.toggleTheme(),
+  },
+  {
+    id: 'semantic.enable',
+    title: 'Enable semantic search',
+    keywords: ['embeddings', 'ai', 'similar', 'model'],
+    // Downloads the local model (~90MB) — deliberately a command, never
+    // automatic: the first network fetch is the user's call. EmbeddingsSync
+    // reacts to `ready` with the backfill, and the persisted flag makes
+    // later launches load from cache without asking again.
+    run: async () => {
+      setSemanticEnabled(true)
+      await ensureEmbeddingsVisibly()
+    },
   },
   {
     id: 'index.rebuild',

--- a/apps/desktop/src/lib/semantic.test.ts
+++ b/apps/desktop/src/lib/semantic.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { setBridge } from '@reflect/core'
+import { ensureEmbeddingsVisibly } from './semantic'
+
+const startOperation = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/operations', () => ({ startOperation }))
+
+afterEach(() => {
+  setBridge(null)
+  startOperation.mockReset()
+})
+
+function operationHandle() {
+  const handle = { progress: vi.fn(), done: vi.fn(), fail: vi.fn() }
+  startOperation.mockReturnValue(handle)
+  return handle
+}
+
+describe('ensureEmbeddingsVisibly', () => {
+  it('resolves the operation only at a terminal status (a racing ensure returns loading)', async () => {
+    const handle = operationHandle()
+    let emit: ((payload: unknown) => void) | null = null
+    setBridge({
+      invoke: async (command) => {
+        if (command === 'embed_ensure') {
+          return { status: 'loading' } // someone else is mid-download
+        }
+        if (command === 'embed_status') {
+          return { status: 'loading' }
+        }
+        return null
+      },
+      listen: async (_event, handler) => {
+        emit = handler
+        return () => {
+          emit = null
+        }
+      },
+    })
+
+    const pending = ensureEmbeddingsVisibly()
+    await vi.waitFor(() => expect(emit).not.toBeNull())
+    expect(handle.done).not.toHaveBeenCalled() // still loading — not "done"
+
+    emit?.({ status: 'ready', model: 'all-MiniLM-L6-v2' })
+    const status = await pending
+    expect(status).toEqual({ status: 'ready', model: 'all-MiniLM-L6-v2' })
+    expect(handle.done).toHaveBeenCalledTimes(1)
+  })
+
+  it('a failed load fails the operation with the message', async () => {
+    const handle = operationHandle()
+    setBridge({
+      invoke: async (command) =>
+        command === 'embed_ensure' ? { status: 'failed', message: 'no disk space' } : null,
+      listen: async () => () => {},
+    })
+    const status = await ensureEmbeddingsVisibly()
+    expect(status.status).toBe('failed')
+    expect(handle.fail).toHaveBeenCalledWith('no disk space')
+  })
+})

--- a/apps/desktop/src/lib/semantic.test.ts
+++ b/apps/desktop/src/lib/semantic.test.ts
@@ -19,7 +19,9 @@ function operationHandle() {
 describe('ensureEmbeddingsVisibly', () => {
   it('resolves the operation only at a terminal status (a racing ensure returns loading)', async () => {
     const handle = operationHandle()
-    let emit: ((payload: unknown) => void) | null = null
+    // Boxed: TS control-flow analysis doesn't track closure assignments and
+    // would narrow a plain `let` to `never` at the call site below.
+    const emitter: { fire: ((payload: unknown) => void) | null } = { fire: null }
     setBridge({
       invoke: async (command) => {
         if (command === 'embed_ensure') {
@@ -31,18 +33,18 @@ describe('ensureEmbeddingsVisibly', () => {
         return null
       },
       listen: async (_event, handler) => {
-        emit = handler
+        emitter.fire = handler
         return () => {
-          emit = null
+          emitter.fire = null
         }
       },
     })
 
     const pending = ensureEmbeddingsVisibly()
-    await vi.waitFor(() => expect(emit).not.toBeNull())
+    await vi.waitFor(() => expect(emitter.fire).not.toBeNull())
     expect(handle.done).not.toHaveBeenCalled() // still loading — not "done"
 
-    emit?.({ status: 'ready', model: 'all-MiniLM-L6-v2' })
+    emitter.fire?.({ status: 'ready', model: 'all-MiniLM-L6-v2' })
     const status = await pending
     expect(status).toEqual({ status: 'ready', model: 'all-MiniLM-L6-v2' })
     expect(handle.done).toHaveBeenCalledTimes(1)

--- a/apps/desktop/src/lib/semantic.ts
+++ b/apps/desktop/src/lib/semantic.ts
@@ -1,4 +1,10 @@
-import { backfillEmbeddings, embedEnsure, type EmbedStatus } from '@reflect/core'
+import {
+  backfillEmbeddings,
+  embedEnsure,
+  embedStatus,
+  subscribeEmbedStatus,
+  type EmbedStatus,
+} from '@reflect/core'
 import { startOperation } from '@/lib/operations'
 
 /**
@@ -27,11 +33,43 @@ export function setSemanticEnabled(enabled: boolean): void {
   }
 }
 
+/**
+ * Resolve once the runtime reaches a terminal state. `embed_ensure` returns
+ * `loading` to a caller that raced an in-flight load — the event stream (plus
+ * a re-poll, in case the terminal event fired between the two) carries the
+ * real outcome.
+ */
+async function awaitTerminalStatus(initial: EmbedStatus): Promise<EmbedStatus> {
+  if (initial.status === 'ready' || initial.status === 'failed') {
+    return initial
+  }
+  return new Promise((resolve) => {
+    let unlisten: (() => void) | null = null
+    let settled = false
+    const settle = (status: EmbedStatus): void => {
+      if (!settled && (status.status === 'ready' || status.status === 'failed')) {
+        settled = true
+        unlisten?.()
+        resolve(status)
+      }
+    }
+    void subscribeEmbedStatus(settle).then((fn) => {
+      if (settled) {
+        fn()
+        return
+      }
+      unlisten = fn
+      // The terminal event may have fired before the subscription landed.
+      void embedStatus().then(settle)
+    })
+  })
+}
+
 /** Load (downloading if needed) the model, visibly. Resolves with the outcome. */
 export async function ensureEmbeddingsVisibly(): Promise<EmbedStatus> {
   const operation = startOperation('Loading semantic search model')
   try {
-    const status = await embedEnsure()
+    const status = await awaitTerminalStatus(await embedEnsure())
     if (status.status === 'failed') {
       operation.fail(status.message)
     } else {

--- a/apps/desktop/src/lib/semantic.ts
+++ b/apps/desktop/src/lib/semantic.ts
@@ -88,15 +88,20 @@ export async function backfillEmbeddingsVisibly(options: {
   generation: number
   modelId: string
   isStale?: () => boolean
-}): Promise<void> {
+}): Promise<'completed' | 'aborted' | 'failed'> {
   const operation = startOperation('Indexing notes for semantic search')
   try {
-    await backfillEmbeddings({
+    const outcome = await backfillEmbeddings({
       ...options,
       onProgress: (done, total) => operation.progress(done, total),
     })
+    // Either way the entry leaves the status surface (there is no "finished"
+    // state to misreport) — but an abort is the caller's signal that this
+    // pass didn't cover the graph; the next ready cycle re-runs it cheaply.
     operation.done()
+    return outcome
   } catch (cause) {
     operation.fail(cause instanceof Error ? cause.message : String(cause))
+    return 'failed'
   }
 }

--- a/apps/desktop/src/lib/semantic.ts
+++ b/apps/desktop/src/lib/semantic.ts
@@ -1,0 +1,64 @@
+import { backfillEmbeddings, embedEnsure, type EmbedStatus } from '@reflect/core'
+import { startOperation } from '@/lib/operations'
+
+/**
+ * Semantic-search enablement (Plan 09). The model is ~90MB and downloads from
+ * the network, so it is **opt-in**: the `semantic.enable` command flips a
+ * persisted flag and kicks the first download; later launches auto-load from
+ * the local cache because the flag is set. Acceptance: "first semantic use
+ * downloads the model with progress; later uses are instant."
+ */
+
+const ENABLED_KEY = 'reflect.semantic.enabled'
+
+export function semanticEnabled(): boolean {
+  try {
+    return localStorage.getItem(ENABLED_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+export function setSemanticEnabled(enabled: boolean): void {
+  try {
+    localStorage.setItem(ENABLED_KEY, String(enabled))
+  } catch {
+    // best-effort; the command can be re-run
+  }
+}
+
+/** Load (downloading if needed) the model, visibly. Resolves with the outcome. */
+export async function ensureEmbeddingsVisibly(): Promise<EmbedStatus> {
+  const operation = startOperation('Loading semantic search model')
+  try {
+    const status = await embedEnsure()
+    if (status.status === 'failed') {
+      operation.fail(status.message)
+    } else {
+      operation.done()
+    }
+    return status
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause)
+    operation.fail(message)
+    return { status: 'failed', message }
+  }
+}
+
+/** Embed every indexed note (incremental — the hash-skip makes re-runs cheap). */
+export async function backfillEmbeddingsVisibly(options: {
+  generation: number
+  modelId: string
+  isStale?: () => boolean
+}): Promise<void> {
+  const operation = startOperation('Indexing notes for semantic search')
+  try {
+    await backfillEmbeddings({
+      ...options,
+      onProgress: (done, total) => operation.progress(done, total),
+    })
+    operation.done()
+  } catch (cause) {
+    operation.fail(cause instanceof Error ? cause.message : String(cause))
+  }
+}

--- a/apps/desktop/src/lib/use-embed-status.ts
+++ b/apps/desktop/src/lib/use-embed-status.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react'
+import { embedStatus, hasBridge, subscribeEmbedStatus, type EmbedStatus } from '@reflect/core'
+
+/**
+ * The embedding runtime's live status (Plan 09). Polls once on mount, then
+ * tracks `embed:status` events. Without a bridge (browser dev) semantic
+ * features stay in `uninitialized` — i.e. invisible.
+ */
+export function useEmbedStatus(): EmbedStatus {
+  const [status, setStatus] = useState<EmbedStatus>({ status: 'uninitialized' })
+
+  useEffect(() => {
+    if (!hasBridge()) {
+      return
+    }
+    let active = true
+    let unlisten: (() => void) | null = null
+    void embedStatus().then((current) => {
+      if (active) {
+        setStatus(current)
+      }
+    })
+    void subscribeEmbedStatus((next) => {
+      if (active) {
+        setStatus(next)
+      }
+    }).then((fn) => {
+      if (active) {
+        unlisten = fn
+      } else {
+        fn()
+      }
+    })
+    return () => {
+      active = false
+      unlisten?.()
+    }
+  }, [])
+
+  return status
+}

--- a/docs/plans/09-semantic-search-and-embeddings.md
+++ b/docs/plans/09-semantic-search-and-embeddings.md
@@ -14,6 +14,37 @@ chunking, the `retrieve()` API, and ranking live in `@reflect/core` (`actions/em
 **Libraries:** `fastembed` (Rust, local embeddings) + `sqlite-vec` (vectors). See
 [Libraries](libraries.md).
 
+## Delivery (decided 2026-06-09)
+
+Both halves ship together on one branch, commits sequenced runtime-first so the
+native risk is reviewable in isolation:
+
+- **09a — embedding runtime + vector store:** `fastembed` **in-process,
+  off-thread** (decided — sidecar isolation only if crashes materialize) with
+  **all-MiniLM-L6-v2** (384-dim, ~90MB, decided), downloaded on demand into app
+  data with status surfaced through the operations store; the same
+  recoverable-init contract as sqlite-vec (failure = "semantic unavailable",
+  never a crash). Migration 0002 adds `embedding_chunks` + the `vec0` vector
+  table + `index_meta.embeddingModel`; vector writes are generation-pinned
+  commands, vector KNN reads go through the ordinary read-only `db_query`
+  (sqlite-vec accepts JSON-text vectors, so no bespoke read command).
+- **09b — chunking, retrieval, hybrid search, related notes:** sentence-aware
+  chunker in core (pure); incremental hash-diff embedding pass riding the
+  post-index-apply hook (TS orchestration per conventions — Rust stays
+  primitives); one `retrieve()` with **reciprocal rank fusion** for hybrid
+  (deterministic, no tuned weights); **⌘K goes hybrid by default with no
+  toggle** (decided — exact lexical matches keep top billing through RRF, and
+  the surface degrades invisibly to lexical-only without the model); and the
+  **related-notes panel** (decided — the Plan 07 "suggested backlinks"
+  deferral lands here) under the backlinks panel, seeded by the note's own
+  content, self-excluded, hidden when unavailable.
+
+**Recorded consequences:** `fastembed` pulls ONNX Runtime — its dylib must be
+code-signed at notarization time (Plan 15), and model-dependent Rust tests are
+gated behind an ignored integration flag (unit tests use a fake embedder).
+kysely-codegen replays migrations through better-sqlite3, so the codegen script
+loads the `sqlite-vec` npm extension to create the `vec0` table.
+
 ## Scope
 
 **In:** local embedding runtime in Rust, sentence-aware chunking, `sqlite-vec` storage,

--- a/docs/plans/09-semantic-search-and-embeddings.md
+++ b/docs/plans/09-semantic-search-and-embeddings.md
@@ -107,8 +107,10 @@ embedding execution should leave the WebView for performance.
    ```
    Vector search → dedupe chunks back to notes → optionally blend with FTS (hybrid).
 
-5. **Search integration.** Add a semantic/hybrid toggle to the `⌘K` surface (Plan 08):
-   "meat dishes" finds recipe notes lacking those exact words. Same UI, additive ranking.
+5. **Search integration.** Blend semantic hits into the `⌘K` surface (Plan 08) — hybrid
+   by default with **no toggle** (decided, see Delivery): "meat dishes" finds recipe
+   notes lacking those exact words. Same UI, additive ranking; lexical-only when the
+   model is unavailable.
 
 6. **Privacy contract.** `private: true` notes may stay in the **local** lexical + vector
    indexes (local recall is fine), but retrieval used for cloud AI (Plan 10) must exclude

--- a/packages/core/src/embeddings/chunk.test.ts
+++ b/packages/core/src/embeddings/chunk.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { chunkNote } from './chunk'
+
+const PATH = 'notes/a.md'
+
+describe('chunkNote', () => {
+  it('chunks per heading section with whole-file offsets and stable hashes', async () => {
+    const source = '# Alpha\n\nFirst section text.\n\n# Beta\n\nSecond section text.\n'
+    const chunks = await chunkNote(PATH, source)
+    expect(chunks).toHaveLength(2)
+    expect(chunks[0].heading).toBe('Alpha')
+    expect(chunks[1].heading).toBe('Beta')
+    // Offsets slice back to the exact chunk text.
+    for (const chunk of chunks) {
+      expect(source.slice(chunk.posFrom, chunk.posTo)).toBe(chunk.text)
+    }
+
+    const again = await chunkNote(PATH, source)
+    expect(again.map((chunk) => chunk.contentHash)).toEqual(
+      chunks.map((chunk) => chunk.contentHash),
+    )
+  })
+
+  it('an unchanged section keeps its hash when another section changes', async () => {
+    const before = '# Stable\n\nUnchanged text here.\n\n# Volatile\n\nOld content.\n'
+    const after = '# Stable\n\nUnchanged text here.\n\n# Volatile\n\nNew content entirely.\n'
+    const a = await chunkNote(PATH, before)
+    const b = await chunkNote(PATH, after)
+    expect(b[0].contentHash).toBe(a[0].contentHash) // the hash-skip foundation
+    expect(b[1].contentHash).not.toBe(a[1].contentHash)
+  })
+
+  it('splits a long section into sentence-aligned chunks', async () => {
+    const sentence = 'This sentence is reasonably long and ends with a period. '
+    const source = `# Long\n\n${sentence.repeat(40)}`
+    const chunks = await chunkNote(PATH, source)
+    expect(chunks.length).toBeGreaterThan(1)
+    for (const chunk of chunks) {
+      expect(chunk.heading).toBe('Long')
+      expect(source.slice(chunk.posFrom, chunk.posTo)).toBe(chunk.text)
+    }
+    // Chunks cover the section contiguously, in order.
+    for (let i = 1; i < chunks.length; i += 1) {
+      expect(chunks[i].posFrom).toBe(chunks[i - 1].posTo)
+    }
+  })
+
+  it('skips frontmatter and handles heading-less notes', async () => {
+    const source = '---\ntitle: Meta\n---\n\nJust a body without headings.\n'
+    const chunks = await chunkNote(PATH, source)
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0].heading).toBeNull()
+    expect(chunks[0].text).not.toContain('title: Meta')
+  })
+
+  it('returns nothing for empty or whitespace-only notes', async () => {
+    expect(await chunkNote(PATH, '')).toEqual([])
+    expect(await chunkNote(PATH, '\n\n  \n')).toEqual([])
+  })
+
+  it('merges a runt tail chunk into its predecessor', async () => {
+    const sentence = 'A solid sentence that carries real length for the chunker to count. '
+    const source = `# One\n\n${sentence.repeat(16)}Tiny tail.`
+    const chunks = await chunkNote(PATH, source)
+    const last = chunks[chunks.length - 1]
+    expect(last.text.length).toBeGreaterThanOrEqual(200)
+    expect(last.text.endsWith('Tiny tail.')).toBe(true)
+  })
+})

--- a/packages/core/src/embeddings/chunk.ts
+++ b/packages/core/src/embeddings/chunk.ts
@@ -1,0 +1,120 @@
+import { parseNote, splitFrontmatter } from '../markdown'
+import { hashContent } from '../indexing/hash'
+
+/**
+ * Sentence-aware note chunking (Plan 09). Sections split on headings, then
+ * sentences accumulate toward a target size — small enough that a chunk is
+ * about one idea, large enough that the embedding has context. Offsets are
+ * whole-file positions (the same base the index uses for links), and each
+ * chunk carries a content hash so unchanged chunks are never re-embedded.
+ */
+
+export interface NoteChunk {
+  /** Nearest enclosing heading's text, if any. */
+  heading: string | null
+  posFrom: number
+  posTo: number
+  text: string
+  contentHash: string
+}
+
+/** Accumulate sentences up to this size before starting a new chunk. */
+const TARGET_CHARS = 1000
+/** A trailing chunk smaller than this merges into its predecessor. */
+const MIN_CHARS = 200
+
+/** Sentence-ish boundaries: end punctuation + space, or a blank line. */
+function sentenceSpans(text: string, base: number): Array<{ from: number; to: number }> {
+  const spans: Array<{ from: number; to: number }> = []
+  let start = 0
+  const breaks = /[.!?][)"'”]?\s+|\n{2,}/g
+  for (const match of text.matchAll(breaks)) {
+    const end = match.index + match[0].length
+    spans.push({ from: base + start, to: base + end })
+    start = end
+  }
+  if (start < text.length) {
+    spans.push({ from: base + start, to: base + text.length })
+  }
+  return spans
+}
+
+interface Section {
+  heading: string | null
+  from: number
+  to: number
+}
+
+/** Chunk a note's source into embedding units. Pure; empty input → []. */
+export async function chunkNote(path: string, source: string): Promise<NoteChunk[]> {
+  const parsed = parseNote({ path, source })
+  const headings = parsed.headings
+
+  // Sections: the run before the first heading, then one per heading (each
+  // extending to the next heading or end of file).
+  const sections: Section[] = []
+  const bodyStart = splitFrontmatter(source).bodyOffset
+  const firstHeadingAt = headings.length > 0 ? headings[0].from : source.length
+  if (firstHeadingAt > bodyStart) {
+    sections.push({ heading: null, from: bodyStart, to: firstHeadingAt })
+  }
+  headings.forEach((heading, i) => {
+    const to = i + 1 < headings.length ? headings[i + 1].from : source.length
+    sections.push({ heading: heading.text, from: heading.from, to })
+  })
+
+  const chunks: NoteChunk[] = []
+  for (const section of sections) {
+    const text = source.slice(section.from, section.to)
+    if (text.trim() === '') {
+      continue
+    }
+    let chunkFrom = -1
+    let chunkTo = -1
+    const flush = async (): Promise<void> => {
+      if (chunkFrom === -1) {
+        return
+      }
+      const chunkText = source.slice(chunkFrom, chunkTo)
+      if (chunkText.trim() === '') {
+        chunkFrom = -1
+        return
+      }
+      chunks.push({
+        heading: section.heading,
+        posFrom: chunkFrom,
+        posTo: chunkTo,
+        text: chunkText,
+        contentHash: await hashContent(chunkText),
+      })
+      chunkFrom = -1
+    }
+    for (const span of sentenceSpans(text, section.from)) {
+      if (chunkFrom === -1) {
+        chunkFrom = span.from
+      }
+      chunkTo = span.to
+      if (chunkTo - chunkFrom >= TARGET_CHARS) {
+        await flush()
+      }
+    }
+    await flush()
+  }
+
+  // A runt tail reads better (and embeds better) merged into its predecessor.
+  if (chunks.length >= 2) {
+    const last = chunks[chunks.length - 1]
+    const prev = chunks[chunks.length - 2]
+    if (last.text.length < MIN_CHARS && prev.heading === last.heading) {
+      const text = source.slice(prev.posFrom, last.posTo)
+      chunks.splice(chunks.length - 2, 2, {
+        heading: prev.heading,
+        posFrom: prev.posFrom,
+        posTo: last.posTo,
+        text,
+        contentHash: await hashContent(text),
+      })
+    }
+  }
+  return chunks
+}

--- a/packages/core/src/embeddings/commands.ts
+++ b/packages/core/src/embeddings/commands.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod'
+import { getBridge, type Unlisten } from '../ipc/bridge'
+import { call } from '../ipc/invoke'
+
+/** Typed bindings for the Rust embedding runtime + vector writes (Plan 09). */
+
+export const embedStatusSchema = z.discriminatedUnion('status', [
+  z.object({ status: z.literal('uninitialized') }),
+  z.object({ status: z.literal('loading') }),
+  z.object({ status: z.literal('ready'), model: z.string() }),
+  z.object({ status: z.literal('failed'), message: z.string() }),
+])
+export type EmbedStatus = z.infer<typeof embedStatusSchema>
+
+const voidSchema = z.null()
+const vectorsSchema = z.array(z.array(z.number()))
+
+export function embedStatus(): Promise<EmbedStatus> {
+  return call('embed_status', {}, embedStatusSchema)
+}
+
+/** Load (downloading on first use) the model. Resolves with the outcome. */
+export function embedEnsure(): Promise<EmbedStatus> {
+  return call('embed_ensure', {}, embedStatusSchema)
+}
+
+/** Embed texts → 384-dim vectors. Errors unless status is `ready`. */
+export function embedTexts(texts: string[]): Promise<number[][]> {
+  return call('embed_texts', { texts }, vectorsSchema)
+}
+
+/** One chunk in the `embed_apply` payload; `vector` only for new/changed. */
+export interface EmbedChunkPayload {
+  heading: string | null
+  posFrom: number
+  posTo: number
+  text: string
+  contentHash: string
+  modelId: string
+  vector: number[] | null
+}
+
+/** Replace a note's chunk set (hash-diff applied in Rust; generation-pinned). */
+export async function embedApply(
+  path: string,
+  chunks: EmbedChunkPayload[],
+  generation: number,
+): Promise<void> {
+  await call('embed_apply', { path, chunks, generation }, voidSchema)
+}
+
+/** Drop a deleted note's chunks + vectors (generation-pinned). */
+export async function embedRemove(path: string, generation: number): Promise<void> {
+  await call('embed_remove', { path, generation }, voidSchema)
+}
+
+/** Live runtime status changes (download started/finished/failed). */
+export function subscribeEmbedStatus(handler: (status: EmbedStatus) => void): Promise<Unlisten> {
+  return getBridge().listen('embed:status', (payload) => {
+    const parsed = embedStatusSchema.safeParse(payload)
+    if (parsed.success) {
+      handler(parsed.data)
+    } else {
+      console.error('invalid embed:status payload:', parsed.error)
+    }
+  })
+}

--- a/packages/core/src/embeddings/pipeline.test.ts
+++ b/packages/core/src/embeddings/pipeline.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { setBridge } from '../ipc/bridge'
+import { embedNote } from './pipeline'
+
+afterEach(() => {
+  setBridge(null)
+})
+
+interface AppliedChunk {
+  contentHash: string
+  vector: number[] | null
+}
+
+/**
+ * Bridge fake for the pipeline: a note on "disk", stored hash+model rows for
+ * the db_query the diff makes, and capture of embed_texts / embed_apply.
+ */
+function fakePipelineBridge(options: {
+  content: string
+  storedRows: Array<{ content_hash: string; model_id: string }>
+}) {
+  const embedded: string[][] = []
+  const applied: { path: string; chunks: AppliedChunk[] }[] = []
+  setBridge({
+    invoke: async (command, args) => {
+      if (command === 'note_read') {
+        return options.content
+      }
+      if (command === 'db_query') {
+        return options.storedRows
+      }
+      if (command === 'embed_texts') {
+        const texts = (args as { texts: string[] }).texts
+        embedded.push(texts)
+        return texts.map(() => [0.5, 0.5])
+      }
+      if (command === 'embed_apply') {
+        const { path, chunks } = args as { path: string; chunks: AppliedChunk[] }
+        applied.push({ path, chunks })
+        return null
+      }
+      if (command === 'embed_remove') {
+        applied.push({ path: (args as { path: string }).path, chunks: [] })
+        return null
+      }
+      return null
+    },
+    listen: async () => () => {},
+  })
+  return { embedded, applied }
+}
+
+const MODEL = 'all-MiniLM-L6-v2'
+
+describe('embedNote', () => {
+  it('embeds everything for a brand-new note', async () => {
+    const { embedded, applied } = fakePipelineBridge({
+      content: '# One\n\nAlpha text.\n\n# Two\n\nBeta text.\n',
+      storedRows: [],
+    })
+    const count = await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
+    expect(count).toBe(2)
+    expect(embedded).toHaveLength(1) // one batched embed_texts call
+    expect(applied[0].chunks.every((chunk) => chunk.vector !== null)).toBe(true)
+  })
+
+  it('the hash-skip embeds nothing when stored hashes match', async () => {
+    const content = '# One\n\nAlpha text.\n'
+    // First pass captures the chunk hash the second pass will find "stored".
+    const first = fakePipelineBridge({ content, storedRows: [] })
+    await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
+    const hash = first.applied[0].chunks[0].contentHash
+
+    const second = fakePipelineBridge({
+      content,
+      storedRows: [{ content_hash: hash, model_id: MODEL }],
+    })
+    const count = await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
+    expect(count).toBe(0)
+    expect(second.embedded).toHaveLength(0) // nothing re-embedded
+    expect(second.applied[0].chunks[0].vector).toBeNull() // metadata-only row
+  })
+
+  it('a model change re-embeds chunks whose hashes are unchanged', async () => {
+    const content = '# One\n\nAlpha text.\n'
+    const first = fakePipelineBridge({ content, storedRows: [] })
+    await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
+    const hash = first.applied[0].chunks[0].contentHash
+
+    const second = fakePipelineBridge({
+      content,
+      storedRows: [{ content_hash: hash, model_id: 'old-model' }],
+    })
+    const count = await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
+    expect(count).toBe(1) // same hash, different model → new vector
+    expect(second.embedded).toHaveLength(1)
+  })
+
+  it('an emptied note drops its chunks via embed_remove', async () => {
+    const { applied } = fakePipelineBridge({ content: '\n', storedRows: [] })
+    const count = await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
+    expect(count).toBe(0)
+    expect(applied).toEqual([{ path: 'notes/a.md', chunks: [] }])
+  })
+})

--- a/packages/core/src/embeddings/pipeline.test.ts
+++ b/packages/core/src/embeddings/pipeline.test.ts
@@ -96,6 +96,29 @@ describe('embedNote', () => {
     expect(second.embedded).toHaveLength(1)
   })
 
+  it('duplicate-hash chunks only skip as many embeds as rows exist', async () => {
+    // Two byte-identical sections (above the runt-merge threshold) produce
+    // two chunks with one hash.
+    const section = `# A\n\n${'The same sentence again. '.repeat(12)}\n`
+    const dup = section + section
+    const first = fakePipelineBridge({ content: dup, storedRows: [] })
+    await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
+    const hashes = first.applied[0].chunks.map((chunk) => chunk.contentHash)
+    expect(hashes[0]).toBe(hashes[1]) // genuinely duplicated chunks
+
+    // Only ONE stored row for that hash: exactly one chunk may skip; the
+    // other must re-embed (vector present), or apply_chunks errors loudly.
+    const second = fakePipelineBridge({
+      content: dup,
+      storedRows: [{ content_hash: hashes[0], model_id: MODEL }],
+    })
+    const count = await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
+    expect(count).toBe(1)
+    const sent = second.applied[0].chunks
+    expect(sent.filter((chunk) => chunk.vector === null)).toHaveLength(1)
+    expect(sent.filter((chunk) => chunk.vector !== null)).toHaveLength(1)
+  })
+
   it('an emptied note drops its chunks via embed_remove', async () => {
     const { applied } = fakePipelineBridge({ content: '\n', storedRows: [] })
     const count = await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })

--- a/packages/core/src/embeddings/pipeline.ts
+++ b/packages/core/src/embeddings/pipeline.ts
@@ -40,27 +40,43 @@ export async function embedNote(options: EmbedNoteOptions): Promise<number> {
     return 0
   }
 
-  // Stored hash+model pairs: a model change makes every chunk "new", so a
-  // model switch re-embeds naturally — no separate rebuild bookkeeping.
+  // Stored hash+model pairs, **counted**: duplicate identical sections mean
+  // several chunks can share one hash, and only as many may skip embedding as
+  // there are stored rows to pair with (apply_chunks pairs one row per
+  // skipped chunk — an unmatched skip is a loud error). A model change makes
+  // every chunk "new", so a model switch re-embeds with no extra bookkeeping.
   const existing = await db
     .selectFrom('embeddingChunks')
     .where('notePath', '=', path)
     .select(['contentHash', 'modelId'])
     .execute()
-  const stored = new Set(existing.map((row) => `${row.modelId} ${row.contentHash}`))
+  const available = new Map<string, number>()
+  for (const row of existing) {
+    const key = `${row.modelId} ${row.contentHash}`
+    available.set(key, (available.get(key) ?? 0) + 1)
+  }
 
-  const toEmbed = chunks.filter((chunk) => !stored.has(`${modelId} ${chunk.contentHash}`))
+  const skip = chunks.map((chunk) => {
+    const key = `${modelId} ${chunk.contentHash}`
+    const remaining = available.get(key) ?? 0
+    if (remaining > 0) {
+      available.set(key, remaining - 1)
+      return true
+    }
+    return false
+  })
+  const toEmbed = chunks.filter((_, i) => !skip[i])
   const vectors = toEmbed.length > 0 ? await embedTexts(toEmbed.map((chunk) => chunk.text)) : []
-  const vectorByHash = new Map(toEmbed.map((chunk, i) => [chunk.contentHash, vectors[i]]))
+  let vectorAt = 0
 
-  const payload: EmbedChunkPayload[] = chunks.map((chunk) => ({
+  const payload: EmbedChunkPayload[] = chunks.map((chunk, i) => ({
     heading: chunk.heading,
     posFrom: chunk.posFrom,
     posTo: chunk.posTo,
     text: chunk.text,
     contentHash: chunk.contentHash,
     modelId,
-    vector: vectorByHash.get(chunk.contentHash) ?? null,
+    vector: skip[i] ? null : vectors[vectorAt++],
   }))
   await embedApply(path, payload, generation)
   return toEmbed.length

--- a/packages/core/src/embeddings/pipeline.ts
+++ b/packages/core/src/embeddings/pipeline.ts
@@ -92,13 +92,13 @@ export async function backfillEmbeddings(options: {
   onProgress?: (done: number, total: number) => void
   /** Abort between notes (e.g. graph switch). */
   isStale?: () => boolean
-}): Promise<void> {
+}): Promise<'completed' | 'aborted'> {
   const { generation, modelId, onProgress, isStale } = options
   const rows = await db.selectFrom('notes').select('path').orderBy('path').execute()
   let done = 0
   for (const row of rows) {
     if (isStale?.()) {
-      return
+      return 'aborted'
     }
     try {
       await embedNote({ path: row.path, generation, modelId })
@@ -108,4 +108,5 @@ export async function backfillEmbeddings(options: {
     done += 1
     onProgress?.(done, rows.length)
   }
+  return 'completed'
 }

--- a/packages/core/src/embeddings/pipeline.ts
+++ b/packages/core/src/embeddings/pipeline.ts
@@ -1,0 +1,95 @@
+import { readNote } from '../graph/commands'
+import { db } from '../indexing/db'
+import { chunkNote } from './chunk'
+import { embedApply, embedRemove, embedTexts, type EmbedChunkPayload } from './commands'
+
+/**
+ * The incremental embedding pass (Plan 09): chunk a note, diff chunk hashes
+ * against the stored rows, embed only what changed, and apply as one
+ * generation-pinned write. TS owns this orchestration (Rust supplies
+ * `embed_texts` + the table writes), mirroring the indexing pipeline.
+ */
+
+export interface EmbedNoteOptions {
+  path: string
+  generation: number
+  /** The model recorded per vector (from the runtime's `ready` status). */
+  modelId: string
+  /** Pre-loaded content (the watcher path has it); read from disk if absent. */
+  content?: string
+}
+
+/**
+ * Bring one note's embeddings up to date. Returns the number of chunks that
+ * were (re)embedded — 0 means the hash-skip caught everything.
+ */
+export async function embedNote(options: EmbedNoteOptions): Promise<number> {
+  const { path, generation, modelId } = options
+  let content = options.content
+  if (content === undefined) {
+    try {
+      content = await readNote(path)
+    } catch {
+      return 0 // deleted between event and read; the remove path handles it
+    }
+  }
+
+  const chunks = await chunkNote(path, content)
+  if (chunks.length === 0) {
+    await embedRemove(path, generation)
+    return 0
+  }
+
+  // Stored hash+model pairs: a model change makes every chunk "new", so a
+  // model switch re-embeds naturally — no separate rebuild bookkeeping.
+  const existing = await db
+    .selectFrom('embeddingChunks')
+    .where('notePath', '=', path)
+    .select(['contentHash', 'modelId'])
+    .execute()
+  const stored = new Set(existing.map((row) => `${row.modelId} ${row.contentHash}`))
+
+  const toEmbed = chunks.filter((chunk) => !stored.has(`${modelId} ${chunk.contentHash}`))
+  const vectors = toEmbed.length > 0 ? await embedTexts(toEmbed.map((chunk) => chunk.text)) : []
+  const vectorByHash = new Map(toEmbed.map((chunk, i) => [chunk.contentHash, vectors[i]]))
+
+  const payload: EmbedChunkPayload[] = chunks.map((chunk) => ({
+    heading: chunk.heading,
+    posFrom: chunk.posFrom,
+    posTo: chunk.posTo,
+    text: chunk.text,
+    contentHash: chunk.contentHash,
+    modelId,
+    vector: vectorByHash.get(chunk.contentHash) ?? null,
+  }))
+  await embedApply(path, payload, generation)
+  return toEmbed.length
+}
+
+/**
+ * Backfill every indexed note (initial enable, repair). Serialized; the
+ * hash-skip makes re-runs cheap. Reports per-note progress.
+ */
+export async function backfillEmbeddings(options: {
+  generation: number
+  modelId: string
+  onProgress?: (done: number, total: number) => void
+  /** Abort between notes (e.g. graph switch). */
+  isStale?: () => boolean
+}): Promise<void> {
+  const { generation, modelId, onProgress, isStale } = options
+  const rows = await db.selectFrom('notes').select('path').orderBy('path').execute()
+  let done = 0
+  for (const row of rows) {
+    if (isStale?.()) {
+      return
+    }
+    try {
+      await embedNote({ path: row.path, generation, modelId })
+    } catch (cause) {
+      console.error(`embedding backfill failed for ${row.path}:`, cause)
+    }
+    done += 1
+    onProgress?.(done, rows.length)
+  }
+}

--- a/packages/core/src/embeddings/retrieve.test.ts
+++ b/packages/core/src/embeddings/retrieve.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { fuseRanked, type RetrievalHit } from './retrieve'
+
+function hit(path: string, overrides?: Partial<RetrievalHit>): RetrievalHit {
+  return {
+    path,
+    title: path,
+    score: 0,
+    snippet: `about ${path}`,
+    heading: null,
+    isPrivate: false,
+    ...overrides,
+  }
+}
+
+describe('fuseRanked (reciprocal rank fusion)', () => {
+  it('a note ranked in both lists beats single-list notes', () => {
+    const lexical = [hit('notes/both.md'), hit('notes/lex-only.md')]
+    const semantic = [hit('notes/sem-only.md'), hit('notes/both.md')]
+    const fused = fuseRanked([lexical, semantic], 10)
+    expect(fused[0].path).toBe('notes/both.md')
+    expect(fused).toHaveLength(3)
+  })
+
+  it('preserves single-list order and respects the limit', () => {
+    const lexical = [hit('a'), hit('b'), hit('c')]
+    const fused = fuseRanked([lexical], 2)
+    expect(fused.map((entry) => entry.path)).toEqual(['a', 'b'])
+  })
+
+  it('fills an empty snippet from the other list and is deterministic', () => {
+    const semantic = [hit('a', { snippet: '' })]
+    const lexical = [hit('a', { snippet: 'lexical snippet' })]
+    const fused = fuseRanked([semantic, lexical], 5)
+    expect(fused[0].snippet).toBe('lexical snippet')
+    expect(fuseRanked([semantic, lexical], 5)).toEqual(fused)
+  })
+
+  it('keeps the private flag through fusion', () => {
+    const fused = fuseRanked([[hit('p', { isPrivate: true })]], 5)
+    expect(fused[0].isPrivate).toBe(true)
+  })
+})

--- a/packages/core/src/embeddings/retrieve.ts
+++ b/packages/core/src/embeddings/retrieve.ts
@@ -139,9 +139,60 @@ export async function retrieve(query: string, options?: RetrieveOptions): Promis
   if (mode === 'semantic') {
     return withPrivacy(await semanticHits(query, limit), excludePrivateContent)
   }
+  // Hybrid degrades, never breaks: a failing semantic leg (embed error, vec
+  // query error — even while the runtime claims ready) must not take lexical
+  // search down with it. A failing lexical leg is a real error and throws.
   const [lexical, semantic] = await Promise.all([
     lexicalHits(query, limit),
-    semanticHits(query, limit),
+    semanticHits(query, limit).catch((cause): RetrievalHit[] => {
+      console.error('semantic leg failed; serving lexical only:', cause)
+      return []
+    }),
   ])
   return withPrivacy(fuseRanked([lexical, semantic], limit), excludePrivateContent)
+}
+
+/**
+ * Semantic neighbors of an existing note, seeded by its own **stored** lead
+ * chunk vector — no re-embedding, no pane-provided seed text: the embedding
+ * sync keeps chunks current on every save, and the index invalidation scope
+ * refetches consumers, so freshness is automatic. Returns [] when the note
+ * has no vectors yet (model never enabled, or not yet embedded).
+ */
+export async function relatedNotes(path: string, limit = 6): Promise<RetrievalHit[]> {
+  const seed = await sql<{ vec: string }>`
+    SELECT vec_to_json(v.embedding) AS vec
+    FROM embedding_chunks c
+    JOIN embedding_vectors v ON v.rowid = c.id
+    WHERE c.note_path = ${path}
+    ORDER BY c.pos_from
+    LIMIT 1
+  `.execute(db)
+  const vec = seed.rows[0]?.vec
+  if (vec === undefined) {
+    return []
+  }
+  const result = await sql<ChunkHitRow>`
+    SELECT c.note_path AS path, n.title, c.heading, c.text,
+           n.is_private AS isPrivate, v.distance
+    FROM embedding_vectors v
+    JOIN embedding_chunks c ON c.id = v.rowid
+    JOIN notes n ON n.path = c.note_path
+    WHERE v.embedding MATCH ${vec} AND k = ${KNN_CANDIDATES}
+    ORDER BY v.distance
+  `.execute(db)
+  const byNote = new Map<string, RetrievalHit>()
+  for (const row of result.rows) {
+    if (row.path !== path && !byNote.has(row.path)) {
+      byNote.set(row.path, {
+        path: row.path,
+        title: row.title,
+        score: 1 / (1 + row.distance),
+        snippet: row.text.trim(),
+        heading: row.heading,
+        isPrivate: row.isPrivate !== 0,
+      })
+    }
+  }
+  return [...byNote.values()].slice(0, limit)
 }

--- a/packages/core/src/embeddings/retrieve.ts
+++ b/packages/core/src/embeddings/retrieve.ts
@@ -1,0 +1,147 @@
+import { sql } from 'kysely'
+import { db } from '../indexing/db'
+import { searchNotesRanked } from '../indexing/search'
+import { embedTexts } from './commands'
+
+/**
+ * The shared retrieval contract (Plan 09): one `retrieve()` for search and AI.
+ * Lexical = FTS (title-boosted); semantic = embed the query, KNN over chunks,
+ * dedupe to best chunk per note; hybrid = reciprocal rank fusion of the two
+ * (deterministic, no tuned weights). Private notes stay locally recallable —
+ * `excludePrivateContent` strips their *content* for callers that ship hits to
+ * external services (Plan 10), enforced again at the AI boundary.
+ */
+
+export interface RetrievalHit {
+  path: string
+  title: string
+  score: number
+  /** Chunk text (semantic) or highlight-markered FTS snippet (lexical). */
+  snippet: string
+  heading: string | null
+  isPrivate: boolean
+}
+
+export interface RetrieveOptions {
+  limit?: number
+  mode?: 'semantic' | 'lexical' | 'hybrid'
+  /** AI callers set true: private hits keep title/flag but lose content. */
+  excludePrivateContent?: boolean
+}
+
+const KNN_CANDIDATES = 24
+
+interface ChunkHitRow {
+  path: string
+  title: string
+  heading: string | null
+  text: string
+  isPrivate: number
+  distance: number
+}
+
+async function semanticHits(query: string, limit: number): Promise<RetrievalHit[]> {
+  const [vector] = await embedTexts([query])
+  const result = await sql<ChunkHitRow>`
+    SELECT c.note_path AS path, n.title, c.heading, c.text,
+           n.is_private AS isPrivate, v.distance
+    FROM embedding_vectors v
+    JOIN embedding_chunks c ON c.id = v.rowid
+    JOIN notes n ON n.path = c.note_path
+    WHERE v.embedding MATCH ${JSON.stringify(vector)} AND k = ${KNN_CANDIDATES}
+    ORDER BY v.distance
+  `.execute(db)
+
+  // Best chunk per note wins; distance maps to a similarity-ish score
+  // (lower distance = higher score) for callers that want magnitudes.
+  const byNote = new Map<string, RetrievalHit>()
+  for (const row of result.rows) {
+    if (!byNote.has(row.path)) {
+      byNote.set(row.path, {
+        path: row.path,
+        title: row.title,
+        score: 1 / (1 + row.distance),
+        snippet: row.text.trim(),
+        heading: row.heading,
+        isPrivate: row.isPrivate !== 0,
+      })
+    }
+  }
+  return [...byNote.values()].slice(0, limit)
+}
+
+async function lexicalHits(query: string, limit: number): Promise<RetrievalHit[]> {
+  const hits = await searchNotesRanked(query, limit)
+  if (hits.length === 0) {
+    return []
+  }
+  const flags = await db
+    .selectFrom('notes')
+    .where(
+      'path',
+      'in',
+      hits.map((hit) => hit.path),
+    )
+    .select(['path', 'isPrivate'])
+    .execute()
+  const privateByPath = new Map(flags.map((row) => [row.path, row.isPrivate !== 0]))
+  return hits.map((hit, index) => ({
+    path: hit.path,
+    title: hit.title,
+    score: 1 / (1 + index), // FTS rank order; raw bm25 scores are not exposed
+    snippet: hit.snippet,
+    heading: null,
+    isPrivate: privateByPath.get(hit.path) ?? false,
+  }))
+}
+
+/** Reciprocal rank fusion: order-based, scale-free, deterministic. */
+export function fuseRanked(lists: RetrievalHit[][], limit: number): RetrievalHit[] {
+  const K = 60 // the standard RRF damping constant
+  const fused = new Map<string, { hit: RetrievalHit; score: number }>()
+  for (const list of lists) {
+    list.forEach((hit, index) => {
+      const entry = fused.get(hit.path)
+      const score = 1 / (K + index + 1)
+      if (entry) {
+        entry.score += score
+        // Prefer a snippet-bearing form when one side lacks content.
+        if (entry.hit.snippet === '' && hit.snippet !== '') {
+          entry.hit = { ...hit }
+        }
+      } else {
+        fused.set(hit.path, { hit: { ...hit }, score })
+      }
+    })
+  }
+  return [...fused.values()]
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map(({ hit, score }) => ({ ...hit, score }))
+}
+
+/** Strip private notes' content while keeping the hit + flag. */
+function withPrivacy(hits: RetrievalHit[], excludePrivateContent: boolean): RetrievalHit[] {
+  if (!excludePrivateContent) {
+    return hits
+  }
+  return hits.map((hit) => (hit.isPrivate ? { ...hit, snippet: '', heading: null } : hit))
+}
+
+export async function retrieve(query: string, options?: RetrieveOptions): Promise<RetrievalHit[]> {
+  const limit = options?.limit ?? 12
+  const mode = options?.mode ?? 'hybrid'
+  const excludePrivateContent = options?.excludePrivateContent ?? false
+
+  if (mode === 'lexical') {
+    return withPrivacy(await lexicalHits(query, limit), excludePrivateContent)
+  }
+  if (mode === 'semantic') {
+    return withPrivacy(await semanticHits(query, limit), excludePrivateContent)
+  }
+  const [lexical, semantic] = await Promise.all([
+    lexicalHits(query, limit),
+    semanticHits(query, limit),
+  ])
+  return withPrivacy(fuseRanked([lexical, semantic], limit), excludePrivateContent)
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export {
 export { embedNote, backfillEmbeddings } from './embeddings/pipeline'
 export {
   retrieve,
+  relatedNotes,
   fuseRanked,
   type RetrievalHit,
   type RetrieveOptions,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,27 @@ export { setBridge, hasBridge, type IpcBridge, type Unlisten } from './ipc/bridg
 export { call } from './ipc/invoke'
 export { getAppVersion } from './ipc/commands'
 export { confirmQuit, subscribeQuitRequested } from './app/quit'
+
+// Embeddings & retrieval (Plan 09)
+export { chunkNote, type NoteChunk } from './embeddings/chunk'
+export {
+  embedStatus,
+  embedEnsure,
+  embedTexts,
+  embedApply,
+  embedRemove,
+  subscribeEmbedStatus,
+  embedStatusSchema,
+  type EmbedStatus,
+  type EmbedChunkPayload,
+} from './embeddings/commands'
+export { embedNote, backfillEmbeddings } from './embeddings/pipeline'
+export {
+  retrieve,
+  fuseRanked,
+  type RetrievalHit,
+  type RetrieveOptions,
+} from './embeddings/retrieve'
 export { appErrorSchema, isAppError, toAppError, type AppError } from './errors'
 
 // Graph & file storage (Plan 02)

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -19,6 +19,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "better-sqlite3": "^12.10.0",
     "kysely-codegen": "^0.20.0",
+    "sqlite-vec": "^0.1.9",
     "typescript": "~5.8.3",
     "vitest": "^3"
   }

--- a/packages/db/scripts/generate-schema.mjs
+++ b/packages/db/scripts/generate-schema.mjs
@@ -14,6 +14,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import Database from 'better-sqlite3'
+import * as sqliteVec from 'sqlite-vec'
 
 const require = createRequire(import.meta.url)
 const here = dirname(fileURLToPath(import.meta.url))
@@ -27,6 +28,9 @@ const dbPath = join(tmp, 'index.sqlite')
 try {
   const db = new Database(dbPath)
   try {
+    // The 0002 migration creates a vec0 virtual table; the throwaway DB needs
+    // the sqlite-vec extension loaded just like the Rust runtime registers it.
+    sqliteVec.load(db)
     const files = readdirSync(migrationsDir)
       .filter((file) => file.endsWith('.sql'))
       .sort()
@@ -36,6 +40,10 @@ try {
     for (const file of files) {
       db.exec(readFileSync(join(migrationsDir, file), 'utf8'))
     }
+    // kysely-codegen introspects over its own connection, which has no
+    // sqlite-vec loaded — drop the vec0 table (vector reads go through raw
+    // SQL at runtime; it was never going to appear in the typed schema).
+    db.exec('DROP TABLE IF EXISTS embedding_vectors')
   } finally {
     db.close() // always close, even if a migration exec throws
   }

--- a/packages/db/src/schema.gen.ts
+++ b/packages/db/src/schema.gen.ts
@@ -30,6 +30,17 @@ export interface Backlinks {
   targetRaw: string | null;
 }
 
+export interface EmbeddingChunks {
+  contentHash: string;
+  heading: string | null;
+  id: Generated<number | null>;
+  modelId: string;
+  notePath: string;
+  posFrom: number;
+  posTo: number;
+  text: string;
+}
+
 export interface IndexMeta {
   key: string;
   value: string;
@@ -82,6 +93,7 @@ export interface DB {
   aliases: Aliases;
   assets: Assets;
   backlinks: Backlinks;
+  embeddingChunks: EmbeddingChunks;
   indexMeta: IndexMeta;
   links: Links;
   noteKeys: NoteKeys;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
       kysely-codegen:
         specifier: ^0.20.0
         version: 0.20.0(better-sqlite3@12.10.0)(kysely@0.28.17)(typescript@5.8.3)
+      sqlite-vec:
+        specifier: ^0.1.9
+        version: 0.1.9
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -2326,6 +2329,34 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  sqlite-vec-darwin-arm64@0.1.9:
+    resolution: {integrity: sha512-jSsZpE42OfBkGL/ItyJTVCUwl6o6Ka3U5rc4j+UBDIQzC1ulSSKMEhQLthsOnF/MdAf1MuAkYhkdKmmcjaIZQg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  sqlite-vec-darwin-x64@0.1.9:
+    resolution: {integrity: sha512-KDlVyqQT7pnOhU1ymB9gs7dMbSoVmKHitT+k1/xkjarcX8bBqPxWrGlK/R+C5WmWkfvWwyq5FfXfiBYCBs6PlA==}
+    cpu: [x64]
+    os: [darwin]
+
+  sqlite-vec-linux-arm64@0.1.9:
+    resolution: {integrity: sha512-5wXVJ9c9kR4CHm/wVqXb/R+XUHTdpZ4nWbPHlS+gc9qQFVHs92Km4bPnCKX4rtcPMzvNis+SIzMJR1SCEwpuUw==}
+    cpu: [arm64]
+    os: [linux]
+
+  sqlite-vec-linux-x64@0.1.9:
+    resolution: {integrity: sha512-w3tCH8xK2finW8fQJ/m8uqKodXUZ9KAuAar2UIhz4BHILfpE0WM/MTGCRfa7RjYbrYim5Luk3guvMOGI7T7JQA==}
+    cpu: [x64]
+    os: [linux]
+
+  sqlite-vec-windows-x64@0.1.9:
+    resolution: {integrity: sha512-y3gEIyy/17bq2QFPQOWLE68TYWcRZkBQVA2XLrTPHNTOp55xJi/BBBmOm40tVMDMjtP+Elpk6UBUXdaq+46b0Q==}
+    cpu: [x64]
+    os: [win32]
+
+  sqlite-vec@0.1.9:
+    resolution: {integrity: sha512-L7XJWRIBNvR9O5+vh1FQ+IGkh/3D2AzVksW5gdtk28m78Hy8skFD0pqReKH1Yp0/BUKRGcffgKvyO/EON5JXpA==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -4633,6 +4664,29 @@ snapshots:
   source-map-js@1.2.1: {}
 
   space-separated-tokens@2.0.2: {}
+
+  sqlite-vec-darwin-arm64@0.1.9:
+    optional: true
+
+  sqlite-vec-darwin-x64@0.1.9:
+    optional: true
+
+  sqlite-vec-linux-arm64@0.1.9:
+    optional: true
+
+  sqlite-vec-linux-x64@0.1.9:
+    optional: true
+
+  sqlite-vec-windows-x64@0.1.9:
+    optional: true
+
+  sqlite-vec@0.1.9:
+    optionalDependencies:
+      sqlite-vec-darwin-arm64: 0.1.9
+      sqlite-vec-darwin-x64: 0.1.9
+      sqlite-vec-linux-arm64: 0.1.9
+      sqlite-vec-linux-x64: 0.1.9
+      sqlite-vec-windows-x64: 0.1.9
 
   stackback@0.0.2: {}
 


### PR DESCRIPTION
Throwaway draft to measure the Rust CI job with the ort/cargo caching from #20 applied on top of #18's fastembed branch. Will be closed after collecting cold/warm timings.

Baseline from #18's runs (old workflow): cold 5m40s, warm 3m18s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)