### PR TITLE
fix(audio-memo): bump mic icon size to compensate for glyph padding

### DIFF
--- a/apps/desktop/src/components/audio-memo/audio-memo-button.tsx
+++ b/apps/desktop/src/components/audio-memo/audio-memo-button.tsx
@@ -37,7 +37,7 @@ export function AudioMemoButton(): ReactElement {
               !memo.available && 'opacity-50 hover:bg-transparent hover:text-text-muted',
             )}
           >
-            <MicIcon className="size-4" />
+            <MicIcon className="size-[18px]" />
           </Button>
         </TooltipTrigger>
         <TooltipContent side="bottom">
@@ -72,7 +72,7 @@ export function AudioMemoButton(): ReactElement {
           }}
         >
           {memo.phase === 'error' ? (
-            <MicIcon className="size-4" />
+            <MicIcon className="size-[18px]" />
           ) : (
             <Square aria-hidden fill="currentColor" className="size-3" />
           )}

--- a/apps/desktop/src/components/icons/mic-icon.tsx
+++ b/apps/desktop/src/components/icons/mic-icon.tsx
@@ -8,8 +8,6 @@ interface MicIconProps {
 export function MicIcon({ className }: MicIconProps): ReactElement {
   return (
     <svg
-      width="24"
-      height="24"
       viewBox="0 0 24 24"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Summary

The V1 mic SVG glyph has ~3px of internal padding on all sides within its 24×24 viewBox, so at `size-4` (16px) the visible glyph rendered at only ~10px — noticeably smaller than the previous lucide `Mic` icon.

- Remove the hardcoded `width="24" height="24"` attributes from the SVG so CSS has clean control over size
- Render at `size-[18px]` in the button to compensate for the internal padding and match the visual weight of the old icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Icon-only styling in the audio memo button with no logic or API changes.
> 
> **Overview**
> Adjusts the audio memo mic control so the custom V1 glyph matches the visual weight of the previous icon.
> 
> **`MicIcon`** drops fixed `width`/`height` on the SVG so sizing comes only from the passed `className`. **`AudioMemoButton`** renders the mic at **`size-[18px]`** instead of **`size-4`**, offsetting internal padding in the 24×24 viewBox so the drawn shape reads larger in the toolbar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f97da6fc9f576181e1484661f1cb8a096dc3300. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->