### PR TITLE
Remove help (?) button from sidebar footer

### DIFF
--- a/apps/desktop/src/components/sidebar/graph-footer.tsx
+++ b/apps/desktop/src/components/sidebar/graph-footer.tsx
@@ -1,7 +1,6 @@
 import type { ReactElement } from 'react'
 import type { GraphInfo } from '@reflect/core'
 import { Check, FolderOpen } from 'lucide-react'
-import { HelpIcon } from '@/components/icons/help-icon'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -11,21 +10,17 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
 import { useGraph } from '@/providers/graph-provider'
-import { useRouter } from '@/routing/router'
 
 const MENU_ITEM_CLASS = 'gap-2 px-2 py-1.5 text-[13px] text-text-secondary'
 
 /**
- * The sidebar footer, in the original app's idiom (its account nav): the
- * graph's color swatch and name on the left — a dropdown menu for switching
- * to a recent graph or the OS folder picker — and a help button on the right
- * (Settings hosts the keyboard cheat sheet, the closest analog to the old
- * help menu). The swatch pulses while the graph indexes. The menu content
- * matches the trigger width, so it stays inset from the sidebar edges.
+ * The sidebar footer: the graph's color swatch and name on the left — a
+ * dropdown menu for switching to a recent graph or the OS folder picker. The
+ * swatch pulses while the graph indexes. The menu content matches the trigger
+ * width, so it stays inset from the sidebar edges.
  */
 export function GraphFooter({ graph }: { graph: GraphInfo }): ReactElement {
   const { recents, indexing, openRecent, pickAndOpen } = useGraph()
-  const { navigate } = useRouter()
 
   return (
     <div className="flex items-center px-4 py-3">
@@ -84,15 +79,6 @@ export function GraphFooter({ graph }: { graph: GraphInfo }): ReactElement {
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-      <button
-        type="button"
-        aria-label="Help"
-        title="Help"
-        onClick={() => navigate({ kind: 'settings' })}
-        className="flex-none text-text-muted transition-colors duration-100 hover:text-text"
-      >
-        <HelpIcon />
-      </button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Removes the `?` (Help) icon button from the `GraphFooter` component in the sidebar
- Cleans up the now-unused `HelpIcon` import, `useRouter` import, and `navigate` destructure

## Reviewer notes

The button previously navigated to the settings route — settings remains accessible via the nav item in the sidebar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI removal with no auth, data, or routing logic changes beyond dropping one navigation shortcut.
> 
> **Overview**
> Removes the sidebar footer **Help** (`?`) control that previously opened **Settings** via `navigate({ kind: 'settings' })`, along with unused `HelpIcon`, `useRouter`, and `navigate` wiring in `GraphFooter`.
> 
> The footer layout is now only the graph switcher dropdown; the component comment no longer mentions the help button. **Settings** stays available from the main sidebar nav.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd31e624031452f88ca21ca262cd9d2af5764409. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the help button from the sidebar footer. The sidebar now displays only the graph selector with options for switching or opening graphs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->