### PR TITLE
Fix macOS close button and restore inspector access (⌘⇧I)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -18,7 +18,9 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["protocol-asset"] }
+# `devtools` compiles the web inspector into release builds too (it is otherwise
+# debug-only), so a shipped app stays debuggable — see `src/devtools.rs`.
+tauri = { version = "2", features = ["protocol-asset", "devtools"] }
 tauri-plugin-opener = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
+    "core:window:allow-destroy",
     "opener:default",
     "dialog:default",
     {

--- a/apps/desktop/src-tauri/src/devtools.rs
+++ b/apps/desktop/src-tauri/src/devtools.rs
@@ -1,0 +1,25 @@
+//! Web-inspector access — debuggable in every build, not just `cargo dev`.
+//!
+//! Tauri compiles the inspector in automatically for debug builds but strips it
+//! from release builds unless the `tauri` crate's `devtools` feature is on (set
+//! in `Cargo.toml`). With it on, the methods below exist in release too, so a
+//! shipped app can always be opened up and debugged.
+//!
+//! The frontend binds ⌘⇧I to {@link toggle_devtools} (`@reflect/core`'s
+//! `toggleDevtools`); on macOS the webview's native ⌘⌥I and right-click
+//! "Inspect Element" work as well once the feature is compiled in.
+
+use tauri::WebviewWindow;
+
+/// Open the calling window's web inspector, or close it if it is already open.
+///
+/// A no-op-shaped command: it returns unit (serialized as `null`) so the typed
+/// binding can validate the response like any other IPC call.
+#[tauri::command]
+pub fn toggle_devtools(window: WebviewWindow) {
+    if window.is_devtools_open() {
+        window.close_devtools();
+    } else {
+        window.open_devtools();
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@
 
 mod capture;
 mod db;
+mod devtools;
 mod error;
 mod fs;
 mod git;
@@ -189,6 +190,7 @@ pub fn run() {
             git::git_merge_remote,
             git::git_push,
             quit::quit_confirm,
+            devtools::toggle_devtools,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -14,6 +14,8 @@ const toggleNotePinned = vi.hoisted(() => vi.fn(async () => true))
 const toggleNotePrivate = vi.hoisted(() => vi.fn(async () => true))
 const getNote = vi.hoisted(() => vi.fn<() => Promise<NoteRow | undefined>>(async () => undefined))
 const getPinnedNotes = vi.hoisted(() => vi.fn<() => Promise<PinnedNote[]>>(async () => []))
+const hasBridge = vi.hoisted(() => vi.fn(() => true))
+const toggleDevtools = vi.hoisted(() => vi.fn(async () => undefined))
 const operationFail = vi.hoisted(() => vi.fn())
 const startOperation = vi.hoisted(() =>
   vi.fn(() => ({ progress: vi.fn(), done: vi.fn(), fail: operationFail })),
@@ -35,6 +37,8 @@ vi.mock('@reflect/core', async (importOriginal) => ({
   embedStatus,
   getNote,
   getPinnedNotes,
+  hasBridge,
+  toggleDevtools,
 }))
 
 // Importing registers the commands (module side effect, like production).
@@ -92,6 +96,10 @@ describe('keybindingFor', () => {
 
   it('audioMemo.toggle is bound to Mod-Shift-r', () => {
     expect(keybindingFor('audioMemo.toggle')).toBe('Mod-Shift-r')
+  })
+
+  it('dev.toggleDevtools is bound to Mod-Shift-i', () => {
+    expect(keybindingFor('dev.toggleDevtools')).toBe('Mod-Shift-i')
   })
 })
 
@@ -219,6 +227,23 @@ describe('app commands', () => {
     const { context } = fakeContext({ route: () => ({ kind: 'note', path: 'notes/a.md' }) })
     await expect(command('note.togglePrivate').run(context)).resolves.toBeUndefined()
     expect(startOperation).toHaveBeenCalledWith('Unlocking note')
+  })
+
+  it('dev.toggleDevtools toggles the inspector through the native shell', async () => {
+    hasBridge.mockReturnValue(true)
+    toggleDevtools.mockClear()
+    const { context } = fakeContext()
+    await command('dev.toggleDevtools').run(context)
+    expect(toggleDevtools).toHaveBeenCalledTimes(1)
+  })
+
+  it('dev.toggleDevtools no-ops without a native shell (plain-browser dev)', async () => {
+    hasBridge.mockReturnValue(false)
+    toggleDevtools.mockClear()
+    const { context } = fakeContext()
+    await expect(command('dev.toggleDevtools').run(context)).resolves.toBeUndefined()
+    expect(toggleDevtools).not.toHaveBeenCalled()
+    hasBridge.mockReturnValue(true)
   })
 
   it('semantic.enable persists the opt-in through the context capability', async () => {

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -1,4 +1,11 @@
-import { errorMessage, getNote, getPinnedNotes, randomNotePath } from '@reflect/core'
+import {
+  errorMessage,
+  getNote,
+  getPinnedNotes,
+  hasBridge,
+  randomNotePath,
+  toggleDevtools,
+} from '@reflect/core'
 import { untitledNotePath } from '@/lib/create-note'
 import { todayIso } from '@/lib/dates'
 import { runGistPublish } from '@/lib/note-gist'
@@ -209,6 +216,26 @@ const APP_COMMANDS: AppCommand[] = [
         return
       }
       await rebuildIndexVisibly(generation)
+    },
+  },
+  {
+    id: 'dev.toggleDevtools',
+    title: 'Developer tools',
+    keywords: ['devtools', 'inspector', 'debug', 'console', 'inspect', 'web inspector'],
+    // The web inspector ships in every build (see `src-tauri/src/devtools.rs`),
+    // so users can always debug. Plain-browser dev has no native shell — and its
+    // own DevTools — so this no-ops there rather than throwing through the
+    // bridge. Errors are swallowed: a debug affordance never interrupts the user.
+    keybinding: 'Mod-Shift-i',
+    run: async () => {
+      if (!hasBridge()) {
+        return
+      }
+      try {
+        await toggleDevtools()
+      } catch {
+        // Best effort — opening the inspector is never worth a surfaced failure.
+      }
     },
   },
 ]

--- a/apps/desktop/src/lib/native-menu/menu.ts
+++ b/apps/desktop/src/lib/native-menu/menu.ts
@@ -99,6 +99,8 @@ export function appMenuLayout(): AppSubmenuLayout[] {
         command('history.forward'),
         separator(),
         command('sidebar.toggle'),
+        separator(),
+        command('dev.toggleDevtools'),
       ],
     },
     {

--- a/packages/core/src/app/devtools.ts
+++ b/packages/core/src/app/devtools.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+import { call } from '../ipc/invoke'
+
+/**
+ * Toggle the native web inspector for the calling window — open it, or close it
+ * if it is already open.
+ *
+ * The Rust shell compiles the inspector into every build (debug and release; see
+ * `apps/desktop/src-tauri/src/devtools.rs`), so a shipped app stays debuggable.
+ * Hosts without a native shell (plain-browser dev) have no inspector to toggle;
+ * callers gate on `hasBridge()` before invoking.
+ */
+export function toggleDevtools(): Promise<void> {
+  return call('toggle_devtools', {}, z.null()).then(() => undefined)
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export {
   type AppPlatform,
 } from './ipc/commands'
 export { confirmQuit, subscribeQuitRequested } from './app/quit'
+export { toggleDevtools } from './app/devtools'
 
 // Embeddings & retrieval (Plan 09)
 export { chunkNote, type NoteChunk } from './embeddings/chunk'


### PR DESCRIPTION
## Summary

Two desktop-shell fixes, both rooted in native capabilities the app no longer had.

### 1. The macOS red close button did nothing

`quit-flush.ts` registers a JS `onCloseRequested` listener (to flush dirty note buffers before the webview dies). The moment that listener exists, Tauri's core calls `api.prevent_close()` — the OS no longer closes the window, and Tauri's JS wrapper becomes responsible for calling `window.destroy()` itself after the handler resolves.

But `destroy()` invokes `plugin:window|destroy`, which requires `core:window:allow-destroy`. The capability only granted `core:window:default` (a **getters-only** set) plus `allow-start-dragging`, so `destroy()` rejected with a permission error and the window silently stayed open.

This is why *only* the close button was affected:
- **Minimize / zoom** are pure-native button actions with no JS interception → worked.
- **⌘Q** takes the Rust `ExitRequested` → `app:quit-requested` → `quit_confirm` path, which needs no window permission → worked.

**Fix:** grant `core:window:allow-destroy` in `capabilities/default.json` (mirroring how `allow-start-dragging` was already added for the same reason).

### 2. ⌘⇧I no longer opened the inspector

Two gaps:
- Release builds had the inspector **compiled out** — Tauri auto-enables devtools for debug builds but strips them from release unless the `tauri` crate's `devtools` feature is set.
- There was **never a JS-bound inspector shortcut**. WKWebView's native default is ⌘⌥I (Option, not Shift) and is debug-only.

Users should always be able to debug a shipped app, so:
- Enable the `tauri` **`devtools` feature** → inspector ships in release, and native ⌘⌥I / right-click "Inspect Element" return as fallbacks.
- Add a Rust `toggle_devtools` command (`src-tauri/src/devtools.rs`).
- Expose it via `@reflect/core`'s typed `toggleDevtools()` binding.
- Bind `dev.toggleDevtools` (⌘⇧I, "Developer tools") through the existing command registry — so it also appears in the ⌘K palette, the ⌘/ cheat-sheet, and the **View** menu. Guarded by `hasBridge()` so plain-browser dev no-ops.

## Reviewer notes

- **Both fixes are build-time changes** (a capability grant and a Cargo feature). They take effect on rebuild (`pnpm tauri dev` / `tauri build`), **not** a webview hot-reload.
- App-defined commands need no ACL grant (same as the existing `git_*` / `quit_confirm` commands), so `toggle_devtools` adds nothing to capabilities.
- The `devtools` feature is enabled **intentionally for release** — shipped apps stay debuggable. Please don't read it as an oversight.
- `Cargo.lock` is unchanged (the inspector code already lives in the compiled tauri/wry deps).

## Testing

- `pnpm exec vitest run` on `app-commands.test.ts` (added bound-key + bridged/non-bridged cases) and `menu.test.ts` — 25 pass.
- `pnpm typecheck` — all packages clean.
- `pnpm lint` — clean for changed files.
- `cargo check -p reflect-open` — compiles clean with the `devtools` feature and new command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop-shell capability and debug affordance only; no auth, data, or business-logic changes. Intentionally ships devtools in release for field debugging.
> 
> **Overview**
> Fixes the **macOS red close button** doing nothing after the app started intercepting close to flush dirty notes: grants **`core:window:allow-destroy`** so the frontend can call `window.destroy()` once flush completes (previously blocked by Tauri ACL).
> 
> Restores **web inspector access in shipped builds** by enabling Tauri’s **`devtools` feature**, adding a **`toggle_devtools`** Rust command, **`toggleDevtools()`** in `@reflect/core`, and a **`dev.toggleDevtools`** app command (**⌘⇧I**) wired into the palette, shortcuts, and **View** menu. The command no-ops in plain-browser dev via `hasBridge()` and swallows IPC errors so debugging never surfaces failures to users.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c257e8af9bca75436ab83690f9f2ceec2ca707cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->