### PR TITLE
Stretch the note editor to fill the viewport (click anywhere to focus)

### DIFF
--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -11,6 +11,7 @@ import { useNoteDocument } from '@/editor/use-note-document'
 import { useWikiLinkNavigation } from '@/editor/use-wiki-link-navigation'
 import { WikiAutocomplete } from '@/editor/wiki-autocomplete'
 import { createNoteWithTitle } from '@/lib/create-note'
+import { cn } from '@/lib/utils'
 import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
 
@@ -23,6 +24,12 @@ interface NotePaneProps {
   autoFocus?: boolean
   /** Called once the autofocus actually happened (the editor mounted). */
   onAutoFocused?: () => void
+  /**
+   * Extra classes for the pane root in every state (loading, error,
+   * protected, editing). The note route uses this to make the pane a
+   * stretching flex column so the editor can fill the viewport.
+   */
+  className?: string
   /**
    * Extra classes for the editable area (e.g. the daily stream's per-day
    * `min-h-*`). Applied to the contenteditable root, so the reserved space
@@ -58,6 +65,7 @@ export function NotePane({
   lazy = false,
   autoFocus = false,
   onAutoFocused,
+  className,
   editorClassName,
   contextInSidebar = false,
 }: NotePaneProps): ReactElement {
@@ -120,13 +128,13 @@ export function NotePane({
 
   if (document.status === 'loading') {
     return (
-      <div className="px-1 py-2 text-sm text-text-muted">Loading note…</div>
+      <div className={cn('px-1 py-2 text-sm text-text-muted', className)}>Loading note…</div>
     )
   }
 
   if (document.status === 'error') {
     return (
-      <div role="alert" className="px-1 py-2 text-sm text-red-500">
+      <div role="alert" className={cn('px-1 py-2 text-sm text-red-500', className)}>
         Couldn’t open {path}: {document.error}
       </div>
     )
@@ -134,7 +142,7 @@ export function NotePane({
 
   if (document.protected) {
     return (
-      <div>
+      <div className={className}>
         <ProtectedNoteView content={document.initialContent} />
         <div className={contextInSidebar ? 'lg:hidden' : undefined}>
           <BacklinksPanel path={path} />
@@ -145,7 +153,7 @@ export function NotePane({
   }
 
   return (
-    <div className="relative" aria-label={`Editing ${path}`}>
+    <div className={cn('relative', className)} aria-label={`Editing ${path}`}>
       {document.error !== null ? (
         <InlineAlert tone="error" className="mb-4">
           Saving failed: {document.error}. Your edits are kept in the editor and the next

--- a/apps/desktop/src/components/route-content.tsx
+++ b/apps/desktop/src/components/route-content.tsx
@@ -28,10 +28,21 @@ export function RouteContent(): ReactElement {
       // is a real calendar day by the time it reaches a view.
       return <DailyStream targetDate={route.date} />
     case 'note':
+      // The vertical padding lives on the inner column (not the scroll
+      // container) so `min-h-full` fills the viewport exactly; the flex chain
+      // stretches the editor over any leftover space, making the whole note
+      // body click-to-focus.
       return (
-        <ScrollRestored className="h-full overflow-auto px-6 py-8">
-          <div className="mx-auto w-full max-w-2xl">
-            <NotePane path={route.path} lazy autoFocus contextInSidebar />
+        <ScrollRestored className="h-full overflow-auto px-6">
+          <div className="mx-auto flex min-h-full w-full max-w-2xl flex-col py-8">
+            <NotePane
+              path={route.path}
+              lazy
+              autoFocus
+              contextInSidebar
+              className="flex grow flex-col"
+              editorClassName="grow"
+            />
           </div>
         </ScrollRestored>
       )


### PR DESCRIPTION
## What

On the note route, the editor now stretches vertically to fill the scroll area, so clicking anywhere in the note body places the caret — previously the ProseMirror mount hugged its content (e.g. ~73px for a two-line note) and clicks below it did nothing.

## How

- `route-content.tsx`: the note route builds a height chain — the inner `max-w-2xl` column becomes `flex min-h-full flex-col`, with the vertical `py-8` padding moved off the scroll container onto that column (padding on the scroll container would make `min-h-full` overshoot the viewport by 64px and always show a scrollbar). The pane and the contenteditable each get `grow`.
- `note-pane.tsx`: new `className` prop applied to the pane root in every state (loading, error, protected, editing) so a route can make the pane a stretching flex column. The daily stream call site is unchanged — it keeps its per-day `min-h-*` sizing.

This leans on the existing contract documented on `NoteEditor`: the mount div *is* the contenteditable, so reserved space there is click-to-focus (the daily stream already relies on this). `ProseKit` renders no DOM wrapper, so the flex chain reaches the mount div directly.

## Notes for review

- `grow` rather than `flex-1`: `flex-1` sets `flex-basis: 0%`, which can mis-size an auto-height column once the note is taller than the viewport; `grow` keeps basis `auto` so long notes keep their natural height and scroll normally.
- Below the `lg` breakpoint, the inline backlinks/related panels sit after the stretched editor — the same trade-off the daily stream makes with `min-h-[60vh]`.
- No new tests: the route-content suite mocks the editor (jsdom can't lay out contenteditable), so a class-name assertion would document nothing real. `pnpm typecheck`, `pnpm lint`, and the existing route-content tests (9) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only CSS and optional `className` on `NotePane`; no document, save, or routing logic changes.
> 
> **Overview**
> On the **note route**, the editor now **fills the remaining viewport height** so clicks in empty space below short content still focus the editor (instead of only the tight ProseMirror box).
> 
> **`route-content.tsx`** builds a flex height chain: scroll area keeps horizontal padding only; the inner `max-w-2xl` column is `flex min-h-full flex-col` with `py-8` moved there so `min-h-full` matches the viewport without extra scrollbar from padded scroll container. **`NotePane`** gets `className="flex grow flex-col"` and **`editorClassName="grow"`**.
> 
> **`note-pane.tsx`** adds an optional **`className`** merged onto the pane root in loading, error, protected, and editing states so the route can stretch the pane. Daily stream usage is unchanged (still per-day `min-h-*` on the editor only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dfa7db228a1a06b9ee899f4168c7e16f5303c39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->