### PR TITLE
Command palette: expand modal with a live note preview

### DIFF
--- a/apps/desktop/src/components/command-palette/command-palette.test.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.test.tsx
@@ -10,12 +10,21 @@ import { PaletteProvider, usePalette } from './palette-provider'
 const suggestWikiTargets = vi.hoisted(() => vi.fn())
 const searchWithFilters = vi.hoisted(() => vi.fn())
 const retrieve = vi.hoisted(() => vi.fn())
+const readNote = vi.hoisted(() => vi.fn<(path: string) => Promise<string>>())
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   hasBridge: () => true,
   suggestWikiTargets,
   searchWithFilters,
   retrieve,
+  readNote,
+}))
+// jsdom can't host the ProseMirror contenteditable (same stub as the
+// route-content tests); the preview's data path stays real.
+vi.mock('@/editor/markdown-preview', () => ({
+  MarkdownPreview: ({ content }: { content: string }) => (
+    <div data-testid="markdown-preview">{content}</div>
+  ),
 }))
 // The model is absent by default: the palette is exactly the lexical surface
 // it was before Plan 09 (hybrid mode is additive). The gating tests flip both
@@ -49,6 +58,7 @@ afterEach(cleanup)
 beforeEach(() => {
   embedReady.value = false
   semanticSetting.enabled = false
+  readNote.mockReset().mockResolvedValue('')
 })
 
 // cmdk scrolls the selected item into view and observes list size; jsdom has
@@ -181,7 +191,8 @@ describe('CommandPalette', () => {
     ])
     const { view, navigate } = renderPalette('#work is:daily')
     await view.findByText('Work log')
-    expect(view.getByText('Mon, June 8th, 2026')).toBeDefined() // dailies keep labels
+    // The label renders in the row (and again as the preview pane's header).
+    expect(view.getAllByText('Mon, June 8th, 2026').length).toBeGreaterThan(0)
     expect(searchWithFilters).toHaveBeenCalledWith(
       expect.objectContaining({
         filtered: true,
@@ -226,6 +237,63 @@ describe('CommandPalette', () => {
     expect(retrieve).toHaveBeenCalledWith('rust', { mode: 'hybrid' })
   })
 
+  it('previews the highlighted note and follows arrow-key selection', async () => {
+    suggestWikiTargets.mockResolvedValue([])
+    searchWithFilters.mockResolvedValue([
+      { path: 'notes/first.md', title: 'First', dailyDate: null, snippet: null },
+      { path: 'notes/second.md', title: 'Second', dailyDate: null, snippet: null },
+    ])
+    readNote.mockImplementation(async (path) =>
+      path === 'notes/first.md' ? '# First\n\nfirst body\n' : '# Second\n\nsecond body\n',
+    )
+    const { view } = renderPalette('note')
+    await view.findByText('First')
+
+    // cmdk highlights the top hit; its content renders in the preview pane.
+    const preview = await view.findByTestId('markdown-preview')
+    await waitFor(() => expect(preview.textContent).toContain('first body'))
+
+    await userEvent.keyboard('{ArrowDown}')
+    await waitFor(() =>
+      expect(view.getByTestId('markdown-preview').textContent).toContain('second body'),
+    )
+    expect(readNote).toHaveBeenCalledWith('notes/first.md')
+    expect(readNote).toHaveBeenCalledWith('notes/second.md')
+  })
+
+  it('frontmatter never reaches the preview', async () => {
+    suggestWikiTargets.mockResolvedValue([])
+    searchWithFilters.mockResolvedValue([
+      { path: 'notes/pinned.md', title: 'Pinned', dailyDate: null, snippet: null },
+    ])
+    readNote.mockResolvedValue('---\npinned: true\n---\n# Pinned\n\nbody\n')
+    const { view } = renderPalette('pinned')
+    const preview = await view.findByTestId('markdown-preview')
+    await waitFor(() => expect(preview.textContent).toContain('body'))
+    expect(preview.textContent).not.toContain('pinned: true')
+  })
+
+  it('a daily note without a file yet previews as Empty under its day label', async () => {
+    suggestWikiTargets.mockResolvedValue([
+      { target: '2026-06-16', path: null, title: '2026-06-16', alias: null, date: '2026-06-16' },
+    ])
+    searchWithFilters.mockResolvedValue([])
+    readNote.mockRejectedValue({ kind: 'notFound', message: 'no such note' })
+    const { view } = renderPalette('2026-06-16')
+    const preview = await view.findByTestId('palette-preview')
+    await waitFor(() => expect(preview.textContent).toContain('Empty'))
+    expect(preview.textContent).toContain('Tue, June 16th, 2026')
+  })
+
+  it('> command mode renders the single column without a preview pane', async () => {
+    suggestWikiTargets.mockResolvedValue([])
+    searchWithFilters.mockResolvedValue([])
+    const { view } = renderPalette('> toggle theme')
+    await view.findByText('Toggle theme')
+    expect(view.queryByTestId('palette-preview')).toBeNull()
+    expect(view.queryByText('No note selected')).toBeNull()
+  })
+
   it('a daily suggestion renders its day label and opens the daily route', async () => {
     suggestWikiTargets.mockResolvedValue([
       {
@@ -238,7 +306,8 @@ describe('CommandPalette', () => {
     ])
     searchWithFilters.mockResolvedValue([])
     const { view, navigate } = renderPalette('2026-06-09')
-    await view.findByText('Tue, June 9th, 2026')
+    // The label renders in the row (and again as the preview pane's header).
+    await view.findAllByText('Tue, June 9th, 2026')
 
     await userEvent.keyboard('{Enter}')
     await waitFor(() =>

--- a/apps/desktop/src/components/command-palette/command-palette.test.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.test.tsx
@@ -191,8 +191,8 @@ describe('CommandPalette', () => {
     ])
     const { view, navigate } = renderPalette('#work is:daily')
     await view.findByText('Work log')
-    // The label renders in the row (and again as the preview pane's header).
-    expect(view.getAllByText('Mon, June 8th, 2026').length).toBeGreaterThan(0)
+    // The label renders in the row and again as the preview pane's header.
+    await waitFor(() => expect(view.getAllByText('Mon, June 8th, 2026')).toHaveLength(2))
     expect(searchWithFilters).toHaveBeenCalledWith(
       expect.objectContaining({
         filtered: true,
@@ -285,6 +285,17 @@ describe('CommandPalette', () => {
     expect(preview.textContent).toContain('Tue, June 16th, 2026')
   })
 
+  it('a query matching only commands still highlights one, so Enter runs it', async () => {
+    suggestWikiTargets.mockResolvedValue([])
+    searchWithFilters.mockResolvedValue([])
+    const toggleTheme = vi.fn()
+    const { view } = renderPalette('toggle theme', { toggleTheme })
+    await view.findByText('Toggle theme')
+
+    await userEvent.keyboard('{Enter}')
+    await waitFor(() => expect(toggleTheme).toHaveBeenCalled())
+  })
+
   it('> command mode renders the single column without a preview pane', async () => {
     suggestWikiTargets.mockResolvedValue([])
     searchWithFilters.mockResolvedValue([])
@@ -306,8 +317,8 @@ describe('CommandPalette', () => {
     ])
     searchWithFilters.mockResolvedValue([])
     const { view, navigate } = renderPalette('2026-06-09')
-    // The label renders in the row (and again as the preview pane's header).
-    await view.findAllByText('Tue, June 9th, 2026')
+    // The label renders in the row and again as the preview pane's header.
+    await waitFor(() => expect(view.getAllByText('Tue, June 9th, 2026')).toHaveLength(2))
 
     await userEvent.keyboard('{Enter}')
     await waitFor(() =>

--- a/apps/desktop/src/components/command-palette/command-palette.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.tsx
@@ -63,18 +63,30 @@ export function CommandPalette({ context }: CommandPaletteProps): ReactElement |
   }, [open])
   // Each new result set highlights its top note. Without this, cmdk keeps any
   // still-valid selection — and commands match synchronously while notes load
-  // async, so the first command would stay highlighted over the top hit. Read
-  // the selection through a ref: this must re-run on new results, not on
-  // arrow-key moves within the same set.
+  // async, so the first command would stay highlighted over the top hit. Keyed
+  // on the list's *content*, not array identity, so a refetch or deferred-query
+  // settle that reproduces the same list never moves a selection the user made;
+  // the selection rides in a ref for the same reason. With no notes at all, a
+  // stale note selection clears so cmdk's first-item default can highlight a
+  // matching command (Enter must always have a target).
   const selectedValueRef = useRef(selectedValue)
   selectedValueRef.current = selectedValue
-  const notes = sections.notes
+  const notesRef = useRef(sections.notes)
+  notesRef.current = sections.notes
+  const notesKey = sections.notes.map((entry) => entry.path).join('\n')
   useEffect(() => {
-    const selectionInNotes = notes.some((entry) => entry.path === selectedValueRef.current)
-    if (open && notes.length > 0 && !selectionInNotes) {
-      setSelectedValue(notes[0].path)
+    if (!open) {
+      return
     }
-  }, [open, notes])
+    const notes = notesRef.current
+    if (notes.length > 0) {
+      if (!notes.some((entry) => entry.path === selectedValueRef.current)) {
+        setSelectedValue(notes[0].path)
+      }
+    } else if (!selectedValueRef.current.startsWith('command:')) {
+      setSelectedValue('')
+    }
+  }, [open, notesKey])
 
   if (!open) {
     return null

--- a/apps/desktop/src/components/command-palette/command-palette.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement } from 'react'
+import { useEffect, useRef, useState, type ReactElement } from 'react'
 import { Command } from 'cmdk'
 import { parseHighlights } from '@reflect/core'
 import { CalendarDays, FileText } from 'lucide-react'
@@ -7,10 +7,12 @@ import { ShortcutKeys } from '@/components/shortcut-keys'
 import { runCommand } from '@/lib/commands/registry'
 import type { CommandContext } from '@/lib/commands/types'
 import { formatDayLabel } from '@/lib/dates'
+import { cn } from '@/lib/utils'
 import { useSettings } from '@/providers/settings-provider'
 import { routeForPath } from '@/routing/route'
 import { commandIcon } from './command-icons'
 import { type NoteEntry } from './entries'
+import { NotePreview } from './note-preview'
 import { usePalette } from './palette-provider'
 import { usePaletteResults } from './use-palette-results'
 
@@ -19,6 +21,10 @@ import { usePaletteResults } from './use-palette-results'
  * cmdk owns traversal (↑/↓/Enter/Esc) and we own ranking (`shouldFilter`
  * off — the index already ordered everything). Empty query = recent notes
  * (the recall feed, decided); `>` filters to commands.
+ *
+ * Note modes render two panes — results beside a live preview of the
+ * highlighted note (cmdk's selection, mirrored via controlled `value`).
+ * Command mode (`>`) stays the original single narrow column.
  */
 
 interface CommandPaletteProps {
@@ -46,6 +52,29 @@ export function CommandPalette({ context }: CommandPaletteProps): ReactElement |
   const { open, query, setQuery, closePalette } = usePalette()
   const { settings } = useSettings()
   const { sections, resultsSettled, searchFailed } = usePaletteResults(open, query)
+  // cmdk's highlighted item, mirrored so the preview pane can follow it. Reset
+  // on close so a reopened palette highlights its first result, not the last
+  // session's pick.
+  const [selectedValue, setSelectedValue] = useState('')
+  useEffect(() => {
+    if (!open) {
+      setSelectedValue('')
+    }
+  }, [open])
+  // Each new result set highlights its top note. Without this, cmdk keeps any
+  // still-valid selection — and commands match synchronously while notes load
+  // async, so the first command would stay highlighted over the top hit. Read
+  // the selection through a ref: this must re-run on new results, not on
+  // arrow-key moves within the same set.
+  const selectedValueRef = useRef(selectedValue)
+  selectedValueRef.current = selectedValue
+  const notes = sections.notes
+  useEffect(() => {
+    const selectionInNotes = notes.some((entry) => entry.path === selectedValueRef.current)
+    if (open && notes.length > 0 && !selectionInNotes) {
+      setSelectedValue(notes[0].path)
+    }
+  }, [open, notes])
 
   if (!open) {
     return null
@@ -56,6 +85,14 @@ export function CommandPalette({ context }: CommandPaletteProps): ReactElement |
     context.navigate(routeForPath(entry.path))
   }
 
+  // Width follows the palette's *mode*, not the result count: note modes keep
+  // the preview pane (placeholder included) so the frame never jumps while
+  // results stream in; `>` command mode stays the narrow single column.
+  const splitLayout = !sections.commandsOnly
+  const selectedNote = splitLayout
+    ? (sections.notes.find((entry) => entry.path === selectedValue) ?? null)
+    : null
+
   return (
     // The overlay is ours (no portal): click-outside closes, Esc closes below.
     <div
@@ -64,7 +101,7 @@ export function CommandPalette({ context }: CommandPaletteProps): ReactElement |
       data-testid="palette-overlay"
     >
       <div
-        className="w-full max-w-xl"
+        className={cn('w-full', splitLayout ? 'max-w-4xl' : 'max-w-xl')}
         onPointerDown={(event) => {
           event.stopPropagation() // clicks inside must not close
         }}
@@ -72,6 +109,8 @@ export function CommandPalette({ context }: CommandPaletteProps): ReactElement |
         <Command
           label="Command palette"
           shouldFilter={false}
+          value={selectedValue}
+          onValueChange={setSelectedValue}
           onKeyDown={(event) => {
             if (event.key === 'Escape') {
               event.preventDefault()
@@ -87,78 +126,93 @@ export function CommandPalette({ context }: CommandPaletteProps): ReactElement |
             placeholder="Search notes, or > for commands…"
             className="reflect-palette-input"
           />
-          <Command.List className="reflect-palette-list">
-            {searchFailed ? (
-              <div role="alert" className="reflect-palette-empty">
-                Search unavailable — the index didn’t answer.
+          <div className={cn(splitLayout && 'flex h-[min(60vh,36rem)]')}>
+            <Command.List
+              className={cn('reflect-palette-list', splitLayout && 'reflect-palette-list-split')}
+            >
+              {searchFailed ? (
+                <div role="alert" className="reflect-palette-empty">
+                  Search unavailable — the index didn’t answer.
+                </div>
+              ) : null}
+              {resultsSettled && !searchFailed ? (
+                <Command.Empty className="reflect-palette-empty">No results</Command.Empty>
+              ) : null}
+              {sections.notes.length > 0 ? (
+                <Command.Group
+                  heading={query.trim() === '' ? 'Recent' : 'Notes'}
+                  className="reflect-palette-group"
+                >
+                  {sections.notes.map((entry) => {
+                    const Icon = entry.date !== null ? CalendarDays : FileText
+                    return (
+                      <Command.Item
+                        key={entry.path}
+                        value={entry.path}
+                        onSelect={() => openNote(entry)}
+                        className="reflect-palette-item"
+                      >
+                        <span className="flex items-center gap-2.5">
+                          <Icon
+                            aria-hidden
+                            strokeWidth={1.75}
+                            className="size-4 shrink-0 text-text-muted"
+                          />
+                          <span className="min-w-0 flex-1">
+                            <span className="block truncate text-sm">
+                              {entry.date !== null
+                                ? formatDayLabel(entry.date, settings.dateFormat)
+                                : entry.title}
+                            </span>
+                            {entry.snippet !== null ? <Snippet snippet={entry.snippet} /> : null}
+                          </span>
+                        </span>
+                      </Command.Item>
+                    )
+                  })}
+                </Command.Group>
+              ) : null}
+              {sections.commands.length > 0 ? (
+                <Command.Group heading="Commands" className="reflect-palette-group">
+                  {sections.commands.map((command) => {
+                    const Icon = commandIcon(command.id)
+                    return (
+                      <Command.Item
+                        key={command.id}
+                        value={`command:${command.id}`}
+                        onSelect={() => {
+                          closePalette()
+                          void runCommand(command.id, context)
+                        }}
+                        className="reflect-palette-item"
+                      >
+                        <span className="flex items-center gap-2.5">
+                          <Icon
+                            aria-hidden
+                            strokeWidth={1.75}
+                            className="size-4 shrink-0 text-text-muted"
+                          />
+                          <span className="min-w-0 flex-1 truncate text-sm">{command.title}</span>
+                          {command.keybinding ? <ShortcutKeys binding={command.keybinding} /> : null}
+                        </span>
+                      </Command.Item>
+                    )
+                  })}
+                </Command.Group>
+              ) : null}
+            </Command.List>
+            {splitLayout ? (
+              <div className="min-w-0 flex-1 overflow-y-auto border-l border-border">
+                {selectedNote !== null ? (
+                  <NotePreview key={selectedNote.path} entry={selectedNote} />
+                ) : (
+                  <div className="flex h-full items-center justify-center text-sm text-text-muted">
+                    No note selected
+                  </div>
+                )}
               </div>
             ) : null}
-            {resultsSettled && !searchFailed ? (
-              <Command.Empty className="reflect-palette-empty">No results</Command.Empty>
-            ) : null}
-            {sections.notes.length > 0 ? (
-              <Command.Group
-                heading={query.trim() === '' ? 'Recent' : 'Notes'}
-                className="reflect-palette-group"
-              >
-                {sections.notes.map((entry) => {
-                  const Icon = entry.date !== null ? CalendarDays : FileText
-                  return (
-                    <Command.Item
-                      key={entry.path}
-                      value={entry.path}
-                      onSelect={() => openNote(entry)}
-                      className="reflect-palette-item"
-                    >
-                      <span className="flex items-center gap-2.5">
-                        <Icon
-                          aria-hidden
-                          strokeWidth={1.75}
-                          className="size-4 shrink-0 text-text-muted"
-                        />
-                        <span className="min-w-0 flex-1">
-                          <span className="block truncate text-sm">
-                            {entry.date !== null
-                              ? formatDayLabel(entry.date, settings.dateFormat)
-                              : entry.title}
-                          </span>
-                          {entry.snippet !== null ? <Snippet snippet={entry.snippet} /> : null}
-                        </span>
-                      </span>
-                    </Command.Item>
-                  )
-                })}
-              </Command.Group>
-            ) : null}
-            {sections.commands.length > 0 ? (
-              <Command.Group heading="Commands" className="reflect-palette-group">
-                {sections.commands.map((command) => {
-                  const Icon = commandIcon(command.id)
-                  return (
-                    <Command.Item
-                      key={command.id}
-                      value={`command:${command.id}`}
-                      onSelect={() => {
-                        closePalette()
-                        void runCommand(command.id, context)
-                      }}
-                      className="reflect-palette-item"
-                    >
-                      <span className="flex items-center gap-2.5">
-                        <Icon
-                          aria-hidden
-                          strokeWidth={1.75}
-                          className="size-4 shrink-0 text-text-muted"
-                        />
-                        <span className="min-w-0 flex-1 truncate text-sm">{command.title}</span>
-                        {command.keybinding ? <ShortcutKeys binding={command.keybinding} /> : null}
-                      </span>
-                    </Command.Item>
-                  )
-                })}
-              </Command.Group>
-            ) : null}
-          </Command.List>
+          </div>
           <div
             aria-hidden
             className="flex items-center gap-4 border-t border-border px-3.5 py-2 text-[11px] text-text-muted"

--- a/apps/desktop/src/components/command-palette/note-preview.tsx
+++ b/apps/desktop/src/components/command-palette/note-preview.tsx
@@ -41,9 +41,21 @@ export function NotePreview({ entry }: NotePreviewProps): ReactElement {
   const { data, isError } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'note-preview', entry.path],
     queryFn: () => readNoteForPreview(entry.path),
+    enabled: graph !== null,
   })
 
   const body = data === null || data === undefined ? null : splitFrontmatter(data).body
+
+  let content: ReactElement | null
+  if (isError) {
+    content = <p className="text-sm text-text-muted">This note can’t be previewed.</p>
+  } else if (data === undefined) {
+    content = null // still loading; blank beats a flash of the wrong state
+  } else if (body === null || body.trim() === '') {
+    content = <p className="text-sm text-text-muted italic">Empty</p>
+  } else {
+    content = <MarkdownPreview content={body} resolveImageUrl={images.resolveUrl} />
+  }
 
   return (
     <div data-testid="palette-preview" className="h-full px-5 py-4">
@@ -52,13 +64,7 @@ export function NotePreview({ entry }: NotePreviewProps): ReactElement {
           {formatDayLabel(entry.date, settings.dateFormat)}
         </h2>
       ) : null}
-      {isError ? (
-        <p className="text-sm text-text-muted">This note can’t be previewed.</p>
-      ) : data === undefined ? null : body === null || body.trim() === '' ? (
-        <p className="text-sm text-text-muted italic">Empty</p>
-      ) : (
-        <MarkdownPreview content={body} resolveImageUrl={images.resolveUrl} />
-      )}
+      {content}
     </div>
   )
 }

--- a/apps/desktop/src/components/command-palette/note-preview.tsx
+++ b/apps/desktop/src/components/command-palette/note-preview.tsx
@@ -1,0 +1,64 @@
+import { type ReactElement } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { isAppError, readNote, splitFrontmatter } from '@reflect/core'
+import { MarkdownPreview } from '@/editor/markdown-preview'
+import { useImagePersistence } from '@/editor/use-image-persistence'
+import { formatDayLabel } from '@/lib/dates'
+import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
+import { useGraph } from '@/providers/graph-provider'
+import { useSettings } from '@/providers/settings-provider'
+import type { NoteEntry } from './entries'
+
+/**
+ * The palette's live preview pane: the highlighted result's markdown, read
+ * straight from disk and rendered read-only. Keyed under the index scope so an
+ * edit that re-indexes while the palette is open refreshes the preview too.
+ *
+ * A missing file is not an error here — daily suggestions are valid jump
+ * targets before their file exists (the lazy contract) — it previews as Empty.
+ */
+
+interface NotePreviewProps {
+  /** The highlighted palette entry to preview. */
+  entry: NoteEntry
+}
+
+async function readNoteForPreview(path: string): Promise<string | null> {
+  try {
+    return await readNote(path)
+  } catch (cause) {
+    if (isAppError(cause) && cause.kind === 'notFound') {
+      return null
+    }
+    throw cause
+  }
+}
+
+export function NotePreview({ entry }: NotePreviewProps): ReactElement {
+  const { graph } = useGraph()
+  const { settings } = useSettings()
+  const { options: images } = useImagePersistence(graph?.root ?? null, graph?.generation ?? null)
+  const { data, isError } = useQuery({
+    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'note-preview', entry.path],
+    queryFn: () => readNoteForPreview(entry.path),
+  })
+
+  const body = data === null || data === undefined ? null : splitFrontmatter(data).body
+
+  return (
+    <div data-testid="palette-preview" className="h-full px-5 py-4">
+      {entry.date !== null ? (
+        <h2 className="mb-3 text-lg font-semibold">
+          {formatDayLabel(entry.date, settings.dateFormat)}
+        </h2>
+      ) : null}
+      {isError ? (
+        <p className="text-sm text-text-muted">This note can’t be previewed.</p>
+      ) : data === undefined ? null : body === null || body.trim() === '' ? (
+        <p className="text-sm text-text-muted italic">Empty</p>
+      ) : (
+        <MarkdownPreview content={body} resolveImageUrl={images.resolveUrl} />
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/editor/markdown-preview.tsx
+++ b/apps/desktop/src/editor/markdown-preview.tsx
@@ -1,0 +1,73 @@
+import { useLayoutEffect, useRef, useState, type ReactElement } from 'react'
+import {
+  defineEditorExtension,
+  defineMarkMode,
+  markdownToDoc,
+  type TypedEditor,
+} from '@meowdown/core'
+import { createEditor, definePlugin, union, type Editor, type PlainExtension } from '@prosekit/core'
+import { Plugin } from '@prosekit/pm/state'
+import { ProseKit } from '@prosekit/react'
+import '@meowdown/core/style.css'
+import { cn } from '@/lib/utils'
+import { defineImages } from './images'
+import { defineWikiLinks } from './wiki-links'
+
+/**
+ * A read-only rendering of note markdown, built from the same meowdown
+ * extension set as {@link NoteEditor} so previews look exactly like the note
+ * would in the editor — wiki-link chips, images, and headings included. Syntax
+ * marks are hidden (`hide` mark mode) and the view never becomes editable, so
+ * this can render any note (protected ones included) without ever writing.
+ *
+ * Unlike the uncontrolled editor, `content` is **live**: the document is
+ * replaced whenever it changes, so one mounted preview can follow a moving
+ * selection (the ⌘K palette's preview pane).
+ */
+
+interface MarkdownPreviewProps {
+  /** The markdown body to render (callers strip frontmatter first). */
+  content: string
+  /** Resolve `![…](…)` sources to displayable URLs; unresolved images are skipped. */
+  resolveImageUrl?: (src: string) => string | null
+  /** Extra classes for the rendered root. */
+  className?: string
+}
+
+function defineReadOnly(): PlainExtension {
+  return definePlugin(new Plugin({ props: { editable: () => false } }))
+}
+
+function createPreviewEditor(resolveUrl: (src: string) => string | null): Editor {
+  return createEditor({
+    extension: union(
+      defineEditorExtension(),
+      defineMarkMode('hide'),
+      defineWikiLinks(),
+      defineImages({ resolveUrl }),
+      defineReadOnly(),
+    ),
+  })
+}
+
+export function MarkdownPreview({
+  content,
+  resolveImageUrl,
+  className,
+}: MarkdownPreviewProps): ReactElement {
+  // The extension set is created once; the resolver is read through a ref so
+  // a changing prop never rebuilds the editor.
+  const resolveRef = useRef<((src: string) => string | null) | undefined>(resolveImageUrl)
+  resolveRef.current = resolveImageUrl
+  const [editor] = useState(() => createPreviewEditor((src) => resolveRef.current?.(src) ?? null))
+
+  useLayoutEffect(() => {
+    editor.setContent(markdownToDoc(editor as TypedEditor, content))
+  }, [editor, content])
+
+  return (
+    <ProseKit editor={editor}>
+      <div ref={editor.mount} className={cn('reflect-editor', className)} />
+    </ProseKit>
+  )
+}

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -362,6 +362,14 @@ body,
   overflow-y: auto;
   padding: 0.375rem;
 }
+/* Note modes pair the list with a live preview: the flex row owns the height,
+   the list becomes a fixed-width column inside it. */
+.reflect-palette-list-split {
+  max-height: none;
+  height: 100%;
+  width: 40%;
+  flex-shrink: 0;
+}
 .reflect-palette-group [cmdk-group-heading] {
   padding: 0.375rem 0.625rem 0.125rem;
   font-size: 0.6875rem;


### PR DESCRIPTION
## Summary

The ⌘K palette's note modes now render two panes — the results list beside a live, read-only preview of the highlighted note — restoring the old app's search experience. Command mode (`>`) keeps the original narrow single column.

- **Layout**: note modes widen the modal (`max-w-xl` → `max-w-4xl`) with a fixed-height body (`min(60vh, 36rem)`); the list becomes a 40% column and the preview fills the rest. Width follows the palette's *mode*, not the result count, so the frame never jumps while results stream in.
- **Live preview** (`note-preview.tsx`): cmdk's highlighted item is mirrored via controlled `value`, so arrowing through results updates the pane instantly. Content loads via `readNote` under the index query scope — an edit that re-indexes while the palette is open refreshes the preview. Frontmatter is stripped; daily notes get their day label as a header; a daily whose file doesn't exist yet previews as *Empty* (the lazy contract).
- **Rendering** (`markdown-preview.tsx`): a reusable read-only renderer built from the same meowdown/ProseKit extension set as the editor — wiki-link chips, images, hidden syntax marks — so previews look exactly like the note would, and can never write back (safe for protected notes).
- **Selection fix this surfaced**: commands match synchronously while notes load async, so cmdk would keep the first command highlighted over the top note hit. Each new result set now snaps the highlight to its top note; arrow-key moves within a settled set are untouched.

## Test plan

- 4 new palette tests: preview follows arrow-key selection, frontmatter never reaches the preview, missing daily previews as *Empty* under its day label, `>` mode renders no preview pane.
- Per project convention the ProseMirror contenteditable is stubbed in jsdom; the rendered editor is worth a manual look in `pnpm tauri dev` (open ⌘K, arrow through results).
- `pnpm check` and the palette/editor/settings/route-content suites pass (185 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-focused palette and read-only preview paths; no auth or persistence changes beyond existing `readNote` usage, with solid test coverage.
> 
> **Overview**
> The ⌘K palette’s **note search modes** now use a **two-pane layout**: results on the left and a **live preview** of the highlighted note on the right. The modal widens (`max-w-4xl`) with a fixed-height body; **`>` command mode** stays the narrow single column with no preview.
> 
> **`command-palette.tsx`** mirrors cmdk selection via controlled `value` so the preview follows arrow keys, resets on close, and **snaps to the top note** when the result list changes (so async note hits beat synchronously matched commands for Enter). **`note-preview.tsx`** loads markdown with `readNote` under the index query scope, strips frontmatter, shows day labels for dailies, and treats missing files as *Empty*.
> 
> **`markdown-preview.tsx`** adds a reusable read-only meowdown/ProseKit renderer (same extensions as the editor, non-editable) with live content updates for palette navigation.
> 
> Palette tests cover preview selection, frontmatter stripping, empty dailies, command-only layout, and command-only Enter behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84f02d8d81065fb479473b922c4151310fcf0a9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Side-by-side preview pane in the command palette showing selected note content.
  * Preview updates live as you navigate results; empty daily notes show as “Empty”.
  * Command-only mode keeps a single-column layout without a preview; commands remain selectable.

* **Bug Fixes**
  * Preview excludes markdown frontmatter and shows a muted message when content is missing.

* **Tests**
  * Added/extended tests covering preview behavior, keyboard navigation, and command-mode UI.

* **Style**
  * Layout styles added to support the split list/preview view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->