### PR TITLE
Tidy similar notes sidebar

### DIFF
--- a/apps/desktop/src/components/context-sidebar/similar-notes-section.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/similar-notes-section.test.tsx
@@ -49,7 +49,7 @@ beforeEach(() => {
 describe('SimilarNotesSection', () => {
   it('renders nothing at all when the note has no semantic neighbors', async () => {
     const view = renderSimilar('daily/2026-06-09.md', false)
-    await waitFor(() => expect(relatedNotes).toHaveBeenCalledWith('daily/2026-06-09.md'))
+    await waitFor(() => expect(relatedNotes).toHaveBeenCalledWith('daily/2026-06-09.md', 6))
     expect(view.container.firstChild).toBeNull()
     view.unmount()
   })
@@ -97,9 +97,30 @@ describe('SimilarNotesSection', () => {
     await view.findByText('Rust')
     expect(view.getByText('Similar notes')).toBeDefined()
     expect(view.getByText('Zig')).toBeDefined()
+    const rustRow = view.getByRole('button', { name: 'Rust' })
+    expect(rustRow.className).toContain('px-3')
+    expect(rustRow.parentElement?.className ?? '').not.toContain('-mx-1')
     // V1 rows are bare titles — snippets never render here.
     expect(view.queryByText('borrow checker notes')).toBeNull()
     expect(view.queryByText('comptime experiments')).toBeNull()
+    view.unmount()
+  })
+
+  it('shows no more than six neighbors', async () => {
+    relatedNotes.mockResolvedValue(
+      Array.from({ length: 7 }, (_, index) => ({
+        path: `notes/note-${index + 1}.md`,
+        title: `Note ${index + 1}`,
+        score: 1 - index / 10,
+        snippet: `snippet ${index + 1}`,
+        heading: null,
+        isPrivate: false,
+      })),
+    )
+    const view = renderSimilar('notes/languages.md', false)
+    await view.findByText('Note 6')
+    expect(view.queryByText('Note 7')).toBeNull()
+    expect(relatedNotes).toHaveBeenCalledWith('notes/languages.md', 6)
     view.unmount()
   })
 

--- a/apps/desktop/src/components/context-sidebar/similar-notes-section.tsx
+++ b/apps/desktop/src/components/context-sidebar/similar-notes-section.tsx
@@ -13,14 +13,14 @@ interface SimilarNotesSectionProps {
 /**
  * "Similar notes" as a context-sidebar section, in the old app's exact shape:
  * one truncated title per neighbor with a flipped return-arrow on the right —
- * no snippets. Rows borrow the Pinned shelf's idiom (`SidebarNoteRow`):
- * compact `py-1` rows whose hover wash bleeds past the section's text line.
- * Neighbors of `path` are seeded by the note's stored chunk vectors. Renders
- * nothing at all when there are no results — semantic search may be disabled
- * or the note not yet embedded, and an empty box would just advertise a
- * missing feature. Query errors are deliberately just as quiet: a failing
- * semantic leg means an optional feature is unavailable, not that the index
- * is broken. Shared by the daily and note context sidebars.
+ * no snippets. Rows use the same horizontal inset as the Published URL
+ * section so the sidebar's note metadata reads on one line. Neighbors of
+ * `path` are seeded by the note's stored chunk vectors. Renders nothing at all
+ * when there are no results — semantic search may be disabled or the note not
+ * yet embedded, and an empty box would just advertise a missing feature. Query
+ * errors are deliberately just as quiet: a failing semantic leg means an
+ * optional feature is unavailable, not that the index is broken. Shared by the
+ * daily and note context sidebars.
  */
 export function SimilarNotesSection({ path }: SimilarNotesSectionProps): ReactElement | null {
   const { navigate } = useRouter()
@@ -33,13 +33,11 @@ export function SimilarNotesSection({ path }: SimilarNotesSectionProps): ReactEl
     <SidebarSection storageKey="similar" title="Similar notes">
       <ul className="space-y-1">
         {related.map((hit) => (
-          // The negative margin lets the hover wash bleed past the section's
-          // padding so the title text stays on the header's alignment line.
-          <li key={hit.path} className="-mx-1">
+          <li key={hit.path}>
             <button
               type="button"
               onClick={() => navigate(routeForPath(hit.path))}
-              className="flex w-full items-center space-x-1 rounded-md px-2.5 py-1 leading-5 text-text-secondary transition-colors duration-100 hover:bg-surface-hover hover:text-text"
+              className="flex w-full items-center space-x-1 rounded-md px-3 py-1 leading-5 text-text-secondary transition-colors duration-100 hover:bg-surface-hover hover:text-text"
             >
               <span className="min-w-0 flex-1 truncate text-left text-xs font-medium">
                 {hit.title}

--- a/apps/desktop/src/lib/use-similar-notes.ts
+++ b/apps/desktop/src/lib/use-similar-notes.ts
@@ -4,6 +4,8 @@ import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
 
+const SIMILAR_NOTES_LIMIT = 6
+
 /**
  * The note's semantic neighbors ("Similar notes"), one query shared by every
  * surface that shows them (the in-note panel and the context sidebars). The
@@ -21,8 +23,8 @@ export function useSimilarNotes(path: string): RetrievalHit[] {
   const { settings } = useSettings()
   const { data } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'related', path],
-    queryFn: () => relatedNotes(path),
+    queryFn: () => relatedNotes(path, SIMILAR_NOTES_LIMIT),
     enabled: hasBridge() && graph !== null && settings.semanticSearchEnabled,
   })
-  return settings.semanticSearchEnabled ? (data ?? []) : []
+  return settings.semanticSearchEnabled ? (data ?? []).slice(0, SIMILAR_NOTES_LIMIT) : []
 }


### PR DESCRIPTION
## Summary
- Align similar-note rows with the Published URL sidebar inset
- Cap similar notes at six results from the shared hook
- Add regression coverage for spacing classes and the six-note limit

## Verification
- pnpm --filter @reflect/desktop test src/components/context-sidebar/similar-notes-section.test.tsx
- pnpm check
- pnpm build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sidebar styling and a bounded optional semantic-search display; no auth, persistence, or core indexing logic changes in this diff.
> 
> **Overview**
> **Similar notes** in the context sidebar now match the **Published URL** horizontal inset: row buttons use `px-3` and the list items no longer use negative margins for a full-bleed hover wash.
> 
> The shared **`useSimilarNotes`** hook enforces a **six-result** ceiling by passing that limit into `relatedNotes` and slicing returned data, so every consumer (sidebar and in-note panel) stays consistent. Tests assert the `relatedNotes` call arity, spacing classes, and that a seventh neighbor is not shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4df4a8d799e7ac6d10ac638e0553696b7659a50f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->