### PR TITLE
Release: next-branch beta flow — prerelease versions publish as GitHub pre-releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    # next is the development default; master only advances on release merges.
+    branches: [master, next]
   pull_request:
   workflow_dispatch:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,12 @@ Drawn from the product docs — read these for deeper context:
 
 ### Development workflow
 
+Development happens on `next` (the default branch); branch from it and target it with
+PRs. `master` is the public-release branch and only advances when `next` is merged
+into it for a stable release. Versions on `next` carry a prerelease suffix
+(`0.2.0-beta.1`), which the release pipeline publishes as GitHub pre-releases — see
+[docs/macos-distribution.md](docs/macos-distribution.md).
+
 1. Make your changes
 2. Run typecheck (`pnpm typecheck`)
 3. Run lint (`pnpm lint`) — fix any errors; `pnpm lint:fix` auto-fixes where possible

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4569,7 +4569,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.1.0"
+version = "0.2.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -437,8 +437,10 @@ function ensureTagMatchesCommit(tag, commit) {
 
 /**
  * Build a signed + notarized DMG and upload it to a new GitHub release tagged
- * v<version> (from tauri.conf.json). All preflight checks run before the
- * build so a doomed publish fails in seconds, not after notarization.
+ * v<version> (from tauri.conf.json). A version with a prerelease segment
+ * (e.g. `0.2.0-beta.1`, the `next`-branch convention) publishes as a GitHub
+ * pre-release. All preflight checks run before the build so a doomed publish
+ * fails in seconds, not after notarization.
  */
 function publish({ draft }) {
   ensureGhReady()
@@ -452,7 +454,10 @@ function publish({ draft }) {
 
   const { dmg, updaterArchive, updaterSignature } = bundlePaths()
   const manifestPath = writeUpdaterManifest({ version, tag })
-  log(`creating GitHub release ${tag} from commit ${commit.slice(0, 7)}…`)
+  // Pre-releases are invisible to `releases/latest` — the committed updater
+  // endpoint — so installed stable apps never see a beta.
+  const prerelease = version.includes('-')
+  log(`creating GitHub ${prerelease ? 'pre-release' : 'release'} ${tag} from commit ${commit.slice(0, 7)}…`)
   const releaseArgs = [
     'release',
     'create',
@@ -467,6 +472,7 @@ function publish({ draft }) {
     commit,
     '--generate-notes',
   ]
+  if (prerelease) releaseArgs.push('--prerelease')
   if (draft) releaseArgs.push('--draft')
   const result = spawnSync('gh', releaseArgs, { encoding: 'utf8', stdio: ['inherit', 'pipe', 'inherit'] })
   if (result.status !== 0) fail(`creating the GitHub release failed${result.stdout ? `\n${result.stdout.trim()}` : ''}`)

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.1.0"
+version = "0.2.0-beta.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.1.0",
+  "version": "0.2.0-beta.1",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -98,6 +98,23 @@ than after notarization:
 Pass `--draft` to create the release without publishing it, then review and publish it
 from the GitHub UI.
 
+## Beta releases
+
+Development happens on `next` (the repo default branch); `master` only advances when
+`next` is merged into it for a public release. On `next`, `version` in
+`tauri.conf.json` carries a prerelease suffix (e.g. `0.2.0-beta.1`), and `publish`
+turns that suffix into a GitHub **pre-release** automatically. `releases/latest` — the
+committed updater endpoint — ignores pre-releases, so stable installs never see a
+beta.
+
+Beta installs poll that same stable endpoint: they get offered the next stable release
+when it ships, but not newer betas. A dedicated beta updater channel is future work.
+
+Cutting a beta is the normal release flow on `next`: bump the prerelease version
+(`0.2.0-beta.2`, …) in `tauri.conf.json` + `src-tauri/Cargo.toml`, then run the
+Release workflow on `next`. For a stable release, merge `next` into `master`, set a
+stable version there (e.g. `0.2.0`), and run the workflow on `master`.
+
 ## Releasing from CI
 
 `.github/workflows/release.yml` runs `pnpm release:macos publish` on a GitHub-hosted


### PR DESCRIPTION
## Summary

Moves development to `next` and makes releases cut from it beta releases.

Repo settings already changed (this PR is the code half): `next` was created from master and is now the **GitHub default branch**.

- **`release-macos.mjs`**: a version with a prerelease segment (`0.2.0-beta.1`) now publishes with `--prerelease`. This is the piece that protects stable users: the committed updater endpoint is `releases/latest/download/latest.json`, and GitHub points `releases/latest` only at full releases — so a beta never becomes what installed apps see. Stable releases are unchanged.
- **Version bumped to `0.2.0-beta.1`** (`tauri.conf.json`, `src-tauri/Cargo.toml`, lockfile) so `next` is immediately beta-releasable.
- **`ci.yml`** also runs on pushes to `next`.
- **Docs**: branch model in AGENTS.md; a "Beta releases" section in docs/macos-distribution.md.

## Release flows

- **Beta**: bump the prerelease version on `next`, run the Release workflow on `next`. Tagged `v0.2.0-beta.1`, marked Pre-release.
- **Stable**: merge `next` into `master`, set the stable version there, run the workflow on `master`.

The release workflow itself needed no changes — the branch you dispatch it on decides what gets built, and the version string decides stable vs pre-release.

## Known limitation

Beta installs poll the same stable endpoint, so they're offered the next *stable* release but not newer betas (semver: an installed `0.2.0-beta.1` is newer than the published `0.1.0` manifest, and `0.2.0` will be offered when it ships). A dedicated beta updater channel (e.g. a rolling `beta` release as a second endpoint) is future work, noted in the docs.

## Testing

- `pnpm check` passes; `node --check` on the script; CI YAML parses.
- The prerelease path gets its first real exercise on the next beta release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release and CI branching docs only; runtime updater behavior for stable users is unchanged because pre-releases are excluded from releases/latest.
> 
> **Overview**
> Documents **`next` as the development default** and **`master` for stable releases**, and wires CI to run on pushes to **`next`** as well as **`master`**.
> 
> **`release-macos.mjs`** now treats a **prerelease segment in the version** (e.g. `0.2.0-beta.1`) as a signal to create a GitHub **pre-release** (`--prerelease`), so betas do not become `releases/latest` and stable auto-update clients keep polling the same endpoint unchanged.
> 
> **App version is set to `0.2.0-beta.1`** in `tauri.conf.json`, `src-tauri/Cargo.toml`, and the lockfile so `next` can ship betas immediately. **AGENTS.md** and **docs/macos-distribution.md** add the beta/stable release flows and note that beta installs still use the stable updater channel (no dedicated beta channel yet).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1920f7ff64f6585b671d29181676a6b51b74758c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->