### PR TITLE
Audio memos: record, transcribe via BYOK OpenAI/Gemini, append to today's daily note

### DIFF
--- a/apps/desktop/src-tauri/Entitlements.plist
+++ b/apps/desktop/src-tauri/Entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Applied at codesign time (bundle.macOS.entitlements). The release build
+     signs with the hardened runtime, which blocks microphone capture unless
+     this entitlement is granted — without it, audio memos fail silently in
+     notarized builds. -->
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Merged into the bundle's Info.plist by tauri-build (and embedded into dev
+     binaries), so the macOS microphone prompt works in both `tauri dev` and
+     release builds. -->
+<plist version="1.0">
+<dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Reflect uses the microphone to record audio memos that are transcribed into your daily note.</string>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/tauri.macos.conf.json
+++ b/apps/desktop/src-tauri/tauri.macos.conf.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "bundle": {
-    "externalBin": ["binaries/reflect"]
+    "externalBin": ["binaries/reflect"],
+    "macOS": {
+      "entitlements": "Entitlements.plist"
+    }
   }
 }

--- a/apps/desktop/src/components/audio-memo/audio-memo-button.test.tsx
+++ b/apps/desktop/src/components/audio-memo/audio-memo-button.test.tsx
@@ -1,0 +1,99 @@
+import { cleanup, render, type RenderResult } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
+
+const memo = vi.hoisted(() => ({
+  phase: 'idle' as 'idle' | 'requesting' | 'recording' | 'transcribing' | 'error',
+  elapsedMs: 0,
+  stream: null,
+  available: true,
+  unavailableReason: null as string | null,
+  error: null as string | null,
+  canRetry: false,
+  toggle: vi.fn(),
+  cancel: vi.fn(),
+  retry: vi.fn(),
+  discard: vi.fn(),
+}))
+
+vi.mock('@/providers/audio-memo-provider', () => ({
+  useAudioMemo: () => ({ ...memo }),
+}))
+
+const { AudioMemoButton } = await import('./audio-memo-button')
+
+function renderButton(): RenderResult {
+  return render(
+    <TooltipProvider>
+      <AudioMemoButton />
+    </TooltipProvider>,
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  memo.phase = 'idle'
+  memo.elapsedMs = 0
+  memo.available = true
+  memo.unavailableReason = null
+  memo.error = null
+  memo.canRetry = false
+})
+
+afterEach(cleanup)
+
+describe('AudioMemoButton', () => {
+  it('recording shows the stop control and the elapsed time', async () => {
+    memo.phase = 'recording'
+    memo.elapsedMs = 83_000
+    const view = renderButton()
+
+    expect(view.getByText('1:23')).not.toBeNull()
+    await userEvent.click(view.getByRole('button', { name: 'Stop recording' }))
+    expect(memo.toggle).toHaveBeenCalled()
+  })
+
+  it('escape cancels a recording without transcribing', async () => {
+    memo.phase = 'recording'
+    const view = renderButton()
+
+    view.getByRole('button', { name: 'Stop recording' }).focus()
+    await userEvent.keyboard('{Escape}')
+    expect(memo.cancel).toHaveBeenCalled()
+    expect(memo.toggle).not.toHaveBeenCalled()
+  })
+
+  it('transcribing disables the control and shows progress', () => {
+    memo.phase = 'transcribing'
+    const view = renderButton()
+
+    expect(view.getByText('Transcribing…')).not.toBeNull()
+    expect(
+      view.getByRole('button', { name: 'Transcribing audio memo' }),
+    ).toHaveProperty('disabled', true)
+  })
+
+  it('a resumable failure offers Retry and Discard', async () => {
+    memo.phase = 'error'
+    memo.error = 'provider down'
+    memo.canRetry = true
+    const view = renderButton()
+
+    expect(view.getByText('provider down')).not.toBeNull()
+    await userEvent.click(view.getByRole('button', { name: 'Retry' }))
+    expect(memo.retry).toHaveBeenCalled()
+    await userEvent.click(view.getByRole('button', { name: 'Discard' }))
+    expect(memo.discard).toHaveBeenCalled()
+  })
+
+  it('a non-resumable failure hides Retry', () => {
+    memo.phase = 'error'
+    memo.error = 'came back empty'
+    memo.canRetry = false
+    const view = renderButton()
+
+    expect(view.queryByRole('button', { name: 'Retry' })).toBeNull()
+    expect(view.getByRole('button', { name: 'Discard' })).not.toBeNull()
+  })
+})

--- a/apps/desktop/src/components/audio-memo/audio-memo-button.test.tsx
+++ b/apps/desktop/src/components/audio-memo/audio-memo-button.test.tsx
@@ -64,6 +64,15 @@ describe('AudioMemoButton', () => {
     expect(memo.toggle).not.toHaveBeenCalled()
   })
 
+  it('escape is inert while transcribing — stopping committed the save', async () => {
+    memo.phase = 'transcribing'
+    renderButton()
+
+    await userEvent.keyboard('{Escape}')
+    expect(memo.cancel).not.toHaveBeenCalled()
+    expect(memo.discard).not.toHaveBeenCalled()
+  })
+
   it('transcribing disables the control and shows progress', () => {
     memo.phase = 'transcribing'
     const view = renderButton()

--- a/apps/desktop/src/components/audio-memo/audio-memo-button.test.tsx
+++ b/apps/desktop/src/components/audio-memo/audio-memo-button.test.tsx
@@ -44,6 +44,22 @@ beforeEach(() => {
 afterEach(cleanup)
 
 describe('AudioMemoButton', () => {
+  it('unavailable renders aria-disabled — never natively disabled — and ignores clicks', async () => {
+    memo.available = false
+    memo.unavailableReason = 'Add an OpenAI or Gemini model in Settings to record audio memos'
+    const view = renderButton()
+
+    // aria-disabled (not `disabled`) keeps pointer events alive so the
+    // explanatory tooltip can fire; the reason copy itself is asserted in the
+    // provider test, and jsdom can't drive Radix's tooltip-open mechanics.
+    const micButton = view.getByRole('button', { name: 'Record audio memo' })
+    expect(micButton.getAttribute('aria-disabled')).toBe('true')
+    expect(micButton).toHaveProperty('disabled', false)
+
+    await userEvent.click(micButton)
+    expect(memo.toggle).not.toHaveBeenCalled()
+  })
+
   it('recording shows the stop control and the elapsed time', async () => {
     memo.phase = 'recording'
     memo.elapsedMs = 83_000

--- a/apps/desktop/src/components/audio-memo/audio-memo-button.tsx
+++ b/apps/desktop/src/components/audio-memo/audio-memo-button.tsx
@@ -1,0 +1,78 @@
+import type { ReactElement } from 'react'
+import { Loader2, Mic, Square } from 'lucide-react'
+import { RecordingPopover } from '@/components/audio-memo/recording-popover'
+import { Button } from '@/components/ui/button'
+import { Popover, PopoverAnchor } from '@/components/ui/popover'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { useAudioMemo } from '@/providers/audio-memo-provider'
+
+/**
+ * The microphone beside the sidebar search box. Idle it starts a memo;
+ * while one is in flight it becomes the red stop control with the recording
+ * panel anchored beside it. Disabled (with the reason as a tooltip) when no
+ * OpenAI/Gemini model is configured — `aria-disabled` rather than `disabled`
+ * so the tooltip still fires.
+ */
+export function AudioMemoButton(): ReactElement {
+  const memo = useAudioMemo()
+
+  if (memo.phase === 'idle' || memo.phase === 'requesting') {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Record audio memo"
+            aria-disabled={!memo.available || undefined}
+            onClick={() => {
+              if (memo.available) {
+                memo.toggle()
+              }
+            }}
+            className={cn(
+              'text-text-muted hover:text-text-secondary dark:hover:text-text',
+              !memo.available && 'opacity-50 hover:bg-transparent hover:text-text-muted',
+            )}
+          >
+            <Mic aria-hidden strokeWidth={1.75} className="size-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {memo.unavailableReason ?? 'Record audio memo'}
+        </TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  return (
+    <Popover open>
+      <PopoverAnchor asChild>
+        <Button
+          variant="destructive"
+          size="icon-sm"
+          className="rounded-full"
+          aria-label={memo.phase === 'recording' ? 'Stop recording' : 'Audio memo status'}
+          disabled={memo.phase === 'transcribing'}
+          onClick={() => {
+            if (memo.phase === 'recording') {
+              memo.toggle()
+            } else if (memo.phase === 'error') {
+              memo.discard()
+            }
+          }}
+        >
+          {memo.phase === 'transcribing' ? (
+            <Loader2 aria-hidden className="size-3.5 animate-spin" />
+          ) : memo.phase === 'error' ? (
+            <Mic aria-hidden strokeWidth={1.75} className="size-4" />
+          ) : (
+            <Square aria-hidden fill="currentColor" className="size-3" />
+          )}
+        </Button>
+      </PopoverAnchor>
+      <RecordingPopover />
+    </Popover>
+  )
+}

--- a/apps/desktop/src/components/audio-memo/audio-memo-button.tsx
+++ b/apps/desktop/src/components/audio-memo/audio-memo-button.tsx
@@ -46,6 +46,13 @@ export function AudioMemoButton(): ReactElement {
     )
   }
 
+  const activeLabel =
+    memo.phase === 'recording'
+      ? 'Stop recording'
+      : memo.phase === 'error'
+        ? 'Discard audio memo'
+        : 'Transcribing audio memo'
+
   return (
     <Popover open>
       <PopoverAnchor asChild>
@@ -53,7 +60,7 @@ export function AudioMemoButton(): ReactElement {
           variant="destructive"
           size="icon-sm"
           className="rounded-full"
-          aria-label={memo.phase === 'recording' ? 'Stop recording' : 'Audio memo status'}
+          aria-label={activeLabel}
           disabled={memo.phase === 'transcribing'}
           onClick={() => {
             if (memo.phase === 'recording') {

--- a/apps/desktop/src/components/audio-memo/recording-popover.tsx
+++ b/apps/desktop/src/components/audio-memo/recording-popover.tsx
@@ -1,0 +1,62 @@
+import type { ReactElement } from 'react'
+import { Loader2 } from 'lucide-react'
+import { RecordingWaveform } from '@/components/audio-memo/recording-waveform'
+import { Button } from '@/components/ui/button'
+import { PopoverContent } from '@/components/ui/popover'
+import { useAudioMemo } from '@/providers/audio-memo-provider'
+
+/**
+ * The floating panel beside the mic while a memo is in flight: waveform +
+ * elapsed time during recording, a spinner while transcribing, and the
+ * failure state with Retry/Discard. Esc discards (a recording is cancelled
+ * without transcribing); clicks elsewhere deliberately don't dismiss — the
+ * recording owns its lifecycle.
+ */
+export function RecordingPopover(): ReactElement {
+  const memo = useAudioMemo()
+
+  return (
+    <PopoverContent
+      side="right"
+      align="center"
+      sideOffset={10}
+      className="w-auto px-3 py-2"
+      onOpenAutoFocus={(event) => event.preventDefault()}
+      onEscapeKeyDown={() => (memo.phase === 'error' ? memo.discard() : memo.cancel())}
+      onInteractOutside={(event) => event.preventDefault()}
+    >
+      {memo.phase === 'error' ? (
+        <div className="flex max-w-72 flex-col gap-2">
+          <p className="text-xs text-destructive">{memo.error}</p>
+          <div className="flex gap-1.5">
+            {memo.canRetry ? (
+              <Button size="xs" variant="secondary" onClick={() => memo.retry()}>
+                Retry
+              </Button>
+            ) : null}
+            <Button size="xs" variant="ghost" onClick={() => memo.discard()}>
+              Discard
+            </Button>
+          </div>
+        </div>
+      ) : memo.phase === 'transcribing' ? (
+        <div className="flex items-center gap-2 text-sm text-text-muted">
+          <Loader2 aria-hidden className="size-4 animate-spin" />
+          Transcribing…
+        </div>
+      ) : (
+        <div className="flex items-center gap-3">
+          {memo.stream ? <RecordingWaveform stream={memo.stream} /> : null}
+          <span className="text-sm font-medium tabular-nums">{formatElapsed(memo.elapsedMs)}</span>
+        </div>
+      )}
+    </PopoverContent>
+  )
+}
+
+function formatElapsed(elapsedMs: number): string {
+  const totalSeconds = Math.floor(elapsedMs / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}:${String(seconds).padStart(2, '0')}`
+}

--- a/apps/desktop/src/components/audio-memo/recording-popover.tsx
+++ b/apps/desktop/src/components/audio-memo/recording-popover.tsx
@@ -8,9 +8,11 @@ import { useAudioMemo } from '@/providers/audio-memo-provider'
 /**
  * The floating panel beside the mic while a memo is in flight: waveform +
  * elapsed time during recording, a spinner while transcribing, and the
- * failure state with Retry/Discard. Esc discards (a recording is cancelled
- * without transcribing); clicks elsewhere deliberately don't dismiss — the
- * recording owns its lifecycle.
+ * failure state with Retry/Discard. Esc cancels a live recording and
+ * dismisses an error, but is deliberately inert while transcribing — the
+ * user already committed the memo by stopping, and "cancelling" a save
+ * that may have reached the provider would only feign control. Clicks
+ * elsewhere don't dismiss; the recording owns its lifecycle.
  */
 export function RecordingPopover(): ReactElement {
   const memo = useAudioMemo()
@@ -22,7 +24,13 @@ export function RecordingPopover(): ReactElement {
       sideOffset={10}
       className="w-auto px-3 py-2"
       onOpenAutoFocus={(event) => event.preventDefault()}
-      onEscapeKeyDown={() => (memo.phase === 'error' ? memo.discard() : memo.cancel())}
+      onEscapeKeyDown={() => {
+        if (memo.phase === 'recording') {
+          memo.cancel()
+        } else if (memo.phase === 'error') {
+          memo.discard()
+        }
+      }}
       onInteractOutside={(event) => event.preventDefault()}
     >
       {memo.phase === 'error' ? (

--- a/apps/desktop/src/components/audio-memo/recording-waveform.tsx
+++ b/apps/desktop/src/components/audio-memo/recording-waveform.tsx
@@ -34,8 +34,16 @@ export function RecordingWaveform({ stream }: RecordingWaveformProps): ReactElem
     // The canvas carries a text color class; bars inherit the theme through it.
     const color = getComputedStyle(canvas).color
 
-    const audioContext = new AudioContext()
-    const source = audioContext.createMediaStreamSource(stream)
+    let audioContext: AudioContext
+    let source: MediaStreamAudioSourceNode
+    try {
+      audioContext = new AudioContext()
+      source = audioContext.createMediaStreamSource(stream)
+    } catch {
+      // Context limit reached or the stream already died — keep the static
+      // baseline rather than crash the tree over a decoration.
+      return
+    }
     const analyser = audioContext.createAnalyser()
     analyser.fftSize = 512
     source.connect(analyser)

--- a/apps/desktop/src/components/audio-memo/recording-waveform.tsx
+++ b/apps/desktop/src/components/audio-memo/recording-waveform.tsx
@@ -58,15 +58,17 @@ export function RecordingWaveform({ stream }: RecordingWaveformProps): ReactElem
         context.fillStyle = color
         bars.forEach((amplitude, index) => {
           const height = Math.max(BAR_WIDTH, amplitude * CSS_HEIGHT)
-          context.beginPath()
-          context.roundRect(
-            index * (BAR_WIDTH + BAR_GAP),
-            (CSS_HEIGHT - height) / 2,
-            BAR_WIDTH,
-            height,
-            BAR_WIDTH / 2,
-          )
-          context.fill()
+          const left = index * (BAR_WIDTH + BAR_GAP)
+          const top = (CSS_HEIGHT - height) / 2
+          // roundRect is Safari 16+; an un-updated older WebKit still records,
+          // it just gets square bars instead of a crash.
+          if (typeof context.roundRect === 'function') {
+            context.beginPath()
+            context.roundRect(left, top, BAR_WIDTH, height, BAR_WIDTH / 2)
+            context.fill()
+          } else {
+            context.fillRect(left, top, BAR_WIDTH, height)
+          }
         })
       }
       frame = requestAnimationFrame(loop)

--- a/apps/desktop/src/components/audio-memo/recording-waveform.tsx
+++ b/apps/desktop/src/components/audio-memo/recording-waveform.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useRef, type ReactElement } from 'react'
+
+interface RecordingWaveformProps {
+  /** The live microphone stream (from the audio-memo provider). */
+  stream: MediaStream
+}
+
+const BAR_COUNT = 48
+const BAR_WIDTH = 2
+const BAR_GAP = 2
+const SAMPLE_INTERVAL_MS = 60
+const CSS_WIDTH = BAR_COUNT * (BAR_WIDTH + BAR_GAP) - BAR_GAP
+const CSS_HEIGHT = 28
+
+/**
+ * The rolling input-level trace shown while recording: a new amplitude bar
+ * every tick, scrolling left as the recording grows (silence renders as the
+ * dotted baseline). Purely presentational — it taps the stream through its
+ * own AudioContext and owns that lifecycle.
+ */
+export function RecordingWaveform({ stream }: RecordingWaveformProps): ReactElement {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    const context = canvas?.getContext('2d')
+    if (!canvas || !context) {
+      return
+    }
+    const scale = window.devicePixelRatio || 1
+    canvas.width = CSS_WIDTH * scale
+    canvas.height = CSS_HEIGHT * scale
+    context.scale(scale, scale)
+    // The canvas carries a text color class; bars inherit the theme through it.
+    const color = getComputedStyle(canvas).color
+
+    const audioContext = new AudioContext()
+    const source = audioContext.createMediaStreamSource(stream)
+    const analyser = audioContext.createAnalyser()
+    analyser.fftSize = 512
+    source.connect(analyser)
+    const samples = new Uint8Array(analyser.fftSize)
+    const bars: number[] = Array.from({ length: BAR_COUNT }, () => 0)
+
+    let lastSampleAt = 0
+    let frame = requestAnimationFrame(function loop(now: number) {
+      if (now - lastSampleAt >= SAMPLE_INTERVAL_MS) {
+        lastSampleAt = now
+        analyser.getByteTimeDomainData(samples)
+        let peak = 0
+        for (const sample of samples) {
+          peak = Math.max(peak, Math.abs(sample - 128) / 128)
+        }
+        bars.push(Math.min(1, peak * 1.4))
+        bars.splice(0, bars.length - BAR_COUNT)
+
+        context.clearRect(0, 0, CSS_WIDTH, CSS_HEIGHT)
+        context.fillStyle = color
+        bars.forEach((amplitude, index) => {
+          const height = Math.max(BAR_WIDTH, amplitude * CSS_HEIGHT)
+          context.beginPath()
+          context.roundRect(
+            index * (BAR_WIDTH + BAR_GAP),
+            (CSS_HEIGHT - height) / 2,
+            BAR_WIDTH,
+            height,
+            BAR_WIDTH / 2,
+          )
+          context.fill()
+        })
+      }
+      frame = requestAnimationFrame(loop)
+    })
+
+    return () => {
+      cancelAnimationFrame(frame)
+      source.disconnect()
+      void audioContext.close()
+    }
+  }, [stream])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden
+      className="text-destructive"
+      style={{ width: CSS_WIDTH, height: CSS_HEIGHT }}
+    />
+  )
+}

--- a/apps/desktop/src/components/command-palette/command-palette.test.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.test.tsx
@@ -87,6 +87,7 @@ function renderPalette(query: string, context?: Partial<CommandContext>) {
     forward: vi.fn(),
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
+    toggleAudioMemo: vi.fn(),
     generation: () => 1,
     openPalette: vi.fn(),
     enableSemanticSearch: vi.fn(),

--- a/apps/desktop/src/components/graph-workspace.tsx
+++ b/apps/desktop/src/components/graph-workspace.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react'
 import type { GraphInfo } from '@reflect/core'
 import { PaletteProvider } from '@/components/command-palette/palette-provider'
 import { WorkspaceContent } from '@/components/workspace-content'
+import { AudioMemoProvider } from '@/providers/audio-memo-provider'
 import { SidebarProvider } from '@/providers/sidebar-provider'
 import { SyncProvider } from '@/providers/sync-provider'
 import { RouterProvider } from '@/routing/router'
@@ -23,7 +24,11 @@ export function GraphWorkspace({ graph }: GraphWorkspaceProps): ReactElement {
       <SyncProvider graph={graph}>
         <PaletteProvider>
           <SidebarProvider>
-            <WorkspaceContent graph={graph} />
+            {/* Above the sidebar: a recording must survive the sidebar (and its
+                mic button) unmounting on collapse. */}
+            <AudioMemoProvider graph={graph}>
+              <WorkspaceContent graph={graph} />
+            </AudioMemoProvider>
           </SidebarProvider>
         </PaletteProvider>
       </SyncProvider>

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DEFAULT_SETTINGS, type GraphInfo, type PinnedNote, type Settings } from '@reflect/core'
 import type { CommandContext } from '@/lib/commands/types'
 import { TooltipProvider } from '@/components/ui/tooltip'
@@ -73,6 +73,14 @@ const { Sidebar } = await import('./sidebar')
 const { registerAppCommands } = await import('@/lib/commands/app-commands')
 registerAppCommands()
 
+beforeEach(() => {
+  // The hoisted mock is shared module state — restore it so mic-related cases
+  // can't inherit mutations from earlier tests.
+  audioMemo.available = true
+  audioMemo.unavailableReason = null
+  audioMemo.toggle.mockReset()
+})
+
 afterEach(cleanup) // `globals: false` disables testing-library's automatic cleanup
 
 function renderSidebar(overrides?: Partial<CommandContext>) {
@@ -122,9 +130,6 @@ describe('Sidebar', () => {
   })
 
   it('the mic button starts an audio memo', async () => {
-    audioMemo.available = true
-    audioMemo.unavailableReason = null
-    audioMemo.toggle.mockClear()
     const { view } = renderSidebar()
     await userEvent.click(view.getByRole('button', { name: /record audio memo/i }))
     expect(audioMemo.toggle).toHaveBeenCalled()
@@ -133,7 +138,6 @@ describe('Sidebar', () => {
   it('the mic button disables (without vanishing) when no provider can transcribe', async () => {
     audioMemo.available = false
     audioMemo.unavailableReason = 'Add an OpenAI or Gemini model in Settings to record audio memos'
-    audioMemo.toggle.mockClear()
     const { view } = renderSidebar()
     const micButton = view.getByRole('button', { name: /record audio memo/i })
     expect(micButton.getAttribute('aria-disabled')).toBe('true')

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -49,6 +49,23 @@ vi.mock('@/providers/sync-provider', () => ({
   }),
 }))
 
+const audioMemo = vi.hoisted(() => ({
+  phase: 'idle' as const,
+  elapsedMs: 0,
+  stream: null,
+  available: true,
+  unavailableReason: null as string | null,
+  error: null,
+  canRetry: false,
+  toggle: vi.fn(),
+  cancel: vi.fn(),
+  retry: vi.fn(),
+  discard: vi.fn(),
+}))
+vi.mock('@/providers/audio-memo-provider', () => ({
+  useAudioMemo: () => audioMemo,
+}))
+
 const GRAPH: GraphInfo = { root: '/notes', name: 'Notes', cloudSync: null, generation: 1 }
 
 // Import after the core mock so the command registry sees the mocked module.
@@ -68,6 +85,7 @@ function renderSidebar(overrides?: Partial<CommandContext>) {
     forward: vi.fn(),
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
+    toggleAudioMemo: vi.fn(),
     generation: () => 1,
     openPalette,
     enableSemanticSearch: vi.fn(),
@@ -101,6 +119,26 @@ describe('Sidebar', () => {
     const { view, openPalette } = renderSidebar()
     await userEvent.click(view.getByRole('button', { name: /search anything/i }))
     expect(openPalette).toHaveBeenCalled()
+  })
+
+  it('the mic button starts an audio memo', async () => {
+    audioMemo.available = true
+    audioMemo.unavailableReason = null
+    audioMemo.toggle.mockClear()
+    const { view } = renderSidebar()
+    await userEvent.click(view.getByRole('button', { name: /record audio memo/i }))
+    expect(audioMemo.toggle).toHaveBeenCalled()
+  })
+
+  it('the mic button disables (without vanishing) when no provider can transcribe', async () => {
+    audioMemo.available = false
+    audioMemo.unavailableReason = 'Add an OpenAI or Gemini model in Settings to record audio memos'
+    audioMemo.toggle.mockClear()
+    const { view } = renderSidebar()
+    const micButton = view.getByRole('button', { name: /record audio memo/i })
+    expect(micButton.getAttribute('aria-disabled')).toBe('true')
+    await userEvent.click(micButton)
+    expect(audioMemo.toggle).not.toHaveBeenCalled()
   })
 
   it('pinned notes render their own section', async () => {

--- a/apps/desktop/src/components/sidebar/sidebar.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react'
 import type { GraphInfo } from '@reflect/core'
 import { Settings, SquarePen } from 'lucide-react'
+import { AudioMemoButton } from '@/components/audio-memo/audio-memo-button'
 import { ListIcon } from '@/components/icons/list-icon'
 import { PencilIcon } from '@/components/icons/pencil-icon'
 import { keybindingFor } from '@/lib/commands/app-commands'
@@ -49,8 +50,11 @@ export function Sidebar({ graph, context }: SidebarProps): ReactElement {
       </div>
 
       <div className="flex flex-none flex-col">
-        <div className="mt-1 px-4">
-          <SidebarSearch onOpen={() => context.openPalette()} />
+        <div className="mt-1 flex items-center gap-1.5 px-4">
+          <div className="min-w-0 flex-1">
+            <SidebarSearch onOpen={() => context.openPalette()} />
+          </div>
+          <AudioMemoButton />
         </div>
 
         <nav aria-label="Primary" className="mt-6 space-y-1 px-4">

--- a/apps/desktop/src/hooks/use-audio-recorder.test.ts
+++ b/apps/desktop/src/hooks/use-audio-recorder.test.ts
@@ -13,6 +13,7 @@ class FakeMediaRecorder {
   ondataavailable: ((event: { data: Blob }) => void) | null = null
   onstop: (() => void) | null = null
   state: RecordingState = 'inactive'
+  stopCalls = 0
   readonly mimeType: string
 
   constructor(_stream: MediaStream, options?: { mimeType?: string }) {
@@ -25,6 +26,7 @@ class FakeMediaRecorder {
   }
 
   stop(): void {
+    this.stopCalls += 1
     this.state = 'inactive'
     this.ondataavailable?.({ data: new Blob(['audio-bytes']) })
     this.onstop?.()
@@ -165,6 +167,28 @@ describe('useAudioRecorder', () => {
     expect(track.stop).toHaveBeenCalled()
     expect(result.current.status).toBe('idle')
     expect(FakeMediaRecorder.instances).toHaveLength(0)
+  })
+
+  it('concurrent stops share one in-flight result and stop the recorder once', async () => {
+    getUserMedia.mockResolvedValue(fakeStream([{ stop: vi.fn() }]))
+    const { result } = renderHook(() => useAudioRecorder())
+
+    await act(async () => {
+      await result.current.start()
+    })
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+
+    const [first, second] = await act(async () => {
+      const racingStop = result.current.stop()
+      const racingStopTwin = result.current.stop()
+      return Promise.all([racingStop, racingStopTwin])
+    })
+
+    expect(FakeMediaRecorder.instances[0].stopCalls).toBe(1)
+    expect(first).not.toBeNull()
+    expect(second).toBe(first)
   })
 
   it('fires onMaxDuration once when the cap is reached', async () => {

--- a/apps/desktop/src/hooks/use-audio-recorder.test.ts
+++ b/apps/desktop/src/hooks/use-audio-recorder.test.ts
@@ -141,6 +141,33 @@ describe('useAudioRecorder', () => {
     expect(result.current.status).toBe('idle')
   })
 
+  it('overlapping starts acquire a single stream', async () => {
+    const track = { stop: vi.fn() }
+    let release: (stream: MediaStream) => void = () => {}
+    getUserMedia.mockImplementation(
+      () =>
+        new Promise<MediaStream>((resolve) => {
+          release = resolve
+        }),
+    )
+    const { result } = renderHook(() => useAudioRecorder())
+
+    let firstStart: Promise<void> = Promise.resolve()
+    let secondStart: Promise<void> = Promise.resolve()
+    act(() => {
+      firstStart = result.current.start()
+      secondStart = result.current.start()
+    })
+    await act(async () => {
+      release(fakeStream([track]))
+      await Promise.all([firstStart, secondStart])
+    })
+
+    expect(getUserMedia).toHaveBeenCalledTimes(1)
+    expect(FakeMediaRecorder.instances).toHaveLength(1)
+    expect(result.current.status).toBe('recording')
+  })
+
   it('a cancel during the permission prompt releases the stream it resolves into', async () => {
     const track = { stop: vi.fn() }
     let release: (stream: MediaStream) => void = () => {}

--- a/apps/desktop/src/hooks/use-audio-recorder.test.ts
+++ b/apps/desktop/src/hooks/use-audio-recorder.test.ts
@@ -167,6 +167,45 @@ describe('useAudioRecorder', () => {
     expect(FakeMediaRecorder.instances).toHaveLength(0)
   })
 
+  it('fires onMaxDuration once when the cap is reached', async () => {
+    getUserMedia.mockResolvedValue(fakeStream([{ stop: vi.fn() }]))
+    const onMaxDuration = vi.fn()
+    const { result } = renderHook(() =>
+      useAudioRecorder({ maxDurationMs: 1000, onMaxDuration }),
+    )
+
+    await act(async () => {
+      await result.current.start()
+    })
+    act(() => {
+      vi.advanceTimersByTime(999)
+    })
+    expect(onMaxDuration).not.toHaveBeenCalled()
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+    expect(onMaxDuration).toHaveBeenCalledTimes(1)
+  })
+
+  it('stopping before the cap disarms it', async () => {
+    getUserMedia.mockResolvedValue(fakeStream([{ stop: vi.fn() }]))
+    const onMaxDuration = vi.fn()
+    const { result } = renderHook(() =>
+      useAudioRecorder({ maxDurationMs: 1000, onMaxDuration }),
+    )
+
+    await act(async () => {
+      await result.current.start()
+    })
+    await act(async () => {
+      await result.current.stop()
+    })
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+    expect(onMaxDuration).not.toHaveBeenCalled()
+  })
+
   it('unmount releases the microphone', async () => {
     const track = { stop: vi.fn() }
     getUserMedia.mockResolvedValue(fakeStream([track]))

--- a/apps/desktop/src/hooks/use-audio-recorder.test.ts
+++ b/apps/desktop/src/hooks/use-audio-recorder.test.ts
@@ -218,6 +218,23 @@ describe('useAudioRecorder', () => {
     expect(second).toBe(first)
   })
 
+  it('stop on an already-inactive recorder settles instead of throwing', async () => {
+    getUserMedia.mockResolvedValue(fakeStream([{ stop: vi.fn() }]))
+    const { result } = renderHook(() => useAudioRecorder())
+
+    await act(async () => {
+      await result.current.start()
+    })
+    // Simulate an external stop landing first (a racing cancel).
+    FakeMediaRecorder.instances[0].state = 'inactive'
+
+    const recording = await act(async () => result.current.stop())
+
+    expect(recording).toBeNull()
+    expect(FakeMediaRecorder.instances[0].stopCalls).toBe(0)
+    expect(result.current.status).toBe('idle')
+  })
+
   it('fires onMaxDuration once when the cap is reached', async () => {
     getUserMedia.mockResolvedValue(fakeStream([{ stop: vi.fn() }]))
     const onMaxDuration = vi.fn()

--- a/apps/desktop/src/hooks/use-audio-recorder.test.ts
+++ b/apps/desktop/src/hooks/use-audio-recorder.test.ts
@@ -5,6 +5,7 @@ import { isRecordingSupported, useAudioRecorder } from './use-audio-recorder'
 class FakeMediaRecorder {
   static instances: FakeMediaRecorder[] = []
   static supported = ['audio/mp4']
+  static failConstruction = false
 
   static isTypeSupported(type: string): boolean {
     return FakeMediaRecorder.supported.includes(type)
@@ -17,6 +18,9 @@ class FakeMediaRecorder {
   readonly mimeType: string
 
   constructor(_stream: MediaStream, options?: { mimeType?: string }) {
+    if (FakeMediaRecorder.failConstruction) {
+      throw new Error('NotSupportedError')
+    }
     this.mimeType = options?.mimeType ?? ''
     FakeMediaRecorder.instances.push(this)
   }
@@ -46,6 +50,7 @@ const getUserMedia = vi.fn<() => Promise<MediaStream>>()
 beforeEach(() => {
   FakeMediaRecorder.instances = []
   FakeMediaRecorder.supported = ['audio/mp4']
+  FakeMediaRecorder.failConstruction = false
   vi.stubGlobal('MediaRecorder', FakeMediaRecorder)
   vi.stubGlobal('navigator', { mediaDevices: { getUserMedia } })
   getUserMedia.mockReset()
@@ -127,6 +132,34 @@ describe('useAudioRecorder', () => {
     expect(result.current.status).toBe('idle')
     expect(result.current.stream).toBeNull()
     expect(track.stop).toHaveBeenCalled()
+  })
+
+  it('a recorder that fails to set up releases the stream and recovers to idle', async () => {
+    const track = { stop: vi.fn() }
+    getUserMedia.mockResolvedValue(fakeStream([track]))
+    FakeMediaRecorder.failConstruction = true
+    const { result } = renderHook(() => useAudioRecorder())
+
+    // Catch inside act: a rejection crossing the act boundary breaks the
+    // shared act scope for every later call.
+    let failure: unknown = null
+    await act(async () => {
+      await result.current.start().catch((cause: unknown) => {
+        failure = cause
+      })
+    })
+    expect(failure).toBeInstanceOf(Error)
+    expect(track.stop).toHaveBeenCalled()
+    expect(result.current.status).toBe('idle')
+
+    // The failure must not wedge the hook: a later start records normally.
+    FakeMediaRecorder.failConstruction = false
+    const freshTrack = { stop: vi.fn() }
+    getUserMedia.mockResolvedValue(fakeStream([freshTrack]))
+    await act(async () => {
+      await result.current.start()
+    })
+    expect(result.current.status).toBe('recording')
   })
 
   it('rethrows a permission denial and returns to idle', async () => {

--- a/apps/desktop/src/hooks/use-audio-recorder.test.ts
+++ b/apps/desktop/src/hooks/use-audio-recorder.test.ts
@@ -1,0 +1,189 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { isRecordingSupported, useAudioRecorder } from './use-audio-recorder'
+
+class FakeMediaRecorder {
+  static instances: FakeMediaRecorder[] = []
+  static supported = ['audio/mp4']
+
+  static isTypeSupported(type: string): boolean {
+    return FakeMediaRecorder.supported.includes(type)
+  }
+
+  ondataavailable: ((event: { data: Blob }) => void) | null = null
+  onstop: (() => void) | null = null
+  state: RecordingState = 'inactive'
+  readonly mimeType: string
+
+  constructor(_stream: MediaStream, options?: { mimeType?: string }) {
+    this.mimeType = options?.mimeType ?? ''
+    FakeMediaRecorder.instances.push(this)
+  }
+
+  start(): void {
+    this.state = 'recording'
+  }
+
+  stop(): void {
+    this.state = 'inactive'
+    this.ondataavailable?.({ data: new Blob(['audio-bytes']) })
+    this.onstop?.()
+  }
+}
+
+interface FakeTrack {
+  stop: () => void
+}
+
+function fakeStream(tracks: FakeTrack[]): MediaStream {
+  return { getTracks: () => tracks } as unknown as MediaStream
+}
+
+const getUserMedia = vi.fn<() => Promise<MediaStream>>()
+
+beforeEach(() => {
+  FakeMediaRecorder.instances = []
+  FakeMediaRecorder.supported = ['audio/mp4']
+  vi.stubGlobal('MediaRecorder', FakeMediaRecorder)
+  vi.stubGlobal('navigator', { mediaDevices: { getUserMedia } })
+  getUserMedia.mockReset()
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe('useAudioRecorder', () => {
+  it('records with the first supported container and assembles the result', async () => {
+    const track = { stop: vi.fn() }
+    getUserMedia.mockResolvedValue(fakeStream([track]))
+    const { result } = renderHook(() => useAudioRecorder())
+
+    await act(async () => {
+      await result.current.start()
+    })
+    expect(result.current.status).toBe('recording')
+    expect(result.current.stream).not.toBeNull()
+    // WKWebView profile: webm unsupported, mp4 picked.
+    expect(FakeMediaRecorder.instances[0].mimeType).toBe('audio/mp4')
+
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+    expect(result.current.elapsedMs).toBe(3000)
+
+    const recording = await act(async () => result.current.stop())
+    expect(recording).not.toBeNull()
+    expect(recording?.mimeType).toBe('audio/mp4')
+    expect(recording?.durationMs).toBe(3000)
+    expect(recording?.blob.size).toBeGreaterThan(0)
+    expect(track.stop).toHaveBeenCalled()
+    expect(result.current.status).toBe('idle')
+    expect(result.current.elapsedMs).toBe(0)
+  })
+
+  it('prefers opus-in-webm where the platform supports it', async () => {
+    FakeMediaRecorder.supported = ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4']
+    getUserMedia.mockResolvedValue(fakeStream([{ stop: vi.fn() }]))
+    const { result } = renderHook(() => useAudioRecorder())
+
+    await act(async () => {
+      await result.current.start()
+    })
+    expect(FakeMediaRecorder.instances[0].mimeType).toBe('audio/webm;codecs=opus')
+  })
+
+  it('discards a sub-half-second recording as a misclick', async () => {
+    getUserMedia.mockResolvedValue(fakeStream([{ stop: vi.fn() }]))
+    const { result } = renderHook(() => useAudioRecorder())
+
+    await act(async () => {
+      await result.current.start()
+    })
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+    const recording = await act(async () => result.current.stop())
+    expect(recording).toBeNull()
+    expect(result.current.status).toBe('idle')
+  })
+
+  it('cancel stops the tracks and discards without a result', async () => {
+    const track = { stop: vi.fn() }
+    getUserMedia.mockResolvedValue(fakeStream([track]))
+    const { result } = renderHook(() => useAudioRecorder())
+
+    await act(async () => {
+      await result.current.start()
+    })
+    act(() => {
+      result.current.cancel()
+    })
+    expect(result.current.status).toBe('idle')
+    expect(result.current.stream).toBeNull()
+    expect(track.stop).toHaveBeenCalled()
+  })
+
+  it('rethrows a permission denial and returns to idle', async () => {
+    getUserMedia.mockRejectedValue(new Error('Permission denied'))
+    const { result } = renderHook(() => useAudioRecorder())
+
+    await expect(
+      act(async () => {
+        await result.current.start()
+      }),
+    ).rejects.toThrow('Permission denied')
+    expect(result.current.status).toBe('idle')
+  })
+
+  it('a cancel during the permission prompt releases the stream it resolves into', async () => {
+    const track = { stop: vi.fn() }
+    let release: (stream: MediaStream) => void = () => {}
+    getUserMedia.mockImplementation(
+      () =>
+        new Promise<MediaStream>((resolve) => {
+          release = resolve
+        }),
+    )
+    const { result } = renderHook(() => useAudioRecorder())
+
+    let pending: Promise<void> = Promise.resolve()
+    act(() => {
+      pending = result.current.start()
+    })
+    expect(result.current.status).toBe('requesting')
+    act(() => {
+      result.current.cancel()
+    })
+    await act(async () => {
+      release(fakeStream([track]))
+      await pending
+    })
+    expect(track.stop).toHaveBeenCalled()
+    expect(result.current.status).toBe('idle')
+    expect(FakeMediaRecorder.instances).toHaveLength(0)
+  })
+
+  it('unmount releases the microphone', async () => {
+    const track = { stop: vi.fn() }
+    getUserMedia.mockResolvedValue(fakeStream([track]))
+    const { result, unmount } = renderHook(() => useAudioRecorder())
+
+    await act(async () => {
+      await result.current.start()
+    })
+    unmount()
+    expect(track.stop).toHaveBeenCalled()
+  })
+})
+
+describe('isRecordingSupported', () => {
+  it('requires both MediaRecorder and getUserMedia', () => {
+    expect(isRecordingSupported()).toBe(true)
+    vi.stubGlobal('navigator', {})
+    expect(isRecordingSupported()).toBe(false)
+  })
+})

--- a/apps/desktop/src/hooks/use-audio-recorder.ts
+++ b/apps/desktop/src/hooks/use-audio-recorder.ts
@@ -16,6 +16,13 @@ export interface RecorderResult {
   durationMs: number
 }
 
+export interface UseAudioRecorderOptions {
+  /** Auto-stop guard: `onMaxDuration` fires once when a recording reaches this. */
+  maxDurationMs?: number
+  /** Called when the cap is hit — the host decides what stopping means. */
+  onMaxDuration?: () => void
+}
+
 export interface UseAudioRecorderValue {
   status: RecorderStatus
   /** Live while recording; 0 otherwise. */
@@ -57,7 +64,7 @@ export function isRecordingSupported(): boolean {
   )
 }
 
-export function useAudioRecorder(): UseAudioRecorderValue {
+export function useAudioRecorder(options: UseAudioRecorderOptions = {}): UseAudioRecorderValue {
   const [status, setStatus] = useState<RecorderStatus>('idle')
   const [elapsedMs, setElapsedMs] = useState(0)
   const [stream, setStream] = useState<MediaStream | null>(null)
@@ -67,6 +74,11 @@ export function useAudioRecorder(): UseAudioRecorderValue {
   const chunksRef = useRef<Blob[]>([])
   const startedAtRef = useRef(0)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const maxTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Read at fire time, not captured at start — the host's callback identity
+  // changes across renders.
+  const optionsRef = useRef(options)
+  optionsRef.current = options
   // Bumped by cancel/unmount so an in-flight getUserMedia resolves into a dead
   // session and releases the mic instead of recording into the void.
   const sessionRef = useRef(0)
@@ -78,6 +90,10 @@ export function useAudioRecorder(): UseAudioRecorderValue {
     if (intervalRef.current !== null) {
       clearInterval(intervalRef.current)
       intervalRef.current = null
+    }
+    if (maxTimeoutRef.current !== null) {
+      clearTimeout(maxTimeoutRef.current)
+      maxTimeoutRef.current = null
     }
     for (const track of streamRef.current?.getTracks() ?? []) {
       track.stop()
@@ -124,6 +140,12 @@ export function useAudioRecorder(): UseAudioRecorderValue {
     intervalRef.current = setInterval(() => {
       setElapsedMs(Date.now() - startedAtRef.current)
     }, ELAPSED_TICK_MS)
+    const maxDurationMs = optionsRef.current.maxDurationMs
+    if (maxDurationMs !== undefined) {
+      maxTimeoutRef.current = setTimeout(() => {
+        optionsRef.current.onMaxDuration?.()
+      }, maxDurationMs)
+    }
     setStream(input)
     setStatus('recording')
   }, [])

--- a/apps/desktop/src/hooks/use-audio-recorder.ts
+++ b/apps/desktop/src/hooks/use-audio-recorder.ts
@@ -1,0 +1,164 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/**
+ * Microphone recording for audio memos: stream acquisition, the MediaRecorder
+ * lifecycle, and elapsed time — nothing else. The waveform taps the exposed
+ * stream itself, and transcription belongs to the audio-memo provider, so this
+ * stays testable with two small global stubs.
+ */
+
+export type RecorderStatus = 'idle' | 'requesting' | 'recording'
+
+export interface RecorderResult {
+  blob: Blob
+  /** The container the recorder actually produced (codec parameters intact). */
+  mimeType: string
+  durationMs: number
+}
+
+export interface UseAudioRecorderValue {
+  status: RecorderStatus
+  /** Live while recording; 0 otherwise. */
+  elapsedMs: number
+  /** The live input stream, for waveform visualization. */
+  stream: MediaStream | null
+  /** Ask for the microphone and start recording. Rejects when access is denied. */
+  start: () => Promise<void>
+  /** Stop and assemble the recording — `null` for one too short to be a memo. */
+  stop: () => Promise<RecorderResult | null>
+  /** Stop and discard everything. */
+  cancel: () => void
+}
+
+/**
+ * Preference order matters per platform: Chrome/WebView2 take the opus-in-webm
+ * entries; WKWebView supports none of them and falls through to `audio/mp4`
+ * (AAC). Both containers are accepted by the transcription providers.
+ */
+const MIME_CANDIDATES = ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4']
+
+/** Below this a recording is a misclick, not a memo. */
+const MIN_DURATION_MS = 500
+
+const ELAPSED_TICK_MS = 200
+
+const FALLBACK_MIME_TYPE = 'audio/mp4'
+
+function pickMimeType(): string | undefined {
+  return MIME_CANDIDATES.find((candidate) => MediaRecorder.isTypeSupported(candidate))
+}
+
+/** True when the platform exposes the recording APIs this hook needs. */
+export function isRecordingSupported(): boolean {
+  return (
+    typeof MediaRecorder !== 'undefined' &&
+    typeof navigator !== 'undefined' &&
+    typeof navigator.mediaDevices?.getUserMedia === 'function'
+  )
+}
+
+export function useAudioRecorder(): UseAudioRecorderValue {
+  const [status, setStatus] = useState<RecorderStatus>('idle')
+  const [elapsedMs, setElapsedMs] = useState(0)
+  const [stream, setStream] = useState<MediaStream | null>(null)
+
+  const recorderRef = useRef<MediaRecorder | null>(null)
+  const streamRef = useRef<MediaStream | null>(null)
+  const chunksRef = useRef<Blob[]>([])
+  const startedAtRef = useRef(0)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  // Bumped by cancel/unmount so an in-flight getUserMedia resolves into a dead
+  // session and releases the mic instead of recording into the void.
+  const sessionRef = useRef(0)
+
+  const teardown = useCallback((): void => {
+    sessionRef.current += 1
+    recorderRef.current = null
+    chunksRef.current = []
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+    for (const track of streamRef.current?.getTracks() ?? []) {
+      track.stop()
+    }
+    streamRef.current = null
+    setStream(null)
+    setElapsedMs(0)
+    setStatus('idle')
+  }, [])
+
+  const start = useCallback(async (): Promise<void> => {
+    if (recorderRef.current !== null || streamRef.current !== null) {
+      return
+    }
+    const session = sessionRef.current
+    setStatus('requesting')
+    let input: MediaStream
+    try {
+      input = await navigator.mediaDevices.getUserMedia({ audio: true })
+    } catch (cause) {
+      setStatus('idle')
+      throw cause
+    }
+    if (sessionRef.current !== session) {
+      for (const track of input.getTracks()) {
+        track.stop()
+      }
+      return
+    }
+
+    const mimeType = pickMimeType()
+    const recorder = new MediaRecorder(input, mimeType ? { mimeType } : undefined)
+    chunksRef.current = []
+    recorder.ondataavailable = (event: BlobEvent) => {
+      if (event.data.size > 0) {
+        chunksRef.current.push(event.data)
+      }
+    }
+    recorder.start()
+
+    recorderRef.current = recorder
+    streamRef.current = input
+    startedAtRef.current = Date.now()
+    intervalRef.current = setInterval(() => {
+      setElapsedMs(Date.now() - startedAtRef.current)
+    }, ELAPSED_TICK_MS)
+    setStream(input)
+    setStatus('recording')
+  }, [])
+
+  const stop = useCallback(async (): Promise<RecorderResult | null> => {
+    const recorder = recorderRef.current
+    if (recorder === null) {
+      teardown()
+      return null
+    }
+    const durationMs = Date.now() - startedAtRef.current
+    await new Promise<void>((resolve) => {
+      recorder.onstop = () => resolve()
+      recorder.stop()
+    })
+    const mimeType = recorder.mimeType || pickMimeType() || FALLBACK_MIME_TYPE
+    const blob = new Blob(chunksRef.current, { type: mimeType })
+    teardown()
+    if (durationMs < MIN_DURATION_MS || blob.size === 0) {
+      return null
+    }
+    return { blob, mimeType, durationMs }
+  }, [teardown])
+
+  const cancel = useCallback((): void => {
+    const recorder = recorderRef.current
+    if (recorder !== null && recorder.state !== 'inactive') {
+      recorder.onstop = null
+      recorder.stop()
+    }
+    teardown()
+  }, [teardown])
+
+  // Never leave the mic open past unmount.
+  useEffect(() => cancel, [cancel])
+
+  return { status, elapsedMs, stream, start, stop, cancel }
+}

--- a/apps/desktop/src/hooks/use-audio-recorder.ts
+++ b/apps/desktop/src/hooks/use-audio-recorder.ts
@@ -178,7 +178,13 @@ export function useAudioRecorder(options: UseAudioRecorderOptions = {}): UseAudi
       const durationMs = Date.now() - startedAtRef.current
       await new Promise<void>((resolve) => {
         recorder.onstop = () => resolve()
-        recorder.stop()
+        if (recorder.state === 'inactive') {
+          // Already stopped (a cancel raced us): its onstop may never fire,
+          // and stop() on an inactive recorder throws — settle immediately.
+          resolve()
+        } else {
+          recorder.stop()
+        }
       })
       const mimeType = recorder.mimeType || pickMimeType() || FALLBACK_MIME_TYPE
       const blob = new Blob(chunksRef.current, { type: mimeType })

--- a/apps/desktop/src/hooks/use-audio-recorder.ts
+++ b/apps/desktop/src/hooks/use-audio-recorder.ts
@@ -150,24 +150,38 @@ export function useAudioRecorder(options: UseAudioRecorderOptions = {}): UseAudi
     setStatus('recording')
   }, [])
 
-  const stop = useCallback(async (): Promise<RecorderResult | null> => {
+  const stopPromiseRef = useRef<Promise<RecorderResult | null> | null>(null)
+
+  const stop = useCallback((): Promise<RecorderResult | null> => {
+    // Concurrent stops (a click racing the collapse handler or the duration
+    // cap) share one in-flight promise: a second MediaRecorder.stop() would
+    // throw and replace the first caller's onstop resolver, stranding it.
+    if (stopPromiseRef.current !== null) {
+      return stopPromiseRef.current
+    }
     const recorder = recorderRef.current
     if (recorder === null) {
       teardown()
-      return null
+      return Promise.resolve(null)
     }
-    const durationMs = Date.now() - startedAtRef.current
-    await new Promise<void>((resolve) => {
-      recorder.onstop = () => resolve()
-      recorder.stop()
+    const stopped = (async (): Promise<RecorderResult | null> => {
+      const durationMs = Date.now() - startedAtRef.current
+      await new Promise<void>((resolve) => {
+        recorder.onstop = () => resolve()
+        recorder.stop()
+      })
+      const mimeType = recorder.mimeType || pickMimeType() || FALLBACK_MIME_TYPE
+      const blob = new Blob(chunksRef.current, { type: mimeType })
+      teardown()
+      if (durationMs < MIN_DURATION_MS || blob.size === 0) {
+        return null
+      }
+      return { blob, mimeType, durationMs }
+    })().finally(() => {
+      stopPromiseRef.current = null
     })
-    const mimeType = recorder.mimeType || pickMimeType() || FALLBACK_MIME_TYPE
-    const blob = new Blob(chunksRef.current, { type: mimeType })
-    teardown()
-    if (durationMs < MIN_DURATION_MS || blob.size === 0) {
-      return null
-    }
-    return { blob, mimeType, durationMs }
+    stopPromiseRef.current = stopped
+    return stopped
   }, [teardown])
 
   const cancel = useCallback((): void => {

--- a/apps/desktop/src/hooks/use-audio-recorder.ts
+++ b/apps/desktop/src/hooks/use-audio-recorder.ts
@@ -82,9 +82,13 @@ export function useAudioRecorder(options: UseAudioRecorderOptions = {}): UseAudi
   // Bumped by cancel/unmount so an in-flight getUserMedia resolves into a dead
   // session and releases the mic instead of recording into the void.
   const sessionRef = useRef(0)
+  // Guards start()'s await gap: a second start() arriving while getUserMedia
+  // is pending must not acquire a second stream and orphan the first.
+  const requestingRef = useRef(false)
 
   const teardown = useCallback((): void => {
     sessionRef.current += 1
+    requestingRef.current = false
     recorderRef.current = null
     chunksRef.current = []
     if (intervalRef.current !== null) {
@@ -105,24 +109,30 @@ export function useAudioRecorder(options: UseAudioRecorderOptions = {}): UseAudi
   }, [])
 
   const start = useCallback(async (): Promise<void> => {
-    if (recorderRef.current !== null || streamRef.current !== null) {
+    if (requestingRef.current || recorderRef.current !== null || streamRef.current !== null) {
       return
     }
+    requestingRef.current = true
     const session = sessionRef.current
     setStatus('requesting')
     let input: MediaStream
     try {
       input = await navigator.mediaDevices.getUserMedia({ audio: true })
     } catch (cause) {
-      setStatus('idle')
+      if (sessionRef.current === session) {
+        requestingRef.current = false
+        setStatus('idle')
+      }
       throw cause
     }
     if (sessionRef.current !== session) {
+      // Cancelled while pending; a newer start() may own requestingRef now.
       for (const track of input.getTracks()) {
         track.stop()
       }
       return
     }
+    requestingRef.current = false
 
     const mimeType = pickMimeType()
     const recorder = new MediaRecorder(input, mimeType ? { mimeType } : undefined)

--- a/apps/desktop/src/hooks/use-audio-recorder.ts
+++ b/apps/desktop/src/hooks/use-audio-recorder.ts
@@ -135,14 +135,25 @@ export function useAudioRecorder(options: UseAudioRecorderOptions = {}): UseAudi
     requestingRef.current = false
 
     const mimeType = pickMimeType()
-    const recorder = new MediaRecorder(input, mimeType ? { mimeType } : undefined)
-    chunksRef.current = []
-    recorder.ondataavailable = (event: BlobEvent) => {
-      if (event.data.size > 0) {
-        chunksRef.current.push(event.data)
+    let recorder: MediaRecorder
+    try {
+      recorder = new MediaRecorder(input, mimeType ? { mimeType } : undefined)
+      chunksRef.current = []
+      recorder.ondataavailable = (event: BlobEvent) => {
+        if (event.data.size > 0) {
+          chunksRef.current.push(event.data)
+        }
       }
+      recorder.start()
+    } catch (cause) {
+      // A recorder that failed to set up must not strand the acquired stream
+      // hot or the status at 'requesting'.
+      for (const track of input.getTracks()) {
+        track.stop()
+      }
+      setStatus('idle')
+      throw cause
     }
-    recorder.start()
 
     recorderRef.current = recorder
     streamRef.current = input

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -43,6 +43,7 @@ function fakeContext(overrides?: Partial<CommandContext>) {
     forward: vi.fn(),
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
+    toggleAudioMemo: vi.fn(),
     generation: () => 7,
     openPalette: vi.fn(),
     enableSemanticSearch: vi.fn(),
@@ -78,6 +79,8 @@ describe('app commands', () => {
     expect(context.toggleTheme).toHaveBeenCalled()
     await command('sidebar.toggle').run(context)
     expect(context.toggleSidebar).toHaveBeenCalled()
+    await command('audioMemo.toggle').run(context)
+    expect(context.toggleAudioMemo).toHaveBeenCalled()
   })
 
   it('settings.open navigates to the settings screen', async () => {

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -120,6 +120,15 @@ const APP_COMMANDS: AppCommand[] = [
     },
   },
   {
+    id: 'audioMemo.toggle',
+    title: 'Record audio memo',
+    keywords: ['voice', 'mic', 'dictate', 'transcribe', 'speech', 'capture'],
+    // Starts a memo (or stops-and-saves the one recording). No default
+    // keybinding: the palette keeps it keyboard-reachable without spending a
+    // shortcut.
+    run: (context) => context.toggleAudioMemo(),
+  },
+  {
     id: 'theme.toggle',
     title: 'Toggle theme',
     keywords: ['dark', 'light', 'appearance'],

--- a/apps/desktop/src/lib/commands/registry.test.ts
+++ b/apps/desktop/src/lib/commands/registry.test.ts
@@ -14,6 +14,7 @@ function fakeContext(overrides?: Partial<CommandContext>): CommandContext {
     forward: vi.fn(),
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
+    toggleAudioMemo: vi.fn(),
     generation: () => 1,
     openPalette: vi.fn(),
     enableSemanticSearch: vi.fn(),

--- a/apps/desktop/src/lib/commands/types.ts
+++ b/apps/desktop/src/lib/commands/types.ts
@@ -16,6 +16,8 @@ export interface CommandContext {
   toggleTheme: () => void
   /** Collapse/expand the workspace sidebar. */
   toggleSidebar: () => void
+  /** Start an audio memo, or stop-and-save the one recording. */
+  toggleAudioMemo: () => void
   /**
    * The open **index session** generation (`index_open`), or null when none —
    * what index/embedding commands echo. File writes (`note_write`) take

--- a/apps/desktop/src/providers/audio-memo-provider.test.tsx
+++ b/apps/desktop/src/providers/audio-memo-provider.test.tsx
@@ -289,6 +289,46 @@ describe('AudioMemoProvider', () => {
     await waitFor(() => expect(failOperation).toHaveBeenCalledWith('provider down'))
   })
 
+  it('a parked error never invisibly blocks recording: toggle surfaces, then clears it', async () => {
+    saveAudioMemo.mockResolvedValue({ ok: false, message: 'provider down', resume: null })
+    const { result, rerender } = renderHook(() => useAudioMemo(), { wrapper })
+
+    // Fail a save, then collapse — the error popover unmounts with the mic.
+    await act(async () => {
+      result.current.toggle()
+    })
+    await act(async () => {
+      result.current.toggle()
+    })
+    await waitFor(() => expect(result.current.phase).toBe('error'))
+    sidebarState.collapsed = true
+    await act(async () => {
+      rerender()
+    })
+
+    // Collapsed: toggle re-surfaces the error instead of doing nothing.
+    toggleSidebar.mockClear()
+    await act(async () => {
+      result.current.toggle()
+    })
+    expect(toggleSidebar).toHaveBeenCalled()
+    expect(result.current.phase).toBe('error')
+
+    // Visible: toggle acknowledges the error; the next one records.
+    sidebarState.collapsed = false
+    await act(async () => {
+      rerender()
+    })
+    await act(async () => {
+      result.current.toggle()
+    })
+    expect(result.current.phase).toBe('idle')
+    await act(async () => {
+      result.current.toggle()
+    })
+    expect(result.current.phase).toBe('recording')
+  })
+
   it('starting from a collapsed sidebar expands it first', async () => {
     sidebarState.collapsed = true
     const { result } = renderHook(() => useAudioMemo(), { wrapper })

--- a/apps/desktop/src/providers/audio-memo-provider.test.tsx
+++ b/apps/desktop/src/providers/audio-memo-provider.test.tsx
@@ -20,6 +20,8 @@ const recorderControls = vi.hoisted(() => ({
   /** Park stop() until releaseStop, simulating MediaRecorder's async onstop. */
   holdStop: false,
   releaseStop: () => {},
+  /** Make start() reject like a denied getUserMedia. */
+  failStart: null as DOMException | null,
   options: null as { maxDurationMs?: number; onMaxDuration?: () => void } | null,
 }))
 
@@ -41,6 +43,9 @@ vi.mock('@/hooks/use-audio-recorder', () => ({
       stream: null,
       start: async () => {
         recorderControls.startSpy()
+        if (recorderControls.failStart !== null) {
+          throw recorderControls.failStart
+        }
         setStatus(recorderControls.holdStart ? 'requesting' : 'recording')
       },
       stop: async () => {
@@ -101,6 +106,7 @@ beforeEach(() => {
   recorderControls.supported = true
   recorderControls.holdStart = false
   recorderControls.holdStop = false
+  recorderControls.failStart = null
   recorderControls.options = null
   sidebarState.collapsed = false
   SETTINGS.current = {
@@ -247,6 +253,36 @@ describe('AudioMemoProvider', () => {
     })
     await waitFor(() => expect(result.current.phase).toBe('idle'))
     expect(saveAudioMemo).toHaveBeenCalledTimes(1)
+  })
+
+  it('a second toggle during the permission prompt aborts the request', async () => {
+    recorderControls.holdStart = true
+    const { result } = renderHook(() => useAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    expect(result.current.phase).toBe('requesting')
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    expect(recorderControls.cancelSpy).toHaveBeenCalled()
+    expect(result.current.phase).toBe('idle')
+  })
+
+  it('a denied microphone maps to platform-appropriate guidance', async () => {
+    recorderControls.failStart = new DOMException('denied', 'NotAllowedError')
+    const { result } = renderHook(() => useAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+
+    await waitFor(() => expect(result.current.phase).toBe('error'))
+    // jsdom is not a Macintosh user agent — the copy must not name macOS paths.
+    expect(result.current.error).toMatch(/system settings/i)
+    expect(result.current.error).not.toMatch(/Privacy & Security/)
   })
 
   it('collapsing the sidebar during the permission prompt abandons the request', async () => {

--- a/apps/desktop/src/providers/audio-memo-provider.test.tsx
+++ b/apps/desktop/src/providers/audio-memo-provider.test.tsx
@@ -15,6 +15,8 @@ const recorderControls = vi.hoisted(() => ({
   cancelSpy: vi.fn(),
   stopResult: null as { blob: Blob; mimeType: string; durationMs: number } | null,
   supported: true,
+  /** Park start() at 'requesting', simulating an open OS permission prompt. */
+  holdStart: false,
   options: null as { maxDurationMs?: number; onMaxDuration?: () => void } | null,
 }))
 
@@ -36,7 +38,7 @@ vi.mock('@/hooks/use-audio-recorder', () => ({
       stream: null,
       start: async () => {
         recorderControls.startSpy()
-        setStatus('recording')
+        setStatus(recorderControls.holdStart ? 'requesting' : 'recording')
       },
       stop: async () => {
         recorderControls.stopSpy()
@@ -89,6 +91,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   recorderControls.stopResult = RECORDING
   recorderControls.supported = true
+  recorderControls.holdStart = false
   recorderControls.options = null
   sidebarState.collapsed = false
   SETTINGS.current = {
@@ -214,6 +217,61 @@ describe('AudioMemoProvider', () => {
     })
 
     await waitFor(() => expect(saveAudioMemo).toHaveBeenCalled())
+  })
+
+  it('collapsing the sidebar during the permission prompt abandons the request', async () => {
+    recorderControls.holdStart = true
+    const { result, rerender } = renderHook(() => useAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    expect(result.current.phase).toBe('requesting')
+
+    sidebarState.collapsed = true
+    await act(async () => {
+      rerender()
+    })
+
+    expect(recorderControls.cancelSpy).toHaveBeenCalled()
+    expect(saveAudioMemo).not.toHaveBeenCalled()
+  })
+
+  it('a second save cannot start while one is in flight', async () => {
+    let release: (outcome: SaveAudioMemoOutcome) => void = () => {}
+    saveAudioMemo
+      .mockResolvedValueOnce({
+        ok: false,
+        message: 'disk full',
+        resume: { kind: 'append', text: 'memo transcript' },
+      })
+      .mockImplementationOnce(
+        () =>
+          new Promise<SaveAudioMemoOutcome>((resolve) => {
+            release = resolve
+          }),
+      )
+    const { result } = renderHook(() => useAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    await act(async () => {
+      result.current.toggle()
+    })
+    await waitFor(() => expect(result.current.phase).toBe('error'))
+
+    // Two rapid retries: only one pipeline may run, or the note gets the
+    // transcript twice.
+    await act(async () => {
+      result.current.retry()
+      result.current.retry()
+    })
+    await act(async () => {
+      release({ ok: true, text: 'memo transcript' })
+    })
+    await waitFor(() => expect(result.current.phase).toBe('idle'))
+    expect(saveAudioMemo).toHaveBeenCalledTimes(2)
   })
 
   it('a failure while the sidebar is collapsed surfaces through operations', async () => {

--- a/apps/desktop/src/providers/audio-memo-provider.test.tsx
+++ b/apps/desktop/src/providers/audio-memo-provider.test.tsx
@@ -17,6 +17,9 @@ const recorderControls = vi.hoisted(() => ({
   supported: true,
   /** Park start() at 'requesting', simulating an open OS permission prompt. */
   holdStart: false,
+  /** Park stop() until releaseStop, simulating MediaRecorder's async onstop. */
+  holdStop: false,
+  releaseStop: () => {},
   options: null as { maxDurationMs?: number; onMaxDuration?: () => void } | null,
 }))
 
@@ -42,6 +45,11 @@ vi.mock('@/hooks/use-audio-recorder', () => ({
       },
       stop: async () => {
         recorderControls.stopSpy()
+        if (recorderControls.holdStop) {
+          await new Promise<void>((resolve) => {
+            recorderControls.releaseStop = resolve
+          })
+        }
         setStatus('idle')
         return recorderControls.stopResult
       },
@@ -92,6 +100,7 @@ beforeEach(() => {
   recorderControls.stopResult = RECORDING
   recorderControls.supported = true
   recorderControls.holdStart = false
+  recorderControls.holdStop = false
   recorderControls.options = null
   sidebarState.collapsed = false
   SETTINGS.current = {
@@ -217,6 +226,27 @@ describe('AudioMemoProvider', () => {
     })
 
     await waitFor(() => expect(saveAudioMemo).toHaveBeenCalled())
+  })
+
+  it('the stop click commits immediately — no recording-phase gap for Esc to cancel in', async () => {
+    recorderControls.holdStop = true
+    const { result } = renderHook(() => useAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    act(() => {
+      void result.current.toggle()
+    })
+    // The recorder's stop hasn't settled, but the phase already left
+    // 'recording' — cancel() is unreachable from the popover.
+    expect(result.current.phase).toBe('transcribing')
+
+    await act(async () => {
+      recorderControls.releaseStop()
+    })
+    await waitFor(() => expect(result.current.phase).toBe('idle'))
+    expect(saveAudioMemo).toHaveBeenCalledTimes(1)
   })
 
   it('collapsing the sidebar during the permission prompt abandons the request', async () => {

--- a/apps/desktop/src/providers/audio-memo-provider.test.tsx
+++ b/apps/desktop/src/providers/audio-memo-provider.test.tsx
@@ -1,11 +1,11 @@
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { useState, type ReactElement, type ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { GraphInfo, Settings } from '@reflect/core'
+import type { GraphInfo, SaveAudioMemoInput, SaveAudioMemoOutcome, Settings } from '@reflect/core'
 
-const getSecret = vi.hoisted(() => vi.fn<(name: string) => Promise<string | null>>())
-const transcribeAudio = vi.hoisted(() => vi.fn<() => Promise<string>>())
-const appendToDailyNote = vi.hoisted(() => vi.fn<() => Promise<void>>())
+const saveAudioMemo = vi.hoisted(() =>
+  vi.fn<(input: SaveAudioMemoInput) => Promise<SaveAudioMemoOutcome>>(),
+)
 const failOperation = vi.hoisted(() => vi.fn<(message: string) => void>())
 const toggleSidebar = vi.hoisted(() => vi.fn())
 
@@ -14,26 +14,25 @@ const recorderControls = vi.hoisted(() => ({
   stopSpy: vi.fn(),
   cancelSpy: vi.fn(),
   stopResult: null as { blob: Blob; mimeType: string; durationMs: number } | null,
-  elapsedMs: 0,
   supported: true,
+  options: null as { maxDurationMs?: number; onMaxDuration?: () => void } | null,
 }))
 
 const sidebarState = vi.hoisted(() => ({ collapsed: false }))
 
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
-  getSecret,
-  transcribeAudio,
-  appendToDailyNote,
+  saveAudioMemo,
 }))
 
 vi.mock('@/hooks/use-audio-recorder', () => ({
   isRecordingSupported: () => recorderControls.supported,
-  useAudioRecorder: () => {
+  useAudioRecorder: (options: { maxDurationMs?: number; onMaxDuration?: () => void }) => {
+    recorderControls.options = options
     const [status, setStatus] = useState<'idle' | 'requesting' | 'recording'>('idle')
     return {
       status,
-      elapsedMs: recorderControls.elapsedMs,
+      elapsedMs: 0,
       stream: null,
       start: async () => {
         recorderControls.startSpy()
@@ -89,22 +88,20 @@ const RECORDING = {
 beforeEach(() => {
   vi.clearAllMocks()
   recorderControls.stopResult = RECORDING
-  recorderControls.elapsedMs = 0
   recorderControls.supported = true
+  recorderControls.options = null
   sidebarState.collapsed = false
   SETTINGS.current = {
     aiModels: [{ id: 'cfg-openai', provider: 'openai', model: 'gpt-5.1', keyHint: 'wxyz1' }],
     defaultAiModelId: 'cfg-openai',
   }
-  getSecret.mockResolvedValue('sk-live-key')
-  transcribeAudio.mockResolvedValue('memo transcript')
-  appendToDailyNote.mockResolvedValue(undefined)
+  saveAudioMemo.mockResolvedValue({ ok: true, text: 'memo transcript' })
 })
 
 afterEach(cleanup)
 
 describe('AudioMemoProvider', () => {
-  it('toggle records, then stops, transcribes with the configured key, and appends to today', async () => {
+  it('toggle records, then stops and hands the recording to the core action', async () => {
     const { result } = renderHook(() => useAudioMemo(), { wrapper })
     expect(result.current.available).toBe(true)
 
@@ -118,23 +115,17 @@ describe('AudioMemoProvider', () => {
     })
     await waitFor(() => expect(result.current.phase).toBe('idle'))
 
-    expect(getSecret).toHaveBeenCalledWith('ai-api-key:cfg-openai')
-    expect(transcribeAudio).toHaveBeenCalledWith(
+    expect(saveAudioMemo).toHaveBeenCalledWith(
       expect.objectContaining({
-        provider: 'openai',
-        apiKey: 'sk-live-key',
-        audio: RECORDING.blob,
-        mimeType: 'audio/mp4',
+        payload: { kind: 'transcribe', audio: RECORDING.blob, mimeType: 'audio/mp4' },
+        models: { models: SETTINGS.current.aiModels, defaultModelId: 'cfg-openai' },
+        date: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        generation: 3,
       }),
     )
-    expect(appendToDailyNote).toHaveBeenCalledWith({
-      date: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
-      text: 'memo transcript',
-      generation: 3,
-    })
   })
 
-  it('a too-short recording is discarded without transcription', async () => {
+  it('a too-short recording is discarded without saving', async () => {
     recorderControls.stopResult = null
     const { result } = renderHook(() => useAudioMemo(), { wrapper })
 
@@ -146,11 +137,14 @@ describe('AudioMemoProvider', () => {
     })
 
     expect(result.current.phase).toBe('idle')
-    expect(transcribeAudio).not.toHaveBeenCalled()
+    expect(saveAudioMemo).not.toHaveBeenCalled()
   })
 
-  it('a transcription failure parks an error whose retry re-transcribes', async () => {
-    transcribeAudio.mockRejectedValueOnce({ kind: 'network', message: 'provider down' })
+  it('a resumable failure parks an error whose retry re-runs the returned step', async () => {
+    const resumePayload = { kind: 'append' as const, text: 'memo transcript' }
+    saveAudioMemo
+      .mockResolvedValueOnce({ ok: false, message: 'disk full', resume: resumePayload })
+      .mockResolvedValueOnce({ ok: true, text: 'memo transcript' })
     const { result } = renderHook(() => useAudioMemo(), { wrapper })
 
     await act(async () => {
@@ -160,42 +154,21 @@ describe('AudioMemoProvider', () => {
       result.current.toggle()
     })
     await waitFor(() => expect(result.current.phase).toBe('error'))
-    expect(result.current.error).toBe('provider down')
+    expect(result.current.error).toBe('disk full')
     expect(result.current.canRetry).toBe(true)
 
     await act(async () => {
       result.current.retry()
     })
     await waitFor(() => expect(result.current.phase).toBe('idle'))
-    expect(transcribeAudio).toHaveBeenCalledTimes(2)
-    expect(appendToDailyNote).toHaveBeenCalledTimes(1)
-  })
-
-  it('an append failure retries the append only — transcription is never paid twice', async () => {
-    appendToDailyNote.mockRejectedValueOnce({ kind: 'io', message: 'disk full' })
-    const { result } = renderHook(() => useAudioMemo(), { wrapper })
-
-    await act(async () => {
-      result.current.toggle()
-    })
-    await act(async () => {
-      result.current.toggle()
-    })
-    await waitFor(() => expect(result.current.phase).toBe('error'))
-
-    await act(async () => {
-      result.current.retry()
-    })
-    await waitFor(() => expect(result.current.phase).toBe('idle'))
-    expect(transcribeAudio).toHaveBeenCalledTimes(1)
-    expect(appendToDailyNote).toHaveBeenCalledTimes(2)
-    expect(appendToDailyNote).toHaveBeenLastCalledWith(
-      expect.objectContaining({ text: 'memo transcript' }),
+    expect(saveAudioMemo).toHaveBeenCalledTimes(2)
+    expect(saveAudioMemo).toHaveBeenLastCalledWith(
+      expect.objectContaining({ payload: resumePayload }),
     )
   })
 
-  it('an empty transcript surfaces as a non-retryable error', async () => {
-    transcribeAudio.mockResolvedValue('')
+  it('a non-resumable failure offers no retry; discard returns to idle', async () => {
+    saveAudioMemo.mockResolvedValue({ ok: false, message: 'came back empty', resume: null })
     const { result } = renderHook(() => useAudioMemo(), { wrapper })
 
     await act(async () => {
@@ -206,12 +179,25 @@ describe('AudioMemoProvider', () => {
     })
     await waitFor(() => expect(result.current.phase).toBe('error'))
     expect(result.current.canRetry).toBe(false)
-    expect(appendToDailyNote).not.toHaveBeenCalled()
 
     act(() => {
       result.current.discard()
     })
     expect(result.current.phase).toBe('idle')
+  })
+
+  it('arms the recorder cap and saves when it fires', async () => {
+    const { result } = renderHook(() => useAudioMemo(), { wrapper })
+    expect(recorderControls.options?.maxDurationMs).toBe(10 * 60_000)
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    await act(async () => {
+      recorderControls.options?.onMaxDuration?.()
+    })
+
+    await waitFor(() => expect(saveAudioMemo).toHaveBeenCalled())
   })
 
   it('collapsing the sidebar mid-recording stops and saves', async () => {
@@ -227,11 +213,11 @@ describe('AudioMemoProvider', () => {
       rerender()
     })
 
-    await waitFor(() => expect(appendToDailyNote).toHaveBeenCalled())
+    await waitFor(() => expect(saveAudioMemo).toHaveBeenCalled())
   })
 
   it('a failure while the sidebar is collapsed surfaces through operations', async () => {
-    transcribeAudio.mockRejectedValueOnce({ kind: 'network', message: 'provider down' })
+    saveAudioMemo.mockResolvedValue({ ok: false, message: 'provider down', resume: null })
     const { result, rerender } = renderHook(() => useAudioMemo(), { wrapper })
 
     await act(async () => {
@@ -288,6 +274,6 @@ describe('AudioMemoProvider', () => {
 
     expect(result.current.phase).toBe('idle')
     expect(recorderControls.cancelSpy).toHaveBeenCalled()
-    expect(transcribeAudio).not.toHaveBeenCalled()
+    expect(saveAudioMemo).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/providers/audio-memo-provider.test.tsx
+++ b/apps/desktop/src/providers/audio-memo-provider.test.tsx
@@ -1,0 +1,293 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { useState, type ReactElement, type ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GraphInfo, Settings } from '@reflect/core'
+
+const getSecret = vi.hoisted(() => vi.fn<(name: string) => Promise<string | null>>())
+const transcribeAudio = vi.hoisted(() => vi.fn<() => Promise<string>>())
+const appendToDailyNote = vi.hoisted(() => vi.fn<() => Promise<void>>())
+const failOperation = vi.hoisted(() => vi.fn<(message: string) => void>())
+const toggleSidebar = vi.hoisted(() => vi.fn())
+
+const recorderControls = vi.hoisted(() => ({
+  startSpy: vi.fn(),
+  stopSpy: vi.fn(),
+  cancelSpy: vi.fn(),
+  stopResult: null as { blob: Blob; mimeType: string; durationMs: number } | null,
+  elapsedMs: 0,
+  supported: true,
+}))
+
+const sidebarState = vi.hoisted(() => ({ collapsed: false }))
+
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  getSecret,
+  transcribeAudio,
+  appendToDailyNote,
+}))
+
+vi.mock('@/hooks/use-audio-recorder', () => ({
+  isRecordingSupported: () => recorderControls.supported,
+  useAudioRecorder: () => {
+    const [status, setStatus] = useState<'idle' | 'requesting' | 'recording'>('idle')
+    return {
+      status,
+      elapsedMs: recorderControls.elapsedMs,
+      stream: null,
+      start: async () => {
+        recorderControls.startSpy()
+        setStatus('recording')
+      },
+      stop: async () => {
+        recorderControls.stopSpy()
+        setStatus('idle')
+        return recorderControls.stopResult
+      },
+      cancel: () => {
+        recorderControls.cancelSpy()
+        setStatus('idle')
+      },
+    }
+  },
+}))
+
+const SETTINGS = vi.hoisted(() => ({
+  current: {
+    aiModels: [{ id: 'cfg-openai', provider: 'openai', model: 'gpt-5.1', keyHint: 'wxyz1' }],
+    defaultAiModelId: 'cfg-openai',
+  },
+}))
+
+vi.mock('@/providers/settings-provider', () => ({
+  useSettings: () => ({ settings: SETTINGS.current as unknown as Settings }),
+}))
+vi.mock('@/providers/sidebar-provider', () => ({
+  useSidebar: () => ({ collapsed: sidebarState.collapsed, toggleSidebar }),
+}))
+vi.mock('@/lib/provider-fetch', () => ({
+  providerFetch: vi.fn(),
+}))
+vi.mock('@/lib/operations', () => ({
+  startOperation: () => ({ progress: vi.fn(), done: vi.fn(), fail: failOperation }),
+}))
+
+const { AudioMemoProvider, useAudioMemo } = await import('./audio-memo-provider')
+
+const GRAPH: GraphInfo = { root: '/notes', name: 'Notes', cloudSync: null, generation: 3 }
+
+function wrapper({ children }: { children: ReactNode }): ReactElement {
+  return <AudioMemoProvider graph={GRAPH}>{children}</AudioMemoProvider>
+}
+
+const RECORDING = {
+  blob: new Blob(['audio'], { type: 'audio/mp4' }),
+  mimeType: 'audio/mp4',
+  durationMs: 4000,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  recorderControls.stopResult = RECORDING
+  recorderControls.elapsedMs = 0
+  recorderControls.supported = true
+  sidebarState.collapsed = false
+  SETTINGS.current = {
+    aiModels: [{ id: 'cfg-openai', provider: 'openai', model: 'gpt-5.1', keyHint: 'wxyz1' }],
+    defaultAiModelId: 'cfg-openai',
+  }
+  getSecret.mockResolvedValue('sk-live-key')
+  transcribeAudio.mockResolvedValue('memo transcript')
+  appendToDailyNote.mockResolvedValue(undefined)
+})
+
+afterEach(cleanup)
+
+describe('AudioMemoProvider', () => {
+  it('toggle records, then stops, transcribes with the configured key, and appends to today', async () => {
+    const { result } = renderHook(() => useAudioMemo(), { wrapper })
+    expect(result.current.available).toBe(true)
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    expect(result.current.phase).toBe('recording')
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    await waitFor(() => expect(result.current.phase).toBe('idle'))
+
+    expect(getSecret).toHaveBeenCalledWith('ai-api-key:cfg-openai')
+    expect(transcribeAudio).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'openai',
+        apiKey: 'sk-live-key',
+        audio: RECORDING.blob,
+        mimeType: 'audio/mp4',
+      }),
+    )
+    expect(appendToDailyNote).toHaveBeenCalledWith({
+      date: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      text: 'memo transcript',
+      generation: 3,
+    })
+  })
+
+  it('a too-short recording is discarded without transcription', async () => {
+    recorderControls.stopResult = null
+    const { result } = renderHook(() => useAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    await act(async () => {
+      result.current.toggle()
+    })
+
+    expect(result.current.phase).toBe('idle')
+    expect(transcribeAudio).not.toHaveBeenCalled()
+  })
+
+  it('a transcription failure parks an error whose retry re-transcribes', async () => {
+    transcribeAudio.mockRejectedValueOnce({ kind: 'network', message: 'provider down' })
+    const { result } = renderHook(() => useAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    await act(async () => {
+      result.current.toggle()
+    })
+    await waitFor(() => expect(result.current.phase).toBe('error'))
+    expect(result.current.error).toBe('provider down')
+    expect(result.current.canRetry).toBe(true)
+
+    await act(async () => {
+      result.current.retry()
+    })
+    await waitFor(() => expect(result.current.phase).toBe('idle'))
+    expect(transcribeAudio).toHaveBeenCalledTimes(2)
+    expect(appendToDailyNote).toHaveBeenCalledTimes(1)
+  })
+
+  it('an append failure retries the append only — transcription is never paid twice', async () => {
+    appendToDailyNote.mockRejectedValueOnce({ kind: 'io', message: 'disk full' })
+    const { result } = renderHook(() => useAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    await act(async () => {
+      result.current.toggle()
+    })
+    await waitFor(() => expect(result.current.phase).toBe('error'))
+
+    await act(async () => {
+      result.current.retry()
+    })
+    await waitFor(() => expect(result.current.phase).toBe('idle'))
+    expect(transcribeAudio).toHaveBeenCalledTimes(1)
+    expect(appendToDailyNote).toHaveBeenCalledTimes(2)
+    expect(appendToDailyNote).toHaveBeenLastCalledWith(
+      expect.objectContaining({ text: 'memo transcript' }),
+    )
+  })
+
+  it('an empty transcript surfaces as a non-retryable error', async () => {
+    transcribeAudio.mockResolvedValue('')
+    const { result } = renderHook(() => useAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    await act(async () => {
+      result.current.toggle()
+    })
+    await waitFor(() => expect(result.current.phase).toBe('error'))
+    expect(result.current.canRetry).toBe(false)
+    expect(appendToDailyNote).not.toHaveBeenCalled()
+
+    act(() => {
+      result.current.discard()
+    })
+    expect(result.current.phase).toBe('idle')
+  })
+
+  it('collapsing the sidebar mid-recording stops and saves', async () => {
+    const { result, rerender } = renderHook(() => useAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    expect(result.current.phase).toBe('recording')
+
+    sidebarState.collapsed = true
+    await act(async () => {
+      rerender()
+    })
+
+    await waitFor(() => expect(appendToDailyNote).toHaveBeenCalled())
+  })
+
+  it('a failure while the sidebar is collapsed surfaces through operations', async () => {
+    transcribeAudio.mockRejectedValueOnce({ kind: 'network', message: 'provider down' })
+    const { result, rerender } = renderHook(() => useAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    sidebarState.collapsed = true
+    await act(async () => {
+      rerender()
+    })
+
+    await waitFor(() => expect(failOperation).toHaveBeenCalledWith('provider down'))
+  })
+
+  it('starting from a collapsed sidebar expands it first', async () => {
+    sidebarState.collapsed = true
+    const { result } = renderHook(() => useAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+
+    expect(toggleSidebar).toHaveBeenCalled()
+    expect(recorderControls.startSpy).toHaveBeenCalled()
+  })
+
+  it('is unavailable without an OpenAI or Gemini model, and toggle is a no-op', async () => {
+    SETTINGS.current = {
+      aiModels: [
+        { id: 'claude', provider: 'anthropic', model: 'claude-fable-5', keyHint: 'wxyz1' },
+      ],
+      defaultAiModelId: 'claude',
+    }
+    const { result } = renderHook(() => useAudioMemo(), { wrapper })
+
+    expect(result.current.available).toBe(false)
+    expect(result.current.unavailableReason).toMatch(/OpenAI or Gemini/)
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    expect(result.current.phase).toBe('idle')
+    expect(recorderControls.startSpy).not.toHaveBeenCalled()
+  })
+
+  it('cancel discards the recording without saving', async () => {
+    const { result } = renderHook(() => useAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    act(() => {
+      result.current.cancel()
+    })
+
+    expect(result.current.phase).toBe('idle')
+    expect(recorderControls.cancelSpy).toHaveBeenCalled()
+    expect(transcribeAudio).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/providers/audio-memo-provider.tsx
+++ b/apps/desktop/src/providers/audio-memo-provider.tsx
@@ -66,6 +66,14 @@ const MAX_DURATION_MS = 10 * 60_000
 const NO_PROVIDER_REASON = 'Add an OpenAI or Gemini model in Settings to record audio memos'
 const UNSUPPORTED_REASON = 'Audio recording is not supported on this platform'
 
+/** Same macOS check as `hasMacosTitleBarOverlay` — settings paths differ per OS. */
+function micDeniedMessage(): string {
+  const isMac = typeof navigator !== 'undefined' && navigator.userAgent.includes('Macintosh')
+  return isMac
+    ? 'Microphone access was denied. Allow it in System Settings → Privacy & Security → Microphone.'
+    : 'Microphone access was denied. Allow microphone access for Reflect in your system settings.'
+}
+
 interface AudioMemoProviderProps {
   graph: GraphInfo
   children: ReactNode
@@ -158,7 +166,7 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
     } catch (cause) {
       setError(
         cause instanceof DOMException && cause.name === 'NotAllowedError'
-          ? 'Microphone access was denied. Allow it in System Settings → Privacy & Security → Microphone.'
+          ? micDeniedMessage()
           : errorMessage(cause),
       )
     }
@@ -186,6 +194,10 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
   const toggle = useCallback((): void => {
     if (recorder.status === 'recording') {
       void stopAndSave()
+    } else if (recorder.status === 'requesting') {
+      // A second press while the OS prompt is up aborts the request — the
+      // alternative is a click that visibly does nothing.
+      cancelRecorder()
     } else if (error !== null) {
       // A parked error must never invisibly block recording. Collapsed, the
       // error UI doesn't exist — surface it; visible, it was on screen and a
@@ -199,7 +211,7 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
     } else if (recorder.status === 'idle' && !saving) {
       void start()
     }
-  }, [recorder.status, saving, error, stopAndSave, start, toggleSidebar, discard])
+  }, [recorder.status, saving, error, stopAndSave, cancelRecorder, start, toggleSidebar, discard])
 
   const cancel = useCallback((): void => {
     cancelRecorder()

--- a/apps/desktop/src/providers/audio-memo-provider.tsx
+++ b/apps/desktop/src/providers/audio-memo-provider.tsx
@@ -1,0 +1,283 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from 'react'
+import {
+  aiKeySecretName,
+  appendToDailyNote,
+  errorMessage,
+  getSecret,
+  pickTranscriptionConfig,
+  transcribeAudio,
+  type GraphInfo,
+} from '@reflect/core'
+import { isRecordingSupported, useAudioRecorder } from '@/hooks/use-audio-recorder'
+import { todayIso } from '@/lib/dates'
+import { startOperation } from '@/lib/operations'
+import { providerFetch } from '@/lib/provider-fetch'
+import { useSettings } from '@/providers/settings-provider'
+import { useSidebar } from '@/providers/sidebar-provider'
+
+/**
+ * Audio memos: record speech, transcribe it through the user's own OpenAI or
+ * Gemini key, and append the text to today's daily note. State lives here —
+ * above the sidebar — because the mic button unmounts with the sidebar
+ * (`Mod-\`), and a recording must never outlive its UI invisibly: collapsing
+ * mid-recording stops and saves instead of leaving a hidden hot microphone.
+ *
+ * Recording is allowed even when today's note is `private: true`: only the
+ * freshly captured audio is sent to the provider, never any note content, and
+ * the transcript itself is written locally.
+ */
+
+export type AudioMemoPhase = 'idle' | 'requesting' | 'recording' | 'transcribing' | 'error'
+
+type RetryPayload =
+  | { kind: 'transcribe'; blob: Blob; mimeType: string }
+  | { kind: 'append'; text: string }
+
+interface AudioMemoContextValue {
+  phase: AudioMemoPhase
+  /** Live while recording. */
+  elapsedMs: number
+  /** The live input stream, for the waveform. */
+  stream: MediaStream | null
+  /** False when no OpenAI/Gemini model is configured or the platform can't record. */
+  available: boolean
+  /** Why the mic is disabled (tooltip copy), null when `available`. */
+  unavailableReason: string | null
+  /** The failure shown in the error phase. */
+  error: string | null
+  /** True when retrying the failure is possible without re-recording. */
+  canRetry: boolean
+  /** Idle → start recording (expanding a collapsed sidebar); recording → stop & save. */
+  toggle: () => void
+  /** Discard the in-flight recording without transcribing. */
+  cancel: () => void
+  /** Re-run the failed step — transcription is never paid for twice. */
+  retry: () => void
+  /** Leave the error phase, dropping the failed payload. */
+  discard: () => void
+}
+
+const AudioMemoContext = createContext<AudioMemoContextValue | null>(null)
+
+/** Auto-stop cap: bounds the transcription payload (Gemini inlines base64). */
+const MAX_DURATION_MS = 10 * 60_000
+
+const NO_PROVIDER_REASON = 'Add an OpenAI or Gemini model in Settings to record audio memos'
+const UNSUPPORTED_REASON = 'Audio recording is not supported on this platform'
+
+interface AudioMemoProviderProps {
+  graph: GraphInfo
+  children: ReactNode
+}
+
+export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): ReactElement {
+  const recorder = useAudioRecorder()
+  const { settings } = useSettings()
+  const { collapsed, toggleSidebar } = useSidebar()
+
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [failed, setFailed] = useState<RetryPayload | null>(null)
+
+  const supported = isRecordingSupported()
+  const transcriptionConfig = useMemo(
+    () =>
+      pickTranscriptionConfig({
+        models: settings.aiModels,
+        defaultModelId: settings.defaultAiModelId,
+      }),
+    [settings.aiModels, settings.defaultAiModelId],
+  )
+
+  const collapsedRef = useRef(collapsed)
+  collapsedRef.current = collapsed
+
+  const save = useCallback(
+    async (payload: RetryPayload): Promise<void> => {
+      setSaving(true)
+      setError(null)
+      setFailed(payload)
+      try {
+        let text: string
+        if (payload.kind === 'transcribe') {
+          const config = pickTranscriptionConfig({
+            models: settings.aiModels,
+            defaultModelId: settings.defaultAiModelId,
+          })
+          if (config === null) {
+            setFailed(null)
+            throw new Error('No OpenAI or Gemini model is configured.')
+          }
+          const apiKey = await getSecret(aiKeySecretName(config.id))
+          if (apiKey === null) {
+            setFailed(null)
+            throw new Error(
+              `The API key for the configured ${config.provider} model is missing from the keychain.`,
+            )
+          }
+          text = await transcribeAudio({
+            provider: config.provider,
+            apiKey,
+            audio: payload.blob,
+            mimeType: payload.mimeType,
+            fetchFn: providerFetch,
+          })
+          if (text === '') {
+            setFailed(null)
+            throw new Error('The recording came back empty — nothing to append.')
+          }
+          // Transcription succeeded: a later failure retries the append only.
+          setFailed({ kind: 'append', text })
+        } else {
+          text = payload.text
+        }
+        await appendToDailyNote({ date: todayIso(), text, generation: graph.generation })
+        setFailed(null)
+      } catch (cause) {
+        const message = errorMessage(cause)
+        setError(message)
+        if (collapsedRef.current) {
+          // The mic button (and its popover) unmounted with the sidebar — the
+          // failure must still surface somewhere.
+          startOperation('Saving audio memo').fail(message)
+        }
+        return
+      } finally {
+        setSaving(false)
+      }
+    },
+    [settings.aiModels, settings.defaultAiModelId, graph.generation],
+  )
+
+  const start = useCallback(async (): Promise<void> => {
+    if (!supported || transcriptionConfig === null) {
+      return
+    }
+    setError(null)
+    setFailed(null)
+    if (collapsedRef.current) {
+      // Never record without visible recording UI.
+      toggleSidebar()
+    }
+    try {
+      await recorder.start()
+    } catch (cause) {
+      setError(
+        cause instanceof DOMException && cause.name === 'NotAllowedError'
+          ? 'Microphone access was denied. Allow it in System Settings → Privacy & Security → Microphone.'
+          : errorMessage(cause),
+      )
+    }
+  }, [supported, transcriptionConfig, toggleSidebar, recorder])
+
+  const stopAndSave = useCallback(async (): Promise<void> => {
+    const recording = await recorder.stop()
+    if (recording === null) {
+      return
+    }
+    await save({ kind: 'transcribe', blob: recording.blob, mimeType: recording.mimeType })
+  }, [recorder, save])
+
+  const toggle = useCallback((): void => {
+    if (recorder.status === 'recording') {
+      void stopAndSave()
+    } else if (recorder.status === 'idle' && !saving && error === null) {
+      void start()
+    }
+  }, [recorder.status, saving, error, stopAndSave, start])
+
+  const cancel = useCallback((): void => {
+    recorder.cancel()
+    setError(null)
+    setFailed(null)
+  }, [recorder])
+
+  const retry = useCallback((): void => {
+    if (failed !== null) {
+      void save(failed)
+    }
+  }, [failed, save])
+
+  const discard = useCallback((): void => {
+    setError(null)
+    setFailed(null)
+  }, [])
+
+  // Collapsing the sidebar mid-recording: stop and save rather than keep a
+  // hot microphone with no indicator on screen.
+  useEffect(() => {
+    if (collapsed && recorder.status === 'recording') {
+      void stopAndSave()
+    }
+  }, [collapsed, recorder.status, stopAndSave])
+
+  useEffect(() => {
+    if (recorder.status === 'recording' && recorder.elapsedMs >= MAX_DURATION_MS) {
+      void stopAndSave()
+    }
+  }, [recorder.status, recorder.elapsedMs, stopAndSave])
+
+  const phase: AudioMemoPhase =
+    error !== null
+      ? 'error'
+      : saving
+        ? 'transcribing'
+        : recorder.status === 'idle'
+          ? 'idle'
+          : recorder.status
+
+  const unavailableReason = !supported
+    ? UNSUPPORTED_REASON
+    : transcriptionConfig === null
+      ? NO_PROVIDER_REASON
+      : null
+
+  const value = useMemo<AudioMemoContextValue>(
+    () => ({
+      phase,
+      elapsedMs: recorder.elapsedMs,
+      stream: recorder.stream,
+      available: unavailableReason === null,
+      unavailableReason,
+      error,
+      canRetry: failed !== null,
+      toggle,
+      cancel,
+      retry,
+      discard,
+    }),
+    [
+      phase,
+      recorder.elapsedMs,
+      recorder.stream,
+      unavailableReason,
+      error,
+      failed,
+      toggle,
+      cancel,
+      retry,
+      discard,
+    ],
+  )
+
+  return <AudioMemoContext.Provider value={value}>{children}</AudioMemoContext.Provider>
+}
+
+/** Access the audio-memo surface. Use within an AudioMemoProvider. */
+export function useAudioMemo(): AudioMemoContextValue {
+  const context = useContext(AudioMemoContext)
+  if (!context) {
+    throw new Error('useAudioMemo must be used within an AudioMemoProvider')
+  }
+  return context
+}

--- a/apps/desktop/src/providers/audio-memo-provider.tsx
+++ b/apps/desktop/src/providers/audio-memo-provider.tsx
@@ -165,8 +165,13 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
   }, [supported, transcriptionConfig, toggleSidebar, startRecorder])
 
   const stopAndSave = useCallback(async (): Promise<void> => {
+    // The stop click commits the memo: flip to 'transcribing' before the stop
+    // settles, so an Esc landing in the await gap can't read a lingering
+    // 'recording' phase and cancel a recording the user just saved.
+    setSaving(true)
     const recording = await stopRecorder()
     if (recording === null) {
+      setSaving(false)
       return
     }
     await runSave({ kind: 'transcribe', audio: recording.blob, mimeType: recording.mimeType })

--- a/apps/desktop/src/providers/audio-memo-provider.tsx
+++ b/apps/desktop/src/providers/audio-memo-provider.tsx
@@ -173,13 +173,28 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
   }, [stopRecorder, runSave])
   stopAndSaveRef.current = () => void stopAndSave()
 
+  const discard = useCallback((): void => {
+    setError(null)
+    setResume(null)
+  }, [])
+
   const toggle = useCallback((): void => {
     if (recorder.status === 'recording') {
       void stopAndSave()
-    } else if (recorder.status === 'idle' && !saving && error === null) {
+    } else if (error !== null) {
+      // A parked error must never invisibly block recording. Collapsed, the
+      // error UI doesn't exist — surface it; visible, it was on screen and a
+      // fresh record request acknowledges it (the same click the red mic
+      // anchor handles).
+      if (collapsedRef.current) {
+        toggleSidebar()
+      } else {
+        discard()
+      }
+    } else if (recorder.status === 'idle' && !saving) {
       void start()
     }
-  }, [recorder.status, saving, error, stopAndSave, start])
+  }, [recorder.status, saving, error, stopAndSave, start, toggleSidebar, discard])
 
   const cancel = useCallback((): void => {
     cancelRecorder()
@@ -192,11 +207,6 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
       void runSave(resume)
     }
   }, [resume, runSave])
-
-  const discard = useCallback((): void => {
-    setError(null)
-    setResume(null)
-  }, [])
 
   // Collapsing the sidebar mid-flow: stop-and-save a live recording, and
   // abandon a pending permission request — a grant arriving after the

--- a/apps/desktop/src/providers/audio-memo-provider.tsx
+++ b/apps/desktop/src/providers/audio-memo-provider.tsx
@@ -10,12 +10,10 @@ import {
   type ReactNode,
 } from 'react'
 import {
-  aiKeySecretName,
-  appendToDailyNote,
   errorMessage,
-  getSecret,
   pickTranscriptionConfig,
-  transcribeAudio,
+  saveAudioMemo,
+  type AudioMemoResume,
   type GraphInfo,
 } from '@reflect/core'
 import { isRecordingSupported, useAudioRecorder } from '@/hooks/use-audio-recorder'
@@ -26,22 +24,15 @@ import { useSettings } from '@/providers/settings-provider'
 import { useSidebar } from '@/providers/sidebar-provider'
 
 /**
- * Audio memos: record speech, transcribe it through the user's own OpenAI or
- * Gemini key, and append the text to today's daily note. State lives here —
- * above the sidebar — because the mic button unmounts with the sidebar
- * (`Mod-\`), and a recording must never outlive its UI invisibly: collapsing
- * mid-recording stops and saves instead of leaving a hidden hot microphone.
- *
- * Recording is allowed even when today's note is `private: true`: only the
- * freshly captured audio is sent to the provider, never any note content, and
- * the transcript itself is written locally.
+ * The React surface for audio memos: recording state + the bridge to the
+ * core capture action (`saveAudioMemo`, which owns transcription, privacy,
+ * and the daily-note append). State lives here — above the sidebar — because
+ * the mic button unmounts with the sidebar (`Mod-\`), and a recording must
+ * never outlive its UI invisibly: collapsing mid-recording stops and saves
+ * instead of leaving a hidden hot microphone.
  */
 
 export type AudioMemoPhase = 'idle' | 'requesting' | 'recording' | 'transcribing' | 'error'
-
-type RetryPayload =
-  | { kind: 'transcribe'; blob: Blob; mimeType: string }
-  | { kind: 'append'; text: string }
 
 interface AudioMemoContextValue {
   phase: AudioMemoPhase
@@ -55,7 +46,7 @@ interface AudioMemoContextValue {
   unavailableReason: string | null
   /** The failure shown in the error phase. */
   error: string | null
-  /** True when retrying the failure is possible without re-recording. */
+  /** True when a retry can pick up where the failure left off. */
   canRetry: boolean
   /** Idle → start recording (expanding a collapsed sidebar); recording → stop & save. */
   toggle: () => void
@@ -81,13 +72,18 @@ interface AudioMemoProviderProps {
 }
 
 export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): ReactElement {
-  const recorder = useAudioRecorder()
   const { settings } = useSettings()
   const { collapsed, toggleSidebar } = useSidebar()
 
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [failed, setFailed] = useState<RetryPayload | null>(null)
+  const [resume, setResume] = useState<AudioMemoResume | null>(null)
+
+  const stopAndSaveRef = useRef<() => void>(() => {})
+  const recorder = useAudioRecorder({
+    maxDurationMs: MAX_DURATION_MS,
+    onMaxDuration: () => stopAndSaveRef.current(),
+  })
 
   const supported = isRecordingSupported()
   const transcriptionConfig = useMemo(
@@ -102,56 +98,29 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
   const collapsedRef = useRef(collapsed)
   collapsedRef.current = collapsed
 
-  const save = useCallback(
-    async (payload: RetryPayload): Promise<void> => {
+  const runSave = useCallback(
+    async (payload: AudioMemoResume): Promise<void> => {
       setSaving(true)
       setError(null)
-      setFailed(payload)
       try {
-        let text: string
-        if (payload.kind === 'transcribe') {
-          const config = pickTranscriptionConfig({
-            models: settings.aiModels,
-            defaultModelId: settings.defaultAiModelId,
-          })
-          if (config === null) {
-            setFailed(null)
-            throw new Error('No OpenAI or Gemini model is configured.')
-          }
-          const apiKey = await getSecret(aiKeySecretName(config.id))
-          if (apiKey === null) {
-            setFailed(null)
-            throw new Error(
-              `The API key for the configured ${config.provider} model is missing from the keychain.`,
-            )
-          }
-          text = await transcribeAudio({
-            provider: config.provider,
-            apiKey,
-            audio: payload.blob,
-            mimeType: payload.mimeType,
-            fetchFn: providerFetch,
-          })
-          if (text === '') {
-            setFailed(null)
-            throw new Error('The recording came back empty — nothing to append.')
-          }
-          // Transcription succeeded: a later failure retries the append only.
-          setFailed({ kind: 'append', text })
+        const outcome = await saveAudioMemo({
+          payload,
+          models: { models: settings.aiModels, defaultModelId: settings.defaultAiModelId },
+          date: todayIso(),
+          generation: graph.generation,
+          fetchFn: providerFetch,
+        })
+        if (outcome.ok) {
+          setResume(null)
         } else {
-          text = payload.text
+          setError(outcome.message)
+          setResume(outcome.resume)
+          if (collapsedRef.current) {
+            // The mic button (and its popover) unmounted with the sidebar —
+            // the failure must still surface somewhere.
+            startOperation('Saving audio memo').fail(outcome.message)
+          }
         }
-        await appendToDailyNote({ date: todayIso(), text, generation: graph.generation })
-        setFailed(null)
-      } catch (cause) {
-        const message = errorMessage(cause)
-        setError(message)
-        if (collapsedRef.current) {
-          // The mic button (and its popover) unmounted with the sidebar — the
-          // failure must still surface somewhere.
-          startOperation('Saving audio memo').fail(message)
-        }
-        return
       } finally {
         setSaving(false)
       }
@@ -164,7 +133,7 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
       return
     }
     setError(null)
-    setFailed(null)
+    setResume(null)
     if (collapsedRef.current) {
       // Never record without visible recording UI.
       toggleSidebar()
@@ -185,8 +154,9 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
     if (recording === null) {
       return
     }
-    await save({ kind: 'transcribe', blob: recording.blob, mimeType: recording.mimeType })
-  }, [recorder, save])
+    await runSave({ kind: 'transcribe', audio: recording.blob, mimeType: recording.mimeType })
+  }, [recorder, runSave])
+  stopAndSaveRef.current = () => void stopAndSave()
 
   const toggle = useCallback((): void => {
     if (recorder.status === 'recording') {
@@ -199,18 +169,18 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
   const cancel = useCallback((): void => {
     recorder.cancel()
     setError(null)
-    setFailed(null)
+    setResume(null)
   }, [recorder])
 
   const retry = useCallback((): void => {
-    if (failed !== null) {
-      void save(failed)
+    if (resume !== null) {
+      void runSave(resume)
     }
-  }, [failed, save])
+  }, [resume, runSave])
 
   const discard = useCallback((): void => {
     setError(null)
-    setFailed(null)
+    setResume(null)
   }, [])
 
   // Collapsing the sidebar mid-recording: stop and save rather than keep a
@@ -220,12 +190,6 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
       void stopAndSave()
     }
   }, [collapsed, recorder.status, stopAndSave])
-
-  useEffect(() => {
-    if (recorder.status === 'recording' && recorder.elapsedMs >= MAX_DURATION_MS) {
-      void stopAndSave()
-    }
-  }, [recorder.status, recorder.elapsedMs, stopAndSave])
 
   const phase: AudioMemoPhase =
     error !== null
@@ -250,7 +214,7 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
       available: unavailableReason === null,
       unavailableReason,
       error,
-      canRetry: failed !== null,
+      canRetry: resume !== null,
       toggle,
       cancel,
       retry,
@@ -262,7 +226,7 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
       recorder.stream,
       unavailableReason,
       error,
-      failed,
+      resume,
       toggle,
       cancel,
       retry,

--- a/apps/desktop/src/providers/audio-memo-provider.tsx
+++ b/apps/desktop/src/providers/audio-memo-provider.tsx
@@ -98,8 +98,16 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
   const collapsedRef = useRef(collapsed)
   collapsedRef.current = collapsed
 
+  // Re-entry guard: state-based `saving` flips a render too late to stop a
+  // rapid second Retry, and two pipelines would append the transcript twice.
+  const savingRef = useRef(false)
+
   const runSave = useCallback(
     async (payload: AudioMemoResume): Promise<void> => {
+      if (savingRef.current) {
+        return
+      }
+      savingRef.current = true
       setSaving(true)
       setError(null)
       try {
@@ -122,6 +130,7 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
           }
         }
       } finally {
+        savingRef.current = false
         setSaving(false)
       }
     },
@@ -183,13 +192,20 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
     setResume(null)
   }, [])
 
-  // Collapsing the sidebar mid-recording: stop and save rather than keep a
-  // hot microphone with no indicator on screen.
+  // Collapsing the sidebar mid-flow: stop-and-save a live recording, and
+  // abandon a pending permission request — a grant arriving after the
+  // collapse would otherwise start a recording with no UI mounted.
+  const cancelRecorder = recorder.cancel
   useEffect(() => {
-    if (collapsed && recorder.status === 'recording') {
-      void stopAndSave()
+    if (!collapsed) {
+      return
     }
-  }, [collapsed, recorder.status, stopAndSave])
+    if (recorder.status === 'recording') {
+      void stopAndSave()
+    } else if (recorder.status === 'requesting') {
+      cancelRecorder()
+    }
+  }, [collapsed, recorder.status, cancelRecorder, stopAndSave])
 
   const phase: AudioMemoPhase =
     error !== null

--- a/apps/desktop/src/providers/audio-memo-provider.tsx
+++ b/apps/desktop/src/providers/audio-memo-provider.tsx
@@ -84,6 +84,12 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
     maxDurationMs: MAX_DURATION_MS,
     onMaxDuration: () => stopAndSaveRef.current(),
   })
+  // The hook's functions are stable; the wrapper object is not (elapsed ticks
+  // remint it every render). Callbacks and effects must hang off the
+  // functions, or the collapse effect re-fires on every recording tick.
+  const startRecorder = recorder.start
+  const stopRecorder = recorder.stop
+  const cancelRecorder = recorder.cancel
 
   const supported = isRecordingSupported()
   const transcriptionConfig = useMemo(
@@ -148,7 +154,7 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
       toggleSidebar()
     }
     try {
-      await recorder.start()
+      await startRecorder()
     } catch (cause) {
       setError(
         cause instanceof DOMException && cause.name === 'NotAllowedError'
@@ -156,15 +162,15 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
           : errorMessage(cause),
       )
     }
-  }, [supported, transcriptionConfig, toggleSidebar, recorder])
+  }, [supported, transcriptionConfig, toggleSidebar, startRecorder])
 
   const stopAndSave = useCallback(async (): Promise<void> => {
-    const recording = await recorder.stop()
+    const recording = await stopRecorder()
     if (recording === null) {
       return
     }
     await runSave({ kind: 'transcribe', audio: recording.blob, mimeType: recording.mimeType })
-  }, [recorder, runSave])
+  }, [stopRecorder, runSave])
   stopAndSaveRef.current = () => void stopAndSave()
 
   const toggle = useCallback((): void => {
@@ -176,10 +182,10 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
   }, [recorder.status, saving, error, stopAndSave, start])
 
   const cancel = useCallback((): void => {
-    recorder.cancel()
+    cancelRecorder()
     setError(null)
     setResume(null)
-  }, [recorder])
+  }, [cancelRecorder])
 
   const retry = useCallback((): void => {
     if (resume !== null) {
@@ -195,7 +201,6 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
   // Collapsing the sidebar mid-flow: stop-and-save a live recording, and
   // abandon a pending permission request — a grant arriving after the
   // collapse would otherwise start a recording with no UI mounted.
-  const cancelRecorder = recorder.cancel
   useEffect(() => {
     if (!collapsed) {
       return

--- a/apps/desktop/src/routing/app-shortcuts.test.tsx
+++ b/apps/desktop/src/routing/app-shortcuts.test.tsx
@@ -20,6 +20,9 @@ vi.mock('@/providers/settings-provider', () => ({
     updateSettings: vi.fn(),
   }),
 }))
+vi.mock('@/providers/audio-memo-provider', () => ({
+  useAudioMemo: () => ({ toggle: vi.fn() }),
+}))
 
 registerAppCommands() // production does this in main.tsx
 

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -5,6 +5,7 @@ import { APP_COMMANDS } from '@/lib/commands/app-commands'
 import { runCommand } from '@/lib/commands/registry'
 import { retryFailedEmbeddings } from '@/lib/semantic'
 import type { CommandContext } from '@/lib/commands/types'
+import { useAudioMemo } from '@/providers/audio-memo-provider'
 import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
 import { useSidebar } from '@/providers/sidebar-provider'
@@ -45,6 +46,7 @@ export function useAppShortcuts(): CommandContext {
   const { graph } = useGraph()
   const { openPalette, open: paletteOpen } = usePalette()
   const { toggleSidebar } = useSidebar()
+  const { toggle: toggleAudioMemo } = useAudioMemo()
   const { updateSettings } = useSettings()
 
   // The palette is modal: app shortcuts must not navigate behind its overlay.
@@ -67,6 +69,7 @@ export function useAppShortcuts(): CommandContext {
       forward,
       toggleTheme: () => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark'),
       toggleSidebar,
+      toggleAudioMemo,
       generation: () => generationRef.current,
       openPalette,
       enableSemanticSearch: () => {
@@ -76,7 +79,17 @@ export function useAppShortcuts(): CommandContext {
         void retryFailedEmbeddings()
       },
     }),
-    [navigate, back, forward, resolvedTheme, setTheme, openPalette, toggleSidebar, updateSettings],
+    [
+      navigate,
+      back,
+      forward,
+      resolvedTheme,
+      setTheme,
+      openPalette,
+      toggleSidebar,
+      toggleAudioMemo,
+      updateSettings,
+    ],
   )
 
   useEffect(() => {

--- a/packages/core/src/actions/audio-memo.test.ts
+++ b/packages/core/src/actions/audio-memo.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { appendToDailyNote } from './audio-memo'
+import { readNote, writeNote } from '../graph/commands'
+
+vi.mock('../graph/commands', () => ({
+  readNote: vi.fn(),
+  writeNote: vi.fn(),
+}))
+
+const readNoteMock = vi.mocked(readNote)
+const writeNoteMock = vi.mocked(writeNote)
+
+beforeEach(() => {
+  readNoteMock.mockReset()
+  writeNoteMock.mockReset()
+  writeNoteMock.mockResolvedValue(undefined)
+})
+
+describe('appendToDailyNote', () => {
+  it('appends to the existing daily note, pinned to the generation', async () => {
+    readNoteMock.mockResolvedValue('morning thoughts\n')
+
+    await appendToDailyNote({ date: '2026-06-11', text: 'memo text', generation: 7 })
+
+    expect(readNoteMock).toHaveBeenCalledWith('daily/2026-06-11.md')
+    expect(writeNoteMock).toHaveBeenCalledWith(
+      'daily/2026-06-11.md',
+      'morning thoughts\n\nmemo text\n',
+      7,
+    )
+  })
+
+  it('creates the note when the day has none yet', async () => {
+    readNoteMock.mockRejectedValue({ kind: 'notFound', message: 'no such note' })
+
+    await appendToDailyNote({ date: '2026-06-11', text: 'memo text', generation: 7 })
+
+    expect(writeNoteMock).toHaveBeenCalledWith('daily/2026-06-11.md', 'memo text\n', 7)
+  })
+
+  it('rethrows read failures other than notFound and never writes', async () => {
+    readNoteMock.mockRejectedValue({ kind: 'io', message: 'disk gone' })
+
+    await expect(
+      appendToDailyNote({ date: '2026-06-11', text: 'memo text', generation: 7 }),
+    ).rejects.toMatchObject({ kind: 'io' })
+    expect(writeNoteMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid date before any file access', async () => {
+    await expect(
+      appendToDailyNote({ date: 'not-a-date', text: 'memo text', generation: 7 }),
+    ).rejects.toThrow()
+    expect(readNoteMock).not.toHaveBeenCalled()
+    expect(writeNoteMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/actions/audio-memo.test.ts
+++ b/packages/core/src/actions/audio-memo.test.ts
@@ -1,25 +1,132 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { appendToDailyNote } from './audio-memo'
+import type { AiModelsState } from '../ai/models'
+import { appendToDailyNote, saveAudioMemo, type AudioMemoResume } from './audio-memo'
 import { readNote, writeNote } from '../graph/commands'
+import { transcribeAudio } from '../ai/transcribe'
+import { getSecret } from '../secrets/keychain'
 
 vi.mock('../graph/commands', () => ({
   readNote: vi.fn(),
   writeNote: vi.fn(),
 }))
+vi.mock('../ai/transcribe', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../ai/transcribe')>()),
+  transcribeAudio: vi.fn(),
+}))
+vi.mock('../secrets/keychain', () => ({
+  getSecret: vi.fn(),
+}))
 
 const readNoteMock = vi.mocked(readNote)
 const writeNoteMock = vi.mocked(writeNote)
+const transcribeMock = vi.mocked(transcribeAudio)
+const getSecretMock = vi.mocked(getSecret)
+
+const MODELS: AiModelsState = {
+  models: [{ id: 'cfg-openai', provider: 'openai', model: 'gpt-5.1', keyHint: 'wxyz1' }],
+  defaultModelId: 'cfg-openai',
+}
+
+const RECORDING: AudioMemoResume & { kind: 'transcribe' } = {
+  kind: 'transcribe',
+  audio: new Blob(['audio'], { type: 'audio/mp4' }),
+  mimeType: 'audio/mp4',
+}
+
+function save(payload: AudioMemoResume, models: AiModelsState = MODELS) {
+  return saveAudioMemo({ payload, models, date: '2026-06-11', generation: 3 })
+}
 
 beforeEach(() => {
-  readNoteMock.mockReset()
-  writeNoteMock.mockReset()
+  vi.clearAllMocks()
+  readNoteMock.mockResolvedValue('morning thoughts\n')
   writeNoteMock.mockResolvedValue(undefined)
+  getSecretMock.mockResolvedValue('sk-live-key')
+  transcribeMock.mockResolvedValue('memo transcript')
+})
+
+describe('saveAudioMemo', () => {
+  it('transcribes with the picked entry’s key and appends to the day’s note', async () => {
+    const outcome = await save(RECORDING)
+
+    expect(outcome).toEqual({ ok: true, text: 'memo transcript' })
+    expect(getSecretMock).toHaveBeenCalledWith('ai-api-key:cfg-openai')
+    expect(transcribeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'openai',
+        apiKey: 'sk-live-key',
+        audio: RECORDING.audio,
+        mimeType: 'audio/mp4',
+      }),
+    )
+    expect(writeNoteMock).toHaveBeenCalledWith(
+      'daily/2026-06-11.md',
+      'morning thoughts\n\nmemo transcript\n',
+      3,
+    )
+  })
+
+  it('an append payload skips transcription entirely', async () => {
+    const outcome = await save({ kind: 'append', text: 'already transcribed' })
+
+    expect(outcome).toEqual({ ok: true, text: 'already transcribed' })
+    expect(transcribeMock).not.toHaveBeenCalled()
+    expect(getSecretMock).not.toHaveBeenCalled()
+  })
+
+  it('reports a missing provider as resumable — a retry sees fixed settings', async () => {
+    const outcome = await save(RECORDING, { models: [], defaultModelId: null })
+
+    expect(outcome).toEqual({
+      ok: false,
+      message: 'No OpenAI or Gemini model is configured.',
+      resume: RECORDING,
+    })
+    expect(writeNoteMock).not.toHaveBeenCalled()
+  })
+
+  it('reports a missing keychain entry as resumable', async () => {
+    getSecretMock.mockResolvedValue(null)
+
+    const outcome = await save(RECORDING)
+
+    expect(outcome).toMatchObject({ ok: false, resume: RECORDING })
+    expect(outcome.ok === false && outcome.message).toMatch(/keychain/)
+  })
+
+  it('a transcription failure resumes at the transcribe step', async () => {
+    transcribeMock.mockRejectedValue({ kind: 'network', message: 'provider down' })
+
+    const outcome = await save(RECORDING)
+
+    expect(outcome).toEqual({ ok: false, message: 'provider down', resume: RECORDING })
+  })
+
+  it('an empty transcript is not resumable — retrying silence cannot help', async () => {
+    transcribeMock.mockResolvedValue('')
+
+    const outcome = await save(RECORDING)
+
+    expect(outcome).toMatchObject({ ok: false, resume: null })
+    expect(writeNoteMock).not.toHaveBeenCalled()
+  })
+
+  it('an append failure resumes with the transcript — transcription is never paid twice', async () => {
+    writeNoteMock.mockRejectedValue({ kind: 'io', message: 'disk full' })
+
+    const outcome = await save(RECORDING)
+
+    expect(outcome).toEqual({
+      ok: false,
+      message: 'disk full',
+      resume: { kind: 'append', text: 'memo transcript' },
+    })
+    expect(transcribeMock).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('appendToDailyNote', () => {
   it('appends to the existing daily note, pinned to the generation', async () => {
-    readNoteMock.mockResolvedValue('morning thoughts\n')
-
     await appendToDailyNote({ date: '2026-06-11', text: 'memo text', generation: 7 })
 
     expect(readNoteMock).toHaveBeenCalledWith('daily/2026-06-11.md')

--- a/packages/core/src/actions/audio-memo.ts
+++ b/packages/core/src/actions/audio-memo.ts
@@ -1,12 +1,115 @@
-import { isAppError } from '../errors'
+import { errorMessage, isAppError } from '../errors'
+import { pickTranscriptionConfig, type AiModelsState } from '../ai/models'
+import { aiKeySecretName } from '../ai/secrets'
+import { transcribeAudio } from '../ai/transcribe'
 import { readNote, writeNote } from '../graph/commands'
 import { dailyPath } from '../graph/paths'
 import { appendBlock } from '../markdown/edit'
+import { getSecret } from '../secrets/keychain'
 
 /**
  * Capture actions for audio memos (the first of the `actions/` capture
- * family — Plan 11's link capture will sit alongside).
+ * family — Plan 11's link capture will sit alongside). The whole flow lives
+ * here, not in the UI: record (host) → transcribe (BYOK provider) → append
+ * to today's daily note.
+ *
+ * Privacy: only the freshly captured audio is sent to the provider — never
+ * any note content — and the transcript is written locally, so recording is
+ * allowed even when today's note is `private: true`.
  */
+
+/**
+ * The step to (re-)run. A failure hands back the payload for the step that
+ * failed, so a retry after a successful transcription re-runs the append
+ * only — transcription is never paid for twice.
+ */
+export type AudioMemoResume =
+  | { kind: 'transcribe'; audio: Blob; mimeType: string }
+  | { kind: 'append'; text: string }
+
+/**
+ * Every expected failure is data, not a throw: `resume` is what a retry
+ * should re-run, or `null` when retrying cannot help (an empty transcript).
+ */
+export type SaveAudioMemoOutcome =
+  | { ok: true; text: string }
+  | { ok: false; message: string; resume: AudioMemoResume | null }
+
+export interface SaveAudioMemoInput {
+  /** A fresh recording, or the resume payload from a prior failure. */
+  payload: AudioMemoResume
+  /** The configured-models state — decides the provider and keychain entry. */
+  models: AiModelsState
+  /** The target day (local ISO date) — resolved at save time, not record time. */
+  date: string
+  /** `GraphInfo.generation` — pins the write to the issuing graph. */
+  generation: number
+  /** Host transport for the provider call (the Tauri HTTP plugin's fetch). */
+  fetchFn?: typeof fetch
+}
+
+/** Transcribe + append one audio memo, reporting failures as resumable data. */
+export async function saveAudioMemo(input: SaveAudioMemoInput): Promise<SaveAudioMemoOutcome> {
+  let step = input.payload
+  if (step.kind === 'transcribe') {
+    const transcribed = await transcribeStep(step, input.models, input.fetchFn)
+    if (!transcribed.ok) {
+      return transcribed
+    }
+    step = { kind: 'append', text: transcribed.text }
+  }
+  try {
+    await appendToDailyNote({ date: input.date, text: step.text, generation: input.generation })
+  } catch (cause) {
+    return { ok: false, message: errorMessage(cause), resume: step }
+  }
+  return { ok: true, text: step.text }
+}
+
+type TranscribeStepOutcome =
+  | { ok: true; text: string }
+  | { ok: false; message: string; resume: AudioMemoResume | null }
+
+async function transcribeStep(
+  payload: AudioMemoResume & { kind: 'transcribe' },
+  models: AiModelsState,
+  fetchFn: typeof fetch | undefined,
+): Promise<TranscribeStepOutcome> {
+  // Re-picked on every run (not once at record time): a retry after the user
+  // fixes their model configuration should see the fix.
+  const config = pickTranscriptionConfig(models)
+  if (config === null) {
+    return { ok: false, message: 'No OpenAI or Gemini model is configured.', resume: payload }
+  }
+  const apiKey = await getSecret(aiKeySecretName(config.id))
+  if (apiKey === null) {
+    return {
+      ok: false,
+      message: `The API key for the configured ${config.provider} model is missing from the keychain.`,
+      resume: payload,
+    }
+  }
+  let text: string
+  try {
+    text = await transcribeAudio({
+      provider: config.provider,
+      apiKey,
+      audio: payload.audio,
+      mimeType: payload.mimeType,
+      fetchFn,
+    })
+  } catch (cause) {
+    return { ok: false, message: errorMessage(cause), resume: payload }
+  }
+  if (text === '') {
+    return {
+      ok: false,
+      message: 'The recording came back empty — nothing to append.',
+      resume: null,
+    }
+  }
+  return { ok: true, text }
+}
 
 export interface AppendToDailyNoteInput {
   /** The target day, as a local ISO date (`YYYY-MM-DD`). */

--- a/packages/core/src/actions/audio-memo.ts
+++ b/packages/core/src/actions/audio-memo.ts
@@ -1,0 +1,38 @@
+import { isAppError } from '../errors'
+import { readNote, writeNote } from '../graph/commands'
+import { dailyPath } from '../graph/paths'
+import { appendBlock } from '../markdown/edit'
+
+/**
+ * Capture actions for audio memos (the first of the `actions/` capture
+ * family — Plan 11's link capture will sit alongside).
+ */
+
+export interface AppendToDailyNoteInput {
+  /** The target day, as a local ISO date (`YYYY-MM-DD`). */
+  date: string
+  /** The block to append (an audio-memo transcript). */
+  text: string
+  /** `GraphInfo.generation` — pins the write to the issuing graph. */
+  generation: number
+}
+
+/**
+ * Append `text` to the day's daily note, creating the file when the day has
+ * none yet — capture must never depend on the note already existing. The
+ * write goes straight to disk: the watcher reindexes it, and an open editor
+ * session reconciles it like any external change (clean buffers reload in
+ * place; dirty ones park a conflict rather than being clobbered).
+ */
+export async function appendToDailyNote(input: AppendToDailyNoteInput): Promise<void> {
+  const path = dailyPath(input.date)
+  let source = ''
+  try {
+    source = await readNote(path)
+  } catch (cause) {
+    if (!isAppError(cause) || cause.kind !== 'notFound') {
+      throw cause
+    }
+  }
+  await writeNote(path, appendBlock(source, input.text), input.generation)
+}

--- a/packages/core/src/ai/models.test.ts
+++ b/packages/core/src/ai/models.test.ts
@@ -3,6 +3,7 @@ import type { AiModelConfig } from '../settings/schema'
 import {
   apiKeyHint,
   defaultAiModel,
+  pickTranscriptionConfig,
   withAiModelAdded,
   withAiModelRemoved,
   type AiModelsState,
@@ -67,6 +68,38 @@ describe('withAiModelRemoved', () => {
 
   it('removing the last entry clears the default', () => {
     expect(withAiModelRemoved(state([config({ id: 'a' })], 'a'), 'a')).toEqual(state([], null))
+  })
+})
+
+describe('pickTranscriptionConfig', () => {
+  it('prefers any openai entry over a google default', () => {
+    const models = [
+      config({ id: 'gemini', provider: 'google', model: 'gemini-2.5-flash' }),
+      config({ id: 'oai', provider: 'openai' }),
+    ]
+    expect(pickTranscriptionConfig(state(models, 'gemini'))?.id).toBe('oai')
+  })
+
+  it('prefers the app default among entries of the chosen provider', () => {
+    const models = [config({ id: 'first' }), config({ id: 'second' })]
+    expect(pickTranscriptionConfig(state(models, 'second'))?.id).toBe('second')
+  })
+
+  it('falls back to google when no openai entry exists', () => {
+    const models = [
+      config({ id: 'claude', provider: 'anthropic', model: 'claude-fable-5' }),
+      config({ id: 'gemini', provider: 'google', model: 'gemini-2.5-flash' }),
+    ]
+    expect(pickTranscriptionConfig(state(models, 'claude'))?.id).toBe('gemini')
+  })
+
+  it('returns null when only anthropic entries exist', () => {
+    const models = [config({ id: 'claude', provider: 'anthropic', model: 'claude-fable-5' })]
+    expect(pickTranscriptionConfig(state(models, 'claude'))).toBeNull()
+  })
+
+  it('returns null for the empty list', () => {
+    expect(pickTranscriptionConfig(state([], null))).toBeNull()
   })
 })
 

--- a/packages/core/src/ai/models.ts
+++ b/packages/core/src/ai/models.ts
@@ -66,3 +66,34 @@ export function defaultAiModel(state: AiModelsState): AiModelConfig | null {
     state.models.find((model) => model.id === state.defaultModelId) ?? state.models[0] ?? null
   )
 }
+
+/**
+ * Providers with a speech-to-text path, in preference order (Anthropic has
+ * no audio API).
+ */
+export const TRANSCRIPTION_PROVIDERS = ['openai', 'google'] as const
+
+export type TranscriptionProvider = (typeof TRANSCRIPTION_PROVIDERS)[number]
+
+/** A configured entry known to belong to a transcription-capable provider. */
+export type TranscriptionConfig = AiModelConfig & { provider: TranscriptionProvider }
+
+/**
+ * The configured entry audio transcription should run on: any OpenAI entry
+ * wins over any Google entry, and within a provider the app default wins over
+ * the first. `null` means no capable provider is configured — the feature is
+ * unavailable. The entry only addresses the provider + API key; the
+ * transcription model itself is fixed per provider (see `transcribe.ts`), so
+ * the entry's chat-model choice never transfers.
+ */
+export function pickTranscriptionConfig(state: AiModelsState): TranscriptionConfig | null {
+  for (const provider of TRANSCRIPTION_PROVIDERS) {
+    const candidates = state.models.filter(
+      (model): model is TranscriptionConfig => model.provider === provider,
+    )
+    if (candidates.length > 0) {
+      return candidates.find((model) => model.id === state.defaultModelId) ?? candidates[0]
+    }
+  }
+  return null
+}

--- a/packages/core/src/ai/transcribe.test.ts
+++ b/packages/core/src/ai/transcribe.test.ts
@@ -124,6 +124,29 @@ describe('transcribeAudio (openai)', () => {
       message: 'offline',
     })
   })
+
+  it('bounds every request with a timeout signal', async () => {
+    const signals: (AbortSignal | null | undefined)[] = []
+    const fetchFn: typeof fetch = async (_input, init) => {
+      signals.push(init?.signal)
+      return jsonResponse(200, { text: 'ok' })
+    }
+
+    await transcribeAudio(request({ fetchFn }))
+
+    expect(signals[0]).toBeInstanceOf(AbortSignal)
+  })
+
+  it('maps a stalled connection to a settled network error', async () => {
+    const fetchFn: typeof fetch = async () => {
+      throw new DOMException('The operation timed out.', 'TimeoutError')
+    }
+
+    await expect(transcribeAudio(request({ fetchFn }))).rejects.toMatchObject({
+      kind: 'network',
+      message: expect.stringContaining('timed out'),
+    })
+  })
 })
 
 describe('transcribeAudio (google)', () => {

--- a/packages/core/src/ai/transcribe.test.ts
+++ b/packages/core/src/ai/transcribe.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  GOOGLE_TRANSCRIPTION_FALLBACK_MODEL,
   GOOGLE_TRANSCRIPTION_MODEL,
   OPENAI_TRANSCRIPTION_FALLBACK_MODEL,
   OPENAI_TRANSCRIPTION_MODEL,
@@ -161,6 +162,35 @@ describe('transcribeAudio (google)', () => {
       contents: { parts: { inline_data?: { mime_type: string } }[] }[]
     }
     expect(payload.contents[0].parts[1].inline_data?.mime_type).toBe('audio/webm')
+  })
+
+  it('falls back to the stable model when the primary one is retired (404)', async () => {
+    const calls: RecordedCall[] = []
+    const fetchFn = recordingFetch(calls, (call) =>
+      call.url.includes(GOOGLE_TRANSCRIPTION_FALLBACK_MODEL)
+        ? geminiResponse('fallback transcript')
+        : jsonResponse(404, { error: { message: 'This model is no longer available.' } }),
+    )
+
+    const text = await transcribeAudio(request({ provider: 'google', fetchFn }))
+
+    expect(text).toBe('fallback transcript')
+    expect(calls).toHaveLength(2)
+    expect(calls[0].url).toContain(GOOGLE_TRANSCRIPTION_MODEL)
+    expect(calls[1].url).toContain(GOOGLE_TRANSCRIPTION_FALLBACK_MODEL)
+  })
+
+  it('does not retry non-404 failures', async () => {
+    const calls: RecordedCall[] = []
+    const fetchFn = recordingFetch(calls, () =>
+      jsonResponse(429, { error: { message: 'quota exhausted' } }),
+    )
+
+    await expect(transcribeAudio(request({ provider: 'google', fetchFn }))).rejects.toMatchObject({
+      kind: 'network',
+      message: expect.stringContaining('quota exhausted'),
+    })
+    expect(calls).toHaveLength(1)
   })
 
   it('returns an empty transcript when no candidates come back', async () => {

--- a/packages/core/src/ai/transcribe.test.ts
+++ b/packages/core/src/ai/transcribe.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest'
+import {
+  GOOGLE_TRANSCRIPTION_MODEL,
+  OPENAI_TRANSCRIPTION_FALLBACK_MODEL,
+  OPENAI_TRANSCRIPTION_MODEL,
+  bytesToBase64,
+  transcribeAudio,
+  type TranscriptionRequest,
+} from './transcribe'
+
+interface RecordedCall {
+  url: string
+  headers: Record<string, string>
+  body: RequestInit['body']
+}
+
+function recordingFetch(
+  calls: RecordedCall[],
+  respond: (call: RecordedCall, index: number) => Response,
+): typeof fetch {
+  return async (input, init) => {
+    const call: RecordedCall = {
+      url: String(input),
+      headers: (init?.headers ?? {}) as Record<string, string>,
+      body: init?.body ?? null,
+    }
+    calls.push(call)
+    return respond(call, calls.length - 1)
+  }
+}
+
+function jsonResponse(status: number, payload: unknown): Response {
+  return new Response(JSON.stringify(payload), { status })
+}
+
+function request(overrides: Partial<TranscriptionRequest>): TranscriptionRequest {
+  return {
+    provider: 'openai',
+    apiKey: 'sk-test',
+    audio: new Blob(['abc'], { type: 'audio/mp4' }),
+    mimeType: 'audio/mp4',
+    ...overrides,
+  }
+}
+
+describe('transcribeAudio (openai)', () => {
+  it('posts multipart with an extension-correct filename and returns the trimmed text', async () => {
+    const calls: RecordedCall[] = []
+    const fetchFn = recordingFetch(calls, () => jsonResponse(200, { text: '  Hello world.  ' }))
+
+    const text = await transcribeAudio(request({ fetchFn }))
+
+    expect(text).toBe('Hello world.')
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe('https://api.openai.com/v1/audio/transcriptions')
+    expect(calls[0].headers.Authorization).toBe('Bearer sk-test')
+    const form = calls[0].body as FormData
+    expect(form.get('model')).toBe(OPENAI_TRANSCRIPTION_MODEL)
+    const file = form.get('file') as File
+    // whisper-1 sniffs by extension: an audio-only MP4 must upload as .m4a.
+    expect(file.name).toBe('memo.m4a')
+  })
+
+  it('names webm recordings .webm', async () => {
+    const calls: RecordedCall[] = []
+    const fetchFn = recordingFetch(calls, () => jsonResponse(200, { text: 'hi' }))
+
+    await transcribeAudio(
+      request({ fetchFn, mimeType: 'audio/webm;codecs=opus', audio: new Blob(['abc']) }),
+    )
+
+    const file = (calls[0].body as FormData).get('file') as File
+    expect(file.name).toBe('memo.webm')
+  })
+
+  it('falls back to whisper-1 only when the primary model is missing on the key', async () => {
+    const calls: RecordedCall[] = []
+    const fetchFn = recordingFetch(calls, (_call, index) =>
+      index === 0
+        ? jsonResponse(404, { error: { message: 'no such model', code: 'model_not_found' } })
+        : jsonResponse(200, { text: 'fallback worked' }),
+    )
+
+    const text = await transcribeAudio(request({ fetchFn }))
+
+    expect(text).toBe('fallback worked')
+    expect(calls).toHaveLength(2)
+    expect((calls[1].body as FormData).get('model')).toBe(OPENAI_TRANSCRIPTION_FALLBACK_MODEL)
+  })
+
+  it('does not retry other request rejections', async () => {
+    const calls: RecordedCall[] = []
+    const fetchFn = recordingFetch(calls, () =>
+      jsonResponse(400, { error: { message: 'Invalid file format.', code: null } }),
+    )
+
+    await expect(transcribeAudio(request({ fetchFn }))).rejects.toMatchObject({
+      kind: 'network',
+      message: expect.stringContaining('Invalid file format.'),
+    })
+    expect(calls).toHaveLength(1)
+  })
+
+  it('reports a rejected key as an auth error', async () => {
+    const fetchFn = recordingFetch([], () => jsonResponse(401, { error: { message: 'bad key' } }))
+
+    await expect(transcribeAudio(request({ fetchFn }))).rejects.toMatchObject({ kind: 'auth' })
+  })
+
+  it('reports an unrecognizable success body as a parse error', async () => {
+    const fetchFn = recordingFetch([], () => jsonResponse(200, { transcript: 'wrong shape' }))
+
+    await expect(transcribeAudio(request({ fetchFn }))).rejects.toMatchObject({ kind: 'parse' })
+  })
+
+  it('reports a thrown fetch as a network error', async () => {
+    const fetchFn: typeof fetch = async () => {
+      throw new TypeError('offline')
+    }
+
+    await expect(transcribeAudio(request({ fetchFn }))).rejects.toMatchObject({
+      kind: 'network',
+      message: 'offline',
+    })
+  })
+})
+
+describe('transcribeAudio (google)', () => {
+  function geminiResponse(text: string): Response {
+    return jsonResponse(200, { candidates: [{ content: { parts: [{ text }] } }] })
+  }
+
+  it('posts inline base64 audio to the fixed transcription model', async () => {
+    const calls: RecordedCall[] = []
+    const fetchFn = recordingFetch(calls, () => geminiResponse(' transcript here '))
+
+    const text = await transcribeAudio(request({ provider: 'google', apiKey: 'AIza-test', fetchFn }))
+
+    expect(text).toBe('transcript here')
+    expect(calls[0].url).toBe(
+      `https://generativelanguage.googleapis.com/v1beta/models/${GOOGLE_TRANSCRIPTION_MODEL}:generateContent`,
+    )
+    expect(calls[0].headers['x-goog-api-key']).toBe('AIza-test')
+    const payload = JSON.parse(String(calls[0].body)) as {
+      contents: { parts: { text?: string; inline_data?: { mime_type: string; data: string } }[] }[]
+    }
+    const parts = payload.contents[0].parts
+    expect(parts[0].text).toContain('Transcribe')
+    expect(parts[1].inline_data).toEqual({ mime_type: 'audio/mp4', data: btoa('abc') })
+  })
+
+  it('strips codec parameters from the declared MIME type', async () => {
+    const calls: RecordedCall[] = []
+    const fetchFn = recordingFetch(calls, () => geminiResponse('ok'))
+
+    await transcribeAudio(
+      request({ provider: 'google', fetchFn, mimeType: 'audio/webm;codecs=opus' }),
+    )
+
+    const payload = JSON.parse(String(calls[0].body)) as {
+      contents: { parts: { inline_data?: { mime_type: string } }[] }[]
+    }
+    expect(payload.contents[0].parts[1].inline_data?.mime_type).toBe('audio/webm')
+  })
+
+  it('returns an empty transcript when no candidates come back', async () => {
+    const fetchFn = recordingFetch([], () => jsonResponse(200, {}))
+
+    const text = await transcribeAudio(request({ provider: 'google', fetchFn }))
+
+    expect(text).toBe('')
+  })
+
+  it('reports a rejected key as an auth error', async () => {
+    const fetchFn = recordingFetch([], () => jsonResponse(403, { error: { message: 'denied' } }))
+
+    await expect(transcribeAudio(request({ provider: 'google', fetchFn }))).rejects.toMatchObject({
+      kind: 'auth',
+    })
+  })
+})
+
+describe('bytesToBase64', () => {
+  it('matches btoa on small payloads', () => {
+    expect(bytesToBase64(new TextEncoder().encode('abc'))).toBe(btoa('abc'))
+  })
+
+  it('survives payloads beyond one chunk', () => {
+    const bytes = new Uint8Array(0x8000 * 2 + 7).fill(65)
+    expect(bytesToBase64(bytes)).toBe(btoa('A'.repeat(bytes.length)))
+  })
+})

--- a/packages/core/src/ai/transcribe.ts
+++ b/packages/core/src/ai/transcribe.ts
@@ -100,14 +100,32 @@ function httpError(provider: TranscriptionProvider, status: number, body: string
   )
 }
 
+/**
+ * Bounds a provider connection that accepts and then stalls — the UI must
+ * always settle into success or a retryable error, never hang transcribing.
+ */
+export const TRANSCRIPTION_TIMEOUT_MS = 120_000
+
 async function send(
   fetchFn: typeof fetch,
   input: string,
   init: RequestInit,
 ): Promise<Response> {
   try {
-    return await fetchFn(input, init)
+    return await fetchFn(input, {
+      ...init,
+      signal: AbortSignal.timeout(TRANSCRIPTION_TIMEOUT_MS),
+    })
   } catch (cause) {
+    if (
+      cause instanceof DOMException &&
+      (cause.name === 'TimeoutError' || cause.name === 'AbortError')
+    ) {
+      throw new ReflectError(
+        'network',
+        `transcription request timed out after ${TRANSCRIPTION_TIMEOUT_MS / 1000}s`,
+      )
+    }
     throw new ReflectError('network', cause instanceof Error ? cause.message : String(cause))
   }
 }

--- a/packages/core/src/ai/transcribe.ts
+++ b/packages/core/src/ai/transcribe.ts
@@ -22,6 +22,13 @@ export const OPENAI_TRANSCRIPTION_FALLBACK_MODEL = 'whisper-1'
 
 export const GOOGLE_TRANSCRIPTION_MODEL = 'gemini-3.5-flash'
 
+/**
+ * Retried once when the primary model 404s. Google retires models on a short
+ * clock (the spike caught `gemini-3-pro-preview` dying within months of
+ * release), and a retired transcription model must degrade, not hard-fail.
+ */
+export const GOOGLE_TRANSCRIPTION_FALLBACK_MODEL = 'gemini-2.5-flash'
+
 export interface TranscriptionRequest {
   provider: TranscriptionProvider
   apiKey: string
@@ -177,10 +184,8 @@ const GEMINI_INSTRUCTION =
 async function transcribeWithGemini(request: TranscriptionRequest): Promise<string> {
   const fetchFn = request.fetchFn ?? fetch
   const data = bytesToBase64(new Uint8Array(await request.audio.arrayBuffer()))
-  const response = await send(
-    fetchFn,
-    `https://generativelanguage.googleapis.com/v1beta/models/${GOOGLE_TRANSCRIPTION_MODEL}:generateContent`,
-    {
+  const attempt = (model: string): Promise<Response> =>
+    send(fetchFn, `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`, {
       method: 'POST',
       headers: { 'x-goog-api-key': request.apiKey, 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -193,9 +198,15 @@ async function transcribeWithGemini(request: TranscriptionRequest): Promise<stri
           },
         ],
       }),
-    },
-  )
-  const body = await response.text()
+    })
+
+  let response = await attempt(GOOGLE_TRANSCRIPTION_MODEL)
+  let body = await response.text()
+  // A 404 on the model path means Google retired the model.
+  if (response.status === 404) {
+    response = await attempt(GOOGLE_TRANSCRIPTION_FALLBACK_MODEL)
+    body = await response.text()
+  }
   if (!response.ok) {
     throw httpError('google', response.status, body)
   }

--- a/packages/core/src/ai/transcribe.ts
+++ b/packages/core/src/ai/transcribe.ts
@@ -1,0 +1,209 @@
+import { z } from 'zod'
+import { ReflectError } from '../errors'
+import type { TranscriptionProvider } from './models'
+
+/**
+ * BYOK audio transcription (audio memos): one short recording in, plain text
+ * out. OpenAI is served by its dedicated transcription endpoint, Gemini by a
+ * `generateContent` call with inline audio. Both run on fixed transcription
+ * models — the configured entry only picks the provider and key (see
+ * `pickTranscriptionConfig`); chat-model choices don't transfer because chat
+ * models can't take this endpoint (OpenAI) or would bill pro-tier rates for
+ * speech-to-text (Gemini).
+ */
+
+export const OPENAI_TRANSCRIPTION_MODEL = 'gpt-4o-mini-transcribe'
+
+/**
+ * Retried once when the primary model is missing on the key — project-scoped
+ * OpenAI keys can expose `whisper-1` but not the 4o transcription models.
+ */
+export const OPENAI_TRANSCRIPTION_FALLBACK_MODEL = 'whisper-1'
+
+export const GOOGLE_TRANSCRIPTION_MODEL = 'gemini-3.5-flash'
+
+export interface TranscriptionRequest {
+  provider: TranscriptionProvider
+  apiKey: string
+  /** The recording, as MediaRecorder produced it. */
+  audio: Blob
+  /** The recording's MIME type, possibly with codec parameters. */
+  mimeType: string
+  /**
+   * Host transport — the desktop app passes the Tauri HTTP plugin's fetch
+   * (CORS-free); `@reflect/core` itself stays platform-agnostic.
+   */
+  fetchFn?: typeof fetch
+}
+
+/**
+ * Transcribe one recording, returning the trimmed transcript (empty when the
+ * provider heard nothing). Throws {@link ReflectError}: `auth` when the key is
+ * rejected, `network` when the call can't complete, `parse` when the response
+ * shape is unrecognizable.
+ */
+export async function transcribeAudio(request: TranscriptionRequest): Promise<string> {
+  return request.provider === 'openai'
+    ? transcribeWithOpenAi(request)
+    : transcribeWithGemini(request)
+}
+
+/** `audio/webm;codecs=opus` → `audio/webm` — parameters confuse provider sniffing. */
+function baseMimeType(mimeType: string): string {
+  return (mimeType.split(';')[0] ?? mimeType).trim().toLowerCase()
+}
+
+const EXTENSION_BY_MIME: Record<string, string> = {
+  // An audio-only MP4 *is* an M4A — and whisper-1 sniffs by extension, so a
+  // WKWebView recording named `.mp4` is rejected while `.m4a` is accepted.
+  'audio/mp4': 'm4a',
+  'audio/webm': 'webm',
+  'audio/ogg': 'ogg',
+  'audio/wav': 'wav',
+  'audio/mpeg': 'mp3',
+}
+
+function uploadFilename(mimeType: string): string {
+  return `memo.${EXTENSION_BY_MIME[baseMimeType(mimeType)] ?? 'm4a'}`
+}
+
+/** The provider's own error message when the body carries one, else the raw body. */
+function providerErrorMessage(body: string): string {
+  const parsed = z
+    .object({ error: z.object({ message: z.string() }) })
+    .safeParse(safeJson(body))
+  return parsed.success ? parsed.data.error.message : body.slice(0, 200)
+}
+
+function safeJson(body: string): unknown {
+  try {
+    return JSON.parse(body)
+  } catch {
+    return null
+  }
+}
+
+function httpError(provider: TranscriptionProvider, status: number, body: string): ReflectError {
+  if (status === 401 || status === 403) {
+    return new ReflectError('auth', `${provider} rejected the API key (${status})`)
+  }
+  return new ReflectError(
+    'network',
+    `${provider} transcription failed (${status}): ${providerErrorMessage(body)}`,
+  )
+}
+
+async function send(
+  fetchFn: typeof fetch,
+  input: string,
+  init: RequestInit,
+): Promise<Response> {
+  try {
+    return await fetchFn(input, init)
+  } catch (cause) {
+    throw new ReflectError('network', cause instanceof Error ? cause.message : String(cause))
+  }
+}
+
+const openAiResponseSchema = z.object({ text: z.string() })
+
+function isModelNotFound(body: string): boolean {
+  const parsed = z
+    .object({ error: z.object({ code: z.string().nullable() }) })
+    .safeParse(safeJson(body))
+  return parsed.success && parsed.data.error.code === 'model_not_found'
+}
+
+async function transcribeWithOpenAi(request: TranscriptionRequest): Promise<string> {
+  const fetchFn = request.fetchFn ?? fetch
+  const attempt = (model: string): Promise<Response> => {
+    const form = new FormData()
+    form.append('file', request.audio, uploadFilename(request.mimeType))
+    form.append('model', model)
+    return send(fetchFn, 'https://api.openai.com/v1/audio/transcriptions', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${request.apiKey}` },
+      body: form,
+    })
+  }
+
+  let response = await attempt(OPENAI_TRANSCRIPTION_MODEL)
+  let body = await response.text()
+  if (!response.ok && isModelNotFound(body)) {
+    response = await attempt(OPENAI_TRANSCRIPTION_FALLBACK_MODEL)
+    body = await response.text()
+  }
+  if (!response.ok) {
+    throw httpError('openai', response.status, body)
+  }
+
+  const parsed = openAiResponseSchema.safeParse(safeJson(body))
+  if (!parsed.success) {
+    throw new ReflectError('parse', `unrecognized openai transcription response: ${body.slice(0, 200)}`)
+  }
+  return parsed.data.text.trim()
+}
+
+const geminiResponseSchema = z.object({
+  candidates: z
+    .array(
+      z.object({
+        content: z
+          .object({
+            parts: z.array(z.object({ text: z.string().optional() })).optional(),
+          })
+          .optional(),
+      }),
+    )
+    .optional(),
+})
+
+/**
+ * Encode in 32 KiB chunks: spreading a whole multi-megabyte recording into
+ * one `String.fromCharCode` call overflows the argument limit.
+ */
+export function bytesToBase64(bytes: Uint8Array): string {
+  const CHUNK_SIZE = 0x8000
+  let binary = ''
+  for (let offset = 0; offset < bytes.length; offset += CHUNK_SIZE) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + CHUNK_SIZE))
+  }
+  return btoa(binary)
+}
+
+const GEMINI_INSTRUCTION =
+  'Transcribe this audio recording verbatim. Return only the transcribed text, with no commentary or formatting.'
+
+async function transcribeWithGemini(request: TranscriptionRequest): Promise<string> {
+  const fetchFn = request.fetchFn ?? fetch
+  const data = bytesToBase64(new Uint8Array(await request.audio.arrayBuffer()))
+  const response = await send(
+    fetchFn,
+    `https://generativelanguage.googleapis.com/v1beta/models/${GOOGLE_TRANSCRIPTION_MODEL}:generateContent`,
+    {
+      method: 'POST',
+      headers: { 'x-goog-api-key': request.apiKey, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [
+          {
+            parts: [
+              { text: GEMINI_INSTRUCTION },
+              { inline_data: { mime_type: baseMimeType(request.mimeType), data } },
+            ],
+          },
+        ],
+      }),
+    },
+  )
+  const body = await response.text()
+  if (!response.ok) {
+    throw httpError('google', response.status, body)
+  }
+
+  const parsed = geminiResponseSchema.safeParse(safeJson(body))
+  if (!parsed.success) {
+    throw new ReflectError('parse', `unrecognized gemini response: ${body.slice(0, 200)}`)
+  }
+  const parts = parsed.data.candidates?.[0]?.content?.parts ?? []
+  return parts.map((part) => part.text ?? '').join('').trim()
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -144,7 +144,14 @@ export {
 } from './ai/transcribe'
 
 // Capture actions (audio memos; Plan 11's link capture joins here)
-export { appendToDailyNote, type AppendToDailyNoteInput } from './actions/audio-memo'
+export {
+  appendToDailyNote,
+  saveAudioMemo,
+  type AppendToDailyNoteInput,
+  type AudioMemoResume,
+  type SaveAudioMemoInput,
+  type SaveAudioMemoOutcome,
+} from './actions/audio-memo'
 
 // Backup & sync (Plan 12)
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -124,13 +124,27 @@ export { aiKeySecretName } from './ai/secrets'
 export { setSecret, getSecret, deleteSecret } from './secrets/keychain'
 export {
   KEY_HINT_LENGTH,
+  TRANSCRIPTION_PROVIDERS,
   apiKeyHint,
   withAiModelAdded,
   withAiModelRemoved,
   defaultAiModel,
+  pickTranscriptionConfig,
   type AiModelsState,
+  type TranscriptionConfig,
+  type TranscriptionProvider,
 } from './ai/models'
 export { validateApiKey, type ApiKeyValidation } from './ai/validate-key'
+export {
+  GOOGLE_TRANSCRIPTION_MODEL,
+  OPENAI_TRANSCRIPTION_FALLBACK_MODEL,
+  OPENAI_TRANSCRIPTION_MODEL,
+  transcribeAudio,
+  type TranscriptionRequest,
+} from './ai/transcribe'
+
+// Capture actions (audio memos; Plan 11's link capture joins here)
+export { appendToDailyNote, type AppendToDailyNoteInput } from './actions/audio-memo'
 
 // Backup & sync (Plan 12)
 export {
@@ -184,6 +198,7 @@ export {
   pinnedOrder,
   PARSED_NOTE_VERSION,
   parseNote,
+  appendBlock,
   appendUnderHeading,
   renameWikiLink,
   resolved,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -135,13 +135,9 @@ export {
   type TranscriptionProvider,
 } from './ai/models'
 export { validateApiKey, type ApiKeyValidation } from './ai/validate-key'
-export {
-  GOOGLE_TRANSCRIPTION_MODEL,
-  OPENAI_TRANSCRIPTION_FALLBACK_MODEL,
-  OPENAI_TRANSCRIPTION_MODEL,
-  transcribeAudio,
-  type TranscriptionRequest,
-} from './ai/transcribe'
+// The fixed per-provider model ids stay internal to `ai/transcribe` —
+// exporting them would let callers couple to vendor model names.
+export { transcribeAudio, type TranscriptionRequest } from './ai/transcribe'
 
 // Capture actions (audio memos; Plan 11's link capture joins here)
 export {

--- a/packages/core/src/markdown/edit.test.ts
+++ b/packages/core/src/markdown/edit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { appendUnderHeading, renameWikiLink } from './edit'
+import { appendBlock, appendUnderHeading, renameWikiLink } from './edit'
 
 describe('renameWikiLink', () => {
   it('rewrites matching targets, preserves aliases, skips code and non-matches', () => {
@@ -43,5 +43,30 @@ describe('appendUnderHeading', () => {
 
   it('matches the heading case-insensitively', () => {
     expect(appendUnderHeading(doc, 'a', '- new')).toBe('# A\n\nalpha\n\n- new\n\n# B\n\nbeta')
+  })
+})
+
+describe('appendBlock', () => {
+  it('appends one blank line after the existing content', () => {
+    expect(appendBlock('alpha\n', 'new text')).toBe('alpha\n\nnew text\n')
+  })
+
+  it('collapses extra trailing whitespace to the single separator', () => {
+    expect(appendBlock('alpha\n\n\n', 'new text')).toBe('alpha\n\nnew text\n')
+  })
+
+  it('becomes the whole body of an empty note', () => {
+    expect(appendBlock('', 'new text')).toBe('new text\n')
+    expect(appendBlock('\n', 'new text')).toBe('new text\n')
+  })
+
+  it('appends after frontmatter when the note has nothing else', () => {
+    expect(appendBlock('---\nprivate: true\n---\n', 'new text')).toBe(
+      '---\nprivate: true\n---\n\nnew text\n',
+    )
+  })
+
+  it('trims the block itself', () => {
+    expect(appendBlock('alpha', '  new text \n')).toBe('alpha\n\nnew text\n')
   })
 })

--- a/packages/core/src/markdown/edit.ts
+++ b/packages/core/src/markdown/edit.ts
@@ -56,6 +56,18 @@ function nextSectionStart(headings: Heading[], target: Heading, eof: number): nu
  * matches `heading` (case-insensitive). If no such heading exists, append a new
  * `## heading` section at end of file. Used by capture (Plan 11).
  */
+/**
+ * Append `block` as its own paragraph at the end of the note, one blank line
+ * after the existing content (none for an empty note). The flat variant of
+ * {@link appendUnderHeading} — used by audio-memo capture, where the
+ * transcript reads as ordinary note content rather than a section entry.
+ */
+export function appendBlock(source: string, block: string): string {
+  const base = source.replace(/\s*$/, '')
+  const prefix = base.length > 0 ? `${base}\n\n` : ''
+  return `${prefix}${block.trim()}\n`
+}
+
 export function appendUnderHeading(source: string, heading: string, block: string): string {
   const headingKey = heading.trim().toLowerCase()
   const { headings } = parseNote({ path: '', source })

--- a/packages/core/src/markdown/index.ts
+++ b/packages/core/src/markdown/index.ts
@@ -31,7 +31,7 @@ export {
   type InlineWikiLink,
   type InlineImage,
 } from './scan'
-export { appendUnderHeading, renameWikiLink } from './edit'
+export { appendBlock, appendUnderHeading, renameWikiLink } from './edit'
 export {
   detectConflictMarkers,
   resolveConflictMarkers,


### PR DESCRIPTION
## What

A microphone button beside the sidebar search records an audio memo with native web APIs, transcribes it through the user's own OpenAI or Gemini key, and appends the transcript to today's daily note (creating the file when the day has none). While recording, the mic becomes a red stop control with a live waveform + elapsed-time pill anchored beside it; Esc cancels. When no capable provider is configured, the mic disables with a tooltip explaining why. `audioMemo.toggle` joins the command registry, so the flow is palette-reachable.

## How

- **Provider routing** (`packages/core/src/ai/models.ts`): `pickTranscriptionConfig` prefers any OpenAI entry over Google (Anthropic has no audio path), and the app-default entry within a provider. The configured entry only picks the provider + keychain key — transcription runs on fixed models: `gpt-4o-mini-transcribe` (one-shot `whisper-1` fallback on model-not-found) and `gemini-3.5-flash`. Both calls were spike-verified against the live APIs, including the quirk that whisper-1 sniffs by filename (an audio-only MP4 must upload as `.m4a`).
- **Client** (`packages/core/src/ai/transcribe.ts`): multipart for OpenAI, chunked-base64 `inline_data` for Gemini, typed `auth`/`network`/`parse` errors matching the `errors.ts` contract.
- **Write path** (`packages/core/src/actions/audio-memo.ts`): first module of the `actions/` capture family (Plan 11's link capture joins it). Appends a plain paragraph straight to disk pinned to `graph.generation`; the watcher reindexes and an open editor reconciles it like any external change — clean buffers reload in place, dirty ones park a conflict rather than being clobbered.
- **Recording state** (`apps/desktop/src/providers/audio-memo-provider.tsx`) lives **above** the sidebar because sidebar collapse unmounts it: collapsing mid-recording stops-and-saves rather than leaving a hot microphone with no indicator, and failures while collapsed surface through the operations status. Retry semantics are split so a failed append never re-pays for transcription. Recording auto-stops at 10 minutes (bounds Gemini's inline payload).
- **macOS**: new `Info.plist` (`NSMicrophoneUsageDescription`, embedded in dev binaries too) and `Entitlements.plist` (`com.apple.security.device.audio-input`) wired into the hardened-runtime release signing. **Zero Rust code changes** — both API hosts were already in the HTTP capability scope.

## Privacy notes

- Recording is allowed even when today's note is `private: true`: only the freshly captured audio leaves the machine, never any note content, and the transcript is written locally. (Stated in a comment at the call site.)
- BYOK throughout — keys come from the OS keychain per configured entry; nothing proxies through Reflect infrastructure.

## Testing

- 109 tests pass (50 core, 59 desktop), `pnpm check` clean. New coverage: transcription client (multipart fields, fallback, error mapping), provider preference, `appendBlock`/`appendToDailyNote`, recorder lifecycle (incl. cancel-during-permission-prompt releasing the mic), orchestration (retry split, collapse stop-and-save, gating), sidebar button + command registry.
- ⚠️ Two things need a manual `pnpm tauri dev` pass on a Mac, since they live in the native shell: **FormData multipart through `tauri-plugin-http`'s fetch** (if it mangles the body, the fix is hand-rolling multipart bytes in `transcribe.ts`) and the **WKWebView getUserMedia / TCC prompt** flow.
- Windows/Linux note: recordings there are webm/opus; Gemini's documented inline formats don't list webm (it worked in informal testing elsewhere, but is unverified here). OpenAI accepts webm explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Sends user audio to third-party APIs and writes to daily notes; large surface area but BYOK, resumable saves, and extensive tests mitigate most failure modes.
> 
> **Overview**
> Adds **audio memos**: record from a sidebar mic, transcribe with the user’s OpenAI or Gemini key, and append the text to today’s daily note.
> 
> **Core** introduces `pickTranscriptionConfig`, `transcribeAudio` (OpenAI multipart + Gemini inline audio, model fallbacks, timeouts), `saveAudioMemo` with resumable transcribe/append steps, and `appendBlock` for flat daily-note appends.
> 
> **Desktop** adds `useAudioRecorder`, `AudioMemoProvider` (above the sidebar so collapse doesn’t leave a hidden mic—collapse mid-record stops-and-saves), mic UI with waveform popover, and `audioMemo.toggle` in the command palette. macOS gets `NSMicrophoneUsageDescription`, audio-input entitlements, and hardened-runtime signing config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad24e5a14fa2864d9af2a70e98ad6af226fd98b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio memo recording to the sidebar with a microphone button.
  * Record audio with real-time waveform visualization.
  * Automatic transcription of recordings using OpenAI or Google APIs.
  * New "Record audio memo" command accessible via the command palette.
  * Added macOS microphone permissions and entitlements support.

* **Tests**
  * Added comprehensive test coverage for audio recording, transcription, and UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->