### PR TITLE
Fix missing comma in dmy date format

### DIFF
--- a/apps/desktop/src/lib/dates.test.ts
+++ b/apps/desktop/src/lib/dates.test.ts
@@ -39,9 +39,9 @@ describe('dates', () => {
 
   it('formatFullDate spells the date out per the date format', () => {
     expect(formatFullDate(new Date(2026, 5, 10), 'mdy')).toBe('June 10th, 2026')
-    expect(formatFullDate(new Date(2026, 5, 10), 'dmy')).toBe('10th June 2026')
+    expect(formatFullDate(new Date(2026, 5, 10), 'dmy')).toBe('10th June, 2026')
     expect(formatFullDate(new Date(2026, 0, 1), 'mdy')).toBe('January 1st, 2026')
-    expect(formatFullDate(new Date(2026, 0, 22), 'dmy')).toBe('22nd January 2026')
+    expect(formatFullDate(new Date(2026, 0, 22), 'dmy')).toBe('22nd January, 2026')
   })
 
   describe('formatTimeOfDay', () => {

--- a/apps/desktop/src/lib/dates.ts
+++ b/apps/desktop/src/lib/dates.ts
@@ -48,11 +48,11 @@ export function formatDayLabel(date: string, dateFormat: DateFormat): string {
 
 /**
  * A date spelled out in full per the date-format setting: `June 10th, 2026`
- * for `mdy`, `10th June 2026` for `dmy` (the forms the settings screen shows
+ * for `mdy`, `10th June, 2026` for `dmy` (the forms the settings screen shows
  * as the options themselves).
  */
 export function formatFullDate(date: Date, dateFormat: DateFormat): string {
-  return format(date, dateFormat === 'dmy' ? 'do MMMM yyyy' : 'MMMM do, yyyy')
+  return format(date, dateFormat === 'dmy' ? 'do MMMM, yyyy' : 'MMMM do, yyyy')
 }
 
 /**


### PR DESCRIPTION
## Summary

- The `dmy` date format option in Settings was displaying `11th June 2026` (no comma) instead of `11th June, 2026`
- Fixed the format string in `formatFullDate` from `'do MMMM yyyy'` to `'do MMMM, yyyy'`
- Updated the JSDoc comment and two test assertions to match

## Test plan

- [ ] Open Settings → Date & Time → Date format dropdown
- [ ] Confirm the `dmy` option now reads `11th June, 2026` (with comma)
- [ ] Run `pnpm test` in `apps/desktop` to confirm the updated assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only date string formatting in the desktop app; no data, auth, or API impact.
> 
> **Overview**
> Fixes **dmy** full-date display so it includes a comma after the month (e.g. `10th June, 2026` instead of `10th June 2026`), matching the Settings date-format dropdown labels.
> 
> The change is in `formatFullDate`’s date-fns pattern (`'do MMMM, yyyy'` for **dmy**). JSDoc and unit tests are updated accordingly; **`mdy`** formatting is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e36f2fb23c3cdd1c39b5acdb7777f8eae95eea49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->