### PR TITLE
Tasks: add "Convert to bullet" (V2 convert-to-checklist)

### DIFF
--- a/apps/desktop/src/components/tasks/task-editor.tsx
+++ b/apps/desktop/src/components/tasks/task-editor.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useMemo, useState, type MutableRefObject, type ReactElement } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type MutableRefObject,
+  type ReactElement,
+} from 'react'
 import { Priority } from '@prosekit/core'
 import { useKeymap } from '@prosekit/react'
 import { type OpenTask } from '@reflect/core'
@@ -39,10 +46,19 @@ interface TaskEditorProps {
   onCancel: () => void
   /** ⌘↵: complete the task (saving the edit first when `content` isn't null). */
   onComplete: (content: string | null) => void
+  /** ⌘⇧K: convert the task to a plain bullet (saving the edit first when changed). */
+  onConvertToBullet: (content: string | null) => void
   /** Persist a changed edit when the row unmounts (selection moved), without exiting. */
   onFlush: (content: string) => void
   /** ↑/↓ (Shift to extend): move the selection between rows while editing (V1). */
   onNavigate: TaskNavigate
+  /**
+   * Lets the toolbar's "Convert to bullet" button drive the same flush-then-convert
+   * the ⌘⇧K keymap does. While this row is the sole selection it holds a trigger
+   * that commits the live draft and converts; it clears on unmount so the screen
+   * falls back to a plain (no-edit) convert when no row is being edited.
+   */
+  convertControllerRef?: MutableRefObject<(() => void) | null>
 }
 
 /**
@@ -76,6 +92,10 @@ function TaskCommitKeymap({
       },
       'Mod-Enter': () => {
         apiRef.current.complete()
+        return true
+      },
+      'Mod-Shift-k': () => {
+        apiRef.current.convertToBullet()
         return true
       },
       Escape: () => {
@@ -126,8 +146,10 @@ export function TaskEditor({
   onDeleteEmpty,
   onCancel,
   onComplete,
+  onConvertToBullet,
   onFlush,
   onNavigate,
+  convertControllerRef,
 }: TaskEditorProps): ReactElement {
   const { graph } = useGraph()
   const { settings } = useSettings()
@@ -146,8 +168,22 @@ export function TaskEditor({
     onDeleteEmpty,
     onCancel,
     onComplete,
+    onConvertToBullet,
     onFlush,
   })
+
+  // Expose the flush-then-convert trigger to the screen while this row is edited,
+  // so the toolbar button converts through the same path the ⌘⇧K keymap uses —
+  // never a stale-content write that drops the unsaved draft. Cleared on unmount.
+  useEffect(() => {
+    if (convertControllerRef === undefined) {
+      return
+    }
+    convertControllerRef.current = () => apiRef.current.convertToBullet()
+    return () => {
+      convertControllerRef.current = null
+    }
+  }, [convertControllerRef, apiRef])
 
   const handleRef = useCallback((handle: NoteEditorHandle | null) => {
     handle?.focus()

--- a/apps/desktop/src/components/tasks/task-group-section.tsx
+++ b/apps/desktop/src/components/tasks/task-group-section.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react'
+import type { MutableRefObject, ReactElement } from 'react'
 import { AlarmClock, Calendar, FileText, Pin, Plus, Star } from 'lucide-react'
 import type { OpenTask, TaskGroup } from '@reflect/core'
 import { taskKey } from '@/lib/tasks/task-identity'
@@ -18,6 +18,8 @@ interface TaskGroupSectionProps {
   today: string
   /** Add a task to this group and open its editor (the header's "+ Add", V1). */
   onAdd: (target: InsertTaskTarget) => void
+  /** Holds the editing row's flush-then-convert trigger for the toolbar button. */
+  convertControllerRef: MutableRefObject<(() => void) | null>
   onOpen: (notePath: string) => void
 }
 
@@ -62,6 +64,7 @@ export function TaskGroupSection({
   editHandlers,
   today,
   onAdd,
+  convertControllerRef,
   onOpen,
 }: TaskGroupSectionProps): ReactElement {
   const showSource = group.kind !== 'note'
@@ -113,6 +116,7 @@ export function TaskGroupSection({
                 editing={selection.isSoleSelected(key)}
                 onSelect={(event) => selection.clickSelect(key, event)}
                 {...editHandlers(task)}
+                convertControllerRef={convertControllerRef}
                 onOpen={onOpen}
               />
             )

--- a/apps/desktop/src/components/tasks/task-row.tsx
+++ b/apps/desktop/src/components/tasks/task-row.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent, ReactElement } from 'react'
+import type { MouseEvent, MutableRefObject, ReactElement } from 'react'
 import { ArrowRight, Circle, CircleCheck } from 'lucide-react'
 import type { OpenTask } from '@reflect/core'
 import { formatDayLabel } from '@/lib/dates'
@@ -31,10 +31,14 @@ interface TaskRowProps {
   onEditCancel: () => void
   /** ⌘↵ in the editor: complete the task, saving the edit first when `content` isn't null. */
   onEditComplete: (content: string | null) => void
+  /** ⌘⇧K in the editor: convert the task to a bullet, saving the edit first when changed. */
+  onEditConvertToBullet: (content: string | null) => void
   /** Persist a changed edit when the row unmounts (selection moved), without exiting. */
   onEditFlush: (content: string) => void
   /** ↑/↓ in the editor: move the selection between rows (Shift extends). */
   onEditNavigate: TaskNavigate
+  /** Holds the editing row's flush-then-convert trigger for the toolbar button. */
+  convertControllerRef: MutableRefObject<(() => void) | null>
   onOpen: (notePath: string) => void
 }
 
@@ -59,8 +63,10 @@ export function TaskRow({
   onEditDeleteEmpty,
   onEditCancel,
   onEditComplete,
+  onEditConvertToBullet,
   onEditFlush,
   onEditNavigate,
+  convertControllerRef,
   onOpen,
 }: TaskRowProps): ReactElement {
   const { settings } = useSettings()
@@ -103,8 +109,10 @@ export function TaskRow({
           onDeleteEmpty={onEditDeleteEmpty}
           onCancel={onEditCancel}
           onComplete={onEditComplete}
+          onConvertToBullet={onEditConvertToBullet}
           onFlush={onEditFlush}
           onNavigate={onEditNavigate}
+          convertControllerRef={convertControllerRef}
         />
       ) : (
         <button

--- a/apps/desktop/src/components/tasks/tasks-screen.test.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.test.tsx
@@ -31,7 +31,14 @@ const toggleTask = vi.hoisted(() => vi.fn())
 const deleteTask = vi.hoisted(() => vi.fn())
 const editTask = vi.hoisted(() => vi.fn())
 const insertTask = vi.hoisted(() => vi.fn())
-vi.mock('@/lib/note-task', () => ({ toggleTask, deleteTask, editTask, insertTask }))
+const convertTaskToBullet = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/note-task', () => ({
+  toggleTask,
+  deleteTask,
+  editTask,
+  insertTask,
+  convertTaskToBullet,
+}))
 
 // The real inline editor mounts ProseKit, which jsdom can't render (no
 // getClientRects/getAnimations). Stub it with the callback surface the row
@@ -155,6 +162,8 @@ beforeEach(() => {
   editTask.mockReset()
   insertTask.mockReset()
   insertTask.mockResolvedValue(0)
+  convertTaskToBullet.mockReset()
+  convertTaskToBullet.mockResolvedValue(undefined)
   startOperation.mockClear()
   fail.mockReset()
   resetRecentlyCompleted()
@@ -689,6 +698,44 @@ describe('TasksScreen', () => {
       'plan [[2026-06-20]]',
       1,
     )
+    view.unmount()
+  })
+
+  it('converts the selection to bullets via the toolbar button, dropping the rows', async () => {
+    getOpenTasks.mockResolvedValue([
+      task({ notePath: 'notes/a.md', markerOffset: 2, raw: '[ ] plan', text: 'plan', noteTitle: 'A' }),
+      task({ notePath: 'notes/b.md', markerOffset: 2, raw: '[ ] ship', text: 'ship', noteTitle: 'B' }),
+    ])
+    const view = renderScreen()
+
+    await view.findByText('plan')
+    await userEvent.keyboard('{Meta>}a{/Meta}') // select both (no editor)
+    await userEvent.click(view.getByRole('button', { name: /Convert to bullet \(2\)/ }))
+
+    await waitFor(() => expect(convertTaskToBullet).toHaveBeenCalledTimes(2))
+    expect(convertTaskToBullet).toHaveBeenCalledWith(expect.objectContaining({ notePath: 'notes/a.md' }), 1)
+    expect(convertTaskToBullet).toHaveBeenCalledWith(expect.objectContaining({ notePath: 'notes/b.md' }), 1)
+    // The converted rows are no longer checkboxes, so they leave the view.
+    await waitFor(() => expect(view.queryByText('plan')).toBeNull())
+    expect(view.queryByText('ship')).toBeNull()
+    view.unmount()
+  })
+
+  it('converts the selection to bullets with ⌘⇧K', async () => {
+    getOpenTasks.mockResolvedValue([
+      task({ notePath: 'notes/a.md', markerOffset: 2, raw: '[ ] plan', text: 'plan', noteTitle: 'A' }),
+    ])
+    const view = renderScreen()
+
+    await userEvent.click(await view.findByRole('button', { name: 'plan' }))
+    await userEvent.keyboard('{Meta>}{Shift>}k{/Shift}{/Meta}')
+    await waitFor(() =>
+      expect(convertTaskToBullet).toHaveBeenCalledWith(
+        expect.objectContaining({ notePath: 'notes/a.md', markerOffset: 2 }),
+        1,
+      ),
+    )
+    await waitFor(() => expect(view.queryByText('plan')).toBeNull())
     view.unmount()
   })
 

--- a/apps/desktop/src/components/tasks/tasks-screen.test.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { OpenTask } from '@reflect/core'
-import type { ReactNode } from 'react'
+import { useEffect, type MutableRefObject, type ReactNode } from 'react'
 import { resetRecentlyCompleted } from '@/lib/tasks/recently-completed'
 import { RouterProvider, useRouter } from '@/routing/router'
 import { TasksScreen } from './tasks-screen'
@@ -53,8 +53,10 @@ vi.mock('./task-editor', () => ({
     onDeleteEmpty,
     onCancel,
     onComplete,
+    onConvertToBullet,
     onFlush,
     onNavigate,
+    convertControllerRef,
   }: {
     task: { text: string }
     onCommit: (content: string) => void
@@ -63,9 +65,23 @@ vi.mock('./task-editor', () => ({
     onDeleteEmpty: () => void
     onCancel: () => void
     onComplete: (content: string | null) => void
+    onConvertToBullet: (content: string | null) => void
     onFlush: (content: string) => void
     onNavigate: (direction: -1 | 1, options: { span: boolean }) => void
-  }) => (
+    convertControllerRef?: MutableRefObject<(() => void) | null>
+  }) => {
+    // Mirror the real editor: expose a flush-then-convert trigger (simulating a
+    // changed draft) so the toolbar button routes the sole row through it.
+    useEffect(() => {
+      if (convertControllerRef === undefined) {
+        return
+      }
+      convertControllerRef.current = () => onConvertToBullet('edited content')
+      return () => {
+        convertControllerRef.current = null
+      }
+    })
+    return (
     <div data-task-editor data-testid="task-editor">
       <span>editing: {task.text}</span>
       <button type="button" onClick={() => onCommit('edited content')}>
@@ -95,6 +111,12 @@ vi.mock('./task-editor', () => ({
       <button type="button" onClick={() => onComplete(null)}>
         complete-unchanged
       </button>
+      <button type="button" onClick={() => onConvertToBullet('edited content')}>
+        convert-edited
+      </button>
+      <button type="button" onClick={() => onConvertToBullet(null)}>
+        convert-unchanged
+      </button>
       <button type="button" onClick={() => onFlush('edited content')}>
         flush-edit
       </button>
@@ -105,7 +127,8 @@ vi.mock('./task-editor', () => ({
         nav-up
       </button>
     </div>
-  ),
+    )
+  },
 }))
 
 const fail = vi.hoisted(() => vi.fn())
@@ -701,7 +724,7 @@ describe('TasksScreen', () => {
     view.unmount()
   })
 
-  it('converts the selection to bullets via the toolbar button, dropping the rows', async () => {
+  it('converts a multi-selection to bullets via the toolbar button (no editor, bulk)', async () => {
     getOpenTasks.mockResolvedValue([
       task({ notePath: 'notes/a.md', markerOffset: 2, raw: '[ ] plan', text: 'plan', noteTitle: 'A' }),
       task({ notePath: 'notes/b.md', markerOffset: 2, raw: '[ ] ship', text: 'ship', noteTitle: 'B' }),
@@ -709,7 +732,7 @@ describe('TasksScreen', () => {
     const view = renderScreen()
 
     await view.findByText('plan')
-    await userEvent.keyboard('{Meta>}a{/Meta}') // select both (no editor)
+    await userEvent.keyboard('{Meta>}a{/Meta}') // select both (no editor mounts)
     await userEvent.click(view.getByRole('button', { name: /Convert to bullet \(2\)/ }))
 
     await waitFor(() => expect(convertTaskToBullet).toHaveBeenCalledTimes(2))
@@ -721,21 +744,63 @@ describe('TasksScreen', () => {
     view.unmount()
   })
 
-  it('converts the selection to bullets with ⌘⇧K', async () => {
+  it('converts a multi-selection to bullets with ⌘⇧K', async () => {
+    getOpenTasks.mockResolvedValue([
+      task({ notePath: 'notes/a.md', markerOffset: 2, raw: '[ ] plan', text: 'plan', noteTitle: 'A' }),
+      task({ notePath: 'notes/b.md', markerOffset: 2, raw: '[ ] ship', text: 'ship', noteTitle: 'B' }),
+    ])
+    const view = renderScreen()
+
+    await view.findByText('plan')
+    await userEvent.keyboard('{Meta>}a{/Meta}') // select both (no editor mounts)
+    await userEvent.keyboard('{Meta>}{Shift>}k{/Shift}{/Meta}')
+    await waitFor(() => expect(convertTaskToBullet).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(view.queryByText('plan')).toBeNull())
+    view.unmount()
+  })
+
+  it('converts a sole-edited row through its editor — saving the draft before converting', async () => {
+    // The toolbar button on the sole (edited) row routes through the editor so the
+    // unsaved draft is saved first, then the marker is stripped — the data-loss race
+    // Bugbot flagged (convert landing before the editor's commit) can't happen.
+    editTask.mockResolvedValue(undefined)
+    getOpenTasks.mockResolvedValue([
+      task({ notePath: 'notes/a.md', markerOffset: 2, raw: '[ ] plan', text: 'plan', noteTitle: 'A' }),
+    ])
+    const view = renderScreen()
+
+    await userEvent.click(await view.findByRole('button', { name: 'plan' })) // sole → editor mounts
+    await userEvent.click(view.getByRole('button', { name: /Convert to bullet \(1\)/ }))
+
+    // Edit first (persist the draft), then convert the rewritten line.
+    await waitFor(() =>
+      expect(editTask).toHaveBeenCalledWith(
+        expect.objectContaining({ notePath: 'notes/a.md', markerOffset: 2 }),
+        'edited content',
+        1,
+      ),
+    )
+    await waitFor(() =>
+      expect(convertTaskToBullet).toHaveBeenCalledWith(
+        expect.objectContaining({ markerOffset: 2, raw: '[ ] edited content' }),
+        1,
+      ),
+    )
+    await waitFor(() => expect(view.queryByText('plan')).toBeNull())
+    view.unmount()
+  })
+
+  it('converts an edited row from the editor’s own ⌘⇧K (save then convert)', async () => {
+    editTask.mockResolvedValue(undefined)
     getOpenTasks.mockResolvedValue([
       task({ notePath: 'notes/a.md', markerOffset: 2, raw: '[ ] plan', text: 'plan', noteTitle: 'A' }),
     ])
     const view = renderScreen()
 
     await userEvent.click(await view.findByRole('button', { name: 'plan' }))
-    await userEvent.keyboard('{Meta>}{Shift>}k{/Shift}{/Meta}')
-    await waitFor(() =>
-      expect(convertTaskToBullet).toHaveBeenCalledWith(
-        expect.objectContaining({ notePath: 'notes/a.md', markerOffset: 2 }),
-        1,
-      ),
-    )
-    await waitFor(() => expect(view.queryByText('plan')).toBeNull())
+    await userEvent.click(view.getByRole('button', { name: 'convert-edited' }))
+    await waitFor(() => expect(editTask).toHaveBeenCalledWith(expect.anything(), 'edited content', 1))
+    await waitFor(() => expect(convertTaskToBullet).toHaveBeenCalled())
     view.unmount()
   })
 

--- a/apps/desktop/src/components/tasks/tasks-screen.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.tsx
@@ -1,7 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Archive, CalendarClock, List, Search } from 'lucide-react'
-import { getCompletedTasks, getOpenTasks, groupTasks, hasBridge, type TaskGroup } from '@reflect/core'
+import {
+  getCompletedTasks,
+  getOpenTasks,
+  groupTasks,
+  hasBridge,
+  type OpenTask,
+  type TaskGroup,
+} from '@reflect/core'
 import { Input } from '@/components/ui/input'
 import { useRecentlyCompleted } from '@/lib/tasks/recently-completed'
 import { sameTask, taskKey } from '@/lib/tasks/task-identity'
@@ -156,26 +163,30 @@ export function TasksScreen(): ReactElement {
     },
     [actions, selection, scrollToKey],
   )
+  // The tasks behind the current selection's keys, in selection order — what the
+  // toolbar actions (schedule, convert) act on. A row whose key no longer
+  // resolves (pruned by a reindex) is dropped rather than acted on.
+  const selectedTasks = useCallback(
+    (): OpenTask[] =>
+      [...selection.selected]
+        .map((key) => tasksByKey.get(key))
+        .filter((task): task is OpenTask => task !== undefined),
+    [selection, tasksByKey],
+  )
   // Schedule the current selection (the calendar / ⌘⇧S), then deselect (V1).
   const onSchedule = useCallback(
     (isoDate: string | null) => {
-      const tasks = [...selection.selected]
-        .map((key) => tasksByKey.get(key))
-        .filter((task): task is NonNullable<typeof task> => task !== undefined)
-      actions.schedule(tasks, isoDate)
+      actions.schedule(selectedTasks(), isoDate)
       selection.clear()
     },
-    [actions, selection, tasksByKey],
+    [actions, selection, selectedTasks],
   )
   // Convert the current selection to plain bullets (the toolbar / ⌘⇧K): the rows
   // leave the Tasks view, so deselect after, like scheduling.
   const onConvertToBullet = useCallback(() => {
-    const tasks = [...selection.selected]
-      .map((key) => tasksByKey.get(key))
-      .filter((task): task is NonNullable<typeof task> => task !== undefined)
-    actions.convertToBullet(tasks)
+    actions.convertToBullet(selectedTasks())
     selection.clear()
-  }, [actions, selection, tasksByKey])
+  }, [actions, selection, selectedTasks])
   useTaskKeyboard({
     selection,
     actions,

--- a/apps/desktop/src/components/tasks/tasks-screen.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Archive, CalendarClock, Search } from 'lucide-react'
+import { Archive, CalendarClock, List, Search } from 'lucide-react'
 import { getCompletedTasks, getOpenTasks, groupTasks, hasBridge, type TaskGroup } from '@reflect/core'
 import { Input } from '@/components/ui/input'
 import { useRecentlyCompleted } from '@/lib/tasks/recently-completed'
@@ -167,6 +167,15 @@ export function TasksScreen(): ReactElement {
     },
     [actions, selection, tasksByKey],
   )
+  // Convert the current selection to plain bullets (the toolbar / ⌘⇧K): the rows
+  // leave the Tasks view, so deselect after, like scheduling.
+  const onConvertToBullet = useCallback(() => {
+    const tasks = [...selection.selected]
+      .map((key) => tasksByKey.get(key))
+      .filter((task): task is NonNullable<typeof task> => task !== undefined)
+    actions.convertToBullet(tasks)
+    selection.clear()
+  }, [actions, selection, tasksByKey])
   useTaskKeyboard({
     selection,
     actions,
@@ -179,6 +188,7 @@ export function TasksScreen(): ReactElement {
     scrollToKey,
     onToggleFilters: () => setFiltersOpen((open) => !open),
     onToggleSchedule: () => setScheduleOpen((open) => !open),
+    onConvertToBullet,
   })
 
   // Move focus into the Tasks surface on mount so the shortcuts work the moment
@@ -224,6 +234,17 @@ export function TasksScreen(): ReactElement {
               Schedule ({selection.selectedCount})
             </button>
           </TaskScheduleCalendar>
+        ) : null}
+        {selection.selectedCount > 0 ? (
+          <button
+            type="button"
+            onClick={onConvertToBullet}
+            title="Drop the checkbox, keeping the line as a plain bullet — leaves the Tasks list"
+            className="flex flex-none items-center gap-2 rounded-md px-2 py-1 text-sm text-text-muted transition-colors hover:text-text focus-visible:text-text focus-visible:outline-none"
+          >
+            <List aria-hidden className="size-4" />
+            Convert to bullet ({selection.selectedCount})
+          </button>
         ) : null}
         {recentlyCompleted.length > 0 ? (
           <button

--- a/apps/desktop/src/components/tasks/tasks-screen.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.tsx
@@ -183,10 +183,20 @@ export function TasksScreen(): ReactElement {
     [actions, selection, selectedTasks],
   )
   // Convert the current selection to plain bullets (the toolbar / ⌘⇧K): the rows
-  // leave the Tasks view, so deselect after, like scheduling.
+  // leave the Tasks view, so deselect after, like scheduling. When a single row is
+  // being inline-edited it holds a flush-then-convert trigger here — route through
+  // it so the unsaved draft is saved first, never written stale by the convert
+  // landing ahead of the editor's commit (the keyboard ⌘⇧K hits the editor's own
+  // keymap; this covers the toolbar button and an unfocused sole selection).
+  const convertControllerRef = useRef<(() => void) | null>(null)
   const onConvertToBullet = useCallback(() => {
-    actions.convertToBullet(selectedTasks())
-    selection.clear()
+    const convertEditing = convertControllerRef.current
+    if (convertEditing !== null) {
+      convertEditing()
+    } else {
+      actions.convertToBullet(selectedTasks())
+      selection.clear()
+    }
   }, [actions, selection, selectedTasks])
   useTaskKeyboard({
     selection,
@@ -291,6 +301,7 @@ export function TasksScreen(): ReactElement {
               editHandlers={editHandlers}
               today={today}
               onAdd={onAdd}
+              convertControllerRef={convertControllerRef}
               onOpen={(path) => navigate(routeForPath(path))}
             />
           ))

--- a/apps/desktop/src/editor/document-binding.test.ts
+++ b/apps/desktop/src/editor/document-binding.test.ts
@@ -36,6 +36,7 @@ function fakeSession(path: string) {
     commitTaskToggle: async () => false,
     commitTaskEdit: async () => false,
     commitTaskRemove: async () => false,
+    commitTaskToBullet: async () => false,
     dispose,
     discard,
   }

--- a/apps/desktop/src/editor/move-note.test.ts
+++ b/apps/desktop/src/editor/move-note.test.ts
@@ -40,6 +40,7 @@ function fakeSession(path: string) {
     commitTaskToggle: async () => false,
     commitTaskEdit: async () => false,
     commitTaskRemove: async () => false,
+    commitTaskToBullet: async () => false,
     dispose: () => {},
     discard: () => {},
   }

--- a/apps/desktop/src/editor/note-session.test.ts
+++ b/apps/desktop/src/editor/note-session.test.ts
@@ -877,3 +877,39 @@ describe('commitTaskRemove', () => {
     expect(h.applied.at(-1)).toBe('- [ ] x\n')
   })
 })
+
+describe('commitTaskToBullet', () => {
+  it('strips the marker to a plain bullet while preserving unsaved edits', async () => {
+    const source = '- [ ] buy milk\n- [ ] call mum\n'
+    const h = harness({ disk: source })
+    h.session.load()
+    await settled()
+
+    h.session.editorChanged('- [ ] buy milk\n- [ ] call mum\n\njot\n') // unsaved when it arrives
+    expect(await h.session.commitTaskToBullet(firstTask(source))).toBe(true)
+    expect(h.writes.at(-1)?.contents).toBe('- buy milk\n- [ ] call mum\n\njot\n')
+    expect(h.applied.at(-1)).toBe('- buy milk\n- [ ] call mum\n\njot\n')
+  })
+
+  it('drops a checked marker too', async () => {
+    const source = '- [x] done\n'
+    const h = harness({ disk: source })
+    h.session.load()
+    await settled()
+
+    expect(await h.session.commitTaskToBullet(firstTask(source))).toBe(true)
+    expect(h.writes.at(-1)?.contents).toBe('- done\n')
+  })
+
+  it('propagates TaskStaleError when the task line is gone', async () => {
+    const source = '- [ ] gone\n'
+    const h = harness({ disk: source })
+    h.session.load()
+    await settled()
+
+    h.session.editorChanged('- [ ] something else entirely\n')
+    await expect(h.session.commitTaskToBullet(firstTask(source))).rejects.toBeInstanceOf(
+      TaskStaleError,
+    )
+  })
+})

--- a/apps/desktop/src/editor/note-session.ts
+++ b/apps/desktop/src/editor/note-session.ts
@@ -4,6 +4,7 @@ import {
   isAppError,
   removeTaskLine,
   splitFrontmatter,
+  taskLineToBullet,
   toggleTaskMarker,
   upsertFrontmatter,
   type GistFrontmatter,
@@ -290,6 +291,14 @@ export interface NoteSession {
    * {@link commitTaskToggle}.
    */
   commitTaskRemove: (task: TaskMarker) => Promise<boolean>
+  /**
+   * Demote a task to a plain bullet from the Tasks view — the "Convert to bullet"
+   * path (Plan 18 follow-up). Strips just the marker from the line in the live
+   * buffer (keeping its content) so the item leaves the Tasks projection while
+   * staying in the note, then flushes now; same gating, `false`-when-busy,
+   * transactional revert, and `TaskStaleError` propagation as {@link commitTaskToggle}.
+   */
+  commitTaskToBullet: (task: TaskMarker) => Promise<boolean>
   /** Flush pending edits and detach: no further snapshots are emitted. */
   dispose: () => void
   /**
@@ -741,6 +750,10 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
     return commitBodyEdit((full) => removeTaskLine(full, task))
   }
 
+  function commitTaskToBullet(task: TaskMarker): Promise<boolean> {
+    return commitBodyEdit((full) => taskLineToBullet(full, task))
+  }
+
   function dispose(): void {
     // A discarded session must not write: its file is being deleted, and a
     // flush would recreate it. Otherwise flush first — the queued save step
@@ -778,6 +791,7 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
     commitTaskToggle,
     commitTaskEdit,
     commitTaskRemove,
+    commitTaskToBullet,
     dispose,
     discard,
   }

--- a/apps/desktop/src/editor/open-documents.test.ts
+++ b/apps/desktop/src/editor/open-documents.test.ts
@@ -21,6 +21,7 @@ function fakeSession(path: string, log: string[]): NoteSession {
     commitTaskToggle: async () => false,
     commitTaskEdit: async () => false,
     commitTaskRemove: async () => false,
+    commitTaskToBullet: async () => false,
     dispose: () => {},
     discard: () => {},
   }

--- a/apps/desktop/src/editor/rename-coordinator.test.ts
+++ b/apps/desktop/src/editor/rename-coordinator.test.ts
@@ -111,6 +111,7 @@ function fakeSession(content: string): NoteSession & {
     commitTaskToggle: async () => false,
     commitTaskEdit: async () => false,
     commitTaskRemove: async () => false,
+    commitTaskToBullet: async () => false,
     dispose: () => {},
     discard: () => {},
   }

--- a/apps/desktop/src/lib/note-task.test.ts
+++ b/apps/desktop/src/lib/note-task.test.ts
@@ -1,6 +1,6 @@
 import { TaskStaleError } from '@reflect/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { deleteTask, editTask, NoteBusyError, toggleTask } from './note-task'
+import { convertTaskToBullet, deleteTask, editTask, NoteBusyError, toggleTask } from './note-task'
 
 const openSession = vi.hoisted(() => vi.fn())
 vi.mock('@/editor/open-documents', () => ({ openSession }))
@@ -160,6 +160,39 @@ describe('deleteTask', () => {
   it('throws NoteBusyError when the session declines, never clobbering via disk', async () => {
     openSession.mockReturnValue({ commitTaskRemove: vi.fn().mockResolvedValue(false) })
     await expect(deleteTask(task, 7)).rejects.toBeInstanceOf(NoteBusyError)
+    expect(writeNote).not.toHaveBeenCalled()
+  })
+})
+
+describe('convertTaskToBullet', () => {
+  it('strips the marker to a plain bullet on disk when the note is not open', async () => {
+    openSession.mockReturnValue(null)
+    readNote.mockResolvedValue('- [ ] do it\n- [ ] keep\n')
+    writeNote.mockResolvedValue(undefined)
+
+    await convertTaskToBullet(task, 7)
+    expect(writeNote).toHaveBeenCalledWith('notes/a.md', '- do it\n- [ ] keep\n', 7)
+  })
+
+  it('routes through the live session when the note is open', async () => {
+    const commitTaskToBullet = vi.fn().mockResolvedValue(true)
+    openSession.mockReturnValue({ commitTaskToBullet })
+
+    await convertTaskToBullet(task, 7)
+    expect(commitTaskToBullet).toHaveBeenCalledWith({ markerOffset: 2, raw: '[ ] do it' })
+    expect(writeNote).not.toHaveBeenCalled()
+  })
+
+  it('throws NoteBusyError when the session declines, never clobbering via disk', async () => {
+    openSession.mockReturnValue({ commitTaskToBullet: vi.fn().mockResolvedValue(false) })
+    await expect(convertTaskToBullet(task, 7)).rejects.toBeInstanceOf(NoteBusyError)
+    expect(writeNote).not.toHaveBeenCalled()
+  })
+
+  it('propagates TaskStaleError from the disk path when the index is stale', async () => {
+    openSession.mockReturnValue(null)
+    readNote.mockResolvedValue('- [ ] something else entirely\n')
+    await expect(convertTaskToBullet(task, 7)).rejects.toBeInstanceOf(TaskStaleError)
     expect(writeNote).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/lib/note-task.ts
+++ b/apps/desktop/src/lib/note-task.ts
@@ -4,6 +4,7 @@ import {
   isAppError,
   readNote,
   removeTaskLine,
+  taskLineToBullet,
   toggleTaskMarker,
   writeNote,
   type TaskMarker,
@@ -128,6 +129,22 @@ export function deleteTask(task: TaskRef, generation: number): Promise<void> {
     generation,
     (owner, marker) => owner.commitTaskRemove(marker),
     (source, marker) => removeTaskLine(source, marker),
+  )
+}
+
+/**
+ * Demote a task to a plain bullet from the Tasks view — "Convert to bullet"
+ * (Plan 18 follow-up). Strips just the `[ ]`/`[x]` marker, keeping the bullet and
+ * content, so the item drops out of the Tasks projection while staying in the
+ * note. Routes session-or-disk and is guarded by the task's `raw` like its
+ * siblings.
+ */
+export function convertTaskToBullet(task: TaskRef, generation: number): Promise<void> {
+  return applyTaskChange(
+    task,
+    generation,
+    (owner, marker) => owner.commitTaskToBullet(marker),
+    (source, marker) => taskLineToBullet(source, marker),
   )
 }
 

--- a/apps/desktop/src/lib/tasks/use-task-actions.ts
+++ b/apps/desktop/src/lib/tasks/use-task-actions.ts
@@ -91,6 +91,14 @@ export interface TaskActions {
    * the Tasks view but stays in its note as an ordinary list item.
    */
   convertToBullet: (tasks: OpenTask[]) => void
+  /**
+   * Convert the inline-edited task to a bullet, saving its edit first (⌘⇧K while
+   * editing). The two writes run **sequentially** — edit then strip the marker
+   * from the rebuilt line — so the unsaved draft is never lost to the convert
+   * landing first; the convert is given the post-edit `raw`, like {@link
+   * editAndComplete}.
+   */
+  editAndConvertToBullet: (task: OpenTask, content: string) => void
   /** Archive (⌘⇧↵): stop showing the session's completed tasks in the active list. */
   archive: () => void
   isPending: boolean
@@ -274,6 +282,33 @@ export function useTaskActions(): TaskActions {
     },
   })
 
+  const editAndConvertMutation = useMutation({
+    mutationFn: async ({ task, content }: { task: OpenTask; content: string }) => {
+      const generation = graph?.generation
+      if (generation === undefined) {
+        throw new Error('No graph is open.')
+      }
+      // Edit, then strip the marker off the *rewritten* line — sequential, and the
+      // convert is given the post-edit `raw` so it locates the line the edit just
+      // wrote (the marker offset is unchanged; only the content after it moved).
+      // Saving first is what keeps the inline draft from being lost to the convert.
+      await editTask(task, content, generation)
+      await convertTaskToBullet({ ...task, raw: taskRawWithContent(task, content) }, generation)
+    },
+    onMutate: async ({ task }: { task: OpenTask; content: string }) => {
+      const snapshot = await cache.snapshot()
+      // The row leaves the view (it's no longer a checkbox) — same optimistic shape
+      // as a plain convert.
+      cache.patch(
+        (rows) => withoutTasks(rows, [task]),
+        (rows) => withoutTasks(rows, [task]),
+      )
+      forgetRecentlyCompleted(root, [taskKey(task)])
+      return snapshot
+    },
+    onError: (cause) => cache.reconcile('Converting task', cause),
+  })
+
   const insertMutation = useMutation({
     mutationFn: (target: InsertTaskTarget) => {
       const generation = graph?.generation
@@ -343,7 +378,8 @@ export function useTaskActions(): TaskActions {
       editAndCompleteMutation.isPending ||
       insertMutation.isPending ||
       scheduleMutation.isPending ||
-      convertMutation.isPending,
+      convertMutation.isPending ||
+      editAndConvertMutation.isPending,
     complete: (tasks) => {
       // ⌘↵ *completes*; with archived rows in the selection, toggling an
       // already-checked task would reopen it on disk. Only act on open rows.
@@ -432,6 +468,11 @@ export function useTaskActions(): TaskActions {
     convertToBullet: (tasks) => {
       if (tasks.length > 0 && graph?.generation !== undefined && !convertMutation.isPending) {
         convertMutation.mutate(tasks)
+      }
+    },
+    editAndConvertToBullet: (task, content) => {
+      if (graph?.generation !== undefined && !editAndConvertMutation.isPending) {
+        editAndConvertMutation.mutate({ task, content })
       }
     },
     archive: () => archiveRecentlyCompleted(root),

--- a/apps/desktop/src/lib/tasks/use-task-actions.ts
+++ b/apps/desktop/src/lib/tasks/use-task-actions.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query'
 import { clearTaskDueDate, setTaskDueDate, type OpenTask } from '@reflect/core'
-import { deleteTask, editTask, insertTask, toggleTask } from '@/lib/note-task'
+import { convertTaskToBullet, deleteTask, editTask, insertTask, toggleTask } from '@/lib/note-task'
 import { taskContent } from '@/lib/tasks/task-content'
 import {
   archiveRecentlyCompleted,
@@ -85,6 +85,12 @@ export interface TaskActions {
    * adds/replaces the `[[YYYY-MM-DD]]` link the projection reads as the due date.
    */
   schedule: (tasks: OpenTask[], isoDate: string | null) => void
+  /**
+   * Convert a selection to plain bullets (⌘⇧K, V1's "Convert to checklist"
+   * restated for markdown): strip each task's `[ ]`/`[x]` marker so it leaves
+   * the Tasks view but stays in its note as an ordinary list item.
+   */
+  convertToBullet: (tasks: OpenTask[]) => void
   /** Archive (⌘⇧↵): stop showing the session's completed tasks in the active list. */
   archive: () => void
   isPending: boolean
@@ -235,6 +241,39 @@ export function useTaskActions(): TaskActions {
     onError: (cause) => cache.reconcile('Scheduling tasks', cause),
   })
 
+  const convertMutation = useMutation({
+    mutationFn: async (tasks: OpenTask[]) => {
+      const generation = graph?.generation
+      if (generation === undefined) {
+        throw new Error('No graph is open.')
+      }
+      // Sequential, like the other batch writes — tasks can share a note, and the
+      // core edit relocates by `raw`, so a same-note batch tolerates offset drift.
+      for (const task of tasks) {
+        await convertTaskToBullet(task, generation)
+      }
+    },
+    onMutate: async (tasks: OpenTask[]) => {
+      const snapshot = await cache.snapshot()
+      // A converted task is no longer a checkbox, so it leaves both lists outright
+      // — same optimistic shape as a delete.
+      cache.patch(
+        (rows) => withoutTasks(rows, tasks),
+        (rows) => withoutTasks(rows, tasks),
+      )
+      // A converted task must not linger struck in the session's completed set.
+      forgetRecentlyCompleted(root, tasks.map(taskKey))
+      return snapshot
+    },
+    onError: (cause, tasks) => {
+      cache.reconcile('Converting tasks', cause)
+      // The convert dropped checked rows from the session's struck set; if it
+      // failed they're still `[x]` on disk, so restore them or they'd vanish from
+      // the default list (gone from open, struck-set, and the unloaded archived query).
+      markRecentlyCompleted(root, tasks.filter((task) => task.checked))
+    },
+  })
+
   const insertMutation = useMutation({
     mutationFn: (target: InsertTaskTarget) => {
       const generation = graph?.generation
@@ -303,7 +342,8 @@ export function useTaskActions(): TaskActions {
       editMutation.isPending ||
       editAndCompleteMutation.isPending ||
       insertMutation.isPending ||
-      scheduleMutation.isPending,
+      scheduleMutation.isPending ||
+      convertMutation.isPending,
     complete: (tasks) => {
       // ⌘↵ *completes*; with archived rows in the selection, toggling an
       // already-checked task would reopen it on disk. Only act on open rows.
@@ -387,6 +427,11 @@ export function useTaskActions(): TaskActions {
     schedule: (tasks, isoDate) => {
       if (tasks.length > 0 && graph?.generation !== undefined && !scheduleMutation.isPending) {
         scheduleMutation.mutate({ tasks, isoDate })
+      }
+    },
+    convertToBullet: (tasks) => {
+      if (tasks.length > 0 && graph?.generation !== undefined && !convertMutation.isPending) {
+        convertMutation.mutate(tasks)
       }
     },
     archive: () => archiveRecentlyCompleted(root),

--- a/apps/desktop/src/lib/tasks/use-task-editor-finalizer.test.ts
+++ b/apps/desktop/src/lib/tasks/use-task-editor-finalizer.test.ts
@@ -9,6 +9,7 @@ function setup(initial = 'milk') {
   const onDeleteEmpty = vi.fn()
   const onCancel = vi.fn()
   const onComplete = vi.fn()
+  const onConvertToBullet = vi.fn()
   const onFlush = vi.fn()
   const { result, unmount } = renderHook(() =>
     useTaskEditorFinalizer({
@@ -19,12 +20,25 @@ function setup(initial = 'milk') {
       onDeleteEmpty,
       onCancel,
       onComplete,
+      onConvertToBullet,
       onFlush,
     }),
   )
   const api = () => result.current.apiRef.current
   const type = (markdown: string) => result.current.onChange(markdown)
-  return { api, type, unmount, onCommit, onContinue, onDelete, onDeleteEmpty, onCancel, onComplete, onFlush }
+  return {
+    api,
+    type,
+    unmount,
+    onCommit,
+    onContinue,
+    onDelete,
+    onDeleteEmpty,
+    onCancel,
+    onComplete,
+    onConvertToBullet,
+    onFlush,
+  }
 }
 
 describe('useTaskEditorFinalizer', () => {
@@ -116,6 +130,23 @@ describe('useTaskEditorFinalizer', () => {
     expect(emptied.onComplete).not.toHaveBeenCalled()
   })
 
+  it('converts to a bullet: unchanged converts as-is, a change saves first, emptied deletes', () => {
+    const unchanged = setup('milk')
+    unchanged.api().convertToBullet()
+    expect(unchanged.onConvertToBullet).toHaveBeenCalledWith(null)
+
+    const changed = setup('milk')
+    changed.type('oat milk')
+    changed.api().convertToBullet()
+    expect(changed.onConvertToBullet).toHaveBeenCalledWith('oat milk')
+
+    const emptied = setup('milk')
+    emptied.type('   ')
+    emptied.api().convertToBullet()
+    expect(emptied.onDelete).toHaveBeenCalled()
+    expect(emptied.onConvertToBullet).not.toHaveBeenCalled()
+  })
+
   it('unmount persists a change via onFlush — never cancels/clears the new selection', () => {
     const changed = setup('milk')
     changed.type('oat milk')
@@ -161,6 +192,7 @@ describe('useTaskEditorFinalizer', () => {
           onDeleteEmpty: vi.fn(),
           onCancel: vi.fn(),
           onComplete: vi.fn(),
+          onConvertToBullet: vi.fn(),
           onFlush: props.onFlush,
         }),
       { initialProps: { onFlush: onFlushA } },

--- a/apps/desktop/src/lib/tasks/use-task-editor-finalizer.ts
+++ b/apps/desktop/src/lib/tasks/use-task-editor-finalizer.ts
@@ -13,6 +13,12 @@ export interface TaskEditorApi {
   cancel: () => void
   /** ⌘↵: save any change, then complete the task (or delete it if emptied). */
   complete: () => void
+  /**
+   * ⌘⇧K: save any change, then strip the marker so the task becomes a plain
+   * bullet and leaves the Tasks view (an emptied row is deleted instead). Saving
+   * first is what keeps the unsaved draft from being lost to the convert.
+   */
+  convertToBullet: () => void
   /** ⌘⌫: delete the task outright, discarding any pending edit. */
   delete: () => void
   /** Backspace on an empty row: delete it and select the previous task (V1). */
@@ -42,6 +48,12 @@ export interface TaskEditorFinalizerOptions {
    * changed it (save **and** complete), or `null` to complete the unchanged task.
    */
   onComplete: (content: string | null) => void
+  /**
+   * Convert the task to a plain bullet and exit (⌘⇧K). `content` is the new text
+   * when the edit changed it (save **and** convert), or `null` to convert the
+   * unchanged task as-is.
+   */
+  onConvertToBullet: (content: string | null) => void
   /**
    * Persist a changed edit **without** exiting edit mode — the row is unmounting
    * because the selection already moved elsewhere, so it must not clear it.
@@ -84,6 +96,7 @@ export function useTaskEditorFinalizer({
   onDeleteEmpty,
   onCancel,
   onComplete,
+  onConvertToBullet,
   onFlush,
 }: TaskEditorFinalizerOptions): TaskEditorFinalizer {
   const currentRef = useRef(initial)
@@ -96,6 +109,7 @@ export function useTaskEditorFinalizer({
     commitAndContinue: () => {},
     cancel: () => {},
     complete: () => {},
+    convertToBullet: () => {},
     delete: () => {},
     deleteEmpty: () => {},
     isEmpty: () => false,
@@ -182,6 +196,21 @@ export function useTaskEditorFinalizer({
           onComplete(result.content)
         } else {
           onComplete(null)
+        }
+      },
+      convertToBullet: () => {
+        if (!claim()) {
+          return
+        }
+        // Emptying then converting means delete (an empty bullet is just noise);
+        // an unchanged task converts as-is; otherwise save the new text and convert.
+        const result = resolveTaskEdit(initial, currentRef.current)
+        if (result.type === 'delete') {
+          onDelete()
+        } else if (result.type === 'commit') {
+          onConvertToBullet(result.content)
+        } else {
+          onConvertToBullet(null)
         }
       },
       delete: () => {

--- a/apps/desktop/src/lib/tasks/use-task-keyboard.test.ts
+++ b/apps/desktop/src/lib/tasks/use-task-keyboard.test.ts
@@ -50,6 +50,7 @@ function makeActions(over: Partial<TaskActions> = {}): TaskActions {
     editAndComplete: vi.fn(),
     schedule: vi.fn(),
     convertToBullet: vi.fn(),
+    editAndConvertToBullet: vi.fn(),
     archive: vi.fn(),
     isPending: false,
     ...over,
@@ -195,6 +196,19 @@ describe('useTaskKeyboard', () => {
     const selEvent = press(root, 'k', { metaKey: true, shiftKey: true })
     expect(withSel.onConvertToBullet).toHaveBeenCalledTimes(1)
     expect(selEvent.defaultPrevented).toBe(true)
+  })
+
+  it('backs off ⌘⇧K while the inline editor is focused (it handles convert itself)', () => {
+    const editor = document.createElement('div')
+    editor.setAttribute('data-task-editor', '')
+    root.appendChild(editor)
+    const selection = makeSelection({ selected: new Set(['k']), selectedCount: 1 })
+    const { onConvertToBullet } = mount({ selection, tasksByKey: new Map([['k', task()]]) })
+
+    press(editor, 'k', { metaKey: true, shiftKey: true })
+    // The editor's own keymap flushes the draft then converts — the screen handler
+    // must not also fire (that's the data-loss race Bugbot flagged).
+    expect(onConvertToBullet).not.toHaveBeenCalled()
   })
 
   it('plain ⌫ removes a single empty row and selects the previous (V1)', () => {

--- a/apps/desktop/src/lib/tasks/use-task-keyboard.test.ts
+++ b/apps/desktop/src/lib/tasks/use-task-keyboard.test.ts
@@ -49,6 +49,7 @@ function makeActions(over: Partial<TaskActions> = {}): TaskActions {
     insertAfter: vi.fn().mockResolvedValue(null),
     editAndComplete: vi.fn(),
     schedule: vi.fn(),
+    convertToBullet: vi.fn(),
     archive: vi.fn(),
     isPending: false,
     ...over,
@@ -81,6 +82,7 @@ function mount(options: {
   const scrollToKey = vi.fn()
   const onToggleFilters = vi.fn()
   const onToggleSchedule = vi.fn()
+  const onConvertToBullet = vi.fn()
   renderHook(() =>
     useTaskKeyboard({
       selection,
@@ -94,9 +96,10 @@ function mount(options: {
       scrollToKey,
       onToggleFilters,
       onToggleSchedule,
+      onConvertToBullet,
     }),
   )
-  return { selection, actions, setQuery, scrollToKey, onToggleFilters, onToggleSchedule }
+  return { selection, actions, setQuery, scrollToKey, onToggleFilters, onToggleSchedule, onConvertToBullet }
 }
 
 /** Let the `void insert(...).then(...)` microtask settle before asserting. */
@@ -179,6 +182,18 @@ describe('useTaskKeyboard', () => {
     const withSel = mount({ selection: makeSelection({ selectedCount: 2 }) })
     const selEvent = press(root, 's', { metaKey: true, shiftKey: true })
     expect(withSel.onToggleSchedule).toHaveBeenCalledTimes(1)
+    expect(selEvent.defaultPrevented).toBe(true)
+  })
+
+  it('converts the selection to bullets on ⌘⇧K only when something is selected', () => {
+    const withNone = mount({ selection: makeSelection({ selectedCount: 0 }) })
+    const noneEvent = press(root, 'k', { metaKey: true, shiftKey: true })
+    expect(withNone.onConvertToBullet).not.toHaveBeenCalled()
+    expect(noneEvent.defaultPrevented).toBe(false)
+
+    const withSel = mount({ selection: makeSelection({ selectedCount: 2 }) })
+    const selEvent = press(root, 'k', { metaKey: true, shiftKey: true })
+    expect(withSel.onConvertToBullet).toHaveBeenCalledTimes(1)
     expect(selEvent.defaultPrevented).toBe(true)
   })
 

--- a/apps/desktop/src/lib/tasks/use-task-keyboard.ts
+++ b/apps/desktop/src/lib/tasks/use-task-keyboard.ts
@@ -102,15 +102,6 @@ export function useTaskKeyboard({
         }
         return
       }
-      // ⌘⇧K converts the selection to plain bullets (V1's "Convert to checklist")
-      // — likewise a screen-level chord that fires only with a selection to act on.
-      if ((event.metaKey || event.ctrlKey) && event.shiftKey && (event.key === 'k' || event.key === 'K')) {
-        if (selection.selectedCount > 0) {
-          event.preventDefault()
-          onConvertToBullet()
-        }
-        return
-      }
       const target = event.target as HTMLElement | null
       // Focus outside the Tasks surface (the workspace sidebar, another panel) keeps
       // its own keys — only `body`/no-focus and elements inside the surface drive the
@@ -204,6 +195,15 @@ export function useTaskKeyboard({
       } else if (mod && (event.key === 'a' || event.key === 'A')) {
         event.preventDefault()
         selection.selectAll()
+      } else if (mod && event.shiftKey && (event.key === 'k' || event.key === 'K')) {
+        // ⌘⇧K converts the selection to plain bullets (V1's "Convert to checklist").
+        // Below the OWNS_KEYS bail on purpose: while the inline editor is focused it
+        // handles ⌘⇧K itself (flush the draft, then convert), so this fires only for a
+        // multi-selection or an unfocused single selection — never racing a live draft.
+        if (selection.selectedCount > 0) {
+          event.preventDefault()
+          onConvertToBullet()
+        }
       } else if (event.key === 'ArrowDown') {
         event.preventDefault()
         if (event.shiftKey) {

--- a/apps/desktop/src/lib/tasks/use-task-keyboard.ts
+++ b/apps/desktop/src/lib/tasks/use-task-keyboard.ts
@@ -29,6 +29,8 @@ export interface TaskKeyboardOptions {
   onToggleFilters: () => void
   /** ⌘⇧S: open/close the schedule calendar for the selection (V1). */
   onToggleSchedule: () => void
+  /** ⌘⇧K: convert the selection to plain bullets (V1's "Convert to checklist"). */
+  onConvertToBullet: () => void
 }
 
 /** Elements that own their own keyboard nav — the shortcuts back off entirely. */
@@ -44,8 +46,9 @@ const OWNS_KEYS = '[data-task-editor], [role="menu"], [role="dialog"], [role="li
  * The map: Return adds a task (to the selected task's note, else today's daily),
  * ⌘A select all, ↑/↓ move a single selection (Shift to extend the range), ⌘↵
  * complete the selection, ⌘⇧↵ archive (stop showing the session's completed
- * tasks), ⌘⌫ delete (plain ⌫ deletes only empty rows, so a stray Backspace can't
- * lose content), Esc clears the selection then the search box.
+ * tasks), ⌘⇧K convert the selection to plain bullets (drop the checkbox), ⌘⌫
+ * delete (plain ⌫ deletes only empty rows, so a stray Backspace can't lose
+ * content), Esc clears the selection then the search box.
  *
  * Scoping: the listener is on `document` (so the shortcuts work the moment you're
  * on Tasks, no click needed — the screen focuses its surface on mount), but backs
@@ -72,6 +75,7 @@ export function useTaskKeyboard({
   scrollToKey,
   onToggleFilters,
   onToggleSchedule,
+  onConvertToBullet,
 }: TaskKeyboardOptions): void {
   const handlerRef = useRef<(event: KeyboardEvent) => void>(() => {})
   useEffect(() => {
@@ -95,6 +99,15 @@ export function useTaskKeyboard({
         if (selection.selectedCount > 0) {
           event.preventDefault()
           onToggleSchedule()
+        }
+        return
+      }
+      // ⌘⇧K converts the selection to plain bullets (V1's "Convert to checklist")
+      // — likewise a screen-level chord that fires only with a selection to act on.
+      if ((event.metaKey || event.ctrlKey) && event.shiftKey && (event.key === 'k' || event.key === 'K')) {
+        if (selection.selectedCount > 0) {
+          event.preventDefault()
+          onConvertToBullet()
         }
         return
       }

--- a/apps/desktop/src/lib/tasks/use-task-row-handlers.ts
+++ b/apps/desktop/src/lib/tasks/use-task-row-handlers.ts
@@ -14,6 +14,7 @@ export interface TaskRowEditHandlers {
   onEditDeleteEmpty: () => void
   onEditCancel: () => void
   onEditComplete: (content: string | null) => void
+  onEditConvertToBullet: (content: string | null) => void
   onEditFlush: (content: string) => void
   onEditNavigate: TaskNavigate
 }
@@ -110,6 +111,18 @@ export function useTaskRowHandlers({
           actions.complete([task])
         } else {
           actions.editAndComplete(task, content)
+        }
+        selection.clear()
+      },
+      onEditConvertToBullet: (content) => {
+        // ⌘⇧K while editing (or the toolbar button on the sole row): convert to a
+        // bullet, saving the edit first when it changed (V1 muscle memory). An
+        // emptied row took the delete path in the finalizer, so `content` is the
+        // new text or null (unchanged) here.
+        if (content === null) {
+          actions.convertToBullet([task])
+        } else {
+          actions.editAndConvertToBullet(task, content)
         }
         selection.clear()
       },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -361,6 +361,7 @@ export {
   renameWikiLink,
   setTaskDueDate,
   clearTaskDueDate,
+  taskLineToBullet,
   toggleTaskMarker,
   TaskStaleError,
   resolved,

--- a/packages/core/src/markdown/edit.test.ts
+++ b/packages/core/src/markdown/edit.test.ts
@@ -9,6 +9,7 @@ import {
   removeTaskLine,
   renameWikiLink,
   setTaskDueDate,
+  taskLineToBullet,
   TaskStaleError,
   toggleTaskMarker,
 } from './edit'
@@ -330,5 +331,53 @@ describe('removeTaskLine', () => {
   it('refuses loudly when the task line is gone', () => {
     const task = indexedTask('- [ ] buy milk\n')
     expect(() => removeTaskLine('- [ ] something else\n', task)).toThrow(TaskStaleError)
+  })
+})
+
+describe('taskLineToBullet', () => {
+  function indexedTask(source: string, index = 0) {
+    const task = parseNote({ path: 'notes/n.md', source }).tasks[index]
+    return { markerOffset: task.markerOffset, raw: task.raw }
+  }
+
+  it('drops the marker, leaving the bullet and content', () => {
+    const source = '- [ ] buy milk\n'
+    expect(taskLineToBullet(source, indexedTask(source))).toBe('- buy milk\n')
+  })
+
+  it('drops a checked marker too', () => {
+    const source = '- [x] done\n'
+    expect(taskLineToBullet(source, indexedTask(source))).toBe('- done\n')
+  })
+
+  it('preserves the bullet character and indentation', () => {
+    const source = '  * [ ] sub\n'
+    expect(taskLineToBullet(source, indexedTask(source))).toBe('  * sub\n')
+  })
+
+  it('collapses an empty task to a bare bullet', () => {
+    const source = '- [ ] \n'
+    expect(taskLineToBullet(source, indexedTask(source))).toBe('- \n')
+  })
+
+  it('keeps wiki links and tags in the content', () => {
+    const source = '- [ ] ship [[2026-07-01]] #release\n'
+    expect(taskLineToBullet(source, indexedTask(source))).toBe('- ship [[2026-07-01]] #release\n')
+  })
+
+  it('converts a middle task, leaving its neighbours as tasks', () => {
+    const source = '- [ ] a\n- [ ] b\n- [ ] c\n'
+    expect(taskLineToBullet(source, indexedTask(source, 1))).toBe('- [ ] a\n- b\n- [ ] c\n')
+  })
+
+  it('relocates by raw when an edit above drifts the offset', () => {
+    const source = '- [ ] buy milk\n'
+    const stale = indexedTask(source)
+    expect(taskLineToBullet(`Intro.\n\n${source}`, stale)).toBe('Intro.\n\n- buy milk\n')
+  })
+
+  it('refuses loudly when the task line is gone', () => {
+    const task = indexedTask('- [ ] buy milk\n')
+    expect(() => taskLineToBullet('- [ ] something else\n', task)).toThrow(TaskStaleError)
   })
 })

--- a/packages/core/src/markdown/edit.ts
+++ b/packages/core/src/markdown/edit.ts
@@ -131,6 +131,35 @@ export function appendTaskLine(source: string): { source: string; markerOffset: 
 }
 
 /**
+ * Demote a task back to a plain bullet by removing exactly its `[ ]`/`[x]` marker
+ * and the run of horizontal whitespace after it — `- [ ] text` becomes `- text`,
+ * the list bullet, indentation, and content all untouched. This is the Tasks
+ * view's "Convert to bullet" (Plan 18 follow-up): a GFM checkbox is the only
+ * thing the projection treats as a task, so dropping the marker lifts the item
+ * out of the Tasks view while keeping it in the note as ordinary markdown — no
+ * invented syntax, unlike a per-item checklist flag. Located by {@link
+ * locateTaskMarker}, the same staleness guard the toggle uses, so a drifted or
+ * ambiguous line — or a position that no longer holds a marker — refuses loudly
+ * with {@link TaskStaleError} rather than rewriting the wrong line. An empty task
+ * (`- [ ] `) collapses to a bare bullet (`- `).
+ */
+export function taskLineToBullet(source: string, task: TaskMarker): string {
+  const offset = locateTaskMarker(source, task.markerOffset, task.raw)
+  const marker = source.slice(offset, offset + 3)
+  if (parseTaskMarker(marker) === null) {
+    throw new TaskStaleError(`no task marker at offset ${offset}: ${JSON.stringify(marker)}`)
+  }
+  let contentStart = offset + 3
+  while (
+    contentStart < source.length &&
+    (source[contentStart] === ' ' || source[contentStart] === '\t')
+  ) {
+    contentStart += 1
+  }
+  return source.slice(0, offset) + source.slice(contentStart)
+}
+
+/**
  * Schedule a task by setting its due date to `isoDate` (a `YYYY-MM-DD`), working
  * on the task's **content** — the markdown after the marker. A task's due date is
  * the first calendar-valid `[[YYYY-MM-DD]]` link inside it (the same rule the

--- a/packages/core/src/markdown/index.ts
+++ b/packages/core/src/markdown/index.ts
@@ -45,6 +45,7 @@ export {
   renameWikiLink,
   setTaskDueDate,
   clearTaskDueDate,
+  taskLineToBullet,
   toggleTaskMarker,
   TaskStaleError,
 } from './edit'


### PR DESCRIPTION
## What

Adds a **"Convert to bullet"** action to the Tasks page (Plan 18 follow-up). Select one or more tasks and either click the **"Convert to bullet (N)"** toolbar button (next to *Schedule*) or press **⌘⇧K** — each selected task's checkbox is dropped, turning `- [ ] buy milk` into `- buy milk`. The rows leave the Tasks view immediately and the lines remain in their notes as ordinary bullets. Works on checked/archived rows too.

## Why

This is the V2 port of V1's Tasks-page "Convert to checklist" button.

V1 used a `kind: task | checklist` attribute (both render as checkboxes; checklists just don't aggregate into Tasks). V2 has no per-item task/checklist distinction — **every GFM checkbox is a task** — and [Plan 18](docs/plans/18-tasks.md) deliberately rejected per-item opt-out as "invented syntax", mapping checklists to a note-level `checklist: true` flag that was ultimately **dropped** and never built.

Rather than resurrect that flag (which would convert a task's *entire note* — a footgun for daily notes with many tasks), this demotes the selected task(s) to a plain bullet. That is per-item (matching V1's granularity), pure standard markdown (no invented syntax), and naturally removes them from the view because a checkbox is the only thing the projection treats as a task.

## How

Mirrors the existing toggle/edit/delete chain end-to-end:

- **Core** — `taskLineToBullet(source, task)` in `markdown/edit.ts`: strips the 3-char marker + following horizontal whitespace, keeping the bullet/indent/content; guarded by `locateTaskMarker`/`TaskStaleError` like its siblings. Exported through both `@reflect/core` barrels.
- **Session** — `commitTaskToBullet` on `NoteSession` (thin `commitBodyEdit` wrapper) so an open note edits its live buffer.
- **Bridge** — `convertTaskToBullet` in `lib/note-task.ts` (session-or-disk via `applyTaskChange`, serialized per path, `raw`-guarded).
- **Action** — `convertMutation` + `convertToBullet` in `use-task-actions.ts`: optimistic `withoutTasks` on both lists, mirroring `deleteMutation`'s struck-row/`recently-completed` handling.
- **UI** — "Convert to bullet (N)" toolbar button (`List` icon) shown when a selection exists; **⌘⇧K** screen-level chord in `use-task-keyboard.ts` (V1's `Mod+Shift+K`), fires only with a selection.

No schema/migration/Rust changes.

## Reviewer notes

- Adding `commitTaskToBullet` to the `NoteSession` interface required updating the 4 fake-session test objects (document-binding/move-note/open-documents/rename-coordinator).
- Tests added at every layer: core primitive (`edit.test.ts`), bridge (`note-task.test.ts`), session (`note-session.test.ts`), keyboard (`use-task-keyboard.test.ts`), and a screen integration test for both the button and ⌘⇧K (`tasks-screen.test.tsx`).
- `pnpm typecheck` clean; `pnpm lint` 0 errors (the 4 warnings are pre-existing React-Compiler notices in untouched files); all targeted tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches note markdown writes and the live session buffer (same paths as task edit/delete); behavior is guarded by `TaskStaleError` and mirrors proven task mutations, but multi-note batch converts can still affect user data.
> 
> **Overview**
> Adds **Convert to bullet** on the Tasks page so selected checkbox lines lose their `[ ]`/`[x]` marker and stay in the note as plain list items, which removes them from the Tasks projection.
> 
> The change is wired like existing task writes: core `taskLineToBullet`, `commitTaskToBullet` on open notes, `convertTaskToBullet` on disk/session, and optimistic cache updates in `use-task-actions`. The toolbar shows **Convert to bullet (N)** when rows are selected; **⌘⇧K** works at the screen level and inside the inline editor.
> 
> While a single row is being edited, a shared `convertControllerRef` routes the toolbar through the editor’s flush-then-convert path so unsaved drafts are saved before the marker is stripped, avoiding a race with bulk convert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc658cab02da0df4d25ba2fda223dad6ce2b1536. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->