### PR TITLE
Fix double scrollbar on the settings route

### DIFF
--- a/apps/desktop/src/components/app-shell.tsx
+++ b/apps/desktop/src/components/app-shell.tsx
@@ -15,7 +15,9 @@ interface AppShellProps {
  * The application frame, in the original app's shape: a sunken sidebar beside
  * the raised note pane, no header bar — the document is the chrome. Layout
  * and landmark regions only; what fills the slots (and whether the sidebar
- * shows at all) is the workspace's business.
+ * shows at all) is the workspace's business. The frame never scrolls: every
+ * route mounts its own scroll container, so the center region clips instead
+ * of growing a second scrollbar around a route's own.
  */
 export function AppShell({ sidebar, context, children, className }: AppShellProps): ReactElement {
   return (
@@ -34,7 +36,7 @@ export function AppShell({ sidebar, context, children, className }: AppShellProp
         </aside>
       ) : null}
 
-      <main className="min-w-0 flex-1 overflow-auto bg-surface">{children}</main>
+      <main className="min-w-0 flex-1 overflow-hidden bg-surface">{children}</main>
 
       {context ? (
         <aside

--- a/apps/desktop/src/routing/scroll-restore.tsx
+++ b/apps/desktop/src/routing/scroll-restore.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, type ReactElement, type ReactNode } from 'react'
+import { cn } from '@/lib/utils'
 import { useRouter } from './router'
 
 interface ScrollRestoredProps {
@@ -11,6 +12,11 @@ interface ScrollRestoredProps {
  * it reports its offset as the user scrolls and restores the saved offset when
  * a history entry is revisited via back/forward. The daily stream does the same
  * through its virtualizer; this is for plain views (note, search).
+ *
+ * The container is positioned (`relative`) so absolutely-positioned
+ * descendants — `sr-only` controls especially — resolve against it and scroll
+ * with the content. Without it they escape to the workspace column at their
+ * static offsets, overflowing the frame into a second scrollbar.
  */
 export function ScrollRestored({ className, children }: ScrollRestoredProps): ReactElement {
   const { entryId, saveScrollState, savedScroll } = useRouter()
@@ -28,7 +34,7 @@ export function ScrollRestored({ className, children }: ScrollRestoredProps): Re
   return (
     <div
       ref={ref}
-      className={className}
+      className={cn('relative', className)}
       onScroll={(event) => saveScrollState(event.currentTarget.scrollTop)}
     >
       {children}

--- a/apps/desktop/src/routing/scroll-restore.tsx
+++ b/apps/desktop/src/routing/scroll-restore.tsx
@@ -34,7 +34,7 @@ export function ScrollRestored({ className, children }: ScrollRestoredProps): Re
   return (
     <div
       ref={ref}
-      className={cn('relative', className)}
+      className={cn(className, 'relative')}
       onScroll={(event) => saveScrollState(event.currentTarget.scrollTop)}
     >
       {children}


### PR DESCRIPTION
## What

Settings showed two vertical scrollbars: the route's own scroll container plus a phantom one on the app shell's `<main>`.

- `ScrollRestored` now applies `relative` to itself, making the scroll container the containing block for absolutely-positioned descendants.
- `AppShell`'s center `<main>` moves from `overflow-auto` to `overflow-hidden`, since every route mounts its own scroll container and the frame itself should never scroll.

## Why

The keyboard-shortcuts section renders an `sr-only` label per binding for assistive tech. Tailwind's `sr-only` uses `position: absolute`, and the settings scroller wasn't positioned — so those spans resolved against the nearest positioned ancestor, the workspace column *outside* the scroller. They sat at their static offsets past the fold (scrollHeight 1075 vs clientHeight 720 in a 720px window), invisibly overflowing `<main overflow-auto>` into a second scrollbar.

The `relative` on `ScrollRestored` fixes the escape for the settings and note routes; the `overflow-hidden` on the frame makes the "routes own scrolling" contract explicit so any future escaping absolute element clips instead of resurrecting the double scrollbar. The daily stream is unaffected — its virtualizer content already lives in a `relative` wrapper.

## Verification

- Reproduced and confirmed the fix in a live browser harness mounting the real settings route: `main` overflow drops 1075 → 720 (no outer scrollbar), the inner scroller still scrolls and restores its offset, and no `sr-only` element escapes the container.
- `route-content`, `settings-screen`, and `router` tests pass (24 tests); `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small layout/CSS contract changes in the shell and scroll wrapper; low risk beyond verifying scroll restore and overflow on note/settings routes.
> 
> **Overview**
> Fixes a **double vertical scrollbar** on settings (and note routes) by tightening where scrolling happens and where absolutely positioned a11y nodes are anchored.
> 
> **`AppShell`** center `<main>` switches from `overflow-auto` to **`overflow-hidden`**, documenting that routes own scroll containers and the frame should not grow a second scrollbar.
> 
> **`ScrollRestored`** always merges **`relative`** onto its scroll div so `sr-only` / absolutely positioned descendants (e.g. keyboard shortcut labels) stay inside the route scroller instead of inflating the workspace column past the fold.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c35c282e510c15795bcc13c434745a0a39589af4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected scroll container positioning to properly support absolutely-positioned UI elements within scrollable regions.
  * Optimized center pane scrolling behavior to eliminate redundant scrollbars and ensure each route independently manages scroll containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->