### PR TITLE
Daily stream: anchor in the layout phase to kill the entry flicker

### DIFF
--- a/apps/desktop/src/components/daily-stream.test.tsx
+++ b/apps/desktop/src/components/daily-stream.test.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useEffect, useState, type ReactElement, type ReactNode } from 'react'
+import { useEffect, useLayoutEffect, useState, type ReactElement, type ReactNode } from 'react'
 import { setBridge } from '@reflect/core'
 import { RouterProvider, useRouter } from '@/routing/router'
 import { todayIso } from '@/lib/dates'
@@ -55,6 +55,17 @@ Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
   },
 })
 
+// jsdom's scrollHeight is also always 0, which would clamp every
+// `scrollToIndex`/`scrollToOffset` command to `top: 0`. Give the stream a
+// scroll range taller than the day window so anchor commands keep their
+// real offsets.
+Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+  configurable: true,
+  get(this: HTMLElement) {
+    return this.dataset['testid'] === 'daily-stream' ? 10_000_000 : 0
+  },
+})
+
 setBridge({
   // Reads never resolve: every day stays a loading placeholder.
   invoke: () => new Promise(() => {}),
@@ -82,6 +93,18 @@ function SaveScrollProbe({ offset }: { offset: number }): ReactElement | null {
   useEffect(() => {
     saveScrollState(offset)
   }, [saveScrollState, offset])
+  return null
+}
+
+/**
+ * Runs `onLayout` in the layout phase of every commit it participates in.
+ * Mounted as a sibling *after* the stream, its layout effect runs once all of
+ * the stream's layout effects have — the end of the commit's layout phase.
+ */
+function LayoutPhaseProbe({ onLayout }: { onLayout: () => void }): null {
+  useLayoutEffect(() => {
+    onLayout()
+  }, [onLayout])
   return null
 }
 
@@ -117,6 +140,37 @@ describe('DailyStream', () => {
 
     expect(scrollToSpy.mock.calls.length).toBeGreaterThan(0)
     expect(scrollToSpy.mock.calls[0][0]).toMatchObject({ top: 4321 })
+    view.unmount()
+  })
+
+  it('issues the anchor scroll inside the mount commit’s layout phase', () => {
+    // Pins the layout-phase anchoring that fixes the entry flicker: rows
+    // measure during the mount commit itself (their refs fire before the
+    // virtualizer has attached the scroll element, so its above-viewport
+    // resize compensation is a silent no-op), which moves the target day's
+    // true start away from the estimate-derived `initialOffset` before first
+    // paint. An anchor deferred to a passive effect corrects the offset only
+    // after the mis-anchored frame has painted. By the end of the mount
+    // commit's layout phase, both the virtualizer's element-attach apply and
+    // the anchor's own command must therefore already be issued.
+    let commandsDuringLayout = -1
+    const today = todayIso()
+    const view = render(
+      <StreamProviders>
+        <DailyStream targetDate={today} />
+        <LayoutPhaseProbe
+          onLayout={() => {
+            if (commandsDuringLayout === -1) {
+              commandsDuringLayout = scrollToSpy.mock.calls.length
+            }
+          }}
+        />
+      </StreamProviders>,
+    )
+
+    const expected = indexOfDate(createDayWindow(today), today) * ESTIMATED_DAY_HEIGHT
+    expect(commandsDuringLayout).toBeGreaterThanOrEqual(2)
+    expect(scrollToSpy.mock.calls[commandsDuringLayout - 1][0]).toMatchObject({ top: expected })
     view.unmount()
   })
 

--- a/apps/desktop/src/components/daily-stream.tsx
+++ b/apps/desktop/src/components/daily-stream.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react'
+import { useCallback, useLayoutEffect, useRef, useState, type ReactElement } from 'react'
 import { useVirtualizer, type VirtualItem, type Virtualizer } from '@tanstack/react-virtual'
 import { dailyPath } from '@reflect/core'
 import { NotePane } from '@/components/note-pane'
@@ -88,9 +88,9 @@ export function DailyStream({ targetDate }: DailyStreamProps): ReactElement {
     // The mount-time anchor. The virtualizer applies this to the scroll
     // element inside its own layout effect — before first paint — so the
     // stream never paints the top of the window and then visibly lurches
-    // down to the target day (the anchor effect below runs post-paint). A
-    // remount of an entry the user navigated back to restores its saved
-    // offset the same jump-free way.
+    // down to the target day, and it decides which rows the first render
+    // mounts at all. A remount of an entry the user navigated back to
+    // restores its saved offset the same jump-free way.
     initialOffset: () =>
       savedScroll() ?? indexOfDate(dayWindow, targetDateRef.current) * ESTIMATED_DAY_HEIGHT,
   })
@@ -111,11 +111,19 @@ export function DailyStream({ targetDate }: DailyStreamProps): ReactElement {
   // pressed while already on today — the router clears the entry's saved
   // offset for that case; `entryId` covers back/forward between entries whose
   // routes resolve to the same day). A back/forward-restored entry carries its
-  // offset; a fresh navigation anchors to the target day. On mount this lands
-  // where `initialOffset` already put the viewport — but `scrollToIndex` also
-  // installs the virtualizer's index-pinning reconcile, which keeps the target
-  // day at the viewport top while the surrounding rows measure in.
-  useEffect(() => {
+  // offset; a fresh navigation anchors to the target day.
+  //
+  // A layout effect, not a passive one: rows measure during the mount commit
+  // itself — their `measureElement` refs fire before the virtualizer's own
+  // layout effect has attached the scroll element, so its above-viewport
+  // resize compensation is a silent no-op — and that moves the target day's
+  // true start away from the estimate-derived `initialOffset` before first
+  // paint. A post-paint anchor let that mis-anchored frame become visible: a
+  // one-frame flicker on every entry into the stream. Anchoring in the layout
+  // phase installs `scrollToIndex`'s index-pinning reconcile (rAF, still
+  // pre-paint), which pins the target day to the viewport top before the
+  // frame is shown and holds it there while the surrounding rows measure in.
+  useLayoutEffect(() => {
     const restored = savedScroll()
     if (restored !== null) {
       // A restored arrival also cancels any focus still pending from a prior


### PR DESCRIPTION
## What

Entering the daily stream (clicking "Daily notes", ⌘D, opening the app) painted one mis-anchored frame — the viewport ~50px past the target day's heading, showing its content with the date scrolled off above — then snapped back on the next frame. Frame-by-frame extraction of a screen recording pinned it to a single wrong painted frame followed by a correction.

## Why it happened

Verified against the installed `@tanstack/virtual-core` 3.17.0 source:

1. Rows measure during the mount commit itself: their `measureElement` refs fire **before** the virtualizer's own layout effect has attached the scroll element, so its above-viewport resize compensation calls `scrollElement?.scrollTo` on `null` — a silent no-op — and the accumulated adjustments are dropped when the element attaches.
2. With notes warm in the query cache, rows mount at real heights (shorter than the 220px estimate), shifting the target day's true `start` away from the estimate-derived `initialOffset` before first paint.
3. The anchor was a passive `useEffect`, so its `scrollToIndex` correction landed one frame **after** paint. That frame is the flicker.

## The fix

Make the anchor a `useLayoutEffect`. It runs in the same commit — after the virtualizer's internal layout effects have attached the scroll element (hook order guarantees this) — and `scrollToIndex` installs its index-pinning reconcile on `requestAnimationFrame`, which also runs before paint, so the target day is re-pinned with fresh measurements before any frame is shown. Back/forward restores take the same pre-paint path via `scrollToOffset`.

## Testing

- New regression test uses a `LayoutPhaseProbe` sibling whose layout effect snapshots the scroll commands at the end of the mount commit's layout phase: both the virtualizer's element-attach apply and the anchor's command must already be issued. **Mutation-tested**: fails against the `useEffect` version (`expected 1 to be >= 2`), passes with the fix.
- Reviewer note: a simpler `flushSync`-without-`act` approach was tried first and does **not** discriminate — the virtualizer's follow-on sync render makes React flush pending passive effects inside the commit in the test environment — hence the probe.
- jsdom's `scrollHeight` is now stubbed alongside `offsetHeight`; without it `getMaxScrollOffset()` clamps every `scrollToIndex`/`scrollToOffset` command to `top: 0`.
- All 4 daily-stream tests pass; `pnpm check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized scroll-timing change in the daily stream view with targeted tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a **one-frame flicker** when entering the daily stream by moving the arrival anchor from `useEffect` to **`useLayoutEffect`** in `DailyStream`, so `scrollToIndex` / `scrollToOffset` run in the same commit’s layout phase (before paint) after row measurement can shift the target day away from `initialOffset`.
> 
> Tests add a **`scrollHeight` jsdom stub** so anchor commands aren’t clamped to `top: 0`, plus a **`LayoutPhaseProbe`** regression that asserts the anchor scroll is issued by the end of the mount commit’s layout phase (not deferred to a passive effect).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fa09a0e59b1ef253ef89d5a6fdc8dc65f6d45bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visual smoothness for scroll anchoring in the daily stream by eliminating brief visual glitches that occurred during view transitions.

* **Tests**
  * Enhanced test coverage for scroll anchoring behavior during the layout phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->