### PR TITLE
padding top fix

### DIFF
--- a/apps/desktop/src/components/context-sidebar/daily-context-sidebar.tsx
+++ b/apps/desktop/src/components/context-sidebar/daily-context-sidebar.tsx
@@ -28,7 +28,7 @@ export function DailyContextSidebar({ date }: DailyContextSidebarProps): ReactEl
         'flex flex-col text-text',
         // The calendar's controls must clear the WindowDragRegion strip when
         // the macOS title bar is overlaid.
-        hasMacosTitleBarOverlay ? 'pt-7' : 'pt-2',
+        hasMacosTitleBarOverlay ? 'pt-0' : 'pt-2',
       )}
     >
       <DayCalendar selectedDate={date} today={today} />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single Tailwind class change for macOS overlay layout only; no logic or data paths affected.
> 
> **Overview**
> Fixes excess top spacing on the **daily note context sidebar** when the macOS overlaid title bar is active.
> 
> In `DailyContextSidebar`, the macOS branch changes from **`pt-7` to `pt-0`** so the calendar is not pushed down by an extra 28px; non-macOS overlay behavior stays **`pt-2`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10a19ccefc6c8ffe1086052dff32db76fb3ed567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->