### PR TITLE
Fix sidebar history arrows (and calendar nav) clicks swallowed by the window drag region

### DIFF
--- a/apps/desktop/src/components/context-sidebar/day-calendar.tsx
+++ b/apps/desktop/src/components/context-sidebar/day-calendar.tsx
@@ -79,7 +79,10 @@ export function DayCalendar({ selectedDate, today }: DayCalendarProps): ReactEle
         <div className="cursor-default text-sm font-semibold text-text">
           {monthLabel(month)}
         </div>
-        <nav className="flex items-center justify-center space-x-1 text-text-muted">
+        {/* z-40 lifts the buttons above the WindowDragRegion strip overlaying
+            the title-bar band, so clicks land instead of dragging the window
+            (see NavigateArrows for the stacking contract). */}
+        <nav className="relative z-40 flex items-center justify-center space-x-1 text-text-muted">
           <button
             type="button"
             aria-label="Previous month"

--- a/apps/desktop/src/components/sidebar/navigate-arrows.tsx
+++ b/apps/desktop/src/components/sidebar/navigate-arrows.tsx
@@ -25,7 +25,12 @@ export function NavigateArrows(): ReactElement {
     'disabled:hover:bg-transparent disabled:hover:text-text-muted'
 
   return (
-    <div className="flex items-center">
+    // The arrows sit inside the overlaid macOS title-bar band, where the
+    // WindowDragRegion strip (z-40, mounted before the app) would otherwise
+    // swallow their clicks into a window drag. Matching its z-index puts the
+    // buttons above it by tree order while same-z overlays mounted later
+    // (the command palette) still cover them.
+    <div className="relative z-40 flex items-center">
       <button
         type="button"
         aria-label="Go back"

--- a/apps/desktop/src/components/window-drag-region.tsx
+++ b/apps/desktop/src/components/window-drag-region.tsx
@@ -8,10 +8,12 @@ import { hasMacosTitleBarOverlay } from '@/lib/window-chrome'
  * double-click toggle zoom, matching native title-bar behavior.
  *
  * Mouse events on the strip never reach content beneath it, so interactive
- * elements must stay below its 28px height (`h-7` here, `pt-7` clearance in
- * the surfaces that need it — see `hasMacosTitleBarOverlay` call sites).
- * Renders nothing outside the macOS desktop webview, where the native title
- * bar still exists.
+ * elements within its 28px height (`h-7`) must raise themselves above it
+ * with `relative z-40`: the strip mounts before the app, so at equal
+ * z-index the app's controls win by tree order, while same-z overlays
+ * mounted later (the command palette) still cover those controls. See
+ * `NavigateArrows` and the `DayCalendar` header. Renders nothing outside
+ * the macOS desktop webview, where the native title bar still exists.
  */
 export function WindowDragRegion(): ReactElement | null {
   if (!hasMacosTitleBarOverlay) {


### PR DESCRIPTION
## What

The sidebar's back/forward history arrows worked only intermittently — and the calendar header's prev/today/next buttons had the same problem. Clicks in the upper portion of these buttons did nothing (or nudged the window) instead of navigating.

## Why

With the overlaid macOS title bar, `WindowDragRegion` mounts an invisible full-width strip (`fixed top-0 z-40 h-7`) that captures every mouse event in the top 28px to make the band draggable. The V1 restyle (#66) originally cleared it with `pt-7`, but the padding fixes (#64, #69) tightened the sidebars to `pt-2`/`pt-0` to match V1's look — sliding the controls under the strip:

- **History arrows**: buttons span y=12–36px, so the strip covered their top 16px. Only the bottom ~8px sliver was clickable — hence "sometimes works, sometimes doesn't" depending on where you clicked.
- **Calendar nav** (right sidebar): buttons span y=16–40px, top 12px dead.

Clicks landing on the strip started a window drag and never reached the button.

## How

Keeps the tightened V1 layout and raises just the button clusters above the strip with `relative z-40`:

- The strip mounts before the app, so at **equal** z-index the controls win by tree order.
- Same-z overlays mounted later in the tree (the ⌘K palette backdrop, also `z-40`) still correctly cover the controls when open — a higher z like `z-50` would have broken that.
- Only the button clusters are raised, so the rest of the title-bar band stays draggable.

Also updates `WindowDragRegion`'s doc comment, which still claimed interactive elements must stay below the band, and documents the stacking contract at each call site.

## Notes for reviewers

- jsdom does no real hit-testing, so unit tests can't catch this class of bug (the existing arrow tests passed throughout). Verified `pnpm check` and the sidebar/context-sidebar/router suites (26 tests) pass; worth a quick manual click in the macOS app, including the top edge of the arrows.
- Non-macOS platforms are unaffected: the strip doesn't render there and the added z-index changes nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> macOS-only stacking/CSS change with no auth, data, or API impact; non-macOS paths unchanged.
> 
> **Overview**
> Fixes **macOS overlaid title-bar** clicks on sidebar history arrows and calendar month navigation being swallowed by `WindowDragRegion` (the fixed `z-40` drag strip).
> 
> Adds **`relative z-40`** on the `NavigateArrows` wrapper and the `DayCalendar` header `<nav>` so those controls stack above the strip (same z-index, later in the tree) without bumping past later overlays like the command palette. **`WindowDragRegion`** and call-site comments now document this stacking contract instead of saying controls must stay below the band.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e440e838e929a7121086527b114378cd673f0631. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed navigation buttons (calendar controls and back/forward arrows) in the sidebar that were not properly clickable when positioned above drag regions. Elements now render with correct layering to ensure full interactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->