### PR TITLE
Chat: fix history dropdown collapsing to icon-button width

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ When writing or modifying code in this project, please adhere to the following c
 3.  **Tests as Documentation**: Rely on comprehensive tests (which will be added later if not present) to document the behavior and usage of the code, rather than extensive comments within the code itself.
 4.  **File naming conventions**: Use kebab-case when naming directories, TypeScript, and other files.
 5.  **Type checking**: after major modifications run `pnpm typecheck` and fix any errors.
-6.  **UX/UI** We are using Tailwind CSS, React, shadcn/ui components and Lucide React icons. Generate responsive designs. Provide default props for React Components. Check to see if a shadcn component exists under `components/ui` before installing it.
+6.  **UX/UI** We are using Tailwind CSS, React, shadcn/ui components and Lucide React icons. Generate responsive designs. Provide default props for React Components. **Always check `apps/desktop/src/components/ui/` first before building any custom UI.** For any popup, popover, dropdown, dialog, tooltip, menu, or overlay — use the existing shadcn component from that directory. Never build a custom implementation when a shadcn primitive already exists.
 7.  **Models/db/tables** When pulling in a database type, Kysely.
 8.  **Open-source conventions** Pretend you are writing code for a open-source project. Write best-in-class code.
 
@@ -235,5 +235,5 @@ Non-negotiables:
 # React UI and Styling
 
 - Use Shadcn UI, Radix, and Tailwind Aria for components and styling
-- Prefer using Shadcn components for anything UI related
+- **Always use the shadcn component from `apps/desktop/src/components/ui/` for any interactive or overlay UI** — dropdown menus, popovers, dialogs, tooltips, comboboxes, etc. Never hand-roll these.
 - Implement responsive design with Tailwind CSS to cater for smaller screens.

--- a/apps/desktop/src/components/chat/chat-history-menu.tsx
+++ b/apps/desktop/src/components/chat/chat-history-menu.tsx
@@ -44,7 +44,7 @@ export function ChatHistoryMenu(): ReactElement | null {
           <History aria-hidden />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent aria-label="Chat history" side="top" align="end" sideOffset={6}>
+      <DropdownMenuContent aria-label="Chat history" side="top" align="end" sideOffset={6} className="w-72">
         {conversations === undefined || conversations.length === 0 ? (
           <DropdownMenuItem disabled className="px-2 py-1.5 text-[13px] text-text-muted">
             No past chats
@@ -60,7 +60,7 @@ export function ChatHistoryMenu(): ReactElement | null {
                     void openConversation(conversation.id)
                   }
                 }}
-                className="group/conversation w-64 gap-2 px-2 py-1.5 text-[13px] text-text-secondary"
+                className="group/conversation gap-2 px-2 py-1.5 text-[13px] text-text-secondary"
               >
                 <span className="min-w-0 flex-1 truncate">{conversation.title}</span>
                 <span className="shrink-0 text-xs text-text-muted">


### PR DESCRIPTION
## Summary

- **Bug fix:** `ChatHistoryMenu` was rendering as a ~28px-wide sliver because `DropdownMenuContent` defaults to `w-(--radix-dropdown-menu-trigger-width)` — matching the tiny History icon button — and then clipped all content via `overflow-x-hidden`. Added `className="w-72"` to the content and dropped the now-redundant `w-64` from each item.
- **AGENTS.md:** Strengthened the shadcn guidance in both the Code Conventions and React UI sections to say *always* reach for the existing component in `components/ui` before building any custom overlay UI (dropdowns, popovers, dialogs, tooltips, etc.).

## Root cause

`DropdownMenuContent` in this repo's shadcn build has `w-(--radix-dropdown-menu-trigger-width)` baked into its base classes. That's fine for select/combobox patterns where the trigger shows the selected value, but wrong for icon-button-triggered menus. Child `w-64` classes can't expand a parent that has `overflow-x-hidden`.

## Reviewer notes

No logic changes — purely layout. The `w-72` value gives comfortable room for a title + relative timestamp + delete button in one row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only change in one menu plus documentation; no chat or data logic touched.
> 
> **Overview**
> **Fixes the chat history dropdown** so it no longer collapses to the width of the History icon trigger. `DropdownMenuContent` sets `w-(--radix-dropdown-menu-trigger-width)` and `overflow-x-hidden`, so child `w-64` on items could not widen the panel. The menu content now uses **`className="w-72"`**, and per-item **`w-64`** was removed as redundant.
> 
> **AGENTS.md** now tells agents to **always** use shadcn primitives from `apps/desktop/src/components/ui/` for overlays (dropdowns, popovers, dialogs, tooltips, etc.) instead of custom UI, in both Code Conventions and React UI sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1365003f998d45f64eb0e8a0a77d25f64fc51d78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->