### PR TITLE
CI: macOS release workflow — build, sign, notarize, publish (Plan 15 step 9)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,125 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      draft:
+        description: Create the GitHub release as a draft for review
+        type: boolean
+        default: false
+  push:
+    tags: [v*]
+
+# Never run two releases at once, and never cancel one mid-notarization —
+# queue instead. A cancelled run can leave a half-published release behind.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+# `gh release create` pushes the v<version> tag and uploads the assets.
+permissions:
+  contents: write
+
+jobs:
+  macos:
+    name: Build · sign · notarize · publish (macOS)
+    runs-on: macos-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          # Unlike CI, credentials stay: the publish preflights run
+          # `git ls-remote` against origin. Full history so the
+          # HEAD-is-on-an-origin-branch check also passes on tag checkouts.
+          persist-credentials: true
+          fetch-depth: 0
+
+      # The release is tagged v<version> from tauri.conf.json regardless of
+      # the pushed tag, so a mismatch would publish under the wrong name.
+      - name: Verify the pushed tag matches tauri.conf.json
+        if: github.ref_type == 'tag'
+        run: |
+          version="$(jq -r .version apps/desktop/src-tauri/tauri.conf.json)"
+          if [ "$GITHUB_REF_NAME" != "v${version}" ]; then
+            echo "::error::pushed tag ${GITHUB_REF_NAME} but tauri.conf.json says ${version} — fix the tag, or bump the version (and src-tauri/Cargo.toml)"
+            exit 1
+          fi
+
+      # Without the certificate, signing only fails at codesign time — after
+      # the whole Rust build. Check every required secret up front instead.
+      # docs/macos-distribution.md describes how to produce each one.
+      - name: Verify release secrets are configured
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+        run: |
+          missing=()
+          for name in APPLE_SIGNING_IDENTITY APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD TAURI_SIGNING_PRIVATE_KEY; do
+            [ -n "${!name}" ] || missing+=("$name")
+          done
+          if { [ -z "$APPLE_API_KEY" ] || [ -z "$APPLE_API_ISSUER" ] || [ -z "$APPLE_API_KEY_CONTENT" ]; } &&
+            { [ -z "$APPLE_ID" ] || [ -z "$APPLE_PASSWORD" ]; }; then
+            missing+=("APPLE_API_KEY+APPLE_API_ISSUER+APPLE_API_KEY_CONTENT (or APPLE_ID+APPLE_PASSWORD)")
+          fi
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::missing release secret(s): ${missing[*]} — see docs/macos-distribution.md"
+            exit 1
+          fi
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+
+      - name: Install Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # A failed notarization still compiled everything; keep the cache.
+          cache-on-failure: true
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The release script takes APPLE_API_KEY_PATH (a .p8 file on disk), so
+      # materialize the key content outside the workspace.
+      - name: Stage the App Store Connect API key
+        env:
+          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
+        run: |
+          if [ -n "$APPLE_API_KEY_CONTENT" ]; then
+            printf '%s\n' "$APPLE_API_KEY_CONTENT" > "$RUNNER_TEMP/apple-api-key.p8"
+            echo "APPLE_API_KEY_PATH=$RUNNER_TEMP/apple-api-key.p8" >> "$GITHUB_ENV"
+          fi
+
+      # Tauri imports APPLE_CERTIFICATE into a temporary keychain, signs and
+      # notarizes the .app, and signs the updater archive; the script then
+      # notarizes + staples the DMG, runs the Gatekeeper checks, writes
+      # latest.json, and creates the GitHub release.
+      - name: Build, sign, notarize and publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: pnpm release:macos publish ${{ inputs.draft && '--draft' || '' }}

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -47,7 +47,8 @@ can still build unsigned bundles with plain `pnpm tauri build`.
 ## What `pnpm release:macos` does
 
 1. Auto-detects the Developer ID identity from the keychain and derives the team ID.
-2. Loads notarization credentials (keychain item, or environment variables — see CI below).
+2. Loads notarization credentials (keychain item, or environment variables — see
+   [Releasing from CI](#releasing-from-ci) below).
 3. Runs `pnpm tauri build`, which stages the `reflect` CLI sidecar, then signs inside-out
    (sidecar → main binary → `.app`) with hardened runtime, notarizes the `.app` via
    `notarytool`, staples the ticket, and builds + signs the DMG.
@@ -97,21 +98,45 @@ than after notarization:
 Pass `--draft` to create the release without publishing it, then review and publish it
 from the GitHub UI.
 
-## CI
+## Releasing from CI
 
-Everything the script auto-detects can be supplied via environment variables instead,
-which take precedence over the keychain:
+`.github/workflows/release.yml` runs `pnpm release:macos publish` on a GitHub-hosted
+macOS runner — the same pipeline as a local release, including DMG notarization, the
+Gatekeeper checks, and the updater artifacts. Trigger it from **Actions → Release →
+Run workflow** (tick *draft* to review the release before publishing), or by pushing
+the matching `v<version>` tag. The publish preflights apply unchanged, so bump
+`version` in `tauri.conf.json` (and `src-tauri/Cargo.toml`) on the released branch
+first.
 
-| Variable | Purpose |
+The script reads all signing material from environment variables, which take
+precedence over the keychain (exporting them works for local releases too); the
+workflow wires them from repository Actions secrets of the same names. Create these
+under **Settings → Secrets and variables → Actions**:
+
+| Secret | Value |
 | --- | --- |
-| `APPLE_SIGNING_IDENTITY` | Full identity string, e.g. `Developer ID Application: … (TEAMID)` |
-| `APPLE_ID` / `APPLE_PASSWORD` / `APPLE_TEAM_ID` | Apple ID notarization (app-specific password) |
-| `APPLE_API_KEY` / `APPLE_API_ISSUER` / `APPLE_API_KEY_PATH` | App Store Connect API key notarization (preferred for CI — not tied to a personal Apple ID) |
-| `APPLE_CERTIFICATE` / `APPLE_CERTIFICATE_PASSWORD` | base64 `.p12` + password; Tauri imports it into a temporary keychain on runners with no cert installed |
-| `TAURI_SIGNING_PRIVATE_KEY` (or `…_PATH`) / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | The updater signing key (content or path) + its password; overrides the `reflect-updater` keychain item |
+| `APPLE_SIGNING_IDENTITY` | Full identity string, e.g. `Developer ID Application: … (TEAMID)` — from `security find-identity -v -p codesigning` |
+| `APPLE_CERTIFICATE` | The Developer ID certificate + private key: export a `.p12` from Keychain Access, then `base64 -i certificate.p12`. Tauri imports it into a temporary keychain on the runner |
+| `APPLE_CERTIFICATE_PASSWORD` | The password set on that `.p12` export |
+| `APPLE_API_KEY` | App Store Connect API key ID, for notarization (preferred in CI — not tied to a personal Apple ID) |
+| `APPLE_API_ISSUER` | The API key's issuer UUID |
+| `APPLE_API_KEY_CONTENT` | The `.p8` key file's content; the workflow stages it on disk and sets `APPLE_API_KEY_PATH`, the variable the script reads |
+| `TAURI_SIGNING_PRIVATE_KEY` | The updater private key: `security find-generic-password -s reflect-updater -w \| base64 --decode` |
 
-See the [Tauri macOS signing docs](https://v2.tauri.app/distribute/sign/macos/) for the
-runner keychain setup.
+Notes:
+
+- Apple ID notarization works instead of the API key: set `APPLE_ID` +
+  `APPLE_PASSWORD` (an app-specific password), plus `APPLE_TEAM_ID` if the signing
+  identity doesn't end in `(TEAMID)`.
+- Leave `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` unset: the key has no password, GitHub
+  rejects empty-string secrets, and the workflow defaults it to empty. (Locally,
+  `TAURI_SIGNING_PRIVATE_KEY_PATH` also works in place of the key content.)
+- No PAT is needed — the release is created with the workflow's own `GITHUB_TOKEN`.
+
+The workflow verifies the secrets before building, so a misconfigured runner fails in
+seconds rather than after the build and notarization. See the
+[Tauri macOS signing docs](https://v2.tauri.app/distribute/sign/macos/) for background
+on the runner keychain setup.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

The release half of Plan 15 step 9: a GitHub Actions workflow that produces and publishes the signed macOS release.

- **`.github/workflows/release.yml`** — on `workflow_dispatch` (with a `draft` checkbox) or a `v*` tag push, a `macos-latest` job runs the existing `pnpm release:macos publish` pipeline: Tauri build with Developer ID signing (hardened runtime, inside-out incl. the CLI sidecar), `.app` **and** DMG notarization + stapling, updater artifacts (`Reflect.app.tar.gz` + `.sig`) and `latest.json`, full Gatekeeper verification, then `gh release create` with everything attached. Reusing the script keeps one release path instead of two (the plan's `tauri-apps/tauri-action` alternative does less — no DMG notarization, no Gatekeeper verify, no `latest.json`).
- **`docs/macos-distribution.md`** — the CI section now describes the workflow and lists the exact Actions secrets to create, including how to produce each value. No key material is committed.

## Workflow design

- Follows the ci.yml conventions: SHA-pinned actions (same pins), least-privilege permissions — here `contents: write`, which `gh release create` needs for the tag + assets.
- Deviates from ci.yml on checkout deliberately: `persist-credentials: true` (the publish preflights run `git ls-remote` against origin) and `fetch-depth: 0` (the HEAD-is-on-an-origin-branch preflight must also pass on detached tag checkouts).
- Fails fast, before the ~30-minute build: a secrets preflight (a missing certificate otherwise only surfaces at codesign time, after the full Rust compile) and, on tag pushes, a tag ↔ `tauri.conf.json` version match (the script tags `v<version>` from the config regardless of the pushed tag).
- `APPLE_API_KEY_CONTENT` (the `.p8` body) is staged to `$RUNNER_TEMP` and exposed as `APPLE_API_KEY_PATH`, the variable the script reads. Apple-ID notarization (`APPLE_ID`/`APPLE_PASSWORD`) works as the fallback path.
- `concurrency: release` with `cancel-in-progress: false` — releases queue rather than cancel mid-notarization.

## Secrets the repo admin must create

`APPLE_SIGNING_IDENTITY`, `APPLE_CERTIFICATE` (base64 `.p12`), `APPLE_CERTIFICATE_PASSWORD`, `APPLE_API_KEY`, `APPLE_API_ISSUER`, `APPLE_API_KEY_CONTENT`, `TAURI_SIGNING_PRIVATE_KEY` — production commands for each are in the docs. `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` stays unset (the key has no password; GitHub rejects empty secrets; the workflow defaults it to empty).

## Testing

- YAML parses; the embedded bash snippets were syntax-checked and functionally exercised under macOS `/bin/bash` 3.2 (empty secrets → fail with the full list; API-key set → pass; Apple-ID set → pass; tag match/mismatch both behave).
- `pnpm check` passes (pre-existing warnings only).
- Not exercised end-to-end: an actual CI release run needs the repo secrets in place. First real run is the verification — `--draft` recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release automation and many signing/notarization secrets; misconfiguration could fail releases or publish under the wrong version tag, but it reuses the existing local release script rather than a second pipeline.
> 
> **Overview**
> Adds **automated macOS releases in GitHub Actions** by introducing `.github/workflows/release.yml`, which runs the existing `pnpm release:macos publish` pipeline (sign, notarize, Gatekeeper checks, updater artifacts, `gh release create`).
> 
> Triggers are **manual** (`workflow_dispatch` with optional **draft**) or **tag push** (`v*`). The job uses queued concurrency (no cancel mid-notarization), `contents: write`, checkout with credentials and full history for publish preflights, and **fail-fast checks**: required Apple/Tauri secrets before build, and on tag pushes a match between the pushed tag and `tauri.conf.json` version. It stages `APPLE_API_KEY_CONTENT` to disk as `APPLE_API_KEY_PATH` for the release script.
> 
> **`docs/macos-distribution.md`** renames/expands the CI section into **Releasing from CI**: documents the workflow, trigger paths, and the exact Actions secrets (including how to produce each value) plus notes on Apple ID fallback and updater key password handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c498c57c326616114172f6acdc588d07b68bb46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->