### PR TITLE
Fix command failure labels + iOS bundle version (bugs from #155 + a related one)

### DIFF
--- a/apps/desktop/src-tauri/gen/apple/project.yml
+++ b/apps/desktop/src-tauri/gen/apple/project.yml
@@ -61,8 +61,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "0.1.0"
+        CFBundleShortVersionString: "0.2.0-beta.1"
+        CFBundleVersion: "0.2.0-beta.1"
     entitlements:
       path: reflect-open_iOS/reflect-open_iOS.entitlements
     scheme:

--- a/apps/desktop/src-tauri/gen/apple/project.yml
+++ b/apps/desktop/src-tauri/gen/apple/project.yml
@@ -61,8 +61,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: "0.2.0-beta.1"
-        CFBundleVersion: "0.2.0-beta.1"
+        CFBundleShortVersionString: 0.2.0
+        CFBundleVersion: 0.2.0
     entitlements:
       path: reflect-open_iOS/reflect-open_iOS.entitlements
     scheme:

--- a/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/Info.plist
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.0-beta.1</string>
+	<string>0.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.2.0-beta.1</string>
+	<string>0.2.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>

--- a/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/Info.plist
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>0.2.0-beta.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.1.0</string>
+	<string>0.2.0-beta.1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>

--- a/apps/desktop/src-tauri/ios.project.yml
+++ b/apps/desktop/src-tauri/ios.project.yml
@@ -61,8 +61,11 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: "0.2.0-beta.1"
-        CFBundleVersion: "0.2.0-beta.1"
+        # Rendered by Tauri from `version` in tauri.conf.json (the prerelease
+        # tag is stripped — Apple requires three dot-separated integers), so the
+        # version lives in one place and never drifts. Do not hardcode a literal.
+        CFBundleShortVersionString: {{apple.bundle-version-short}}
+        CFBundleVersion: {{apple.bundle-version}}
     entitlements:
       path: reflect-open_iOS/reflect-open_iOS.entitlements
     scheme:

--- a/apps/desktop/src-tauri/ios.project.yml
+++ b/apps/desktop/src-tauri/ios.project.yml
@@ -61,8 +61,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "0.1.0"
+        CFBundleShortVersionString: "0.2.0-beta.1"
+        CFBundleVersion: "0.2.0-beta.1"
     entitlements:
       path: reflect-open_iOS/reflect-open_iOS.entitlements
     scheme:

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { EmbedStatus } from '@reflect/core'
+import type { EmbedStatus, NoteRow } from '@reflect/core'
 import type { Route } from '@/routing/route'
 import { resetOperations } from '@/lib/operations'
 import type { CommandContext } from './types'
@@ -11,16 +11,28 @@ const embedStatus = vi.hoisted(() =>
 )
 const backfillEmbeddingsVisibly = vi.hoisted(() => vi.fn(async () => 'completed'))
 const toggleNotePinned = vi.hoisted(() => vi.fn(async () => true))
+const toggleNotePrivate = vi.hoisted(() => vi.fn(async () => true))
+const getNote = vi.hoisted(() => vi.fn<() => Promise<NoteRow | undefined>>(async () => undefined))
+const operationFail = vi.hoisted(() => vi.fn())
+const startOperation = vi.hoisted(() =>
+  vi.fn(() => ({ progress: vi.fn(), done: vi.fn(), fail: operationFail })),
+)
 vi.mock('@/lib/semantic', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/semantic')>()),
   backfillEmbeddingsVisibly,
 }))
 vi.mock('@/lib/note-pin', () => ({ toggleNotePinned }))
+vi.mock('@/lib/note-private', () => ({ toggleNotePrivate }))
+vi.mock('@/lib/operations', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/operations')>()),
+  startOperation,
+}))
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   randomNotePath,
   rebuildIndex,
   embedStatus,
+  getNote,
 }))
 
 // Importing registers the commands (module side effect, like production).
@@ -51,6 +63,18 @@ function fakeContext(overrides?: Partial<CommandContext>) {
     ...overrides,
   }
   return { context, navigated }
+}
+
+function noteRow(isPrivate: boolean): NoteRow {
+  return {
+    path: 'notes/a.md',
+    title: 'A',
+    dailyDate: null,
+    isPrivate,
+    hasConflict: false,
+    gistUrl: null,
+    gistStale: false,
+  }
 }
 
 describe('keybindingFor', () => {
@@ -154,6 +178,37 @@ describe('app commands', () => {
     const { context: noGraph } = fakeContext({ generation: () => null })
     await command('note.togglePin').run(noGraph)
     expect(toggleNotePinned).not.toHaveBeenCalled()
+  })
+
+  it('note.togglePrivate flips the flag of the route note without surfacing an operation', async () => {
+    toggleNotePrivate.mockClear()
+    startOperation.mockClear()
+    getNote.mockResolvedValueOnce(noteRow(false))
+    const { context } = fakeContext({ route: () => ({ kind: 'note', path: 'notes/a.md' }) })
+    await command('note.togglePrivate').run(context)
+    expect(toggleNotePrivate).toHaveBeenCalledWith('notes/a.md', 7)
+    expect(startOperation).not.toHaveBeenCalled()
+  })
+
+  it('note.togglePrivate reports a failed lock as "Locking note"', async () => {
+    startOperation.mockClear()
+    operationFail.mockClear()
+    getNote.mockResolvedValueOnce(noteRow(false))
+    toggleNotePrivate.mockRejectedValueOnce({ kind: 'io', message: 'disk on fire' })
+    const { context } = fakeContext({ route: () => ({ kind: 'note', path: 'notes/a.md' }) })
+    // runCommand has no error channel — the command must absorb and report.
+    await expect(command('note.togglePrivate').run(context)).resolves.toBeUndefined()
+    expect(startOperation).toHaveBeenCalledWith('Locking note')
+    expect(operationFail).toHaveBeenCalledTimes(1)
+  })
+
+  it('note.togglePrivate reports a failed unlock as "Unlocking note"', async () => {
+    startOperation.mockClear()
+    getNote.mockResolvedValueOnce(noteRow(true))
+    toggleNotePrivate.mockRejectedValueOnce({ kind: 'io', message: 'disk on fire' })
+    const { context } = fakeContext({ route: () => ({ kind: 'note', path: 'notes/a.md' }) })
+    await expect(command('note.togglePrivate').run(context)).resolves.toBeUndefined()
+    expect(startOperation).toHaveBeenCalledWith('Unlocking note')
   })
 
   it('semantic.enable persists the opt-in through the context capability', async () => {

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { EmbedStatus, NoteRow } from '@reflect/core'
+import type { EmbedStatus, NoteRow, PinnedNote } from '@reflect/core'
 import type { Route } from '@/routing/route'
 import { resetOperations } from '@/lib/operations'
 import type { CommandContext } from './types'
@@ -13,6 +13,7 @@ const backfillEmbeddingsVisibly = vi.hoisted(() => vi.fn(async () => 'completed'
 const toggleNotePinned = vi.hoisted(() => vi.fn(async () => true))
 const toggleNotePrivate = vi.hoisted(() => vi.fn(async () => true))
 const getNote = vi.hoisted(() => vi.fn<() => Promise<NoteRow | undefined>>(async () => undefined))
+const getPinnedNotes = vi.hoisted(() => vi.fn<() => Promise<PinnedNote[]>>(async () => []))
 const operationFail = vi.hoisted(() => vi.fn())
 const startOperation = vi.hoisted(() =>
   vi.fn(() => ({ progress: vi.fn(), done: vi.fn(), fail: operationFail })),
@@ -33,6 +34,7 @@ vi.mock('@reflect/core', async (importOriginal) => ({
   rebuildIndex,
   embedStatus,
   getNote,
+  getPinnedNotes,
 }))
 
 // Importing registers the commands (module side effect, like production).
@@ -159,16 +161,24 @@ describe('app commands', () => {
     expect(toggleNotePinned).toHaveBeenCalledWith('daily/2026-06-09.md', 7)
   })
 
-  it('note.togglePin reports a failed toggle as an operation, never an unhandled throw', async () => {
-    try {
-      toggleNotePinned.mockClear()
-      toggleNotePinned.mockRejectedValueOnce({ kind: 'io', message: 'disk on fire' })
-      const { context } = fakeContext({ route: () => ({ kind: 'note', path: 'notes/a.md' }) })
-      // runCommand has no error channel — the command must absorb and report.
-      await expect(command('note.togglePin').run(context)).resolves.toBeUndefined()
-    } finally {
-      resetOperations()
-    }
+  it('note.togglePin reports a failed pin as "Pinning note", never an unhandled throw', async () => {
+    toggleNotePinned.mockClear()
+    startOperation.mockClear()
+    getPinnedNotes.mockResolvedValueOnce([])
+    toggleNotePinned.mockRejectedValueOnce({ kind: 'io', message: 'disk on fire' })
+    const { context } = fakeContext({ route: () => ({ kind: 'note', path: 'notes/a.md' }) })
+    // runCommand has no error channel — the command must absorb and report.
+    await expect(command('note.togglePin').run(context)).resolves.toBeUndefined()
+    expect(startOperation).toHaveBeenCalledWith('Pinning note')
+  })
+
+  it('note.togglePin reports a failed unpin as "Unpinning note"', async () => {
+    startOperation.mockClear()
+    getPinnedNotes.mockResolvedValueOnce([{ path: 'notes/a.md', title: 'A', dailyDate: null }])
+    toggleNotePinned.mockRejectedValueOnce({ kind: 'io', message: 'disk on fire' })
+    const { context } = fakeContext({ route: () => ({ kind: 'note', path: 'notes/a.md' }) })
+    await expect(command('note.togglePin').run(context)).resolves.toBeUndefined()
+    expect(startOperation).toHaveBeenCalledWith('Unpinning note')
   })
 
   it('note.togglePin no-ops on note-less routes and without a graph', async () => {

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -1,4 +1,4 @@
-import { errorMessage, randomNotePath } from '@reflect/core'
+import { errorMessage, getNote, randomNotePath } from '@reflect/core'
 import { untitledNotePath } from '@/lib/create-note'
 import { todayIso } from '@/lib/dates'
 import { runGistPublish } from '@/lib/note-gist'
@@ -109,10 +109,15 @@ const APP_COMMANDS: AppCommand[] = [
       if (generation === null || path === null) {
         return
       }
+      // Read the current flag first so a failure is surfaced with the toggle's
+      // actual direction — the sidebar's Lock/Unlock wording — instead of a
+      // fixed "private" label that misreads when the user is unlocking.
+      let wasPrivate = false
       try {
+        wasPrivate = (await getNote(path))?.isPrivate ?? false
         await toggleNotePrivate(path, generation)
       } catch (cause) {
-        startOperation('Marking note as private').fail(errorMessage(cause))
+        startOperation(wasPrivate ? 'Unlocking note' : 'Locking note').fail(errorMessage(cause))
       }
     },
   },

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -1,4 +1,4 @@
-import { errorMessage, getNote, randomNotePath } from '@reflect/core'
+import { errorMessage, getNote, getPinnedNotes, randomNotePath } from '@reflect/core'
 import { untitledNotePath } from '@/lib/create-note'
 import { todayIso } from '@/lib/dates'
 import { runGistPublish } from '@/lib/note-gist'
@@ -86,12 +86,16 @@ const APP_COMMANDS: AppCommand[] = [
       if (generation === null || path === null) {
         return
       }
+      // Read the current state first so a failure is surfaced with the toggle's
+      // actual direction — the sidebar's pin/unpin wording — not a fixed label.
+      let wasPinned = false
       try {
+        wasPinned = (await getPinnedNotes()).some((note) => note.path === path)
         await toggleNotePinned(path, generation)
       } catch (cause) {
         // runCommand has no error channel of its own — an unreported failure
         // here would be a silent ⌘O. Surface it like other background work.
-        startOperation('Pinning note').fail(errorMessage(cause))
+        startOperation(wasPinned ? 'Unpinning note' : 'Pinning note').fail(errorMessage(cause))
       }
     },
   },


### PR DESCRIPTION
Fixes the two issues Cursor Bugbot flagged on the release PR [#155](https://github.com/team-reflect/reflect-open/pull/155), plus a third bug of the same class found while fixing them. All land on `next` so the next-into-master release can pick them up.

## 1. iOS bundle version still `0.1.0` (medium, flagged on #155)

The release bumped the app to `0.2.0-beta.1` in `tauri.conf.json` and `src-tauri/Cargo.toml`, but the iOS version reported `0.1.0`.

**Root cause:** Tauri renders `bundle.iOS.template` (`ios.project.yml`) through Handlebars and exposes the app version from `tauri.conf.json` as template variables. The template had committed the *rendered literal* (`0.1.0`) instead of the placeholders, freezing the version so it drifted every release.

**Fix — derive it, don't hardcode it.** The template now uses the variables Tauri provides (matching Tauri's own default template):

```yaml
CFBundleShortVersionString: {{apple.bundle-version-short}}
CFBundleVersion: {{apple.bundle-version}}
```

So the version lives in one place (`tauri.conf.json`, already bumped by the release flow) and propagates on the next `tauri ios init` — no manual iOS bumps ever again. The committed generated files (`gen/apple/project.yml`, `gen/apple/reflect-open_iOS/Info.plist`) are set to the value Tauri actually emits: it strips the prerelease tag and requires three dot-separated integers, so `0.2.0-beta.1` → **`0.2.0`** (a literal `0.2.0-beta.1` is rejected by Apple/Xcode archive validation for these keys).

## 2. Private toggle wrong error label (low, flagged on #155)

The `note.togglePrivate` palette command always surfaced failures as `Marking note as private`, even when the user was *unlocking* a note — disagreeing with the Lock/Unlock wording the sidebar action uses.

Now it reads the note's current `private` flag (the same index row the sidebar derives its direction from) before toggling, and words the failure by direction: **Locking note** / **Unlocking note**.

## 3. Pin toggle wrong error label (related, found here)

`note.togglePin` had the identical latent bug — it always reported `Pinning note` on failure, even when unpinning, disagreeing with the sidebar's `Pinning note` / `Unpinning note` wording. Fixed the same way: read the current pinned state (the same pinned-notes index query the sidebar uses) and word the failure by direction.

In both #2 and #3 the read sits inside the existing `try`, so a query failure is still surfaced through the operations status line rather than thrown silently (these commands have no error channel of their own).

## Tests
Added `app-commands.test.ts` cases for both commands: a successful toggle surfaces no operation, and each failure direction reports the matching label (`Locking`/`Unlocking note`, `Pinning`/`Unpinning note`).

## Verification
- `pnpm typecheck` — pass
- `pnpm lint` — pass (only pre-existing warnings, unrelated)
- `pnpm exec vitest run` on the command + sidebar suites — pass (app-commands 15 → 19)
- `plutil -lint` on the generated `Info.plist` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)