### PR TITLE
Sidebar and settings polish: smaller graph name, week-start select, shadcn graph menu

### DIFF
--- a/apps/desktop/src/components/settings/appearance-section.tsx
+++ b/apps/desktop/src/components/settings/appearance-section.tsx
@@ -1,6 +1,17 @@
 import type { ReactElement } from 'react'
-import type { ThemePreference, WeekStartDay } from '@reflect/core'
+import {
+  weekStartDaySchema,
+  type ThemePreference,
+  type WeekStartDay,
+} from '@reflect/core'
 import { Monitor, Moon, Sun, type LucideIcon } from 'lucide-react'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { cn } from '@/lib/utils'
 import { useSettings } from '@/providers/settings-provider'
 import { SettingsField } from './field'
@@ -74,30 +85,24 @@ export function AppearanceSection(): ReactElement {
         legend="Start week on"
         description="The first day shown in the daily notes calendar."
       >
-        <div className="mt-3 grid grid-cols-2 gap-2">
-          {WEEK_START_OPTIONS.map(({ value, label }) => {
-            const selected = settings.weekStartDay === value
-            return (
-              <SettingsOptionCard
-                key={value}
-                selected={selected}
-                className={cn(
-                  'items-center justify-center px-3 py-2.5',
-                  selected ? 'text-accent-soft-text' : 'text-text-secondary',
-                )}
-              >
-                <input
-                  type="radio"
-                  name="week-start-day"
-                  value={value}
-                  checked={selected}
-                  onChange={() => updateSettings({ weekStartDay: value })}
-                  className="sr-only"
-                />
-                <span className="text-sm font-medium">{label}</span>
-              </SettingsOptionCard>
-            )
-          })}
+        <div className="mt-3">
+          <Select
+            value={settings.weekStartDay}
+            onValueChange={(value) =>
+              updateSettings({ weekStartDay: weekStartDaySchema.parse(value) })
+            }
+          >
+            <SelectTrigger aria-label="Start week on" className="w-36">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {WEEK_START_OPTIONS.map(({ value, label }) => (
+                <SelectItem key={value} value={value}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
       </SettingsField>
     </SettingsSection>

--- a/apps/desktop/src/components/sidebar/graph-footer.tsx
+++ b/apps/desktop/src/components/sidebar/graph-footer.tsx
@@ -13,7 +13,7 @@ import { cn } from '@/lib/utils'
 import { useGraph } from '@/providers/graph-provider'
 import { useRouter } from '@/routing/router'
 
-const menuItemClass = 'gap-2 px-2 py-1.5 text-[13px] text-text-secondary'
+const MENU_ITEM_CLASS = 'gap-2 px-2 py-1.5 text-[13px] text-text-secondary'
 
 /**
  * The sidebar footer, in the original app's idiom (its account nav): the
@@ -65,7 +65,7 @@ export function GraphFooter({ graph }: { graph: GraphInfo }): ReactElement {
                     void openRecent(recent.root)
                   }
                 }}
-                className={menuItemClass}
+                className={MENU_ITEM_CLASS}
               >
                 <span className="min-w-0 flex-1 truncate">{recent.name}</span>
                 {current ? (
@@ -77,7 +77,7 @@ export function GraphFooter({ graph }: { graph: GraphInfo }): ReactElement {
           {recents.length > 0 ? <DropdownMenuSeparator /> : null}
           <DropdownMenuItem
             onSelect={() => void pickAndOpen()}
-            className={menuItemClass}
+            className={MENU_ITEM_CLASS}
           >
             <FolderOpen aria-hidden strokeWidth={1.75} className="size-3.5 shrink-0" />
             <span className="min-w-0 flex-1 truncate">Open another graph…</span>

--- a/apps/desktop/src/components/sidebar/graph-footer.tsx
+++ b/apps/desktop/src/components/sidebar/graph-footer.tsx
@@ -1,129 +1,98 @@
-import { useState, type ReactElement } from 'react'
+import type { ReactElement } from 'react'
 import type { GraphInfo } from '@reflect/core'
 import { Check, FolderOpen } from 'lucide-react'
 import { HelpIcon } from '@/components/icons/help-icon'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
 import { useGraph } from '@/providers/graph-provider'
 import { useRouter } from '@/routing/router'
 
+const menuItemClass = 'gap-2 px-2 py-1.5 text-[13px] text-text-secondary'
+
 /**
  * The sidebar footer, in the original app's idiom (its account nav): the
- * graph's color swatch and name on the left — a disclosure for switching to a
- * recent graph or the OS folder picker — and a help button on the right
+ * graph's color swatch and name on the left — a dropdown menu for switching
+ * to a recent graph or the OS folder picker — and a help button on the right
  * (Settings hosts the keyboard cheat sheet, the closest analog to the old
- * help menu). The swatch pulses while the graph indexes. No portal: the
- * footer is its own positioning context, and a fixed backdrop handles
- * click-outside.
+ * help menu). The swatch pulses while the graph indexes. The menu content
+ * matches the trigger width, so it stays inset from the sidebar edges.
  */
 export function GraphFooter({ graph }: { graph: GraphInfo }): ReactElement {
   const { recents, indexing, openRecent, pickAndOpen } = useGraph()
   const { navigate } = useRouter()
-  const [open, setOpen] = useState(false)
-
-  const choose = (action: () => Promise<void>): void => {
-    setOpen(false)
-    void action()
-  }
 
   return (
-    <div
-      className="relative"
-      onKeyDown={(event) => {
-        if (event.key === 'Escape' && open) {
-          event.stopPropagation()
-          setOpen(false)
-        }
-      }}
-    >
-      {open ? (
-        <>
+    <div className="flex items-center px-4 py-3">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
           <button
             type="button"
-            aria-label="Close graph menu"
-            tabIndex={-1}
-            onClick={() => setOpen(false)}
-            className="fixed inset-0 z-20 cursor-default"
-          />
-          <div
-            role="menu"
-            aria-label="Switch graph"
-            className="absolute inset-x-0 bottom-full z-30 mb-1.5 rounded-lg border border-border bg-surface p-1 shadow-pop"
+            title={graph.root}
+            className="flex min-w-0 flex-1 items-center space-x-2.5 text-left"
           >
-            {recents.map((recent) => {
-              const current = recent.root === graph.root
-              return (
-                <button
-                  key={recent.root}
-                  type="button"
-                  role="menuitem"
-                  title={recent.root}
-                  onClick={() => {
-                    if (current) {
-                      setOpen(false)
-                      return
-                    }
-                    choose(() => openRecent(recent.root))
-                  }}
-                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-[13px] text-text-secondary hover:bg-surface-hover hover:text-text"
-                >
-                  <span className="min-w-0 flex-1 truncate text-left">{recent.name}</span>
-                  {current ? (
-                    <Check aria-hidden className="size-3.5 shrink-0 text-accent" />
-                  ) : null}
-                </button>
-              )
-            })}
-            {recents.length > 0 ? (
-              <div role="separator" className="mx-2 my-1 border-t border-border" />
-            ) : null}
-            <button
-              type="button"
-              role="menuitem"
-              onClick={() => choose(pickAndOpen)}
-              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-[13px] text-text-secondary hover:bg-surface-hover hover:text-text"
-            >
-              <FolderOpen aria-hidden strokeWidth={1.75} className="size-3.5 shrink-0" />
-              <span className="min-w-0 flex-1 truncate text-left">Open another graph…</span>
-            </button>
-          </div>
-        </>
-      ) : null}
-
-      <div className="flex items-center px-4 py-3">
-        <button
-          type="button"
-          aria-haspopup="menu"
-          aria-expanded={open}
-          title={graph.root}
-          onClick={() => setOpen((current) => !current)}
-          className="flex min-w-0 flex-1 items-center space-x-2.5 text-left"
-        >
-          <span
-            aria-hidden
-            className={cn(
-              'h-5 w-5 flex-none rounded-md bg-accent',
-              indexing && 'motion-safe:animate-pulse',
-            )}
-          />
-          <span className="min-w-0 truncate text-sm font-medium text-text">
-            {graph.name}
-          </span>
-          {indexing ? (
-            <span role="status" className="sr-only">
-              Indexing
+            <span
+              aria-hidden
+              className={cn(
+                'h-5 w-5 flex-none rounded-md bg-accent',
+                indexing && 'motion-safe:animate-pulse',
+              )}
+            />
+            <span className="min-w-0 truncate text-xs font-medium text-text">
+              {graph.name}
             </span>
-          ) : null}
-        </button>
-        <button
-          type="button"
-          aria-label="Help"
-          title="Help"
-          onClick={() => navigate({ kind: 'settings' })}
-          className="flex-none text-text-muted transition-colors duration-100 hover:text-text"
-        >
-          <HelpIcon />
-        </button>
-      </div>
+            {indexing ? (
+              <span role="status" className="sr-only">
+                Indexing
+              </span>
+            ) : null}
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent aria-label="Switch graph" side="top" sideOffset={6}>
+          {recents.map((recent) => {
+            const current = recent.root === graph.root
+            return (
+              <DropdownMenuItem
+                key={recent.root}
+                title={recent.root}
+                onSelect={() => {
+                  if (!current) {
+                    void openRecent(recent.root)
+                  }
+                }}
+                className={menuItemClass}
+              >
+                <span className="min-w-0 flex-1 truncate">{recent.name}</span>
+                {current ? (
+                  <Check aria-hidden className="size-3.5 shrink-0 text-accent" />
+                ) : null}
+              </DropdownMenuItem>
+            )
+          })}
+          {recents.length > 0 ? <DropdownMenuSeparator /> : null}
+          <DropdownMenuItem
+            onSelect={() => void pickAndOpen()}
+            className={menuItemClass}
+          >
+            <FolderOpen aria-hidden strokeWidth={1.75} className="size-3.5 shrink-0" />
+            <span className="min-w-0 flex-1 truncate">Open another graph…</span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <button
+        type="button"
+        aria-label="Help"
+        title="Help"
+        onClick={() => navigate({ kind: 'settings' })}
+        className="flex-none text-text-muted transition-colors duration-100 hover:text-text"
+      >
+        <HelpIcon />
+      </button>
     </div>
   )
 }

--- a/apps/desktop/src/components/ui/dropdown-menu.tsx
+++ b/apps/desktop/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,267 @@
+import * as React from "react"
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { CheckIcon, ChevronRightIcon } from "lucide-react"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  align = "start",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        align={align}
+        className={cn("z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-surface-hover focus:text-foreground not-data-[variant=destructive]:focus:**:text-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-surface-hover focus:text-foreground focus:**:text-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon
+          />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-surface-hover focus:text-foreground focus:**:text-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon
+          />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-surface-hover focus:text-foreground not-data-[variant=destructive]:focus:**:text-foreground data-inset:pl-7 data-open:bg-surface-hover data-open:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn("z-50 min-w-[96px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}


### PR DESCRIPTION
## What changed

- **Sidebar graph name** is now `text-xs` (was `text-sm`) in `graph-footer.tsx`.
- **"Start week on"** in Settings → Appearance is now a shadcn `Select` instead of two radio cards, following the exact pattern the Date & time section already uses (same trigger width, `aria-label`, and `weekStartDaySchema.parse()` validating the value before `updateSettings`).
- **Graph switcher popup** is now a proper shadcn `DropdownMenu`. The previous implementation was hand-rolled (manual open state, full-screen backdrop button, manual Escape handling) and rendered flush with the app's left edge. Radix now handles open/close, click-outside, Escape, arrow-key navigation, and ARIA wiring; the portal-positioned content matches the trigger width, so it sits inset 16px from the sidebar edges.

## Notes for reviewers

- `ui/dropdown-menu.tsx` is newly added via `pnpm dlx shadcn@latest add dropdown-menu`, with this repo's standard post-add patch applied: stock shadcn uses `focus:bg-accent`, which in this app resolves to the brand indigo (the DS owns `--accent`), so focus/hover washes were swapped to `focus:bg-surface-hover focus:text-foreground` — same patch as the existing `select.tsx` and `command.tsx`.
- Menu item visuals are unchanged: same sizing, truncation, accent check on the current graph, and the separator before "Open another graph…".

## Testing

- `pnpm check` (typecheck + lint) passes.
- `settings-screen.test.tsx` (19 tests) and `sidebar.test.tsx` (6 tests, including opening the graph menu and selecting "Open another graph…") pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and component wiring only; settings persistence and graph open/switch actions are unchanged.
> 
> **Overview**
> **Sidebar and settings UI polish** swaps two hand-built controls for shared shadcn/Radix primitives and tightens sidebar typography.
> 
> In **Settings → Appearance**, **Start week on** moves from two radio option cards to a **`Select`** (same `w-36` trigger, `aria-label`, and **`weekStartDaySchema.parse()`** before `updateSettings` as other settings selects).
> 
> In the **sidebar graph footer**, the graph switcher drops manual open state, full-screen backdrop, and Escape handling in favor of a new **`DropdownMenu`** (`ui/dropdown-menu.tsx`, with **`focus:bg-surface-hover`** instead of stock `bg-accent` to match `select`/`command`). The menu opens upward, content width matches the trigger so it stays inset from the sidebar, and recent graphs / **Open another graph…** behavior is unchanged. The graph name label is **`text-xs`** (was `text-sm`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d1726fb8899bd7267d431b717b7cb63bd376f2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Changed "Start week on" setting from radio buttons to dropdown selector
  * Redesigned graph footer dropdown menu with improved navigation structure
  * Refined text sizing in sidebar graph display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->