### PR TITLE
Add shared graph .gitignore defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.2.0-beta.3"
+version = "0.2.0-beta.4"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.2.0-beta.3"
+version = "0.2.0-beta.4"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/src/fs/io.rs
+++ b/apps/desktop/src-tauri/src/fs/io.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 use std::time::UNIX_EPOCH;
 
 use crate::error::{AppError, AppResult};
+use crate::graph_gitignore;
 
 use super::FileMeta;
 
@@ -26,10 +27,7 @@ pub(super) fn bootstrap(root: &Path) -> AppResult<()> {
     }
     let gitignore = root.join(".gitignore");
     if !gitignore.exists() {
-        fs::write(
-            &gitignore,
-            "# Reflect local index + caches (rebuildable; never committed)\n/.reflect/\n",
-        )?;
+        fs::write(&gitignore, graph_gitignore::default_contents())?;
     }
     let meta = root.join(REFLECT_DIR).join("meta.json");
     if !meta.exists() {
@@ -129,7 +127,11 @@ mod tests {
         for sub in TOP_LEVEL_DIRS {
             assert!(dir.path().join(sub).is_dir(), "missing dir {sub}");
         }
-        assert!(dir.path().join(".gitignore").exists());
+        let gitignore = fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+        assert!(gitignore.contains("/.reflect/"));
+        assert!(gitignore.contains(".DS_Store"));
+        assert!(gitignore.contains("Thumbs.db"));
+        assert!(gitignore.contains("*.swp"));
         assert!(dir.path().join(".reflect/meta.json").exists());
     }
 

--- a/apps/desktop/src-tauri/src/git/mod.rs
+++ b/apps/desktop/src-tauri/src/git/mod.rs
@@ -100,7 +100,7 @@ fn disconnect(root: &Path) -> AppResult<GitStatus> {
 
 fn setup(root: &Path, remote_url: Option<String>, branch: Option<String>) -> AppResult<GitStatus> {
     let repo = repo::open_or_init(root)?;
-    repo::ensure_reflect_ignored(root)?;
+    repo::ensure_gitignore_defaults(root)?;
     if let Some(url) = remote_url {
         if repo.find_remote("origin").is_ok() {
             repo.remote_set_url("origin", &url)?;

--- a/apps/desktop/src-tauri/src/git/repo.rs
+++ b/apps/desktop/src-tauri/src/git/repo.rs
@@ -1,13 +1,12 @@
 //! Repository plumbing: open/init/adopt, branch + signature resolution, and
-//! the `.reflect/` ignore guarantee.
+//! graph `.gitignore` defaults.
 
-use std::fs;
-use std::io::Write;
 use std::path::Path;
 
 use git2::{Repository, RepositoryInitOptions, Signature};
 
 use crate::error::{AppError, AppResult};
+use crate::graph_gitignore;
 
 /// The branch Reflect creates for new backup repos. Adopted repos keep
 /// whatever branch their HEAD already points at — nothing below hardcodes it.
@@ -87,34 +86,8 @@ pub(super) fn signature(repo: &Repository) -> AppResult<Signature<'static>> {
     Ok(Signature::now("Reflect", "backup@reflect.app")?)
 }
 
-/// Make sure `.reflect/` is ignored even in adopted repos whose `.gitignore`
-/// predates Reflect. The graph bootstrap (Plan 02) already writes one, but a
-/// user pointing Reflect at an existing repo may have their own. Idempotent:
-/// an existing `.reflect` entry (any common spelling) is left alone.
-pub(super) fn ensure_reflect_ignored(root: &Path) -> AppResult<()> {
-    let path = root.join(".gitignore");
-    let existing = fs::read_to_string(&path).unwrap_or_default();
-    let already = existing.lines().any(|line| {
-        matches!(
-            line.trim(),
-            "/.reflect/" | ".reflect/" | "/.reflect" | ".reflect"
-        )
-    });
-    if already {
-        return Ok(());
-    }
-    let mut file = fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)?;
-    let separator = if existing.is_empty() || existing.ends_with('\n') {
-        ""
-    } else {
-        "\n"
-    };
-    write!(
-        file,
-        "{separator}# Reflect local index + caches (rebuildable; never committed)\n/.reflect/\n"
-    )?;
-    Ok(())
+/// Make sure graph repositories carry Reflect's safe ignore defaults. The graph
+/// bootstrap already writes these, but setup may adopt an existing repository.
+pub(super) fn ensure_gitignore_defaults(root: &Path) -> AppResult<()> {
+    graph_gitignore::ensure_defaults(root)
 }

--- a/apps/desktop/src-tauri/src/git/tests.rs
+++ b/apps/desktop/src-tauri/src/git/tests.rs
@@ -20,7 +20,7 @@ fn scaffold_graph(root: &Path) {
     }
     fs::write(
         root.join(".gitignore"),
-        "# Reflect local index + caches (rebuildable; never committed)\n/.reflect/\n",
+        crate::graph_gitignore::default_contents(),
     )
     .unwrap();
     fs::write(root.join(".reflect/index.sqlite"), "not a real db").unwrap();
@@ -95,6 +95,21 @@ fn setup_initializes_main_and_origin() {
         Some(fixture.remote_url.as_str())
     );
     assert!(!status.in_progress);
+}
+
+#[test]
+fn setup_creates_graph_gitignore_defaults_when_missing() {
+    let dir = tempdir().unwrap();
+    let root = dir.path().join("graph");
+    fs::create_dir_all(&root).unwrap();
+
+    setup(&root, None, None).unwrap();
+
+    let gitignore = read(&root, ".gitignore");
+    assert!(gitignore.contains("/.reflect/"));
+    assert!(gitignore.contains(".DS_Store"));
+    assert!(gitignore.contains("Thumbs.db"));
+    assert!(gitignore.contains("*.swp"));
 }
 
 #[test]
@@ -635,7 +650,7 @@ fn fetch_without_remote_is_a_typed_error() {
 }
 
 #[test]
-fn adopting_an_existing_repo_appends_reflect_ignore() {
+fn adopting_an_existing_repo_appends_graph_gitignore_defaults() {
     let dir = tempdir().unwrap();
     let root = dir.path().join("graph");
     scaffold_graph(&root);
@@ -646,11 +661,17 @@ fn adopting_an_existing_repo_appends_reflect_ignore() {
     let gitignore = read(&root, ".gitignore");
     assert!(gitignore.contains("node_modules/"));
     assert!(gitignore.contains("/.reflect/"));
+    assert!(gitignore.contains(".DS_Store"));
+    assert!(gitignore.contains("Thumbs.db"));
+    assert!(gitignore.contains("*.swp"));
 
     // Idempotent: a second setup must not duplicate the entry.
     setup(&root, None, None).unwrap();
     let again = read(&root, ".gitignore");
     assert_eq!(again.matches(".reflect").count(), 1, "{again}");
+    assert_eq!(again.matches(".DS_Store").count(), 1, "{again}");
+    assert_eq!(again.matches("Thumbs.db").count(), 1, "{again}");
+    assert_eq!(again.matches("*.swp").count(), 1, "{again}");
 }
 
 // ---- the Plan 17 rename matrix ----------------------------------------------

--- a/apps/desktop/src-tauri/src/graph_gitignore.rs
+++ b/apps/desktop/src-tauri/src/graph_gitignore.rs
@@ -1,0 +1,93 @@
+//! Shared `.gitignore` defaults for graph roots.
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+use crate::error::AppResult;
+
+const DEFAULT_GROUPS: &[(&str, &[&str])] = &[
+    (
+        "Reflect local index + caches (rebuildable; never committed)",
+        &["/.reflect/"],
+    ),
+    ("macOS Finder metadata", &[".DS_Store", "._*"]),
+    (
+        "Windows Explorer metadata",
+        &["Thumbs.db", "ehthumbs.db", "Desktop.ini"],
+    ),
+    ("Editor swap and backup files", &["*.swp", "*.swo", "*~"]),
+];
+
+/// The default `.gitignore` written for newly bootstrapped graphs.
+pub(crate) fn default_contents() -> String {
+    let mut contents = String::new();
+    for &(heading, patterns) in DEFAULT_GROUPS {
+        if !contents.is_empty() {
+            contents.push('\n');
+        }
+        contents.push_str("# ");
+        contents.push_str(heading);
+        contents.push('\n');
+        for pattern in patterns {
+            contents.push_str(pattern);
+            contents.push('\n');
+        }
+    }
+    contents
+}
+
+/// Ensure graph repositories ignore only local machine/cache noise.
+pub(crate) fn ensure_defaults(root: &Path) -> AppResult<()> {
+    let path = root.join(".gitignore");
+    let existing = fs::read_to_string(&path).unwrap_or_default();
+    let mut missing_groups: Vec<(&str, Vec<&str>)> = Vec::new();
+
+    for &(heading, patterns) in DEFAULT_GROUPS {
+        let missing_patterns = patterns
+            .iter()
+            .copied()
+            .filter(|pattern| !has_pattern(&existing, pattern))
+            .collect::<Vec<_>>();
+        if !missing_patterns.is_empty() {
+            missing_groups.push((heading, missing_patterns));
+        }
+    }
+
+    if missing_groups.is_empty() {
+        return Ok(());
+    }
+
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)?;
+    let mut prefix = if existing.is_empty() {
+        ""
+    } else if existing.ends_with('\n') {
+        "\n"
+    } else {
+        "\n\n"
+    };
+
+    for (heading, patterns) in missing_groups {
+        write!(file, "{prefix}# {heading}\n")?;
+        for pattern in patterns {
+            writeln!(file, "{pattern}")?;
+        }
+        prefix = "\n";
+    }
+
+    Ok(())
+}
+
+fn has_pattern(existing: &str, pattern: &str) -> bool {
+    existing
+        .lines()
+        .map(str::trim)
+        .any(|line| line == pattern || is_reflect_equivalent(line, pattern))
+}
+
+fn is_reflect_equivalent(line: &str, pattern: &str) -> bool {
+    pattern == "/.reflect/" && matches!(line, "/.reflect" | ".reflect/" | ".reflect")
+}

--- a/apps/desktop/src-tauri/src/graph_gitignore.rs
+++ b/apps/desktop/src-tauri/src/graph_gitignore.rs
@@ -71,7 +71,7 @@ pub(crate) fn ensure_defaults(root: &Path) -> AppResult<()> {
     };
 
     for (heading, patterns) in missing_groups {
-        write!(file, "{prefix}# {heading}\n")?;
+        writeln!(file, "{prefix}# {heading}")?;
         for pattern in patterns {
             writeln!(file, "{pattern}")?;
         }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod db;
 mod error;
 mod fs;
 mod git;
+mod graph_gitignore;
 mod quit;
 mod recents;
 mod secrets;

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.2.0-beta.3",
+  "version": "0.2.0-beta.4",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
## Summary
- Centralize graph repository `.gitignore` defaults in a shared Rust helper
- Apply the defaults during graph bootstrap and git setup, including adopted repos
- Expand tests to cover the shared ignore content and idempotent updates

## Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only how local ignore files are written during graph bootstrap and git setup; no backup protocol or auth behavior changes.
> 
> **Overview**
> Graph roots now share one Rust helper for **`.gitignore`** instead of ad‑hoc strings and a reflect-only append path.
> 
> **New graphs** get a fuller default file: `/.reflect/` plus common OS junk (e.g. `.DS_Store`, `Thumbs.db`) and editor swap patterns (`*.swp`, etc.). **Bootstrap** and **git setup** both use this module—setup still **appends only missing pattern groups** when adopting an existing repo, with the same idempotency and legacy `/.reflect` spellings as before.
> 
> Tests assert the expanded content and non-duplication on repeat setup. Desktop app version bumps to **0.2.0-beta.4**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5108f8c4ff88c17aad6da0b24131971d8197aff1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->