### PR TITLE
Align incoming-backlinks section with note content and indent its groups

### DIFF
--- a/apps/desktop/src/components/backlink-source-group.tsx
+++ b/apps/desktop/src/components/backlink-source-group.tsx
@@ -18,8 +18,8 @@ interface BacklinkSourceGroupProps {
 /**
  * One referencing note in the incoming-backlinks section, in old Reflect's
  * presentation: an accent-colored title that opens the note, the linking
- * lines beneath as selectable text, and a chevron in the left gutter —
- * revealed on hover — that toggles just this group. The group chevron
+ * lines beneath as selectable text, and a chevron in the indent to its
+ * left — revealed on hover — that toggles just this group. The group chevron
  * deliberately overrides the panel-level toggle (old Reflect's behavior):
  * collapsing the panel collapses every group, after which one source can be
  * peeked at without re-expanding the rest. Groups are separated by hairline
@@ -64,7 +64,7 @@ export function BacklinkSourceGroup({
           >
             <ChevronRight
               aria-hidden
-              className={`size-4 transition-transform ${expanded ? 'rotate-90' : ''}`}
+              className={`size-3 transition-transform ${expanded ? 'rotate-90' : ''}`}
             />
           </button>
         ) : null}

--- a/apps/desktop/src/components/backlinks-panel.tsx
+++ b/apps/desktop/src/components/backlinks-panel.tsx
@@ -21,8 +21,8 @@ const EXPANDED_STORAGE_KEY = 'reflect.backlinks-expanded'
 /**
  * Incoming backlinks at the bottom of every note — daily and ordinary — in
  * old Reflect's presentation: an "Incoming backlinks (N)" header with a
- * gutter chevron, references grouped by source note, and hairline dividers
- * between groups. The header toggle collapses the linking lines while the
+ * leading chevron, indented references grouped by source note, and hairline
+ * dividers between groups. The header toggle collapses the linking lines while the
  * source titles stay visible, and the choice persists for the session
  * across all notes. Ambient and always-available — the associative recall
  * the product is built on — and cheap: one indexed query per visible note,
@@ -74,15 +74,11 @@ export function BacklinksPanel({ path }: BacklinksPanelProps): ReactElement | nu
           type="button"
           aria-expanded={expanded}
           onClick={toggleExpanded}
-          className="relative flex w-full items-center text-left"
+          className="flex w-full items-center gap-2 text-left"
         >
-          {/* V1 floats the chevron in the note gutter, vertically centered
-              (`inset-y-0 left-[15px]` inside its 40px gutter). The stream
-              gutter bottoms out at 1.5rem, so -left-5 keeps the 16px icon
-              centered there — -left-6 presses it flush against the pane edge. */}
           <ChevronRight
             aria-hidden
-            className={`absolute inset-y-0 -left-5 my-auto size-4 text-text-muted transition-transform ${
+            className={`size-3 shrink-0 text-text-muted transition-transform ${
               expanded ? 'rotate-90' : ''
             }`}
           />
@@ -92,7 +88,10 @@ export function BacklinksPanel({ path }: BacklinksPanelProps): ReactElement | nu
         </button>
       </h3>
 
-      <div className="mt-5">
+      {/* pl-5 = the header's 12px chevron + 8px gap, so group titles line up
+          with the header label and the group hover-chevrons (-left-5) land
+          back at the section's left edge, under the header chevron. */}
+      <div className="mt-5 pl-5">
         {groups.map((group, index) => (
           <BacklinkSourceGroup
             // Scoped to the open note: the pane is reused across navigation,


### PR DESCRIPTION
## What changed

- **Header alignment**: the "Incoming backlinks" chevron was absolutely positioned at `-left-5`, floating it out into the note gutter past the content edge. It's now an inline flex child of the header button, so the section starts flush with the rest of the note content (e.g. the date heading), with the label following after a `gap-2`.
- **Indented contents**: the source-group list gets `pl-5` (20px = 12px chevron + 8px gap), so group titles and linking lines align with the header label. Side effect worth noting: each group's hover-reveal chevron (positioned `-left-5`) now lands exactly at the section's left edge, directly under the header chevron.
- **Smaller arrows**: header chevron shrunk from `size-4` to `size-3`; the group hover chevrons match so the section doesn't mix two arrow sizes.

## Why

The backlinks section's arrow hung out in the gutter, misaligned with the rest of the note content, and the oversized chevron drew too much attention for a collapsed-by-default ambient surface.

## Notes for review

Layout-only change — no behavior or query changes. `pnpm check` and the 9 backlinks-panel tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only presentation tweaks in backlinks components with no data or interaction logic changes.
> 
> **Overview**
> **Incoming backlinks** layout is aligned with the rest of the note stream instead of floating chevrons in the gutter.
> 
> The panel header chevron moves from absolute `-left-5` positioning into an inline **flex** row with `gap-2`, so the section starts flush with other note content. The group list gains **`pl-5`** so source titles and snippets line up with the header label; per-group hover chevrons (still at `-left-5`) sit under the header chevron at the section edge. Header and group **`ChevronRight`** icons shrink from **`size-4`** to **`size-3`** for a consistent, subtler affordance. Comments/docs are updated to describe the indent/chevron relationship; **no query, toggle, or navigation behavior changes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd576d220c29a0c4be96fa67746069be029a8b8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->