### PR TITLE
Settings: AI models section with BYOK providers and keychain-stored keys

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -27,6 +27,7 @@
     "@tanstack/react-virtual": "^3.14.2",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.7.1",
+    "@tauri-apps/plugin-http": "^2.5.9",
     "@tauri-apps/plugin-opener": "^2",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -617,6 +617,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +708,7 @@ dependencies = [
  "idna",
  "indexmap 2.14.0",
  "log",
+ "publicsuffix",
  "serde",
  "serde_derive",
  "serde_json",
@@ -943,6 +950,12 @@ checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "dbus"
@@ -1709,8 +1722,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1720,9 +1735,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2112,6 +2129,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2755,6 +2773,12 @@ checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rust2"
@@ -3824,6 +3848,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3851,6 +3891,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4054,6 +4149,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-http",
  "tauri-plugin-opener",
  "tempfile",
  "tracing",
@@ -4098,6 +4194,8 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -4115,6 +4213,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4122,6 +4222,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4131,6 +4232,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4295,6 +4397,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -5177,6 +5280,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-http"
+version = "2.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5bd512048e1985b7ec78f96d99083e2ddaf7e0d906b2b63c44ce5bb8b894067"
+dependencies = [
+ "bytes",
+ "cookie_store",
+ "data-url",
+ "http",
+ "regex",
+ "reqwest 0.12.28",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+ "urlpattern",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5484,7 +5611,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -956,6 +956,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
+]
+
+[[package]]
 name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2573,6 +2583,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2907,7 +2932,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
 ]
@@ -4018,6 +4043,7 @@ dependencies = [
  "base64 0.22.1",
  "dirs",
  "fastembed",
+ "keyring",
  "notify",
  "notify-debouncer-full",
  "rusqlite",
@@ -4380,6 +4406,19 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
 
 [[package]]
 name = "security-framework"
@@ -7147,6 +7186,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ keyring = { version = "3", features = [
   "windows-native",
   "sync-secret-service",
 ] }
+tauri-plugin-http = "2.5.9"
 
 [dev-dependencies]
 tauri = { version = "2", features = ["test"] }

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -35,6 +35,11 @@ base64 = "0.22.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 fastembed = "5"
+keyring = { version = "3", features = [
+  "apple-native",
+  "windows-native",
+  "sync-secret-service",
+] }
 
 [dev-dependencies]
 tauri = { version = "2", features = ["test"] }

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -6,6 +6,14 @@
   "permissions": [
     "core:default",
     "opener:default",
-    "dialog:default"
+    "dialog:default",
+    {
+      "identifier": "http:default",
+      "allow": [
+        { "url": "https://api.openai.com/*" },
+        { "url": "https://api.anthropic.com/*" },
+        { "url": "https://generativelanguage.googleapis.com/*" }
+      ]
+    }
   ]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@
 //! primitive it exposes. Each module wires one capability:
 //! [`fs`] (graph file IO), [`db`] (SQLite index), [`watcher`] (file events),
 //! [`recents`] (recent-graphs store), [`settings`] (user settings store),
-//! [`error`] (the shared error contract).
+//! [`secrets`] (OS keychain), [`error`] (the shared error contract).
 
 mod db;
 mod embed;
@@ -14,6 +14,7 @@ mod error;
 mod fs;
 mod quit;
 mod recents;
+mod secrets;
 mod settings;
 mod watcher;
 
@@ -61,6 +62,9 @@ pub fn run() {
             recents::forget_recent,
             settings::settings_load,
             settings::settings_save,
+            secrets::secret_set,
+            secrets::secret_get,
+            secrets::secret_delete,
             db::index_open,
             db::index_apply,
             db::index_apply_batch,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -43,6 +43,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_http::init())
         .manage(fs::GraphState::default())
         .manage(db::IndexState::default())
         .manage(watcher::WatcherState::default())

--- a/apps/desktop/src-tauri/src/secrets.rs
+++ b/apps/desktop/src-tauri/src/secrets.rs
@@ -1,0 +1,89 @@
+//! Secrets in the OS keychain (Plan 10): the only place BYOK API keys live.
+//!
+//! Per the product principles, credentials never touch markdown, Git, or
+//! `.reflect/`. Rust exposes the keychain as an opaque name → value store (a
+//! capability); which names exist and what they hold is `@reflect/core`
+//! policy (see `ai/secrets.ts`).
+
+use keyring::Entry;
+
+use crate::error::{AppError, AppResult};
+
+/// The keychain service every Reflect secret is filed under.
+const SERVICE: &str = "reflect-open";
+
+fn entry(name: &str) -> AppResult<Entry> {
+    Entry::new(SERVICE, name).map_err(|err| AppError::io(err.to_string()))
+}
+
+fn set_in(entry: &Entry, value: &str) -> AppResult<()> {
+    entry
+        .set_password(value)
+        .map_err(|err| AppError::io(err.to_string()))
+}
+
+/// A missing entry is an expected state (key not configured yet), not an error.
+fn get_from(entry: &Entry) -> AppResult<Option<String>> {
+    match entry.get_password() {
+        Ok(value) => Ok(Some(value)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(err) => Err(AppError::io(err.to_string())),
+    }
+}
+
+/// Deleting a missing entry succeeds so the operation is idempotent
+/// (retry-safe from the frontend).
+fn delete_from(entry: &Entry) -> AppResult<()> {
+    match entry.delete_credential() {
+        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+        Err(err) => Err(AppError::io(err.to_string())),
+    }
+}
+
+/// Command: store `value` under `name`, replacing any prior value.
+#[tauri::command]
+pub fn secret_set(name: String, value: String) -> AppResult<()> {
+    set_in(&entry(&name)?, &value)
+}
+
+/// Command: the secret stored under `name`, or `None` when there isn't one.
+#[tauri::command]
+pub fn secret_get(name: String) -> AppResult<Option<String>> {
+    get_from(&entry(&name)?)
+}
+
+/// Command: remove the secret stored under `name`.
+#[tauri::command]
+pub fn secret_delete(name: String) -> AppResult<()> {
+    delete_from(&entry(&name)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The mock keystore scopes state to one `Entry` (no shared backing store),
+    /// so the round trip is exercised on a single entry. What this asserts is
+    /// the error mapping the frontend relies on: a missing entry reads as
+    /// `None` (not an error) and delete is idempotent. The real cross-process
+    /// persistence is the OS keychain's contract, not ours.
+    #[test]
+    fn keychain_round_trip_on_one_entry() {
+        keyring::set_default_credential_builder(keyring::mock::default_credential_builder());
+        let entry = entry("ai-api-key:test").unwrap();
+
+        assert_eq!(get_from(&entry).unwrap(), None);
+
+        set_in(&entry, "sk-secret").unwrap();
+        assert_eq!(get_from(&entry).unwrap(), Some("sk-secret".into()));
+
+        set_in(&entry, "sk-rotated").unwrap();
+        assert_eq!(get_from(&entry).unwrap(), Some("sk-rotated".into()));
+
+        delete_from(&entry).unwrap();
+        assert_eq!(get_from(&entry).unwrap(), None);
+
+        // Idempotent: deleting again is fine.
+        delete_from(&entry).unwrap();
+    }
+}

--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -75,7 +75,7 @@ describe('SettingsScreen', () => {
     fireEvent.click(radio(/^show/i))
 
     await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system', aiModels: [] }]),
+      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system', aiModels: [], defaultAiModelId: null }]),
     )
     expect(radio(/^show/i).checked).toBe(true)
     expect(radio(/^focus/i).checked).toBe(false)
@@ -90,7 +90,7 @@ describe('SettingsScreen', () => {
 
     expect(radio(/^light/i).checked).toBe(true)
     await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkdownSyntax: 'focus', theme: 'light', aiModels: [] }]),
+      expect(saved).toEqual([{ editorMarkdownSyntax: 'focus', theme: 'light', aiModels: [], defaultAiModelId: null }]),
     )
   })
 

--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -75,7 +75,7 @@ describe('SettingsScreen', () => {
     fireEvent.click(radio(/^show/i))
 
     await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system' }]),
+      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system', aiModels: [] }]),
     )
     expect(radio(/^show/i).checked).toBe(true)
     expect(radio(/^focus/i).checked).toBe(false)
@@ -90,7 +90,7 @@ describe('SettingsScreen', () => {
 
     expect(radio(/^light/i).checked).toBe(true)
     await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkdownSyntax: 'focus', theme: 'light' }]),
+      expect(saved).toEqual([{ editorMarkdownSyntax: 'focus', theme: 'light', aiModels: [] }]),
     )
   })
 

--- a/apps/desktop/src/components/settings-screen.tsx
+++ b/apps/desktop/src/components/settings-screen.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react'
 import { AboutSection } from './settings/about-section'
+import { AiModelsSection } from './settings/ai-models-section'
 import { AppearanceSection } from './settings/appearance-section'
 import { EditorSection } from './settings/editor-section'
 import { KeyboardSection } from './settings/keyboard-section'
@@ -16,6 +17,7 @@ export function SettingsScreen(): ReactElement {
       <div className="mt-6">
         <AppearanceSection />
         <EditorSection />
+        <AiModelsSection />
         <KeyboardSection />
         <AboutSection />
       </div>

--- a/apps/desktop/src/components/settings/add-ai-model-dialog.tsx
+++ b/apps/desktop/src/components/settings/add-ai-model-dialog.tsx
@@ -1,7 +1,21 @@
-import { useState, type ChangeEvent, type ReactElement } from 'react'
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent,
+  type ReactElement,
+} from 'react'
 import { useForm } from 'react-hook-form'
-import { AI_PROVIDERS, aiProvider, errorMessage, type AiProviderId } from '@reflect/core'
+import {
+  AI_PROVIDERS,
+  aiProvider,
+  errorMessage,
+  validateApiKey,
+  type AiProviderId,
+} from '@reflect/core'
 import { InlineAlert } from '@/components/inline-alert'
+import { providerFetch } from '@/lib/provider-fetch'
 import type { NewAiModel } from '@/hooks/use-ai-models'
 
 interface AddAiModelDialogProps {
@@ -24,10 +38,13 @@ const FIELD_CONTROL_CLASS =
 
 /**
  * The "Add AI model" modal: pick a provider, pick one of its models, paste an
- * API key, optionally mark it as the app default. Submitting hands the draft
- * to {@link AddAiModelDialogProps.onAdd} — the key goes to the OS keychain,
- * never into the settings document — and a failure keeps the dialog open with
- * the typed key intact so the user can retry.
+ * API key, optionally mark it as the app default. The key is verified against
+ * the provider before anything is stored — a rejected key shows inline; an
+ * unreachable provider (offline) downgrades the submit to an explicit "Save
+ * anyway" instead of hard-blocking on connectivity. Submitting hands the
+ * draft to {@link AddAiModelDialogProps.onAdd} — the key goes to the OS
+ * keychain, never into the settings document — and a failure keeps the
+ * dialog open with the typed key intact so the user can retry.
  */
 export function AddAiModelDialog({ onAdd, onClose }: AddAiModelDialogProps): ReactElement {
   const { register, handleSubmit, watch, setValue, formState } = useForm<AddAiModelForm>({
@@ -39,16 +56,43 @@ export function AddAiModelDialog({ onAdd, onClose }: AddAiModelDialogProps): Rea
     },
   })
   const [submitError, setSubmitError] = useState<string | null>(null)
+  // Set when the provider couldn't be reached to verify the key; the next
+  // submit then saves without verification (the button says so).
+  const [unverified, setUnverified] = useState(false)
+  const dialogRef = useRef<HTMLDivElement | null>(null)
+
+  // Modal focus contract: focus returns to the opener when the dialog closes
+  // (the trap itself is in the keydown handler below).
+  useEffect(() => {
+    const opener = document.activeElement
+    return () => {
+      if (opener instanceof HTMLElement) {
+        opener.focus()
+      }
+    }
+  }, [])
 
   const provider = aiProvider(watch('provider'))
 
   const submit = handleSubmit(async (values) => {
     setSubmitError(null)
+    const apiKey = values.apiKey.trim()
     try {
+      if (!unverified) {
+        const validation = await validateApiKey(values.provider, apiKey, providerFetch)
+        if (validation === 'invalid') {
+          setSubmitError(`${aiProvider(values.provider).label} rejected this API key.`)
+          return
+        }
+        if (validation === 'unreachable') {
+          setUnverified(true)
+          return
+        }
+      }
       await onAdd({
         provider: values.provider,
         model: values.model,
-        apiKey: values.apiKey.trim(),
+        apiKey,
         isDefault: values.isDefault,
       })
       onClose()
@@ -57,6 +101,36 @@ export function AddAiModelDialog({ onAdd, onClose }: AddAiModelDialogProps): Rea
     }
   })
 
+  const handleDialogKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      onClose()
+      return
+    }
+    if (event.key !== 'Tab') {
+      return
+    }
+    // Keyboard-native product: Tab must cycle within the modal, not escape
+    // into the settings page behind it.
+    const container = dialogRef.current
+    if (!container) {
+      return
+    }
+    const focusable = container.querySelectorAll<HTMLElement>('select, input, button')
+    if (focusable.length === 0) {
+      return
+    }
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault()
+      first.focus()
+    }
+  }
+
   return (
     <div
       className="fixed inset-0 z-40 flex items-start justify-center bg-black/20 pt-[18vh]"
@@ -64,6 +138,7 @@ export function AddAiModelDialog({ onAdd, onClose }: AddAiModelDialogProps): Rea
       data-testid="add-ai-model-overlay"
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-label="Add AI model"
@@ -71,12 +146,7 @@ export function AddAiModelDialog({ onAdd, onClose }: AddAiModelDialogProps): Rea
         onPointerDown={(event) => {
           event.stopPropagation() // clicks inside must not close
         }}
-        onKeyDown={(event) => {
-          if (event.key === 'Escape') {
-            event.preventDefault()
-            onClose()
-          }
-        }}
+        onKeyDown={handleDialogKeyDown}
       >
         <h2 className="text-sm font-semibold text-text">Add AI model</h2>
         <p className="mt-0.5 text-xs text-text-muted">
@@ -98,6 +168,7 @@ export function AddAiModelDialog({ onAdd, onClose }: AddAiModelDialogProps): Rea
                   // Each provider has its own model list; reset to its first.
                   const next = aiProvider(event.target.value as AiProviderId)
                   setValue('model', next.models[0].id)
+                  setUnverified(false)
                 },
               })}
             >
@@ -130,6 +201,9 @@ export function AddAiModelDialog({ onAdd, onClose }: AddAiModelDialogProps): Rea
               className={FIELD_CONTROL_CLASS}
               {...register('apiKey', {
                 validate: (value) => value.trim().length > 0 || 'Enter an API key.',
+                onChange: () => {
+                  setUnverified(false)
+                },
               })}
             />
             {formState.errors.apiKey ? (
@@ -145,6 +219,12 @@ export function AddAiModelDialog({ onAdd, onClose }: AddAiModelDialogProps): Rea
           </label>
 
           {submitError !== null ? <InlineAlert tone="error">{submitError}</InlineAlert> : null}
+          {unverified ? (
+            <InlineAlert tone="warning">
+              Couldn’t reach {provider.label} to verify the key. Submit again to save it
+              unverified.
+            </InlineAlert>
+          ) : null}
 
           <div className="mt-1 flex justify-end gap-2">
             <button
@@ -159,7 +239,7 @@ export function AddAiModelDialog({ onAdd, onClose }: AddAiModelDialogProps): Rea
               disabled={formState.isSubmitting}
               className="rounded-md bg-accent px-3 py-1.5 text-[13px] font-medium text-text-on-brand shadow-sm transition-colors duration-100 hover:bg-accent-hover disabled:opacity-50"
             >
-              Add model
+              {unverified ? 'Save anyway' : 'Add model'}
             </button>
           </div>
         </form>

--- a/apps/desktop/src/components/settings/add-ai-model-dialog.tsx
+++ b/apps/desktop/src/components/settings/add-ai-model-dialog.tsx
@@ -1,0 +1,169 @@
+import { useState, type ChangeEvent, type ReactElement } from 'react'
+import { useForm } from 'react-hook-form'
+import { AI_PROVIDERS, aiProvider, errorMessage, type AiProviderId } from '@reflect/core'
+import { InlineAlert } from '@/components/inline-alert'
+import type { NewAiModel } from '@/hooks/use-ai-models'
+
+interface AddAiModelDialogProps {
+  /** Persists the new model (keychain + settings); rejects on failure. */
+  onAdd: (draft: NewAiModel) => Promise<void>
+  onClose: () => void
+}
+
+interface AddAiModelForm {
+  provider: AiProviderId
+  model: string
+  apiKey: string
+  isDefault: boolean
+}
+
+const FIELD_LABEL_CLASS = 'text-xs font-medium text-text-secondary'
+const FIELD_CONTROL_CLASS =
+  'w-full rounded-md border border-border bg-bg px-2.5 py-1.5 text-sm text-text ' +
+  'focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring'
+
+/**
+ * The "Add AI model" modal: pick a provider, pick one of its models, paste an
+ * API key, optionally mark it as the app default. Submitting hands the draft
+ * to {@link AddAiModelDialogProps.onAdd} — the key goes to the OS keychain,
+ * never into the settings document — and a failure keeps the dialog open with
+ * the typed key intact so the user can retry.
+ */
+export function AddAiModelDialog({ onAdd, onClose }: AddAiModelDialogProps): ReactElement {
+  const { register, handleSubmit, watch, setValue, formState } = useForm<AddAiModelForm>({
+    defaultValues: {
+      provider: AI_PROVIDERS[0].id,
+      model: AI_PROVIDERS[0].models[0].id,
+      apiKey: '',
+      isDefault: false,
+    },
+  })
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const provider = aiProvider(watch('provider'))
+
+  const submit = handleSubmit(async (values) => {
+    setSubmitError(null)
+    try {
+      await onAdd({
+        provider: values.provider,
+        model: values.model,
+        apiKey: values.apiKey.trim(),
+        isDefault: values.isDefault,
+      })
+      onClose()
+    } catch (error: unknown) {
+      setSubmitError(errorMessage(error))
+    }
+  })
+
+  return (
+    <div
+      className="fixed inset-0 z-40 flex items-start justify-center bg-black/20 pt-[18vh]"
+      onPointerDown={onClose}
+      data-testid="add-ai-model-overlay"
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Add AI model"
+        className="w-full max-w-sm rounded-lg border border-border bg-surface p-4 shadow-lg"
+        onPointerDown={(event) => {
+          event.stopPropagation() // clicks inside must not close
+        }}
+        onKeyDown={(event) => {
+          if (event.key === 'Escape') {
+            event.preventDefault()
+            onClose()
+          }
+        }}
+      >
+        <h2 className="text-sm font-semibold text-text">Add AI model</h2>
+        <p className="mt-0.5 text-xs text-text-muted">
+          The API key is stored in your OS keychain, never in your graph.
+        </p>
+        <form
+          className="mt-3 flex flex-col gap-3"
+          onSubmit={(event) => {
+            void submit(event)
+          }}
+        >
+          <label className="flex flex-col gap-1">
+            <span className={FIELD_LABEL_CLASS}>Provider</span>
+            <select
+              autoFocus
+              className={FIELD_CONTROL_CLASS}
+              {...register('provider', {
+                onChange: (event: ChangeEvent<HTMLSelectElement>) => {
+                  // Each provider has its own model list; reset to its first.
+                  const next = aiProvider(event.target.value as AiProviderId)
+                  setValue('model', next.models[0].id)
+                },
+              })}
+            >
+              {AI_PROVIDERS.map((candidate) => (
+                <option key={candidate.id} value={candidate.id}>
+                  {candidate.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span className={FIELD_LABEL_CLASS}>Model</span>
+            <select className={FIELD_CONTROL_CLASS} {...register('model')}>
+              {provider.models.map((model) => (
+                <option key={model.id} value={model.id}>
+                  {model.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span className={FIELD_LABEL_CLASS}>API key</span>
+            <input
+              type="password"
+              placeholder={provider.keyPlaceholder}
+              autoComplete="off"
+              spellCheck={false}
+              className={FIELD_CONTROL_CLASS}
+              {...register('apiKey', {
+                validate: (value) => value.trim().length > 0 || 'Enter an API key.',
+              })}
+            />
+            {formState.errors.apiKey ? (
+              <span role="alert" className="text-xs text-red-600 dark:text-red-400">
+                {formState.errors.apiKey.message}
+              </span>
+            ) : null}
+          </label>
+
+          <label className="flex items-center gap-2">
+            <input type="checkbox" className="accent-accent" {...register('isDefault')} />
+            <span className="text-sm text-text">Use as the default model</span>
+          </label>
+
+          {submitError !== null ? <InlineAlert tone="error">{submitError}</InlineAlert> : null}
+
+          <div className="mt-1 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border border-border px-3 py-1.5 text-[13px] font-medium text-text-secondary transition-colors duration-100 hover:bg-surface-hover"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={formState.isSubmitting}
+              className="rounded-md bg-accent px-3 py-1.5 text-[13px] font-medium text-text-on-brand shadow-sm transition-colors duration-100 hover:bg-accent-hover disabled:opacity-50"
+            >
+              Add model
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/components/settings/ai-model-row.tsx
+++ b/apps/desktop/src/components/settings/ai-model-row.tsx
@@ -1,0 +1,63 @@
+import type { ReactElement } from 'react'
+import { Trash2 } from 'lucide-react'
+import { aiModelLabel, aiProvider, errorMessage, type AiModelConfig } from '@reflect/core'
+import { startOperation } from '@/lib/operations'
+
+interface AiModelRowProps {
+  config: AiModelConfig
+  /** Make this entry the app-wide default. */
+  onMakeDefault: (id: string) => void
+  /** Remove the entry and its keychain secret; rejects on failure. */
+  onRemove: (id: string) => Promise<void>
+}
+
+/**
+ * One configured AI model in the settings list: provider + model, the stored
+ * key's trailing characters, and the default/remove controls. The row owns
+ * its own removal (including surfacing a keychain failure as an operation).
+ */
+export function AiModelRow({ config, onMakeDefault, onRemove }: AiModelRowProps): ReactElement {
+  const providerLabel = aiProvider(config.provider).label
+  const modelLabel = aiModelLabel(config.provider, config.model)
+  const name = `${providerLabel} — ${modelLabel}`
+
+  const remove = (): void => {
+    onRemove(config.id).catch((error: unknown) => {
+      startOperation(`Removing ${name}`).fail(errorMessage(error))
+    })
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-4 px-4 py-3">
+      <div className="min-w-0">
+        <div className="truncate text-sm font-medium text-text">{name}</div>
+        <p className="mt-0.5 text-xs text-text-muted">
+          API key <span className="font-mono">·····{config.keyHint}</span>
+        </p>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        {config.isDefault ? (
+          <span className="rounded-full bg-accent-soft px-2 py-0.5 text-[11px] font-medium text-accent-soft-text">
+            Default
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={() => onMakeDefault(config.id)}
+            className="rounded-md px-2 py-0.5 text-xs text-text-secondary transition-colors duration-100 hover:bg-surface-hover hover:text-text"
+          >
+            Make default
+          </button>
+        )}
+        <button
+          type="button"
+          aria-label={`Remove ${name}`}
+          onClick={remove}
+          className="rounded-md p-1.5 text-text-muted transition-colors duration-100 hover:bg-surface-hover hover:text-text"
+        >
+          <Trash2 aria-hidden strokeWidth={1.75} className="size-4" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/components/settings/ai-model-row.tsx
+++ b/apps/desktop/src/components/settings/ai-model-row.tsx
@@ -5,6 +5,8 @@ import { startOperation } from '@/lib/operations'
 
 interface AiModelRowProps {
   config: AiModelConfig
+  /** Whether this entry is the (resolved) app-wide default. */
+  isDefault: boolean
   /** Make this entry the app-wide default. */
   onMakeDefault: (id: string) => void
   /** Remove the entry and its keychain secret; rejects on failure. */
@@ -16,7 +18,12 @@ interface AiModelRowProps {
  * key's trailing characters, and the default/remove controls. The row owns
  * its own removal (including surfacing a keychain failure as an operation).
  */
-export function AiModelRow({ config, onMakeDefault, onRemove }: AiModelRowProps): ReactElement {
+export function AiModelRow({
+  config,
+  isDefault,
+  onMakeDefault,
+  onRemove,
+}: AiModelRowProps): ReactElement {
   const providerLabel = aiProvider(config.provider).label
   const modelLabel = aiModelLabel(config.provider, config.model)
   const name = `${providerLabel} — ${modelLabel}`
@@ -36,7 +43,7 @@ export function AiModelRow({ config, onMakeDefault, onRemove }: AiModelRowProps)
         </p>
       </div>
       <div className="flex shrink-0 items-center gap-2">
-        {config.isDefault ? (
+        {isDefault ? (
           <span className="rounded-full bg-accent-soft px-2 py-0.5 text-[11px] font-medium text-accent-soft-text">
             Default
           </span>

--- a/apps/desktop/src/components/settings/ai-models-section.test.tsx
+++ b/apps/desktop/src/components/settings/ai-models-section.test.tsx
@@ -10,15 +10,20 @@ let stored: Record<string, unknown>
 let saved: unknown[]
 let secrets: Map<string, string>
 let failSecretSet: boolean
+let failLoad: boolean
 
 function installFakeBridge(): void {
   saved = []
   secrets = new Map()
   failSecretSet = false
+  failLoad = false
   setBridge({
     invoke: async (command, args) => {
       switch (command) {
         case 'settings_load':
+          if (failLoad) {
+            throw { kind: 'io', message: 'corrupt store' }
+          }
           return stored
         case 'settings_save':
           saved.push(args.settings)
@@ -172,6 +177,25 @@ describe('AiModelsSection', () => {
       ]),
     )
     expect(secrets.has('ai-api-key:a')).toBe(false)
+  })
+
+  it('refuses to add when the settings store failed to load (no orphaned key)', async () => {
+    failLoad = true
+    renderSection()
+    await waitFor(() => expect(screen.getByText(/No AI models configured/)).toBeTruthy())
+
+    fireEvent.click(screen.getByRole('button', { name: /add model/i }))
+    const dialog = within(screen.getByRole('dialog', { name: 'Add AI model' }))
+    fireEvent.change(dialog.getByLabelText('API key'), { target: { value: 'sk-test' } })
+    fireEvent.click(dialog.getByRole('button', { name: 'Add model' }))
+
+    // A session-only entry would vanish on restart, stranding the key in the
+    // keychain with no UI to delete it — so the key must never be stored.
+    await waitFor(() =>
+      expect(dialog.getByRole('alert').textContent).toMatch(/could not be loaded/i),
+    )
+    expect(secrets.size).toBe(0)
+    expect(saved).toEqual([])
   })
 
   it('overlapping removes both land instead of clobbering each other', async () => {

--- a/apps/desktop/src/components/settings/ai-models-section.test.tsx
+++ b/apps/desktop/src/components/settings/ai-models-section.test.tsx
@@ -174,6 +174,33 @@ describe('AiModelsSection', () => {
     expect(secrets.has('ai-api-key:a')).toBe(false)
   })
 
+  it('overlapping removes both land instead of clobbering each other', async () => {
+    stored = {
+      aiModels: [
+        entry({ id: 'a', isDefault: true }),
+        entry({ id: 'b', provider: 'openai', model: 'gpt-5.1', keyHint: 'abcd2' }),
+      ],
+    }
+    secrets.set('ai-api-key:a', 'sk-a')
+    secrets.set('ai-api-key:b', 'sk-b')
+    renderSection()
+    await waitFor(() =>
+      expect(screen.getByText('Anthropic — Claude Opus 4.8')).toBeTruthy(),
+    )
+
+    // Both removes fire in the same tick; each suspends on its keychain
+    // delete, so each settings update applies after the other's snapshot
+    // went stale. A snapshot-based write would leave one row behind with
+    // its key already gone from the keychain.
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Remove Anthropic — Claude Opus 4.8' }),
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Remove OpenAI — GPT-5.1' }))
+
+    await waitFor(() => expect(lastSavedModels()).toEqual([]))
+    expect(secrets.size).toBe(0)
+  })
+
   it('make default moves the flag', async () => {
     stored = {
       aiModels: [

--- a/apps/desktop/src/components/settings/ai-models-section.test.tsx
+++ b/apps/desktop/src/components/settings/ai-models-section.test.tsx
@@ -1,0 +1,198 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { setBridge, settingsSchema, type AiModelConfig } from '@reflect/core'
+import { SettingsProvider } from '@/providers/settings-provider'
+import { resetOperations } from '@/lib/operations'
+import { AiModelsSection } from './ai-models-section'
+
+let stored: Record<string, unknown>
+let saved: unknown[]
+let secrets: Map<string, string>
+let failSecretSet: boolean
+
+function installFakeBridge(): void {
+  saved = []
+  secrets = new Map()
+  failSecretSet = false
+  setBridge({
+    invoke: async (command, args) => {
+      switch (command) {
+        case 'settings_load':
+          return stored
+        case 'settings_save':
+          saved.push(args.settings)
+          return null
+        case 'secret_set':
+          if (failSecretSet) {
+            throw { kind: 'io', message: 'keychain locked' }
+          }
+          secrets.set(args.name as string, args.value as string)
+          return null
+        case 'secret_delete':
+          secrets.delete(args.name as string)
+          return null
+        default:
+          return null
+      }
+    },
+    listen: async () => () => {},
+  })
+}
+
+let queryClient: QueryClient
+
+function renderSection(): void {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <SettingsProvider>
+        <AiModelsSection />
+      </SettingsProvider>
+    </QueryClientProvider>,
+  )
+}
+
+/** The aiModels list of the most recently persisted document. */
+function lastSavedModels(): AiModelConfig[] {
+  return settingsSchema.parse(saved.at(-1)).aiModels
+}
+
+function entry(overrides: Partial<AiModelConfig>): AiModelConfig {
+  return {
+    id: 'id',
+    provider: 'anthropic',
+    model: 'claude-opus-4-8',
+    keyHint: 'wxyz1',
+    isDefault: false,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  stored = {}
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  })
+  installFakeBridge()
+})
+
+afterEach(() => {
+  cleanup()
+  setBridge(null)
+  queryClient.clear()
+  resetOperations()
+})
+
+describe('AiModelsSection', () => {
+  it('lists configured models with their key hint and default badge', async () => {
+    stored = {
+      aiModels: [
+        entry({ id: 'a', isDefault: true }),
+        entry({ id: 'b', provider: 'openai', model: 'gpt-5.1', keyHint: 'abcd2' }),
+      ],
+    }
+    renderSection()
+
+    await waitFor(() =>
+      expect(screen.getByText('Anthropic — Claude Opus 4.8')).toBeTruthy(),
+    )
+    expect(screen.getByText('OpenAI — GPT-5.1')).toBeTruthy()
+    expect(screen.getByText(/wxyz1/)).toBeTruthy()
+    expect(screen.getByText(/abcd2/)).toBeTruthy()
+    expect(screen.getByText('Default')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Make default' })).toBeTruthy()
+  })
+
+  it('adds a model: key goes to the keychain, entry (with hint) to settings', async () => {
+    renderSection()
+    await waitFor(() => expect(screen.getByText(/No AI models configured/)).toBeTruthy())
+
+    fireEvent.click(screen.getByRole('button', { name: /add model/i }))
+    const dialog = within(screen.getByRole('dialog', { name: 'Add AI model' }))
+
+    fireEvent.change(dialog.getByLabelText('Provider'), { target: { value: 'anthropic' } })
+    fireEvent.change(dialog.getByLabelText('Model'), {
+      target: { value: 'claude-sonnet-4-6' },
+    })
+    fireEvent.change(dialog.getByLabelText('API key'), {
+      target: { value: 'sk-ant-test-wxyz1' },
+    })
+    fireEvent.click(dialog.getByRole('button', { name: 'Add model' }))
+
+    await waitFor(() => expect(saved).toHaveLength(1))
+    const [added] = lastSavedModels()
+    expect(added).toMatchObject({
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      keyHint: 'wxyz1',
+      isDefault: true, // the first entry is always the default
+    })
+    // The full key reached the keychain (and only the keychain).
+    expect(secrets.get(`ai-api-key:${added.id}`)).toBe('sk-ant-test-wxyz1')
+    expect(JSON.stringify(saved)).not.toContain('sk-ant-test-wxyz1')
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('a failed keychain write keeps the dialog open and persists nothing', async () => {
+    renderSection()
+    await waitFor(() => expect(screen.getByText(/No AI models configured/)).toBeTruthy())
+    failSecretSet = true
+
+    fireEvent.click(screen.getByRole('button', { name: /add model/i }))
+    const dialog = within(screen.getByRole('dialog', { name: 'Add AI model' }))
+    fireEvent.change(dialog.getByLabelText('API key'), { target: { value: 'sk-test' } })
+    fireEvent.click(dialog.getByRole('button', { name: 'Add model' }))
+
+    await waitFor(() => expect(dialog.getByRole('alert').textContent).toBe('keychain locked'))
+    expect(screen.getByRole('dialog')).toBeTruthy()
+    expect(saved).toEqual([])
+    expect(secrets.size).toBe(0)
+  })
+
+  it('removes a model, deletes its secret, and promotes the next default', async () => {
+    stored = {
+      aiModels: [
+        entry({ id: 'a', isDefault: true }),
+        entry({ id: 'b', provider: 'openai', model: 'gpt-5.1', keyHint: 'abcd2' }),
+      ],
+    }
+    secrets.set('ai-api-key:a', 'sk-a')
+    renderSection()
+    await waitFor(() =>
+      expect(screen.getByText('Anthropic — Claude Opus 4.8')).toBeTruthy(),
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Remove Anthropic — Claude Opus 4.8' }),
+    )
+
+    await waitFor(() =>
+      expect(lastSavedModels()).toEqual([
+        entry({ id: 'b', provider: 'openai', model: 'gpt-5.1', keyHint: 'abcd2', isDefault: true }),
+      ]),
+    )
+    expect(secrets.has('ai-api-key:a')).toBe(false)
+  })
+
+  it('make default moves the flag', async () => {
+    stored = {
+      aiModels: [
+        entry({ id: 'a', isDefault: true }),
+        entry({ id: 'b', provider: 'openai', model: 'gpt-5.1', keyHint: 'abcd2' }),
+      ],
+    }
+    renderSection()
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Make default' })).toBeTruthy(),
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Make default' }))
+
+    await waitFor(() =>
+      expect(lastSavedModels().map((model) => [model.id, model.isDefault])).toEqual([
+        ['a', false],
+        ['b', true],
+      ]),
+    )
+  })
+})

--- a/apps/desktop/src/components/settings/ai-models-section.test.tsx
+++ b/apps/desktop/src/components/settings/ai-models-section.test.tsx
@@ -1,10 +1,15 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { setBridge, settingsSchema, type AiModelConfig } from '@reflect/core'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setBridge, settingsSchema, type AiModelConfig, type Settings } from '@reflect/core'
 import { SettingsProvider } from '@/providers/settings-provider'
 import { resetOperations } from '@/lib/operations'
 import { AiModelsSection } from './ai-models-section'
+
+// The dialog verifies keys against the provider through this transport; the
+// default per-test behavior is "key accepted".
+const { providerFetchMock } = vi.hoisted(() => ({ providerFetchMock: vi.fn() }))
+vi.mock('@/lib/provider-fetch', () => ({ providerFetch: providerFetchMock }))
 
 let stored: Record<string, unknown>
 let saved: unknown[]
@@ -57,9 +62,9 @@ function renderSection(): void {
   )
 }
 
-/** The aiModels list of the most recently persisted document. */
-function lastSavedModels(): AiModelConfig[] {
-  return settingsSchema.parse(saved.at(-1)).aiModels
+/** The most recently persisted document, parsed. */
+function lastSavedDoc(): Settings {
+  return settingsSchema.parse(saved.at(-1))
 }
 
 function entry(overrides: Partial<AiModelConfig>): AiModelConfig {
@@ -68,9 +73,24 @@ function entry(overrides: Partial<AiModelConfig>): AiModelConfig {
     provider: 'anthropic',
     model: 'claude-opus-4-8',
     keyHint: 'wxyz1',
-    isDefault: false,
     ...overrides,
   }
+}
+
+/** Two configured entries with 'a' as the default. */
+function twoStoredModels(): Record<string, unknown> {
+  return {
+    aiModels: [
+      entry({ id: 'a' }),
+      entry({ id: 'b', provider: 'openai', model: 'gpt-5.1', keyHint: 'abcd2' }),
+    ],
+    defaultAiModelId: 'a',
+  }
+}
+
+function openDialog(): ReturnType<typeof within> {
+  fireEvent.click(screen.getByRole('button', { name: /add model/i }))
+  return within(screen.getByRole('dialog', { name: 'Add AI model' }))
 }
 
 beforeEach(() => {
@@ -79,6 +99,8 @@ beforeEach(() => {
     defaultOptions: { queries: { retry: false, staleTime: Infinity } },
   })
   installFakeBridge()
+  providerFetchMock.mockReset()
+  providerFetchMock.mockResolvedValue(new Response(null, { status: 200 }))
 })
 
 afterEach(() => {
@@ -90,12 +112,7 @@ afterEach(() => {
 
 describe('AiModelsSection', () => {
   it('lists configured models with their key hint and default badge', async () => {
-    stored = {
-      aiModels: [
-        entry({ id: 'a', isDefault: true }),
-        entry({ id: 'b', provider: 'openai', model: 'gpt-5.1', keyHint: 'abcd2' }),
-      ],
-    }
+    stored = twoStoredModels()
     renderSection()
 
     await waitFor(() =>
@@ -108,13 +125,11 @@ describe('AiModelsSection', () => {
     expect(screen.getByRole('button', { name: 'Make default' })).toBeTruthy()
   })
 
-  it('adds a model: key goes to the keychain, entry (with hint) to settings', async () => {
+  it('adds a model: key verified, then keychain + settings entry', async () => {
     renderSection()
     await waitFor(() => expect(screen.getByText(/No AI models configured/)).toBeTruthy())
 
-    fireEvent.click(screen.getByRole('button', { name: /add model/i }))
-    const dialog = within(screen.getByRole('dialog', { name: 'Add AI model' }))
-
+    const dialog = openDialog()
     fireEvent.change(dialog.getByLabelText('Provider'), { target: { value: 'anthropic' } })
     fireEvent.change(dialog.getByLabelText('Model'), {
       target: { value: 'claude-sonnet-4-6' },
@@ -125,16 +140,58 @@ describe('AiModelsSection', () => {
     fireEvent.click(dialog.getByRole('button', { name: 'Add model' }))
 
     await waitFor(() => expect(saved).toHaveLength(1))
-    const [added] = lastSavedModels()
+    const doc = lastSavedDoc()
+    const [added] = doc.aiModels
     expect(added).toMatchObject({
       provider: 'anthropic',
       model: 'claude-sonnet-4-6',
       keyHint: 'wxyz1',
-      isDefault: true, // the first entry is always the default
     })
+    // The first entry becomes the default automatically.
+    expect(doc.defaultAiModelId).toBe(added.id)
+    // The key was verified against the provider before being stored.
+    expect(providerFetchMock).toHaveBeenCalledWith(
+      'https://api.anthropic.com/v1/models',
+      expect.objectContaining({ method: 'GET' }),
+    )
     // The full key reached the keychain (and only the keychain).
     expect(secrets.get(`ai-api-key:${added.id}`)).toBe('sk-ant-test-wxyz1')
     expect(JSON.stringify(saved)).not.toContain('sk-ant-test-wxyz1')
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('rejects a key the provider turns down, storing nothing', async () => {
+    providerFetchMock.mockResolvedValue(new Response(null, { status: 401 }))
+    renderSection()
+    await waitFor(() => expect(screen.getByText(/No AI models configured/)).toBeTruthy())
+
+    const dialog = openDialog()
+    fireEvent.change(dialog.getByLabelText('API key'), { target: { value: 'sk-typo' } })
+    fireEvent.click(dialog.getByRole('button', { name: 'Add model' }))
+
+    await waitFor(() =>
+      expect(dialog.getByRole('alert').textContent).toMatch(/rejected this API key/i),
+    )
+    expect(secrets.size).toBe(0)
+    expect(saved).toEqual([])
+  })
+
+  it('offers save-anyway when the provider cannot be reached', async () => {
+    providerFetchMock.mockRejectedValue(new TypeError('offline'))
+    renderSection()
+    await waitFor(() => expect(screen.getByText(/No AI models configured/)).toBeTruthy())
+
+    const dialog = openDialog()
+    fireEvent.change(dialog.getByLabelText('API key'), { target: { value: 'sk-offline-key' } })
+    fireEvent.click(dialog.getByRole('button', { name: 'Add model' }))
+
+    // First submit downgrades to an explicit unverified save, not a block.
+    await waitFor(() => expect(dialog.getByRole('alert').textContent).toMatch(/reach OpenAI/))
+    expect(saved).toEqual([])
+
+    fireEvent.click(dialog.getByRole('button', { name: 'Save anyway' }))
+    await waitFor(() => expect(saved).toHaveLength(1))
+    expect(secrets.size).toBe(1)
     expect(screen.queryByRole('dialog')).toBeNull()
   })
 
@@ -143,8 +200,7 @@ describe('AiModelsSection', () => {
     await waitFor(() => expect(screen.getByText(/No AI models configured/)).toBeTruthy())
     failSecretSet = true
 
-    fireEvent.click(screen.getByRole('button', { name: /add model/i }))
-    const dialog = within(screen.getByRole('dialog', { name: 'Add AI model' }))
+    const dialog = openDialog()
     fireEvent.change(dialog.getByLabelText('API key'), { target: { value: 'sk-test' } })
     fireEvent.click(dialog.getByRole('button', { name: 'Add model' }))
 
@@ -154,38 +210,12 @@ describe('AiModelsSection', () => {
     expect(secrets.size).toBe(0)
   })
 
-  it('removes a model, deletes its secret, and promotes the next default', async () => {
-    stored = {
-      aiModels: [
-        entry({ id: 'a', isDefault: true }),
-        entry({ id: 'b', provider: 'openai', model: 'gpt-5.1', keyHint: 'abcd2' }),
-      ],
-    }
-    secrets.set('ai-api-key:a', 'sk-a')
-    renderSection()
-    await waitFor(() =>
-      expect(screen.getByText('Anthropic — Claude Opus 4.8')).toBeTruthy(),
-    )
-
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Remove Anthropic — Claude Opus 4.8' }),
-    )
-
-    await waitFor(() =>
-      expect(lastSavedModels()).toEqual([
-        entry({ id: 'b', provider: 'openai', model: 'gpt-5.1', keyHint: 'abcd2', isDefault: true }),
-      ]),
-    )
-    expect(secrets.has('ai-api-key:a')).toBe(false)
-  })
-
   it('refuses to add when the settings store failed to load (no orphaned key)', async () => {
     failLoad = true
     renderSection()
     await waitFor(() => expect(screen.getByText(/No AI models configured/)).toBeTruthy())
 
-    fireEvent.click(screen.getByRole('button', { name: /add model/i }))
-    const dialog = within(screen.getByRole('dialog', { name: 'Add AI model' }))
+    const dialog = openDialog()
     fireEvent.change(dialog.getByLabelText('API key'), { target: { value: 'sk-test' } })
     fireEvent.click(dialog.getByRole('button', { name: 'Add model' }))
 
@@ -198,13 +228,29 @@ describe('AiModelsSection', () => {
     expect(saved).toEqual([])
   })
 
+  it('removes a model, deletes its secret, and promotes the next default', async () => {
+    stored = twoStoredModels()
+    secrets.set('ai-api-key:a', 'sk-a')
+    renderSection()
+    await waitFor(() =>
+      expect(screen.getByText('Anthropic — Claude Opus 4.8')).toBeTruthy(),
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Remove Anthropic — Claude Opus 4.8' }),
+    )
+
+    await waitFor(() =>
+      expect(lastSavedDoc()).toMatchObject({
+        aiModels: [entry({ id: 'b', provider: 'openai', model: 'gpt-5.1', keyHint: 'abcd2' })],
+        defaultAiModelId: 'b',
+      }),
+    )
+    expect(secrets.has('ai-api-key:a')).toBe(false)
+  })
+
   it('overlapping removes both land instead of clobbering each other', async () => {
-    stored = {
-      aiModels: [
-        entry({ id: 'a', isDefault: true }),
-        entry({ id: 'b', provider: 'openai', model: 'gpt-5.1', keyHint: 'abcd2' }),
-      ],
-    }
+    stored = twoStoredModels()
     secrets.set('ai-api-key:a', 'sk-a')
     secrets.set('ai-api-key:b', 'sk-b')
     renderSection()
@@ -221,17 +267,14 @@ describe('AiModelsSection', () => {
     )
     fireEvent.click(screen.getByRole('button', { name: 'Remove OpenAI — GPT-5.1' }))
 
-    await waitFor(() => expect(lastSavedModels()).toEqual([]))
+    await waitFor(() =>
+      expect(lastSavedDoc()).toMatchObject({ aiModels: [], defaultAiModelId: null }),
+    )
     expect(secrets.size).toBe(0)
   })
 
-  it('make default moves the flag', async () => {
-    stored = {
-      aiModels: [
-        entry({ id: 'a', isDefault: true }),
-        entry({ id: 'b', provider: 'openai', model: 'gpt-5.1', keyHint: 'abcd2' }),
-      ],
-    }
+  it('make default moves the id', async () => {
+    stored = twoStoredModels()
     renderSection()
     await waitFor(() =>
       expect(screen.getByRole('button', { name: 'Make default' })).toBeTruthy(),
@@ -239,11 +282,30 @@ describe('AiModelsSection', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Make default' }))
 
-    await waitFor(() =>
-      expect(lastSavedModels().map((model) => [model.id, model.isDefault])).toEqual([
-        ['a', false],
-        ['b', true],
-      ]),
-    )
+    await waitFor(() => expect(lastSavedDoc().defaultAiModelId).toBe('b'))
+    expect(lastSavedDoc().aiModels).toHaveLength(2)
+  })
+
+  it('traps Tab inside the dialog', async () => {
+    renderSection()
+    await waitFor(() => expect(screen.getByText(/No AI models configured/)).toBeTruthy())
+
+    const dialog = openDialog()
+    const submitButton = dialog.getByRole('button', { name: 'Add model' })
+    submitButton.focus()
+    fireEvent.keyDown(submitButton, { key: 'Tab' })
+
+    // From the last control, Tab wraps to the first instead of escaping
+    // into the settings page behind the modal.
+    expect(document.activeElement).toBe(dialog.getByLabelText('Provider'))
+  })
+
+  it('falls back to the first entry when the default id dangles', async () => {
+    stored = { ...twoStoredModels(), defaultAiModelId: 'gone' }
+    renderSection()
+
+    await waitFor(() => expect(screen.getByText('Default')).toBeTruthy())
+    // The badge lands on the first row; the second still offers "Make default".
+    expect(screen.getByRole('button', { name: 'Make default' })).toBeTruthy()
   })
 })

--- a/apps/desktop/src/components/settings/ai-models-section.tsx
+++ b/apps/desktop/src/components/settings/ai-models-section.tsx
@@ -1,0 +1,48 @@
+import { useState, type ReactElement } from 'react'
+import { Plus } from 'lucide-react'
+import { useAiModels } from '@/hooks/use-ai-models'
+import { AddAiModelDialog } from './add-ai-model-dialog'
+import { AiModelRow } from './ai-model-row'
+import { SettingsSection } from './section'
+
+/**
+ * Settings → AI models (Plan 10): the configured BYOK providers. Each entry
+ * pairs a provider + model choice (persisted in the settings document) with
+ * an API key (persisted in the OS keychain); the list shows which is the
+ * app-wide default and only the key's trailing characters.
+ */
+export function AiModelsSection(): ReactElement {
+  const { models, addModel, removeModel, makeDefault } = useAiModels()
+  const [adding, setAdding] = useState(false)
+
+  return (
+    <SettingsSection title="AI models">
+      {models.length === 0 ? (
+        <p className="px-4 py-3.5 text-xs text-text-muted">
+          No AI models configured. Add a provider API key to use AI features — keys are
+          stored in your OS keychain and calls go directly to the provider.
+        </p>
+      ) : (
+        models.map((config) => (
+          <AiModelRow
+            key={config.id}
+            config={config}
+            onMakeDefault={makeDefault}
+            onRemove={removeModel}
+          />
+        ))
+      )}
+      <div className="px-4 py-2.5">
+        <button
+          type="button"
+          onClick={() => setAdding(true)}
+          className="flex items-center gap-1.5 rounded-md px-2 py-1 text-[13px] font-medium text-accent transition-colors duration-100 hover:bg-surface-hover"
+        >
+          <Plus aria-hidden strokeWidth={1.75} className="size-4" />
+          Add model
+        </button>
+      </div>
+      {adding ? <AddAiModelDialog onAdd={addModel} onClose={() => setAdding(false)} /> : null}
+    </SettingsSection>
+  )
+}

--- a/apps/desktop/src/components/settings/ai-models-section.tsx
+++ b/apps/desktop/src/components/settings/ai-models-section.tsx
@@ -12,7 +12,7 @@ import { SettingsSection } from './section'
  * app-wide default and only the key's trailing characters.
  */
 export function AiModelsSection(): ReactElement {
-  const { models, addModel, removeModel, makeDefault } = useAiModels()
+  const { models, defaultModel, addModel, removeModel, makeDefault } = useAiModels()
   const [adding, setAdding] = useState(false)
 
   return (
@@ -27,6 +27,7 @@ export function AiModelsSection(): ReactElement {
           <AiModelRow
             key={config.id}
             config={config}
+            isDefault={config.id === defaultModel?.id}
             onMakeDefault={makeDefault}
             onRemove={removeModel}
           />

--- a/apps/desktop/src/hooks/use-ai-models.ts
+++ b/apps/desktop/src/hooks/use-ai-models.ts
@@ -1,0 +1,81 @@
+import { useCallback } from 'react'
+import {
+  aiKeySecretName,
+  apiKeyHint,
+  deleteSecret,
+  setSecret,
+  withAiModelAdded,
+  withAiModelRemoved,
+  withDefaultAiModel,
+  type AiModelConfig,
+  type AiProviderId,
+} from '@reflect/core'
+import { useSettings } from '@/providers/settings-provider'
+
+/**
+ * The configured-AI-models surface (Plan 10): one hook owning the pairing of
+ * the settings document (provider, model, key hint, default flag) with the OS
+ * keychain (the key itself). Components never touch the secret commands
+ * directly, so the "settings entry ⇄ keychain entry" invariant has one owner.
+ */
+
+/** What the add-model dialog collects; the key goes to the keychain only. */
+export interface NewAiModel {
+  provider: AiProviderId
+  model: string
+  apiKey: string
+  isDefault: boolean
+}
+
+interface UseAiModelsValue {
+  models: AiModelConfig[]
+  /**
+   * Store the key in the keychain, then add the settings entry. Rejects (and
+   * adds nothing) if the keychain write fails, so an entry can never point at
+   * a key that was never stored.
+   */
+  addModel: (draft: NewAiModel) => Promise<void>
+  /** Delete the key from the keychain, then drop the settings entry. */
+  removeModel: (id: string) => Promise<void>
+  /** Make the entry with `id` the app-wide default. */
+  makeDefault: (id: string) => void
+}
+
+export function useAiModels(): UseAiModelsValue {
+  const { settings, updateSettings } = useSettings()
+  const models = settings.aiModels
+
+  const addModel = useCallback(
+    async (draft: NewAiModel): Promise<void> => {
+      const id = crypto.randomUUID()
+      await setSecret(aiKeySecretName(id), draft.apiKey)
+      updateSettings({
+        aiModels: withAiModelAdded(models, {
+          id,
+          provider: draft.provider,
+          model: draft.model,
+          keyHint: apiKeyHint(draft.apiKey),
+          isDefault: draft.isDefault,
+        }),
+      })
+    },
+    [models, updateSettings],
+  )
+
+  const removeModel = useCallback(
+    async (id: string): Promise<void> => {
+      await deleteSecret(aiKeySecretName(id))
+      updateSettings({ aiModels: withAiModelRemoved(models, id) })
+    },
+    [models, updateSettings],
+  )
+
+  const makeDefault = useCallback(
+    (id: string): void => {
+      updateSettings({ aiModels: withDefaultAiModel(models, id) })
+    },
+    [models, updateSettings],
+  )
+
+  return { models, addModel, removeModel, makeDefault }
+}

--- a/apps/desktop/src/hooks/use-ai-models.ts
+++ b/apps/desktop/src/hooks/use-ai-models.ts
@@ -9,6 +9,7 @@ import {
   withDefaultAiModel,
   type AiModelConfig,
   type AiProviderId,
+  type AppError,
 } from '@reflect/core'
 import { useSettings } from '@/providers/settings-provider'
 
@@ -31,8 +32,10 @@ interface UseAiModelsValue {
   models: AiModelConfig[]
   /**
    * Store the key in the keychain, then add the settings entry. Rejects (and
-   * adds nothing) if the keychain write fails, so an entry can never point at
-   * a key that was never stored.
+   * adds nothing) if the keychain write fails — so an entry can never point
+   * at a key that was never stored — or if the settings store could not be
+   * read this session, so a key can never be stored for an entry that won't
+   * survive a restart.
    */
   addModel: (draft: NewAiModel) => Promise<void>
   /** Delete the key from the keychain, then drop the settings entry. */
@@ -42,7 +45,7 @@ interface UseAiModelsValue {
 }
 
 export function useAiModels(): UseAiModelsValue {
-  const { settings, updateSettingsWith } = useSettings()
+  const { settings, updateSettingsWith, whenSettingsLoaded } = useSettings()
   const models = settings.aiModels
 
   // Every write goes through `updateSettingsWith` so the list is rebuilt from
@@ -53,6 +56,19 @@ export function useAiModels(): UseAiModelsValue {
 
   const addModel = useCallback(
     async (draft: NewAiModel): Promise<void> => {
+      // Refuse before the key touches the keychain: with an unreadable
+      // settings store the entry would be session-only, and after a restart
+      // the stored key would be orphaned with no UI left to delete it.
+      // Awaiting the outcome (rather than reading a flag) also covers an add
+      // racing the in-flight load that then fails.
+      if ((await whenSettingsLoaded()) === 'failed') {
+        const error: AppError = {
+          kind: 'io',
+          message:
+            'Settings could not be loaded, so new AI models cannot be saved. The API key was not stored.',
+        }
+        throw error
+      }
       const id = crypto.randomUUID()
       await setSecret(aiKeySecretName(id), draft.apiKey)
       updateSettingsWith((current) => ({
@@ -65,7 +81,7 @@ export function useAiModels(): UseAiModelsValue {
         }),
       }))
     },
-    [updateSettingsWith],
+    [whenSettingsLoaded, updateSettingsWith],
   )
 
   const removeModel = useCallback(

--- a/apps/desktop/src/hooks/use-ai-models.ts
+++ b/apps/desktop/src/hooks/use-ai-models.ts
@@ -70,6 +70,12 @@ export function useAiModels(): UseAiModelsValue {
 
   const removeModel = useCallback(
     async (id: string): Promise<void> => {
+      // Keychain first, deliberately. The two stores can't be updated
+      // transactionally; interrupted in this order, the leftover is a
+      // visibly dead settings row the user can remove again. The reverse
+      // order would strand the credential invisibly in the keychain — the
+      // keyring API can't enumerate entries, so it could never be swept.
+      // The settings write itself is retried by the provider on failure.
       await deleteSecret(aiKeySecretName(id))
       updateSettingsWith((current) => ({ aiModels: withAiModelRemoved(current.aiModels, id) }))
     },

--- a/apps/desktop/src/hooks/use-ai-models.ts
+++ b/apps/desktop/src/hooks/use-ai-models.ts
@@ -2,11 +2,11 @@ import { useCallback } from 'react'
 import {
   aiKeySecretName,
   apiKeyHint,
+  defaultAiModel,
   deleteSecret,
   setSecret,
   withAiModelAdded,
   withAiModelRemoved,
-  withDefaultAiModel,
   type AiModelConfig,
   type AiProviderId,
   type AppError,
@@ -15,9 +15,9 @@ import { useSettings } from '@/providers/settings-provider'
 
 /**
  * The configured-AI-models surface (Plan 10): one hook owning the pairing of
- * the settings document (provider, model, key hint, default flag) with the OS
- * keychain (the key itself). Components never touch the secret commands
- * directly, so the "settings entry ⇄ keychain entry" invariant has one owner.
+ * the settings document (entries + default id) with the OS keychain (the key
+ * itself). Components never touch the secret commands directly, so the
+ * "settings entry ⇄ keychain entry" invariant has one owner.
  */
 
 /** What the add-model dialog collects; the key goes to the keychain only. */
@@ -30,6 +30,8 @@ export interface NewAiModel {
 
 interface UseAiModelsValue {
   models: AiModelConfig[]
+  /** The entry AI features use by default (null only when the list is empty). */
+  defaultModel: AiModelConfig | null
   /**
    * Store the key in the keychain, then add the settings entry. Rejects (and
    * adds nothing) if the keychain write fails — so an entry can never point
@@ -47,12 +49,13 @@ interface UseAiModelsValue {
 export function useAiModels(): UseAiModelsValue {
   const { settings, updateSettingsWith, whenSettingsLoaded } = useSettings()
   const models = settings.aiModels
+  const defaultModel = defaultAiModel({ models, defaultModelId: settings.defaultAiModelId })
 
-  // Every write goes through `updateSettingsWith` so the list is rebuilt from
-  // the settings as they are when the update applies — not from this render's
-  // snapshot. The keychain awaits make these genuinely concurrent: a second
-  // add/remove can land mid-flight, and a snapshot-based write would clobber
-  // it (or resurrect an entry whose key was already deleted).
+  // Every write goes through `updateSettingsWith` so the state is rebuilt
+  // from the settings as they are when the update applies — not from this
+  // render's snapshot. The keychain awaits make these genuinely concurrent:
+  // a second add/remove can land mid-flight, and a snapshot-based write
+  // would clobber it (or resurrect an entry whose key was already deleted).
 
   const addModel = useCallback(
     async (draft: NewAiModel): Promise<void> => {
@@ -71,15 +74,14 @@ export function useAiModels(): UseAiModelsValue {
       }
       const id = crypto.randomUUID()
       await setSecret(aiKeySecretName(id), draft.apiKey)
-      updateSettingsWith((current) => ({
-        aiModels: withAiModelAdded(current.aiModels, {
-          id,
-          provider: draft.provider,
-          model: draft.model,
-          keyHint: apiKeyHint(draft.apiKey),
-          isDefault: draft.isDefault,
-        }),
-      }))
+      updateSettingsWith((current) => {
+        const next = withAiModelAdded(
+          { models: current.aiModels, defaultModelId: current.defaultAiModelId },
+          { id, provider: draft.provider, model: draft.model, keyHint: apiKeyHint(draft.apiKey) },
+          draft.isDefault,
+        )
+        return { aiModels: next.models, defaultAiModelId: next.defaultModelId }
+      })
     },
     [whenSettingsLoaded, updateSettingsWith],
   )
@@ -93,17 +95,23 @@ export function useAiModels(): UseAiModelsValue {
       // keyring API can't enumerate entries, so it could never be swept.
       // The settings write itself is retried by the provider on failure.
       await deleteSecret(aiKeySecretName(id))
-      updateSettingsWith((current) => ({ aiModels: withAiModelRemoved(current.aiModels, id) }))
+      updateSettingsWith((current) => {
+        const next = withAiModelRemoved(
+          { models: current.aiModels, defaultModelId: current.defaultAiModelId },
+          id,
+        )
+        return { aiModels: next.models, defaultAiModelId: next.defaultModelId }
+      })
     },
     [updateSettingsWith],
   )
 
   const makeDefault = useCallback(
     (id: string): void => {
-      updateSettingsWith((current) => ({ aiModels: withDefaultAiModel(current.aiModels, id) }))
+      updateSettingsWith(() => ({ defaultAiModelId: id }))
     },
     [updateSettingsWith],
   )
 
-  return { models, addModel, removeModel, makeDefault }
+  return { models, defaultModel, addModel, removeModel, makeDefault }
 }

--- a/apps/desktop/src/hooks/use-ai-models.ts
+++ b/apps/desktop/src/hooks/use-ai-models.ts
@@ -42,39 +42,45 @@ interface UseAiModelsValue {
 }
 
 export function useAiModels(): UseAiModelsValue {
-  const { settings, updateSettings } = useSettings()
+  const { settings, updateSettingsWith } = useSettings()
   const models = settings.aiModels
+
+  // Every write goes through `updateSettingsWith` so the list is rebuilt from
+  // the settings as they are when the update applies — not from this render's
+  // snapshot. The keychain awaits make these genuinely concurrent: a second
+  // add/remove can land mid-flight, and a snapshot-based write would clobber
+  // it (or resurrect an entry whose key was already deleted).
 
   const addModel = useCallback(
     async (draft: NewAiModel): Promise<void> => {
       const id = crypto.randomUUID()
       await setSecret(aiKeySecretName(id), draft.apiKey)
-      updateSettings({
-        aiModels: withAiModelAdded(models, {
+      updateSettingsWith((current) => ({
+        aiModels: withAiModelAdded(current.aiModels, {
           id,
           provider: draft.provider,
           model: draft.model,
           keyHint: apiKeyHint(draft.apiKey),
           isDefault: draft.isDefault,
         }),
-      })
+      }))
     },
-    [models, updateSettings],
+    [updateSettingsWith],
   )
 
   const removeModel = useCallback(
     async (id: string): Promise<void> => {
       await deleteSecret(aiKeySecretName(id))
-      updateSettings({ aiModels: withAiModelRemoved(models, id) })
+      updateSettingsWith((current) => ({ aiModels: withAiModelRemoved(current.aiModels, id) }))
     },
-    [models, updateSettings],
+    [updateSettingsWith],
   )
 
   const makeDefault = useCallback(
     (id: string): void => {
-      updateSettings({ aiModels: withDefaultAiModel(models, id) })
+      updateSettingsWith((current) => ({ aiModels: withDefaultAiModel(current.aiModels, id) }))
     },
-    [models, updateSettings],
+    [updateSettingsWith],
   )
 
   return { models, addModel, removeModel, makeDefault }

--- a/apps/desktop/src/lib/provider-fetch.ts
+++ b/apps/desktop/src/lib/provider-fetch.ts
@@ -1,0 +1,14 @@
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
+import { hasBridge } from '@reflect/core'
+
+/**
+ * The transport for direct app → AI-provider calls (BYOK, Plan 10). Inside
+ * the Tauri shell this is the HTTP plugin's fetch — requests go out from the
+ * Rust side, so webview CORS doesn't apply (OpenAI's API sends no CORS
+ * headers and would be unreachable from the webview otherwise). The allowed
+ * hosts are scoped in `src-tauri/capabilities/default.json`. In plain-browser
+ * dev there is no shell, so this falls back to the global fetch.
+ */
+export function providerFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  return hasBridge() ? tauriFetch(input, init) : fetch(input, init)
+}

--- a/apps/desktop/src/providers/settings-provider.test.tsx
+++ b/apps/desktop/src/providers/settings-provider.test.tsx
@@ -252,6 +252,22 @@ describe('SettingsProvider', () => {
     expect(saved).toEqual([])
   })
 
+  it('with no bridge (browser dev) the load settles as failed instead of hanging', async () => {
+    setBridge(null)
+    const { result } = renderHook(() => useSettings(), { wrapper })
+
+    // Waiters must not hang on a query that will never run.
+    await expect(result.current.whenSettingsLoaded()).resolves.toBe('failed')
+
+    // Read-modify-write updates drain immediately (session-only) rather than
+    // queueing forever, and nothing is ever persisted.
+    act(() => {
+      result.current.updateSettingsWith(() => ({ editorMarkdownSyntax: 'show' }))
+    })
+    expect(result.current.settings.editorMarkdownSyntax).toBe('show')
+    expect(saved).toEqual([])
+  })
+
   it('keeps the applied value and surfaces a failed save as an operation', async () => {
     const { result } = renderHook(
       () => ({ ...useSettings(), operations: useOperations() }),

--- a/apps/desktop/src/providers/settings-provider.test.tsx
+++ b/apps/desktop/src/providers/settings-provider.test.tsx
@@ -165,6 +165,30 @@ describe('SettingsProvider', () => {
     expect(result.current.settings.editorMarkdownSyntax).toBe('focus')
   })
 
+  it('updateSettingsWith builds each patch from the latest settings, not the closure', async () => {
+    stored = {
+      aiModels: [
+        { id: 'a', provider: 'openai', model: 'gpt-5.1', keyHint: '11111', isDefault: true },
+        { id: 'b', provider: 'openai', model: 'gpt-5', keyHint: '22222', isDefault: false },
+      ],
+    }
+    const { result } = renderHook(() => useSettings(), { wrapper })
+    await loadSettled()
+
+    // Both updaters are dispatched from the same render — equally "stale"
+    // closures. Sequential application means the second still sees the
+    // first's result; a snapshot-based merge would resurrect entry 'a'.
+    act(() => {
+      result.current.updateSettingsWith((current) => ({
+        aiModels: current.aiModels.filter((model) => model.id !== 'a'),
+      }))
+      result.current.updateSettingsWith((current) => ({
+        aiModels: current.aiModels.filter((model) => model.id !== 'b'),
+      }))
+    })
+    expect(result.current.settings.aiModels).toEqual([])
+  })
+
   it('keeps the applied value and surfaces a failed save as an operation', async () => {
     const { result } = renderHook(
       () => ({ ...useSettings(), operations: useOperations() }),

--- a/apps/desktop/src/providers/settings-provider.test.tsx
+++ b/apps/desktop/src/providers/settings-provider.test.tsx
@@ -2,7 +2,7 @@ import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { ReactNode } from 'react'
-import { setBridge } from '@reflect/core'
+import { setBridge, type AiModelConfig } from '@reflect/core'
 import { resetOperations, useOperations } from '@/lib/operations'
 import { flushSettings } from '@/lib/settings-flush'
 import { SETTINGS_QUERY_KEY, SettingsProvider, useSettings } from './settings-provider'
@@ -187,6 +187,69 @@ describe('SettingsProvider', () => {
       }))
     })
     expect(result.current.settings.aiModels).toEqual([])
+  })
+
+  it('a read-modify-write racing the initial load replays over the loaded document', async () => {
+    const persisted: AiModelConfig = {
+      id: 'a',
+      provider: 'openai',
+      model: 'gpt-5.1',
+      keyHint: '11111',
+      isDefault: true,
+    }
+    const added: AiModelConfig = {
+      id: 'b',
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      keyHint: '22222',
+      isDefault: false,
+    }
+    stored = { aiModels: [persisted] }
+    gateLoad = true
+    const { result } = renderHook(() => useSettings(), { wrapper })
+
+    act(() => {
+      result.current.updateSettingsWith((current) => ({
+        aiModels: [...current.aiModels, added],
+      }))
+    })
+    // Held until hydration: applied over defaults, this "add one" would
+    // compute [added] and the eventual save would erase the persisted entry.
+    expect(result.current.settings.aiModels).toEqual([])
+    expect(saved).toEqual([])
+
+    act(() => {
+      releaseLoad()
+    })
+    await waitFor(() => expect(result.current.settings.aiModels).toEqual([persisted, added]))
+    await waitFor(() =>
+      expect(saved).toEqual([expect.objectContaining({ aiModels: [persisted, added] })]),
+    )
+  })
+
+  it('a queued read-modify-write still applies session-only when the load fails', async () => {
+    const added: AiModelConfig = {
+      id: 'b',
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      keyHint: '22222',
+      isDefault: true,
+    }
+    failLoad = true
+    const { result } = renderHook(() => useSettings(), { wrapper })
+
+    act(() => {
+      result.current.updateSettingsWith((current) => ({
+        aiModels: [...current.aiModels, added],
+      }))
+    })
+    // The failed load drains the queue over defaults — the edit must not
+    // vanish — but nothing is written over a store that couldn't be read.
+    await waitFor(() => expect(result.current.settings.aiModels).toEqual([added]))
+    await act(async () => {
+      await flushSettings()
+    })
+    expect(saved).toEqual([])
   })
 
   it('keeps the applied value and surfaces a failed save as an operation', async () => {

--- a/apps/desktop/src/providers/settings-provider.test.tsx
+++ b/apps/desktop/src/providers/settings-provider.test.tsx
@@ -118,7 +118,7 @@ describe('SettingsProvider', () => {
     expect(result.current.settings.editorMarkdownSyntax).toBe('show')
     // The persisted document keeps unknown keys (newer-version settings survive).
     await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system', aiModels: [], futureKey: true }]),
+      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system', aiModels: [], defaultAiModelId: null, futureKey: true }]),
     )
   })
 
@@ -142,7 +142,7 @@ describe('SettingsProvider', () => {
     // The load result must not clobber the update, and the deferred flush
     // persists the update merged over the *loaded* document.
     await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system', aiModels: [], futureKey: true }]),
+      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system', aiModels: [], defaultAiModelId: null, futureKey: true }]),
     )
     expect(result.current.settings.editorMarkdownSyntax).toBe('show')
   })
@@ -160,7 +160,7 @@ describe('SettingsProvider', () => {
       releaseLoad()
     })
     await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkdownSyntax: 'focus', theme: 'system', aiModels: [] }]),
+      expect(saved).toEqual([{ editorMarkdownSyntax: 'focus', theme: 'system', aiModels: [], defaultAiModelId: null }]),
     )
     expect(result.current.settings.editorMarkdownSyntax).toBe('focus')
   })
@@ -168,8 +168,8 @@ describe('SettingsProvider', () => {
   it('updateSettingsWith builds each patch from the latest settings, not the closure', async () => {
     stored = {
       aiModels: [
-        { id: 'a', provider: 'openai', model: 'gpt-5.1', keyHint: '11111', isDefault: true },
-        { id: 'b', provider: 'openai', model: 'gpt-5', keyHint: '22222', isDefault: false },
+        { id: 'a', provider: 'openai', model: 'gpt-5.1', keyHint: '11111' },
+        { id: 'b', provider: 'openai', model: 'gpt-5', keyHint: '22222' },
       ],
     }
     const { result } = renderHook(() => useSettings(), { wrapper })
@@ -195,14 +195,12 @@ describe('SettingsProvider', () => {
       provider: 'openai',
       model: 'gpt-5.1',
       keyHint: '11111',
-      isDefault: true,
     }
     const added: AiModelConfig = {
       id: 'b',
       provider: 'anthropic',
       model: 'claude-opus-4-8',
       keyHint: '22222',
-      isDefault: false,
     }
     stored = { aiModels: [persisted] }
     gateLoad = true
@@ -233,7 +231,6 @@ describe('SettingsProvider', () => {
       provider: 'anthropic',
       model: 'claude-opus-4-8',
       keyHint: '22222',
-      isDefault: true,
     }
     failLoad = true
     const { result } = renderHook(() => useSettings(), { wrapper })
@@ -308,7 +305,7 @@ describe('SettingsProvider', () => {
       result.current.updateSettings({ editorMarkdownSyntax: 'show' })
     })
     await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system', aiModels: [] }]),
+      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system', aiModels: [], defaultAiModelId: null }]),
     )
   })
 
@@ -330,7 +327,7 @@ describe('SettingsProvider', () => {
     await act(async () => {
       await flushSettings()
     })
-    expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system', aiModels: [] }])
+    expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system', aiModels: [], defaultAiModelId: null }])
   })
 
   it('surfaces a failed load and keeps changes session-only', async () => {

--- a/apps/desktop/src/providers/settings-provider.test.tsx
+++ b/apps/desktop/src/providers/settings-provider.test.tsx
@@ -118,7 +118,7 @@ describe('SettingsProvider', () => {
     expect(result.current.settings.editorMarkdownSyntax).toBe('show')
     // The persisted document keeps unknown keys (newer-version settings survive).
     await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system', futureKey: true }]),
+      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system', aiModels: [], futureKey: true }]),
     )
   })
 
@@ -142,7 +142,7 @@ describe('SettingsProvider', () => {
     // The load result must not clobber the update, and the deferred flush
     // persists the update merged over the *loaded* document.
     await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system', futureKey: true }]),
+      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system', aiModels: [], futureKey: true }]),
     )
     expect(result.current.settings.editorMarkdownSyntax).toBe('show')
   })
@@ -160,7 +160,7 @@ describe('SettingsProvider', () => {
       releaseLoad()
     })
     await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkdownSyntax: 'focus', theme: 'system' }]),
+      expect(saved).toEqual([{ editorMarkdownSyntax: 'focus', theme: 'system', aiModels: [] }]),
     )
     expect(result.current.settings.editorMarkdownSyntax).toBe('focus')
   })
@@ -205,7 +205,7 @@ describe('SettingsProvider', () => {
       result.current.updateSettings({ editorMarkdownSyntax: 'show' })
     })
     await waitFor(() =>
-      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system' }]),
+      expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system', aiModels: [] }]),
     )
   })
 
@@ -227,7 +227,7 @@ describe('SettingsProvider', () => {
     await act(async () => {
       await flushSettings()
     })
-    expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system' }])
+    expect(saved).toEqual([{ editorMarkdownSyntax: 'show', theme: 'system', aiModels: [] }])
   })
 
   it('surfaces a failed load and keeps changes session-only', async () => {

--- a/apps/desktop/src/providers/settings-provider.tsx
+++ b/apps/desktop/src/providers/settings-provider.tsx
@@ -42,7 +42,9 @@ interface SettingsContextValue {
    * merged settings at apply time. Use this for read-modify-write updates
    * (e.g. list edits after an `await`): React applies functional updaters
    * sequentially, so concurrent edits compose instead of clobbering each
-   * other through a stale render-time snapshot.
+   * other through a stale render-time snapshot. Updaters dispatched before
+   * hydration are queued and replayed over the loaded document — an edit of
+   * a list the disk is about to supply must not be computed from defaults.
    */
   updateSettingsWith: (updater: (current: Settings) => Partial<Settings>) => void
 }
@@ -81,19 +83,48 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
     setOverrides((current) => ({ ...current, ...patch }))
   }, [])
 
+  const applyUpdater = useCallback((updater: (current: Settings) => Partial<Settings>) => {
+    setOverrides((current) => {
+      // Rebuild the merged document from the *queued* overrides, not the
+      // render-time `settings` value — React applies these updaters in
+      // order, so each one sees the result of the previous edit even when
+      // both were dispatched from stale closures.
+      const merged: Settings = { ...DEFAULT_SETTINGS, ...loadedRef.current, ...current }
+      return { ...current, ...updater(merged) }
+    })
+  }, [])
+
+  // Read-modify-write trails hydration, like persistence does: an updater
+  // applied over defaults would compute its patch from a list the disk
+  // document is about to supply (an early "add" would then override — and on
+  // the next save erase — every persisted entry). `null` marks the queue as
+  // drained; from then on updaters apply directly.
+  const pendingUpdaters = useRef<((current: Settings) => Partial<Settings>)[] | null>([])
+
   const updateSettingsWith = useCallback(
     (updater: (current: Settings) => Partial<Settings>) => {
-      setOverrides((current) => {
-        // Rebuild the merged document from the *queued* overrides, not the
-        // render-time `settings` value — React applies these updaters in
-        // order, so each one sees the result of the previous edit even when
-        // both were dispatched from stale closures.
-        const merged: Settings = { ...DEFAULT_SETTINGS, ...loadedRef.current, ...current }
-        return { ...current, ...updater(merged) }
-      })
+      if (pendingUpdaters.current !== null) {
+        pendingUpdaters.current.push(updater)
+        return
+      }
+      applyUpdater(updater)
     },
-    [],
+    [applyUpdater],
   )
+
+  useEffect(() => {
+    // Drain once the load settles either way — after a failed load the
+    // updaters apply over defaults and changes stay session-only, matching
+    // the scalar-update semantics below.
+    if ((loaded === undefined && !loadError) || pendingUpdaters.current === null) {
+      return
+    }
+    const queued = pendingUpdaters.current
+    pendingUpdaters.current = null
+    for (const updater of queued) {
+      applyUpdater(updater)
+    }
+  }, [loaded, loadError, applyUpdater])
 
   // A corrupt store fails the load *by design* (Rust errors rather than
   // reading empty, so a later save can't wipe the real document). Changes

--- a/apps/desktop/src/providers/settings-provider.tsx
+++ b/apps/desktop/src/providers/settings-provider.tsx
@@ -47,9 +47,34 @@ interface SettingsContextValue {
    * a list the disk is about to supply must not be computed from defaults.
    */
   updateSettingsWith: (updater: (current: Settings) => Partial<Settings>) => void
+  /**
+   * Resolves once the initial disk load has settled, and with which outcome.
+   * After `'failed'`, changes apply session-only and nothing persists —
+   * callers that pair a settings entry with state elsewhere (e.g. a keychain
+   * secret) must await this before writing the other half, or a restart
+   * loses the entry and strands its counterpart. A boolean can't close that
+   * window: a write racing the in-flight load needs the eventual outcome.
+   */
+  whenSettingsLoaded: () => Promise<SettingsLoadOutcome>
 }
 
+/** How the initial settings load ended (`'failed'` ⇒ session-only mode). */
+export type SettingsLoadOutcome = 'loaded' | 'failed'
+
 const SettingsContext = createContext<SettingsContextValue | null>(null)
+
+interface LoadSettle {
+  promise: Promise<SettingsLoadOutcome>
+  resolve: (outcome: SettingsLoadOutcome) => void
+}
+
+function createLoadSettle(): LoadSettle {
+  let resolve: (outcome: SettingsLoadOutcome) => void = () => {}
+  const promise = new Promise<SettingsLoadOutcome>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+  return { promise, resolve }
+}
 
 /** Shallow own-key equality — settings documents are flat JSON objects. */
 function sameDocument(a: Settings, b: Settings): boolean {
@@ -126,6 +151,25 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
     }
   }, [loaded, loadError, applyUpdater])
 
+  // Settling the load outcome as a promise lets callers *await* it; resolving
+  // an already-resolved promise is a no-op, so the effect can stay simple.
+  const loadSettle = useRef<LoadSettle | null>(null)
+  if (loadSettle.current === null) {
+    loadSettle.current = createLoadSettle()
+  }
+  useEffect(() => {
+    if (loaded !== undefined) {
+      loadSettle.current?.resolve('loaded')
+    } else if (loadError !== null) {
+      loadSettle.current?.resolve('failed')
+    }
+  }, [loaded, loadError])
+  const whenSettingsLoaded = useCallback(
+    (): Promise<SettingsLoadOutcome> =>
+      loadSettle.current?.promise ?? Promise.resolve('failed'),
+    [],
+  )
+
   // A corrupt store fails the load *by design* (Rust errors rather than
   // reading empty, so a later save can't wipe the real document). Changes
   // then apply for the session only — surface that state, don't hide it.
@@ -186,8 +230,8 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
   }, [persistIfChanged])
 
   const value = useMemo<SettingsContextValue>(
-    () => ({ settings, updateSettings, updateSettingsWith }),
-    [settings, updateSettings, updateSettingsWith],
+    () => ({ settings, updateSettings, updateSettingsWith, whenSettingsLoaded }),
+    [settings, updateSettings, updateSettingsWith, whenSettingsLoaded],
   )
 
   return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>

--- a/apps/desktop/src/providers/settings-provider.tsx
+++ b/apps/desktop/src/providers/settings-provider.tsx
@@ -61,6 +61,8 @@ interface SettingsContextValue {
 /** How the initial settings load ended (`'failed'` ⇒ session-only mode). */
 export type SettingsLoadOutcome = 'loaded' | 'failed'
 
+type SettingsLoadState = SettingsLoadOutcome | 'pending'
+
 const SettingsContext = createContext<SettingsContextValue | null>(null)
 
 interface LoadSettle {
@@ -97,6 +99,14 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
   const [overrides, setOverrides] = useState<Partial<Settings>>({})
   const loadedRef = useRef(loaded)
   loadedRef.current = loaded
+
+  // One derived load-state drives everything that waits on hydration (the
+  // updater queue drain, the settle promise). With no bridge installed
+  // (plain-browser dev) the query never runs, so there is nothing to wait
+  // for: that settles immediately as 'failed' — i.e. session-only — instead
+  // of leaving waiters hanging on a load that will never happen.
+  const loadState: SettingsLoadState =
+    !hasBridge() || loadError !== null ? 'failed' : loaded !== undefined ? 'loaded' : 'pending'
 
   // Defaults are usable before the IPC load settles — no loading gate.
   const settings = useMemo<Settings>(
@@ -138,10 +148,10 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
   )
 
   useEffect(() => {
-    // Drain once the load settles either way — after a failed load the
-    // updaters apply over defaults and changes stay session-only, matching
-    // the scalar-update semantics below.
-    if ((loaded === undefined && !loadError) || pendingUpdaters.current === null) {
+    // Drain once the load settles either way — after 'failed' the updaters
+    // apply over defaults and changes stay session-only, matching the
+    // scalar-update semantics below.
+    if (loadState === 'pending' || pendingUpdaters.current === null) {
       return
     }
     const queued = pendingUpdaters.current
@@ -149,7 +159,7 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
     for (const updater of queued) {
       applyUpdater(updater)
     }
-  }, [loaded, loadError, applyUpdater])
+  }, [loadState, applyUpdater])
 
   // Settling the load outcome as a promise lets callers *await* it; resolving
   // an already-resolved promise is a no-op, so the effect can stay simple.
@@ -158,12 +168,10 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
     loadSettle.current = createLoadSettle()
   }
   useEffect(() => {
-    if (loaded !== undefined) {
-      loadSettle.current?.resolve('loaded')
-    } else if (loadError !== null) {
-      loadSettle.current?.resolve('failed')
+    if (loadState !== 'pending') {
+      loadSettle.current?.resolve(loadState)
     }
-  }, [loaded, loadError])
+  }, [loadState])
   const whenSettingsLoaded = useCallback(
     (): Promise<SettingsLoadOutcome> =>
       loadSettle.current?.promise ?? Promise.resolve('failed'),

--- a/apps/desktop/src/providers/settings-provider.tsx
+++ b/apps/desktop/src/providers/settings-provider.tsx
@@ -37,6 +37,14 @@ interface SettingsContextValue {
   settings: Settings
   /** Merge `patch` into the settings: applied immediately, persisted async. */
   updateSettings: (patch: Partial<Settings>) => void
+  /**
+   * Like {@link updateSettings}, but the patch is computed from the latest
+   * merged settings at apply time. Use this for read-modify-write updates
+   * (e.g. list edits after an `await`): React applies functional updaters
+   * sequentially, so concurrent edits compose instead of clobbering each
+   * other through a stale render-time snapshot.
+   */
+  updateSettingsWith: (updater: (current: Settings) => Partial<Settings>) => void
 }
 
 const SettingsContext = createContext<SettingsContextValue | null>(null)
@@ -60,6 +68,8 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
     staleTime: Infinity,
   })
   const [overrides, setOverrides] = useState<Partial<Settings>>({})
+  const loadedRef = useRef(loaded)
+  loadedRef.current = loaded
 
   // Defaults are usable before the IPC load settles — no loading gate.
   const settings = useMemo<Settings>(
@@ -70,6 +80,20 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
   const updateSettings = useCallback((patch: Partial<Settings>) => {
     setOverrides((current) => ({ ...current, ...patch }))
   }, [])
+
+  const updateSettingsWith = useCallback(
+    (updater: (current: Settings) => Partial<Settings>) => {
+      setOverrides((current) => {
+        // Rebuild the merged document from the *queued* overrides, not the
+        // render-time `settings` value — React applies these updaters in
+        // order, so each one sees the result of the previous edit even when
+        // both were dispatched from stale closures.
+        const merged: Settings = { ...DEFAULT_SETTINGS, ...loadedRef.current, ...current }
+        return { ...current, ...updater(merged) }
+      })
+    },
+    [],
+  )
 
   // A corrupt store fails the load *by design* (Rust errors rather than
   // reading empty, so a later save can't wipe the real document). Changes
@@ -93,8 +117,6 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
   const lastPersisted = useRef<Settings | null>(null)
   const settingsRef = useRef(settings)
   settingsRef.current = settings
-  const loadedRef = useRef(loaded)
-  loadedRef.current = loaded
 
   const persistIfChanged = useCallback((): Promise<void> => {
     const disk = loadedRef.current
@@ -133,8 +155,8 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
   }, [persistIfChanged])
 
   const value = useMemo<SettingsContextValue>(
-    () => ({ settings, updateSettings }),
-    [settings, updateSettings],
+    () => ({ settings, updateSettings, updateSettingsWith }),
+    [settings, updateSettings, updateSettingsWith],
   )
 
   return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>

--- a/packages/core/src/ai/models.test.ts
+++ b/packages/core/src/ai/models.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import type { AiModelConfig } from '../settings/schema'
+import {
+  apiKeyHint,
+  defaultAiModel,
+  withAiModelAdded,
+  withAiModelRemoved,
+  withDefaultAiModel,
+} from './models'
+
+function config(overrides: Partial<AiModelConfig>): AiModelConfig {
+  return {
+    id: 'id',
+    provider: 'openai',
+    model: 'gpt-5.1',
+    keyHint: 'hint1',
+    isDefault: false,
+    ...overrides,
+  }
+}
+
+describe('apiKeyHint', () => {
+  it('keeps only the trailing characters of a key', () => {
+    expect(apiKeyHint('sk-ant-api03-secret-wxyz1')).toBe('wxyz1')
+  })
+
+  it('never exposes more than the key itself', () => {
+    expect(apiKeyHint('abc')).toBe('abc')
+  })
+})
+
+describe('withAiModelAdded', () => {
+  it('makes the first entry the default even when not requested', () => {
+    const added = withAiModelAdded([], config({ id: 'a', isDefault: false }))
+    expect(added).toEqual([config({ id: 'a', isDefault: true })])
+  })
+
+  it('appends a non-default entry without touching the default', () => {
+    const existing = [config({ id: 'a', isDefault: true })]
+    const added = withAiModelAdded(existing, config({ id: 'b' }))
+    expect(added.map((model) => [model.id, model.isDefault])).toEqual([
+      ['a', true],
+      ['b', false],
+    ])
+  })
+
+  it('an entry added as default demotes the previous default', () => {
+    const existing = [config({ id: 'a', isDefault: true })]
+    const added = withAiModelAdded(existing, config({ id: 'b', isDefault: true }))
+    expect(added.map((model) => [model.id, model.isDefault])).toEqual([
+      ['a', false],
+      ['b', true],
+    ])
+  })
+})
+
+describe('withAiModelRemoved', () => {
+  it('removes the entry with the id', () => {
+    const models = [config({ id: 'a', isDefault: true }), config({ id: 'b' })]
+    expect(withAiModelRemoved(models, 'b')).toEqual([config({ id: 'a', isDefault: true })])
+  })
+
+  it('promotes the first remaining entry when the default is removed', () => {
+    const models = [config({ id: 'a', isDefault: true }), config({ id: 'b' })]
+    expect(withAiModelRemoved(models, 'a')).toEqual([config({ id: 'b', isDefault: true })])
+  })
+
+  it('removing the last entry yields the empty list', () => {
+    expect(withAiModelRemoved([config({ id: 'a', isDefault: true })], 'a')).toEqual([])
+  })
+})
+
+describe('withDefaultAiModel', () => {
+  it('moves the default flag to the chosen entry', () => {
+    const models = [config({ id: 'a', isDefault: true }), config({ id: 'b' })]
+    expect(withDefaultAiModel(models, 'b').map((model) => [model.id, model.isDefault])).toEqual([
+      ['a', false],
+      ['b', true],
+    ])
+  })
+})
+
+describe('defaultAiModel', () => {
+  it('returns the flagged entry', () => {
+    const models = [config({ id: 'a' }), config({ id: 'b', isDefault: true })]
+    expect(defaultAiModel(models)?.id).toBe('b')
+  })
+
+  it('falls back to the first entry when no flag survived', () => {
+    const models = [config({ id: 'a' }), config({ id: 'b' })]
+    expect(defaultAiModel(models)?.id).toBe('a')
+  })
+
+  it('returns null for the empty list', () => {
+    expect(defaultAiModel([])).toBeNull()
+  })
+})

--- a/packages/core/src/ai/models.test.ts
+++ b/packages/core/src/ai/models.test.ts
@@ -5,7 +5,7 @@ import {
   defaultAiModel,
   withAiModelAdded,
   withAiModelRemoved,
-  withDefaultAiModel,
+  type AiModelsState,
 } from './models'
 
 function config(overrides: Partial<AiModelConfig>): AiModelConfig {
@@ -14,9 +14,12 @@ function config(overrides: Partial<AiModelConfig>): AiModelConfig {
     provider: 'openai',
     model: 'gpt-5.1',
     keyHint: 'hint1',
-    isDefault: false,
     ...overrides,
   }
+}
+
+function state(models: AiModelConfig[], defaultModelId: string | null): AiModelsState {
+  return { models, defaultModelId }
 }
 
 describe('apiKeyHint', () => {
@@ -24,74 +27,62 @@ describe('apiKeyHint', () => {
     expect(apiKeyHint('sk-ant-api03-secret-wxyz1')).toBe('wxyz1')
   })
 
-  it('never exposes more than the key itself', () => {
-    expect(apiKeyHint('abc')).toBe('abc')
+  it('returns no hint for a key short enough that it would reveal most of it', () => {
+    expect(apiKeyHint('abc')).toBe('')
+    expect(apiKeyHint('123456789')).toBe('')
+    expect(apiKeyHint('1234567890')).toBe('67890')
   })
 })
 
 describe('withAiModelAdded', () => {
   it('makes the first entry the default even when not requested', () => {
-    const added = withAiModelAdded([], config({ id: 'a', isDefault: false }))
-    expect(added).toEqual([config({ id: 'a', isDefault: true })])
+    expect(withAiModelAdded(state([], null), config({ id: 'a' }), false)).toEqual(
+      state([config({ id: 'a' })], 'a'),
+    )
   })
 
   it('appends a non-default entry without touching the default', () => {
-    const existing = [config({ id: 'a', isDefault: true })]
-    const added = withAiModelAdded(existing, config({ id: 'b' }))
-    expect(added.map((model) => [model.id, model.isDefault])).toEqual([
-      ['a', true],
-      ['b', false],
-    ])
+    const before = state([config({ id: 'a' })], 'a')
+    expect(withAiModelAdded(before, config({ id: 'b' }), false)).toEqual(
+      state([config({ id: 'a' }), config({ id: 'b' })], 'a'),
+    )
   })
 
-  it('an entry added as default demotes the previous default', () => {
-    const existing = [config({ id: 'a', isDefault: true })]
-    const added = withAiModelAdded(existing, config({ id: 'b', isDefault: true }))
-    expect(added.map((model) => [model.id, model.isDefault])).toEqual([
-      ['a', false],
-      ['b', true],
-    ])
+  it('an entry added as default takes over', () => {
+    const before = state([config({ id: 'a' })], 'a')
+    expect(withAiModelAdded(before, config({ id: 'b' }), true).defaultModelId).toBe('b')
   })
 })
 
 describe('withAiModelRemoved', () => {
   it('removes the entry with the id', () => {
-    const models = [config({ id: 'a', isDefault: true }), config({ id: 'b' })]
-    expect(withAiModelRemoved(models, 'b')).toEqual([config({ id: 'a', isDefault: true })])
+    const before = state([config({ id: 'a' }), config({ id: 'b' })], 'a')
+    expect(withAiModelRemoved(before, 'b')).toEqual(state([config({ id: 'a' })], 'a'))
   })
 
   it('promotes the first remaining entry when the default is removed', () => {
-    const models = [config({ id: 'a', isDefault: true }), config({ id: 'b' })]
-    expect(withAiModelRemoved(models, 'a')).toEqual([config({ id: 'b', isDefault: true })])
+    const before = state([config({ id: 'a' }), config({ id: 'b' })], 'a')
+    expect(withAiModelRemoved(before, 'a')).toEqual(state([config({ id: 'b' })], 'b'))
   })
 
-  it('removing the last entry yields the empty list', () => {
-    expect(withAiModelRemoved([config({ id: 'a', isDefault: true })], 'a')).toEqual([])
-  })
-})
-
-describe('withDefaultAiModel', () => {
-  it('moves the default flag to the chosen entry', () => {
-    const models = [config({ id: 'a', isDefault: true }), config({ id: 'b' })]
-    expect(withDefaultAiModel(models, 'b').map((model) => [model.id, model.isDefault])).toEqual([
-      ['a', false],
-      ['b', true],
-    ])
+  it('removing the last entry clears the default', () => {
+    expect(withAiModelRemoved(state([config({ id: 'a' })], 'a'), 'a')).toEqual(state([], null))
   })
 })
 
 describe('defaultAiModel', () => {
-  it('returns the flagged entry', () => {
-    const models = [config({ id: 'a' }), config({ id: 'b', isDefault: true })]
-    expect(defaultAiModel(models)?.id).toBe('b')
+  it('returns the entry the id points at', () => {
+    const models = [config({ id: 'a' }), config({ id: 'b' })]
+    expect(defaultAiModel(state(models, 'b'))?.id).toBe('b')
   })
 
-  it('falls back to the first entry when no flag survived', () => {
+  it('falls back to the first entry for a null or dangling id', () => {
     const models = [config({ id: 'a' }), config({ id: 'b' })]
-    expect(defaultAiModel(models)?.id).toBe('a')
+    expect(defaultAiModel(state(models, null))?.id).toBe('a')
+    expect(defaultAiModel(state(models, 'gone'))?.id).toBe('a')
   })
 
   it('returns null for the empty list', () => {
-    expect(defaultAiModel([])).toBeNull()
+    expect(defaultAiModel(state([], null))).toBeNull()
   })
 })

--- a/packages/core/src/ai/models.ts
+++ b/packages/core/src/ai/models.ts
@@ -1,0 +1,50 @@
+import type { AiModelConfig } from '../settings/schema'
+
+/**
+ * Pure transforms over the configured-AI-models list (Plan 10). They maintain
+ * one invariant: a non-empty list has exactly one default entry. Callers pair
+ * these with the keychain bindings in `secrets.ts` — the list never carries
+ * the keys themselves.
+ */
+
+/** How many trailing key characters are kept as the display hint. */
+export const KEY_HINT_LENGTH = 5
+
+/** The display-only suffix of an API key (`keyHint` in the settings doc). */
+export function apiKeyHint(key: string): string {
+  return key.slice(-KEY_HINT_LENGTH)
+}
+
+/**
+ * Append `entry`, keeping a single default: the first entry is always the
+ * default, and an entry added as default demotes the previous one.
+ */
+export function withAiModelAdded(models: AiModelConfig[], entry: AiModelConfig): AiModelConfig[] {
+  const isDefault = entry.isDefault || models.length === 0
+  const existing = isDefault
+    ? models.map((model) => ({ ...model, isDefault: false }))
+    : [...models]
+  return [...existing, { ...entry, isDefault }]
+}
+
+/**
+ * Remove the entry with `id`. If it was the default, the first remaining
+ * entry is promoted so the list never ends up default-less.
+ */
+export function withAiModelRemoved(models: AiModelConfig[], id: string): AiModelConfig[] {
+  const remaining = models.filter((model) => model.id !== id)
+  if (remaining.length === 0 || remaining.some((model) => model.isDefault)) {
+    return remaining
+  }
+  return remaining.map((model, index) => (index === 0 ? { ...model, isDefault: true } : model))
+}
+
+/** Make the entry with `id` the sole default. */
+export function withDefaultAiModel(models: AiModelConfig[], id: string): AiModelConfig[] {
+  return models.map((model) => ({ ...model, isDefault: model.id === id }))
+}
+
+/** The entry AI features should use when no explicit choice is made. */
+export function defaultAiModel(models: AiModelConfig[]): AiModelConfig | null {
+  return models.find((model) => model.isDefault) ?? models[0] ?? null
+}

--- a/packages/core/src/ai/models.ts
+++ b/packages/core/src/ai/models.ts
@@ -1,50 +1,68 @@
 import type { AiModelConfig } from '../settings/schema'
 
 /**
- * Pure transforms over the configured-AI-models list (Plan 10). They maintain
- * one invariant: a non-empty list has exactly one default entry. Callers pair
- * these with the keychain bindings in `secrets.ts` — the list never carries
- * the keys themselves.
+ * Pure transforms over the configured-AI-models state (Plan 10). The default
+ * is a single id (`defaultAiModelId` in the settings document), so "at most
+ * one default" holds by construction; a dangling id resolves through
+ * {@link defaultAiModel}'s first-entry fallback. Callers pair these with the
+ * keychain bindings in `secrets.ts` — the state never carries the keys
+ * themselves.
  */
+
+/** The two settings-document keys these transforms operate on, together. */
+export interface AiModelsState {
+  models: AiModelConfig[]
+  defaultModelId: string | null
+}
 
 /** How many trailing key characters are kept as the display hint. */
 export const KEY_HINT_LENGTH = 5
 
-/** The display-only suffix of an API key (`keyHint` in the settings doc). */
+/**
+ * The display-only suffix of an API key (`keyHint` in the settings doc).
+ * Empty for keys shorter than twice the hint — a hint must never reveal
+ * most of the key it identifies.
+ */
 export function apiKeyHint(key: string): string {
-  return key.slice(-KEY_HINT_LENGTH)
+  return key.length >= KEY_HINT_LENGTH * 2 ? key.slice(-KEY_HINT_LENGTH) : ''
 }
 
 /**
- * Append `entry`, keeping a single default: the first entry is always the
- * default, and an entry added as default demotes the previous one.
+ * Append `entry`; it becomes the default when requested or when it is the
+ * first entry.
  */
-export function withAiModelAdded(models: AiModelConfig[], entry: AiModelConfig): AiModelConfig[] {
-  const isDefault = entry.isDefault || models.length === 0
-  const existing = isDefault
-    ? models.map((model) => ({ ...model, isDefault: false }))
-    : [...models]
-  return [...existing, { ...entry, isDefault }]
+export function withAiModelAdded(
+  state: AiModelsState,
+  entry: AiModelConfig,
+  makeDefault: boolean,
+): AiModelsState {
+  return {
+    models: [...state.models, entry],
+    defaultModelId:
+      makeDefault || state.models.length === 0 ? entry.id : state.defaultModelId,
+  }
 }
 
 /**
  * Remove the entry with `id`. If it was the default, the first remaining
- * entry is promoted so the list never ends up default-less.
+ * entry takes over (`null` when the list empties).
  */
-export function withAiModelRemoved(models: AiModelConfig[], id: string): AiModelConfig[] {
-  const remaining = models.filter((model) => model.id !== id)
-  if (remaining.length === 0 || remaining.some((model) => model.isDefault)) {
-    return remaining
+export function withAiModelRemoved(state: AiModelsState, id: string): AiModelsState {
+  const models = state.models.filter((model) => model.id !== id)
+  return {
+    models,
+    defaultModelId:
+      state.defaultModelId === id ? (models[0]?.id ?? null) : state.defaultModelId,
   }
-  return remaining.map((model, index) => (index === 0 ? { ...model, isDefault: true } : model))
 }
 
-/** Make the entry with `id` the sole default. */
-export function withDefaultAiModel(models: AiModelConfig[], id: string): AiModelConfig[] {
-  return models.map((model) => ({ ...model, isDefault: model.id === id }))
-}
-
-/** The entry AI features should use when no explicit choice is made. */
-export function defaultAiModel(models: AiModelConfig[]): AiModelConfig | null {
-  return models.find((model) => model.isDefault) ?? models[0] ?? null
+/**
+ * The entry AI features should use when no explicit choice is made: the one
+ * `defaultModelId` points at, falling back to the first entry when the id is
+ * null or dangling.
+ */
+export function defaultAiModel(state: AiModelsState): AiModelConfig | null {
+  return (
+    state.models.find((model) => model.id === state.defaultModelId) ?? state.models[0] ?? null
+  )
 }

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -1,0 +1,81 @@
+import type { AiProviderId } from '../settings/schema'
+
+/**
+ * The static BYOK provider catalog (Plan 10): display names, key hints, and
+ * the curated model list the settings UI offers per provider. This is policy
+ * data, not configuration — the user's chosen entries live in settings as
+ * `AiModelConfig` values.
+ */
+
+/** One selectable model in a provider's curated list. */
+export interface AiModelOption {
+  /** The provider's model identifier, sent verbatim on API calls. */
+  id: string
+  /** Human-readable name shown in pickers. */
+  label: string
+}
+
+/** One supported BYOK provider. */
+export interface AiProviderInfo {
+  id: AiProviderId
+  /** Human-readable provider name shown in pickers. */
+  label: string
+  /** Placeholder illustrating the provider's API-key format. */
+  keyPlaceholder: string
+  /** Curated models, most capable first (the first is the picker default). */
+  models: AiModelOption[]
+}
+
+export const AI_PROVIDERS: AiProviderInfo[] = [
+  {
+    id: 'openai',
+    label: 'OpenAI',
+    keyPlaceholder: 'sk-…',
+    models: [
+      { id: 'gpt-5.1', label: 'GPT-5.1' },
+      { id: 'gpt-5', label: 'GPT-5' },
+      { id: 'gpt-5-mini', label: 'GPT-5 mini' },
+      { id: 'gpt-5-nano', label: 'GPT-5 nano' },
+    ],
+  },
+  {
+    id: 'anthropic',
+    label: 'Anthropic',
+    keyPlaceholder: 'sk-ant-…',
+    models: [
+      { id: 'claude-fable-5', label: 'Claude Fable 5' },
+      { id: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
+      { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+      { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
+    ],
+  },
+  {
+    id: 'google',
+    label: 'Google Gemini',
+    keyPlaceholder: 'AIza…',
+    models: [
+      { id: 'gemini-3-pro-preview', label: 'Gemini 3 Pro' },
+      { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
+      { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+      { id: 'gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash Lite' },
+    ],
+  },
+]
+
+/** The catalog entry for `id` (every `AiProviderId` is in the catalog). */
+export function aiProvider(id: AiProviderId): AiProviderInfo {
+  const provider = AI_PROVIDERS.find((candidate) => candidate.id === id)
+  if (!provider) {
+    throw new Error(`unknown AI provider: ${id}`)
+  }
+  return provider
+}
+
+/**
+ * Display name for a model, falling back to the raw id for models outside the
+ * curated list (a settings document may carry ids added by a newer version).
+ */
+export function aiModelLabel(provider: AiProviderId, modelId: string): string {
+  const match = aiProvider(provider).models.find((model) => model.id === modelId)
+  return match?.label ?? modelId
+}

--- a/packages/core/src/ai/secrets.ts
+++ b/packages/core/src/ai/secrets.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod'
+import { call } from '../ipc/invoke'
+
+/**
+ * Typed bindings for the OS-keychain commands (Plan 10). BYOK API keys go
+ * through here and **only** here — never into markdown, Git, `.reflect/`, or
+ * the settings document.
+ */
+
+/** Commands that return `()` from Rust serialize as `null` over IPC. */
+const voidSchema = z.null()
+
+const secretSchema = z.string().nullable()
+
+/**
+ * The keychain account name holding the API key for a configured AI model
+ * (`AiModelConfig.id` is the stable half of the address).
+ */
+export function aiKeySecretName(configId: string): string {
+  return `ai-api-key:${configId}`
+}
+
+/** Store `value` in the OS keychain under `name`, replacing any prior value. */
+export async function setSecret(name: string, value: string): Promise<void> {
+  await call('secret_set', { name, value }, voidSchema)
+}
+
+/** Read the secret stored under `name`, or `null` when none exists. */
+export async function getSecret(name: string): Promise<string | null> {
+  return call('secret_get', { name }, secretSchema)
+}
+
+/** Remove the secret stored under `name` (a missing entry is not an error). */
+export async function deleteSecret(name: string): Promise<void> {
+  await call('secret_delete', { name }, voidSchema)
+}

--- a/packages/core/src/ai/validate-key.test.ts
+++ b/packages/core/src/ai/validate-key.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { validateApiKey } from './validate-key'
+
+function fetchReturning(status: number): typeof fetch {
+  return async () => new Response(null, { status })
+}
+
+const fetchThrowing: typeof fetch = async () => {
+  throw new TypeError('network down')
+}
+
+describe('validateApiKey', () => {
+  it('sends the provider-specific auth headers to the model-listing endpoint', async () => {
+    const calls: { url: string; headers: Record<string, string> }[] = []
+    const recordingFetch: typeof fetch = async (input, init) => {
+      calls.push({
+        url: String(input),
+        headers: (init?.headers ?? {}) as Record<string, string>,
+      })
+      return new Response(null, { status: 200 })
+    }
+
+    await validateApiKey('openai', 'sk-test', recordingFetch)
+    await validateApiKey('anthropic', 'sk-ant-test', recordingFetch)
+    await validateApiKey('google', 'AIza-test', recordingFetch)
+
+    expect(calls[0].url).toBe('https://api.openai.com/v1/models')
+    expect(calls[0].headers.Authorization).toBe('Bearer sk-test')
+    expect(calls[1].url).toBe('https://api.anthropic.com/v1/models')
+    expect(calls[1].headers['x-api-key']).toBe('sk-ant-test')
+    expect(calls[1].headers['anthropic-version']).toBe('2023-06-01')
+    expect(calls[2].url).toBe('https://generativelanguage.googleapis.com/v1beta/models')
+    expect(calls[2].headers['x-goog-api-key']).toBe('AIza-test')
+  })
+
+  it('reads an ok response as valid', async () => {
+    expect(await validateApiKey('openai', 'sk-test', fetchReturning(200))).toBe('valid')
+  })
+
+  it('reads an auth rejection as invalid', async () => {
+    expect(await validateApiKey('openai', 'sk-test', fetchReturning(401))).toBe('invalid')
+    expect(await validateApiKey('anthropic', 'sk-test', fetchReturning(403))).toBe('invalid')
+    // Gemini reports malformed keys as 400.
+    expect(await validateApiKey('google', 'bad', fetchReturning(400))).toBe('invalid')
+  })
+
+  it('reads anything that is not an auth decision as unreachable', async () => {
+    expect(await validateApiKey('openai', 'sk-test', fetchReturning(500))).toBe('unreachable')
+    expect(await validateApiKey('openai', 'sk-test', fetchReturning(429))).toBe('unreachable')
+    expect(await validateApiKey('openai', 'sk-test', fetchThrowing)).toBe('unreachable')
+  })
+})

--- a/packages/core/src/ai/validate-key.ts
+++ b/packages/core/src/ai/validate-key.ts
@@ -1,0 +1,69 @@
+import type { AiProviderId } from '../settings/schema'
+
+/**
+ * BYOK key validation (Plan 10): one cheap authenticated probe against the
+ * provider's model-listing endpoint, so a typo'd or wrong-provider key is
+ * caught at entry instead of failing later inside an AI call. Only the
+ * response status is read — no body parsing, no data retained.
+ */
+
+/**
+ * `'unreachable'` means the probe couldn't make an auth decision (offline,
+ * provider outage, rate limit) — callers should let the user save anyway
+ * rather than hard-blocking on connectivity.
+ */
+export type ApiKeyValidation = 'valid' | 'invalid' | 'unreachable'
+
+interface KeyProbe {
+  url: string
+  headers: (key: string) => Record<string, string>
+  /** Statuses that mean "the provider rejected this key" (vs. can't tell). */
+  invalidStatuses: number[]
+}
+
+const PROBES: Record<AiProviderId, KeyProbe> = {
+  openai: {
+    url: 'https://api.openai.com/v1/models',
+    headers: (key) => ({ Authorization: `Bearer ${key}` }),
+    invalidStatuses: [401, 403],
+  },
+  anthropic: {
+    url: 'https://api.anthropic.com/v1/models',
+    headers: (key) => ({
+      'x-api-key': key,
+      'anthropic-version': '2023-06-01',
+      // Required for direct-from-browser calls; harmless elsewhere.
+      'anthropic-dangerous-direct-browser-access': 'true',
+    }),
+    invalidStatuses: [401, 403],
+  },
+  google: {
+    url: 'https://generativelanguage.googleapis.com/v1beta/models',
+    headers: (key) => ({ 'x-goog-api-key': key }),
+    // Gemini reports a malformed key as 400 INVALID_ARGUMENT.
+    invalidStatuses: [400, 401, 403],
+  },
+}
+
+/**
+ * Probe `provider` with `apiKey`. `fetchFn` lets hosts substitute a
+ * CORS-free transport (the desktop app passes the Tauri HTTP plugin's fetch;
+ * `@reflect/core` itself stays platform-agnostic).
+ */
+export async function validateApiKey(
+  provider: AiProviderId,
+  apiKey: string,
+  fetchFn: typeof fetch = fetch,
+): Promise<ApiKeyValidation> {
+  const probe = PROBES[provider]
+  let response: Response
+  try {
+    response = await fetchFn(probe.url, { method: 'GET', headers: probe.headers(apiKey) })
+  } catch {
+    return 'unreachable'
+  }
+  if (response.ok) {
+    return 'valid'
+  }
+  return probe.invalidStatuses.includes(response.status) ? 'invalid' : 'unreachable'
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,12 +76,35 @@ export {
   settingsSchema,
   editorMarkdownSyntaxSchema,
   themePreferenceSchema,
+  aiProviderIdSchema,
+  aiModelConfigSchema,
+  aiModelsSchema,
   DEFAULT_SETTINGS,
   type Settings,
   type EditorMarkdownSyntax,
   type ThemePreference,
+  type AiProviderId,
+  type AiModelConfig,
 } from './settings/schema'
 export { loadSettings, saveSettings } from './settings/commands'
+
+// AI providers & keychain secrets (Plan 10)
+export {
+  AI_PROVIDERS,
+  aiProvider,
+  aiModelLabel,
+  type AiProviderInfo,
+  type AiModelOption,
+} from './ai/provider-catalog'
+export { aiKeySecretName, setSecret, getSecret, deleteSecret } from './ai/secrets'
+export {
+  KEY_HINT_LENGTH,
+  apiKeyHint,
+  withAiModelAdded,
+  withAiModelRemoved,
+  withDefaultAiModel,
+  defaultAiModel,
+} from './ai/models'
 
 // Markdown document model (Plan 03)
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -79,6 +79,7 @@ export {
   aiProviderIdSchema,
   aiModelConfigSchema,
   aiModelsSchema,
+  defaultAiModelIdSchema,
   DEFAULT_SETTINGS,
   type Settings,
   type EditorMarkdownSyntax,
@@ -102,9 +103,10 @@ export {
   apiKeyHint,
   withAiModelAdded,
   withAiModelRemoved,
-  withDefaultAiModel,
   defaultAiModel,
+  type AiModelsState,
 } from './ai/models'
+export { validateApiKey, type ApiKeyValidation } from './ai/validate-key'
 
 // Markdown document model (Plan 03)
 export {

--- a/packages/core/src/settings/schema.test.ts
+++ b/packages/core/src/settings/schema.test.ts
@@ -6,9 +6,11 @@ describe('settingsSchema', () => {
     expect(settingsSchema.parse({})).toEqual({
       editorMarkdownSyntax: 'focus',
       theme: 'system',
+      aiModels: [],
     })
     expect(DEFAULT_SETTINGS.editorMarkdownSyntax).toBe('focus')
     expect(DEFAULT_SETTINGS.theme).toBe('system')
+    expect(DEFAULT_SETTINGS.aiModels).toEqual([])
   })
 
   it('accepts valid values', () => {
@@ -28,6 +30,44 @@ describe('settingsSchema', () => {
 
   it('preserves unknown keys so newer-version settings survive a round trip', () => {
     const parsed = settingsSchema.parse({ editorMarkdownSyntax: 'show', futureKey: true })
-    expect(parsed).toEqual({ editorMarkdownSyntax: 'show', theme: 'system', futureKey: true })
+    expect(parsed).toEqual({
+      editorMarkdownSyntax: 'show',
+      theme: 'system',
+      aiModels: [],
+      futureKey: true,
+    })
+  })
+
+  describe('aiModels', () => {
+    const valid = {
+      id: 'abc',
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      keyHint: 'wxyz1',
+      isDefault: true,
+    }
+
+    it('passes valid entries through', () => {
+      expect(settingsSchema.parse({ aiModels: [valid] }).aiModels).toEqual([valid])
+    })
+
+    it('defaults the per-entry display fields', () => {
+      const entry = { id: 'abc', provider: 'openai', model: 'gpt-5.1' }
+      expect(settingsSchema.parse({ aiModels: [entry] }).aiModels).toEqual([
+        { ...entry, keyHint: '', isDefault: false },
+      ])
+    })
+
+    it('drops a corrupt entry without losing the rest', () => {
+      const parsed = settingsSchema.parse({
+        aiModels: [valid, { provider: 'aliens' }, 42],
+      })
+      expect(parsed.aiModels).toEqual([valid])
+    })
+
+    it('degrades a non-array value to the empty list', () => {
+      expect(settingsSchema.parse({ aiModels: 'nope' }).aiModels).toEqual([])
+      expect(settingsSchema.parse({ aiModels: { id: 'x' } }).aiModels).toEqual([])
+    })
   })
 })

--- a/packages/core/src/settings/schema.test.ts
+++ b/packages/core/src/settings/schema.test.ts
@@ -7,10 +7,12 @@ describe('settingsSchema', () => {
       editorMarkdownSyntax: 'focus',
       theme: 'system',
       aiModels: [],
+      defaultAiModelId: null,
     })
     expect(DEFAULT_SETTINGS.editorMarkdownSyntax).toBe('focus')
     expect(DEFAULT_SETTINGS.theme).toBe('system')
     expect(DEFAULT_SETTINGS.aiModels).toEqual([])
+    expect(DEFAULT_SETTINGS.defaultAiModelId).toBeNull()
   })
 
   it('accepts valid values', () => {
@@ -34,6 +36,7 @@ describe('settingsSchema', () => {
       editorMarkdownSyntax: 'show',
       theme: 'system',
       aiModels: [],
+      defaultAiModelId: null,
       futureKey: true,
     })
   })
@@ -44,7 +47,6 @@ describe('settingsSchema', () => {
       provider: 'anthropic',
       model: 'claude-opus-4-8',
       keyHint: 'wxyz1',
-      isDefault: true,
     }
 
     it('passes valid entries through', () => {
@@ -54,7 +56,7 @@ describe('settingsSchema', () => {
     it('defaults the per-entry display fields', () => {
       const entry = { id: 'abc', provider: 'openai', model: 'gpt-5.1' }
       expect(settingsSchema.parse({ aiModels: [entry] }).aiModels).toEqual([
-        { ...entry, keyHint: '', isDefault: false },
+        { ...entry, keyHint: '' },
       ])
     })
 
@@ -68,6 +70,14 @@ describe('settingsSchema', () => {
     it('degrades a non-array value to the empty list', () => {
       expect(settingsSchema.parse({ aiModels: 'nope' }).aiModels).toEqual([])
       expect(settingsSchema.parse({ aiModels: { id: 'x' } }).aiModels).toEqual([])
+    })
+  })
+
+  describe('defaultAiModelId', () => {
+    it('passes a string id through and defaults invalid values to null', () => {
+      expect(settingsSchema.parse({ defaultAiModelId: 'abc' }).defaultAiModelId).toBe('abc')
+      expect(settingsSchema.parse({ defaultAiModelId: null }).defaultAiModelId).toBeNull()
+      expect(settingsSchema.parse({ defaultAiModelId: 42 }).defaultAiModelId).toBeNull()
     })
   })
 })

--- a/packages/core/src/settings/schema.ts
+++ b/packages/core/src/settings/schema.ts
@@ -40,20 +40,28 @@ export const aiProviderIdSchema = z.enum(['openai', 'anthropic', 'google'])
 export type AiProviderId = z.infer<typeof aiProviderIdSchema>
 
 /**
- * One configured AI model: a provider, the chosen model id, and whether it is
- * the app-wide default. The API key itself lives in the OS keychain (addressed
- * by `id` — see `aiKeySecretName`) and **never** in this document; `keyHint`
- * keeps only the key's trailing characters so the settings UI can identify it.
+ * One configured AI model: a provider and the chosen model id. The API key
+ * itself lives in the OS keychain (addressed by `id` — see `aiKeySecretName`)
+ * and **never** in this document; `keyHint` keeps only the key's trailing
+ * characters so the settings UI can identify it. Which entry is the app-wide
+ * default is a sibling scalar (`defaultAiModelId`), not a per-entry flag, so
+ * "at most one default" holds by construction.
  */
 export const aiModelConfigSchema = z.object({
   id: z.string().min(1),
   provider: aiProviderIdSchema,
   model: z.string().min(1),
   keyHint: z.string().catch(''),
-  isDefault: z.boolean().catch(false),
 })
 
 export type AiModelConfig = z.infer<typeof aiModelConfigSchema>
+
+/**
+ * The `aiModels` entry AI features use by default. A dangling or null id is
+ * legal (hand-edits, removed entries) — readers resolve it through
+ * `defaultAiModel`, which falls back to the first entry.
+ */
+export const defaultAiModelIdSchema = z.string().nullable().catch(null)
 
 /**
  * The configured AI models. Resilience is per entry, not per list: a corrupt
@@ -75,6 +83,7 @@ export const settingsSchema = z
     editorMarkdownSyntax: editorMarkdownSyntaxSchema,
     theme: themePreferenceSchema,
     aiModels: aiModelsSchema,
+    defaultAiModelId: defaultAiModelIdSchema,
   })
   .passthrough()
 

--- a/packages/core/src/settings/schema.ts
+++ b/packages/core/src/settings/schema.ts
@@ -31,10 +31,50 @@ export const themePreferenceSchema = z.enum(['system', 'light', 'dark']).catch('
 
 export type ThemePreference = z.infer<typeof themePreferenceSchema>
 
+/**
+ * The cloud AI providers Reflect can call directly (BYOK — the user's own
+ * keys, no Reflect-hosted proxy).
+ */
+export const aiProviderIdSchema = z.enum(['openai', 'anthropic', 'google'])
+
+export type AiProviderId = z.infer<typeof aiProviderIdSchema>
+
+/**
+ * One configured AI model: a provider, the chosen model id, and whether it is
+ * the app-wide default. The API key itself lives in the OS keychain (addressed
+ * by `id` — see `aiKeySecretName`) and **never** in this document; `keyHint`
+ * keeps only the key's trailing characters so the settings UI can identify it.
+ */
+export const aiModelConfigSchema = z.object({
+  id: z.string().min(1),
+  provider: aiProviderIdSchema,
+  model: z.string().min(1),
+  keyHint: z.string().catch(''),
+  isDefault: z.boolean().catch(false),
+})
+
+export type AiModelConfig = z.infer<typeof aiModelConfigSchema>
+
+/**
+ * The configured AI models. Resilience is per entry, not per list: a corrupt
+ * entry is dropped while the rest load, so one bad hand-edit can't wipe every
+ * configured provider. A non-array value degrades to the empty list.
+ */
+export const aiModelsSchema = z
+  .array(z.unknown())
+  .catch([])
+  .transform((entries) =>
+    entries.flatMap((entry) => {
+      const parsed = aiModelConfigSchema.safeParse(entry)
+      return parsed.success ? [parsed.data] : []
+    }),
+  )
+
 export const settingsSchema = z
   .object({
     editorMarkdownSyntax: editorMarkdownSyntaxSchema,
     theme: themePreferenceSchema,
+    aiModels: aiModelsSchema,
   })
   .passthrough()
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.1
         version: 2.7.1
+      '@tauri-apps/plugin-http':
+        specifier: ^2.5.9
+        version: 2.5.9
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.4
@@ -1274,6 +1277,9 @@ packages:
 
   '@tauri-apps/plugin-dialog@2.7.1':
     resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
+
+  '@tauri-apps/plugin-http@2.5.9':
+    resolution: {integrity: sha512-lCiY0+vs4HvIUSvZrBs8TC3TiCB0MOPRmiUjTq4prW7SlcJE2jdLeT6KBsJrT9Tlplufl7W1pY6SFAO3gCWxDA==}
 
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
@@ -3595,6 +3601,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.11.2
 
   '@tauri-apps/plugin-dialog@2.7.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-http@2.5.9':
     dependencies:
       '@tauri-apps/api': 2.11.0
 


### PR DESCRIPTION
## What

Adds a **Settings → AI models** section where users configure the BYOK providers AI features will use (groundwork for Plan 10's copilot sidebar):

- A card listing each configured model — provider + model name (e.g. "Anthropic — Claude Opus 4.8"), the key's trailing five characters (`·····wxyz1`), a **Default** badge / "Make default" action, and a remove button.
- An **Add AI model** dialog (react-hook-form, matching the palette's overlay idiom): provider select → model select (list swaps per provider) → API key → "use as default" checkbox. A keychain failure shows inline and keeps the typed key for retry.
- A curated model catalog per provider (`packages/core/src/ai/provider-catalog.ts`): GPT-5.1/5/mini/nano, Claude Fable 5 / Opus 4.8 / Sonnet 4.6 / Haiku 4.5, Gemini 3 Pro + 2.5 family. Unknown model ids still render (label falls back to the raw id) so documents from newer versions survive.

## How

- **Keys live in the OS keychain only.** New `keyring`-backed Rust module (`secrets.rs`) exposing `secret_set/get/delete` under service `reflect-open`, exactly as Plan 10 specified. The settings document keeps only a 5-char `keyHint`; the section test asserts the full key never appears in a persisted document. The key is written to the keychain *before* the settings entry is added, so an entry can never point at a key that was never stored.
- **`aiModels` settings key** follows the existing resilience contract, with per-entry recovery: a corrupt entry is dropped while the rest load (one bad hand-edit can't wipe every provider). Stored in the user settings document (config dir), not in a graph's `.reflect/` — per the settings-store contract, AGENTS.md principles, and Plan 10 (graphs sync via Git/iCloud; keys/config are per-user).
- **Exactly one default**: pure list transforms in `packages/core/src/ai/models.ts` promote the first entry automatically and re-promote on removal.
- `useAiModels()` owns the keychain ⇄ settings pairing; components never touch the secret commands directly. `getSecret` is exported from core so the copilot can read keys at call time.

## Testing

- `pnpm typecheck` clean across the workspace.
- Core: 20 tests (schema resilience cases, list-transform invariants).
- Desktop: 18 tests, including full chains through a fake bridge — add (secret stored, hint persisted, dialog closes), keychain failure (dialog stays open, nothing persisted), remove (secret deleted, default promoted), make-default.
- Rust: 42 tests pass, including the keychain error-mapping round trip against the mock store (missing entry reads as `None`, delete is idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential storage (keychain), outbound HTTP to third-party APIs, and non-trivial settings concurrency; mitigated by scoped HTTP allowlist, key-before-settings ordering, and load-outcome guards.
> 
> **Overview**
> Adds **Settings → AI models** for BYOK: users pick OpenAI, Anthropic, or Google, choose a curated model, and store API keys only in the **OS keychain** (`secrets.rs` + `keyring`); settings persist `aiModels` (provider, model, 5-char `keyHint`) and `defaultAiModelId`, never the full key.
> 
> **`@reflect/core`** gains provider catalog, `validateApiKey` (model-list probe), keychain IPC helpers, and pure list/default transforms. **`useAiModels`** writes keychain before settings, blocks adds when settings failed to load, and removes keychain before dropping settings rows. **`SettingsProvider`** adds `updateSettingsWith` and `whenSettingsLoaded` so concurrent add/remove and hydration races do not clobber list state or orphan secrets.
> 
> The add-model flow verifies keys via **`providerFetch`** (Tauri HTTP plugin with allowlisted provider hosts); offline paths offer **Save anyway**. UI includes list rows (default badge, remove), modal with focus trap, and broad tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f914bac7b62659eda12f382670e3fac6b8056177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

## Follow-up commits (review hardening + retrospective items)

- **Concurrency & hydration fixes** (Bugbot rounds 1–4): list edits compose via functional settings updates; read-modify-write trails hydration; adds refuse when the settings store is unreadable (so a key is never stored for an entry that can't persist); no-bridge browser dev settles the load instead of hanging.
- **Key validation on add**: the key is probed against the provider's model-listing endpoint before storing — rejected keys show inline; an unreachable provider downgrades to an explicit "Save anyway". Runs through the new Tauri HTTP plugin (scoped to the three provider hosts in capabilities) since the webview enforces CORS and OpenAI's API doesn't allow browser origins.
- **`defaultAiModelId`** replaces per-entry `isDefault` flags — "at most one default" by construction, dangling ids fall back to the first entry. Changed before the persisted format ships.
- **`apiKeyHint`** returns no hint for keys shorter than twice the hint length.
- **Dialog focus trap**: Tab cycles within the modal; focus returns to the opener on close.
