### PR TITLE
Fix index rebuild dropping notes with astral characters

### DIFF
--- a/apps/desktop/src/lib/rebuild-index.ts
+++ b/apps/desktop/src/lib/rebuild-index.ts
@@ -38,7 +38,13 @@ async function runRebuild(generation: number): Promise<void> {
   try {
     await rebuildIndex({
       generation,
-      onSkippedNote: (note) => skippedNotes.push(`${note.path}: ${note.message}`),
+      onSkippedNote: (note) => {
+        // The status toast lingers only briefly and samples the first few, so
+        // log every skip in full — this is the durable record of which notes
+        // fell out of the index and why.
+        console.warn(`Index rebuild skipped ${note.path}: ${note.message}`)
+        skippedNotes.push(`${note.path}: ${note.message}`)
+      },
     })
     if (skippedNotes.length === 0) {
       operation.done()

--- a/packages/core/src/indexing/snippet.test.ts
+++ b/packages/core/src/indexing/snippet.test.ts
@@ -1,6 +1,23 @@
 import { describe, expect, it } from 'vitest'
 import { lineSnippet, previewSnippet } from './snippet'
 
+/** True when `text` contains a UTF-16 surrogate without its pair. */
+function hasLoneSurrogate(text: string): boolean {
+  for (let index = 0; index < text.length; index++) {
+    const code = text.charCodeAt(index)
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = text.charCodeAt(index + 1)
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true
+      }
+      index++
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true
+    }
+  }
+  return false
+}
+
 describe('lineSnippet', () => {
   it('returns the whole line containing the position', () => {
     const content = 'first line\nsee [[Target]] here\nlast line\n'
@@ -70,6 +87,23 @@ describe('previewSnippet', () => {
     const long = 'x'.repeat(200)
     const snippet = previewSnippet(long, 'Title', 50)
     expect(snippet).toBe(`${'x'.repeat(50)}…`)
+  })
+
+  it('never splits an astral character at the truncation boundary', () => {
+    // 𝐒 (U+1D5D2) is a surrogate pair; a raw slice(0, 50) would cut it in half
+    // and leave a lone high surrogate the Rust index writer's serde_json
+    // rejects ("unexpected end of hex escape"), dropping the note from the index.
+    const text = `${'x'.repeat(49)}𝐒𝐏𝐈𝐍 the rest is dropped`
+    const snippet = previewSnippet(text, 'Title', 50)
+    expect(hasLoneSurrogate(snippet)).toBe(false)
+    expect(snippet).toBe(`${'x'.repeat(49)}…`)
+  })
+
+  it('keeps a whole astral character that fits within the limit', () => {
+    const text = `${'x'.repeat(48)}𝐒 spilling well past the cap to force a cut`
+    const snippet = previewSnippet(text, 'Title', 50)
+    expect(hasLoneSurrogate(snippet)).toBe(false)
+    expect(snippet).toBe(`${'x'.repeat(48)}𝐒…`)
   })
 
   it('returns empty for empty or title-only text', () => {

--- a/packages/core/src/indexing/snippet.ts
+++ b/packages/core/src/indexing/snippet.ts
@@ -8,6 +8,23 @@
 const DEFAULT_MAX_LENGTH = 160
 const PREVIEW_MAX_LENGTH = 120
 
+/**
+ * `text.slice(0, maxLength)` that never ends on a lone UTF-16 high surrogate.
+ * A raw code-unit slice can cut an astral character — an emoji, or the
+ * mathematical-alphanumeric letters people paste from Twitter — in half,
+ * leaving a dangling high surrogate. That half-character survives `JSON.stringify`
+ * as a lone `\udXXX`, which the Rust index writer's serde_json rejects with
+ * "unexpected end of hex escape", and the whole note is dropped from the rebuilt
+ * index. Trimming the orphaned surrogate keeps the slice a single code unit
+ * shorter and always well-formed.
+ */
+function sliceWithoutSplittingSurrogate(text: string, maxLength: number): string {
+  const end = Math.min(maxLength, text.length)
+  const lastCode = text.charCodeAt(end - 1)
+  const isLoneHighSurrogate = lastCode >= 0xd800 && lastCode <= 0xdbff
+  return text.slice(0, isLoneHighSurrogate ? end - 1 : end)
+}
+
 /** The single line of `content` containing `pos`, windowed to `maxLength`. */
 export function lineSnippet(content: string, pos: number, maxLength = DEFAULT_MAX_LENGTH): string {
   const at = Math.max(0, Math.min(pos, content.length))
@@ -57,5 +74,7 @@ export function previewSnippet(
       body = body.slice(foldedTitle.length + 1)
     }
   }
-  return body.length <= maxLength ? body : `${body.slice(0, maxLength).trimEnd()}…`
+  return body.length <= maxLength
+    ? body
+    : `${sliceWithoutSplittingSurrogate(body, maxLength).trimEnd()}…`
 }


### PR DESCRIPTION
## Summary

Notes containing **astral-plane characters** (emoji, the mathematical-alphanumeric
letters people paste from Twitter, etc.) were silently dropped from the index on a
rebuild. In the `reflect-open-graph` corpus this skipped `daily/2024-01-04.md` and
`daily/2024-02-22.md`, surfacing as:

> Rebuilt with 2 skipped note(s): daily/2024-01-04.md: unexpected end of hex escape at line 1 column 1587; daily/2024-02-22.md: unexpected end of hex escape at line 1 column 2090

## Root cause

`previewSnippet` truncates the All-Notes preview with `body.slice(0, 120)` — a
UTF-16 **code-unit** slice. Astral characters are surrogate *pairs*; when offset
120 lands between the two halves, the slice keeps a **lone high surrogate**. That
half-character survives `JSON.stringify` as a lone `\udXXX`, and the Rust index
writer's `serde_json` rejects it (`unexpected end of hex escape`). The
`index_apply_batch` call fails, the batch is bisected down to the offending note,
and it gets skipped from the rebuilt index — so the note disappears from search,
links, and All Notes until the bad byte is removed by hand.

The codebase already knows this pitfall: `slug.ts` truncates via `[...str].slice()`
(code points) "never splitting a surrogate pair". `previewSnippet` was the one
hot-path truncation that didn't.

## Fix

- **`previewSnippet`** now truncates without splitting a surrogate pair — a small
  `sliceWithoutSplittingSurrogate` helper trims a dangling high surrogate so the
  preview is always well-formed UTF-16. Verified against both failing notes: the
  full serialized `IndexedNote` payload then contains zero lone surrogates and the
  preview ends cleanly on the complete glyphs (`…𝐒𝐞𝐥𝐟-𝐏𝐥𝐚𝐲 𝐟𝐈𝐧𝐞-𝐭𝐮𝐍…`).
- **Skipped-note logging**: every skip is now `console.warn`'d during a rebuild.
  The status toast lingers only ~8s and samples the first three; the console is now
  the durable record of which notes fell out of the index and why.

## Testing

- New regression tests in `snippet.test.ts` cover the boundary-split and
  fits-within-limit astral cases.
- `pnpm vitest run` — core indexing (snippet / indexed-note / pipeline, 40 tests)
  and desktop (rebuild-index-field / operations, 7 tests) all pass.
- `pnpm typecheck` and `pnpm lint` clean.

> Note: I couldn't get the running `tauri dev` webview to pick up the fix during
> this session (it kept executing stale in-memory JS even though vite was serving
> the patched module and after a manual reload), so the end-to-end rebuild was
> verified at the unit/serialization level rather than live. A fresh build should
> index both notes with 0 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized indexing preview truncation and observability; no auth, persistence, or API contract changes beyond fixing malformed preview strings.
> 
> **Overview**
> Fixes **silent index drops** during rebuild when a note’s All-Notes **preview** was truncated on a UTF-16 code-unit boundary and split an astral character (emoji, math letters, etc.). That produced malformed JSON (`unexpected end of hex escape`) and the Rust writer skipped the whole note.
> 
> **`previewSnippet`** now truncates via **`sliceWithoutSplittingSurrogate`**, backing off one code unit when the cut would leave a lone high surrogate, so indexed previews stay well-formed. Regression tests cover boundary-split and fits-within-limit astral cases.
> 
> **Desktop rebuild** logs **every** skipped note with **`console.warn`** in addition to the short status toast sample, so skips are easier to diagnose after the toast disappears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3476f32f01bf9faed3275026200155f3b8401eea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->