### PR TITLE
Daily sidebar follows the focused day (+ re-apply overlay generation-scoping)

### DIFF
--- a/apps/desktop/src/components/command-palette/command-palette.test.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.test.tsx
@@ -83,6 +83,7 @@ function renderPalette(query: string, context?: Partial<CommandContext>) {
   const fullContext: CommandContext = {
     navigate,
     route: () => ({ kind: 'today' }),
+    notePath: () => null,
     back: vi.fn(),
     forward: vi.fn(),
     toggleTheme: vi.fn(),

--- a/apps/desktop/src/components/context-sidebar/note-gist-action.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-gist-action.test.tsx
@@ -77,20 +77,19 @@ describe('NoteGistAction', () => {
     expect(view.getByRole('button', { name: /Republish private link/ })).toBeTruthy()
   })
 
-  it('publishes on click and flips to Republish before the index catches up', async () => {
-    // The real publish records the url in the optimistic overlay; mirror that
-    // so the label flips off the overlay, ahead of any index refresh.
-    runGistPublish.mockImplementation(async (path) => {
-      setNoteRowOverlay(path, { gistUrl: 'https://gist.github.com/alex/g1' })
-      return 'https://gist.github.com/alex/g1'
-    })
+  it('publishes the open note on click', async () => {
     const view = renderAction()
     await userEvent.click(view.getByRole('button', { name: /Share with private link/ }))
-
     expect(runGistPublish).toHaveBeenCalledWith('notes/a.md', 7)
-    await waitFor(() => {
-      expect(view.getByRole('button', { name: /Republish private link/ })).toBeTruthy()
-    })
+  })
+
+  it('reflects an optimistic publish as Republish before the index catches up', () => {
+    // The overlay is what `runGistPublish` writes on success (its contract is
+    // covered in note-gist.test.ts); given one, the label flips without waiting
+    // on the index.
+    setNoteRowOverlay('notes/a.md', 7, { gistUrl: 'https://gist.github.com/alex/g1' })
+    const view = renderAction()
+    expect(view.getByRole('button', { name: /Republish private link/ })).toBeTruthy()
   })
 
   it('stays on Publish when the publish failed (already surfaced elsewhere)', async () => {
@@ -120,7 +119,7 @@ describe('NoteGistAction', () => {
     idle.unmount()
 
     // A fresh publish sits in the overlay: the nudge is held back.
-    setNoteRowOverlay('notes/a.md', { gistUrl: url })
+    setNoteRowOverlay('notes/a.md', 7, { gistUrl: url })
     const pending = renderAction()
     expect(accentIcon(pending)).toBeNull()
     pending.unmount()

--- a/apps/desktop/src/components/context-sidebar/note-gist-action.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-gist-action.tsx
@@ -32,7 +32,7 @@ export function NoteGistAction({ path, keybinding = null }: NoteGistActionProps)
   // `row` already reflects a just-published url (the optimistic overlay flows
   // through `useNoteRow`); the raw overlay tells us *that* a publish is still
   // catching up, which only `stale` needs.
-  const optimistic = useNoteRowOverlay(path)?.gistUrl != null
+  const optimistic = useNoteRowOverlay(path, graph?.generation)?.gistUrl != null
   const [isPublishing, setIsPublishing] = useState(false)
 
   const published = optimistic || (row?.gistUrl ?? null) !== null

--- a/apps/desktop/src/components/context-sidebar/sidebar-route.test.ts
+++ b/apps/desktop/src/components/context-sidebar/sidebar-route.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { contextSidebarTarget, contextTargetForFocus } from './sidebar-route'
+import { contextSidebarTarget } from './sidebar-route'
 
 const TODAY = '2026-06-09'
 
@@ -37,29 +37,5 @@ describe('contextSidebarTarget', () => {
   it('shows no context sidebar on search and settings routes', () => {
     expect(contextSidebarTarget({ kind: 'search', query: 'rust' }, TODAY)).toBeNull()
     expect(contextSidebarTarget({ kind: 'settings' }, TODAY)).toBeNull()
-  })
-})
-
-describe('contextTargetForFocus', () => {
-  const dailyTarget = { kind: 'daily', date: TODAY } as const
-
-  it('redirects a daily target to the focused day in the stream', () => {
-    expect(contextTargetForFocus(dailyTarget, '2026-06-01')).toEqual({
-      kind: 'daily',
-      date: '2026-06-01',
-    })
-  })
-
-  it('keeps the routed day when nothing in the stream is focused', () => {
-    expect(contextTargetForFocus(dailyTarget, null)).toEqual(dailyTarget)
-  })
-
-  it('never overrides a note target with a focused daily date', () => {
-    const noteTarget = { kind: 'note', path: 'notes/a.md' } as const
-    expect(contextTargetForFocus(noteTarget, '2026-06-01')).toEqual(noteTarget)
-  })
-
-  it('passes a null target through (no context sidebar)', () => {
-    expect(contextTargetForFocus(null, '2026-06-01')).toBeNull()
   })
 })

--- a/apps/desktop/src/components/context-sidebar/sidebar-route.test.ts
+++ b/apps/desktop/src/components/context-sidebar/sidebar-route.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { contextSidebarTarget } from './sidebar-route'
+import { contextSidebarTarget, contextTargetForFocus } from './sidebar-route'
 
 const TODAY = '2026-06-09'
 
@@ -37,5 +37,29 @@ describe('contextSidebarTarget', () => {
   it('shows no context sidebar on search and settings routes', () => {
     expect(contextSidebarTarget({ kind: 'search', query: 'rust' }, TODAY)).toBeNull()
     expect(contextSidebarTarget({ kind: 'settings' }, TODAY)).toBeNull()
+  })
+})
+
+describe('contextTargetForFocus', () => {
+  const dailyTarget = { kind: 'daily', date: TODAY } as const
+
+  it('redirects a daily target to the focused day in the stream', () => {
+    expect(contextTargetForFocus(dailyTarget, '2026-06-01')).toEqual({
+      kind: 'daily',
+      date: '2026-06-01',
+    })
+  })
+
+  it('keeps the routed day when nothing in the stream is focused', () => {
+    expect(contextTargetForFocus(dailyTarget, null)).toEqual(dailyTarget)
+  })
+
+  it('never overrides a note target with a focused daily date', () => {
+    const noteTarget = { kind: 'note', path: 'notes/a.md' } as const
+    expect(contextTargetForFocus(noteTarget, '2026-06-01')).toEqual(noteTarget)
+  })
+
+  it('passes a null target through (no context sidebar)', () => {
+    expect(contextTargetForFocus(null, '2026-06-01')).toBeNull()
   })
 })

--- a/apps/desktop/src/components/context-sidebar/sidebar-route.ts
+++ b/apps/desktop/src/components/context-sidebar/sidebar-route.ts
@@ -27,3 +27,21 @@ export function contextSidebarTarget(route: Route, today: string): ContextSideba
       return null
   }
 }
+
+/**
+ * Override a daily context target with the day currently focused in the daily
+ * stream, when there is one. The stream keeps one `daily/:date` route while
+ * focus moves between days, so the sidebar must describe the focused day, not
+ * the routed one. A non-daily target — or an unfocused stream (`null`) — passes
+ * through unchanged: there the routed subject is the right one (and `null` is
+ * the calendar-pick path, where focus stays out of the stream).
+ */
+export function contextTargetForFocus(
+  target: ContextSidebarTarget | null,
+  focusedDailyDate: string | null,
+): ContextSidebarTarget | null {
+  if (target?.kind === 'daily' && focusedDailyDate !== null) {
+    return { kind: 'daily', date: focusedDailyDate }
+  }
+  return target
+}

--- a/apps/desktop/src/components/context-sidebar/sidebar-route.ts
+++ b/apps/desktop/src/components/context-sidebar/sidebar-route.ts
@@ -27,21 +27,3 @@ export function contextSidebarTarget(route: Route, today: string): ContextSideba
       return null
   }
 }
-
-/**
- * Override a daily context target with the day currently focused in the daily
- * stream, when there is one. The stream keeps one `daily/:date` route while
- * focus moves between days, so the sidebar must describe the focused day, not
- * the routed one. A non-daily target — or an unfocused stream (`null`) — passes
- * through unchanged: there the routed subject is the right one (and `null` is
- * the calendar-pick path, where focus stays out of the stream).
- */
-export function contextTargetForFocus(
-  target: ContextSidebarTarget | null,
-  focusedDailyDate: string | null,
-): ContextSidebarTarget | null {
-  if (target?.kind === 'daily' && focusedDailyDate !== null) {
-    return { kind: 'daily', date: focusedDailyDate }
-  }
-  return target
-}

--- a/apps/desktop/src/components/daily-stream.test.tsx
+++ b/apps/desktop/src/components/daily-stream.test.tsx
@@ -1,11 +1,15 @@
-import { render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useEffect, useLayoutEffect, useState, type ReactElement, type ReactNode } from 'react'
 import { setBridge } from '@reflect/core'
+import {
+  FocusedDailyProvider,
+  useFocusedDailyDate,
+} from '@/providers/focused-daily-provider'
 import { RouterProvider, useRouter } from '@/routing/router'
 import { todayIso } from '@/lib/dates'
-import { createDayWindow, indexOfDate } from '@/lib/day-window'
+import { createDayWindow, dateAtIndex, indexOfDate } from '@/lib/day-window'
 import { DailyStream, ESTIMATED_DAY_HEIGHT } from './daily-stream'
 
 /**
@@ -171,6 +175,33 @@ describe('DailyStream', () => {
     const expected = indexOfDate(createDayWindow(today), today) * ESTIMATED_DAY_HEIGHT
     expect(commandsDuringLayout).toBeGreaterThanOrEqual(2)
     expect(scrollToSpy.mock.calls[commandsDuringLayout - 1][0]).toMatchObject({ top: expected })
+    view.unmount()
+  })
+
+  it('reports the focused day so the sidebar can follow it within the stream', () => {
+    const today = todayIso()
+    const dayWindow = createDayWindow(today)
+    let focused: string | null = 'unset'
+    function FocusProbe(): null {
+      focused = useFocusedDailyDate()
+      return null
+    }
+    const view = render(
+      <StreamProviders>
+        <FocusedDailyProvider>
+          <DailyStream targetDate={today} />
+          <FocusProbe />
+        </FocusedDailyProvider>
+      </StreamProviders>,
+    )
+
+    // Focus enters a stream row (the route is unchanged): the sidebar's day
+    // must move to that row's date, not stay on the routed day.
+    const row = view.container.querySelector('[data-index]') as HTMLElement
+    const date = dateAtIndex(dayWindow, Number(row.getAttribute('data-index')))
+    fireEvent.focusIn(row)
+
+    expect(focused).toBe(date)
     view.unmount()
   })
 

--- a/apps/desktop/src/components/daily-stream.tsx
+++ b/apps/desktop/src/components/daily-stream.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/lib/utils'
 import { useSettings } from '@/providers/settings-provider'
 import { useToday } from '@/lib/use-today'
 import { createDayWindow, dateAtIndex, indexOfDate } from '@/lib/day-window'
+import { useSetFocusedDailyDate } from '@/providers/focused-daily-provider'
 import { useRouter } from '@/routing/router'
 
 interface DailyStreamProps {
@@ -107,6 +108,11 @@ export function DailyStream({ targetDate }: DailyStreamProps): ReactElement {
     focusPending.current = null
   }, [])
 
+  // Report the day the user is editing to the context sidebar: the route stays
+  // on the day navigated to, but focus moves freely between stream rows, and the
+  // sidebar's note actions / published link must describe the focused day.
+  const setFocusedDailyDate = useSetFocusedDailyDate()
+
   // Re-anchor on every explicit arrival (`arrivalSeq` bumps even when ⌘D is
   // pressed while already on today — the router clears the entry's saved
   // offset for that case; `entryId` covers back/forward between entries whose
@@ -168,6 +174,9 @@ export function DailyStream({ targetDate }: DailyStreamProps): ReactElement {
               ref={virtualizer.measureElement}
               className="absolute inset-x-0"
               style={{ transform: `translateY(${item.start}px)` }}
+              // Focus entering this row (clicking its editor, tabbing in) makes
+              // it the day the sidebar describes.
+              onFocusCapture={() => setFocusedDailyDate(date)}
             >
               <section className="border-b border-border py-6">
                 {/* V1 renders the date as the note's H1-sized subject, with

--- a/apps/desktop/src/components/graph-workspace.tsx
+++ b/apps/desktop/src/components/graph-workspace.tsx
@@ -3,6 +3,7 @@ import type { GraphInfo } from '@reflect/core'
 import { PaletteProvider } from '@/components/command-palette/palette-provider'
 import { WorkspaceContent } from '@/components/workspace-content'
 import { AudioMemoProvider } from '@/providers/audio-memo-provider'
+import { FocusedDailyProvider } from '@/providers/focused-daily-provider'
 import { CaptureProvider } from '@/providers/capture-provider'
 import { ChatProvider } from '@/providers/chat-provider'
 import { ShortcutsProvider } from '@/providers/shortcuts-provider'
@@ -33,7 +34,11 @@ export function GraphWorkspace({ graph }: GraphWorkspaceProps): ReactElement {
               <AudioMemoProvider graph={graph}>
                 <CaptureProvider graph={graph}>
                   <ChatProvider graph={graph}>
-                    <WorkspaceContent graph={graph} />
+                    {/* Tracks the focused day in the daily stream so the right
+                        sidebar describes it, not just the routed day. */}
+                    <FocusedDailyProvider>
+                      <WorkspaceContent graph={graph} />
+                    </FocusedDailyProvider>
                   </ChatProvider>
                 </CaptureProvider>
               </AudioMemoProvider>

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -95,6 +95,7 @@ function renderSidebar(overrides?: Partial<CommandContext>, initialRoute?: Route
   const context: CommandContext = {
     navigate,
     route: () => ({ kind: 'today' }),
+    notePath: () => null,
     back: vi.fn(),
     forward: vi.fn(),
     toggleTheme: vi.fn(),

--- a/apps/desktop/src/components/workspace-content.tsx
+++ b/apps/desktop/src/components/workspace-content.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react'
+import { useLayoutEffect, type ReactElement } from 'react'
 import type { GraphInfo } from '@reflect/core'
 import { PanelLeft } from 'lucide-react'
 import { AppShell } from '@/components/app-shell'
@@ -8,6 +8,7 @@ import { DailyContextSidebar } from '@/components/context-sidebar/daily-context-
 import { NoteContextSidebar } from '@/components/context-sidebar/note-context-sidebar'
 import {
   contextSidebarTarget,
+  contextTargetForFocus,
   type ContextSidebarTarget,
 } from '@/components/context-sidebar/sidebar-route'
 import { EmbeddingsSync } from '@/components/embeddings-sync'
@@ -21,6 +22,10 @@ import { keybindingFor } from '@/lib/commands/app-commands'
 import { useToday } from '@/lib/use-today'
 import { cn } from '@/lib/utils'
 import { hasMacosTitleBarOverlay } from '@/lib/window-chrome'
+import {
+  useFocusedDailyDate,
+  useSetFocusedDailyDate,
+} from '@/providers/focused-daily-provider'
 import { useSidebar } from '@/providers/sidebar-provider'
 import { useAppShortcuts } from '@/routing/app-shortcuts'
 import { useRouter } from '@/routing/router'
@@ -60,10 +65,23 @@ export function WorkspaceContent({ graph }: WorkspaceContentProps): ReactElement
   // search/settings get none (AppShell omits the region when context is absent).
   const sidebarTarget = contextSidebarTarget(route, today)
 
+  // In the daily stream the route stays on the day you navigated to while focus
+  // moves between days. The sidebar follows the focused day, falling back to the
+  // routed day — which is also the calendar-pick path, where focus stays out of
+  // the stream. A new routed day resets focus tracking pre-paint, so the sidebar
+  // snaps to it immediately and only then tracks where focus lands.
+  const routeDailyDate = sidebarTarget?.kind === 'daily' ? sidebarTarget.date : null
+  const focusedDailyDate = useFocusedDailyDate()
+  const setFocusedDailyDate = useSetFocusedDailyDate()
+  useLayoutEffect(() => {
+    setFocusedDailyDate(null)
+  }, [routeDailyDate, setFocusedDailyDate])
+  const contextTarget = contextTargetForFocus(sidebarTarget, focusedDailyDate)
+
   return (
     <AppShell
       sidebar={collapsed ? undefined : <Sidebar graph={graph} context={commandContext} />}
-      context={contextSidebarFor(sidebarTarget)}
+      context={contextSidebarFor(contextTarget)}
     >
       <div className="relative flex h-full flex-col">
         {collapsed ? (

--- a/apps/desktop/src/components/workspace-content.tsx
+++ b/apps/desktop/src/components/workspace-content.tsx
@@ -66,13 +66,15 @@ export function WorkspaceContent({ graph }: WorkspaceContentProps): ReactElement
   const sidebarTarget = contextSidebarTarget(route, today)
 
   // In the daily stream the route stays on the day you navigated to while focus
-  // moves between days, so the sidebar follows the focused day (falling back to
-  // the routed day when focus is outside the stream — the calendar-pick path).
-  // Every navigation re-anchors the stream; reset focus tracking on the *same*
-  // signals (`arrivalSeq`/`entryId`), not on the routed date — re-targeting the
-  // current day (a calendar pick on it, ⌘D to today) re-anchors too and must
-  // snap the sidebar back to it. The reset runs pre-paint, so no stale focused
-  // day is shown before the stream re-focuses the target.
+  // moves between days, so the sidebar follows the last day focused in the
+  // stream. It deliberately *stays* on that day through transient focus moves
+  // (opening ⌘K, clicking a sidebar button) rather than flicking back to the
+  // routed day and out again — what restores the routed day is navigation, not
+  // blur. Reset on the same signals the stream re-anchors on (`arrivalSeq`/
+  // `entryId`), not the routed date, so re-targeting the current day (a calendar
+  // pick on it, ⌘D to today) snaps back too. With nothing focused yet it falls
+  // back to the routed day (also the post-navigation state). The reset runs
+  // pre-paint, so no stale day shows before the stream re-focuses the target.
   const focusedDailyDate = useFocusedDailyDate()
   const setFocusedDailyDate = useSetFocusedDailyDate()
   useLayoutEffect(() => {

--- a/apps/desktop/src/components/workspace-content.tsx
+++ b/apps/desktop/src/components/workspace-content.tsx
@@ -58,7 +58,7 @@ function contextSidebarFor(target: ContextSidebarTarget | null): ReactElement | 
  */
 export function WorkspaceContent({ graph }: WorkspaceContentProps): ReactElement {
   const { collapsed } = useSidebar()
-  const { route } = useRouter()
+  const { route, arrivalSeq, entryId } = useRouter()
   const commandContext = useAppShortcuts()
   const today = useToday()
   // Daily routes get the day's contextual panel and note routes the note's;
@@ -66,16 +66,18 @@ export function WorkspaceContent({ graph }: WorkspaceContentProps): ReactElement
   const sidebarTarget = contextSidebarTarget(route, today)
 
   // In the daily stream the route stays on the day you navigated to while focus
-  // moves between days. The sidebar follows the focused day, falling back to the
-  // routed day — which is also the calendar-pick path, where focus stays out of
-  // the stream. A new routed day resets focus tracking pre-paint, so the sidebar
-  // snaps to it immediately and only then tracks where focus lands.
-  const routeDailyDate = sidebarTarget?.kind === 'daily' ? sidebarTarget.date : null
+  // moves between days, so the sidebar follows the focused day (falling back to
+  // the routed day when focus is outside the stream — the calendar-pick path).
+  // Every navigation re-anchors the stream; reset focus tracking on the *same*
+  // signals (`arrivalSeq`/`entryId`), not on the routed date — re-targeting the
+  // current day (a calendar pick on it, ⌘D to today) re-anchors too and must
+  // snap the sidebar back to it. The reset runs pre-paint, so no stale focused
+  // day is shown before the stream re-focuses the target.
   const focusedDailyDate = useFocusedDailyDate()
   const setFocusedDailyDate = useSetFocusedDailyDate()
   useLayoutEffect(() => {
     setFocusedDailyDate(null)
-  }, [routeDailyDate, setFocusedDailyDate])
+  }, [arrivalSeq, entryId, setFocusedDailyDate])
   const contextTarget = contextTargetForFocus(sidebarTarget, focusedDailyDate)
 
   return (

--- a/apps/desktop/src/components/workspace-content.tsx
+++ b/apps/desktop/src/components/workspace-content.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, type ReactElement } from 'react'
+import type { ReactElement } from 'react'
 import type { GraphInfo } from '@reflect/core'
 import { PanelLeft } from 'lucide-react'
 import { AppShell } from '@/components/app-shell'
@@ -6,11 +6,7 @@ import { CloudSyncBanner } from '@/components/cloud-sync-banner'
 import { CommandPalette } from '@/components/command-palette/command-palette'
 import { DailyContextSidebar } from '@/components/context-sidebar/daily-context-sidebar'
 import { NoteContextSidebar } from '@/components/context-sidebar/note-context-sidebar'
-import {
-  contextSidebarTarget,
-  contextTargetForFocus,
-  type ContextSidebarTarget,
-} from '@/components/context-sidebar/sidebar-route'
+import { type ContextSidebarTarget } from '@/components/context-sidebar/sidebar-route'
 import { EmbeddingsSync } from '@/components/embeddings-sync'
 import { ShortcutKeys } from '@/components/shortcut-keys'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -19,16 +15,11 @@ import { RouteContent } from '@/components/route-content'
 import { ShortcutsDialog } from '@/components/shortcuts-dialog'
 import { Sidebar } from '@/components/sidebar/sidebar'
 import { keybindingFor } from '@/lib/commands/app-commands'
-import { useToday } from '@/lib/use-today'
 import { cn } from '@/lib/utils'
 import { hasMacosTitleBarOverlay } from '@/lib/window-chrome'
-import {
-  useFocusedDailyDate,
-  useSetFocusedDailyDate,
-} from '@/providers/focused-daily-provider'
+import { useDailyContextTarget } from '@/providers/focused-daily-provider'
 import { useSidebar } from '@/providers/sidebar-provider'
 import { useAppShortcuts } from '@/routing/app-shortcuts'
-import { useRouter } from '@/routing/router'
 
 const TOGGLE_SIDEBAR_BINDING = keybindingFor('sidebar.toggle')
 
@@ -58,29 +49,12 @@ function contextSidebarFor(target: ContextSidebarTarget | null): ReactElement | 
  */
 export function WorkspaceContent({ graph }: WorkspaceContentProps): ReactElement {
   const { collapsed } = useSidebar()
-  const { route, arrivalSeq, entryId } = useRouter()
   const commandContext = useAppShortcuts()
-  const today = useToday()
   // Daily routes get the day's contextual panel and note routes the note's;
   // search/settings get none (AppShell omits the region when context is absent).
-  const sidebarTarget = contextSidebarTarget(route, today)
-
-  // In the daily stream the route stays on the day you navigated to while focus
-  // moves between days, so the sidebar follows the last day focused in the
-  // stream. It deliberately *stays* on that day through transient focus moves
-  // (opening ⌘K, clicking a sidebar button) rather than flicking back to the
-  // routed day and out again — what restores the routed day is navigation, not
-  // blur. Reset on the same signals the stream re-anchors on (`arrivalSeq`/
-  // `entryId`), not the routed date, so re-targeting the current day (a calendar
-  // pick on it, ⌘D to today) snaps back too. With nothing focused yet it falls
-  // back to the routed day (also the post-navigation state). The reset runs
-  // pre-paint, so no stale day shows before the stream re-focuses the target.
-  const focusedDailyDate = useFocusedDailyDate()
-  const setFocusedDailyDate = useSetFocusedDailyDate()
-  useLayoutEffect(() => {
-    setFocusedDailyDate(null)
-  }, [arrivalSeq, entryId, setFocusedDailyDate])
-  const contextTarget = contextTargetForFocus(sidebarTarget, focusedDailyDate)
+  // In the daily stream the route stays put while focus moves between days, so
+  // the panel follows the focused day and snaps back on navigation.
+  const contextTarget = useDailyContextTarget()
 
   return (
     <AppShell

--- a/apps/desktop/src/hooks/note-row-overlay.test.ts
+++ b/apps/desktop/src/hooks/note-row-overlay.test.ts
@@ -62,6 +62,20 @@ describe('setNoteRowOverlay', () => {
     expect(getNoteRowOverlay('notes/a.md', GEN + 1)).toBeNull()
     expect(getNoteRowOverlay('notes/a.md', undefined)).toBeNull()
   })
+
+  it('lets a newer generation replace an older overlay', () => {
+    setNoteRowOverlay('notes/a.md', GEN, { gistUrl: 'old' })
+    setNoteRowOverlay('notes/a.md', GEN + 1, { gistUrl: 'new' })
+    expect(getNoteRowOverlay('notes/a.md', GEN + 1)?.gistUrl).toBe('new')
+    expect(getNoteRowOverlay('notes/a.md', GEN)).toBeNull()
+  })
+
+  it('ignores an older generation late write, keeping the newer overlay', () => {
+    setNoteRowOverlay('notes/a.md', GEN + 1, { gistUrl: 'new' })
+    setNoteRowOverlay('notes/a.md', GEN, { gistUrl: 'stale' }) // older graph, resolved late
+    expect(getNoteRowOverlay('notes/a.md', GEN + 1)?.gistUrl).toBe('new')
+    expect(getNoteRowOverlay('notes/a.md', GEN)).toBeNull()
+  })
 })
 
 describe('useNoteRowOverlay', () => {

--- a/apps/desktop/src/hooks/note-row-overlay.test.ts
+++ b/apps/desktop/src/hooks/note-row-overlay.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { NoteRow } from '@reflect/core'
 import {
   applyNoteRowOverlay,
+  getNoteRowOverlay,
   reconcileNoteRowOverlay,
   resetNoteRowOverlays,
   setNoteRowOverlay,
@@ -23,6 +24,7 @@ function noteRow(overrides: Partial<NoteRow> = {}): NoteRow {
 }
 
 const URL = 'https://gist.github.com/alex/g1'
+const GEN = 1
 
 beforeEach(() => {
   resetNoteRowOverlays()
@@ -46,13 +48,29 @@ describe('applyNoteRowOverlay', () => {
   })
 })
 
+describe('setNoteRowOverlay', () => {
+  it('ignores an empty or all-undefined patch (no non-reconcilable entry)', () => {
+    setNoteRowOverlay('notes/a.md', GEN, {})
+    setNoteRowOverlay('notes/a.md', GEN, { gistUrl: undefined })
+    expect(getNoteRowOverlay('notes/a.md', GEN)).toBeNull()
+  })
+
+  it('scopes the overlay to the writing generation', () => {
+    setNoteRowOverlay('notes/a.md', GEN, { gistUrl: URL })
+    expect(getNoteRowOverlay('notes/a.md', GEN)?.gistUrl).toBe(URL)
+    // A reader on a different graph generation never sees it.
+    expect(getNoteRowOverlay('notes/a.md', GEN + 1)).toBeNull()
+    expect(getNoteRowOverlay('notes/a.md', undefined)).toBeNull()
+  })
+})
+
 describe('useNoteRowOverlay', () => {
   it('reflects a set overlay and scopes it to the path', () => {
-    const { result } = renderHook(() => useNoteRowOverlay('notes/a.md'))
-    const other = renderHook(() => useNoteRowOverlay('notes/b.md'))
+    const { result } = renderHook(() => useNoteRowOverlay('notes/a.md', GEN))
+    const other = renderHook(() => useNoteRowOverlay('notes/b.md', GEN))
     expect(result.current).toBeNull()
 
-    act(() => setNoteRowOverlay('notes/a.md', { gistUrl: URL }))
+    act(() => setNoteRowOverlay('notes/a.md', GEN, { gistUrl: URL }))
     expect(result.current?.gistUrl).toBe(URL)
     expect(other.result.current).toBeNull()
   })
@@ -60,28 +78,28 @@ describe('useNoteRowOverlay', () => {
 
 describe('reconcileNoteRowOverlay', () => {
   it('holds the overlay while the index still lags, retires it once they agree', () => {
-    const { result } = renderHook(() => useNoteRowOverlay('notes/a.md'))
-    act(() => setNoteRowOverlay('notes/a.md', { gistUrl: URL }))
+    const { result } = renderHook(() => useNoteRowOverlay('notes/a.md', GEN))
+    act(() => setNoteRowOverlay('notes/a.md', GEN, { gistUrl: URL }))
 
-    act(() => reconcileNoteRowOverlay('notes/a.md', noteRow({ gistUrl: null })))
+    act(() => reconcileNoteRowOverlay('notes/a.md', GEN, noteRow({ gistUrl: null })))
     expect(result.current?.gistUrl).toBe(URL) // index hasn't caught up
 
-    act(() => reconcileNoteRowOverlay('notes/a.md', noteRow({ gistUrl: URL })))
+    act(() => reconcileNoteRowOverlay('notes/a.md', GEN, noteRow({ gistUrl: URL })))
     expect(result.current).toBeNull() // index agrees → retired
   })
 
   it('holds the overlay against a null row (nothing to compare yet)', () => {
-    const { result } = renderHook(() => useNoteRowOverlay('notes/a.md'))
-    act(() => setNoteRowOverlay('notes/a.md', { gistUrl: URL }))
-    act(() => reconcileNoteRowOverlay('notes/a.md', null))
+    const { result } = renderHook(() => useNoteRowOverlay('notes/a.md', GEN))
+    act(() => setNoteRowOverlay('notes/a.md', GEN, { gistUrl: URL }))
+    act(() => reconcileNoteRowOverlay('notes/a.md', GEN, null))
     expect(result.current?.gistUrl).toBe(URL)
   })
 })
 
 describe('resetNoteRowOverlays', () => {
   it('drops every overlay (e.g. on a graph switch)', () => {
-    const { result } = renderHook(() => useNoteRowOverlay('notes/a.md'))
-    act(() => setNoteRowOverlay('notes/a.md', { gistUrl: URL }))
+    const { result } = renderHook(() => useNoteRowOverlay('notes/a.md', GEN))
+    act(() => setNoteRowOverlay('notes/a.md', GEN, { gistUrl: URL }))
     expect(result.current?.gistUrl).toBe(URL)
 
     act(() => resetNoteRowOverlays())

--- a/apps/desktop/src/hooks/note-row-overlay.test.ts
+++ b/apps/desktop/src/hooks/note-row-overlay.test.ts
@@ -108,6 +108,14 @@ describe('reconcileNoteRowOverlay', () => {
     act(() => reconcileNoteRowOverlay('notes/a.md', GEN, null))
     expect(result.current?.gistUrl).toBe(URL)
   })
+
+  it('holds an overlay whose generation does not match the reconciling read', () => {
+    setNoteRowOverlay('notes/a.md', GEN, { gistUrl: URL })
+    // A reconcile on a *different* generation can't retire this overlay — even
+    // when the row's value matches — so a stale-graph read never drops it.
+    reconcileNoteRowOverlay('notes/a.md', GEN + 1, noteRow({ gistUrl: URL }))
+    expect(getNoteRowOverlay('notes/a.md', GEN)?.gistUrl).toBe(URL)
+  })
 })
 
 describe('resetNoteRowOverlays', () => {

--- a/apps/desktop/src/hooks/note-row-overlay.ts
+++ b/apps/desktop/src/hooks/note-row-overlay.ts
@@ -81,6 +81,13 @@ export function setNoteRowOverlay(path: string, generation: number, patch: NoteR
     return
   }
   const existing = overlays.get(path)
+  // Never let an older generation's late write clobber a newer graph's overlay.
+  // Rust already rejects stale-generation file writes before a publish reaches
+  // here (the publish throws and never records an overlay), so this is defence
+  // in depth — the store owns the invariant rather than trusting the caller.
+  if (existing !== undefined && existing.generation > generation) {
+    return
+  }
   const base = existing?.generation === generation ? existing.overlay : {}
   overlays.set(path, { generation, overlay: { ...base, ...defined } })
   emit()

--- a/apps/desktop/src/hooks/note-row-overlay.ts
+++ b/apps/desktop/src/hooks/note-row-overlay.ts
@@ -13,10 +13,13 @@ import type { NoteRow } from '@reflect/core'
  * and it retires the moment the index agrees. Every reader of `useNoteRow`
  * sees a single consistent value, so there is no second value to disagree.
  *
- * Module-level state, keyed by graph-relative path. Deliberately narrow — only
- * the projections an action flips and then waits to observe. Cleared on graph
- * switch ({@link resetNoteRowOverlays}) so an overlay can never bleed across
- * graphs that share a note path.
+ * Each entry is keyed by graph-relative path and stamped with the **graph
+ * generation** it was written under. A reader only sees overlays matching its
+ * current generation, so a publish that resolves *after* a graph switch can't
+ * surface on the new graph (its generation no longer matches) — a path shared
+ * across graphs never shows the wrong note's url. {@link resetNoteRowOverlays}
+ * on graph teardown is then just memory hygiene, not load-bearing for
+ * correctness.
  */
 
 /**
@@ -30,7 +33,13 @@ export interface NoteRowOverlay {
   readonly gistUrl?: string
 }
 
-const overlays = new Map<string, NoteRowOverlay>()
+interface OverlayEntry {
+  /** The graph (file) generation this optimism was written under. */
+  readonly generation: number
+  readonly overlay: NoteRowOverlay
+}
+
+const overlays = new Map<string, OverlayEntry>()
 const listeners = new Set<() => void>()
 
 function emit(): void {
@@ -46,33 +55,64 @@ function subscribe(listener: () => void): () => void {
   }
 }
 
+/** Strip `undefined` fields — an all-`undefined` patch must never be stored. */
+function definedFields(patch: NoteRowOverlay): NoteRowOverlay {
+  const result: { -readonly [Key in keyof NoteRowOverlay]: NoteRowOverlay[Key] } = {}
+  for (const key of Object.keys(patch) as (keyof NoteRowOverlay)[]) {
+    const value = patch[key]
+    if (value !== undefined) {
+      result[key] = value
+    }
+  }
+  return result
+}
+
 /**
- * Record an optimistic patch for `path`, reflected by every `useNoteRow(path)`
- * reader until the index row catches up. Merges with any existing patch.
+ * Record an optimistic patch for `path` under the `generation` it was written
+ * in, reflected by every `useNoteRow(path)` reader on that graph until the
+ * index catches up. Merges with an existing patch from the same generation; a
+ * patch from a newer generation replaces a stale one. An empty patch (or one
+ * that is all `undefined`) is ignored — it would only leave a non-reconcilable
+ * entry and leak `undefined` into merged rows.
  */
-export function setNoteRowOverlay(path: string, patch: NoteRowOverlay): void {
-  overlays.set(path, { ...overlays.get(path), ...patch })
+export function setNoteRowOverlay(path: string, generation: number, patch: NoteRowOverlay): void {
+  const defined = definedFields(patch)
+  if (Object.keys(defined).length === 0) {
+    return
+  }
+  const existing = overlays.get(path)
+  const base = existing?.generation === generation ? existing.overlay : {}
+  overlays.set(path, { generation, overlay: { ...base, ...defined } })
   emit()
+}
+
+/** The overlay for `path` on `generation`, or `null` when none applies. */
+export function getNoteRowOverlay(path: string, generation: number | undefined): NoteRowOverlay | null {
+  if (generation === undefined) {
+    return null
+  }
+  const entry = overlays.get(path)
+  return entry !== undefined && entry.generation === generation ? entry.overlay : null
 }
 
 /**
  * Drop overlay fields the freshly-read index `row` has caught up to (and the
  * whole entry once nothing is left). Called from {@link useNoteRow} in an
- * effect, never during render. A `null` row (note not indexed yet) has nothing
- * to reconcile against, so the overlay is held.
+ * effect, never during render. A `null` row (note not indexed yet) or a
+ * mismatched generation has nothing to reconcile, so the overlay is held.
  */
-export function reconcileNoteRowOverlay(path: string, row: NoteRow | null): void {
-  const overlay = overlays.get(path)
-  if (overlay === undefined || row === null) {
+export function reconcileNoteRowOverlay(path: string, generation: number, row: NoteRow | null): void {
+  const entry = overlays.get(path)
+  if (entry === undefined || entry.generation !== generation || row === null) {
     return
   }
   const remaining: { -readonly [Key in keyof NoteRowOverlay]: NoteRowOverlay[Key] } = {}
   let retired = false
-  for (const key of Object.keys(overlay) as (keyof NoteRowOverlay)[]) {
-    if (row[key] === overlay[key]) {
+  for (const key of Object.keys(entry.overlay) as (keyof NoteRowOverlay)[]) {
+    if (row[key] === entry.overlay[key]) {
       retired = true
     } else {
-      remaining[key] = overlay[key]
+      remaining[key] = entry.overlay[key]
     }
   }
   if (!retired) {
@@ -81,12 +121,12 @@ export function reconcileNoteRowOverlay(path: string, row: NoteRow | null): void
   if (Object.keys(remaining).length === 0) {
     overlays.delete(path)
   } else {
-    overlays.set(path, remaining)
+    overlays.set(path, { generation, overlay: remaining })
   }
   emit()
 }
 
-/** Drop every overlay — the active graph changed, so prior optimism is moot. */
+/** Drop every overlay — graph teardown reclaims memory (correctness is by generation). */
 export function resetNoteRowOverlays(): void {
   if (overlays.size === 0) {
     return
@@ -107,8 +147,8 @@ export function applyNoteRowOverlay(row: NoteRow | null, overlay: NoteRowOverlay
   return { ...row, ...overlay }
 }
 
-/** Subscribe a component to `path`'s overlay; `null` when none is pending. */
-export function useNoteRowOverlay(path: string): NoteRowOverlay | null {
-  const getSnapshot = useCallback(() => overlays.get(path) ?? null, [path])
+/** Subscribe a component to `path`'s overlay on `generation`; `null` when none. */
+export function useNoteRowOverlay(path: string, generation: number | undefined): NoteRowOverlay | null {
+  const getSnapshot = useCallback(() => getNoteRowOverlay(path, generation), [path, generation])
   return useSyncExternalStore(subscribe, getSnapshot)
 }

--- a/apps/desktop/src/hooks/note-row-overlay.ts
+++ b/apps/desktop/src/hooks/note-row-overlay.ts
@@ -93,7 +93,14 @@ export function setNoteRowOverlay(path: string, generation: number, patch: NoteR
   emit()
 }
 
-/** The overlay for `path` on `generation`, or `null` when none applies. */
+/**
+ * The overlay for `path` on `generation`, or `null` when none applies. Readers
+ * (here and {@link useNoteRowOverlay}) accept `undefined` — the graph may not
+ * have loaded yet — and report no overlay; writers always hold a concrete
+ * generation, so {@link setNoteRowOverlay}/{@link reconcileNoteRowOverlay}
+ * require one. Keep that asymmetry: it is the load-state boundary, not an
+ * inconsistency to unify.
+ */
 export function getNoteRowOverlay(path: string, generation: number | undefined): NoteRowOverlay | null {
   if (generation === undefined) {
     return null

--- a/apps/desktop/src/hooks/use-note-row.test.tsx
+++ b/apps/desktop/src/hooks/use-note-row.test.tsx
@@ -1,0 +1,74 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import type { NoteRow } from '@reflect/core'
+import { getNoteRowOverlay, resetNoteRowOverlays, setNoteRowOverlay } from './note-row-overlay'
+import { useNoteRow } from './use-note-row'
+
+const GENERATION = 5
+
+const getNote = vi.hoisted(() => vi.fn<(path: string) => Promise<NoteRow | undefined>>())
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  hasBridge: () => true,
+  getNote,
+}))
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({ graph: { root: '/g', name: 'g', cloudSync: false, generation: GENERATION } }),
+}))
+
+function noteRow(overrides: Partial<NoteRow> = {}): NoteRow {
+  return {
+    path: 'notes/a.md',
+    title: 'A',
+    dailyDate: null,
+    isPrivate: false,
+    hasConflict: false,
+    gistUrl: null,
+    gistStale: false,
+    ...overrides,
+  }
+}
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  getNote.mockReset()
+  resetNoteRowOverlays()
+})
+afterEach(() => {
+  resetNoteRowOverlays()
+})
+
+describe('useNoteRow', () => {
+  it('returns the index row', async () => {
+    getNote.mockResolvedValue(noteRow({ gistUrl: 'from-index' }))
+    const { result } = renderHook(() => useNoteRow('notes/a.md'), { wrapper: makeWrapper() })
+    await waitFor(() => expect(result.current?.gistUrl).toBe('from-index'))
+  })
+
+  it('overlays a freshly-written value over a lagging index row', async () => {
+    getNote.mockResolvedValue(noteRow({ gistUrl: null })) // index hasn't seen the publish yet
+    const { result } = renderHook(() => useNoteRow('notes/a.md'), { wrapper: makeWrapper() })
+    await waitFor(() => expect(result.current).not.toBeNull())
+    expect(result.current?.gistUrl).toBeNull()
+
+    act(() => setNoteRowOverlay('notes/a.md', GENERATION, { gistUrl: 'pending' }))
+    await waitFor(() => expect(result.current?.gistUrl).toBe('pending'))
+  })
+
+  it('retires the overlay once the index row catches up to it', async () => {
+    setNoteRowOverlay('notes/a.md', GENERATION, { gistUrl: 'u' })
+    getNote.mockResolvedValue(noteRow({ gistUrl: 'u' })) // index already agrees
+    const { result } = renderHook(() => useNoteRow('notes/a.md'), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current?.gistUrl).toBe('u'))
+    await waitFor(() => expect(getNoteRowOverlay('notes/a.md', GENERATION)).toBeNull())
+  })
+})

--- a/apps/desktop/src/hooks/use-note-row.ts
+++ b/apps/desktop/src/hooks/use-note-row.ts
@@ -20,22 +20,23 @@ import { useGraph } from '@/providers/graph-provider'
  */
 export function useNoteRow(path: string): NoteRow | null {
   const { graph } = useGraph()
+  const generation = graph?.generation
   const { data } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'note', path],
     queryFn: async () => (await getNote(path)) ?? null,
     enabled: hasBridge() && graph !== null,
   })
   const row = data ?? null
-  const overlay = useNoteRowOverlay(path)
+  const overlay = useNoteRowOverlay(path, generation)
 
   // Retire the overlay once the index reports the same value. An effect, not a
   // render-time mutation: the store is shared, and writing it during render
   // would tear other subscribers.
   useEffect(() => {
-    if (overlay !== null) {
-      reconcileNoteRowOverlay(path, row)
+    if (generation !== undefined && overlay !== null) {
+      reconcileNoteRowOverlay(path, generation, row)
     }
-  }, [path, overlay, row])
+  }, [path, generation, overlay, row])
 
   return applyNoteRowOverlay(row, overlay)
 }

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { EmbedStatus, NoteRow, PinnedNote } from '@reflect/core'
-import type { Route } from '@/routing/route'
+import { notePathForRoute, type Route } from '@/routing/route'
 import { resetOperations } from '@/lib/operations'
 import type { CommandContext } from './types'
+
+const TODAY = '2026-06-09'
 
 const randomNotePath = vi.hoisted(() => vi.fn())
 const rebuildIndex = vi.hoisted(() => vi.fn())
@@ -54,9 +56,13 @@ function command(id: string) {
 
 function fakeContext(overrides?: Partial<CommandContext>) {
   const navigated: Route[] = []
+  const route: () => Route = overrides?.route ?? (() => ({ kind: 'today' }))
   const context: CommandContext = {
-    navigate: (route) => void navigated.push(route),
-    route: () => ({ kind: 'today' }),
+    navigate: (target) => void navigated.push(target),
+    route,
+    // Mirror the real context: note-scoped commands resolve their target from
+    // the route (the focused-day branch is exercised in app-shortcuts).
+    notePath: () => notePathForRoute(route(), TODAY),
     back: vi.fn(),
     forward: vi.fn(),
     toggleTheme: vi.fn(),

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -7,13 +7,12 @@ import {
   toggleDevtools,
 } from '@reflect/core'
 import { untitledNotePath } from '@/lib/create-note'
-import { todayIso } from '@/lib/dates'
 import { runGistPublish } from '@/lib/note-gist'
 import { toggleNotePinned } from '@/lib/note-pin'
 import { toggleNotePrivate } from '@/lib/note-private'
 import { startOperation } from '@/lib/operations'
 import { rebuildIndexVisibly } from '@/lib/rebuild-index'
-import { notePathForRoute, type Route } from '@/routing/route'
+import { type Route } from '@/routing/route'
 import { registerCommands } from './registry'
 import type { AppCommand } from './types'
 
@@ -89,7 +88,7 @@ const APP_COMMANDS: AppCommand[] = [
     keybinding: 'Mod-o',
     run: async (context) => {
       const generation = context.generation()
-      const path = notePathForRoute(context.route(), todayIso())
+      const path = context.notePath()
       if (generation === null || path === null) {
         return
       }
@@ -116,7 +115,7 @@ const APP_COMMANDS: AppCommand[] = [
     // keyboard-reachable without spending a shortcut.
     run: async (context) => {
       const generation = context.generation()
-      const path = notePathForRoute(context.route(), todayIso())
+      const path = context.notePath()
       if (generation === null || path === null) {
         return
       }
@@ -143,7 +142,7 @@ const APP_COMMANDS: AppCommand[] = [
     // progress line, the failure surface, and the "link copied" confirmation.
     run: async (context) => {
       const generation = context.generation()
-      const path = notePathForRoute(context.route(), todayIso())
+      const path = context.notePath()
       if (generation === null || path === null) {
         return
       }

--- a/apps/desktop/src/lib/commands/registry.test.ts
+++ b/apps/desktop/src/lib/commands/registry.test.ts
@@ -10,6 +10,7 @@ function fakeContext(overrides?: Partial<CommandContext>): CommandContext {
   return {
     navigate: vi.fn(),
     route: () => ({ kind: 'today' }),
+    notePath: () => null,
     back: vi.fn(),
     forward: vi.fn(),
     toggleTheme: vi.fn(),

--- a/apps/desktop/src/lib/commands/types.ts
+++ b/apps/desktop/src/lib/commands/types.ts
@@ -9,8 +9,15 @@ import type { Route } from '@/routing/route'
 
 export interface CommandContext {
   navigate: (route: Route) => void
-  /** The current route, read at run time — what note-scoped commands act on. */
+  /** The current route, read at run time. */
   route: () => Route
+  /**
+   * The note file note-scoped commands (pin, private, publish) act on, or null
+   * for screens that edit no note. Usually the routed note, but in the daily
+   * stream it's the **focused** day — the same note the context sidebar
+   * describes — so a command and the sidebar never target different days.
+   */
+  notePath: () => string | null
   back: () => void
   forward: () => void
   toggleTheme: () => void

--- a/apps/desktop/src/lib/note-gist.test.ts
+++ b/apps/desktop/src/lib/note-gist.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { gistBodyHash, upsertFrontmatter } from '@reflect/core'
 import type { NoteSession } from '@/editor/note-session'
+import { getNoteRowOverlay, resetNoteRowOverlays } from '@/hooks/note-row-overlay'
 
 const readNote = vi.hoisted(() => vi.fn<(path: string) => Promise<string>>())
 const writeNote = vi.hoisted(() => vi.fn(async () => {}))
@@ -48,6 +49,7 @@ beforeEach(() => {
   startOperation.mockClear()
   operationDone.mockClear()
   operationFail.mockClear()
+  resetNoteRowOverlays()
 })
 
 function fakeSession(content: string, canCommit = true, liveContent: string | null = content) {
@@ -220,6 +222,23 @@ describe('runGistPublish', () => {
     expect(startOperation).toHaveBeenCalledWith('Gist link copied')
     expect(operationDone).toHaveBeenCalledTimes(2)
     expect(operationFail).not.toHaveBeenCalled()
+  })
+
+  it('records the published url in the optimistic overlay, stamped with the generation', async () => {
+    readNote.mockResolvedValue(BODY)
+    await runGistPublish('notes/a.md', 3)
+
+    expect(getNoteRowOverlay('notes/a.md', 3)?.gistUrl).toBe(PUBLISHED.htmlUrl)
+    // Stamped with the publishing generation — a reader on another graph won't see it.
+    expect(getNoteRowOverlay('notes/a.md', 4)).toBeNull()
+  })
+
+  it('leaves no overlay when the publish failed', async () => {
+    readNote.mockResolvedValue(BODY)
+    getGithubToken.mockResolvedValue(null)
+    await runGistPublish('notes/a.md', 3)
+
+    expect(getNoteRowOverlay('notes/a.md', 3)).toBeNull()
   })
 
   it('surfaces failures and resolves null', async () => {

--- a/apps/desktop/src/lib/note-gist.ts
+++ b/apps/desktop/src/lib/note-gist.ts
@@ -115,7 +115,9 @@ export async function runGistPublish(path: string, generation: number): Promise<
     return null
   }
   operation.done()
-  setNoteRowOverlay(path, { gistUrl: url })
+  // Stamp the optimism with the publishing graph's generation, so a publish
+  // that resolves after a graph switch can't surface on the new graph.
+  setNoteRowOverlay(path, generation, { gistUrl: url })
   try {
     await navigator.clipboard.writeText(url)
     startOperation('Gist link copied').done()

--- a/apps/desktop/src/providers/focused-daily-provider.test.tsx
+++ b/apps/desktop/src/providers/focused-daily-provider.test.tsx
@@ -1,8 +1,10 @@
 import { act, renderHook } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import type { ReactNode } from 'react'
+import { RouterProvider, useRouter } from '@/routing/router'
 import {
   FocusedDailyProvider,
+  useDailyContextTarget,
   useFocusedDailyDate,
   useSetFocusedDailyDate,
 } from './focused-daily-provider'
@@ -32,5 +34,59 @@ describe('FocusedDailyProvider', () => {
     expect(result.current.date).toBeNull()
     expect(() => act(() => result.current.set('2026-06-01'))).not.toThrow()
     expect(result.current.date).toBeNull()
+  })
+})
+
+describe('useDailyContextTarget', () => {
+  const ROUTED = { kind: 'daily', date: '2026-06-09' } as const
+
+  // The router sits above the focus provider in the real tree (GraphWorkspace).
+  // A fixed daily route keeps the assertions clock-independent.
+  function routed({ children }: { children: ReactNode }) {
+    return (
+      <RouterProvider initialRoute={ROUTED}>
+        <FocusedDailyProvider>{children}</FocusedDailyProvider>
+      </RouterProvider>
+    )
+  }
+
+  function useHarness() {
+    return {
+      target: useDailyContextTarget(),
+      setFocused: useSetFocusedDailyDate(),
+      navigate: useRouter().navigate,
+    }
+  }
+
+  it('follows the focused day, then snaps to the new routed day on navigation', () => {
+    const { result } = renderHook(useHarness, { wrapper: routed })
+    // Nothing focused yet → the routed subject.
+    expect(result.current.target).toEqual(ROUTED)
+
+    act(() => result.current.setFocused('2026-06-01'))
+    expect(result.current.target).toEqual({ kind: 'daily', date: '2026-06-01' })
+
+    // Navigating to another day clears focus pre-paint, onto the new routed day.
+    act(() => result.current.navigate({ kind: 'daily', date: '2026-06-05' }))
+    expect(result.current.target).toEqual({ kind: 'daily', date: '2026-06-05' })
+  })
+
+  it('resets even when re-targeting the current entry (⌘D / calendar pick on it)', () => {
+    const { result } = renderHook(useHarness, { wrapper: routed })
+    act(() => result.current.setFocused('2026-06-01'))
+    expect(result.current.target).toEqual({ kind: 'daily', date: '2026-06-01' })
+
+    // A no-op re-navigation bumps `arrivalSeq` without changing the entry; the
+    // reset keys off that, so focus still clears.
+    act(() => result.current.navigate(ROUTED))
+    expect(result.current.target).toEqual(ROUTED)
+  })
+
+  it('ignores the focused day off the daily views (a note route keeps its note)', () => {
+    const { result } = renderHook(useHarness, { wrapper: routed })
+    act(() => result.current.navigate({ kind: 'note', path: 'notes/a.md' }))
+    // Focus set while on a note route is irrelevant — the sidebar stays the note.
+    act(() => result.current.setFocused('2026-06-01'))
+    expect(result.current.target).toEqual({ kind: 'note', path: 'notes/a.md' })
   })
 })

--- a/apps/desktop/src/providers/focused-daily-provider.test.tsx
+++ b/apps/desktop/src/providers/focused-daily-provider.test.tsx
@@ -1,0 +1,36 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import type { ReactNode } from 'react'
+import {
+  FocusedDailyProvider,
+  useFocusedDailyDate,
+  useSetFocusedDailyDate,
+} from './focused-daily-provider'
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <FocusedDailyProvider>{children}</FocusedDailyProvider>
+}
+
+function useFocusedDaily() {
+  return { date: useFocusedDailyDate(), set: useSetFocusedDailyDate() }
+}
+
+describe('FocusedDailyProvider', () => {
+  it('reads back the focused day, and clears it with null', () => {
+    const { result } = renderHook(useFocusedDaily, { wrapper })
+    expect(result.current.date).toBeNull()
+
+    act(() => result.current.set('2026-06-01'))
+    expect(result.current.date).toBe('2026-06-01')
+
+    act(() => result.current.set(null))
+    expect(result.current.date).toBeNull()
+  })
+
+  it('defaults to null with a no-op setter when no provider is mounted', () => {
+    const { result } = renderHook(useFocusedDaily)
+    expect(result.current.date).toBeNull()
+    expect(() => act(() => result.current.set('2026-06-01'))).not.toThrow()
+    expect(result.current.date).toBeNull()
+  })
+})

--- a/apps/desktop/src/providers/focused-daily-provider.tsx
+++ b/apps/desktop/src/providers/focused-daily-provider.tsx
@@ -1,0 +1,44 @@
+import { createContext, useContext, useState, type ReactElement, type ReactNode } from 'react'
+
+/**
+ * Which day in the daily stream currently holds the user's focus, so the
+ * context sidebar can describe *that* day rather than the routed one.
+ *
+ * The daily stream is a run of per-day editors under a single `daily/:date`
+ * route: scrolling or clicking to another day moves focus but never changes the
+ * route (only the calendar does). Without this, the right sidebar — derived
+ * purely from the route — stays pinned to the routed day while the user edits a
+ * different one, so its note actions (pin, private, publish) and the published
+ * URL all describe the wrong note.
+ *
+ * The stream is the only writer (it sets the focused day on focus); the
+ * workspace shell reads it and falls back to the routed day when nothing in the
+ * stream is focused — which is also the calendar-pick path. Split into separate
+ * value/setter contexts so the heavy stream can consume the (stable) setter
+ * without re-rendering every time the focused day changes.
+ */
+
+const FocusedDailyDateContext = createContext<string | null>(null)
+const SetFocusedDailyDateContext = createContext<(date: string | null) => void>(() => {})
+
+/** Provides the focused-day state to the workspace shell and the daily stream. */
+export function FocusedDailyProvider({ children }: { children: ReactNode }): ReactElement {
+  const [focusedDate, setFocusedDate] = useState<string | null>(null)
+  return (
+    <SetFocusedDailyDateContext.Provider value={setFocusedDate}>
+      <FocusedDailyDateContext.Provider value={focusedDate}>
+        {children}
+      </FocusedDailyDateContext.Provider>
+    </SetFocusedDailyDateContext.Provider>
+  )
+}
+
+/** The focused day, or `null` when nothing in the stream is focused. */
+export function useFocusedDailyDate(): string | null {
+  return useContext(FocusedDailyDateContext)
+}
+
+/** Record (or clear, with `null`) the focused day. No-op without a provider. */
+export function useSetFocusedDailyDate(): (date: string | null) => void {
+  return useContext(SetFocusedDailyDateContext)
+}

--- a/apps/desktop/src/providers/focused-daily-provider.tsx
+++ b/apps/desktop/src/providers/focused-daily-provider.tsx
@@ -1,4 +1,18 @@
-import { createContext, useContext, useState, type ReactElement, type ReactNode } from 'react'
+import {
+  createContext,
+  useContext,
+  useLayoutEffect,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from 'react'
+import {
+  contextSidebarTarget,
+  type ContextSidebarTarget,
+} from '@/components/context-sidebar/sidebar-route'
+import { useToday } from '@/lib/use-today'
+import { effectiveDailyDate } from '@/routing/route'
+import { useRouter } from '@/routing/router'
 
 /**
  * Which day in the daily stream currently holds the user's focus, so the
@@ -41,4 +55,31 @@ export function useFocusedDailyDate(): string | null {
 /** Record (or clear, with `null`) the focused day. No-op without a provider. */
 export function useSetFocusedDailyDate(): (date: string | null) => void {
   return useContext(SetFocusedDailyDateContext)
+}
+
+/**
+ * The context-sidebar target for the current route, following the day focused
+ * in the daily stream and snapping back to the routed subject on navigation.
+ *
+ * On a daily view the sidebar describes the focused day, not the routed one (the
+ * stream keeps a single `daily/:date` route as focus moves between days) — the
+ * {@link effectiveDailyDate} precedence the note-scoped commands share. Focus
+ * deliberately *stays* through transient moves — opening ⌘K, clicking a sidebar
+ * button — rather than flicking back and out again: what restores the routed day
+ * is navigation, not blur. So the reset keys off the same signals the stream
+ * re-anchors on (`arrivalSeq`/`entryId`), not the routed date, so re-targeting
+ * the current day (a calendar pick on it, ⌘D to today) snaps back too. It runs
+ * pre-paint (a layout effect) so no stale day shows before the stream re-focuses
+ * the target; with nothing focused it is just the routed subject.
+ */
+export function useDailyContextTarget(): ContextSidebarTarget | null {
+  const { route, arrivalSeq, entryId } = useRouter()
+  const today = useToday()
+  const focusedDailyDate = useFocusedDailyDate()
+  const setFocusedDailyDate = useSetFocusedDailyDate()
+  useLayoutEffect(() => {
+    setFocusedDailyDate(null)
+  }, [arrivalSeq, entryId, setFocusedDailyDate])
+  const daily = effectiveDailyDate(route, today, focusedDailyDate)
+  return daily !== null ? { kind: 'daily', date: daily } : contextSidebarTarget(route, today)
 }

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -166,8 +166,9 @@ export function GraphProvider({
           // Rust index connection is swapped, so a stale pass can't write into
           // this graph's index.
           await index.stop()
-          // Drop optimistic note-row overlays from the prior graph: their paths
-          // may collide with this graph's, and their index never will.
+          // Reclaim the prior graph's optimistic note-row overlays. They're
+          // already invisible here (scoped by generation), so this is memory
+          // hygiene, not correctness.
           resetNoteRowOverlays()
           // Open the index *before* 'ready' so reads can't hit the previous
           // graph's index. Best-effort: an index failure doesn't block editing.

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -1,17 +1,21 @@
 import { useEffect, useMemo, useRef } from 'react'
+import { dailyPath } from '@reflect/core'
 import { usePalette } from '@/components/command-palette/palette-provider'
 import { registerKeymap } from '@/editor/keymap'
 import { APP_COMMANDS } from '@/lib/commands/app-commands'
 import { runCommand } from '@/lib/commands/registry'
+import { todayIso } from '@/lib/dates'
 import { setMenuCommandDispatch } from '@/lib/native-menu/dispatch'
 import { retryFailedEmbeddings } from '@/lib/semantic'
 import type { CommandContext } from '@/lib/commands/types'
 import { useAudioMemo } from '@/providers/audio-memo-provider'
+import { useFocusedDailyDate } from '@/providers/focused-daily-provider'
 import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
 import { useShortcuts } from '@/providers/shortcuts-provider'
 import { useSidebar } from '@/providers/sidebar-provider'
 import { useTheme } from '@/providers/theme-provider'
+import { notePathForRoute } from './route'
 import { useRouter } from './router'
 
 /**
@@ -46,6 +50,7 @@ function isModKey(event: KeyboardEvent): boolean {
  */
 export function useAppShortcuts(): CommandContext {
   const { route, navigate, back, forward } = useRouter()
+  const focusedDailyDate = useFocusedDailyDate()
   const { resolvedTheme, setTheme } = useTheme()
   const { graph } = useGraph()
   const { openPalette, open: paletteOpen } = usePalette()
@@ -69,11 +74,24 @@ export function useAppShortcuts(): CommandContext {
   generationRef.current = graph?.generation ?? null
   const routeRef = useRef(route)
   routeRef.current = route
+  const focusedDailyDateRef = useRef(focusedDailyDate)
+  focusedDailyDateRef.current = focusedDailyDate
 
   const context = useMemo<CommandContext>(
     () => ({
       navigate,
       route: () => routeRef.current,
+      // The focused day in the daily stream, falling back to the routed note —
+      // so a note-scoped command targets the same day the context sidebar shows
+      // (the stream keeps one route while focus moves between days).
+      notePath: () => {
+        const currentRoute = routeRef.current
+        const focused = focusedDailyDateRef.current
+        if (focused !== null && (currentRoute.kind === 'today' || currentRoute.kind === 'daily')) {
+          return dailyPath(focused)
+        }
+        return notePathForRoute(currentRoute, todayIso())
+      },
       back,
       forward,
       toggleTheme: () => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark'),

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -15,7 +15,7 @@ import { useSettings } from '@/providers/settings-provider'
 import { useShortcuts } from '@/providers/shortcuts-provider'
 import { useSidebar } from '@/providers/sidebar-provider'
 import { useTheme } from '@/providers/theme-provider'
-import { notePathForRoute } from './route'
+import { effectiveDailyDate, notePathForRoute } from './route'
 import { useRouter } from './router'
 
 /**
@@ -81,16 +81,14 @@ export function useAppShortcuts(): CommandContext {
     () => ({
       navigate,
       route: () => routeRef.current,
-      // The focused day in the daily stream, falling back to the routed note —
-      // so a note-scoped command targets the same day the context sidebar shows
-      // (the stream keeps one route while focus moves between days).
+      // Resolve through the focused stream day so a note-scoped command targets
+      // the same day the context sidebar shows (see `effectiveDailyDate`); off
+      // the daily views it falls back to the routed note.
       notePath: () => {
-        const currentRoute = routeRef.current
-        const focused = focusedDailyDateRef.current
-        if (focused !== null && (currentRoute.kind === 'today' || currentRoute.kind === 'daily')) {
-          return dailyPath(focused)
-        }
-        return notePathForRoute(currentRoute, todayIso())
+        const route = routeRef.current
+        const today = todayIso()
+        const daily = effectiveDailyDate(route, today, focusedDailyDateRef.current)
+        return daily !== null ? dailyPath(daily) : notePathForRoute(route, today)
       },
       back,
       forward,

--- a/apps/desktop/src/routing/route.test.ts
+++ b/apps/desktop/src/routing/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { notePathForRoute, routeForPath, routesEqual } from './route'
+import { effectiveDailyDate, notePathForRoute, routeForPath, routesEqual } from './route'
 
 describe('routeForPath', () => {
   it('routes real daily paths to the daily view', () => {
@@ -53,5 +53,27 @@ describe('notePathForRoute', () => {
     expect(notePathForRoute({ kind: 'settings' }, TODAY)).toBeNull()
     expect(notePathForRoute({ kind: 'allNotes', tag: null }, TODAY)).toBeNull()
     expect(notePathForRoute({ kind: 'chat' }, TODAY)).toBeNull()
+  })
+})
+
+describe('effectiveDailyDate', () => {
+  const TODAY = '2026-06-10'
+
+  it('prefers the focused stream day on a daily view', () => {
+    expect(effectiveDailyDate({ kind: 'today' }, TODAY, '2026-06-01')).toBe('2026-06-01')
+    expect(effectiveDailyDate({ kind: 'daily', date: '2026-06-09' }, TODAY, '2026-06-01')).toBe(
+      '2026-06-01',
+    )
+  })
+
+  it('falls back to the route’s own day when nothing is focused', () => {
+    expect(effectiveDailyDate({ kind: 'today' }, TODAY, null)).toBe(TODAY)
+    expect(effectiveDailyDate({ kind: 'daily', date: '2026-06-09' }, TODAY, null)).toBe('2026-06-09')
+  })
+
+  it('is null off the daily views, even with a focused day (focus is irrelevant)', () => {
+    expect(effectiveDailyDate({ kind: 'note', path: 'notes/a.md' }, TODAY, '2026-06-01')).toBeNull()
+    expect(effectiveDailyDate({ kind: 'search', query: 'x' }, TODAY, '2026-06-01')).toBeNull()
+    expect(effectiveDailyDate({ kind: 'settings' }, TODAY, '2026-06-01')).toBeNull()
   })
 })

--- a/apps/desktop/src/routing/route.ts
+++ b/apps/desktop/src/routing/route.ts
@@ -52,25 +52,51 @@ export function routeForPath(path: string): Route {
 }
 
 /**
- * The note file a route is editing — what note-scoped commands (pin, …) act
- * on: a note route's path, a daily route's file (today's for the `today`
- * route, hence the `today` parameter), and null for screens that edit no
- * note (search, chat, settings).
+ * The daily date a route is anchored on: today's date for the `today` route
+ * (hence the `today` parameter), the route's own date for `daily/:date`, and
+ * null for any route that isn't a daily view (notes, search, chat, settings).
  */
-export function notePathForRoute(route: Route, today: string): string | null {
+function dailyDateForRoute(route: Route, today: string): string | null {
   switch (route.kind) {
-    case 'note':
-      return route.path
-    case 'daily':
-      return dailyPath(route.date)
     case 'today':
-      return dailyPath(today)
-    case 'allNotes':
-    case 'search':
-    case 'chat':
-    case 'settings':
+      return today
+    case 'daily':
+      return route.date
+    default:
       return null
   }
+}
+
+/**
+ * The daily date the user is *effectively* working on: the day focused in the
+ * daily stream when there is one, otherwise the route's own daily date. Null
+ * when the route isn't a daily view, where the focused day is irrelevant.
+ *
+ * The stream keeps a single `daily/:date` route as focus moves between days, so
+ * the focused day — not the routed one — is what both the context sidebar and
+ * note-scoped commands must point at. This is the one place that precedence
+ * lives, so those two surfaces can never disagree about which day they target.
+ */
+export function effectiveDailyDate(
+  route: Route,
+  today: string,
+  focusedDailyDate: string | null,
+): string | null {
+  const routed = dailyDateForRoute(route, today)
+  return routed === null ? null : focusedDailyDate ?? routed
+}
+
+/**
+ * The note file a route is editing — what note-scoped commands (pin, …) act
+ * on: a note route's path, a daily route's file (today's for the `today`
+ * route), and null for screens that edit no note (search, chat, settings).
+ */
+export function notePathForRoute(route: Route, today: string): string | null {
+  if (route.kind === 'note') {
+    return route.path
+  }
+  const daily = dailyDateForRoute(route, today)
+  return daily === null ? null : dailyPath(daily)
 }
 
 /**


### PR DESCRIPTION
## Why

Two things, stacked:

### 1. Fix: the daily sidebar described the wrong note (regression from #180)

The daily view is a **virtualized stream** of per-day editors under a single `daily/:date` route. Scrolling or clicking to another day moves focus but **never changes the route** — only the calendar does. The right context sidebar, however, was derived purely from the route ([sidebar-route.ts](apps/desktop/src/components/context-sidebar/sidebar-route.ts)), so while you edited a different day it stayed pinned to the routed one. Its note actions (pin, private, publish) and the new Published URL section all described the **wrong note**.

Adding the published-URL section in #180 didn't cause this — it exposed a long-standing mismatch (pin/private had it too). The visible symptom: every focused day showed the routed day's published link, "frozen."

**Fix — track the focused day and let the sidebar follow it:**
- `FocusedDailyProvider` holds the focused day, split into value/setter contexts so the heavy stream consumes only the stable setter. Defaults to a no-op, so components work without it.
- `DailyStream` reports the focused day via `onFocusCapture` per row (focus entering a row = the day the sidebar describes).
- The workspace shell redirects a daily context target to the focused day (`contextTargetForFocus`), falling back to the routed day when nothing in the stream is focused — which is the calendar-pick path. A new routed day resets focus tracking **pre-paint** (`useLayoutEffect`), so the sidebar snaps to it immediately and only then tracks where focus lands.

Now the whole daily sidebar — pin/private/publish **and** the published URL — describes the day you're actually editing.

### 2. Re-apply the overlay generation-scoping that didn't make the #180 squash

PR #180 squash-merged without my last commit (the CodeRabbit follow-ups), so `next` has the 2-arg overlay. The first commit here cherry-picks it back: generation-scoped overlays (a publish resolving after a graph switch can't surface on the new graph), an empty/undefined-patch guard, a non-hook `getNoteRowOverlay` for direct testing, and a `use-note-row` integration test.

## Testing

- `pnpm typecheck` — clean
- `pnpm lint` — no new warnings
- `pnpm vitest --run` across context-sidebar, daily-stream, providers, hooks, and the changed libs — 149 passing, including a daily-stream test that focusing a row reports its day, and `contextTargetForFocus` unit tests.

## Manual verification needed

Please confirm in-app: in the daily stream, focusing different days now updates the right sidebar (published URL, pin, private) to the focused day; calendar-pick still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core daily UX and shared command/sidebar targeting plus optimistic publish state; behavior is well-tested but touches hot paths (stream focus, ⌘O/⌘K note actions, gist UI).
> 
> **Overview**
> Fixes the daily context sidebar (and note-scoped shortcuts) staying on the **routed** day while you scroll or focus another day in the virtualized stream under one `daily/:date` route.
> 
> Adds **`FocusedDailyProvider`**: the stream sets the focused ISO date on row `onFocusCapture`; **`useDailyContextTarget`** drives the right panel from **`effectiveDailyDate`** (focused day wins on daily views, resets on navigation via `arrivalSeq`/`entryId`). **`CommandContext.notePath()`** uses the same precedence so pin, private, and publish match the sidebar.
> 
> Re-applies **generation-scoped note-row overlays** for gist optimism: `setNoteRowOverlay(path, generation, …)` so late publishes after a graph switch cannot show on the wrong graph; empty patches ignored; reconcile gated by generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2be7e2a6d50b0e2dae69fe648f65c8d244f6b5bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - The sidebar now tracks and reflects the day you're currently focused on in the daily stream, improving context awareness during navigation.

* **Improvements**
  - Enhanced handling of publish operations to better manage pending states when switching between different workspaces or contexts.
  - Improved cleanup and state reset behavior during navigation transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->