### PR TITLE
Fix schema tests: add weekStartDay to expected settings shape

### DIFF
--- a/packages/core/src/settings/schema.test.ts
+++ b/packages/core/src/settings/schema.test.ts
@@ -7,6 +7,7 @@ describe('settingsSchema', () => {
       editorMarkdownSyntax: 'focus',
       semanticSearchEnabled: false,
       theme: 'system',
+      weekStartDay: 'monday',
       allNotesFilterTags: ['book', 'link', 'person'],
       aiModels: [],
       defaultAiModelId: null,
@@ -14,6 +15,7 @@ describe('settingsSchema', () => {
     expect(DEFAULT_SETTINGS.editorMarkdownSyntax).toBe('focus')
     expect(DEFAULT_SETTINGS.semanticSearchEnabled).toBe(false)
     expect(DEFAULT_SETTINGS.theme).toBe('system')
+    expect(DEFAULT_SETTINGS.weekStartDay).toBe('monday')
     expect(DEFAULT_SETTINGS.allNotesFilterTags).toEqual(['book', 'link', 'person'])
     expect(DEFAULT_SETTINGS.aiModels).toEqual([])
     expect(DEFAULT_SETTINGS.defaultAiModelId).toBeNull()
@@ -25,6 +27,8 @@ describe('settingsSchema', () => {
     expect(settingsSchema.parse({ theme: 'dark' }).theme).toBe('dark')
     expect(settingsSchema.parse({ theme: 'light' }).theme).toBe('light')
     expect(settingsSchema.parse({ theme: 'system' }).theme).toBe('system')
+    expect(settingsSchema.parse({ weekStartDay: 'monday' }).weekStartDay).toBe('monday')
+    expect(settingsSchema.parse({ weekStartDay: 'sunday' }).weekStartDay).toBe('sunday')
     expect(settingsSchema.parse({ semanticSearchEnabled: true }).semanticSearchEnabled).toBe(true)
     expect(settingsSchema.parse({ semanticSearchEnabled: false }).semanticSearchEnabled).toBe(false)
     expect(
@@ -38,6 +42,8 @@ describe('settingsSchema', () => {
     expect(settingsSchema.parse({ editorMarkdownSyntax: 42 }).editorMarkdownSyntax).toBe('focus')
     expect(settingsSchema.parse({ theme: 'sepia' }).theme).toBe('system')
     expect(settingsSchema.parse({ theme: 7 }).theme).toBe('system')
+    expect(settingsSchema.parse({ weekStartDay: 'saturday' }).weekStartDay).toBe('monday')
+    expect(settingsSchema.parse({ weekStartDay: 42 }).weekStartDay).toBe('monday')
     expect(settingsSchema.parse({ semanticSearchEnabled: 'yes' }).semanticSearchEnabled).toBe(false)
     expect(settingsSchema.parse({ semanticSearchEnabled: 1 }).semanticSearchEnabled).toBe(false)
     expect(settingsSchema.parse({ allNotesFilterTags: 'book' }).allNotesFilterTags).toEqual([
@@ -58,6 +64,7 @@ describe('settingsSchema', () => {
       editorMarkdownSyntax: 'show',
       semanticSearchEnabled: false,
       theme: 'system',
+      weekStartDay: 'monday',
       allNotesFilterTags: ['book', 'link', 'person'],
       aiModels: [],
       defaultAiModelId: null,


### PR DESCRIPTION
## Summary

- Updates the two `settingsSchema` deep-equality tests to include the `weekStartDay: 'monday'` field added in #59
- Adds `weekStartDay` valid-value and invalid-degradation assertions to round out coverage

The implementation was merged in #59 before the test fix was pushed; this cherry-picks that commit onto master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime or settings behavior modified in this diff.
> 
> **Overview**
> Aligns **`settingsSchema`** tests with the **`weekStartDay`** setting introduced elsewhere (#59), so default-shape and round-trip expectations match the parsed document.
> 
> Adds **`weekStartDay: 'monday'`** to deep-equality expectations (fresh install and unknown-key preservation), asserts **`DEFAULT_SETTINGS.weekStartDay`**, and extends coverage for valid values (`monday` / `sunday`) and invalid input degrading to the default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa0bb97870ebbcbfa4a049112bff8e9742cd2f68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->