### PR TITLE
Reduce min-height for past days in daily stream

### DIFF
--- a/apps/desktop/src/components/daily-stream.tsx
+++ b/apps/desktop/src/components/daily-stream.tsx
@@ -123,7 +123,7 @@ export function DailyStream({ targetDate }: DailyStreamProps): ReactElement {
                   lazy
                   autoFocus={autoFocus}
                   onAutoFocused={consumeFocus}
-                  editorClassName={isPast ? 'min-h-[200px]' : 'min-h-[60vh]'}
+                  editorClassName={isPast ? 'min-h-[100px]' : 'min-h-[60vh]'}
                 />
               </section>
             </div>


### PR DESCRIPTION
## Summary
Reduce the minimum height for past days in the daily notes stream from 200px to 100px, resulting in more compact display of historical notes while maintaining readability.

## Changes
- Updated `editorClassName` for past days in DailyStream from `min-h-[200px]` to `min-h-[100px]`

## Testing
Past days in the daily stream should now have a smaller minimum height, allowing the view to be more vertically compact while future days and today still reserve their full viewport space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change on past-day layout only; no data, routing, or save behavior.
> 
> **Overview**
> **Past days** in the daily stream use a smaller minimum editor height (`min-h-[100px]` instead of `min-h-[200px]`) on `NotePane`, so historical rows take less vertical space when scrolling.
> 
> **Today and future days** are unchanged and still use `min-h-[60vh]` for a full writing area.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8e28cd4d838627a37bcbcb265ffc85b056506ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->