### PR TITLE
Device-flow UX: copy the code first, one access remedy per credential

### DIFF
--- a/apps/desktop/src/components/settings/connect-github-dialog.test.tsx
+++ b/apps/desktop/src/components/settings/connect-github-dialog.test.tsx
@@ -307,4 +307,43 @@ describe('ConnectGithubDialog', () => {
       'https://github.com/apps/reflect-github-app/installations/new',
     )
   })
+
+  it('promotes the grant remedy when a created repo still cannot be seen', async () => {
+    // App user, "selected repositories" install: they create the repo via
+    // the handoff, but the app was never granted access to it. After
+    // "I created it — connect" a 404 means visibility, not existence — the
+    // grant flow takes over instead of looping back into the create guide.
+    storeCredential(appCredential())
+    sync.connectExistingRepo.mockResolvedValueOnce('notFound').mockResolvedValueOnce('notFound')
+    sync.connectNewRepo.mockResolvedValueOnce('manualCreateNeeded')
+    const onClose = renderWizard()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'I created it — connect' }))
+
+    expect(await screen.findByText(/still can’t see the new repository/i)).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Create on GitHub…' })).toBeNull()
+    // The repo exists now — re-running the API create would just 422.
+    expect(sync.connectNewRepo).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Grant access on GitHub…' }))
+    expect(openedUrls).toHaveBeenCalledWith(
+      'https://github.com/apps/reflect-github-app/installations/new',
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'I granted it — try again' }))
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+  })
+
+  it('keeps the created-but-unseen remedy token-flavored for PAT users', async () => {
+    sync.connectExistingRepo.mockResolvedValueOnce('notFound').mockResolvedValueOnce('notFound')
+    sync.connectNewRepo.mockResolvedValueOnce('manualCreateNeeded')
+    renderWizard()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'I created it — connect' }))
+
+    expect(await screen.findByText(/included in your token’s repository access/i)).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /grant access/i })).toBeNull()
+  })
 })

--- a/apps/desktop/src/components/settings/connect-github-dialog.test.tsx
+++ b/apps/desktop/src/components/settings/connect-github-dialog.test.tsx
@@ -16,14 +16,29 @@ vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn() }))
 const httpFetch = vi.mocked(tauriFetch)
 const openedUrls = vi.mocked(openUrl)
 
-beforeEach(() => {
-  // A stored credential + GitHub accepting it ("alex") makes the auth step
-  // skip itself, so a Continue lands straight on the finish step.
+/** A keychain holding the given credential; GET /user accepting it makes the auth step skip itself. */
+function storeCredential(auth: Record<string, unknown>): void {
   setBridge({
-    invoke: async (command) =>
-      command === 'secret_get' ? JSON.stringify({ kind: 'pat', token: 'ghp_abc' }) : null,
+    invoke: async (command) => (command === 'secret_get' ? JSON.stringify(auth) : null),
     listen: async () => () => {},
   })
+}
+
+/** A device-flow (GitHub App) credential with a comfortably unexpired token. */
+function appCredential(): Record<string, unknown> {
+  return {
+    kind: 'app',
+    accessToken: 'ghu_live',
+    refreshToken: 'ghr_live',
+    expiresAt: Date.now() + 60 * 60 * 1000,
+  }
+}
+
+beforeEach(() => {
+  // A stored credential + GitHub accepting it ("alex") makes the auth step
+  // skip itself, so a Continue lands straight on the finish step. PAT by
+  // default; app-credential tests re-store before rendering.
+  storeCredential({ kind: 'pat', token: 'ghp_abc' })
   // A fresh Response per call — bodies are single-use, and a wizard run can
   // pass through the auth step more than once.
   httpFetch.mockImplementation(
@@ -195,6 +210,8 @@ describe('ConnectGithubDialog', () => {
     expect(await screen.findByText(/was not found/i)).toBeTruthy()
     expect(sync.connectNewRepo).not.toHaveBeenCalled()
     expect(onClose).not.toHaveBeenCalled()
+    // PAT remedy is token scope — the app-install flow is someone else's fix.
+    expect(screen.queryByRole('button', { name: /grant access/i })).toBeNull()
   })
 
   it('offers a way back to change the repository after a failed connect', async () => {
@@ -239,5 +256,55 @@ describe('ConnectGithubDialog', () => {
     // in a silently rejected promise.
     expect(await screen.findByText(/open the browser/i)).toBeTruthy()
     expect(screen.getByText(/github\.com\/new\?name=g-backup/)).toBeTruthy()
+  })
+
+  it('routes an app sign-in that cannot see the repo to the install flow', async () => {
+    // GitHub's 404 can't distinguish "doesn't exist" from "no access", and
+    // for app sign-ins it's almost always the latter — so granting access
+    // is the remedy, with no token language anywhere.
+    storeCredential(appCredential())
+    sync.connectExistingRepo.mockResolvedValueOnce('notFound')
+    const onClose = renderWizard()
+
+    fireEvent.click(screen.getByRole('radio', { name: /use an existing repository/i }))
+    fireEvent.change(screen.getByLabelText('Existing repository'), {
+      target: { value: 'alex/notes' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    expect(await screen.findByText(/grant it access on GitHub/i)).toBeTruthy()
+    expect(screen.queryByText(/token/i)).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Grant access on GitHub…' }))
+    expect(openedUrls).toHaveBeenCalledWith(
+      'https://github.com/apps/reflect-github-app/installations/new',
+    )
+
+    // Back from the browser with access granted: the retry connects.
+    fireEvent.click(screen.getByRole('button', { name: 'I granted it — try again' }))
+    await waitFor(() =>
+      expect(sync.connectExistingRepo).toHaveBeenLastCalledWith(
+        { owner: 'alex', name: 'notes' },
+        { allowPublic: false },
+      ),
+    )
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('points the app create guide at granting access, not token scope', async () => {
+    storeCredential(appCredential())
+    sync.connectExistingRepo.mockResolvedValueOnce('notFound')
+    sync.connectNewRepo.mockResolvedValueOnce('manualCreateNeeded')
+    renderWizard()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    expect(await screen.findByText(/Reflect can’t create the repository itself/i)).toBeTruthy()
+    expect(screen.queryByText(/token/i)).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /grant the Reflect app access/i }))
+    expect(openedUrls).toHaveBeenCalledWith(
+      'https://github.com/apps/reflect-github-app/installations/new',
+    )
   })
 })

--- a/apps/desktop/src/components/settings/connect-github-dialog.tsx
+++ b/apps/desktop/src/components/settings/connect-github-dialog.tsx
@@ -2,7 +2,7 @@ import { useState, type ReactElement } from 'react'
 import { openUrl } from '@tauri-apps/plugin-opener'
 import {
   githubAppInstallUrl,
-  isDeviceFlowConfigured,
+  loadGithubAuth,
   newRepoUrl,
   type GithubRepoRef,
   type GithubUser,
@@ -31,6 +31,9 @@ interface ConnectGithubDialogProps {
 
 type Step = 'repo' | 'auth' | 'finish'
 
+/** Which credential the sign-in stored — decides the can't-find-repo remedy. */
+type AuthKind = 'app' | 'pat' | null
+
 const STEP_DESCRIPTIONS: Record<Step, string> = {
   repo: 'Back up this graph to a private GitHub repository of your own.',
   auth: 'Sign in so Reflect can push your backups.',
@@ -50,6 +53,11 @@ const STEP_DESCRIPTIONS: Record<Step, string> = {
  * yet and the user never clicked "Create on GitHub". Connecting a public
  * repo demands explicit confirmation — every note in the graph, including
  * `private: true` ones, would be world-readable.
+ *
+ * "Can't find the repo" has one remedy per credential kind, never both at
+ * once: app sign-ins route to the GitHub App install page (authorization ≠
+ * installation — the token only reaches repositories the app is installed
+ * on), while PAT users get token-scope guidance.
  */
 export function ConnectGithubDialog({
   suggestedRepoName,
@@ -62,9 +70,12 @@ export function ConnectGithubDialog({
   const [repoName, setRepoName] = useState(suggestedRepoName)
   const [existingRepo, setExistingRepo] = useState('')
   const [user, setUser] = useState<GithubUser | null>(null)
+  const [authKind, setAuthKind] = useState<AuthKind>(null)
   const [publicConfirm, setPublicConfirm] = useState<GithubRepoRef | null>(null)
   /** The finish step's "repo not found yet" guidance (create-mode only). */
   const [showCreateGuide, setShowCreateGuide] = useState(false)
+  /** App sign-in couldn't see the repo → offer the install-access remedy. */
+  const [showGrantHint, setShowGrantHint] = useState(false)
 
   useRestoreFocus()
 
@@ -76,12 +87,19 @@ export function ConnectGithubDialog({
     return name.length === 0 ? null : { owner: forUser.login, name }
   }
 
-  async function finish(forUser: GithubUser, allowPublic = false): Promise<void> {
+  async function finish(
+    forUser: GithubUser,
+    options: { allowPublic?: boolean; kind?: AuthKind } = {},
+  ): Promise<void> {
+    // The first run is invoked from the same tick that learned the credential
+    // kind, before state has committed — so it arrives as a parameter.
+    const kind = options.kind ?? authKind
     await action.run(async () => {
-      // Each attempt re-derives the guide from its own outcome — a stale
-      // "can't create repositories" panel from an earlier path must not
-      // outlive the detour (e.g. consent screen → choose another repo).
+      // Each attempt re-derives the guidance from its own outcome — a stale
+      // "can't create repositories" or "grant access" panel from an earlier
+      // path must not outlive the detour (e.g. consent → choose another repo).
       setShowCreateGuide(false)
+      setShowGrantHint(false)
       const ref = publicConfirm ?? targetRef(forUser)
       if (ref === null) {
         action.setError(
@@ -92,7 +110,7 @@ export function ConnectGithubDialog({
         setStep('repo')
         return
       }
-      const result = await connectExistingRepo(ref, { allowPublic })
+      const result = await connectExistingRepo(ref, { allowPublic: options.allowPublic ?? false })
       if (result === 'connected') {
         onClose()
         return
@@ -104,9 +122,19 @@ export function ConnectGithubDialog({
       // Not found. For an existing repo that's the answer; for a new one,
       // create it — by API when the token can, by guided handoff otherwise.
       if (mode === 'existing') {
-        action.setError(
-          'That repository was not found (check the name and the token’s repo access).',
-        )
+        // GitHub's 404 can't distinguish "doesn't exist" from "no access".
+        // App sign-ins almost always mean the latter (the app isn't
+        // installed on the repo), so that's the remedy they get.
+        if (kind === 'app') {
+          setShowGrantHint(true)
+          action.setError(
+            'Reflect can’t see that repository — grant it access on GitHub, or check the name.',
+          )
+        } else {
+          action.setError(
+            'That repository was not found (check the name and the token’s repo access).',
+          )
+        }
         return
       }
       const created = await connectNewRepo(ref.name)
@@ -134,7 +162,11 @@ export function ConnectGithubDialog({
   function onAuthed(authedUser: GithubUser): void {
     setUser(authedUser)
     setStep('finish')
-    void finish(authedUser)
+    void loadGithubAuth().then((auth) => {
+      const kind = auth?.kind ?? null
+      setAuthKind(kind)
+      return finish(authedUser, { kind })
+    })
   }
 
   /** Back to the repo step — every finish-step dead end must offer this. */
@@ -142,6 +174,7 @@ export function ConnectGithubDialog({
     action.setError(null)
     setPublicConfirm(null)
     setShowCreateGuide(false)
+    setShowGrantHint(false)
     setStep('repo')
   }
 
@@ -253,7 +286,7 @@ export function ConnectGithubDialog({
                     disabled={action.pending || user === null}
                     onClick={() => {
                       if (user !== null) {
-                        void finish(user, true)
+                        void finish(user, { allowPublic: true })
                       }
                     }}
                   >
@@ -264,7 +297,9 @@ export function ConnectGithubDialog({
             ) : showCreateGuide && user !== null ? (
               <>
                 <p className="text-sm text-text">
-                  Your token can’t create repositories, but GitHub can — everything is
+                  {authKind === 'app'
+                    ? 'Reflect can’t create the repository itself, but GitHub can — everything is'
+                    : 'Your token can’t create repositories, but GitHub can — everything is'}{' '}
                   pre-filled, so it’s one click. Create{' '}
                   <strong>
                     {user.login}/{repoName.trim()}
@@ -284,10 +319,24 @@ export function ConnectGithubDialog({
                     I created it — connect
                   </Button>
                 </div>
-                <p className="text-xs text-text-muted">
-                  If connecting still can’t find it, make sure the new repository is included in
-                  your token’s repository access.
-                </p>
+                {authKind === 'app' ? (
+                  <p className="text-xs text-text-muted">
+                    If connecting still can’t find it,{' '}
+                    <button
+                      type="button"
+                      className="underline"
+                      onClick={() => openExternal(githubAppInstallUrl())}
+                    >
+                      grant the Reflect app access
+                    </button>{' '}
+                    to the new repository.
+                  </p>
+                ) : (
+                  <p className="text-xs text-text-muted">
+                    If connecting still can’t find it, make sure the new repository is included in
+                    your token’s repository access.
+                  </p>
+                )}
               </>
             ) : (
               <p className="text-sm text-text-muted">
@@ -299,28 +348,28 @@ export function ConnectGithubDialog({
               <>
                 <InlineAlert tone="error">{action.error}</InlineAlert>
                 {publicConfirm === null ? (
-                  // A failed connect must never strand the user here: this is
-                  // the way back to change the repository (the consent screen
-                  // above has its own "Choose another repo").
-                  <Button variant="outline" size="sm" onClick={backToRepo}>
-                    Change repository
-                  </Button>
+                  // A failed connect must never strand the user here: change
+                  // the repository, or — for app sign-ins that can't see the
+                  // repo — grant the app access (authorization and
+                  // installation are separate GitHub App concepts; the token
+                  // only reaches repositories the app is installed on).
+                  <div className="flex flex-wrap gap-2">
+                    {showGrantHint && user !== null ? (
+                      <>
+                        <Button size="sm" onClick={() => openExternal(githubAppInstallUrl())}>
+                          Grant access on GitHub…
+                        </Button>
+                        <Button variant="outline" size="sm" onClick={() => void finish(user)}>
+                          I granted it — try again
+                        </Button>
+                      </>
+                    ) : null}
+                    <Button variant="outline" size="sm" onClick={backToRepo}>
+                      Change repository
+                    </Button>
+                  </div>
                 ) : null}
               </>
-            ) : null}
-
-            {isDeviceFlowConfigured() && publicConfirm === null ? (
-              // Authorization and installation are separate GitHub App
-              // concepts: a signed-in token only reaches repositories the
-              // app is installed on. When the repo can't be seen, this is
-              // usually why.
-              <button
-                type="button"
-                className="text-left text-xs text-text-muted underline"
-                onClick={() => openExternal(githubAppInstallUrl())}
-              >
-                Can’t see your repository? Grant the Reflect app access on GitHub…
-              </button>
             ) : null}
           </div>
         ) : null}

--- a/apps/desktop/src/components/settings/connect-github-dialog.tsx
+++ b/apps/desktop/src/components/settings/connect-github-dialog.tsx
@@ -76,6 +76,12 @@ export function ConnectGithubDialog({
   const [showCreateGuide, setShowCreateGuide] = useState(false)
   /** App sign-in couldn't see the repo → offer the install-access remedy. */
   const [showGrantHint, setShowGrantHint] = useState(false)
+  /**
+   * The user clicked "I created it — connect". From here on a 404 means
+   * "can't see it", not "doesn't exist": the remedy is access (install the
+   * app / widen the token), never the create guide again.
+   */
+  const [claimedCreated, setClaimedCreated] = useState(false)
 
   useRestoreFocus()
 
@@ -89,11 +95,13 @@ export function ConnectGithubDialog({
 
   async function finish(
     forUser: GithubUser,
-    options: { allowPublic?: boolean; kind?: AuthKind } = {},
+    options: { allowPublic?: boolean; kind?: AuthKind; claimedCreated?: boolean } = {},
   ): Promise<void> {
-    // The first run is invoked from the same tick that learned the credential
-    // kind, before state has committed — so it arrives as a parameter.
+    // Two values are read at call time because their setters fire in the
+    // same tick as the call (state hasn't committed): the credential kind on
+    // the first run, and the created-it claim on its button's click.
     const kind = options.kind ?? authKind
+    const claimed = options.claimedCreated ?? claimedCreated
     await action.run(async () => {
       // Each attempt re-derives the guidance from its own outcome — a stale
       // "can't create repositories" or "grant access" panel from an earlier
@@ -119,20 +127,25 @@ export function ConnectGithubDialog({
         setPublicConfirm(ref)
         return
       }
-      // Not found. For an existing repo that's the answer; for a new one,
-      // create it — by API when the token can, by guided handoff otherwise.
-      if (mode === 'existing') {
+      // Not found. For an existing repo — or one the user says they already
+      // created — that means "can't see it"; for a new one, create it, by
+      // API when the token can and by guided handoff otherwise.
+      if (mode === 'existing' || claimed) {
         // GitHub's 404 can't distinguish "doesn't exist" from "no access".
         // App sign-ins almost always mean the latter (the app isn't
         // installed on the repo), so that's the remedy they get.
         if (kind === 'app') {
           setShowGrantHint(true)
           action.setError(
-            'Reflect can’t see that repository — grant it access on GitHub, or check the name.',
+            claimed
+              ? 'Reflect still can’t see the new repository — grant it access on GitHub.'
+              : 'Reflect can’t see that repository — grant it access on GitHub, or check the name.',
           )
         } else {
           action.setError(
-            'That repository was not found (check the name and the token’s repo access).',
+            claimed
+              ? 'Still not found — make sure the new repository is included in your token’s repository access.'
+              : 'That repository was not found (check the name and the token’s repo access).',
           )
         }
         return
@@ -175,6 +188,7 @@ export function ConnectGithubDialog({
     setPublicConfirm(null)
     setShowCreateGuide(false)
     setShowGrantHint(false)
+    setClaimedCreated(false)
     setStep('repo')
   }
 
@@ -314,7 +328,10 @@ export function ConnectGithubDialog({
                     variant="outline"
                     size="sm"
                     disabled={action.pending}
-                    onClick={() => void finish(user)}
+                    onClick={() => {
+                      setClaimedCreated(true)
+                      void finish(user, { claimedCreated: true })
+                    }}
                   >
                     I created it — connect
                   </Button>

--- a/apps/desktop/src/components/settings/github-auth-step.test.tsx
+++ b/apps/desktop/src/components/settings/github-auth-step.test.tsx
@@ -1,17 +1,26 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { setBridge } from '@reflect/core'
+import { runDeviceFlow, setBridge } from '@reflect/core'
 import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
+import { openUrl } from '@tauri-apps/plugin-opener'
 import { GithubAuthStep } from './github-auth-step'
 
 // The Reflect GitHub App is registered, so the device flow leads and the PAT
-// path sits behind a "use a personal access token instead" toggle — these
-// tests exercise the PAT path through that toggle. The keychain is the
-// bridge fake; GET /user (instant token validation) goes through the mocked
-// Tauri HTTP plugin.
+// path sits behind a "use a personal access token instead" toggle. The
+// keychain is the bridge fake; GET /user (instant token validation) goes
+// through the mocked Tauri HTTP plugin. The device-flow tests stub core's
+// runDeviceFlow (polling policy is unit-tested in core) to drive the
+// code-handoff view.
 
 vi.mock('@tauri-apps/plugin-http', () => ({ fetch: vi.fn() }))
+vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn(async () => {}) }))
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  runDeviceFlow: vi.fn(),
+}))
 const httpFetch = vi.mocked(tauriFetch)
+const openedUrls = vi.mocked(openUrl)
+const mockFlow = vi.mocked(runDeviceFlow)
 
 /** Switch the step from the device-flow lead to PAT entry. */
 async function switchToPat(): Promise<void> {
@@ -21,10 +30,29 @@ async function switchToPat(): Promise<void> {
   await screen.findByLabelText('Personal access token')
 }
 
+/** Render with no stored credential and a flow that stays at the code view. */
+async function renderCodeView(): Promise<void> {
+  fakeKeychain()
+  mockFlow.mockImplementation(async (options) => {
+    options.onCode({ userCode: 'ABCD-1234', verificationUri: 'https://github.com/login/device' })
+    return new Promise(() => {}) // polling stays in flight
+  })
+  render(<GithubAuthStep onAuthed={vi.fn()} />)
+  fireEvent.click(await screen.findByRole('button', { name: 'Sign in with GitHub' }))
+  await screen.findByText('ABCD-1234')
+}
+
+function stubClipboard(writeText: (text: string) => Promise<void>): void {
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+}
+
 afterEach(() => {
   cleanup()
   setBridge(null)
   httpFetch.mockReset()
+  openedUrls.mockClear() // clear calls, keep the resolving implementation
+  mockFlow.mockReset()
+  Reflect.deleteProperty(navigator, 'clipboard')
 })
 
 function fakeKeychain(initial: Record<string, string> = {}) {
@@ -177,5 +205,44 @@ describe('GithubAuthStep', () => {
     )
     await new Promise((resolve) => setTimeout(resolve, 0)) // flush the probe's chain
     expect(onAuthed).toHaveBeenCalledTimes(1)
+  })
+
+  it('copies the code to the clipboard before opening GitHub', async () => {
+    const writeText = vi.fn(async () => {})
+    stubClipboard(writeText)
+    await renderCodeView()
+
+    // GitHub's page asks for the code immediately, so the browser must not
+    // open (and steal focus from the visible code) until it's in hand.
+    expect(openedUrls).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy code and open GitHub' }))
+
+    await waitFor(() =>
+      expect(openedUrls).toHaveBeenCalledWith('https://github.com/login/device'),
+    )
+    expect(writeText).toHaveBeenCalledWith('ABCD-1234')
+    expect(writeText.mock.invocationCallOrder[0]).toBeLessThan(
+      openedUrls.mock.invocationCallOrder[0],
+    )
+    expect(await screen.findByText(/code copied/i)).toBeTruthy()
+  })
+
+  it('holds the GitHub handoff when the clipboard is unavailable', async () => {
+    stubClipboard(async () => {
+      throw new Error('denied')
+    })
+    await renderCodeView()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy code and open GitHub' }))
+
+    // The user is told to copy by hand first; only then does GitHub open.
+    expect(await screen.findByText(/select the code above/i)).toBeTruthy()
+    expect(openedUrls).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open GitHub' }))
+    await waitFor(() =>
+      expect(openedUrls).toHaveBeenCalledWith('https://github.com/login/device'),
+    )
   })
 })

--- a/apps/desktop/src/components/settings/github-auth-step.tsx
+++ b/apps/desktop/src/components/settings/github-auth-step.tsx
@@ -40,6 +40,7 @@ export function GithubAuthStep({ onAuthed, repoName }: GithubAuthStepProps): Rea
   // The device flow leads when the app is registered; the PAT path stays one
   // click away (some users prefer a scoped token; GHES needs it).
   const [usePat, setUsePat] = useState(!isDeviceFlowConfigured())
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle')
   const authedRef = useRef(false)
 
   // Auth can complete twice — the mount-time probe of a stored credential
@@ -83,9 +84,31 @@ export function GithubAuthStep({ onAuthed, repoName }: GithubAuthStepProps): Rea
   }
 
   async function signIn(): Promise<void> {
+    setCopyState('idle') // each attempt mints a fresh code
     if (await deviceFlow.signIn()) {
       await pat.run(verifyAndFinish)
     }
+  }
+
+  /**
+   * The code goes to the clipboard *before* the browser opens — GitHub's
+   * device page asks for it immediately, and once the browser has focus the
+   * code in this dialog is out of sight. If copying isn't possible, hold the
+   * handoff and have the user copy by hand first.
+   */
+  async function copyCodeAndOpen(flow: { userCode: string; verificationUri: string }): Promise<void> {
+    if (copyState !== 'failed') {
+      try {
+        await navigator.clipboard.writeText(flow.userCode)
+        setCopyState('copied')
+      } catch {
+        setCopyState('failed')
+        return
+      }
+    }
+    void openUrl(flow.verificationUri).catch(() => {
+      // The URI is shown in the dialog; the user can browse there directly.
+    })
   }
 
   async function savePat(): Promise<void> {
@@ -167,20 +190,32 @@ export function GithubAuthStep({ onAuthed, repoName }: GithubAuthStepProps): Rea
       ) : (
         <div className="flex flex-col gap-2">
           <p className="text-xs text-text-muted">
-            Enter this code at{' '}
-            <button
-              type="button"
-              className="underline"
-              onClick={() => void openUrl(flowView.verificationUri)}
-            >
-              {flowView.verificationUri}
-            </button>
-            :
+            {copyState === 'copied'
+              ? 'Code copied — paste it on the GitHub page:'
+              : 'GitHub will ask for this one-time code:'}
           </p>
           <p className="select-text text-center font-mono text-xl tracking-[0.3em] text-text">
             {flowView.userCode}
           </p>
-          <p className="text-center text-xs text-text-muted">Waiting for GitHub…</p>
+          <Button size="sm" onClick={() => void copyCodeAndOpen(flowView)}>
+            {copyState === 'failed' ? 'Open GitHub' : 'Copy code and open GitHub'}
+          </Button>
+          {copyState === 'failed' ? (
+            <p className="text-xs text-text-muted">
+              Couldn’t copy automatically — select the code above and copy it first.
+            </p>
+          ) : null}
+          <p className="text-center text-xs text-text-muted">
+            Waiting for you to enter it at{' '}
+            <button
+              type="button"
+              className="underline"
+              onClick={() => void openUrl(flowView.verificationUri).catch(() => {})}
+            >
+              {flowView.verificationUri}
+            </button>
+            …
+          </p>
         </div>
       )}
       {error !== null ? <InlineAlert tone="error">{error}</InlineAlert> : null}

--- a/apps/desktop/src/hooks/use-device-flow-auth.test.tsx
+++ b/apps/desktop/src/hooks/use-device-flow-auth.test.tsx
@@ -1,10 +1,8 @@
 import { act, cleanup, renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { openUrl } from '@tauri-apps/plugin-opener'
 import { runDeviceFlow, ReflectError, type GithubAuth } from '@reflect/core'
 import { useDeviceFlowAuth } from './use-device-flow-auth'
 
-vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn(async () => {}) }))
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   runDeviceFlow: vi.fn(),
@@ -19,7 +17,9 @@ afterEach(() => {
 })
 
 describe('useDeviceFlowAuth', () => {
-  it('surfaces the user code, opens the browser, and resolves true on success', async () => {
+  it('surfaces the user code and resolves true on success', async () => {
+    // No browser side effects here: the surface opens GitHub only after the
+    // user has the code (copy first, then hand off).
     mockFlow.mockImplementation(async (options) => {
       options.onCode({ userCode: 'ABCD-1234', verificationUri: 'https://github.com/login/device' })
       return AUTH
@@ -37,7 +37,6 @@ describe('useDeviceFlowAuth', () => {
       userCode: 'ABCD-1234',
       verificationUri: 'https://github.com/login/device',
     })
-    expect(vi.mocked(openUrl)).toHaveBeenCalledWith('https://github.com/login/device')
     expect(result.current.busy).toBe(false)
     expect(result.current.error).toBeNull()
   })

--- a/apps/desktop/src/hooks/use-device-flow-auth.ts
+++ b/apps/desktop/src/hooks/use-device-flow-auth.ts
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from 'react'
-import { openUrl } from '@tauri-apps/plugin-opener'
 import { errorMessage, runDeviceFlow } from '@reflect/core'
 import { providerFetch } from '@/lib/provider-fetch'
 
@@ -13,10 +12,12 @@ export interface DeviceFlowAuth {
   busy: boolean
   error: string | null
   /**
-   * Run the device flow: GitHub issues a code (surfaced via `view` and
-   * auto-opened in the browser), then polling waits for the user to enter
-   * it. Resolves `true` once the credential is stored in the keychain,
-   * `false` on failure (the error is in `error`) or unmount.
+   * Run the device flow: GitHub issues a code (surfaced via `view`), then
+   * polling waits for the user to enter it. The browser is *not* opened
+   * here — the surface does that after the user has the code in hand, so
+   * the page asking for the code never steals focus from the code itself.
+   * Resolves `true` once the credential is stored in the keychain, `false`
+   * on failure (the error is in `error`) or unmount.
    */
   signIn: () => Promise<boolean>
 }
@@ -55,9 +56,6 @@ export function useDeviceFlowAuth(): DeviceFlowAuth {
         signal: abortRef.current?.signal,
         onCode: (code) => {
           setView({ view: 'code', userCode: code.userCode, verificationUri: code.verificationUri })
-          void openUrl(code.verificationUri).catch(() => {
-            // The URI is shown in the dialog; failing to auto-open is cosmetic.
-          })
         },
       })
       return auth !== null


### PR DESCRIPTION
## What

Three UX fixes for the GitHub device-flow sign-in and the connect wizard's "can't find the repo" handling, following the first live look at the flow.

### 1. Copy the code before GitHub opens (db972a1 → rebased)

The hook auto-opened `github.com/login/device` the instant GitHub issued the code — the browser stole focus while the code sat uncopied in the dialog. Now the code view leads with the code and a single **"Copy code and open GitHub"** action: clipboard write first, browser second (ordering pinned by test). If the clipboard is unavailable, the handoff *waits* — the user is told to copy by hand and the button becomes a plain "Open GitHub". The auto-open is gone from `useDeviceFlowAuth`; the surface owns handoff timing.

### 2. One "can't find the repo" remedy per credential kind

GitHub's 404 can't distinguish "doesn't exist" from "no access", and the remedy differs by credential — so the wizard used to hedge across all of them at once (token-scope error + PAT-flavored create guide + a permanent muted footer link to the install page). The dialog now learns the stored credential kind at sign-in and shows exactly one remedy:

- **App sign-ins** → the install flow (authorization ≠ installation): *"Reflect can't see that repository — grant it access on GitHub"*, with **Grant access on GitHub…** as the primary action and **I granted it — try again** to retry in place. No token language anywhere.
- **PATs** → the token-scope wording, unchanged, with no install link.
- The always-visible footer link is gone; the remedy appears exactly when the failure does.

The kind is threaded into the first connect attempt as a parameter — reading it from state in the same tick would have shown PAT copy to app users on exactly the attempt that matters (the fresh sign-in that 404s because the app isn't installed yet).

### 3. "I created it — connect" records the claim

After the user creates the repo via the `github.com/new` handoff, a 404 means *visibility*, not existence. The wizard now remembers the claim: instead of looping back into the create guide (where the fix was a fine-print caption), the access remedy takes over — grant buttons for app sign-ins, token-scope wording for PATs — and stays until it connects or the user changes the repository. The claimed retry also skips the silent API re-create, which would 422 against the now-existing repo.

## The app-user flow after this PR

```
sign in (copy code → authorize)            once per machine
   └─ connect 404 → Grant access on GitHub → I granted it — try again → ✓
create mode: Create on GitHub… → I created it — connect
   └─ still 404 → same grant flow (never loops back to the guide)
```

## Verification

- 73 desktop test files / 508 tests pass (7 new: copy-then-open ordering, clipboard-unavailable hold, app not-found → grant → retry → connected, app create guide wording + grant link, claimed-created promotion for both credential kinds, PAT remains grant-free)
- `pnpm check` clean
- Rebased on master after #109 (generic git remotes) — no file overlap, full suite green on the rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop-only GitHub backup UX and wizard error paths; behavior is covered by new tests and does not change core auth or sync protocols.
> 
> **Overview**
> Improves **GitHub device-flow sign-in** and the **Connect GitHub** wizard’s handling when a repo can’t be found.
> 
> **Device flow:** `useDeviceFlowAuth` no longer opens the browser when the code is issued. `GithubAuthStep` shows the code first and uses **Copy code and open GitHub** so the clipboard is written before `openUrl`. If copy fails, the UI waits for manual copy and only then offers **Open GitHub**.
> 
> **Connect wizard:** After sign-in, the dialog reads stored credential kind via `loadGithubAuth` and threads `authKind` into `finish` so the first post-auth 404 gets the right copy. **App** users see grant/install actions (`showGrantHint`, install URL) with no token wording; **PAT** users keep token-scope errors and no grant buttons. The always-visible install footer is removed. **I created it — connect** sets `claimedCreated` so a later 404 is treated as visibility (grant or token scope), not another create guide, and skips redundant API create.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 314e3150b7b3ad4c7195629a76006ade5ccd23db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->