### PR TITLE
Release v0.2.0-beta.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.2.0-beta.7"
+version = "0.2.0-beta.8"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.2.0-beta.7"
+version = "0.2.0-beta.8"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.2.0-beta.7",
+  "version": "0.2.0-beta.8",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.2.0-beta.8.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version string updates only; no runtime, security, or behavioral code changes.
> 
> **Overview**
> **Release bump only** — no application or dependency logic changes in this PR.
> 
> The version moves from `0.2.0-beta.7` to **`0.2.0-beta.8`** in `apps/desktop/src-tauri/Cargo.toml` (`reflect-open`), `apps/desktop/src-tauri/tauri.conf.json` (`productName` / bundle version), and `Cargo.lock` for the `reflect-open` package entry.
> 
> This aligns the Rust crate, Tauri bundle metadata, and lockfile so tagged releases and the updater (`latest.json`) can ship **beta.8**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab9cf81e2f3b4d7cd7bbdd9d6d506689cbc0258b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->