### PR TITLE
Signed/notarized macOS distribution builds via pnpm release:macos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,7 @@ pnpm dev              # turbo dev across packages (Vite on http://localhost:1420
 pnpm tauri dev        # Full Tauri app with hot reload (stages the CLI sidecar first)
 pnpm build            # turbo build pipeline → apps/desktop/dist/
 pnpm tauri build      # Native app bundle, incl. the reflect CLI sidecar
+pnpm release:macos    # Signed + notarized macOS build for distribution (docs/macos-distribution.md)
 ```
 
 # Code Conventions

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "sidecar": "node scripts/build-sidecar.mjs",
+    "release:macos": "node scripts/release-macos.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "tauri": "tauri"

--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -245,11 +245,22 @@ function build({ notarize }) {
     log('notarization skipped (--no-notarize): the bundle will not pass Gatekeeper on other Macs')
   }
 
-  const result = spawnSync('pnpm', ['tauri', 'build'], {
-    cwd: appDir,
-    stdio: 'inherit',
-    env: { ...process.env, APPLE_SIGNING_IDENTITY: identity, ...credentials?.buildEnv },
-  })
+  const buildEnv = { ...process.env, APPLE_SIGNING_IDENTITY: identity, ...credentials?.buildEnv }
+  if (!notarize) {
+    // Tauri notarizes the .app whenever these are present, so inherited shell
+    // exports would silently override --no-notarize.
+    for (const name of [
+      'APPLE_ID',
+      'APPLE_PASSWORD',
+      'APPLE_TEAM_ID',
+      'APPLE_API_KEY',
+      'APPLE_API_ISSUER',
+      'APPLE_API_KEY_PATH',
+    ]) {
+      delete buildEnv[name]
+    }
+  }
+  const result = spawnSync('pnpm', ['tauri', 'build'], { cwd: appDir, stdio: 'inherit', env: buildEnv })
   if (result.status !== 0) fail('tauri build failed')
 
   if (notarize) notarizeDmg(bundlePaths().dmg, credentials)

--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -1,0 +1,324 @@
+// Build a signed, notarized, distribution-ready macOS bundle of Reflect.
+//
+// Usage:
+//   pnpm release:macos              Signed + notarized build, then verify
+//   pnpm release:macos setup        Store notarization credentials (one-time)
+//   pnpm release:macos verify       Re-run Gatekeeper checks on existing bundles
+//   pnpm release:macos --no-notarize  Signed-only build (won't pass Gatekeeper elsewhere)
+//
+// Signing configuration is intentionally not committed — contributors must be
+// able to build without Reflect's certificate. The Developer ID identity is
+// auto-detected from the login keychain and notarization credentials come from
+// the keychain item created by `setup`. Environment variables override
+// auto-detection (what CI should use): APPLE_SIGNING_IDENTITY, plus either
+// APPLE_ID/APPLE_PASSWORD/APPLE_TEAM_ID or the App Store Connect key trio
+// APPLE_API_KEY/APPLE_API_ISSUER/APPLE_API_KEY_PATH.
+//
+// Full procedure and troubleshooting: docs/macos-distribution.md
+
+import { execFileSync, spawnSync } from 'node:child_process'
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { basename, dirname, join } from 'node:path'
+import { createInterface } from 'node:readline/promises'
+import { fileURLToPath } from 'node:url'
+
+const KEYCHAIN_SERVICE = 'reflect-notary'
+const APP_SPECIFIC_PASSWORD_URL = 'https://account.apple.com'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const appDir = join(here, '..')
+const repoRoot = join(here, '..', '..', '..')
+
+function log(message) {
+  console.log(`release-macos: ${message}`)
+}
+
+function fail(message) {
+  console.error(`release-macos: error: ${message}`)
+  process.exit(1)
+}
+
+function capture(command, args, options = {}) {
+  return execFileSync(command, args, { encoding: 'utf8', ...options })
+}
+
+/** Run a command and return { status, output } with stdout+stderr combined. */
+function run(command, args) {
+  const result = spawnSync(command, args, { encoding: 'utf8' })
+  return { status: result.status, output: `${result.stdout ?? ''}${result.stderr ?? ''}` }
+}
+
+/**
+ * Resolve the Developer ID Application identity: APPLE_SIGNING_IDENTITY wins,
+ * otherwise the login keychain is searched. Fails with remediation if absent.
+ */
+function findSigningIdentity() {
+  if (process.env.APPLE_SIGNING_IDENTITY) return process.env.APPLE_SIGNING_IDENTITY
+
+  const { output } = run('security', ['find-identity', '-v', '-p', 'codesigning'])
+  const identities = [
+    ...new Set([...output.matchAll(/"(Developer ID Application: [^"]+)"/g)].map((match) => match[1])),
+  ]
+  if (identities.length === 0) {
+    fail(
+      'no "Developer ID Application" certificate found in the keychain.\n' +
+        '  Distribution outside the App Store requires one (created by the Apple Developer\n' +
+        '  Account Holder at https://developer.apple.com/account/resources/certificates).\n' +
+        '  For an unsigned local build, use `pnpm tauri build` instead.',
+    )
+  }
+  if (identities.length > 1) {
+    log(`multiple Developer ID identities found; using "${identities[0]}" (override with APPLE_SIGNING_IDENTITY)`)
+  }
+  return identities[0]
+}
+
+/** Extract the 10-character team ID from an identity like "… (789ULN5MZB)". */
+function teamIdFromIdentity(identity) {
+  const teamId = identity.match(/\(([0-9A-Z]{10})\)$/)?.[1]
+  if (!teamId) fail(`could not extract a team ID from identity "${identity}" — set APPLE_TEAM_ID explicitly`)
+  return teamId
+}
+
+/** Read the Apple ID + app-specific password stored by `setup`, or null. */
+function readKeychainCredentials() {
+  const meta = run('security', ['find-generic-password', '-s', KEYCHAIN_SERVICE])
+  if (meta.status !== 0) return null
+  const account = meta.output.match(/"acct"<blob>="([^"]+)"/)?.[1]
+  const password = run('security', ['find-generic-password', '-s', KEYCHAIN_SERVICE, '-w'])
+  if (!account || password.status !== 0) return null
+  return { account, password: password.output.trim() }
+}
+
+/**
+ * Resolve notarization credentials in precedence order: App Store Connect API
+ * key env vars, Apple ID env vars, then the keychain item from `setup`.
+ * Returns { buildEnv, notarytoolArgs, source } or null when nothing is found.
+ * buildEnv is merged into `tauri build`'s environment (Tauri notarizes the
+ * .app itself); notarytoolArgs are used for the separate DMG submission.
+ */
+function resolveNotaryCredentials(teamId) {
+  const { APPLE_API_KEY, APPLE_API_ISSUER, APPLE_API_KEY_PATH, APPLE_ID, APPLE_PASSWORD, APPLE_TEAM_ID } =
+    process.env
+
+  if (APPLE_API_KEY && APPLE_API_ISSUER) {
+    if (!APPLE_API_KEY_PATH) fail('APPLE_API_KEY is set but APPLE_API_KEY_PATH (path to the .p8 file) is not')
+    return {
+      buildEnv: {},
+      notarytoolArgs: ['--key', APPLE_API_KEY_PATH, '--key-id', APPLE_API_KEY, '--issuer', APPLE_API_ISSUER],
+      source: 'App Store Connect API key (environment)',
+    }
+  }
+
+  if (APPLE_ID && APPLE_PASSWORD) {
+    const team = APPLE_TEAM_ID ?? teamId
+    return {
+      buildEnv: { APPLE_TEAM_ID: team },
+      notarytoolArgs: ['--apple-id', APPLE_ID, '--password', APPLE_PASSWORD, '--team-id', team],
+      source: `Apple ID ${APPLE_ID} (environment)`,
+    }
+  }
+
+  const stored = readKeychainCredentials()
+  if (!stored) return null
+  return {
+    buildEnv: { APPLE_ID: stored.account, APPLE_PASSWORD: stored.password, APPLE_TEAM_ID: teamId },
+    notarytoolArgs: ['--apple-id', stored.account, '--password', stored.password, '--team-id', teamId],
+    source: `Apple ID ${stored.account} (keychain item "${KEYCHAIN_SERVICE}")`,
+  }
+}
+
+/** Derive bundle output paths from tauri.conf.json and cargo's target dir. */
+function bundlePaths() {
+  const conf = JSON.parse(readFileSync(join(appDir, 'src-tauri', 'tauri.conf.json'), 'utf8'))
+  const metadata = JSON.parse(
+    capture('cargo', ['metadata', '--format-version', '1', '--no-deps'], { cwd: repoRoot }),
+  )
+  const arch = { arm64: 'aarch64', x64: 'x86_64' }[process.arch]
+  if (!arch) fail(`unsupported architecture: ${process.arch}`)
+  const bundleDir = join(metadata.target_directory, 'release', 'bundle')
+  return {
+    app: join(bundleDir, 'macos', `${conf.productName}.app`),
+    dmg: join(bundleDir, 'dmg', `${conf.productName}_${conf.version}_${arch}.dmg`),
+  }
+}
+
+/**
+ * Notarize and staple the DMG. Tauri notarizes the .app during the build but
+ * not the DMG wrapped around it afterwards; without its own ticket the DMG is
+ * rejected by `spctl --type open` and downloads get Gatekeeper friction.
+ */
+function notarizeDmg(dmg, credentials) {
+  log(`submitting ${basename(dmg)} to Apple's notary service (typically 1-10 minutes)…`)
+  const submit = spawnSync(
+    'xcrun',
+    ['notarytool', 'submit', dmg, ...credentials.notarytoolArgs, '--wait', '--output-format', 'json'],
+    { encoding: 'utf8' },
+  )
+  let verdict = {}
+  try {
+    verdict = JSON.parse(submit.stdout || '{}')
+  } catch {
+    // fall through to the failure path with whatever notarytool printed
+  }
+  if (submit.status !== 0 || verdict.status !== 'Accepted') {
+    if (verdict.id) {
+      log(`fetching notarization log for submission ${verdict.id}…`)
+      const detail = run('xcrun', ['notarytool', 'log', verdict.id, ...credentials.notarytoolArgs])
+      console.error(detail.output)
+    } else {
+      console.error(submit.stderr ?? '')
+    }
+    fail(`DMG notarization ${verdict.status ?? 'failed'}`)
+  }
+  log(`DMG notarization accepted (submission ${verdict.id}); stapling…`)
+  execFileSync('xcrun', ['stapler', 'staple', dmg], { stdio: 'inherit' })
+}
+
+/** Assert one Gatekeeper/codesign check, failing loudly with its output. */
+function expectCheck(description, command, args, expected) {
+  const { output } = run(command, args)
+  const passed = expected.every((needle) => output.includes(needle))
+  if (!passed) fail(`${description} failed:\n${output.trim()}`)
+  log(`${description}: ok`)
+}
+
+/** Verify the built bundles match the expected distribution state. */
+function verify({ notarized }) {
+  const { app, dmg } = bundlePaths()
+  if (!existsSync(app)) fail(`${app} does not exist — run \`pnpm release:macos\` first`)
+  if (!existsSync(dmg)) fail(`${dmg} does not exist — run \`pnpm release:macos\` first`)
+
+  expectCheck('codesign verify (app)', 'codesign', ['--verify', '--deep', '--strict', '--verbose=2', app], [
+    'valid on disk',
+    'satisfies its Designated Requirement',
+  ])
+
+  if (!notarized) {
+    log('signed-only verification passed (not notarized: Gatekeeper will reject this bundle on other Macs)')
+    return
+  }
+
+  expectCheck('Gatekeeper (app)', 'spctl', ['--assess', '--type', 'execute', '-v', app], [
+    'accepted',
+    'source=Notarized Developer ID',
+  ])
+  expectCheck('stapled ticket (app)', 'xcrun', ['stapler', 'validate', app], ['The validate action worked!'])
+  expectCheck(
+    'Gatekeeper (dmg)',
+    'spctl',
+    ['--assess', '--type', 'open', '--context', 'context:primary-signature', '-v', dmg],
+    ['accepted', 'source=Notarized Developer ID'],
+  )
+  expectCheck('stapled ticket (dmg)', 'xcrun', ['stapler', 'validate', dmg], ['The validate action worked!'])
+}
+
+function printArtifacts() {
+  const { app, dmg } = bundlePaths()
+  const dmgSizeMb = (statSync(dmg).size / (1024 * 1024)).toFixed(1)
+  log('distribution bundles:')
+  console.log(`  ${app}`)
+  console.log(`  ${dmg} (${dmgSizeMb} MB)`)
+}
+
+function build({ notarize }) {
+  const identity = findSigningIdentity()
+  const teamId = teamIdFromIdentity(identity)
+  log(`signing identity: ${identity}`)
+
+  let credentials = null
+  if (notarize) {
+    if (run('xcrun', ['--find', 'notarytool']).status !== 0) {
+      fail('notarytool not found — install the Xcode Command Line Tools (`xcode-select --install`)')
+    }
+    credentials = resolveNotaryCredentials(teamId)
+    if (!credentials) {
+      fail(
+        'no notarization credentials found.\n' +
+          '  Run `pnpm release:macos setup` once to store them in the keychain,\n' +
+          '  export APPLE_ID/APPLE_PASSWORD/APPLE_TEAM_ID (or the APPLE_API_KEY trio),\n' +
+          '  or pass --no-notarize for a signed-only build.',
+      )
+    }
+    log(`notarizing as: ${credentials.source}`)
+  } else {
+    log('notarization skipped (--no-notarize): the bundle will not pass Gatekeeper on other Macs')
+  }
+
+  const result = spawnSync('pnpm', ['tauri', 'build'], {
+    cwd: appDir,
+    stdio: 'inherit',
+    env: { ...process.env, APPLE_SIGNING_IDENTITY: identity, ...credentials?.buildEnv },
+  })
+  if (result.status !== 0) fail('tauri build failed')
+
+  if (notarize) notarizeDmg(bundlePaths().dmg, credentials)
+  verify({ notarized: notarize })
+  printArtifacts()
+  log(notarize ? 'done — ready to distribute' : 'done — signed but NOT notarized')
+}
+
+async function setup() {
+  console.log(
+    `This stores notarization credentials in your login keychain (item "${KEYCHAIN_SERVICE}").\n` +
+      `You need an app-specific password for an Apple ID on the team:\n` +
+      `  ${APP_SPECIFIC_PASSWORD_URL} → Sign-In and Security → App-Specific Passwords\n`,
+  )
+  const readline = createInterface({ input: process.stdin, output: process.stdout })
+  const account = (await readline.question('Apple ID email: ')).trim()
+  readline.close()
+  if (!/^\S+@\S+\.\S+$/.test(account)) fail(`"${account}" does not look like an email address`)
+
+  // `security … -w` with no value prompts for the secret itself, so the
+  // password never touches this process, its arguments, or shell history.
+  console.log('Paste the app-specific password when prompted:')
+  const result = spawnSync(
+    'security',
+    ['add-generic-password', '-U', '-s', KEYCHAIN_SERVICE, '-a', account, '-w'],
+    { stdio: 'inherit' },
+  )
+  if (result.status !== 0) fail('storing the password in the keychain failed')
+  log(`stored credentials for ${account} — you can now run \`pnpm release:macos\``)
+}
+
+const USAGE = `Usage: pnpm release:macos [command] [flags]
+
+Commands:
+  build     Signed + notarized release build, then verify (default)
+  setup     Store the notarization Apple ID + app-specific password in the keychain
+  verify    Re-run signing/Gatekeeper checks on already-built bundles
+
+Flags:
+  --no-notarize   Skip notarization (signed-only build/verify)
+  --help          Show this help
+
+Docs: docs/macos-distribution.md`
+
+async function main() {
+  const argv = process.argv.slice(2)
+  const flags = argv.filter((arg) => arg.startsWith('--'))
+  const commands = argv.filter((arg) => !arg.startsWith('--'))
+  const unknownFlag = flags.find((flag) => !['--no-notarize', '--help'].includes(flag))
+  if (unknownFlag) fail(`unknown flag "${unknownFlag}"\n\n${USAGE}`)
+  if (flags.includes('--help')) {
+    console.log(USAGE)
+    return
+  }
+  if (process.platform !== 'darwin') fail('this command only runs on macOS')
+
+  const command = commands[0] ?? 'build'
+  const notarize = !flags.includes('--no-notarize')
+  switch (command) {
+    case 'build':
+      return build({ notarize })
+    case 'setup':
+      return setup()
+    case 'verify':
+      verify({ notarized: notarize })
+      return printArtifacts()
+    default:
+      fail(`unknown command "${command}"\n\n${USAGE}`)
+  }
+}
+
+await main()

--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -73,8 +73,14 @@ function findSigningIdentity() {
   return identities[0]
 }
 
-/** Extract the 10-character team ID from an identity like "… (789ULN5MZB)". */
-function teamIdFromIdentity(identity) {
+/**
+ * Resolve the notarization team ID: APPLE_TEAM_ID wins, otherwise it's
+ * extracted from an identity like "… (789ULN5MZB)". Only called by the
+ * credential paths that actually need a team ID, so bare identities work
+ * with --no-notarize and API-key notarization.
+ */
+function resolveTeamId(identity) {
+  if (process.env.APPLE_TEAM_ID) return process.env.APPLE_TEAM_ID
   const teamId = identity.match(/\(([0-9A-Z]{10})\)$/)?.[1]
   if (!teamId) fail(`could not extract a team ID from identity "${identity}" — set APPLE_TEAM_ID explicitly`)
   return teamId
@@ -97,9 +103,8 @@ function readKeychainCredentials() {
  * buildEnv is merged into `tauri build`'s environment (Tauri notarizes the
  * .app itself); notarytoolArgs are used for the separate DMG submission.
  */
-function resolveNotaryCredentials(teamId) {
-  const { APPLE_API_KEY, APPLE_API_ISSUER, APPLE_API_KEY_PATH, APPLE_ID, APPLE_PASSWORD, APPLE_TEAM_ID } =
-    process.env
+function resolveNotaryCredentials(identity) {
+  const { APPLE_API_KEY, APPLE_API_ISSUER, APPLE_API_KEY_PATH, APPLE_ID, APPLE_PASSWORD } = process.env
 
   if (APPLE_API_KEY && APPLE_API_ISSUER) {
     if (!APPLE_API_KEY_PATH) fail('APPLE_API_KEY is set but APPLE_API_KEY_PATH (path to the .p8 file) is not')
@@ -111,16 +116,17 @@ function resolveNotaryCredentials(teamId) {
   }
 
   if (APPLE_ID && APPLE_PASSWORD) {
-    const team = APPLE_TEAM_ID ?? teamId
+    const teamId = resolveTeamId(identity)
     return {
-      buildEnv: { APPLE_TEAM_ID: team },
-      notarytoolArgs: ['--apple-id', APPLE_ID, '--password', APPLE_PASSWORD, '--team-id', team],
+      buildEnv: { APPLE_TEAM_ID: teamId },
+      notarytoolArgs: ['--apple-id', APPLE_ID, '--password', APPLE_PASSWORD, '--team-id', teamId],
       source: `Apple ID ${APPLE_ID} (environment)`,
     }
   }
 
   const stored = readKeychainCredentials()
   if (!stored) return null
+  const teamId = resolveTeamId(identity)
   return {
     buildEnv: { APPLE_ID: stored.account, APPLE_PASSWORD: stored.password, APPLE_TEAM_ID: teamId },
     notarytoolArgs: ['--apple-id', stored.account, '--password', stored.password, '--team-id', teamId],
@@ -223,7 +229,6 @@ function printArtifacts() {
 
 function build({ notarize }) {
   const identity = findSigningIdentity()
-  const teamId = teamIdFromIdentity(identity)
   log(`signing identity: ${identity}`)
 
   let credentials = null
@@ -231,7 +236,7 @@ function build({ notarize }) {
     if (run('xcrun', ['--find', 'notarytool']).status !== 0) {
       fail('notarytool not found — install the Xcode Command Line Tools (`xcode-select --install`)')
     }
-    credentials = resolveNotaryCredentials(teamId)
+    credentials = resolveNotaryCredentials(identity)
     if (!credentials) {
       fail(
         'no notarization credentials found.\n' +

--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -134,14 +134,24 @@ function resolveNotaryCredentials(identity) {
   }
 }
 
+/**
+ * The architecture segment of the host triple (e.g. "aarch64"). Taken from
+ * rustc — the same source Tauri names bundle artifacts from — rather than
+ * process.arch, which diverges when Node runs under Rosetta.
+ */
+function hostArch() {
+  const arch = capture('rustc', ['-vV']).match(/^host: (\S+)/m)?.[1]?.split('-')[0]
+  if (!arch) fail('could not determine the host triple from rustc -vV')
+  return arch
+}
+
 /** Derive bundle output paths from tauri.conf.json and cargo's target dir. */
 function bundlePaths() {
   const conf = JSON.parse(readFileSync(join(appDir, 'src-tauri', 'tauri.conf.json'), 'utf8'))
   const metadata = JSON.parse(
     capture('cargo', ['metadata', '--format-version', '1', '--no-deps'], { cwd: repoRoot }),
   )
-  const arch = { arm64: 'aarch64', x64: 'x86_64' }[process.arch]
-  if (!arch) fail(`unsupported architecture: ${process.arch}`)
+  const arch = hostArch()
   const bundleDir = join(metadata.target_directory, 'release', 'bundle')
   return {
     app: join(bundleDir, 'macos', `${conf.productName}.app`),

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "reflect-open",
+  "productName": "Reflect",
   "version": "0.1.0",
-  "identifier": "com.alex.reflect-open",
+  "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",
     "devUrl": "http://localhost:1420",
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "reflect-open",
+        "title": "Reflect",
         "width": 1300,
         "height": 650,
         "titleBarStyle": "Overlay",

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -1,0 +1,99 @@
+# macOS Distribution Builds
+
+How to produce a signed, notarized macOS build of Reflect for distribution outside the
+Mac App Store.
+
+```bash
+pnpm release:macos setup   # once: store notarization credentials in the keychain
+pnpm release:macos         # signed + notarized build, verified end to end
+```
+
+The helper lives at `apps/desktop/scripts/release-macos.mjs` and is exposed as
+`pnpm release:macos` from the repo root.
+
+## What you need
+
+1. **A Developer ID Application certificate** in your login keychain. This certificate
+   type (not "Apple Distribution", which is App Store only) is required for distribution
+   outside the App Store, and only the Apple Developer **Account Holder** can create one,
+   at [developer.apple.com → Certificates](https://developer.apple.com/account/resources/certificates).
+   Confirm it's installed with:
+
+   ```bash
+   security find-identity -v -p codesigning
+   ```
+
+2. **An Apple ID on the team with an app-specific password** for notarization. Create the
+   password at [account.apple.com](https://account.apple.com) → Sign-In and Security →
+   App-Specific Passwords, then run `pnpm release:macos setup`. The setup command stores
+   it in your login keychain (item `reflect-notary`) — the password never touches shell
+   history or the repo.
+
+3. **Xcode Command Line Tools** (`xcode-select --install`) for `notarytool` and `stapler`.
+
+Nothing signing-related is committed to the repo: contributors without the certificate
+can still build unsigned bundles with plain `pnpm tauri build`.
+
+## What `pnpm release:macos` does
+
+1. Auto-detects the Developer ID identity from the keychain and derives the team ID.
+2. Loads notarization credentials (keychain item, or environment variables — see CI below).
+3. Runs `pnpm tauri build`, which stages the `reflect` CLI sidecar, then signs inside-out
+   (sidecar → main binary → `.app`) with hardened runtime, notarizes the `.app` via
+   `notarytool`, staples the ticket, and builds + signs the DMG.
+4. Notarizes and staples the **DMG** itself. Tauri only notarizes the `.app`; without its
+   own ticket the DMG container fails `spctl --type open` and downloads can hit
+   Gatekeeper friction.
+5. Verifies everything — `codesign --verify --deep --strict`, Gatekeeper assessment of
+   the app and DMG (`accepted` / `source=Notarized Developer ID`), and stapled tickets —
+   and fails loudly if any check is off.
+
+Bundles land in `target/release/bundle/macos/Reflect.app` and
+`target/release/bundle/dmg/Reflect_<version>_<arch>.dmg`.
+
+## Commands and flags
+
+```bash
+pnpm release:macos                 # build + notarize + verify (default)
+pnpm release:macos setup           # store Apple ID + app-specific password in the keychain
+pnpm release:macos verify          # re-run all checks on already-built bundles
+pnpm release:macos --no-notarize   # signed-only build (runs locally; Gatekeeper rejects it elsewhere)
+```
+
+## CI
+
+Everything the script auto-detects can be supplied via environment variables instead,
+which take precedence over the keychain:
+
+| Variable | Purpose |
+| --- | --- |
+| `APPLE_SIGNING_IDENTITY` | Full identity string, e.g. `Developer ID Application: … (TEAMID)` |
+| `APPLE_ID` / `APPLE_PASSWORD` / `APPLE_TEAM_ID` | Apple ID notarization (app-specific password) |
+| `APPLE_API_KEY` / `APPLE_API_ISSUER` / `APPLE_API_KEY_PATH` | App Store Connect API key notarization (preferred for CI — not tied to a personal Apple ID) |
+| `APPLE_CERTIFICATE` / `APPLE_CERTIFICATE_PASSWORD` | base64 `.p12` + password; Tauri imports it into a temporary keychain on runners with no cert installed |
+
+See the [Tauri macOS signing docs](https://v2.tauri.app/distribute/sign/macos/) for the
+runner keychain setup.
+
+## Troubleshooting
+
+- **`no "Developer ID Application" certificate found`** — the cert isn't in your *login*
+  keychain, or it's the wrong type. An invalid/incomplete cert won't show up in
+  `security find-identity` at all.
+- **Notarization fails (`status: Invalid`)** — the script automatically prints the notary
+  log, which lists each offending file. Common cause: a binary that wasn't signed with
+  hardened runtime.
+- **`rejected, source=Unnotarized Developer ID`** — signing worked but the artifact has no
+  notarization ticket; rerun without `--no-notarize`.
+- **Notarization hangs** — Apple's service occasionally queues submissions for a long
+  time; check status with `xcrun notarytool history --apple-id <id> --team-id <team>`.
+
+## Current limitations
+
+- Builds target the host architecture only (Apple Silicon in practice). A universal
+  build needs the `x86_64-apple-darwin` rustup target, a universal sidecar from
+  `scripts/build-sidecar.mjs`, and `pnpm tauri build --target universal-apple-darwin`.
+- The iOS project template (`src-tauri/ios.project.yml`) still uses the pre-rename bundle
+  identifier and needs its own provisioning pass.
+- Updater-artifact signing (`TAURI_SIGNING_PRIVATE_KEY`) is separate from Apple signing
+  and not yet set up; it becomes relevant if we adopt Tauri's updater plugin.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "oxlint apps packages",
     "lint:fix": "oxlint --fix apps packages",
     "check": "pnpm typecheck && pnpm lint",
-    "tauri": "pnpm --filter @reflect/desktop tauri"
+    "tauri": "pnpm --filter @reflect/desktop tauri",
+    "release:macos": "pnpm --filter @reflect/desktop release:macos"
   },
   "devDependencies": {
     "oxlint": "^1.69.0",


### PR DESCRIPTION
## What

- **`pnpm release:macos`** (new helper, `apps/desktop/scripts/release-macos.mjs`, wired into root and desktop `package.json`): a one-command pipeline that produces a distribution-ready macOS build. Subcommands: `build` (default), `setup`, `verify`; flag `--no-notarize` for signed-only builds.
- **App identity renamed for distribution**: `productName` → `Reflect`, identifier → `app.reflect.desktop` (was `reflect-open` / `com.alex.reflect-open`).
- **Docs**: new `docs/macos-distribution.md` (prereqs, pipeline, CI env vars, troubleshooting) and a one-line entry in AGENTS.md common commands.

## How it works

1. Auto-detects the Developer ID Application identity from the login keychain and derives the team ID from it.
2. Loads notarization credentials from the `reflect-notary` keychain item (created once via `pnpm release:macos setup` — the app-specific password is prompted for by `security` itself, never touching argv or shell history). Env vars override for CI: `APPLE_SIGNING_IDENTITY`, `APPLE_ID`/`APPLE_PASSWORD`/`APPLE_TEAM_ID`, or the App Store Connect `APPLE_API_KEY` trio.
3. Runs `pnpm tauri build` — Tauri signs the sidecar/binary/app inside-out with hardened runtime, notarizes the `.app`, staples, and builds the DMG.
4. Notarizes and staples the **DMG itself** (Tauri only notarizes the `.app`; without its own ticket the DMG fails `spctl --type open`). On rejection it auto-fetches Apple's notarization log.
5. Verifies fail-loud: `codesign --verify --deep --strict`, Gatekeeper assessment of app + DMG (`accepted` / `source=Notarized Developer ID`), stapled tickets.

## Why

Nothing signing-related is committed — contributors without Reflect's certificate still build unsigned bundles with plain `pnpm tauri build`, while team members (and later CI) get a reproducible release path.

## Reviewer notes

- Validated end to end on Apple Silicon: full run completed with both app and DMG notarized (Apple status *Accepted*) and all five verification checks passing.
- Identifier change moves local app data (`~/Library/Application Support/<identifier>`); dev installs start fresh.
- Known follow-ups (documented in the doc's Limitations section): universal binary support, the iOS template still uses the old identifier, updater-artifact signing if we adopt Tauri's updater plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shipping bundle ID and app data location for existing dev installs; release script handles Apple signing credentials and notarization, which are security-sensitive but not committed to the repo.
> 
> **Overview**
> Adds **`pnpm release:macos`** — a macOS-only release helper (`apps/desktop/scripts/release-macos.mjs`) that signs with a Developer ID identity (keychain or env), runs `pnpm tauri build`, **notarizes and staples the DMG** (in addition to what Tauri does for the `.app`), then runs fail-loud `codesign` / Gatekeeper / stapler checks. Subcommands: default **build**, **`setup`** (keychain `reflect-notary` credentials via `security`, no password in argv), **`verify`**; **`--no-notarize`** strips Apple creds from the build env so inherited shell vars cannot force notarization.
> 
> Wires the script from root and `@reflect/desktop` `package.json`, documents the flow in **`docs/macos-distribution.md`**, and lists the command in **AGENTS.md**.
> 
> **Tauri bundle identity** in `tauri.conf.json` is updated for distribution: **`productName` / window title → `Reflect`**, **`identifier` → `app.reflect.desktop`** (was `reflect-open` / `com.alex.reflect-open`), which changes the Application Support path for local installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b209660e00253c7f08df110683783900328cdd82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->