### PR TITLE
Add a graph folder reveal action to the sidebar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.2.0-beta.3"
+version = "0.2.0-beta.4"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.2.0-beta.3"
+version = "0.2.0-beta.4"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.2.0-beta.3",
+  "version": "0.2.0-beta.4",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",

--- a/apps/desktop/src/components/sidebar/graph-footer.tsx
+++ b/apps/desktop/src/components/sidebar/graph-footer.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react'
 import type { GraphInfo } from '@reflect/core'
-import { Check, FolderOpen } from 'lucide-react'
+import { revealItemInDir } from '@tauri-apps/plugin-opener'
+import { Check, FolderOpen, LocateFixed } from 'lucide-react'
 import { GraphSwatch } from '@/components/graph-swatch'
 import {
   DropdownMenu,
@@ -139,6 +140,17 @@ export function GraphFooter({ graph }: { graph: GraphInfo }): ReactElement {
               ))}
             </DropdownMenuSubContent>
           </DropdownMenuSub>
+          <DropdownMenuItem
+            onSelect={() => {
+              void revealItemInDir(graph.root).catch((cause: unknown) => {
+                console.error('open graph folder failed:', cause)
+              })
+            }}
+            className={MENU_ITEM_CLASS}
+          >
+            <LocateFixed aria-hidden strokeWidth={1.75} className="size-3.5 shrink-0" />
+            <span className="min-w-0 flex-1 truncate">Open graph in Finder</span>
+          </DropdownMenuItem>
           <DropdownMenuItem
             onSelect={() => void pickAndOpen()}
             className={MENU_ITEM_CLASS}

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -11,6 +11,7 @@ import { UpdateProvider } from '@/providers/update-provider'
 import { RouterProvider } from '@/routing/router'
 
 const getPinnedNotes = vi.hoisted(() => vi.fn<() => Promise<PinnedNote[]>>(async () => []))
+const revealItemInDir = vi.hoisted(() => vi.fn<(path: string) => Promise<void>>(async () => {}))
 const openRecent = vi.hoisted(() => vi.fn())
 const pickAndOpen = vi.hoisted(() => vi.fn())
 const updateSettingsWith = vi.hoisted(() =>
@@ -22,6 +23,7 @@ vi.mock('@reflect/core', async (importOriginal) => ({
   hasBridge: () => true,
   getPinnedNotes,
 }))
+vi.mock('@tauri-apps/plugin-opener', () => ({ revealItemInDir }))
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({
     graph: GRAPH,
@@ -82,6 +84,7 @@ beforeEach(() => {
   audioMemo.available = true
   audioMemo.unavailableReason = null
   audioMemo.toggle.mockReset()
+  revealItemInDir.mockClear()
 })
 
 afterEach(cleanup) // `globals: false` disables testing-library's automatic cleanup
@@ -240,6 +243,15 @@ describe('Sidebar', () => {
     await userEvent.click(view.getByRole('button', { name: /Notes/ }))
     await userEvent.click(view.getByRole('menuitem', { name: /open another graph/i }))
     expect(pickAndOpen).toHaveBeenCalled()
+  })
+
+  it('the graph footer opens the current graph in the system file manager', async () => {
+    const { view } = renderSidebar()
+
+    await userEvent.click(view.getByRole('button', { name: /Notes/ }))
+    await userEvent.click(view.getByRole('menuitem', { name: /open graph in finder/i }))
+
+    expect(revealItemInDir).toHaveBeenCalledWith('/notes')
   })
 
   it('the graph footer recolors the current graph', async () => {


### PR DESCRIPTION
## Summary
- Add a graph footer menu item that opens the current graph root in Finder/system file manager
- Wire the action through `revealItemInDir` and log failures if the reveal call rejects
- Cover the new sidebar behavior with a focused test
- Bump the app version to `0.2.0-beta.4`

## Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI addition using an existing Tauri opener API; no auth, sync, or data-path changes.
> 
> **Overview**
> Adds **Open graph in Finder** to the graph footer dropdown so users can jump to the active graph’s root folder in the system file manager via Tauri’s `revealItemInDir`.
> 
> Failures from that call are logged to the console; a sidebar test mocks the opener plugin and asserts the current graph path is passed through.
> 
> Release version is bumped to **0.2.0-beta.4** in `Cargo.toml`, `tauri.conf.json`, and `Cargo.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fc779a696a223ec51a8a5b4d4e844f3b3de737e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->