### PR TITLE
Chat: corrective tag refusals + graph overview in the system prompt

### DIFF
--- a/apps/desktop/src/components/chat/chat-screen.test.tsx
+++ b/apps/desktop/src/components/chat/chat-screen.test.tsx
@@ -2,7 +2,16 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactElement } from 'react'
-import type { AiProviderConfig, ChatStreamEvent, StreamChatOptions } from '@reflect/core'
+import {
+  cloudSafeGraphContext,
+  type AiProviderConfig,
+  type ChatStreamEvent,
+  type CloudGraphContext,
+  type CloudSafe,
+  type GraphContextDeps,
+  type GraphInfo,
+  type StreamChatOptions,
+} from '@reflect/core'
 import { ChatProvider, useChatSession } from '@/providers/chat-provider'
 import { RouterProvider } from '@/routing/router'
 
@@ -18,10 +27,16 @@ const streamChat = vi.hoisted(() =>
   vi.fn<(options: StreamChatOptions) => AsyncGenerator<ChatStreamEvent>>(),
 )
 const getSecret = vi.hoisted(() => vi.fn<(name: string) => Promise<string | null>>())
+const loadChatGraphContext = vi.hoisted(() =>
+  vi.fn<
+    (graphName: string, deps?: GraphContextDeps) => Promise<CloudSafe<CloudGraphContext>>
+  >(),
+)
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   streamChat,
   getSecret,
+  loadChatGraphContext,
 }))
 
 const settingsState = vi.hoisted(() => ({
@@ -52,11 +67,24 @@ const { ChatScreen } = await import('./chat-screen')
 
 afterEach(cleanup)
 
+const GRAPH: GraphInfo = { root: '/graphs/test', name: 'test-graph', cloudSync: null, generation: 1 }
+
+const GRAPH_CONTEXT = cloudSafeGraphContext({
+  graphName: 'test-graph',
+  noteCount: 3,
+  dailyNoteCount: 1,
+  earliestDailyDate: '2026-06-01',
+  latestDailyDate: '2026-06-01',
+  tags: [{ tag: 'book', count: 2 }],
+  tagsTruncated: false,
+})
+
 beforeEach(() => {
   settingsState.models = []
   settingsState.defaultId = null
   streamChat.mockReset()
   getSecret.mockReset().mockResolvedValue('sk-test')
+  loadChatGraphContext.mockReset().mockResolvedValue(GRAPH_CONTEXT)
 })
 
 const MODEL: AiProviderConfig = { id: 'm1', provider: 'openai', model: 'gpt-5.1', keyHint: '12345' }
@@ -93,7 +121,7 @@ function renderChat() {
   probedSend = null
   return render(
     <RouterProvider>
-      <ChatProvider>
+      <ChatProvider graph={GRAPH}>
         <ChatScreen />
         <SendProbe />
       </ChatProvider>
@@ -172,6 +200,37 @@ describe('ChatScreen', () => {
     await waitFor(() => expect(streamChat).toHaveBeenCalledTimes(1))
     // Same entry (id → keychain key), with the picked model applied.
     expect(streamChat.mock.lastCall?.[0].config).toEqual({ ...MODEL, model: 'gpt-5.5' })
+  })
+
+  it('sends the graph overview context with each turn', async () => {
+    configureModel()
+    scriptTurn([
+      { type: 'text-delta', text: 'Hi.' },
+      { type: 'complete', messages: [{ role: 'assistant', content: 'Hi.' }] },
+    ])
+    const view = renderChat()
+
+    await userEvent.type(view.getByLabelText('Chat message'), 'hi{Enter}')
+
+    await waitFor(() => expect(streamChat).toHaveBeenCalledTimes(1))
+    expect(loadChatGraphContext).toHaveBeenCalledWith('test-graph')
+    expect(streamChat.mock.lastCall?.[0].context).toEqual(GRAPH_CONTEXT)
+  })
+
+  it('still sends the turn, without an overview, when the context load fails', async () => {
+    configureModel()
+    loadChatGraphContext.mockRejectedValue(new Error('index not open'))
+    scriptTurn([
+      { type: 'text-delta', text: 'Hi.' },
+      { type: 'complete', messages: [{ role: 'assistant', content: 'Hi.' }] },
+    ])
+    const view = renderChat()
+
+    await userEvent.type(view.getByLabelText('Chat message'), 'hi{Enter}')
+
+    await waitFor(() => expect(streamChat).toHaveBeenCalledTimes(1))
+    expect(streamChat.mock.lastCall?.[0].context).toBeNull()
+    expect(await view.findByText('Hi.')).toBeDefined()
   })
 
   it('renders listing chips: recent notes by tag and a daily range', async () => {

--- a/apps/desktop/src/components/chat/chat-screen.test.tsx
+++ b/apps/desktop/src/components/chat/chat-screen.test.tsx
@@ -185,6 +185,18 @@ describe('ChatScreen', () => {
           toolCallId: 'tool-1',
           tag: 'book',
           notes: [{ path: 'notes/atlas.md', title: 'Atlas' }],
+          error: null,
+        },
+      },
+      { type: 'tool-call', call: { tool: 'recents', toolCallId: 'tool-3', tag: '*' } },
+      {
+        type: 'tool-result',
+        result: {
+          tool: 'recents',
+          toolCallId: 'tool-3',
+          tag: '*',
+          notes: [],
+          error: 'Not a tag — omit the tag to list all recent notes.',
         },
       },
       {
@@ -211,6 +223,8 @@ describe('ChatScreen', () => {
     await userEvent.type(view.getByLabelText('Chat message'), 'what have I been reading?{Enter}')
 
     await view.findByText(/Listed #book notes · 1 note/)
+    // A refused listing shows the refusal, not a misleading count.
+    await view.findByText(/Listed #\* notes — Not a tag/)
     await view.findByText(/Listed daily notes 2026-06-01 – 2026-06-11 · 2 days/)
   })
 

--- a/apps/desktop/src/components/chat/chat-tool-chip.tsx
+++ b/apps/desktop/src/components/chat/chat-tool-chip.tsx
@@ -59,7 +59,11 @@ export function ChatToolChip({ part }: ChatToolChipProps): ReactElement {
       <ChipFrame pending={pending} icon={<History aria-hidden className="size-3.5" />}>
         <span className="truncate">
           Listed {call.tag !== null ? `#${call.tag}` : 'recent'} notes
-          {result !== null ? countSuffix(result.notes.length, 'note') : ''}
+          {result !== null
+            ? result.error !== null
+              ? ` — ${result.error}`
+              : countSuffix(result.notes.length, 'note')
+            : ''}
         </span>
       </ChipFrame>
     )

--- a/apps/desktop/src/components/graph-workspace.tsx
+++ b/apps/desktop/src/components/graph-workspace.tsx
@@ -28,7 +28,7 @@ export function GraphWorkspace({ graph }: GraphWorkspaceProps): ReactElement {
             {/* Above the sidebar: a recording must survive the sidebar (and its
                 mic button) unmounting on collapse. */}
             <AudioMemoProvider graph={graph}>
-              <ChatProvider>
+              <ChatProvider graph={graph}>
                 <WorkspaceContent graph={graph} />
               </ChatProvider>
             </AudioMemoProvider>

--- a/apps/desktop/src/providers/chat-provider.tsx
+++ b/apps/desktop/src/providers/chat-provider.tsx
@@ -14,12 +14,14 @@ import {
   chatModelOptions,
   errorMessage,
   getSecret,
+  loadChatGraphContext,
   resolveChatModel,
   streamChat,
   type AiProviderConfig,
   type ChatModelOption,
   type ChatModelSelection,
   type ChatStreamEvent,
+  type GraphInfo,
 } from '@reflect/core'
 import { toChatAttachment, type ChatAttachment } from '@/lib/chat-attachments'
 import { appendEvent, buildHistory, userMessage, type ChatTurn } from '@/lib/chat-transcript'
@@ -68,7 +70,13 @@ interface ChatContextValue {
 
 const ChatContext = createContext<ChatContextValue | null>(null)
 
-export function ChatProvider({ children }: { children: ReactNode }): ReactElement {
+interface ChatProviderProps {
+  /** The open graph — names the prompt's overview block. */
+  graph: GraphInfo
+  children: ReactNode
+}
+
+export function ChatProvider({ graph, children }: ChatProviderProps): ReactElement {
   const { settings } = useSettings()
   const [turns, setTurns] = useState<ChatTurn[]>([])
   const [attachments, setAttachments] = useState<ChatAttachment[]>([])
@@ -150,7 +158,15 @@ export function ChatProvider({ children }: { children: ReactNode }): ReactElemen
     activeSendRef.current = activeSend
 
     try {
-      const apiKey = await getSecret(aiKeySecretName(config.id))
+      // The graph overview degrades to null (prompt without the block)
+      // rather than blocking the turn — a cold index shouldn't kill chat.
+      const [apiKey, context] = await Promise.all([
+        getSecret(aiKeySecretName(config.id)),
+        loadChatGraphContext(graph.name).catch((cause: unknown) => {
+          console.error('chat graph context failed:', errorMessage(cause))
+          return null
+        }),
+      ])
       if (apiKey === null) {
         applyEvent({
           type: 'error',
@@ -165,6 +181,7 @@ export function ChatProvider({ children }: { children: ReactNode }): ReactElemen
         fetchFn: providerFetch,
         messages,
         today: todayIso(),
+        context,
         signal: controller.signal,
       })
       for await (const event of events) {
@@ -192,7 +209,7 @@ export function ChatProvider({ children }: { children: ReactNode }): ReactElemen
         activeSendRef.current = null
       }
     }
-  }, [])
+  }, [graph.name])
 
   const stop = useCallback(() => {
     activeSendRef.current?.controller.abort()

--- a/packages/core/src/ai/chat/graph-context.test.ts
+++ b/packages/core/src/ai/chat/graph-context.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import type { GraphStatsOptions } from '../../indexing/graph-stats'
+import { loadChatGraphContext, MAX_CONTEXT_TAGS } from './graph-context'
+
+describe('loadChatGraphContext', () => {
+  it('loads stats at the prompt tag cap and stamps the graph name on them', async () => {
+    const seen: GraphStatsOptions[] = []
+    const context = await loadChatGraphContext('atlas-graph', {
+      loadGraphStatsFn: async (options) => {
+        seen.push(options)
+        return {
+          noteCount: 7,
+          dailyNoteCount: 2,
+          earliestDailyDate: '2026-06-01',
+          latestDailyDate: '2026-06-10',
+          tags: [{ tag: 'book', count: 2 }],
+          tagsTruncated: false,
+        }
+      },
+    })
+
+    expect(seen).toEqual([{ tagLimit: MAX_CONTEXT_TAGS }])
+    expect(context).toEqual({
+      graphName: 'atlas-graph',
+      noteCount: 7,
+      dailyNoteCount: 2,
+      earliestDailyDate: '2026-06-01',
+      latestDailyDate: '2026-06-10',
+      tags: [{ tag: 'book', count: 2 }],
+      tagsTruncated: false,
+    })
+  })
+})

--- a/packages/core/src/ai/chat/graph-context.ts
+++ b/packages/core/src/ai/chat/graph-context.ts
@@ -1,0 +1,28 @@
+import { loadGraphStats, type GraphStats, type GraphStatsOptions } from '../../indexing/graph-stats'
+import { cloudSafeGraphContext, type CloudGraphContext, type CloudSafe } from '../checkers'
+
+/**
+ * The graph-level grounding block for one chat turn's system prompt: what
+ * the graph is called, how many notes the assistant can see, the span of
+ * the daily journal, and which tags exist — so tag filters and date ranges
+ * are typed from knowledge, not guessed. Loaded fresh per turn (the stats
+ * are three local SQLite reads), computed over non-private rows only.
+ */
+
+/** Most tags the prompt lists (token budget — the most-used tags win). */
+export const MAX_CONTEXT_TAGS = 40
+
+/** Injectable effects so tests can drive the loader without a live bridge. */
+export interface GraphContextDeps {
+  loadGraphStatsFn?: (options: GraphStatsOptions) => Promise<GraphStats>
+}
+
+/** Load the prompt context for the open graph. `deps` is a test seam. */
+export async function loadChatGraphContext(
+  graphName: string,
+  deps: GraphContextDeps = {},
+): Promise<CloudSafe<CloudGraphContext>> {
+  const loadStatsFn = deps.loadGraphStatsFn ?? loadGraphStats
+  const stats = await loadStatsFn({ tagLimit: MAX_CONTEXT_TAGS })
+  return cloudSafeGraphContext({ graphName, ...stats })
+}

--- a/packages/core/src/ai/chat/stream-chat.test.ts
+++ b/packages/core/src/ai/chat/stream-chat.test.ts
@@ -6,6 +6,7 @@ import type {
   LanguageModelV3Usage,
 } from '@ai-sdk/provider'
 import type { RetrievalHit } from '../../embeddings/retrieve'
+import { cloudSafeGraphContext } from '../checkers'
 import { streamChatTurn, type ChatStreamEvent } from './stream-chat'
 
 const USAGE: LanguageModelV3Usage = {
@@ -101,6 +102,7 @@ describe('streamChatTurn', () => {
       streamChatTurn(model, {
         messages: [{ role: 'user', content: 'where is the launch plan?' }],
         today: '2026-06-11',
+        context: null,
         toolDeps: { retrieveFn: async () => [PUBLIC_HIT, PRIVATE_HIT], readNoteFn: async () => 'launch plan\n' },
       }),
     )
@@ -138,6 +140,7 @@ describe('streamChatTurn', () => {
       streamChatTurn(model, {
         messages: [{ role: 'user', content: 'what do my notes say?' }],
         today: '2026-06-11',
+        context: null,
         toolDeps: { retrieveFn: async () => [PUBLIC_HIT, PRIVATE_HIT], readNoteFn: async () => 'launch plan\n' },
       }),
     )
@@ -149,6 +152,30 @@ describe('streamChatTurn', () => {
     expect(outbound).not.toContain(PRIVATE_TITLE)
     expect(outbound).not.toContain(PRIVATE_PATH)
     expect(outbound).toContain('notes/atlas.md')
+  })
+
+  it('carries the graph overview in the outbound system prompt', async () => {
+    const model = new MockLanguageModelV3({ doStream: sequence([textTurn('hi')]) })
+    await collect(
+      streamChatTurn(model, {
+        messages: [{ role: 'user', content: 'hi' }],
+        today: '2026-06-11',
+        context: cloudSafeGraphContext({
+          graphName: 'atlas-graph',
+          noteCount: 7,
+          dailyNoteCount: 2,
+          earliestDailyDate: '2026-06-01',
+          latestDailyDate: '2026-06-10',
+          tags: [{ tag: 'book', count: 2 }],
+          tagsTruncated: false,
+        }),
+      }),
+    )
+
+    const outbound = JSON.stringify(model.doStreamCalls[0]?.prompt)
+    expect(outbound).toContain('atlas-graph')
+    expect(outbound).toContain('#book (2)')
+    expect(outbound).toContain('Daily notes span 2026-06-01 to 2026-06-10.')
   })
 
   it('yields a terminal error event when the stream errors', async () => {
@@ -164,6 +191,7 @@ describe('streamChatTurn', () => {
       streamChatTurn(model, {
         messages: [{ role: 'user', content: 'hi' }],
         today: '2026-06-11',
+        context: null,
       }),
     )
     expect(events.at(-1)).toEqual({ type: 'error', message: 'rate limited', messages: [] })
@@ -186,6 +214,7 @@ describe('streamChatTurn', () => {
       streamChatTurn(model, {
         messages: [{ role: 'user', content: 'where is the launch plan?' }],
         today: '2026-06-11',
+        context: null,
         toolDeps: { retrieveFn: async () => [PUBLIC_HIT], readNoteFn: async () => 'launch plan\n' },
       }),
     )
@@ -222,6 +251,7 @@ describe('streamChatTurn', () => {
       streamChatTurn(model, {
         messages: [{ role: 'user', content: 'plan and budget?' }],
         today: '2026-06-11',
+        context: null,
         toolDeps: { retrieveFn: async () => [PUBLIC_HIT], readNoteFn: async () => 'launch plan\n' },
       }),
     )

--- a/packages/core/src/ai/chat/stream-chat.ts
+++ b/packages/core/src/ai/chat/stream-chat.ts
@@ -4,6 +4,7 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import { createOpenAI } from '@ai-sdk/openai'
 import { errorMessage } from '../../errors'
 import type { AiProviderConfig } from '../../settings/schema'
+import type { CloudGraphContext, CloudSafe } from '../checkers'
 import { chatSystemPrompt } from './system-prompt'
 import {
   buildNoteTools,
@@ -40,6 +41,12 @@ export interface StreamChatOptions {
   messages: ModelMessage[]
   /** Local ISO date for the system prompt (daily-note key space). */
   today: string
+  /**
+   * Graph overview for the system prompt (`loadChatGraphContext`), or
+   * `null` to send the prompt without it — required so call sites decide
+   * the degraded mode explicitly rather than forgetting the block.
+   */
+  context: CloudSafe<CloudGraphContext> | null
   /** Aborts the provider call mid-stream (the UI's stop button). */
   signal?: AbortSignal
 }
@@ -80,6 +87,8 @@ export interface ChatTurnOptions {
   messages: ModelMessage[]
   /** Local ISO date for the system prompt (daily-note key space). */
   today: string
+  /** Graph overview for the system prompt, or `null` to omit the block. */
+  context: CloudSafe<CloudGraphContext> | null
   /** Aborts the provider call mid-stream (the UI's stop button). */
   signal?: AbortSignal
   /** Test seam for the note tools' effects. */
@@ -114,7 +123,7 @@ export async function* streamChatTurn(
   try {
     const result = streamText({
       model,
-      system: chatSystemPrompt({ today: options.today }),
+      system: chatSystemPrompt({ today: options.today, context: options.context }),
       messages: options.messages,
       tools,
       stopWhen: stepCountIs(MAX_STEPS),

--- a/packages/core/src/ai/chat/system-prompt.test.ts
+++ b/packages/core/src/ai/chat/system-prompt.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { cloudSafeGraphContext, type CloudGraphContext } from '../checkers'
+import { chatSystemPrompt } from './system-prompt'
+
+function context(overrides: Partial<CloudGraphContext> = {}) {
+  return cloudSafeGraphContext({
+    graphName: 'atlas-graph',
+    noteCount: 12,
+    dailyNoteCount: 4,
+    earliestDailyDate: '2026-01-02',
+    latestDailyDate: '2026-06-10',
+    tags: [
+      { tag: 'Book', count: 3 },
+      { tag: 'health', count: 1 },
+    ],
+    tagsTruncated: false,
+    ...overrides,
+  })
+}
+
+describe('chatSystemPrompt', () => {
+  it('renders the date and grounding rules without an overview when context is null', () => {
+    const prompt = chatSystemPrompt({ today: '2026-06-12', context: null })
+    expect(prompt).toContain('Today’s date is 2026-06-12.')
+    expect(prompt).toContain('Grounding rules:')
+    expect(prompt).not.toContain('Graph overview')
+  })
+
+  it('renders the graph name, sizes, daily span, and the full tag vocabulary', () => {
+    const prompt = chatSystemPrompt({ today: '2026-06-12', context: context() })
+    expect(prompt).toContain('Graph overview (private notes are excluded from every figure):')
+    expect(prompt).toContain('“atlas-graph” — 12 notes and 4 daily notes')
+    expect(prompt).toContain('Daily notes span 2026-01-02 to 2026-06-10.')
+    expect(prompt).toContain('#Book (3), #health (1)')
+    // The complete list is asserted as complete, so the model never guesses.
+    expect(prompt).toContain('These are the only tags')
+  })
+
+  it('softens the tag claim when the facet list was capped', () => {
+    const prompt = chatSystemPrompt({
+      today: '2026-06-12',
+      context: context({ tagsTruncated: true }),
+    })
+    expect(prompt).toContain('Most-used tags')
+    expect(prompt).toContain('More tags exist beyond these.')
+    expect(prompt).not.toContain('These are the only tags')
+  })
+
+  it('tells the model outright when no tags exist', () => {
+    const prompt = chatSystemPrompt({ today: '2026-06-12', context: context({ tags: [] }) })
+    expect(prompt).toContain('No tags are in use — never pass a tag filter.')
+  })
+
+  it('omits the daily span when the graph has no daily notes', () => {
+    const prompt = chatSystemPrompt({
+      today: '2026-06-12',
+      context: context({ dailyNoteCount: 0, earliestDailyDate: null, latestDailyDate: null }),
+    })
+    expect(prompt).toContain('0 daily notes')
+    expect(prompt).not.toContain('Daily notes span')
+  })
+})

--- a/packages/core/src/ai/chat/system-prompt.ts
+++ b/packages/core/src/ai/chat/system-prompt.ts
@@ -1,3 +1,5 @@
+import type { CloudGraphContext, CloudSafe } from '../checkers'
+
 /**
  * The grounded chat system prompt (Plan 10). Reflect's chat is deliberately
  * note-grounded — search first, cite what you used, never invent notes —
@@ -7,13 +9,19 @@
 export interface SystemPromptInput {
   /** Local ISO date (`YYYY-MM-DD`) — daily notes live under this key space. */
   today: string
+  /**
+   * Graph-level grounding block ({@link CloudGraphContext}), or `null` when
+   * it could not be loaded — the prompt then simply omits the overview.
+   */
+  context: CloudSafe<CloudGraphContext> | null
 }
 
 /** Build the system prompt for one chat session. */
-export function chatSystemPrompt({ today }: SystemPromptInput): string {
+export function chatSystemPrompt({ today, context }: SystemPromptInput): string {
   return [
     'You are Reflect’s assistant, embedded in the user’s personal note graph.',
     `Today’s date is ${today}. Daily notes are markdown files named daily/YYYY-MM-DD.md; other notes live under notes/.`,
+    ...graphOverviewLines(context),
     '',
     'Grounding rules:',
     '- When a question could be answered by the user’s notes, look them up before answering: search_notes finds notes by topic or keyword, list_daily_notes finds daily notes in a date range (questions like “yesterday” or “last week”), and list_recent_notes shows what was edited lately. Call read_note when you need a note’s full content.',
@@ -24,4 +32,35 @@ export function chatSystemPrompt({ today }: SystemPromptInput): string {
     '',
     'Style: answer in concise markdown. Prefer short paragraphs and lists over headings.',
   ].join('\n')
+}
+
+/**
+ * The "graph overview" prompt block: name, sizes, daily span, and the tag
+ * vocabulary. The tag line is deliberately assertive — when the list is
+ * complete the model is told these are the *only* tags, so it never guesses
+ * a filter that can only return nothing.
+ */
+function graphOverviewLines(context: CloudSafe<CloudGraphContext> | null): string[] {
+  if (context === null) {
+    return []
+  }
+  const lines = [
+    '',
+    'Graph overview (private notes are excluded from every figure):',
+    `- Graph: “${context.graphName}” — ${context.noteCount} notes and ${context.dailyNoteCount} daily notes.`,
+  ]
+  if (context.earliestDailyDate !== null && context.latestDailyDate !== null) {
+    lines.push(`- Daily notes span ${context.earliestDailyDate} to ${context.latestDailyDate}.`)
+  }
+  if (context.tags.length === 0) {
+    lines.push('- No tags are in use — never pass a tag filter.')
+  } else {
+    const list = context.tags.map((facet) => `#${facet.tag} (${facet.count})`).join(', ')
+    lines.push(
+      context.tagsTruncated
+        ? `- Most-used tags, by note count: ${list}. More tags exist beyond these.`
+        : `- Tags in use, by note count: ${list}. These are the only tags — any other tag matches nothing.`,
+    )
+  }
+  return lines
 }

--- a/packages/core/src/ai/chat/system-prompt.ts
+++ b/packages/core/src/ai/chat/system-prompt.ts
@@ -17,6 +17,7 @@ export function chatSystemPrompt({ today }: SystemPromptInput): string {
     '',
     'Grounding rules:',
     '- When a question could be answered by the user’s notes, look them up before answering: search_notes finds notes by topic or keyword, list_daily_notes finds daily notes in a date range (questions like “yesterday” or “last week”), and list_recent_notes shows what was edited lately. Call read_note when you need a note’s full content.',
+    '- For “what have I written or worked on lately?”, call list_recent_notes with no tag — pass a tag only when the user names one. Tool inputs are plain values; there is no wildcard or operator syntax (never pass “*”).',
     '- Ground answers in what the tools return. If the notes don’t cover something, say so plainly instead of guessing.',
     '- Cite every note you draw on with a wiki link of its exact title, e.g. [[Project Atlas]]. Do not invent titles that the tools did not return.',
     '- Private notes are excluded from search and cannot be read. If a tool reports a note is private, tell the user that — never speculate about its contents.',

--- a/packages/core/src/ai/chat/tools.test.ts
+++ b/packages/core/src/ai/chat/tools.test.ts
@@ -5,6 +5,7 @@ import type { DailyNoteRow, DailyNotesRange } from '../../indexing/queries'
 import type { RecentNoteRow, RecentNotesOptions } from '../../indexing/note-list'
 import {
   buildNoteTools,
+  INVALID_TAG_ERROR,
   MAX_DAILY_NOTE_DAYS,
   MAX_NOTE_CONTENT_CHARS,
   type ListDailyNotesOutput,
@@ -96,7 +97,7 @@ async function runRead(tools: NoteTools, path: string): Promise<ReadNoteOutput> 
 /** Execute `list_recent_notes` directly, asserting a non-streaming output. */
 async function runRecents(
   tools: NoteTools,
-  input: { limit?: number; tag?: string },
+  input: { limit?: number; tag?: string | null },
 ): Promise<ListRecentNotesOutput> {
   const execute = tools.list_recent_notes.execute
   if (!execute) {
@@ -267,6 +268,37 @@ describe('list_recent_notes', () => {
     expect(seen).toEqual([{ limit: 3, tag: 'book' }])
   })
 
+  it('treats an explicit null tag as no filter', async () => {
+    const seen: RecentNotesOptions[] = []
+    const tools = buildNoteTools({
+      listRecentNotesFn: async (options) => {
+        seen.push(options)
+        return []
+      },
+    })
+    await runRecents(tools, { tag: null })
+    expect(seen).toEqual([{ limit: 10, tag: null }])
+  })
+
+  it('refuses a non-tag filter without querying, pointing at the no-tag call', async () => {
+    const seen: RecentNotesOptions[] = []
+    const tools = buildNoteTools({
+      listRecentNotesFn: async (options) => {
+        seen.push(options)
+        return []
+      },
+    })
+    for (const tag of ['*', ' ', '#book', ']INVALIDNOFILTER[']) {
+      const output = await runRecents(tools, { tag })
+      if (output.ok) {
+        expect.unreachable('expected a refusal')
+      }
+      expect(output.tag).toBe(tag)
+      expect(output.error).toBe(INVALID_TAG_ERROR)
+    }
+    expect(seen).toEqual([])
+  })
+
   it('maps rows onto listings: preview as snippet, ISO modifiedAt, no daily date', async () => {
     const mtime = 1_750_000_000_000
     const tools = buildNoteTools({
@@ -274,6 +306,9 @@ describe('list_recent_notes', () => {
       readNoteFn: async () => 'a public body\n',
     })
     const output = await runRecents(tools, {})
+    if (!output.ok) {
+      expect.unreachable('expected a listing')
+    }
     expect(output.notes).toEqual([
       {
         path: 'notes/public.md',
@@ -297,6 +332,9 @@ describe('list_recent_notes', () => {
     const payload = JSON.stringify(output)
     expect(payload).not.toContain(PRIVATE_TITLE)
     expect(payload).not.toContain(PRIVATE_PATH)
+    if (!output.ok) {
+      expect.unreachable('expected a listing')
+    }
     expect(output.notes).toHaveLength(1)
   })
 
@@ -306,6 +344,9 @@ describe('list_recent_notes', () => {
       readNoteFn: async () => '---\nprivate: true\n---\n# Diary\n',
     })
     const output = await runRecents(tools, {})
+    if (!output.ok) {
+      expect.unreachable('expected a listing')
+    }
     expect(output.notes).toEqual([])
     expect(JSON.stringify(output)).not.toContain(PRIVATE_TITLE)
   })
@@ -318,6 +359,9 @@ describe('list_recent_notes', () => {
       },
     })
     const output = await runRecents(tools, {})
+    if (!output.ok) {
+      expect.unreachable('expected a listing')
+    }
     expect(output.notes).toEqual([])
   })
 })

--- a/packages/core/src/ai/chat/tools.ts
+++ b/packages/core/src/ai/chat/tools.ts
@@ -6,7 +6,7 @@ import { retrieve, type RetrievalHit, type RetrieveOptions } from '../../embeddi
 import { listDailyNotes, type DailyNoteRow, type DailyNotesRange } from '../../indexing/queries'
 import { listRecentNotes, type RecentNoteRow, type RecentNotesOptions } from '../../indexing/note-list'
 import { parseFrontmatter, splitFrontmatter } from '../../markdown/frontmatter'
-import { parseNote } from '../../markdown/extract'
+import { isTagName, parseNote } from '../../markdown/extract'
 import {
   cloudSafeNoteContent,
   cloudSafeNoteListings,
@@ -63,9 +63,19 @@ export type ReadNoteOutput =
   | { ok: true; note: CloudSafe<CloudNoteContent> }
   | { ok: false; path: string; error: string }
 
-export interface ListRecentNotesOutput {
-  notes: CloudSafe<CloudNoteListing>[]
-}
+/**
+ * A listing, or a corrective refusal for a `tag` the tag grammar can never
+ * produce. Without the refusal a junk filter (`*`, `all`, whitespace…) reads
+ * as a clean "0 notes" — indistinguishable from a real tag nothing carries —
+ * and a model hunting for an "all notes" sentinel just keeps guessing.
+ */
+export type ListRecentNotesOutput =
+  | { ok: true; notes: CloudSafe<CloudNoteListing>[] }
+  | { ok: false; tag: string; error: string }
+
+/** The refusal text — one string, read verbatim by both model and chip. */
+export const INVALID_TAG_ERROR =
+  'Not a tag — omit the tag to list all recent notes. Tags are single words like "book" or "project/atlas".'
 
 export interface ListDailyNotesOutput {
   days: CloudSafe<CloudNoteListing>[]
@@ -98,9 +108,11 @@ const listRecentNotesInput = z.object({
     .describe(`How many notes to return (default ${DEFAULT_RECENT_LIMIT})`),
   tag: z
     .string()
-    .min(1)
-    .optional()
-    .describe('Only notes carrying this tag (case-insensitive, without the #)'),
+    .nullish()
+    .describe(
+      'Only notes carrying this tag (case-insensitive, without the #). ' +
+        'Omit, or pass null, to list all recent notes.',
+    ),
 })
 
 const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'an ISO date, YYYY-MM-DD')
@@ -151,7 +163,8 @@ export function buildNoteTools(deps: NoteToolDeps = {}) {
     search_notes: tool({
       description:
         'Search the user’s notes by meaning and keywords. Returns the best-matching ' +
-        'notes with short snippets. Private notes are excluded.',
+        'notes with short snippets. Queries are plain language — there is no wildcard ' +
+        'or operator syntax. Private notes are excluded.',
       inputSchema: searchNotesInput,
       execute: async ({ query, limit }): Promise<SearchNotesOutput> => {
         const hits = await retrieveFn(query, {
@@ -164,16 +177,23 @@ export function buildNoteTools(deps: NoteToolDeps = {}) {
 
     list_recent_notes: tool({
       description:
-        'List the most recently edited notes, newest first, optionally only those carrying ' +
-        'a tag. Daily notes are not included — use list_daily_notes for those. ' +
+        'List the most recently edited notes, newest first — call it with no tag to see ' +
+        'what the user wrote or worked on lately. Pass a tag only to narrow to notes ' +
+        'carrying it. Daily notes are not included — use list_daily_notes for those. ' +
         'Private notes are excluded.',
       inputSchema: listRecentNotesInput,
       execute: async ({ limit, tag }): Promise<ListRecentNotesOutput> => {
+        if (tag != null && !isTagName(tag)) {
+          return { ok: false, tag, error: INVALID_TAG_ERROR }
+        }
         const rows = await listRecentNotesFn({
           limit: limit ?? DEFAULT_RECENT_LIMIT,
           tag: tag ?? null,
         })
-        return { notes: await cloudSafeNoteListings(rows.map(listingCandidate), isPrivateLive) }
+        return {
+          ok: true,
+          notes: await cloudSafeNoteListings(rows.map(listingCandidate), isPrivateLive),
+        }
       },
     }),
 
@@ -248,11 +268,17 @@ export type NoteToolCall =
   | { tool: 'recents'; toolCallId: string; tag: string | null }
   | { tool: 'dailies'; toolCallId: string; start: string; end: string }
 
-/** One settled tool invocation. A failed read keeps its refusal. */
+/** One settled tool invocation. A failed read or listing keeps its refusal. */
 export type NoteToolResult =
   | { tool: 'search'; toolCallId: string; query: string; hits: NoteHitSummary[] }
   | { tool: 'read'; toolCallId: string; path: string; title: string | null; error: string | null }
-  | { tool: 'recents'; toolCallId: string; tag: string | null; notes: NoteHitSummary[] }
+  | {
+      tool: 'recents'
+      toolCallId: string
+      tag: string | null
+      notes: NoteHitSummary[]
+      error: string | null
+    }
   | { tool: 'dailies'; toolCallId: string; start: string; end: string; days: NoteHitSummary[] }
 
 /** Map an SDK tool-call part onto {@link NoteToolCall} (null for dynamic). */
@@ -301,13 +327,24 @@ export function noteToolResult(part: TypedToolResult<NoteTools>): NoteToolResult
         ? { tool: 'read', toolCallId: part.toolCallId, path: output.note.path, title: output.note.title, error: null }
         : { tool: 'read', toolCallId: part.toolCallId, path: output.path, title: null, error: output.error }
     }
-    case 'list_recent_notes':
-      return {
-        tool: 'recents',
-        toolCallId: part.toolCallId,
-        tag: part.input.tag ?? null,
-        notes: part.output.notes.map(listingSummary),
-      }
+    case 'list_recent_notes': {
+      const output = part.output
+      return output.ok
+        ? {
+            tool: 'recents',
+            toolCallId: part.toolCallId,
+            tag: part.input.tag ?? null,
+            notes: output.notes.map(listingSummary),
+            error: null,
+          }
+        : {
+            tool: 'recents',
+            toolCallId: part.toolCallId,
+            tag: output.tag,
+            notes: [],
+            error: output.error,
+          }
+    }
     case 'list_daily_notes':
       return {
         tool: 'dailies',

--- a/packages/core/src/ai/checkers.ts
+++ b/packages/core/src/ai/checkers.ts
@@ -132,6 +132,38 @@ export async function cloudSafeNoteListings(
     )
 }
 
+/** The graph-level prompt context as an external service may see it. */
+export interface CloudGraphContext {
+  /** The graph's display name (its root folder name). */
+  graphName: string
+  /** Non-daily notes the assistant can list or read. */
+  noteCount: number
+  /** Days with a daily note. */
+  dailyNoteCount: number
+  /** ISO date of the first daily note, `null` when there are none. */
+  earliestDailyDate: string | null
+  /** ISO date of the latest daily note, `null` when there are none. */
+  latestDailyDate: string | null
+  /** Tag facets, most-used first. */
+  tags: { tag: string; count: number }[]
+  /** The facet list was capped — more tags exist. */
+  tagsTruncated: boolean
+}
+
+/**
+ * Gate the graph-level stats block for the system prompt. Unlike the
+ * per-note gates there is nothing to re-check live: these are aggregates
+ * with no note identity attached, so privacy rests on the **queries** —
+ * callers must compute every figure over `is_private = 0` rows only
+ * (`loadGraphStats` does). The index-lag window the live probes close
+ * elsewhere (a note marked private moments before reindex) is accepted
+ * here: no title, path, or content can leak through an aggregate — at
+ * worst a tag name that was public seconds earlier is still counted.
+ */
+export function cloudSafeGraphContext(context: CloudGraphContext): CloudSafe<CloudGraphContext> {
+  return mint(context)
+}
+
 /** A note's content as an external service may see it. */
 export interface CloudNoteContent {
   path: string

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -148,11 +148,13 @@ export {
 export { validateApiKey, type ApiKeyValidation } from './ai/validate-key'
 export {
   assertCloudAllowed,
+  cloudSafeGraphContext,
   cloudSafeNoteContent,
   cloudSafeNoteListings,
   cloudSafeSearchHits,
   isPrivateNoteError,
   PrivateNoteError,
+  type CloudGraphContext,
   type CloudNoteContent,
   type CloudNoteListing,
   type CloudSafe,
@@ -174,6 +176,11 @@ export {
   type SearchNotesOutput,
 } from './ai/chat/tools'
 export { chatSystemPrompt, type SystemPromptInput } from './ai/chat/system-prompt'
+export {
+  loadChatGraphContext,
+  MAX_CONTEXT_TAGS,
+  type GraphContextDeps,
+} from './ai/chat/graph-context'
 export {
   streamChat,
   type ChatStreamEvent,

--- a/packages/core/src/indexing/graph-stats.test.ts
+++ b/packages/core/src/indexing/graph-stats.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setBridge } from '../ipc/bridge'
+import { loadGraphStats } from './graph-stats'
+
+// A fake bridge resolves `db_query` so the tests exercise the real compiled
+// SQL (snake_case columns, parameters) — the same harness note-list.test uses.
+const mockInvoke = vi.fn<(command: string, args: Record<string, unknown>) => Promise<unknown>>()
+
+beforeEach(() => {
+  mockInvoke.mockReset()
+  setBridge({ invoke: mockInvoke, listen: async () => () => {} })
+})
+
+afterEach(() => {
+  setBridge(null)
+})
+
+describe('loadGraphStats', () => {
+  it('computes counts, daily span, and tag facets — every query private-excluded', async () => {
+    mockInvoke
+      .mockResolvedValueOnce([{ count: 5 }])
+      .mockResolvedValueOnce([{ count: 3, earliest: '2026-01-02', latest: '2026-06-01' }])
+      .mockResolvedValueOnce([
+        { tag: 'Book', count: 2 },
+        { tag: 'health', count: 1 },
+      ])
+
+    const stats = await loadGraphStats({ tagLimit: 40 })
+
+    expect(stats).toEqual({
+      noteCount: 5,
+      dailyNoteCount: 3,
+      earliestDailyDate: '2026-01-02',
+      latestDailyDate: '2026-06-01',
+      tags: [
+        { tag: 'Book', count: 2 },
+        { tag: 'health', count: 1 },
+      ],
+      tagsTruncated: false,
+    })
+
+    expect(mockInvoke).toHaveBeenCalledTimes(3)
+    for (const [command, args] of mockInvoke.mock.calls) {
+      expect(command).toBe('db_query')
+      // The hard block: every aggregate is computed over public rows only.
+      expect(String(args.sql)).toContain('"is_private" = ?')
+      expect(args.params).toContain(0)
+    }
+
+    const [, noteArgs] = mockInvoke.mock.calls[0]
+    expect(String(noteArgs.sql)).toContain('"daily_date" is null')
+
+    const [, dailyArgs] = mockInvoke.mock.calls[1]
+    const dailySql = String(dailyArgs.sql)
+    expect(dailySql).toContain('"daily_date" is not null')
+    expect(dailySql).toContain('min(daily_date)')
+    expect(dailySql).toContain('max(daily_date)')
+
+    const [, tagArgs] = mockInvoke.mock.calls[2]
+    const tagSql = String(tagArgs.sql)
+    expect(tagSql).toContain('inner join "notes"')
+    expect(tagSql).toContain('group by "tags"."tag_key"')
+    expect(tagSql).toContain('order by count(*) desc')
+    // One row past the cap, so truncation is detectable.
+    expect(tagArgs.params).toContain(41)
+  })
+
+  it('caps the facets at the limit and flags the truncation', async () => {
+    mockInvoke
+      .mockResolvedValueOnce([{ count: 9 }])
+      .mockResolvedValueOnce([{ count: 0, earliest: null, latest: null }])
+      .mockResolvedValueOnce([
+        { tag: 'a', count: 3 },
+        { tag: 'b', count: 2 },
+        { tag: 'c', count: 1 },
+      ])
+
+    const stats = await loadGraphStats({ tagLimit: 2 })
+
+    expect(stats.tags).toEqual([
+      { tag: 'a', count: 3 },
+      { tag: 'b', count: 2 },
+    ])
+    expect(stats.tagsTruncated).toBe(true)
+  })
+
+  it('maps an empty graph to zero counts, a null span, and no tags', async () => {
+    mockInvoke
+      .mockResolvedValueOnce([{ count: 0 }])
+      .mockResolvedValueOnce([{ count: 0, earliest: null, latest: null }])
+      .mockResolvedValueOnce([])
+
+    const stats = await loadGraphStats({ tagLimit: 40 })
+
+    expect(stats).toEqual({
+      noteCount: 0,
+      dailyNoteCount: 0,
+      earliestDailyDate: null,
+      latestDailyDate: null,
+      tags: [],
+      tagsTruncated: false,
+    })
+  })
+})

--- a/packages/core/src/indexing/graph-stats.ts
+++ b/packages/core/src/indexing/graph-stats.ts
@@ -1,0 +1,81 @@
+import { sql } from 'kysely'
+import { db } from './db'
+import type { NoteTagFacet } from './note-list'
+
+/**
+ * Graph-level aggregates for the AI chat's system prompt (the "graph
+ * overview" block): how many notes the assistant can see, the span of the
+ * daily journal, and which tags exist — so the model types tag filters and
+ * date ranges from knowledge instead of guessing.
+ *
+ * Every figure is computed over `is_private = 0` rows only. These are
+ * provider-bound aggregates; the privacy contract is documented on
+ * `cloudSafeGraphContext` in `../ai/checkers`, which is the only way this
+ * data reaches a prompt.
+ */
+
+/** The aggregates of one graph, private notes excluded throughout. */
+export interface GraphStats {
+  /** Non-daily notes the assistant can list or read. */
+  noteCount: number
+  /** Days with a (non-private) daily note. */
+  dailyNoteCount: number
+  /** ISO date of the first daily note, `null` when there are none. */
+  earliestDailyDate: string | null
+  /** ISO date of the latest daily note, `null` when there are none. */
+  latestDailyDate: string | null
+  /** Tag facets over non-daily notes, most-used first then alphabetical. */
+  tags: NoteTagFacet[]
+  /** The facet list was capped at `tagLimit` — more tags exist. */
+  tagsTruncated: boolean
+}
+
+export interface GraphStatsOptions {
+  /** Facet cap — the most-used tags win (prompt token budget, not recall). */
+  tagLimit: number
+}
+
+/** Load {@link GraphStats} from the active graph's index. */
+export async function loadGraphStats({ tagLimit }: GraphStatsOptions): Promise<GraphStats> {
+  const [noteRow, dailyRow, tagRows] = await Promise.all([
+    db
+      .selectFrom('notes')
+      .where('dailyDate', 'is', null)
+      .where('isPrivate', '=', 0)
+      .select(sql<number>`count(*)`.as('count'))
+      .executeTakeFirst(),
+    db
+      .selectFrom('notes')
+      .where('dailyDate', 'is not', null)
+      .where('isPrivate', '=', 0)
+      .select([
+        sql<number>`count(*)`.as('count'),
+        sql<string | null>`min(daily_date)`.as('earliest'),
+        sql<string | null>`max(daily_date)`.as('latest'),
+      ])
+      .executeTakeFirst(),
+    // The same facet shape as `listNoteTags` (grouped on the stored folded
+    // `tag_key`, one deterministic display casing), narrowed to non-private
+    // notes and capped one past the limit so truncation is detectable.
+    db
+      .selectFrom('tags')
+      .innerJoin('notes', 'notes.path', 'tags.notePath')
+      .where('notes.dailyDate', 'is', null)
+      .where('notes.isPrivate', '=', 0)
+      .select([sql<string>`min(tags.tag)`.as('tag'), sql<number>`count(*)`.as('count')])
+      .groupBy('tags.tagKey')
+      .orderBy(sql`count(*)`, 'desc')
+      .orderBy('tags.tagKey')
+      .limit(tagLimit + 1)
+      .execute(),
+  ])
+  const tagsTruncated = tagRows.length > tagLimit
+  return {
+    noteCount: noteRow?.count ?? 0,
+    dailyNoteCount: dailyRow?.count ?? 0,
+    earliestDailyDate: dailyRow?.earliest ?? null,
+    latestDailyDate: dailyRow?.latest ?? null,
+    tags: tagsTruncated ? tagRows.slice(0, tagLimit) : tagRows,
+    tagsTruncated,
+  }
+}


### PR DESCRIPTION
## What

Asked *"what notes have I written recently?"*, GPT-5.5 burned seven `list_recent_notes` calls guessing "no filter" sentinels for `tag` — `" "`, `"]INVALIDNOFILTER["`, `":*"`, `"all"`, `","`, `"*"`, `"#"` — every one answered with a clean `0 notes`, before it gave up and called `search_notes("*")`. Seven of the turn's eight steps wasted on flailing.

This PR fixes the failure from both ends: corrective feedback when the model holds the tool wrong, and enough context that it doesn't guess in the first place.

### 1. Corrective refusals for junk tags

- A tag the tag grammar can never produce previously returned `0 notes` — indistinguishable from a real tag nothing carries, so the model had no signal. `list_recent_notes` now validates `tag` with the existing `isTagName` grammar predicate and returns a structured `{ ok: false, tag, error }` refusal *without querying*, telling the model to omit the tag to list everything — mirroring `read_note`'s refusal shape.
- `tag` is now `nullish` (a legal "no filter" spelling for models that insist on filling every param), and its description says omit/null lists everything.
- The system prompt says a no-tag `list_recent_notes` call answers "what have I written lately", and that tool inputs have no wildcard/operator syntax (`search_notes` description too, for the `"*"` fallback).
- The recents chip renders the refusal (`Listed #* notes — Not a tag…`) instead of a misleading `· 0 notes`, the same way failed reads do.

### 2. Graph overview block in the system prompt

The model had no sense of the graph it grounds in. Each turn's prompt now carries:

```
Graph overview (private notes are excluded from every figure):
- Graph: “reflect-open-graph” — 124 notes and 37 daily notes.
- Daily notes span 2025-11-02 to 2026-06-12.
- Tags in use, by note count: #book (12), #project/atlas (5). These are the only tags — any other tag matches nothing.
```

- `loadGraphStats` (new `indexing/graph-stats.ts`) computes note count, daily count + span, and tag facets — **every query filtered to `is_private = 0` in SQL**; facets are capped (top 40 by use, one row past the cap fetched so truncation is detectable).
- The tag line is deliberately assertive: complete list → "these are the only tags"; capped → "more tags exist"; none → "never pass a tag filter". Tags counted are those on non-daily notes, exactly matching what `list_recent_notes` can filter — a daily-only tag in the list would re-create the "0 notes" confusion.
- `streamChat` *requires* `context` (`| null`) so call sites choose the degraded mode explicitly. The chat provider loads it per send (three local SQLite reads, in parallel with the keychain read) and degrades to `null` with a logged error — a cold index never blocks the turn.
- `ChatProvider` now takes the open `graph` as a prop (same pattern as `AudioMemoProvider`); only the graph *name* goes into the prompt, not the root path. There is no graph UUID — `GraphInfo` identity is root + name.

## Notes for review

- **Privacy:** the new `cloudSafeGraphContext` gate in `checkers.ts` keeps the invariant that everything provider-bound is minted in the privacy module. Its docstring owns the one deliberate trade-off: aggregates can't be live-re-checked per note the way listings are, so privacy rests on the SQL filter — at worst the index-lag window exposes a bare tag name that was public seconds earlier, never a title/path/content.
- Checked the obvious suspect for the flailing first: `@ai-sdk/openai` defaults `strictJsonSchema: true`, but tool schemas go out non-strict and keep `tag`/`limit` optional — this was model behavior, not schema serialization.
- `ListRecentNotesOutput` became a discriminated union (`ok: true/false`); `NoteToolResult`'s recents arm gained `error: string | null`; the refusal string is one constant read verbatim by both the model and the chip.
- Follow-up deliberately left out: a `list_tags` *tool* is now mostly redundant (the prompt carries the vocabulary), and the existing `listNoteTags()` UI query isn't private-safe anyway.

## Testing

- Tool tests: junk tags (`*`, `" "`, `#book`, `]INVALIDNOFILTER[`) refuse without hitting the query; explicit `null` tag lists all.
- New `graph-stats` tests assert `is_private = 0` on every compiled query, facet capping/truncation, and empty-graph mapping; new `system-prompt` tests cover the overview block's variants (null context, full, capped, zero tags, no dailies).
- `stream-chat` test asserts the overview reaches the outbound provider prompt; chat-screen tests cover context plumbing per turn and the degraded (context-load-failed) path, plus the refusal chip rendering.
- `pnpm check` green; core chat + graph-stats tests 47/47, desktop chat tests 28/28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)