### PR TITLE
Keep tooltips clear of the window edges with default collision padding

### DIFF
--- a/apps/desktop/src/components/ui/tooltip.tsx
+++ b/apps/desktop/src/components/ui/tooltip.tsx
@@ -31,6 +31,7 @@ function TooltipTrigger({
 function TooltipContent({
   className,
   sideOffset = 6,
+  collisionPadding = 8,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
   return (
@@ -38,6 +39,7 @@ function TooltipContent({
       <TooltipPrimitive.Content
         data-slot="tooltip-content"
         sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
         className={cn(
           "z-50 flex items-center gap-2 origin-(--radix-tooltip-content-transform-origin) rounded-md bg-popover px-2.5 py-1.5 text-xs text-popover-foreground shadow-md ring-1 ring-foreground/10 animate-in fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,


### PR DESCRIPTION
## What changed

`TooltipContent` in `apps/desktop/src/components/ui/tooltip.tsx` now defaults Radix's `collisionPadding` to `8` (it was unset, and Radix defaults it to `0`).

## Why

Tooltips rendered near a viewport edge sat flush against the window — e.g. the "Private notes are never sent to AI…" explainer on the context sidebar's **Mark as private** action touched the left edge. Radix already shifts floating content to stay inside the viewport; the padding makes it treat the boundary as 8px inset, so every tooltip keeps a margin on all sides.

## Notes for review

- This is the repo's only tooltip implementation (nothing else imports the Radix tooltip primitives), so the default applies everywhere.
- `collisionPadding` remains an ordinary prop, so individual call sites can still override it.
- `pnpm check` passes; the only lint warnings are pre-existing in unrelated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single shared UI default with no auth, data, or API impact; behavior is still overridable per tooltip.
> 
> **Overview**
> **`TooltipContent`** now passes **`collisionPadding={8}`** by default to Radix, so viewport collision handling keeps an 8px inset instead of sitting flush on window edges.
> 
> The prop stays overridable per call site; every consumer of `@/components/ui/tooltip` picks up the new default with no other file changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fa686b881c482057d1c1c503fbc8c781b444dfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->