### PR TITLE
README: rewrite for an external developer audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,50 @@
 # Reflect
 
-**A local-first, markdown-native, AI-native notes app for macOS.**
+**Daily notes, linked thinking, and an AI that answers from your own notes —
+in plain files on your Mac.**
 
 [![Release](https://img.shields.io/github/v/release/team-reflect/reflect-open)](https://github.com/team-reflect/reflect-open/releases/latest)
 [![CI](https://github.com/team-reflect/reflect-open/actions/workflows/ci.yml/badge.svg)](https://github.com/team-reflect/reflect-open/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-Your notes are plain `.md` files in a folder you choose. Reflect gives them a
-fast keyboard-native editor, a knowledge graph built from `[[wiki links]]`,
-local full-text *and* semantic search, an AI chat that reads your notes with
-your own API key — and never runs a server. There is no account, no telemetry,
-and no Reflect-hosted API in any code path.
+Reflect opens to today's note. Write your day — meetings, ideas, journal —
+and type `[[` to link the people and projects in it. Those links grow into a
+personal graph of everything you've written, and search and AI sit on top of
+it, so "what did we decide about this last spring?" is one search (`⌘K`) or
+one question (`⌘J`) away.
 
-- **Daily notes first.** The app opens to today (`⌘D`). Capture goes there by
-  default; structure emerges from links, not folders.
-- **`[[Wiki links]]` & backlinks.** Autocomplete on `[[`, create-on-link,
-  incoming backlinks under every note. Renames rewrite inbound links and keep
-  the old title as an alias.
-- **Search (`⌘K`).** SQLite FTS5 with filters (`#tag`, `is:daily`, `links:`,
-  `linked-from:`, `updated:>2026-01-01`), plus semantic search powered by
-  on-device embeddings — note content never leaves the machine to be indexed.
-- **AI chat (`⌘J`), bring-your-own-key.** OpenAI, Anthropic, or Google — your
-  key, stored in the macOS keychain, calls made directly to the provider.
-  The model reads your graph through search/read tools with citations.
-- **`private: true` is a hard block.** Flag a note and its content can never
-  be sent to any external service — enforced in the type system at every AI
-  call site, re-checked from disk at call time, covered by tests.
-- **Audio memos.** Record into today's note; the recording is saved locally
-  first and transcribed asynchronously with your own provider key.
-- **Backup & sync via git.** Connect GitHub in-app (private repo by default)
-  or [any git host over SSH](docs/generic-git-remotes.md). Conflicts surface
-  as plain-language review, never raw merge mechanics.
-- **A real CLI.** `reflect today`, `reflect search`, `reflect show` — script
-  your notes, pipe them to agents ([docs/cli.md](docs/cli.md)).
-- **Native, not Electron.** Tauri 2: a React frontend in a Rust shell. Signed,
-  notarized, auto-updating.
+It's built on a single promise: **your notes stay yours.** They are ordinary
+text files in a folder you choose — no account, no cloud database, no
+telemetry. Nothing leaves your Mac except services you explicitly connect,
+and if Reflect disappeared tomorrow, your notes would still open in any text
+editor.
+
+## Highlights
+
+- **Today, first.** The app opens to today's note. Capture everything there
+  and let links — not folders — organize it.
+- **Links that build a graph.** Type `[[` to connect notes; every note shows
+  what links back to it. Rename freely — links follow.
+- **Search that gets meaning (`⌘K`).** Instant search over every note, plus
+  optional semantic search that finds "that pasta thing" even if you never
+  wrote "pasta". Both run entirely on your Mac.
+- **Ask your notes (`⌘J`).** Connect your own OpenAI, Anthropic, or Google
+  account; Reflect talks straight to the provider — there is no middleman
+  server. Answers cite the notes they came from, as clickable links.
+- **A private flag that means it.** Mark a note `private: true` and its
+  content can never be sent to any AI or online service — enforced in code,
+  covered by tests.
+- **Talk instead of type.** Record an audio memo; it's saved instantly and
+  transcribed into your daily note with your own key.
+- **Free backup, full history.** Connect GitHub in-app (or
+  [any git host you run](docs/generic-git-remotes.md)) and every change is
+  versioned in a repository you own. Conflicts read as plain choices, not
+  merge jargon.
+- **Keyboard-native and light.** Every core action has a shortcut (`⌘/` shows
+  them all), in a native app — Tauri, not Electron — that's signed, notarized,
+  and auto-updating.
+- **Scriptable.** A real CLI — `reflect today`, `reflect search`,
+  `reflect show` — for scripts and agents ([docs/cli.md](docs/cli.md)).
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,39 +1,109 @@
 # Reflect
 
-Reflect is a local-first, markdown-native note-taking app. Notes are plain
-`.md` files on your disk — daily notes in `daily/`, everything else in
-`notes/` — connected by `[[wiki links]]` instead of folders. Everything
-derived from them (search, backlinks, tags) lives in a rebuildable SQLite
-index; deleting it loses nothing.
+**A local-first, markdown-native, AI-native notes app for macOS.**
 
-This repository is **Reflect V2**: an offline-first, open-source rewrite. See
-the [product vision](docs/reflect-v2-product-vision.md) for the full picture.
+[![Release](https://img.shields.io/github/v/release/team-reflect/reflect-open)](https://github.com/team-reflect/reflect-open/releases/latest)
+[![CI](https://github.com/team-reflect/reflect-open/actions/workflows/ci.yml/badge.svg)](https://github.com/team-reflect/reflect-open/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-## Principles
+Your notes are plain `.md` files in a folder you choose. Reflect gives them a
+fast keyboard-native editor, a knowledge graph built from `[[wiki links]]`,
+local full-text *and* semantic search, an AI chat that reads your notes with
+your own API key — and never runs a server. There is no account, no telemetry,
+and no Reflect-hosted API in any code path.
 
-- **Markdown is the source of truth.** SQLite under `.reflect/` is a
-  projection, never durable storage. Full export works from day one.
-- **Daily notes first, association over hierarchy.** The app opens to today;
-  wiki links and backlinks are the organizing model. No folders.
-- **No Reflect-hosted APIs.** AI features are bring-your-own-key and talk
-  directly to the provider; sync goes to a git repository you control —
-  GitHub guided in-app, [any other host over SSH](docs/generic-git-remotes.md).
-  Notes marked `private: true` are never sent to any external service —
-  [what leaves the device, and when](docs/privacy.md).
-- **Keyboard-native, minimal UI.** Built on Tauri 2 — no Electron.
+- **Daily notes first.** The app opens to today (`⌘D`). Capture goes there by
+  default; structure emerges from links, not folders.
+- **`[[Wiki links]]` & backlinks.** Autocomplete on `[[`, create-on-link,
+  incoming backlinks under every note. Renames rewrite inbound links and keep
+  the old title as an alias.
+- **Search (`⌘K`).** SQLite FTS5 with filters (`#tag`, `is:daily`, `links:`,
+  `linked-from:`, `updated:>2026-01-01`), plus semantic search powered by
+  on-device embeddings — note content never leaves the machine to be indexed.
+- **AI chat (`⌘J`), bring-your-own-key.** OpenAI, Anthropic, or Google — your
+  key, stored in the macOS keychain, calls made directly to the provider.
+  The model reads your graph through search/read tools with citations.
+- **`private: true` is a hard block.** Flag a note and its content can never
+  be sent to any external service — enforced in the type system at every AI
+  call site, re-checked from disk at call time, covered by tests.
+- **Audio memos.** Record into today's note; the recording is saved locally
+  first and transcribed asynchronously with your own provider key.
+- **Backup & sync via git.** Connect GitHub in-app (private repo by default)
+  or [any git host over SSH](docs/generic-git-remotes.md). Conflicts surface
+  as plain-language review, never raw merge mechanics.
+- **A real CLI.** `reflect today`, `reflect search`, `reflect show` — script
+  your notes, pipe them to agents ([docs/cli.md](docs/cli.md)).
+- **Native, not Electron.** Tauri 2: a React frontend in a Rust shell. Signed,
+  notarized, auto-updating.
+
+## Install
+
+Download the latest DMG from
+[**Releases**](https://github.com/team-reflect/reflect-open/releases/latest)
+(macOS, Apple Silicon). The app is Developer-ID signed and notarized, and
+updates itself from GitHub Releases — update payloads are verified against a
+public key compiled into the app.
+
+Or [build from source](#building-from-source).
+
+## Your notes are just files
+
+Reflect calls a notes folder a **graph**. Point it at any folder and it
+scaffolds:
+
+```text
+my-graph/
+├── daily/2026-06-12.md     # daily notes, named by date
+├── notes/some-title.md     # everything else, readable title-derived names
+├── assets/                 # images and attachments, relative-linked
+├── audio-memos/            # recordings awaiting/after transcription
+└── .reflect/               # SQLite index — rebuildable, git-ignored
+```
+
+Markdown is the source of truth. Everything derived from it — search index,
+backlinks, tags, embeddings — lives in `.reflect/index.sqlite` and is rebuilt
+from the files on demand; deleting it loses nothing. Frontmatter stays
+minimal: a stable `id`, optional `aliases`, and the `private` / `pinned`
+flags. Edit your notes with any other tool while Reflect runs — the file
+watcher picks up external changes and re-indexes.
+
+## Privacy model
+
+Every network call the app can make — what it carries, where it goes, and
+what's off by default — is documented in
+[**What leaves the device, and when**](docs/privacy.md). The short version:
+nothing leaves your machine unless you add a provider key or connect a git
+remote, and `private: true` notes are excluded from anything that reads
+content. Secrets live in the OS keychain only.
+
+## Building from source
+
+Prerequisites: a recent stable [Rust toolchain](https://rustup.rs), Node.js
+with [pnpm](https://pnpm.io) 10 (`corepack enable` uses the pinned version),
+and the Xcode Command Line Tools.
+
+```bash
+git clone https://github.com/team-reflect/reflect-open.git
+cd reflect-open
+pnpm install
+pnpm tauri dev      # run the full app with hot reload
+pnpm tauri build    # produce a native bundle
+```
 
 ## Architecture
 
-A pnpm/Turborepo monorepo with one load-bearing rule: **TypeScript owns policy,
-Rust owns capabilities.**
+A pnpm/Turborepo monorepo with one load-bearing rule: **TypeScript owns
+policy, Rust owns capabilities.**
 
 ```text
 reflect-open/
 ├── apps/desktop/          # The Tauri app
 │   ├── src/               # React UI: providers, components, the editor
-│   └── src-tauri/         # Rust shell: file IO, SQLite, file watching, recents
+│   └── src-tauri/         # Rust shell: file IO, SQLite, watching, git, embeddings
+├── apps/cli/              # The `reflect` CLI (Rust, bundled as a sidecar)
 ├── packages/core/         # All business logic (platform-agnostic TypeScript)
 ├── packages/db/           # Kysely schema + the query-builder dialect
+├── crates/index-schema/   # SQLite migrations shared by app and CLI
 ├── design-system/         # Tokens + UI primitives
 └── docs/plans/            # The numbered implementation plans (see below)
 ```
@@ -41,35 +111,64 @@ reflect-open/
 Data flows in one loop: the editor writes a markdown file (atomic write in
 Rust) → the file watcher reports the change → `@reflect/core` re-parses the
 note and applies its projection to SQLite → queries (search, backlinks) read
-the projection via Kysely. Our own saves take the same path as external edits,
-so the index can never disagree with the files.
+the projection via Kysely. Reflect's own saves take the same path as external
+edits, so the index can never disagree with the files.
 
 `@reflect/core` never imports Tauri. It talks to the native shell through an
-injected bridge (`setBridge`), which is what keeps it testable in plain vitest
-and reusable by the planned CLI. The desktop app installs the Tauri adapter at
-startup ([apps/desktop/src/lib/tauri-bridge.ts](apps/desktop/src/lib/tauri-bridge.ts)).
+injected bridge (`setBridge`), which keeps it testable in plain vitest. The
+desktop app installs the Tauri adapter at startup
+([apps/desktop/src/lib/tauri-bridge.ts](apps/desktop/src/lib/tauri-bridge.ts)).
+
+The editor is [meowdown](https://github.com/prosekit/meowdown) (MIT):
+ProseMirror over a Lezer markdown parse, rendering markdown in place while
+round-tripping it byte-faithfully. Notes the editor cannot round-trip open
+read-only rather than ever being silently rewritten.
+
+### The plans
+
+Code and comments reference numbered plans (e.g. "Plan 04b"). These are the
+dependency-ordered design documents in [docs/plans/](docs/plans/) —
+[00-overview.md](docs/plans/00-overview.md) is the roadmap and records what
+shipped in each release, and
+[architecture-conventions.md](docs/plans/architecture-conventions.md) holds
+the cross-cutting decisions every plan assumes. A comment like "Plan 02"
+points at the design rationale for that subsystem.
 
 ## Development
 
 ```bash
-pnpm install
-pnpm tauri dev        # full app with hot reload
 pnpm dev              # Vite only (http://localhost:1420, no native shell)
-
 pnpm typecheck        # all packages (tsc)
-pnpm test             # all packages (vitest); pass --run path/to/test for one file
+pnpm test             # all packages (vitest); --run path/to/test for one file
 pnpm lint             # oxlint
-cd apps/desktop/src-tauri && cargo test   # Rust suite
+
+# Rust — stage the CLI sidecar once per checkout first, or tauri-build fails:
+pnpm --filter @reflect/desktop sidecar
+cargo test --workspace
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for conventions and
-[AGENTS.md](AGENTS.md) for the full contributor/agent guide.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for conventions, the step-by-step
+guides in [docs/contributing/](docs/contributing/) (adding a command, adding a
+setting, editor architecture), and [AGENTS.md](AGENTS.md) for the full
+contributor guide.
 
-## The plans
+## Status & roadmap
 
-Code and comments reference numbered plans (e.g. "Plan 04b"). These are the
-dependency-ordered implementation phases in [docs/plans/](docs/plans/) —
-[00-overview.md](docs/plans/00-overview.md) is the roadmap, and
-[architecture-conventions.md](docs/plans/architecture-conventions.md) holds the
-cross-cutting decisions every plan assumes. A comment like "Plan 02" points at
-the design rationale for that subsystem.
+Reflect is early (`0.1.x`) but used daily. Shipped today: everything listed
+above. Designed but not yet built — each has a written plan:
+
+- **Browser link capture** ([Plan 11](docs/plans/11-link-capture.md)) — Chrome
+  extension → local native-messaging bridge → daily note.
+- **Import / export surfaces** ([Plan 13](docs/plans/13-import-export-portability.md)) —
+  the graph is already portable markdown you can copy wholesale; the in-app
+  Obsidian import and Markdown/JSON/HTML export are still to come.
+- **Tasks** ([Plan 18](docs/plans/18-tasks.md)) — GFM checkboxes aggregated
+  into a Tasks view, as a pure projection.
+
+Windows, mobile, and a plugin API are out of scope for now; the
+[product vision](docs/reflect-v2-product-vision.md) explains the long-term
+direction and what is deliberately *not* planned.
+
+## License
+
+[MIT](LICENSE) — including the editor and every bundled dependency.

--- a/README.md
+++ b/README.md
@@ -1,57 +1,57 @@
 # Reflect
 
-**Daily notes, linked thinking, and an AI that answers from your own notes —
-in plain files on your Mac.**
+**Daily notes, linked thinking, and an AI that answers from your own notes.
+All in plain files on your Mac.**
 
 [![Release](https://img.shields.io/github/v/release/team-reflect/reflect-open)](https://github.com/team-reflect/reflect-open/releases/latest)
 [![CI](https://github.com/team-reflect/reflect-open/actions/workflows/ci.yml/badge.svg)](https://github.com/team-reflect/reflect-open/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-Reflect opens to today's note. Write your day — meetings, ideas, journal —
-and type `[[` to link the people and projects in it. Those links grow into a
+Reflect opens to today's note. Write your day (meetings, ideas, journal) and
+type `[[` to link the people and projects in it. Those links grow into a
 personal graph of everything you've written, and search and AI sit on top of
 it, so "what did we decide about this last spring?" is one search (`⌘K`) or
 one question (`⌘J`) away.
 
 It's built on a single promise: **your notes stay yours.** They are ordinary
-text files in a folder you choose — no account, no cloud database, no
-telemetry. Nothing leaves your Mac except services you explicitly connect,
-and if Reflect disappeared tomorrow, your notes would still open in any text
-editor.
+text files in a folder you choose. There's no account, no cloud database, and
+no telemetry; nothing leaves your Mac except through services you explicitly
+connect. If Reflect disappeared tomorrow, your notes would still open in any
+text editor.
 
 ## Highlights
 
 - **Today, first.** The app opens to today's note. Capture everything there
-  and let links — not folders — organize it.
+  and let links, not folders, organize it.
 - **Links that build a graph.** Type `[[` to connect notes; every note shows
-  what links back to it. Rename freely — links follow.
+  what links back to it. Rename a note and its links follow.
 - **Search that gets meaning (`⌘K`).** Instant search over every note, plus
   optional semantic search that finds "that pasta thing" even if you never
   wrote "pasta". Both run entirely on your Mac.
 - **Ask your notes (`⌘J`).** Connect your own OpenAI, Anthropic, or Google
-  account; Reflect talks straight to the provider — there is no middleman
-  server. Answers cite the notes they came from, as clickable links.
+  account; Reflect talks straight to the provider, with no middleman server.
+  Answers cite the notes they came from, as clickable links.
 - **A private flag that means it.** Mark a note `private: true` and its
-  content can never be sent to any AI or online service — enforced in code,
-  covered by tests.
+  content can never be sent to any AI or online service. That rule is
+  enforced in code and covered by tests.
 - **Talk instead of type.** Record an audio memo; it's saved instantly and
   transcribed into your daily note with your own key.
 - **Free backup, full history.** Connect GitHub in-app (or
   [any git host you run](docs/generic-git-remotes.md)) and every change is
-  versioned in a repository you own. Conflicts read as plain choices, not
-  merge jargon.
+  versioned in a repository you own. Conflicts show up as plain choices
+  instead of merge jargon.
 - **Keyboard-native and light.** Every core action has a shortcut (`⌘/` shows
-  them all), in a native app — Tauri, not Electron — that's signed, notarized,
-  and auto-updating.
-- **Scriptable.** A real CLI — `reflect today`, `reflect search`,
-  `reflect show` — for scripts and agents ([docs/cli.md](docs/cli.md)).
+  them all). The app itself is Tauri rather than Electron: native, signed,
+  notarized, and auto-updating.
+- **Scriptable.** A real CLI (`reflect today`, `reflect search`,
+  `reflect show`) for scripts and agents; see [docs/cli.md](docs/cli.md).
 
 ## Install
 
 Download the latest DMG from
 [**Releases**](https://github.com/team-reflect/reflect-open/releases/latest)
 (macOS, Apple Silicon). The app is Developer-ID signed and notarized, and
-updates itself from GitHub Releases — update payloads are verified against a
+updates itself from GitHub Releases; update payloads are verified against a
 public key compiled into the app.
 
 Or [build from source](#building-from-source).
@@ -67,21 +67,21 @@ my-graph/
 ├── notes/some-title.md     # everything else, readable title-derived names
 ├── assets/                 # images and attachments, relative-linked
 ├── audio-memos/            # recordings awaiting/after transcription
-└── .reflect/               # SQLite index — rebuildable, git-ignored
+└── .reflect/               # SQLite index (rebuildable, git-ignored)
 ```
 
-Markdown is the source of truth. Everything derived from it — search index,
-backlinks, tags, embeddings — lives in `.reflect/index.sqlite` and is rebuilt
+Markdown is the source of truth. Everything derived from it (search index,
+backlinks, tags, embeddings) lives in `.reflect/index.sqlite` and is rebuilt
 from the files on demand; deleting it loses nothing. Frontmatter stays
 minimal: a stable `id`, optional `aliases`, and the `private` / `pinned`
-flags. Edit your notes with any other tool while Reflect runs — the file
+flags. Edit your notes with any other tool while Reflect runs; the file
 watcher picks up external changes and re-indexes.
 
 ## Privacy model
 
-Every network call the app can make — what it carries, where it goes, and
-what's off by default — is documented in
-[**What leaves the device, and when**](docs/privacy.md). The short version:
+Every network call the app can make is documented in
+[**What leaves the device, and when**](docs/privacy.md): what each one
+carries, where it goes, and what's off by default. The short version:
 nothing leaves your machine unless you add a provider key or connect a git
 remote, and `private: true` notes are excluded from anything that reads
 content. Secrets live in the OS keychain only.
@@ -137,9 +137,9 @@ read-only rather than ever being silently rewritten.
 ### The plans
 
 Code and comments reference numbered plans (e.g. "Plan 04b"). These are the
-dependency-ordered design documents in [docs/plans/](docs/plans/) —
+dependency-ordered design documents in [docs/plans/](docs/plans/).
 [00-overview.md](docs/plans/00-overview.md) is the roadmap and records what
-shipped in each release, and
+shipped in each release;
 [architecture-conventions.md](docs/plans/architecture-conventions.md) holds
 the cross-cutting decisions every plan assumes. A comment like "Plan 02"
 points at the design rationale for that subsystem.
@@ -152,7 +152,7 @@ pnpm typecheck        # all packages (tsc)
 pnpm test             # all packages (vitest); --run path/to/test for one file
 pnpm lint             # oxlint
 
-# Rust — stage the CLI sidecar once per checkout first, or tauri-build fails:
+# Rust: stage the CLI sidecar once per checkout first, or tauri-build fails
 pnpm --filter @reflect/desktop sidecar
 cargo test --workspace
 ```
@@ -165,15 +165,17 @@ contributor guide.
 ## Status & roadmap
 
 Reflect is early (`0.1.x`) but used daily. Shipped today: everything listed
-above. Designed but not yet built — each has a written plan:
+above. Designed but not yet built, each with a written plan:
 
-- **Browser link capture** ([Plan 11](docs/plans/11-link-capture.md)) — Chrome
-  extension → local native-messaging bridge → daily note.
-- **Import / export surfaces** ([Plan 13](docs/plans/13-import-export-portability.md)) —
-  the graph is already portable markdown you can copy wholesale; the in-app
-  Obsidian import and Markdown/JSON/HTML export are still to come.
-- **Tasks** ([Plan 18](docs/plans/18-tasks.md)) — GFM checkboxes aggregated
-  into a Tasks view, as a pure projection.
+- **Browser link capture** ([Plan 11](docs/plans/11-link-capture.md)): a
+  Chrome extension that hands the page to the desktop app, which saves it
+  into today's note.
+- **Import / export surfaces**
+  ([Plan 13](docs/plans/13-import-export-portability.md)): the graph is
+  already portable markdown you can copy wholesale; in-app Obsidian import
+  and Markdown/JSON/HTML export are still to come.
+- **Tasks** ([Plan 18](docs/plans/18-tasks.md)): checkboxes in your notes,
+  collected into one Tasks view.
 
 Windows, mobile, and a plugin API are out of scope for now; the
 [product vision](docs/reflect-v2-product-vision.md) explains the long-term
@@ -181,4 +183,4 @@ direction and what is deliberately *not* planned.
 
 ## License
 
-[MIT](LICENSE) — including the editor and every bundled dependency.
+[MIT](LICENSE), including the editor and every bundled dependency.


### PR DESCRIPTION
## What changed

Full rewrite of [README.md](README.md) to open-source standard. The previous README was written for people already inside the project — it led with architecture and the plan system, and had no feature overview, no install instructions, no data-format or privacy sections, and no license section. The end reader is now an outside developer deciding whether to use or contribute to Reflect.

New structure:

- **Pitch + badges** (release / CI / MIT) and a verified feature list — daily notes, wiki links & backlinks, FTS5 + on-device semantic search, BYOK AI chat with citations, `private: true` hard block, audio memos, git backup/sync, the `reflect` CLI, Tauri shell.
- **Install** — points at the signed, notarized `v0.1.0` DMG on GitHub Releases (Apple Silicon), with the updater-verification note from docs/privacy.md.
- **Your notes are just files** — the graph layout, the minimal frontmatter contract (`id`, `aliases`, `private`, `pinned`), and the rebuildable `.reflect/` index.
- **Privacy model** — three-sentence summary linking to [docs/privacy.md](docs/privacy.md).
- **Building from source** + **Development** — prerequisites, the sidecar-staging gotcha external contributors would otherwise hit, and pointers to CONTRIBUTING/docs/contributing/AGENTS.
- **Architecture + plans** — carried over from the old README (its strongest sections), extended with `apps/cli`, `crates/index-schema`, and a paragraph on meowdown and the round-trip protection guard.
- **Status & roadmap** — honest about what's designed but unbuilt (link capture Plan 11, import/export Plan 13, tasks Plan 18), so the README makes no promise the app doesn't keep.
- **License** — MIT.

## Accuracy notes for the reviewer

Every claim was checked against the shipped code or release artifacts: search filter tokens against `filter-query.ts` (`#tag`, `is:daily`, `links:`, `linked-from:`, `updated:`), chat citations against the system prompt and chat-turn rendering, providers against the catalog (OpenAI/Anthropic/Google), the DMG arch against the actual `v0.1.0` assets (`aarch64` only — hence "Apple Silicon"), and the meowdown MIT license against the published 0.3.0 package. The old README's "Full export works from day one" claim is gone — Plan 13 hasn't been built, and the roadmap section now says so plainly.

One thing this PR deliberately doesn't include: a screenshot/hero image — there's no asset in the repo to use. Worth adding one before announcing.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to README.md with no runtime or build impact.
> 
> **Overview**
> **Reframes `README.md` for external developers** — product pitch, badges, feature highlights, install (signed Apple Silicon DMG), on-disk graph layout, privacy summary, and MIT license — instead of leading with internal architecture and plan references.
> 
> **Contributor-facing updates** add build-from-source steps, the CLI **sidecar** staging note for `tauri-build`, pointers to `docs/contributing/`, and a **Status & roadmap** section that drops overstated export claims and lists unbuilt plans (link capture, import/export, tasks). **Architecture** is retained and extended with `apps/cli`, `crates/index-schema`, and **meowdown** round-trip behavior; **Principles** and the old top-level **plans** section are reorganized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb60e47a6d68ca1779b127e3cc71bc5013c1a6c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->