### PR TITLE
fix license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Alex MacCaw and the Reflect contributors
+Copyright (c) 2026 Reflect App, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line legal metadata change with no runtime or security impact.
> 
> **Overview**
> Updates the **MIT license** copyright line in `LICENSE` from *"Alex MacCaw and the Reflect contributors"* to **Reflect App, LLC**, aligning the legal notice with the entity named elsewhere in the project docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61a95d86343a2e319a475bfeaff5bf23e294c5a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->