### PR TITLE
docs: update plan roadmap status

### DIFF
--- a/docs/plans/00-overview.md
+++ b/docs/plans/00-overview.md
@@ -4,25 +4,29 @@ This directory holds the numbered, dependency-ordered plans for building the **f
 version (first wave)** of Reflect V2: the open-source, local-first, markdown-native,
 AI-native rewrite described in the product docs.
 
-## Status at first release (2026-06-12)
+## Current source status (2026-06-14)
 
-The first macOS release ships Plans 01–10, 12, 14–17 (Plan 16 at its V1 scope: SSH +
-path remotes; HTTPS credential helpers later). Two deliberate divergences:
+The source tree now implements Plans 01–12 and 14–17, with Plan 16 at its V1 scope
+(SSH agent auth + path remotes; HTTPS credential helpers remain V2). Plan 11 is no
+longer deferred: the repo contains the WXT extension (`apps/extension`), the native
+messaging sidecar (`apps/native-host`), desktop capture commands
+(`apps/desktop/src-tauri/src/capture.rs`), and the TS drain/enrichment path in
+`@reflect/core`.
 
-- **Plan 11 (link capture) is deferred — the first release ships without the browser
-  integration.** The design and [bridge spike](../spikes/link-capture-bridge.md) stand;
-  the capture envelope/inbox architecture is unbuilt, and no extension exists yet.
-- **Plan 13 (import/export) has not been built.** The graph is already a plain markdown
-  folder (copyable, inspectable — the core portability promise holds), but the in-app
-  import (Obsidian/markdown) and export (Markdown/JSON/HTML ZIP) surfaces are
-  outstanding.
+Plan 13 is **partial**: a Reflect V1 Markdown ZIP importer exists in
+`packages/core/src/import/v1-markdown.ts`, using `fflate`, but the general previewed
+Obsidian/markdown importer and Markdown/JSON/HTML export surfaces are still
+outstanding. Plan 18 remains an unbuilt add-on. Plan 19 is active implementation work,
+not just a future track: the existing Tauri app has a platform root gate, mobile UI tree,
+fixed-root onboarding, target-gated Rust capabilities, and the first-party iOS keyboard
+plugin; physical-device validation and App Store/TestFlight hardening are still open.
 
-Two features landed beyond the written plans: **audio memos** (raw-first capture with
-async BYOK cloud transcription — listed below as deferred, but shipped early via
-`actions/audio-memo`), and **durable AI chat persistence** (the `chat_*` tables in
-`index.sqlite` are the one sanctioned non-rebuildable exception to the
-projection-only rule). The AI copilot (Plan 10) shipped **read-only** (chat over
-local context); patchsets/edits remain a later wave, per the plan's revision note.
+Two features landed beyond the original written plans: **audio memos** (raw-first
+capture with async BYOK cloud transcription via `actions/audio-memo`) and **durable AI
+chat persistence** (the `chat_*` tables in `index.sqlite` are the one sanctioned
+non-rebuildable exception to the projection-only rule). The AI copilot (Plan 10) ships
+as a dedicated, read-only chat view over local tools; patchsets/edits remain a later
+wave, per the plan's revision note.
 
 Read these alongside the source docs they implement:
 
@@ -63,16 +67,16 @@ before the editor, and the editor lands before search/AI.
 | 07 | [Backlinks](07-backlinks.md) | `[[` autocomplete, create-from-unresolved, incoming backlinks, rename-rewrite + aliases |
 | 08 | [Lexical search & command palette](08-lexical-search-and-command-palette.md) | `⌘K` search/command surface, FTS over titles/body, filters, navigation commands |
 | 09 | [Semantic search & local embeddings](09-semantic-search-and-embeddings.md) | Local embedding runtime (Rust), chunking, `sqlite-vec`, incremental re-embed, retrieval layer |
-| 10 | [AI copilot sidebar](10-ai-copilot-sidebar.md) | BYOK provider, keychain secrets, context/retrieval, chat/summarize/rewrite, reviewable patchsets, `private: true` hard-block |
-| 11 | [Link capture](11-link-capture.md) | **Deferred — not in the first release.** Chrome extension → native-messaging bridge → desktop write path, screenshots, BYOK enrichment, daily-note `[[Links]]` |
+| 10 | [AI copilot sidebar](10-ai-copilot-sidebar.md) | BYOK providers, keychain secrets, read-only chat route over `search_notes`/`read_note`, durable chat history, `private: true` hard-block; patchsets deferred |
+| 11 | [Link capture](11-link-capture.md) | Chrome extension → native-messaging sidecar → desktop capture inbox, screenshots, meta/BYOK enrichment, dedicated capture notes + daily-note `[[Links]]` |
 | 12 | [Backup & sync (GitHub-only)](12-backup-and-sync.md) | GitHub/Git backup + restore (the only supported remote), Git-native conflict surface, manual review, checkpoints; file-sync providers unsupported |
-| 13 | [Import / export / portability](13-import-export-portability.md) | **Not started — outstanding at release.** Markdown/Obsidian-graph import, JSON/Markdown/HTML export, attachments preserved |
+| 13 | [Import / export / portability](13-import-export-portability.md) | **Partial.** Reflect V1 Markdown ZIP import exists; general Obsidian/markdown import and Markdown/JSON/HTML export remain outstanding |
 | 14 | [CLI (read/discovery)](14-cli-read-discovery.md) | `reflect today`, `reflect search`, `reflect show`, path lookup |
 | 15 | [Hardening, packaging & OSS release](15-hardening-packaging-release.md) | a11y, perf budgets, signing/notarization, MIT + docs, onboarding, release pipeline |
 | 16 | [Generic git remotes](16-generic-git-remotes.md) | Any git host (GitLab/Gitea/GHES/NAS) via hand-wired `origin`, zero new UI — V1 SSH (agent) + path remotes, V2 HTTPS (credential helpers) |
 | 17 | [Readable filenames](17-readable-filenames.md) | Title-derived note filenames (slug + collision suffix), frontmatter `id` adoption, rename-on-settled-title file moves, id-healed external renames |
 | 18 | [Tasks](18-tasks.md) | **Post-release add-on.** GFM-checkbox tasks as a rebuildable projection: interactive editor checkboxes, Tasks view (Overdue/Today/Upcoming), `[[date]]`/daily scheduling, guarded toggle write-back, `checklist: true` opt-out |
-| 19 | [Mobile companion](19-mobile.md) | **Post-release add-on.** iOS (then Android) as a target of the existing Tauri app: today/daily browsing, in-place note editing, quick capture, new notes, lexical search, GitHub sync parity; shell decision in [TDR 0003](../decisions/0003-mobile-shell.md) |
+| 19 | [Mobile companion](19-mobile.md) | **In progress.** iOS target of the existing Tauri app: mobile root gate, fixed graph root, onboarding, Daily/All shell, editable notes, keyboard plugin; device validation + store hardening remain |
 
 ## Milestone map
 
@@ -92,8 +96,8 @@ demonstrable.
   search, then local semantic search.
 - **M3 — AI-native** (Plan 10): the right-sidebar copilot over local context.
 - **M4 — Capture & durability** (Plans 11–13): link capture, backup/sync, import/export.
-  *(Shipped partially: backup/sync landed; link capture was cut from the first release;
-  import/export is unbuilt. Audio-memo capture shipped instead, ahead of plan.)*
+  *(Shipped partially: backup/sync and link capture landed; Plan 13 is limited to the
+  V1 Markdown ZIP importer so far. Audio-memo capture shipped ahead of plan.)*
 - **M5 — Reach & release** (Plans 14–15): CLI, hardening, packaging, open-source launch.
 
 ## Dependency graph (abridged)
@@ -144,8 +148,9 @@ they are not re-litigated per phase:
   external service — AI, capture enrichment, conflict resolution, or otherwise.
 - **Secrets live in the OS keychain.** Never in markdown, Git, or `.reflect/`.
 - **Keyboard-native.** Every core workflow reachable from the keyboard.
-- **Portable data + export from day one.** Backup must be free, via **GitHub only**;
-  file-sync providers (iCloud/Dropbox/Drive) are unsupported for sync by design.
+- **Portable data.** The graph is already a plain markdown folder; full in-app export
+  surfaces are still Plan 13 work. Backup must be free, via **GitHub only**; file-sync
+  providers (iCloud/Dropbox/Drive) are unsupported for sync by design.
 - **No Electron, no web app, Mac-first.** Tauri shell; iOS/Windows later.
 - **MIT open-source core.** Write as if the code is public and will be critiqued. The
   editor [meowdown](https://github.com/prosekit/meowdown) is **first-party** (owned by the
@@ -154,15 +159,13 @@ they are not re-litigated per phase:
 ## Explicitly deferred (NOT first wave)
 
 Do not build these now; keep the door open in the data model. Tasks (now planned as a
-post-release add-on — [Plan 18](18-tasks.md)), link capture
-(Plan 11 — designed, deferred from the first release), full browser clipper / article
-extraction, graph-map view, templates,
-contacts/calendar, publishing, any non-GitHub sync (iCloud/Dropbox/Drive are unsupported
-by design, not "deferred"), a public plugin API, typed-entity layer, and full multi-device
-sync conflict automation (incl. AI-assisted resolution). Mobile
-did not block the Mac release and is now planned as a post-release add-on —
-[Plan 19](19-mobile.md): capture/read/**edit**/lexical-search on iOS first (Tauri
-mobile, per [TDR 0003](../decisions/0003-mobile-shell.md)), Android shortly after.
+post-release add-on — [Plan 18](18-tasks.md)), full browser clipper / article extraction,
+graph-map view, templates, contacts/calendar, publishing, any non-GitHub sync
+(iCloud/Dropbox/Drive are unsupported by design, not "deferred"), a public plugin API,
+typed-entity layer, and full multi-device sync conflict automation (incl. AI-assisted
+resolution). Mobile did not block the Mac release and is now in active Plan 19 work:
+read/**edit**/lexical-search on iOS first (Tauri mobile, per
+[TDR 0003](../decisions/0003-mobile-shell.md)), Android shortly after.
 
 ## Conventions (apply to every plan)
 

--- a/docs/plans/05-markdown-editor.md
+++ b/docs/plans/05-markdown-editor.md
@@ -33,7 +33,7 @@ ProseMirror rich editor:
   resolves the round-trip concern that would otherwise push us to a source-buffer editor.
 
 This supersedes the earlier CodeMirror-6 recommendation. Round-trip fidelity is now
-verified (the Plan 01 spike — [docs/spikes/meowdown-wiki-links.md](spikes/meowdown-wiki-links.md));
+verified (the Plan 01 spike — [docs/spikes/meowdown-wiki-links.md](../spikes/meowdown-wiki-links.md));
 the remaining watch-item is meowdown's early maturity (see Risks).
 
 > **License:** meowdown is **first-party** (owned by the team) and MIT-licensed, so it fits

--- a/docs/plans/06-daily-notes-and-routing.md
+++ b/docs/plans/06-daily-notes-and-routing.md
@@ -27,7 +27,8 @@ seam).
   navigation (step 3), and the `⌘D/⌘N/⌘[/⌘]` shortcuts through the keymap registry
   (step 5). The note route carries `path` (identity = path in the first wave, Plan 03;
   `id` joins later).
-- **06b** — the virtualized daily stream + navigation polish (planned 2026-06-09):
+- **06b** — the virtualized daily stream + navigation polish (implemented in
+  `apps/desktop/src/components/daily-stream.tsx` and the route history scroll API):
 
   1. **The stream (step 2).** A virtualized chronological list where **every day is a
      virtual note**: each row mounts the Plan 05 single-note editor (`NotePane` with
@@ -54,7 +55,7 @@ seam).
      indicator — product states, not spinners.
 
   **Deferred from 06b:** jot-to-today quick capture → **Plan 11** (decided
-  2026-06-09; `⌘D` + typing covers the need until capture is formalized).
+  2026-06-09; `⌘D` + typing covered the need until the capture pipeline landed).
 
   **Tests (headless):** window↔date math, router scroll-state semantics, lazy
   materialize-on-edit (exists), launch-focus. Stream scroll feel + height

--- a/docs/plans/10-ai-copilot-sidebar.md
+++ b/docs/plans/10-ai-copilot-sidebar.md
@@ -31,17 +31,19 @@ keychain (introduced here, reused by Plan 12).
 (`assertCloudAllowed`); keychain is a Rust primitive. See
 [Architecture & Conventions](architecture-conventions.md).
 
-**Libraries:** Vercel AI SDK (`ai` + `@ai-sdk/openai`/…), `diff` (jsdiff, patchsets),
-`keyring` (Rust, BYOK keys). See [Libraries](libraries.md).
+**Libraries:** Vercel AI SDK (`ai` + `@ai-sdk/openai`/`@ai-sdk/anthropic`/
+`@ai-sdk/google`), `keyring` (Rust, BYOK keys). `diff`/jsdiff is not installed because
+patchsets are deferred. See [Libraries](libraries.md).
 
 ## Scope
 
-**In:** provider config (BYOK, OpenAI-first), keychain secrets, context assembly from
-local retrieval, chat over current note + related notes, summarize, rewrite selection,
-patchset generation/review/apply, local checkpoints, transparent context UI, privacy
-enforcement.
+**In:** provider config (BYOK, multi-provider), keychain secrets, context assembly from
+local retrieval, read-only chat over notes, transparent tool activity, durable chat
+history, and privacy enforcement. The original summarize/rewrite/patchset scope is still
+recorded below as the next wave.
 **Out:** local generative models (later), background auto-extraction beyond opt-in
-reviewable suggestions, agentic multi-step tools (later), audio (deferred).
+reviewable suggestions, agentic multi-step tools (later), audio memos (shipped
+separately through `actions/audio-memo`).
 
 ## Steps
 

--- a/docs/plans/11-link-capture.md
+++ b/docs/plans/11-link-capture.md
@@ -1,6 +1,6 @@
 # Plan 11 — Link Capture
 
-> **Status (2026-06-12): Implemented.** The pipeline below is built end-to-end:
+> **Status (2026-06-14): Implemented.** The pipeline below is built end-to-end:
 > `apps/extension` (WXT MV3, popup + queue + ⌘⇧K), `apps/native-host`
 > (`reflect-capture-host`, bundled as a second sidecar), the capture inbox +
 > watcher carve-out, `drainCaptureInbox`/`reconcileCaptureEnrichment` in
@@ -13,7 +13,8 @@
 > `notes/capture-<stamp>.md` (screenshots are always taken, so the
 > "enough phase-1 content" condition below is always met) plus the daily
 > `[[Links]]` backlink; enrichment status lives in the capture note's
-> frontmatter (`captureStatus: pending | done | skipped`).
+> frontmatter (`captureStatus: pending | done | skipped`). The macOS Tauri
+> overlay bundles both sidecars (`binaries/reflect`, `binaries/reflect-capture-host`).
 
 **Goal:** Launch-grade web capture: a Chrome extension hands URL/title/selection/
 screenshot to the **installed desktop app** through a local **capture inbox**; the

--- a/docs/plans/13-import-export-portability.md
+++ b/docs/plans/13-import-export-portability.md
@@ -1,10 +1,12 @@
 # Plan 13 — Import / Export / Portability
 
-> **Status (2026-06-12): Not started — outstanding at the first release.** The graph is
-> already a plain markdown folder (the core "open your folder and it's just files"
-> promise holds, and Obsidian-style vaults are close enough to open directly in many
-> cases), but none of the in-app surfaces below — previewed import, Markdown/JSON/HTML
-> ZIP export — exist yet.
+> **Status (2026-06-14): Partial.** The graph is already a plain markdown folder (the
+> core "open your folder and it's just files" promise holds). A focused Reflect V1
+> Markdown ZIP importer exists in `packages/core/src/import/v1-markdown.ts`: it unzips
+> with `fflate`, preserves V1 IDs as frontmatter, normalizes task markers, routes daily
+> notes into `daily/YYYY-MM-DD.md`, and writes collision-safe regular notes through the
+> graph command layer. The general previewed Obsidian/markdown import and all
+> Markdown/JSON/HTML export surfaces below are still outstanding.
 
 **Goal:** Make data ownership tangible from day one: import existing markdown/Obsidian
 graphs, and export the graph to Markdown, JSON, and HTML with backlinks, tags, and
@@ -19,10 +21,10 @@ metadata).
 
 ## Scope
 
-**In:** Markdown / Obsidian-style graph import; full-graph export to Markdown ZIP,
-JSON, and HTML ZIP; attachments preserved; backlinks/tags/daily-dates preserved.
-**Out:** V1 graph migration (later — not a first-wave constraint), Evernote/Roam/Notion/
-Readwise importers (later), publishing (deferred).
+**In:** Reflect V1 Markdown ZIP import (shipped), Markdown / Obsidian-style graph import
+(planned), full-graph export to Markdown ZIP, JSON, and HTML ZIP; attachments preserved;
+backlinks/tags/daily-dates preserved.
+**Out:** Evernote/Roam/Notion/Readwise importers (later), publishing (deferred).
 
 ## Why now (not later)
 
@@ -40,6 +42,11 @@ cheap to do well early, and a strong trust signal for an open-source launch.
      links;
    - assign `id`s to regular notes without one; tolerate unknown frontmatter (Plan 03).
    Run as a previewed job (counts, conflicts, skips) before writing. Reindex on finish.
+
+   **Shipped narrow importer:** `importReflectMarkdownZip` handles Reflect V1 Markdown
+   ZIP exports today. It is not a general Obsidian importer: it accepts the old Reflect
+   ZIP shape, skips unsafe paths, keeps existing graph files by choosing available note
+   paths, and reports `{ imported, regular, daily, skipped, renamed }`.
 
 2. **Import safety.** Never overwrite existing graph files silently; surface name
    collisions; import into a subfolder or merge with explicit choices. Large imports show
@@ -75,12 +82,15 @@ cheap to do well early, and a strong trust signal for an open-source launch.
 
 - **Markdown export is a faithful copy** (source of truth is already files); JSON + HTML
   are derived views.
-- **Import is previewed, non-destructive, and reindexed** on completion.
+- **Import is non-destructive.** The shipped V1 ZIP importer chooses collision-safe paths;
+  the broader Obsidian/markdown importer still needs the preview UX described above.
 - **Markdown round-trips** (export→import) to an equivalent graph.
 - **Attachments, backlinks, tags, daily dates, and aliases are always preserved.**
 
 ## Acceptance criteria
 
+- Importing a Reflect V1 Markdown ZIP yields working regular and daily notes in Reflect
+  layout without overwriting existing files.
 - Importing an Obsidian-style graph yields working notes, backlinks, aliases, and
   attachments in Reflect layout, with a pre-write preview.
 - Export produces valid Markdown ZIP, JSON, and HTML ZIP excluding `.reflect/`.

--- a/docs/plans/15-hardening-packaging-release.md
+++ b/docs/plans/15-hardening-packaging-release.md
@@ -10,11 +10,12 @@ docs, and a release pipeline. This is **M5.**
 ## Scope
 
 **In:** onboarding/first-run, keyboard-map completeness + discoverability, accessibility,
-performance budgets, error/repair UX, privacy review, signing/notarization, MIT licensing
-+ public docs, CI, and **auto-update** (Tauri updater plugin).
-**Out:** mobile release (planned, separate track), Windows/Android (later), publishing/
-tasks (deferred features), link capture (Plan 11 — deferred from the first release).
-Audio memos shipped ahead of plan and are **in** scope for the privacy review.
+performance budgets, error/repair UX, privacy review, signing/notarization,
+MIT licensing and public docs, CI, **auto-update** (Tauri updater plugin), and the
+bundled CLI + capture host sidecars.
+**Out:** mobile release (active separate track), Windows/Android packaging (later),
+publishing/tasks (deferred features). Audio memos and link capture both shipped ahead of
+the original release scope and are **in** scope for the privacy/signing review.
 
 ## Steps
 
@@ -42,21 +43,23 @@ Audio memos shipped ahead of plan and are **in** scope for the privacy review.
 
 6. **Privacy review (release gate).** End-to-end audit that `private: true` is enforced at
    every external call site — copilot (Plan 10), retrieval (Plan 09), audio transcription,
-   conflict resolution (Plan 12). (Capture, Plan 11, joins this list when it ships.) Confirm secrets are keychain-only (never markdown/Git/
-   `.reflect/`) and that no Reflect-hosted API exists in the core path. Document exactly
-   what leaves the device and when.
+   capture enrichment/meta fetch (Plan 11), and conflict resolution (Plan 12). Confirm
+   secrets are keychain-only (never markdown/Git/`.reflect/`) and that no Reflect-hosted
+   API exists in the core path. Document exactly what leaves the device and when.
 
 7. **Signing & notarization.** Apple Developer ID signing + notarization for the Tauri
    bundle; verify Gatekeeper-clean install. **Every bundled native dylib must be signed
    with the hardened runtime** — notably the ONNX/embedding runtime (Plan 9) and any
    sqlite-vec/native-messaging-host binaries — for both arm64 and x64; an unsigned nested
-   binary fails notarization. Bundle the `reflect` CLI (Plan 14); consider a Homebrew cask.
-   Confirm **first
-   release is notarized non-sandboxed** (security-scoped bookmarks, Plan 02, only needed if
-   we later sandbox for the App Store). Native-messaging host registration is moot for the
-   first release (link capture, Plan 11, is deferred). **Two distinct keys:** Apple Developer ID (Gatekeeper/
-   notarization) *and* the Tauri **updater signing key** (minisign, verifies update payloads
-   — step 10); both private keys live in CI secrets, never in the repo.
+   binary fails notarization. Bundle the `reflect` CLI (Plan 14) and
+   `reflect-capture-host` (Plan 11) through the macOS Tauri overlay; consider a Homebrew
+   cask. Confirm **first release is notarized non-sandboxed** (security-scoped bookmarks,
+   Plan 02, only needed if we later sandbox for the App Store). Native-messaging host
+   manifests are rewritten on launch for detected browsers, so packaging must verify both
+   the sidecar path and manifest registration after app moves/translocation. **Two
+   distinct keys:** Apple Developer ID (Gatekeeper/notarization) *and* the Tauri
+   **updater signing key** (minisign, verifies update payloads — step 10); both private
+   keys live in CI secrets, never in the repo.
 
 8. **Licensing & open-source readiness.** MIT `LICENSE`; per-file headers where
    appropriate; `README` (what/why/install/build), `CONTRIBUTING`, architecture overview
@@ -66,10 +69,12 @@ Audio memos shipped ahead of plan and are **in** scope for the privacy review.
    permissive. License/dependency scanning is **manual** for now (a periodic audit; no
    automated CI gate yet — revisit if the dep tree grows).
 
-9. **CI + release.** GitHub Actions: typecheck, lint (oxlint adherence config), tests,
-   Rust build, Tauri bundle, and a release workflow (`tauri-apps/tauri-action`) that builds,
-   code-signs + notarizes, **updater-signs**, and publishes a GitHub Release with the DMG,
-   the updater artifacts, and the `latest.json` manifest. Bundles the `reflect` CLI.
+9. **CI + release.** GitHub Actions: typecheck, lint (oxlint), tests, build,
+   generated-schema drift check, Rust fmt/clippy/test, Tauri sidecar staging before Rust
+   compilation, and a release workflow that runs the repo's `pnpm release:macos publish`
+   script to build, code-sign + notarize, **updater-sign**, and publish a GitHub Release
+   with the DMG, updater artifacts, and `latest.json` manifest. Bundles the `reflect` CLI
+   and `reflect-capture-host` sidecars.
 
 10. **Auto-update (Tauri best practices).** Ship first-class auto-update with the official
     plugin — `tauri-plugin-updater` (Rust) + `@tauri-apps/plugin-updater` (JS), paired with
@@ -97,10 +102,9 @@ Audio memos shipped ahead of plan and are **in** scope for the privacy review.
 
 A user can: install the Mac app; open today's markdown daily note instantly; write in a
 beautiful markdown editor without thinking about files; create `[[Wiki Links]]` naturally;
-search locally; ask the AI sidebar about the current and related notes with their own key;
-back up their notes for free; and open their note folder to find portable markdown files.
-(Browser-page capture drops out of this checklist while link capture, Plan 11, is
-deferred; it rejoins when capture ships.)
+search locally; ask the Chat view about the current and related notes with their own key;
+back up their notes for free; capture a browser page through the extension/native host;
+and open their note folder to find portable markdown files.
 
 ## Acceptance criteria
 
@@ -109,7 +113,8 @@ deferred; it rejoins when capture ships.)
 - a11y + perf budgets met; deleting `.reflect/` fully rebuilds with no data loss.
 - Privacy review passes: `private: true` enforced everywhere; secrets keychain-only; no
   hosted API in the core path.
-- Signed, notarized DMG installs Gatekeeper-clean; CLI bundled; CI green.
+- Signed, notarized DMG installs Gatekeeper-clean; CLI and capture host are bundled; CI
+  green.
 - **Auto-update works end-to-end:** an installed older build detects a newer GitHub
   Release, downloads the updater-signed artifact, verifies it against the pubkey, installs,
   and relaunches; a tampered/unsigned payload is rejected.

--- a/docs/plans/19-mobile.md
+++ b/docs/plans/19-mobile.md
@@ -16,6 +16,15 @@ Rust core (git2 sync, rusqlite/FTS5 index, keychain) and the React frontend by
 building mobile as a target of the existing crate; Capacitor is the documented
 fallback with explicit triggers.
 
+> **Status (2026-06-14): In progress in source.** The app has the platform root gate
+> (`src/platform-root.tsx`), mobile route shell (`src/mobile/`), fixed-root graph
+> bootstrap/onboarding in `GraphProvider`, mobile-gated Rust commands and stand-ins
+> (`mobile_graph_root`, `watcher_mobile.rs`, `embed_mobile.rs`), iOS identity/config, and
+> the first-party `tauri-plugin-keyboard`. The Daily/All shell, editable note screen,
+> note actions, share helper, and settings sheet exist. Still open: physical-device
+> editing validation, full GitHub-connect restore polish on mobile, foreground-sync
+> product hardening, TestFlight/App Store packaging, and Android follow-through.
+
 **Depends on:** Plans 02–05 (graph/storage, document model, index, **editor**),
 06 (daily notes/route model), 07 (backlinks/autocomplete), 08 (lexical
 search), 12 + 16 (GitHub sync over HTTPS + device flow), 17 (readable
@@ -293,20 +302,19 @@ Steps 1 and 2 are the existential gates; nothing else starts until both pass.
    safe-area tokens, sync-status pill stub. Desktop bundle unaffected
    (verify chunk split).
 
-   > **Status (2026-06-12): steps 3–4 partially landed, ahead of the spike-B
-   > gate.** Done: `mobile_graph_root` + `app_platform` commands with core
-   > wrappers, Files-app exposure (`UIFileSharingEnabled` +
+   > **Status (2026-06-14): steps 3–4 have moved past skeleton.** Done:
+   > `mobile_graph_root` + `app_platform` commands with core wrappers,
+   > Files-app exposure (`UIFileSharingEnabled` +
    > `LSSupportsOpeningDocumentsInPlace`), identity normalized to
    > `app.reflect.ios` / product name Reflect, the lazy `PlatformRoot` gate
    > (desktop chrome split into `desktop-root.tsx`), the fixed-root mobile
-   > bootstrap in `GraphProvider`, and a Today screen mounting the real
-   > editor via `NotePane`. **Verified on the simulator end-to-end:** boot →
-   > auto-bootstrap in `Documents/` → type into meowdown → the daily note
-   > lands on disk through the shared save pipeline. Two findings: the
-   > document stack requires `RouterProvider` (a missing router unmounted the
-   > tree to a white screen — `MobileErrorBoundary` now makes that class
-   > visible). Still open from these steps: tab/stack navigation, day pager,
-   > and the sync-status pill.
+   > bootstrap in `GraphProvider`, and the `MobileShell` route tree. The mobile
+   > surfaces now include Daily, All/search, editable note pages, note actions,
+   > share helper, onboarding, and settings sheet. **Verified earlier on the
+   > simulator end-to-end:** boot → auto-bootstrap in `Documents/` → type into
+   > meowdown → the daily note lands on disk through the shared save pipeline.
+   > Remaining from the gate: physical-device editing validation and final
+   > product hardening.
    >
    > **Also landed 2026-06-12: step 5 and the decision-8 keyboard plugin.**
    > The write-event seam ships as `setLocalWriteEcho`/`echoLocalWrite` in

--- a/docs/plans/libraries.md
+++ b/docs/plans/libraries.md
@@ -1,15 +1,16 @@
 # Libraries & Dependencies
 
-Canonical record of the libraries chosen for each plan step (decided with the user). The
-foundational libraries installed in Plan 01 are listed first for completeness; later
-phases name the additions they bring in. Licensing is **MIT-core** — meowdown is
-first-party (owned by the team) and MIT-licensed, so there is no copyleft constraint.
+Canonical record of the libraries chosen for each plan step (decided with the user and
+checked against `package.json`/`Cargo.toml` on 2026-06-14). The foundational libraries
+installed in Plan 01 are listed first for completeness; later phases name the additions
+they bring in. Licensing is **MIT-core** — meowdown is first-party (owned by the team)
+and MIT-licensed, so there is no copyleft constraint.
 
 ## Installed in Plan 01 (foundation)
 
 - **Monorepo / build:** pnpm workspaces, Turborepo, TypeScript, Vite, `@vitejs/plugin-react`.
-- **UI:** React 19, Tailwind CSS v4 (`@tailwindcss/vite`), `clsx` + `tailwind-merge` (the
-  `cn` helper), `lucide-react`.
+- **UI:** React 19, Tailwind CSS v4 (`@tailwindcss/vite`), shadcn primitives via
+  `radix-ui`, `clsx` + `tailwind-merge` (the `cn` helper), `lucide-react`.
 - **Validation:** `zod`.
 - **Database:** `kysely` (query builder, TS); `rusqlite` (bundled) + `sqlite-vec` (Rust).
 - **Editor:** meowdown (`@meowdown/react`, `@meowdown/core`) on ProseKit (`@prosekit/*`) +
@@ -22,7 +23,7 @@ first-party (owned by the team) and MIT-licensed, so there is no copyleft constr
 | Need | Library | Plan |
 | --- | --- | --- |
 | Projection/IPC data cache + invalidation (server-state) | `@tanstack/react-query` | 04 |
-| Shared UI / session state (theme, route, palette, sync) | React context + hooks; `zustand` *available if a slice earns it* | 06 / 08 |
+| Shared UI / session state (theme, route, palette, sync) | React context + hooks (no external store dependency today) | 06 / 08 |
 | Frontmatter YAML (tolerant, round-trippable) | `yaml` (eemeli) | 03 |
 | Note IDs (ULID) | `ulidx` | 02 |
 | Routing (typed product routes + history) | **custom, no dependency** | 06 |
@@ -31,9 +32,9 @@ first-party (owned by the team) and MIT-licensed, so there is no copyleft constr
 | UI components (dialogs, popovers, menus) | shadcn/ui (on Radix Primitives) | 07 / 08 / 10 / 15 |
 | Command palette (⌘K) | `cmdk` | 08 |
 | Mobile day carousel (touch swipe, V1 parity) | `embla-carousel-react` | 19 |
-| AI provider (BYOK, streaming, multi-provider) | Vercel AI SDK (`ai` + `@ai-sdk/openai` …) | 10 |
-| Diff / patch (patchsets, conflict diffs) | `diff` (jsdiff) | 10 / 12 |
-| Export — ZIP | `fflate` (client-side) | 13 |
+| AI provider (BYOK, streaming, multi-provider) | Vercel AI SDK (`ai` + `@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/google`) | 10 |
+| Diff / patch (patchsets, conflict diffs) | Not installed; patchsets remain deferred | 10 / 12 |
+| Import/export — ZIP | `fflate` (client-side; currently used by the V1 Markdown ZIP importer) | 13 |
 | Export — HTML | reuse the editor: `markdownToDoc` → ProseMirror `DOMSerializer` (no remark) | 13 |
 | Chrome extension framework | WXT | 11 |
 | Auto-update (JS API + relaunch) | `@tauri-apps/plugin-updater` + `@tauri-apps/plugin-process` | 15 |
@@ -54,18 +55,21 @@ first-party (owned by the team) and MIT-licensed, so there is no copyleft constr
 | SSH transport for generic remotes (agent auth) | `git2` `ssh` feature (vendored libssh2 + openssl) | 16 |
 | Local embeddings | `fastembed` | 09 |
 | Image processing (screenshot downscale) | `image` | 11 |
+| Bounded capture meta fetch | `reqwest` with rustls | 11 |
 | CLI framework (derive) | `clap` v4 | 14 |
 | CLI local "today" (tz/DST-correct) | `jiff` | 14 |
 | CLI content hashes (match TS SHA-256) | `sha2` | 14 |
 | CLI frontmatter reads (tolerant YAML) | `saphyr` | 14 |
 | CLI first-H1 title fallback | `pulldown-cmark` | 14 |
 | Auto-update | `tauri-plugin-updater` | 15 |
+| Window-state restore | `tauri-plugin-window-state` | 15 |
+| Mobile keyboard bridge | first-party `tauri-plugin-keyboard` | 19 |
 
 ## Notes & caveats
 
-- **Export is fully client-side (TS):** `fflate` for zipping; HTML rendered by reusing the
-  editor's ProseMirror schema + `DOMSerializer` (no remark, reuses libraries we already
-  ship). Rust just persists the produced bytes to a chosen path.
+- **Plan 13 is only partial in source:** `fflate` is installed and used by
+  `importReflectMarkdownZip`; the Markdown/JSON/HTML export pipeline described in the
+  plan is still outstanding.
 - **The CLI (Plan 14) is a Rust binary** (superseding the earlier `cac` + `node:sqlite`
   Node-CLI choice): rusqlite `bundled` gives the same SQLite + FTS5 as the desktop app via
   one workspace lockfile, and the binary ships as a Tauri sidecar. `saphyr` is chosen for


### PR DESCRIPTION
## Summary
- refresh the plan overview to reflect current source status for capture, import/export, mobile, audio memos, and chat persistence
- update Plan 13, Plan 15, Plan 19, and libraries docs against the codebase
- clean up stale plan language around daily stream, chat scope, link capture, and meowdown spike links

## Testing
- pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security behavior changes.
> 
> **Overview**
> Replaces the **2026-06-12 first-release snapshot** in `00-overview.md` with **current source status (2026-06-14)**: Plans **01–12** and **14–17** are described as implemented, **Plan 11** is no longer deferred, **Plan 13** is partial (V1 Markdown ZIP only), **Plan 19** is in progress, and **audio memos** / **durable `chat_*` persistence** are called out as beyond-plan additions. The plans table, **M4** milestone note, portability guardrail, and deferred/mobile wording are updated to match.
> 
> Individual plans are aligned to the tree: **06b** daily stream marked implemented; **10** scoped to read-only Chat + multi-provider SDK (no `diff`/patchsets); **11** status date + dual sidecar bundling; **13** partial importer details and acceptance criteria; **15** privacy/release checklist includes capture host, extension capture, and `pnpm release:macos publish` CI; **19** in-progress block and steps 3–4 status. **`libraries.md`** is reconciled with `package.json`/`Cargo.toml` (Radix/shadcn, no zustand/jsdiff, `reqwest`, keyboard plugin, Plan 13 export still outstanding). **`05-markdown-editor.md`** fixes the meowdown spike link path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8ff45ff2d77a2aee826a6805efc94371174f436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->