### PR TITLE
Remove unsaved-changes indicator from note pane

### DIFF
--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -166,14 +166,6 @@ export function NotePane({
         />
       ) : null}
 
-      {document.dirty ? (
-        <span
-          aria-label="Unsaved changes"
-          title="Unsaved changes"
-          className="absolute -top-1 right-0 size-2 rounded-full bg-accent"
-        />
-      ) : null}
-
       <NoteEditor
         key={path}
         initialContent={document.initialContent}


### PR DESCRIPTION
## What changed

Removed the small accent-colored dot that appeared in the top-right of a note whenever the buffer had unsaved changes (`document.dirty`).

## Why

Autosave is debounced and happens seamlessly in the background, so surfacing transient dirty state is noise — the dot flickered on every keystroke while typing. There's nothing actionable about it.

## Notes for reviewers

- The `dirty` flag and the debounced save pipeline in the note session are untouched; only the visual indicator is gone.
- Save *failures* still surface via the existing `InlineAlert` error banner, which is the actionable case worth keeping.
- Nothing else referenced the indicator; `pnpm check` (typecheck + lint) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only removal of a dirty-state indicator; save logic and failure/conflict alerts are unchanged.
> 
> **Overview**
> Removes the **unsaved-changes dot** from the note pane—the small accent circle that showed when `document.dirty` was true.
> 
> **Autosave** still runs on the existing debounced pipeline; only the transient visual cue is gone. Save failures and external-edit conflicts remain surfaced via the existing error `InlineAlert` and `NoteConflictBanner`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8d4e527c331fe0597a6aee08dc3364c39afb9a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->