### PR TITLE
[codex] Fix published link persistence

### DIFF
--- a/apps/desktop/src/components/context-sidebar/daily-context-sidebar.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/daily-context-sidebar.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
+import type { NoteRow } from '@reflect/core'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { formatDayLabel } from '@/lib/dates'
 import { monthLabel, monthOf } from '@/lib/month-grid'
@@ -11,10 +12,12 @@ import { DailyContextSidebar } from './daily-context-sidebar'
 
 const dailyDatesInRange = vi.hoisted(() => vi.fn())
 const relatedNotes = vi.hoisted(() => vi.fn())
+const getNote = vi.hoisted(() => vi.fn<() => Promise<NoteRow | undefined>>(async () => undefined))
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   hasBridge: () => true,
   dailyDatesInRange,
+  getNote,
   relatedNotes,
 }))
 vi.mock('@/providers/graph-provider', () => ({
@@ -49,8 +52,22 @@ function renderSidebar(date: string) {
 beforeEach(() => {
   window.sessionStorage.clear()
   dailyDatesInRange.mockReset().mockResolvedValue([])
+  getNote.mockReset().mockResolvedValue(undefined)
   relatedNotes.mockReset().mockResolvedValue([])
 })
+
+function noteRow(overrides: Partial<NoteRow> = {}): NoteRow {
+  return {
+    path: 'daily/2026-06-09.md',
+    title: '2026-06-09',
+    dailyDate: '2026-06-09',
+    isPrivate: false,
+    hasConflict: false,
+    gistUrl: null,
+    gistStale: false,
+    ...overrides,
+  }
+}
 
 describe('DailyContextSidebar calendar header', () => {
   it('jumps to today from the calendar-icon button', async () => {
@@ -137,6 +154,17 @@ describe('DailyContextSidebar related notes', () => {
 })
 
 describe('DailyContextSidebar sections', () => {
+  it('shows the published URL section for a published daily note', async () => {
+    getNote.mockResolvedValue(
+      noteRow({ gistUrl: 'https://gist.github.com/alex/daily20260609' }),
+    )
+    const view = renderSidebar('2026-06-09')
+
+    await view.findByText('Published URL')
+    expect(view.getByRole('link', { name: 'https://gist.github.com/alex/daily20260609' })).toBeDefined()
+    view.unmount()
+  })
+
   it('collapses a section and persists the state for the session', async () => {
     const view = renderSidebar('2026-06-09')
     const header = view.getByRole('button', { name: /Note actions/ })

--- a/apps/desktop/src/components/context-sidebar/daily-context-sidebar.tsx
+++ b/apps/desktop/src/components/context-sidebar/daily-context-sidebar.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react'
 import { dailyPath } from '@reflect/core'
 import { DayCalendar } from './day-calendar'
 import { NoteActionsSection } from './note-actions-section'
+import { PublishedUrlSection } from './published-url-section'
 import { SimilarNotesSection } from './similar-notes-section'
 import { useToday } from '@/lib/use-today'
 import { cn } from '@/lib/utils'
@@ -34,6 +35,7 @@ export function DailyContextSidebar({ date }: DailyContextSidebarProps): ReactEl
       <DayCalendar selectedDate={date} today={today} />
       <div className="my-4 space-y-4 pb-4">
         <NoteActionsSection path={dailyPath(date)} />
+        <PublishedUrlSection path={dailyPath(date)} />
         <SimilarNotesSection path={dailyPath(date)} />
       </div>
     </div>

--- a/apps/desktop/src/components/context-sidebar/note-gist-action.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-gist-action.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { NoteRow } from '@reflect/core'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { NoteGistAction } from './note-gist-action'
+import { clearPendingPublishedUrl } from './published-url-bridge'
 
 const useGithubConnected = vi.hoisted(() => vi.fn(() => true))
 const useNoteRow = vi.hoisted(() => vi.fn<(path: string) => NoteRow | null>(() => null))
@@ -40,6 +41,7 @@ function renderAction() {
 }
 
 beforeEach(() => {
+  clearPendingPublishedUrl('notes/a.md', 'https://gist.github.com/alex/g1')
   useGithubConnected.mockReset().mockReturnValue(true)
   useNoteRow.mockReset().mockReturnValue(null)
   runGistPublish.mockReset().mockResolvedValue('https://gist.github.com/alex/g1')

--- a/apps/desktop/src/components/context-sidebar/note-gist-action.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-gist-action.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from 'react'
+import { useEffect, useState, type ReactElement } from 'react'
 import { CloudUpload } from 'lucide-react'
 import { ShortcutKeys } from '@/components/shortcut-keys'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -7,23 +7,17 @@ import { useNoteRow } from '@/hooks/use-note-row'
 import { runGistPublish } from '@/lib/note-gist'
 import { cn } from '@/lib/utils'
 import { useGraph } from '@/providers/graph-provider'
+import {
+  clearPendingPublishedUrl,
+  setPendingPublishedUrl,
+  usePendingPublishedUrl,
+} from './published-url-bridge'
 
 interface NoteGistActionProps {
   /** Graph-relative path of the note the action operates on. */
   path: string
   /** Keybinding hint, from the matching command definition. */
   keybinding?: string | null
-}
-
-/**
- * The last publish's result, held until the index reflects it — the same
- * bridge as `NoteToggleAction`: the label otherwise lags one watcher
- * round-trip behind the frontmatter write, and in that window the button
- * would still read "Share with private link" after the gist already exists.
- */
-interface PendingPublish {
-  path: string
-  url: string
 }
 
 /**
@@ -40,18 +34,20 @@ export function NoteGistAction({ path, keybinding = null }: NoteGistActionProps)
   const connected = useGithubConnected()
   const row = useNoteRow(path)
   const [isPublishing, setIsPublishing] = useState(false)
-  const [pending, setPending] = useState<PendingPublish | null>(null)
+  const pendingUrl = usePendingPublishedUrl(path)
 
-  // Render-time state adjustment: drop the bridge once the index reports the
-  // published url (or the action moved to another note). Deliberately url-only:
-  // also waiting for `gistStale` to clear could hold the bridge forever — a
+  // Drop the bridge once the index reports the published url. Deliberately
+  // url-only: also waiting for `gistStale` to clear could hold the bridge forever — a
   // body edited right after publishing keeps recomputing stale, and a stuck
   // bridge would suppress the republish nudge until navigation. The cost is a
   // one-watcher-round-trip nudge flash after a same-url republish.
-  if (pending !== null && (pending.path !== path || row?.gistUrl === pending.url)) {
-    setPending(null)
-  }
-  const bridged = pending !== null && pending.path === path
+  useEffect(() => {
+    if (pendingUrl !== null && row?.gistUrl === pendingUrl) {
+      clearPendingPublishedUrl(path, pendingUrl)
+    }
+  }, [path, pendingUrl, row?.gistUrl])
+
+  const bridged = pendingUrl !== null
   const published = bridged || (row?.gistUrl ?? null) !== null
   const stale = !bridged && (row?.gistStale ?? false)
 
@@ -67,8 +63,8 @@ export function NoteGistAction({ path, keybinding = null }: NoteGistActionProps)
     setIsPublishing(true)
     try {
       const url = await runGistPublish(path, generation)
-      if (url !== null) {
-        setPending({ path, url })
+      if (url !== null && row?.gistUrl !== url) {
+        setPendingPublishedUrl(path, url)
       }
     } finally {
       setIsPublishing(false)

--- a/apps/desktop/src/components/context-sidebar/published-url-bridge.ts
+++ b/apps/desktop/src/components/context-sidebar/published-url-bridge.ts
@@ -1,0 +1,53 @@
+import { useSyncExternalStore } from 'react'
+
+interface PendingPublishedUrl {
+  readonly path: string
+  readonly url: string
+}
+
+let pendingPublishedUrl: PendingPublishedUrl | null = null
+const listeners = new Set<() => void>()
+
+function emitChange(): void {
+  for (const listener of listeners) {
+    listener()
+  }
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+function getSnapshot(): PendingPublishedUrl | null {
+  return pendingPublishedUrl
+}
+
+/**
+ * Holds a freshly published URL until the index row catches up, so every
+ * sidebar surface can reflect the successful publish immediately.
+ */
+export function setPendingPublishedUrl(path: string, url: string): void {
+  pendingPublishedUrl = { path, url }
+  emitChange()
+}
+
+/**
+ * Clears the pending URL for a note once the index reports the same value.
+ */
+export function clearPendingPublishedUrl(path: string, url: string): void {
+  if (pendingPublishedUrl?.path !== path || pendingPublishedUrl.url !== url) {
+    return
+  }
+  pendingPublishedUrl = null
+  emitChange()
+}
+
+/**
+ * Returns the pending published URL for `path`, if a publish completed before
+ * the index row was refreshed.
+ */
+export function usePendingPublishedUrl(path: string): string | null {
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+  return snapshot?.path === path ? snapshot.url : null
+}

--- a/apps/desktop/src/components/context-sidebar/published-url-section.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/published-url-section.test.tsx
@@ -5,6 +5,7 @@ import type { NoteRow } from '@reflect/core'
 import { openUrl } from '@tauri-apps/plugin-opener'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { PublishedUrlSection } from './published-url-section'
+import { clearPendingPublishedUrl, setPendingPublishedUrl } from './published-url-bridge'
 
 const useNoteRow = vi.hoisted(() => vi.fn<(path: string) => NoteRow | null>(() => null))
 const operationDone = vi.hoisted(() => vi.fn())
@@ -47,6 +48,8 @@ function stubClipboard(writeText: (text: string) => Promise<void>): void {
 
 beforeEach(() => {
   window.sessionStorage.clear()
+  clearPendingPublishedUrl('notes/a.md', 'https://gist.github.com/alex/g1')
+  clearPendingPublishedUrl('notes/a.md', 'https://gist.github.com/alex/pending')
   useNoteRow.mockReset().mockReturnValue(null)
   vi.mocked(openUrl).mockClear()
   startOperation.mockClear()
@@ -68,6 +71,15 @@ describe('PublishedUrlSection', () => {
   it('shows the published gist URL for a published note', () => {
     const url = 'https://gist.github.com/alex/g1'
     useNoteRow.mockReturnValue(noteRow({ gistUrl: url }))
+
+    const view = renderSection()
+    expect(view.getByText('Published URL')).toBeTruthy()
+    expect(view.getByRole('link', { name: url }).getAttribute('href')).toBe(url)
+  })
+
+  it('shows a just-published URL before the index row catches up', () => {
+    const url = 'https://gist.github.com/alex/pending'
+    setPendingPublishedUrl('notes/a.md', url)
 
     const view = renderSection()
     expect(view.getByText('Published URL')).toBeTruthy()

--- a/apps/desktop/src/components/context-sidebar/published-url-section.tsx
+++ b/apps/desktop/src/components/context-sidebar/published-url-section.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useNoteRow } from '@/hooks/use-note-row'
 import { startOperation } from '@/lib/operations'
+import { usePendingPublishedUrl } from './published-url-bridge'
 import { SidebarSection } from './sidebar-section'
 
 interface PublishedUrlSectionProps {
@@ -23,7 +24,8 @@ const COPY_RESET_MS = 1400
  */
 export function PublishedUrlSection({ path }: PublishedUrlSectionProps): ReactElement | null {
   const row = useNoteRow(path)
-  const url = row?.gistUrl ?? null
+  const pendingUrl = usePendingPublishedUrl(path)
+  const url = row?.gistUrl ?? pendingUrl
   const [copyState, setCopyState] = useState<CopyState>('idle')
 
   useEffect(() => {

--- a/apps/desktop/src/editor/note-session.test.ts
+++ b/apps/desktop/src/editor/note-session.test.ts
@@ -345,6 +345,15 @@ describe('frontmatter ownership (Plan 07b)', () => {
     expect(h.snapshots.at(-1)?.dirty).toBe(false)
   })
 
+  it('commitFrontmatter declines when the session has no write channel', async () => {
+    const h = harness({ disk: '# Hello\n', write: false })
+    h.session.load()
+    await vi.runAllTimersAsync()
+
+    await expect(h.session.commitFrontmatter({ pinned: true })).resolves.toBe(false)
+    expect(h.writes).toEqual([])
+  })
+
   it('commitFrontmatter under a parked conflict writes through and refreshes the park', async () => {
     const h = harness()
     h.session.load()

--- a/apps/desktop/src/editor/note-session.ts
+++ b/apps/desktop/src/editor/note-session.ts
@@ -618,6 +618,9 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
   }
 
   async function commitFrontmatter(patch: FrontmatterPatch): Promise<boolean> {
+    if (io.write === null) {
+      return false
+    }
     if (!updateFrontmatter(patch)) {
       return false
     }
@@ -630,14 +633,12 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
     // content and write it through. The park refreshes in place, so "load
     // theirs" adopts the patched bytes, and recording the write in `disk`
     // makes the watcher's echo a recognized no-op.
-    if (io.write !== null) {
-      const patched = upsertFrontmatter(conflict, yamlPatch(patch))
-      if (patched !== conflict) {
-        await io.write(path, patched)
-        conflict = patched
-        disk = patched
-        emit()
-      }
+    const patched = upsertFrontmatter(conflict, yamlPatch(patch))
+    if (patched !== conflict) {
+      await io.write(path, patched)
+      conflict = patched
+      disk = patched
+      emit()
     }
     return true
   }

--- a/apps/desktop/src/lib/note-gist.test.ts
+++ b/apps/desktop/src/lib/note-gist.test.ts
@@ -50,9 +50,13 @@ beforeEach(() => {
   operationFail.mockClear()
 })
 
-function fakeSession(content: string, canCommit = true) {
+function fakeSession(content: string, canCommit = true, liveContent: string | null = content) {
   const commitFrontmatter = vi.fn(async () => canCommit)
-  const session = { content: () => content, commitFrontmatter } as unknown as NoteSession
+  const session = {
+    content: () => content,
+    liveContent: () => liveContent,
+    commitFrontmatter,
+  } as unknown as NoteSession
   return { session, commitFrontmatter }
 }
 
@@ -110,6 +114,21 @@ describe('publishNoteToGist', () => {
     openSession.mockReturnValue(session)
     readNote.mockResolvedValue(BODY)
     await publishNoteToGist('notes/a.md', 3)
+    expect(writeNote).toHaveBeenCalled()
+  })
+
+  it('falls back to disk content when the open session is not ready', async () => {
+    const { session } = fakeSession('', false, null)
+    openSession.mockReturnValue(session)
+    readNote.mockResolvedValue(BODY)
+
+    await publishNoteToGist('notes/a.md', 3)
+
+    expect(createGist).toHaveBeenCalledWith(
+      'tok',
+      { name: 'A.md', content: BODY },
+      expect.any(Function),
+    )
     expect(writeNote).toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/lib/note-gist.ts
+++ b/apps/desktop/src/lib/note-gist.ts
@@ -40,7 +40,7 @@ import { providerFetch } from '@/lib/provider-fetch'
  */
 export async function publishNoteToGist(path: string, generation: number): Promise<string> {
   const owner = openSession(path)
-  const source = owner !== null ? owner.content() : await readNoteOrEmpty(path)
+  const source = owner?.liveContent() ?? (await readNoteOrEmpty(path))
   const parsed = parseNote({ path, source })
   assertCloudAllowed({ path, isPrivate: parsed.frontmatter.private })
 


### PR DESCRIPTION
## Summary

Fixes the published-link follow-up from #167:

- shows the Published URL section in daily-note sidebars as well as ordinary note sidebars
- makes gist publishing read from the open session only when that session is fully loaded; otherwise it falls back to disk
- makes `commitFrontmatter()` return `false` when a live session has no write channel, so publish/pin/private callers use their disk fallback instead of treating an unwritten frontmatter patch as persisted

## Root Cause

The URL section was only mounted in `NoteContextSidebar`; daily routes use `DailyContextSidebar`, so published daily notes had no URL section. Separately, `commitFrontmatter()` could report success even with `io.write === null`, which let callers skip the disk fallback even though no frontmatter was written.

## Validation

- `pnpm --filter @reflect/desktop test src/editor/note-session.test.ts src/lib/note-gist.test.ts src/components/context-sidebar/daily-context-sidebar.test.tsx src/components/context-sidebar/published-url-section.test.tsx`
- `pnpm --filter @reflect/desktop typecheck`
- `pnpm check`
- `pnpm build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gist frontmatter persistence and publish content sourcing; incorrect behavior could leave gist metadata unrecorded or publish wrong body, though behavior is covered by new tests.
> 
> **Overview**
> Fixes published-link follow-up: daily notes now show **Published URL** in `DailyContextSidebar`, matching ordinary note sidebars.
> 
> Gist publish persistence is tightened. `commitFrontmatter()` returns **false** when the session has no write channel so callers use disk fallback instead of treating an unwritten patch as success. `publishNoteToGist` reads via `liveContent()` and falls back to disk when the open session is not ready, avoiding empty or stale publishes.
> 
> A shared **`published-url-bridge`** (`useSyncExternalStore`) holds the URL right after publish until the index row updates. `NoteGistAction` and `PublishedUrlSection` both use it so the republish label and URL section appear immediately without duplicating local pending state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0074c33b9c89c46158d1202f5115985c9cfacd71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Published URL" section to the daily context sidebar, displaying links to published notes when available.

* **Bug Fixes**
  * Improved note publishing logic to better handle edge cases when note sessions lack write capability, with more reliable fallback to disk content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->