### PR TITLE
Fix chat citation and tag navigation

### DIFF
--- a/apps/desktop/src/components/chat/chat-screen.test.tsx
+++ b/apps/desktop/src/components/chat/chat-screen.test.tsx
@@ -16,7 +16,7 @@ import {
   type StreamChatOptions,
 } from '@reflect/core'
 import { ChatProvider, useChatSession } from '@/providers/chat-provider'
-import { RouterProvider } from '@/routing/router'
+import { RouterProvider, useRouter } from '@/routing/router'
 
 /**
  * The chat view over a faked engine: the provider stack and screen are real,
@@ -30,6 +30,9 @@ const streamChat = vi.hoisted(() =>
   vi.fn<(options: StreamChatOptions) => AsyncGenerator<ChatStreamEvent>>(),
 )
 const getSecret = vi.hoisted(() => vi.fn<(name: string) => Promise<string | null>>())
+const resolveWikiTarget = vi.hoisted(() =>
+  vi.fn<(target: string) => Promise<{ kind: 'resolved'; ref: string } | { kind: 'unresolved'; text: string }>>(),
+)
 const loadChatGraphContext = vi.hoisted(() =>
   vi.fn<
     (graphName: string, deps?: GraphContextDeps) => Promise<CloudSafe<CloudGraphContext>>
@@ -39,6 +42,7 @@ vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   streamChat,
   getSecret,
+  resolveWikiTarget,
   loadChatGraphContext,
 }))
 
@@ -79,9 +83,37 @@ vi.mock('@/providers/graph-provider', () => ({
 // jsdom can't host the ProseMirror contenteditable (same stub as the palette
 // tests); markdown rendering is the editor's concern, not this screen's.
 vi.mock('@/editor/markdown-preview', () => ({
-  MarkdownPreview: ({ content }: { content: string }) => (
-    <div data-testid="markdown-preview">{content}</div>
-  ),
+  MarkdownPreview: ({
+    content,
+    onWikiLinkClick,
+    onTagClick,
+  }: {
+    content: string
+    onWikiLinkClick?: (target: string) => void
+    onTagClick?: (tag: string) => void
+  }) => {
+    const wikiTargets = Array.from(content.matchAll(/\[\[([^\]|]+)(?:\|[^\]]*)?\]\]/g)).map(
+      (match) => match[1],
+    )
+    const tags = Array.from(content.matchAll(/(^|\s)#(\p{L}[\p{L}\p{N}/_-]*)/gu)).map(
+      (match) => match[2],
+    )
+    return (
+      <div data-testid="markdown-preview">
+        {content}
+        {wikiTargets.map((target) => (
+          <button key={target} type="button" onClick={() => onWikiLinkClick?.(target)}>
+            Open {target}
+          </button>
+        ))}
+        {tags.map((tag) => (
+          <button key={tag} type="button" onClick={() => onTagClick?.(tag)}>
+            Open #{tag}
+          </button>
+        ))}
+      </div>
+    )
+  },
 }))
 vi.mock('@/lib/provider-fetch', () => ({ providerFetch: vi.fn() }))
 
@@ -112,6 +144,10 @@ beforeEach(() => {
   streamChat.mockReset()
   getSecret.mockReset().mockResolvedValue('sk-test')
   loadChatGraphContext.mockReset().mockResolvedValue(GRAPH_CONTEXT)
+  resolveWikiTarget.mockReset().mockImplementation(async (target) => ({
+    kind: 'resolved',
+    ref: `notes/${target.toLowerCase()}.md`,
+  }))
 })
 
 const MODEL: AiProviderConfig = { id: 'm1', provider: 'openai', model: 'gpt-5.1', keyHint: '12345' }
@@ -136,6 +172,7 @@ function pngFile(name: string): File {
 
 let probedSend: ((text: string) => Promise<void>) | null = null
 let probedNewChat: (() => void) | null = null
+let probedRoute: unknown = null
 
 function SendProbe(): ReactElement | null {
   const session = useChatSession()
@@ -144,8 +181,14 @@ function SendProbe(): ReactElement | null {
   return null
 }
 
+function RouteProbe(): ReactElement | null {
+  probedRoute = useRouter().route
+  return null
+}
+
 function renderChat() {
   probedSend = null
+  probedRoute = null
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <QueryClientProvider client={client}>
@@ -153,6 +196,7 @@ function renderChat() {
         <ChatProvider graph={GRAPH}>
           <ChatScreen />
           <SendProbe />
+          <RouteProbe />
         </ChatProvider>
       </RouterProvider>
     </QueryClientProvider>,
@@ -198,6 +242,26 @@ describe('ChatScreen', () => {
     const options = streamChat.mock.lastCall?.[0]
     expect(options?.config).toEqual(MODEL)
     expect(options?.messages.at(-1)).toEqual({ role: 'user', content: 'when does atlas ship?' })
+  })
+
+  it('opens cited wiki links and tags from settled chat markdown', async () => {
+    configureModel()
+    scriptTurn([
+      { type: 'text-delta', text: 'See [[Atlas]] and #book.' },
+      {
+        type: 'complete',
+        messages: [{ role: 'assistant', content: 'See [[Atlas]] and #book.' }],
+      },
+    ])
+    const view = renderChat()
+
+    await userEvent.type(view.getByLabelText('Chat message'), 'what should I open?{Enter}')
+    await userEvent.click(await view.findByRole('button', { name: 'Open Atlas' }))
+
+    await waitFor(() => expect(probedRoute).toEqual({ kind: 'note', path: 'notes/atlas.md' }))
+
+    await userEvent.click(view.getByRole('button', { name: 'Open #book' }))
+    expect(probedRoute).toEqual({ kind: 'allNotes', tag: 'book' })
   })
 
   it('offers the provider catalog in the picker, keeping a custom model selectable', async () => {
@@ -322,7 +386,8 @@ describe('ChatScreen', () => {
 
     await userEvent.type(view.getByLabelText('Chat message'), 'what have I been reading?{Enter}')
 
-    await view.findByText(/Listed #book notes · 1 note/)
+    await userEvent.click(await view.findByRole('button', { name: '#book' }))
+    expect(probedRoute).toEqual({ kind: 'allNotes', tag: 'book' })
     // A refused listing shows the refusal, not a misleading count.
     await view.findByText(/Listed #\* notes — Not a tag/)
     await view.findByText(/Listed daily notes 2026-06-01 – 2026-06-11 · 2 days/)

--- a/apps/desktop/src/components/chat/chat-tool-chip.tsx
+++ b/apps/desktop/src/components/chat/chat-tool-chip.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, ReactNode } from 'react'
 import { CalendarDays, FileText, History, Search } from 'lucide-react'
-import { isToolPending, type AssistantPart } from '@reflect/core'
+import { isTagName, isToolPending, type AssistantPart } from '@reflect/core'
 import { routeForPath } from '@/routing/route'
 import { useRouter } from '@/routing/router'
 import { Spinner } from '@/components/ui/spinner'
@@ -56,10 +56,22 @@ export function ChatToolChip({ part }: ChatToolChipProps): ReactElement {
 
   if (call.tool === 'recents') {
     const result = part.result?.tool === 'recents' ? part.result : null
+    const tagLabel =
+      call.tag !== null && isTagName(call.tag) ? (
+        <button
+          type="button"
+          onClick={() => navigate({ kind: 'allNotes', tag: call.tag })}
+          className="underline-offset-2 hover:text-text hover:underline"
+        >
+          #{call.tag}
+        </button>
+      ) : (
+        (call.tag !== null ? `#${call.tag}` : 'recent')
+      )
     return (
       <ChipFrame pending={pending} icon={<History aria-hidden className="size-3.5" />}>
         <span className="truncate">
-          Listed {call.tag !== null ? `#${call.tag}` : 'recent'} notes
+          Listed {tagLabel} notes
           {result !== null
             ? result.error !== null
               ? ` — ${result.error}`

--- a/apps/desktop/src/components/chat/chat-turn.tsx
+++ b/apps/desktop/src/components/chat/chat-turn.tsx
@@ -3,6 +3,7 @@ import { MarkdownPreview } from '@/editor/markdown-preview'
 import { useWikiLinkNavigation } from '@/editor/use-wiki-link-navigation'
 import type { ChatTurn as ChatTurnModel } from '@reflect/core'
 import { cn } from '@/lib/utils'
+import { useRouter } from '@/routing/router'
 import { ChatToolChip } from './chat-tool-chip'
 
 interface ChatTurnProps {
@@ -26,6 +27,7 @@ interface ChatTurnProps {
  */
 export function ChatTurn({ turn }: ChatTurnProps): ReactElement {
   const navigateWikiLink = useWikiLinkNavigation(null)
+  const { navigate } = useRouter()
   const lastIndex = turn.parts.length - 1
 
   return (
@@ -64,6 +66,7 @@ export function ChatTurn({ turn }: ChatTurnProps): ReactElement {
                   key={index}
                   content={part.text}
                   onWikiLinkClick={navigateWikiLink}
+                  onTagClick={(tag) => navigate({ kind: 'allNotes', tag })}
                   className="text-sm"
                 />
               )

--- a/apps/desktop/src/editor/markdown-preview.tsx
+++ b/apps/desktop/src/editor/markdown-preview.tsx
@@ -11,6 +11,7 @@ import { ProseKit } from '@prosekit/react'
 import '@meowdown/core/style.css'
 import { cn } from '@/lib/utils'
 import { defineImages } from './images'
+import { defineTags } from './tags'
 import { defineWikiLinks } from './wiki-links'
 
 /**
@@ -35,6 +36,8 @@ interface MarkdownPreviewProps {
    * inert chips (the palette preview's behavior).
    */
   onWikiLinkClick?: (target: string) => void
+  /** Navigate a clicked `#tag` name, without the leading `#`. */
+  onTagClick?: (tag: string) => void
   /** Extra classes for the rendered root. */
   className?: string
 }
@@ -46,6 +49,7 @@ function defineReadOnly(): PlainExtension {
 function createPreviewEditor(
   resolveUrl: (src: string) => string | null,
   onNavigate: ((target: string) => void) | undefined,
+  onTagNavigate: ((tag: string) => void) | undefined,
 ): Editor {
   return createEditor({
     extension: union(
@@ -54,6 +58,7 @@ function createPreviewEditor(
       // No handler, no plugin option: a registered callback makes the plugin
       // consume chip clicks, and an inert preview must not swallow them.
       defineWikiLinks(onNavigate ? { onNavigate } : {}),
+      defineTags(onTagNavigate ? { onNavigate: onTagNavigate } : {}),
       defineImages({ resolveUrl }),
       defineReadOnly(),
     ),
@@ -64,6 +69,7 @@ export function MarkdownPreview({
   content,
   resolveImageUrl,
   onWikiLinkClick,
+  onTagClick,
   className,
 }: MarkdownPreviewProps): ReactElement {
   // The extension set is created once; the resolver and click handler are
@@ -74,10 +80,13 @@ export function MarkdownPreview({
   resolveRef.current = resolveImageUrl
   const navigateRef = useRef<((target: string) => void) | undefined>(onWikiLinkClick)
   navigateRef.current = onWikiLinkClick
+  const tagNavigateRef = useRef<((tag: string) => void) | undefined>(onTagClick)
+  tagNavigateRef.current = onTagClick
   const [editor] = useState(() =>
     createPreviewEditor(
       (src) => resolveRef.current?.(src) ?? null,
       onWikiLinkClick ? (target) => navigateRef.current?.(target) : undefined,
+      onTagClick ? (tag) => tagNavigateRef.current?.(tag) : undefined,
     ),
   )
 

--- a/apps/desktop/src/editor/tags.test.ts
+++ b/apps/desktop/src/editor/tags.test.ts
@@ -1,0 +1,55 @@
+import type { EditorState } from '@prosekit/pm/state'
+import type { EditorView } from '@prosekit/pm/view'
+import { describe, expect, it, vi } from 'vitest'
+import { createMeowdownEditor } from './meowdown'
+import { computeTagRanges, createTagPlugin, defineTags } from './tags'
+
+function stateFor(markdown: string): EditorState {
+  return createMeowdownEditor(markdown, defineTags({ onNavigate: () => {} })).state
+}
+
+function tagsFor(markdown: string): string[] {
+  return computeTagRanges(stateFor(markdown)).map((range) => range.tag)
+}
+
+describe('computeTagRanges', () => {
+  it('finds tags that match the note index grammar', () => {
+    expect(tagsFor('Read #book and #project/reflect-v2 today.')).toEqual([
+      'book',
+      'project/reflect-v2',
+    ])
+  })
+
+  it('ignores invalid tag-looking text', () => {
+    expect(tagsFor('#123 nope, a#middle nope, ##heading nope, #-dash nope')).toEqual([])
+  })
+
+  it('ignores tags inside code spans and code blocks', () => {
+    expect(tagsFor('Real #book, code `#secret`.\n\n```\n#hidden\n```')).toEqual(['book'])
+  })
+})
+
+describe('tag click navigation', () => {
+  function tagClickEvent(tag: string): MouseEvent {
+    const span = document.createElement('span')
+    span.className = 'reflect-tag-link'
+    span.setAttribute('data-tag', tag)
+    const event = new MouseEvent('click')
+    Object.defineProperty(event, 'target', { value: span })
+    return event
+  }
+
+  it('navigates when clicking a rendered tag', () => {
+    const onNavigate = vi.fn()
+    const plugin = createTagPlugin({ onNavigate })
+    const handled = plugin.props.handleClick!.call(
+      plugin,
+      { state: stateFor('See #book') } as unknown as EditorView,
+      5,
+      tagClickEvent('book'),
+    )
+
+    expect(handled).toBe(true)
+    expect(onNavigate).toHaveBeenCalledWith('book')
+  })
+})

--- a/apps/desktop/src/editor/tags.ts
+++ b/apps/desktop/src/editor/tags.ts
@@ -1,0 +1,139 @@
+import { definePlugin, type PlainExtension } from '@prosekit/core'
+import type { Mark, Node as ProseMirrorNode } from '@prosekit/pm/model'
+import { Plugin, PluginKey, type EditorState } from '@prosekit/pm/state'
+import { Decoration, DecorationSet } from '@prosekit/pm/view'
+
+/**
+ * Click-to-navigate rendering for authored `#tags` in read-only markdown
+ * previews. The indexer's tag grammar is intentionally small: a tag starts
+ * after whitespace or the block start, begins with a letter, then continues
+ * through letters, numbers, `/`, `_`, or `-`.
+ */
+
+const TAG_RE = /(^|\s)#(\p{L}[\p{L}\p{N}/_-]*)/gu
+const tagKey = new PluginKey<DecorationSet>('reflect-tags')
+
+export interface TagOptions {
+  /** Called with the tag name, without the leading `#`. */
+  onNavigate?: (tag: string) => void
+}
+
+export interface TagRange {
+  from: number
+  to: number
+  tag: string
+}
+
+function isCodeMark(mark: Mark): boolean {
+  return mark.type.name === 'code' || mark.type.spec.code === true
+}
+
+function inlineTextSegments(node: ProseMirrorNode): { text: string; excluded: boolean }[] | null {
+  const segments: { text: string; excluded: boolean }[] = []
+  let supported = true
+  node.forEach((child) => {
+    if (!child.isText) {
+      supported = false
+      return
+    }
+    segments.push({
+      text: child.text ?? '',
+      excluded: child.marks.some(isCodeMark),
+    })
+  })
+  return supported ? segments : null
+}
+
+function excludedOffsets(segments: readonly { text: string; excluded: boolean }[]): TagRange[] {
+  const ranges: TagRange[] = []
+  let cursor = 0
+  for (const segment of segments) {
+    const next = cursor + segment.text.length
+    if (segment.excluded) {
+      ranges.push({ from: cursor, to: next, tag: '' })
+    }
+    cursor = next
+  }
+  return ranges
+}
+
+function inRange(offset: number, ranges: readonly Pick<TagRange, 'from' | 'to'>[]): boolean {
+  return ranges.some((range) => offset >= range.from && offset < range.to)
+}
+
+/** Compute every clickable tag in a ProseMirror document. Pure for tests. */
+export function computeTagRanges(state: EditorState): TagRange[] {
+  const ranges: TagRange[] = []
+  state.doc.descendants((node, pos) => {
+    if (node.type.spec.code) {
+      return false
+    }
+    if (!node.isTextblock) {
+      return true
+    }
+    const segments = inlineTextSegments(node)
+    if (segments === null) {
+      return false
+    }
+    const text = segments.map((segment) => segment.text).join('')
+    const excluded = excludedOffsets(segments)
+    const base = pos + 1
+    for (const match of text.matchAll(TAG_RE)) {
+      const hashOffset = (match.index ?? 0) + match[1].length
+      if (inRange(hashOffset, excluded)) {
+        continue
+      }
+      ranges.push({
+        from: base + hashOffset,
+        to: base + hashOffset + match[2].length + 1,
+        tag: match[2],
+      })
+    }
+    return false
+  })
+  return ranges
+}
+
+function buildTagDecorations(state: EditorState): DecorationSet {
+  return DecorationSet.create(
+    state.doc,
+    computeTagRanges(state).map((range) =>
+      Decoration.inline(range.from, range.to, {
+        class: 'reflect-tag-link',
+        'data-tag': range.tag,
+      }),
+    ),
+  )
+}
+
+export function createTagPlugin(options: TagOptions): Plugin<DecorationSet> {
+  const enabled = options.onNavigate !== undefined
+  return new Plugin<DecorationSet>({
+    key: tagKey,
+    state: {
+      init: (_, state) => (enabled ? buildTagDecorations(state) : DecorationSet.empty),
+      apply: (tr, value, _oldState, newState) =>
+        enabled && tr.docChanged ? buildTagDecorations(newState) : value,
+    },
+    props: {
+      decorations: (state) => tagKey.getState(state),
+      handleClick: (_view, _pos, event) => {
+        if (!options.onNavigate) {
+          return false
+        }
+        const tag = (event.target as HTMLElement | null)
+          ?.closest?.('.reflect-tag-link')
+          ?.getAttribute('data-tag')
+        if (!tag) {
+          return false
+        }
+        options.onNavigate(tag)
+        return true
+      },
+    },
+  })
+}
+
+export function defineTags(options: TagOptions = {}): PlainExtension {
+  return definePlugin(createTagPlugin(options))
+}

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -386,6 +386,14 @@ body {
   cursor: pointer;
 }
 
+.reflect-editor .reflect-tag-link {
+  color: var(--accent-soft-text, var(--accent));
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.16em;
+  cursor: pointer;
+}
+
 /* ---- [[ autocomplete (Plan 07) ---------------------------------------------
    The popup is a prosekit custom element (positioned by its positioner); all
    visual treatment is ours. Items carry `data-highlighted` while traversed. */


### PR DESCRIPTION
## Summary
- make settled AI chat markdown route wiki-link citations through the existing note navigation flow
- render clickable #tags in chat markdown and route them to All Notes filtered by tag
- make valid recents-tool tag chips clickable, leaving invalid tag refusals inert

## Testing
- pnpm exec vitest run src/editor/tags.test.ts
- pnpm exec vitest run src/components/chat/chat-screen.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side routing and read-only preview decorations only; no auth, persistence, or streaming behavior changes beyond click handlers.
> 
> **Overview**
> Settled assistant messages in chat now treat **`[[wiki links]]`** and **`#tags`** as navigation affordances instead of static text.
> 
> **`MarkdownPreview`** gains an optional **`onTagClick`** hook backed by a new ProseMirror **`defineTags`** plugin that highlights tags matching the indexer grammar (letter-led names with `/`, `_`, `-`), skips code spans/blocks, and handles clicks. **`ChatTurn`** wires tag clicks to **`allNotes`** filtered by tag (wiki citations still use the existing no-create navigation path).
> 
> **Recents** tool chips render valid tag names as clickable **`#tag`** buttons to the same All Notes view; invalid tags (e.g. **`*`**) stay plain text. Styles add **`.reflect-tag-link`** for underlined accent tags in previews. Chat screen tests assert routing for markdown citations/tags and recents chip clicks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b444226504bf19cdba77099d9afdd38d384fc2d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->