### PR TITLE
Fix editor gutter lost to cascade layers and edge-flush backlink chevrons

### DIFF
--- a/apps/desktop/src/components/backlink-source-group.tsx
+++ b/apps/desktop/src/components/backlink-source-group.tsx
@@ -60,11 +60,12 @@ export function BacklinkSourceGroup({
             aria-expanded={expanded}
             aria-label={`${expanded ? 'Collapse' : 'Expand'} references from ${source.title}`}
             onClick={() => setExpanded(!expanded)}
-            className={`absolute -left-6 flex items-center text-text-muted opacity-0 transition group-hover:opacity-100 focus-visible:opacity-100 ${
-              expanded ? 'rotate-90' : ''
-            }`}
+            className="absolute inset-y-0 -left-5 flex items-center text-text-muted opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
           >
-            <ChevronRight aria-hidden className="size-4" />
+            <ChevronRight
+              aria-hidden
+              className={`size-4 transition-transform ${expanded ? 'rotate-90' : ''}`}
+            />
           </button>
         ) : null}
       </div>

--- a/apps/desktop/src/components/backlinks-panel.tsx
+++ b/apps/desktop/src/components/backlinks-panel.tsx
@@ -76,9 +76,13 @@ export function BacklinksPanel({ path }: BacklinksPanelProps): ReactElement | nu
           onClick={toggleExpanded}
           className="relative flex w-full items-center text-left"
         >
+          {/* V1 floats the chevron in the note gutter, vertically centered
+              (`inset-y-0 left-[15px]` inside its 40px gutter). The stream
+              gutter bottoms out at 1.5rem, so -left-5 keeps the 16px icon
+              centered there — -left-6 presses it flush against the pane edge. */}
           <ChevronRight
             aria-hidden
-            className={`absolute -left-6 size-4 text-text-muted transition-transform ${
+            className={`absolute inset-y-0 -left-5 my-auto size-4 text-text-muted transition-transform ${
               expanded ? 'rotate-90' : ''
             }`}
           />

--- a/apps/desktop/src/components/daily-stream.tsx
+++ b/apps/desktop/src/components/daily-stream.tsx
@@ -21,8 +21,12 @@ interface DailyStreamProps {
  * Rows and the dividers between them span the pane's full width, and because
  * the editor's share of the gutter is its own padding, clicking anywhere
  * across the row focuses that day's note.
+ *
+ * An ordinary class (styles/index.css), not a `px-*` utility: on the editor it
+ * must out-cascade the un-layered `.reflect-editor` padding reset, which every
+ * `@layer utilities` rule loses to regardless of order.
  */
-const STREAM_GUTTER = 'px-[max(1.5rem,calc((100%-42rem)/2))]'
+const STREAM_GUTTER = 'reflect-stream-gutter'
 
 /**
  * Compensate the scroll position whenever a row **above** the viewport changes

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -194,6 +194,15 @@ body,
   font-family: var(--font-reading, var(--font-sans));
 }
 
+/* The daily stream's horizontal gutter (STREAM_GUTTER in daily-stream.tsx),
+   shared by each row's day label, pane chrome, and the editor itself so they
+   align. An un-layered class — a `px-*` utility sits in `@layer utilities`
+   and would lose to the un-layered `padding: 0` reset above; this rule beats
+   it as the later equal-specificity declaration. Keep it below that reset. */
+.reflect-stream-gutter {
+  padding-inline: max(1.5rem, calc((100% - 42rem) / 2));
+}
+
 /* Block spacing comes from the element margins below, not the theme's
    uniform sibling gap. */
 .reflect-editor > * + * {


### PR DESCRIPTION
## What changed

**Daily-stream editor had no horizontal gutter.** Note content rendered flush against the pane's left edge while the date heading sat correctly indented. The gutter utility `px-[max(1.5rem,calc((100%-42rem)/2))]` is emitted inside Tailwind v4's `@layer utilities`, and un-layered CSS always beats layered CSS — so the un-layered `.reflect-editor { padding: 0 }` reset (required to cancel the meowdown theme's own un-layered `.ProseMirror` padding) silently defeated it on the editor only.

The gutter is now an ordinary un-layered `.reflect-stream-gutter` class in `index.css`, placed directly after the `.reflect-editor` reset so it wins the equal-specificity tie by source order — the same load-order mechanism that file already documents for theme overrides. `STREAM_GUTTER` in `daily-stream.tsx` points at it, so the day label, pane chrome, and editor share one definition and stay aligned by construction. Comments at both sites explain why this must not be converted back to a `px-*` utility.

**Backlink chevrons pressed flush against the pane edge.** Both the "Incoming backlinks (N)" header chevron and the per-source hover chevron used `absolute -left-6` with no vertical centering; at the gutter's 1.5rem minimum the 16px icon touched the pane edge. They now follow V1's treatment (`note-incoming-backlinks` in the V1 codebase: vertically centered via `inset-y-0` + flex centering, glyph optically centered in the gutter): `inset-y-0 -left-5` leaves 4px of edge clearance at the minimum gutter with the glyph at the gutter's midpoint. Positioning stays text-anchored rather than V1's edge-anchored `left-[15px]` because V2's gutter grows to center the 42rem column on wide panes — an edge-pinned chevron would drift away from the header (V1's column was width-capped by an ancestor, so it never hit this). The source-group `rotate-90` also moved onto the square icon instead of the now row-height button.

## Verification

- `pnpm check` (typecheck + lint) passes; `backlinks-panel.test.tsx` passes (9/9).
- Inspected the production CSS bundle: meowdown theme padding → `.reflect-editor` reset → `.reflect-stream-gutter` appear in exactly that cascade order, and the old gutter utility is gone.

## Reviewer notes

The non-obvious constraint here is CSS cascade layers: any un-layered declaration beats any `@layer utilities` declaration regardless of order or specificity. Since both the meowdown theme and our editor overrides are un-layered, padding on the editor element can only be controlled by un-layered rules — hence a real class instead of an arbitrary-value utility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS layout and chevron positioning only; no auth, data, or API changes.
> 
> **Overview**
> **Daily stream editor gutter** — Replaces the Tailwind `px-[max(...)]` utility with an un-layered `.reflect-stream-gutter` rule in `index.css` (after `.reflect-editor { padding: 0 }`) so horizontal padding actually applies on the editor. `STREAM_GUTTER` in `daily-stream.tsx` now references that class so day labels, pane chrome, and editor stay aligned.
> 
> **Backlink chevrons** — Incoming-backlinks header and per-source expand buttons move from `-left-6` to `inset-y-0 -left-5` with vertical centering so the 16px icon sits in the gutter with edge clearance. Per-source `rotate-90` moves from the button to the `ChevronRight` icon; hover uses `transition-opacity` on the button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 978bcef7a8cf43e9277675206699f9b365abcf38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined chevron icon positioning and alignment in the backlinks panel for improved visual consistency.
  * Optimized gutter spacing and centering behavior in the daily stream layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->