### PR TITLE
Similar notes: seed from every chunk, pinned-shelf row styling

### DIFF
--- a/apps/desktop/src/components/context-sidebar/similar-notes-section.tsx
+++ b/apps/desktop/src/components/context-sidebar/similar-notes-section.tsx
@@ -13,12 +13,14 @@ interface SimilarNotesSectionProps {
 /**
  * "Similar notes" as a context-sidebar section, in the old app's exact shape:
  * one truncated title per neighbor with a flipped return-arrow on the right —
- * no snippets. Neighbors of `path` are seeded by the note's stored chunk
- * vectors. Renders nothing at all when there are no results — semantic search
- * may be disabled or the note not yet embedded, and an empty box would just
- * advertise a missing feature. Query errors are deliberately just as quiet:
- * a failing semantic leg means an optional feature is unavailable, not that
- * the index is broken. Shared by the daily and note context sidebars.
+ * no snippets. Rows borrow the Pinned shelf's idiom (`SidebarNoteRow`):
+ * compact `py-1` rows whose hover wash bleeds past the section's text line.
+ * Neighbors of `path` are seeded by the note's stored chunk vectors. Renders
+ * nothing at all when there are no results — semantic search may be disabled
+ * or the note not yet embedded, and an empty box would just advertise a
+ * missing feature. Query errors are deliberately just as quiet: a failing
+ * semantic leg means an optional feature is unavailable, not that the index
+ * is broken. Shared by the daily and note context sidebars.
  */
 export function SimilarNotesSection({ path }: SimilarNotesSectionProps): ReactElement | null {
   const { navigate } = useRouter()
@@ -29,15 +31,19 @@ export function SimilarNotesSection({ path }: SimilarNotesSectionProps): ReactEl
 
   return (
     <SidebarSection storageKey="similar" title="Similar notes">
-      <ul className="space-y-2">
+      <ul className="space-y-1">
         {related.map((hit) => (
-          <li key={hit.path}>
+          // The negative margin lets the hover wash bleed past the section's
+          // padding so the title text stays on the header's alignment line.
+          <li key={hit.path} className="-mx-1">
             <button
               type="button"
               onClick={() => navigate(routeForPath(hit.path))}
-              className="flex w-full cursor-pointer items-center space-x-1 rounded-lg px-3 py-2 text-left text-xs transition-colors duration-100 hover:bg-surface-hover"
+              className="flex w-full items-center space-x-1 rounded-md px-2.5 py-1 leading-5 text-text-secondary transition-colors duration-100 hover:bg-surface-hover hover:text-text"
             >
-              <span className="min-w-0 flex-1 truncate">{hit.title}</span>
+              <span className="min-w-0 flex-1 truncate text-left text-xs font-medium">
+                {hit.title}
+              </span>
               <span aria-hidden className="flex-none -scale-x-100">
                 <ArrowUturnLeftIcon width={13} height={13} />
               </span>

--- a/packages/core/src/embeddings/retrieve.test.ts
+++ b/packages/core/src/embeddings/retrieve.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { bestChunkPerNote, fuseRanked, type ChunkHitRow, type RetrievalHit } from './retrieve'
+import {
+  bestChunkPerNote,
+  fuseRanked,
+  mergeNearestFirst,
+  type ChunkHitRow,
+  type RetrievalHit,
+} from './retrieve'
 
 function hit(path: string, overrides?: Partial<RetrievalHit>): RetrievalHit {
   return {
@@ -58,6 +64,36 @@ describe('bestChunkPerNote', () => {
     const hits = bestChunkPerNote([row('notes/p.md', 0.1, { isPrivate: 1 })], 12)
     expect(hits[0].snippet).toBe('about notes/p.md')
     expect(hits[0].isPrivate).toBe(true)
+  })
+})
+
+describe('mergeNearestFirst (multi-seed related notes)', () => {
+  it('interleaves seed lists by distance so every seed contributes', () => {
+    const fromLeadChunk = [row('notes/morning.md', 0.3), row('notes/noise.md', 0.6)]
+    const fromLaterChunk = [row('notes/afternoon.md', 0.4)]
+    const merged = mergeNearestFirst([fromLeadChunk, fromLaterChunk])
+    expect(merged.map((entry) => entry.path)).toEqual([
+      'notes/morning.md',
+      'notes/afternoon.md',
+      'notes/noise.md',
+    ])
+  })
+
+  it('a neighbor found only by a later seed survives bestChunkPerNote', () => {
+    const fromLeadChunk = [row('notes/self.md', 0.0)]
+    const fromLaterChunk = [row('notes/self.md', 0.0), row('notes/afternoon.md', 0.4)]
+    const merged = mergeNearestFirst([fromLeadChunk, fromLaterChunk])
+    const hits = bestChunkPerNote(merged, 10, 'notes/self.md')
+    expect(hits.map((hit) => hit.path)).toEqual(['notes/afternoon.md'])
+  })
+
+  it('a note hit by several seeds keeps its best distance', () => {
+    const fromLeadChunk = [row('notes/both.md', 0.5, { text: 'far chunk' })]
+    const fromLaterChunk = [row('notes/both.md', 0.2, { text: 'near chunk' })]
+    const hits = bestChunkPerNote(mergeNearestFirst([fromLeadChunk, fromLaterChunk]), 10)
+    expect(hits).toHaveLength(1)
+    expect(hits[0].snippet).toBe('near chunk')
+    expect(hits[0].score).toBeCloseTo(0.8)
   })
 })
 

--- a/packages/core/src/embeddings/retrieve.ts
+++ b/packages/core/src/embeddings/retrieve.ts
@@ -199,35 +199,59 @@ export async function retrieve(query: string, options?: RetrieveOptions): Promis
 }
 
 /**
- * Semantic neighbors of an existing note, seeded by its own **stored** lead
- * chunk vector — no re-embedding, no pane-provided seed text: the embedding
- * sync keeps chunks current on every save, and the index invalidation scope
- * refetches consumers, so freshness is automatic. Returns [] when the note
- * has no vectors yet (model never enabled, or not yet embedded). Candidates
- * past {@link MAX_COSINE_DISTANCE} are dropped rather than padded in, so a
- * sparse graph shows few (or no) neighbors instead of wrong ones.
+ * KNN result lists from several seed vectors, merged nearest-first so
+ * {@link bestChunkPerNote} keeps each note's best distance across seeds.
  */
-export async function relatedNotes(path: string, limit = 6): Promise<RetrievalHit[]> {
-  const seed = await sql<{ vec: string }>`
+export function mergeNearestFirst(lists: ReadonlyArray<readonly ChunkHitRow[]>): ChunkHitRow[] {
+  return lists.flat().sort((a, b) => a.distance - b.distance)
+}
+
+/**
+ * Seed-vector cap for {@link relatedNotes}: one KNN query runs per seed, so
+ * a pathological note (a huge import) must not turn every sidebar refetch
+ * into hundreds of queries. Sixteen seeds cover ~16k chars of note text —
+ * past any real daily note — before later topics stop influencing neighbors.
+ */
+const MAX_RELATED_SEEDS = 16
+
+/**
+ * Semantic neighbors of an existing note, seeded by its own **stored** chunk
+ * vectors — no re-embedding, no pane-provided seed text: the embedding sync
+ * keeps chunks current on every save, and the index invalidation scope
+ * refetches consumers, so freshness is automatic. Every chunk seeds its own
+ * KNN pass (capped at {@link MAX_RELATED_SEEDS}) and the lists merge
+ * nearest-first, so a multi-topic note — a daily note above all — surfaces
+ * neighbors for anything written in it, not just its lead paragraph.
+ * Returns [] when the note has no vectors yet (model never enabled, or not
+ * yet embedded). Candidates past {@link MAX_COSINE_DISTANCE} are dropped
+ * rather than padded in, so a sparse graph shows few (or no) neighbors
+ * instead of wrong ones.
+ */
+export async function relatedNotes(path: string, limit = 10): Promise<RetrievalHit[]> {
+  const seeds = await sql<{ vec: string }>`
     SELECT vec_to_json(v.embedding) AS vec
     FROM embedding_chunks c
     JOIN embedding_vectors v ON v.rowid = c.id
     WHERE c.note_path = ${path}
     ORDER BY c.pos_from
-    LIMIT 1
+    LIMIT ${MAX_RELATED_SEEDS}
   `.execute(db)
-  const vec = seed.rows[0]?.vec
-  if (vec === undefined) {
+  if (seeds.rows.length === 0) {
     return []
   }
-  const result = await sql<ChunkHitRow>`
-    SELECT c.note_path AS path, n.title, c.heading, c.text,
-           n.is_private AS isPrivate, v.distance
-    FROM embedding_vectors v
-    JOIN embedding_chunks c ON c.id = v.rowid
-    JOIN notes n ON n.path = c.note_path
-    WHERE v.embedding MATCH ${vec} AND k = ${KNN_CANDIDATES}
-    ORDER BY v.distance
-  `.execute(db)
-  return bestChunkPerNote(result.rows, limit, path)
+  const neighborLists = await Promise.all(
+    seeds.rows.map(async (seed) => {
+      const result = await sql<ChunkHitRow>`
+        SELECT c.note_path AS path, n.title, c.heading, c.text,
+               n.is_private AS isPrivate, v.distance
+        FROM embedding_vectors v
+        JOIN embedding_chunks c ON c.id = v.rowid
+        JOIN notes n ON n.path = c.note_path
+        WHERE v.embedding MATCH ${seed.vec} AND k = ${KNN_CANDIDATES}
+        ORDER BY v.distance
+      `.execute(db)
+      return result.rows
+    }),
+  )
+  return bestChunkPerNote(mergeNearestFirst(neighborLists), limit, path)
 }


### PR DESCRIPTION
## What changed

**`relatedNotes` now seeds from every stored chunk vector, not just the lead chunk** (`packages/core/src/embeddings/retrieve.ts`). Each chunk runs its own KNN pass (capped at 16 seeds to bound query count on huge imports), and the result lists merge nearest-first so `bestChunkPerNote` keeps each neighbor's best distance across seeds. The default limit rises from 6 to 10.

**Similar-notes rows adopt the Pinned shelf's styling** (`apps/desktop/src/components/context-sidebar/similar-notes-section.tsx`): compact `px-2.5 py-1 leading-5` rows with `space-y-1`, `text-xs font-medium` in `text-text-secondary` with `hover:text-text`, and the pinned shelf's negative-margin trick so the hover wash bleeds past the section padding while the title text stays on the header's alignment line. The flipped return-arrow stays.

## Why

Similar notes were already wired into the daily context sidebar, but in practice rarely appeared there: a daily note is multi-topic, and seeding from only the first ~1000 characters meant everything written later in the day never influenced the neighbors. Verified against a live graph index that the multi-seed merge surfaces neighbors the lead-chunk seed missed.

The row restyle makes the list compact enough to show the longer neighbor list without dominating the sidebar.

## Notes for review

- The 0.7 cosine-distance noise cutoff is deliberately unchanged: measured with the actual all-MiniLM-L6-v2 model, related chunk-to-chunk content lands at ~0.47–0.63 and unrelated at ~0.9+, so the cutoff behaves correctly for note-to-note matching too. A note whose content has no semantic neighbors still shows nothing rather than padding in wrong notes.
- `mergeNearestFirst` is exported and unit-tested (three new tests in `retrieve.test.ts`); the SQL path itself stays thin, matching the existing test approach.
- `pnpm check` clean; embeddings (12) and context-sidebar (35) tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Sidebar refetches can run up to 16 KNN queries per note (capped), changing neighbor results and load; logic is tested but behavior shifts for long notes.
> 
> **Overview**
> **Similar notes** now seed semantic neighbors from **every stored chunk** (up to 16), not only the lead chunk. Each seed runs a KNN query; results are merged with new **`mergeNearestFirst`** so **`bestChunkPerNote`** keeps each neighbor’s best distance. Default neighbor count rises **6 → 10**, aimed especially at multi-topic **daily notes**.
> 
> The context sidebar **Similar notes** list uses **Pinned shelf** row styling: tighter spacing (`space-y-1`, `py-1`), secondary text with hover promotion, and **`-mx-1`** so the hover wash aligns with the section header.
> 
> Three unit tests cover **`mergeNearestFirst`** interleaving, later-seed-only neighbors, and deduping to the nearest chunk per note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49df11296521416c5fbbbcf96951d177425717d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->