### PR TITLE
Handle skipped notes during index rebuild

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.2.0-beta.3"
+version = "0.2.0-beta.4"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.2.0-beta.3"
+version = "0.2.0-beta.4"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.2.0-beta.3",
+  "version": "0.2.0-beta.4",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -233,7 +233,9 @@ describe('app commands', () => {
       rebuildIndex.mockResolvedValueOnce(undefined)
       const { context } = fakeContext()
       await command('index.rebuild').run(context)
-      expect(rebuildIndex).toHaveBeenCalledWith({ generation: 7 })
+      expect(rebuildIndex).toHaveBeenCalledWith(
+        expect.objectContaining({ generation: 7, onSkippedNote: expect.any(Function) }),
+      )
 
       // No graph open → no rebuild.
       rebuildIndex.mockClear()

--- a/apps/desktop/src/lib/rebuild-index.test.ts
+++ b/apps/desktop/src/lib/rebuild-index.test.ts
@@ -3,7 +3,12 @@ import type { EmbedStatus } from '@reflect/core'
 import { resetOperations } from '@/lib/operations'
 
 const rebuildIndex = vi.hoisted(() =>
-  vi.fn<(options: { generation: number }) => Promise<void>>(async () => undefined),
+  vi.fn<
+    (options: {
+      generation: number
+      onSkippedNote?: (note: { path: string; message: string }) => void
+    }) => Promise<void>
+  >(async () => undefined),
 )
 const embedStatus = vi.hoisted(() =>
   vi.fn<() => Promise<EmbedStatus>>(async () => ({ status: 'uninitialized' })),
@@ -55,10 +60,21 @@ describe('rebuildIndexVisibly', () => {
     await rebuildIndexVisibly(8)
 
     expect(rebuildIndex).toHaveBeenCalledTimes(2)
-    expect(rebuildIndex).toHaveBeenNthCalledWith(2, { generation: 8 })
+    expect(rebuildIndex).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ generation: 8, onSkippedNote: expect.any(Function) }),
+    )
 
     finishFirst()
     await first
+  })
+
+  it('does not reject when a rebuild reports skipped notes', async () => {
+    rebuildIndex.mockImplementationOnce(async (options) => {
+      options.onSkippedNote?.({ path: 'notes/bad.md', message: 'unexpected end of hex escape' })
+    })
+
+    await expect(rebuildIndexVisibly(7)).resolves.toBeUndefined()
   })
 
   it('absorbs a failed rebuild and releases the in-flight guard', async () => {

--- a/apps/desktop/src/lib/rebuild-index.ts
+++ b/apps/desktop/src/lib/rebuild-index.ts
@@ -34,9 +34,19 @@ export function rebuildIndexVisibly(generation: number): Promise<void> {
 
 async function runRebuild(generation: number): Promise<void> {
   const operation = startOperation('Rebuilding search index')
+  const skippedNotes: string[] = []
   try {
-    await rebuildIndex({ generation })
-    operation.done()
+    await rebuildIndex({
+      generation,
+      onSkippedNote: (note) => skippedNotes.push(`${note.path}: ${note.message}`),
+    })
+    if (skippedNotes.length === 0) {
+      operation.done()
+    } else {
+      const sample = skippedNotes.slice(0, 3).join('; ')
+      const suffix = skippedNotes.length > 3 ? `; +${skippedNotes.length - 3} more` : ''
+      operation.fail(`Rebuilt with ${skippedNotes.length} skipped note(s): ${sample}${suffix}`)
+    }
   } catch (cause) {
     operation.fail(errorMessage(cause))
     return

--- a/packages/core/src/indexing/indexer.ts
+++ b/packages/core/src/indexing/indexer.ts
@@ -1,4 +1,4 @@
-import { isAppError } from '../errors'
+import { errorMessage, isAppError } from '../errors'
 import { listFiles, readNote } from '../graph/commands'
 import { parseNote } from '../markdown'
 import {
@@ -67,12 +67,52 @@ export interface IndexPassOptions {
   /** Aborts the pass early when the active graph changes. */
   signal?: AbortSignal
   /**
+   * Called when a full rebuild cannot apply one note's projection even after
+   * retrying it outside the batch. The rebuild continues so one bad projection
+   * cannot leave the whole cache empty after `index_clear`. If omitted, that
+   * final single-note failure is thrown.
+   */
+  onSkippedNote?: (note: SkippedIndexedNote) => void
+  /**
    * Called after id-based move healing relocates a note's rows (Plan 17): an
    * external rename observed after the fact. The desktop layer uses it to
    * carry live sessions and rewrite routes, exactly as for an in-app rename
    * — without it, history entries keep pointing at the dead path.
    */
   onMoved?: (from: string, to: string) => void
+}
+
+/** One note omitted from a rebuild because its projection could not be written. */
+export interface SkippedIndexedNote {
+  /** Graph-relative markdown path. */
+  path: string
+  /** Displayable reason from the failed write. */
+  message: string
+}
+
+async function applyRebuildBatch(
+  notes: IndexedNote[],
+  generation: number,
+  onSkippedNote?: (note: SkippedIndexedNote) => void,
+): Promise<void> {
+  if (notes.length === 0) {
+    return
+  }
+  try {
+    await applyIndexedNotes(notes, generation)
+    return
+  } catch (cause) {
+    if (notes.length === 1) {
+      if (onSkippedNote === undefined) {
+        throw cause
+      }
+      onSkippedNote({ path: notes[0].path, message: errorMessage(cause) })
+      return
+    }
+    const midpoint = Math.ceil(notes.length / 2)
+    await applyRebuildBatch(notes.slice(0, midpoint), generation, onSkippedNote)
+    await applyRebuildBatch(notes.slice(midpoint), generation, onSkippedNote)
+  }
 }
 
 /**
@@ -83,7 +123,7 @@ export interface IndexPassOptions {
  * empty or half-populated.
  */
 export async function rebuildIndex(options: IndexPassOptions): Promise<void> {
-  const { generation } = options
+  const { generation, onSkippedNote } = options
   if (options.signal?.aborted) {
     return // don't wipe the current index for an already-cancelled pass
   }
@@ -96,11 +136,11 @@ export async function rebuildIndex(options: IndexPassOptions): Promise<void> {
     const fileHash = await hashContent(content)
     batch.push(buildIndexedNote(parsed, { fileHash, mtime: file.modifiedMs, source: content }))
     if (batch.length >= REBUILD_BATCH_SIZE) {
-      await applyIndexedNotes(batch, generation)
+      await applyRebuildBatch(batch, generation, onSkippedNote)
       batch = []
     }
   }
-  await applyIndexedNotes(batch, generation)
+  await applyRebuildBatch(batch, generation, onSkippedNote)
   // The rows now match the current projection — stamp it so `syncIndex` can
   // reconcile cheaply from here on. A superseded pass stamps into a stale
   // generation, which Rust drops: the next open then rebuilds again, which is

--- a/packages/core/src/indexing/pipeline.test.ts
+++ b/packages/core/src/indexing/pipeline.test.ts
@@ -80,6 +80,84 @@ describe('rebuildIndex', () => {
       generation: 1,
     })
   })
+
+  it('splits a failed rebuild batch and still applies the notes individually', async () => {
+    mockInvoke.mockImplementation(async (command, args) => {
+      if (command === 'list_files') {
+        return [
+          { path: 'notes/a.md', size: 1, modifiedMs: 1 },
+          { path: 'notes/b.md', size: 1, modifiedMs: 2 },
+          { path: 'notes/c.md', size: 1, modifiedMs: 3 },
+        ]
+      }
+      if (command === 'note_read') {
+        return `# ${String(args.path)}\n`
+      }
+      if (command === 'index_apply_batch') {
+        const notes = args.notes as Array<{ path: string }>
+        if (notes.length > 1) {
+          throw new Error('batch payload refused')
+        }
+        return null
+      }
+      return null
+    })
+
+    await rebuildIndex({ generation: 1 })
+
+    const applied = mockInvoke.mock.calls
+      .filter(([command]) => command === 'index_apply_batch')
+      .map(([, args]) => (args as { notes: Array<{ path: string }> }).notes.map((note) => note.path))
+    expect(applied).toEqual([
+      ['notes/a.md', 'notes/b.md', 'notes/c.md'],
+      ['notes/a.md', 'notes/b.md'],
+      ['notes/a.md'],
+      ['notes/b.md'],
+      ['notes/c.md'],
+    ])
+    expect(mockInvoke.mock.calls.some(([command]) => command === 'index_meta_set')).toBe(true)
+  })
+
+  it('reports and skips a note whose projection cannot be written alone', async () => {
+    mockInvoke.mockImplementation(async (command, args) => {
+      if (command === 'list_files') {
+        return [{ path: 'notes/bad.md', size: 1, modifiedMs: 1 }]
+      }
+      if (command === 'note_read') {
+        return `# ${String(args.path)}\n`
+      }
+      if (command === 'index_apply_batch') {
+        throw { kind: 'parse', message: 'unexpected end of hex escape' }
+      }
+      return null
+    })
+    const skipped: Array<{ path: string; message: string }> = []
+
+    await rebuildIndex({ generation: 1, onSkippedNote: (note) => skipped.push(note) })
+
+    expect(skipped).toEqual([
+      { path: 'notes/bad.md', message: 'unexpected end of hex escape' },
+    ])
+    expect(mockInvoke.mock.calls.some(([command]) => command === 'index_meta_set')).toBe(true)
+  })
+
+  it('throws a single-note write failure when no skip callback is registered', async () => {
+    mockInvoke.mockImplementation(async (command, args) => {
+      if (command === 'list_files') {
+        return [{ path: 'notes/bad.md', size: 1, modifiedMs: 1 }]
+      }
+      if (command === 'note_read') {
+        return `# ${String(args.path)}\n`
+      }
+      if (command === 'index_apply_batch') {
+        throw new Error('single note refused')
+      }
+      return null
+    })
+
+    await expect(rebuildIndex({ generation: 1 })).rejects.toThrow('single note refused')
+    expect(mockInvoke.mock.calls.some(([command]) => command === 'index_meta_set')).toBe(false)
+  })
 })
 
 describe('syncIndex', () => {
@@ -230,7 +308,8 @@ describe('reconcileIndex move healing (Plan 17)', () => {
     expect(commands).toContain('index_move')
     expect(commands).not.toContain('index_remove')
     const apply = calls.find(([command]) => command === 'index_apply')
-    expect((apply?.[1].note as { path: string }).path).toBe(NEW)
+    expect(apply).toBeDefined()
+    expect((apply![1].note as { path: string }).path).toBe(NEW)
   })
 
   it('a legacy file without an id still reconciles as delete+create', async () => {


### PR DESCRIPTION
## Summary
- Teach full rebuilds to split failing batches, skip irrecoverable notes, and keep stamping index generations
- Surface skipped-note summaries in the desktop rebuild operation instead of treating them as a hard failure
- Update tests to cover batch splitting, skipped-note reporting, and the new rebuild callback wiring

## Testing
- Added unit tests for rebuild batch splitting and skipped-note handling
- Added desktop command tests for the new rebuild callback wiring

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core rebuild semantics after an index wipe—incorrect skip logic could leave notes unindexed silently, though the desktop now surfaces skips and tests cover the split/skip paths.
> 
> **Overview**
> **Full rebuilds no longer fail entirely when one note’s projection cannot be written** after `index_clear`. `rebuildIndex` routes batch applies through `applyRebuildBatch`, which recursively splits failed batches and, for a lone bad note, either invokes optional `onSkippedNote` or rethrows if no callback is set; the projection version stamp still runs when the pass completes.
> 
> The desktop **`rebuildIndexVisibly` path collects skipped notes** via that callback and reports them on the rebuild operation (sample paths/messages) instead of treating a partial skip as success with no signal. Tests cover batch splitting, skip vs throw behavior, and the `index.rebuild` wiring.
> 
> Desktop app version is bumped to **0.2.0-beta.4** in Cargo/Tauri manifests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa7402badb83eeccdfd94c6752b2f4812d76d995. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->