### PR TITLE
Add React Compiler + gate Rules of React via eslint-plugin-react-hooks

### DIFF
--- a/apps/desktop/eslint.config.js
+++ b/apps/desktop/eslint.config.js
@@ -1,0 +1,51 @@
+import reactHooks from 'eslint-plugin-react-hooks'
+import tseslint from 'typescript-eslint'
+
+/**
+ * ESLint flat config scoped to the React frontend.
+ *
+ * The project's primary linter is oxlint (`pnpm lint`). This config adds only
+ * the React Hooks + React Compiler rule set from `eslint-plugin-react-hooks`
+ * (`recommended-latest`), which oxlint does not implement. Those rules flag the
+ * Rules of React violations that cause the React Compiler to silently skip
+ * ("bail out" on) a component, so they keep the codebase compiler-friendly.
+ *
+ * Run via `pnpm --filter @reflect/desktop lint:react`, and wired into the
+ * repo-wide `pnpm lint` so it gates CI alongside oxlint.
+ *
+ * @see https://react.dev/learn/react-compiler
+ * @see https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks
+ */
+export default tseslint.config(
+  {
+    ignores: ['dist/**', 'src-tauri/**'],
+  },
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+        sourceType: 'module',
+      },
+    },
+    ...reactHooks.configs.flat['recommended-latest'],
+  },
+  {
+    // Test harnesses legitimately break the Rules of React that the compiler
+    // assumes — reassigning module-scoped probe variables from a render to
+    // capture output, rendering throwaway components, etc. None of this code is
+    // compiled by the React Compiler in production, so the purity/effect rules
+    // don't apply. The classic correctness rules (rules-of-hooks, deps) stay on.
+    files: ['src/**/*.{test,spec}.{ts,tsx}'],
+    rules: {
+      'react-hooks/globals': 'off',
+      'react-hooks/refs': 'off',
+      'react-hooks/set-state-in-effect': 'off',
+      'react-hooks/set-state-in-render': 'off',
+      'react-hooks/immutability': 'off',
+      'react-hooks/purity': 'off',
+      'react-hooks/incompatible-library': 'off',
+    },
+  },
+)

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,6 +12,7 @@
     "release:macos": "node scripts/release-macos.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "lint:react": "eslint .",
     "tauri": "tauri"
   },
   "dependencies": {
@@ -58,9 +59,13 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
+    "babel-plugin-react-compiler": "^1.0.0",
+    "eslint": "^10.5.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "jsdom": "^29.1.1",
     "tailwindcss": "^4.3.0",
     "typescript": "~5.8.3",
+    "typescript-eslint": "^8.61.1",
     "vite": "^7.0.4",
     "vitest": "^3"
   }

--- a/apps/desktop/react-compiler-plugin.ts
+++ b/apps/desktop/react-compiler-plugin.ts
@@ -1,0 +1,22 @@
+import react from '@vitejs/plugin-react'
+
+/**
+ * `@vitejs/plugin-react` configured with the React Compiler enabled.
+ *
+ * The React Compiler (https://react.dev/learn/react-compiler) runs as a Babel
+ * plugin and automatically memoizes components and hooks at build time, so we
+ * no longer have to reach for manual `useMemo` / `useCallback` / `React.memo`.
+ * It targets React 19 by default, which is the version this app ships.
+ *
+ * Shared between `vite.config.ts` (dev + production builds) and
+ * `vitest.config.ts` so tests exercise the same compiled output the app ships.
+ *
+ * @returns The React Vite plugin with `babel-plugin-react-compiler` applied.
+ */
+export function reactWithCompiler(): ReturnType<typeof react> {
+  return react({
+    babel: {
+      plugins: ['babel-plugin-react-compiler'],
+    },
+  })
+}

--- a/apps/desktop/src/components/backlink-source-group.tsx
+++ b/apps/desktop/src/components/backlink-source-group.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactElement } from 'react'
+import { useState, type ReactElement } from 'react'
 import { ChevronRight } from 'lucide-react'
 import type { BacklinkSource } from '@/lib/group-backlinks'
 
@@ -33,9 +33,15 @@ export function BacklinkSourceGroup({
 }: BacklinkSourceGroupProps): ReactElement {
   const [expanded, setExpanded] = useState(expandedOverride)
 
-  useEffect(() => {
+  // Reset to the panel-level toggle whenever it changes; the group chevron can
+  // then locally override again until the next panel toggle. Adjusting state
+  // during render (React applies it before paint, no wasted re-render) is the
+  // recommended alternative to a prop-syncing effect.
+  const [appliedOverride, setAppliedOverride] = useState(expandedOverride)
+  if (appliedOverride !== expandedOverride) {
+    setAppliedOverride(expandedOverride)
     setExpanded(expandedOverride)
-  }, [expandedOverride])
+  }
 
   return (
     <div className="group relative">

--- a/apps/desktop/src/components/command-palette/command-palette.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.tsx
@@ -56,11 +56,15 @@ export function CommandPalette({ context }: CommandPaletteProps): ReactElement |
   // on close so a reopened palette highlights its first result, not the last
   // session's pick.
   const [selectedValue, setSelectedValue] = useState('')
-  useEffect(() => {
+  // Reset on close so a reopened palette highlights its first result, not the
+  // last session's pick. Adjusting during render avoids a prop-syncing effect.
+  const [appliedOpen, setAppliedOpen] = useState(open)
+  if (appliedOpen !== open) {
+    setAppliedOpen(open)
     if (!open) {
       setSelectedValue('')
     }
-  }, [open])
+  }
   // Each new result set highlights its top note. Without this, cmdk keeps any
   // still-valid selection — and commands match synchronously while notes load
   // async, so the first command would stay highlighted over the top hit. Keyed
@@ -70,9 +74,11 @@ export function CommandPalette({ context }: CommandPaletteProps): ReactElement |
   // stale note selection clears so cmdk's first-item default can highlight a
   // matching command (Enter must always have a target).
   const selectedValueRef = useRef(selectedValue)
-  selectedValueRef.current = selectedValue
   const notesRef = useRef(sections.notes)
-  notesRef.current = sections.notes
+  useEffect(() => {
+    selectedValueRef.current = selectedValue
+    notesRef.current = sections.notes
+  })
   const notesKey = sections.notes.map((entry) => entry.path).join('\n')
   useEffect(() => {
     if (!open) {

--- a/apps/desktop/src/components/context-sidebar/published-url-section.tsx
+++ b/apps/desktop/src/components/context-sidebar/published-url-section.tsx
@@ -31,9 +31,12 @@ export function PublishedUrlSection({ path }: PublishedUrlSectionProps): ReactEl
   const [copyState, setCopyState] = useState<CopyState>('idle')
   const [isUpdating, setIsUpdating] = useState(false)
 
-  useEffect(() => {
+  // Reset the transient "copied" badge whenever the published URL changes.
+  const [appliedUrl, setAppliedUrl] = useState(url)
+  if (appliedUrl !== url) {
+    setAppliedUrl(url)
     setCopyState('idle')
-  }, [url])
+  }
 
   useEffect(() => {
     if (copyState !== 'copied') {

--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, type ReactElement } from 'react'
+import { useCallback, useState, type ReactElement } from 'react'
 import { isDaily } from '@reflect/core'
 import { BacklinksPanel } from '@/components/backlinks-panel'
 import { InlineAlert } from '@/components/inline-alert'
@@ -77,14 +77,15 @@ export function NotePane({
   const dailyNote = isDaily(path)
   // One seed per (pane, path): a fresh seed carries a fresh `id:`, and a mere
   // re-render must not mint a new identity (the session is keyed on the seed).
-  const seedRef = useRef<{ path: string; seed: string } | null>(null)
-  let missingSeed: string | undefined
-  if (lazy && !dailyNote) {
-    if (seedRef.current === null || seedRef.current.path !== path) {
-      seedRef.current = { path, seed: untitledNoteSeed() }
-    }
-    missingSeed = seedRef.current.seed
+  // Re-mint during render when the path changes — only the committed render's
+  // seed reaches the session, so the transient stale render is harmless, and
+  // this avoids writing a ref during render.
+  const needsSeed = lazy && !dailyNote
+  const [seed, setSeed] = useState(() => ({ path, seed: untitledNoteSeed() }))
+  if (needsSeed && seed.path !== path) {
+    setSeed({ path, seed: untitledNoteSeed() })
   }
+  const missingSeed = needsSeed ? seed.seed : undefined
   const document = useNoteDocument(path, generation, {
     createIfMissing: lazy,
     // Daily notes are excluded from rename tracking: their date labels are

--- a/apps/desktop/src/components/settings/model-combobox.tsx
+++ b/apps/desktop/src/components/settings/model-combobox.tsx
@@ -18,13 +18,15 @@ interface FilterCountSyncProps {
 }
 
 /**
- * Reads the cmdk filtered item count each render and writes it into a ref so
- * the parent's keydown handler always sees the latest value synchronously.
- * Must be rendered inside a {@link Command}.
+ * Tracks the cmdk filtered item count in a ref so the parent's keydown handler
+ * (which fires long after render) always sees the latest value. Must be
+ * rendered inside a {@link Command}.
  */
 function FilterCountSync({ countRef }: FilterCountSyncProps): null {
   const count = useCommandState((state) => state.filtered.count)
-  countRef.current = count
+  useEffect(() => {
+    countRef.current = count
+  })
   return null
 }
 
@@ -54,9 +56,15 @@ export function ModelCombobox({
   const [inputValue, setInputValue] = useState('')
   const filteredCountRef = useRef(models.length)
 
-  // Clear stale search text whenever the popover closes or the provider changes.
   const clearInput = () => setInputValue('')
-  useEffect(clearInput, [provider])
+  // Clear stale search text whenever the provider changes (popover close is
+  // handled in the open-change handler). Adjusting during render avoids a
+  // prop-syncing effect.
+  const [appliedProvider, setAppliedProvider] = useState(provider)
+  if (appliedProvider !== provider) {
+    setAppliedProvider(provider)
+    setInputValue('')
+  }
 
   const handleOpenChange = (isOpen: boolean) => {
     setOpen(isOpen)

--- a/apps/desktop/src/editor/bullet-after-heading-keymap.ts
+++ b/apps/desktop/src/editor/bullet-after-heading-keymap.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { Priority } from '@prosekit/core'
 import { type Command, TextSelection } from '@prosekit/pm/state'
 import { useKeymap } from '@prosekit/react'
@@ -68,8 +68,16 @@ interface BulletAfterHeadingKeymapProps {
  */
 export function BulletAfterHeadingKeymap({ enabled }: BulletAfterHeadingKeymapProps): null {
   const enabledRef = useRef(enabled)
-  enabledRef.current = enabled
-  const keymap = useMemo(() => ({ Enter: bulletAfterHeadingOnEnter(() => enabledRef.current) }), [])
+  useEffect(() => {
+    enabledRef.current = enabled
+  })
+  const keymap = useMemo(
+    // The getter is invoked only when the Enter command fires (a keypress),
+    // never during render.
+    // eslint-disable-next-line react-hooks/refs
+    () => ({ Enter: bulletAfterHeadingOnEnter(() => enabledRef.current) }),
+    [],
+  )
   useKeymap(keymap, { priority: Priority.high })
   return null
 }

--- a/apps/desktop/src/editor/markdown-preview.tsx
+++ b/apps/desktop/src/editor/markdown-preview.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useRef, type ReactElement } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactElement } from 'react'
 import { MeowdownEditor, type EditorHandle } from '@meowdown/react'
 import '@meowdown/core/style.css'
 import '@meowdown/react/style.css'
@@ -41,15 +41,17 @@ export function MarkdownPreview({
   // The resolver and click handler are read through refs so a changing prop
   // never rebuilds the editor's extensions.
   const resolveRef = useRef(resolveImageUrl)
-  resolveRef.current = resolveImageUrl
   const navigateRef = useRef(onWikiLinkClick)
-  navigateRef.current = onWikiLinkClick
+  useEffect(() => {
+    resolveRef.current = resolveImageUrl
+    navigateRef.current = onWikiLinkClick
+  })
 
   // Whether wiki links navigate at all is fixed by the first render — hosts
   // either always pass the handler (chat) or never do (palette preview). An
   // inert preview must not register a click handler, which would swallow chip
   // clicks.
-  const navigates = useRef(onWikiLinkClick != null).current
+  const [navigates] = useState(() => onWikiLinkClick != null)
 
   const resolveImageUrlStable = useCallback(
     (src: string) => resolveRef.current?.(src) ?? undefined,

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useEffect,
   useImperativeHandle,
   useRef,
   type ReactElement,
@@ -111,15 +112,17 @@ export function NoteEditor({
   // rebuilds meowdown's extensions (the uncontrolled-editor contract).
   // TODO: This violates "Rule of hooks". Refactor this later.
   const onChangeRef = useRef(onChange)
-  onChangeRef.current = onChange
   const onWikiLinkClickRef = useRef(onWikiLinkClick)
-  onWikiLinkClickRef.current = onWikiLinkClick
   const resolveImageUrlRef = useRef(resolveImageUrl)
-  resolveImageUrlRef.current = resolveImageUrl
   const saveImageRef = useRef(saveImage)
-  saveImageRef.current = saveImage
   const onImageSaveErrorRef = useRef(onImageSaveError)
-  onImageSaveErrorRef.current = onImageSaveError
+  useEffect(() => {
+    onChangeRef.current = onChange
+    onWikiLinkClickRef.current = onWikiLinkClick
+    resolveImageUrlRef.current = resolveImageUrl
+    saveImageRef.current = saveImage
+    onImageSaveErrorRef.current = onImageSaveError
+  })
 
   useImperativeHandle(
     handleRef,

--- a/apps/desktop/src/editor/use-note-document.ts
+++ b/apps/desktop/src/editor/use-note-document.ts
@@ -79,9 +79,7 @@ export function useNoteDocument(
   /** Mirrors the snapshot's conflict for non-reactive checks (rename gating). */
   const conflictRef = useRef<string | null>(null)
   /** The pane's lifecycle policy object — one per hook instance. */
-  const bindingRef = useRef<DocumentBinding | null>(null)
-  bindingRef.current ??= createDocumentBinding()
-  const binding = bindingRef.current
+  const [binding] = useState<DocumentBinding>(() => createDocumentBinding())
 
   // Writes read the generation at write time, not at session creation, so the
   // session must NOT be keyed on `generation`: reopening the *same* graph bumps
@@ -92,7 +90,9 @@ export function useNoteDocument(
   // the unmounted pane never re-renders, its ref keeps the old generation, and
   // Rust rejects its final flush instead of landing it in the new graph.
   const generationRef = useRef(generation)
-  generationRef.current = generation
+  useEffect(() => {
+    generationRef.current = generation
+  })
   const canWrite = generation !== null
 
   useEffect(() => {

--- a/apps/desktop/src/editor/use-note-document.ts
+++ b/apps/desktop/src/editor/use-note-document.ts
@@ -90,9 +90,12 @@ export function useNoteDocument(
   // the unmounted pane never re-renders, its ref keeps the old generation, and
   // Rust rejects its final flush instead of landing it in the new graph.
   const generationRef = useRef(generation)
-  useEffect(() => {
-    generationRef.current = generation
-  })
+  // Written during render, not in an effect: a debounced save or rename reads
+  // this at write time, and reopening the *same* graph bumps the generation
+  // without remounting the pane — an effect-based update would lag and let a
+  // write land with the previous generation, which Rust rejects.
+  // eslint-disable-next-line react-hooks/refs
+  generationRef.current = generation
   const canWrite = generation !== null
 
   useEffect(() => {

--- a/apps/desktop/src/hooks/use-audio-recorder.ts
+++ b/apps/desktop/src/hooks/use-audio-recorder.ts
@@ -78,7 +78,9 @@ export function useAudioRecorder(options: UseAudioRecorderOptions = {}): UseAudi
   // Read at fire time, not captured at start — the host's callback identity
   // changes across renders.
   const optionsRef = useRef(options)
-  optionsRef.current = options
+  useEffect(() => {
+    optionsRef.current = options
+  })
   // Bumped by cancel/unmount so an in-flight getUserMedia resolves into a dead
   // session and releases the mic instead of recording into the void.
   const sessionRef = useRef(0)

--- a/apps/desktop/src/hooks/use-poll.ts
+++ b/apps/desktop/src/hooks/use-poll.ts
@@ -15,7 +15,9 @@ export function usePoll(
 ): void {
   // Always call the latest tick without re-arming the timer every render.
   const tickRef = useRef(tick)
-  tickRef.current = tick
+  useEffect(() => {
+    tickRef.current = tick
+  })
 
   useEffect(() => {
     if (!enabled) {

--- a/apps/desktop/src/lib/tasks/use-task-editor-finalizer.ts
+++ b/apps/desktop/src/lib/tasks/use-task-editor-finalizer.ts
@@ -110,89 +110,93 @@ export function useTaskEditorFinalizer({
   // Reassigned each render (like apiRef) so the unmount cleanup — registered once
   // — flushes against this render's `initial`/`onFlush`, not the mount-time ones.
   const flushRef = useRef<() => void>(() => {})
-  flushRef.current = (): void => {
-    if (doneRef.current) {
-      return
+  useEffect(() => {
+    flushRef.current = (): void => {
+      if (doneRef.current) {
+        return
+      }
+      // Selection already moved → persist a real change (or the cleared line as an
+      // empty task) without touching the selection or the cancel/exit path. An
+      // unchanged editor claims nothing — so a StrictMode double-cleanup can't
+      // starve a later explicit commit/cancel of the single-shot claim.
+      const result = resolveTaskEdit(initial, currentRef.current)
+      if (result.type === 'cancel') {
+        return
+      }
+      doneRef.current = true
+      onFlush(result.type === 'commit' ? result.content : '')
     }
-    // Selection already moved → persist a real change (or the cleared line as an
-    // empty task) without touching the selection or the cancel/exit path. An
-    // unchanged editor claims nothing — so a StrictMode double-cleanup can't
-    // starve a later explicit commit/cancel of the single-shot claim.
-    const result = resolveTaskEdit(initial, currentRef.current)
-    if (result.type === 'cancel') {
-      return
+  })
+  useEffect(() => {
+    apiRef.current = {
+      commit: () => {
+        if (!claim()) {
+          return
+        }
+        const result = resolveTaskEdit(initial, currentRef.current)
+        if (result.type === 'commit') {
+          onCommit(result.content)
+        } else if (result.type === 'delete') {
+          onDelete()
+        } else {
+          onCancel()
+        }
+      },
+      commitAndContinue: () => {
+        if (!claim()) {
+          return
+        }
+        // Enter always adds the next task (V1). Hand the screen the resolved content
+        // to persist first — the new text, `''` for an emptied row, or `null` when
+        // unchanged (don't rewrite) — so the insert can sequence after the save.
+        const result = resolveTaskEdit(initial, currentRef.current)
+        onContinue(
+          result.type === 'commit' ? result.content : result.type === 'delete' ? '' : null,
+        )
+      },
+      cancel: () => {
+        if (!claim()) {
+          return
+        }
+        // An editor left empty on Escape — a Return-to-add row never typed into, or
+        // a task whose text was cleared — removes the line rather than leaving a
+        // blank task (V1). Decided on the *live* editor content, never the row's
+        // (possibly stale) projected text: Escape discards the unsaved edit, so a
+        // row with typed content is kept, not deleted.
+        if (currentRef.current.trim() === '') {
+          onDelete()
+        } else {
+          onCancel()
+        }
+      },
+      complete: () => {
+        if (!claim()) {
+          return
+        }
+        // Emptying then completing means delete (an empty task can't be "done");
+        // an unchanged task just toggles; otherwise save the new text and complete.
+        const result = resolveTaskEdit(initial, currentRef.current)
+        if (result.type === 'delete') {
+          onDelete()
+        } else if (result.type === 'commit') {
+          onComplete(result.content)
+        } else {
+          onComplete(null)
+        }
+      },
+      delete: () => {
+        if (claim()) {
+          onDelete()
+        }
+      },
+      deleteEmpty: () => {
+        if (claim()) {
+          onDeleteEmpty()
+        }
+      },
+      isEmpty: () => currentRef.current.trim() === '',
     }
-    doneRef.current = true
-    onFlush(result.type === 'commit' ? result.content : '')
-  }
-  apiRef.current = {
-    commit: () => {
-      if (!claim()) {
-        return
-      }
-      const result = resolveTaskEdit(initial, currentRef.current)
-      if (result.type === 'commit') {
-        onCommit(result.content)
-      } else if (result.type === 'delete') {
-        onDelete()
-      } else {
-        onCancel()
-      }
-    },
-    commitAndContinue: () => {
-      if (!claim()) {
-        return
-      }
-      // Enter always adds the next task (V1). Hand the screen the resolved content
-      // to persist first — the new text, `''` for an emptied row, or `null` when
-      // unchanged (don't rewrite) — so the insert can sequence after the save.
-      const result = resolveTaskEdit(initial, currentRef.current)
-      onContinue(
-        result.type === 'commit' ? result.content : result.type === 'delete' ? '' : null,
-      )
-    },
-    cancel: () => {
-      if (!claim()) {
-        return
-      }
-      // An editor left empty on Escape — a Return-to-add row never typed into, or
-      // a task whose text was cleared — removes the line rather than leaving a
-      // blank task (V1). Decided on the *live* editor content, never the row's
-      // (possibly stale) projected text: Escape discards the unsaved edit, so a
-      // row with typed content is kept, not deleted.
-      if (currentRef.current.trim() === '') {
-        onDelete()
-      } else {
-        onCancel()
-      }
-    },
-    complete: () => {
-      if (!claim()) {
-        return
-      }
-      // Emptying then completing means delete (an empty task can't be "done");
-      // an unchanged task just toggles; otherwise save the new text and complete.
-      const result = resolveTaskEdit(initial, currentRef.current)
-      if (result.type === 'delete') {
-        onDelete()
-      } else if (result.type === 'commit') {
-        onComplete(result.content)
-      } else {
-        onComplete(null)
-      }
-    },
-    delete: () => {
-      if (claim()) {
-        onDelete()
-      }
-    },
-    deleteEmpty: () => {
-      if (claim()) {
-        onDeleteEmpty()
-      }
-    },
-    isEmpty: () => currentRef.current.trim() === '',
-  }
+  })
 
   // Persist a pending edit when the row unmounts — the selection moved off it, so
   // flush (never clear/cancel) keeps the now-current selection intact.

--- a/apps/desktop/src/lib/tasks/use-task-keyboard.ts
+++ b/apps/desktop/src/lib/tasks/use-task-keyboard.ts
@@ -74,146 +74,148 @@ export function useTaskKeyboard({
   onToggleSchedule,
 }: TaskKeyboardOptions): void {
   const handlerRef = useRef<(event: KeyboardEvent) => void>(() => {})
-  handlerRef.current = (event) => {
-    // Respect anything a focused widget already handled (e.g. the filters menu's
-    // own arrow/Escape navigation).
-    if (event.defaultPrevented) {
-      return
-    }
-    // ⌘⇧E toggles the filters menu (V1) — a screen-level chord that fires
-    // regardless of focus, before the surface-scoping bails, so the same keys
-    // open and close it (the open menu portals outside the surface).
-    if ((event.metaKey || event.ctrlKey) && event.shiftKey && (event.key === 'e' || event.key === 'E')) {
-      event.preventDefault()
-      onToggleFilters()
-      return
-    }
-    // ⌘⇧S opens/closes the schedule calendar for the selection (V1) — also a
-    // screen-level chord, but only when there's something to schedule.
-    if ((event.metaKey || event.ctrlKey) && event.shiftKey && (event.key === 's' || event.key === 'S')) {
-      if (selection.selectedCount > 0) {
-        event.preventDefault()
-        onToggleSchedule()
+  useEffect(() => {
+    handlerRef.current = (event) => {
+      // Respect anything a focused widget already handled (e.g. the filters menu's
+      // own arrow/Escape navigation).
+      if (event.defaultPrevented) {
+        return
       }
-      return
-    }
-    const target = event.target as HTMLElement | null
-    // Focus outside the Tasks surface (the workspace sidebar, another panel) keeps
-    // its own keys — only `body`/no-focus and elements inside the surface drive the
-    // shortcuts. `body` is allowed so they still fire when focus falls back to it.
-    const root = rootRef.current
-    if (root !== null && target !== null && target !== root.ownerDocument.body && !root.contains(target)) {
-      return
-    }
-    // Back off when a focused control inside the surface owns the key: the inline
-    // editor (it owns its keys, and a ⌘⌫ there must not race its commit-on-unmount)
-    // or a portaled overlay (filters menu, dialog, ⌘K palette).
-    if (target?.closest?.(OWNS_KEYS) != null) {
-      return
-    }
-    const inSearch = target instanceof HTMLInputElement
-    // The note a Return-inserted task lands in (V1 group-based): the active row's
-    // group — Current → today's daily, a note → that note, Overdue/Upcoming refuse
-    // (`null`) — else, with nothing selected, today's daily. The pivot must still be
-    // *selected*: `activeKey()` keeps pointing at the last-touched row even after a
-    // ⌘-click deselects it (or all of them), so an unselected pivot falls to today.
-    const insertTarget = (): InsertTaskTarget | null => {
-      const activeKey = selection.activeKey()
-      const active =
-        activeKey !== null && selection.selected.has(activeKey)
-          ? tasksByKey.get(activeKey)
-          : undefined
-      return active !== undefined ? insertTargetForBucket(active, today) : todaysDailyTarget(today)
-    }
-    const selectExclusively = (key: string): void => {
-      selection.clickSelect(key, { metaKey: false, ctrlKey: false, shiftKey: false })
-      scrollToKey(key)
-    }
-    const mod = event.metaKey || event.ctrlKey
-    const selectedTasks = (): OpenTask[] =>
-      [...selection.selected]
-        .map((key) => tasksByKey.get(key))
-        .filter((task): task is OpenTask => task !== undefined)
+      // ⌘⇧E toggles the filters menu (V1) — a screen-level chord that fires
+      // regardless of focus, before the surface-scoping bails, so the same keys
+      // open and close it (the open menu portals outside the surface).
+      if ((event.metaKey || event.ctrlKey) && event.shiftKey && (event.key === 'e' || event.key === 'E')) {
+        event.preventDefault()
+        onToggleFilters()
+        return
+      }
+      // ⌘⇧S opens/closes the schedule calendar for the selection (V1) — also a
+      // screen-level chord, but only when there's something to schedule.
+      if ((event.metaKey || event.ctrlKey) && event.shiftKey && (event.key === 's' || event.key === 'S')) {
+        if (selection.selectedCount > 0) {
+          event.preventDefault()
+          onToggleSchedule()
+        }
+        return
+      }
+      const target = event.target as HTMLElement | null
+      // Focus outside the Tasks surface (the workspace sidebar, another panel) keeps
+      // its own keys — only `body`/no-focus and elements inside the surface drive the
+      // shortcuts. `body` is allowed so they still fire when focus falls back to it.
+      const root = rootRef.current
+      if (root !== null && target !== null && target !== root.ownerDocument.body && !root.contains(target)) {
+        return
+      }
+      // Back off when a focused control inside the surface owns the key: the inline
+      // editor (it owns its keys, and a ⌘⌫ there must not race its commit-on-unmount)
+      // or a portaled overlay (filters menu, dialog, ⌘K palette).
+      if (target?.closest?.(OWNS_KEYS) != null) {
+        return
+      }
+      const inSearch = target instanceof HTMLInputElement
+      // The note a Return-inserted task lands in (V1 group-based): the active row's
+      // group — Current → today's daily, a note → that note, Overdue/Upcoming refuse
+      // (`null`) — else, with nothing selected, today's daily. The pivot must still be
+      // *selected*: `activeKey()` keeps pointing at the last-touched row even after a
+      // ⌘-click deselects it (or all of them), so an unselected pivot falls to today.
+      const insertTarget = (): InsertTaskTarget | null => {
+        const activeKey = selection.activeKey()
+        const active =
+          activeKey !== null && selection.selected.has(activeKey)
+            ? tasksByKey.get(activeKey)
+            : undefined
+        return active !== undefined ? insertTargetForBucket(active, today) : todaysDailyTarget(today)
+      }
+      const selectExclusively = (key: string): void => {
+        selection.clickSelect(key, { metaKey: false, ctrlKey: false, shiftKey: false })
+        scrollToKey(key)
+      }
+      const mod = event.metaKey || event.ctrlKey
+      const selectedTasks = (): OpenTask[] =>
+        [...selection.selected]
+          .map((key) => tasksByKey.get(key))
+          .filter((task): task is OpenTask => task !== undefined)
 
-    if (inSearch) {
-      if (event.key === 'Escape') {
-        setQuery('')
-        selection.clear()
-        target.blur()
-      }
-      return
-    }
-    if (mod && event.key === 'Enter') {
-      event.preventDefault()
-      if (event.shiftKey) {
-        actions.archive() // ⌘⇧↵ — hide the session's completed tasks
-      } else {
-        actions.toggle(selectedTasks()) // ⌘↵ — complete, or reopen if all checked
-      }
-    } else if (event.key === 'Enter') {
-      // Return adds a task (V1). A sole selection's editor owns Enter (it bailed
-      // above via OWNS_KEYS and continues the entry there), so this fires from the
-      // list itself: insert, then select the new row to open its editor focused.
-      // A null target means the active row is Overdue/Upcoming — nothing to add to.
-      // Skip while a write is in flight so a held/rapid Return can't append several
-      // empty rows before the first insert's editor takes focus.
-      event.preventDefault()
-      const target = insertTarget()
-      if (target !== null && !actions.isPending) {
-        void actions.insert(target).then((created) => {
-          if (created !== null) {
-            selectExclusively(taskKey(created))
-          }
-        })
-      }
-    } else if (mod && event.key === 'Backspace') {
-      event.preventDefault()
-      actions.remove(selectedTasks())
-      selection.clear()
-    } else if (event.key === 'Backspace') {
-      // Plain ⌫ deletes only a single empty row (V1) — never content, and never a
-      // multi-selection (which is ambiguous). The sole-selection case usually runs
-      // in the focused editor; here it covers an unfocused single selection, and
-      // lands on the previous row so the keyboard flow continues.
-      const selected = selectedTasks()
-      if (selected.length === 1 && selected[0].text.trim() === '') {
-        event.preventDefault()
-        const previous = previousTaskKey(orderedTasks, selected[0])
-        actions.remove(selected)
-        if (previous !== null) {
-          selectExclusively(previous)
-        } else {
+      if (inSearch) {
+        if (event.key === 'Escape') {
+          setQuery('')
           selection.clear()
+          target.blur()
+        }
+        return
+      }
+      if (mod && event.key === 'Enter') {
+        event.preventDefault()
+        if (event.shiftKey) {
+          actions.archive() // ⌘⇧↵ — hide the session's completed tasks
+        } else {
+          actions.toggle(selectedTasks()) // ⌘↵ — complete, or reopen if all checked
+        }
+      } else if (event.key === 'Enter') {
+        // Return adds a task (V1). A sole selection's editor owns Enter (it bailed
+        // above via OWNS_KEYS and continues the entry there), so this fires from the
+        // list itself: insert, then select the new row to open its editor focused.
+        // A null target means the active row is Overdue/Upcoming — nothing to add to.
+        // Skip while a write is in flight so a held/rapid Return can't append several
+        // empty rows before the first insert's editor takes focus.
+        event.preventDefault()
+        const target = insertTarget()
+        if (target !== null && !actions.isPending) {
+          void actions.insert(target).then((created) => {
+            if (created !== null) {
+              selectExclusively(taskKey(created))
+            }
+          })
+        }
+      } else if (mod && event.key === 'Backspace') {
+        event.preventDefault()
+        actions.remove(selectedTasks())
+        selection.clear()
+      } else if (event.key === 'Backspace') {
+        // Plain ⌫ deletes only a single empty row (V1) — never content, and never a
+        // multi-selection (which is ambiguous). The sole-selection case usually runs
+        // in the focused editor; here it covers an unfocused single selection, and
+        // lands on the previous row so the keyboard flow continues.
+        const selected = selectedTasks()
+        if (selected.length === 1 && selected[0].text.trim() === '') {
+          event.preventDefault()
+          const previous = previousTaskKey(orderedTasks, selected[0])
+          actions.remove(selected)
+          if (previous !== null) {
+            selectExclusively(previous)
+          } else {
+            selection.clear()
+          }
+        }
+      } else if (mod && (event.key === 'a' || event.key === 'A')) {
+        event.preventDefault()
+        selection.selectAll()
+      } else if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        if (event.shiftKey) {
+          selection.extend(1)
+        } else {
+          selection.move(1)
+        }
+        scrollToKey(selection.activeKey())
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        if (event.shiftKey) {
+          selection.extend(-1)
+        } else {
+          selection.move(-1)
+        }
+        scrollToKey(selection.activeKey())
+      } else if (event.key === 'Escape') {
+        // V1 clears the selection and the search query together.
+        if (selection.selectedCount > 0 || query !== '') {
+          event.preventDefault()
+          selection.clear()
+          setQuery('')
         }
       }
-    } else if (mod && (event.key === 'a' || event.key === 'A')) {
-      event.preventDefault()
-      selection.selectAll()
-    } else if (event.key === 'ArrowDown') {
-      event.preventDefault()
-      if (event.shiftKey) {
-        selection.extend(1)
-      } else {
-        selection.move(1)
-      }
-      scrollToKey(selection.activeKey())
-    } else if (event.key === 'ArrowUp') {
-      event.preventDefault()
-      if (event.shiftKey) {
-        selection.extend(-1)
-      } else {
-        selection.move(-1)
-      }
-      scrollToKey(selection.activeKey())
-    } else if (event.key === 'Escape') {
-      // V1 clears the selection and the search query together.
-      if (selection.selectedCount > 0 || query !== '') {
-        event.preventDefault()
-        selection.clear()
-        setQuery('')
-      }
     }
-  }
+  })
 
   useEffect(() => {
     const listener = (event: KeyboardEvent): void => handlerRef.current(event)

--- a/apps/desktop/src/lib/tasks/use-task-selection.ts
+++ b/apps/desktop/src/lib/tasks/use-task-selection.ts
@@ -50,7 +50,9 @@ export function useTaskSelection(orderedKeys: readonly string[]): TaskSelection 
   // The latest order, read by mutators that run from a keydown listener closing
   // over an older render.
   const orderRef = useRef(orderedKeys)
-  orderRef.current = orderedKeys
+  useEffect(() => {
+    orderRef.current = orderedKeys
+  })
   const anchorRef = useRef<string | null>(null)
   const cursorRef = useRef<string | null>(null)
 
@@ -59,6 +61,10 @@ export function useTaskSelection(orderedKeys: readonly string[]): TaskSelection 
   // only runs when the set of rows actually changes.
   useEffect(() => {
     const valid = new Set(orderedKeys)
+    // Reconcile the selection to a changed visible order; the functional update
+    // returns the same Set when nothing vanished, so steady-state renders never
+    // cascade.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setSelected((current) =>
       [...current].every((key) => valid.has(key))
         ? current

--- a/apps/desktop/src/lib/use-scroll-restoration.ts
+++ b/apps/desktop/src/lib/use-scroll-restoration.ts
@@ -21,6 +21,10 @@ export function useScrollRestoration(
   const { arrivalSeq, entryId, saveScrollState, savedScroll } = useRouter()
   useEffect(() => {
     if (ready && element) {
+      // Setting scrollTop is a DOM side effect inside an effect; the rule treats
+      // the `element` argument as immutable, but mutating the live DOM node here
+      // is intentional.
+      // eslint-disable-next-line react-hooks/immutability
       element.scrollTop = savedScroll() ?? 0
     }
   }, [arrivalSeq, entryId, ready, savedScroll, element])

--- a/apps/desktop/src/mobile/mobile-shell.tsx
+++ b/apps/desktop/src/mobile/mobile-shell.tsx
@@ -13,7 +13,7 @@ import { useRouter } from '@/routing/router'
 export function MobileShell(): ReactElement {
   const { route, navigate, entryId } = useRouter()
   const [allQuery, setAllQuery] = useState('')
-  const lastTab = useRef<MobileTab>('daily')
+  const [lastTab, setLastTab] = useState<MobileTab>('daily')
 
   // A `search` history entry seeds the live query — once per entry, so the
   // user can keep typing without the effect snapping the text back.
@@ -25,13 +25,18 @@ export function MobileShell(): ReactElement {
     }
   }, [route, entryId])
 
+  // A note keeps whichever tab it was opened from: routes that don't map to a
+  // tab fall back to the last one, remembered across renders. Tracking that in
+  // state (adjusted during render) avoids reading/writing a ref in render.
   const tab: MobileTab =
     route.kind === 'allNotes' || route.kind === 'search'
       ? 'all'
       : route.kind === 'today' || route.kind === 'daily'
         ? 'daily'
-        : lastTab.current
-  lastTab.current = tab
+        : lastTab
+  if (tab !== lastTab) {
+    setLastTab(tab)
+  }
 
   return (
     <div className="flex h-dvh w-screen flex-col">

--- a/apps/desktop/src/mobile/screens/all-notes.tsx
+++ b/apps/desktop/src/mobile/screens/all-notes.tsx
@@ -226,12 +226,10 @@ function SearchResults({
                 <span className="line-clamp-2 text-xs text-text-muted">
                   {parseHighlights(hit.snippet).map((segment, index) =>
                     segment.highlighted ? (
-                      // eslint-disable-next-line react/no-array-index-key
                       <mark key={index} className="rounded-sm bg-primary/15 text-text">
                         {segment.text}
                       </mark>
                     ) : (
-                      // eslint-disable-next-line react/no-array-index-key
                       <span key={index}>{segment.text}</span>
                     ),
                   )}

--- a/apps/desktop/src/mobile/use-day-carousel.ts
+++ b/apps/desktop/src/mobile/use-day-carousel.ts
@@ -129,6 +129,10 @@ export function useDayCarousel(date: string, onSelect: (date: string) => void): 
   // same frame as the strip's new selection (no visible lag).
   useLayoutEffect(() => {
     if (indexWithin(dayWindow, date) === -1) {
+      // Re-anchor the window when a far date link lands outside it; runs only on
+      // that rare miss, and the rebuilt window then contains the date, so it
+      // cannot loop.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDayWindow(createDayWindow(date, CAROUSEL_WINDOW))
     }
   }, [date, dayWindow])

--- a/apps/desktop/src/platform-root.tsx
+++ b/apps/desktop/src/platform-root.tsx
@@ -15,11 +15,14 @@ const MobileRoot = lazy(() =>
  * versa. Plain-browser dev (no Tauri bridge) gets the desktop tree.
  */
 export function PlatformRoot(): ReactElement {
-  const [platform, setPlatform] = useState<AppPlatform | null>(null)
+  // Plain-browser dev has no bridge — start on the desktop tree directly. With a
+  // bridge, resolve the real platform asynchronously in the effect below.
+  const [platform, setPlatform] = useState<AppPlatform | null>(() =>
+    hasBridge() ? null : 'desktop',
+  )
 
   useEffect(() => {
     if (!hasBridge()) {
-      setPlatform('desktop')
       return
     }
     let active = true

--- a/apps/desktop/src/providers/audio-memo-provider.tsx
+++ b/apps/desktop/src/providers/audio-memo-provider.tsx
@@ -136,7 +136,9 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
   )
 
   const collapsedRef = useRef(collapsed)
-  collapsedRef.current = collapsed
+  useEffect(() => {
+    collapsedRef.current = collapsed
+  })
 
   /** Committed recordings waiting their turn; the pump owns the head. */
   const queueRef = useRef<PendingCapture[]>([])
@@ -161,7 +163,9 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
     providers: settings.aiProviders,
     defaultProviderId: settings.defaultAiProviderId,
   })
-  providersRef.current = { providers: settings.aiProviders, defaultProviderId: settings.defaultAiProviderId }
+  useEffect(() => {
+    providersRef.current = { providers: settings.aiProviders, defaultProviderId: settings.defaultAiProviderId }
+  })
 
   // One reconciler per graph session (this provider remounts per graph). It
   // owns the launch pass and all retry triggers; the pump only schedules.
@@ -294,7 +298,9 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
     stopSettledRef.current = settled
     return settled
   }, [stopRecorder, pump])
-  stopAndSaveRef.current = () => void stopAndSave()
+  useEffect(() => {
+    stopAndSaveRef.current = () => void stopAndSave()
+  })
 
   const discard = useCallback((): void => {
     parkedRef.current = null

--- a/apps/desktop/src/providers/capture-provider.tsx
+++ b/apps/desktop/src/providers/capture-provider.tsx
@@ -26,10 +26,12 @@ export function CaptureProvider({ graph, children }: CaptureProviderProps): Reac
     providers: settings.aiProviders,
     defaultProviderId: settings.defaultAiProviderId,
   })
-  providersRef.current = {
-    providers: settings.aiProviders,
-    defaultProviderId: settings.defaultAiProviderId,
-  }
+  useEffect(() => {
+    providersRef.current = {
+      providers: settings.aiProviders,
+      defaultProviderId: settings.defaultAiProviderId,
+    }
+  })
 
   useEffect(() => {
     const controller = createCaptureController({

--- a/apps/desktop/src/providers/chat-provider.tsx
+++ b/apps/desktop/src/providers/chat-provider.tsx
@@ -140,15 +140,17 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
   // Read at call time, not captured: send() can fire long after the render
   // that created it.
   const turnsRef = useRef(turns)
-  turnsRef.current = turns
   const attachmentsRef = useRef(attachments)
-  attachmentsRef.current = attachments
   const activeModelRef = useRef<AiProviderConfig | null>(activeModel)
-  activeModelRef.current = activeModel
   const conversationIdRef = useRef(conversationId)
-  conversationIdRef.current = conversationId
   const generationRef = useRef<number | null>(indexGeneration)
-  generationRef.current = indexGeneration
+  useEffect(() => {
+    turnsRef.current = turns
+    attachmentsRef.current = attachments
+    activeModelRef.current = activeModel
+    conversationIdRef.current = conversationId
+    generationRef.current = indexGeneration
+  })
 
   // The in-flight send, tracked synchronously — the no-concurrent-sends
   // guard can't ride on rendered state, which only reflects a send after

--- a/apps/desktop/src/providers/settings-provider.tsx
+++ b/apps/desktop/src/providers/settings-provider.tsx
@@ -143,7 +143,9 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
   })
   const [overrides, setOverrides] = useState<Partial<Settings>>({})
   const loadedRef = useRef(loaded)
-  loadedRef.current = loaded
+  useEffect(() => {
+    loadedRef.current = loaded
+  })
 
   // One derived load-state drives everything that waits on hydration (the
   // updater queue drain, the settle promise). With no bridge installed
@@ -244,7 +246,9 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
   const persistQueue = useRef<Promise<void>>(Promise.resolve())
   const lastPersisted = useRef<Settings | null>(null)
   const settingsRef = useRef(settings)
-  settingsRef.current = settings
+  useEffect(() => {
+    settingsRef.current = settings
+  })
 
   const persistIfChanged = useCallback((): Promise<void> => {
     const disk = loadedRef.current

--- a/apps/desktop/src/providers/sync-provider.tsx
+++ b/apps/desktop/src/providers/sync-provider.tsx
@@ -55,6 +55,10 @@ export function SyncProvider({ graph, children }: SyncProviderProps): ReactEleme
 
   useEffect(() => {
     const next = createBackupController({ graph, indexGeneration })
+    // The controller is an imperative lifecycle object created per (graph, index
+    // session); it must be instantiated in an effect (it subscribes and starts)
+    // and stored so useSyncExternalStore can read it.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setController(next)
     void next.start()
     return () => {

--- a/apps/desktop/src/providers/update-provider.tsx
+++ b/apps/desktop/src/providers/update-provider.tsx
@@ -69,6 +69,10 @@ export function UpdateProvider({ children, autoCheck }: UpdateProviderProps): Re
       return
     }
     const next = createUpdateController({ autoCheck: resolvedAutoCheck })
+    // The controller is an imperative lifecycle object created for the app's
+    // lifetime; it must be instantiated in an effect (it subscribes and starts)
+    // and stored so useSyncExternalStore can read it.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setController(next)
     next.start()
     return () => {

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -64,20 +64,22 @@ export function useAppShortcuts(): CommandContext {
   // The palette is modal: app shortcuts must not navigate behind its overlay.
   // A ref keeps the listener stable across open/close renders.
   const paletteOpenRef = useRef(paletteOpen)
-  paletteOpenRef.current = paletteOpen
 
   // Same for the ⌘/ cheat-sheet, except ⌘/ itself toggles it closed.
   const shortcutsOpenRef = useRef(shortcutsOpen)
-  shortcutsOpenRef.current = shortcutsOpen
 
   // Read at run time, not captured: a command can fire long after the render
   // that created the context (palette open across an index rebuild, etc.).
   const generationRef = useRef<number | null>(graph?.generation ?? null)
-  generationRef.current = graph?.generation ?? null
   const routeRef = useRef(route)
-  routeRef.current = route
   const focusedDailyDateRef = useRef(focusedDailyDate)
-  focusedDailyDateRef.current = focusedDailyDate
+  useEffect(() => {
+    paletteOpenRef.current = paletteOpen
+    shortcutsOpenRef.current = shortcutsOpen
+    generationRef.current = graph?.generation ?? null
+    routeRef.current = route
+    focusedDailyDateRef.current = focusedDailyDate
+  })
 
   const context = useMemo<CommandContext>(
     () => ({

--- a/apps/desktop/src/routing/router.tsx
+++ b/apps/desktop/src/routing/router.tsx
@@ -77,7 +77,9 @@ export function RouterProvider({
   const scrollById = useRef(new Map<number, number>())
   /** The active entry id, readable without depending on render order. */
   const currentId = useRef(0)
-  currentId.current = history.stack[history.index].id
+  useEffect(() => {
+    currentId.current = history.stack[history.index].id
+  })
 
   const navigate = useCallback((route: Route) => {
     const target = normalizeRoute(route)

--- a/apps/desktop/src/routing/router.tsx
+++ b/apps/desktop/src/routing/router.tsx
@@ -77,9 +77,12 @@ export function RouterProvider({
   const scrollById = useRef(new Map<number, number>())
   /** The active entry id, readable without depending on render order. */
   const currentId = useRef(0)
-  useEffect(() => {
-    currentId.current = history.stack[history.index].id
-  })
+  // Written during render, not in an effect: descendant scroll-restoration
+  // effects read this id (through saveScrollState/savedScroll) on the same
+  // commit, and React runs effects child-before-parent — so updating it in an
+  // effect here would lag a frame and restore or save the wrong entry's offset.
+  // eslint-disable-next-line react-hooks/refs
+  currentId.current = history.stack[history.index].id
 
   const navigate = useCallback((route: Route) => {
     const target = normalizeRoute(route)

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,14 +1,14 @@
 import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { reactWithCompiler } from './react-compiler-plugin'
 
 // @ts-expect-error process is a Node.js global available in the Vite config context
 const host = process.env.TAURI_DEV_HOST
 
 // https://vite.dev/config/
 export default defineConfig(async () => ({
-  plugins: [react(), tailwindcss()],
+  plugins: [reactWithCompiler(), tailwindcss()],
 
   resolve: {
     alias: {

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,11 +1,11 @@
 import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
-import react from '@vitejs/plugin-react'
+import { reactWithCompiler } from './react-compiler-plugin'
 
 // Editor (ProseMirror/contenteditable) tests will move to browser-mode vitest
 // later (Plan 01 step 9); jsdom covers pure logic + light component tests.
 export default defineConfig({
-  plugins: [react()],
+  plugins: [reactWithCompiler()],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "turbo run build",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
-    "lint": "oxlint apps packages",
+    "lint": "oxlint apps packages && pnpm --filter @reflect/desktop lint:react",
     "lint:fix": "oxlint --fix apps packages",
     "check": "pnpm typecheck && pnpm lint",
     "tauri": "pnpm --filter @reflect/desktop tauri",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,15 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.6.0
         version: 4.7.0(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
+      eslint:
+        specifier: ^10.5.0
+        version: 10.5.0(jiti@2.7.0)
+      eslint-plugin-react-hooks:
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@10.5.0(jiti@2.7.0))
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@1.8.0)
@@ -153,6 +162,9 @@ importers:
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
+      typescript-eslint:
+        specifier: ^8.61.1
+        version: 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.8.3)
       vite:
         specifier: ^7.0.4
         version: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
@@ -192,7 +204,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@wxt-dev/module-react':
         specifier: ^1.2.2
-        version: 1.2.2(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(wxt@0.20.26(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(yaml@2.9.0))
+        version: 1.2.2(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(wxt@0.20.26(@types/node@25.9.3)(eslint@10.5.0(jiti@2.7.0))(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(yaml@2.9.0))
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -204,7 +216,7 @@ importers:
         version: 3.2.6(@types/node@25.9.3)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(yaml@2.9.0)
       wxt:
         specifier: ^0.20.26
-        version: 0.20.26(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(yaml@2.9.0)
+        version: 0.20.26(@types/node@25.9.3)(eslint@10.5.0(jiti@2.7.0))(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(yaml@2.9.0)
 
   design-system: {}
 
@@ -843,6 +855,36 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.6.0':
+    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.2':
+    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   '@exodus/bytes@1.15.1':
     resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -872,6 +914,26 @@ packages:
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -2352,6 +2414,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -2366,6 +2431,9 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -2395,6 +2463,65 @@ packages:
 
   '@types/webextension-polyfill@0.12.5':
     resolution: {integrity: sha512-uKSAv6LgcVdINmxXMKBuVIcg/2m5JZugoZO8x20g7j2bXJkPIl/lVGQcDlbV+aXAiTyXT2RA5U5mI4IGCDMQeg==}
+
+  '@typescript-eslint/eslint-plugin@8.61.1':
+    resolution: {integrity: sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.61.1
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.61.1':
+    resolution: {integrity: sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.61.1':
+    resolution: {integrity: sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.61.1':
+    resolution: {integrity: sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.61.1':
+    resolution: {integrity: sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.61.1':
+    resolution: {integrity: sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.61.1':
+    resolution: {integrity: sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.61.1':
+    resolution: {integrity: sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.61.1':
+    resolution: {integrity: sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.61.1':
+    resolution: {integrity: sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
@@ -2482,6 +2609,11 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -2508,6 +2640,9 @@ packages:
     peerDependenciesMeta:
       ajv:
         optional: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
@@ -2588,6 +2723,9 @@ packages:
 
   atomically@2.1.1:
     resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
+
+  babel-plugin-react-compiler@1.0.0:
+    resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2955,6 +3093,9 @@ packages:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
 
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -3158,13 +3299,61 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
+
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.5.0:
+    resolution: {integrity: sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
 
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -3217,6 +3406,12 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
   fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
     engines: {node: '>=6'}
@@ -3247,6 +3442,10 @@ packages:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
@@ -3262,10 +3461,21 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
   firefox-profile@4.7.0:
     resolution: {integrity: sha512-aGApEu5bfCNbA4PGUZiRJAIU6jKmghV2UVdklXAofnNtiDjqYw0czLS46W7IfFqVKgKhFB8Ao2YoNGHY4BoIMQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   form-data-encoder@4.1.0:
     resolution: {integrity: sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==}
@@ -3359,6 +3569,10 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
@@ -3399,6 +3613,12 @@ packages:
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hermes-estree@0.25.1:
+    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
+
+  hermes-parser@0.25.1:
+    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
   hono@4.12.25:
     resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
@@ -3447,6 +3667,10 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
@@ -3456,6 +3680,10 @@ packages:
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
 
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
@@ -3652,12 +3880,18 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
   json-parse-even-better-errors@3.0.2:
     resolution: {integrity: sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -3667,6 +3901,9 @@ packages:
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -3688,6 +3925,9 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -3746,6 +3986,10 @@ packages:
 
   layerr@3.0.0:
     resolution: {integrity: sha512-tv754Ki2dXpPVApOrjTyRo4/QegVb9eVFq4mjqp4+NM5NaX7syQvN5BBNfV/ZpAHCEHV24XdUVrBAoka4jt3pA==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
@@ -3850,6 +4094,10 @@ packages:
   local-pkg@1.2.1:
     resolution: {integrity: sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==}
     engines: {node: '>=14'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -4027,6 +4275,9 @@ packages:
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
@@ -4129,6 +4380,10 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
   ora@8.2.0:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
@@ -4152,6 +4407,14 @@ packages:
         optional: true
       vite-plus:
         optional: true
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
 
   package-json@10.0.1:
     resolution: {integrity: sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==}
@@ -4185,6 +4448,10 @@ packages:
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -4259,6 +4526,10 @@ packages:
     engines: {node: '>=10'}
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -4960,6 +5231,12 @@ packages:
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
 
@@ -4984,6 +5261,10 @@ packages:
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
   type-fest@3.13.1:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
     engines: {node: '>=14.16'}
@@ -5002,6 +5283,13 @@ packages:
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
+  typescript-eslint@8.61.1:
+    resolution: {integrity: sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -5081,6 +5369,9 @@ packages:
   update-notifier@7.3.1:
     resolution: {integrity: sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA==}
     engines: {node: '>=18'}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -5268,6 +5559,10 @@ packages:
   winreg@0.0.12:
     resolution: {integrity: sha512-typ/+JRmi7RqP1NanzFULK36vczznSNN8kWVA9vIqXyv8GhghUlwhGp1Xj3Nms1FsPcNnsQrJOR10N58/nQ9hQ==}
 
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
   wrap-ansi@10.0.0:
     resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
     engines: {node: '>=20'}
@@ -5336,6 +5631,10 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
   yocto-spinner@1.2.0:
     resolution: {integrity: sha512-Yw0hUB6UA3o4YUgKy3oSe9a4cxoaZ9sBfYDw+JSxo6Id0KoJGoxzPA24qqUXYKBWABs/zDSGTz9kww7t3F0XGw==}
     engines: {node: '>=18.19'}
@@ -5351,6 +5650,12 @@ packages:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
       zod: ^3.25.28 || ^4
+
+  zod-validation-error@4.0.2:
+    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   zod@3.23.0:
     resolution: {integrity: sha512-OFLT+LTocvabn6q76BTwVB0hExEBS0IduTr3cqZyMqEDbOnYmcU+y0tUAYbND4uwclpBGi4I4UUBGzylWpjLGA==}
@@ -6067,6 +6372,36 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.5.0(jiti@2.7.0))':
+    dependencies:
+      eslint: 10.5.0(jiti@2.7.0)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.6.0':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.2':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
+
   '@exodus/bytes@1.15.1(@noble/hashes@1.8.0)':
     optionalDependencies:
       '@noble/hashes': 1.8.0
@@ -6091,6 +6426,22 @@ snapshots:
   '@hono/node-server@1.19.14(hono@4.12.25)':
     dependencies:
       hono: 4.12.25
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -7632,6 +7983,8 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/esrecurse@4.3.1': {}
+
   '@types/estree@1.0.9': {}
 
   '@types/filesystem@0.0.36':
@@ -7645,6 +7998,8 @@ snapshots:
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -7673,6 +8028,97 @@ snapshots:
   '@types/validate-npm-package-name@4.0.2': {}
 
   '@types/webextension-polyfill@0.12.5': {}
+
+  '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.8.3))(eslint@10.5.0(jiti@2.7.0))(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 8.61.1
+      '@typescript-eslint/type-utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.61.1
+      eslint: 10.5.0(jiti@2.7.0)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.61.1
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/typescript-estree': 8.61.1(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.61.1
+      debug: 4.4.3
+      eslint: 10.5.0(jiti@2.7.0)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.61.1(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@5.8.3)
+      '@typescript-eslint/types': 8.61.1
+      debug: 4.4.3
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.61.1':
+    dependencies:
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/visitor-keys': 8.61.1
+
+  '@typescript-eslint/tsconfig-utils@8.61.1(typescript@5.8.3)':
+    dependencies:
+      typescript: 5.8.3
+
+  '@typescript-eslint/type-utils@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/typescript-estree': 8.61.1(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.8.3)
+      debug: 4.4.3
+      eslint: 10.5.0(jiti@2.7.0)
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.61.1': {}
+
+  '@typescript-eslint/typescript-estree@8.61.1(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.61.1(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@5.8.3)
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/visitor-keys': 8.61.1
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.3
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
+      '@typescript-eslint/scope-manager': 8.61.1
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/typescript-estree': 8.61.1(typescript@5.8.3)
+      eslint: 10.5.0(jiti@2.7.0)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.61.1':
+    dependencies:
+      '@typescript-eslint/types': 8.61.1
+      eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.1': {}
 
@@ -7748,11 +8194,11 @@ snapshots:
       '@types/filesystem': 0.0.36
       '@types/har-format': 1.2.16
 
-  '@wxt-dev/module-react@1.2.2(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(wxt@0.20.26(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(yaml@2.9.0))':
+  '@wxt-dev/module-react@1.2.2(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(wxt@0.20.26(@types/node@25.9.3)(eslint@10.5.0(jiti@2.7.0))(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(yaml@2.9.0))':
     dependencies:
       '@vitejs/plugin-react': 4.7.0(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
-      wxt: 0.20.26(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(yaml@2.9.0)
+      wxt: 0.20.26(@types/node@25.9.3)(eslint@10.5.0(jiti@2.7.0))(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7791,6 +8237,10 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn@8.16.0: {}
 
   adm-zip@0.5.17: {}
@@ -7808,6 +8258,13 @@ snapshots:
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
 
   ajv@8.20.0:
     dependencies:
@@ -7874,6 +8331,10 @@ snapshots:
     dependencies:
       stubborn-fs: 2.0.0
       when-exit: 2.1.5
+
+  babel-plugin-react-compiler@1.0.0:
+    dependencies:
+      '@babel/types': 7.29.7
 
   balanced-match@1.0.2: {}
 
@@ -8222,6 +8683,8 @@ snapshots:
 
   deep-extend@0.6.0: {}
 
+  deep-is@0.1.4: {}
+
   deepmerge@4.3.1: {}
 
   default-browser-id@5.0.1: {}
@@ -8416,11 +8879,88 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  eslint-plugin-react-hooks@7.1.1(eslint@10.5.0(jiti@2.7.0)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.7
+      eslint: 10.5.0(jiti@2.7.0)
+      hermes-parser: 0.25.1
+      zod: 3.25.76
+      zod-validation-error: 4.0.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.5.0(jiti@2.7.0):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.6.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 5.0.1
+
   esprima@4.0.1: {}
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
 
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
+
+  esutils@2.0.3: {}
 
   etag@1.8.1: {}
 
@@ -8513,6 +9053,10 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
   fast-redact@3.5.0: {}
 
   fast-uri@3.1.2: {}
@@ -8536,6 +9080,10 @@ snapshots:
     dependencies:
       is-unicode-supported: 2.1.0
 
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
   file-uri-to-path@1.0.0: {}
 
   filesize@11.0.17: {}
@@ -8555,6 +9103,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
   firefox-profile@4.7.0:
     dependencies:
       adm-zip: 0.5.17
@@ -8562,6 +9115,13 @@ snapshots:
       ini: 4.1.3
       minimist: 1.2.8
       xml2js: 0.6.2
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
 
   form-data-encoder@4.1.0: {}
 
@@ -8644,6 +9204,10 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
   glob-to-regexp@0.4.1: {}
 
   global-directory@4.0.1:
@@ -8685,6 +9249,12 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hermes-estree@0.25.1: {}
+
+  hermes-parser@0.25.1:
+    dependencies:
+      hermes-estree: 0.25.1
 
   hono@4.12.25: {}
 
@@ -8734,6 +9304,8 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  ignore@7.0.5: {}
+
   immediate@3.0.6: {}
 
   import-fresh@3.3.1:
@@ -8742,6 +9314,8 @@ snapshots:
       resolve-from: 4.0.0
 
   import-meta-resolve@4.2.0: {}
+
+  imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
 
@@ -8884,15 +9458,21 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-buffer@3.0.1: {}
+
   json-parse-even-better-errors@2.3.1: {}
 
   json-parse-even-better-errors@3.0.2: {}
+
+  json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
 
@@ -8933,6 +9513,10 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
@@ -8963,6 +9547,11 @@ snapshots:
       package-json: 10.0.1
 
   layerr@3.0.0: {}
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   lie@3.3.0:
     dependencies:
@@ -9049,6 +9638,10 @@ snapshots:
       mlly: 1.8.2
       pkg-types: 2.3.1
       quansync: 0.2.11
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
 
   lodash.includes@4.3.0: {}
 
@@ -9212,6 +9805,8 @@ snapshots:
 
   napi-build-utils@2.0.0: {}
 
+  natural-compare@1.4.0: {}
+
   negotiator@1.0.0: {}
 
   node-abi@3.92.0:
@@ -9317,6 +9912,15 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
   ora@8.2.0:
     dependencies:
       chalk: 5.6.2
@@ -9355,6 +9959,14 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.69.0
       '@oxlint/binding-win32-x64-msvc': 1.69.0
 
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
   package-json@10.0.1:
     dependencies:
       ky: 1.14.3
@@ -9392,6 +10004,8 @@ snapshots:
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
+
+  path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
@@ -9474,6 +10088,8 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
+
+  prelude-ls@1.2.1: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -10300,6 +10916,10 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
+  ts-api-utils@2.5.0(typescript@5.8.3):
+    dependencies:
+      typescript: 5.8.3
+
   ts-morph@26.0.0:
     dependencies:
       '@ts-morph/common': 0.27.0
@@ -10333,6 +10953,10 @@ snapshots:
 
   tw-animate-css@1.4.0: {}
 
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
   type-fest@3.13.1: {}
 
   type-fest@4.41.0: {}
@@ -10348,6 +10972,17 @@ snapshots:
       mime-types: 3.0.2
 
   typedarray@0.0.6: {}
+
+  typescript-eslint@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.8.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.8.3))(eslint@10.5.0(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.61.1(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.8.3)
+      eslint: 10.5.0(jiti@2.7.0)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@5.8.3: {}
 
@@ -10438,6 +11073,10 @@ snapshots:
       pupa: 3.3.0
       semver: 7.8.3
       xdg-basedir: 5.1.0
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   use-callback-ref@1.3.3(@types/react@19.2.17)(react@19.2.7):
     dependencies:
@@ -10634,6 +11273,8 @@ snapshots:
 
   winreg@0.0.12: {}
 
+  word-wrap@1.2.5: {}
+
   wrap-ansi@10.0.0:
     dependencies:
       ansi-styles: 6.2.3
@@ -10659,7 +11300,7 @@ snapshots:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
-  wxt@0.20.26(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(yaml@2.9.0):
+  wxt@0.20.26(@types/node@25.9.3)(eslint@10.5.0(jiti@2.7.0))(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(yaml@2.9.0):
     dependencies:
       '@1natsu/wait-element': 4.2.0
       '@aklinker1/rollup-plugin-visualizer': 5.12.0(rollup@4.61.1)
@@ -10703,6 +11344,8 @@ snapshots:
       vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
       vite-node: 3.2.4(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
       web-ext-run: 0.2.4
+    optionalDependencies:
+      eslint: 10.5.0(jiti@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - canvas
@@ -10752,6 +11395,8 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
+  yocto-queue@0.1.0: {}
+
   yocto-spinner@1.2.0:
     dependencies:
       yoctocolors: 2.1.2
@@ -10764,6 +11409,10 @@ snapshots:
       jszip: 3.10.1
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod-validation-error@4.0.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
 


### PR DESCRIPTION
## What

Implements [React Compiler](https://react.dev/learn/react-compiler) in the desktop app and adopts the React team's recommended lint rules to keep the codebase compiler-friendly, gated in CI.

## Changes

**Compiler**
- `babel-plugin-react-compiler` runs in both `vite.config.ts` (dev + production) and `vitest.config.ts` via a shared `reactWithCompiler()` helper ([`react-compiler-plugin.ts`](apps/desktop/react-compiler-plugin.ts)), so dev, prod, and tests run the same compiled output. React 19 is the default target.

**Lint (`eslint-plugin-react-hooks` recommended-latest)**
- The repo lints with **oxlint, not ESLint**. oxlint doesn't implement the React Compiler rule set, so this adds a minimal, scoped ESLint flat config ([`eslint.config.js`](apps/desktop/eslint.config.js)) that enables **only** `eslint-plugin-react-hooks` recommended-latest on `src/**` (with the TS parser). No broader ESLint ruleset is introduced.
- A test-file override turns off the compiler's purity/effect rules for `*.test.*` — test harnesses legitimately break the Rules of React (reassigning module-scoped probe vars, etc.) and aren't compiled in production.
- Wired into `pnpm lint` (and thus `pnpm check`) so it **gates CI alongside oxlint**. Also runnable directly: `pnpm --filter @reflect/desktop lint:react`.

**Pre-existing violations fixed (the reason this PR touches ~28 files)**

The preset surfaced 70 long-standing Rules-of-React violations. All are resolved:
- **Latest-ref writes** (`ref.current = x` during render, read later in handlers/timers) → moved into unconditional effects.
- **Prop-sync `setState` in effects** (reset-on-prop-change) → React's adjust-during-render guard.
- **Lazy-init / render-read refs** (`useNoteDocument` binding, the note-pane seed, the mobile sticky-tab, `platform-root`) → `useState` (lazy initializer / during-render guard).
- A handful of **documented `eslint-disable` lines** for genuinely legitimate cases: imperative controller lifecycles feeding `useSyncExternalStore` (`sync-provider`, `update-provider`), DOM mutation of a hook arg (`use-scroll-restoration`), keypress-deferred ref getters (`bullet-after-heading-keymap`), and selection/window reconciliation (`use-task-selection`, `use-day-carousel`).

4 `react-hooks/incompatible-library` **warnings** remain (TanStack Virtual / react-hook-form return functions the compiler can't memoize). These are advisory by design and don't block CI.

## Verification

- ✅ `pnpm typecheck`
- ✅ `pnpm lint` (oxlint + react-hooks) — exit 0
- ✅ Production build — `useMemoCache` present in the bundle, confirming the compiler is actively transforming components
- ✅ Full desktop test suite — **948 tests across 113 files pass**, with the compiler enabled in the test pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad touch of editor, routing, tasks, and providers with subtle timing semantics (generation refs, selection flush, scroll restoration); behavior should be equivalent but regressions are possible outside what tests cover. Compiler changes build output globally for the desktop React tree.
> 
> **Overview**
> Enables **React Compiler** on the desktop app via shared `reactWithCompiler()` in Vite and Vitest, and adds a scoped ESLint flat config that runs only `eslint-plugin-react-hooks` **recommended-latest** (what oxlint does not cover). Root `pnpm lint` now runs oxlint plus `lint:react`, so compiler-related hook rules gate CI.
> 
> Across ~28 source files, existing **Rules of React** violations are fixed so the compiler can optimize components instead of bailing out: latest-ref updates moved out of render into effects, prop-sync resets use adjust-during-render guards instead of effects, and a few lifecycle cases use `useState` or documented `eslint-disable` where intentional (e.g. router scroll id, `useSyncExternalStore` controllers). A test-file override relaxes compiler purity rules for harness code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84c2699ab7d3f360737ac2263f8b33ca96a36f9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->