### PR TITLE
Use full page text in capture enrichment

### DIFF
--- a/packages/core/src/actions/capture.test.ts
+++ b/packages/core/src/actions/capture.test.ts
@@ -250,7 +250,9 @@ describe('drainCaptureInbox', () => {
 
     expect(outcome).toEqual({ pending: 1, drained: 1, deduped: 0, invalid: 0, stopped: null })
     const note = files.get(IDENTITY.notePath)
-    expect(note).toContain('## Page Text\n\nFirst paragraph.\n\nSecond paragraph.')
+    expect(note).toContain(
+      '## Page Text\n\n<!-- reflect-capture-page-text:start -->\nFirst paragraph.\n\nSecond paragraph.\n<!-- reflect-capture-page-text:end -->',
+    )
   })
 
   it('removes the spool only after the note and daily entry are written', async () => {
@@ -477,7 +479,7 @@ describe('reconcileCaptureEnrichment', () => {
       'This is an article heading, not the capture image section.',
       'Second paragraph.',
     ].join('\n\n')
-    await drainOne({ selection: 'quoted text', contentText })
+    await drainOne({ selection: 'quoted text\n\n## Page Text\n\nnot actual page text', contentText })
     scrapeMock.mockResolvedValue({
       title: 'An article',
       description: 'A scraped description.',

--- a/packages/core/src/actions/capture.test.ts
+++ b/packages/core/src/actions/capture.test.ts
@@ -479,7 +479,11 @@ describe('reconcileCaptureEnrichment', () => {
       'This is an article heading, not the capture image section.',
       'Second paragraph.',
     ].join('\n\n')
-    await drainOne({ selection: 'quoted text\n\n## Page Text\n\nnot actual page text', contentText })
+    await drainOne({
+      selection:
+        'quoted text\n\n<!-- reflect-capture-page-text:start -->\n\n## Page Text\n\nnot actual page text',
+      contentText,
+    })
     scrapeMock.mockResolvedValue({
       title: 'An article',
       description: 'A scraped description.',

--- a/packages/core/src/actions/capture.test.ts
+++ b/packages/core/src/actions/capture.test.ts
@@ -469,7 +469,13 @@ describe('reconcileCaptureEnrichment', () => {
   }
 
   it('patches the AI description into the metadata bullets with provenance', async () => {
-    await drainOne({ selection: 'quoted text', contentText: 'First paragraph.\n\nSecond paragraph.' })
+    const contentText = [
+      'First paragraph.',
+      '- Description: A line from the captured article.',
+      '## Article heading',
+      'Second paragraph.',
+    ].join('\n\n')
+    await drainOne({ selection: 'quoted text', contentText })
     scrapeMock.mockResolvedValue({
       title: 'An article',
       description: 'A scraped description.',
@@ -482,6 +488,8 @@ describe('reconcileCaptureEnrichment', () => {
     const note = files.get(IDENTITY.notePath) ?? ''
     expect(note).toContain('- Type: #link\n- Description: An AI description of the page.\n\n## Selection')
     expect(note).not.toContain('A scraped description.')
+    expect(note).toContain('- Description: A line from the captured article.')
+    expect(note).toContain('## Article heading')
     expect(note).toContain('captureStatus: done')
     expect(note).toContain('captureProvider: openai')
     expect(note).toContain('captureModel: gpt-5.5')
@@ -490,7 +498,7 @@ describe('reconcileCaptureEnrichment', () => {
         url: URL,
         title: 'An article',
         metaDescription: 'A scraped description.',
-        contentText: 'First paragraph.\n\nSecond paragraph.',
+        contentText,
         screenshotBase64: btoa('jpeg-bytes'),
       }),
     )

--- a/packages/core/src/actions/capture.test.ts
+++ b/packages/core/src/actions/capture.test.ts
@@ -473,6 +473,8 @@ describe('reconcileCaptureEnrichment', () => {
       'First paragraph.',
       '- Description: A line from the captured article.',
       '## Article heading',
+      '## Screenshot',
+      'This is an article heading, not the capture image section.',
       'Second paragraph.',
     ].join('\n\n')
     await drainOne({ selection: 'quoted text', contentText })
@@ -490,6 +492,7 @@ describe('reconcileCaptureEnrichment', () => {
     expect(note).not.toContain('A scraped description.')
     expect(note).toContain('- Description: A line from the captured article.')
     expect(note).toContain('## Article heading')
+    expect(note).toContain('This is an article heading, not the capture image section.')
     expect(note).toContain('captureStatus: done')
     expect(note).toContain('captureProvider: openai')
     expect(note).toContain('captureModel: gpt-5.5')

--- a/packages/core/src/actions/capture.test.ts
+++ b/packages/core/src/actions/capture.test.ts
@@ -228,14 +228,16 @@ describe('drainCaptureInbox', () => {
     expect(note).toContain('captureStatus: pending')
     expect(note).toContain('captureScreenshot: assets/capture-2026-06-11-153022-845-7c9e.jpg')
     expect(note).toContain('# An article')
-    expect(note).toContain('[example.com](https://example.com/article)')
-    expect(note).toContain('check later')
-    expect(note).toContain('> quoted text')
-    expect(note).toContain(`![An article](${IDENTITY.assetPath})`)
+    expect(note).toContain('- URL: https://example.com/article')
+    expect(note).toContain('- Type: #link')
+    expect(note).not.toContain('Highlights')
+    expect(note).toContain('## Note\n\ncheck later')
+    expect(note).toContain('## Selection\n\nquoted text')
+    expect(note).toContain(`## Screenshot\n\n![An article](${IDENTITY.assetPath})`)
 
     const daily = files.get(DAILY)
     expect(daily).toContain('## Links')
-    expect(daily).toContain('[[capture-2026-06-11-153022-845-7c9e|An article]]')
+    expect(daily).toContain('- [[capture-2026-06-11-153022-845-7c9e|An article]]')
     expect(spool.size).toBe(0)
   })
 
@@ -291,7 +293,7 @@ describe('drainCaptureInbox', () => {
     const daily = files.get(DAILY) ?? ''
     expect(daily.match(/## Links/g)).toHaveLength(1)
     expect(daily).toContain('[[capture-2026-06-11-090000-000-0000|Old]]')
-    expect(daily).toContain('[[capture-2026-06-11-153022-845-7c9e|An article]]')
+    expect(daily).toContain('- [[capture-2026-06-11-153022-845-7c9e|An article]]')
   })
 
   it('saves a private-day capture raw, marked skipped', async () => {
@@ -302,7 +304,7 @@ describe('drainCaptureInbox', () => {
 
     expect(outcome.drained).toBe(1)
     expect(files.get(IDENTITY.notePath)).toContain('captureStatus: skipped')
-    expect(files.get(DAILY)).toContain('[[capture-2026-06-11-153022-845-7c9e|An article]]')
+    expect(files.get(DAILY)).toContain('- [[capture-2026-06-11-153022-845-7c9e|An article]]')
   })
 
   it('refreshes a same-day same-URL same-selection re-capture in place', async () => {
@@ -466,8 +468,8 @@ describe('reconcileCaptureEnrichment', () => {
     writeNoteMock.mockClear()
   }
 
-  it('patches the AI description under the link line with provenance', async () => {
-    await drainOne({ selection: 'quoted text' })
+  it('patches the AI description into the metadata bullets with provenance', async () => {
+    await drainOne({ selection: 'quoted text', contentText: 'First paragraph.\n\nSecond paragraph.' })
     scrapeMock.mockResolvedValue({
       title: 'An article',
       description: 'A scraped description.',
@@ -478,9 +480,8 @@ describe('reconcileCaptureEnrichment', () => {
 
     expect(outcome).toEqual({ pending: 1, enriched: 1, skipped: 0, stopped: null })
     const note = files.get(IDENTITY.notePath) ?? ''
-    expect(note).toContain(
-      '[example.com](https://example.com/article)\n\nAn AI description of the page.\n\n> quoted text',
-    )
+    expect(note).toContain('- Type: #link\n- Description: An AI description of the page.\n\n## Selection')
+    expect(note).not.toContain('A scraped description.')
     expect(note).toContain('captureStatus: done')
     expect(note).toContain('captureProvider: openai')
     expect(note).toContain('captureModel: gpt-5.5')
@@ -489,6 +490,7 @@ describe('reconcileCaptureEnrichment', () => {
         url: URL,
         title: 'An article',
         metaDescription: 'A scraped description.',
+        contentText: 'First paragraph.\n\nSecond paragraph.',
         screenshotBase64: btoa('jpeg-bytes'),
       }),
     )
@@ -508,7 +510,7 @@ describe('reconcileCaptureEnrichment', () => {
 
     expect(outcome.enriched).toBe(1)
     const note = files.get(IDENTITY.notePath) ?? ''
-    expect(note).toContain('A scraped description.')
+    expect(note).toContain('- Description: A scraped description.')
     expect(note).toContain('captureStatus: done')
     expect(note).not.toContain('captureProvider')
     expect(describeMock).not.toHaveBeenCalled()
@@ -588,7 +590,7 @@ describe('reconcileCaptureEnrichment', () => {
     expect(describeMock).toHaveBeenCalledWith(
       expect.objectContaining({ metaDescription: undefined }),
     )
-    expect(files.get(IDENTITY.notePath)).toContain('An AI description of the page.')
+    expect(files.get(IDENTITY.notePath)).toContain('- Description: An AI description of the page.')
   })
 
   it('a provider refusal falls back to the scraped description, done without AI provenance', async () => {
@@ -604,9 +606,21 @@ describe('reconcileCaptureEnrichment', () => {
 
     expect(outcome.enriched).toBe(1)
     const note = files.get(IDENTITY.notePath) ?? ''
-    expect(note).toContain('A scraped description.')
+    expect(note).toContain('- Description: A scraped description.')
     expect(note).toContain('captureStatus: done')
     expect(note).not.toContain('captureProvider')
+  })
+
+  it('omits the description bullet when no description source exists', async () => {
+    await drainOne()
+    scrapeMock.mockResolvedValue({ title: 'An article', description: null, siteName: null })
+
+    const outcome = await reconcile({ providers: NO_PROVIDERS })
+
+    expect(outcome.enriched).toBe(1)
+    const note = files.get(IDENTITY.notePath) ?? ''
+    expect(note).not.toContain('- Description:')
+    expect(note).toContain('captureStatus: done')
   })
 
   it('an auth failure from the provider stops the pass', async () => {

--- a/packages/core/src/actions/capture.test.ts
+++ b/packages/core/src/actions/capture.test.ts
@@ -624,6 +624,21 @@ describe('reconcileCaptureEnrichment', () => {
     expect(note).not.toContain('captureProvider')
   })
 
+  it('a provider refusal without scraped description does not stamp AI provenance', async () => {
+    await drainOne()
+    scrapeMock.mockResolvedValue({ title: 'An article', description: null, siteName: null })
+    describeMock.mockRejectedValue(new DescriptionRejectedError('image too large'))
+
+    const outcome = await reconcile()
+
+    expect(outcome.enriched).toBe(1)
+    const note = files.get(IDENTITY.notePath) ?? ''
+    expect(note).not.toContain('- Description:')
+    expect(note).toContain('captureStatus: done')
+    expect(note).not.toContain('captureProvider')
+    expect(note).not.toContain('captureModel')
+  })
+
   it('omits the description bullet when no description source exists', async () => {
     await drainOne()
     scrapeMock.mockResolvedValue({ title: 'An article', description: null, siteName: null })

--- a/packages/core/src/actions/capture.ts
+++ b/packages/core/src/actions/capture.ts
@@ -213,26 +213,29 @@ function captureNoteBody(
   return `${parts.join('\n\n')}\n`
 }
 
-function h2SectionBody(body: string, heading: string): string | undefined {
-  const marker = new RegExp(`^## ${heading}[ \\t]*$`, 'mu')
-  const match = marker.exec(body)
-  if (match === null) {
+function capturePageTextFromBody(body: string): string | undefined {
+  const marker = /^## Page Text[ \t]*$/mu.exec(body)
+  if (marker === null) {
     return undefined
   }
-  const contentStart = body.indexOf('\n', match.index + match[0].length)
+  const contentStart = body.indexOf('\n', marker.index + marker[0].length)
   if (contentStart === -1) {
     return undefined
   }
   const rest = body.slice(contentStart + 1)
-  const nextHeading = rest.search(/^##\s+/mu)
-  const content = (nextHeading === -1 ? rest : rest.slice(0, nextHeading))
+  const screenshotSection = /^## Screenshot[ \t]*$/mu.exec(rest)
+  const content = (screenshotSection === null ? rest : rest.slice(0, screenshotSection.index))
     .replace(/\n+!\[[^\]\n]*\]\(assets\/capture-[^)]+\.jpg\)\s*$/u, '')
     .trim()
   return content === '' ? undefined : content
 }
 
-function capturePageTextFromBody(body: string): string | undefined {
-  return h2SectionBody(body, 'Page Text')
+function firstSectionStart(body: string): number {
+  const match = /^##\s+/mu.exec(body)
+  if (match === null) {
+    return body.length
+  }
+  return match.index
 }
 
 async function captureNoteSource(
@@ -588,10 +591,15 @@ function metadataValue(text: string): string {
  */
 function withDescription(body: string, description: string): string {
   const line = `- Description: ${metadataValue(description)}`
-  if (/^- Description: /mu.test(body)) {
-    return body.replace(/^- Description: .*$/mu, line)
+  const metadataEnd = firstSectionStart(body)
+  const metadata = body.slice(0, metadataEnd)
+  const existing = /^- Description: .*$/mu.exec(metadata)
+  if (existing !== null) {
+    const from = existing.index
+    const to = existing.index + existing[0].length
+    return `${metadata.slice(0, from)}${line}${metadata.slice(to)}${body.slice(metadataEnd)}`
   }
-  const typeLine = /^- Type: #link[ \t]*$/mu.exec(body)
+  const typeLine = /^- Type: #link[ \t]*$/mu.exec(metadata)
   if (typeLine === null) {
     return `${body.replace(/\s*$/, '')}\n\n${line}\n`
   }

--- a/packages/core/src/actions/capture.ts
+++ b/packages/core/src/actions/capture.ts
@@ -214,30 +214,35 @@ function captureNoteBody(
 }
 
 function capturePageTextFromBody(body: string): string | undefined {
-  const marker = /^## Page Text[ \t]*$/mu.exec(body)
-  if (marker === null) {
+  const marker = '\n## Page Text\n\n'
+  const markerAt = body.indexOf(marker)
+  if (markerAt === -1) {
     return undefined
   }
-  const contentStart = body.indexOf('\n', marker.index + marker[0].length)
-  if (contentStart === -1) {
-    return undefined
-  }
-  const rest = body.slice(contentStart + 1)
-  const content = rest
-    .replace(
-      /\n+## Screenshot[ \t]*\n+!\[[^\]\n]*\]\(assets\/capture-[^)]+\.jpg\)\s*$/u,
-      '',
-    )
-    .trim()
+  const rest = body.slice(markerAt + marker.length)
+  const screenshotMarker = '\n\n## Screenshot\n\n'
+  const screenshotAt = rest.lastIndexOf(screenshotMarker)
+  const candidateImage =
+    screenshotAt === -1 ? null : rest.slice(screenshotAt + screenshotMarker.length).trim()
+  const content =
+    candidateImage !== null &&
+    candidateImage.startsWith('![') &&
+    candidateImage.includes('](assets/capture-') &&
+    candidateImage.endsWith('.jpg)')
+      ? rest.slice(0, screenshotAt).trim()
+      : rest.trim()
   return content === '' ? undefined : content
 }
 
 function firstSectionStart(body: string): number {
-  const match = /^##\s+/mu.exec(body)
-  if (match === null) {
-    return body.length
+  let offset = 0
+  for (const line of body.split('\n')) {
+    if (line.startsWith('## ')) {
+      return offset
+    }
+    offset += line.length + 1
   }
-  return match.index
+  return body.length
 }
 
 async function captureNoteSource(
@@ -593,19 +598,20 @@ function metadataValue(text: string): string {
 function withDescription(body: string, description: string): string {
   const line = `- Description: ${metadataValue(description)}`
   const metadataEnd = firstSectionStart(body)
-  const metadata = body.slice(0, metadataEnd)
-  const existing = /^- Description: .*$/mu.exec(metadata)
-  if (existing !== null) {
-    const from = existing.index
-    const to = existing.index + existing[0].length
-    return `${metadata.slice(0, from)}${line}${metadata.slice(to)}${body.slice(metadataEnd)}`
+  const metadataLines = body.slice(0, metadataEnd).split('\n')
+  const descriptionLine = metadataLines.findIndex((candidate) =>
+    candidate.startsWith('- Description: '),
+  )
+  if (descriptionLine !== -1) {
+    metadataLines[descriptionLine] = line
+    return `${metadataLines.join('\n')}${body.slice(metadataEnd)}`
   }
-  const typeLine = /^- Type: #link[ \t]*$/mu.exec(metadata)
-  if (typeLine === null) {
+  const typeLine = metadataLines.findIndex((candidate) => candidate.trimEnd() === '- Type: #link')
+  if (typeLine === -1) {
     throw new Error('capture note is missing Type metadata')
   }
-  const insertAt = typeLine.index + typeLine[0].length
-  return `${body.slice(0, insertAt)}\n${line}${body.slice(insertAt)}`
+  metadataLines.splice(typeLine + 1, 0, line)
+  return `${metadataLines.join('\n')}${body.slice(metadataEnd)}`
 }
 
 /**

--- a/packages/core/src/actions/capture.ts
+++ b/packages/core/src/actions/capture.ts
@@ -763,11 +763,11 @@ export async function reconcileCaptureEnrichment(
         }
       }
 
-      const text =
-        description && metadataValue(description) !== '' ? description : pageMeta?.description ?? null
+      const usedAi =
+        description !== null && metadataValue(description) !== '' && config !== null
+      const text = usedAi ? description : pageMeta?.description ?? null
       const newBody = text !== null ? withDescription(split.body, text) : split.body
       const reassembled = source.slice(0, split.bodyOffset) + newBody
-      const usedAi = text === description && config !== null
       await writeNote(
         identity.notePath,
         upsertFrontmatter(reassembled, {

--- a/packages/core/src/actions/capture.ts
+++ b/packages/core/src/actions/capture.ts
@@ -28,14 +28,14 @@ import type { ReconcileStop } from './audio-memo'
 /**
  * Link capture (Plan 11), the second of the `actions/` capture family — the
  * same raw-first shape as audio memos: the spooled envelope is drained into a
- * durable **raw** save (a dedicated capture note + a `[[Links]]` entry in the
+ * durable **raw** save (a dedicated capture note + a bullet under `## Links` in the
  * capture-day daily note), and enrichment (meta scrape + BYOK AI description)
  * runs later, patching the note in place and retrying freely.
  *
  * 1. **Drain** ({@link drainCaptureInbox}): every `.json` envelope the
  *    native-messaging host spooled into `.reflect/inbox/` becomes
  *    `notes/capture-<stamp>.md` (provenance in frontmatter, screenshot
- *    promoted into `assets/`) plus a `[[capture-…|Title]]` line under the
+ *    promoted into `assets/`) plus a `- [[capture-…|Title]]` line under the
  *    daily note's `## Links` heading. Identity derives from `capturedAt`, so
  *    a crashed drain re-runs idempotently; the spool files are removed last.
  *    Re-capturing the same URL on the same day with the same selection
@@ -43,7 +43,8 @@ import type { ReconcileStop } from './audio-memo'
  * 2. **Enrich** ({@link reconcileCaptureEnrichment}): every capture note with
  *    `captureStatus: pending` gets the page's meta tags (scraped through the
  *    hard-capped Rust fetch) and — when a provider is configured — an AI
- *    description grounded in the screenshot, inserted under the link line.
+ *    description grounded in the screenshot, inserted as the `Description`
+ *    metadata bullet.
  *    A note the user edited (the body hash no longer matches) or made
  *    private is skipped, never clobbered.
  *
@@ -190,28 +191,48 @@ function captureNoteBody(
   hasScreenshot: boolean,
 ): string {
   const title = displayTitle(envelope)
-  const parts = [`# ${title}`, `[${urlHost(envelope.url)}](${envelope.url})`]
+  const parts = [
+    `# ${title}`,
+    [`- URL: ${envelope.url}`, '- Type: #link'].join('\n'),
+  ]
   const note = envelope.note?.trim()
   if (note) {
-    parts.push(note)
+    parts.push(`## Note\n\n${note}`)
   }
   const selection = envelope.selection?.trim()
   if (selection) {
-    parts.push(
-      selection
-        .split('\n')
-        .map((line) => `> ${line}`)
-        .join('\n'),
-    )
+    parts.push(`## Selection\n\n${selection}`)
   }
   const contentText = envelope.contentText?.trim()
   if (contentText) {
     parts.push(`## Page Text\n\n${contentText}`)
   }
   if (hasScreenshot) {
-    parts.push(`![${title}](${identity.assetPath})`)
+    parts.push(`## Screenshot\n\n![${title}](${identity.assetPath})`)
   }
   return `${parts.join('\n\n')}\n`
+}
+
+function h2SectionBody(body: string, heading: string): string | undefined {
+  const marker = new RegExp(`^## ${heading}[ \\t]*$`, 'mu')
+  const match = marker.exec(body)
+  if (match === null) {
+    return undefined
+  }
+  const contentStart = body.indexOf('\n', match.index + match[0].length)
+  if (contentStart === -1) {
+    return undefined
+  }
+  const rest = body.slice(contentStart + 1)
+  const nextHeading = rest.search(/^##\s+/mu)
+  const content = (nextHeading === -1 ? rest : rest.slice(0, nextHeading))
+    .replace(/\n+!\[[^\]\n]*\]\(assets\/capture-[^)]+\.jpg\)\s*$/u, '')
+    .trim()
+  return content === '' ? undefined : content
+}
+
+function capturePageTextFromBody(body: string): string | undefined {
+  return h2SectionBody(body, 'Page Text')
 }
 
 async function captureNoteSource(
@@ -434,7 +455,11 @@ export async function drainCaptureInbox(
       if (!dailySource.includes(`[[${identity.base}`)) {
         await writeNote(
           daily,
-          appendUnderHeading(dailySource, LINKS_HEADING, `[[${identity.base}|${displayTitle(envelope)}]]`),
+          appendUnderHeading(
+            dailySource,
+            LINKS_HEADING,
+            `- [[${identity.base}|${displayTitle(envelope)}]]`,
+          ),
           input.generation,
         )
       }
@@ -552,26 +577,33 @@ export interface ReconcileCaptureEnrichmentOutcome {
   stopped: ReconcileStop | null
 }
 
+function metadataValue(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
 /**
- * Insert the description paragraph directly under the capture's link line.
- * The body is hash-verified raw output of {@link captureNoteBody}, so the
- * anchor is always present; the append fallback only guards the impossible.
+ * Insert or replace the single visible generated-text surface for link
+ * captures. The raw body has a `- Type: #link` anchor; the fallback only
+ * covers older pending captures or hand-edited-but-hash-matching oddities.
  */
-function withDescription(body: string, url: string, description: string): string {
-  const anchor = body.indexOf(`](${url})`)
-  if (anchor === -1) {
-    return `${body.replace(/\s*$/, '')}\n\n${description}\n`
+function withDescription(body: string, description: string): string {
+  const line = `- Description: ${metadataValue(description)}`
+  if (/^- Description: /mu.test(body)) {
+    return body.replace(/^- Description: .*$/mu, line)
   }
-  const lineEnd = body.indexOf('\n', anchor)
-  const insertAt = lineEnd === -1 ? body.length : lineEnd
-  return `${body.slice(0, insertAt)}\n\n${description}${body.slice(insertAt)}`
+  const typeLine = /^- Type: #link[ \t]*$/mu.exec(body)
+  if (typeLine === null) {
+    return `${body.replace(/\s*$/, '')}\n\n${line}\n`
+  }
+  const insertAt = typeLine.index + typeLine[0].length
+  return `${body.slice(0, insertAt)}\n${line}${body.slice(insertAt)}`
 }
 
 /**
  * Enrich every pending capture: scrape the page's meta tags, generate the AI
  * description (when a provider is configured — the screenshot, title, URL,
- * and scraped meta ground it), insert the description under the link line,
- * and stamp provenance + `captureStatus: done`. Both privacy flags are
+ * and scraped meta ground it), insert the `Description` metadata bullet, and
+ * stamp provenance + `captureStatus: done`. Both privacy flags are
  * re-checked live before any outbound call; an edited body (hash mismatch)
  * is skipped, never clobbered. Transient failures (offline, auth) stop the
  * pass for the next trigger to retry; a provider refusing one capture falls
@@ -706,6 +738,7 @@ export async function reconcileCaptureEnrichment(
             url: meta.captureUrl,
             title: parseNote({ path: identity.notePath, source }).title,
             metaDescription: pageMeta?.description ?? undefined,
+            contentText: capturePageTextFromBody(split.body),
             screenshotBase64,
           })
         } catch (cause) {
@@ -719,10 +752,11 @@ export async function reconcileCaptureEnrichment(
         }
       }
 
-      const text = description ?? pageMeta?.description ?? null
-      const newBody = text !== null ? withDescription(split.body, meta.captureUrl, text) : split.body
+      const text =
+        description && metadataValue(description) !== '' ? description : pageMeta?.description ?? null
+      const newBody = text !== null ? withDescription(split.body, text) : split.body
       const reassembled = source.slice(0, split.bodyOffset) + newBody
-      const usedAi = description !== null && config !== null
+      const usedAi = text === description && config !== null
       await writeNote(
         identity.notePath,
         upsertFrontmatter(reassembled, {

--- a/packages/core/src/actions/capture.ts
+++ b/packages/core/src/actions/capture.ts
@@ -228,7 +228,6 @@ function capturePageTextFromBody(body: string): string | undefined {
       /\n+## Screenshot[ \t]*\n+!\[[^\]\n]*\]\(assets\/capture-[^)]+\.jpg\)\s*$/u,
       '',
     )
-    .replace(/\n+!\[[^\]\n]*\]\(assets\/capture-[^)]+\.jpg\)\s*$/u, '')
     .trim()
   return content === '' ? undefined : content
 }
@@ -589,8 +588,7 @@ function metadataValue(text: string): string {
 
 /**
  * Insert or replace the single visible generated-text surface for link
- * captures. The raw body has a `- Type: #link` anchor; the fallback only
- * covers older pending captures or hand-edited-but-hash-matching oddities.
+ * captures. The raw body has a `- Type: #link` anchor.
  */
 function withDescription(body: string, description: string): string {
   const line = `- Description: ${metadataValue(description)}`
@@ -604,7 +602,7 @@ function withDescription(body: string, description: string): string {
   }
   const typeLine = /^- Type: #link[ \t]*$/mu.exec(metadata)
   if (typeLine === null) {
-    return `${body.replace(/\s*$/, '')}\n\n${line}\n`
+    throw new Error('capture note is missing Type metadata')
   }
   const insertAt = typeLine.index + typeLine[0].length
   return `${body.slice(0, insertAt)}\n${line}${body.slice(insertAt)}`

--- a/packages/core/src/actions/capture.ts
+++ b/packages/core/src/actions/capture.ts
@@ -178,6 +178,9 @@ function urlHost(url: string): string {
   }
 }
 
+const PAGE_TEXT_START = '<!-- reflect-capture-page-text:start -->'
+const PAGE_TEXT_END = '<!-- reflect-capture-page-text:end -->'
+
 /** The capture's display title: the page title, else the URL's host. */
 function displayTitle(envelope: CaptureEnvelope): string {
   const title = wikiLinkSafe(envelope.title)
@@ -205,7 +208,7 @@ function captureNoteBody(
   }
   const contentText = envelope.contentText?.trim()
   if (contentText) {
-    parts.push(`## Page Text\n\n${contentText}`)
+    parts.push(`## Page Text\n\n${PAGE_TEXT_START}\n${contentText}\n${PAGE_TEXT_END}`)
   }
   if (hasScreenshot) {
     parts.push(`## Screenshot\n\n![${title}](${identity.assetPath})`)
@@ -214,23 +217,16 @@ function captureNoteBody(
 }
 
 function capturePageTextFromBody(body: string): string | undefined {
-  const marker = '\n## Page Text\n\n'
-  const markerAt = body.indexOf(marker)
-  if (markerAt === -1) {
+  const startAt = body.indexOf(PAGE_TEXT_START)
+  if (startAt === -1) {
     return undefined
   }
-  const rest = body.slice(markerAt + marker.length)
-  const screenshotMarker = '\n\n## Screenshot\n\n'
-  const screenshotAt = rest.lastIndexOf(screenshotMarker)
-  const candidateImage =
-    screenshotAt === -1 ? null : rest.slice(screenshotAt + screenshotMarker.length).trim()
-  const content =
-    candidateImage !== null &&
-    candidateImage.startsWith('![') &&
-    candidateImage.includes('](assets/capture-') &&
-    candidateImage.endsWith('.jpg)')
-      ? rest.slice(0, screenshotAt).trim()
-      : rest.trim()
+  const contentStart = startAt + PAGE_TEXT_START.length
+  const endAt = body.indexOf(PAGE_TEXT_END, contentStart)
+  if (endAt === -1) {
+    throw new Error('capture note is missing page text end marker')
+  }
+  const content = body.slice(contentStart, endAt).trim()
   return content === '' ? undefined : content
 }
 

--- a/packages/core/src/actions/capture.ts
+++ b/packages/core/src/actions/capture.ts
@@ -217,11 +217,12 @@ function captureNoteBody(
 }
 
 function capturePageTextFromBody(body: string): string | undefined {
-  const startAt = body.indexOf(PAGE_TEXT_START)
-  if (startAt === -1) {
+  const marker = `\n## Page Text\n\n${PAGE_TEXT_START}\n`
+  const markerAt = body.indexOf(marker)
+  if (markerAt === -1) {
     return undefined
   }
-  const contentStart = startAt + PAGE_TEXT_START.length
+  const contentStart = markerAt + marker.length
   const endAt = body.indexOf(PAGE_TEXT_END, contentStart)
   if (endAt === -1) {
     throw new Error('capture note is missing page text end marker')

--- a/packages/core/src/actions/capture.ts
+++ b/packages/core/src/actions/capture.ts
@@ -223,8 +223,11 @@ function capturePageTextFromBody(body: string): string | undefined {
     return undefined
   }
   const rest = body.slice(contentStart + 1)
-  const screenshotSection = /^## Screenshot[ \t]*$/mu.exec(rest)
-  const content = (screenshotSection === null ? rest : rest.slice(0, screenshotSection.index))
+  const content = rest
+    .replace(
+      /\n+## Screenshot[ \t]*\n+!\[[^\]\n]*\]\(assets\/capture-[^)]+\.jpg\)\s*$/u,
+      '',
+    )
     .replace(/\n+!\[[^\]\n]*\]\(assets\/capture-[^)]+\.jpg\)\s*$/u, '')
     .trim()
   return content === '' ? undefined : content

--- a/packages/core/src/ai/describe-page.test.ts
+++ b/packages/core/src/ai/describe-page.test.ts
@@ -115,6 +115,17 @@ describe('describePage', () => {
     expect(text).not.toContain('x'.repeat(1_001))
   })
 
+  it('adds extracted page text to the prompt and caps long pages', async () => {
+    const calls = modelAnswering('A description.')
+
+    await request({ contentText: `Important opening paragraph.\n\n${'x'.repeat(7_000)}` })
+
+    const parts = calls[0].prompt[0].content as Array<{ type: string; text?: string }>
+    const text = parts.find((part) => part.type === 'text')?.text ?? ''
+    expect(text).toContain('Extracted page text: Important opening paragraph.')
+    expect(text).not.toContain('x'.repeat(6_001))
+  })
+
   it.each([
     [401, 'auth'],
     [403, 'auth'],

--- a/packages/core/src/ai/describe-page.ts
+++ b/packages/core/src/ai/describe-page.ts
@@ -15,6 +15,7 @@ const DESCRIBE_TIMEOUT_MS = 60_000
 
 /** Caps the prompt's selection excerpt; the model needs gist, not the article. */
 const MAX_SELECTION_CHARS = 1_000
+const MAX_CONTENT_TEXT_CHARS = 6_000
 
 export interface DescribePageRequest {
   /** The provider entry to call (the app default). */
@@ -28,6 +29,8 @@ export interface DescribePageRequest {
   title: string
   /** Text the user had selected, if any. */
   selection?: string
+  /** Extracted full-page text, capped before it enters the provider prompt. */
+  contentText?: string
   /** Scraped meta description, if the scrape produced one. */
   metaDescription?: string
   /** Downscaled JPEG screenshot, base64 (no data-URL prefix), if captured. */
@@ -84,8 +87,11 @@ function describePrompt(request: DescribePageRequest): string {
   if (request.selection) {
     lines.push(`Text the user highlighted: ${request.selection.slice(0, MAX_SELECTION_CHARS)}`)
   }
+  if (request.contentText) {
+    lines.push(`Extracted page text: ${request.contentText.slice(0, MAX_CONTENT_TEXT_CHARS)}`)
+  }
   lines.push(
-    'Base the description on the screenshot when one is attached.',
+    'Base the description on the extracted page text when present, and the screenshot when one is attached.',
     'Answer with the description only — no preamble, no markdown.',
   )
   return lines.join('\n')


### PR DESCRIPTION
## Summary
- Add extracted page text to link-capture notes and pass it into AI description prompts
- Reformat capture notes to use structured metadata bullets and section headings
- Keep enrichment anchored to the `Description` bullet, with fallback to scraped meta descriptions

## Testing
- Added unit tests covering note formatting, description insertion, missing-description fallback, and prompt capping for long page text

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persisted capture note shape and enrichment/description selection logic; scoped to link capture but affects outbound AI prompts and note content users see.
> 
> **Overview**
> Link capture notes now use **structured metadata** (`URL`, `Type: #link`, optional `Description`) and **section headings** (`Note`, `Selection`, `Page Text`, `Screenshot`) instead of an inline host link, blockquoted selection, and bare image. Daily `## Links` entries are written as **bulleted** wiki links.
> 
> **Page text** is stored under `## Page Text` inside HTML comment markers; enrichment reads that block (not arbitrary body text) and passes it into **`describePage`**, which includes a capped excerpt in the prompt and instructs the model to lean on page text plus the screenshot.
> 
> Enrichment **inserts or updates** a single `- Description:` bullet in the metadata block (anchored on `- Type: #link`), prefers **non-empty AI output** over scraped meta, and **omits** the description bullet when neither AI nor scrape provides text—without stamping AI provenance on empty/refused paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c716d88abdd2741cd2f52dcd198e18eb658054bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->