### PR TITLE
Enable #tag autocomplete in the note editor

### DIFF
--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -104,7 +104,7 @@ export function NotePane({
     saveError: imageSaveError,
   } = useImagePersistence(graphRoot, generation)
   const onWikiLinkClick = useWikiLinkNavigation(generation)
-  const { onWikilinkSearch } = useEditorAutocomplete()
+  const { onWikilinkSearch, onTagSearch } = useEditorAutocomplete()
 
   const bindEditor = document.bindEditor
   const handleRef = useCallback(
@@ -216,6 +216,7 @@ export function NotePane({
         onImageSaveError={onImageSaveError}
         onWikiLinkClick={onWikiLinkClick}
         onWikilinkSearch={onWikilinkSearch}
+        onTagSearch={onTagSearch}
         // Daily notes carry no title semantics (the date is their subject),
         // so an empty leading H1 there is just an empty heading.
         titlePlaceholder={dailyNote ? undefined : 'Untitled'}

--- a/apps/desktop/src/editor/use-editor-autocomplete.ts
+++ b/apps/desktop/src/editor/use-editor-autocomplete.ts
@@ -27,8 +27,8 @@ export interface EditorAutocomplete {
  * index's job, so neither menu re-sorts what the host returns. Both handlers
  * are no-ops without a bridge or an open graph.
  *
- * A consumer wires whichever menus it wants — the note pane takes only
- * `onWikilinkSearch`, the task editor takes both — so returning both here never
+ * A consumer wires whichever menus it wants — the note pane and the task editor
+ * both take `onWikilinkSearch` and `onTagSearch` — so returning both here never
  * forces a menu onto an editor that doesn't pass it through.
  */
 export function useEditorAutocomplete(): EditorAutocomplete {


### PR DESCRIPTION
## Summary

Typing `#` in the main note editor now opens an autocomplete menu over the graph's existing tags (most-used first) — the same `#` menu the Tasks inline editor already had.

## Background

The meowdown editor exposes no static "tags" prop; its only tag API is the dynamic `onTagSearch` handler (returns `TagItem[]`, opens the `#` menu). Reflect already implements that handler in `useEditorAutocomplete`, backed by `suggestTags` (which reads the app's `tags` SQLite projection of `#hashtags`). But the note pane only wired `onWikilinkSearch`, so the tag menu worked while editing tasks yet never appeared while editing a regular note.

## Changes

- `note-pane.tsx`: destructure `onTagSearch` from `useEditorAutocomplete()` and pass it through to `<NoteEditor>`.
- `use-editor-autocomplete.ts`: refresh the now-stale doc comment (the note pane no longer takes "only `onWikilinkSearch`").

No new data, handler, or provider — it reuses the existing tag-search plumbing.

## Notes

This also surfaces the `#` menu in the daily stream (same note pane). That's the expected behavior; if tag autocomplete should be scoped to standalone notes only, that can be gated.

## Testing

- `pnpm --filter @reflect/desktop typecheck` — passes
- `oxlint` on both changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-line wiring plus a doc comment; reuses existing tag search with no persistence or auth changes.
> 
> **Overview**
> The main **note pane** now passes **`onTagSearch`** from `useEditorAutocomplete` into **`NoteEditor`**, so typing `#` opens the same tag autocomplete menu (graph tags, most-used first) that the Tasks inline editor already had.
> 
> No new search logic or data layer — only plumbing that was already implemented in the hook. The daily stream uses the same pane, so tag autocomplete appears there too. A comment in `use-editor-autocomplete.ts` was updated to say the note pane wires both handlers, not wikilinks only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc3d65184cd42216253bd8edfccda4658de81a9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->