### PR TITLE
Cleanup: shared @reflect/utils dates, explicit generated-date marker, week-start

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -26,6 +26,7 @@
     "@reflect/core": "workspace:*",
     "@reflect/db": "workspace:*",
     "@reflect/design-system": "workspace:*",
+    "@reflect/utils": "workspace:*",
     "@tanstack/react-query": "^5.101.0",
     "@tanstack/react-virtual": "^3.14.2",
     "@tauri-apps/api": "^2",

--- a/apps/desktop/src/components/command-palette/entries.test.ts
+++ b/apps/desktop/src/components/command-palette/entries.test.ts
@@ -41,7 +41,7 @@ describe('buildPaletteSections', () => {
       title: '2020-01-06',
       alias: null,
       date: '2020-01-06',
-      phrase: 'This Monday',
+      generated: { phrase: 'This Monday' },
     }
     const result = sections({
       query: 'mon',

--- a/apps/desktop/src/components/command-palette/entries.ts
+++ b/apps/desktop/src/components/command-palette/entries.ts
@@ -94,12 +94,12 @@ export function buildPaletteSections(options: {
   // the rest; one row per note, the stronger (title) form wins.
   const notes: NoteEntry[] = []
   const seen = new Set<string>()
-  // Real note matches lead; generated date suggestions (they carry a phrase)
-  // trail them. In the global palette your existing notes should outrank
-  // "Next Monday" — the opposite of the `[[` menu, where dates lead.
+  // Real note matches lead; generated date suggestions trail them. In the
+  // global palette your existing notes should outrank "Next Monday" — the
+  // opposite of the `[[` menu, where dates lead.
   const orderedSuggestions = [
-    ...suggestions.filter((suggestion) => suggestion.phrase === undefined),
-    ...suggestions.filter((suggestion) => suggestion.phrase !== undefined),
+    ...suggestions.filter((suggestion) => suggestion.generated === undefined),
+    ...suggestions.filter((suggestion) => suggestion.generated !== undefined),
   ]
   for (const suggestion of orderedSuggestions) {
     // A pathless suggestion is a valid daily whose file doesn't exist yet
@@ -115,7 +115,7 @@ export function buildPaletteSections(options: {
         title: suggestion.title,
         date: suggestion.date,
         snippet: null,
-        phrase: suggestion.phrase ?? null,
+        phrase: suggestion.generated?.phrase ?? null,
       })
     }
   }

--- a/apps/desktop/src/components/command-palette/use-palette-results.ts
+++ b/apps/desktop/src/components/command-palette/use-palette-results.ts
@@ -61,8 +61,21 @@ export function usePaletteResults(open: boolean, query: string): PaletteResults 
     isLoading: suggestionsLoading,
     isError: suggestionsError,
   } = useQuery({
-    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'palette-suggest', trimmed, settings.dateFormat, today],
-    queryFn: () => suggestWikiTargets(trimmed, 8, { today, dateFormat: settings.dateFormat }),
+    queryKey: [
+      INDEX_QUERY_SCOPE,
+      graph?.root,
+      'palette-suggest',
+      trimmed,
+      settings.dateFormat,
+      settings.weekStartDay,
+      today,
+    ],
+    queryFn: () =>
+      suggestWikiTargets(trimmed, 8, {
+        today,
+        dateFormat: settings.dateFormat,
+        weekStartDay: settings.weekStartDay,
+      }),
     enabled: searching && !parsed.filtered,
   })
   const useHybrid = hybrid && !parsed.filtered

--- a/apps/desktop/src/editor/use-editor-autocomplete.ts
+++ b/apps/desktop/src/editor/use-editor-autocomplete.ts
@@ -56,6 +56,7 @@ export function useEditorAutocomplete(): EditorAutocomplete {
       const suggestions = await suggestWikiTargets(query, 8, {
         today: todayIso(),
         dateFormat: settings.dateFormat,
+        weekStartDay: settings.weekStartDay,
       })
       return buildAutocompleteEntries(query, suggestions, { offerCreate: true }).map((entry) => {
         if (entry.kind === 'create') {
@@ -71,11 +72,11 @@ export function useEditorAutocomplete(): EditorAutocomplete {
             },
           }
         }
-        const { target, title, alias, date, path, phrase } = entry.suggestion
+        const { target, title, alias, date, path, generated } = entry.suggestion
         // A generated date leads with its phrase ("Next Friday"), resolved day
         // as the detail; everything else keeps the title/alias/daily form.
-        if (phrase !== undefined && date !== null) {
-          return { target, label: phrase, detail: formatDayLabel(date, settings.dateFormat) }
+        if (generated !== undefined && date !== null) {
+          return { target, label: generated.phrase, detail: formatDayLabel(date, settings.dateFormat) }
         }
         const label = date !== null ? formatDayLabel(date, settings.dateFormat) : title
         const detail =
@@ -89,7 +90,7 @@ export function useEditorAutocomplete(): EditorAutocomplete {
         return { target, label, ...(detail !== undefined ? { detail } : {}) }
       })
     },
-    [graph, settings.dateFormat, createFromAutocomplete],
+    [graph, settings.dateFormat, settings.weekStartDay, createFromAutocomplete],
   )
 
   const onTagSearch = useCallback(

--- a/apps/desktop/src/editor/wiki-autocomplete-entries.test.ts
+++ b/apps/desktop/src/editor/wiki-autocomplete-entries.test.ts
@@ -53,7 +53,7 @@ describe('buildAutocompleteEntries', () => {
         title: '2019-12-29',
         path: null,
         date: '2019-12-29',
-        phrase: '3 days ago',
+        generated: { phrase: '3 days ago' },
       }),
     ])
     expect(entries.every((entry) => entry.kind === 'suggestion')).toBe(true)

--- a/apps/desktop/src/editor/wiki-autocomplete-entries.ts
+++ b/apps/desktop/src/editor/wiki-autocomplete-entries.ts
@@ -42,10 +42,10 @@ export function buildAutocompleteEntries(
       foldKey(suggestion.target) === key ||
       (suggestion.alias !== null && foldKey(suggestion.alias) === key),
   )
-  // A generated date suggestion (it carries a `phrase`) means the query reads as
-  // a date — "3 days ago", "next friday" — so offering to create a note with
-  // that literal title would be noise.
-  const hasDateSuggestion = suggestions.some((suggestion) => suggestion.phrase !== undefined)
+  // A generated date suggestion means the query reads as a date — "3 days ago",
+  // "next friday" — so offering to create a note with that literal title would
+  // be noise.
+  const hasDateSuggestion = suggestions.some((suggestion) => suggestion.generated !== undefined)
   if (!resolvesAsTyped && !hasDateSuggestion) {
     entries.push({ kind: 'create', title })
   }

--- a/apps/desktop/src/lib/dates.ts
+++ b/apps/desktop/src/lib/dates.ts
@@ -1,12 +1,16 @@
-import { addDays, format, isSameDay, isSameWeek, isValid, parse } from 'date-fns'
+import { format, isSameDay, isSameWeek, parse } from 'date-fns'
 import type { DateFormat, TimeFormat } from '@reflect/core'
 
 /**
- * The one date module (Plan 06). Daily notes are keyed by **local** calendar
- * dates as ISO `YYYY-MM-DD` strings — "today" follows the user's clock, and all
- * arithmetic round-trips through date-fns so DST transitions can't skip or
- * repeat a day. Nothing else in the app may compute dates by hand.
+ * The app's date layer (Plan 06). Daily notes are keyed by **local** calendar
+ * dates as ISO `YYYY-MM-DD` strings — "today" follows the user's clock. Pure
+ * calendar arithmetic (`addDaysIso`, `isIsoDate`) lives in `@reflect/utils` and
+ * is re-exported here; this module owns the date-fns-backed *display* formatting
+ * and the local clock. Nothing else in the app may compute dates by hand.
  */
+
+// Pure calendar math is shared with the indexing layer — one implementation.
+export { addDaysIso, isIsoDate } from '@reflect/utils'
 
 const ISO_DATE_FORMAT = 'yyyy-MM-dd'
 
@@ -18,19 +22,6 @@ export function parseIsoDate(date: string): Date {
 /** Today's local calendar date as `YYYY-MM-DD`. */
 export function todayIso(): string {
   return format(new Date(), ISO_DATE_FORMAT)
-}
-
-/** Is `value` a real calendar date in ISO `YYYY-MM-DD` form? */
-export function isIsoDate(value: string): boolean {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-    return false
-  }
-  return isValid(parseIsoDate(value))
-}
-
-/** The ISO date `days` after `date` (negative for before). DST-safe. */
-export function addDaysIso(date: string, days: number): string {
-  return format(addDays(parseIsoDate(date), days), ISO_DATE_FORMAT)
 }
 
 /**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     "@lezer/common": "^1.5.2",
     "@lezer/markdown": "^1.6.4",
     "@reflect/db": "workspace:*",
+    "@reflect/utils": "workspace:*",
     "ai": "^6.0.202",
     "fflate": "^0.8.3",
     "kysely": "^0.28.17",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -485,6 +485,7 @@ export {
   type TagSuggestion,
   type FileChange,
   type WikiSuggestion,
+  type GeneratedDate,
   type DateSuggestionContext,
   type HighlightSegment,
   type ParsedSearchQuery,

--- a/packages/core/src/indexing/date-suggestions.test.ts
+++ b/packages/core/src/indexing/date-suggestions.test.ts
@@ -1,16 +1,20 @@
 import { describe, expect, it } from 'vitest'
 import { generateDateSuggestions, type DateSuggestion } from './date-suggestions'
-import type { DateFormat } from '../settings/schema'
+import type { DateFormat, WeekStartDay } from '../settings/schema'
 
 /**
  * The V1 backlink-menu doc's worked examples are the spec here: today is
- * Wednesday, 1 January 2020, date format day/month (`dmy`) unless a case says
- * otherwise. See `docs/reflect-v1-backlink-menu.md`.
+ * Wednesday, 1 January 2020, date format day/month (`dmy`) and a Monday week
+ * start unless a case says otherwise. See `docs/reflect-v1-backlink-menu.md`.
  */
 const TODAY = '2020-01-01'
 
-function gen(query: string, dateFormat: DateFormat = 'dmy'): DateSuggestion[] {
-  return generateDateSuggestions(query, { today: TODAY, dateFormat })
+function gen(
+  query: string,
+  dateFormat: DateFormat = 'dmy',
+  weekStartDay: WeekStartDay = 'monday',
+): DateSuggestion[] {
+  return generateDateSuggestions(query, { today: TODAY, dateFormat, weekStartDay })
 }
 
 describe('generateDateSuggestions', () => {
@@ -76,6 +80,24 @@ describe('generateDateSuggestions', () => {
         { date: '2020-01-13', phrase: 'Next Monday' },
         { date: '2019-12-30', phrase: 'Last Monday' },
       ])
+    })
+  })
+
+  describe('week-start preference', () => {
+    // "this week" also prefix-matches "weekend", so the Week row leads and the
+    // Weekend row follows — we assert the leading Week row's anchor date.
+    it('anchors this/next week to a Monday start', () => {
+      expect(gen('this week', 'dmy', 'monday')[0]).toEqual({ date: '2019-12-30', phrase: 'This Week' })
+      expect(gen('next week', 'dmy', 'monday')[0]).toEqual({ date: '2020-01-06', phrase: 'Next Week' })
+    })
+
+    it('anchors this/next week to a Sunday start when configured', () => {
+      expect(gen('this week', 'dmy', 'sunday')[0]).toEqual({ date: '2019-12-29', phrase: 'This Week' })
+      expect(gen('next week', 'dmy', 'sunday')[0]).toEqual({ date: '2020-01-05', phrase: 'Next Week' })
+    })
+
+    it('leaves weekday phrases unaffected by the week start', () => {
+      expect(gen('this monday', 'dmy', 'sunday')).toEqual([{ date: '2020-01-06', phrase: 'This Monday' }])
     })
   })
 

--- a/packages/core/src/indexing/date-suggestions.ts
+++ b/packages/core/src/indexing/date-suggestions.ts
@@ -7,16 +7,16 @@
  * — then merges them, de-duplicating by resolved day. See
  * `docs/reflect-v1-backlink-menu.md` for the behaviour this ports.
  *
- * Pure and dependency-free: the clock is injected as `today` (an ISO
- * `YYYY-MM-DD` *local* date, computed at the UI edge) and every offset is
- * computed in UTC on the ISO string, so DST can never skip or repeat a day.
+ * Pure: the clock is injected as `today` (an ISO `YYYY-MM-DD` *local* date,
+ * computed at the UI edge) and the calendar arithmetic comes from
+ * `@reflect/utils`, which works in UTC so DST can never skip or repeat a day.
  * Each result is an ISO `YYYY-MM-DD` — the canonical daily-note form — paired
  * with the human `phrase` to show in the menu (`null` for a bare ISO query,
  * which needs no friendlier label than the date itself).
  */
 
-import { isCalendarDate } from '../markdown/resolve'
-import type { DateFormat } from '../settings/schema'
+import { addDaysIso, addMonthsIso, isCalendarDate, isoFromParts, weekdayIso } from '@reflect/utils'
+import type { DateFormat, WeekStartDay } from '../settings/schema'
 
 /** One synthesised daily-note target: the resolved day plus its menu label. */
 export interface DateSuggestion {
@@ -26,12 +26,14 @@ export interface DateSuggestion {
   phrase: string | null
 }
 
-/** What the generator needs from its caller: the local clock and the slash-date order. */
+/** What the generator needs from its caller: the local clock and display preferences. */
 export interface DateSuggestionContext {
   /** Today's local calendar date, ISO `YYYY-MM-DD`. */
   today: string
   /** Reading order for ambiguous typed slash-dates (`mdy` → M/D, `dmy` → D/M). */
   dateFormat: DateFormat
+  /** Which day "this/next/last week" (and weekend) anchor to. */
+  weekStartDay: WeekStartDay
 }
 
 /** At most this many date suggestions survive into the menu. */
@@ -43,46 +45,12 @@ const MIN_PHRASE_CHARS = 3
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 
-// --- UTC date arithmetic (no date-fns in core; UTC sidesteps DST entirely) ---
-
-function parseUtc(iso: string): Date {
-  const [year, month, day] = iso.split('-').map(Number) as [number, number, number]
-  return new Date(Date.UTC(year, month - 1, day))
-}
-
-function toIso(date: Date): string {
-  return fromParts(date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate())
-}
-
-function fromParts(year: number, month: number, day: number): string {
-  const pad = (value: number, width: number): string => String(value).padStart(width, '0')
-  return `${pad(year, 4)}-${pad(month, 2)}-${pad(day, 2)}`
-}
-
-function addDays(iso: string, days: number): string {
-  const date = parseUtc(iso)
-  date.setUTCDate(date.getUTCDate() + days)
-  return toIso(date)
-}
-
-/** Add months with end-of-month clamping (date-fns semantics): Jan 31 + 1mo → Feb 28. */
-function addMonths(iso: string, months: number): string {
-  const [year, month, day] = iso.split('-').map(Number) as [number, number, number]
-  const zeroBased = month - 1 + months
-  const targetYear = year + Math.floor(zeroBased / 12)
-  const targetMonth = ((zeroBased % 12) + 12) % 12
-  const lastDay = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate()
-  return fromParts(targetYear, targetMonth + 1, Math.min(day, lastDay))
-}
-
-/** Day of week for an ISO date: 0 = Sunday … 6 = Saturday. */
-function weekday(iso: string): number {
-  return parseUtc(iso).getUTCDay()
-}
-
 /** Is `iso` within {@link MAX_RELATIVE_YEARS} of `today`? ISO strings sort chronologically. */
 function withinRelativeLimit(iso: string, today: string): boolean {
-  return iso >= addMonths(today, -12 * MAX_RELATIVE_YEARS) && iso <= addMonths(today, 12 * MAX_RELATIVE_YEARS)
+  return (
+    iso >= addMonthsIso(today, -12 * MAX_RELATIVE_YEARS) &&
+    iso <= addMonthsIso(today, 12 * MAX_RELATIVE_YEARS)
+  )
 }
 
 function titleCase(word: string): string {
@@ -146,7 +114,8 @@ function extractUnit(tokens: readonly string[]): Unit | null {
 function extractDirection(tokens: readonly string[]): Direction | null {
   const hasPast = tokens.includes('ago')
   const hasFuture = tokens.some(
-    (token) => token === 'from' || token === 'now' || token === 'later' || token === 'in' || token === 'hence',
+    (token) =>
+      token === 'from' || token === 'now' || token === 'later' || token === 'in' || token === 'hence',
   )
   if (hasPast && !hasFuture) {
     return 'past'
@@ -160,13 +129,13 @@ function extractDirection(tokens: readonly string[]): Direction | null {
 function shiftByUnit(today: string, unit: Unit, amount: number): string {
   switch (unit) {
     case 'day':
-      return addDays(today, amount)
+      return addDaysIso(today, amount)
     case 'week':
-      return addDays(today, amount * 7)
+      return addDaysIso(today, amount * 7)
     case 'month':
-      return addMonths(today, amount)
+      return addMonthsIso(today, amount)
     case 'year':
-      return addMonths(today, amount * 12)
+      return addMonthsIso(today, amount * 12)
   }
 }
 
@@ -225,12 +194,19 @@ const WEEKDAYS: readonly { word: string; dow: number }[] = [
 
 /** The smallest date on or after `today` whose weekday is `target` (today counts). */
 function upcomingWeekday(today: string, target: number): string {
-  return addDays(today, (target - weekday(today) + 7) % 7)
+  return addDaysIso(today, (target - weekdayIso(today) + 7) % 7)
 }
 
-/** Monday of `today`'s week — a fixed Monday start, independent of any week-start preference. */
-function mondayOfWeek(today: string): string {
-  return addDays(today, -((weekday(today) + 6) % 7))
+/** The first day of `today`'s week, honouring the user's week-start preference. */
+function firstOfWeek(today: string, weekStartDay: WeekStartDay): string {
+  const startDow = weekStartDay === 'sunday' ? 0 : 1
+  return addDaysIso(today, -((weekdayIso(today) - startDow + 7) % 7))
+}
+
+/** The Saturday of `today`'s week (the same week the week-start preference defines). */
+function weekendOf(today: string, weekStartDay: WeekStartDay): string {
+  const startDow = weekStartDay === 'sunday' ? 0 : 1
+  return addDaysIso(firstOfWeek(today, weekStartDay), (6 - startDow + 7) % 7)
 }
 
 function resolveWeekday(today: string, target: number, modifier: Modifier): string {
@@ -238,14 +214,14 @@ function resolveWeekday(today: string, target: number, modifier: Modifier): stri
   if (modifier === 'this') {
     return upcoming
   }
-  return addDays(upcoming, modifier === 'next' ? 7 : -7)
+  return addDaysIso(upcoming, modifier === 'next' ? 7 : -7)
 }
 
 function resolveFromAnchor(anchor: string, modifier: Modifier, stepDays: number): string {
   if (modifier === 'this') {
     return anchor
   }
-  return addDays(anchor, modifier === 'next' ? stepDays : -stepDays)
+  return addDaysIso(anchor, modifier === 'next' ? stepDays : -stepDays)
 }
 
 interface NlUnit {
@@ -255,42 +231,44 @@ interface NlUnit {
   display: string
   /** Sort weight within a modifier: weekdays (0–6) before week/weekend/month. */
   order: number
-  resolve: (today: string, modifier: Modifier) => string
+  resolve: (context: DateSuggestionContext, modifier: Modifier) => string
 }
 
-function nlUnits(): NlUnit[] {
-  const weekdays: NlUnit[] = WEEKDAYS.map(({ word, dow }, index) => ({
-    word,
-    display: titleCase(word),
-    order: index,
-    resolve: (today, modifier) => resolveWeekday(today, dow, modifier),
-  }))
-  return [
-    ...weekdays,
-    {
-      word: 'week',
-      display: 'Week',
-      order: 7,
-      resolve: (today, modifier) => resolveFromAnchor(mondayOfWeek(today), modifier, 7),
+// Built once at module load — the resolvers take all runtime state as arguments.
+const NL_UNITS: readonly NlUnit[] = [
+  ...WEEKDAYS.map(
+    ({ word, dow }, index): NlUnit => ({
+      word,
+      display: titleCase(word),
+      order: index,
+      resolve: (context, modifier) => resolveWeekday(context.today, dow, modifier),
+    }),
+  ),
+  {
+    word: 'week',
+    display: 'Week',
+    order: 7,
+    resolve: (context, modifier) =>
+      resolveFromAnchor(firstOfWeek(context.today, context.weekStartDay), modifier, 7),
+  },
+  {
+    word: 'weekend',
+    display: 'Weekend',
+    order: 8,
+    resolve: (context, modifier) =>
+      resolveFromAnchor(weekendOf(context.today, context.weekStartDay), modifier, 7),
+  },
+  {
+    word: 'month',
+    display: 'Month',
+    order: 9,
+    resolve: (context, modifier) => {
+      const [year, month] = context.today.split('-').map(Number) as [number, number]
+      const first = isoFromParts(year, month, 1)
+      return modifier === 'this' ? first : addMonthsIso(first, modifier === 'next' ? 1 : -1)
     },
-    {
-      word: 'weekend',
-      display: 'Weekend',
-      order: 8,
-      resolve: (today, modifier) => resolveFromAnchor(addDays(mondayOfWeek(today), 5), modifier, 7),
-    },
-    {
-      word: 'month',
-      display: 'Month',
-      order: 9,
-      resolve: (today, modifier) => {
-        const [year, month] = today.split('-').map(Number) as [number, number]
-        const first = fromParts(year, month, 1)
-        return modifier === 'this' ? first : addMonths(first, modifier === 'next' ? 1 : -1)
-      },
-    },
-  ]
-}
+  },
+]
 
 interface NlCandidate {
   phrase: string
@@ -326,15 +304,14 @@ function naturalLanguageSuggestions(
   }
   const candidates: NlCandidate[] = [
     { phrase: 'Today', date: context.today, modifier: null, unitWord: 'today', sort: 0 },
-    { phrase: 'Yesterday', date: addDays(context.today, -1), modifier: null, unitWord: 'yesterday', sort: 1 },
-    { phrase: 'Tomorrow', date: addDays(context.today, 1), modifier: null, unitWord: 'tomorrow', sort: 2 },
+    { phrase: 'Yesterday', date: addDaysIso(context.today, -1), modifier: null, unitWord: 'yesterday', sort: 1 },
+    { phrase: 'Tomorrow', date: addDaysIso(context.today, 1), modifier: null, unitWord: 'tomorrow', sort: 2 },
   ]
-  const units = nlUnits()
   MODIFIERS.forEach((modifier, modifierIndex) => {
-    for (const unit of units) {
+    for (const unit of NL_UNITS) {
       candidates.push({
         phrase: `${titleCase(modifier)} ${unit.display}`,
-        date: unit.resolve(context.today, modifier),
+        date: unit.resolve(context, modifier),
         modifier,
         unitWord: unit.word,
         // Sort by unit first (so `mon` yields the three Mondays before Months),
@@ -353,7 +330,7 @@ function naturalLanguageSuggestions(
 
 function typedDateSuggestions(
   lower: string,
-  echo: string,
+  rawQuery: string,
   context: DateSuggestionContext,
 ): DateSuggestion[] {
   if (ISO_DATE_RE.test(lower)) {
@@ -400,12 +377,12 @@ function typedDateSuggestions(
     if (reading.month < 1 || reading.month > 12) {
       return
     }
-    const iso = fromParts(year, reading.month, reading.day)
+    const iso = isoFromParts(year, reading.month, reading.day)
     if (!isCalendarDate(iso) || seen.has(iso)) {
       return
     }
     seen.add(iso)
-    results.push({ date: iso, phrase: echo })
+    results.push({ date: iso, phrase: rawQuery })
   })
   return results
 }
@@ -466,7 +443,7 @@ function matchDay(token: string): number | null {
 function monthNameSuggestions(
   query: string,
   tokens: readonly string[],
-  echo: string,
+  rawQuery: string,
   context: DateSuggestionContext,
 ): DateSuggestion[] {
   if (query.length < MIN_PHRASE_CHARS) {
@@ -476,23 +453,25 @@ function monthNameSuggestions(
   let day: number | null = null
   let year: number | null = null
   for (const token of tokens) {
-    if (month === null && matchMonth(token) !== null) {
-      month = matchMonth(token)
+    const matchedMonth = matchMonth(token)
+    if (month === null && matchedMonth !== null) {
+      month = matchedMonth
       continue
     }
     if (year === null && /^\d{4}$/.test(token)) {
       year = Number(token)
       continue
     }
-    if (day === null && matchDay(token) !== null) {
-      day = matchDay(token)
+    const matchedDay = matchDay(token)
+    if (day === null && matchedDay !== null) {
+      day = matchedDay
     }
   }
   if (month === null || day === null) {
     return []
   }
-  const iso = fromParts(year ?? Number(context.today.slice(0, 4)), month, day)
-  return isCalendarDate(iso) ? [{ date: iso, phrase: echo }] : []
+  const iso = isoFromParts(year ?? Number(context.today.slice(0, 4)), month, day)
+  return isCalendarDate(iso) ? [{ date: iso, phrase: rawQuery }] : []
 }
 
 /**

--- a/packages/core/src/indexing/filter-query.ts
+++ b/packages/core/src/indexing/filter-query.ts
@@ -17,6 +17,7 @@
  * A malformed token (impossible date, empty value) stays search text — typing
  * never makes results vanish behind a filter the user didn't form yet.
  */
+import { isCalendarDate } from '@reflect/utils'
 import { foldTag } from '../markdown'
 
 export interface SearchFilters {
@@ -61,19 +62,6 @@ const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
  * would guarantee zero rows for a tag that cannot exist.
  */
 const TAG_TOKEN_RE = /^#\p{L}[\p{L}\p{N}/_-]*$/u
-
-function isCalendarDate(value: string): boolean {
-  // Callers gate on ISO_DATE_RE first, so the split always yields three parts.
-  const parts = value.split('-').map(Number)
-  const year = parts[0]!
-  const month = parts[1]!
-  const day = parts[2]!
-  if (month < 1 || month > 12) {
-    return false
-  }
-  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate()
-  return day >= 1 && day <= daysInMonth
-}
 
 /** Epoch ms of the **local** start of `YYYY-MM-DD` (+`days`). */
 function localDayStartMs(date: string, days = 0): number {

--- a/packages/core/src/indexing/index.ts
+++ b/packages/core/src/indexing/index.ts
@@ -90,7 +90,12 @@ export {
   type RecentNoteRow,
   type RecentNotesOptions,
 } from './note-list'
-export { rankWikiSuggestions, mergeDateSuggestions, type WikiSuggestion } from './suggest'
+export {
+  rankWikiSuggestions,
+  mergeDateSuggestions,
+  type WikiSuggestion,
+  type GeneratedDate,
+} from './suggest'
 export {
   generateDateSuggestions,
   type DateSuggestion,

--- a/packages/core/src/indexing/queries.test.ts
+++ b/packages/core/src/indexing/queries.test.ts
@@ -178,7 +178,7 @@ describe('suggestWikiTargets', () => {
   // Wednesday, 1 January 2020, day/month — the date generator's worked-example
   // clock. This exercises the live glue (generator + merge) the editor hits;
   // the parts themselves are unit-tested in date-suggestions/suggest.
-  const clock = { today: '2020-01-01', dateFormat: 'dmy' as const }
+  const clock = { today: '2020-01-01', dateFormat: 'dmy' as const, weekStartDay: 'monday' as const }
 
   it('synthesises a daily target from a fuzzy query when given a clock', async () => {
     mockInvoke.mockResolvedValue([]) // no title or alias matches
@@ -190,7 +190,7 @@ describe('suggestWikiTargets', () => {
         title: '2019-12-29',
         alias: null,
         date: '2019-12-29',
-        phrase: '3 days ago',
+        generated: { phrase: '3 days ago' },
       },
     ])
   })
@@ -205,7 +205,7 @@ describe('suggestWikiTargets', () => {
 
     expect(result.map((row) => row.target)).toEqual(['Today', '2020-01-01'])
     expect(result[0]!.path).toBe('notes/today.md')
-    expect(result[1]).toMatchObject({ date: '2020-01-01', phrase: 'Today', path: null })
+    expect(result[1]).toMatchObject({ date: '2020-01-01', generated: { phrase: 'Today' }, path: null })
   })
 
   it('does not synthesise dates without a clock (legacy callers unchanged)', async () => {

--- a/packages/core/src/indexing/suggest.test.ts
+++ b/packages/core/src/indexing/suggest.test.ts
@@ -104,7 +104,11 @@ describe('mergeDateSuggestions', () => {
       { key: 'mon', limit: 8 },
     )
     expect(result.map((row) => row.target)).toEqual(['2020-01-06', 'Monday Standup'])
-    expect(result[0]).toMatchObject({ date: '2020-01-06', phrase: 'This Monday', path: null })
+    expect(result[0]).toMatchObject({
+      date: '2020-01-06',
+      generated: { phrase: 'This Monday' },
+      path: null,
+    })
   })
 
   it('keeps an exact title match in the very top slot, dates next', () => {
@@ -116,7 +120,7 @@ describe('mergeDateSuggestions', () => {
     expect(result.map((row) => row.target)).toEqual(['Today', '2020-01-01', 'Today Notes'])
   })
 
-  it('reuses an existing daily row (real path) and attaches the phrase once', () => {
+  it('reuses an existing daily row (real path) and marks it generated once', () => {
     const existingDaily = ranked('2020-01-06', {
       target: '2020-01-06',
       path: 'daily/2020-01-06.md',
@@ -128,16 +132,19 @@ describe('mergeDateSuggestions', () => {
       { key: 'mon', limit: 8 },
     )
     expect(result).toHaveLength(2)
-    expect(result[0]).toMatchObject({ path: 'daily/2020-01-06.md', phrase: 'This Monday' })
+    expect(result[0]).toMatchObject({
+      path: 'daily/2020-01-06.md',
+      generated: { phrase: 'This Monday' },
+    })
     expect(result.map((row) => row.target)).toEqual(['2020-01-06', 'Other'])
   })
 
-  it('a bare-ISO date carries no phrase', () => {
+  it('a bare-ISO date is not marked generated', () => {
     const result = mergeDateSuggestions([], [{ date: '2026-06-19', phrase: null }], {
       key: '2026-06-19',
       limit: 8,
     })
-    expect(result[0]!.phrase).toBeUndefined()
+    expect(result[0]!.generated).toBeUndefined()
   })
 
   it('honours the limit across dates plus matches', () => {

--- a/packages/core/src/indexing/suggest.ts
+++ b/packages/core/src/indexing/suggest.ts
@@ -9,6 +9,18 @@
 import { foldKey } from '../markdown/keys'
 import type { DateSuggestion } from './date-suggestions'
 
+/**
+ * Marks a suggestion the date generator synthesised from a fuzzy query and
+ * carries its menu label. The presence of this object — not a bare optional
+ * field — is the explicit discriminator hosts branch on (suppress the "Create"
+ * row, trail real notes in the palette); the `phrase` can never drift onto a
+ * non-generated row.
+ */
+export interface GeneratedDate {
+  /** Human label for the menu ("3 days ago", "Next Friday"). */
+  phrase: string
+}
+
 /** A `[[` autocomplete candidate. */
 export interface WikiSuggestion {
   /** What `[[…]]` should contain when chosen (the canonical title, or an ISO date). */
@@ -21,12 +33,8 @@ export interface WikiSuggestion {
   alias: string | null
   /** Set on daily-note suggestions. */
   date: string | null
-  /**
-   * Human label for a generated date suggestion ("3 days ago", "Next Friday").
-   * Present only on rows synthesised by the date generator — its absence is how
-   * hosts tell a generated daily apart from a real note or an existing daily.
-   */
-  phrase?: string
+  /** Set only on rows the date generator synthesised; see {@link GeneratedDate}. */
+  generated?: GeneratedDate
 }
 
 /** One `notes` row considered for suggestion (a title match or recency fill). */
@@ -151,10 +159,13 @@ export function mergeDateSuggestions(
 
   const reused = new Set<WikiSuggestion>()
   const dateRows: WikiSuggestion[] = dates.map(({ date, phrase }) => {
+    // A bare ISO query has no friendlier phrase, so it stays a plain daily (no
+    // `generated` marker) and behaves like an existing daily, not a synthesised one.
+    const generated = phrase === null ? undefined : { phrase }
     const existing = rankedByDate.get(date)
     if (existing !== undefined) {
       reused.add(existing)
-      return phrase === null ? existing : { ...existing, phrase }
+      return generated === undefined ? existing : { ...existing, generated }
     }
     return {
       target: date,
@@ -162,7 +173,7 @@ export function mergeDateSuggestions(
       title: date,
       alias: null,
       date,
-      ...(phrase === null ? {} : { phrase }),
+      ...(generated === undefined ? {} : { generated }),
     }
   })
 

--- a/packages/core/src/markdown/resolve.ts
+++ b/packages/core/src/markdown/resolve.ts
@@ -9,23 +9,10 @@
  * id when present" is honoured at the lookup layer.
  */
 
+import { isCalendarDate } from '@reflect/utils'
 import { foldKey } from './keys'
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
-
-/**
- * Is `value` a real calendar day (not just `YYYY-MM-DD`-shaped)? Callers gate on
- * {@link ISO_DATE_RE} first, so the split always yields three numeric parts.
- */
-export function isCalendarDate(value: string): boolean {
-  const [year, month, day] = value.split('-').map(Number) as [number, number, number]
-  if (month < 1 || month > 12) {
-    return false
-  }
-  // Day 0 of the next month = the last day of `month` (leap-years included).
-  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate()
-  return day >= 1 && day <= daysInMonth
-}
 
 /** A wiki-link target normalized for matching. */
 export interface NormalizedTarget {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@reflect/utils",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "types": "./src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests"
+  },
+  "devDependencies": {
+    "typescript": "~5.8.3",
+    "vitest": "^4"
+  }
+}

--- a/packages/utils/src/dates.test.ts
+++ b/packages/utils/src/dates.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import {
+  addDaysIso,
+  addMonthsIso,
+  isCalendarDate,
+  isIsoDate,
+  isoFromParts,
+  weekdayIso,
+} from './dates'
+
+describe('addDaysIso', () => {
+  it('adds and subtracts calendar days across month and year boundaries', () => {
+    expect(addDaysIso('2020-01-01', -1)).toBe('2019-12-31')
+    expect(addDaysIso('2020-02-28', 1)).toBe('2020-02-29') // leap year
+    expect(addDaysIso('2021-02-28', 1)).toBe('2021-03-01')
+    expect(addDaysIso('2020-01-01', 0)).toBe('2020-01-01')
+  })
+
+  it('is DST-safe (a spring-forward day still advances by one calendar day)', () => {
+    // 2020-03-08 is the US spring-forward day; UTC math never skips it.
+    expect(addDaysIso('2020-03-08', 1)).toBe('2020-03-09')
+  })
+})
+
+describe('addMonthsIso', () => {
+  it('clamps to the end of the target month (date-fns semantics)', () => {
+    expect(addMonthsIso('2024-01-31', 1)).toBe('2024-02-29') // leap year
+    expect(addMonthsIso('2023-01-31', 1)).toBe('2023-02-28')
+    expect(addMonthsIso('2024-03-31', -1)).toBe('2024-02-29')
+  })
+
+  it('rolls over years in both directions', () => {
+    expect(addMonthsIso('2020-06-15', 12)).toBe('2021-06-15')
+    expect(addMonthsIso('2020-01-15', -1)).toBe('2019-12-15')
+  })
+})
+
+describe('weekdayIso', () => {
+  it('returns 0 for Sunday through 6 for Saturday', () => {
+    expect(weekdayIso('2020-01-01')).toBe(3) // Wednesday
+    expect(weekdayIso('2020-01-05')).toBe(0) // Sunday
+    expect(weekdayIso('2020-01-04')).toBe(6) // Saturday
+  })
+})
+
+describe('isoFromParts', () => {
+  it('zero-pads year, month, and day', () => {
+    expect(isoFromParts(2020, 1, 2)).toBe('2020-01-02')
+    expect(isoFromParts(23, 6, 5)).toBe('0023-06-05')
+  })
+})
+
+describe('isCalendarDate / isIsoDate', () => {
+  it('accepts real days and rejects impossible ones', () => {
+    expect(isCalendarDate('2024-02-29')).toBe(true)
+    expect(isCalendarDate('2023-02-29')).toBe(false)
+    expect(isCalendarDate('2026-02-31')).toBe(false)
+    expect(isCalendarDate('2026-13-01')).toBe(false)
+  })
+
+  it('isIsoDate also enforces the YYYY-MM-DD shape', () => {
+    expect(isIsoDate('2020-01-01')).toBe(true)
+    expect(isIsoDate('2020-1-1')).toBe(false)
+    expect(isIsoDate('not-a-date')).toBe(false)
+    expect(isIsoDate('2026-02-31')).toBe(false)
+  })
+})

--- a/packages/utils/src/dates.ts
+++ b/packages/utils/src/dates.ts
@@ -1,0 +1,74 @@
+/**
+ * Calendar arithmetic on ISO `YYYY-MM-DD` date strings, computed in UTC.
+ *
+ * UTC sidesteps daylight saving entirely: adding days or months can never skip
+ * or repeat a day, so callers get correct calendar shifts without a
+ * timezone-aware date library. "Today" is intentionally absent — it depends on
+ * the local clock and belongs at the application edge (e.g. the desktop app's
+ * `todayIso`).
+ */
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+/** Parse an ISO `YYYY-MM-DD` string as a UTC-midnight {@link Date}. */
+export function parseIsoUtc(iso: string): Date {
+  const [year, month, day] = iso.split('-').map(Number) as [number, number, number]
+  return new Date(Date.UTC(year, month - 1, day))
+}
+
+/** Format a {@link Date} as an ISO `YYYY-MM-DD` string from its UTC fields. */
+export function formatIsoUtc(date: Date): string {
+  return isoFromParts(date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate())
+}
+
+/** Build an ISO `YYYY-MM-DD` string from numeric parts (1-based `month`). */
+export function isoFromParts(year: number, month: number, day: number): string {
+  const pad = (value: number, width: number): string => String(value).padStart(width, '0')
+  return `${pad(year, 4)}-${pad(month, 2)}-${pad(day, 2)}`
+}
+
+/** The ISO date `days` after `iso` (negative for before). DST-safe. */
+export function addDaysIso(iso: string, days: number): string {
+  const date = parseIsoUtc(iso)
+  date.setUTCDate(date.getUTCDate() + days)
+  return formatIsoUtc(date)
+}
+
+/**
+ * The ISO date `months` after `iso` (negative for before), clamping to the end
+ * of the target month — so `2024-01-31` plus one month is `2024-02-29`, matching
+ * date-fns `addMonths`.
+ */
+export function addMonthsIso(iso: string, months: number): string {
+  const [year, month, day] = iso.split('-').map(Number) as [number, number, number]
+  const zeroBased = month - 1 + months
+  const targetYear = year + Math.floor(zeroBased / 12)
+  const targetMonth = ((zeroBased % 12) + 12) % 12
+  const lastDay = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate()
+  return isoFromParts(targetYear, targetMonth + 1, Math.min(day, lastDay))
+}
+
+/** Day of week for an ISO date: 0 = Sunday … 6 = Saturday. */
+export function weekdayIso(iso: string): number {
+  return parseIsoUtc(iso).getUTCDay()
+}
+
+/**
+ * Is `value` a real calendar day, not merely `YYYY-MM-DD`-shaped? Rejects
+ * impossible dates such as `2026-02-31`. Assumes the input is already
+ * ISO-shaped; use {@link isIsoDate} for untrusted strings.
+ */
+export function isCalendarDate(value: string): boolean {
+  const [year, month, day] = value.split('-').map(Number) as [number, number, number]
+  if (month < 1 || month > 12) {
+    return false
+  }
+  // Day 0 of the next month = the last day of `month` (leap years included).
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate()
+  return day >= 1 && day <= daysInMonth
+}
+
+/** Is `value` a syntactically ISO `YYYY-MM-DD` string naming a real calendar day? */
+export function isIsoDate(value: string): boolean {
+  return ISO_DATE_RE.test(value) && isCalendarDate(value)
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * `@reflect/utils` — small, dependency-free helpers shared across the workspace.
+ */
+export {
+  addDaysIso,
+  addMonthsIso,
+  formatIsoUtc,
+  isCalendarDate,
+  isIsoDate,
+  isoFromParts,
+  parseIsoUtc,
+  weekdayIso,
+} from './dates'

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@reflect/design-system':
         specifier: workspace:*
         version: link:../../design-system
+      '@reflect/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
       '@tanstack/react-query':
         specifier: ^5.101.0
         version: 5.101.0(react@19.2.7)
@@ -243,6 +246,9 @@ importers:
       '@reflect/db':
         specifier: workspace:*
         version: link:../db
+      '@reflect/utils':
+        specifier: workspace:*
+        version: link:../utils
       ai:
         specifier: ^6.0.202
         version: 6.0.202(zod@4.4.3)
@@ -293,6 +299,15 @@ importers:
       sqlite-vec:
         specifier: ^0.1.9
         version: 0.1.9
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: ^4
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+
+  packages/utils:
+    devDependencies:
       typescript:
         specifier: ~5.8.3
         version: 5.8.3


### PR DESCRIPTION
A follow-up cleanup PR addressing review notes from [#227](https://github.com/team-reflect/reflect-open/pull/227) (now merged into `next`). Targets `next` directly; the diff is the cleanup alone.

## 1. One shared implementation of ISO date arithmetic — `@reflect/utils`
There were **four** independent copies of UTC calendar math. New dependency-free [`@reflect/utils`](packages/utils/src/dates.ts) holds the primitives (`addDaysIso`, `addMonthsIso`, `weekdayIso`, `isoFromParts`, `isCalendarDate`, `isIsoDate`), and:
- `markdown/resolve.ts` and `indexing/filter-query.ts` drop their local `isCalendarDate`.
- `indexing/date-suggestions.ts` drops its private UTC helpers.
- `apps/desktop/src/lib/dates.ts` re-exports `addDaysIso`/`isIsoDate` from utils, keeping date-fns **only** for display formatting and the local-clock `todayIso`.
- Removes the awkward `indexing → markdown` import of `isCalendarDate`.

`@reflect/utils` is consumed by both `@reflect/core` and `@reflect/desktop` (workspace deps), and ships with its own tests (the `addMonthsIso` clamping is pinned against the date-fns semantics it replaces).

## 2. Explicit generated-date discriminator
`WikiSuggestion.phrase?` was doing double duty — display label **and** "this row is a generated date." It's now `generated?: { phrase }` ([GeneratedDate](packages/core/src/indexing/suggest.ts)). Presence of the object is the discriminator hosts branch on (suppress "Create", trail real notes in the palette); a phrase can no longer drift onto a non-generated row.

## 3. Week-start preference — correcting a wrong assumption
#227 claimed "V2 has no week-start setting." It does — `weekStartDay: 'monday' | 'sunday'` ([schema.ts](packages/core/src/settings/schema.ts)). `this/next/last week` and `weekend` now anchor to it (`firstOfWeek`), threaded through `DateSuggestionContext` and both the editor and palette hosts. Weekday phrases (`this monday`, `next friday`) are intentionally unaffected.

## 4. NL polish
- `nlUnits()` hoisted to a module constant — no per-keystroke allocation of the unit table + closures.
- Month/day token matching no longer calls its matcher twice per token.
- `echo` parameter renamed to `rawQuery`.

## Testing
- `pnpm typecheck` — 5/5 packages (incl. new utils). `pnpm lint` — exit 0 (4 pre-existing React Compiler warnings, unrelated).
- New `@reflect/utils` tests (8), plus week-start and `generated`-marker cases added to the date-suggestions / merge / palette / editor suites. Broader sweep: 438 core + 209 desktop tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor and UX alignment for wiki/date autocomplete with broad test coverage; no auth, sync, or data-migration paths touched.
> 
> **Overview**
> Introduces **`@reflect/utils`** as the single home for UTC ISO calendar math (`addDaysIso`, `isCalendarDate`, etc.), replacing duplicated helpers in core indexing, markdown resolution, filter parsing, and desktop `dates.ts` (which now re-exports pure math and keeps date-fns for display/`todayIso`).
> 
> **`WikiSuggestion`** no longer uses optional **`phrase`** for “synthesised daily” rows; it uses **`generated?: { phrase }`** so palette/autocomplete can reliably suppress Create rows and reorder results without mis-tagging real notes.
> 
> **`weekStartDay`** from settings is passed into date suggestion generation and React Query cache keys so **this/next/last week** and **weekend** anchor to Monday or Sunday per user preference (weekday phrases unchanged).
> 
> Date-suggestion internals drop inline UTC helpers in favor of utils, hoist the NL unit table to a module constant, and add tests for week-start and the new marker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e13169ae72f8ba5d65462b7dcb422ee7a0d6b15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
