### PR TITLE
Chat: close three persistence races found in review

### DIFF
--- a/apps/desktop/src-tauri/src/db/chat_write.rs
+++ b/apps/desktop/src-tauri/src/db/chat_write.rs
@@ -31,7 +31,6 @@ pub struct ChatConversation {
 pub struct ChatMessageRow {
     pub(super) id: String,
     pub(super) conversation_id: String,
-    pub(super) seq: i64,
     pub(super) user_text: String,
     pub(super) attachments: String,
     pub(super) parts: String,
@@ -42,9 +41,14 @@ pub struct ChatMessageRow {
 /// Upsert the conversation row and the message row. The conversation keeps its
 /// original `title`/`created_ms` (set once, on insert) and bumps `updated_ms`;
 /// the message updates by **primary key** — deliberately not `INSERT OR
-/// REPLACE`, which deletes any row violating *any* unique constraint, so a
-/// `(conversation_id, seq)` collision would silently destroy a different turn.
-/// With `ON CONFLICT(id)` such a collision fails loudly instead.
+/// REPLACE`, which deletes any row violating *any* unique constraint and would
+/// silently destroy another turn on a `(conversation_id, seq)` collision.
+///
+/// `seq` is assigned **here**, inside the insert (`MAX(seq) + 1` over the
+/// conversation), never by the caller: the frontend's view of a conversation
+/// can undercount the table (the read path drops rows it cannot parse), so a
+/// TS-derived counter could collide with a row it never saw. A settle-time
+/// re-save conflicts on `id` and leaves `seq` untouched.
 pub(super) fn save_message(
     conn: &Connection,
     conversation: &ChatConversation,
@@ -65,7 +69,10 @@ pub(super) fn save_message(
         "INSERT INTO chat_messages(
             id, conversation_id, seq, user_text, attachments, parts,
             response_messages, created_ms)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+         VALUES (
+            ?1, ?2,
+            (SELECT COALESCE(MAX(seq) + 1, 0) FROM chat_messages WHERE conversation_id = ?2),
+            ?3, ?4, ?5, ?6, ?7)
          ON CONFLICT(id) DO UPDATE SET
             user_text = excluded.user_text,
             attachments = excluded.attachments,
@@ -75,7 +82,6 @@ pub(super) fn save_message(
     .execute(params![
         message.id,
         message.conversation_id,
-        message.seq,
         message.user_text,
         message.attachments,
         message.parts,

--- a/apps/desktop/src-tauri/src/db/tests.rs
+++ b/apps/desktop/src-tauri/src/db/tests.rs
@@ -870,11 +870,10 @@ fn conversation(id: &str) -> ChatConversation {
     }
 }
 
-fn chat_message(id: &str, conversation_id: &str, seq: i64) -> ChatMessageRow {
+fn chat_message(id: &str, conversation_id: &str) -> ChatMessageRow {
     ChatMessageRow {
         id: id.to_string(),
         conversation_id: conversation_id.to_string(),
-        seq,
         user_text: "What did I write about Rust?".to_string(),
         attachments: "[]".to_string(),
         parts: "[]".to_string(),
@@ -886,7 +885,7 @@ fn chat_message(id: &str, conversation_id: &str, seq: i64) -> ChatMessageRow {
 #[test]
 fn chat_message_save_round_trips_and_upserts_the_conversation() {
     let conn = migrated();
-    save_message(&conn, &conversation("c1"), &chat_message("m1", "c1", 0)).unwrap();
+    save_message(&conn, &conversation("c1"), &chat_message("m1", "c1")).unwrap();
 
     let rows = run_query(
         &conn,
@@ -906,7 +905,7 @@ fn chat_message_save_round_trips_and_upserts_the_conversation() {
     later.title = "ignored".to_string();
     later.created_ms = 9_000;
     later.updated_ms = 9_000;
-    save_message(&conn, &later, &chat_message("m2", "c1", 1)).unwrap();
+    save_message(&conn, &later, &chat_message("m2", "c1")).unwrap();
     let rows = run_query(
         &conn,
         "SELECT title, created_ms, updated_ms FROM chat_conversations WHERE id = 'c1'",
@@ -925,8 +924,8 @@ fn chat_message_save_round_trips_and_upserts_the_conversation() {
 fn chat_message_resave_updates_by_id() {
     // The settle-time save re-sends the same row id with the streamed result.
     let conn = migrated();
-    save_message(&conn, &conversation("c1"), &chat_message("m1", "c1", 0)).unwrap();
-    let mut settled = chat_message("m1", "c1", 0);
+    save_message(&conn, &conversation("c1"), &chat_message("m1", "c1")).unwrap();
+    let mut settled = chat_message("m1", "c1");
     settled.parts = r#"[{"kind":"text","text":"You wrote three notes."}]"#.to_string();
     settled.response_messages =
         r#"[{"role":"assistant","content":"You wrote three notes."}]"#.to_string();
@@ -946,25 +945,48 @@ fn chat_message_resave_updates_by_id() {
 }
 
 #[test]
-fn chat_message_seq_collision_errors_instead_of_replacing() {
-    // A different id landing on an occupied (conversation, seq) means caller
-    // bookkeeping is broken; failing loudly beats silently destroying a turn
-    // (which INSERT OR REPLACE would do — it deletes rows violating ANY
-    // unique constraint, not just the primary key).
+fn chat_message_seq_is_assigned_per_conversation() {
+    // seq is computed inside the insert (MAX + 1 per conversation), never by
+    // the caller — the frontend's view can undercount the table (the read
+    // path drops rows it cannot parse), so a TS-derived counter could collide
+    // with a row it never saw. Counters are independent per conversation, a
+    // re-save keeps its slot, and the unique index stays on as a backstop.
     let conn = migrated();
-    save_message(&conn, &conversation("c1"), &chat_message("m1", "c1", 0)).unwrap();
-    let collision = chat_message("m2", "c1", 0);
-    assert!(save_message(&conn, &conversation("c1"), &collision).is_err());
-    let rows = run_query(&conn, "SELECT id FROM chat_messages", &[]).unwrap();
-    assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0]["id"], Value::from("m1"));
+    save_message(&conn, &conversation("c1"), &chat_message("m1", "c1")).unwrap();
+    save_message(&conn, &conversation("c1"), &chat_message("m2", "c1")).unwrap();
+    save_message(&conn, &conversation("c2"), &chat_message("m3", "c2")).unwrap();
+    save_message(&conn, &conversation("c1"), &chat_message("m2", "c1")).unwrap();
+
+    let rows = run_query(
+        &conn,
+        "SELECT id, seq FROM chat_messages ORDER BY conversation_id, seq",
+        &[],
+    )
+    .unwrap();
+    let slots: Vec<(String, i64)> = rows
+        .iter()
+        .map(|row| {
+            (
+                row["id"].as_str().unwrap().to_string(),
+                row["seq"].as_i64().unwrap(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        slots,
+        vec![
+            ("m1".to_string(), 0),
+            ("m2".to_string(), 1),
+            ("m3".to_string(), 0),
+        ]
+    );
 }
 
 #[test]
 fn chat_conversation_delete_cascades_to_messages() {
     let conn = migrated();
-    save_message(&conn, &conversation("c1"), &chat_message("m1", "c1", 0)).unwrap();
-    save_message(&conn, &conversation("c2"), &chat_message("m2", "c2", 0)).unwrap();
+    save_message(&conn, &conversation("c1"), &chat_message("m1", "c1")).unwrap();
+    save_message(&conn, &conversation("c2"), &chat_message("m2", "c2")).unwrap();
     delete_conversation(&conn, "c1").unwrap();
 
     let conversations = run_query(&conn, "SELECT id FROM chat_conversations", &[]).unwrap();
@@ -981,7 +1003,7 @@ fn clear_index_preserves_chat_history() {
     // wipe must leave them alone.
     let conn = migrated();
     apply_note(&conn, &note("notes/a.md", "A", vec![])).unwrap();
-    save_message(&conn, &conversation("c1"), &chat_message("m1", "c1", 0)).unwrap();
+    save_message(&conn, &conversation("c1"), &chat_message("m1", "c1")).unwrap();
     clear_index(&conn).unwrap();
 
     let notes = run_query(&conn, "SELECT count(*) AS n FROM notes", &[]).unwrap();

--- a/apps/desktop/src/providers/chat-provider.test.tsx
+++ b/apps/desktop/src/providers/chat-provider.test.tsx
@@ -181,6 +181,40 @@ describe('ChatProvider persistence', () => {
     expect(session?.turns).toEqual([RESTORED_TURN])
   })
 
+  it('abandons a switch when a send settled while the rows loaded', async () => {
+    // The send both starts AND finishes during the load — the in-flight slot
+    // is already clear when the rows arrive, but the switch must still be
+    // abandoned: swapping the transcript would hide the turn the user just
+    // streamed into the on-screen conversation.
+    let releaseLoad: (turns: ChatTurn[]) => void = () => {}
+    core.loadChatMessages.mockImplementation(
+      () =>
+        new Promise<ChatTurn[]>((resolve) => {
+          releaseLoad = resolve
+        }),
+    )
+    scriptTurn([{ type: 'complete', messages: [{ role: 'assistant', content: 'Hi.' }] }])
+    renderProvider()
+    await waitFor(() => expect(core.listChatConversations).toHaveBeenCalled())
+    const homeConversation = session?.activeConversationId
+
+    let openDone: Promise<void> | undefined
+    await act(async () => {
+      openDone = session?.openConversation('conv-9')
+      await Promise.resolve()
+    })
+    await act(() => session?.send('hello'))
+    expect(session?.turns.at(-1)?.status).toBe('done')
+
+    releaseLoad([RESTORED_TURN])
+    await act(async () => {
+      await openDone
+    })
+
+    expect(session?.activeConversationId).toBe(homeConversation)
+    expect(session?.turns.map((turn) => turn.userText)).toEqual(['hello'])
+  })
+
   it('deleting the active conversation starts a fresh chat', async () => {
     core.listChatConversations.mockResolvedValue([conversation()])
     renderProvider()

--- a/apps/desktop/src/providers/chat-provider.test.tsx
+++ b/apps/desktop/src/providers/chat-provider.test.tsx
@@ -143,13 +143,11 @@ describe('ChatProvider persistence', () => {
     const first = core.saveChatMessage.mock.calls[0][0]
     const second = core.saveChatMessage.mock.calls[1][0]
     expect(first).toMatchObject({
-      seq: 0,
       generation: 7,
       conversation: { id: session?.activeConversationId, title: 'hello there' },
       turn: { userText: 'hello there', responseMessages: [] },
     })
     expect(second).toMatchObject({
-      seq: 0,
       turn: {
         status: 'done',
         responseMessages: [{ role: 'assistant', content: 'Hi.' }],
@@ -158,7 +156,7 @@ describe('ChatProvider persistence', () => {
     })
   })
 
-  it('numbers turns after restored history', async () => {
+  it('saves later turns into the restored conversation', async () => {
     core.listChatConversations.mockResolvedValue([conversation()])
     scriptTurn([{ type: 'complete', messages: [{ role: 'assistant', content: 'More.' }] }])
     renderProvider()
@@ -167,8 +165,8 @@ describe('ChatProvider persistence', () => {
     await act(() => session?.send('and today?'))
 
     expect(core.saveChatMessage.mock.calls[0][0]).toMatchObject({
-      seq: 1,
       conversation: { id: 'conv-1', title: 'what did I write yesterday?' },
+      turn: { userText: 'and today?' },
     })
   })
 
@@ -229,5 +227,37 @@ describe('ChatProvider persistence', () => {
     })
 
     expect(core.saveChatMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('lets an in-flight save land before deleting its conversation', async () => {
+    // The delete and a dispatched save are independent IPC commands with no
+    // ordering guarantee — the provider must hold the delete until the
+    // conversation's save chain settles, or the upsert could resurrect it.
+    let releaseSave: () => void = () => {}
+    core.saveChatMessage.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseSave = resolve
+        }),
+    )
+    scriptTurn([{ type: 'complete', messages: [{ role: 'assistant', content: 'Hi.' }] }])
+    renderProvider()
+    await waitFor(() => expect(core.listChatConversations).toHaveBeenCalled())
+
+    await act(() => session?.send('hello'))
+    const sentInto = core.saveChatMessage.mock.calls[0][0] as { conversation: { id: string } }
+
+    let deleteDone: Promise<void> | undefined
+    await act(async () => {
+      deleteDone = session?.deleteConversation(sentInto.conversation.id)
+      await Promise.resolve()
+    })
+    expect(core.deleteChatConversation).not.toHaveBeenCalled()
+
+    releaseSave()
+    await act(async () => {
+      await deleteDone
+    })
+    expect(core.deleteChatConversation).toHaveBeenCalledWith(sentInto.conversation.id, 7)
   })
 })

--- a/apps/desktop/src/providers/chat-provider.tsx
+++ b/apps/desktop/src/providers/chat-provider.tsx
@@ -156,6 +156,10 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
   // Conversations deleted this session: a settle-time save landing after its
   // conversation was deleted would re-create the row via the upsert.
   const deletedConversationsRef = useRef(new Set<string>())
+  // The tail of each conversation's save chain. Saves are serialized per
+  // conversation so a delete can wait for in-flight saves to land first —
+  // two independent IPC commands carry no ordering guarantee in Rust.
+  const pendingSavesRef = useRef(new Map<string, Promise<void>>())
 
   // The workspace tree is keyed by graph root, so switching graphs unmounts
   // this provider — an in-flight turn must die with it, or its tools would
@@ -170,11 +174,12 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
   /**
    * Persist one turn into its conversation, best-effort: the generation it
    * was issued under gates the write in Rust (a stale save no-ops), deleted
-   * conversations are never resurrected, and a failure logs without touching
-   * the in-memory conversation.
+   * conversations are never resurrected — the guard runs again when the
+   * save's turn in the chain comes up, not just at enqueue time — and a
+   * failure logs without touching the in-memory conversation.
    */
   const persistTurn = useCallback(
-    (conversation: ChatConversation, turn: ChatTurn, seq: number, createdMs: number) => {
+    (conversation: ChatConversation, turn: ChatTurn, createdMs: number) => {
       const generation = generationRef.current
       if (
         !hasBridge() ||
@@ -183,11 +188,20 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
       ) {
         return
       }
-      saveChatMessage({ conversation, turn, seq, createdMs, generation })
-        .then(invalidateChatQueries)
+      const queue = pendingSavesRef.current
+      const chained = (queue.get(conversation.id) ?? Promise.resolve())
+        .then(() => {
+          if (deletedConversationsRef.current.has(conversation.id)) {
+            return
+          }
+          return saveChatMessage({ conversation, turn, createdMs, generation }).then(
+            invalidateChatQueries,
+          )
+        })
         .catch((cause) => {
           console.error('chat: saving the turn failed:', errorMessage(cause))
         })
+      queue.set(conversation.id, chained)
     },
     [],
   )
@@ -243,7 +257,6 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
       // by New chat (or a conversation switch) still persists into the
       // conversation it was sent under.
       const sendConversationId = conversationIdRef.current
-      const seq = turnsRef.current.length
       const turnCreatedMs = Date.now()
       const title = conversationTitle(turnsRef.current[0]?.userText ?? trimmed)
       const conversationMeta = (): ChatConversation => ({
@@ -277,7 +290,7 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
       // The user half lands immediately, so a crash mid-stream keeps the
       // question (restored with an empty response, which the model history
       // derivation already omits).
-      persistTurn(conversationMeta(), localTurn, seq, turnCreatedMs)
+      persistTurn(conversationMeta(), localTurn, turnCreatedMs)
 
       const controller = new AbortController()
       const activeSend = { controller, session: sessionRef.current }
@@ -327,7 +340,7 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
         applyEvent({ type: 'error', message: errorMessage(cause), messages: [] })
       } finally {
         updateTurn((turn) => ({ ...turn, status: 'done' }))
-        persistTurn(conversationMeta(), localTurn, seq, turnCreatedMs)
+        persistTurn(conversationMeta(), localTurn, turnCreatedMs)
         // Only release the slot if it's still ours: a turn detached by New
         // chat must not, while winding down, unhook the controller a newer
         // turn has since registered — Stop and the unmount abort always have
@@ -362,8 +375,11 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
     setAttachments([])
     try {
       const restored = await loadChatMessages(id)
-      if (session !== sessionRef.current) {
-        return // superseded by another switch or New chat
+      // Superseded by another switch or New chat — or by a send: a message
+      // composed while the rows loaded belongs to the conversation that was
+      // on screen, so the user's turn must not be swapped out from under it.
+      if (session !== sessionRef.current || activeSendRef.current?.session === session) {
+        return
       }
       setConversationId(id)
       setTurns(restored)
@@ -377,6 +393,11 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
       deletedConversationsRef.current.add(id)
       const generation = generationRef.current
       if (hasBridge() && generation !== null) {
+        // Let any in-flight save for this conversation land first — the
+        // delete and a dispatched save are independent commands, so issuing
+        // the delete now could be overtaken in Rust and the save's upsert
+        // would resurrect the row. (The chain never rejects.)
+        await pendingSavesRef.current.get(id)
         try {
           await deleteChatConversation(id, generation)
         } catch (cause) {

--- a/apps/desktop/src/providers/chat-provider.tsx
+++ b/apps/desktop/src/providers/chat-provider.tsx
@@ -152,6 +152,11 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
   // "this conversation is busy" and never clears a successor's slot.
   const sessionRef = useRef(0)
   const activeSendRef = useRef<{ controller: AbortController; session: number } | null>(null)
+  // The session of the most recent send — unlike `activeSendRef` this is not
+  // cleared when the turn settles, so a pending conversation switch can tell
+  // that the on-screen conversation received a message even after the stream
+  // finished.
+  const lastSendSessionRef = useRef(-1)
 
   // Conversations deleted this session: a settle-time save landing after its
   // conversation was deleted would re-create the row via the upsert.
@@ -295,6 +300,7 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
       const controller = new AbortController()
       const activeSend = { controller, session: sessionRef.current }
       activeSendRef.current = activeSend
+      lastSendSessionRef.current = activeSend.session
 
       try {
         // The graph overview degrades to null (prompt without the block)
@@ -378,7 +384,10 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
       // Superseded by another switch or New chat — or by a send: a message
       // composed while the rows loaded belongs to the conversation that was
       // on screen, so the user's turn must not be swapped out from under it.
-      if (session !== sessionRef.current || activeSendRef.current?.session === session) {
+      // Checked via the last send's session (not the in-flight slot, which
+      // is cleared on settle) — a turn that finished streaming before the
+      // rows arrived still anchors the switch to the conversation it's in.
+      if (session !== sessionRef.current || lastSendSessionRef.current === session) {
         return
       }
       setConversationId(id)

--- a/packages/core/src/ai/chat/store.test.ts
+++ b/packages/core/src/ai/chat/store.test.ts
@@ -47,14 +47,14 @@ const conversation = { id: 'conv-1', title: 'what is this?', createdMs: 1_000, u
 describe('saveChatMessage', () => {
   it('sends the conversation and the JSON-encoded message row', async () => {
     invoke.mockResolvedValue(null)
-    await saveChatMessage({ conversation, turn, seq: 3, createdMs: 2_000, generation: 7 })
+    await saveChatMessage({ conversation, turn, createdMs: 2_000, generation: 7 })
 
+    // No `seq` in the payload — Rust assigns it inside the insert.
     expect(invoke).toHaveBeenCalledWith('chat_message_save', {
       conversation,
       message: {
         id: 'turn-1',
         conversationId: 'conv-1',
-        seq: 3,
         userText: 'what is this?',
         attachments: JSON.stringify(turn.attachments),
         parts: JSON.stringify(turn.parts),

--- a/packages/core/src/ai/chat/store.ts
+++ b/packages/core/src/ai/chat/store.ts
@@ -110,12 +110,16 @@ const responseMessagesSchema = z.array(
     .passthrough(),
 )
 
-/** Save one turn (and upsert its conversation row) for `generation`. */
+/**
+ * Save one turn (and upsert its conversation row) for `generation`. The
+ * turn's position (`seq`) is assigned by Rust inside the insert — never
+ * here: this side's view of a conversation can undercount the table (see
+ * {@link loadChatMessages} dropping unreadable rows), so a counter derived
+ * from it could collide with a row it never saw.
+ */
 export async function saveChatMessage(input: {
   conversation: ChatConversation
   turn: ChatTurn
-  /** The turn's position in its conversation (unique per conversation). */
-  seq: number
   createdMs: number
   generation: number
 }): Promise<void> {
@@ -126,7 +130,6 @@ export async function saveChatMessage(input: {
       message: {
         id: input.turn.id,
         conversationId: input.conversation.id,
-        seq: input.seq,
         userText: input.turn.userText,
         attachments: JSON.stringify(input.turn.attachments),
         parts: JSON.stringify(input.turn.parts),


### PR DESCRIPTION
## What

Follow-up to #134, which was merged before its final commit landed — this cherry-picks the review fixes for the three races Bugbot found:

1. **Seq collision after dropped corrupt rows** — `seq` is now assigned by Rust inside the insert (`MAX(seq) + 1` per conversation, atomic in the save transaction) and removed from the TS payload entirely. The frontend's view of a conversation can undercount the table (the read path drops rows it can't parse), so a TS-derived counter could collide with a row it never saw and wedge persistence for that conversation. The unique index stays on as a backstop.
2. **Delete racing an in-flight save** — saves are serialized per conversation through a promise chain, the deleted-conversation guard re-runs when each save actually executes, and `deleteConversation` awaits the chain before issuing the Rust delete. Two independent IPC commands carry no ordering guarantee, so a dispatched save could otherwise overtake the delete and resurrect the row.
3. **Send during conversation load** — `openConversation` abandons the switch if a message was sent while the rows loaded; the send belongs to the conversation that was on screen, and swapping the transcript out from under it would orphan the user's turn.

## Reviewer notes

- Identical content to commit `3092826` on the original #134 branch (the squash merge captured the branch one commit early); the tree here matches that branch's final, fully-reviewed state byte-for-byte.
- Each fix has test coverage: Rust seq-assignment test, provider tests for the delete-ordering and deleted-mid-stream guards.
- Verified: `cargo fmt --check`, clippy, 98 Rust tests, `pnpm check`, full core + desktop vitest suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches durable chat persistence and ordering-sensitive UI races; changes are localized with tests but incorrect behavior could lose or resurrect conversation rows.
> 
> **Overview**
> Closes three chat persistence races from review follow-up to merged chat history work.
> 
> **Turn ordering (`seq`)** — Rust now assigns `seq` on insert with `MAX(seq) + 1` per conversation; `seq` is removed from the TS/Rust message payload and from client turn counting. Settle-time upserts still key on message `id`, so `seq` is unchanged on re-save. This avoids collisions when the UI undercounts rows because `loadChatMessages` drops corrupt entries.
> 
> **Delete vs save** — The desktop `ChatProvider` chains saves per conversation, re-checks the deleted-conversation guard when each chained save runs, and `deleteConversation` awaits that chain before calling Rust delete so an upsert cannot resurrect a row after delete.
> 
> **Switch vs send** — `openConversation` cancels applying loaded history if a send happened in the same session while messages were loading (tracked via `lastSendSessionRef`, including after the stream finishes), so the on-screen transcript is not replaced and the new turn is not orphaned.
> 
> Tests updated across Rust DB tests, core `saveChatMessage`, and provider scenarios for seq assignment, delete ordering, and abandoned switch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5134efad972cbe6106f8869ef87d601c4cb85e58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->