### PR TITLE
Sidebar graph switcher: show graph name only, not full path

### DIFF
--- a/apps/desktop/src/components/sidebar/graph-footer.tsx
+++ b/apps/desktop/src/components/sidebar/graph-footer.tsx
@@ -1,7 +1,6 @@
 import { useState, type ReactElement } from 'react'
 import type { GraphInfo } from '@reflect/core'
 import { Check, ChevronsUpDown, FolderOpen } from 'lucide-react'
-import { cn } from '@/lib/utils'
 import { useGraph } from '@/providers/graph-provider'
 
 /**
@@ -102,15 +101,14 @@ export function GraphFooter({ graph }: { graph: GraphInfo }): ReactElement {
           <span className="block truncate text-[13px] font-medium text-text">
             {graph.name}
           </span>
-          <span
-            role={indexing ? 'status' : undefined}
-            className={cn(
-              'block truncate text-[11px] text-text-muted',
-              indexing && 'motion-safe:animate-pulse',
-            )}
-          >
-            {indexing ? 'Indexing…' : graph.root}
-          </span>
+          {indexing ? (
+            <span
+              role="status"
+              className="block truncate text-[11px] text-text-muted motion-safe:animate-pulse"
+            >
+              Indexing…
+            </span>
+          ) : null}
         </span>
         <ChevronsUpDown
           aria-hidden


### PR DESCRIPTION
## What changed

The graph switcher in the sidebar footer displayed the graph's full filesystem path as a second line under the graph name. This drops the path line — the trigger now shows just the graph name.

- The second line now renders only while indexing, showing the "Indexing…" status.
- The full path is still discoverable via the existing hover tooltip (`title={graph.root}`) on the trigger and on recent-graph menu items.
- Removed the now-unused `cn` import.

## Why

The full path is noisy in a narrow sidebar and usually truncated anyway; the graph name is what identifies the graph.

## Notes for reviewers

`pnpm typecheck` passes. The dropdown menu entries already showed names only, so only the trigger button changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow sidebar presentation change with no auth, data, or API impact; indexing status behavior is preserved.
> 
> **Overview**
> The sidebar **graph switcher** trigger no longer shows the graph’s filesystem path under the name when idle—it only shows the **graph name**, with a second line appearing solely during **indexing** (`Indexing…` with pulse styling).
> 
> Path discovery is unchanged via **`title={graph.root}`** on the trigger (and recent items). The unused **`cn`** helper import was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e0d2ea69401e2b8a6de79e62b4045da9e2d4f7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined the indexing status display in the sidebar—the status indicator now only appears when actively indexing, providing a cleaner interface during normal operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->