### PR TITLE
Restyle keyboard shortcuts to match V1's single-pill design

### DIFF
--- a/apps/desktop/src/components/kbd.tsx
+++ b/apps/desktop/src/components/kbd.tsx
@@ -1,26 +1,28 @@
 import type { ReactElement, ReactNode } from 'react'
 import { cn } from '@/lib/utils'
 
+/**
+ * The V1 shortcut chrome: a single rounded pill with a hairline border,
+ * surface background, and a subtle shadow. Shared between {@link Kbd}
+ * (one literal key) and `ShortcutKeys` (a whole binding in one pill).
+ */
+export const KBD_FRAME_CLASS =
+  'inline-flex items-center justify-center rounded-md border border-border-strong bg-surface px-1 py-0.5 text-[10px] font-semibold uppercase text-text-muted shadow-input dark:border-white/10 dark:bg-white/5'
+
 interface KbdProps {
   children: ReactNode
   className?: string
 }
 
 /**
- * One keycap, in the original Reflect idiom: a small, low-contrast bordered
- * cap that annotates without shouting. Composed by {@link ShortcutKeys} for
- * whole bindings and used directly for literal hints (↑↓, esc).
+ * One literal key in the original Reflect idiom — a small bordered pill that
+ * annotates without shouting. Used for standalone hints (↑↓, esc); whole
+ * bindings render through `ShortcutKeys`, which groups keys in one pill.
  */
 export function Kbd({ children, className }: KbdProps): ReactElement {
   return (
     <kbd
-      className={cn(
-        'inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-[4px]',
-        'border border-border bg-surface px-1',
-        'font-sans text-[10px] font-medium leading-none text-text-muted',
-        'shadow-input dark:bg-white/5',
-        className,
-      )}
+      className={cn(KBD_FRAME_CLASS, 'min-w-[1lh] text-center font-shortcut leading-4', className)}
     >
       {children}
     </kbd>

--- a/apps/desktop/src/components/shortcut-keys.test.tsx
+++ b/apps/desktop/src/components/shortcut-keys.test.tsx
@@ -37,6 +37,15 @@ describe('ShortcutKeys', () => {
     view.unmount()
   })
 
+  it('groups all keys inside a single pill, V1-style', () => {
+    isApplePlatform.mockReturnValue(true)
+    const view = render(<ShortcutKeys binding="Mod-Shift-Enter" />)
+    const pills = view.container.querySelectorAll(':scope > span')
+    expect(pills).toHaveLength(1)
+    expect(pills[0]?.querySelectorAll('kbd')).toHaveLength(3)
+    view.unmount()
+  })
+
   it('ghost mode renders the keys as plain joined text, not keycaps', () => {
     isApplePlatform.mockReturnValue(true)
     const view = render(<ShortcutKeys binding="Mod-k" ghost />)

--- a/apps/desktop/src/components/shortcut-keys.tsx
+++ b/apps/desktop/src/components/shortcut-keys.tsx
@@ -1,20 +1,21 @@
 import { useMemo, type ReactElement } from 'react'
-import { Kbd } from '@/components/kbd'
+import { KBD_FRAME_CLASS } from '@/components/kbd'
 import { formatBinding, isApplePlatform } from '@/lib/keybindings'
 import { cn } from '@/lib/utils'
 
 interface ShortcutKeysProps {
   /** A keymap-registry binding, e.g. `Mod-d` or `Mod-\`. */
   binding: string
-  /** Render as borderless inline text (V1's search-bar ⌘K) instead of keycaps. */
+  /** Render as borderless inline text (V1's search-bar ⌘K) instead of a keycap pill. */
   ghost?: boolean
   className?: string
 }
 
 /**
- * Renders a registry binding as a row of keycaps (⌘ D on Apple, Ctrl D
- * elsewhere). The display half of the central keymap registry — every surface
- * that hints a shortcut (sidebar, palette, settings cheat sheet) goes through
+ * Renders a registry binding in the V1 idiom: all keys grouped inside a
+ * single bordered pill (⌘D on Apple, Ctrl D elsewhere), not one keycap per
+ * key. The display half of the central keymap registry — every surface that
+ * hints a shortcut (sidebar, palette, settings cheat sheet) goes through
  * this so bindings always read the same way.
  */
 export function ShortcutKeys({ binding, ghost, className }: ShortcutKeysProps): ReactElement {
@@ -30,9 +31,17 @@ export function ShortcutKeys({ binding, ghost, className }: ShortcutKeysProps): 
     )
   }
   return (
-    <span aria-hidden className={cn('inline-flex shrink-0 gap-[3px]', className)}>
+    <span aria-hidden className={cn(KBD_FRAME_CLASS, 'shrink-0', className)}>
       {keys.map((key, index) => (
-        <Kbd key={index}>{key}</Kbd>
+        <kbd
+          key={index}
+          className={cn(
+            'block text-center font-shortcut leading-4',
+            key.length === 1 ? '-mx-0.5 min-w-[1lh]' : 'mx-0.5',
+          )}
+        >
+          {key}
+        </kbd>
       ))}
     </span>
   )


### PR DESCRIPTION
## What changed

V2 rendered each key of a shortcut as its own separate 18px keycap box (`[⌘] [⇧] [F]`), while V1 renders the whole binding as a single bordered pill containing all keys (`[⌘⇧F]`). This ports V1's `ShortcutElement` design onto V2's design-system tokens:

- **`shortcut-keys.tsx`** — non-ghost mode now renders one pill per binding with V1's exact inner-key layout: `font-shortcut` glyph font, single-character keys get `-mx-0.5 min-w-[1lh]` for uniform key width, multi-character keys get `mx-0.5`, `leading-4`. Ghost mode (the sidebar search's `⌘K`) is unchanged.
- **`kbd.tsx`** — the standalone `Kbd` (command-palette footer hints like ↑↓/esc) uses the same pill chrome, shared via an exported `KBD_FRAME_CLASS`.

## Token mapping

Theme utilities only, no raw colors: V1's `border-coolgray-300` → `border-border-strong`, `bg-white` → `bg-surface`, `shadow-sm` → `shadow-input` (identical value), plus V1's exact dark-mode literals (`dark:border-white/10 dark:bg-white/5`). Text stays `text-text-muted`, which the token file documents as the shortcut color.

## Reviewer notes

- Every surface showing shortcuts restyles automatically — sidebar items, command palette rows and footer, settings keyboard cheat sheet, pin action — since they all route through `ShortcutKeys`/`Kbd`.
- One visible side effect: the palette footer's "esc" hint now renders uppercase, matching V1's `uppercase` treatment.
- Added a test pinning the single-pill grouping; `pnpm check` and all `shortcut-keys` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to shared shortcut components with no behavior or data-path impact.
> 
> **Overview**
> **Keyboard shortcut hints now match V1’s single-pill look** instead of one bordered box per key.
> 
> `ShortcutKeys` (non-ghost) wraps the whole binding in one pill using a shared **`KBD_FRAME_CLASS`** from `kbd.tsx` (`border-border-strong`, `bg-surface`, `shadow-input`, dark-mode literals). Inner keys stay as plain `<kbd>` elements with V1 spacing (`font-shortcut`, `-mx-0.5 min-w-[1lh]` for single glyphs, `mx-0.5` for longer labels). Standalone **`Kbd`** (e.g. palette ↑↓ / esc) uses the same chrome; ghost sidebar `⌘K` text is unchanged.
> 
> A test asserts **one outer pill** and three inner keys for `Mod-Shift-Enter`. Anything that already uses `ShortcutKeys` / `Kbd` (palette, sidebar, settings cheat sheet, pin action) picks up the new styling automatically; palette **esc** may read uppercase via `uppercase` on the frame.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50af74ec9c2be47ef55c5d57976b88e94765d5b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->