### PR TITLE
Settings: semantic search opt-in with model download progress

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4018,6 +4018,7 @@ dependencies = [
  "base64 0.22.1",
  "dirs",
  "fastembed",
+ "hf-hub",
  "notify",
  "notify-debouncer-full",
  "rusqlite",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -35,6 +35,9 @@ base64 = "0.22.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 fastembed = "5"
+# Direct dependency on fastembed's own downloader, used to pre-fetch the
+# embedding model with byte-level progress (fastembed downloads silently).
+hf-hub = { version = "0.5.0", default-features = false, features = ["ureq", "native-tls"] }
 
 [dev-dependencies]
 tauri = { version = "2", features = ["test"] }

--- a/apps/desktop/src-tauri/src/embed.rs
+++ b/apps/desktop/src-tauri/src/embed.rs
@@ -4,9 +4,13 @@
 //! "unavailable" state (the same recoverable contract as sqlite-vec): semantic
 //! search is strictly additive, so nothing here may ever take the app down.
 
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
+use hf_hub::api::sync::ApiBuilder;
+use hf_hub::api::Progress;
+use hf_hub::Cache;
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager, State};
 
@@ -16,17 +20,45 @@ use crate::error::{AppError, AppResult};
 /// an embedding rebuild (`index_meta.embeddingModel` comparison in TS).
 pub const MODEL_ID: &str = "all-MiniLM-L6-v2";
 
+/// The hf-hub repo and files fastembed resolves for `AllMiniLML6V2`. Mirrored
+/// here so the pre-download (the progress-reporting path) fills the exact
+/// cache `try_new` reads. If fastembed ever changes its file set, the only
+/// cost is that it downloads the difference itself — without progress.
+const MODEL_REPO: &str = "Qdrant/all-MiniLM-L6-v2-onnx";
+const MODEL_FILES: [&str; 5] = [
+    "model.onnx",
+    "tokenizer.json",
+    "config.json",
+    "special_tokens_map.json",
+    "tokenizer_config.json",
+];
+
 #[derive(Clone, Serialize)]
-#[serde(rename_all = "camelCase", tag = "status")]
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase", tag = "status")]
 pub enum EmbedStatus {
     /// No model loaded yet; `embed_ensure` will download/load it.
     Uninitialized,
-    /// Download/load in progress (first run downloads ~90MB).
-    Loading,
+    /// Download/load in progress (first run downloads ~90MB). The byte
+    /// counters are only present on the progress events an active download
+    /// emits — a status poll, or the load of an already-cached model, carries
+    /// no totals to report.
+    Loading {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        downloaded_bytes: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        total_bytes: Option<u64>,
+    },
     /// `embed_texts` is ready; `model` is recorded per vector (rebuild key).
     Ready { model: String },
     /// Load failed; semantic search is unavailable (lexical still works).
     Failed { message: String },
+}
+
+fn loading_status() -> EmbedStatus {
+    EmbedStatus::Loading {
+        downloaded_bytes: None,
+        total_bytes: None,
+    }
 }
 
 #[derive(Default)]
@@ -56,7 +88,7 @@ fn lock_state<'a>(
 fn status_of(runtime: &Runtime) -> EmbedStatus {
     match runtime {
         Runtime::Uninitialized => EmbedStatus::Uninitialized,
-        Runtime::Loading => EmbedStatus::Loading,
+        Runtime::Loading => loading_status(),
         Runtime::Ready(_) => EmbedStatus::Ready {
             model: MODEL_ID.to_string(),
         },
@@ -68,6 +100,117 @@ fn status_of(runtime: &Runtime) -> EmbedStatus {
 
 fn emit_status(app: &AppHandle, status: &EmbedStatus) {
     let _ = app.emit("embed:status", status);
+}
+
+/// How many newly-downloaded bytes accumulate between progress events — about
+/// ninety events for the full model, comfortably few for the IPC channel yet
+/// smooth enough for a progress bar.
+const PROGRESS_EMIT_STEP: u64 = 1024 * 1024;
+
+struct DownloadState {
+    app: AppHandle,
+    downloaded: u64,
+    total: u64,
+    emitted: u64,
+}
+
+impl DownloadState {
+    fn emit(&mut self) {
+        self.emitted = self.downloaded;
+        emit_status(
+            &self.app,
+            &EmbedStatus::Loading {
+                downloaded_bytes: Some(self.downloaded),
+                total_bytes: Some(self.total),
+            },
+        );
+    }
+}
+
+/// Cumulative byte progress across the whole file set, surfaced as
+/// `embed:status` events. hf-hub takes the reporter by value per file, so the
+/// shared tally lives behind an `Arc` and each download gets a clone.
+#[derive(Clone)]
+struct DownloadProgress(Arc<Mutex<DownloadState>>);
+
+impl DownloadProgress {
+    fn new(app: AppHandle, total: u64) -> Self {
+        let mut state = DownloadState {
+            app,
+            downloaded: 0,
+            total,
+            emitted: 0,
+        };
+        // Surface the total before the first chunk lands, so the bar starts
+        // at a real 0% instead of indeterminate.
+        state.emit();
+        Self(Arc::new(Mutex::new(state)))
+    }
+}
+
+impl Progress for DownloadProgress {
+    fn init(&mut self, _size: usize, _filename: &str) {}
+
+    fn update(&mut self, size: usize) {
+        let Ok(mut state) = self.0.lock() else {
+            return;
+        };
+        state.downloaded += size as u64;
+        if state.downloaded - state.emitted >= PROGRESS_EMIT_STEP || state.downloaded >= state.total
+        {
+            state.emit();
+        }
+    }
+
+    fn finish(&mut self) {}
+}
+
+/// Fetch whatever model files are missing from the cache, with byte progress.
+/// fastembed downloads these itself inside `try_new`, but silently; fetching
+/// them first through the same hf-hub cache gives the UI a real progress bar
+/// and leaves `try_new` a pure cache hit. Mirrors fastembed's resolution —
+/// env overrides included — so both sides agree on location and endpoint.
+fn download_model_files(app: &AppHandle, cache_dir: &PathBuf) -> Result<(), String> {
+    let cache_dir = std::env::var("HF_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| cache_dir.clone());
+    let endpoint =
+        std::env::var("HF_ENDPOINT").unwrap_or_else(|_| "https://huggingface.co".to_string());
+
+    let cached = Cache::new(cache_dir.clone()).model(MODEL_REPO.to_string());
+    let missing: Vec<&str> = MODEL_FILES
+        .iter()
+        .copied()
+        .filter(|file| cached.get(file).is_none())
+        .collect();
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    let api = ApiBuilder::new()
+        .with_cache_dir(cache_dir)
+        .with_endpoint(endpoint)
+        .build()
+        .map_err(|err| format!("hf-hub api: {err}"))?;
+    let repo = api.model(MODEL_REPO.to_string());
+
+    // Size every missing file up front (HEAD-weight requests, ~nothing next
+    // to the 90MB body) so the bar tracks one stable total instead of
+    // restarting per file.
+    let mut total: u64 = 0;
+    for file in &missing {
+        total += api
+            .metadata(&repo.url(file))
+            .map_err(|err| format!("sizing {file}: {err}"))?
+            .size() as u64;
+    }
+
+    let progress = DownloadProgress::new(app.clone(), total);
+    for file in missing {
+        repo.download_with_progress(file, progress.clone())
+            .map_err(|err| format!("downloading {file}: {err}"))?;
+    }
+    Ok(())
 }
 
 /// Current runtime status (poll on startup; live changes arrive on
@@ -100,13 +243,15 @@ pub async fn embed_ensure(app: AppHandle, state: State<'_, EmbedState>) -> AppRe
             }
         }
     }
-    emit_status(&app, &EmbedStatus::Loading);
+    emit_status(&app, &loading_status());
 
     // From here every path — success, load failure, even a panicked blocking
     // task — must land the state in Ready or Failed: an early `?` would wedge
     // the runtime in Loading forever (later ensures return early on Loading).
+    let app_for_progress = app.clone();
     let loaded: Result<TextEmbedding, String> =
         match tauri::async_runtime::spawn_blocking(move || {
+            download_model_files(&app_for_progress, &cache_dir)?;
             TextEmbedding::try_new(
                 InitOptions::new(EmbeddingModel::AllMiniLML6V2).with_cache_dir(cache_dir),
             )

--- a/apps/desktop/src-tauri/src/embed.rs
+++ b/apps/desktop/src-tauri/src/embed.rs
@@ -4,7 +4,7 @@
 //! "unavailable" state (the same recoverable contract as sqlite-vec): semantic
 //! search is strictly additive, so nothing here may ever take the app down.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
@@ -174,10 +174,10 @@ impl Progress for DownloadProgress {
 /// them first through the same hf-hub cache gives the UI a real progress bar
 /// and leaves `try_new` a pure cache hit. Mirrors fastembed's resolution —
 /// env overrides included — so both sides agree on location and endpoint.
-fn download_model_files(app: &AppHandle, cache_dir: &PathBuf) -> Result<(), String> {
+fn download_model_files(app: &AppHandle, cache_dir: &Path) -> Result<(), String> {
     let cache_dir = std::env::var("HF_HOME")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| cache_dir.clone());
+        .unwrap_or_else(|_| cache_dir.to_path_buf());
     let endpoint =
         std::env::var("HF_ENDPOINT").unwrap_or_else(|_| "https://huggingface.co".to_string());
 

--- a/apps/desktop/src-tauri/src/embed.rs
+++ b/apps/desktop/src-tauri/src/embed.rs
@@ -34,7 +34,11 @@ const MODEL_FILES: [&str; 5] = [
 ];
 
 #[derive(Clone, Serialize)]
-#[serde(rename_all = "camelCase", rename_all_fields = "camelCase", tag = "status")]
+#[serde(
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    tag = "status"
+)]
 pub enum EmbedStatus {
     /// No model loaded yet; `embed_ensure` will download/load it.
     Uninitialized,

--- a/apps/desktop/src/components/command-palette/command-palette.test.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.test.tsx
@@ -59,6 +59,7 @@ function renderPalette(query: string, context?: Partial<CommandContext>) {
     toggleSidebar: vi.fn(),
     generation: () => 1,
     openPalette: vi.fn(),
+    enableSemanticSearch: vi.fn(),
     ...context,
   }
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })

--- a/apps/desktop/src/components/embeddings-sync.tsx
+++ b/apps/desktop/src/components/embeddings-sync.tsx
@@ -1,16 +1,22 @@
 import { useEffect, useRef } from 'react'
 import { embedNote, embedRemove, subscribeFileChanges } from '@reflect/core'
-import { backfillEmbeddingsVisibly, ensureEmbeddingsVisibly, semanticEnabled } from '@/lib/semantic'
+import {
+  backfillEmbeddingsVisibly,
+  consumeLegacySemanticOptIn,
+  ensureEmbeddingsVisibly,
+} from '@/lib/semantic'
 import { useEmbedStatus } from '@/lib/use-embed-status'
 import { useGraph } from '@/providers/graph-provider'
+import { useSettings } from '@/providers/settings-provider'
 
 /**
  * Keeps embeddings in sync with the graph (Plan 09). Renders nothing; mounted
  * once per workspace. Three jobs, all gated on the runtime being `ready`:
  *
- * - auto-load the model on launch when semantic search was previously enabled
- *   (the cache makes this instant; the first download only ever happens via
- *   the explicit `semantic.enable` command);
+ * - load the model whenever `semanticSearchEnabled` is on and the runtime is
+ *   untouched — at launch for users who opted in earlier (the cache makes
+ *   that instant) and the moment the setting flips on (the one place the
+ *   first download starts);
  * - run one incremental backfill per graph-open once `ready` (hash-skip makes
  *   this cheap when nothing changed);
  * - follow the watcher: changed notes re-embed, deleted notes drop vectors.
@@ -18,6 +24,7 @@ import { useGraph } from '@/providers/graph-provider'
  */
 export function EmbeddingsSync(): null {
   const { graph, indexGeneration } = useGraph()
+  const { settings, updateSettings } = useSettings()
   const status = useEmbedStatus()
   const queue = useRef<Promise<void>>(Promise.resolve())
 
@@ -25,15 +32,26 @@ export function EmbeddingsSync(): null {
   // the file-write generation in GraphInfo — the counters are independent.
   const generation = indexGeneration
   const root = graph?.root ?? null
+  const enabled = settings.semanticSearchEnabled
   const ready = status.status === 'ready'
   const modelId = status.status === 'ready' ? status.model : null
 
-  // Auto-load on launch for users who opted in earlier.
+  // The opt-in predates the settings document (it lived in localStorage);
+  // carry it over once so those users keep semantic search across the move.
   useEffect(() => {
-    if (status.status === 'uninitialized' && semanticEnabled()) {
+    if (consumeLegacySemanticOptIn()) {
+      updateSettings({ semanticSearchEnabled: true })
+    }
+  }, [updateSettings])
+
+  // Load while enabled and untouched. Deliberately not retried on `failed`:
+  // an automatic loop would hammer a broken download — recovery is the
+  // settings screen's explicit retry.
+  useEffect(() => {
+    if (enabled && status.status === 'uninitialized') {
       void ensureEmbeddingsVisibly()
     }
-  }, [status.status])
+  }, [enabled, status.status])
 
   // One backfill per (graph, model) once ready, then live watcher follow-up.
   useEffect(() => {

--- a/apps/desktop/src/components/embeddings-sync.tsx
+++ b/apps/desktop/src/components/embeddings-sync.tsx
@@ -45,8 +45,8 @@ export function EmbeddingsSync(): null {
   }, [updateSettings])
 
   // Load while enabled and untouched. Deliberately not retried on `failed`:
-  // an automatic loop would hammer a broken download — recovery is the
-  // settings screen's explicit retry.
+  // an automatic loop would hammer a broken download — recovery rides the
+  // explicit enable/retry actions instead (see retryFailedEmbeddings).
   useEffect(() => {
     if (enabled && status.status === 'uninitialized') {
       void ensureEmbeddingsVisibly()

--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -1,12 +1,13 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { setBridge } from '@reflect/core'
+import { setBridge, type EmbedStatus } from '@reflect/core'
 import { SettingsProvider } from '@/providers/settings-provider'
 import { SettingsScreen } from './settings-screen'
 
 let stored: Record<string, unknown>
 let saved: unknown[]
+let embedStatus: EmbedStatus
 
 function installFakeBridge(): void {
   saved = []
@@ -18,6 +19,8 @@ function installFakeBridge(): void {
         case 'settings_save':
           saved.push(args.settings)
           return null
+        case 'embed_status':
+          return embedStatus
         default:
           return null
       }
@@ -48,6 +51,7 @@ function radio(name: RegExp): HTMLInputElement {
 
 beforeEach(() => {
   stored = {}
+  embedStatus = { status: 'uninitialized' }
   queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: Infinity } },
   })
@@ -75,7 +79,9 @@ describe('SettingsScreen', () => {
     fireEvent.click(radio(/^show/i))
 
     await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system' }]),
+      expect(saved).toEqual([
+        { editorMarkdownSyntax: 'show', semanticSearchEnabled: false, theme: 'system' },
+      ]),
     )
     expect(radio(/^show/i).checked).toBe(true)
     expect(radio(/^focus/i).checked).toBe(false)
@@ -90,8 +96,63 @@ describe('SettingsScreen', () => {
 
     expect(radio(/^light/i).checked).toBe(true)
     await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkdownSyntax: 'focus', theme: 'light' }]),
+      expect(saved).toEqual([
+        { editorMarkdownSyntax: 'focus', semanticSearchEnabled: false, theme: 'light' },
+      ]),
     )
+  })
+
+  it('enabling semantic search persists the opt-in', async () => {
+    renderScreen()
+    const enable = await screen.findByRole('button', { name: /enable semantic search/i })
+
+    fireEvent.click(enable)
+
+    await waitFor(() =>
+      expect(saved).toEqual([
+        { editorMarkdownSyntax: 'focus', semanticSearchEnabled: true, theme: 'system' },
+      ]),
+    )
+    // The control flips to the loading state (EmbeddingsSync owns the actual
+    // download; the runtime here still reports `uninitialized`).
+    expect(screen.getByRole('progressbar', { name: /model download/i })).toBeTruthy()
+  })
+
+  it('shows byte-level progress while the model downloads', async () => {
+    stored = { semanticSearchEnabled: true }
+    embedStatus = { status: 'loading', downloadedBytes: 45_000_000, totalBytes: 90_000_000 }
+    renderScreen()
+
+    const bar = await screen.findByRole('progressbar', { name: /model download/i })
+    await waitFor(() => expect(bar.getAttribute('aria-valuenow')).toBe('50'))
+    expect(screen.getByText('Downloading the model — 45 MB of 90 MB')).toBeTruthy()
+  })
+
+  it('shows the downloaded model once ready and persists a disable', async () => {
+    stored = { semanticSearchEnabled: true }
+    embedStatus = { status: 'ready', model: 'all-MiniLM-L6-v2' }
+    renderScreen()
+
+    expect(await screen.findByText(/model downloaded \(all-MiniLM-L6-v2\)/i)).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /disable/i }))
+
+    await waitFor(() =>
+      expect(saved).toEqual([
+        { editorMarkdownSyntax: 'focus', semanticSearchEnabled: false, theme: 'system' },
+      ]),
+    )
+    expect(screen.getByRole('button', { name: /enable semantic search/i })).toBeTruthy()
+  })
+
+  it('surfaces a failed load with a retry affordance', async () => {
+    stored = { semanticSearchEnabled: true }
+    embedStatus = { status: 'failed', message: 'no disk space' }
+    renderScreen()
+
+    expect(await screen.findByRole('alert')).toBeTruthy()
+    expect(screen.getByText(/no disk space/i)).toBeTruthy()
+    expect(screen.getByRole('button', { name: /try again/i })).toBeTruthy()
   })
 
   it('lists registered shortcuts from both keymap scopes', () => {

--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -167,7 +167,7 @@ describe('SettingsScreen', () => {
     )
   })
 
-  it('surfaces a failed load with a retry affordance', async () => {
+  it('surfaces a failed load with retry and disable affordances', async () => {
     stored = { semanticSearchEnabled: true }
     embedStatus = { status: 'failed', message: 'no disk space' }
     renderScreen()
@@ -175,6 +175,16 @@ describe('SettingsScreen', () => {
     expect(await screen.findByRole('alert')).toBeTruthy()
     expect(screen.getByText(/no disk space/i)).toBeTruthy()
     expect(screen.getByRole('button', { name: /try again/i })).toBeTruthy()
+
+    // Backing out after a failure must work too — the opt-in isn't a trap.
+    fireEvent.click(screen.getByRole('button', { name: /disable/i }))
+
+    await waitFor(() =>
+      expect(saved).toEqual([
+        { editorMarkdownSyntax: 'focus', semanticSearchEnabled: false, theme: 'system' },
+      ]),
+    )
+    expect(screen.getByRole('button', { name: /enable semantic search/i })).toBeTruthy()
   })
 
   it('lists registered shortcuts from both keymap scopes', () => {

--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -7,12 +7,15 @@ import { SettingsScreen } from './settings-screen'
 
 let stored: Record<string, unknown>
 let saved: unknown[]
+let invoked: string[]
 let embedStatus: EmbedStatus
 
 function installFakeBridge(): void {
   saved = []
+  invoked = []
   setBridge({
     invoke: async (command, args) => {
+      invoked.push(command)
       switch (command) {
         case 'settings_load':
           return stored
@@ -20,6 +23,7 @@ function installFakeBridge(): void {
           saved.push(args.settings)
           return null
         case 'embed_status':
+        case 'embed_ensure':
           return embedStatus
         default:
           return null
@@ -143,6 +147,24 @@ describe('SettingsScreen', () => {
       ]),
     )
     expect(screen.getByRole('button', { name: /enable semantic search/i })).toBeTruthy()
+  })
+
+  it('re-enabling after a failed load retries the download', async () => {
+    embedStatus = { status: 'failed', message: 'offline' }
+    renderScreen()
+    const enable = await screen.findByRole('button', { name: /enable semantic search/i })
+
+    fireEvent.click(enable)
+
+    // The opt-in persists AND the broken runtime gets a fresh embed_ensure —
+    // EmbeddingsSync only loads `uninitialized` runtimes, so the explicit
+    // action carries the retry.
+    await waitFor(() => expect(invoked).toContain('embed_ensure'))
+    await waitFor(() =>
+      expect(saved).toEqual([
+        { editorMarkdownSyntax: 'focus', semanticSearchEnabled: true, theme: 'system' },
+      ]),
+    )
   })
 
   it('surfaces a failed load with a retry affordance', async () => {

--- a/apps/desktop/src/components/settings-screen.tsx
+++ b/apps/desktop/src/components/settings-screen.tsx
@@ -3,6 +3,7 @@ import { AboutSection } from './settings/about-section'
 import { AppearanceSection } from './settings/appearance-section'
 import { EditorSection } from './settings/editor-section'
 import { KeyboardSection } from './settings/keyboard-section'
+import { SearchSection } from './settings/search-section'
 
 /**
  * The settings screen (a routed view, like notes — reached via ⌘, or the
@@ -16,6 +17,7 @@ export function SettingsScreen(): ReactElement {
       <div className="mt-6">
         <AppearanceSection />
         <EditorSection />
+        <SearchSection />
         <KeyboardSection />
         <AboutSection />
       </div>

--- a/apps/desktop/src/components/settings/model-download-progress.tsx
+++ b/apps/desktop/src/components/settings/model-download-progress.tsx
@@ -1,0 +1,55 @@
+import type { ReactElement } from 'react'
+
+interface ModelDownloadProgressProps {
+  /** Bytes fetched so far, when an active download has reported them. */
+  downloadedBytes?: number
+  /** Bytes the download will fetch in total, reported alongside the above. */
+  totalBytes?: number
+}
+
+function formatMegabytes(bytes: number): string {
+  return `${Math.round(bytes / 1_000_000)} MB`
+}
+
+/**
+ * The embedding-model download as a progress bar: determinate while the
+ * runtime reports byte counts, an indeterminate shimmer in the unmeasured
+ * moments around them (before the first progress event, and the model-load
+ * phase after the last byte lands).
+ */
+export function ModelDownloadProgress({
+  downloadedBytes,
+  totalBytes,
+}: ModelDownloadProgressProps): ReactElement {
+  const fraction =
+    downloadedBytes !== undefined && totalBytes !== undefined && totalBytes > 0
+      ? Math.min(downloadedBytes / totalBytes, 1)
+      : null
+  const label =
+    downloadedBytes !== undefined && totalBytes !== undefined && fraction !== null && fraction < 1
+      ? `Downloading the model — ${formatMegabytes(downloadedBytes)} of ${formatMegabytes(totalBytes)}`
+      : 'Preparing the model…'
+
+  return (
+    <div>
+      <div
+        role="progressbar"
+        aria-label="Semantic search model download"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={fraction !== null ? Math.round(fraction * 100) : undefined}
+        className="h-1.5 overflow-hidden rounded-full bg-accent-soft"
+      >
+        {fraction !== null ? (
+          <div
+            className="h-full rounded-full bg-accent transition-[width] duration-200"
+            style={{ width: `${fraction * 100}%` }}
+          />
+        ) : (
+          <div className="h-full w-full animate-pulse rounded-full bg-accent/40" />
+        )}
+      </div>
+      <p className="mt-1.5 text-xs text-text-muted">{label}</p>
+    </div>
+  )
+}

--- a/apps/desktop/src/components/settings/search-section.tsx
+++ b/apps/desktop/src/components/settings/search-section.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement, ReactNode } from 'react'
 import { Sparkles } from 'lucide-react'
 import { InlineAlert } from '@/components/inline-alert'
-import { ensureEmbeddingsVisibly } from '@/lib/semantic'
+import { ensureEmbeddingsVisibly, retryFailedEmbeddings } from '@/lib/semantic'
 import { useEmbedStatus } from '@/lib/use-embed-status'
 import { useSettings } from '@/providers/settings-provider'
 import { SettingsField } from './field'
@@ -24,7 +24,12 @@ export function SearchSection(): ReactElement {
       <div>
         <button
           type="button"
-          onClick={() => updateSettings({ semanticSearchEnabled: true })}
+          onClick={() => {
+            updateSettings({ semanticSearchEnabled: true })
+            // EmbeddingsSync loads an untouched runtime; a `failed` one only
+            // retries on an explicit action like this.
+            void retryFailedEmbeddings()
+          }}
           className="inline-flex items-center gap-1.5 rounded-md bg-accent px-2.5 py-1.5 text-xs font-medium text-text-on-brand shadow-sm transition-colors duration-100 hover:bg-accent-hover"
         >
           <Sparkles aria-hidden strokeWidth={1.75} className="size-3.5" />

--- a/apps/desktop/src/components/settings/search-section.tsx
+++ b/apps/desktop/src/components/settings/search-section.tsx
@@ -63,13 +63,22 @@ export function SearchSection(): ReactElement {
     control = (
       <div>
         <InlineAlert tone="error">Couldn’t load the model: {status.message}</InlineAlert>
-        <button
-          type="button"
-          onClick={() => void ensureEmbeddingsVisibly()}
-          className="mt-2 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-text-secondary transition-colors duration-100 hover:bg-surface-hover"
-        >
-          Try again
-        </button>
+        <div className="mt-2 flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => void ensureEmbeddingsVisibly()}
+            className="rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-text-secondary transition-colors duration-100 hover:bg-surface-hover"
+          >
+            Try again
+          </button>
+          <button
+            type="button"
+            onClick={() => updateSettings({ semanticSearchEnabled: false })}
+            className="rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-text-secondary transition-colors duration-100 hover:bg-surface-hover"
+          >
+            Disable
+          </button>
+        </div>
       </div>
     )
   } else {

--- a/apps/desktop/src/components/settings/search-section.tsx
+++ b/apps/desktop/src/components/settings/search-section.tsx
@@ -1,0 +1,90 @@
+import type { ReactElement, ReactNode } from 'react'
+import { Sparkles } from 'lucide-react'
+import { InlineAlert } from '@/components/inline-alert'
+import { ensureEmbeddingsVisibly } from '@/lib/semantic'
+import { useEmbedStatus } from '@/lib/use-embed-status'
+import { useSettings } from '@/providers/settings-provider'
+import { SettingsField } from './field'
+import { ModelDownloadProgress } from './model-download-progress'
+import { SettingsSection } from './section'
+
+/**
+ * The search settings: the semantic-search opt-in (Plan 09). Enabling
+ * persists `semanticSearchEnabled`; EmbeddingsSync reacts by loading the
+ * model, and the first load's ~90MB download streams through this section as
+ * a progress bar (the `embed:status` events carry byte counts).
+ */
+export function SearchSection(): ReactElement {
+  const { settings, updateSettings } = useSettings()
+  const status = useEmbedStatus()
+
+  let control: ReactNode
+  if (!settings.semanticSearchEnabled) {
+    control = (
+      <div>
+        <button
+          type="button"
+          onClick={() => updateSettings({ semanticSearchEnabled: true })}
+          className="inline-flex items-center gap-1.5 rounded-md bg-accent px-2.5 py-1.5 text-xs font-medium text-text-on-brand shadow-sm transition-colors duration-100 hover:bg-accent-hover"
+        >
+          <Sparkles aria-hidden strokeWidth={1.75} className="size-3.5" />
+          Enable semantic search
+        </button>
+        {status.status === 'ready' ? (
+          <p className="mt-2 text-xs text-text-muted">
+            The model is still loaded for this session; disabling takes full effect on the next
+            launch.
+          </p>
+        ) : null}
+      </div>
+    )
+  } else if (status.status === 'ready') {
+    control = (
+      <div className="flex items-center justify-between gap-4">
+        <span className="flex items-center gap-2 text-xs text-text-muted">
+          <span aria-hidden className="size-1.5 rounded-full bg-emerald-500" />
+          Model downloaded ({status.model})
+        </span>
+        <button
+          type="button"
+          onClick={() => updateSettings({ semanticSearchEnabled: false })}
+          className="shrink-0 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-text-secondary transition-colors duration-100 hover:bg-surface-hover"
+        >
+          Disable
+        </button>
+      </div>
+    )
+  } else if (status.status === 'failed') {
+    control = (
+      <div>
+        <InlineAlert tone="error">Couldn’t load the model: {status.message}</InlineAlert>
+        <button
+          type="button"
+          onClick={() => void ensureEmbeddingsVisibly()}
+          className="mt-2 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-text-secondary transition-colors duration-100 hover:bg-surface-hover"
+        >
+          Try again
+        </button>
+      </div>
+    )
+  } else {
+    // `loading`, or the `uninitialized` beat before EmbeddingsSync reacts.
+    control = (
+      <ModelDownloadProgress
+        downloadedBytes={status.status === 'loading' ? status.downloadedBytes : undefined}
+        totalBytes={status.status === 'loading' ? status.totalBytes : undefined}
+      />
+    )
+  }
+
+  return (
+    <SettingsSection title="Search">
+      <SettingsField
+        legend="Semantic search"
+        description="Find notes by meaning, not just keywords — smarter ⌘K results and related notes. Runs entirely on this device; enabling downloads a small model (~90 MB) once."
+      >
+        <div className="mt-3">{control}</div>
+      </SettingsField>
+    </SettingsSection>
+  )
+}

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -48,6 +48,7 @@ function renderSidebar(overrides?: Partial<CommandContext>) {
     toggleSidebar: vi.fn(),
     generation: () => 1,
     openPalette,
+    enableSemanticSearch: vi.fn(),
     ...overrides,
   }
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -9,13 +9,9 @@ const rebuildIndex = vi.hoisted(() => vi.fn())
 const embedStatus = vi.hoisted(() =>
   vi.fn<() => Promise<EmbedStatus>>(async () => ({ status: 'uninitialized' })),
 )
-const ensureEmbeddingsVisibly = vi.hoisted(() => vi.fn(async () => ({ status: 'ready', model: 'm' })))
-const setSemanticEnabled = vi.hoisted(() => vi.fn())
 const backfillEmbeddingsVisibly = vi.hoisted(() => vi.fn(async () => 'completed'))
 vi.mock('@/lib/semantic', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/semantic')>()),
-  ensureEmbeddingsVisibly,
-  setSemanticEnabled,
   backfillEmbeddingsVisibly,
 }))
 vi.mock('@reflect/core', async (importOriginal) => ({
@@ -46,6 +42,7 @@ function fakeContext(overrides?: Partial<CommandContext>) {
     toggleSidebar: vi.fn(),
     generation: () => 7,
     openPalette: vi.fn(),
+    enableSemanticSearch: vi.fn(),
     ...overrides,
   }
   return { context, navigated }
@@ -106,11 +103,11 @@ describe('app commands', () => {
     expect(navigated).toHaveLength(1) // unchanged
   })
 
-  it('semantic.enable persists the opt-in and loads the model visibly', async () => {
+  it('semantic.enable persists the opt-in through the context capability', async () => {
     const { context } = fakeContext()
     await command('semantic.enable').run(context)
-    expect(setSemanticEnabled).toHaveBeenCalledWith(true)
-    expect(ensureEmbeddingsVisibly).toHaveBeenCalled()
+    // EmbeddingsSync owns the download reaction; the command only opts in.
+    expect(context.enableSemanticSearch).toHaveBeenCalled()
   })
 
   it('index.rebuild runs at the open generation and reports as an operation', async () => {

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -1,11 +1,7 @@
 import { embedStatus, notePath, randomNotePath, rebuildIndex } from '@reflect/core'
 import { ulid } from 'ulidx'
 import { startOperation } from '@/lib/operations'
-import {
-  backfillEmbeddingsVisibly,
-  ensureEmbeddingsVisibly,
-  setSemanticEnabled,
-} from '@/lib/semantic'
+import { backfillEmbeddingsVisibly } from '@/lib/semantic'
 import { registerCommands } from './registry'
 import type { AppCommand } from './types'
 
@@ -86,14 +82,12 @@ const APP_COMMANDS: AppCommand[] = [
     id: 'semantic.enable',
     title: 'Enable semantic search',
     keywords: ['embeddings', 'ai', 'similar', 'model'],
-    // Downloads the local model (~90MB) — deliberately a command, never
-    // automatic: the first network fetch is the user's call. EmbeddingsSync
-    // reacts to `ready` with the backfill, and the persisted flag makes
-    // later launches load from cache without asking again.
-    run: async () => {
-      setSemanticEnabled(true)
-      await ensureEmbeddingsVisibly()
-    },
+    // Downloads the local model (~90MB) — deliberately opt-in, never
+    // automatic: the first network fetch is the user's call. Persisting the
+    // setting is the entire command — EmbeddingsSync loads the model when the
+    // flag flips on and backfills once it's `ready`; later launches load from
+    // cache without asking again.
+    run: (context) => context.enableSemanticSearch(),
   },
   {
     id: 'index.rebuild',

--- a/apps/desktop/src/lib/commands/registry.test.ts
+++ b/apps/desktop/src/lib/commands/registry.test.ts
@@ -15,6 +15,7 @@ function fakeContext(overrides?: Partial<CommandContext>): CommandContext {
     toggleSidebar: vi.fn(),
     generation: () => 1,
     openPalette: vi.fn(),
+    enableSemanticSearch: vi.fn(),
     ...overrides,
   }
 }

--- a/apps/desktop/src/lib/commands/types.ts
+++ b/apps/desktop/src/lib/commands/types.ts
@@ -22,6 +22,12 @@ export interface CommandContext {
   generation: () => number | null
   /** Open the ⌘K palette (optionally pre-filled). */
   openPalette: (query?: string) => void
+  /**
+   * Persist the semantic-search opt-in (`semanticSearchEnabled`).
+   * EmbeddingsSync reacts to the setting by loading — first time:
+   * downloading — the model, so flipping the flag is the whole command.
+   */
+  enableSemanticSearch: () => void
 }
 
 export interface AppCommand {

--- a/apps/desktop/src/lib/semantic.test.ts
+++ b/apps/desktop/src/lib/semantic.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { setBridge } from '@reflect/core'
-import { ensureEmbeddingsVisibly } from './semantic'
+import { consumeLegacySemanticOptIn, ensureEmbeddingsVisibly } from './semantic'
 
 const startOperation = vi.hoisted(() => vi.fn())
 vi.mock('@/lib/operations', () => ({ startOperation }))
@@ -15,6 +15,19 @@ function operationHandle() {
   startOperation.mockReturnValue(handle)
   return handle
 }
+
+describe('consumeLegacySemanticOptIn', () => {
+  it('returns a stored opt-in exactly once (the settings document owns it after)', () => {
+    localStorage.setItem('reflect.semantic.enabled', 'true')
+    expect(consumeLegacySemanticOptIn()).toBe(true)
+    expect(consumeLegacySemanticOptIn()).toBe(false)
+    expect(localStorage.getItem('reflect.semantic.enabled')).toBeNull()
+  })
+
+  it('is false when the legacy key was never set', () => {
+    expect(consumeLegacySemanticOptIn()).toBe(false)
+  })
+})
 
 describe('ensureEmbeddingsVisibly', () => {
   it('resolves the operation only at a terminal status (a racing ensure returns loading)', async () => {

--- a/apps/desktop/src/lib/semantic.test.ts
+++ b/apps/desktop/src/lib/semantic.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { setBridge } from '@reflect/core'
-import { consumeLegacySemanticOptIn, ensureEmbeddingsVisibly } from './semantic'
+import {
+  consumeLegacySemanticOptIn,
+  ensureEmbeddingsVisibly,
+  retryFailedEmbeddings,
+} from './semantic'
 
 const startOperation = vi.hoisted(() => vi.fn())
 vi.mock('@/lib/operations', () => ({ startOperation }))
@@ -26,6 +30,33 @@ describe('consumeLegacySemanticOptIn', () => {
 
   it('is false when the legacy key was never set', () => {
     expect(consumeLegacySemanticOptIn()).toBe(false)
+  })
+})
+
+describe('retryFailedEmbeddings', () => {
+  function bridgeWithStatus(status: unknown): string[] {
+    const invoked: string[] = []
+    setBridge({
+      invoke: async (command) => {
+        invoked.push(command)
+        return status
+      },
+      listen: async () => () => {},
+    })
+    return invoked
+  }
+
+  it('re-kicks a failed load', async () => {
+    operationHandle()
+    const invoked = bridgeWithStatus({ status: 'failed', message: 'offline' })
+    await retryFailedEmbeddings()
+    expect(invoked).toContain('embed_ensure')
+  })
+
+  it('is a no-op for any other status', async () => {
+    const invoked = bridgeWithStatus({ status: 'ready', model: 'all-MiniLM-L6-v2' })
+    await retryFailedEmbeddings()
+    expect(invoked).toEqual(['embed_status'])
   })
 })
 

--- a/apps/desktop/src/lib/semantic.ts
+++ b/apps/desktop/src/lib/semantic.ts
@@ -8,28 +8,29 @@ import {
 import { startOperation } from '@/lib/operations'
 
 /**
- * Semantic-search enablement (Plan 09). The model is ~90MB and downloads from
- * the network, so it is **opt-in**: the `semantic.enable` command flips a
- * persisted flag and kicks the first download; later launches auto-load from
- * the local cache because the flag is set. Acceptance: "first semantic use
- * downloads the model with progress; later uses are instant."
+ * Semantic-search loading (Plan 09). The model is ~90MB and downloads from
+ * the network, so it is **opt-in**: the `semanticSearchEnabled` setting flips
+ * the persisted opt-in and `EmbeddingsSync` kicks the first download; later
+ * launches auto-load from the local cache because the flag is set.
+ * Acceptance: "first semantic use downloads the model with progress; later
+ * uses are instant."
  */
 
-const ENABLED_KEY = 'reflect.semantic.enabled'
+/** Where the opt-in lived before it moved into the settings document. */
+const LEGACY_ENABLED_KEY = 'reflect.semantic.enabled'
 
-export function semanticEnabled(): boolean {
+/**
+ * Read-and-clear the pre-settings localStorage opt-in. Returns true exactly
+ * once for a user who enabled semantic search before the flag moved into
+ * settings — the caller persists it there and the key never matters again.
+ */
+export function consumeLegacySemanticOptIn(): boolean {
   try {
-    return localStorage.getItem(ENABLED_KEY) === 'true'
+    const enabled = localStorage.getItem(LEGACY_ENABLED_KEY) === 'true'
+    localStorage.removeItem(LEGACY_ENABLED_KEY)
+    return enabled
   } catch {
     return false
-  }
-}
-
-export function setSemanticEnabled(enabled: boolean): void {
-  try {
-    localStorage.setItem(ENABLED_KEY, String(enabled))
-  } catch {
-    // best-effort; the command can be re-run
   }
 }
 

--- a/apps/desktop/src/lib/semantic.ts
+++ b/apps/desktop/src/lib/semantic.ts
@@ -66,6 +66,20 @@ async function awaitTerminalStatus(initial: EmbedStatus): Promise<EmbedStatus> {
   })
 }
 
+/**
+ * Re-kick a `failed` model load; a no-op for every other status. The explicit
+ * enable actions (settings button, `semantic.enable` command) run this so
+ * opting back in after a failure retries the download — EmbeddingsSync itself
+ * only loads an `uninitialized` runtime, because reacting to `failed` would
+ * loop a broken download forever.
+ */
+export async function retryFailedEmbeddings(): Promise<void> {
+  const status = await embedStatus()
+  if (status.status === 'failed') {
+    await ensureEmbeddingsVisibly()
+  }
+}
+
 /** Load (downloading if needed) the model, visibly. Resolves with the outcome. */
 export async function ensureEmbeddingsVisibly(): Promise<EmbedStatus> {
   const operation = startOperation('Loading semantic search model')

--- a/apps/desktop/src/providers/settings-provider.test.tsx
+++ b/apps/desktop/src/providers/settings-provider.test.tsx
@@ -118,7 +118,14 @@ describe('SettingsProvider', () => {
     expect(result.current.settings.editorMarkdownSyntax).toBe('show')
     // The persisted document keeps unknown keys (newer-version settings survive).
     await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system', futureKey: true }]),
+      expect(saved).toEqual([
+        {
+          editorMarkdownSyntax: 'show',
+          semanticSearchEnabled: false,
+          theme: 'system',
+          futureKey: true,
+        },
+      ]),
     )
   })
 
@@ -142,7 +149,14 @@ describe('SettingsProvider', () => {
     // The load result must not clobber the update, and the deferred flush
     // persists the update merged over the *loaded* document.
     await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system', futureKey: true }]),
+      expect(saved).toEqual([
+        {
+          editorMarkdownSyntax: 'show',
+          semanticSearchEnabled: false,
+          theme: 'system',
+          futureKey: true,
+        },
+      ]),
     )
     expect(result.current.settings.editorMarkdownSyntax).toBe('show')
   })
@@ -160,7 +174,9 @@ describe('SettingsProvider', () => {
       releaseLoad()
     })
     await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkdownSyntax: 'focus', theme: 'system' }]),
+      expect(saved).toEqual([
+        { editorMarkdownSyntax: 'focus', semanticSearchEnabled: false, theme: 'system' },
+      ]),
     )
     expect(result.current.settings.editorMarkdownSyntax).toBe('focus')
   })
@@ -205,7 +221,9 @@ describe('SettingsProvider', () => {
       result.current.updateSettings({ editorMarkdownSyntax: 'show' })
     })
     await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system' }]),
+      expect(saved).toEqual([
+        { editorMarkdownSyntax: 'show', semanticSearchEnabled: false, theme: 'system' },
+      ]),
     )
   })
 
@@ -227,7 +245,9 @@ describe('SettingsProvider', () => {
     await act(async () => {
       await flushSettings()
     })
-    expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system' }])
+    expect(saved).toEqual([
+      { editorMarkdownSyntax: 'show', semanticSearchEnabled: false, theme: 'system' },
+    ])
   })
 
   it('surfaces a failed load and keeps changes session-only', async () => {

--- a/apps/desktop/src/routing/app-shortcuts.test.tsx
+++ b/apps/desktop/src/routing/app-shortcuts.test.tsx
@@ -14,6 +14,12 @@ vi.mock('@/providers/graph-provider', () => ({
 vi.mock('@/providers/theme-provider', () => ({
   useTheme: () => ({ theme: 'light', resolvedTheme: 'light', setTheme: vi.fn() }),
 }))
+vi.mock('@/providers/settings-provider', () => ({
+  useSettings: () => ({
+    settings: { editorMarkdownSyntax: 'focus', semanticSearchEnabled: false, theme: 'system' },
+    updateSettings: vi.fn(),
+  }),
+}))
 
 registerAppCommands() // production does this in main.tsx
 

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -5,6 +5,7 @@ import { APP_COMMANDS } from '@/lib/commands/app-commands'
 import { runCommand } from '@/lib/commands/registry'
 import type { CommandContext } from '@/lib/commands/types'
 import { useGraph } from '@/providers/graph-provider'
+import { useSettings } from '@/providers/settings-provider'
 import { useSidebar } from '@/providers/sidebar-provider'
 import { useTheme } from '@/providers/theme-provider'
 import { useRouter } from './router'
@@ -43,6 +44,7 @@ export function useAppShortcuts(): CommandContext {
   const { graph } = useGraph()
   const { openPalette, open: paletteOpen } = usePalette()
   const { toggleSidebar } = useSidebar()
+  const { updateSettings } = useSettings()
 
   // The palette is modal: app shortcuts must not navigate behind its overlay.
   // A ref keeps the listener stable across open/close renders.
@@ -63,8 +65,9 @@ export function useAppShortcuts(): CommandContext {
       toggleSidebar,
       generation: () => generationRef.current,
       openPalette,
+      enableSemanticSearch: () => updateSettings({ semanticSearchEnabled: true }),
     }),
-    [navigate, back, forward, resolvedTheme, setTheme, openPalette, toggleSidebar],
+    [navigate, back, forward, resolvedTheme, setTheme, openPalette, toggleSidebar, updateSettings],
   )
 
   useEffect(() => {

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -3,6 +3,7 @@ import { usePalette } from '@/components/command-palette/palette-provider'
 import { registerKeymap } from '@/editor/keymap'
 import { APP_COMMANDS } from '@/lib/commands/app-commands'
 import { runCommand } from '@/lib/commands/registry'
+import { retryFailedEmbeddings } from '@/lib/semantic'
 import type { CommandContext } from '@/lib/commands/types'
 import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
@@ -65,7 +66,12 @@ export function useAppShortcuts(): CommandContext {
       toggleSidebar,
       generation: () => generationRef.current,
       openPalette,
-      enableSemanticSearch: () => updateSettings({ semanticSearchEnabled: true }),
+      enableSemanticSearch: () => {
+        updateSettings({ semanticSearchEnabled: true })
+        // EmbeddingsSync loads an untouched runtime; a `failed` one only
+        // retries on an explicit action like this command.
+        void retryFailedEmbeddings()
+      },
     }),
     [navigate, back, forward, resolvedTheme, setTheme, openPalette, toggleSidebar, updateSettings],
   )

--- a/packages/core/src/embeddings/commands.ts
+++ b/packages/core/src/embeddings/commands.ts
@@ -6,7 +6,13 @@ import { call } from '../ipc/invoke'
 
 export const embedStatusSchema = z.discriminatedUnion('status', [
   z.object({ status: z.literal('uninitialized') }),
-  z.object({ status: z.literal('loading') }),
+  z.object({
+    status: z.literal('loading'),
+    /** Bytes fetched so far; only present on an active download's events. */
+    downloadedBytes: z.number().int().nonnegative().optional(),
+    /** Bytes the download will fetch in total; present alongside the above. */
+    totalBytes: z.number().int().nonnegative().optional(),
+  }),
   z.object({ status: z.literal('ready'), model: z.string() }),
   z.object({ status: z.literal('failed'), message: z.string() }),
 ])

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,6 +75,7 @@ export {
 export {
   settingsSchema,
   editorMarkdownSyntaxSchema,
+  semanticSearchEnabledSchema,
   themePreferenceSchema,
   DEFAULT_SETTINGS,
   type Settings,

--- a/packages/core/src/settings/schema.test.ts
+++ b/packages/core/src/settings/schema.test.ts
@@ -5,9 +5,11 @@ describe('settingsSchema', () => {
   it('defaults every key on an empty document (fresh install)', () => {
     expect(settingsSchema.parse({})).toEqual({
       editorMarkdownSyntax: 'focus',
+      semanticSearchEnabled: false,
       theme: 'system',
     })
     expect(DEFAULT_SETTINGS.editorMarkdownSyntax).toBe('focus')
+    expect(DEFAULT_SETTINGS.semanticSearchEnabled).toBe(false)
     expect(DEFAULT_SETTINGS.theme).toBe('system')
   })
 
@@ -17,6 +19,8 @@ describe('settingsSchema', () => {
     expect(settingsSchema.parse({ theme: 'dark' }).theme).toBe('dark')
     expect(settingsSchema.parse({ theme: 'light' }).theme).toBe('light')
     expect(settingsSchema.parse({ theme: 'system' }).theme).toBe('system')
+    expect(settingsSchema.parse({ semanticSearchEnabled: true }).semanticSearchEnabled).toBe(true)
+    expect(settingsSchema.parse({ semanticSearchEnabled: false }).semanticSearchEnabled).toBe(false)
   })
 
   it('degrades an invalid value to its default instead of failing the load', () => {
@@ -24,10 +28,17 @@ describe('settingsSchema', () => {
     expect(settingsSchema.parse({ editorMarkdownSyntax: 42 }).editorMarkdownSyntax).toBe('focus')
     expect(settingsSchema.parse({ theme: 'sepia' }).theme).toBe('system')
     expect(settingsSchema.parse({ theme: 7 }).theme).toBe('system')
+    expect(settingsSchema.parse({ semanticSearchEnabled: 'yes' }).semanticSearchEnabled).toBe(false)
+    expect(settingsSchema.parse({ semanticSearchEnabled: 1 }).semanticSearchEnabled).toBe(false)
   })
 
   it('preserves unknown keys so newer-version settings survive a round trip', () => {
     const parsed = settingsSchema.parse({ editorMarkdownSyntax: 'show', futureKey: true })
-    expect(parsed).toEqual({ editorMarkdownSyntax: 'show', theme: 'system', futureKey: true })
+    expect(parsed).toEqual({
+      editorMarkdownSyntax: 'show',
+      semanticSearchEnabled: false,
+      theme: 'system',
+      futureKey: true,
+    })
   })
 })

--- a/packages/core/src/settings/schema.ts
+++ b/packages/core/src/settings/schema.ts
@@ -31,9 +31,17 @@ export const themePreferenceSchema = z.enum(['system', 'light', 'dark']).catch('
 
 export type ThemePreference = z.infer<typeof themePreferenceSchema>
 
+/**
+ * Whether semantic search is on. Off by default — turning it on downloads the
+ * ~90MB embedding model, and that first network fetch is the user's call
+ * (Plan 09). Later launches load the cached model because this flag is set.
+ */
+export const semanticSearchEnabledSchema = z.boolean().catch(false)
+
 export const settingsSchema = z
   .object({
     editorMarkdownSyntax: editorMarkdownSyntaxSchema,
+    semanticSearchEnabled: semanticSearchEnabledSchema,
     theme: themePreferenceSchema,
   })
   .passthrough()


### PR DESCRIPTION
## What

Adds a **Semantic search** section to the settings screen. Enabling it downloads the embedding model (~90 MB) with a real byte-level progress bar; the section also renders ready (model name + Disable), failed (error + Try again), and indeterminate "Preparing the model…" states.

<details>
<summary>How the pieces fit</summary>

- **Rust** (`embed.rs`): fastembed downloads the model silently inside `try_new`, so `embed_ensure` now pre-fetches the five model files through hf-hub (fastembed's own downloader, added as a direct dependency) using its `Progress` trait. Missing files are sized up front so the bar tracks one stable total; progress streams over the existing `embed:status` event as `loading` + `downloadedBytes`/`totalBytes`, and `try_new` then hits a warm cache. If fastembed's file list ever drifts, it downloads the difference itself — without progress, but nothing breaks.
- **Settings document**: the opt-in moves from localStorage into `semanticSearchEnabled` (`.catch(false)`, per `docs/contributing/adding-a-setting.md`), with a one-shot migration so existing users keep semantic search.
- **One owner for the download reaction**: `EmbeddingsSync` loads the model whenever the setting is on and the runtime is untouched — covering launch and mid-session enables — so the settings button and the `semantic.enable` palette command just flip the flag (the command gains an `enableSemanticSearch` capability on `CommandContext`). Failed loads don't auto-retry; recovery is the explicit retry button.

</details>

## Reviewer notes

- The model repo/file list in `embed.rs` mirrors fastembed's `AllMiniLML6V2` definition (soft coupling — see comment there for the failure mode).
- Disabling doesn't unload an already-loaded model, so semantic results persist until relaunch; the UI copy says so.
- Progress events are throttled to ~1 per MiB (~90 events for the full download).

## Testing

- `pnpm typecheck`, `cargo check` clean
- New/updated tests: settings schema (default/invalid/round-trip), settings screen (enable persists, byte progress renders, ready + disable persists, failed + retry), legacy opt-in migration, `semantic.enable` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds network downloads (~90MB) and changes when/how the embedding runtime loads; failures are contained to semantic search, but cache/repo coupling with fastembed could drift silently without progress.
> 
> **Overview**
> Adds a **Search** settings section for semantic search opt-in, with enable/disable, byte-level download progress, ready/failed states, and explicit retry (no auto-retry on failed loads).
> 
> **Rust:** `embed_ensure` pre-fetches missing Hugging Face model files via **hf-hub** before `fastembed::try_new`, emitting throttled `embed:status` `loading` events with optional `downloadedBytes` / `totalBytes` so the UI can show a real progress bar.
> 
> **Settings & flow:** Opt-in moves from `localStorage` to persisted `semanticSearchEnabled` (with one-shot legacy migration). **`EmbeddingsSync`** is the single owner that starts loading when the flag is on and the runtime is `uninitialized`. Settings and the `semantic.enable` command only flip the flag (via new `CommandContext.enableSemanticSearch`); **`retryFailedEmbeddings`** handles re-enable after failure.
> 
> **Core:** `EmbedStatus` loading variant and settings schema extended for the new flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b452ec57f3176ea14f94dbb512b6e61694259e2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->