### PR TITLE
Audio memos: size-5 mic icon, back-to-back recording with a serial save queue

### DIFF
--- a/apps/desktop/src/components/audio-memo/audio-memo-button.test.tsx
+++ b/apps/desktop/src/components/audio-memo/audio-memo-button.test.tsx
@@ -89,14 +89,15 @@ describe('AudioMemoButton', () => {
     expect(memo.discard).not.toHaveBeenCalled()
   })
 
-  it('transcribing disables the control and shows progress', () => {
+  it('transcribing shows progress while the mic stays live for the next memo', async () => {
     memo.phase = 'transcribing'
     const view = renderButton()
 
     expect(view.getByText('Transcribing…')).not.toBeNull()
-    expect(
-      view.getByRole('button', { name: 'Transcribing audio memo' }),
-    ).toHaveProperty('disabled', true)
+    const micButton = view.getByRole('button', { name: 'Record audio memo' })
+    expect(micButton).toHaveProperty('disabled', false)
+    await userEvent.click(micButton)
+    expect(memo.toggle).toHaveBeenCalled()
   })
 
   it('a resumable failure offers Retry and Discard', async () => {

--- a/apps/desktop/src/components/audio-memo/audio-memo-button.tsx
+++ b/apps/desktop/src/components/audio-memo/audio-memo-button.tsx
@@ -10,10 +10,11 @@ import { useAudioMemo } from '@/providers/audio-memo-provider'
 
 /**
  * The microphone beside the sidebar search box. Idle it starts a memo;
- * while one is in flight it becomes the red stop control with the recording
- * panel anchored beside it. Disabled (with the reason as a tooltip) when no
- * OpenAI/Gemini model is configured — `aria-disabled` rather than `disabled`
- * so the tooltip still fires.
+ * recording it becomes the red stop control with the recording panel anchored
+ * beside it. While earlier memos are still transcribing the mic stays live —
+ * memos queue, so the next recording can start immediately. Disabled (with
+ * the reason as a tooltip) when no OpenAI/Gemini model is configured —
+ * `aria-disabled` rather than `disabled` so the tooltip still fires.
  */
 export function AudioMemoButton(): ReactElement {
   const memo = useAudioMemo()
@@ -47,12 +48,26 @@ export function AudioMemoButton(): ReactElement {
     )
   }
 
-  const activeLabel =
-    memo.phase === 'recording'
-      ? 'Stop recording'
-      : memo.phase === 'error'
-        ? 'Discard audio memo'
-        : 'Transcribing audio memo'
+  if (memo.phase === 'transcribing') {
+    return (
+      <Popover open>
+        <PopoverAnchor asChild>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Record audio memo"
+            onClick={() => memo.toggle()}
+            className="text-text-muted hover:text-text-secondary dark:hover:text-text"
+          >
+            <MicIcon className="size-5" />
+          </Button>
+        </PopoverAnchor>
+        <RecordingPopover />
+      </Popover>
+    )
+  }
+
+  const activeLabel = memo.phase === 'recording' ? 'Stop recording' : 'Discard audio memo'
 
   return (
     <Popover open>
@@ -62,11 +77,10 @@ export function AudioMemoButton(): ReactElement {
           size="icon-sm"
           className="rounded-full"
           aria-label={activeLabel}
-          disabled={memo.phase === 'transcribing'}
           onClick={() => {
             if (memo.phase === 'recording') {
               memo.toggle()
-            } else if (memo.phase === 'error') {
+            } else {
               memo.discard()
             }
           }}

--- a/apps/desktop/src/components/audio-memo/audio-memo-button.tsx
+++ b/apps/desktop/src/components/audio-memo/audio-memo-button.tsx
@@ -37,7 +37,7 @@ export function AudioMemoButton(): ReactElement {
               !memo.available && 'opacity-50 hover:bg-transparent hover:text-text-muted',
             )}
           >
-            <MicIcon className="size-[18px]" />
+            <MicIcon className="size-5" />
           </Button>
         </TooltipTrigger>
         <TooltipContent side="bottom">
@@ -72,7 +72,7 @@ export function AudioMemoButton(): ReactElement {
           }}
         >
           {memo.phase === 'error' ? (
-            <MicIcon className="size-[18px]" />
+            <MicIcon className="size-5" />
           ) : (
             <Square aria-hidden fill="currentColor" className="size-3" />
           )}

--- a/apps/desktop/src/components/audio-memo/recording-popover.tsx
+++ b/apps/desktop/src/components/audio-memo/recording-popover.tsx
@@ -11,8 +11,10 @@ import { useAudioMemo } from '@/providers/audio-memo-provider'
  * failure state with Retry/Discard. Esc cancels a live recording and
  * dismisses an error, but is deliberately inert while transcribing — the
  * user already committed the memo by stopping, and "cancelling" a save
- * that may have reached the provider would only feign control. Clicks
- * elsewhere don't dismiss; the recording owns its lifecycle.
+ * that may have reached the provider would only feign control. The mic
+ * beside the panel stays live while transcribing: memos queue, so the next
+ * recording can start immediately. Clicks elsewhere don't dismiss; the
+ * recording owns its lifecycle.
  */
 export function RecordingPopover(): ReactElement {
   const memo = useAudioMemo()

--- a/apps/desktop/src/providers/audio-memo-provider.test.tsx
+++ b/apps/desktop/src/providers/audio-memo-provider.test.tsx
@@ -255,6 +255,34 @@ describe('AudioMemoProvider', () => {
     expect(saveAudioMemo).toHaveBeenCalledTimes(1)
   })
 
+  it('a mic click landing in the stop gap starts the next memo once the recorder frees', async () => {
+    recorderControls.holdStop = true
+    const { result } = renderHook(() => useAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    act(() => {
+      void result.current.toggle()
+    })
+    expect(result.current.phase).toBe('transcribing')
+
+    // The button already reads as the idle mic — the click must not be
+    // swallowed by the stop's re-entry guard.
+    await act(async () => {
+      result.current.toggle()
+    })
+    expect(recorderControls.startSpy).toHaveBeenCalledTimes(1)
+
+    recorderControls.holdStop = false
+    await act(async () => {
+      recorderControls.releaseStop()
+    })
+    await waitFor(() => expect(result.current.phase).toBe('recording'))
+    expect(recorderControls.startSpy).toHaveBeenCalledTimes(2)
+    expect(saveAudioMemo).toHaveBeenCalledTimes(1)
+  })
+
   it('a new recording can start while a save is pending, and saves run serially in order', async () => {
     let releaseFirst: (outcome: SaveAudioMemoOutcome) => void = () => {}
     saveAudioMemo.mockImplementationOnce(

--- a/apps/desktop/src/providers/audio-memo-provider.test.tsx
+++ b/apps/desktop/src/providers/audio-memo-provider.test.tsx
@@ -255,6 +255,154 @@ describe('AudioMemoProvider', () => {
     expect(saveAudioMemo).toHaveBeenCalledTimes(1)
   })
 
+  it('a new recording can start while a save is pending, and saves run serially in order', async () => {
+    let releaseFirst: (outcome: SaveAudioMemoOutcome) => void = () => {}
+    saveAudioMemo.mockImplementationOnce(
+      () =>
+        new Promise<SaveAudioMemoOutcome>((resolve) => {
+          releaseFirst = resolve
+        }),
+    )
+    const second = {
+      blob: new Blob(['second'], { type: 'audio/mp4' }),
+      mimeType: 'audio/mp4',
+      durationMs: 2000,
+    }
+    const { result } = renderHook(() => useAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    await act(async () => {
+      result.current.toggle()
+    })
+    expect(result.current.phase).toBe('transcribing')
+
+    // The first save is still in flight — the mic must accept the next memo.
+    await act(async () => {
+      result.current.toggle()
+    })
+    expect(result.current.phase).toBe('recording')
+
+    recorderControls.stopResult = second
+    await act(async () => {
+      result.current.toggle()
+    })
+    expect(result.current.phase).toBe('transcribing')
+    expect(result.current.pendingCount).toBe(2)
+    // Serial: the second memo waits — concurrent saves would race the
+    // daily-note read-modify-write.
+    expect(saveAudioMemo).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      releaseFirst({ ok: true, text: 'memo one' })
+    })
+    await waitFor(() => expect(result.current.phase).toBe('idle'))
+    expect(result.current.pendingCount).toBe(0)
+    expect(saveAudioMemo).toHaveBeenCalledTimes(2)
+    expect(saveAudioMemo).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        payload: { kind: 'transcribe', audio: second.blob, mimeType: 'audio/mp4' },
+      }),
+    )
+  })
+
+  it('a failure parks the queue; retry lands the failed memo before the ones behind it', async () => {
+    let releaseFirst: (outcome: SaveAudioMemoOutcome) => void = () => {}
+    saveAudioMemo.mockImplementationOnce(
+      () =>
+        new Promise<SaveAudioMemoOutcome>((resolve) => {
+          releaseFirst = resolve
+        }),
+    )
+    const second = {
+      blob: new Blob(['second'], { type: 'audio/mp4' }),
+      mimeType: 'audio/mp4',
+      durationMs: 2000,
+    }
+    const { result } = renderHook(() => useAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    await act(async () => {
+      result.current.toggle()
+    })
+    await act(async () => {
+      result.current.toggle()
+    })
+    recorderControls.stopResult = second
+    await act(async () => {
+      result.current.toggle()
+    })
+
+    await act(async () => {
+      releaseFirst({ ok: false, message: 'provider down', resume: { kind: 'append', text: 'memo one' } })
+    })
+    await waitFor(() => expect(result.current.phase).toBe('error'))
+    // The second memo holds behind the failure — retrying later must not
+    // append the first transcript after the second.
+    expect(saveAudioMemo).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      result.current.retry()
+    })
+    await waitFor(() => expect(result.current.phase).toBe('idle'))
+    expect(saveAudioMemo).toHaveBeenCalledTimes(3)
+    expect(saveAudioMemo.mock.calls[1]?.[0].payload).toEqual({ kind: 'append', text: 'memo one' })
+    expect(saveAudioMemo.mock.calls[2]?.[0].payload).toEqual({
+      kind: 'transcribe',
+      audio: second.blob,
+      mimeType: 'audio/mp4',
+    })
+  })
+
+  it('discarding a failed memo releases the queue behind it', async () => {
+    let releaseFirst: (outcome: SaveAudioMemoOutcome) => void = () => {}
+    saveAudioMemo.mockImplementationOnce(
+      () =>
+        new Promise<SaveAudioMemoOutcome>((resolve) => {
+          releaseFirst = resolve
+        }),
+    )
+    const second = {
+      blob: new Blob(['second'], { type: 'audio/mp4' }),
+      mimeType: 'audio/mp4',
+      durationMs: 2000,
+    }
+    const { result } = renderHook(() => useAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    await act(async () => {
+      result.current.toggle()
+    })
+    await act(async () => {
+      result.current.toggle()
+    })
+    recorderControls.stopResult = second
+    await act(async () => {
+      result.current.toggle()
+    })
+
+    await act(async () => {
+      releaseFirst({ ok: false, message: 'provider down', resume: { kind: 'append', text: 'memo one' } })
+    })
+    await waitFor(() => expect(result.current.phase).toBe('error'))
+
+    await act(async () => {
+      result.current.discard()
+    })
+    await waitFor(() => expect(result.current.phase).toBe('idle'))
+    expect(saveAudioMemo).toHaveBeenCalledTimes(2)
+    expect(saveAudioMemo).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        payload: { kind: 'transcribe', audio: second.blob, mimeType: 'audio/mp4' },
+      }),
+    )
+  })
+
   it('a second toggle during the permission prompt aborts the request', async () => {
     recorderControls.holdStart = true
     const { result } = renderHook(() => useAudioMemo(), { wrapper })

--- a/apps/desktop/src/providers/audio-memo-provider.tsx
+++ b/apps/desktop/src/providers/audio-memo-provider.tsx
@@ -15,6 +15,7 @@ import {
   saveAudioMemo,
   type AudioMemoResume,
   type GraphInfo,
+  type SaveAudioMemoOutcome,
 } from '@reflect/core'
 import { isRecordingSupported, useAudioRecorder } from '@/hooks/use-audio-recorder'
 import { todayIso } from '@/lib/dates'
@@ -30,8 +31,18 @@ import { useSidebar } from '@/providers/sidebar-provider'
  * the mic button unmounts with the sidebar (`Mod-\`), and a recording must
  * never outlive its UI invisibly: collapsing mid-recording stops and saves
  * instead of leaving a hidden hot microphone.
+ *
+ * Saves drain through a serial queue so memos can be recorded back-to-back
+ * while earlier ones are still transcribing. One save at a time keeps the
+ * daily-note read-modify-write race-free and appends memos in recording
+ * order; a resumable failure parks the queue behind the error, so a retry
+ * lands its transcript before the memos recorded after it.
  */
 
+/**
+ * 'transcribing' means committed memos are still saving in the background —
+ * the mic stays available, so the next recording can start immediately.
+ */
 export type AudioMemoPhase = 'idle' | 'requesting' | 'recording' | 'transcribing' | 'error'
 
 interface AudioMemoContextValue {
@@ -40,6 +51,8 @@ interface AudioMemoContextValue {
   elapsedMs: number
   /** The live input stream, for the waveform. */
   stream: MediaStream | null
+  /** Memos committed but not yet appended — queued plus in flight. */
+  pendingCount: number
   /** False when no OpenAI/Gemini model is configured or the platform can't record. */
   available: boolean
   /** Why the mic is disabled (tooltip copy), null when `available`. */
@@ -54,7 +67,7 @@ interface AudioMemoContextValue {
   cancel: () => void
   /** Re-run the failed step — transcription is never paid for twice. */
   retry: () => void
-  /** Leave the error phase, dropping the failed payload. */
+  /** Drop the failed memo and let the queue continue. */
   discard: () => void
 }
 
@@ -83,7 +96,9 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
   const { settings } = useSettings()
   const { collapsed, toggleSidebar } = useSidebar()
 
-  const [saving, setSaving] = useState(false)
+  const [pendingCount, setPendingCount] = useState(0)
+  /** True from the stop click until the recorder hands over the blob. */
+  const [stopping, setStopping] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [resume, setResume] = useState<AudioMemoResume | null>(null)
 
@@ -112,51 +127,66 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
   const collapsedRef = useRef(collapsed)
   collapsedRef.current = collapsed
 
-  // Re-entry guard: state-based `saving` flips a render too late to stop a
-  // rapid second Retry, and two pipelines would append the transcript twice.
-  const savingRef = useRef(false)
+  /** Committed memos waiting their turn; the pump owns the head. */
+  const queueRef = useRef<AudioMemoResume[]>([])
+  /** Single-drainer guard: one pump loop at a time, one append at a time. */
+  const pumpingRef = useRef(false)
+  /**
+   * The failed step a retry should re-run. While parked, the queue holds —
+   * memo order in the note must survive the failure. A ref, not state: rapid
+   * double Retry must see the first click's take synchronously, or two
+   * pipelines append the transcript twice.
+   */
+  const parkedRef = useRef<AudioMemoResume | null>(null)
+  /** Re-entry guard for the stop click's await gap. */
+  const stoppingRef = useRef(false)
 
-  const runSave = useCallback(
-    async (payload: AudioMemoResume): Promise<void> => {
-      if (savingRef.current) {
-        return
-      }
-      savingRef.current = true
-      setSaving(true)
-      setError(null)
-      try {
-        const outcome = await saveAudioMemo({
-          payload,
-          models: { models: settings.aiModels, defaultModelId: settings.defaultAiModelId },
-          date: todayIso(),
-          generation: graph.generation,
-          fetchFn: providerFetch,
-        })
-        if (outcome.ok) {
-          setResume(null)
-        } else {
-          setError(outcome.message)
+  const pump = useCallback(async (): Promise<void> => {
+    if (pumpingRef.current) {
+      return
+    }
+    pumpingRef.current = true
+    try {
+      while (parkedRef.current === null) {
+        const payload = queueRef.current.shift()
+        if (payload === undefined) {
+          break
+        }
+        let outcome: SaveAudioMemoOutcome
+        try {
+          outcome = await saveAudioMemo({
+            payload,
+            models: { models: settings.aiModels, defaultModelId: settings.defaultAiModelId },
+            date: todayIso(),
+            generation: graph.generation,
+            fetchFn: providerFetch,
+          })
+        } finally {
+          setPendingCount((count) => count - 1)
+        }
+        if (!outcome.ok) {
+          // Resumable: park the queue behind the failure. Non-resumable
+          // (nothing to re-run, nothing to mis-order): surface and keep
+          // draining the memos behind it.
+          parkedRef.current = outcome.resume
           setResume(outcome.resume)
+          setError(outcome.message)
           if (collapsedRef.current) {
             // The mic button (and its popover) unmounted with the sidebar —
             // the failure must still surface somewhere.
             startOperation('Saving audio memo').fail(outcome.message)
           }
         }
-      } finally {
-        savingRef.current = false
-        setSaving(false)
       }
-    },
-    [settings.aiModels, settings.defaultAiModelId, graph.generation],
-  )
+    } finally {
+      pumpingRef.current = false
+    }
+  }, [settings.aiModels, settings.defaultAiModelId, graph.generation])
 
   const start = useCallback(async (): Promise<void> => {
     if (!supported || transcriptionConfig === null) {
       return
     }
-    setError(null)
-    setResume(null)
     if (collapsedRef.current) {
       // Never record without visible recording UI.
       toggleSidebar()
@@ -173,23 +203,38 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
   }, [supported, transcriptionConfig, toggleSidebar, startRecorder])
 
   const stopAndSave = useCallback(async (): Promise<void> => {
+    if (stoppingRef.current) {
+      return
+    }
+    stoppingRef.current = true
     // The stop click commits the memo: flip to 'transcribing' before the stop
     // settles, so an Esc landing in the await gap can't read a lingering
     // 'recording' phase and cancel a recording the user just saved.
-    setSaving(true)
-    const recording = await stopRecorder()
-    if (recording === null) {
-      setSaving(false)
-      return
+    setStopping(true)
+    try {
+      const recording = await stopRecorder()
+      if (recording !== null) {
+        queueRef.current.push({
+          kind: 'transcribe',
+          audio: recording.blob,
+          mimeType: recording.mimeType,
+        })
+        setPendingCount((count) => count + 1)
+        void pump()
+      }
+    } finally {
+      stoppingRef.current = false
+      setStopping(false)
     }
-    await runSave({ kind: 'transcribe', audio: recording.blob, mimeType: recording.mimeType })
-  }, [stopRecorder, runSave])
+  }, [stopRecorder, pump])
   stopAndSaveRef.current = () => void stopAndSave()
 
   const discard = useCallback((): void => {
+    parkedRef.current = null
     setError(null)
     setResume(null)
-  }, [])
+    void pump()
+  }, [pump])
 
   const toggle = useCallback((): void => {
     if (recorder.status === 'recording') {
@@ -208,22 +253,27 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
       } else {
         discard()
       }
-    } else if (recorder.status === 'idle' && !saving) {
+    } else if (recorder.status === 'idle') {
       void start()
     }
-  }, [recorder.status, saving, error, stopAndSave, cancelRecorder, start, toggleSidebar, discard])
+  }, [recorder.status, error, stopAndSave, cancelRecorder, start, toggleSidebar, discard])
 
   const cancel = useCallback((): void => {
     cancelRecorder()
-    setError(null)
-    setResume(null)
   }, [cancelRecorder])
 
   const retry = useCallback((): void => {
-    if (resume !== null) {
-      void runSave(resume)
+    const parked = parkedRef.current
+    if (parked === null) {
+      return
     }
-  }, [resume, runSave])
+    parkedRef.current = null
+    setError(null)
+    setResume(null)
+    queueRef.current.unshift(parked)
+    setPendingCount((count) => count + 1)
+    void pump()
+  }, [pump])
 
   // Collapsing the sidebar mid-flow: stop-and-save a live recording, and
   // abandon a pending permission request — a grant arriving after the
@@ -239,14 +289,18 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
     }
   }, [collapsed, recorder.status, cancelRecorder, stopAndSave])
 
+  // A live capture owns the surface — a background save's failure parks and
+  // shows after the stop, never yanking the waveform mid-recording.
   const phase: AudioMemoPhase =
-    error !== null
-      ? 'error'
-      : saving
-        ? 'transcribing'
-        : recorder.status === 'idle'
-          ? 'idle'
-          : recorder.status
+    recorder.status === 'recording' && !stopping
+      ? 'recording'
+      : recorder.status === 'requesting'
+        ? 'requesting'
+        : error !== null
+          ? 'error'
+          : stopping || pendingCount > 0
+            ? 'transcribing'
+            : 'idle'
 
   const unavailableReason = !supported
     ? UNSUPPORTED_REASON
@@ -259,6 +313,7 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
       phase,
       elapsedMs: recorder.elapsedMs,
       stream: recorder.stream,
+      pendingCount,
       available: unavailableReason === null,
       unavailableReason,
       error,
@@ -272,6 +327,7 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
       phase,
       recorder.elapsedMs,
       recorder.stream,
+      pendingCount,
       unavailableReason,
       error,
       resume,

--- a/apps/desktop/src/providers/audio-memo-provider.tsx
+++ b/apps/desktop/src/providers/audio-memo-provider.tsx
@@ -140,6 +140,8 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
   const parkedRef = useRef<AudioMemoResume | null>(null)
   /** Re-entry guard for the stop click's await gap. */
   const stoppingRef = useRef(false)
+  /** The in-flight stop, so a mic click in the gap can chain the next memo. */
+  const stopSettledRef = useRef<Promise<void>>(Promise.resolve())
 
   const pump = useCallback(async (): Promise<void> => {
     if (pumpingRef.current) {
@@ -211,21 +213,25 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
     // settles, so an Esc landing in the await gap can't read a lingering
     // 'recording' phase and cancel a recording the user just saved.
     setStopping(true)
-    try {
-      const recording = await stopRecorder()
-      if (recording !== null) {
-        queueRef.current.push({
-          kind: 'transcribe',
-          audio: recording.blob,
-          mimeType: recording.mimeType,
-        })
-        setPendingCount((count) => count + 1)
-        void pump()
+    const settled = (async (): Promise<void> => {
+      try {
+        const recording = await stopRecorder()
+        if (recording !== null) {
+          queueRef.current.push({
+            kind: 'transcribe',
+            audio: recording.blob,
+            mimeType: recording.mimeType,
+          })
+          setPendingCount((count) => count + 1)
+          void pump()
+        }
+      } finally {
+        stoppingRef.current = false
+        setStopping(false)
       }
-    } finally {
-      stoppingRef.current = false
-      setStopping(false)
-    }
+    })()
+    stopSettledRef.current = settled
+    return settled
   }, [stopRecorder, pump])
   stopAndSaveRef.current = () => void stopAndSave()
 
@@ -238,7 +244,14 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
 
   const toggle = useCallback((): void => {
     if (recorder.status === 'recording') {
-      void stopAndSave()
+      if (stoppingRef.current) {
+        // The click landed in the stop's await gap, where the button already
+        // reads as the idle mic — honor it as "record the next memo" once
+        // the recorder frees, instead of swallowing it on the re-entry guard.
+        void stopSettledRef.current.then(() => start())
+      } else {
+        void stopAndSave()
+      }
     } else if (recorder.status === 'requesting') {
       // A second press while the OS prompt is up aborts the request — the
       // alternative is a click that visibly does nothing.


### PR DESCRIPTION
## Summary

- Bump the mic icon from `size-[18px]` to `size-5` (20px)
- **Record memos in quick succession**: stopping a recording no longer blocks the mic while transcription runs. Saves drain through a serial queue in the provider — the stop click enqueues the memo and frees the button immediately.

## Design notes

- **Serial, not concurrent**: `saveAudioMemo` does a read-modify-write append on today's daily note, so concurrent saves would race and could drop a transcript. One save at a time also guarantees memos land in recording order.
- **Failures park the queue**: a resumable failure (provider down, append failed) holds the memos behind it so a retry lands its transcript before later memos — never out of order. Discarding the failed memo releases the queue. Non-resumable failures (empty transcript) surface the error but let the rest drain, since they produce no append.
- **Phase priority**: a live recording now wins the surface over a background failure — the error shows after the stop instead of yanking the waveform mid-recording.
- **UI**: during `transcribing` the button stays a live mic with the "Transcribing…" popover beside it, instead of a disabled spinner button.

## Test plan

- [ ] Record a memo, stop it, and immediately record another while the first is transcribing — both transcripts append in recording order
- [ ] Fail a save (e.g. provider down) with another memo queued — Retry appends the failed memo's transcript first; Discard drops it and saves the rest
- [ ] Esc remains inert while transcribing; Esc during a recording still cancels it
- [x] `pnpm test --run` on the audio-memo provider and button suites (26 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes memo persistence ordering and concurrency around daily-note appends; mistakes could drop or mis-order transcripts, though behavior is heavily covered by new provider tests.
> 
> **Overview**
> Enables **back-to-back audio memos** while earlier ones are still transcribing: stopping a recording enqueues the blob and frees the mic immediately instead of blocking on `saveAudioMemo`.
> 
> `AudioMemoProvider` replaces the single in-flight save with a **serial queue** (`pump`, `pendingCount`, `parkedRef`) so daily-note appends stay ordered and race-free. Resumable failures **park** later memos until Retry or Discard; a click during the async stop gap chains the next recording; phase logic gives **live recording** priority over a background error.
> 
> **UI:** During `transcribing`, the sidebar mic is an enabled ghost button (not a disabled red control) with the “Transcribing…” popover; mic icon uses `size-5`. Provider and button tests cover queue ordering, parking, and the stop-gap toggle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ac1bb6ebe70db9907a8edd558a0f43221020c7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->