### PR TITLE
Reduce published URL font size

### DIFF
--- a/apps/desktop/src/components/context-sidebar/published-url-section.tsx
+++ b/apps/desktop/src/components/context-sidebar/published-url-section.tsx
@@ -65,7 +65,7 @@ export function PublishedUrlSection({ path }: PublishedUrlSectionProps): ReactEl
         <a
           href={url}
           onClick={openPublishedUrl}
-          className="min-w-0 flex-1 truncate text-sm text-text hover:underline"
+          className="min-w-0 flex-1 truncate text-xs text-text hover:underline"
           title={url}
         >
           {url}


### PR DESCRIPTION
## Summary
- Reduce the published URL text size in the context sidebar from text-sm to text-xs.

## Testing
- pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class change only; no logic, data, or API impact.
> 
> **Overview**
> **Published URL** link in the context sidebar now uses **`text-xs`** instead of **`text-sm`**, so long gist URLs read as smaller, denser sidebar text. Behavior (open, copy, truncate) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e44ffb3b419d7ee0fac56ef3fd29d35cd47d354. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->