### PR TITLE
Plan 16 + V1: any git host over SSH (agent auth, path remotes, zero new UI)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2945,6 +2945,7 @@ checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
+ "libssh2-sys",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -2976,6 +2977,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
@@ -3716,6 +3731,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3723,6 +3747,7 @@ checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ the [product vision](docs/reflect-v2-product-vision.md) for the full picture.
 - **Daily notes first, association over hierarchy.** The app opens to today;
   wiki links and backlinks are the organizing model. No folders.
 - **No Reflect-hosted APIs.** AI features are bring-your-own-key and talk
-  directly to the provider; sync goes to GitHub. Notes marked `private: true`
-  are never sent to any external service.
+  directly to the provider; sync goes to a git repository you control —
+  GitHub guided in-app, [any other host over SSH](docs/generic-git-remotes.md).
+  Notes marked `private: true` are never sent to any external service.
 - **Keyboard-native, minimal UI.** Built on Tauri 2 — no Electron.
 
 ## Architecture

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -42,9 +42,17 @@ keyring = { version = "3", features = [
   "windows-native",
   "sync-secret-service",
 ] }
-# Git backup/sync primitives (Plan 12). HTTPS-only remotes — SSH is deliberately
-# unsupported (token auth via credential callback), so the libssh2 feature is off.
-git2 = { version = "0.21", default-features = false, features = ["https", "vendored-libgit2"] }
+# Git backup/sync primitives (Plan 12) + SSH transport for generic remotes
+# (Plan 16 V1: agent auth only). Everything is vendored/static — libssh2 and
+# openssl must never link against homebrew dylibs the distributed app won't
+# have (libssh2-sys only consults pkg-config when LIBSSH2_SYS_USE_PKG_CONFIG
+# is set, and vendored-openssl pins the rest).
+git2 = { version = "0.21", default-features = false, features = [
+  "https",
+  "ssh",
+  "vendored-libgit2",
+  "vendored-openssl",
+] }
 tauri-plugin-http = "2.5.9"
 tauri-plugin-window-state = "2"
 

--- a/apps/desktop/src-tauri/src/error.rs
+++ b/apps/desktop/src-tauri/src/error.rs
@@ -76,8 +76,16 @@ impl From<git2::Error> for AppError {
         // rate limits; at the transport layer that's indistinguishable from a
         // rejected credential without the response body. Misclassification is
         // not sticky — the auth state never blocks the next cycle's retry.
+        //
+        // SSH (Plan 16): Certificate code = host-key verification failure, and
+        // Ssh-class errors (no agent, rejected keys, handshake) are all fixed
+        // by user action, so they surface as Auth (needs attention) rather
+        // than retrying as Network. An ssh *connectivity* failure carries the
+        // Net class and still lands in Network.
         let lowered = message.to_lowercase();
         if err.code() == ErrorCode::Auth
+            || err.code() == ErrorCode::Certificate
+            || err.class() == ErrorClass::Ssh
             || lowered.contains("status code: 401")
             || lowered.contains("status code: 403")
             || lowered.contains("authentication")
@@ -140,6 +148,27 @@ mod tests {
                 ErrorClass::Http,
                 "request failed with status code: 403",
             ),
+        ];
+        for error in cases {
+            assert!(matches!(error, AppError::Auth { .. }), "{error:?}");
+        }
+    }
+
+    #[test]
+    fn ssh_failures_classify_as_auth() {
+        // All user-fixable: unknown host key, no agent, no accepted key.
+        let cases = [
+            classify(
+                ErrorCode::Certificate,
+                ErrorClass::Ssh,
+                "remote host key is not registered in known_hosts",
+            ),
+            classify(
+                ErrorCode::GenericError,
+                ErrorClass::Ssh,
+                "failed to connect to ssh agent",
+            ),
+            classify(ErrorCode::Auth, ErrorClass::Ssh, "no key this host accepts"),
         ];
         for error in cases {
             assert!(matches!(error, AppError::Auth { .. }), "{error:?}");

--- a/apps/desktop/src-tauri/src/git/remote.rs
+++ b/apps/desktop/src-tauri/src/git/remote.rs
@@ -1,8 +1,10 @@
-//! Network operations: fetch and push over HTTPS with token credentials.
+//! Network operations: fetch and push over HTTPS or SSH.
 //!
-//! Tokens arrive per call and are supplied through libgit2's credential
-//! callback — they are **never** embedded in the remote URL, so they never
-//! touch `.git/config` or disk.
+//! Credentials are supplied through libgit2's credential callback — they are
+//! **never** embedded in the remote URL, so they never touch `.git/config` or
+//! disk. A per-call token (the managed GitHub sign-in) authenticates over
+//! HTTPS; without one, credentials resolve locally — the SSH agent for ssh
+//! remotes (Plan 16 V1; generic HTTPS waits for V2's credential helpers).
 
 use std::cell::RefCell;
 use std::path::Path;
@@ -37,23 +39,78 @@ pub struct PushOutcome {
     pub rejection_message: Option<String>,
 }
 
-/// `RemoteCallbacks` pre-wired with the token credential handler — the one
+/// Pick a credential for one callback invocation.
+///
+/// With a token (the managed GitHub path) it is HTTPS basic auth as
+/// `x-access-token` — never offered for any other credential type, so a
+/// token can never leak to a transport we didn't intend. Without one
+/// (generic remotes, Plan 16 V1) the chain is: answer a bare username probe,
+/// then offer the SSH agent exactly once — libgit2 re-invokes the callback
+/// after a rejection, and re-offering the same agent would loop forever, so
+/// the second ask becomes the actionable error. Generic HTTPS fails fast
+/// until V2 adds credential-helper resolution. Errors carry
+/// `ErrorCode::Auth` so they classify as `AppError::Auth` (surfaced as
+/// needs-attention, not retried blindly).
+fn resolve_credential(
+    token: Option<&str>,
+    username_from_url: Option<&str>,
+    allowed: CredentialType,
+    ssh_agent_tried: &mut bool,
+) -> Result<Cred, git2::Error> {
+    use git2::{ErrorClass, ErrorCode};
+    if let Some(token) = token {
+        if !allowed.contains(CredentialType::USER_PASS_PLAINTEXT) {
+            return Err(git2::Error::new(
+                ErrorCode::Auth,
+                ErrorClass::Callback,
+                "the remote requires an unsupported credential type (token sign-in is HTTPS-only)",
+            ));
+        }
+        return Cred::userpass_plaintext("x-access-token", token);
+    }
+    // SSH asks in two rounds: first the username alone (`ssh://host/…` URLs
+    // that don't carry one), then a key for it.
+    if allowed.contains(CredentialType::USERNAME) {
+        return Cred::username(username_from_url.unwrap_or("git"));
+    }
+    if allowed.contains(CredentialType::SSH_KEY) {
+        if *ssh_agent_tried {
+            return Err(git2::Error::new(
+                ErrorCode::Auth,
+                ErrorClass::Ssh,
+                "the SSH agent offered no key this host accepts — `ssh-add` the right key, then check `ssh -T git@<host>` works",
+            ));
+        }
+        *ssh_agent_tried = true;
+        return Cred::ssh_key_from_agent(username_from_url.unwrap_or("git"));
+    }
+    if allowed.contains(CredentialType::USER_PASS_PLAINTEXT) {
+        return Err(git2::Error::new(
+            ErrorCode::Auth,
+            ErrorClass::Http,
+            "HTTPS sign-in is only supported for github.com — use an SSH remote URL (git@host:owner/repo.git) for other hosts",
+        ));
+    }
+    Err(git2::Error::new(
+        ErrorCode::Auth,
+        ErrorClass::Callback,
+        "the remote requires an unsupported credential type",
+    ))
+}
+
+/// `RemoteCallbacks` pre-wired with the credential chain — the one
 /// configuration fetch, clone, and push all share. Callers layer their own
 /// callbacks (push status, sideband) on top.
 fn callbacks_with_credentials<'cb>(token: Option<String>) -> RemoteCallbacks<'cb> {
     let mut callbacks = RemoteCallbacks::new();
-    callbacks.credentials(move |_url, _username, allowed| {
-        if !allowed.contains(CredentialType::USER_PASS_PLAINTEXT) {
-            return Err(git2::Error::from_str(
-                "the remote requires an unsupported credential type (only HTTPS token auth is supported)",
-            ));
-        }
-        match &token {
-            Some(token) => Cred::userpass_plaintext("x-access-token", token),
-            None => Err(git2::Error::from_str(
-                "the remote requires authentication but no token is connected",
-            )),
-        }
+    let mut ssh_agent_tried = false;
+    callbacks.credentials(move |_url, username_from_url, allowed| {
+        resolve_credential(
+            token.as_deref(),
+            username_from_url,
+            allowed,
+            &mut ssh_agent_tried,
+        )
     });
     callbacks
 }
@@ -194,5 +251,115 @@ fn classify_rejection(message: String, sideband: &str) -> PushOutcome {
         pushed: false,
         non_fast_forward,
         rejection_message: Some(full),
+    }
+}
+
+#[cfg(test)]
+mod credential_tests {
+    use git2::{Cred, CredentialType, ErrorCode};
+
+    use super::resolve_credential;
+
+    // `Cred` implements no `Debug`, so unwrap/expect can't print it.
+    fn expect_ok(result: Result<Cred, git2::Error>) {
+        if let Err(err) = result {
+            panic!("expected a credential: {err}");
+        }
+    }
+
+    fn expect_err(result: Result<Cred, git2::Error>) -> git2::Error {
+        match result {
+            Ok(_) => panic!("expected an error, got a credential"),
+            Err(err) => err,
+        }
+    }
+
+    #[test]
+    fn token_authenticates_https() {
+        let mut tried = false;
+        expect_ok(resolve_credential(
+            Some("ghs_token"),
+            None,
+            CredentialType::USER_PASS_PLAINTEXT,
+            &mut tried,
+        ));
+    }
+
+    #[test]
+    fn token_is_never_offered_to_non_https_transports() {
+        // A github.com remote rewired to ssh, or any future transport, must
+        // not receive the managed token as some other credential shape.
+        let mut tried = false;
+        let err = expect_err(resolve_credential(
+            Some("ghs_token"),
+            Some("git"),
+            CredentialType::SSH_KEY,
+            &mut tried,
+        ));
+        assert_eq!(err.code(), ErrorCode::Auth);
+        assert!(err.message().contains("HTTPS-only"), "{err}");
+        assert!(!tried, "the agent must not be consulted on the token path");
+    }
+
+    #[test]
+    fn ssh_username_probe_is_answered() {
+        let mut tried = false;
+        expect_ok(resolve_credential(
+            None,
+            None,
+            CredentialType::USERNAME,
+            &mut tried,
+        ));
+        assert!(!tried);
+    }
+
+    #[test]
+    fn ssh_agent_is_offered_once_then_errors_actionably() {
+        // libgit2 re-invokes the callback after a rejected credential; the
+        // second ask must become the actionable error, not an infinite loop.
+        let mut tried = false;
+        expect_ok(resolve_credential(
+            None,
+            Some("git"),
+            CredentialType::SSH_KEY,
+            &mut tried,
+        ));
+        assert!(tried);
+
+        let err = expect_err(resolve_credential(
+            None,
+            Some("git"),
+            CredentialType::SSH_KEY,
+            &mut tried,
+        ));
+        assert_eq!(err.code(), ErrorCode::Auth);
+        assert!(err.message().contains("ssh-add"), "{err}");
+    }
+
+    #[test]
+    fn generic_https_fails_fast_with_the_ssh_suggestion() {
+        // Plan 16 V1: no credential-helper resolution yet — an honest error
+        // beats a half-try that dies somewhere less explicable.
+        let mut tried = false;
+        let err = expect_err(resolve_credential(
+            None,
+            None,
+            CredentialType::USER_PASS_PLAINTEXT,
+            &mut tried,
+        ));
+        assert_eq!(err.code(), ErrorCode::Auth);
+        assert!(err.message().contains("SSH remote URL"), "{err}");
+    }
+
+    #[test]
+    fn unsupported_credential_types_error_with_auth() {
+        let mut tried = false;
+        let err = expect_err(resolve_credential(
+            None,
+            None,
+            CredentialType::SSH_INTERACTIVE,
+            &mut tried,
+        ));
+        assert_eq!(err.code(), ErrorCode::Auth);
     }
 }

--- a/apps/desktop/src/components/settings/backup-section.test.tsx
+++ b/apps/desktop/src/components/settings/backup-section.test.tsx
@@ -1,0 +1,71 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { BackupState } from '@/lib/backup-controller'
+import { BackupSection } from './backup-section'
+
+// The section's GitHub-vs-generic split (Plan 16): a hand-wired remote must
+// render host-neutrally, and its auth errors must surface the engine's
+// actionable message — "reconnect GitHub" can't fix an ssh-agent problem.
+
+const sync = vi.hoisted(() => ({
+  backup: { phase: 'loading' } as BackupState,
+  disconnectGraph: vi.fn(async () => {}),
+  signOut: vi.fn(async () => {}),
+  backUpNow: vi.fn(async () => {}),
+}))
+vi.mock('@/providers/sync-provider', () => ({ useSync: () => sync }))
+vi.mock('@/providers/graph-provider', () => ({ useGraph: () => ({ graph: null }) }))
+
+afterEach(() => {
+  cleanup()
+})
+
+function renderSection(backup: BackupState): void {
+  sync.backup = backup
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <BackupSection />
+    </QueryClientProvider>,
+  )
+}
+
+const AUTH_ERROR = {
+  state: 'error',
+  errorKind: 'auth',
+  message: 'the SSH agent offered no key this host accepts — `ssh-add` the right key',
+} as const
+
+describe('BackupSection', () => {
+  it('renders a generic remote host-neutrally with the engine’s own auth message', async () => {
+    renderSection({
+      phase: 'connected',
+      remoteUrl: 'git@gitlab.com:alex/notes.git',
+      repo: null,
+      status: AUTH_ERROR,
+    })
+
+    expect(await screen.findByText('Backup', { selector: 'legend' })).toBeTruthy()
+    expect(screen.queryByText('GitHub backup')).toBeNull()
+    expect(screen.getByText('git@gitlab.com:alex/notes.git')).toBeTruthy()
+    // The actionable message, not a GitHub reconnect that can't help.
+    expect(screen.getByText(/ssh-add/)).toBeTruthy()
+    expect(screen.queryByText(/reconnect GitHub/)).toBeNull()
+    // Machine-level GitHub sign-out is noise next to a non-GitHub graph.
+    expect(screen.queryByRole('button', { name: 'Sign out of GitHub' })).toBeNull()
+  })
+
+  it('renders a GitHub remote with the reconnect affordances', async () => {
+    renderSection({
+      phase: 'connected',
+      remoteUrl: 'https://github.com/alex/notes.git',
+      repo: { owner: 'alex', name: 'notes' },
+      status: AUTH_ERROR,
+    })
+
+    expect(await screen.findByText('GitHub backup')).toBeTruthy()
+    expect(screen.getByText('alex/notes')).toBeTruthy()
+    expect(screen.getByText(/reconnect GitHub/)).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Sign out of GitHub' })).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/components/settings/backup-section.tsx
+++ b/apps/desktop/src/components/settings/backup-section.tsx
@@ -21,7 +21,9 @@ function statusLine(backup: Extract<BackupState, { phase: 'connected' }>): strin
     case 'offline':
       return backup.status.message
     case 'error':
-      return backup.status.errorKind === 'auth'
+      // "Reconnect GitHub" only helps when GitHub is the remote; a generic
+      // remote's auth message already names the fix (ssh-add, known_hosts…).
+      return backup.status.errorKind === 'auth' && backup.repo !== null
         ? 'Backup failed — reconnect GitHub'
         : `Backup failed: ${backup.status.message}`
   }
@@ -50,12 +52,18 @@ export function BackupSection(): ReactElement {
     backup.phase === 'connected'
       ? (backup.repo !== null ? `${backup.repo.owner}/${backup.repo.name}` : backup.remoteUrl)
       : null
+  // A hand-wired non-GitHub remote (Plan 16) renders the section host-neutral.
+  const genericRemote = backup.phase === 'connected' && backup.repo === null
 
   return (
     <SettingsSection id="backup">
       <SettingsField
-        legend="GitHub backup"
-        description="Back up this graph to a GitHub repository. Edits back up automatically a few moments after you stop typing."
+        legend={genericRemote ? 'Backup' : 'GitHub backup'}
+        description={
+          genericRemote
+            ? 'This graph backs up to its own git remote. Edits back up automatically a few moments after you stop typing.'
+            : 'Back up this graph to a GitHub repository. Edits back up automatically a few moments after you stop typing.'
+        }
       >
         <div className="mt-3 flex flex-col gap-2">
           {backup.phase === 'loading' ? (
@@ -101,14 +109,18 @@ export function BackupSection(): ReactElement {
                 >
                   Stop backing up
                 </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  title="Removes the GitHub token from this machine — every connected graph stops backing up"
-                  onClick={() => void action.run(signOut)}
-                >
-                  Sign out of GitHub
-                </Button>
+                {backup.repo !== null ? (
+                  // Machine-level GitHub sign-out is noise next to a graph
+                  // that doesn't back up to GitHub.
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    title="Removes the GitHub token from this machine — every connected graph stops backing up"
+                    onClick={() => void action.run(signOut)}
+                  >
+                    Sign out of GitHub
+                  </Button>
+                ) : null}
               </div>
             </>
           ) : null}

--- a/apps/desktop/src/lib/backup-controller.test.ts
+++ b/apps/desktop/src/lib/backup-controller.test.ts
@@ -139,7 +139,7 @@ describe('createBackupController', () => {
   it('never offers the GitHub token to a generic remote', async () => {
     // A GitHub credential in the keychain + a foreign origin: the token must
     // not ride along as basic auth to a host the user never authorized.
-    const { invocations } = fakeBridge({ remoteUrl: 'https://gitlab.com/alex/notes.git' })
+    const { invocations } = fakeBridge({ remoteUrl: 'git@gitlab.com:alex/notes.git' })
     const controller = createBackupController({ graph: GRAPH, indexGeneration: 1 })
     await controller.start()
     await vi.waitFor(() => {
@@ -151,6 +151,32 @@ describe('createBackupController', () => {
         expect(args).toMatchObject({ token: null })
       }
     }
+    controller.dispose()
+  })
+
+  it('refuses a generic HTTPS remote at adoption with the SSH suggestion', async () => {
+    // A *public* generic HTTPS remote would pull anonymously and only fail
+    // on push — edits arriving while the user's own never leave. The guard
+    // surfaces the error before the engine ever starts.
+    const { calls } = fakeBridge({ remoteUrl: 'https://gitlab.com/alex/notes.git' })
+    const controller = createBackupController({ graph: GRAPH, indexGeneration: 1 })
+    await controller.start()
+
+    expect(controller.getState()).toMatchObject({
+      phase: 'connected',
+      repo: null,
+      status: { state: 'error', errorKind: 'rejected' },
+    })
+    const state = controller.getState()
+    if (state.phase === 'connected' && state.status.state === 'error') {
+      expect(state.status.message).toContain('git remote set-url')
+    }
+
+    // No engine: no git work now, and focus events stay inert.
+    window.dispatchEvent(new Event('focus'))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(calls).not.toContain('git_commit_all')
+    expect(calls).not.toContain('git_fetch')
     controller.dispose()
   })
 

--- a/apps/desktop/src/lib/backup-controller.test.ts
+++ b/apps/desktop/src/lib/backup-controller.test.ts
@@ -33,6 +33,8 @@ interface FakeOptions {
   failStatus?: boolean
   /** Scripted `git_merge_remote` outcome (defaults to up-to-date). */
   mergeOutcome?: unknown
+  /** The graph's origin (defaults to a GitHub HTTPS remote). */
+  remoteUrl?: string
 }
 
 /** Bridge fake with a mutable repo status, recording every command. */
@@ -43,7 +45,7 @@ function fakeBridge(options: FakeOptions = {}) {
   const status = {
     initialized: true,
     branch: 'main',
-    remoteUrl: 'https://github.com/alex/notes.git' as string | null,
+    remoteUrl: (options.remoteUrl ?? 'https://github.com/alex/notes.git') as string | null,
     ahead: 0,
     behind: 0,
     inProgress: false,
@@ -108,6 +110,47 @@ describe('createBackupController', () => {
 
     expect(controller.getState()).toEqual({ phase: 'disconnected' })
     expect(calls).not.toContain('git_commit_all')
+    controller.dispose()
+  })
+
+  it('adopts a hand-wired generic remote without any stored credential', async () => {
+    // Plan 16 V1: a non-GitHub origin (here SSH) needs no GitHub sign-in —
+    // its credentials live with the user's git tooling, resolved in Rust.
+    const { calls, invocations } = fakeBridge({
+      auth: null,
+      remoteUrl: 'git@gitlab.com:alex/notes.git',
+    })
+    const controller = createBackupController({ graph: GRAPH, indexGeneration: 1 })
+    await controller.start()
+    await vi.waitFor(() => {
+      expect(calls).toContain('git_fetch')
+    })
+
+    expect(controller.getState()).toMatchObject({
+      phase: 'connected',
+      remoteUrl: 'git@gitlab.com:alex/notes.git',
+      repo: null,
+    })
+    const fetch = invocations.find(({ command }) => command === 'git_fetch')
+    expect(fetch?.args).toMatchObject({ token: null })
+    controller.dispose()
+  })
+
+  it('never offers the GitHub token to a generic remote', async () => {
+    // A GitHub credential in the keychain + a foreign origin: the token must
+    // not ride along as basic auth to a host the user never authorized.
+    const { invocations } = fakeBridge({ remoteUrl: 'https://gitlab.com/alex/notes.git' })
+    const controller = createBackupController({ graph: GRAPH, indexGeneration: 1 })
+    await controller.start()
+    await vi.waitFor(() => {
+      expect(invocations.some(({ command }) => command === 'git_fetch')).toBe(true)
+    })
+
+    for (const { command, args } of invocations) {
+      if (command === 'git_fetch' || command === 'git_push') {
+        expect(args).toMatchObject({ token: null })
+      }
+    }
     controller.dispose()
   })
 

--- a/apps/desktop/src/lib/backup-controller.ts
+++ b/apps/desktop/src/lib/backup-controller.ts
@@ -29,8 +29,11 @@ import { providerFetch } from '@/lib/provider-fetch'
 import { invalidateIndexQueries } from '@/lib/query-client'
 
 /**
- * Backup state as the UI sees it. `connected` means the graph has a repo,
- * an `origin` remote, and a stored GitHub credential — the engine is running.
+ * Backup state as the UI sees it. `connected` means the graph has a repo and
+ * an `origin` remote, and the engine is running. `repo` is set for GitHub
+ * remotes (which additionally require the stored GitHub credential) and
+ * `null` for hand-wired generic remotes (Plan 16: GitLab/Gitea/self-hosted
+ * over SSH, or a bare path repo), whose credentials resolve locally in Rust.
  */
 export type BackupState =
   | { phase: 'loading' }
@@ -160,22 +163,31 @@ export function createBackupController(options: BackupControllerOptions): Backup
       if (disposed) {
         return
       }
-      if (!status.initialized || status.remoteUrl === null || auth === null) {
+      if (!status.initialized || status.remoteUrl === null) {
         setState({ phase: 'disconnected' })
         return
       }
       const remoteUrl = status.remoteUrl
       const repo = parseGithubRemote(remoteUrl)
+      if (repo !== null && auth === null) {
+        // A GitHub remote needs the managed sign-in; the wizard is the fix.
+        // Generic remotes adopt without it — their credentials live with the
+        // user's own git tooling (ssh agent), not in our keychain.
+        setState({ phase: 'disconnected' })
+        return
+      }
       const next = createSyncEngine({
         generation,
-        getToken: () => getGithubToken(providerFetch),
+        // The managed token is for github.com only — a generic host must
+        // never receive it. Rust resolves generic credentials locally.
+        getToken: repo === null ? async () => null : () => getGithubToken(providerFetch),
         onStatus: (engineStatus) => {
           setState({ phase: 'connected', remoteUrl, repo, status: engineStatus })
         },
         onLargeFilesSkipped: (files) => {
           // Surface the guardrail loudly: these files are NOT in the backup.
           const names = files.map((file) => file.path).join(', ')
-          startOperation('Backing up').fail(`Too large for GitHub backup (kept local): ${names}`)
+          startOperation('Backing up').fail(`Too large to back up (kept local): ${names}`)
         },
         onRemoteChanges,
       })

--- a/apps/desktop/src/lib/backup-controller.ts
+++ b/apps/desktop/src/lib/backup-controller.ts
@@ -176,6 +176,25 @@ export function createBackupController(options: BackupControllerOptions): Backup
         setState({ phase: 'disconnected' })
         return
       }
+      if (repo === null && /^https?:\/\//i.test(remoteUrl)) {
+        // Plan 16 V1 speaks SSH (and paths) to generic hosts, not HTTPS.
+        // Fail at adoption, not at the first push: a *public* HTTPS remote
+        // would pull anonymously and only 401 on push — the other device's
+        // edits arriving while this one's silently never leave. The engine
+        // never starts; `rejected` = acting (not retrying) is the fix.
+        setState({
+          phase: 'connected',
+          remoteUrl,
+          repo: null,
+          status: {
+            state: 'error',
+            errorKind: 'rejected',
+            message:
+              'HTTPS isn’t supported for this host yet — switch the remote to its SSH form: git remote set-url origin git@<host>:<owner>/<repo>.git',
+          },
+        })
+        return
+      }
       const next = createSyncEngine({
         generation,
         // The managed token is for github.com only — a generic host must

--- a/docs/generic-git-remotes.md
+++ b/docs/generic-git-remotes.md
@@ -1,0 +1,60 @@
+# Back up to any git host (SSH)
+
+GitHub gets the guided in-app flow (Settings → Backup → Connect GitHub…).
+Every other git host — GitLab, Gitea, Codeberg, GitHub Enterprise, your own
+server, a bare repo on a NAS — works with zero UI: wire the remote yourself
+and Reflect's sync loop adopts it (Plan 16).
+
+The contract: **if `ssh -T git@host` works in your terminal, sync works.**
+Reflect authenticates SSH remotes through your ssh-agent — it never asks for,
+stores, or manages credentials for non-GitHub hosts, and the managed GitHub
+sign-in is never sent anywhere but github.com. HTTPS URLs for non-GitHub
+hosts aren't supported yet (that's Plan 16 V2, via git credential helpers) —
+use the SSH form.
+
+## Recipe
+
+```bash
+cd /path/to/your/graph
+git init -b main                                     # skip if it's already a repo
+git remote add origin git@gitlab.com:you/notes.git   # any SSH remote
+ssh -T git@gitlab.com   # confirms key auth works and records the host key
+```
+
+Then open (or refocus) the graph in Reflect. Settings → Backup shows the
+remote, edits back up automatically a few moments after you stop typing, and
+pulls/merges run on launch and focus — conflict handling included, same as
+GitHub.
+
+A bare repo on another disk needs no credentials at all:
+
+```bash
+git init --bare /Volumes/NAS/notes.git
+cd /path/to/your/graph && git remote add origin /Volumes/NAS/notes.git
+```
+
+## Restore on another machine
+
+```bash
+git clone git@gitlab.com:you/notes.git ~/notes
+```
+
+…then open `~/notes` as a graph. The index rebuilds from the files, and the
+remote is adopted automatically.
+
+## When it fails
+
+Failures surface in Settings → Backup (and the sidebar dot) and retry on
+focus — sync never wedges.
+
+- **"the SSH agent offered no key this host accepts"** — `ssh-add` your key,
+  confirm `ssh -T git@<host>` works, refocus Reflect.
+- **Unknown host key** — connect once with `ssh <host>` so it lands in
+  `~/.ssh/known_hosts`. Reflect never bypasses host-key verification.
+- **HTTPS remote** — switch it to the SSH URL:
+  `git remote set-url origin git@host:owner/repo.git`.
+
+One caution that the GitHub flow handles for you but a hand-wired remote
+can't: there is no host API to check repository visibility, so keeping the
+backup private is your responsibility — **notes marked `private: true` are
+included in the backup**.

--- a/docs/generic-git-remotes.md
+++ b/docs/generic-git-remotes.md
@@ -51,8 +51,12 @@ focus — sync never wedges.
   confirm `ssh -T git@<host>` works, refocus Reflect.
 - **Unknown host key** — connect once with `ssh <host>` so it lands in
   `~/.ssh/known_hosts`. Reflect never bypasses host-key verification.
-- **HTTPS remote** — switch it to the SSH URL:
-  `git remote set-url origin git@host:owner/repo.git`.
+- **HTTPS remote** — refused at adoption with this same advice: switch it to
+  the SSH URL, `git remote set-url origin git@host:owner/repo.git`.
+
+One more terminal-side fact: **"Stop backing up"** in Settings drops the
+graph's `origin` (history stays). For a hand-wired remote the way back is the
+same `git remote add origin …` you started with.
 
 One caution that the GitHub flow handles for you but a hand-wired remote
 can't: there is no host API to check repository visibility, so keeping the

--- a/docs/plans/00-overview.md
+++ b/docs/plans/00-overview.md
@@ -49,6 +49,7 @@ before the editor, and the editor lands before search/AI.
 | 13 | [Import / export / portability](13-import-export-portability.md) | Markdown/Obsidian-graph import, JSON/Markdown/HTML export, attachments preserved |
 | 14 | [CLI (read/discovery)](14-cli-read-discovery.md) | `reflect today`, `reflect search`, `reflect show`, path lookup |
 | 15 | [Hardening, packaging & OSS release](15-hardening-packaging-release.md) | a11y, perf budgets, signing/notarization, MIT + docs, onboarding, release pipeline |
+| 16 | [Generic git remotes](16-generic-git-remotes.md) | Any git host (GitLab/Gitea/GHES/NAS) via hand-wired `origin` — local credential resolution (helpers, SSH agent), zero new UI |
 
 ## Milestone map
 

--- a/docs/plans/00-overview.md
+++ b/docs/plans/00-overview.md
@@ -49,7 +49,7 @@ before the editor, and the editor lands before search/AI.
 | 13 | [Import / export / portability](13-import-export-portability.md) | Markdown/Obsidian-graph import, JSON/Markdown/HTML export, attachments preserved |
 | 14 | [CLI (read/discovery)](14-cli-read-discovery.md) | `reflect today`, `reflect search`, `reflect show`, path lookup |
 | 15 | [Hardening, packaging & OSS release](15-hardening-packaging-release.md) | a11y, perf budgets, signing/notarization, MIT + docs, onboarding, release pipeline |
-| 16 | [Generic git remotes](16-generic-git-remotes.md) | Any git host (GitLab/Gitea/GHES/NAS) via hand-wired `origin` — local credential resolution (helpers, SSH agent), zero new UI |
+| 16 | [Generic git remotes](16-generic-git-remotes.md) | Any git host (GitLab/Gitea/GHES/NAS) via hand-wired `origin`, zero new UI — V1 SSH (agent) + path remotes, V2 HTTPS (credential helpers) |
 
 ## Milestone map
 

--- a/docs/plans/12-backup-and-sync.md
+++ b/docs/plans/12-backup-and-sync.md
@@ -210,9 +210,10 @@ present) · `Backup failed` (action needed). Git mechanics never surface.
 - meowdown conflict widget (parse marker blocks → keep-mine/keep-theirs UI).
 - AI-assisted resolution via the Plan 10 copilot (markers parse to base/ours/theirs;
   `private: true` notes never go to cloud AI).
-- Custom merge driver for daily notes; Git LFS / asset offload; generic-remote UX
-  toggle; background sync on mobile; "purge history" escape hatch; stale-`index.lock`
-  recovery on startup.
+- Custom merge driver for daily notes; Git LFS / asset offload; background sync on
+  mobile; "purge history" escape hatch; stale-`index.lock` recovery on startup.
+- ~~Generic-remote UX toggle~~ → became [Plan 16](16-generic-git-remotes.md): any git
+  host via a hand-wired `origin`, no UI (V1 ships SSH-agent auth + path remotes).
 
 ## Risks
 

--- a/docs/plans/16-generic-git-remotes.md
+++ b/docs/plans/16-generic-git-remotes.md
@@ -1,0 +1,188 @@
+# Plan 16 — Generic Git Remotes (Bring Your Own Host)
+
+**Goal:** Back up and sync a graph to **any git remote** — GitLab, Gitea, Codeberg,
+GitHub Enterprise, a self-hosted server, or a bare repo on a NAS — with **zero new UI**.
+The contract: a user runs `git init` (or Reflect already did) and
+`git remote add origin <url>` in their graph, and the existing sync loop (Plan 12)
+adopts it — debounced commit → push, pull/merge on launch/focus, conflicts-as-data.
+Everything else just works.
+
+**Depends on:** Plan 12 (the whole sync loop; this plan only widens its credential
+story). **Status:** proposed.
+
+**Explicitly not in scope:** host pickers, a "custom remote" wizard, per-host settings
+UI, or per-host REST sugar (repo creation, visibility checks, install links — those
+stay GitHub-only conveniences). File-sync providers (iCloud/Dropbox) remain unsupported
+by design; this plan is about other *git hosts*, not other *sync mechanisms*.
+
+## Where we stand (why it doesn't work today)
+
+The Plan 12 architecture already did most of the work: the Rust layer speaks
+`remote URL + credential callback` and the engine/controller/conflict policy are
+host-agnostic. Four things block a hand-wired remote:
+
+1. **Adoption gating.** `backup-controller.start()` refuses to adopt unless a
+   **GitHub** credential is stored (`loadGithubAuth() !== null`), even though the
+   repo + remote are fine.
+2. **Credential routing — also today's one security wart.** The engine feeds
+   `getGithubToken()` into every fetch/push, and `remote.rs` sends it as
+   `x-access-token:<token>` basic auth to **whatever host origin points at**. A
+   hand-wired non-GitHub origin would today (a) fail auth and (b) leak the user's
+   GitHub token to that host. Fixing the routing is worth landing even if the rest
+   of this plan stalls.
+3. **HTTPS-only build.** `git2` is compiled `default-features = false,
+   features = ["https", "vendored-libgit2"]` — `git@host:…` remotes cannot connect
+   at all, and SSH is the URL form most users will paste.
+4. **Credential callback is token-or-fail.** `callbacks_with_credentials(None)`
+   errors with "no token is connected" instead of trying anything local.
+
+Already in place and reused as-is: nullable token plumbing end-to-end
+(`gitFetch(token: string | null)` → `Option<String>`), `PushOutcome` rejections-as-data,
+conflict markers + protected notes, `parseGithubRemote` returning `null` for foreign
+URLs (the controller already carries `repo: null` without falling over).
+
+## Design
+
+### 1. Remote-aware credential routing (core TS)
+
+Classify the remote once at adoption: `parseGithubRemote(remoteUrl)` non-null →
+**github**, else **generic**.
+
+- **github** → unchanged: `getToken: () => getGithubToken(providerFetch)` (device-flow
+  refresh and all).
+- **generic** → `getToken: () => null`, always. The Rust side resolves credentials
+  locally (below). The stored GitHub credential is **never** offered to a non-GitHub
+  host — closing wart (2).
+
+GitHub Enterprise falls out naturally: `ghe.corp.com` doesn't parse as github.com, so
+it takes the generic path and authenticates with whatever the user's git credential
+helper holds — which is exactly the GHES story we wanted anyway.
+
+### 2. Local credential resolution (Rust, `remote.rs`)
+
+When the per-call token is `None`, the credential callback becomes a chain driven by
+libgit2's `allowed` types instead of an error:
+
+- `USER_PASS_PLAINTEXT` (HTTPS) → `Cred::credential_helper(&repo.config()?, url,
+  username_from_url)`. git2-rs implements helper execution itself: it reads
+  `credential.helper` from git config and runs the helper (`osxkeychain` on macOS,
+  `manager` on Windows, `libsecret`/`store` on Linux). **This is the whole trick** —
+  the user's one-time `git push` from a terminal stores a login in the same place
+  we read from. We *read* helpers, never write them.
+- `SSH_KEY` (ssh remotes) → `Cred::ssh_key_from_agent(username_from_url
+  .unwrap_or("git"))`, falling back to the default key files
+  (`~/.ssh/id_ed25519`, `~/.ssh/id_rsa`, unencrypted only — passphrase prompting is
+  UI and stays out; passphrase keys work via the agent).
+- `DEFAULT` → `Cred::default()` (NTLM/Negotiate proxies; cheap to include).
+
+**Retry guard:** libgit2 re-invokes the callback after a rejected credential, which
+loops forever if the chain keeps producing the same answer. Track attempted types in
+the existing `RefCell` pattern and return a clear `Auth` error once the chain is
+exhausted — message names what was tried ("credential helper had no login for
+gitlab.com; run `git push` from a terminal once so it stores one").
+
+When the token is `Some(…)` (GitHub path) behavior is byte-for-byte today's.
+
+### 3. SSH transport
+
+`git2 = { features = ["https", "ssh", "vendored-libgit2"] }` — adds vendored
+`libssh2`. Host-key verification: libgit2 ≥ 1.5 enforces known_hosts checking by
+default (post-CVE-2023-22742); we keep the default and **do not** install a
+permissive `certificate_check`. An unknown host fails with a hint:
+"connect once with `ssh <host>` so it's added to known_hosts".
+
+Recommendation: **SSH ships in this wave.** `git@…` is the URL form muscle memory
+produces; without it, "add a remote and it just works" fails for most of the target
+persona. It's isolated in Phase 3 so it can be cut to HTTPS-only if the spike turns
+up build pain (signing/notarization of vendored libssh2, binary size, Windows).
+
+### 4. Adoption gating (backup controller)
+
+`start()` adopts when `status.initialized && remoteUrl !== null` — and then:
+
+- **github remote** → still requires `loadGithubAuth() !== null` (otherwise
+  `disconnected`, as today: the wizard is the fix).
+- **generic remote** → adopt unconditionally. If local credentials turn out missing,
+  the first cycle surfaces the auth error in the existing status UI and the engine
+  keeps retrying on focus — same shape as any other sync error, no new states.
+
+### 5. Existing-surface degradation audit (not new UI)
+
+The generic path bypasses the wizard entirely, but a few connected-state surfaces
+assume GitHub when `repo === null`:
+
+- Settings/status panel: show the bare remote URL (already carried in state); hide
+  "View on GitHub"-style affordances and the app-install link.
+- `auth`-state recovery action: for github remotes it reopens the wizard; for generic
+  remotes the message points at the terminal ("check that `git push` works from a
+  terminal in this graph") instead of a sign-in that can't help.
+- Public-repo confirmation: API-based, GitHub-only. Generic remotes skip it — wiring
+  your own remote is the opt-in. Documented loudly (notes marked `private: true` are
+  in the backup; host visibility is the user's responsibility).
+- `MAX_FILE_BYTES` (95 MB) guard stays for all remotes (every sensible host has a
+  limit; ours just mirrors GitHub's). Message drops the "for GitHub" phrasing.
+
+### 6. Restore on a new machine
+
+`git clone <url>` in a terminal, then open the folder as a graph. Adoption (§4) picks
+the remote up and the index rebuilds from files (Plan 04). This already nearly works;
+it becomes the documented generic-restore path. Restore-from-GitHub dialog stays
+GitHub-only.
+
+### 7. Free bonus: path remotes
+
+With credential resolution no longer token-or-fail, **file-path remotes work with no
+credentials at all**: `git init --bare /Volumes/NAS/notes.git && git remote add origin
+/Volumes/NAS/notes.git` gives local/NAS/USB backup for free — and bare-repo remotes
+become the medium for cheap full-loop integration tests (commit → push → clone →
+conflict → merge, zero network, zero mocks).
+
+## Phases
+
+**Phase 0 — Spike (timeboxed, settles the two real unknowns).**
+(a) `Cred::credential_helper` from inside the GUI app on macOS: helpers resolve via
+`git` on a GUI-app `PATH` (`/usr/bin` has Apple git, but CLT presence and helper
+discovery need proving — same class of gotcha as the CLI sidecar). (b) SSH: agent auth
+against a real host from the packaged app + confirm libgit2's default known_hosts
+enforcement in our vendored version. Outcome decides whether Phase 3 ships now or
+the plan goes HTTPS-first.
+
+**Phase 1 — Rust.** Credential chain + retry guard in `remote.rs`; error-taxonomy
+pass in `error.rs` (today anchors on `ErrorCode::Auth` + HTTP status substrings; add
+the SSH/certificate classes so helper-miss, rejected key, and host-key failures all
+land in `Auth`/`Network` correctly, with the negative tests that pinned the last
+round). Integration tests over local bare-repo remotes with `token: None`.
+
+**Phase 2 — Core TS + controller.** Remote classification, `getToken` routing
+(github → token, generic → null), adoption gating, status-message wording, the §5
+audit. Unit tests: classification, controller adopts a generic remote with no stored
+GitHub auth, github-auth never requested for generic remotes.
+
+**Phase 3 — SSH build.** Cargo feature change, CI (macOS sign/notarize with vendored
+libssh2, Windows/Linux builds), binary-size delta recorded in the PR.
+
+**Phase 4 — Docs + validation.** README/docs "Use any git host" section with the
+exact terminal recipe (init, remote add, one `git push -u` to seed the credential
+helper); Plan 12's Deferred line moves to a pointer here; manual matrix before ship:
+GitLab.com (HTTPS + helper), GitLab/Gitea over SSH, Gitea in Docker, bare path remote,
+GHES if reachable. Memory + libraries.md updates.
+
+## Failure cases
+
+| Case | Behavior |
+| --- | --- |
+| No credential anywhere (helper empty, no agent) | `Auth` error in status: "couldn't sign in to origin — run `git push` from a terminal in this graph once". Engine retries on focus; nothing wedges. |
+| Helper exists but prompts (GCM UI) | Helper runs outside our process; worst case it pops its own dialog or fails → `Auth` error as above. Spike confirms osxkeychain never prompts. |
+| Unknown SSH host key | Fail (no bypass): "connect once with `ssh <host>`…". |
+| Host rejects a push (protected branch, size limits, hooks) | Already data: `PushOutcome.rejection_message` surfaces verbatim, non-FF retries merge-then-push as today. |
+| Remote deleted / URL typo | Existing not-found/network mapping; status error, retry on focus. |
+| GitHub token near a generic remote | Never sent (§1). The reverse — helper credentials for github.com — also never happens; github remotes always use the managed token. |
+
+## Deferred
+
+- Per-host token entry UI / per-host keychain entries (the moment we want "no
+  terminal ever" for non-GitHub hosts).
+- Writing credentials back to helpers; SSH passphrase prompting.
+- GitLab/Gitea REST sugar (repo creation, visibility checks) behind the same
+  one-module-per-host pattern as `github.ts`.
+- `git://` and proxy edge cases beyond what libgit2 defaults handle.

--- a/docs/plans/16-generic-git-remotes.md
+++ b/docs/plans/16-generic-git-remotes.md
@@ -15,7 +15,11 @@ executing a helper program from a GUI app is the riskiest unknown in the whole p
 and deserves its own wave (and spike) rather than holding V1 hostage.
 
 **Depends on:** Plan 12 (the whole sync loop; this plan only widens its credential
-story). **Status:** proposed.
+story). **Status:** V1 implemented (SSH agent + path remotes; see
+[docs/generic-git-remotes.md](../generic-git-remotes.md) for the user contract).
+Outstanding V1 validation, manual by nature: agent auth from the *packaged* app
+against a real host (the Phase 0 spike items). V2 (HTTPS credential helpers) not
+started.
 
 **Explicitly not in scope:** host pickers, a "custom remote" wizard, per-host settings
 UI, or per-host REST sugar (repo creation, visibility checks, install links — those

--- a/docs/plans/16-generic-git-remotes.md
+++ b/docs/plans/16-generic-git-remotes.md
@@ -7,6 +7,13 @@ The contract: a user runs `git init` (or Reflect already did) and
 adopts it — debounced commit → push, pull/merge on launch/focus, conflicts-as-data.
 Everything else just works.
 
+**Delivery is two waves.** **V1 is SSH-only** (agent auth), which also gets path
+remotes for free: the credential code is a few deterministic lines, `git@…` is the
+URL form muscle memory pastes, and the user contract is one sentence — *if
+`ssh -T git@host` works, sync works*. **V2 adds HTTPS** via git credential helpers;
+executing a helper program from a GUI app is the riskiest unknown in the whole plan
+and deserves its own wave (and spike) rather than holding V1 hostage.
+
 **Depends on:** Plan 12 (the whole sync loop; this plan only widens its credential
 story). **Status:** proposed.
 
@@ -18,8 +25,9 @@ by design; this plan is about other *git hosts*, not other *sync mechanisms*.
 ## Where we stand (why it doesn't work today)
 
 The Plan 12 architecture already did most of the work: the Rust layer speaks
-`remote URL + credential callback` and the engine/controller/conflict policy are
-host-agnostic. Four things block a hand-wired remote:
+`remote URL + credential callback`, token plumbing is nullable end-to-end
+(`gitFetch(token: string | null)` → `Option<String>`), and the engine, controller,
+and conflict policy are host-agnostic. Four things block a hand-wired remote:
 
 1. **Adoption gating.** `backup-controller.start()` refuses to adopt unless a
    **GitHub** credential is stored (`loadGithubAuth() !== null`), even though the
@@ -36,14 +44,9 @@ host-agnostic. Four things block a hand-wired remote:
 4. **Credential callback is token-or-fail.** `callbacks_with_credentials(None)`
    errors with "no token is connected" instead of trying anything local.
 
-Already in place and reused as-is: nullable token plumbing end-to-end
-(`gitFetch(token: string | null)` → `Option<String>`), `PushOutcome` rejections-as-data,
-conflict markers + protected notes, `parseGithubRemote` returning `null` for foreign
-URLs (the controller already carries `repo: null` without falling over).
-
 ## Design
 
-### 1. Remote-aware credential routing (core TS)
+### 1. Remote-aware credential routing (core TS) — V1, shared by every wave
 
 Classify the remote once at adoption: `parseGithubRemote(remoteUrl)` non-null →
 **github**, else **generic**.
@@ -52,38 +55,45 @@ Classify the remote once at adoption: `parseGithubRemote(remoteUrl)` non-null �
   refresh and all).
 - **generic** → `getToken: () => null`, always. The Rust side resolves credentials
   locally (below). The stored GitHub credential is **never** offered to a non-GitHub
-  host — closing wart (2).
+  host — closing wart (2) regardless of which transports ship when.
 
 GitHub Enterprise falls out naturally: `ghe.corp.com` doesn't parse as github.com, so
-it takes the generic path and authenticates with whatever the user's git credential
-helper holds — which is exactly the GHES story we wanted anyway.
+it takes the generic path — SSH in V1, credential helpers in V2.
 
 ### 2. Local credential resolution (Rust, `remote.rs`)
 
 When the per-call token is `None`, the credential callback becomes a chain driven by
-libgit2's `allowed` types instead of an error:
+libgit2's `allowed` types instead of an error. When the token is `Some(…)` (GitHub
+path), behavior is byte-for-byte today's.
 
-- `USER_PASS_PLAINTEXT` (HTTPS) → `Cred::credential_helper(&repo.config()?, url,
+**V1:**
+
+- `SSH_KEY` → `Cred::ssh_key_from_agent(username_from_url.unwrap_or("git"))`.
+  **Agent-only** — no key-file scanning, no passphrase prompting; the agent *is* the
+  contract (macOS runs one by default; passphrase keys work because the agent holds
+  them unlocked). **Retry guard:** libgit2 re-invokes the callback after a rejected
+  credential, which loops forever if we keep producing the same answer — second ask
+  fails with an `Auth` error naming the fix ("the SSH agent had no accepted key for
+  this host — `ssh-add` your key, or check `ssh -T git@<host>` works").
+- `USER_PASS_PLAINTEXT` (generic HTTPS remote) → **fail fast and honest**: "HTTPS
+  authentication for non-GitHub hosts isn't supported yet — use an SSH remote URL
+  (`git@host:owner/repo.git`)". No half-trying.
+- Path remotes never invoke the callback at all — **bare repos on a NAS/USB/second
+  disk work in V1 with no credentials**, and become the medium for cheap full-loop
+  integration tests (commit → push → clone → conflict → merge; zero network, zero
+  mocks).
+
+**V2:**
+
+- `USER_PASS_PLAINTEXT` → `Cred::credential_helper(&repo.config()?, url,
   username_from_url)`. git2-rs implements helper execution itself: it reads
   `credential.helper` from git config and runs the helper (`osxkeychain` on macOS,
-  `manager` on Windows, `libsecret`/`store` on Linux). **This is the whole trick** —
-  the user's one-time `git push` from a terminal stores a login in the same place
-  we read from. We *read* helpers, never write them.
-- `SSH_KEY` (ssh remotes) → `Cred::ssh_key_from_agent(username_from_url
-  .unwrap_or("git"))`, falling back to the default key files
-  (`~/.ssh/id_ed25519`, `~/.ssh/id_rsa`, unencrypted only — passphrase prompting is
-  UI and stays out; passphrase keys work via the agent).
+  `manager` on Windows, `libsecret`/`store` on Linux). The user's one-time
+  `git push` from a terminal stores a login in the same place we read from. We
+  *read* helpers, never write them.
 - `DEFAULT` → `Cred::default()` (NTLM/Negotiate proxies; cheap to include).
 
-**Retry guard:** libgit2 re-invokes the callback after a rejected credential, which
-loops forever if the chain keeps producing the same answer. Track attempted types in
-the existing `RefCell` pattern and return a clear `Auth` error once the chain is
-exhausted — message names what was tried ("credential helper had no login for
-gitlab.com; run `git push` from a terminal once so it stores one").
-
-When the token is `Some(…)` (GitHub path) behavior is byte-for-byte today's.
-
-### 3. SSH transport
+### 3. SSH transport (V1)
 
 `git2 = { features = ["https", "ssh", "vendored-libgit2"] }` — adds vendored
 `libssh2`. Host-key verification: libgit2 ≥ 1.5 enforces known_hosts checking by
@@ -91,12 +101,7 @@ default (post-CVE-2023-22742); we keep the default and **do not** install a
 permissive `certificate_check`. An unknown host fails with a hint:
 "connect once with `ssh <host>` so it's added to known_hosts".
 
-Recommendation: **SSH ships in this wave.** `git@…` is the URL form muscle memory
-produces; without it, "add a remote and it just works" fails for most of the target
-persona. It's isolated in Phase 3 so it can be cut to HTTPS-only if the spike turns
-up build pain (signing/notarization of vendored libssh2, binary size, Windows).
-
-### 4. Adoption gating (backup controller)
+### 4. Adoption gating (backup controller) — V1
 
 `start()` adopts when `status.initialized && remoteUrl !== null` — and then:
 
@@ -106,7 +111,7 @@ up build pain (signing/notarization of vendored libssh2, binary size, Windows).
   the first cycle surfaces the auth error in the existing status UI and the engine
   keeps retrying on focus — same shape as any other sync error, no new states.
 
-### 5. Existing-surface degradation audit (not new UI)
+### 5. Existing-surface degradation audit (not new UI) — V1
 
 The generic path bypasses the wizard entirely, but a few connected-state surfaces
 assume GitHub when `repo === null`:
@@ -114,75 +119,82 @@ assume GitHub when `repo === null`:
 - Settings/status panel: show the bare remote URL (already carried in state); hide
   "View on GitHub"-style affordances and the app-install link.
 - `auth`-state recovery action: for github remotes it reopens the wizard; for generic
-  remotes the message points at the terminal ("check that `git push` works from a
-  terminal in this graph") instead of a sign-in that can't help.
+  remotes the message points at the terminal instead of a sign-in that can't help.
 - Public-repo confirmation: API-based, GitHub-only. Generic remotes skip it — wiring
   your own remote is the opt-in. Documented loudly (notes marked `private: true` are
   in the backup; host visibility is the user's responsibility).
 - `MAX_FILE_BYTES` (95 MB) guard stays for all remotes (every sensible host has a
   limit; ours just mirrors GitHub's). Message drops the "for GitHub" phrasing.
 
-### 6. Restore on a new machine
+### 6. Restore on a new machine — V1 (docs only)
 
 `git clone <url>` in a terminal, then open the folder as a graph. Adoption (§4) picks
 the remote up and the index rebuilds from files (Plan 04). This already nearly works;
 it becomes the documented generic-restore path. Restore-from-GitHub dialog stays
 GitHub-only.
 
-### 7. Free bonus: path remotes
+## V1 phases (SSH + path remotes)
 
-With credential resolution no longer token-or-fail, **file-path remotes work with no
-credentials at all**: `git init --bare /Volumes/NAS/notes.git && git remote add origin
-/Volumes/NAS/notes.git` gives local/NAS/USB backup for free — and bare-repo remotes
-become the medium for cheap full-loop integration tests (commit → push → clone →
-conflict → merge, zero network, zero mocks).
+**Phase 0 — Spike (small).** (a) Agent auth from the *packaged* app: a
+launchd-launched GUI app must see `SSH_AUTH_SOCK` (macOS's default agent uses a
+launchd socket, so it should; third-party agents like 1Password need one manual
+check). (b) Vendored libssh2 through the macOS sign/notarize pipeline and the
+Windows/Linux builds; record the binary-size delta.
 
-## Phases
-
-**Phase 0 — Spike (timeboxed, settles the two real unknowns).**
-(a) `Cred::credential_helper` from inside the GUI app on macOS: helpers resolve via
-`git` on a GUI-app `PATH` (`/usr/bin` has Apple git, but CLT presence and helper
-discovery need proving — same class of gotcha as the CLI sidecar). (b) SSH: agent auth
-against a real host from the packaged app + confirm libgit2's default known_hosts
-enforcement in our vendored version. Outcome decides whether Phase 3 ships now or
-the plan goes HTTPS-first.
-
-**Phase 1 — Rust.** Credential chain + retry guard in `remote.rs`; error-taxonomy
-pass in `error.rs` (today anchors on `ErrorCode::Auth` + HTTP status substrings; add
-the SSH/certificate classes so helper-miss, rejected key, and host-key failures all
-land in `Auth`/`Network` correctly, with the negative tests that pinned the last
-round). Integration tests over local bare-repo remotes with `token: None`.
+**Phase 1 — Rust.** `ssh` feature; credential callback chain (agent + retry guard +
+HTTPS fail-fast); error-taxonomy pass in `error.rs` (today anchors on
+`ErrorCode::Auth` + HTTP status substrings; add the SSH/certificate classes so
+agent-miss, rejected key, and host-key failures land in `Auth`/`Network` correctly,
+with negative tests). Full-loop integration tests over local bare-path remotes with
+`token: None`.
 
 **Phase 2 — Core TS + controller.** Remote classification, `getToken` routing
 (github → token, generic → null), adoption gating, status-message wording, the §5
 audit. Unit tests: classification, controller adopts a generic remote with no stored
 GitHub auth, github-auth never requested for generic remotes.
 
-**Phase 3 — SSH build.** Cargo feature change, CI (macOS sign/notarize with vendored
-libssh2, Windows/Linux builds), binary-size delta recorded in the PR.
+**Phase 3 — Docs + validation.** README/docs "Use any git host (SSH)" section with
+the terminal recipe (init, `git remote add origin git@…`, confirm `ssh -T`); Plan
+12's Deferred line moves to a pointer here; libraries.md gains libssh2. Manual
+matrix: GitLab.com over SSH, Gitea in Docker over SSH, bare path remote on an
+external volume, GHES over SSH if reachable.
 
-**Phase 4 — Docs + validation.** README/docs "Use any git host" section with the
-exact terminal recipe (init, remote add, one `git push -u` to seed the credential
-helper); Plan 12's Deferred line moves to a pointer here; manual matrix before ship:
-GitLab.com (HTTPS + helper), GitLab/Gitea over SSH, Gitea in Docker, bare path remote,
-GHES if reachable. Memory + libraries.md updates.
+## V2 phases (HTTPS via credential helpers)
+
+**Phase 0 — Spike.** `Cred::credential_helper` from inside the GUI app on macOS:
+helpers resolve via `git` on a GUI-app `PATH` (`/usr/bin` has Apple git, but CLT
+presence and helper discovery need proving — same class of gotcha as the CLI
+sidecar). Git Credential Manager prompting behavior on Windows (helpers may pop
+their own UI).
+
+**Phase 1 — Rust.** Helper + `Cred::default()` join the chain; the V1 HTTPS
+fail-fast message is replaced by real resolution; helper-miss keeps a terminal-hint
+error ("run `git push` from a terminal in this graph once so the credential helper
+stores a login").
+
+**Phase 2 — Docs + validation.** HTTPS recipe (the one-time `git push -u` to seed
+the helper). Matrix: GitLab.com over HTTPS + osxkeychain, GHES over HTTPS, Windows
+GCM.
 
 ## Failure cases
 
 | Case | Behavior |
 | --- | --- |
-| No credential anywhere (helper empty, no agent) | `Auth` error in status: "couldn't sign in to origin — run `git push` from a terminal in this graph once". Engine retries on focus; nothing wedges. |
-| Helper exists but prompts (GCM UI) | Helper runs outside our process; worst case it pops its own dialog or fails → `Auth` error as above. Spike confirms osxkeychain never prompts. |
+| No agent / key not added (V1) | `Auth` error in status: "`ssh-add` your key, or check `ssh -T git@<host>` works". Engine retries on focus; nothing wedges. |
+| Generic HTTPS remote (V1) | Immediate, clear status error suggesting an SSH remote URL — not a hang, not a half-try. |
 | Unknown SSH host key | Fail (no bypass): "connect once with `ssh <host>`…". |
+| Helper exists but prompts (GCM UI, V2) | Helper runs outside our process; worst case it pops its own dialog or fails → `Auth` error with the terminal hint. Spike confirms osxkeychain never prompts. |
 | Host rejects a push (protected branch, size limits, hooks) | Already data: `PushOutcome.rejection_message` surfaces verbatim, non-FF retries merge-then-push as today. |
 | Remote deleted / URL typo | Existing not-found/network mapping; status error, retry on focus. |
-| GitHub token near a generic remote | Never sent (§1). The reverse — helper credentials for github.com — also never happens; github remotes always use the managed token. |
+| GitHub token near a generic remote | Never sent (§1). The reverse — local credentials for github.com — also never happens; github remotes always use the managed token. |
 
-## Deferred
+## Deferred (beyond V2)
 
 - Per-host token entry UI / per-host keychain entries (the moment we want "no
   terminal ever" for non-GitHub hosts).
-- Writing credentials back to helpers; SSH passphrase prompting.
+- Default key-file fallback (`~/.ssh/id_ed25519`, `id_rsa`) if agent-only proves too
+  strict in practice; SSH passphrase prompting (agent covers passphrase keys).
+- Writing credentials back to helpers.
 - GitLab/Gitea REST sugar (repo creation, visibility checks) behind the same
   one-module-per-host pattern as `github.ts`.
 - `git://` and proxy edge cases beyond what libgit2 defaults handle.

--- a/docs/plans/libraries.md
+++ b/docs/plans/libraries.md
@@ -50,6 +50,7 @@ first-party (owned by the team) and MIT-licensed, so there is no copyleft constr
 | Note IDs (ULID) | `ulid` | 02 |
 | Keychain / secrets | `keyring` | 10 / 12 |
 | Git (commits, merge, conflicts) | `git2` (libgit2) | 12 |
+| SSH transport for generic remotes (agent auth) | `git2` `ssh` feature (vendored libssh2 + openssl) | 16 |
 | Local embeddings | `fastembed` | 09 |
 | Image processing (screenshot downscale) | `image` | 11 |
 | CLI framework (derive) | `clap` v4 | 14 |


### PR DESCRIPTION
## What

Plan doc **and the V1 implementation**: back up a graph to **any git host** — GitLab, Gitea, Codeberg, GitHub Enterprise, self-hosted, or a bare repo on a NAS — with **zero new UI**.

The contract: `git init` + `git remote add origin git@host:you/notes.git` in the graph, and the existing Plan 12 sync loop adopts it. **If `ssh -T git@host` works in a terminal, sync works.** User doc: [docs/generic-git-remotes.md](../blob/claude/plan-generic-git-remotes/docs/generic-git-remotes.md).

## V1 (this PR): SSH agent + path remotes

- **Rust** — `git2` gains the `ssh` feature (vendored libssh2 + openssl; nothing links homebrew dylibs). The credential callback becomes a chain: with a token it's byte-for-byte today's GitHub behavior — and the token is **never offered to any other transport**; without one, it answers the SSH username probe, offers the **ssh-agent exactly once** (libgit2 re-asks after a rejection — the second ask becomes the actionable `ssh-add` error instead of an infinite loop), and **fails generic HTTPS fast** with the SSH-URL suggestion. Host-key verification stays on libgit2's default known_hosts enforcement — no bypass.
- **Error taxonomy** — `Certificate` and `Ssh`-class failures classify as `Auth` (user-fixable, surfaced as needs-attention) with negative tests; `Net` stays retryable `Network`.
- **Controller** — generic remotes adopt without a stored GitHub credential; `getToken` routes `null` for them, so the managed GitHub token **never leaves github.com**. This also closes a pre-existing wart: a hand-wired foreign origin would previously have received the GitHub token as basic auth. GitHub remotes still require the managed sign-in.
- **Settings** — host-neutral section for generic remotes (bare remote URL, generic legend); auth errors show the engine's actionable message instead of "reconnect GitHub"; machine-level GitHub sign-out hidden where it can't help.
- **Free fallout** — bare path remotes (NAS/USB) sync with no credentials at all; GHES works via the generic path; GitHub-over-SSH works without the wizard.

## V2 (planned, not here): HTTPS via git credential helpers

Executing a helper from a GUI-app PATH is the plan's riskiest unknown — it spikes and ships separately. Until then generic HTTPS remotes get an honest error suggesting the SSH URL form.

## Verification

- 81 Rust tests (6 new credential-chain units, 1 new ssh-classification case; the full sync loop already runs against local bare path remotes with `token: None`), `cargo fmt` + clippy clean.
- 499 desktop tests across 72 files (new: generic remote adopts with no stored credential; GitHub token never rides to a generic remote), `pnpm check` clean.
- **Remaining manual validation** (Phase 0 spike, needs the packaged app): ssh-agent auth against a real host from the GUI app — launchd's default agent socket should be visible, 1Password-style agents need one check. Binary-size delta from vendored libssh2/openssl: read it off the next `pnpm release:macos` rather than a debug-build guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes backup credential routing and vendored SSH/TLS in the desktop binary; fixes a prior risk of sending the GitHub token to non-GitHub origins, but SSH agent and host-key behavior still need validation in packaged builds.
> 
> **Overview**
> **Plan 16 V1** lets graphs back up to **any git host** by hand-wiring `origin`—no new UI. The existing Plan 12 sync loop adopts SSH and path remotes when `ssh -T` (or a bare path) works.
> 
> **Rust / `git2`:** Enables **SSH** with **vendored libssh2 + OpenSSL** so shipped builds do not depend on system/Homebrew libs. Fetch/push credentials go through a **`resolve_credential` chain**: GitHub token → HTTPS `x-access-token` only (never offered to SSH); no token → SSH username probe, **ssh-agent once** (second callback → actionable `ssh-add` error); generic HTTPS → **fail fast** with SSH URL guidance. **SSH/Certificate** libgit2 errors map to **`Auth`** (user-fixable), not blind network retries.
> 
> **TypeScript:** **`backup-controller`** adopts when `origin` exists—GitHub still needs keychain sign-in; **generic remotes do not**. **`getToken` is always `null`** for non-`github.com` HTTPS remotes so the managed token **cannot leak** to other hosts. **Generic `https://` remotes** are rejected at adoption (before sync starts) with `git remote set-url` instructions.
> 
> **Settings:** Backup section is **host-neutral** for generic remotes (URL, engine error text); **“Reconnect GitHub”** and sign-out stay on the GitHub path only.
> 
> **Docs:** User guide (`generic-git-remotes.md`), Plan 16, README sync wording, roadmap/libraries updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0505fa31e352410b7236c1aa240d1a68634bdc13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Backup and sync now work with any Git host via SSH, not limited to GitHub
  * Support for user-controlled Git repositories with improved SSH authentication error messages
  * Private notes remain never sent externally

* **Documentation**
  * Added comprehensive guides for setting up and troubleshooting generic Git remotes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->