### PR TITLE
Add a new chat shortcut and surface All notes binding

### DIFF
--- a/apps/desktop/src/components/chat/chat-input.tsx
+++ b/apps/desktop/src/components/chat/chat-input.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, type ReactElement } from 'react'
 import { aiProvider, type AiProviderConfig, type ChatModelOption } from '@reflect/core'
 import { ArrowUp, Plus, Square, X } from 'lucide-react'
+import { ShortcutKeys } from '@/components/shortcut-keys'
 import { Button } from '@/components/ui/button'
 import {
   Select,
@@ -12,8 +13,11 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { imageFilesFrom } from '@/lib/chat-attachments'
+import { keybindingFor } from '@/lib/commands/app-commands'
 import { useChatSession } from '@/providers/chat-provider'
 import { ChatHistoryMenu } from './chat-history-menu'
+
+const NEW_CHAT_BINDING = keybindingFor('chat.new')
 
 interface ModelOptionGroup {
   configId: string
@@ -190,6 +194,9 @@ export function ChatInput(): ReactElement {
             <Button variant="ghost" size="sm" onClick={newChat}>
               <Plus aria-hidden data-icon="inline-start" />
               New chat
+              {NEW_CHAT_BINDING ? (
+                <ShortcutKeys binding={NEW_CHAT_BINDING} className="ml-1 text-text-muted" />
+              ) : null}
             </Button>
           ) : null}
           {streaming ? (

--- a/apps/desktop/src/components/command-palette/command-palette.test.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.test.tsx
@@ -88,6 +88,7 @@ function renderPalette(query: string, context?: Partial<CommandContext>) {
     forward: vi.fn(),
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
+    newChat: vi.fn(),
     toggleAudioMemo: vi.fn(),
     generation: () => 1,
     openPalette: vi.fn(),

--- a/apps/desktop/src/components/context-sidebar/daily-context-sidebar.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/daily-context-sidebar.test.tsx
@@ -1,7 +1,7 @@
-import { render, waitFor } from '@testing-library/react'
+import { cleanup, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
 import type { NoteRow } from '@reflect/core'
 import { TooltipProvider } from '@/components/ui/tooltip'
@@ -69,6 +69,8 @@ beforeEach(() => {
   useNoteRow.mockReset().mockReturnValue(null)
 })
 
+afterEach(cleanup)
+
 describe('DailyContextSidebar calendar header', () => {
   it('jumps to today from the calendar-icon button', async () => {
     const view = renderSidebar('2026-06-09')
@@ -126,7 +128,7 @@ describe('DailyContextSidebar calendar', () => {
 describe('DailyContextSidebar related notes', () => {
   it('renders no Similar notes section without results', async () => {
     const view = renderSidebar('2026-06-09')
-    await waitFor(() => expect(relatedNotes).toHaveBeenCalledWith('daily/2026-06-09.md'))
+    await waitFor(() => expect(relatedNotes).toHaveBeenCalledWith('daily/2026-06-09.md', 6))
     expect(view.queryByText('Similar notes')).toBeNull()
     view.unmount()
   })

--- a/apps/desktop/src/components/context-sidebar/note-context-sidebar.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-context-sidebar.test.tsx
@@ -1,7 +1,7 @@
-import { render, waitFor } from '@testing-library/react'
+import { cleanup, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { RouterProvider, useRouter } from '@/routing/router'
@@ -47,10 +47,12 @@ beforeEach(() => {
   relatedNotes.mockReset().mockResolvedValue([])
 })
 
+afterEach(cleanup)
+
 describe('NoteContextSidebar', () => {
   it('queries the note path for similar notes and shows no section without results', async () => {
     const view = renderSidebar('notes/rust.md')
-    await waitFor(() => expect(relatedNotes).toHaveBeenCalledWith('notes/rust.md'))
+    await waitFor(() => expect(relatedNotes).toHaveBeenCalledWith('notes/rust.md', 6))
     expect(view.queryByText('Similar notes')).toBeNull()
     view.unmount()
   })

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -100,6 +100,7 @@ function renderSidebar(overrides?: Partial<CommandContext>, initialRoute?: Route
     forward: vi.fn(),
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
+    newChat: vi.fn(),
     toggleAudioMemo: vi.fn(),
     generation: () => 1,
     openPalette,

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -67,6 +67,7 @@ function fakeContext(overrides?: Partial<CommandContext>) {
     forward: vi.fn(),
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
+    newChat: vi.fn(),
     toggleAudioMemo: vi.fn(),
     generation: () => 7,
     openPalette: vi.fn(),
@@ -92,6 +93,7 @@ function noteRow(isPrivate: boolean): NoteRow {
 describe('keybindingFor', () => {
   it('returns the binding UI hints derive from', () => {
     expect(keybindingFor('nav.today')).toBe('Mod-d')
+    expect(keybindingFor('nav.allNotes')).toBe('Mod-Shift-a')
     expect(keybindingFor('palette.open')).toBe('Mod-k')
   })
 
@@ -139,6 +141,17 @@ describe('app commands', () => {
     await command('shortcuts.show').run(context)
     expect(context.openShortcuts).toHaveBeenCalledTimes(1)
     expect(keybindingFor('shortcuts.show')).toBe('Mod-/')
+  })
+
+  it('chat.new starts a fresh conversation only from the chat route', async () => {
+    const { context } = fakeContext({ route: () => ({ kind: 'chat' }) })
+    await command('chat.new').run(context)
+    expect(context.newChat).toHaveBeenCalledTimes(1)
+    expect(keybindingFor('chat.new')).toBe('Mod-Shift-n')
+
+    const { context: outsideChat } = fakeContext()
+    await command('chat.new').run(outsideChat)
+    expect(outsideChat.newChat).not.toHaveBeenCalled()
   })
 
   it('note.new navigates to a fresh lazy ULID note path', async () => {

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -43,6 +43,7 @@ const APP_COMMANDS: AppCommand[] = [
     id: 'nav.allNotes',
     title: 'All notes',
     keywords: ['notes', 'list', 'browse', 'library'],
+    keybinding: 'Mod-Shift-a',
     run: (context) => context.navigate({ kind: 'allNotes', tag: null }),
   },
   {
@@ -58,6 +59,18 @@ const APP_COMMANDS: AppCommand[] = [
     keywords: ['ai', 'assistant', 'copilot', 'ask'],
     keybinding: 'Mod-j',
     run: (context) => context.navigate({ kind: 'chat' }),
+  },
+  {
+    id: 'chat.new',
+    title: 'New chat',
+    keywords: ['ai', 'assistant', 'copilot', 'conversation'],
+    keybinding: 'Mod-Shift-n',
+    run: (context) => {
+      if (context.route().kind !== 'chat') {
+        return
+      }
+      context.newChat()
+    },
   },
   {
     id: 'history.back',

--- a/apps/desktop/src/lib/commands/registry.test.ts
+++ b/apps/desktop/src/lib/commands/registry.test.ts
@@ -15,6 +15,7 @@ function fakeContext(overrides?: Partial<CommandContext>): CommandContext {
     forward: vi.fn(),
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
+    newChat: vi.fn(),
     toggleAudioMemo: vi.fn(),
     generation: () => 1,
     openPalette: vi.fn(),

--- a/apps/desktop/src/lib/commands/types.ts
+++ b/apps/desktop/src/lib/commands/types.ts
@@ -23,6 +23,8 @@ export interface CommandContext {
   toggleTheme: () => void
   /** Collapse/expand the workspace sidebar. */
   toggleSidebar: () => void
+  /** Start a fresh chat conversation. */
+  newChat: () => void
   /** Start an audio memo, or stop-and-save the one recording. */
   toggleAudioMemo: () => void
   /**

--- a/apps/desktop/src/lib/native-menu/menu.test.ts
+++ b/apps/desktop/src/lib/native-menu/menu.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { APP_COMMANDS } from '@/lib/commands/app-commands'
+import { APP_COMMANDS, keybindingFor } from '@/lib/commands/app-commands'
 import { appMenuLayout } from './menu'
 
 function referencedCommandIds(): string[] {
@@ -21,19 +21,21 @@ describe('appMenuLayout', () => {
   it('surfaces every ported V1 menu shortcut', () => {
     const referenced = new Set(referencedCommandIds())
     // The V1 Electron menu items that have a V2 command: Preferences ⌘,
-    // New Note ⌘N, Search ⌘K, Select Daily Note ⌘D, Back ⌘[, Forward ⌘],
-    // Open Shortcuts ⌘/.
+    // New Note ⌘N, Search ⌘K, Select Daily Note ⌘D, All Notes ⌘⇧A,
+    // Back ⌘[, Forward ⌘], Open Shortcuts ⌘/.
     for (const commandId of [
       'settings.open',
       'note.new',
       'palette.open',
       'nav.today',
+      'nav.allNotes',
       'history.back',
       'history.forward',
       'shortcuts.show',
     ]) {
       expect(referenced).toContain(commandId)
     }
+    expect(keybindingFor('nav.allNotes')).toBe('Mod-Shift-a')
   })
 
   it('lists each command at most once across the whole menu', () => {

--- a/apps/desktop/src/routing/app-shortcuts.test.tsx
+++ b/apps/desktop/src/routing/app-shortcuts.test.tsx
@@ -1,5 +1,5 @@
-import { renderHook, act } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
 import { PaletteProvider, usePalette } from '@/components/command-palette/palette-provider'
 import { listRegisteredBindings } from '@/editor/keymap'
@@ -8,6 +8,8 @@ import { ShortcutsProvider, useShortcuts } from '@/providers/shortcuts-provider'
 import { SidebarProvider } from '@/providers/sidebar-provider'
 import { useAppShortcuts } from './app-shortcuts'
 import { RouterProvider, useRouter } from './router'
+
+const newChat = vi.hoisted(() => vi.fn())
 
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({ graph: { root: '/g', name: 'g', cloudSync: null, generation: 1 } }),
@@ -24,8 +26,13 @@ vi.mock('@/providers/settings-provider', () => ({
 vi.mock('@/providers/audio-memo-provider', () => ({
   useAudioMemo: () => ({ toggle: vi.fn() }),
 }))
+vi.mock('@/providers/chat-provider', () => ({
+  useChatSession: () => ({ newChat }),
+}))
 
 registerAppCommands() // production does this in main.tsx
+
+afterEach(cleanup)
 
 function shortcutsHook() {
   return renderHook(
@@ -47,14 +54,24 @@ function shortcutsHook() {
   )
 }
 
-function press(key: string) {
-  window.dispatchEvent(new KeyboardEvent('keydown', { key, metaKey: true, cancelable: true }))
+function press(key: string, options: KeyboardEventInit = {}) {
+  window.dispatchEvent(
+    new KeyboardEvent('keydown', { key, metaKey: true, cancelable: true, ...options }),
+  )
 }
 
 describe('app shortcuts', () => {
   it('registers the command keybindings in the central keymap registry', () => {
     const bindings = listRegisteredBindings()
-    for (const key of ['Mod-d', 'Mod-n', 'Mod-[', 'Mod-]', 'Mod-k']) {
+    for (const key of [
+      'Mod-d',
+      'Mod-Shift-a',
+      'Mod-n',
+      'Mod-Shift-n',
+      'Mod-[',
+      'Mod-]',
+      'Mod-k',
+    ]) {
       expect(bindings.get(key)).toBe('app')
     }
   })
@@ -82,6 +99,33 @@ describe('app shortcuts', () => {
     expect(result.current.palette.open).toBe(false)
     act(() => press('k'))
     expect(result.current.palette.open).toBe(true)
+  })
+
+  it('⌘⇧A opens All notes', () => {
+    const { result } = shortcutsHook()
+
+    act(() => press('a', { shiftKey: true }))
+    expect(result.current.router.route).toEqual({ kind: 'allNotes', tag: null })
+  })
+
+  it('⌘⇧N starts a fresh chat when the chat route is active', () => {
+    newChat.mockClear()
+    const { result } = shortcutsHook()
+
+    act(() => press('j'))
+    expect(result.current.router.route).toEqual({ kind: 'chat' })
+
+    act(() => press('n', { shiftKey: true }))
+    expect(newChat).toHaveBeenCalledTimes(1)
+  })
+
+  it('⌘⇧N is inert outside the chat route', () => {
+    newChat.mockClear()
+    const { result } = shortcutsHook()
+
+    act(() => press('n', { shiftKey: true }))
+    expect(result.current.router.route).toEqual({ kind: 'today' })
+    expect(newChat).not.toHaveBeenCalled()
   })
 
   it('matches uppercase keys (caps lock) and ignores auto-repeat', () => {
@@ -129,7 +173,7 @@ describe('app shortcuts', () => {
     const { result } = shortcutsHook()
     act(() => {
       window.dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'n', metaKey: true, shiftKey: true }),
+        new KeyboardEvent('keydown', { key: 'n', metaKey: true, altKey: true }),
       )
     })
     expect(result.current.router.route).toEqual({ kind: 'today' })

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -9,6 +9,7 @@ import { setMenuCommandDispatch } from '@/lib/native-menu/dispatch'
 import { retryFailedEmbeddings } from '@/lib/semantic'
 import type { CommandContext } from '@/lib/commands/types'
 import { useAudioMemo } from '@/providers/audio-memo-provider'
+import { useChatSession } from '@/providers/chat-provider'
 import { useFocusedDailyDate } from '@/providers/focused-daily-provider'
 import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
@@ -57,6 +58,7 @@ export function useAppShortcuts(): CommandContext {
   const { openShortcuts, closeShortcuts, open: shortcutsOpen } = useShortcuts()
   const { toggleSidebar } = useSidebar()
   const { toggle: toggleAudioMemo } = useAudioMemo()
+  const { newChat } = useChatSession()
   const { updateSettings } = useSettings()
 
   // The palette is modal: app shortcuts must not navigate behind its overlay.
@@ -94,6 +96,7 @@ export function useAppShortcuts(): CommandContext {
       forward,
       toggleTheme: () => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark'),
       toggleSidebar,
+      newChat,
       toggleAudioMemo,
       generation: () => generationRef.current,
       openPalette,
@@ -114,6 +117,7 @@ export function useAppShortcuts(): CommandContext {
       openPalette,
       openShortcuts,
       toggleSidebar,
+      newChat,
       toggleAudioMemo,
       updateSettings,
     ],


### PR DESCRIPTION
## Summary
- Add `chat.new` as a keyboard command that starts a fresh chat only when the chat route is active
- Surface the All notes shortcut binding in the command palette, sidebar, and chat input
- Thread `newChat` through the app command context and shortcut provider
- Update command and shortcut tests to cover the new bindings and route gating

## Testing
- Unit tests updated for command registration, shortcut handling, menu references, and UI affordances

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation and chat-session resets only; route gating limits **Mod-Shift-N** to chat. Low risk aside from possible shortcut overlap with other **Mod-Shift** bindings users expect.
> 
> **Overview**
> Introduces **`chat.new`** (**Mod-Shift-N**): starts a fresh conversation only when the active route is chat, via a new **`newChat`** capability on **`CommandContext`** hooked up from the chat session in **`useAppShortcuts`**.
> 
> Assigns **`nav.allNotes`** the **Mod-Shift-A** binding (palette, shortcuts, and native menu tests now expect it). The chat **New chat** button shows the binding through **`ShortcutKeys`** when defined.
> 
> Test harnesses gain **`newChat`** mocks, shortcut/integration coverage for the new chords and chat gating, **`afterEach(cleanup)`** in several suites, and updated **`relatedNotes`** expectations (second argument **`6`**). The “extra modifiers” shortcut test now uses **Alt** so **Mod-Shift-N** is not conflated with **Mod-N**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f6b3821f31adcdbec72003ec148a168714728ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->