### PR TITLE
Persist window size/position and set default dimensions to 1300×650

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4152,6 +4152,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-http",
  "tauri-plugin-opener",
+ "tauri-plugin-window-state",
  "tempfile",
  "tracing",
  "tracing-subscriber",
@@ -5324,6 +5325,21 @@ dependencies = [
  "url",
  "windows 0.61.3",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.13.0",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -44,6 +44,7 @@ keyring = { version = "3", features = [
   "sync-secret-service",
 ] }
 tauri-plugin-http = "2.5.9"
+tauri-plugin-window-state = "2"
 
 [dev-dependencies]
 tauri = { version = "2", features = ["test"] }

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
     "core:window:allow-start-dragging",
     "opener:default",
     "dialog:default",
+    "window-state:default",
     {
       "identifier": "http:default",
       "allow": [

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -44,6 +44,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_http::init())
+        .plugin(tauri_plugin_window_state::Builder::default().build())
         .manage(fs::GraphState::default())
         .manage(db::IndexState::default())
         .manage(watcher::WatcherState::default())

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -13,8 +13,8 @@
     "windows": [
       {
         "title": "reflect-open",
-        "width": 800,
-        "height": 600,
+        "width": 1300,
+        "height": 650,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true
       }


### PR DESCRIPTION
## Summary

- Adds `tauri-plugin-window-state` (v2) to automatically save and restore the window's size and position across restarts — no frontend code needed, the plugin hooks into the close/restore lifecycle automatically.
- Bumps the initial default window size from 800×600 to 1300×650.

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | Added `tauri-plugin-window-state = "2"` dependency |
| `src/lib.rs` | Registered `tauri_plugin_window_state::Builder::default().build()` |
| `capabilities/default.json` | Added `"window-state:default"` permission grant |
| `tauri.conf.json` | Default window `width`/`height` set to 1300×650 |
| `Cargo.lock` | Updated to include resolved `tauri-plugin-window-state 2.4.1` |

## Test plan

- [ ] Launch app — window opens at ~1300×650 on first run (no saved state)
- [ ] Resize/move the window, then quit and relaunch — size and position are restored
- [ ] Confirm no permission errors in the Tauri console on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop shell-only change using a standard Tauri plugin; no auth, data, or business-logic impact.
> 
> **Overview**
> Adds **`tauri-plugin-window-state`** so the main window’s size and position are saved on close and restored on launch, with no frontend changes.
> 
> Wiring is limited to registering the plugin in `lib.rs`, adding the `window-state:default` capability, and the new Cargo dependency/lock entry. **`tauri.conf.json`** default dimensions change from **800×600** to **1300×650** for first launch when no saved state exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a834edc46fcc26fac014b224426002f8037db83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->