### PR TITLE
Tone down trash note action color

### DIFF
--- a/apps/desktop/src/components/context-sidebar/note-trash-action.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-trash-action.tsx
@@ -63,12 +63,12 @@ export function NoteTrashAction({ path }: NoteTrashActionProps): ReactElement | 
       <button
         type="button"
         onClick={() => setConfirmingTrash(true)}
-        className="group relative flex w-full items-center space-x-2 rounded-lg px-3 py-2 text-start transition-colors duration-100 hover:bg-destructive/10"
+        className="group relative flex w-full items-center space-x-2 rounded-lg px-3 py-2 text-start transition-colors duration-100 hover:bg-surface-hover"
       >
-        <span className="flex h-5 w-5 flex-none items-center justify-center text-destructive/80 transition-colors duration-100 group-hover:text-destructive">
+        <span className="flex h-5 w-5 flex-none items-center justify-center text-text-muted transition-colors duration-100 group-hover:text-destructive">
           <Trash2 size={14} aria-hidden />
         </span>
-        <span className="min-w-0 flex-1 truncate text-xs font-medium text-destructive">
+        <span className="min-w-0 flex-1 truncate text-xs font-medium transition-colors duration-100 group-hover:text-destructive">
           Trash note
         </span>
       </button>


### PR DESCRIPTION
## Summary
- keep the sidebar Trash note action neutral at rest
- apply destructive text color to the icon and label only on hover

## Testing
- pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS class changes only on a sidebar button; no behavior or data-path changes.
> 
> **Overview**
> The context sidebar **Trash note** control is **neutral by default** instead of always looking destructive.
> 
> Hover now uses the standard `surface-hover` background, with **muted** icon/label at rest and **destructive** color applied to the icon and label **only on hover**. The confirmation dialog and destructive confirm button are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68fec2ee284891787f9c2f1f9cfeaf49c095d6bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->