### PR TITLE
Tasks: fix edit-mode height shift, shadcn toolbar buttons, center checkbox

### DIFF
--- a/apps/desktop/src/components/tasks/task-filters-menu.tsx
+++ b/apps/desktop/src/components/tasks/task-filters-menu.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react'
 import { ListFilter } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -38,9 +39,11 @@ export function TaskFiltersMenu({
 }: TaskFiltersMenuProps): ReactElement {
   return (
     <DropdownMenu open={open} onOpenChange={onOpenChange}>
-      <DropdownMenuTrigger className="flex items-center gap-2 rounded-md px-2 py-1 text-sm text-text-muted transition-colors hover:text-text focus-visible:text-text focus-visible:outline-none">
-        <ListFilter aria-hidden className="size-4" />
-        Task filters
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="font-normal text-text-muted">
+          <ListFilter aria-hidden className="size-4" />
+          Task filters
+        </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-56">
         <DropdownMenuLabel>Tasks</DropdownMenuLabel>

--- a/apps/desktop/src/components/tasks/task-row.tsx
+++ b/apps/desktop/src/components/tasks/task-row.tsx
@@ -84,7 +84,9 @@ export function TaskRow({
         // write-back (and so focus can't drift off the editor onto it).
         disabled={task.checked || isPending || editing}
         onClick={complete}
-        className="mt-px shrink-0 text-text-muted transition-colors hover:text-text focus-visible:text-text focus-visible:outline-none disabled:cursor-default"
+        // h-6 matches the text/editor's leading-6 line so the circle centers on
+        // the first line (items-start keeps it there when a task wraps).
+        className="flex h-6 shrink-0 items-center text-text-muted transition-colors hover:text-text focus-visible:text-text focus-visible:outline-none disabled:cursor-default"
       >
         {done ? (
           <CircleCheck aria-hidden className="size-[18px] text-accent" strokeWidth={2} />

--- a/apps/desktop/src/components/tasks/tasks-screen.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } 
 import { useQuery } from '@tanstack/react-query'
 import { Archive, CalendarClock, Search } from 'lucide-react'
 import { getCompletedTasks, getOpenTasks, groupTasks, hasBridge, type TaskGroup } from '@reflect/core'
+import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useRecentlyCompleted } from '@/lib/tasks/recently-completed'
 import { sameTask, taskKey } from '@/lib/tasks/task-identity'
@@ -216,24 +217,17 @@ export function TasksScreen(): ReactElement {
             today={today}
             onSchedule={onSchedule}
           >
-            <button
-              type="button"
-              className="flex flex-none items-center gap-2 rounded-md px-2 py-1 text-sm text-text-muted transition-colors hover:text-text focus-visible:text-text focus-visible:outline-none"
-            >
+            <Button type="button" variant="ghost" className="font-normal text-text-muted">
               <CalendarClock aria-hidden className="size-4" />
               Schedule ({selection.selectedCount})
-            </button>
+            </Button>
           </TaskScheduleCalendar>
         ) : null}
         {recentlyCompleted.length > 0 ? (
-          <button
-            type="button"
-            onClick={actions.archive}
-            className="flex flex-none items-center gap-2 rounded-md px-2 py-1 text-sm text-text-muted transition-colors hover:text-text focus-visible:text-text focus-visible:outline-none"
-          >
+          <Button type="button" variant="ghost" onClick={actions.archive} className="font-normal text-text-muted">
             <Archive aria-hidden className="size-4" />
             Archive ({recentlyCompleted.length})
-          </button>
+          </Button>
         ) : null}
         <TaskFiltersMenu
           filters={filters}

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -323,6 +323,16 @@ body {
   margin: 0.4em 0;
 }
 
+/* The Tasks inline editor (TaskEditor) shares each row's single-line leading-6
+   box with the read-only TaskText, which renders the content in a marginless
+   span. The editor wraps it in a paragraph, so the `.reflect-editor p` block
+   margin above would grow the row the moment it enters edit mode. Zero it (same
+   0-1-1 specificity, later source order wins the tie) so focusing a task never
+   shifts its height. */
+.reflect-task-editor p {
+  margin: 0;
+}
+
 .reflect-editor blockquote {
   border-left: 2px solid var(--accent-soft, var(--border));
   color: var(--text-secondary);


### PR DESCRIPTION
Three small polish fixes to the Tasks view.

## What changed

### 1. Focusing a task no longer shifts its height
The inline editor (`TaskEditor`) renders the task content inside a `<p>`, which inherited the editor's general `.reflect-editor p { margin: 0.4em 0 }` rule. The read-only `TaskText` renders a marginless `<span>`, so entering edit mode grew the row by ~0.8em (~10px). Added a scoped `.reflect-task-editor p { margin: 0 }` (same 0-1-1 specificity, later source order) so view and edit modes share one `leading-6` line box and the row height stays fixed.

### 2. Toolbar buttons use the shadcn `Button`
The **Schedule**, **Archive**, and **Task filters** header buttons were hand-rolled `<button>` / `DropdownMenuTrigger` markup. They now use the shadcn `Button` (`variant="ghost"`), kept visually similar with `font-normal text-text-muted` (the default Button is `font-medium`). They pick up the standard ghost hover background and focus ring instead of the previous text-color-only treatment. The filters trigger uses `DropdownMenuTrigger asChild`; Schedule already nested under `PopoverTrigger asChild`.

### 3. Checkbox centered on the first text line
The row is `items-start` with a `leading-6` (24px) text line, but the 18px circle only had `mt-px`, leaving it ~2px high. The checkbox button now gets a 24px box (`h-6 flex items-center`) so the circle centers on the first line — in both view and edit modes — and stays first-line-aligned when a task wraps to multiple lines. Row content height is unchanged.

## Testing
- `pnpm typecheck` — clean
- `pnpm test --run src/components/tasks/tasks-screen.test.tsx` — 37/37 pass
- `pnpm lint` — 0 errors (pre-existing warnings only, in untouched files)

Visual confirmation in `tauri dev` still recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop Tasks UI and scoped CSS only; no data, auth, or API changes.
> 
> **Overview**
> Three UI polish fixes in the Tasks view.
> 
> **Edit mode no longer jumps row height** — Adds `.reflect-task-editor p { margin: 0 }` so the inline `TaskEditor` paragraph doesn’t pick up `.reflect-editor p` margins that read-only `TaskText` doesn’t have; view and edit share the same `leading-6` line box.
> 
> **Header actions use shadcn `Button`** — Schedule, Archive, and Task filters replace hand-styled `<button>` / trigger markup with `Button variant="ghost"` (muted styling via `font-normal text-text-muted`). Filters use `DropdownMenuTrigger asChild`.
> 
> **Checkbox aligns with the first line** — The complete control uses `h-6 flex items-center` instead of `mt-px` so the 18px circle centers on the `leading-6` text line when tasks wrap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef2f70be8e3dd0b07f359f19e3855f0f22d0d047. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->