### PR TITLE
Chat: remember the last-used model across sessions

### DIFF
--- a/apps/desktop/src/components/chat/chat-screen.test.tsx
+++ b/apps/desktop/src/components/chat/chat-screen.test.tsx
@@ -6,11 +6,13 @@ import type { ReactElement } from 'react'
 import {
   cloudSafeGraphContext,
   type AiProviderConfig,
+  type ChatModelSelection,
   type ChatStreamEvent,
   type CloudGraphContext,
   type CloudSafe,
   type GraphContextDeps,
   type GraphInfo,
+  type Settings,
   type StreamChatOptions,
 } from '@reflect/core'
 import { ChatProvider, useChatSession } from '@/providers/chat-provider'
@@ -43,13 +45,30 @@ vi.mock('@reflect/core', async (importOriginal) => ({
 const settingsState = vi.hoisted(() => ({
   models: [] as AiProviderConfig[],
   defaultId: null as string | null,
+  selection: null as ChatModelSelection | null,
 }))
-vi.mock('@/providers/settings-provider', () => ({
-  useSettings: () => ({
-    settings: { aiProviders: settingsState.models, defaultAiProviderId: settingsState.defaultId },
-    updateSettings: () => {},
-  }),
-}))
+// Stateful like the real provider: a chatModelSelection patch re-renders with
+// the new value, so picking a model in the UI applies instantly here too.
+vi.mock('@/providers/settings-provider', async () => {
+  const { useState } = await import('react')
+  return {
+    useSettings: () => {
+      const [selection, setSelection] = useState(settingsState.selection)
+      return {
+        settings: {
+          aiProviders: settingsState.models,
+          defaultAiProviderId: settingsState.defaultId,
+          chatModelSelection: selection,
+        },
+        updateSettings: (patch: Partial<Settings>) => {
+          if (patch.chatModelSelection !== undefined) {
+            setSelection(patch.chatModelSelection)
+          }
+        },
+      }
+    },
+  }
+})
 
 // No open index → the provider's persistence layer stays inert; these tests
 // cover the screen, chat-provider.test.tsx covers persistence.
@@ -89,6 +108,7 @@ const GRAPH_CONTEXT = cloudSafeGraphContext({
 beforeEach(() => {
   settingsState.models = []
   settingsState.defaultId = null
+  settingsState.selection = null
   streamChat.mockReset()
   getSecret.mockReset().mockResolvedValue('sk-test')
   loadChatGraphContext.mockReset().mockResolvedValue(GRAPH_CONTEXT)
@@ -210,6 +230,17 @@ describe('ChatScreen', () => {
     await waitFor(() => expect(streamChat).toHaveBeenCalledTimes(1))
     // Same entry (id → keychain key), with the picked model applied.
     expect(streamChat.mock.lastCall?.[0].config).toEqual({ ...MODEL, model: 'gpt-5.5' })
+  })
+
+  it('starts the picker on the model persisted from the last session', async () => {
+    configureModel()
+    settingsState.selection = { configId: 'm1', modelId: 'gpt-5.5' }
+    const view = renderChat()
+
+    fireEvent.keyDown(view.getByRole('combobox', { name: 'Model' }), { key: 'ArrowDown' })
+
+    const picked = await screen.findByRole('option', { name: 'GPT-5.5' })
+    expect(picked.getAttribute('aria-selected')).toBe('true')
   })
 
   it('sends the graph overview context with each turn', async () => {

--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -126,6 +126,7 @@ describe('SettingsScreen', () => {
           graphColors: {},
           aiProviders: [],
           defaultAiProviderId: null,
+          chatModelSelection: null,
         },
       ]),
     )
@@ -163,6 +164,7 @@ describe('SettingsScreen', () => {
           graphColors: {},
           aiProviders: [],
           defaultAiProviderId: null,
+          chatModelSelection: null,
         },
       ]),
     )
@@ -190,6 +192,7 @@ describe('SettingsScreen', () => {
           graphColors: {},
           aiProviders: [],
           defaultAiProviderId: null,
+          chatModelSelection: null,
         },
       ]),
     )
@@ -230,6 +233,7 @@ describe('SettingsScreen', () => {
           graphColors: {},
           aiProviders: [],
           defaultAiProviderId: null,
+          chatModelSelection: null,
         },
       ]),
     )
@@ -266,6 +270,7 @@ describe('SettingsScreen', () => {
           graphColors: {},
           aiProviders: [],
           defaultAiProviderId: null,
+          chatModelSelection: null,
         },
       ]),
     )
@@ -293,6 +298,7 @@ describe('SettingsScreen', () => {
           graphColors: {},
           aiProviders: [],
           defaultAiProviderId: null,
+          chatModelSelection: null,
         },
       ]),
     )
@@ -352,6 +358,7 @@ describe('SettingsScreen', () => {
           graphColors: {},
           aiProviders: [],
           defaultAiProviderId: null,
+          chatModelSelection: null,
         },
       ]),
     )
@@ -365,7 +372,7 @@ describe('SettingsScreen', () => {
 
     await waitFor(() =>
       expect(saved).toEqual([
-        { editorMarkdownSyntax: 'focus', editorSpellCheck: true, semanticSearchEnabled: true, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], graphColors: {}, aiProviders: [], defaultAiProviderId: null },
+        { editorMarkdownSyntax: 'focus', editorSpellCheck: true, semanticSearchEnabled: true, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], graphColors: {}, aiProviders: [], defaultAiProviderId: null, chatModelSelection: null },
       ]),
     )
     // The control flips to the loading state (EmbeddingsSync owns the actual
@@ -394,7 +401,7 @@ describe('SettingsScreen', () => {
 
     await waitFor(() =>
       expect(saved).toEqual([
-        { editorMarkdownSyntax: 'focus', editorSpellCheck: true, semanticSearchEnabled: false, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], graphColors: {}, aiProviders: [], defaultAiProviderId: null },
+        { editorMarkdownSyntax: 'focus', editorSpellCheck: true, semanticSearchEnabled: false, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], graphColors: {}, aiProviders: [], defaultAiProviderId: null, chatModelSelection: null },
       ]),
     )
     expect(screen.getByRole('button', { name: /enable semantic search/i })).toBeTruthy()
@@ -417,7 +424,7 @@ describe('SettingsScreen', () => {
     await waitFor(() => expect(invoked).toContain('embed_ensure'))
     await waitFor(() =>
       expect(saved).toEqual([
-        { editorMarkdownSyntax: 'focus', editorSpellCheck: true, semanticSearchEnabled: true, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], graphColors: {}, aiProviders: [], defaultAiProviderId: null },
+        { editorMarkdownSyntax: 'focus', editorSpellCheck: true, semanticSearchEnabled: true, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], graphColors: {}, aiProviders: [], defaultAiProviderId: null, chatModelSelection: null },
       ]),
     )
   })
@@ -436,7 +443,7 @@ describe('SettingsScreen', () => {
 
     await waitFor(() =>
       expect(saved).toEqual([
-        { editorMarkdownSyntax: 'focus', editorSpellCheck: true, semanticSearchEnabled: false, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], graphColors: {}, aiProviders: [], defaultAiProviderId: null },
+        { editorMarkdownSyntax: 'focus', editorSpellCheck: true, semanticSearchEnabled: false, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], graphColors: {}, aiProviders: [], defaultAiProviderId: null, chatModelSelection: null },
       ]),
     )
     expect(screen.getByRole('button', { name: /enable semantic search/i })).toBeTruthy()

--- a/apps/desktop/src/providers/chat-provider.test.tsx
+++ b/apps/desktop/src/providers/chat-provider.test.tsx
@@ -4,9 +4,11 @@ import type { ReactElement } from 'react'
 import type {
   AiProviderConfig,
   ChatConversation,
+  ChatModelSelection,
   ChatStreamEvent,
   ChatTurn,
   GraphInfo,
+  Settings,
   StreamChatOptions,
 } from '@reflect/core'
 import { ChatProvider, useChatSession } from '@/providers/chat-provider'
@@ -37,13 +39,32 @@ vi.mock('@reflect/core', async (importOriginal) => ({
 const settingsState = vi.hoisted(() => ({
   models: [] as AiProviderConfig[],
   defaultId: null as string | null,
+  selection: null as ChatModelSelection | null,
 }))
-vi.mock('@/providers/settings-provider', () => ({
-  useSettings: () => ({
-    settings: { aiProviders: settingsState.models, defaultAiProviderId: settingsState.defaultId },
-    updateSettings: () => {},
-  }),
-}))
+const updateSettings = vi.hoisted(() => vi.fn<(patch: Partial<Settings>) => void>())
+// Stateful like the real provider: a chatModelSelection patch re-renders with
+// the new value, so selectModel applies instantly here too.
+vi.mock('@/providers/settings-provider', async () => {
+  const { useState } = await import('react')
+  return {
+    useSettings: () => {
+      const [selection, setSelection] = useState(settingsState.selection)
+      return {
+        settings: {
+          aiProviders: settingsState.models,
+          defaultAiProviderId: settingsState.defaultId,
+          chatModelSelection: selection,
+        },
+        updateSettings: (patch: Partial<Settings>) => {
+          updateSettings(patch)
+          if (patch.chatModelSelection !== undefined) {
+            setSelection(patch.chatModelSelection)
+          }
+        },
+      }
+    },
+  }
+})
 
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({ indexGeneration: 7, graph: { root: '/g' } }),
@@ -98,6 +119,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   settingsState.models = [MODEL]
   settingsState.defaultId = 'm1'
+  settingsState.selection = null
   core.hasBridge.mockReturnValue(true)
   core.getSecret.mockResolvedValue('sk-test')
   core.loadChatGraphContext.mockResolvedValue(null)
@@ -293,5 +315,36 @@ describe('ChatProvider persistence', () => {
       await deleteDone
     })
     expect(core.deleteChatConversation).toHaveBeenCalledWith(sentInto.conversation.id, 7)
+  })
+})
+
+describe('ChatProvider model selection', () => {
+  it('starts on the persisted model selection', async () => {
+    settingsState.selection = { configId: 'm1', modelId: 'gpt-5.5' }
+    renderProvider()
+    await waitFor(() => expect(core.listChatConversations).toHaveBeenCalled())
+
+    expect(session?.activeModel).toEqual({ ...MODEL, model: 'gpt-5.5' })
+  })
+
+  it('persists a picked model and applies it to the session', async () => {
+    renderProvider()
+    await waitFor(() => expect(core.listChatConversations).toHaveBeenCalled())
+    expect(session?.activeModel).toEqual(MODEL)
+
+    act(() => session?.selectModel({ configId: 'm1', modelId: 'gpt-5.5' }))
+
+    expect(updateSettings).toHaveBeenCalledWith({
+      chatModelSelection: { configId: 'm1', modelId: 'gpt-5.5' },
+    })
+    expect(session?.activeModel).toEqual({ ...MODEL, model: 'gpt-5.5' })
+  })
+
+  it('falls back to the default model when the persisted selection dangles', async () => {
+    settingsState.selection = { configId: 'gone', modelId: 'gpt-5.5' }
+    renderProvider()
+    await waitFor(() => expect(core.listChatConversations).toHaveBeenCalled())
+
+    expect(session?.activeModel).toEqual(MODEL)
   })
 })

--- a/apps/desktop/src/providers/chat-provider.tsx
+++ b/apps/desktop/src/providers/chat-provider.tsx
@@ -73,10 +73,14 @@ interface ChatContextValue {
   modelOptions: ChatModelOption[]
   /**
    * The provider entry + model the next turn calls (`model` already carries
-   * the session's choice) — session override or the settings default.
+   * the picker's choice) — the persisted last pick or the settings default.
    */
   activeModel: AiProviderConfig | null
-  /** Override the session's model (null returns to the settings default). */
+  /**
+   * Pick the chat model. Persisted (`chatModelSelection` in the settings
+   * document), so later sessions start on it; null returns to the app
+   * default.
+   */
   selectModel: (selection: ChatModelSelection | null) => void
   /** Images queued for the next message (dropped or pasted onto the chat). */
   attachments: ChatAttachment[]
@@ -116,20 +120,21 @@ interface ChatProviderProps {
 }
 
 export function ChatProvider({ graph, children }: ChatProviderProps): ReactElement {
-  const { settings } = useSettings()
+  const { settings, updateSettings } = useSettings()
   const { indexGeneration } = useGraph()
   const [turns, setTurns] = useState<ChatTurn[]>([])
   const [attachments, setAttachments] = useState<ChatAttachment[]>([])
-  const [selection, setSelection] = useState<ChatModelSelection | null>(null)
   const [conversationId, setConversationId] = useState<string>(() => crypto.randomUUID())
 
   const status: ChatStatus = turns.at(-1)?.status === 'streaming' ? 'streaming' : 'idle'
 
   const providers = settings.aiProviders
   const modelOptions = useMemo(() => chatModelOptions(providers), [providers])
+  // The picker's choice lives in the settings document, not session state, so
+  // the model used last is the one the next session starts on.
   const activeModel = resolveChatModel(
     { providers, defaultProviderId: settings.defaultAiProviderId },
-    selection,
+    settings.chatModelSelection,
   )
 
   // Read at call time, not captured: send() can fire long after the render
@@ -421,9 +426,12 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
     [newChat],
   )
 
-  const selectModel = useCallback((next: ChatModelSelection | null) => {
-    setSelection(next)
-  }, [])
+  const selectModel = useCallback(
+    (next: ChatModelSelection | null) => {
+      updateSettings({ chatModelSelection: next })
+    },
+    [updateSettings],
+  )
 
   const attachImages = useCallback(async (files: File[]): Promise<void> => {
     // Reading files is async: a drop still in flight when New chat clears

--- a/apps/desktop/src/providers/settings-provider.test.tsx
+++ b/apps/desktop/src/providers/settings-provider.test.tsx
@@ -139,6 +139,7 @@ describe('SettingsProvider', () => {
           graphColors: {},
           aiProviders: [],
           defaultAiProviderId: null,
+          chatModelSelection: null,
         },
       ]),
     )
@@ -193,6 +194,7 @@ describe('SettingsProvider', () => {
           graphColors: {},
           aiProviders: [],
           defaultAiProviderId: null,
+          chatModelSelection: null,
           futureKey: true,
         },
       ]),
@@ -232,6 +234,7 @@ describe('SettingsProvider', () => {
           graphColors: {},
           aiProviders: [],
           defaultAiProviderId: null,
+          chatModelSelection: null,
           futureKey: true,
         },
       ]),
@@ -265,6 +268,7 @@ describe('SettingsProvider', () => {
           graphColors: {},
           aiProviders: [],
           defaultAiProviderId: null,
+          chatModelSelection: null,
         },
       ]),
     )
@@ -424,6 +428,7 @@ describe('SettingsProvider', () => {
           graphColors: {},
           aiProviders: [],
           defaultAiProviderId: null,
+          chatModelSelection: null,
         },
       ]),
     )
@@ -460,6 +465,7 @@ describe('SettingsProvider', () => {
         graphColors: {},
         aiProviders: [],
         defaultAiProviderId: null,
+        chatModelSelection: null,
       },
     ])
   })

--- a/packages/core/src/ai/chat/model-options.ts
+++ b/packages/core/src/ai/chat/model-options.ts
@@ -1,12 +1,13 @@
-import type { AiProviderConfig, AiProviderId } from '../../settings/schema'
+import type { AiProviderConfig, AiProviderId, ChatModelSelection } from '../../settings/schema'
 import { aiProvider } from '../provider-catalog'
 import { defaultAiProvider, type AiProvidersState } from '../provider-config'
 
 /**
  * The chat screen's model picker (Plan 10): every configured provider offers
  * its full curated model list, not just the entry's default model. These are
- * pure derivations over the configured-provider state — the session's choice
- * itself lives in the chat provider and is never persisted.
+ * pure derivations over the configured-provider state — the choice itself is
+ * the `chatModelSelection` settings key, persisted so the next session starts
+ * on the model the user picked last.
  */
 
 /** One pick in the chat model picker: a configured provider entry + model. */
@@ -20,11 +21,7 @@ export interface ChatModelOption {
   label: string
 }
 
-/** A session's model choice — references a {@link ChatModelOption}. */
-export interface ChatModelSelection {
-  configId: string
-  modelId: string
-}
+export type { ChatModelSelection }
 
 /**
  * Every model the chat picker offers, grouped consecutively per configured

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -102,6 +102,7 @@ export {
   aiProviderConfigSchema,
   aiProvidersSchema,
   defaultAiProviderIdSchema,
+  chatModelSelectionSchema,
   DEFAULT_SETTINGS,
   type Settings,
   type EditorMarkdownSyntax,

--- a/packages/core/src/settings/schema.test.ts
+++ b/packages/core/src/settings/schema.test.ts
@@ -15,6 +15,7 @@ describe('settingsSchema', () => {
       graphColors: {},
       aiProviders: [],
       defaultAiProviderId: null,
+      chatModelSelection: null,
     })
     expect(DEFAULT_SETTINGS.editorMarkdownSyntax).toBe('focus')
     expect(DEFAULT_SETTINGS.editorSpellCheck).toBe(true)
@@ -27,6 +28,7 @@ describe('settingsSchema', () => {
     expect(DEFAULT_SETTINGS.graphColors).toEqual({})
     expect(DEFAULT_SETTINGS.aiProviders).toEqual([])
     expect(DEFAULT_SETTINGS.defaultAiProviderId).toBeNull()
+    expect(DEFAULT_SETTINGS.chatModelSelection).toBeNull()
   })
 
   it('accepts valid values', () => {
@@ -92,6 +94,7 @@ describe('settingsSchema', () => {
       graphColors: {},
       aiProviders: [],
       defaultAiProviderId: null,
+      chatModelSelection: null,
       futureKey: true,
     })
   })
@@ -152,6 +155,27 @@ describe('settingsSchema', () => {
       expect(settingsSchema.parse({ defaultAiProviderId: 'abc' }).defaultAiProviderId).toBe('abc')
       expect(settingsSchema.parse({ defaultAiProviderId: null }).defaultAiProviderId).toBeNull()
       expect(settingsSchema.parse({ defaultAiProviderId: 42 }).defaultAiProviderId).toBeNull()
+    })
+  })
+
+  describe('chatModelSelection', () => {
+    it('passes a valid selection through', () => {
+      const selection = { configId: 'abc', modelId: 'claude-opus-4-8' }
+      expect(settingsSchema.parse({ chatModelSelection: selection }).chatModelSelection).toEqual(
+        selection,
+      )
+      expect(settingsSchema.parse({ chatModelSelection: null }).chatModelSelection).toBeNull()
+    })
+
+    it('degrades an invalid value to null', () => {
+      expect(settingsSchema.parse({ chatModelSelection: 'gpt-5.5' }).chatModelSelection).toBeNull()
+      expect(
+        settingsSchema.parse({ chatModelSelection: { configId: 'abc' } }).chatModelSelection,
+      ).toBeNull()
+      expect(
+        settingsSchema.parse({ chatModelSelection: { configId: '', modelId: 'gpt-5.5' } })
+          .chatModelSelection,
+      ).toBeNull()
     })
   })
 })

--- a/packages/core/src/settings/schema.ts
+++ b/packages/core/src/settings/schema.ts
@@ -161,6 +161,26 @@ export type AiProviderConfig = z.infer<typeof aiProviderConfigSchema>
 export const defaultAiProviderIdSchema = z.string().nullable().catch(null)
 
 /**
+ * The model the chat last used: a configured `aiProviders` entry (`configId`)
+ * plus a model id within it. Persisted so the next chat session starts on
+ * whatever the user picked last; null (the default) means the app default
+ * entry and its configured model. A dangling reference is legal (the entry
+ * may have been removed since) — readers resolve it through
+ * `resolveChatModel`, which falls back to the default entry — and an invalid
+ * value degrades to null.
+ */
+export const chatModelSelectionSchema = z
+  .object({
+    configId: z.string().min(1),
+    modelId: z.string().min(1),
+  })
+  .nullable()
+  .catch(null)
+
+/** A chat model choice — a configured provider entry + a model within it. */
+export type ChatModelSelection = NonNullable<z.infer<typeof chatModelSelectionSchema>>
+
+/**
  * The configured AI providers. Resilience is per entry, not per list: a
  * corrupt entry is dropped while the rest load, so one bad hand-edit can't
  * wipe every configured provider. A non-array value degrades to the empty
@@ -189,6 +209,7 @@ export const settingsSchema = z
     graphColors: graphColorsSchema,
     aiProviders: aiProvidersSchema,
     defaultAiProviderId: defaultAiProviderIdSchema,
+    chatModelSelection: chatModelSelectionSchema,
   })
   .passthrough()
 


### PR DESCRIPTION
## What

Switching the AI model in the chat composer now persists the choice, and later sessions default to whatever was used last.

## Why

The picker's selection lived in transient React state inside `ChatProvider`, so every relaunch (or graph switch, which remounts the provider) snapped back to the settings default.

## How

- **`chatModelSelection` settings key** (`packages/core/src/settings/schema.ts`): `{ configId, modelId } | null`, defaulting to and degrading invalid values to `null`, alongside `defaultAiProviderId`. The `ChatModelSelection` type moved here since it's now a persisted shape; `model-options.ts` re-exports it for its existing consumers.
- **`ChatProvider`** derives `activeModel` from `settings.chatModelSelection` instead of local state, and `selectModel` writes through `updateSettings` — applied instantly via the settings provider's overrides, persisted async.
- A dangling persisted selection (the provider entry was removed) already falls back to the default entry via `resolveChatModel`, so no migration or cleanup is needed.

## Notes for review

- The selection is app-wide, not per-graph — it sits next to `defaultAiProviderId` rather than in a per-graph record like `graphColors`.
- The settings mocks in the chat tests became stateful (a `chatModelSelection` patch re-renders), mirroring the real provider's instant-apply so the existing pick-then-send test keeps passing; the new key also ripples into the full-document assertions in the settings provider/screen tests.
- New tests: schema valid/invalid/default cases; provider starts on the persisted pick, persists a new pick, and falls back when the selection dangles; the screen's picker opens with the persisted model selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-preference persistence with schema validation and existing fallback resolution; no auth or data-migration changes.
> 
> **Overview**
> **Chat model choice is now persisted in settings** instead of ephemeral `ChatProvider` state, so relaunches and graph remounts keep the last picker selection.
> 
> Adds **`chatModelSelection`** (`{ configId, modelId } | null`) to the settings schema with the same degrade-to-null resilience as other keys; **`ChatModelSelection`** moves from `model-options.ts` into the schema (re-exported for existing imports). **`ChatProvider`** derives `activeModel` from `settings.chatModelSelection` and **`selectModel`** writes via `updateSettings`. Invalid or removed provider entries still fall back through existing **`resolveChatModel`** logic.
> 
> Tests gain stateful settings mocks, full-document expectations including the new key, and coverage for persisted picker state, `selectModel` persistence, and dangling selections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fe0284d0b97593a75424003fbedc8527f4d7908. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->