### PR TITLE
Move "New note" above "All notes" in sidebar

### DIFF
--- a/apps/desktop/src/components/sidebar/sidebar.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.tsx
@@ -68,6 +68,21 @@ export function Sidebar({ graph, context }: SidebarProps): ReactElement {
             onClick={() => void runCommand('nav.today', context)}
           />
           <SidebarItem
+            icon={
+              <span className={lucideBox}>
+                <SquarePen aria-hidden strokeWidth={1.75} className="size-4" />
+              </span>
+            }
+            label="New note"
+            binding={keybindingFor('note.new') ?? undefined}
+            // Active while the open note is still on its ULID placeholder
+            // name — the state this row creates. The birth rename onto a
+            // title slug is also what hands the note off to ordinary
+            // navigation, releasing the highlight.
+            active={route.kind === 'note' && isUntitledNotePath(route.path)}
+            onClick={() => void runCommand('note.new', context)}
+          />
+          <SidebarItem
             icon={<ListIcon className="shrink-0" />}
             label="All notes"
             binding={keybindingFor('nav.allNotes') ?? undefined}
@@ -84,21 +99,6 @@ export function Sidebar({ graph, context }: SidebarProps): ReactElement {
             binding={keybindingFor('nav.tasks') ?? undefined}
             active={route.kind === 'tasks'}
             onClick={() => void runCommand('nav.tasks', context)}
-          />
-          <SidebarItem
-            icon={
-              <span className={lucideBox}>
-                <SquarePen aria-hidden strokeWidth={1.75} className="size-4" />
-              </span>
-            }
-            label="New note"
-            binding={keybindingFor('note.new') ?? undefined}
-            // Active while the open note is still on its ULID placeholder
-            // name — the state this row creates. The birth rename onto a
-            // title slug is also what hands the note off to ordinary
-            // navigation, releasing the highlight.
-            active={route.kind === 'note' && isUntitledNotePath(route.path)}
-            onClick={() => void runCommand('note.new', context)}
           />
           <SidebarItem
             icon={


### PR DESCRIPTION
## What

Reorders the primary sidebar nav so **New note** sits directly above **All notes**.

New order: Daily notes → New note → All notes → Tasks → Chat → Settings.

## Why

New note is one of the most common actions; placing it higher in the nav makes it quicker to reach.

## Notes for reviewers

Pure reorder — the `SidebarItem` for New note is unchanged (same icon, label, binding, `active` logic, and `note.new` command). No behavior or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only nav reorder in the sidebar with no logic, routing, or command changes.
> 
> **Overview**
> Moves the **New note** primary nav row so it sits directly under **Daily notes** and above **All notes** (before Tasks, Chat, and Settings).
> 
> The `SidebarItem` is unchanged—same icon, `note.new` command, keybinding, and untitled-note `active` logic. Only JSX order in `sidebar.tsx` changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a2906ee9ac6009c0a1fb1e1b380b4db99fccf3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->