### PR TITLE
style(tasks): use default Button typography on toolbar actions

### DIFF
--- a/apps/desktop/src/components/tasks/tasks-screen.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.tsx
@@ -248,7 +248,7 @@ export function TasksScreen(): ReactElement {
             today={today}
             onSchedule={onSchedule}
           >
-            <Button type="button" variant="ghost" className="font-normal text-text-muted">
+            <Button type="button" variant="ghost" className="text-text-muted">
               <CalendarClock aria-hidden className="size-4" />
               Schedule ({selection.selectedCount})
             </Button>
@@ -260,14 +260,14 @@ export function TasksScreen(): ReactElement {
             variant="ghost"
             onClick={onConvertToBullet}
             title="Drop the checkbox, keeping the line as a plain bullet — leaves the Tasks list"
-            className="font-normal text-text-muted"
+            className="text-text-muted"
           >
             <List aria-hidden className="size-4" />
             Convert to bullet ({selection.selectedCount})
           </Button>
         ) : null}
         {recentlyCompleted.length > 0 ? (
-          <Button type="button" variant="ghost" onClick={actions.archive} className="font-normal text-text-muted">
+          <Button type="button" variant="ghost" onClick={actions.archive} className="text-text-muted">
             <Archive aria-hidden className="size-4" />
             Archive ({recentlyCompleted.length})
           </Button>


### PR DESCRIPTION
## Summary
- Remove redundant `font-normal` overrides from Schedule, Convert to bullet, and Archive buttons on the tasks screen
- Task toolbar actions now inherit the shared `Button` component's default `text-sm` / `font-medium` styling

## Test plan
- [ ] Open the Tasks screen with selected tasks and recently completed tasks visible
- [ ] Confirm Schedule, Convert to bullet, and Archive buttons render with consistent typography vs other ghost buttons in the app


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined button styling in the task management interface for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->