### PR TITLE
Navigate on plain click of wiki-link chips

### DIFF
--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -58,7 +58,7 @@ interface NoteEditorProps {
   markMode?: MarkMode
   /** Image rendering + paste/drop persistence (Plan 05b). */
   images?: ImageOptions
-  /** Mod+click on a `[[wiki link]]` chip (Plan 06 navigation). */
+  /** Click on a `[[wiki link]]` chip (Plan 06 navigation). */
   onWikiLinkClick?: (target: string) => void
   /**
    * Extra classes for the editable root. The mount div *is* the ProseMirror

--- a/apps/desktop/src/editor/wiki-links.test.ts
+++ b/apps/desktop/src/editor/wiki-links.test.ts
@@ -1,9 +1,10 @@
 import { docToMarkdown, markdownToDoc, type TypedEditor } from '@meowdown/core'
 import { createEditor, union } from '@prosekit/core'
 import { defineEditorExtension } from '@meowdown/core'
-import { TextSelection } from '@prosekit/pm/state'
-import { describe, expect, it } from 'vitest'
-import { computeWikiLinkRanges, defineWikiLinks } from './wiki-links'
+import { TextSelection, type EditorState } from '@prosekit/pm/state'
+import type { EditorView } from '@prosekit/pm/view'
+import { describe, expect, it, vi } from 'vitest'
+import { computeWikiLinkRanges, createWikiLinkPlugin, defineWikiLinks } from './wiki-links'
 
 function editorWith(markdown: string) {
   const editor = createEditor({ extension: union(defineEditorExtension(), defineWikiLinks()) })
@@ -59,5 +60,83 @@ describe('wiki-link decorations', () => {
       const editor = editorWith(markdown)
       expect(docToMarkdown(editor.state.doc).replace(/\n$/, '')).toBe(markdown)
     }
+  })
+})
+
+describe('wiki-link click navigation', () => {
+  function chipFor(state: EditorState, target: string) {
+    return computeWikiLinkRanges(state).find(
+      (range) => range.kind === 'chip' && range.target === target,
+    )!
+  }
+
+  function caretInside(state: EditorState, pos: number): EditorState {
+    return state.apply(state.tr.setSelection(TextSelection.create(state.doc, pos)))
+  }
+
+  function chipClickEvent(target: string, init: MouseEventInit = {}): MouseEvent {
+    const span = document.createElement('span')
+    span.setAttribute('data-wiki-target', target)
+    const event = new MouseEvent('click', init)
+    Object.defineProperty(event, 'target', { value: span })
+    return event
+  }
+
+  /** Run the gesture the way ProseMirror does: mousedown snapshot, then click. */
+  function press(state: EditorState, pos: number, event: MouseEvent) {
+    const onNavigate = vi.fn()
+    const plugin = createWikiLinkPlugin({ onNavigate })
+    const view = { state } as unknown as EditorView
+    plugin.props.handleDOMEvents!.mousedown!.call(plugin, view, new MouseEvent('mousedown'))
+    const handled = plugin.props.handleClick!.call(plugin, view, pos, event)
+    return { handled, onNavigate }
+  }
+
+  it('navigates on plain click of a rendered link', () => {
+    const { state } = editorWith('See [[Charlotte]] here.')
+    const chip = chipFor(state, 'Charlotte')
+    const { handled, onNavigate } = press(state, chip.from + 3, chipClickEvent('Charlotte'))
+    expect(handled).toBe(true)
+    expect(onNavigate).toHaveBeenCalledWith('Charlotte')
+  })
+
+  it('places the caret instead when the clicked link is already being edited', () => {
+    const { state } = editorWith('See [[Charlotte]] here.')
+    const chip = chipFor(state, 'Charlotte')
+    const editing = caretInside(state, chip.from + 3)
+    const { handled, onNavigate } = press(editing, chip.from + 5, chipClickEvent('Charlotte'))
+    expect(handled).toBe(false)
+    expect(onNavigate).not.toHaveBeenCalled()
+  })
+
+  it('Mod+click navigates even while editing the link', () => {
+    const { state } = editorWith('See [[Charlotte]] here.')
+    const chip = chipFor(state, 'Charlotte')
+    const editing = caretInside(state, chip.from + 3)
+    const { handled, onNavigate } = press(
+      editing,
+      chip.from + 5,
+      chipClickEvent('Charlotte', { metaKey: true }),
+    )
+    expect(handled).toBe(true)
+    expect(onNavigate).toHaveBeenCalledWith('Charlotte')
+  })
+
+  it('navigates when clicking one link while editing another', () => {
+    const { state } = editorWith('[[Alpha]] and [[Beta]]')
+    const editing = caretInside(state, chipFor(state, 'Alpha').from + 3)
+    const beta = chipFor(editing, 'Beta')
+    const { handled, onNavigate } = press(editing, beta.from + 3, chipClickEvent('Beta'))
+    expect(handled).toBe(true)
+    expect(onNavigate).toHaveBeenCalledWith('Beta')
+  })
+
+  it('ignores clicks outside any link', () => {
+    const { state } = editorWith('See [[Charlotte]] here.')
+    const event = new MouseEvent('click')
+    Object.defineProperty(event, 'target', { value: document.createElement('span') })
+    const { handled, onNavigate } = press(state, 1, event)
+    expect(handled).toBe(false)
+    expect(onNavigate).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/editor/wiki-links.ts
+++ b/apps/desktop/src/editor/wiki-links.ts
@@ -27,8 +27,11 @@ const wikiLinkKey = new PluginKey<DecorationSet>('reflect-wiki-links')
 
 export interface WikiLinkOptions {
   /**
-   * Called with the link target on Mod+click (plain click places the caret, as
-   * in any live-preview editor). Resolution/navigation is the caller's job.
+   * Called with the link target on click. Links act like links: a plain click
+   * navigates. The exception is a link the caret is already inside (syntax
+   * revealed, being edited) — there a plain click places the caret so the
+   * text stays mouse-editable, and Mod+click still navigates.
+   * Resolution/navigation is the caller's job.
    */
   onNavigate?: (target: string) => void
 }
@@ -101,6 +104,39 @@ export function computeWikiLinkRanges(state: EditorState): WikiLinkRange[] {
   return ranges
 }
 
+/** The selection as it stood at mousedown, before the click moved the caret. */
+interface SelectionSnapshot {
+  from: number
+  to: number
+  empty: boolean
+}
+
+/**
+ * Whether a plain click at `pos` should edit (place the caret) rather than
+ * navigate: true when the pre-click caret already sat inside the clicked
+ * link — the syntax-revealed state, the user is editing it. The snapshot
+ * must be taken at mousedown: by the time the click handler runs, the
+ * browser has already moved the caret to the clicked position, so the
+ * live selection always looks "inside the link". Pure; exported for tests.
+ */
+export function clickEditsLink(
+  state: EditorState,
+  pos: number,
+  selectionBefore: SelectionSnapshot | null,
+): boolean {
+  if (!selectionBefore || !selectionBefore.empty) {
+    return false
+  }
+  return computeWikiLinkRanges(state).some(
+    (range) =>
+      range.kind === 'chip' &&
+      range.from <= pos &&
+      pos <= range.to &&
+      selectionBefore.from >= range.from &&
+      selectionBefore.to <= range.to,
+  )
+}
+
 function buildDecorations(state: EditorState): DecorationSet {
   const decorations = computeWikiLinkRanges(state).map((range) => {
     if (range.kind === 'chip') {
@@ -116,7 +152,10 @@ function buildDecorations(state: EditorState): DecorationSet {
   return DecorationSet.create(state.doc, decorations)
 }
 
-function createWikiLinkPlugin(options: WikiLinkOptions): Plugin<DecorationSet> {
+/** The decoration + click-handling plugin. Exported for tests. */
+export function createWikiLinkPlugin(options: WikiLinkOptions): Plugin<DecorationSet> {
+  let selectionBeforeClick: SelectionSnapshot | null = null
+
   return new Plugin<DecorationSet>({
     key: wikiLinkKey,
     state: {
@@ -132,8 +171,15 @@ function createWikiLinkPlugin(options: WikiLinkOptions): Plugin<DecorationSet> {
     },
     props: {
       decorations: (state) => wikiLinkKey.getState(state),
-      handleClick: (_view, _pos, event) => {
-        if (!options.onNavigate || !(event.metaKey || event.ctrlKey)) {
+      handleDOMEvents: {
+        mousedown: (view) => {
+          const { from, to, empty } = view.state.selection
+          selectionBeforeClick = { from, to, empty }
+          return false
+        },
+      },
+      handleClick: (view, pos, event) => {
+        if (!options.onNavigate) {
           return false
         }
         // The chip decoration carries the target; read it off the clicked span.
@@ -141,6 +187,10 @@ function createWikiLinkPlugin(options: WikiLinkOptions): Plugin<DecorationSet> {
           ?.closest?.('[data-wiki-target]')
           ?.getAttribute('data-wiki-target')
         if (!target) {
+          return false
+        }
+        const modClick = event.metaKey || event.ctrlKey
+        if (!modClick && clickEditsLink(view.state, pos, selectionBeforeClick)) {
           return false
         }
         options.onNavigate(target)

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -176,8 +176,11 @@ body,
   padding: 0.05em 0.15em;
   cursor: pointer;
 }
+/* Caret inside the link: syntax is revealed for editing, so clicks place the
+   caret (navigation needs Mod+click here) — signal that with a text cursor. */
 .reflect-editor .md-wiki-link.is-active {
   background: transparent;
+  cursor: text;
 }
 
 /* ---- [[ autocomplete (Plan 07) ---------------------------------------------


### PR DESCRIPTION
## What changed

Clicking a `[[backlink]]` chip in the editor now navigates to that note. Previously a plain click only placed the caret and navigation required Mod+click (the interim live-preview convention, deliberately deferred in `docs/non-daily-notes/plan.md`) — even though the chip is styled as a link with a pointer cursor.

The click behavior is now:

- **Plain click on a rendered link** → opens the target note.
- **Plain click on a link being edited** (caret already inside, syntax revealed) → places the caret, so the link text stays mouse-editable.
- **Mod+click** → always navigates, including mid-edit.

The active (being-edited) chip shows a text cursor instead of a pointer to signal the caret behavior.

## Why the mousedown snapshot

The "is the user editing this link?" check needs the selection as it stood *before* the click — by the time ProseMirror's `handleClick` runs, the browser has already moved the caret into the clicked link, so the live selection always looks "inside". The plugin snapshots the selection on mousedown and `handleClick` checks the clicked chip against that snapshot via a new pure helper, `clickEditsLink`.

## Notes for reviewers

- The backlinks panel and sidebar "Linked from" rows already navigated on click; the editor chip was the only click surface that didn't.
- `createWikiLinkPlugin` is now exported for tests, matching the file's existing "exported for tests" idiom.
- New tests cover: plain-click navigation, caret placement while editing, Mod+click while editing, clicking a second link while editing another, and clicks outside links.

## Verification

- `pnpm test --run src/editor` — 134 tests pass (5 new)
- `pnpm check` — typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor interaction and navigation UX only; existing `onWikiLinkClick` wiring is unchanged and serialization remains decoration-only.
> 
> **Overview**
> **Wiki-link chips in the editor now navigate on a plain click**, aligning chip behavior with other link surfaces (backlinks panel, sidebar). **Mod+click** is no longer required for normal navigation.
> 
> **Editing exception:** If the caret was already inside the clicked link before the click (syntax revealed), a plain click still **places the caret** so link text stays mouse-editable. **Mod+click** still navigates in that state. The plugin snapshots selection on **mousedown** and uses a new **`clickEditsLink`** helper because the live selection at click time always looks “inside” the link.
> 
> **UI:** Active (being-edited) chips use **`cursor: text`** instead of pointer to signal caret placement vs navigation.
> 
> **Tests:** Five new cases cover plain navigation, edit-in-place, Mod+click while editing, clicking another link while editing one, and clicks outside links. **`createWikiLinkPlugin`** is exported for direct plugin testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb0c4393df3f893f416307f509de907a31bf0981. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->