### PR TITLE
Give the custom tag dropdown list its missing padding

### DIFF
--- a/apps/desktop/src/components/all-notes/custom-filter-menu.tsx
+++ b/apps/desktop/src/components/all-notes/custom-filter-menu.tsx
@@ -4,6 +4,7 @@ import { ChevronDown } from 'lucide-react'
 import {
   Command,
   CommandEmpty,
+  CommandGroup,
   CommandInput,
   CommandItem,
   CommandList,
@@ -87,25 +88,27 @@ export function CustomFilterMenu({
             {/* A force-mounted item never counts as a match, so cmdk would
                 show the empty state right above it — render one or the other. */}
             {offerTyped ? null : <CommandEmpty>{emptyMessage}</CommandEmpty>}
-            {facets.map((facet) => (
-              <CommandItem
-                key={foldTag(facet.tag)}
-                value={facet.tag}
-                keywords={[`#${facet.tag}`]}
-                data-checked={activeTag !== null && foldTag(activeTag) === foldTag(facet.tag)}
-                onSelect={() => choose(facet.tag)}
-              >
-                <span className="min-w-0 flex-1 truncate">#{facet.tag}</span>
-                <span className="shrink-0 text-xs tabular-nums text-text-muted">
-                  {facet.count}
-                </span>
-              </CommandItem>
-            ))}
-            {offerTyped ? (
-              <CommandItem forceMount value={`custom:${typed}`} onSelect={() => choose(typed)}>
-                <span className="min-w-0 flex-1 truncate">Filter by #{typed}</span>
-              </CommandItem>
-            ) : null}
+            <CommandGroup>
+              {facets.map((facet) => (
+                <CommandItem
+                  key={foldTag(facet.tag)}
+                  value={facet.tag}
+                  keywords={[`#${facet.tag}`]}
+                  data-checked={activeTag !== null && foldTag(activeTag) === foldTag(facet.tag)}
+                  onSelect={() => choose(facet.tag)}
+                >
+                  <span className="min-w-0 flex-1 truncate">#{facet.tag}</span>
+                  <span className="shrink-0 text-xs tabular-nums text-text-muted">
+                    {facet.count}
+                  </span>
+                </CommandItem>
+              ))}
+              {offerTyped ? (
+                <CommandItem forceMount value={`custom:${typed}`} onSelect={() => choose(typed)}>
+                  <span className="min-w-0 flex-1 truncate">Filter by #{typed}</span>
+                </CommandItem>
+              ) : null}
+            </CommandGroup>
           </CommandList>
         </Command>
       </PopoverContent>

--- a/apps/desktop/src/components/all-notes/custom-filter-menu.tsx
+++ b/apps/desktop/src/components/all-notes/custom-filter-menu.tsx
@@ -88,27 +88,33 @@ export function CustomFilterMenu({
             {/* A force-mounted item never counts as a match, so cmdk would
                 show the empty state right above it — render one or the other. */}
             {offerTyped ? null : <CommandEmpty>{emptyMessage}</CommandEmpty>}
-            <CommandGroup>
-              {facets.map((facet) => (
-                <CommandItem
-                  key={foldTag(facet.tag)}
-                  value={facet.tag}
-                  keywords={[`#${facet.tag}`]}
-                  data-checked={activeTag !== null && foldTag(activeTag) === foldTag(facet.tag)}
-                  onSelect={() => choose(facet.tag)}
-                >
-                  <span className="min-w-0 flex-1 truncate">#{facet.tag}</span>
-                  <span className="shrink-0 text-xs tabular-nums text-text-muted">
-                    {facet.count}
-                  </span>
-                </CommandItem>
-              ))}
-              {offerTyped ? (
+            {facets.length > 0 ? (
+              <CommandGroup>
+                {facets.map((facet) => (
+                  <CommandItem
+                    key={foldTag(facet.tag)}
+                    value={facet.tag}
+                    keywords={[`#${facet.tag}`]}
+                    data-checked={activeTag !== null && foldTag(activeTag) === foldTag(facet.tag)}
+                    onSelect={() => choose(facet.tag)}
+                  >
+                    <span className="min-w-0 flex-1 truncate">#{facet.tag}</span>
+                    <span className="shrink-0 text-xs tabular-nums text-text-muted">
+                      {facet.count}
+                    </span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ) : null}
+            {offerTyped ? (
+              // The group needs forceMount too: cmdk hides a group whenever
+              // no item inside it matches the query, even force-mounted ones.
+              <CommandGroup forceMount>
                 <CommandItem forceMount value={`custom:${typed}`} onSelect={() => choose(typed)}>
                   <span className="min-w-0 flex-1 truncate">Filter by #{typed}</span>
                 </CommandItem>
-              ) : null}
-            </CommandGroup>
+              </CommandGroup>
+            ) : null}
           </CommandList>
         </Command>
       </PopoverContent>


### PR DESCRIPTION
## Summary

The "Custom" tag-filter dropdown in All Notes rendered its tag rows flush against the popover edges, with no gap below the search input — the selected-row highlight touched the panel border.

Root cause: the menu placed `CommandItem`s directly inside `CommandList`, but in our shadcn Command primitive it's `CommandGroup` that supplies the list's inner `p-1` inset. This wraps the tag rows (both the facet list and the typed "Filter by #tag" row) in a `CommandGroup`, the canonical shadcn structure, so the list gets proper horizontal and vertical padding. The empty-state message stays a direct child of `CommandList`, per the standard pattern.

## Testing

- `pnpm check` (typecheck + lint) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout change in one combobox component; no data, auth, or API impact.
> 
> **Overview**
> Fixes the All Notes **Custom** tag-filter dropdown so list rows are inset from the popover edges instead of sitting flush against the panel (highlights touching the border).
> 
> Facet tag rows are wrapped in a **`CommandGroup`** so they pick up the shadcn **`p-1`** inset that **`CommandList`** alone does not apply. The free-typed **Filter by #tag** row moves into its own **`CommandGroup`** with **`forceMount`**, so cmdk still shows it when it would not match the search query. **`CommandEmpty`** stays a direct child of **`CommandList`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d2d67a9e55e2400ab2ee0420c2dd41dc5e4bc6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->