### PR TITLE
Quality pass: component decomposition, shared hooks, contributor guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,17 @@ cargo test        # from apps/desktop/src-tauri, if you touched Rust
   rebuildable cache. Never make the index durable.
 - No Reflect-hosted APIs, no Electron, secrets only in the OS keychain.
 
+## Guides
+
+Step-by-step walkthroughs for the most common kinds of change:
+
+- [Adding a native command](docs/contributing/adding-a-command.md) — the full
+  Rust → bridge → zod → React path, with conventions and a checklist.
+- [Adding a user setting](docs/contributing/adding-a-setting.md) — schema key,
+  defaults-by-construction, the settings screen. (No Rust involved.)
+- [Editor architecture](docs/contributing/editor-architecture.md) — the
+  session/adapter split, the save loop, and where new editor code goes.
+
 ## "Plan NN" in comments?
 
 Numbered plans in [docs/plans/](docs/plans/) are the implementation roadmap;

--- a/apps/desktop/src/components/backlinks-panel.tsx
+++ b/apps/desktop/src/components/backlinks-panel.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { getBacklinksWithContext, hasBridge } from '@reflect/core'
+import { NoteLinkList } from '@/components/note-link-list'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
 import { routeForPath } from '@/routing/route'
@@ -35,31 +36,16 @@ export function BacklinksPanel({ path }: BacklinksPanelProps): ReactElement | nu
   }
 
   return (
-    <section
-      aria-label="Backlinks"
-      className="mt-6 border-t border-black/5 pt-3 dark:border-white/5"
-    >
-      <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-[color:var(--text-muted)]">
-        Linked from
-      </h3>
-      <ul className="space-y-0.5">
-        {data.map((backlink) => (
-          <li key={`${backlink.sourcePath}:${backlink.posFrom}`}>
-            <button
-              type="button"
-              onClick={() => navigate(routeForPath(backlink.sourcePath))}
-              className="w-full rounded px-2 py-1 text-left hover:bg-black/5 dark:hover:bg-white/5"
-            >
-              <span className="block text-sm font-medium">{backlink.sourceTitle}</span>
-              {backlink.snippet !== '' ? (
-                <span className="block truncate text-xs text-[color:var(--text-muted)]">
-                  {backlink.snippet}
-                </span>
-              ) : null}
-            </button>
-          </li>
-        ))}
-      </ul>
-    </section>
+    <NoteLinkList
+      ariaLabel="Backlinks"
+      heading="Linked from"
+      items={data.map((backlink) => ({
+        key: `${backlink.sourcePath}:${backlink.posFrom}`,
+        title: backlink.sourceTitle,
+        snippet: backlink.snippet,
+        path: backlink.sourcePath,
+      }))}
+      onOpen={(target) => navigate(routeForPath(target))}
+    />
   )
 }

--- a/apps/desktop/src/components/cloud-sync-banner.test.tsx
+++ b/apps/desktop/src/components/cloud-sync-banner.test.tsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { CloudSyncBanner } from './cloud-sync-banner'
+
+describe('CloudSyncBanner', () => {
+  it('maps known provider ids to human labels', () => {
+    const view = render(<CloudSyncBanner provider="icloud" />)
+    expect(view.container.textContent).toContain('This graph is inside iCloud Drive.')
+    view.unmount()
+  })
+
+  it('shows an unknown provider id as-is', () => {
+    const view = render(<CloudSyncBanner provider="syncthing" />)
+    expect(view.container.textContent).toContain('This graph is inside syncthing.')
+    view.unmount()
+  })
+})

--- a/apps/desktop/src/components/cloud-sync-banner.tsx
+++ b/apps/desktop/src/components/cloud-sync-banner.tsx
@@ -1,0 +1,31 @@
+import type { ReactElement } from 'react'
+
+/** Human labels for the cloud-sync providers Rust detects under a graph root. */
+const CLOUD_LABELS: Record<string, string> = {
+  icloud: 'iCloud Drive',
+  dropbox: 'Dropbox',
+  googleDrive: 'Google Drive',
+  oneDrive: 'OneDrive',
+}
+
+interface CloudSyncBannerProps {
+  /** The detected provider id (`GraphInfo.cloudSync`); unknown ids show as-is. */
+  provider: string
+}
+
+/**
+ * Full-width warning strip shown when the open graph lives inside a
+ * cloud-synced folder: Reflect syncs via GitHub, and a second sync layer can
+ * corrupt the local index. Persistent (not dismissible) by design — the fix is
+ * moving the folder, not hiding the banner.
+ */
+export function CloudSyncBanner({ provider }: CloudSyncBannerProps): ReactElement {
+  const label = CLOUD_LABELS[provider] ?? provider
+  return (
+    <div className="border-b border-amber-500/30 bg-amber-500/10 px-6 py-2 text-xs text-amber-700 dark:text-amber-300">
+      This graph is inside {label}. Reflect syncs via GitHub — a cloud-synced
+      folder is unsupported and can corrupt the local index. Consider moving it to a
+      non-synced location.
+    </div>
+  )
+}

--- a/apps/desktop/src/components/graph-workspace.tsx
+++ b/apps/desktop/src/components/graph-workspace.tsx
@@ -1,39 +1,19 @@
-import { useCallback, useEffect, type ReactElement } from 'react'
+import type { ReactElement } from 'react'
 import type { GraphInfo } from '@reflect/core'
-import { Settings } from 'lucide-react'
-import { AppShell } from '@/components/app-shell'
-import { CommandPalette } from '@/components/command-palette/command-palette'
-import { EmbeddingsSync } from '@/components/embeddings-sync'
-import { PaletteProvider, usePalette } from '@/components/command-palette/palette-provider'
-import { DailyStream } from '@/components/daily-stream'
-import { NotePane } from '@/components/note-pane'
-import { SettingsScreen } from '@/components/settings-screen'
-import { useAppVersion } from '@/hooks/use-app-version'
-import { isIsoDate } from '@/lib/dates'
-import { useToday } from '@/lib/use-today'
-import { OperationsStatus } from '@/components/operations-status'
-import { useGraph } from '@/providers/graph-provider'
-import { useTheme } from '@/providers/theme-provider'
-import { useAppShortcuts } from '@/routing/app-shortcuts'
-import { RouterProvider, useRouter } from '@/routing/router'
-import { ScrollRestored } from '@/routing/scroll-restore'
-
-const CLOUD_LABELS: Record<string, string> = {
-  icloud: 'iCloud Drive',
-  dropbox: 'Dropbox',
-  googleDrive: 'Google Drive',
-  oneDrive: 'OneDrive',
-}
+import { PaletteProvider } from '@/components/command-palette/palette-provider'
+import { WorkspaceContent } from '@/components/workspace-content'
+import { RouterProvider } from '@/routing/router'
 
 interface GraphWorkspaceProps {
   graph: GraphInfo
 }
 
 /**
- * The main surface once a graph is open: the shell + header around the
- * route-driven content (Plan 06). The app opens to today's daily note — the
- * chronological spine — and all navigation goes through the typed router.
- * Keyed by the graph root so switching graphs starts a fresh history.
+ * The main surface once a graph is open (Plan 06): mounts the per-graph
+ * providers — the typed router and the ⌘K palette — around
+ * {@link WorkspaceContent}. The app opens to today's daily note, the
+ * chronological spine. Keyed by the graph root so switching graphs starts a
+ * fresh history.
  */
 export function GraphWorkspace({ graph }: GraphWorkspaceProps): ReactElement {
   return (
@@ -43,129 +23,4 @@ export function GraphWorkspace({ graph }: GraphWorkspaceProps): ReactElement {
       </PaletteProvider>
     </RouterProvider>
   )
-}
-
-function WorkspaceContent({ graph }: GraphWorkspaceProps): ReactElement {
-  const { resolvedTheme, setTheme } = useTheme()
-  const { indexing } = useGraph()
-  const { navigate } = useRouter()
-  const version = useAppVersion()
-  const commandContext = useAppShortcuts()
-
-  const toggleTheme = useCallback((): void => {
-    setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')
-  }, [resolvedTheme, setTheme])
-
-  const cloudLabel = graph.cloudSync ? (CLOUD_LABELS[graph.cloudSync] ?? graph.cloudSync) : null
-
-  return (
-    <AppShell
-      rail={
-        <span className="text-xs font-semibold text-[color:var(--text-secondary)]">R</span>
-      }
-      sidebar={
-        <div className="p-4 text-sm text-[color:var(--text-secondary)]">Context</div>
-      }
-    >
-      <div className="flex h-full flex-col">
-        <header className="flex items-center justify-between gap-4 border-b border-black/10 px-6 py-3 dark:border-white/10">
-          <h1 className="truncate text-sm font-semibold" title={graph.root}>
-            {graph.name}
-          </h1>
-          <div className="flex items-center gap-3">
-            {indexing ? (
-              <span
-                role="status"
-                className="text-xs text-[color:var(--text-muted)] motion-safe:animate-pulse"
-              >
-                Indexing…
-              </span>
-            ) : null}
-            <span className="text-xs text-[color:var(--text-muted)]">v{version ?? '—'}</span>
-            <button
-              type="button"
-              onClick={toggleTheme}
-              className="rounded-md border border-black/10 px-2.5 py-1 text-xs font-medium dark:border-white/10"
-            >
-              {resolvedTheme === 'dark' ? 'Light' : 'Dark'} mode
-            </button>
-            <button
-              type="button"
-              aria-label="Open settings"
-              title="Settings (⌘,)"
-              onClick={() => navigate({ kind: 'settings' })}
-              className="rounded-md border border-black/10 p-1.5 text-[color:var(--text-secondary)] dark:border-white/10"
-            >
-              <Settings aria-hidden className="size-3.5" />
-            </button>
-          </div>
-        </header>
-
-        {cloudLabel ? (
-          <div className="border-b border-amber-500/30 bg-amber-500/10 px-6 py-2 text-xs text-amber-700 dark:text-amber-300">
-            This graph is inside {cloudLabel}. Reflect syncs via GitHub — a cloud-synced
-            folder is unsupported and can corrupt the local index. Consider moving it to a
-            non-synced location.
-          </div>
-        ) : null}
-
-        <div className="min-h-0 flex-1">
-          <RouteContent />
-        </div>
-
-        <OperationsStatus />
-        <CommandPalette context={commandContext} />
-        <EmbeddingsSync />
-      </div>
-    </AppShell>
-  )
-}
-
-/**
- * `search/:query` is a deep-link target, not a second search surface (decided
- * 2026-06-09): arriving opens the ⌘K palette pre-filled over the stream.
- */
-function SearchRoute({ query, today }: { query: string; today: string }): ReactElement {
-  const { openPalette } = usePalette()
-  const { arrivalSeq, entryId } = useRouter()
-  // Keyed on the *arrival*, not just the value (the daily stream's lesson):
-  // re-navigating to the same search route bumps arrivalSeq without a remount,
-  // and back/forward changes entryId without bumping arrivalSeq — both are
-  // arrivals, and arriving on search opens the palette (decided).
-  useEffect(() => {
-    openPalette(query)
-  }, [query, arrivalSeq, entryId, openPalette])
-  return <DailyStream targetDate={today} />
-}
-
-/** Route → view. `today` tracks the live clock — midnight re-renders it. */
-function RouteContent(): ReactElement {
-  const { route } = useRouter()
-  const today = useToday()
-  switch (route.kind) {
-    case 'today':
-      return <DailyStream targetDate={today} />
-    case 'daily':
-      // A malformed date (impossible calendar day) anchors to today instead of
-      // letting dailyPath throw mid-render.
-      return <DailyStream targetDate={isIsoDate(route.date) ? route.date : today} />
-    case 'note':
-      return (
-        <ScrollRestored className="h-full overflow-auto px-6 py-8">
-          <div className="mx-auto w-full max-w-2xl">
-            <NotePane path={route.path} lazy autoFocus />
-          </div>
-        </ScrollRestored>
-      )
-    case 'search':
-      return <SearchRoute query={route.query} today={today} />
-    case 'settings':
-      return (
-        <ScrollRestored className="h-full overflow-auto px-6 py-8">
-          <div className="mx-auto w-full max-w-2xl">
-            <SettingsScreen />
-          </div>
-        </ScrollRestored>
-      )
-  }
 }

--- a/apps/desktop/src/components/inline-alert.tsx
+++ b/apps/desktop/src/components/inline-alert.tsx
@@ -1,0 +1,37 @@
+import type { ReactElement, ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+/** Visual severity of an {@link InlineAlert}. */
+export type InlineAlertTone = 'warning' | 'error'
+
+const TONE_CLASSES: Record<InlineAlertTone, string> = {
+  warning: 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300',
+  error: 'border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300',
+}
+
+interface InlineAlertProps {
+  tone?: InlineAlertTone
+  children: ReactNode
+  className?: string
+}
+
+/**
+ * The in-flow alert banner used across the app (save failures, conflicts, the
+ * read-only notice, the cloud-sync warning): one place for the tone palette and
+ * the `role="alert"` semantics, so every surface announces consistently to
+ * assistive tech.
+ */
+export function InlineAlert({
+  tone = 'warning',
+  children,
+  className,
+}: InlineAlertProps): ReactElement {
+  return (
+    <div
+      role="alert"
+      className={cn('rounded-md border px-3 py-2 text-xs', TONE_CLASSES[tone], className)}
+    >
+      {children}
+    </div>
+  )
+}

--- a/apps/desktop/src/components/note-conflict-banner.tsx
+++ b/apps/desktop/src/components/note-conflict-banner.tsx
@@ -1,0 +1,42 @@
+import type { ReactElement } from 'react'
+import { InlineAlert } from '@/components/inline-alert'
+
+interface NoteConflictBannerProps {
+  /** Resolve by keeping the editor buffer (rewrites the file). */
+  onKeepMine: () => void
+  /** Resolve by loading the external content (discards the buffer). */
+  onLoadTheirs: () => void
+}
+
+/**
+ * The non-destructive conflict prompt (Plan 05): an external change raced
+ * unsaved edits, saves are paused, and nothing is written until the user
+ * picks a side. The two actions map 1:1 onto the note session's
+ * `keepMine`/`loadTheirs`.
+ */
+export function NoteConflictBanner({
+  onKeepMine,
+  onLoadTheirs,
+}: NoteConflictBannerProps): ReactElement {
+  return (
+    <InlineAlert className="mb-4 flex flex-wrap items-center gap-3">
+      <span className="min-w-0 flex-1">
+        This note changed on disk while you had unsaved edits.
+      </span>
+      <button
+        type="button"
+        onClick={onKeepMine}
+        className="rounded border border-current/30 px-2 py-0.5 font-medium"
+      >
+        Keep mine
+      </button>
+      <button
+        type="button"
+        onClick={onLoadTheirs}
+        className="rounded border border-current/30 px-2 py-0.5 font-medium"
+      >
+        Load theirs
+      </button>
+    </InlineAlert>
+  )
+}

--- a/apps/desktop/src/components/note-link-list.tsx
+++ b/apps/desktop/src/components/note-link-list.tsx
@@ -1,0 +1,65 @@
+import type { ReactElement } from 'react'
+
+/** One row in a {@link NoteLinkList}: a note reference with optional context. */
+export interface NoteLinkItem {
+  /** Stable list identity (a path, or path:position for repeated sources). */
+  key: string
+  /** The note title shown as the row's main line. */
+  title: string
+  /** Context line under the title (the linking text, a snippet); `''` hides it. */
+  snippet: string
+  /** Graph-relative path to navigate to on click. */
+  path: string
+}
+
+interface NoteLinkListProps {
+  /** Accessible name of the section (e.g. "Backlinks", "Related notes"). */
+  ariaLabel: string
+  /** The section heading text. */
+  heading: string
+  items: NoteLinkItem[]
+  /** Open the clicked note (the host wires this to the router). */
+  onOpen: (path: string) => void
+}
+
+/**
+ * The note-context section under an open note — one presentation shared by
+ * backlinks ("Linked from") and semantic neighbors ("Related"), so the two
+ * ambient-recall surfaces stay visually identical and panels stay thin query
+ * adapters.
+ */
+export function NoteLinkList({
+  ariaLabel,
+  heading,
+  items,
+  onOpen,
+}: NoteLinkListProps): ReactElement {
+  return (
+    <section
+      aria-label={ariaLabel}
+      className="mt-6 border-t border-black/5 pt-3 dark:border-white/5"
+    >
+      <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-[color:var(--text-muted)]">
+        {heading}
+      </h3>
+      <ul className="space-y-0.5">
+        {items.map((item) => (
+          <li key={item.key}>
+            <button
+              type="button"
+              onClick={() => onOpen(item.path)}
+              className="w-full rounded px-2 py-1 text-left hover:bg-black/5 dark:hover:bg-white/5"
+            >
+              <span className="block truncate text-sm font-medium">{item.title}</span>
+              {item.snippet !== '' ? (
+                <span className="block truncate text-xs text-[color:var(--text-muted)]">
+                  {item.snippet}
+                </span>
+              ) : null}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -1,17 +1,18 @@
-import { useCallback, useEffect, useRef, type ReactElement } from 'react'
-import { isDaily, resolveWikiTarget } from '@reflect/core'
+import { useCallback, type ReactElement } from 'react'
+import { isDaily } from '@reflect/core'
 import { BacklinksPanel } from '@/components/backlinks-panel'
+import { InlineAlert } from '@/components/inline-alert'
+import { NoteConflictBanner } from '@/components/note-conflict-banner'
+import { ProtectedNoteView } from '@/components/protected-note-view'
 import { RelatedNotes } from '@/components/related-notes'
 import { NoteEditor, type NoteEditorHandle } from '@/editor/note-editor'
 import { useImagePersistence } from '@/editor/use-image-persistence'
 import { useNoteDocument } from '@/editor/use-note-document'
+import { useWikiLinkNavigation } from '@/editor/use-wiki-link-navigation'
 import { WikiAutocomplete } from '@/editor/wiki-autocomplete'
 import { createNoteWithTitle } from '@/lib/create-note'
-import { isIsoDate } from '@/lib/dates'
 import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
-import { useRouter } from '@/routing/router'
-import { routeForPath } from '@/routing/route'
 
 interface NotePaneProps {
   /** Graph-relative path of the note to edit. */
@@ -31,6 +32,10 @@ interface NotePaneProps {
  * Notes the editor can't faithfully round-trip open **protected** (read-only)
  * so a converter gap can never silently rewrite a file. Plan 06 mounts one of
  * these per day in the daily stream.
+ *
+ * The pane is composition only: document semantics live in
+ * `useNoteDocument`/`note-session.ts`, link-click behavior in
+ * `useWikiLinkNavigation`, and the banners are shared components.
  */
 export function NotePane({
   path,
@@ -39,7 +44,6 @@ export function NotePane({
   onAutoFocused,
 }: NotePaneProps): ReactElement {
   const { graph } = useGraph()
-  const { navigate } = useRouter()
   const { settings } = useSettings()
   const graphRoot = graph?.root ?? null
   const generation = graph?.generation ?? null
@@ -53,47 +57,7 @@ export function NotePane({
     graphRoot,
     generation,
   )
-
-  const unmountedRef = useRef(false)
-  useEffect(() => {
-    unmountedRef.current = false
-    return () => {
-      unmountedRef.current = true
-    }
-  }, [])
-
-  // Mod+click on a [[wiki link]]: resolve via the index; an unresolved ISO date
-  // is still a valid daily target (created lazily on first write). An
-  // unresolved non-date target is created and opened on the spot (Plan 07's
-  // create-from-unresolved — frictionless, consistent with lazy dailies).
-  const onWikiLinkClick = useCallback(
-    (target: string) => {
-      void (async () => {
-        try {
-          const resolution = await resolveWikiTarget(target)
-          // The pane can unmount while resolution is in flight (route change,
-          // graph switch) — a late navigate would yank the user somewhere
-          // they've already left.
-          if (unmountedRef.current) {
-            return
-          }
-          if (resolution.kind === 'resolved') {
-            navigate(routeForPath(resolution.ref))
-          } else if (isIsoDate(resolution.text)) {
-            navigate({ kind: 'daily', date: resolution.text })
-          } else if (generation !== null && resolution.text.trim() !== '') {
-            const created = await createNoteWithTitle(resolution.text, generation)
-            if (!unmountedRef.current) {
-              navigate({ kind: 'note', path: created })
-            }
-          }
-        } catch (err) {
-          console.error('wiki-link resolution failed:', err)
-        }
-      })()
-    },
-    [navigate, generation],
-  )
+  const onWikiLinkClick = useWikiLinkNavigation(generation)
 
   // The `[[` autocomplete's create row: make the file; the popover inserts the
   // link text either way (a failed create just leaves an unresolved link).
@@ -135,17 +99,7 @@ export function NotePane({
   if (document.protected) {
     return (
       <div>
-        <div
-          role="alert"
-          className="mb-4 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300"
-        >
-          This note contains markdown the editor can’t yet reproduce faithfully (for
-          example task lists), so it’s open read-only to protect your file. Edit it in
-          another tool for now.
-        </div>
-        <pre className="reflect-protected-note whitespace-pre-wrap text-sm leading-relaxed">
-          {document.initialContent}
-        </pre>
+        <ProtectedNoteView content={document.initialContent} />
         <BacklinksPanel path={path} />
       </div>
     )
@@ -154,47 +108,23 @@ export function NotePane({
   return (
     <div className="relative" aria-label={`Editing ${path}`}>
       {document.error !== null ? (
-        <div
-          role="alert"
-          className="mb-4 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-700 dark:text-red-300"
-        >
+        <InlineAlert tone="error" className="mb-4">
           Saving failed: {document.error}. Your edits are kept in the editor and the next
           successful save will persist them.
-        </div>
+        </InlineAlert>
       ) : null}
 
       {imageSaveError !== null ? (
-        <div
-          role="alert"
-          className="mb-4 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-700 dark:text-red-300"
-        >
+        <InlineAlert tone="error" className="mb-4">
           Couldn’t save the pasted image: {imageSaveError}. It was not added to the note.
-        </div>
+        </InlineAlert>
       ) : null}
 
       {document.conflict !== null ? (
-        <div
-          role="alert"
-          className="mb-4 flex flex-wrap items-center gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300"
-        >
-          <span className="min-w-0 flex-1">
-            This note changed on disk while you had unsaved edits.
-          </span>
-          <button
-            type="button"
-            onClick={document.keepMine}
-            className="rounded border border-current/30 px-2 py-0.5 font-medium"
-          >
-            Keep mine
-          </button>
-          <button
-            type="button"
-            onClick={document.loadTheirs}
-            className="rounded border border-current/30 px-2 py-0.5 font-medium"
-          >
-            Load theirs
-          </button>
-        </div>
+        <NoteConflictBanner
+          onKeepMine={document.keepMine}
+          onLoadTheirs={document.loadTheirs}
+        />
       ) : null}
 
       {document.dirty ? (

--- a/apps/desktop/src/components/protected-note-view.tsx
+++ b/apps/desktop/src/components/protected-note-view.tsx
@@ -1,0 +1,28 @@
+import type { ReactElement } from 'react'
+import { InlineAlert } from '@/components/inline-alert'
+
+interface ProtectedNoteViewProps {
+  /** The full file content (frontmatter included — honest display). */
+  content: string
+}
+
+/**
+ * The read-only fallback for a note the editor can't faithfully round-trip
+ * (a converter gap, e.g. task lists): the file is shown verbatim and never
+ * auto-rewritten, so no content can be silently lost (Plan 05's data-loss
+ * gate).
+ */
+export function ProtectedNoteView({ content }: ProtectedNoteViewProps): ReactElement {
+  return (
+    <div>
+      <InlineAlert className="mb-4">
+        This note contains markdown the editor can’t yet reproduce faithfully (for
+        example task lists), so it’s open read-only to protect your file. Edit it in
+        another tool for now.
+      </InlineAlert>
+      <pre className="reflect-protected-note whitespace-pre-wrap text-sm leading-relaxed">
+        {content}
+      </pre>
+    </div>
+  )
+}

--- a/apps/desktop/src/components/related-notes.tsx
+++ b/apps/desktop/src/components/related-notes.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { hasBridge, relatedNotes } from '@reflect/core'
+import { NoteLinkList } from '@/components/note-link-list'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
 import { routeForPath } from '@/routing/route'
@@ -35,31 +36,16 @@ export function RelatedNotes({ path }: RelatedNotesProps): ReactElement | null {
   }
 
   return (
-    <section
-      aria-label="Related notes"
-      className="mt-6 border-t border-black/5 pt-3 dark:border-white/5"
-    >
-      <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-[color:var(--text-muted)]">
-        Related
-      </h3>
-      <ul className="space-y-0.5">
-        {related.map((hit) => (
-          <li key={hit.path}>
-            <button
-              type="button"
-              onClick={() => navigate(routeForPath(hit.path))}
-              className="w-full rounded px-2 py-1 text-left hover:bg-black/5 dark:hover:bg-white/5"
-            >
-              <span className="block truncate text-sm font-medium">{hit.title}</span>
-              {hit.snippet !== '' ? (
-                <span className="block truncate text-xs text-[color:var(--text-muted)]">
-                  {hit.snippet}
-                </span>
-              ) : null}
-            </button>
-          </li>
-        ))}
-      </ul>
-    </section>
+    <NoteLinkList
+      ariaLabel="Related notes"
+      heading="Related"
+      items={related.map((hit) => ({
+        key: hit.path,
+        title: hit.title,
+        snippet: hit.snippet,
+        path: hit.path,
+      }))}
+      onOpen={(target) => navigate(routeForPath(target))}
+    />
   )
 }

--- a/apps/desktop/src/components/route-content.tsx
+++ b/apps/desktop/src/components/route-content.tsx
@@ -1,0 +1,45 @@
+import type { ReactElement } from 'react'
+import { DailyStream } from '@/components/daily-stream'
+import { NotePane } from '@/components/note-pane'
+import { SearchRoute } from '@/components/search-route'
+import { SettingsScreen } from '@/components/settings-screen'
+import { isIsoDate } from '@/lib/dates'
+import { useToday } from '@/lib/use-today'
+import { useRouter } from '@/routing/router'
+import { ScrollRestored } from '@/routing/scroll-restore'
+
+/**
+ * The route → view mapping (Plan 06): the single place a {@link Route} kind
+ * becomes a workspace surface. `today` tracks the live clock — midnight
+ * re-renders it.
+ */
+export function RouteContent(): ReactElement {
+  const { route } = useRouter()
+  const today = useToday()
+  switch (route.kind) {
+    case 'today':
+      return <DailyStream targetDate={today} />
+    case 'daily':
+      // A malformed date (impossible calendar day) anchors to today instead of
+      // letting dailyPath throw mid-render.
+      return <DailyStream targetDate={isIsoDate(route.date) ? route.date : today} />
+    case 'note':
+      return (
+        <ScrollRestored className="h-full overflow-auto px-6 py-8">
+          <div className="mx-auto w-full max-w-2xl">
+            <NotePane path={route.path} lazy autoFocus />
+          </div>
+        </ScrollRestored>
+      )
+    case 'search':
+      return <SearchRoute query={route.query} today={today} />
+    case 'settings':
+      return (
+        <ScrollRestored className="h-full overflow-auto px-6 py-8">
+          <div className="mx-auto w-full max-w-2xl">
+            <SettingsScreen />
+          </div>
+        </ScrollRestored>
+      )
+  }
+}

--- a/apps/desktop/src/components/search-route.tsx
+++ b/apps/desktop/src/components/search-route.tsx
@@ -1,0 +1,28 @@
+import { useEffect, type ReactElement } from 'react'
+import { usePalette } from '@/components/command-palette/palette-provider'
+import { DailyStream } from '@/components/daily-stream'
+import { useRouter } from '@/routing/router'
+
+interface SearchRouteProps {
+  /** The query carried by the `search/:query` route. */
+  query: string
+  /** The current day, anchoring the stream rendered behind the palette. */
+  today: string
+}
+
+/**
+ * `search/:query` is a deep-link target, not a second search surface (decided
+ * 2026-06-09): arriving opens the ⌘K palette pre-filled over the stream.
+ */
+export function SearchRoute({ query, today }: SearchRouteProps): ReactElement {
+  const { openPalette } = usePalette()
+  const { arrivalSeq, entryId } = useRouter()
+  // Keyed on the *arrival*, not just the value (the daily stream's lesson):
+  // re-navigating to the same search route bumps arrivalSeq without a remount,
+  // and back/forward changes entryId without bumping arrivalSeq — both are
+  // arrivals, and arriving on search opens the palette (decided).
+  useEffect(() => {
+    openPalette(query)
+  }, [query, arrivalSeq, entryId, openPalette])
+  return <DailyStream targetDate={today} />
+}

--- a/apps/desktop/src/components/workspace-content.tsx
+++ b/apps/desktop/src/components/workspace-content.tsx
@@ -1,0 +1,73 @@
+import { useCallback, type ReactElement } from 'react'
+import type { GraphInfo } from '@reflect/core'
+import { AppShell } from '@/components/app-shell'
+import { CloudSyncBanner } from '@/components/cloud-sync-banner'
+import { CommandPalette } from '@/components/command-palette/command-palette'
+import { EmbeddingsSync } from '@/components/embeddings-sync'
+import { OperationsStatus } from '@/components/operations-status'
+import { RouteContent } from '@/components/route-content'
+import { WorkspaceHeader } from '@/components/workspace-header'
+import { useAppVersion } from '@/hooks/use-app-version'
+import { useGraph } from '@/providers/graph-provider'
+import { useTheme } from '@/providers/theme-provider'
+import { useAppShortcuts } from '@/routing/app-shortcuts'
+import { useRouter } from '@/routing/router'
+
+interface WorkspaceContentProps {
+  graph: GraphInfo
+}
+
+/**
+ * Everything inside the workspace's router/palette providers: the shell and
+ * header around the route-driven content, plus the always-mounted global
+ * surfaces (operations status, ⌘K palette, embeddings sync). Split from
+ * {@link GraphWorkspace} because these hooks need the providers it mounts.
+ */
+export function WorkspaceContent({ graph }: WorkspaceContentProps): ReactElement {
+  const { resolvedTheme, setTheme } = useTheme()
+  const { indexing } = useGraph()
+  const { navigate } = useRouter()
+  const version = useAppVersion()
+  const commandContext = useAppShortcuts()
+
+  const toggleTheme = useCallback((): void => {
+    setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')
+  }, [resolvedTheme, setTheme])
+
+  const openSettings = useCallback((): void => {
+    navigate({ kind: 'settings' })
+  }, [navigate])
+
+  return (
+    <AppShell
+      rail={
+        <span className="text-xs font-semibold text-[color:var(--text-secondary)]">R</span>
+      }
+      sidebar={
+        <div className="p-4 text-sm text-[color:var(--text-secondary)]">Context</div>
+      }
+    >
+      <div className="flex h-full flex-col">
+        <WorkspaceHeader
+          graphName={graph.name}
+          graphRoot={graph.root}
+          indexing={indexing}
+          version={version}
+          resolvedTheme={resolvedTheme}
+          onToggleTheme={toggleTheme}
+          onOpenSettings={openSettings}
+        />
+
+        {graph.cloudSync ? <CloudSyncBanner provider={graph.cloudSync} /> : null}
+
+        <div className="min-h-0 flex-1">
+          <RouteContent />
+        </div>
+
+        <OperationsStatus />
+        <CommandPalette context={commandContext} />
+        <EmbeddingsSync />
+      </div>
+    </AppShell>
+  )
+}

--- a/apps/desktop/src/components/workspace-header.test.tsx
+++ b/apps/desktop/src/components/workspace-header.test.tsx
@@ -1,0 +1,52 @@
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { WorkspaceHeader } from './workspace-header'
+
+function renderHeader(overrides: Partial<Parameters<typeof WorkspaceHeader>[0]> = {}) {
+  const onToggleTheme = vi.fn()
+  const onOpenSettings = vi.fn()
+  const view = render(
+    <WorkspaceHeader
+      graphName="My Graph"
+      graphRoot="/graphs/mine"
+      indexing={false}
+      version="1.2.3"
+      resolvedTheme="light"
+      onToggleTheme={onToggleTheme}
+      onOpenSettings={onOpenSettings}
+      {...overrides}
+    />,
+  )
+  return { view, onToggleTheme, onOpenSettings }
+}
+
+describe('WorkspaceHeader', () => {
+  it('shows the graph name (root as tooltip) and version', () => {
+    const { view } = renderHeader()
+    expect(view.getByTitle('/graphs/mine').textContent).toBe('My Graph')
+    expect(view.getByText('v1.2.3')).toBeTruthy()
+    expect(view.queryByRole('status')).toBeNull()
+    view.unmount()
+  })
+
+  it('shows the indexing indicator while the reconcile runs', () => {
+    const { view } = renderHeader({ indexing: true })
+    expect(view.getByRole('status').textContent).toBe('Indexing…')
+    view.unmount()
+  })
+
+  it('offers the opposite theme and toggles on click', async () => {
+    const { view, onToggleTheme } = renderHeader({ resolvedTheme: 'dark' })
+    await userEvent.click(view.getByText('Light mode'))
+    expect(onToggleTheme).toHaveBeenCalledOnce()
+    view.unmount()
+  })
+
+  it('opens settings', async () => {
+    const { view, onOpenSettings } = renderHeader()
+    await userEvent.click(view.getByLabelText('Open settings'))
+    expect(onOpenSettings).toHaveBeenCalledOnce()
+    view.unmount()
+  })
+})

--- a/apps/desktop/src/components/workspace-header.tsx
+++ b/apps/desktop/src/components/workspace-header.tsx
@@ -1,0 +1,67 @@
+import type { ReactElement } from 'react'
+import { Settings } from 'lucide-react'
+import type { ResolvedTheme } from '@/providers/theme-provider'
+
+interface WorkspaceHeaderProps {
+  /** Display name of the open graph. */
+  graphName: string
+  /** Absolute root path (shown as the title tooltip). */
+  graphRoot: string
+  /** True while the background index reconcile is running. */
+  indexing: boolean
+  /** App version, or `null` while it loads. */
+  version: string | null
+  resolvedTheme: ResolvedTheme
+  onToggleTheme: () => void
+  onOpenSettings: () => void
+}
+
+/**
+ * The workspace title bar: graph name, indexing status, version, and the
+ * theme/settings controls. Purely presentational — the workspace passes state
+ * down so this renders (and tests) without any provider.
+ */
+export function WorkspaceHeader({
+  graphName,
+  graphRoot,
+  indexing,
+  version,
+  resolvedTheme,
+  onToggleTheme,
+  onOpenSettings,
+}: WorkspaceHeaderProps): ReactElement {
+  return (
+    <header className="flex items-center justify-between gap-4 border-b border-black/10 px-6 py-3 dark:border-white/10">
+      <h1 className="truncate text-sm font-semibold" title={graphRoot}>
+        {graphName}
+      </h1>
+      <div className="flex items-center gap-3">
+        {indexing ? (
+          <span
+            role="status"
+            className="text-xs text-[color:var(--text-muted)] motion-safe:animate-pulse"
+          >
+            Indexing…
+          </span>
+        ) : null}
+        <span className="text-xs text-[color:var(--text-muted)]">v{version ?? '—'}</span>
+        <button
+          type="button"
+          onClick={onToggleTheme}
+          className="rounded-md border border-black/10 px-2.5 py-1 text-xs font-medium dark:border-white/10"
+        >
+          {resolvedTheme === 'dark' ? 'Light' : 'Dark'} mode
+        </button>
+        <button
+          type="button"
+          aria-label="Open settings"
+          title="Settings (⌘,)"
+          onClick={onOpenSettings}
+          className="rounded-md border border-black/10 p-1.5 text-[color:var(--text-secondary)] dark:border-white/10"
+        >
+          <Settings aria-hidden className="size-3.5" />
+        </button>
+      </div>
+    </header>
+  )
+}

--- a/apps/desktop/src/editor/note-session.ts
+++ b/apps/desktop/src/editor/note-session.ts
@@ -1,4 +1,4 @@
-import { isAppError, splitFrontmatter, upsertFrontmatter } from '@reflect/core'
+import { errorMessage, isAppError, splitFrontmatter, upsertFrontmatter } from '@reflect/core'
 import type { RoundTripFidelity } from './roundtrip'
 
 /**
@@ -251,7 +251,7 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
       })
       .catch((cause) => {
         console.error('failed to save note:', cause)
-        error = messageOf(cause)
+        error = errorMessage(cause)
         emit()
       })
   }
@@ -399,7 +399,7 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
         onContent?.(content, 'load')
       } catch (cause) {
         if (!disposed) {
-          error = messageOf(cause)
+          error = errorMessage(cause)
           status = 'error'
           emit()
         }
@@ -479,11 +479,4 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
     updateFrontmatter,
     dispose,
   }
-}
-
-function messageOf(error: unknown): string {
-  if (isAppError(error)) {
-    return error.message
-  }
-  return error instanceof Error ? error.message : String(error)
 }

--- a/apps/desktop/src/editor/rename-coordinator.ts
+++ b/apps/desktop/src/editor/rename-coordinator.ts
@@ -1,6 +1,6 @@
 import {
+  errorMessage,
   getLinkSources,
-  isAppError,
   nextAliases,
   parseNote,
   readNote,
@@ -48,13 +48,6 @@ export interface RenameCoordinator {
   dispose(): void
 }
 
-function messageOf(error: unknown): string {
-  if (isAppError(error)) {
-    return error.message
-  }
-  return error instanceof Error ? error.message : String(error)
-}
-
 export function createRenameCoordinator(options: RenameCoordinatorOptions): RenameCoordinator {
   const { path, generation, canFire } = options
   /** Serializes rewrites — a second settle waits for the first. */
@@ -100,7 +93,7 @@ export function createRenameCoordinator(options: RenameCoordinatorOptions): Rena
           // baseline has already advanced (re-arming would re-fire with a
           // stale `from` after further edits), so the alias is the safety
           // net that keeps every un-rewritten link resolving to this note.
-          failure = messageOf(cause)
+          failure = errorMessage(cause)
           console.error('rename link rewrite failed:', cause)
         }
         if (collision) {
@@ -150,7 +143,7 @@ export function createRenameCoordinator(options: RenameCoordinatorOptions): Rena
           }
         }
       } catch (cause) {
-        failure = messageOf(cause)
+        failure = errorMessage(cause)
         console.error('rename alias placement failed:', cause)
       } finally {
         if (failure !== null) {

--- a/apps/desktop/src/editor/use-image-persistence.ts
+++ b/apps/desktop/src/editor/use-image-persistence.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react'
 import { convertFileSrc } from '@tauri-apps/api/core'
-import { assetPath, toAppError, writeAsset } from '@reflect/core'
+import { assetPath, errorMessage, writeAsset } from '@reflect/core'
 import type { ImageOptions } from './images'
 
 /** Asset file extension for each image MIME type the editor accepts on paste/drop. */
@@ -96,7 +96,7 @@ export function useImagePersistence(
   )
 
   const onSaveError = useCallback((error: unknown) => {
-    setSaveError(toAppError(error).message)
+    setSaveError(errorMessage(error))
   }, [])
 
   const options = useMemo<ImageOptions>(

--- a/apps/desktop/src/editor/use-note-document.ts
+++ b/apps/desktop/src/editor/use-note-document.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { hasBridge, readNote, subscribeFileChanges, writeNote } from '@reflect/core'
+import { readNote, writeNote, type FileChange } from '@reflect/core'
+import { useFileChanges } from '@/lib/use-file-changes'
 import type { NoteEditorHandle } from './note-editor'
 import { registerOpenDocument } from './open-documents'
 import { createRenameCoordinator, type RenameCoordinator } from './rename-coordinator'
@@ -152,29 +153,15 @@ export function useNoteDocument(
   }, [path, canWrite, createIfMissing, trackRenames])
 
   // External-change reconciliation via the watcher (Plan 04b events).
-  useEffect(() => {
-    if (!path || !hasBridge()) {
-      return
-    }
-    let active = true
-    let unlisten: (() => void) | null = null
-    void subscribeFileChanges((changes) => {
-      if (!active || !changes.some((change) => change.path === path && change.kind === 'upsert')) {
-        return
+  const onFileChanges = useCallback(
+    (changes: FileChange[]) => {
+      if (changes.some((change) => change.path === path && change.kind === 'upsert')) {
+        sessionRef.current?.externalChanged()
       }
-      sessionRef.current?.externalChanged()
-    }).then((fn) => {
-      if (active) {
-        unlisten = fn
-      } else {
-        fn()
-      }
-    })
-    return () => {
-      active = false
-      unlisten?.()
-    }
-  }, [path])
+    },
+    [path],
+  )
+  useFileChanges(path ? onFileChanges : null)
 
   // Flush pending edits when the window loses focus, and register with the
   // app-global registry so quit-time teardown (window close, ⌘Q — paths where

--- a/apps/desktop/src/editor/use-wiki-link-navigation.test.tsx
+++ b/apps/desktop/src/editor/use-wiki-link-navigation.test.tsx
@@ -1,0 +1,123 @@
+import { render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import { RouterProvider, useRouter } from '@/routing/router'
+import { useWikiLinkNavigation } from './use-wiki-link-navigation'
+
+const resolveWikiTarget = vi.hoisted(() => vi.fn())
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  resolveWikiTarget,
+}))
+
+const createNoteWithTitle = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/create-note', () => ({ createNoteWithTitle }))
+
+let lastHandler: ((target: string) => void) | null = null
+
+function Host({ generation }: { generation: number | null }): ReactNode {
+  lastHandler = useWikiLinkNavigation(generation)
+  return null
+}
+
+function RouteProbe(): ReactNode {
+  const { route } = useRouter()
+  return <output data-testid="route">{JSON.stringify(route)}</output>
+}
+
+function renderHost(generation: number | null = 1) {
+  return render(
+    <RouterProvider>
+      <Host generation={generation} />
+      <RouteProbe />
+    </RouterProvider>,
+  )
+}
+
+function currentRoute(view: ReturnType<typeof renderHost>): string {
+  return view.getByTestId('route').textContent ?? ''
+}
+
+beforeEach(() => {
+  resolveWikiTarget.mockReset()
+  createNoteWithTitle.mockReset()
+  lastHandler = null
+})
+
+describe('useWikiLinkNavigation', () => {
+  it('navigates to the resolved note', async () => {
+    resolveWikiTarget.mockResolvedValue({ kind: 'resolved', ref: 'notes/target.md' })
+    const view = renderHost()
+    lastHandler?.('Target')
+    await waitFor(() => expect(currentRoute(view)).toContain('notes/target.md'))
+    expect(createNoteWithTitle).not.toHaveBeenCalled()
+    view.unmount()
+  })
+
+  it('treats an unresolved ISO date as a daily target', async () => {
+    resolveWikiTarget.mockResolvedValue({ kind: 'unresolved', text: '2026-06-09' })
+    const view = renderHost()
+    lastHandler?.('2026-06-09')
+    await waitFor(() => expect(currentRoute(view)).toContain('"daily"'))
+    expect(currentRoute(view)).toContain('2026-06-09')
+    expect(createNoteWithTitle).not.toHaveBeenCalled()
+    view.unmount()
+  })
+
+  it('creates and opens an unresolved title', async () => {
+    resolveWikiTarget.mockResolvedValue({ kind: 'unresolved', text: 'Brand New' })
+    createNoteWithTitle.mockResolvedValue('notes/created.md')
+    const view = renderHost(7)
+    lastHandler?.('Brand New')
+    await waitFor(() => expect(currentRoute(view)).toContain('notes/created.md'))
+    expect(createNoteWithTitle).toHaveBeenCalledWith('Brand New', 7)
+    view.unmount()
+  })
+
+  it('does not create when no generation is available', async () => {
+    resolveWikiTarget.mockResolvedValue({ kind: 'unresolved', text: 'Brand New' })
+    const view = renderHost(null)
+    lastHandler?.('Brand New')
+    await waitFor(() => expect(resolveWikiTarget).toHaveBeenCalled())
+    expect(createNoteWithTitle).not.toHaveBeenCalled()
+    expect(currentRoute(view)).toContain('"today"')
+    view.unmount()
+  })
+
+  it('ignores an unresolved empty target', async () => {
+    resolveWikiTarget.mockResolvedValue({ kind: 'unresolved', text: '   ' })
+    const view = renderHost()
+    lastHandler?.('   ')
+    await waitFor(() => expect(resolveWikiTarget).toHaveBeenCalled())
+    expect(createNoteWithTitle).not.toHaveBeenCalled()
+    expect(currentRoute(view)).toContain('"today"')
+    view.unmount()
+  })
+
+  it('drops a resolution that lands after the host unmounts', async () => {
+    let resolve: (value: { kind: 'resolved'; ref: string }) => void = () => {}
+    resolveWikiTarget.mockReturnValue(
+      new Promise((promiseResolve) => {
+        resolve = promiseResolve
+      }),
+    )
+    const view = render(
+      <RouterProvider>
+        <Host key="host" generation={1} />
+        <RouteProbe key="probe" />
+      </RouterProvider>,
+    )
+    lastHandler?.('Target')
+    // Unmount only the host; the router (and probe) live on, so a navigate
+    // slipping through the guard would be visible as a route change.
+    view.rerender(
+      <RouterProvider>
+        <RouteProbe key="probe" />
+      </RouterProvider>,
+    )
+    resolve({ kind: 'resolved', ref: 'notes/target.md' })
+    await new Promise((tick) => setTimeout(tick, 0))
+    expect(view.getByTestId('route').textContent).toContain('"today"')
+    view.unmount()
+  })
+})

--- a/apps/desktop/src/editor/use-wiki-link-navigation.ts
+++ b/apps/desktop/src/editor/use-wiki-link-navigation.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { resolveWikiTarget } from '@reflect/core'
+import { createNoteWithTitle } from '@/lib/create-note'
+import { isIsoDate } from '@/lib/dates'
+import { routeForPath } from '@/routing/route'
+import { useRouter } from '@/routing/router'
+
+/**
+ * Navigation for a clicked `[[wiki link]]`: resolve via the index, then open
+ * the target. An unresolved ISO date is still a valid daily target (created
+ * lazily on first write), and an unresolved non-empty title is created and
+ * opened on the spot — Plan 07's create-from-unresolved, consistent with lazy
+ * dailies. With no graph generation available, unresolved titles are a no-op
+ * (nothing can be written).
+ *
+ * Resolution is async, and the host pane can unmount while it's in flight
+ * (route change, graph switch) — a late navigate would yank the user somewhere
+ * they've already left, so the hook guards every navigation on its own
+ * lifetime.
+ *
+ * @param generation the open graph's write generation (`GraphInfo.generation`),
+ *   or `null` when no graph is writable.
+ * @returns a stable-per-`generation` click handler for the editor's wiki-link
+ *   extension.
+ */
+export function useWikiLinkNavigation(generation: number | null): (target: string) => void {
+  const { navigate } = useRouter()
+
+  const unmountedRef = useRef(false)
+  useEffect(() => {
+    unmountedRef.current = false
+    return () => {
+      unmountedRef.current = true
+    }
+  }, [])
+
+  return useCallback(
+    (target: string) => {
+      void (async () => {
+        try {
+          const resolution = await resolveWikiTarget(target)
+          if (unmountedRef.current) {
+            return
+          }
+          if (resolution.kind === 'resolved') {
+            navigate(routeForPath(resolution.ref))
+          } else if (isIsoDate(resolution.text)) {
+            navigate({ kind: 'daily', date: resolution.text })
+          } else if (generation !== null && resolution.text.trim() !== '') {
+            const created = await createNoteWithTitle(resolution.text, generation)
+            if (!unmountedRef.current) {
+              navigate({ kind: 'note', path: created })
+            }
+          }
+        } catch (err) {
+          console.error('wiki-link resolution failed:', err)
+        }
+      })()
+    },
+    [navigate, generation],
+  )
+}

--- a/apps/desktop/src/lib/use-file-changes.test.tsx
+++ b/apps/desktop/src/lib/use-file-changes.test.tsx
@@ -1,0 +1,111 @@
+import { act, render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FileChange } from '@reflect/core'
+import { useFileChanges } from './use-file-changes'
+
+const subscribeFileChanges = vi.hoisted(() => vi.fn())
+const hasBridge = vi.hoisted(() => vi.fn(() => true))
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  hasBridge,
+  subscribeFileChanges,
+}))
+
+interface Subscription {
+  emit: (changes: FileChange[]) => void
+  unlisten: ReturnType<typeof vi.fn>
+  resolve: () => Promise<void>
+}
+
+/** Capture the watcher callback and hand back a controllable unlisten. */
+function stubSubscription(): Subscription {
+  let listener: ((changes: FileChange[]) => void) | null = null
+  const unlisten = vi.fn()
+  let resolveSubscribe: (stop: () => void) => void = () => {}
+  subscribeFileChanges.mockImplementation((callback: (changes: FileChange[]) => void) => {
+    listener = callback
+    return new Promise<() => void>((promiseResolve) => {
+      resolveSubscribe = promiseResolve
+    })
+  })
+  return {
+    emit: (changes) => listener?.(changes),
+    unlisten,
+    resolve: async () => {
+      resolveSubscribe(unlisten)
+      await act(async () => {})
+    },
+  }
+}
+
+function Host({ handler }: { handler: ((changes: FileChange[]) => void) | null }): null {
+  useFileChanges(handler)
+  return null
+}
+
+const UPSERT: FileChange[] = [{ path: 'notes/a.md', kind: 'upsert' }]
+
+beforeEach(() => {
+  subscribeFileChanges.mockReset()
+  hasBridge.mockReturnValue(true)
+})
+
+describe('useFileChanges', () => {
+  it('delivers watcher events to the handler', async () => {
+    const subscription = stubSubscription()
+    const handler = vi.fn()
+    const view = render(<Host handler={handler} />)
+    await subscription.resolve()
+    subscription.emit(UPSERT)
+    expect(handler).toHaveBeenCalledWith(UPSERT)
+    view.unmount()
+  })
+
+  it('drops events that race the teardown', async () => {
+    const subscription = stubSubscription()
+    const handler = vi.fn()
+    const view = render(<Host handler={handler} />)
+    await subscription.resolve()
+    view.unmount()
+    subscription.emit(UPSERT)
+    expect(handler).not.toHaveBeenCalled()
+    expect(subscription.unlisten).toHaveBeenCalledOnce()
+  })
+
+  it('closes an unlisten that resolves after teardown', async () => {
+    const subscription = stubSubscription()
+    const view = render(<Host handler={vi.fn()} />)
+    view.unmount()
+    await subscription.resolve()
+    expect(subscription.unlisten).toHaveBeenCalledOnce()
+  })
+
+  it('resubscribes when the handler identity changes', async () => {
+    const first = stubSubscription()
+    const view = render(<Host handler={vi.fn()} />)
+    await first.resolve()
+    expect(subscribeFileChanges).toHaveBeenCalledTimes(1)
+
+    const second = stubSubscription()
+    const nextHandler = vi.fn()
+    view.rerender(<Host handler={nextHandler} />)
+    await second.resolve()
+    expect(subscribeFileChanges).toHaveBeenCalledTimes(2)
+    expect(first.unlisten).toHaveBeenCalledOnce()
+
+    second.emit(UPSERT)
+    expect(nextHandler).toHaveBeenCalledWith(UPSERT)
+    view.unmount()
+  })
+
+  it('does nothing when disabled or without a bridge', () => {
+    const view = render(<Host handler={null} />)
+    expect(subscribeFileChanges).not.toHaveBeenCalled()
+    view.unmount()
+
+    hasBridge.mockReturnValue(false)
+    const bridgeless = render(<Host handler={vi.fn()} />)
+    expect(subscribeFileChanges).not.toHaveBeenCalled()
+    bridgeless.unmount()
+  })
+})

--- a/apps/desktop/src/lib/use-file-changes.ts
+++ b/apps/desktop/src/lib/use-file-changes.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react'
+import { hasBridge, subscribeFileChanges, type FileChange } from '@reflect/core'
+
+/**
+ * Subscribe to the watcher's file-change events (Plan 04b) for the lifetime of
+ * the component. Owns the fiddly parts of the subscription lifecycle so call
+ * sites don't re-implement them:
+ *
+ * - events delivered after teardown are dropped (the unsubscribe is async, so
+ *   a change can race the cleanup);
+ * - an unlisten that resolves *after* teardown is closed immediately instead
+ *   of leaking;
+ * - without a bridge (browser dev) the hook is a no-op.
+ *
+ * The subscription follows the handler's identity: memoize the handler over
+ * its real dependencies and the hook resubscribes exactly when they change.
+ * Pass `null` to disable.
+ */
+export function useFileChanges(handler: ((changes: FileChange[]) => void) | null): void {
+  useEffect(() => {
+    if (handler === null || !hasBridge()) {
+      return
+    }
+    let active = true
+    let unlisten: (() => void) | null = null
+    void subscribeFileChanges((changes) => {
+      if (active) {
+        handler(changes)
+      }
+    }).then((stop) => {
+      if (active) {
+        unlisten = stop
+      } else {
+        stop()
+      }
+    })
+    return () => {
+      active = false
+      unlisten?.()
+    }
+  }, [handler])
+}

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -10,11 +10,11 @@ import {
 } from 'react'
 import { open } from '@tauri-apps/plugin-dialog'
 import {
+  errorMessage,
   forgetRecent,
   hasBridge,
   openGraph,
   recentGraphs,
-  toAppError,
   type GraphInfo,
   type RecentGraph,
 } from '@reflect/core'
@@ -49,12 +49,6 @@ interface GraphContextValue {
 
 const GraphContext = createContext<GraphContextValue | null>(null)
 
-function messageOf(error: unknown): string {
-  // `toAppError` already normalizes Errors/strings/objects safely, so unknown
-  // throws never render as `[object Object]`.
-  return toAppError(error).message
-}
-
 /**
  * Owns the active graph and the open/choose flow. On mount it auto-opens the
  * most-recent graph (so the app reopens where you left off) and otherwise shows
@@ -77,7 +71,7 @@ export function GraphProvider({ children }: { children: ReactNode }) {
   // a graph switch can stop the prior pass before the Rust connection is swapped.
   const indexRef = useRef(
     createGraphIndex({
-      onError: (stage, err) => console.error(`index ${stage} failed:`, messageOf(err)),
+      onError: (stage, err) => console.error(`index ${stage} failed:`, errorMessage(err)),
       onProgress: (progress) => setIndexing(progress === 'reconciling'),
       onApplied: invalidateIndexQueries,
     }),
@@ -98,7 +92,7 @@ export function GraphProvider({ children }: { children: ReactNode }) {
         // primary load. As a post-open refresh it must not clobber an open error
         // or set one on a screen (the workspace) that never shows it.
         if (options?.surfaceErrors) {
-          setError(messageOf(err))
+          setError(errorMessage(err))
         }
         return []
       }
@@ -138,7 +132,7 @@ export function GraphProvider({ children }: { children: ReactNode }) {
           if (seq !== openSeq.current) {
             return
           }
-          setError(messageOf(err))
+          setError(errorMessage(err))
           setStatus('choosing')
         }
         if (seq === openSeq.current) {
@@ -185,7 +179,7 @@ export function GraphProvider({ children }: { children: ReactNode }) {
       })
       selected = typeof result === 'string' ? result : null
     } catch (err) {
-      setError(messageOf(err))
+      setError(errorMessage(err))
       return
     }
     if (selected) {

--- a/apps/desktop/src/providers/settings-provider.tsx
+++ b/apps/desktop/src/providers/settings-provider.tsx
@@ -15,7 +15,7 @@ import {
   hasBridge,
   loadSettings,
   saveSettings,
-  toAppError,
+  errorMessage,
   type Settings,
 } from '@reflect/core'
 import { startOperation } from '@/lib/operations'
@@ -78,7 +78,7 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
   useEffect(() => {
     if (loadError && !loadErrorSurfaced.current) {
       loadErrorSurfaced.current = true
-      startOperation('Loading settings').fail(toAppError(loadError).message)
+      startOperation('Loading settings').fail(errorMessage(loadError))
     }
   }, [loadError])
 
@@ -116,7 +116,7 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
         // The in-memory value stays applied and `lastPersisted` still points
         // at the confirmed disk document, so the difference is retried later.
         // The failure is product status, not console noise.
-        startOperation('Saving settings').fail(toAppError(error).message)
+        startOperation('Saving settings').fail(errorMessage(error))
       })
     return persistQueue.current
   }, [])

--- a/docs/contributing/adding-a-command.md
+++ b/docs/contributing/adding-a-command.md
@@ -1,0 +1,141 @@
+# Adding a native command
+
+How a value travels from Rust to a React component, and every file you touch
+to add a new command. The canonical in-tree example is `app_version` — a real
+`#[tauri::command]`, a zod-validated response, no direct `invoke` in the UI —
+and this guide walks the same path with a hypothetical `note_stat` command.
+
+```
+React component / hook
+  └─ typed binding            packages/core/src/<domain>/commands.ts
+       └─ call()              packages/core/src/ipc/invoke.ts   (zod validation)
+            └─ bridge.invoke  packages/core/src/ipc/bridge.ts   (injected transport)
+                 └─ Tauri IPC apps/desktop/src/lib/tauri-bridge.ts
+                      └─ #[tauri::command]  apps/desktop/src-tauri/src/<module>.rs
+```
+
+Before writing any Rust, check whether you actually need a new command. Per
+[architecture-conventions](../plans/architecture-conventions.md), Rust owns
+**capabilities** (file IO, SQLite, watching, OS stores) and TypeScript owns
+**policy**. If your feature is a new *rule* over existing primitives — a new
+query shape, a different orchestration — it belongs in `@reflect/core`, built
+on the commands that already exist.
+
+## 1. The Rust command
+
+Pick the module that owns the capability (`fs.rs` for graph file IO, `db/` for
+the index, `settings.rs`, `recents.rs`, …) or add a new one for a genuinely new
+capability. Commands are snake_case, return `AppResult<T>`, and serialize
+camelCase:
+
+```rust
+// apps/desktop/src-tauri/src/fs/mod.rs
+use crate::error::AppResult;
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NoteStat {
+    pub size_bytes: u64,
+    pub modified_ms: u64,
+}
+
+/// Command: file metadata for one note (graph-relative path).
+#[tauri::command]
+pub fn note_stat(path: String, state: tauri::State<GraphState>) -> AppResult<NoteStat> {
+    let root = current_root(&state)?;
+    let resolved = resolve(&root, &path)?; // traversal guard — see below
+    // ...
+}
+```
+
+Conventions that matter here:
+
+- **Errors are the shared contract.** Return `AppError` (`error.rs`); it
+  serializes as `{ kind, message }` and the frontend branches on `kind`
+  through the matching zod union in `packages/core/src/errors.ts`. Never
+  return bare strings. `std::io::Error` and `rusqlite::Error` already convert
+  via `From` (`?` just works); NotFound is mapped for you.
+- **Paths must not escape the graph.** Anything taking a graph-relative path
+  resolves it via `resolve()` (`fs/resolve.rs`), which rejects traversal and
+  symlink escapes. Don't build paths by hand.
+- **Writes are generation-pinned.** Mutating commands take a `generation`
+  argument (from `graph_open`) and get the root via `root_for_generation`,
+  which rejects stale ones — a write racing a graph switch fails loudly
+  instead of landing in the wrong graph. A new mutating command must follow
+  this pattern; read-only commands use `current_root`.
+- **No product policy.** A command exposes a primitive. If you find yourself
+  encoding "what to do when X", that decision belongs in `@reflect/core`.
+
+Register it in `apps/desktop/src-tauri/src/lib.rs` inside
+`tauri::generate_handler![...]` — forgetting this compiles fine and fails at
+runtime with a "command not found" rejection.
+
+Test the logic with `#[cfg(test)]` against the pure helper, not the command
+wrapper: `settings.rs` is a good model — `settings_load`/`settings_save` are
+two-liners over `load_from`/`save_to`, and the tests exercise those with
+`tempfile`. Run with `cargo test` from `apps/desktop/src-tauri`.
+
+## 2. The TypeScript binding
+
+Every command gets a typed binding in `packages/core` — components never call
+`invoke` or touch the bridge directly. In the matching domain module
+(`graph/commands.ts`, `settings/commands.ts`, …):
+
+```ts
+import { z } from 'zod'
+import { call } from '../ipc/invoke'
+
+export const noteStatSchema = z.object({
+  sizeBytes: z.number(),
+  modifiedMs: z.number(),
+})
+
+export type NoteStat = z.infer<typeof noteStatSchema>
+
+/** File metadata for one note (graph-relative path). */
+export async function noteStat(path: string): Promise<NoteStat> {
+  return call('note_stat', { path }, noteStatSchema)
+}
+```
+
+- `call()` (`ipc/invoke.ts`) is the single boundary where the untyped IPC
+  response becomes a typed value: it validates with your schema (a mismatch
+  throws a `parse` `AppError` naming the command) and coerces any rejection
+  into an `AppError`. Your binding adds no error handling of its own.
+- Commands returning `()` from Rust serialize as `null`: validate with
+  `z.null()` (see the `voidSchema` convention in `graph/commands.ts`).
+- Schemas live next to the binding (or in the domain's `schemas.ts` when
+  shared) — zod at the boundary, plain types inside.
+- Export the binding (and its types) from `packages/core/src/index.ts`; the
+  apps only import from the package root.
+
+## 3. Tests on the TS side
+
+`@reflect/core` never imports Tauri, so tests install a fake bridge instead of
+module-mocking:
+
+```ts
+import { setBridge } from '@reflect/core' // or '../ipc/bridge' within core
+setBridge({
+  invoke: vi.fn().mockResolvedValue({ sizeBytes: 12, modifiedMs: 99 }),
+  listen: async () => () => {},
+})
+```
+
+`packages/core/src/ipc/invoke.test.ts` shows the full pattern, including the
+error paths (well-formed `AppError` pass-through, foreign rejection coercion,
+schema-mismatch → `parse`). Reset with `setBridge(null)` in `afterEach`. A
+binding that is a one-line `call()` needs no test of its own — cover the
+schema if it normalizes, and the behavior in whatever core/UI module consumes
+it.
+
+## Checklist
+
+- [ ] Rust: command in the owning capability module, returns `AppResult<T>`,
+      camelCase serde, traversal-guarded paths, generation-pinned if mutating
+- [ ] Rust: registered in `lib.rs` `generate_handler!`
+- [ ] Rust: `#[cfg(test)]` tests on the pure helper; `cargo test` passes
+- [ ] TS: zod schema + typed binding through `call()` in the domain module
+- [ ] TS: exported from `packages/core/src/index.ts`
+- [ ] TS: behavior covered with a fake bridge where it matters
+- [ ] `pnpm typecheck && pnpm lint && pnpm test --run <touched paths>`

--- a/docs/contributing/adding-a-setting.md
+++ b/docs/contributing/adding-a-setting.md
@@ -1,0 +1,89 @@
+# Adding a user setting
+
+User settings are one JSON document in the OS config dir (next to the recents
+store — never inside a graph's `.reflect/`, because preferences follow the
+user across graphs and must survive graph deletion). The split of
+responsibilities follows the usual rule:
+
+- **Rust** (`apps/desktop/src-tauri/src/settings.rs`) persists the document as
+  an *opaque* JSON object — atomic writes, corrupt-store-errors-loudly. It has
+  no idea what keys exist. **You will not touch Rust to add a setting.**
+- **`@reflect/core`** (`packages/core/src/settings/schema.ts`) owns the known
+  keys, their defaults, and validation.
+- **The desktop app** consumes settings through `useSettings()`
+  (`apps/desktop/src/providers/settings-provider.tsx`) and renders controls in
+  `settings-screen.tsx`.
+
+## 1. Declare the key in the schema
+
+Add a field to `settingsSchema` in `packages/core/src/settings/schema.ts`:
+
+```ts
+export const editorMarkdownSyntaxSchema = z.enum(['focus', 'show']).catch('focus')
+
+export const settingsSchema = z
+  .object({
+    editorMarkdownSyntax: editorMarkdownSyntaxSchema,
+    // yourNewSetting: yourNewSettingSchema,
+  })
+  .passthrough()
+```
+
+The resilience contract (it mirrors the frontmatter schema):
+
+- **Every value schema ends in `.catch(default)`.** A missing *or invalid*
+  value degrades to its default instead of failing the whole load. Because of
+  this, `DEFAULT_SETTINGS` (`settingsSchema.parse({})`) picks up your default
+  automatically — there is no separate defaults table to update, and there are
+  no migrations: an old document simply lacks the key and parses to the
+  default.
+- **`.passthrough()` keeps unknown keys.** A document written by a newer app
+  version round-trips through an older one without losing fields. This is also
+  why saves always write the *full merged document*, never a single key.
+- **Name the persisted key implementation-neutrally.** The document outlives
+  any one library: `editorMarkdownSyntax`, not `meowdownMarkMode` — map to the
+  library's vocabulary at the consuming boundary instead.
+
+Export any new value type from `packages/core/src/index.ts` (alongside
+`EditorMarkdownSyntax`). Cover the new key in
+`packages/core/src/settings/schema.test.ts`: default on missing, degrade on
+invalid, accepted values pass through.
+
+## 2. Consume it
+
+```tsx
+const { settings, updateSettings } = useSettings()
+// read:  settings.yourNewSetting
+// write: updateSettings({ yourNewSetting: value })
+```
+
+Semantics you get for free from the provider (and must not re-implement):
+
+- **Instant apply.** `updateSettings` merges into local state immediately;
+  defaults are usable before the disk load settles, so there is no loading
+  gate to handle.
+- **Async, ordered persistence.** Writes are chained in apply order, trail
+  hydration (nothing is written before the disk document has been read), and
+  save the full merged document. Failures surface through the operations
+  status UI and retry on the next change or the quit flush.
+- **No save button.** Settings apply live — design your control accordingly.
+
+## 3. Add the control
+
+`apps/desktop/src/components/settings-screen.tsx` is a routed view (⌘, or the
+palette's "Open settings"). Follow the existing pattern: a `<section>` per
+group, a `<fieldset>` with a `legend` and a one-line description per setting,
+and `onChange` calling `updateSettings` directly. Add a test in
+`settings-screen.test.tsx` — the existing ones render the screen inside the
+*real* provider over a fake bridge (`setBridge`), interact with the control,
+and assert the document that reaches `settings_save`. That covers the whole
+chain (control → patch → merge → persist), not just the click handler.
+
+## Checklist
+
+- [ ] Value schema with `.catch(default)` added to `settingsSchema`
+- [ ] New types exported from `packages/core/src/index.ts`
+- [ ] Schema tests: missing → default, invalid → default, valid round-trips
+- [ ] Control in `settings-screen.tsx` wired to `updateSettings`
+- [ ] Screen test covering the new control
+- [ ] No Rust changes, no migrations, no per-key save logic

--- a/docs/contributing/editor-architecture.md
+++ b/docs/contributing/editor-architecture.md
@@ -1,0 +1,116 @@
+# Editor architecture
+
+A map of `apps/desktop/src/editor/` for contributors. The design docs are
+Plans 05/05b (editor + fidelity), 06 (daily notes), and 07/07b (backlinks,
+renames); this is the orientation layer those plans don't give you.
+
+## The layers
+
+```
+NotePane / DailyStream                  components — composition only
+  ├─ useNoteDocument()                  React adapter (use-note-document.ts)
+  │    └─ createNoteSession()           pure document state machine (note-session.ts)
+  │         └─ readNote / writeNote     @reflect/core typed commands
+  ├─ useWikiLinkNavigation()            [[link]] click → route / create
+  ├─ useImagePersistence()              paste/drop → assets/ write
+  └─ <NoteEditor>                       meowdown + our extensions (note-editor.tsx)
+```
+
+The load-bearing split is **session vs. adapter**: `note-session.ts` owns every
+save/conflict/protection rule as a pure state machine — no React, no editor, no
+IPC (file access is injected) — and `use-note-document.ts` only wires it to
+React state, the `@reflect/core` commands, the watcher stream, and the editor's
+imperative handle. Tests drive the session directly with fake IO
+(`note-session.test.ts`); if you're changing *what happens*, you're almost
+certainly in the session, and your test belongs there too.
+
+`NoteEditor` is **uncontrolled**: `initialContent` is read once, and showing
+different content goes through the imperative `NoteEditorHandle` (or a remount
+via `key`), never a prop change. Edits flow out through `onEditorChange`; the
+session pushes content back in through `applyContent` and recognizes the
+editor's synchronous re-entrant change event so a programmatic reload is never
+mistaken for a user edit.
+
+## The save loop
+
+```
+keystroke → session.editorChanged() → debounce (800ms) → atomic write
+  → file watcher event → core reindex (the ONLY incremental index path)
+  → the same event returns to the session → recognized as our echo → ignored
+```
+
+Saving never triggers indexing directly: our own write flows
+file → watcher → index like any external change, so there is one reindex path
+to reason about (Plan 04b). On every change event the session re-reads the
+file and compares by content: a match against what it last wrote (or a
+still-settling in-flight write) is our own echo and is ignored.
+
+Invariants the loop maintains:
+
+- **External changes never clobber a dirty buffer.** A clean buffer reloads
+  imperatively; a dirty one parks the external content as a `conflict` for the
+  user ("keep mine" rewrites the file, "load theirs" discards the buffer).
+- **Writes are generation-pinned.** Every write carries the open graph's
+  generation (read at write time, not captured at session creation); Rust
+  rejects stale ones, so a flush racing a graph switch fails loudly instead of
+  landing in the wrong graph.
+- **Frontmatter belongs to the session, not the editor.** meowdown mangles a
+  `---` block, so the session splits every disk read, keeps the exact header
+  bytes aside, and rejoins them on every write. The editor only ever sees the
+  body; metadata writes go through `session.updateFrontmatter()` without
+  disturbing the view.
+- **Round-trip fidelity gates editability** (`roundtrip.ts`). Before the save
+  pipeline may rewrite a note, the editor must prove it can reproduce it; a
+  converter gap (e.g. task lists today) opens the note as a `protected`
+  read-only view rather than silently rewriting the file minus what the editor
+  couldn't model.
+
+## Work that outlives a pane
+
+React unmount effects never run on the quit paths (window close, ⌘Q), and some
+editor work must survive pane teardown. Two pieces live outside React:
+
+- **`open-documents.ts`** — the app-global registry of live sessions. Quit
+  teardown (`flushOpenDocuments`) flushes every buffer and awaits settle-time
+  work before the webview dies; the rename coordinator uses `openSession(path)`
+  to discover whether a note is open (possibly *reopened* in a new pane) and
+  route through its live session instead of racing the disk.
+- **`rename-coordinator.ts` + `title-rename.ts`** — the auto-rename flow
+  (Plan 07b). The tracker watches the session's `onContent` stream and fires
+  only on *settled* titles (quiet timer, or a settle point: blur/teardown/quit)
+  — never per keystroke, so intermediate titles don't spray junk rewrites
+  across the graph. The coordinator serializes the graph-wide link rewrite and
+  records the old title as an alias, reporting progress through the global
+  operations store — a rename is app-level background work, not pane state.
+
+## File map
+
+| File | Owns |
+|---|---|
+| `note-session.ts` | save pipeline, conflicts, protection, frontmatter — the rules |
+| `use-note-document.ts` | React adapter: session ↔ state/commands/watcher/editor |
+| `note-editor.tsx` | meowdown composition + our extensions; imperative handle |
+| `roundtrip.ts` | fidelity classification (`exact` / `normalizing` / `lossy`) |
+| `open-documents.ts` | app-global live-session registry; quit flush |
+| `title-rename.ts` | settled-title detection (pure, timer-driven) |
+| `rename-coordinator.ts` | rename lifecycle: rewrite chain + alias placement |
+| `wiki-links.ts` | `[[…]]` chips as view decorations over literal text |
+| `wiki-autocomplete.tsx` / `-entries.ts` | `[[` popover; pure row assembly |
+| `use-wiki-link-navigation.ts` | chip click → resolve → navigate or create |
+| `images.ts` / `use-image-persistence.ts` | image widgets; paste/drop → `assets/` |
+| `keymap.ts` | central shortcut registry (rejects duplicate bindings) |
+
+## Where new code goes
+
+- **A new save/reload/conflict behavior** → `note-session.ts`, with a direct
+  test. If you need React state for it, expose it on the snapshot and let the
+  adapter stay dumb.
+- **A new editor feature** (decoration, input rule) → its own module composed
+  in `note-editor.tsx`. Keep markdown *literal* in the document and render via
+  decorations — that's what keeps serialization byte-identical (see
+  `wiki-links.ts` for the full rationale). Shortcuts go through `keymap.ts`.
+- **Markdown grammar** (what counts as a wiki link, an image, a heading) →
+  `packages/core/src/markdown/`, never the editor: the editor and the indexer
+  share one grammar so chips and index links can't drift.
+- **Pane-level wiring** → a focused hook next to the existing ones, composed
+  in `note-pane.tsx`; components stay composition-only.

--- a/docs/open-quality-pass/final-report.md
+++ b/docs/open-quality-pass/final-report.md
@@ -1,0 +1,103 @@
+# Quality pass — final report
+
+- **PR:** https://github.com/team-reflect/reflect-open/pull/23
+- **Branch:** `refactor/open-quality-pass-20260609-2228`
+- **Base:** `origin/master` @ `4fe1dc859e6cb79c58244a8a0c1d5985d207df1a`
+- **Diff:** 33 files changed, +1408 / −357 (before this report)
+
+## Commits
+
+| SHA | Subject |
+|---|---|
+| `9009b00` | docs: quality-pass plan — audit, targets, rejected refactors |
+| `0fcb715` | refactor(desktop): extract wiki-link navigation hook and note-pane banners |
+| `191b853` | refactor(desktop): split graph-workspace into one component per file |
+| `6eb5692` | refactor(desktop): share one NoteLinkList between backlinks and related notes |
+| `c20193b` | refactor(desktop): extract useFileChanges watcher-subscription hook |
+| `93a4ee8` | refactor: dedupe error-message normalization via core errorMessage helper |
+| `dda5502` | docs: contributor guides for commands, settings, and the editor |
+| `fdcd238` | docs: quality-pass status — targets done, verification green |
+
+(This report is committed after `fdcd238`.)
+
+## Files by theme
+
+**T1 — Note-pane decomposition**
+- `apps/desktop/src/editor/use-wiki-link-navigation.ts` (+ `.test.tsx`, new)
+- `apps/desktop/src/components/inline-alert.tsx` (new)
+- `apps/desktop/src/components/note-conflict-banner.tsx` (new)
+- `apps/desktop/src/components/protected-note-view.tsx` (new)
+- `apps/desktop/src/components/note-pane.tsx` (now composition-only)
+
+**T2 — graph-workspace split**
+- `apps/desktop/src/components/workspace-header.tsx` (+ `.test.tsx`, new)
+- `apps/desktop/src/components/cloud-sync-banner.tsx` (+ `.test.tsx`, new)
+- `apps/desktop/src/components/search-route.tsx`, `route-content.tsx`,
+  `workspace-content.tsx` (new)
+- `apps/desktop/src/components/graph-workspace.tsx` (163 → 12 lines)
+
+**T3 — Shared link list**
+- `apps/desktop/src/components/note-link-list.tsx` (new)
+- `apps/desktop/src/components/backlinks-panel.tsx`, `related-notes.tsx`
+  (thin query adapters; existing tests pass unchanged)
+
+**T4 — Watcher subscription hook**
+- `apps/desktop/src/lib/use-file-changes.ts` (+ `.test.tsx`, new)
+- `apps/desktop/src/editor/use-note-document.ts` (adopts the hook)
+
+**T5 — Error-message dedup**
+- `packages/core/src/errors.ts` (`errorMessage`), `errors.test.ts`, `index.ts`
+- `apps/desktop/src/editor/note-session.ts`, `rename-coordinator.ts`,
+  `use-image-persistence.ts`
+- `apps/desktop/src/providers/graph-provider.tsx`, `settings-provider.tsx`
+
+**T6 — Contributor docs**
+- `docs/contributing/adding-a-command.md`, `adding-a-setting.md`,
+  `editor-architecture.md` (new); `CONTRIBUTING.md` (links)
+
+**Artifacts**
+- `docs/open-quality-pass/plan.md`, `status.md`, `final-report.md`
+
+## Verification (run at `dda5502`/`fdcd238`)
+
+| Command | Result |
+|---|---|
+| `pnpm typecheck` | pass — `Tasks: 3 successful, 3 total` |
+| `pnpm lint` | pass — oxlint over `apps packages`, exit 0 |
+| `pnpm test` | pass — 3/3 tasks; desktop suite: 35 files / 204 tests, all green |
+| `pnpm build` | pass — Vite build OK; pre-existing >500 kB chunk warning only |
+
+`pnpm install --frozen-lockfile` was not needed (dependencies already
+installed); no Rust files were touched, so `cargo test` was not required.
+
+## Tests added
+
+- `use-wiki-link-navigation.test.tsx` — 6 (resolve→navigate, ISO date→daily,
+  unresolved→create+open, null generation, empty target, unmount guard)
+- `use-file-changes.test.tsx` — 5 (delivery, drop-after-teardown, late-unlisten
+  close, resubscribe on handler change, disabled/no-bridge)
+- `workspace-header.test.tsx` — 4; `cloud-sync-banner.test.tsx` — 2
+- `errors.test.ts` — 2 new `errorMessage` cases
+
+## Plan deviations
+
+- **T4:** `useFileChanges` adopted in `use-note-document.ts` only.
+  `embeddings-sync.tsx` keeps its inline subscription — it shares one `active`
+  flag between subscription teardown and the work queue's staleness epoch, and
+  splitting that would require new epoch machinery (more code, not less).
+
+## Remaining recommendations (out of scope, see plan.md "Rejected")
+
+1. **Code-split the 1.2 MB bundle chunk** — the Vite warning predates this
+   branch; `manualChunks` for meowdown/ProseMirror and the ONNX runtime would
+   be the natural cut.
+2. **Promote `InlineAlert` to the design-system package** once that package
+   exports components at all (today it ships only CSS/tokens/assets) — a
+   package-level decision, not a refactor.
+3. **Settings radio-group extraction** when a second enum-valued setting
+   lands; one consumer doesn't justify the abstraction yet.
+4. **`queries.ts` split** by domain if it keeps growing; current size doesn't
+   warrant it.
+5. **Embeddings-sync epoch refactor** if a third watcher consumer appears —
+   that would justify generalizing `useFileChanges` with an epoch/staleness
+   parameter.

--- a/docs/open-quality-pass/plan.md
+++ b/docs/open-quality-pass/plan.md
@@ -1,0 +1,126 @@
+# Open quality pass — plan
+
+Branch: `refactor/open-quality-pass-20260609-2228` · Base: `origin/master` @ `4fe1dc8`
+
+## Architecture observations
+
+The repo is a pnpm/Turborepo monorepo (`apps/desktop`, `packages/core`,
+`packages/db`, `design-system`) with one load-bearing rule that is genuinely
+held to: TypeScript owns policy, Rust owns capabilities, and `@reflect/core`
+never imports Tauri (bridge injection keeps it vitest-testable). Most modules
+are already small, documented, and tested — `note-session.ts` is a pure state
+machine with a React adapter, the command registry is explicit, the router is
+a typed in-memory history stack. This is *not* a codebase that needs a rewrite.
+
+What an honest "if we started again" critique still finds:
+
+1. **`note-pane.tsx` braids four concerns and is untested.** Document binding,
+   wiki-link resolution/navigation/creation (real domain behavior: resolved →
+   navigate, ISO date → daily route, unresolved → create-and-open, unmount
+   guard), three hand-rolled alert banners, and editor wiring all live in one
+   224-line component with no test file. The wiki-link behavior is only
+   "documented" by a comment.
+2. **One-component-per-file is violated exactly where contributors will look
+   first.** `graph-workspace.tsx` holds four components (workspace, content,
+   search route, route switch) — the routing/view boundary is real but
+   invisible. The header is also hook-coupled, so it can't be rendered in a
+   test without faking five providers.
+3. **Near-identical components.** `BacklinksPanel` and `RelatedNotes` are the
+   same section/list/button rendering with different queries. The amber/red
+   inline alert styling is hand-copied 5× across `note-pane.tsx` and
+   `graph-workspace.tsx`.
+4. **Duplicated fiddly plumbing.** The watcher subscription dance (active
+   flag, late-resolving unlisten) appears in `use-note-document.ts` and
+   `embeddings-sync.tsx`; `messageOf(error)` is re-implemented in
+   `note-session.ts`, `rename-coordinator.ts`, and `graph-provider.tsx`, two
+   of which re-derive what `toAppError().message` already guarantees.
+5. **Contributor docs stop at conventions.** CONTRIBUTING/AGENTS say *where*
+   code goes, but there is no task-oriented guide for the three things a new
+   contributor most likely wants to do: add a command, add a setting, or
+   touch the editor stack (session ← hook ← pane layering, roundtrip
+   protection, frontmatter ownership).
+
+## Refactor targets (chosen)
+
+### T1 — Note pane decomposition + tests
+- Extract `use-wiki-link-navigation.ts` (hook owning resolve → navigate /
+  daily / create, with the unmount guard) + tests for all four behaviors.
+- Extract `inline-alert.tsx` (tone: `warning` | `error`) and reuse it for the
+  save-error, image-error, conflict, protected, and cloud-sync banners.
+- Extract `note-conflict-banner.tsx` (Keep mine / Load theirs) and
+  `protected-note-view.tsx`; `note-pane.tsx` becomes composition.
+
+### T2 — Workspace/routing boundary
+- Split `graph-workspace.tsx` into `workspace-header.tsx` (props-driven,
+  testable without providers), `cloud-sync-banner.tsx` (owns the cloud-label
+  map), `route-content.tsx`, and `search-route.tsx`.
+- Add tests for the header and the cloud banner labels.
+
+### T3 — Shared note-link list
+- Extract `note-link-list.tsx` (section + title/snippet button list);
+  `BacklinksPanel` and `RelatedNotes` become thin query adapters. Existing
+  tests must keep passing unchanged — that is the behavior-preservation proof.
+
+### T4 — Watcher subscription hook
+- Extract `use-file-changes.ts` reproducing today's exact lifecycle semantics
+  (resubscribe on handler identity change, drop events after teardown, close
+  a late-resolving unlisten). Adopt in `use-note-document.ts` and
+  `embeddings-sync.tsx`. Test the lifecycle directly.
+
+### T5 — Error-message dedup
+- Add `errorMessage(value: unknown): string` to `@reflect/core` errors (thin
+  wrapper over `toAppError`), replace the three local `messageOf` copies and
+  inline `toAppError(x).message` call sites. Check note-session tests for
+  message-shape assertions before changing.
+
+### T6 — Contributor guides
+- `docs/contributing/adding-a-command.md`, `adding-a-setting.md`,
+  `editor-architecture.md`; link from `CONTRIBUTING.md`.
+
+## Rejected (deliberately)
+
+- **Splitting `note-session.ts` (489 lines).** It is one state machine whose
+  invariants (save chain, echo detection, conflict gating) are co-located on
+  purpose and covered by a 261-line test file. Splitting scatters invariants.
+- **Extracting graph-provider's open-sequencing into a standalone machine.**
+  Real subtlety, but already covered by `graph-provider.test.tsx`; the
+  rewrite risk outweighs the testability gain in this pass.
+- **Moving `InlineAlert` into `design-system/`.** The package currently
+  exports only CSS/tokens/assets, no React entry point; adding one is a
+  bigger decision than this pass should smuggle in. App-level component now,
+  promotion noted as follow-up.
+- **Generic radio-card group for settings.** One setting exists; premature.
+- **Splitting `packages/core/indexing/queries.ts` (265 lines).** A cohesive,
+  flat collection of query functions; splitting is churn.
+- **Any palette restructure.** Already well-factored (provider / results hook
+  / entries / registry, each tested).
+
+## Acceptance criteria
+
+- No behavior or public-API changes; existing tests pass unmodified (except
+  imports if a symbol moves).
+- Every extracted module has a doc comment and direct tests (T1, T2, T4, T5).
+- `note-pane.tsx` and `graph-workspace.tsx` each contain exactly one
+  component.
+- New contributor guides accurately reflect the code as it is on this branch.
+- `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm build` pass.
+
+## Verification plan
+
+1. `pnpm install --frozen-lockfile` (worktree has no `node_modules`).
+2. `pnpm typecheck && pnpm lint && pnpm test` after each theme; full
+   `pnpm build` at the end.
+3. Grep-verify no orphaned imports/exports after moves.
+
+## Risks / caveats
+
+- `embeddings-sync.tsx` adoption of `use-file-changes` must preserve the
+  queue's cross-graph persistence and the at-event-time staleness checks;
+  mitigated by keeping resubscribe-on-deps semantics identical.
+- `errorMessage` swap slightly changes non-Error object rendering in
+  note-session (`String(obj)` → JSON) — strictly better, but check test
+  assertions.
+- `pnpm build` runs Vite + tsc only (no Tauri bundle); Rust is untouched, so
+  `cargo test` is out of scope and will be noted, not claimed.
+- jsdom tests can't validate real editor focus/scroll behavior; UI changes
+  here are markup-preserving extractions to minimize that exposure.

--- a/docs/open-quality-pass/status.md
+++ b/docs/open-quality-pass/status.md
@@ -1,0 +1,42 @@
+# Quality pass — status
+
+Branch: `refactor/open-quality-pass-20260609-2228` (base: `origin/master` @ `4fe1dc8`)
+Last updated: 2026-06-09
+
+## Targets (from [plan.md](plan.md))
+
+| Target | Status | Commit |
+|---|---|---|
+| Plan & architecture audit | done | `9009b00` |
+| T1 — Note-pane decomposition (wiki-link hook, InlineAlert, banners) | done | `0fcb715` |
+| T2 — graph-workspace split (header, cloud banner, route content) | done | `191b853` |
+| T3 — Shared NoteLinkList for backlinks/related | done | `6eb5692` |
+| T4 — useFileChanges subscription hook | done (scope note below) | `c20193b` |
+| T5 — `errorMessage` in core, dedupe `messageOf` | done | `93a4ee8` |
+| T6 — Contributor guides + CONTRIBUTING.md links | done | `dda5502` |
+
+## Deviations from plan
+
+- **T4 (partial adoption).** The plan proposed adopting `useFileChanges` in
+  both `use-note-document.ts` and `embeddings-sync.tsx`. Only the former was
+  converted: embeddings-sync's subscription is entangled with its work queue's
+  staleness epoch (one `active` flag covers backfill staleness *and* queued
+  watcher items), so forcing the shared hook there would have required adding
+  an epoch mechanism — more code, not less. Rationale recorded in the T4
+  commit message.
+
+## Verification (run at HEAD = `dda5502`)
+
+| Command | Result |
+|---|---|
+| `pnpm typecheck` | pass — 3/3 tasks |
+| `pnpm lint` | pass — oxlint, exit 0 |
+| `pnpm test` | pass — 3/3 tasks; desktop: 35 files / 204 tests |
+| `pnpm build` | pass — pre-existing >500 kB chunk warning only |
+
+No Rust files were touched, so `cargo test` was not required.
+
+## Remaining
+
+- Write `final-report.md` (needs PR URL)
+- Push branch, open PR against `master`

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isAppError, toAppError } from './errors'
+import { errorMessage, isAppError, toAppError } from './errors'
 
 describe('isAppError', () => {
   it('accepts every contract kind', () => {
@@ -47,5 +47,17 @@ describe('toAppError', () => {
   it('coerces null and undefined without throwing', () => {
     expect(toAppError(null)).toEqual({ kind: 'unknown', message: 'null' })
     expect(toAppError(undefined).kind).toBe('unknown')
+  })
+})
+
+describe('errorMessage', () => {
+  it('uses the command error message when well-formed', () => {
+    expect(errorMessage({ kind: 'io', message: 'disk full' })).toBe('disk full')
+  })
+
+  it('normalizes Errors, strings, and arbitrary objects', () => {
+    expect(errorMessage(new Error('boom'))).toBe('boom')
+    expect(errorMessage('plain failure')).toBe('plain failure')
+    expect(errorMessage({ code: 7 })).toBe('{"code":7}')
   })
 })

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -48,3 +48,12 @@ export function toAppError(value: unknown): AppError {
   }
   return { kind: 'unknown', message }
 }
+
+/**
+ * The display message for any thrown/rejected value — {@link toAppError}'s
+ * normalization, as a string. The standard way to render a caught `unknown`
+ * to the user (or a log line) without `[object Object]` surprises.
+ */
+export function errorMessage(value: unknown): string {
+  return toAppError(value).message
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,7 +37,7 @@ export {
   type RetrievalHit,
   type RetrieveOptions,
 } from './embeddings/retrieve'
-export { appErrorSchema, isAppError, toAppError, type AppError } from './errors'
+export { appErrorSchema, errorMessage, isAppError, toAppError, type AppError } from './errors'
 
 // Graph & file storage (Plan 02)
 export {


### PR DESCRIPTION
## Summary

A disciplined refactoring pass over the desktop app, planned and scoped in
[`docs/open-quality-pass/plan.md`](docs/open-quality-pass/plan.md) (which also
records the refactors that were considered and **rejected** to avoid churn).
Behavior and public APIs are preserved throughout — several pre-existing test
suites pass unchanged against the refactored code, which is the
behavior-preservation proof.

## Refactor themes

**Component decomposition (one component per file, composition-only screens)**
- `note-pane.tsx` is now pure composition: wiki-link click handling moved to
  `useWikiLinkNavigation`, and its inline UI branches became `InlineAlert`,
  `NoteConflictBanner`, and `ProtectedNoteView`.
- `graph-workspace.tsx` (163 lines → 12) split into `WorkspaceHeader`
  (props-driven, testable without providers), `CloudSyncBanner`,
  `SearchRoute`, `RouteContent` (the single route→view switch), and
  `WorkspaceContent`.
- `BacklinksPanel` and `RelatedNotes` now share one `NoteLinkList`
  presentational component instead of two hand-rolled copies.

**Extracted, reusable logic**
- `useFileChanges` — the watcher-subscription effect (bridge gating,
  unsubscribe race, drop-after-teardown) extracted from `use-note-document.ts`
  and covered by 5 focused tests.
- `errorMessage()` promoted to `@reflect/core`: three identical local
  `messageOf` helpers (note-session, rename-coordinator, graph-provider) and
  two inline `toAppError(x).message` sites now share the one tested helper.

**Contributor documentation**
- `docs/contributing/adding-a-command.md` — the full Rust → bridge → zod →
  React path with conventions (traversal guard, generation pinning) and a
  checklist.
- `docs/contributing/adding-a-setting.md` — the no-Rust recipe (catch-defaults,
  passthrough, instant apply).
- `docs/contributing/editor-architecture.md` — the session/adapter split, the
  save loop, and where new editor code goes. All linked from CONTRIBUTING.md.

## Tests & verification

New tests: `use-wiki-link-navigation.test.tsx` (6), `use-file-changes.test.tsx`
(5), `workspace-header.test.tsx` (4), `cloud-sync-banner.test.tsx` (2), plus
`errorMessage` coverage in `packages/core/src/errors.test.ts` (2).

Run at HEAD:
- `pnpm typecheck` — pass (3/3 tasks)
- `pnpm lint` — pass (oxlint, exit 0)
- `pnpm test` — pass (3/3 tasks; desktop: 35 files / 204 tests)
- `pnpm build` — pass (pre-existing >500 kB chunk-size warning only)

No Rust files touched.

## Caveats

- **T4 partial adoption (plan deviation):** `useFileChanges` was adopted in
  `use-note-document.ts` only. `embeddings-sync.tsx` keeps its inline
  subscription because it is entangled with the work queue's staleness epoch;
  forcing the shared hook there would add an epoch mechanism — more code, not
  less. Detailed in the T4 commit message and `docs/open-quality-pass/status.md`.
- `NoteLinkList` unifies title truncation across the two panels — a minor
  (intentional) visual alignment.
- The audit artifacts live under `docs/open-quality-pass/`; happy to drop them
  from the PR if you'd rather keep the tree clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with broad test coverage and no Rust or API changes; minor UI alignment from shared `NoteLinkList` and slightly different error strings for non-Error objects via `errorMessage`.
> 
> **Overview**
> Behavior-preserving refactor of the desktop UI and contributor docs: large screens are split into focused components and hooks, duplicated UI and error handling are centralized, and new tests cover extracted logic.
> 
> **`note-pane`** is composition-only: wiki-link clicks move to **`useWikiLinkNavigation`** (with tests for resolve, daily routes, create-on-click, and unmount guards). Save/conflict/protected flows use **`InlineAlert`**, **`NoteConflictBanner`**, and **`ProtectedNoteView`**.
> 
> **`graph-workspace`** shrinks to provider wiring; **`WorkspaceContent`**, props-driven **`WorkspaceHeader`**, **`CloudSyncBanner`**, **`RouteContent`**, and **`SearchRoute`** own the shell, routing, and search deep-link behavior (header and cloud banner get unit tests).
> 
> **`BacklinksPanel`** and **`RelatedNotes`** share **`NoteLinkList`** so both panels use the same list UI. **`useFileChanges`** centralizes file-watcher subscription lifecycle; **`use-note-document`** adopts it (`embeddings-sync` keeps its inline subscription per plan deviation).
> 
> **`errorMessage()`** in **`@reflect/core`** replaces local **`messageOf`** / **`toAppError().message`** call sites across session, rename, image persistence, and providers.
> 
> **CONTRIBUTING** links three new guides (commands, settings, editor architecture) plus **`docs/open-quality-pass/`** audit artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b468a9052241b1ef91b030da8e70b524e3ece8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->