### PR TITLE
Disable user-select on UI chrome for native desktop feel

### DIFF
--- a/apps/desktop/src/components/settings/github-auth-step.tsx
+++ b/apps/desktop/src/components/settings/github-auth-step.tsx
@@ -106,7 +106,7 @@ export function GithubAuthStep({ onAuthed }: GithubAuthStepProps): ReactElement 
             </button>
             :
           </p>
-          <p className="text-center font-mono text-xl tracking-[0.3em] text-text">
+          <p className="select-text text-center font-mono text-xl tracking-[0.3em] text-text">
             {flowView.userCode}
           </p>
           <p className="text-center text-xs text-text-muted">Waiting for GitHub…</p>

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -321,6 +321,7 @@ body {
 /* Inline images: the literal `![alt](src)` text keeps a widget-rendered
    preview directly beneath it (Plan 05b). */
 .reflect-editor .md-image {
+  -webkit-user-select: none;
   user-select: none;
   margin: 0.25em 0 0.5em;
 }

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -175,11 +175,17 @@ body {
     user-select: none;
   }
 
+  /* The * rule above applies none to every element explicitly, so it also
+     hits children inside selectable roots. Restore text on those roots AND
+     their descendants so inner p/h* nodes inside the editor are selectable. */
   input,
   textarea,
   [contenteditable],
+  [contenteditable] *,
   .reflect-editor,
-  .reflect-protected-note {
+  .reflect-editor *,
+  .reflect-protected-note,
+  .reflect-protected-note * {
     -webkit-user-select: text;
     user-select: text;
   }

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -166,19 +166,23 @@ body {
 
 /* Native desktop apps don't allow selecting arbitrary UI chrome; the WebView
    default (user-select: auto) makes every label and sidebar item feel like a
-   webpage. Disable globally and opt in only where selection is meaningful. */
-* {
-  -webkit-user-select: none;
-  user-select: none;
-}
+   webpage. Disable globally and opt in only where selection is meaningful.
+   Placed in @layer base so Tailwind's select-* utilities (select-text,
+   select-all, select-none) in @layer utilities can override per-element. */
+@layer base {
+  * {
+    -webkit-user-select: none;
+    user-select: none;
+  }
 
-input,
-textarea,
-[contenteditable],
-.reflect-editor,
-.reflect-protected-note {
-  -webkit-user-select: text;
-  user-select: text;
+  input,
+  textarea,
+  [contenteditable],
+  .reflect-editor,
+  .reflect-protected-note {
+    -webkit-user-select: text;
+    user-select: text;
+  }
 }
 
 /* One keyboard-focus treatment everywhere. Zero-specificity (`:where`) so any

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -164,6 +164,23 @@ body {
   overscroll-behavior: none;
 }
 
+/* Native desktop apps don't allow selecting arbitrary UI chrome; the WebView
+   default (user-select: auto) makes every label and sidebar item feel like a
+   webpage. Disable globally and opt in only where selection is meaningful. */
+* {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+input,
+textarea,
+[contenteditable],
+.reflect-editor,
+.reflect-protected-note {
+  -webkit-user-select: text;
+  user-select: text;
+}
+
 /* One keyboard-focus treatment everywhere. Zero-specificity (`:where`) so any
    component rule below — the editor's `outline: none`, the palette input —
    can still opt out. */


### PR DESCRIPTION
## Summary

- Sets `user-select: none` (+ `-webkit-user-select`) globally so UI chrome — labels, sidebar items, buttons, palette rows — behaves like native macOS rather than a webpage
- Opts back in with `user-select: text` for `input`, `textarea`, `[contenteditable]`, `.reflect-editor`, and `.reflect-protected-note` — the only surfaces where text selection is meaningful

## Why

The WebView default (`user-select: auto`) lets users accidentally highlight any label or button text on click/drag, which feels broken on a desktop app. Every native macOS app disables selection on chrome elements; Tauri's WKWebView needs this to be done explicitly in CSS.

Both the unprefixed and `-webkit-` forms are set since WKWebView still respects the prefix.

## Test plan

- [ ] Click and drag across sidebar, toolbar buttons, and palette items — no text highlight
- [ ] Click and drag inside the note editor — text selects normally
- [ ] Tab into an `<input>` (e.g. search) and select text — works as expected
- [ ] Verify the protected-note fallback (raw-markdown read-only view) is still selectable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS and one class on the GitHub auth step; no auth, data, or business-logic changes.
> 
> **Overview**
> Disables accidental text selection across the desktop shell so chrome behaves more like a native app than a webpage.
> 
> **Global CSS** in `index.css` sets `user-select: none` (with `-webkit-` for WKWebView) on all elements inside `@layer base`, so Tailwind `select-*` utilities can still override. Selection is turned back on for form fields, `[contenteditable]`, `.reflect-editor` (including descendants), and `.reflect-protected-note`. Inline image widgets inside the editor (`.md-image`) are explicitly non-selectable so image chrome doesn’t highlight when the surrounding note is selectable.
> 
> **GitHub device flow** adds `select-text` on the monospace user code in `github-auth-step.tsx` so users can copy the authorization code despite the global default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2d8ed2befcff9b2a850796fb21c2f79c4b2bb2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced GitHub device flow code display by enabling text selection on authorization codes for easier copying.
  * Implemented refined text selection behavior across the application—enabled in interactive editors, form inputs, and editing areas; disabled globally elsewhere for improved interface clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->