### PR TITLE
fix: daily stream height

### DIFF
--- a/apps/desktop/src/components/daily-stream.tsx
+++ b/apps/desktop/src/components/daily-stream.tsx
@@ -123,7 +123,7 @@ export function DailyStream({ targetDate }: DailyStreamProps): ReactElement {
                   lazy
                   autoFocus={autoFocus}
                   onAutoFocused={consumeFocus}
-                  editorClassName={isPast ? 'min-h-[200px]' : 'min-h-[60vh]'}
+                  editorClassName={isPast ? 'min-h-[100px]' : 'min-h-[60vh]'}
                 />
               </section>
             </div>


### PR DESCRIPTION
## Summary
- Fixes the height of the daily stream component.

## Test plan
- [ ] Verify daily stream renders correctly at expected height

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout tweak for past-day rows with no logic, data, or API changes.
> 
> **Overview**
> Reduces the minimum editor height for **past** days in the daily stream from `200px` to `100px`, so empty or short past entries take less vertical space while **today** and future days still use `min-h-[60vh]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0da3989423ed1e703a08b2da9ab63112e43a7d91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced the minimum height of the editor container for past entries, providing a more compact view while maintaining the current layout for today's and future entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->