### PR TITLE
Daily stream: per-day min-height matching V1 (past 200px, today/future 60vh)

### DIFF
--- a/apps/desktop/src/components/daily-stream.tsx
+++ b/apps/desktop/src/components/daily-stream.tsx
@@ -96,6 +96,10 @@ export function DailyStream({ targetDate }: DailyStreamProps): ReactElement {
         {virtualizer.getVirtualItems().map((item) => {
           const date = dateAtIndex(dayWindow, item.index)
           const isToday = date === today
+          // V1's daily-note sizing: past days hug their content (an empty day
+          // collapses to a short row), while today and future days reserve
+          // most of a viewport of writing room. ISO dates compare lexically.
+          const isPast = date < today
           const autoFocus = focusPending.current === date
           return (
             <div
@@ -119,6 +123,7 @@ export function DailyStream({ targetDate }: DailyStreamProps): ReactElement {
                   lazy
                   autoFocus={autoFocus}
                   onAutoFocused={consumeFocus}
+                  editorClassName={isPast ? 'min-h-[200px]' : 'min-h-[60vh]'}
                 />
               </section>
             </div>

--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -23,6 +23,12 @@ interface NotePaneProps {
   autoFocus?: boolean
   /** Called once the autofocus actually happened (the editor mounted). */
   onAutoFocused?: () => void
+  /**
+   * Extra classes for the editable area (e.g. the daily stream's per-day
+   * `min-h-*`). Applied to the contenteditable root, so the reserved space
+   * is click-to-focus.
+   */
+  editorClassName?: string
 }
 
 /** The seeded title for a brand-new (missing) ordinary note. */
@@ -45,6 +51,7 @@ export function NotePane({
   lazy = false,
   autoFocus = false,
   onAutoFocused,
+  editorClassName,
 }: NotePaneProps): ReactElement {
   const { graph } = useGraph()
   const { settings } = useSettings()
@@ -163,6 +170,7 @@ export function NotePane({
         markMode={settings.editorMarkdownSyntax}
         images={images}
         onWikiLinkClick={onWikiLinkClick}
+        className={editorClassName}
         handleRef={handleRef}
       >
         <WikiAutocomplete onCreate={createFromAutocomplete} />

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -18,6 +18,7 @@ import {
 import { createEditor, defineDocChangeHandler, union, type Editor } from '@prosekit/core'
 import { ProseKit, useExtension } from '@prosekit/react'
 import '@meowdown/core/style.css'
+import { cn } from '@/lib/utils'
 import { defineImages, type ImageOptions } from './images'
 import { defineReflectKeymap } from './keymap'
 import { selectFirstHeadingText } from './title-selection'
@@ -59,6 +60,12 @@ interface NoteEditorProps {
   images?: ImageOptions
   /** Mod+click on a `[[wiki link]]` chip (Plan 06 navigation). */
   onWikiLinkClick?: (target: string) => void
+  /**
+   * Extra classes for the editable root. The mount div *is* the ProseMirror
+   * contenteditable, so e.g. a `min-h-*` here makes the whole reserved area
+   * click-to-focus (the daily stream uses this for per-day sizing).
+   */
+  className?: string
   /** Imperative handle (React 19 ref-as-prop). */
   handleRef?: Ref<NoteEditorHandle>
   /**
@@ -95,6 +102,7 @@ export function NoteEditor({
   markMode = 'focus',
   images,
   onWikiLinkClick,
+  className,
   handleRef,
   children,
 }: NoteEditorProps): ReactElement {
@@ -151,7 +159,7 @@ export function NoteEditor({
 
   return (
     <ProseKit editor={editor}>
-      <div ref={editor.mount} className="reflect-editor" />
+      <div ref={editor.mount} className={cn('reflect-editor', className)} />
       {children}
     </ProseKit>
   )


### PR DESCRIPTION
## What changed

Ports Reflect V1's daily-note sizing behavior to the V2 daily stream:

- **Past days** get `min-h-[200px]` — an empty past day collapses to a short row, and a day with content grows naturally to fit it.
- **Today and future days** get `min-h-[60vh]` — there's always most of a viewport of writing room.

This is exactly V1's rule (`note-item.tsx`: `minHeight: dailyTense === 'past' ? '200px' : '60vh'`). V1 has no explicit has-content check — the content-hugging behavior is emergent from min-height being a floor, not a cap.

## How

- `DailyStream` computes `isPast = date < today` per row (ISO strings compare lexically; `today` is the existing `useToday()` hook, so the rule flips at midnight) and passes the class to `NotePane`.
- `NotePane` gains an optional `editorClassName` prop, forwarded to the editor. The standalone note view doesn't pass it, so ordinary notes are unaffected.
- `NoteEditor` gains an optional `className` merged onto the mount div with `cn()`. That div **is** the ProseMirror contenteditable, so the reserved space is part of the editor — clicking the empty area below the text focuses the note, same as V1 (which also applied the min-height to the editor element rather than a wrapper).

## Notes for review

- The virtualizer already measures rows dynamically (`measureElement`), so the taller today/future rows need no change to its sizing config.
- `pnpm typecheck` passes; `route-content.test.tsx` (the suite covering the daily stream) passes 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Tailwind min-heights on the daily stream; ordinary note editing paths are untouched.
> 
> **Overview**
> Ports Reflect V1 daily-note row sizing into the V2 **daily stream**: **past** days use `min-h-[200px]` so empty rows stay short and content can grow; **today and future** days use `min-h-[60vh]` for a large writing area. `DailyStream` derives `isPast` from lexical ISO date comparison against `useToday()` and passes the class per row.
> 
> **`NotePane`** adds optional `editorClassName`, forwarded to **`NoteEditor`**, which merges an optional `className` onto the ProseMirror mount div via `cn()`. That puts the min-height on the contenteditable root so the reserved space is click-to-focus. Standalone note views omit the prop, so non-stream notes are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fa1356edf8a8ad2fe9fb74427483ce82ff88864. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the note editor to adjust its size based on the viewing context. Past days now display with a compact editor view, while today and future dates show an expanded editor for better note-taking space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->