### PR TITLE
Polish iOS interactions: remove keyboard accessory bar, native bottom sheets, touch CSS

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -48,6 +48,7 @@
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0",
     "ulidx": "^2.4.1",
+    "vaul": "^1.1.2",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/apps/desktop/src/components/ui/drawer.tsx
+++ b/apps/desktop/src/components/ui/drawer.tsx
@@ -1,0 +1,132 @@
+import * as React from "react"
+import { Drawer as DrawerPrimitive } from "vaul"
+
+import { cn } from "@/lib/utils"
+
+/**
+ * A bottom sheet for touch surfaces, built on vaul (drag-to-dismiss + spring
+ * physics). The mobile-native answer to a centered dialog or a popover: content
+ * slides up from the bottom edge and can be flicked back down to dismiss.
+ * Tokens mirror {@link Dialog} so the two read as one system. Bottom-anchored
+ * only — the other directions vaul supports aren't needed on Reflect's mobile
+ * surfaces — and the home-indicator safe area is padded for by default.
+ */
+function Drawer(props: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+}
+
+function DrawerTrigger(
+  props: React.ComponentProps<typeof DrawerPrimitive.Trigger>
+) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />
+}
+
+function DrawerClose(props: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
+}
+
+function DrawerPortal(
+  props: React.ComponentProps<typeof DrawerPrimitive.Portal>
+) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/30 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPortal>
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          "fixed inset-x-0 bottom-0 z-50 mt-24 flex max-h-[85vh] flex-col gap-3 rounded-t-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 outline-none",
+          // Pad past the home indicator so the last row isn't tucked under it.
+          "pb-[max(env(safe-area-inset-bottom),1rem)]",
+          className
+        )}
+        {...props}
+      >
+        <DrawerPrimitive.Handle className="mx-auto mb-1 h-1 w-10 shrink-0 rounded-full bg-border" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  )
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn("flex flex-col gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn("font-heading text-base leading-none font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerTitle,
+  DrawerTrigger,
+}

--- a/apps/desktop/src/mobile/note-actions-menu.test.tsx
+++ b/apps/desktop/src/mobile/note-actions-menu.test.tsx
@@ -1,4 +1,5 @@
-import { cleanup, render, waitFor } from '@testing-library/react'
+import { type ReactNode } from 'react'
+import { cleanup, render, waitFor, within } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -6,10 +7,22 @@ import { setBridge } from '@reflect/core'
 import { NoteActionsMenu } from './note-actions-menu'
 
 /**
- * The note-actions menu (Plan 19): pin toggles the frontmatter flag, and
+ * The note-actions sheet (Plan 19): pin toggles the frontmatter flag, and
  * delete confirms then moves the note to trash and notifies the screen. Runs
  * the real toggle/delete core paths over a fake IPC bridge.
+ *
+ * The drawer wrapper is vaul, which needs browser APIs jsdom doesn't provide
+ * (matchMedia, pointer capture); its drag/animation is verified on-device.
+ * Here it's mocked to a passthrough so the action rows are always rendered and
+ * the test can exercise the IPC side effects directly.
  */
+
+vi.mock('@/components/ui/drawer', () => ({
+  Drawer: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  DrawerTrigger: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  DrawerContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DrawerTitle: ({ children }: { children?: ReactNode }) => <h2>{children}</h2>,
+}))
 
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({ graph: { root: '/g', name: 'g', cloudSync: null, generation: 1 } }),
@@ -53,8 +66,7 @@ describe('NoteActionsMenu', () => {
     const user = userEvent.setup()
     const { view } = mount()
 
-    await user.click(view.getByRole('button', { name: 'Note actions' }))
-    await user.click(await view.findByRole('menuitem', { name: 'Pin' }))
+    await user.click(view.getByRole('button', { name: 'Pin' }))
 
     await waitFor(() => {
       const write = calls.find((call) => call.command === 'note_write')
@@ -66,10 +78,10 @@ describe('NoteActionsMenu', () => {
     const user = userEvent.setup()
     const { view, onDeleted } = mount()
 
-    await user.click(view.getByRole('button', { name: 'Note actions' }))
-    await user.click(await view.findByRole('menuitem', { name: 'Delete' }))
-    // Confirm in the dialog (the destructive button).
-    await user.click(await view.findByRole('button', { name: 'Delete' }))
+    await user.click(view.getByRole('button', { name: 'Delete' }))
+    // A second "Delete" appears in the confirm dialog; scope to it.
+    const dialog = await view.findByRole('dialog')
+    await user.click(within(dialog).getByRole('button', { name: 'Delete' }))
 
     await waitFor(() => {
       expect(calls.some((call) => call.command === 'note_delete')).toBe(true)

--- a/apps/desktop/src/mobile/note-actions-menu.tsx
+++ b/apps/desktop/src/mobile/note-actions-menu.tsx
@@ -11,11 +11,11 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
+  Drawer,
+  DrawerContent,
+  DrawerTitle,
+  DrawerTrigger,
+} from '@/components/ui/drawer'
 import { toggleNotePinned } from '@/lib/note-pin'
 import { deleteOpenNote } from '@/lib/note-delete'
 import { shareNote } from '@/mobile/share'
@@ -30,7 +30,7 @@ interface NoteActionsMenuProps {
 }
 
 /**
- * The note screen's "⋯" actions menu (Plan 19, V1 parity): pin/unpin, share,
+ * The note screen's "⋯" action sheet (Plan 19): pin/unpin, share,
  * and delete-to-trash. Pin reflects the index's pinned set; {@link shareNote}
  * hands the note's body to the OS share sheet via the Web Share API
  * (`navigator.share`); delete confirms first (it's destructive, even if
@@ -40,6 +40,7 @@ interface NoteActionsMenuProps {
 export function NoteActionsMenu({ path, onDeleted }: NoteActionsMenuProps): ReactElement {
   const { graph } = useGraph()
   const isPinned = usePinnedNotes().some((note) => note.path === path)
+  const [actionsOpen, setActionsOpen] = useState(false)
   const [confirmingDelete, setConfirmingDelete] = useState(false)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -71,27 +72,54 @@ export function NoteActionsMenu({ path, onDeleted }: NoteActionsMenuProps): Reac
 
   return (
     <>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
+      <Drawer open={actionsOpen} onOpenChange={setActionsOpen}>
+        <DrawerTrigger asChild>
           <Button variant="ghost" size="icon" className="size-10" aria-label="Note actions">
             <MoreHorizontal />
           </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem onSelect={pin}>
-            {isPinned ? <PinOff /> : <Pin />}
-            {isPinned ? 'Unpin' : 'Pin'}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={share}>
-            <Share />
-            Share
-          </DropdownMenuItem>
-          <DropdownMenuItem variant="destructive" onSelect={() => setConfirmingDelete(true)}>
-            <Trash2 />
-            Delete
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+        </DrawerTrigger>
+        <DrawerContent>
+          <DrawerTitle className="sr-only">Note actions</DrawerTitle>
+          <div className="flex flex-col gap-1">
+            <Button
+              variant="ghost"
+              size="lg"
+              className="h-12 justify-start gap-3 text-base"
+              onClick={() => {
+                pin()
+                setActionsOpen(false)
+              }}
+            >
+              {isPinned ? <PinOff /> : <Pin />}
+              {isPinned ? 'Unpin' : 'Pin'}
+            </Button>
+            <Button
+              variant="ghost"
+              size="lg"
+              className="h-12 justify-start gap-3 text-base"
+              onClick={() => {
+                share()
+                setActionsOpen(false)
+              }}
+            >
+              <Share />
+              Share
+            </Button>
+            <Button
+              variant="ghost"
+              size="lg"
+              className="h-12 justify-start gap-3 text-base text-destructive hover:text-destructive"
+              onClick={() => {
+                setActionsOpen(false)
+                setConfirmingDelete(true)
+              }}
+            >
+              <Trash2 />
+              Delete
+            </Button>
+          </div>
+        </DrawerContent>
+      </Drawer>
 
       <Dialog open={confirmingDelete} onOpenChange={(open) => !busy && setConfirmingDelete(open)}>
         <DialogContent>

--- a/apps/desktop/src/mobile/settings-sheet.tsx
+++ b/apps/desktop/src/mobile/settings-sheet.tsx
@@ -11,7 +11,7 @@ import {
   parseGithubRemote,
 } from '@reflect/core'
 import { Button } from '@/components/ui/button'
-import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
+import { Drawer, DrawerContent, DrawerTitle, DrawerTrigger } from '@/components/ui/drawer'
 import { useAppVersion } from '@/hooks/use-app-version'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
@@ -71,18 +71,14 @@ export function SettingsSheet(): ReactElement {
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
+    <Drawer open={open} onOpenChange={setOpen}>
+      <DrawerTrigger asChild>
         <Button variant="ghost" size="icon" className="size-9" aria-label="Settings">
           <Settings />
         </Button>
-      </DialogTrigger>
-      <DialogContent
-        showCloseButton={false}
-        className="inset-x-0 bottom-0 top-auto left-0 max-w-none translate-x-0 translate-y-0 rounded-b-none data-closed:zoom-out-100 data-open:zoom-in-100"
-        style={{ paddingBottom: 'max(env(safe-area-inset-bottom), 1rem)' }}
-      >
-        <DialogTitle>Settings</DialogTitle>
+      </DrawerTrigger>
+      <DrawerContent>
+        <DrawerTitle>Settings</DrawerTitle>
         <dl className="divide-y divide-border text-sm">
           <Row label="Graph" value={graph?.name ?? '—'} />
           <Row label="Notes" value={notes === undefined ? '…' : String(notes.length)} />
@@ -106,8 +102,8 @@ export function SettingsSheet(): ReactElement {
           ) : null}
           <Row label="Version" value={version ?? '…'} />
         </dl>
-      </DialogContent>
-    </Dialog>
+      </DrawerContent>
+    </Drawer>
   )
 }
 

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -170,14 +170,24 @@ body {
    Placed in @layer base so Tailwind's select-* utilities (select-text,
    select-all, select-none) in @layer utilities can override per-element. */
 @layer base {
+  /* Strip the mobile-webview "this is a webpage" tells: the gray flash on
+     every tap, and the long-press callout menu. `tap-highlight-color` is an
+     inherited property (set once on html); both are no-ops on desktop
+     pointers, so no platform gate is needed. */
+  html {
+    -webkit-tap-highlight-color: transparent;
+  }
+
   * {
     -webkit-user-select: none;
     user-select: none;
+    -webkit-touch-callout: none;
   }
 
   /* The * rule above applies none to every element explicitly, so it also
-     hits children inside selectable roots. Restore text on those roots AND
-     their descendants so inner p/h* nodes inside the editor are selectable. */
+     hits children inside selectable roots. Restore text selection — and the
+     long-press callout (the iOS selection magnifier) — on those roots AND
+     their descendants so editing text still works. */
   input,
   textarea,
   [contenteditable],
@@ -188,6 +198,18 @@ body {
   .reflect-protected-note * {
     -webkit-user-select: text;
     user-select: text;
+    -webkit-touch-callout: default;
+  }
+
+  /* Interactive chrome skips the double-tap-zoom wait. The viewport already
+     sets user-scalable=no (so the gesture is gone), making this belt-and-
+     suspenders; scoped to controls so it never fights editor or carousel
+     panning. */
+  button,
+  a,
+  [role='button'],
+  label {
+    touch-action: manipulation;
   }
 }
 

--- a/plugins/tauri-plugin-keyboard/ios/Sources/KeyboardPlugin.swift
+++ b/plugins/tauri-plugin-keyboard/ios/Sources/KeyboardPlugin.swift
@@ -1,3 +1,4 @@
+import ObjectiveC
 import SwiftRs
 import Tauri
 import UIKit
@@ -29,6 +30,10 @@ class KeyboardPlugin: Plugin {
     // The system's automatic inset adjustment is the source of the jump:
     // page layout owns keyboard avoidance instead (via the events below).
     webview.scrollView.contentInsetAdjustmentBehavior = .never
+    // iOS injects a form-assistant bar (‹ › field stepper + Done) above the
+    // keyboard for any focused field or contenteditable. Reflect edits one
+    // continuous document, so the bar is meaningless chrome — strip it.
+    Self.suppressInputAccessoryBar()
     let center = NotificationCenter.default
     center.addObserver(
       self,
@@ -79,6 +84,29 @@ class KeyboardPlugin: Plugin {
   /// when a screen mounts and subscribes).
   @objc public func currentHeight(_ invoke: Invoke) {
     invoke.resolve(currentState)
+  }
+
+  /// `WKContentView` (the webview's private first responder) returns the
+  /// keyboard's form-assistant bar from `inputAccessoryView`. Replace that
+  /// getter at the *class* level with one returning nil, so the swap doesn't
+  /// depend on the content view already existing when the plugin loads, and so
+  /// it survives the content view being recreated. Guarded by the class lookup,
+  /// so a future WebKit rename degrades to "bar stays" rather than crashing.
+  /// Idempotent via the static flag. iPad's separate `inputAssistantItem`
+  /// shortcut bar is intentionally left untouched here.
+  private static var didSuppressAccessoryBar = false
+  private static func suppressInputAccessoryBar() {
+    guard !didSuppressAccessoryBar, let contentClass = NSClassFromString("WKContentView")
+    else { return }
+    didSuppressAccessoryBar = true
+    let selector = NSSelectorFromString("inputAccessoryView")
+    let block: @convention(block) (AnyObject) -> UIView? = { _ in nil }
+    let implementation = imp_implementationWithBlock(block)
+    if let method = class_getInstanceMethod(contentClass, selector) {
+      class_replaceMethod(contentClass, selector, implementation, method_getTypeEncoding(method))
+    } else {
+      class_replaceMethod(contentClass, selector, implementation, "@@:")
+    }
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       ulidx:
         specifier: ^2.4.1
         version: 2.4.1
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -5494,6 +5497,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -11286,6 +11295,15 @@ snapshots:
   validate-npm-package-name@7.0.2: {}
 
   vary@1.1.2: {}
+
+  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   vfile-message@4.0.3:
     dependencies:


### PR DESCRIPTION
## What & why

iOS interactions felt "webby" — a gray flash on every tap, long-press callout menus, the keyboard form-assistant bar, and center-zoom dialogs instead of native sheets. A mobile web framework (Ionic/Konsta) would be the wrong tool here: the causes are specific and cheap to fix on the existing React + Tailwind + Radix stack.

This is three of a four-phase plan; the fourth (view transitions) is intentionally deferred.

## Changes

**Native — remove the keyboard accessory bar** (`plugins/tauri-plugin-keyboard/ios/Sources/KeyboardPlugin.swift`)
iOS injects a form-assistant bar (‹ › field stepper + Done) above the keyboard for any focused field/contenteditable. Reflect edits one continuous document, so it's noise. The plugin now overrides `inputAccessoryView → nil` at the **class level** on `WKContentView` — class-level (rather than per-instance) so it doesn't depend on the content view already existing when the plugin loads. Guarded by the class lookup (degrades to "bar stays" on a future WebKit rename) and idempotent.

**CSS — touch resets** (`apps/desktop/src/styles/index.css`)
- `-webkit-tap-highlight-color: transparent` (the big perceived-wonkiness fix)
- `-webkit-touch-callout: none`, **restored to `default`** on the editor/input selectable set so the iOS selection magnifier still works
- `touch-action: manipulation` on controls

All no-ops on desktop pointers, so no platform gate.

**Sheets — native bottom drawers** (`vaul` + new `apps/desktop/src/components/ui/drawer.tsx`)
- New `Drawer` (bottom sheet: slide-up, drag-to-dismiss, safe-area padded, tokens bridged to match `dialog.tsx`)
- Migrated the mobile **settings sheet** (previously a `Dialog` hacked into a sheet that *zoomed*) → real Drawer
- Migrated the **note-actions** list (previously a `DropdownMenu`) → action sheet; the delete confirmation stays a centered `Dialog` (correct iOS pattern for destructive confirms)

## Deferred

Per-route **View Transitions** (slide/fade on nav). It's iOS 18.2+ only (target is iOS 14) and the note screen remounts the editor on open, so it needs on-device tuning before building out. Wrap points are already mapped for the follow-up.

## Testing

- `pnpm typecheck` — clean
- `pnpm lint` (oxlint + eslint) — 0 errors (pre-existing warnings only, none in touched files)
- `pnpm test src/mobile` — 33/33 pass

**Not yet verified — needs a device/sim:**
- The Swift change can only be confirmed with a full `tauri ios` build (no HMR). Logic reviewed; not compiled in CI.
- The *feel* of the CSS + sheets (no tap flash, drawer slide/drag, safe area, body scroll-lock vs `overscroll-behavior: none`) needs eyeballing on the simulator.

## Reviewer notes

- `vaul ^1.1.2` (React 19 peer-compatible) added to `apps/desktop`.
- No standalone drawer unit test: vaul needs browser APIs jsdom lacks, so a jsdom test would be flaky and mostly test vaul. Consistent with this repo deferring editor/contenteditable tests to browser-mode vitest. The note-actions test mocks the drawer wrapper to a passthrough and verifies the real IPC paths instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The Swift class-level `inputAccessoryView` override is fragile against WebKit changes but is guarded; drawer and CSS changes are UI-only with limited blast radius.
> 
> **Overview**
> Makes mobile surfaces feel less like a web page by adding **vaul**-based bottom **Drawer** UI (aligned with existing dialog tokens), moving **settings** off a bottom-hacked `Dialog`, and turning **note actions** from a `DropdownMenu` into a full action sheet while **delete** still uses a centered confirm dialog.
> 
> **Global touch CSS** removes tap flash and default long-press callout on chrome, restores callout/selection on editor inputs, and sets `touch-action: manipulation` on controls.
> 
> On **iOS**, `KeyboardPlugin` now class-swizzles `WKContentView` so `inputAccessoryView` is nil, dropping the form-assistant bar above the keyboard for contenteditable editing.
> 
> **Tests** mock the drawer in `note-actions-menu` tests and click action buttons directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31d732798b43dd8041f1906e0c54973e0038d3a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->