### PR TITLE
Swallow Tauri's benign unlisten() rejection in the IPC bridge

### DIFF
--- a/apps/desktop/src/lib/tauri-bridge.ts
+++ b/apps/desktop/src/lib/tauri-bridge.ts
@@ -9,7 +9,20 @@ import { setBridge, type IpcBridge } from '@reflect/core'
  */
 export const tauriBridge: IpcBridge = {
   invoke: (command, args) => invoke(command, args),
-  listen: (event, handler) => listen(event, (incoming) => handler(incoming.payload)),
+  listen: async (event, handler) => {
+    const unlisten = await listen(event, (incoming) => handler(incoming.payload))
+    return () => {
+      // Tauri types unlisten() as `() => void`, but at runtime it is async and
+      // can reject: its injected cleanup script reads `listeners[eventId].handlerId`
+      // unguarded, so tearing a listener down around the time its registration
+      // script lands throws "undefined is not an object" (tauri-apps/tauri#13746,
+      // still unguarded on Tauri's `dev`). Subscriptions that resolve after their
+      // owner has already unmounted hit this — see use-file-changes.ts. The
+      // teardown is benign, so swallow the rejection instead of letting it surface
+      // as an unhandled promise rejection.
+      void Promise.resolve(unlisten() as void | Promise<void>).catch(() => {})
+    }
+  },
 }
 
 /**


### PR DESCRIPTION
## What

Wraps the desktop `listen` bridge adapter ([tauri-bridge.ts](apps/desktop/src/lib/tauri-bridge.ts)) so the unlisten function it returns swallows the rejection Tauri's async unlisten can throw.

## Why

The macOS app console logged, during ordinary use (e.g. fast note-switching):

> Unhandled Promise Rejection: TypeError: undefined is not an object (evaluating 'listeners[eventId].handlerId')

This is an **upstream Tauri bug** ([tauri-apps/tauri#13746](https://github.com/tauri-apps/tauri/issues/13746)), not ours. Tauri's injected event-cleanup script reads `listeners[eventId].handlerId` without guarding that the specific `eventId` is still present:

```js
const listeners = (window['…'] || {})[event]
if (listeners) {                                   // only checks the event bucket
  window.__TAURI_INTERNALS__.unregisterCallback(listeners[eventId].handlerId)  // 💥 eventId may be undefined
}
```

When a listener is torn down around the time its async registration script lands, `listeners[eventId]` is `undefined` and it throws. Tauri types `UnlistenFn` as `() => void`, but at runtime it is `async` and returns a *rejecting* promise — so calling it fire-and-forget let the rejection escape as an unhandled promise rejection.

Two app-specific factors made this surface constantly:
- `index:changed` has many persistent subscribers (live indexing, embeddings, backup, capture, transcription, plus the per-note editor hook), so the event bucket is always populated while an individual `eventId` may not be — exactly the crash condition.
- [use-file-changes.ts](apps/desktop/src/lib/use-file-changes.ts) immediately calls `stop()` → `unlisten()` when a subscription resolves *after* its component unmounted. Fast note-switching hits this routinely.

I checked Tauri's latest `dev` branch — the script is **still unguarded there**, so upgrading Tauri does not fix it. The fix has to live on our side.

## Approach

The bridge's `listen` adapter is the single boundary every `index:changed` subscriber passes through, so wrapping it there fixes all of them at once and keeps `@reflect/core`'s `Unlisten = () => void` contract honest (the returned function genuinely returns void and never rejects):

```ts
return () => {
  void Promise.resolve(unlisten() as void | Promise<void>).catch(() => {})
}
```

## Reviewer notes

- **Accepted tradeoff:** because Tauri's script throws *before* its own `invoke('plugin:event|unlisten')`, that one teardown skips the Rust-side cleanup — a tiny listener leak bounded by window lifetime. Not cleanly fixable without patching Tauri; negligible in practice.
- Tests install their own in-memory bridge via `setBridge`, so this real-shell-only adapter has no test fixture and no test impact. `tsc --noEmit` and `oxlint` pass.

## Testing

Reload the app (full `tauri dev` restart is safest) and switch notes rapidly with the console open — the rejection no longer appears.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized adapter change at the IPC boundary; worst case is skipping one Rust-side unlisten when Tauri’s script already failed, with impact bounded to window lifetime.
> 
> **Overview**
> Fixes **unhandled promise rejections** in the macOS app when event listeners tear down during fast note-switching (and similar races).
> 
> The desktop **`tauriBridge.listen`** adapter now **awaits** Tauri’s `listen`, then returns an **`Unlisten`** that calls Tauri’s teardown via `Promise.resolve(...).catch(() => {})`. That keeps **`@reflect/core`’s `() => void` contract** while hiding a known upstream bug ([tauri-apps/tauri#13746](https://github.com/tauri-apps/tauri/issues/13746)) where async `unlisten` can throw when registration and cleanup overlap.
> 
> All IPC event subscribers go through this single boundary, so the change applies app-wide without touching individual hooks like **`use-file-changes.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a982bd88d2048aee578ab029d1157168ffa466f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->