### PR TITLE
Generate V1-style date suggestions in the [[ menu & command palette

### DIFF
--- a/apps/desktop/src/components/command-palette/command-palette.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.tsx
@@ -181,10 +181,17 @@ export function CommandPalette({ context }: CommandPaletteProps): ReactElement |
                           />
                           <span className="min-w-0 flex-1">
                             <span className="block truncate text-sm">
-                              {entry.date !== null
-                                ? formatDayLabel(entry.date, settings.dateFormat)
-                                : entry.title}
+                              {entry.phrase !== null
+                                ? entry.phrase
+                                : entry.date !== null
+                                  ? formatDayLabel(entry.date, settings.dateFormat)
+                                  : entry.title}
                             </span>
+                            {entry.phrase !== null && entry.date !== null ? (
+                              <span className="block truncate text-xs text-text-muted">
+                                {formatDayLabel(entry.date, settings.dateFormat)}
+                              </span>
+                            ) : null}
                             {entry.snippet !== null ? <Snippet snippet={entry.snippet} /> : null}
                           </span>
                         </span>

--- a/apps/desktop/src/components/command-palette/entries.test.ts
+++ b/apps/desktop/src/components/command-palette/entries.test.ts
@@ -34,6 +34,27 @@ function sections(
 }
 
 describe('buildPaletteSections', () => {
+  it('appends generated date suggestions after real note matches', () => {
+    const generated: WikiSuggestion = {
+      target: '2020-01-06',
+      path: null,
+      title: '2020-01-06',
+      alias: null,
+      date: '2020-01-06',
+      phrase: 'This Monday',
+    }
+    const result = sections({
+      query: 'mon',
+      // Core returns dates first; the palette must push them behind real notes.
+      suggestions: [generated, suggestion('notes/monday-standup.md', 'Monday Standup')],
+    })
+    expect(result.notes.map((note) => note.path)).toEqual([
+      'notes/monday-standup.md',
+      'daily/2020-01-06.md',
+    ])
+    expect(result.notes.find((note) => note.date === '2020-01-06')?.phrase).toBe('This Monday')
+  })
+
   it('an empty query is the recall feed: suggestions only, no commands', () => {
     const result = sections({
       query: '',
@@ -89,7 +110,13 @@ describe('buildPaletteSections', () => {
       ],
     })
     expect(result.notes).toEqual([
-      { path: 'daily/2026-08-01.md', title: '2026-08-01', date: '2026-08-01', snippet: null },
+      {
+        path: 'daily/2026-08-01.md',
+        title: '2026-08-01',
+        date: '2026-08-01',
+        snippet: null,
+        phrase: null,
+      },
     ])
   })
 

--- a/apps/desktop/src/components/command-palette/entries.ts
+++ b/apps/desktop/src/components/command-palette/entries.ts
@@ -16,6 +16,8 @@ export interface NoteEntry {
   date: string | null
   /** Body snippet with highlight markers (search hits only). */
   snippet: string | null
+  /** Human label for a generated date suggestion ("Next Friday"); null otherwise. */
+  phrase: string | null
 }
 
 export interface PaletteSections {
@@ -82,6 +84,7 @@ export function buildPaletteSections(options: {
         title: hit.title,
         date: hit.dailyDate,
         snippet: hit.snippet,
+        phrase: null,
       })),
       commands: [],
     }
@@ -91,7 +94,14 @@ export function buildPaletteSections(options: {
   // the rest; one row per note, the stronger (title) form wins.
   const notes: NoteEntry[] = []
   const seen = new Set<string>()
-  for (const suggestion of suggestions) {
+  // Real note matches lead; generated date suggestions (they carry a phrase)
+  // trail them. In the global palette your existing notes should outrank
+  // "Next Monday" — the opposite of the `[[` menu, where dates lead.
+  const orderedSuggestions = [
+    ...suggestions.filter((suggestion) => suggestion.phrase === undefined),
+    ...suggestions.filter((suggestion) => suggestion.phrase !== undefined),
+  ]
+  for (const suggestion of orderedSuggestions) {
     // A pathless suggestion is a valid daily whose file doesn't exist yet
     // (the lazy contract) — it must still be jumpable: synthesize its daily
     // path, and routeForPath downstream yields the daily route, where the
@@ -105,6 +115,7 @@ export function buildPaletteSections(options: {
         title: suggestion.title,
         date: suggestion.date,
         snippet: null,
+        phrase: suggestion.phrase ?? null,
       })
     }
   }
@@ -113,7 +124,13 @@ export function buildPaletteSections(options: {
   for (const hit of bodyHits) {
     if (!seen.has(hit.path)) {
       seen.add(hit.path)
-      notes.push({ path: hit.path, title: hit.title, date: hit.dailyDate, snippet: hit.snippet })
+      notes.push({
+        path: hit.path,
+        title: hit.title,
+        date: hit.dailyDate,
+        snippet: hit.snippet,
+        phrase: null,
+      })
     }
   }
 

--- a/apps/desktop/src/components/command-palette/use-palette-results.ts
+++ b/apps/desktop/src/components/command-palette/use-palette-results.ts
@@ -50,15 +50,19 @@ export function usePaletteResults(open: boolean, query: string): PaletteResults 
   // query with empty filters — one search path.
   const parsed = useMemo(() => parseSearchQuery(trimmed), [trimmed])
   const searching = open && hasBridge() && graph !== null && !trimmed.startsWith('>')
+  // The generated date suggestions are relative to today, so the calendar day is
+  // part of the cache identity — without it a palette cached before midnight
+  // would serve a stale "Tomorrow" afterwards. Computed once so the key and the
+  // query agree on the same day.
+  const today = todayIso()
 
   const {
     data: suggestions,
     isLoading: suggestionsLoading,
     isError: suggestionsError,
   } = useQuery({
-    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'palette-suggest', trimmed, settings.dateFormat],
-    queryFn: () =>
-      suggestWikiTargets(trimmed, 8, { today: todayIso(), dateFormat: settings.dateFormat }),
+    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'palette-suggest', trimmed, settings.dateFormat, today],
+    queryFn: () => suggestWikiTargets(trimmed, 8, { today, dateFormat: settings.dateFormat }),
     enabled: searching && !parsed.filtered,
   })
   const useHybrid = hybrid && !parsed.filtered

--- a/apps/desktop/src/components/command-palette/use-palette-results.ts
+++ b/apps/desktop/src/components/command-palette/use-palette-results.ts
@@ -8,6 +8,7 @@ import {
   suggestWikiTargets,
 } from '@reflect/core'
 import { listCommands } from '@/lib/commands/registry'
+import { todayIso } from '@/lib/dates'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useEmbedStatus } from '@/lib/use-embed-status'
 import { useGraph } from '@/providers/graph-provider'
@@ -55,8 +56,9 @@ export function usePaletteResults(open: boolean, query: string): PaletteResults 
     isLoading: suggestionsLoading,
     isError: suggestionsError,
   } = useQuery({
-    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'palette-suggest', trimmed],
-    queryFn: () => suggestWikiTargets(trimmed, 8),
+    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'palette-suggest', trimmed, settings.dateFormat],
+    queryFn: () =>
+      suggestWikiTargets(trimmed, 8, { today: todayIso(), dateFormat: settings.dateFormat }),
     enabled: searching && !parsed.filtered,
   })
   const useHybrid = hybrid && !parsed.filtered

--- a/apps/desktop/src/editor/use-editor-autocomplete.ts
+++ b/apps/desktop/src/editor/use-editor-autocomplete.ts
@@ -8,7 +8,7 @@ import {
 import { hasBridge, suggestTags, suggestWikiTargets } from '@reflect/core'
 import { buildAutocompleteEntries } from '@/editor/wiki-autocomplete-entries'
 import { createNoteWithTitle } from '@/lib/create-note'
-import { formatDayLabel } from '@/lib/dates'
+import { formatDayLabel, todayIso } from '@/lib/dates'
 import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
 
@@ -23,7 +23,8 @@ export interface EditorAutocomplete {
 /**
  * The editor's `[[` and `#` autocomplete, shared by every note editor (the
  * note pane and the Tasks view's inline editor). meowdown owns the menu UI and
- * hands us the (lowercased, punctuation-stripped) query; ranking stays the
+ * hands us the raw text typed after `[[` (case preserved, spaces and slashes
+ * intact — only `[`, `]`, and newlines close the menu); ranking stays the
  * index's job, so neither menu re-sorts what the host returns. Both handlers
  * are no-ops without a bridge or an open graph.
  *
@@ -52,7 +53,10 @@ export function useEditorAutocomplete(): EditorAutocomplete {
       if (!hasBridge() || graph === null) {
         return []
       }
-      const suggestions = await suggestWikiTargets(query)
+      const suggestions = await suggestWikiTargets(query, 8, {
+        today: todayIso(),
+        dateFormat: settings.dateFormat,
+      })
       return buildAutocompleteEntries(query, suggestions, { offerCreate: true }).map((entry) => {
         if (entry.kind === 'create') {
           return {
@@ -67,7 +71,12 @@ export function useEditorAutocomplete(): EditorAutocomplete {
             },
           }
         }
-        const { target, title, alias, date, path } = entry.suggestion
+        const { target, title, alias, date, path, phrase } = entry.suggestion
+        // A generated date leads with its phrase ("Next Friday"), resolved day
+        // as the detail; everything else keeps the title/alias/daily form.
+        if (phrase !== undefined && date !== null) {
+          return { target, label: phrase, detail: formatDayLabel(date, settings.dateFormat) }
+        }
         const label = date !== null ? formatDayLabel(date, settings.dateFormat) : title
         const detail =
           alias !== null

--- a/apps/desktop/src/editor/wiki-autocomplete-entries.test.ts
+++ b/apps/desktop/src/editor/wiki-autocomplete-entries.test.ts
@@ -46,6 +46,19 @@ describe('buildAutocompleteEntries', () => {
     expect(buildAutocompleteEntries('  ', [])).toEqual([])
   })
 
+  it('does not offer create when a generated date suggestion is present', () => {
+    const entries = buildAutocompleteEntries('3 days ago', [
+      suggestion({
+        target: '2019-12-29',
+        title: '2019-12-29',
+        path: null,
+        date: '2019-12-29',
+        phrase: '3 days ago',
+      }),
+    ])
+    expect(entries.every((entry) => entry.kind === 'suggestion')).toBe(true)
+  })
+
   it('never offers create from unsettled (in-flight) suggestions', () => {
     // The visible list belongs to the previous query while fetching — a match
     // for the current text may be about to arrive.

--- a/apps/desktop/src/editor/wiki-autocomplete-entries.ts
+++ b/apps/desktop/src/editor/wiki-autocomplete-entries.ts
@@ -42,7 +42,11 @@ export function buildAutocompleteEntries(
       foldKey(suggestion.target) === key ||
       (suggestion.alias !== null && foldKey(suggestion.alias) === key),
   )
-  if (!resolvesAsTyped) {
+  // A generated date suggestion (it carries a `phrase`) means the query reads as
+  // a date — "3 days ago", "next friday" — so offering to create a note with
+  // that literal title would be noise.
+  const hasDateSuggestion = suggestions.some((suggestion) => suggestion.phrase !== undefined)
+  if (!resolvesAsTyped && !hasDateSuggestion) {
     entries.push({ kind: 'create', title })
   }
   return entries

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -485,6 +485,7 @@ export {
   type TagSuggestion,
   type FileChange,
   type WikiSuggestion,
+  type DateSuggestionContext,
   type HighlightSegment,
   type ParsedSearchQuery,
   type SearchFilters,

--- a/packages/core/src/indexing/date-suggestions.test.ts
+++ b/packages/core/src/indexing/date-suggestions.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+import { generateDateSuggestions, type DateSuggestion } from './date-suggestions'
+import type { DateFormat } from '../settings/schema'
+
+/**
+ * The V1 backlink-menu doc's worked examples are the spec here: today is
+ * Wednesday, 1 January 2020, date format day/month (`dmy`) unless a case says
+ * otherwise. See `docs/reflect-v1-backlink-menu.md`.
+ */
+const TODAY = '2020-01-01'
+
+function gen(query: string, dateFormat: DateFormat = 'dmy'): DateSuggestion[] {
+  return generateDateSuggestions(query, { today: TODAY, dateFormat })
+}
+
+describe('generateDateSuggestions', () => {
+  it('returns nothing for an empty or too-short query', () => {
+    expect(gen('')).toEqual([])
+    expect(gen('   ')).toEqual([])
+    expect(gen('to')).toEqual([])
+  })
+
+  describe('relative offsets', () => {
+    it('reads "3 days ago" as a single past-day offset', () => {
+      expect(gen('3 days ago')).toEqual([{ date: '2019-12-29', phrase: '3 days ago' }])
+    })
+
+    it('treats spelled numbers one–ten as digits', () => {
+      expect(gen('three days ago')).toEqual([{ date: '2019-12-29', phrase: '3 days ago' }])
+    })
+
+    it('offers future day/week/month for a bare number (top 3)', () => {
+      expect(gen('1')).toEqual([
+        { date: '2020-01-02', phrase: '1 day from now' },
+        { date: '2020-01-08', phrase: '1 week from now' },
+        { date: '2020-02-01', phrase: '1 month from now' },
+      ])
+    })
+
+    it('shows both directions when a unit but no direction is given', () => {
+      expect(gen('one day')).toEqual([
+        { date: '2020-01-02', phrase: '1 day from now' },
+        { date: '2019-12-31', phrase: '1 day ago' },
+      ])
+    })
+
+    it('drops offsets beyond the ~15-year sanity limit', () => {
+      expect(gen('17 years')).toEqual([])
+      expect(gen('1000 years')).toEqual([])
+    })
+
+    it('does not fire on a month-name day number ("December 2")', () => {
+      // "2" must not become "2 days from now" — the month-name reading wins.
+      expect(gen('December 2')).toEqual([{ date: '2020-12-02', phrase: 'December 2' }])
+    })
+  })
+
+  describe('natural-language phrases', () => {
+    it('resolves today / yesterday / tomorrow', () => {
+      expect(gen('today')).toEqual([{ date: '2020-01-01', phrase: 'Today' }])
+      expect(gen('yesterday')).toEqual([{ date: '2019-12-31', phrase: 'Yesterday' }])
+      expect(gen('tomorrow')).toEqual([{ date: '2020-01-02', phrase: 'Tomorrow' }])
+    })
+
+    it('reads "this monday" as the upcoming Monday', () => {
+      expect(gen('this monday')).toEqual([{ date: '2020-01-06', phrase: 'This Monday' }])
+    })
+
+    it('reads "next fri" as the Friday after the upcoming one', () => {
+      expect(gen('next fri')).toEqual([{ date: '2020-01-10', phrase: 'Next Friday' }])
+    })
+
+    it('surfaces this/next/last for a bare weekday prefix', () => {
+      expect(gen('mon')).toEqual([
+        { date: '2020-01-06', phrase: 'This Monday' },
+        { date: '2020-01-13', phrase: 'Next Monday' },
+        { date: '2019-12-30', phrase: 'Last Monday' },
+      ])
+    })
+  })
+
+  describe('typed calendar dates', () => {
+    it('parses a full ISO date with no phrase', () => {
+      expect(gen('2026-06-19')).toEqual([{ date: '2026-06-19', phrase: null }])
+    })
+
+    it('rejects an impossible ISO date', () => {
+      expect(gen('2026-02-31')).toEqual([])
+    })
+
+    it('offers both readings for ambiguous shorthand (current year for each)', () => {
+      // V1 happened to mix years here; V2 defaults shorthand to the current year
+      // for both readings, deliberately.
+      expect(gen('12/10', 'dmy')).toEqual([
+        { date: '2020-10-12', phrase: '12/10' },
+        { date: '2020-12-10', phrase: '12/10' },
+      ])
+    })
+
+    it('reads shorthand per the date-format preference', () => {
+      expect(gen('12/25', 'mdy')).toEqual([{ date: '2020-12-25', phrase: '12/25' }])
+      expect(gen('12/25', 'dmy')).toEqual([{ date: '2020-12-25', phrase: '12/25' }])
+    })
+
+    it('parses a full slash date and offers only the valid reading', () => {
+      expect(gen('23/2/2023', 'dmy')).toEqual([{ date: '2023-02-23', phrase: '23/2/2023' }])
+    })
+  })
+
+  describe('month-name dates', () => {
+    it('parses "December 2nd" with the current year', () => {
+      expect(gen('December 2nd')).toEqual([{ date: '2020-12-02', phrase: 'December 2nd' }])
+    })
+
+    it('accepts either word order and abbreviations', () => {
+      expect(gen('2nd December')).toEqual([{ date: '2020-12-02', phrase: '2nd December' }])
+      expect(gen('Dec 2')).toEqual([{ date: '2020-12-02', phrase: 'Dec 2' }])
+    })
+
+    it('tolerates a malformed ordinal suffix', () => {
+      expect(gen('31th December')).toEqual([{ date: '2020-12-31', phrase: '31th December' }])
+    })
+
+    it('honours an explicit year', () => {
+      expect(gen('March 3 2024')).toEqual([{ date: '2024-03-03', phrase: 'March 3 2024' }])
+    })
+
+    it('needs both a month and a day', () => {
+      expect(gen('December')).toEqual([])
+    })
+  })
+})

--- a/packages/core/src/indexing/date-suggestions.test.ts
+++ b/packages/core/src/indexing/date-suggestions.test.ts
@@ -105,6 +105,12 @@ describe('generateDateSuggestions', () => {
     it('parses a full slash date and offers only the valid reading', () => {
       expect(gen('23/2/2023', 'dmy')).toEqual([{ date: '2023-02-23', phrase: '23/2/2023' }])
     })
+
+    it('ignores a typed date whose explicit year is not four digits', () => {
+      // "12/25/23" must not resolve to the year 0023.
+      expect(gen('12/25/23', 'mdy')).toEqual([])
+      expect(gen('1/2/99', 'dmy')).toEqual([])
+    })
   })
 
   describe('month-name dates', () => {

--- a/packages/core/src/indexing/date-suggestions.ts
+++ b/packages/core/src/indexing/date-suggestions.ts
@@ -370,6 +370,11 @@ function typedDateSuggestions(
   if (parts.length < 2 || parts.length > 3 || !parts.every((part) => /^\d+$/.test(part))) {
     return []
   }
+  // An explicit year must be four digits — "12/25/23" must resolve to nothing,
+  // not the year 23. We don't guess a century for a two-digit year.
+  if (parts.length === 3 && parts[2].length !== 4) {
+    return []
+  }
   const [first, second] = parts.map(Number)
   const year = parts.length === 3 ? Number(parts[2]) : Number(context.today.slice(0, 4))
   // The preferred reading follows the date-format setting; the swapped reading

--- a/packages/core/src/indexing/date-suggestions.ts
+++ b/packages/core/src/indexing/date-suggestions.ts
@@ -1,0 +1,525 @@
+/**
+ * Date-suggestion generator for the `[[` autocomplete and the command palette:
+ * synthesises daily-note targets from a fuzzy query the way the original Reflect
+ * did. It interprets the query four ways at once — relative offsets
+ * ("3 days ago"), natural-language dates ("next friday", "tomorrow"), typed
+ * calendar dates ("12/25", "2026-06-19"), and month-name dates ("December 2nd")
+ * — then merges them, de-duplicating by resolved day. See
+ * `docs/reflect-v1-backlink-menu.md` for the behaviour this ports.
+ *
+ * Pure and dependency-free: the clock is injected as `today` (an ISO
+ * `YYYY-MM-DD` *local* date, computed at the UI edge) and every offset is
+ * computed in UTC on the ISO string, so DST can never skip or repeat a day.
+ * Each result is an ISO `YYYY-MM-DD` — the canonical daily-note form — paired
+ * with the human `phrase` to show in the menu (`null` for a bare ISO query,
+ * which needs no friendlier label than the date itself).
+ */
+
+import { isCalendarDate } from '../markdown/resolve'
+import type { DateFormat } from '../settings/schema'
+
+/** One synthesised daily-note target: the resolved day plus its menu label. */
+export interface DateSuggestion {
+  /** Resolved daily-note date, ISO `YYYY-MM-DD`. */
+  date: string
+  /** Human label for the menu ("3 days ago", "Next Friday"); `null` for a bare ISO query. */
+  phrase: string | null
+}
+
+/** What the generator needs from its caller: the local clock and the slash-date order. */
+export interface DateSuggestionContext {
+  /** Today's local calendar date, ISO `YYYY-MM-DD`. */
+  today: string
+  /** Reading order for ambiguous typed slash-dates (`mdy` → M/D, `dmy` → D/M). */
+  dateFormat: DateFormat
+}
+
+/** At most this many date suggestions survive into the menu. */
+const MAX_RESULTS = 3
+/** Relative offsets beyond this many years from today are treated as nonsense. */
+const MAX_RELATIVE_YEARS = 15
+/** Natural-language phrases need at least this many typed characters to appear. */
+const MIN_PHRASE_CHARS = 3
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+// --- UTC date arithmetic (no date-fns in core; UTC sidesteps DST entirely) ---
+
+function parseUtc(iso: string): Date {
+  const [year, month, day] = iso.split('-').map(Number)
+  return new Date(Date.UTC(year, month - 1, day))
+}
+
+function toIso(date: Date): string {
+  return fromParts(date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate())
+}
+
+function fromParts(year: number, month: number, day: number): string {
+  const pad = (value: number, width: number): string => String(value).padStart(width, '0')
+  return `${pad(year, 4)}-${pad(month, 2)}-${pad(day, 2)}`
+}
+
+function addDays(iso: string, days: number): string {
+  const date = parseUtc(iso)
+  date.setUTCDate(date.getUTCDate() + days)
+  return toIso(date)
+}
+
+/** Add months with end-of-month clamping (date-fns semantics): Jan 31 + 1mo → Feb 28. */
+function addMonths(iso: string, months: number): string {
+  const [year, month, day] = iso.split('-').map(Number)
+  const zeroBased = month - 1 + months
+  const targetYear = year + Math.floor(zeroBased / 12)
+  const targetMonth = ((zeroBased % 12) + 12) % 12
+  const lastDay = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate()
+  return fromParts(targetYear, targetMonth + 1, Math.min(day, lastDay))
+}
+
+/** Day of week for an ISO date: 0 = Sunday … 6 = Saturday. */
+function weekday(iso: string): number {
+  return parseUtc(iso).getUTCDay()
+}
+
+/** Is `iso` within {@link MAX_RELATIVE_YEARS} of `today`? ISO strings sort chronologically. */
+function withinRelativeLimit(iso: string, today: string): boolean {
+  return iso >= addMonths(today, -12 * MAX_RELATIVE_YEARS) && iso <= addMonths(today, 12 * MAX_RELATIVE_YEARS)
+}
+
+function titleCase(word: string): string {
+  return word.charAt(0).toUpperCase() + word.slice(1)
+}
+
+// --- Relative offsets ("3 days ago", "2 weeks from now", "1") ---
+
+type Unit = 'day' | 'week' | 'month' | 'year'
+const UNITS: readonly Unit[] = ['day', 'week', 'month', 'year']
+type Direction = 'future' | 'past'
+const DIRECTIONS: readonly Direction[] = ['future', 'past']
+
+const SPELLED_NUMBERS: Record<string, number> = {
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+  ten: 10,
+}
+
+const UNIT_WORDS: Record<string, Unit> = {
+  day: 'day',
+  days: 'day',
+  week: 'week',
+  weeks: 'week',
+  month: 'month',
+  months: 'month',
+  year: 'year',
+  years: 'year',
+}
+
+function extractNumber(tokens: readonly string[]): number | null {
+  for (const token of tokens) {
+    if (/^\d+$/.test(token)) {
+      return Number(token)
+    }
+    if (token in SPELLED_NUMBERS) {
+      return SPELLED_NUMBERS[token]
+    }
+  }
+  return null
+}
+
+function extractUnit(tokens: readonly string[]): Unit | null {
+  for (const token of tokens) {
+    if (token in UNIT_WORDS) {
+      return UNIT_WORDS[token]
+    }
+  }
+  return null
+}
+
+function extractDirection(tokens: readonly string[]): Direction | null {
+  const hasPast = tokens.includes('ago')
+  const hasFuture = tokens.some(
+    (token) => token === 'from' || token === 'now' || token === 'later' || token === 'in' || token === 'hence',
+  )
+  if (hasPast && !hasFuture) {
+    return 'past'
+  }
+  if (hasFuture && !hasPast) {
+    return 'future'
+  }
+  return null
+}
+
+function shiftByUnit(today: string, unit: Unit, amount: number): string {
+  switch (unit) {
+    case 'day':
+      return addDays(today, amount)
+    case 'week':
+      return addDays(today, amount * 7)
+    case 'month':
+      return addMonths(today, amount)
+    case 'year':
+      return addMonths(today, amount * 12)
+  }
+}
+
+function relativeSuggestions(tokens: readonly string[], context: DateSuggestionContext): DateSuggestion[] {
+  const amount = extractNumber(tokens)
+  if (amount === null) {
+    return []
+  }
+  const unitFilter = extractUnit(tokens)
+  const directionFilter = extractDirection(tokens)
+  // A bare number ("1") offers offsets in every unit; otherwise a unit or
+  // direction word must anchor the query, so "december 2" never becomes
+  // "2 days from now".
+  const isBareNumber = tokens.length === 1
+  if (!isBareNumber && unitFilter === null && directionFilter === null) {
+    return []
+  }
+  const results: DateSuggestion[] = []
+  for (const direction of DIRECTIONS) {
+    if (directionFilter !== null && direction !== directionFilter) {
+      continue
+    }
+    for (const unit of UNITS) {
+      if (unitFilter !== null && unit !== unitFilter) {
+        continue
+      }
+      const date = shiftByUnit(context.today, unit, direction === 'future' ? amount : -amount)
+      if (!withinRelativeLimit(date, context.today)) {
+        continue
+      }
+      const plural = amount === 1 ? '' : 's'
+      const phrase =
+        direction === 'future' ? `${amount} ${unit}${plural} from now` : `${amount} ${unit}${plural} ago`
+      results.push({ date, phrase })
+    }
+  }
+  return results
+}
+
+// --- Natural-language phrases ("tomorrow", "next friday", "this week") ---
+
+type Modifier = 'this' | 'next' | 'last'
+const MODIFIERS: readonly Modifier[] = ['this', 'next', 'last']
+
+const WEEKDAY_ORDER: readonly string[] = [
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday',
+]
+const WEEKDAY_INDEX: Record<string, number> = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+}
+
+/** The smallest date on or after `today` whose weekday is `target` (today counts). */
+function upcomingWeekday(today: string, target: number): string {
+  return addDays(today, (target - weekday(today) + 7) % 7)
+}
+
+/** Monday of `today`'s week — a fixed Monday start, independent of any week-start preference. */
+function mondayOfWeek(today: string): string {
+  return addDays(today, -((weekday(today) + 6) % 7))
+}
+
+function resolveWeekday(today: string, target: number, modifier: Modifier): string {
+  const upcoming = upcomingWeekday(today, target)
+  if (modifier === 'this') {
+    return upcoming
+  }
+  return addDays(upcoming, modifier === 'next' ? 7 : -7)
+}
+
+function resolveFromAnchor(anchor: string, modifier: Modifier, stepDays: number): string {
+  if (modifier === 'this') {
+    return anchor
+  }
+  return addDays(anchor, modifier === 'next' ? stepDays : -stepDays)
+}
+
+interface NlUnit {
+  /** The unit word a single-token query prefix-matches ("monday", "week", "month"). */
+  word: string
+  /** Capitalised display name for the phrase ("Monday", "Week"). */
+  display: string
+  /** Sort weight within a modifier: weekdays (0–6) before week/weekend/month. */
+  order: number
+  resolve: (today: string, modifier: Modifier) => string
+}
+
+function nlUnits(): NlUnit[] {
+  const weekdays: NlUnit[] = WEEKDAY_ORDER.map((name, index) => ({
+    word: name,
+    display: titleCase(name),
+    order: index,
+    resolve: (today, modifier) => resolveWeekday(today, WEEKDAY_INDEX[name], modifier),
+  }))
+  return [
+    ...weekdays,
+    {
+      word: 'week',
+      display: 'Week',
+      order: 7,
+      resolve: (today, modifier) => resolveFromAnchor(mondayOfWeek(today), modifier, 7),
+    },
+    {
+      word: 'weekend',
+      display: 'Weekend',
+      order: 8,
+      resolve: (today, modifier) => resolveFromAnchor(addDays(mondayOfWeek(today), 5), modifier, 7),
+    },
+    {
+      word: 'month',
+      display: 'Month',
+      order: 9,
+      resolve: (today, modifier) => {
+        const [year, month] = today.split('-').map(Number)
+        const first = fromParts(year, month, 1)
+        return modifier === 'this' ? first : addMonths(first, modifier === 'next' ? 1 : -1)
+      },
+    },
+  ]
+}
+
+interface NlCandidate {
+  phrase: string
+  date: string
+  modifier: Modifier | null
+  unitWord: string
+  sort: number
+}
+
+/**
+ * Does the query match this phrase? A one-token query prefix-matches the unit
+ * word (`mon` → *…Monday*, `yest` → *Yesterday*); a two-token query matches the
+ * modifier then the unit (`next fri` → *Next Friday*).
+ */
+function phraseMatches(tokens: readonly string[], modifier: Modifier | null, unitWord: string): boolean {
+  if (tokens.length === 1) {
+    return unitWord.startsWith(tokens[0])
+  }
+  if (tokens.length === 2) {
+    return modifier !== null && modifier.startsWith(tokens[0]) && unitWord.startsWith(tokens[1])
+  }
+  return false
+}
+
+function naturalLanguageSuggestions(
+  query: string,
+  tokens: readonly string[],
+  context: DateSuggestionContext,
+): DateSuggestion[] {
+  if (query.length < MIN_PHRASE_CHARS) {
+    return []
+  }
+  const candidates: NlCandidate[] = [
+    { phrase: 'Today', date: context.today, modifier: null, unitWord: 'today', sort: 0 },
+    { phrase: 'Yesterday', date: addDays(context.today, -1), modifier: null, unitWord: 'yesterday', sort: 1 },
+    { phrase: 'Tomorrow', date: addDays(context.today, 1), modifier: null, unitWord: 'tomorrow', sort: 2 },
+  ]
+  const units = nlUnits()
+  MODIFIERS.forEach((modifier, modifierIndex) => {
+    for (const unit of units) {
+      candidates.push({
+        phrase: `${titleCase(modifier)} ${unit.display}`,
+        date: unit.resolve(context.today, modifier),
+        modifier,
+        unitWord: unit.word,
+        // Sort by unit first (so `mon` yields the three Mondays before Months),
+        // then modifier (this < next < last). Offset keeps standalone words first.
+        sort: 10 + unit.order * MODIFIERS.length + modifierIndex,
+      })
+    }
+  })
+  return candidates
+    .filter((candidate) => phraseMatches(tokens, candidate.modifier, candidate.unitWord))
+    .sort((left, right) => left.sort - right.sort)
+    .map((candidate) => ({ date: candidate.date, phrase: candidate.phrase }))
+}
+
+// --- Typed calendar dates ("2026-06-19", "12/25", "23/2/2023") ---
+
+function typedDateSuggestions(
+  lower: string,
+  echo: string,
+  context: DateSuggestionContext,
+): DateSuggestion[] {
+  if (ISO_DATE_RE.test(lower)) {
+    return isCalendarDate(lower) ? [{ date: lower, phrase: null }] : []
+  }
+  if (!lower.includes('/')) {
+    return []
+  }
+  const parts = lower.split('/').map((part) => part.trim())
+  if (parts.length < 2 || parts.length > 3 || !parts.every((part) => /^\d+$/.test(part))) {
+    return []
+  }
+  const [first, second] = parts.map(Number)
+  const year = parts.length === 3 ? Number(parts[2]) : Number(context.today.slice(0, 4))
+  // The preferred reading follows the date-format setting; the swapped reading
+  // is offered only for bare shorthand, where "12/10" is genuinely ambiguous.
+  const readings =
+    context.dateFormat === 'dmy'
+      ? [
+          { day: first, month: second },
+          { day: second, month: first },
+        ]
+      : [
+          { month: first, day: second },
+          { month: second, day: first },
+        ]
+  const allowSwap = parts.length === 2
+  const seen = new Set<string>()
+  const results: DateSuggestion[] = []
+  readings.forEach((reading, index) => {
+    if (index === 1 && !allowSwap) {
+      return
+    }
+    if (reading.month < 1 || reading.month > 12) {
+      return
+    }
+    const iso = fromParts(year, reading.month, reading.day)
+    if (!isCalendarDate(iso) || seen.has(iso)) {
+      return
+    }
+    seen.add(iso)
+    results.push({ date: iso, phrase: echo })
+  })
+  return results
+}
+
+// --- Month-name dates ("December 2nd", "2 Dec", "Mar 3 2024") ---
+
+const MONTH_ABBREVIATIONS: Record<string, number> = {
+  jan: 1,
+  feb: 2,
+  mar: 3,
+  apr: 4,
+  may: 5,
+  jun: 6,
+  jul: 7,
+  aug: 8,
+  sep: 9,
+  sept: 9,
+  oct: 10,
+  nov: 11,
+  dec: 12,
+}
+const MONTH_NAMES: readonly string[] = [
+  'january',
+  'february',
+  'march',
+  'april',
+  'may',
+  'june',
+  'july',
+  'august',
+  'september',
+  'october',
+  'november',
+  'december',
+]
+
+function matchMonth(token: string): number | null {
+  if (token.length < 3) {
+    return null
+  }
+  if (token in MONTH_ABBREVIATIONS) {
+    return MONTH_ABBREVIATIONS[token]
+  }
+  const index = MONTH_NAMES.findIndex((name) => name.startsWith(token))
+  return index === -1 ? null : index + 1
+}
+
+function matchDay(token: string): number | null {
+  const match = /^(\d{1,2})(?:st|nd|rd|th)?$/.exec(token)
+  if (match === null) {
+    return null
+  }
+  const day = Number(match[1])
+  return day >= 1 && day <= 31 ? day : null
+}
+
+function monthNameSuggestions(
+  query: string,
+  tokens: readonly string[],
+  echo: string,
+  context: DateSuggestionContext,
+): DateSuggestion[] {
+  if (query.length < MIN_PHRASE_CHARS) {
+    return []
+  }
+  let month: number | null = null
+  let day: number | null = null
+  let year: number | null = null
+  for (const token of tokens) {
+    if (month === null && matchMonth(token) !== null) {
+      month = matchMonth(token)
+      continue
+    }
+    if (year === null && /^\d{4}$/.test(token)) {
+      year = Number(token)
+      continue
+    }
+    if (day === null && matchDay(token) !== null) {
+      day = matchDay(token)
+    }
+  }
+  if (month === null || day === null) {
+    return []
+  }
+  const iso = fromParts(year ?? Number(context.today.slice(0, 4)), month, day)
+  return isCalendarDate(iso) ? [{ date: iso, phrase: echo }] : []
+}
+
+/**
+ * Synthesise up to {@link MAX_RESULTS} daily-note targets from `query`, merging
+ * the four interpretations and keeping one entry per resolved day (the most
+ * specific phrasing wins). Returns `[]` for an empty query or one no
+ * interpretation recognises.
+ */
+export function generateDateSuggestions(query: string, context: DateSuggestionContext): DateSuggestion[] {
+  const trimmed = query.trim()
+  if (trimmed === '') {
+    return []
+  }
+  const lower = trimmed.toLowerCase()
+  const tokens = lower.split(/\s+/).filter(Boolean)
+
+  const collected: DateSuggestion[] = [
+    ...typedDateSuggestions(lower, trimmed, context),
+    ...monthNameSuggestions(lower, tokens, trimmed, context),
+    ...relativeSuggestions(tokens, context),
+    ...naturalLanguageSuggestions(lower, tokens, context),
+  ]
+
+  const seen = new Set<string>()
+  const result: DateSuggestion[] = []
+  for (const suggestion of collected) {
+    if (seen.has(suggestion.date)) {
+      continue
+    }
+    seen.add(suggestion.date)
+    result.push(suggestion)
+    if (result.length >= MAX_RESULTS) {
+      break
+    }
+  }
+  return result
+}

--- a/packages/core/src/indexing/index.ts
+++ b/packages/core/src/indexing/index.ts
@@ -90,7 +90,12 @@ export {
   type RecentNoteRow,
   type RecentNotesOptions,
 } from './note-list'
-export { rankWikiSuggestions, type WikiSuggestion } from './suggest'
+export { rankWikiSuggestions, mergeDateSuggestions, type WikiSuggestion } from './suggest'
+export {
+  generateDateSuggestions,
+  type DateSuggestion,
+  type DateSuggestionContext,
+} from './date-suggestions'
 export {
   parseHighlights,
   randomNotePath,

--- a/packages/core/src/indexing/queries.test.ts
+++ b/packages/core/src/indexing/queries.test.ts
@@ -6,6 +6,7 @@ import {
   getNoteIdsByPath,
   getPinnedNotes,
   listDailyNotes,
+  suggestWikiTargets,
 } from './queries'
 
 // A fake bridge resolves `db_query` so the test exercises the real compiled
@@ -170,5 +171,52 @@ describe('getNoteIdsByPath', () => {
     expect(ids.get('notes/0.md')).toBe('id-notes/0.md')
     expect(ids.get('notes/500.md')).toBe('id-notes/500.md')
     expect(ids.get('notes/1000.md')).toBe('id-notes/1000.md')
+  })
+})
+
+describe('suggestWikiTargets', () => {
+  // Wednesday, 1 January 2020, day/month — the date generator's worked-example
+  // clock. This exercises the live glue (generator + merge) the editor hits;
+  // the parts themselves are unit-tested in date-suggestions/suggest.
+  const clock = { today: '2020-01-01', dateFormat: 'dmy' as const }
+
+  it('synthesises a daily target from a fuzzy query when given a clock', async () => {
+    mockInvoke.mockResolvedValue([]) // no title or alias matches
+
+    await expect(suggestWikiTargets('3 days ago', 8, clock)).resolves.toEqual([
+      {
+        target: '2019-12-29',
+        path: null,
+        title: '2019-12-29',
+        alias: null,
+        date: '2019-12-29',
+        phrase: '3 days ago',
+      },
+    ])
+  })
+
+  it('keeps an exact title match above the generated date (folded key threaded into the merge)', async () => {
+    mockInvoke.mockResolvedValue([]) // aliases query + fallback
+    mockInvoke.mockResolvedValueOnce([
+      { path: 'notes/today.md', title: 'Today', title_key: 'today', daily_date: null, mtime: 1 },
+    ])
+
+    const result = await suggestWikiTargets('today', 8, clock)
+
+    expect(result.map((row) => row.target)).toEqual(['Today', '2020-01-01'])
+    expect(result[0].path).toBe('notes/today.md')
+    expect(result[1]).toMatchObject({ date: '2020-01-01', phrase: 'Today', path: null })
+  })
+
+  it('does not synthesise dates without a clock (legacy callers unchanged)', async () => {
+    mockInvoke.mockResolvedValue([])
+    await expect(suggestWikiTargets('today')).resolves.toEqual([])
+  })
+
+  it('still injects the bare daily for a full ISO query without a clock', async () => {
+    mockInvoke.mockResolvedValue([])
+    await expect(suggestWikiTargets('2020-01-01')).resolves.toEqual([
+      { target: '2020-01-01', path: null, title: '2020-01-01', alias: null, date: '2020-01-01' },
+    ])
   })
 })

--- a/packages/core/src/indexing/queries.ts
+++ b/packages/core/src/indexing/queries.ts
@@ -8,10 +8,12 @@ import {
   type Resolution,
   type TaskMarker,
 } from '../markdown'
+import { generateDateSuggestions, type DateSuggestionContext } from './date-suggestions'
 import { db } from './db'
 import { buildFtsMatch } from './search-query'
 import { lineSnippet } from './snippet'
 import {
+  mergeDateSuggestions,
   rankWikiSuggestions,
   type AliasCandidate,
   type TitleCandidate,
@@ -226,8 +228,18 @@ export async function suggestTags(query: string, limit = 8): Promise<TagSuggesti
  * titles before aliases, recent first); an empty query suggests recent notes.
  * A full `YYYY-MM-DD` query always yields that daily as the first candidate —
  * dailies are valid targets before their file exists (created lazily on write).
+ *
+ * Pass `dateGen` (the clock + date-format preference) to also synthesise
+ * date suggestions from fuzzy queries — "3 days ago", "next friday", "12/25",
+ * "December 2nd" — via {@link generateDateSuggestions}, merged ahead of the
+ * index matches. Omit it (e.g. legacy callers) to keep the plain title/alias
+ * behaviour with only the full-ISO daily injection.
  */
-export async function suggestWikiTargets(query: string, limit = 8): Promise<WikiSuggestion[]> {
+export async function suggestWikiTargets(
+  query: string,
+  limit = 8,
+  dateGen?: DateSuggestionContext,
+): Promise<WikiSuggestion[]> {
   const normalized = normalizeWikiTarget(query)
   const key = normalized.key
 
@@ -264,6 +276,12 @@ export async function suggestWikiTargets(query: string, limit = 8): Promise<Wiki
   }
 
   const ranked = rankWikiSuggestions(key, titles, aliases, limit)
+
+  // With a clock, the generator covers the full-ISO daily too (and more), so it
+  // supersedes the bare injection below.
+  if (dateGen !== undefined) {
+    return mergeDateSuggestions(ranked, generateDateSuggestions(query, dateGen), { key, limit })
+  }
 
   if (normalized.date !== undefined) {
     const date = normalized.date

--- a/packages/core/src/indexing/suggest.test.ts
+++ b/packages/core/src/indexing/suggest.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { rankWikiSuggestions, type AliasCandidate, type TitleCandidate } from './suggest'
+import {
+  mergeDateSuggestions,
+  rankWikiSuggestions,
+  type AliasCandidate,
+  type TitleCandidate,
+  type WikiSuggestion,
+} from './suggest'
 
 function note(
   title: string,
@@ -71,5 +77,76 @@ describe('rankWikiSuggestions', () => {
   it('honours the limit after merging', () => {
     const titles = Array.from({ length: 10 }, (_, i) => note(`Note ${i}`, i))
     expect(rankWikiSuggestions('note', titles, [], 3)).toHaveLength(3)
+  })
+})
+
+function ranked(title: string, extra?: Partial<WikiSuggestion>): WikiSuggestion {
+  return {
+    target: title,
+    path: `notes/${title.toLowerCase().replaceAll(' ', '-')}.md`,
+    title,
+    alias: null,
+    date: null,
+    ...extra,
+  }
+}
+
+describe('mergeDateSuggestions', () => {
+  it('passes ranked through untouched when there are no dates', () => {
+    const rows = [ranked('Alpha'), ranked('Beta')]
+    expect(mergeDateSuggestions(rows, [], { key: 'al', limit: 8 })).toEqual(rows)
+  })
+
+  it('leads with date suggestions ahead of non-exact matches', () => {
+    const result = mergeDateSuggestions(
+      [ranked('Monday Standup')],
+      [{ date: '2020-01-06', phrase: 'This Monday' }],
+      { key: 'mon', limit: 8 },
+    )
+    expect(result.map((row) => row.target)).toEqual(['2020-01-06', 'Monday Standup'])
+    expect(result[0]).toMatchObject({ date: '2020-01-06', phrase: 'This Monday', path: null })
+  })
+
+  it('keeps an exact title match in the very top slot, dates next', () => {
+    const result = mergeDateSuggestions(
+      [ranked('Today'), ranked('Today Notes')],
+      [{ date: '2020-01-01', phrase: 'Today' }],
+      { key: 'today', limit: 8 },
+    )
+    expect(result.map((row) => row.target)).toEqual(['Today', '2020-01-01', 'Today Notes'])
+  })
+
+  it('reuses an existing daily row (real path) and attaches the phrase once', () => {
+    const existingDaily = ranked('2020-01-06', {
+      target: '2020-01-06',
+      path: 'daily/2020-01-06.md',
+      date: '2020-01-06',
+    })
+    const result = mergeDateSuggestions(
+      [existingDaily, ranked('Other')],
+      [{ date: '2020-01-06', phrase: 'This Monday' }],
+      { key: 'mon', limit: 8 },
+    )
+    expect(result).toHaveLength(2)
+    expect(result[0]).toMatchObject({ path: 'daily/2020-01-06.md', phrase: 'This Monday' })
+    expect(result.map((row) => row.target)).toEqual(['2020-01-06', 'Other'])
+  })
+
+  it('a bare-ISO date carries no phrase', () => {
+    const result = mergeDateSuggestions([], [{ date: '2026-06-19', phrase: null }], {
+      key: '2026-06-19',
+      limit: 8,
+    })
+    expect(result[0].phrase).toBeUndefined()
+  })
+
+  it('honours the limit across dates plus matches', () => {
+    const rows = Array.from({ length: 8 }, (_, i) => ranked(`Note ${i}`))
+    const result = mergeDateSuggestions(rows, [{ date: '2020-01-02', phrase: 'Tomorrow' }], {
+      key: 'note',
+      limit: 5,
+    })
+    expect(result).toHaveLength(5)
+    expect(result[0].target).toBe('2020-01-02')
   })
 })

--- a/packages/core/src/indexing/suggest.ts
+++ b/packages/core/src/indexing/suggest.ts
@@ -6,6 +6,9 @@
  * lives here where it can be unit-tested without a database.
  */
 
+import { foldKey } from '../markdown/keys'
+import type { DateSuggestion } from './date-suggestions'
+
 /** A `[[` autocomplete candidate. */
 export interface WikiSuggestion {
   /** What `[[…]]` should contain when chosen (the canonical title, or an ISO date). */
@@ -18,6 +21,12 @@ export interface WikiSuggestion {
   alias: string | null
   /** Set on daily-note suggestions. */
   date: string | null
+  /**
+   * Human label for a generated date suggestion ("3 days ago", "Next Friday").
+   * Present only on rows synthesised by the date generator — its absence is how
+   * hosts tell a generated daily apart from a real note or an existing daily.
+   */
+  phrase?: string
 }
 
 /** One `notes` row considered for suggestion (a title match or recency fill). */
@@ -112,4 +121,60 @@ export function rankWikiSuggestions(
     }
   }
   return result
+}
+
+/**
+ * Fold generated date suggestions into the ranked index results for the `[[`
+ * menu. Dates lead the list — except an exact title/alias match keeps the very
+ * top slot, the way V1 lets a note literally titled "Today" outrank the
+ * generated *Today*. When a generated day already exists as an indexed daily,
+ * that real row is reused (so the link resolves to the existing file) but
+ * carries the phrase, and a day never appears twice.
+ *
+ * Pure so the ordering policy is unit-testable without a database; the only
+ * caller is {@link suggestWikiTargets}.
+ */
+export function mergeDateSuggestions(
+  ranked: WikiSuggestion[],
+  dates: readonly DateSuggestion[],
+  options: { key: string; limit: number },
+): WikiSuggestion[] {
+  if (dates.length === 0) {
+    return ranked.slice(0, options.limit)
+  }
+  const rankedByDate = new Map<string, WikiSuggestion>()
+  for (const suggestion of ranked) {
+    if (suggestion.date !== null) {
+      rankedByDate.set(suggestion.date, suggestion)
+    }
+  }
+
+  const reused = new Set<WikiSuggestion>()
+  const dateRows: WikiSuggestion[] = dates.map(({ date, phrase }) => {
+    const existing = rankedByDate.get(date)
+    if (existing !== undefined) {
+      reused.add(existing)
+      return phrase === null ? existing : { ...existing, phrase }
+    }
+    return {
+      target: date,
+      path: null,
+      title: date,
+      alias: null,
+      date,
+      ...(phrase === null ? {} : { phrase }),
+    }
+  })
+
+  const rest = ranked.filter((suggestion) => !reused.has(suggestion))
+  const exactIndex = rest.findIndex(
+    (suggestion) =>
+      foldKey(suggestion.target) === options.key ||
+      (suggestion.alias !== null && foldKey(suggestion.alias) === options.key),
+  )
+  const ordered =
+    exactIndex >= 0
+      ? [rest[exactIndex], ...dateRows, ...rest.filter((_, index) => index !== exactIndex)]
+      : [...dateRows, ...rest]
+  return ordered.slice(0, options.limit)
 }

--- a/packages/core/src/markdown/resolve.ts
+++ b/packages/core/src/markdown/resolve.ts
@@ -14,7 +14,7 @@ import { foldKey } from './keys'
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 
 /** Is `value` a real calendar day (not just `YYYY-MM-DD`-shaped)? */
-function isCalendarDate(value: string): boolean {
+export function isCalendarDate(value: string): boolean {
   const [year, month, day] = value.split('-').map(Number)
   if (month < 1 || month > 12) {
     return false


### PR DESCRIPTION
## What

Typing `[[3 days ago`, `[[next friday`, `[[tomorrow`, `[[12/25`, or `[[December 2nd` now surfaces the matching **daily note** — synthesised from the query and lazily created on link — in both the editor's `[[` autocomplete and the command palette.

Before this, V2 only recognised a full ISO `YYYY-MM-DD`, so linking to a date meant typing the exact string. This ports the distinctive date-generator behaviour of the original Reflect; see [`docs/reflect-v1-backlink-menu.md`](docs/reflect-v1-backlink-menu.md) for the spec.

## Why

`[[Wiki Links]]` + daily-notes-first is core to Reflect, and "link to a date you've never opened" is a defining flow. ISO-only recognition made it the one wiki-link path that required knowing the exact canonical string — a clear parity gap with V1.

## How

**Core**
- New pure, dependency-free generator [`packages/core/src/indexing/date-suggestions.ts`](packages/core/src/indexing/date-suggestions.ts) interpreting the query four ways and merging by resolved day (cap 3):
  - **Relative offsets** — `3 days ago`, `one day`, bare `1`; spelled `one`–`ten`; ~15-year sanity cap (so `17 years` / `1000 years` stay quiet); guarded so a month-name day number never becomes "2 days from now".
  - **Natural language** — `today`/`yesterday`/`tomorrow`; `this|next|last` + weekday/`week`/`weekend`/`month`; prefix-matched (`mon`, `next fri`).
  - **Typed calendar** — ISO `2026-06-19` and slash `12/25` / `23/2/2023` per the date-format preference, with ambiguous `12/10` → both readings.
  - **Month-name** — `December 2nd`, `2 Dec`, abbreviations, malformed ordinals (`31th`), optional year.
  - The clock is injected as `today` and all arithmetic runs in **UTC**, so DST can't skip or repeat a day (no `date-fns` dependency added to core).
- `WikiSuggestion` gains an optional `phrase`; pure `mergeDateSuggestions` folds dates into the ranked index results: **dates lead, but an exact title/alias match keeps the top slot**, and an existing daily is reused so the link resolves to its real file (no duplicate day).
- `suggestWikiTargets(query, limit, dateGen?)` takes an opt-in context; the no-`dateGen` path is unchanged.

**Editor `[[` menu** — passes the clock + date-format, renders the phrase as the label and the resolved day as the detail, and suppresses the "Create …" row when the query reads as a date. Also fixed a stale comment: meowdown `0.8.1` hands the handler the **raw** post-`[[` text (case/spaces/slashes preserved), not a "lowercased, punctuation-stripped" query.

**Command palette** — opts in too; generated dates are appended **after** real note matches (in a global open surface your notes should outrank "Next Monday", unlike the `[[` menu where dates lead). The phrase renders above a muted resolved date; path-less dailies were already jumpable via the existing `dailyPath` synthesis.

## Reviewer notes — deliberate divergences from V1 (documented in tests)
- **Ambiguous shorthand** (`12/10`) uses the **current year for both** readings (V1's mixed Oct-2020/Dec-2019 looked like an idiosyncrasy).
- **Relative phrases always use digits** ("1 day ago"), so `[[one day ago]]` reads "1 day ago" (V1's spelled-echo came from a separate NL engine that isn't ported).
- **`this/next/last week`** uses a fixed **Monday start** in this PR. _Correction:_ V2 **does** have a `weekStartDay` setting — the follow-up [#229](https://github.com/team-reflect/reflect-open/pull/229) makes these phrases respect it.

## Testing
- `pnpm typecheck` clean; `pnpm lint` 0 errors (the 4 warnings are pre-existing, in unrelated files).
- New tests green: **21** generator cases mirror the V1 doc's worked-examples table (today = 2020-01-01, `dmy`), plus `mergeDateSuggestions` ordering/reuse/cap, editor create-suppression, and palette-append coverage.
- Verified via unit tests + typecheck/lint; **not** yet run in a live `tauri dev` session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive autocomplete/indexing behavior behind an opt-in API; legacy `suggestWikiTargets` callers unchanged. Main risk is date-parsing edge cases or wrong day near midnight, mitigated by tests and `today` in the cache key.
> 
> **Overview**
> Ports **V1-style daily-note suggestions** from natural-language and partial date queries (e.g. `3 days ago`, `next friday`, `12/25`, `December 2nd`) into the **`[[` autocomplete** and **command palette**, not only full ISO `YYYY-MM-DD`.
> 
> **Core:** New pure `generateDateSuggestions` (injected `today` + `dateFormat`, UTC math, cap 3) and optional `phrase` on `WikiSuggestion`. `suggestWikiTargets` accepts an opt-in `DateSuggestionContext`; without it, behavior stays the same (ISO daily injection only). `mergeDateSuggestions` puts generated dates first in the `[[` menu but keeps an exact title/alias match on top and reuses existing daily rows.
> 
> **Desktop:** Editor and palette pass clock + format into `suggestWikiTargets`; palette query cache keys include `today` so relative labels don’t go stale after midnight. Palette **reorders** suggestions so real notes beat generated dates (opposite of `[[`). UI shows **phrase** as primary label with formatted date as detail; **Create** is suppressed when a generated date suggestion is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa0b852505989d0091ed1ec6895497d3930455c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
