### PR TITLE
Reduce daily stream date heading font size

### DIFF
--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -235,7 +235,7 @@ body {
    date as the note's subject) without living inside the editor DOM. */
 .reflect-daily-subject {
   font-family: var(--font-reading, var(--font-sans));
-  font-size: var(--text-2xl, 1.5rem);
+  font-size: var(--text-xl, 1.25rem);
   font-weight: 650;
   letter-spacing: var(--tracking-snug, -0.01em);
 }

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -231,8 +231,8 @@ body {
 .reflect-editor h3 { font-size: var(--text-lg, 1.125rem); }
 .reflect-editor h1:first-child { margin-top: 0; }
 
-/* The daily note's date heading shares the editor H1 metrics (V1 renders the
-   date as the note's subject) without living inside the editor DOM. */
+/* The daily note's date heading (V1 renders the date as the note's subject)
+   without living inside the editor DOM. */
 .reflect-daily-subject {
   font-family: var(--font-reading, var(--font-sans));
   font-size: var(--text-xl, 1.25rem);


### PR DESCRIPTION
## Summary

- Reduces `.reflect-daily-subject` font size from `text-2xl` (1.5rem / 24px) to `text-xl` (1.25rem / 20px)

## Why

The date heading felt visually heavy. One step down in the type scale keeps it prominent without dominating the note content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only typography tweak on a presentation class with no logic, data, or API impact.
> 
> **Overview**
> **Typography:** The daily stream date heading (`.reflect-daily-subject` in `index.css`) now uses `text-xl` (1.25rem) instead of `text-2xl` (1.5rem), so it aligns with editor **H2** scale rather than **H1** and reads less dominant above note content. A nearby CSS comment was tightened; markup in `daily-stream.tsx` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4dcf3c6cfe8d4eeef04a7ef852b016683babfed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined the typography sizing in the daily reflection section for improved visual balance and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->