### PR TITLE
Release v0.2.0-beta.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.2.0-beta.5"
+version = "0.2.0-beta.6"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.2.0-beta.5"
+version = "0.2.0-beta.6"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.2.0-beta.5",
+  "version": "0.2.0-beta.6",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.2.0-beta.6.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-string-only release prep with no runtime, security, or behavioral changes.
> 
> **Overview**
> **Release version bump** from `0.2.0-beta.5` to **`0.2.0-beta.6`** with no application or dependency logic changes.
> 
> The new version is aligned in **`Cargo.lock`**, **`apps/desktop/src-tauri/Cargo.toml`** (`reflect-open`), and **`tauri.conf.json`** (`productName` / bundle version) so builds and the updater see a single release number.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 518578790ca9aa0c72c28f15fa033896ee939a6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped application version to 0.2.0-beta.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->