### PR TITLE
Add a Rebuild index button to settings

### DIFF
--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -1,10 +1,18 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setBridge, type EmbedStatus } from '@reflect/core'
 import { formatFullDate } from '@/lib/dates'
+import { resetOperations } from '@/lib/operations'
 import { SettingsProvider } from '@/providers/settings-provider'
 import { SettingsScreen } from './settings-screen'
+
+// The rebuild-index field reads the open index generation from the graph
+// provider; the screen tests run without a GraphProvider, so stub the hook.
+const graph = vi.hoisted(() => ({ indexGeneration: 7 as number | null }))
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({ indexGeneration: graph.indexGeneration }),
+}))
 
 // jsdom doesn't implement this; Radix Select scrolls the selected option into
 // view when the listbox opens.
@@ -30,6 +38,8 @@ function installFakeBridge(): void {
         case 'embed_status':
         case 'embed_ensure':
           return embedStatus
+        case 'list_files':
+          return []
         default:
           return null
       }
@@ -61,6 +71,7 @@ function radio(name: RegExp): HTMLInputElement {
 beforeEach(() => {
   stored = {}
   embedStatus = { status: 'uninitialized' }
+  graph.indexGeneration = 7
   queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: Infinity } },
   })
@@ -408,6 +419,29 @@ describe('SettingsScreen', () => {
       ]),
     )
     expect(screen.getByRole('button', { name: /enable semantic search/i })).toBeTruthy()
+  })
+
+  it('rebuilding the index wipes and re-applies the projection through the bridge', async () => {
+    try {
+      renderScreen()
+
+      fireEvent.click(screen.getByRole('button', { name: /rebuild index/i }))
+
+      // The whole chain: button → rebuildIndexVisibly → wipe, then the
+      // projection-version stamp that marks a completed rebuild. (The graph is
+      // empty here, so there is no apply batch in between.)
+      await waitFor(() => expect(invoked).toContain('index_clear'))
+      await waitFor(() => expect(invoked).toContain('index_meta_set'))
+    } finally {
+      resetOperations()
+    }
+  })
+
+  it('disables the index rebuild until a graph index is open', () => {
+    graph.indexGeneration = null
+    renderScreen()
+    const button = screen.getByRole('button', { name: /rebuild index/i })
+    expect(button.hasAttribute('disabled')).toBe(true)
   })
 
   it('lists registered shortcuts from both keymap scopes', () => {

--- a/apps/desktop/src/components/settings/rebuild-index-field.test.tsx
+++ b/apps/desktop/src/components/settings/rebuild-index-field.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const rebuildIndexVisibly = vi.hoisted(() => vi.fn(async () => undefined))
+const graph = vi.hoisted(() => ({ indexGeneration: 7 as number | null }))
+vi.mock('@/lib/rebuild-index', () => ({ rebuildIndexVisibly }))
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({ indexGeneration: graph.indexGeneration }),
+}))
+
+const { RebuildIndexField } = await import('./rebuild-index-field')
+
+function rebuildButton(): HTMLButtonElement {
+  const element = screen.getByRole('button', { name: /rebuild/i })
+  if (!(element instanceof HTMLButtonElement)) {
+    throw new Error('expected a <button>')
+  }
+  return element
+}
+
+beforeEach(() => {
+  graph.indexGeneration = 7
+  rebuildIndexVisibly.mockClear()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('RebuildIndexField', () => {
+  it('rebuilds at the open index generation', async () => {
+    render(<RebuildIndexField />)
+
+    fireEvent.click(rebuildButton())
+
+    await waitFor(() => expect(rebuildIndexVisibly).toHaveBeenCalledWith(7))
+  })
+
+  it('disables the button while a rebuild is in flight, then re-enables it', async () => {
+    let finish: () => void = () => {}
+    rebuildIndexVisibly.mockImplementationOnce(
+      () => new Promise((resolve) => (finish = () => resolve(undefined))),
+    )
+    render(<RebuildIndexField />)
+
+    fireEvent.click(rebuildButton())
+
+    const pending = await screen.findByRole('button', { name: /rebuilding/i })
+    expect(pending.hasAttribute('disabled')).toBe(true)
+
+    finish()
+    await waitFor(() => expect(rebuildButton().hasAttribute('disabled')).toBe(false))
+  })
+
+  it('is disabled when no graph index is open', () => {
+    graph.indexGeneration = null
+    render(<RebuildIndexField />)
+
+    expect(rebuildButton().hasAttribute('disabled')).toBe(true)
+    fireEvent.click(rebuildButton())
+    expect(rebuildIndexVisibly).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/components/settings/rebuild-index-field.tsx
+++ b/apps/desktop/src/components/settings/rebuild-index-field.tsx
@@ -8,9 +8,10 @@ import { SettingsField } from './field'
 /**
  * The recovery lever for the local index: a one-click full rebuild from the
  * markdown files (the same action as the palette's "Rebuild search index").
- * Progress and failures surface through the operations status UI; the button
- * itself only holds the in-flight state so a second click can't start an
- * overlapping rebuild.
+ * Progress and failures surface through the operations status UI. The local
+ * in-flight state only drives the label and disabled treatment —
+ * rebuildIndexVisibly itself coalesces overlapping requests, including races
+ * with the palette command.
  */
 export function RebuildIndexField(): ReactElement {
   const { indexGeneration } = useGraph()

--- a/apps/desktop/src/components/settings/rebuild-index-field.tsx
+++ b/apps/desktop/src/components/settings/rebuild-index-field.tsx
@@ -1,0 +1,55 @@
+import { useState, type ReactElement } from 'react'
+import { RefreshCw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { rebuildIndexVisibly } from '@/lib/rebuild-index'
+import { useGraph } from '@/providers/graph-provider'
+import { SettingsField } from './field'
+
+/**
+ * The recovery lever for the local index: a one-click full rebuild from the
+ * markdown files (the same action as the palette's "Rebuild search index").
+ * Progress and failures surface through the operations status UI; the button
+ * itself only holds the in-flight state so a second click can't start an
+ * overlapping rebuild.
+ */
+export function RebuildIndexField(): ReactElement {
+  const { indexGeneration } = useGraph()
+  const [rebuilding, setRebuilding] = useState(false)
+
+  const rebuild = async (): Promise<void> => {
+    if (indexGeneration === null || rebuilding) {
+      return
+    }
+    setRebuilding(true)
+    try {
+      await rebuildIndexVisibly(indexGeneration)
+    } finally {
+      setRebuilding(false)
+    }
+  }
+
+  return (
+    <SettingsField
+      legend="Rebuild index"
+      description="Reflect keeps a local index of your notes to power search and links. If results ever look stale or incomplete, rebuild it — your notes are never changed."
+    >
+      <div className="mt-3">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={indexGeneration === null || rebuilding}
+          onClick={() => void rebuild()}
+          className="text-text-secondary"
+        >
+          <RefreshCw
+            aria-hidden
+            strokeWidth={1.75}
+            className={rebuilding ? 'animate-spin' : undefined}
+          />
+          {rebuilding ? 'Rebuilding…' : 'Rebuild index'}
+        </Button>
+      </div>
+    </SettingsField>
+  )
+}

--- a/apps/desktop/src/components/settings/search-section.tsx
+++ b/apps/desktop/src/components/settings/search-section.tsx
@@ -6,13 +6,15 @@ import { useEmbedStatus } from '@/lib/use-embed-status'
 import { useSettings } from '@/providers/settings-provider'
 import { SettingsField } from './field'
 import { ModelDownloadProgress } from './model-download-progress'
+import { RebuildIndexField } from './rebuild-index-field'
 import { SettingsSection } from './section'
 
 /**
- * The search settings: the semantic-search opt-in (Plan 09). Enabling
- * persists `semanticSearchEnabled`; EmbeddingsSync reacts by loading the
- * model, and the first load's ~90MB download streams through this section as
- * a progress bar (the `embed:status` events carry byte counts).
+ * The search settings: the semantic-search opt-in (Plan 09) and the index
+ * rebuild action. Enabling semantic search persists `semanticSearchEnabled`;
+ * EmbeddingsSync reacts by loading the model, and the first load's ~90MB
+ * download streams through this section as a progress bar (the `embed:status`
+ * events carry byte counts).
  */
 export function SearchSection(): ReactElement {
   const { settings, updateSettings } = useSettings()
@@ -90,6 +92,7 @@ export function SearchSection(): ReactElement {
       >
         <div className="mt-3">{control}</div>
       </SettingsField>
+      <RebuildIndexField />
     </SettingsSection>
   )
 }

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -1,10 +1,10 @@
-import { embedStatus, errorMessage, notePath, randomNotePath, rebuildIndex } from '@reflect/core'
+import { errorMessage, notePath, randomNotePath } from '@reflect/core'
 import { ulid } from 'ulidx'
 import { todayIso } from '@/lib/dates'
 import { toggleNotePinned } from '@/lib/note-pin'
 import { toggleNotePrivate } from '@/lib/note-private'
 import { startOperation } from '@/lib/operations'
-import { backfillEmbeddingsVisibly } from '@/lib/semantic'
+import { rebuildIndexVisibly } from '@/lib/rebuild-index'
 import { notePathForRoute, type Route } from '@/routing/route'
 import { registerCommands } from './registry'
 import type { AppCommand } from './types'
@@ -159,22 +159,7 @@ const APP_COMMANDS: AppCommand[] = [
       if (generation === null) {
         return
       }
-      // The index is a rebuildable cache; a full rebuild is safe and visible.
-      const operation = startOperation('Rebuilding search index')
-      try {
-        await rebuildIndex({ generation })
-        operation.done()
-      } catch (cause) {
-        operation.fail(cause instanceof Error ? cause.message : String(cause))
-        return
-      }
-      // index_clear wiped the embedding tables with everything else — rebuild
-      // them too, or semantic search stays silently empty until some other
-      // trigger re-embeds.
-      const embed = await embedStatus()
-      if (embed.status === 'ready') {
-        await backfillEmbeddingsVisibly({ generation, modelId: embed.model })
-      }
+      await rebuildIndexVisibly(generation)
     },
   },
 ]

--- a/apps/desktop/src/lib/rebuild-index.test.ts
+++ b/apps/desktop/src/lib/rebuild-index.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EmbedStatus } from '@reflect/core'
+import { resetOperations } from '@/lib/operations'
+
+const rebuildIndex = vi.hoisted(() =>
+  vi.fn<(options: { generation: number }) => Promise<void>>(async () => undefined),
+)
+const embedStatus = vi.hoisted(() =>
+  vi.fn<() => Promise<EmbedStatus>>(async () => ({ status: 'uninitialized' })),
+)
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  rebuildIndex,
+  embedStatus,
+}))
+
+const { rebuildIndexVisibly } = await import('./rebuild-index')
+
+beforeEach(() => {
+  rebuildIndex.mockClear()
+})
+
+afterEach(() => {
+  resetOperations()
+})
+
+describe('rebuildIndexVisibly', () => {
+  it('coalesces concurrent requests at the same generation onto one pass', async () => {
+    let finish: () => void = () => {}
+    rebuildIndex.mockImplementationOnce(
+      () => new Promise((resolve) => (finish = () => resolve(undefined))),
+    )
+
+    const first = rebuildIndexVisibly(7)
+    const second = rebuildIndexVisibly(7)
+
+    expect(second).toBe(first)
+    expect(rebuildIndex).toHaveBeenCalledTimes(1)
+
+    finish()
+    await first
+
+    // Once settled, the guard is released and the next request rebuilds again.
+    await rebuildIndexVisibly(7)
+    expect(rebuildIndex).toHaveBeenCalledTimes(2)
+  })
+
+  it('starts a fresh pass for a different generation', async () => {
+    let finishFirst: () => void = () => {}
+    rebuildIndex.mockImplementationOnce(
+      () => new Promise((resolve) => (finishFirst = () => resolve(undefined))),
+    )
+
+    const first = rebuildIndexVisibly(7)
+    await rebuildIndexVisibly(8)
+
+    expect(rebuildIndex).toHaveBeenCalledTimes(2)
+    expect(rebuildIndex).toHaveBeenNthCalledWith(2, { generation: 8 })
+
+    finishFirst()
+    await first
+  })
+
+  it('absorbs a failed rebuild and releases the in-flight guard', async () => {
+    rebuildIndex.mockRejectedValueOnce(new Error('index on fire'))
+    await expect(rebuildIndexVisibly(7)).resolves.toBeUndefined()
+
+    await rebuildIndexVisibly(7)
+    expect(rebuildIndex).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/desktop/src/lib/rebuild-index.ts
+++ b/apps/desktop/src/lib/rebuild-index.ts
@@ -3,6 +3,8 @@ import { startOperation } from '@/lib/operations'
 import { invalidateIndexQueries } from '@/lib/query-client'
 import { backfillEmbeddingsVisibly } from '@/lib/semantic'
 
+let inFlight: { generation: number; promise: Promise<void> } | null = null
+
 /**
  * Full index rebuild with user-visible status: wipe and re-derive the SQLite
  * projection from the markdown files, refresh the query caches, and re-embed
@@ -10,8 +12,27 @@ import { backfillEmbeddingsVisibly } from '@/lib/semantic'
  * the settings page's Rebuild index button so the whole recipe stays one
  * definition. The index is a rebuildable cache — a full rebuild is always
  * safe and never touches the notes themselves.
+ *
+ * Requests coalesce while a rebuild runs: a second call at the same
+ * generation (a double-click, or the palette and the settings button racing)
+ * returns the in-flight pass instead of starting an overlapping wipe. A call
+ * at a *different* generation starts fresh — the graph changed, and Rust's
+ * generation gate drops the superseded pass's writes anyway.
  */
-export async function rebuildIndexVisibly(generation: number): Promise<void> {
+export function rebuildIndexVisibly(generation: number): Promise<void> {
+  if (inFlight !== null && inFlight.generation === generation) {
+    return inFlight.promise
+  }
+  const promise = runRebuild(generation).finally(() => {
+    if (inFlight !== null && inFlight.promise === promise) {
+      inFlight = null
+    }
+  })
+  inFlight = { generation, promise }
+  return promise
+}
+
+async function runRebuild(generation: number): Promise<void> {
   const operation = startOperation('Rebuilding search index')
   try {
     await rebuildIndex({ generation })

--- a/apps/desktop/src/lib/rebuild-index.ts
+++ b/apps/desktop/src/lib/rebuild-index.ts
@@ -1,0 +1,34 @@
+import { embedStatus, errorMessage, rebuildIndex } from '@reflect/core'
+import { startOperation } from '@/lib/operations'
+import { invalidateIndexQueries } from '@/lib/query-client'
+import { backfillEmbeddingsVisibly } from '@/lib/semantic'
+
+/**
+ * Full index rebuild with user-visible status: wipe and re-derive the SQLite
+ * projection from the markdown files, refresh the query caches, and re-embed
+ * if semantic search is on. Shared by the `index.rebuild` palette command and
+ * the settings page's Rebuild index button so the whole recipe stays one
+ * definition. The index is a rebuildable cache — a full rebuild is always
+ * safe and never touches the notes themselves.
+ */
+export async function rebuildIndexVisibly(generation: number): Promise<void> {
+  const operation = startOperation('Rebuilding search index')
+  try {
+    await rebuildIndex({ generation })
+    operation.done()
+  } catch (cause) {
+    operation.fail(errorMessage(cause))
+    return
+  }
+  // A manual rebuild bypasses the watcher pipeline (whose onApplied refreshes
+  // the caches), so cached note lists, backlinks, and tags would otherwise
+  // show pre-rebuild rows until some unrelated change invalidated them.
+  invalidateIndexQueries()
+  // index_clear wiped the embedding tables with everything else — rebuild
+  // them too, or semantic search stays silently empty until some other
+  // trigger re-embeds.
+  const embed = await embedStatus()
+  if (embed.status === 'ready') {
+    await backfillEmbeddingsVisibly({ generation, modelId: embed.model })
+  }
+}


### PR DESCRIPTION
## Summary

The SQLite projection under `.reflect/` is a rebuildable cache, but the only repair lever was the palette's "Rebuild search index" command. This adds the same action to the settings page as a **Rebuild index** button in the Search section, worded non-technically: "Reflect keeps a local index of your notes to power search and links. If results ever look stale or incomplete, rebuild it — your notes are never changed."

- The button disables while a rebuild is in flight (label flips to "Rebuilding…") and until a graph index is open; progress and failures surface through the existing operations status UI.
- The palette command's recipe — wipe and re-derive the projection, then re-run the embedding backfill when semantic search is on — moves into a shared `rebuildIndexVisibly()` helper (`apps/desktop/src/lib/rebuild-index.ts`), so the button and `index.rebuild` stay one definition.
- Fix that fell out of the extraction: the helper invalidates the TanStack Query index caches after a successful rebuild. The palette path previously skipped this — a manual rebuild bypasses the watcher pipeline whose `onApplied` refreshes the caches, so note lists, backlinks, and tags kept showing pre-rebuild rows until an unrelated change invalidated them. Both entry points get the fix.

## Test plan

- New `rebuild-index-field.test.tsx`: clicking rebuilds at the open index generation, the button disables while in flight and re-enables after, and it stays disabled (click is a no-op) with no graph open.
- `settings-screen.test.tsx`: exercises the whole chain through the fake bridge — click → `index_clear` → the projection-version stamp that marks a completed rebuild — plus the disabled state without a graph.
- Existing `app-commands.test.ts` coverage of `index.rebuild` (generation gating, embedding backfill) passes unchanged against the extracted helper.
- `pnpm check` (typecheck + lint) clean; 37 tests across the three affected files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches index wipe/rebuild and query invalidation paths used by search and navigation; changes are localized to desktop UI and a shared helper with tests, but stale-data fixes affect post-rebuild UX broadly.
> 
> **Overview**
> Adds a **Rebuild index** control to Settings → Search so users can run the same full local-index rebuild as the palette’s “Rebuild search index,” with copy that stresses notes are unchanged. The button uses the open graph’s `indexGeneration`, shows **Rebuilding…** / spin while work runs, stays disabled when no index is open, and relies on the existing operations UI for progress and errors.
> 
> Palette `index.rebuild` and the new UI both call a shared **`rebuildIndexVisibly()`** helper that runs the wipe/re-derive flow, surfaces status via operations, **invalidates TanStack Query index caches** after success (fixing stale lists/backlinks/tags when rebuild bypasses the watcher’s `onApplied`), optionally re-runs embedding backfill when semantic search is ready, and **coalesces** concurrent rebuilds at the same generation.
> 
> Tests cover the field component, settings-screen integration through the fake bridge (`index_clear` / `index_meta_set`), and helper coalescing / generation / failure behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3efcf1118f74dcddfd79bf37b9da9385860f224. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->