### PR TITLE
fix(types): annotate third-party callback event params explicitly

### DIFF
--- a/apps/desktop/src/components/command-palette/command-palette.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactElement } from 'react'
+import { useEffect, useRef, useState, type KeyboardEvent, type ReactElement } from 'react'
 import { Command } from 'cmdk'
 import { parseHighlights } from '@reflect/core'
 import { CalendarDays, FileText } from 'lucide-react'
@@ -123,7 +123,7 @@ export function CommandPalette({ context }: CommandPaletteProps): ReactElement |
           shouldFilter={false}
           value={selectedValue}
           onValueChange={setSelectedValue}
-          onKeyDown={(event) => {
+          onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
             if (event.key === 'Escape') {
               event.preventDefault()
               closePalette()

--- a/apps/desktop/src/editor/wiki-autocomplete.tsx
+++ b/apps/desktop/src/editor/wiki-autocomplete.tsx
@@ -7,6 +7,7 @@ import {
   AutocompletePopup,
   AutocompletePositioner,
   AutocompleteRoot,
+  type AutocompleteRootProps,
 } from '@prosekit/react/autocomplete'
 import { hasBridge, suggestWikiTargets } from '@reflect/core'
 import { formatDayLabel } from '@/lib/dates'
@@ -26,6 +27,9 @@ import { buildAutocompleteEntries } from './wiki-autocomplete-entries'
 
 /** `[[` plus a partial target; a typed `]` or `[` ends the match. */
 const WIKI_TRIGGER = /\[\[([^[\]]*)$/u
+
+type QueryChangeEvent = Parameters<NonNullable<AutocompleteRootProps['onQueryChange']>>[0]
+type OpenChangeEvent = Parameters<NonNullable<AutocompleteRootProps['onOpenChange']>>[0]
 
 interface WikiAutocompleteProps {
   /**
@@ -71,8 +75,8 @@ export function WikiAutocomplete({ onCreate }: WikiAutocompleteProps): ReactElem
       editor={editor}
       regex={WIKI_TRIGGER}
       filter={null} // ranking is the index's job; the popup must not re-filter
-      onQueryChange={(event) => setQuery(event.detail)}
-      onOpenChange={(event) => setOpen(event.detail)}
+      onQueryChange={(event: QueryChangeEvent) => setQuery(event.detail)}
+      onOpenChange={(event: OpenChangeEvent) => setOpen(event.detail)}
     >
       <AutocompletePositioner>
         <AutocompletePopup className="reflect-autocomplete">


### PR DESCRIPTION
## What changed

Adds explicit types to three callback event parameters that previously relied on contextual typing from third-party component props:

- `command-palette.tsx`: `onKeyDown` on cmdk's `Command` now takes `KeyboardEvent<HTMLDivElement>` (cmdk's `Command` renders a div per its declarations).
- `wiki-autocomplete.tsx`: `onQueryChange` / `onOpenChange` on ProseKit's `AutocompleteRoot` now take `QueryChangeEvent` / `OpenChangeEvent` aliases derived from `AutocompleteRootProps`.

## Why

`pnpm typecheck` reported TS7006 implicit-any errors on exactly these three parameters in a checkout of master. All three are props of third-party components (cmdk, ProseKit) while plain-DOM handlers in the same files never erred — the signature of those packages' type declarations failing to resolve, which turns the components into `any` and strips contextual typing. The likely root cause there is a stale/partial `node_modules` (the errors do not reproduce in a fresh worktree install, where typecheck passes before and after this change). Explicit annotations keep these spots typed regardless of how the host environment resolves the packages' types.

## Notes for review

- The ProseKit event types are derived via `Parameters<NonNullable<AutocompleteRootProps['onQueryChange']>>[0]` instead of importing the event classes from `@prosekit/web/autocomplete`, because `@prosekit/web` is a transitive dependency not declared in `apps/desktop/package.json` — and deriving tracks future ProseKit type changes automatically.
- `pnpm check` (typecheck + lint) passes; the two oxlint warnings in unrelated files pre-exist on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only annotations on existing handlers; no logic, API, or runtime behavior changes.
> 
> **Overview**
> Adds explicit TypeScript annotations on third-party component callbacks so `pnpm typecheck` no longer reports **TS7006** implicit-`any` on those parameters when package typings fail to resolve (e.g. stale `node_modules`).
> 
> In **`command-palette.tsx`**, cmdk's `Command` **`onKeyDown`** handler is typed as `KeyboardEvent<HTMLDivElement>`. In **`wiki-autocomplete.tsx`**, ProseKit **`AutocompleteRoot`** **`onQueryChange`** / **`onOpenChange`** use local aliases (`QueryChangeEvent`, `OpenChangeEvent`) derived from `AutocompleteRootProps` via `Parameters<…>`, plus an import of `AutocompleteRootProps`. Handler bodies are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5328c4fa2ae351b8e7dc7e3728c484b6822896a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->