### PR TITLE
Menu: native macOS app menu derived from the command registry

### DIFF
--- a/apps/desktop/src/lib/native-menu/accelerator.test.ts
+++ b/apps/desktop/src/lib/native-menu/accelerator.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { bindingToAccelerator } from './accelerator'
+
+describe('bindingToAccelerator', () => {
+  it('maps Mod to the platform-resolving CmdOrCtrl', () => {
+    expect(bindingToAccelerator('Mod-d')).toBe('CmdOrCtrl+D')
+    expect(bindingToAccelerator('Mod-Shift-p')).toBe('CmdOrCtrl+Shift+P')
+    expect(bindingToAccelerator('Ctrl-Alt-x')).toBe('Ctrl+Alt+X')
+  })
+
+  it('keeps punctuation keys verbatim — muda parses the literal characters', () => {
+    expect(bindingToAccelerator('Mod-[')).toBe('CmdOrCtrl+[')
+    expect(bindingToAccelerator('Mod-]')).toBe('CmdOrCtrl+]')
+    expect(bindingToAccelerator('Mod-\\')).toBe('CmdOrCtrl+\\')
+    expect(bindingToAccelerator('Mod-,')).toBe('CmdOrCtrl+,')
+    expect(bindingToAccelerator('Mod-/')).toBe('CmdOrCtrl+/')
+  })
+
+  it('treats a trailing dash as the literal "-" key, not a separator', () => {
+    expect(bindingToAccelerator('Mod--')).toBe('CmdOrCtrl+-')
+  })
+
+  it('passes named keys through for muda to parse', () => {
+    expect(bindingToAccelerator('Mod-Enter')).toBe('CmdOrCtrl+Enter')
+  })
+})

--- a/apps/desktop/src/lib/native-menu/accelerator.ts
+++ b/apps/desktop/src/lib/native-menu/accelerator.ts
@@ -1,0 +1,35 @@
+/**
+ * Converts a keymap-registry binding (`Mod-d`, `Mod-\`, …) into the
+ * accelerator string Tauri's menu layer (muda) parses — `CmdOrCtrl+D`,
+ * `CmdOrCtrl+\`. Same binding grammar as `lib/keybindings.ts`: ProseMirror
+ * style, parts joined by `-`, a trailing `-` meaning the literal `-` key.
+ *
+ * muda accepts single letters and punctuation verbatim (`[`, `]`, `\`, `,`,
+ * `/`) plus named keys like `Enter`, so the key part passes through; only the
+ * modifiers need translating.
+ */
+
+const ACCELERATOR_MODIFIERS: Record<string, string> = {
+  mod: 'CmdOrCtrl',
+  meta: 'Cmd',
+  shift: 'Shift',
+  alt: 'Alt',
+  ctrl: 'Ctrl',
+}
+
+/** The muda accelerator string for a keymap-registry binding. */
+export function bindingToAccelerator(binding: string): string {
+  const parts = binding.endsWith('-')
+    ? [...binding.slice(0, -1).split('-').filter(Boolean), '-']
+    : binding.split('-')
+
+  return parts
+    .map((part, index) => {
+      const lower = part.toLowerCase()
+      if (index < parts.length - 1 && lower in ACCELERATOR_MODIFIERS) {
+        return ACCELERATOR_MODIFIERS[lower]
+      }
+      return part.length === 1 ? part.toUpperCase() : part
+    })
+    .join('+')
+}

--- a/apps/desktop/src/lib/native-menu/dispatch.ts
+++ b/apps/desktop/src/lib/native-menu/dispatch.ts
@@ -1,0 +1,24 @@
+/**
+ * Native menu → command registry hand-off. The menu is built once at startup,
+ * before React mounts, so item activations land here and are forwarded to
+ * whichever mounted workspace currently owns the {@link import('@/lib/commands/types').CommandContext}.
+ *
+ * `useAppShortcuts` publishes its dispatcher on mount and clears it on
+ * unmount. While no dispatcher is set (the moments before first mount, or
+ * screens without a workspace) menu items are inert — there is nothing for a
+ * command to act on, which is the same answer the keydown path gives there.
+ */
+
+type MenuCommandDispatch = (commandId: string) => void
+
+let current: MenuCommandDispatch | null = null
+
+/** Publish (or with `null`, withdraw) the active menu-command dispatcher. */
+export function setMenuCommandDispatch(dispatch: MenuCommandDispatch | null): void {
+  current = dispatch
+}
+
+/** Forward a native menu activation to the active dispatcher, if any. */
+export function dispatchMenuCommand(commandId: string): void {
+  current?.(commandId)
+}

--- a/apps/desktop/src/lib/native-menu/menu.test.ts
+++ b/apps/desktop/src/lib/native-menu/menu.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { APP_COMMANDS } from '@/lib/commands/app-commands'
+import { appMenuLayout } from './menu'
+
+function referencedCommandIds(): string[] {
+  return appMenuLayout().flatMap((submenu) =>
+    submenu.entries.flatMap((entry) => (entry.kind === 'command' ? [entry.commandId] : [])),
+  )
+}
+
+describe('appMenuLayout', () => {
+  it('references only registered command ids', () => {
+    const known = new Set(APP_COMMANDS.map((appCommand) => appCommand.id))
+    const referenced = referencedCommandIds()
+    expect(referenced.length).toBeGreaterThan(0)
+    for (const commandId of referenced) {
+      expect(known).toContain(commandId)
+    }
+  })
+
+  it('surfaces every ported V1 menu shortcut', () => {
+    const referenced = new Set(referencedCommandIds())
+    // The V1 Electron menu items that have a V2 command: Preferences ⌘,
+    // New Note ⌘N, Search ⌘K, Select Daily Note ⌘D, Back ⌘[, Forward ⌘],
+    // Open Shortcuts ⌘/.
+    for (const commandId of [
+      'settings.open',
+      'note.new',
+      'palette.open',
+      'nav.today',
+      'history.back',
+      'history.forward',
+      'shortcuts.show',
+    ]) {
+      expect(referenced).toContain(commandId)
+    }
+  })
+
+  it('lists each command at most once across the whole menu', () => {
+    const referenced = referencedCommandIds()
+    expect(new Set(referenced).size).toBe(referenced.length)
+  })
+})

--- a/apps/desktop/src/lib/native-menu/menu.ts
+++ b/apps/desktop/src/lib/native-menu/menu.ts
@@ -1,0 +1,186 @@
+import { isTauri } from '@tauri-apps/api/core'
+import {
+  Menu,
+  Submenu,
+  type MenuItemOptions,
+  type PredefinedMenuItemOptions,
+} from '@tauri-apps/api/menu'
+import { APP_COMMANDS } from '@/lib/commands/app-commands'
+import { bindingToAccelerator } from './accelerator'
+import { dispatchMenuCommand } from './dispatch'
+
+/**
+ * The native macOS application menu (the V1 Electron menu, ported). Command
+ * items derive from {@link APP_COMMANDS} — id, label, and accelerator come
+ * from the one command definition, the same source the ⌘K palette and the ⌘/
+ * cheat-sheet read — so the menu cannot drift from the bindings that fire.
+ * Everything else is a predefined (native role) item.
+ *
+ * Activations route through `dispatchMenuCommand` into the same guarded
+ * dispatch `useAppShortcuts` runs keydown bindings through, so menu clicks
+ * respect the modal palette/cheat-sheet exactly like keystrokes do.
+ */
+
+type PredefinedItem = PredefinedMenuItemOptions['item']
+
+export type AppMenuEntry =
+  | { kind: 'command'; commandId: string; text?: string }
+  | { kind: 'predefined'; item: PredefinedItem; text?: string }
+
+export interface AppSubmenuLayout {
+  text: string
+  /**
+   * macOS NSApp role: `windows` gains the automatic window list,
+   * `help` gains the Search field.
+   */
+  nsAppRole?: 'windows' | 'help'
+  entries: AppMenuEntry[]
+}
+
+function command(commandId: string, text?: string): AppMenuEntry {
+  return { kind: 'command', commandId, text }
+}
+
+function predefined(item: PredefinedItem, text?: string): AppMenuEntry {
+  return { kind: 'predefined', item, text }
+}
+
+function separator(): AppMenuEntry {
+  return predefined('Separator')
+}
+
+/**
+ * The menu structure, as pure data so tests can hold it against the command
+ * registry. macOS replaces the first submenu's title with the app name.
+ */
+export function appMenuLayout(): AppSubmenuLayout[] {
+  return [
+    {
+      text: 'Reflect',
+      entries: [
+        predefined({ About: null }, 'About Reflect'),
+        separator(),
+        command('settings.open', 'Settings…'),
+        separator(),
+        predefined('Services'),
+        separator(),
+        predefined('Hide', 'Hide Reflect'),
+        predefined('HideOthers'),
+        predefined('ShowAll'),
+        separator(),
+        predefined('Quit', 'Quit Reflect'),
+      ],
+    },
+    {
+      text: 'File',
+      entries: [command('note.new'), separator(), predefined('CloseWindow')],
+    },
+    {
+      text: 'Edit',
+      entries: [
+        predefined('Undo'),
+        predefined('Redo'),
+        separator(),
+        predefined('Cut'),
+        predefined('Copy'),
+        predefined('Paste'),
+        predefined('SelectAll'),
+      ],
+    },
+    {
+      text: 'View',
+      entries: [
+        command('palette.open'),
+        command('nav.today'),
+        command('nav.allNotes'),
+        command('chat.open'),
+        separator(),
+        command('history.back'),
+        command('history.forward'),
+        separator(),
+        command('sidebar.toggle'),
+      ],
+    },
+    {
+      text: 'Window',
+      nsAppRole: 'windows',
+      entries: [
+        predefined('Minimize'),
+        predefined('Maximize', 'Zoom'),
+        separator(),
+        predefined('BringAllToFront'),
+      ],
+    },
+    {
+      text: 'Help',
+      nsAppRole: 'help',
+      entries: [command('shortcuts.show')],
+    },
+  ]
+}
+
+function menuItemOptions(commandId: string, text?: string): MenuItemOptions {
+  const appCommand = APP_COMMANDS.find((candidate) => candidate.id === commandId)
+  if (!appCommand) {
+    throw new Error(`native menu references unknown command: ${commandId}`)
+  }
+  return {
+    id: appCommand.id,
+    text: text ?? appCommand.title,
+    accelerator: appCommand.keybinding ? bindingToAccelerator(appCommand.keybinding) : undefined,
+    action: dispatchMenuCommand,
+  }
+}
+
+function entryOptions(entry: AppMenuEntry): MenuItemOptions | PredefinedMenuItemOptions {
+  return entry.kind === 'command'
+    ? menuItemOptions(entry.commandId, entry.text)
+    : { item: entry.item, text: entry.text }
+}
+
+/**
+ * True in the macOS desktop webview only — iPadOS masquerades as macOS in the
+ * user agent and is excluded by the touch-point check (same test as
+ * `lib/window-chrome.ts`).
+ */
+function isMacosDesktop(): boolean {
+  return (
+    isTauri() &&
+    typeof navigator !== 'undefined' &&
+    navigator.userAgent.includes('Macintosh') &&
+    navigator.maxTouchPoints === 0
+  )
+}
+
+/**
+ * Build the application menu and install it, replacing Tauri's default.
+ * Call once at startup, before React mounts — the menu holds command ids, not
+ * state, so it never needs rebuilding.
+ *
+ * macOS-only for now: other desktop platforms would render an in-window
+ * menubar we haven't designed for, and every shortcut already works there
+ * through the keydown path. Keyboard equivalents the webview handles are
+ * consumed before the menu sees them (`useAppShortcuts` prevents the default),
+ * so a focused webview never double-fires a command.
+ */
+export async function installNativeMenu(): Promise<void> {
+  if (!isMacosDesktop()) {
+    return
+  }
+  const submenus = await Promise.all(
+    appMenuLayout().map(async (layout) => {
+      const submenu = await Submenu.new({
+        text: layout.text,
+        items: layout.entries.map(entryOptions),
+      })
+      if (layout.nsAppRole === 'windows') {
+        await submenu.setAsWindowsMenuForNSApp()
+      } else if (layout.nsAppRole === 'help') {
+        await submenu.setAsHelpMenuForNSApp()
+      }
+      return submenu
+    }),
+  )
+  const menu = await Menu.new({ items: submenus })
+  await menu.setAsAppMenu()
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -6,6 +6,7 @@ import { WindowDragRegion } from '@/components/window-drag-region'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { queryClient } from '@/lib/query-client'
 import { registerAppCommands } from '@/lib/commands/app-commands'
+import { installNativeMenu } from '@/lib/native-menu/menu'
 import { installTauriBridge } from '@/lib/tauri-bridge'
 import { GraphProvider } from '@/providers/graph-provider'
 import { SettingsProvider } from '@/providers/settings-provider'
@@ -15,6 +16,9 @@ import '@/styles/index.css'
 
 installTauriBridge()
 registerAppCommands()
+installNativeMenu().catch((cause: unknown) => {
+  console.error('failed to install the native menu', cause)
+})
 
 const rootElement = document.getElementById('root')
 if (!rootElement) {

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -3,6 +3,7 @@ import { usePalette } from '@/components/command-palette/palette-provider'
 import { registerKeymap } from '@/editor/keymap'
 import { APP_COMMANDS } from '@/lib/commands/app-commands'
 import { runCommand } from '@/lib/commands/registry'
+import { setMenuCommandDispatch } from '@/lib/native-menu/dispatch'
 import { retryFailedEmbeddings } from '@/lib/semantic'
 import type { CommandContext } from '@/lib/commands/types'
 import { useAudioMemo } from '@/providers/audio-memo-provider'
@@ -39,7 +40,9 @@ function isModKey(event: KeyboardEvent): boolean {
 /**
  * Install the app-level shortcut listener and build the {@link CommandContext}
  * commands run with. Mount once inside the router + palette providers; the
- * returned context is also what the palette itself runs commands through.
+ * returned context is also what the palette itself runs commands through, and
+ * the native menu's command items dispatch into the same guard path while
+ * mounted (`setMenuCommandDispatch`).
  */
 export function useAppShortcuts(): CommandContext {
   const { route, navigate, back, forward } = useRouter()
@@ -101,30 +104,44 @@ export function useAppShortcuts(): CommandContext {
   )
 
   useEffect(() => {
-    function onKeyDown(event: KeyboardEvent) {
+    // The one guarded entry point for app commands, shared by keystrokes and
+    // native menu activations. Returns whether the command was handled.
+    function triggerCommand(id: string): boolean {
       if (paletteOpenRef.current) {
-        return // modal palette owns the keyboard; Esc closes, then keys resume
+        return false // modal palette owns the screen; Esc closes, then commands resume
       }
+      if (shortcutsOpenRef.current) {
+        // The cheat-sheet is modal too: nothing may navigate behind it, but
+        // the command that opened it closes it again.
+        if (id === 'shortcuts.show') {
+          closeShortcuts()
+          return true
+        }
+        return false
+      }
+      void runCommand(id, context)
+      return true
+    }
+
+    function onKeyDown(event: KeyboardEvent) {
       if (!isModKey(event) || event.altKey || event.shiftKey || event.repeat) {
         return // held keys must not spam navigations (e.g. a stack of new notes)
       }
       const id = BINDING_TO_ID.get(`Mod-${event.key.toLowerCase()}`)
-      if (shortcutsOpenRef.current) {
-        // The cheat-sheet is modal too: nothing may navigate behind it, but
-        // the key that opened it closes it again.
-        if (id === 'shortcuts.show') {
-          event.preventDefault()
-          closeShortcuts()
-        }
+      if (id === undefined) {
         return
       }
-      if (id !== undefined) {
+      if (triggerCommand(id)) {
+        // Also keeps the native menu's matching accelerator from firing the
+        // same command again: the webview consumes the key equivalent.
         event.preventDefault()
-        void runCommand(id, context)
       }
     }
+
+    setMenuCommandDispatch(triggerCommand)
     window.addEventListener('keydown', onKeyDown)
     return () => {
+      setMenuCommandDispatch(null)
       window.removeEventListener('keydown', onKeyDown)
     }
   }, [context, closeShortcuts])


### PR DESCRIPTION
## What

Ports the V1 Electron system menu to the Tauri app as a native macOS menu, built JS-side from `APP_COMMANDS`:

- **`lib/native-menu/menu.ts`** — the menu layout as pure data (`appMenuLayout()`), mapped onto `Menu`/`Submenu`/`PredefinedMenuItem` from `@tauri-apps/api/menu` and installed once at startup. Command items derive id, label, and accelerator from the command definition — the same single source the ⌘K palette and ⌘/ cheat-sheet read — so the menu can't drift from the bindings that actually fire. Native roles (About, Services, Hide, Quit, Undo/Redo/Cut/Copy/Paste/Select All, Minimize/Zoom) are predefined items; the Window and Help submenus get their NSApp roles (automatic window list, Help search field).
- **`lib/native-menu/accelerator.ts`** — converts keymap-registry bindings (`Mod-d`, `Mod-\`) to muda accelerator strings (`CmdOrCtrl+D`, `CmdOrCtrl+\`).
- **`lib/native-menu/dispatch.ts`** — hand-off from menu activations to the active workspace's command context.
- **`routing/app-shortcuts.ts`** — keydown and menu activations now share one guarded `triggerCommand` path, so menu clicks respect the modal palette/cheat-sheet exactly like keystrokes. The keydown handler's `preventDefault` also stops a matching menu accelerator from double-firing the command while the webview has focus.

V1 menu shortcuts carried over: Settings ⌘, · New note ⌘N · Search ⌘K · Go to today ⌘D · Back ⌘[ · Forward ⌘] · Keyboard shortcuts ⌘/, plus All notes, Chat ⌘J, and Toggle sidebar ⌘\ from the V2 registry. V1's find-in-page (⌘F) has no V2 command yet and is not included.

## Notes for review

- macOS-only by design: other desktop platforms would render an in-window menubar we haven't designed for, and every shortcut already works there through the keydown path. iPadOS is excluded by the touch-point check (same test as `window-chrome.ts`).
- No capability changes needed: `core:default` already includes `core:menu:default`, which grants all menu commands (verified against the generated permission reference).
- No Rust changes. The predefined Quit item goes through `RunEvent::ExitRequested` like the old default menu, so the quit-flush path is untouched.

## Testing

- Unit tests: accelerator conversion (incl. punctuation keys verified against muda's parser table) and menu-layout integrity against the registry.
- Verified live in `pnpm tauri dev`: menu installs on cold launch with all six submenus and correct key equivalents (read back via Accessibility), and confirmed visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the central app command dispatch path and runs menu installation at startup; scope is limited to macOS Tauri with tests, but navigation/modal behavior regressions are possible.
> 
> **Overview**
> Adds a **native macOS application menu** for the Tauri desktop app, ported from the V1 Electron menu. Command items are built from `APP_COMMANDS` (ids, labels, accelerators) so the menu stays aligned with ⌘K and the shortcut cheat-sheet.
> 
> New `lib/native-menu/` pieces: **`bindingToAccelerator`** maps registry bindings to muda strings; **`appMenuLayout` / `installNativeMenu`** define six submenus (Reflect, File, Edit, View, Window, Help) with native predefined roles where needed; **`dispatchMenuCommand`** forwards menu clicks to the active workspace dispatcher.
> 
> **`main.tsx`** installs the menu once before React mounts (macOS desktop Tauri only; iPadOS excluded).
> 
> **`useAppShortcuts`** introduces a shared **`triggerCommand`** path for keydown and menu activations, including palette/shortcuts modal guards; registers/clears the menu dispatcher on mount/unmount. Keydown `preventDefault` avoids double-firing when accelerators match.
> 
> Unit tests cover accelerators and menu layout integrity against the command registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdefef3a4d77e6d2bd34a7edbea3875a416280df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->