### PR TITLE
Harden TypeScript strictness + enforce conventions via oxlint

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["typescript", "import"],
+  "rules": {
+    "typescript/no-explicit-any": "error",
+    "import/no-default-export": "error",
+    "import/no-namespace": "error"
+  },
+  "overrides": [
+    {
+      "files": ["**/*.config.{ts,js,mjs}", "apps/extension/entrypoints/**"],
+      "rules": {
+        "import/no-default-export": "off"
+      }
+    },
+    {
+      "files": ["apps/desktop/src/components/ui/**", "**/scripts/**"],
+      "rules": {
+        "import/no-namespace": "off"
+      }
+    }
+  ]
+}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -21,7 +21,7 @@
       }
     },
     {
-      "files": ["**/*.test.{ts,tsx}", "**/*.spec.{ts,tsx}"],
+      "files": ["**/*.test.{ts,tsx}", "**/*.spec.{ts,tsx}", "**/scripts/**"],
       "rules": {
         "eslint/max-lines": "off"
       }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -4,7 +4,8 @@
   "rules": {
     "typescript/no-explicit-any": "error",
     "import/no-default-export": "error",
-    "import/no-namespace": "error"
+    "import/no-namespace": "error",
+    "eslint/max-lines": ["warn", 500]
   },
   "overrides": [
     {
@@ -17,6 +18,12 @@
       "files": ["apps/desktop/src/components/ui/**", "**/scripts/**"],
       "rules": {
         "import/no-namespace": "off"
+      }
+    },
+    {
+      "files": ["**/*.test.{ts,tsx}", "**/*.spec.{ts,tsx}"],
+      "rules": {
+        "eslint/max-lines": "off"
       }
     }
   ]

--- a/apps/desktop/src/components/all-notes/all-notes-screen.test.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.test.tsx
@@ -102,8 +102,8 @@ beforeEach(() => {
     if (command !== 'db_query') {
       return null
     }
-    const sql = String(args.sql)
-    const params = args.params as unknown[]
+    const sql = String(args['sql'])
+    const params = args['params'] as unknown[]
     if (sql.includes('group by')) {
       return facetRows
     }
@@ -180,7 +180,7 @@ describe('AllNotesScreen', () => {
       if (command !== 'db_query') {
         return null
       }
-      const sql = String(args.sql)
+      const sql = String(args['sql'])
       if (sql.includes('group by')) {
         return facetRows
       }
@@ -283,7 +283,7 @@ describe('AllNotesScreen', () => {
       if (command !== 'db_query') {
         return null
       }
-      const sql = String(args.sql)
+      const sql = String(args['sql'])
       if (sql.includes('"preview"')) {
         return many
       }

--- a/apps/desktop/src/components/all-notes/all-notes-table.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-table.tsx
@@ -64,7 +64,7 @@ export function AllNotesTable({
       ) : (
         <ul className="relative" style={{ height: virtualizer.getTotalSize() }}>
           {virtualizer.getVirtualItems().map((item) => {
-            const note = rows[item.index]
+            const note = rows[item.index]!
             return (
               <li
                 key={note.path}

--- a/apps/desktop/src/components/backlinks-panel.test.tsx
+++ b/apps/desktop/src/components/backlinks-panel.test.tsx
@@ -185,9 +185,9 @@ describe('BacklinksPanel', () => {
     )
     const headers = view.getAllByRole('button', { name: /Incoming backlink \(1\)/ })
 
-    await userEvent.click(headers[0])
-    expect(headers[0].getAttribute('aria-expanded')).toBe('false')
-    expect(headers[1].getAttribute('aria-expanded')).toBe('false')
+    await userEvent.click(headers[0]!)
+    expect(headers[0]!.getAttribute('aria-expanded')).toBe('false')
+    expect(headers[1]!.getAttribute('aria-expanded')).toBe('false')
     expect(view.queryByText('discussed [[Roadmap]] follow-ups')).toBeNull()
     view.unmount()
   })

--- a/apps/desktop/src/components/chat/chat-screen.test.tsx
+++ b/apps/desktop/src/components/chat/chat-screen.test.tsx
@@ -91,7 +91,7 @@ vi.mock('@/editor/markdown-preview', () => ({
     onWikiLinkClick?: (target: string) => void
   }) => {
     const wikiTargets = Array.from(content.matchAll(/\[\[([^\]|]+)(?:\|[^\]]*)?\]\]/g)).map(
-      (match) => match[1],
+      (match) => match[1]!,
     )
     return (
       <div data-testid="markdown-preview">

--- a/apps/desktop/src/components/command-palette/command-palette.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.tsx
@@ -87,7 +87,7 @@ export function CommandPalette({ context }: CommandPaletteProps): ReactElement |
     const notes = notesRef.current
     if (notes.length > 0) {
       if (!notes.some((entry) => entry.path === selectedValueRef.current)) {
-        setSelectedValue(notes[0].path)
+        setSelectedValue(notes[0]!.path)
       }
     } else if (!selectedValueRef.current.startsWith('command:')) {
       setSelectedValue('')

--- a/apps/desktop/src/components/command-palette/entries.test.ts
+++ b/apps/desktop/src/components/command-palette/entries.test.ts
@@ -69,8 +69,8 @@ describe('buildPaletteSections', () => {
       hits: [hit('notes/a.md', 'Alpha'), hit('notes/b.md', 'Beta', 'about alpha')],
     })
     expect(result.notes.map((note) => note.path)).toEqual(['notes/a.md', 'notes/b.md'])
-    expect(result.notes[0].snippet).toBeNull() // the title form won
-    expect(result.notes[1].snippet).toContain('alpha')
+    expect(result.notes[0]!.snippet).toBeNull() // the title form won
+    expect(result.notes[1]!.snippet).toContain('alpha')
   })
 
   it('a daily body hit keeps its day label in the merge', () => {
@@ -78,7 +78,7 @@ describe('buildPaletteSections', () => {
       query: 'standup',
       hits: [hit('daily/2026-06-05.md', '2026-06-05', 'standup notes', '2026-06-05')],
     })
-    expect(result.notes[0].date).toBe('2026-06-05')
+    expect(result.notes[0]!.date).toBe('2026-06-05')
   })
 
   it('a not-yet-created daily (pathless suggestion) is still jumpable', () => {
@@ -121,7 +121,7 @@ describe('buildPaletteSections', () => {
       commands: COMMANDS,
     })
     expect(result.notes.map((note) => note.path)).toEqual(['daily/2026-06-08.md', 'notes/w.md'])
-    expect(result.notes[0].date).toBe('2026-06-08')
+    expect(result.notes[0]!.date).toBe('2026-06-08')
     expect(result.commands).toEqual([])
   })
 
@@ -177,6 +177,6 @@ describe('buildPaletteSections', () => {
         },
       ],
     })
-    expect(result.notes[0].date).toBe('2026-06-09')
+    expect(result.notes[0]!.date).toBe('2026-06-09')
   })
 })

--- a/apps/desktop/src/components/context-sidebar/day-calendar.tsx
+++ b/apps/desktop/src/components/context-sidebar/day-calendar.tsx
@@ -125,7 +125,7 @@ export function DayCalendar({ selectedDate, today }: DayCalendarProps): ReactEle
 
         <div className="px-4 py-2">
           {grid.weeks.map((week) => (
-            <div key={week[0].date} className="grid grid-cols-7 text-center">
+            <div key={week[0]!.date} className="grid grid-cols-7 text-center">
               {week.map((cell) => {
                 const isSelected = cell.date === selectedDate
                 const isToday = cell.date === today

--- a/apps/desktop/src/components/daily-stream.test.tsx
+++ b/apps/desktop/src/components/daily-stream.test.tsx
@@ -123,7 +123,7 @@ describe('DailyStream', () => {
 
     const expected = indexOfDate(createDayWindow(today), today) * ESTIMATED_DAY_HEIGHT
     expect(scrollToSpy.mock.calls.length).toBeGreaterThan(0)
-    expect(scrollToSpy.mock.calls[0][0]).toMatchObject({ top: expected })
+    expect(scrollToSpy.mock.calls[0]![0]).toMatchObject({ top: expected })
     view.unmount()
   })
 
@@ -143,7 +143,7 @@ describe('DailyStream', () => {
     )
 
     expect(scrollToSpy.mock.calls.length).toBeGreaterThan(0)
-    expect(scrollToSpy.mock.calls[0][0]).toMatchObject({ top: 4321 })
+    expect(scrollToSpy.mock.calls[0]![0]).toMatchObject({ top: 4321 })
     view.unmount()
   })
 
@@ -174,7 +174,7 @@ describe('DailyStream', () => {
 
     const expected = indexOfDate(createDayWindow(today), today) * ESTIMATED_DAY_HEIGHT
     expect(commandsDuringLayout).toBeGreaterThanOrEqual(2)
-    expect(scrollToSpy.mock.calls[commandsDuringLayout - 1][0]).toMatchObject({ top: expected })
+    expect(scrollToSpy.mock.calls[commandsDuringLayout - 1]![0]).toMatchObject({ top: expected })
     view.unmount()
   })
 

--- a/apps/desktop/src/components/graph-chooser.test.tsx
+++ b/apps/desktop/src/components/graph-chooser.test.tsx
@@ -42,10 +42,10 @@ beforeEach(() => {
         case 'recent_graphs':
           return recents
         case 'forget_recent':
-          recents = recents.filter((recent) => recent.root !== args.root)
+          recents = recents.filter((recent) => recent.root !== args['root'])
           return null
         case 'graph_open':
-          return { root: String(args.path), name: 'work', cloudSync: null, generation: 1 }
+          return { root: String(args['path']), name: 'work', cloudSync: null, generation: 1 }
         case 'index_open':
           return 1
         case 'list_files':

--- a/apps/desktop/src/components/graph-swatch.tsx
+++ b/apps/desktop/src/components/graph-swatch.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils'
 
 interface GraphSwatchProps {
   /** The graph's chosen color; `undefined` renders the default (app accent). */
-  color?: GraphColor
+  color?: GraphColor | undefined
   /** Size (and shape overrides) — the swatch has no intrinsic dimensions. */
   className?: string
 }

--- a/apps/desktop/src/components/inline-alert.tsx
+++ b/apps/desktop/src/components/inline-alert.tsx
@@ -12,7 +12,7 @@ const TONE_CLASSES: Record<InlineAlertTone, string> = {
 interface InlineAlertProps {
   tone?: InlineAlertTone
   children: ReactNode
-  className?: string
+  className?: string | undefined
 }
 
 /**

--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -85,7 +85,6 @@ export function NotePane({
   if (needsSeed && seed.path !== path) {
     setSeed({ path, seed: untitledNoteSeed() })
   }
-  const missingSeed = needsSeed ? seed.seed : undefined
   const document = useNoteDocument(path, generation, {
     createIfMissing: lazy,
     // Daily notes are excluded from rename tracking: their date labels are
@@ -96,7 +95,7 @@ export function NotePane({
     // caret lands in, ghosted "Untitled" by the title placeholder — only
     // reaches disk if the user edits, and typing names the note. Daily
     // notes stay unseeded — the date is their identity.
-    missingSeed,
+    ...(needsSeed ? { missingSeed: seed.seed } : {}),
   })
   const {
     resolveImageUrl,
@@ -220,7 +219,7 @@ export function NotePane({
         onTagSearch={onTagSearch}
         // Daily notes carry no title semantics (the date is their subject),
         // so an empty leading H1 there is just an empty heading.
-        titlePlaceholder={dailyNote ? undefined : 'Untitled'}
+        {...(dailyNote ? {} : { titlePlaceholder: 'Untitled' })}
         className={cn(gutterClassName, editorClassName)}
         handleRef={handleRef}
       />

--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -45,7 +45,7 @@ function installFakeBridge(): void {
         case 'settings_load':
           return stored
         case 'settings_save':
-          saved.push(args.settings)
+          saved.push(args['settings'])
           return null
         case 'embed_status':
         case 'embed_ensure':

--- a/apps/desktop/src/components/settings/add-ai-provider-dialog.tsx
+++ b/apps/desktop/src/components/settings/add-ai-provider-dialog.tsx
@@ -57,8 +57,8 @@ const FIELD_LABEL_CLASS = 'text-xs font-medium text-text-secondary'
 export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps): ReactElement {
   const { register, handleSubmit, watch, setValue, formState } = useForm<AddAiProviderForm>({
     defaultValues: {
-      provider: AI_PROVIDERS[0].id,
-      model: AI_PROVIDERS[0].models[0].id,
+      provider: AI_PROVIDERS[0]!.id,
+      model: AI_PROVIDERS[0]!.models[0]!.id,
       apiKey: '',
       isDefault: false,
     },
@@ -133,7 +133,7 @@ export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps
               onValueChange={(value) => {
                 const next = aiProvider(aiProviderIdSchema.parse(value))
                 setValue('provider', next.id)
-                setValue('model', next.models[0].id)
+                setValue('model', next.models[0]!.id)
                 setUnverified(false)
               }}
             >

--- a/apps/desktop/src/components/settings/add-ai-provider-dialog.tsx
+++ b/apps/desktop/src/components/settings/add-ai-provider-dialog.tsx
@@ -57,8 +57,8 @@ const FIELD_LABEL_CLASS = 'text-xs font-medium text-text-secondary'
 export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps): ReactElement {
   const { register, handleSubmit, watch, setValue, formState } = useForm<AddAiProviderForm>({
     defaultValues: {
-      provider: AI_PROVIDERS[0]!.id,
-      model: AI_PROVIDERS[0]!.models[0]!.id,
+      provider: AI_PROVIDERS[0].id,
+      model: AI_PROVIDERS[0].models[0].id,
       apiKey: '',
       isDefault: false,
     },
@@ -133,7 +133,7 @@ export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps
               onValueChange={(value) => {
                 const next = aiProvider(aiProviderIdSchema.parse(value))
                 setValue('provider', next.id)
-                setValue('model', next.models[0]!.id)
+                setValue('model', next.models[0].id)
                 setUnverified(false)
               }}
             >

--- a/apps/desktop/src/components/settings/ai-providers-section.test.tsx
+++ b/apps/desktop/src/components/settings/ai-providers-section.test.tsx
@@ -43,16 +43,16 @@ function installFakeBridge(): void {
           }
           return stored
         case 'settings_save':
-          saved.push(args.settings)
+          saved.push(args['settings'])
           return null
         case 'secret_set':
           if (failSecretSet) {
             throw { kind: 'io', message: 'keychain locked' }
           }
-          secrets.set(args.name as string, args.value as string)
+          secrets.set(args['name'] as string, args['value'] as string)
           return null
         case 'secret_delete':
-          secrets.delete(args.name as string)
+          secrets.delete(args['name'] as string)
           return null
         default:
           return null
@@ -162,14 +162,14 @@ describe('AiProvidersSection', () => {
       keyHint: 'wxyz1',
     })
     // The first entry becomes the default automatically.
-    expect(doc.defaultAiProviderId).toBe(added.id)
+    expect(doc.defaultAiProviderId).toBe(added!.id)
     // The key was verified against the provider before being stored.
     expect(providerFetchMock).toHaveBeenCalledWith(
       'https://api.anthropic.com/v1/models',
       expect.objectContaining({ method: 'GET' }),
     )
     // The full key reached the keychain (and only the keychain).
-    expect(secrets.get(`ai-api-key:${added.id}`)).toBe('sk-ant-test-wxyz1')
+    expect(secrets.get(`ai-api-key:${added!.id}`)).toBe('sk-ant-test-wxyz1')
     expect(JSON.stringify(saved)).not.toContain('sk-ant-test-wxyz1')
     expect(screen.queryByRole('dialog')).toBeNull()
   })

--- a/apps/desktop/src/components/settings/github-auth-step.test.tsx
+++ b/apps/desktop/src/components/settings/github-auth-step.test.tsx
@@ -59,12 +59,12 @@ function fakeKeychain(initial: Record<string, string> = {}) {
   const store = new Map(Object.entries(initial))
   setBridge({
     invoke: async (command, args) => {
-      const name = args.name as string
+      const name = args['name'] as string
       if (command === 'secret_get') {
         return store.get(name) ?? null
       }
       if (command === 'secret_set') {
-        store.set(name, args.value as string)
+        store.set(name, args['value'] as string)
         return null
       }
       if (command === 'secret_delete') {
@@ -222,8 +222,8 @@ describe('GithubAuthStep', () => {
       expect(openedUrls).toHaveBeenCalledWith('https://github.com/login/device'),
     )
     expect(writeText).toHaveBeenCalledWith('ABCD-1234')
-    expect(writeText.mock.invocationCallOrder[0]).toBeLessThan(
-      openedUrls.mock.invocationCallOrder[0],
+    expect(writeText.mock.invocationCallOrder[0]!).toBeLessThan(
+      openedUrls.mock.invocationCallOrder[0]!,
     )
     expect(await screen.findByText(/code copied/i)).toBeTruthy()
   })

--- a/apps/desktop/src/components/settings/github-auth-step.tsx
+++ b/apps/desktop/src/components/settings/github-auth-step.tsx
@@ -21,7 +21,7 @@ interface GithubAuthStepProps {
    * already knows it — the instructions name it instead of speaking
    * abstractly about "your backup repository".
    */
-  repoName?: string
+  repoName?: string | undefined
 }
 
 const FIELD_LABEL_CLASS = 'text-xs font-medium text-text-secondary'

--- a/apps/desktop/src/components/settings/model-download-progress.tsx
+++ b/apps/desktop/src/components/settings/model-download-progress.tsx
@@ -3,7 +3,7 @@ import type { EmbedProgress } from '@reflect/core'
 
 interface ModelDownloadProgressProps {
   /** Byte counts from an active download, once the runtime has reported them. */
-  progress?: EmbedProgress
+  progress?: EmbedProgress | undefined
 }
 
 function formatMegabytes(bytes: number): string {

--- a/apps/desktop/src/components/settings/update-field.tsx
+++ b/apps/desktop/src/components/settings/update-field.tsx
@@ -14,8 +14,8 @@ export function UpdateField(): ReactElement {
   const action: {
     label: string
     icon: typeof RefreshCw
-    run?: () => Promise<void>
-    spinning?: boolean
+    run?: (() => Promise<void>) | undefined
+    spinning?: boolean | undefined
   } = (() => {
     switch (state.phase) {
       case 'checking':

--- a/apps/desktop/src/components/settings/use-active-settings-section.ts
+++ b/apps/desktop/src/components/settings/use-active-settings-section.ts
@@ -47,7 +47,7 @@ export function useActiveSettingsSection(
       const atBottom =
         container.scrollTop > 0 &&
         container.scrollTop + container.clientHeight >= container.scrollHeight - 1
-      setActiveId(atBottom ? SETTINGS_SECTIONS[SETTINGS_SECTIONS.length - 1].id : current)
+      setActiveId(atBottom ? SETTINGS_SECTIONS[SETTINGS_SECTIONS.length - 1]!.id : current)
     }
     compute()
     // ScrollRestored restores a saved scrollTop in its own effect, which runs

--- a/apps/desktop/src/components/sidebar/sidebar-item.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar-item.tsx
@@ -7,7 +7,7 @@ interface SidebarItemProps {
   icon: ReactNode
   label: string
   /** Keymap binding hinted on hover/focus (e.g. `Mod-d`). */
-  binding?: string
+  binding?: string | undefined
   active?: boolean
   onClick: () => void
 }

--- a/apps/desktop/src/components/tasks/task-schedule-calendar.tsx
+++ b/apps/desktop/src/components/tasks/task-schedule-calendar.tsx
@@ -92,7 +92,7 @@ export function TaskScheduleCalendar({
         </div>
         <div className="px-3 pb-1">
           {grid.weeks.map((week) => (
-            <div key={week[0].date} className="grid grid-cols-7 text-center">
+            <div key={week[0]!.date} className="grid grid-cols-7 text-center">
               {week.map((cell) => {
                 const isToday = cell.date === today
                 return (

--- a/apps/desktop/src/components/ui/dropdown-menu.tsx
+++ b/apps/desktop/src/components/ui/dropdown-menu.tsx
@@ -96,7 +96,7 @@ function DropdownMenuCheckboxItem({
         "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-surface-hover focus:text-foreground focus:**:text-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
-      checked={checked}
+      {...(checked !== undefined ? { checked } : {})}
       {...props}
     >
       <span

--- a/apps/desktop/src/editor/alias-placement.test.ts
+++ b/apps/desktop/src/editor/alias-placement.test.ts
@@ -46,7 +46,7 @@ describe('placeOldTitleAlias', () => {
     await placeOldTitleAlias(PATH, RENAME, 7)
 
     expect(io.writeNote).toHaveBeenCalledTimes(1)
-    const [path, content, generation] = io.writeNote.mock.calls[0]
+    const [path, content, generation] = io.writeNote.mock.calls[0]!
     expect(path).toBe(PATH)
     expect(content).toContain('aliases:')
     expect(content).toContain('Old Title')

--- a/apps/desktop/src/editor/document-binding.ts
+++ b/apps/desktop/src/editor/document-binding.ts
@@ -117,8 +117,9 @@ export function createDocumentBinding(): DocumentBinding {
       // quit-time flush, settle-time rename work, and reopened-note lookups.
       unregister = registerOpenDocument({
         session: bound,
-        settle: owner ? () => owner.settle() : undefined,
-        settled: owner ? () => owner.settled() : undefined,
+        ...(owner
+          ? { settle: () => owner.settle(), settled: () => owner.settled() }
+          : {}),
       })
       return { session: bound, coordinator: owner, created: adopted === null }
     },

--- a/apps/desktop/src/editor/markdown-preview.tsx
+++ b/apps/desktop/src/editor/markdown-preview.tsx
@@ -75,7 +75,7 @@ export function MarkdownPreview({
       readOnly
       initialMarkdown={content}
       resolveImageUrl={resolveImageUrlStable}
-      onWikilinkClick={navigates ? onWikilinkClickStable : undefined}
+      {...(navigates ? { onWikilinkClick: onWikilinkClickStable } : {})}
       editorClassName={cn('reflect-editor', className)}
     />
   )

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -161,11 +161,11 @@ export function NoteEditor({
       initialMarkdown={initialContent}
       spellCheck={spellCheck}
       editorClassName={cn('reflect-editor', className)}
-      placeholder={titlePlaceholder}
+      {...(titlePlaceholder !== undefined ? { placeholder: titlePlaceholder } : {})}
       onDocChange={handleDocChange}
       onWikilinkClick={handleWikilinkClick}
-      onWikilinkSearch={onWikilinkSearch}
-      onTagSearch={onTagSearch}
+      {...(onWikilinkSearch !== undefined ? { onWikilinkSearch } : {})}
+      {...(onTagSearch !== undefined ? { onTagSearch } : {})}
       resolveImageUrl={handleResolveImageUrl}
       onImagePaste={handleImagePaste}
       onImageSaveError={handleImageSaveError}

--- a/apps/desktop/src/editor/note-session.test.ts
+++ b/apps/desktop/src/editor/note-session.test.ts
@@ -6,7 +6,7 @@ import type { RoundTripFidelity } from './roundtrip'
 /** The first task's {@link TaskMarker} as the index records it. */
 function firstTask(source: string): TaskMarker {
   const [task] = parseNote({ path: 'notes/a.md', source }).tasks
-  return { markerOffset: task.markerOffset, raw: task.raw }
+  return { markerOffset: task!.markerOffset, raw: task!.raw }
 }
 
 /**
@@ -408,7 +408,7 @@ describe('frontmatter ownership (Plan 07b)', () => {
     h.session.externalChanged()
     await vi.runAllTimersAsync()
     expect(h.contents.map((c) => c.origin)).toEqual(['load', 'saved', 'external'])
-    expect(h.contents[1].content).toBe(`${FM}# Renamed\n`)
+    expect(h.contents[1]!.content).toBe(`${FM}# Renamed\n`)
   })
 })
 

--- a/apps/desktop/src/editor/note-session.ts
+++ b/apps/desktop/src/editor/note-session.ts
@@ -113,7 +113,7 @@ export interface NoteSessionOptions {
    * (including "load theirs"), or a landed save. `saved` is the only
    * user-driven origin — the title-rename tracker (Plan 07b) keys off it.
    */
-  onContent?: (content: string, origin: NoteContentOrigin) => void
+  onContent?: ((content: string, origin: NoteContentOrigin) => void) | undefined
   /**
    * Push content into the live editor (external reload / "load theirs"). The
    * editor's change handler may fire synchronously during this call; the
@@ -127,7 +127,7 @@ export interface NoteSessionOptions {
    * only to the initial load: a note deleted mid-session still reconciles to
    * a no-op rather than silently emptying the editor.
    */
-  createIfMissing?: boolean
+  createIfMissing?: boolean | undefined
   /**
    * Markdown to seed a **missing** note's buffer with (only meaningful with
    * `createIfMissing`) — the new-note title template. The seed is adopted as
@@ -136,7 +136,7 @@ export interface NoteSessionOptions {
    * rename tracker baselines on the real (empty) disk content, so the first
    * authored title stays a birth, not a rename.
    */
-  missingSeed?: string
+  missingSeed?: string | undefined
   saveDebounceMs?: number
 }
 
@@ -178,21 +178,21 @@ export interface FrontmatterPatch {
 export function frontmatterPatchToYaml(patch: FrontmatterPatch): Record<string, unknown> {
   const yaml: Record<string, unknown> = {}
   if (patch.aliases !== undefined) {
-    yaml.aliases = patch.aliases
+    yaml['aliases'] = patch.aliases
   }
   if (patch.pinned !== undefined) {
-    yaml.pinned = patch.pinned === false ? undefined : patch.pinned
+    yaml['pinned'] = patch.pinned === false ? undefined : patch.pinned
   }
   if (patch.private !== undefined) {
-    yaml.private = patch.private === false ? undefined : true
+    yaml['private'] = patch.private === false ? undefined : true
   }
   if (patch.gist !== undefined) {
     if (patch.gist === false) {
-      yaml.gist = undefined
+      yaml['gist'] = undefined
     } else {
       // Spelled out key-by-key so the YAML block's shape (and key order) is
       // this module's contract, not whatever object the caller happened to hold.
-      yaml.gist = {
+      yaml['gist'] = {
         id: patch.gist.id,
         url: patch.gist.url,
         file: patch.gist.file,

--- a/apps/desktop/src/editor/rename-coordinator.test.ts
+++ b/apps/desktop/src/editor/rename-coordinator.test.ts
@@ -148,7 +148,7 @@ describe('rename coordinator', () => {
     await coordinator.settled()
 
     expect(io.rewriteLinksForTitleChange).toHaveBeenCalledTimes(1)
-    const rewrite = io.rewriteLinksForTitleChange.mock.calls[0][0] as {
+    const rewrite = io.rewriteLinksForTitleChange.mock.calls[0]![0] as {
       path: string
       from: string
       to: string
@@ -206,7 +206,7 @@ describe('rename coordinator', () => {
 
     expect(io.readNote).not.toHaveBeenCalled()
     expect(io.writeNote).not.toHaveBeenCalled()
-    expect(operationLog.records[0].outcome).toBe('done')
+    expect(operationLog.records[0]!.outcome).toBe('done')
   })
 
   it('a failed rewrite still places the alias (the safety net) and says so', async () => {
@@ -218,9 +218,9 @@ describe('rename coordinator', () => {
 
     const expected = upsertFrontmatter('# New Title\n', { aliases: ['Old Title'] })
     expect(io.writeNote).toHaveBeenCalledWith(PATH, expected, 7)
-    expect(operationLog.records[0].outcome).toBe('failed')
-    expect(operationLog.records[0].message).toContain('index unavailable')
-    expect(operationLog.records[0].message).toContain('kept as an alias')
+    expect(operationLog.records[0]!.outcome).toBe('failed')
+    expect(operationLog.records[0]!.message).toContain('index unavailable')
+    expect(operationLog.records[0]!.message).toContain('kept as an alias')
   })
 
   it('a failed alias after a clean rewrite reports exactly that', async () => {
@@ -229,9 +229,9 @@ describe('rename coordinator', () => {
     const coordinator = makeCoordinator()
     await renameOnce(coordinator, 'Old Title', 'New Title')
 
-    expect(operationLog.records[0].outcome).toBe('failed')
-    expect(operationLog.records[0].message).toContain('links were rewritten')
-    expect(operationLog.records[0].message).toContain('read denied')
+    expect(operationLog.records[0]!.outcome).toBe('failed')
+    expect(operationLog.records[0]!.message).toContain('links were rewritten')
+    expect(operationLog.records[0]!.message).toContain('read denied')
   })
 
   it('both phases failing reports both, flagging links that may not resolve', async () => {
@@ -241,7 +241,7 @@ describe('rename coordinator', () => {
     const coordinator = makeCoordinator()
     await renameOnce(coordinator, 'Old Title', 'New Title')
 
-    const { message } = operationLog.records[0]
+    const { message } = operationLog.records[0]!
     expect(message).toContain('index unavailable')
     expect(message).toContain('read denied')
     expect(message).toContain('may no longer resolve')
@@ -299,7 +299,7 @@ describe('rename coordinator', () => {
       expect(openSession('notes/new-title.md')).toBe(session)
       expect(openSession(PATH)).toBeNull()
       expect(moves).toEqual([[PATH, 'notes/new-title.md']])
-      expect(operationLog.records[0].outcome).toBe('done')
+      expect(operationLog.records[0]!.outcome).toBe('done')
     } finally {
       unsubscribe()
       retargetOpenDocument('notes/new-title.md', PATH, session) // restore for other tests
@@ -338,9 +338,9 @@ describe('rename coordinator', () => {
       expect(session.retarget).toHaveBeenNthCalledWith(1, 'notes/new-title.md')
       expect(session.retarget).toHaveBeenNthCalledWith(2, PATH)
       expect(openSession(PATH)).toBe(session)
-      expect(operationLog.records[0].outcome).toBe('failed')
-      expect(operationLog.records[0].message).toContain('keeps its old name')
-      expect(operationLog.records[0].message).toContain('disk full')
+      expect(operationLog.records[0]!.outcome).toBe('failed')
+      expect(operationLog.records[0]!.message).toContain('keeps its old name')
+      expect(operationLog.records[0]!.message).toContain('disk full')
     } finally {
       unregister()
     }
@@ -370,7 +370,7 @@ describe('rename coordinator', () => {
     await coordinator.settled()
 
     // Both the rewrite and the second move key off the note's current path.
-    expect(io.rewriteLinksForTitleChange.mock.calls[1][0]).toMatchObject({
+    expect(io.rewriteLinksForTitleChange.mock.calls[1]![0]).toMatchObject({
       path: 'notes/b.md',
     })
     expect(io.slugPathForTitle).toHaveBeenLastCalledWith('notes/b.md', 'C')
@@ -389,8 +389,8 @@ describe('rename coordinator', () => {
     await coordinator.settled()
 
     expect(io.rewriteLinksForTitleChange).toHaveBeenCalledTimes(2)
-    expect(io.rewriteLinksForTitleChange.mock.calls[0][0]).toMatchObject({ from: 'A', to: 'B' })
-    expect(io.rewriteLinksForTitleChange.mock.calls[1][0]).toMatchObject({ from: 'B', to: 'C' })
+    expect(io.rewriteLinksForTitleChange.mock.calls[0]![0]).toMatchObject({ from: 'A', to: 'B' })
+    expect(io.rewriteLinksForTitleChange.mock.calls[1]![0]).toMatchObject({ from: 'B', to: 'C' })
     // A (the intermediate title) is pruned; B (the latest old title) joins.
     const secondAliasWrite = io.writeNote.mock.calls.filter((call) => call[0] === PATH).at(-1)
     expect(secondAliasWrite?.[1]).toBe(

--- a/apps/desktop/src/editor/title-rename.ts
+++ b/apps/desktop/src/editor/title-rename.ts
@@ -46,7 +46,7 @@ export interface TitleRenameTrackerOptions {
    * ("keep mine"), while adopted external content clears it via `baseline`
    * ("load theirs") — exactly the two ways a conflict can end.
    */
-  canFire?: () => boolean
+  canFire?: (() => boolean) | undefined
   quietMs?: number
 }
 

--- a/apps/desktop/src/editor/use-editor-autocomplete.ts
+++ b/apps/desktop/src/editor/use-editor-autocomplete.ts
@@ -77,7 +77,7 @@ export function useEditorAutocomplete(): EditorAutocomplete {
                 ? `${date} · new`
                 : date
               : undefined
-        return { target, label, detail }
+        return { target, label, ...(detail !== undefined ? { detail } : {}) }
       })
     },
     [graph, settings.dateFormat, createFromAutocomplete],

--- a/apps/desktop/src/editor/use-note-document.test.tsx
+++ b/apps/desktop/src/editor/use-note-document.test.tsx
@@ -196,7 +196,7 @@ describe('useNoteDocument', () => {
       expect(files['notes/a.md']).toBeUndefined()
       expect(files['notes/new-title.md']).toContain('aliases:')
       expect(files['notes/new-title.md']).toContain('Old Title')
-      expect(files['notes/new-title.md'].endsWith('# New Title\n')).toBe(true)
+      expect(files['notes/new-title.md']!.endsWith('# New Title\n')).toBe(true)
     } finally {
       vi.useRealTimers()
     }

--- a/apps/desktop/src/editor/use-note-document.ts
+++ b/apps/desktop/src/editor/use-note-document.ts
@@ -57,7 +57,7 @@ export interface NoteDocumentOptions {
    * template). Requires `createIfMissing`; see `NoteSessionOptions.missingSeed`
    * for the lazy-contract semantics.
    */
-  missingSeed?: string
+  missingSeed?: string | undefined
 }
 
 /**

--- a/apps/desktop/src/editor/wiki-autocomplete-entries.test.ts
+++ b/apps/desktop/src/editor/wiki-autocomplete-entries.test.ts
@@ -60,6 +60,6 @@ describe('buildAutocompleteEntries', () => {
       { offerCreate: false },
     )
     expect(entries).toHaveLength(1)
-    expect(entries[0].kind).toBe('suggestion')
+    expect(entries[0]!.kind).toBe('suggestion')
   })
 })

--- a/apps/desktop/src/hooks/note-row-overlay.ts
+++ b/apps/desktop/src/hooks/note-row-overlay.ts
@@ -26,11 +26,23 @@ import type { NoteRow } from '@reflect/core'
  * Index-row fields an action may assert ahead of the re-index. Publishing
  * yields a concrete `gistUrl` and a fresh `gistStale: false`; unpublishing
  * yields `gistUrl: null`. These overlays are short-lived read-model facts that
- * retire as soon as the index catches up.
+ * retire as soon as the index catches up. As a *stored* value every field is
+ * concrete — {@link definedFields} strips any `undefined` before it lands.
  */
 export interface NoteRowOverlay {
   readonly gistUrl?: string | null
   readonly gistStale?: boolean
+}
+
+/**
+ * The shape callers may hand {@link setNoteRowOverlay}: the same fields, but
+ * an explicit `undefined` is allowed (e.g. a conditionally-built patch). Such
+ * fields are dropped by {@link definedFields}, so an all-`undefined` patch is a
+ * no-op and `undefined` never reaches a stored {@link NoteRowOverlay}.
+ */
+export interface NoteRowOverlayPatch {
+  readonly gistUrl?: string | null | undefined
+  readonly gistStale?: boolean | undefined
 }
 
 type MutableNoteRowOverlay = {
@@ -60,7 +72,7 @@ function subscribe(listener: () => void): () => void {
 }
 
 /** Strip `undefined` fields — an all-`undefined` patch must never be stored. */
-function definedFields(patch: NoteRowOverlay): NoteRowOverlay {
+function definedFields(patch: NoteRowOverlayPatch): NoteRowOverlay {
   const result: MutableNoteRowOverlay = {}
   if (patch.gistUrl !== undefined) {
     result.gistUrl = patch.gistUrl
@@ -79,7 +91,7 @@ function definedFields(patch: NoteRowOverlay): NoteRowOverlay {
  * that is all `undefined`) is ignored — it would only leave a non-reconcilable
  * entry and leak `undefined` into merged rows.
  */
-export function setNoteRowOverlay(path: string, generation: number, patch: NoteRowOverlay): void {
+export function setNoteRowOverlay(path: string, generation: number, patch: NoteRowOverlayPatch): void {
   const defined = definedFields(patch)
   if (Object.keys(defined).length === 0) {
     return
@@ -130,9 +142,15 @@ export function reconcileNoteRowOverlay(path: string, generation: number, row: N
     if (row[key] === entry.overlay[key]) {
       retired = true
     } else if (key === 'gistUrl') {
-      remaining.gistUrl = entry.overlay.gistUrl
+      const gistUrl = entry.overlay.gistUrl
+      if (gistUrl !== undefined) {
+        remaining.gistUrl = gistUrl
+      }
     } else {
-      remaining.gistStale = entry.overlay.gistStale
+      const gistStale = entry.overlay.gistStale
+      if (gistStale !== undefined) {
+        remaining.gistStale = gistStale
+      }
     }
   }
   if (!retired) {

--- a/apps/desktop/src/hooks/use-audio-recorder.test.ts
+++ b/apps/desktop/src/hooks/use-audio-recorder.test.ts
@@ -75,7 +75,7 @@ describe('useAudioRecorder', () => {
     expect(result.current.status).toBe('recording')
     expect(result.current.stream).not.toBeNull()
     // WKWebView profile: webm unsupported, mp4 picked.
-    expect(FakeMediaRecorder.instances[0].mimeType).toBe('audio/mp4')
+    expect(FakeMediaRecorder.instances[0]!.mimeType).toBe('audio/mp4')
 
     act(() => {
       vi.advanceTimersByTime(3000)
@@ -100,7 +100,7 @@ describe('useAudioRecorder', () => {
     await act(async () => {
       await result.current.start()
     })
-    expect(FakeMediaRecorder.instances[0].mimeType).toBe('audio/webm;codecs=opus')
+    expect(FakeMediaRecorder.instances[0]!.mimeType).toBe('audio/webm;codecs=opus')
   })
 
   it('discards a sub-half-second recording as a misclick', async () => {
@@ -246,7 +246,7 @@ describe('useAudioRecorder', () => {
       return Promise.all([racingStop, racingStopTwin])
     })
 
-    expect(FakeMediaRecorder.instances[0].stopCalls).toBe(1)
+    expect(FakeMediaRecorder.instances[0]!.stopCalls).toBe(1)
     expect(first).not.toBeNull()
     expect(second).toBe(first)
   })
@@ -259,12 +259,12 @@ describe('useAudioRecorder', () => {
       await result.current.start()
     })
     // Simulate an external stop landing first (a racing cancel).
-    FakeMediaRecorder.instances[0].state = 'inactive'
+    FakeMediaRecorder.instances[0]!.state = 'inactive'
 
     const recording = await act(async () => result.current.stop())
 
     expect(recording).toBeNull()
-    expect(FakeMediaRecorder.instances[0].stopCalls).toBe(0)
+    expect(FakeMediaRecorder.instances[0]!.stopCalls).toBe(0)
     expect(result.current.status).toBe('idle')
   })
 

--- a/apps/desktop/src/hooks/use-device-flow-auth.ts
+++ b/apps/desktop/src/hooks/use-device-flow-auth.ts
@@ -52,9 +52,10 @@ export function useDeviceFlowAuth(): DeviceFlowAuth {
     setError(null)
     setBusy(true)
     try {
+      const signal = abortRef.current?.signal
       const auth = await runDeviceFlow({
         fetchFn: providerFetch,
-        signal: abortRef.current?.signal,
+        ...(signal !== undefined ? { signal } : {}),
         onCode: (code) => {
           setView({ view: 'code', userCode: code.userCode, verificationUri: code.verificationUri })
         },

--- a/apps/desktop/src/lib/backup-controller.test.ts
+++ b/apps/desktop/src/lib/backup-controller.test.ts
@@ -62,7 +62,7 @@ function fakeBridge(options: FakeOptions = {}) {
           }
           return status
         case 'git_setup':
-          status.remoteUrl = typeof args.remoteUrl === 'string' ? args.remoteUrl : null
+          status.remoteUrl = typeof args['remoteUrl'] === 'string' ? args['remoteUrl'] : null
           return status
         case 'secret_get':
           return auth

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -158,7 +158,7 @@ describe('app commands', () => {
     const { context, navigated } = fakeContext()
     await command('note.new').run(context)
     expect(navigated).toHaveLength(1)
-    const route = navigated[0]
+    const route = navigated[0]!
     expect(route.kind).toBe('note')
     expect((route as { kind: 'note'; path: string }).path).toMatch(/^notes\/[0-9a-z]+\.md$/)
   })

--- a/apps/desktop/src/lib/create-note.test.ts
+++ b/apps/desktop/src/lib/create-note.test.ts
@@ -20,11 +20,11 @@ interface BridgeBehavior {
 function bindBridge({ occupied = [] }: BridgeBehavior = {}): ReturnType<typeof vi.fn> {
   const invoke = vi.fn(async (command: string, args?: Record<string, unknown>) => {
     if (command === 'db_query') {
-      const candidate = (args?.params as unknown[])?.[0]
+      const candidate = (args?.['params'] as unknown[])?.[0]
       return occupied.includes(String(candidate)) ? [{ path: candidate }] : []
     }
     if (command === 'note_exists') {
-      return occupied.includes(String(args?.path))
+      return occupied.includes(String(args?.['path']))
     }
     return null
   })

--- a/apps/desktop/src/lib/github-account.test.ts
+++ b/apps/desktop/src/lib/github-account.test.ts
@@ -10,12 +10,12 @@ function fakeKeychain(initial: Record<string, string> = {}): Map<string, string>
   const store = new Map(Object.entries(initial))
   setBridge({
     invoke: async (command, args) => {
-      const name = args.name as string
+      const name = args['name'] as string
       if (command === 'secret_get') {
         return store.get(name) ?? null
       }
       if (command === 'secret_set') {
-        store.set(name, args.value as string)
+        store.set(name, args['value'] as string)
         return null
       }
       if (command === 'secret_delete') {

--- a/apps/desktop/src/lib/github-repos.ts
+++ b/apps/desktop/src/lib/github-repos.ts
@@ -11,7 +11,7 @@ export function parseRepoInput(input: string): GithubRepoRef | null {
     return fromUrl
   }
   const match = /^([\w.-]+)\/([\w.-]+)$/.exec(trimmed)
-  return match === null ? null : { owner: match[1], name: match[2] }
+  return match === null ? null : { owner: match[1]!, name: match[2]! }
 }
 
 /**

--- a/apps/desktop/src/lib/keybindings.ts
+++ b/apps/desktop/src/lib/keybindings.ts
@@ -64,10 +64,10 @@ export function formatBinding(binding: string, apple: boolean): string[] {
   return parts.map((part, index) => {
     const lower = part.toLowerCase()
     if (index < parts.length - 1 && lower in modifiers) {
-      return modifiers[lower]
+      return modifiers[lower]!
     }
     if (lower in KEY_SYMBOLS) {
-      return KEY_SYMBOLS[lower]
+      return KEY_SYMBOLS[lower]!
     }
     return part.length === 1 ? part.toUpperCase() : part
   })

--- a/apps/desktop/src/lib/month-grid.test.ts
+++ b/apps/desktop/src/lib/month-grid.test.ts
@@ -48,9 +48,9 @@ describe('buildMonthGrid', () => {
     // August 2026 starts on a Saturday.
     const grid = buildMonthGrid('2026-08')
     expect(grid.start).toBe('2026-07-27')
-    expect(grid.weeks[0].slice(0, 5).every((cell) => !cell.inMonth)).toBe(true)
-    expect(grid.weeks[0][5]).toEqual({ date: '2026-08-01', inMonth: true })
-    const lastWeek = grid.weeks[grid.weeks.length - 1]
+    expect(grid.weeks[0]!.slice(0, 5).every((cell) => !cell.inMonth)).toBe(true)
+    expect(grid.weeks[0]![5]).toEqual({ date: '2026-08-01', inMonth: true })
+    const lastWeek = grid.weeks[grid.weeks.length - 1]!
     expect(lastWeek[0]).toEqual({ date: '2026-08-31', inMonth: true })
     expect(lastWeek.slice(1).every((cell) => !cell.inMonth)).toBe(true)
   })
@@ -72,7 +72,7 @@ describe('buildMonthGrid', () => {
     const DAY_MILLIS = 86_400_000
     const utcMillis = (date: string): number => {
       const [year, monthPart, day] = date.split('-').map(Number)
-      return Date.UTC(year, monthPart - 1, day)
+      return Date.UTC(year!, monthPart! - 1, day!)
     }
 
     for (const { month, lastDay } of [
@@ -86,7 +86,7 @@ describe('buildMonthGrid', () => {
 
       const cells = grid.weeks.flat()
       for (let index = 1; index < cells.length; index += 1) {
-        expect(utcMillis(cells[index].date) - utcMillis(cells[index - 1].date)).toBe(
+        expect(utcMillis(cells[index]!.date) - utcMillis(cells[index - 1]!.date)).toBe(
           DAY_MILLIS,
         )
       }

--- a/apps/desktop/src/lib/native-menu/menu.ts
+++ b/apps/desktop/src/lib/native-menu/menu.ts
@@ -24,8 +24,8 @@ import { dispatchMenuCommand } from './dispatch'
 type PredefinedItem = PredefinedMenuItemOptions['item']
 
 export type AppMenuEntry =
-  | { kind: 'command'; commandId: string; text?: string }
-  | { kind: 'predefined'; item: PredefinedItem; text?: string }
+  | { kind: 'command'; commandId: string; text?: string | undefined }
+  | { kind: 'predefined'; item: PredefinedItem; text?: string | undefined }
 
 export interface AppSubmenuLayout {
   text: string
@@ -126,10 +126,11 @@ function menuItemOptions(commandId: string, text?: string): MenuItemOptions {
   if (!appCommand) {
     throw new Error(`native menu references unknown command: ${commandId}`)
   }
+  const accelerator = appCommand.keybinding ? bindingToAccelerator(appCommand.keybinding) : undefined
   return {
     id: appCommand.id,
     text: text ?? appCommand.title,
-    accelerator: appCommand.keybinding ? bindingToAccelerator(appCommand.keybinding) : undefined,
+    ...(accelerator !== undefined ? { accelerator } : {}),
     action: dispatchMenuCommand,
   }
 }
@@ -137,7 +138,7 @@ function menuItemOptions(commandId: string, text?: string): MenuItemOptions {
 function entryOptions(entry: AppMenuEntry): MenuItemOptions | PredefinedMenuItemOptions {
   return entry.kind === 'command'
     ? menuItemOptions(entry.commandId, entry.text)
-    : { item: entry.item, text: entry.text }
+    : { item: entry.item, ...(entry.text !== undefined ? { text: entry.text } : {}) }
 }
 
 /**

--- a/apps/desktop/src/lib/operations.test.ts
+++ b/apps/desktop/src/lib/operations.test.ts
@@ -21,11 +21,11 @@ describe('operations store', () => {
       handle = startOperation('Renaming "A" → "B"')
     })
     expect(result.current).toHaveLength(1)
-    expect(result.current[0].label).toBe('Renaming "A" → "B"')
-    expect(result.current[0].progress).toBeNull()
+    expect(result.current[0]!.label).toBe('Renaming "A" → "B"')
+    expect(result.current[0]!.progress).toBeNull()
 
     act(() => handle.progress(3, 12))
-    expect(result.current[0].progress).toEqual({ done: 3, total: 12 })
+    expect(result.current[0]!.progress).toEqual({ done: 3, total: 12 })
 
     act(() => handle.done())
     // Once shown, the entry stays for the minimum visible window — a fast
@@ -42,8 +42,8 @@ describe('operations store', () => {
       handle = startOperation('Renaming "A" → "B"')
     })
     act(() => handle.fail('disk full'))
-    expect(result.current[0].status).toBe('failed')
-    expect(result.current[0].message).toBe('disk full')
+    expect(result.current[0]!.status).toBe('failed')
+    expect(result.current[0]!.message).toBe('disk full')
 
     act(() => vi.advanceTimersByTime(8000 + 1200))
     expect(result.current).toEqual([])
@@ -56,8 +56,8 @@ describe('operations store', () => {
       handle = startOperation('Rebuilding search index')
     })
     act(() => handle.warn('Rebuilt with 1 skipped note: notes/bad.md'))
-    expect(result.current[0].status).toBe('warning')
-    expect(result.current[0].message).toBe('Rebuilt with 1 skipped note: notes/bad.md')
+    expect(result.current[0]!.status).toBe('warning')
+    expect(result.current[0]!.message).toBe('Rebuilt with 1 skipped note: notes/bad.md')
 
     act(() => vi.advanceTimersByTime(8000 + 1200))
     expect(result.current).toEqual([])

--- a/apps/desktop/src/lib/tasks/recently-completed.test.ts
+++ b/apps/desktop/src/lib/tasks/recently-completed.test.ts
@@ -39,10 +39,10 @@ describe('recently-completed', () => {
 
     act(() => markRecentlyCompleted('/g', [task({ notePath: 'a.md', markerOffset: 2 })]))
     expect(result.current).toHaveLength(1)
-    expect(result.current[0].checked).toBe(true)
+    expect(result.current[0]!.checked).toBe(true)
     // The marker in raw is flipped to [x] to match disk — these rows outlive the
     // reindex, so a stale [ ] would later fail a reopen/edit/delete write-back.
-    expect(result.current[0].raw).toBe('[x] do it')
+    expect(result.current[0]!.raw).toBe('[x] do it')
   })
 
   it('dedupes by task key', () => {

--- a/apps/desktop/src/lib/tasks/use-task-keyboard.ts
+++ b/apps/desktop/src/lib/tasks/use-task-keyboard.ts
@@ -177,9 +177,10 @@ export function useTaskKeyboard({
         // in the focused editor; here it covers an unfocused single selection, and
         // lands on the previous row so the keyboard flow continues.
         const selected = selectedTasks()
-        if (selected.length === 1 && selected[0].text.trim() === '') {
+        const sole = selected.length === 1 ? selected[0] : undefined
+        if (sole !== undefined && sole.text.trim() === '') {
           event.preventDefault()
-          const previous = previousTaskKey(orderedTasks, selected[0])
+          const previous = previousTaskKey(orderedTasks, sole)
           actions.remove(selected)
           if (previous !== null) {
             selectExclusively(previous)

--- a/apps/desktop/src/lib/tasks/use-task-selection.ts
+++ b/apps/desktop/src/lib/tasks/use-task-selection.ts
@@ -123,8 +123,8 @@ export function useTaskSelection(orderedKeys: readonly string[]): TaskSelection 
       return
     }
     setSelected(new Set(order))
-    anchorRef.current = order[0]
-    cursorRef.current = order[order.length - 1]
+    anchorRef.current = order[0]!
+    cursorRef.current = order[order.length - 1]!
   }, [])
 
   const clear = useCallback(() => {
@@ -142,7 +142,7 @@ export function useTaskSelection(orderedKeys: readonly string[]): TaskSelection 
     const index = from === null ? -1 : order.indexOf(from)
     const next =
       index === -1 ? (direction === 1 ? 0 : order.length - 1) : clamp(index + direction, order.length)
-    const key = order[next]
+    const key = order[next]!
     setSelected(new Set([key]))
     anchorRef.current = key
     cursorRef.current = key
@@ -162,7 +162,7 @@ export function useTaskSelection(orderedKeys: readonly string[]): TaskSelection 
       const from = cursorRef.current ?? base
       const index = order.indexOf(from)
       const next = clamp((index === -1 ? 0 : index) + direction, order.length)
-      const key = order[next]
+      const key = order[next]!
       setSelected(new Set(rangeBetween(base, key)))
       cursorRef.current = key
     },

--- a/apps/desktop/src/lib/welcome-note.test.ts
+++ b/apps/desktop/src/lib/welcome-note.test.ts
@@ -23,13 +23,13 @@ function installFakeBridge(options: {
         case 'list_files':
           return (options.existingFiles ?? []).map((path) => ({ path, size: 0, modifiedMs: 0 }))
         case 'note_write':
-          graph.written.push({ path: String(args.path), contents: String(args.contents) })
+          graph.written.push({ path: String(args['path']), contents: String(args['contents']) })
           return null
         case 'index_meta_set':
-          graph.meta[String(args.key)] = String(args.value)
+          graph.meta[String(args['key'])] = String(args['value'])
           return null
         case 'db_query': {
-          const key = String((args.params as unknown[])?.[0])
+          const key = String((args['params'] as unknown[])?.[0])
           return key in graph.meta ? [{ value: graph.meta[key] }] : []
         }
         default:
@@ -52,18 +52,18 @@ describe('ensureWelcomeNote', () => {
     const graph = installFakeBridge({})
     expect(await ensureWelcomeNote(GENERATIONS)).toBe(true)
     expect(graph.written).toHaveLength(1)
-    expect(graph.written[0].path).toBe(WELCOME_NOTE_PATH)
+    expect(graph.written[0]!.path).toBe(WELCOME_NOTE_PATH)
     expect(WELCOME_NOTE_PATH).toBe('notes/how-to-use-reflect.md')
     expect(graph.meta[WELCOME_SEEDED_META_KEY]).toBe('true')
 
     const { frontmatter, title } = parseNote({
-      path: graph.written[0].path,
-      source: graph.written[0].contents,
+      path: graph.written[0]!.path,
+      source: graph.written[0]!.contents,
     })
     expect(title).toBe('How to use Reflect')
     expect(isPinned(frontmatter)).toBe(true)
     expect(frontmatter.id).toMatch(/^[0-9a-z]{26}$/)
-    expect(graph.written[0].contents).toContain('[[Wiki Links]]')
+    expect(graph.written[0]!.contents).toContain('[[Wiki Links]]')
   })
 
   it('marks a graph with existing notes without writing into it', async () => {

--- a/apps/desktop/src/mobile/mobile-error-boundary.tsx
+++ b/apps/desktop/src/mobile/mobile-error-boundary.tsx
@@ -14,17 +14,17 @@ export class MobileErrorBoundary extends Component<
   { children: ReactNode },
   MobileErrorBoundaryState
 > {
-  state: MobileErrorBoundaryState = { message: null }
+  override state: MobileErrorBoundaryState = { message: null }
 
   static getDerivedStateFromError(error: unknown): MobileErrorBoundaryState {
     return { message: error instanceof Error ? error.message : String(error) }
   }
 
-  componentDidCatch(error: unknown, info: ErrorInfo): void {
+  override componentDidCatch(error: unknown, info: ErrorInfo): void {
     console.error('mobile render crash:', error, info.componentStack)
   }
 
-  render(): ReactNode {
+  override render(): ReactNode {
     if (this.state.message !== null) {
       return (
         <div className="flex h-dvh w-screen flex-col items-center justify-center gap-2 px-8 text-center">

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -133,7 +133,7 @@ function dayCellLabel(date: string): string {
 /** A day in `date`'s week that isn't `date` itself (always present). */
 function otherDayInWeek(date: string): string {
   const week = weekOf(date, 'monday')
-  return week.find((day) => day !== date) ?? week[0]
+  return week.find((day) => day !== date) ?? week[0]!
 }
 
 describe('MobileShell', () => {

--- a/apps/desktop/src/mobile/note-actions-menu.test.tsx
+++ b/apps/desktop/src/mobile/note-actions-menu.test.tsx
@@ -58,7 +58,7 @@ describe('NoteActionsMenu', () => {
 
     await waitFor(() => {
       const write = calls.find((call) => call.command === 'note_write')
-      expect(write?.args.contents).toContain('pinned: true')
+      expect(write?.args['contents']).toContain('pinned: true')
     })
   })
 

--- a/apps/desktop/src/mobile/screens/all-notes.tsx
+++ b/apps/desktop/src/mobile/screens/all-notes.tsx
@@ -165,6 +165,9 @@ function NoteRows({
       <ul className="relative" style={{ height: virtualizer.getTotalSize() }}>
         {virtualizer.getVirtualItems().map((item) => {
           const note = rows[item.index]
+          if (note === undefined) {
+            return null
+          }
           return (
             <li
               key={note.path}

--- a/apps/desktop/src/providers/chat-provider.test.tsx
+++ b/apps/desktop/src/providers/chat-provider.test.tsx
@@ -162,8 +162,8 @@ describe('ChatProvider persistence', () => {
     await act(() => session?.send('hello there'))
 
     expect(core.saveChatMessage).toHaveBeenCalledTimes(2)
-    const first = core.saveChatMessage.mock.calls[0][0]
-    const second = core.saveChatMessage.mock.calls[1][0]
+    const first = core.saveChatMessage.mock.calls[0]![0]
+    const second = core.saveChatMessage.mock.calls[1]![0]
     expect(first).toMatchObject({
       generation: 7,
       conversation: { id: session?.activeConversationId, title: 'hello there' },
@@ -186,7 +186,7 @@ describe('ChatProvider persistence', () => {
 
     await act(() => session?.send('and today?'))
 
-    expect(core.saveChatMessage.mock.calls[0][0]).toMatchObject({
+    expect(core.saveChatMessage.mock.calls[0]![0]).toMatchObject({
       conversation: { id: 'conv-1', title: 'what did I write yesterday?' },
       turn: { userText: 'and today?' },
     })
@@ -272,7 +272,7 @@ describe('ChatProvider persistence', () => {
       sendDone = session?.send('hello')
       await Promise.resolve()
     })
-    const sentInto = core.saveChatMessage.mock.calls[0][0] as { conversation: { id: string } }
+    const sentInto = core.saveChatMessage.mock.calls[0]![0] as { conversation: { id: string } }
 
     // Delete the conversation while the turn is streaming, then let it settle:
     // the settle-time save must not resurrect the deleted row.
@@ -301,7 +301,7 @@ describe('ChatProvider persistence', () => {
     await waitFor(() => expect(core.listChatConversations).toHaveBeenCalled())
 
     await act(() => session?.send('hello'))
-    const sentInto = core.saveChatMessage.mock.calls[0][0] as { conversation: { id: string } }
+    const sentInto = core.saveChatMessage.mock.calls[0]![0] as { conversation: { id: string } }
 
     let deleteDone: Promise<void> | undefined
     await act(async () => {

--- a/apps/desktop/src/providers/graph-index.test.ts
+++ b/apps/desktop/src/providers/graph-index.test.ts
@@ -75,11 +75,11 @@ describe('createGraphIndex', () => {
     expect(onApplied).toHaveBeenCalledTimes(1)
     expect(mockWatchStart).toHaveBeenCalledTimes(1)
     // Sequenced: reconcile → subscribe → watchStart.
-    expect(mockSync.mock.invocationCallOrder[0]).toBeLessThan(
-      mockSubscribe.mock.invocationCallOrder[0],
+    expect(mockSync.mock.invocationCallOrder[0]!).toBeLessThan(
+      mockSubscribe.mock.invocationCallOrder[0]!,
     )
-    expect(mockSubscribe.mock.invocationCallOrder[0]).toBeLessThan(
-      mockWatchStart.mock.invocationCallOrder[0],
+    expect(mockSubscribe.mock.invocationCallOrder[0]!).toBeLessThan(
+      mockWatchStart.mock.invocationCallOrder[0]!,
     )
     expect(unlisten).not.toHaveBeenCalled() // retained as the active subscription
   })

--- a/apps/desktop/src/providers/graph-index.ts
+++ b/apps/desktop/src/providers/graph-index.ts
@@ -127,7 +127,11 @@ export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
       // later step threw) is torn down in `finally` so listeners can't leak.
       let pending: (() => void) | null = null
       try {
-        await syncIndex({ generation, signal: controller.signal, onMoved })
+        await syncIndex({
+          generation,
+          signal: controller.signal,
+          ...(onMoved !== undefined ? { onMoved } : {}),
+        })
         if (isStale()) {
           return
         }

--- a/apps/desktop/src/providers/graph-provider.test.tsx
+++ b/apps/desktop/src/providers/graph-provider.test.tsx
@@ -44,13 +44,13 @@ function installFakeBridge(): void {
   let generation = 0
   setBridge({
     invoke: async (command, args) => {
-      invokeLog.push(command === 'graph_open' ? `graph_open:${String(args.path)}` : command)
+      invokeLog.push(command === 'graph_open' ? `graph_open:${String(args['path'])}` : command)
       switch (command) {
         case 'graph_open': {
           if (failOpens) {
             throw { kind: 'io', message: 'cannot open graph' }
           }
-          const root = String(args.path)
+          const root = String(args['path'])
           await new Promise<void>((resolve) => {
             pendingOpens.set(root, resolve)
           })
@@ -64,20 +64,20 @@ function installFakeBridge(): void {
         case 'settings_load':
           return settingsStore
         case 'settings_save':
-          settingsStore = args.settings as Record<string, unknown>
+          settingsStore = args['settings'] as Record<string, unknown>
           return null
         case 'index_open':
           return generation
         case 'list_files':
           return storedFiles
         case 'index_meta_set':
-          metaStore[String(args.key)] = String(args.value)
+          metaStore[String(args['key'])] = String(args['value'])
           return null
         case 'db_query': {
           // The only meta read the provider issues is the welcome marker.
-          const sql = String(args.sql ?? '')
+          const sql = String(args['sql'] ?? '')
           if (/index_?meta/i.test(sql)) {
-            const key = String((args.params as unknown[])?.[0])
+            const key = String((args['params'] as unknown[])?.[0])
             return key in metaStore ? [{ value: metaStore[key] }] : []
           }
           return []
@@ -185,12 +185,12 @@ describe('GraphProvider welcome seeding', () => {
 
     expect(result.current.status).toBe('ready')
     expect(invokeLog).toContain('note_write')
-    expect(metaStore.welcomeSeeded).toBe('true')
+    expect(metaStore['welcomeSeeded']).toBe('true')
   })
 
   it('never seeds a marked graph, even when it is empty (deleted notes stay deleted)', async () => {
     storedRecents = [{ root: '/known', name: 'known', openedMs: 1 }]
-    metaStore.welcomeSeeded = 'true'
+    metaStore['welcomeSeeded'] = 'true'
     const { result } = renderHook(() => useGraph(), { wrapper })
 
     await act(async () => {
@@ -215,7 +215,7 @@ describe('GraphProvider welcome seeding', () => {
 
     expect(invokeLog).not.toContain('note_write')
     // Onboarding was considered: emptying this graph later won't re-seed.
-    expect(metaStore.welcomeSeeded).toBe('true')
+    expect(metaStore['welcomeSeeded']).toBe('true')
   })
 })
 
@@ -248,7 +248,7 @@ describe('GraphProvider mobile onboarding (Plan 19, step 6)', () => {
     expect(result.current.graph?.root).toBe(MOBILE_ROOT)
     // The gate is persisted (through the settings provider) so later launches
     // open the root directly — persistence trails the state update, so wait.
-    await waitFor(() => expect(settingsStore.mobileOnboarded).toBe(true))
+    await waitFor(() => expect(settingsStore['mobileOnboarded']).toBe(true))
   })
 
   it('keeps onboarding up (flag unset) when the open fails, for an in-app retry', async () => {
@@ -265,7 +265,7 @@ describe('GraphProvider mobile onboarding (Plan 19, step 6)', () => {
     // stranded past onboarding on a broken open.
     expect(result.current.needsOnboarding).toBe(true)
     expect(result.current.graph).toBeNull()
-    expect(settingsStore.mobileOnboarded).toBeUndefined()
+    expect(settingsStore['mobileOnboarded']).toBeUndefined()
   })
 
   it('opens the fixed root directly when already onboarded', async () => {

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -259,7 +259,7 @@ export function GraphProvider({
         return
       }
       if (list.length > 0) {
-        await openRecent(list[0].root)
+        await openRecent(list[0]!.root)
       } else {
         setStatus('choosing')
       }

--- a/apps/desktop/src/providers/settings-provider.test.tsx
+++ b/apps/desktop/src/providers/settings-provider.test.tsx
@@ -50,7 +50,7 @@ function installFakeBridge(): void {
           if (failSaves) {
             throw { kind: 'io', message: 'disk full' }
           }
-          saved.push(args.settings)
+          saved.push(args['settings'])
           return null
         default:
           return null

--- a/apps/desktop/src/routing/router.tsx
+++ b/apps/desktop/src/routing/router.tsx
@@ -48,7 +48,7 @@ const RouterContext = createContext<RouterValue | null>(null)
 
 interface RouterProviderProps {
   /** The launch route; defaults to today (the daily note is the spine). */
-  initialRoute?: Route
+  initialRoute?: Route | undefined
   children: ReactNode
 }
 
@@ -82,16 +82,17 @@ export function RouterProvider({
   // commit, and React runs effects child-before-parent — so updating it in an
   // effect here would lag a frame and restore or save the wrong entry's offset.
   // eslint-disable-next-line react-hooks/refs
-  currentId.current = history.stack[history.index].id
+  currentId.current = history.stack[history.index]!.id
 
   const navigate = useCallback((route: Route) => {
     const target = normalizeRoute(route)
     setHistory((current) => {
-      if (routesEqual(current.stack[current.index].route, target)) {
+      const currentEntry = current.stack[current.index]!
+      if (routesEqual(currentEntry.route, target)) {
         // No stack growth — but this is still an explicit arrival: forget the
         // entry's saved offset so the view re-anchors to its target instead of
         // restoring the old scroll position.
-        scrollById.current.delete(current.stack[current.index].id)
+        scrollById.current.delete(currentEntry.id)
         return current
       }
       const dropped = current.stack.slice(current.index + 1)
@@ -150,10 +151,11 @@ export function RouterProvider({
     [],
   )
 
-  const value = useMemo<RouterValue>(
-    () => ({
-      route: history.stack[history.index].route,
-      entryId: history.stack[history.index].id,
+  const value = useMemo<RouterValue>(() => {
+    const entry = history.stack[history.index]!
+    return {
+      route: entry.route,
+      entryId: entry.id,
       arrivalSeq,
       navigate,
       back,
@@ -162,9 +164,8 @@ export function RouterProvider({
       canForward: history.index < history.stack.length - 1,
       saveScrollState,
       savedScroll,
-    }),
-    [history, arrivalSeq, navigate, back, forward, saveScrollState, savedScroll],
-  )
+    }
+  }, [history, arrivalSeq, navigate, back, forward, saveScrollState, savedScroll])
 
   return <RouterContext.Provider value={value}>{children}</RouterContext.Provider>
 }

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -1,30 +1,14 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
     "jsx": "react-jsx",
 
     /* Path aliases */
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    },
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    }
   },
   "include": ["src"]
 }

--- a/apps/extension/lib/capture-message.ts
+++ b/apps/extension/lib/capture-message.ts
@@ -11,13 +11,13 @@ export interface CapturedPage {
   url: string
   title: string
   /** `tabs.captureVisibleTab`'s data URL, when the page allowed a screenshot. */
-  screenshotDataUrl?: string
+  screenshotDataUrl?: string | undefined
   /** The page's current selection, when the page allowed the script. */
-  selection?: string
+  selection?: string | undefined
   /** Defuddle-extracted page paragraphs, when the user asks to include them. */
-  contentText?: string
+  contentText?: string | undefined
   /** The user's comment from the popup. */
-  note?: string
+  note?: string | undefined
 }
 
 /** Only http(s) pages are capturable — the envelope (and product) contract. */

--- a/apps/extension/manifest-key.test.ts
+++ b/apps/extension/manifest-key.test.ts
@@ -39,6 +39,6 @@ describe('pinned extension identity', () => {
 
     // The dev/unpacked ID derived from the committed key must be among the
     // allowlisted origins (the store ID joins the list after first publish).
-    expect(originMatches).toContain(extensionIdFromKey(keyMatch![1]))
+    expect(originMatches).toContain(extensionIdFromKey(keyMatch![1]!))
   })
 })

--- a/apps/extension/tsconfig.json
+++ b/apps/extension/tsconfig.json
@@ -10,6 +10,11 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "verbatimModuleSyntax": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/apps/extension/tsconfig.json
+++ b/apps/extension/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  // The extension extends the WXT-generated config, so it can't also extend
+  // ../../tsconfig.base.json. The strictness block below must be kept in sync
+  // with that base by hand.
   "extends": "./.wxt/tsconfig.json",
   "compilerOptions": {
     "target": "ES2022",

--- a/packages/core/src/actions/audio-memo.ts
+++ b/packages/core/src/actions/audio-memo.ts
@@ -134,6 +134,16 @@ export function audioMemoFromPath(path: string): AudioMemoIdentity | null {
     return null
   }
   const [, base, date, hours, minutes, seconds, extension] = match
+  if (
+    base === undefined ||
+    date === undefined ||
+    hours === undefined ||
+    minutes === undefined ||
+    seconds === undefined ||
+    extension === undefined
+  ) {
+    return null
+  }
   if (Number(hours) > 23 || Number(minutes) > 59 || Number(seconds) > 59) {
     return null
   }
@@ -246,7 +256,7 @@ async function memoNoteBody(input: {
   memo: AudioMemoIdentity
   provider: TranscriptionProvider
   apiKey: string
-  fetchFn?: typeof fetch
+  fetchFn?: typeof fetch | undefined
 }): Promise<{ body: string; rejected: boolean }> {
   try {
     const text = await transcribeAudio({

--- a/packages/core/src/actions/capture.ts
+++ b/packages/core/src/actions/capture.ts
@@ -128,6 +128,15 @@ export function captureFromPath(path: string): CaptureIdentity | null {
     return null
   }
   const [, base, date, hours, minutes, seconds] = match
+  if (
+    base === undefined ||
+    date === undefined ||
+    hours === undefined ||
+    minutes === undefined ||
+    seconds === undefined
+  ) {
+    return null
+  }
   if (Number(hours) > 23 || Number(minutes) > 59 || Number(seconds) > 59) {
     return null
   }
@@ -245,7 +254,7 @@ function firstSectionStart(body: string): number {
 async function captureNoteSource(
   envelope: CaptureEnvelope,
   identity: CaptureIdentity,
-  options: { hasScreenshot: boolean; status: CaptureStatus; selectionHash?: string },
+  options: { hasScreenshot: boolean; status: CaptureStatus; selectionHash?: string | undefined },
 ): Promise<string> {
   const body = captureNoteBody(envelope, identity, options.hasScreenshot)
   return upsertFrontmatter(body, {

--- a/packages/core/src/ai/chat/context-window.test.ts
+++ b/packages/core/src/ai/chat/context-window.test.ts
@@ -58,7 +58,7 @@ describe('estimateTokens', () => {
 
   it('counts tool results by their JSON encoding', () => {
     const [, result] = toolExchange('tool-1', 4_000)
-    const tokens = estimateTokens(result)
+    const tokens = estimateTokens(result!)
     expect(tokens).toBeGreaterThan(1_000)
     expect(tokens).toBeLessThan(1_100)
   })
@@ -108,13 +108,13 @@ describe('fitToContextWindow', () => {
 
     const toolMessages = fitted.filter((message) => message.role === 'tool')
     expect(toolMessages).toHaveLength(2)
-    expect(toolMessages[0].content[0]).toMatchObject({
+    expect(toolMessages[0]!.content[0]).toMatchObject({
       toolCallId: 'tool-old',
       output: { type: 'text', value: '[Old tool result elided to fit the context window.]' },
     })
     // The newest turns keep their results verbatim — the model may still be
     // working from them.
-    expect(toolMessages[1].content[0]).toMatchObject({
+    expect(toolMessages[1]!.content[0]).toMatchObject({
       toolCallId: 'tool-new',
       output: { type: 'json' },
     })

--- a/packages/core/src/ai/chat/context-window.ts
+++ b/packages/core/src/ai/chat/context-window.ts
@@ -122,11 +122,15 @@ export function fitToContextWindow(
   const kept: ModelMessage[][] = []
   let used = 0
   for (let index = elided.length - 1; index >= 0; index -= 1) {
-    const cost = totalTokens(elided[index])
+    const segment = elided[index]
+    if (segment === undefined) {
+      continue
+    }
+    const cost = totalTokens(segment)
     if (kept.length > 0 && used + cost > budget) {
       break
     }
-    kept.unshift(elided[index])
+    kept.unshift(segment)
     used += cost
   }
   return kept.flat()

--- a/packages/core/src/ai/chat/store.test.ts
+++ b/packages/core/src/ai/chat/store.test.ts
@@ -83,7 +83,7 @@ describe('loadChatMessages', () => {
     const turns = await loadChatMessages('conv-1')
     expect(turns).toEqual([turn])
     // The query went through the read-only bridge with the conversation bound.
-    const [command, args] = invoke.mock.calls[0]
+    const [command, args] = invoke.mock.calls[0]!
     expect(command).toBe('db_query')
     expect(args).toMatchObject({ params: ['conv-1'] })
   })

--- a/packages/core/src/ai/chat/stream-chat.ts
+++ b/packages/core/src/ai/chat/stream-chat.ts
@@ -90,9 +90,9 @@ export interface ChatTurnOptions {
   /** Graph overview for the system prompt, or `null` to omit the block. */
   context: CloudSafe<CloudGraphContext> | null
   /** Aborts the provider call mid-stream (the UI's stop button). */
-  signal?: AbortSignal
+  signal?: AbortSignal | undefined
   /** Test seam for the note tools' effects. */
-  toolDeps?: NoteToolDeps
+  toolDeps?: NoteToolDeps | undefined
 }
 
 /**
@@ -127,7 +127,7 @@ export async function* streamChatTurn(
       messages: options.messages,
       tools,
       stopWhen: stepCountIs(MAX_STEPS),
-      abortSignal: options.signal,
+      ...(options.signal !== undefined ? { abortSignal: options.signal } : {}),
       onStepFinish: (step) => {
         stepMessages = [...step.response.messages]
       },

--- a/packages/core/src/ai/describe-page.test.ts
+++ b/packages/core/src/ai/describe-page.test.ts
@@ -84,9 +84,9 @@ describe('describePage', () => {
 
     expect(description).toBe('A concise description.')
     expect(calls).toHaveLength(1)
-    const [message] = calls[0].prompt
-    expect(message.role).toBe('user')
-    const parts = message.content as Array<{ type: string; mediaType?: string; text?: string }>
+    const [message] = calls[0]!.prompt
+    expect(message!.role).toBe('user')
+    const parts = message!.content as Array<{ type: string; mediaType?: string; text?: string }>
     const text = parts.find((part) => part.type === 'text')?.text ?? ''
     expect(text).toContain('https://example.com/article')
     expect(text).toContain('An article')
@@ -101,7 +101,7 @@ describe('describePage', () => {
 
     await request()
 
-    const parts = calls[0].prompt[0].content as Array<{ type: string }>
+    const parts = calls[0]!.prompt[0]!.content as Array<{ type: string }>
     expect(parts.map((part) => part.type)).toEqual(['text'])
   })
 
@@ -110,7 +110,7 @@ describe('describePage', () => {
 
     await request({ selection: 'x'.repeat(5_000) })
 
-    const parts = calls[0].prompt[0].content as Array<{ type: string; text?: string }>
+    const parts = calls[0]!.prompt[0]!.content as Array<{ type: string; text?: string }>
     const text = parts.find((part) => part.type === 'text')?.text ?? ''
     expect(text).not.toContain('x'.repeat(1_001))
   })
@@ -120,7 +120,7 @@ describe('describePage', () => {
 
     await request({ contentText: `Important opening paragraph.\n\n${'x'.repeat(7_000)}` })
 
-    const parts = calls[0].prompt[0].content as Array<{ type: string; text?: string }>
+    const parts = calls[0]!.prompt[0]!.content as Array<{ type: string; text?: string }>
     const text = parts.find((part) => part.type === 'text')?.text ?? ''
     expect(text).toContain('Extracted page text: Important opening paragraph.')
     expect(text).not.toContain('x'.repeat(6_001))

--- a/packages/core/src/ai/describe-page.ts
+++ b/packages/core/src/ai/describe-page.ts
@@ -23,18 +23,18 @@ export interface DescribePageRequest {
   /** The BYOK API key, read from the OS keychain by the caller. */
   apiKey: string
   /** Host transport (the Tauri HTTP plugin's fetch; tests pass a stub). */
-  fetchFn?: typeof fetch
+  fetchFn?: typeof fetch | undefined
   /** The captured page. */
   url: string
   title: string
   /** Text the user had selected, if any. */
-  selection?: string
+  selection?: string | undefined
   /** Extracted full-page text, capped before it enters the provider prompt. */
-  contentText?: string
+  contentText?: string | undefined
   /** Scraped meta description, if the scrape produced one. */
-  metaDescription?: string
+  metaDescription?: string | undefined
   /** Downscaled JPEG screenshot, base64 (no data-URL prefix), if captured. */
-  screenshotBase64?: string
+  screenshotBase64?: string | undefined
 }
 
 /**

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -1,5 +1,8 @@
 import type { AiProviderId } from '../settings/schema'
 
+/** A compile-time guarantee that an array has at least one element. */
+type NonEmptyArray<ElementType> = [ElementType, ...ElementType[]]
+
 /**
  * The static BYOK provider catalog (Plan 10): display names, key hints, and
  * the curated model list the settings UI offers per provider. This is policy
@@ -30,10 +33,10 @@ export interface AiProviderInfo {
   /** Placeholder illustrating the provider's API-key format. */
   keyPlaceholder: string
   /** Curated models, most capable first (the first is the picker default). */
-  models: AiModelOption[]
+  models: NonEmptyArray<AiModelOption>
 }
 
-export const AI_PROVIDERS: AiProviderInfo[] = [
+export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
   {
     id: 'openai',
     label: 'OpenAI',

--- a/packages/core/src/ai/provider-config.ts
+++ b/packages/core/src/ai/provider-config.ts
@@ -95,7 +95,7 @@ export function pickTranscriptionConfig(state: AiProvidersState): TranscriptionC
     )
     if (candidates.length > 0) {
       return (
-        candidates.find((candidate) => candidate.id === state.defaultProviderId) ?? candidates[0]
+        candidates.find((candidate) => candidate.id === state.defaultProviderId) ?? candidates[0]!
       )
     }
   }

--- a/packages/core/src/ai/transcribe.test.ts
+++ b/packages/core/src/ai/transcribe.test.ts
@@ -54,9 +54,9 @@ describe('transcribeAudio (openai)', () => {
 
     expect(text).toBe('Hello world.')
     expect(calls).toHaveLength(1)
-    expect(calls[0].url).toBe('https://api.openai.com/v1/audio/transcriptions')
-    expect(calls[0].headers.Authorization).toBe('Bearer sk-test')
-    const form = calls[0].body as FormData
+    expect(calls[0]!.url).toBe('https://api.openai.com/v1/audio/transcriptions')
+    expect(calls[0]!.headers['Authorization']).toBe('Bearer sk-test')
+    const form = calls[0]!.body as FormData
     expect(form.get('model')).toBe(OPENAI_TRANSCRIPTION_MODEL)
     const file = form.get('file') as File
     // whisper-1 sniffs by extension: an audio-only MP4 must upload as .m4a.
@@ -71,7 +71,7 @@ describe('transcribeAudio (openai)', () => {
       request({ fetchFn, mimeType: 'audio/webm;codecs=opus', audio: new Blob(['abc']) }),
     )
 
-    const file = (calls[0].body as FormData).get('file') as File
+    const file = (calls[0]!.body as FormData).get('file') as File
     expect(file.name).toBe('memo.webm')
   })
 
@@ -87,7 +87,7 @@ describe('transcribeAudio (openai)', () => {
 
     expect(text).toBe('fallback worked')
     expect(calls).toHaveLength(2)
-    expect((calls[1].body as FormData).get('model')).toBe(OPENAI_TRANSCRIPTION_FALLBACK_MODEL)
+    expect((calls[1]!.body as FormData).get('model')).toBe(OPENAI_TRANSCRIPTION_FALLBACK_MODEL)
   })
 
   it('marks a refused recording as a rejection — retrying the same bytes cannot help', async () => {
@@ -183,16 +183,16 @@ describe('transcribeAudio (google)', () => {
     const text = await transcribeAudio(request({ provider: 'google', apiKey: 'AIza-test', fetchFn }))
 
     expect(text).toBe('transcript here')
-    expect(calls[0].url).toBe(
+    expect(calls[0]!.url).toBe(
       `https://generativelanguage.googleapis.com/v1beta/models/${GOOGLE_TRANSCRIPTION_MODEL}:generateContent`,
     )
-    expect(calls[0].headers['x-goog-api-key']).toBe('AIza-test')
-    const payload = JSON.parse(String(calls[0].body)) as {
+    expect(calls[0]!.headers['x-goog-api-key']).toBe('AIza-test')
+    const payload = JSON.parse(String(calls[0]!.body)) as {
       contents: { parts: { text?: string; inline_data?: { mime_type: string; data: string } }[] }[]
     }
-    const parts = payload.contents[0].parts
-    expect(parts[0].text).toContain('Transcribe')
-    expect(parts[1].inline_data).toEqual({ mime_type: 'audio/mp4', data: btoa('abc') })
+    const parts = payload.contents[0]!.parts
+    expect(parts[0]!.text).toContain('Transcribe')
+    expect(parts[1]!.inline_data).toEqual({ mime_type: 'audio/mp4', data: btoa('abc') })
   })
 
   it('strips codec parameters from the declared MIME type', async () => {
@@ -203,10 +203,10 @@ describe('transcribeAudio (google)', () => {
       request({ provider: 'google', fetchFn, mimeType: 'audio/webm;codecs=opus' }),
     )
 
-    const payload = JSON.parse(String(calls[0].body)) as {
+    const payload = JSON.parse(String(calls[0]!.body)) as {
       contents: { parts: { inline_data?: { mime_type: string } }[] }[]
     }
-    expect(payload.contents[0].parts[1].inline_data?.mime_type).toBe('audio/webm')
+    expect(payload.contents[0]!.parts[1]!.inline_data?.mime_type).toBe('audio/webm')
   })
 
   it('falls back to the stable model when the primary one is retired (404)', async () => {
@@ -221,8 +221,8 @@ describe('transcribeAudio (google)', () => {
 
     expect(text).toBe('fallback transcript')
     expect(calls).toHaveLength(2)
-    expect(calls[0].url).toContain(GOOGLE_TRANSCRIPTION_MODEL)
-    expect(calls[1].url).toContain(GOOGLE_TRANSCRIPTION_FALLBACK_MODEL)
+    expect(calls[0]!.url).toContain(GOOGLE_TRANSCRIPTION_MODEL)
+    expect(calls[1]!.url).toContain(GOOGLE_TRANSCRIPTION_FALLBACK_MODEL)
   })
 
   it('does not retry non-404 failures', async () => {

--- a/packages/core/src/ai/transcribe.ts
+++ b/packages/core/src/ai/transcribe.ts
@@ -40,7 +40,7 @@ export interface TranscriptionRequest {
    * Host transport — the desktop app passes the Tauri HTTP plugin's fetch
    * (CORS-free); `@reflect/core` itself stays platform-agnostic.
    */
-  fetchFn?: typeof fetch
+  fetchFn?: typeof fetch | undefined
 }
 
 /**

--- a/packages/core/src/ai/validate-key.test.ts
+++ b/packages/core/src/ai/validate-key.test.ts
@@ -24,13 +24,13 @@ describe('validateApiKey', () => {
     await validateApiKey('anthropic', 'sk-ant-test', recordingFetch)
     await validateApiKey('google', 'AIza-test', recordingFetch)
 
-    expect(calls[0].url).toBe('https://api.openai.com/v1/models')
-    expect(calls[0].headers.Authorization).toBe('Bearer sk-test')
-    expect(calls[1].url).toBe('https://api.anthropic.com/v1/models')
-    expect(calls[1].headers['x-api-key']).toBe('sk-ant-test')
-    expect(calls[1].headers['anthropic-version']).toBe('2023-06-01')
-    expect(calls[2].url).toBe('https://generativelanguage.googleapis.com/v1beta/models')
-    expect(calls[2].headers['x-goog-api-key']).toBe('AIza-test')
+    expect(calls[0]!.url).toBe('https://api.openai.com/v1/models')
+    expect(calls[0]!.headers['Authorization']).toBe('Bearer sk-test')
+    expect(calls[1]!.url).toBe('https://api.anthropic.com/v1/models')
+    expect(calls[1]!.headers['x-api-key']).toBe('sk-ant-test')
+    expect(calls[1]!.headers['anthropic-version']).toBe('2023-06-01')
+    expect(calls[2]!.url).toBe('https://generativelanguage.googleapis.com/v1beta/models')
+    expect(calls[2]!.headers['x-goog-api-key']).toBe('AIza-test')
   })
 
   it('reads an ok response as valid', async () => {

--- a/packages/core/src/embeddings/chunk.test.ts
+++ b/packages/core/src/embeddings/chunk.test.ts
@@ -8,8 +8,8 @@ describe('chunkNote', () => {
     const source = '# Alpha\n\nFirst section text.\n\n# Beta\n\nSecond section text.\n'
     const chunks = await chunkNote(PATH, source)
     expect(chunks).toHaveLength(2)
-    expect(chunks[0].heading).toBe('Alpha')
-    expect(chunks[1].heading).toBe('Beta')
+    expect(chunks[0]!.heading).toBe('Alpha')
+    expect(chunks[1]!.heading).toBe('Beta')
     // Offsets slice back to the exact chunk text.
     for (const chunk of chunks) {
       expect(source.slice(chunk.posFrom, chunk.posTo)).toBe(chunk.text)
@@ -26,8 +26,8 @@ describe('chunkNote', () => {
     const after = '# Stable\n\nUnchanged text here.\n\n# Volatile\n\nNew content entirely.\n'
     const a = await chunkNote(PATH, before)
     const b = await chunkNote(PATH, after)
-    expect(b[0].contentHash).toBe(a[0].contentHash) // the hash-skip foundation
-    expect(b[1].contentHash).not.toBe(a[1].contentHash)
+    expect(b[0]!.contentHash).toBe(a[0]!.contentHash) // the hash-skip foundation
+    expect(b[1]!.contentHash).not.toBe(a[1]!.contentHash)
   })
 
   it('splits a long section into sentence-aligned chunks', async () => {
@@ -41,7 +41,7 @@ describe('chunkNote', () => {
     }
     // Chunks cover the section contiguously, in order.
     for (let i = 1; i < chunks.length; i += 1) {
-      expect(chunks[i].posFrom).toBe(chunks[i - 1].posTo)
+      expect(chunks[i]!.posFrom).toBe(chunks[i - 1]!.posTo)
     }
   })
 
@@ -49,8 +49,8 @@ describe('chunkNote', () => {
     const source = '---\ntitle: Meta\n---\n\nJust a body without headings.\n'
     const chunks = await chunkNote(PATH, source)
     expect(chunks).toHaveLength(1)
-    expect(chunks[0].heading).toBeNull()
-    expect(chunks[0].text).not.toContain('title: Meta')
+    expect(chunks[0]!.heading).toBeNull()
+    expect(chunks[0]!.text).not.toContain('title: Meta')
   })
 
   it('returns nothing for empty or whitespace-only notes', async () => {
@@ -62,7 +62,7 @@ describe('chunkNote', () => {
     const sentence = 'A solid sentence that carries real length for the chunker to count. '
     const source = `# One\n\n${sentence.repeat(16)}Tiny tail.`
     const chunks = await chunkNote(PATH, source)
-    const last = chunks[chunks.length - 1]
+    const last = chunks[chunks.length - 1]!
     expect(last.text.length).toBeGreaterThanOrEqual(200)
     expect(last.text.endsWith('Tiny tail.')).toBe(true)
   })

--- a/packages/core/src/embeddings/chunk.ts
+++ b/packages/core/src/embeddings/chunk.ts
@@ -54,12 +54,12 @@ export async function chunkNote(path: string, source: string): Promise<NoteChunk
   // extending to the next heading or end of file).
   const sections: Section[] = []
   const bodyStart = splitFrontmatter(source).bodyOffset
-  const firstHeadingAt = headings.length > 0 ? headings[0].from : source.length
+  const firstHeadingAt = headings.length > 0 ? headings[0]!.from : source.length
   if (firstHeadingAt > bodyStart) {
     sections.push({ heading: null, from: bodyStart, to: firstHeadingAt })
   }
   headings.forEach((heading, i) => {
-    const to = i + 1 < headings.length ? headings[i + 1].from : source.length
+    const to = i + 1 < headings.length ? headings[i + 1]!.from : source.length
     sections.push({ heading: heading.text, from: heading.from, to })
   })
 
@@ -103,8 +103,8 @@ export async function chunkNote(path: string, source: string): Promise<NoteChunk
 
   // A runt tail reads better (and embeds better) merged into its predecessor.
   if (chunks.length >= 2) {
-    const last = chunks[chunks.length - 1]
-    const prev = chunks[chunks.length - 2]
+    const last = chunks[chunks.length - 1]!
+    const prev = chunks[chunks.length - 2]!
     if (last.text.length < MIN_CHARS && prev.heading === last.heading) {
       const text = source.slice(prev.posFrom, last.posTo)
       chunks.splice(chunks.length - 2, 2, {

--- a/packages/core/src/embeddings/pipeline.test.ts
+++ b/packages/core/src/embeddings/pipeline.test.ts
@@ -61,7 +61,7 @@ describe('embedNote', () => {
     const count = await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
     expect(count).toBe(2)
     expect(embedded).toHaveLength(1) // one batched embed_texts call
-    expect(applied[0].chunks.every((chunk) => chunk.vector !== null)).toBe(true)
+    expect(applied[0]!.chunks.every((chunk) => chunk.vector !== null)).toBe(true)
   })
 
   it('the hash-skip embeds nothing when stored hashes match', async () => {
@@ -69,7 +69,7 @@ describe('embedNote', () => {
     // First pass captures the chunk hash the second pass will find "stored".
     const first = fakePipelineBridge({ content, storedRows: [] })
     await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
-    const hash = first.applied[0].chunks[0].contentHash
+    const hash = first.applied[0]!.chunks[0]!.contentHash
 
     const second = fakePipelineBridge({
       content,
@@ -78,14 +78,14 @@ describe('embedNote', () => {
     const count = await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
     expect(count).toBe(0)
     expect(second.embedded).toHaveLength(0) // nothing re-embedded
-    expect(second.applied[0].chunks[0].vector).toBeNull() // metadata-only row
+    expect(second.applied[0]!.chunks[0]!.vector).toBeNull() // metadata-only row
   })
 
   it('a model change re-embeds chunks whose hashes are unchanged', async () => {
     const content = '# One\n\nAlpha text.\n'
     const first = fakePipelineBridge({ content, storedRows: [] })
     await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
-    const hash = first.applied[0].chunks[0].contentHash
+    const hash = first.applied[0]!.chunks[0]!.contentHash
 
     const second = fakePipelineBridge({
       content,
@@ -103,18 +103,18 @@ describe('embedNote', () => {
     const dup = section + section
     const first = fakePipelineBridge({ content: dup, storedRows: [] })
     await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
-    const hashes = first.applied[0].chunks.map((chunk) => chunk.contentHash)
+    const hashes = first.applied[0]!.chunks.map((chunk) => chunk.contentHash)
     expect(hashes[0]).toBe(hashes[1]) // genuinely duplicated chunks
 
     // Only ONE stored row for that hash: exactly one chunk may skip; the
     // other must re-embed (vector present), or apply_chunks errors loudly.
     const second = fakePipelineBridge({
       content: dup,
-      storedRows: [{ content_hash: hashes[0], model_id: MODEL }],
+      storedRows: [{ content_hash: hashes[0]!, model_id: MODEL }],
     })
     const count = await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
     expect(count).toBe(1)
-    const sent = second.applied[0].chunks
+    const sent = second.applied[0]!.chunks
     expect(sent.filter((chunk) => chunk.vector === null)).toHaveLength(1)
     expect(sent.filter((chunk) => chunk.vector !== null)).toHaveLength(1)
   })

--- a/packages/core/src/embeddings/pipeline.ts
+++ b/packages/core/src/embeddings/pipeline.ts
@@ -76,7 +76,9 @@ export async function embedNote(options: EmbedNoteOptions): Promise<number> {
     text: chunk.text,
     contentHash: chunk.contentHash,
     modelId,
-    vector: skip[i] ? null : vectors[vectorAt++],
+    // A non-skipped chunk always has a freshly-embedded vector: `vectors` is
+    // exactly as long as the non-skipped chunks, consumed in order here.
+    vector: skip[i] ? null : vectors[vectorAt++]!,
   }))
   await embedApply(path, payload, generation)
   return toEmbed.length

--- a/packages/core/src/embeddings/retrieve.test.ts
+++ b/packages/core/src/embeddings/retrieve.test.ts
@@ -50,8 +50,8 @@ describe('bestChunkPerNote', () => {
     ]
     const hits = bestChunkPerNote(rows, 12)
     expect(hits).toHaveLength(1)
-    expect(hits[0].snippet).toBe('best chunk')
-    expect(hits[0].score).toBeCloseTo(0.8)
+    expect(hits[0]!.snippet).toBe('best chunk')
+    expect(hits[0]!.score).toBeCloseTo(0.8)
   })
 
   it('excludes the seed note and respects the limit', () => {
@@ -62,8 +62,8 @@ describe('bestChunkPerNote', () => {
 
   it('trims snippets and converts the private flag', () => {
     const hits = bestChunkPerNote([row('notes/p.md', 0.1, { isPrivate: 1 })], 12)
-    expect(hits[0].snippet).toBe('about notes/p.md')
-    expect(hits[0].isPrivate).toBe(true)
+    expect(hits[0]!.snippet).toBe('about notes/p.md')
+    expect(hits[0]!.isPrivate).toBe(true)
   })
 })
 
@@ -92,8 +92,8 @@ describe('mergeNearestFirst (multi-seed related notes)', () => {
     const fromLaterChunk = [row('notes/both.md', 0.2, { text: 'near chunk' })]
     const hits = bestChunkPerNote(mergeNearestFirst([fromLeadChunk, fromLaterChunk]), 10)
     expect(hits).toHaveLength(1)
-    expect(hits[0].snippet).toBe('near chunk')
-    expect(hits[0].score).toBeCloseTo(0.8)
+    expect(hits[0]!.snippet).toBe('near chunk')
+    expect(hits[0]!.score).toBeCloseTo(0.8)
   })
 })
 
@@ -102,7 +102,7 @@ describe('fuseRanked (reciprocal rank fusion)', () => {
     const lexical = [hit('notes/both.md'), hit('notes/lex-only.md')]
     const semantic = [hit('notes/sem-only.md'), hit('notes/both.md')]
     const fused = fuseRanked([lexical, semantic], 10)
-    expect(fused[0].path).toBe('notes/both.md')
+    expect(fused[0]!.path).toBe('notes/both.md')
     expect(fused).toHaveLength(3)
   })
 
@@ -116,12 +116,12 @@ describe('fuseRanked (reciprocal rank fusion)', () => {
     const semantic = [hit('a', { snippet: '' })]
     const lexical = [hit('a', { snippet: 'lexical snippet' })]
     const fused = fuseRanked([semantic, lexical], 5)
-    expect(fused[0].snippet).toBe('lexical snippet')
+    expect(fused[0]!.snippet).toBe('lexical snippet')
     expect(fuseRanked([semantic, lexical], 5)).toEqual(fused)
   })
 
   it('keeps the private flag through fusion', () => {
     const fused = fuseRanked([[hit('p', { isPrivate: true })]], 5)
-    expect(fused[0].isPrivate).toBe(true)
+    expect(fused[0]!.isPrivate).toBe(true)
   })
 })

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -53,7 +53,7 @@ describe('toAppError', () => {
     expect(toAppError(BigInt(1)).kind).toBe('unknown')
 
     const circular: Record<string, unknown> = {}
-    circular.self = circular
+    circular['self'] = circular
     expect(toAppError(circular).kind).toBe('unknown')
   })
 

--- a/packages/core/src/graph/paths.ts
+++ b/packages/core/src/graph/paths.ts
@@ -21,8 +21,9 @@ export function dailyPath(date: string): string {
     throw new Error(`dailyPath expects an ISO YYYY-MM-DD date, got: ${date}`)
   }
   // Reject well-formatted but invalid dates (e.g. 2026-13-99, 2026-02-31) by
-  // round-tripping through UTC and comparing the components.
-  const [year, month, day] = date.split('-').map(Number)
+  // round-tripping through UTC and comparing the components. The regex above
+  // guarantees three numeric parts, so the destructure can't yield undefined.
+  const [year, month, day] = date.split('-').map(Number) as [number, number, number]
   const utc = new Date(Date.UTC(year, month - 1, day))
   if (
     utc.getUTCFullYear() !== year ||

--- a/packages/core/src/import/v1-markdown.ts
+++ b/packages/core/src/import/v1-markdown.ts
@@ -247,16 +247,16 @@ function parseDailyHeadingDate(line: string): string | null {
   if (parts.length !== 3) {
     return null
   }
-
-  if (parts[1] === undefined || parts[2] === undefined) {
+  const [first, second, third] = parts
+  if (first === undefined || second === undefined || third === undefined) {
     return null
   }
 
-  if (MONTHS.has(parts[0].toLowerCase())) {
-    return isoDate(parts[2], parts[0], parts[1].replace(/,$/, ''))
+  if (MONTHS.has(first.toLowerCase())) {
+    return isoDate(third, first, second.replace(/,$/, ''))
   }
 
-  return isoDate(parts[2], parts[1].replace(/,$/, ''), parts[0])
+  return isoDate(third, second.replace(/,$/, ''), first)
 }
 
 function isoDate(yearText: string, monthText: string, dayText: string): string | null {

--- a/packages/core/src/indexing/file-changes.test.ts
+++ b/packages/core/src/indexing/file-changes.test.ts
@@ -56,7 +56,7 @@ describe('subscribeFileChanges', () => {
     emitFromBridge([{ path: 'notes/watched.md', kind: 'upsert' }])
     emitFileChanges([{ path: 'notes/merged.md', kind: 'upsert' }])
 
-    expect(received.map((batch) => batch[0].path)).toEqual([
+    expect(received.map((batch) => batch[0]!.path)).toEqual([
       'notes/watched.md',
       'notes/merged.md',
     ])

--- a/packages/core/src/indexing/filter-query.test.ts
+++ b/packages/core/src/indexing/filter-query.test.ts
@@ -3,7 +3,7 @@ import { parseSearchQuery } from './filter-query'
 
 function startOfLocalDay(date: string, days = 0): number {
   const [year, month, day] = date.split('-').map(Number)
-  return new Date(year, month - 1, day + days).getTime()
+  return new Date(year!, month! - 1, day! + days).getTime()
 }
 
 describe('parseSearchQuery', () => {

--- a/packages/core/src/indexing/filter-query.ts
+++ b/packages/core/src/indexing/filter-query.ts
@@ -63,7 +63,11 @@ const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 const TAG_TOKEN_RE = /^#\p{L}[\p{L}\p{N}/_-]*$/u
 
 function isCalendarDate(value: string): boolean {
-  const [year, month, day] = value.split('-').map(Number)
+  // Callers gate on ISO_DATE_RE first, so the split always yields three parts.
+  const parts = value.split('-').map(Number)
+  const year = parts[0]!
+  const month = parts[1]!
+  const day = parts[2]!
   if (month < 1 || month > 12) {
     return false
   }
@@ -73,7 +77,11 @@ function isCalendarDate(value: string): boolean {
 
 /** Epoch ms of the **local** start of `YYYY-MM-DD` (+`days`). */
 function localDayStartMs(date: string, days = 0): number {
-  const [year, month, day] = date.split('-').map(Number)
+  // Callers gate on ISO_DATE_RE first, so the split always yields three parts.
+  const parts = date.split('-').map(Number)
+  const year = parts[0]!
+  const month = parts[1]!
+  const day = parts[2]!
   return new Date(year, month - 1, day + days).getTime()
 }
 

--- a/packages/core/src/indexing/filtered-search.test.ts
+++ b/packages/core/src/indexing/filtered-search.test.ts
@@ -7,7 +7,7 @@ const mockInvoke = vi.fn<(command: string, args: Record<string, unknown>) => Pro
 
 function startOfLocalDay(date: string): number {
   const [year, month, day] = date.split('-').map(Number)
-  return new Date(year, month - 1, day).getTime()
+  return new Date(year!, month! - 1, day!).getTime()
 }
 
 beforeEach(() => {
@@ -31,15 +31,15 @@ describe('searchWithFilters', () => {
       { path: 'notes/work.md', title: 'Work', dailyDate: null, snippet: null },
     ])
 
-    const [command, args] = mockInvoke.mock.calls[0]
+    const [command, args] = mockInvoke.mock.calls[0]!
     expect(command).toBe('db_query')
-    const sql = String(args.sql)
+    const sql = String(args['sql'])
     expect(sql).toContain('from "tags"')
     expect(sql).toContain('inner join "notes"')
     expect(sql).toContain('"tags"."tag_key"')
     expect(sql).not.toContain('search_fts')
     expect(sql).not.toContain('lower(')
-    expect(args.params).toEqual(['work', 12])
+    expect(args['params']).toEqual(['work', 12])
   })
 
   it('keeps additional tag filters as indexed existence checks', async () => {
@@ -49,14 +49,14 @@ describe('searchWithFilters', () => {
 
     await searchWithFilters(parseSearchQuery('#Work #Home'), 12)
 
-    const [, args] = mockInvoke.mock.calls[0]
-    const sql = String(args.sql)
+    const [, args] = mockInvoke.mock.calls[0]!
+    const sql = String(args['sql'])
     expect(sql).toContain('from "tags"')
     expect(sql).toContain('from "tags" as "filter_tags"')
     expect(sql).toContain('"filter_tags"."note_path" = "notes"."path"')
     expect(sql).toContain('"filter_tags"."tag_key"')
     expect(sql).not.toContain('search_fts')
-    expect(args.params).toEqual(['work', 'home', 12])
+    expect(args['params']).toEqual(['work', 'home', 12])
   })
 
   it('applies non-tag filters on the tag-first recall path', async () => {
@@ -75,13 +75,13 @@ describe('searchWithFilters', () => {
         snippet: null,
       },
     ])
-    const [, args] = mockInvoke.mock.calls[0]
-    const sql = String(args.sql)
+    const [, args] = mockInvoke.mock.calls[0]!
+    const sql = String(args['sql'])
     expect(sql).toContain('from "tags"')
     expect(sql).toContain('"notes"."daily_date" is not null')
     expect(sql).toContain('"notes"."is_pinned" =')
     expect(sql).toContain('"notes"."mtime" >=')
     expect(sql).not.toContain('search_fts')
-    expect(args.params).toEqual(['work', 1, startOfLocalDay('2026-01-01'), 12])
+    expect(args['params']).toEqual(['work', 1, startOfLocalDay('2026-01-01'), 12])
   })
 })

--- a/packages/core/src/indexing/filtered-search.ts
+++ b/packages/core/src/indexing/filtered-search.ts
@@ -56,7 +56,8 @@ export async function searchWithFilters(
       .selectFrom('tags')
       .innerJoin('notes', 'notes.path', 'tags.notePath')
       .select(['notes.path', 'notes.title', 'notes.dailyDate'])
-      .where('tags.tagKey', '=', primaryTag)
+      // The length guard above guarantees a primary tag.
+      .where('tags.tagKey', '=', primaryTag!)
       .distinct()
       .limit(limit)
 

--- a/packages/core/src/indexing/graph-stats.test.ts
+++ b/packages/core/src/indexing/graph-stats.test.ts
@@ -43,26 +43,26 @@ describe('loadGraphStats', () => {
     for (const [command, args] of mockInvoke.mock.calls) {
       expect(command).toBe('db_query')
       // The hard block: every aggregate is computed over public rows only.
-      expect(String(args.sql)).toContain('"is_private" = ?')
-      expect(args.params).toContain(0)
+      expect(String(args['sql'])).toContain('"is_private" = ?')
+      expect(args['params']).toContain(0)
     }
 
-    const [, noteArgs] = mockInvoke.mock.calls[0]
-    expect(String(noteArgs.sql)).toContain('"daily_date" is null')
+    const [, noteArgs] = mockInvoke.mock.calls[0]!
+    expect(String(noteArgs['sql'])).toContain('"daily_date" is null')
 
-    const [, dailyArgs] = mockInvoke.mock.calls[1]
-    const dailySql = String(dailyArgs.sql)
+    const [, dailyArgs] = mockInvoke.mock.calls[1]!
+    const dailySql = String(dailyArgs['sql'])
     expect(dailySql).toContain('"daily_date" is not null')
     expect(dailySql).toContain('min(daily_date)')
     expect(dailySql).toContain('max(daily_date)')
 
-    const [, tagArgs] = mockInvoke.mock.calls[2]
-    const tagSql = String(tagArgs.sql)
+    const [, tagArgs] = mockInvoke.mock.calls[2]!
+    const tagSql = String(tagArgs['sql'])
     expect(tagSql).toContain('inner join "notes"')
     expect(tagSql).toContain('group by "tags"."tag_key"')
     expect(tagSql).toContain('order by count(*) desc')
     // One row past the cap, so truncation is detectable.
-    expect(tagArgs.params).toContain(41)
+    expect(tagArgs['params']).toContain(41)
   })
 
   it('caps the facets at the limit and flags the truncation', async () => {

--- a/packages/core/src/indexing/group-tasks.test.ts
+++ b/packages/core/src/indexing/group-tasks.test.ts
@@ -52,8 +52,8 @@ describe('groupTasks', () => {
     )
     // No Overdue bucket: a daily-note task with no explicit due date is current.
     expect(groups.map((group) => group.kind)).toEqual(['current', 'upcoming'])
-    expect(groups[0].tasks.map((entry) => entry.text)).toEqual(['past', 'today'])
-    expect(groups[1].tasks.map((entry) => entry.text)).toEqual(['future'])
+    expect(groups[0]!.tasks.map((entry) => entry.text)).toEqual(['past', 'today'])
+    expect(groups[1]!.tasks.map((entry) => entry.text)).toEqual(['future'])
   })
 
   it('marks a task with an explicit past due date as Overdue', () => {
@@ -62,7 +62,7 @@ describe('groupTasks', () => {
       TODAY,
     )
     expect(groups.map((group) => group.kind)).toEqual(['overdue'])
-    expect(groups[0].tasks.map((entry) => entry.text)).toEqual(['late'])
+    expect(groups[0]!.tasks.map((entry) => entry.text)).toEqual(['late'])
   })
 
   it('lets the explicit due date override the note daily date, both directions', () => {
@@ -76,9 +76,9 @@ describe('groupTasks', () => {
       TODAY,
     )
     const byKind = Object.fromEntries(groups.map((group) => [group.kind, group.tasks.map((entry) => entry.text)]))
-    expect(byKind.overdue).toEqual(['pulled-in'])
-    expect(byKind.upcoming).toEqual(['pushed-out'])
-    expect(byKind.current).toBeUndefined()
+    expect(byKind['overdue']).toEqual(['pulled-in'])
+    expect(byKind['upcoming']).toEqual(['pushed-out'])
+    expect(byKind['current']).toBeUndefined()
   })
 
   it('puts a due-dated task from a regular note into a date bucket, not a note group', () => {
@@ -99,7 +99,7 @@ describe('groupTasks', () => {
     )
     expect(groups).toHaveLength(1)
     expect(groups[0]).toMatchObject({ kind: 'note', label: 'Project', notePath: 'notes/p.md' })
-    expect(groups[0].tasks.map((entry) => entry.text)).toEqual(['first', 'second'])
+    expect(groups[0]!.tasks.map((entry) => entry.text)).toEqual(['first', 'second'])
   })
 
   it('orders the display Current → Overdue → Upcoming → note groups', () => {
@@ -124,8 +124,8 @@ describe('groupTasks', () => {
       ],
       TODAY,
     )
-    expect(groups[0].kind).toBe('overdue')
-    expect(groups[0].tasks.map((entry) => entry.text)).toEqual(['a', 'c', 'b'])
+    expect(groups[0]!.kind).toBe('overdue')
+    expect(groups[0]!.tasks.map((entry) => entry.text)).toEqual(['a', 'c', 'b'])
   })
 
   it('orders note groups pinned-first, then most-recently edited', () => {

--- a/packages/core/src/indexing/group-tasks.ts
+++ b/packages/core/src/indexing/group-tasks.ts
@@ -104,8 +104,9 @@ function comparePinPrecedence(
  * note metadata is shared by all its tasks, so the first task carries the sort key.
  */
 function compareNoteGroups(left: TaskGroup, right: TaskGroup): number {
-  const first = left.tasks[0]
-  const second = right.tasks[0]
+  // Groups are never built empty, so each has a first task carrying the sort key.
+  const first = left.tasks[0]!
+  const second = right.tasks[0]!
   const byPin = comparePinPrecedence(first, second)
   if (byPin !== 0) {
     return byPin
@@ -163,8 +164,9 @@ export function groupTasks(tasks: readonly OpenTask[], today: string): TaskGroup
   const noteGroups: TaskGroup[] = [...byNote.values()]
     .map((noteTasks) => ({
       kind: 'note' as const,
-      label: noteTasks[0].noteTitle,
-      notePath: noteTasks[0].notePath,
+      // A `byNote` entry only exists once a task has been pushed into it.
+      label: noteTasks[0]!.noteTitle,
+      notePath: noteTasks[0]!.notePath,
       tasks: noteTasks.sort((left, right) => left.markerOffset - right.markerOffset),
     }))
     .sort(compareNoteGroups)

--- a/packages/core/src/indexing/indexer.ts
+++ b/packages/core/src/indexing/indexer.ts
@@ -49,7 +49,7 @@ export const PROJECTION_VERSION_KEY = 'projection_version'
  */
 export async function indexNote(
   path: string,
-  options: { generation: number; content?: string; mtime?: number },
+  options: { generation: number; content?: string | undefined; mtime?: number | undefined },
 ): Promise<void> {
   const content = options.content ?? (await readNote(path))
   const parsed = parseNote({ path, source: content })
@@ -106,7 +106,7 @@ async function applyRebuildBatch(
       if (onSkippedNote === undefined) {
         throw cause
       }
-      onSkippedNote({ path: notes[0].path, message: errorMessage(cause) })
+      onSkippedNote({ path: notes[0]!.path, message: errorMessage(cause) })
       return
     }
     const midpoint = Math.ceil(notes.length / 2)

--- a/packages/core/src/indexing/live.test.ts
+++ b/packages/core/src/indexing/live.test.ts
@@ -27,13 +27,13 @@ describe('applyIndexChanges', () => {
     const applied: string[] = []
     fakeBridge(async (command, args) => {
       if (command === 'note_read') {
-        if (args.path === 'notes/bad.md') {
+        if (args['path'] === 'notes/bad.md') {
           throw { kind: 'io', message: 'unreadable' }
         }
         return '# ok'
       }
       if (command === 'index_apply') {
-        applied.push((args.note as { path: string }).path)
+        applied.push((args['note'] as { path: string }).path)
       }
       return null
     })
@@ -88,8 +88,8 @@ describe('subscribeIndexChanges', () => {
     let releaseFirstRead: () => void = () => {}
     const { emitChanges } = fakeBridge(async (command, args) => {
       if (command === 'note_read') {
-        order.push(`read:${String(args.path)}`)
-        if (args.path === 'notes/slow.md') {
+        order.push(`read:${String(args['path'])}`)
+        if (args['path'] === 'notes/slow.md') {
           await new Promise<void>((resolve) => {
             releaseFirstRead = resolve
           })
@@ -97,7 +97,7 @@ describe('subscribeIndexChanges', () => {
         return '# content'
       }
       if (command === 'index_apply') {
-        order.push(`apply:${(args.note as { path: string }).path}`)
+        order.push(`apply:${(args['note'] as { path: string }).path}`)
       }
       return null
     })
@@ -130,7 +130,7 @@ describe('subscribeIndexChanges', () => {
         return '# content'
       }
       if (command === 'index_apply') {
-        order.push(`apply:${(args.note as { path: string }).path}`)
+        order.push(`apply:${(args['note'] as { path: string }).path}`)
       }
       return null
     })
@@ -158,7 +158,7 @@ describe('subscribeIndexChanges', () => {
         return '# content'
       }
       if (command === 'index_apply') {
-        mtimes.push((args.note as { mtime: number }).mtime)
+        mtimes.push((args['note'] as { mtime: number }).mtime)
       }
       return null
     })
@@ -201,13 +201,13 @@ describe('applyIndexChanges move healing (Plan 17)', () => {
     fakeBridge(async (command, args) => {
       calls.push([command, args])
       if (command === 'note_read') {
-        if (args.path === NEW) {
+        if (args['path'] === NEW) {
           return CONTENT
         }
         throw { kind: 'notFound', message: 'missing' }
       }
       if (command === 'db_query') {
-        const params = (args.params as unknown[]) ?? []
+        const params = (args['params'] as unknown[]) ?? []
         if (params.includes(OLD)) {
           return [{ path: OLD, id: options?.rowId === undefined ? '01abcdefghjkmnpqrstvwxyz00' : options.rowId }]
         }
@@ -235,8 +235,8 @@ describe('applyIndexChanges move healing (Plan 17)', () => {
     const move = calls.find(([command]) => command === 'index_move')
     expect(move?.[1]).toEqual({ from: OLD, to: NEW, generation: 7 })
     const apply = calls.find(([command]) => command === 'index_apply')
-    expect((apply?.[1].note as { path: string; mtime: number }).path).toBe(NEW)
-    expect((apply?.[1].note as { path: string; mtime: number }).mtime).toBe(42)
+    expect((apply?.[1]['note'] as { path: string; mtime: number }).path).toBe(NEW)
+    expect((apply?.[1]['note'] as { path: string; mtime: number }).mtime).toBe(42)
   })
 
   it('announces the heal via onMoved so the app can follow', async () => {

--- a/packages/core/src/indexing/local-write-echo.test.ts
+++ b/packages/core/src/indexing/local-write-echo.test.ts
@@ -29,8 +29,8 @@ describe('local write echo (Plan 19, decision 5)', () => {
     await writeNote('daily/2026-06-12.md', 'hello', 1)
 
     expect(seen).toHaveLength(1)
-    expect(seen[0][0]).toMatchObject({ path: 'daily/2026-06-12.md', kind: 'upsert' })
-    expect(seen[0][0].modifiedMs).toBeTypeOf('number')
+    expect(seen[0]![0]).toMatchObject({ path: 'daily/2026-06-12.md', kind: 'upsert' })
+    expect(seen[0]![0]!.modifiedMs).toBeTypeOf('number')
     unlisten()
   })
 

--- a/packages/core/src/indexing/move-healing.ts
+++ b/packages/core/src/indexing/move-healing.ts
@@ -40,7 +40,7 @@ export interface ExternalMoveScan {
 export async function detectExternalMoves(
   orphanPaths: string[],
   arrivalPaths: string[],
-  options?: { signal?: AbortSignal },
+  options?: { signal?: AbortSignal | undefined },
 ): Promise<ExternalMoveScan> {
   const content = new Map<string, string>()
   if (orphanPaths.length === 0 || arrivalPaths.length === 0) {

--- a/packages/core/src/indexing/note-list.test.ts
+++ b/packages/core/src/indexing/note-list.test.ts
@@ -56,9 +56,9 @@ describe('listNotes', () => {
       },
     ])
 
-    const [command, args] = mockInvoke.mock.calls[0]
+    const [command, args] = mockInvoke.mock.calls[0]!
     expect(command).toBe('db_query')
-    const sql = String(args.sql)
+    const sql = String(args['sql'])
     // The snippet is the stored projection column — no note_text join, no
     // per-query derivation.
     expect(sql).toContain('"preview"')
@@ -72,12 +72,12 @@ describe('listNotes', () => {
     // The tag fetch joins the same note predicates — never a `note_path IN`
     // list, whose per-row parameter would hit SQLite's bound-parameter
     // ceiling on large graphs.
-    const [, tagArgs] = mockInvoke.mock.calls[1]
-    const tagSql = String(tagArgs.sql)
+    const [, tagArgs] = mockInvoke.mock.calls[1]!
+    const tagSql = String(tagArgs['sql'])
     expect(tagSql).toContain('inner join "notes"')
     expect(tagSql).toContain('"daily_date" is null')
     expect(tagSql).not.toContain(' in (')
-    expect(tagArgs.params).toEqual([])
+    expect(tagArgs['params']).toEqual([])
   })
 
   it('narrows both queries to one tag via tag-first joins on the stored folded tag_key', async () => {
@@ -90,22 +90,22 @@ describe('listNotes', () => {
     await listNotes({ tag: 'Book' })
 
     expect(mockInvoke).toHaveBeenCalledTimes(2)
-    const [, listArgs] = mockInvoke.mock.calls[0]
-    const listSql = String(listArgs.sql)
+    const [, listArgs] = mockInvoke.mock.calls[0]!
+    const listSql = String(listArgs['sql'])
     expect(listSql).toContain('from "tags"')
     expect(listSql).toContain('inner join "notes"')
     expect(listSql).toContain('"tags"."tag_key"')
     expect(listSql).not.toContain('exists')
     expect(listSql).not.toContain('lower(')
-    expect(listArgs.params).toEqual(['book'])
+    expect(listArgs['params']).toEqual(['book'])
 
-    const [, tagArgs] = mockInvoke.mock.calls[1]
-    const tagSql = String(tagArgs.sql)
+    const [, tagArgs] = mockInvoke.mock.calls[1]!
+    const tagSql = String(tagArgs['sql'])
     expect(tagSql).toContain('inner join "tags" as "filter_tags"')
     expect(tagSql).toContain('"filter_tags"."tag_key"')
     expect(tagSql).not.toContain('exists')
     expect(tagSql).not.toContain('lower(')
-    expect(tagArgs.params).toEqual(['book'])
+    expect(tagArgs['params']).toEqual(['book'])
   })
 
   it('skips the tag fetch entirely when no notes match', async () => {
@@ -138,14 +138,14 @@ describe('listRecentNotes', () => {
         isPrivate: false,
       },
     ])
-    const [command, args] = mockInvoke.mock.calls[0]
+    const [command, args] = mockInvoke.mock.calls[0]!
     expect(command).toBe('db_query')
-    const sql = String(args.sql)
+    const sql = String(args['sql'])
     expect(sql).toContain('"daily_date" is null')
     expect(sql).toContain('"is_private"')
     expect(sql).toContain('order by "notes"."mtime" desc')
     expect(sql).toContain('limit')
-    expect(args.params).toEqual([0, 5])
+    expect(args['params']).toEqual([0, 5])
   })
 
   it('narrows to one tag via the stored folded tag_key', async () => {
@@ -153,14 +153,14 @@ describe('listRecentNotes', () => {
 
     await listRecentNotes({ limit: 5, tag: 'Book' })
 
-    const [, args] = mockInvoke.mock.calls[0]
-    const sql = String(args.sql)
+    const [, args] = mockInvoke.mock.calls[0]!
+    const sql = String(args['sql'])
     expect(sql).toContain('from "tags"')
     expect(sql).toContain('inner join "notes"')
     expect(sql).toContain('"tags"."tag_key"')
     expect(sql).not.toContain('exists')
     expect(sql).not.toContain('lower(')
-    expect(args.params).toEqual(['book', 0, 5])
+    expect(args['params']).toEqual(['book', 0, 5])
   })
 })
 
@@ -177,9 +177,9 @@ describe('listNoteTags', () => {
       { tag: 'Book', count: 3 },
       { tag: 'link', count: 12 },
     ])
-    const [command, args] = mockInvoke.mock.calls[0]
+    const [command, args] = mockInvoke.mock.calls[0]!
     expect(command).toBe('db_query')
-    const sql = String(args.sql)
+    const sql = String(args['sql'])
     expect(sql).toContain('"daily_date" is null')
     expect(sql).toContain('group by "tags"."tag_key"')
   })

--- a/packages/core/src/indexing/parity.test.ts
+++ b/packages/core/src/indexing/parity.test.ts
@@ -104,7 +104,7 @@ async function deriveExpectations(): Promise<ExpectedParity> {
 describe('TS↔Rust parity corpus', () => {
   it('expected.json matches what the core pipeline derives', async () => {
     const derived = await deriveExpectations()
-    if (process.env.UPDATE_PARITY) {
+    if (process.env['UPDATE_PARITY']) {
       writeFileSync(expectedFile, `${JSON.stringify(derived, null, 2)}\n`)
     }
     const committed: ExpectedParity = JSON.parse(readFileSync(expectedFile, 'utf8'))

--- a/packages/core/src/indexing/pipeline.test.ts
+++ b/packages/core/src/indexing/pipeline.test.ts
@@ -18,7 +18,7 @@ beforeEach(() => {
   metaRows = []
   mockInvoke.mockReset()
   mockInvoke.mockImplementation(async (command, args) => {
-    const sql = String(args.sql ?? '')
+    const sql = String(args['sql'] ?? '')
     switch (command) {
       case 'note_read':
         return '# Hello\n\n[[World]]'
@@ -53,11 +53,11 @@ describe('indexNote', () => {
     expect(apply).toBeDefined()
     const args = apply![1] as { note: Record<string, unknown>; generation: number }
     expect(args.generation).toBe(7)
-    expect(args.note.path).toBe('notes/a.md')
-    expect(args.note.title).toBe('Hello')
-    expect(args.note.mtime).toBe(5)
-    expect(args.note.fileHash).toMatch(/^[0-9a-f]{64}$/)
-    expect((args.note.links as { targetKey: string }[]).map((link) => link.targetKey)).toContain('world')
+    expect(args.note['path']).toBe('notes/a.md')
+    expect(args.note['title']).toBe('Hello')
+    expect(args.note['mtime']).toBe(5)
+    expect(args.note['fileHash']).toMatch(/^[0-9a-f]{64}$/)
+    expect((args.note['links'] as { targetKey: string }[]).map((link) => link.targetKey)).toContain('world')
   })
 })
 
@@ -91,10 +91,10 @@ describe('rebuildIndex', () => {
         ]
       }
       if (command === 'note_read') {
-        return `# ${String(args.path)}\n`
+        return `# ${String(args['path'])}\n`
       }
       if (command === 'index_apply_batch') {
-        const notes = args.notes as Array<{ path: string }>
+        const notes = args['notes'] as Array<{ path: string }>
         if (notes.length > 1) {
           throw new Error('batch payload refused')
         }
@@ -124,7 +124,7 @@ describe('rebuildIndex', () => {
         return [{ path: 'notes/bad.md', size: 1, modifiedMs: 1 }]
       }
       if (command === 'note_read') {
-        return `# ${String(args.path)}\n`
+        return `# ${String(args['path'])}\n`
       }
       if (command === 'index_apply_batch') {
         throw { kind: 'parse', message: 'unexpected end of hex escape' }
@@ -147,7 +147,7 @@ describe('rebuildIndex', () => {
         return [{ path: 'notes/bad.md', size: 1, modifiedMs: 1 }]
       }
       if (command === 'note_read') {
-        return `# ${String(args.path)}\n`
+        return `# ${String(args['path'])}\n`
       }
       if (command === 'index_apply_batch') {
         throw new Error('single note refused')
@@ -251,12 +251,12 @@ describe('reconcileIndex move healing (Plan 17)', () => {
     const calls: Array<[string, Record<string, unknown>]> = []
     mockInvoke.mockImplementation(async (command, args) => {
       calls.push([command, args])
-      const sql = String(args.sql ?? '')
+      const sql = String(args['sql'] ?? '')
       if (command === 'list_files') {
         return [{ path: NEW, size: 1, modifiedMs: 9 }]
       }
       if (command === 'note_read') {
-        if (args.path === NEW) {
+        if (args['path'] === NEW) {
           return options.content ?? CONTENT
         }
         throw { kind: 'notFound', message: 'missing' }
@@ -265,7 +265,7 @@ describe('reconcileIndex move healing (Plan 17)', () => {
         if (sql.includes('file_hash')) {
           return [{ path: OLD, file_hash: options.storedHash }]
         }
-        if (((args.params as unknown[]) ?? []).includes(OLD)) {
+        if (((args['params'] as unknown[]) ?? []).includes(OLD)) {
           return [{ path: OLD, id: '01abcdefghjkmnpqrstvwxyz00' }]
         }
         return []
@@ -309,7 +309,7 @@ describe('reconcileIndex move healing (Plan 17)', () => {
     expect(commands).not.toContain('index_remove')
     const apply = calls.find(([command]) => command === 'index_apply')
     expect(apply).toBeDefined()
-    expect((apply![1].note as { path: string }).path).toBe(NEW)
+    expect((apply![1]['note'] as { path: string }).path).toBe(NEW)
   })
 
   it('a legacy file without an id still reconciles as delete+create', async () => {

--- a/packages/core/src/indexing/queries.test.ts
+++ b/packages/core/src/indexing/queries.test.ts
@@ -32,12 +32,12 @@ describe('dailyDatesInRange', () => {
     const dates = await dailyDatesInRange('2026-06-01', '2026-06-30')
 
     expect(dates).toEqual(['2026-06-01', '2026-06-09'])
-    const [command, args] = mockInvoke.mock.calls[0]
+    const [command, args] = mockInvoke.mock.calls[0]!
     expect(command).toBe('db_query')
-    const sql = String(args.sql)
+    const sql = String(args['sql'])
     expect(sql).toContain('daily_date')
     expect(sql).toContain('is not null')
-    expect(args.params).toEqual(['2026-06-01', '2026-06-30'])
+    expect(args['params']).toEqual(['2026-06-01', '2026-06-30'])
   })
 
   it('returns an empty list when no daily notes exist in the range', async () => {
@@ -71,15 +71,15 @@ describe('listDailyNotes', () => {
         isPrivate: false,
       },
     ])
-    const [command, args] = mockInvoke.mock.calls[0]
+    const [command, args] = mockInvoke.mock.calls[0]!
     expect(command).toBe('db_query')
-    const sql = String(args.sql)
+    const sql = String(args['sql'])
     expect(sql).toContain('daily_date')
     expect(sql).toContain('is not null')
     expect(sql).toContain('"is_private"')
     expect(sql).toContain('order by "daily_date" desc')
     expect(sql).toContain('limit')
-    expect(args.params).toEqual(['2026-06-01', '2026-06-30', 0, 32])
+    expect(args['params']).toEqual(['2026-06-01', '2026-06-30', 0, 32])
   })
 
   it('returns an empty list when no daily notes exist in the range', async () => {
@@ -103,15 +103,15 @@ describe('getPinnedNotes', () => {
       { path: 'notes/a.md', title: 'Alpha', dailyDate: null },
       { path: 'notes/b.md', title: 'Beta', dailyDate: null },
     ])
-    const [command, args] = mockInvoke.mock.calls[0]
+    const [command, args] = mockInvoke.mock.calls[0]!
     expect(command).toBe('db_query')
-    const sql = String(args.sql)
+    const sql = String(args['sql'])
     expect(sql).toContain('is_pinned')
     // Ordered pins lead (NULL orders sort last), alphabetical within.
     expect(sql).toContain('order by pinned_order IS NULL')
     expect(sql).toContain('"pinned_order"')
     expect(sql).toContain('title_key')
-    expect(args.params).toEqual([1])
+    expect(args['params']).toEqual([1])
   })
 })
 
@@ -122,9 +122,9 @@ describe('getDuplicateNoteIds', () => {
     await expect(getDuplicateNoteIds()).resolves.toEqual([])
 
     expect(mockInvoke).toHaveBeenCalledTimes(1)
-    const [command, args] = mockInvoke.mock.calls[0]
+    const [command, args] = mockInvoke.mock.calls[0]!
     expect(command).toBe('db_query')
-    const sql = String(args.sql)
+    const sql = String(args['sql'])
     expect(sql).toContain('group by')
     expect(sql).toContain('count(*)')
     expect(sql).toContain('is not null')
@@ -141,8 +141,8 @@ describe('getDuplicateNoteIds', () => {
     await expect(getDuplicateNoteIds()).resolves.toEqual([
       { id: 'dup-1', paths: ['notes/a.md', 'notes/b.md'] },
     ])
-    const [, args] = mockInvoke.mock.calls[1]
-    expect(args.params).toEqual(['dup-1'])
+    const [, args] = mockInvoke.mock.calls[1]!
+    expect(args['params']).toEqual(['dup-1'])
   })
 })
 
@@ -157,7 +157,7 @@ describe('getNoteIdsByPath', () => {
     // a single statement would blow the bound-variable budget.
     const paths = Array.from({ length: 1200 }, (_, index) => `notes/${index}.md`)
     mockInvoke.mockImplementation(async (_command, args) => {
-      const params = args.params as string[]
+      const params = args['params'] as string[]
       return [{ path: params[0], id: `id-${params[0]}` }]
     })
 
@@ -165,7 +165,7 @@ describe('getNoteIdsByPath', () => {
 
     expect(mockInvoke).toHaveBeenCalledTimes(3) // 500 + 500 + 200
     for (const [, args] of mockInvoke.mock.calls) {
-      expect((args.params as string[]).length).toBeLessThanOrEqual(500)
+      expect((args['params'] as string[]).length).toBeLessThanOrEqual(500)
     }
     expect(ids.get('notes/0.md')).toBe('id-notes/0.md')
     expect(ids.get('notes/500.md')).toBe('id-notes/500.md')

--- a/packages/core/src/indexing/suggest.test.ts
+++ b/packages/core/src/indexing/suggest.test.ts
@@ -35,7 +35,7 @@ describe('rankWikiSuggestions', () => {
     const viaAlias = alias(note('Acme Corp', 99), 'meetco')
     const result = rankWikiSuggestions('meetco', [note('Meetco', 1)], [viaAlias], 8)
     expect(result.map((s) => s.title)).toEqual(['Meetco', 'Acme Corp'])
-    expect(result[1].alias).toBe('meetco')
+    expect(result[1]!.alias).toBe('meetco')
   })
 
   it('ties break on recency, then title', () => {
@@ -53,7 +53,7 @@ describe('rankWikiSuggestions', () => {
     const target = note('Roadmap', 5)
     const result = rankWikiSuggestions('roadmap', [target], [alias(target, 'roadmap 2026')], 8)
     expect(result).toHaveLength(1)
-    expect(result[0].alias).toBeNull() // the exact title row won
+    expect(result[0]!.alias).toBeNull() // the exact title row won
   })
 
   it('an empty key is a recency feed (no match ranking)', () => {
@@ -64,8 +64,8 @@ describe('rankWikiSuggestions', () => {
   it('daily rows target their date, not their title', () => {
     const daily = note('2026-06-09', 1, { dailyDate: '2026-06-09' })
     const result = rankWikiSuggestions('2026', [daily], [], 8)
-    expect(result[0].target).toBe('2026-06-09')
-    expect(result[0].date).toBe('2026-06-09')
+    expect(result[0]!.target).toBe('2026-06-09')
+    expect(result[0]!.date).toBe('2026-06-09')
   })
 
   it('honours the limit after merging', () => {

--- a/packages/core/src/markdown/edit.test.ts
+++ b/packages/core/src/markdown/edit.test.ts
@@ -86,7 +86,7 @@ describe('appendBlock', () => {
 describe('toggleTaskMarker', () => {
   /** The first task's `{ markerOffset, raw }` as the index would record it. */
   function indexedTask(source: string) {
-    const [task] = parseNote({ path: 'notes/n.md', source }).tasks
+    const task = parseNote({ path: 'notes/n.md', source }).tasks[0]!
     return { markerOffset: task.markerOffset, raw: task.raw }
   }
 
@@ -162,7 +162,7 @@ describe('toggleTaskMarker', () => {
 describe('editTaskLine', () => {
   /** The first task's `{ markerOffset, raw }` as the index would record it. */
   function indexedTask(source: string) {
-    const [task] = parseNote({ path: 'notes/n.md', source }).tasks
+    const task = parseNote({ path: 'notes/n.md', source }).tasks[0]!
     return { markerOffset: task.markerOffset, raw: task.raw }
   }
 
@@ -229,7 +229,7 @@ describe('appendTaskLine', () => {
   it('starts the note with a single empty task', () => {
     const { source, markerOffset } = appendTaskLine('')
     expect(source).toBe('- [ ] \n')
-    const [task] = parseNote({ path: 'n.md', source }).tasks
+    const task = parseNote({ path: 'n.md', source }).tasks[0]!
     expect(task.markerOffset).toBe(markerOffset)
     expect(task.text).toBe('')
     expect(task.checked).toBe(false)
@@ -240,15 +240,15 @@ describe('appendTaskLine', () => {
     expect(source).toBe('- [ ] buy milk\n- [ ] \n')
     const tasks = parseNote({ path: 'n.md', source }).tasks
     expect(tasks).toHaveLength(2)
-    expect(tasks[1].markerOffset).toBe(markerOffset)
-    expect(tasks[1].text).toBe('')
+    expect(tasks[1]!.markerOffset).toBe(markerOffset)
+    expect(tasks[1]!.text).toBe('')
   })
 
   it('appends after prose, with the marker locatable by the parser', () => {
     const { source, markerOffset } = appendTaskLine('# Notes\n\nsome intro')
     const tasks = parseNote({ path: 'n.md', source }).tasks
     expect(tasks).toHaveLength(1)
-    expect(tasks[0].markerOffset).toBe(markerOffset)
+    expect(tasks[0]!.markerOffset).toBe(markerOffset)
   })
 })
 
@@ -299,7 +299,7 @@ describe('clearTaskDueDate', () => {
 
 describe('removeTaskLine', () => {
   function indexedTask(source: string, index = 0) {
-    const task = parseNote({ path: 'notes/n.md', source }).tasks[index]
+    const task = parseNote({ path: 'notes/n.md', source }).tasks[index]!
     return { markerOffset: task.markerOffset, raw: task.raw }
   }
 

--- a/packages/core/src/markdown/edit.ts
+++ b/packages/core/src/markdown/edit.ts
@@ -47,7 +47,7 @@ function locateTaskMarker(source: string, markerOffset: number, raw: string): nu
   if (matches.length > 1) {
     throw new TaskStaleError(`task line is ambiguous: ${JSON.stringify(raw)}`)
   }
-  return matches[0].markerOffset
+  return matches[0]!.markerOffset
 }
 
 /**

--- a/packages/core/src/markdown/extract.test.ts
+++ b/packages/core/src/markdown/extract.test.ts
@@ -13,7 +13,7 @@ describe('parseNote — wiki links', () => {
       { target: 'Project X', alias: 'the project' },
       { target: '2026-06-09', alias: undefined },
     ])
-    const first = note.wikiLinks[0]
+    const first = note.wikiLinks[0]!
     expect(note.text.slice(0)).toContain('Charlotte')
     expect(first.from).toBe('See '.length)
     expect(first.to).toBe('See [[Charlotte]]'.length)
@@ -143,7 +143,7 @@ describe('parseNote — tasks', () => {
 
   it('strips inline syntax from text but keeps it verbatim in raw', () => {
     const note = parse('- [ ] call [[Bob]] about **billing**\n')
-    const [item] = note.tasks
+    const item = note.tasks[0]!
     expect(item.text).toBe('call Bob about billing')
     expect(item.raw).toBe('[ ] call [[Bob]] about **billing**')
     // markerOffset points at the `[` of the checkbox, not the wiki link.
@@ -154,7 +154,7 @@ describe('parseNote — tasks', () => {
   it('offsets the marker past frontmatter', () => {
     const source = '---\nid: abc\n---\n- [ ] later\n'
     const note = parse(source)
-    const [item] = note.tasks
+    const item = note.tasks[0]!
     expect(item.markerOffset).toBe(source.indexOf('[ ]'))
     expect(source.slice(item.markerOffset, item.markerOffset + item.raw.length)).toBe(item.raw)
   })
@@ -181,12 +181,12 @@ describe('parseNote — tasks', () => {
 
   it('reads the first calendar [[YYYY-MM-DD]] link in the item as the due date', () => {
     const note = parse('- [ ] ship it [[2026-07-01]] and review [[2026-08-01]]\n')
-    expect(note.tasks[0].dueDate).toBe('2026-07-01') // first date link wins
+    expect(note.tasks[0]!.dueDate).toBe('2026-07-01') // first date link wins
   })
 
   it('ignores an impossible date as a due date', () => {
     const note = parse('- [ ] not a real day [[2026-02-31]]\n')
-    expect(note.tasks[0].dueDate).toBeNull()
+    expect(note.tasks[0]!.dueDate).toBeNull()
   })
 
   it('does not borrow a due-date link from a neighbouring task', () => {

--- a/packages/core/src/markdown/extract.ts
+++ b/packages/core/src/markdown/extract.ts
@@ -188,11 +188,12 @@ function inAnyRange(index: number, ranges: Span[]): boolean {
 
 function collectTags(body: string, excluded: Span[], into: Map<string, string>): void {
   for (const match of body.matchAll(TAG_RE)) {
-    const hashIndex = (match.index ?? 0) + match[1].length
+    // Both groups are mandatory in TAG_RE, so a match always populates them.
+    const hashIndex = (match.index ?? 0) + match[1]!.length
     if (inAnyRange(hashIndex, excluded)) {
       continue
     }
-    const tag = match[2]
+    const tag = match[2]!
     const key = foldTag(tag)
     if (!into.has(key)) {
       into.set(key, tag) // dedupe case-insensitively, keep first-seen casing

--- a/packages/core/src/markdown/frontmatter.test.ts
+++ b/packages/core/src/markdown/frontmatter.test.ts
@@ -38,7 +38,7 @@ describe('parseFrontmatter', () => {
     expect(data.id).toBe('abc')
     expect(data.aliases).toEqual(['a', 'b'])
     expect(data.private).toBe(false)
-    expect((data as Record<string, unknown>).custom).toBe('hello')
+    expect((data as Record<string, unknown>)['custom']).toBe('hello')
   })
 
   it('degrades broken YAML to defaults + a warning, never throwing', () => {

--- a/packages/core/src/markdown/frontmatter.ts
+++ b/packages/core/src/markdown/frontmatter.ts
@@ -111,7 +111,7 @@ export function upsertFrontmatter(source: string, patch: Record<string, unknown>
   // must not: re-serializing a partial parse would drop the bytes the parser
   // couldn't model. Refuse rather than silently corrupt the note's frontmatter.
   if (doc.errors.length > 0) {
-    throw new Error(`refusing to update invalid YAML frontmatter: ${doc.errors[0].message}`)
+    throw new Error(`refusing to update invalid YAML frontmatter: ${doc.errors[0]!.message}`)
   }
   for (const [key, value] of Object.entries(patch)) {
     if (value === undefined) {

--- a/packages/core/src/markdown/link-syntax.ts
+++ b/packages/core/src/markdown/link-syntax.ts
@@ -29,9 +29,11 @@ export function parseInlineLink(source: string): InlineLinkParts | null {
   if (!match) {
     return null
   }
+  // All three groups are mandatory in INLINE_LINK_RE, so a successful match
+  // always populates them.
   return {
     isImage: match[1] === '!',
-    text: match[2],
-    href: match[3].replace(/^<|>$/g, ''),
+    text: match[2]!,
+    href: match[3]!.replace(/^<|>$/g, ''),
   }
 }

--- a/packages/core/src/markdown/model.ts
+++ b/packages/core/src/markdown/model.ts
@@ -116,7 +116,7 @@ export interface WikiLink extends Span {
   /** The link target as written (pre-resolution), trimmed. */
   target: string
   /** Display alias after `|`, if present. */
-  alias?: string
+  alias?: string | undefined
 }
 
 /** A standard markdown link or autolink `[text](href)`. */
@@ -124,7 +124,7 @@ export interface MarkdownLink extends Span {
   href: string
   text: string
   /** Host for external `http(s)` links, else undefined. */
-  domain?: string
+  domain?: string | undefined
 }
 
 /** An ATX or setext heading. */
@@ -191,12 +191,12 @@ export interface ParsedNote {
   /** Graph-relative path; the note's identity in the first wave. */
   path: string
   /** Stable id from frontmatter, if the note carries one (else identity = path). */
-  id?: string
+  id?: string | undefined
   /** `frontmatter.title` → first H1 → filename (or the date for daily notes). */
   title: string
   frontmatter: Frontmatter
   /** Set when YAML frontmatter failed to parse; the note is still usable. */
-  frontmatterWarning?: string
+  frontmatterWarning?: string | undefined
   wikiLinks: WikiLink[]
   links: MarkdownLink[]
   /** Body `#tag` names (without the leading `#`), deduped, in document order. */

--- a/packages/core/src/markdown/resolve.ts
+++ b/packages/core/src/markdown/resolve.ts
@@ -13,9 +13,12 @@ import { foldKey } from './keys'
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 
-/** Is `value` a real calendar day (not just `YYYY-MM-DD`-shaped)? */
+/**
+ * Is `value` a real calendar day (not just `YYYY-MM-DD`-shaped)? Callers gate on
+ * {@link ISO_DATE_RE} first, so the split always yields three numeric parts.
+ */
 function isCalendarDate(value: string): boolean {
-  const [year, month, day] = value.split('-').map(Number)
+  const [year, month, day] = value.split('-').map(Number) as [number, number, number]
   if (month < 1 || month > 12) {
     return false
   }

--- a/packages/core/src/markdown/roundtrip.test.ts
+++ b/packages/core/src/markdown/roundtrip.test.ts
@@ -7,7 +7,7 @@ import { parseNote } from './extract'
  * truth and files may be edited outside Reflect, so the bar is: every input
  * parses into a usable note, and position-based edits touch only what they must.
  */
-const CORPUS: Record<string, string> = {
+const CORPUS = {
   reflect: '---\nid: 01HXX\naliases: [pjx]\n---\n# Project X\n\nLinks [[Charlotte]] and #status/active.\n',
   obsidian: '# Notes\n\nSee [[Some Page|alias]] and ![img](assets/a.png) and [ext](https://x.com).\n',
   gfm: '## Tasks\n\n- [ ] todo\n- [x] done\n\n| a | b |\n| - | - |\n| 1 | 2 |\n\n~~strike~~\n',

--- a/packages/core/src/markdown/scan.test.ts
+++ b/packages/core/src/markdown/scan.test.ts
@@ -7,7 +7,8 @@ describe('scanInlineWikiLinks', () => {
     const links = scanInlineWikiLinks(text)
     expect(links).toHaveLength(2)
 
-    const [plain, aliased] = links
+    const plain = links[0]!
+    const aliased = links[1]!
     expect(plain.target).toBe('Charlotte')
     expect(plain.alias).toBeNull()
     expect(text.slice(plain.from, plain.to)).toBe('[[Charlotte]]')
@@ -21,7 +22,7 @@ describe('scanInlineWikiLinks', () => {
 
   it('falls back to the target when the alias is blank', () => {
     const text = 'see [[Target|   ]] here'
-    const [link] = scanInlineWikiLinks(text)
+    const link = scanInlineWikiLinks(text)[0]!
     expect(link.alias).toBeNull()
     expect(text.slice(link.displayFrom, link.displayTo)).toBe('Target')
   })
@@ -42,7 +43,7 @@ describe('scanInlineImages', () => {
     const images = scanInlineImages(text)
     expect(images).toHaveLength(2)
     expect(images[0]).toMatchObject({ alt: 'screenshot', src: 'assets/shot.png' })
-    expect(text.slice(images[0].from, images[0].to)).toBe('![screenshot](assets/shot.png)')
+    expect(text.slice(images[0]!.from, images[0]!.to)).toBe('![screenshot](assets/shot.png)')
     expect(images[1]).toMatchObject({ alt: '', src: 'https://x.com/i.jpg' })
   })
 

--- a/packages/core/src/sync/engine.test.ts
+++ b/packages/core/src/sync/engine.test.ts
@@ -79,8 +79,8 @@ describe('createSyncEngine', () => {
     await vi.runAllTimersAsync()
 
     expect(commandsOf(calls)).toEqual(['git_commit_all', 'git_push'])
-    expect(calls[0].args.generation).toBe(7)
-    expect(calls[1].args.token).toBe('tok')
+    expect(calls[0]!.args['generation']).toBe(7)
+    expect(calls[1]!.args['token']).toBe('tok')
     expect(statuses.map((status) => status.state)).toEqual(['syncing', 'idle'])
     engine.stop()
   })
@@ -496,7 +496,7 @@ describe('createSyncEngine', () => {
     await vi.runAllTimersAsync()
 
     const push = calls.find((call) => call.command === 'git_push')
-    expect(push?.args.token).toBeNull()
+    expect(push?.args['token']).toBeNull()
     expect(statuses.at(-1)).toMatchObject({ state: 'error', errorKind: 'auth' })
     engine.stop()
   })

--- a/packages/core/src/sync/gists.test.ts
+++ b/packages/core/src/sync/gists.test.ts
@@ -19,7 +19,7 @@ describe('createGist', () => {
     const [url, init] = fetchFn.mock.calls[0] as unknown as [string, RequestInit]
     expect(url).toBe('https://api.github.com/gists')
     expect(init.method).toBe('POST')
-    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer tok')
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer tok')
     expect(JSON.parse(init.body as string)).toEqual({
       public: false,
       files: { 'A.md': { content: '# A\n' } },

--- a/packages/core/src/sync/github.test.ts
+++ b/packages/core/src/sync/github.test.ts
@@ -23,12 +23,12 @@ function fakeKeychain(initial: Record<string, string> = {}) {
   const store = new Map(Object.entries(initial))
   setBridge({
     invoke: async (command, args) => {
-      const name = args.name as string
+      const name = args['name'] as string
       if (command === 'secret_get') {
         return store.get(name) ?? null
       }
       if (command === 'secret_set') {
-        store.set(name, args.value as string)
+        store.set(name, args['value'] as string)
         return null
       }
       if (command === 'secret_delete') {
@@ -263,7 +263,7 @@ describe('getGithubToken', () => {
       return jsonResponse({ access_token: 'ghu_new', refresh_token: 'ghr_new', expires_in: 28800 })
     })
     await getGithubToken(fetchFn, () => 2_000)
-    expect(bodies[0].client_id).toBe('fork-app')
+    expect(bodies[0]!['client_id']).toBe('fork-app')
   })
 
   it('surfaces a transient refresh failure as retryable, not as disconnected', async () => {

--- a/packages/core/src/sync/github.ts
+++ b/packages/core/src/sync/github.ts
@@ -286,7 +286,7 @@ export async function runDeviceFlow(options: RunDeviceFlowOptions): Promise<Gith
 
 function toAuth(
   accessToken: string,
-  parsed: { refresh_token?: string; expires_in?: number },
+  parsed: { refresh_token?: string | undefined; expires_in?: number | undefined },
   nowMs: number,
   clientId: string = GITHUB_APP_CLIENT_ID,
 ): GithubAuth {
@@ -460,7 +460,7 @@ export function parseGithubRemote(url: string): GithubRepoRef | null {
   if (match === null) {
     return null
   }
-  return { owner: match[1], name: match[2] }
+  return { owner: match[1]!, name: match[2]! }
 }
 
 /** The canonical HTTPS remote URL for a repo (token never embedded). */

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,18 +1,4 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "skipLibCheck": true,
-    "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
-  },
+  "extends": "../../tsconfig.base.json",
   "include": ["src"]
 }

--- a/packages/db/src/dialect.test.ts
+++ b/packages/db/src/dialect.test.ts
@@ -18,7 +18,7 @@ describe('IpcDialect (Kysely → injected runner bridge)', () => {
       .execute()
 
     expect(runQuery).toHaveBeenCalledTimes(1)
-    const [sql, params] = runQuery.mock.calls[0]
+    const [sql, params] = runQuery.mock.calls[0]!
     expect(sql).toContain('"file_hash"')
     expect(sql).toContain('"title_key"')
     expect(params).toEqual(['project x'])

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,18 +1,7 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "lib": ["ES2022"],
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "skipLibCheck": true,
-    "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "lib": ["ES2022"]
   },
   "include": ["src"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+
+    /* Strictness — shared across every TypeScript package. */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "verbatimModuleSyntax": true,
+    "noImplicitOverride": true
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,6 +16,9 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "verbatimModuleSyntax": true,
-    "noImplicitOverride": true
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "exactOptionalPropertyTypes": true
   }
 }


### PR DESCRIPTION
## Summary

Tightens TypeScript strictness across the monorepo and codifies the conventions in `AGENTS.md` into CI-enforced lint rules, rather than relying on discipline alone. Done in three reviewable commits.

The codebase was already in great shape (zero real `as any` in source, named exports throughout, zod at boundaries), so this is mostly **enforcement gaps** and **measured strictness upgrades** — not cleanup of messy code.

### Phase 1 — Shared tsconfig base + oxlint rule config (`82ac48d`)
- New `tsconfig.base.json`; `desktop`, `core`, and `db` now `extend` it instead of duplicating ~12 compiler options each. The extension keeps its own config (it extends the WXT-generated tsconfig); design-system has no TS project.
- Two zero/near-zero-cost flags: **`verbatimModuleSyntax`** (0 new errors — type imports were already marked correctly) and **`noImplicitOverride`** (3 trivial fixes in `MobileErrorBoundary`).
- New root **`.oxlintrc.json`** turning documented conventions into CI rules:
  - `typescript/no-explicit-any` — 0 existing violations (a ratchet)
  - `import/no-default-export` — 0 existing violations (a ratchet; config files + WXT entrypoints overridden)
  - `import/no-namespace` — catches `import * as React`; vendored shadcn `ui/` and node build scripts overridden
  - `consistent-type-imports` was **intentionally omitted**: `verbatimModuleSyntax` already enforces `import type` at the compiler level, and the rule fights the idiomatic vitest `importOriginal<typeof import('...')>()` mock pattern.

### Phase 2 — `max-lines` warning (`dab168b`)
- `eslint/max-lines` at 500 as a **warning** (does not block CI), exempting test files. Surfaces `capture.ts`, `note-session.ts`, `queries.ts`, and `github.ts` as refactor candidates.

### Phase 3 — `noUncheckedIndexedAccess` + friends (`06fd541`)
Enabled `noUncheckedIndexedAccess`, `noPropertyAccessFromIndexSignature`, and `exactOptionalPropertyTypes`. These surfaced **~518 latent issues** across 118 files (56 source, 60 test, 2 config), all resolved with real fixes:
- Index-signature access: `obj.x` → `obj['x']` (mechanical)
- Possibly-undefined indexed access: real guards / `??` defaults where undefined is reachable; minimal `!` only where presence is already guaranteed by a nearby length check or loop invariant; `!` on controlled fixtures in tests
- `exactOptionalPropertyTypes`: widened our own optional fields to `?: T | undefined` where undefined means "absent"; conditional spread for third-party target types

**No escape hatches introduced** — no new `any` / `as any` / `as unknown` / `@ts-ignore` / `@ts-expect-error`. (The `as unknown[]` casts visible in the diff are pre-existing test mocks whose access syntax merely changed.)

## A note on scope
Phase 3 is large (~518 fixes) and would normally be split into its own PR(s) per the reviewer's own advice — it's bundled here at the author's explicit request. It's isolated in its own commit, so it can be reviewed independently of phases 1–2.

## Testing
- `pnpm check` (typecheck across all packages + lint) — **green** (only pre-existing React Compiler `incompatible-library` warnings remain)
- Full test suite — **green**: core 762, desktop 948, extension 28, db 4 (1742 total)

## Follow-ups (out of scope)
- Refactor the 4 oversized modules flagged by `max-lines` (tracked backlog, not blocking): `packages/core/src/actions/capture.ts` (797), `apps/desktop/src/editor/note-session.ts` (784), `packages/core/src/indexing/queries.ts` (591), `packages/core/src/sync/github.ts` (564). Build scripts are now exempt from the rule, so these four are the only remaining warnings.
- Audit the ~101 manual `useMemo`/`useCallback` now that the React Compiler is on (careful, by hand — not a mechanical sweep)
- Pre-existing `no-unsafe-optional-chaining` / `no-useless-spread` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large touch surface (~118 files) but behavior-preserving typing fixes; highest review attention belongs to conditional prop spreads and any new `!` assertions in production paths, not tests.
> 
> **Overview**
> **Centralizes TypeScript strictness** via new `tsconfig.base.json` (desktop, core, db extend it; extension mirrors the same flags manually because it extends WXT). Adds **`verbatimModuleSyntax`**, **`noImplicitOverride`**, **`noUncheckedIndexedAccess`**, **`noPropertyAccessFromIndexSignature`**, and **`exactOptionalPropertyTypes`**.
> 
> **Adds `.oxlintrc.json`** to CI-enforce no `any`, no default exports, no namespace imports, and a **500-line `max-lines` warning** (tests/config exempt).
> 
> **Code changes** are almost entirely mechanical compliance: bracket notation for index signatures and mock `args`, non-null assertions or guards where indexed access is provably safe, **`T | undefined` on optional props** and **conditional spreads** for `exactOptionalPropertyTypes`, plus small real fixes (e.g. `NoteRowOverlayPatch`, `NonEmptyArray` on AI catalog, regex capture guards in `audioMemoFromPath` / `captureFromPath`, undefined check in mobile virtualized list).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e9c2d331e9e88c81fc6c1c89409260bd12e4b18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
