### PR TITLE
Replace HTML title attributes with shadcn Tooltip

### DIFF
--- a/apps/desktop/src/components/context-sidebar/daily-context-sidebar.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/daily-context-sidebar.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { formatDayLabel } from '@/lib/dates'
 import { monthLabel, monthOf } from '@/lib/month-grid'
 import { RouterProvider, useRouter } from '@/routing/router'
@@ -34,12 +35,14 @@ function RouteProbe(): ReactNode {
 function renderSidebar(date: string) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
-    <QueryClientProvider client={client}>
-      <RouterProvider>
-        <DailyContextSidebar date={date} />
-        <RouteProbe />
-      </RouterProvider>
-    </QueryClientProvider>,
+    <TooltipProvider>
+      <QueryClientProvider client={client}>
+        <RouterProvider>
+          <DailyContextSidebar date={date} />
+          <RouteProbe />
+        </RouterProvider>
+      </QueryClientProvider>
+    </TooltipProvider>,
   )
 }
 
@@ -87,14 +90,16 @@ describe('DailyContextSidebar calendar', () => {
     const view = renderSidebar('2026-06-09')
     expect(view.getByText(monthLabel('2026-06'))).toBeDefined()
     view.rerender(
-      <QueryClientProvider
-        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
-      >
-        <RouterProvider>
-          <DailyContextSidebar date="2026-09-01" />
-          <RouteProbe />
-        </RouterProvider>
-      </QueryClientProvider>,
+      <TooltipProvider>
+        <QueryClientProvider
+          client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+        >
+          <RouterProvider>
+            <DailyContextSidebar date="2026-09-01" />
+            <RouteProbe />
+          </RouterProvider>
+        </QueryClientProvider>
+      </TooltipProvider>,
     )
     expect(view.getByText(monthLabel('2026-09'))).toBeDefined()
     view.unmount()

--- a/apps/desktop/src/components/context-sidebar/day-calendar.tsx
+++ b/apps/desktop/src/components/context-sidebar/day-calendar.tsx
@@ -4,9 +4,10 @@ import { dailyDatesInRange, hasBridge, type WeekStartDay } from '@reflect/core'
 import { CalendarIcon } from '@/components/icons/calendar-icon'
 import { ChevronLeftIcon } from '@/components/icons/chevron-left-icon'
 import { ChevronRightIcon } from '@/components/icons/chevron-right-icon'
+import { ShortcutKeys } from '@/components/shortcut-keys'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { keybindingFor } from '@/lib/commands/app-commands'
 import { formatDayLabel } from '@/lib/dates'
-import { formatBindingLabel } from '@/lib/keybindings'
 import {
   addMonths,
   buildMonthGrid,
@@ -33,10 +34,6 @@ function toWeekStartsOn(weekStartDay: WeekStartDay): 0 | 1 {
 }
 
 const TODAY_BINDING = keybindingFor('nav.today')
-const TODAY_TITLE =
-  TODAY_BINDING !== null
-    ? `Jump to Today (${formatBindingLabel(TODAY_BINDING)})`
-    : 'Jump to Today'
 
 const HEADER_BUTTON_CLASS =
   'cursor-default rounded-md transition-colors duration-100 hover:bg-surface-hover hover:text-text'
@@ -91,15 +88,21 @@ export function DayCalendar({ selectedDate, today }: DayCalendarProps): ReactEle
           >
             <ChevronLeftIcon />
           </button>
-          <button
-            type="button"
-            aria-label="Jump to today"
-            title={TODAY_TITLE}
-            onClick={() => navigate({ kind: 'today' })}
-            className={HEADER_BUTTON_CLASS}
-          >
-            <CalendarIcon />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="Jump to today"
+                onClick={() => navigate({ kind: 'today' })}
+                className={HEADER_BUTTON_CLASS}
+              >
+                <CalendarIcon />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Jump to Today {TODAY_BINDING && <ShortcutKeys binding={TODAY_BINDING} />}
+            </TooltipContent>
+          </Tooltip>
           <button
             type="button"
             aria-label="Next month"

--- a/apps/desktop/src/components/context-sidebar/note-actions-section.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-actions-section.test.tsx
@@ -2,6 +2,7 @@ import { render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { NoteActionsSection } from './note-actions-section'
 
 const getPinnedNotes = vi.hoisted(() => vi.fn())
@@ -28,9 +29,11 @@ vi.mock('@/providers/graph-provider', () => ({
 function renderSection(path: string) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
-    <QueryClientProvider client={client}>
-      <NoteActionsSection path={path} />
-    </QueryClientProvider>,
+    <TooltipProvider>
+      <QueryClientProvider client={client}>
+        <NoteActionsSection path={path} />
+      </QueryClientProvider>
+    </TooltipProvider>,
   )
 }
 

--- a/apps/desktop/src/components/context-sidebar/note-context-sidebar.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-context-sidebar.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { RouterProvider, useRouter } from '@/routing/router'
 import { NoteContextSidebar } from './note-context-sidebar'
 
@@ -30,12 +31,14 @@ function RouteProbe(): ReactNode {
 function renderSidebar(path: string) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
-    <QueryClientProvider client={client}>
-      <RouterProvider>
-        <NoteContextSidebar path={path} />
-        <RouteProbe />
-      </RouterProvider>
-    </QueryClientProvider>,
+    <TooltipProvider>
+      <QueryClientProvider client={client}>
+        <RouterProvider>
+          <NoteContextSidebar path={path} />
+          <RouteProbe />
+        </RouterProvider>
+      </QueryClientProvider>
+    </TooltipProvider>,
   )
 }
 

--- a/apps/desktop/src/components/context-sidebar/note-toggle-action.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-toggle-action.tsx
@@ -1,6 +1,7 @@
 import { useState, type ReactElement, type ReactNode } from 'react'
 import { errorMessage } from '@reflect/core'
 import { ShortcutKeys } from '@/components/shortcut-keys'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { startOperation } from '@/lib/operations'
 import { cn } from '@/lib/utils'
 import { useGraph } from '@/providers/graph-provider'
@@ -20,7 +21,7 @@ interface NoteToggleActionProps {
   operations: { activate: string; deactivate: string }
   /** Keybinding hint, from the matching command definition. */
   keybinding?: string | null
-  /** Optional native tooltip explaining the flag's meaning. */
+  /** Optional tooltip explaining the flag's meaning. */
   tooltip?: string
 }
 
@@ -82,12 +83,11 @@ export function NoteToggleAction({
     }
   }
 
-  return (
+  const button = (
     <button
       type="button"
       onClick={() => void onToggle()}
       disabled={isToggling}
-      title={tooltip}
       className="group relative flex w-full items-center space-x-2 rounded-lg px-3 py-2 text-start transition-colors duration-100 hover:bg-surface-hover disabled:opacity-50"
     >
       <span
@@ -105,5 +105,16 @@ export function NoteToggleAction({
         <ShortcutKeys binding={keybinding} className="invisible group-hover:visible" />
       ) : null}
     </button>
+  )
+
+  if (!tooltip) {
+    return button
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
   )
 }

--- a/apps/desktop/src/components/sidebar/graph-footer.tsx
+++ b/apps/desktop/src/components/sidebar/graph-footer.tsx
@@ -57,20 +57,24 @@ export function GraphFooter({ graph }: { graph: GraphInfo }): ReactElement {
           {recents.map((recent) => {
             const current = recent.root === graph.root
             return (
-              <DropdownMenuItem
-                key={recent.root}
-                onSelect={() => {
-                  if (!current) {
-                    void openRecent(recent.root)
-                  }
-                }}
-                className={MENU_ITEM_CLASS}
-              >
-                <span className="min-w-0 flex-1 truncate">{recent.name}</span>
-                {current ? (
-                  <Check aria-hidden className="size-3.5 shrink-0 text-accent" />
-                ) : null}
-              </DropdownMenuItem>
+              <Tooltip key={recent.root} delayDuration={700}>
+                <TooltipTrigger asChild>
+                  <DropdownMenuItem
+                    onSelect={() => {
+                      if (!current) {
+                        void openRecent(recent.root)
+                      }
+                    }}
+                    className={MENU_ITEM_CLASS}
+                  >
+                    <span className="min-w-0 flex-1 truncate">{recent.name}</span>
+                    {current ? (
+                      <Check aria-hidden className="size-3.5 shrink-0 text-accent" />
+                    ) : null}
+                  </DropdownMenuItem>
+                </TooltipTrigger>
+                <TooltipContent side="right">{recent.root}</TooltipContent>
+              </Tooltip>
             )
           })}
           {recents.length > 0 ? <DropdownMenuSeparator /> : null}

--- a/apps/desktop/src/components/sidebar/graph-footer.tsx
+++ b/apps/desktop/src/components/sidebar/graph-footer.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { useGraph } from '@/providers/graph-provider'
 
@@ -25,36 +26,39 @@ export function GraphFooter({ graph }: { graph: GraphInfo }): ReactElement {
   return (
     <div className="flex items-center px-4 py-3">
       <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            title={graph.root}
-            className="flex min-w-0 flex-1 items-center space-x-2.5 text-left"
-          >
-            <span
-              aria-hidden
-              className={cn(
-                'h-5 w-5 flex-none rounded-md bg-accent',
-                indexing && 'motion-safe:animate-pulse',
-              )}
-            />
-            <span className="min-w-0 truncate text-xs font-medium text-text">
-              {graph.name}
-            </span>
-            {indexing ? (
-              <span role="status" className="sr-only">
-                Indexing
-              </span>
-            ) : null}
-          </button>
-        </DropdownMenuTrigger>
+        <Tooltip delayDuration={700}>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="flex min-w-0 flex-1 items-center space-x-2.5 text-left"
+              >
+                <span
+                  aria-hidden
+                  className={cn(
+                    'h-5 w-5 flex-none rounded-md bg-accent',
+                    indexing && 'motion-safe:animate-pulse',
+                  )}
+                />
+                <span className="min-w-0 truncate text-xs font-medium text-text">
+                  {graph.name}
+                </span>
+                {indexing ? (
+                  <span role="status" className="sr-only">
+                    Indexing
+                  </span>
+                ) : null}
+              </button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>{graph.root}</TooltipContent>
+        </Tooltip>
         <DropdownMenuContent aria-label="Switch graph" side="top" sideOffset={6}>
           {recents.map((recent) => {
             const current = recent.root === graph.root
             return (
               <DropdownMenuItem
                 key={recent.root}
-                title={recent.root}
                 onSelect={() => {
                   if (!current) {
                     void openRecent(recent.root)

--- a/apps/desktop/src/components/sidebar/navigate-arrows.tsx
+++ b/apps/desktop/src/components/sidebar/navigate-arrows.tsx
@@ -1,15 +1,17 @@
 import type { ReactElement } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { ShortcutKeys } from '@/components/shortcut-keys'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { keybindingFor } from '@/lib/commands/app-commands'
-import { formatBindingLabel } from '@/lib/keybindings'
 import { useRouter } from '@/routing/router'
 
 const BACK_BINDING = keybindingFor('history.back')
 const FORWARD_BINDING = keybindingFor('history.forward')
 
-function buttonTitle(label: string, binding: string | null): string {
-  return binding !== null ? `${label} (${formatBindingLabel(binding)})` : label
-}
+const BUTTON_CLASS =
+  'rounded-md p-1 text-text-muted transition-colors duration-100 ' +
+  'hover:bg-surface-hover hover:text-text disabled:opacity-50 ' +
+  'disabled:hover:bg-transparent disabled:hover:text-text-muted'
 
 /**
  * The sidebar's back/forward history arrows (the original app's
@@ -19,11 +21,6 @@ function buttonTitle(label: string, binding: string | null): string {
 export function NavigateArrows(): ReactElement {
   const { back, forward, canBack, canForward } = useRouter()
 
-  const buttonClass =
-    'rounded-md p-1 text-text-muted transition-colors duration-100 ' +
-    'hover:bg-surface-hover hover:text-text disabled:opacity-50 ' +
-    'disabled:hover:bg-transparent disabled:hover:text-text-muted'
-
   return (
     // The arrows sit inside the overlaid macOS title-bar band, where the
     // WindowDragRegion strip (z-40, mounted before the app) would otherwise
@@ -31,26 +28,38 @@ export function NavigateArrows(): ReactElement {
     // buttons above it by tree order while same-z overlays mounted later
     // (the command palette) still cover them.
     <div className="relative z-40 flex items-center">
-      <button
-        type="button"
-        aria-label="Go back"
-        title={buttonTitle('Go back', BACK_BINDING)}
-        disabled={!canBack}
-        onClick={back}
-        className={buttonClass}
-      >
-        <ChevronLeft aria-hidden className="size-4" />
-      </button>
-      <button
-        type="button"
-        aria-label="Go forward"
-        title={buttonTitle('Go forward', FORWARD_BINDING)}
-        disabled={!canForward}
-        onClick={forward}
-        className={buttonClass}
-      >
-        <ChevronRight aria-hidden className="size-4" />
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label="Go back"
+            disabled={!canBack}
+            onClick={back}
+            className={BUTTON_CLASS}
+          >
+            <ChevronLeft aria-hidden className="size-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>
+          Go back {BACK_BINDING && <ShortcutKeys binding={BACK_BINDING} />}
+        </TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label="Go forward"
+            disabled={!canForward}
+            onClick={forward}
+            className={BUTTON_CLASS}
+          >
+            <ChevronRight aria-hidden className="size-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>
+          Go forward {FORWARD_BINDING && <ShortcutKeys binding={FORWARD_BINDING} />}
+        </TooltipContent>
+      </Tooltip>
     </div>
   )
 }

--- a/apps/desktop/src/components/sidebar/navigate-arrows.tsx
+++ b/apps/desktop/src/components/sidebar/navigate-arrows.tsx
@@ -29,16 +29,20 @@ export function NavigateArrows(): ReactElement {
     // (the command palette) still cover them.
     <div className="relative z-40 flex items-center">
       <Tooltip>
+        {/* Span wrapper keeps pointer events alive when the button is disabled,
+            so the tooltip still opens at the start of the history stack. */}
         <TooltipTrigger asChild>
-          <button
-            type="button"
-            aria-label="Go back"
-            disabled={!canBack}
-            onClick={back}
-            className={BUTTON_CLASS}
-          >
-            <ChevronLeft aria-hidden className="size-4" />
-          </button>
+          <span>
+            <button
+              type="button"
+              aria-label="Go back"
+              disabled={!canBack}
+              onClick={back}
+              className={BUTTON_CLASS}
+            >
+              <ChevronLeft aria-hidden className="size-4" />
+            </button>
+          </span>
         </TooltipTrigger>
         <TooltipContent>
           Go back {BACK_BINDING && <ShortcutKeys binding={BACK_BINDING} />}
@@ -46,15 +50,17 @@ export function NavigateArrows(): ReactElement {
       </Tooltip>
       <Tooltip>
         <TooltipTrigger asChild>
-          <button
-            type="button"
-            aria-label="Go forward"
-            disabled={!canForward}
-            onClick={forward}
-            className={BUTTON_CLASS}
-          >
-            <ChevronRight aria-hidden className="size-4" />
-          </button>
+          <span>
+            <button
+              type="button"
+              aria-label="Go forward"
+              disabled={!canForward}
+              onClick={forward}
+              className={BUTTON_CLASS}
+            >
+              <ChevronRight aria-hidden className="size-4" />
+            </button>
+          </span>
         </TooltipTrigger>
         <TooltipContent>
           Go forward {FORWARD_BINDING && <ShortcutKeys binding={FORWARD_BINDING} />}

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { GraphInfo, PinnedNote } from '@reflect/core'
 import type { CommandContext } from '@/lib/commands/types'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { RouterProvider } from '@/routing/router'
 
 const getPinnedNotes = vi.hoisted(() => vi.fn<() => Promise<PinnedNote[]>>(async () => []))
@@ -60,11 +61,13 @@ function renderSidebar(overrides?: Partial<CommandContext>) {
   }
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   const view = render(
-    <QueryClientProvider client={client}>
-      <RouterProvider>
-        <Sidebar graph={GRAPH} context={context} />
-      </RouterProvider>
-    </QueryClientProvider>,
+    <TooltipProvider>
+      <QueryClientProvider client={client}>
+        <RouterProvider>
+          <Sidebar graph={GRAPH} context={context} />
+        </RouterProvider>
+      </QueryClientProvider>
+    </TooltipProvider>,
   )
   return { view, navigate, openPalette, context }
 }

--- a/apps/desktop/src/components/ui/tooltip.tsx
+++ b/apps/desktop/src/components/ui/tooltip.tsx
@@ -1,0 +1,51 @@
+import * as React from "react"
+import { Tooltip as TooltipPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 400,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 6,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 flex items-center gap-2 origin-(--radix-tooltip-content-transform-origin) rounded-md bg-popover px-2.5 py-1.5 text-xs text-popover-foreground shadow-md ring-1 ring-foreground/10 animate-in fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className,
+        )}
+        {...props}
+      />
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger }

--- a/apps/desktop/src/components/workspace-content.tsx
+++ b/apps/desktop/src/components/workspace-content.tsx
@@ -11,15 +11,20 @@ import {
   type ContextSidebarTarget,
 } from '@/components/context-sidebar/sidebar-route'
 import { EmbeddingsSync } from '@/components/embeddings-sync'
+import { ShortcutKeys } from '@/components/shortcut-keys'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { OperationsStatus } from '@/components/operations-status'
 import { RouteContent } from '@/components/route-content'
 import { Sidebar } from '@/components/sidebar/sidebar'
+import { keybindingFor } from '@/lib/commands/app-commands'
 import { useToday } from '@/lib/use-today'
 import { cn } from '@/lib/utils'
 import { hasMacosTitleBarOverlay } from '@/lib/window-chrome'
 import { useSidebar } from '@/providers/sidebar-provider'
 import { useAppShortcuts } from '@/routing/app-shortcuts'
 import { useRouter } from '@/routing/router'
+
+const TOGGLE_SIDEBAR_BINDING = keybindingFor('sidebar.toggle')
 
 interface WorkspaceContentProps {
   graph: GraphInfo
@@ -61,20 +66,27 @@ export function WorkspaceContent({ graph }: WorkspaceContentProps): ReactElement
     >
       <div className="relative flex h-full flex-col">
         {collapsed ? (
-          <button
-            type="button"
-            aria-label="Show sidebar"
-            title="Show sidebar"
-            onClick={() => commandContext.toggleSidebar()}
-            className={cn(
-              'absolute left-3 z-10 rounded-md p-1 text-text-muted transition-colors duration-100 hover:bg-surface-hover hover:text-text-secondary',
-              // Clear the overlaid macOS title bar: the traffic lights float
-              // exactly where this button otherwise sits.
-              hasMacosTitleBarOverlay ? 'top-9' : 'top-2.5',
-            )}
-          >
-            <PanelLeft aria-hidden strokeWidth={1.75} className="size-4" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="Show sidebar"
+                onClick={() => commandContext.toggleSidebar()}
+                className={cn(
+                  'absolute left-3 z-10 rounded-md p-1 text-text-muted transition-colors duration-100 hover:bg-surface-hover hover:text-text-secondary',
+                  // Clear the overlaid macOS title bar: the traffic lights float
+                  // exactly where this button otherwise sits.
+                  hasMacosTitleBarOverlay ? 'top-9' : 'top-2.5',
+                )}
+              >
+                <PanelLeft aria-hidden strokeWidth={1.75} className="size-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Show sidebar{' '}
+              {TOGGLE_SIDEBAR_BINDING && <ShortcutKeys binding={TOGGLE_SIDEBAR_BINDING} />}
+            </TooltipContent>
+          </Tooltip>
         ) : null}
 
         {graph.cloudSync ? <CloudSyncBanner provider={graph.cloudSync} /> : null}

--- a/apps/desktop/src/components/workspace-header.test.tsx
+++ b/apps/desktop/src/components/workspace-header.test.tsx
@@ -1,22 +1,25 @@
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { WorkspaceHeader } from './workspace-header'
 
 function renderHeader(overrides: Partial<Parameters<typeof WorkspaceHeader>[0]> = {}) {
   const onToggleTheme = vi.fn()
   const onOpenSettings = vi.fn()
   const view = render(
-    <WorkspaceHeader
-      graphName="My Graph"
-      graphRoot="/graphs/mine"
-      indexing={false}
-      version="1.2.3"
-      resolvedTheme="light"
-      onToggleTheme={onToggleTheme}
-      onOpenSettings={onOpenSettings}
-      {...overrides}
-    />,
+    <TooltipProvider>
+      <WorkspaceHeader
+        graphName="My Graph"
+        graphRoot="/graphs/mine"
+        indexing={false}
+        version="1.2.3"
+        resolvedTheme="light"
+        onToggleTheme={onToggleTheme}
+        onOpenSettings={onOpenSettings}
+        {...overrides}
+      />
+    </TooltipProvider>,
   )
   return { view, onToggleTheme, onOpenSettings }
 }
@@ -24,7 +27,7 @@ function renderHeader(overrides: Partial<Parameters<typeof WorkspaceHeader>[0]> 
 describe('WorkspaceHeader', () => {
   it('shows the graph name (root as tooltip) and version', () => {
     const { view } = renderHeader()
-    expect(view.getByTitle('/graphs/mine').textContent).toBe('My Graph')
+    expect(view.getByRole('heading', { level: 1 }).textContent).toBe('My Graph')
     expect(view.getByText('v1.2.3')).toBeTruthy()
     expect(view.queryByRole('status')).toBeNull()
     view.unmount()

--- a/apps/desktop/src/components/workspace-header.tsx
+++ b/apps/desktop/src/components/workspace-header.tsx
@@ -1,11 +1,16 @@
 import type { ReactElement } from 'react'
 import { Settings } from 'lucide-react'
+import { ShortcutKeys } from '@/components/shortcut-keys'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { keybindingFor } from '@/lib/commands/app-commands'
 import type { ResolvedTheme } from '@/providers/theme-provider'
+
+const SETTINGS_BINDING = keybindingFor('settings.open')
 
 interface WorkspaceHeaderProps {
   /** Display name of the open graph. */
   graphName: string
-  /** Absolute root path (shown as the title tooltip). */
+  /** Absolute root path (shown as a tooltip when the name is truncated). */
   graphRoot: string
   /** True while the background index reconcile is running. */
   indexing: boolean
@@ -32,9 +37,12 @@ export function WorkspaceHeader({
 }: WorkspaceHeaderProps): ReactElement {
   return (
     <header className="flex items-center justify-between gap-4 border-b border-black/10 px-6 py-3 dark:border-white/10">
-      <h1 className="truncate text-sm font-semibold" title={graphRoot}>
-        {graphName}
-      </h1>
+      <Tooltip delayDuration={700}>
+        <TooltipTrigger asChild>
+          <h1 className="truncate text-sm font-semibold">{graphName}</h1>
+        </TooltipTrigger>
+        <TooltipContent>{graphRoot}</TooltipContent>
+      </Tooltip>
       <div className="flex items-center gap-3">
         {indexing ? (
           <span
@@ -52,15 +60,21 @@ export function WorkspaceHeader({
         >
           {resolvedTheme === 'dark' ? 'Light' : 'Dark'} mode
         </button>
-        <button
-          type="button"
-          aria-label="Open settings"
-          title="Settings (⌘,)"
-          onClick={onOpenSettings}
-          className="rounded-md border border-black/10 p-1.5 text-[color:var(--text-secondary)] dark:border-white/10"
-        >
-          <Settings aria-hidden className="size-3.5" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label="Open settings"
+              onClick={onOpenSettings}
+              className="rounded-md border border-black/10 p-1.5 text-[color:var(--text-secondary)] dark:border-white/10"
+            >
+              <Settings aria-hidden className="size-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            Settings {SETTINGS_BINDING && <ShortcutKeys binding={SETTINGS_BINDING} />}
+          </TooltipContent>
+        </Tooltip>
       </div>
     </header>
   )

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { App } from '@/app'
 import { WindowDragRegion } from '@/components/window-drag-region'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { queryClient } from '@/lib/query-client'
 import { registerAppCommands } from '@/lib/commands/app-commands'
 import { installTauriBridge } from '@/lib/tauri-bridge'
@@ -25,8 +26,10 @@ createRoot(rootElement).render(
       <SettingsProvider>
         <ThemeProvider>
           <GraphProvider>
-            <WindowDragRegion />
-            <App />
+            <TooltipProvider>
+              <WindowDragRegion />
+              <App />
+            </TooltipProvider>
           </GraphProvider>
         </ThemeProvider>
       </SettingsProvider>


### PR DESCRIPTION
## Summary

- Adds `components/ui/tooltip.tsx` — a shadcn-style `Tooltip` / `TooltipTrigger` / `TooltipContent` / `TooltipProvider` backed by `@radix-ui/react-tooltip` (already in the lockfile via radix-ui monorepo)
- Mounts `<TooltipProvider>` once in `main.tsx`, above `<App>`
- Migrates all 9 desktop-app `title=` usages to the new component; removes the no-op `title` from `DropdownMenuItem` in `graph-footer`

## Why

Native `title` tooltips have three concrete problems here:

1. **Can't show formatted shortcut keys** — back/forward, settings, show-sidebar, and jump-to-today all embed keyboard bindings as plain strings; `ShortcutKeys` chips couldn't be used inside a `title`
2. **Unstyled and OS-themed** — doesn't match the design system
3. **Touch-only devices get nothing** — hover-only, which matters for the iOS target

## What changed per file

| File | Change |
|------|--------|
| `components/ui/tooltip.tsx` | New shadcn component; `delayDuration` defaults to 400ms |
| `main.tsx` | `<TooltipProvider>` wrapping `<App>` |
| `navigate-arrows.tsx` | Removed `buttonTitle()` helper; each arrow has a Tooltip with `ShortcutKeys` |
| `workspace-header.tsx` | `<h1>` overflow path tooltip (700ms delay); settings button with `ShortcutKeys` |
| `workspace-content.tsx` | Show-sidebar button tooltip with `ShortcutKeys` for the toggle binding |
| `day-calendar.tsx` | Today button tooltip; removed `TODAY_TITLE` constant and `formatBindingLabel` import |
| `note-toggle-action.tsx` | Wraps button in `<Tooltip>` when `tooltip` prop is present; no API change for callers |
| `graph-footer.tsx` | Dropdown trigger gets a path tooltip (700ms); `title` dropped from `DropdownMenuItem` |

## Reviewer notes

- `TooltipTrigger asChild` + `DropdownMenuTrigger asChild` chaining in `graph-footer` is the [supported Radix pattern](https://www.radix-ui.com/primitives/docs/guides/composition) for composing primitives — both just merge props/event listeners onto the underlying `<button>`
- Path overflow tooltips use `delayDuration={700}` to feel closer to native title behavior; action-button tooltips use the 400ms default
- `design-system/IconButton.jsx` retains its `title={label}` as a fallback for non-desktop contexts; any desktop-app usage can wrap it in a `<Tooltip>` at the call site if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only tooltip migration with no auth, data, or routing logic changes; main review surface is Radix composition (e.g. tooltip + dropdown triggers) and test provider wiring.
> 
> **Overview**
> Introduces a shadcn-style **Radix tooltip** layer (`TooltipProvider`, `Tooltip`, `TooltipTrigger`, `TooltipContent`) and mounts **`TooltipProvider` once** in `main.tsx` so the whole desktop app can use it.
> 
> **Replaces native `title` tooltips** across the workspace with styled tooltips that can embed **`ShortcutKeys`** for command hints: history back/forward, settings, show sidebar, jump to today, and similar. Path overflow hints (graph name / root in **workspace header** and **graph footer**, including recent-graph menu rows) use tooltips with a **700ms** delay instead of `title`; action buttons keep the default **400ms**.
> 
> **`note-toggle-action`** drops `title` on the button and wraps it in a tooltip only when the optional `tooltip` prop is set. **`formatBindingLabel` / `buttonTitle` helpers** are removed where shortcuts now render as chips in tooltip content.
> 
> Tests that render components using tooltips wrap trees in **`TooltipProvider`**; **workspace-header** tests assert the graph name via heading role instead of `getByTitle`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2140b43725102d0ed48f25bcbe41382512e45f4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->