### PR TITLE
Match similar-notes item padding to note-actions rows

### DIFF
--- a/apps/desktop/src/components/context-sidebar/similar-notes-section.tsx
+++ b/apps/desktop/src/components/context-sidebar/similar-notes-section.tsx
@@ -35,7 +35,7 @@ export function SimilarNotesSection({ path }: SimilarNotesSectionProps): ReactEl
             <button
               type="button"
               onClick={() => navigate(routeForPath(hit.path))}
-              className="flex w-full cursor-pointer items-center space-x-1 px-4 text-left text-xs"
+              className="flex w-full cursor-pointer items-center space-x-1 rounded-lg px-3 py-2 text-left text-xs transition-colors duration-100 hover:bg-surface-hover"
             >
               <span className="min-w-0 flex-1 truncate">{hit.title}</span>
               <span aria-hidden className="flex-none -scale-x-100">


### PR DESCRIPTION
## What changed

Aligned the row padding in the **Similar notes** sidebar section to match **Note actions**.

Both sections use `SidebarSection`, but the similar-notes buttons only had `px-4` with no vertical padding, while `NoteToggleAction` (used by Note actions) has `px-3 py-2 rounded-lg hover:bg-surface-hover`. This made the visual gap between the section header and the first item look noticeably tighter in Similar notes.

**Before:** `px-4` — no `py`, no rounded corners, no hover background  
**After:** `px-3 py-2 rounded-lg hover:bg-surface-hover transition-colors duration-100` — matches NoteToggleAction exactly

## Why

The two adjacent sidebar sections should feel visually consistent. Using the same padding/shape tokens means both are governed by `SidebarSection`'s shared layout, which was already the intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced "Similar notes" section button styling with improved padding, full-width flex layout configuration, and text alignment adjustments for better visual consistency across the interface
  * Added smooth hover background transition effect to provide enhanced visual feedback and improve overall user interaction experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Tailwind class tweaks on sidebar navigation buttons; no logic, data, or API changes.
> 
> **Overview**
> Updates **Similar notes** sidebar row buttons so their spacing and interaction match **Note actions** (`NoteToggleAction`).
> 
> Horizontal padding shifts from `px-4` to `px-3`, with added `py-2`, `rounded-lg`, and `hover:bg-surface-hover` plus a short `transition-colors` — aligning the gap under the section header and hover affordance with adjacent sidebar rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f79a5b3b80ee9c6bd8270a61ccbab83a9d30f3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->