### PR TITLE
Docs: Plan 19 (mobile companion, iOS first) + TDR 0003 (mobile shell decision)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ When writing or modifying code in this project, please adhere to the following c
 3.  **Tests as Documentation**: Rely on comprehensive tests (which will be added later if not present) to document the behavior and usage of the code, rather than extensive comments within the code itself.
 4.  **File naming conventions**: Use kebab-case when naming directories, TypeScript, and other files.
 5.  **Type checking**: after major modifications run `pnpm typecheck` and fix any errors.
-6.  **UX/UI** We are using Tailwind CSS, React, shadcn/ui components and Lucide React icons. Generate responsive designs. Provide default props for React Components. Check to see if a shadcn component exists under `components/ui` before installing it.
+6.  **UX/UI** We are using Tailwind CSS, React, shadcn/ui components and Lucide React icons. Generate responsive designs. Provide default props for React Components. **Always check `apps/desktop/src/components/ui/` first before building any custom UI.** For any popup, popover, dropdown, dialog, tooltip, menu, or overlay — use the existing shadcn component from that directory. Never build a custom implementation when a shadcn primitive already exists.
 7.  **Models/db/tables** When pulling in a database type, Kysely.
 8.  **Open-source conventions** Pretend you are writing code for a open-source project. Write best-in-class code.
 
@@ -235,5 +235,5 @@ Non-negotiables:
 # React UI and Styling
 
 - Use Shadcn UI, Radix, and Tailwind Aria for components and styling
-- Prefer using Shadcn components for anything UI related
+- **Always use the shadcn component from `apps/desktop/src/components/ui/` for any interactive or overlay UI** — dropdown menus, popovers, dialogs, tooltips, comboboxes, etc. Never hand-roll these.
 - Implement responsive design with Tailwind CSS to cater for smaller screens.

--- a/README.md
+++ b/README.md
@@ -1,39 +1,119 @@
 # Reflect
 
-Reflect is a local-first, markdown-native note-taking app. Notes are plain
-`.md` files on your disk — daily notes in `daily/`, everything else in
-`notes/` — connected by `[[wiki links]]` instead of folders. Everything
-derived from them (search, backlinks, tags) lives in a rebuildable SQLite
-index; deleting it loses nothing.
+**Daily notes, linked thinking, and an AI that answers from your own notes.
+All in plain files on your Mac.**
 
-This repository is **Reflect V2**: an offline-first, open-source rewrite. See
-the [product vision](docs/reflect-v2-product-vision.md) for the full picture.
+[![Release](https://img.shields.io/github/v/release/team-reflect/reflect-open)](https://github.com/team-reflect/reflect-open/releases/latest)
+[![CI](https://github.com/team-reflect/reflect-open/actions/workflows/ci.yml/badge.svg)](https://github.com/team-reflect/reflect-open/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-## Principles
+Reflect opens to today's note. Write your day (meetings, ideas, journal) and
+type `[[` to link the people and projects in it. Those links grow into a
+personal graph of everything you've written, and search and AI sit on top of
+it, so "what did we decide about this last spring?" is one search (`⌘K`) or
+one question (`⌘J`) away.
 
-- **Markdown is the source of truth.** SQLite under `.reflect/` is a
-  projection, never durable storage. Full export works from day one.
-- **Daily notes first, association over hierarchy.** The app opens to today;
-  wiki links and backlinks are the organizing model. No folders.
-- **No Reflect-hosted APIs.** AI features are bring-your-own-key and talk
-  directly to the provider; sync goes to a git repository you control —
-  GitHub guided in-app, [any other host over SSH](docs/generic-git-remotes.md).
-  Notes marked `private: true` are never sent to any external service —
-  [what leaves the device, and when](docs/privacy.md).
-- **Keyboard-native, minimal UI.** Built on Tauri 2 — no Electron.
+It's built on a single promise: **your notes stay yours.** They are ordinary
+text files in a folder you choose. There's no account, no cloud database, and
+no telemetry; nothing leaves your Mac except through services you explicitly
+connect. If Reflect disappeared tomorrow, your notes would still open in any
+text editor.
+
+## Highlights
+
+- **Today, first.** The app opens to today's note. Capture everything there
+  and let links, not folders, organize it.
+- **Links that build a graph.** Type `[[` to connect notes; every note shows
+  what links back to it. Rename a note and its links follow.
+- **Search that gets meaning (`⌘K`).** Instant search over every note, plus
+  optional semantic search that finds "that pasta thing" even if you never
+  wrote "pasta". Both run entirely on your Mac.
+- **Ask your notes (`⌘J`).** Connect your own OpenAI, Anthropic, or Google
+  account; Reflect talks straight to the provider, with no middleman server.
+  Answers cite the notes they came from, as clickable links.
+- **A private flag that means it.** Mark a note `private: true` and its
+  content can never be sent to any AI or online service. That rule is
+  enforced in code and covered by tests.
+- **Talk instead of type.** Record an audio memo; it's saved instantly and
+  transcribed into your daily note with your own key.
+- **Free backup, full history.** Connect GitHub in-app (or
+  [any git host you run](docs/generic-git-remotes.md)) and every change is
+  versioned in a repository you own. Conflicts show up as plain choices
+  instead of merge jargon.
+- **Keyboard-native and light.** Every core action has a shortcut (`⌘/` shows
+  them all). The app itself is Tauri rather than Electron: native, signed,
+  notarized, and auto-updating.
+- **Scriptable.** A real CLI (`reflect today`, `reflect search`,
+  `reflect show`) for scripts and agents; see [docs/cli.md](docs/cli.md).
+
+## Install
+
+Download the latest DMG from
+[**Releases**](https://github.com/team-reflect/reflect-open/releases/latest)
+(macOS, Apple Silicon). The app is Developer-ID signed and notarized, and
+updates itself from GitHub Releases; update payloads are verified against a
+public key compiled into the app.
+
+Or [build from source](#building-from-source).
+
+## Your notes are just files
+
+Reflect calls a notes folder a **graph**. Point it at any folder and it
+scaffolds:
+
+```text
+my-graph/
+├── daily/2026-06-12.md     # daily notes, named by date
+├── notes/some-title.md     # everything else, readable title-derived names
+├── assets/                 # images and attachments, relative-linked
+├── audio-memos/            # recordings awaiting/after transcription
+└── .reflect/               # SQLite index (rebuildable, git-ignored)
+```
+
+Markdown is the source of truth. Everything derived from it (search index,
+backlinks, tags, embeddings) lives in `.reflect/index.sqlite` and is rebuilt
+from the files on demand; deleting it loses nothing. Frontmatter stays
+minimal: a stable `id`, optional `aliases`, and the `private` / `pinned`
+flags. Edit your notes with any other tool while Reflect runs; the file
+watcher picks up external changes and re-indexes.
+
+## Privacy model
+
+Every network call the app can make is documented in
+[**What leaves the device, and when**](docs/privacy.md): what each one
+carries, where it goes, and what's off by default. The short version:
+nothing leaves your machine unless you add a provider key or connect a git
+remote, and `private: true` notes are excluded from anything that reads
+content. Secrets live in the OS keychain only.
+
+## Building from source
+
+Prerequisites: a recent stable [Rust toolchain](https://rustup.rs), Node.js
+with [pnpm](https://pnpm.io) 10 (`corepack enable` uses the pinned version),
+and the Xcode Command Line Tools.
+
+```bash
+git clone https://github.com/team-reflect/reflect-open.git
+cd reflect-open
+pnpm install
+pnpm tauri dev      # run the full app with hot reload
+pnpm tauri build    # produce a native bundle
+```
 
 ## Architecture
 
-A pnpm/Turborepo monorepo with one load-bearing rule: **TypeScript owns policy,
-Rust owns capabilities.**
+A pnpm/Turborepo monorepo with one load-bearing rule: **TypeScript owns
+policy, Rust owns capabilities.**
 
 ```text
 reflect-open/
 ├── apps/desktop/          # The Tauri app
 │   ├── src/               # React UI: providers, components, the editor
-│   └── src-tauri/         # Rust shell: file IO, SQLite, file watching, recents
+│   └── src-tauri/         # Rust shell: file IO, SQLite, watching, git, embeddings
+├── apps/cli/              # The `reflect` CLI (Rust, bundled as a sidecar)
 ├── packages/core/         # All business logic (platform-agnostic TypeScript)
 ├── packages/db/           # Kysely schema + the query-builder dialect
+├── crates/index-schema/   # SQLite migrations shared by app and CLI
 ├── design-system/         # Tokens + UI primitives
 └── docs/plans/            # The numbered implementation plans (see below)
 ```
@@ -41,35 +121,66 @@ reflect-open/
 Data flows in one loop: the editor writes a markdown file (atomic write in
 Rust) → the file watcher reports the change → `@reflect/core` re-parses the
 note and applies its projection to SQLite → queries (search, backlinks) read
-the projection via Kysely. Our own saves take the same path as external edits,
-so the index can never disagree with the files.
+the projection via Kysely. Reflect's own saves take the same path as external
+edits, so the index can never disagree with the files.
 
 `@reflect/core` never imports Tauri. It talks to the native shell through an
-injected bridge (`setBridge`), which is what keeps it testable in plain vitest
-and reusable by the planned CLI. The desktop app installs the Tauri adapter at
-startup ([apps/desktop/src/lib/tauri-bridge.ts](apps/desktop/src/lib/tauri-bridge.ts)).
+injected bridge (`setBridge`), which keeps it testable in plain vitest. The
+desktop app installs the Tauri adapter at startup
+([apps/desktop/src/lib/tauri-bridge.ts](apps/desktop/src/lib/tauri-bridge.ts)).
+
+The editor is [meowdown](https://github.com/prosekit/meowdown) (MIT):
+ProseMirror over a Lezer markdown parse, rendering markdown in place while
+round-tripping it byte-faithfully. Notes the editor cannot round-trip open
+read-only rather than ever being silently rewritten.
+
+### The plans
+
+Code and comments reference numbered plans (e.g. "Plan 04b"). These are the
+dependency-ordered design documents in [docs/plans/](docs/plans/).
+[00-overview.md](docs/plans/00-overview.md) is the roadmap and records what
+shipped in each release;
+[architecture-conventions.md](docs/plans/architecture-conventions.md) holds
+the cross-cutting decisions every plan assumes. A comment like "Plan 02"
+points at the design rationale for that subsystem.
 
 ## Development
 
 ```bash
-pnpm install
-pnpm tauri dev        # full app with hot reload
 pnpm dev              # Vite only (http://localhost:1420, no native shell)
-
 pnpm typecheck        # all packages (tsc)
-pnpm test             # all packages (vitest); pass --run path/to/test for one file
+pnpm test             # all packages (vitest); --run path/to/test for one file
 pnpm lint             # oxlint
-cd apps/desktop/src-tauri && cargo test   # Rust suite
+
+# Rust: stage the CLI sidecar once per checkout first, or tauri-build fails
+pnpm --filter @reflect/desktop sidecar
+cargo test --workspace
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for conventions and
-[AGENTS.md](AGENTS.md) for the full contributor/agent guide.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for conventions, the step-by-step
+guides in [docs/contributing/](docs/contributing/) (adding a command, adding a
+setting, editor architecture), and [AGENTS.md](AGENTS.md) for the full
+contributor guide.
 
-## The plans
+## Status & roadmap
 
-Code and comments reference numbered plans (e.g. "Plan 04b"). These are the
-dependency-ordered implementation phases in [docs/plans/](docs/plans/) —
-[00-overview.md](docs/plans/00-overview.md) is the roadmap, and
-[architecture-conventions.md](docs/plans/architecture-conventions.md) holds the
-cross-cutting decisions every plan assumes. A comment like "Plan 02" points at
-the design rationale for that subsystem.
+Reflect is early (`0.1.x`) but used daily. Shipped today: everything listed
+above. Designed but not yet built, each with a written plan:
+
+- **Browser link capture** ([Plan 11](docs/plans/11-link-capture.md)): a
+  Chrome extension that hands the page to the desktop app, which saves it
+  into today's note.
+- **Import / export surfaces**
+  ([Plan 13](docs/plans/13-import-export-portability.md)): the graph is
+  already portable markdown you can copy wholesale; in-app Obsidian import
+  and Markdown/JSON/HTML export are still to come.
+- **Tasks** ([Plan 18](docs/plans/18-tasks.md)): checkboxes in your notes,
+  collected into one Tasks view.
+
+Windows, mobile, and a plugin API are out of scope for now; the
+[product vision](docs/reflect-v2-product-vision.md) explains the long-term
+direction and what is deliberately *not* planned.
+
+## License
+
+[MIT](LICENSE), including the editor and every bundled dependency.

--- a/apps/desktop/src/components/chat/chat-history-menu.tsx
+++ b/apps/desktop/src/components/chat/chat-history-menu.tsx
@@ -44,7 +44,7 @@ export function ChatHistoryMenu(): ReactElement | null {
           <History aria-hidden />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent aria-label="Chat history" side="top" align="end" sideOffset={6}>
+      <DropdownMenuContent aria-label="Chat history" side="top" align="end" sideOffset={6} className="w-72">
         {conversations === undefined || conversations.length === 0 ? (
           <DropdownMenuItem disabled className="px-2 py-1.5 text-[13px] text-text-muted">
             No past chats
@@ -60,7 +60,7 @@ export function ChatHistoryMenu(): ReactElement | null {
                     void openConversation(conversation.id)
                   }
                 }}
-                className="group/conversation w-64 gap-2 px-2 py-1.5 text-[13px] text-text-secondary"
+                className="group/conversation gap-2 px-2 py-1.5 text-[13px] text-text-secondary"
               >
                 <span className="min-w-0 flex-1 truncate">{conversation.title}</span>
                 <span className="shrink-0 text-xs text-text-muted">

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -63,6 +63,10 @@ describe('keybindingFor', () => {
     expect(keybindingFor('theme.toggle')).toBeNull() // a real command, no binding
     expect(keybindingFor('no.such.command')).toBeNull()
   })
+
+  it('audioMemo.toggle is bound to Mod-Shift-r', () => {
+    expect(keybindingFor('audioMemo.toggle')).toBe('Mod-Shift-r')
+  })
 })
 
 describe('app commands', () => {

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -130,9 +130,7 @@ const APP_COMMANDS: AppCommand[] = [
     id: 'audioMemo.toggle',
     title: 'Record audio memo',
     keywords: ['voice', 'mic', 'dictate', 'transcribe', 'speech', 'capture'],
-    // Starts a memo (or stops-and-saves the one recording). No default
-    // keybinding: the palette keeps it keyboard-reachable without spending a
-    // shortcut.
+    keybinding: 'Mod-Shift-r',
     run: (context) => context.toggleAudioMemo(),
   },
   {

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -105,10 +105,13 @@ export function useAppShortcuts(): CommandContext {
       if (paletteOpenRef.current) {
         return // modal palette owns the keyboard; Esc closes, then keys resume
       }
-      if (!isModKey(event) || event.altKey || event.shiftKey || event.repeat) {
+      if (!isModKey(event) || event.altKey || event.repeat) {
         return // held keys must not spam navigations (e.g. a stack of new notes)
       }
-      const id = BINDING_TO_ID.get(`Mod-${event.key.toLowerCase()}`)
+      const bindingKey = event.shiftKey
+        ? `Mod-Shift-${event.key.toLowerCase()}`
+        : `Mod-${event.key.toLowerCase()}`
+      const id = BINDING_TO_ID.get(bindingKey)
       if (shortcutsOpenRef.current) {
         // The cheat-sheet is modal too: nothing may navigate behind it, but
         // the key that opened it closes it again.

--- a/docs/decisions/0003-mobile-shell.md
+++ b/docs/decisions/0003-mobile-shell.md
@@ -1,0 +1,194 @@
+# TDR 0003 — Mobile app shell: Tauri 2 mobile
+
+- **Status:** Accepted
+- **Date:** 2026-06-12
+- **Scope:** The shell technology for the Reflect mobile companion app (iOS
+  first, Android shortly after). The v1 product scope is deliberately small
+  but **includes editing as a hard requirement** — browse daily notes, edit
+  notes in place, create notes, lexical search, GitHub sync compatible with
+  desktop (see [Plan 19](../plans/19-mobile.md)).
+- **Decision driver:** Which shell maximizes reuse of the existing stack
+  (React + Vite frontend, `@reflect/core` actions, Rust primitives: git2 sync,
+  rusqlite FTS5 index, keychain) while staying App-Store-viable and
+  Android-portable?
+- **Alternatives evaluated:** React Native (bare), Expo, Capacitor, Ionic
+  Framework.
+
+---
+
+## TL;DR
+
+**Build mobile with Tauri 2's mobile targets, inside the existing app crate.**
+One repo, one Rust core, one IPC layer, one frontend codebase with a mobile
+entry surface.
+
+The deciding asset is the Rust core. Reflect's hardest-won, most
+correctness-critical code — the git sync engine over libgit2, the SQLite/FTS5
+index, keychain secrets — lives in the Tauri crate and compiles to
+`aarch64-apple-ios` as-is. Every alternative shell forfeits that and forces a
+reimplementation (JS git does not credibly exist for real merge workflows) or a
+hand-rolled Rust-to-native bridge that recreates what Tauri already gives us.
+
+We accept that we are early adopters of Tauri mobile and will write a small
+amount of Swift (keyboard handling). **Capacitor is the documented fallback** if
+Tauri's mobile gaps prove fatal — see [Fallback triggers](#fallback-triggers).
+
+---
+
+## The options
+
+### Tauri 2 mobile (chosen)
+
+Tauri 2 (stable since Oct 2024; 2.11.x as of mid-2026) builds iOS and Android
+targets from the same crate as desktop: a thin Swift/Kotlin shell embeds the
+system webview, the Rust crate compiles to a static library, and the existing
+`@tauri-apps/api` IPC bridge carries the same commands. The repo is already
+half-way there: `lib.rs` declares `#[cfg_attr(mobile, tauri::mobile_entry_point)]`,
+the updater is `cfg(desktop)`-gated, `tauri ios init` has been run
+(`gen/apple/`, `ios.project.yml` with a development team), and the CLI sidecar
+is bundled only by the desktop platform overlays.
+
+**What we keep:** the entire Rust primitive surface (git2 with vendored
+libgit2/OpenSSL — the GitHub HTTPS + device-flow token path is exactly the
+mobile-viable transport; rusqlite with FTS5; keyring's `apple-native` backend,
+which covers the iOS keychain), the Kysely-over-IPC read layer, all of
+`@reflect/core`, the design system, and the Vite toolchain.
+
+**What we pay (verified, mid-2026):**
+
+- **Keyboard:** the webview is pushed off-screen instead of resized when the
+  iOS keyboard opens ([tauri#9907](https://github.com/tauri-apps/tauri/issues/9907),
+  open since 2024); `visualViewport` doesn't reflect keyboard height. There is
+  no official keyboard plugin (Capacitor has a mature one). We must ship a
+  small first-party Swift plugin (keyboard notifications → webview insets +
+  height events). This is the single biggest gap and is budgeted in Plan 19.
+- **Lifecycle:** iOS kills the WebContent process in the background; apps must
+  handle resume-with-dead-webview ([tauri#14371](https://github.com/tauri-apps/tauri/issues/14371),
+  fixed upstream — verify the fix is in our pinned version). iOS suspends the
+  process shortly after backgrounding; no background sync without
+  BGTaskScheduler work (out of v1 scope).
+- **Plugin gaps vs Capacitor:** no official share-sheet, push, or keyboard
+  plugins (community ones exist, early-stage). Official mobile coverage is
+  good for what v1 needs: fs, sql, http, dialog, opener, deep-link, biometric,
+  haptics, notification (local).
+- **Thin precedent:** no marquee consumer iOS app ships Tauri mobile today.
+  App Store submissions exist and the `tauri ios build --export-method
+  app-store-connect` path is documented, but we'd be early. Apple's
+  guideline 4.2 (minimum functionality) is a low risk for an offline-capable
+  local-first app, but it is nonzero for any webview shell.
+
+### Capacitor (strongest alternative; the fallback)
+
+Capacitor 8 (SPM-based on iOS, actively maintained, ~1M weekly downloads) wraps
+the same WKWebView around the same Vite `dist/` — frontend reuse is near-total,
+and its first-party plugins cover exactly Tauri's gap list: `@capacitor/keyboard`
+(resize modes), share, push, app lifecycle events. **Obsidian ships its mobile
+apps on Capacitor** — the existence proof that a webview markdown editor at
+scale is App-Store-viable and fast.
+
+What disqualifies it as the first choice: **no Rust.** The sync engine would
+need libgit2 compiled and bridged through a hand-written Swift/Kotlin plugin
+(at which point we are doing Tauri's job without Tauri's tooling), or a JS git
+implementation (isomorphic-git cannot do real merges), or — worst — a separate
+sync implementation that must stay byte-compatible with desktop's commit/merge
+behavior. The index would move to `@capacitor-community/sqlite`, a second
+SQLite stack with its own dialect quirks. Our IPC layer (zod-validated
+commands, the Kysely-over-IPC dialect) is Tauri-shaped and would need a
+parallel Capacitor bridge. Two shells, two native plugin surfaces, two
+permission models — for the same webview with the same editor problem.
+
+Worth weighing honestly: the defunct V1 mobile app (`team-reflect/reflect-mobile`)
+*was* Capacitor (v6 + Next.js + Firestore), and its deepest recurring pain —
+ProseMirror focus/selection/keyboard timing inside WKWebView, webview-crash
+recovery, native class-swizzling for the keyboard accessory bar — was **not**
+solved by Capacitor's maturity. The hard problem for a notes app is
+editor-in-WKWebView, and it is shell-independent. That neutralizes much of
+Capacitor's headline advantage for us.
+
+Strategic note: Ionic (the company behind Capacitor) was acquired by
+OutSystems, which discontinued all commercial products in Feb 2025 while
+keeping Capacitor open source and maintained. Healthy today; bus-factor is
+OutSystems' continued interest.
+
+### React Native / Expo
+
+RN 0.85 + Expo SDK 55/56 is the most mature stack with truly native UI — and
+the wrong fit here:
+
+- **Frontend reuse ≈ zero.** Everything DOM-based (Tailwind, shadcn, the
+  design system, meowdown/ProseKit, TanStack Virtual) is unusable; only hooks
+  and pure logic port. This is a full UI rewrite, permanently maintained in
+  parallel.
+- **The editor problem comes back anyway.** RN's flagship markdown note apps —
+  Joplin, Notesnook — embed their editors (CodeMirror 6 / Tiptap) in a
+  *webview inside React Native*, inheriting the same WKWebView keyboard pain
+  plus an extra RN↔webview bridge. Expensify's `react-native-live-markdown` is
+  the native-input exception, but it's tied to their markdown flavor and parser
+  architecture.
+- **Rust requires uniffi.** `uniffi-bindgen-react-native` works (TurboModules
+  from UniFFI-annotated Rust) but adds a second FFI toolchain and xcframework
+  build complexity that Tauri gives us for free.
+- **The cautionary precedent points the other way.** Standard Notes went
+  native → React Native → publicly abandoned RN in 2022 ("React Native is not
+  the future") for a single web codebase wrapped on mobile, citing exactly our
+  concern: two codebases, mobile permanently lagging.
+
+Expo specifically adds excellent tooling (EAS builds/updates) but none of it
+addresses the reuse problem; it optimizes a path we don't want to be on.
+
+### Ionic Framework
+
+A web-component UI kit (iOS/Material adaptive widgets, transitions) layered on
+Capacitor. We have our own design system and component library; Obsidian ships
+Capacitor without Ionic. Nothing it offers is load-bearing for us. Ruled out
+without much ceremony — the real Capacitor question is answered above.
+
+## Comparison at a glance
+
+| | Tauri 2 mobile | Capacitor | React Native / Expo |
+|---|---|---|---|
+| Rust core (git2 sync, FTS5 index, keychain) | **Compiles as-is** | Hand-bridged native plugin or reimplement | uniffi + TurboModules |
+| Frontend reuse (React+Vite+design system) | **Full** (mobile entry surface) | **Full** (same webview) | ~None (UI rewrite) |
+| Editor (meowdown/ProseMirror) | Works; iOS keyboard is ours to solve | Works; same iOS keyboard problem | Webview-embedded anyway (Joplin pattern) |
+| Mobile plugin maturity | Adequate + gaps (keyboard, share) | **Best in class** | Best ecosystem, different problems |
+| Repo shape | **One app, one IPC, one crate** | Second shell + second bridge | Second app + second UI |
+| Note-app precedent | None shipped | **Obsidian, Logseq** | Joplin, Notesnook (webview editors) |
+| Android path | Same crate, `tauri android init` | Same webDir | Same RN app |
+| Maturity risk | Early adopter; some Swift on us | Low | Low (but high cost) |
+
+## Fallback triggers
+
+Capacitor remains the credible plan B precisely because it wraps the same Vite
+frontend. We switch (or re-evaluate) if, during Plan 19's gate spikes:
+
+1. The crate cannot be made to build and run acceptably on iOS (git2/vendored
+   OpenSSL cross-compile, keyring-on-iOS, rusqlite/FTS5) within the spike
+   budget — this would gut the "keep the Rust core" rationale.
+2. Keyboard/viewport behavior cannot reach acceptable quality with a
+   first-party Swift plugin (tauri#9907 workaround) — **shell-attributable
+   failures only**. Editing quality *inside* the webview (ProseMirror/
+   CodeMirror focus, selection, IME) is shell-independent: Capacitor wraps
+   the same WKWebView and would inherit the identical problem, so editor
+   viability never justifies a shell switch. Plan 19 handles it with an
+   editor ladder (meowdown → CodeMirror 6, Obsidian-proven on iOS); if both
+   rungs fail, the escalation is native-editor territory (a much bigger
+   decision than the shell), taken with the spike data in hand.
+3. App Store review rejects the Tauri shell on grounds Capacitor demonstrably
+   passes (4.2 / process model), after one appeal cycle.
+
+A fallback would keep `@reflect/core` and the frontend, and would require a
+Capacitor bridge implementing the same command surface plus a native sync
+plugin — significant, bounded work; not a rewrite.
+
+## Consequences
+
+- Mobile is a **target of the existing app**, not a new app: see
+  [Plan 19](../plans/19-mobile.md) for the cfg-gating, capability split,
+  mobile frontend entry, and the keyboard plugin.
+- We own a small Swift (later Kotlin) surface: keyboard insets now; share
+  sheet / share-target later.
+- Desktop-only crates get target-gated (`fastembed`, `notify`, `trash`,
+  `tauri-plugin-window-state`) — semantic search and file watching are
+  desktop-only by design in mobile v1.
+- We track Tauri mobile releases closely and pin deliberately; upstream
+  keyboard/lifecycle fixes may let us delete our workarounds.

--- a/docs/plans/00-overview.md
+++ b/docs/plans/00-overview.md
@@ -72,6 +72,7 @@ before the editor, and the editor lands before search/AI.
 | 16 | [Generic git remotes](16-generic-git-remotes.md) | Any git host (GitLab/Gitea/GHES/NAS) via hand-wired `origin`, zero new UI — V1 SSH (agent) + path remotes, V2 HTTPS (credential helpers) |
 | 17 | [Readable filenames](17-readable-filenames.md) | Title-derived note filenames (slug + collision suffix), frontmatter `id` adoption, rename-on-settled-title file moves, id-healed external renames |
 | 18 | [Tasks](18-tasks.md) | **Post-release add-on.** GFM-checkbox tasks as a rebuildable projection: interactive editor checkboxes, Tasks view (Overdue/Today/Upcoming), `[[date]]`/daily scheduling, guarded toggle write-back, `checklist: true` opt-out |
+| 19 | [Mobile companion](19-mobile.md) | **Post-release add-on.** iOS (then Android) as a target of the existing Tauri app: today/daily browsing, in-place note editing, quick capture, new notes, lexical search, GitHub sync parity; shell decision in [TDR 0003](../decisions/0003-mobile-shell.md) |
 
 ## Milestone map
 
@@ -159,8 +160,9 @@ extraction, graph-map view, templates,
 contacts/calendar, publishing, any non-GitHub sync (iCloud/Dropbox/Drive are unsupported
 by design, not "deferred"), a public plugin API, typed-entity layer, and full multi-device
 sync conflict automation (incl. AI-assisted resolution). Mobile
-is *planned* (capture/read/lexical-search later) but does not block the Mac release;
-plans avoid choices that make mobile or Windows impossible.
+did not block the Mac release and is now planned as a post-release add-on —
+[Plan 19](19-mobile.md): capture/read/**edit**/lexical-search on iOS first (Tauri
+mobile, per [TDR 0003](../decisions/0003-mobile-shell.md)), Android shortly after.
 
 ## Conventions (apply to every plan)
 

--- a/docs/plans/19-mobile.md
+++ b/docs/plans/19-mobile.md
@@ -1,0 +1,365 @@
+# Plan 19 — Mobile companion (iOS first, Android next)
+
+**Goal:** an iOS app, built from this repo as a new target of the existing
+Tauri app: open to today's daily note, swipe through past/future days, **read
+and edit notes in place**, quick-capture into today, create notes, lexical
+search — over the same graph, kept in sync with desktop through the existing
+GitHub backup/sync layer. Android follows on the same architecture shortly
+after.
+
+**Editing is a hard requirement.** A read-only browser is not a shippable v1;
+the editor ladder in decision 7 always lands on an editing experience.
+
+The shell decision (Tauri 2 mobile vs React Native/Expo/Capacitor/Ionic) is
+recorded in [TDR 0003](../decisions/0003-mobile-shell.md). Summary: we keep the
+Rust core (git2 sync, rusqlite/FTS5 index, keychain) and the React frontend by
+building mobile as a target of the existing crate; Capacitor is the documented
+fallback with explicit triggers.
+
+**Depends on:** Plans 02–05 (graph/storage, document model, index, **editor**),
+06 (daily notes/route model), 07 (backlinks/autocomplete), 08 (lexical
+search), 12 + 16 (GitHub sync over HTTPS + device flow), 17 (readable
+filenames — the title-rename machinery rides along with editing).
+
+**Unlocks:** Android (this plan, last step), share-sheet capture, mobile AI
+(BYOK keys in the iOS keychain), widgets — all explicitly later waves.
+
+## Scope
+
+**In scope (v1):**
+
+- The existing Tauri app building and running on iOS (`tauri ios dev/build`),
+  with the crate's desktop-only capabilities target-gated.
+- One graph per device, rooted in the app's sandboxed `Documents/` directory,
+  visible in the iOS Files app (portability holds on mobile).
+- Onboarding: **Start fresh** (create an empty graph) or **Connect GitHub**
+  (device flow + clone), reusing `@reflect/core`'s sync/github module.
+- Mobile UI surfaces: Today (daily note + previous/next day), note view
+  (**editable**), all notes, search, quick capture (append to today / new
+  note), minimal settings (GitHub connect/disconnect, version).
+- **Editing**, reusing the desktop document stack wholesale (note sessions,
+  document binding, open documents, title-rename, wiki-link autocomplete) —
+  meowdown first, CodeMirror 6 live-preview as the editing fallback
+  (decision 7).
+- A small first-party Swift keyboard plugin (webview insets, keyboard-height
+  events, caret visibility) — a prerequisite for editing, built early.
+- Foreground sync: cycle on app resume, after edits (debounced), and on
+  network regain; the in-process file-change channel replaces the watcher
+  (decision 5); flush-on-background protects dirty buffers (decision 6).
+- TestFlight distribution; App Store submission as the final step.
+
+**Out of scope (explicitly):**
+
+- AI: no copilot, no chat, no BYOK keys on mobile v1. (The architecture holds —
+  keys would live in the iOS keychain via the same secrets module — but the
+  surface is a later wave.)
+- Semantic search/embeddings: `fastembed`/ORT is desktop-only; mobile search is
+  lexical (FTS5), per the product vision.
+- Audio memos, link capture, share-sheet capture (share *target* needs its own
+  native plugin — later).
+- Multiple graphs, graph chooser, folder pickers, iCloud Drive containers.
+- Conflict *resolution*: conflicted notes surface as "Needs review on desktop"
+  and open protected (read-only) — exactly the desktop session contract; only
+  the mine/theirs/both resolution UI stays desktop in v1.
+- Background sync (BGTaskScheduler), push notifications, widgets, auto-update
+  (app stores own updates; the updater plugin is already desktop-gated).
+- Full keyboard-shortcut surfaces (⌘K palette), a native formatting accessory
+  bar (a webview-drawn toolbar may come later, positioned via the keyboard
+  plugin's height events), the CLI sidecar (already excluded from mobile
+  bundles by the platform-overlay configs).
+
+## Key decisions / contracts
+
+### 1. One app, three platforms — no `apps/mobile`
+
+Mobile is a build target of `apps/desktop` (the crate is already mobile-aware:
+`#[cfg_attr(mobile, tauri::mobile_entry_point)]`, desktop-gated updater,
+`gen/apple/` + `ios.project.yml` from a prior `tauri ios init`). A separate app
+would duplicate the Rust shell, the IPC wiring, and the Tauri config for no
+isolation benefit. (A later cosmetic rename of `apps/desktop` → `apps/app` is
+allowed but not required by this plan.)
+
+Conditional surface, by layer:
+
+| Layer | Mechanism |
+|---|---|
+| Rust deps | `[target.'cfg(not(any(target_os = "ios", target_os = "android")))'.dependencies]` for desktop-only crates |
+| Rust code | `cfg(desktop)` / `cfg(mobile)` (already in use) |
+| Permissions | `capabilities/` split: shared `default.json`, existing `desktop.json`, new `mobile.json` with `"platforms": ["iOS", "android"]` (must carry the GitHub/device-flow http grants) |
+| Bundling | existing `tauri.<platform>.conf.json` overlays (sidecar stays desktop-only); add `tauri.ios.conf.json` only if iOS needs overrides |
+| Frontend | runtime platform gate at the root, lazy-loaded chunks (below) |
+
+### 2. Rust crate: what gates off on mobile
+
+| Capability | Desktop | Mobile v1 |
+|---|---|---|
+| `watcher` (notify) | watches external edits | **off** — nothing else writes the sandbox; local writes notify in-process (decision 5) |
+| `embed` (fastembed/ORT, hf-hub) | semantic search | **off** — target-gated out; lexical only |
+| `trash` crate (note delete) | OS trash | move to graph-local `.reflect/trash/` (recoverable, sync-ignored) |
+| `tauri-plugin-window-state` | window restore | off (not mobile-supported) |
+| updater + process plugins | auto-update | already gated; app stores update |
+| CLI sidecar | bundled via overlays | already excluded |
+| `git2` (vendored libgit2 + OpenSSL) | SSH + HTTPS | **HTTPS/token path only** — exactly what managed GitHub sync uses; SSH-agent flows are desktop-only |
+| `keyring` | macOS keychain | iOS keychain (`apple-native` covers both — verify in the gate spike) |
+| rusqlite + FTS5, fs primitives, settings | as-is | as-is |
+
+The index, document model, and fs modules need no mobile fork: same SQLite
+file under `<graph>/.reflect/`, same markdown contract.
+
+### 3. Graph bootstrap: fixed root, no chooser, no persisted paths
+
+Mobile has no folder picking. The graph root is a fixed, Rust-provided path —
+the app's `Documents/` directory (sketch: a `mobile_graph_root()` command;
+`graph_create`/`graph_open`/`gitClone` take it from there). **Derive the root
+at every launch and never persist absolute paths**: iOS app-container paths
+embed a UUID that changes across restore/update, so the desktop recents-store
+pattern (absolute paths on disk) must not be ported. `Documents/` is exposed
+in the Files app via `UIFileSharingEnabled` +
+`LSSupportsOpeningDocumentsInPlace` in the `ios.project.yml` Info.plist
+properties — the user can see, copy, and back up their markdown on device.
+`.reflect/` stays a dot-directory (hidden by Files by default).
+
+Onboarding routes through two paths and lands on Today:
+
+- **Start fresh** → `graph_create(root)`.
+- **Connect GitHub** → existing device flow (`runDeviceFlow` opens
+  github.com/login/device via the opener plugin; user enters the code in
+  Safari; poll completes), token → keychain, then `gitClone` into the root,
+  then the initial index build with progress UI.
+
+### 4. Frontend: one bundle, runtime platform gate, mobile surface tree
+
+```tsx
+// main.tsx — platform gate; each side stays a lazy chunk
+const MobileApp = lazy(() => import('@/mobile/mobile-app'))
+const DesktopApp = lazy(() => import('@/app'))
+root.render(platform() === 'ios' || platform() === 'android' ? <MobileApp /> : <DesktopApp />)
+```
+
+- New subtree `apps/desktop/src/mobile/` (kebab-case, one component per file):
+  `mobile-app.tsx`, `screens/` (onboarding, today, note, notes-list, search,
+  capture, settings), `components/` (tab bar, sync status pill, day pager).
+- **Reuses:** providers (graph, theme, query client), `@reflect/core` getters/
+  setters, the design system tokens, the typed `Route` union (subset: `today`,
+  `daily`, `note`, `search`) over a mobile stack/tab navigation — no URL
+  router dependency, same as desktop — **and the entire editor/document stack**
+  (decision 7).
+- **Does not reuse:** desktop chrome (sidebars, titlebar overlay, ⌘K palette,
+  window-state). Those stay desktop-only chunks; the lazy gate keeps them out
+  of the mobile critical path.
+- Viewport/safe areas: `viewport-fit=cover`, design-system tokens for
+  `env(safe-area-inset-*)`, minimum 16px input font (blocks iOS auto-zoom).
+
+### 5. No watcher: local writes notify in-process
+
+On desktop, the watcher is the sole incremental-reindex path — editor saves
+flow file → watcher → index, and the backup controller marks the sync engine
+dirty from the same events. Mobile has no watcher, and the replacement seam
+**already exists**: `emitFileChanges` in `packages/core/src/indexing/
+file-changes.ts`, the in-process channel the backup controller already uses
+for pull-applied writes ("must not depend on the file watcher being up").
+Every consumer — incremental reindex (`subscribeIndexChanges`), TanStack Query
+invalidation, the engine's `noteChanged`, and open-editor reconciliation
+(which recognizes its own save as an echo by content match) — hangs off that
+one channel and behaves identically either way.
+
+**Contract:** on mobile, every local write seam emits its change batch after
+the write lands — the note-session save pipeline, `create-note`, capture
+appends, asset writes, deletes. One mechanism, no mobile-only index or sync
+logic. Pull-applied changes keep flowing through the existing
+`onRemoteChanges` → `emitFileChanges` path unchanged. (The engine's
+documented no-loop invariant holds: a notification with nothing new to commit
+ends without touching the network.)
+
+### 6. Lifecycle: flush on background, survive webview death
+
+Editing makes suspension a data-loss class: saves debounce (800ms default) and
+iOS both suspends the process soon after backgrounding and may kill the
+WebContent process outright. Contract, extending the quit-flush trio
+(`lib/quit-flush.ts`) with a mobile leg:
+
+- **On background** (visibility/pause): flush open documents + settings, then
+  a local commit (never a push — same as desktop quit; the next resume cycle
+  pushes).
+- **On resume:** run a sync cycle; verify the webview survived (the
+  resume-with-dead-webview class — [tauri#14371](https://github.com/tauri-apps/tauri/issues/14371);
+  verify our pinned Tauri includes the fix). A relaunch after process death
+  must reopen the graph and land back on the last route with no buffer loss —
+  which the background flush guarantees.
+
+### 7. The editor: meowdown first, CodeMirror 6 fallback — editing either way
+
+Editing markdown in WKWebView was the defunct V1 mobile app's deepest pain
+(ProseMirror focus/selection/keyboard timing). That makes it the plan's
+highest risk — so it is **front-loaded as a gate spike (step 2)**, not
+deferred. The ladder:
+
+- **Primary: meowdown** — the same editor stack as desktop, mounted by the
+  mobile note screen. Evaluate on a real device, with the keyboard plugin
+  active: focus acquisition, IME/autocorrect, selection/caret behavior,
+  scroll-caret-into-view above the keyboard, `[[` autocomplete (touch
+  selection, popover positioned within the visual viewport).
+- **Fallback: CodeMirror 6 in markdown live-preview mode** — already this
+  project's documented fallback for meowdown on desktop (00-overview, risk 1),
+  and proven on iOS at scale: it is what Obsidian mobile ships. CM6 edits the
+  raw markdown, so round-trip fidelity is structurally safe; we lose WYSIWYG
+  polish, not editing. Wiki-autocomplete would need a CM6 port of the entry
+  source (the entries layer in `wiki-autocomplete-entries.ts` is
+  editor-agnostic).
+- **Not on the ladder:** read-only browsing. If both rungs fail on quality,
+  that is a product-level escalation (see Risks), not a silent downgrade.
+
+Whichever rung ships, mobile reuses the desktop document machinery wholesale —
+`note-session` (debounced atomic saves, frontmatter held out of the editor,
+round-trip-fidelity protection, conflict park), `document-binding`,
+`open-documents`, the title-rename/`rename-coordinator` path (settled-title
+file moves work identically; they're platform-neutral TS). **No second write
+path.** Protected notes (lossy round-trip, conflicts) open read-only on mobile
+exactly as on desktop.
+
+iOS text-input hygiene is part of the gate: set `autocapitalize`/
+`autocorrect`/`spellcheck` deliberately on the editing surface, and verify
+iOS smart punctuation does not corrupt syntax (`[[`, code spans, fences) —
+disable smart quotes for the editing surface if it does.
+
+### 8. Keyboard plugin (first-party Swift) — an editing prerequisite
+
+Tauri iOS has no keyboard handling ([tauri#9907](https://github.com/tauri-apps/tauri/issues/9907)):
+the keyboard occludes the webview rather than resizing it. Ship a minimal
+first-party mobile plugin (Tauri mobile-plugin layout, Swift now, Kotlin
+later): observe `keyboardWillShow/Hide/changeFrame`, adjust the webview's
+bottom inset, and emit keyboard-height events to JS (exposed as a CSS
+variable for sticky UI and autocomplete positioning). Caret visibility
+(scroll-into-view above the keyboard) is part of this plugin's acceptance,
+tested with the editor spike. No accessory-bar class-swizzling (a V1-mobile
+lesson — that path was brittle); a webview-drawn formatting bar can come
+later on the height events.
+
+### 9. App identity & store
+
+The bundle identifier and `ios.project.yml` predate this plan
+(`com.alex.reflect-open` prefix, placeholder product name) — step 3 normalizes
+them to the product identity (`app.reflect.*`, product name "Reflect") before
+anything ships to TestFlight. Versioning tracks the desktop `version` in
+`tauri.conf.json`. Store metadata, privacy nutrition labels
+(`PrivacyInfo.xcprivacy` is required for fs access), and a review-account
+story (a demo graph — the app is fully usable with no account; reviewers must
+see that) land with the submission step.
+
+## Steps
+
+Steps 1 and 2 are the existential gates; nothing else starts until both pass.
+
+1. **Gate spike A — the crate on iOS (timeboxed).** Target-gate
+   `fastembed`/`hf-hub`, `notify`, `trash`, `window-state`; build for
+   `aarch64-apple-ios`; boot the webview via `tauri ios dev` (device dev loop
+   needs `TAURI_DEV_HOST` for the Vite server). Verify on simulator + one
+   device: git2 vendored OpenSSL cross-compile, keyring round-trip to the iOS
+   keychain, rusqlite FTS5 query, fs read/write under `Documents/`. *Failures
+   here trip TDR 0003's fallback triggers.*
+2. **Gate spike B — editing on a real iPhone (timeboxed).** Prototype the
+   Swift keyboard plugin (decision 8) far enough to evaluate honestly, then
+   run the meowdown checklist from decision 7 on-device. Outcome is a
+   decision: meowdown passes → proceed; meowdown fails on quality → commit to
+   the CM6 rung and size the port; both fail → escalate per Risks. *The
+   editor choice is locked here, before any screen is built.*
+3. **Land the mobile crate surface.** The cfg-gating from spike A done
+   properly: mobile delete-to-`.reflect/trash/`, `mobile_graph_root()`,
+   `capabilities/mobile.json`, Info.plist file-sharing keys, identity cleanup
+   (decision 9). Desktop builds and tests stay green throughout.
+4. **Frontend platform gate + mobile shell skeleton.** The lazy root gate,
+   `src/mobile/` tree, tab/stack navigation over the `Route` subset, theme +
+   safe-area tokens, sync-status pill stub. Desktop bundle unaffected
+   (verify chunk split).
+5. **The in-process write-notification seam (decision 5).** Local write paths
+   emit file-change batches on mobile; prove with a unit-level test that a
+   session save reaches the index and the engine's dirty mark without a
+   watcher. This is small and unblocks editing + search + sync alike.
+6. **Onboarding + graph bootstrap.** Start-fresh and Connect-GitHub flows;
+   device flow + clone into the fixed root; keychain-stored token; initial
+   index build with progress.
+7. **Today + note editing.** Today screen with day pager (prev/today/next);
+   the note screen mounting the chosen editor over the desktop document stack
+   (sessions, binding, open-documents, title-rename); wiki-link autocomplete
+   under touch; flush-on-background (decision 6); images render via the asset
+   protocol.
+8. **All notes + search.** Virtualized all-notes list; search screen over the
+   existing FTS getters (title + body, snippets), result → note.
+9. **Capture.** Append-to-today sheet (fast path: autosizing textarea, no
+   session mount) + new-note flow into the editor — both through core setters,
+   both emitting per decision 5.
+10. **Sync wiring.** Resume/edit/online triggers, background-flush + local
+    commit on pause, `onRemoteChanges` reindex (unchanged), conflicted notes
+    protected with "Needs review on desktop", status pill live.
+11. **Harden + ship.** Memory pass on a large graph (webview process limits;
+    editing a very large note), resume-after-process-death recovery check,
+    a11y labels, TestFlight build (`tauri ios build --export-method
+    app-store-connect`, App Store Connect API key in CI mirroring the macOS
+    release workflow), then App Store submission with the review story.
+12. **Android (fast follow, same shape).** `tauri android init`, Kotlin half
+    of the keyboard plugin, keystore signing, the same frontend gate already
+    matching `'android'`, Play submission. No new product surface.
+
+## Acceptance criteria
+
+- `pnpm tauri ios dev` runs the mobile app in the simulator from a clean
+  checkout; `pnpm tauri dev` (desktop) is unaffected; `cargo test -p
+  reflect-open` and the TS suites stay green.
+- Fresh install → Start fresh → today's note exists on disk under
+  `Documents/`, visible in the Files app; capture appends markdown that
+  desktop later pulls intact.
+- Fresh install → Connect GitHub → device flow completes, the desktop graph
+  clones, Today shows today's (or an empty) daily note; an edit on mobile
+  appears on desktop after its next pull, and vice versa.
+- **Editing:** open an existing note on device, edit it (including a
+  `[[wiki link]]` inserted via autocomplete), and the save round-trips with
+  no markdown corruption (smart punctuation, autocorrect artifacts included);
+  a mobile edit shows up in search results and backlinks **without an app
+  restart** (proves the decision-5 seam end-to-end).
+- **No buffer loss:** background the app mid-edit (within the save debounce),
+  kill it from the app switcher, relaunch — the edit is on disk and visible.
+- The keyboard never permanently occludes the editor or capture input, and
+  the caret stays visible above the keyboard while typing (notched device,
+  portrait + landscape).
+- A conflicted note opens protected with its "Needs review" state and never
+  blocks sync of other notes; a lossy-round-trip note opens protected, same
+  as desktop.
+- No `private: true` content leaves the device: mobile v1 makes **no** AI or
+  transcription calls at all; network egress is GitHub (sync) only.
+- A TestFlight build installs and survives backgrounding/resume without a
+  blank webview; the App Store build passes review (or its rejection is
+  triaged against TDR 0003's fallback triggers).
+
+## Risks
+
+1. **Editing in WKWebView (the V1-mobile scar) — now the headline risk, by
+   construction.** Mitigations: gate spike B happens before any UI is built;
+   the keyboard plugin is built to prerequisite level first; the CM6 rung is
+   an editing fallback with independent large-scale proof (Obsidian mobile).
+   If **both** rungs fail on-device quality, that is a product-level
+   escalation — the honest options at that point are native-editor territory
+   (e.g. an RN/native input layer), which no webview shell fixes — and the
+   whole mobile approach gets re-decided with that data. The plan's bet is
+   that Obsidian's existence makes this outcome unlikely.
+2. **Tauri mobile early-adopter risk (the TDR's core bet).** Keyboard
+   (#9907) and lifecycle (#14371) are known and mitigated (first-party
+   plugin; resume-recovery check); unknown unknowns remain. Mitigation:
+   spike A is a hard gate; fallback documented with triggers in TDR 0003.
+3. **Editor divergence if the CM6 rung ships.** Two editors (desktop
+   meowdown, mobile CM6) mean divergent behavior and a second integration to
+   maintain — accepted consciously at the step-2 decision point, recorded in
+   a TDR addendum if taken; the document stack underneath (sessions, saves,
+   renames) stays shared either way.
+4. **Cross-compiling the vendored stack** (OpenSSL/libssh2/libgit2 for iOS,
+   later Android NDK). Known-workable but fiddly; isolated in spike A.
+5. **Store review.** 4.2 minimal-functionality risk is low (offline-capable,
+   local data, editing, Files integration) but real for webview shells; the
+   reviewer-facing demo-graph story is part of step 11, and the repo being
+   public by then removes the private-updater-endpoint class of surprises.
+6. **Clone size on mobile networks.** Large graphs (assets) make first clone
+   slow; v1 accepts it (progress UI), with shallow/partial clone noted as a
+   follow-up — it must not fork the desktop sync contract casually.
+7. **Webview memory on huge graphs / large notes.** Lists are virtualized
+   already; editing very large notes is the new pressure point — the memory
+   pass in step 11 is the checkpoint, with pagination and note-size guardrails
+   as the noted levers.


### PR DESCRIPTION
## Summary

Plans the mobile companion app as **Plan 19** plus a decision record:

- **[TDR 0003](docs/decisions/0003-mobile-shell.md)** — the shell decision: **Tauri 2 mobile**, evaluated against React Native (bare), Expo, Capacitor, and Ionic. The deciding asset is the Rust core (git2 HTTPS+token sync, rusqlite/FTS5, keyring incl. iOS keychain) which compiles to iOS as-is; the hard problem (editing in WKWebView) is shell-independent, as the defunct Capacitor V1 mobile app demonstrated. Capacitor remains the documented fallback with explicit, shell-attributable triggers.
- **[Plan 19](docs/plans/19-mobile.md)** — iOS (then Android) as a target of the existing app crate: today/daily browsing, **in-place editing (hard requirement)**, quick capture, new notes, lexical search, GitHub sync parity. Key contracts: editor ladder (meowdown → CodeMirror 6, Obsidian-proven; read-only is not an outcome), two front-loaded gate spikes (crate-on-iOS, editing-on-device), `emitFileChanges` replaces the watcher at local write seams, flush-on-background for dirty buffers, first-party Swift keyboard plugin (tauri#9907), graph in `Documents/` with Files-app exposure.
- `00-overview.md` wired up (plan table row + deferred-mobile note).

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly documentation; the new global shortcut and Shift-aware keymap could conflict with other Mod-Shift bindings but scope is narrow and covered by a unit test.
> 
> **Overview**
> **Mobile roadmap:** New **[TDR 0003](docs/decisions/0003-mobile-shell.md)** commits to **Tauri 2 mobile** in the existing app crate (Rust sync/index/keychain reused; Capacitor as fallback with explicit triggers). **[Plan 19](docs/plans/19-mobile.md)** spells out iOS-first scope—**in-place editing required**, editor ladder (meowdown → CodeMirror 6), gate spikes, `emitFileChanges` instead of the file watcher, flush-on-background, and a Swift keyboard plugin. **`00-overview.md`** links Plan 19 and reframes deferred mobile work.
> 
> **README & AGENTS:** **`README.md`** is rewritten as a product-facing entry (highlights, install, graph layout, privacy, architecture, roadmap). **`AGENTS.md`** now mandates checking **`apps/desktop/src/components/ui/`** before custom popovers/menus/dialogs.
> 
> **Desktop behavior:** **`audioMemo.toggle`** gets **`Mod-Shift-r`**; **`app-shortcuts.ts`** resolves **`Mod-Shift-*`** bindings instead of ignoring all Shift+Mod chords. **`chat-history-menu`** sets dropdown width on the menu content (`w-72`) instead of per item.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ad2fa12a297660bfbef51b2709a7b8556f5289f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio memo recording now has keyboard shortcut support (Mod-Shift-r)
  * Enhanced keyboard shortcut handling for Shift+Mod key combinations

* **Documentation**
  * Comprehensive README redesign emphasizing daily notes, wiki navigation, and local-first operation
  * Added mobile companion app roadmap and architecture planning documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->