### PR TITLE
Plan 11: redesign link-capture bridge as spooler + async AI enrichment

### DIFF
--- a/docs/plans/11-link-capture.md
+++ b/docs/plans/11-link-capture.md
@@ -1,12 +1,16 @@
 # Plan 11 — Link Capture
 
 **Goal:** Launch-grade web capture: a Chrome extension hands URL/title/selection/
-screenshot to the **installed desktop app** over a local bridge; the desktop app owns all
-writes, BYOK AI enrichment, and privacy — appending to today's daily note.
+screenshot to the **installed desktop app** through a local **capture inbox**; the
+desktop app owns all writes, BYOK AI enrichment, and privacy — appending to today's
+daily note. Capture works **even when the desktop app is closed**: the raw link is
+spooled immediately and enriched asynchronously later.
 
 **Depends on:** Plan 02 (writes/assets), Plan 06 (append-to-today), Plan 10 (BYOK AI +
 keychain + privacy).
 **Unlocks:** the capture half of Reflect's daily-first spine.
+**Research:** bridge options, app-closed behavior, and the mobile story are mapped in
+[the bridge spike](../spikes/link-capture-bridge.md).
 
 **Architecture:** the extension lives in `apps/extension`; all durable writes, AI
 enrichment, and privacy checks go through `apps/desktop` + `@reflect/core`
@@ -18,95 +22,175 @@ downscale). See [Libraries](libraries.md).
 ## Scope
 
 **In:** Chrome extension (capture active URL, title, selection/highlights, screenshot),
-the extension→desktop bridge, desktop write path (daily-note `[[Links]]` entry + optional
-dedicated note), screenshot assets, BYOK AI description, provenance frontmatter, privacy
-enforcement.
-**Out:** Safari/iOS share (later), full article extraction / read-later (deferred),
-dedup-heavy clipping (basic dedup only).
+the native-messaging host + capture inbox, desktop write path (daily-note `[[Links]]`
+entry + optional dedicated note), screenshot assets, async enrichment (meta-tag scrape +
+BYOK AI description), provenance frontmatter, privacy enforcement.
+**Out:** Safari/iOS/Android share (later — but the capture envelope + inbox drain are
+deliberately platform-agnostic so mobile reuses them; see the spike doc), full article
+extraction / read-later (deferred), dedup-heavy clipping (basic dedup only).
 
 ## Architecture (inverted from V1: desktop owns writes)
 
 V1 called a Reflect-hosted `link-description-api`. V2 must not. Instead:
 
 - The **extension** captures and forwards; it stores **no model keys** and makes **no AI
-  calls**.
+  calls** — enrichment never happens in the extension.
 - The **desktop app** owns durable writes, file paths, asset storage, keychain access,
   BYOK AI calls, and the `private: true` check.
 
-### Bridge: native messaging first, loopback HTTP fallback
+### Bridge: native messaging host as a spooler (chosen)
 
-- **First spike: Chrome native messaging** — the official extension↔native-app channel;
-  no exposed local port. A small native-messaging host binary (bundled with the app)
-  relays the capture to the running desktop app (local IPC).
-- **Fallback: loopback HTTP** on `127.0.0.1` if screenshot payload size / streaming /
-  packaging make native messaging awkward. If used, it **must authenticate**: a
-  per-session token (minted by the desktop app, handed to the extension on pairing),
-  short TTL, plus strict `Origin`/sender checks — so a random local process can't inject
-  spoofed captures. Reject unauthenticated requests.
-- **Not** a `reflect://` deep link (too limited for screenshots/structured payloads/
+The host is a **spooler, not a relay** — it never talks to the running app directly;
+the inbox *is* the IPC:
+
+- Chrome spawns the bundled host binary per capture (`runtime.sendNativeMessage`); the
+  host validates the payload and **atomically writes** it (tmp + rename, one uniquely
+  named file per capture) into the **capture inbox**, then acks. Size limits are a
+  non-issue: extension→host allows 64 MiB; host→extension (1 MB cap) carries only acks.
+- **App running** → the file watcher sees the new capture within ~1 s and drains it.
+  **App closed** → the capture waits; the app drains the inbox on next launch. Either
+  way the raw link is never lost, and no daemon or open port exists.
+- The host locates the inbox via a pointer file the app maintains in a fixed app-data
+  location (active graph). No graph configured → the host returns a typed error the
+  extension surfaces ("open Reflect and pick a graph first").
+- The host is a tiny dedicated Rust crate bundled as a Tauri sidecar (`externalBin`,
+  signed/notarized with the app — verify [tauri#11992](https://github.com/tauri-apps/tauri/issues/11992)
+  in the code spike). **Not** a dual-mode main binary (browser kills the host on
+  disconnect; single-instance forwarding would sever Chrome's stdio; stdout must stay
+  protocol-pure).
+- The desktop app **rewrites user-level host manifests on every launch**, for **detected
+  browsers only** (Chrome channels, Chromium, Edge, Brave, Vivaldi, Opera, Arc — Arc has
+  its own dir; Windows uses HKCU keys). Launch-time rewrite self-heals macOS app
+  translocation and app moves. `allowed_origins` pins both the Chrome Web Store and Edge
+  Add-ons extension IDs; dev builds share the store ID via the manifest `key` trick.
+- **Fallback: loopback HTTP** only if native-messaging **packaging** proves unshippable
+  (payload size is not a reason). If ever built, copy Joplin's model: loopback-only
+  bind, `/ping` discovery, accept/reject pairing dialog minting a token, Host-header
+  validation. Reject unauthenticated requests.
+- **Not** a `reflect://` deep link (~2 KB practical URL budget; no structured payloads/
   retries) except as a URL-only last resort, and **never** a Reflect-hosted relay.
-  Choose in a short spike (reuses Plan 01's spike discipline).
+
+### Two-phase write: raw now, enrich later
+
+Every capture lands in two phases so saving never waits on the network or AI:
+
+1. **Raw entry (synchronous on drain):** the `[[Links]]` entry with URL/title/selection
+   + provenance is written immediately. This is the durable save.
+2. **Enrichment (asynchronous):** meta-tag scrape + AI description run later in the
+   desktop app and **update the existing entry in place**. Deferred while the app is
+   closed; retried on failure.
 
 ## Steps
 
 1. **Chrome extension** (`apps/extension`, MV3): action button + `⌘⇧P` (or `⌘⇧K` if reserved)
    to capture the active tab's URL, title, user-selected text/highlights, and a
    screenshot (`captureVisibleTab`). Minimal UI: confirm + optional note. No keys, no AI.
+   If the host is missing (app not installed) the extension explains + links the
+   download, queues the capture in `chrome.storage`, and retries later. Status states
+   are honest: **saved** (drained), **queued** (spooled or stored locally), **failed**.
 
-2. **Native-messaging host + desktop receiver.** Register the host manifest on install;
-   host forwards the capture payload to the desktop app. Desktop validates the payload
-   with zod, queues it, and acknowledges (so the extension can show success/retry).
+2. **Native-messaging host (sidecar) + manifest registration.** Tiny Rust crate built in
+   `beforeBuildCommand`, bundled via `externalBin`; pure-stdio discipline (log to
+   stderr). Validates with zod, writes the capture envelope + screenshot into the inbox
+   atomically, acks saved/queued or a typed error. Desktop app registers/rewrites
+   manifests for detected browsers on every launch.
 
-3. **Privacy gate first.** Resolve the capture target (today's daily note, or a chosen
-   note). If the target is `private: true`, **save the raw link locally without any cloud
-   AI** (no URL fetch, screenshot, selection, or note content sent out). Otherwise proceed
-   to enrichment.
+3. **Capture inbox + drain (core action).** A platform-agnostic capture envelope (zod)
+   in `actions/capture` — `{url, title, selection?, screenshotRef?, note?, capturedAt,
+   source}` — written identically by the desktop host today and by the future iOS
+   share extension (app-group inbox) / Android intent handler. `drainCaptureInbox`
+   validates, writes the **raw** entry (phase 1), schedules enrichment (phase 2), and
+   removes the spool file. Extend the Rust watcher (currently `daily/`+`notes/` `.md`
+   only) to also report the inbox dir.
 
-4. **BYOK enrichment.** Using the user's key (Plan 10), generate a short description from
-   URL + title + screenshot + selected text. Direct app→provider; obey the same provider/
-   error/visibility rules as the copilot.
+4. **Privacy gate first.** Resolve the capture target (today's daily note, or a chosen
+   note). If the target is `private: true`, **save the raw link locally and skip all
+   enrichment** (no URL fetch, no meta scrape, no screenshot/selection/note content sent
+   out). Otherwise proceed to enrichment.
 
-5. **Write path (desktop-owned).** Default shape:
+5. **Async enrichment (desktop-owned, never in the extension).** Runs after the raw
+   entry is saved, queued + retried like any background job:
+   - **Meta-tag scrape (no AI needed):** the app fetches the captured URL and extracts
+     `<title>`, meta description, and OpenGraph tags (`og:title`, `og:description`,
+     `og:image`, site name) to enrich the entry.
+   - **AI description (only when an AI connection is enabled, Plan 10):** feed the
+     screenshot + URL + title + selection + scraped meta to the user's configured
+     provider (e.g. OpenAI) to generate a short description of the website. Direct
+     app→provider; obey the same provider/error/visibility rules as the copilot.
+   - Enrichment **patches only the captured entry** (located via provenance/URL); if
+     the user already edited or removed it, skip rather than clobber. Record the
+     provider/model used in provenance.
+
+6. **Write path (desktop-owned).** Default shape:
    - append a `[[Links]]` entry to **today's daily note** (Plan 06 append-under-heading);
    - create a **dedicated markdown note** when the capture is rich (description +
      highlights + screenshot worth preserving);
-   - store screenshots under `assets/` with relative links (Plan 02);
+   - store screenshots under `assets/` with relative links (Plan 02), downscaled via the
+     `image` crate;
    - write minimal **provenance** frontmatter/markdown: original URL, captured title,
      captured time, source = extension, screenshot asset path, selection/highlights, and
      the AI provider/model used.
    Then reindex (Plan 04). Basic dedup: re-capturing the same URL updates rather than
    duplicates.
 
-6. **Errors + retries.** Reviewable failures (offline, no key, provider error). The
-   extension surfaces success/queued/failed; the raw link is always saved even if
-   enrichment fails.
+7. **Errors + retries.** Reviewable failures (offline, no key, provider error). The
+   extension surfaces saved/queued/failed; the raw link is always saved even if
+   enrichment fails; enrichment retries on next launch/online.
 
-7. **Tests.** Payload schema validation; private-target path writes raw link with **zero**
-   outbound AI; enrichment path produces description + provenance; screenshot lands in
-   `assets/` with a relative link; dedup updates in place.
+8. **Tests.** Envelope schema validation; spool-drain round-trip including the
+   **app-closed** path (file written with no app, drained on next start);
+   private-target path writes raw link with **zero** outbound traffic (no URL fetch, no
+   AI); enrichment updates the raw entry in place with description + meta + provenance;
+   enrichment skips an edited/removed entry; screenshot lands in `assets/` with a
+   relative link; dedup updates in place.
 
 ## Key decisions / contracts
 
 - **Desktop owns all writes, AI, and keys; the extension only captures + forwards.**
-- **Native messaging is the first bridge**, loopback HTTP the fallback; no hosted relay.
-- **Privacy check runs before enrichment**; private targets never hit cloud AI.
+- **The native-messaging host is a spooler; the capture inbox is the IPC.** Capture
+  works with the app closed; no socket, no port, no daemon.
+- **Two-phase write:** raw entry saved synchronously on drain; meta scrape + AI
+  description run asynchronously and update in place — never blocking the save, never
+  running in the extension.
+- **Manifests are rewritten every app launch, for detected browsers only.**
+- **The capture envelope + `drainCaptureInbox` are platform-agnostic** — the future
+  iOS share extension and Android intent handler write the same envelope into their own
+  inboxes (app-group container / direct), so mobile costs no rearchitecture.
+- **Privacy check runs before enrichment**; private targets never hit the network —
+  no meta fetch, no cloud AI.
 - **Captures are normal markdown + assets with provenance**, indexed like any note.
+- **Loopback HTTP only on packaging failure; deep links URL-only last resort; never a
+  hosted relay.**
 
 ## Acceptance criteria
 
 - With the extension installed, capturing a page appends a `[[Links]]` entry to today's
-  daily note with an AI description + screenshot under `assets/`.
-- Capturing into a `private: true` target saves the raw link with no outbound AI
+  daily note, then asynchronously gains an AI description + meta + screenshot under
+  `assets/`.
+- **Capturing with the desktop app closed** queues the capture; it lands (raw, then
+  enriched) on next app launch (test-asserted).
+- With no AI connection enabled, captures still get the raw entry + scraped meta tags;
+  no provider call is made.
+- Capturing into a `private: true` target saves the raw link with no outbound traffic
   (test-asserted).
-- Enrichment failure still saves the raw link; the extension shows status.
+- Enrichment failure still saves the raw link; the extension shows honest
+  saved/queued/failed status.
 - Re-capturing the same URL updates rather than duplicates.
 - `pnpm typecheck` + tests pass.
 
 ## Risks
 
-- **Native messaging packaging/registration** across install paths. De-risk in the spike;
-  keep the loopback fallback ready.
-- **Screenshot payload size** over the bridge. Compress/downscale; fall back to HTTP if
-  native messaging limits bite.
+- **Sidecar signing/notarization** — [tauri#11992](https://github.com/tauri-apps/tauri/issues/11992)
+  reports externalBin notarization failures; verify first in the code spike. Loopback
+  fallback stays documented. (Registration itself is de-risked: user-level manifest
+  writes, KeePassXC/Claude Desktop precedent — see the spike doc.)
+- **Inbox discovery** — the host depends on the app-data pointer file (active graph,
+  multi-graph switching, unwritable inbox). Keep the pointer format versioned + typed
+  errors for every miss.
+- **Async enrichment racing user edits** — the entry may be edited/moved before
+  enrichment lands; patch only the located entry, skip otherwise (tested).
 - **Privacy leakage via capture.** Same severity as Plan 10 — gate before enrichment +
   outbound-payload test.
+- **Stale manifests after uninstall** point browsers at a missing binary ("failed to
+  start native messaging host") — harmless but noisy; document cleanup in Plan 15
+  packaging.

--- a/docs/plans/11-link-capture.md
+++ b/docs/plans/11-link-capture.md
@@ -93,7 +93,10 @@ Every capture lands in two phases so saving never waits on the network or AI:
 
 2. **Native-messaging host (sidecar) + manifest registration.** Tiny Rust crate built in
    `beforeBuildCommand`, bundled via `externalBin`; pure-stdio discipline (log to
-   stderr). Validates with zod, writes the capture envelope + screenshot into the inbox
+   stderr). Deserializes the capture envelope using typed Rust structs (generated from
+   or manually mirroring the shared `@reflect/core` zod schema — Zod does not run in
+   Rust; the TS schema is the single source of truth and the Rust structs must match it),
+   writes the validated envelope + screenshot into the inbox
    atomically, acks **queued** on success or a typed error on failure. The host never
    observes drain, so it never acks "saved". Desktop app registers/rewrites
    manifests for detected browsers on every launch.
@@ -142,8 +145,12 @@ Every capture lands in two phases so saving never waits on the network or AI:
    - write minimal **provenance** frontmatter/markdown: original URL, captured title,
      captured time, source = extension, screenshot asset path (already written by drain
      step 3.3), selection/highlights, and (after enrichment) the AI provider/model used.
-   Then reindex (Plan 04). Basic dedup: re-capturing the same URL updates rather than
-   duplicates.
+   Then reindex (Plan 04). **Dedup:** a re-capture is detected when the same URL already
+   has an entry in today's `[[Links]]` section (same day, same note). In that case the
+   existing entry is updated in place — enrichment/provenance/screenshot are refreshed,
+   not duplicated. A capture on a *different day*, or into a *different note*, or with a
+   *different selection* always creates a new entry. URL alone is not the dedup key when
+   the target note or day differs.
 
 7. **Errors + retries.** Reviewable failures (offline, no key, provider error). The
    extension surfaces queued/failed; the raw link is always saved even if
@@ -177,8 +184,8 @@ Every capture lands in two phases so saving never waits on the network or AI:
 ## Acceptance criteria
 
 - With the extension installed, capturing a page appends a `[[Links]]` entry to today's
-  daily note, then asynchronously gains an AI description + meta + screenshot under
-  `assets/`.
+  daily note with the screenshot already saved under `assets/` (phase 1, synchronous),
+  then asynchronously gains an AI description + scraped meta tags (phase 2).
 - **Capturing with the desktop app closed** queues the capture; it lands (raw, then
   enriched) on next app launch (test-asserted).
 - With no AI connection enabled, captures still get the raw entry + scraped meta tags;

--- a/docs/plans/11-link-capture.md
+++ b/docs/plans/11-link-capture.md
@@ -87,26 +87,34 @@ Every capture lands in two phases so saving never waits on the network or AI:
    screenshot (`captureVisibleTab`). Minimal UI: confirm + optional note. No keys, no AI.
    If the host is missing (app not installed) the extension explains + links the
    download, queues the capture in `chrome.storage`, and retries later. Status states
-   are honest: **saved** (drained), **queued** (spooled or stored locally), **failed**.
+   are honest: **queued** (spooled into inbox or held in `chrome.storage` — the host
+   cannot observe drain), **failed**. The extension never claims "saved" since it has
+   no visibility into when the desktop app processes the spool.
 
 2. **Native-messaging host (sidecar) + manifest registration.** Tiny Rust crate built in
    `beforeBuildCommand`, bundled via `externalBin`; pure-stdio discipline (log to
    stderr). Validates with zod, writes the capture envelope + screenshot into the inbox
-   atomically, acks saved/queued or a typed error. Desktop app registers/rewrites
+   atomically, acks **queued** on success or a typed error on failure. The host never
+   observes drain, so it never acks "saved". Desktop app registers/rewrites
    manifests for detected browsers on every launch.
 
 3. **Capture inbox + drain (core action).** A platform-agnostic capture envelope (zod)
    in `actions/capture` — `{url, title, selection?, screenshotRef?, note?, capturedAt,
    source}` — written identically by the desktop host today and by the future iOS
    share extension (app-group inbox) / Android intent handler. `drainCaptureInbox`
-   validates, writes the **raw** entry (phase 1), schedules enrichment (phase 2), and
-   removes the spool file. Extend the Rust watcher (currently `daily/`+`notes/` `.md`
-   only) to also report the inbox dir.
+   executes these steps **in order**:
+   1. Resolve the capture target (today's daily note, or a chosen note).
+   2. **Privacy gate:** if the target is `private: true`, skip all enrichment and all
+      outbound traffic (no URL fetch, no meta scrape, no screenshot/selection/note
+      content sent out) — write the raw link only.
+   3. Copy the screenshot from the spool into `assets/` (downscaled via `image`) and
+      record the asset path. **The spool is not removed until assets are safely written.**
+   4. Write the **raw** `[[Links]]` entry + provenance (phase 1 — the durable save).
+   5. Remove the spool file.
+   6. If not private: schedule async enrichment (phase 2).
 
-4. **Privacy gate first.** Resolve the capture target (today's daily note, or a chosen
-   note). If the target is `private: true`, **save the raw link locally and skip all
-   enrichment** (no URL fetch, no meta scrape, no screenshot/selection/note content sent
-   out). Otherwise proceed to enrichment.
+   Extend the Rust watcher (currently `daily/`+`notes/` `.md` only) to also report the
+   inbox dir.
 
 5. **Async enrichment (desktop-owned, never in the extension).** Runs after the raw
    entry is saved, queued + retried like any background job:
@@ -121,20 +129,18 @@ Every capture lands in two phases so saving never waits on the network or AI:
      the user already edited or removed it, skip rather than clobber. Record the
      provider/model used in provenance.
 
-6. **Write path (desktop-owned).** Default shape:
+6. **Write path (desktop-owned, executed inside drain step 3 above).** Default shape:
    - append a `[[Links]]` entry to **today's daily note** (Plan 06 append-under-heading);
    - create a **dedicated markdown note** when the capture is rich (description +
      highlights + screenshot worth preserving);
-   - store screenshots under `assets/` with relative links (Plan 02), downscaled via the
-     `image` crate;
    - write minimal **provenance** frontmatter/markdown: original URL, captured title,
-     captured time, source = extension, screenshot asset path, selection/highlights, and
-     the AI provider/model used.
+     captured time, source = extension, screenshot asset path (already written by drain
+     step 3.3), selection/highlights, and (after enrichment) the AI provider/model used.
    Then reindex (Plan 04). Basic dedup: re-capturing the same URL updates rather than
    duplicates.
 
 7. **Errors + retries.** Reviewable failures (offline, no key, provider error). The
-   extension surfaces saved/queued/failed; the raw link is always saved even if
+   extension surfaces queued/failed; the raw link is always saved even if
    enrichment fails; enrichment retries on next launch/online.
 
 8. **Tests.** Envelope schema validation; spool-drain round-trip including the

--- a/docs/plans/11-link-capture.md
+++ b/docs/plans/11-link-capture.md
@@ -140,8 +140,10 @@ Every capture lands in two phases so saving never waits on the network or AI:
 
 6. **Write path (desktop-owned, executed inside drain step 3 above).** Default shape:
    - append a `[[Links]]` entry to **today's daily note** (Plan 06 append-under-heading);
-   - create a **dedicated markdown note** when the capture is rich (description +
-     highlights + screenshot worth preserving);
+   - create a **dedicated markdown note** when the capture has enough phase-1 content
+     to be worth preserving (selection/highlights present, or a screenshot) — the
+     description arrives later in phase 2 and is patched into the dedicated note then,
+     not used to decide whether to create it;
    - write minimal **provenance** frontmatter/markdown: original URL, captured title,
      captured time, source = extension, screenshot asset path (already written by drain
      step 3.3), selection/highlights, and (after enrichment) the AI provider/model used.

--- a/docs/plans/11-link-capture.md
+++ b/docs/plans/11-link-capture.md
@@ -113,6 +113,12 @@ Every capture lands in two phases so saving never waits on the network or AI:
    5. Remove the spool file.
    6. If not private: schedule async enrichment (phase 2).
 
+   **Two triggers for drain** — the app calls `drainCaptureInbox` in both places:
+   - **On launch:** scan the inbox directory for any files already present (captures
+     that arrived while the app was closed); drain each before starting the watcher.
+     The watcher only fires on *new* events and will miss pre-existing spool files.
+   - **On watcher event:** drain the newly created file as it lands.
+
    Extend the Rust watcher (currently `daily/`+`notes/` `.md` only) to also report the
    inbox dir.
 

--- a/docs/plans/11-link-capture.md
+++ b/docs/plans/11-link-capture.md
@@ -196,7 +196,9 @@ Every capture lands in two phases so saving never waits on the network or AI:
   (test-asserted).
 - Enrichment failure still saves the raw link; the extension shows honest
   saved/queued/failed status.
-- Re-capturing the same URL updates rather than duplicates.
+- Re-capturing the same URL **on the same day into the same note with the same
+  selection context** updates rather than duplicates; a different day, note, or
+  selection always creates a new entry.
 - `pnpm typecheck` + tests pass.
 
 ## Risks

--- a/docs/spikes/link-capture-bridge.md
+++ b/docs/spikes/link-capture-bridge.md
@@ -1,0 +1,193 @@
+# Spike — Link-capture bridge & mobile capture architecture (Plan 11)
+
+**Question:** How should the Chrome extension hand captures to the desktop app — and does
+the desktop app have to be running? Can the same architecture serve iOS/Android
+share-sheet capture later, all with **zero Reflect-hosted infrastructure**?
+(Desk research for the [Plan 11](../plans/11-link-capture.md) bridge spike; the code
+spike below still has to validate packaging.)
+
+**Verdict: native messaging, with the host as a *spooler*, not a relay.** The host binary
+writes the capture into a **capture inbox** (a spool directory of JSON + asset files);
+the desktop app drains the inbox — immediately via its file watcher when running, or on
+next launch when not. The inbox *is* the IPC. The same envelope + drain action serves
+iOS (app-group inbox written by a share extension) and Android (ACTION_SEND) later.
+**No hosted API is needed for any scenario**, and the desktop app does **not** need to be
+open to capture.
+
+## Key findings
+
+### 1. Native messaging works with the app closed — that decides it
+
+- Chrome itself spawns the host binary per `sendNativeMessage` call and communicates over
+  stdio; no daemon, launchd job, or running app is required
+  ([Chrome native messaging](https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging)).
+  A capture succeeds with Reflect closed **iff the host can do something useful alone** —
+  which a spool-to-inbox host can. (Counterexample: Bitwarden's host is a live proxy to
+  the app and hangs when the app is closed —
+  [bitwarden/clients#20929](https://github.com/bitwarden/clients/issues/20929).)
+- Size limits don't bite: **extension→host is 64 MiB** in current Chrome (4 GB in
+  Firefox); only **host→extension is 1 MB**, so replies must stay small JSON acks. A
+  base64 screenshot of a few MB fits comfortably. This removes the plan's stated reason
+  for the loopback-HTTP fallback ("screenshot payload size").
+- `runtime.sendNativeMessage` spawns one host process per message and treats the first
+  reply as the response — the right shape for infrequent captures, with no MV3
+  service-worker keepalive concerns (a `connectNative` port would also keep the SW alive
+  if ever needed —
+  [SW lifecycle](https://developer.chrome.com/docs/extensions/develop/concepts/service-workers/lifecycle)).
+- Protocol discipline: 4-byte native-order length prefix + UTF-8 JSON; **stdout must stay
+  protocol-pure** (log to stderr); binary data travels base64 inside JSON
+  (`tabs.captureVisibleTab` already returns a base64 data URL).
+
+### 2. The spool inbox beats a socket relay
+
+KeePassXC/Bitwarden/1Password all relay host→socket→running-app because they need the
+app's live unlocked state. Captures have no such dependency, so the relay (and its
+must-be-running flaw) is pure cost. Instead:
+
+- Host validates the payload, decodes the screenshot, and **atomically writes**
+  (`tmp/` + `rename(2)`, Maildir discipline, one uniquely-named file per capture) into
+  the inbox.
+- App running → its watcher sees the new file within ~1 s and runs the normal pipeline
+  (privacy gate → BYOK enrichment → daily-note `[[Links]]` append → assets →
+  provenance → reindex). App closed → the capture waits; the app drains the inbox on next
+  launch. Raw link is never lost — which Plan 11 step 6 requires anyway.
+- The host finds the inbox via a small pointer file the app maintains in a fixed app-data
+  location (active graph path). No graph configured → the host replies with a typed error
+  the extension can surface ("Open Reflect and pick a graph first").
+- Security: filesystem permissions (user-only) replace ports and tokens entirely, and the
+  browser enforces the `allowed_origins` extension-ID allowlist on who may launch the
+  host — strictly stronger than any loopback token scheme.
+- Nothing surveyed ships exactly this (password managers can't), but every mobile capture
+  app does (§5) — it's the same inbox pattern, which is the point.
+
+### 3. Packaging & registration (the real risk, now mapped)
+
+- **Sidecar:** a tiny Rust crate in the workspace, bundled via `externalBin`; lands in
+  `Reflect.app/Contents/MacOS/` and is **signed + notarized with the app** by the Tauri
+  bundler ([sidecar docs](https://v2.tauri.app/develop/sidecar/)). Tauri doesn't auto-build
+  workspace bins — build + rename to `<name>-<triple>` in `beforeBuildCommand` (the
+  official Node-sidecar guide's pattern). Watch open bug
+  [tauri#11992](https://github.com/tauri-apps/tauri/issues/11992) ("nested code is
+  modified" notarization failure with externalBin) — first thing the code spike checks.
+- **Do not** make the main binary dual-mode (argv flag): the browser SIGKILLs the host on
+  disconnect, `tauri-plugin-single-instance` would forward-and-exit (severing Chrome's
+  stdio pipes), and WebView/log chatter on stdout corrupts framing. A ~300 KB dedicated
+  host crate is the ecosystem norm (KeePassXC `keepassxc-proxy`, 1Password
+  `BrowserSupport`, Claude Desktop `chrome-native-host`).
+- **Registration:** the app **rewrites user-level manifests on every launch** (no admin
+  rights anywhere; self-heals macOS app-translocation and app moves — what Claude Desktop
+  and KeePassXC's "update manifests at startup" do). Only write for **browsers actually
+  detected** (Claude Desktop drew criticism for spraying manifests for uninstalled
+  browsers). Locations:
+  - macOS/Linux: per-browser `NativeMessagingHosts/` dirs — Chrome (+Beta/Dev/Canary),
+    Chromium, Edge, Brave, Vivaldi, Opera, and **Arc has its own**
+    (`~/Library/Application Support/Arc/User Data/NativeMessagingHosts/`).
+  - Windows: one `HKCU\Software\Google\Chrome\NativeMessagingHosts\<name>` key covers
+    Chrome/Brave/Vivaldi/Opera, and Edge falls back to it by documented search order; add
+    an explicit Edge key for completeness.
+  - The manifest `path` may point inside the .app bundle (standard practice).
+- **Stable extension IDs:** pin the Chrome Web Store ID via the manifest `key` trick so
+  dev builds share it; list both CWS and Edge Add-ons IDs in `allowed_origins`
+  (wildcards are not allowed). Firefox later: different manifest (`allowed_extensions` +
+  fixed gecko ID); Safari: a wholly different pipeline (extension inside a containing
+  app, `SFSafariWebExtensionHandler`) — out of first wave, but see §6.
+
+### 4. Loopback HTTP: demoted to packaging-failure fallback only
+
+Joplin's design (127.0.0.1:41184+, `/ping` discovery scan, accept/reject pairing dialog
+minting a token) is the best-of-breed loopback pattern if we ever need it. But it shares
+one structural flaw — **nothing works when the app is closed** (Joplin's #1 support
+issue) — plus port-squatting/impersonation by local processes, DNS-rebinding history
+(Zotero), Chrome's Local-Network-Access churn (extensions exempt with host permissions,
+but real breakage shipped in Chrome 142–143, fixed ≥144), and the standing cautionary
+tale of unauthenticated loopback servers
+([CVE-2025-49596](https://www.oligo.security/blog/critical-rce-vulnerability-in-anthropic-mcp-inspector-cve-2025-49596)).
+Native messaging avoids the entire class. Deep links stay a last resort: ~2 KB practical
+URL budget; Obsidian's clipper abandoned URI transfer for the clipboard because of it.
+
+### 5. Mobile: the same inbox, a different transport
+
+The capture envelope + inbox drain is **exactly** the shipping consensus on mobile, which
+is what makes "down the road" cheap:
+
+- **iOS share extension** (the share-button flow Reflect V1 users know): a separate
+  Xcode target; receives the page URL via `NSItemProvider`, and title/selection via the
+  `NSExtensionJavaScriptPreprocessingFile` JS hook (runs in the Safari page, returns
+  `{title, selection, …}` to the extension). It **cannot** write to the app's Documents
+  or launch the app (App-Review-risky responder-chain hacks aside) — it writes a capture
+  JSON into the **App Group shared container** and exits. The main app drains on next
+  launch/foreground into its local graph clone and enriches with BYOK keys (sharable via
+  keychain access group if ever needed). Joplin, Logseq (Capacitor send-intent), Drafts
+  ("Quick Capture… without further interaction"), and Bear all ship this shape; use one
+  uniquely-named file per capture (Joplin's single fixed filename can drop a second
+  capture — a visible flaw to avoid). ~120 MB extension memory cap is irrelevant for
+  URL+selection captures.
+- **Tauri 2 fits:** extra Xcode targets are added in the XcodeGen `project.yml` Tauri
+  already templates (`src-tauri/ios.project.yml`), entitlements (App Groups) in the
+  generated-and-committed entitlements files — proven workable
+  ([tauri#10074](https://github.com/tauri-apps/tauri/issues/10074),
+  [tauri#14332](https://github.com/tauri-apps/tauri/issues/14332)), with
+  [IT-ess/tauri-plugin-mobile-sharetarget](https://github.com/IT-ess/tauri-plugin-mobile-sharetarget)
+  as a working iOS+Android example (Rust-side FIFO queue for cold-start webview timing).
+- **Android is easier:** an ACTION_SEND intent filter in the committed
+  `gen/android` manifest; Chrome shares URL (`EXTRA_TEXT`) + title (`EXTRA_SUBJECT`); the
+  share launches the **full app process**, so it can ingest and even sync immediately.
+- **Sync closes the loop:** the mobile app drains into its *own* Git clone (Plan 12);
+  GitHub propagates to desktop. No relay, no hosted API, no cross-device IPC.
+
+### 6. Scenario matrix
+
+| Scenario | Path | Outcome |
+|---|---|---|
+| Desktop app running | extension → host → inbox → watcher | Saved + enriched in seconds; extension shows success |
+| App installed, not running | extension → host → inbox | Saved (host acks "queued"); enriched on next app launch |
+| App not installed | `connectNative` fails ("host not found") | Extension explains + links download; queues capture in `chrome.storage`, retries later |
+| No graph configured | host finds no inbox pointer | Typed error; extension says "open Reflect first" |
+| Private target | normal path; privacy gate in app | Raw link saved, zero outbound AI (Plan 11 step 3 unchanged) |
+| iOS (later) | share extension → app-group inbox | Saved instantly; ingested + enriched on next app open; syncs via GitHub |
+| Android (later) | ACTION_SEND → full app | Saved + enriched immediately |
+| iOS Safari extension (much later) | same WXT codebase → `sendNativeMessage` → Swift handler → app-group inbox | Possible; plumbing-heavy (`safari-web-extension-converter`); an optimization, not the first mobile path |
+| Any scenario needing Reflect-hosted infra | — | **None exist.** Zotero's hosted fallback only buys "app not installed", which is inherently unservable without infra and acceptably degrades to install-prompt + retry queue |
+
+## Implications for Plan 11
+
+1. **Reframe step 2:** the host doesn't "forward to the running desktop app" — it spools
+   to the capture inbox; the app's watcher/launch-drain is the receiver. Drop any socket.
+2. **Shared contract:** define the capture envelope (zod) in `@reflect/core`
+   (`actions/capture`) as platform-agnostic — `{url, title, selection?, screenshotRef?,
+   note?, capturedAt, source}` — written identically by the NM host (desktop), share
+   extension (iOS), and intent handler (Android). `drainCaptureInbox` is one core action.
+3. **Registration detail:** manifests rewritten **every launch** (not "on install"), only
+   for detected browsers; both store IDs in `allowed_origins`; `key`-pinned dev ID.
+4. **Watcher change:** the Rust watcher currently only reports `.md` under `daily/` and
+   `notes/` — it needs to also watch the inbox dir (or a second watcher).
+5. **Loopback HTTP fallback narrows** to "native-messaging packaging proves unshippable"
+   (size is a non-issue); if ever built, copy Joplin's pairing flow + Host-header checks.
+6. **Acceptance criterion to add:** capturing with the desktop app **closed** queues the
+   capture and it lands (raw, then enriched) on next launch — the spool design gives this
+   for free, and it's the headline UX win.
+7. **Mobile door-openers now (cheap):** keep the envelope platform-agnostic (done via #2);
+   nothing else in the desktop design needs to change. Reserve the App Group ID when iOS
+   work actually starts.
+
+## What the code spike must still verify
+
+- `externalBin` sidecar **signs + notarizes** cleanly with the current Tauri version
+  ([tauri#11992](https://github.com/tauri-apps/tauri/issues/11992) is open).
+- End-to-end WXT MV3 → `sendNativeMessage` → Rust host → inbox file → app watcher drain,
+  with a real ~2–4 MB `captureVisibleTab` screenshot (latency + memory).
+- Manifest registration empirically on Arc and one non-Chrome Chromium (Brave or Edge);
+  Windows HKCU path.
+- Host behavior with no inbox pointer / unwritable inbox (typed errors reach the
+  extension UI).
+
+## Caveats
+
+- Enrichment is deferred when the app is closed — the daily-note entry appears on next
+  launch, not "live". That's inherent to no-hosted-API and matches the product principle;
+  the extension should say "queued" honestly rather than "saved to today's note".
+- AppImage (Linux) executable paths are unstable across mounts — manifest registration on
+  Linux must point at a stable installed path (deb/rpm) or re-register per run; deal with
+  it when Linux packaging lands (Plan 15).
+- Firefox/Safari support are real but separate workstreams (different manifest dialect /
+  containing-app pipeline); the envelope + inbox are unchanged for both.

--- a/docs/spikes/link-capture-bridge.md
+++ b/docs/spikes/link-capture-bridge.md
@@ -47,10 +47,11 @@ must-be-running flaw) is pure cost. Instead:
 - Host validates the payload, decodes the screenshot, and **atomically writes**
   (`tmp/` + `rename(2)`, Maildir discipline, one uniquely-named file per capture) into
   the inbox.
-- App running → its watcher sees the new file within ~1 s and runs the normal pipeline
-  (privacy gate → BYOK enrichment → daily-note `[[Links]]` append → assets →
-  provenance → reindex). App closed → the capture waits; the app drains the inbox on next
-  launch. Raw link is never lost — which Plan 11 step 6 requires anyway.
+- App running → its watcher sees the new file within ~1 s and runs the drain pipeline:
+  resolve target → privacy gate → copy assets to `assets/` → write raw `[[Links]]`
+  entry + provenance → remove spool file → schedule async enrichment (meta scrape +
+  BYOK AI description) → reindex. App closed → the capture waits; the app drains the
+  inbox on next launch. Raw link is never lost.
 - The host finds the inbox via a small pointer file the app maintains in a fixed app-data
   location (active graph path). No graph configured → the host replies with a typed error
   the extension can surface ("Open Reflect and pick a graph first").


### PR DESCRIPTION
## Summary

- **Native-messaging host is now a spooler, not a relay.** The tiny Rust sidecar atomically writes each capture into a file-system inbox (tmp + rename per capture). The app drains the inbox via its file watcher when running, or on next launch when closed. No open port, no daemon, no must-be-running app.
- **Two-phase write.** Raw `[[Links]]` entry is saved synchronously on drain (link never lost). Meta-tag scrape + BYOK AI description (screenshot + scraped meta fed to OpenAI etc.) run asynchronously in the desktop app and patch the entry in place.
- **Loopback HTTP demoted** to packaging-failure fallback (payload size is not a reason — extension→host allows 64 MiB). Deep links removed as a content channel (~2 KB practical limit).
- **Platform-agnostic capture envelope.** The zod schema + `drainCaptureInbox` core action are designed to be reused by future iOS (share extension → app-group inbox) and Android (ACTION_SEND) capture paths with no rearchitecture.
- **Manifest registration** rewritten every app launch for detected browsers only (self-heals macOS app translocation; avoids spraying manifests for uninstalled browsers).
- New acceptance criterion: **capture with the app closed** is test-asserted.

## Files changed

- `docs/plans/11-link-capture.md` — full rewrite incorporating the above
- `docs/spikes/link-capture-bridge.md` — new spike doc: four-area research report (native messaging mechanics, loopback HTTP precedents, Tauri packaging, mobile share-sheet consensus), scenario matrix, and implications for the plan

## What a reviewer should know

The central inversion (spooler vs. relay) came from the finding that Chrome spawns the native-messaging host itself — no running app is required. Password managers relay to a live app because they need its unlocked state; captures have no such dependency, so the relay and its "must-be-running" flaw are pure cost. The spool + file-watcher pattern is exactly what iOS capture apps (Joplin, Drafts, Logseq) ship for their share extensions, which is also why the same envelope works for mobile later.

The code spike still needs to verify `externalBin` sidecar notarization ([tauri#11992](https://github.com/tauri-apps/tauri/issues/11992)) and the end-to-end WXT → host → inbox → watcher drain with a real screenshot. No code changed in this PR — docs and architecture only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and architecture planning only; no runtime, auth, or data-path code changes in this PR.
> 
> **Overview**
> **Documentation-only** redesign of Plan 11 link capture: the Chrome extension→desktop bridge is no longer “native messaging first, relay to running app” but a **spooler + capture inbox** model with **two-phase writes** and clearer mobile/fallback rules.
> 
> The native-messaging host **only** validates and atomically writes captures (inbox pointer file, tmp+rename); the desktop app **drains** via launch scan + file watcher—so capture works **with the app closed**. **Loopback HTTP** is demoted to packaging-failure fallback (screenshot size is explicitly not a reason); **`reflect://` deep links** are URL-only last resort. A new spike doc (`link-capture-bridge.md`) records research, scenario matrix, and packaging risks (e.g. Tauri `externalBin` notarization).
> 
> Plan updates add **`drainCaptureInbox`** ordering (privacy before any network, assets before spool delete), **async enrichment** (meta scrape + BYOK AI patches in place), **honest extension status** (queued/failed, not “saved”), **dedup** scoped to same day/note/selection, and acceptance tests for **app-closed** capture and **private** targets with zero outbound traffic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b99dff8338586b44516aa6c03389c26adc4776e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated planning documentation for link-capture functionality, including architectural design for a browser extension capture pipeline with desktop app integration and asynchronous enrichment.
  * Added spike documentation outlining technical approach for multi-platform capture bridge with offline-first queueing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->