### PR TITLE
Stop whole-app rubber-banding by locking the document scroller

### DIFF
--- a/apps/desktop/src/components/graph-chooser.tsx
+++ b/apps/desktop/src/components/graph-chooser.tsx
@@ -10,8 +10,11 @@ export function GraphChooser(): ReactElement {
   const { recents, error, pickAndOpen, openRecent, forget } = useGraph()
 
   return (
-    <div className="flex h-screen w-screen items-center justify-center bg-surface-app p-8">
-      <div className="w-full max-w-sm space-y-6">
+    <div className="flex h-screen w-screen overflow-auto bg-surface-app p-8">
+      {/* Auto margins (not items-center) so the card centers when it fits but
+          scrolls from the top when the recents list outgrows the viewport —
+          flex centering would clip the overflowing top edge. */}
+      <div className="m-auto w-full max-w-sm space-y-6">
         <div className="space-y-1 text-center">
           <h1 className="text-xl font-semibold text-text">Open a graph</h1>
           <p className="text-sm text-text-secondary">

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -154,6 +154,16 @@ body,
   height: 100%;
 }
 
+/* The app frame (AppShell) never scrolls — every route mounts its own scroll
+   container — so the document scroller must never engage. Without this,
+   reaching an inner pane's scroll boundary chains the gesture up to <body>
+   and WKWebView elastically bounces the entire window (macOS rubber-banding). */
+html,
+body {
+  overflow: hidden;
+  overscroll-behavior: none;
+}
+
 /* One keyboard-focus treatment everywhere. Zero-specificity (`:where`) so any
    component rule below — the editor's `outline: none`, the palette input —
    can still opt out. */


### PR DESCRIPTION
## What changed

Locked the root scroller in `apps/desktop/src/styles/index.css`:

```css
html,
body {
  overflow: hidden;
  overscroll-behavior: none;
}
```

## Why

The whole app rubber-banded on macOS trackpad scroll. The `AppShell` clips its own content (`overflow-hidden`), but `<body>` itself was still a live scroll target: when a gesture reached the boundary of an inner pane (daily stream, sidebar, all-notes list), the scroll chained up to the document, and WKWebView responded with its native elastic bounce — bouncing the entire window even though nothing scrolls at that level.

The two properties work together: `overflow: hidden` makes the document non-scrollable, and `overscroll-behavior: none` stops inner scroll containers from chaining boundary overscroll up to it.

## Notes for review

- Every screen is fixed-viewport (`h-screen w-screen`) with its own scroll container — the AppShell doc comment already states "the frame never scrolls" — so nothing depended on document scrolling.
- Inner panes keep their normal scrolling untouched.
- `pnpm check` (typecheck + lint) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only scroll/overscroll behavior and a small chooser layout tweak; no auth, data, or API changes.
> 
> **Overview**
> Stops **whole-window elastic bounce** on macOS by making the document non-scrollable: `html` and `body` now use `overflow: hidden` and `overscroll-behavior: none` so overscroll at inner panes no longer chains to WKWebView’s document scroller.
> 
> On the **no-graph chooser**, layout shifts from flex vertical centering to an outer `overflow-auto` frame with `m-auto` on the card so a long recents list stays reachable (scroll from the top) instead of clipping when content exceeds the viewport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 707f261b6019689439ed40e95afaee1589d87f80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Modified GraphChooser layout to enable scrolling for overflow content
  * Disabled document scrolling and scroll rubber-banding globally

<!-- end of auto-generated comment: release notes by coderabbit.ai -->