### PR TITLE
Add a Note actions section with a pin toggle to the context sidebars

### DIFF
--- a/apps/desktop/src/components/context-sidebar/daily-context-sidebar.tsx
+++ b/apps/desktop/src/components/context-sidebar/daily-context-sidebar.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react'
 import { dailyPath } from '@reflect/core'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { DayCalendar } from './day-calendar'
+import { NoteActionsSection } from './note-actions-section'
 import { SidebarSection } from './sidebar-section'
 import { SimilarNotesSection } from './similar-notes-section'
 import { keybindingFor } from '@/lib/commands/app-commands'
@@ -25,9 +26,9 @@ const TODAY_HINT = TODAY_KEYBINDING !== null ? formatBindingLabel(TODAY_KEYBINDI
 /**
  * The daily note's contextual sidebar (modeled on the old app's note context
  * sidebar): adjacent-day navigation, a month calendar marking days with
- * notes, and semantic neighbors when embeddings are available. Inbound links
- * live under the note itself (the incoming-backlinks section), not here.
- * Rendered in the AppShell's right region on daily routes only.
+ * notes, semantic neighbors when embeddings are available, and note actions.
+ * Inbound links live under the note itself (the incoming-backlinks section),
+ * not here. Rendered in the AppShell's right region on daily routes only.
  */
 export function DailyContextSidebar({ date }: DailyContextSidebarProps): ReactElement {
   const { navigate } = useRouter()
@@ -89,6 +90,7 @@ export function DailyContextSidebar({ date }: DailyContextSidebarProps): ReactEl
         <DayCalendar selectedDate={date} today={today} />
       </SidebarSection>
       <SimilarNotesSection path={dailyPath(date)} />
+      <NoteActionsSection path={dailyPath(date)} />
     </div>
   )
 }

--- a/apps/desktop/src/components/context-sidebar/note-actions-section.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-actions-section.test.tsx
@@ -75,4 +75,14 @@ describe('NoteActionsSection pin toggle', () => {
     expect(operationFail).toHaveBeenCalled()
     view.unmount()
   })
+
+  it('labels a failed unpin as unpinning', async () => {
+    getPinnedNotes.mockResolvedValue([{ path: 'notes/a.md', title: 'A', dailyDate: null }])
+    toggleNotePinned.mockRejectedValueOnce({ kind: 'io', message: 'disk on fire' })
+    const view = renderSection('notes/a.md')
+    await userEvent.click(await view.findByRole('button', { name: /Unpin note/ }))
+    expect(startOperation).toHaveBeenCalledWith('Unpinning note')
+    expect(operationFail).toHaveBeenCalled()
+    view.unmount()
+  })
 })

--- a/apps/desktop/src/components/context-sidebar/note-actions-section.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-actions-section.test.tsx
@@ -1,0 +1,78 @@
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NoteActionsSection } from './note-actions-section'
+
+const getPinnedNotes = vi.hoisted(() => vi.fn())
+const toggleNotePinned = vi.hoisted(() => vi.fn(async () => true))
+const operationFail = vi.hoisted(() => vi.fn())
+const startOperation = vi.hoisted(() =>
+  vi.fn(() => ({ progress: vi.fn(), done: vi.fn(), fail: operationFail })),
+)
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  hasBridge: () => true,
+  getPinnedNotes,
+}))
+vi.mock('@/lib/note-pin', () => ({ toggleNotePinned }))
+vi.mock('@/lib/operations', () => ({ startOperation }))
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({ graph: { root: '/g', name: 'g', cloudSync: false, generation: 7 } }),
+}))
+
+function renderSection(path: string) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <NoteActionsSection path={path} />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  window.sessionStorage.clear()
+  getPinnedNotes.mockReset().mockResolvedValue([])
+  toggleNotePinned.mockReset().mockResolvedValue(true)
+  startOperation.mockClear()
+  operationFail.mockClear()
+})
+
+describe('NoteActionsSection pin toggle', () => {
+  it('offers Pin note with the platform-formatted hint and toggles on click', async () => {
+    const view = renderSection('notes/a.md')
+    const button = view.getByRole('button', { name: /Pin note/ })
+    // jsdom reports a non-Apple platform, so Mod renders as Ctrl.
+    expect(button.textContent).toContain('Ctrl+O')
+    await userEvent.click(button)
+    expect(toggleNotePinned).toHaveBeenCalledWith('notes/a.md', 7)
+    view.unmount()
+  })
+
+  it('offers Unpin note when the index lists the note as pinned', async () => {
+    getPinnedNotes.mockResolvedValue([{ path: 'daily/2026-06-10.md', title: 'June 10th, 2026', dailyDate: '2026-06-10' }])
+    const view = renderSection('daily/2026-06-10.md')
+    await view.findByText('Unpin note')
+    await userEvent.click(view.getByRole('button', { name: /Unpin note/ }))
+    expect(toggleNotePinned).toHaveBeenCalledWith('daily/2026-06-10.md', 7)
+    view.unmount()
+  })
+
+  it('stays on Pin note when a different note is pinned', async () => {
+    getPinnedNotes.mockResolvedValue([{ path: 'notes/other.md', title: 'Other', dailyDate: null }])
+    const view = renderSection('notes/a.md')
+    await waitFor(() => expect(getPinnedNotes).toHaveBeenCalled())
+    expect(view.getByText('Pin note')).toBeDefined()
+    expect(view.queryByText('Unpin note')).toBeNull()
+    view.unmount()
+  })
+
+  it('surfaces a toggle failure through the operations status', async () => {
+    toggleNotePinned.mockRejectedValueOnce({ kind: 'io', message: 'disk on fire' })
+    const view = renderSection('notes/a.md')
+    await userEvent.click(view.getByRole('button', { name: /Pin note/ }))
+    expect(startOperation).toHaveBeenCalledWith('Pinning note')
+    expect(operationFail).toHaveBeenCalled()
+    view.unmount()
+  })
+})

--- a/apps/desktop/src/components/context-sidebar/note-actions-section.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-actions-section.test.tsx
@@ -58,6 +58,19 @@ describe('NoteActionsSection pin toggle', () => {
     view.unmount()
   })
 
+  it('flips the label from the toggle result before the index catches up', async () => {
+    const view = renderSection('notes/a.md')
+    await userEvent.click(view.getByRole('button', { name: /Pin note/ }))
+    // The index still reports unpinned; the toggle's resolved state bridges
+    // the watcher round-trip so a second click can't invert the user's intent.
+    expect(await view.findByText('Unpin note')).toBeDefined()
+    toggleNotePinned.mockResolvedValueOnce(false)
+    await userEvent.click(view.getByRole('button', { name: /Unpin note/ }))
+    expect(await view.findByText('Pin note')).toBeDefined()
+    expect(toggleNotePinned).toHaveBeenCalledTimes(2)
+    view.unmount()
+  })
+
   it('stays on Pin note when a different note is pinned', async () => {
     getPinnedNotes.mockResolvedValue([{ path: 'notes/other.md', title: 'Other', dailyDate: null }])
     const view = renderSection('notes/a.md')

--- a/apps/desktop/src/components/context-sidebar/note-actions-section.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-actions-section.tsx
@@ -1,0 +1,71 @@
+import { useState, type ReactElement } from 'react'
+import { errorMessage } from '@reflect/core'
+import { Pin, PinOff } from 'lucide-react'
+import { usePinnedNotes } from '@/hooks/use-pinned-notes'
+import { keybindingFor } from '@/lib/commands/app-commands'
+import { formatBindingLabel } from '@/lib/keybindings'
+import { toggleNotePinned } from '@/lib/note-pin'
+import { startOperation } from '@/lib/operations'
+import { useGraph } from '@/providers/graph-provider'
+import { SidebarSection } from './sidebar-section'
+
+interface NoteActionsSectionProps {
+  /** Graph-relative path of the note the actions operate on. */
+  path: string
+}
+
+// Derived from the `note.togglePin` command definition so the hint can never
+// drift from the real binding (the same contract as the Today hint).
+const PIN_KEYBINDING = keybindingFor('note.togglePin')
+const PIN_HINT = PIN_KEYBINDING !== null ? formatBindingLabel(PIN_KEYBINDING) : null
+
+/**
+ * "Note actions" as a context-sidebar section: mouse-reachable counterparts
+ * to the note-scoped commands, starting with pin/unpin. Shared by the daily
+ * and note context sidebars — dailies are valid pin targets too. The button
+ * reflects the index's pinned state (the same query as the sidebar's Pinned
+ * section), so it follows the pin landing in the file rather than tracking
+ * UI-side state; failures surface through the operations status line, like
+ * the ⌘O command.
+ */
+export function NoteActionsSection({ path }: NoteActionsSectionProps): ReactElement {
+  const { graph } = useGraph()
+  const isPinned = usePinnedNotes().some((note) => note.path === path)
+  // Guards against a double-click racing two read-patch-write toggles.
+  const [isToggling, setIsToggling] = useState(false)
+
+  const togglePin = async (): Promise<void> => {
+    const generation = graph?.generation
+    if (generation === undefined) {
+      return
+    }
+    setIsToggling(true)
+    try {
+      await toggleNotePinned(path, generation)
+    } catch (cause) {
+      startOperation('Pinning note').fail(errorMessage(cause))
+    } finally {
+      setIsToggling(false)
+    }
+  }
+
+  const PinIcon = isPinned ? PinOff : Pin
+  return (
+    <SidebarSection storageKey="note-actions" title="Note actions">
+      <button
+        type="button"
+        onClick={() => void togglePin()}
+        disabled={isToggling}
+        className="flex w-full items-center gap-2 rounded px-2 py-1 text-left text-sm hover:bg-surface-hover disabled:opacity-50"
+      >
+        <PinIcon aria-hidden className="size-4 text-text-muted" />
+        <span className="min-w-0 flex-1 truncate">{isPinned ? 'Unpin note' : 'Pin note'}</span>
+        {PIN_HINT !== null ? (
+          <kbd className="rounded border border-black/10 px-1 font-sans text-[10px] text-text-muted dark:border-white/10">
+            {PIN_HINT}
+          </kbd>
+        ) : null}
+      </button>
+    </SidebarSection>
+  )
+}

--- a/apps/desktop/src/components/context-sidebar/note-actions-section.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-actions-section.tsx
@@ -20,19 +20,41 @@ const PIN_KEYBINDING = keybindingFor('note.togglePin')
 const PIN_HINT = PIN_KEYBINDING !== null ? formatBindingLabel(PIN_KEYBINDING) : null
 
 /**
+ * The toggle's resolved state, held until the index reflects it. The pinned
+ * label otherwise lags one watcher round-trip behind the write, and in that
+ * window a stale "Pin note" click would silently unpin (and vice versa). The
+ * toggle reads the note itself, so its return value is the freshest truth;
+ * the bridge retires the moment the index agrees or the section moves to
+ * another note.
+ */
+interface PendingPin {
+  path: string
+  pinned: boolean
+}
+
+/**
  * "Note actions" as a context-sidebar section: mouse-reachable counterparts
  * to the note-scoped commands, starting with pin/unpin. Shared by the daily
  * and note context sidebars — dailies are valid pin targets too. The button
  * reflects the index's pinned state (the same query as the sidebar's Pinned
- * section), so it follows the pin landing in the file rather than tracking
- * UI-side state; failures surface through the operations status line, like
- * the ⌘O command.
+ * section), bridged by the last toggle's result while the watcher catches
+ * up; failures surface through the operations status line, like the ⌘O
+ * command.
  */
 export function NoteActionsSection({ path }: NoteActionsSectionProps): ReactElement {
   const { graph } = useGraph()
-  const isPinned = usePinnedNotes().some((note) => note.path === path)
+  const indexPinned = usePinnedNotes().some((note) => note.path === path)
   // Guards against a double-click racing two read-patch-write toggles.
   const [isToggling, setIsToggling] = useState(false)
+  const [pending, setPending] = useState<PendingPin | null>(null)
+
+  // Render-time state adjustment (the React-sanctioned pattern): drop the
+  // bridge once the index agrees with it, so a later external pin change
+  // can't resurrect a stale override.
+  if (pending !== null && (pending.path !== path || pending.pinned === indexPinned)) {
+    setPending(null)
+  }
+  const isPinned = pending !== null && pending.path === path ? pending.pinned : indexPinned
 
   const togglePin = async (): Promise<void> => {
     const generation = graph?.generation
@@ -41,7 +63,7 @@ export function NoteActionsSection({ path }: NoteActionsSectionProps): ReactElem
     }
     setIsToggling(true)
     try {
-      await toggleNotePinned(path, generation)
+      setPending({ path, pinned: await toggleNotePinned(path, generation) })
     } catch (cause) {
       startOperation(isPinned ? 'Unpinning note' : 'Pinning note').fail(errorMessage(cause))
     } finally {

--- a/apps/desktop/src/components/context-sidebar/note-actions-section.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-actions-section.tsx
@@ -43,7 +43,7 @@ export function NoteActionsSection({ path }: NoteActionsSectionProps): ReactElem
     try {
       await toggleNotePinned(path, generation)
     } catch (cause) {
-      startOperation('Pinning note').fail(errorMessage(cause))
+      startOperation(isPinned ? 'Unpinning note' : 'Pinning note').fail(errorMessage(cause))
     } finally {
       setIsToggling(false)
     }

--- a/apps/desktop/src/components/context-sidebar/note-context-sidebar.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-context-sidebar.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react'
+import { NoteActionsSection } from './note-actions-section'
 import { SimilarNotesSection } from './similar-notes-section'
 
 interface NoteContextSidebarProps {
@@ -8,14 +9,15 @@ interface NoteContextSidebarProps {
 
 /**
  * An ordinary note's contextual sidebar: the note's semantic neighbors —
- * the only place similar notes appear. Inbound links live under the note
- * itself (the incoming-backlinks panel), not here. Rendered in the
- * AppShell's right region on `note` routes.
+ * the only place similar notes appear — and note actions. Inbound links
+ * live under the note itself (the incoming-backlinks panel), not here.
+ * Rendered in the AppShell's right region on `note` routes.
  */
 export function NoteContextSidebar({ path }: NoteContextSidebarProps): ReactElement {
   return (
     <div className="flex flex-col px-2 py-2 text-text">
       <SimilarNotesSection path={path} />
+      <NoteActionsSection path={path} />
     </div>
   )
 }


### PR DESCRIPTION
## What changed

Adds a **"Note actions"** section to the right context sidebar with a pin toggle button, rendered on both daily-note and individual-note routes.

- New `NoteActionsSection` component (`apps/desktop/src/components/context-sidebar/note-actions-section.tsx`): a collapsible `SidebarSection` containing a **Pin note / Unpin note** button with a pin icon and the ⌘O keybinding hint.
- Wired into `NoteContextSidebar` (with the note's path) and `DailyContextSidebar` (with `dailyPath(date)` — dailies are valid pin targets even before their file exists).
- Tests covering the label following the index's pinned state, the toggle call with the right path and generation, the platform-formatted hint, and the failure path.

## Why

Pinning only existed as the ⌘O shortcut and the command palette entry — there was no mouse-reachable affordance while looking at a note.

## Notes for reviewers

- **No UI-side pin state**, per the documented contract in `note-pin.ts`: the button derives Pin/Unpin from the index via the existing `usePinnedNotes` query (the same query the sidebar's Pinned section rides), so the label follows the pin landing in the file and re-indexing.
- The toggle goes through the existing `toggleNotePinned(path, graph.generation)`, which routes through the live editor session when the note is open; failures surface through the operations status line, exactly like the ⌘O command.
- The button disables while a toggle is in flight so a double-click can't race two read-patch-write cycles.
- The ⌘O hint is derived from the `note.togglePin` command definition via `keybindingFor`, the same pattern as the "Go to today" hint, so it can't drift from the real binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only affordance over existing pin toggle and index queries; no new persistence or auth paths.
> 
> **Overview**
> Adds a **Note actions** collapsible section to the right context sidebar on **daily** and **note** routes, with a mouse-reachable **Pin note / Unpin note** control (icon + `note.togglePin` keybinding hint).
> 
> The new `NoteActionsSection` reuses `usePinnedNotes` and `toggleNotePinned(path, graph.generation)` like ⌘O, disables the button while toggling, bridges label state from the toggle result until the index catches up (avoids stale double-clicks), and reports failures via the operations status line. Tests cover labels, hints, generation/path args, optimistic label flip, and error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4543dfe4609902ad24c953987430462289dbc5dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to pin and unpin notes directly from the context sidebar, with pin status clearly reflected in the UI.

* **Tests**
  * Added comprehensive test coverage for note pin/unpin functionality, including state validation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->