### PR TITLE
chore: add pnpm check housekeeping script, fold lint into dev workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,9 +29,10 @@ Drawn from the product docs — read these for deeper context:
 
 1. Make your changes
 2. Run typecheck (`pnpm typecheck`)
-3. Run specific tests for your changes (`pnpm test --run path/to/test`)
+3. Run lint (`pnpm lint`) — fix any errors; `pnpm lint:fix` auto-fixes where possible
+4. Run specific tests for your changes (`pnpm test --run path/to/test`)
 
-You don't need to bother linting because this will be done in a GitHub Action.
+`pnpm check` runs typecheck + lint together. Run it before declaring any work done.
 
 ### Running tests
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
     "lint": "oxlint apps packages",
+    "lint:fix": "oxlint --fix apps packages",
+    "check": "pnpm typecheck && pnpm lint",
     "tauri": "pnpm --filter @reflect/desktop tauri"
   },
   "devDependencies": {


### PR DESCRIPTION
## What changed

- **package.json**: added a `check` script (`pnpm typecheck && pnpm lint`) as a one-shot housekeeping command, plus a `lint:fix` helper (`oxlint --fix apps packages`).
- **AGENTS.md**: the development workflow now includes running lint locally (step 3, between typecheck and tests), replacing the previous "linting is handled by CI" guidance. It also points agents at `pnpm check` before declaring work done.

## Why

Lint failures were only surfacing in CI, after the work was already "done". Making typecheck + lint part of the standard local dev cycle (and giving it a single `pnpm check` entry point) catches these earlier and keeps agent-driven changes consistent.

## Notes for reviewers

- Verified `pnpm check` passes cleanly on this branch: typecheck succeeds across all 4 workspace packages and oxlint reports no issues.
- No behavior changes to existing scripts; `lint` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and npm script additions only; no application or CI behavior changes.
> 
> **Overview**
> Adds **`pnpm check`** (`typecheck` then `lint`) and **`pnpm lint:fix`** (`oxlint --fix`) at the monorepo root so local housekeeping matches what CI already runs.
> 
> **AGENTS.md** now treats lint as a required dev step (between typecheck and targeted tests) and tells agents to run **`pnpm check`** before calling work done, instead of relying on CI-only lint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc783e96a14d1709b88156082a92043d56242ed2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->