### PR TITLE
Anchor the daily stream before first paint to fix the jerky startup scroll

### DIFF
--- a/apps/desktop/src/components/daily-stream.test.tsx
+++ b/apps/desktop/src/components/daily-stream.test.tsx
@@ -1,0 +1,138 @@
+import { render } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useEffect, useState, type ReactElement, type ReactNode } from 'react'
+import { setBridge } from '@reflect/core'
+import { RouterProvider, useRouter } from '@/routing/router'
+import { todayIso } from '@/lib/dates'
+import { createDayWindow, indexOfDate } from '@/lib/day-window'
+import { DailyStream, ESTIMATED_DAY_HEIGHT } from './daily-stream'
+
+/**
+ * The stream's first-paint anchor: the virtualizer's `initialOffset` must put
+ * the scroll element at the target day (or a back/forward entry's saved
+ * offset) in the mount layout effect — before paint — so opening the app never
+ * paints the top of the five-year window and then visibly lurches down to
+ * today. These tests pin the *first* scroll command the stream issues; the
+ * jsdom environment never resolves a note read, so they also cover the
+ * loading-placeholder contract (reserved editor space, delayed hint).
+ */
+
+vi.mock('@/editor/note-editor', () => ({
+  NoteEditor: () => <div data-testid="fake-editor" />,
+}))
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({
+    graph: { root: '/g', name: 'g', cloudSync: null, generation: 1 },
+    indexing: false,
+  }),
+}))
+vi.mock('@/providers/settings-provider', () => ({
+  useSettings: () => ({
+    settings: { dateFormat: 'mdy', editorMarkdownSyntax: 'always', editorSpellCheck: true },
+    updateSettings: async () => {},
+  }),
+}))
+
+// jsdom implements neither — the virtualizer needs both.
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+globalThis.ResizeObserver ??= ResizeObserverStub as unknown as typeof ResizeObserver
+const scrollToSpy = vi.fn()
+Element.prototype.scrollTo = scrollToSpy as unknown as typeof Element.prototype.scrollTo
+
+// jsdom has no layout, so every offsetHeight is 0 — the virtualizer then
+// computes an empty range and renders no rows. Give the scroll container a
+// viewport and let each row measure exactly the estimate, so the range around
+// the anchor is rendered without any size-correction churn.
+Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+  configurable: true,
+  get(this: HTMLElement) {
+    return this.dataset['testid'] === 'daily-stream' ? 800 : ESTIMATED_DAY_HEIGHT
+  },
+})
+
+setBridge({
+  // Reads never resolve: every day stays a loading placeholder.
+  invoke: () => new Promise(() => {}),
+  listen: async () => () => {},
+})
+
+beforeEach(() => {
+  scrollToSpy.mockClear()
+})
+
+function StreamProviders({ children }: { children: ReactNode }): ReactElement {
+  const [client] = useState(
+    () => new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+  )
+  return (
+    <QueryClientProvider client={client}>
+      <RouterProvider initialRoute={{ kind: 'today' }}>{children}</RouterProvider>
+    </QueryClientProvider>
+  )
+}
+
+/** Records `offset` on the current history entry, as a view's scroll would. */
+function SaveScrollProbe({ offset }: { offset: number }): ReactElement | null {
+  const { saveScrollState } = useRouter()
+  useEffect(() => {
+    saveScrollState(offset)
+  }, [saveScrollState, offset])
+  return null
+}
+
+describe('DailyStream', () => {
+  it('issues the anchor-to-today offset as its very first scroll command', () => {
+    const today = todayIso()
+    const view = render(
+      <StreamProviders>
+        <DailyStream targetDate={today} />
+      </StreamProviders>,
+    )
+
+    const expected = indexOfDate(createDayWindow(today), today) * ESTIMATED_DAY_HEIGHT
+    expect(scrollToSpy.mock.calls.length).toBeGreaterThan(0)
+    expect(scrollToSpy.mock.calls[0][0]).toMatchObject({ top: expected })
+    view.unmount()
+  })
+
+  it('mounts straight at a restored entry’s saved offset, not the anchor', () => {
+    const view = render(
+      <StreamProviders>
+        <SaveScrollProbe offset={4321} />
+      </StreamProviders>,
+    )
+    scrollToSpy.mockClear()
+
+    view.rerender(
+      <StreamProviders>
+        <SaveScrollProbe offset={4321} />
+        <DailyStream targetDate={todayIso()} />
+      </StreamProviders>,
+    )
+
+    expect(scrollToSpy.mock.calls.length).toBeGreaterThan(0)
+    expect(scrollToSpy.mock.calls[0][0]).toMatchObject({ top: 4321 })
+    view.unmount()
+  })
+
+  it('reserves the editor’s space on loading placeholders, with the hint delayed', () => {
+    const view = render(
+      <StreamProviders>
+        <DailyStream targetDate={todayIso()} />
+      </StreamProviders>,
+    )
+
+    const placeholders = view.getAllByText('Loading note…')
+    expect(placeholders.length).toBeGreaterThan(0)
+    for (const placeholder of placeholders) {
+      expect(placeholder.className).toContain('reflect-note-loading')
+      expect(placeholder.className).toMatch(/min-h-/)
+    }
+    view.unmount()
+  })
+})

--- a/apps/desktop/src/components/daily-stream.tsx
+++ b/apps/desktop/src/components/daily-stream.tsx
@@ -29,6 +29,13 @@ interface DailyStreamProps {
 const STREAM_GUTTER = 'reflect-stream-gutter'
 
 /**
+ * The size guess for unmounted rows — also the unit for the mount-time anchor
+ * offset, so `initialOffset` lands exactly where `scrollToIndex` would before
+ * any row has been measured.
+ */
+export const ESTIMATED_DAY_HEIGHT = 220
+
+/**
  * Compensate the scroll position whenever a row **above** the viewport changes
  * size, unconditionally. Days mount as a short loading placeholder and grow
  * when their note arrives, so every load above the anchor would otherwise push
@@ -63,12 +70,29 @@ export function DailyStream({ targetDate }: DailyStreamProps): ReactElement {
   const today = useToday()
   const { settings } = useSettings()
 
+  // targetDate is read at arrival time, not reacted to: on the `today` route
+  // it drifts when local midnight passes (`todayIso()` per render), and that
+  // drift is not a navigation — re-running the anchor effect then would
+  // misread the entry's continuously-saved offset as a back/forward restore.
+  // The next real arrival (⌘D, a link) reads the fresh value and anchors to
+  // the new today.
+  const targetDateRef = useRef(targetDate)
+  targetDateRef.current = targetDate
+
   const virtualizer = useVirtualizer({
     count: dayWindow.count,
     getScrollElement: () => scrollRef.current,
-    estimateSize: () => 220,
+    estimateSize: () => ESTIMATED_DAY_HEIGHT,
     overscan: 2,
     paddingEnd: 240,
+    // The mount-time anchor. The virtualizer applies this to the scroll
+    // element inside its own layout effect — before first paint — so the
+    // stream never paints the top of the window and then visibly lurches
+    // down to the target day (the anchor effect below runs post-paint). A
+    // remount of an entry the user navigated back to restores its saved
+    // offset the same jump-free way.
+    initialOffset: () =>
+      savedScroll() ?? indexOfDate(dayWindow, targetDateRef.current) * ESTIMATED_DAY_HEIGHT,
   })
   // An instance field, not an option — reassigning every render is idempotent.
   virtualizer.shouldAdjustScrollPositionOnItemSizeChange = adjustScrollForResizeAboveViewport
@@ -83,19 +107,14 @@ export function DailyStream({ targetDate }: DailyStreamProps): ReactElement {
     focusPending.current = null
   }, [])
 
-  // targetDate is read at arrival time, not reacted to: on the `today` route
-  // it drifts when local midnight passes (`todayIso()` per render), and that
-  // drift is not a navigation — re-running the effect then would misread the
-  // entry's continuously-saved offset as a back/forward restore. The next real
-  // arrival (⌘D, a link) reads the fresh value and anchors to the new today.
-  const targetDateRef = useRef(targetDate)
-  targetDateRef.current = targetDate
-
   // Re-anchor on every explicit arrival (`arrivalSeq` bumps even when ⌘D is
   // pressed while already on today — the router clears the entry's saved
   // offset for that case; `entryId` covers back/forward between entries whose
   // routes resolve to the same day). A back/forward-restored entry carries its
-  // offset; a fresh navigation anchors to the target day.
+  // offset; a fresh navigation anchors to the target day. On mount this lands
+  // where `initialOffset` already put the viewport — but `scrollToIndex` also
+  // installs the virtualizer's index-pinning reconcile, which keeps the target
+  // day at the viewport top while the surrounding rows measure in.
   useEffect(() => {
     const restored = savedScroll()
     if (restored !== null) {

--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -32,7 +32,9 @@ interface NotePaneProps {
   /**
    * Extra classes for the editable area (e.g. the daily stream's per-day
    * `min-h-*`). Applied to the contenteditable root, so the reserved space
-   * is click-to-focus.
+   * is click-to-focus — and to the loading/error placeholders, so a pane
+   * holds the same space in every state instead of collapsing and re-expanding
+   * around the stream's scroll anchor while its note arrives.
    */
   editorClassName?: string
   /**
@@ -127,8 +129,18 @@ export function NotePane({
   )
 
   if (document.status === 'loading') {
+    // `reflect-note-loading` keeps the hint invisible for the first beat:
+    // local reads resolve in milliseconds, and the text flashing on every
+    // daily-stream row reads as flicker while the stream anchors.
     return (
-      <div className={cn('px-1 py-2 text-sm text-text-muted', gutterClassName, className)}>
+      <div
+        className={cn(
+          'reflect-note-loading px-1 py-2 text-sm text-text-muted',
+          gutterClassName,
+          editorClassName,
+          className,
+        )}
+      >
         Loading note…
       </div>
     )
@@ -138,7 +150,12 @@ export function NotePane({
     return (
       <div
         role="alert"
-        className={cn('px-1 py-2 text-sm text-red-500', gutterClassName, className)}
+        className={cn(
+          'px-1 py-2 text-sm text-red-500',
+          gutterClassName,
+          editorClassName,
+          className,
+        )}
       >
         Couldn’t open {path}: {document.error}
       </div>

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -240,6 +240,23 @@ body {
   letter-spacing: var(--tracking-snug, -0.01em);
 }
 
+/* NotePane's loading placeholder: hold the editor's reserved space silently,
+   revealing the hint text only when a load is genuinely slow. Local note
+   reads resolve in milliseconds, and "Loading note…" flashing on every
+   daily-stream row reads as flicker while the stream anchors. Opacity only —
+   the placeholder must keep its layout size either way. */
+.reflect-note-loading {
+  opacity: 0;
+  animation: reflect-note-loading-reveal var(--duration-slow, 300ms)
+    var(--ease-standard, ease) 400ms forwards;
+}
+
+@keyframes reflect-note-loading-reveal {
+  to {
+    opacity: 1;
+  }
+}
+
 .reflect-editor p {
   margin: 0.4em 0;
 }


### PR DESCRIPTION
## What

Opening the app did a visible multi-step lurch: it painted the top of the five-year day window, teleported ~400k px down to today, then settled in several jumps as notes loaded. Two causes, both fixed:

1. **The anchor ran after first paint.** The stream anchored via `scrollToIndex` in a post-paint `useEffect`. The fix passes TanStack Virtual's `initialOffset` instead, which the virtualizer applies to the scroll element inside its own mount **layout** effect — before the first frame paints. The first frame now starts on the target day, or on a back/forward entry's saved offset (fixing the same jump when returning from a note route). The post-paint effect still runs: `scrollToIndex` installs the library's index-pinning reconcile, which holds today at the viewport top while surrounding rows measure in.

2. **Rows collapsed and re-expanded as notes arrived.** Each day mounted as a short "Loading note…" placeholder and grew when its note loaded, churning the scroll compensation. `NotePane` now applies `editorClassName` to its loading/error placeholders too, so every day reserves its final space up front (`60vh` for today/future, `100px` for past days) and the placeholder→editor swap is layout-neutral for typical notes.

Also: the "Loading note…" hint flashed on every row for the few milliseconds a local read takes. A new `reflect-note-loading` rule keeps it invisible for 400ms and fades it in only when a load is genuinely slow — the placeholder holds its layout size either way.

## Reviewer notes

- `initialOffset` is computed as `index × ESTIMATED_DAY_HEIGHT`, which is exactly the offset `scrollToIndex` would derive before any row has been measured, so the pre-paint anchor and the post-paint re-pin agree.
- The new tests pin the *first* scroll command the stream issues (it was `top: 0` before this change). jsdom quirk worth knowing: the virtualizer renders **zero rows** in jsdom because `calculateRange` returns null for a zero-height viewport — the test stubs `HTMLElement.prototype.offsetHeight` (viewport for the scroll container, exact-estimate size for rows) to render the range without resize churn.
- Past days with long content can still resize above the viewport as they load, but that's compensated within the same frame by the existing `shouldAdjustScrollPositionOnItemSizeChange` override plus the reconcile loop.
- Verified with `pnpm check` and the desktop test suite for the touched areas (`daily-stream.test.tsx`, `route-content.test.tsx`). Worth a quick visual pass in `pnpm tauri dev` — frame-level smoothness is the one thing the tests can't capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only scroll and loading presentation changes in the daily stream; no auth, data, or persistence logic touched.
> 
> **Overview**
> Fixes the visible startup lurch when opening the daily stream by anchoring scroll **before first paint** and keeping row heights stable while notes load.
> 
> **DailyStream** now sets TanStack Virtual's `initialOffset` (saved back/forward scroll or `index × ESTIMATED_DAY_HEIGHT`) so the viewport lands on today or a restored offset in a layout effect instead of painting from the top of the five-year window. The post-paint anchor effect still runs `scrollToIndex` for index-pinning while rows measure in. `ESTIMATED_DAY_HEIGHT` is exported as the shared estimate for both `estimateSize` and the pre-paint offset.
> 
> **NotePane** applies `editorClassName` (e.g. `min-h-[60vh]` / `min-h-[100px]`) to loading and error placeholders so days reserve final height before the editor mounts, reducing scroll churn as notes arrive.
> 
> **CSS** adds `.reflect-note-loading` to hide "Loading note…" for ~400ms then fade it in, avoiding flicker on fast local reads.
> 
> New **`daily-stream.test.tsx`** asserts the first `scrollTo` targets today or a restored offset, and that loading rows use reserved height and the delayed-hint class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d88e109c8aac27bf026e1ee0e6d750b97ff7b272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->