### PR TITLE
fix(chat): drop stray focus outline on the composer textarea

### DIFF
--- a/apps/desktop/src/components/chat/chat-input.tsx
+++ b/apps/desktop/src/components/chat/chat-input.tsx
@@ -50,6 +50,9 @@ export function ChatInput(): ReactElement {
           aria-label="Chat message"
           rows={2}
           autoFocus
+          /* Opts out of the global :focus-visible outline (styles/index.css);
+             the wrapper's focus-within border is the focus treatment here. */
+          data-slot="textarea"
           className="field-sizing-content max-h-48 w-full resize-none bg-transparent px-3.5 pt-3 text-sm text-text outline-none placeholder:text-text-muted"
         />
         <div className="flex items-center gap-2 px-2.5 pb-2.5">


### PR DESCRIPTION
## What changed

Tagged the AI chat composer's `<textarea>` with `data-slot="textarea"` so it opts into the existing global-focus-ring exemption in `styles/index.css`.

## Why

Focusing the chat input drew a rectangular 2px outline around the textarea, clashing with the composer's rounded `focus-within:border-ring` border:

- `styles/index.css` applies a global `:focus-visible` outline to all form controls. That rule is **unlayered**, so the Tailwind `outline-none` utility on the textarea (which lives in a cascade layer) can never override it.
- shadcn inputs already opt out via the `:where([data-slot='input'], [data-slot='textarea'], [cmdk-input]):focus-visible { outline: none }` rule, but the chat composer uses a raw `<textarea>` without the attribute.

Adding `data-slot="textarea"` reuses that exemption; the wrapper's focus-within border remains the sole focus treatment, as designed.

## Reviewer notes

- One-attribute change plus a comment explaining the constraint — no CSS edits.
- `pnpm check` passes; all 7 `chat-screen.test.tsx` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-attribute focus styling fix with no auth, data, or behavior changes.
> 
> **Overview**
> Fixes a **double focus ring** on the AI chat composer: the raw `<textarea>` in `chat-input.tsx` now sets `data-slot="textarea"` so it matches the same **global `:focus-visible` outline opt-out** already used by shadcn `Textarea` in `styles/index.css`.
> 
> `outline-none` on the element could not win against the unlayered global form-control outline, so focus showed both that rectangle and the wrapper’s `focus-within:border-ring`. With the attribute, only the rounded wrapper border indicates focus, as intended. A short comment documents why the slot is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2960800c2d65595340540150b4fee279a503ea5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->