### PR TITLE
Render Markdown escapes in note index

### DIFF
--- a/packages/core/src/indexing/indexed-note.ts
+++ b/packages/core/src/indexing/indexed-note.ts
@@ -37,9 +37,10 @@ import { previewSnippet } from './snippet'
  * 3 — repairs `notes.mtime` 0 rows written by the watcher path before it
  * carried `modifiedMs` (hash-reconcile can never refresh them) ·
  * 4 — `notes.has_conflict` (sync conflict markers, Plan 12) ·
- * 5 — `notes.gist_url` + `notes.gist_stale` (gist publishing).
+ * 5 — `notes.gist_url` + `notes.gist_stale` (gist publishing) ·
+ * 6 — rendered Markdown escapes in titles, wiki-link targets, and previews.
  */
-export const PROJECTION_VERSION = 5
+export const PROJECTION_VERSION = 6
 
 export const indexedLinkSchema = z.object({
   kind: z.enum(['wiki', 'md']),

--- a/packages/core/src/markdown/extract.test.ts
+++ b/packages/core/src/markdown/extract.test.ts
@@ -19,6 +19,14 @@ describe('parseNote — wiki links', () => {
     expect(first.to).toBe('See [[Charlotte]]'.length)
   })
 
+  it('renders markdown escapes inside wiki-link targets and aliases', () => {
+    const note = parse('See [[www\\.reddit.com/r/test|www\\.reddit.com]].')
+    expect(note.wikiLinks.map((w) => ({ target: w.target, alias: w.alias }))).toEqual([
+      { target: 'www.reddit.com/r/test', alias: 'www.reddit.com' },
+    ])
+    expect(note.text).toBe('See www.reddit.com/r/test www.reddit.com.')
+  })
+
   it('does not match wiki links inside code spans or empty brackets', () => {
     const note = parse('Code `[[NotALink]]` stays literal, and [[]] is ignored.')
     expect(note.wikiLinks).toEqual([])
@@ -37,6 +45,15 @@ describe('parseNote — headings & title', () => {
       expect.objectContaining({ level: 1, text: 'Title', slug: 'title' }),
       expect.objectContaining({ level: 2, text: 'A Section!', slug: 'a-section' }),
     ])
+  })
+
+  it('renders markdown escapes in headings and derived titles', () => {
+    const note = parse('# www\\.reddit.com/r/test\n\nbody')
+    expect(note.title).toBe('www.reddit.com/r/test')
+    expect(note.headings[0]).toEqual(
+      expect.objectContaining({ text: 'www.reddit.com/r/test', slug: 'wwwredditcomrtest' }),
+    )
+    expect(note.text).toBe('www.reddit.com/r/test body')
   })
 
   it('derives title from frontmatter, else first H1, else filename/date', () => {

--- a/packages/core/src/markdown/extract.test.ts
+++ b/packages/core/src/markdown/extract.test.ts
@@ -114,6 +114,11 @@ describe('parseNote — links, assets, tags, text', () => {
     expect(note.text).toBe('Hi Some bold text with Link alias.')
   })
 
+  it('keeps markdown escapes literal inside code text', () => {
+    const note = parse('Rendered www\\.reddit.com, code `www\\.reddit.com`.\n\n```\nwww\\.reddit.com\n```')
+    expect(note.text).toBe('Rendered www.reddit.com, code www\\.reddit.com. www\\.reddit.com')
+  })
+
   it('keeps #tags inside fenced code out of the tag list', () => {
     const note = parse('real #tag\n\n```\nnot #acode tag\n```')
     expect(note.tags).toEqual(['tag'])

--- a/packages/core/src/markdown/extract.ts
+++ b/packages/core/src/markdown/extract.ts
@@ -39,6 +39,12 @@ export function isTagName(value: string): boolean {
 }
 // Inner of a wiki link, for plain-text rendering.
 const WIKI_INNER_RE = /\[\[([^\]\n]*)\]\]/g
+// CommonMark backslash escapes are visible in source, but not rendered text.
+const MARKDOWN_ESCAPE_RE = /\\([!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/g
+
+function unescapeMarkdownText(text: string): string {
+  return text.replace(MARKDOWN_ESCAPE_RE, '$1')
+}
 
 /** Names whose source range is markup to drop from plain text. */
 function isSyntaxNode(name: string): boolean {
@@ -64,12 +70,10 @@ function headingLevelOf(name: string): number | null {
 function cleanHeadingText(raw: string): string {
   const newline = raw.indexOf('\n')
   if (newline !== -1) {
-    return raw.slice(0, newline).trim() // setext: heading text is the first line
+    return unescapeMarkdownText(raw.slice(0, newline).trim()) // setext: heading text is the first line
   }
-  return raw
-    .replace(/^#{1,6}[ \t]*/, '')
-    .replace(/[ \t]*#*[ \t]*$/, '')
-    .trim()
+  const text = raw.replace(/^#{1,6}[ \t]*/, '').replace(/[ \t]*#*[ \t]*$/, '').trim()
+  return unescapeMarkdownText(text)
 }
 
 /** GitHub-style anchor slug. */
@@ -113,8 +117,9 @@ function basename(path: string): string {
 function readWikiLink(body: string, from: number, to: number, offset: number): WikiLink {
   const inner = body.slice(from + 2, to - 2)
   const pipe = inner.indexOf('|')
-  const target = (pipe === -1 ? inner : inner.slice(0, pipe)).trim()
-  const alias = pipe === -1 ? undefined : inner.slice(pipe + 1).trim() || undefined
+  const target = unescapeMarkdownText((pipe === -1 ? inner : inner.slice(0, pipe)).trim())
+  const alias =
+    pipe === -1 ? undefined : unescapeMarkdownText(inner.slice(pipe + 1).trim()) || undefined
   return { target, alias, from: from + offset, to: to + offset }
 }
 
@@ -141,6 +146,7 @@ function buildPlainText(body: string, cuts: Span[]): string {
   kept += body.slice(pos)
   return kept
     .replace(WIKI_INNER_RE, (_, inner: string) => inner.replace(/\|/g, ' '))
+    .replace(MARKDOWN_ESCAPE_RE, '$1')
     .replace(/\s+/g, ' ')
     .trim()
 }

--- a/packages/core/src/markdown/extract.ts
+++ b/packages/core/src/markdown/extract.ts
@@ -62,6 +62,10 @@ function isTagExcludedNode(name: string): boolean {
   )
 }
 
+function isLiteralPlainTextNode(name: string): boolean {
+  return name === 'InlineCode' || name === 'FencedCode' || name === 'CodeBlock'
+}
+
 function headingLevelOf(name: string): number | null {
   const match = /^(?:ATXHeading|SetextHeading)([1-6])$/.exec(name)
   return match ? Number(match[1]) : null
@@ -132,23 +136,56 @@ function readLink(body: string, from: number, to: number, offset: number): Markd
   return { href, text, from: from + offset, to: to + offset, domain: hostOf(href) }
 }
 
+function renderMarkdownText(text: string): string {
+  return text
+    .replace(WIKI_INNER_RE, (_, inner: string) => inner.replace(/\|/g, ' '))
+    .replace(MARKDOWN_ESCAPE_RE, '$1')
+}
+
+function appendPlainTextChunk(
+  body: string,
+  from: number,
+  to: number,
+  literalRanges: Span[],
+): string {
+  let kept = ''
+  let cursor = from
+  for (const literalRange of literalRanges) {
+    if (literalRange.to <= cursor) {
+      continue
+    }
+    if (literalRange.from >= to) {
+      break
+    }
+
+    const literalFrom = Math.max(cursor, literalRange.from)
+    const literalTo = Math.min(to, literalRange.to)
+    if (cursor < literalFrom) {
+      kept += renderMarkdownText(body.slice(cursor, literalFrom))
+    }
+    kept += body.slice(literalFrom, literalTo)
+    cursor = literalTo
+  }
+  if (cursor < to) {
+    kept += renderMarkdownText(body.slice(cursor, to))
+  }
+  return kept
+}
+
 /** Body text minus the cut (syntax) ranges, with wiki brackets/pipes flattened. */
-function buildPlainText(body: string, cuts: Span[]): string {
+function buildPlainText(body: string, cuts: Span[], literalRanges: Span[]): string {
   const sorted = [...cuts].sort((a, b) => a.from - b.from)
+  const sortedLiteralRanges = [...literalRanges].sort((a, b) => a.from - b.from)
   let kept = ''
   let pos = 0
   for (const cut of sorted) {
     if (cut.from > pos) {
-      kept += body.slice(pos, cut.from)
+      kept += appendPlainTextChunk(body, pos, cut.from, sortedLiteralRanges)
     }
     pos = Math.max(pos, cut.to)
   }
-  kept += body.slice(pos)
-  return kept
-    .replace(WIKI_INNER_RE, (_, inner: string) => inner.replace(/\|/g, ' '))
-    .replace(MARKDOWN_ESCAPE_RE, '$1')
-    .replace(/\s+/g, ' ')
-    .trim()
+  kept += appendPlainTextChunk(body, pos, body.length, sortedLiteralRanges)
+  return kept.replace(/\s+/g, ' ').trim()
 }
 
 function inAnyRange(index: number, ranges: Span[]): boolean {
@@ -221,6 +258,7 @@ export function parseNote(input: { path: string; source: string }): ParsedNote {
   const assets: AssetRef[] = []
   const cuts: Span[] = [] // body coords — syntax to drop from plain text
   const tagExcluded: Span[] = [] // body coords — regions that don't yield tags
+  const literalPlainText: Span[] = [] // body coords — regions that render backslashes literally
 
   tree.iterate({
     enter: (node) => {
@@ -231,6 +269,9 @@ export function parseNote(input: { path: string; source: string }): ParsedNote {
       }
       if (isTagExcludedNode(name)) {
         tagExcluded.push({ from, to })
+      }
+      if (isLiteralPlainTextNode(name)) {
+        literalPlainText.push({ from, to })
       }
 
       if (name === 'WikiLink') {
@@ -275,6 +316,6 @@ export function parseNote(input: { path: string; source: string }): ParsedNote {
     tags: [...tags.values()],
     headings,
     assets,
-    text: buildPlainText(body, cuts),
+    text: buildPlainText(body, cuts, literalPlainText),
   }
 }


### PR DESCRIPTION
## Summary
- render CommonMark backslash escapes in extracted headings, wiki-link targets/aliases, and plain-text previews
- bump the index projection version so existing graphs rebuild stale escaped titles/previews
- add regression coverage for escaped URL-like headings and wiki links

## Testing
- pnpm --filter @reflect/core test -- src/markdown/extract.test.ts src/indexing/indexed-note.test.ts src/indexing/pipeline.test.ts
- pnpm check

Note: lint passes with existing warnings outside this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core markdown parsing and indexed title/preview/link derivation; the projection version bump triggers a full graph re-index, but behavior is localized to escape handling with targeted tests.
> 
> **Overview**
> **Note extraction** now treats CommonMark backslash escapes like rendered Markdown: headings, wiki-link targets/aliases, and collapsed plain-text previews unescape `\.` and similar, while **inline and fenced code** still keep backslashes literal.
> 
> Plain-text building was refactored so non-code spans run through escape + wiki flattening via `appendPlainTextChunk`, with code-block ranges passed through unchanged.
> 
> **Index projection** is bumped to **v6** so existing graphs re-index unchanged files and refresh titles, link keys, and previews that previously kept escape characters in the source form.
> 
> Regression tests cover URL-like escaped headings, wiki links, and mixed rendered vs code text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7393acb43f869213bff2dbe4d229b0abdf15e6ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->