### PR TITLE
Clarify private note tooltip

### DIFF
--- a/apps/desktop/src/components/context-sidebar/note-actions-section.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-actions-section.tsx
@@ -64,7 +64,7 @@ export function NoteActionsSection({
           deactivate: 'Unlocking note',
         }}
         keybinding={PRIVATE_KEYBINDING}
-        tooltip="Private notes are never sent to AI or any other external service"
+        tooltip="Locks this note out of AI. Backup and sync still include it."
       />
       <NoteGistAction path={path} keybinding={GIST_KEYBINDING} />
       {showTrash ? <NoteTrashAction path={path} /> : null}


### PR DESCRIPTION
## Summary
- Clarify that locking a note keeps it out of AI while backup and sync still include it

## Testing
- pnpm check
- pnpm --filter @reflect/desktop test --run src/components/context-sidebar/note-actions-section.test.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only UI change with no logic or data-handling impact.
> 
> **Overview**
> Updates the **Lock note** action tooltip in the note context sidebar so it matches actual behavior: locking excludes the note from AI, while **backup and sync still include it**.
> 
> Replaces the previous copy that implied private notes are never sent to any external service.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 988623a5db2c30b903d384ba04f28d374a9dfceb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->