### PR TITLE
Cut a new release

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,6 +37,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.4.0",
+    "embla-carousel-react": "^8.6.0",
     "lucide-react": "^1.17.0",
     "radix-ui": "^1.5.0",
     "react": "^19.1.0",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -72,8 +72,9 @@ fastembed = "5"
 # embedding model with byte-level progress (fastembed downloads silently).
 hf-hub = { version = "0.5.0", default-features = false, features = ["ureq", "native-tls"] }
 
-# Mobile-only capabilities (Plan 19): the first-party keyboard bridge —
-# desktop has no software keyboard to track.
+# Mobile-only capabilities (Plan 19): the first-party keyboard bridge — no
+# software keyboard on desktop. (Sharing uses the webview's Web Share API,
+# `navigator.share`, so it needs no native plugin.)
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
 tauri-plugin-keyboard = { path = "../../../plugins/tauri-plugin-keyboard" }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -114,7 +114,8 @@ pub fn run() {
         .plugin(tauri_plugin_window_state::Builder::default().build());
 
     // The keyboard bridge (Plan 19, decision 8) is mobile-only: desktop has
-    // no software keyboard to track.
+    // no software keyboard to track. (Sharing uses the webview's Web Share
+    // API, so it needs no native plugin.)
     #[cfg(mobile)]
     let builder = builder.plugin(tauri_plugin_keyboard::init());
 

--- a/apps/desktop/src/editor/document-binding.test.ts
+++ b/apps/desktop/src/editor/document-binding.test.ts
@@ -31,6 +31,7 @@ function fakeSession(path: string) {
     loadTheirs: () => {},
     commitFrontmatter: async () => true,
     content: () => '',
+    liveContent: () => '',
     updateFrontmatter: () => true,
     dispose,
     discard,

--- a/apps/desktop/src/editor/document-binding.test.ts
+++ b/apps/desktop/src/editor/document-binding.test.ts
@@ -15,6 +15,7 @@ function fakeSession(path: string) {
   let current = path
   const flush = vi.fn(async () => {})
   const dispose = vi.fn()
+  const discard = vi.fn()
   const session: NoteSession = {
     get path() {
       return current
@@ -32,6 +33,7 @@ function fakeSession(path: string) {
     content: () => '',
     updateFrontmatter: () => true,
     dispose,
+    discard,
   }
   return { session, flush, dispose }
 }

--- a/apps/desktop/src/editor/move-note.test.ts
+++ b/apps/desktop/src/editor/move-note.test.ts
@@ -35,6 +35,7 @@ function fakeSession(path: string) {
     loadTheirs: () => {},
     commitFrontmatter: async () => true,
     content: () => '',
+    liveContent: () => '',
     updateFrontmatter: () => true,
     dispose: () => {},
     discard: () => {},

--- a/apps/desktop/src/editor/move-note.test.ts
+++ b/apps/desktop/src/editor/move-note.test.ts
@@ -37,6 +37,7 @@ function fakeSession(path: string) {
     content: () => '',
     updateFrontmatter: () => true,
     dispose: () => {},
+    discard: () => {},
   }
   return { session, flush }
 }

--- a/apps/desktop/src/editor/note-session.test.ts
+++ b/apps/desktop/src/editor/note-session.test.ts
@@ -122,6 +122,26 @@ describe('createNoteSession', () => {
     expect(snapshots.length).toBe(emittedBeforeDispose)
   })
 
+  it('discard detaches without writing — even with a pending edit (delete path)', async () => {
+    const { session, writes } = harness()
+    session.load()
+    await settled()
+
+    session.editorChanged('# Unsaved edit\n')
+    session.discard()
+    await settled()
+
+    // Nothing written: the file is being deleted, so a flush would recreate it.
+    expect(writes).toEqual([])
+
+    // The pane tears down via flush() → dispose() (document-binding); neither
+    // may write after a discard, or the trashed file would come back.
+    await session.flush()
+    session.dispose()
+    await settled()
+    expect(writes).toEqual([])
+  })
+
   it('does not re-emit identical snapshots', async () => {
     const { session, snapshots } = harness()
     session.load()

--- a/apps/desktop/src/editor/note-session.ts
+++ b/apps/desktop/src/editor/note-session.ts
@@ -244,6 +244,13 @@ export interface NoteSession {
   commitFrontmatter: (patch: FrontmatterPatch) => Promise<boolean>
   /** Flush pending edits and detach: no further snapshots are emitted. */
   dispose: () => void
+  /**
+   * Detach **without** flushing — for deleting the note: a final flush (which
+   * `dispose` performs) would rewrite the buffer and recreate the file we are
+   * removing. After `discard`, a later `dispose` (e.g. on the pane's unmount)
+   * is a no-op. Pending saves are cancelled.
+   */
+  discard: () => void
 }
 
 /** Exact frontmatter bytes (may be empty) and the body that follows them. */
@@ -294,6 +301,9 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
   /** A watcher event arrived during the load; replay reconciliation after it. */
   let missedChange = false
   let disposed = false
+  // Set by `discard` — tells `dispose` to skip its flush (the file is being
+  // deleted, so rewriting it would recreate it).
+  let discarded = false
 
   let lastEmitted: NoteSessionSnapshot | null = null
 
@@ -327,10 +337,13 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
   }
 
   function save(): void {
-    // A parked conflict pauses all saves: writing the buffer before the user
+    // A discarded session never writes: its file is being deleted, so any
+    // save — including a teardown `flush()` (the pane unmounts via flush →
+    // dispose) or an already-queued step — would recreate it. A parked
+    // conflict likewise pauses all saves: writing the buffer before the user
     // chooses Keep mine / Load theirs would clobber the external change and
     // defeat the non-destructive flow.
-    if (io.write === null || !dirty || isProtected || conflict !== null) {
+    if (discarded || io.write === null || !dirty || isProtected || conflict !== null) {
       return
     }
     const write = io.write
@@ -338,9 +351,10 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
       .then(async () => {
         // Re-check at execution time and take the freshest buffer — a queued
         // step can run behind a slow prior write, during which the user may
-        // have reverted or kept typing. (After dispose the buffer is frozen, so
-        // this same step doubles as the final flush.)
-        if (!dirty || isProtected || conflict !== null) {
+        // have reverted or kept typing, or the session may have been discarded
+        // for a delete. (After dispose the buffer is frozen, so this same step
+        // doubles as the final flush.)
+        if (discarded || !dirty || isProtected || conflict !== null) {
           return
         }
         const content = header + buffer
@@ -620,9 +634,19 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
   }
 
   function dispose(): void {
-    // Flush first: the queued save step reads the (now frozen) buffer, so
-    // pending edits persist to this session's path even after the UI moves on.
-    void flush()
+    // A discarded session must not write: its file is being deleted, and a
+    // flush would recreate it. Otherwise flush first — the queued save step
+    // reads the (now frozen) buffer, so pending edits persist to this
+    // session's path even after the UI moves on.
+    if (!discarded) {
+      void flush()
+    }
+    disposed = true
+  }
+
+  function discard(): void {
+    cancelScheduledSave()
+    discarded = true
     disposed = true
   }
 
@@ -643,5 +667,6 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
     updateFrontmatter,
     commitFrontmatter,
     dispose,
+    discard,
   }
 }

--- a/apps/desktop/src/editor/note-session.ts
+++ b/apps/desktop/src/editor/note-session.ts
@@ -222,6 +222,15 @@ export interface NoteSession {
   /** The full current document (frontmatter + buffer), as a save would write it. */
   content: () => string
   /**
+   * The live document **only when the session has loaded** (`status` is
+   * `ready`), else `null`. Distinguishes a genuinely-empty loaded note (return
+   * `''` — authoritative) from one still loading (return `null` — the buffer
+   * is `''` only because the read hasn't landed). Callers that read the live
+   * buffer for an out-of-band use (e.g. sharing) fall back to disk on `null`
+   * rather than treating the loading buffer's emptiness as the truth.
+   */
+  liveContent: () => string | null
+  /**
    * Patch frontmatter keys (e.g. `aliases`, Plan 07b) without touching the
    * editor: the header is updated in place and saved through the normal
    * pipeline. Returns false (and does nothing) when the session can't take
@@ -664,6 +673,7 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
     keepMine,
     loadTheirs,
     content: () => header + buffer,
+    liveContent: () => (status === 'ready' ? header + buffer : null),
     updateFrontmatter,
     commitFrontmatter,
     dispose,

--- a/apps/desktop/src/editor/open-documents.test.ts
+++ b/apps/desktop/src/editor/open-documents.test.ts
@@ -18,6 +18,7 @@ function fakeSession(path: string, log: string[]): NoteSession {
     content: () => '',
     updateFrontmatter: () => true,
     dispose: () => {},
+    discard: () => {},
   }
 }
 

--- a/apps/desktop/src/editor/open-documents.test.ts
+++ b/apps/desktop/src/editor/open-documents.test.ts
@@ -16,6 +16,7 @@ function fakeSession(path: string, log: string[]): NoteSession {
     loadTheirs: () => {},
     commitFrontmatter: async () => true,
     content: () => '',
+    liveContent: () => '',
     updateFrontmatter: () => true,
     dispose: () => {},
     discard: () => {},

--- a/apps/desktop/src/editor/rename-coordinator.test.ts
+++ b/apps/desktop/src/editor/rename-coordinator.test.ts
@@ -106,6 +106,7 @@ function fakeSession(content: string): NoteSession & {
     loadTheirs: () => {},
     commitFrontmatter: async () => true,
     content: () => content,
+    liveContent: () => content,
     updateFrontmatter: vi.fn(() => true),
     dispose: () => {},
     discard: () => {},

--- a/apps/desktop/src/editor/rename-coordinator.test.ts
+++ b/apps/desktop/src/editor/rename-coordinator.test.ts
@@ -108,6 +108,7 @@ function fakeSession(content: string): NoteSession & {
     content: () => content,
     updateFrontmatter: vi.fn(() => true),
     dispose: () => {},
+    discard: () => {},
   }
 }
 

--- a/apps/desktop/src/lib/day-window.test.ts
+++ b/apps/desktop/src/lib/day-window.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { createDayWindow, dateAtIndex, indexOfDate, FUTURE_DAYS, PAST_DAYS } from './day-window'
+import {
+  createDayWindow,
+  dateAtIndex,
+  indexOfDate,
+  indexWithin,
+  FUTURE_DAYS,
+  PAST_DAYS,
+} from './day-window'
 
 describe('day window', () => {
   const window = createDayWindow('2026-06-09')
@@ -24,5 +31,37 @@ describe('day window', () => {
   it('clamps out-of-window dates to the edges instead of erroring', () => {
     expect(indexOfDate(window, '1990-01-01')).toBe(0)
     expect(indexOfDate(window, '2099-01-01')).toBe(window.count - 1)
+  })
+})
+
+describe('a symmetric (carousel) window', () => {
+  const radius = 366
+  const window = createDayWindow('2026-06-12', { past: radius, future: radius })
+
+  it('centers the anchor and round-trips index↔date', () => {
+    expect(window.count).toBe(radius * 2 + 1)
+    expect(window.anchorIndex).toBe(radius)
+    const center = indexWithin(window, '2026-06-12')
+    expect(center).toBe(radius)
+    expect(dateAtIndex(window, center)).toBe('2026-06-12')
+  })
+
+  it('reports the in-window edges, not a clamp', () => {
+    expect(indexWithin(window, dateAtIndex(window, 0))).toBe(0)
+    expect(indexWithin(window, dateAtIndex(window, window.count - 1))).toBe(window.count - 1)
+  })
+})
+
+describe('indexWithin', () => {
+  const window = createDayWindow('2026-06-12', { past: 366, future: 366 })
+
+  it('returns -1 for a date outside the window (the re-anchor signal)', () => {
+    expect(indexWithin(window, '2025-01-01')).toBe(-1)
+    expect(indexWithin(window, '2028-01-01')).toBe(-1)
+  })
+
+  it('returns -1 one day past each edge', () => {
+    expect(indexWithin(window, dateAtIndex(window, -1))).toBe(-1)
+    expect(indexWithin(window, dateAtIndex(window, window.count))).toBe(-1)
   })
 })

--- a/apps/desktop/src/lib/day-window.ts
+++ b/apps/desktop/src/lib/day-window.ts
@@ -2,31 +2,54 @@ import { differenceInCalendarDays } from 'date-fns'
 import { addDaysIso, parseIsoDate } from './dates'
 
 /**
- * The daily stream's virtual window (Plan 06b): a **fixed** chronological range
- * of days around an anchor (today at mount), indexed `0 … count-1` from oldest
- * to newest. Virtual rows are free until mounted, so a generous static window
- * (~5 years back, 1 year forward) sidesteps bidirectional infinite scroll's
- * prepend/scroll-compensation problem entirely. Index↔date is pure offset math.
+ * The daily surfaces' virtual window (Plan 06b / Plan 19): a **fixed**
+ * chronological range of days around an anchor, indexed `0 … count-1` from
+ * oldest to newest. Virtual rows/slides are free until mounted, so a generous
+ * static window sidesteps bidirectional infinite scroll's prepend/scroll-
+ * compensation problem entirely. Index↔date is pure offset math.
+ *
+ * Two surfaces share this module: the desktop daily stream (a wide, asymmetric
+ * window it virtualizes with TanStack Virtual) and the mobile day carousel (a
+ * tighter symmetric window Embla pages through). They differ only in radius and
+ * in how they treat a date outside the window — see {@link indexOfDate} (clamps
+ * to the nearest edge) versus {@link indexWithin} (reports `-1` so the caller
+ * can re-anchor around the far date).
  */
 
+/** The desktop stream's default reach: ~5 years back, ~1 year forward. */
 export const PAST_DAYS = 5 * 365
 export const FUTURE_DAYS = 365
+
+/** How far the window reaches either side of its anchor day. */
+export interface DayWindowRadius {
+  /** Days before the anchor — index 0 is `anchor - past`. */
+  past: number
+  /** Days after the anchor — the last index is `anchor + future`. */
+  future: number
+}
 
 export interface DayWindow {
   /** ISO date of index 0 (the oldest day in the window). */
   start: string
-  /** Total number of days (virtual rows). */
+  /** Total number of days (virtual rows/slides). */
   count: number
-  /** Index of the anchor day (today at creation). */
+  /** Index of the anchor day (the date the window was built around). */
   anchorIndex: number
 }
 
-/** Build the window around `anchor` (today). Stable for the life of the view. */
-export function createDayWindow(anchor: string): DayWindow {
+/**
+ * Build the window around `anchor`, reaching `past` days back and `future` days
+ * forward (defaulting to the desktop stream's asymmetric reach). Stable for the
+ * life of the view.
+ */
+export function createDayWindow(
+  anchor: string,
+  { past = PAST_DAYS, future = FUTURE_DAYS }: Partial<DayWindowRadius> = {},
+): DayWindow {
   return {
-    start: addDaysIso(anchor, -PAST_DAYS),
-    count: PAST_DAYS + FUTURE_DAYS + 1,
-    anchorIndex: PAST_DAYS,
+    start: addDaysIso(anchor, -past),
+    count: past + future + 1,
+    anchorIndex: past,
   }
 }
 
@@ -35,11 +58,27 @@ export function dateAtIndex(window: DayWindow, index: number): string {
   return addDaysIso(window.start, index)
 }
 
+/** Signed offset of `date` from the window's first day (may fall out of range). */
+function offsetOfDate(window: DayWindow, date: string): number {
+  return differenceInCalendarDays(parseIsoDate(date), parseIsoDate(window.start))
+}
+
 /**
- * The index of `date` within the window, clamped to its bounds — a date link
- * outside the window still scrolls to the nearest edge instead of erroring.
+ * The index of `date` **clamped** to the window's bounds — a date link outside
+ * the window still scrolls to the nearest edge instead of erroring. Used by the
+ * desktop stream, whose window is wide enough that the clamp is effectively
+ * unreachable in normal use.
  */
 export function indexOfDate(window: DayWindow, date: string): number {
-  const offset = differenceInCalendarDays(parseIsoDate(date), parseIsoDate(window.start))
-  return Math.max(0, Math.min(window.count - 1, offset))
+  return Math.max(0, Math.min(window.count - 1, offsetOfDate(window, date)))
+}
+
+/**
+ * The index of `date` within the window, or `-1` when it lies outside. The
+ * mobile carousel uses the `-1` as its signal to re-anchor the window around a
+ * far date link rather than scroll to an edge.
+ */
+export function indexWithin(window: DayWindow, date: string): number {
+  const index = offsetOfDate(window, date)
+  return index >= 0 && index < window.count ? index : -1
 }

--- a/apps/desktop/src/mobile/calendar-strip.tsx
+++ b/apps/desktop/src/mobile/calendar-strip.tsx
@@ -3,6 +3,7 @@ import { format } from 'date-fns'
 import { Button } from '@/components/ui/button'
 import { parseIsoDate } from '@/lib/dates'
 import { monthLabel, weekOf } from '@/mobile/calendar'
+import { SettingsSheet } from '@/mobile/settings-sheet'
 import { cn } from '@/lib/utils'
 import { useSettings } from '@/providers/settings-provider'
 
@@ -32,8 +33,9 @@ export function CalendarStrip({ date, today, onSelect }: CalendarStripProps): Re
       className="shrink-0 border-b border-border px-2 pb-1"
       style={{ paddingTop: 'env(safe-area-inset-top)' }}
     >
-      <div className="flex items-center justify-between px-2 py-1">
-        <h1 className="text-base font-semibold">{monthLabel(date)}</h1>
+      <div className="flex items-center gap-1 px-1 py-1">
+        <SettingsSheet />
+        <h1 className="min-w-0 flex-1 truncate text-base font-semibold">{monthLabel(date)}</h1>
         {date !== today && (
           <Button variant="ghost" size="sm" onClick={() => onSelect(today)}>
             Today

--- a/apps/desktop/src/mobile/calendar-strip.tsx
+++ b/apps/desktop/src/mobile/calendar-strip.tsx
@@ -1,0 +1,84 @@
+import { useMemo, type ReactElement } from 'react'
+import { format } from 'date-fns'
+import { Button } from '@/components/ui/button'
+import { parseIsoDate } from '@/lib/dates'
+import { monthLabel, weekOf } from '@/mobile/calendar'
+import { cn } from '@/lib/utils'
+import { useSettings } from '@/providers/settings-provider'
+
+interface CalendarStripProps {
+  /** The selected day (the centered carousel slide). */
+  date: string
+  /** Today's live ISO date — owned by the parent so the strip and the
+   *  parent's select logic share one value (no midnight-rollover skew). */
+  today: string
+  /** Select a day — drives the carousel and the route. */
+  onSelect: (date: string) => void
+}
+
+/**
+ * V1's calendar strip: a month header and the selected day's week as seven
+ * day-of-week / day-number cells, the selected day circled. Tapping a cell
+ * selects that day; the week shown always contains the selection, so the
+ * strip and the carousel stay in lockstep through the parent's `date`. A
+ * **Today** affordance appears in the header when the selection has wandered.
+ */
+export function CalendarStrip({ date, today, onSelect }: CalendarStripProps): ReactElement {
+  const { settings } = useSettings()
+  const week = useMemo(() => weekOf(date, settings.weekStartDay), [date, settings.weekStartDay])
+
+  return (
+    <header
+      className="shrink-0 border-b border-border px-2 pb-1"
+      style={{ paddingTop: 'env(safe-area-inset-top)' }}
+    >
+      <div className="flex items-center justify-between px-2 py-1">
+        <h1 className="text-base font-semibold">{monthLabel(date)}</h1>
+        {date !== today && (
+          <Button variant="ghost" size="sm" onClick={() => onSelect(today)}>
+            Today
+          </Button>
+        )}
+      </div>
+      <div className="flex">
+        {week.map((day) => {
+          const selected = day === date
+          const isToday = day === today
+          return (
+            <button
+              key={day}
+              type="button"
+              aria-label={format(parseIsoDate(day), 'EEEE, MMMM do')}
+              aria-current={selected ? 'date' : undefined}
+              onClick={() => onSelect(day)}
+              className="flex flex-1 flex-col items-center gap-0.5 py-1"
+            >
+              <span className="text-[11px] font-medium text-text-muted">
+                {format(parseIsoDate(day), 'EEEEE')}
+              </span>
+              <span
+                className={cn(
+                  'flex size-8 items-center justify-center rounded-full text-sm tabular-nums',
+                  selected && 'bg-primary font-semibold text-primary-foreground',
+                  !selected && isToday && 'font-semibold text-primary',
+                  !selected && !isToday && 'text-text',
+                )}
+              >
+                {format(parseIsoDate(day), 'd')}
+              </span>
+              {/* Today dot (V1) — a fixed-height slot so cells stay aligned;
+                  shown only when today isn't the selected (circled) day. */}
+              <span
+                aria-hidden
+                className={cn(
+                  'size-1 rounded-full',
+                  !selected && isToday ? 'bg-primary' : 'bg-transparent',
+                )}
+              />
+            </button>
+          )
+        })}
+      </div>
+    </header>
+  )
+}

--- a/apps/desktop/src/mobile/calendar.test.ts
+++ b/apps/desktop/src/mobile/calendar.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { monthLabel, weekOf } from './calendar'
+
+/**
+ * 2026-06-12 is a Friday; 2026-06-14 a Sunday — fixed anchors for the
+ * week-start math.
+ */
+describe('weekOf', () => {
+  it('builds a Monday-first week containing the date', () => {
+    const week = weekOf('2026-06-12', 'monday')
+    expect(week).toEqual([
+      '2026-06-08',
+      '2026-06-09',
+      '2026-06-10',
+      '2026-06-11',
+      '2026-06-12',
+      '2026-06-13',
+      '2026-06-14',
+    ])
+  })
+
+  it('builds a Sunday-first week containing the date', () => {
+    const week = weekOf('2026-06-12', 'sunday')
+    expect(week[0]).toBe('2026-06-07')
+    expect(week[6]).toBe('2026-06-13')
+    expect(week).toContain('2026-06-12')
+  })
+
+  it('keeps a Sunday in its own Monday-first week (the wrap edge)', () => {
+    // 2026-06-14 is a Sunday: a Monday-first week runs Mon 06-08 … Sun 06-14.
+    expect(weekOf('2026-06-14', 'monday')).toEqual([
+      '2026-06-08',
+      '2026-06-09',
+      '2026-06-10',
+      '2026-06-11',
+      '2026-06-12',
+      '2026-06-13',
+      '2026-06-14',
+    ])
+  })
+
+  it('spans the year boundary without skipping or repeating a day', () => {
+    // 2026-01-01 is a Thursday: a Monday-first week reaches back into 2025.
+    const week = weekOf('2026-01-01', 'monday')
+    expect(week[0]).toBe('2025-12-29')
+    expect(week[6]).toBe('2026-01-04')
+    expect(week).toContain('2026-01-01')
+  })
+})
+
+describe('monthLabel', () => {
+  it('formats the month and year', () => {
+    expect(monthLabel('2026-06-12')).toBe('June 2026')
+  })
+})

--- a/apps/desktop/src/mobile/calendar.ts
+++ b/apps/desktop/src/mobile/calendar.ts
@@ -1,0 +1,24 @@
+import { format, getDay } from 'date-fns'
+import type { WeekStartDay } from '@reflect/core'
+import { addDaysIso, parseIsoDate } from '@/lib/dates'
+
+/**
+ * Date math for the V1-parity Daily surface's **calendar strip** — the month
+ * header and week row above the day carousel. Pure; the strip component stays
+ * thin over it. The carousel's own slide-window math is the shared
+ * {@link module:@/lib/day-window} (the desktop daily stream uses the same
+ * module), so day-paging stays consistent across surfaces.
+ */
+
+/** The seven ISO dates of `date`'s week, honoring the week-start setting. */
+export function weekOf(date: string, weekStart: WeekStartDay): string[] {
+  const weekday = getDay(parseIsoDate(date)) // 0 = Sunday … 6 = Saturday
+  const offsetToFirst = weekStart === 'monday' ? (weekday === 0 ? -6 : 1 - weekday) : -weekday
+  const first = addDaysIso(date, offsetToFirst)
+  return Array.from({ length: 7 }, (_, index) => addDaysIso(first, index))
+}
+
+/** The strip's month header, e.g. `June 2026`. */
+export function monthLabel(date: string): string {
+  return format(parseIsoDate(date), 'MMMM yyyy')
+}

--- a/apps/desktop/src/mobile/day-carousel.tsx
+++ b/apps/desktop/src/mobile/day-carousel.tsx
@@ -1,0 +1,56 @@
+import { type ReactElement } from 'react'
+import { dailyPath } from '@reflect/core'
+import { NotePane } from '@/components/note-pane'
+import { dateAtIndex } from '@/lib/day-window'
+import { useDayCarousel } from '@/mobile/use-day-carousel'
+
+interface DayCarouselProps {
+  /** The selected day (from the route). Drives the carousel position. */
+  date: string
+  /** Settle on a day — the parent turns this into a daily-route navigation. */
+  onSelect: (date: string) => void
+}
+
+/** Slides within this many of the selection mount an editor; the rest are
+ *  empty spacers Embla can still measure (bounds webview memory). */
+const MOUNT_RADIUS = 1
+
+/**
+ * V1's swipeable day carousel: horizontal paging between daily notes. The slide
+ * window, Embla wiring, and route↔slide sync all live in {@link useDayCarousel};
+ * this component just renders the slides, mounting a `NotePane` only near the
+ * selection and leaving the rest as empty spacers.
+ */
+export function DayCarousel({ date, onSelect }: DayCarouselProps): ReactElement {
+  const { emblaRef, dayWindow, selectedIndex } = useDayCarousel(date, onSelect)
+
+  return (
+    <div className="min-h-0 flex-1 overflow-hidden" ref={emblaRef}>
+      <div className="flex h-full">
+        {Array.from({ length: dayWindow.count }, (_, index) => {
+          const day = dateAtIndex(dayWindow, index)
+          const mounted = Math.abs(index - selectedIndex) <= MOUNT_RADIUS
+          return (
+            <div key={day} className="min-w-0 flex-[0_0_100%]">
+              {mounted ? (
+                <div
+                  className="h-full overflow-y-auto"
+                  style={{
+                    paddingBottom: 'max(env(safe-area-inset-bottom), var(--keyboard-height, 0px))',
+                  }}
+                >
+                  <NotePane
+                    path={dailyPath(day)}
+                    lazy
+                    gutterClassName="px-4"
+                    editorClassName="min-h-[60dvh]"
+                  />
+                </div>
+              ) : null}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -2,12 +2,36 @@ import { cleanup, render, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { format } from 'date-fns'
 import type { ReactElement } from 'react'
 import { setBridge } from '@reflect/core'
 import { RouterProvider, useRouter } from '@/routing/router'
 import type { Route } from '@/routing/route'
-import { addDaysIso, formatDayLabel, todayIso } from '@/lib/dates'
+import { addDaysIso, parseIsoDate, todayIso } from '@/lib/dates'
+import { monthLabel, weekOf } from './calendar'
 import { MobileShell } from './mobile-shell'
+
+// jsdom implements none of these; Embla (the day carousel) needs them to init.
+class ObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+  takeRecords(): [] {
+    return []
+  }
+}
+globalThis.ResizeObserver ??= ObserverStub as unknown as typeof ResizeObserver
+globalThis.IntersectionObserver ??= ObserverStub as unknown as typeof IntersectionObserver
+globalThis.matchMedia ??= ((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  addListener: () => {},
+  removeListener: () => {},
+  dispatchEvent: () => false,
+})) as unknown as typeof matchMedia
 
 /**
  * The tabbed mobile shell (Plan 19, V1 parity): the daily spine pages
@@ -40,7 +64,7 @@ vi.mock('@/providers/graph-provider', () => ({
 }))
 vi.mock('@/providers/settings-provider', () => ({
   useSettings: () => ({
-    settings: { editorMarkdownSyntax: 'always', dateFormat: 'mdy' },
+    settings: { editorMarkdownSyntax: 'always', dateFormat: 'mdy', weekStartDay: 'monday' },
     updateSettings: async () => {},
   }),
 }))
@@ -101,8 +125,15 @@ function NavProbe({ to }: { to: Route }): ReactElement {
   )
 }
 
-function dayHeading(date: string): string {
-  return formatDayLabel(date, 'mdy')
+/** The calendar strip's per-day aria-label (CalendarStrip uses this form). */
+function dayCellLabel(date: string): string {
+  return format(parseIsoDate(date), 'EEEE, MMMM do')
+}
+
+/** A day in `date`'s week that isn't `date` itself (always present). */
+function otherDayInWeek(date: string): string {
+  const week = weekOf(date, 'monday')
+  return week.find((day) => day !== date) ?? week[0]
 }
 
 describe('MobileShell', () => {
@@ -111,24 +142,49 @@ describe('MobileShell', () => {
     files[`daily/${today}.md`] = 'captured on the go'
     const view = mount({ kind: 'today' })
 
-    expect(view.getByRole('heading').textContent).toContain(dayHeading(today))
+    // The header is the month; the carousel mounts today's slide (±1
+    // neighbours), and today's shows its note.
+    expect(view.getByRole('heading').textContent).toBe(monthLabel(today))
     await waitFor(() => {
-      expect(view.getByTestId('fake-editor').textContent).toContain('captured on the go')
+      const editors = view.getAllByTestId('fake-editor')
+      expect(editors.some((editor) => editor.textContent?.includes('captured on the go'))).toBe(true)
     })
   })
 
-  it('pages between days and jumps back to today', async () => {
+  it('selects a day from the calendar strip and jumps back to today', async () => {
     const user = userEvent.setup()
     const today = todayIso()
-    const yesterday = addDaysIso(today, -1)
+    const other = otherDayInWeek(today)
     const view = mount({ kind: 'today' })
 
     expect(view.queryByRole('button', { name: 'Today' })).toBeNull()
-    await user.click(view.getByRole('button', { name: 'Previous day' }))
-    expect(view.getByRole('heading').textContent).toContain(dayHeading(yesterday))
+    await user.click(view.getByRole('button', { name: dayCellLabel(other) }))
+    expect(view.getByRole('button', { name: dayCellLabel(other) }).getAttribute('aria-current')).toBe(
+      'date',
+    )
+    expect(view.getByRole('button', { name: 'Today' })).toBeTruthy()
 
     await user.click(view.getByRole('button', { name: 'Today' }))
-    expect(view.getByRole('heading').textContent).toContain(dayHeading(today))
+    expect(view.queryByRole('button', { name: 'Today' })).toBeNull()
+    expect(view.getByRole('button', { name: dayCellLabel(today) }).getAttribute('aria-current')).toBe(
+      'date',
+    )
+  })
+
+  it('re-anchors the carousel when a date link lands outside its window', async () => {
+    const user = userEvent.setup()
+    // Beyond the ±366-day window — only reachable as a date-link navigation,
+    // which forces the carousel to rebuild its window around the day.
+    const farDay = addDaysIso(todayIso(), 400)
+    files[`daily/${farDay}.md`] = 'far future plans'
+    const view = mount({ kind: 'today' }, { kind: 'daily', date: farDay })
+
+    await user.click(view.getByRole('button', { name: 'probe-navigate' }))
+    expect(view.getByRole('heading').textContent).toBe(monthLabel(farDay))
+    await waitFor(() => {
+      const editors = view.getAllByTestId('fake-editor')
+      expect(editors.some((editor) => editor.textContent?.includes('far future plans'))).toBe(true)
+    })
   })
 
   it('opens a note from in-screen navigation and pops back through history', async () => {
@@ -140,7 +196,7 @@ describe('MobileShell', () => {
     expect(view.getByRole('heading').textContent).toContain('meeting-notes')
 
     await user.click(view.getByRole('button', { name: 'Back' }))
-    expect(view.getByRole('heading').textContent).toContain(dayHeading(todayIso()))
+    expect(view.getByRole('heading').textContent).toBe(monthLabel(todayIso()))
   })
 
   it('switches tabs: All shows the searchable list, Daily returns to today', async () => {
@@ -152,7 +208,7 @@ describe('MobileShell', () => {
     expect((await view.findByText('No notes yet')).textContent).toBe('No notes yet')
 
     await user.click(view.getByRole('button', { name: 'Daily' }))
-    expect(view.getByRole('heading').textContent).toContain(dayHeading(todayIso()))
+    expect(view.getByRole('heading').textContent).toBe(monthLabel(todayIso()))
   })
 
   it('renders a search entry as the All tab with the query seeded', async () => {
@@ -176,6 +232,6 @@ describe('MobileShell', () => {
     })
 
     await user.click(view.getByRole('button', { name: 'Back' }))
-    expect(view.getByRole('heading').textContent).toContain(dayHeading(todayIso()))
+    expect(view.getByRole('heading').textContent).toBe(monthLabel(todayIso()))
   })
 })

--- a/apps/desktop/src/mobile/mobile-screen.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.tsx
@@ -24,8 +24,10 @@ export function MobileScreen({ allQuery, onAllQueryChange }: MobileScreenProps):
   const today = useToday()
 
   switch (route.kind) {
+    // One stable key for the whole daily surface (today + any day): a day
+    // change scrolls the carousel rather than remounting it.
     case 'daily':
-      return <MobileDaily key={route.date} date={route.date} />
+      return <MobileDaily key="daily" date={route.date} />
     case 'note':
       return <MobileNote key={route.path} path={route.path} />
     case 'allNotes':
@@ -36,6 +38,6 @@ export function MobileScreen({ allQuery, onAllQueryChange }: MobileScreenProps):
       // the live query from the entry.
       return <MobileAllNotes query={allQuery} onQueryChange={onAllQueryChange} tag={null} />
     default:
-      return <MobileDaily key="today" date={today} />
+      return <MobileDaily key="daily" date={today} />
   }
 }

--- a/apps/desktop/src/mobile/note-actions-menu.test.tsx
+++ b/apps/desktop/src/mobile/note-actions-menu.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setBridge } from '@reflect/core'
+import { NoteActionsMenu } from './note-actions-menu'
+
+/**
+ * The note-actions menu (Plan 19): pin toggles the frontmatter flag, and
+ * delete confirms then moves the note to trash and notifies the screen. Runs
+ * the real toggle/delete core paths over a fake IPC bridge.
+ */
+
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({ graph: { root: '/g', name: 'g', cloudSync: null, generation: 1 } }),
+}))
+// The pinned set comes from the index; an empty list means "not pinned".
+vi.mock('@/hooks/use-pinned-notes', () => ({ usePinnedNotes: () => [] }))
+// No session is open for the note in this unit; discard is a no-op lookup.
+vi.mock('@/editor/open-documents', () => ({ openSession: () => null }))
+
+const calls: Array<{ command: string; args: Record<string, unknown> }> = []
+const mockInvoke = vi.fn<(command: string, args: Record<string, unknown>) => Promise<unknown>>()
+
+setBridge({ invoke: mockInvoke, listen: async () => () => {} })
+
+beforeEach(() => {
+  calls.length = 0
+  mockInvoke.mockReset()
+  mockInvoke.mockImplementation(async (command, args) => {
+    calls.push({ command, args })
+    if (command === 'note_read') {
+      return '# Meeting\n'
+    }
+    return null
+  })
+})
+
+afterEach(cleanup)
+
+function mount(onDeleted = vi.fn()): { view: ReturnType<typeof render>; onDeleted: typeof onDeleted } {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const view = render(
+    <QueryClientProvider client={queryClient}>
+      <NoteActionsMenu path="notes/meeting.md" onDeleted={onDeleted} />
+    </QueryClientProvider>,
+  )
+  return { view, onDeleted }
+}
+
+describe('NoteActionsMenu', () => {
+  it('pins the note by writing the frontmatter flag', async () => {
+    const user = userEvent.setup()
+    const { view } = mount()
+
+    await user.click(view.getByRole('button', { name: 'Note actions' }))
+    await user.click(await view.findByRole('menuitem', { name: 'Pin' }))
+
+    await waitFor(() => {
+      const write = calls.find((call) => call.command === 'note_write')
+      expect(write?.args.contents).toContain('pinned: true')
+    })
+  })
+
+  it('deletes after confirmation and notifies the screen', async () => {
+    const user = userEvent.setup()
+    const { view, onDeleted } = mount()
+
+    await user.click(view.getByRole('button', { name: 'Note actions' }))
+    await user.click(await view.findByRole('menuitem', { name: 'Delete' }))
+    // Confirm in the dialog (the destructive button).
+    await user.click(await view.findByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => {
+      expect(calls.some((call) => call.command === 'note_delete')).toBe(true)
+    })
+    expect(onDeleted).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/mobile/note-actions-menu.tsx
+++ b/apps/desktop/src/mobile/note-actions-menu.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactElement } from 'react'
-import { MoreHorizontal, Pin, PinOff, Trash2 } from 'lucide-react'
+import { MoreHorizontal, Pin, PinOff, Share, Trash2 } from 'lucide-react'
 import { errorMessage } from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import {
@@ -18,6 +18,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { toggleNotePinned } from '@/lib/note-pin'
 import { deleteOpenNote } from '@/mobile/note-delete'
+import { shareNote } from '@/mobile/share'
 import { useGraph } from '@/providers/graph-provider'
 import { usePinnedNotes } from '@/hooks/use-pinned-notes'
 
@@ -29,11 +30,12 @@ interface NoteActionsMenuProps {
 }
 
 /**
- * The note screen's "⋯" actions menu (Plan 19, V1 parity): pin/unpin and
- * delete-to-trash. Pin reflects the index's pinned set; delete confirms
- * first (it's destructive, even if recoverable from `.reflect/trash/`) and
- * routes through {@link deleteOpenNote} so the open session is discarded
- * rather than flushed. Share lands with its native plugin in a later slice.
+ * The note screen's "⋯" actions menu (Plan 19, V1 parity): pin/unpin, share,
+ * and delete-to-trash. Pin reflects the index's pinned set; {@link shareNote}
+ * hands the note's body to the OS share sheet via the Web Share API
+ * (`navigator.share`); delete confirms first (it's destructive, even if
+ * recoverable from `.reflect/trash/`) and routes through
+ * {@link deleteOpenNote} so the open session is discarded rather than flushed.
  */
 export function NoteActionsMenu({ path, onDeleted }: NoteActionsMenuProps): ReactElement {
   const { graph } = useGraph()
@@ -46,6 +48,10 @@ export function NoteActionsMenu({ path, onDeleted }: NoteActionsMenuProps): Reac
     if (graph !== null) {
       void toggleNotePinned(path, graph.generation).catch(() => {})
     }
+  }
+
+  const share = (): void => {
+    void shareNote(path).catch((cause) => console.error('share failed:', errorMessage(cause)))
   }
 
   const confirmDelete = (): void => {
@@ -75,6 +81,10 @@ export function NoteActionsMenu({ path, onDeleted }: NoteActionsMenuProps): Reac
           <DropdownMenuItem onSelect={pin}>
             {isPinned ? <PinOff /> : <Pin />}
             {isPinned ? 'Unpin' : 'Pin'}
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={share}>
+            <Share />
+            Share
           </DropdownMenuItem>
           <DropdownMenuItem variant="destructive" onSelect={() => setConfirmingDelete(true)}>
             <Trash2 />

--- a/apps/desktop/src/mobile/note-actions-menu.tsx
+++ b/apps/desktop/src/mobile/note-actions-menu.tsx
@@ -1,0 +1,108 @@
+import { useState, type ReactElement } from 'react'
+import { MoreHorizontal, Pin, PinOff, Trash2 } from 'lucide-react'
+import { errorMessage } from '@reflect/core'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { toggleNotePinned } from '@/lib/note-pin'
+import { deleteOpenNote } from '@/mobile/note-delete'
+import { useGraph } from '@/providers/graph-provider'
+import { usePinnedNotes } from '@/hooks/use-pinned-notes'
+
+interface NoteActionsMenuProps {
+  /** Graph-relative path of the note the actions operate on. */
+  path: string
+  /** Called after the note is deleted, so the screen can navigate away. */
+  onDeleted: () => void
+}
+
+/**
+ * The note screen's "⋯" actions menu (Plan 19, V1 parity): pin/unpin and
+ * delete-to-trash. Pin reflects the index's pinned set; delete confirms
+ * first (it's destructive, even if recoverable from `.reflect/trash/`) and
+ * routes through {@link deleteOpenNote} so the open session is discarded
+ * rather than flushed. Share lands with its native plugin in a later slice.
+ */
+export function NoteActionsMenu({ path, onDeleted }: NoteActionsMenuProps): ReactElement {
+  const { graph } = useGraph()
+  const isPinned = usePinnedNotes().some((note) => note.path === path)
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const pin = (): void => {
+    if (graph !== null) {
+      void toggleNotePinned(path, graph.generation).catch(() => {})
+    }
+  }
+
+  const confirmDelete = (): void => {
+    if (graph === null) {
+      return
+    }
+    setBusy(true)
+    setError(null)
+    void deleteOpenNote(path, graph.generation)
+      .then(() => {
+        setConfirmingDelete(false)
+        onDeleted()
+      })
+      .catch((cause) => setError(errorMessage(cause)))
+      .finally(() => setBusy(false))
+  }
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" className="size-10" aria-label="Note actions">
+            <MoreHorizontal />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={pin}>
+            {isPinned ? <PinOff /> : <Pin />}
+            {isPinned ? 'Unpin' : 'Pin'}
+          </DropdownMenuItem>
+          <DropdownMenuItem variant="destructive" onSelect={() => setConfirmingDelete(true)}>
+            <Trash2 />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={confirmingDelete} onOpenChange={(open) => !busy && setConfirmingDelete(open)}>
+        <DialogContent>
+          <DialogTitle>Delete this note?</DialogTitle>
+          <DialogDescription>
+            It moves to the graph’s trash and disappears from your notes. You can recover it on
+            desktop.
+          </DialogDescription>
+          {error !== null && <p className="text-sm text-destructive">{error}</p>}
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="ghost" disabled={busy}>
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button variant="destructive" disabled={busy} onClick={confirmDelete}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/apps/desktop/src/mobile/note-delete.test.ts
+++ b/apps/desktop/src/mobile/note-delete.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { deleteOpenNote } from './note-delete'
+
+/**
+ * `deleteOpenNote` deletes first, then discards the open session — so a
+ * failed delete never leaves a discarded-but-mounted session (which would
+ * silently stop persisting the user's edits).
+ */
+
+const deleteNoteMock = vi.fn<(path: string, generation: number) => Promise<void>>()
+const discard = vi.fn()
+const openSessionMock = vi.fn<(path: string) => { discard: () => void } | null>()
+
+vi.mock('@reflect/core', () => ({
+  deleteNote: (path: string, generation: number) => deleteNoteMock(path, generation),
+}))
+vi.mock('@/editor/open-documents', () => ({
+  openSession: (path: string) => openSessionMock(path),
+}))
+
+afterEach(() => {
+  deleteNoteMock.mockReset()
+  discard.mockReset()
+  openSessionMock.mockReset()
+})
+
+describe('deleteOpenNote', () => {
+  it('discards the open session after a successful delete', async () => {
+    deleteNoteMock.mockResolvedValue()
+    openSessionMock.mockReturnValue({ discard })
+
+    await deleteOpenNote('notes/gone.md', 3)
+
+    expect(deleteNoteMock).toHaveBeenCalledWith('notes/gone.md', 3)
+    expect(discard).toHaveBeenCalledOnce()
+  })
+
+  it('leaves the session intact when the delete fails', async () => {
+    deleteNoteMock.mockRejectedValue(new Error('disk full'))
+    openSessionMock.mockReturnValue({ discard })
+
+    await expect(deleteOpenNote('notes/gone.md', 3)).rejects.toThrow('disk full')
+
+    // The session was never discarded — the screen stays editable.
+    expect(discard).not.toHaveBeenCalled()
+    expect(openSessionMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/mobile/note-delete.ts
+++ b/apps/desktop/src/mobile/note-delete.ts
@@ -1,0 +1,22 @@
+import { deleteNote } from '@reflect/core'
+import { openSession } from '@/editor/open-documents'
+
+/**
+ * Delete a note from the mobile note screen (Plan 19, V1 parity). On mobile
+ * `deleteNote` moves the file into the graph-local `.reflect/trash/`
+ * (recoverable, sync-ignored) and emits the in-process `remove` so the index
+ * and queries drop it.
+ *
+ * **Delete first, discard second.** If the delete fails, the open session is
+ * left fully intact — the note screen stays mounted and editable, edits keep
+ * persisting. Only once the file is in trash do we `discard` the session: it
+ * stays `dirty` after its file vanishes (a removed file is "nothing to
+ * reconcile", so dirtiness isn't cleared), and a normal teardown flush would
+ * therefore rewrite — recreate — the file. `discard` detaches without
+ * writing, so the pane's unmount (flush → dispose) is a no-op. The caller
+ * navigates away after this resolves.
+ */
+export async function deleteOpenNote(path: string, generation: number): Promise<void> {
+  await deleteNote(path, generation)
+  openSession(path)?.discard()
+}

--- a/apps/desktop/src/mobile/screens/daily.tsx
+++ b/apps/desktop/src/mobile/screens/daily.tsx
@@ -1,65 +1,38 @@
 import { type ReactElement } from 'react'
-import { ChevronLeft, ChevronRight, Plus } from 'lucide-react'
-import { dailyPath } from '@reflect/core'
-import { NotePane } from '@/components/note-pane'
+import { Plus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { untitledNotePath } from '@/lib/create-note'
-import { addDaysIso, formatDayLabel } from '@/lib/dates'
 import { useToday } from '@/lib/use-today'
-import { useSettings } from '@/providers/settings-provider'
+import { CalendarStrip } from '@/mobile/calendar-strip'
+import { DayCarousel } from '@/mobile/day-carousel'
 import { useRouter } from '@/routing/router'
 
 /**
- * One daily note — the mobile spine (Plan 19). The header pages between
- * days, with a jump back to today whenever the view has wandered; the body
- * is the shared document stack via `NotePane`, exactly as on desktop. The
- * scroll container yields to the keyboard via `--keyboard-height`, and the
- * new-note button floats above both — V1 parity: the daily note itself is
- * the capture surface, and `+` opens a fresh untitled note (the same
- * seed/ghost-title flow as desktop's ⌘N).
+ * The mobile spine (Plan 19, V1 parity): a month header + week calendar strip
+ * over a swipeable day carousel of daily notes. The strip and the carousel
+ * stay in lockstep through `date` — tapping a strip day or swiping the
+ * carousel both navigate a daily route, which flows back as `date`. The
+ * new-note button floats above it all (V1: the daily note is the capture
+ * surface; `+` opens a fresh untitled note via desktop's ⌘N seed flow).
+ *
+ * Mounted once for the daily surface (a stable key in `MobileScreen`), so a
+ * day change scrolls the carousel rather than remounting it.
  */
 export function MobileDaily({ date }: { date: string }): ReactElement {
-  const { settings } = useSettings()
   const { navigate } = useRouter()
-  // Live: the Today affordance appears at midnight without a re-navigation.
-  const isToday = date === useToday()
+  // One live `today` for the whole surface: the strip marks today's cell and
+  // the `select` below decide "is this today?" from the *same* value, so they
+  // can't disagree across the midnight rollover (which would otherwise route a
+  // tap on the highlighted today cell to a frozen `daily` date). Selecting
+  // today routes to the live `today` route, keeping the spine rolling over.
+  const today = useToday()
+  const select = (day: string): void =>
+    navigate(day === today ? { kind: 'today' } : { kind: 'daily', date: day })
 
   return (
-    <div className="flex h-full w-screen flex-col" style={{ paddingTop: 'env(safe-area-inset-top)' }}>
-      <header className="flex shrink-0 items-center gap-1 border-b border-border px-1 pb-1">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-10"
-          aria-label="Previous day"
-          onClick={() => navigate({ kind: 'daily', date: addDaysIso(date, -1) })}
-        >
-          <ChevronLeft />
-        </Button>
-        <h1 className="min-w-0 flex-1 truncate text-center text-base font-semibold">
-          {formatDayLabel(date, settings.dateFormat)}
-        </h1>
-        {!isToday && (
-          <Button variant="ghost" size="sm" onClick={() => navigate({ kind: 'today' })}>
-            Today
-          </Button>
-        )}
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-10"
-          aria-label="Next day"
-          onClick={() => navigate({ kind: 'daily', date: addDaysIso(date, 1) })}
-        >
-          <ChevronRight />
-        </Button>
-      </header>
-      <main
-        className="min-h-0 flex-1 overflow-y-auto"
-        style={{ paddingBottom: 'max(env(safe-area-inset-bottom), var(--keyboard-height, 0px))' }}
-      >
-        <NotePane path={dailyPath(date)} lazy gutterClassName="px-4" editorClassName="min-h-[60dvh]" />
-      </main>
+    <div className="flex h-full w-screen flex-col">
+      <CalendarStrip date={date} today={today} onSelect={select} />
+      <DayCarousel date={date} onSelect={select} />
       <Button
         size="icon"
         aria-label="New note"

--- a/apps/desktop/src/mobile/screens/note.tsx
+++ b/apps/desktop/src/mobile/screens/note.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft } from 'lucide-react'
 import { NotePane } from '@/components/note-pane'
 import { Button } from '@/components/ui/button'
 import { isUntitledNotePath } from '@/lib/create-note'
+import { NoteActionsMenu } from '@/mobile/note-actions-menu'
 import { useRouter } from '@/routing/router'
 
 /**
@@ -32,7 +33,10 @@ export function MobileNote({ path }: { path: string }): ReactElement {
         <h1 className="min-w-0 flex-1 truncate text-base font-semibold">
           {untitled ? 'New note' : noteTitleFromPath(path)}
         </h1>
-        <div aria-hidden className="size-10 shrink-0" />
+        <NoteActionsMenu
+          path={path}
+          onDeleted={() => (canBack ? back() : navigate({ kind: 'today' }))}
+        />
       </header>
       <main
         className="min-h-0 flex-1 overflow-y-auto"

--- a/apps/desktop/src/mobile/settings-sheet.tsx
+++ b/apps/desktop/src/mobile/settings-sheet.tsx
@@ -1,0 +1,59 @@
+import { useState, type ReactElement } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Settings } from 'lucide-react'
+import { hasBridge, listNotes } from '@reflect/core'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
+import { useAppVersion } from '@/hooks/use-app-version'
+import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
+import { useGraph } from '@/providers/graph-provider'
+
+/**
+ * The mobile settings sheet (Plan 19, V1 parity) — the trigger lives in V1's
+ * avatar spot (top-left of the Daily header). A deliberately small surface:
+ * the graph's name, its note count, and the app version. GitHub
+ * connect/disconnect and sync status arrive with the sync slice; this sheet
+ * is where they'll land.
+ */
+export function SettingsSheet(): ReactElement {
+  const { graph } = useGraph()
+  const version = useAppVersion()
+  const [open, setOpen] = useState(false)
+
+  const { data: notes } = useQuery({
+    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'mobile-note-count'],
+    queryFn: () => listNotes(),
+    enabled: open && hasBridge() && graph !== null,
+  })
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="icon" className="size-9" aria-label="Settings">
+          <Settings />
+        </Button>
+      </DialogTrigger>
+      <DialogContent
+        showCloseButton={false}
+        className="inset-x-0 bottom-0 top-auto left-0 max-w-none translate-x-0 translate-y-0 rounded-b-none data-closed:zoom-out-100 data-open:zoom-in-100"
+        style={{ paddingBottom: 'max(env(safe-area-inset-bottom), 1rem)' }}
+      >
+        <DialogTitle>Settings</DialogTitle>
+        <dl className="divide-y divide-border text-sm">
+          <Row label="Graph" value={graph?.name ?? '—'} />
+          <Row label="Notes" value={notes === undefined ? '…' : String(notes.length)} />
+          <Row label="Version" value={version ?? '…'} />
+        </dl>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function Row({ label, value }: { label: string; value: string }): ReactElement {
+  return (
+    <div className="flex items-center justify-between py-2.5">
+      <dt className="text-text-muted">{label}</dt>
+      <dd className="font-medium tabular-nums">{value}</dd>
+    </div>
+  )
+}

--- a/apps/desktop/src/mobile/share.test.ts
+++ b/apps/desktop/src/mobile/share.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const shareMock = vi.fn<(data: ShareData) => Promise<void>>()
+const openSessionMock = vi.fn<(path: string) => { liveContent: () => string | null } | null>()
+
+vi.mock('@/editor/open-documents', () => ({
+  openSession: (path: string) => openSessionMock(path),
+}))
+
+beforeEach(() => {
+  Object.defineProperty(navigator, 'share', { configurable: true, value: shareMock })
+  shareMock.mockReset()
+  shareMock.mockResolvedValue(undefined)
+  openSessionMock.mockReset()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('shareNote', () => {
+  it('shares the live editor buffer body (frontmatter stripped, title as subject)', async () => {
+    openSessionMock.mockReturnValue({
+      liveContent: () => '---\nid: abc123\n---\n# Meeting\n\nAgenda + the unsaved line.\n',
+    })
+    const { shareNote } = await import('./share')
+
+    await shareNote('notes/meeting-notes.md')
+
+    expect(shareMock).toHaveBeenCalledWith({
+      title: 'meeting-notes',
+      text: '# Meeting\n\nAgenda + the unsaved line.\n',
+    })
+  })
+
+  it('shares the empty body when a ready note was cleared (not stale content)', async () => {
+    openSessionMock.mockReturnValue({ liveContent: () => '' })
+    const { shareNote } = await import('./share')
+
+    await shareNote('notes/meeting-notes.md')
+
+    expect(shareMock).toHaveBeenCalledWith({ title: 'meeting-notes', text: '' })
+  })
+
+  it('shares empty rather than reading disk while the session is still loading', async () => {
+    // liveContent() is null until load() lands; reading disk here would
+    // require an await and break navigator.share's transient activation.
+    openSessionMock.mockReturnValue({ liveContent: () => null })
+    const { shareNote } = await import('./share')
+
+    await shareNote('notes/meeting-notes.md')
+
+    expect(shareMock).toHaveBeenCalledWith({ title: 'meeting-notes', text: '' })
+  })
+})

--- a/apps/desktop/src/mobile/share.ts
+++ b/apps/desktop/src/mobile/share.ts
@@ -1,0 +1,35 @@
+import { splitFrontmatter } from '@reflect/core'
+import { openSession } from '@/editor/open-documents'
+
+/**
+ * Share a note through the OS share sheet (Plan 19, V1 parity) via the Web
+ * Share API. The Tauri iOS WKWebView exposes a working `navigator.share`
+ * (verified on-device), so no native plugin is needed — WebKit presents the
+ * same `UIActivityViewController`.
+ *
+ * **Activation invariant:** `navigator.share` requires the tap's transient
+ * user activation, which any `await` before the call consumes — so the
+ * content must be read *synchronously*. The only synchronous source is the
+ * open editor session's live buffer, which is also exactly what we want:
+ * Share lives only on the note screen, where the note is open and its
+ * debounced buffer holds the user's latest typing. `liveContent()` returns
+ * that buffer once the session is ready (authoritative even when empty), or
+ * `null` while it's still loading — a window not reachable via the menu in
+ * practice, where we share empty rather than break activation with an async
+ * disk read.
+ *
+ * Shares the markdown **body** (frontmatter stripped, so the recipient never
+ * sees the `id:` block), with the title (the readable filename) as the
+ * subject for targets that use one (Mail).
+ */
+export async function shareNote(path: string): Promise<void> {
+  const live = openSession(path)?.liveContent() ?? ''
+  const text = splitFrontmatter(live).body.trimStart()
+  await navigator.share({ title: noteTitle(path), text })
+}
+
+/** The basename without its `.md` — the note's working title (Plan 17). */
+function noteTitle(path: string): string {
+  const base = path.slice(path.lastIndexOf('/') + 1)
+  return base.endsWith('.md') ? base.slice(0, -'.md'.length) : base
+}

--- a/apps/desktop/src/mobile/use-day-carousel.test.ts
+++ b/apps/desktop/src/mobile/use-day-carousel.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { reconcileCarousel, type ReconcileInput } from './use-day-carousel'
+
+/**
+ * The carousel's follow-the-route decision in isolation — Embla pointer
+ * gestures can't be driven under jsdom, so the branchy reconciliation that the
+ * integration test can only reach indirectly is pinned here as pure logic.
+ */
+const base: ReconcileInput = {
+  index: 10,
+  windowStart: '2025-06-11',
+  lastWindowStart: '2025-06-11',
+  date: '2026-06-12',
+  reported: '2026-06-01',
+}
+
+describe('reconcileCarousel', () => {
+  it('scrolls for an ordinary in-window jump', () => {
+    expect(reconcileCarousel(base)).toEqual({ action: 'scroll', index: 10 })
+  })
+
+  it('does nothing for the echo of our own swipe', () => {
+    // The route just echoed back the day we reported — re-scrolling would
+    // cancel Embla's settling animation.
+    expect(reconcileCarousel({ ...base, date: '2026-06-01', reported: '2026-06-01' })).toEqual({
+      action: 'none',
+    })
+  })
+
+  it('does nothing when the date is outside the window (a re-anchor is pending)', () => {
+    expect(reconcileCarousel({ ...base, index: -1 })).toEqual({ action: 'none' })
+  })
+
+  it('reinitializes when the window was re-anchored', () => {
+    expect(reconcileCarousel({ ...base, lastWindowStart: '2024-01-01' })).toEqual({
+      action: 'reinit',
+      index: 10,
+    })
+  })
+
+  it('reinitializes after a re-anchor even when the date matches the last report', () => {
+    // A far date link re-anchors *and* is later echoed back: the window change
+    // must win over the echo guard, or the rebuilt slides never get shown.
+    expect(
+      reconcileCarousel({
+        ...base,
+        lastWindowStart: '2024-01-01',
+        date: '2026-06-01',
+        reported: '2026-06-01',
+      }),
+    ).toEqual({ action: 'reinit', index: 10 })
+  })
+
+  it('treats an outside date as a no-op even while the window is mid-re-anchor', () => {
+    // `index === -1` is checked first: the window effect will rebuild before
+    // this reconciliation matters, so there is nothing to scroll yet.
+    expect(reconcileCarousel({ ...base, index: -1, lastWindowStart: '2024-01-01' })).toEqual({
+      action: 'none',
+    })
+  })
+})

--- a/apps/desktop/src/mobile/use-day-carousel.ts
+++ b/apps/desktop/src/mobile/use-day-carousel.ts
@@ -1,0 +1,167 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import useEmblaCarousel from 'embla-carousel-react'
+import { createDayWindow, dateAtIndex, indexWithin, type DayWindow } from '@/lib/day-window'
+
+/**
+ * Days either side of the carousel anchor. A generous fixed **symmetric**
+ * window (~1 year each way) lets Embla page between days without runtime
+ * re-anchoring; only the slides near the selection mount an editor, so the
+ * empty ones are cheap spacers. A date-link beyond it (the rare case)
+ * re-anchors the window around the new day. The desktop daily stream shares the
+ * window math ({@link createDayWindow}) with a wider, asymmetric reach — but it
+ * truly virtualizes its rows, where the carousel renders every slide spacer and
+ * only mounts the editors near the selection.
+ */
+export const CAROUSEL_RADIUS = 366
+
+const CAROUSEL_WINDOW: Readonly<{ past: number; future: number }> = {
+  past: CAROUSEL_RADIUS,
+  future: CAROUSEL_RADIUS,
+}
+
+/** What the carousel should do when the external target `date` changes. */
+export type CarouselSync =
+  | { action: 'none' }
+  | { action: 'reinit'; index: number }
+  | { action: 'scroll'; index: number }
+
+/** Inputs to {@link reconcileCarousel} — all plain values, no Embla handle. */
+export interface ReconcileInput {
+  /** Index of the target date in the current window, or `-1` if outside it. */
+  index: number
+  /** The current window's start date. */
+  windowStart: string
+  /** The window start the carousel was last reconciled against. */
+  lastWindowStart: string
+  /** The target date the carousel is being asked to show. */
+  date: string
+  /** The day last reported back through `onSelect` — the echo guard. */
+  reported: string
+}
+
+/**
+ * Decide how the carousel should follow an external `date` change. Pure, so the
+ * branchy reconciliation can be unit-tested without driving Embla:
+ *
+ * - `none` when the date is outside the window (`index === -1`, a re-anchor is
+ *   pending) or is the echo of our own swipe (already reported) — re-scrolling
+ *   then would cancel the in-flight animation.
+ * - `reinit` when the window was re-anchored (its start moved): Embla must
+ *   reinitialize onto the rebuilt slide set at the target index.
+ * - `scroll` for an ordinary in-window jump (calendar tap, Today, near link).
+ */
+export function reconcileCarousel(input: ReconcileInput): CarouselSync {
+  if (input.index === -1) {
+    return { action: 'none' }
+  }
+  if (input.windowStart !== input.lastWindowStart) {
+    return { action: 'reinit', index: input.index }
+  }
+  if (input.date === input.reported) {
+    return { action: 'none' }
+  }
+  return { action: 'scroll', index: input.index }
+}
+
+export interface DayCarousel {
+  /** Attach to the Embla viewport element. */
+  emblaRef: ReturnType<typeof useEmblaCarousel>[0]
+  /** The current slide window (`count` is the slide total). */
+  dayWindow: DayWindow
+  /** The centered slide's index — the view mounts editors around it. */
+  selectedIndex: number
+}
+
+/**
+ * Drives the swipeable day carousel: owns the slide window, the Embla instance,
+ * and the bidirectional `date ↔ slide` sync, leaving {@link DayCarousel} (the
+ * component) purely declarative.
+ *
+ * A settled swipe reports its day via `onSelect` (which the parent turns into a
+ * daily-route navigation); the route flows back in as `date` and scrolls the
+ * carousel to match — guarded by {@link reconcileCarousel} so the swipe's own
+ * echo doesn't re-scroll and cancel the animation. A `date` beyond the window
+ * re-anchors it, and the follow effect then reinitializes Embla onto the new
+ * slides.
+ */
+export function useDayCarousel(date: string, onSelect: (date: string) => void): DayCarousel {
+  const [dayWindow, setDayWindow] = useState<DayWindow>(() => createDayWindow(date, CAROUSEL_WINDOW))
+  const [emblaRef, emblaApi] = useEmblaCarousel({
+    startIndex: indexWithin(dayWindow, date),
+    align: 'center',
+    skipSnaps: false,
+  })
+  const [selectedIndex, setSelectedIndex] = useState(() => indexWithin(dayWindow, date))
+  // The day we last reported via onSelect — so the route echo it produces
+  // doesn't trigger a redundant (animation-cancelling) scrollTo.
+  const reportedRef = useRef(date)
+  // The window start we last reconciled against — a change means a re-anchor,
+  // so Embla must reinitialize rather than scroll.
+  const windowStartRef = useRef(dayWindow.start)
+
+  const onEmblaSelect = useCallback(
+    (api: NonNullable<typeof emblaApi>) => {
+      const index = api.selectedScrollSnap()
+      setSelectedIndex(index)
+      const day = dateAtIndex(dayWindow, index)
+      if (day !== reportedRef.current) {
+        reportedRef.current = day
+        onSelect(day)
+      }
+    },
+    [dayWindow, onSelect],
+  )
+
+  useEffect(() => {
+    if (!emblaApi) {
+      return
+    }
+    emblaApi.on('select', onEmblaSelect)
+    return () => {
+      emblaApi.off('select', onEmblaSelect)
+    }
+  }, [emblaApi, onEmblaSelect])
+
+  // Re-anchor only when the requested day falls outside the window (a far date
+  // link): rebuild the window centered on it. The follow effect below then
+  // reinitializes Embla onto the new slides — so `reportedRef` is left
+  // untouched here. Layout effect so the rebuilt window + scroll land in the
+  // same frame as the strip's new selection (no visible lag).
+  useLayoutEffect(() => {
+    if (indexWithin(dayWindow, date) === -1) {
+      setDayWindow(createDayWindow(date, CAROUSEL_WINDOW))
+    }
+  }, [date, dayWindow])
+
+  // Follow an external selection (calendar tap, Today, date link): scroll, or
+  // reinit after a re-anchor, or do nothing for our own swipe's echo —
+  // {@link reconcileCarousel} owns the decision. A *layout* effect so Embla's
+  // scroll and `selectedIndex` (which decides slide mounting) update before
+  // paint — otherwise the centered/mounted slide lags the route by a frame and
+  // the strip could show one day while the editor still shows the previous.
+  useLayoutEffect(() => {
+    if (!emblaApi) {
+      return
+    }
+    const sync = reconcileCarousel({
+      index: indexWithin(dayWindow, date),
+      windowStart: dayWindow.start,
+      lastWindowStart: windowStartRef.current,
+      date,
+      reported: reportedRef.current,
+    })
+    if (sync.action === 'none') {
+      return
+    }
+    windowStartRef.current = dayWindow.start
+    reportedRef.current = date
+    if (sync.action === 'reinit') {
+      emblaApi.reInit({ startIndex: sync.index })
+    } else {
+      emblaApi.scrollTo(sync.index, true)
+    }
+    setSelectedIndex(sync.index)
+  }, [emblaApi, date, dayWindow])
+
+  return { emblaRef, dayWindow, selectedIndex }
+}

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -225,18 +225,30 @@ body {
   --meowdown-selection: var(--accent-soft, rgb(99 102 241 / 12%));
 
   /* The panes own all spacing and sizing: cancel the theme's editor padding
-     (no floating UI of ours needs the `--meowdown-gutter`) and font size. */
+     (no floating UI of ours needs the `--meowdown-gutter`) and font size.
+     The matching .reflect-editor.ProseMirror block below re-states these with
+     0-2-0 specificity; see the note on .reflect-stream-gutter for why. */
   padding: 0;
   font-size: inherit;
   font-family: var(--font-reading, var(--font-sans));
 }
 
+.reflect-editor.ProseMirror {
+  padding: 0;
+  font-size: inherit;
+}
+
 /* The daily stream's horizontal gutter (STREAM_GUTTER in daily-stream.tsx),
    shared by each row's day label, pane chrome, and the editor itself so they
-   align. An un-layered class — a `px-*` utility sits in `@layer utilities`
-   and would lose to the un-layered `padding: 0` reset above; this rule beats
-   it as the later equal-specificity declaration. Keep it below that reset. */
+   align. Un-layered so it beats the un-layered `padding: 0` reset above by
+   source order. The `.ProseMirror` compound bumps specificity to 0-2-0:
+   meowdown's stylesheet is injected dynamically when the editor lazy-loads,
+   so its `.ProseMirror { padding }` rule arrives after this file and wins
+   equal-specificity ties; the compound restores our rule's priority. */
 .reflect-stream-gutter {
+  padding-inline: max(1.5rem, calc((100% - 42rem) / 2));
+}
+.reflect-stream-gutter.ProseMirror {
   padding-inline: max(1.5rem, calc((100% - 42rem) / 2));
 }
 

--- a/docs/plans/19-mobile.md
+++ b/docs/plans/19-mobile.md
@@ -344,8 +344,9 @@ Steps 1 and 2 are the existential gates; nothing else starts until both pass.
    Embla day carousel replacing the chevron pager; the `+` button opens a
    fresh untitled note (desktop's ⌘N seed/ghost-title flow — V1 had no
    capture sheet, and the 2026-06-12 product call removed the V2 one). Then
-   the settings sheet (V1's avatar spot) and note actions (pin, share via a
-   small native share plugin, trash).
+   the settings sheet (V1's avatar spot) and note actions (pin, share via the
+   webview's Web Share API — `navigator.share`, verified working in the Tauri
+   iOS WKWebView, so no native plugin — and trash).
 10. **Sync wiring.** Resume/edit/online triggers, background-flush + local
     commit on pause, `onRemoteChanges` reindex (unchanged), conflicted notes
     protected with "Needs review on desktop", status pill live.

--- a/docs/reflect-v2-mobile-grounding-brief.md
+++ b/docs/reflect-v2-mobile-grounding-brief.md
@@ -49,7 +49,7 @@ Plan 19 defines the binding scope. Summarized, with the product-owner calls of 2
 | Full editing (meowdown; CM6 live-preview fallback) | **In** | Hard requirement. The editor choice is locked by an on-device gate spike before screens are built (Plan 19, decision 7 / step 2). |
 | New note (`+` button) | **In** | V1 parity (product call 2026-06-12): there is **no capture sheet** — the daily note is the capture surface; `+` opens a fresh untitled note via desktop's ⌘N seed/ghost-title flow. |
 | All notes + lexical search (FTS5) | **In** | Same index schema and getters as desktop; search embedded in the All tab with filter badges, V1-style. |
-| Note actions (pin, share, trash) | **In** | Product call 2026-06-12: full V1 parity — pin/unpin (frontmatter flag), native share sheet (small Swift plugin), trash to `.reflect/trash/`. |
+| Note actions (pin, share, trash) | **In** | Product call 2026-06-12: full V1 parity — pin/unpin (frontmatter flag), share via the Web Share API (`navigator.share`, verified working in the Tauri iOS WKWebView — no native plugin needed), trash to `.reflect/trash/`. |
 | Settings sheet | **In** | V1's avatar spot: graph name, note count, GitHub connect/disconnect, sync status, version. |
 | GitHub sync (device flow, HTTPS) | **In** | Foreground-only; cycle on resume, after debounced edits, and on network regain. |
 | Onboarding: Start fresh / Connect GitHub | **In** | One graph per device, fixed root in `Documents/`, Files-app visible. |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
+      embla-carousel-react:
+        specifier: ^8.6.0
+        version: 8.6.0(react@19.2.7)
       lucide-react:
         specifier: ^1.17.0
         version: 1.17.0(react@19.2.7)
@@ -2923,6 +2926,19 @@ packages:
 
   electron-to-chromium@1.5.368:
     resolution: {integrity: sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==}
+
+  embla-carousel-react@8.6.0:
+    resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
+  embla-carousel-reactive-utils@8.6.0:
+    resolution: {integrity: sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==}
+    peerDependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel@8.6.0:
+    resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -7869,6 +7885,18 @@ snapshots:
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.368: {}
+
+  embla-carousel-react@8.6.0(react@19.2.7):
+    dependencies:
+      embla-carousel: 8.6.0
+      embla-carousel-reactive-utils: 8.6.0(embla-carousel@8.6.0)
+      react: 19.2.7
+
+  embla-carousel-reactive-utils@8.6.0(embla-carousel@8.6.0):
+    dependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel@8.6.0: {}
 
   emoji-regex@10.6.0: {}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New `discard`/`liveContent` behavior on the core note save path affects delete correctness; the carousel and route sync are complex but covered by unit and shell integration tests.
> 
> **Overview**
> Delivers **Plan 19 mobile daily V1 parity**: the chevron day pager is replaced by a **month header + week calendar strip** and an **Embla swipeable day carousel**, with a stable `MobileDaily` mount so route day changes scroll the carousel instead of remounting it. Shared **`day-window`** now accepts configurable past/future radii and adds **`indexWithin`** (outside-window → re-anchor) for the carousel, alongside the desktop stream’s clamping **`indexOfDate`**.
> 
> Adds mobile **settings sheet** (graph name, note count, version) from the strip, and a note **⋯ menu** (pin/unpin, **Web Share API** share, confirmed trash). Share reads the open session synchronously via new **`liveContent()`**; delete uses **`deleteOpenNote`** (delete first, then **`discard`** on the session).
> 
> **`NoteSession`** gains **`discard`** so teardown after delete never flushes pending edits and recreates the file; saves and **`dispose`** respect the discarded flag. Docs/comments note sharing needs no native Tauri plugin.
> 
> Small **CSS** tweak raises ProseMirror gutter specificity so lazy-loaded meowdown styles don’t override stream padding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b6352c0f0b51bcddde1cf8a0c4eef56705c6530. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->