### PR TITLE
Clarify GitHub backup account actions

### DIFF
--- a/apps/desktop/src/components/settings/backup-section.test.tsx
+++ b/apps/desktop/src/components/settings/backup-section.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { openUrl } from '@tauri-apps/plugin-opener'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { BackupState } from '@/lib/backup-controller'
@@ -109,5 +109,21 @@ describe('BackupSection', () => {
     await waitFor(() =>
       expect(screen.queryByRole('heading', { name: 'Sign out of GitHub?' })).toBeNull(),
     )
+  })
+
+  it('shows sign-out failures inside the confirmation dialog', async () => {
+    sync.signOut.mockRejectedValueOnce(new Error('Keychain denied'))
+    renderSection({
+      phase: 'connected',
+      remoteUrl: 'https://github.com/alex/notes.git',
+      repo: { owner: 'alex', name: 'notes' },
+      status: { state: 'idle' },
+    })
+
+    fireEvent.click(await screen.findByRole('button', { name: /Sign out of GitHub/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Sign out' }))
+
+    expect(await screen.findByRole('heading', { name: 'Sign out of GitHub?' })).toBeTruthy()
+    expect(within(screen.getByRole('dialog')).getByText('Keychain denied')).toBeTruthy()
   })
 })

--- a/apps/desktop/src/components/settings/backup-section.test.tsx
+++ b/apps/desktop/src/components/settings/backup-section.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { openUrl } from '@tauri-apps/plugin-opener'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { BackupState } from '@/lib/backup-controller'
 import { BackupSection } from './backup-section'
@@ -14,11 +15,13 @@ const sync = vi.hoisted(() => ({
   signOut: vi.fn(async () => {}),
   backUpNow: vi.fn(async () => {}),
 }))
+vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn(async () => {}) }))
 vi.mock('@/providers/sync-provider', () => ({ useSync: () => sync }))
 vi.mock('@/providers/graph-provider', () => ({ useGraph: () => ({ graph: null }) }))
 
 afterEach(() => {
   cleanup()
+  vi.clearAllMocks()
 })
 
 function renderSection(backup: BackupState): void {
@@ -52,7 +55,8 @@ describe('BackupSection', () => {
     expect(screen.getByText(/ssh-add/)).toBeTruthy()
     expect(screen.queryByText(/reconnect GitHub/)).toBeNull()
     // Machine-level GitHub sign-out is noise next to a non-GitHub graph.
-    expect(screen.queryByRole('button', { name: 'Sign out of GitHub' })).toBeNull()
+    expect(screen.queryByRole('button', { name: /Sign out of GitHub/ })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Open GitHub repo' })).toBeNull()
   })
 
   it('renders a GitHub remote with the reconnect affordances', async () => {
@@ -66,6 +70,41 @@ describe('BackupSection', () => {
     expect(await screen.findByText('GitHub backup')).toBeTruthy()
     expect(screen.getByText('alex/notes')).toBeTruthy()
     expect(screen.getByText(/reconnect GitHub/)).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Sign out of GitHub' })).toBeTruthy()
+    expect(screen.getByText('GitHub account')).toBeTruthy()
+    expect(screen.getByText(/connected graphs stop backing up/i)).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Open GitHub repo' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Sign out of GitHub/ })).toBeTruthy()
+  })
+
+  it('opens the connected GitHub repository', async () => {
+    renderSection({
+      phase: 'connected',
+      remoteUrl: 'https://github.com/alex/notes.git',
+      repo: { owner: 'alex', name: 'notes' },
+      status: { state: 'idle' },
+    })
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open GitHub repo' }))
+
+    expect(openUrl).toHaveBeenCalledWith('https://github.com/alex/notes')
+  })
+
+  it('confirms before signing out of GitHub', async () => {
+    renderSection({
+      phase: 'connected',
+      remoteUrl: 'https://github.com/alex/notes.git',
+      repo: { owner: 'alex', name: 'notes' },
+      status: { state: 'idle' },
+    })
+
+    fireEvent.click(await screen.findByRole('button', { name: /Sign out of GitHub/ }))
+
+    expect(screen.getByRole('heading', { name: 'Sign out of GitHub?' })).toBeTruthy()
+    expect(screen.getByText(/Every GitHub-backed graph will stop backing up/i)).toBeTruthy()
+    expect(sync.signOut).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign out' }))
+
+    await waitFor(() => expect(sync.signOut).toHaveBeenCalledTimes(1))
   })
 })

--- a/apps/desktop/src/components/settings/backup-section.test.tsx
+++ b/apps/desktop/src/components/settings/backup-section.test.tsx
@@ -109,6 +109,24 @@ describe('BackupSection', () => {
     ).toBeNull()
   })
 
+  it('clears stale open-repo errors before retrying', async () => {
+    vi.mocked(openUrl).mockRejectedValueOnce(new Error('No browser'))
+    renderSection({
+      phase: 'connected',
+      remoteUrl: 'https://github.com/alex/notes.git',
+      repo: { owner: 'alex', name: 'notes' },
+      status: { state: 'idle' },
+    })
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open GitHub repo' }))
+
+    expect(await screen.findByText(/Couldn’t open the browser/)).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open GitHub repo' }))
+
+    await waitFor(() => expect(screen.queryByText(/Couldn’t open the browser/)).toBeNull())
+  })
+
   it('confirms before signing out of GitHub', async () => {
     renderSection({
       phase: 'connected',
@@ -146,5 +164,33 @@ describe('BackupSection', () => {
     expect(await screen.findByRole('heading', { name: 'Sign out of GitHub?' })).toBeTruthy()
     expect(within(screen.getByRole('dialog')).getByText('Keychain denied')).toBeTruthy()
     expect(screen.getAllByText('Keychain denied')).toHaveLength(1)
+  })
+
+  it('does not close the sign-out dialog while sign-out is pending', async () => {
+    let resolveSignOut: () => void = () => {}
+    sync.signOut.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSignOut = resolve
+        }),
+    )
+    renderSection({
+      phase: 'connected',
+      remoteUrl: 'https://github.com/alex/notes.git',
+      repo: { owner: 'alex', name: 'notes' },
+      status: { state: 'idle' },
+    })
+
+    fireEvent.click(await screen.findByRole('button', { name: /Sign out of GitHub/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Sign out' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(screen.getByRole('heading', { name: 'Sign out of GitHub?' })).toBeTruthy()
+
+    resolveSignOut()
+
+    await waitFor(() =>
+      expect(screen.queryByRole('heading', { name: 'Sign out of GitHub?' })).toBeNull(),
+    )
   })
 })

--- a/apps/desktop/src/components/settings/backup-section.test.tsx
+++ b/apps/desktop/src/components/settings/backup-section.test.tsx
@@ -89,6 +89,26 @@ describe('BackupSection', () => {
     expect(openUrl).toHaveBeenCalledWith('https://github.com/alex/notes')
   })
 
+  it('keeps unrelated action errors out of the sign-out dialog', async () => {
+    vi.mocked(openUrl).mockRejectedValueOnce(new Error('No browser'))
+    renderSection({
+      phase: 'connected',
+      remoteUrl: 'https://github.com/alex/notes.git',
+      repo: { owner: 'alex', name: 'notes' },
+      status: { state: 'idle' },
+    })
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open GitHub repo' }))
+
+    expect(await screen.findByText(/Couldn’t open the browser/)).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /Sign out of GitHub/ }))
+
+    expect(
+      within(screen.getByRole('dialog')).queryByText(/Couldn’t open the browser/),
+    ).toBeNull()
+  })
+
   it('confirms before signing out of GitHub', async () => {
     renderSection({
       phase: 'connected',
@@ -125,5 +145,6 @@ describe('BackupSection', () => {
 
     expect(await screen.findByRole('heading', { name: 'Sign out of GitHub?' })).toBeTruthy()
     expect(within(screen.getByRole('dialog')).getByText('Keychain denied')).toBeTruthy()
+    expect(screen.getAllByText('Keychain denied')).toHaveLength(1)
   })
 })

--- a/apps/desktop/src/components/settings/backup-section.test.tsx
+++ b/apps/desktop/src/components/settings/backup-section.test.tsx
@@ -127,6 +127,33 @@ describe('BackupSection', () => {
     await waitFor(() => expect(screen.queryByText(/Couldn’t open the browser/)).toBeNull())
   })
 
+  it('ignores an older open-repo failure after a newer retry succeeds', async () => {
+    let rejectFirstOpen: (reason?: unknown) => void = () => {}
+    vi.mocked(openUrl)
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectFirstOpen = reject
+          }),
+      )
+      .mockResolvedValueOnce()
+    renderSection({
+      phase: 'connected',
+      remoteUrl: 'https://github.com/alex/notes.git',
+      repo: { owner: 'alex', name: 'notes' },
+      status: { state: 'idle' },
+    })
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open GitHub repo' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Open GitHub repo' }))
+
+    await waitFor(() => expect(openUrl).toHaveBeenCalledTimes(2))
+
+    rejectFirstOpen(new Error('Old failure'))
+
+    await waitFor(() => expect(screen.queryByText(/Couldn’t open the browser/)).toBeNull())
+  })
+
   it('confirms before signing out of GitHub', async () => {
     renderSection({
       phase: 'connected',

--- a/apps/desktop/src/components/settings/backup-section.test.tsx
+++ b/apps/desktop/src/components/settings/backup-section.test.tsx
@@ -106,5 +106,8 @@ describe('BackupSection', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Sign out' }))
 
     await waitFor(() => expect(sync.signOut).toHaveBeenCalledTimes(1))
+    await waitFor(() =>
+      expect(screen.queryByRole('heading', { name: 'Sign out of GitHub?' })).toBeNull(),
+    )
   })
 })

--- a/apps/desktop/src/components/settings/backup-section.tsx
+++ b/apps/desktop/src/components/settings/backup-section.tsx
@@ -93,6 +93,13 @@ export function BackupSection(): ReactElement {
     })
   }
 
+  async function confirmSignOut(): Promise<void> {
+    await action.run(async () => {
+      await signOut()
+      setSignOutOpen(false)
+    })
+  }
+
   return (
     <SettingsSection id="backup">
       <SettingsField
@@ -189,7 +196,7 @@ export function BackupSection(): ReactElement {
                         <Button
                           variant="destructive"
                           disabled={action.pending}
-                          onClick={() => void action.run(signOut)}
+                          onClick={() => void confirmSignOut()}
                         >
                           Sign out
                         </Button>

--- a/apps/desktop/src/components/settings/backup-section.tsx
+++ b/apps/desktop/src/components/settings/backup-section.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from 'react'
+import { useRef, useState, type ReactElement } from 'react'
 import { openUrl } from '@tauri-apps/plugin-opener'
 import { useQuery } from '@tanstack/react-query'
 import { getConflictedNotes, getDuplicateNoteIds, hasBridge } from '@reflect/core'
@@ -57,6 +57,7 @@ export function BackupSection(): ReactElement {
   const { graph } = useGraph()
   const [connectOpen, setConnectOpen] = useState(false)
   const [signOutOpen, setSignOutOpen] = useState(false)
+  const openRepoAttempt = useRef(0)
   const action = useAsyncAction()
   const signOutAction = useAsyncAction()
 
@@ -89,13 +90,19 @@ export function BackupSection(): ReactElement {
       return
     }
     const url = githubRepoBrowserUrl(backup.repo)
+    const attempt = openRepoAttempt.current + 1
+    openRepoAttempt.current = attempt
     action.setError(null)
     void openUrl(url)
       .then(() => {
-        action.setError(null)
+        if (openRepoAttempt.current === attempt) {
+          action.setError(null)
+        }
       })
       .catch(() => {
-        action.setError(`Couldn’t open the browser — visit ${url} yourself.`)
+        if (openRepoAttempt.current === attempt) {
+          action.setError(`Couldn’t open the browser — visit ${url} yourself.`)
+        }
       })
   }
 

--- a/apps/desktop/src/components/settings/backup-section.tsx
+++ b/apps/desktop/src/components/settings/backup-section.tsx
@@ -58,6 +58,7 @@ export function BackupSection(): ReactElement {
   const [connectOpen, setConnectOpen] = useState(false)
   const [signOutOpen, setSignOutOpen] = useState(false)
   const action = useAsyncAction()
+  const signOutAction = useAsyncAction()
 
   const conflicted = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, 'conflicted-notes', graph?.root],
@@ -94,7 +95,7 @@ export function BackupSection(): ReactElement {
   }
 
   async function confirmSignOut(): Promise<void> {
-    await action.run(async () => {
+    await signOutAction.run(async () => {
       await signOut()
       setSignOutOpen(false)
     })
@@ -176,7 +177,7 @@ export function BackupSection(): ReactElement {
                         variant="destructive"
                         size="sm"
                         title="Removes the GitHub token from this machine"
-                        disabled={action.pending}
+                        disabled={signOutAction.pending}
                       >
                         Sign out of GitHub…
                       </Button>
@@ -189,8 +190,10 @@ export function BackupSection(): ReactElement {
                           GitHub-backed graph will stop backing up until you sign in again.
                         </DialogDescription>
                       </DialogHeader>
-                      {action.error !== null ? (
-                        <p className="text-xs text-red-700 dark:text-red-300">{action.error}</p>
+                      {signOutAction.error !== null ? (
+                        <p className="text-xs text-red-700 dark:text-red-300">
+                          {signOutAction.error}
+                        </p>
                       ) : null}
                       <DialogFooter>
                         <DialogClose asChild>
@@ -198,7 +201,7 @@ export function BackupSection(): ReactElement {
                         </DialogClose>
                         <Button
                           variant="destructive"
-                          disabled={action.pending}
+                          disabled={signOutAction.pending}
                           onClick={() => void confirmSignOut()}
                         >
                           Sign out

--- a/apps/desktop/src/components/settings/backup-section.tsx
+++ b/apps/desktop/src/components/settings/backup-section.tsx
@@ -89,9 +89,21 @@ export function BackupSection(): ReactElement {
       return
     }
     const url = githubRepoBrowserUrl(backup.repo)
-    void openUrl(url).catch(() => {
-      action.setError(`Couldn’t open the browser — visit ${url} yourself.`)
-    })
+    action.setError(null)
+    void openUrl(url)
+      .then(() => {
+        action.setError(null)
+      })
+      .catch(() => {
+        action.setError(`Couldn’t open the browser — visit ${url} yourself.`)
+      })
+  }
+
+  function setSignOutDialogOpen(open: boolean): void {
+    if (!open && signOutAction.pending) {
+      return
+    }
+    setSignOutOpen(open)
   }
 
   async function confirmSignOut(): Promise<void> {
@@ -171,7 +183,7 @@ export function BackupSection(): ReactElement {
                       Sign out on this machine; connected graphs stop backing up.
                     </p>
                   </div>
-                  <Dialog open={signOutOpen} onOpenChange={setSignOutOpen}>
+                  <Dialog open={signOutOpen} onOpenChange={setSignOutDialogOpen}>
                     <DialogTrigger asChild>
                       <Button
                         variant="destructive"
@@ -182,7 +194,7 @@ export function BackupSection(): ReactElement {
                         Sign out of GitHub…
                       </Button>
                     </DialogTrigger>
-                    <DialogContent>
+                    <DialogContent showCloseButton={!signOutAction.pending}>
                       <DialogHeader>
                         <DialogTitle>Sign out of GitHub?</DialogTitle>
                         <DialogDescription>
@@ -197,7 +209,9 @@ export function BackupSection(): ReactElement {
                       ) : null}
                       <DialogFooter>
                         <DialogClose asChild>
-                          <Button variant="outline">Cancel</Button>
+                          <Button variant="outline" disabled={signOutAction.pending}>
+                            Cancel
+                          </Button>
                         </DialogClose>
                         <Button
                           variant="destructive"

--- a/apps/desktop/src/components/settings/backup-section.tsx
+++ b/apps/desktop/src/components/settings/backup-section.tsx
@@ -1,11 +1,23 @@
 import { useState, type ReactElement } from 'react'
+import { openUrl } from '@tauri-apps/plugin-opener'
 import { useQuery } from '@tanstack/react-query'
 import { getConflictedNotes, getDuplicateNoteIds, hasBridge } from '@reflect/core'
+import { ExternalLink } from 'lucide-react'
 import { ConnectGithubDialog } from '@/components/settings/connect-github-dialog'
 import { SettingsField } from '@/components/settings/field'
 import { SettingsSection } from '@/components/settings/section'
 import { SyncForkNotice } from '@/components/settings/sync-fork-notice'
 import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
 import { useAsyncAction } from '@/hooks/use-async-action'
 import { suggestRepoName } from '@/lib/github-repos'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
@@ -30,6 +42,10 @@ function statusLine(backup: Extract<BackupState, { phase: 'connected' }>): strin
   }
 }
 
+function githubRepoBrowserUrl(repo: NonNullable<Extract<BackupState, { phase: 'connected' }>['repo']>): string {
+  return `https://github.com/${repo.owner}/${repo.name}`
+}
+
 /**
  * Settings → Backup: connect a GitHub repository, see the current backup
  * state in product language, back up on demand, and disconnect. Conflicted
@@ -40,6 +56,7 @@ export function BackupSection(): ReactElement {
   const { backup, disconnectGraph, signOut, backUpNow } = useSync()
   const { graph } = useGraph()
   const [connectOpen, setConnectOpen] = useState(false)
+  const [signOutOpen, setSignOutOpen] = useState(false)
   const action = useAsyncAction()
 
   const conflicted = useQuery({
@@ -65,6 +82,16 @@ export function BackupSection(): ReactElement {
       : null
   // A hand-wired non-GitHub remote (Plan 16) renders the section host-neutral.
   const genericRemote = backup.phase === 'connected' && backup.repo === null
+
+  function openGithubRepo(): void {
+    if (backup.phase !== 'connected' || backup.repo === null) {
+      return
+    }
+    const url = githubRepoBrowserUrl(backup.repo)
+    void openUrl(url).catch(() => {
+      action.setError(`Couldn’t open the browser — visit ${url} yourself.`)
+    })
+  }
 
   return (
     <SettingsSection id="backup">
@@ -122,18 +149,55 @@ export function BackupSection(): ReactElement {
                   Stop backing up
                 </Button>
                 {backup.repo !== null ? (
-                  // Machine-level GitHub sign-out is noise next to a graph
-                  // that doesn't back up to GitHub.
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    title="Removes the GitHub token from this machine — every connected graph stops backing up"
-                    onClick={() => void action.run(signOut)}
-                  >
-                    Sign out of GitHub
+                  <Button variant="ghost" size="sm" onClick={openGithubRepo}>
+                    <ExternalLink aria-hidden />
+                    Open GitHub repo
                   </Button>
                 ) : null}
               </div>
+              {backup.repo !== null ? (
+                <div className="mt-2 flex flex-col gap-2 border-t border-border/70 pt-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="text-xs font-medium text-text">GitHub account</p>
+                    <p className="text-xs text-text-muted">
+                      Sign out on this machine; connected graphs stop backing up.
+                    </p>
+                  </div>
+                  <Dialog open={signOutOpen} onOpenChange={setSignOutOpen}>
+                    <DialogTrigger asChild>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        title="Removes the GitHub token from this machine"
+                        disabled={action.pending}
+                      >
+                        Sign out of GitHub…
+                      </Button>
+                    </DialogTrigger>
+                    <DialogContent>
+                      <DialogHeader>
+                        <DialogTitle>Sign out of GitHub?</DialogTitle>
+                        <DialogDescription>
+                          This removes the GitHub token from this machine. Every
+                          GitHub-backed graph will stop backing up until you sign in again.
+                        </DialogDescription>
+                      </DialogHeader>
+                      <DialogFooter>
+                        <DialogClose asChild>
+                          <Button variant="outline">Cancel</Button>
+                        </DialogClose>
+                        <Button
+                          variant="destructive"
+                          disabled={action.pending}
+                          onClick={() => void action.run(signOut)}
+                        >
+                          Sign out
+                        </Button>
+                      </DialogFooter>
+                    </DialogContent>
+                  </Dialog>
+                </div>
+              ) : null}
             </>
           ) : null}
 

--- a/apps/desktop/src/components/settings/backup-section.tsx
+++ b/apps/desktop/src/components/settings/backup-section.tsx
@@ -189,6 +189,9 @@ export function BackupSection(): ReactElement {
                           GitHub-backed graph will stop backing up until you sign in again.
                         </DialogDescription>
                       </DialogHeader>
+                      {action.error !== null ? (
+                        <p className="text-xs text-red-700 dark:text-red-300">{action.error}</p>
+                      ) : null}
                       <DialogFooter>
                         <DialogClose asChild>
                           <Button variant="outline">Cancel</Button>


### PR DESCRIPTION
## Summary
- separate graph-level backup controls from machine-level GitHub sign-out
- add a confirmation dialog before clearing the GitHub token
- add an Open GitHub repo action for connected GitHub backups

## Testing
- pnpm --dir apps/desktop test --run src/components/settings/backup-section.test.tsx
- pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop settings UI and local GitHub token sign-out only; no backup engine or auth protocol changes beyond clearer UX and guarded sign-out.
> 
> **Overview**
> **Settings → Backup** for GitHub-connected graphs now separates **graph backup** actions from **machine-level GitHub account** actions, and adds safer flows for opening the repo and signing out.
> 
> Connected GitHub backups get an **Open GitHub repo** control that opens `https://github.com/{owner}/{name}` via Tauri `openUrl`, with inline errors if the browser fails and attempt tracking so stale failures don’t overwrite a successful retry. **Sign out of GitHub** moves into a dedicated **GitHub account** block (destructive trigger + confirmation dialog), uses its own async error state so open-repo errors don’t appear in the dialog, blocks dismiss while sign-out is pending, and only calls `signOut` after confirmation.
> 
> Non-GitHub remotes stay unchanged: no open-repo or sign-out affordances. Tests in `backup-section.test.tsx` cover the new UI, opener behavior, error isolation, and sign-out dialog edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a37eacee61d6970299014f6c8fa8c3a8346eea3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->