### PR TITLE
Shortcuts: bind ⌘⇧R to audio memo toggle (matches V1)

### DIFF
--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -63,6 +63,10 @@ describe('keybindingFor', () => {
     expect(keybindingFor('theme.toggle')).toBeNull() // a real command, no binding
     expect(keybindingFor('no.such.command')).toBeNull()
   })
+
+  it('audioMemo.toggle is bound to Mod-Shift-r', () => {
+    expect(keybindingFor('audioMemo.toggle')).toBe('Mod-Shift-r')
+  })
 })
 
 describe('app commands', () => {

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -130,9 +130,7 @@ const APP_COMMANDS: AppCommand[] = [
     id: 'audioMemo.toggle',
     title: 'Record audio memo',
     keywords: ['voice', 'mic', 'dictate', 'transcribe', 'speech', 'capture'],
-    // Starts a memo (or stops-and-saves the one recording). No default
-    // keybinding: the palette keeps it keyboard-reachable without spending a
-    // shortcut.
+    keybinding: 'Mod-Shift-r',
     run: (context) => context.toggleAudioMemo(),
   },
   {

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -105,10 +105,13 @@ export function useAppShortcuts(): CommandContext {
       if (paletteOpenRef.current) {
         return // modal palette owns the keyboard; Esc closes, then keys resume
       }
-      if (!isModKey(event) || event.altKey || event.shiftKey || event.repeat) {
+      if (!isModKey(event) || event.altKey || event.repeat) {
         return // held keys must not spam navigations (e.g. a stack of new notes)
       }
-      const id = BINDING_TO_ID.get(`Mod-${event.key.toLowerCase()}`)
+      const bindingKey = event.shiftKey
+        ? `Mod-Shift-${event.key.toLowerCase()}`
+        : `Mod-${event.key.toLowerCase()}`
+      const id = BINDING_TO_ID.get(bindingKey)
       if (shortcutsOpenRef.current) {
         // The cheat-sheet is modal too: nothing may navigate behind it, but
         // the key that opened it closes it again.


### PR DESCRIPTION
## Summary

- Adds `keybinding: 'Mod-Shift-r'` to the `audioMemo.toggle` command, matching the shortcut from Reflect V1
- Updates `app-shortcuts.ts` to support `Mod+Shift` key combos: removes the `shiftKey` bail-out and builds a `Mod-Shift-{key}` lookup string when Shift is held
- The ⌘/ cheat-sheet gains the entry automatically (it derives from command definitions, never hand-listed)

## Test plan

- [ ] `pnpm --filter @reflect/desktop test` — all 661 tests pass, including the new `audioMemo.toggle is bound to Mod-Shift-r` assertion
- [ ] Press ⌘⇧R in the app: starts a recording; press again to stop and save
- [ ] Open ⌘/ cheat-sheet: "Record audio memo" row shows ⌘⇧R
- [ ] Other `Mod-{key}` shortcuts (⌘D, ⌘N, ⌘K, etc.) still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized keyboard-routing change; no auth, data, or API surface touched.
> 
> **Overview**
> Adds **`Mod-Shift-r`** (⌘⇧R) as the default shortcut for **Record audio memo**, aligned with Reflect V1. The command registry entry now owns the binding, so the ⌘/ cheat-sheet picks it up automatically.
> 
> **`app-shortcuts.ts`** no longer ignores all Shift+Mod chords. It builds either `Mod-{key}` or `Mod-Shift-{key}` for lookup in the command keymap, which is what makes the new shortcut fire without changing other Mod-only bindings.
> 
> A unit test asserts `keybindingFor('audioMemo.toggle')` returns `Mod-Shift-r`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f275d3b2f329df34d6ce632b59d578340d6c1d46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->