### PR TITLE
Shrink lock icon and simplify private toggle labels

### DIFF
--- a/apps/desktop/src/components/context-sidebar/note-actions-section.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-actions-section.test.tsx
@@ -111,46 +111,46 @@ describe('NoteActionsSection pin toggle', () => {
 })
 
 describe('NoteActionsSection private toggle', () => {
-  it('offers Mark this note as private and toggles on click', async () => {
+  it('offers Mark as private and toggles on click', async () => {
     const view = renderSection('notes/a.md')
-    await userEvent.click(view.getByRole('button', { name: /Mark this note as private/ }))
+    await userEvent.click(view.getByRole('button', { name: /Mark as private/ }))
     expect(toggleNotePrivate).toHaveBeenCalledWith('notes/a.md', 7)
     view.unmount()
   })
 
-  it('offers Un-mark this note as private when the index reports the note private', async () => {
+  it('offers Mark as public when the index reports the note private', async () => {
     getNote.mockResolvedValue(noteRow('daily/2026-06-10.md', true))
     const view = renderSection('daily/2026-06-10.md')
-    await view.findByText('Un-mark this note as private')
-    await userEvent.click(view.getByRole('button', { name: /Un-mark this note as private/ }))
+    await view.findByText('Mark as public')
+    await userEvent.click(view.getByRole('button', { name: /Mark as public/ }))
     expect(toggleNotePrivate).toHaveBeenCalledWith('daily/2026-06-10.md', 7)
     view.unmount()
   })
 
   it('flips the label from the toggle result before the index catches up', async () => {
     const view = renderSection('notes/a.md')
-    await userEvent.click(view.getByRole('button', { name: /Mark this note as private/ }))
-    expect(await view.findByText('Un-mark this note as private')).toBeDefined()
+    await userEvent.click(view.getByRole('button', { name: /Mark as private/ }))
+    expect(await view.findByText('Mark as public')).toBeDefined()
     toggleNotePrivate.mockResolvedValueOnce(false)
-    await userEvent.click(view.getByRole('button', { name: /Un-mark this note as private/ }))
-    expect(await view.findByText('Mark this note as private')).toBeDefined()
+    await userEvent.click(view.getByRole('button', { name: /Mark as public/ }))
+    expect(await view.findByText('Mark as private')).toBeDefined()
     expect(toggleNotePrivate).toHaveBeenCalledTimes(2)
     view.unmount()
   })
 
-  it('stays on Mark this note as private for a note the index reports as not private', async () => {
+  it('stays on Mark as private for a note the index reports as not private', async () => {
     getNote.mockResolvedValue(noteRow('notes/a.md', false))
     const view = renderSection('notes/a.md')
     await waitFor(() => expect(getNote).toHaveBeenCalled())
-    expect(view.getByText('Mark this note as private')).toBeDefined()
-    expect(view.queryByText('Un-mark this note as private')).toBeNull()
+    expect(view.getByText('Mark as private')).toBeDefined()
+    expect(view.queryByText('Mark as public')).toBeNull()
     view.unmount()
   })
 
   it('surfaces a toggle failure through the operations status', async () => {
     toggleNotePrivate.mockRejectedValueOnce({ kind: 'io', message: 'disk on fire' })
     const view = renderSection('notes/a.md')
-    await userEvent.click(view.getByRole('button', { name: /Mark this note as private/ }))
+    await userEvent.click(view.getByRole('button', { name: /Mark as private/ }))
     expect(startOperation).toHaveBeenCalledWith('Marking note as private')
     expect(operationFail).toHaveBeenCalled()
     view.unmount()
@@ -160,7 +160,7 @@ describe('NoteActionsSection private toggle', () => {
     getNote.mockResolvedValue(noteRow('notes/a.md', true))
     toggleNotePrivate.mockRejectedValueOnce({ kind: 'io', message: 'disk on fire' })
     const view = renderSection('notes/a.md')
-    await userEvent.click(await view.findByRole('button', { name: /Un-mark this note as private/ }))
+    await userEvent.click(await view.findByRole('button', { name: /Mark as public/ }))
     expect(startOperation).toHaveBeenCalledWith('Un-marking note as private')
     expect(operationFail).toHaveBeenCalled()
     view.unmount()

--- a/apps/desktop/src/components/context-sidebar/note-actions-section.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-actions-section.tsx
@@ -46,10 +46,10 @@ export function NoteActionsSection({ path }: NoteActionsSectionProps): ReactElem
         path={path}
         indexActive={isPrivate}
         toggle={toggleNotePrivate}
-        icon={<Lock size={18} aria-hidden />}
+        icon={<Lock size={14} aria-hidden />}
         labels={{
-          active: 'Un-mark this note as private',
-          inactive: 'Mark this note as private',
+          active: 'Mark as public',
+          inactive: 'Mark as private',
         }}
         operations={{
           activate: 'Marking note as private',


### PR DESCRIPTION
## Summary

- Reduces the `Lock` icon size from 18 → 14 to better match the `PinIcon`'s visual weight in the Note actions sidebar section.
- Simplifies the toggle labels from `"Mark this note as private"` / `"Un-mark this note as private"` to `"Mark as private"` / `"Mark as public"` — shorter and clearer about what each state means.

## Test plan

- [ ] Open the context sidebar on any note — lock icon should appear slightly smaller, on par with the pin icon.
- [ ] With a non-private note: label reads "Mark as private"; clicking toggles it to "Mark as public".
- [ ] With a private note: label reads "Mark as public"; clicking toggles it back to "Mark as private".
- [ ] Unit tests updated and passing (`note-actions-section.test.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and icon sizing only in the context sidebar; toggle behavior and operation messages are unchanged.
> 
> **Overview**
> Tweaks the **Note actions** sidebar private toggle: the lock icon is **14px** (was 18) so it lines up visually with the pin icon, and button copy is shortened to **Mark as private** / **Mark as public** instead of the longer “mark/un-mark this note as private” wording. Operation status strings are unchanged.
> 
> Tests in `note-actions-section.test.tsx` were updated to match the new labels and accessibility names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb8bef9760ff3c034d61299bc2f24b4566a3b50e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined lock icon size in the private note toggle.
  * Improved private note toggle action labels for clarity: "Mark as public" now provides clearer wording for toggling note privacy status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->