### PR TITLE
Docs: V1 mobile overview + V2 mobile grounding brief

### DIFF
--- a/docs/reflect-v1-mobile-overview.md
+++ b/docs/reflect-v1-mobile-overview.md
@@ -1,0 +1,231 @@
+# Reflect V1 Mobile Overview
+
+This document is a handoff for an agent or engineer building the mobile experience for a second version of Reflect. It summarizes what the existing iOS app does, how it shares code with the V1 web app, and which architectural choices shaped the mobile implementation.
+
+It is a companion to the [V1 Overview](./reflect-v1-overview.md), which covers the shared product model (graphs, notes, backlinks, tasks, sync). This document focuses on what is different on mobile.
+
+Source code: the `reflect-mobile` repository (separate from the main V1 `reflect` repo).
+
+## Product Summary
+
+Reflect V1 Mobile is a capture-first companion app, not a port of the desktop experience. It is an iOS app (iPhone-first, iPad-capable) built with Capacitor 6 wrapping a Next.js 14 + Ionic React web app, sharing the V1 domain model and sync stack with the web codebase.
+
+The product bet is that mobile is where life happens and desktop is where organization happens. The app optimizes three things:
+
+1. **Frictionless capture**: daily note opens by default, voice memos are reachable from the lock screen, Siri, widgets, and home-screen quick actions, and a share extension saves links from any app.
+2. **Trustworthy recording**: audio capture and upload run natively, surviving webview crashes, phone calls, route changes, and network loss.
+3. **Fast recall on the go**: full local SQLite projection of the graph with full-text search, so reading and searching notes works offline.
+
+What mobile deliberately does *not* try to be: the place where users manage templates, connections, imports, the graph map, or note history. Those stay on desktop/web.
+
+## Relationship to the V1 Web Codebase
+
+The mobile repo does not depend on the web repo as a package. Instead, shared code is **rsynced from a sibling checkout** of the main `reflect` repo:
+
+- `sync.sh` copies directories listed in `sync-include.txt` from `../reflect` into the mobile repo.
+- `sync-ignore.txt` excludes web/desktop-only files (`*.desktop.ts`, import helpers, service-worker hooks, OPFS, web SQLite setup, embedding/vector search, asset text extraction, web keychain).
+
+What is synced (shared, treat as read-only in the mobile repo):
+
+- `client/actions`, `client/errors`, and most `client/models/*` (note, graph, task, backlink, change, search, user, preferences, etc.).
+- `helpers`, `lib`, `shared`, `testing`.
+- `services/api`, `services/asset`, `services/auth`, `services/db`, `services/firebase`, `services/search`, `services/logger`, `services/export/export-json.ts`.
+
+What is mobile-owned:
+
+- `client/core/` (app shell, router), `client/screens/`, `client/models/ui/`, `client/models/capacitor/`.
+- `components/` (all UI components).
+- `capacitor/` (TypeScript plugin bridges) and `ios/` (the Xcode project and Swift code).
+- `pages/` (a thin Next.js shell), build scripts, fastlane, CI.
+
+Where the web repo has platform variants, mobile either provides its own file with the same path (e.g. `services/db/sqlite/kysely-setup.ts`, `lib/platform-keychain.ts`) or stubs the capability (e.g. vector search returns no results).
+
+This code-sharing model kept the domain logic identical across platforms, but it is manual, drift-prone, and makes the synced files second-class citizens in the mobile repo. A V2 monorepo with shared packages removes this entire class of problem.
+
+`services/platform.ts` is hardcoded on mobile: `currentPlatform()` always returns `Platform.Mobile` and the agent is `iphone`. Shared code branches on this to disable web-only behavior.
+
+## How to Think About the Mobile App
+
+The app is three layers with different reliability guarantees:
+
+1. **The webview app** (Next.js + Ionic React + MobX): all product UI, the editor, local SQLite, and sync. Assumed to be restartable at any time.
+2. **The TypeScript bridge** (`capacitor/`): seven small plugin interfaces (alert, assets, auth-sync, image-preview, keyboard-toolbar, native-actions, recording) that define the webview↔native contract.
+3. **The native Swift layer** (`ios/App/`): custom Capacitor plugins plus app extensions. Anything that must not fail when the webview is dead lives here — audio recording and upload, share-extension link capture, auth token storage, asset caching.
+
+The defining V1 mobile design decision is that **critical capture paths do not depend on JavaScript being alive**. Recording uploads straight from Swift to storage; the share extension calls the Reflect API directly with natively-stored OAuth tokens; pending uploads persist in App Group defaults across app restarts. The webview is treated as crashy (it is — the repo ships webview-crash detection and Sentry context for it), and the native layer is the reliability floor.
+
+## Main App Surfaces
+
+Navigation is an Ionic tab bar with three tabs, plus modals. Routing is Ionic React Router (react-router v5) with routes like `/:graph/daily/:id`, `/:graph/all/:id`, `/:graph/all/tag/:tag`, `/:graph/tasks`, and `/:graph/all/ai-chat`.
+
+### Daily (default tab)
+
+The daily-notes surface is a horizontal Swiper carousel of date slides (roughly ±50 days around the selected date, re-centered as the user swipes near the edges), with a swipeable calendar strip at the top that stays in sync with the main carousel. The component mounts once and is reused across navigation to preserve swiper state.
+
+The app re-navigates to today when it wakes from background and the date has changed — open the app, see today.
+
+### All Notes
+
+A virtualized list (react-virtuoso) of notes with an `IonSearchbar`, filter badges (tags, dates, pinned, public), and tap-to-open. Search is local FTS with the same ranking logic as desktop (BM25 with subject boosting, recency boost, exact-subject pinning). Tag taps from the editor land here as filtered lists.
+
+### Search Chat (AI)
+
+From the search bar, the user can start an AI chat grounded in the current search results — the same "chat over an explicit retrieval set" model as desktop, presented as its own page (`/:graph/all/ai-chat`) rather than a modal toggle. The chat view model is shared with the notes-list code.
+
+### Tasks
+
+A grouped task list (today / overdue / upcoming, mirroring desktop's groupings) with mobile-native interactions: drag-and-drop between groups via dnd-kit with haptic feedback, a quick-edit modal for editing a task without opening its note, and a scheduling picker.
+
+### Profile / Settings (modal)
+
+A card modal, not a screen: avatar and email, graph switcher, note/recording counts, a small settings subset (font size, week start, date/time format), JSON export (written to the cache directory and handed to the iOS share sheet), recovery-key creation, encryption key access, sign out, and account deletion. Full preferences (templates, connections, AI providers, billing) remain on desktop/web.
+
+### Note actions
+
+Each note has an options popover: pin/unpin, share (native share sheet with the note's markdown), publish/copy public URL/unpublish, move to trash. This is the mobile equivalent of the desktop context sidebar, reduced to actions only — there is no suggested-backlinks/similar-notes/contacts intelligence on mobile.
+
+### What is absent vs. desktop
+
+No graph map, no note history UI, no imports, no command palette (search is a tab, not `Cmd+K`), no semantic search, no split panes, no template/prompt-template management, no calendar/meeting context on daily notes, no connections management. The mobile app reads and writes the same graph; it just exposes a smaller surface over it.
+
+## The Editor on Mobile
+
+The same `@team-reflect/reflect-editor` (ProseMirror + Yjs) is embedded with mobile-specific configuration: `mobile` mode on, inline toolbar off, merge menu off, backlinks and tags open on tap instead of becoming selectable.
+
+The signature mobile piece is the **native keyboard accessory toolbar**:
+
+- A Swift Capacitor plugin renders a toolbar above the iOS keyboard; the webview drives its items and enabled states.
+- Items: slash commands, AI prediction toggle, bullet, todo, backlink, tag, indent/outdent, move up/down, and image insertion (via the Capacitor Camera plugin, base64 round-trip into the editor's upload pipeline).
+- A MobX view model (`client/models/capacitor/keyboard-toolbar-view.ts`) observes editor selection and enables/disables indent/move buttons accordingly.
+- The native side detects hardware keyboards (`GCKeyboard`) and hides the toolbar when one is attached.
+
+AI in the editor matches desktop: prompt templates are passed into the editor (AI palette) and prediction is toggleable from the toolbar. Editor focus is managed outside the editor (a `requestedFocusForNoteId` flag on the mobile UI store) so navigation — e.g. tapping a backlink — can blur, route, and restore focus on the destination note.
+
+`y-prosemirror` is patched via patch-package for a null-selection crash; expect mobile webview selection behavior to be a recurring source of editor bugs.
+
+## Capture: Audio Recording
+
+Audio is the most engineered feature in the app and the clearest expression of the native-reliability philosophy.
+
+Entry points: in-app record button, lock-screen widget, Dynamic Island / Live Activity, Siri App Intents ("Start recording in Reflect" / stop), home-screen quick action, and a `reflect-widget://` deep link.
+
+The native flow (`RecordingPlugin.swift`, ~600 lines):
+
+1. `AVAudioRecorder` captures AAC mono at 44.1kHz; a Live Activity shows the elapsed timer with a stop button (Dynamic Island on iOS 17+).
+2. Audio interruptions (calls, Siri, alarms) and input-route changes (headphones unplugged) stop the recording cleanly instead of corrupting it.
+3. On stop, Swift uploads the file directly to Firebase Storage with metadata (`processAs: audioRecording-v2`, user/graph/note IDs, transcription language/format flags) using natively-stored auth tokens — no webview involved.
+4. Failures persist in App Group defaults and retry with exponential backoff; `NWPathMonitor` retries when the network returns; a background task buys upload time after the app is backgrounded.
+5. The V1 backend transcribes the file and the transcript syncs into the daily note through the normal note-sync pipeline.
+
+The webview side (`capacitor/recording.ts` + a recording modal with a live waveform from native metering events) is presentation only. Transcription preferences (language, format, prompt hints) are pushed from the webview's preference store into the native plugin reactively.
+
+## Capture: Share Extension, Widgets, Intents
+
+- **Share extension** (separate target, SwiftUI): accepts URLs, web pages, and text from the iOS share sheet and POSTs to `/api/graphs/{graphId}/links/async` directly, using OAuth tokens shared through the `group.ReflectData` App Group. Link enrichment then happens through the V1 operations pipeline (the client later applies the resulting note). Errors are queued in App Group defaults and reported to Sentry when the main app next foregrounds.
+- **Lock-screen widget**: a record button that deep-links via `reflect-widget://`.
+- **Siri App Intents**: start/stop recording.
+- **Quick actions** (home-screen long-press): Create Note and Record Audio.
+- **Native action handshake**: because these entry points can fire before the webview is ready, a `NativeActions` plugin queues the requested action natively; the webview calls `finishSetup()` when its UI is mounted and then `confirmPerformed()` — a two-stage handshake that prevents lost or double-fired actions across app restarts.
+- **Universal links / dynamic links**: associated domains for `m.reflect.app`, `l.reflect.app`, and Firebase Dynamic Links domains; used for email-link auth and web→app handoff.
+- **Push notifications** are wired (`@capacitor/push-notifications`, APNs entitlement) but are a minor surface.
+
+## Authentication and Secrets
+
+- Sign in with Apple, Google (native sheets via `@capacitor-firebase/authentication`), or email (OTP code or magic link; magic links round-trip through Firebase Dynamic Links into `/auth/callback/email`).
+- After Firebase auth resolves in the webview, an **auth-sync bridge** sends the Firebase ID token to Swift, which exchanges it for Reflect OAuth access/refresh tokens via `/api/oauth/token` and stores them in App Group defaults. This is what lets the share extension, recording uploads, and widgets authenticate without the webview.
+- Graph encryption passwords are stored in the iOS Keychain (`capacitor-secure-storage-plugin`), keyed per graph.
+- OAuth client credentials and the API endpoint live in `ReflectConfig.plist`, which is git-ignored and generated from env vars by a fastlane lane (`sync_config`).
+
+The boot gate sequence mirrors desktop, expressed as a loading-state machine on the root store: Auth → SQLite migrating → graph setup → graph loading → encryption unlock → version check → initial sync (with progress UI) → main tabs.
+
+## Data, Sync, and Offline
+
+The mobile app runs the full V1 local-first stack, with a Capacitor-specific bottom layer:
+
+- **SQLite** via `@capacitor-community/sqlite` with a `capacitor-sqlite-kysely` dialect, one database file, the same Kysely schema and migration pattern as the web. All DB access is serialized through a `pLimit(1)` lock because the Capacitor bridge cannot tolerate concurrent access.
+- **Tables** match the web projection: `notes` (with Yjs update state + derived fields), `notesFts`, `noteBacklinks`, `assets`/`assetsFts`, `contacts`, `books`, `commitBackups`, `jobs`, `lastSyncs`, plus a `notesVec` table that exists in the schema but is unused.
+- **Search** is FTS5 only (unicode61 tokenizer, BM25 with 3× subject weighting, recency/pinned/exact-match re-ranking). The vector search manager is a stub that returns empty results — there is no on-device embedding or semantic search in V1 mobile. The trigram extension used on desktop is also disabled on mobile.
+- **Sync** is the shared table-sync abstraction: Firestore→SQLite down-sync with per-table watermarks (`lastSyncs`) and pagination; SQLite→Firestore up-sync with `hasChanges` flags, debounced flushes, and flush-on-reconnect. Note content syncs as Yjs commits through the shared change manager. Deletes are soft locally until the remote delete succeeds.
+- **Job queue** (`jobs` table): reindex search, rewrite backlinks, repair outdated docs — persisted so background work survives app restarts.
+- **Offline**: reading, searching, editing, and creating notes all work offline; changes queue locally. Network state comes from `@capacitor/network`. The app also monitors free disk space periodically and pauses sync when the device is nearly full.
+
+### Assets
+
+Encrypted asset handling has a native cache layer:
+
+- Files are encrypted client-side (`@team-reflect/file-crypto` in a worker) and uploaded to the asset host; the encrypted blobs are also cached natively in `Library/Caches/AssetsCache`.
+- A `reserveUpload → addUpload → getUpload` bridge protocol coordinates the webview's crypto pipeline with the native cache and resolves races between concurrent uploads and downloads.
+- A custom `reflect-assets://` WKWebView scheme handler serves images: it fetches the encrypted blob (with retries), decrypts AES-GCM natively, and returns the asset to the webview — so images in notes work offline and load fast.
+- Image capture comes from the Capacitor Camera plugin; full-screen image preview is a native viewer (Agrume).
+
+## Native Resilience Machinery
+
+Worth knowing because it reveals where V1 mobile actually hurt:
+
+- **WebView crash detection**: the bridge view controller posts a notification when WKWebView terminates; the app tracks it in Sentry with an "activated recently" flag to separate startup crashes from background kills.
+- **Beta workaround plugin**: iOS 17.2 betas broke Firebase persistence; a dedicated plugin detects OS beta upgrades, backs up local data, and warns the user. The lesson: webview storage on iOS is not stable ground — keep canonical local state in SQLite/native files, not IndexedDB.
+- **Recording state recovery**: pending uploads, requested native actions, and extension errors all persist in App Group defaults precisely because the webview and even the app process are assumed mortal.
+
+## Build, Release, and CI
+
+- **Dev loop**: `nr dev` runs Next.js on port 3001; `capacitor.config.ts` auto-detects the machine's LAN IP and points the device/simulator at it. The app is also testable in a desktop browser in responsive mode.
+- **Builds**: `nr dist` does a static Next.js export to `out/`, `cap sync`/`copy`, and syncs `ReflectConfig.plist` from env vars. Env vars come from Vercel (`vercel env pull`).
+- **Release**: fastlane lanes handle config sync, build-number bumps (build numbers are UTC timestamps, `YYYYMMDDHHmm`), certificate management (fastlane match against a private encrypted certificates repo), TestFlight upload, and version bumps after App Store promotion.
+- **CI** (GitHub Actions): lint + 4-shard vitest with the Firebase emulator on every push; every push to `next` or a `testflight-*` branch builds and uploads a TestFlight build on a macOS runner.
+- **Crash reporting**: Sentry on both sides (`@sentry/capacitor` natively, `@sentry/nextjs` in the webview), with shared user context set from the auth-sync plugin.
+
+## Code Map for V2 Readers
+
+Mobile-owned starting points (paths in the `reflect-mobile` repo):
+
+- `client/core/app.tsx`, `client/core/loader.tsx`: app shell and loading-state gates.
+- `client/core/router-tabs.tsx`: tab structure and routes.
+- `client/models/ui/mobile-view.ts`: central mobile UI state (app lifecycle, recording modal, focus requests, disk space).
+- `client/models/ui/navigation-view.ts`: navigation + deep-link intents.
+- `client/screens/note-edit/`: daily-note swiper and editor integration (`note-daily-edit-view.ts`, `note-edit-main.tsx`).
+- `client/models/capacitor/keyboard-toolbar-view.ts` + `capacitor/keyboard-toolbar.ts`: keyboard accessory toolbar.
+- `client/screens/notes-list/`: all-notes list, search, filters, AI chat.
+- `client/screens/tasks/`: task groups, drag-and-drop, quick edit.
+- `client/screens/profile/`: settings modal, export, recovery key.
+- `capacitor/`: the full webview↔native contract in seven small files.
+- `ios/App/App/Capacitor Plugins/`: Swift plugins (Recording, AuthSync, NativeActions, KeyboardToolbar, Assets, Alert, ImagePreview, BetaWorkaround).
+- `ios/App/ShareExtension/`: share-sheet link capture.
+- `ios/App/App Widget/`: lock-screen widget and recording Live Activity.
+- `ios/App/fastlane/Fastfile` and `.github/workflows/`: release pipeline.
+- `services/db/sqlite/kysely-setup.ts`, `services/db/sqlite/sqlite-db.ts`: mobile SQLite bottom layer.
+- `sync.sh`, `sync-include.txt`, `sync-ignore.txt`: the code-sharing mechanism with the main repo.
+
+## V2 Design Notes
+
+Things V1 mobile got right and worth preserving:
+
+- **Capture-first scope.** Mobile as a companion (daily note, voice, share, tasks, search) rather than a full port. Users did not lose anything important by not having the map or preferences on their phone.
+- **Native reliability floor.** Recording and link capture work even when the web layer is dead. Whatever V2's shell is, voice capture and share-ins should not depend on the app's main runtime being healthy.
+- **OS-level capture entry points.** Lock-screen widget, Live Activity, Siri intents, quick actions, and the share extension are a large part of mobile's value. These require native targets and shared auth state (App Groups in V1) regardless of framework.
+- **Keyboard accessory toolbar.** The single most important mobile editor affordance; selection-aware enable/disable matters.
+- **Open-to-today + swipeable days.** The daily carousel with a synced calendar strip is the right mental model for mobile daily notes.
+- **Full local projection.** Having the whole graph in SQLite with FTS made the app feel fast and genuinely offline-capable.
+- **The native-action handshake.** Queuing OS-triggered actions natively until the UI declares readiness eliminates a whole class of cold-start races.
+
+Things V2 changes or must decide differently:
+
+- **Shell**: V2 already targets Tauri 2 iOS instead of Capacitor, sharing one frontend and Rust core in a monorepo. That dissolves the rsync code-sharing scheme, the Capacitor plugin layer, and the serial-DB-lock constraint — but every native capability above (share extension, widgets, Live Activities, intents, background audio, App Groups, keychain) still has to be rebuilt as native iOS targets alongside the Tauri shell. Capacitor gave V1 most of these as plugins; V2 owns them directly.
+- **No Reflect-hosted APIs.** V1 mobile's most reliable paths — native recording upload and share-extension capture — work by POSTing to Reflect's servers with OAuth tokens. V2's principles (markdown source of truth, no Reflect infrastructure, BYOK) remove that option. The share extension and voice capture need a new design: write to shared local storage (App Group container) and let the app ingest into markdown, with sync via Git/iCloud. This is the hardest open problem this document surfaces; "capture when the app isn't running" was previously solved by the server.
+- **Transcription**: V1 transcribed server-side after upload. V2 must choose on-device transcription (Apple Speech / local models) or BYOK provider calls, and honor `private: true` as a hard block at the capture layer.
+- **Sync without Firestore.** V1 mobile got real-time-ish sync and watermarked catch-up from Firestore listeners. Git/iCloud-based sync has different latency and conflict characteristics; the daily-note-on-two-devices case (phone + desktop, same day) becomes the canonical conflict to design for.
+- **Semantic search parity.** V1 quietly shipped mobile without vector search and nobody seems to have missed it badly — useful data point when deciding whether on-device embeddings are worth it in V2.
+- **iPad**: V1 supports iPad orientations but ships a phone UI. Decide early whether V2 treats iPad as a desktop-class layout or a big phone.
+- **WebView fragility is real.** Crash detection, beta-OS workarounds, and patched selection bugs were all responses to WKWebView instability. Keep canonical state out of webview storage, and keep an eye on editor selection behavior in any embedded-webview editor.
+
+Questions a V2 mobile agent should answer before building:
+
+- How does the share extension write a link into a markdown graph when the main app process isn't running, and how does that interact with Git/iCloud sync?
+- Where does audio capture live (native target writing to an App Group container?) and when/where does transcription happen under BYOK?
+- Which capture entry points ship at v1: share extension, widget, intents, quick actions — and which can wait?
+- Is the mobile SQLite index the same `.reflect/index.sqlite` schema as desktop (one schema, two writers?) or a separate projection?
+- What is the offline conflict story for the daily note edited on two devices?
+- Does mobile get the full editor or a constrained capture editor at first release?
+
+## One-Sentence Product Brief
+
+Reflect V1 Mobile is a capture-first iOS companion to the Reflect graph — open-to-today daily notes, native-grade voice memos, share-sheet link capture, tasks, and offline full-text search — built as a Capacitor shell around the shared V1 web codebase with a native Swift reliability layer for everything that must not fail.

--- a/docs/reflect-v1-overview.md
+++ b/docs/reflect-v1-overview.md
@@ -4,6 +4,7 @@ This document is a handoff for an agent or engineer building a second version of
 
 For deeper implementation notes, see:
 
+- [Mobile app](./reflect-v1-mobile-overview.md)
 - [Search](./search.md)
 - [Note sync](./note-sync.md)
 - [SQLite persistence](./sqlite-persistence.md)

--- a/docs/reflect-v2-mobile-grounding-brief.md
+++ b/docs/reflect-v2-mobile-grounding-brief.md
@@ -1,0 +1,225 @@
+# Reflect V2 Mobile Grounding Brief
+
+**Purpose:** Provide a broad, product-oriented overview of what the Reflect V2 mobile app should be, so a mobile-implementation agent understands the product model, the inherited V2 constraints, the lessons from V1 mobile, and the shape of the later waves — before and while working through the implementation plan.
+
+**Decision status:** This brief is grounding material, not the source of truth. The implementation plan is [Plan 19 (mobile companion)](./plans/19-mobile.md) and the shell decision is [TDR 0003 (Tauri 2 mobile)](./decisions/0003-mobile-shell.md) — when this brief conflicts with either, they win, along with [Reflect V2 Product Vision](./reflect-v2-product-vision.md), [Reflect V2 Indexing Strategy](./reflect-v2-indexing-strategy.md), and [Reflect V2 Sync Strategy](./reflect-v2-sync-strategy.md). First-release scope calls recorded in section 3 were confirmed with the product owner on 2026-06-12.
+
+**Primary sources:** [Reflect V1 Mobile Overview](./reflect-v1-mobile-overview.md) (from exploration of the `reflect-mobile` repo), Plan 19 and TDR 0003, and the V2 decision docs above.
+
+---
+
+## 1. Executive Summary
+
+Reflect V2 mobile is **the same app as desktop, on a phone** — not a second product.
+
+- **One codebase, three platforms.** V2 mobile is a build target of the existing Tauri 2 app (`apps/desktop`): the same Rust core (git2 sync, rusqlite/FTS5 index, keychain), the same `@reflect/core` business logic, the same React frontend behind a lazy platform gate with a mobile surface tree (`src/mobile/`). This is the single largest improvement over V1, where mobile was a separate Capacitor repo kept alive by rsyncing code from the web app. TDR 0003 records why (the Rust core is the deciding asset) and names Capacitor as the documented fallback with explicit triggers.
+- **Same graph, same files.** The phone holds a real markdown workspace (`daily/`, `notes/`, `assets/`, ignored `.reflect/`) in the app's `Documents/` directory — visible in the iOS Files app, so portability holds on mobile — synced with desktop through the same GitHub device-flow + libgit2 layer. There is no server, no account, no encryption password: onboarding is "Start fresh" or "Connect GitHub".
+- **Capture-and-edit product scope, deliberately narrow.** Open to today's daily note, swipe through days, **edit notes in place with the real editor**, quick-capture into today, create notes, lexical search, minimal settings. Editing is a hard requirement — Plan 19 is explicit that a read-only browser is not a shippable v1.
+- **The V1 reliability lesson carries over, re-solved locally.** V1 mobile's defining design was that critical capture paths survived webview death — but it achieved that by POSTing to Reflect servers, which V2 forbids. V2's equivalents are local: flush-on-background with a local commit, raw-first artifacts, and (in later waves) an App Group capture inbox instead of a server.
+- **Mobile must not distort desktop.** Desktop avoids choices that make mobile impossible (libgit2 over system git, SQLite everywhere), and mobile reuses desktop seams rather than forking them — the in-process file-change channel replaces the watcher, the document stack is reused wholesale, and there is no second write path.
+
+---
+
+## 2. What V2 Mobile Is — and Is Not
+
+### 2.1 Identity
+
+A capture-and-recall companion to the desktop app, sharing one product identity:
+
+1. **Time:** open to today's daily note; page through the chronological spine.
+2. **Association:** `[[Wiki Links]]` work everywhere, including autocomplete under touch; backlinks stay readable on the phone.
+3. **Recall:** local lexical search over titles, bodies, and backlinks — instant and offline.
+
+### 2.2 What it is not
+
+- Not a viewer. Editing ships in v1, on the same document machinery as desktop (sessions, debounced atomic saves, title rename, round-trip protection).
+- Not a parity port. No copilot, no semantic search, no ⌘K palette, no CLI sidecar, no map, no publishing, no multiple graphs in the first release.
+- Not a separate codebase, schema, or design system.
+- Not a cloud client. The phone is a peer device operating on its own copy of the graph; network egress in v1 is GitHub sync only.
+
+---
+
+## 3. First-Release Scope
+
+Plan 19 defines the binding scope. Summarized, with the product-owner calls of 2026-06-12 noted where they refine sequencing:
+
+| Capability | First mobile release | Notes |
+| --- | --- | --- |
+| Today + day pager, daily notes | **In** | The default screen; open-to-today. |
+| Full editing (meowdown; CM6 live-preview fallback) | **In** | Hard requirement. The editor choice is locked by an on-device gate spike before screens are built (Plan 19, decision 7 / step 2). |
+| Quick capture (append to today / new note) | **In** | Fast path that doesn't mount a full session. |
+| All notes + lexical search (FTS5) | **In** | Same index schema and getters as desktop. |
+| GitHub sync (device flow, HTTPS) | **In** | Foreground-only; cycle on resume, after debounced edits, and on network regain. |
+| Onboarding: Start fresh / Connect GitHub | **In** | One graph per device, fixed root in `Documents/`, Files-app visible. |
+| Minimal settings | **In** | GitHub connect/disconnect, version. No graph chooser. |
+| Conflict **resolution** UI | **Out** | Conflicted notes open protected with "Needs review on desktop" — the same session contract as desktop; mine/theirs/both stays desktop-only in v1. |
+| Audio memos | **Later wave** | Product owner: first post-release wave, reusing desktop's raw-first + async BYOK transcription pipeline; OS entry points (widget, Siri, Live Activity) come with it. |
+| Share-sheet capture | **Later wave** | Product owner: deferred together with link capture (Plan 11) so mobile and desktop ship one consistent capture model. Needs its own native share-target plugin. |
+| AI copilot (BYOK) | **Later wave** | Architecture holds (keys would live in the iOS keychain via the same secrets module); the surface is deferred. |
+| Semantic search / embeddings | **Later** | `fastembed`/ORT is desktop-only; mobile is lexical-first per the indexing strategy. |
+| Tasks, widgets, push, background sync, multiple graphs | **Out of v1** | Per Plan 19's explicit out-of-scope list; tasks follow desktop's Plan 18. |
+| Android | **Fast follow** | Same architecture, last step of Plan 19 (Kotlin keyboard-plugin half, Play submission). No new product surface. |
+
+The later-wave rows matter in v1 even though they ship nothing: the workspace layout, privacy enforcement points, and native-target provisioning should not need rework when audio and share-sheet capture arrive (section 7).
+
+---
+
+## 4. Inherited V2 Decisions That Bind Mobile
+
+Settled in the decision docs; not mobile-negotiable:
+
+- **Markdown is the source of truth.** Notes are `.md` files; attachments are normal files under `assets/`. On mobile the workspace is additionally Files-app visible — the user can see, copy, and back up their markdown on device.
+- **SQLite under `.reflect/` is a rebuildable projection** — with the durable `chat_*` exception. `.reflect/` is per-device and never synced: the phone builds its own index, and desktop chat history does not appear on mobile. Mobile adds one graph-local convention: deleted notes move to sync-ignored `.reflect/trash/` instead of the OS trash.
+- **No Reflect-hosted APIs.** Every V1 mobile flow that depended on a Reflect endpoint (share extension, link enrichment, audio upload/transcription, OAuth token exchange, push) is unavailable in that form. External calls go directly to user-approved providers; in mobile v1 that means GitHub only.
+- **BYOK AI with `private: true` as a hard block.** Mobile v1 sidesteps the question by making no AI or transcription calls at all — an acceptance criterion, not an accident. When audio and AI arrive, provider calls use user keys from the iOS keychain and `private: true` is enforced at every call site, including the capture inbox boundary.
+- **Git-only sync, libgit2.** Chosen partly *because* system git is impossible on iOS. GitHub over HTTPS with device-flow tokens is the mobile transport (SSH-agent flows stay desktop-only). File-sync providers (iCloud Drive, Dropbox) are **unsupported for sync by design**, not deferred — even though iCloud would feel native on iOS. Do not reopen this.
+- **Secrets in the OS keychain.** The GitHub token (and later AI keys) go in the iOS keychain via the same `keyring` module (`apple-native` covers macOS and iOS); never in markdown, Git, or `.reflect/`.
+- **Design system and conventions.** Same `design-system/` tokens (including safe-area tokens), Tailwind + shadcn, AGENTS.md conventions, MIT open-source core — the mobile shell and its Swift plugins are public, critiqued code.
+
+---
+
+## 5. Architecture Orientation
+
+Plan 19 owns the implementation detail; this is the mental model:
+
+- **Shell:** Tauri 2's iOS target generated from `ios.project.yml` (XcodeGen) into `gen/apple/`. Template edits require `tauri ios init` regeneration. The CLI sidecar is excluded from mobile bundles by the platform overlays. App identity is `app.reflect.ios` / product name "Reflect".
+- **Rust crate:** compiles to `aarch64-apple-ios` with desktop-only capabilities target-gated (watcher, embeddings, OS trash, window-state, updater). The index, document model, and fs modules need no mobile fork. Gate spike A passed on the simulator on 2026-06-12 (keychain, FTS5, file IO, libgit2 probes all green); physical-device verification remains.
+- **Frontend:** one bundle, a lazy platform gate at the root (`PlatformRoot`), and a mobile surface tree under `src/mobile/` — screens over a subset of the typed `Route` union, no URL router. Desktop chrome (sidebars, titlebar, palette) stays in desktop-only chunks. The Today screen already mounts the real editor through the shared save pipeline (verified end-to-end on the simulator).
+- **No watcher on mobile:** every local write emits its file-change batch in-process (`emitFileChanges` — the seam the backup controller already used for pull-applied writes). Incremental reindex, query invalidation, sync dirty-marking, and open-editor reconciliation all hang off that one channel. This is the contract that keeps mobile from growing its own index or sync logic.
+- **Keyboard:** Tauri iOS has no keyboard handling, so a small first-party Swift plugin (`plugins/tauri-plugin-keyboard`) streams keyboard height to JS and keeps the caret visible above the keyboard. Notably, V1 mobile's native accessory-bar approach (class-swizzling) is deliberately **not** ported — it was brittle; if mobile grows a formatting toolbar it will be webview-drawn, positioned via the plugin's height events.
+- **Lifecycle:** iOS suspends quickly and can kill the WebContent process. The contract: flush open documents + settings and make a local commit on background (never a push); on resume, run a sync cycle and survive a dead webview. A relaunch must land back on the last route with no buffer loss.
+
+### The two existential gates
+
+Plan 19 front-loads its risk into two timeboxed spikes, and nothing else proceeds until both pass:
+
+1. **The crate on iOS** (spike A — simulator half passed).
+2. **Editing on a real iPhone** (spike B — pending). Editing markdown in WKWebView was V1 mobile's deepest scar (ProseMirror focus/selection/keyboard timing, patched selection crashes). The ladder is meowdown → CodeMirror 6 live-preview (Obsidian mobile's proven approach) → product-level escalation. Read-only is not a rung.
+
+---
+
+## 6. Sync on Mobile
+
+The heart of the mobile product, and where mobile differs most from desktop in daily feel:
+
+- **Same engine, same contracts.** libgit2 commit/fetch/merge, conflict markers, the no-loop invariant — unchanged. Pull-applied changes flow through the existing `onRemoteChanges` reindex path.
+- **Foreground-only.** Sync cycles run on app resume, after debounced edits, and on network regain. Background sync (BGTaskScheduler) is explicitly out of v1. The phone therefore spends much of its life in "not yet pushed" — the plain-language status surface ("Backed up / Syncing / Needs review") is more prominent on mobile than desktop because the user consciously opens the app to sync.
+- **Capture latency is the contract.** "Open app, type a thought, lock phone" must always be safe: local commit never blocks on the network; push is opportunistic; flush-on-background protects the save debounce window. Plan 19's acceptance criteria pin this (kill the app mid-debounce; the edit is on disk).
+- **Conflicts are contained, not resolved, on mobile v1.** A conflicted note opens protected ("Needs review on desktop") and never blocks sync of other notes. This is the same session contract desktop uses; only the resolution UI stays desktop-side.
+- **The canonical conflict** is phone and Mac both appending to **today's daily note** while the phone was offline. It is mostly an append/append merge, and Plan 12 already lists a custom daily-note merge driver as future work — mobile multiplies that future work's value. Treat daily-note append/append as a first-class test scenario from day one even while resolution remains desktop-bound.
+- **First sync is onboarding.** Cloning a years-old graph with assets over cellular, foregrounded, is a V1-power-user's first experience. v1 accepts slow clones with progress UI; shallow/partial clone is a noted follow-up that must not casually fork the desktop sync contract.
+
+---
+
+## 7. Lessons Carried from V1 Mobile
+
+From the [V1 Mobile Overview](./reflect-v1-mobile-overview.md), translated into V2 guidance:
+
+### 7.1 Preserved (and already reflected in Plan 19)
+
+- **Open-to-today with day paging.** V1's daily carousel was the right mobile mental model; V2's Today screen + day pager is its descendant. Ported flows should match V1's interaction patterns unless deliberately decided otherwise.
+- **Capture-first surface count.** V1 succeeded with three tabs and almost no chrome. V2's screen list (Today, note, all notes, search, capture, settings) holds the same line; resist accreting desktop surfaces.
+- **Full local projection = offline trust.** Everything readable and searchable offline, always.
+- **Editing in WKWebView is the headline risk.** V1's editor pain (focus, selection, keyboard timing, a patched y-prosemirror selection crash) is why Plan 19 gates the editor on a real device before building screens, and why iOS text-input hygiene (smart punctuation vs. `[[` syntax, autocorrect artifacts) is part of the gate.
+- **Webview storage is not stable ground.** V1 shipped webview-crash detection and an iOS-beta workaround for broken IndexedDB. V2's posture: canonical state lives in markdown + SQLite below the webview; the lifecycle contract assumes the WebContent process can die at any time.
+
+### 7.2 Re-solved (V1's answer is forbidden or was brittle)
+
+- **Background capture without a server.** V1's share extension and voice memos worked when the app was dead *because a server received the payload*. The V2 equivalent for the later waves is local: a share-target/extension writes pending items (raw audio, shared URLs/text) into an App Group container as a capture inbox; the main app ingests into markdown on next launch and syncs. Extensions must not touch the Git repo or SQLite directly. `private: true` enforcement applies at the inbox boundary.
+- **Transcription.** V1 transcribed server-side after upload. The V2 audio wave reuses desktop's decision: raw-first recordings are the durable, sync-safe artifact; async BYOK cloud transcription with explicit privacy UX and `private: true` lockout.
+- **The native accessory toolbar.** V1's signature editor affordance was a native keyboard accessory bar — but its implementation (input-accessory swizzling) was brittle, and Plan 19 explicitly does not port it. The keyboard-height plugin is the stable primitive; a webview-drawn toolbar can be layered on later if editing on touch demands it.
+- **Onboarding.** V1 mobile gated entry behind account auth → graph selection → encryption unlock → initial Firestore sync. V2 has no accounts and no encryption password: Start fresh or Connect GitHub, then land on Today. Most of V1's loading-gate machinery simply has no V2 equivalent — don't rebuild it.
+
+### 7.3 Dropped
+
+Push notifications (no server), OAuth token exchange, Firebase everything, App-Store-tester backdoors, the separate mobile repo and its rsync code-sharing, and Capacitor itself — though TDR 0003 keeps Capacitor as the documented fallback if Tauri mobile's gaps prove fatal.
+
+---
+
+## 8. Feature Surface Mapping (V1 Mobile → V2 Mobile)
+
+| V1 mobile capability | V2 mobile direction |
+| --- | --- |
+| Daily tab (swiper carousel, calendar strip) | **v1**: Today screen + day pager |
+| Full rich editor + native keyboard toolbar | **v1**: meowdown (or CM6 fallback) + keyboard-height plugin; formatting toolbar webview-drawn, later |
+| All Notes list + FTS search | **v1**: virtualized list + FTS5 search screen |
+| Quick capture into today | **v1**: append-to-today sheet + new-note flow |
+| Auth (Apple/Google/OTP), encryption unlock | **Dropped** — no accounts, no E2EE; onboarding = Start fresh / Connect GitHub |
+| Graph switcher | **Dropped in v1** — one graph per device, fixed root |
+| Trash / delete | **v1** — to graph-local `.reflect/trash/` (recoverable, sync-ignored) |
+| Pin, publish, share-as-text note actions | Not in Plan 19's v1 surface; cheap later, publishing deferred product-wide |
+| JSON export via share sheet | Superseded: the workspace is Files-app-visible markdown |
+| Tasks tab | Post-release, follows desktop Plan 18 |
+| Search-grounded AI chat | Later wave, with the copilot |
+| Voice memos + widget/Siri/Live Activity | Later wave (raw-first + BYOK transcription; OS entry points with it) |
+| Share extension | Later wave, designed with link capture (Plan 11); App Group inbox |
+| Note history UI | Git history exists; history UI deferred product-wide |
+| Push notifications | Dropped — no server |
+| Deep links (`reflect://`) | Tauri's deep-link plugin exists; not a v1 surface — revisit with the command registry |
+| TestFlight automation, timestamp build numbers | Carry the shape into this repo's CI (Plan 19 step 11 mirrors the macOS release workflow) |
+
+---
+
+## 9. Risk Register (Mobile-Specific)
+
+Aligned with Plan 19's risks, ordered by product impact:
+
+1. **Editing quality in WKWebView** — the headline risk by construction; mitigated by gate spike B, the keyboard plugin as prerequisite, and the CM6 rung with independent large-scale proof (Obsidian mobile). Both rungs failing escalates to a product-level re-decision (native-editor territory), per TDR 0003's triggers.
+2. **Tauri mobile early-adopter risk** — no marquee consumer iOS app ships Tauri mobile today; keyboard and lifecycle gaps are known and budgeted, unknown unknowns are not. Capacitor fallback documented with triggers.
+3. **Editor divergence if the CM6 rung ships** — two editors to maintain; accepted consciously at the gate decision, with the document stack shared either way.
+4. **Cross-compiling the vendored stack** (OpenSSL/libssh2/libgit2; later Android NDK) — known-workable but fiddly; isolated in spike A. One landed example: cargo link directives don't reach the Xcode link, so libgit2's zlib/iconv live in `ios.project.yml`.
+5. **App Store review** — 4.2 minimal-functionality risk is low for an offline-capable local-first editor but nonzero for webview shells; the reviewer story (fully usable with no account, demo graph) ships with submission.
+6. **Clone size on mobile networks** — accepted in v1 with progress UI; shallow/partial clone is the follow-up lever.
+7. **Webview memory on huge graphs / very large notes** — editing is the new pressure point; the step-11 memory pass is the checkpoint, with note-size guardrails as the lever.
+
+---
+
+## 10. UX Model
+
+Keyboard-native is desktop identity; mobile translates it rather than imports it:
+
+- **Touch-native, capture-first.** Thumb-reachable core actions; search as a visible surface, not a chord; the keyboard never occludes the caret. Full shortcut surfaces (⌘K palette) are explicitly out of v1 — hardware-keyboard iPad users fall back to visible affordances for now.
+- **Minimal UI applies double.** Six screens, a tab/stack shell, a sync-status pill. No settings sprawl: GitHub connect/disconnect and version.
+- **Same visual language.** Design-system tokens, safe-area-aware layout (`viewport-fit=cover`), 16px minimum input font (blocks iOS auto-zoom), dark mode. iPad ships as "a big phone" in v1; a desktop-class iPad layout is an explicit later decision.
+- **Plain-language sync.** "Backed up / Syncing / Needs review" — never commits, branches, or merges. Conflict language on mobile is "Needs review on desktop".
+
+---
+
+## 11. Definition of Success (First Mobile Release)
+
+Plan 19's acceptance criteria are the binding list. The product-level summary: a user succeeds if they can
+
+1. Install the iOS app and either start fresh or connect their GitHub graph in minutes.
+2. See today's daily note instantly, offline or online.
+3. Edit any note — including inserting a `[[wiki link]]` via autocomplete — with no markdown corruption, and find the edit in search and backlinks without restarting.
+4. Lock the phone mid-thought and lose nothing, even if iOS kills the app.
+5. See the edit on their Mac after the next sync — and when the rare conflict happens, keep working on everything else while the conflicted note waits for desktop review.
+6. Open the Files app and see their notes as portable markdown.
+
+And the codebase succeeds if audio memos, share-sheet capture, and the AI copilot can be added in later waves **without** re-architecting the workspace, sync, privacy enforcement, or navigation.
+
+---
+
+## 12. Open Questions
+
+Beyond Plan 19's settled scope, these remain genuinely open:
+
+1. **App Group + capture-inbox schema** for the audio/share waves: file layout, ingest semantics, `private: true` handling at the inbox boundary, and when to provision the App Group + extension targets in the Xcode template (cheap early, annoying to retrofit — but not needed for v1).
+2. **Daily-note merge driver timing**: when does append/append auto-merge graduate from Plan 12 "future work" to required, given foreground-only mobile sync multiplies conflict frequency?
+3. **Semantic search graduation** (inherited from the indexing strategy): what battery/storage/latency evidence gates local embeddings on iOS, and does sqlite-vec/fastembed ever run there or does mobile stay lexical until a different runtime appears?
+4. **Mobile conflict resolution**: how long is "resolve on desktop" acceptable — and if AI-assisted merge arrives first, how does mobile apply resolutions that require BYOK calls (the sync strategy's open question)?
+5. **iPad posture**: how long does "big phone" hold before a two-pane layout is worth building?
+6. **Deep links and the command registry**: when external automation (shortcuts, widgets) arrives, does `reflect://` map onto the same typed command layer as desktop?
+7. **A formatting toolbar**: does on-device editing (spike B and beyond) demonstrate the need for a webview-drawn accessory bar, and what minimal item set earns its place?
+
+---
+
+## 13. Bottom Line for the Mobile Agent
+
+Reflect V2 mobile is best understood as:
+
+> The same local-first markdown app, recompiled for the pocket: today's note on open, real editing under a keyboard that finally behaves, instant offline search, and Git sync that hides behind three plain words — with voice, share-sheet, and AI capture waves arriving behind it on the same foundations.
+
+Build it from the constraints that make V2 distinct: one codebase, markdown files the user can see in the Files app, a rebuildable per-device index, no servers, no accounts, `private: true` as a hard line when AI arrives — and V1 mobile's hardest-won lessons applied: gate the editor on a real device before building screens, keep canonical state below the webview, and make "lock the phone mid-thought" always safe.
+
+Plan 19 is the route; this brief is the map of why.


### PR DESCRIPTION
## What

Two new mobile-track docs, plus a cross-link:

- **[docs/reflect-v1-mobile-overview.md](https://github.com/team-reflect/reflect-open/blob/claude/relaxed-kowalevski-2fb767/docs/reflect-v1-mobile-overview.md)** — a handoff overview of the V1 mobile app (the `reflect-mobile` Capacitor repo), written in the same style as `reflect-v1-overview.md`. Covers the three-layer architecture (webview app / Capacitor bridge / native Swift reliability layer), the rsync code-sharing model with the V1 web repo, app surfaces, the native-first audio pipeline, share extension + widgets + Siri intents, the mobile SQLite/FTS/sync stack (no semantic search shipped on mobile), the fastlane/TestFlight pipeline, and V2-facing design notes.
- **[docs/reflect-v2-mobile-grounding-brief.md](https://github.com/team-reflect/reflect-open/blob/claude/relaxed-kowalevski-2fb767/docs/reflect-v2-mobile-grounding-brief.md)** — product-oriented grounding for V2 mobile, written to sit *under* [Plan 19](https://github.com/team-reflect/reflect-open/blob/next/docs/plans/19-mobile.md) and [TDR 0003](https://github.com/team-reflect/reflect-open/blob/next/docs/decisions/0003-mobile-shell.md) (it explicitly defers to both). Synthesizes the inherited V2 constraints, the first-release scope, V1 lessons mapped to preserve/re-solve/drop, a mobile risk register, and open questions for the later capture waves (audio, share-sheet, AI).
- One line added to `reflect-v1-overview.md` linking the mobile overview.

## Why

Plan 19 is the implementation route for mobile; these docs are the grounding around it: what the V1 mobile app actually did (sourced from exploring `~/repos/reflect-mobile`), and why the V2 scope is shaped the way it is. The brief also records sequencing calls confirmed with Alex on 2026-06-12: audio memos as the first post-release wave, share-sheet capture deferred together with link capture (Plan 11), full editing in v1, AI copilot deferred.

## Notes for review

- The grounding brief was drafted before I found Plan 19 on `next`, then reconciled against it — claims that conflicted (workspace location, conflict-resolution UI, graph chooser, the native accessory toolbar) now follow Plan 19. Worth a skim for any remaining drift.
- The V1 overview's factual claims (plugin inventory, sync exclusions, release pipeline) come from the `reflect-mobile` repo as of `36495e13`; the V1 app is described as it exists today.
- Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)