### PR TITLE
Mobile (Plan 19): V1 Daily — month header, week calendar strip, swipe carousel

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,6 +37,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.4.0",
+    "embla-carousel-react": "^8.6.0",
     "lucide-react": "^1.17.0",
     "radix-ui": "^1.5.0",
     "react": "^19.1.0",

--- a/apps/desktop/src/lib/day-window.test.ts
+++ b/apps/desktop/src/lib/day-window.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { createDayWindow, dateAtIndex, indexOfDate, FUTURE_DAYS, PAST_DAYS } from './day-window'
+import {
+  createDayWindow,
+  dateAtIndex,
+  indexOfDate,
+  indexWithin,
+  FUTURE_DAYS,
+  PAST_DAYS,
+} from './day-window'
 
 describe('day window', () => {
   const window = createDayWindow('2026-06-09')
@@ -24,5 +31,37 @@ describe('day window', () => {
   it('clamps out-of-window dates to the edges instead of erroring', () => {
     expect(indexOfDate(window, '1990-01-01')).toBe(0)
     expect(indexOfDate(window, '2099-01-01')).toBe(window.count - 1)
+  })
+})
+
+describe('a symmetric (carousel) window', () => {
+  const radius = 366
+  const window = createDayWindow('2026-06-12', { past: radius, future: radius })
+
+  it('centers the anchor and round-trips index↔date', () => {
+    expect(window.count).toBe(radius * 2 + 1)
+    expect(window.anchorIndex).toBe(radius)
+    const center = indexWithin(window, '2026-06-12')
+    expect(center).toBe(radius)
+    expect(dateAtIndex(window, center)).toBe('2026-06-12')
+  })
+
+  it('reports the in-window edges, not a clamp', () => {
+    expect(indexWithin(window, dateAtIndex(window, 0))).toBe(0)
+    expect(indexWithin(window, dateAtIndex(window, window.count - 1))).toBe(window.count - 1)
+  })
+})
+
+describe('indexWithin', () => {
+  const window = createDayWindow('2026-06-12', { past: 366, future: 366 })
+
+  it('returns -1 for a date outside the window (the re-anchor signal)', () => {
+    expect(indexWithin(window, '2025-01-01')).toBe(-1)
+    expect(indexWithin(window, '2028-01-01')).toBe(-1)
+  })
+
+  it('returns -1 one day past each edge', () => {
+    expect(indexWithin(window, dateAtIndex(window, -1))).toBe(-1)
+    expect(indexWithin(window, dateAtIndex(window, window.count))).toBe(-1)
   })
 })

--- a/apps/desktop/src/lib/day-window.ts
+++ b/apps/desktop/src/lib/day-window.ts
@@ -2,31 +2,54 @@ import { differenceInCalendarDays } from 'date-fns'
 import { addDaysIso, parseIsoDate } from './dates'
 
 /**
- * The daily stream's virtual window (Plan 06b): a **fixed** chronological range
- * of days around an anchor (today at mount), indexed `0 … count-1` from oldest
- * to newest. Virtual rows are free until mounted, so a generous static window
- * (~5 years back, 1 year forward) sidesteps bidirectional infinite scroll's
- * prepend/scroll-compensation problem entirely. Index↔date is pure offset math.
+ * The daily surfaces' virtual window (Plan 06b / Plan 19): a **fixed**
+ * chronological range of days around an anchor, indexed `0 … count-1` from
+ * oldest to newest. Virtual rows/slides are free until mounted, so a generous
+ * static window sidesteps bidirectional infinite scroll's prepend/scroll-
+ * compensation problem entirely. Index↔date is pure offset math.
+ *
+ * Two surfaces share this module: the desktop daily stream (a wide, asymmetric
+ * window it virtualizes with TanStack Virtual) and the mobile day carousel (a
+ * tighter symmetric window Embla pages through). They differ only in radius and
+ * in how they treat a date outside the window — see {@link indexOfDate} (clamps
+ * to the nearest edge) versus {@link indexWithin} (reports `-1` so the caller
+ * can re-anchor around the far date).
  */
 
+/** The desktop stream's default reach: ~5 years back, ~1 year forward. */
 export const PAST_DAYS = 5 * 365
 export const FUTURE_DAYS = 365
+
+/** How far the window reaches either side of its anchor day. */
+export interface DayWindowRadius {
+  /** Days before the anchor — index 0 is `anchor - past`. */
+  past: number
+  /** Days after the anchor — the last index is `anchor + future`. */
+  future: number
+}
 
 export interface DayWindow {
   /** ISO date of index 0 (the oldest day in the window). */
   start: string
-  /** Total number of days (virtual rows). */
+  /** Total number of days (virtual rows/slides). */
   count: number
-  /** Index of the anchor day (today at creation). */
+  /** Index of the anchor day (the date the window was built around). */
   anchorIndex: number
 }
 
-/** Build the window around `anchor` (today). Stable for the life of the view. */
-export function createDayWindow(anchor: string): DayWindow {
+/**
+ * Build the window around `anchor`, reaching `past` days back and `future` days
+ * forward (defaulting to the desktop stream's asymmetric reach). Stable for the
+ * life of the view.
+ */
+export function createDayWindow(
+  anchor: string,
+  { past = PAST_DAYS, future = FUTURE_DAYS }: Partial<DayWindowRadius> = {},
+): DayWindow {
   return {
-    start: addDaysIso(anchor, -PAST_DAYS),
-    count: PAST_DAYS + FUTURE_DAYS + 1,
-    anchorIndex: PAST_DAYS,
+    start: addDaysIso(anchor, -past),
+    count: past + future + 1,
+    anchorIndex: past,
   }
 }
 
@@ -35,11 +58,27 @@ export function dateAtIndex(window: DayWindow, index: number): string {
   return addDaysIso(window.start, index)
 }
 
+/** Signed offset of `date` from the window's first day (may fall out of range). */
+function offsetOfDate(window: DayWindow, date: string): number {
+  return differenceInCalendarDays(parseIsoDate(date), parseIsoDate(window.start))
+}
+
 /**
- * The index of `date` within the window, clamped to its bounds — a date link
- * outside the window still scrolls to the nearest edge instead of erroring.
+ * The index of `date` **clamped** to the window's bounds — a date link outside
+ * the window still scrolls to the nearest edge instead of erroring. Used by the
+ * desktop stream, whose window is wide enough that the clamp is effectively
+ * unreachable in normal use.
  */
 export function indexOfDate(window: DayWindow, date: string): number {
-  const offset = differenceInCalendarDays(parseIsoDate(date), parseIsoDate(window.start))
-  return Math.max(0, Math.min(window.count - 1, offset))
+  return Math.max(0, Math.min(window.count - 1, offsetOfDate(window, date)))
+}
+
+/**
+ * The index of `date` within the window, or `-1` when it lies outside. The
+ * mobile carousel uses the `-1` as its signal to re-anchor the window around a
+ * far date link rather than scroll to an edge.
+ */
+export function indexWithin(window: DayWindow, date: string): number {
+  const index = offsetOfDate(window, date)
+  return index >= 0 && index < window.count ? index : -1
 }

--- a/apps/desktop/src/mobile/calendar-strip.tsx
+++ b/apps/desktop/src/mobile/calendar-strip.tsx
@@ -50,7 +50,7 @@ export function CalendarStrip({ date, onSelect }: CalendarStripProps): ReactElem
               aria-label={format(parseIsoDate(day), 'EEEE, MMMM do')}
               aria-current={selected ? 'date' : undefined}
               onClick={() => onSelect(day)}
-              className="flex flex-1 flex-col items-center gap-1 py-1"
+              className="flex flex-1 flex-col items-center gap-0.5 py-1"
             >
               <span className="text-[11px] font-medium text-text-muted">
                 {format(parseIsoDate(day), 'EEEEE')}
@@ -65,6 +65,15 @@ export function CalendarStrip({ date, onSelect }: CalendarStripProps): ReactElem
               >
                 {format(parseIsoDate(day), 'd')}
               </span>
+              {/* Today dot (V1) — a fixed-height slot so cells stay aligned;
+                  shown only when today isn't the selected (circled) day. */}
+              <span
+                aria-hidden
+                className={cn(
+                  'size-1 rounded-full',
+                  !selected && isToday ? 'bg-primary' : 'bg-transparent',
+                )}
+              />
             </button>
           )
         })}

--- a/apps/desktop/src/mobile/calendar-strip.tsx
+++ b/apps/desktop/src/mobile/calendar-strip.tsx
@@ -1,15 +1,17 @@
 import { useMemo, type ReactElement } from 'react'
 import { format } from 'date-fns'
 import { Button } from '@/components/ui/button'
-import { parseIsoDate, todayIso } from '@/lib/dates'
+import { parseIsoDate } from '@/lib/dates'
 import { monthLabel, weekOf } from '@/mobile/calendar'
 import { cn } from '@/lib/utils'
 import { useSettings } from '@/providers/settings-provider'
-import { useToday } from '@/lib/use-today'
 
 interface CalendarStripProps {
   /** The selected day (the centered carousel slide). */
   date: string
+  /** Today's live ISO date — owned by the parent so the strip and the
+   *  parent's select logic share one value (no midnight-rollover skew). */
+  today: string
   /** Select a day — drives the carousel and the route. */
   onSelect: (date: string) => void
 }
@@ -21,9 +23,8 @@ interface CalendarStripProps {
  * strip and the carousel stay in lockstep through the parent's `date`. A
  * **Today** affordance appears in the header when the selection has wandered.
  */
-export function CalendarStrip({ date, onSelect }: CalendarStripProps): ReactElement {
+export function CalendarStrip({ date, today, onSelect }: CalendarStripProps): ReactElement {
   const { settings } = useSettings()
-  const today = useToday()
   const week = useMemo(() => weekOf(date, settings.weekStartDay), [date, settings.weekStartDay])
 
   return (
@@ -34,7 +35,7 @@ export function CalendarStrip({ date, onSelect }: CalendarStripProps): ReactElem
       <div className="flex items-center justify-between px-2 py-1">
         <h1 className="text-base font-semibold">{monthLabel(date)}</h1>
         {date !== today && (
-          <Button variant="ghost" size="sm" onClick={() => onSelect(todayIso())}>
+          <Button variant="ghost" size="sm" onClick={() => onSelect(today)}>
             Today
           </Button>
         )}

--- a/apps/desktop/src/mobile/calendar-strip.tsx
+++ b/apps/desktop/src/mobile/calendar-strip.tsx
@@ -1,0 +1,74 @@
+import { useMemo, type ReactElement } from 'react'
+import { format } from 'date-fns'
+import { Button } from '@/components/ui/button'
+import { parseIsoDate, todayIso } from '@/lib/dates'
+import { monthLabel, weekOf } from '@/mobile/calendar'
+import { cn } from '@/lib/utils'
+import { useSettings } from '@/providers/settings-provider'
+import { useToday } from '@/lib/use-today'
+
+interface CalendarStripProps {
+  /** The selected day (the centered carousel slide). */
+  date: string
+  /** Select a day — drives the carousel and the route. */
+  onSelect: (date: string) => void
+}
+
+/**
+ * V1's calendar strip: a month header and the selected day's week as seven
+ * day-of-week / day-number cells, the selected day circled. Tapping a cell
+ * selects that day; the week shown always contains the selection, so the
+ * strip and the carousel stay in lockstep through the parent's `date`. A
+ * **Today** affordance appears in the header when the selection has wandered.
+ */
+export function CalendarStrip({ date, onSelect }: CalendarStripProps): ReactElement {
+  const { settings } = useSettings()
+  const today = useToday()
+  const week = useMemo(() => weekOf(date, settings.weekStartDay), [date, settings.weekStartDay])
+
+  return (
+    <header
+      className="shrink-0 border-b border-border px-2 pb-1"
+      style={{ paddingTop: 'env(safe-area-inset-top)' }}
+    >
+      <div className="flex items-center justify-between px-2 py-1">
+        <h1 className="text-base font-semibold">{monthLabel(date)}</h1>
+        {date !== today && (
+          <Button variant="ghost" size="sm" onClick={() => onSelect(todayIso())}>
+            Today
+          </Button>
+        )}
+      </div>
+      <div className="flex">
+        {week.map((day) => {
+          const selected = day === date
+          const isToday = day === today
+          return (
+            <button
+              key={day}
+              type="button"
+              aria-label={format(parseIsoDate(day), 'EEEE, MMMM do')}
+              aria-current={selected ? 'date' : undefined}
+              onClick={() => onSelect(day)}
+              className="flex flex-1 flex-col items-center gap-1 py-1"
+            >
+              <span className="text-[11px] font-medium text-text-muted">
+                {format(parseIsoDate(day), 'EEEEE')}
+              </span>
+              <span
+                className={cn(
+                  'flex size-8 items-center justify-center rounded-full text-sm tabular-nums',
+                  selected && 'bg-primary font-semibold text-primary-foreground',
+                  !selected && isToday && 'font-semibold text-primary',
+                  !selected && !isToday && 'text-text',
+                )}
+              >
+                {format(parseIsoDate(day), 'd')}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+    </header>
+  )
+}

--- a/apps/desktop/src/mobile/calendar.test.ts
+++ b/apps/desktop/src/mobile/calendar.test.ts
@@ -1,16 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import {
-  CAROUSEL_RADIUS,
-  carouselDateAt,
-  carouselIndexOf,
-  carouselWindow,
-  monthLabel,
-  weekOf,
-} from './calendar'
+import { monthLabel, weekOf } from './calendar'
 
 /**
- * 2026-06-12 is a Friday; 2026-06-15 a Monday, 2026-06-14 a Sunday — fixed
- * anchors for the week-start math.
+ * 2026-06-12 is a Friday; 2026-06-14 a Sunday — fixed anchors for the
+ * week-start math.
  */
 describe('weekOf', () => {
   it('builds a Monday-first week containing the date', () => {
@@ -45,26 +38,18 @@ describe('weekOf', () => {
       '2026-06-14',
     ])
   })
+
+  it('spans the year boundary without skipping or repeating a day', () => {
+    // 2026-01-01 is a Thursday: a Monday-first week reaches back into 2025.
+    const week = weekOf('2026-01-01', 'monday')
+    expect(week[0]).toBe('2025-12-29')
+    expect(week[6]).toBe('2026-01-04')
+    expect(week).toContain('2026-01-01')
+  })
 })
 
 describe('monthLabel', () => {
   it('formats the month and year', () => {
     expect(monthLabel('2026-06-12')).toBe('June 2026')
   })
-})
-
-describe('carousel window', () => {
-  it('centers the anchor and round-trips index↔date', () => {
-    const window = carouselWindow('2026-06-12')
-    expect(window.count).toBe(CAROUSEL_RADIUS * 2 + 1)
-    const center = carouselIndexOf(window, '2026-06-12')
-    expect(center).toBe(CAROUSEL_RADIUS)
-    expect(carouselDateAt(window, center)).toBe('2026-06-12')
-  })
-
-  it('returns -1 for a date outside the window', () => {
-    const window = carouselWindow('2026-06-12')
-    expect(carouselIndexOf(window, '2025-01-01')).toBe(-1)
-  })
-
 })

--- a/apps/desktop/src/mobile/calendar.test.ts
+++ b/apps/desktop/src/mobile/calendar.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CAROUSEL_RADIUS,
+  carouselDateAt,
+  carouselIndexOf,
+  carouselWindow,
+  monthLabel,
+  weekOf,
+} from './calendar'
+
+/**
+ * 2026-06-12 is a Friday; 2026-06-15 a Monday, 2026-06-14 a Sunday — fixed
+ * anchors for the week-start math.
+ */
+describe('weekOf', () => {
+  it('builds a Monday-first week containing the date', () => {
+    const week = weekOf('2026-06-12', 'monday')
+    expect(week).toEqual([
+      '2026-06-08',
+      '2026-06-09',
+      '2026-06-10',
+      '2026-06-11',
+      '2026-06-12',
+      '2026-06-13',
+      '2026-06-14',
+    ])
+  })
+
+  it('builds a Sunday-first week containing the date', () => {
+    const week = weekOf('2026-06-12', 'sunday')
+    expect(week[0]).toBe('2026-06-07')
+    expect(week[6]).toBe('2026-06-13')
+    expect(week).toContain('2026-06-12')
+  })
+
+  it('keeps a Sunday in its own Monday-first week (the wrap edge)', () => {
+    // 2026-06-14 is a Sunday: a Monday-first week runs Mon 06-08 … Sun 06-14.
+    expect(weekOf('2026-06-14', 'monday')).toEqual([
+      '2026-06-08',
+      '2026-06-09',
+      '2026-06-10',
+      '2026-06-11',
+      '2026-06-12',
+      '2026-06-13',
+      '2026-06-14',
+    ])
+  })
+})
+
+describe('monthLabel', () => {
+  it('formats the month and year', () => {
+    expect(monthLabel('2026-06-12')).toBe('June 2026')
+  })
+})
+
+describe('carousel window', () => {
+  it('centers the anchor and round-trips index↔date', () => {
+    const window = carouselWindow('2026-06-12')
+    expect(window.count).toBe(CAROUSEL_RADIUS * 2 + 1)
+    const center = carouselIndexOf(window, '2026-06-12')
+    expect(center).toBe(CAROUSEL_RADIUS)
+    expect(carouselDateAt(window, center)).toBe('2026-06-12')
+  })
+
+  it('returns -1 for a date outside the window', () => {
+    const window = carouselWindow('2026-06-12')
+    expect(carouselIndexOf(window, '2025-01-01')).toBe(-1)
+  })
+
+})

--- a/apps/desktop/src/mobile/calendar.ts
+++ b/apps/desktop/src/mobile/calendar.ts
@@ -1,0 +1,55 @@
+import { differenceInCalendarDays, format, getDay } from 'date-fns'
+import type { WeekStartDay } from '@reflect/core'
+import { addDaysIso, parseIsoDate } from '@/lib/dates'
+
+/**
+ * Date math for the V1-parity Daily surface: the week calendar strip and the
+ * swipeable day carousel. Pure; the components stay thin over it.
+ */
+
+/**
+ * Days either side of the carousel anchor. A generous fixed window (≈1 year
+ * each way) sidesteps runtime re-anchoring — Embla measures the empty slides
+ * cheaply, and only slides near the selection mount an editor (the same
+ * "generous static window" tactic the desktop daily stream uses with
+ * TanStack Virtual). Anchored once at mount; a date-link far outside it is a
+ * route navigation, not a swipe.
+ */
+export const CAROUSEL_RADIUS = 366
+
+/** The seven ISO dates of `date`'s week, honoring the week-start setting. */
+export function weekOf(date: string, weekStart: WeekStartDay): string[] {
+  const weekday = getDay(parseIsoDate(date)) // 0 = Sunday … 6 = Saturday
+  const offsetToFirst = weekStart === 'monday' ? (weekday === 0 ? -6 : 1 - weekday) : -weekday
+  const first = addDaysIso(date, offsetToFirst)
+  return Array.from({ length: 7 }, (_, index) => addDaysIso(first, index))
+}
+
+/** The strip's month header, e.g. `June 2026`. */
+export function monthLabel(date: string): string {
+  return format(parseIsoDate(date), 'MMMM yyyy')
+}
+
+/** A fixed slide window around an anchor date. */
+export interface CarouselWindow {
+  /** ISO date of slide 0 (the oldest). */
+  start: string
+  /** Total slide count. */
+  count: number
+}
+
+/** Build the window centered on `anchor` (the selected day at mount). */
+export function carouselWindow(anchor: string): CarouselWindow {
+  return { start: addDaysIso(anchor, -CAROUSEL_RADIUS), count: CAROUSEL_RADIUS * 2 + 1 }
+}
+
+/** The ISO date at `index` (0 = oldest). */
+export function carouselDateAt(window: CarouselWindow, index: number): string {
+  return addDaysIso(window.start, index)
+}
+
+/** The slide index of `date`, or `-1` when it lies outside the window. */
+export function carouselIndexOf(window: CarouselWindow, date: string): number {
+  const index = differenceInCalendarDays(parseIsoDate(date), parseIsoDate(window.start))
+  return index >= 0 && index < window.count ? index : -1
+}

--- a/apps/desktop/src/mobile/calendar.ts
+++ b/apps/desktop/src/mobile/calendar.ts
@@ -1,21 +1,14 @@
-import { differenceInCalendarDays, format, getDay } from 'date-fns'
+import { format, getDay } from 'date-fns'
 import type { WeekStartDay } from '@reflect/core'
 import { addDaysIso, parseIsoDate } from '@/lib/dates'
 
 /**
- * Date math for the V1-parity Daily surface: the week calendar strip and the
- * swipeable day carousel. Pure; the components stay thin over it.
+ * Date math for the V1-parity Daily surface's **calendar strip** — the month
+ * header and week row above the day carousel. Pure; the strip component stays
+ * thin over it. The carousel's own slide-window math is the shared
+ * {@link module:@/lib/day-window} (the desktop daily stream uses the same
+ * module), so day-paging stays consistent across surfaces.
  */
-
-/**
- * Days either side of the carousel anchor. A generous fixed window (≈1 year
- * each way) sidesteps runtime re-anchoring — Embla measures the empty slides
- * cheaply, and only slides near the selection mount an editor (the same
- * "generous static window" tactic the desktop daily stream uses with
- * TanStack Virtual). Anchored once at mount; a date-link far outside it is a
- * route navigation, not a swipe.
- */
-export const CAROUSEL_RADIUS = 366
 
 /** The seven ISO dates of `date`'s week, honoring the week-start setting. */
 export function weekOf(date: string, weekStart: WeekStartDay): string[] {
@@ -28,28 +21,4 @@ export function weekOf(date: string, weekStart: WeekStartDay): string[] {
 /** The strip's month header, e.g. `June 2026`. */
 export function monthLabel(date: string): string {
   return format(parseIsoDate(date), 'MMMM yyyy')
-}
-
-/** A fixed slide window around an anchor date. */
-export interface CarouselWindow {
-  /** ISO date of slide 0 (the oldest). */
-  start: string
-  /** Total slide count. */
-  count: number
-}
-
-/** Build the window centered on `anchor` (the selected day at mount). */
-export function carouselWindow(anchor: string): CarouselWindow {
-  return { start: addDaysIso(anchor, -CAROUSEL_RADIUS), count: CAROUSEL_RADIUS * 2 + 1 }
-}
-
-/** The ISO date at `index` (0 = oldest). */
-export function carouselDateAt(window: CarouselWindow, index: number): string {
-  return addDaysIso(window.start, index)
-}
-
-/** The slide index of `date`, or `-1` when it lies outside the window. */
-export function carouselIndexOf(window: CarouselWindow, date: string): number {
-  const index = differenceInCalendarDays(parseIsoDate(date), parseIsoDate(window.start))
-  return index >= 0 && index < window.count ? index : -1
 }

--- a/apps/desktop/src/mobile/day-carousel.tsx
+++ b/apps/desktop/src/mobile/day-carousel.tsx
@@ -59,26 +59,42 @@ export function DayCarousel({ date, onSelect }: DayCarouselProps): ReactElement 
   }, [emblaApi, onEmblaSelect])
 
   // Re-anchor only when the requested day falls outside the window (a far
-  // date link). Rebuilding the window remounts Embla at the new start index.
+  // date link). Rebuilds the window centered on it; the follow effect below
+  // then reinitializes Embla onto the new slides (it must not be short-
+  // circuited here, so `reportedRef` is left untouched).
   useEffect(() => {
     if (carouselIndexOf(window, date) === -1) {
-      reportedRef.current = date
       setWindow(carouselWindow(date))
     }
   }, [date, window])
 
-  // Follow an external selection (calendar strip tap, Today, date link) by
-  // scrolling to its slide — skipped when this is the echo of our own swipe.
+  // Follow an external selection (calendar strip tap, Today, date link). A
+  // re-anchor changes the slide set, so Embla is reinitialized onto the new
+  // window at the target slide; an in-window change just scrolls. Both are
+  // skipped when this is the echo of our own swipe.
+  const windowStartRef = useRef(window.start)
   useEffect(() => {
-    if (!emblaApi || date === reportedRef.current) {
+    if (!emblaApi) {
       return
     }
     const index = carouselIndexOf(window, date)
-    if (index !== -1) {
-      reportedRef.current = date
-      emblaApi.scrollTo(index, true)
-      setSelectedIndex(index)
+    if (index === -1) {
+      return // re-anchor pending — the window effect rebuilds, then this reruns
     }
+    if (windowStartRef.current !== window.start) {
+      // The window was re-anchored: reinit onto the rebuilt slides at the date.
+      windowStartRef.current = window.start
+      reportedRef.current = date
+      emblaApi.reInit({ startIndex: index })
+      setSelectedIndex(index)
+      return
+    }
+    if (date === reportedRef.current) {
+      return
+    }
+    reportedRef.current = date
+    emblaApi.scrollTo(index, true)
+    setSelectedIndex(index)
   }, [emblaApi, date, window])
 
   return (

--- a/apps/desktop/src/mobile/day-carousel.tsx
+++ b/apps/desktop/src/mobile/day-carousel.tsx
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react'
+import useEmblaCarousel from 'embla-carousel-react'
+import { dailyPath } from '@reflect/core'
+import { NotePane } from '@/components/note-pane'
+import { carouselDateAt, carouselIndexOf, carouselWindow, type CarouselWindow } from '@/mobile/calendar'
+
+interface DayCarouselProps {
+  /** The selected day (from the route). Drives the carousel position. */
+  date: string
+  /** Settle on a day — the parent turns this into a daily-route navigation. */
+  onSelect: (date: string) => void
+}
+
+/** Slides within this many of the selection mount an editor; the rest are
+ *  empty spacers Embla can still measure (bounds webview memory). */
+const MOUNT_RADIUS = 1
+
+/**
+ * V1's swipeable day carousel: horizontal paging between daily notes over a
+ * generous fixed window (≈1 year each way — no runtime re-anchoring). Each
+ * settled slide navigates its day; the route flows back in as `date` and
+ * scrolls the carousel to match (guarded so a swipe's own navigation doesn't
+ * re-scroll). A date-link beyond the window re-anchors the window around it
+ * — the rare case, never the common swipe.
+ */
+export function DayCarousel({ date, onSelect }: DayCarouselProps): ReactElement {
+  const [window, setWindow] = useState<CarouselWindow>(() => carouselWindow(date))
+  const [emblaRef, emblaApi] = useEmblaCarousel({
+    startIndex: carouselIndexOf(window, date),
+    align: 'center',
+    skipSnaps: false,
+  })
+  const [selectedIndex, setSelectedIndex] = useState(() => carouselIndexOf(window, date))
+  // The day we last reported via onSelect — so the route echo it produces
+  // doesn't trigger a redundant (animation-cancelling) scrollTo.
+  const reportedRef = useRef(date)
+
+  const onEmblaSelect = useCallback(
+    (api: NonNullable<typeof emblaApi>) => {
+      const index = api.selectedScrollSnap()
+      setSelectedIndex(index)
+      const day = carouselDateAt(window, index)
+      if (day !== reportedRef.current) {
+        reportedRef.current = day
+        onSelect(day)
+      }
+    },
+    [window, onSelect],
+  )
+
+  useEffect(() => {
+    if (!emblaApi) {
+      return
+    }
+    emblaApi.on('select', onEmblaSelect)
+    return () => {
+      emblaApi.off('select', onEmblaSelect)
+    }
+  }, [emblaApi, onEmblaSelect])
+
+  // Re-anchor only when the requested day falls outside the window (a far
+  // date link). Rebuilding the window remounts Embla at the new start index.
+  useEffect(() => {
+    if (carouselIndexOf(window, date) === -1) {
+      reportedRef.current = date
+      setWindow(carouselWindow(date))
+    }
+  }, [date, window])
+
+  // Follow an external selection (calendar strip tap, Today, date link) by
+  // scrolling to its slide — skipped when this is the echo of our own swipe.
+  useEffect(() => {
+    if (!emblaApi || date === reportedRef.current) {
+      return
+    }
+    const index = carouselIndexOf(window, date)
+    if (index !== -1) {
+      reportedRef.current = date
+      emblaApi.scrollTo(index, true)
+      setSelectedIndex(index)
+    }
+  }, [emblaApi, date, window])
+
+  return (
+    <div className="min-h-0 flex-1 overflow-hidden" ref={emblaRef}>
+      <div className="flex h-full">
+        {Array.from({ length: window.count }, (_, index) => {
+          const day = carouselDateAt(window, index)
+          const mounted = Math.abs(index - selectedIndex) <= MOUNT_RADIUS
+          return (
+            <div key={day} className="min-w-0 flex-[0_0_100%]">
+              {mounted ? (
+                <div
+                  className="h-full overflow-y-auto"
+                  style={{
+                    paddingBottom: 'max(env(safe-area-inset-bottom), var(--keyboard-height, 0px))',
+                  }}
+                >
+                  <NotePane
+                    path={dailyPath(day)}
+                    lazy
+                    gutterClassName="px-4"
+                    editorClassName="min-h-[60dvh]"
+                  />
+                </div>
+              ) : null}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/mobile/day-carousel.tsx
+++ b/apps/desktop/src/mobile/day-carousel.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react'
-import useEmblaCarousel from 'embla-carousel-react'
+import { type ReactElement } from 'react'
 import { dailyPath } from '@reflect/core'
 import { NotePane } from '@/components/note-pane'
-import { carouselDateAt, carouselIndexOf, carouselWindow, type CarouselWindow } from '@/mobile/calendar'
+import { dateAtIndex } from '@/lib/day-window'
+import { useDayCarousel } from '@/mobile/use-day-carousel'
 
 interface DayCarouselProps {
   /** The selected day (from the route). Drives the carousel position. */
@@ -16,92 +16,19 @@ interface DayCarouselProps {
 const MOUNT_RADIUS = 1
 
 /**
- * V1's swipeable day carousel: horizontal paging between daily notes over a
- * generous fixed window (≈1 year each way — no runtime re-anchoring). Each
- * settled slide navigates its day; the route flows back in as `date` and
- * scrolls the carousel to match (guarded so a swipe's own navigation doesn't
- * re-scroll). A date-link beyond the window re-anchors the window around it
- * — the rare case, never the common swipe.
+ * V1's swipeable day carousel: horizontal paging between daily notes. The slide
+ * window, Embla wiring, and route↔slide sync all live in {@link useDayCarousel};
+ * this component just renders the slides, mounting a `NotePane` only near the
+ * selection and leaving the rest as empty spacers.
  */
 export function DayCarousel({ date, onSelect }: DayCarouselProps): ReactElement {
-  const [window, setWindow] = useState<CarouselWindow>(() => carouselWindow(date))
-  const [emblaRef, emblaApi] = useEmblaCarousel({
-    startIndex: carouselIndexOf(window, date),
-    align: 'center',
-    skipSnaps: false,
-  })
-  const [selectedIndex, setSelectedIndex] = useState(() => carouselIndexOf(window, date))
-  // The day we last reported via onSelect — so the route echo it produces
-  // doesn't trigger a redundant (animation-cancelling) scrollTo.
-  const reportedRef = useRef(date)
-
-  const onEmblaSelect = useCallback(
-    (api: NonNullable<typeof emblaApi>) => {
-      const index = api.selectedScrollSnap()
-      setSelectedIndex(index)
-      const day = carouselDateAt(window, index)
-      if (day !== reportedRef.current) {
-        reportedRef.current = day
-        onSelect(day)
-      }
-    },
-    [window, onSelect],
-  )
-
-  useEffect(() => {
-    if (!emblaApi) {
-      return
-    }
-    emblaApi.on('select', onEmblaSelect)
-    return () => {
-      emblaApi.off('select', onEmblaSelect)
-    }
-  }, [emblaApi, onEmblaSelect])
-
-  // Re-anchor only when the requested day falls outside the window (a far
-  // date link). Rebuilds the window centered on it; the follow effect below
-  // then reinitializes Embla onto the new slides (it must not be short-
-  // circuited here, so `reportedRef` is left untouched).
-  useEffect(() => {
-    if (carouselIndexOf(window, date) === -1) {
-      setWindow(carouselWindow(date))
-    }
-  }, [date, window])
-
-  // Follow an external selection (calendar strip tap, Today, date link). A
-  // re-anchor changes the slide set, so Embla is reinitialized onto the new
-  // window at the target slide; an in-window change just scrolls. Both are
-  // skipped when this is the echo of our own swipe.
-  const windowStartRef = useRef(window.start)
-  useEffect(() => {
-    if (!emblaApi) {
-      return
-    }
-    const index = carouselIndexOf(window, date)
-    if (index === -1) {
-      return // re-anchor pending — the window effect rebuilds, then this reruns
-    }
-    if (windowStartRef.current !== window.start) {
-      // The window was re-anchored: reinit onto the rebuilt slides at the date.
-      windowStartRef.current = window.start
-      reportedRef.current = date
-      emblaApi.reInit({ startIndex: index })
-      setSelectedIndex(index)
-      return
-    }
-    if (date === reportedRef.current) {
-      return
-    }
-    reportedRef.current = date
-    emblaApi.scrollTo(index, true)
-    setSelectedIndex(index)
-  }, [emblaApi, date, window])
+  const { emblaRef, dayWindow, selectedIndex } = useDayCarousel(date, onSelect)
 
   return (
     <div className="min-h-0 flex-1 overflow-hidden" ref={emblaRef}>
       <div className="flex h-full">
-        {Array.from({ length: window.count }, (_, index) => {
-          const day = carouselDateAt(window, index)
+        {Array.from({ length: dayWindow.count }, (_, index) => {
+          const day = dateAtIndex(dayWindow, index)
           const mounted = Math.abs(index - selectedIndex) <= MOUNT_RADIUS
           return (
             <div key={day} className="min-w-0 flex-[0_0_100%]">

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -2,12 +2,36 @@ import { cleanup, render, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { format } from 'date-fns'
 import type { ReactElement } from 'react'
 import { setBridge } from '@reflect/core'
 import { RouterProvider, useRouter } from '@/routing/router'
 import type { Route } from '@/routing/route'
-import { addDaysIso, formatDayLabel, todayIso } from '@/lib/dates'
+import { parseIsoDate, todayIso } from '@/lib/dates'
+import { monthLabel, weekOf } from './calendar'
 import { MobileShell } from './mobile-shell'
+
+// jsdom implements none of these; Embla (the day carousel) needs them to init.
+class ObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+  takeRecords(): [] {
+    return []
+  }
+}
+globalThis.ResizeObserver ??= ObserverStub as unknown as typeof ResizeObserver
+globalThis.IntersectionObserver ??= ObserverStub as unknown as typeof IntersectionObserver
+globalThis.matchMedia ??= ((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  addListener: () => {},
+  removeListener: () => {},
+  dispatchEvent: () => false,
+})) as unknown as typeof matchMedia
 
 /**
  * The tabbed mobile shell (Plan 19, V1 parity): the daily spine pages
@@ -40,7 +64,7 @@ vi.mock('@/providers/graph-provider', () => ({
 }))
 vi.mock('@/providers/settings-provider', () => ({
   useSettings: () => ({
-    settings: { editorMarkdownSyntax: 'always', dateFormat: 'mdy' },
+    settings: { editorMarkdownSyntax: 'always', dateFormat: 'mdy', weekStartDay: 'monday' },
     updateSettings: async () => {},
   }),
 }))
@@ -101,8 +125,15 @@ function NavProbe({ to }: { to: Route }): ReactElement {
   )
 }
 
-function dayHeading(date: string): string {
-  return formatDayLabel(date, 'mdy')
+/** The calendar strip's per-day aria-label (CalendarStrip uses this form). */
+function dayCellLabel(date: string): string {
+  return format(parseIsoDate(date), 'EEEE, MMMM do')
+}
+
+/** A day in `date`'s week that isn't `date` itself (always present). */
+function otherDayInWeek(date: string): string {
+  const week = weekOf(date, 'monday')
+  return week.find((day) => day !== date) ?? week[0]
 }
 
 describe('MobileShell', () => {
@@ -111,24 +142,33 @@ describe('MobileShell', () => {
     files[`daily/${today}.md`] = 'captured on the go'
     const view = mount({ kind: 'today' })
 
-    expect(view.getByRole('heading').textContent).toContain(dayHeading(today))
+    // The header is the month; the carousel mounts today's slide (±1
+    // neighbours), and today's shows its note.
+    expect(view.getByRole('heading').textContent).toBe(monthLabel(today))
     await waitFor(() => {
-      expect(view.getByTestId('fake-editor').textContent).toContain('captured on the go')
+      const editors = view.getAllByTestId('fake-editor')
+      expect(editors.some((editor) => editor.textContent?.includes('captured on the go'))).toBe(true)
     })
   })
 
-  it('pages between days and jumps back to today', async () => {
+  it('selects a day from the calendar strip and jumps back to today', async () => {
     const user = userEvent.setup()
     const today = todayIso()
-    const yesterday = addDaysIso(today, -1)
+    const other = otherDayInWeek(today)
     const view = mount({ kind: 'today' })
 
     expect(view.queryByRole('button', { name: 'Today' })).toBeNull()
-    await user.click(view.getByRole('button', { name: 'Previous day' }))
-    expect(view.getByRole('heading').textContent).toContain(dayHeading(yesterday))
+    await user.click(view.getByRole('button', { name: dayCellLabel(other) }))
+    expect(view.getByRole('button', { name: dayCellLabel(other) }).getAttribute('aria-current')).toBe(
+      'date',
+    )
+    expect(view.getByRole('button', { name: 'Today' })).toBeTruthy()
 
     await user.click(view.getByRole('button', { name: 'Today' }))
-    expect(view.getByRole('heading').textContent).toContain(dayHeading(today))
+    expect(view.queryByRole('button', { name: 'Today' })).toBeNull()
+    expect(view.getByRole('button', { name: dayCellLabel(today) }).getAttribute('aria-current')).toBe(
+      'date',
+    )
   })
 
   it('opens a note from in-screen navigation and pops back through history', async () => {
@@ -140,7 +180,7 @@ describe('MobileShell', () => {
     expect(view.getByRole('heading').textContent).toContain('meeting-notes')
 
     await user.click(view.getByRole('button', { name: 'Back' }))
-    expect(view.getByRole('heading').textContent).toContain(dayHeading(todayIso()))
+    expect(view.getByRole('heading').textContent).toBe(monthLabel(todayIso()))
   })
 
   it('switches tabs: All shows the searchable list, Daily returns to today', async () => {
@@ -152,7 +192,7 @@ describe('MobileShell', () => {
     expect((await view.findByText('No notes yet')).textContent).toBe('No notes yet')
 
     await user.click(view.getByRole('button', { name: 'Daily' }))
-    expect(view.getByRole('heading').textContent).toContain(dayHeading(todayIso()))
+    expect(view.getByRole('heading').textContent).toBe(monthLabel(todayIso()))
   })
 
   it('renders a search entry as the All tab with the query seeded', async () => {
@@ -176,6 +216,6 @@ describe('MobileShell', () => {
     })
 
     await user.click(view.getByRole('button', { name: 'Back' }))
-    expect(view.getByRole('heading').textContent).toContain(dayHeading(todayIso()))
+    expect(view.getByRole('heading').textContent).toBe(monthLabel(todayIso()))
   })
 })

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -7,7 +7,7 @@ import type { ReactElement } from 'react'
 import { setBridge } from '@reflect/core'
 import { RouterProvider, useRouter } from '@/routing/router'
 import type { Route } from '@/routing/route'
-import { parseIsoDate, todayIso } from '@/lib/dates'
+import { addDaysIso, parseIsoDate, todayIso } from '@/lib/dates'
 import { monthLabel, weekOf } from './calendar'
 import { MobileShell } from './mobile-shell'
 
@@ -169,6 +169,22 @@ describe('MobileShell', () => {
     expect(view.getByRole('button', { name: dayCellLabel(today) }).getAttribute('aria-current')).toBe(
       'date',
     )
+  })
+
+  it('re-anchors the carousel when a date link lands outside its window', async () => {
+    const user = userEvent.setup()
+    // Beyond the ±366-day window — only reachable as a date-link navigation,
+    // which forces the carousel to rebuild its window around the day.
+    const farDay = addDaysIso(todayIso(), 400)
+    files[`daily/${farDay}.md`] = 'far future plans'
+    const view = mount({ kind: 'today' }, { kind: 'daily', date: farDay })
+
+    await user.click(view.getByRole('button', { name: 'probe-navigate' }))
+    expect(view.getByRole('heading').textContent).toBe(monthLabel(farDay))
+    await waitFor(() => {
+      const editors = view.getAllByTestId('fake-editor')
+      expect(editors.some((editor) => editor.textContent?.includes('far future plans'))).toBe(true)
+    })
   })
 
   it('opens a note from in-screen navigation and pops back through history', async () => {

--- a/apps/desktop/src/mobile/mobile-screen.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.tsx
@@ -24,8 +24,10 @@ export function MobileScreen({ allQuery, onAllQueryChange }: MobileScreenProps):
   const today = useToday()
 
   switch (route.kind) {
+    // One stable key for the whole daily surface (today + any day): a day
+    // change scrolls the carousel rather than remounting it.
     case 'daily':
-      return <MobileDaily key={route.date} date={route.date} />
+      return <MobileDaily key="daily" date={route.date} />
     case 'note':
       return <MobileNote key={route.path} path={route.path} />
     case 'allNotes':
@@ -36,6 +38,6 @@ export function MobileScreen({ allQuery, onAllQueryChange }: MobileScreenProps):
       // the live query from the entry.
       return <MobileAllNotes query={allQuery} onQueryChange={onAllQueryChange} tag={null} />
     default:
-      return <MobileDaily key="today" date={today} />
+      return <MobileDaily key="daily" date={today} />
   }
 }

--- a/apps/desktop/src/mobile/screens/daily.tsx
+++ b/apps/desktop/src/mobile/screens/daily.tsx
@@ -2,6 +2,7 @@ import { type ReactElement } from 'react'
 import { Plus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { untitledNotePath } from '@/lib/create-note'
+import { todayIso } from '@/lib/dates'
 import { CalendarStrip } from '@/mobile/calendar-strip'
 import { DayCarousel } from '@/mobile/day-carousel'
 import { useRouter } from '@/routing/router'
@@ -19,7 +20,11 @@ import { useRouter } from '@/routing/router'
  */
 export function MobileDaily({ date }: { date: string }): ReactElement {
   const { navigate } = useRouter()
-  const select = (day: string): void => navigate({ kind: 'daily', date: day })
+  // Selecting today routes to the live `today` route (not a frozen `daily`
+  // date), so the spine keeps rolling over at midnight — the Today button and
+  // tapping today's cell both land here.
+  const select = (day: string): void =>
+    navigate(day === todayIso() ? { kind: 'today' } : { kind: 'daily', date: day })
 
   return (
     <div className="flex h-full w-screen flex-col">

--- a/apps/desktop/src/mobile/screens/daily.tsx
+++ b/apps/desktop/src/mobile/screens/daily.tsx
@@ -2,7 +2,7 @@ import { type ReactElement } from 'react'
 import { Plus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { untitledNotePath } from '@/lib/create-note'
-import { todayIso } from '@/lib/dates'
+import { useToday } from '@/lib/use-today'
 import { CalendarStrip } from '@/mobile/calendar-strip'
 import { DayCarousel } from '@/mobile/day-carousel'
 import { useRouter } from '@/routing/router'
@@ -20,15 +20,18 @@ import { useRouter } from '@/routing/router'
  */
 export function MobileDaily({ date }: { date: string }): ReactElement {
   const { navigate } = useRouter()
-  // Selecting today routes to the live `today` route (not a frozen `daily`
-  // date), so the spine keeps rolling over at midnight — the Today button and
-  // tapping today's cell both land here.
+  // One live `today` for the whole surface: the strip marks today's cell and
+  // the `select` below decide "is this today?" from the *same* value, so they
+  // can't disagree across the midnight rollover (which would otherwise route a
+  // tap on the highlighted today cell to a frozen `daily` date). Selecting
+  // today routes to the live `today` route, keeping the spine rolling over.
+  const today = useToday()
   const select = (day: string): void =>
-    navigate(day === todayIso() ? { kind: 'today' } : { kind: 'daily', date: day })
+    navigate(day === today ? { kind: 'today' } : { kind: 'daily', date: day })
 
   return (
     <div className="flex h-full w-screen flex-col">
-      <CalendarStrip date={date} onSelect={select} />
+      <CalendarStrip date={date} today={today} onSelect={select} />
       <DayCarousel date={date} onSelect={select} />
       <Button
         size="icon"

--- a/apps/desktop/src/mobile/screens/daily.tsx
+++ b/apps/desktop/src/mobile/screens/daily.tsx
@@ -1,65 +1,30 @@
 import { type ReactElement } from 'react'
-import { ChevronLeft, ChevronRight, Plus } from 'lucide-react'
-import { dailyPath } from '@reflect/core'
-import { NotePane } from '@/components/note-pane'
+import { Plus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { untitledNotePath } from '@/lib/create-note'
-import { addDaysIso, formatDayLabel } from '@/lib/dates'
-import { useToday } from '@/lib/use-today'
-import { useSettings } from '@/providers/settings-provider'
+import { CalendarStrip } from '@/mobile/calendar-strip'
+import { DayCarousel } from '@/mobile/day-carousel'
 import { useRouter } from '@/routing/router'
 
 /**
- * One daily note — the mobile spine (Plan 19). The header pages between
- * days, with a jump back to today whenever the view has wandered; the body
- * is the shared document stack via `NotePane`, exactly as on desktop. The
- * scroll container yields to the keyboard via `--keyboard-height`, and the
- * new-note button floats above both — V1 parity: the daily note itself is
- * the capture surface, and `+` opens a fresh untitled note (the same
- * seed/ghost-title flow as desktop's ⌘N).
+ * The mobile spine (Plan 19, V1 parity): a month header + week calendar strip
+ * over a swipeable day carousel of daily notes. The strip and the carousel
+ * stay in lockstep through `date` — tapping a strip day or swiping the
+ * carousel both navigate a daily route, which flows back as `date`. The
+ * new-note button floats above it all (V1: the daily note is the capture
+ * surface; `+` opens a fresh untitled note via desktop's ⌘N seed flow).
+ *
+ * Mounted once for the daily surface (a stable key in `MobileScreen`), so a
+ * day change scrolls the carousel rather than remounting it.
  */
 export function MobileDaily({ date }: { date: string }): ReactElement {
-  const { settings } = useSettings()
   const { navigate } = useRouter()
-  // Live: the Today affordance appears at midnight without a re-navigation.
-  const isToday = date === useToday()
+  const select = (day: string): void => navigate({ kind: 'daily', date: day })
 
   return (
-    <div className="flex h-full w-screen flex-col" style={{ paddingTop: 'env(safe-area-inset-top)' }}>
-      <header className="flex shrink-0 items-center gap-1 border-b border-border px-1 pb-1">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-10"
-          aria-label="Previous day"
-          onClick={() => navigate({ kind: 'daily', date: addDaysIso(date, -1) })}
-        >
-          <ChevronLeft />
-        </Button>
-        <h1 className="min-w-0 flex-1 truncate text-center text-base font-semibold">
-          {formatDayLabel(date, settings.dateFormat)}
-        </h1>
-        {!isToday && (
-          <Button variant="ghost" size="sm" onClick={() => navigate({ kind: 'today' })}>
-            Today
-          </Button>
-        )}
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-10"
-          aria-label="Next day"
-          onClick={() => navigate({ kind: 'daily', date: addDaysIso(date, 1) })}
-        >
-          <ChevronRight />
-        </Button>
-      </header>
-      <main
-        className="min-h-0 flex-1 overflow-y-auto"
-        style={{ paddingBottom: 'max(env(safe-area-inset-bottom), var(--keyboard-height, 0px))' }}
-      >
-        <NotePane path={dailyPath(date)} lazy gutterClassName="px-4" editorClassName="min-h-[60dvh]" />
-      </main>
+    <div className="flex h-full w-screen flex-col">
+      <CalendarStrip date={date} onSelect={select} />
+      <DayCarousel date={date} onSelect={select} />
       <Button
         size="icon"
         aria-label="New note"

--- a/apps/desktop/src/mobile/use-day-carousel.test.ts
+++ b/apps/desktop/src/mobile/use-day-carousel.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { reconcileCarousel, type ReconcileInput } from './use-day-carousel'
+
+/**
+ * The carousel's follow-the-route decision in isolation — Embla pointer
+ * gestures can't be driven under jsdom, so the branchy reconciliation that the
+ * integration test can only reach indirectly is pinned here as pure logic.
+ */
+const base: ReconcileInput = {
+  index: 10,
+  windowStart: '2025-06-11',
+  lastWindowStart: '2025-06-11',
+  date: '2026-06-12',
+  reported: '2026-06-01',
+}
+
+describe('reconcileCarousel', () => {
+  it('scrolls for an ordinary in-window jump', () => {
+    expect(reconcileCarousel(base)).toEqual({ action: 'scroll', index: 10 })
+  })
+
+  it('does nothing for the echo of our own swipe', () => {
+    // The route just echoed back the day we reported — re-scrolling would
+    // cancel Embla's settling animation.
+    expect(reconcileCarousel({ ...base, date: '2026-06-01', reported: '2026-06-01' })).toEqual({
+      action: 'none',
+    })
+  })
+
+  it('does nothing when the date is outside the window (a re-anchor is pending)', () => {
+    expect(reconcileCarousel({ ...base, index: -1 })).toEqual({ action: 'none' })
+  })
+
+  it('reinitializes when the window was re-anchored', () => {
+    expect(reconcileCarousel({ ...base, lastWindowStart: '2024-01-01' })).toEqual({
+      action: 'reinit',
+      index: 10,
+    })
+  })
+
+  it('reinitializes after a re-anchor even when the date matches the last report', () => {
+    // A far date link re-anchors *and* is later echoed back: the window change
+    // must win over the echo guard, or the rebuilt slides never get shown.
+    expect(
+      reconcileCarousel({
+        ...base,
+        lastWindowStart: '2024-01-01',
+        date: '2026-06-01',
+        reported: '2026-06-01',
+      }),
+    ).toEqual({ action: 'reinit', index: 10 })
+  })
+
+  it('treats an outside date as a no-op even while the window is mid-re-anchor', () => {
+    // `index === -1` is checked first: the window effect will rebuild before
+    // this reconciliation matters, so there is nothing to scroll yet.
+    expect(reconcileCarousel({ ...base, index: -1, lastWindowStart: '2024-01-01' })).toEqual({
+      action: 'none',
+    })
+  })
+})

--- a/apps/desktop/src/mobile/use-day-carousel.ts
+++ b/apps/desktop/src/mobile/use-day-carousel.ts
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import useEmblaCarousel from 'embla-carousel-react'
+import { createDayWindow, dateAtIndex, indexWithin, type DayWindow } from '@/lib/day-window'
+
+/**
+ * Days either side of the carousel anchor. A generous fixed **symmetric**
+ * window (~1 year each way) lets Embla page between days without runtime
+ * re-anchoring; only the slides near the selection mount an editor, so the
+ * empty ones are cheap spacers. A date-link beyond it (the rare case)
+ * re-anchors the window around the new day. The desktop daily stream shares the
+ * window math ({@link createDayWindow}) with a wider, asymmetric reach — but it
+ * truly virtualizes its rows, where the carousel renders every slide spacer and
+ * only mounts the editors near the selection.
+ */
+export const CAROUSEL_RADIUS = 366
+
+const CAROUSEL_WINDOW: Readonly<{ past: number; future: number }> = {
+  past: CAROUSEL_RADIUS,
+  future: CAROUSEL_RADIUS,
+}
+
+/** What the carousel should do when the external target `date` changes. */
+export type CarouselSync =
+  | { action: 'none' }
+  | { action: 'reinit'; index: number }
+  | { action: 'scroll'; index: number }
+
+/** Inputs to {@link reconcileCarousel} — all plain values, no Embla handle. */
+export interface ReconcileInput {
+  /** Index of the target date in the current window, or `-1` if outside it. */
+  index: number
+  /** The current window's start date. */
+  windowStart: string
+  /** The window start the carousel was last reconciled against. */
+  lastWindowStart: string
+  /** The target date the carousel is being asked to show. */
+  date: string
+  /** The day last reported back through `onSelect` — the echo guard. */
+  reported: string
+}
+
+/**
+ * Decide how the carousel should follow an external `date` change. Pure, so the
+ * branchy reconciliation can be unit-tested without driving Embla:
+ *
+ * - `none` when the date is outside the window (`index === -1`, a re-anchor is
+ *   pending) or is the echo of our own swipe (already reported) — re-scrolling
+ *   then would cancel the in-flight animation.
+ * - `reinit` when the window was re-anchored (its start moved): Embla must
+ *   reinitialize onto the rebuilt slide set at the target index.
+ * - `scroll` for an ordinary in-window jump (calendar tap, Today, near link).
+ */
+export function reconcileCarousel(input: ReconcileInput): CarouselSync {
+  if (input.index === -1) {
+    return { action: 'none' }
+  }
+  if (input.windowStart !== input.lastWindowStart) {
+    return { action: 'reinit', index: input.index }
+  }
+  if (input.date === input.reported) {
+    return { action: 'none' }
+  }
+  return { action: 'scroll', index: input.index }
+}
+
+export interface DayCarousel {
+  /** Attach to the Embla viewport element. */
+  emblaRef: ReturnType<typeof useEmblaCarousel>[0]
+  /** The current slide window (`count` is the slide total). */
+  dayWindow: DayWindow
+  /** The centered slide's index — the view mounts editors around it. */
+  selectedIndex: number
+}
+
+/**
+ * Drives the swipeable day carousel: owns the slide window, the Embla instance,
+ * and the bidirectional `date ↔ slide` sync, leaving {@link DayCarousel} (the
+ * component) purely declarative.
+ *
+ * A settled swipe reports its day via `onSelect` (which the parent turns into a
+ * daily-route navigation); the route flows back in as `date` and scrolls the
+ * carousel to match — guarded by {@link reconcileCarousel} so the swipe's own
+ * echo doesn't re-scroll and cancel the animation. A `date` beyond the window
+ * re-anchors it, and the follow effect then reinitializes Embla onto the new
+ * slides.
+ */
+export function useDayCarousel(date: string, onSelect: (date: string) => void): DayCarousel {
+  const [dayWindow, setDayWindow] = useState<DayWindow>(() => createDayWindow(date, CAROUSEL_WINDOW))
+  const [emblaRef, emblaApi] = useEmblaCarousel({
+    startIndex: indexWithin(dayWindow, date),
+    align: 'center',
+    skipSnaps: false,
+  })
+  const [selectedIndex, setSelectedIndex] = useState(() => indexWithin(dayWindow, date))
+  // The day we last reported via onSelect — so the route echo it produces
+  // doesn't trigger a redundant (animation-cancelling) scrollTo.
+  const reportedRef = useRef(date)
+  // The window start we last reconciled against — a change means a re-anchor,
+  // so Embla must reinitialize rather than scroll.
+  const windowStartRef = useRef(dayWindow.start)
+
+  const onEmblaSelect = useCallback(
+    (api: NonNullable<typeof emblaApi>) => {
+      const index = api.selectedScrollSnap()
+      setSelectedIndex(index)
+      const day = dateAtIndex(dayWindow, index)
+      if (day !== reportedRef.current) {
+        reportedRef.current = day
+        onSelect(day)
+      }
+    },
+    [dayWindow, onSelect],
+  )
+
+  useEffect(() => {
+    if (!emblaApi) {
+      return
+    }
+    emblaApi.on('select', onEmblaSelect)
+    return () => {
+      emblaApi.off('select', onEmblaSelect)
+    }
+  }, [emblaApi, onEmblaSelect])
+
+  // Re-anchor only when the requested day falls outside the window (a far date
+  // link): rebuild the window centered on it. The follow effect below then
+  // reinitializes Embla onto the new slides — so `reportedRef` is left
+  // untouched here.
+  useEffect(() => {
+    if (indexWithin(dayWindow, date) === -1) {
+      setDayWindow(createDayWindow(date, CAROUSEL_WINDOW))
+    }
+  }, [date, dayWindow])
+
+  // Follow an external selection (calendar tap, Today, date link): scroll, or
+  // reinit after a re-anchor, or do nothing for our own swipe's echo —
+  // {@link reconcileCarousel} owns the decision.
+  useEffect(() => {
+    if (!emblaApi) {
+      return
+    }
+    const sync = reconcileCarousel({
+      index: indexWithin(dayWindow, date),
+      windowStart: dayWindow.start,
+      lastWindowStart: windowStartRef.current,
+      date,
+      reported: reportedRef.current,
+    })
+    if (sync.action === 'none') {
+      return
+    }
+    windowStartRef.current = dayWindow.start
+    reportedRef.current = date
+    if (sync.action === 'reinit') {
+      emblaApi.reInit({ startIndex: sync.index })
+    } else {
+      emblaApi.scrollTo(sync.index, true)
+    }
+    setSelectedIndex(sync.index)
+  }, [emblaApi, date, dayWindow])
+
+  return { emblaRef, dayWindow, selectedIndex }
+}

--- a/apps/desktop/src/mobile/use-day-carousel.ts
+++ b/apps/desktop/src/mobile/use-day-carousel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import useEmblaCarousel from 'embla-carousel-react'
 import { createDayWindow, dateAtIndex, indexWithin, type DayWindow } from '@/lib/day-window'
 
@@ -125,8 +125,9 @@ export function useDayCarousel(date: string, onSelect: (date: string) => void): 
   // Re-anchor only when the requested day falls outside the window (a far date
   // link): rebuild the window centered on it. The follow effect below then
   // reinitializes Embla onto the new slides — so `reportedRef` is left
-  // untouched here.
-  useEffect(() => {
+  // untouched here. Layout effect so the rebuilt window + scroll land in the
+  // same frame as the strip's new selection (no visible lag).
+  useLayoutEffect(() => {
     if (indexWithin(dayWindow, date) === -1) {
       setDayWindow(createDayWindow(date, CAROUSEL_WINDOW))
     }
@@ -134,8 +135,11 @@ export function useDayCarousel(date: string, onSelect: (date: string) => void): 
 
   // Follow an external selection (calendar tap, Today, date link): scroll, or
   // reinit after a re-anchor, or do nothing for our own swipe's echo —
-  // {@link reconcileCarousel} owns the decision.
-  useEffect(() => {
+  // {@link reconcileCarousel} owns the decision. A *layout* effect so Embla's
+  // scroll and `selectedIndex` (which decides slide mounting) update before
+  // paint — otherwise the centered/mounted slide lags the route by a frame and
+  // the strip could show one day while the editor still shows the previous.
+  useLayoutEffect(() => {
     if (!emblaApi) {
       return
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
+      embla-carousel-react:
+        specifier: ^8.6.0
+        version: 8.6.0(react@19.2.7)
       lucide-react:
         specifier: ^1.17.0
         version: 1.17.0(react@19.2.7)
@@ -2923,6 +2926,19 @@ packages:
 
   electron-to-chromium@1.5.368:
     resolution: {integrity: sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==}
+
+  embla-carousel-react@8.6.0:
+    resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
+  embla-carousel-reactive-utils@8.6.0:
+    resolution: {integrity: sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==}
+    peerDependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel@8.6.0:
+    resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -7869,6 +7885,18 @@ snapshots:
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.368: {}
+
+  embla-carousel-react@8.6.0(react@19.2.7):
+    dependencies:
+      embla-carousel: 8.6.0
+      embla-carousel-reactive-utils: 8.6.0(embla-carousel@8.6.0)
+      react: 19.2.7
+
+  embla-carousel-reactive-utils@8.6.0(embla-carousel@8.6.0):
+    dependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel@8.6.0: {}
 
   emoji-regex@10.6.0: {}
 


### PR DESCRIPTION
## Summary

The big visual step toward the V1 screenshot: the Daily surface gets V1's month header + week calendar strip over a swipeable day carousel, replacing the chevron pager.

- **[CalendarStrip](apps/desktop/src/mobile/calendar-strip.tsx)** — `June 2026` header and the selected day's week as seven day-of-week/number cells; the selected day circled, today dotted, a **Today** affordance when the selection has wandered. Honors the `weekStartDay` setting.
- **[DayCarousel](apps/desktop/src/mobile/day-carousel.tsx)** — horizontal paging between daily notes on Embla. Strip taps and swipes both navigate daily routes; the route flows back as the selected date and scrolls the carousel (guarded so a swipe's own navigation doesn't re-scroll). A generous fixed **±366-day window** sidesteps runtime re-anchoring (the desktop daily-stream tactic), and only slides within **±1** of the selection mount a `NotePane`, bounding webview memory. The daily surface mounts once (stable key in `MobileScreen`), so a day change scrolls rather than remounts.
- **[calendar.ts](apps/desktop/src/mobile/calendar.ts)** — pure date math (week-start-aware week, month label, window index↔date), 6 unit tests.

## Verification

- Simulator (matches the V1 screenshot): the strip renders `June 2026` + M–S with 12 circled; swiping pages to the 13th (12 keeps its today-dot, Today button appears); tapping the 9th navigates there; Today returns to the 12th; and **editing inside a slide saves to the right day** — `daily/2026-06-09.md` round-tripped the typed text.
- 15/15 mobile tests (shell test grows Embla jsdom stubs + strip-cell-driven day selection); `pnpm check` clean. Rebased on `next` past the Gists merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core mobile daily navigation and note editing paths with non-trivial Embla/route sync; desktop day-window API is extended but defaults preserve existing stream behavior.
> 
> **Overview**
> **Mobile Daily** drops prev/next chevrons for a **month header + week calendar strip** (respecting `weekStartDay`) over a **horizontal swipe carousel** of daily notes. Strip taps, swipes, and routes stay aligned; **Today** appears when the selection isn’t live today, and selecting today uses the `today` route for midnight rollover.
> 
> The carousel uses **Embla** with a fixed **±366-day** slide window from shared `day-window` math. **`createDayWindow`** now accepts custom past/future radii; **`indexWithin`** returns `-1` outside the window so far date links **re-anchor** the window (desktop stream still uses clamping via **`indexOfDate`**). **`useDayCarousel`** syncs route ↔ slides via **`reconcileCarousel`** (scroll, reinit, or no-op on swipe echo). Only slides within **±1** of the selection mount **`NotePane`** to cap memory. **`MobileScreen`** keeps a stable **`daily`** key so day changes scroll the carousel instead of remounting.
> 
> Adds **`embla-carousel-react`**, calendar helpers/tests, carousel reconciliation tests, and updates mobile shell tests (Embla jsdom stubs, strip-driven navigation, far-date re-anchor).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b8d40751f90e84d33c121c1c4ea20a9c08bd7b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile daily calendar now includes a swipeable carousel for horizontal day navigation and a week strip for quick date selection.

* **Tests**
  * Added comprehensive test coverage for new calendar utilities and mobile screen interactions.

* **Refactor**
  * Restructured mobile daily screen to use carousel-based date navigation instead of traditional controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->