### PR TITLE
Add gist unpublish action

### DIFF
--- a/apps/desktop/src/components/context-sidebar/note-gist-action.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-gist-action.test.tsx
@@ -13,10 +13,11 @@ const runGistPublish = vi.hoisted(() =>
     async () => 'https://gist.github.com/alex/g1',
   ),
 )
+const runGistUnpublish = vi.hoisted(() => vi.fn<(path: string, generation: number) => Promise<boolean>>(async () => true))
 
 vi.mock('@/hooks/use-github-connected', () => ({ useGithubConnected }))
 vi.mock('@/hooks/use-note-row', () => ({ useNoteRow }))
-vi.mock('@/lib/note-gist', () => ({ runGistPublish }))
+vi.mock('@/lib/note-gist', () => ({ runGistPublish, runGistUnpublish }))
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({ graph: { root: '/g', name: 'g', cloudSync: false, generation: 7 } }),
 }))
@@ -47,6 +48,7 @@ beforeEach(() => {
   useGithubConnected.mockReset().mockReturnValue(true)
   useNoteRow.mockReset().mockReturnValue(null)
   runGistPublish.mockReset().mockResolvedValue('https://gist.github.com/alex/g1')
+  runGistUnpublish.mockReset().mockResolvedValue(true)
 })
 
 afterEach(() => {
@@ -71,10 +73,10 @@ describe('NoteGistAction', () => {
     expect(view.getByRole('button', { name: /Share with private link/ })).toBeTruthy()
   })
 
-  it('offers Republish private link once the note carries a gist', () => {
+  it('offers Unpublish link once the note carries a gist', () => {
     useNoteRow.mockReturnValue(noteRow({ gistUrl: 'https://gist.github.com/alex/g1' }))
     const view = renderAction()
-    expect(view.getByRole('button', { name: /Republish private link/ })).toBeTruthy()
+    expect(view.getByRole('button', { name: /Unpublish link/ })).toBeTruthy()
   })
 
   it('publishes the open note on click', async () => {
@@ -83,13 +85,20 @@ describe('NoteGistAction', () => {
     expect(runGistPublish).toHaveBeenCalledWith('notes/a.md', 7)
   })
 
+  it('unpublishes the open note on click once it carries a gist', async () => {
+    useNoteRow.mockReturnValue(noteRow({ gistUrl: 'https://gist.github.com/alex/g1' }))
+    const view = renderAction()
+    await userEvent.click(view.getByRole('button', { name: /Unpublish link/ }))
+    expect(runGistUnpublish).toHaveBeenCalledWith('notes/a.md', 7)
+  })
+
   it('reflects an optimistic publish as Republish before the index catches up', () => {
     // The overlay is what `runGistPublish` writes on success (its contract is
     // covered in note-gist.test.ts); given one, the label flips without waiting
     // on the index.
     setNoteRowOverlay('notes/a.md', 7, { gistUrl: 'https://gist.github.com/alex/g1' })
     const view = renderAction()
-    expect(view.getByRole('button', { name: /Republish private link/ })).toBeTruthy()
+    expect(view.getByRole('button', { name: /Unpublish link/ })).toBeTruthy()
   })
 
   it('stays on Publish when the publish failed (already surfaced elsewhere)', async () => {
@@ -102,31 +111,4 @@ describe('NoteGistAction', () => {
     })
   })
 
-  it('holds the stale nudge while a publish is optimistically pending, then follows the index', () => {
-    // A published, edited note. Right after a republish the gist matches the
-    // body again, so the lagging index's "stale" must be held back rather than
-    // flashing — the overlay (url-only) suppresses it until the index agrees,
-    // and never waits on `gist_stale`, so a still-editing note can't mute the
-    // nudge forever.
-    const url = 'https://gist.github.com/alex/g1'
-    useNoteRow.mockReturnValue(noteRow({ gistUrl: url, gistStale: true }))
-    const accentIcon = (view: ReturnType<typeof renderAction>) =>
-      view.getByRole('button').querySelector('.text-accent')
-
-    // Nothing pending: the index reads stale, so the nudge shows.
-    const idle = renderAction()
-    expect(accentIcon(idle)).toBeTruthy()
-    idle.unmount()
-
-    // A fresh publish sits in the overlay: the nudge is held back.
-    setNoteRowOverlay('notes/a.md', 7, { gistUrl: url })
-    const pending = renderAction()
-    expect(accentIcon(pending)).toBeNull()
-    pending.unmount()
-
-    // Overlay retired (the index caught up): the nudge follows the index again.
-    resetNoteRowOverlays()
-    const settled = renderAction()
-    expect(accentIcon(settled)).toBeTruthy()
-  })
 })

--- a/apps/desktop/src/components/context-sidebar/note-gist-action.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-gist-action.tsx
@@ -1,12 +1,11 @@
 import { useState, type ReactElement } from 'react'
-import { CloudUpload } from 'lucide-react'
+import { CloudOff, CloudUpload } from 'lucide-react'
 import { ShortcutKeys } from '@/components/shortcut-keys'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useNoteRowOverlay } from '@/hooks/note-row-overlay'
 import { useGithubConnected } from '@/hooks/use-github-connected'
 import { useNoteRow } from '@/hooks/use-note-row'
-import { runGistPublish } from '@/lib/note-gist'
-import { cn } from '@/lib/utils'
+import { runGistPublish, runGistUnpublish } from '@/lib/note-gist'
 import { useGraph } from '@/providers/graph-provider'
 
 interface NoteGistActionProps {
@@ -20,28 +19,23 @@ interface NoteGistActionProps {
  * Private-link sharing as a Note actions button. Rendered only when a GitHub
  * credential is stored and the note isn't private (the publish path enforces
  * the privacy block again on live content — this is just not offering it).
- * After the first publish the label flips to "Republish private link", and an
- * accent-tinted icon plus tooltip nudge when the body changed since
- * (`gist_stale` from the index). Failures surface through the operations
- * status line; success copies the gist-backed link to the clipboard.
+ * After the first publish the label flips to "Unpublish link". The published
+ * URL section owns the update action, including the stale-body nudge from the
+ * index. Failures and success state surface through the operations status line.
  */
 export function NoteGistAction({ path, keybinding = null }: NoteGistActionProps): ReactElement | null {
   const { graph } = useGraph()
   const connected = useGithubConnected()
   const row = useNoteRow(path)
-  // `row` already reflects a just-published url (the optimistic overlay flows
-  // through `useNoteRow`); the raw overlay tells us *that* a publish is still
-  // catching up, which only `stale` needs.
+  // `row` already reflects a just-published or just-unpublished URL (the
+  // optimistic overlay flows through `useNoteRow`); the raw overlay tells us
+  // that a publish is still catching up, which keeps the action in the
+  // published state until the index agrees.
   const optimistic = useNoteRowOverlay(path, graph?.generation)?.gistUrl != null
   const [isPublishing, setIsPublishing] = useState(false)
+  const [isUnpublishing, setIsUnpublishing] = useState(false)
 
   const published = optimistic || (row?.gistUrl ?? null) !== null
-  // While the overlay still stands in for a not-yet-indexed publish, don't nudge
-  // "stale": the index reflects the pre-publish body for one more watcher
-  // round-trip. The overlay is url-only — it never waits on `gist_stale`, so a
-  // body edited right after publishing can't pin the nudge shut.
-  const stale = !optimistic && (row?.gistStale ?? false)
-
   if (!connected || row?.isPrivate === true) {
     return null
   }
@@ -59,31 +53,43 @@ export function NoteGistAction({ path, keybinding = null }: NoteGistActionProps)
     }
   }
 
-  const label = isPublishing
+  const onUnpublish = async (): Promise<void> => {
+    const generation = graph?.generation
+    if (generation === undefined) {
+      return
+    }
+    setIsUnpublishing(true)
+    try {
+      await runGistUnpublish(path, generation)
+    } finally {
+      setIsUnpublishing(false)
+    }
+  }
+
+  const isBusy = isPublishing || isUnpublishing
+  const label = isUnpublishing
+    ? 'Unpublishing…'
+    : isPublishing
     ? 'Publishing…'
     : published
-      ? 'Republish private link'
+      ? 'Unpublish link'
       : 'Share with private link'
-  const tooltip = stale
-    ? 'The note changed since its private GitHub gist was last published'
+  const tooltip = published
+    ? 'Delete the private GitHub gist for this note'
     : 'Creates a secret GitHub gist and copies its private link'
+  const Icon = published ? CloudOff : CloudUpload
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <button
           type="button"
-          onClick={() => void onPublish()}
-          disabled={isPublishing}
+          onClick={() => void (published ? onUnpublish() : onPublish())}
+          disabled={isBusy}
           className="group relative flex w-full items-center space-x-2 rounded-lg px-3 py-2 text-start transition-colors duration-100 hover:bg-surface-hover disabled:opacity-50"
         >
-          <span
-            className={cn(
-              'flex h-5 w-5 flex-none items-center justify-center transition-colors duration-100',
-              stale ? 'text-accent' : 'text-text-muted group-hover:text-text',
-            )}
-          >
-            <CloudUpload size={14} aria-hidden />
+          <span className="flex h-5 w-5 flex-none items-center justify-center text-text-muted transition-colors duration-100 group-hover:text-text">
+            <Icon size={14} aria-hidden />
           </span>
           <span className="min-w-0 flex-1 truncate text-xs font-medium">{label}</span>
           {keybinding !== null ? (

--- a/apps/desktop/src/components/context-sidebar/published-url-section.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/published-url-section.test.tsx
@@ -12,10 +12,19 @@ const operationFail = vi.hoisted(() => vi.fn())
 const startOperation = vi.hoisted(() =>
   vi.fn(() => ({ progress: vi.fn(), done: operationDone, fail: operationFail })),
 )
+const runGistPublish = vi.hoisted(() =>
+  vi.fn<(path: string, generation: number) => Promise<string | null>>(
+    async () => 'https://gist.github.com/alex/g1',
+  ),
+)
 
 vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn(async () => {}) }))
 vi.mock('@/hooks/use-note-row', () => ({ useNoteRow }))
+vi.mock('@/lib/note-gist', () => ({ runGistPublish }))
 vi.mock('@/lib/operations', () => ({ startOperation }))
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({ graph: { root: '/g', name: 'g', cloudSync: false, generation: 7 } }),
+}))
 
 function noteRow(overrides: Partial<NoteRow> = {}): NoteRow {
   return {
@@ -50,6 +59,7 @@ beforeEach(() => {
   useNoteRow.mockReset().mockReturnValue(null)
   vi.mocked(openUrl).mockClear()
   startOperation.mockClear()
+  runGistPublish.mockReset().mockResolvedValue('https://gist.github.com/alex/g1')
   operationDone.mockClear()
   operationFail.mockClear()
   Reflect.deleteProperty(navigator, 'clipboard')
@@ -95,6 +105,26 @@ describe('PublishedUrlSection', () => {
     expect(writeText).toHaveBeenCalledWith(url)
     expect(startOperation).toHaveBeenCalledWith('Published URL copied')
     expect(operationDone).toHaveBeenCalled()
+  })
+
+  it('updates the published gist from the URL section icon', async () => {
+    const url = 'https://gist.github.com/alex/g1'
+    useNoteRow.mockReturnValue(noteRow({ gistUrl: url }))
+
+    const view = renderSection()
+    await userEvent.click(view.getByRole('button', { name: 'Update published gist' }))
+
+    expect(runGistPublish).toHaveBeenCalledWith('notes/a.md', 7)
+  })
+
+  it('shows the stale update affordance beside the copy button', () => {
+    const url = 'https://gist.github.com/alex/g1'
+    useNoteRow.mockReturnValue(noteRow({ gistUrl: url, gistStale: true }))
+
+    const view = renderSection()
+    expect(view.getByRole('button', { name: 'Copy published URL' })).toBeTruthy()
+    expect(view.getByRole('button', { name: 'Update published gist' })).toBeTruthy()
+    expect(view.getByRole('button', { name: 'Update published gist' }).className).toContain('text-accent')
   })
 
   it('surfaces copy failures through the operations status', async () => {

--- a/apps/desktop/src/components/context-sidebar/published-url-section.tsx
+++ b/apps/desktop/src/components/context-sidebar/published-url-section.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useState, type MouseEvent, type ReactElement } from 'react'
 import { openUrl } from '@tauri-apps/plugin-opener'
-import { Check, Copy } from 'lucide-react'
+import { Check, Copy, RefreshCw } from 'lucide-react'
 import { errorMessage } from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useNoteRow } from '@/hooks/use-note-row'
+import { runGistPublish } from '@/lib/note-gist'
 import { startOperation } from '@/lib/operations'
+import { cn } from '@/lib/utils'
+import { useGraph } from '@/providers/graph-provider'
 import { SidebarSection } from './sidebar-section'
 
 interface PublishedUrlSectionProps {
@@ -22,9 +25,11 @@ const COPY_RESET_MS = 1400
  * plus a compact copy affordance for sharing it again.
  */
 export function PublishedUrlSection({ path }: PublishedUrlSectionProps): ReactElement | null {
+  const { graph } = useGraph()
   const row = useNoteRow(path)
   const url = row?.gistUrl ?? null
   const [copyState, setCopyState] = useState<CopyState>('idle')
+  const [isUpdating, setIsUpdating] = useState(false)
 
   useEffect(() => {
     setCopyState('idle')
@@ -57,6 +62,19 @@ export function PublishedUrlSection({ path }: PublishedUrlSectionProps): ReactEl
     void openUrl(url)
   }
 
+  const updateGist = async (): Promise<void> => {
+    const generation = graph?.generation
+    if (generation === undefined) {
+      return
+    }
+    setIsUpdating(true)
+    try {
+      await runGistPublish(path, generation)
+    } finally {
+      setIsUpdating(false)
+    }
+  }
+
   const Icon = copyState === 'copied' ? Check : Copy
 
   return (
@@ -84,6 +102,24 @@ export function PublishedUrlSection({ path }: PublishedUrlSectionProps): ReactEl
             </Button>
           </TooltipTrigger>
           <TooltipContent>{copyState === 'copied' ? 'Copied' : 'Copy published URL'}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label="Update published gist"
+              onClick={() => void updateGist()}
+              disabled={isUpdating}
+              className={cn('text-text-muted hover:text-text', row?.gistStale === true && 'text-accent')}
+            >
+              <RefreshCw aria-hidden className={cn('size-3.5', isUpdating && 'animate-spin')} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {row?.gistStale === true ? 'Update gist with latest note' : 'Update published gist'}
+          </TooltipContent>
         </Tooltip>
       </div>
     </SidebarSection>

--- a/apps/desktop/src/editor/note-session.ts
+++ b/apps/desktop/src/editor/note-session.ts
@@ -160,10 +160,10 @@ export interface FrontmatterPatch {
   private?: boolean
   /**
    * The published GitHub Gist block (id, url, file, hash of the published
-   * body) — written whole after every publish. Publishing is set-only in the
-   * first wave; there is no unpublish, so no delete encoding either.
+   * body) — written whole after every publish. `false` removes the block when
+   * the user unpublishes the link.
    */
-  gist?: GistFrontmatter
+  gist?: GistFrontmatter | false
 }
 
 /**
@@ -183,13 +183,17 @@ export function frontmatterPatchToYaml(patch: FrontmatterPatch): Record<string, 
     yaml.private = patch.private === false ? undefined : true
   }
   if (patch.gist !== undefined) {
-    // Spelled out key-by-key so the YAML block's shape (and key order) is
-    // this module's contract, not whatever object the caller happened to hold.
-    yaml.gist = {
-      id: patch.gist.id,
-      url: patch.gist.url,
-      file: patch.gist.file,
-      hash: patch.gist.hash,
+    if (patch.gist === false) {
+      yaml.gist = undefined
+    } else {
+      // Spelled out key-by-key so the YAML block's shape (and key order) is
+      // this module's contract, not whatever object the caller happened to hold.
+      yaml.gist = {
+        id: patch.gist.id,
+        url: patch.gist.url,
+        file: patch.gist.file,
+        hash: patch.gist.hash,
+      }
     }
   }
   return yaml

--- a/apps/desktop/src/hooks/note-row-overlay.test.ts
+++ b/apps/desktop/src/hooks/note-row-overlay.test.ts
@@ -35,7 +35,10 @@ afterEach(() => {
 
 describe('applyNoteRowOverlay', () => {
   it('merges overlay fields over the row', () => {
-    expect(applyNoteRowOverlay(noteRow(), { gistUrl: URL })?.gistUrl).toBe(URL)
+    expect(applyNoteRowOverlay(noteRow({ gistStale: true }), { gistUrl: URL, gistStale: false })).toMatchObject({
+      gistUrl: URL,
+      gistStale: false,
+    })
   })
 
   it('passes a null row through — the overlay only sharpens an existing row', () => {
@@ -87,6 +90,17 @@ describe('useNoteRowOverlay', () => {
     act(() => setNoteRowOverlay('notes/a.md', GEN, { gistUrl: URL }))
     expect(result.current?.gistUrl).toBe(URL)
     expect(other.result.current).toBeNull()
+  })
+
+  it('retires overlay fields independently as the index catches up', () => {
+    const { result } = renderHook(() => useNoteRowOverlay('notes/a.md', GEN))
+    act(() => setNoteRowOverlay('notes/a.md', GEN, { gistUrl: URL, gistStale: false }))
+
+    act(() => reconcileNoteRowOverlay('notes/a.md', GEN, noteRow({ gistUrl: URL, gistStale: true })))
+    expect(result.current).toEqual({ gistStale: false })
+
+    act(() => reconcileNoteRowOverlay('notes/a.md', GEN, noteRow({ gistUrl: URL, gistStale: false })))
+    expect(result.current).toBeNull()
   })
 })
 

--- a/apps/desktop/src/hooks/note-row-overlay.ts
+++ b/apps/desktop/src/hooks/note-row-overlay.ts
@@ -23,14 +23,18 @@ import type { NoteRow } from '@reflect/core'
  */
 
 /**
- * Index-row fields an action may assert ahead of the re-index. `gistUrl` is the
- * only one today: publishing yields a concrete URL, and unpublishing yields
- * `null`. `gistStale` is intentionally absent: a body edited right after
- * publishing keeps it `true`, which would pin the overlay open forever and mute
- * the update nudge.
+ * Index-row fields an action may assert ahead of the re-index. Publishing
+ * yields a concrete `gistUrl` and a fresh `gistStale: false`; unpublishing
+ * yields `gistUrl: null`. These overlays are short-lived read-model facts that
+ * retire as soon as the index catches up.
  */
 export interface NoteRowOverlay {
   readonly gistUrl?: string | null
+  readonly gistStale?: boolean
+}
+
+type MutableNoteRowOverlay = {
+  -readonly [Key in keyof NoteRowOverlay]: NoteRowOverlay[Key]
 }
 
 interface OverlayEntry {
@@ -57,12 +61,12 @@ function subscribe(listener: () => void): () => void {
 
 /** Strip `undefined` fields — an all-`undefined` patch must never be stored. */
 function definedFields(patch: NoteRowOverlay): NoteRowOverlay {
-  const result: { -readonly [Key in keyof NoteRowOverlay]: NoteRowOverlay[Key] } = {}
-  for (const key of Object.keys(patch) as (keyof NoteRowOverlay)[]) {
-    const value = patch[key]
-    if (value !== undefined) {
-      result[key] = value
-    }
+  const result: MutableNoteRowOverlay = {}
+  if (patch.gistUrl !== undefined) {
+    result.gistUrl = patch.gistUrl
+  }
+  if (patch.gistStale !== undefined) {
+    result.gistStale = patch.gistStale
   }
   return result
 }
@@ -120,13 +124,15 @@ export function reconcileNoteRowOverlay(path: string, generation: number, row: N
   if (entry === undefined || entry.generation !== generation || row === null) {
     return
   }
-  const remaining: { -readonly [Key in keyof NoteRowOverlay]: NoteRowOverlay[Key] } = {}
+  const remaining: MutableNoteRowOverlay = {}
   let retired = false
   for (const key of Object.keys(entry.overlay) as (keyof NoteRowOverlay)[]) {
     if (row[key] === entry.overlay[key]) {
       retired = true
+    } else if (key === 'gistUrl') {
+      remaining.gistUrl = entry.overlay.gistUrl
     } else {
-      remaining[key] = entry.overlay[key]
+      remaining.gistStale = entry.overlay.gistStale
     }
   }
   if (!retired) {

--- a/apps/desktop/src/hooks/note-row-overlay.ts
+++ b/apps/desktop/src/hooks/note-row-overlay.ts
@@ -24,13 +24,13 @@ import type { NoteRow } from '@reflect/core'
 
 /**
  * Index-row fields an action may assert ahead of the re-index. `gistUrl` is the
- * only one today (publishing always yields a concrete URL — never `null`, so a
- * publish can't be optimistically "unpublished"). `gistStale` is intentionally
- * absent: a body edited right after publishing keeps it `true`, which would
- * pin the overlay open forever and mute the republish nudge.
+ * only one today: publishing yields a concrete URL, and unpublishing yields
+ * `null`. `gistStale` is intentionally absent: a body edited right after
+ * publishing keeps it `true`, which would pin the overlay open forever and mute
+ * the update nudge.
  */
 export interface NoteRowOverlay {
-  readonly gistUrl?: string
+  readonly gistUrl?: string | null
 }
 
 interface OverlayEntry {

--- a/apps/desktop/src/lib/note-gist.test.ts
+++ b/apps/desktop/src/lib/note-gist.test.ts
@@ -353,4 +353,31 @@ describe('runGistUnpublish', () => {
     expect(operationFail).toHaveBeenCalledWith(expect.stringMatching(/connect github/i))
     expect(getNoteRowOverlay('notes/a.md', 3)).toBeNull()
   })
+
+  it('blocks publish or update while an unpublish is in flight for the same note', async () => {
+    let resolveDelete: () => void = () => {}
+    let markDeleteStarted: () => void = () => {}
+    const deleteStarted = new Promise<void>((resolve) => {
+      markDeleteStarted = resolve
+    })
+    deleteGist.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          markDeleteStarted()
+          resolveDelete = resolve
+        }),
+    )
+    readNote.mockResolvedValue(REPUBLISH_SOURCE)
+
+    const unpublish = runGistUnpublish('notes/a.md', 3)
+    await deleteStarted
+
+    await expect(runGistPublish('notes/a.md', 3)).resolves.toBeNull()
+    expect(createGist).not.toHaveBeenCalled()
+    expect(updateGist).not.toHaveBeenCalled()
+    expect(operationFail).toHaveBeenCalledWith(expect.stringMatching(/current gist operation/i))
+
+    resolveDelete()
+    await expect(unpublish).resolves.toBe(true)
+  })
 })

--- a/apps/desktop/src/lib/note-gist.test.ts
+++ b/apps/desktop/src/lib/note-gist.test.ts
@@ -211,6 +211,32 @@ describe('unpublishNoteGist', () => {
     expect(writeNote).toHaveBeenCalledWith('notes/a.md', BODY, 3)
   })
 
+  it('does not delete the remote gist when clearing local frontmatter fails', async () => {
+    readNote.mockResolvedValue(REPUBLISH_SOURCE)
+    writeNote.mockRejectedValueOnce(new Error('disk on fire'))
+
+    await expect(unpublishNoteGist('notes/a.md', 3)).rejects.toMatchObject({
+      message: 'disk on fire',
+    })
+
+    expect(deleteGist).not.toHaveBeenCalled()
+  })
+
+  it('restores local gist frontmatter when the remote delete fails', async () => {
+    readNote
+      .mockResolvedValueOnce(REPUBLISH_SOURCE)
+      .mockResolvedValueOnce(REPUBLISH_SOURCE)
+      .mockResolvedValueOnce(BODY)
+    deleteGist.mockRejectedValueOnce(new Error('network down'))
+
+    await expect(unpublishNoteGist('notes/a.md', 3)).rejects.toMatchObject({
+      message: 'network down',
+    })
+
+    expect(writeNote).toHaveBeenNthCalledWith(1, 'notes/a.md', BODY, 3)
+    expect(writeNote).toHaveBeenNthCalledWith(2, 'notes/a.md', REPUBLISH_SOURCE, 3)
+  })
+
   it('routes the gist removal through the live session when the note is open', async () => {
     const { session, commitFrontmatter } = fakeSession(REPUBLISH_SOURCE)
     openSession.mockReturnValue(session)
@@ -268,7 +294,10 @@ describe('runGistPublish', () => {
     readNote.mockResolvedValue(BODY)
     await runGistPublish('notes/a.md', 3)
 
-    expect(getNoteRowOverlay('notes/a.md', 3)?.gistUrl).toBe(PUBLISHED.htmlUrl)
+    expect(getNoteRowOverlay('notes/a.md', 3)).toMatchObject({
+      gistUrl: PUBLISHED.htmlUrl,
+      gistStale: false,
+    })
     // Stamped with the publishing generation — a reader on another graph won't see it.
     expect(getNoteRowOverlay('notes/a.md', 4)).toBeNull()
   })
@@ -293,7 +322,7 @@ describe('runGistPublish', () => {
   it('a failed clipboard copy never reads as a failed publish', async () => {
     readNote.mockResolvedValue(BODY)
     writeText.mockRejectedValueOnce(new Error('Document is not focused'))
-    // The publish landed: the url comes back so the UI flips to Republish.
+    // The publish landed: the url comes back so the UI flips to its published state.
     await expect(runGistPublish('notes/a.md', 3)).resolves.toBe(PUBLISHED.htmlUrl)
 
     expect(startOperation).toHaveBeenCalledWith('Publishing gist')
@@ -312,7 +341,7 @@ describe('runGistUnpublish', () => {
 
     expect(startOperation).toHaveBeenCalledWith('Unpublishing gist')
     expect(operationDone).toHaveBeenCalled()
-    expect(getNoteRowOverlay('notes/a.md', 3)?.gistUrl).toBeNull()
+    expect(getNoteRowOverlay('notes/a.md', 3)).toMatchObject({ gistUrl: null, gistStale: false })
   })
 
   it('surfaces failures and leaves no overlay', async () => {

--- a/apps/desktop/src/lib/note-gist.test.ts
+++ b/apps/desktop/src/lib/note-gist.test.ts
@@ -28,7 +28,7 @@ vi.mock('@reflect/core', async (importOriginal) => ({
 vi.mock('@/editor/open-documents', () => ({ openSession }))
 vi.mock('@/lib/operations', () => ({ startOperation }))
 
-const { publishNoteToGist, runGistPublish } = await import('./note-gist')
+const { publishNoteToGist, runGistPublish, runGistUnpublish, unpublishNoteGist } = await import('./note-gist')
 
 const PUBLISHED = { id: 'g1', htmlUrl: 'https://gist.github.com/alex/g1' }
 const BODY = '# A\n\nhello\n'
@@ -202,6 +202,46 @@ describe('publishNoteToGist', () => {
   })
 })
 
+describe('unpublishNoteGist', () => {
+  it('deletes the existing gist and removes the frontmatter block', async () => {
+    readNote.mockResolvedValue(REPUBLISH_SOURCE)
+    await expect(unpublishNoteGist('notes/a.md', 3)).resolves.toBeUndefined()
+
+    expect(deleteGist).toHaveBeenCalledWith('tok', 'g0', expect.any(Function))
+    expect(writeNote).toHaveBeenCalledWith('notes/a.md', BODY, 3)
+  })
+
+  it('routes the gist removal through the live session when the note is open', async () => {
+    const { session, commitFrontmatter } = fakeSession(REPUBLISH_SOURCE)
+    openSession.mockReturnValue(session)
+
+    await unpublishNoteGist('notes/a.md', 3)
+
+    expect(commitFrontmatter).toHaveBeenCalledWith({ gist: false })
+    expect(writeNote).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op when the note has no gist block', async () => {
+    readNote.mockResolvedValue(BODY)
+
+    await unpublishNoteGist('notes/a.md', 3)
+
+    expect(deleteGist).not.toHaveBeenCalled()
+    expect(writeNote).not.toHaveBeenCalled()
+  })
+
+  it('asks for a GitHub connection before deleting the gist', async () => {
+    readNote.mockResolvedValue(REPUBLISH_SOURCE)
+    getGithubToken.mockResolvedValue(null)
+
+    await expect(unpublishNoteGist('notes/a.md', 3)).rejects.toMatchObject({
+      kind: 'auth',
+      message: expect.stringMatching(/connect github/i),
+    })
+    expect(deleteGist).not.toHaveBeenCalled()
+  })
+})
+
 describe('runGistPublish', () => {
   const writeText = vi.fn(async () => {})
 
@@ -261,5 +301,27 @@ describe('runGistPublish', () => {
     expect(startOperation).not.toHaveBeenCalledWith('Gist link copied')
     expect(operationDone).toHaveBeenCalledTimes(1) // the publish itself
     expect(operationFail).toHaveBeenCalledWith(expect.stringMatching(/not focused/i))
+  })
+})
+
+describe('runGistUnpublish', () => {
+  it('unpublishes and clears the published url in the optimistic overlay', async () => {
+    readNote.mockResolvedValue(REPUBLISH_SOURCE)
+
+    await expect(runGistUnpublish('notes/a.md', 3)).resolves.toBe(true)
+
+    expect(startOperation).toHaveBeenCalledWith('Unpublishing gist')
+    expect(operationDone).toHaveBeenCalled()
+    expect(getNoteRowOverlay('notes/a.md', 3)?.gistUrl).toBeNull()
+  })
+
+  it('surfaces failures and leaves no overlay', async () => {
+    readNote.mockResolvedValue(REPUBLISH_SOURCE)
+    getGithubToken.mockResolvedValue(null)
+
+    await expect(runGistUnpublish('notes/a.md', 3)).resolves.toBe(false)
+
+    expect(operationFail).toHaveBeenCalledWith(expect.stringMatching(/connect github/i))
+    expect(getNoteRowOverlay('notes/a.md', 3)).toBeNull()
   })
 })

--- a/apps/desktop/src/lib/note-gist.ts
+++ b/apps/desktop/src/lib/note-gist.ts
@@ -17,6 +17,21 @@ import { commitNoteFrontmatter, readNoteSource } from '@/lib/note-frontmatter'
 import { startOperation } from '@/lib/operations'
 import { providerFetch } from '@/lib/provider-fetch'
 
+const activeGistOperations = new Set<string>()
+
+function claimGistOperation(path: string): boolean {
+  if (activeGistOperations.has(path)) {
+    startOperation('Gist operation already running').fail('Wait for the current gist operation to finish')
+    return false
+  }
+  activeGistOperations.add(path)
+  return true
+}
+
+function releaseGistOperation(path: string): void {
+  activeGistOperations.delete(path)
+}
+
 /**
  * Publish a note's body to a GitHub Gist (always secret), recording the gist
  * in the note's `gist` frontmatter block. A note that already carries the
@@ -139,25 +154,32 @@ export async function unpublishNoteGist(path: string, generation: number): Promi
  * reflects the publish immediately, before the watcher re-indexes the file.
  */
 export async function runGistPublish(path: string, generation: number): Promise<string | null> {
-  const operation = startOperation('Publishing gist')
-  let url: string
-  try {
-    url = await publishNoteToGist(path, generation)
-  } catch (cause) {
-    operation.fail(errorMessage(cause))
+  if (!claimGistOperation(path)) {
     return null
   }
-  operation.done()
-  // Stamp the optimism with the publishing graph's generation, so a publish
-  // that resolves after a graph switch can't surface on the new graph.
-  setNoteRowOverlay(path, generation, { gistUrl: url, gistStale: false })
   try {
-    await navigator.clipboard.writeText(url)
-    startOperation('Gist link copied').done()
-  } catch (cause) {
-    startOperation('Copying the gist link').fail(errorMessage(cause))
+    const operation = startOperation('Publishing gist')
+    let url: string
+    try {
+      url = await publishNoteToGist(path, generation)
+    } catch (cause) {
+      operation.fail(errorMessage(cause))
+      return null
+    }
+    operation.done()
+    // Stamp the optimism with the publishing graph's generation, so a publish
+    // that resolves after a graph switch can't surface on the new graph.
+    setNoteRowOverlay(path, generation, { gistUrl: url, gistStale: false })
+    try {
+      await navigator.clipboard.writeText(url)
+      startOperation('Gist link copied').done()
+    } catch (cause) {
+      startOperation('Copying the gist link').fail(errorMessage(cause))
+    }
+    return url
+  } finally {
+    releaseGistOperation(path)
   }
-  return url
 }
 
 /**
@@ -166,14 +188,21 @@ export async function runGistPublish(path: string, generation: number): Promise<
  * index catches up.
  */
 export async function runGistUnpublish(path: string, generation: number): Promise<boolean> {
-  const operation = startOperation('Unpublishing gist')
-  try {
-    await unpublishNoteGist(path, generation)
-  } catch (cause) {
-    operation.fail(errorMessage(cause))
+  if (!claimGistOperation(path)) {
     return false
   }
-  operation.done()
-  setNoteRowOverlay(path, generation, { gistUrl: null, gistStale: false })
-  return true
+  try {
+    const operation = startOperation('Unpublishing gist')
+    try {
+      await unpublishNoteGist(path, generation)
+    } catch (cause) {
+      operation.fail(errorMessage(cause))
+      return false
+    }
+    operation.done()
+    setNoteRowOverlay(path, generation, { gistUrl: null, gistStale: false })
+    return true
+  } finally {
+    releaseGistOperation(path)
+  }
 }

--- a/apps/desktop/src/lib/note-gist.ts
+++ b/apps/desktop/src/lib/note-gist.ts
@@ -92,6 +92,33 @@ export async function publishNoteToGist(path: string, generation: number): Promi
 }
 
 /**
+ * Delete the note's published GitHub Gist and remove the local `gist`
+ * frontmatter block. A missing local block is already unpublished, so this is a
+ * no-op. A remote 404 is success through {@link deleteGist}: the desired shared
+ * link is gone, and the local record can be cleared.
+ */
+export async function unpublishNoteGist(path: string, generation: number): Promise<void> {
+  const source = await readNoteSource(path)
+  const parsed = parseNote({ path, source })
+  if (parsed.frontmatterWarning !== undefined) {
+    throw new ReflectError('parse', 'The note has invalid frontmatter — fix it before unpublishing')
+  }
+
+  const previous = parsed.frontmatter.gist
+  if (previous === undefined) {
+    return
+  }
+
+  const token = await getGithubToken(providerFetch)
+  if (token === null) {
+    throw new ReflectError('auth', 'Connect GitHub in Settings to unpublish gists')
+  }
+
+  await deleteGist(token, previous.id, providerFetch)
+  await commitNoteFrontmatter(path, { gist: false }, generation)
+}
+
+/**
  * The publish action as both entry points run it (Note actions button, ⌘K
  * command): publish, copy the gist link, and surface progress through the
  * operations status line — the second short-lived entry is the only success
@@ -125,4 +152,22 @@ export async function runGistPublish(path: string, generation: number): Promise<
     startOperation('Copying the gist link').fail(errorMessage(cause))
   }
   return url
+}
+
+/**
+ * The unpublish action as the sidebar runs it: delete the remote gist, clear
+ * the local gist metadata, and hide the published URL optimistically while the
+ * index catches up.
+ */
+export async function runGistUnpublish(path: string, generation: number): Promise<boolean> {
+  const operation = startOperation('Unpublishing gist')
+  try {
+    await unpublishNoteGist(path, generation)
+  } catch (cause) {
+    operation.fail(errorMessage(cause))
+    return false
+  }
+  operation.done()
+  setNoteRowOverlay(path, generation, { gistUrl: null })
+  return true
 }

--- a/apps/desktop/src/lib/note-gist.ts
+++ b/apps/desktop/src/lib/note-gist.ts
@@ -94,8 +94,9 @@ export async function publishNoteToGist(path: string, generation: number): Promi
 /**
  * Delete the note's published GitHub Gist and remove the local `gist`
  * frontmatter block. A missing local block is already unpublished, so this is a
- * no-op. A remote 404 is success through {@link deleteGist}: the desired shared
- * link is gone, and the local record can be cleared.
+ * no-op. The local record is cleared before the remote delete, so a local write
+ * failure cannot leave Reflect pointing at a dead link. If GitHub rejects the
+ * delete, the local block is restored before the error is surfaced.
  */
 export async function unpublishNoteGist(path: string, generation: number): Promise<void> {
   const source = await readNoteSource(path)
@@ -114,8 +115,13 @@ export async function unpublishNoteGist(path: string, generation: number): Promi
     throw new ReflectError('auth', 'Connect GitHub in Settings to unpublish gists')
   }
 
-  await deleteGist(token, previous.id, providerFetch)
   await commitNoteFrontmatter(path, { gist: false }, generation)
+  try {
+    await deleteGist(token, previous.id, providerFetch)
+  } catch (cause) {
+    await commitNoteFrontmatter(path, { gist: previous }, generation)
+    throw cause
+  }
 }
 
 /**
@@ -144,7 +150,7 @@ export async function runGistPublish(path: string, generation: number): Promise<
   operation.done()
   // Stamp the optimism with the publishing graph's generation, so a publish
   // that resolves after a graph switch can't surface on the new graph.
-  setNoteRowOverlay(path, generation, { gistUrl: url })
+  setNoteRowOverlay(path, generation, { gistUrl: url, gistStale: false })
   try {
     await navigator.clipboard.writeText(url)
     startOperation('Gist link copied').done()
@@ -168,6 +174,6 @@ export async function runGistUnpublish(path: string, generation: number): Promis
     return false
   }
   operation.done()
-  setNoteRowOverlay(path, generation, { gistUrl: null })
+  setNoteRowOverlay(path, generation, { gistUrl: null, gistStale: false })
   return true
 }


### PR DESCRIPTION
## Summary
- replace the republish sidebar action with an Unpublish link action that deletes the GitHub gist and clears gist frontmatter
- move gist update into the Published URL section as a refresh icon beside copy, with tooltip and stale-state emphasis
- allow optimistic note-row overlays to hide the Published URL section after unpublish while indexing catches up

## Testing
- pnpm --filter @reflect/desktop test --run src/lib/note-gist.test.ts
- pnpm --filter @reflect/desktop test --run src/components/context-sidebar/note-gist-action.test.tsx src/components/context-sidebar/published-url-section.test.tsx
- pnpm --filter @reflect/desktop test --run src/hooks/note-row-overlay.test.ts
- pnpm check
- pnpm build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Unpublish deletes remote gists and uses clear-local-then-delete with rollback on failure; ordering is intentional but touches external APIs and note frontmatter writes.
> 
> **Overview**
> Adds **unpublish** for private GitHub gists and splits publish vs update/republish across the sidebar.
> 
> The note **gist action** stays **Share with private link** until a gist exists, then switches to **Unpublish link** (`runGistUnpublish`) instead of republish. The **Published URL** section gains an **Update published gist** control (refresh icon) that calls `runGistPublish`, including accent styling when `gist_stale` is true.
> 
> Backend work in `note-gist` introduces `unpublishNoteGist` / `runGistUnpublish`: clear local `gist` frontmatter first (`gist: false`), delete the remote gist, and **restore** frontmatter if GitHub delete fails. Publish and unpublish share a **per-note mutex** so overlapping operations are rejected. Optimistic **note-row overlays** now support `gistUrl: null` and `gistStale`, with fields reconciled independently as the index catches up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2045b5c9f953d8247c2e48af0a31208926659f24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->