### PR TITLE
Filter semantic search results by the cosine noise cutoff

### DIFF
--- a/packages/core/src/embeddings/retrieve.test.ts
+++ b/packages/core/src/embeddings/retrieve.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { fuseRanked, type RetrievalHit } from './retrieve'
+import { bestChunkPerNote, fuseRanked, type ChunkHitRow, type RetrievalHit } from './retrieve'
 
 function hit(path: string, overrides?: Partial<RetrievalHit>): RetrievalHit {
   return {
@@ -12,6 +12,54 @@ function hit(path: string, overrides?: Partial<RetrievalHit>): RetrievalHit {
     ...overrides,
   }
 }
+
+function row(path: string, distance: number, overrides?: Partial<ChunkHitRow>): ChunkHitRow {
+  return {
+    path,
+    title: path,
+    heading: null,
+    text: ` about ${path} `,
+    isPrivate: 0,
+    distance,
+    ...overrides,
+  }
+}
+
+describe('bestChunkPerNote', () => {
+  it('drops neighbors past the cosine noise cutoff (gibberish queries find nothing)', () => {
+    const rows = [row('notes/a.md', 0.84), row('notes/b.md', 0.92)]
+    expect(bestChunkPerNote(rows, 12)).toEqual([])
+  })
+
+  it('keeps near matches while dropping the noisy tail', () => {
+    const rows = [row('notes/match.md', 0.3), row('notes/noise.md', 0.75)]
+    const hits = bestChunkPerNote(rows, 12)
+    expect(hits.map((hit) => hit.path)).toEqual(['notes/match.md'])
+  })
+
+  it('collapses to the best chunk per note, scored as cosine similarity', () => {
+    const rows = [
+      row('notes/a.md', 0.2, { text: 'best chunk' }),
+      row('notes/a.md', 0.4, { text: 'worse chunk' }),
+    ]
+    const hits = bestChunkPerNote(rows, 12)
+    expect(hits).toHaveLength(1)
+    expect(hits[0].snippet).toBe('best chunk')
+    expect(hits[0].score).toBeCloseTo(0.8)
+  })
+
+  it('excludes the seed note and respects the limit', () => {
+    const rows = [row('notes/self.md', 0.0), row('notes/a.md', 0.1), row('notes/b.md', 0.2)]
+    const hits = bestChunkPerNote(rows, 1, 'notes/self.md')
+    expect(hits.map((hit) => hit.path)).toEqual(['notes/a.md'])
+  })
+
+  it('trims snippets and converts the private flag', () => {
+    const hits = bestChunkPerNote([row('notes/p.md', 0.1, { isPrivate: 1 })], 12)
+    expect(hits[0].snippet).toBe('about notes/p.md')
+    expect(hits[0].isPrivate).toBe(true)
+  })
+})
 
 describe('fuseRanked (reciprocal rank fusion)', () => {
   it('a note ranked in both lists beats single-list notes', () => {

--- a/packages/core/src/embeddings/retrieve.ts
+++ b/packages/core/src/embeddings/retrieve.ts
@@ -7,7 +7,8 @@ import { embedTexts } from './commands'
 /**
  * The shared retrieval contract (Plan 09): one `retrieve()` for search and AI.
  * Lexical = FTS (title-boosted); semantic = embed the query, KNN over chunks,
- * dedupe to best chunk per note; hybrid = reciprocal rank fusion of the two
+ * drop neighbors past the noise cutoff, dedupe to best chunk per note;
+ * hybrid = reciprocal rank fusion of the two
  * (deterministic, no tuned weights). Private notes stay locally recallable —
  * `excludePrivateContent` strips their *content* for callers that ship hits to
  * external services (Plan 10), enforced again at the AI boundary.
@@ -33,22 +34,56 @@ export interface RetrieveOptions {
 const KNN_CANDIDATES = 24
 
 /**
- * Neighbors farther than this cosine distance are noise, not "similar notes":
- * KNN always fills the candidate list with the nearest chunks however
- * unrelated they are (worst in small graphs). 0.7 is the old app's tuned
- * cutoff for the same model family, carried over for parity. The
- * `embedding_vectors` table's metric is cosine (migration 0003), so vec0
- * distances threshold directly.
+ * Neighbors farther than this cosine distance are noise, not matches: KNN
+ * always fills the candidate list with the nearest chunks however unrelated
+ * they are (worst in small graphs), so without a cutoff a gibberish query
+ * still "finds" notes. 0.7 is the old app's tuned cutoff for the same model
+ * family, carried over for parity; with all-MiniLM-L6-v2 it also separates
+ * query→chunk matching cleanly (real matches land under ~0.65, gibberish and
+ * unrelated queries at ~0.72+). The `embedding_vectors` table's metric is
+ * cosine (migration 0003), so vec0 distances threshold directly.
  */
-const MAX_RELATED_COSINE_DISTANCE = 0.7
+const MAX_COSINE_DISTANCE = 0.7
 
-interface ChunkHitRow {
+export interface ChunkHitRow {
   path: string
   title: string
   heading: string | null
   text: string
   isPrivate: number
   distance: number
+}
+
+/**
+ * Collapse KNN chunk rows (ordered nearest-first) into one hit per note —
+ * the best chunk wins. Rows past {@link MAX_COSINE_DISTANCE} are dropped
+ * rather than padded in, and `excludePath` removes the seed note itself when
+ * the query came from a stored note vector. The score is cosine similarity
+ * (the vec0 table's metric is cosine) for callers that want magnitudes.
+ */
+export function bestChunkPerNote(
+  rows: readonly ChunkHitRow[],
+  limit: number,
+  excludePath?: string,
+): RetrievalHit[] {
+  const byNote = new Map<string, RetrievalHit>()
+  for (const row of rows) {
+    if (row.distance > MAX_COSINE_DISTANCE) {
+      continue
+    }
+    if (row.path === excludePath || byNote.has(row.path)) {
+      continue
+    }
+    byNote.set(row.path, {
+      path: row.path,
+      title: row.title,
+      score: 1 - row.distance,
+      snippet: row.text.trim(),
+      heading: row.heading,
+      isPrivate: row.isPrivate !== 0,
+    })
+  }
+  return [...byNote.values()].slice(0, limit)
 }
 
 async function semanticHits(query: string, limit: number): Promise<RetrievalHit[]> {
@@ -62,23 +97,7 @@ async function semanticHits(query: string, limit: number): Promise<RetrievalHit[
     WHERE v.embedding MATCH ${JSON.stringify(vector)} AND k = ${KNN_CANDIDATES}
     ORDER BY v.distance
   `.execute(db)
-
-  // Best chunk per note wins; the score is cosine similarity (the vec0
-  // table's metric is cosine) for callers that want magnitudes.
-  const byNote = new Map<string, RetrievalHit>()
-  for (const row of result.rows) {
-    if (!byNote.has(row.path)) {
-      byNote.set(row.path, {
-        path: row.path,
-        title: row.title,
-        score: 1 - row.distance,
-        snippet: row.text.trim(),
-        heading: row.heading,
-        isPrivate: row.isPrivate !== 0,
-      })
-    }
-  }
-  return [...byNote.values()].slice(0, limit)
+  return bestChunkPerNote(result.rows, limit)
 }
 
 async function lexicalHits(query: string, limit: number): Promise<RetrievalHit[]> {
@@ -185,8 +204,8 @@ export async function retrieve(query: string, options?: RetrieveOptions): Promis
  * sync keeps chunks current on every save, and the index invalidation scope
  * refetches consumers, so freshness is automatic. Returns [] when the note
  * has no vectors yet (model never enabled, or not yet embedded). Candidates
- * past {@link MAX_RELATED_COSINE_DISTANCE} are dropped rather than padded in,
- * so a sparse graph shows few (or no) neighbors instead of wrong ones.
+ * past {@link MAX_COSINE_DISTANCE} are dropped rather than padded in, so a
+ * sparse graph shows few (or no) neighbors instead of wrong ones.
  */
 export async function relatedNotes(path: string, limit = 6): Promise<RetrievalHit[]> {
   const seed = await sql<{ vec: string }>`
@@ -210,21 +229,5 @@ export async function relatedNotes(path: string, limit = 6): Promise<RetrievalHi
     WHERE v.embedding MATCH ${vec} AND k = ${KNN_CANDIDATES}
     ORDER BY v.distance
   `.execute(db)
-  const byNote = new Map<string, RetrievalHit>()
-  for (const row of result.rows) {
-    if (row.distance > MAX_RELATED_COSINE_DISTANCE) {
-      continue
-    }
-    if (row.path !== path && !byNote.has(row.path)) {
-      byNote.set(row.path, {
-        path: row.path,
-        title: row.title,
-        score: 1 - row.distance,
-        snippet: row.text.trim(),
-        heading: row.heading,
-        isPrivate: row.isPrivate !== 0,
-      })
-    }
-  }
-  return [...byNote.values()].slice(0, limit)
+  return bestChunkPerNote(result.rows, limit, path)
 }


### PR DESCRIPTION
## What changed

Semantic search returned results for any query — even gibberish like `xxxxxxxxxxxx` that appears nowhere in the graph. The sqlite-vec KNN query always fills its candidate list with the nearest `k=24` chunks however distant they are; the lexical (FTS) leg correctly found nothing, but `semanticHits()` served the unfiltered neighbors, so hybrid search showed pure noise.

`relatedNotes()` already guarded against exactly this with a 0.7 cosine-distance cutoff (`MAX_RELATED_COSINE_DISTANCE`); search never applied one.

- Extracted the near-identical dedupe loops from `semanticHits()` and `relatedNotes()` into a shared, pure `bestChunkPerNote()` helper that drops rows past the cutoff, collapses to the best chunk per note, and (for related notes) excludes the seed note.
- Renamed the constant to `MAX_COSINE_DISTANCE` since it now governs both paths.
- Added unit tests for the cutoff, per-note dedup, seed exclusion, limit, snippet trimming, and the similarity/private-flag conversions.

## Why 0.7 works for search too

The 0.7 value was tuned for note→note similarity; I verified it also separates query→chunk matching cleanly by running the same model (all-MiniLM-L6-v2) against realistic note chunks:

| Query type | Best-match cosine distance |
|---|---|
| Relevant ("vacation ideas", "taxes", "vector search sqlite") | 0.30 – 0.65 |
| Fuzzy-related ("baking" vs a sourdough note) | 0.49 – 0.63 |
| Gibberish (`xxxxxxxxxxxx`, `qqqqqqqq`, …) | 0.72+ |
| Real-but-unrelated ("quantum chromodynamics") | 0.83+ |

Margin on both sides of 0.7, so no behavior change for legitimate queries. These numbers are recorded in the constant's doc comment.

## Notes for reviewers

- AI callers using `retrieve()` (semantic or hybrid mode) also stop receiving junk context for off-topic questions — same code path.
- Hybrid behavior for gibberish is now: lexical finds nothing, semantic filters everything out → empty results, as expected.
- Verified with `pnpm check` and `pnpm test --run src/embeddings/retrieve.test.ts` (9 tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared retrieval behavior for semantic/hybrid search and AI context; legitimate edge-case queries near the 0.7 distance boundary could lose hits, but the threshold was already validated for related notes.
> 
> **Overview**
> Semantic search and hybrid retrieval no longer return KNN neighbors when every chunk is past the **0.7 cosine-distance** noise threshold—gibberish or off-topic queries can return empty results instead of the nearest unrelated chunks.
> 
> The dedupe/cutoff logic shared by **`semanticHits`** and **`relatedNotes`** is moved into a pure **`bestChunkPerNote()`** helper (drop distant rows, keep the best chunk per note, optional seed exclusion, similarity scoring). The constant is renamed to **`MAX_COSINE_DISTANCE`** and documented for query→chunk behavior. Unit tests cover the cutoff, deduping, limits, seed exclusion, and snippet/private handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b4e99f286514c3ee3a7109d822e9454628b0d92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->