### PR TITLE
Mobile (Plan 19): Daily/All tab shell with the searchable All tab (V1 parity)

### DIFF
--- a/apps/desktop/src/mobile/mobile-app.tsx
+++ b/apps/desktop/src/mobile/mobile-app.tsx
@@ -1,6 +1,6 @@
 import { type ReactElement } from 'react'
 import { MobileErrorBoundary } from '@/mobile/mobile-error-boundary'
-import { MobileScreen } from '@/mobile/mobile-screen'
+import { MobileShell } from '@/mobile/mobile-shell'
 import { useKeyboardHeightVar } from '@/mobile/use-keyboard'
 import { useGraph } from '@/providers/graph-provider'
 import { RouterProvider } from '@/routing/router'
@@ -24,7 +24,7 @@ export function MobileApp(): ReactElement {
     return (
       <MobileErrorBoundary>
         <RouterProvider key={graph.root}>
-          <MobileScreen />
+          <MobileShell />
         </RouterProvider>
       </MobileErrorBoundary>
     )

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -155,6 +155,16 @@ describe('MobileShell', () => {
     expect(view.getByRole('heading').textContent).toContain(dayHeading(todayIso()))
   })
 
+  it('renders a search entry as the All tab with the query seeded', async () => {
+    const view = mount({ kind: 'search', query: 'meeting' })
+
+    const box = view.getByRole('searchbox', { name: 'Search notes' })
+    await waitFor(() => {
+      expect((box as HTMLInputElement).value).toBe('meeting')
+    })
+    expect(view.getByRole('button', { name: 'All' }).getAttribute('aria-current')).toBe('page')
+  })
+
   it('back from a cold note entry lands on today', async () => {
     const user = userEvent.setup()
     files['notes/meeting-notes.md'] = 'agenda'

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -7,14 +7,15 @@ import { setBridge } from '@reflect/core'
 import { RouterProvider, useRouter } from '@/routing/router'
 import type { Route } from '@/routing/route'
 import { addDaysIso, formatDayLabel, todayIso } from '@/lib/dates'
-import { MobileScreen } from './mobile-screen'
+import { MobileShell } from './mobile-shell'
 
 /**
- * The mobile route switch (Plan 19): the daily spine pages between days, a
- * note screen pops back to where it came from, and a cold note entry lands
- * on today. Drives the real router → MobileScreen → NotePane stack over a
- * fake IPC bridge; only the ProseMirror view is stubbed (jsdom can't host
- * contenteditable), mirroring `route-content.test.tsx`.
+ * The tabbed mobile shell (Plan 19, V1 parity): the daily spine pages
+ * between days, the All tab lists and searches, a note screen pops back to
+ * where it came from, and a cold note entry lands on today. Drives the real
+ * router → MobileShell → screens → NotePane stack over a fake IPC bridge;
+ * only the ProseMirror view is stubbed (jsdom can't host contenteditable),
+ * mirroring `route-content.test.tsx`.
  */
 
 vi.mock('@/editor/note-editor', () => ({
@@ -83,7 +84,7 @@ function mount(initialRoute: Route, probeRoute?: Route): ReturnType<typeof rende
   return render(
     <QueryClientProvider client={queryClient}>
       <RouterProvider initialRoute={initialRoute}>
-        <MobileScreen />
+        <MobileShell />
         {probeRoute ? <NavProbe to={probeRoute} /> : null}
       </RouterProvider>
     </QueryClientProvider>,
@@ -104,7 +105,7 @@ function dayHeading(date: string): string {
   return formatDayLabel(date, 'mdy')
 }
 
-describe('MobileScreen', () => {
+describe('MobileShell', () => {
   it('renders today as the daily spine with its note content', async () => {
     const today = todayIso()
     files[`daily/${today}.md`] = 'captured on the go'
@@ -139,6 +140,18 @@ describe('MobileScreen', () => {
     expect(view.getByRole('heading').textContent).toContain('meeting-notes')
 
     await user.click(view.getByRole('button', { name: 'Back' }))
+    expect(view.getByRole('heading').textContent).toContain(dayHeading(todayIso()))
+  })
+
+  it('switches tabs: All shows the searchable list, Daily returns to today', async () => {
+    const user = userEvent.setup()
+    const view = mount({ kind: 'today' })
+
+    await user.click(view.getByRole('button', { name: 'All' }))
+    expect(view.getByRole('searchbox', { name: 'Search notes' })).toBeTruthy()
+    expect((await view.findByText('No notes yet')).textContent).toBe('No notes yet')
+
+    await user.click(view.getByRole('button', { name: 'Daily' }))
     expect(view.getByRole('heading').textContent).toContain(dayHeading(todayIso()))
   })
 

--- a/apps/desktop/src/mobile/mobile-screen.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.tsx
@@ -1,18 +1,25 @@
 import { type ReactElement } from 'react'
 import { useToday } from '@/lib/use-today'
+import { MobileAllNotes } from '@/mobile/screens/all-notes'
 import { MobileDaily } from '@/mobile/screens/daily'
 import { MobileNote } from '@/mobile/screens/note'
 import { useRouter } from '@/routing/router'
 
+interface MobileScreenProps {
+  /** The All tab's search text (owned by the shell — survives navigation). */
+  allQuery: string
+  onAllQueryChange: (query: string) => void
+}
+
 /**
  * The mobile route switch (Plan 19): the same typed `Route` history desktop
- * uses, rendered one screen at a time. Kinds without a mobile surface yet
- * (search, all-notes, chat, settings) fall back to today — navigation to
- * them only happens once their screens exist in later slices. Today is
- * `useToday()`'s **live** date, so an app left open overnight rolls to the
- * new day's note at midnight instead of editing yesterday's.
+ * uses, rendered one screen at a time — the daily spine, notes, and the All
+ * tab. Kinds without a mobile surface yet (search, chat, settings) fall back
+ * to today. Today is `useToday()`'s **live** date, so an app left open
+ * overnight rolls to the new day's note at midnight instead of editing
+ * yesterday's.
  */
-export function MobileScreen(): ReactElement {
+export function MobileScreen({ allQuery, onAllQueryChange }: MobileScreenProps): ReactElement {
   const { route } = useRouter()
   const today = useToday()
 
@@ -21,6 +28,8 @@ export function MobileScreen(): ReactElement {
       return <MobileDaily key={route.date} date={route.date} />
     case 'note':
       return <MobileNote key={route.path} path={route.path} />
+    case 'allNotes':
+      return <MobileAllNotes query={allQuery} onQueryChange={onAllQueryChange} tag={route.tag} />
     default:
       return <MobileDaily key="today" date={today} />
   }

--- a/apps/desktop/src/mobile/mobile-screen.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.tsx
@@ -14,8 +14,8 @@ interface MobileScreenProps {
 /**
  * The mobile route switch (Plan 19): the same typed `Route` history desktop
  * uses, rendered one screen at a time — the daily spine, notes, and the All
- * tab. Kinds without a mobile surface yet (search, chat, settings) fall back
- * to today. Today is `useToday()`'s **live** date, so an app left open
+ * tab (which also hosts `search` entries). Kinds without a mobile surface
+ * yet (chat, settings) fall back to today. Today is `useToday()`'s **live** date, so an app left open
  * overnight rolls to the new day's note at midnight instead of editing
  * yesterday's.
  */
@@ -30,6 +30,11 @@ export function MobileScreen({ allQuery, onAllQueryChange }: MobileScreenProps):
       return <MobileNote key={route.path} path={route.path} />
     case 'allNotes':
       return <MobileAllNotes query={allQuery} onQueryChange={onAllQueryChange} tag={route.tag} />
+    case 'search':
+      // Mobile has no dedicated search surface: a search entry (shared
+      // history shapes with desktop) renders as the All tab; the shell seeds
+      // the live query from the entry.
+      return <MobileAllNotes query={allQuery} onQueryChange={onAllQueryChange} tag={null} />
     default:
       return <MobileDaily key="today" date={today} />
   }

--- a/apps/desktop/src/mobile/mobile-shell.tsx
+++ b/apps/desktop/src/mobile/mobile-shell.tsx
@@ -1,0 +1,39 @@
+import { useRef, useState, type ReactElement } from 'react'
+import { MobileScreen } from '@/mobile/mobile-screen'
+import { MobileTabBar, type MobileTab } from '@/mobile/mobile-tab-bar'
+import { useRouter } from '@/routing/router'
+
+/**
+ * The tabbed mobile shell (Plan 19, V1 parity): screens above, the
+ * Daily / All bar below. The active tab derives from the route — a note
+ * keeps whichever tab it was opened from, so reading a search result
+ * doesn't flip the bar. The All tab's search text lives here, not in the
+ * screen, so opening a note and coming back doesn't lose the query.
+ */
+export function MobileShell(): ReactElement {
+  const { route, navigate } = useRouter()
+  const [allQuery, setAllQuery] = useState('')
+  const lastTab = useRef<MobileTab>('daily')
+
+  const tab: MobileTab =
+    route.kind === 'allNotes' || route.kind === 'search'
+      ? 'all'
+      : route.kind === 'today' || route.kind === 'daily'
+        ? 'daily'
+        : lastTab.current
+  lastTab.current = tab
+
+  return (
+    <div className="flex h-dvh w-screen flex-col">
+      <div className="min-h-0 flex-1">
+        <MobileScreen allQuery={allQuery} onAllQueryChange={setAllQuery} />
+      </div>
+      <MobileTabBar
+        tab={tab}
+        onSelect={(next) =>
+          navigate(next === 'daily' ? { kind: 'today' } : { kind: 'allNotes', tag: null })
+        }
+      />
+    </div>
+  )
+}

--- a/apps/desktop/src/mobile/mobile-shell.tsx
+++ b/apps/desktop/src/mobile/mobile-shell.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type ReactElement } from 'react'
+import { useEffect, useRef, useState, type ReactElement } from 'react'
 import { MobileScreen } from '@/mobile/mobile-screen'
 import { MobileTabBar, type MobileTab } from '@/mobile/mobile-tab-bar'
 import { useRouter } from '@/routing/router'
@@ -11,9 +11,19 @@ import { useRouter } from '@/routing/router'
  * screen, so opening a note and coming back doesn't lose the query.
  */
 export function MobileShell(): ReactElement {
-  const { route, navigate } = useRouter()
+  const { route, navigate, entryId } = useRouter()
   const [allQuery, setAllQuery] = useState('')
   const lastTab = useRef<MobileTab>('daily')
+
+  // A `search` history entry seeds the live query — once per entry, so the
+  // user can keep typing without the effect snapping the text back.
+  const seededEntry = useRef<number | null>(null)
+  useEffect(() => {
+    if (route.kind === 'search' && seededEntry.current !== entryId) {
+      seededEntry.current = entryId
+      setAllQuery(route.query)
+    }
+  }, [route, entryId])
 
   const tab: MobileTab =
     route.kind === 'allNotes' || route.kind === 'search'

--- a/apps/desktop/src/mobile/mobile-tab-bar.tsx
+++ b/apps/desktop/src/mobile/mobile-tab-bar.tsx
@@ -1,0 +1,67 @@
+import { type ReactElement } from 'react'
+import { Files, SquarePen } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export type MobileTab = 'daily' | 'all'
+
+interface MobileTabBarProps {
+  tab: MobileTab
+  onSelect: (tab: MobileTab) => void
+}
+
+/**
+ * The V1-parity bottom tab bar: Daily (the chronological spine) and All
+ * (every note + search). It sits at the very bottom of the shell — the
+ * software keyboard simply covers it, as in V1; screens pad their own scroll
+ * containers via `--keyboard-height` instead.
+ */
+export function MobileTabBar({ tab, onSelect }: MobileTabBarProps): ReactElement {
+  return (
+    <nav
+      aria-label="Sections"
+      className="flex shrink-0 border-t border-border"
+      style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+    >
+      <TabButton
+        label="Daily"
+        icon={<SquarePen className="size-5" />}
+        active={tab === 'daily'}
+        onClick={() => onSelect('daily')}
+      />
+      <TabButton
+        label="All"
+        icon={<Files className="size-5" />}
+        active={tab === 'all'}
+        onClick={() => onSelect('all')}
+      />
+    </nav>
+  )
+}
+
+function TabButton({
+  label,
+  icon,
+  active,
+  onClick,
+}: {
+  label: string
+  icon: ReactElement
+  active: boolean
+  onClick: () => void
+}): ReactElement {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-current={active ? 'page' : undefined}
+      onClick={onClick}
+      className={cn(
+        'flex flex-1 flex-col items-center gap-0.5 pb-1 pt-2 text-[11px] font-medium',
+        active ? 'text-primary' : 'text-text-muted',
+      )}
+    >
+      {icon}
+      {label}
+    </button>
+  )
+}

--- a/apps/desktop/src/mobile/screens/all-notes.test.ts
+++ b/apps/desktop/src/mobile/screens/all-notes.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { searchQueryWithTag } from './all-notes'
+
+/**
+ * The route tag must constrain typed searches (the badge stays honest while
+ * searching) without duplicating a `#tag` token the user typed themselves.
+ */
+describe('searchQueryWithTag', () => {
+  it('passes the parsed query through when no tag is active', () => {
+    const parsed = searchQueryWithTag('meeting notes', null)
+    expect(parsed.text).toBe('meeting notes')
+    expect(parsed.filters.tags).toEqual([])
+  })
+
+  it('merges the active route tag as a folded filter', () => {
+    const parsed = searchQueryWithTag('meeting', 'Book')
+    expect(parsed.filters.tags).toEqual(['book'])
+    expect(parsed.filtered).toBe(true)
+    expect(parsed.text).toBe('meeting')
+  })
+
+  it('does not duplicate a tag the query already carries', () => {
+    const parsed = searchQueryWithTag('#book meeting', 'Book')
+    expect(parsed.filters.tags).toEqual(['book'])
+  })
+})

--- a/apps/desktop/src/mobile/screens/all-notes.tsx
+++ b/apps/desktop/src/mobile/screens/all-notes.tsx
@@ -11,6 +11,7 @@ import {
   foldTag,
   type FilteredSearchHit,
   type NoteListEntry,
+  type ParsedSearchQuery,
 } from '@reflect/core'
 import { Input } from '@/components/ui/input'
 import { formatRecencyLabel } from '@/lib/dates'
@@ -22,6 +23,27 @@ import { routeForPath } from '@/routing/route'
 import { useRouter } from '@/routing/router'
 
 const SEARCH_LIMIT = 50
+
+/**
+ * A typed search constrained by the route's tag badge: the badge stays
+ * honest while searching (exported for tests). Tags parsed from `#tokens`
+ * in the text dedupe against the route tag by folded key.
+ */
+export function searchQueryWithTag(query: string, tag: string | null): ParsedSearchQuery {
+  const parsed = parseSearchQuery(query)
+  if (tag === null) {
+    return parsed
+  }
+  const key = foldTag(tag)
+  if (parsed.filters.tags.includes(key)) {
+    return parsed
+  }
+  return {
+    ...parsed,
+    filtered: true,
+    filters: { ...parsed.filters, tags: [...parsed.filters.tags, key] },
+  }
+}
 
 interface MobileAllNotesProps {
   /** The live search text — lifted to the shell so it survives navigation. */
@@ -56,8 +78,14 @@ export function MobileAllNotes({ query, onQueryChange, tag }: MobileAllNotesProp
     enabled,
   })
   const { data: hits } = useQuery({
-    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'mobile-search', query],
-    queryFn: () => searchWithFilters(parseSearchQuery(query), SEARCH_LIMIT),
+    queryKey: [
+      INDEX_QUERY_SCOPE,
+      graph?.root,
+      'mobile-search',
+      query,
+      tag === null ? null : foldTag(tag),
+    ],
+    queryFn: () => searchWithFilters(searchQueryWithTag(query, tag), SEARCH_LIMIT),
     enabled: enabled && searching,
   })
 

--- a/apps/desktop/src/mobile/screens/all-notes.tsx
+++ b/apps/desktop/src/mobile/screens/all-notes.tsx
@@ -1,0 +1,224 @@
+import { useMemo, useState, type ReactElement } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import {
+  hasBridge,
+  listNotes,
+  listNoteTags,
+  parseHighlights,
+  parseSearchQuery,
+  searchWithFilters,
+  foldTag,
+  type FilteredSearchHit,
+  type NoteListEntry,
+} from '@reflect/core'
+import { Input } from '@/components/ui/input'
+import { formatRecencyLabel } from '@/lib/dates'
+import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
+import { cn } from '@/lib/utils'
+import { useGraph } from '@/providers/graph-provider'
+import { useSettings } from '@/providers/settings-provider'
+import { routeForPath } from '@/routing/route'
+import { useRouter } from '@/routing/router'
+
+const SEARCH_LIMIT = 50
+
+interface MobileAllNotesProps {
+  /** The live search text — lifted to the shell so it survives navigation. */
+  query: string
+  onQueryChange: (query: string) => void
+  /** The active tag filter from the `allNotes` route (`null` = every note). */
+  tag: string | null
+}
+
+/**
+ * The All tab (Plan 19, V1 parity): every non-daily note, newest first, with
+ * an embedded search bar and tag filter badges — V1's All Notes shape. A
+ * blank query lists notes (`listNotes`); typing switches to ranked FTS
+ * (`searchWithFilters`, the same engine as desktop's palette). Rows are
+ * virtualized; the scroll element is **state, not a ref**, so a warm-cache
+ * single-render mount still hands the element to the virtualizer.
+ */
+export function MobileAllNotes({ query, onQueryChange, tag }: MobileAllNotesProps): ReactElement {
+  const { graph } = useGraph()
+  const { navigate } = useRouter()
+  const enabled = hasBridge() && graph !== null
+  const searching = query.trim() !== ''
+
+  const { data: notes } = useQuery({
+    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'mobile-all-notes', tag === null ? null : foldTag(tag)],
+    queryFn: () => listNotes({ tag }),
+    enabled: enabled && !searching,
+  })
+  const { data: facets } = useQuery({
+    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'all-notes-tags'],
+    queryFn: () => listNoteTags(),
+    enabled,
+  })
+  const { data: hits } = useQuery({
+    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'mobile-search', query],
+    queryFn: () => searchWithFilters(parseSearchQuery(query), SEARCH_LIMIT),
+    enabled: enabled && searching,
+  })
+
+  return (
+    <div
+      className="flex h-full w-screen flex-col"
+      style={{ paddingTop: 'env(safe-area-inset-top)' }}
+    >
+      <header className="shrink-0 space-y-2 border-b border-border px-4 pb-2 pt-1">
+        <Input
+          type="search"
+          inputMode="search"
+          placeholder="Search notes…"
+          aria-label="Search notes"
+          value={query}
+          onChange={(event) => onQueryChange(event.target.value)}
+          className="text-base"
+        />
+        {facets !== undefined && facets.length > 0 && (
+          <div className="flex gap-1.5 overflow-x-auto pb-1">
+            {facets.map((facet) => {
+              const active = tag !== null && foldTag(tag) === foldTag(facet.tag)
+              return (
+                <button
+                  key={facet.tag}
+                  type="button"
+                  onClick={() => navigate({ kind: 'allNotes', tag: active ? null : facet.tag })}
+                  className={cn(
+                    'shrink-0 rounded-full border border-border px-2.5 py-0.5 text-xs',
+                    active ? 'bg-primary text-primary-foreground' : 'text-text-muted',
+                  )}
+                >
+                  #{facet.tag}
+                </button>
+              )
+            })}
+          </div>
+        )}
+      </header>
+      {searching ? (
+        <SearchResults hits={hits} onOpen={(path) => navigate(routeForPath(path))} />
+      ) : (
+        <NoteRows notes={notes} onOpen={(path) => navigate(routeForPath(path))} />
+      )}
+    </div>
+  )
+}
+
+/** The virtualized note list (blank query). */
+function NoteRows({
+  notes,
+  onOpen,
+}: {
+  notes: NoteListEntry[] | undefined
+  onOpen: (path: string) => void
+}): ReactElement {
+  const { settings } = useSettings()
+  const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null)
+  const rows = useMemo(() => notes ?? [], [notes])
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollElement,
+    estimateSize: () => 64,
+    overscan: 10,
+  })
+
+  if (notes !== undefined && notes.length === 0) {
+    return <Empty message="No notes yet" />
+  }
+
+  return (
+    <div
+      ref={setScrollElement}
+      className="min-h-0 flex-1 overflow-y-auto"
+      style={{ paddingBottom: 'max(env(safe-area-inset-bottom), var(--keyboard-height, 0px))' }}
+    >
+      <ul className="relative" style={{ height: virtualizer.getTotalSize() }}>
+        {virtualizer.getVirtualItems().map((item) => {
+          const note = rows[item.index]
+          return (
+            <li
+              key={note.path}
+              data-index={item.index}
+              ref={virtualizer.measureElement}
+              className="absolute inset-x-0"
+              style={{ transform: `translateY(${item.start}px)` }}
+            >
+              <button
+                type="button"
+                onClick={() => onOpen(note.path)}
+                className="flex w-full flex-col gap-0.5 border-b border-border px-4 py-2.5 text-left"
+              >
+                <span className="flex items-baseline justify-between gap-2">
+                  <span className="min-w-0 truncate text-sm font-medium">{note.title}</span>
+                  <span className="shrink-0 text-xs text-text-muted">
+                    {formatRecencyLabel(note.mtime, settings)}
+                  </span>
+                </span>
+                {note.snippet !== '' && (
+                  <span className="line-clamp-2 text-xs text-text-muted">{note.snippet}</span>
+                )}
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+/** Ranked FTS results with highlighted snippets. */
+function SearchResults({
+  hits,
+  onOpen,
+}: {
+  hits: FilteredSearchHit[] | undefined
+  onOpen: (path: string) => void
+}): ReactElement {
+  if (hits !== undefined && hits.length === 0) {
+    return <Empty message="No matches" />
+  }
+
+  return (
+    <div
+      className="min-h-0 flex-1 overflow-y-auto"
+      style={{ paddingBottom: 'max(env(safe-area-inset-bottom), var(--keyboard-height, 0px))' }}
+    >
+      <ul>
+        {(hits ?? []).map((hit) => (
+          <li key={hit.path}>
+            <button
+              type="button"
+              onClick={() => onOpen(hit.path)}
+              className="flex w-full flex-col gap-0.5 border-b border-border px-4 py-2.5 text-left"
+            >
+              <span className="truncate text-sm font-medium">{hit.title}</span>
+              {hit.snippet !== null && (
+                <span className="line-clamp-2 text-xs text-text-muted">
+                  {parseHighlights(hit.snippet).map((segment, index) =>
+                    segment.highlighted ? (
+                      // eslint-disable-next-line react/no-array-index-key
+                      <mark key={index} className="rounded-sm bg-primary/15 text-text">
+                        {segment.text}
+                      </mark>
+                    ) : (
+                      // eslint-disable-next-line react/no-array-index-key
+                      <span key={index}>{segment.text}</span>
+                    ),
+                  )}
+                </span>
+              )}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function Empty({ message }: { message: string }): ReactElement {
+  return (
+    <div className="flex flex-1 items-center justify-center text-sm text-text-muted">{message}</div>
+  )
+}

--- a/apps/desktop/src/mobile/screens/daily.tsx
+++ b/apps/desktop/src/mobile/screens/daily.tsx
@@ -25,7 +25,7 @@ export function MobileDaily({ date }: { date: string }): ReactElement {
   const isToday = date === useToday()
 
   return (
-    <div className="flex h-dvh w-screen flex-col" style={{ paddingTop: 'env(safe-area-inset-top)' }}>
+    <div className="flex h-full w-screen flex-col" style={{ paddingTop: 'env(safe-area-inset-top)' }}>
       <header className="flex shrink-0 items-center gap-1 border-b border-border px-1 pb-1">
         <Button
           variant="ghost"
@@ -64,7 +64,7 @@ export function MobileDaily({ date }: { date: string }): ReactElement {
         size="icon"
         aria-label="New note"
         className="fixed right-4 z-40 size-12 rounded-full shadow-lg"
-        style={{ bottom: 'calc(max(env(safe-area-inset-bottom), var(--keyboard-height, 0px)) + 1rem)' }}
+        style={{ bottom: 'calc(max(env(safe-area-inset-bottom), var(--keyboard-height, 0px)) + 4.25rem)' }}
         onClick={() => navigate({ kind: 'note', path: untitledNotePath() })}
       >
         <Plus className="size-6" />

--- a/apps/desktop/src/mobile/screens/note.tsx
+++ b/apps/desktop/src/mobile/screens/note.tsx
@@ -18,7 +18,7 @@ export function MobileNote({ path }: { path: string }): ReactElement {
   const untitled = isUntitledNotePath(path)
 
   return (
-    <div className="flex h-dvh w-screen flex-col" style={{ paddingTop: 'env(safe-area-inset-top)' }}>
+    <div className="flex h-full w-screen flex-col" style={{ paddingTop: 'env(safe-area-inset-top)' }}>
       <header className="flex shrink-0 items-center gap-1 border-b border-border px-1 pb-1">
         <Button
           variant="ghost"


### PR DESCRIPTION
## Summary

The tab-shell slice of the V1-parity direction ([product calls recorded in #152](https://github.com/team-reflect/reflect-open/pull/152)): the mobile app gains V1's two-tab structure.

- **[MobileTabBar](apps/desktop/src/mobile/mobile-tab-bar.tsx)** — Daily + All at the bottom, V1's icons/labels; the software keyboard covers it naturally (V1 behavior) while screens pad via `--keyboard-height`.
- **[MobileShell](apps/desktop/src/mobile/mobile-shell.tsx)** — owns the viewport layout and the tab↔route mapping: a note keeps the tab it was opened from, and the All tab's **search text lives in the shell**, so result → note → back keeps the query (V1's per-tab state, without per-tab navigation stacks).
- **[MobileAllNotes](apps/desktop/src/mobile/screens/all-notes.tsx)** — V1's All Notes shape: embedded search bar, tag filter badges (`listNoteTags`, route-carried tag so back works), a virtualized newest-first list (`listNotes`, scroll-element-as-state per the TanStack pitfall) with recency stamps and snippets, switching to ranked FTS with **highlighted snippets** (`searchWithFilters` + `parseHighlights`) when the query is non-blank — the same engine as desktop's palette.

## Verification

- Simulator: tab switching both ways; the list showing the graph's three notes with snippets and times; searching "sheet" returns two ranked hits with highlight marks; tapping a hit opens the note; Back returns to All **with the query and results intact**; Daily lands on today.
- Shell test suite grows tab coverage (5 tests, real router + fake bridge); `pnpm check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mobile-only UI and routing; reuses existing index/search APIs and desktop route kinds without changing auth or persistence.
> 
> **Overview**
> Replaces the mobile root **route-only** layout with a **V1-style two-tab shell**: **Daily** and **All** sit in a bottom bar, with screens stacked above.
> 
> **`MobileShell`** owns layout, tab↔route mapping (notes keep the tab they were opened from), and **All-tab search text** lifted out of the screen so note → back preserves query and results. **`search`** history entries seed that query once per history entry and render as the All tab.
> 
> **`MobileScreen`** now routes **`allNotes`** and **`search`** to a new **`MobileAllNotes`** screen: embedded search, horizontal tag badges, virtualized **`listNotes`** when empty, and **`searchWithFilters`** with highlighted snippets when typing (route tag merged via **`searchQueryWithTag`**).
> 
> Daily/note screens switch from **`h-dvh`** to **`h-full`** inside the shell; the daily **+** FAB sits higher to clear the tab bar. Tests target **`MobileShell`** and add tab/search seed coverage plus unit tests for tag-aware search parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f699242579fcf0995eaf2b5f370ef16d8a13451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->