### PR TITLE
Align sidebar pinned notes with nav tab icons

### DIFF
--- a/apps/desktop/src/components/sidebar/sidebar-note-row.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar-note-row.tsx
@@ -23,13 +23,15 @@ export function SidebarNoteRow({ path, title, date }: SidebarNoteRowProps): Reac
   const target = routeForPath(path)
   const active = routesEqual(route, target)
   return (
-    <li className="mx-2">
+    // The negative margin lets the hover wash bleed past the section's
+    // padding so the title text stays on the section's alignment line.
+    <li className="-mx-2.5">
       <button
         type="button"
         onClick={() => navigate(target)}
         aria-current={active ? 'page' : undefined}
         className={cn(
-          'flex w-full items-center rounded-md px-2 py-1 leading-5',
+          'flex w-full items-center rounded-md px-2.5 py-1 leading-5',
           'transition-colors duration-100',
           active
             ? 'bg-surface-hover text-text dark:bg-transparent dark:text-accent'

--- a/apps/desktop/src/components/sidebar/sidebar-pinned.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar-pinned.tsx
@@ -16,8 +16,10 @@ export function SidebarPinned(): ReactElement | null {
   }
 
   return (
-    <section aria-label="Pinned notes">
-      <h2 className="px-4 pt-4 text-2xs font-medium leading-5 tracking-wide text-text-muted">
+    // px-6.5 starts the section's text at the nav rows' icon edge (the nav's
+    // px-4 plus each row's px-2.5).
+    <section aria-label="Pinned notes" className="px-6.5">
+      <h2 className="pt-4 text-2xs font-medium leading-5 tracking-wide text-text-muted">
         Pinned notes
       </h2>
       <ul className="mt-2 flex flex-col space-y-1">


### PR DESCRIPTION
## What changed

The sidebar's Pinned notes section (header and note rows) now lines up with the left edge of the nav tab icons above it, instead of sitting flush with the nav rows' outer edge.

- `SidebarPinned` carries the section's horizontal padding once (`px-6.5` = 26px, the nav's `px-4` plus each row's `px-2.5`), rather than the header and list items padding themselves individually.
- `SidebarNoteRow` drops its own `mx-2`/`px-2`; the `li` uses `-mx-2.5` with `px-2.5` inside the button so the title text stays on the section's alignment line while the hover wash bleeds outward to the same 16px bounds as the nav rows' wash.

## Why

The pinned header and note titles started at 16px from the sidebar edge while the tab icons start at 26px, which made the shelf look misaligned with the navigation above it.

## Notes for reviewers

`SidebarNoteRow` is only used by the pinned shelf, so the negative-margin assumption (a padded parent section) holds everywhere it renders. Typecheck, lint, and the sidebar tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tailwind-only layout tweaks in sidebar components with no logic or data changes; `SidebarNoteRow` is only used by the pinned shelf.
> 
> **Overview**
> Aligns the **Pinned notes** shelf with the nav tab icons by moving horizontal padding to `SidebarPinned` (`px-6.5`, matching nav `px-4` + row `px-2.5`) and dropping per-header/list padding.
> 
> `SidebarNoteRow` uses `-mx-2.5` on the list item and `px-2.5` on the button so titles stay on that alignment line while row hover/active backgrounds extend to the same outer bounds as nav rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c9164c74590d243dd7682c79e76d8be04952cb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->