### PR TITLE
Release: publish command — sign, notarize, and upload the DMG to a GitHub release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,7 @@ pnpm tauri dev        # Full Tauri app with hot reload (stages the CLI sidecar f
 pnpm build            # turbo build pipeline → apps/desktop/dist/
 pnpm tauri build      # Native app bundle, incl. the reflect CLI sidecar
 pnpm release:macos    # Signed + notarized macOS build for distribution (docs/macos-distribution.md)
+pnpm release:macos publish  # The above, then upload the DMG to a new GitHub release
 ```
 
 # Code Conventions

--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -4,6 +4,7 @@
 //   pnpm release:macos              Signed + notarized build, then verify
 //   pnpm release:macos setup        Store notarization credentials (one-time)
 //   pnpm release:macos verify       Re-run Gatekeeper checks on existing bundles
+//   pnpm release:macos publish      Build, then upload the DMG to a new GitHub release
 //   pnpm release:macos --no-notarize  Signed-only build (won't pass Gatekeeper elsewhere)
 //
 // Signing configuration is intentionally not committed — contributors must be
@@ -145,9 +146,14 @@ function hostArch() {
   return arch
 }
 
+/** Parse tauri.conf.json — the source of truth for the bundle name and version. */
+function readTauriConf() {
+  return JSON.parse(readFileSync(join(appDir, 'src-tauri', 'tauri.conf.json'), 'utf8'))
+}
+
 /** Derive bundle output paths from tauri.conf.json and cargo's target dir. */
 function bundlePaths() {
-  const conf = JSON.parse(readFileSync(join(appDir, 'src-tauri', 'tauri.conf.json'), 'utf8'))
+  const conf = readTauriConf()
   const metadata = JSON.parse(
     capture('cargo', ['metadata', '--format-version', '1', '--no-deps'], { cwd: repoRoot }),
   )
@@ -284,6 +290,75 @@ function build({ notarize }) {
   log(notarize ? 'done — ready to distribute' : 'done — signed but NOT notarized')
 }
 
+/** Assert the GitHub CLI is installed and authenticated. */
+function ensureGhReady() {
+  if (run('gh', ['--version']).status !== 0) {
+    fail('GitHub CLI not found — install it from https://cli.github.com and run `gh auth login`')
+  }
+  const auth = run('gh', ['auth', 'status'])
+  if (auth.status !== 0) fail(`gh is not authenticated — run \`gh auth login\`\n${auth.output.trim()}`)
+}
+
+/**
+ * Assert HEAD is a clean, pushed commit and return its SHA. The release tag
+ * is created at this commit, so it must exist on GitHub and match what gets
+ * built.
+ */
+function ensurePublishableCommit() {
+  if (capture('git', ['status', '--porcelain']).trim() !== '') {
+    fail('the working tree has uncommitted changes — commit or stash them before publishing')
+  }
+  const commit = capture('git', ['rev-parse', 'HEAD']).trim()
+  if (capture('git', ['branch', '--remotes', '--contains', commit]).trim() === '') {
+    fail('HEAD is not on any remote branch — push it first so the release tag points at published code')
+  }
+  return commit
+}
+
+/** Assert no release exists for the tag yet, distinguishing "absent" from gh errors. */
+function ensureReleaseIsNew(tag) {
+  const existing = run('gh', ['release', 'view', tag])
+  if (existing.status === 0) {
+    fail(`release ${tag} already exists — bump "version" in apps/desktop/src-tauri/tauri.conf.json first`)
+  }
+  if (!/release not found/i.test(existing.output)) {
+    fail(`could not check GitHub for an existing ${tag} release:\n${existing.output.trim()}`)
+  }
+}
+
+/**
+ * Build a signed + notarized DMG and upload it to a new GitHub release tagged
+ * v<version> (from tauri.conf.json). All preflight checks run before the
+ * build so a doomed publish fails in seconds, not after notarization.
+ */
+function publish({ draft }) {
+  ensureGhReady()
+  const commit = ensurePublishableCommit()
+  const { productName, version } = readTauriConf()
+  const tag = `v${version}`
+  ensureReleaseIsNew(tag)
+
+  build({ notarize: true })
+
+  const { dmg } = bundlePaths()
+  log(`creating GitHub release ${tag} from commit ${commit.slice(0, 7)}…`)
+  const releaseArgs = [
+    'release',
+    'create',
+    tag,
+    dmg,
+    '--title',
+    `${productName} ${version}`,
+    '--target',
+    commit,
+    '--generate-notes',
+  ]
+  if (draft) releaseArgs.push('--draft')
+  const result = spawnSync('gh', releaseArgs, { encoding: 'utf8', stdio: ['inherit', 'pipe', 'inherit'] })
+  if (result.status !== 0) fail(`creating the GitHub release failed${result.stdout ? `\n${result.stdout.trim()}` : ''}`)
+  log(`${draft ? 'draft release created' : 'release published'}: ${result.stdout.trim()}`)
+}
+
 async function setup() {
   console.log(
     `This stores notarization credentials in your login keychain (item "${KEYCHAIN_SERVICE}").\n` +
@@ -313,9 +388,11 @@ Commands:
   build     Signed + notarized release build, then verify (default)
   setup     Store the notarization Apple ID + app-specific password in the keychain
   verify    Re-run signing/Gatekeeper checks on already-built bundles
+  publish   Build, then upload the DMG to a new GitHub release (needs the gh CLI)
 
 Flags:
   --no-notarize   Skip notarization (signed-only build/verify)
+  --draft         Create the GitHub release as a draft (publish only)
   --help          Show this help
 
 Docs: docs/macos-distribution.md`
@@ -324,7 +401,7 @@ async function main() {
   const argv = process.argv.slice(2)
   const flags = argv.filter((arg) => arg.startsWith('--'))
   const commands = argv.filter((arg) => !arg.startsWith('--'))
-  const unknownFlag = flags.find((flag) => !['--no-notarize', '--help'].includes(flag))
+  const unknownFlag = flags.find((flag) => !['--no-notarize', '--draft', '--help'].includes(flag))
   if (unknownFlag) fail(`unknown flag "${unknownFlag}"\n\n${USAGE}`)
   if (flags.includes('--help')) {
     console.log(USAGE)
@@ -334,6 +411,8 @@ async function main() {
 
   const command = commands[0] ?? 'build'
   const notarize = !flags.includes('--no-notarize')
+  if (command === 'publish' && !notarize) fail('publish always notarizes — drop --no-notarize')
+  if (command !== 'publish' && flags.includes('--draft')) fail('--draft only applies to publish')
   switch (command) {
     case 'build':
       return build({ notarize })
@@ -342,6 +421,8 @@ async function main() {
     case 'verify':
       verify({ notarized: notarize })
       return printArtifacts()
+    case 'publish':
+      return publish({ draft: flags.includes('--draft') })
     default:
       fail(`unknown command "${command}"\n\n${USAGE}`)
   }

--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -300,17 +300,17 @@ function ensureGhReady() {
 }
 
 /**
- * Assert HEAD is a clean, pushed commit and return its SHA. The release tag
- * is created at this commit, so it must exist on GitHub and match what gets
- * built.
+ * Assert HEAD is a clean commit pushed to origin — the repo gh releases to —
+ * and return its SHA. The release tag is created at this commit, so it must
+ * exist on GitHub and match what gets built.
  */
 function ensurePublishableCommit() {
   if (capture('git', ['status', '--porcelain']).trim() !== '') {
     fail('the working tree has uncommitted changes — commit or stash them before publishing')
   }
   const commit = capture('git', ['rev-parse', 'HEAD']).trim()
-  if (capture('git', ['branch', '--remotes', '--contains', commit]).trim() === '') {
-    fail('HEAD is not on any remote branch — push it first so the release tag points at published code')
+  if (capture('git', ['branch', '--remotes', '--contains', commit, '--list', 'origin/*']).trim() === '') {
+    fail('HEAD is not on any origin branch — push it first so the release tag points at published code')
   }
   return commit
 }

--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -327,6 +327,29 @@ function ensureReleaseIsNew(tag) {
 }
 
 /**
+ * Assert that if the tag already exists on origin, it points at the commit
+ * being released. `gh release create` silently reuses an existing tag and
+ * ignores --target, which would attach the release to whatever old commit
+ * the tag names instead of the code that was just built.
+ */
+function ensureTagMatchesCommit(tag, commit) {
+  // The "^{}" pattern makes ls-remote include the peeled line for annotated
+  // tags; gh-created tags are lightweight and resolve to the commit directly.
+  const output = capture('git', ['ls-remote', '--tags', 'origin', tag, `${tag}^{}`]).trim()
+  if (output === '') return
+  const refs = output.split('\n').map((line) => line.split('\t'))
+  const peeled = refs.find(([, name]) => name === `refs/tags/${tag}^{}`)
+  const taggedCommit = (peeled ?? refs[0])[0]
+  if (taggedCommit !== commit) {
+    fail(
+      `tag ${tag} already exists on origin at ${taggedCommit.slice(0, 7)} but HEAD is ${commit.slice(0, 7)}.\n` +
+        '  gh would attach the release to the existing tag, not the commit being built —\n' +
+        '  delete the remote tag or bump "version" in apps/desktop/src-tauri/tauri.conf.json.',
+    )
+  }
+}
+
+/**
  * Build a signed + notarized DMG and upload it to a new GitHub release tagged
  * v<version> (from tauri.conf.json). All preflight checks run before the
  * build so a doomed publish fails in seconds, not after notarization.
@@ -337,6 +360,7 @@ function publish({ draft }) {
   const { productName, version } = readTauriConf()
   const tag = `v${version}`
   ensureReleaseIsNew(tag)
+  ensureTagMatchesCommit(tag, commit)
 
   build({ notarize: true })
 

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -73,7 +73,7 @@ it needs the [GitHub CLI](https://cli.github.com) authenticated with `gh auth lo
 All preflight checks run before the build, so a doomed publish fails in seconds rather
 than after notarization:
 
-- the working tree is clean and `HEAD` is on a remote branch — the release tag is
+- the working tree is clean and `HEAD` is on an `origin` branch — the release tag is
   created at that exact commit;
 - no release for `v<version>` exists yet, and any existing `v<version>` tag on origin
   points at `HEAD` (`gh` reuses an existing tag, which would release the wrong commit).

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -4,8 +4,9 @@ How to produce a signed, notarized macOS build of Reflect for distribution outsi
 Mac App Store.
 
 ```bash
-pnpm release:macos setup   # once: store notarization credentials in the keychain
-pnpm release:macos         # signed + notarized build, verified end to end
+pnpm release:macos setup     # once: store notarization credentials in the keychain
+pnpm release:macos           # signed + notarized build, verified end to end
+pnpm release:macos publish   # the above, then upload the DMG to a new GitHub release
 ```
 
 The helper lives at `apps/desktop/scripts/release-macos.mjs` and is exposed as
@@ -57,8 +58,28 @@ Bundles land in `target/release/bundle/macos/Reflect.app` and
 pnpm release:macos                 # build + notarize + verify (default)
 pnpm release:macos setup           # store Apple ID + app-specific password in the keychain
 pnpm release:macos verify          # re-run all checks on already-built bundles
+pnpm release:macos publish         # build + notarize + verify, then create a GitHub release
+pnpm release:macos publish --draft # same, but leave the release as a draft for review
 pnpm release:macos --no-notarize   # signed-only build (runs locally; Gatekeeper rejects it elsewhere)
 ```
+
+## Publishing to GitHub Releases
+
+`pnpm release:macos publish` runs the full build above, then creates a GitHub release
+tagged `v<version>` (the `version` in `apps/desktop/src-tauri/tauri.conf.json`) with the
+notarized DMG attached and auto-generated release notes. Beyond the signing requirements,
+it needs the [GitHub CLI](https://cli.github.com) authenticated with `gh auth login`.
+
+All preflight checks run before the build, so a doomed publish fails in seconds rather
+than after notarization:
+
+- the working tree is clean and `HEAD` is on a remote branch — the release tag is
+  created at that exact commit;
+- no release for `v<version>` exists yet. Publishing a new release means bumping
+  `version` in `tauri.conf.json` first (keep `src-tauri/Cargo.toml` in step).
+
+Pass `--draft` to create the release without publishing it, then review and publish it
+from the GitHub UI.
 
 ## CI
 

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -75,8 +75,10 @@ than after notarization:
 
 - the working tree is clean and `HEAD` is on a remote branch — the release tag is
   created at that exact commit;
-- no release for `v<version>` exists yet. Publishing a new release means bumping
-  `version` in `tauri.conf.json` first (keep `src-tauri/Cargo.toml` in step).
+- no release for `v<version>` exists yet, and any existing `v<version>` tag on origin
+  points at `HEAD` (`gh` reuses an existing tag, which would release the wrong commit).
+  Publishing a new release means bumping `version` in `tauri.conf.json` first (keep
+  `src-tauri/Cargo.toml` in step).
 
 Pass `--draft` to create the release without publishing it, then review and publish it
 from the GitHub UI.


### PR DESCRIPTION
## What

Adds a `publish` subcommand to `release-macos.mjs`, so one command produces and ships a release:

```bash
pnpm release:macos publish           # build + notarize + verify, then create a GitHub release
pnpm release:macos publish --draft   # same, but leave the release as a draft for review
```

It runs the existing signed + notarized build and Gatekeeper verification, then `gh release create v<version>` (version from `tauri.conf.json`) with the DMG attached, `--generate-notes`, and `--target` pinned to the built commit. Prints the release URL when done.

## Why

We could already build a signed, notarized DMG locally, but getting it into GitHub Releases was manual. This closes the loop so others can download builds.

## Notes for review

- **Preflights run before the build**, so a doomed publish fails in seconds instead of after a 1–10 minute notarization wait: `gh` installed + authenticated, clean working tree, `HEAD` on a remote branch, and no existing `v<version>` release (the error says to bump `tauri.conf.json`).
- `publish --no-notarize` is rejected — an un-notarized build should never ship to other machines. `--draft` is rejected outside `publish`.
- The existing-release check distinguishes "release not found" (proceed) from other `gh` failures (fail loudly).
- Docs updated in `docs/macos-distribution.md` (new "Publishing to GitHub Releases" section) and the command list in `AGENTS.md`.
- Tested the cheap paths: `--help`, both invalid flag combos, the dirty-tree preflight (stopped a real `publish` run before building), and the `release not found` message the check parses. Not tested end-to-end since that would publish a real release. `pnpm lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-script and documentation only; no app runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`pnpm release:macos publish`** so a signed, notarized DMG can be shipped to **GitHub Releases** in one step (optional **`--draft`**).
> 
> The **`publish`** path runs **preflights before the build**: `gh` installed/authenticated, clean tree, `HEAD` on `origin`, no existing `v<version>` release, and remote tag alignment so `gh` does not attach a release to the wrong commit. It then reuses the existing notarized build and runs **`gh release create`** with the DMG, version from **`tauri.conf.json`**, **`--target`** at `HEAD`, and generated notes. **`publish --no-notarize`** is rejected; **`--draft`** is limited to **`publish`**.
> 
> Docs in **`docs/macos-distribution.md`** and **`AGENTS.md`** document the new command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29c7802024c9bfd9e188e18bbd1506d9af0978ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->