### PR TITLE
UI: standardize loading spinners behind a shared Spinner component

### DIFF
--- a/apps/desktop/src/components/audio-memo/recording-popover.tsx
+++ b/apps/desktop/src/components/audio-memo/recording-popover.tsx
@@ -1,8 +1,8 @@
 import type { ReactElement } from 'react'
-import { Loader2 } from 'lucide-react'
 import { RecordingWaveform } from '@/components/audio-memo/recording-waveform'
 import { Button } from '@/components/ui/button'
 import { PopoverContent } from '@/components/ui/popover'
+import { Spinner } from '@/components/ui/spinner'
 import { useAudioMemo } from '@/providers/audio-memo-provider'
 
 /**
@@ -51,7 +51,7 @@ export function RecordingPopover(): ReactElement {
         </div>
       ) : memo.phase === 'transcribing' ? (
         <div className="flex items-center gap-2 text-sm text-text-muted">
-          <Loader2 aria-hidden className="size-4 animate-spin" />
+          <Spinner />
           Transcribing…
         </div>
       ) : (

--- a/apps/desktop/src/components/chat/chat-tool-chip.tsx
+++ b/apps/desktop/src/components/chat/chat-tool-chip.tsx
@@ -1,8 +1,9 @@
 import type { ReactElement, ReactNode } from 'react'
-import { CalendarDays, FileText, History, LoaderCircle, Search } from 'lucide-react'
+import { CalendarDays, FileText, History, Search } from 'lucide-react'
 import { isToolPending, type AssistantPart } from '@/lib/chat-transcript'
 import { routeForPath } from '@/routing/route'
 import { useRouter } from '@/routing/router'
+import { Spinner } from '@/components/ui/spinner'
 
 interface ChatToolChipProps {
   part: Extract<AssistantPart, { kind: 'tool' }>
@@ -23,7 +24,7 @@ interface ChipFrameProps {
 function ChipFrame({ pending, icon, children }: ChipFrameProps): ReactElement {
   return (
     <span className="flex items-center gap-1.5 text-xs text-text-muted">
-      {pending ? <LoaderCircle aria-hidden className="size-3.5 animate-spin" /> : icon}
+      {pending ? <Spinner /> : icon}
       {children}
     </span>
   )

--- a/apps/desktop/src/components/ui/spinner.tsx
+++ b/apps/desktop/src/components/ui/spinner.tsx
@@ -1,0 +1,13 @@
+import type { ReactElement } from 'react'
+import { LoaderCircle } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface SpinnerProps {
+  /** Additional classes, typically a size utility (e.g. `size-4`). Defaults to `size-3`. */
+  className?: string
+}
+
+/** A spinning loading indicator. Pair with a visible text label and set `aria-hidden` is applied automatically. */
+export function Spinner({ className }: SpinnerProps): ReactElement {
+  return <LoaderCircle aria-hidden className={cn('size-3 animate-spin', className)} />
+}


### PR DESCRIPTION
## Summary

- Adds `components/ui/spinner.tsx` — a single `<Spinner>` primitive backed by `LoaderCircle` with `animate-spin`, defaulting to `size-3` (12px)
- Replaces ad-hoc `Loader2` (recording-popover) and `LoaderCircle` (chat-tool-chip) inline usages with the new component
- The spinning `RefreshCw` in `rebuild-index-field` is left intentionally — it's a button icon that doubles as progress feedback, a distinct pattern

## Test plan

- [ ] Chat tool chips show a small spinner while a tool call is pending
- [ ] Recording popover shows a spinner while transcribing
- [ ] Rebuild index button still spins its refresh icon during rebuild (unchanged)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentational refactor with a minor default spinner size change; no logic, auth, or data paths touched.
> 
> **Overview**
> Introduces a shared **`Spinner`** UI primitive (`LoaderCircle` + `animate-spin`, default **`size-3`**, **`aria-hidden`**, optional **`className`**) so loading states don’t repeat inline Lucide markup.
> 
> **Recording popover** swaps **`Loader2`** for **`Spinner`** next to “Transcribing…”. **Chat tool chips** use **`Spinner`** in **`ChipFrame`** while a tool call is pending instead of an inline **`LoaderCircle`**. Pending chips now use the shared default size rather than ad-hoc **`size-3.5`** / **`size-4`** classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16b03c7df93baeba65518d1ac1c8cf3093c0f435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->