### PR TITLE
Refresh Reflect V1 port status docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,20 +164,28 @@ contributor guide.
 
 ## Status & roadmap
 
-Reflect is early (`0.1.x`) but used daily. Shipped today: everything listed
-above. Designed but not yet built, each with a written plan:
+Reflect is early (`0.2.x` beta) but used daily. Shipped today: everything
+listed above, plus browser link capture through the Chrome extension/native
+host pipeline described in [Plan 11](docs/plans/11-link-capture.md).
 
-- **Browser link capture** ([Plan 11](docs/plans/11-link-capture.md)): a
-  Chrome extension that hands the page to the desktop app, which saves it
-  into today's note.
+Closed by decision:
+
 - **Import / export surfaces**
-  ([Plan 13](docs/plans/13-import-export-portability.md)): the graph is
-  already portable markdown you can copy wholesale; in-app Obsidian import
-  and Markdown/JSON/HTML export are still to come.
+  ([Plan 13](docs/plans/13-import-export-portability.md)): no dedicated
+  import/export suite is planned. The graph folder itself is the portable
+  artifact; copy or zip the markdown files and assets directly. The existing
+  V1 Markdown ZIP importer remains a migration convenience.
+
+Designed or in progress, each with a written plan:
+
 - **Tasks** ([Plan 18](docs/plans/18-tasks.md)): checkboxes in your notes,
   collected into one Tasks view.
+- **Mobile companion** ([Plan 19](docs/plans/19-mobile.md)): iOS is in
+  progress in the Tauri app, with Daily/All surfaces and editing foundations
+  landed; device validation, sync hardening, and TestFlight/App Store release
+  remain.
 
-Windows, mobile, and a plugin API are out of scope for now; the
+Windows, Android, and a plugin API are out of scope for now; the
 [product vision](docs/reflect-v2-product-vision.md) explains the long-term
 direction and what is deliberately *not* planned.
 

--- a/docs/plans/00-overview.md
+++ b/docs/plans/00-overview.md
@@ -4,18 +4,25 @@ This directory holds the numbered, dependency-ordered plans for building the **f
 version (first wave)** of Reflect V2: the open-source, local-first, markdown-native,
 AI-native rewrite described in the product docs.
 
-## Status at first release (2026-06-12)
+## Current status
 
-The first macOS release ships Plans 01–10, 12, 14–17 (Plan 16 at its V1 scope: SSH +
-path remotes; HTTPS credential helpers later). Two deliberate divergences:
+The first macOS release shipped Plans 01–10, 12, 14–17 (Plan 16 at its V1 scope:
+SSH + path remotes; HTTPS credential helpers later). Since that release, the
+roadmap has moved in a few places:
 
-- **Plan 11 (link capture) is deferred — the first release ships without the browser
-  integration.** The design and [bridge spike](../spikes/link-capture-bridge.md) stand;
-  the capture envelope/inbox architecture is unbuilt, and no extension exists yet.
-- **Plan 13 (import/export) has not been built.** The graph is already a plain markdown
-  folder (copyable, inspectable — the core portability promise holds), but the in-app
-  import (Obsidian/markdown) and export (Markdown/JSON/HTML ZIP) surfaces are
-  outstanding.
+- **Plan 11 (link capture) is now implemented.** The WXT Chrome extension,
+  native-messaging host sidecar, capture inbox, desktop drain controller, screenshot
+  asset path, and BYOK enrichment flow are built end-to-end. Remaining capture work is
+  narrower: browser/store packaging validation beyond macOS, Safari/mobile share
+  targets, and full article/read-later clipping.
+- **Plan 13 (import/export portability) is closed by decision.** We are not building a
+  dedicated import/export suite. The graph folder itself is the portable artifact; copy
+  or zip `daily/`, `notes/`, and `assets/` directly. The existing V1 Markdown ZIP
+  importer remains a migration convenience, not a broader roadmap commitment.
+- **Plan 19 (mobile) is in progress.** The iOS Tauri target, fixed graph root,
+  onboarding, Daily/All mobile surfaces, keyboard-height plugin, and shared editor
+  plumbing have landed. Physical-device editor validation, foreground sync wiring,
+  background-flush/kill recovery, TestFlight/App Store release, and Android remain.
 
 Two features landed beyond the written plans: **audio memos** (raw-first capture with
 async BYOK cloud transcription — listed below as deferred, but shipped early via
@@ -64,15 +71,15 @@ before the editor, and the editor lands before search/AI.
 | 08 | [Lexical search & command palette](08-lexical-search-and-command-palette.md) | `⌘K` search/command surface, FTS over titles/body, filters, navigation commands |
 | 09 | [Semantic search & local embeddings](09-semantic-search-and-embeddings.md) | Local embedding runtime (Rust), chunking, `sqlite-vec`, incremental re-embed, retrieval layer |
 | 10 | [AI copilot sidebar](10-ai-copilot-sidebar.md) | BYOK provider, keychain secrets, context/retrieval, chat/summarize/rewrite, reviewable patchsets, `private: true` hard-block |
-| 11 | [Link capture](11-link-capture.md) | **Deferred — not in the first release.** Chrome extension → native-messaging bridge → desktop write path, screenshots, BYOK enrichment, daily-note `[[Links]]` |
+| 11 | [Link capture](11-link-capture.md) | **Implemented.** Chrome extension → native-messaging host/inbox → desktop write path, screenshots, BYOK enrichment, daily-note `[[Links]]` |
 | 12 | [Backup & sync (GitHub-only)](12-backup-and-sync.md) | GitHub/Git backup + restore (the only supported remote), Git-native conflict surface, manual review, checkpoints; file-sync providers unsupported |
-| 13 | [Import / export / portability](13-import-export-portability.md) | **Not started — outstanding at release.** Markdown/Obsidian-graph import, JSON/Markdown/HTML export, attachments preserved |
+| 13 | [Import / export / portability](13-import-export-portability.md) | **Closed by decision.** Markdown files are the portability surface; no JSON/HTML/ZIP export or Obsidian/folder import suite is planned |
 | 14 | [CLI (read/discovery)](14-cli-read-discovery.md) | `reflect today`, `reflect search`, `reflect show`, path lookup |
 | 15 | [Hardening, packaging & OSS release](15-hardening-packaging-release.md) | a11y, perf budgets, signing/notarization, MIT + docs, onboarding, release pipeline |
 | 16 | [Generic git remotes](16-generic-git-remotes.md) | Any git host (GitLab/Gitea/GHES/NAS) via hand-wired `origin`, zero new UI — V1 SSH (agent) + path remotes, V2 HTTPS (credential helpers) |
 | 17 | [Readable filenames](17-readable-filenames.md) | Title-derived note filenames (slug + collision suffix), frontmatter `id` adoption, rename-on-settled-title file moves, id-healed external renames |
 | 18 | [Tasks](18-tasks.md) | **Post-release add-on.** GFM-checkbox tasks as a rebuildable projection: interactive editor checkboxes, Tasks view (Overdue/Today/Upcoming), `[[date]]`/daily scheduling, guarded toggle write-back, `checklist: true` opt-out |
-| 19 | [Mobile companion](19-mobile.md) | **Post-release add-on.** iOS (then Android) as a target of the existing Tauri app: today/daily browsing, in-place note editing, quick capture, new notes, lexical search, GitHub sync parity; shell decision in [TDR 0003](../decisions/0003-mobile-shell.md) |
+| 19 | [Mobile companion](19-mobile.md) | **In progress.** iOS as a target of the existing Tauri app: Daily/All surfaces and editing foundations landed; device validation, sync hardening, TestFlight/App Store, then Android remain |
 
 ## Milestone map
 
@@ -91,9 +98,10 @@ demonstrable.
 - **M2 — A connected graph you can find** (Plans 07–09): backlinks, `⌘K` lexical
   search, then local semantic search.
 - **M3 — AI-native** (Plan 10): the right-sidebar copilot over local context.
-- **M4 — Capture & durability** (Plans 11–13): link capture, backup/sync, import/export.
-  *(Shipped partially: backup/sync landed; link capture was cut from the first release;
-  import/export is unbuilt. Audio-memo capture shipped instead, ahead of plan.)*
+- **M4 — Capture & durability** (Plans 11–13): link capture, backup/sync, and the
+  markdown-folder portability contract. *(Shipped substantially: backup/sync, link
+  capture, and audio memos landed; Plan 13 is closed because the graph itself is the
+  export.)*
 - **M5 — Reach & release** (Plans 14–15): CLI, hardening, packaging, open-source launch.
 
 ## Dependency graph (abridged)
@@ -102,7 +110,7 @@ demonstrable.
 01 ─┬─ 02 ─┬─ 03 ─┬─ 04 ─┬─ 05 ─ 06 ─┬─ 07 ─┬─ 08 ─ 09 ─ 10
     │      │      │      │           │      │
     │      │      │      └───────────┴──────┘  (index feeds backlinks + search)
-    │      │      └─ 13 (import/export needs the doc model)
+    │      │      └─ 13 (closed: markdown graph is the portability surface)
     │      └─ 11 (capture writes via the file/IO + daily-note contract)
     └─ 12 (GitHub-only backup/sync; thin internal seam, after M1)
 14 (CLI) reuses 02+03+04.  15 (release) gates everything.
@@ -144,8 +152,9 @@ they are not re-litigated per phase:
   external service — AI, capture enrichment, conflict resolution, or otherwise.
 - **Secrets live in the OS keychain.** Never in markdown, Git, or `.reflect/`.
 - **Keyboard-native.** Every core workflow reachable from the keyboard.
-- **Portable data + export from day one.** Backup must be free, via **GitHub only**;
-  file-sync providers (iCloud/Dropbox/Drive) are unsupported for sync by design.
+- **Portable data from day one.** The graph folder itself is the export; backup must be
+  free, via **GitHub only**. File-sync providers (iCloud/Dropbox/Drive) are unsupported
+  for sync by design.
 - **No Electron, no web app, Mac-first.** Tauri shell; iOS/Windows later.
 - **MIT open-source core.** Write as if the code is public and will be critiqued. The
   editor [meowdown](https://github.com/prosekit/meowdown) is **first-party** (owned by the
@@ -154,15 +163,14 @@ they are not re-litigated per phase:
 ## Explicitly deferred (NOT first wave)
 
 Do not build these now; keep the door open in the data model. Tasks (now planned as a
-post-release add-on — [Plan 18](18-tasks.md)), link capture
-(Plan 11 — designed, deferred from the first release), full browser clipper / article
-extraction, graph-map view, templates,
+post-release add-on — [Plan 18](18-tasks.md)), full browser clipper / article
+extraction beyond the implemented Plan 11 link-capture flow, graph-map view, templates,
 contacts/calendar, publishing, any non-GitHub sync (iCloud/Dropbox/Drive are unsupported
 by design, not "deferred"), a public plugin API, typed-entity layer, and full multi-device
-sync conflict automation (incl. AI-assisted resolution). Mobile
-did not block the Mac release and is now planned as a post-release add-on —
-[Plan 19](19-mobile.md): capture/read/**edit**/lexical-search on iOS first (Tauri
-mobile, per [TDR 0003](../decisions/0003-mobile-shell.md)), Android shortly after.
+sync conflict automation (incl. AI-assisted resolution). Mobile did not block the Mac
+release, but [Plan 19](19-mobile.md) is now underway: capture/read/**edit**/lexical-search
+on iOS first (Tauri mobile, per [TDR 0003](../decisions/0003-mobile-shell.md)), Android
+shortly after.
 
 ## Conventions (apply to every plan)
 

--- a/docs/plans/03-markdown-document-model.md
+++ b/docs/plans/03-markdown-document-model.md
@@ -104,9 +104,9 @@ edits — and write the wiki-link inline extension exactly once. A single
 by node position rather than re-serializing. The editor's `docToMarkdown` and these edits
 operate on the same syntax, so a round-trip test covers both.
 
-**remark is optional, and only for HTML export** (Plan 13), where `mdast`→`mdast-util-to-
-hast` is convenient. If we use it there, it's a leaf dependency of the export action, not
-the canonical model. (Even that can be done from the Lezer tree if we prefer zero remark.)
+**remark is intentionally out of the editor/indexer hot path.** Plan 13 is closed by
+product decision, so there is no planned HTML export pipeline that would justify adding
+remark for portability.
 
 ## Key decisions / contracts
 

--- a/docs/plans/13-import-export-portability.md
+++ b/docs/plans/13-import-export-portability.md
@@ -1,96 +1,51 @@
 # Plan 13 — Import / Export / Portability
 
-> **Status (2026-06-12): Not started — outstanding at the first release.** The graph is
-> already a plain markdown folder (the core "open your folder and it's just files"
-> promise holds, and Obsidian-style vaults are close enough to open directly in many
-> cases), but none of the in-app surfaces below — previewed import, Markdown/JSON/HTML
-> ZIP export — exist yet.
+> **Status:** Closed by product decision. We are **not** building a dedicated
+> import/export portability surface. Reflect's portability contract is the graph
+> itself: ordinary markdown files in `daily/`, `notes/`, and `assets/`, plus a
+> rebuildable `.reflect/` index that can be deleted at any time.
 
-**Goal:** Make data ownership tangible from day one: import existing markdown/Obsidian
-graphs, and export the graph to Markdown, JSON, and HTML with backlinks, tags, and
-daily dates preserved.
+## Decision
 
-**Depends on:** Plan 02 (file IO), Plan 03 (doc model), Plan 04 (projections for export
-metadata).
-**Unlocks:** trust + adoption; a migration on-ramp.
+Markdown is good enough.
 
-**Libraries:** export is client-side TS — `fflate` (ZIP) + the editor's ProseMirror
-`DOMSerializer` for HTML (no remark). See [Libraries](libraries.md).
+The original plan called for previewed Markdown/Obsidian import plus Markdown,
+JSON, and HTML ZIP export. That work is no longer planned. It adds product and
+maintenance surface without improving the core promise: the user's durable data is
+already plain files they can copy, back up, edit, zip, inspect in GitHub, or open in
+another markdown tool.
 
-## Scope
+The small V1 Markdown ZIP importer that exists today is treated as a migration
+convenience, not the start of a broader import/export suite.
 
-**In:** Markdown / Obsidian-style graph import; full-graph export to Markdown ZIP,
-JSON, and HTML ZIP; attachments preserved; backlinks/tags/daily-dates preserved.
-**Out:** V1 graph migration (later — not a first-wave constraint), Evernote/Roam/Notion/
-Readwise importers (later), publishing (deferred).
+## Portability Contract
 
-## Why now (not later)
+- The graph folder is the export. Copy or zip the folder directly.
+- `daily/`, `notes/`, and `assets/` contain the user-owned durable data.
+- `.reflect/` is excluded from the portability contract. It is a rebuildable local
+  projection, except for explicitly documented durable local tables such as
+  `chat_*`.
+- Markdown frontmatter carries minimal metadata such as stable IDs, aliases,
+  `private`, `pinned`, and capture provenance.
+- Backlinks, tags, daily-note dates, attachments, and readable filenames remain useful
+  outside Reflect because they are encoded in the files themselves.
 
-Portability is an explicit Reflect value, not a checkbox. Because the source of truth is
-already plain markdown files, "export" is mostly faithful copying + format conversion —
-cheap to do well early, and a strong trust signal for an open-source launch.
+## Non-Goals
 
-## Steps
+- No Markdown ZIP export button.
+- No JSON export.
+- No HTML export.
+- No Obsidian/folder import workflow.
+- No generalized importer framework for Evernote, Roam, Notion, Readwise, Kindle, or
+  other apps.
+- No export-to-import round-trip test suite beyond the normal markdown parser,
+  writer, and index rebuild guarantees.
 
-1. **Import: markdown / Obsidian graph.** Point at a folder; copy/normalize into the
-   Reflect layout (`daily/`, `notes/`, `assets/`):
-   - detect daily notes by filename pattern → `daily/YYYY-MM-DD.md`;
-   - keep `[[wiki links]]` as-is (already the canonical syntax); map Obsidian aliases →
-     frontmatter `aliases` (Plan 03); carry attachments into `assets/` and fix relative
-     links;
-   - assign `id`s to regular notes without one; tolerate unknown frontmatter (Plan 03).
-   Run as a previewed job (counts, conflicts, skips) before writing. Reindex on finish.
+## What Remains
 
-2. **Import safety.** Never overwrite existing graph files silently; surface name
-   collisions; import into a subfolder or merge with explicit choices. Large imports show
-   progress and are cancellable.
+Keep the existing V1 Markdown ZIP importer working while it is useful for migration.
+Future migration tools can be considered case-by-case, but they should not reopen a
+general import/export product area unless the portability premise changes.
 
-   **Export runs client-side (TS):** zip with **`fflate`** (in `@reflect/core`); Rust just
-   persists the produced bytes to a chosen path via a save command. Perf is fine at our
-   scale, and it reuses libraries we already ship.
-
-3. **Export: Markdown ZIP.** The portable baseline — the graph *is* markdown, so export is
-   a faithful `fflate` ZIP of `daily/`, `notes/`, `assets/` (excluding `.reflect/`), with
-   links and frontmatter intact. This is the "open your folder and it's just files" promise,
-   packaged.
-
-4. **Export: JSON.** A structured dump (notes with id/path/title/frontmatter/body, links,
-   backlinks, tags, aliases, daily dates, asset references) for programmatic reuse and a
-   future re-import path. Derive from Plan 04 projections + file bodies; zod-typed schema.
-
-5. **Export: HTML ZIP.** Rendered, self-contained HTML — **reuse the editor**: parse each
-   note with `markdownToDoc` and serialize the ProseMirror doc to HTML via ProseMirror's
-   `DOMSerializer` (no remark; one parser everywhere). Wiki links → relative anchors,
-   assets bundled, zipped with `fflate`.
-
-6. **Round-trip guarantee.** Markdown export → fresh import reproduces an equivalent graph
-   (same notes, links, tags, dailies, attachments). This is the portability contract,
-   test-asserted.
-
-7. **Tests.** Obsidian fixture imports with links/aliases/attachments preserved; daily
-   detection; collision handling; each export format produced; markdown export→import
-   round-trip equivalence.
-
-## Key decisions / contracts
-
-- **Markdown export is a faithful copy** (source of truth is already files); JSON + HTML
-  are derived views.
-- **Import is previewed, non-destructive, and reindexed** on completion.
-- **Markdown round-trips** (export→import) to an equivalent graph.
-- **Attachments, backlinks, tags, daily dates, and aliases are always preserved.**
-
-## Acceptance criteria
-
-- Importing an Obsidian-style graph yields working notes, backlinks, aliases, and
-  attachments in Reflect layout, with a pre-write preview.
-- Export produces valid Markdown ZIP, JSON, and HTML ZIP excluding `.reflect/`.
-- Markdown export re-imported reproduces an equivalent graph (test-asserted).
-- `pnpm typecheck` + tests pass.
-
-## Risks
-
-- **Link/attachment path rewriting** during import (Obsidian shortest-path vs relative).
-  Mitigate with AST-based link rewriting (Plan 03) + a fixture corpus.
-- **Frontmatter dialect drift** across tools. Mitigate with tolerant parsing +
-  passthrough of unknown keys (Plan 03).
-- **Large-graph performance.** Stream + batch; show progress; keep memory bounded.
+The acceptance criterion for this plan is now simple: a user can close Reflect, copy
+their graph folder, and still have their notes and assets in normal markdown files.

--- a/docs/plans/14-cli-read-discovery.md
+++ b/docs/plans/14-cli-read-discovery.md
@@ -196,7 +196,7 @@ note is blocked even when the index is stale or absent.
 
 `--json` emits stable serde-serialized camelCase shapes, documented in `docs/cli.md` and
 locked by snapshot tests (the Rust analog of the original zod contract; share field names
-with the Plan 13 export JSON where sensible):
+with markdown frontmatter where sensible):
 
 ```jsonc
 // today / show

--- a/docs/plans/15-hardening-packaging-release.md
+++ b/docs/plans/15-hardening-packaging-release.md
@@ -13,8 +13,9 @@ docs, and a release pipeline. This is **M5.**
 performance budgets, error/repair UX, privacy review, signing/notarization, MIT licensing
 + public docs, CI, and **auto-update** (Tauri updater plugin).
 **Out:** mobile release (planned, separate track), Windows/Android (later), publishing/
-tasks (deferred features), link capture (Plan 11 — deferred from the first release).
-Audio memos shipped ahead of plan and are **in** scope for the privacy review.
+tasks (deferred features), and full browser clipping/article extraction. Audio memos and
+Plan 11 link capture both shipped beyond the original release scope and are **in** scope
+for the privacy review.
 
 ## Steps
 
@@ -42,7 +43,7 @@ Audio memos shipped ahead of plan and are **in** scope for the privacy review.
 
 6. **Privacy review (release gate).** End-to-end audit that `private: true` is enforced at
    every external call site — copilot (Plan 10), retrieval (Plan 09), audio transcription,
-   conflict resolution (Plan 12). (Capture, Plan 11, joins this list when it ships.) Confirm secrets are keychain-only (never markdown/Git/
+   capture enrichment (Plan 11), and conflict resolution (Plan 12). Confirm secrets are keychain-only (never markdown/Git/
    `.reflect/`) and that no Reflect-hosted API exists in the core path. Document exactly
    what leaves the device and when.
 
@@ -53,8 +54,8 @@ Audio memos shipped ahead of plan and are **in** scope for the privacy review.
    binary fails notarization. Bundle the `reflect` CLI (Plan 14); consider a Homebrew cask.
    Confirm **first
    release is notarized non-sandboxed** (security-scoped bookmarks, Plan 02, only needed if
-   we later sandbox for the App Store). Native-messaging host registration is moot for the
-   first release (link capture, Plan 11, is deferred). **Two distinct keys:** Apple Developer ID (Gatekeeper/
+   we later sandbox for the App Store). Native-messaging host registration and signing are
+   part of the release bundle now that Plan 11 ships a host sidecar. **Two distinct keys:** Apple Developer ID (Gatekeeper/
    notarization) *and* the Tauri **updater signing key** (minisign, verifies update payloads
    — step 10); both private keys live in CI secrets, never in the repo.
 
@@ -99,8 +100,7 @@ A user can: install the Mac app; open today's markdown daily note instantly; wri
 beautiful markdown editor without thinking about files; create `[[Wiki Links]]` naturally;
 search locally; ask the AI sidebar about the current and related notes with their own key;
 back up their notes for free; and open their note folder to find portable markdown files.
-(Browser-page capture drops out of this checklist while link capture, Plan 11, is
-deferred; it rejoins when capture ships.)
+Browser-page capture is also part of the current walkthrough now that Plan 11 has shipped.
 
 ## Acceptance criteria
 

--- a/docs/plans/libraries.md
+++ b/docs/plans/libraries.md
@@ -33,8 +33,6 @@ first-party (owned by the team) and MIT-licensed, so there is no copyleft constr
 | Mobile day carousel (touch swipe, V1 parity) | `embla-carousel-react` | 19 |
 | AI provider (BYOK, streaming, multi-provider) | Vercel AI SDK (`ai` + `@ai-sdk/openai` …) | 10 |
 | Diff / patch (patchsets, conflict diffs) | `diff` (jsdiff) | 10 / 12 |
-| Export — ZIP | `fflate` (client-side) | 13 |
-| Export — HTML | reuse the editor: `markdownToDoc` → ProseMirror `DOMSerializer` (no remark) | 13 |
 | Chrome extension framework | WXT | 11 |
 | Auto-update (JS API + relaunch) | `@tauri-apps/plugin-updater` + `@tauri-apps/plugin-process` | 15 |
 
@@ -63,9 +61,8 @@ first-party (owned by the team) and MIT-licensed, so there is no copyleft constr
 
 ## Notes & caveats
 
-- **Export is fully client-side (TS):** `fflate` for zipping; HTML rendered by reusing the
-  editor's ProseMirror schema + `DOMSerializer` (no remark, reuses libraries we already
-  ship). Rust just persists the produced bytes to a chosen path.
+- **Plan 13 is closed by product decision:** no ZIP, JSON, or HTML export dependencies are
+  planned. The graph folder's markdown files and assets are the portability surface.
 - **The CLI (Plan 14) is a Rust binary** (superseding the earlier `cac` + `node:sqlite`
   Node-CLI choice): rusqlite `bundled` gives the same SQLite + FTS5 as the desktop app via
   one workspace lockfile, and the binary ships as a Tauri sidecar. `saphyr` is chosen for

--- a/docs/reflect-v2-grounding-brief.md
+++ b/docs/reflect-v2-grounding-brief.md
@@ -399,8 +399,8 @@ V2 considerations:
 
 - Daily note is again the capture destination.
 - Web capture creates an information-ingestion stream that should be searchable and linkable.
-- V2 link capture is designed but deferred from the first macOS release; full article clipping is deferred further still.
-- When capture ships, the path should be a Chrome extension talking to the installed desktop app through a local bridge.
+- V2 link capture is implemented for the desktop Chrome-extension path; full article clipping, Safari, and mobile share targets are deferred further still.
+- The shipped desktop path is a Chrome extension talking to the installed desktop app through the native host/inbox bridge.
 - The desktop app should own markdown writes, screenshot asset storage, BYOK AI calls, keychain access, and privacy checks.
 - V2 should not host a link-description API; enrichment calls should go directly from the app to the user's chosen model provider.
 - Captured links should append to today's daily note by default, with a dedicated markdown note when the capture includes richer description, highlights, or screenshot context.
@@ -655,8 +655,9 @@ Caveat:
 V2 considerations:
 
 - Data portability is an explicit value, not a checkbox.
-- V2 should preserve clean export paths from day one.
-- The proprietary internal format can exist, but open export must remain reliable.
+- V2 preserves portability by making markdown files and assets the source of truth.
+- No dedicated import/export suite is planned for V2; copying or zipping the graph folder is the export path.
+- The small V1 Markdown ZIP importer is a migration convenience, not the beginning of a broader importer framework.
 - Backup and recovery need a clear architecture, especially with local-first files, GitHub backup, optional encrypted layers, and sync conflict recovery.
 
 ---
@@ -825,7 +826,7 @@ The major hard parts for V2:
 | Kindle sync       | Book notes, highlights, `#book`, author backlinks        | Generalize source-specific importers                    |
 | API               | OAuth, append-only due to E2EE                           | Read/discovery CLI first; markdown files are write path |
 | Deep links        | External command URLs                                    | Unify with command registry                             |
-| Import/export     | Multiple imports; JSON/CSV/Markdown/HTML export          | Maintain portability from day one                       |
+| Import/export     | Multiple imports; JSON/CSV/Markdown/HTML export          | Superseded by markdown-folder portability               |
 | Security          | E2EE with XChaCha20-Poly1305; Doyensec audit             | Treat trust boundaries explicitly                       |
 | Note history      | Continuous revisions; restore to new note                | Preserve for trust and sync safety                      |
 | Tasks             | Aggregate, schedule, complete, archive                   | Choose lightweight vs serious task system               |
@@ -1035,22 +1036,18 @@ Current docs intentionally avoid becoming a full task manager. V2 must choose:
 
 The worst path is half-building a complex task manager and losing the simplicity of the note-taking product.
 
-### 9.8 Preserve Export from Day One
+### 9.8 Preserve Portability Through Markdown
 
-The docs make data portability part of Reflect's values. V2 should not defer export/import until late.
+The docs make data portability part of Reflect's values. V2 should satisfy that promise through its storage model rather than a parallel import/export product area.
 
 Minimum viable V2 portability:
 
-- Full JSON export
-- Markdown export
-- HTML export
-- Attachments
-- Backlinks preserved
-- Tags preserved
-- Tasks preserved
-- Daily note dates preserved
-- Published-note state preserved or clearly excluded
-- Import compatibility from existing Reflect export
+- Notes are plain markdown files under `daily/` and `notes/`.
+- Attachments live as normal files under `assets/` and use relative markdown links.
+- Backlinks, tags, tasks, and daily-note dates remain readable in markdown.
+- `.reflect/` stays out of the durable portability contract except for deliberately documented durable local tables such as `chat_*`.
+- Users can copy or zip the graph folder directly.
+- The existing V1 Markdown ZIP importer remains a migration convenience while it is useful.
 
 ### 9.9 Make Mobile Capture Excellent
 
@@ -1064,7 +1061,7 @@ Some earlier V2 questions have now been answered in the decision docs. This sect
 
 ### Resolved Direction
 
-- **V1 graph compatibility**: prioritize markdown and Obsidian-style vault import first; preserve V1 migration as a later path without forcing V2 to keep the V1 graph format.
+- **V1 graph compatibility**: keep the existing V1 Markdown ZIP importer as a migration convenience. Do not build a generalized Obsidian/folder import surface unless the portability premise changes.
 - **Data model**: keep V2 note-first. Use readable markdown files, stable IDs, aliases, and case-insensitive backlink resolution.
 - **Entities**: do not introduce a typed entity layer in the first wave. Canonical people, companies, projects, and other entities can emerge later as projections over notes and aliases.
 - **AI model**: use BYOK/cloud generative AI first. Treat local generative models as a later possibility. Keep local embeddings separate from generative AI.
@@ -1072,7 +1069,7 @@ Some earlier V2 questions have now been answered in the decision docs. This sect
 - **Tasks**: deferred from the first release; now planned as a post-release add-on (Plan 18). As decided here: lightweight markdown-backed projections (GFM checkboxes + a `tasks` table + a Tasks view) rather than a full task-management system.
 - **Contacts and calendar**: defer as first-wave surfaces, but preserve them as future memory context for meetings, backlinks, daily notes, and AI.
 - **Daily AI automation**: allow opt-in background extraction into reviewable suggestions. Do not silently mutate notes with summaries, entities, backlinks, or tasks.
-- **Links**: basic Chrome link capture is designed (Plan 11: extension hands URL/title/selection/screenshot to the desktop app via a local bridge; desktop owns BYOK AI and markdown/asset writes; no Reflect-hosted link-description API) but **deferred — the first macOS release ships without it**.
+- **Links**: basic Chrome link capture shipped (Plan 11: extension hands URL/title/selection/screenshot to the desktop app via the native host/inbox bridge; desktop owns BYOK AI and markdown/asset writes; no Reflect-hosted link-description API). Safari, mobile share targets, and full article clipping remain later work.
 - **Audio**: **shipped in the first release** (ahead of the original deferral): raw-first audio memos with async BYOK cloud transcription, explicit privacy UX, and `private: true` cloud-processing lockouts.
 - **Publishing and templates**: defer both. They should not block the first-wave editor, storage, search, sync, and AI foundation.
 
@@ -1132,6 +1129,6 @@ The V2 rewrite should not start from a generic notes-app architecture. It should
 - Search as retrieval layer
 - Capture from everywhere
 - AI as an assistant over personal context
-- Strong portability and user ownership
+- Strong markdown-folder portability and user ownership
 
-The highest-leverage V2 work is likely to be architectural, not cosmetic: unified ingestion, typed commands, better entity/backlink semantics, privacy-preserving AI/search, robust sync/history, and preserving data portability.
+The highest-leverage V2 work is likely to be architectural, not cosmetic: unified ingestion, typed commands, better entity/backlink semantics, privacy-preserving AI/search, robust sync/history, and keeping the markdown graph easy to copy, inspect, and recover.

--- a/docs/reflect-v2-indexing-strategy.md
+++ b/docs/reflect-v2-indexing-strategy.md
@@ -17,7 +17,8 @@ It complements [Reflect V2 Product Vision](./reflect-v2-product-vision.md).
 > - **One durable exception to "projections only":** the `chat_*` tables hold AI chat
 >   history, which is not derivable from markdown. Index wipes/rebuilds must leave
 >   them untouched.
-> - The `web_captures` projection is deferred along with link capture (Plan 11).
+> - Link-capture provenance now lives in normal markdown/frontmatter plus asset
+>   references; a separate `web_captures` projection has not been added yet.
 
 ## Strategy
 

--- a/docs/reflect-v2-mobile-grounding-brief.md
+++ b/docs/reflect-v2-mobile-grounding-brief.md
@@ -56,7 +56,7 @@ Plan 19 defines the binding scope. Summarized, with the product-owner calls of 2
 | Minimal settings | **In** | GitHub connect/disconnect, version. No graph chooser. |
 | Conflict **resolution** UI | **Out** | Conflicted notes open protected with "Needs review on desktop" — the same session contract as desktop; mine/theirs/both stays desktop-only in v1. |
 | Audio memos | **Later wave** | Product owner: first post-release wave, reusing desktop's raw-first + async BYOK transcription pipeline; OS entry points (widget, Siri, Live Activity) come with it. |
-| Share-sheet capture | **Later wave** | Product owner: deferred together with link capture (Plan 11) so mobile and desktop ship one consistent capture model. Needs its own native share-target plugin. |
+| Share-sheet capture | **Later wave** | Product owner: defer until the mobile share-target plugin can reuse the Plan 11 capture envelope/inbox model. Desktop Chrome capture has shipped; mobile still needs App Group ingestion. |
 | AI copilot (BYOK) | **Later wave** | Architecture holds (keys would live in the iOS keychain via the same secrets module); the surface is deferred. |
 | Semantic search / embeddings | **Later** | `fastembed`/ORT is desktop-only; mobile is lexical-first per the indexing strategy. |
 | Tasks, widgets, push, background sync, multiple graphs | **Out of v1** | Per Plan 19's explicit out-of-scope list; tasks follow desktop's Plan 18. |
@@ -154,7 +154,7 @@ Push notifications (no server), OAuth token exchange, Firebase everything, App-S
 | Tasks tab | Post-release, follows desktop Plan 18 |
 | Search-grounded AI chat | Later wave, with the copilot |
 | Voice memos + widget/Siri/Live Activity | Later wave (raw-first + BYOK transcription; OS entry points with it) |
-| Share extension | Later wave, designed with link capture (Plan 11); App Group inbox |
+| Share extension | Later wave, reusing the shipped Plan 11 capture envelope; App Group inbox still needed |
 | Note history UI | Git history exists; history UI deferred product-wide |
 | Push notifications | Dropped — no server |
 | Deep links (`reflect://`) | Tauri's deep-link plugin exists; not a v1 surface — revisit with the command registry |

--- a/docs/reflect-v2-product-vision.md
+++ b/docs/reflect-v2-product-vision.md
@@ -141,7 +141,7 @@ The implementation should leave room for Tauri, a native shell with a WebView, o
 
 V2 should be open source at the core.
 
-The app, local storage format, editor behaviors, import/export path, and protocol assumptions should be inspectable and community-extensible. The business model is TBD; V2 should not assume a specific monetization path yet.
+The app, local storage format, editor behaviors, and protocol assumptions should be inspectable and community-extensible. The business model is TBD; V2 should not assume a specific monetization path yet.
 
 The open-source promise should apply to the local app and storage model first. The intended license for the open-source core is MIT.
 
@@ -219,7 +219,6 @@ This local layer can store:
 - AI context cache.
 - File modification state.
 - UI state.
-- Import/export bookkeeping.
 
 The local database should be treated as a cache/projection unless a specific field cannot safely live in markdown. Any non-rebuildable local state should be deliberately justified. See [Reflect V2 Indexing Strategy](./reflect-v2-indexing-strategy.md) for the proposed projection and vector-index model.
 
@@ -360,9 +359,11 @@ The search system should operate over markdown files plus the local projection d
 
 ## Link Capture
 
-> **Status (2026-06-12):** Link capture is **deferred — the first macOS release ships
-> without it**. The design below (and [Plan 11](./plans/11-link-capture.md) plus the
-> bridge spike) remains the intended post-launch direction.
+> **Status:** Link capture is now implemented for the desktop Chrome-extension path:
+> extension → native-messaging host → capture inbox → desktop markdown/assets write →
+> async BYOK enrichment. Safari/mobile share targets, full article clipping, and
+> read-later state remain later work; [Plan 11](./plans/11-link-capture.md) is the
+> current implementation contract.
 
 V2 should include basic link capture. This is narrower than a full browser clipper, but it is still part of Reflect's daily-first capture spine.
 
@@ -506,8 +507,8 @@ These should be treated as core to the V2 vision:
 | Semantic search    | Required on supported desktop runtimes; mobile can start lexical-only.                              |
 | AI note copilot    | Required right-sidebar experience.                                                                  |
 | BYOK AI            | Required initial AI model.                                                                          |
-| Link capture       | Designed (Plan 11) but **deferred from the first macOS release**: Chrome extension to local desktop bridge, daily note entry, optional note. |
-| Import/export      | Required for trust and portability; prioritize markdown and Obsidian-style vaults first.            |
+| Link capture       | Implemented for the desktop Chrome-extension path (Plan 11): native host/inbox bridge, daily note entry, dedicated capture note, screenshots, BYOK enrichment. |
+| Portability        | Required for trust: the graph folder itself is the portable artifact; no dedicated import/export suite is planned. |
 | Backup             | Free/open backup path required.                                                                     |
 | Open-source core   | Required.                                                                                           |
 | Local DB/index     | Allowed and expected for projections.                                                               |
@@ -560,7 +561,7 @@ Implementation details are not final, but future agents should start from these 
 - **AI**: BYOK generative provider calls with visible/current context and local retrieval, excluding locked notes.
 - **AI edits**: multi-note patchsets, checkpointed before application; unsafe edits require review.
 - **Search**: local lexical search and local-only semantic embeddings.
-- **Link capture**: deferred from the first release. When built: Chrome extension sends URL/title/selection/screenshot data to a local desktop bridge; the desktop app uses BYOK AI, writes markdown/assets, and appends the capture to today's daily note.
+- **Link capture**: shipped for the desktop Chrome-extension path. The extension sends URL/title/selection/screenshot data to a native host/inbox bridge; the desktop app uses BYOK AI, writes markdown/assets, and appends the capture to today's daily note. Safari/mobile share targets and full article clipping remain later work.
 - **Audio memos**: shipped — raw-first capture (the recording is the durable artifact), async BYOK cloud transcription with `private: true` cloud-processing lockouts.
 - **Network model**: no Reflect-hosted APIs for the core product; external calls go directly to user-approved providers such as LLM providers, GitHub, Git remotes, iCloud Drive, or cloud transcription providers.
 - **Desktop shell**: Mac-first, no Electron, spike Tauri against a native WebView shell.
@@ -597,7 +598,6 @@ Reflect V2 succeeds if a user can:
 7. Back up their notes for free.
 8. Open their note folder and see portable markdown files.
 
-(A ninth item — save the current browser page into today's note with screenshot-backed
-BYOK AI enrichment — rejoins this list when link capture ships post-launch.)
+9. Save the current browser page into today's note with screenshot-backed BYOK AI enrichment.
 
 The product should feel like Reflect's memory model survived, but the substrate became open, local, markdown-native, and AI-ready.


### PR DESCRIPTION
## Summary
- update roadmap/status docs for shipped link capture, mobile progress, and release/privacy/indexing notes
- close Plan 13 by product decision: markdown graph folder is the portability surface, with no dedicated import/export suite planned
- remove stale export-library and export-JSON guidance from plan docs

## Verification
- pnpm check
- pnpm build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to roadmap and product plans; no runtime or data-path behavior is modified.
> 
> **Overview**
> Updates **README** and V2 plan/vision docs so status matches the repo: **`0.2.x` beta**, **desktop Chrome link capture shipped** (Plan 11), **Plan 19 mobile in progress**, and **Android** called out alongside Windows as out of scope for now.
> 
> **Plan 13 is closed by product decision** — portability is the graph folder (`daily/`, `notes/`, `assets/`); no planned Markdown/JSON/HTML ZIP export or Obsidian/folder import suite. **`importReflectMarkdownZip`** stays documented only as a V1 migration convenience. Related edits drop planned **remark/HTML export**, **export JSON** CLI alignment, and **import/export bookkeeping** from vision/indexing copy; **M4** and guardrails now describe the markdown-folder contract instead of a partial Plan 13.
> 
> Link capture wording flips from **deferred** to **implemented** on desktop (native host/inbox); Safari, mobile share, and full clipping stay later. Indexing notes capture provenance in markdown/frontmatter rather than a deferred **`web_captures`** projection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86f12ac1cf95f4fd4e684cdfe0cda05c1718c83c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->