### PR TITLE
Reduce incoming-backlinks children font size to text-xs

### DIFF
--- a/apps/desktop/src/components/backlink-source-group.tsx
+++ b/apps/desktop/src/components/backlink-source-group.tsx
@@ -49,7 +49,7 @@ export function BacklinkSourceGroup({
         <button
           type="button"
           onClick={() => onOpen(source.path)}
-          className="min-w-0 cursor-pointer truncate text-left text-sm text-accent"
+          className="min-w-0 cursor-pointer truncate text-left text-xs text-accent"
         >
           {source.title}
         </button>
@@ -73,7 +73,7 @@ export function BacklinkSourceGroup({
       {expanded ? (
         <div className="mt-1 space-y-1">
           {source.snippets.map((snippet) => (
-            <p key={snippet.key} className="select-text text-sm text-text">
+            <p key={snippet.key} className="select-text text-xs text-text">
               {snippet.text}
             </p>
           ))}


### PR DESCRIPTION
## Summary

- Source note titles and snippet text in the incoming-backlinks panel were `text-sm` (14px); reduced to `text-xs` (12px) to visually de-emphasise contextual references relative to the note body.
- The plural heading (`Incoming backlink` / `Incoming backlinks`) was already correctly implemented — no change needed there.

## Test plan

- [ ] Open a note with incoming backlinks and confirm the panel children render at 12px.
- [ ] Verify the panel header label still reads "Incoming backlink (1)" for a single backlink and "Incoming backlinks (N)" for multiple.
- [ ] Confirm source titles are still clickable and snippets are selectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Tailwind class changes in one UI component with no logic or data-handling impact.
> 
> **Overview**
> **Incoming backlinks panel typography** is tightened so contextual references read below the note body in visual weight.
> 
> Source note title buttons and expanded snippet lines in `BacklinkSourceGroup` move from **`text-sm` (14px)** to **`text-xs` (12px)**. Behavior (clickable titles, selectable snippets, expand/collapse) is unchanged; only styling differs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3494de46c084fad7259eaef87c09e3d06ed1a54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->