### PR TITLE
Add sticky scroll-spy section navigator to settings

### DIFF
--- a/apps/desktop/src/components/route-content.tsx
+++ b/apps/desktop/src/components/route-content.tsx
@@ -3,6 +3,7 @@ import { AllNotesScreen } from '@/components/all-notes/all-notes-screen'
 import { DailyStream } from '@/components/daily-stream'
 import { NotePane } from '@/components/note-pane'
 import { SearchRoute } from '@/components/search-route'
+import { SettingsNavigator } from '@/components/settings/settings-navigator'
 import { SettingsScreen } from '@/components/settings-screen'
 import { useToday } from '@/lib/use-today'
 import { useRouter } from '@/routing/router'
@@ -52,9 +53,16 @@ export function RouteContent(): ReactElement {
     case 'search':
       return <SearchRoute query={route.query} today={today} />
     case 'settings':
+      // The section navigator floats in the left gutter — absolutely
+      // positioned off the centered column so the column never shifts — and
+      // only renders when the container query says the gutter can fit it:
+      // the 42rem column plus a 12rem rail either side, with a little slack.
       return (
-        <ScrollRestored className="h-full overflow-auto px-6 py-8">
-          <div className="mx-auto w-full max-w-2xl">
+        <ScrollRestored className="@container h-full overflow-auto px-6 py-8">
+          <div className="relative mx-auto w-full max-w-2xl">
+            <div className="absolute inset-y-0 right-full hidden w-48 pr-8 @min-[68rem]:block">
+              <SettingsNavigator className="sticky top-8" />
+            </div>
             <SettingsScreen />
           </div>
         </ScrollRestored>

--- a/apps/desktop/src/components/settings/about-section.tsx
+++ b/apps/desktop/src/components/settings/about-section.tsx
@@ -5,7 +5,7 @@ import { SettingsSection } from './section'
 export function AboutSection(): ReactElement {
   const version = useAppVersion()
   return (
-    <SettingsSection title="About">
+    <SettingsSection id="about">
       <div className="flex items-center justify-between gap-4 px-4 py-3.5">
         <div className="min-w-0">
           <div className="text-sm font-medium text-text">Reflect Open</div>

--- a/apps/desktop/src/components/settings/ai-models-section.tsx
+++ b/apps/desktop/src/components/settings/ai-models-section.tsx
@@ -16,7 +16,7 @@ export function AiModelsSection(): ReactElement {
   const [adding, setAdding] = useState(false)
 
   return (
-    <SettingsSection title="AI models">
+    <SettingsSection id="ai-models">
       {models.length === 0 ? (
         <p className="px-4 py-3.5 text-xs text-text-muted">
           No AI models configured. Add a provider API key to use AI features — keys are

--- a/apps/desktop/src/components/settings/all-notes-section.tsx
+++ b/apps/desktop/src/components/settings/all-notes-section.tsx
@@ -51,7 +51,7 @@ export function AllNotesSection(): ReactElement {
   }
 
   return (
-    <SettingsSection title="All notes">
+    <SettingsSection id="all-notes">
       <SettingsField
         legend="Filter tags"
         description="Tags pinned as one-click filters at the top of the All Notes screen."

--- a/apps/desktop/src/components/settings/appearance-section.tsx
+++ b/apps/desktop/src/components/settings/appearance-section.tsx
@@ -49,7 +49,7 @@ export function AppearanceSection(): ReactElement {
   const { settings, updateSettings } = useSettings()
 
   return (
-    <SettingsSection title="Appearance">
+    <SettingsSection id="appearance">
       <SettingsField
         legend="Theme"
         description="System follows your OS appearance. Saved with your settings."

--- a/apps/desktop/src/components/settings/date-time-section.tsx
+++ b/apps/desktop/src/components/settings/date-time-section.tsx
@@ -42,7 +42,7 @@ export function DateTimeSection(): ReactElement {
   const today = new Date()
 
   return (
-    <SettingsSection title="Date & time">
+    <SettingsSection id="date-time">
       <SettingsField
         legend="Date format"
         description="The day and month order for dates shown throughout Reflect."

--- a/apps/desktop/src/components/settings/editor-section.tsx
+++ b/apps/desktop/src/components/settings/editor-section.tsx
@@ -30,7 +30,7 @@ export function EditorSection(): ReactElement {
   const { settings, updateSettings } = useSettings()
 
   return (
-    <SettingsSection title="Editor">
+    <SettingsSection id="editor">
       <SettingsField
         legend="Markdown syntax"
         description="How literal markdown characters (#, **, [[ ]]) are displayed while editing."

--- a/apps/desktop/src/components/settings/keyboard-section.tsx
+++ b/apps/desktop/src/components/settings/keyboard-section.tsx
@@ -49,7 +49,7 @@ function ShortcutGroup({
 
 export function KeyboardSection(): ReactElement {
   return (
-    <SettingsSection title="Keyboard shortcuts">
+    <SettingsSection id="keyboard">
       <ShortcutGroup heading="App" shortcuts={APP_SHORTCUTS} />
       <ShortcutGroup heading="Editor" shortcuts={EDITOR_SHORTCUTS} />
     </SettingsSection>

--- a/apps/desktop/src/components/settings/search-section.tsx
+++ b/apps/desktop/src/components/settings/search-section.tsx
@@ -83,7 +83,7 @@ export function SearchSection(): ReactElement {
   }
 
   return (
-    <SettingsSection title="Search">
+    <SettingsSection id="search">
       <SettingsField
         legend="Semantic search"
         description="Find notes by meaning, not just keywords — smarter ⌘K results and related notes. Runs entirely on this device; enabling downloads a small model (~90 MB) once."

--- a/apps/desktop/src/components/settings/section-scrolling.ts
+++ b/apps/desktop/src/components/settings/section-scrolling.ts
@@ -1,0 +1,47 @@
+import { settingsSectionDomId, type SettingsSectionId } from './sections'
+
+/**
+ * Breathing room (px) left above a section's heading when jumping to it —
+ * matches the settings page's `py-8` so a jumped-to heading sits exactly
+ * where the page's own top padding would put it.
+ */
+export const SECTION_JUMP_OFFSET_PX = 32
+
+/**
+ * The nearest ancestor that actually scrolls. Used instead of
+ * `Element.scrollIntoView`, which walks the whole ancestor chain and can
+ * permanently nudge `overflow: hidden` boxes like the workspace frame —
+ * scrolling the one container that owns the settings overflow keeps the rest
+ * of the layout pinned.
+ */
+export function findScrollContainer(node: HTMLElement): HTMLElement | null {
+  for (let parent = node.parentElement; parent !== null; parent = parent.parentElement) {
+    const { overflowY } = getComputedStyle(parent)
+    if (overflowY === 'auto' || overflowY === 'scroll') {
+      return parent
+    }
+  }
+  return null
+}
+
+/**
+ * Scrolls the settings page so the given section's heading lands just below
+ * the container's top edge. `anchor` is any element inside the settings
+ * scroll container (the navigator passes its own node). Smooth unless the OS
+ * asks for reduced motion.
+ */
+export function scrollToSettingsSection(anchor: HTMLElement, id: SettingsSectionId): void {
+  const target = document.getElementById(settingsSectionDomId(id))
+  const container = findScrollContainer(anchor)
+  if (!target || !container) {
+    return
+  }
+  const offset = target.getBoundingClientRect().top - container.getBoundingClientRect().top
+  const behavior: ScrollBehavior = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    ? 'auto'
+    : 'smooth'
+  container.scrollTo({
+    top: Math.max(0, container.scrollTop + offset - SECTION_JUMP_OFFSET_PX),
+    behavior,
+  })
+}

--- a/apps/desktop/src/components/settings/section.tsx
+++ b/apps/desktop/src/components/settings/section.tsx
@@ -1,19 +1,25 @@
 import type { ReactElement, ReactNode } from 'react'
+import { settingsSectionDomId, settingsSectionTitle, type SettingsSectionId } from './sections'
 
 interface SettingsSectionProps {
-  /** The small heading shown above the card. */
-  title: string
+  /**
+   * Which {@link SETTINGS_SECTIONS} entry this card renders. Supplies the
+   * heading text and the DOM anchor the sticky navigator jumps to.
+   */
+  id: SettingsSectionId
   /** The card's rows, separated by hairline dividers. */
   children: ReactNode
 }
 
 /**
  * The settings page idiom (the original app's): a small section heading over
- * a bordered card whose rows are separated by hairline dividers.
+ * a bordered card whose rows are separated by hairline dividers. Every card is
+ * registered in the sections registry so the navigator can list and target it.
  */
-export function SettingsSection({ title, children }: SettingsSectionProps): ReactElement {
+export function SettingsSection({ id, children }: SettingsSectionProps): ReactElement {
+  const title = settingsSectionTitle(id)
   return (
-    <section aria-label={title} className="mt-8 first:mt-0">
+    <section id={settingsSectionDomId(id)} aria-label={title} className="mt-8 first:mt-0">
       <h2 className="px-1 text-[13px] font-semibold text-text">{title}</h2>
       <div className="mt-2 divide-y divide-border rounded-lg border border-border bg-surface shadow-sm">
         {children}

--- a/apps/desktop/src/components/settings/sections.ts
+++ b/apps/desktop/src/components/settings/sections.ts
@@ -1,0 +1,28 @@
+/**
+ * The canonical, ordered registry of settings page sections. The section
+ * cards and the sticky navigator both render from this list, so the
+ * navigator's labels and jump targets can never drift from the page itself.
+ */
+export const SETTINGS_SECTIONS = [
+  { id: 'appearance', title: 'Appearance' },
+  { id: 'date-time', title: 'Date & time' },
+  { id: 'editor', title: 'Editor' },
+  { id: 'all-notes', title: 'All notes' },
+  { id: 'search', title: 'Search' },
+  { id: 'ai-models', title: 'AI models' },
+  { id: 'keyboard', title: 'Keyboard shortcuts' },
+  { id: 'about', title: 'About' },
+] as const
+
+/** Identifier of one {@link SETTINGS_SECTIONS} entry. */
+export type SettingsSectionId = (typeof SETTINGS_SECTIONS)[number]['id']
+
+/** The heading a section renders — shared by its card and the navigator. */
+export function settingsSectionTitle(id: SettingsSectionId): string {
+  return SETTINGS_SECTIONS.find((section) => section.id === id)?.title ?? id
+}
+
+/** The DOM id a section card carries (prefixed to keep document ids unique). */
+export function settingsSectionDomId(id: SettingsSectionId): string {
+  return `settings-${id}`
+}

--- a/apps/desktop/src/components/settings/settings-navigator.test.tsx
+++ b/apps/desktop/src/components/settings/settings-navigator.test.tsx
@@ -1,0 +1,133 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SETTINGS_SECTIONS, settingsSectionDomId } from './sections'
+import { SettingsNavigator } from './settings-navigator'
+
+// jsdom implements neither; the navigator re-measures its marker on resize,
+// and the jump checks the reduced-motion preference.
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+globalThis.ResizeObserver ??= ResizeObserverStub as unknown as typeof ResizeObserver
+window.matchMedia ??= (query: string): MediaQueryList => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  addListener: () => {},
+  removeListener: () => {},
+  dispatchEvent: () => false,
+})
+
+/**
+ * Simulated page geometry: the scroll container is an 800px viewport over
+ * 4100px of content, with one section every 500px starting at the page's
+ * 32px top padding. jsdom does no layout, so the scroller's metrics and every
+ * section's `getBoundingClientRect` are stubbed in terms of `scrollTop`.
+ */
+const VIEWPORT_PX = 800
+const CONTENT_PX = 4100
+const SECTION_STRIDE_PX = 500
+const PAGE_PADDING_PX = 32
+
+function sectionTop(index: number): number {
+  return PAGE_PADDING_PX + index * SECTION_STRIDE_PX
+}
+
+function renderNavigatorPage(): HTMLElement {
+  const view = render(
+    <div data-testid="scroller" style={{ overflowY: 'auto' }}>
+      <div>
+        <SettingsNavigator />
+        {SETTINGS_SECTIONS.map((section) => (
+          <section key={section.id} id={settingsSectionDomId(section.id)} />
+        ))}
+      </div>
+    </div>,
+  )
+  const scroller = view.getByTestId('scroller')
+
+  let scrollTop = 0
+  Object.defineProperty(scroller, 'scrollTop', {
+    configurable: true,
+    get: () => scrollTop,
+    set: (value: number) => {
+      scrollTop = value
+    },
+  })
+  Object.defineProperty(scroller, 'clientHeight', { configurable: true, get: () => VIEWPORT_PX })
+  Object.defineProperty(scroller, 'scrollHeight', { configurable: true, get: () => CONTENT_PX })
+  scroller.getBoundingClientRect = () => new DOMRect(0, 0, VIEWPORT_PX, VIEWPORT_PX)
+
+  SETTINGS_SECTIONS.forEach((section, index) => {
+    const element = document.getElementById(settingsSectionDomId(section.id))
+    if (!element) {
+      throw new Error(`missing section element for ${section.id}`)
+    }
+    element.getBoundingClientRect = () =>
+      new DOMRect(0, sectionTop(index) - scrollTop, VIEWPORT_PX, SECTION_STRIDE_PX)
+  })
+
+  // The hook computed once on mount, before this geometry existed — resync.
+  fireEvent.scroll(scroller)
+  return scroller
+}
+
+function scrollPageTo(scroller: HTMLElement, top: number): void {
+  scroller.scrollTop = top
+  fireEvent.scroll(scroller)
+}
+
+function activeEntry(): string | null | undefined {
+  return screen
+    .getAllByRole('button')
+    .find((button) => button.getAttribute('aria-current') === 'location')?.textContent
+}
+
+afterEach(() => {
+  cleanup() // `globals: false` disables testing-library's automatic cleanup
+})
+
+describe('SettingsNavigator', () => {
+  it('lists every registered section in order', () => {
+    renderNavigatorPage()
+    const labels = screen.getAllByRole('button').map((button) => button.textContent)
+    expect(labels).toEqual(SETTINGS_SECTIONS.map((section) => section.title))
+  })
+
+  it('marks the section under the reading line as the page scrolls', () => {
+    const scroller = renderNavigatorPage()
+    expect(activeEntry()).toBe('Appearance')
+
+    // Scroll until the Editor section (index 2) sits at the jump offset.
+    scrollPageTo(scroller, sectionTop(2) - PAGE_PADDING_PX)
+    expect(activeEntry()).toBe('Editor')
+
+    scrollPageTo(scroller, 0)
+    expect(activeEntry()).toBe('Appearance')
+  })
+
+  it('hands the last section the marker at the very bottom of the page', () => {
+    const scroller = renderNavigatorPage()
+    scrollPageTo(scroller, CONTENT_PX - VIEWPORT_PX)
+    // About's top never crosses the reading line, but the page can scroll no
+    // further — the bottom override keeps the last entry reachable.
+    expect(activeEntry()).toBe('About')
+  })
+
+  it('clicking an entry scrolls its section to the top of the page', () => {
+    const scroller = renderNavigatorPage()
+    const scrollTo = vi.fn()
+    scroller.scrollTo = scrollTo
+
+    fireEvent.click(screen.getByRole('button', { name: 'Editor' }))
+
+    expect(scrollTo).toHaveBeenCalledWith({
+      top: sectionTop(2) - PAGE_PADDING_PX,
+      behavior: 'smooth',
+    })
+  })
+})

--- a/apps/desktop/src/components/settings/settings-navigator.tsx
+++ b/apps/desktop/src/components/settings/settings-navigator.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactElement } from 'react'
+import { cn } from '@/lib/utils'
+import { scrollToSettingsSection } from './section-scrolling'
+import { SETTINGS_SECTIONS, type SettingsSectionId } from './sections'
+import { useActiveSettingsSection } from './use-active-settings-section'
+
+/** Where the sliding marker sits, in the rail's own coordinates. */
+interface MarkerPosition {
+  top: number
+  height: number
+}
+
+interface SettingsNavigatorProps {
+  className?: string
+}
+
+/**
+ * The sticky "on this page" rail beside the settings column: one entry per
+ * registered section, with an accent marker that slides along a hairline
+ * track to the section currently being read. Clicking an entry
+ * smooth-scrolls the page to its card. The settings route only shows the
+ * rail when the gutter is wide enough (a container query), so it must cope
+ * with mounting at `display: none` — the marker re-measures when the rail
+ * gains a size.
+ */
+export function SettingsNavigator({ className }: SettingsNavigatorProps): ReactElement {
+  const navRef = useRef<HTMLElement | null>(null)
+  const itemRefs = useRef(new Map<SettingsSectionId, HTMLButtonElement>())
+  const activeId = useActiveSettingsSection(navRef)
+  const [marker, setMarker] = useState<MarkerPosition | null>(null)
+
+  const measure = useCallback((): void => {
+    const item = itemRefs.current.get(activeId)
+    if (!item || item.offsetHeight === 0) {
+      setMarker(null)
+      return
+    }
+    setMarker({ top: item.offsetTop, height: item.offsetHeight })
+  }, [activeId])
+
+  useLayoutEffect(() => {
+    measure()
+  }, [measure])
+
+  useEffect(() => {
+    const nav = navRef.current
+    if (!nav) {
+      return
+    }
+    const resizeObserver = new ResizeObserver(() => measure())
+    resizeObserver.observe(nav)
+    return () => resizeObserver.disconnect()
+  }, [measure])
+
+  return (
+    <nav ref={navRef} aria-label="Settings sections" className={cn('text-[13px]', className)}>
+      <div className="relative flex flex-col border-l border-border">
+        {marker !== null && (
+          <span
+            aria-hidden
+            className="absolute -left-px top-0 w-0.5 rounded-full bg-accent transition-[transform,height] duration-200 ease-out motion-reduce:transition-none"
+            style={{ transform: `translateY(${marker.top}px)`, height: `${marker.height}px` }}
+          />
+        )}
+        {SETTINGS_SECTIONS.map((section) => {
+          const isActive = section.id === activeId
+          return (
+            <button
+              key={section.id}
+              type="button"
+              ref={(node) => {
+                if (node) {
+                  itemRefs.current.set(section.id, node)
+                } else {
+                  itemRefs.current.delete(section.id)
+                }
+              }}
+              aria-current={isActive ? 'location' : undefined}
+              onClick={() => {
+                if (navRef.current) {
+                  scrollToSettingsSection(navRef.current, section.id)
+                }
+              }}
+              className={cn(
+                'truncate rounded-r-md py-1 pl-4 pr-2 text-left outline-none transition-colors duration-200',
+                'focus-visible:ring-2 focus-visible:ring-ring/50',
+                isActive ? 'text-text' : 'text-text-secondary hover:text-text',
+              )}
+            >
+              {section.title}
+            </button>
+          )
+        })}
+      </div>
+    </nav>
+  )
+}

--- a/apps/desktop/src/components/settings/use-active-settings-section.ts
+++ b/apps/desktop/src/components/settings/use-active-settings-section.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState, type RefObject } from 'react'
+import { findScrollContainer, SECTION_JUMP_OFFSET_PX } from './section-scrolling'
+import { SETTINGS_SECTIONS, settingsSectionDomId, type SettingsSectionId } from './sections'
+
+/**
+ * The reading line: a section is active while it is the last one whose top
+ * has crossed this many pixels below the container's top edge. Sits just
+ * under the jump offset so clicking a navigator entry always lands with that
+ * entry active.
+ */
+const ACTIVATION_LINE_PX = SECTION_JUMP_OFFSET_PX + 16
+
+/**
+ * Tracks which settings section the user is reading. Listens to the settings
+ * scroll container — found by walking up from `anchorRef`, which must be
+ * rendered inside it — and recomputes on scroll and resize. The active
+ * section is the last one whose top has crossed the reading line; once the
+ * container is scrolled to the very bottom the final section wins instead,
+ * since a short last card may never reach the line on its own.
+ */
+export function useActiveSettingsSection(
+  anchorRef: RefObject<HTMLElement | null>,
+): SettingsSectionId {
+  const [activeId, setActiveId] = useState<SettingsSectionId>(SETTINGS_SECTIONS[0].id)
+
+  useEffect(() => {
+    const anchor = anchorRef.current
+    if (!anchor) {
+      return
+    }
+    const container = findScrollContainer(anchor)
+    if (!container) {
+      return
+    }
+
+    // No rAF coalescing: browsers already deliver at most one scroll event
+    // per frame, and the work is eight getBoundingClientRect calls.
+    const compute = (): void => {
+      const containerTop = container.getBoundingClientRect().top
+      let current: SettingsSectionId = SETTINGS_SECTIONS[0].id
+      for (const section of SETTINGS_SECTIONS) {
+        const element = document.getElementById(settingsSectionDomId(section.id))
+        if (element && element.getBoundingClientRect().top - containerTop <= ACTIVATION_LINE_PX) {
+          current = section.id
+        }
+      }
+      const atBottom =
+        container.scrollTop > 0 &&
+        container.scrollTop + container.clientHeight >= container.scrollHeight - 1
+      setActiveId(atBottom ? SETTINGS_SECTIONS[SETTINGS_SECTIONS.length - 1].id : current)
+    }
+    compute()
+    container.addEventListener('scroll', compute, { passive: true })
+    const resizeObserver = new ResizeObserver(compute)
+    resizeObserver.observe(container)
+    return () => {
+      container.removeEventListener('scroll', compute)
+      resizeObserver.disconnect()
+    }
+  }, [anchorRef])
+
+  return activeId
+}

--- a/apps/desktop/src/components/settings/use-active-settings-section.ts
+++ b/apps/desktop/src/components/settings/use-active-settings-section.ts
@@ -50,6 +50,11 @@ export function useActiveSettingsSection(
       setActiveId(atBottom ? SETTINGS_SECTIONS[SETTINGS_SECTIONS.length - 1].id : current)
     }
     compute()
+    // ScrollRestored restores a saved scrollTop in its own effect, which runs
+    // after this one (React flushes child effects first) and whose scroll
+    // event only lands a frame later. Recompute in a microtask — after the
+    // whole effect pass, before paint — so a revisited entry starts right.
+    queueMicrotask(compute)
     container.addEventListener('scroll', compute, { passive: true })
     const resizeObserver = new ResizeObserver(compute)
     resizeObserver.observe(container)


### PR DESCRIPTION
## What

The settings page now shows a sticky "on this page" rail in the left gutter: one entry per section, with an accent marker that slides along a hairline track to the section currently being read. Clicking an entry smooth-scrolls that section's card to the top of the page. The rail hides when the window is too narrow for the gutter to fit it, and the settings column never shifts either way.


## How

- **`sections.ts`** — a single ordered registry of the 8 settings sections. `SettingsSection` now takes a registry `id` instead of a freeform `title` and derives both its heading and DOM anchor from it, so the rail's labels and jump targets cannot drift from the page.
- **`use-active-settings-section.ts`** — scroll-spy: the active section is the last one whose top crossed a reading line 48px below the container edge, with a bottom-of-page override so the short About card stays reachable. Computes directly in the scroll handler — browsers deliver at most one scroll event per frame, so rAF coalescing would be pure indirection.
- **`section-scrolling.ts`** — jumps scroll only the container that owns the settings overflow (`scrollIntoView` also nudges `overflow: hidden` ancestors and can leave the frame shifted), land each heading exactly 32px below the top to match the page's `py-8`, and honor `prefers-reduced-motion`.
- **`settings-navigator.tsx`** — the rail. The marker is measured from the active item and animated via transform/height transitions; a ResizeObserver re-measures when the rail toggles between `display: none` and visible.
- **`route-content.tsx`** — the rail is absolutely positioned off the centered column (`right-full`) and gated by a container query at `@min-[68rem]` — the 42rem column plus a 12rem rail either side, with slack.

## Notes for review

- Container queries compare against the **content box**, so the scroll container's `px-6` padding eats into the threshold — that's why the gate is an arbitrary `@min-[68rem]` rather than the named `@6xl` (which missed by 20px at common window sizes).
- Verified in the running app (light + dark): marker tracks scrolling, click-to-jump lands with the clicked entry active, rail hides at narrow widths and re-measures its marker correctly when reappearing.
- New unit tests drive the real hook over stubbed geometry: ordering, reading-line activation, bottom override, and the jump's scroll math.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only settings navigation and layout; no persistence, auth, or data-path changes beyond DOM ids on section cards.
> 
> **Overview**
> Adds a sticky **“on this page”** section rail on the settings route: entries mirror the eight settings blocks, a sliding accent marks the section in view, and clicks jump-scroll within the settings overflow container (not `scrollIntoView`, to avoid shifting the workspace frame). The rail sits in the left gutter via absolute positioning and only appears when a container query (`@min-[68rem]`) says the gutter fits, so the centered column never moves.
> 
> **`SETTINGS_SECTIONS`** is the single ordered registry; **`SettingsSection`** now takes a registry **`id`** instead of a freeform **`title`**, derives heading text and DOM anchors (`settings-{id}`), and every section component was updated accordingly.
> 
> Scroll-spy (**`useActiveSettingsSection`**) picks the last section whose top crossed a reading line, with a bottom-of-page override for short sections like About; **`section-scrolling`** handles jump offset (32px, matching `py-8`) and **`prefers-reduced-motion`**. **`SettingsNavigator`** re-measures the marker when the rail toggles from hidden to visible. Unit tests cover list order, scroll activation, bottom override, and click-to-jump math.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0feb7f2ce82b361bdb99e8f883390351526db76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

