### PR TITLE
Chat: persist conversations in SQLite + moving context window

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Drawn from the product docs — read these for deeper context:
 
 - **Daily notes first.** The app opens to today's note. All capture flows into the daily note by default.
 - **Association over hierarchy.** `[[Wiki Links]]` replace folders. The note graph is the organizing model; there are no folders.
-- **Markdown is the source of truth.** Notes are `.md` files (`daily/YYYY-MM-DD.md`, `notes/`). SQLite under `.reflect/` is a rebuildable projection, never durable storage.
+- **Markdown is the source of truth.** Notes are `.md` files (`daily/YYYY-MM-DD.md`, `notes/`). SQLite under `.reflect/` is a rebuildable projection of the notes — with one durable exception: the `chat_*` tables hold AI chat history, which is not derivable from markdown. Index wipes and rebuilds must leave them untouched.
 - **No Reflect-hosted APIs.** LLM calls go directly to user-approved providers (OpenAI, Anthropic, etc.). Sync goes to GitHub/iCloud/Git. Never proxy through Reflect infrastructure.
 - **BYOK AI.** AI features use user-supplied keys. Never assume Reflect operates AI infrastructure.
 - **`private: true` is a hard block.** Notes with this frontmatter flag must never have their content sent to any external service — AI, transcription, or otherwise. Enforce at every call site.

--- a/apps/desktop/src-tauri/src/db/chat_write.rs
+++ b/apps/desktop/src-tauri/src/db/chat_write.rs
@@ -1,0 +1,93 @@
+//! The chat history write path: conversation + message upserts.
+//!
+//! Unlike every other table in the index, `chat_conversations`/`chat_messages`
+//! are **durable** — chat history is not derived from markdown and cannot be
+//! rebuilt, so `clear_index` and projection-wipe migrations must leave these
+//! rows alone. Mutations are plain functions over a [`Connection`]; the
+//! command layer ([`super`]) owns transactions and generation gating.
+
+use rusqlite::{params, Connection};
+use serde::Deserialize;
+
+use crate::error::AppResult;
+
+/// A conversation's metadata, sent with every message save so the row can be
+/// created lazily on the first message. Mirrors the zod contract in
+/// `packages/core/src/ai/chat/store.ts` field-for-field.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChatConversation {
+    pub(super) id: String,
+    pub(super) title: String,
+    pub(super) created_ms: i64,
+    pub(super) updated_ms: i64,
+}
+
+/// One persisted exchange: the user message and everything the assistant did
+/// in response. The JSON columns are opaque strings here — the TS store owns
+/// their shapes and validates them on read.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChatMessageRow {
+    pub(super) id: String,
+    pub(super) conversation_id: String,
+    pub(super) seq: i64,
+    pub(super) user_text: String,
+    pub(super) attachments: String,
+    pub(super) parts: String,
+    pub(super) response_messages: String,
+    pub(super) created_ms: i64,
+}
+
+/// Upsert the conversation row and the message row. The conversation keeps its
+/// original `title`/`created_ms` (set once, on insert) and bumps `updated_ms`;
+/// the message updates by **primary key** — deliberately not `INSERT OR
+/// REPLACE`, which deletes any row violating *any* unique constraint, so a
+/// `(conversation_id, seq)` collision would silently destroy a different turn.
+/// With `ON CONFLICT(id)` such a collision fails loudly instead.
+pub(super) fn save_message(
+    conn: &Connection,
+    conversation: &ChatConversation,
+    message: &ChatMessageRow,
+) -> AppResult<()> {
+    conn.prepare_cached(
+        "INSERT INTO chat_conversations(id, title, created_ms, updated_ms)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(id) DO UPDATE SET updated_ms = excluded.updated_ms",
+    )?
+    .execute(params![
+        conversation.id,
+        conversation.title,
+        conversation.created_ms,
+        conversation.updated_ms,
+    ])?;
+    conn.prepare_cached(
+        "INSERT INTO chat_messages(
+            id, conversation_id, seq, user_text, attachments, parts,
+            response_messages, created_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+         ON CONFLICT(id) DO UPDATE SET
+            user_text = excluded.user_text,
+            attachments = excluded.attachments,
+            parts = excluded.parts,
+            response_messages = excluded.response_messages",
+    )?
+    .execute(params![
+        message.id,
+        message.conversation_id,
+        message.seq,
+        message.user_text,
+        message.attachments,
+        message.parts,
+        message.response_messages,
+        message.created_ms,
+    ])?;
+    Ok(())
+}
+
+/// Delete a conversation; its messages cascade.
+pub(super) fn delete_conversation(conn: &Connection, id: &str) -> AppResult<()> {
+    conn.prepare_cached("DELETE FROM chat_conversations WHERE id = ?1")?
+        .execute(params![id])?;
+    Ok(())
+}

--- a/apps/desktop/src-tauri/src/db/mod.rs
+++ b/apps/desktop/src-tauri/src/db/mod.rs
@@ -6,9 +6,12 @@
 //! module owns the schema/migrations ([`migrations`]), all writes — one
 //! transaction per batch, generation-gated here in the command layer
 //! ([`write`] holds the row logic) — plus a read-only `db_query` bridge
-//! ([`query`]) that executes the SQL the frontend builds with Kysely. The DB is
-//! a cache: deleting it loses nothing durable.
+//! ([`query`]) that executes the SQL the frontend builds with Kysely. The DB
+//! is *mostly* a cache: the note projection is rebuildable from markdown, but
+//! the `chat_*` tables ([`chat_write`]) hold durable chat history — deleting
+//! the file loses those.
 
+mod chat_write;
 mod embed_write;
 mod migrations;
 mod query;
@@ -25,6 +28,7 @@ use tauri::State;
 use crate::error::{AppError, AppResult};
 use crate::fs::GraphState;
 
+pub use chat_write::{ChatConversation, ChatMessageRow};
 pub use embed_write::EmbeddedChunk;
 pub use write::IndexedNote;
 
@@ -249,7 +253,9 @@ pub fn index_meta_set(
     Ok(())
 }
 
-/// Wipe all derived tables (the TS layer then re-applies every note; no-op if stale).
+/// Wipe all derived tables (the TS layer then re-applies every note; no-op if
+/// stale). The `chat_*` tables are deliberately untouched — chat history is
+/// durable, not a rebuildable projection.
 #[tauri::command]
 pub fn index_clear(generation: u64, index: State<IndexState>) -> AppResult<()> {
     let state = lock_state(&index)?;
@@ -258,6 +264,44 @@ pub fn index_clear(generation: u64, index: State<IndexState>) -> AppResult<()> {
     }
     let conn = state.conn.as_ref().ok_or_else(AppError::no_graph)?;
     write::clear_index(conn)
+}
+
+/// Upsert one chat message and its conversation row in a single transaction
+/// (no-op if stale). Called at send time with the user half and again at
+/// settle with the full record, so a crash mid-stream keeps the user message.
+/// Stale-generation writes are dropped like every other index write — a turn
+/// detached by a graph switch must not land in the new graph's history.
+#[tauri::command]
+pub fn chat_message_save(
+    conversation: ChatConversation,
+    message: ChatMessageRow,
+    generation: u64,
+    index: State<IndexState>,
+) -> AppResult<()> {
+    let mut state = lock_state(&index)?;
+    if state.generation != generation {
+        return Ok(());
+    }
+    let conn = state.conn.as_mut().ok_or_else(AppError::no_graph)?;
+    let tx = conn.transaction()?;
+    chat_write::save_message(&tx, &conversation, &message)?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// Delete a conversation and (via cascade) its messages (no-op if stale).
+#[tauri::command]
+pub fn chat_conversation_delete(
+    id: String,
+    generation: u64,
+    index: State<IndexState>,
+) -> AppResult<()> {
+    let state = lock_state(&index)?;
+    if state.generation != generation {
+        return Ok(());
+    }
+    let conn = state.conn.as_ref().ok_or_else(AppError::no_graph)?;
+    chat_write::delete_conversation(conn, &id)
 }
 
 /// Replace a note's embedding chunk set (diff applied in one transaction;

--- a/apps/desktop/src-tauri/src/db/tests.rs
+++ b/apps/desktop/src-tauri/src/db/tests.rs
@@ -895,7 +895,10 @@ fn chat_message_save_round_trips_and_upserts_the_conversation() {
     )
     .unwrap();
     assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0]["title"], Value::from("What did I write about Rust?"));
+    assert_eq!(
+        rows[0]["title"],
+        Value::from("What did I write about Rust?")
+    );
 
     // A later save bumps updated_ms but never rewrites title/created_ms —
     // the title is the conversation's identity, set once at creation.
@@ -910,7 +913,10 @@ fn chat_message_save_round_trips_and_upserts_the_conversation() {
         &[],
     )
     .unwrap();
-    assert_eq!(rows[0]["title"], Value::from("What did I write about Rust?"));
+    assert_eq!(
+        rows[0]["title"],
+        Value::from("What did I write about Rust?")
+    );
     assert_eq!(rows[0]["created_ms"], Value::from(1_000));
     assert_eq!(rows[0]["updated_ms"], Value::from(9_000));
 }
@@ -926,7 +932,12 @@ fn chat_message_resave_updates_by_id() {
         r#"[{"role":"assistant","content":"You wrote three notes."}]"#.to_string();
     save_message(&conn, &conversation("c1"), &settled).unwrap();
 
-    let rows = run_query(&conn, "SELECT parts FROM chat_messages WHERE id = 'm1'", &[]).unwrap();
+    let rows = run_query(
+        &conn,
+        "SELECT parts FROM chat_messages WHERE id = 'm1'",
+        &[],
+    )
+    .unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(
         rows[0]["parts"],

--- a/apps/desktop/src-tauri/src/db/tests.rs
+++ b/apps/desktop/src-tauri/src/db/tests.rs
@@ -5,6 +5,7 @@
 use rusqlite::Connection;
 use serde_json::Value;
 
+use super::chat_write::{delete_conversation, save_message, ChatConversation, ChatMessageRow};
 use super::embed_write::{apply_chunks, remove_chunks, EmbeddedChunk};
 use super::migrations::{migrate, migrate_to, open_in_memory, open_index_at, validate_migrations};
 use super::query::run_query;
@@ -60,7 +61,7 @@ fn migrations_are_valid_and_idempotent() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 7); // applied migrations (0001 through 0007)
+    assert_eq!(version, 8); // applied migrations (0001 through 0008)
     migrate(&mut conn).expect("re-running to_latest is a no-op");
 }
 
@@ -264,7 +265,7 @@ fn open_index_at_creates_migrates_and_reopens() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 7);
+    assert_eq!(version, 8);
     let journal: String = conn
         .query_row("PRAGMA journal_mode", [], |row| row.get(0))
         .unwrap();
@@ -856,4 +857,124 @@ fn watcher_echo_after_a_move_is_benign_and_vectors_survive() {
         vec![("notes/kept-title.md".to_string(), "e1".to_string())]
     );
     assert_eq!(vector_count(&conn), 1);
+}
+
+// ---- chat history (0008) ----------------------------------------------------
+
+fn conversation(id: &str) -> ChatConversation {
+    ChatConversation {
+        id: id.to_string(),
+        title: "What did I write about Rust?".to_string(),
+        created_ms: 1_000,
+        updated_ms: 1_000,
+    }
+}
+
+fn chat_message(id: &str, conversation_id: &str, seq: i64) -> ChatMessageRow {
+    ChatMessageRow {
+        id: id.to_string(),
+        conversation_id: conversation_id.to_string(),
+        seq,
+        user_text: "What did I write about Rust?".to_string(),
+        attachments: "[]".to_string(),
+        parts: "[]".to_string(),
+        response_messages: "[]".to_string(),
+        created_ms: 1_000,
+    }
+}
+
+#[test]
+fn chat_message_save_round_trips_and_upserts_the_conversation() {
+    let conn = migrated();
+    save_message(&conn, &conversation("c1"), &chat_message("m1", "c1", 0)).unwrap();
+
+    let rows = run_query(
+        &conn,
+        "SELECT title, created_ms, updated_ms FROM chat_conversations WHERE id = 'c1'",
+        &[],
+    )
+    .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["title"], Value::from("What did I write about Rust?"));
+
+    // A later save bumps updated_ms but never rewrites title/created_ms —
+    // the title is the conversation's identity, set once at creation.
+    let mut later = conversation("c1");
+    later.title = "ignored".to_string();
+    later.created_ms = 9_000;
+    later.updated_ms = 9_000;
+    save_message(&conn, &later, &chat_message("m2", "c1", 1)).unwrap();
+    let rows = run_query(
+        &conn,
+        "SELECT title, created_ms, updated_ms FROM chat_conversations WHERE id = 'c1'",
+        &[],
+    )
+    .unwrap();
+    assert_eq!(rows[0]["title"], Value::from("What did I write about Rust?"));
+    assert_eq!(rows[0]["created_ms"], Value::from(1_000));
+    assert_eq!(rows[0]["updated_ms"], Value::from(9_000));
+}
+
+#[test]
+fn chat_message_resave_updates_by_id() {
+    // The settle-time save re-sends the same row id with the streamed result.
+    let conn = migrated();
+    save_message(&conn, &conversation("c1"), &chat_message("m1", "c1", 0)).unwrap();
+    let mut settled = chat_message("m1", "c1", 0);
+    settled.parts = r#"[{"kind":"text","text":"You wrote three notes."}]"#.to_string();
+    settled.response_messages =
+        r#"[{"role":"assistant","content":"You wrote three notes."}]"#.to_string();
+    save_message(&conn, &conversation("c1"), &settled).unwrap();
+
+    let rows = run_query(&conn, "SELECT parts FROM chat_messages WHERE id = 'm1'", &[]).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0]["parts"],
+        Value::from(r#"[{"kind":"text","text":"You wrote three notes."}]"#)
+    );
+}
+
+#[test]
+fn chat_message_seq_collision_errors_instead_of_replacing() {
+    // A different id landing on an occupied (conversation, seq) means caller
+    // bookkeeping is broken; failing loudly beats silently destroying a turn
+    // (which INSERT OR REPLACE would do — it deletes rows violating ANY
+    // unique constraint, not just the primary key).
+    let conn = migrated();
+    save_message(&conn, &conversation("c1"), &chat_message("m1", "c1", 0)).unwrap();
+    let collision = chat_message("m2", "c1", 0);
+    assert!(save_message(&conn, &conversation("c1"), &collision).is_err());
+    let rows = run_query(&conn, "SELECT id FROM chat_messages", &[]).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["id"], Value::from("m1"));
+}
+
+#[test]
+fn chat_conversation_delete_cascades_to_messages() {
+    let conn = migrated();
+    save_message(&conn, &conversation("c1"), &chat_message("m1", "c1", 0)).unwrap();
+    save_message(&conn, &conversation("c2"), &chat_message("m2", "c2", 0)).unwrap();
+    delete_conversation(&conn, "c1").unwrap();
+
+    let conversations = run_query(&conn, "SELECT id FROM chat_conversations", &[]).unwrap();
+    assert_eq!(conversations.len(), 1);
+    assert_eq!(conversations[0]["id"], Value::from("c2"));
+    let messages = run_query(&conn, "SELECT id FROM chat_messages", &[]).unwrap();
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0]["id"], Value::from("m2"));
+}
+
+#[test]
+fn clear_index_preserves_chat_history() {
+    // Chat rows are durable, not a rebuildable projection — the full-rebuild
+    // wipe must leave them alone.
+    let conn = migrated();
+    apply_note(&conn, &note("notes/a.md", "A", vec![])).unwrap();
+    save_message(&conn, &conversation("c1"), &chat_message("m1", "c1", 0)).unwrap();
+    clear_index(&conn).unwrap();
+
+    let notes = run_query(&conn, "SELECT count(*) AS n FROM notes", &[]).unwrap();
+    assert_eq!(notes[0]["n"], Value::from(0));
+    let messages = run_query(&conn, "SELECT count(*) AS n FROM chat_messages", &[]).unwrap();
+    assert_eq!(messages[0]["n"], Value::from(1));
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -80,6 +80,8 @@ pub fn run() {
             db::note_move_indexed,
             db::index_meta_set,
             db::db_query,
+            db::chat_message_save,
+            db::chat_conversation_delete,
             db::embed_apply,
             db::embed_remove,
             embed::embed_status,

--- a/apps/desktop/src/components/chat/chat-history-menu.tsx
+++ b/apps/desktop/src/components/chat/chat-history-menu.tsx
@@ -1,0 +1,91 @@
+import type { ReactElement } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { formatDistanceToNow } from 'date-fns'
+import { hasBridge, listChatConversations } from '@reflect/core'
+import { Check, History, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { CHAT_QUERY_SCOPE } from '@/lib/query-client'
+import { useChatSession } from '@/providers/chat-provider'
+import { useGraph } from '@/providers/graph-provider'
+
+/**
+ * The conversation history: a dropdown over the persisted conversations,
+ * newest first — select one to load it, `×` to delete it. The active
+ * conversation is checked. Kept fresh by `invalidateChatQueries` after every
+ * save and delete, so the list updates while a new conversation streams.
+ */
+export function ChatHistoryMenu(): ReactElement | null {
+  const { graph, indexGeneration } = useGraph()
+  const { activeConversationId, openConversation, deleteConversation } = useChatSession()
+
+  const enabled = hasBridge() && indexGeneration !== null
+  const { data: conversations } = useQuery({
+    // The graph root is part of the key: conversations belong to one graph,
+    // and a graph switch must never serve the previous graph's cached list.
+    queryKey: [CHAT_QUERY_SCOPE, 'conversations', graph?.root],
+    queryFn: () => listChatConversations(),
+    enabled,
+  })
+
+  if (!enabled) {
+    return null
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon-sm" aria-label="Chat history">
+          <History aria-hidden />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent aria-label="Chat history" side="top" align="end" sideOffset={6}>
+        {conversations === undefined || conversations.length === 0 ? (
+          <DropdownMenuItem disabled className="px-2 py-1.5 text-[13px] text-text-muted">
+            No past chats
+          </DropdownMenuItem>
+        ) : (
+          conversations.map((conversation) => {
+            const current = conversation.id === activeConversationId
+            return (
+              <DropdownMenuItem
+                key={conversation.id}
+                onSelect={() => {
+                  if (!current) {
+                    void openConversation(conversation.id)
+                  }
+                }}
+                className="group/conversation w-64 gap-2 px-2 py-1.5 text-[13px] text-text-secondary"
+              >
+                <span className="min-w-0 flex-1 truncate">{conversation.title}</span>
+                <span className="shrink-0 text-xs text-text-muted">
+                  {formatDistanceToNow(conversation.updatedMs, { addSuffix: true })}
+                </span>
+                {current ? (
+                  <Check aria-hidden className="size-3.5 shrink-0 text-accent" />
+                ) : (
+                  <button
+                    type="button"
+                    aria-label={`Delete “${conversation.title}”`}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      void deleteConversation(conversation.id)
+                    }}
+                    className="invisible shrink-0 text-text-muted hover:text-text group-hover/conversation:visible"
+                  >
+                    <X aria-hidden className="size-3.5" />
+                  </button>
+                )}
+              </DropdownMenuItem>
+            )
+          })
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/desktop/src/components/chat/chat-input.tsx
+++ b/apps/desktop/src/components/chat/chat-input.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/select'
 import { imageFilesFrom } from '@/lib/chat-attachments'
 import { useChatSession } from '@/providers/chat-provider'
+import { ChatHistoryMenu } from './chat-history-menu'
 
 interface ModelOptionGroup {
   configId: string
@@ -58,8 +59,8 @@ function groupModelOptions(
  * full model list — and a send button that turns into stop while a turn
  * streams. Pasted images queue as attachments and preview above the
  * textarea — a message can be a photo alone, so Enter sends whenever there
- * is text *or* something attached. "New chat" appears once there's a
- * conversation to clear.
+ * is text *or* something attached. The history menu loads past
+ * conversations; "New chat" appears once there's a conversation to leave.
  */
 export function ChatInput(): ReactElement {
   const {
@@ -184,6 +185,7 @@ export function ChatInput(): ReactElement {
             </SelectContent>
           </Select>
           <div className="flex-1" />
+          <ChatHistoryMenu />
           {turns.length > 0 && !streaming ? (
             <Button variant="ghost" size="sm" onClick={newChat}>
               <Plus aria-hidden data-icon="inline-start" />

--- a/apps/desktop/src/components/chat/chat-screen.test.tsx
+++ b/apps/desktop/src/components/chat/chat-screen.test.tsx
@@ -1,4 +1,5 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactElement } from 'react'
@@ -48,6 +49,12 @@ vi.mock('@/providers/settings-provider', () => ({
     settings: { aiProviders: settingsState.models, defaultAiProviderId: settingsState.defaultId },
     updateSettings: () => {},
   }),
+}))
+
+// No open index → the provider's persistence layer stays inert; these tests
+// cover the screen, chat-provider.test.tsx covers persistence.
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({ indexGeneration: null, graph: null }),
 }))
 
 // jsdom can't host the ProseMirror contenteditable (same stub as the palette
@@ -119,13 +126,16 @@ function SendProbe(): ReactElement | null {
 
 function renderChat() {
   probedSend = null
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
-    <RouterProvider>
-      <ChatProvider graph={GRAPH}>
-        <ChatScreen />
-        <SendProbe />
-      </ChatProvider>
-    </RouterProvider>,
+    <QueryClientProvider client={client}>
+      <RouterProvider>
+        <ChatProvider graph={GRAPH}>
+          <ChatScreen />
+          <SendProbe />
+        </ChatProvider>
+      </RouterProvider>
+    </QueryClientProvider>,
   )
 }
 

--- a/apps/desktop/src/components/chat/chat-tool-chip.tsx
+++ b/apps/desktop/src/components/chat/chat-tool-chip.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, ReactNode } from 'react'
 import { CalendarDays, FileText, History, Search } from 'lucide-react'
-import { isToolPending, type AssistantPart } from '@/lib/chat-transcript'
+import { isToolPending, type AssistantPart } from '@reflect/core'
 import { routeForPath } from '@/routing/route'
 import { useRouter } from '@/routing/router'
 import { Spinner } from '@/components/ui/spinner'

--- a/apps/desktop/src/components/chat/chat-turn.tsx
+++ b/apps/desktop/src/components/chat/chat-turn.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react'
 import { MarkdownPreview } from '@/editor/markdown-preview'
 import { useWikiLinkNavigation } from '@/editor/use-wiki-link-navigation'
-import type { ChatTurn as ChatTurnModel } from '@/lib/chat-transcript'
+import type { ChatTurn as ChatTurnModel } from '@reflect/core'
 import { cn } from '@/lib/utils'
 import { ChatToolChip } from './chat-tool-chip'
 

--- a/apps/desktop/src/lib/chat-attachments.ts
+++ b/apps/desktop/src/lib/chat-attachments.ts
@@ -1,22 +1,16 @@
+import type { ChatAttachment } from '@reflect/core'
 import { base64Of } from '@/lib/base64'
 
 /**
  * Image attachments for the chat composer. A dropped or pasted photo is read
  * once into a {@link ChatAttachment} whose `data:` URL serves double duty —
  * it is the `<img src>` for the composer preview and the transcript bubble,
- * and the image payload the AI SDK sends to the provider.
+ * and the image payload the AI SDK sends to the provider. The type itself
+ * lives in `@reflect/core` (it is part of the persisted conversation model);
+ * this module owns only the browser side — reading `File`s into it.
  */
 
-/** One image the user attached to a chat turn. */
-export interface ChatAttachment {
-  id: string
-  /** Original filename — the preview's alt text and accessible labels. */
-  name: string
-  /** IANA media type, e.g. `image/png`. */
-  mediaType: string
-  /** The image bytes as a `data:` URL — rendered as-is and sent to the provider. */
-  dataUrl: string
-}
+export type { ChatAttachment } from '@reflect/core'
 
 /** The image files in a drop or paste payload; everything else is ignored. */
 export function imageFilesFrom(data: DataTransfer | null): File[] {

--- a/apps/desktop/src/lib/query-client.ts
+++ b/apps/desktop/src/lib/query-client.ts
@@ -27,3 +27,11 @@ export const INDEX_QUERY_SCOPE = 'index'
 export function invalidateIndexQueries(): void {
   void queryClient.invalidateQueries({ queryKey: [INDEX_QUERY_SCOPE] })
 }
+
+/** Chat-history queries nest under this key (e.g. `['chat', 'conversations', root]`). */
+export const CHAT_QUERY_SCOPE = 'chat'
+
+/** Refetch chat-history queries; called after a turn save or a delete. */
+export function invalidateChatQueries(): void {
+  void queryClient.invalidateQueries({ queryKey: [CHAT_QUERY_SCOPE] })
+}

--- a/apps/desktop/src/providers/chat-provider.test.tsx
+++ b/apps/desktop/src/providers/chat-provider.test.tsx
@@ -1,0 +1,233 @@
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactElement } from 'react'
+import type {
+  AiProviderConfig,
+  ChatConversation,
+  ChatStreamEvent,
+  ChatTurn,
+  GraphInfo,
+  StreamChatOptions,
+} from '@reflect/core'
+import { ChatProvider, useChatSession } from '@/providers/chat-provider'
+
+/**
+ * The provider's persistence lifecycle over a fully scripted store: resuming
+ * the latest conversation (and not resuming a stale one), the send/settle
+ * save pair, conversation switching, and the deleted-conversation guard.
+ * The engine (`streamChat`) and the store functions are mocks — the Rust
+ * round-trip is covered by the store and `db` tests.
+ */
+
+const core = vi.hoisted(() => ({
+  streamChat: vi.fn<(options: StreamChatOptions) => AsyncGenerator<ChatStreamEvent>>(),
+  getSecret: vi.fn<(name: string) => Promise<string | null>>(),
+  hasBridge: vi.fn<() => boolean>(),
+  loadChatGraphContext: vi.fn<(graphName: string) => Promise<null>>(),
+  listChatConversations: vi.fn<(limit?: number) => Promise<ChatConversation[]>>(),
+  loadChatMessages: vi.fn<(id: string) => Promise<ChatTurn[]>>(),
+  saveChatMessage: vi.fn<(input: unknown) => Promise<void>>(),
+  deleteChatConversation: vi.fn<(id: string, generation: number) => Promise<void>>(),
+}))
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  ...core,
+}))
+
+const settingsState = vi.hoisted(() => ({
+  models: [] as AiProviderConfig[],
+  defaultId: null as string | null,
+}))
+vi.mock('@/providers/settings-provider', () => ({
+  useSettings: () => ({
+    settings: { aiProviders: settingsState.models, defaultAiProviderId: settingsState.defaultId },
+    updateSettings: () => {},
+  }),
+}))
+
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({ indexGeneration: 7, graph: { root: '/g' } }),
+}))
+
+vi.mock('@/lib/provider-fetch', () => ({ providerFetch: vi.fn() }))
+
+const MODEL: AiProviderConfig = { id: 'm1', provider: 'openai', model: 'gpt-5.4', keyHint: '12345' }
+
+const RESTORED_TURN: ChatTurn = {
+  id: 'turn-old',
+  userText: 'what did I write yesterday?',
+  attachments: [],
+  parts: [{ kind: 'text', text: 'Three notes.' }],
+  responseMessages: [{ role: 'assistant', content: 'Three notes.' }],
+  status: 'done',
+}
+
+function conversation(overrides: Partial<ChatConversation> = {}): ChatConversation {
+  return { id: 'conv-1', title: 'what did I write yesterday?', createdMs: 1, updatedMs: Date.now(), ...overrides }
+}
+
+let session: ReturnType<typeof useChatSession> | null = null
+
+function Probe(): ReactElement | null {
+  session = useChatSession()
+  return null
+}
+
+const GRAPH: GraphInfo = { root: '/g', name: 'test-graph', cloudSync: null, generation: 1 }
+
+function renderProvider() {
+  session = null
+  return render(
+    <ChatProvider graph={GRAPH}>
+      <Probe />
+    </ChatProvider>,
+  )
+}
+
+function scriptTurn(events: ChatStreamEvent[]) {
+  core.streamChat.mockImplementation(function script() {
+    return (async function* () {
+      yield* events
+    })()
+  })
+}
+
+afterEach(cleanup)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  settingsState.models = [MODEL]
+  settingsState.defaultId = 'm1'
+  core.hasBridge.mockReturnValue(true)
+  core.getSecret.mockResolvedValue('sk-test')
+  core.loadChatGraphContext.mockResolvedValue(null)
+  core.listChatConversations.mockResolvedValue([])
+  core.loadChatMessages.mockResolvedValue([RESTORED_TURN])
+  core.saveChatMessage.mockResolvedValue(undefined)
+  core.deleteChatConversation.mockResolvedValue(undefined)
+})
+
+describe('ChatProvider persistence', () => {
+  it('resumes the latest conversation when it is fresh enough', async () => {
+    core.listChatConversations.mockResolvedValue([conversation()])
+    renderProvider()
+
+    await waitFor(() => expect(session?.turns).toEqual([RESTORED_TURN]))
+    expect(session?.activeConversationId).toBe('conv-1')
+    expect(core.loadChatMessages).toHaveBeenCalledWith('conv-1')
+  })
+
+  it('starts fresh when the latest conversation idled past the cutoff', async () => {
+    core.listChatConversations.mockResolvedValue([
+      conversation({ updatedMs: Date.now() - 7 * 60 * 60 * 1000 }),
+    ])
+    renderProvider()
+
+    await waitFor(() => expect(core.listChatConversations).toHaveBeenCalled())
+    expect(core.loadChatMessages).not.toHaveBeenCalled()
+    expect(session?.turns).toEqual([])
+    expect(session?.activeConversationId).not.toBe('conv-1')
+  })
+
+  it('saves the user half at send and the settled turn after the stream', async () => {
+    scriptTurn([
+      { type: 'text-delta', text: 'Hi.' },
+      { type: 'complete', messages: [{ role: 'assistant', content: 'Hi.' }] },
+    ])
+    renderProvider()
+    await waitFor(() => expect(core.listChatConversations).toHaveBeenCalled())
+
+    await act(() => session?.send('hello there'))
+
+    expect(core.saveChatMessage).toHaveBeenCalledTimes(2)
+    const first = core.saveChatMessage.mock.calls[0][0]
+    const second = core.saveChatMessage.mock.calls[1][0]
+    expect(first).toMatchObject({
+      seq: 0,
+      generation: 7,
+      conversation: { id: session?.activeConversationId, title: 'hello there' },
+      turn: { userText: 'hello there', responseMessages: [] },
+    })
+    expect(second).toMatchObject({
+      seq: 0,
+      turn: {
+        status: 'done',
+        responseMessages: [{ role: 'assistant', content: 'Hi.' }],
+        parts: [{ kind: 'text', text: 'Hi.' }],
+      },
+    })
+  })
+
+  it('numbers turns after restored history', async () => {
+    core.listChatConversations.mockResolvedValue([conversation()])
+    scriptTurn([{ type: 'complete', messages: [{ role: 'assistant', content: 'More.' }] }])
+    renderProvider()
+    await waitFor(() => expect(session?.turns).toHaveLength(1))
+
+    await act(() => session?.send('and today?'))
+
+    expect(core.saveChatMessage.mock.calls[0][0]).toMatchObject({
+      seq: 1,
+      conversation: { id: 'conv-1', title: 'what did I write yesterday?' },
+    })
+  })
+
+  it('opens a past conversation and switches the active id', async () => {
+    renderProvider()
+    await waitFor(() => expect(core.listChatConversations).toHaveBeenCalled())
+
+    await act(() => session?.openConversation('conv-9'))
+
+    expect(core.loadChatMessages).toHaveBeenCalledWith('conv-9')
+    expect(session?.activeConversationId).toBe('conv-9')
+    expect(session?.turns).toEqual([RESTORED_TURN])
+  })
+
+  it('deleting the active conversation starts a fresh chat', async () => {
+    core.listChatConversations.mockResolvedValue([conversation()])
+    renderProvider()
+    await waitFor(() => expect(session?.activeConversationId).toBe('conv-1'))
+
+    await act(() => session?.deleteConversation('conv-1'))
+
+    expect(core.deleteChatConversation).toHaveBeenCalledWith('conv-1', 7)
+    expect(session?.turns).toEqual([])
+    expect(session?.activeConversationId).not.toBe('conv-1')
+  })
+
+  it('never saves into a conversation deleted mid-stream', async () => {
+    let releaseStream: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      releaseStream = resolve
+    })
+    core.streamChat.mockImplementation(function script() {
+      return (async function* () {
+        yield { type: 'text-delta', text: 'Half…' } satisfies ChatStreamEvent
+        await gate
+        yield {
+          type: 'complete',
+          messages: [{ role: 'assistant', content: 'Done.' }],
+        } satisfies ChatStreamEvent
+      })()
+    })
+    renderProvider()
+    await waitFor(() => expect(core.listChatConversations).toHaveBeenCalled())
+
+    let sendDone: Promise<void> | undefined
+    await act(async () => {
+      sendDone = session?.send('hello')
+      await Promise.resolve()
+    })
+    const sentInto = core.saveChatMessage.mock.calls[0][0] as { conversation: { id: string } }
+
+    // Delete the conversation while the turn is streaming, then let it settle:
+    // the settle-time save must not resurrect the deleted row.
+    await act(() => session?.deleteConversation(sentInto.conversation.id))
+    releaseStream()
+    await act(async () => {
+      await sendDone
+    })
+
+    expect(core.saveChatMessage).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/providers/chat-provider.tsx
+++ b/apps/desktop/src/providers/chat-provider.tsx
@@ -11,34 +11,58 @@ import {
 } from 'react'
 import {
   aiKeySecretName,
+  appendEvent,
+  buildHistory,
   chatModelOptions,
+  deleteChatConversation,
   errorMessage,
   getSecret,
+  hasBridge,
+  listChatConversations,
   loadChatGraphContext,
+  loadChatMessages,
   resolveChatModel,
+  saveChatMessage,
   streamChat,
+  userMessage,
   type AiProviderConfig,
+  type ChatConversation,
   type ChatModelOption,
   type ChatModelSelection,
   type ChatStreamEvent,
+  type ChatTurn,
   type GraphInfo,
 } from '@reflect/core'
 import { toChatAttachment, type ChatAttachment } from '@/lib/chat-attachments'
-import { appendEvent, buildHistory, userMessage, type ChatTurn } from '@/lib/chat-transcript'
 import { todayIso } from '@/lib/dates'
 import { providerFetch } from '@/lib/provider-fetch'
+import { invalidateChatQueries } from '@/lib/query-client'
+import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
 
 /**
  * One chat session per open graph (Plan 10): the conversation lives here, not
- * in the screen, so navigating away and back keeps it. Session-only by
- * design — a relaunch (or graph switch, which remounts the workspace tree)
- * starts fresh. The state is just {@link ChatTurn}s: what each turn renders
- * and what it contributed to the model history are one record, and the
- * history a new turn resends is derived from them.
+ * in the screen, so navigating away and back keeps it. The state is just
+ * {@link ChatTurn}s — what each turn renders and what it contributed to the
+ * model history are one record, and the history a new turn resends is derived
+ * from them.
+ *
+ * Conversations persist to the graph's index DB (`@reflect/core`'s chat
+ * store): each turn is saved when sent (the user half) and again when it
+ * settles, so a relaunch restores the conversation exactly. On mount the
+ * latest conversation is resumed unless it has been idle past
+ * {@link CHAT_IDLE_CUTOFF_MS} — then a fresh one starts and the old one stays
+ * in the history. Persistence is best-effort: a failed save logs and the
+ * in-memory conversation carries on.
  */
 
 export type ChatStatus = 'idle' | 'streaming'
+
+/** Resume the latest conversation within this window; otherwise start fresh. */
+const CHAT_IDLE_CUTOFF_MS = 6 * 60 * 60 * 1000
+
+/** Conversation titles are the first message, cut for the history list. */
+const TITLE_MAX_CHARS = 60
 
 interface ChatContextValue {
   turns: ChatTurn[]
@@ -64,11 +88,26 @@ interface ChatContextValue {
   send: (text: string) => Promise<void>
   /** Abort the in-flight turn (partial text stays in the transcript). */
   stop: () => void
-  /** Drop the conversation and start over. */
+  /** Leave the conversation in the history and start a fresh one. */
   newChat: () => void
+  /** The persisted conversation the transcript belongs to. */
+  activeConversationId: string
+  /** Load a past conversation from the history. */
+  openConversation: (id: string) => Promise<void>
+  /** Delete a conversation; deleting the active one starts a fresh chat. */
+  deleteConversation: (id: string) => Promise<void>
 }
 
 const ChatContext = createContext<ChatContextValue | null>(null)
+
+/** `title` for a conversation row: its first message, cut to list length. */
+function conversationTitle(firstUserText: string): string {
+  const trimmed = firstUserText.trim().replace(/\s+/g, ' ')
+  if (trimmed === '') {
+    return 'New chat'
+  }
+  return trimmed.length > TITLE_MAX_CHARS ? `${trimmed.slice(0, TITLE_MAX_CHARS)}…` : trimmed
+}
 
 interface ChatProviderProps {
   /** The open graph — names the prompt's overview block. */
@@ -78,9 +117,11 @@ interface ChatProviderProps {
 
 export function ChatProvider({ graph, children }: ChatProviderProps): ReactElement {
   const { settings } = useSettings()
+  const { indexGeneration } = useGraph()
   const [turns, setTurns] = useState<ChatTurn[]>([])
   const [attachments, setAttachments] = useState<ChatAttachment[]>([])
   const [selection, setSelection] = useState<ChatModelSelection | null>(null)
+  const [conversationId, setConversationId] = useState<string>(() => crypto.randomUUID())
 
   const status: ChatStatus = turns.at(-1)?.status === 'streaming' ? 'streaming' : 'idle'
 
@@ -99,6 +140,10 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
   attachmentsRef.current = attachments
   const activeModelRef = useRef<AiProviderConfig | null>(activeModel)
   activeModelRef.current = activeModel
+  const conversationIdRef = useRef(conversationId)
+  conversationIdRef.current = conversationId
+  const generationRef = useRef<number | null>(indexGeneration)
+  generationRef.current = indexGeneration
 
   // The in-flight send, tracked synchronously — the no-concurrent-sends
   // guard can't ride on rendered state, which only reflects a send after
@@ -107,6 +152,10 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
   // "this conversation is busy" and never clears a successor's slot.
   const sessionRef = useRef(0)
   const activeSendRef = useRef<{ controller: AbortController; session: number } | null>(null)
+
+  // Conversations deleted this session: a settle-time save landing after its
+  // conversation was deleted would re-create the row via the upsert.
+  const deletedConversationsRef = useRef(new Set<string>())
 
   // The workspace tree is keyed by graph root, so switching graphs unmounts
   // this provider — an in-flight turn must die with it, or its tools would
@@ -118,98 +167,178 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
     }
   }, [])
 
-  const send = useCallback(async (text: string): Promise<void> => {
-    const trimmed = text.trim()
-    const attached = attachmentsRef.current
-    const config = activeModelRef.current
-    if (
-      (trimmed === '' && attached.length === 0) ||
-      config === null ||
-      activeSendRef.current?.session === sessionRef.current
-    ) {
+  /**
+   * Persist one turn into its conversation, best-effort: the generation it
+   * was issued under gates the write in Rust (a stale save no-ops), deleted
+   * conversations are never resurrected, and a failure logs without touching
+   * the in-memory conversation.
+   */
+  const persistTurn = useCallback(
+    (conversation: ChatConversation, turn: ChatTurn, seq: number, createdMs: number) => {
+      const generation = generationRef.current
+      if (
+        !hasBridge() ||
+        generation === null ||
+        deletedConversationsRef.current.has(conversation.id)
+      ) {
+        return
+      }
+      saveChatMessage({ conversation, turn, seq, createdMs, generation })
+        .then(invalidateChatQueries)
+        .catch((cause) => {
+          console.error('chat: saving the turn failed:', errorMessage(cause))
+        })
+    },
+    [],
+  )
+
+  // Resume the latest conversation on mount — unless it has been idle past
+  // the cutoff (then the next message starts a fresh one and the old chat
+  // stays in the history). Guarded against races: by the time the rows
+  // arrive the user may have started typing into the fresh conversation.
+  useEffect(() => {
+    if (!hasBridge() || indexGeneration === null) {
       return
     }
-    setAttachments([])
-
-    const turnId = crypto.randomUUID()
-    const messages = [...buildHistory(turnsRef.current), userMessage(trimmed, attached)]
-    const updateTurn = (updater: (turn: ChatTurn) => ChatTurn) => {
-      setTurns((current) =>
-        current.map((turn) => (turn.id === turnId ? updater(turn) : turn)),
-      )
+    const session = sessionRef.current
+    let active = true
+    void (async () => {
+      try {
+        const [latest] = await listChatConversations(1)
+        if (latest === undefined || Date.now() - latest.updatedMs > CHAT_IDLE_CUTOFF_MS) {
+          return
+        }
+        const restored = await loadChatMessages(latest.id)
+        if (!active || session !== sessionRef.current || turnsRef.current.length > 0) {
+          return
+        }
+        setConversationId(latest.id)
+        setTurns(restored)
+      } catch (cause) {
+        console.error('chat: restoring the last conversation failed:', errorMessage(cause))
+      }
+    })()
+    return () => {
+      active = false
     }
-    const applyEvent = (event: ChatStreamEvent) => {
-      updateTurn((turn) => ({ ...turn, parts: appendEvent(turn.parts, event) }))
-    }
+  }, [indexGeneration])
 
-    setTurns((current) => [
-      ...current,
-      {
+  const send = useCallback(
+    async (text: string): Promise<void> => {
+      const trimmed = text.trim()
+      const attached = attachmentsRef.current
+      const config = activeModelRef.current
+      if (
+        (trimmed === '' && attached.length === 0) ||
+        config === null ||
+        activeSendRef.current?.session === sessionRef.current
+      ) {
+        return
+      }
+      setAttachments([])
+
+      const turnId = crypto.randomUUID()
+      const messages = [...buildHistory(turnsRef.current), userMessage(trimmed, attached)]
+      // Everything the settle-time save needs, captured now: a turn detached
+      // by New chat (or a conversation switch) still persists into the
+      // conversation it was sent under.
+      const sendConversationId = conversationIdRef.current
+      const seq = turnsRef.current.length
+      const turnCreatedMs = Date.now()
+      const title = conversationTitle(turnsRef.current[0]?.userText ?? trimmed)
+      const conversationMeta = (): ChatConversation => ({
+        id: sendConversationId,
+        title,
+        createdMs: turnCreatedMs,
+        updatedMs: Date.now(),
+      })
+      // The turn is folded locally alongside the rendered state — the settle
+      // save must not depend on the turn still being mounted in `turns`.
+      let localTurn: ChatTurn = {
         id: turnId,
         userText: trimmed,
         attachments: attached,
         parts: [],
         responseMessages: [],
         status: 'streaming',
-      },
-    ])
-    const controller = new AbortController()
-    const activeSend = { controller, session: sessionRef.current }
-    activeSendRef.current = activeSend
+      }
 
-    try {
-      // The graph overview degrades to null (prompt without the block)
-      // rather than blocking the turn — a cold index shouldn't kill chat.
-      const [apiKey, context] = await Promise.all([
-        getSecret(aiKeySecretName(config.id)),
-        loadChatGraphContext(graph.name).catch((cause: unknown) => {
-          console.error('chat graph context failed:', errorMessage(cause))
-          return null
-        }),
-      ])
-      if (apiKey === null) {
-        applyEvent({
-          type: 'error',
-          message: 'No API key found for this provider — re-add it in Settings → AI providers.',
-          messages: [],
+      const updateTurn = (updater: (turn: ChatTurn) => ChatTurn) => {
+        localTurn = updater(localTurn)
+        setTurns((current) =>
+          current.map((turn) => (turn.id === turnId ? updater(turn) : turn)),
+        )
+      }
+      const applyEvent = (event: ChatStreamEvent) => {
+        updateTurn((turn) => ({ ...turn, parts: appendEvent(turn.parts, event) }))
+      }
+
+      setTurns((current) => [...current, localTurn])
+      // The user half lands immediately, so a crash mid-stream keeps the
+      // question (restored with an empty response, which the model history
+      // derivation already omits).
+      persistTurn(conversationMeta(), localTurn, seq, turnCreatedMs)
+
+      const controller = new AbortController()
+      const activeSend = { controller, session: sessionRef.current }
+      activeSendRef.current = activeSend
+
+      try {
+        // The graph overview degrades to null (prompt without the block)
+        // rather than blocking the turn — a cold index shouldn't kill chat.
+        const [apiKey, context] = await Promise.all([
+          getSecret(aiKeySecretName(config.id)),
+          loadChatGraphContext(graph.name).catch((cause: unknown) => {
+            console.error('chat graph context failed:', errorMessage(cause))
+            return null
+          }),
+        ])
+        if (apiKey === null) {
+          applyEvent({
+            type: 'error',
+            message: 'No API key found for this provider — re-add it in Settings → AI providers.',
+            messages: [],
+          })
+          return
+        }
+        const events = streamChat({
+          config,
+          apiKey,
+          fetchFn: providerFetch,
+          messages,
+          today: todayIso(),
+          context,
+          signal: controller.signal,
         })
-        return
-      }
-      const events = streamChat({
-        config,
-        apiKey,
-        fetchFn: providerFetch,
-        messages,
-        today: todayIso(),
-        context,
-        signal: controller.signal,
-      })
-      for await (const event of events) {
-        // Every terminal event carries the turn's messages — for a stopped or
-        // failed turn that's the completed steps plus partial text, so the
-        // derived history matches what stayed on screen.
-        if (event.type === 'complete' || event.type === 'aborted' || event.type === 'error') {
-          updateTurn((turn) => ({ ...turn, responseMessages: event.messages }))
+        for await (const event of events) {
+          // Every terminal event carries the turn's messages — for a stopped or
+          // failed turn that's the completed steps plus partial text, so the
+          // derived history matches what stayed on screen.
+          if (event.type === 'complete' || event.type === 'aborted' || event.type === 'error') {
+            updateTurn((turn) => ({ ...turn, responseMessages: event.messages }))
+          }
+          if (event.type !== 'complete') {
+            applyEvent(event)
+          }
         }
-        if (event.type !== 'complete') {
-          applyEvent(event)
+      } catch (cause) {
+        // streamChat normalizes its own failures; this guards the seams around
+        // it (keychain read, event application) so the UI never sticks.
+        applyEvent({ type: 'error', message: errorMessage(cause), messages: [] })
+      } finally {
+        updateTurn((turn) => ({ ...turn, status: 'done' }))
+        persistTurn(conversationMeta(), localTurn, seq, turnCreatedMs)
+        // Only release the slot if it's still ours: a turn detached by New
+        // chat must not, while winding down, unhook the controller a newer
+        // turn has since registered — Stop and the unmount abort always have
+        // to target the live stream.
+        if (activeSendRef.current === activeSend) {
+          activeSendRef.current = null
         }
       }
-    } catch (cause) {
-      // streamChat normalizes its own failures; this guards the seams around
-      // it (keychain read, event application) so the UI never sticks.
-      applyEvent({ type: 'error', message: errorMessage(cause), messages: [] })
-    } finally {
-      updateTurn((turn) => ({ ...turn, status: 'done' }))
-      // Only release the slot if it's still ours: a turn detached by New
-      // chat must not, while winding down, unhook the controller a newer
-      // turn has since registered — Stop and the unmount abort always have
-      // to target the live stream.
-      if (activeSendRef.current === activeSend) {
-        activeSendRef.current = null
-      }
-    }
-  }, [graph.name])
+    },
+    [graph.name, persistTurn],
+  )
 
   const stop = useCallback(() => {
     activeSendRef.current?.controller.abort()
@@ -220,7 +349,47 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
     sessionRef.current += 1
     setTurns([])
     setAttachments([])
+    setConversationId(crypto.randomUUID())
   }, [])
+
+  const openConversation = useCallback(async (id: string): Promise<void> => {
+    if (id === conversationIdRef.current) {
+      return
+    }
+    activeSendRef.current?.controller.abort()
+    sessionRef.current += 1
+    const session = sessionRef.current
+    setAttachments([])
+    try {
+      const restored = await loadChatMessages(id)
+      if (session !== sessionRef.current) {
+        return // superseded by another switch or New chat
+      }
+      setConversationId(id)
+      setTurns(restored)
+    } catch (cause) {
+      console.error('chat: opening the conversation failed:', errorMessage(cause))
+    }
+  }, [])
+
+  const deleteConversation = useCallback(
+    async (id: string): Promise<void> => {
+      deletedConversationsRef.current.add(id)
+      const generation = generationRef.current
+      if (hasBridge() && generation !== null) {
+        try {
+          await deleteChatConversation(id, generation)
+        } catch (cause) {
+          console.error('chat: deleting the conversation failed:', errorMessage(cause))
+        }
+        invalidateChatQueries()
+      }
+      if (id === conversationIdRef.current) {
+        newChat()
+      }
+    },
+    [newChat],
+  )
 
   const selectModel = useCallback((next: ChatModelSelection | null) => {
     setSelection(next)
@@ -255,6 +424,9 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
       send,
       stop,
       newChat,
+      activeConversationId: conversationId,
+      openConversation,
+      deleteConversation,
     }),
     [
       turns,
@@ -269,6 +441,9 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
       send,
       stop,
       newChat,
+      conversationId,
+      openConversation,
+      deleteConversation,
     ],
   )
   return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>

--- a/crates/index-schema/migrations/0008_chat.sql
+++ b/crates/index-schema/migrations/0008_chat.sql
@@ -1,0 +1,30 @@
+-- Chat history (Plan 10 follow-up): conversations and their turns, persisted
+-- so chats survive relaunches. UNLIKE every other table in this database,
+-- these rows are DURABLE — they are not derived from markdown and cannot be
+-- rebuilt. `index_clear` and future projection-wipe migrations must leave
+-- `chat_conversations` / `chat_messages` untouched.
+
+CREATE TABLE chat_conversations (
+  id TEXT PRIMARY KEY NOT NULL,
+  -- First user message, truncated; set once at creation.
+  title TEXT NOT NULL,
+  created_ms INTEGER NOT NULL,
+  updated_ms INTEGER NOT NULL
+);
+
+-- One row per exchange: the user message and everything the assistant did in
+-- response (matching the engine's settle granularity). The JSON columns are
+-- opaque here — the TS layer owns their shapes and validates on read.
+CREATE TABLE chat_messages (
+  id TEXT PRIMARY KEY NOT NULL,
+  conversation_id TEXT NOT NULL REFERENCES chat_conversations(id) ON DELETE CASCADE,
+  seq INTEGER NOT NULL,
+  user_text TEXT NOT NULL,
+  attachments TEXT NOT NULL,        -- JSON ChatAttachment[]
+  parts TEXT NOT NULL,              -- JSON AssistantPart[]
+  response_messages TEXT NOT NULL,  -- JSON ChatModelMessage[]
+  created_ms INTEGER NOT NULL
+);
+
+CREATE UNIQUE INDEX chat_messages_conversation_seq ON chat_messages(conversation_id, seq);
+CREATE INDEX chat_conversations_updated ON chat_conversations(updated_ms);

--- a/crates/index-schema/src/lib.rs
+++ b/crates/index-schema/src/lib.rs
@@ -9,6 +9,10 @@
 //! `rusqlite_migration` tracks the applied version in SQLite's `user_version`
 //! pragma. Append a new `M::up(include_str!(...))` (never edit a shipped one)
 //! as later plans add tables — and bump [`LATEST_SCHEMA_VERSION`] with it.
+//!
+//! Almost every table is a rebuildable projection of the markdown — except
+//! the `chat_*` tables (0008), which hold durable chat history. Wipe-style
+//! migrations (0004, 0006) and `index_clear` must never touch them.
 
 /// Directory inside a graph that holds the index (and marks a dir as a graph).
 pub const REFLECT_DIR: &str = ".reflect";
@@ -19,7 +23,7 @@ pub const INDEX_FILE: &str = "index.sqlite";
 /// `user_version` after every migration has run. Read-only consumers compare
 /// this against `PRAGMA user_version` to detect an index written by a newer
 /// (or older) app than they were built for.
-pub const LATEST_SCHEMA_VERSION: usize = 7;
+pub const LATEST_SCHEMA_VERSION: usize = 8;
 
 /// The `index_meta` key holding the TS-owned projection version (the rows'
 /// derivation version, distinct from the schema version above).
@@ -46,6 +50,7 @@ mod schema {
             M::up(include_str!("../migrations/0005_note_list_projection.sql")),
             M::up(include_str!("../migrations/0006_conflicts.sql")),
             M::up(include_str!("../migrations/0007_note_id_index.sql")),
+            M::up(include_str!("../migrations/0008_chat.sql")),
         ])
     });
 

--- a/packages/core/src/ai/chat/context-window.test.ts
+++ b/packages/core/src/ai/chat/context-window.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import type { ModelMessage } from 'ai'
+import { estimateTokens, fitToContextWindow } from './context-window'
+
+/**
+ * Budget math under test (empty system prompt): the usable budget is
+ * `(contextWindow − 60_000 turn reserve) × 0.8`, so a window of 61_000
+ * yields an 800-token budget — small enough to drive trimming with
+ * hand-sized messages (4 chars ≈ 1 token, +4 per message).
+ */
+function windowForBudget(budget: number): number {
+  return 60_000 + Math.ceil(budget / 0.8)
+}
+
+function turn(userChars: number, assistantChars: number): ModelMessage[] {
+  return [
+    { role: 'user', content: 'u'.repeat(userChars) },
+    { role: 'assistant', content: 'a'.repeat(assistantChars) },
+  ]
+}
+
+function toolExchange(callId: string, outputChars: number): ModelMessage[] {
+  return [
+    {
+      role: 'assistant',
+      content: [
+        { type: 'tool-call', toolCallId: callId, toolName: 'read_note', input: { path: 'notes/a.md' } },
+      ],
+    },
+    {
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: callId,
+          toolName: 'read_note',
+          output: { type: 'json', value: { content: 'n'.repeat(outputChars) } },
+        },
+      ],
+    },
+  ]
+}
+
+describe('estimateTokens', () => {
+  it('counts text by length and adds per-message overhead', () => {
+    expect(estimateTokens({ role: 'user', content: 'x'.repeat(400) })).toBe(104)
+  })
+
+  it('counts images flat — never by data-URL length', () => {
+    const photo: ModelMessage = {
+      role: 'user',
+      content: [
+        { type: 'image', image: `data:image/png;base64,${'a'.repeat(400_000)}`, mediaType: 'image/png' },
+      ],
+    }
+    expect(estimateTokens(photo)).toBe(1_604)
+  })
+
+  it('counts tool results by their JSON encoding', () => {
+    const [, result] = toolExchange('tool-1', 4_000)
+    const tokens = estimateTokens(result)
+    expect(tokens).toBeGreaterThan(1_000)
+    expect(tokens).toBeLessThan(1_100)
+  })
+})
+
+describe('fitToContextWindow', () => {
+  it('passes an under-budget history through untouched', () => {
+    const messages = [...turn(400, 400), ...turn(400, 400)]
+    expect(
+      fitToContextWindow(messages, { contextWindow: 1_000_000, systemPrompt: '' }),
+    ).toBe(messages)
+  })
+
+  it('drops the oldest turns whole, at user-message boundaries', () => {
+    const oldest = turn(2_000, 2_000)
+    const middle = turn(2_000, 2_000)
+    const newest = turn(2_000, 2_000)
+    // Each turn ≈ 1_008 tokens; budget fits two but not three.
+    const fitted = fitToContextWindow([...oldest, ...middle, ...newest], {
+      contextWindow: windowForBudget(2_200),
+      systemPrompt: '',
+    })
+    expect(fitted).toEqual([...middle, ...newest])
+  })
+
+  it('elides old tool results before dropping any turn', () => {
+    const oldest: ModelMessage[] = [
+      { role: 'user', content: 'find my note' },
+      ...toolExchange('tool-old', 8_000),
+      { role: 'assistant', content: 'Found it.' },
+    ]
+    const middle = turn(200, 200)
+    const newest: ModelMessage[] = [
+      { role: 'user', content: 'read it again' },
+      ...toolExchange('tool-new', 200),
+      { role: 'assistant', content: 'Here you go.' },
+    ]
+    // Raw ≈ 2_300 tokens (the old 8k-char tool dump); elided ≈ 450 — over
+    // an 800-token budget only the bulk needs to go, not any turn.
+    const fitted = fitToContextWindow([...oldest, ...middle, ...newest], {
+      contextWindow: windowForBudget(800),
+      systemPrompt: '',
+    })
+
+    const users = fitted.filter((message) => message.role === 'user')
+    expect(users).toHaveLength(3)
+
+    const toolMessages = fitted.filter((message) => message.role === 'tool')
+    expect(toolMessages).toHaveLength(2)
+    expect(toolMessages[0].content[0]).toMatchObject({
+      toolCallId: 'tool-old',
+      output: { type: 'text', value: '[Old tool result elided to fit the context window.]' },
+    })
+    // The newest turns keep their results verbatim — the model may still be
+    // working from them.
+    expect(toolMessages[1].content[0]).toMatchObject({
+      toolCallId: 'tool-new',
+      output: { type: 'json' },
+    })
+    // The pairing survives elision: the call part is still there.
+    const calls = fitted.filter(
+      (message) =>
+        message.role === 'assistant' &&
+        typeof message.content !== 'string' &&
+        message.content.some((part) => part.type === 'tool-call'),
+    )
+    expect(calls).toHaveLength(2)
+  })
+
+  it('keeps the newest turn even when it alone overruns the budget', () => {
+    const messages = turn(40_000, 40_000)
+    const fitted = fitToContextWindow(messages, {
+      contextWindow: windowForBudget(800),
+      systemPrompt: '',
+    })
+    expect(fitted).toEqual(messages)
+  })
+
+  it('counts the system prompt against the budget', () => {
+    const messages = [...turn(2_000, 2_000), ...turn(2_000, 2_000)]
+    const roomy = fitToContextWindow(messages, {
+      contextWindow: windowForBudget(2_200),
+      systemPrompt: '',
+    })
+    expect(roomy).toHaveLength(4)
+    // The same window with a fat system prompt no longer fits both turns.
+    const squeezed = fitToContextWindow(messages, {
+      contextWindow: windowForBudget(2_200),
+      systemPrompt: 's'.repeat(8_000),
+    })
+    expect(squeezed).toEqual(messages.slice(2))
+  })
+})

--- a/packages/core/src/ai/chat/context-window.ts
+++ b/packages/core/src/ai/chat/context-window.ts
@@ -1,0 +1,169 @@
+import type { ModelMessage } from 'ai'
+
+/**
+ * The moving context window: fit a conversation's model-facing history into
+ * a model's context budget before each turn. Two degradation stages, both
+ * deterministic and free (no summarization calls on the user's BYOK dime):
+ *
+ * 1. **Elide** old tool results — a single `read_note` result can be 24k
+ *    chars, so dropping whole turns first would evict real conversation to
+ *    keep note dumps the model has already digested.
+ * 2. **Drop** the oldest turns whole. Trimming happens only at turn
+ *    boundaries (a segment starts at each `user` message), so a tool call
+ *    can never be split from its result — providers reject dangling pairs.
+ *
+ * Token counts are estimates (~4 chars/token); every constant errs toward
+ * sending less, never toward blowing the window.
+ */
+
+/** Rough chars-per-token for prose and JSON; the headroom factor covers it. */
+const CHARS_PER_TOKEN = 4
+
+/**
+ * Flat per-image estimate. Providers downscale and bill far below the data
+ * URL's size, so estimating from `image.length` would wildly overshoot
+ * (a 1 MB photo is ~340k chars of base64 but ~1.6k tokens).
+ */
+const IMAGE_TOKENS = 1_600
+
+/** Per-message framing overhead (role markers etc.). */
+const MESSAGE_OVERHEAD_TOKENS = 4
+
+/**
+ * History budget ceiling even on 1M-token models: beyond this the marginal
+ * recall is not worth the per-turn BYOK cost (OpenAI bills long-context
+ * requests at 2×, and a 1M-token Claude turn costs whole dollars).
+ */
+const PRACTICAL_WINDOW_CEILING = 200_000
+
+/**
+ * Window share reserved for what the turn itself adds *after* trimming: up
+ * to `MAX_STEPS` (8) tool round-trips, each returning up to
+ * `MAX_NOTE_CONTENT_CHARS` (24k chars ≈ 6k tokens), plus the streamed
+ * reply. A reply-only reserve would trim to "fits" and still blow the
+ * window mid-turn.
+ */
+const TURN_RESERVE_TOKENS = 60_000
+
+/** Spend at most this share of the budget — absorbs estimation error. */
+const ESTIMATE_HEADROOM = 0.8
+
+/** The newest turns keep their tool results verbatim during elision. */
+const KEEP_INTACT_SEGMENTS = 2
+
+/** What an elided tool result is replaced with (the model still sees that a call happened). */
+const ELIDED_TOOL_RESULT = '[Old tool result elided to fit the context window.]'
+
+export interface ContextWindowOptions {
+  /** The model's context window in tokens (`modelContextWindow`). */
+  contextWindow: number
+  /** The system prompt the turn will send — counted against the window. */
+  systemPrompt: string
+}
+
+/** Every content-part shape any {@link ModelMessage} role can carry. */
+type ContentPart = Exclude<ModelMessage['content'], string>[number]
+
+/** Estimated token cost of one model message. */
+export function estimateTokens(message: ModelMessage): number {
+  const content: string | readonly ContentPart[] = message.content
+  if (typeof content === 'string') {
+    return MESSAGE_OVERHEAD_TOKENS + textTokens(content)
+  }
+  return content.reduce((total, part) => total + partTokens(part), MESSAGE_OVERHEAD_TOKENS)
+}
+
+function partTokens(part: ContentPart): number {
+  switch (part.type) {
+    case 'text':
+    case 'reasoning':
+      return textTokens(part.text)
+    case 'image':
+      return IMAGE_TOKENS
+    default:
+      // Tool calls, tool results, files: the JSON encoding is what travels.
+      return textTokens(JSON.stringify(part))
+  }
+}
+
+function textTokens(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN)
+}
+
+function totalTokens(messages: readonly ModelMessage[]): number {
+  return messages.reduce((total, message) => total + estimateTokens(message), 0)
+}
+
+/**
+ * Fit `messages` into the model's context budget. Under budget the history
+ * passes through untouched; over budget, old tool results are elided first,
+ * then the oldest turns dropped whole. The newest turn always survives —
+ * if even that alone overruns the budget, the provider's own limit is the
+ * backstop.
+ */
+export function fitToContextWindow(
+  messages: ModelMessage[],
+  options: ContextWindowOptions,
+): ModelMessage[] {
+  const window = Math.min(options.contextWindow, PRACTICAL_WINDOW_CEILING)
+  const budget = Math.floor(
+    (window - textTokens(options.systemPrompt) - TURN_RESERVE_TOKENS) * ESTIMATE_HEADROOM,
+  )
+  if (totalTokens(messages) <= budget) {
+    return messages
+  }
+
+  const segments = splitIntoTurnSegments(messages)
+  const elided = segments.map((segment, index) =>
+    index < segments.length - KEEP_INTACT_SEGMENTS ? segment.map(elideToolResults) : segment,
+  )
+
+  // Keep the longest newest-first run of whole segments that fits.
+  const kept: ModelMessage[][] = []
+  let used = 0
+  for (let index = elided.length - 1; index >= 0; index -= 1) {
+    const cost = totalTokens(elided[index])
+    if (kept.length > 0 && used + cost > budget) {
+      break
+    }
+    kept.unshift(elided[index])
+    used += cost
+  }
+  return kept.flat()
+}
+
+/**
+ * Group messages into turn segments: each starts at a `user` message and
+ * carries everything the assistant did in response (assistant messages, tool
+ * results). Trimming whole segments is what keeps tool pairs intact.
+ */
+function splitIntoTurnSegments(messages: ModelMessage[]): ModelMessage[][] {
+  const segments: ModelMessage[][] = []
+  for (const message of messages) {
+    const current = segments.at(-1)
+    if (message.role === 'user' || current === undefined) {
+      segments.push([message])
+    } else {
+      current.push(message)
+    }
+  }
+  return segments
+}
+
+/**
+ * Replace a tool message's result payloads with a short placeholder. The
+ * call/result pairing survives (providers require it); only the bulk goes.
+ */
+function elideToolResults(message: ModelMessage): ModelMessage {
+  if (message.role !== 'tool') {
+    return message
+  }
+  return {
+    ...message,
+    content: message.content.map((part) =>
+      part.type === 'tool-result'
+        ? { ...part, output: { type: 'text' as const, value: ELIDED_TOOL_RESULT } }
+        : part,
+    ),
+  }
+}

--- a/packages/core/src/ai/chat/store.test.ts
+++ b/packages/core/src/ai/chat/store.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setBridge } from '../../ipc/bridge'
+import { loadChatMessages, saveChatMessage } from './store'
+import type { ChatTurn } from './transcript'
+
+/**
+ * The store against a scripted bridge: writes assert the exact Rust command
+ * payload (the serde contract), reads assert the JSON columns parse back
+ * into the same {@link ChatTurn} — and that a corrupt row is dropped, not
+ * fatal.
+ */
+
+const invoke = vi.fn<(command: string, args: Record<string, unknown>) => Promise<unknown>>()
+
+beforeEach(() => {
+  invoke.mockReset()
+  setBridge({ invoke, listen: async () => () => {} })
+})
+
+afterEach(() => {
+  setBridge(null)
+  vi.restoreAllMocks()
+})
+
+const turn: ChatTurn = {
+  id: 'turn-1',
+  userText: 'what is this?',
+  attachments: [
+    { id: 'att-1', name: 'cat.png', mediaType: 'image/png', dataUrl: 'data:image/png;base64,iVBORw==' },
+  ],
+  parts: [
+    {
+      kind: 'tool',
+      call: { tool: 'search', toolCallId: 'tool-1', query: 'cat' },
+      result: { tool: 'search', toolCallId: 'tool-1', query: 'cat', hits: [{ path: 'notes/a.md', title: 'Cats' }] },
+      error: null,
+    },
+    { kind: 'text', text: 'A cat, per [[Cats]].' },
+    { kind: 'notice', tone: 'info', text: 'Stopped.' },
+  ],
+  responseMessages: [{ role: 'assistant', content: 'A cat, per [[Cats]].' }],
+  status: 'done',
+}
+
+const conversation = { id: 'conv-1', title: 'what is this?', createdMs: 1_000, updatedMs: 2_000 }
+
+describe('saveChatMessage', () => {
+  it('sends the conversation and the JSON-encoded message row', async () => {
+    invoke.mockResolvedValue(null)
+    await saveChatMessage({ conversation, turn, seq: 3, createdMs: 2_000, generation: 7 })
+
+    expect(invoke).toHaveBeenCalledWith('chat_message_save', {
+      conversation,
+      message: {
+        id: 'turn-1',
+        conversationId: 'conv-1',
+        seq: 3,
+        userText: 'what is this?',
+        attachments: JSON.stringify(turn.attachments),
+        parts: JSON.stringify(turn.parts),
+        responseMessages: JSON.stringify(turn.responseMessages),
+        createdMs: 2_000,
+      },
+      generation: 7,
+    })
+  })
+})
+
+describe('loadChatMessages', () => {
+  function messageRow(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+    return {
+      id: 'turn-1',
+      user_text: turn.userText,
+      attachments: JSON.stringify(turn.attachments),
+      parts: JSON.stringify(turn.parts),
+      response_messages: JSON.stringify(turn.responseMessages),
+      ...overrides,
+    }
+  }
+
+  it('round-trips a persisted turn, restored as done', async () => {
+    invoke.mockResolvedValue([messageRow()])
+    const turns = await loadChatMessages('conv-1')
+    expect(turns).toEqual([turn])
+    // The query went through the read-only bridge with the conversation bound.
+    const [command, args] = invoke.mock.calls[0]
+    expect(command).toBe('db_query')
+    expect(args).toMatchObject({ params: ['conv-1'] })
+  })
+
+  it('drops an unreadable row but keeps the rest', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    invoke.mockResolvedValue([
+      messageRow({ id: 'turn-bad', parts: '{not json' }),
+      messageRow(),
+    ])
+    const turns = await loadChatMessages('conv-1')
+    expect(turns).toEqual([turn])
+    expect(error).toHaveBeenCalledOnce()
+  })
+
+  it('drops a row whose parts fail validation', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    invoke.mockResolvedValue([
+      messageRow({ parts: JSON.stringify([{ kind: 'mystery' }]) }),
+    ])
+    expect(await loadChatMessages('conv-1')).toEqual([])
+  })
+})

--- a/packages/core/src/ai/chat/store.ts
+++ b/packages/core/src/ai/chat/store.ts
@@ -1,0 +1,212 @@
+import { z } from 'zod'
+import type { ModelMessage } from 'ai'
+import { db } from '../../indexing/db'
+import { call } from '../../ipc/invoke'
+import type { AssistantPart, ChatTurn } from './transcript'
+
+/**
+ * Chat history persistence (the durable `chat_*` tables in the graph's
+ * index database). One {@link ChatTurn} persists as one `chat_messages` row;
+ * its three JSON columns are validated here on read, so a corrupt row is
+ * dropped with a logged error instead of wedging the whole conversation
+ * (per-entry resilience, the same policy as the settings document).
+ *
+ * Writes go through generation-gated Rust commands like every other index
+ * mutation — a save issued for one graph can never land in another's
+ * history. Reads ride the ordinary read-only Kysely `db_query` bridge.
+ */
+
+/** Chat write commands return `()` from Rust, which serializes to `null`. */
+const voidSchema = z.null()
+
+/** One conversation's metadata row. */
+export interface ChatConversation {
+  id: string
+  /** First user message, truncated; fixed at creation. */
+  title: string
+  createdMs: number
+  updatedMs: number
+}
+
+const hitSummarySchema = z.object({ path: z.string(), title: z.string() })
+
+const toolCallSchema = z.discriminatedUnion('tool', [
+  z.object({ tool: z.literal('search'), toolCallId: z.string(), query: z.string() }),
+  z.object({ tool: z.literal('read'), toolCallId: z.string(), path: z.string() }),
+  z.object({ tool: z.literal('recents'), toolCallId: z.string(), tag: z.string().nullable() }),
+  z.object({
+    tool: z.literal('dailies'),
+    toolCallId: z.string(),
+    start: z.string(),
+    end: z.string(),
+  }),
+])
+
+const toolResultSchema = z.discriminatedUnion('tool', [
+  z.object({
+    tool: z.literal('search'),
+    toolCallId: z.string(),
+    query: z.string(),
+    hits: z.array(hitSummarySchema),
+  }),
+  z.object({
+    tool: z.literal('read'),
+    toolCallId: z.string(),
+    path: z.string(),
+    title: z.string().nullable(),
+    error: z.string().nullable(),
+  }),
+  z.object({
+    tool: z.literal('recents'),
+    toolCallId: z.string(),
+    tag: z.string().nullable(),
+    notes: z.array(hitSummarySchema),
+    error: z.string().nullable(),
+  }),
+  z.object({
+    tool: z.literal('dailies'),
+    toolCallId: z.string(),
+    start: z.string(),
+    end: z.string(),
+    days: z.array(hitSummarySchema),
+  }),
+])
+
+const partsSchema: z.ZodType<AssistantPart[]> = z.array(
+  z.discriminatedUnion('kind', [
+    z.object({ kind: z.literal('text'), text: z.string() }),
+    z.object({
+      kind: z.literal('tool'),
+      call: toolCallSchema,
+      result: toolResultSchema.nullable(),
+      error: z.string().nullable(),
+    }),
+    z.object({ kind: z.literal('notice'), tone: z.enum(['error', 'info']), text: z.string() }),
+  ]),
+)
+
+const attachmentsSchema = z.array(
+  z.object({
+    id: z.string(),
+    name: z.string(),
+    mediaType: z.string(),
+    dataUrl: z.string(),
+  }),
+)
+
+/**
+ * Persisted model messages are validated by envelope only — the AI SDK's
+ * content unions are wide and provider-shaped, and we stored exactly what the
+ * SDK produced, so re-encoding its full shape here would just chase the SDK's
+ * types. The cast back to {@link ModelMessage} is sound for rows this app
+ * wrote; gross corruption still fails the envelope and drops the row.
+ */
+const responseMessagesSchema = z.array(
+  z
+    .object({
+      role: z.enum(['system', 'user', 'assistant', 'tool']),
+      content: z.unknown(),
+    })
+    .passthrough(),
+)
+
+/** Save one turn (and upsert its conversation row) for `generation`. */
+export async function saveChatMessage(input: {
+  conversation: ChatConversation
+  turn: ChatTurn
+  /** The turn's position in its conversation (unique per conversation). */
+  seq: number
+  createdMs: number
+  generation: number
+}): Promise<void> {
+  await call(
+    'chat_message_save',
+    {
+      conversation: input.conversation,
+      message: {
+        id: input.turn.id,
+        conversationId: input.conversation.id,
+        seq: input.seq,
+        userText: input.turn.userText,
+        attachments: JSON.stringify(input.turn.attachments),
+        parts: JSON.stringify(input.turn.parts),
+        responseMessages: JSON.stringify(input.turn.responseMessages),
+        createdMs: input.createdMs,
+      },
+      generation: input.generation,
+    },
+    voidSchema,
+  )
+}
+
+/** Delete a conversation and its messages (for `generation`). */
+export async function deleteChatConversation(id: string, generation: number): Promise<void> {
+  await call('chat_conversation_delete', { id, generation }, voidSchema)
+}
+
+/** The most recently active conversations, newest first. */
+export async function listChatConversations(limit = 50): Promise<ChatConversation[]> {
+  return db
+    .selectFrom('chatConversations')
+    .select(['id', 'title', 'createdMs', 'updatedMs'])
+    .orderBy('updatedMs', 'desc')
+    .limit(limit)
+    .execute()
+}
+
+/**
+ * Load a conversation's turns in order. Restored turns are always `done` —
+ * a row whose stream never settled (crash mid-turn) comes back with empty
+ * `responseMessages`, which `buildHistory` already omits from the model view.
+ */
+export async function loadChatMessages(conversationId: string): Promise<ChatTurn[]> {
+  const rows = await db
+    .selectFrom('chatMessages')
+    .select(['id', 'userText', 'attachments', 'parts', 'responseMessages'])
+    .where('conversationId', '=', conversationId)
+    .orderBy('seq', 'asc')
+    .execute()
+  return rows.flatMap((row) => {
+    const turn = parseTurn(row)
+    if (turn === null) {
+      console.error(`dropping unreadable chat message ${row.id} in ${conversationId}`)
+      return []
+    }
+    return [turn]
+  })
+}
+
+interface StoredMessageRow {
+  id: string
+  userText: string
+  attachments: string
+  parts: string
+  responseMessages: string
+}
+
+function parseTurn(row: StoredMessageRow): ChatTurn | null {
+  const attachments = parseJson(row.attachments, attachmentsSchema)
+  const parts = parseJson(row.parts, partsSchema)
+  const responseMessages = parseJson(row.responseMessages, responseMessagesSchema)
+  if (attachments === null || parts === null || responseMessages === null) {
+    return null
+  }
+  return {
+    id: row.id,
+    userText: row.userText,
+    attachments,
+    parts,
+    // See responseMessagesSchema: envelope-validated, shape owned by the SDK.
+    responseMessages: responseMessages as ModelMessage[],
+    status: 'done',
+  }
+}
+
+function parseJson<TOutput>(raw: string, schema: z.ZodType<TOutput>): TOutput | null {
+  try {
+    const result = schema.safeParse(JSON.parse(raw))
+    return result.success ? result.data : null
+  } catch {
+    return null
+  }
+}

--- a/packages/core/src/ai/chat/stream-chat.ts
+++ b/packages/core/src/ai/chat/stream-chat.ts
@@ -3,8 +3,10 @@ import { createAnthropic } from '@ai-sdk/anthropic'
 import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import { createOpenAI } from '@ai-sdk/openai'
 import { errorMessage } from '../../errors'
+import { modelContextWindow } from '../provider-catalog'
 import type { AiProviderConfig } from '../../settings/schema'
 import type { CloudGraphContext, CloudSafe } from '../checkers'
+import { fitToContextWindow } from './context-window'
 import { chatSystemPrompt } from './system-prompt'
 import {
   buildNoteTools,
@@ -74,11 +76,22 @@ function languageModel(config: AiProviderConfig, apiKey: string, fetchFn: typeof
 
 /**
  * Run one chat turn against the user's configured provider, yielding
- * normalized {@link ChatStreamEvent}s. See {@link streamChatTurn} for the
- * stream's contract.
+ * normalized {@link ChatStreamEvent}s. The history is first fitted to the
+ * model's context budget ({@link fitToContextWindow}) — a long conversation
+ * trims its oldest turns here rather than erroring at the provider. See
+ * {@link streamChatTurn} for the stream's contract.
  */
 export function streamChat(options: StreamChatOptions): AsyncGenerator<ChatStreamEvent> {
-  return streamChatTurn(languageModel(options.config, options.apiKey, options.fetchFn), options)
+  const messages = fitToContextWindow(options.messages, {
+    contextWindow: modelContextWindow(options.config.provider, options.config.model),
+    systemPrompt: chatSystemPrompt({ today: options.today, context: options.context }),
+  })
+  return streamChatTurn(languageModel(options.config, options.apiKey, options.fetchFn), {
+    messages,
+    today: options.today,
+    context: options.context,
+    signal: options.signal,
+  })
 }
 
 /** {@link streamChatTurn}'s options: {@link StreamChatOptions} minus provider wiring. */

--- a/packages/core/src/ai/chat/transcript.test.ts
+++ b/packages/core/src/ai/chat/transcript.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import type { ChatStreamEvent } from '@reflect/core'
-import type { ChatAttachment } from './chat-attachments'
+import type { ChatStreamEvent } from './stream-chat'
 import {
   appendEvent,
   buildHistory,
   userMessage,
   type AssistantPart,
+  type ChatAttachment,
   type ChatTurn,
-} from './chat-transcript'
+} from './transcript'
 
 function fold(events: ChatStreamEvent[]): AssistantPart[] {
   return events.reduce<AssistantPart[]>(appendEvent, [])

--- a/packages/core/src/ai/chat/transcript.ts
+++ b/packages/core/src/ai/chat/transcript.ts
@@ -1,24 +1,32 @@
-import type {
-  ChatModelMessage,
-  ChatStreamEvent,
-  NoteToolCall,
-  NoteToolResult,
-} from '@reflect/core'
-import type { ChatAttachment } from '@/lib/chat-attachments'
+import type { ModelMessage } from 'ai'
+import type { ChatStreamEvent } from './stream-chat'
+import type { NoteToolCall, NoteToolResult } from './tools'
 
 /**
- * The chat view's conversation model (Plan 10). A {@link ChatTurn} is the
- * single source of truth for one exchange: the user's text and image
- * attachments, the assistant's renderable parts, and the model-facing
- * messages the turn contributed. The provider stores only turns — the
- * history a new turn resends is *derived* via {@link buildHistory}, so the
- * transcript and the model's view can never drift apart.
+ * The chat conversation model (Plan 10). A {@link ChatTurn} is the single
+ * source of truth for one exchange: the user's text and image attachments,
+ * the assistant's renderable parts, and the model-facing messages the turn
+ * contributed. Hosts store only turns — the history a new turn resends is
+ * *derived* via {@link buildHistory}, so the transcript and the model's view
+ * can never drift apart. The same record is what the store persists
+ * (`./store`), so a restored conversation renders and resends identically.
  *
  * Parts are built by folding the engine's {@link ChatStreamEvent}s with
  * {@link appendEvent} (pure, so the fold is unit-testable without
  * streaming). Tool parts are generic — only the chip that renders them
  * switches on which tool it was.
  */
+
+/** One image the user attached to a chat turn. */
+export interface ChatAttachment {
+  id: string
+  /** Original filename — the preview's alt text and accessible labels. */
+  name: string
+  /** IANA media type, e.g. `image/png`. */
+  mediaType: string
+  /** The image bytes as a `data:` URL — rendered as-is and sent to the provider. */
+  dataUrl: string
+}
 
 /** One renderable slice of an assistant message. */
 export type AssistantPart =
@@ -34,7 +42,7 @@ export interface ChatTurn {
   attachments: ChatAttachment[]
   parts: AssistantPart[]
   /** The model-facing messages this turn contributed once it settled. */
-  responseMessages: ChatModelMessage[]
+  responseMessages: ModelMessage[]
   status: 'streaming' | 'done'
 }
 
@@ -110,7 +118,7 @@ function settleTools(
 export function userMessage(
   text: string,
   attachments: readonly ChatAttachment[],
-): ChatModelMessage {
+): ModelMessage {
   if (attachments.length === 0) {
     return { role: 'user', content: text }
   }
@@ -138,10 +146,10 @@ export function userMessage(
  * enforce, and invite the model to answer a question the transcript shows
  * as failed.
  */
-export function buildHistory(turns: readonly ChatTurn[]): ChatModelMessage[] {
+export function buildHistory(turns: readonly ChatTurn[]): ModelMessage[] {
   return turns
     .filter((turn) => turn.responseMessages.length > 0)
-    .flatMap((turn): ChatModelMessage[] => [
+    .flatMap((turn): ModelMessage[] => [
       userMessage(turn.userText, turn.attachments),
       ...turn.responseMessages,
     ])

--- a/packages/core/src/ai/provider-catalog.test.ts
+++ b/packages/core/src/ai/provider-catalog.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { AI_PROVIDERS, DEFAULT_CONTEXT_WINDOW, modelContextWindow } from './provider-catalog'
+
+describe('modelContextWindow', () => {
+  it('every curated model declares a usable context window', () => {
+    for (const provider of AI_PROVIDERS) {
+      for (const model of provider.models) {
+        // The chat engine's budget math needs real headroom beyond the
+        // 60k-token turn reserve — a window this small would be a typo.
+        expect(model.contextWindow, `${provider.id}/${model.id}`).toBeGreaterThanOrEqual(100_000)
+      }
+    }
+  })
+
+  it('resolves a curated model and falls back for unknown ids', () => {
+    expect(modelContextWindow('anthropic', 'claude-haiku-4-5')).toBe(200_000)
+    // Settings may carry ids added by a newer app version.
+    expect(modelContextWindow('anthropic', 'claude-fable-6')).toBe(DEFAULT_CONTEXT_WINDOW)
+  })
+})

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -13,6 +13,13 @@ export interface AiModelOption {
   id: string
   /** Human-readable name shown in pickers. */
   label: string
+  /**
+   * The model's context window in tokens — a deliberate floor, not a spec
+   * sheet: the chat engine only needs a budget that never exceeds the real
+   * window (`ai/chat/context-window`), so undershooting is safe and exact
+   * vendor numbers don't matter.
+   */
+  contextWindow: number
 }
 
 /** One supported BYOK provider. */
@@ -32,10 +39,10 @@ export const AI_PROVIDERS: AiProviderInfo[] = [
     label: 'OpenAI',
     keyPlaceholder: 'sk-…',
     models: [
-      { id: 'gpt-5.5', label: 'GPT-5.5' },
-      { id: 'gpt-5.4', label: 'GPT-5.4' },
-      { id: 'gpt-5.4-mini', label: 'GPT-5.4 mini' },
-      { id: 'gpt-5.4-nano', label: 'GPT-5.4 nano' },
+      { id: 'gpt-5.5', label: 'GPT-5.5', contextWindow: 1_000_000 },
+      { id: 'gpt-5.4', label: 'GPT-5.4', contextWindow: 1_000_000 },
+      { id: 'gpt-5.4-mini', label: 'GPT-5.4 mini', contextWindow: 400_000 },
+      { id: 'gpt-5.4-nano', label: 'GPT-5.4 nano', contextWindow: 400_000 },
     ],
   },
   {
@@ -43,10 +50,10 @@ export const AI_PROVIDERS: AiProviderInfo[] = [
     label: 'Anthropic',
     keyPlaceholder: 'sk-ant-…',
     models: [
-      { id: 'claude-fable-5', label: 'Claude Fable 5' },
-      { id: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
-      { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
-      { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
+      { id: 'claude-fable-5', label: 'Claude Fable 5', contextWindow: 1_000_000 },
+      { id: 'claude-opus-4-8', label: 'Claude Opus 4.8', contextWindow: 1_000_000 },
+      { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6', contextWindow: 1_000_000 },
+      { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5', contextWindow: 200_000 },
     ],
   },
   {
@@ -54,10 +61,10 @@ export const AI_PROVIDERS: AiProviderInfo[] = [
     label: 'Google Gemini',
     keyPlaceholder: 'AIza…',
     models: [
-      { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro' },
-      { id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash' },
-      { id: 'gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash Lite' },
-      { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
+      { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro', contextWindow: 1_000_000 },
+      { id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash', contextWindow: 1_000_000 },
+      { id: 'gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash Lite', contextWindow: 1_000_000 },
+      { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', contextWindow: 1_000_000 },
     ],
   },
 ]
@@ -78,4 +85,20 @@ export function aiProvider(id: AiProviderId): AiProviderInfo {
 export function aiModelLabel(provider: AiProviderId, modelId: string): string {
   const match = aiProvider(provider).models.find((model) => model.id === modelId)
   return match?.label ?? modelId
+}
+
+/**
+ * Floor for models outside the curated list (a settings document may carry
+ * ids added by a newer version): small enough to be safe on any model worth
+ * configuring, large enough not to cripple the history.
+ */
+export const DEFAULT_CONTEXT_WINDOW = 128_000
+
+/**
+ * Context window (in tokens) for a model, falling back to
+ * {@link DEFAULT_CONTEXT_WINDOW} for ids outside the curated list.
+ */
+export function modelContextWindow(provider: AiProviderId, modelId: string): number {
+  const match = aiProvider(provider).models.find((model) => model.id === modelId)
+  return match?.contextWindow ?? DEFAULT_CONTEXT_WINDOW
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -122,6 +122,8 @@ export {
   AI_PROVIDERS,
   aiProvider,
   aiModelLabel,
+  DEFAULT_CONTEXT_WINDOW,
+  modelContextWindow,
   type AiProviderInfo,
   type AiModelOption,
 } from './ai/provider-catalog'
@@ -186,6 +188,27 @@ export {
   type ChatStreamEvent,
   type StreamChatOptions,
 } from './ai/chat/stream-chat'
+export {
+  appendEvent,
+  buildHistory,
+  isToolPending,
+  userMessage,
+  type AssistantPart,
+  type ChatAttachment,
+  type ChatTurn,
+} from './ai/chat/transcript'
+export {
+  deleteChatConversation,
+  listChatConversations,
+  loadChatMessages,
+  saveChatMessage,
+  type ChatConversation,
+} from './ai/chat/store'
+export {
+  estimateTokens,
+  fitToContextWindow,
+  type ContextWindowOptions,
+} from './ai/chat/context-window'
 export type { ModelMessage as ChatModelMessage } from 'ai'
 // The fixed per-provider model ids stay internal to `ai/transcribe` —
 // exporting them would let callers couple to vendor model names.

--- a/packages/db/src/schema.gen.ts
+++ b/packages/db/src/schema.gen.ts
@@ -30,6 +30,24 @@ export interface Backlinks {
   targetRaw: string | null;
 }
 
+export interface ChatConversations {
+  createdMs: number;
+  id: string;
+  title: string;
+  updatedMs: number;
+}
+
+export interface ChatMessages {
+  attachments: string;
+  conversationId: string;
+  createdMs: number;
+  id: string;
+  parts: string;
+  responseMessages: string;
+  seq: number;
+  userText: string;
+}
+
 export interface EmbeddingChunks {
   contentHash: string;
   heading: string | null;
@@ -98,6 +116,8 @@ export interface DB {
   aliases: Aliases;
   assets: Assets;
   backlinks: Backlinks;
+  chatConversations: ChatConversations;
+  chatMessages: ChatMessages;
   embeddingChunks: EmbeddingChunks;
   indexMeta: IndexMeta;
   links: Links;


### PR DESCRIPTION
## What

Chat history now survives relaunches, with a conversation model and a context-window budget so long chats can't blow the model's limit.

**Persistence** — new `0008_chat.sql` migration adds `chat_conversations` + `chat_messages` (one row per exchange) to the graph's index DB. These are the one **durable** exception to the rebuildable-projection rule: `index_clear` and future wipe migrations must leave `chat_*` alone (documented in AGENTS.md, the schema crate, and `db/mod.rs`; covered by a test). Writes go through two generation-gated Rust commands (`chat_message_save`, `chat_conversation_delete`); each turn saves twice — the user half at send, the full record at settle — so a crash mid-stream keeps the question. Upserts are `ON CONFLICT(id)`, deliberately not `INSERT OR REPLACE`, so a `(conversation, seq)` collision fails loudly instead of silently deleting another turn.

**Conversations** — the provider resumes the latest conversation on launch unless it idled past 6 hours (then a fresh one starts; the old one stays browsable). A history dropdown in the composer lists conversations (first-message titles + relative time) with load and delete. Deleting the active conversation mid-stream can't be resurrected by the settle-time save (deleted-ids guard).

**Moving context window** — the provider catalog now records per-model `contextWindow` floors (1M Fable 5/Opus 4.8/Sonnet 4.6/GPT-5.5/5.4/Gemini, 200K Haiku 4.5, 128K fallback for unknown ids). Before each turn `streamChat` fits the history: old turns' tool results elide to placeholders first (a single `read_note` dump is up to 24K chars), then the oldest turns drop whole at user-message boundaries so tool call/result pairs never split. The 60K-token reserve covers **mid-turn growth** (8 tool round-trips), not just the reply; a 200K practical ceiling keeps BYOK cost sane on 1M-token models.

**Refactor** — the conversation model (`ChatTurn`, `appendEvent`, `buildHistory`, `ChatAttachment`) moved from `apps/desktop/src/lib/chat-transcript.ts` into `packages/core/src/ai/chat/transcript.ts`, since the new store and windowing consume it (all TS business logic in core).

## Why

Chat was session-only — a relaunch lost everything — and `buildHistory()` resent the entire conversation every turn with no regard for context limits.

## Reviewer notes

- Rebased over #129/#130: `streamChat` threads the new graph-context option through trimming (the system-prompt estimate includes the overview block), and the persisted `recents` tool-result schema carries the corrective-refusal `error` field.
- The persisted JSON columns are zod-validated on read; a corrupt row is dropped with a logged error rather than wedging the conversation (same per-entry policy as the settings document).
- Model messages are envelope-validated only — their content unions are SDK-shaped and we store exactly what the SDK produced.
- Verified: `pnpm check`, 564 core + 631 desktop + 4 db vitest tests, 100 Rust tests, codegen diff committed. Not verified live end-to-end (no local AI keys); everything below the provider call is under test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces durable local chat data that index rebuilds must not wipe, plus generation-gated writes and mid-stream delete guards; mistakes could lose history or resurrect deleted threads, but behavior is heavily tested.
> 
> **Overview**
> **Chat history now persists** in the graph index via migration `0008` (`chat_conversations` / `chat_messages`). Those tables are documented as **durable**—`index_clear` and full projection wipes leave them alone. Rust adds generation-gated `chat_message_save` and `chat_conversation_delete`; each turn saves at send (user half) and again at settle. `@reflect/core` gains a zod-validated store plus list/load/delete APIs.
> 
> **Desktop UX** resumes the latest conversation on launch unless idle past 6 hours; **New chat** leaves the old thread in history. A composer **history dropdown** loads or deletes past chats, with query invalidation keyed by graph root.
> 
> **Long chats** are bounded before each provider call: the catalog records per-model `contextWindow`, and `streamChat` runs `fitToContextWindow`—elide old tool results first, then drop oldest turns at user-message boundaries, with a 60k-token mid-turn reserve.
> 
> The conversation model (`ChatTurn`, transcript helpers, `ChatAttachment`) moves from desktop into `@reflect/core` for the store and engine to share.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 871239135afd2b590f9d42c16ccea9926ce1d79c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->