### PR TITLE
Let users pick a per-graph identity color

### DIFF
--- a/apps/desktop/src/components/graph-chooser.test.tsx
+++ b/apps/desktop/src/components/graph-chooser.test.tsx
@@ -1,15 +1,29 @@
+import type { ReactNode } from 'react'
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom/vitest'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setBridge } from '@reflect/core'
 import { GraphProvider } from '@/providers/graph-provider'
+import { SettingsProvider } from '@/providers/settings-provider'
 import { GraphChooser } from './graph-chooser'
 
 vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn() }))
 
 let invokeLog: Array<[string, Record<string, unknown>]>
 let recents: Array<{ root: string; name: string; openedMs: number }>
+let storedSettings: Record<string, unknown>
+let queryClient: QueryClient
+
+// Mirrors the main.tsx provider order: settings above the graph lifecycle.
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>
+    <SettingsProvider>
+      <GraphProvider>{children}</GraphProvider>
+    </SettingsProvider>
+  </QueryClientProvider>
+)
 
 beforeEach(() => {
   invokeLog = []
@@ -17,6 +31,10 @@ beforeEach(() => {
     { root: '/graphs/work', name: 'work', openedMs: 2 },
     { root: '/graphs/personal', name: 'personal', openedMs: 1 },
   ]
+  storedSettings = {}
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  })
   setBridge({
     invoke: async (command, args) => {
       invokeLog.push([command, args])
@@ -33,6 +51,8 @@ beforeEach(() => {
         case 'list_files':
         case 'db_query':
           return []
+        case 'settings_load':
+          return storedSettings
         default:
           return null
       }
@@ -44,6 +64,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup() // `globals: false` disables testing-library's automatic cleanup
   setBridge(null)
+  queryClient.clear()
 })
 
 describe('GraphChooser', () => {
@@ -51,11 +72,7 @@ describe('GraphChooser', () => {
   // own flows are exercised after that first open settles.
   it('lists recent graphs and reopens one on click', async () => {
     const user = userEvent.setup()
-    render(
-      <GraphProvider>
-        <GraphChooser />
-      </GraphProvider>,
-    )
+    render(<GraphChooser />, { wrapper })
 
     await waitFor(() => expect(screen.getByText('personal')).toBeInTheDocument())
     expect(screen.getByText('/graphs/personal')).toBeInTheDocument()
@@ -68,16 +85,27 @@ describe('GraphChooser', () => {
 
   it('forgets a recent graph and refreshes the list', async () => {
     const user = userEvent.setup()
-    render(
-      <GraphProvider>
-        <GraphChooser />
-      </GraphProvider>,
-    )
+    render(<GraphChooser />, { wrapper })
 
     await waitFor(() => expect(screen.getByText('personal')).toBeInTheDocument())
     await user.click(screen.getByRole('button', { name: 'Forget personal' }))
 
     await waitFor(() => expect(screen.queryByText('personal')).not.toBeInTheDocument())
     expect(invokeLog).toContainEqual(['forget_recent', { root: '/graphs/personal' }])
+  })
+
+  it('tints a recent folder icon with the chosen graph color, muted otherwise', async () => {
+    storedSettings = { graphColors: { '/graphs/personal': 'teal' } }
+    render(<GraphChooser />, { wrapper })
+
+    await waitFor(() => expect(screen.getByText('personal')).toBeInTheDocument())
+    const personalIcon = screen
+      .getByText('personal')
+      .closest('button')
+      ?.querySelector('svg')
+    await waitFor(() => expect(personalIcon).toHaveStyle({ color: '#14b8a6' }))
+
+    const workIcon = screen.getByText('work').closest('button')?.querySelector('svg')
+    expect(workIcon).toHaveClass('text-text-muted')
   })
 })

--- a/apps/desktop/src/components/graph-chooser.tsx
+++ b/apps/desktop/src/components/graph-chooser.tsx
@@ -1,14 +1,20 @@
 import { type ReactElement } from 'react'
 import { Folder, FolderPlus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { useGraphColors } from '@/hooks/use-graph-colors'
+import { graphColorCss } from '@/lib/graph-colors'
+import { cn } from '@/lib/utils'
 import { useGraph } from '@/providers/graph-provider'
 
 /**
  * First-run / no-graph screen: open a folder as a graph, or reopen a recent one.
- * Shown by `App` whenever no graph is active (Plan 02 loading gate).
+ * Shown by `App` whenever no graph is active (Plan 02 loading gate). A recent's
+ * folder icon takes the graph's identity color once one is chosen (sidebar
+ * footer → Graph color); until then it stays muted.
  */
 export function GraphChooser(): ReactElement {
   const { recents, error, pickAndOpen, openRecent, forget } = useGraph()
+  const { colorFor } = useGraphColors()
 
   return (
     <div className="flex h-screen w-screen overflow-auto bg-surface-app p-8">
@@ -44,42 +50,46 @@ export function GraphChooser(): ReactElement {
               Recent
             </p>
             <ul className="space-y-px">
-              {recents.map((recent) => (
-                <li
-                  key={recent.root}
-                  className="group flex items-center justify-between gap-2 rounded-md px-2 py-1.5 transition-colors duration-100 hover:bg-surface-hover"
-                >
-                  <button
-                    type="button"
-                    onClick={() => void openRecent(recent.root)}
-                    className="flex min-w-0 flex-1 items-center gap-2.5 text-left"
+              {recents.map((recent) => {
+                const color = colorFor(recent.root)
+                return (
+                  <li
+                    key={recent.root}
+                    className="group flex items-center justify-between gap-2 rounded-md px-2 py-1.5 transition-colors duration-100 hover:bg-surface-hover"
                   >
-                    <Folder
-                      aria-hidden
-                      strokeWidth={1.75}
-                      className="size-4 shrink-0 text-text-muted"
-                    />
-                    <span className="min-w-0">
-                      <span className="block truncate text-sm font-medium text-text">
-                        {recent.name}
+                    <button
+                      type="button"
+                      onClick={() => void openRecent(recent.root)}
+                      className="flex min-w-0 flex-1 items-center gap-2.5 text-left"
+                    >
+                      <Folder
+                        aria-hidden
+                        strokeWidth={1.75}
+                        className={cn('size-4 shrink-0', color === undefined && 'text-text-muted')}
+                        style={color === undefined ? undefined : { color: graphColorCss(color) }}
+                      />
+                      <span className="min-w-0">
+                        <span className="block truncate text-sm font-medium text-text">
+                          {recent.name}
+                        </span>
+                        <span className="block truncate text-xs text-text-muted">
+                          {recent.root}
+                        </span>
                       </span>
-                      <span className="block truncate text-xs text-text-muted">
-                        {recent.root}
-                      </span>
-                    </span>
-                  </button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="xs"
-                    onClick={() => void forget(recent.root)}
-                    aria-label={`Forget ${recent.name}`}
-                    className="shrink-0 text-text-muted opacity-0 transition-opacity duration-100 hover:text-text-secondary group-hover:opacity-100 focus-visible:opacity-100 group-focus-within:opacity-100"
-                  >
-                    Forget
-                  </Button>
-                </li>
-              ))}
+                    </button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="xs"
+                      onClick={() => void forget(recent.root)}
+                      aria-label={`Forget ${recent.name}`}
+                      className="shrink-0 text-text-muted opacity-0 transition-opacity duration-100 hover:text-text-secondary group-hover:opacity-100 focus-visible:opacity-100 group-focus-within:opacity-100"
+                    >
+                      Forget
+                    </Button>
+                  </li>
+                )
+              })}
             </ul>
           </div>
         ) : null}

--- a/apps/desktop/src/components/graph-swatch.tsx
+++ b/apps/desktop/src/components/graph-swatch.tsx
@@ -1,0 +1,26 @@
+import type { ReactElement } from 'react'
+import type { GraphColor } from '@reflect/core'
+import { graphColorCss } from '@/lib/graph-colors'
+import { cn } from '@/lib/utils'
+
+interface GraphSwatchProps {
+  /** The graph's chosen color; `undefined` renders the default (app accent). */
+  color?: GraphColor
+  /** Size (and shape overrides) — the swatch has no intrinsic dimensions. */
+  className?: string
+}
+
+/**
+ * A graph's identity color as a small rounded square — the visual anchor for
+ * "which graph is this" in the sidebar footer, the graph switcher, and the
+ * color picker. Decorative: always paired with the graph's name.
+ */
+export function GraphSwatch({ color, className }: GraphSwatchProps): ReactElement {
+  return (
+    <span
+      aria-hidden
+      className={cn('flex-none rounded-md', className)}
+      style={{ backgroundColor: graphColorCss(color) }}
+    />
+  )
+}

--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -98,6 +98,7 @@ describe('SettingsScreen', () => {
           dateFormat: 'mdy',
           weekStartDay: 'monday',
           allNotesFilterTags: ['book', 'link', 'person'],
+          graphColors: {},
           aiModels: [],
           defaultAiModelId: null,
         },
@@ -134,6 +135,7 @@ describe('SettingsScreen', () => {
           dateFormat: 'mdy',
           weekStartDay: 'monday',
           allNotesFilterTags: ['book', 'link', 'person'],
+          graphColors: {},
           aiModels: [],
           defaultAiModelId: null,
         },
@@ -160,6 +162,7 @@ describe('SettingsScreen', () => {
           dateFormat: 'mdy',
           weekStartDay: 'monday',
           allNotesFilterTags: ['book', 'link', 'person'],
+          graphColors: {},
           aiModels: [],
           defaultAiModelId: null,
         },
@@ -199,6 +202,7 @@ describe('SettingsScreen', () => {
           dateFormat: 'dmy',
           weekStartDay: 'monday',
           allNotesFilterTags: ['book', 'link', 'person'],
+          graphColors: {},
           aiModels: [],
           defaultAiModelId: null,
         },
@@ -234,6 +238,7 @@ describe('SettingsScreen', () => {
           dateFormat: 'mdy',
           weekStartDay: 'monday',
           allNotesFilterTags: ['book', 'link', 'person'],
+          graphColors: {},
           aiModels: [],
           defaultAiModelId: null,
         },
@@ -260,6 +265,7 @@ describe('SettingsScreen', () => {
           dateFormat: 'mdy',
           weekStartDay: 'monday',
           allNotesFilterTags: ['book', 'link', 'person', 'meeting'],
+          graphColors: {},
           aiModels: [],
           defaultAiModelId: null,
         },
@@ -318,6 +324,7 @@ describe('SettingsScreen', () => {
           dateFormat: 'mdy',
           weekStartDay: 'monday',
           allNotesFilterTags: ['person'],
+          graphColors: {},
           aiModels: [],
           defaultAiModelId: null,
         },
@@ -333,7 +340,7 @@ describe('SettingsScreen', () => {
 
     await waitFor(() =>
       expect(saved).toEqual([
-        { editorMarkdownSyntax: 'focus', editorSpellCheck: true, semanticSearchEnabled: true, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], aiModels: [], defaultAiModelId: null },
+        { editorMarkdownSyntax: 'focus', editorSpellCheck: true, semanticSearchEnabled: true, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], graphColors: {}, aiModels: [], defaultAiModelId: null },
       ]),
     )
     // The control flips to the loading state (EmbeddingsSync owns the actual
@@ -362,7 +369,7 @@ describe('SettingsScreen', () => {
 
     await waitFor(() =>
       expect(saved).toEqual([
-        { editorMarkdownSyntax: 'focus', editorSpellCheck: true, semanticSearchEnabled: false, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], aiModels: [], defaultAiModelId: null },
+        { editorMarkdownSyntax: 'focus', editorSpellCheck: true, semanticSearchEnabled: false, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], graphColors: {}, aiModels: [], defaultAiModelId: null },
       ]),
     )
     expect(screen.getByRole('button', { name: /enable semantic search/i })).toBeTruthy()
@@ -385,7 +392,7 @@ describe('SettingsScreen', () => {
     await waitFor(() => expect(invoked).toContain('embed_ensure'))
     await waitFor(() =>
       expect(saved).toEqual([
-        { editorMarkdownSyntax: 'focus', editorSpellCheck: true, semanticSearchEnabled: true, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], aiModels: [], defaultAiModelId: null },
+        { editorMarkdownSyntax: 'focus', editorSpellCheck: true, semanticSearchEnabled: true, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], graphColors: {}, aiModels: [], defaultAiModelId: null },
       ]),
     )
   })
@@ -404,7 +411,7 @@ describe('SettingsScreen', () => {
 
     await waitFor(() =>
       expect(saved).toEqual([
-        { editorMarkdownSyntax: 'focus', editorSpellCheck: true, semanticSearchEnabled: false, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], aiModels: [], defaultAiModelId: null },
+        { editorMarkdownSyntax: 'focus', editorSpellCheck: true, semanticSearchEnabled: false, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], graphColors: {}, aiModels: [], defaultAiModelId: null },
       ]),
     )
     expect(screen.getByRole('button', { name: /enable semantic search/i })).toBeTruthy()

--- a/apps/desktop/src/components/sidebar/graph-footer.tsx
+++ b/apps/desktop/src/components/sidebar/graph-footer.tsx
@@ -1,14 +1,20 @@
 import type { ReactElement } from 'react'
 import type { GraphInfo } from '@reflect/core'
 import { Check, FolderOpen } from 'lucide-react'
+import { GraphSwatch } from '@/components/graph-swatch'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useGraphColors } from '@/hooks/use-graph-colors'
+import { DEFAULT_GRAPH_COLOR, GRAPH_COLOR_OPTIONS } from '@/lib/graph-colors'
 import { cn } from '@/lib/utils'
 import { useGraph } from '@/providers/graph-provider'
 
@@ -16,12 +22,14 @@ const MENU_ITEM_CLASS = 'gap-2 px-2 py-1.5 text-[13px] text-text-secondary'
 
 /**
  * The sidebar footer: the graph's color swatch and name on the left — a
- * dropdown menu for switching to a recent graph or the OS folder picker. The
- * swatch pulses while the graph indexes. The menu content matches the trigger
- * width, so it stays inset from the sidebar edges.
+ * dropdown menu for switching to a recent graph, recoloring this graph, or
+ * the OS folder picker. The swatch pulses while the graph indexes. The menu
+ * content matches the trigger width, so it stays inset from the sidebar edges.
  */
 export function GraphFooter({ graph }: { graph: GraphInfo }): ReactElement {
   const { recents, indexing, openRecent, pickAndOpen } = useGraph()
+  const { colorFor, setColor } = useGraphColors()
+  const currentColor = colorFor(graph.root) ?? DEFAULT_GRAPH_COLOR
 
   return (
     <div className="flex items-center px-4 py-3">
@@ -33,12 +41,9 @@ export function GraphFooter({ graph }: { graph: GraphInfo }): ReactElement {
                 type="button"
                 className="flex min-w-0 flex-1 items-center space-x-2.5 text-left"
               >
-                <span
-                  aria-hidden
-                  className={cn(
-                    'h-5 w-5 flex-none rounded-md bg-accent',
-                    indexing && 'motion-safe:animate-pulse',
-                  )}
+                <GraphSwatch
+                  color={colorFor(graph.root)}
+                  className={cn('h-5 w-5', indexing && 'motion-safe:animate-pulse')}
                 />
                 <span className="min-w-0 truncate text-xs font-medium text-text">
                   {graph.name}
@@ -67,6 +72,7 @@ export function GraphFooter({ graph }: { graph: GraphInfo }): ReactElement {
                     }}
                     className={MENU_ITEM_CLASS}
                   >
+                    <GraphSwatch color={colorFor(recent.root)} className="size-3.5 rounded" />
                     <span className="min-w-0 flex-1 truncate">{recent.name}</span>
                     {current ? (
                       <Check aria-hidden className="size-3.5 shrink-0 text-accent" />
@@ -78,6 +84,27 @@ export function GraphFooter({ graph }: { graph: GraphInfo }): ReactElement {
             )
           })}
           {recents.length > 0 ? <DropdownMenuSeparator /> : null}
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger className={MENU_ITEM_CLASS}>
+              <GraphSwatch color={currentColor} className="size-3.5 rounded" />
+              <span className="min-w-0 flex-1 truncate">Graph color</span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent aria-label="Graph color">
+              {GRAPH_COLOR_OPTIONS.map((option) => (
+                <DropdownMenuItem
+                  key={option.id}
+                  onSelect={() => setColor(graph.root, option.id)}
+                  className={MENU_ITEM_CLASS}
+                >
+                  <GraphSwatch color={option.id} className="size-3.5 rounded" />
+                  <span className="min-w-0 flex-1">{option.label}</span>
+                  {option.id === currentColor ? (
+                    <Check aria-hidden className="size-3.5 shrink-0 text-accent" />
+                  ) : null}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
           <DropdownMenuItem
             onSelect={() => void pickAndOpen()}
             className={MENU_ITEM_CLASS}

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { GraphInfo, PinnedNote } from '@reflect/core'
+import { DEFAULT_SETTINGS, type GraphInfo, type PinnedNote, type Settings } from '@reflect/core'
 import type { CommandContext } from '@/lib/commands/types'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { RouterProvider } from '@/routing/router'
@@ -10,6 +10,9 @@ import { RouterProvider } from '@/routing/router'
 const getPinnedNotes = vi.hoisted(() => vi.fn<() => Promise<PinnedNote[]>>(async () => []))
 const openRecent = vi.hoisted(() => vi.fn())
 const pickAndOpen = vi.hoisted(() => vi.fn())
+const updateSettingsWith = vi.hoisted(() =>
+  vi.fn<(updater: (current: Settings) => Partial<Settings>) => void>(),
+)
 
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
@@ -30,8 +33,9 @@ vi.mock('@/providers/graph-provider', () => ({
 }))
 vi.mock('@/providers/settings-provider', () => ({
   useSettings: () => ({
-    settings: { dateFormat: 'mdy' },
+    settings: { dateFormat: 'mdy', graphColors: {} },
     updateSettings: () => {},
+    updateSettingsWith,
   }),
 }))
 
@@ -148,5 +152,18 @@ describe('Sidebar', () => {
     await userEvent.click(view.getByRole('button', { name: /Notes/ }))
     await userEvent.click(view.getByRole('menuitem', { name: /open another graph/i }))
     expect(pickAndOpen).toHaveBeenCalled()
+  })
+
+  it('the graph footer recolors the current graph', async () => {
+    const { view } = renderSidebar()
+
+    await userEvent.click(view.getByRole('button', { name: /Notes/ }))
+    await userEvent.click(view.getByRole('menuitem', { name: 'Graph color' }))
+    await userEvent.click(await view.findByRole('menuitem', { name: 'Teal' }))
+
+    // The patch composes over the latest settings at apply time — feed the
+    // updater a document and check the record it builds.
+    const updater = updateSettingsWith.mock.lastCall?.[0]
+    expect(updater?.(DEFAULT_SETTINGS)).toEqual({ graphColors: { '/notes': 'teal' } })
   })
 })

--- a/apps/desktop/src/hooks/use-graph-colors.ts
+++ b/apps/desktop/src/hooks/use-graph-colors.ts
@@ -1,0 +1,35 @@
+import { useCallback } from 'react'
+import type { GraphColor } from '@reflect/core'
+import { useSettings } from '@/providers/settings-provider'
+
+interface GraphColorsValue {
+  /** The color chosen for `root`, or `undefined` if it's on the default. */
+  colorFor: (root: string) => GraphColor | undefined
+  /** Choose `color` for `root`; applied instantly, persisted with settings. */
+  setColor: (root: string, color: GraphColor) => void
+}
+
+/**
+ * Per-graph identity colors, backed by the `graphColors` settings record
+ * (keyed by graph root path). Entries survive a graph being forgotten from
+ * recents on purpose — re-opening the graph restores its color.
+ */
+export function useGraphColors(): GraphColorsValue {
+  const { settings, updateSettingsWith } = useSettings()
+  const colors = settings.graphColors
+
+  const colorFor = useCallback((root: string) => colors[root], [colors])
+
+  const setColor = useCallback(
+    (root: string, color: GraphColor) => {
+      // Read-modify-write of a record: compose over the latest settings, not a
+      // render-time snapshot (see updateSettingsWith).
+      updateSettingsWith((current) => ({
+        graphColors: { ...current.graphColors, [root]: color },
+      }))
+    },
+    [updateSettingsWith],
+  )
+
+  return { colorFor, setColor }
+}

--- a/apps/desktop/src/lib/graph-colors.ts
+++ b/apps/desktop/src/lib/graph-colors.ts
@@ -1,0 +1,56 @@
+import { GRAPH_COLOR_IDS, type GraphColor } from '@reflect/core'
+
+/**
+ * Presentation for the graph identity colors (`graphColors` in settings).
+ * The ids and their order come from `@reflect/core`; this module owns how
+ * each id renders. `indigo` is the default and resolves through the live
+ * `--accent` token so it tracks the light/dark theme like the rest of the
+ * chrome; the other hues are fixed mid-range values (the design system
+ * deliberately has no ramps beyond indigo) chosen to read on both themes.
+ */
+
+/** The color a graph shows before the user picks one. */
+export const DEFAULT_GRAPH_COLOR: GraphColor = 'indigo'
+
+const GRAPH_COLOR_CSS: Record<GraphColor, string> = {
+  indigo: 'var(--accent)',
+  blue: '#3b82f6',
+  teal: '#14b8a6',
+  green: '#22c55e',
+  amber: '#f59e0b',
+  orange: '#f97316',
+  red: '#ef4444',
+  pink: '#ec4899',
+  purple: '#a855f7',
+}
+
+const GRAPH_COLOR_LABELS: Record<GraphColor, string> = {
+  indigo: 'Indigo',
+  blue: 'Blue',
+  teal: 'Teal',
+  green: 'Green',
+  amber: 'Amber',
+  orange: 'Orange',
+  red: 'Red',
+  pink: 'Pink',
+  purple: 'Purple',
+}
+
+/** A picker entry: the color id, its display label, and its CSS value. */
+export interface GraphColorOption {
+  id: GraphColor
+  label: string
+  css: string
+}
+
+/** Every graph color as a picker option, in display order. */
+export const GRAPH_COLOR_OPTIONS: GraphColorOption[] = GRAPH_COLOR_IDS.map((id) => ({
+  id,
+  label: GRAPH_COLOR_LABELS[id],
+  css: GRAPH_COLOR_CSS[id],
+}))
+
+/** The CSS color for a graph color id; `undefined` means the default. */
+export function graphColorCss(color: GraphColor | undefined): string {
+  return GRAPH_COLOR_CSS[color ?? DEFAULT_GRAPH_COLOR]
+}

--- a/apps/desktop/src/providers/settings-provider.test.tsx
+++ b/apps/desktop/src/providers/settings-provider.test.tsx
@@ -136,10 +136,35 @@ describe('SettingsProvider', () => {
           dateFormat: 'mdy',
           weekStartDay: 'monday',
           allNotesFilterTags: ['book'],
+          graphColors: {},
           aiModels: [],
           defaultAiModelId: null,
         },
       ]),
+    )
+  })
+
+  it('an equal-but-rebuilt record value does not trigger a save', async () => {
+    stored = { graphColors: { '/graphs/work': 'teal' } }
+    const { result } = renderHook(() => useSettings(), { wrapper })
+    await loadSettled()
+
+    // Same entries, new instance — re-choosing the current color rebuilds the
+    // record without changing it; that must not count as a change.
+    act(() => {
+      result.current.updateSettings({ graphColors: { '/graphs/work': 'teal' } })
+    })
+    await act(async () => {
+      await flushSettings()
+    })
+    expect(saved).toEqual([])
+
+    // A genuinely changed record still persists.
+    act(() => {
+      result.current.updateSettings({ graphColors: { '/graphs/work': 'pink' } })
+    })
+    await waitFor(() =>
+      expect(saved).toMatchObject([{ graphColors: { '/graphs/work': 'pink' } }]),
     )
   })
 
@@ -165,6 +190,7 @@ describe('SettingsProvider', () => {
           dateFormat: 'mdy',
           weekStartDay: 'monday',
           allNotesFilterTags: ['book', 'link', 'person'],
+          graphColors: {},
           aiModels: [],
           defaultAiModelId: null,
           futureKey: true,
@@ -203,6 +229,7 @@ describe('SettingsProvider', () => {
           dateFormat: 'mdy',
           weekStartDay: 'monday',
           allNotesFilterTags: ['book', 'link', 'person'],
+          graphColors: {},
           aiModels: [],
           defaultAiModelId: null,
           futureKey: true,
@@ -235,6 +262,7 @@ describe('SettingsProvider', () => {
           dateFormat: 'mdy',
           weekStartDay: 'monday',
           allNotesFilterTags: ['book', 'link', 'person'],
+          graphColors: {},
           aiModels: [],
           defaultAiModelId: null,
         },
@@ -393,6 +421,7 @@ describe('SettingsProvider', () => {
           dateFormat: 'mdy',
           weekStartDay: 'monday',
           allNotesFilterTags: ['book', 'link', 'person'],
+          graphColors: {},
           aiModels: [],
           defaultAiModelId: null,
         },
@@ -428,6 +457,7 @@ describe('SettingsProvider', () => {
         dateFormat: 'mdy',
         weekStartDay: 'monday',
         allNotesFilterTags: ['book', 'link', 'person'],
+        graphColors: {},
         aiModels: [],
         defaultAiModelId: null,
       },

--- a/apps/desktop/src/providers/settings-provider.tsx
+++ b/apps/desktop/src/providers/settings-provider.tsx
@@ -79,23 +79,37 @@ function createLoadSettle(): LoadSettle {
 }
 
 /**
- * One settings value equals another: identity, or element-wise for arrays —
- * documents are flat JSON, so arrays are the only non-primitive values
+ * One settings value equals another: identity, element-wise for arrays
  * (`allNotesFilterTags`; `aiModels` holds plain config objects, compared as
- * JSON below). Reference equality alone would make an equal-but-rebuilt array
- * (a re-parse — `aiModels`' transform rebuilds its array on every parse — or
- * a no-op update) read as a change and trigger spurious saves.
+ * JSON below), or key-wise for plain-object records (`graphColors`, whose
+ * values are scalars). Reference equality alone would make an equal-but-
+ * rebuilt value (a re-parse — the schema transforms rebuild arrays and
+ * records on every parse — or a no-op update) read as a change and trigger
+ * spurious saves.
  */
 function sameValue(a: unknown, b: unknown): boolean {
   if (Object.is(a, b)) {
     return true
   }
-  return (
-    Array.isArray(a) &&
-    Array.isArray(b) &&
-    a.length === b.length &&
-    a.every((item, index) => sameItem(item, b[index]))
-  )
+  if (Array.isArray(a) || Array.isArray(b)) {
+    return (
+      Array.isArray(a) &&
+      Array.isArray(b) &&
+      a.length === b.length &&
+      a.every((item, index) => sameItem(item, b[index]))
+    )
+  }
+  if (isRecord(a) && isRecord(b)) {
+    const aKeys = Object.keys(a)
+    const bKeys = Object.keys(b)
+    return aKeys.length === bKeys.length && aKeys.every((key) => sameItem(a[key], b[key]))
+  }
+  return false
+}
+
+/** A plain-object record (not an array, not null). */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 /** One array element equals another: identity for scalars, JSON for objects. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -83,6 +83,9 @@ export {
   dateFormatSchema,
   weekStartDaySchema,
   allNotesFilterTagsSchema,
+  graphColorSchema,
+  graphColorsSchema,
+  GRAPH_COLOR_IDS,
   aiProviderIdSchema,
   aiModelConfigSchema,
   aiModelsSchema,
@@ -95,6 +98,8 @@ export {
   type DateFormat,
   type WeekStartDay,
   type AllNotesFilterTags,
+  type GraphColor,
+  type GraphColors,
   type AiProviderId,
   type AiModelConfig,
 } from './settings/schema'

--- a/packages/core/src/settings/schema.test.ts
+++ b/packages/core/src/settings/schema.test.ts
@@ -12,6 +12,7 @@ describe('settingsSchema', () => {
       dateFormat: 'mdy',
       weekStartDay: 'monday',
       allNotesFilterTags: ['book', 'link', 'person'],
+      graphColors: {},
       aiModels: [],
       defaultAiModelId: null,
     })
@@ -23,6 +24,7 @@ describe('settingsSchema', () => {
     expect(DEFAULT_SETTINGS.dateFormat).toBe('mdy')
     expect(DEFAULT_SETTINGS.weekStartDay).toBe('monday')
     expect(DEFAULT_SETTINGS.allNotesFilterTags).toEqual(['book', 'link', 'person'])
+    expect(DEFAULT_SETTINGS.graphColors).toEqual({})
     expect(DEFAULT_SETTINGS.aiModels).toEqual([])
     expect(DEFAULT_SETTINGS.defaultAiModelId).toBeNull()
   })
@@ -87,9 +89,29 @@ describe('settingsSchema', () => {
       dateFormat: 'mdy',
       weekStartDay: 'monday',
       allNotesFilterTags: ['book', 'link', 'person'],
+      graphColors: {},
       aiModels: [],
       defaultAiModelId: null,
       futureKey: true,
+    })
+  })
+
+  describe('graphColors', () => {
+    it('passes valid entries through', () => {
+      const colors = { '/graphs/work': 'teal', '/graphs/home': 'amber' }
+      expect(settingsSchema.parse({ graphColors: colors }).graphColors).toEqual(colors)
+    })
+
+    it('drops a corrupt entry without losing the rest', () => {
+      const parsed = settingsSchema.parse({
+        graphColors: { '/graphs/work': 'teal', '/graphs/home': 'chartreuse', '/graphs/x': 42 },
+      })
+      expect(parsed.graphColors).toEqual({ '/graphs/work': 'teal' })
+    })
+
+    it('degrades a non-object value to the empty record', () => {
+      expect(settingsSchema.parse({ graphColors: 'teal' }).graphColors).toEqual({})
+      expect(settingsSchema.parse({ graphColors: ['teal'] }).graphColors).toEqual({})
     })
   })
 

--- a/packages/core/src/settings/schema.ts
+++ b/packages/core/src/settings/schema.ts
@@ -84,6 +84,51 @@ export type AllNotesFilterTags = z.infer<typeof allNotesFilterTagsSchema>
 export const semanticSearchEnabledSchema = z.boolean().catch(false)
 
 /**
+ * The preset palette for a graph's identity color (the swatch shown next to
+ * the graph name). A closed set of named ids — not raw hex — so the UI can
+ * map each id to values that read well in both light and dark themes.
+ */
+export const graphColorSchema = z.enum([
+  'indigo',
+  'blue',
+  'teal',
+  'green',
+  'amber',
+  'orange',
+  'red',
+  'pink',
+  'purple',
+])
+
+export type GraphColor = z.infer<typeof graphColorSchema>
+
+/** Every graph color id, in the order pickers should display them. */
+export const GRAPH_COLOR_IDS = graphColorSchema.options
+
+export type GraphColors = Record<string, GraphColor>
+
+/**
+ * Identity colors the user has chosen per graph, keyed by the graph's absolute
+ * root path. An absent key means the default (the app accent). Entries for
+ * forgotten graphs are kept on purpose — re-opening that graph later restores
+ * its color. Resilience is per entry: a corrupt value is dropped while the
+ * rest load, and a non-object value degrades to the empty record.
+ */
+export const graphColorsSchema = z
+  .record(z.string(), z.unknown())
+  .catch({})
+  .transform((entries) => {
+    const colors: GraphColors = {}
+    for (const [root, value] of Object.entries(entries)) {
+      const parsed = graphColorSchema.safeParse(value)
+      if (parsed.success) {
+        colors[root] = parsed.data
+      }
+    }
+    return colors
+  })
+
+/**
  * The cloud AI providers Reflect can call directly (BYOK — the user's own
  * keys, no Reflect-hosted proxy).
  */
@@ -140,6 +185,7 @@ export const settingsSchema = z
     dateFormat: dateFormatSchema,
     weekStartDay: weekStartDaySchema,
     allNotesFilterTags: allNotesFilterTagsSchema,
+    graphColors: graphColorsSchema,
     aiModels: aiModelsSchema,
     defaultAiModelId: defaultAiModelIdSchema,
   })


### PR DESCRIPTION
## What

Adds a per-graph identity color. The sidebar footer's graph dropdown gains a **Graph color** submenu with a nine-color preset palette (Indigo, Blue, Teal, Green, Amber, Orange, Red, Pink, Purple). The chosen color renders:

- on the sidebar footer swatch (previously hard-coded to `bg-accent`),
- as a dot next to each graph in the switcher menu,
- as a tint on that graph's folder icon on the chooser screen (muted until a color is chosen).

## How

- **Storage**: a `graphColors` record (graph root path → color id) in the existing settings document. Rust persists settings opaquely, so there are no native changes; the zod schema in `@reflect/core` owns the enum and validation, with `aiModels`-style per-entry resilience (a corrupt entry drops, the rest load). Entries deliberately survive "Forget" — re-opening a graph restores its color. Recents was rejected as a home because it truncates at 12 entries.
- **Palette**: `indigo` is the default and resolves through the live `--accent` token, so it keeps tracking light/dark like today. The other hues are fixed mid-range values (the design system intentionally has no ramps beyond indigo) chosen to read on both themes.
- **UI**: a shared `GraphSwatch` component + `useGraphColors` hook (writes through `updateSettingsWith` for race-safe record updates). The picker is a Radix submenu, fully keyboard-navigable.
- **Supporting fix**: the settings provider's `sameValue` assumed arrays were the only non-primitive setting values; it now deep-compares plain-object records too, so a rebuilt-but-equal record (e.g. re-choosing the current color) doesn't trigger a spurious disk write.

## Testing

- `pnpm check` (typecheck + lint) clean.
- 12 core schema tests and 55 desktop tests pass, including new coverage: choosing Teal from the footer menu produces the right settings patch, a chosen color tints the chooser folder icon, a corrupt `graphColors` entry drops without losing the rest, and an equal-but-rebuilt record doesn't re-save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and settings-schema changes only; no auth, native, or graph data paths. The `sameValue` record comparison is a small behavioral fix in persistence deduplication.
> 
> **Overview**
> Adds **per-graph identity colors** persisted in settings as a `graphColors` map (graph root path → preset color id). `@reflect/core` defines a nine-color enum with per-entry validation; corrupt entries drop without breaking the rest.
> 
> The sidebar footer graph menu gains a **Graph color** submenu; colors show on the footer swatch (replacing hard-coded accent), on switcher rows via shared `GraphSwatch`, and as folder icon tints on the open-graph chooser (muted until a color is chosen). `useGraphColors` updates through `updateSettingsWith` for safe record merges.
> 
> **Settings provider:** `sameValue` now deep-compares plain-object records (not only arrays), so re-selecting the current color or schema re-parses do not trigger extra disk writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ebff385b612d84d01d6a69bcda2e85a402f8425. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->