### PR TITLE
Fix intermittently blank All Notes list (virtualizer never acquired its scroll container)

### DIFF
--- a/apps/desktop/src/components/all-notes/all-notes-screen.test.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactElement } from 'react'
 import { setBridge } from '@reflect/core'
+import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { RouterProvider, useRouter } from '@/routing/router'
 import { AllNotesScreen } from './all-notes-screen'
 
@@ -143,8 +144,9 @@ function ReArrive(): ReactElement {
   )
 }
 
-function renderScreen() {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+function renderScreen(
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+) {
   return render(
     <QueryClientProvider client={client}>
       <RouterProvider initialRoute={{ kind: 'allNotes', tag: null }}>
@@ -208,6 +210,44 @@ describe('AllNotesScreen', () => {
     fireEvent.click(view.getByTestId('re-arrive'))
 
     await waitFor(() => expect(scroller.scrollTop).toBe(0))
+    view.unmount()
+  })
+
+  it('renders rows from a warm cache without waiting for a refetch', () => {
+    // The app client uses staleTime: Infinity, so returning to All Notes with
+    // fresh cached data commits exactly one render — no fetch, no follow-up.
+    // The virtualizer must acquire the scroll container on that lone render
+    // (regression: it read a parent ref that attaches after its layout
+    // effect, leaving the list blank until something else re-rendered).
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    })
+    client.setQueryData(
+      [INDEX_QUERY_SCOPE, '/g', 'all-notes', null],
+      [
+        {
+          path: 'notes/health.md',
+          title: 'Health Stacked',
+          snippet: 'Shop your health goals.',
+          tags: ['link'],
+          mtime: HEALTH_MTIME,
+        },
+        {
+          path: 'notes/tokyo.md',
+          title: 'Tokyo Gâteau',
+          snippet: 'Dandelion chocolate.',
+          tags: ['link'],
+          mtime: TOKYO_MTIME,
+        },
+      ],
+    )
+    client.setQueryData([INDEX_QUERY_SCOPE, '/g', 'all-notes-tags'], facetRows)
+
+    const view = renderScreen(client)
+
+    // Deliberately synchronous: the rows must be in the first committed frame.
+    expect(view.getByText('Health Stacked')).toBeDefined()
+    expect(view.getByText('Tokyo Gâteau')).toBeDefined()
     view.unmount()
   })
 

--- a/apps/desktop/src/components/all-notes/all-notes-screen.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ReactElement } from 'react'
+import { useEffect, useState, type ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { foldTag, hasBridge, listNotes, listNoteTags } from '@reflect/core'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
@@ -27,7 +27,14 @@ interface AllNotesScreenProps {
 export function AllNotesScreen({ tag }: AllNotesScreenProps): ReactElement {
   const { graph } = useGraph()
   const { arrivalSeq, entryId, navigate, saveScrollState, savedScroll } = useRouter()
-  const scrollRef = useRef<HTMLDivElement | null>(null)
+  // The scroll container lives in state, not a ref: the virtualizer down in
+  // AllNotesTable reads it via getScrollElement, and a plain ref would be null
+  // during the table's mount-time layout effect (refs on ancestor DOM nodes
+  // attach after a child component's effects). With a warm query cache that
+  // mount is the only render, so the virtualizer would never acquire the
+  // element and the list would stay blank. State forces the post-attach
+  // re-render that hands the element over.
+  const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null)
   const enabled = hasBridge() && graph !== null
 
   const { data: notes } = useQuery({
@@ -50,10 +57,10 @@ export function AllNotesScreen({ tag }: AllNotesScreenProps): ReactElement {
   // and lose the position.
   const ready = notes !== undefined
   useEffect(() => {
-    if (ready && scrollRef.current) {
-      scrollRef.current.scrollTop = savedScroll() ?? 0
+    if (ready && scrollElement) {
+      scrollElement.scrollTop = savedScroll() ?? 0
     }
-  }, [arrivalSeq, entryId, ready, savedScroll])
+  }, [arrivalSeq, entryId, ready, savedScroll, scrollElement])
 
   return (
     <div aria-label="All notes" className="flex h-full min-h-0 flex-col">
@@ -69,7 +76,7 @@ export function AllNotesScreen({ tag }: AllNotesScreenProps): ReactElement {
         </div>
       </header>
       <div
-        ref={scrollRef}
+        ref={setScrollElement}
         data-testid="all-notes-scroll"
         onScroll={(event) => saveScrollState(event.currentTarget.scrollTop)}
         className="min-h-0 flex-1 overflow-auto"
@@ -78,7 +85,7 @@ export function AllNotesScreen({ tag }: AllNotesScreenProps): ReactElement {
           notes={notes}
           tag={tag}
           onOpen={(path) => navigate(routeForPath(path))}
-          scrollRef={scrollRef}
+          scrollElement={scrollElement}
         />
       </div>
     </div>

--- a/apps/desktop/src/components/all-notes/all-notes-table.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-table.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement, RefObject } from 'react'
+import type { ReactElement } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import type { NoteListEntry } from '@reflect/core'
 import { cn } from '@/lib/utils'
@@ -10,8 +10,13 @@ interface AllNotesTableProps {
   /** The active tag filter, for the empty state's wording. */
   tag: string | null
   onOpen: (path: string) => void
-  /** The screen's scroll container — the virtualizer windows against it. */
-  scrollRef: RefObject<HTMLDivElement | null>
+  /**
+   * The screen's scroll container — the virtualizer windows against it. An
+   * element (state in the screen), not a ref: the virtualizer only re-checks
+   * its scroll element on render, so it must re-render when the container
+   * attaches or a warm-cache mount leaves it permanently unmeasured (blank).
+   */
+  scrollElement: HTMLDivElement | null
 }
 
 const ESTIMATED_ROW_HEIGHT = 49
@@ -26,12 +31,12 @@ export function AllNotesTable({
   notes,
   tag,
   onOpen,
-  scrollRef,
+  scrollElement,
 }: AllNotesTableProps): ReactElement | null {
   const rows = notes ?? []
   const virtualizer = useVirtualizer({
     count: rows.length,
-    getScrollElement: () => scrollRef.current,
+    getScrollElement: () => scrollElement,
     estimateSize: () => ESTIMATED_ROW_HEIGHT,
     overscan: 10,
   })


### PR DESCRIPTION
## What

Navigating to All Notes fairly often rendered a blank list — table header visible, no rows, no "No notes yet." empty state — until you clicked **All notes** again. The notes data was loaded the whole time; the virtualizer was rendering zero rows.

## Why

`AllNotesTable`'s `useVirtualizer` read the scroll container from a `RefObject` owned by `AllNotesScreen`. React attaches refs on ancestor DOM nodes *after* a child component's layout effects run, so during the table's mount `getScrollElement()` returned `null` — and TanStack Virtual only re-checks its scroll element on a subsequent render (`_willUpdate`). With no viewport, `calculateRange` returns `null` and `getVirtualItems()` is empty.

Normally the async notes query forces a second render and hides this. But the app's query client uses `staleTime: Infinity`, so arriving with a warm cache commits **exactly one render** — the virtualizer never acquires the element and the list stays blank. Clicking "All notes" again bumps `arrivalSeq`, re-rendering the screen, which is why the rows then appeared. That's also why it was intermittent: it only struck when no index invalidation had happened since the last fetch.

Reproduced the failure in a minimal browser harness mirroring this component structure (0 rows, `scrollElement: null`, StrictMode included) and confirmed the state-based wiring renders rows on every variant.

## How

The canonical TanStack pattern for a parent-owned scroll container: hold the element in `useState` (`ref={setScrollElement}`) and pass it down as `scrollElement: HTMLDivElement | null`. Attaching the element triggers the post-attach re-render the virtualizer needs. The scroll-restore effect now also gates on the element being attached.

`DailyStream`'s virtualizer keeps its ref in the same component that renders the div, which is not affected by this ordering.

## Reviewer notes

- The new regression test seeds a warm query cache (`staleTime: Infinity`, matching the app client) and asserts rows **synchronously** on the first committed frame — it fails against the previous ref wiring and passes now.
- `pnpm check` clean; all 9 tests in `all-notes-screen.test.tsx` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI fix to scroll wiring and virtualization on All Notes; regression test added, no auth or data-layer changes.
> 
> **Overview**
> Fixes an intermittent **blank All Notes list** when notes are already in the React Query cache (`staleTime: Infinity`): a single render left TanStack Virtual with no scroll viewport because the parent’s `RefObject` was still `null` during the table’s mount/layout effects.
> 
> **All Notes** now keeps the scroll container in **`useState`** via `ref={setScrollElement}` and passes `scrollElement` into `AllNotesTable` instead of a ref. That post-attach re-render lets `getScrollElement` see the real DOM node; scroll restore also waits on `scrollElement` being set.
> 
> Adds a **regression test** that seeds warm query data and asserts note rows appear **synchronously** on the first frame (and allows injecting a `QueryClient` in `renderScreen`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b31086af59a9c8141beb543eeadd555c2c5d396. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->