### PR TITLE
[codex] Add warning status for operations

### DIFF
--- a/apps/desktop/src/components/operations-status.tsx
+++ b/apps/desktop/src/components/operations-status.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react'
-import { useOperations } from '@/lib/operations'
+import { type Operation, useOperations } from '@/lib/operations'
 
 /**
  * The global status surface (foundations hardening): a small, unobtrusive
@@ -7,6 +7,14 @@ import { useOperations } from '@/lib/operations'
  * rewrite is the first tenant; indexing/sync states can migrate here as
  * they're touched. Renders nothing when idle.
  */
+
+function messageClassName(status: Operation['status']): string {
+  if (status === 'failed') {
+    return 'block text-red-600 dark:text-red-400'
+  }
+  return 'block text-amber-700 dark:text-amber-300'
+}
+
 export function OperationsStatus(): ReactElement | null {
   const operations = useOperations()
   if (operations.length === 0) {
@@ -26,8 +34,8 @@ export function OperationsStatus(): ReactElement | null {
               {operation.progress.done}/{operation.progress.total}
             </span>
           ) : null}
-          {operation.status === 'failed' ? (
-            <span className="block text-red-600 dark:text-red-400">{operation.message}</span>
+          {operation.status !== 'running' ? (
+            <span className={messageClassName(operation.status)}>{operation.message}</span>
           ) : null}
         </div>
       ))}

--- a/apps/desktop/src/lib/operations.test.ts
+++ b/apps/desktop/src/lib/operations.test.ts
@@ -49,6 +49,20 @@ describe('operations store', () => {
     expect(result.current).toEqual([])
   })
 
+  it('a warning operation lingers without being marked failed', () => {
+    const { result } = renderHook(() => useOperations())
+    let handle!: ReturnType<typeof startOperation>
+    act(() => {
+      handle = startOperation('Rebuilding search index')
+    })
+    act(() => handle.warn('Rebuilt with 1 skipped note: notes/bad.md'))
+    expect(result.current[0].status).toBe('warning')
+    expect(result.current[0].message).toBe('Rebuilt with 1 skipped note: notes/bad.md')
+
+    act(() => vi.advanceTimersByTime(8000 + 1200))
+    expect(result.current).toEqual([])
+  })
+
   it('handles are scoped: finishing one operation leaves others running', () => {
     const { result } = renderHook(() => useOperations())
     let first!: ReturnType<typeof startOperation>

--- a/apps/desktop/src/lib/operations.ts
+++ b/apps/desktop/src/lib/operations.ts
@@ -13,8 +13,8 @@ export interface Operation {
   id: number
   label: string
   progress: { done: number; total: number } | null
-  status: 'running' | 'failed'
-  /** The lingering line under the label when the operation failed. */
+  status: 'running' | 'warning' | 'failed'
+  /** The lingering line under the label when the operation needs attention. */
   message: string | null
 }
 
@@ -22,6 +22,8 @@ export interface OperationHandle {
   progress: (done: number, total: number) => void
   /** The operation completed; its entry disappears. */
   done: () => void
+  /** The operation completed with caveats; its warning lingers briefly. */
+  warn: (message: string) => void
   /** The operation failed; the entry lingers briefly so the error is seen. */
   fail: (message: string) => void
 }
@@ -83,6 +85,10 @@ export function startOperation(label: string): OperationHandle {
   return {
     progress: (done, total) => patch(id, { progress: { done, total } }),
     done: () => removeAfterMinimum(0),
+    warn: (message) => {
+      patch(id, { status: 'warning', message })
+      removeAfterMinimum(LINGER_MS)
+    },
     fail: (message) => {
       patch(id, { status: 'failed', message })
       removeAfterMinimum(LINGER_MS)

--- a/apps/desktop/src/lib/rebuild-index.ts
+++ b/apps/desktop/src/lib/rebuild-index.ts
@@ -45,7 +45,7 @@ async function runRebuild(generation: number): Promise<void> {
     } else {
       const sample = skippedNotes.slice(0, 3).join('; ')
       const suffix = skippedNotes.length > 3 ? `; +${skippedNotes.length - 3} more` : ''
-      operation.fail(`Rebuilt with ${skippedNotes.length} skipped note(s): ${sample}${suffix}`)
+      operation.warn(`Rebuilt with ${skippedNotes.length} skipped note(s): ${sample}${suffix}`)
     }
   } catch (cause) {
     operation.fail(errorMessage(cause))


### PR DESCRIPTION
## Summary
- add a warning terminal state to global operations
- render warning messages in amber instead of failure red
- report index rebuilds with skipped notes as partial-success warnings

## Why
The skipped-note rebuild path can complete most of the index successfully. Showing that state as a failed operation overstates the severity and makes the user-facing status less precise.

## Validation
- pnpm --filter @reflect/desktop exec vitest run src/lib/operations.test.ts src/lib/rebuild-index.test.ts src/lib/commands/app-commands.test.ts
- pnpm check

## Follow-up
Manual rebuild performance can likely improve by preserving embedding chunks/vectors across index clears, then pruning orphan chunks after the note projection has been rebuilt. The embedding pipeline already has chunk-level content hashes, but today manual index_clear removes the stored embeddings, so the subsequent backfill has nothing to hash-skip against.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized changes to operation status UX and rebuild messaging; no auth, data migration, or core indexing failure paths altered beyond classification of skipped-note success.
> 
> **Overview**
> Adds a **`warning`** terminal state to the global operations store so background work can finish with caveats without looking like a hard failure.
> 
> `OperationHandle` gains **`warn(message)`**, which sets status to `warning`, shows the message for the same linger window as **`fail`**, then clears. **`OperationsStatus`** now shows lingering text for any non-`running` status: **red** for `failed`, **amber** for `warning`.
> 
> Manual index rebuilds that complete but skip some notes now call **`operation.warn(...)`** instead of **`operation.fail(...)`**, reflecting partial success while still surfacing which notes were skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1caa8ca39b195fc18c142efa91803ef875c4749d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->