### PR TITLE
Match All Notes view to V1's layout and styling

### DIFF
--- a/apps/desktop/src/components/all-notes/all-notes-row.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-row.tsx
@@ -9,7 +9,7 @@ import { useSettings } from '@/providers/settings-provider'
  * row in {@link AllNotesTable} uses the same classes so the columns line up.
  */
 export const ALL_NOTES_GRID =
-  'grid grid-cols-[minmax(0,1.3fr)_minmax(0,2fr)_minmax(0,8rem)_5rem] items-center gap-4'
+  'grid grid-cols-[15rem_minmax(0,1fr)_minmax(0,8rem)_5rem] items-center gap-4 pl-12 pr-7'
 
 interface AllNotesRowProps {
   note: NoteListEntry
@@ -25,15 +25,15 @@ export function AllNotesRow({ note, onOpen }: AllNotesRowProps): ReactElement {
       onClick={() => onOpen(note.path)}
       className={cn(
         ALL_NOTES_GRID,
-        'w-full px-3 py-3 text-left transition-colors duration-100 hover:bg-surface-hover',
+        'h-12 w-full text-left transition-colors duration-100 hover:bg-surface-hover',
       )}
     >
-      <span className="truncate text-sm font-medium text-text">{note.title}</span>
-      <span className="truncate text-[13px] text-text-muted">{note.snippet}</span>
-      <span className="truncate text-[13px] text-text-muted">
+      <span className="truncate text-[13px] font-medium text-text">{note.title}</span>
+      <span className="truncate text-[13px] text-text-secondary">{note.snippet}</span>
+      <span className="truncate text-right text-[13px] text-text-secondary">
         {note.tags.map((tag) => `#${tag}`).join(' ')}
       </span>
-      <span className="text-right text-[13px] tabular-nums text-text-muted">
+      <span className="text-right text-[13px] tabular-nums text-text-secondary">
         {formatRecencyLabel(note.mtime, settings)}
       </span>
     </button>

--- a/apps/desktop/src/components/all-notes/all-notes-row.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-row.tsx
@@ -9,7 +9,7 @@ import { useSettings } from '@/providers/settings-provider'
  * row in {@link AllNotesTable} uses the same classes so the columns line up.
  */
 export const ALL_NOTES_GRID =
-  'grid grid-cols-[15rem_minmax(0,1fr)_minmax(0,8rem)_5rem] items-center gap-4 pl-12 pr-7'
+  'grid grid-cols-[15rem_minmax(0,1fr)_minmax(0,8rem)_5rem] items-center gap-4 pl-4 pr-7 lg:pl-12'
 
 interface AllNotesRowProps {
   note: NoteListEntry

--- a/apps/desktop/src/components/all-notes/all-notes-screen.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.tsx
@@ -57,33 +57,29 @@ export function AllNotesScreen({ tag }: AllNotesScreenProps): ReactElement {
 
   return (
     <div aria-label="All notes" className="flex h-full min-h-0 flex-col">
-      <header className="px-6 pb-4 pt-8">
-        <div className="mx-auto flex w-full max-w-5xl flex-wrap items-center justify-between gap-3">
-          <h1 className="text-lg font-semibold text-text">Notes</h1>
-          <div className="flex flex-wrap items-center gap-3">
-            <AllNotesFilters
-              tag={tag}
-              facets={facets ?? []}
-              onSelect={(next) => navigate({ kind: 'allNotes', tag: next })}
-            />
-            <NewNoteButton />
-          </div>
+      <header className="flex flex-none flex-wrap items-center justify-between gap-3 border-b border-border py-4 pl-4 pr-7 lg:pl-12">
+        <h1 className="text-[15px] font-semibold text-text">Notes</h1>
+        <div className="flex flex-wrap items-center gap-3">
+          <AllNotesFilters
+            tag={tag}
+            facets={facets ?? []}
+            onSelect={(next) => navigate({ kind: 'allNotes', tag: next })}
+          />
+          <NewNoteButton />
         </div>
       </header>
       <div
         ref={scrollRef}
         data-testid="all-notes-scroll"
         onScroll={(event) => saveScrollState(event.currentTarget.scrollTop)}
-        className="min-h-0 flex-1 overflow-auto px-6 pb-8"
+        className="min-h-0 flex-1 overflow-auto"
       >
-        <div className="mx-auto w-full max-w-5xl">
-          <AllNotesTable
-            notes={notes}
-            tag={tag}
-            onOpen={(path) => navigate(routeForPath(path))}
-            scrollRef={scrollRef}
-          />
-        </div>
+        <AllNotesTable
+          notes={notes}
+          tag={tag}
+          onOpen={(path) => navigate(routeForPath(path))}
+          scrollRef={scrollRef}
+        />
       </div>
     </div>
   )

--- a/apps/desktop/src/components/all-notes/all-notes-table.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-table.tsx
@@ -14,7 +14,7 @@ interface AllNotesTableProps {
   scrollRef: RefObject<HTMLDivElement | null>
 }
 
-const ESTIMATED_ROW_HEIGHT = 46
+const ESTIMATED_ROW_HEIGHT = 49
 
 /**
  * The All Notes table: a sticky header row over virtualized note rows. The
@@ -44,16 +44,16 @@ export function AllNotesTable({
       <div
         className={cn(
           ALL_NOTES_GRID,
-          'sticky top-0 z-10 border-b border-border bg-surface px-3 pb-2 text-xs font-medium text-text-muted',
+          'sticky top-0 z-10 border-b border-border bg-surface py-3 text-[13px] font-medium leading-none text-text-secondary shadow-sm',
         )}
       >
         <span>Subject</span>
         <span>Snippet</span>
-        <span>Tags</span>
+        <span className="text-right">Tags</span>
         <span className="text-right">Updated</span>
       </div>
       {notes.length === 0 ? (
-        <p className="px-3 py-8 text-sm text-text-muted">
+        <p className="py-8 pl-12 pr-7 text-sm text-text-muted">
           {tag === null ? 'No notes yet.' : `No notes tagged #${tag}.`}
         </p>
       ) : (

--- a/apps/desktop/src/components/all-notes/all-notes-table.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-table.tsx
@@ -53,7 +53,7 @@ export function AllNotesTable({
         <span className="text-right">Updated</span>
       </div>
       {notes.length === 0 ? (
-        <p className="py-8 pl-12 pr-7 text-sm text-text-muted">
+        <p className="py-8 pl-4 pr-7 text-sm text-text-muted lg:pl-12">
           {tag === null ? 'No notes yet.' : `No notes tagged #${tag}.`}
         </p>
       ) : (


### PR DESCRIPTION
## What changed

Copies the V1 notes-list styling across to the V2 All Notes view:

- **Full-width table, no section padding** — removed the `max-w-5xl mx-auto` centering wrappers and `px-6` section padding. Horizontal inset now comes from V1's row gutters (`pl-12 pr-7`), carried on the shared `ALL_NOTES_GRID` constant so the header row, note rows, and empty state all stay aligned.
- **Page header** — now V1's bordered bar (`border-b py-4 pl-4 pr-7 lg:pl-12`) with the "Notes" title at 15px semibold (V1's `text-2sm`), lining up with the Subject column.
- **Table header** — V1's treatment: `py-3`, 13px medium with `leading-none`, secondary text color, bottom border plus `shadow-sm` (the DS token matches V1's inline `0 1px 2px rgba(0,0,0,.05)`), and the Tags column right-aligned like Updated.
- **Rows** — V1 column metrics: fixed 240px Subject (V1 `w-60`), flexible Snippet, right-aligned Tags, 80px Updated (V1 `w-20`), fixed 48px row height (V1 `h-12`), all text at 13px. Virtualizer row estimate bumped to 49px (48px row + 1px divider).

## Why

The V2 view was centered with generous padding and its own column proportions; this brings it in line with V1's visual design (follow-up to #66, which restyled the rest of the app — the filter tabs and New note button were already covered there).

## Notes for reviewers

Colors follow the design-system token rule rather than V1's literal palette — they map exactly anyway (`coolgray-500` → `text-text-secondary`, `coolgray-800` → `text-text`, `coolgray-100` → `border-border`), so dark mode keeps working untouched.

Verified with `pnpm check` and `pnpm test --run src/components/all-notes` (8/8 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS and layout changes in the all-notes components; no data, routing, or virtualization behavior changes.
> 
> **Overview**
> Aligns the V2 **All Notes** screen with V1’s full-width list layout and typography.
> 
> **Layout:** Drops `max-w-5xl` centering and outer `px-6` padding so the table spans the view. Horizontal inset moves onto shared `ALL_NOTES_GRID` (`pl-4 pr-7 lg:pl-12`) so header, rows, and empty state stay aligned. The page header becomes a bordered bar with V1-style gutters; the scroll area no longer adds section padding.
> 
> **Grid & rows:** Column template switches to fixed **15rem** Subject, flexible Snippet, **8rem** Tags, **5rem** Updated, with **48px** (`h-12`) rows and **13px** text; snippet/tags/updated use `text-text-secondary`, tags right-aligned. Virtualizer estimate goes **46 → 49px**.
> 
> **Table chrome:** Sticky header gets `py-3`, 13px medium `leading-none`, `shadow-sm`, and right-aligned Tags label; empty-state padding matches the new gutters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2125b56991421b78546b2afa0f383679e6693bc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the all notes list layout with improved column sizing and grid spacing.
  * Updated text sizing and color styling throughout the notes list for better visual consistency.
  * Enhanced header styling with fixed positioning, borders, and improved visual hierarchy.
  * Adjusted vertical spacing, padding, and text alignment across the notes list view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->