### PR TITLE
Replace model Select with a free-form combobox in Add AI Model dialog

### DIFF
--- a/apps/desktop/src/components/settings/add-ai-model-dialog.tsx
+++ b/apps/desktop/src/components/settings/add-ai-model-dialog.tsx
@@ -27,6 +27,7 @@ import {
 import { InlineAlert } from '@/components/inline-alert'
 import { providerFetch } from '@/lib/provider-fetch'
 import type { NewAiModel } from '@/hooks/use-ai-models'
+import { ModelCombobox } from './model-combobox'
 
 interface AddAiModelDialogProps {
   /** Persists the new model (keychain + settings); rejects on failure. */
@@ -151,21 +152,12 @@ export function AddAiModelDialog({ onAdd, onClose }: AddAiModelDialogProps): Rea
 
           <div className="flex flex-col gap-1">
             <span className={FIELD_LABEL_CLASS}>Model</span>
-            <Select
+            <ModelCombobox
               value={watch('model')}
-              onValueChange={(value) => setValue('model', value)}
-            >
-              <SelectTrigger aria-label="Model" className="w-full">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {provider.models.map((model) => (
-                  <SelectItem key={model.id} value={model.id}>
-                    {model.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+              provider={provider.id}
+              models={provider.models}
+              onChange={(modelId) => setValue('model', modelId)}
+            />
           </div>
 
           <label className="flex flex-col gap-1">

--- a/apps/desktop/src/components/settings/ai-models-section.test.tsx
+++ b/apps/desktop/src/components/settings/ai-models-section.test.tsx
@@ -15,6 +15,14 @@ vi.mock('@/lib/provider-fetch', () => ({ providerFetch: providerFetchMock }))
 // view when the listbox opens.
 Element.prototype.scrollIntoView ??= () => {}
 
+// jsdom doesn't implement ResizeObserver; cmdk uses it to observe the command
+// list dimensions.
+globalThis.ResizeObserver ??= class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
 let stored: Record<string, unknown>
 let saved: unknown[]
 let secrets: Map<string, string>

--- a/apps/desktop/src/components/settings/ai-models-section.test.tsx
+++ b/apps/desktop/src/components/settings/ai-models-section.test.tsx
@@ -138,10 +138,8 @@ describe('AiModelsSection', () => {
     // options render in a portal, so they're queried from screen.
     fireEvent.keyDown(dialog.getByRole('combobox', { name: 'Provider' }), { key: 'ArrowDown' })
     fireEvent.keyDown(await screen.findByRole('option', { name: 'Anthropic' }), { key: 'Enter' })
-    fireEvent.keyDown(dialog.getByRole('combobox', { name: 'Model' }), { key: 'ArrowDown' })
-    fireEvent.keyDown(await screen.findByRole('option', { name: 'Claude Sonnet 4.6' }), {
-      key: 'Enter',
-    })
+    fireEvent.click(dialog.getByRole('combobox', { name: 'Model' }))
+    fireEvent.click(await screen.findByRole('option', { name: /Claude Sonnet 4\.6/ }))
     fireEvent.change(dialog.getByLabelText('API key'), {
       target: { value: 'sk-ant-test-wxyz1' },
     })

--- a/apps/desktop/src/components/settings/model-combobox.tsx
+++ b/apps/desktop/src/components/settings/model-combobox.tsx
@@ -1,0 +1,124 @@
+import { useRef, useState, type ReactElement } from 'react'
+import { useCommandState } from 'cmdk'
+import { ChevronsUpDownIcon } from 'lucide-react'
+import { aiModelLabel, type AiModelOption, type AiProviderId } from '@reflect/core'
+import { Button } from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+
+interface FilterCountSyncProps {
+  countRef: React.MutableRefObject<number>
+}
+
+/**
+ * Reads the cmdk filtered item count each render and writes it into a ref so
+ * the parent's keydown handler always sees the latest value synchronously.
+ * Must be rendered inside a {@link Command}.
+ */
+function FilterCountSync({ countRef }: FilterCountSyncProps): null {
+  const count = useCommandState((state) => state.filtered.count)
+  countRef.current = count
+  return null
+}
+
+interface ModelComboboxProps {
+  /** Currently selected model id (may be a custom string not in the catalog). */
+  value: string
+  /** Provider whose curated model list to show. */
+  provider: AiProviderId
+  /** Curated options for quick-select (most capable first). */
+  models: AiModelOption[]
+  /** Called with the new model id — either a catalog id or a custom string. */
+  onChange: (modelId: string) => void
+}
+
+/**
+ * A combobox for selecting an AI model. Shows the provider's curated models
+ * as quick-select options (searchable) and also accepts any arbitrary model
+ * string — type a custom id and press Enter to confirm it.
+ */
+export function ModelCombobox({
+  value,
+  provider,
+  models,
+  onChange,
+}: ModelComboboxProps): ReactElement {
+  const [open, setOpen] = useState(false)
+  const [inputValue, setInputValue] = useState('')
+  const filteredCountRef = useRef(models.length)
+
+  const commit = (modelId: string) => {
+    onChange(modelId)
+    setOpen(false)
+    setInputValue('')
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' && filteredCountRef.current === 0 && inputValue.trim()) {
+      event.preventDefault()
+      commit(inputValue.trim())
+    }
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          aria-label="Model"
+          className="w-full justify-between font-normal"
+        >
+          <span className="truncate">{aiModelLabel(provider, value)}</span>
+          <ChevronsUpDownIcon className="ml-2 size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="p-0"
+        style={{ width: 'var(--radix-popover-trigger-width)' }}
+        align="start"
+      >
+        <Command>
+          <FilterCountSync countRef={filteredCountRef} />
+          <CommandInput
+            placeholder="Search or type a model name…"
+            value={inputValue}
+            onValueChange={setInputValue}
+            onKeyDown={handleKeyDown}
+          />
+          <CommandList>
+            <CommandEmpty>
+              Press{' '}
+              <kbd className="rounded bg-muted px-1 py-0.5 font-mono text-xs">Enter</kbd>{' '}
+              to use &ldquo;{inputValue}&rdquo;
+            </CommandEmpty>
+            <CommandGroup>
+              {models.map((model) => (
+                <CommandItem
+                  key={model.id}
+                  value={`${model.label} ${model.id}`}
+                  onSelect={() => commit(model.id)}
+                  data-checked={model.id === value}
+                >
+                  {model.label}
+                  <span className="ml-auto font-mono text-xs text-muted-foreground">
+                    {model.id}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/desktop/src/components/settings/model-combobox.tsx
+++ b/apps/desktop/src/components/settings/model-combobox.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type ReactElement } from 'react'
+import { useEffect, useRef, useState, type ReactElement } from 'react'
 import { useCommandState } from 'cmdk'
 import { ChevronsUpDownIcon } from 'lucide-react'
 import { aiModelLabel, type AiModelOption, type AiProviderId } from '@reflect/core'
@@ -54,10 +54,19 @@ export function ModelCombobox({
   const [inputValue, setInputValue] = useState('')
   const filteredCountRef = useRef(models.length)
 
+  // Clear stale search text whenever the popover closes or the provider changes.
+  const clearInput = () => setInputValue('')
+  useEffect(clearInput, [provider])
+
+  const handleOpenChange = (isOpen: boolean) => {
+    setOpen(isOpen)
+    if (!isOpen) clearInput()
+  }
+
   const commit = (modelId: string) => {
     onChange(modelId)
     setOpen(false)
-    setInputValue('')
+    clearInput()
   }
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -68,7 +77,7 @@ export function ModelCombobox({
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button
           type="button"


### PR DESCRIPTION
## Summary

- Replaces the plain `<Select>` for model selection in the **Add AI Model** dialog with a `Popover` + `Command` combobox (the shadcn pattern).
- Users can now type any arbitrary model ID (e.g. `gpt-4-turbo-preview`, `claude-3-5-sonnet-20241022`) — when no catalog items match, `CommandEmpty` prompts **Press `Enter` to use "..."** and Enter commits the custom string.
- Curated models are still available as quick-select options with both the human label and raw model ID shown; they're searchable by either.
- Uses `useCommandState` from `cmdk` to accurately detect when zero catalog items are visible, so the custom-value Enter path never fires while a curated item is highlighted.

## Files

| File | Change |
|---|---|
| `apps/desktop/src/components/settings/model-combobox.tsx` | New — `ModelCombobox` component |
| `apps/desktop/src/components/settings/add-ai-model-dialog.tsx` | Swap model `<Select>` → `<ModelCombobox>` |

## Reviewer notes

- The `FilterCountSync` helper renders inside `<Command>` and writes the cmdk filtered-item count into a ref each render so the `onKeyDown` handler always sees the current count synchronously (no async/stale-closure concerns).
- No schema changes — custom model strings are already valid per `aiModelConfigSchema` (`model: z.string().min(1)`); `aiModelLabel` already falls back to the raw id for strings outside the catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings UI only; model values were already arbitrary strings in schema with no persistence or API contract changes.
> 
> **Overview**
> Replaces the **Add AI Model** dialog’s model dropdown with a searchable **combobox** so users can pick curated models or enter any model ID.
> 
> The new `ModelCombobox` uses Popover + cmdk: catalog entries are searchable by label or id, and when nothing matches, **Enter** commits the typed string as a custom model. The trigger still shows a friendly label via `aiModelLabel` (including ids outside the catalog). `FilterCountSync` keeps the custom Enter path from firing while filtered catalog items are visible.
> 
> Tests stub `ResizeObserver` for cmdk and select a catalog model via click instead of keyboard on the model control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0e884beaf999662a396f270b15d731b864c139e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->