### PR TITLE
Chat + Settings: remove redundant descriptive copy

### DIFF
--- a/apps/desktop/src/components/chat/chat-turn-list.tsx
+++ b/apps/desktop/src/components/chat/chat-turn-list.tsx
@@ -28,19 +28,15 @@ export function ChatTurnList(): ReactElement {
       }}
       className="min-h-0 flex-1 overflow-y-auto px-6"
     >
-      <div className="mx-auto w-full max-w-2xl py-8">
-        {turns.length === 0 ? (
-          <p className="mt-16 text-center text-sm text-text-muted">
-            Ask about your notes — answers are grounded in your graph and cite the notes they use.
-          </p>
-        ) : (
+      {turns.length > 0 && (
+        <div className="mx-auto w-full max-w-2xl py-8">
           <div className="flex flex-col gap-6">
             {turns.map((turn) => (
               <ChatTurn key={turn.id} turn={turn} />
             ))}
           </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/desktop/src/components/settings/about-section.tsx
+++ b/apps/desktop/src/components/settings/about-section.tsx
@@ -9,9 +9,6 @@ export function AboutSection(): ReactElement {
       <div className="flex items-center justify-between gap-4 px-4 py-3.5">
         <div className="min-w-0">
           <div className="text-sm font-medium text-text">Reflect Open</div>
-          <p className="mt-0.5 text-xs text-text-muted">
-            Local-first networked notes. Your graph is a folder of markdown files.
-          </p>
         </div>
         <span className="shrink-0 text-sm text-text-secondary">
           {version !== null ? `v${version}` : '—'}


### PR DESCRIPTION
## Summary

- **Chat empty state**: removes the "Ask about your notes — answers are grounded in your graph…" paragraph. The textarea's placeholder already reads "Ask about your notes…", so the paragraph was redundant and cluttered the empty canvas.
- **About section**: removes the "Local-first networked notes. Your graph is a folder of markdown files." subtitle, leaving just the app name and version for a sparser look.

## Test plan

- [ ] Open chat with a fresh session — empty state should be a clean blank area with the input at the bottom
- [ ] Open Settings → About — should show "Reflect Open" and the version number, no subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and conditional layout only; no behavior, auth, or data paths change.
> 
> **Overview**
> **Chat** drops the empty-state paragraph that repeated the input placeholder and only mounts the centered turn list when there is at least one turn, so a new session is a blank scroll area above the composer.
> 
> **Settings → About** removes the “local-first networked notes” subtitle so the row is just **Reflect Open** and the version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 829a463f323f1f93711b5106a2595e99826bec1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->