### PR TITLE
Add whole-page text capture to extension

### DIFF
--- a/apps/extension/entrypoints/capture-content.content.ts
+++ b/apps/extension/entrypoints/capture-content.content.ts
@@ -35,7 +35,7 @@ function extractPageText(): ExtractPageTextResponse {
   try {
     const clone = document.cloneNode(true)
     if (!(clone instanceof Document)) {
-      return { ok: false, message: 'Could not clone the page document.' }
+      return { ok: true, contentText: formatParagraphs(fallbackParagraphs()) }
     }
     const article = new Defuddle(clone, {
       url: document.location.href,
@@ -49,7 +49,11 @@ function extractPageText(): ExtractPageTextResponse {
     )
     return { ok: true, contentText }
   } catch (cause) {
-    return { ok: false, message: cause instanceof Error ? cause.message : String(cause) }
+    try {
+      return { ok: true, contentText: formatParagraphs(fallbackParagraphs()) }
+    } catch {
+      return { ok: false, message: cause instanceof Error ? cause.message : String(cause) }
+    }
   }
 }
 

--- a/apps/extension/entrypoints/capture-content.content.ts
+++ b/apps/extension/entrypoints/capture-content.content.ts
@@ -31,7 +31,10 @@ function fallbackParagraphs(): string[] {
   return root ? visibleParagraphs(root) : []
 }
 
-function extractPageText(): ExtractPageTextResponse {
+function extractPageText(expectedUrl: string): ExtractPageTextResponse {
+  if (document.location.href !== expectedUrl) {
+    return { ok: false, message: 'page URL changed before text extraction' }
+  }
   try {
     const clone = document.cloneNode(true)
     if (!(clone instanceof Document)) {
@@ -70,7 +73,7 @@ export default defineContentScript({
       if (!request.success) {
         return undefined
       }
-      return Promise.resolve(extractPageText())
+      return Promise.resolve(extractPageText(request.data.expectedUrl))
     }
     window.__reflectCaptureTextListener = listener
     browser.runtime.onMessage.addListener(listener)

--- a/apps/extension/entrypoints/capture-content.content.ts
+++ b/apps/extension/entrypoints/capture-content.content.ts
@@ -3,6 +3,7 @@ import { browser } from 'wxt/browser'
 import {
   extractPageTextRequestSchema,
   formatParagraphs,
+  normalizeParagraphText,
   samePageUrl,
   type ExtractPageTextResponse,
 } from '@/lib/page-text'
@@ -33,8 +34,8 @@ function isVisibleElement(element: Element): boolean {
 function textFromElements(elements: readonly Element[]): string[] {
   return elements
     .filter(isVisibleElement)
-    .filter((paragraph) => paragraph.textContent !== null)
-    .map((paragraph) => paragraph.textContent ?? '')
+    .map((paragraph) => normalizeParagraphText(paragraph.textContent ?? ''))
+    .filter((text) => text.length > 0)
 }
 
 function hasNestedTextBlock(element: Element): boolean {
@@ -44,9 +45,9 @@ function hasNestedTextBlock(element: Element): boolean {
 }
 
 function visibleTextBlocks(root: ParentNode): string[] {
-  const primary = Array.from(root.querySelectorAll(PRIMARY_TEXT_SELECTOR))
-  if (primary.length > 0) {
-    return textFromElements(primary)
+  const primaryText = textFromElements(Array.from(root.querySelectorAll(PRIMARY_TEXT_SELECTOR)))
+  if (primaryText.length > 0) {
+    return primaryText
   }
   const fallback = Array.from(root.querySelectorAll(FALLBACK_TEXT_SELECTOR)).filter(
     (element) => !hasNestedTextBlock(element),

--- a/apps/extension/entrypoints/capture-content.content.ts
+++ b/apps/extension/entrypoints/capture-content.content.ts
@@ -3,6 +3,7 @@ import { browser } from 'wxt/browser'
 import {
   extractPageTextRequestSchema,
   formatParagraphs,
+  samePageUrl,
   type ExtractPageTextResponse,
 } from '@/lib/page-text'
 
@@ -14,25 +15,58 @@ declare global {
   }
 }
 
-function visibleParagraphs(root: ParentNode): string[] {
-  return Array.from(root.querySelectorAll('p'))
+const PRIMARY_TEXT_SELECTOR = 'p, [role="paragraph"]'
+const FALLBACK_TEXT_SELECTOR = `${PRIMARY_TEXT_SELECTOR}, li, blockquote, pre, div`
+
+function isVisibleElement(element: Element): boolean {
+  if (!element.isConnected) {
+    return true
+  }
+  const view = element.ownerDocument.defaultView
+  if (!view) {
+    return true
+  }
+  const style = view.getComputedStyle(element)
+  return style.display !== 'none' && style.visibility !== 'hidden'
+}
+
+function textFromElements(elements: readonly Element[]): string[] {
+  return elements
+    .filter(isVisibleElement)
     .filter((paragraph) => paragraph.textContent !== null)
     .map((paragraph) => paragraph.textContent ?? '')
+}
+
+function hasNestedTextBlock(element: Element): boolean {
+  return Array.from(element.children).some(
+    (child) => child.matches(FALLBACK_TEXT_SELECTOR) || child.querySelector(FALLBACK_TEXT_SELECTOR),
+  )
+}
+
+function visibleTextBlocks(root: ParentNode): string[] {
+  const primary = Array.from(root.querySelectorAll(PRIMARY_TEXT_SELECTOR))
+  if (primary.length > 0) {
+    return textFromElements(primary)
+  }
+  const fallback = Array.from(root.querySelectorAll(FALLBACK_TEXT_SELECTOR)).filter(
+    (element) => !hasNestedTextBlock(element),
+  )
+  return textFromElements(fallback)
 }
 
 function paragraphsFromHtml(html: string): string[] {
   const template = document.createElement('template')
   template.innerHTML = html
-  return visibleParagraphs(template.content)
+  return visibleTextBlocks(template.content)
 }
 
 function fallbackParagraphs(): string[] {
   const root = document.querySelector('article, main') ?? document.body
-  return root ? visibleParagraphs(root) : []
+  return root ? visibleTextBlocks(root) : []
 }
 
 function extractPageText(expectedUrl: string): ExtractPageTextResponse {
-  if (document.location.href !== expectedUrl) {
+  if (!samePageUrl(document.location.href, expectedUrl)) {
     return { ok: false, message: 'page URL changed before text extraction' }
   }
   try {

--- a/apps/extension/entrypoints/capture-content.content.ts
+++ b/apps/extension/entrypoints/capture-content.content.ts
@@ -1,0 +1,69 @@
+import Defuddle from 'defuddle'
+import { browser } from 'wxt/browser'
+import {
+  extractPageTextRequestSchema,
+  formatParagraphs,
+  type ExtractPageTextResponse,
+} from '@/lib/page-text'
+
+declare global {
+  interface Window {
+    __reflectCaptureTextInstalled?: boolean
+  }
+}
+
+function visibleParagraphs(root: ParentNode): string[] {
+  return Array.from(root.querySelectorAll('p'))
+    .filter((paragraph) => paragraph.textContent !== null)
+    .map((paragraph) => paragraph.textContent ?? '')
+}
+
+function paragraphsFromHtml(html: string): string[] {
+  const template = document.createElement('template')
+  template.innerHTML = html
+  return visibleParagraphs(template.content)
+}
+
+function fallbackParagraphs(): string[] {
+  const root = document.querySelector('article, main') ?? document.body
+  return root ? visibleParagraphs(root) : []
+}
+
+function extractPageText(): ExtractPageTextResponse {
+  try {
+    const clone = document.cloneNode(true)
+    if (!(clone instanceof Document)) {
+      return { ok: false, message: 'Could not clone the page document.' }
+    }
+    const article = new Defuddle(clone, {
+      url: document.location.href,
+      useAsync: false,
+      includeReplies: false,
+      removeImages: true,
+    }).parse()
+    const articleParagraphs = article.content ? paragraphsFromHtml(article.content) : []
+    const contentText = formatParagraphs(
+      articleParagraphs.length > 0 ? articleParagraphs : fallbackParagraphs(),
+    )
+    return { ok: true, contentText }
+  } catch (cause) {
+    return { ok: false, message: cause instanceof Error ? cause.message : String(cause) }
+  }
+}
+
+export default defineContentScript({
+  registration: 'runtime',
+  main() {
+    if (window.__reflectCaptureTextInstalled) {
+      return
+    }
+    window.__reflectCaptureTextInstalled = true
+    browser.runtime.onMessage.addListener((message: unknown) => {
+      const request = extractPageTextRequestSchema.safeParse(message)
+      if (!request.success) {
+        return undefined
+      }
+      return Promise.resolve(extractPageText())
+    })
+  },
+})

--- a/apps/extension/entrypoints/capture-content.content.ts
+++ b/apps/extension/entrypoints/capture-content.content.ts
@@ -6,9 +6,11 @@ import {
   type ExtractPageTextResponse,
 } from '@/lib/page-text'
 
+type PageTextListener = (message: unknown) => Promise<ExtractPageTextResponse> | undefined
+
 declare global {
   interface Window {
-    __reflectCaptureTextInstalled?: boolean
+    __reflectCaptureTextListener?: PageTextListener
   }
 }
 
@@ -54,16 +56,19 @@ function extractPageText(): ExtractPageTextResponse {
 export default defineContentScript({
   registration: 'runtime',
   main() {
-    if (window.__reflectCaptureTextInstalled) {
-      return
+    const previousListener = window.__reflectCaptureTextListener
+    if (previousListener) {
+      browser.runtime.onMessage.removeListener(previousListener)
     }
-    window.__reflectCaptureTextInstalled = true
-    browser.runtime.onMessage.addListener((message: unknown) => {
+
+    const listener: PageTextListener = (message) => {
       const request = extractPageTextRequestSchema.safeParse(message)
       if (!request.success) {
         return undefined
       }
       return Promise.resolve(extractPageText())
-    })
+    }
+    window.__reflectCaptureTextListener = listener
+    browser.runtime.onMessage.addListener(listener)
   },
 })

--- a/apps/extension/entrypoints/popup/app.tsx
+++ b/apps/extension/entrypoints/popup/app.tsx
@@ -7,7 +7,7 @@ import {
   readIncludePageTextPreference,
   writeIncludePageTextPreference,
 } from '@/lib/popup-preferences'
-import { extractPageText } from './extract-page-text'
+import { tryExtractPageText } from './extract-page-text'
 import { useCapturedPage } from './use-captured-page'
 
 /**
@@ -106,7 +106,7 @@ export function CapturePopup(): ReactElement {
     }
     setSave({ phase: 'saving' })
     try {
-      const contentText = includePageText ? await extractPageText(captured.tabId) : undefined
+      const contentText = includePageText ? await tryExtractPageText(captured.tabId) : undefined
       const outcome = await saveCapture({
         ...captured.page,
         contentText,

--- a/apps/extension/entrypoints/popup/app.tsx
+++ b/apps/extension/entrypoints/popup/app.tsx
@@ -118,7 +118,9 @@ export function CapturePopup(): ReactElement {
     }
     setSave({ phase: 'saving' })
     try {
-      const contentText = includePageText ? await tryExtractPageText(captured.tabId) : undefined
+      const contentText = includePageText
+        ? await tryExtractPageText(captured.tabId, captured.page.url)
+        : undefined
       const outcome = await saveCapture({
         ...captured.page,
         contentText,

--- a/apps/extension/entrypoints/popup/app.tsx
+++ b/apps/extension/entrypoints/popup/app.tsx
@@ -67,6 +67,7 @@ export function CapturePopup(): ReactElement {
   const [note, setNote] = useState('')
   const [includePageText, setIncludePageText] = useState(false)
   const includePageTextTouched = useRef(false)
+  const [includePageTextPreferenceLoaded, setIncludePageTextPreferenceLoaded] = useState(false)
   const [save, setSave] = useState<SaveState>({ phase: 'idle' })
   const [heldCount, setHeldCount] = useState(0)
 
@@ -81,9 +82,15 @@ export function CapturePopup(): ReactElement {
         if (!cancelled && !includePageTextTouched.current) {
           setIncludePageText(preference)
         }
+        if (!cancelled) {
+          setIncludePageTextPreferenceLoaded(true)
+        }
       },
       (cause) => {
         console.warn('capture page text preference could not be read:', cause)
+        if (!cancelled) {
+          setIncludePageTextPreferenceLoaded(true)
+        }
       },
     )
     return () => {
@@ -101,7 +108,12 @@ export function CapturePopup(): ReactElement {
 
   async function onSubmit(event: FormEvent): Promise<void> {
     event.preventDefault()
-    if (captured.status !== 'ready' || save.phase === 'saving' || save.phase === 'queued') {
+    if (
+      captured.status !== 'ready' ||
+      !includePageTextPreferenceLoaded ||
+      save.phase === 'saving' ||
+      save.phase === 'queued'
+    ) {
       return
     }
     setSave({ phase: 'saving' })
@@ -136,10 +148,12 @@ export function CapturePopup(): ReactElement {
 
   const { page } = captured
   const host = new URL(page.url).host
-  const busy = save.phase === 'saving' || save.phase === 'queued'
+  const busy =
+    save.phase === 'saving' || save.phase === 'queued' || !includePageTextPreferenceLoaded
 
   function onIncludePageTextChange(checked: boolean): void {
     includePageTextTouched.current = true
+    setIncludePageTextPreferenceLoaded(true)
     setIncludePageText(checked)
     void writeIncludePageTextPreference(checked).catch((cause) => {
       console.warn('capture page text preference could not be saved:', cause)

--- a/apps/extension/entrypoints/popup/app.tsx
+++ b/apps/extension/entrypoints/popup/app.tsx
@@ -1,8 +1,12 @@
-import { useEffect, useState, type FormEvent, type ReactElement } from 'react'
+import { useEffect, useRef, useState, type FormEvent, type ReactElement } from 'react'
 import { browser } from 'wxt/browser'
 import { buildWireMessage } from '@/lib/capture-message'
 import { enqueueCapture, readQueue } from '@/lib/flush'
 import { flushResultSchema, type FlushResult } from '@/lib/messages'
+import {
+  readIncludePageTextPreference,
+  writeIncludePageTextPreference,
+} from '@/lib/popup-preferences'
 import { extractPageText } from './extract-page-text'
 import { useCapturedPage } from './use-captured-page'
 
@@ -62,11 +66,29 @@ export function CapturePopup(): ReactElement {
   const captured = useCapturedPage()
   const [note, setNote] = useState('')
   const [includePageText, setIncludePageText] = useState(false)
+  const includePageTextTouched = useRef(false)
   const [save, setSave] = useState<SaveState>({ phase: 'idle' })
   const [heldCount, setHeldCount] = useState(0)
 
   useEffect(() => {
     void readQueue().then((queue) => setHeldCount(queue.length))
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    void readIncludePageTextPreference().then(
+      (preference) => {
+        if (!cancelled && !includePageTextTouched.current) {
+          setIncludePageText(preference)
+        }
+      },
+      (cause) => {
+        console.warn('capture page text preference could not be read:', cause)
+      },
+    )
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   useEffect(() => {
@@ -116,6 +138,14 @@ export function CapturePopup(): ReactElement {
   const host = new URL(page.url).host
   const busy = save.phase === 'saving' || save.phase === 'queued'
 
+  function onIncludePageTextChange(checked: boolean): void {
+    includePageTextTouched.current = true
+    setIncludePageText(checked)
+    void writeIncludePageTextPreference(checked).catch((cause) => {
+      console.warn('capture page text preference could not be saved:', cause)
+    })
+  }
+
   return (
     <form onSubmit={onSubmit} className="flex flex-col gap-3 p-3">
       {page.screenshotDataUrl ? (
@@ -147,7 +177,7 @@ export function CapturePopup(): ReactElement {
         <input
           type="checkbox"
           checked={includePageText}
-          onChange={(event) => setIncludePageText(event.target.checked)}
+          onChange={(event) => onIncludePageTextChange(event.target.checked)}
           disabled={busy}
           className="size-3.5 rounded border-border text-accent focus:ring-focus-ring"
         />

--- a/apps/extension/entrypoints/popup/app.tsx
+++ b/apps/extension/entrypoints/popup/app.tsx
@@ -3,6 +3,7 @@ import { browser } from 'wxt/browser'
 import { buildWireMessage } from '@/lib/capture-message'
 import { enqueueCapture, readQueue } from '@/lib/flush'
 import { flushResultSchema, type FlushResult } from '@/lib/messages'
+import { extractPageText } from './extract-page-text'
 import { useCapturedPage } from './use-captured-page'
 
 /**
@@ -60,6 +61,7 @@ function holdMessage(result: FlushResult): string {
 export function CapturePopup(): ReactElement {
   const captured = useCapturedPage()
   const [note, setNote] = useState('')
+  const [includePageText, setIncludePageText] = useState(false)
   const [save, setSave] = useState<SaveState>({ phase: 'idle' })
   const [heldCount, setHeldCount] = useState(0)
 
@@ -82,8 +84,10 @@ export function CapturePopup(): ReactElement {
     }
     setSave({ phase: 'saving' })
     try {
+      const contentText = includePageText ? await extractPageText(captured.tabId) : undefined
       const outcome = await saveCapture({
         ...captured.page,
+        contentText,
         note,
         id: crypto.randomUUID(),
         capturedAt: new Date(),
@@ -139,6 +143,16 @@ export function CapturePopup(): ReactElement {
         disabled={busy}
         className="rounded-md border border-border bg-input-bg px-2 py-1.5 text-sm text-text outline-none placeholder:text-text-muted focus:ring-2 focus:ring-focus-ring"
       />
+      <label className="flex items-center gap-2 text-xs text-text-secondary">
+        <input
+          type="checkbox"
+          checked={includePageText}
+          onChange={(event) => setIncludePageText(event.target.checked)}
+          disabled={busy}
+          className="size-3.5 rounded border-border text-accent focus:ring-focus-ring"
+        />
+        Capture page text
+      </label>
       <button
         type="submit"
         disabled={busy}

--- a/apps/extension/entrypoints/popup/extract-page-text.test.ts
+++ b/apps/extension/entrypoints/popup/extract-page-text.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { tryExtractPageText } from './extract-page-text'
+
+const browserMocks = vi.hoisted(() => ({
+  executeScript: vi.fn(),
+  sendMessage: vi.fn(),
+}))
+
+vi.mock('wxt/browser', () => ({
+  browser: {
+    scripting: {
+      executeScript: browserMocks.executeScript,
+    },
+    tabs: {
+      sendMessage: browserMocks.sendMessage,
+    },
+  },
+}))
+
+vi.mock('@/lib/page-text', () => ({
+  EXTRACT_PAGE_TEXT_MESSAGE_TYPE: 'reflect:capture-page-text',
+  extractPageTextResponseSchema: {
+    parse: (value: unknown) => value,
+  },
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  browserMocks.executeScript.mockResolvedValue([])
+  browserMocks.sendMessage.mockResolvedValue({ ok: true, contentText: ' Article text ' })
+})
+
+describe('tryExtractPageText', () => {
+  it('returns extracted text when the content script responds', async () => {
+    await expect(tryExtractPageText(42)).resolves.toBe('Article text')
+  })
+
+  it('degrades to no page text when optional extraction fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    browserMocks.sendMessage.mockRejectedValue(new Error('receiving end does not exist'))
+
+    await expect(tryExtractPageText(42)).resolves.toBeUndefined()
+    expect(warn).toHaveBeenCalled()
+
+    warn.mockRestore()
+  })
+})

--- a/apps/extension/entrypoints/popup/extract-page-text.test.ts
+++ b/apps/extension/entrypoints/popup/extract-page-text.test.ts
@@ -32,14 +32,20 @@ beforeEach(() => {
 
 describe('tryExtractPageText', () => {
   it('returns extracted text when the content script responds', async () => {
-    await expect(tryExtractPageText(42)).resolves.toBe('Article text')
+    await expect(tryExtractPageText(42, 'https://example.com/article')).resolves.toBe(
+      'Article text',
+    )
+    expect(browserMocks.sendMessage).toHaveBeenCalledWith(42, {
+      type: 'reflect:capture-page-text',
+      expectedUrl: 'https://example.com/article',
+    })
   })
 
   it('degrades to no page text when optional extraction fails', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     browserMocks.sendMessage.mockRejectedValue(new Error('receiving end does not exist'))
 
-    await expect(tryExtractPageText(42)).resolves.toBeUndefined()
+    await expect(tryExtractPageText(42, 'https://example.com/article')).resolves.toBeUndefined()
     expect(warn).toHaveBeenCalled()
 
     warn.mockRestore()

--- a/apps/extension/entrypoints/popup/extract-page-text.ts
+++ b/apps/extension/entrypoints/popup/extract-page-text.ts
@@ -1,0 +1,24 @@
+import { browser } from 'wxt/browser'
+import {
+  EXTRACT_PAGE_TEXT_MESSAGE_TYPE,
+  extractPageTextResponseSchema,
+  type ExtractPageTextRequest,
+} from '@/lib/page-text'
+
+const CAPTURE_CONTENT_SCRIPT = '/content-scripts/capture-content.js'
+
+/** Extract normalized article paragraphs from the active tab's live DOM. */
+export async function extractPageText(tabId: number): Promise<string | undefined> {
+  await browser.scripting.executeScript({
+    target: { tabId },
+    files: [CAPTURE_CONTENT_SCRIPT],
+  })
+  const request: ExtractPageTextRequest = { type: EXTRACT_PAGE_TEXT_MESSAGE_TYPE }
+  const response: unknown = await browser.tabs.sendMessage(tabId, request)
+  const parsed = extractPageTextResponseSchema.parse(response)
+  if (!parsed.ok) {
+    throw new Error(parsed.message)
+  }
+  const contentText = parsed.contentText.trim()
+  return contentText === '' ? undefined : contentText
+}

--- a/apps/extension/entrypoints/popup/extract-page-text.ts
+++ b/apps/extension/entrypoints/popup/extract-page-text.ts
@@ -22,3 +22,13 @@ export async function extractPageText(tabId: number): Promise<string | undefined
   const contentText = parsed.contentText.trim()
   return contentText === '' ? undefined : contentText
 }
+
+/** Try optional page-text extraction without blocking the rest of the capture. */
+export async function tryExtractPageText(tabId: number): Promise<string | undefined> {
+  try {
+    return await extractPageText(tabId)
+  } catch (cause) {
+    console.warn('capture page text could not be extracted:', cause)
+    return undefined
+  }
+}

--- a/apps/extension/entrypoints/popup/extract-page-text.ts
+++ b/apps/extension/entrypoints/popup/extract-page-text.ts
@@ -8,12 +8,18 @@ import {
 const CAPTURE_CONTENT_SCRIPT = '/content-scripts/capture-content.js'
 
 /** Extract normalized article paragraphs from the active tab's live DOM. */
-export async function extractPageText(tabId: number): Promise<string | undefined> {
+export async function extractPageText(
+  tabId: number,
+  expectedUrl: string,
+): Promise<string | undefined> {
   await browser.scripting.executeScript({
     target: { tabId },
     files: [CAPTURE_CONTENT_SCRIPT],
   })
-  const request: ExtractPageTextRequest = { type: EXTRACT_PAGE_TEXT_MESSAGE_TYPE }
+  const request: ExtractPageTextRequest = {
+    type: EXTRACT_PAGE_TEXT_MESSAGE_TYPE,
+    expectedUrl,
+  }
   const response: unknown = await browser.tabs.sendMessage(tabId, request)
   const parsed = extractPageTextResponseSchema.parse(response)
   if (!parsed.ok) {
@@ -24,9 +30,12 @@ export async function extractPageText(tabId: number): Promise<string | undefined
 }
 
 /** Try optional page-text extraction without blocking the rest of the capture. */
-export async function tryExtractPageText(tabId: number): Promise<string | undefined> {
+export async function tryExtractPageText(
+  tabId: number,
+  expectedUrl: string,
+): Promise<string | undefined> {
   try {
-    return await extractPageText(tabId)
+    return await extractPageText(tabId, expectedUrl)
   } catch (cause) {
     console.warn('capture page text could not be extracted:', cause)
     return undefined

--- a/apps/extension/entrypoints/popup/use-captured-page.ts
+++ b/apps/extension/entrypoints/popup/use-captured-page.ts
@@ -13,7 +13,7 @@ import { isCapturableUrl, type CapturedPage } from '@/lib/capture-message'
 export type CapturedPageState =
   | { status: 'loading' }
   | { status: 'uncapturable' }
-  | { status: 'ready'; page: CapturedPage }
+  | { status: 'ready'; page: CapturedPage; tabId: number }
 
 const SCREENSHOT_QUALITY = 85
 
@@ -48,6 +48,7 @@ async function snapshotActiveTab(): Promise<CapturedPageState> {
   return {
     status: 'ready',
     page: { url: tab.url, title: tab.title ?? '', screenshotDataUrl, selection },
+    tabId: tab.id,
   }
 }
 

--- a/apps/extension/lib/capture-message.test.ts
+++ b/apps/extension/lib/capture-message.test.ts
@@ -29,11 +29,13 @@ describe('buildWireMessage', () => {
       url: 'https://example.com/article',
       title: '  An article  ',
       selection: 'quoted',
+      contentText: 'First paragraph.\n\nSecond paragraph.',
       note: 'check later',
       screenshotDataUrl: 'data:image/jpeg;base64,aGVsbG8=',
     })
     expect(captureWireMessageSchema.parse(message)).toEqual(message)
     expect(message.envelope.title).toBe('An article')
+    expect(message.envelope.contentText).toBe('First paragraph.\n\nSecond paragraph.')
     expect(message.envelope.capturedAt).toBe('2026-06-12T15:30:22.845Z')
     expect(message.screenshotBase64).toBe('aGVsbG8=')
   })
@@ -45,9 +47,11 @@ describe('buildWireMessage', () => {
       url: 'https://example.com',
       title: 'Example',
       selection: '   ',
+      contentText: '',
       note: '',
     })
     expect(message.envelope.selection).toBeUndefined()
+    expect(message.envelope.contentText).toBeUndefined()
     expect(message.envelope.note).toBeUndefined()
     expect(message.screenshotBase64).toBeUndefined()
   })

--- a/apps/extension/lib/capture-message.ts
+++ b/apps/extension/lib/capture-message.ts
@@ -14,6 +14,8 @@ export interface CapturedPage {
   screenshotDataUrl?: string
   /** The page's current selection, when the page allowed the script. */
   selection?: string
+  /** Defuddle-extracted page paragraphs, when the user asks to include them. */
+  contentText?: string
   /** The user's comment from the popup. */
   note?: string
 }
@@ -49,6 +51,7 @@ export function buildWireMessage(input: BuildWireMessageInput): CaptureWireMessa
       url: input.url,
       title: input.title.trim(),
       selection: presence(input.selection),
+      contentText: presence(input.contentText),
       note: presence(input.note),
       capturedAt: input.capturedAt.toISOString(),
       source: 'extension',

--- a/apps/extension/lib/page-text.test.ts
+++ b/apps/extension/lib/page-text.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { formatParagraphs, normalizeParagraphText } from './page-text'
+import { formatParagraphs, normalizeParagraphText, samePageUrl } from './page-text'
 
 describe('normalizeParagraphText', () => {
   it('collapses inline whitespace inside one paragraph', () => {
@@ -14,5 +14,17 @@ describe('formatParagraphs', () => {
     expect(formatParagraphs([' First paragraph. ', ' ', 'Second\nparagraph.'])).toBe(
       'First paragraph.\n\nSecond paragraph.',
     )
+  })
+})
+
+describe('samePageUrl', () => {
+  it('accepts normalized-equivalent page URLs', () => {
+    expect(samePageUrl('https://example.com:443/article#intro', 'https://example.com/article')).toBe(
+      true,
+    )
+  })
+
+  it('rejects different pages', () => {
+    expect(samePageUrl('https://example.com/article', 'https://example.com/other')).toBe(false)
   })
 })

--- a/apps/extension/lib/page-text.test.ts
+++ b/apps/extension/lib/page-text.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { formatParagraphs, normalizeParagraphText } from './page-text'
+
+describe('normalizeParagraphText', () => {
+  it('collapses inline whitespace inside one paragraph', () => {
+    expect(normalizeParagraphText('  First\n paragraph\t with   spaces.  ')).toBe(
+      'First paragraph with spaces.',
+    )
+  })
+})
+
+describe('formatParagraphs', () => {
+  it('keeps paragraph breaks while dropping empty paragraphs', () => {
+    expect(formatParagraphs([' First paragraph. ', ' ', 'Second\nparagraph.'])).toBe(
+      'First paragraph.\n\nSecond paragraph.',
+    )
+  })
+})

--- a/apps/extension/lib/page-text.ts
+++ b/apps/extension/lib/page-text.ts
@@ -17,6 +17,23 @@ export const extractPageTextResponseSchema = z.discriminatedUnion('ok', [
 export type ExtractPageTextRequest = z.infer<typeof extractPageTextRequestSchema>
 export type ExtractPageTextResponse = z.infer<typeof extractPageTextResponseSchema>
 
+function comparablePageUrl(value: string): string | null {
+  try {
+    const url = new URL(value)
+    url.hash = ''
+    return url.href
+  } catch {
+    return null
+  }
+}
+
+/** True when two page URLs identify the same document for capture purposes. */
+export function samePageUrl(first: string, second: string): boolean {
+  const firstUrl = comparablePageUrl(first)
+  const secondUrl = comparablePageUrl(second)
+  return firstUrl !== null && secondUrl !== null ? firstUrl === secondUrl : first === second
+}
+
 /** Collapse intra-paragraph whitespace while preserving paragraph breaks. */
 export function normalizeParagraphText(text: string): string {
   return text.replace(/\s+/g, ' ').trim()

--- a/apps/extension/lib/page-text.ts
+++ b/apps/extension/lib/page-text.ts
@@ -5,6 +5,7 @@ export const EXTRACT_PAGE_TEXT_MESSAGE_TYPE = 'reflect:capture-page-text'
 /** Popup request sent to the injected content script. */
 export const extractPageTextRequestSchema = z.object({
   type: z.literal(EXTRACT_PAGE_TEXT_MESSAGE_TYPE),
+  expectedUrl: z.string().url(),
 })
 
 /** Content-script reply with normalized paragraph text, or a typed failure. */

--- a/apps/extension/lib/page-text.ts
+++ b/apps/extension/lib/page-text.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+
+export const EXTRACT_PAGE_TEXT_MESSAGE_TYPE = 'reflect:capture-page-text'
+
+/** Popup request sent to the injected content script. */
+export const extractPageTextRequestSchema = z.object({
+  type: z.literal(EXTRACT_PAGE_TEXT_MESSAGE_TYPE),
+})
+
+/** Content-script reply with normalized paragraph text, or a typed failure. */
+export const extractPageTextResponseSchema = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true), contentText: z.string() }),
+  z.object({ ok: z.literal(false), message: z.string() }),
+])
+
+export type ExtractPageTextRequest = z.infer<typeof extractPageTextRequestSchema>
+export type ExtractPageTextResponse = z.infer<typeof extractPageTextResponseSchema>
+
+/** Collapse intra-paragraph whitespace while preserving paragraph breaks. */
+export function normalizeParagraphText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
+/** Join non-empty paragraphs into plain text suitable for markdown capture. */
+export function formatParagraphs(paragraphs: readonly string[]): string {
+  return paragraphs.map(normalizeParagraphText).filter(Boolean).join('\n\n')
+}

--- a/apps/extension/lib/popup-preferences.test.ts
+++ b/apps/extension/lib/popup-preferences.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  readIncludePageTextPreference,
+  writeIncludePageTextPreference,
+} from './popup-preferences'
+
+const store = new Map<string, unknown>()
+
+vi.mock('wxt/browser', () => ({
+  browser: {
+    storage: {
+      local: {
+        get: (key: string) => Promise.resolve(store.has(key) ? { [key]: store.get(key) } : {}),
+        set: (items: Record<string, unknown>) => {
+          for (const [key, value] of Object.entries(items)) {
+            store.set(key, value)
+          }
+          return Promise.resolve()
+        },
+      },
+    },
+  },
+}))
+
+const INCLUDE_PAGE_TEXT_KEY = 'preference:includePageText'
+
+beforeEach(() => {
+  store.clear()
+})
+
+describe('readIncludePageTextPreference', () => {
+  it('defaults to false when the preference has not been saved', async () => {
+    await expect(readIncludePageTextPreference()).resolves.toBe(false)
+  })
+
+  it('reads a saved true value', async () => {
+    store.set(INCLUDE_PAGE_TEXT_KEY, true)
+
+    await expect(readIncludePageTextPreference()).resolves.toBe(true)
+  })
+
+  it('falls back to false for corrupt stored values', async () => {
+    store.set(INCLUDE_PAGE_TEXT_KEY, 'yes please')
+
+    await expect(readIncludePageTextPreference()).resolves.toBe(false)
+  })
+})
+
+describe('writeIncludePageTextPreference', () => {
+  it('persists the latest checkbox value', async () => {
+    await writeIncludePageTextPreference(true)
+    expect(store.get(INCLUDE_PAGE_TEXT_KEY)).toBe(true)
+
+    await writeIncludePageTextPreference(false)
+    expect(store.get(INCLUDE_PAGE_TEXT_KEY)).toBe(false)
+  })
+})

--- a/apps/extension/lib/popup-preferences.ts
+++ b/apps/extension/lib/popup-preferences.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+import { browser } from 'wxt/browser'
+
+const INCLUDE_PAGE_TEXT_KEY = 'preference:includePageText'
+
+const popupPreferencesSchema = z.object({
+  [INCLUDE_PAGE_TEXT_KEY]: z.boolean().optional(),
+})
+
+/** Read the persisted popup choice for full-page text capture. */
+export async function readIncludePageTextPreference(): Promise<boolean> {
+  const stored = await browser.storage.local.get(INCLUDE_PAGE_TEXT_KEY)
+  const parsed = popupPreferencesSchema.safeParse(stored)
+  return parsed.success ? parsed.data[INCLUDE_PAGE_TEXT_KEY] ?? false : false
+}
+
+/** Persist the popup choice for full-page text capture. */
+export async function writeIncludePageTextPreference(includePageText: boolean): Promise<void> {
+  await browser.storage.local.set({ [INCLUDE_PAGE_TEXT_KEY]: includePageText })
+}

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@reflect/core": "workspace:*",
     "@reflect/design-system": "workspace:*",
+    "defuddle": "^0.18.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "zod": "^3.23.0"

--- a/apps/native-host/src/envelope.rs
+++ b/apps/native-host/src/envelope.rs
@@ -21,6 +21,8 @@ pub struct Envelope {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub selection: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub screenshot_ref: Option<String>,

--- a/packages/core/src/actions/capture-envelope.fixtures.json
+++ b/packages/core/src/actions/capture-envelope.fixtures.json
@@ -15,7 +15,7 @@
       }
     },
     {
-      "name": "full with selection, note, and screenshot",
+      "name": "full with selection, page text, note, and screenshot",
       "message": {
         "envelope": {
           "version": 1,
@@ -23,6 +23,7 @@
           "url": "http://localhost:3000/page",
           "title": "Local page",
           "selection": "quoted text",
+          "contentText": "First paragraph.\n\nSecond paragraph.",
           "note": "check later",
           "capturedAt": "2026-06-12T15:30:22.845Z",
           "source": "extension"

--- a/packages/core/src/actions/capture-envelope.test.ts
+++ b/packages/core/src/actions/capture-envelope.test.ts
@@ -19,10 +19,11 @@ describe('captureEnvelopeSchema', () => {
     expect(captureEnvelopeSchema.parse(VALID)).toEqual(VALID)
   })
 
-  it('accepts the full shape with selection, note, and screenshot', () => {
+  it('accepts the full shape with selection, page text, note, and screenshot', () => {
     const full = {
       ...VALID,
       selection: 'quoted text',
+      contentText: 'First paragraph.\n\nSecond paragraph.',
       note: 'check this later',
       screenshotRef: `${VALID.id}.jpg`,
     }

--- a/packages/core/src/actions/capture-envelope.ts
+++ b/packages/core/src/actions/capture-envelope.ts
@@ -37,6 +37,8 @@ export const captureEnvelopeSchema = z.object({
   title: z.string(),
   /** Text the user had selected, verbatim. */
   selection: z.string().optional(),
+  /** Plain text paragraphs extracted from the captured page. */
+  contentText: z.string().optional(),
   /** A comment the user typed into the capture UI. */
   note: z.string().optional(),
   /**

--- a/packages/core/src/actions/capture.test.ts
+++ b/packages/core/src/actions/capture.test.ts
@@ -239,6 +239,18 @@ describe('drainCaptureInbox', () => {
     expect(spool.size).toBe(0)
   })
 
+  it('writes extracted page text into the capture note', async () => {
+    addSpool(envelope({ contentText: 'First paragraph.\n\nSecond paragraph.' }), {
+      screenshot: false,
+    })
+
+    const outcome = await drain()
+
+    expect(outcome).toEqual({ pending: 1, drained: 1, deduped: 0, invalid: 0, stopped: null })
+    const note = files.get(IDENTITY.notePath)
+    expect(note).toContain('## Page Text\n\nFirst paragraph.\n\nSecond paragraph.')
+  })
+
   it('removes the spool only after the note and daily entry are written', async () => {
     addSpool(envelope())
     await drain()

--- a/packages/core/src/actions/capture.ts
+++ b/packages/core/src/actions/capture.ts
@@ -204,6 +204,10 @@ function captureNoteBody(
         .join('\n'),
     )
   }
+  const contentText = envelope.contentText?.trim()
+  if (contentText) {
+    parts.push(`## Page Text\n\n${contentText}`)
+  }
   if (hasScreenshot) {
     parts.push(`![${title}](${identity.assetPath})`)
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       '@reflect/design-system':
         specifier: workspace:*
         version: link:../../design-system
+      defuddle:
+        specifier: ^0.18.1
+        version: 0.18.1
       react:
         specifier: ^19.1.0
         version: 19.2.7
@@ -845,6 +848,9 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  '@mixmark-io/domino@2.2.0':
+    resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -2342,6 +2348,10 @@ packages:
   '@wxt-dev/storage@1.2.8':
     resolution: {integrity: sha512-GWCFKgF5+d7eslOxUDFC70ypA9njupmJb1nQM8uZoX0J3sWT2BO5xJLzb1sYahWAfID9p2BMtnUBN1lkWxPsbQ==}
 
+  '@xmldom/xmldom@0.9.10':
+    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+    engines: {node: '>=14.6'}
+
   '@zag-js/dismissable@1.41.2':
     resolution: {integrity: sha512-hO/tFhRZ7S+LOOljGOQJIubbc3MXg41+iWR1yUXKl76cAenbxaCit1LZmUCwQPvRN0GndK6bDQo5ETjHZz/k7A==}
 
@@ -2668,6 +2678,10 @@ packages:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
 
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
@@ -2852,6 +2866,10 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  defuddle@0.18.1:
+    resolution: {integrity: sha512-AvFPFOsoDjt5xUOA1QxzafSSzJ5dqEIC63yO72tHYtSjj1DYY/XM0XTPUCsHkm5A2f1X9ulBvoSVFJrd4s2ckA==}
+    hasBin: true
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -3792,6 +3810,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mathml-to-latex@1.8.0:
+    resolution: {integrity: sha512-gQ0uK3zqB8HwlfaXJkEL5rgaZNbKUiBMmBP/B/W+b+t6KcseLSuYb1b0BjLgS9ZiQa24ePkqTX8/6FaQuDL7wQ==}
 
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
@@ -4756,6 +4777,10 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  temml@0.13.3:
+    resolution: {integrity: sha512-GLNEdf5qBWux3adbOxFus4jlds8nCdEIkkKq99m/4GGTfqnsjlVlK/i371Ux7yYSg/WNmOyAkNT/GJlZoJ0v+w==}
+    engines: {node: '>=18.13.0'}
+
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
@@ -4837,6 +4862,10 @@ packages:
   turbo@2.9.16:
     resolution: {integrity: sha512-NqgRQy6j6dPYcdSdv0q1g9QsZg7SWg87RERM8otw/1AtKU2yTFVClOM7cbwKzOonZr/Ek1blTBucw64L9H0Bwg==}
     hasBin: true
+
+  turndown@7.2.4:
+    resolution: {integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==}
+    engines: {node: '>=18', npm: '>=9'}
 
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
@@ -5865,6 +5894,9 @@ snapshots:
       - sugar-high
       - y-prosemirror
       - yjs
+
+  '@mixmark-io/domino@2.2.0':
+    optional: true
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
@@ -7351,6 +7383,9 @@ snapshots:
       async-mutex: 0.5.0
       dequal: 2.0.3
 
+  '@xmldom/xmldom@0.9.10':
+    optional: true
+
   '@zag-js/dismissable@1.41.2':
     dependencies:
       '@zag-js/dom-query': 1.41.2
@@ -7679,6 +7714,8 @@ snapshots:
 
   commander@11.1.0: {}
 
+  commander@12.1.0: {}
+
   commander@14.0.3: {}
 
   commander@2.9.0:
@@ -7820,6 +7857,17 @@ snapshots:
   define-lazy-prop@3.0.0: {}
 
   defu@6.1.7: {}
+
+  defuddle@0.18.1:
+    dependencies:
+      commander: 12.1.0
+    optionalDependencies:
+      linkedom: 0.18.12
+      mathml-to-latex: 1.8.0
+      temml: 0.13.3
+      turndown: 7.2.4
+    transitivePeerDependencies:
+      - canvas
 
   depd@2.0.0: {}
 
@@ -8683,6 +8731,11 @@ snapshots:
   marky@1.3.0: {}
 
   math-intrinsics@1.1.0: {}
+
+  mathml-to-latex@1.8.0:
+    dependencies:
+      '@xmldom/xmldom': 0.9.10
+    optional: true
 
   mdast-util-to-hast@13.2.1:
     dependencies:
@@ -9814,6 +9867,9 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  temml@0.13.3:
+    optional: true
+
   thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
@@ -9888,6 +9944,11 @@ snapshots:
       '@turbo/linux-arm64': 2.9.16
       '@turbo/windows-64': 2.9.16
       '@turbo/windows-arm64': 2.9.16
+
+  turndown@7.2.4:
+    dependencies:
+      '@mixmark-io/domino': 2.2.0
+    optional: true
 
   tw-animate-css@1.4.0: {}
 


### PR DESCRIPTION
## Summary
- Add an opt-in popup checkbox to capture normalized page text from the active tab
- Inject a content script that extracts article-style paragraphs with `defuddle`, then falls back to visible page text
- Thread `contentText` through the wire envelope and persist it into the capture note as a `## Page Text` section
- Update schemas, fixtures, and tests to cover the new field end to end

## Testing
- Added unit tests for page-text normalization and capture-envelope parsing
- Added a capture action test covering note generation with extracted page text
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the cross-platform capture wire contract and runs DOM extraction in the active tab; failures are optional but successful captures can store large page text in notes.
> 
> **Overview**
> Adds **optional full-page text** to browser captures via a persisted **Capture page text** checkbox in the extension popup.
> 
> When enabled, save injects a runtime content script that extracts normalized paragraphs with **Defuddle** (visible-DOM fallback, URL guard), then attaches the result as optional **`contentText`** on the wire envelope. Extraction failures degrade gracefully so URL, screenshot, and selection still queue.
> 
> **`contentText`** is threaded through the shared capture envelope (Zod + native host serde + fixtures) and written into the drained capture note as a **`## Page Text`** section. Unit tests cover normalization, preferences, extraction, and note generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fd3d6f3b2ca9bde5063e26e93371570180fee45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->