### PR TITLE
macOS inline title bar: overlay style + window drag region

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -14,7 +14,9 @@
       {
         "title": "reflect-open",
         "width": 800,
-        "height": 600
+        "height": 600,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true
       }
     ],
     "security": {

--- a/apps/desktop/src/components/daily-sidebar/daily-context-sidebar.tsx
+++ b/apps/desktop/src/components/daily-sidebar/daily-context-sidebar.tsx
@@ -4,6 +4,8 @@ import { keybindingFor } from '@/lib/commands/app-commands'
 import { formatBindingLabel } from '@/lib/keybindings'
 import { addDaysIso, formatDayLabel } from '@/lib/dates'
 import { useToday } from '@/lib/use-today'
+import { cn } from '@/lib/utils'
+import { hasMacosTitleBarOverlay } from '@/lib/window-chrome'
 import { useRouter } from '@/routing/router'
 import { DayBacklinks } from './day-backlinks'
 import { DayCalendar } from './day-calendar'
@@ -32,7 +34,14 @@ export function DailyContextSidebar({ date }: DailyContextSidebarProps): ReactEl
   const isToday = date === today
 
   return (
-    <div className="flex flex-col px-2 py-2 text-text">
+    <div
+      className={cn(
+        'flex flex-col px-2 pb-2 text-text',
+        // The day-navigation buttons must clear the WindowDragRegion strip
+        // when the macOS title bar is overlaid.
+        hasMacosTitleBarOverlay ? 'pt-7' : 'pt-2',
+      )}
+    >
       <header className="border-b border-black/5 px-1 pb-2 dark:border-white/5">
         <div className="flex items-center justify-between gap-1">
           <button

--- a/apps/desktop/src/components/sidebar/sidebar.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.tsx
@@ -5,6 +5,8 @@ import { keybindingFor } from '@/lib/commands/app-commands'
 import { runCommand } from '@/lib/commands/registry'
 import type { CommandContext } from '@/lib/commands/types'
 import { formatBindingLabel } from '@/lib/keybindings'
+import { hasMacosTitleBarOverlay } from '@/lib/window-chrome'
+import { cn } from '@/lib/utils'
 import { useRouter } from '@/routing/router'
 import { GraphFooter } from './graph-footer'
 import { SidebarItem } from './sidebar-item'
@@ -28,7 +30,14 @@ const SIDEBAR_TOGGLE_BINDING = keybindingFor('sidebar.toggle')
 export function Sidebar({ graph, context }: SidebarProps): ReactElement {
   const { route } = useRouter()
   return (
-    <div className="flex h-full min-h-0 flex-col px-3 pt-2.5 pb-3">
+    <div
+      className={cn(
+        'flex h-full min-h-0 flex-col px-3 pb-3',
+        // With the overlaid macOS title bar, the traffic lights and the
+        // WindowDragRegion strip own the top 28px — start content below them.
+        hasMacosTitleBarOverlay ? 'pt-7' : 'pt-2.5',
+      )}
+    >
       <div className="flex items-center justify-end pb-1.5">
         <button
           type="button"

--- a/apps/desktop/src/components/window-drag-region.tsx
+++ b/apps/desktop/src/components/window-drag-region.tsx
@@ -1,0 +1,21 @@
+import type { ReactElement } from 'react'
+import { hasMacosTitleBarOverlay } from '@/lib/window-chrome'
+
+/**
+ * Invisible strip standing in for the macOS title bar when it's overlaid
+ * (`titleBarStyle: "Overlay"` in tauri.conf.json). Tauri's built-in
+ * `data-tauri-drag-region` handler makes mousedown drag the window and
+ * double-click toggle zoom, matching native title-bar behavior.
+ *
+ * Mouse events on the strip never reach content beneath it, so interactive
+ * elements must stay below its 28px height (`h-7` here, `pt-7` clearance in
+ * the surfaces that need it — see `hasMacosTitleBarOverlay` call sites).
+ * Renders nothing outside the macOS desktop webview, where the native title
+ * bar still exists.
+ */
+export function WindowDragRegion(): ReactElement | null {
+  if (!hasMacosTitleBarOverlay) {
+    return null
+  }
+  return <div aria-hidden data-tauri-drag-region className="fixed inset-x-0 top-0 z-40 h-7" />
+}

--- a/apps/desktop/src/components/workspace-content.tsx
+++ b/apps/desktop/src/components/workspace-content.tsx
@@ -11,6 +11,8 @@ import { OperationsStatus } from '@/components/operations-status'
 import { RouteContent } from '@/components/route-content'
 import { Sidebar } from '@/components/sidebar/sidebar'
 import { useToday } from '@/lib/use-today'
+import { cn } from '@/lib/utils'
+import { hasMacosTitleBarOverlay } from '@/lib/window-chrome'
 import { useSidebar } from '@/providers/sidebar-provider'
 import { useAppShortcuts } from '@/routing/app-shortcuts'
 import { useRouter } from '@/routing/router'
@@ -47,7 +49,12 @@ export function WorkspaceContent({ graph }: WorkspaceContentProps): ReactElement
             aria-label="Show sidebar"
             title="Show sidebar"
             onClick={() => commandContext.toggleSidebar()}
-            className="absolute top-2.5 left-3 z-10 rounded-md p-1 text-text-muted transition-colors duration-100 hover:bg-surface-hover hover:text-text-secondary"
+            className={cn(
+              'absolute left-3 z-10 rounded-md p-1 text-text-muted transition-colors duration-100 hover:bg-surface-hover hover:text-text-secondary',
+              // Clear the overlaid macOS title bar: the traffic lights float
+              // exactly where this button otherwise sits.
+              hasMacosTitleBarOverlay ? 'top-9' : 'top-2.5',
+            )}
           >
             <PanelLeft aria-hidden strokeWidth={1.75} className="size-4" />
           </button>

--- a/apps/desktop/src/lib/window-chrome.ts
+++ b/apps/desktop/src/lib/window-chrome.ts
@@ -1,0 +1,19 @@
+import { isTauri } from '@tauri-apps/api/core'
+
+/**
+ * Whether the window draws content under a transparent macOS title bar
+ * (`titleBarStyle: "Overlay"` in tauri.conf.json), with the traffic lights
+ * floating over the top-left of the webview.
+ *
+ * True only in the macOS desktop webview: plain-browser dev and other
+ * desktop platforms keep their native title bars, and iPadOS — whose user
+ * agent masquerades as macOS — is excluded by the touch-point check.
+ *
+ * Layout that must clear the title-bar zone (the top 28px, `h-7`/`pt-7`)
+ * keys off this; the zone itself is claimed by `WindowDragRegion`.
+ */
+export const hasMacosTitleBarOverlay: boolean =
+  isTauri() &&
+  typeof navigator !== 'undefined' &&
+  navigator.userAgent.includes('Macintosh') &&
+  navigator.maxTouchPoints === 0

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { App } from '@/app'
+import { WindowDragRegion } from '@/components/window-drag-region'
 import { queryClient } from '@/lib/query-client'
 import { registerAppCommands } from '@/lib/commands/app-commands'
 import { installTauriBridge } from '@/lib/tauri-bridge'
@@ -24,6 +25,7 @@ createRoot(rootElement).render(
       <SettingsProvider>
         <ThemeProvider>
           <GraphProvider>
+            <WindowDragRegion />
             <App />
           </GraphProvider>
         </ThemeProvider>


### PR DESCRIPTION
## What

Switches the desktop window to the inline macOS title-bar style — `titleBarStyle: "Overlay"` + `hiddenTitle: true` in `tauri.conf.json`, Tauri's equivalent of Electron's `hiddenInset` — and adds the supporting frontend chrome:

- **`window-drag-region.tsx`** (new): invisible 28px strip fixed across the top of the window with `data-tauri-drag-region`. Tauri's built-in handler gives it native behavior: mousedown drags the window, double-click toggles zoom. Mounted at the root in `main.tsx` so it covers every screen (chooser, workspace, settings). No capability changes needed — `core:default` already grants `start-dragging` / `internal-toggle-maximize`.
- **`window-chrome.ts`** (new): shared `hasMacosTitleBarOverlay` predicate — true only in the macOS desktop webview (`isTauri()` + UA check, with a `maxTouchPoints` guard because iPadOS masquerades as macOS). Plain-browser dev, iOS, and Windows/Linux render no strip and keep their existing layouts.

## Why

The webview now extends to the full window height with the traffic lights floating over content, but the overlaid title bar no longer handles dragging, and the strip swallows clicks beneath it. Three surfaces had interactive content in that top-28px zone and get conditional clearance (no layout change on other platforms):

- `sidebar.tsx` — top padding `pt-2.5` → `pt-7`, so the hide-sidebar button starts below the strip and the traffic lights float over empty sidebar background.
- `workspace-content.tsx` — the collapsed-state "Show sidebar" button moves `top-2.5` → `top-9`; it sat exactly where the traffic lights now float.
- `daily-context-sidebar.tsx` — same `pt-7` clearance for the day-navigation header.

The note pane needed nothing: route content already has 32px top padding, so clicks there now drag the window — the same feel as native `hiddenInset` apps.

## Reviewer notes

- The cloud-sync banner renders flush to the top of the note pane, so its top edge sits in the drag zone: text is fully visible through the transparent strip, but that sliver isn't clickable. It has no buttons today, so it's left alone — worth revisiting if it gains actions.
- Tauri's `Overlay` keeps the traffic lights at the stock position (Electron's `hiddenInset` insets them slightly). If we later want them centered in a taller header, that needs `tauri-plugin-decorum` or a few lines of `NSWindow` code, plus bumping the strip height.
- Verified: `pnpm typecheck` clean; sidebar + daily-context-sidebar tests pass (15/15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop shell and layout-only changes gated to macOS Tauri; no auth, data, or API impact.
> 
> **Overview**
> Enables a **macOS inline title bar** on the Tauri desktop app: `tauri.conf.json` sets `titleBarStyle: "Overlay"` and `hiddenTitle: true` so the webview fills the window and traffic lights float over content.
> 
> Adds **`hasMacosTitleBarOverlay`** (`window-chrome.ts`) so layout only shifts in the macOS Tauri webview (with an iPadOS guard via `maxTouchPoints`). A root-mounted **`WindowDragRegion`** uses `data-tauri-drag-region` for a 28px top strip (drag + double-click zoom) on that platform only.
> 
> **Sidebar**, **daily context sidebar**, and the collapsed **show sidebar** control get extra top spacing when the overlay is active so buttons sit below the drag strip and traffic lights; other platforms keep prior padding/position.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fffec45ac3e40c07cdb21d11ccec203a9aaa973d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced macOS desktop app with native title bar overlay styling and optimized UI spacing adjustments across sidebars and content areas
  * Implemented native window dragging capability on macOS for improved user experience and window management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->