### PR TITLE
Connect-GitHub wizard: poll for the created repo, sparser copy

### DIFF
--- a/apps/desktop/src/components/settings/connect-github-dialog.test.tsx
+++ b/apps/desktop/src/components/settings/connect-github-dialog.test.tsx
@@ -62,7 +62,9 @@ afterEach(() => {
 })
 
 function renderWizard(onClose = vi.fn()): ReturnType<typeof vi.fn> {
-  render(<ConnectGithubDialog suggestedRepoName="g-backup" onClose={onClose} />)
+  render(
+    <ConnectGithubDialog suggestedRepoName="g-backup" onClose={onClose} pollIntervalMs={15} />,
+  )
   return onClose
 }
 
@@ -98,48 +100,45 @@ describe('ConnectGithubDialog', () => {
     expect(await screen.findByText('alex')).toBeTruthy()
   })
 
-  it('guides through github.com/new when the token cannot create repos', async () => {
-    sync.connectExistingRepo.mockResolvedValueOnce('notFound')
+  it('hands off to github.com/new and connects by polling — no button to click', async () => {
+    sync.connectExistingRepo.mockResolvedValueOnce('notFound').mockResolvedValueOnce('notFound')
     sync.connectNewRepo.mockResolvedValueOnce('manualCreateNeeded')
     const onClose = renderWizard()
 
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
 
     // The guide names the exact repo and opens the prefilled create page.
-    expect(await screen.findByText(/can’t create repositories/i)).toBeTruthy()
+    expect(await screen.findByText(/waiting for the repository/i)).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: 'Create on GitHub…' }))
     expect(openedUrls).toHaveBeenCalledWith(
       expect.stringContaining('https://github.com/new?name=g-backup'),
     )
 
-    // After the handoff, connecting finds the repo and finishes.
-    fireEvent.click(screen.getByRole('button', { name: 'I created it — connect' }))
+    // Once the repo exists, a poll connects it — the user clicks nothing.
     await waitFor(() =>
       expect(sync.connectExistingRepo).toHaveBeenLastCalledWith(
         { owner: 'alex', name: 'g-backup' },
         { allowPublic: false },
       ),
     )
-    expect(onClose).toHaveBeenCalled()
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+    // The repo exists now — re-running the API create would just 422.
+    expect(sync.connectNewRepo).toHaveBeenCalledTimes(1)
   })
 
-  it('drops a stale create guide when the wizard takes a different path', async () => {
-    // Reach the manual-create guide, detour through the public-repo consent
-    // screen and back to the repo step — the old "can't create repositories"
-    // panel must not resurface during the new attempt.
-    sync.connectExistingRepo.mockResolvedValueOnce('notFound')
+  it('stops polling for consent when the created repo turns out public', async () => {
+    sync.connectExistingRepo
+      .mockResolvedValueOnce('notFound') // initial lookup → create guide
+      .mockResolvedValueOnce('needsPublicConfirm') // first poll finds it public
     sync.connectNewRepo.mockResolvedValueOnce('manualCreateNeeded')
     const onClose = renderWizard()
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
-    expect(await screen.findByText(/can’t create repositories/i)).toBeTruthy()
 
-    // "I created it" turns up a public repo → consent → choose another.
-    sync.connectExistingRepo.mockResolvedValueOnce('needsPublicConfirm')
-    fireEvent.click(screen.getByRole('button', { name: 'I created it — connect' }))
     expect(await screen.findByText(/is public/i)).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: 'Choose another repo' }))
 
-    // New attempt with an existing repo; hold it pending to observe the UI.
+    // New attempt with an existing repo; hold it pending to observe the UI —
+    // the stale create guide (and its poll) must not resurface.
     const gate: { resolve: ((value: ConnectExistingResult) => void) | null } = { resolve: null }
     sync.connectExistingRepo.mockImplementationOnce(
       () => new Promise<ConnectExistingResult>((resolve) => (gate.resolve = resolve)),
@@ -151,10 +150,21 @@ describe('ConnectGithubDialog', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
 
     expect(await screen.findByText('Connecting…')).toBeTruthy()
-    expect(screen.queryByText(/can’t create repositories/i)).toBeNull()
+    expect(screen.queryByText(/waiting for the repository/i)).toBeNull()
 
     gate.resolve?.('connected')
     await waitFor(() => expect(onClose).toHaveBeenCalled())
+  })
+
+  it('lets the user back out of the create guide', async () => {
+    sync.connectExistingRepo.mockResolvedValue('notFound')
+    sync.connectNewRepo.mockResolvedValueOnce('manualCreateNeeded')
+    renderWizard()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Change repository' }))
+
+    expect(await screen.findByLabelText('New repository name')).toBeTruthy()
   })
 
   it('validates the existing-repo input before any network work', async () => {
@@ -207,7 +217,7 @@ describe('ConnectGithubDialog', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
 
-    expect(await screen.findByText(/was not found/i)).toBeTruthy()
+    expect(await screen.findByText(/not found/i)).toBeTruthy()
     expect(sync.connectNewRepo).not.toHaveBeenCalled()
     expect(onClose).not.toHaveBeenCalled()
     // PAT remedy is token scope — the app-install flow is someone else's fix.
@@ -225,7 +235,7 @@ describe('ConnectGithubDialog', () => {
       target: { value: 'alex/gone' },
     })
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
-    expect(await screen.findByText(/was not found/i)).toBeTruthy()
+    expect(await screen.findByText(/not found/i)).toBeTruthy()
 
     // Back, fix the name — the stored sign-in carries the retry through.
     fireEvent.click(screen.getByRole('button', { name: 'Change repository' }))
@@ -244,7 +254,7 @@ describe('ConnectGithubDialog', () => {
   })
 
   it('surfaces the create URL when the browser cannot be opened', async () => {
-    sync.connectExistingRepo.mockResolvedValueOnce('notFound')
+    sync.connectExistingRepo.mockResolvedValue('notFound')
     sync.connectNewRepo.mockResolvedValueOnce('manualCreateNeeded')
     openedUrls.mockRejectedValueOnce(new Error('no handler for https'))
     renderWizard()
@@ -272,7 +282,7 @@ describe('ConnectGithubDialog', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
 
-    expect(await screen.findByText(/grant it access on GitHub/i)).toBeTruthy()
+    expect(await screen.findByText(/grant it access/i)).toBeTruthy()
     expect(screen.queryByText(/token/i)).toBeNull()
 
     fireEvent.click(screen.getByRole('button', { name: 'Grant access on GitHub…' }))
@@ -293,57 +303,46 @@ describe('ConnectGithubDialog', () => {
 
   it('points the app create guide at granting access, not token scope', async () => {
     storeCredential(appCredential())
-    sync.connectExistingRepo.mockResolvedValueOnce('notFound')
+    sync.connectExistingRepo.mockResolvedValue('notFound')
     sync.connectNewRepo.mockResolvedValueOnce('manualCreateNeeded')
     renderWizard()
 
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
 
-    expect(await screen.findByText(/Reflect can’t create the repository itself/i)).toBeTruthy()
-    expect(screen.queryByText(/token/i)).toBeNull()
-
-    fireEvent.click(screen.getByRole('button', { name: /grant the Reflect app access/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /grant the Reflect app access/i }))
     expect(openedUrls).toHaveBeenCalledWith(
       'https://github.com/apps/reflect-github-app/installations/new',
     )
+    expect(screen.queryByText(/token/i)).toBeNull()
   })
 
-  it('promotes the grant remedy when a created repo still cannot be seen', async () => {
+  it('keeps polling until an app-created repo becomes visible, then connects', async () => {
     // App user, "selected repositories" install: they create the repo via
-    // the handoff, but the app was never granted access to it. After
-    // "I created it — connect" a 404 means visibility, not existence — the
-    // grant flow takes over instead of looping back into the create guide.
+    // the handoff, but the app gains access to it only when they grant it.
+    // The poll rides through the 404s and connects on the first success.
     storeCredential(appCredential())
-    sync.connectExistingRepo.mockResolvedValueOnce('notFound').mockResolvedValueOnce('notFound')
+    sync.connectExistingRepo
+      .mockResolvedValueOnce('notFound') // initial lookup
+      .mockResolvedValueOnce('notFound') // poll: created, not granted yet
     sync.connectNewRepo.mockResolvedValueOnce('manualCreateNeeded')
     const onClose = renderWizard()
 
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
-    fireEvent.click(await screen.findByRole('button', { name: 'I created it — connect' }))
 
-    expect(await screen.findByText(/still can’t see the new repository/i)).toBeTruthy()
-    expect(screen.queryByRole('button', { name: 'Create on GitHub…' })).toBeNull()
-    // The repo exists now — re-running the API create would just 422.
-    expect(sync.connectNewRepo).toHaveBeenCalledTimes(1)
-
-    fireEvent.click(screen.getByRole('button', { name: 'Grant access on GitHub…' }))
-    expect(openedUrls).toHaveBeenCalledWith(
-      'https://github.com/apps/reflect-github-app/installations/new',
-    )
-
-    fireEvent.click(screen.getByRole('button', { name: 'I granted it — try again' }))
+    expect(await screen.findByText(/waiting for the repository/i)).toBeTruthy()
     await waitFor(() => expect(onClose).toHaveBeenCalled())
+    expect(sync.connectExistingRepo.mock.calls.length).toBeGreaterThanOrEqual(3)
+    expect(sync.connectNewRepo).toHaveBeenCalledTimes(1)
   })
 
-  it('keeps the created-but-unseen remedy token-flavored for PAT users', async () => {
-    sync.connectExistingRepo.mockResolvedValueOnce('notFound').mockResolvedValueOnce('notFound')
+  it('keeps the create-guide hint token-flavored for PAT users', async () => {
+    sync.connectExistingRepo.mockResolvedValue('notFound')
     sync.connectNewRepo.mockResolvedValueOnce('manualCreateNeeded')
     renderWizard()
 
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
-    fireEvent.click(await screen.findByRole('button', { name: 'I created it — connect' }))
 
-    expect(await screen.findByText(/included in your token’s repository access/i)).toBeTruthy()
-    expect(screen.queryByRole('button', { name: /grant access/i })).toBeNull()
+    expect(await screen.findByText(/token’s repository access/i)).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /grant/i })).toBeNull()
   })
 })

--- a/apps/desktop/src/components/settings/connect-github-dialog.tsx
+++ b/apps/desktop/src/components/settings/connect-github-dialog.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { useAsyncAction } from '@/hooks/use-async-action'
+import { usePoll } from '@/hooks/use-poll'
 import { useRestoreFocus } from '@/hooks/use-restore-focus'
 import { parseRepoInput } from '@/lib/github-repos'
 import { useSync } from '@/providers/sync-provider'
@@ -27,6 +28,8 @@ interface ConnectGithubDialogProps {
   /** A suggested name for a newly created backup repo (from the graph name). */
   suggestedRepoName: string
   onClose: () => void
+  /** Delay between repo-existence polls on the create handoff (test hook). */
+  pollIntervalMs?: number
 }
 
 type Step = 'repo' | 'auth' | 'finish'
@@ -35,33 +38,34 @@ type Step = 'repo' | 'auth' | 'finish'
 type AuthKind = 'app' | 'pat' | null
 
 const STEP_DESCRIPTIONS: Record<Step, string> = {
-  repo: 'Back up this graph to a private GitHub repository of your own.',
+  repo: 'Back up this graph to a private GitHub repository.',
   auth: 'Sign in so Reflect can push your backups.',
-  finish: 'Connecting your backup repository…',
+  finish: 'Connecting your repository…',
 }
 
 /**
- * The "Connect GitHub" wizard, ordered around how GitHub tokens actually
- * work: **the repository comes first** (creating it needs no credential —
- * the prefilled github.com/new handoff is one click), then the token (whose
- * instructions can now name that exact repository, and which a fine-grained
- * token can be scoped to because it exists), then the connection — built
- * from the verified sign-in (`owner` is never asked for).
+ * The "Connect GitHub" wizard: repository first (creating one needs no
+ * credential), then the sign-in (whose instructions can name that exact
+ * repository), then the connection — built from the verified sign-in, so
+ * the owner is never asked for.
  *
- * Tokens that *can* create repositories (classic PATs, app tokens) skip the
- * handoff: the finish step silently API-creates when the repo doesn't exist
- * yet and the user never clicked "Create on GitHub". Connecting a public
- * repo demands explicit confirmation — every note in the graph, including
- * `private: true` ones, would be world-readable.
+ * Tokens that can create repositories (classic PATs, app tokens) connect in
+ * one step: the finish step API-creates silently. Tokens that can't are
+ * handed the prefilled github.com/new page while the dialog polls for the
+ * repository and connects the moment it exists — there is no "I created it"
+ * button to click. Connecting a public repo demands explicit confirmation:
+ * every note in the graph, including `private: true` ones, would be
+ * world-readable.
  *
- * "Can't find the repo" has one remedy per credential kind, never both at
- * once: app sign-ins route to the GitHub App install page (authorization ≠
- * installation — the token only reaches repositories the app is installed
- * on), while PAT users get token-scope guidance.
+ * "Can't find the repo" keeps one remedy per credential kind: app sign-ins
+ * route to the GitHub App install page (authorization ≠ installation — the
+ * token only reaches repositories the app is installed on), PAT users get
+ * token-scope guidance.
  */
 export function ConnectGithubDialog({
   suggestedRepoName,
   onClose,
+  pollIntervalMs = 3000,
 }: ConnectGithubDialogProps): ReactElement {
   const { connectNewRepo, connectExistingRepo } = useSync()
   const action = useAsyncAction()
@@ -72,18 +76,37 @@ export function ConnectGithubDialog({
   const [user, setUser] = useState<GithubUser | null>(null)
   const [authKind, setAuthKind] = useState<AuthKind>(null)
   const [publicConfirm, setPublicConfirm] = useState<GithubRepoRef | null>(null)
-  /** The finish step's "repo not found yet" guidance (create-mode only). */
+  /** The finish step's "create it on GitHub" handoff (create-mode only). */
   const [showCreateGuide, setShowCreateGuide] = useState(false)
-  /** App sign-in couldn't see the repo → offer the install-access remedy. */
+  /** App sign-in couldn't see an existing repo → offer the install remedy. */
   const [showGrantHint, setShowGrantHint] = useState(false)
-  /**
-   * The user clicked "I created it — connect". From here on a 404 means
-   * "can't see it", not "doesn't exist": the remedy is access (install the
-   * app / widen the token), never the create guide again.
-   */
-  const [claimedCreated, setClaimedCreated] = useState(false)
 
   useRestoreFocus()
+
+  // While the create handoff is showing, poll for the repository instead of
+  // making the user click "I created it": the connect fires the moment the
+  // repo exists. A 404 just keeps waiting (for app sign-ins it can also mean
+  // access not granted yet — the guide's hint covers that); a public repo
+  // stops the poll for consent.
+  const pollTarget =
+    showCreateGuide && publicConfirm === null && user !== null
+      ? { owner: user.login, name: repoName.trim() }
+      : null
+  usePoll(pollTarget !== null, pollIntervalMs, async () => {
+    if (pollTarget === null) {
+      return 'stop'
+    }
+    const result = await connectExistingRepo(pollTarget, { allowPublic: false })
+    if (result === 'connected') {
+      onClose()
+      return 'stop'
+    }
+    if (result === 'needsPublicConfirm') {
+      setPublicConfirm(pollTarget)
+      return 'stop'
+    }
+    return 'continue'
+  })
 
   function targetRef(forUser: GithubUser): GithubRepoRef | null {
     if (mode === 'existing') {
@@ -95,17 +118,15 @@ export function ConnectGithubDialog({
 
   async function finish(
     forUser: GithubUser,
-    options: { allowPublic?: boolean; kind?: AuthKind; claimedCreated?: boolean } = {},
+    options: { allowPublic?: boolean; kind?: AuthKind } = {},
   ): Promise<void> {
-    // Two values are read at call time because their setters fire in the
-    // same tick as the call (state hasn't committed): the credential kind on
-    // the first run, and the created-it claim on its button's click.
+    // The credential kind is passed in on the first run — its setter fires
+    // in the same tick as the call, before the state commits.
     const kind = options.kind ?? authKind
-    const claimed = options.claimedCreated ?? claimedCreated
     await action.run(async () => {
       // Each attempt re-derives the guidance from its own outcome — a stale
-      // "can't create repositories" or "grant access" panel from an earlier
-      // path must not outlive the detour (e.g. consent → choose another repo).
+      // create guide or grant hint from an earlier path must not outlive the
+      // detour (e.g. consent → choose another repo).
       setShowCreateGuide(false)
       setShowGrantHint(false)
       const ref = publicConfirm ?? targetRef(forUser)
@@ -127,29 +148,22 @@ export function ConnectGithubDialog({
         setPublicConfirm(ref)
         return
       }
-      // Not found. For an existing repo — or one the user says they already
-      // created — that means "can't see it"; for a new one, create it, by
-      // API when the token can and by guided handoff otherwise.
-      if (mode === 'existing' || claimed) {
+      if (mode === 'existing') {
         // GitHub's 404 can't distinguish "doesn't exist" from "no access".
         // App sign-ins almost always mean the latter (the app isn't
         // installed on the repo), so that's the remedy they get.
         if (kind === 'app') {
           setShowGrantHint(true)
-          action.setError(
-            claimed
-              ? 'Reflect still can’t see the new repository — grant it access on GitHub.'
-              : 'Reflect can’t see that repository — grant it access on GitHub, or check the name.',
-          )
+          action.setError('Reflect can’t see that repository. Grant it access or check the name.')
         } else {
           action.setError(
-            claimed
-              ? 'Still not found — make sure the new repository is included in your token’s repository access.'
-              : 'That repository was not found (check the name and the token’s repo access).',
+            'Repository not found. Check the name and your token’s repository access.',
           )
         }
         return
       }
+      // A new repo that doesn't exist yet: create it — by API when the token
+      // can, by the guided handoff (plus polling) otherwise.
       const created = await connectNewRepo(ref.name)
       if (created === 'connected') {
         onClose()
@@ -188,7 +202,6 @@ export function ConnectGithubDialog({
     setPublicConfirm(null)
     setShowCreateGuide(false)
     setShowGrantHint(false)
-    setClaimedCreated(false)
     setStep('repo')
   }
 
@@ -227,18 +240,13 @@ export function ConnectGithubDialog({
                 Create a new private repository
               </label>
               {mode === 'create' ? (
-                <div className="ml-6 flex flex-col gap-2">
-                  <Input
-                    autoFocus
-                    value={repoName}
-                    onChange={(event) => setRepoName(event.target.value)}
-                    aria-label="New repository name"
-                  />
-                  <p className="text-xs text-text-muted">
-                    Reflect creates it for you where it can; otherwise one click on GitHub with
-                    everything pre-filled — private either way.
-                  </p>
-                </div>
+                <Input
+                  autoFocus
+                  value={repoName}
+                  onChange={(event) => setRepoName(event.target.value)}
+                  className="ml-6 w-auto"
+                  aria-label="New repository name"
+                />
               ) : null}
               <label className="flex items-center gap-2 text-sm text-text">
                 <input
@@ -287,8 +295,8 @@ export function ConnectGithubDialog({
                   <strong>
                     {publicConfirm.owner}/{publicConfirm.name} is public.
                   </strong>{' '}
-                  Everything in this graph — including notes marked private — would be readable
-                  by anyone on the internet.
+                  Anyone on the internet can read everything in this graph, including notes
+                  marked private.
                 </InlineAlert>
                 <div className="flex gap-2">
                   <Button variant="outline" size="sm" onClick={backToRepo}>
@@ -311,34 +319,24 @@ export function ConnectGithubDialog({
             ) : showCreateGuide && user !== null ? (
               <>
                 <p className="text-sm text-text">
-                  {authKind === 'app'
-                    ? 'Reflect can’t create the repository itself, but GitHub can — everything is'
-                    : 'Your token can’t create repositories, but GitHub can — everything is'}{' '}
-                  pre-filled, so it’s one click. Create{' '}
+                  Create{' '}
                   <strong>
                     {user.login}/{repoName.trim()}
                   </strong>{' '}
-                  there, then connect.
+                  on GitHub. Reflect will connect it as soon as it exists.
                 </p>
                 <div className="flex gap-2">
                   <Button size="sm" onClick={() => openExternal(newRepoUrl(repoName.trim()))}>
                     Create on GitHub…
                   </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={action.pending}
-                    onClick={() => {
-                      setClaimedCreated(true)
-                      void finish(user, { claimedCreated: true })
-                    }}
-                  >
-                    I created it — connect
+                  <Button variant="outline" size="sm" onClick={backToRepo}>
+                    Change repository
                   </Button>
                 </div>
+                <p className="text-xs text-text-muted">Waiting for the repository…</p>
                 {authKind === 'app' ? (
                   <p className="text-xs text-text-muted">
-                    If connecting still can’t find it,{' '}
+                    If it doesn’t connect,{' '}
                     <button
                       type="button"
                       className="underline"
@@ -346,30 +344,26 @@ export function ConnectGithubDialog({
                     >
                       grant the Reflect app access
                     </button>{' '}
-                    to the new repository.
+                    to it.
                   </p>
                 ) : (
                   <p className="text-xs text-text-muted">
-                    If connecting still can’t find it, make sure the new repository is included in
-                    your token’s repository access.
+                    If it doesn’t connect, add it to your token’s repository access.
                   </p>
                 )}
               </>
-            ) : (
-              <p className="text-sm text-text-muted">
-                {action.pending ? 'Connecting…' : 'Almost there.'}
-              </p>
-            )}
+            ) : action.pending ? (
+              <p className="text-sm text-text-muted">Connecting…</p>
+            ) : null}
 
             {!action.pending && action.error !== null ? (
               <>
                 <InlineAlert tone="error">{action.error}</InlineAlert>
-                {publicConfirm === null ? (
+                {publicConfirm === null && !showCreateGuide ? (
                   // A failed connect must never strand the user here: change
                   // the repository, or — for app sign-ins that can't see the
-                  // repo — grant the app access (authorization and
-                  // installation are separate GitHub App concepts; the token
-                  // only reaches repositories the app is installed on).
+                  // repo — grant the app access. (The create guide renders
+                  // its own escape, so it is excluded.)
                   <div className="flex flex-wrap gap-2">
                     {showGrantHint && user !== null ? (
                       <>

--- a/apps/desktop/src/components/settings/github-auth-step.test.tsx
+++ b/apps/desktop/src/components/settings/github-auth-step.test.tsx
@@ -228,6 +228,21 @@ describe('GithubAuthStep', () => {
     expect(await screen.findByText(/code copied/i)).toBeTruthy()
   })
 
+  it('surfaces the device URL when the browser cannot be opened', async () => {
+    // The handoff URL appears only on failure — it is the one way left to
+    // reach the page asking for the code.
+    stubClipboard(vi.fn(async () => {}))
+    openedUrls.mockRejectedValueOnce(new Error('no handler for https'))
+    await renderCodeView()
+    expect(screen.queryByText(/login\/device/)).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy code and open GitHub' }))
+
+    expect(
+      await screen.findByText(/visit https:\/\/github\.com\/login\/device yourself/i),
+    ).toBeTruthy()
+  })
+
   it('holds the GitHub handoff when the clipboard is unavailable', async () => {
     stubClipboard(async () => {
       throw new Error('denied')

--- a/apps/desktop/src/components/settings/github-auth-step.tsx
+++ b/apps/desktop/src/components/settings/github-auth-step.tsx
@@ -41,6 +41,8 @@ export function GithubAuthStep({ onAuthed, repoName }: GithubAuthStepProps): Rea
   // click away (some users prefer a scoped token; GHES needs it).
   const [usePat, setUsePat] = useState(!isDeviceFlowConfigured())
   const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle')
+  /** Opening the browser failed — show the URL, the only way left to get there. */
+  const [openFailed, setOpenFailed] = useState(false)
   const authedRef = useRef(false)
 
   // Auth can complete twice — the mount-time probe of a stored credential
@@ -85,6 +87,7 @@ export function GithubAuthStep({ onAuthed, repoName }: GithubAuthStepProps): Rea
 
   async function signIn(): Promise<void> {
     setCopyState('idle') // each attempt mints a fresh code
+    setOpenFailed(false)
     if (await deviceFlow.signIn()) {
       await pat.run(verifyAndFinish)
     }
@@ -106,8 +109,9 @@ export function GithubAuthStep({ onAuthed, repoName }: GithubAuthStepProps): Rea
         return
       }
     }
+    setOpenFailed(false)
     void openUrl(flow.verificationUri).catch(() => {
-      // The URI is shown in the dialog; the user can browse there directly.
+      setOpenFailed(true)
     })
   }
 
@@ -205,17 +209,11 @@ export function GithubAuthStep({ onAuthed, repoName }: GithubAuthStepProps): Rea
               Couldn’t copy automatically — select the code above and copy it first.
             </p>
           ) : null}
-          <p className="text-center text-xs text-text-muted">
-            Waiting for you to enter it at{' '}
-            <button
-              type="button"
-              className="underline"
-              onClick={() => void openUrl(flowView.verificationUri).catch(() => {})}
-            >
-              {flowView.verificationUri}
-            </button>
-            …
-          </p>
+          {openFailed ? (
+            <p className="select-text text-xs text-text-muted">
+              Couldn’t open the browser — visit {flowView.verificationUri} yourself.
+            </p>
+          ) : null}
         </div>
       )}
       {error !== null ? <InlineAlert tone="error">{error}</InlineAlert> : null}

--- a/apps/desktop/src/hooks/use-poll.ts
+++ b/apps/desktop/src/hooks/use-poll.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Run `tick` every `intervalMs` while `enabled`, starting one interval after
+ * enablement (callers typically just ran the same check inline). Ticks never
+ * overlap — the next wait starts when the previous tick settles — and a tick
+ * that throws keeps the loop alive: the network checks this exists for fail
+ * transiently. Return 'stop' to end the loop. Disabling or unmounting
+ * cancels future ticks but not one already in flight.
+ */
+export function usePoll(
+  enabled: boolean,
+  intervalMs: number,
+  tick: () => Promise<'continue' | 'stop'>,
+): void {
+  // Always call the latest tick without re-arming the timer every render.
+  const tickRef = useRef(tick)
+  tickRef.current = tick
+
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+
+    function schedule(): void {
+      timer = setTimeout(() => {
+        void tickRef.current().then(
+          (result) => {
+            if (!cancelled && result === 'continue') {
+              schedule()
+            }
+          },
+          () => {
+            if (!cancelled) {
+              schedule()
+            }
+          },
+        )
+      }, intervalMs)
+    }
+
+    schedule()
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [enabled, intervalMs])
+}


### PR DESCRIPTION
## What changed

**Polling replaces the "I created it — connect" button.** After the github.com/new handoff, the dialog now polls the repo lookup (`GET /repos/owner/name`) every 3 seconds while the create guide is showing and connects the moment the repository exists — the user creates the repo in the browser and just comes back to a connected graph. The loop lives in a new `usePoll` hook (delay-first, non-overlapping ticks, survives transient network errors, cancels on unmount), with the interval injectable so tests run it at 15ms.

**That deletes real state, not just a button.** The `claimedCreated` flag and the promoted "still can't see the new repository" error variants existed only because the dialog couldn't tell *when* the user had created the repo. With polling, an app user who hasn't granted repo access yet simply keeps polling until they do, covered by one static hint line. A poll that finds the repo public stops and shows the existing consent screen.

**Sparser copy throughout.** Helper paragraphs that restated controls are gone ("Reflect creates it for you where it can; otherwise one click on GitHub with everything pre-filled — private either way."), "Almost there." is gone, and errors are tightened (e.g. "Repository not found. Check the name and your token's repository access."). The device-flow screen drops "Waiting for you to enter it at…" — the verification URL now appears only when opening the browser actually fails, the one case where the user needs it.

## Notes for review

- Since polling never "fails", the create guide can't rely on an error state to surface a way back, so it carries its own **Change repository** button (previously the escape only appeared after a failed connect).
- The existing-repo remedies are unchanged: app sign-ins still get the install-access flow ("Grant access on GitHub…" / "I granted it — try again"), PAT users still get token-scope guidance. The public-repo consent gate is unchanged in behavior.
- Known race, judged acceptable: a poll tick already in flight when the user clicks "Change repository" can still complete and connect the repo (closing the dialog). That only happens if the repo actually appeared in that ~3s window, in which case connecting is arguably the right outcome.
- Rate limits are a non-issue: one lookup per 3s is ~1.2k/hr against the authenticated 5k/hr limit, and the poll only runs while the create guide is visible.

## Testing

- `pnpm --filter @reflect/desktop test --run` on both touched suites: 23/23 pass (new tests: poll-driven handoff connect, poll → public consent, guide back-out, app-granted-late polling, browser-open failure surfacing the device URL).
- `pnpm check` clean (the two oxlint warnings it prints are pre-existing, in untouched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the backup onboarding path and adds periodic GitHub API lookups while the create guide is open; existing-repo grant/PAT flows are largely unchanged but wizard state and timing races could affect UX.
> 
> **Overview**
> **Connect GitHub** no longer asks users to click **“I created it — connect”** after the `github.com/new` handoff. While the create guide is visible, a new **`usePoll`** hook runs repo lookups every 3s (non-overlapping ticks, survives transient errors) and **`connectExistingRepo`** runs until the repo exists, is public (→ existing consent UI), or the user leaves the guide. **`claimedCreated`** and the “still can’t see the new repository” error paths are removed; app users who lack repo visibility keep polling with a single static hint.
> 
> The create guide adds **Change repository** and **“Waiting for the repository…”** copy; wizard text and not-found errors are tightened. **`GithubAuthStep`** drops the always-visible device verification link and only shows the URL when **`openUrl`** fails.
> 
> Tests pass **`pollIntervalMs={15}`** and cover poll-driven connect, public consent, back-out, late app grant, and browser-open failure for device flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32d1bb672a93720c2af9ed259baa93396a037ff6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->