### PR TITLE
Install pnpm deps automatically in fresh Claude Code worktrees

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -d node_modules ] || pnpm install --prefer-offline >/dev/null"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,6 @@ dist-ssr
 # Reflect graph index + local state (rebuildable projection; never committed)
 .reflect/
 
-# Claude Code session artifacts
-.claude/
+# Claude Code session artifacts (shared hooks in settings.json stay tracked)
+.claude/*
+!.claude/settings.json


### PR DESCRIPTION
## What changed

- Added `.claude/settings.json` with a `SessionStart` hook: `[ -d node_modules ] || pnpm install --prefer-offline >/dev/null`
- Narrowed the `.gitignore` rule from `.claude/` to `.claude/*` + `!.claude/settings.json` so the settings file is tracked and ships with every checkout (a re-include can't work under a whole-directory ignore pattern). Session artifacts like `.claude/worktrees/` stay ignored.

## Why

Claude Code creates a fresh git worktree per session but does not install dependencies itself, and this repo had no hook configured to do it — so every new session started without `node_modules`. With the entire `.claude/` directory gitignored, even a project settings file with a hook could never reach a fresh worktree checkout.

## Notes for reviewers

- The hook runs in the session's working directory (the new worktree) when a session starts, with Claude Code's default 10-minute hook timeout.
- The `[ -d node_modules ] ||` guard means sessions in already-installed checkouts (e.g. the main repo) start with no delay, and `--prefer-offline` keeps fresh-worktree installs fast via pnpm's shared content-addressable store.
- Stdout is redirected to `/dev/null` deliberately: `SessionStart` hook stdout is injected into the model's context, and install logs would be noise. Failures still surface via the non-zero exit code and stderr.
- Verified end-to-end in a fresh worktree: the hook command installed the full pnpm workspace, and a re-run with deps present exits in ~3ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local developer tooling and gitignore only; no runtime, auth, or production behavior changes.
> 
> **Overview**
> Adds a **tracked** `.claude/settings.json` with a **SessionStart** hook that runs `pnpm install --prefer-offline` when `node_modules` is missing, so fresh Claude Code worktrees get dependencies without manual setup.
> 
> Updates **`.gitignore`** from ignoring all of `.claude/` to `.claude/*` with an exception for `!.claude/settings.json`, so session artifacts stay untracked while the shared hook config is committed and available on every checkout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19d91121f89a2d3a2b81fdbe96403190fa615354. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->