### PR TITLE
Fix published-link visibility: daily sidebar + optimistic note-row read model

### DIFF
--- a/apps/desktop/src/components/context-sidebar/daily-context-sidebar.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/daily-context-sidebar.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
+import type { NoteRow } from '@reflect/core'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { formatDayLabel } from '@/lib/dates'
 import { monthLabel, monthOf } from '@/lib/month-grid'
@@ -11,12 +12,14 @@ import { DailyContextSidebar } from './daily-context-sidebar'
 
 const dailyDatesInRange = vi.hoisted(() => vi.fn())
 const relatedNotes = vi.hoisted(() => vi.fn())
+const useNoteRow = vi.hoisted(() => vi.fn<(path: string) => NoteRow | null>(() => null))
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   hasBridge: () => true,
   dailyDatesInRange,
   relatedNotes,
 }))
+vi.mock('@/hooks/use-note-row', () => ({ useNoteRow }))
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({ graph: { root: '/g', name: 'g', cloudSync: false, generation: 1 } }),
 }))
@@ -46,10 +49,24 @@ function renderSidebar(date: string) {
   )
 }
 
+function noteRow(overrides: Partial<NoteRow> = {}): NoteRow {
+  return {
+    path: 'daily/2026-06-09.md',
+    title: '2026-06-09',
+    dailyDate: '2026-06-09',
+    isPrivate: false,
+    hasConflict: false,
+    gistUrl: null,
+    gistStale: false,
+    ...overrides,
+  }
+}
+
 beforeEach(() => {
   window.sessionStorage.clear()
   dailyDatesInRange.mockReset().mockResolvedValue([])
   relatedNotes.mockReset().mockResolvedValue([])
+  useNoteRow.mockReset().mockReturnValue(null)
 })
 
 describe('DailyContextSidebar calendar header', () => {
@@ -159,6 +176,23 @@ describe('DailyContextSidebar sections', () => {
     const view = renderSidebar('2026-06-09')
     expect(view.getByText(monthLabel(monthOf('2026-06-09')))).toBeDefined()
     expect(view.queryByRole('button', { name: /^Calendar$/ })).toBeNull()
+    view.unmount()
+  })
+})
+
+describe('DailyContextSidebar published link', () => {
+  it('shows the Published URL section once the daily note is published', () => {
+    const url = 'https://gist.github.com/alex/daily1'
+    useNoteRow.mockReturnValue(noteRow({ gistUrl: url }))
+    const view = renderSidebar('2026-06-09')
+    expect(view.getByText('Published URL')).toBeDefined()
+    expect(view.getByRole('link', { name: url }).getAttribute('href')).toBe(url)
+    view.unmount()
+  })
+
+  it('omits the Published URL section for an unpublished daily note', () => {
+    const view = renderSidebar('2026-06-09')
+    expect(view.queryByText('Published URL')).toBeNull()
     view.unmount()
   })
 })

--- a/apps/desktop/src/components/context-sidebar/daily-context-sidebar.tsx
+++ b/apps/desktop/src/components/context-sidebar/daily-context-sidebar.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react'
 import { dailyPath } from '@reflect/core'
 import { DayCalendar } from './day-calendar'
 import { NoteActionsSection } from './note-actions-section'
+import { PublishedUrlSection } from './published-url-section'
 import { SimilarNotesSection } from './similar-notes-section'
 import { useToday } from '@/lib/use-today'
 import { cn } from '@/lib/utils'
@@ -34,6 +35,7 @@ export function DailyContextSidebar({ date }: DailyContextSidebarProps): ReactEl
       <DayCalendar selectedDate={date} today={today} />
       <div className="my-4 space-y-4 pb-4">
         <NoteActionsSection path={dailyPath(date)} />
+        <PublishedUrlSection path={dailyPath(date)} />
         <SimilarNotesSection path={dailyPath(date)} />
       </div>
     </div>

--- a/apps/desktop/src/components/context-sidebar/note-gist-action.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-gist-action.test.tsx
@@ -2,13 +2,16 @@ import { cleanup, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { NoteRow } from '@reflect/core'
+import { resetNoteRowOverlays, setNoteRowOverlay } from '@/hooks/note-row-overlay'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { NoteGistAction } from './note-gist-action'
 
 const useGithubConnected = vi.hoisted(() => vi.fn(() => true))
 const useNoteRow = vi.hoisted(() => vi.fn<(path: string) => NoteRow | null>(() => null))
 const runGistPublish = vi.hoisted(() =>
-  vi.fn(async (): Promise<string | null> => 'https://gist.github.com/alex/g1'),
+  vi.fn<(path: string, generation: number) => Promise<string | null>>(
+    async () => 'https://gist.github.com/alex/g1',
+  ),
 )
 
 vi.mock('@/hooks/use-github-connected', () => ({ useGithubConnected }))
@@ -40,6 +43,7 @@ function renderAction() {
 }
 
 beforeEach(() => {
+  resetNoteRowOverlays()
   useGithubConnected.mockReset().mockReturnValue(true)
   useNoteRow.mockReset().mockReturnValue(null)
   runGistPublish.mockReset().mockResolvedValue('https://gist.github.com/alex/g1')
@@ -74,6 +78,12 @@ describe('NoteGistAction', () => {
   })
 
   it('publishes on click and flips to Republish before the index catches up', async () => {
+    // The real publish records the url in the optimistic overlay; mirror that
+    // so the label flips off the overlay, ahead of any index refresh.
+    runGistPublish.mockImplementation(async (path) => {
+      setNoteRowOverlay(path, { gistUrl: 'https://gist.github.com/alex/g1' })
+      return 'https://gist.github.com/alex/g1'
+    })
     const view = renderAction()
     await userEvent.click(view.getByRole('button', { name: /Share with private link/ }))
 
@@ -93,32 +103,31 @@ describe('NoteGistAction', () => {
     })
   })
 
-  it('keeps nudging after a same-url republish — the bridge retires on url match alone', async () => {
-    // A published, edited note: the row already carries the url the republish
-    // will return. Were the bridge to also wait for `gistStale` to clear, a
-    // body that keeps changing would hold it forever and mute the nudge.
+  it('holds the stale nudge while a publish is optimistically pending, then follows the index', () => {
+    // A published, edited note. Right after a republish the gist matches the
+    // body again, so the lagging index's "stale" must be held back rather than
+    // flashing — the overlay (url-only) suppresses it until the index agrees,
+    // and never waits on `gist_stale`, so a still-editing note can't mute the
+    // nudge forever.
     const url = 'https://gist.github.com/alex/g1'
-    runGistPublish.mockResolvedValue(url)
     useNoteRow.mockReturnValue(noteRow({ gistUrl: url, gistStale: true }))
+    const accentIcon = (view: ReturnType<typeof renderAction>) =>
+      view.getByRole('button').querySelector('.text-accent')
 
-    const view = renderAction()
-    const accentIcon = () => view.getByRole('button').querySelector('.text-accent')
-    expect(accentIcon()).toBeTruthy()
+    // Nothing pending: the index reads stale, so the nudge shows.
+    const idle = renderAction()
+    expect(accentIcon(idle)).toBeTruthy()
+    idle.unmount()
 
-    await userEvent.click(view.getByRole('button', { name: /Republish private link/ }))
-    await waitFor(() => {
-      // Index still says stale (the watcher hasn't re-indexed yet) — the
-      // retired bridge must not mask it.
-      expect(accentIcon()).toBeTruthy()
-    })
+    // A fresh publish sits in the overlay: the nudge is held back.
+    setNoteRowOverlay('notes/a.md', { gistUrl: url })
+    const pending = renderAction()
+    expect(accentIcon(pending)).toBeNull()
+    pending.unmount()
 
-    // The watcher catches up: staleness clears, and so does the nudge.
-    useNoteRow.mockReturnValue(noteRow({ gistUrl: url, gistStale: false }))
-    view.rerender(
-      <TooltipProvider>
-        <NoteGistAction path="notes/a.md" />
-      </TooltipProvider>,
-    )
-    expect(accentIcon()).toBeNull()
+    // Overlay retired (the index caught up): the nudge follows the index again.
+    resetNoteRowOverlays()
+    const settled = renderAction()
+    expect(accentIcon(settled)).toBeTruthy()
   })
 })

--- a/apps/desktop/src/components/context-sidebar/note-gist-action.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-gist-action.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactElement } from 'react'
 import { CloudUpload } from 'lucide-react'
 import { ShortcutKeys } from '@/components/shortcut-keys'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useNoteRowOverlay } from '@/hooks/note-row-overlay'
 import { useGithubConnected } from '@/hooks/use-github-connected'
 import { useNoteRow } from '@/hooks/use-note-row'
 import { runGistPublish } from '@/lib/note-gist'
@@ -13,17 +14,6 @@ interface NoteGistActionProps {
   path: string
   /** Keybinding hint, from the matching command definition. */
   keybinding?: string | null
-}
-
-/**
- * The last publish's result, held until the index reflects it — the same
- * bridge as `NoteToggleAction`: the label otherwise lags one watcher
- * round-trip behind the frontmatter write, and in that window the button
- * would still read "Share with private link" after the gist already exists.
- */
-interface PendingPublish {
-  path: string
-  url: string
 }
 
 /**
@@ -39,21 +29,18 @@ export function NoteGistAction({ path, keybinding = null }: NoteGistActionProps)
   const { graph } = useGraph()
   const connected = useGithubConnected()
   const row = useNoteRow(path)
+  // `row` already reflects a just-published url (the optimistic overlay flows
+  // through `useNoteRow`); the raw overlay tells us *that* a publish is still
+  // catching up, which only `stale` needs.
+  const optimistic = useNoteRowOverlay(path)?.gistUrl != null
   const [isPublishing, setIsPublishing] = useState(false)
-  const [pending, setPending] = useState<PendingPublish | null>(null)
 
-  // Render-time state adjustment: drop the bridge once the index reports the
-  // published url (or the action moved to another note). Deliberately url-only:
-  // also waiting for `gistStale` to clear could hold the bridge forever — a
-  // body edited right after publishing keeps recomputing stale, and a stuck
-  // bridge would suppress the republish nudge until navigation. The cost is a
-  // one-watcher-round-trip nudge flash after a same-url republish.
-  if (pending !== null && (pending.path !== path || row?.gistUrl === pending.url)) {
-    setPending(null)
-  }
-  const bridged = pending !== null && pending.path === path
-  const published = bridged || (row?.gistUrl ?? null) !== null
-  const stale = !bridged && (row?.gistStale ?? false)
+  const published = optimistic || (row?.gistUrl ?? null) !== null
+  // While the overlay still stands in for a not-yet-indexed publish, don't nudge
+  // "stale": the index reflects the pre-publish body for one more watcher
+  // round-trip. The overlay is url-only — it never waits on `gist_stale`, so a
+  // body edited right after publishing can't pin the nudge shut.
+  const stale = !optimistic && (row?.gistStale ?? false)
 
   if (!connected || row?.isPrivate === true) {
     return null
@@ -66,10 +53,7 @@ export function NoteGistAction({ path, keybinding = null }: NoteGistActionProps)
     }
     setIsPublishing(true)
     try {
-      const url = await runGistPublish(path, generation)
-      if (url !== null) {
-        setPending({ path, url })
-      }
+      await runGistPublish(path, generation)
     } finally {
       setIsPublishing(false)
     }

--- a/apps/desktop/src/editor/note-session.test.ts
+++ b/apps/desktop/src/editor/note-session.test.ts
@@ -345,6 +345,18 @@ describe('frontmatter ownership (Plan 07b)', () => {
     expect(h.snapshots.at(-1)?.dirty).toBe(false)
   })
 
+  it('commitFrontmatter declines when the session has no write channel', async () => {
+    // No graph generation → no `io.write`. The patch can't land, so report
+    // false rather than the in-memory success that would let publish/pin/private
+    // skip their disk fallback and treat an unwritten flag as persisted.
+    const h = harness({ disk: '# Hello\n', write: false })
+    h.session.load()
+    await vi.runAllTimersAsync()
+
+    await expect(h.session.commitFrontmatter({ pinned: true })).resolves.toBe(false)
+    expect(h.writes).toEqual([])
+  })
+
   it('commitFrontmatter under a parked conflict writes through and refreshes the park', async () => {
     const h = harness()
     h.session.load()

--- a/apps/desktop/src/editor/note-session.ts
+++ b/apps/desktop/src/editor/note-session.ts
@@ -166,8 +166,12 @@ export interface FrontmatterPatch {
   gist?: GistFrontmatter
 }
 
-/** Translate the typed patch into the YAML write (`undefined` deletes a key). */
-function yamlPatch(patch: FrontmatterPatch): Record<string, unknown> {
+/**
+ * Translate the typed patch into the YAML write (`undefined` deletes a key).
+ * Exported so the disk-fallback write (`commitNoteFrontmatter`) encodes a flag
+ * byte-for-byte the same way the live session does — one translation, no drift.
+ */
+export function frontmatterPatchToYaml(patch: FrontmatterPatch): Record<string, unknown> {
   const yaml: Record<string, unknown> = {}
   if (patch.aliases !== undefined) {
     yaml.aliases = patch.aliases
@@ -608,7 +612,7 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
     if (disposed || isProtected || status !== 'ready') {
       return false
     }
-    header = splitDoc(upsertFrontmatter(header + buffer, yamlPatch(patch))).header
+    header = splitDoc(upsertFrontmatter(header + buffer, frontmatterPatchToYaml(patch))).header
     dirty = header + buffer !== disk
     emit()
     if (dirty) {
@@ -618,6 +622,13 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
   }
 
   async function commitFrontmatter(patch: FrontmatterPatch): Promise<boolean> {
+    // No write channel (no graph generation yet) means the patch can't land —
+    // say so, rather than riding `updateFrontmatter`'s in-memory success while
+    // `save()` silently no-ops. A `true` here would let publish/pin/private
+    // skip their disk fallback and treat an unwritten flag as persisted.
+    if (io.write === null) {
+      return false
+    }
     if (!updateFrontmatter(patch)) {
       return false
     }
@@ -630,14 +641,12 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
     // content and write it through. The park refreshes in place, so "load
     // theirs" adopts the patched bytes, and recording the write in `disk`
     // makes the watcher's echo a recognized no-op.
-    if (io.write !== null) {
-      const patched = upsertFrontmatter(conflict, yamlPatch(patch))
-      if (patched !== conflict) {
-        await io.write(path, patched)
-        conflict = patched
-        disk = patched
-        emit()
-      }
+    const patched = upsertFrontmatter(conflict, frontmatterPatchToYaml(patch))
+    if (patched !== conflict) {
+      await io.write(path, patched)
+      conflict = patched
+      disk = patched
+      emit()
     }
     return true
   }

--- a/apps/desktop/src/hooks/note-row-overlay.test.ts
+++ b/apps/desktop/src/hooks/note-row-overlay.test.ts
@@ -1,0 +1,90 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { NoteRow } from '@reflect/core'
+import {
+  applyNoteRowOverlay,
+  reconcileNoteRowOverlay,
+  resetNoteRowOverlays,
+  setNoteRowOverlay,
+  useNoteRowOverlay,
+} from './note-row-overlay'
+
+function noteRow(overrides: Partial<NoteRow> = {}): NoteRow {
+  return {
+    path: 'notes/a.md',
+    title: 'A',
+    dailyDate: null,
+    isPrivate: false,
+    hasConflict: false,
+    gistUrl: null,
+    gistStale: false,
+    ...overrides,
+  }
+}
+
+const URL = 'https://gist.github.com/alex/g1'
+
+beforeEach(() => {
+  resetNoteRowOverlays()
+})
+afterEach(() => {
+  resetNoteRowOverlays()
+})
+
+describe('applyNoteRowOverlay', () => {
+  it('merges overlay fields over the row', () => {
+    expect(applyNoteRowOverlay(noteRow(), { gistUrl: URL })?.gistUrl).toBe(URL)
+  })
+
+  it('passes a null row through — the overlay only sharpens an existing row', () => {
+    expect(applyNoteRowOverlay(null, { gistUrl: URL })).toBeNull()
+  })
+
+  it('returns the same row reference when there is no overlay', () => {
+    const row = noteRow({ gistUrl: 'kept' })
+    expect(applyNoteRowOverlay(row, null)).toBe(row)
+  })
+})
+
+describe('useNoteRowOverlay', () => {
+  it('reflects a set overlay and scopes it to the path', () => {
+    const { result } = renderHook(() => useNoteRowOverlay('notes/a.md'))
+    const other = renderHook(() => useNoteRowOverlay('notes/b.md'))
+    expect(result.current).toBeNull()
+
+    act(() => setNoteRowOverlay('notes/a.md', { gistUrl: URL }))
+    expect(result.current?.gistUrl).toBe(URL)
+    expect(other.result.current).toBeNull()
+  })
+})
+
+describe('reconcileNoteRowOverlay', () => {
+  it('holds the overlay while the index still lags, retires it once they agree', () => {
+    const { result } = renderHook(() => useNoteRowOverlay('notes/a.md'))
+    act(() => setNoteRowOverlay('notes/a.md', { gistUrl: URL }))
+
+    act(() => reconcileNoteRowOverlay('notes/a.md', noteRow({ gistUrl: null })))
+    expect(result.current?.gistUrl).toBe(URL) // index hasn't caught up
+
+    act(() => reconcileNoteRowOverlay('notes/a.md', noteRow({ gistUrl: URL })))
+    expect(result.current).toBeNull() // index agrees → retired
+  })
+
+  it('holds the overlay against a null row (nothing to compare yet)', () => {
+    const { result } = renderHook(() => useNoteRowOverlay('notes/a.md'))
+    act(() => setNoteRowOverlay('notes/a.md', { gistUrl: URL }))
+    act(() => reconcileNoteRowOverlay('notes/a.md', null))
+    expect(result.current?.gistUrl).toBe(URL)
+  })
+})
+
+describe('resetNoteRowOverlays', () => {
+  it('drops every overlay (e.g. on a graph switch)', () => {
+    const { result } = renderHook(() => useNoteRowOverlay('notes/a.md'))
+    act(() => setNoteRowOverlay('notes/a.md', { gistUrl: URL }))
+    expect(result.current?.gistUrl).toBe(URL)
+
+    act(() => resetNoteRowOverlays())
+    expect(result.current).toBeNull()
+  })
+})

--- a/apps/desktop/src/hooks/note-row-overlay.ts
+++ b/apps/desktop/src/hooks/note-row-overlay.ts
@@ -1,0 +1,114 @@
+import { useCallback, useSyncExternalStore } from 'react'
+import type { NoteRow } from '@reflect/core'
+
+/**
+ * The optimistic read overlay for note index rows (Plan 12 follow-up).
+ *
+ * The index lags an in-app frontmatter write by one watcher round-trip, so a
+ * just-published note would briefly read as unpublished. Rather than each
+ * surface (the gist action, the published-URL section, …) carrying its own
+ * pending-state "bridge" — three near-duplicates, one of them with a
+ * precedence bug — the optimism lives **once, in the read model**: an action
+ * records what it just wrote, {@link useNoteRow} merges it over the index row,
+ * and it retires the moment the index agrees. Every reader of `useNoteRow`
+ * sees a single consistent value, so there is no second value to disagree.
+ *
+ * Module-level state, keyed by graph-relative path. Deliberately narrow — only
+ * the projections an action flips and then waits to observe. Cleared on graph
+ * switch ({@link resetNoteRowOverlays}) so an overlay can never bleed across
+ * graphs that share a note path.
+ */
+
+/**
+ * Index-row fields an action may assert ahead of the re-index. `gistUrl` is the
+ * only one today (publishing always yields a concrete URL — never `null`, so a
+ * publish can't be optimistically "unpublished"). `gistStale` is intentionally
+ * absent: a body edited right after publishing keeps it `true`, which would
+ * pin the overlay open forever and mute the republish nudge.
+ */
+export interface NoteRowOverlay {
+  readonly gistUrl?: string
+}
+
+const overlays = new Map<string, NoteRowOverlay>()
+const listeners = new Set<() => void>()
+
+function emit(): void {
+  for (const listener of listeners) {
+    listener()
+  }
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/**
+ * Record an optimistic patch for `path`, reflected by every `useNoteRow(path)`
+ * reader until the index row catches up. Merges with any existing patch.
+ */
+export function setNoteRowOverlay(path: string, patch: NoteRowOverlay): void {
+  overlays.set(path, { ...overlays.get(path), ...patch })
+  emit()
+}
+
+/**
+ * Drop overlay fields the freshly-read index `row` has caught up to (and the
+ * whole entry once nothing is left). Called from {@link useNoteRow} in an
+ * effect, never during render. A `null` row (note not indexed yet) has nothing
+ * to reconcile against, so the overlay is held.
+ */
+export function reconcileNoteRowOverlay(path: string, row: NoteRow | null): void {
+  const overlay = overlays.get(path)
+  if (overlay === undefined || row === null) {
+    return
+  }
+  const remaining: { -readonly [Key in keyof NoteRowOverlay]: NoteRowOverlay[Key] } = {}
+  let retired = false
+  for (const key of Object.keys(overlay) as (keyof NoteRowOverlay)[]) {
+    if (row[key] === overlay[key]) {
+      retired = true
+    } else {
+      remaining[key] = overlay[key]
+    }
+  }
+  if (!retired) {
+    return
+  }
+  if (Object.keys(remaining).length === 0) {
+    overlays.delete(path)
+  } else {
+    overlays.set(path, remaining)
+  }
+  emit()
+}
+
+/** Drop every overlay — the active graph changed, so prior optimism is moot. */
+export function resetNoteRowOverlays(): void {
+  if (overlays.size === 0) {
+    return
+  }
+  overlays.clear()
+  emit()
+}
+
+/**
+ * Merge an overlay over an index row. The overlay only sharpens an existing
+ * row; with no row there is nothing to display yet (a publish targets an
+ * already-indexed note), so `null` passes through.
+ */
+export function applyNoteRowOverlay(row: NoteRow | null, overlay: NoteRowOverlay | null): NoteRow | null {
+  if (row === null || overlay === null) {
+    return row
+  }
+  return { ...row, ...overlay }
+}
+
+/** Subscribe a component to `path`'s overlay; `null` when none is pending. */
+export function useNoteRowOverlay(path: string): NoteRowOverlay | null {
+  const getSnapshot = useCallback(() => overlays.get(path) ?? null, [path])
+  return useSyncExternalStore(subscribe, getSnapshot)
+}

--- a/apps/desktop/src/hooks/use-note-row.ts
+++ b/apps/desktop/src/hooks/use-note-row.ts
@@ -1,14 +1,22 @@
+import { useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { getNote, hasBridge, type NoteRow } from '@reflect/core'
+import {
+  applyNoteRowOverlay,
+  reconcileNoteRowOverlay,
+  useNoteRowOverlay,
+} from '@/hooks/note-row-overlay'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
 
 /**
  * One note's index row by graph-relative path, kept fresh by the usual index
  * invalidation (a frontmatter write lands in the file, the watcher re-indexes
- * it, the query refetches). `null` while loading or when the note has no
- * indexed file yet — the lazy contract means a visible note can predate its
- * row. Powers per-note state like the private flag.
+ * it, the query refetches) and made *immediately* consistent with an in-app
+ * write by the optimistic {@link useNoteRowOverlay}: an action records what it
+ * just wrote, this hook merges it over the index row, and the overlay retires
+ * once the index agrees. `null` while loading or when the note has no indexed
+ * file yet — the lazy contract means a visible note can predate its row.
  */
 export function useNoteRow(path: string): NoteRow | null {
   const { graph } = useGraph()
@@ -17,5 +25,17 @@ export function useNoteRow(path: string): NoteRow | null {
     queryFn: async () => (await getNote(path)) ?? null,
     enabled: hasBridge() && graph !== null,
   })
-  return data ?? null
+  const row = data ?? null
+  const overlay = useNoteRowOverlay(path)
+
+  // Retire the overlay once the index reports the same value. An effect, not a
+  // render-time mutation: the store is shared, and writing it during render
+  // would tear other subscribers.
+  useEffect(() => {
+    if (overlay !== null) {
+      reconcileNoteRowOverlay(path, row)
+    }
+  }, [path, overlay, row])
+
+  return applyNoteRowOverlay(row, overlay)
 }

--- a/apps/desktop/src/lib/note-frontmatter.test.ts
+++ b/apps/desktop/src/lib/note-frontmatter.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NoteSession } from '@/editor/note-session'
+
+const readNote = vi.hoisted(() => vi.fn<(path: string) => Promise<string>>())
+const writeNote = vi.hoisted(() => vi.fn(async () => {}))
+const openSession = vi.hoisted(() => vi.fn<(path: string) => NoteSession | null>(() => null))
+
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  readNote,
+  writeNote,
+}))
+vi.mock('@/editor/open-documents', () => ({ openSession }))
+
+const { commitNoteFrontmatter, readNoteSource } = await import('./note-frontmatter')
+
+function fakeSession(options: { live?: string | null; canCommit?: boolean }) {
+  const commitFrontmatter = vi.fn(async () => options.canCommit ?? true)
+  const session = {
+    liveContent: () => options.live ?? null,
+    commitFrontmatter,
+  } as unknown as NoteSession
+  return { session, commitFrontmatter }
+}
+
+beforeEach(() => {
+  readNote.mockReset()
+  writeNote.mockClear()
+  openSession.mockReset().mockReturnValue(null)
+})
+
+describe('readNoteSource', () => {
+  it("reads the open session's loaded buffer, not disk", async () => {
+    openSession.mockReturnValue(fakeSession({ live: '# live\n' }).session)
+    await expect(readNoteSource('notes/a.md')).resolves.toBe('# live\n')
+    expect(readNote).not.toHaveBeenCalled()
+  })
+
+  it('falls back to disk while the session is still loading (liveContent null)', async () => {
+    openSession.mockReturnValue(fakeSession({ live: null }).session)
+    readNote.mockResolvedValue('# disk\n')
+    await expect(readNoteSource('notes/a.md')).resolves.toBe('# disk\n')
+  })
+
+  it('reads disk when no session is open', async () => {
+    readNote.mockResolvedValue('# disk\n')
+    await expect(readNoteSource('notes/a.md')).resolves.toBe('# disk\n')
+  })
+})
+
+describe('commitNoteFrontmatter', () => {
+  it('lands the patch through the live session when it can take it', async () => {
+    const { session, commitFrontmatter } = fakeSession({ live: '# A\n', canCommit: true })
+    openSession.mockReturnValue(session)
+
+    await commitNoteFrontmatter('notes/a.md', { pinned: true }, 3)
+
+    expect(commitFrontmatter).toHaveBeenCalledWith({ pinned: true })
+    expect(writeNote).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a disk patch when the session declines the patch', async () => {
+    openSession.mockReturnValue(fakeSession({ live: '# A\n', canCommit: false }).session)
+    readNote.mockResolvedValue('# A\n')
+
+    await commitNoteFrontmatter('notes/a.md', { pinned: true }, 3)
+
+    expect(writeNote).toHaveBeenCalledWith('notes/a.md', '---\npinned: true\n---\n# A\n', 3)
+  })
+
+  it('patches disk directly when no session is open', async () => {
+    readNote.mockResolvedValue('# A\n')
+
+    await commitNoteFrontmatter('notes/a.md', { private: true }, 3)
+
+    expect(writeNote).toHaveBeenCalledWith('notes/a.md', '---\nprivate: true\n---\n# A\n', 3)
+  })
+
+  it('writes nothing when the patch changes nothing', async () => {
+    readNote.mockResolvedValue('---\npinned: true\n---\n# A\n')
+
+    await commitNoteFrontmatter('notes/a.md', { pinned: true }, 3)
+
+    expect(writeNote).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/note-frontmatter.ts
+++ b/apps/desktop/src/lib/note-frontmatter.ts
@@ -1,0 +1,50 @@
+import { upsertFrontmatter, writeNote } from '@reflect/core'
+import { frontmatterPatchToYaml, type FrontmatterPatch } from '@/editor/note-session'
+import { openSession } from '@/editor/open-documents'
+import { readNoteOrEmpty } from '@/lib/note-read'
+
+/**
+ * The single safe way to read and write a note's frontmatter from an in-app
+ * action (pin, private, gist publish). Each used to hand-roll the same
+ * session-or-disk dance; the two sharp edges live here once instead of three
+ * times:
+ *
+ * - **Reads** prefer the open session's *loaded* buffer, never a still-loading
+ *   one. A loading session reports `liveContent() === null` (its empty buffer
+ *   isn't the truth yet), so we fall back to disk rather than act on a
+ *   placeholder — the trap behind empty publishes and mis-read toggle states.
+ * - **Writes** go through the session when it can take the patch (so our own
+ *   write never parks a conflict under a dirty buffer), else a read-patch-write
+ *   on disk that a loading/clean session reconciles like any external edit.
+ *   Both encode the flag through {@link frontmatterPatchToYaml}, so a value
+ *   lands identically whichever channel wins.
+ */
+
+/**
+ * The note's current source, read from the freshest authoritative place: the
+ * open session's loaded buffer, or disk when no session has it loaded.
+ */
+export async function readNoteSource(path: string): Promise<string> {
+  return openSession(path)?.liveContent() ?? (await readNoteOrEmpty(path))
+}
+
+/**
+ * Land `patch` on the note's frontmatter, returning once it has persisted.
+ * Routes through the live session when one can take the patch; otherwise
+ * patches disk directly. A patch that changes nothing is a no-op.
+ */
+export async function commitNoteFrontmatter(
+  path: string,
+  patch: FrontmatterPatch,
+  generation: number,
+): Promise<void> {
+  const owner = openSession(path)
+  if (owner !== null && (await owner.commitFrontmatter(patch))) {
+    return
+  }
+  const onDisk = await readNoteOrEmpty(path)
+  const patched = upsertFrontmatter(onDisk, frontmatterPatchToYaml(patch))
+  if (patched !== onDisk) {
+    await writeNote(path, patched, generation)
+  }
+}

--- a/apps/desktop/src/lib/note-gist.test.ts
+++ b/apps/desktop/src/lib/note-gist.test.ts
@@ -50,9 +50,13 @@ beforeEach(() => {
   operationFail.mockClear()
 })
 
-function fakeSession(content: string, canCommit = true) {
+function fakeSession(content: string, canCommit = true, liveContent: string | null = content) {
   const commitFrontmatter = vi.fn(async () => canCommit)
-  const session = { content: () => content, commitFrontmatter } as unknown as NoteSession
+  const session = {
+    content: () => content,
+    liveContent: () => liveContent,
+    commitFrontmatter,
+  } as unknown as NoteSession
   return { session, commitFrontmatter }
 }
 
@@ -110,6 +114,23 @@ describe('publishNoteToGist', () => {
     openSession.mockReturnValue(session)
     readNote.mockResolvedValue(BODY)
     await publishNoteToGist('notes/a.md', 3)
+    expect(writeNote).toHaveBeenCalled()
+  })
+
+  it('reads disk, not the empty buffer, when the open session is still loading', async () => {
+    // liveContent === null means the buffer isn't the truth yet: publish must
+    // read the real body from disk, not publish an empty gist.
+    const { session } = fakeSession('', false, null)
+    openSession.mockReturnValue(session)
+    readNote.mockResolvedValue(BODY)
+
+    await publishNoteToGist('notes/a.md', 3)
+
+    expect(createGist).toHaveBeenCalledWith(
+      'tok',
+      { name: 'A.md', content: BODY },
+      expect.any(Function),
+    )
     expect(writeNote).toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/lib/note-gist.ts
+++ b/apps/desktop/src/lib/note-gist.ts
@@ -10,12 +10,10 @@ import {
   ReflectError,
   splitFrontmatter,
   updateGist,
-  upsertFrontmatter,
-  writeNote,
   type GistFrontmatter,
 } from '@reflect/core'
-import { openSession } from '@/editor/open-documents'
-import { readNoteOrEmpty } from '@/lib/note-read'
+import { setNoteRowOverlay } from '@/hooks/note-row-overlay'
+import { commitNoteFrontmatter, readNoteSource } from '@/lib/note-frontmatter'
 import { startOperation } from '@/lib/operations'
 import { providerFetch } from '@/lib/provider-fetch'
 
@@ -28,19 +26,18 @@ import { providerFetch } from '@/lib/provider-fetch'
  * one. The stored hash is of the body as published, so the indexer's
  * `gist_stale` reflects real edits, never the frontmatter write itself.
  *
- * Reads through the live session when the note is open and lands the
- * frontmatter through `commitFrontmatter`, exactly like the pin/private
- * toggles: a direct disk write under a dirty buffer would park a conflict
- * caused by our own action. With no live session (or one that can't take
- * patches), a read-patch-write on disk is reconciled like an external change.
+ * Reads and writes through the shared {@link readNoteSource} /
+ * {@link commitNoteFrontmatter} channel, exactly like the pin/private toggles:
+ * a direct disk write under a dirty buffer would park a conflict caused by our
+ * own action, and a still-loading session is read from disk rather than from
+ * its empty placeholder buffer.
  *
  * `private: true` is the hard block: the gate runs on the content actually
  * being published (live, not the possibly-lagging index), and it fails
  * closed before any byte leaves the device.
  */
 export async function publishNoteToGist(path: string, generation: number): Promise<string> {
-  const owner = openSession(path)
-  const source = owner !== null ? owner.content() : await readNoteOrEmpty(path)
+  const source = await readNoteSource(path)
   const parsed = parseNote({ path, source })
   assertCloudAllowed({ path, isPrivate: parsed.frontmatter.private })
 
@@ -75,10 +72,7 @@ export async function publishNoteToGist(path: string, generation: number): Promi
     hash: gistBodyHash(body),
   }
   try {
-    if (owner === null || !(await owner.commitFrontmatter({ gist }))) {
-      const onDisk = await readNoteOrEmpty(path)
-      await writeNote(path, upsertFrontmatter(onDisk, { gist }), generation)
-    }
+    await commitNoteFrontmatter(path, { gist }, generation)
   } catch (cause) {
     // The remote and local halves can't be atomic; compensate instead. A
     // *freshly created* gist with no local record would be orphaned (and
@@ -106,6 +100,10 @@ export async function publishNoteToGist(path: string, generation: number): Promi
  * (focus, permissions) gets its own failure line, never a phantom "publish
  * failed" for a gist that exists — or `null` when the publish failed
  * (already surfaced).
+ *
+ * On success it records the url in the optimistic note-row overlay, so every
+ * sidebar surface (the gist action's label, the Published URL section)
+ * reflects the publish immediately, before the watcher re-indexes the file.
  */
 export async function runGistPublish(path: string, generation: number): Promise<string | null> {
   const operation = startOperation('Publishing gist')
@@ -117,6 +115,7 @@ export async function runGistPublish(path: string, generation: number): Promise<
     return null
   }
   operation.done()
+  setNoteRowOverlay(path, { gistUrl: url })
   try {
     await navigator.clipboard.writeText(url)
     startOperation('Gist link copied').done()

--- a/apps/desktop/src/lib/note-pin.test.ts
+++ b/apps/desktop/src/lib/note-pin.test.ts
@@ -21,9 +21,13 @@ beforeEach(() => {
   openSession.mockReturnValue(null)
 })
 
-function fakeSession(content: string, canCommit = true) {
+function fakeSession(content: string, canCommit = true, liveContent: string | null = content) {
   const commitFrontmatter = vi.fn(async () => canCommit)
-  const session = { content: () => content, commitFrontmatter } as unknown as NoteSession
+  const session = {
+    content: () => content,
+    liveContent: () => liveContent,
+    commitFrontmatter,
+  } as unknown as NoteSession
   return { session, commitFrontmatter }
 }
 
@@ -72,10 +76,11 @@ describe('toggleNotePinned', () => {
   })
 
   it('pins a not-yet-created note by creating its file (the lazy contract)', async () => {
-    // ⌘O on a fresh daily whose pane session is still loading: the session
-    // can't take the patch and the file doesn't exist — a missing note reads
-    // as empty, and the pin write is what creates it.
-    const { session } = fakeSession('', false)
+    // ⌘O on a fresh daily whose pane session is still loading: `liveContent`
+    // is null (the buffer isn't the truth yet) so the read falls to disk, the
+    // session can't take the patch, and the file doesn't exist — a missing
+    // note reads as empty, and the pin write is what creates it.
+    const { session } = fakeSession('', false, null)
     openSession.mockReturnValue(session)
     readNote.mockRejectedValue({ kind: 'notFound', message: 'no such note' })
     await expect(toggleNotePinned('daily/2026-06-10.md', 3)).resolves.toBe(true)

--- a/apps/desktop/src/lib/note-pin.ts
+++ b/apps/desktop/src/lib/note-pin.ts
@@ -1,6 +1,5 @@
-import { isPinned, parseNote, upsertFrontmatter, writeNote } from '@reflect/core'
-import { openSession } from '@/editor/open-documents'
-import { readNoteOrEmpty } from '@/lib/note-read'
+import { isPinned, parseNote } from '@reflect/core'
+import { commitNoteFrontmatter, readNoteSource } from '@/lib/note-frontmatter'
 
 /**
  * Toggle a note's `pinned` frontmatter flag. Markdown is the source of truth:
@@ -9,29 +8,18 @@ import { readNoteOrEmpty } from '@/lib/note-read'
  * always clears any explicit `pinned: <order>`; toggling on writes a bare
  * `pinned: true` (the reorder UI, when it lands, is what writes orders).
  *
- * Routes through the live session whenever the note is open (the same liveness
- * contract as the rename coordinator's alias placement): a direct disk write
- * under a dirty buffer would park a conflict caused by our own action, and
- * "keep mine" would silently undo the pin. The session's `commitFrontmatter`
- * owns making the patch land immediately — parked-conflict handling included.
- * With no live session (or one that can't take patches), a read-patch-write on
- * disk is reconciled by any loading/clean session like an external change.
+ * Reads the current state and writes the flip through {@link readNoteSource} /
+ * {@link commitNoteFrontmatter} — the shared session-or-disk channel that keeps
+ * our own write from parking a conflict under a dirty buffer (and never reads a
+ * still-loading buffer). `pinned: false` deletes the key: unpinned is the
+ * absence of the flag, so a note whose only metadata was the pin returns to
+ * having no frontmatter at all.
  *
  * Returns the note's new pinned state.
  */
 export async function toggleNotePinned(path: string, generation: number): Promise<boolean> {
-  const owner = openSession(path)
-  if (owner !== null) {
-    const pinned = !isPinned(parseNote({ path, source: owner.content() }).frontmatter)
-    if (await owner.commitFrontmatter({ pinned })) {
-      return pinned
-    }
-  }
-  const content = await readNoteOrEmpty(path)
-  const pinned = !isPinned(parseNote({ path, source: content }).frontmatter)
-  const patched = upsertFrontmatter(content, { pinned: pinned ? true : undefined })
-  if (patched !== content) {
-    await writeNote(path, patched, generation)
-  }
+  const source = await readNoteSource(path)
+  const pinned = !isPinned(parseNote({ path, source }).frontmatter)
+  await commitNoteFrontmatter(path, { pinned }, generation)
   return pinned
 }

--- a/apps/desktop/src/lib/note-private.test.ts
+++ b/apps/desktop/src/lib/note-private.test.ts
@@ -21,9 +21,13 @@ beforeEach(() => {
   openSession.mockReturnValue(null)
 })
 
-function fakeSession(content: string, canCommit = true) {
+function fakeSession(content: string, canCommit = true, liveContent: string | null = content) {
   const commitFrontmatter = vi.fn(async () => canCommit)
-  const session = { content: () => content, commitFrontmatter } as unknown as NoteSession
+  const session = {
+    content: () => content,
+    liveContent: () => liveContent,
+    commitFrontmatter,
+  } as unknown as NoteSession
   return { session, commitFrontmatter }
 }
 
@@ -79,7 +83,8 @@ describe('toggleNotePrivate', () => {
   })
 
   it('marks a not-yet-created note private by creating its file (the lazy contract)', async () => {
-    const { session } = fakeSession('', false)
+    // Still-loading session: `liveContent` is null, so the read falls to disk.
+    const { session } = fakeSession('', false, null)
     openSession.mockReturnValue(session)
     readNote.mockRejectedValue({ kind: 'notFound', message: 'no such note' })
     await expect(toggleNotePrivate('daily/2026-06-10.md', 3)).resolves.toBe(true)

--- a/apps/desktop/src/lib/note-private.ts
+++ b/apps/desktop/src/lib/note-private.ts
@@ -1,6 +1,5 @@
-import { parseNote, upsertFrontmatter, writeNote } from '@reflect/core'
-import { openSession } from '@/editor/open-documents'
-import { readNoteOrEmpty } from '@/lib/note-read'
+import { parseNote } from '@reflect/core'
+import { commitNoteFrontmatter, readNoteSource } from '@/lib/note-frontmatter'
 
 /**
  * Toggle a note's `private` frontmatter flag — the hard block that keeps the
@@ -11,29 +10,18 @@ import { readNoteOrEmpty } from '@/lib/note-read'
  * index — no UI-side privacy state. Toggling off removes the key entirely:
  * not-private is the absence of the flag, and frontmatter stays minimal.
  *
- * Routes through the live session whenever the note is open, exactly like
- * `toggleNotePinned`: a direct disk write under a dirty buffer would
- * park a conflict caused by our own action, and "keep mine" would silently
- * undo the flag. The session's `commitFrontmatter` owns making the patch land
- * immediately — parked-conflict handling included. With no live session (or
- * one that can't take patches), a read-patch-write on disk is reconciled by
- * any loading/clean session like an external change.
+ * Reads the current state and writes the flip through {@link readNoteSource} /
+ * {@link commitNoteFrontmatter}, exactly like `toggleNotePinned`: the shared
+ * session-or-disk channel keeps our own write from parking a conflict under a
+ * dirty buffer (and never reads a still-loading buffer). Toggling off removes
+ * the key entirely — not-private is the absence of the flag, and frontmatter
+ * stays minimal.
  *
  * Returns the note's new private state.
  */
 export async function toggleNotePrivate(path: string, generation: number): Promise<boolean> {
-  const owner = openSession(path)
-  if (owner !== null) {
-    const isPrivate = !parseNote({ path, source: owner.content() }).frontmatter.private
-    if (await owner.commitFrontmatter({ private: isPrivate })) {
-      return isPrivate
-    }
-  }
-  const content = await readNoteOrEmpty(path)
-  const isPrivate = !parseNote({ path, source: content }).frontmatter.private
-  const patched = upsertFrontmatter(content, { private: isPrivate ? true : undefined })
-  if (patched !== content) {
-    await writeNote(path, patched, generation)
-  }
+  const source = await readNoteSource(path)
+  const isPrivate = !parseNote({ path, source }).frontmatter.private
+  await commitNoteFrontmatter(path, { private: isPrivate }, generation)
   return isPrivate
 }

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -23,6 +23,7 @@ import {
   type RecentGraph,
 } from '@reflect/core'
 import { followHealedMove } from '@/editor/move-note'
+import { resetNoteRowOverlays } from '@/hooks/note-row-overlay'
 import { invalidateIndexQueries } from '@/lib/query-client'
 import { ensureWelcomeNote } from '@/lib/welcome-note'
 import { useSettings } from '@/providers/settings-provider'
@@ -165,6 +166,9 @@ export function GraphProvider({
           // Rust index connection is swapped, so a stale pass can't write into
           // this graph's index.
           await index.stop()
+          // Drop optimistic note-row overlays from the prior graph: their paths
+          // may collide with this graph's, and their index never will.
+          resetNoteRowOverlays()
           // Open the index *before* 'ready' so reads can't hit the previous
           // graph's index. Best-effort: an index failure doesn't block editing.
           const generation = await index.open()


### PR DESCRIPTION
## What

Two commits:

1. **The reported bug** — the daily note's sidebar never showed the **Published URL** section. `DailyContextSidebar` rendered the gist publish action (via `NoteActionsSection`) but not `PublishedUrlSection`, unlike the regular note sidebar. Since Reflect opens to the daily note, publishing it succeeded but the link was never visible or copyable.

2. **The underlying design** — rather than just patch the symptom (or bolt on another per-feature optimistic "bridge"), the post-publish lag is fixed in the read model so this class of issue stops recurring.

## Why the deeper change

Pin, private, and gist-publish each hand-rolled the same two patterns, and that duplication is where the related bugs live:

- **Write side**: "open session → read `content()` → `commitFrontmatter` or fall back to `writeNote`" was copied three times. `content()` is empty while a session is still loading (→ publishing an empty gist / mis-reading a toggle), and `commitFrontmatter` returned `true` without writing when `io.write` was null (no graph generation yet), letting callers skip their disk fallback and treat an unwritten flag as persisted.
- **Read side**: every surface reinvented an optimistic bridge over the index's one-watcher-round-trip lag — `NoteToggleAction`'s, `NoteGistAction`'s, and (in the alternative PR #178) a global `published-url-bridge` whose `row?.gistUrl ?? pendingUrl` precedence could show a **stale/dead URL** after a republish.

## The abstraction

- **One write helper** — `lib/note-frontmatter.ts`: `readNoteSource` (uses `liveContent`, never a loading buffer) + `commitNoteFrontmatter` (session-or-disk, one YAML translation via the now-exported `frontmatterPatchToYaml`). Pin/private/gist all route through it.
- **`commitFrontmatter` returns `false` when `io.write === null`**, so an unwritten patch can't read as persisted.
- **Optimism moves into the read model** — `hooks/note-row-overlay.ts`: an action records what it just wrote, `useNoteRow` merges it over the index row, and it retires once the index agrees. Every `useNoteRow` consumer is optimistic for free, off **one** consistent value — so there's no second value to disagree (the stale-URL bug is structurally impossible), no per-component bridge, and no single-slot global. Cleared on graph switch so optimism can't bleed across graphs sharing a note path.

`NoteGistAction` drops its local `PendingPublish` bridge. `PublishedUrlSection` is unchanged — it already reads `useNoteRow`, and now shows a just-published URL instantly.

## Relationship to #178

#178 targets the same bug. It correctly found the two latent write-side bugs (fixed here too), but its read-side fix is a global single-slot `useSyncExternalStore` bridge that Cursor's bot flagged for a real stale-URL precedence bug. This PR puts the optimism in the read model instead, which removes the precedence ambiguity by construction and retires the per-feature bridges rather than adding another.

## Testing

- `pnpm typecheck` — clean
- `pnpm lint` — no new warnings
- `pnpm vitest --run` across context-sidebar, editor, providers, and the changed libs/hooks — 184+ passing, including new suites for the overlay store, the write helper, the `io.write` guard, and the loading-session read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a “Published URL” section to the daily context sidebar. When a daily note is published, users can view and open the published URL directly; the section hides when unpublished.

* **Bug Fixes**
  * Improved the gist/publish sidebar experience by reflecting the published URL immediately during optimistic updates, and refining the related stale/nudge behavior to match the new timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->