### PR TITLE
Add a Mark as private action to the note action sidebar

### DIFF
--- a/apps/desktop/src/components/context-sidebar/note-actions-section.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-actions-section.test.tsx
@@ -5,7 +5,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NoteActionsSection } from './note-actions-section'
 
 const getPinnedNotes = vi.hoisted(() => vi.fn())
+const getNote = vi.hoisted(() => vi.fn())
 const toggleNotePinned = vi.hoisted(() => vi.fn(async () => true))
+const toggleNotePrivate = vi.hoisted(() => vi.fn(async () => true))
 const operationFail = vi.hoisted(() => vi.fn())
 const startOperation = vi.hoisted(() =>
   vi.fn(() => ({ progress: vi.fn(), done: vi.fn(), fail: operationFail })),
@@ -14,8 +16,10 @@ vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   hasBridge: () => true,
   getPinnedNotes,
+  getNote,
 }))
 vi.mock('@/lib/note-pin', () => ({ toggleNotePinned }))
+vi.mock('@/lib/note-private', () => ({ toggleNotePrivate }))
 vi.mock('@/lib/operations', () => ({ startOperation }))
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({ graph: { root: '/g', name: 'g', cloudSync: false, generation: 7 } }),
@@ -33,10 +37,16 @@ function renderSection(path: string) {
 beforeEach(() => {
   window.sessionStorage.clear()
   getPinnedNotes.mockReset().mockResolvedValue([])
+  getNote.mockReset().mockResolvedValue(undefined)
   toggleNotePinned.mockReset().mockResolvedValue(true)
+  toggleNotePrivate.mockReset().mockResolvedValue(true)
   startOperation.mockClear()
   operationFail.mockClear()
 })
+
+function noteRow(path: string, isPrivate: boolean) {
+  return { path, title: 'A', dailyDate: null, isPrivate }
+}
 
 describe('NoteActionsSection pin toggle', () => {
   it('offers Pin this note with the platform-formatted hint and toggles on click', async () => {
@@ -95,6 +105,63 @@ describe('NoteActionsSection pin toggle', () => {
     const view = renderSection('notes/a.md')
     await userEvent.click(await view.findByRole('button', { name: /Un-pin this note/ }))
     expect(startOperation).toHaveBeenCalledWith('Unpinning note')
+    expect(operationFail).toHaveBeenCalled()
+    view.unmount()
+  })
+})
+
+describe('NoteActionsSection private toggle', () => {
+  it('offers Mark this note as private and toggles on click', async () => {
+    const view = renderSection('notes/a.md')
+    await userEvent.click(view.getByRole('button', { name: /Mark this note as private/ }))
+    expect(toggleNotePrivate).toHaveBeenCalledWith('notes/a.md', 7)
+    view.unmount()
+  })
+
+  it('offers Un-mark this note as private when the index reports the note private', async () => {
+    getNote.mockResolvedValue(noteRow('daily/2026-06-10.md', true))
+    const view = renderSection('daily/2026-06-10.md')
+    await view.findByText('Un-mark this note as private')
+    await userEvent.click(view.getByRole('button', { name: /Un-mark this note as private/ }))
+    expect(toggleNotePrivate).toHaveBeenCalledWith('daily/2026-06-10.md', 7)
+    view.unmount()
+  })
+
+  it('flips the label from the toggle result before the index catches up', async () => {
+    const view = renderSection('notes/a.md')
+    await userEvent.click(view.getByRole('button', { name: /Mark this note as private/ }))
+    expect(await view.findByText('Un-mark this note as private')).toBeDefined()
+    toggleNotePrivate.mockResolvedValueOnce(false)
+    await userEvent.click(view.getByRole('button', { name: /Un-mark this note as private/ }))
+    expect(await view.findByText('Mark this note as private')).toBeDefined()
+    expect(toggleNotePrivate).toHaveBeenCalledTimes(2)
+    view.unmount()
+  })
+
+  it('stays on Mark this note as private for a note the index reports as not private', async () => {
+    getNote.mockResolvedValue(noteRow('notes/a.md', false))
+    const view = renderSection('notes/a.md')
+    await waitFor(() => expect(getNote).toHaveBeenCalled())
+    expect(view.getByText('Mark this note as private')).toBeDefined()
+    expect(view.queryByText('Un-mark this note as private')).toBeNull()
+    view.unmount()
+  })
+
+  it('surfaces a toggle failure through the operations status', async () => {
+    toggleNotePrivate.mockRejectedValueOnce({ kind: 'io', message: 'disk on fire' })
+    const view = renderSection('notes/a.md')
+    await userEvent.click(view.getByRole('button', { name: /Mark this note as private/ }))
+    expect(startOperation).toHaveBeenCalledWith('Marking note as private')
+    expect(operationFail).toHaveBeenCalled()
+    view.unmount()
+  })
+
+  it('labels a failed un-mark as un-marking', async () => {
+    getNote.mockResolvedValue(noteRow('notes/a.md', true))
+    toggleNotePrivate.mockRejectedValueOnce({ kind: 'io', message: 'disk on fire' })
+    const view = renderSection('notes/a.md')
+    await userEvent.click(await view.findByRole('button', { name: /Un-mark this note as private/ }))
+    expect(startOperation).toHaveBeenCalledWith('Un-marking note as private')
     expect(operationFail).toHaveBeenCalled()
     view.unmount()
   })

--- a/apps/desktop/src/components/context-sidebar/note-actions-section.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-actions-section.tsx
@@ -1,13 +1,12 @@
-import { useState, type ReactElement } from 'react'
-import { errorMessage } from '@reflect/core'
+import type { ReactElement } from 'react'
+import { Lock } from 'lucide-react'
 import { PinIcon } from '@/components/icons/pin-icon'
-import { ShortcutKeys } from '@/components/shortcut-keys'
+import { useNoteRow } from '@/hooks/use-note-row'
 import { usePinnedNotes } from '@/hooks/use-pinned-notes'
 import { keybindingFor } from '@/lib/commands/app-commands'
 import { toggleNotePinned } from '@/lib/note-pin'
-import { startOperation } from '@/lib/operations'
-import { cn } from '@/lib/utils'
-import { useGraph } from '@/providers/graph-provider'
+import { toggleNotePrivate } from '@/lib/note-private'
+import { NoteToggleAction } from './note-toggle-action'
 import { SidebarSection } from './sidebar-section'
 
 interface NoteActionsSectionProps {
@@ -15,88 +14,50 @@ interface NoteActionsSectionProps {
   path: string
 }
 
-// Derived from the `note.togglePin` command definition so the hint can never
-// drift from the real binding (the same contract as the Today hint).
+// Derived from the command definitions so the hints can never drift from the
+// real bindings (the same contract as the Today hint).
 const PIN_KEYBINDING = keybindingFor('note.togglePin')
-
-/**
- * The toggle's resolved state, held until the index reflects it. The pinned
- * label otherwise lags one watcher round-trip behind the write, and in that
- * window a stale "Pin this note" click would silently unpin (and vice versa). The
- * toggle reads the note itself, so its return value is the freshest truth;
- * the bridge retires the moment the index agrees or the section moves to
- * another note.
- */
-interface PendingPin {
-  path: string
-  pinned: boolean
-}
+const PRIVATE_KEYBINDING = keybindingFor('note.togglePrivate')
 
 /**
  * "Note actions" as a context-sidebar section: mouse-reachable counterparts
- * to the note-scoped commands, starting with pin/unpin. Shared by the daily
- * and note context sidebars — dailies are valid pin targets too. The button
- * reflects the index's pinned state (the same query as the sidebar's Pinned
- * section), bridged by the last toggle's result while the watcher catches
- * up; failures surface through the operations status line, like the ⌘O
- * command.
+ * to the note-scoped commands — pin/unpin and the `private` flag. Shared by
+ * the daily and note context sidebars; dailies are valid targets for both.
+ * Each action reflects the index's state (the pin from the same query as the
+ * sidebar's Pinned section, privacy from the note's own row), bridged by the
+ * last toggle's result while the watcher catches up.
  */
 export function NoteActionsSection({ path }: NoteActionsSectionProps): ReactElement {
-  const { graph } = useGraph()
-  const indexPinned = usePinnedNotes().some((note) => note.path === path)
-  // Guards against a double-click racing two read-patch-write toggles.
-  const [isToggling, setIsToggling] = useState(false)
-  const [pending, setPending] = useState<PendingPin | null>(null)
-
-  // Render-time state adjustment (the React-sanctioned pattern): drop the
-  // bridge once the index agrees with it, so a later external pin change
-  // can't resurrect a stale override.
-  if (pending !== null && (pending.path !== path || pending.pinned === indexPinned)) {
-    setPending(null)
-  }
-  const isPinned = pending !== null && pending.path === path ? pending.pinned : indexPinned
-
-  const togglePin = async (): Promise<void> => {
-    const generation = graph?.generation
-    if (generation === undefined) {
-      return
-    }
-    setIsToggling(true)
-    try {
-      setPending({ path, pinned: await toggleNotePinned(path, generation) })
-    } catch (cause) {
-      startOperation(isPinned ? 'Unpinning note' : 'Pinning note').fail(errorMessage(cause))
-    } finally {
-      setIsToggling(false)
-    }
-  }
+  const isPinned = usePinnedNotes().some((note) => note.path === path)
+  const isPrivate = useNoteRow(path)?.isPrivate ?? false
 
   return (
     <SidebarSection storageKey="note-actions" title="Note actions">
-      <button
-        type="button"
-        onClick={() => void togglePin()}
-        disabled={isToggling}
-        className="group relative flex w-full items-center space-x-2 rounded-lg px-3 py-2 text-start transition-colors duration-100 hover:bg-surface-hover disabled:opacity-50"
-      >
-        <span
-          className={cn(
-            'flex h-5 w-5 flex-none items-center justify-center transition-colors duration-100',
-            isPinned ? 'text-accent' : 'text-text-muted group-hover:text-text',
-          )}
-        >
-          <PinIcon width={20} height={20} />
-        </span>
-        <span className="min-w-0 flex-1 truncate text-xs font-medium">
-          {isPinned ? 'Un-pin this note' : 'Pin this note'}
-        </span>
-        {PIN_KEYBINDING !== null ? (
-          <ShortcutKeys
-            binding={PIN_KEYBINDING}
-            className="invisible group-hover:visible"
-          />
-        ) : null}
-      </button>
+      <NoteToggleAction
+        path={path}
+        indexActive={isPinned}
+        toggle={toggleNotePinned}
+        icon={<PinIcon width={20} height={20} />}
+        labels={{ active: 'Un-pin this note', inactive: 'Pin this note' }}
+        operations={{ activate: 'Pinning note', deactivate: 'Unpinning note' }}
+        keybinding={PIN_KEYBINDING}
+      />
+      <NoteToggleAction
+        path={path}
+        indexActive={isPrivate}
+        toggle={toggleNotePrivate}
+        icon={<Lock size={18} aria-hidden />}
+        labels={{
+          active: 'Un-mark this note as private',
+          inactive: 'Mark this note as private',
+        }}
+        operations={{
+          activate: 'Marking note as private',
+          deactivate: 'Un-marking note as private',
+        }}
+        keybinding={PRIVATE_KEYBINDING}
+        tooltip="Private notes are never sent to AI or any other external service"
+      />
     </SidebarSection>
   )
 }

--- a/apps/desktop/src/components/context-sidebar/note-toggle-action.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-toggle-action.tsx
@@ -1,0 +1,109 @@
+import { useState, type ReactElement, type ReactNode } from 'react'
+import { errorMessage } from '@reflect/core'
+import { ShortcutKeys } from '@/components/shortcut-keys'
+import { startOperation } from '@/lib/operations'
+import { cn } from '@/lib/utils'
+import { useGraph } from '@/providers/graph-provider'
+
+interface NoteToggleActionProps {
+  /** Graph-relative path of the note the action operates on. */
+  path: string
+  /** The flag's state per the index (lags a write by one watcher round-trip). */
+  indexActive: boolean
+  /** Flip the flag in the note's frontmatter; resolves to the new state. */
+  toggle: (path: string, generation: number) => Promise<boolean>
+  /** Icon left of the label; accent-tinted while the flag is on. */
+  icon: ReactNode
+  /** Button label for each flag state (the action offered, not the state). */
+  labels: { active: string; inactive: string }
+  /** Operation names for failure surfacing, per toggle direction. */
+  operations: { activate: string; deactivate: string }
+  /** Keybinding hint, from the matching command definition. */
+  keybinding?: string | null
+  /** Optional native tooltip explaining the flag's meaning. */
+  tooltip?: string
+}
+
+/**
+ * The toggle's resolved state, held until the index reflects it. The label
+ * otherwise lags one watcher round-trip behind the write, and in that window
+ * a stale click would silently undo the user's toggle. The toggle reads the
+ * note itself, so its return value is the freshest truth; the bridge retires
+ * the moment the index agrees or the action moves to another note.
+ */
+interface PendingToggle {
+  path: string
+  active: boolean
+}
+
+/**
+ * One note-scoped frontmatter-flag toggle as an action-sidebar button — the
+ * shared shape behind pin/unpin and private/un-private. The button reflects
+ * the index's state, bridged by the last toggle's result while the watcher
+ * catches up; failures surface through the operations status line.
+ */
+export function NoteToggleAction({
+  path,
+  indexActive,
+  toggle,
+  icon,
+  labels,
+  operations,
+  keybinding = null,
+  tooltip,
+}: NoteToggleActionProps): ReactElement {
+  const { graph } = useGraph()
+  // Guards against a double-click racing two read-patch-write toggles.
+  const [isToggling, setIsToggling] = useState(false)
+  const [pending, setPending] = useState<PendingToggle | null>(null)
+
+  // Render-time state adjustment (the React-sanctioned pattern): drop the
+  // bridge once the index agrees with it, so a later external flag change
+  // can't resurrect a stale override.
+  if (pending !== null && (pending.path !== path || pending.active === indexActive)) {
+    setPending(null)
+  }
+  const isActive = pending !== null && pending.path === path ? pending.active : indexActive
+
+  const onToggle = async (): Promise<void> => {
+    const generation = graph?.generation
+    if (generation === undefined) {
+      return
+    }
+    setIsToggling(true)
+    try {
+      setPending({ path, active: await toggle(path, generation) })
+    } catch (cause) {
+      startOperation(isActive ? operations.deactivate : operations.activate).fail(
+        errorMessage(cause),
+      )
+    } finally {
+      setIsToggling(false)
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => void onToggle()}
+      disabled={isToggling}
+      title={tooltip}
+      className="group relative flex w-full items-center space-x-2 rounded-lg px-3 py-2 text-start transition-colors duration-100 hover:bg-surface-hover disabled:opacity-50"
+    >
+      <span
+        className={cn(
+          'flex h-5 w-5 flex-none items-center justify-center transition-colors duration-100',
+          isActive ? 'text-accent' : 'text-text-muted group-hover:text-text',
+        )}
+      >
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-xs font-medium">
+        {isActive ? labels.active : labels.inactive}
+      </span>
+      {keybinding !== null ? (
+        <ShortcutKeys binding={keybinding} className="invisible group-hover:visible" />
+      ) : null}
+    </button>
+  )
+}

--- a/apps/desktop/src/editor/note-session.test.ts
+++ b/apps/desktop/src/editor/note-session.test.ts
@@ -241,6 +241,21 @@ describe('frontmatter ownership (Plan 07b)', () => {
     expect(h.applied).toEqual([]) // the editor was never reloaded
   })
 
+  it('marking private writes the flag; un-marking removes the key, not `private: false`', async () => {
+    const h = harness({ disk: '# Hello\n' })
+    h.session.load()
+    await vi.runAllTimersAsync()
+    h.session.updateFrontmatter({ private: true })
+    await vi.runAllTimersAsync()
+    expect(h.writes.at(-1)?.contents).toBe('---\nprivate: true\n---\n# Hello\n')
+
+    h.session.updateFrontmatter({ private: false })
+    await vi.runAllTimersAsync()
+    // Same contract as the pin: not-private is the absence of the flag.
+    expect(h.writes.at(-1)?.contents).toBe('# Hello\n')
+    expect(h.applied).toEqual([]) // the editor was never reloaded
+  })
+
   it('an external frontmatter-only change adopts cleanly without a conflict', async () => {
     const h = harness({ disk: `${FM}# Hello\n` })
     h.session.load()

--- a/apps/desktop/src/editor/note-session.ts
+++ b/apps/desktop/src/editor/note-session.ts
@@ -142,6 +142,12 @@ export interface FrontmatterPatch {
    * only metadata was the pin returns to having no frontmatter at all.
    */
   pinned?: boolean | number
+  /**
+   * The hard privacy flag (`private: true`): the note's content must never be
+   * sent to AI or any other external service. `false` deletes the key — like
+   * the pin, not-private is the absence of the flag.
+   */
+  private?: boolean
 }
 
 /** Translate the typed patch into the YAML write (`undefined` deletes a key). */
@@ -152,6 +158,9 @@ function yamlPatch(patch: FrontmatterPatch): Record<string, unknown> {
   }
   if (patch.pinned !== undefined) {
     yaml.pinned = patch.pinned === false ? undefined : patch.pinned
+  }
+  if (patch.private !== undefined) {
+    yaml.private = patch.private === false ? undefined : true
   }
   return yaml
 }

--- a/apps/desktop/src/hooks/use-note-row.ts
+++ b/apps/desktop/src/hooks/use-note-row.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query'
+import { getNote, hasBridge, type NoteRow } from '@reflect/core'
+import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
+import { useGraph } from '@/providers/graph-provider'
+
+/**
+ * One note's index row by graph-relative path, kept fresh by the usual index
+ * invalidation (a frontmatter write lands in the file, the watcher re-indexes
+ * it, the query refetches). `null` while loading or when the note has no
+ * indexed file yet — the lazy contract means a visible note can predate its
+ * row. Powers per-note state like the private flag.
+ */
+export function useNoteRow(path: string): NoteRow | null {
+  const { graph } = useGraph()
+  const { data } = useQuery({
+    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'note', path],
+    queryFn: async () => (await getNote(path)) ?? null,
+    enabled: hasBridge() && graph !== null,
+  })
+  return data ?? null
+}

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -2,6 +2,7 @@ import { embedStatus, errorMessage, notePath, randomNotePath, rebuildIndex } fro
 import { ulid } from 'ulidx'
 import { todayIso } from '@/lib/dates'
 import { toggleNotePinned } from '@/lib/note-pin'
+import { toggleNotePrivate } from '@/lib/note-private'
 import { startOperation } from '@/lib/operations'
 import { backfillEmbeddingsVisibly } from '@/lib/semantic'
 import { notePathForRoute, type Route } from '@/routing/route'
@@ -83,6 +84,27 @@ const APP_COMMANDS: AppCommand[] = [
         // runCommand has no error channel of its own — an unreported failure
         // here would be a silent ⌘O. Surface it like other background work.
         startOperation('Pinning note').fail(errorMessage(cause))
+      }
+    },
+  },
+  {
+    id: 'note.togglePrivate',
+    title: 'Mark or un-mark note as private',
+    keywords: ['privacy', 'lock', 'secret', 'hide', 'ai'],
+    // Flips the `private` frontmatter flag — the hard block on sending the
+    // note's content to AI or any other external service — of the note the
+    // current route edits. No default keybinding: the palette keeps it
+    // keyboard-reachable without spending a shortcut.
+    run: async (context) => {
+      const generation = context.generation()
+      const path = notePathForRoute(context.route(), todayIso())
+      if (generation === null || path === null) {
+        return
+      }
+      try {
+        await toggleNotePrivate(path, generation)
+      } catch (cause) {
+        startOperation('Marking note as private').fail(errorMessage(cause))
       }
     },
   },

--- a/apps/desktop/src/lib/note-pin.ts
+++ b/apps/desktop/src/lib/note-pin.ts
@@ -1,5 +1,6 @@
-import { isAppError, isPinned, parseNote, readNote, upsertFrontmatter, writeNote } from '@reflect/core'
+import { isPinned, parseNote, upsertFrontmatter, writeNote } from '@reflect/core'
 import { openSession } from '@/editor/open-documents'
+import { readNoteOrEmpty } from '@/lib/note-read'
 
 /**
  * Toggle a note's `pinned` frontmatter flag. Markdown is the source of truth:
@@ -33,22 +34,4 @@ export async function toggleNotePinned(path: string, generation: number): Promis
     await writeNote(path, patched, generation)
   }
   return pinned
-}
-
-/**
- * The note's content, where a missing file reads as an empty note — the lazy
- * contract: dailies (and ⌘N notes) are valid pin targets before their file
- * exists, and the pin write is what creates the file. Covers the gap where the
- * pane's session exists but can't take patches yet (still loading) — its
- * post-load reconcile then adopts our write like any external change.
- */
-async function readNoteOrEmpty(path: string): Promise<string> {
-  try {
-    return await readNote(path)
-  } catch (cause) {
-    if (isAppError(cause) && cause.kind === 'notFound') {
-      return ''
-    }
-    throw cause
-  }
 }

--- a/apps/desktop/src/lib/note-private.test.ts
+++ b/apps/desktop/src/lib/note-private.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NoteSession } from '@/editor/note-session'
+
+const readNote = vi.hoisted(() => vi.fn<(path: string) => Promise<string>>())
+const writeNote = vi.hoisted(() => vi.fn(async () => {}))
+const openSession = vi.hoisted(() => vi.fn<(path: string) => NoteSession | null>(() => null))
+
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  readNote,
+  writeNote,
+}))
+vi.mock('@/editor/open-documents', () => ({ openSession }))
+
+const { toggleNotePrivate } = await import('./note-private')
+
+beforeEach(() => {
+  readNote.mockReset()
+  writeNote.mockClear()
+  openSession.mockReset()
+  openSession.mockReturnValue(null)
+})
+
+function fakeSession(content: string, canCommit = true) {
+  const commitFrontmatter = vi.fn(async () => canCommit)
+  const session = { content: () => content, commitFrontmatter } as unknown as NoteSession
+  return { session, commitFrontmatter }
+}
+
+describe('toggleNotePrivate', () => {
+  it('marks an unopened note private via read-patch-write on disk', async () => {
+    readNote.mockResolvedValue('# A\n')
+    await expect(toggleNotePrivate('notes/a.md', 3)).resolves.toBe(true)
+    expect(writeNote).toHaveBeenCalledWith('notes/a.md', '---\nprivate: true\n---\n# A\n', 3)
+  })
+
+  it('un-marks on disk by removing the key (back to no frontmatter)', async () => {
+    readNote.mockResolvedValue('---\nprivate: true\n---\n# A\n')
+    await expect(toggleNotePrivate('notes/a.md', 3)).resolves.toBe(false)
+    expect(writeNote).toHaveBeenCalledWith('notes/a.md', '# A\n', 3)
+  })
+
+  it('treats the YAML 1.1-style `private: yes` as private and un-marking clears it', async () => {
+    // A 1.2 loader reads `yes` as a string; the schema's coercion still
+    // honours it, so the toggle must too — re-marking would be a silent no-op.
+    readNote.mockResolvedValue('---\nprivate: yes\n---\n# A\n')
+    await expect(toggleNotePrivate('notes/a.md', 3)).resolves.toBe(false)
+    expect(writeNote).toHaveBeenCalledWith('notes/a.md', '# A\n', 3)
+  })
+
+  it('replaces an explicit `private: false` with `private: true` when toggling on', async () => {
+    readNote.mockResolvedValue('---\nprivate: false\n---\n# A\n')
+    await expect(toggleNotePrivate('notes/a.md', 3)).resolves.toBe(true)
+    expect(writeNote).toHaveBeenCalledWith('notes/a.md', '---\nprivate: true\n---\n# A\n', 3)
+  })
+
+  it('routes through the live session, which owns landing the patch', async () => {
+    const { session, commitFrontmatter } = fakeSession('# A\n')
+    openSession.mockReturnValue(session)
+    await expect(toggleNotePrivate('notes/a.md', 3)).resolves.toBe(true)
+    expect(commitFrontmatter).toHaveBeenCalledWith({ private: true })
+    expect(readNote).not.toHaveBeenCalled()
+    expect(writeNote).not.toHaveBeenCalled()
+  })
+
+  it('toggles off through the session when the open note is private', async () => {
+    const { session, commitFrontmatter } = fakeSession('---\nprivate: true\n---\n# A\n')
+    openSession.mockReturnValue(session)
+    await expect(toggleNotePrivate('notes/a.md', 3)).resolves.toBe(false)
+    expect(commitFrontmatter).toHaveBeenCalledWith({ private: false })
+  })
+
+  it('falls back to disk when the session cannot take the patch', async () => {
+    const { session } = fakeSession('# A\n', false)
+    openSession.mockReturnValue(session)
+    readNote.mockResolvedValue('# A\n')
+    await expect(toggleNotePrivate('notes/a.md', 3)).resolves.toBe(true)
+    expect(writeNote).toHaveBeenCalledWith('notes/a.md', '---\nprivate: true\n---\n# A\n', 3)
+  })
+
+  it('marks a not-yet-created note private by creating its file (the lazy contract)', async () => {
+    const { session } = fakeSession('', false)
+    openSession.mockReturnValue(session)
+    readNote.mockRejectedValue({ kind: 'notFound', message: 'no such note' })
+    await expect(toggleNotePrivate('daily/2026-06-10.md', 3)).resolves.toBe(true)
+    expect(writeNote).toHaveBeenCalledWith('daily/2026-06-10.md', '---\nprivate: true\n---\n', 3)
+  })
+
+  it('still surfaces non-notFound read failures', async () => {
+    openSession.mockReturnValue(null)
+    readNote.mockRejectedValue({ kind: 'io', message: 'disk on fire' })
+    await expect(toggleNotePrivate('notes/a.md', 3)).rejects.toMatchObject({ kind: 'io' })
+    expect(writeNote).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/note-private.ts
+++ b/apps/desktop/src/lib/note-private.ts
@@ -1,0 +1,39 @@
+import { parseNote, upsertFrontmatter, writeNote } from '@reflect/core'
+import { openSession } from '@/editor/open-documents'
+import { readNoteOrEmpty } from '@/lib/note-read'
+
+/**
+ * Toggle a note's `private` frontmatter flag — the hard block that keeps the
+ * note's content away from AI and every other external service. It is privacy
+ * from cloud services, not encryption or a local-search filter (the product
+ * vision's contract). Markdown is the source of truth: the flag lands in the
+ * file, the watcher re-indexes it, and `notes.isPrivate` follows from the
+ * index — no UI-side privacy state. Toggling off removes the key entirely:
+ * not-private is the absence of the flag, and frontmatter stays minimal.
+ *
+ * Routes through the live session whenever the note is open, exactly like
+ * `toggleNotePinned`: a direct disk write under a dirty buffer would
+ * park a conflict caused by our own action, and "keep mine" would silently
+ * undo the flag. The session's `commitFrontmatter` owns making the patch land
+ * immediately — parked-conflict handling included. With no live session (or
+ * one that can't take patches), a read-patch-write on disk is reconciled by
+ * any loading/clean session like an external change.
+ *
+ * Returns the note's new private state.
+ */
+export async function toggleNotePrivate(path: string, generation: number): Promise<boolean> {
+  const owner = openSession(path)
+  if (owner !== null) {
+    const isPrivate = !parseNote({ path, source: owner.content() }).frontmatter.private
+    if (await owner.commitFrontmatter({ private: isPrivate })) {
+      return isPrivate
+    }
+  }
+  const content = await readNoteOrEmpty(path)
+  const isPrivate = !parseNote({ path, source: content }).frontmatter.private
+  const patched = upsertFrontmatter(content, { private: isPrivate ? true : undefined })
+  if (patched !== content) {
+    await writeNote(path, patched, generation)
+  }
+  return isPrivate
+}

--- a/apps/desktop/src/lib/note-read.ts
+++ b/apps/desktop/src/lib/note-read.ts
@@ -1,0 +1,20 @@
+import { isAppError, readNote } from '@reflect/core'
+
+/**
+ * The note's content, where a missing file reads as an empty note — the lazy
+ * contract: dailies (and ⌘N notes) are valid frontmatter-toggle targets before
+ * their file exists, and the toggle's write is what creates the file. Covers
+ * the gap where the pane's session exists but can't take patches yet (still
+ * loading) — its post-load reconcile then adopts our write like any external
+ * change.
+ */
+export async function readNoteOrEmpty(path: string): Promise<string> {
+  try {
+    return await readNote(path)
+  } catch (cause) {
+    if (isAppError(cause) && cause.kind === 'notFound') {
+      return ''
+    }
+    throw cause
+  }
+}


### PR DESCRIPTION
## What

Adds a privacy toggle to the "Note actions" context-sidebar section, for both daily and normal notes. It flips the `private: true` frontmatter flag — the hard block on sending a note's content to AI or any other external service. Also adds a `note.togglePrivate` command so the action is reachable from the ⌘K palette (no default keybinding).


## Terminology

Went with **"Mark this note as private" / "Un-mark this note as private"** (matching the "Pin this note / Un-pin this note" voice) rather than "Lock this note":

- The product vision is explicit that `private: true` is a cloud-AI/external-service block, **not** encryption — "Lock" carries an Apple Notes/Bear password-protection connotation.
- "Make public" was rejected for the reverse action since "public" means published/shareable links in Reflect's V1 vocabulary.
- The button carries a tooltip: "Private notes are never sent to AI or any other external service", with a Lucide lock icon that tints accent while the flag is on.

## How

Mirrors the pin action end-to-end:

- **`toggleNotePrivate`** (`apps/desktop/src/lib/note-private.ts`) routes through the live session's `commitFrontmatter` when the note is open (so a dirty buffer can't park a self-inflicted conflict; parked-conflict write-through included), falling back to read-patch-write on disk. The watcher re-indexes and the UI follows from `notes.isPrivate` — no UI-side privacy state.
- **Toggling off deletes the key** rather than writing `private: false` — not-private is the absence of the flag, and a note whose only metadata was the flag returns to having no frontmatter (same contract as the pin).
- **`FrontmatterPatch`** gains `private?: boolean` — the typed allowlist for session-channel frontmatter writes.
- **`NoteToggleAction`** extracts the pin button's pending-state bridge (covers the watcher round-trip so a stale click can't invert the user's intent), double-click guard, and operations-line error surfacing into a shared component; the section now renders pin + private through it.
- **`useNoteRow`** is a new hook over the existing `getNote` index query for per-note state.
- `readNoteOrEmpty` (missing file reads as an empty note — the lazy-creation contract) moved from `note-pin.ts` to a shared `note-read.ts`.

## Scope note

This sets and projects the flag; actual enforcement at AI call sites is the M3 copilot work — nothing in the current code sends note content externally yet.

## Testing

- 16 new tests: `note-private.test.ts` (session route, disk fallback, lazy creation, YAML 1.1 `private: yes` coercion, key deletion), section UI tests (label flip, bridge, failure surfacing), and a session-layer patch test.
- All existing pin/session/context-sidebar/palette tests pass (134 across the touched areas); `pnpm check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches note persistence and live-session frontmatter commits (same paths as pin); enforcement at AI boundaries is out of scope for this PR.
> 
> **Overview**
> Adds **Mark / Un-mark this note as private** to the Note actions sidebar (alongside pin), flipping `private: true` in frontmatter — the contract for blocking note content from AI and external services. A **`note.togglePrivate`** command exposes the same behavior from the ⌘K palette (no default shortcut).
> 
> **`toggleNotePrivate`** mirrors **`toggleNotePinned`**: live-session `commitFrontmatter` when open, otherwise read-patch-write via shared **`readNoteOrEmpty`**; clearing privacy **removes the key** instead of writing `private: false`. **`FrontmatterPatch`** / session YAML handling gain **`private`**. Pin UI logic moves into reusable **`NoteToggleAction`**; privacy state comes from new **`useNoteRow`** (`getNote` / `isPrivate`).
> 
> Tests cover the toggle lib, sidebar actions, and session frontmatter patches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cc4db908d91afe00c297cf9b83d3b40d2148a3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to toggle note privacy status—mark notes as private or unprivate.
  * Introduced new UI control for privacy toggle alongside existing pin/unpin action in the context sidebar.
  * Added keyboard shortcut support for note privacy toggle command.
  * Privacy state now persists in note metadata.

* **Tests**
  * Added comprehensive test coverage for privacy toggle behavior and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->