### PR TITLE
Keychain commands hop to a blocking thread so a prompt can't freeze startup

### DIFF
--- a/apps/desktop/src-tauri/src/secrets.rs
+++ b/apps/desktop/src-tauri/src/secrets.rs
@@ -40,22 +40,35 @@ fn delete_from(entry: &Entry) -> AppResult<()> {
     }
 }
 
+/// Keychain calls run on a blocking thread, never the main loop: macOS parks
+/// `get_password` on a user-facing password prompt whenever the binary's code
+/// signature doesn't match the item's ACL (every dev rebuild), and a sync
+/// command would freeze the whole app — no paint, no notes — until the user
+/// answers.
+async fn run_blocking<T: Send + 'static>(
+    task: impl FnOnce() -> AppResult<T> + Send + 'static,
+) -> AppResult<T> {
+    tauri::async_runtime::spawn_blocking(task)
+        .await
+        .map_err(|err| AppError::io(err.to_string()))?
+}
+
 /// Command: store `value` under `name`, replacing any prior value.
 #[tauri::command]
-pub fn secret_set(name: String, value: String) -> AppResult<()> {
-    set_in(&entry(&name)?, &value)
+pub async fn secret_set(name: String, value: String) -> AppResult<()> {
+    run_blocking(move || set_in(&entry(&name)?, &value)).await
 }
 
 /// Command: the secret stored under `name`, or `None` when there isn't one.
 #[tauri::command]
-pub fn secret_get(name: String) -> AppResult<Option<String>> {
-    get_from(&entry(&name)?)
+pub async fn secret_get(name: String) -> AppResult<Option<String>> {
+    run_blocking(move || get_from(&entry(&name)?)).await
 }
 
 /// Command: remove the secret stored under `name`.
 #[tauri::command]
-pub fn secret_delete(name: String) -> AppResult<()> {
-    delete_from(&entry(&name)?)
+pub async fn secret_delete(name: String) -> AppResult<()> {
+    run_blocking(move || delete_from(&entry(&name)?)).await
 }
 
 #[cfg(test)]
@@ -85,5 +98,17 @@ mod tests {
 
         // Idempotent: deleting again is fine.
         delete_from(&entry).unwrap();
+    }
+
+    /// The commands hop to a blocking thread (a parked keychain prompt must
+    /// never stall the main loop); this exercises that plumbing end-to-end
+    /// against the mock store.
+    #[test]
+    fn commands_resolve_through_the_blocking_hop() {
+        keyring::set_default_credential_builder(keyring::mock::default_credential_builder());
+        tauri::async_runtime::block_on(async {
+            assert_eq!(secret_get("plumbing-test".into()).await.unwrap(), None);
+            secret_delete("plumbing-test".into()).await.unwrap();
+        });
     }
 }


### PR DESCRIPTION
## What

Running `tauri dev` with stored secrets (AI keys, backup token) showed the macOS keychain password prompt **and the app stayed blank — no notes — until it was answered**.

## Why

`secret_set` / `secret_get` / `secret_delete` were synchronous `#[tauri::command]`s, and Tauri executes sync commands **on the main thread**. macOS parks `get_password` on a user-facing prompt whenever the requesting binary's code signature doesn't match the keychain item's ACL — which is every dev rebuild, since ad-hoc dev signatures change per compile. A parked keyring call on the main thread freezes the entire event loop: no paint, no input, until the password lands.

The git commands were already `async` for exactly this reason; the secret commands are the same class of arbitrarily-blocking I/O and just hadn't been treated as such.

## How

All three commands are now `async fn` and run the keyring call through `tauri::async_runtime::spawn_blocking` (a parked prompt shouldn't pin an async-runtime worker either). No frontend changes: callers already awaited promises, and the only launch-time reader — the backup token — lives in a `SyncProvider` effect that renders children unconditionally. With the main loop free, the app paints immediately and the keychain prompt floats above a working window; only the specific feature awaiting the secret (sync init, memo save, chat send) waits.

Note the prompt itself still appears in dev builds — that's macOS ACL behavior with unsigned binaries, not something the app can remove (signed release builds keep a stable identity, so one "Always Allow" persists). This PR makes it non-blocking, which is the part that was ours to fix.

## Testing

- New Rust test exercises the spawn_blocking plumbing end-to-end against the mock keystore; the existing round-trip test still passes (`cargo test -p reflect-open secrets`).
- `cargo clippy -p reflect-open` clean.
- Manual: run `tauri dev` with a stored key and a stale ACL — notes should render with the prompt floating above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Same keyring behavior with threading only; async Tauri commands remain promise-compatible for existing frontend callers.
> 
> **Overview**
> **Keychain Tauri commands no longer block the main thread** during macOS password prompts (common in dev when code signatures don’t match keychain ACLs).
> 
> `secret_set`, `secret_get`, and `secret_delete` are now **async** and delegate keyring work through a shared **`run_blocking`** helper that uses `tauri::async_runtime::spawn_blocking`, matching the existing git command pattern. The UI can paint and handle input while a prompt is up; only callers awaiting a secret wait on the result. No frontend API change.
> 
> Adds a test that runs the async commands through **`block_on`** against the mock keychain to verify the blocking hop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beab2dfb88787958e44aaa7a06224df921b6135d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->