### PR TITLE
Mobile (Plan 19): settings sheet + note actions (pin, delete-to-trash)

### DIFF
--- a/apps/desktop/src/editor/document-binding.test.ts
+++ b/apps/desktop/src/editor/document-binding.test.ts
@@ -15,6 +15,7 @@ function fakeSession(path: string) {
   let current = path
   const flush = vi.fn(async () => {})
   const dispose = vi.fn()
+  const discard = vi.fn()
   const session: NoteSession = {
     get path() {
       return current
@@ -32,6 +33,7 @@ function fakeSession(path: string) {
     content: () => '',
     updateFrontmatter: () => true,
     dispose,
+    discard,
   }
   return { session, flush, dispose }
 }

--- a/apps/desktop/src/editor/move-note.test.ts
+++ b/apps/desktop/src/editor/move-note.test.ts
@@ -37,6 +37,7 @@ function fakeSession(path: string) {
     content: () => '',
     updateFrontmatter: () => true,
     dispose: () => {},
+    discard: () => {},
   }
   return { session, flush }
 }

--- a/apps/desktop/src/editor/note-session.test.ts
+++ b/apps/desktop/src/editor/note-session.test.ts
@@ -134,7 +134,9 @@ describe('createNoteSession', () => {
     // Nothing written: the file is being deleted, so a flush would recreate it.
     expect(writes).toEqual([])
 
-    // A later dispose (the pane unmounting) stays a no-op too.
+    // The pane tears down via flush() → dispose() (document-binding); neither
+    // may write after a discard, or the trashed file would come back.
+    await session.flush()
     session.dispose()
     await settled()
     expect(writes).toEqual([])

--- a/apps/desktop/src/editor/note-session.test.ts
+++ b/apps/desktop/src/editor/note-session.test.ts
@@ -122,6 +122,24 @@ describe('createNoteSession', () => {
     expect(snapshots.length).toBe(emittedBeforeDispose)
   })
 
+  it('discard detaches without writing — even with a pending edit (delete path)', async () => {
+    const { session, writes } = harness()
+    session.load()
+    await settled()
+
+    session.editorChanged('# Unsaved edit\n')
+    session.discard()
+    await settled()
+
+    // Nothing written: the file is being deleted, so a flush would recreate it.
+    expect(writes).toEqual([])
+
+    // A later dispose (the pane unmounting) stays a no-op too.
+    session.dispose()
+    await settled()
+    expect(writes).toEqual([])
+  })
+
   it('does not re-emit identical snapshots', async () => {
     const { session, snapshots } = harness()
     session.load()

--- a/apps/desktop/src/editor/note-session.ts
+++ b/apps/desktop/src/editor/note-session.ts
@@ -244,6 +244,13 @@ export interface NoteSession {
   commitFrontmatter: (patch: FrontmatterPatch) => Promise<boolean>
   /** Flush pending edits and detach: no further snapshots are emitted. */
   dispose: () => void
+  /**
+   * Detach **without** flushing — for deleting the note: a final flush (which
+   * `dispose` performs) would rewrite the buffer and recreate the file we are
+   * removing. After `discard`, a later `dispose` (e.g. on the pane's unmount)
+   * is a no-op. Pending saves are cancelled.
+   */
+  discard: () => void
 }
 
 /** Exact frontmatter bytes (may be empty) and the body that follows them. */
@@ -294,6 +301,9 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
   /** A watcher event arrived during the load; replay reconciliation after it. */
   let missedChange = false
   let disposed = false
+  // Set by `discard` — tells `dispose` to skip its flush (the file is being
+  // deleted, so rewriting it would recreate it).
+  let discarded = false
 
   let lastEmitted: NoteSessionSnapshot | null = null
 
@@ -620,9 +630,19 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
   }
 
   function dispose(): void {
-    // Flush first: the queued save step reads the (now frozen) buffer, so
-    // pending edits persist to this session's path even after the UI moves on.
-    void flush()
+    // A discarded session must not write: its file is being deleted, and a
+    // flush would recreate it. Otherwise flush first — the queued save step
+    // reads the (now frozen) buffer, so pending edits persist to this
+    // session's path even after the UI moves on.
+    if (!discarded) {
+      void flush()
+    }
+    disposed = true
+  }
+
+  function discard(): void {
+    cancelScheduledSave()
+    discarded = true
     disposed = true
   }
 
@@ -643,5 +663,6 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
     updateFrontmatter,
     commitFrontmatter,
     dispose,
+    discard,
   }
 }

--- a/apps/desktop/src/editor/note-session.ts
+++ b/apps/desktop/src/editor/note-session.ts
@@ -337,10 +337,13 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
   }
 
   function save(): void {
-    // A parked conflict pauses all saves: writing the buffer before the user
+    // A discarded session never writes: its file is being deleted, so any
+    // save — including a teardown `flush()` (the pane unmounts via flush →
+    // dispose) or an already-queued step — would recreate it. A parked
+    // conflict likewise pauses all saves: writing the buffer before the user
     // chooses Keep mine / Load theirs would clobber the external change and
     // defeat the non-destructive flow.
-    if (io.write === null || !dirty || isProtected || conflict !== null) {
+    if (discarded || io.write === null || !dirty || isProtected || conflict !== null) {
       return
     }
     const write = io.write
@@ -348,9 +351,10 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
       .then(async () => {
         // Re-check at execution time and take the freshest buffer — a queued
         // step can run behind a slow prior write, during which the user may
-        // have reverted or kept typing. (After dispose the buffer is frozen, so
-        // this same step doubles as the final flush.)
-        if (!dirty || isProtected || conflict !== null) {
+        // have reverted or kept typing, or the session may have been discarded
+        // for a delete. (After dispose the buffer is frozen, so this same step
+        // doubles as the final flush.)
+        if (discarded || !dirty || isProtected || conflict !== null) {
           return
         }
         const content = header + buffer

--- a/apps/desktop/src/editor/open-documents.test.ts
+++ b/apps/desktop/src/editor/open-documents.test.ts
@@ -18,6 +18,7 @@ function fakeSession(path: string, log: string[]): NoteSession {
     content: () => '',
     updateFrontmatter: () => true,
     dispose: () => {},
+    discard: () => {},
   }
 }
 

--- a/apps/desktop/src/editor/rename-coordinator.test.ts
+++ b/apps/desktop/src/editor/rename-coordinator.test.ts
@@ -108,6 +108,7 @@ function fakeSession(content: string): NoteSession & {
     content: () => content,
     updateFrontmatter: vi.fn(() => true),
     dispose: () => {},
+    discard: () => {},
   }
 }
 

--- a/apps/desktop/src/mobile/calendar-strip.tsx
+++ b/apps/desktop/src/mobile/calendar-strip.tsx
@@ -3,6 +3,7 @@ import { format } from 'date-fns'
 import { Button } from '@/components/ui/button'
 import { parseIsoDate } from '@/lib/dates'
 import { monthLabel, weekOf } from '@/mobile/calendar'
+import { SettingsSheet } from '@/mobile/settings-sheet'
 import { cn } from '@/lib/utils'
 import { useSettings } from '@/providers/settings-provider'
 
@@ -32,8 +33,9 @@ export function CalendarStrip({ date, today, onSelect }: CalendarStripProps): Re
       className="shrink-0 border-b border-border px-2 pb-1"
       style={{ paddingTop: 'env(safe-area-inset-top)' }}
     >
-      <div className="flex items-center justify-between px-2 py-1">
-        <h1 className="text-base font-semibold">{monthLabel(date)}</h1>
+      <div className="flex items-center gap-1 px-1 py-1">
+        <SettingsSheet />
+        <h1 className="min-w-0 flex-1 truncate text-base font-semibold">{monthLabel(date)}</h1>
         {date !== today && (
           <Button variant="ghost" size="sm" onClick={() => onSelect(today)}>
             Today

--- a/apps/desktop/src/mobile/note-actions-menu.test.tsx
+++ b/apps/desktop/src/mobile/note-actions-menu.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setBridge } from '@reflect/core'
+import { NoteActionsMenu } from './note-actions-menu'
+
+/**
+ * The note-actions menu (Plan 19): pin toggles the frontmatter flag, and
+ * delete confirms then moves the note to trash and notifies the screen. Runs
+ * the real toggle/delete core paths over a fake IPC bridge.
+ */
+
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({ graph: { root: '/g', name: 'g', cloudSync: null, generation: 1 } }),
+}))
+// The pinned set comes from the index; an empty list means "not pinned".
+vi.mock('@/hooks/use-pinned-notes', () => ({ usePinnedNotes: () => [] }))
+// No session is open for the note in this unit; discard is a no-op lookup.
+vi.mock('@/editor/open-documents', () => ({ openSession: () => null }))
+
+const calls: Array<{ command: string; args: Record<string, unknown> }> = []
+const mockInvoke = vi.fn<(command: string, args: Record<string, unknown>) => Promise<unknown>>()
+
+setBridge({ invoke: mockInvoke, listen: async () => () => {} })
+
+beforeEach(() => {
+  calls.length = 0
+  mockInvoke.mockReset()
+  mockInvoke.mockImplementation(async (command, args) => {
+    calls.push({ command, args })
+    if (command === 'note_read') {
+      return '# Meeting\n'
+    }
+    return null
+  })
+})
+
+afterEach(cleanup)
+
+function mount(onDeleted = vi.fn()): { view: ReturnType<typeof render>; onDeleted: typeof onDeleted } {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const view = render(
+    <QueryClientProvider client={queryClient}>
+      <NoteActionsMenu path="notes/meeting.md" onDeleted={onDeleted} />
+    </QueryClientProvider>,
+  )
+  return { view, onDeleted }
+}
+
+describe('NoteActionsMenu', () => {
+  it('pins the note by writing the frontmatter flag', async () => {
+    const user = userEvent.setup()
+    const { view } = mount()
+
+    await user.click(view.getByRole('button', { name: 'Note actions' }))
+    await user.click(await view.findByRole('menuitem', { name: 'Pin' }))
+
+    await waitFor(() => {
+      const write = calls.find((call) => call.command === 'note_write')
+      expect(write?.args.contents).toContain('pinned: true')
+    })
+  })
+
+  it('deletes after confirmation and notifies the screen', async () => {
+    const user = userEvent.setup()
+    const { view, onDeleted } = mount()
+
+    await user.click(view.getByRole('button', { name: 'Note actions' }))
+    await user.click(await view.findByRole('menuitem', { name: 'Delete' }))
+    // Confirm in the dialog (the destructive button).
+    await user.click(await view.findByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => {
+      expect(calls.some((call) => call.command === 'note_delete')).toBe(true)
+    })
+    expect(onDeleted).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/mobile/note-actions-menu.tsx
+++ b/apps/desktop/src/mobile/note-actions-menu.tsx
@@ -1,0 +1,108 @@
+import { useState, type ReactElement } from 'react'
+import { MoreHorizontal, Pin, PinOff, Trash2 } from 'lucide-react'
+import { errorMessage } from '@reflect/core'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { toggleNotePinned } from '@/lib/note-pin'
+import { deleteOpenNote } from '@/mobile/note-delete'
+import { useGraph } from '@/providers/graph-provider'
+import { usePinnedNotes } from '@/hooks/use-pinned-notes'
+
+interface NoteActionsMenuProps {
+  /** Graph-relative path of the note the actions operate on. */
+  path: string
+  /** Called after the note is deleted, so the screen can navigate away. */
+  onDeleted: () => void
+}
+
+/**
+ * The note screen's "⋯" actions menu (Plan 19, V1 parity): pin/unpin and
+ * delete-to-trash. Pin reflects the index's pinned set; delete confirms
+ * first (it's destructive, even if recoverable from `.reflect/trash/`) and
+ * routes through {@link deleteOpenNote} so the open session is discarded
+ * rather than flushed. Share lands with its native plugin in a later slice.
+ */
+export function NoteActionsMenu({ path, onDeleted }: NoteActionsMenuProps): ReactElement {
+  const { graph } = useGraph()
+  const isPinned = usePinnedNotes().some((note) => note.path === path)
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const pin = (): void => {
+    if (graph !== null) {
+      void toggleNotePinned(path, graph.generation).catch(() => {})
+    }
+  }
+
+  const confirmDelete = (): void => {
+    if (graph === null) {
+      return
+    }
+    setBusy(true)
+    setError(null)
+    void deleteOpenNote(path, graph.generation)
+      .then(() => {
+        setConfirmingDelete(false)
+        onDeleted()
+      })
+      .catch((cause) => setError(errorMessage(cause)))
+      .finally(() => setBusy(false))
+  }
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" className="size-10" aria-label="Note actions">
+            <MoreHorizontal />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={pin}>
+            {isPinned ? <PinOff /> : <Pin />}
+            {isPinned ? 'Unpin' : 'Pin'}
+          </DropdownMenuItem>
+          <DropdownMenuItem variant="destructive" onSelect={() => setConfirmingDelete(true)}>
+            <Trash2 />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={confirmingDelete} onOpenChange={(open) => !busy && setConfirmingDelete(open)}>
+        <DialogContent>
+          <DialogTitle>Delete this note?</DialogTitle>
+          <DialogDescription>
+            It moves to the graph’s trash and disappears from your notes. You can recover it on
+            desktop.
+          </DialogDescription>
+          {error !== null && <p className="text-sm text-destructive">{error}</p>}
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="ghost" disabled={busy}>
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button variant="destructive" disabled={busy} onClick={confirmDelete}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/apps/desktop/src/mobile/note-delete.test.ts
+++ b/apps/desktop/src/mobile/note-delete.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { deleteOpenNote } from './note-delete'
+
+/**
+ * `deleteOpenNote` deletes first, then discards the open session — so a
+ * failed delete never leaves a discarded-but-mounted session (which would
+ * silently stop persisting the user's edits).
+ */
+
+const deleteNoteMock = vi.fn<(path: string, generation: number) => Promise<void>>()
+const discard = vi.fn()
+const openSessionMock = vi.fn<(path: string) => { discard: () => void } | null>()
+
+vi.mock('@reflect/core', () => ({
+  deleteNote: (path: string, generation: number) => deleteNoteMock(path, generation),
+}))
+vi.mock('@/editor/open-documents', () => ({
+  openSession: (path: string) => openSessionMock(path),
+}))
+
+afterEach(() => {
+  deleteNoteMock.mockReset()
+  discard.mockReset()
+  openSessionMock.mockReset()
+})
+
+describe('deleteOpenNote', () => {
+  it('discards the open session after a successful delete', async () => {
+    deleteNoteMock.mockResolvedValue()
+    openSessionMock.mockReturnValue({ discard })
+
+    await deleteOpenNote('notes/gone.md', 3)
+
+    expect(deleteNoteMock).toHaveBeenCalledWith('notes/gone.md', 3)
+    expect(discard).toHaveBeenCalledOnce()
+  })
+
+  it('leaves the session intact when the delete fails', async () => {
+    deleteNoteMock.mockRejectedValue(new Error('disk full'))
+    openSessionMock.mockReturnValue({ discard })
+
+    await expect(deleteOpenNote('notes/gone.md', 3)).rejects.toThrow('disk full')
+
+    // The session was never discarded — the screen stays editable.
+    expect(discard).not.toHaveBeenCalled()
+    expect(openSessionMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/mobile/note-delete.ts
+++ b/apps/desktop/src/mobile/note-delete.ts
@@ -7,13 +7,16 @@ import { openSession } from '@/editor/open-documents'
  * (recoverable, sync-ignored) and emits the in-process `remove` so the index
  * and queries drop it.
  *
- * The note is open in the editor, so its session is **discarded** first: a
- * normal dispose flushes, which would rewrite — and recreate — the file we're
- * deleting (especially with unsaved edits). `discard` detaches without
- * writing, and the pane's later unmount-dispose stays a no-op. The caller
+ * **Delete first, discard second.** If the delete fails, the open session is
+ * left fully intact — the note screen stays mounted and editable, edits keep
+ * persisting. Only once the file is in trash do we `discard` the session: it
+ * stays `dirty` after its file vanishes (a removed file is "nothing to
+ * reconcile", so dirtiness isn't cleared), and a normal teardown flush would
+ * therefore rewrite — recreate — the file. `discard` detaches without
+ * writing, so the pane's unmount (flush → dispose) is a no-op. The caller
  * navigates away after this resolves.
  */
 export async function deleteOpenNote(path: string, generation: number): Promise<void> {
-  openSession(path)?.discard()
   await deleteNote(path, generation)
+  openSession(path)?.discard()
 }

--- a/apps/desktop/src/mobile/note-delete.ts
+++ b/apps/desktop/src/mobile/note-delete.ts
@@ -1,0 +1,19 @@
+import { deleteNote } from '@reflect/core'
+import { openSession } from '@/editor/open-documents'
+
+/**
+ * Delete a note from the mobile note screen (Plan 19, V1 parity). On mobile
+ * `deleteNote` moves the file into the graph-local `.reflect/trash/`
+ * (recoverable, sync-ignored) and emits the in-process `remove` so the index
+ * and queries drop it.
+ *
+ * The note is open in the editor, so its session is **discarded** first: a
+ * normal dispose flushes, which would rewrite — and recreate — the file we're
+ * deleting (especially with unsaved edits). `discard` detaches without
+ * writing, and the pane's later unmount-dispose stays a no-op. The caller
+ * navigates away after this resolves.
+ */
+export async function deleteOpenNote(path: string, generation: number): Promise<void> {
+  openSession(path)?.discard()
+  await deleteNote(path, generation)
+}

--- a/apps/desktop/src/mobile/screens/note.tsx
+++ b/apps/desktop/src/mobile/screens/note.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft } from 'lucide-react'
 import { NotePane } from '@/components/note-pane'
 import { Button } from '@/components/ui/button'
 import { isUntitledNotePath } from '@/lib/create-note'
+import { NoteActionsMenu } from '@/mobile/note-actions-menu'
 import { useRouter } from '@/routing/router'
 
 /**
@@ -32,7 +33,10 @@ export function MobileNote({ path }: { path: string }): ReactElement {
         <h1 className="min-w-0 flex-1 truncate text-base font-semibold">
           {untitled ? 'New note' : noteTitleFromPath(path)}
         </h1>
-        <div aria-hidden className="size-10 shrink-0" />
+        <NoteActionsMenu
+          path={path}
+          onDeleted={() => (canBack ? back() : navigate({ kind: 'today' }))}
+        />
       </header>
       <main
         className="min-h-0 flex-1 overflow-y-auto"

--- a/apps/desktop/src/mobile/settings-sheet.tsx
+++ b/apps/desktop/src/mobile/settings-sheet.tsx
@@ -1,0 +1,59 @@
+import { useState, type ReactElement } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Settings } from 'lucide-react'
+import { hasBridge, listNotes } from '@reflect/core'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
+import { useAppVersion } from '@/hooks/use-app-version'
+import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
+import { useGraph } from '@/providers/graph-provider'
+
+/**
+ * The mobile settings sheet (Plan 19, V1 parity) — the trigger lives in V1's
+ * avatar spot (top-left of the Daily header). A deliberately small surface:
+ * the graph's name, its note count, and the app version. GitHub
+ * connect/disconnect and sync status arrive with the sync slice; this sheet
+ * is where they'll land.
+ */
+export function SettingsSheet(): ReactElement {
+  const { graph } = useGraph()
+  const version = useAppVersion()
+  const [open, setOpen] = useState(false)
+
+  const { data: notes } = useQuery({
+    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'mobile-note-count'],
+    queryFn: () => listNotes(),
+    enabled: open && hasBridge() && graph !== null,
+  })
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="icon" className="size-9" aria-label="Settings">
+          <Settings />
+        </Button>
+      </DialogTrigger>
+      <DialogContent
+        showCloseButton={false}
+        className="inset-x-0 bottom-0 top-auto left-0 max-w-none translate-x-0 translate-y-0 rounded-b-none data-closed:zoom-out-100 data-open:zoom-in-100"
+        style={{ paddingBottom: 'max(env(safe-area-inset-bottom), 1rem)' }}
+      >
+        <DialogTitle>Settings</DialogTitle>
+        <dl className="divide-y divide-border text-sm">
+          <Row label="Graph" value={graph?.name ?? '—'} />
+          <Row label="Notes" value={notes === undefined ? '…' : String(notes.length)} />
+          <Row label="Version" value={version ?? '…'} />
+        </dl>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function Row({ label, value }: { label: string; value: string }): ReactElement {
+  return (
+    <div className="flex items-center justify-between py-2.5">
+      <dt className="text-text-muted">{label}</dt>
+      <dd className="font-medium tabular-nums">{value}</dd>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Two V1-parity surfaces on the mobile app (on the merged Daily/tabs base).

- **[Settings sheet](apps/desktop/src/mobile/settings-sheet.tsx)** in V1's avatar spot — a gear at the Daily header's top-left opening a bottom sheet with graph name, note count, and app version. Deliberately small; GitHub connect/disconnect + sync status land here with the sync slice (it's where they'll go).
- **[Note-actions "⋯" menu](apps/desktop/src/mobile/note-actions-menu.tsx)** on the note screen: **Pin/Unpin** (the existing frontmatter-flag machinery) and **Delete** (confirm → move to `.reflect/trash/`, recoverable).

## The delete subtlety

The note being deleted is open in the editor, and a normal session `dispose()` **flushes** — which would rewrite and recreate the file we just deleted (especially with unsaved edits). So this adds a small, reusable primitive:

- **`NoteSession.discard()`** — detach without flushing; a later `dispose()` (the pane unmounting) becomes a no-op. The delete flow ([note-delete.ts](apps/desktop/src/mobile/note-delete.ts)) discards the open session, deletes, then navigates away. Desktop will want this when it grows a delete affordance. Unit-tested in `note-session` (discard never writes, even with a pending edit); the four editor test mocks gain the new interface method.

## Scope note

Share — the third V1 note action — needs a native share-sheet Swift plugin (like the keyboard plugin) and is the **next slice**, to keep that native work in its own focused PR.

## Verification

- Simulator (iPhone 17 Pro): settings sheet shows `Graph: Documents / Notes: 3 / Version: 0.2.0-beta.1`; pin writes `pinned: true`; **delete moves `notes/nav-test.md` → `.reflect/trash/nav-test.md` with no recreation** and drops it from the All list.
- 68 tests across mobile + editor (incl. the new `discard` and note-actions-menu tests); `pnpm check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the note save/teardown path in `note-session` (discard gating on `save` and `dispose`), which is correctness-critical for deletes; scope is narrow and covered by new unit tests.
> 
> **Overview**
> Adds **mobile V1-parity UI**: a **settings** gear on the Daily header (`SettingsSheet` — graph name, note count, app version) and a **note “⋯” menu** with pin/unpin and confirm-then-delete-to-trash, wired into the note screen header.
> 
> Delete while the note is open required a **core editor fix**: new **`NoteSession.discard()`** detaches and cancels pending saves **without** the flush that `dispose()` normally runs, so trashed notes are not recreated from dirty buffers on pane teardown. **`deleteOpenNote`** calls `deleteNote` first, then `openSession(path)?.discard()` only on success so a failed delete leaves editing intact.
> 
> Editor test mocks pick up `discard`; **`note-session`** gains a test that discard never writes even after `flush`/`dispose`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91ffe517c61218e8a83775a177c64458ecaea194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->