### PR TITLE
Remove status notifications for semantic model load and note indexing

### DIFF
--- a/apps/desktop/src/lib/semantic.test.ts
+++ b/apps/desktop/src/lib/semantic.test.ts
@@ -6,19 +6,9 @@ import {
   retryFailedEmbeddings,
 } from './semantic'
 
-const startOperation = vi.hoisted(() => vi.fn())
-vi.mock('@/lib/operations', () => ({ startOperation }))
-
 afterEach(() => {
   setBridge(null)
-  startOperation.mockReset()
 })
-
-function operationHandle() {
-  const handle = { progress: vi.fn(), done: vi.fn(), fail: vi.fn() }
-  startOperation.mockReturnValue(handle)
-  return handle
-}
 
 describe('consumeLegacySemanticOptIn', () => {
   it('returns a stored opt-in exactly once (the settings document owns it after)', () => {
@@ -47,7 +37,6 @@ describe('retryFailedEmbeddings', () => {
   }
 
   it('re-kicks a failed load', async () => {
-    operationHandle()
     const invoked = bridgeWithStatus({ status: 'failed', message: 'offline' })
     await retryFailedEmbeddings()
     expect(invoked).toContain('embed_ensure')
@@ -61,8 +50,7 @@ describe('retryFailedEmbeddings', () => {
 })
 
 describe('ensureEmbeddingsVisibly', () => {
-  it('resolves the operation only at a terminal status (a racing ensure returns loading)', async () => {
-    const handle = operationHandle()
+  it('resolves only at a terminal status (a racing ensure returns loading)', async () => {
     // Boxed: TS control-flow analysis doesn't track closure assignments and
     // would narrow a plain `let` to `never` at the call site below.
     const emitter: { fire: ((payload: unknown) => void) | null } = { fire: null }
@@ -86,23 +74,19 @@ describe('ensureEmbeddingsVisibly', () => {
 
     const pending = ensureEmbeddingsVisibly()
     await vi.waitFor(() => expect(emitter.fire).not.toBeNull())
-    expect(handle.done).not.toHaveBeenCalled() // still loading — not "done"
 
     emitter.fire?.({ status: 'ready', model: 'all-MiniLM-L6-v2' })
     const status = await pending
     expect(status).toEqual({ status: 'ready', model: 'all-MiniLM-L6-v2' })
-    expect(handle.done).toHaveBeenCalledTimes(1)
   })
 
-  it('a failed load fails the operation with the message', async () => {
-    const handle = operationHandle()
+  it('returns a failed status when the load fails', async () => {
     setBridge({
       invoke: async (command) =>
         command === 'embed_ensure' ? { status: 'failed', message: 'no disk space' } : null,
       listen: async () => () => {},
     })
     const status = await ensureEmbeddingsVisibly()
-    expect(status.status).toBe('failed')
-    expect(handle.fail).toHaveBeenCalledWith('no disk space')
+    expect(status).toEqual({ status: 'failed', message: 'no disk space' })
   })
 })

--- a/apps/desktop/src/lib/semantic.ts
+++ b/apps/desktop/src/lib/semantic.ts
@@ -5,7 +5,6 @@ import {
   subscribeEmbedStatus,
   type EmbedStatus,
 } from '@reflect/core'
-import { startOperation } from '@/lib/operations'
 
 /**
  * Semantic-search loading (Plan 09). The model is ~90MB and downloads from
@@ -80,20 +79,12 @@ export async function retryFailedEmbeddings(): Promise<void> {
   }
 }
 
-/** Load (downloading if needed) the model, visibly. Resolves with the outcome. */
+/** Load (downloading if needed) the model. Resolves with the outcome. */
 export async function ensureEmbeddingsVisibly(): Promise<EmbedStatus> {
-  const operation = startOperation('Loading semantic search model')
   try {
-    const status = await awaitTerminalStatus(await embedEnsure())
-    if (status.status === 'failed') {
-      operation.fail(status.message)
-    } else {
-      operation.done()
-    }
-    return status
+    return await awaitTerminalStatus(await embedEnsure())
   } catch (cause) {
     const message = cause instanceof Error ? cause.message : String(cause)
-    operation.fail(message)
     return { status: 'failed', message }
   }
 }
@@ -104,19 +95,9 @@ export async function backfillEmbeddingsVisibly(options: {
   modelId: string
   isStale?: () => boolean
 }): Promise<'completed' | 'aborted' | 'failed'> {
-  const operation = startOperation('Indexing notes for semantic search')
   try {
-    const outcome = await backfillEmbeddings({
-      ...options,
-      onProgress: (done, total) => operation.progress(done, total),
-    })
-    // Either way the entry leaves the status surface (there is no "finished"
-    // state to misreport) — but an abort is the caller's signal that this
-    // pass didn't cover the graph; the next ready cycle re-runs it cheaply.
-    operation.done()
-    return outcome
-  } catch (cause) {
-    operation.fail(cause instanceof Error ? cause.message : String(cause))
+    return await backfillEmbeddings(options)
+  } catch {
     return 'failed'
   }
 }


### PR DESCRIPTION
## Summary

- Removes the \"Loading semantic search model\" status notification shown during model download/initialization
- Removes the \"Indexing notes for semantic search\" status notification shown during the embedding backfill
- Both operations still run silently in the background; only the UI notifications are gone

## What changed

`ensureEmbeddingsVisibly` and `backfillEmbeddingsVisibly` in `apps/desktop/src/lib/semantic.ts` previously called `startOperation(...)` to surface progress in the operations status overlay. Those calls (and the associated `onProgress` wiring) have been removed. The underlying embedding work is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only removal of progress notifications; embedding orchestration and error handling via return values are preserved.
> 
> **Overview**
> Stops surfacing **semantic model download/load** and **note embedding backfill** in the desktop operations status overlay. `ensureEmbeddingsVisibly` and `backfillEmbeddingsVisibly` no longer call `startOperation` or wire `onProgress` into that UI; they still run the same `@reflect/core` work and return the same `EmbedStatus` / backfill outcomes.
> 
> Unit tests drop the `@/lib/operations` mock and assert behavior via returned statuses instead of `operation.done` / `operation.fail`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e63f583dedb1498b1895b3df00b412950fc84bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->