### PR TITLE
Daily context sidebar: calendar, day navigation, backlinks, related notes

### DIFF
--- a/apps/desktop/src/components/daily-sidebar/daily-context-sidebar.test.tsx
+++ b/apps/desktop/src/components/daily-sidebar/daily-context-sidebar.test.tsx
@@ -1,0 +1,195 @@
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import { addDaysIso, formatDayLabel, todayIso } from '@/lib/dates'
+import { monthLabel, monthOf, addMonths } from '@/lib/month-grid'
+import { RouterProvider, useRouter } from '@/routing/router'
+import { DailyContextSidebar } from './daily-context-sidebar'
+
+const dailyDatesInRange = vi.hoisted(() => vi.fn())
+const getBacklinksWithContext = vi.hoisted(() => vi.fn())
+const relatedNotes = vi.hoisted(() => vi.fn())
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  hasBridge: () => true,
+  dailyDatesInRange,
+  getBacklinksWithContext,
+  relatedNotes,
+}))
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({ graph: { root: '/g', name: 'g', cloudSync: false, generation: 1 } }),
+}))
+
+function RouteProbe(): ReactNode {
+  const { route } = useRouter()
+  return <output data-testid="route">{JSON.stringify(route)}</output>
+}
+
+function renderSidebar(date: string) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <RouterProvider>
+        <DailyContextSidebar date={date} />
+        <RouteProbe />
+      </RouterProvider>
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  window.sessionStorage.clear()
+  dailyDatesInRange.mockReset().mockResolvedValue([])
+  getBacklinksWithContext.mockReset().mockResolvedValue([])
+  relatedNotes.mockReset().mockResolvedValue([])
+})
+
+describe('DailyContextSidebar header', () => {
+  it('shows the day label and a Today badge on today', async () => {
+    const today = todayIso()
+    const view = renderSidebar(today)
+    expect(view.getByRole('heading', { name: formatDayLabel(today) })).toBeDefined()
+    expect(view.getByText('Today')).toBeDefined()
+    expect(view.queryByText('Go to today')).toBeNull()
+    await waitFor(() => expect(getBacklinksWithContext).toHaveBeenCalled())
+    view.unmount()
+  })
+
+  it('offers "Go to today" with the real ⌘D hint on other days', async () => {
+    const past = addDaysIso(todayIso(), -3)
+    const view = renderSidebar(past)
+    const goToToday = view.getByRole('button', { name: /Go to today/ })
+    expect(goToToday.textContent).toContain('⌘D')
+    await userEvent.click(goToToday)
+    expect(view.getByTestId('route').textContent).toContain('"kind":"today"')
+    view.unmount()
+  })
+
+  it('navigates to adjacent days', async () => {
+    const date = '2026-06-09'
+    const view = renderSidebar(date)
+    await userEvent.click(view.getByRole('button', { name: 'Previous day' }))
+    expect(view.getByTestId('route').textContent).toContain('2026-06-08')
+    await userEvent.click(view.getByRole('button', { name: 'Next day' }))
+    expect(view.getByTestId('route').textContent).toContain('2026-06-10')
+    view.unmount()
+  })
+})
+
+describe('DailyContextSidebar calendar', () => {
+  it('marks days that have a daily note and navigates on day click', async () => {
+    dailyDatesInRange.mockResolvedValue(['2026-06-05'])
+    const view = renderSidebar('2026-06-09')
+
+    await view.findByTestId('note-dot-2026-06-05')
+    expect(dailyDatesInRange).toHaveBeenCalledWith('2026-06-01', '2026-07-05')
+    expect(view.queryByTestId('note-dot-2026-06-04')).toBeNull()
+
+    await userEvent.click(view.getByRole('button', { name: formatDayLabel('2026-06-18') }))
+    expect(view.getByTestId('route').textContent).toContain('2026-06-18')
+    view.unmount()
+  })
+
+  it('pages between months across year boundaries', async () => {
+    const view = renderSidebar('2026-01-15')
+    expect(view.getByText(monthLabel('2026-01'))).toBeDefined()
+    await userEvent.click(view.getByRole('button', { name: 'Previous month' }))
+    expect(view.getByText(monthLabel('2025-12'))).toBeDefined()
+    await userEvent.click(view.getByRole('button', { name: 'Next month' }))
+    await userEvent.click(view.getByRole('button', { name: 'Next month' }))
+    expect(view.getByText(monthLabel('2026-02'))).toBeDefined()
+    view.unmount()
+  })
+
+  it('re-anchors the visible month when the selected day changes', () => {
+    const view = renderSidebar('2026-06-09')
+    expect(view.getByText(monthLabel('2026-06'))).toBeDefined()
+    view.rerender(
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
+        <RouterProvider>
+          <DailyContextSidebar date="2026-09-01" />
+          <RouteProbe />
+        </RouterProvider>
+      </QueryClientProvider>,
+    )
+    expect(view.getByText(monthLabel('2026-09'))).toBeDefined()
+    view.unmount()
+  })
+})
+
+describe('DailyContextSidebar backlinks', () => {
+  it('shows a quiet empty state when nothing links to the day', async () => {
+    const view = renderSidebar('2026-06-09')
+    await view.findByText('No notes link to this day yet.')
+    expect(getBacklinksWithContext).toHaveBeenCalledWith('daily/2026-06-09.md')
+    view.unmount()
+  })
+
+  it('lists inbound links with snippets and navigates on click', async () => {
+    getBacklinksWithContext.mockResolvedValue([
+      {
+        sourcePath: 'notes/standup.md',
+        sourceTitle: 'Standup',
+        snippet: 'review on [[2026-06-09]]',
+        posFrom: 4,
+      },
+    ])
+    const view = renderSidebar('2026-06-09')
+    await view.findByText('Standup')
+    expect(view.getByText('review on [[2026-06-09]]')).toBeDefined()
+    await userEvent.click(view.getByText('Standup'))
+    expect(view.getByTestId('route').textContent).toContain('notes/standup.md')
+    view.unmount()
+  })
+})
+
+describe('DailyContextSidebar related notes', () => {
+  it('renders no Related section without results', async () => {
+    const view = renderSidebar('2026-06-09')
+    await waitFor(() => expect(relatedNotes).toHaveBeenCalledWith('daily/2026-06-09.md'))
+    expect(view.queryByText('Related')).toBeNull()
+    view.unmount()
+  })
+
+  it('lists semantic neighbors when they exist', async () => {
+    relatedNotes.mockResolvedValue([
+      {
+        path: 'notes/rust.md',
+        title: 'Rust',
+        score: 0.9,
+        snippet: 'borrow checker notes',
+        heading: null,
+      },
+    ])
+    const view = renderSidebar('2026-06-09')
+    await view.findByText('Rust')
+    expect(view.getByText('Related')).toBeDefined()
+    await userEvent.click(view.getByText('Rust'))
+    expect(view.getByTestId('route').textContent).toContain('notes/rust.md')
+    view.unmount()
+  })
+})
+
+describe('DailyContextSidebar sections', () => {
+  it('collapses a section and persists the state for the session', async () => {
+    const view = renderSidebar('2026-06-09')
+    const header = view.getByRole('button', { name: /Calendar/ })
+    expect(header.getAttribute('aria-expanded')).toBe('true')
+    expect(view.getByText(monthLabel(monthOf('2026-06-09')))).toBeDefined()
+
+    await userEvent.click(header)
+    expect(header.getAttribute('aria-expanded')).toBe('false')
+    expect(view.queryByText(monthLabel(addMonths(monthOf('2026-06-09'), 0)))).toBeNull()
+    view.unmount()
+
+    const reopened = renderSidebar('2026-06-09')
+    expect(
+      reopened.getByRole('button', { name: /Calendar/ }).getAttribute('aria-expanded'),
+    ).toBe('false')
+    reopened.unmount()
+  })
+})

--- a/apps/desktop/src/components/daily-sidebar/daily-context-sidebar.tsx
+++ b/apps/desktop/src/components/daily-sidebar/daily-context-sidebar.tsx
@@ -1,0 +1,87 @@
+import type { ReactElement } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { APP_COMMANDS } from '@/lib/commands/app-commands'
+import { addDaysIso, formatDayLabel } from '@/lib/dates'
+import { useToday } from '@/lib/use-today'
+import { useRouter } from '@/routing/router'
+import { DayBacklinks } from './day-backlinks'
+import { DayCalendar } from './day-calendar'
+import { DayRelatedNotes } from './day-related-notes'
+import { SidebarSection } from './sidebar-section'
+
+interface DailyContextSidebarProps {
+  /** The day the sidebar describes — a validated ISO date from the route. */
+  date: string
+}
+
+// The hint is derived from the real command definition so it can never drift
+// from the actual binding (and disappears if the binding ever does).
+const TODAY_KEYBINDING = APP_COMMANDS.find((command) => command.id === 'nav.today')
+  ?.keybinding
+const TODAY_HINT = TODAY_KEYBINDING
+  ? TODAY_KEYBINDING.replace('Mod-', '⌘').toUpperCase()
+  : null
+
+/**
+ * The daily note's contextual sidebar (modeled on the old app's note context
+ * sidebar): adjacent-day navigation, a month calendar marking days with
+ * notes, the day's inbound links, and semantic neighbors when embeddings are
+ * available. Rendered in the AppShell's right region on daily routes only.
+ */
+export function DailyContextSidebar({ date }: DailyContextSidebarProps): ReactElement {
+  const { navigate } = useRouter()
+  const today = useToday()
+  const isToday = date === today
+
+  return (
+    <div className="flex flex-col px-2 py-2 text-[color:var(--text)]">
+      <header className="border-b border-black/5 px-1 pb-2 dark:border-white/5">
+        <div className="flex items-center justify-between gap-1">
+          <button
+            type="button"
+            aria-label="Previous day"
+            onClick={() => navigate({ kind: 'daily', date: addDaysIso(date, -1) })}
+            className="rounded p-1 text-[color:var(--text-secondary)] hover:bg-black/5 dark:hover:bg-white/5"
+          >
+            <ChevronLeft aria-hidden className="size-4" />
+          </button>
+          <h2 className="min-w-0 truncate text-sm font-semibold">
+            {formatDayLabel(date)}
+          </h2>
+          <button
+            type="button"
+            aria-label="Next day"
+            onClick={() => navigate({ kind: 'daily', date: addDaysIso(date, 1) })}
+            className="rounded p-1 text-[color:var(--text-secondary)] hover:bg-black/5 dark:hover:bg-white/5"
+          >
+            <ChevronRight aria-hidden className="size-4" />
+          </button>
+        </div>
+        <div className="mt-0.5 text-center">
+          {isToday ? (
+            <span className="text-xs font-medium text-[color:var(--accent)]">Today</span>
+          ) : (
+            <button
+              type="button"
+              onClick={() => navigate({ kind: 'today' })}
+              className="inline-flex items-center gap-1.5 rounded px-1.5 py-0.5 text-xs font-medium text-[color:var(--accent)] hover:bg-black/5 dark:hover:bg-white/5"
+            >
+              Go to today
+              {TODAY_HINT !== null ? (
+                <kbd className="rounded border border-black/10 px-1 font-sans text-[10px] text-[color:var(--text-muted)] dark:border-white/10">
+                  {TODAY_HINT}
+                </kbd>
+              ) : null}
+            </button>
+          )}
+        </div>
+      </header>
+
+      <SidebarSection storageKey="calendar" title="Calendar">
+        <DayCalendar selectedDate={date} today={today} />
+      </SidebarSection>
+      <DayBacklinks date={date} />
+      <DayRelatedNotes date={date} />
+    </div>
+  )
+}

--- a/apps/desktop/src/components/daily-sidebar/day-backlinks.tsx
+++ b/apps/desktop/src/components/daily-sidebar/day-backlinks.tsx
@@ -1,0 +1,67 @@
+import type { ReactElement } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { dailyPath, getBacklinksWithContext, hasBridge } from '@reflect/core'
+import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
+import { useGraph } from '@/providers/graph-provider'
+import { routeForPath } from '@/routing/route'
+import { useRouter } from '@/routing/router'
+import { SidebarSection } from './sidebar-section'
+
+interface DayBacklinksProps {
+  /** The day whose inbound links to show (validated ISO date). */
+  date: string
+}
+
+/**
+ * "Linked from" for the selected day: every note linking to its daily note,
+ * with the line around the link (the same query as the in-note backlinks
+ * panel, presented as a sidebar section with a quiet empty state).
+ */
+export function DayBacklinks({ date }: DayBacklinksProps): ReactElement {
+  const { navigate } = useRouter()
+  const { graph } = useGraph()
+  const path = dailyPath(date)
+  const { data, isPending, isError } = useQuery({
+    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'backlinks', path],
+    queryFn: () => getBacklinksWithContext(path),
+    enabled: hasBridge() && graph !== null,
+  })
+
+  const backlinks = data ?? []
+  return (
+    <SidebarSection storageKey="backlinks" title="Linked from" count={data?.length}>
+      {isPending ? (
+        <p className="px-2 py-1 text-xs text-[color:var(--text-muted)]">Loading…</p>
+      ) : isError ? (
+        <p role="alert" className="px-2 py-1 text-xs text-[color:var(--text-muted)]">
+          Couldn’t load backlinks.
+        </p>
+      ) : backlinks.length === 0 ? (
+        <p className="px-2 py-1 text-xs text-[color:var(--text-muted)]">
+          No notes link to this day yet.
+        </p>
+      ) : (
+        <ul className="space-y-0.5">
+          {backlinks.map((backlink) => (
+            <li key={`${backlink.sourcePath}:${backlink.posFrom}`}>
+              <button
+                type="button"
+                onClick={() => navigate(routeForPath(backlink.sourcePath))}
+                className="w-full rounded px-2 py-1 text-left hover:bg-black/5 dark:hover:bg-white/5"
+              >
+                <span className="block truncate text-sm font-medium">
+                  {backlink.sourceTitle}
+                </span>
+                {backlink.snippet !== '' ? (
+                  <span className="block truncate text-xs text-[color:var(--text-muted)]">
+                    {backlink.snippet}
+                  </span>
+                ) : null}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </SidebarSection>
+  )
+}

--- a/apps/desktop/src/components/daily-sidebar/day-calendar.tsx
+++ b/apps/desktop/src/components/daily-sidebar/day-calendar.tsx
@@ -1,0 +1,141 @@
+import { useState, type ReactElement } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { dailyDatesInRange, hasBridge } from '@reflect/core'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { formatDayLabel } from '@/lib/dates'
+import {
+  addMonths,
+  buildMonthGrid,
+  monthLabel,
+  monthOf,
+  weekdayLabels,
+} from '@/lib/month-grid'
+import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
+import { cn } from '@/lib/utils'
+import { useGraph } from '@/providers/graph-provider'
+import { useRouter } from '@/routing/router'
+
+interface DayCalendarProps {
+  /** The day the sidebar describes (highlighted as selected). */
+  selectedDate: string
+  /** Today's live ISO date. */
+  today: string
+}
+
+const WEEKDAYS = weekdayLabels()
+
+/**
+ * Compact month calendar (the old app's daily-note anchor): weeks start
+ * Monday, the selected day and today are highlighted, and days that already
+ * have a daily note carry a dot marker (an indexed `dailyDate` row — daily
+ * files exist only once written, so a row means real content). Clicking a day
+ * navigates to it; the month view follows the selected day.
+ */
+export function DayCalendar({ selectedDate, today }: DayCalendarProps): ReactElement {
+  const { navigate } = useRouter()
+  const { graph } = useGraph()
+
+  const [month, setMonth] = useState(() => monthOf(selectedDate))
+  // Render-time state adjustment (not an effect): navigating to another day
+  // re-anchors the visible month before the stale grid can paint.
+  const [lastSelected, setLastSelected] = useState(selectedDate)
+  if (selectedDate !== lastSelected) {
+    setLastSelected(selectedDate)
+    setMonth(monthOf(selectedDate))
+  }
+
+  const grid = buildMonthGrid(month)
+  const { data: notedDates } = useQuery({
+    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'dailyDates', grid.start, grid.end],
+    queryFn: () => dailyDatesInRange(grid.start, grid.end),
+    enabled: hasBridge() && graph !== null,
+  })
+  const noted = new Set(notedDates ?? [])
+
+  return (
+    <div aria-label="Calendar">
+      <div className="mb-1 flex items-center justify-between px-1">
+        <span className="text-sm font-medium">{monthLabel(month)}</span>
+        <div className="flex items-center">
+          <button
+            type="button"
+            aria-label="Previous month"
+            onClick={() => setMonth(addMonths(month, -1))}
+            className="rounded p-1 text-[color:var(--text-secondary)] hover:bg-black/5 dark:hover:bg-white/5"
+          >
+            <ChevronLeft aria-hidden className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            aria-label="Next month"
+            onClick={() => setMonth(addMonths(month, 1))}
+            className="rounded p-1 text-[color:var(--text-secondary)] hover:bg-black/5 dark:hover:bg-white/5"
+          >
+            <ChevronRight aria-hidden className="size-3.5" />
+          </button>
+        </div>
+      </div>
+
+      <table className="w-full border-separate border-spacing-y-0.5 text-center">
+        <thead>
+          <tr>
+            {WEEKDAYS.map((weekday) => (
+              <th
+                key={weekday}
+                scope="col"
+                className="pb-0.5 text-[10px] font-medium text-[color:var(--text-muted)]"
+              >
+                {weekday}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {grid.weeks.map((week) => (
+            <tr key={week[0].date}>
+              {week.map((cell) => {
+                const isSelected = cell.date === selectedDate
+                const isToday = cell.date === today
+                return (
+                  <td key={cell.date} className="p-0">
+                    <button
+                      type="button"
+                      aria-label={formatDayLabel(cell.date)}
+                      aria-current={isToday ? 'date' : undefined}
+                      aria-pressed={isSelected}
+                      onClick={() => navigate({ kind: 'daily', date: cell.date })}
+                      className={cn(
+                        'relative mx-auto flex size-7 items-center justify-center rounded-md text-xs tabular-nums',
+                        cell.inMonth
+                          ? 'text-[color:var(--text)]'
+                          : 'text-[color:var(--text-muted)]',
+                        isSelected
+                          ? 'bg-[var(--accent)] font-semibold text-white'
+                          : 'hover:bg-black/5 dark:hover:bg-white/5',
+                        isToday && !isSelected
+                          ? 'font-semibold text-[color:var(--accent)]'
+                          : null,
+                      )}
+                    >
+                      {Number(cell.date.slice(8, 10))}
+                      {noted.has(cell.date) ? (
+                        <span
+                          aria-hidden
+                          data-testid={`note-dot-${cell.date}`}
+                          className={cn(
+                            'absolute bottom-0.5 size-1 rounded-full',
+                            isSelected ? 'bg-white/80' : 'bg-[var(--accent)]',
+                          )}
+                        />
+                      ) : null}
+                    </button>
+                  </td>
+                )
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/apps/desktop/src/components/daily-sidebar/day-related-notes.tsx
+++ b/apps/desktop/src/components/daily-sidebar/day-related-notes.tsx
@@ -1,0 +1,58 @@
+import type { ReactElement } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { dailyPath, hasBridge, relatedNotes } from '@reflect/core'
+import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
+import { useGraph } from '@/providers/graph-provider'
+import { routeForPath } from '@/routing/route'
+import { useRouter } from '@/routing/router'
+import { SidebarSection } from './sidebar-section'
+
+interface DayRelatedNotesProps {
+  /** The day whose semantic neighbors to show (validated ISO date). */
+  date: string
+}
+
+/**
+ * Semantic neighbors of the day's note (the old app's "similar notes"),
+ * seeded by the note's stored chunk vectors. Renders nothing at all when
+ * there are no results — semantic search may be disabled or the day not yet
+ * embedded, and an empty box would just advertise a missing feature.
+ */
+export function DayRelatedNotes({ date }: DayRelatedNotesProps): ReactElement | null {
+  const { navigate } = useRouter()
+  const { graph } = useGraph()
+  const path = dailyPath(date)
+  const { data } = useQuery({
+    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'related', path],
+    queryFn: () => relatedNotes(path),
+    enabled: hasBridge() && graph !== null,
+  })
+
+  const related = data ?? []
+  if (related.length === 0) {
+    return null
+  }
+
+  return (
+    <SidebarSection storageKey="related" title="Related" count={related.length}>
+      <ul className="space-y-0.5">
+        {related.map((hit) => (
+          <li key={hit.path}>
+            <button
+              type="button"
+              onClick={() => navigate(routeForPath(hit.path))}
+              className="w-full rounded px-2 py-1 text-left hover:bg-black/5 dark:hover:bg-white/5"
+            >
+              <span className="block truncate text-sm font-medium">{hit.title}</span>
+              {hit.snippet !== '' ? (
+                <span className="block truncate text-xs text-[color:var(--text-muted)]">
+                  {hit.snippet}
+                </span>
+              ) : null}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </SidebarSection>
+  )
+}

--- a/apps/desktop/src/components/daily-sidebar/sidebar-route.test.ts
+++ b/apps/desktop/src/components/daily-sidebar/sidebar-route.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { dailySidebarDate } from './sidebar-route'
+
+const TODAY = '2026-06-09'
+
+describe('dailySidebarDate', () => {
+  it('follows the live clock on the today route', () => {
+    expect(dailySidebarDate({ kind: 'today' }, TODAY)).toBe(TODAY)
+  })
+
+  it('uses the route date on valid daily routes', () => {
+    expect(dailySidebarDate({ kind: 'daily', date: '2026-06-01' }, TODAY)).toBe('2026-06-01')
+  })
+
+  it('anchors malformed daily dates to today, matching the stream', () => {
+    expect(dailySidebarDate({ kind: 'daily', date: '2026-02-31' }, TODAY)).toBe(TODAY)
+    expect(dailySidebarDate({ kind: 'daily', date: 'not-a-date' }, TODAY)).toBe(TODAY)
+  })
+
+  it('shows no daily sidebar on note, search, and settings routes', () => {
+    expect(dailySidebarDate({ kind: 'note', path: 'notes/a.md' }, TODAY)).toBeNull()
+    expect(dailySidebarDate({ kind: 'search', query: 'rust' }, TODAY)).toBeNull()
+    expect(dailySidebarDate({ kind: 'settings' }, TODAY)).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/daily-sidebar/sidebar-route.ts
+++ b/apps/desktop/src/components/daily-sidebar/sidebar-route.ts
@@ -1,0 +1,22 @@
+import { isIsoDate } from '@/lib/dates'
+import type { Route } from '@/routing/route'
+
+/**
+ * The day the daily context sidebar describes for `route`, or `null` when the
+ * route gets no daily sidebar. Mirrors `RouteContent`'s anchoring exactly: the
+ * `today` route follows the live clock, a malformed `daily/:date` anchors to
+ * today (the stream does the same instead of crashing), and `note`, `search`,
+ * and `settings` routes show no daily-only context.
+ */
+export function dailySidebarDate(route: Route, today: string): string | null {
+  switch (route.kind) {
+    case 'today':
+      return today
+    case 'daily':
+      return isIsoDate(route.date) ? route.date : today
+    case 'note':
+    case 'search':
+    case 'settings':
+      return null
+  }
+}

--- a/apps/desktop/src/components/daily-sidebar/sidebar-section.tsx
+++ b/apps/desktop/src/components/daily-sidebar/sidebar-section.tsx
@@ -1,0 +1,59 @@
+import { useState, type ReactElement, type ReactNode } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+
+interface SidebarSectionProps {
+  /** Session-storage key suffix persisting this section's open state. */
+  storageKey: string
+  title: string
+  /** Optional count rendered after the title (e.g. backlink total). */
+  count?: number
+  children: ReactNode
+}
+
+const STORAGE_PREFIX = 'reflect.daily-sidebar.'
+
+function readOpenState(storageKey: string): boolean {
+  return window.sessionStorage.getItem(STORAGE_PREFIX + storageKey) !== 'closed'
+}
+
+/**
+ * One collapsible sidebar section (the old app's `SidebarItem` shape): a
+ * header row with a disclosure chevron, open by default, open/closed state
+ * persisted per section for the session so a collapsed section stays
+ * collapsed while navigating between days.
+ */
+export function SidebarSection({
+  storageKey,
+  title,
+  count,
+  children,
+}: SidebarSectionProps): ReactElement {
+  const [open, setOpen] = useState(() => readOpenState(storageKey))
+
+  const toggle = (): void => {
+    const next = !open
+    setOpen(next)
+    window.sessionStorage.setItem(STORAGE_PREFIX + storageKey, next ? 'open' : 'closed')
+  }
+
+  const Chevron = open ? ChevronDown : ChevronRight
+  return (
+    <section className="border-b border-black/5 py-1 dark:border-white/5">
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={open}
+        className="flex w-full items-center gap-1 rounded px-2 py-1.5 text-left hover:bg-black/5 dark:hover:bg-white/5"
+      >
+        <Chevron aria-hidden className="size-3 text-[color:var(--text-muted)]" />
+        <span className="text-xs font-medium uppercase tracking-wide text-[color:var(--text-muted)]">
+          {title}
+        </span>
+        {count !== undefined && count > 0 ? (
+          <span className="text-xs tabular-nums text-[color:var(--text-muted)]">{count}</span>
+        ) : null}
+      </button>
+      {open ? <div className="px-2 pb-2">{children}</div> : null}
+    </section>
+  )
+}

--- a/apps/desktop/src/components/graph-workspace.tsx
+++ b/apps/desktop/src/components/graph-workspace.tsx
@@ -5,6 +5,8 @@ import { AppShell } from '@/components/app-shell'
 import { CommandPalette } from '@/components/command-palette/command-palette'
 import { EmbeddingsSync } from '@/components/embeddings-sync'
 import { PaletteProvider, usePalette } from '@/components/command-palette/palette-provider'
+import { DailyContextSidebar } from '@/components/daily-sidebar/daily-context-sidebar'
+import { dailySidebarDate } from '@/components/daily-sidebar/sidebar-route'
 import { DailyStream } from '@/components/daily-stream'
 import { NotePane } from '@/components/note-pane'
 import { SettingsScreen } from '@/components/settings-screen'
@@ -48,9 +50,13 @@ export function GraphWorkspace({ graph }: GraphWorkspaceProps): ReactElement {
 function WorkspaceContent({ graph }: GraphWorkspaceProps): ReactElement {
   const { resolvedTheme, setTheme } = useTheme()
   const { indexing } = useGraph()
-  const { navigate } = useRouter()
+  const { navigate, route } = useRouter()
   const version = useAppVersion()
   const commandContext = useAppShortcuts()
+  const today = useToday()
+  // Daily routes get the contextual sidebar; note/search/settings routes get
+  // none (the AppShell collapses the region entirely when sidebar is absent).
+  const sidebarDate = dailySidebarDate(route, today)
 
   const toggleTheme = useCallback((): void => {
     setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')
@@ -64,7 +70,7 @@ function WorkspaceContent({ graph }: GraphWorkspaceProps): ReactElement {
         <span className="text-xs font-semibold text-[color:var(--text-secondary)]">R</span>
       }
       sidebar={
-        <div className="p-4 text-sm text-[color:var(--text-secondary)]">Context</div>
+        sidebarDate !== null ? <DailyContextSidebar date={sidebarDate} /> : undefined
       }
     >
       <div className="flex h-full flex-col">

--- a/apps/desktop/src/lib/month-grid.test.ts
+++ b/apps/desktop/src/lib/month-grid.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { addMonths, buildMonthGrid, monthLabel, monthOf, weekdayLabels } from './month-grid'
+
+describe('monthOf', () => {
+  it('extracts the YYYY-MM month of an ISO date', () => {
+    expect(monthOf('2026-06-09')).toBe('2026-06')
+    expect(monthOf('1999-12-31')).toBe('1999-12')
+  })
+})
+
+describe('monthLabel', () => {
+  it('formats a human month label', () => {
+    expect(monthLabel('2026-06')).toBe('June 2026')
+    expect(monthLabel('2026-01')).toBe('January 2026')
+  })
+})
+
+describe('addMonths', () => {
+  it('moves across year boundaries in both directions', () => {
+    expect(addMonths('2026-12', 1)).toBe('2027-01')
+    expect(addMonths('2026-01', -1)).toBe('2025-12')
+    expect(addMonths('2026-06', 0)).toBe('2026-06')
+  })
+})
+
+describe('weekdayLabels', () => {
+  it('returns seven labels starting on Monday', () => {
+    const labels = weekdayLabels()
+    expect(labels).toHaveLength(7)
+    expect(labels[0]).toBe('Mo')
+    expect(labels[6]).toBe('Su')
+  })
+})
+
+describe('buildMonthGrid', () => {
+  it('pads the month to full Monday-first weeks', () => {
+    // June 2026 starts on a Monday and ends on a Tuesday.
+    const grid = buildMonthGrid('2026-06')
+    expect(grid.start).toBe('2026-06-01')
+    expect(grid.end).toBe('2026-07-05')
+    expect(grid.weeks).toHaveLength(5)
+    for (const week of grid.weeks) {
+      expect(week).toHaveLength(7)
+    }
+  })
+
+  it('flags leading and trailing fill days as outside the month', () => {
+    // August 2026 starts on a Saturday.
+    const grid = buildMonthGrid('2026-08')
+    expect(grid.start).toBe('2026-07-27')
+    expect(grid.weeks[0].slice(0, 5).every((cell) => !cell.inMonth)).toBe(true)
+    expect(grid.weeks[0][5]).toEqual({ date: '2026-08-01', inMonth: true })
+    const lastWeek = grid.weeks[grid.weeks.length - 1]
+    expect(lastWeek[0]).toEqual({ date: '2026-08-31', inMonth: true })
+    expect(lastWeek.slice(1).every((cell) => !cell.inMonth)).toBe(true)
+  })
+
+  it('covers every day of the month exactly once', () => {
+    const grid = buildMonthGrid('2026-02')
+    const inMonth = grid.weeks.flat().filter((cell) => cell.inMonth)
+    expect(inMonth).toHaveLength(28)
+    expect(new Set(inMonth.map((cell) => cell.date)).size).toBe(28)
+  })
+
+  it('rejects malformed months', () => {
+    expect(() => buildMonthGrid('2026-13')).toThrow(/YYYY-MM/)
+    expect(() => buildMonthGrid('June')).toThrow(/YYYY-MM/)
+  })
+})

--- a/apps/desktop/src/lib/month-grid.ts
+++ b/apps/desktop/src/lib/month-grid.ts
@@ -1,0 +1,99 @@
+import {
+  addDays,
+  addMonths as addMonthsToDate,
+  endOfMonth,
+  endOfWeek,
+  format,
+  isValid,
+  parse,
+  startOfMonth,
+  startOfWeek,
+} from 'date-fns'
+import { addDaysIso } from './dates'
+
+/**
+ * Pure month-grid math for the daily sidebar's calendar (no DOM, no queries).
+ * Months are `YYYY-MM` strings and days are ISO `YYYY-MM-DD` strings — the
+ * same local-calendar contract as `lib/dates`. Weeks start on Monday (ISO
+ * 8601), matching the chronological-spine framing of the daily stream.
+ */
+
+const MONTH_FORMAT = 'yyyy-MM'
+const ISO_DATE_FORMAT = 'yyyy-MM-dd'
+const WEEK_STARTS_ON = 1
+
+/** One cell of the calendar grid. */
+export interface MonthGridCell {
+  /** ISO date of the cell. */
+  date: string
+  /** Whether the cell belongs to the grid's month (vs. leading/trailing fill). */
+  inMonth: boolean
+}
+
+/** A month rendered as full weeks, padded with adjacent-month days. */
+export interface MonthGrid {
+  /** The grid's month as `YYYY-MM`. */
+  month: string
+  /** Rows of seven cells, oldest week first. */
+  weeks: MonthGridCell[][]
+  /** ISO date of the first cell (for range queries over the visible grid). */
+  start: string
+  /** ISO date of the last cell (inclusive). */
+  end: string
+}
+
+function parseMonth(month: string): Date {
+  const parsed = parse(month, MONTH_FORMAT, new Date())
+  if (!isValid(parsed)) {
+    throw new Error(`expected a YYYY-MM month, got: ${month}`)
+  }
+  return parsed
+}
+
+/** The `YYYY-MM` month containing the ISO `date`. */
+export function monthOf(date: string): string {
+  return date.slice(0, 7)
+}
+
+/** Human label for a `YYYY-MM` month, e.g. `June 2026`. */
+export function monthLabel(month: string): string {
+  return format(parseMonth(month), 'MMMM yyyy')
+}
+
+/** The `YYYY-MM` month `delta` months after `month` (negative for before). */
+export function addMonths(month: string, delta: number): string {
+  return format(addMonthsToDate(parseMonth(month), delta), MONTH_FORMAT)
+}
+
+/** Two-letter weekday labels for the grid's header row, Monday first. */
+export function weekdayLabels(): string[] {
+  const weekStart = startOfWeek(new Date(), { weekStartsOn: WEEK_STARTS_ON })
+  return [...Array(7).keys()].map((dayOffset) =>
+    format(addDays(weekStart, dayOffset), 'EEEEEE'),
+  )
+}
+
+/** Build the full-week grid for a `YYYY-MM` month. */
+export function buildMonthGrid(month: string): MonthGrid {
+  const monthStart = startOfMonth(parseMonth(month))
+  const gridStart = format(
+    startOfWeek(monthStart, { weekStartsOn: WEEK_STARTS_ON }),
+    ISO_DATE_FORMAT,
+  )
+  const gridEnd = format(
+    endOfWeek(endOfMonth(monthStart), { weekStartsOn: WEEK_STARTS_ON }),
+    ISO_DATE_FORMAT,
+  )
+
+  const weeks: MonthGridCell[][] = []
+  let cursor = gridStart
+  while (cursor <= gridEnd) {
+    const week: MonthGridCell[] = []
+    for (let day = 0; day < 7; day += 1) {
+      week.push({ date: cursor, inMonth: monthOf(cursor) === month })
+      cursor = addDaysIso(cursor, 1)
+    }
+    weeks.push(week)
+  }
+  return { month, weeks, start: gridStart, end: gridEnd }
+}

--- a/docs/daily-context-sidebar/final-report.md
+++ b/docs/daily-context-sidebar/final-report.md
@@ -1,0 +1,98 @@
+# Daily context sidebar — final report
+
+## PR
+
+- **URL:** https://github.com/team-reflect/reflect-open/pull/24
+- **Branch:** `feat/daily-context-sidebar-20260609-2235` → `master`
+- **Base:** `master` @ `4fe1dc859e6cb79c58244a8a0c1d5985d207df1a`
+- **Implementation commit:** `579635646dc1435c11286487dfabb35deceeb556`
+  (a follow-up docs commit adds this report)
+
+## What shipped
+
+A contextual right-hand sidebar for daily-note routes, modeled on old
+Reflect's `note-context-sidebar` and built natively on Reflect Open's typed
+router, TanStack Query index reads, and design tokens. Daily routes (`today`,
+`daily/:date`) fill the existing `AppShell` right region; `note`, `search`,
+and `settings` routes render no sidebar.
+
+Sections: day header (prev/next day, Today badge, "Go to today" with the
+real ⌘D binding-derived hint) · month calendar with note-dot markers and
+day/month navigation · "Linked from" backlinks with snippets and
+loading/error/empty states · "Related" semantic neighbors (rendered only
+with real results) — all in collapsible, session-persisted sections.
+
+## Files changed (by theme)
+
+**Core index query**
+- `packages/core/src/indexing/queries.ts` — new `dailyDatesInRange(start, end)`
+- `packages/core/src/indexing/index.ts`, `packages/core/src/index.ts` — exports
+- `packages/core/src/indexing/queries.test.ts` — new (fake-bridge test)
+
+**Desktop helpers**
+- `apps/desktop/src/lib/month-grid.ts` — Monday-first full-week month grids,
+  month math, weekday labels (+ `month-grid.test.ts`)
+
+**Sidebar components** (`apps/desktop/src/components/daily-sidebar/`)
+- `sidebar-route.ts` — `dailySidebarDate(route, today)` route contract
+  (+ `sidebar-route.test.ts`)
+- `daily-context-sidebar.tsx` — composition + day header
+- `day-calendar.tsx` — month grid, note dots, navigation
+- `day-backlinks.tsx` — "Linked from" section
+- `day-related-notes.tsx` — "Related" section
+- `sidebar-section.tsx` — collapsible section primitive
+- `daily-context-sidebar.test.tsx` — component behavior suite
+
+**Wiring**
+- `apps/desktop/src/components/graph-workspace.tsx` — route→sidebar in the
+  `AppShell` slot (replaces the static "Context" placeholder)
+
+**Docs**
+- `docs/daily-context-sidebar/{plan,status,final-report}.md`
+
+## Verification
+
+| Command | Result |
+| --- | --- |
+| `pnpm install --frozen-lockfile` | ok (worktree had no node_modules) |
+| `pnpm typecheck` | pass (core, db, desktop) |
+| `pnpm lint` | pass (oxlint, no findings) |
+| `pnpm test` | pass — desktop 34 files / 210 tests; core + db suites |
+| `pnpm build` | pass (pre-existing >500 kB chunk warning only) |
+
+## Tests added (25)
+
+- `queries.test.ts` (2): compiled SQL + inclusive bounds for
+  `dailyDatesInRange`; empty range.
+- `month-grid.test.ts` (8): month math across year boundaries, Monday-first
+  padding, fill-day flags, exact month coverage, malformed-month rejection.
+- `sidebar-route.test.ts` (4): today/daily/malformed-daily/no-sidebar routes.
+- `daily-context-sidebar.test.tsx` (11): Today badge vs ⌘D "Go to today",
+  adjacent-day nav, note-dot markers + range query, day-click navigation,
+  month paging and re-anchoring on selection change, backlink empty state and
+  list navigation, Related gating (hidden empty / shown with hits), section
+  collapse + session persistence.
+
+## Browser/screenshot notes
+
+Not feasible in this environment: the workspace only mounts behind the Tauri
+IPC bridge, and `pnpm tauri dev` requires a cold Rust build plus a native
+file-dialog interaction to open a graph — not drivable headlessly, and the
+dev app would share config/recents with other active sessions on this
+machine. Behavior is covered by the jsdom suites above; layout risk is low
+because the sidebar reuses the pre-existing `AppShell` `aside`
+(`w-80`, `hidden lg:block`), which already yields to the editor below the
+`lg` breakpoint.
+
+## Caveats / follow-ups
+
+- Calendar dots mark *indexed* daily notes; a daily file emptied after its
+  first write keeps its dot until the index drops the row.
+- Deferred old-app features (documented in `plan.md`): calendar meetings,
+  public URL/share, suggest-contact, pin/delete/history actions,
+  suggested-backlink accept/ignore.
+- Week start is fixed to Monday; old Reflect made it a preference — a future
+  settings candidate.
+- A real-window UX pass (Tauri dev) is worth doing when a human can drive it:
+  verify sidebar scroll independence and dark-mode contrast of the accent
+  dot/selected-day styles.

--- a/docs/daily-context-sidebar/plan.md
+++ b/docs/daily-context-sidebar/plan.md
@@ -1,0 +1,144 @@
+# Daily context sidebar — plan
+
+Add a contextual right-hand sidebar for the daily-note experience, filling the
+`AppShell` sidebar slot that has been a placeholder since Plan 06. Product/UX
+inspiration comes from the original Reflect app's note context sidebar.
+
+## Old Reflect observations (read-only reference repo)
+
+From `/Users/cloud/repos/team-reflect/reflect`:
+
+- `components/note-context-sidebar/note-context-sidebar.tsx` (lines 16–40)
+  stacks sections top-to-bottom: **calendar** (daily notes only), **note
+  actions**, **public URL**, **suggest contact**, **events/meetings**
+  (Google-credential-gated, daily only), **suggested backlinks**, **similar
+  notes**.
+- `components/sidebar-item/sidebar-item.tsx` — every section is a collapsible
+  unit: title, chevron (hidden until hover), open/close state persisted in
+  session storage per section key.
+- `components/note-context-sidebar/note-calendar/` — month grid
+  (`@veccu/react-calendar`), prev/next month chevrons, "today" affordance
+  (⌘D), selected day highlighted, **dot markers on days that have a non-empty
+  daily note** (`noteStore.hasNonEmptyNoteForDate`), configurable week start.
+- `components/note-context-sidebar/note-meetings/note-meetings.tsx` — renders
+  only with calendar credentials and on daily notes; hidden when empty.
+- `components/note-context-sidebar/note-similar-notes/note-similar-notes.tsx`
+  — up to 5 vector-search neighbors; section hidden when empty.
+- `components/note-context-sidebar/note-suggested-backlinks/` — alias keyword
+  matches with accept/ignore/add-all; only when the editor has focus.
+- `components/note-incoming-backlinks/` — backlinks live *under the note*,
+  not in the sidebar, with per-source grouping and snippets.
+- `client/screens/main/main-shortcuts.tsx` — ⌘D jumps to today; no top-level
+  sidebar toggle (sidebar is always present, sections collapse individually).
+
+Takeaways: sections are individually gated by real data availability and
+hidden when empty; the calendar is the daily-note anchor; everything is quiet,
+compact, and list-shaped.
+
+## Reflect Open layout/data opportunities
+
+- `apps/desktop/src/components/app-shell.tsx:31-38` — right `aside` region
+  already exists (`w-80`, hidden below `lg`); renders only when `sidebar` is
+  passed. No new layout frame needed.
+- `apps/desktop/src/components/graph-workspace.tsx:66-68` — currently passes a
+  static `Context` placeholder for **all** routes; this is the wiring point.
+- Typed routes (`apps/desktop/src/routing/route.ts`): `today`, `daily/:date`,
+  `note`, `search`, `settings`. The daily stream anchors to
+  `route.date` (validated by `isIsoDate`) or live `today`.
+- Index data available today (`@reflect/core`):
+  - `getBacklinksWithContext(path)` — backlinks + snippets (Plan 07).
+  - `relatedNotes(path)` — semantic neighbors from stored vectors (Plan 09);
+    returns `[]` when embeddings are off/not built.
+  - `notes.dailyDate` column — can answer "which days in a range have a daily
+    note" with a tiny new query; freshness rides the existing index
+    invalidation scope (`INDEX_QUERY_SCOPE` + `invalidateIndexQueries`).
+- Real keyboard shortcuts to hint: ⌘D = `nav.today`
+  (`apps/desktop/src/lib/commands/app-commands.ts`).
+- Design system: tokens (`--text-*`, `--accent`, `--accent-soft`, `--border`,
+  `--surface-*`), Tailwind v4, lucide icons — match existing panels
+  (`backlinks-panel.tsx`, `related-notes.tsx`).
+
+## Selected MVP (this PR)
+
+A `DailyContextSidebar` rendered in the `AppShell` sidebar slot **only on
+`today` and `daily` routes**, describing the navigated day:
+
+1. **Day header** — weekday/date label for the target day, "Today" badge.
+2. **Calendar** — compact month grid: prev/next month, weekday header row,
+   dot markers on days with an indexed daily note (new core query
+   `dailyDatesInRange`), selected day + today highlighted, click to navigate
+   to that day, "Today" button with real ⌘D hint. Week starts Monday.
+3. **Linked from** — backlinks into the day's note via
+   `getBacklinksWithContext(dailyPath(date))`, with count, snippets,
+   click-to-navigate, and a graceful empty state.
+4. **Related** — semantic neighbors via `relatedNotes(dailyPath(date))`;
+   section hidden entirely when there are no vectors/results (old-app
+   behavior — no misleading empty box when the feature is off).
+
+Collapsible sections (`SidebarSection`) with per-section open state persisted
+in session storage, mirroring old Reflect's `SidebarItem`.
+
+### Deferred old-app features (not faked)
+
+- **Events/meetings** — requires Google Calendar credentials/integration;
+  Reflect Open has no credential store or calendar bridge. Follow-up.
+- **Public URL / share / publish** — no publishing backend by design (no
+  Reflect-hosted APIs). Out of scope.
+- **Suggest contact** — CRM features don't exist here. Out of scope.
+- **Note actions (pin/delete/history/export)** — no pin model or trash for
+  daily notes in Reflect Open yet; old app hid delete for dailies anyway.
+  Follow-up when those models exist.
+- **Suggested backlinks (accept/ignore)** — needs ignored-suggestion
+  persistence and editor insertion; `relatedNotes` covers discovery for now.
+
+## Architecture
+
+```
+packages/core/src/indexing/queries.ts   + dailyDatesInRange(start, end)
+apps/desktop/src/lib/month-grid.ts      pure month-grid/date helpers
+apps/desktop/src/components/daily-sidebar/
+  sidebar-route.ts                      dailySidebarDate(route, today) → date | null
+  daily-context-sidebar.tsx             composition (header + sections)
+  sidebar-section.tsx                   collapsible section primitive
+  day-calendar.tsx                      month grid + day/today navigation
+  day-backlinks.tsx                     "Linked from" section
+  day-related-notes.tsx                 "Related" section (hidden when empty)
+apps/desktop/src/components/graph-workspace.tsx   route → sidebar wiring
+```
+
+Notes:
+
+- `dailySidebarDate` mirrors `RouteContent`'s anchoring exactly (malformed
+  daily date ⇒ today; `note`/`search`/`settings` ⇒ no sidebar). `search`
+  deliberately shows no sidebar: it's a modal palette over the stream and the
+  sidebar would imply day context the user didn't navigate to.
+- All index reads go through TanStack Query under `INDEX_QUERY_SCOPE` with the
+  graph root in the key, matching `backlinks-panel.tsx` — freshness is
+  event-driven via the existing invalidation hook.
+- The sidebar lives outside the editor focus path; no keybindings are added or
+  intercepted, so keyboard behavior is unchanged.
+
+## Acceptance criteria
+
+- `today` and `daily/:date` routes show the contextual sidebar in the app
+  shell; `note`, `search`, and `settings` routes show none.
+- Malformed `daily/:date` routes anchor the sidebar to today (same as the
+  stream) instead of crashing.
+- Calendar: navigates on day click, marks days with notes, prev/next month
+  works across year boundaries, Today button returns to the `today` route,
+  ⌘D hint matches the real binding.
+- Backlinks section lists sources + snippets and navigates on click; shows a
+  quiet empty state when the day has no inbound links.
+- Related section appears only with real results.
+- Empty/loading states are styled with design tokens; no mock data anywhere.
+- Tests cover: route→sidebar-date contract, month-grid helpers,
+  `dailyDatesInRange`, and sidebar rendering/navigation/empty states.
+
+## Verification plan
+
+- `pnpm typecheck`, `pnpm lint`, `pnpm test` (vitest, targeted suites),
+  `pnpm build`.
+- UI: `pnpm tauri dev` if the native shell builds in this environment —
+  inspect today route, navigate days via calendar, narrow the window below
+  `lg` to confirm the sidebar yields to the editor. If Tauri can't run here,
+  document the blocker and rely on jsdom tests + `pnpm dev` static review.

--- a/docs/daily-context-sidebar/status.md
+++ b/docs/daily-context-sidebar/status.md
@@ -39,6 +39,7 @@ Updated: 2026-06-09
   tests; the sidebar reuses the `AppShell` region that already collapses
   below the `lg` breakpoint, so narrow viewports keep the editor full-width.
 
-## Next
+## Shipped
 
-- Final report, commit, push, PR against `master`.
+- PR: https://github.com/team-reflect/reflect-open/pull/24
+- Implementation commit `5796356`; see `final-report.md` for the full record.

--- a/docs/daily-context-sidebar/status.md
+++ b/docs/daily-context-sidebar/status.md
@@ -1,0 +1,44 @@
+# Daily context sidebar — status
+
+Updated: 2026-06-09
+
+## Done
+
+- Surveyed old Reflect's `note-context-sidebar` (calendar, actions, meetings,
+  suggested backlinks, similar notes, `SidebarItem` collapsibles) and mapped
+  it against Reflect Open's layout/data — see `plan.md`.
+- Core: `dailyDatesInRange(start, end)` query over `notes.dailyDate`
+  (`packages/core/src/indexing/queries.ts`), exported through
+  `indexing/index.ts` and the package root; covered by
+  `queries.test.ts` against the fake IPC bridge.
+- Desktop helpers: `lib/month-grid.ts` (Monday-first full-week grids,
+  month math, weekday labels) and
+  `components/daily-sidebar/sidebar-route.ts` (`dailySidebarDate` route →
+  sidebar-day contract).
+- Sidebar components under `components/daily-sidebar/`:
+  `daily-context-sidebar.tsx` (header with adjacent-day nav, Today badge /
+  "Go to today" with the real ⌘D hint), `day-calendar.tsx` (month grid, note
+  dots, day navigation), `day-backlinks.tsx` ("Linked from" with
+  loading/error/empty states), `day-related-notes.tsx` (hidden when no
+  results), `sidebar-section.tsx` (collapsible, session-persisted).
+- Wired into `graph-workspace.tsx`: daily routes render the sidebar in the
+  existing `AppShell` right region; note/search/settings render none.
+- Tests: 23 new desktop tests + 2 core tests, all passing.
+
+## Verification
+
+- `pnpm typecheck` — pass (core, db, desktop).
+- `pnpm lint` — pass (oxlint, no findings).
+- `pnpm test` — pass: desktop 34 files / 210 tests (23 new), core suite
+  including the new `queries.test.ts`.
+- `pnpm build` — pass (pre-existing >500 kB chunk warning only).
+- Native UI run blocked: `pnpm tauri dev` needs a cold Rust build plus a
+  native file-dialog interaction to open a graph, neither drivable headlessly
+  in this environment; a plain-browser `pnpm dev` has no IPC bridge, so the
+  workspace (and sidebar) can't mount. Covered instead by jsdom component
+  tests; the sidebar reuses the `AppShell` region that already collapses
+  below the `lg` breakpoint, so narrow viewports keep the editor full-width.
+
+## Next
+
+- Final report, commit, push, PR against `master`.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -140,6 +140,7 @@ export {
   indexNote,
   rebuildIndex,
   reconcileIndex,
+  dailyDatesInRange,
   getBacklinks,
   getBacklinksWithContext,
   getLinkSources,

--- a/packages/core/src/indexing/index.ts
+++ b/packages/core/src/indexing/index.ts
@@ -33,6 +33,7 @@ export {
 } from './indexed-note'
 export { indexNote, rebuildIndex, reconcileIndex, type IndexPassOptions } from './indexer'
 export {
+  dailyDatesInRange,
   getBacklinks,
   getBacklinksWithContext,
   getLinkSources,

--- a/packages/core/src/indexing/queries.test.ts
+++ b/packages/core/src/indexing/queries.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { setBridge } from '../ipc/bridge'
+import { dailyDatesInRange } from './queries'
+
+// A fake bridge resolves `db_query` so the test exercises the real compiled
+// SQL (snake_case columns, range parameters) — the same harness pipeline.test
+// uses for the indexer.
+const mockInvoke = vi.fn<(command: string, args: Record<string, unknown>) => Promise<unknown>>()
+setBridge({ invoke: mockInvoke, listen: async () => () => {} })
+
+beforeEach(() => {
+  mockInvoke.mockReset()
+})
+
+describe('dailyDatesInRange', () => {
+  it('queries the notes daily_date column with inclusive bounds', async () => {
+    mockInvoke.mockResolvedValue([
+      { daily_date: '2026-06-01' },
+      { daily_date: '2026-06-09' },
+    ])
+
+    const dates = await dailyDatesInRange('2026-06-01', '2026-06-30')
+
+    expect(dates).toEqual(['2026-06-01', '2026-06-09'])
+    const [command, args] = mockInvoke.mock.calls[0]
+    expect(command).toBe('db_query')
+    const sql = String(args.sql)
+    expect(sql).toContain('daily_date')
+    expect(sql).toContain('is not null')
+    expect(args.params).toEqual(['2026-06-01', '2026-06-30'])
+  })
+
+  it('returns an empty list when no daily notes exist in the range', async () => {
+    mockInvoke.mockResolvedValue([])
+    await expect(dailyDatesInRange('2025-01-01', '2025-01-31')).resolves.toEqual([])
+  })
+})

--- a/packages/core/src/indexing/queries.ts
+++ b/packages/core/src/indexing/queries.ts
@@ -184,6 +184,23 @@ export async function getNote(path: string): Promise<NoteRow | undefined> {
   return row ? { ...row, isPrivate: row.isPrivate !== 0 } : undefined
 }
 
+/**
+ * ISO dates within `[start, end]` (inclusive) that have an indexed daily note,
+ * ascending. Daily files are created lazily on first write, so an indexed row
+ * means the day has real content — this powers the calendar's day markers.
+ */
+export async function dailyDatesInRange(start: string, end: string): Promise<string[]> {
+  const rows = await db
+    .selectFrom('notes')
+    .where('dailyDate', 'is not', null)
+    .where('dailyDate', '>=', start)
+    .where('dailyDate', '<=', end)
+    .select('dailyDate')
+    .orderBy('dailyDate')
+    .execute()
+  return rows.flatMap((row) => (row.dailyDate === null ? [] : [row.dailyDate]))
+}
+
 /** Graph-relative paths of every note carrying `tag`, ordered by path. */
 export async function getNotesByTag(tag: string): Promise<string[]> {
   const rows = await db


### PR DESCRIPTION
## Summary

Fills the `AppShell`'s right context region (a placeholder since Plan 06) with a contextual sidebar for the daily-note experience, rendered on `today` and `daily/:date` routes only:

- **Day header** — adjacent-day navigation, a "Today" badge, and a "Go to today" affordance whose ⌘D hint is derived from the real `nav.today` command binding (it disappears if the binding ever does).
- **Calendar** — compact Monday-first month grid with prev/next month paging, today/selected highlighting, click-to-navigate, and dot markers on days that have a daily note, powered by a new `dailyDatesInRange` index query over `notes.daily_date` (freshness rides the existing index-invalidation scope).
- **Linked from** — the day's inbound links with line snippets (same query as the in-note backlinks panel), with quiet loading/error/empty states.
- **Related** — semantic neighbors from stored chunk vectors (Plan 09); the section renders only when real results exist.
- Sections are collapsible with per-section open state persisted for the session, mirroring old Reflect's `SidebarItem`.

`note`, `search`, and `settings` routes render no sidebar (the `AppShell` collapses the region entirely). A malformed `daily/:date` anchors the sidebar to today, exactly matching the daily stream's behavior.

## Old Reflect references

Product/UX modeled on the original app's `components/note-context-sidebar/` (calendar with note dots and a today shortcut, collapsible session-persisted sections, sections hidden when their data source is empty) and `components/sidebar-item/`. Architecture is native to Reflect Open: typed routes, TanStack Query over the SQLite projection, design-system tokens.

## Implemented vs deferred

Implemented: calendar/date navigation, backlinks, related notes, day quick-nav.
Deferred (need integrations/models Reflect Open doesn't have; not faked): calendar meetings (Google credentials), public URL/share (no hosted APIs by design), suggest-contact, pin/delete/history note actions, suggested-backlink accept/ignore flow. Details in `docs/daily-context-sidebar/plan.md`.

## Tests / verification

- New: `queries.test.ts` (core, `dailyDatesInRange` over the fake IPC bridge), `month-grid.test.ts`, `sidebar-route.test.ts`, `daily-context-sidebar.test.tsx` (route contract, calendar dots/paging/re-anchoring, day + today navigation, backlink list/empty state, related-notes gating, collapse persistence) — 25 new tests.
- `pnpm typecheck`, `pnpm lint`, `pnpm test` (34 files / 210 desktop tests + core/db suites), `pnpm build` all pass.

## Caveats

- Native UI pass not run: `pnpm tauri dev` needs a cold Rust build plus a native file dialog to open a graph, which isn't drivable headlessly in this environment; a bridgeless browser `pnpm dev` can't mount the workspace. The sidebar reuses the existing `aside` region (`hidden lg:block w-80`), so narrow viewports keep the editor full-width by construction.
- Calendar dots mark indexed daily notes; a daily file emptied after creation still gets a dot until the index drops it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive UI and a read-only index query; routing mirrors existing daily stream anchoring and is covered by 25 new tests.
> 
> **Overview**
> Replaces the static **Context** placeholder in `AppShell` with a **daily context sidebar** on `today` and `daily/:date` routes only; `note`, `search`, and `settings` leave the right region empty via `dailySidebarDate`.
> 
> The sidebar adds a day header (prev/next day, Today badge or **Go to today** with a ⌘D hint from `nav.today`), a Monday-first month calendar with note dots and click navigation, **Linked from** backlinks (existing index query + snippets), and **Related** semantic neighbors (hidden when empty). Sections collapse with per-section session storage.
> 
> **Core** adds `dailyDatesInRange` over indexed `dailyDate` rows for calendar markers. **Desktop** adds `month-grid` helpers and wires TanStack Query reads under `INDEX_QUERY_SCOPE`. Malformed `daily/:date` anchors the sidebar to today, matching the daily stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 647a46f01fcb67b8749c10eb59ea0f3d169d071b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->