### PR TITLE
Docs: align plans + product docs with first-release scope; add Plan 18 (tasks)

### DIFF
--- a/docs/plans/00-overview.md
+++ b/docs/plans/00-overview.md
@@ -4,6 +4,26 @@ This directory holds the numbered, dependency-ordered plans for building the **f
 version (first wave)** of Reflect V2: the open-source, local-first, markdown-native,
 AI-native rewrite described in the product docs.
 
+## Status at first release (2026-06-12)
+
+The first macOS release ships Plans 01–10, 12, 14–17 (Plan 16 at its V1 scope: SSH +
+path remotes; HTTPS credential helpers later). Two deliberate divergences:
+
+- **Plan 11 (link capture) is deferred — the first release ships without the browser
+  integration.** The design and [bridge spike](../spikes/link-capture-bridge.md) stand;
+  the capture envelope/inbox architecture is unbuilt, and no extension exists yet.
+- **Plan 13 (import/export) has not been built.** The graph is already a plain markdown
+  folder (copyable, inspectable — the core portability promise holds), but the in-app
+  import (Obsidian/markdown) and export (Markdown/JSON/HTML ZIP) surfaces are
+  outstanding.
+
+Two features landed beyond the written plans: **audio memos** (raw-first capture with
+async BYOK cloud transcription — listed below as deferred, but shipped early via
+`actions/audio-memo`), and **durable AI chat persistence** (the `chat_*` tables in
+`index.sqlite` are the one sanctioned non-rebuildable exception to the
+projection-only rule). The AI copilot (Plan 10) shipped **read-only** (chat over
+local context); patchsets/edits remain a later wave, per the plan's revision note.
+
 Read these alongside the source docs they implement:
 
 - [V2 Product Vision](../reflect-v2-product-vision.md)
@@ -44,13 +64,14 @@ before the editor, and the editor lands before search/AI.
 | 08 | [Lexical search & command palette](08-lexical-search-and-command-palette.md) | `⌘K` search/command surface, FTS over titles/body, filters, navigation commands |
 | 09 | [Semantic search & local embeddings](09-semantic-search-and-embeddings.md) | Local embedding runtime (Rust), chunking, `sqlite-vec`, incremental re-embed, retrieval layer |
 | 10 | [AI copilot sidebar](10-ai-copilot-sidebar.md) | BYOK provider, keychain secrets, context/retrieval, chat/summarize/rewrite, reviewable patchsets, `private: true` hard-block |
-| 11 | [Link capture](11-link-capture.md) | Chrome extension → native-messaging bridge → desktop write path, screenshots, BYOK enrichment, daily-note `[[Links]]` |
+| 11 | [Link capture](11-link-capture.md) | **Deferred — not in the first release.** Chrome extension → native-messaging bridge → desktop write path, screenshots, BYOK enrichment, daily-note `[[Links]]` |
 | 12 | [Backup & sync (GitHub-only)](12-backup-and-sync.md) | GitHub/Git backup + restore (the only supported remote), Git-native conflict surface, manual review, checkpoints; file-sync providers unsupported |
-| 13 | [Import / export / portability](13-import-export-portability.md) | Markdown/Obsidian-graph import, JSON/Markdown/HTML export, attachments preserved |
+| 13 | [Import / export / portability](13-import-export-portability.md) | **Not started — outstanding at release.** Markdown/Obsidian-graph import, JSON/Markdown/HTML export, attachments preserved |
 | 14 | [CLI (read/discovery)](14-cli-read-discovery.md) | `reflect today`, `reflect search`, `reflect show`, path lookup |
 | 15 | [Hardening, packaging & OSS release](15-hardening-packaging-release.md) | a11y, perf budgets, signing/notarization, MIT + docs, onboarding, release pipeline |
 | 16 | [Generic git remotes](16-generic-git-remotes.md) | Any git host (GitLab/Gitea/GHES/NAS) via hand-wired `origin`, zero new UI — V1 SSH (agent) + path remotes, V2 HTTPS (credential helpers) |
 | 17 | [Readable filenames](17-readable-filenames.md) | Title-derived note filenames (slug + collision suffix), frontmatter `id` adoption, rename-on-settled-title file moves, id-healed external renames |
+| 18 | [Tasks](18-tasks.md) | **Post-release add-on.** GFM-checkbox tasks as a rebuildable projection: interactive editor checkboxes, Tasks view (Overdue/Today/Upcoming), `[[date]]`/daily scheduling, guarded toggle write-back, `checklist: true` opt-out |
 
 ## Milestone map
 
@@ -70,6 +91,8 @@ demonstrable.
   search, then local semantic search.
 - **M3 — AI-native** (Plan 10): the right-sidebar copilot over local context.
 - **M4 — Capture & durability** (Plans 11–13): link capture, backup/sync, import/export.
+  *(Shipped partially: backup/sync landed; link capture was cut from the first release;
+  import/export is unbuilt. Audio-memo capture shipped instead, ahead of plan.)*
 - **M5 — Reach & release** (Plans 14–15): CLI, hardening, packaging, open-source launch.
 
 ## Dependency graph (abridged)
@@ -129,8 +152,10 @@ they are not re-litigated per phase:
 
 ## Explicitly deferred (NOT first wave)
 
-Do not build these now; keep the door open in the data model. Tasks, audio
-transcription, full browser clipper / article extraction, graph-map view, templates,
+Do not build these now; keep the door open in the data model. Tasks (now planned as a
+post-release add-on — [Plan 18](18-tasks.md)), link capture
+(Plan 11 — designed, deferred from the first release), full browser clipper / article
+extraction, graph-map view, templates,
 contacts/calendar, publishing, any non-GitHub sync (iCloud/Dropbox/Drive are unsupported
 by design, not "deferred"), a public plugin API, typed-entity layer, and full multi-device
 sync conflict automation (incl. AI-assisted resolution). Mobile

--- a/docs/plans/05-markdown-editor.md
+++ b/docs/plans/05-markdown-editor.md
@@ -86,13 +86,15 @@ they are Reflect's organizing primitive.
   navigation.
 - **05b** — step 7 (images/assets, incl. a Rust binary asset-write command), heading
   toggles from step 9, a **round-trip safety guard** (see below), and the step 10
-  basics. **Task checkboxes (step 8) are blocked upstream:** meowdown's converter
-  currently *loses task-item text entirely* (`- [ ] todo` → empty list) — discovered
-  while building 05b. Until the first-party converter fix ships, any note the editor
-  can't faithfully round-trip opens **protected (read-only)** and is never
-  auto-rewritten, so a converter gap can degrade UX but can never destroy content.
-  Remaining for later: interactive checkboxes (after the upstream fix), ergonomics
-  (indent/outdent, move line, zen), the tight-list serializer fix (also upstream),
+  basics. **Task checkboxes (step 8) were blocked upstream** — meowdown's converter
+  *lost task-item text entirely* (`- [ ] todo` → empty list), discovered while
+  building 05b. **The blocker is cleared:** meowdown 0.3.0 round-trips task lists
+  byte-faithfully (verified 2026-06-12) and models them as `list` nodes with
+  `kind: "task"` + `checked`. Interactive checkboxes now land with
+  [Plan 18 (Tasks)](18-tasks.md) step 1. The round-trip safety guard stays regardless:
+  any note the editor can't faithfully round-trip opens **protected (read-only)** and
+  is never auto-rewritten, so a converter gap can degrade UX but can never destroy
+  content. Remaining for later: ergonomics (indent/outdent, move line, zen),
   and deeper perf/a11y.
 
 ## Steps
@@ -141,8 +143,8 @@ they are Reflect's organizing primitive.
    markdown link → render inline. Large-file guardrail hook for Plan 12.
 
 8. **Task checkboxes.** Add an interactive checkbox node mapped to `- [ ]`/`- [x]` (Lezer
-   emits `Task`/`TaskMarker`) that toggles the underlying markdown. (Tasks-as-a-feature
-   stay deferred; this is just faithful editor rendering.)
+   emits `Task`/`TaskMarker`) that toggles the underlying markdown. (This step now
+   ships as [Plan 18 (Tasks)](18-tasks.md) step 1, where tasks-as-a-feature land too.)
 
 9. **Keyboard ergonomics (product identity).** meowdown ships base keymap/commands/
    history. Layer Reflect shortcuts (bold/italic, toggle heading, toggle checkbox, indent/

--- a/docs/plans/11-link-capture.md
+++ b/docs/plans/11-link-capture.md
@@ -1,5 +1,13 @@
 # Plan 11 — Link Capture
 
+> **Status (2026-06-12): Deferred — the first macOS release ships without link
+> capture.** Nothing below has been built (no `apps/extension`, no native-messaging
+> host, no capture inbox). The design and the
+> [bridge spike](../spikes/link-capture-bridge.md) remain the blueprint for when
+> capture is picked up post-launch; the shipped audio-memo pipeline
+> (`packages/core/src/actions/audio-memo.ts`) already follows the same raw-first
+> capture/async-enrichment shape and is the template to sit alongside.
+
 **Goal:** Launch-grade web capture: a Chrome extension hands URL/title/selection/
 screenshot to the **installed desktop app** through a local **capture inbox**; the
 desktop app owns all writes, BYOK AI enrichment, and privacy — appending to today's

--- a/docs/plans/13-import-export-portability.md
+++ b/docs/plans/13-import-export-portability.md
@@ -1,5 +1,11 @@
 # Plan 13 — Import / Export / Portability
 
+> **Status (2026-06-12): Not started — outstanding at the first release.** The graph is
+> already a plain markdown folder (the core "open your folder and it's just files"
+> promise holds, and Obsidian-style vaults are close enough to open directly in many
+> cases), but none of the in-app surfaces below — previewed import, Markdown/JSON/HTML
+> ZIP export — exist yet.
+
 **Goal:** Make data ownership tangible from day one: import existing markdown/Obsidian
 graphs, and export the graph to Markdown, JSON, and HTML with backlinks, tags, and
 daily dates preserved.

--- a/docs/plans/15-hardening-packaging-release.md
+++ b/docs/plans/15-hardening-packaging-release.md
@@ -13,7 +13,8 @@ docs, and a release pipeline. This is **M5.**
 performance budgets, error/repair UX, privacy review, signing/notarization, MIT licensing
 + public docs, CI, and **auto-update** (Tauri updater plugin).
 **Out:** mobile release (planned, separate track), Windows/Android (later), publishing/
-tasks/audio (deferred features).
+tasks (deferred features), link capture (Plan 11 — deferred from the first release).
+Audio memos shipped ahead of plan and are **in** scope for the privacy review.
 
 ## Steps
 
@@ -35,13 +36,13 @@ tasks/audio (deferred features).
    (must beat Electron — a stated V2 goal). Add perf smoke tests; fix regressions.
 
 5. **Error, repair & recovery UX.** Surface index repair (Plan 04), backup failures (Plan
-   12), provider/key errors (Plan 10), and capture failures (Plan 11) in plain language
+   12), and provider/key errors (Plan 10) in plain language
    with a clear next action. Verify the recovery story end-to-end: delete `.reflect/` →
    rebuild loses nothing; raw conflict versions recoverable.
 
 6. **Privacy review (release gate).** End-to-end audit that `private: true` is enforced at
-   every external call site — copilot (Plan 10), retrieval (Plan 09), capture (Plan 11),
-   conflict resolution (Plan 12). Confirm secrets are keychain-only (never markdown/Git/
+   every external call site — copilot (Plan 10), retrieval (Plan 09), audio transcription,
+   conflict resolution (Plan 12). (Capture, Plan 11, joins this list when it ships.) Confirm secrets are keychain-only (never markdown/Git/
    `.reflect/`) and that no Reflect-hosted API exists in the core path. Document exactly
    what leaves the device and when.
 
@@ -50,9 +51,10 @@ tasks/audio (deferred features).
    with the hardened runtime** — notably the ONNX/embedding runtime (Plan 9) and any
    sqlite-vec/native-messaging-host binaries — for both arm64 and x64; an unsigned nested
    binary fails notarization. Bundle the `reflect` CLI (Plan 14); consider a Homebrew cask.
-   Decide the native-messaging host registration on install (Plan 11). Confirm **first
+   Confirm **first
    release is notarized non-sandboxed** (security-scoped bookmarks, Plan 02, only needed if
-   we later sandbox for the App Store). **Two distinct keys:** Apple Developer ID (Gatekeeper/
+   we later sandbox for the App Store). Native-messaging host registration is moot for the
+   first release (link capture, Plan 11, is deferred). **Two distinct keys:** Apple Developer ID (Gatekeeper/
    notarization) *and* the Tauri **updater signing key** (minisign, verifies update payloads
    — step 10); both private keys live in CI secrets, never in the repo.
 
@@ -96,8 +98,9 @@ tasks/audio (deferred features).
 A user can: install the Mac app; open today's markdown daily note instantly; write in a
 beautiful markdown editor without thinking about files; create `[[Wiki Links]]` naturally;
 search locally; ask the AI sidebar about the current and related notes with their own key;
-save the current browser page into today's note with screenshot-backed BYOK enrichment;
 back up their notes for free; and open their note folder to find portable markdown files.
+(Browser-page capture drops out of this checklist while link capture, Plan 11, is
+deferred; it rejoins when capture ships.)
 
 ## Acceptance criteria
 

--- a/docs/plans/18-tasks.md
+++ b/docs/plans/18-tasks.md
@@ -1,0 +1,195 @@
+# Plan 18 — Tasks (post-release add-on)
+
+**Goal:** Port V1's third center of gravity — tasks embedded in notes, collected into
+one view — as a **lightweight markdown-backed projection**, per the decision docs
+(grounding brief §9.7 Option A: aggregate, schedule, complete; never a task manager).
+A task is a plain GFM checkbox in a note; the Tasks view is a projection over them,
+exactly like backlinks are a projection over `[[links]]`.
+
+**Status:** Add-on — not part of the first macOS release. Build after launch.
+
+**Depends on:** Plan 03 (parser/extraction), Plan 04 (index + watcher), Plan 05
+(editor; step 8's upstream blocker is now **cleared** — see below), Plan 06 (daily
+dates), Plan 08 (commands/palette), Plan 17 (path-keyed projections survive moves).
+**Unlocks:** the V1 daily-capture → task-recall loop; future AI task extraction
+(grounding brief §9.6) over a real projection.
+
+## What changed since tasks were deferred
+
+Tasks were deferred partly because meowdown's converter **lost task-item text**
+(`- [ ] todo` → empty list; Plan 05 step 8). That fix shipped: **meowdown 0.3.0
+round-trips task lists byte-faithfully** (verified 2026-06-12 — `- [ ] buy milk\n- [x]
+call mum\n` round-trips unchanged, including wiki links and tags inside the item), and
+its ProseMirror schema already models tasks first-class: a `list` node with
+`kind: "task"` and a `checked` attr. Task notes no longer open protected. What's
+missing is purely Reflect-side: interactivity, extraction, projection, and the view.
+
+## Scope
+
+**In:** interactive editor checkboxes (click + keyboard); task extraction into a
+rebuildable `tasks` projection; a Tasks route/view grouping open tasks across the
+graph (Overdue / Today / Upcoming / Unscheduled, collapsed Completed); toggle-complete
+from the view with a guarded surgical write-back; date scheduling via `[[YYYY-MM-DD]]`
+links and daily-note inheritance; per-note `checklist: true` opt-out.
+**Out (explicitly — grounding brief §9.7 calls half-building this the worst path):**
+recurrence, reminders, priorities, projects, statuses, dependencies, calendar sync,
+external task integrations, editing task *text* inside the Tasks view, archived-state
+markers in markdown, AI task extraction (later, over this projection), CLI
+`reflect tasks` (later; trivial once the table exists).
+
+## Key decisions / contracts
+
+- **A task is a GFM checkbox item.** `- [ ] text` / `- [x] text`. No invented syntax,
+  no typed-entity layer: the files stay meaningful in GitHub, Obsidian, and any
+  markdown tool. Lezer already parses these (`Task`/`TaskMarker` via the GFM
+  extension in `grammar.ts`).
+- **V1's task-vs-checklist distinction maps to note granularity.** V1 used round vs
+  square checkboxes — unrepresentable in GFM. Instead: every checkbox is a task by
+  default; a note flagged `checklist: true` in frontmatter keeps **all** its checkboxes
+  out of the Tasks view (shopping lists, packing lists). Reuses the established
+  frontmatter-flag machinery end-to-end: `model.ts` schema + coercion, indexer column,
+  `NoteToggleAction` + `toggleNoteChecklist` in the context sidebar (the
+  `note-private.ts` / `note-pin.ts` pattern), `commitFrontmatter` for the land-now
+  patch. Item-level opt-out is rejected — it would require invented syntax.
+- **Scheduling is association, not metadata** — V1's own mechanism (scheduling a task
+  inserted a daily-note backlink) restated in markdown. Scheduled date resolution, in
+  order: (1) the first `[[YYYY-MM-DD]]` wiki link inside the item; (2) for tasks in a
+  daily note, the note's own date (a task jotted today is "today", and becomes overdue
+  tomorrow — the V1 "current daily context" behavior); (3) unscheduled. Rescheduling
+  *is* editing the date link.
+- **The `tasks` table is a pure projection** (rebuildable, wiped + rebuilt on schema
+  bump), keyed by `notes(path)` with `ON UPDATE CASCADE ON DELETE CASCADE` like the
+  other child tables — so Plan 17 moves and deletes need zero new handling.
+- **Write-back is surgical and guarded.** Toggling from the Tasks view replaces
+  exactly the 3-byte marker (`[ ]` ↔ `[x]`) at the indexed offset **only if** the
+  surrounding item text still matches what the index recorded. On mismatch (stale
+  index, concurrent edit): refuse loudly and reindex — never a silent wrong write.
+- **The Tasks view is local-only**, so `private: true` notes' tasks appear in it (same
+  contract as local search/retrieval). Any future exposure of tasks to chat tools goes
+  through the existing `CloudSafe` checkers like every other note-content path.
+- **Completion is the only state.** No archive flag — markdown has no clean home for
+  it. The view shows checked tasks in a collapsed "Completed" section (recent first);
+  hiding old completed tasks is presentation, not data.
+
+### Contract sketches
+
+```ts
+// extract.ts — ParsedNote grows:
+interface ParsedTask {
+  text: string          // inline text of the item's first paragraph, markdown stripped
+  raw: string           // exact source slice of that line (the write-back guard)
+  checked: boolean
+  markerOffset: number  // byte offset of `[ ]`/`[x]` in the source
+  scheduled: string | null // ISO date per the resolution rules above
+}
+
+// markdown/edit.ts — the guarded toggle (pure; the command wraps read→edit→write):
+export function toggleTaskMarker(
+  source: string,
+  markerOffset: number,
+  expectedRaw: string,
+): { source: string; checked: boolean } // throws TaskStaleError on any mismatch
+```
+
+```sql
+-- crates/index-schema/migrations/0009_tasks.sql (+ LATEST_SCHEMA_VERSION bump →
+-- projection wipe/rebuild on first open; chat_* untouched as always)
+CREATE TABLE tasks (
+  note_path     TEXT NOT NULL REFERENCES notes(path)
+                  ON UPDATE CASCADE ON DELETE CASCADE,
+  marker_offset INTEGER NOT NULL,
+  text          TEXT NOT NULL,
+  raw           TEXT NOT NULL,
+  checked       INTEGER NOT NULL,
+  scheduled     TEXT,             -- ISO date or NULL
+  PRIMARY KEY (note_path, marker_offset)
+);
+CREATE INDEX tasks_open_by_date ON tasks (checked, scheduled);
+```
+
+```ts
+// route.ts — Route union grows (exhaustive switches force the rest):
+| { kind: 'tasks' }
+```
+
+## Steps
+
+1. **Editor: interactive checkboxes (Plan 05 step 8, unblocked).** The schema attr
+   (`list` `kind:"task"` / `checked`) already exists; wire interactivity in the
+   meowdown surface file (`editor/meowdown.ts` stays the single coupling point):
+   checkbox click toggles `checked`; `⌘⏎` toggles the task under the caret and
+   converts a plain bullet to a task (V1 muscle memory) — registered through the
+   editor keymap registry (audit meowdown's own bound shortcuts first). Verify
+   serialization stays marker-only (`[ ]`↔`[x]`), pinned by round-trip tests.
+
+2. **Extraction.** Extend `parseNote` with `tasks: ParsedTask[]` from the Lezer
+   `Task`/`TaskMarker` nodes (skip code blocks as elsewhere). Resolve `scheduled`
+   here: first `[[YYYY-MM-DD]]` in the item, else `dateFromDailyPath`, else null.
+
+3. **Projection.** Migration `0009_tasks.sql` (above) + Kysely schema regen + the
+   Rust `index_apply` payload/write path (`db/write.rs`) + the `checklist` flag column
+   on `notes` (extracted in step 5; flagged notes index zero task rows — the flag
+   filters at *index* time so the view query stays trivial).
+
+4. **Toggle write path.** `toggleTaskMarker` in `markdown/edit.ts` (pure, tested);
+   a core command (`indexing/commands.ts` family) doing read → toggle → `note_write`
+   → reindex, surfacing `TaskStaleError` as a reviewable refusal. If the note is open
+   in the editor, the existing external-change reconciliation picks the write up.
+
+5. **`checklist: true` flag.** Frontmatter schema + coercion in `model.ts`
+   (`.catch()` tolerance like `private`/`pinned`), `NoteToggleAction` entry
+   ("Mark as checklist" — short, action-first copy), `toggleNoteChecklist` via
+   `commitFrontmatter`, palette command, indexer respect (step 3).
+
+6. **Tasks route + view.** `{ kind: 'tasks' }` route; sidebar entry; `⌘T` (free) +
+   "Go to tasks" palette command. The view: TanStack Query over the projection,
+   invalidated on `index:changed` like the backlinks panel; groups Overdue / Today /
+   Upcoming / Unscheduled with source-note titles (daily dates render as dates);
+   collapsed Completed section; checkbox toggles via step 4; row click navigates via
+   `routeForPath`. Keyboard: arrows + space/enter to toggle, full flow mouse-free.
+   Virtualize only if a real graph proves it necessary (note the parent-owned scroll
+   container must be virtualizer *state*, not a ref, if so).
+
+7. **Tests.** Extraction (positions, scheduling precedence, code-block skips,
+   checklist flag); toggle round-trip incl. the stale-guard refusal; editor checkbox
+   click/keymap + serialization fidelity; view grouping + invalidation; move/rename
+   keeps task rows (FK cascade); rebuild-from-markdown reproduces the table.
+
+## Acceptance criteria
+
+- `- [ ]` renders as a clickable checkbox in the editor; click and `⌘⏎` toggle it;
+  the file changes by exactly the marker bytes; `pnpm typecheck` + targeted tests pass.
+- `⌘T` opens Tasks: every open checkbox across the graph except `checklist: true`
+  notes, grouped Overdue / Today / Upcoming / Unscheduled, with source-note context;
+  completed tasks sit collapsed below; the whole flow works without the mouse.
+- A task containing `[[2026-07-01]]` schedules for that date; a bare task in
+  `daily/2026-06-12.md` schedules for 2026-06-12 and turns Overdue the next day; a
+  bare task in a regular note is Unscheduled.
+- Toggling from the Tasks view updates the markdown file, the index, and an open
+  editor; toggling against a stale index refuses loudly and recovers via reindex —
+  never writes the wrong bytes.
+- Deleting `.reflect/` and reopening reproduces the identical tasks projection;
+  renaming/moving a note keeps its task rows; external edits re-project within the
+  watcher debounce.
+- The Tasks view includes `private: true` notes (local surface); nothing task-related
+  adds a new external call site.
+
+## Risks
+
+- **Interactivity may need more than an attr toggle** if meowdown/ProseKit doesn't
+  expose checkbox clicks cleanly through `defineEditorExtension()`. Fallback is the
+  proven house pattern: decorations over literal text, like wiki-links/images. Keep
+  all meowdown contact inside `editor/meowdown.ts`.
+- **Offset-keyed write-back races edits.** The `raw`-match guard + loud refusal is
+  the defense; the acceptance test for the stale path is non-negotiable
+  (fail-loud, never silent-wrong).
+- **Serializer normalizations vs the protection guard.** meowdown normalizes
+  `[X]`→`[x]` and loose single-paragraph lists→tight (accepted, pinned in tests);
+  externally-authored files using those shapes open protected today and will continue
+  to — note it in docs, don't fight it here.
+- **Scope creep is the historical failure mode** (grounding brief §9.7): V1 grew
+  task editing inside the view, pending inline task documents, and archive state.
+  Everything in **Out** stays out until a deliberate later plan.
+- **Daily-date inheritance might over-schedule** for users who journal checkboxes in
+  daily notes without meaning "due today". Escape hatches: `checklist: true` on the
+  note, or an explicit future `[[date]]` on the item. Revisit only with real usage.

--- a/docs/plans/18-tasks.md
+++ b/docs/plans/18-tasks.md
@@ -61,9 +61,13 @@ markers in markdown, AI task extraction (later, over this projection), CLI
   bump), keyed by `notes(path)` with `ON UPDATE CASCADE ON DELETE CASCADE` like the
   other child tables — so Plan 17 moves and deletes need zero new handling.
 - **Write-back is surgical and guarded.** Toggling from the Tasks view replaces
-  exactly the 3-byte marker (`[ ]` ↔ `[x]`) at the indexed offset **only if** the
-  surrounding item text still matches what the index recorded. On mismatch (stale
-  index, concurrent edit): refuse loudly and reindex — never a silent wrong write.
+  exactly the three-character marker (`[ ]` ↔ `[x]`) at the indexed position **only
+  if** the surrounding item text still matches what the index recorded. On mismatch
+  (stale index, concurrent edit): refuse loudly and reindex — never a silent wrong
+  write. Positions are **JS string indices (UTF-16 code units), the unit Lezer
+  reports and `extract.ts` already uses** — never UTF-8 byte offsets. The toggle
+  stays in string-land end-to-end (read string → splice → `note_write` the whole
+  string), so no byte conversion ever exists to get wrong.
 - **The Tasks view is local-only**, so `private: true` notes' tasks appear in it (same
   contract as local search/retrieval). Any future exposure of tasks to chat tools goes
   through the existing `CloudSafe` checkers like every other note-content path.
@@ -79,7 +83,8 @@ interface ParsedTask {
   text: string          // inline text of the item's first paragraph, markdown stripped
   raw: string           // exact source slice of that line (the write-back guard)
   checked: boolean
-  markerOffset: number  // byte offset of `[ ]`/`[x]` in the source
+  markerOffset: number  // string index of `[ ]`/`[x]` in the source — UTF-16 code
+                        // units, as Lezer positions are (never UTF-8 bytes)
   scheduled: string | null // ISO date per the resolution rules above
 }
 
@@ -97,7 +102,7 @@ export function toggleTaskMarker(
 CREATE TABLE tasks (
   note_path     TEXT NOT NULL REFERENCES notes(path)
                   ON UPDATE CASCADE ON DELETE CASCADE,
-  marker_offset INTEGER NOT NULL,
+  marker_offset INTEGER NOT NULL,  -- JS string index (UTF-16 units), not bytes
   text          TEXT NOT NULL,
   raw           TEXT NOT NULL,
   checked       INTEGER NOT NULL,
@@ -158,7 +163,8 @@ CREATE INDEX tasks_open_by_date ON tasks (checked, scheduled);
 ## Acceptance criteria
 
 - `- [ ]` renders as a clickable checkbox in the editor; click and `⌘⏎` toggle it;
-  the file changes by exactly the marker bytes; `pnpm typecheck` + targeted tests pass.
+  the file changes by exactly the marker characters; `pnpm typecheck` + targeted
+  tests pass.
 - `⌘T` opens Tasks: every open checkbox across the graph except `checklist: true`
   notes, grouped Overdue / Today / Upcoming / Unscheduled, with source-note context;
   completed tasks sit collapsed below; the whole flow works without the mouse.
@@ -167,7 +173,7 @@ CREATE INDEX tasks_open_by_date ON tasks (checked, scheduled);
   bare task in a regular note is Unscheduled.
 - Toggling from the Tasks view updates the markdown file, the index, and an open
   editor; toggling against a stale index refuses loudly and recovers via reindex —
-  never writes the wrong bytes.
+  never writes a wrong edit.
 - Deleting `.reflect/` and reopening reproduces the identical tasks projection;
   renaming/moving a note keeps its task rows; external edits re-project within the
   watcher debounce.

--- a/docs/reflect-v2-grounding-brief.md
+++ b/docs/reflect-v2-grounding-brief.md
@@ -399,8 +399,8 @@ V2 considerations:
 
 - Daily note is again the capture destination.
 - Web capture creates an information-ingestion stream that should be searchable and linkable.
-- Launch V2 should include basic link capture even if full article clipping is deferred.
-- The first launch path should be a Chrome extension talking to the installed desktop app through a local bridge.
+- V2 link capture is designed but deferred from the first macOS release; full article clipping is deferred further still.
+- When capture ships, the path should be a Chrome extension talking to the installed desktop app through a local bridge.
 - The desktop app should own markdown writes, screenshot asset storage, BYOK AI calls, keychain access, and privacy checks.
 - V2 should not host a link-description API; enrichment calls should go directly from the app to the user's chosen model provider.
 - Captured links should append to today's daily note by default, with a dedicated markdown note when the capture includes richer description, highlights, or screenshot context.
@@ -483,8 +483,8 @@ Use cases mentioned:
 
 V2 considerations:
 
-- Audio capture is a strong wedge for mobile, but it is deferred from the first V2 wave.
-- When V2 implements audio transcription, it should use cloud transcription providers rather than local-only transcription so Mac and mobile can share the same capability and quality expectations.
+- Audio capture is a strong wedge for mobile. (V2 shipped desktop audio memos in the first wave, ahead of the original deferral: raw-first local recordings with async BYOK cloud transcription.)
+- V2 audio transcription uses cloud transcription providers rather than local-only transcription so Mac and mobile can share the same capability and quality expectations.
 - Raw audio should be treated as external cloud-processing data, similar to BYOK/cloud AI context. The product must make this clear before upload.
 - `private: true` notes and captures should block cloud transcription and cloud transcript cleanup unless the user explicitly changes the privacy setting.
 - Transcription should produce structured outputs, not just raw text: summary, tasks, entities, linked notes, cleaned transcript, original audio retention policy.
@@ -1069,11 +1069,11 @@ Some earlier V2 questions have now been answered in the decision docs. This sect
 - **Entities**: do not introduce a typed entity layer in the first wave. Canonical people, companies, projects, and other entities can emerge later as projections over notes and aliases.
 - **AI model**: use BYOK/cloud generative AI first. Treat local generative models as a later possibility. Keep local embeddings separate from generative AI.
 - **API and automation**: start with read/discovery CLI operations such as `reflect search`, `reflect show`, `reflect today`, and path lookup. Manual markdown edits are the write path. Do not introduce Reflect-hosted APIs for the V2 core product.
-- **Tasks**: defer tasks. When ported, tasks should be lightweight markdown-backed projections rather than a full task-management system.
+- **Tasks**: deferred from the first release; now planned as a post-release add-on (Plan 18). As decided here: lightweight markdown-backed projections (GFM checkboxes + a `tasks` table + a Tasks view) rather than a full task-management system.
 - **Contacts and calendar**: defer as first-wave surfaces, but preserve them as future memory context for meetings, backlinks, daily notes, and AI.
 - **Daily AI automation**: allow opt-in background extraction into reviewable suggestions. Do not silently mutate notes with summaries, entities, backlinks, or tasks.
-- **Links**: treat basic Chrome link capture as a launch requirement. The extension should hand URL/title/selection/screenshot data to the desktop app, and the desktop app should use BYOK AI plus local markdown/assets to save the capture. V2 should not host a link-description API.
-- **Audio**: defer audio memos. When implemented, transcription should use cloud providers with explicit privacy UX.
+- **Links**: basic Chrome link capture is designed (Plan 11: extension hands URL/title/selection/screenshot to the desktop app via a local bridge; desktop owns BYOK AI and markdown/asset writes; no Reflect-hosted link-description API) but **deferred — the first macOS release ships without it**.
+- **Audio**: **shipped in the first release** (ahead of the original deferral): raw-first audio memos with async BYOK cloud transcription, explicit privacy UX, and `private: true` cloud-processing lockouts.
 - **Publishing and templates**: defer both. They should not block the first-wave editor, storage, search, sync, and AI foundation.
 
 ### Remaining Open Questions

--- a/docs/reflect-v2-indexing-strategy.md
+++ b/docs/reflect-v2-indexing-strategy.md
@@ -4,6 +4,21 @@ This document captures the current V2 indexing direction. It focuses on using a 
 
 It complements [Reflect V2 Product Vision](./reflect-v2-product-vision.md).
 
+> **Status (2026-06-12) — shipped as designed**, with these specifics:
+>
+> - SQLite lives at `<graph>/.reflect/index.sqlite`; migrations are shared between the
+>   desktop writer and the read-only `reflect` CLI via the `index-schema` crate.
+> - Canonical parser: `@lezer/markdown` (GFM + a first-party wiki-link extension),
+>   shared by the editor and the indexer. Note identity: lowercase ULID `id:` in
+>   frontmatter plus readable slug filenames (Plan 17).
+> - FTS5 lexical search; semantic search via `sqlite-vec` with **local embeddings**
+>   (fastembed/ONNX in Rust, outside the WebView; model downloaded on demand).
+>   Chunks are hashed so unchanged chunks are not re-embedded.
+> - **One durable exception to "projections only":** the `chat_*` tables hold AI chat
+>   history, which is not derivable from markdown. Index wipes/rebuilds must leave
+>   them untouched.
+> - The `web_captures` projection is deferred along with link capture (Plan 11).
+
 ## Strategy
 
 Reflect V2 should use a local projection database.
@@ -65,7 +80,7 @@ Potentially non-rebuildable local state includes:
 - Collapsed sidebar state.
 - Sync adapter credentials or references.
 - Conflict review state.
-- AI conversation history, if the user chooses to keep it.
+- AI conversation history (shipped as the durable `chat_*` tables — the one sanctioned non-rebuildable exception; rebuilds must preserve them).
 
 Secrets do not belong in SQLite or `.reflect/` unless a later security design explicitly chooses encrypted local storage there. BYOK model keys and GitHub credentials should live in per-device OS keychain or secure storage.
 
@@ -188,9 +203,11 @@ Mobile should share the same markdown and sync assumptions as desktop, but it sh
 
 ## Open Questions
 
-- What markdown parser should define the canonical AST?
-- How should note IDs be represented in markdown frontmatter?
-- What local embedding runtime should V2 use outside the WebView?
+Resolved (see the status note above): the canonical parser is `@lezer/markdown`; note
+IDs are lowercase ULID `id:` frontmatter; the local embedding runtime is fastembed/ONNX
+in Rust; chat history persists durably in `chat_*` with a moving context window.
+
+Still open:
+
 - Should vector search stay in sqlite-vec long term or move behind a vector-store adapter?
-- How much AI conversation history should be persisted locally?
 - How should mobile graduate from lexical search to local semantic search?

--- a/docs/reflect-v2-product-vision.md
+++ b/docs/reflect-v2-product-vision.md
@@ -316,7 +316,7 @@ Notes with `private: true` are hard-blocked from cloud AI. They may remain local
 
 ### BYOK First
 
-V2 should start with bring-your-own-key AI, especially OpenAI keys.
+V2 should start with bring-your-own-key AI. (As shipped: OpenAI, Anthropic, and Google keys, stored in the OS keychain.)
 
 The architecture should leave room for:
 
@@ -360,7 +360,11 @@ The search system should operate over markdown files plus the local projection d
 
 ## Link Capture
 
-Launch V2 should include basic link capture. This is narrower than a full browser clipper, but it is still part of Reflect's daily-first capture spine.
+> **Status (2026-06-12):** Link capture is **deferred — the first macOS release ships
+> without it**. The design below (and [Plan 11](./plans/11-link-capture.md) plus the
+> bridge spike) remains the intended post-launch direction.
+
+V2 should include basic link capture. This is narrower than a full browser clipper, but it is still part of Reflect's daily-first capture spine.
 
 The V1 implementation has a useful shape to preserve: browser capture creates a link record, a client-side operation turns that into a link note, and the daily note gets a `[[Links]]` entry pointing at the captured item. The V1 implementation also calls `link-description-api.vercel.app/describe` for an AI-generated summary. V2 should preserve the product behavior, but not the Reflect-hosted API shape.
 
@@ -420,15 +424,26 @@ Full editor parity, local semantic search, heavy AI workflows, and complex confl
 
 ### Shell Spike
 
+> **Resolved:** the spike happened and **Tauri 2 is the shipped desktop shell** (React/
+> TypeScript frontend in a Rust native shell, with the `reflect` CLI bundled as a
+> sidecar). The paragraph below is preserved as the original decision framing.
+
 V2 should not commit to Tauri or a native Mac shell before a focused spike.
 
-The spike should compare Tauri against a native Mac shell with WebView using the real editor, local file access, SQLite/indexing, GitHub backup, keyboard behavior, and window/menu requirements. Tauri remains a serious candidate, but the docs should not treat it as chosen.
+The spike should compare Tauri against a native Mac shell with WebView using the real editor, local file access, SQLite/indexing, GitHub backup, keyboard behavior, and window/menu requirements.
 
 ### Future Windows And Android
 
 Windows and Android should remain possible. The implementation should avoid choices that make them impossible, but should not over-optimize for them before the Mac product is excellent.
 
 ## Backup And Sync Strategy
+
+> **Status (2026-06-12):** the first release ships the Git adapter only — GitHub via
+> device-flow auth, plus generic git remotes over SSH/path. File-sync folder providers
+> (iCloud Drive/Dropbox/Drive) are **unsupported for sync by design** in the first wave
+> (see Plan 12); the adapter list below is the long-term direction. AI-assisted conflict
+> resolution did not ship — conflicts surface as reviewable conflict markers with
+> mine/theirs/both resolution.
 
 V2 should make backup free and understandable.
 
@@ -491,7 +506,7 @@ These should be treated as core to the V2 vision:
 | Semantic search    | Required on supported desktop runtimes; mobile can start lexical-only.                              |
 | AI note copilot    | Required right-sidebar experience.                                                                  |
 | BYOK AI            | Required initial AI model.                                                                          |
-| Link capture       | Required launch surface: Chrome extension to local desktop bridge, daily note entry, optional note. |
+| Link capture       | Designed (Plan 11) but **deferred from the first macOS release**: Chrome extension to local desktop bridge, daily note entry, optional note. |
 | Import/export      | Required for trust and portability; prioritize markdown and Obsidian-style vaults first.            |
 | Backup             | Free/open backup path required.                                                                     |
 | Open-source core   | Required.                                                                                           |
@@ -505,8 +520,8 @@ These may come later, but should not define the first wave:
 
 | Feature                  | V2 stance                                                                                                          |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------ |
-| Tasks                    | Defer. Revisit once markdown task semantics and projections are clear.                                             |
-| Audio transcription      | Defer. When implemented, prefer cloud transcription providers so desktop and mobile can share the same capability. |
+| Tasks                    | Defer from the first release; now planned as a post-release add-on (Plan 18): GFM-checkbox tasks as a lightweight markdown-backed projection. |
+| Audio transcription      | **Shipped early** (despite this table): raw-first audio memos with async BYOK cloud transcription and `private: true` lockouts. |
 | Full browser clipper     | Defer beyond launch link capture. Article extraction, read-later state, and broad clipping can come later.         |
 | Graph/map view           | Defer. Keep backlink graph data, but visual map is not first-wave.                                                 |
 | Templates                | Defer or keep lightweight. Markdown snippets may be enough initially.                                              |
@@ -545,8 +560,8 @@ Implementation details are not final, but future agents should start from these 
 - **AI**: BYOK generative provider calls with visible/current context and local retrieval, excluding locked notes.
 - **AI edits**: multi-note patchsets, checkpointed before application; unsafe edits require review.
 - **Search**: local lexical search and local-only semantic embeddings.
-- **Link capture**: Chrome extension sends URL/title/selection/screenshot data to a local desktop bridge; the desktop app uses BYOK AI, writes markdown/assets, and appends the capture to today's daily note.
-- **Audio memos**: deferred; future transcription should use cloud providers, with explicit privacy UX and `private: true` cloud-processing lockouts.
+- **Link capture**: deferred from the first release. When built: Chrome extension sends URL/title/selection/screenshot data to a local desktop bridge; the desktop app uses BYOK AI, writes markdown/assets, and appends the capture to today's daily note.
+- **Audio memos**: shipped — raw-first capture (the recording is the durable artifact), async BYOK cloud transcription with `private: true` cloud-processing lockouts.
 - **Network model**: no Reflect-hosted APIs for the core product; external calls go directly to user-approved providers such as LLM providers, GitHub, Git remotes, iCloud Drive, or cloud transcription providers.
 - **Desktop shell**: Mac-first, no Electron, spike Tauri against a native WebView shell.
 - **Mobile**: capture/read/lexical search first; same sync assumptions later.
@@ -563,10 +578,8 @@ These should remain explicit until answered:
 
 - How much Git complexity can be fully hidden from users?
 - Which conflict edge cases need stricter review than the default content-conflict policy?
-- What exact model/runtime should power local embeddings?
 - How should mobile eventually access and mutate the same GitHub-backed workspace?
-- Which Chrome extension bridge should ship first: native messaging or loopback HTTP?
-- Which safe multi-note AI patches can auto-apply without review?
+- Which safe multi-note AI patches can auto-apply without review? (The first release ships the copilot read-only; patchsets are a later wave.)
 - What command/skill subset should `~/.agents` discovery expose inside Reflect?
 - What business model, if any, belongs in the long-term product?
 - What is the eventual V1 migration path?
@@ -581,8 +594,10 @@ Reflect V2 succeeds if a user can:
 4. Create `[[Wiki Links]]` naturally.
 5. Search notes locally.
 6. Ask the AI sidebar about the current note and related notes using their own API key.
-7. Save the current browser page into today's note with screenshot-backed BYOK AI enrichment.
-8. Back up their notes for free.
-9. Open their note folder and see portable markdown files.
+7. Back up their notes for free.
+8. Open their note folder and see portable markdown files.
+
+(A ninth item — save the current browser page into today's note with screenshot-backed
+BYOK AI enrichment — rejoins this list when link capture ships post-launch.)
 
 The product should feel like Reflect's memory model survived, but the substrate became open, local, markdown-native, and AI-ready.

--- a/docs/reflect-v2-sync-strategy.md
+++ b/docs/reflect-v2-sync-strategy.md
@@ -4,6 +4,23 @@ This document captures the current V2 sync direction. It focuses on a storage/sy
 
 It complements [Reflect V2 Product Vision](./reflect-v2-product-vision.md).
 
+> **Status (2026-06-12) — what actually shipped in the first release** (see
+> [Plan 12](./plans/12-backup-and-sync.md) and
+> [Plan 16](./plans/16-generic-git-remotes.md), which supersede this doc where they
+> differ):
+>
+> - **Git is the only sync backend.** GitHub via device-flow auth (token in the OS
+>   keychain), plus generic git remotes over SSH (agent) and filesystem paths
+>   (Plan 16 V1). HTTPS credential helpers are a later phase.
+> - **File-sync folder providers (iCloud Drive/Dropbox/Drive) are unsupported for
+>   sync by design** in the first wave — not adapters-in-waiting. The adapter
+>   sections below are preserved as long-term direction only.
+> - **AI-assisted conflict resolution did not ship.** Conflicts surface as standard
+>   conflict markers; conflicted notes open protected, with a reviewable
+>   mine/theirs/both resolution flow and a `has_conflict` "Needs review" projection.
+> - Plain-language product states (Backed up / Backing up / Offline / Needs review /
+>   Backup failed) shipped as described below.
+
 ## Strategy
 
 Reflect V2 should treat sync as an adapter-backed capability, not as a single hard-coded backend.


### PR DESCRIPTION
## What changed

**Release-scope alignment (9 docs).** The first macOS release ships without link capture (Plan 11) and without import/export (Plan 13), while audio memos and durable chat persistence shipped ahead of plan — but the docs still described the original first-wave scope, in both directions. This PR records reality:

- **[00-overview](docs/plans/00-overview.md)** — new "Status at first release (2026-06-12)" section (Plans 01–10, 12, 14–17 shipped; 11 deferred; 13 not started; audio memos + `chat_*` persistence landed beyond plan; copilot shipped read-only); plan table, M4 milestone, and deferred list updated.
- **[Plan 11](docs/plans/11-link-capture.md)** — deferred banner; design preserved as the post-launch blueprint.
- **[Plan 13](docs/plans/13-import-export-portability.md)** — honest "not started" banner.
- **[Plan 15](docs/plans/15-hardening-packaging-release.md)** — capture removed from the error-UX/privacy-review/native-messaging steps and the definition-of-success; audio memos moved *into* privacy-review scope.
- **[Product vision](docs/reflect-v2-product-vision.md)** — link capture deferred (section, tables, defaults, definition of success); audio marked shipped; Tauri shell-spike marked resolved; BYOK updated to the shipped OpenAI/Anthropic/Google set; GitHub-only sync status note; answered open questions pruned.
- **[Grounding brief](docs/reflect-v2-grounding-brief.md)** — Links/Audio/Tasks "Resolved Direction" bullets flipped to match what shipped.
- **[Sync strategy](docs/reflect-v2-sync-strategy.md)** — status block: Git-only backend (GitHub device flow + SSH/path remotes), file-sync providers unsupported by design, conflict markers + mine/theirs/both review instead of AI resolution.
- **[Indexing strategy](docs/reflect-v2-indexing-strategy.md)** — status block (lezer parser, ULID ids, FTS5, sqlite-vec + fastembed/ONNX, `chat_*` durable exception, `web_captures` deferred); open questions pruned to the two still open.

**New: [Plan 18 — Tasks](docs/plans/18-tasks.md)**, a post-release add-on plan porting V1's third center of gravity as a lightweight markdown-backed projection: GFM-checkbox tasks, interactive editor checkboxes (click + ⌘⏎), a ⌘T Tasks view (Overdue/Today/Upcoming/Unscheduled), scheduling via `[[YYYY-MM-DD]]` links with daily-note date inheritance, a guarded surgical toggle write-back, and a `checklist: true` per-note opt-out mapping V1's task-vs-checklist distinction onto note granularity.

## Why a reviewer should care

- Plan 18 is grounded in a **verified** fact, not the stale Plan 05 record: meowdown 0.3.0 round-trips task lists byte-faithfully (tested directly via `markdownToDoc`/`docToMarkdown`, including wiki links and tags inside items) and already models tasks as `list(kind:"task", checked)` PM nodes. The upstream converter blocker is cleared, so Plan 05's two "blocked upstream" passages now point at Plan 18 step 1.
- The plan reuses existing seams deliberately: migration 0009 + schema-version bump (projection wipe/rebuild), `FOREIGN KEY ... ON UPDATE CASCADE` so Plan 17 note moves need zero new handling, and the `NoteToggleAction`/`commitFrontmatter` flag pattern for `checklist: true`. ⌘T and editor ⌘⏎ were checked free.
- One open product decision is *recorded, not made*: Plan 13 (import/export) has zero code. The docs now state the gap honestly; whether to ship a minimal Markdown ZIP export or release with "your folder is the export" remains a call to make before launch.

Docs-only change — no code, no tests to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no runtime, security, or data-path behavior is modified.
> 
> **Overview**
> **Docs-only:** brings plans and product strategy in line with the **first macOS release (2026-06-12)** and adds a post-launch tasks plan.
> 
> **Release reality** is recorded in `docs/plans/00-overview.md` and echoed across vision/indexing/sync/grounding docs: shipped Plans **01–10, 12, 14–17**; **Plan 11 (link capture)** and **Plan 13 (import/export)** called out as deferred/not built; **audio memos** and durable **`chat_*`** persistence noted as shipped beyond plan; copilot **read-only** (no patchsets). M4 and Plan 15 release checklists drop capture from privacy/notarization/success criteria and fold **audio** into privacy review.
> 
> **Plan updates:** Plan 05 says **meowdown 0.3.0** clears the task-list round-trip blocker and points interactive checkboxes to **Plan 18**; Plans 11/13 get status banners; product vision marks **Tauri 2** resolved, **Git-only** sync, expanded **BYOK** providers, and trims answered open questions.
> 
> **New [Plan 18 — Tasks](docs/plans/18-tasks.md):** post-release GFM-checkbox projection (`tasks` table, `⌘T` view, `[[date]]`/daily scheduling, guarded marker toggle write-back, `checklist: true` opt-out)—explicitly **out of** first release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82cde9ee211dc83e7f542761b3ae385f474458b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->