### PR TITLE
Refresh stale OpenAI and Google model lists in the BYOK provider catalog

### DIFF
--- a/apps/desktop/src/components/settings/ai-models-section.test.tsx
+++ b/apps/desktop/src/components/settings/ai-models-section.test.tsx
@@ -94,7 +94,7 @@ function twoStoredModels(): Record<string, unknown> {
   return {
     aiModels: [
       entry({ id: 'a' }),
-      entry({ id: 'b', provider: 'openai', model: 'gpt-5.1', keyHint: 'abcd2' }),
+      entry({ id: 'b', provider: 'openai', model: 'gpt-5.5', keyHint: 'abcd2' }),
     ],
     defaultAiModelId: 'a',
   }
@@ -130,7 +130,7 @@ describe('AiModelsSection', () => {
     await waitFor(() =>
       expect(screen.getByText('Anthropic — Claude Opus 4.8')).toBeTruthy(),
     )
-    expect(screen.getByText('OpenAI — GPT-5.1')).toBeTruthy()
+    expect(screen.getByText('OpenAI — GPT-5.5')).toBeTruthy()
     expect(screen.getByText(/wxyz1/)).toBeTruthy()
     expect(screen.getByText(/abcd2/)).toBeTruthy()
     expect(screen.getByText('Default')).toBeTruthy()
@@ -256,7 +256,7 @@ describe('AiModelsSection', () => {
 
     await waitFor(() =>
       expect(lastSavedDoc()).toMatchObject({
-        aiModels: [entry({ id: 'b', provider: 'openai', model: 'gpt-5.1', keyHint: 'abcd2' })],
+        aiModels: [entry({ id: 'b', provider: 'openai', model: 'gpt-5.5', keyHint: 'abcd2' })],
         defaultAiModelId: 'b',
       }),
     )
@@ -279,7 +279,7 @@ describe('AiModelsSection', () => {
     fireEvent.click(
       screen.getByRole('button', { name: 'Remove Anthropic — Claude Opus 4.8' }),
     )
-    fireEvent.click(screen.getByRole('button', { name: 'Remove OpenAI — GPT-5.1' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Remove OpenAI — GPT-5.5' }))
 
     await waitFor(() =>
       expect(lastSavedDoc()).toMatchObject({ aiModels: [], defaultAiModelId: null }),

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -32,10 +32,10 @@ export const AI_PROVIDERS: AiProviderInfo[] = [
     label: 'OpenAI',
     keyPlaceholder: 'sk-…',
     models: [
-      { id: 'gpt-5.1', label: 'GPT-5.1' },
-      { id: 'gpt-5', label: 'GPT-5' },
-      { id: 'gpt-5-mini', label: 'GPT-5 mini' },
-      { id: 'gpt-5-nano', label: 'GPT-5 nano' },
+      { id: 'gpt-5.5', label: 'GPT-5.5' },
+      { id: 'gpt-5.4', label: 'GPT-5.4' },
+      { id: 'gpt-5.4-mini', label: 'GPT-5.4 mini' },
+      { id: 'gpt-5.4-nano', label: 'GPT-5.4 nano' },
     ],
   },
   {
@@ -54,10 +54,10 @@ export const AI_PROVIDERS: AiProviderInfo[] = [
     label: 'Google Gemini',
     keyPlaceholder: 'AIza…',
     models: [
-      { id: 'gemini-3-pro-preview', label: 'Gemini 3 Pro' },
+      { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro' },
+      { id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash' },
+      { id: 'gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash Lite' },
       { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
-      { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
-      { id: 'gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash Lite' },
     ],
   },
 ]


### PR DESCRIPTION
## What changed

The static BYOK provider catalog (`packages/core/src/ai/provider-catalog.ts`) was carrying dead and superseded model ids:

- **Google**: `gemini-3-pro-preview` now returns 404 from `generativelanguage.googleapis.com` — Google's [models page](https://ai.google.dev/gemini-api/docs/models) lists it as shut down. New list (most capable first, first entry is the Add-dialog default): `gemini-3.1-pro-preview`, `gemini-3.5-flash`, `gemini-3.1-flash-lite`, `gemini-2.5-pro`.
- **OpenAI**: the gpt-5.1-era lineup is superseded by the GPT-5.5/5.4 family, with several gpt-5/5.1-era variants scheduled for shutdown on July 23, 2026. New list: [`gpt-5.5`](https://developers.openai.com/api/docs/models/gpt-5.5), [`gpt-5.4`](https://developers.openai.com/api/docs/models/gpt-5.4), [`gpt-5.4-mini`](https://developers.openai.com/api/docs/models/gpt-5.4-mini), [`gpt-5.4-nano`](https://developers.openai.com/api/docs/models/gpt-5.4-nano).
- **Anthropic**: unchanged — `claude-fable-5`, `claude-opus-4-8`, `claude-sonnet-4-6`, and `claude-haiku-4-5` are all current.

`ai-models-section.test.tsx` asserted the curated `OpenAI — GPT-5.1` label, so its fixtures move to `gpt-5.5`. The `gpt-5.1` strings in `models.test.ts` and `settings/schema.test.ts` are left alone deliberately — they are opaque persisted-settings fixtures exercising the free-form fallback path (`aiModelLabel` falls back to the raw id), which is exactly the situation a user with an old settings doc is in.

## Reviewer notes

- Model ids were verified against the providers' official model documentation rather than live `GET /models` calls (no provider keys available on the dev machine). One id worth a spot-check with a real Gemini key: `gemini-3.5-flash` (GA on the Gemini API since May 19, 2026 per [Google's announcement](https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/)).
- Users who already persisted a dead model id (the Add dialog is a free-form combobox) keep working settings entries; the id just renders raw instead of with a curated label, and the provider error surfaces at call time. A possible follow-up is extending the existing add-time key probe (which already hits each provider's model-listing endpoint) to warn when the chosen id isn't in the live list.

## Testing

- `pnpm check` (typecheck + lint) passes; the two lint warnings are pre-existing in unrelated files.
- `packages/core`: `pnpm test --run src/ai` and `src/settings` pass.
- `apps/desktop`: `pnpm test --run src/components/settings/ai-models-section.test.tsx` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static catalog and test fixture updates only; no runtime logic, auth, or persistence schema changes.
> 
> **Overview**
> Updates the static BYOK **provider catalog** so the Add-model picker reflects current OpenAI and Google API model ids instead of dead or sunset entries.
> 
> **OpenAI** swaps the GPT-5.1-era lineup (`gpt-5.1`, `gpt-5`, mini/nano variants) for **GPT-5.5 / 5.4** family ids, with the first entry still the picker default. **Google Gemini** replaces shut-down `gemini-3-pro-preview` and older 2.5 flash entries with **3.1 Pro**, **3.5 Flash**, **3.1 Flash Lite**, and **2.5 Pro**. **Anthropic** is unchanged.
> 
> Desktop **AI models settings tests** are aligned to use `gpt-5.5` and the `OpenAI — GPT-5.5` label so they match the new curated labels; persisted-settings fallback tests elsewhere are intentionally left on old ids per the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cef6ebbb0e390d53b5b275bf512ca9ae74ab39a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->