### PR TITLE
Fix stray corner artifacts on the [[ autocomplete popup

### DIFF
--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -184,6 +184,10 @@ body,
    The popup is a prosekit custom element (positioned by its positioner); all
    visual treatment is ours. Items carry `data-highlighted` while traversed. */
 .reflect-autocomplete {
+  /* Custom elements default to display:inline; an inline box fragments around
+     block children, painting stray border/corner artifacts above and below the
+     list and ignoring min-width/max-height/overflow. */
+  display: block;
   z-index: 50;
   min-width: 16rem;
   max-width: 24rem;


### PR DESCRIPTION
## What changed

Added `display: block` to `.reflect-autocomplete` (the `[[` wiki-link autocomplete popup) in `apps/desktop/src/styles/index.css`.

## Why

ProseKit's `AutocompletePopup` renders as a custom element (`prosekit-autocomplete-popup`), and unknown elements default to `display: inline`. Since the menu items inside are `display: block`, the inline popup box fragmented around them — its border, padding, and rounded corners painted as stray empty corner boxes above and below the list:

| Before | After |
| --- | --- |
| Border/corners render as detached fragments above and below the items | Proper bordered, rounded, shadowed box wrapping the list |

The inline display also meant `min-width`, `max-height`, and `overflow-y: auto` were silently ignored, so long suggestion lists never scrolled.

## Notes for reviewers

- Verified with a side-by-side repro using the app's exact popup CSS: the inline version reproduces the reported artifacts precisely; `display: block` restores the intended box (and scrolling).
- `.reflect-autocomplete-item` and `.reflect-autocomplete-empty` already set `display: block`; the popup container was the only prosekit custom element missing it. The ⌘K palette uses cmdk (real `div`s) and is unaffected.
- `pnpm check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS rule on autocomplete styling only; no auth, data, or logic changes.
> 
> **Overview**
> Fixes visual glitches on the **`[[` wiki-link autocomplete** by setting **`display: block`** on `.reflect-autocomplete` in `apps/desktop/src/styles/index.css`.
> 
> ProseKit’s `AutocompletePopup` is a custom element that otherwise behaves like **`display: inline`**, so block list items caused the border, padding, and rounded corners to paint as **detached fragments** above and below the menu. The same inline box also prevented **`min-width`**, **`max-height`**, and **`overflow-y: auto`** from applying, so long suggestion lists could not scroll inside the popup.
> 
> A short comment documents the inline-vs-block behavior for future reviewers. The ⌘K palette is unchanged (it uses normal `div`s, not this element).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0293a0f8b75e4129617ecd2fa60b4fa4431300d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->