### PR TITLE
Release tooling: pnpm release:bump (bump version + cut a release in one command)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ pnpm dev              # turbo dev across packages (Vite on http://localhost:1420
 pnpm tauri dev        # Full Tauri app with hot reload (stages the CLI sidecar first)
 pnpm build            # turbo build pipeline → apps/desktop/dist/
 pnpm tauri build      # Native app bundle, incl. the reflect CLI sidecar
+pnpm release:bump     # Bump the version everywhere + push the release tag (docs/macos-distribution.md)
 pnpm release:macos    # Signed + notarized macOS build for distribution (docs/macos-distribution.md)
 pnpm release:macos publish  # The above, then upload the DMG to a new GitHub release
 ```

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "sidecar": "node scripts/build-sidecar.mjs",
+    "release:bump": "node scripts/release-bump.mjs",
     "release:macos": "node scripts/release-macos.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/apps/desktop/scripts/release-bump.mjs
+++ b/apps/desktop/scripts/release-bump.mjs
@@ -218,15 +218,18 @@ async function main() {
   const isPrerelease = next.includes('-')
   const tag = `v${next}`
 
-  // Guardrail: stable versions are for the stable channel, which ships from
-  // master. A stable tag pushed from next would become `releases/latest` and
-  // reach every stable install — refuse it here.
-  if (!isPrerelease && branch === BETA_BRANCH) {
-    fail(
-      `refusing to cut stable ${next} from ${BETA_BRANCH}.\n` +
-        `  Stable releases ship from ${STABLE_BRANCH}: merge ${BETA_BRANCH} → ${STABLE_BRANCH} and run this there.\n` +
-        `  (To open the next beta cycle on ${BETA_BRANCH}, use prepatch/preminor/premajor.)`,
-    )
+  // Guardrail: releases are locked to their branch. A stable version reaches
+  // `releases/latest` and auto-updates every stable install, so it must come
+  // from master and nowhere else — keying on the *required* branch (not just
+  // excluding next) stops a stable tag being pushed from any other synced
+  // branch whose code never landed on master. Betas come from next.
+  const requiredBranch = isPrerelease ? BETA_BRANCH : STABLE_BRANCH
+  if (branch !== requiredBranch) {
+    const channel = isPrerelease ? 'pre-release' : 'stable'
+    const hint = isPrerelease
+      ? `Betas ship from ${BETA_BRANCH} — switch there and run this.`
+      : `Stable releases ship from ${STABLE_BRANCH} — merge ${BETA_BRANCH} → ${STABLE_BRANCH} and run this there.`
+    fail(`refusing to cut ${channel} ${next} from "${branch}".\n  ${hint}`)
   }
 
   if (git(['status', '--porcelain']) !== '') {

--- a/apps/desktop/scripts/release-bump.mjs
+++ b/apps/desktop/scripts/release-bump.mjs
@@ -1,0 +1,328 @@
+// Bump the app version everywhere it lives and push the release tag.
+//
+// The version is declared in three places that must stay in lockstep:
+//   - apps/desktop/src-tauri/tauri.conf.json  (what release-macos.mjs reads)
+//   - apps/desktop/src-tauri/Cargo.toml       (the crate that gets compiled)
+//   - Cargo.lock                              (the reflect-open entry)
+// This script edits all three, commits, pushes the branch, then creates and
+// pushes the `v<version>` tag — which is what triggers the Release workflow
+// (.github/workflows/release.yml) to build, sign, notarize and publish.
+//
+// Usage:
+//   pnpm release:bump                Cut the next beta (0.2.0-beta.1 → 0.2.0-beta.2)
+//   pnpm release:bump beta           Same, explicit
+//   pnpm release:bump stable         Drop the prerelease (0.2.0-beta.3 → 0.2.0)
+//   pnpm release:bump patch|minor|major        Stable bump
+//   pnpm release:bump prepatch|preminor|premajor  Open a new beta cycle (…-beta.1)
+//   pnpm release:bump 0.5.0-beta.1   Set an explicit version
+//
+// Flags:
+//   --dry-run   Show the plan and exit; touch nothing
+//   --no-tag    Bump + commit + push the branch, but don't tag (no release)
+//   --yes       Skip the confirmation prompt
+//   --help
+//
+// Stable releases ship from `master`, betas from `next`; the script refuses to
+// create a stable (non-prerelease) version while on `next` so a beta branch
+// can't accidentally publish to the stable auto-update channel.
+
+import { execFileSync, spawnSync } from 'node:child_process'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { createInterface } from 'node:readline/promises'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const appDir = join(here, '..')
+const repoRoot = join(here, '..', '..', '..')
+const tauriConfPath = join(appDir, 'src-tauri', 'tauri.conf.json')
+const cargoTomlPath = join(appDir, 'src-tauri', 'Cargo.toml')
+const cargoLockPath = join(repoRoot, 'Cargo.lock')
+
+/** The Cargo package whose version drives the release (and its lockfile entry). */
+const CRATE = 'reflect-open'
+/** The only prerelease identifier the app uses; bumped numerically. */
+const PREID = 'beta'
+/** Branches a release is normally cut from. */
+const STABLE_BRANCH = 'master'
+const BETA_BRANCH = 'next'
+
+/** Named bump levels; anything else on the command line is an explicit version. */
+const LEVELS = ['beta', 'stable', 'patch', 'minor', 'major', 'prepatch', 'preminor', 'premajor']
+
+function log(message) {
+  console.log(`release-bump: ${message}`)
+}
+
+function fail(message) {
+  console.error(`release-bump: error: ${message}`)
+  process.exit(1)
+}
+
+// ---------------------------------------------------------------------------
+// Version math — pure and exported so it can be unit-tested in isolation.
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse `MAJOR.MINOR.PATCH` with an optional `-prerelease` tail into its parts.
+ * Throws on anything that isn't a well-formed semver core.
+ */
+export function parseVersion(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/.exec(version)
+  if (!match) throw new Error(`"${version}" is not a MAJOR.MINOR.PATCH[-prerelease] version`)
+  const [, major, minor, patch, prerelease] = match
+  return { major: Number(major), minor: Number(minor), patch: Number(patch), prerelease: prerelease ?? null }
+}
+
+/** Render the parts produced by {@link parseVersion} back into a version string. */
+export function formatVersion({ major, minor, patch, prerelease }) {
+  const core = `${major}.${minor}.${patch}`
+  return prerelease ? `${core}-${prerelease}` : core
+}
+
+/** Extract N from a `beta.N` prerelease, rejecting any other shape. */
+function prereleaseNumber(prerelease) {
+  const match = new RegExp(`^${PREID}\\.(\\d+)$`).exec(prerelease)
+  if (!match) throw new Error(`prerelease "${prerelease}" is not "${PREID}.N" — pass an explicit version instead`)
+  return Number(match[1])
+}
+
+/**
+ * Compute the next version from `current` given a bump level or an explicit
+ * target version. Pure: no I/O, throws (never exits) on invalid input so the
+ * caller and the tests can handle errors uniformly.
+ */
+export function computeNextVersion(current, bump) {
+  if (!LEVELS.includes(bump)) {
+    // Not a level → treat as an explicit version target (validated by parsing).
+    return formatVersion(parseVersion(bump))
+  }
+  const version = parseVersion(current)
+  switch (bump) {
+    case 'beta':
+      if (!version.prerelease) {
+        throw new Error(`${current} is already stable — use prepatch/preminor/premajor to open a new beta cycle`)
+      }
+      return formatVersion({ ...version, prerelease: `${PREID}.${prereleaseNumber(version.prerelease) + 1}` })
+    case 'stable':
+      if (!version.prerelease) throw new Error(`${current} is already stable`)
+      return formatVersion({ ...version, prerelease: null })
+    case 'patch':
+      return formatVersion({ major: version.major, minor: version.minor, patch: version.patch + 1, prerelease: null })
+    case 'minor':
+      return formatVersion({ major: version.major, minor: version.minor + 1, patch: 0, prerelease: null })
+    case 'major':
+      return formatVersion({ major: version.major + 1, minor: 0, patch: 0, prerelease: null })
+    case 'prepatch':
+      return formatVersion({ major: version.major, minor: version.minor, patch: version.patch + 1, prerelease: `${PREID}.1` })
+    case 'preminor':
+      return formatVersion({ major: version.major, minor: version.minor + 1, patch: 0, prerelease: `${PREID}.1` })
+    case 'premajor':
+      return formatVersion({ major: version.major + 1, minor: 0, patch: 0, prerelease: `${PREID}.1` })
+    default:
+      throw new Error(`unhandled bump level "${bump}"`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Git + filesystem side effects.
+// ---------------------------------------------------------------------------
+
+/** Run a git command in the repo, returning trimmed stdout; throws on failure. */
+function git(args) {
+  return execFileSync('git', args, { cwd: repoRoot, encoding: 'utf8' }).trim()
+}
+
+/** Run a git command, returning { status, output } without throwing. */
+function tryGit(args) {
+  const result = spawnSync('git', args, { cwd: repoRoot, encoding: 'utf8' })
+  return { status: result.status, output: `${result.stdout ?? ''}${result.stderr ?? ''}` }
+}
+
+/** The current branch name, or fail on a detached HEAD. */
+function currentBranch() {
+  const branch = git(['rev-parse', '--abbrev-ref', 'HEAD'])
+  if (branch === 'HEAD') {
+    fail(`detached HEAD — check out ${BETA_BRANCH} or ${STABLE_BRANCH} first`)
+  }
+  return branch
+}
+
+/** Read the current version from tauri.conf.json (the release source of truth). */
+function readCurrentVersion() {
+  return JSON.parse(readFileSync(tauriConfPath, 'utf8')).version
+}
+
+/**
+ * Replace the single expected occurrence of `find` with `replace` in a file,
+ * failing loudly if it appears zero or many times — a changed format should
+ * stop the release, not silently skip or over-edit.
+ */
+function replaceOnce(path, find, replace, label) {
+  const content = readFileSync(path, 'utf8')
+  const occurrences = content.split(find).length - 1
+  if (occurrences !== 1) {
+    fail(`expected exactly one \`${find}\` in ${label}, found ${occurrences} — update release-bump.mjs`)
+  }
+  writeFileSync(path, content.replace(find, replace))
+}
+
+/** Edit all three version sites to `next` (from `current`). */
+function writeVersion(current, next) {
+  replaceOnce(tauriConfPath, `"version": "${current}"`, `"version": "${next}"`, 'tauri.conf.json')
+  replaceOnce(cargoTomlPath, `version = "${current}"`, `version = "${next}"`, 'Cargo.toml')
+  // cargo rewrites the lockfile's reflect-open entry from the new Cargo.toml.
+  // --offline keeps it a pure version edit with no registry round-trip.
+  const update = spawnSync('cargo', ['update', '-p', CRATE, '--offline'], { cwd: repoRoot, encoding: 'utf8' })
+  if (update.status !== 0) {
+    fail(`cargo update -p ${CRATE} failed (is cargo installed?):\n${update.stderr ?? ''}`)
+  }
+}
+
+/** Confirm the destructive part of the run unless --yes was passed. */
+async function confirm(question) {
+  const readline = createInterface({ input: process.stdin, output: process.stdout })
+  const answer = (await readline.question(question)).trim().toLowerCase()
+  readline.close()
+  return answer === 'y' || answer === 'yes'
+}
+
+async function main() {
+  const argv = process.argv.slice(2)
+  const flags = argv.filter((arg) => arg.startsWith('--'))
+  const positionals = argv.filter((arg) => !arg.startsWith('--'))
+  const knownFlags = ['--dry-run', '--no-tag', '--yes', '--help']
+  const unknownFlag = flags.find((flag) => !knownFlags.includes(flag))
+  if (unknownFlag) fail(`unknown flag "${unknownFlag}" — try --help`)
+  if (positionals.length > 1) fail(`expected at most one level/version, got: ${positionals.join(' ')}`)
+  if (flags.includes('--help')) {
+    console.log(USAGE)
+    return
+  }
+
+  const dryRun = flags.includes('--dry-run')
+  const noTag = flags.includes('--no-tag')
+  const skipPrompt = flags.includes('--yes')
+  const bump = positionals[0] ?? 'beta'
+
+  const current = readCurrentVersion()
+  let next
+  try {
+    next = computeNextVersion(current, bump)
+  } catch (error) {
+    fail(error.message)
+  }
+  if (next === current) fail(`the new version equals the current one (${current}) — nothing to bump`)
+
+  const branch = currentBranch()
+  const isPrerelease = next.includes('-')
+  const tag = `v${next}`
+
+  // Guardrail: stable versions are for the stable channel, which ships from
+  // master. A stable tag pushed from next would become `releases/latest` and
+  // reach every stable install — refuse it here.
+  if (!isPrerelease && branch === BETA_BRANCH) {
+    fail(
+      `refusing to cut stable ${next} from ${BETA_BRANCH}.\n` +
+        `  Stable releases ship from ${STABLE_BRANCH}: merge ${BETA_BRANCH} → ${STABLE_BRANCH} and run this there.\n` +
+        `  (To open the next beta cycle on ${BETA_BRANCH}, use prepatch/preminor/premajor.)`,
+    )
+  }
+
+  if (git(['status', '--porcelain']) !== '') {
+    fail('the working tree has uncommitted changes — commit or stash them first')
+  }
+
+  log('fetching origin…')
+  const fetch = tryGit(['fetch', 'origin', branch, '--tags'])
+  if (fetch.status !== 0) fail(`git fetch failed:\n${fetch.output.trim()}`)
+
+  if (tryGit(['rev-parse', '--verify', `origin/${branch}`]).status !== 0) {
+    fail(`origin/${branch} does not exist — push ${branch} first`)
+  }
+  if (git(['rev-parse', 'HEAD']) !== git(['rev-parse', `origin/${branch}`])) {
+    fail(
+      `local ${branch} is not in sync with origin/${branch}.\n` +
+        '  Pull or push so the release builds exactly the published code plus the version bump.',
+    )
+  }
+
+  if (git(['tag', '--list', tag]) !== '') fail(`tag ${tag} already exists locally — bump to a new version`)
+  if (git(['ls-remote', '--tags', 'origin', tag]) !== '') {
+    fail(`tag ${tag} already exists on origin — bump to a new version`)
+  }
+
+  const releaseKind = isPrerelease ? 'pre-release' : 'release'
+  log(`current version: ${current}`)
+  log(`next version:    ${next}  (${bump})`)
+  log(`branch:          ${branch}  (in sync with origin)`)
+  log('plan:')
+  console.log('  - update tauri.conf.json, Cargo.toml, Cargo.lock')
+  console.log(`  - commit "Release ${tag}"`)
+  console.log(`  - push ${branch} to origin`)
+  if (noTag) {
+    console.log('  - (skipping the tag — no release will be triggered)')
+  } else {
+    console.log(`  - tag ${tag} and push it → triggers the Release workflow (${releaseKind})`)
+  }
+
+  if (dryRun) {
+    log('dry run — nothing changed')
+    return
+  }
+  if (!skipPrompt && !(await confirm('Proceed? [y/N] '))) {
+    log('aborted — nothing changed')
+    return
+  }
+
+  writeVersion(current, next)
+  git(['add', tauriConfPath, cargoTomlPath, cargoLockPath])
+  git(['commit', '-m', `Release ${tag}`])
+
+  log(`pushing ${branch} to origin…`)
+  if (spawnSync('git', ['push', 'origin', `HEAD:${branch}`], { cwd: repoRoot, stdio: 'inherit' }).status !== 0) {
+    fail('pushing the branch failed — resolve the issue and retry (nothing was tagged)')
+  }
+
+  if (noTag) {
+    log(`bumped to ${next} and pushed ${branch} (no tag).`)
+    log(`to release later: git tag ${tag} && git push origin ${tag}`)
+    return
+  }
+
+  git(['tag', tag])
+  log(`pushing tag ${tag}…`)
+  if (spawnSync('git', ['push', 'origin', tag], { cwd: repoRoot, stdio: 'inherit' }).status !== 0) {
+    fail(`pushing the tag failed — the branch is pushed; run \`git push origin ${tag}\` to trigger the release`)
+  }
+  log(`done — ${tag} pushed; the Release workflow will build & publish the ${releaseKind}.`)
+  log('track it in GitHub → Actions → Release.')
+}
+
+const USAGE = `Usage: pnpm release:bump [level|version] [flags]
+
+Levels:
+  beta       (default) cut the next beta: 0.2.0-beta.1 → 0.2.0-beta.2
+  stable     drop the prerelease:         0.2.0-beta.3 → 0.2.0
+  patch      stable patch bump:           0.2.0 → 0.2.1
+  minor      stable minor bump:           0.2.0 → 0.3.0
+  major      stable major bump:           0.2.0 → 1.0.0
+  prepatch   open a beta cycle:           0.2.0 → 0.2.1-beta.1
+  preminor   open a beta cycle:           0.2.0 → 0.3.0-beta.1
+  premajor   open a beta cycle:           0.2.0 → 1.0.0-beta.1
+  <version>  set an explicit version, e.g. 0.5.0-beta.1
+
+Flags:
+  --dry-run   show the plan and exit; change nothing
+  --no-tag    bump + commit + push the branch, but don't tag (no release)
+  --yes       skip the confirmation prompt
+  --help      show this help
+
+Betas ship from ${BETA_BRANCH}; stable releases from ${STABLE_BRANCH}.
+Docs: docs/macos-distribution.md`
+
+// Only run when invoked directly (`node release-bump.mjs`), not when imported
+// by the unit test — so importing the version math has no side effects.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main()
+}

--- a/apps/desktop/scripts/release-bump.test.mjs
+++ b/apps/desktop/scripts/release-bump.test.mjs
@@ -1,0 +1,61 @@
+import { expect, test } from 'vitest'
+
+import { computeNextVersion, formatVersion, parseVersion } from './release-bump.mjs'
+
+test('parseVersion splits a stable and a prerelease version', () => {
+  expect(parseVersion('0.2.0')).toEqual({ major: 0, minor: 2, patch: 0, prerelease: null })
+  expect(parseVersion('1.4.10-beta.3')).toEqual({ major: 1, minor: 4, patch: 10, prerelease: 'beta.3' })
+})
+
+test('parseVersion rejects malformed input', () => {
+  expect(() => parseVersion('1.2')).toThrow()
+  expect(() => parseVersion('v1.2.3')).toThrow()
+  expect(() => parseVersion('1.2.x')).toThrow()
+})
+
+test('formatVersion round-trips parseVersion', () => {
+  for (const version of ['0.0.0', '0.2.0', '1.4.10-beta.3']) {
+    expect(formatVersion(parseVersion(version))).toBe(version)
+  }
+})
+
+test('beta increments the prerelease number, including past nine', () => {
+  expect(computeNextVersion('0.2.0-beta.1', 'beta')).toBe('0.2.0-beta.2')
+  expect(computeNextVersion('0.2.0-beta.9', 'beta')).toBe('0.2.0-beta.10')
+})
+
+test('beta defaults are only valid on a prerelease version', () => {
+  expect(() => computeNextVersion('0.2.0', 'beta')).toThrow(/already stable/)
+})
+
+test('stable drops the prerelease, keeping the base version', () => {
+  expect(computeNextVersion('0.2.0-beta.3', 'stable')).toBe('0.2.0')
+  expect(() => computeNextVersion('0.2.0', 'stable')).toThrow(/already stable/)
+})
+
+test('patch/minor/major bump the component and clear any prerelease', () => {
+  expect(computeNextVersion('0.2.0', 'patch')).toBe('0.2.1')
+  expect(computeNextVersion('0.2.0', 'minor')).toBe('0.3.0')
+  expect(computeNextVersion('0.2.0', 'major')).toBe('1.0.0')
+  expect(computeNextVersion('0.2.3-beta.1', 'minor')).toBe('0.3.0')
+})
+
+test('prepatch/preminor/premajor open a beta cycle at beta.1', () => {
+  expect(computeNextVersion('0.2.0', 'prepatch')).toBe('0.2.1-beta.1')
+  expect(computeNextVersion('0.2.0', 'preminor')).toBe('0.3.0-beta.1')
+  expect(computeNextVersion('0.2.0', 'premajor')).toBe('1.0.0-beta.1')
+})
+
+test('an explicit version target is accepted verbatim', () => {
+  expect(computeNextVersion('0.2.0-beta.1', '0.5.0-beta.1')).toBe('0.5.0-beta.1')
+  expect(computeNextVersion('0.2.0-beta.1', '1.0.0')).toBe('1.0.0')
+})
+
+test('an explicit garbage version is rejected', () => {
+  expect(() => computeNextVersion('0.2.0', 'nonsense')).toThrow()
+  expect(() => computeNextVersion('0.2.0', '1.2')).toThrow()
+})
+
+test('beta on a non-beta prerelease is rejected', () => {
+  expect(() => computeNextVersion('0.2.0-rc.1', 'beta')).toThrow(/beta\.N/)
+})

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -93,8 +93,10 @@ pnpm release:bump --dry-run      # show the plan, change nothing
 
 Default (no argument) is `beta`, the common case on `next`. The script refuses to run on
 a dirty tree or a branch out of sync with origin, refuses a version whose tag already
-exists, and — because a stable tag would reach every stable install — refuses to cut a
-stable (non-prerelease) version from `next`. It prints the plan and asks for confirmation
+exists, and locks each release to its branch — betas only from `next`, and stable
+versions only from `master` (a stable tag reaches `releases/latest` and auto-updates
+every stable install, so it must never be pushed from a branch whose code hasn't landed
+on `master`). It prints the plan and asks for confirmation
 (skip with `--yes`); `--no-tag` bumps and pushes the branch without tagging, for when you
 want the version commit but aren't ready to release. The typical flows:
 

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -73,6 +73,35 @@ pnpm release:macos publish --draft # same, but leave the release as a draft for 
 pnpm release:macos --no-notarize   # signed-only build (runs locally; Gatekeeper rejects it elsewhere)
 ```
 
+## Cutting a release (`pnpm release:bump`)
+
+The version is declared in three places that must move together —
+`apps/desktop/src-tauri/tauri.conf.json`, `apps/desktop/src-tauri/Cargo.toml`, and the
+`reflect-open` entry in `Cargo.lock`. `pnpm release:bump` is the one-command way to do
+the whole ritual: it edits all three, commits, pushes the branch, and pushes a
+`v<version>` tag — and that tag push is what triggers the Release workflow to build,
+sign, notarize, and publish. You don't run `release:macos` by hand for a normal release.
+
+```bash
+pnpm release:bump                # cut the next beta: 0.2.0-beta.1 → 0.2.0-beta.2
+pnpm release:bump stable         # drop the prerelease: 0.2.0-beta.3 → 0.2.0
+pnpm release:bump patch          # 0.2.0 → 0.2.1   (also: minor, major)
+pnpm release:bump preminor       # open a new beta cycle: 0.2.0 → 0.3.0-beta.1
+pnpm release:bump 0.5.0-beta.1   # set an explicit version
+pnpm release:bump --dry-run      # show the plan, change nothing
+```
+
+Default (no argument) is `beta`, the common case on `next`. The script refuses to run on
+a dirty tree or a branch out of sync with origin, refuses a version whose tag already
+exists, and — because a stable tag would reach every stable install — refuses to cut a
+stable (non-prerelease) version from `next`. It prints the plan and asks for confirmation
+(skip with `--yes`); `--no-tag` bumps and pushes the branch without tagging, for when you
+want the version commit but aren't ready to release. The typical flows:
+
+- **Beta** (on `next`): `pnpm release:bump`.
+- **Stable** (on `master`, after merging `next` → `master`): `pnpm release:bump stable`,
+  then `pnpm release:bump preminor` back on `next` to open the next cycle.
+
 ## Publishing to GitHub Releases
 
 `pnpm release:macos publish` runs the full build above, then creates a GitHub release
@@ -110,10 +139,10 @@ beta.
 Beta installs poll that same stable endpoint: they get offered the next stable release
 when it ships, but not newer betas. A dedicated beta updater channel is future work.
 
-Cutting a beta is the normal release flow on `next`: bump the prerelease version
-(`0.2.0-beta.2`, …) in `tauri.conf.json` + `src-tauri/Cargo.toml`, then run the
-Release workflow on `next`. For a stable release, merge `next` into `master`, set a
-stable version there (e.g. `0.2.0`), and run the workflow on `master`.
+Cutting a beta is the normal release flow on `next`: `pnpm release:bump` (see
+[Cutting a release](#cutting-a-release-pnpm-releasebump) above) bumps the prerelease
+version and pushes the tag that triggers the workflow. For a stable release, merge
+`next` into `master` and run `pnpm release:bump stable` there.
 
 ## Releasing from CI
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint:fix": "oxlint --fix apps packages",
     "check": "pnpm typecheck && pnpm lint",
     "tauri": "pnpm --filter @reflect/desktop tauri",
+    "release:bump": "pnpm --filter @reflect/desktop release:bump",
     "release:macos": "pnpm --filter @reflect/desktop release:macos"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Adds **`pnpm release:bump`** — one command for the whole release ritual, so any engineer can cut a (beta) release without remembering the three version sites or the tag dance.

It bumps the version across all three places that must stay in lockstep — `apps/desktop/src-tauri/tauri.conf.json` (what `release-macos.mjs` reads), `apps/desktop/src-tauri/Cargo.toml`, and the `reflect-open` entry in `Cargo.lock` — then commits, pushes the branch, and pushes the `v<version>` tag. That tag push is what triggers `.github/workflows/release.yml` to build, sign, notarize, and publish. No more hand-editing or `release:macos publish` by hand for a normal release.

## Usage

```bash
pnpm release:bump                # default: next beta  0.2.0-beta.1 → 0.2.0-beta.2
pnpm release:bump stable         # drop prerelease     0.2.0-beta.3 → 0.2.0
pnpm release:bump patch          # 0.2.0 → 0.2.1  (also minor, major)
pnpm release:bump preminor       # open a beta cycle   0.2.0 → 0.3.0-beta.1
pnpm release:bump 0.5.0-beta.1   # explicit version
pnpm release:bump --dry-run      # print the plan, change nothing
```

Levels mirror semver/`npm version` names. `--no-tag` bumps + pushes the branch without tagging (version commit, no release); `--yes` skips the confirmation prompt.

## Safety (the part that matters for "any engineer")

Preflights, all fail-loud, before anything is touched:
- **dirty tree** → refuse;
- **branch out of sync with origin** → refuse (so the build is exactly published code + the bump);
- **tag already exists** (local or origin) → refuse;
- **stable version from `next`** → refuse. A non-prerelease tag becomes `releases/latest` and reaches every stable install, so stable releases must come from `master`. The message points you to merge `next` → `master`.

It prints the plan and asks for confirmation (a tag push kicks off a real, billable build + public release), and labels it pre-release vs release so you see which channel it'll hit.

## Tests / verification

- New `scripts/release-bump.test.mjs` — 11 vitest cases over the pure version math (beta increment incl. past 9, stable finalize, patch/minor/major, pre* cycle-open, explicit version, and the error cases). The script exports the pure helpers and guards `main()` so importing it has no side effects; `scripts/` is outside `tsc`'s `include`, so the `.mjs` test runs under vitest without affecting typecheck.
- `pnpm check` clean (no new warnings); `node --check` on the script.
- Exercised end-to-end in `--dry-run`: default → `0.2.0-beta.2` (pre-release), `minor` → `0.3.0` (release), arg + flag forwarding through the nested pnpm filter confirmed, tree left clean with no tags created.

## Docs

`docs/macos-distribution.md` gets a "Cutting a release" section (now the recommended entry point; the Beta-releases flow points at it), and `AGENTS.md` lists the command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The script performs real git pushes and tags that trigger production builds and stable auto-update; branch guardrails and preflights reduce misuse but mistaken **`--yes`** or partial push failures still need human recovery.
> 
> **Overview**
> Adds **`pnpm release:bump`** as the standard way to cut releases: it keeps **`tauri.conf.json`**, **`Cargo.toml`**, and **`Cargo.lock`** (`reflect-open`) in sync, commits, pushes the branch, and pushes **`v<version>`** so the Release workflow runs without hand-editing versions or running **`release:macos publish`** locally.
> 
> The new **`release-bump.mjs`** script supports semver-style levels (default **`beta`**, plus **`stable`**, patch/minor/major, pre*, or an explicit version) and flags **`--dry-run`**, **`--no-tag`**, and **`--yes`**. Preflights block dirty trees, branches not matching origin, duplicate tags, and **stable bumps off `master`** / **betas off `next`**. Pure version helpers are covered by **`release-bump.test.mjs`**.
> 
> Root and desktop **`package.json`**, **`AGENTS.md`**, and **`docs/macos-distribution.md`** document the command and replace manual bump instructions in the beta-release section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa2a2c6caa095f655ab33d2e6f4ee772d2d56f1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->