### PR TITLE
Fix epoch-zero mtimes on watcher-indexed notes

### DIFF
--- a/apps/desktop/src-tauri/src/fs/io.rs
+++ b/apps/desktop/src-tauri/src/fs/io.rs
@@ -60,12 +60,14 @@ pub(super) fn atomic_write_bytes(target: &Path, contents: &[u8]) -> AppResult<()
     Ok(())
 }
 
-fn modified_ms(meta: &fs::Metadata) -> u64 {
+/// Last-modified time in epoch milliseconds, or `None` when the platform
+/// can't provide one. Shared by `list_files` and the watcher so every index
+/// path derives mtimes the same way.
+pub(crate) fn modified_ms(meta: &fs::Metadata) -> Option<u64> {
     meta.modified()
         .ok()
         .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
         .map(|dur| dur.as_millis() as u64)
-        .unwrap_or(0)
 }
 
 /// Collect markdown files under `root/dir` into `out` (recursive).
@@ -98,7 +100,7 @@ pub(super) fn collect_markdown(root: &Path, dir: &str, out: &mut Vec<FileMeta>) 
                 out.push(FileMeta {
                     path: rel.to_string_lossy().replace('\\', "/"),
                     size: meta.len(),
-                    modified_ms: modified_ms(&meta),
+                    modified_ms: modified_ms(&meta).unwrap_or(0),
                 });
             }
         }

--- a/apps/desktop/src-tauri/src/fs/mod.rs
+++ b/apps/desktop/src-tauri/src/fs/mod.rs
@@ -21,6 +21,8 @@ use crate::error::{AppError, AppResult};
 use self::io::{atomic_write, atomic_write_bytes, bootstrap, collect_markdown, NOTE_DIRS};
 use self::resolve::resolve;
 
+pub(crate) use self::io::modified_ms;
+
 /// The open graph root plus a monotonic generation, kept **under one lock** so
 /// they swap atomically (the same pattern as the index's `IndexState`, Plan 04b).
 /// Mutating commands carry the generation they were issued for and are rejected

--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -34,6 +34,12 @@ pub struct FileChange {
     pub path: String,
     /// `"upsert"` (created/modified) or `"remove"` (deleted).
     pub kind: String,
+    /// Last-modified time in epoch milliseconds, set for upserts. The frontend
+    /// stamps `notes.mtime` from this — without it, watcher-indexed rows would
+    /// carry no real timestamp (and reconcile would never repair them, since it
+    /// is content-hash gated).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub modified_ms: Option<u64>,
 }
 
 /// Graph-relative path if `path` is a tracked markdown note (`.md` under `daily/`
@@ -47,20 +53,26 @@ fn tracked_relpath(path: &Path, root: &Path) -> Option<String> {
 }
 
 /// Reduce a debounced batch of paths to unique tracked changes (last kind wins).
-/// Create/modify vs delete is decided by whether the file currently exists.
+/// Create/modify vs delete is decided by whether the file currently stats; the
+/// same stat supplies the upsert's `modified_ms`.
 fn collect_changes(paths: &[PathBuf], root: &Path) -> Vec<FileChange> {
     let mut seen: std::collections::BTreeMap<String, FileChange> =
         std::collections::BTreeMap::new();
     for path in paths {
         if let Some(rel) = tracked_relpath(path, root) {
-            let kind = if path.exists() { "upsert" } else { "remove" };
-            seen.insert(
-                rel.clone(),
-                FileChange {
-                    path: rel,
-                    kind: kind.to_string(),
+            let change = match std::fs::metadata(path) {
+                Ok(meta) => FileChange {
+                    path: rel.clone(),
+                    kind: "upsert".to_string(),
+                    modified_ms: crate::fs::modified_ms(&meta),
                 },
-            );
+                Err(_) => FileChange {
+                    path: rel.clone(),
+                    kind: "remove".to_string(),
+                    modified_ms: None,
+                },
+            };
+            seen.insert(rel, change);
         }
     }
     seen.into_values().collect()
@@ -178,8 +190,25 @@ mod tests {
             changes,
             vec![FileChange {
                 path: "notes/a.md".to_string(),
-                kind: "remove".to_string()
+                kind: "remove".to_string(),
+                modified_ms: None,
             }]
         );
+    }
+
+    #[test]
+    fn collect_changes_stamps_upserts_with_the_file_mtime() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("notes")).unwrap();
+        let note = root.join("notes/a.md");
+        std::fs::write(&note, "# a").unwrap();
+
+        let changes = collect_changes(&[note], root);
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].path, "notes/a.md");
+        assert_eq!(changes[0].kind, "upsert");
+        // A real timestamp, not epoch zero — All Notes sorts and labels by it.
+        assert!(changes[0].modified_ms.is_some_and(|ms| ms > 0));
     }
 }

--- a/apps/desktop/src/components/all-notes/all-notes-row.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-row.tsx
@@ -34,7 +34,7 @@ export function AllNotesRow({ note, onOpen }: AllNotesRowProps): ReactElement {
         {note.tags.map((tag) => `#${tag}`).join(' ')}
       </span>
       <span className="text-right text-[13px] tabular-nums text-text-secondary">
-        {formatRecencyLabel(note.mtime, settings)}
+        {note.mtime > 0 ? formatRecencyLabel(note.mtime, settings) : '—'}
       </span>
     </button>
   )

--- a/apps/desktop/src/components/all-notes/all-notes-screen.test.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.test.tsx
@@ -173,6 +173,27 @@ describe('AllNotesScreen', () => {
     view.unmount()
   })
 
+  it('renders a dash, not an epoch date, for a row missing its mtime', async () => {
+    mockInvoke.mockImplementation(async (command, args) => {
+      if (command !== 'db_query') {
+        return null
+      }
+      const sql = String(args.sql)
+      if (sql.includes('group by')) {
+        return facetRows
+      }
+      if (sql.includes('"preview"')) {
+        return [{ path: 'notes/legacy.md', title: 'Legacy Note', mtime: 0, preview: '' }]
+      }
+      return []
+    })
+    const view = renderScreen()
+
+    await view.findByText('Legacy Note')
+    expect(view.getByText('—')).toBeDefined()
+    view.unmount()
+  })
+
   it('opens a note when its row is clicked', async () => {
     const view = renderScreen()
 

--- a/packages/core/src/indexing/file-changes.ts
+++ b/packages/core/src/indexing/file-changes.ts
@@ -14,6 +14,11 @@ export const FILE_CHANGES_EVENT = 'index:changed'
 const fileChangeSchema = z.object({
   path: z.string(),
   kind: z.enum(['upsert', 'remove']),
+  /**
+   * The file's last-modified time (epoch ms), present on upserts. The re-index
+   * path stamps `notes.mtime` from it; removes (and older payloads) omit it.
+   */
+  modifiedMs: z.number().optional(),
 })
 const fileChangesSchema = z.array(fileChangeSchema)
 

--- a/packages/core/src/indexing/indexed-note.ts
+++ b/packages/core/src/indexing/indexed-note.ts
@@ -30,9 +30,11 @@ import { previewSnippet } from './snippet'
  * new columns at their migration defaults forever.
  *
  * History: 1 — Plan 04 baseline · 2 — `notes.preview` + `tags.tag_key` (the
- * first stamped version; v2 rows also carry the 0004 pinned columns).
+ * first stamped version; v2 rows also carry the 0004 pinned columns) ·
+ * 3 — repairs `notes.mtime` 0 rows written by the watcher path before it
+ * carried `modifiedMs` (hash-reconcile can never refresh them).
  */
-export const PROJECTION_VERSION = 2
+export const PROJECTION_VERSION = 3
 
 export const indexedLinkSchema = z.object({
   kind: z.enum(['wiki', 'md']),

--- a/packages/core/src/indexing/indexer.ts
+++ b/packages/core/src/indexing/indexer.ts
@@ -38,7 +38,13 @@ const REBUILD_BATCH_SIZE = 256
  */
 export const PROJECTION_VERSION_KEY = 'projection_version'
 
-/** Read, parse, and (re)index a single note for the given index generation. */
+/**
+ * Read, parse, and (re)index a single note for the given index generation.
+ * Without an explicit `mtime` the row is stamped "now" — a watcher event means
+ * the file just changed, and a real timestamp beats epoch zero (which would
+ * sink the note to the bottom of every recency sort and, because reconcile is
+ * content-hash gated, never get repaired).
+ */
 export async function indexNote(
   path: string,
   options: { generation: number; content?: string; mtime?: number },
@@ -47,7 +53,7 @@ export async function indexNote(
   const parsed = parseNote({ path, source: content })
   const fileHash = await hashContent(content)
   await applyIndexedNote(
-    buildIndexedNote(parsed, { fileHash, mtime: options.mtime ?? 0 }),
+    buildIndexedNote(parsed, { fileHash, mtime: options.mtime ?? Date.now() }),
     options.generation,
   )
 }

--- a/packages/core/src/indexing/live.test.ts
+++ b/packages/core/src/indexing/live.test.ts
@@ -127,6 +127,25 @@ describe('subscribeIndexChanges', () => {
     expect(order).toEqual(['apply:notes/a.md', 'applied:notes/a.md'])
   })
 
+  it('stamps the indexed row with the modifiedMs carried by the event', async () => {
+    const mtimes: number[] = []
+    const { emitChanges } = fakeBridge(async (command, args) => {
+      if (command === 'note_read') {
+        return '# content'
+      }
+      if (command === 'index_apply') {
+        mtimes.push((args.note as { mtime: number }).mtime)
+      }
+      return null
+    })
+
+    await subscribeIndexChanges(1)
+    emitChanges([{ path: 'notes/a.md', kind: 'upsert', modifiedMs: 1234 }])
+    await vi.waitFor(() => {
+      expect(mtimes).toEqual([1234])
+    })
+  })
+
   it('drops malformed payloads instead of applying them', async () => {
     const calls: string[] = []
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})

--- a/packages/core/src/indexing/live.ts
+++ b/packages/core/src/indexing/live.ts
@@ -33,7 +33,7 @@ export async function applyIndexChanges(
       if (change.kind === 'remove') {
         await removeFromIndex(change.path, generation)
       } else {
-        await indexNote(change.path, { generation })
+        await indexNote(change.path, { generation, mtime: change.modifiedMs })
       }
     } catch (error) {
       onError(error, change)

--- a/packages/core/src/indexing/pipeline.test.ts
+++ b/packages/core/src/indexing/pipeline.test.ts
@@ -54,6 +54,7 @@ describe('indexNote', () => {
     expect(args.generation).toBe(7)
     expect(args.note.path).toBe('notes/a.md')
     expect(args.note.title).toBe('Hello')
+    expect(args.note.mtime).toBe(5)
     expect(args.note.fileHash).toMatch(/^[0-9a-f]{64}$/)
     expect((args.note.links as { targetKey: string }[]).map((link) => link.targetKey)).toContain('world')
   })
@@ -108,7 +109,7 @@ describe('applyIndexChanges (watcher dispatch)', () => {
   it('re-indexes upserts and removes deletes at the given generation', async () => {
     await applyIndexChanges(
       [
-        { path: 'notes/a.md', kind: 'upsert' },
+        { path: 'notes/a.md', kind: 'upsert', modifiedMs: 4242 },
         { path: 'notes/gone.md', kind: 'remove' },
       ],
       9,
@@ -117,7 +118,19 @@ describe('applyIndexChanges (watcher dispatch)', () => {
     const remove = mockInvoke.mock.calls.find(([cmd]) => cmd === 'index_remove')
     expect((apply![1] as { note: { path: string }; generation: number }).generation).toBe(9)
     expect((apply![1] as { note: { path: string } }).note.path).toBe('notes/a.md')
+    expect((apply![1] as { note: { mtime: number } }).note.mtime).toBe(4242)
     expect(remove![1]).toMatchObject({ path: 'notes/gone.md', generation: 9 })
+  })
+
+  it('stamps "now" — never epoch zero — when an upsert carries no modifiedMs', async () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_750_000_000_000)
+    try {
+      await applyIndexChanges([{ path: 'notes/a.md', kind: 'upsert' }], 9)
+      const apply = mockInvoke.mock.calls.find(([cmd]) => cmd === 'index_apply')
+      expect((apply![1] as { note: { mtime: number } }).note.mtime).toBe(1_750_000_000_000)
+    } finally {
+      nowSpy.mockRestore()
+    }
   })
 })
 


### PR DESCRIPTION
## Problem

The All Notes screen showed notes with an Updated date of **12/31/1969** — `notes.mtime` was 0. Seen on a real graph for two freshly created "Untitled" notes, sunk to the bottom of the `mtime desc` sort.

## Root cause

Every note indexed through the file watcher was stamped with `mtime: 0`, and nothing ever repaired it:

1. The watcher's `index:changed` event carried only `{path, kind}` — no timestamp.
2. `applyIndexChanges` called `indexNote(path, { generation })` with no `mtime`, and `indexNote` defaulted it with `options.mtime ?? 0`.
3. The watcher is deliberately the **sole** incremental-reindex path (the editor doesn't index its own saves), so any note created or edited while the app runs got epoch zero.
4. The zero then stuck forever: `reconcileIndex` is content-hash gated and the hash *matches* (only the mtime was wrong), so the row was skipped on every subsequent launch.

## Fix

- **Carry the real mtime on the event.** `collect_changes` now stats the file once — `fs::metadata` decides upsert-vs-remove and supplies `modified_ms` for upserts — sharing the same `modified_ms` helper `list_files` uses.
- **Thread it through.** The zod event schema gains an optional `modifiedMs`; `applyIndexChanges` passes it to `indexNote`.
- **Never write zero again.** `indexNote`'s fallback is now `Date.now()` — a watcher event means the file just changed, so "now" is within the 400ms debounce of the truth.
- **Repair existing graphs.** `PROJECTION_VERSION` bumped to 3, so the next open does a one-time full rebuild that restamps every row from the on-disk mtime. Fixes already-broken rows with no manual step.
- **Defensive rendering.** The Updated column shows an em dash instead of an epoch date if a row somehow still lacks an mtime.

## Reviewer notes

- The Rust `FileChange` field uses `skip_serializing_if`, so remove events simply omit `modifiedMs`; the TS schema marks it optional — older/other payload shapes still validate.
- `fs::io::modified_ms` now returns `Option<u64>`; `list_files` keeps its previous `unwrap_or(0)` behavior at the call site.

## Tests

- Rust: watcher stamps upserts with a real mtime; remove events carry `None` (48 tests pass).
- Core: `modifiedMs` survives zod validation end-to-end into the row's `mtime`; `Date.now()` fallback applies when absent; explicit `mtime` is honored.
- Desktop: zero-mtime row renders a dash, not an epoch date.
- `pnpm check` (typecheck + lint) and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the sole incremental re-index path and triggers a one-time full rebuild on graph open for projection v3; behavior is well-tested but affects index freshness and All Notes sorting for all users.
> 
> **Overview**
> Fixes **watcher-indexed notes** getting `notes.mtime` of 0 (12/31/1969 in All Notes and wrong recency sort) by threading real file mtimes through the incremental index path and repairing existing bad rows.
> 
> The Rust watcher now **stats** each changed path once: successful metadata → upsert with shared `modified_ms`; failure → remove. That value is emitted as optional **`modifiedMs`** on `index:changed`, validated in core, and passed into **`indexNote`**. When the event omits a timestamp, **`indexNote`** falls back to **`Date.now()`** instead of epoch zero. **`PROJECTION_VERSION` 3** forces a one-time full rebuild so graphs with stuck zero-mt rows are restamped from disk (hash reconcile cannot fix mtime-only drift).
> 
> **All Notes** shows **—** in Updated when `mtime` is still 0. `list_files` keeps prior behavior via `modified_ms(...).unwrap_or(0)` at the call site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3821c6809e6870f48eaabfd3f381ad029c943f88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->