### PR TITLE
docs: update contributing guides

### DIFF
--- a/docs/contributing/adding-a-command.md
+++ b/docs/contributing/adding-a-command.md
@@ -23,10 +23,10 @@ on the commands that already exist.
 
 ## 1. The Rust command
 
-Pick the module that owns the capability (`fs.rs` for graph file IO, `db/` for
-the index, `settings.rs`, `recents.rs`, …) or add a new one for a genuinely new
-capability. Commands are snake_case, return `AppResult<T>`, and serialize
-camelCase:
+Pick the module that owns the capability (`fs/` for graph file IO, `db/` for
+the index, `settings.rs`, `recents.rs`, `secrets.rs`, `git/`, `capture.rs`,
+`embed.rs`, …) or add a new one for a genuinely new capability. Commands are
+snake_case, return `AppResult<T>`, and serialize camelCase:
 
 ```rust
 // apps/desktop/src-tauri/src/fs/mod.rs
@@ -59,10 +59,15 @@ Conventions that matter here:
   resolves it via `resolve()` (`fs/resolve.rs`), which rejects traversal and
   symlink escapes. Don't build paths by hand.
 - **Writes are generation-pinned.** Mutating commands take a `generation`
-  argument (from `graph_open`) and get the root via `root_for_generation`,
-  which rejects stale ones — a write racing a graph switch fails loudly
-  instead of landing in the wrong graph. A new mutating command must follow
-  this pattern; read-only commands use `current_root`.
+  argument (from `graph_open`/`graph_create`) and get the root via
+  `root_for_generation`, which rejects stale ones — a write racing a graph
+  switch fails loudly instead of landing in the wrong graph. A new mutating
+  command must follow this pattern.
+- **Background reads may also pin.** UI reads for the currently open graph can
+  use `current_root`, but a read that belongs to a background pass that can
+  span a graph switch should accept `generation: Option<u64>` (or a required
+  `generation`, if the pass always has one) and use the `root_for` pattern
+  from `fs::note_read`/`asset_read`.
 - **No product policy.** A command exposes a primitive. If you find yourself
   encoding "what to do when X", that decision belongs in `@reflect/core`.
 
@@ -73,7 +78,13 @@ runtime with a "command not found" rejection.
 Test the logic with `#[cfg(test)]` against the pure helper, not the command
 wrapper: `settings.rs` is a good model — `settings_load`/`settings_save` are
 two-liners over `load_from`/`save_to`, and the tests exercise those with
-`tempfile`. Run with `cargo test` from `apps/desktop/src-tauri`.
+`tempfile`. From the repo root, stage the sidecars once before compiling the
+desktop crate, then run the crate tests:
+
+```bash
+pnpm --filter @reflect/desktop sidecar
+cargo test -p reflect-open
+```
 
 ## 2. The TypeScript binding
 
@@ -133,8 +144,10 @@ it.
 
 - [ ] Rust: command in the owning capability module, returns `AppResult<T>`,
       camelCase serde, traversal-guarded paths, generation-pinned if mutating
+      (and pinned for background reads that can span a graph switch)
 - [ ] Rust: registered in `lib.rs` `generate_handler!`
-- [ ] Rust: `#[cfg(test)]` tests on the pure helper; `cargo test` passes
+- [ ] Rust: `#[cfg(test)]` tests on the pure helper; `cargo test -p reflect-open`
+      passes after staging sidecars when the desktop crate compiles
 - [ ] TS: zod schema + typed binding through `call()` in the domain module
 - [ ] TS: exported from `packages/core/src/index.ts`
 - [ ] TS: behavior covered with a fake bridge where it matters

--- a/docs/contributing/adding-a-setting.md
+++ b/docs/contributing/adding-a-setting.md
@@ -12,6 +12,7 @@ responsibilities follows the usual rule:
   keys, their defaults, and validation.
 - **The desktop app** consumes settings through `useSettings()`
   (`apps/desktop/src/providers/settings-provider.tsx`) and renders controls in
+  section components under `apps/desktop/src/components/settings/`, composed by
   `settings-screen.tsx`.
 
 ## 1. Declare the key in the schema
@@ -52,9 +53,10 @@ invalid, accepted values pass through.
 ## 2. Consume it
 
 ```tsx
-const { settings, updateSettings } = useSettings()
+const { settings, updateSettings, updateSettingsWith } = useSettings()
 // read:  settings.yourNewSetting
-// write: updateSettings({ yourNewSetting: value })
+// write scalar: updateSettings({ yourNewSetting: value })
+// write derived/list value: updateSettingsWith((current) => ({ yourList: nextList(current) }))
 ```
 
 Semantics you get for free from the provider (and must not re-implement):
@@ -66,14 +68,28 @@ Semantics you get for free from the provider (and must not re-implement):
   hydration (nothing is written before the disk document has been read), and
   save the full merged document. Failures surface through the operations
   status UI and retry on the next change or the quit flush.
+- **Functional updates for read-modify-write.** Use `updateSettingsWith` for
+  list/object edits or anything derived from the current document. Updaters
+  dispatched before hydration are queued and replayed over the loaded
+  document, so an early edit cannot accidentally compute from defaults and
+  wipe the stored value.
+- **Load-sensitive side effects must await hydration.** If a settings entry is
+  paired with state elsewhere (for example an OS-keychain secret), call
+  `whenSettingsLoaded()` before writing the other half. If the initial load
+  failed, settings are session-only and the paired write would be stranded.
 - **No save button.** Settings apply live — design your control accordingly.
 
 ## 3. Add the control
 
 `apps/desktop/src/components/settings-screen.tsx` is a routed view (⌘, or the
 palette's "Open settings") composed of one section component per group under
-`apps/desktop/src/components/settings/`. Build yours from the shared
-primitives in that directory rather than hand-rolling markup:
+`apps/desktop/src/components/settings/`. Add new groups to
+`SETTINGS_SECTIONS` (`settings/sections.ts`) and render the matching component
+from `SettingsScreen`; the sticky navigator and section DOM ids derive from
+that registry.
+
+Build the section from the shared settings primitives rather than hand-rolling
+the section/card markup:
 
 - `SettingsSection` (`section.tsx`) — the heading + bordered card per group.
 - `SettingsField` (`field.tsx`) — the `<fieldset>` with a `legend` and a
@@ -81,12 +97,21 @@ primitives in that directory rather than hand-rolling markup:
 - `SettingsOptionCard` (`option-card.tsx`) — one choice in a radio group, with
   the shared selected/hover/focus treatment.
 
-`onChange` calls `updateSettings` directly (see `appearance-section.tsx` for
-the complete shape). Add a test in `settings-screen.test.tsx` — the existing
-ones render the screen inside the *real* provider over a fake bridge
-(`setBridge`), interact with the control, and assert the document that reaches
-`settings_save`. That covers the whole chain (control → patch → merge →
-persist), not just the click handler.
+For controls and overlays, check `apps/desktop/src/components/ui/` first and
+use the existing shadcn primitive (`Switch`, `Select`, `Dialog`, `Popover`,
+`Tooltip`, etc.) rather than building a custom one.
+
+`onChange` calls `updateSettings` or `updateSettingsWith` directly (see
+`appearance-section.tsx`, `editor-section.tsx`, and `all-notes-section.tsx` for
+the common shapes). Add the test at the narrowest useful level:
+
+- For a setting whose value should round-trip through the provider, use
+  `settings-screen.test.tsx`: it renders the screen inside the *real* provider
+  over a fake bridge (`setBridge`), interacts with the control, and asserts the
+  document that reaches `settings_save`.
+- For a section with its own branching behavior or provider dependencies, add
+  a focused section test next to it (for example `backup-section.test.tsx` or
+  `rebuild-index-field.test.tsx`) and mock only the surrounding providers.
 
 ## Checklist
 
@@ -95,5 +120,8 @@ persist), not just the click handler.
 - [ ] Schema tests: missing → default, invalid → default, valid round-trips
 - [ ] Section under `components/settings/` built from the shared primitives,
       wired to `updateSettings`
-- [ ] Screen test covering the new control
+- [ ] New section registered in `settings/sections.ts` and rendered from
+      `settings-screen.tsx` if it adds a group
+- [ ] Screen/provider test for persistence, plus focused section tests for
+      section-specific behavior where needed
 - [ ] No Rust changes, no migrations, no per-key save logic

--- a/docs/contributing/editor-architecture.md
+++ b/docs/contributing/editor-architecture.md
@@ -7,8 +7,9 @@ renames); this is the orientation layer those plans don't give you.
 ## The layers
 
 ```text
-NotePane / DailyStream                  components — composition only
+NotePane / DailyStream / MobileNote     components — composition only
   ├─ useNoteDocument()                  React adapter (use-note-document.ts)
+  │    ├─ createDocumentBinding()       create/adopt/teardown/hand-off policy
   │    └─ createNoteSession()           pure document state machine (note-session.ts)
   │         └─ readNote / writeNote     @reflect/core typed commands
   ├─ useWikiLinkNavigation()            [[link]] click → route / create
@@ -20,9 +21,12 @@ The load-bearing split is **session vs. adapter**: `note-session.ts` owns every
 save/conflict/protection rule as a pure state machine — no React, no editor, no
 IPC (file access is injected) — and `use-note-document.ts` only wires it to
 React state, the `@reflect/core` commands, the watcher stream, and the editor's
-imperative handle. Tests drive the session directly with fake IO
-(`note-session.test.ts`); if you're changing *what happens*, you're almost
-certainly in the session, and your test belongs there too.
+imperative handle. `document-binding.ts` owns the pane lifecycle around that
+session: create, adopt after a rename-following route change, teardown, and the
+microtask hand-off when a moved note is not adopted. Tests drive the session
+and binding directly with fake IO (`note-session.test.ts`,
+`document-binding.test.ts`); if you're changing *what happens*, you're almost
+certainly in one of those pure modules, and your test belongs there too.
 
 `NoteEditor` is **uncontrolled**: `initialContent` is read once, and showing
 different content goes through the imperative `NoteEditorHandle` (or a remount
@@ -35,15 +39,17 @@ mistaken for a user edit.
 
 ```text
 keystroke → session.editorChanged() → debounce (800ms) → atomic write
-  → file watcher event → core reindex (the ONLY incremental index path)
+  → file watcher event / local-write echo → core reindex
   → the same event returns to the session → recognized as our echo → ignored
 ```
 
-Saving never triggers indexing directly: our own write flows
-file → watcher → index like any external change, so there is one reindex path
-to reason about (Plan 04b). On every change event the session re-reads the
-file and compares by content: a match against what it last wrote (or a
-still-settling in-flight write) is our own echo and is ignored.
+Saving never calls the indexer from the session: our own write flows through
+the same file-change pipeline as any external change. On desktop that signal
+comes from the watcher; on mobile, where the app sandbox has no external
+writers, the typed write binding emits an in-process local-write echo after
+the write lands. On every change event the session re-reads the file and
+compares by content: a match against what it last wrote (or a still-settling
+in-flight write) is our own echo and is ignored.
 
 Invariants the loop maintains:
 
@@ -51,9 +57,9 @@ Invariants the loop maintains:
   imperatively; a dirty one parks the external content as a `conflict` for the
   user ("keep mine" rewrites the file, "load theirs" discards the buffer).
 - **Writes are generation-pinned.** Every write carries the open graph's
-  generation (read at write time, not captured at session creation); Rust
-  rejects stale ones, so a flush racing a graph switch fails loudly instead of
-  landing in the wrong graph.
+  generation, read at write time rather than captured at session creation.
+  Rust rejects stale ones, so a flush racing a graph switch fails loudly
+  instead of landing in the wrong graph.
 - **Frontmatter belongs to the session, not the editor.** meowdown mangles a
   `---` block, so the session splits every disk read, keeps the exact header
   bytes aside, and rejoins them on every write. The editor only ever sees the
@@ -68,32 +74,41 @@ Invariants the loop maintains:
 ## Work that outlives a pane
 
 React unmount effects never run on the quit paths (window close, ⌘Q), and some
-editor work must survive pane teardown. Two pieces live outside React:
+editor work must survive pane teardown. The pieces to understand are:
 
+- **`document-binding.ts`** — the per-pane lifecycle policy. A rename can move
+  the file and retarget the live session before React has rendered the new
+  route; the binding lets the next render adopt that same session, preserving
+  cursor, selection, undo history, conflict state, and pending writes. If no
+  adoption happens, the deferred hand-off tears the session down.
 - **`open-documents.ts`** — the app-global registry of live sessions. Quit
   teardown (`flushOpenDocuments`) flushes every buffer and awaits settle-time
   work before the webview dies; the rename coordinator uses `openSession(path)`
   to discover whether a note is open (possibly *reopened* in a new pane) and
   route through its live session instead of racing the disk.
-- **`rename-coordinator.ts` + `title-rename.ts`** — the auto-rename flow
-  (Plan 07b). The tracker watches the session's `onContent` stream and fires
-  only on *settled* titles (quiet timer, or a settle point: blur/teardown/quit)
-  — never per keystroke, so intermediate titles don't spray junk rewrites
-  across the graph. The coordinator serializes the graph-wide link rewrite and
-  records the old title as an alias, reporting progress through the global
-  operations store — a rename is app-level background work, not pane state.
+- **`rename-coordinator.ts` + `title-rename.ts` + `move-note.ts`** — the
+  auto-rename flow (Plans 07b/17). The tracker watches the session's
+  `onContent` stream and fires only on *settled* titles (quiet timer, or a
+  settle point: blur/teardown/quit) — never per keystroke, so intermediate
+  titles don't spray junk rewrites across the graph. The coordinator
+  serializes the graph-wide link rewrite, records the old title as an alias,
+  and moves the file onto the new title's slug, reporting progress through the
+  global operations store — a rename is app-level background work, not pane
+  state.
 
 ## File map
 
 | File | Owns |
 |---|---|
 | `note-session.ts` | save pipeline, conflicts, protection, frontmatter — the rules |
+| `document-binding.ts` | create/adopt/teardown/hand-off lifecycle for one pane |
 | `use-note-document.ts` | React adapter: session ↔ state/commands/watcher/editor |
 | `note-editor.tsx` | meowdown composition + our extensions; imperative handle |
 | `roundtrip.ts` | fidelity classification (`exact` / `normalizing` / `lossy`) |
 | `open-documents.ts` | app-global live-session registry; quit flush |
 | `title-rename.ts` | settled-title detection (pure, timer-driven) |
-| `rename-coordinator.ts` | rename lifecycle: rewrite chain + alias placement |
+| `rename-coordinator.ts` | rename lifecycle: rewrite chain + alias placement + file move |
+| `move-note.ts` | move a note while carrying/following a live session |
 | `wiki-links.ts` | `[[…]]` chips as view decorations over literal text |
 | `wiki-autocomplete.tsx` / `-entries.ts` | `[[` popover; pure row assembly |
 | `use-wiki-link-navigation.ts` | chip click → resolve → navigate or create |
@@ -113,4 +128,7 @@ editor work must survive pane teardown. Two pieces live outside React:
   `packages/core/src/markdown/`, never the editor: the editor and the indexer
   share one grammar so chips and index links can't drift.
 - **Pane-level wiring** → a focused hook next to the existing ones, composed
-  in `note-pane.tsx`; components stay composition-only.
+  in `note-pane.tsx`; components stay composition-only. Desktop daily notes
+  mount panes through `daily-stream.tsx`; mobile mounts the same `NotePane`
+  through `mobile/day-carousel.tsx` and `mobile/screens/note.tsx`, so keep
+  note semantics shared and put surface-specific chrome outside the pane.


### PR DESCRIPTION
## Summary
- refresh native command docs with current Rust modules, generation pinning, and desktop crate test workflow
- update settings docs for section registration, shadcn primitives, functional settings updates, and current test patterns
- update editor architecture docs for document binding, mobile composition, local-write echo, and rename/file-move lifecycle

## Testing
- git diff --check
- pnpm check
- pnpm build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation updates with no runtime or build changes.
> 
> **Overview**
> Updates three contributor docs so they match current patterns without changing application code.
> 
> **Native commands** (`adding-a-command.md`) now points at `fs/` and a fuller set of capability modules, clarifies **generation pinning** for writes and for background reads that can outlive a graph switch, and documents the **sidecar + `cargo test -p reflect-open`** workflow instead of a generic `cargo test`.
> 
> **Settings** (`adding-a-setting.md`) adds **`SETTINGS_SECTIONS`**, **`updateSettingsWith`**, **`whenSettingsLoaded()`**, shadcn **`components/ui`** primitives, and a split testing approach (screen/provider round-trip vs focused section tests).
> 
> **Editor** (`editor-architecture.md`) documents **`document-binding.ts`**, mobile **`NotePane`** mounting, **local-write echo** on mobile vs the desktop watcher, and rename lifecycle including **`move-note.ts`** and file moves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96ac009ebda4bd6927559fa5589ff9b6c3af9e87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->