### PR TITLE
[codex] Align note title size

### DIFF
--- a/apps/desktop/src/editor/title-placeholder.test.ts
+++ b/apps/desktop/src/editor/title-placeholder.test.ts
@@ -1,4 +1,5 @@
 import type { EditorState } from '@prosekit/pm/state'
+import type { Decoration } from '@prosekit/pm/view'
 import { DecorationSet } from '@prosekit/pm/view'
 import { describe, expect, it } from 'vitest'
 import { createMeowdownEditor } from './meowdown'
@@ -39,13 +40,39 @@ describe('titlePlaceholderRange', () => {
 })
 
 describe('defineTitlePlaceholder', () => {
-  it('decorates the empty title through the plugin the editor mounts', () => {
-    const state = stateFor('#\n')
-    const decorations = state.plugins
+  function decorationsFor(state: EditorState): Decoration[] {
+    return state.plugins
       .map((plugin) => plugin.props.decorations?.call(plugin, state))
       .filter((set): set is DecorationSet => set instanceof DecorationSet)
       .flatMap((set) => set.find())
+  }
+
+  function decorationClass(decoration: Decoration): string | null {
+    const decorated = decoration as unknown as {
+      readonly type?: { readonly attrs?: { readonly class?: unknown } }
+    }
+    const className = decorated.type?.attrs?.class
+    return typeof className === 'string' ? className : null
+  }
+
+  it('decorates the empty title through the plugin the editor mounts', () => {
+    const state = stateFor('#\n')
+    const decorations = decorationsFor(state)
     const titleEnd = state.doc.firstChild?.nodeSize ?? Number.NaN
     expect(decorations.some(({ from, to }) => from === 0 && to === titleEnd)).toBe(true)
+  })
+
+  it('marks a filled leading H1 as the note title', () => {
+    const state = stateFor('# My Note\n\nBody\n')
+    const decorations = decorationsFor(state)
+    const titleEnd = state.doc.firstChild?.nodeSize ?? Number.NaN
+    expect(
+      decorations.some(
+        (decoration) =>
+          decoration.from === 0 &&
+          decoration.to === titleEnd &&
+          decorationClass(decoration) === 'reflect-note-title',
+      ),
+    ).toBe(true)
   })
 })

--- a/apps/desktop/src/editor/title-placeholder.ts
+++ b/apps/desktop/src/editor/title-placeholder.ts
@@ -7,7 +7,9 @@ import { Decoration, DecorationSet } from '@prosekit/pm/view'
  * Title placeholder for the new-note flow (non-daily notes): a missing note
  * opens seeded with an empty H1 and the caret in it, and this decoration
  * ghosts "Untitled" over that line so it reads as the name field it is —
- * V1's new-note pattern. The ghost is anchored to the document, not the
+ * V1's new-note pattern. The extension also marks the leading H1 as the note
+ * title so it can share the daily-subject typography while ordinary body H1s
+ * keep prose heading styles. The ghost is anchored to the document, not the
  * caret: it stays while the user writes the body, a standing reminder that
  * the note is still unnamed (text styled by `.reflect-title-placeholder`).
  */
@@ -20,31 +22,39 @@ import { Decoration, DecorationSet } from '@prosekit/pm/view'
 export function titlePlaceholderRange(
   doc: ProseMirrorNode,
 ): { from: number; to: number } | null {
-  const first = doc.firstChild
-  const isEmptyTitle =
-    first !== null &&
-    first.type.name === 'heading' &&
-    first.attrs.level === 1 &&
-    first.content.size === 0
-  return isEmptyTitle ? { from: 0, to: first.nodeSize } : null
+  const range = titleHeadingRange(doc)
+  return range !== null && range.isEmpty ? { from: range.from, to: range.to } : null
 }
 
-/** Ghost `placeholder` over the document's leading empty H1. */
+function titleHeadingRange(
+  doc: ProseMirrorNode,
+): { from: number; to: number; isEmpty: boolean } | null {
+  const first = doc.firstChild
+  const isTitle = first !== null && first.type.name === 'heading' && first.attrs.level === 1
+  return isTitle ? { from: 0, to: first.nodeSize, isEmpty: first.content.size === 0 } : null
+}
+
+/** Mark the leading H1 as a note title and ghost `placeholder` when it is empty. */
 export function defineTitlePlaceholder(placeholder: string): PlainExtension {
   return definePlugin(
     new Plugin({
       key: new PluginKey('reflect-title-placeholder'),
       props: {
         decorations: (state) => {
-          const range = titlePlaceholderRange(state.doc)
+          const range = titleHeadingRange(state.doc)
           if (range === null) {
             return null
           }
+          const attrs: { class: string; 'data-placeholder'?: string } = {
+            class: range.isEmpty
+              ? 'reflect-note-title reflect-title-placeholder'
+              : 'reflect-note-title',
+          }
+          if (range.isEmpty) {
+            attrs['data-placeholder'] = placeholder
+          }
           return DecorationSet.create(state.doc, [
-            Decoration.node(range.from, range.to, {
-              class: 'reflect-title-placeholder',
-              'data-placeholder': placeholder,
-            }),
+            Decoration.node(range.from, range.to, attrs),
           ])
         },
       },

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -269,6 +269,7 @@ body {
 .reflect-editor h2 { font-size: var(--text-xl, 1.25rem); }
 .reflect-editor h3 { font-size: var(--text-lg, 1.125rem); }
 .reflect-editor h1:first-child { margin-top: 0; }
+.reflect-editor .reflect-note-title { font-size: var(--text-xl, 1.25rem); }
 
 /* The new-note flow's name field: ghost "Untitled" over the seeded empty H1
    (`editor/title-placeholder.ts`) without occupying layout, so the caret

--- a/design-system/tokens/typography.css
+++ b/design-system/tokens/typography.css
@@ -27,8 +27,8 @@
   --text-sm:   0.875rem;  /* 14px — buttons, menu items, default chrome */
   --text-base: 1rem;      /* 16px — editor body                  */
   --text-lg:   1.125rem;  /* 18px — lead paragraphs              */
-  --text-xl:   1.25rem;   /* 20px — note H2                      */
-  --text-2xl:  1.5rem;    /* 24px — note H1 / daily-note date     */
+  --text-xl:   1.25rem;   /* 20px — note title / note H2 / daily-note date */
+  --text-2xl:  1.5rem;    /* 24px — prose H1                     */
   --text-3xl:  1.875rem;  /* 30px                                */
 
   /* Marketing display sizes */


### PR DESCRIPTION
## Summary

- Mark the leading non-daily H1 as the note title through the existing title-placeholder extension.
- Size that note title with the same `--text-xl` token used by the daily-note date heading.
- Keep ordinary body H1s on the larger prose heading style and update typography token comments.

## Why

New non-daily notes were presenting the title/placeholder larger than daily note subjects. This aligns the new-note title treatment with the smaller daily-note date text while preserving distinct prose heading hierarchy.

## Validation

- `pnpm --filter @reflect/desktop test src/editor/title-placeholder.test.ts`
- `pnpm typecheck`
- `pnpm lint` passed with pre-existing warnings outside this change
- `pnpm build` passed with the existing bundle-size/Turbo output warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor decoration and CSS-only typography changes with no auth, data, or API impact.
> 
> **Overview**
> Non-daily notes now treat the **leading H1** as the note title: the title-placeholder plugin always applies `reflect-note-title` on that node (empty titles still get the Untitled ghost via `reflect-title-placeholder`).
> 
> Editor CSS sets **`.reflect-note-title`** to `--text-xl`, matching **`.reflect-daily-subject`**, while generic **`h1`** in the editor stays at **`--text-2xl`** for body headings. Typography token comments were updated to document that split.
> 
> Tests cover the filled-title decoration class and refactor decoration helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32e091d1706d81e50ab13904b9c84c8546eeec5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->