### PR TITLE
Add V1 markdown import to settings

### DIFF
--- a/apps/desktop/src/components/settings-screen.tsx
+++ b/apps/desktop/src/components/settings-screen.tsx
@@ -6,6 +6,7 @@ import { AppearanceSection } from './settings/appearance-section'
 import { BackupSection } from './settings/backup-section'
 import { DateTimeSection } from './settings/date-time-section'
 import { EditorSection } from './settings/editor-section'
+import { ImportExportSection } from './settings/import-export-section'
 import { KeyboardSection } from './settings/keyboard-section'
 import { SearchSection } from './settings/search-section'
 
@@ -24,6 +25,7 @@ export function SettingsScreen(): ReactElement {
         <EditorSection />
         <AllNotesSection />
         <SearchSection />
+        <ImportExportSection />
         <BackupSection />
         <AiProvidersSection />
         <KeyboardSection />

--- a/apps/desktop/src/components/settings/import-export-section.tsx
+++ b/apps/desktop/src/components/settings/import-export-section.tsx
@@ -1,0 +1,106 @@
+import { useRef, useState, type ChangeEvent, type ReactElement } from 'react'
+import { Upload } from 'lucide-react'
+import {
+  importReflectMarkdownZip,
+  type ReflectMarkdownImportProgress,
+  type ReflectMarkdownImportResult,
+} from '@reflect/core'
+import { Button } from '@/components/ui/button'
+import { useAsyncAction } from '@/hooks/use-async-action'
+import { rebuildIndexVisibly } from '@/lib/rebuild-index'
+import { useGraph } from '@/providers/graph-provider'
+import { SettingsField } from './field'
+import { SettingsSection } from './section'
+
+/** Settings controls for moving Reflect data into and out of the open graph. */
+export function ImportExportSection(): ReactElement {
+  const { graph, indexGeneration } = useGraph()
+  const action = useAsyncAction()
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const [progress, setProgress] = useState<ReflectMarkdownImportProgress | null>(null)
+  const [result, setResult] = useState<ReflectMarkdownImportResult | null>(null)
+
+  const importFile = async (file: File): Promise<void> => {
+    if (graph === null) {
+      throw new Error('Open a graph before importing notes.')
+    }
+    setProgress(null)
+    setResult(null)
+    const data = await file.arrayBuffer()
+    const summary = await importReflectMarkdownZip(data, {
+      generation: graph.generation,
+      onProgress: setProgress,
+    })
+    setResult(summary)
+    if (summary.imported > 0 && indexGeneration !== null) {
+      await rebuildIndexVisibly(indexGeneration)
+    }
+  }
+
+  const onFileChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    const file = event.currentTarget.files?.[0] ?? null
+    event.currentTarget.value = ''
+    if (file === null) {
+      return
+    }
+    void action.run(() => importFile(file))
+  }
+
+  return (
+    <SettingsSection id="import-export">
+      <SettingsField
+        legend="Import Reflect markdown"
+        description="Import a ZIP created by Reflect's Markdown export. Existing notes are kept, and imported filename conflicts get a suffix."
+      >
+        <div className="mt-3 flex flex-col gap-2">
+          <input
+            ref={inputRef}
+            type="file"
+            accept=".zip,application/zip,application/x-zip-compressed"
+            className="sr-only"
+            onChange={onFileChange}
+          />
+          <div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={graph === null || action.pending}
+              onClick={() => inputRef.current?.click()}
+            >
+              <Upload aria-hidden strokeWidth={1.75} />
+              {action.pending ? 'Importing...' : 'Import ZIP...'}
+            </Button>
+          </div>
+
+          {progress !== null && action.pending ? (
+            <p className="text-xs text-text-muted">
+              Importing {progress.done} of {progress.total}
+            </p>
+          ) : null}
+          {result !== null ? (
+            <p className="text-xs text-text-muted">{importSummary(result)}</p>
+          ) : null}
+          {action.error !== null ? (
+            <p className="text-xs text-red-700 dark:text-red-300">{action.error}</p>
+          ) : null}
+        </div>
+      </SettingsField>
+    </SettingsSection>
+  )
+}
+
+function importSummary(result: ReflectMarkdownImportResult): string {
+  const parts = [
+    `${result.imported} ${result.imported === 1 ? 'note' : 'notes'} imported`,
+    `${result.daily} daily`,
+    `${result.regular} regular`,
+  ]
+  if (result.renamed > 0) {
+    parts.push(`${result.renamed} renamed`)
+  }
+  if (result.skipped > 0) {
+    parts.push(`${result.skipped} skipped`)
+  }
+  return `${parts.join(', ')}.`
+}

--- a/apps/desktop/src/components/settings/sections.ts
+++ b/apps/desktop/src/components/settings/sections.ts
@@ -9,6 +9,7 @@ export const SETTINGS_SECTIONS = [
   { id: 'editor', title: 'Editor' },
   { id: 'all-notes', title: 'All notes' },
   { id: 'search', title: 'Search' },
+  { id: 'import-export', title: 'Import & export' },
   { id: 'backup', title: 'Backup' },
   { id: 'ai-providers', title: 'AI providers' },
   { id: 'keyboard', title: 'Keyboard shortcuts' },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
     "@lezer/markdown": "^1.6.4",
     "@reflect/db": "workspace:*",
     "ai": "^6.0.202",
+    "fflate": "^0.8.3",
     "kysely": "^0.28.17",
     "yaml": "^2.9.0",
     "zod": "^3.23.0"

--- a/packages/core/src/import/v1-markdown.test.ts
+++ b/packages/core/src/import/v1-markdown.test.ts
@@ -1,0 +1,136 @@
+import { strToU8, zipSync } from 'fflate'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { noteExists, writeNote } from '../graph/commands'
+import { importReflectMarkdownZip } from './v1-markdown'
+
+vi.mock('../graph/commands', () => ({
+  noteExists: vi.fn(),
+  writeNote: vi.fn(),
+}))
+
+interface WrittenNote {
+  readonly path: string
+  readonly contents: string
+  readonly generation: number
+}
+
+const noteExistsMock = vi.mocked(noteExists)
+const writeNoteMock = vi.mocked(writeNote)
+
+let existingPaths: Set<string>
+let written: WrittenNote[]
+
+beforeEach(() => {
+  existingPaths = new Set()
+  written = []
+  noteExistsMock.mockImplementation(async (path) => existingPaths.has(path))
+  writeNoteMock.mockImplementation(async (path, contents, generation) => {
+    written.push({ path, contents, generation })
+  })
+})
+
+function markdownZip(files: Record<string, string>): Uint8Array {
+  return zipSync(
+    Object.fromEntries(
+      Object.entries(files).map(([archivePath, contents]) => [archivePath, strToU8(contents)]),
+    ),
+  )
+}
+
+describe('importReflectMarkdownZip', () => {
+  it('imports regular notes with V1 ids and normalized task markers', async () => {
+    const result = await importReflectMarkdownZip(
+      markdownZip({
+        'A note-link-oR5K2Q.md': '# A note\n\n+ [x] Done',
+      }),
+      { generation: 42 },
+    )
+
+    expect(result).toEqual({ imported: 1, regular: 1, daily: 0, skipped: 0, renamed: 0 })
+    expect(written).toEqual([
+      {
+        path: 'notes/a-note.md',
+        contents: '---\nid: link-oR5K2Q\n---\n# A note\n\n- [x] Done\n',
+        generation: 42,
+      },
+    ])
+  })
+
+  it('uses the daily heading date when old exports wrote the wrong filename date', async () => {
+    const result = await importReflectMarkdownZip(
+      markdownZip({
+        'daily-notes/2026-02-05.md': '# Fri, February 6th, 2026\n\n+ [ ] Today',
+      }),
+      { generation: 7 },
+    )
+
+    expect(result).toEqual({ imported: 1, regular: 0, daily: 1, skipped: 0, renamed: 0 })
+    expect(written).toEqual([
+      {
+        path: 'daily/2026-02-06.md',
+        contents: '- [ ] Today\n',
+        generation: 7,
+      },
+    ])
+  })
+
+  it('suffixes regular note paths that already exist', async () => {
+    existingPaths.add('notes/meeting.md')
+
+    const result = await importReflectMarkdownZip(
+      markdownZip({
+        'Meeting-abc123.md': '# Meeting\n\nNotes',
+      }),
+      { generation: 3 },
+    )
+
+    expect(result).toEqual({ imported: 1, regular: 1, daily: 0, skipped: 0, renamed: 1 })
+    expect(written[0]?.path).toBe('notes/meeting-2.md')
+  })
+
+  it('keeps colliding daily notes by importing them as regular notes', async () => {
+    existingPaths.add('daily/2026-06-13.md')
+
+    const result = await importReflectMarkdownZip(
+      markdownZip({
+        'daily-notes/2026-06-13.md': '# Sat, June 13th, 2026\n\nAlready have today',
+      }),
+      { generation: 3 },
+    )
+
+    expect(result).toEqual({ imported: 1, regular: 1, daily: 0, skipped: 0, renamed: 1 })
+    expect(written).toEqual([
+      {
+        path: 'notes/daily-2026-06-13.md',
+        contents: '# Daily 2026-06-13\n\nAlready have today\n',
+        generation: 3,
+      },
+    ])
+  })
+
+  it('ignores non-markdown archive entries and macOS resource fork entries', async () => {
+    const result = await importReflectMarkdownZip(
+      markdownZip({
+        'A.md': '# A',
+        'assets/image.png': 'not really png',
+        '__MACOSX/._A.md': 'resource fork',
+      }),
+      { generation: 9 },
+    )
+
+    expect(result).toEqual({ imported: 1, regular: 1, daily: 0, skipped: 0, renamed: 0 })
+    expect(written).toHaveLength(1)
+  })
+
+  it('skips malformed daily-note dates instead of writing an unsafe path', async () => {
+    const result = await importReflectMarkdownZip(
+      markdownZip({
+        'daily-notes/2026-02-31.md': '# Notes\n\nImpossible date',
+      }),
+      { generation: 9 },
+    )
+
+    expect(result).toEqual({ imported: 0, regular: 0, daily: 0, skipped: 1, renamed: 0 })
+    expect(written).toHaveLength(0)
+  })
+})

--- a/packages/core/src/import/v1-markdown.ts
+++ b/packages/core/src/import/v1-markdown.ts
@@ -1,0 +1,326 @@
+import { unzipSync } from 'fflate'
+import { z } from 'zod'
+import { dailyPath, notePath } from '../graph/paths'
+import { noteExists, writeNote } from '../graph/commands'
+import { availableNotePath } from '../indexing/note-paths'
+import { parseFrontmatter, splitFrontmatter, upsertFrontmatter } from '../markdown/frontmatter'
+import { slugForTitle } from '../markdown/slug'
+
+/** Progress for a Reflect markdown zip import. */
+export interface ReflectMarkdownImportProgress {
+  /** Entries already processed, including skipped markdown entries. */
+  done: number
+  /** Markdown entries discovered in the archive. */
+  total: number
+}
+
+/** Summary of notes written from a Reflect markdown zip import. */
+export interface ReflectMarkdownImportResult {
+  /** Total notes written into the graph. */
+  imported: number
+  /** Regular notes written under `notes/`. */
+  regular: number
+  /** Daily notes written under `daily/`. */
+  daily: number
+  /** Markdown entries ignored because they could not be mapped safely. */
+  skipped: number
+  /** Notes whose target path was changed to avoid an overwrite. */
+  renamed: number
+}
+
+export interface ReflectMarkdownImportOptions {
+  /** Open graph file-write generation; passed through to every note write. */
+  generation: number
+  /** Optional callback after each markdown entry is processed. */
+  onProgress?: (progress: ReflectMarkdownImportProgress) => void
+}
+
+interface ZipMarkdownEntry {
+  readonly archivePath: string
+  readonly bytes: Uint8Array
+}
+
+interface PlannedImport {
+  readonly path: string
+  readonly contents: string
+  readonly kind: 'daily' | 'regular'
+  readonly renamed: boolean
+}
+
+const zipMarkdownEntrySchema = z.object({
+  archivePath: z.string().min(1),
+  bytes: z.instanceof(Uint8Array),
+})
+
+const DAILY_EXPORT_PATH_RE = /(?:^|\/)daily-notes\/(\d{4}-\d{2}-\d{2})\.md$/i
+const MARKDOWN_PATH_RE = /\.md$/i
+const LEADING_H1_RE = /^#\s+(.+?)\s*$/m
+const TASK_PLUS_RE = /^([ \t]*)\+([ \t]+\[[ xX]\])/gm
+const ORDINAL_DAY_RE = /^(\d{1,2})(?:st|nd|rd|th)?$/i
+
+const MONTHS = new Map([
+  ['january', 1],
+  ['february', 2],
+  ['march', 3],
+  ['april', 4],
+  ['may', 5],
+  ['june', 6],
+  ['july', 7],
+  ['august', 8],
+  ['september', 9],
+  ['october', 10],
+  ['november', 11],
+  ['december', 12],
+])
+
+/**
+ * Import the markdown zip produced by Reflect v1's Markdown export into the
+ * currently open Reflect v2 graph. Regular note filenames are re-derived from
+ * titles, V1 note ids are preserved in frontmatter, daily notes land under
+ * `daily/YYYY-MM-DD.md`, and existing graph files are never overwritten.
+ */
+export async function importReflectMarkdownZip(
+  data: ArrayBuffer | Uint8Array,
+  options: ReflectMarkdownImportOptions,
+): Promise<ReflectMarkdownImportResult> {
+  const entries = readMarkdownEntries(data)
+  const reserved = new Set<string>()
+  const result: ReflectMarkdownImportResult = {
+    imported: 0,
+    regular: 0,
+    daily: 0,
+    skipped: 0,
+    renamed: 0,
+  }
+
+  let done = 0
+  for (const entry of entries) {
+    const planned = await planImport(entry, reserved)
+    if (planned === null) {
+      result.skipped += 1
+    } else {
+      await writeNote(planned.path, planned.contents, options.generation)
+      result.imported += 1
+      result[planned.kind] += 1
+      if (planned.renamed) {
+        result.renamed += 1
+      }
+    }
+    done += 1
+    options.onProgress?.({ done, total: entries.length })
+  }
+
+  return result
+}
+
+function readMarkdownEntries(data: ArrayBuffer | Uint8Array): ZipMarkdownEntry[] {
+  const bytes = data instanceof Uint8Array ? data : new Uint8Array(data)
+  const unzipped = unzipSync(bytes)
+  return Object.entries(unzipped)
+    .filter(([archivePath]) => isImportableMarkdownPath(archivePath))
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([archivePath, entryBytes]) => zipMarkdownEntrySchema.parse({ archivePath, bytes: entryBytes }))
+}
+
+function isImportableMarkdownPath(archivePath: string): boolean {
+  return (
+    !archivePath.endsWith('/') &&
+    !archivePath.startsWith('__MACOSX/') &&
+    MARKDOWN_PATH_RE.test(archivePath)
+  )
+}
+
+async function planImport(
+  entry: ZipMarkdownEntry,
+  reserved: Set<string>,
+): Promise<PlannedImport | null> {
+  const source = normalizeMarkdown(decodeUtf8(entry.bytes))
+  const dailyDate = dailyDateForEntry(entry.archivePath, source)
+  if (dailyDate !== null) {
+    return planDailyImport(dailyDate, source, reserved)
+  }
+  return planRegularImport(entry.archivePath, source, reserved)
+}
+
+async function planDailyImport(
+  date: string,
+  source: string,
+  reserved: Set<string>,
+): Promise<PlannedImport | null> {
+  const body = ensureFinalNewline(normalizeTaskMarkers(stripDailyHeading(source)))
+  const targetPath = safeDailyPath(date)
+  if (targetPath === null) {
+    return null
+  }
+  if (!(await isTaken(targetPath, reserved))) {
+    reserved.add(targetPath)
+    return { path: targetPath, contents: body, kind: 'daily', renamed: false }
+  }
+
+  const title = `Daily ${date}`
+  const path = await reserveAvailableNotePath(slugForTitle(title), reserved)
+  return {
+    path,
+    contents: ensureFinalNewline(`# ${title}\n\n${body}`),
+    kind: 'regular',
+    renamed: true,
+  }
+}
+
+function safeDailyPath(date: string): string | null {
+  try {
+    return dailyPath(date)
+  } catch {
+    return null
+  }
+}
+
+async function planRegularImport(
+  archivePath: string,
+  source: string,
+  reserved: Set<string>,
+): Promise<PlannedImport> {
+  const stem = basename(archivePath).replace(/\.md$/i, '')
+  const title = firstHeadingTitle(source) ?? stem
+  const id = extractV1Id(stem, title)
+  const slug = slugForTitle(title)
+  const path = await reserveAvailableNotePath(slug, reserved)
+  const contents = ensureFinalNewline(withImportedId(normalizeTaskMarkers(source), id))
+  return {
+    path,
+    contents,
+    kind: 'regular',
+    renamed: path !== notePath(slug),
+  }
+}
+
+async function reserveAvailableNotePath(slug: string, reserved: Set<string>): Promise<string> {
+  const path = await availableNotePath(slug, (candidate) => isTaken(candidate, reserved))
+  reserved.add(path)
+  return path
+}
+
+async function isTaken(path: string, reserved: Set<string>): Promise<boolean> {
+  return reserved.has(path) || (await noteExists(path))
+}
+
+function decodeUtf8(bytes: Uint8Array): string {
+  return new TextDecoder('utf-8').decode(bytes)
+}
+
+function normalizeMarkdown(source: string): string {
+  return source.replace(/^\uFEFF/, '').replace(/\r\n?/g, '\n')
+}
+
+function normalizeTaskMarkers(source: string): string {
+  return source.replace(TASK_PLUS_RE, '$1-$2')
+}
+
+function stripDailyHeading(source: string): string {
+  const [firstLine = '', ...rest] = source.split('\n')
+  if (parseDailyHeadingDate(firstLine) === null) {
+    return source
+  }
+  return rest.join('\n').replace(/^(?:[ \t]*\n)+/, '')
+}
+
+function ensureFinalNewline(source: string): string {
+  return source === '' || source.endsWith('\n') ? source : `${source}\n`
+}
+
+function dailyDateForEntry(archivePath: string, source: string): string | null {
+  const filenameDate = DAILY_EXPORT_PATH_RE.exec(archivePath)?.[1] ?? null
+  if (filenameDate === null) {
+    return null
+  }
+  const headingDate = parseDailyHeadingDate(source.split('\n', 1)[0] ?? '')
+  return headingDate ?? filenameDate
+}
+
+function parseDailyHeadingDate(line: string): string | null {
+  if (!line.startsWith('# ')) {
+    return null
+  }
+  const label = line.slice(2).trim()
+  const withoutWeekday = label.replace(/^[A-Za-z]+,\s+/, '')
+  const parts = withoutWeekday.split(/\s+/)
+  if (parts.length !== 3) {
+    return null
+  }
+
+  if (parts[1] === undefined || parts[2] === undefined) {
+    return null
+  }
+
+  if (MONTHS.has(parts[0].toLowerCase())) {
+    return isoDate(parts[2], parts[0], parts[1].replace(/,$/, ''))
+  }
+
+  return isoDate(parts[2], parts[1].replace(/,$/, ''), parts[0])
+}
+
+function isoDate(yearText: string, monthText: string, dayText: string): string | null {
+  const year = Number(yearText.replace(/,$/, ''))
+  const month = MONTHS.get(monthText.toLowerCase())
+  const dayMatch = ORDINAL_DAY_RE.exec(dayText.replace(/,$/, ''))
+  if (!Number.isInteger(year) || month === undefined || dayMatch === null) {
+    return null
+  }
+  const day = Number(dayMatch[1])
+  const date = new Date(Date.UTC(year, month - 1, day))
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return null
+  }
+  return [
+    String(year).padStart(4, '0'),
+    String(month).padStart(2, '0'),
+    String(day).padStart(2, '0'),
+  ].join('-')
+}
+
+function firstHeadingTitle(source: string): string | null {
+  const body = splitFrontmatter(source).body
+  const match = LEADING_H1_RE.exec(body)
+  return match?.[1]?.trim() || null
+}
+
+function extractV1Id(stem: string, title: string): string | null {
+  const safeTitle = sanitizeV1Filename(title)
+  const expectedPrefix = `${safeTitle}-`
+  if (stem.startsWith(expectedPrefix)) {
+    const id = stem.slice(expectedPrefix.length).trim()
+    return id === '' ? null : id
+  }
+
+  const lastHyphen = stem.lastIndexOf('-')
+  if (lastHyphen === -1 || lastHyphen === stem.length - 1) {
+    return null
+  }
+  return stem.slice(lastHyphen + 1).trim() || null
+}
+
+function sanitizeV1Filename(title: string): string {
+  return title.replace(/[/\\]/g, '').replace(/\s+/g, ' ').trim()
+}
+
+function withImportedId(source: string, id: string | null): string {
+  if (id === null) {
+    return source
+  }
+  const split = splitFrontmatter(source)
+  if (split.raw !== null) {
+    const parsed = parseFrontmatter(split.raw)
+    if (parsed.warning !== undefined || parsed.data.id !== undefined) {
+      return source
+    }
+  }
+  return upsertFrontmatter(source, { id })
+}
+
+function basename(path: string): string {
+  return path.split('/').at(-1) ?? path
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -96,6 +96,12 @@ export {
   captureMetaFetch,
   promoteCaptureScreenshot,
 } from './graph/commands'
+export {
+  importReflectMarkdownZip,
+  type ReflectMarkdownImportOptions,
+  type ReflectMarkdownImportProgress,
+  type ReflectMarkdownImportResult,
+} from './import/v1-markdown'
 
 // User settings (config-dir JSON document; Rust persists, this layer validates)
 export {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,9 @@ importers:
       ai:
         specifier: ^6.0.202
         version: 6.0.202(zod@3.25.76)
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       kysely:
         specifier: ^0.28.17
         version: 0.28.17
@@ -3107,6 +3110,9 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -8096,6 +8102,8 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  fflate@0.8.3: {}
 
   figures@6.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Add a new Settings section for importing Reflect V1 markdown ZIP exports
- Implement ZIP import logic in `@reflect/core` with note path preservation, daily note handling, and collision-safe renaming
- Add core tests covering task normalization, daily note date recovery, path collisions, and malformed archive entries

## Testing
- Added unit tests for the V1 markdown import flow
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bulk graph writes and path mapping can affect user data if edge cases slip through, though overwrite is avoided and malformed dailies are skipped; index rebuild after import adds operational impact on large graphs.
> 
> **Overview**
> Adds **Import & export** in Settings so users can load a Reflect V1 markdown ZIP into the open graph. The UI picks a `.zip`, shows import progress and a short result summary, and triggers a visible index rebuild when any notes were written.
> 
> **`@reflect/core`** gains `importReflectMarkdownZip` (via **fflate**): it unpacks markdown only (skips `__MACOSX/` and non-`.md` entries), maps regular notes to `notes/` with slugs from titles, keeps V1 ids in frontmatter when safe, normalizes `+ [ ]` tasks to `- [ ]`, and routes `daily-notes/` exports to `daily/YYYY-MM-DD.md`—preferring the H1 date when the filename date is wrong. Existing paths are never overwritten; collisions get suffixed paths, and occupied daily slots import as regular notes. Invalid daily dates are skipped instead of writing bad paths. Unit tests cover these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3677af207af486154d2bf58a9e8724c9d9c50599. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->