### PR TITLE
fix(editor): cap editor heading size at --text-xl

### DIFF
--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -301,7 +301,10 @@ body {
 .reflect-editor h1 { font-size: var(--text-2xl, 1.5rem); }
 .reflect-editor h2 { font-size: var(--text-xl, 1.25rem); }
 .reflect-editor h3 { font-size: var(--text-lg, 1.125rem); }
-.reflect-editor h1:first-child { margin-top: 0; }
+/* The leading H1 is the note title, so it takes the design-system "note title"
+   size (--text-xl) rather than the larger prose-H1 size, matching the daily
+   date heading (.reflect-daily-subject) and the new-note "Untitled" ghost. */
+.reflect-editor h1:first-child { margin-top: 0; font-size: var(--text-xl, 1.25rem); }
 .reflect-editor .reflect-note-title { font-size: var(--text-xl, 1.25rem); }
 
 /* The new-note flow's name field: ghost "Untitled" over the seeded empty H1

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -298,13 +298,14 @@ body {
   letter-spacing: var(--tracking-snug, -0.01em);
   margin: 1.25em 0 0.4em;
 }
-.reflect-editor h1 { font-size: var(--text-2xl, 1.5rem); }
+/* Cap headings at --text-xl: the leading H1 is the note title and in-prose
+   `# headings` shouldn't tower over the body, so neither H1 nor H2 exceeds the
+   design-system "note title" size, matching the daily date heading
+   (.reflect-daily-subject) and the new-note "Untitled" ghost. */
+.reflect-editor h1 { font-size: var(--text-xl, 1.25rem); }
 .reflect-editor h2 { font-size: var(--text-xl, 1.25rem); }
 .reflect-editor h3 { font-size: var(--text-lg, 1.125rem); }
-/* The leading H1 is the note title, so it takes the design-system "note title"
-   size (--text-xl) rather than the larger prose-H1 size, matching the daily
-   date heading (.reflect-daily-subject) and the new-note "Untitled" ghost. */
-.reflect-editor h1:first-child { margin-top: 0; font-size: var(--text-xl, 1.25rem); }
+.reflect-editor h1:first-child { margin-top: 0; }
 .reflect-editor .reflect-note-title { font-size: var(--text-xl, 1.25rem); }
 
 /* The new-note flow's name field: ghost "Untitled" over the seeded empty H1


### PR DESCRIPTION
## Summary

No editor heading should exceed the design-system **"note title"** size (`--text-xl`, 20px). Previously prose `# headings` (and the note title, which is the leading H1) rendered at `--text-2xl` (24px) — a step larger than the daily-note date heading (`.reflect-daily-subject`, 20px). That also made the new-note **"Untitled"** placeholder, which ghosts over the leading H1, look oversized.

## Change

Drop `.reflect-editor h1` from `--text-2xl` to `--text-xl`, so H1 and H2 are uniformly capped at `--text-xl` and H3 stays at `--text-lg`. This also removes the now-redundant title-specific override (`h1:first-child` no longer needs its own `font-size`, just `margin-top: 0`).

| Element | Before | After |
| --- | --- | --- |
| Prose H1 / note title / "Untitled" placeholder | `--text-2xl` (24px) | `--text-xl` (20px) |
| H2 | `--text-xl` (20px) | unchanged |
| H3 | `--text-lg` (18px) | unchanged |
| Daily date heading (`.reflect-daily-subject`) | `--text-xl` (20px) | unchanged |

Aligns with the typography token comments: `--text-xl` is designated "note title / note H2 / daily-note date".

## Testing

CSS-only change; no test fixtures assert heading font-size. Recommend an eyeball check in `tauri dev` that titles, in-prose headings, and the daily date heading all sit at the same 20px cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only font-size change in editor prose with no logic, data, or security impact.
> 
> **Overview**
> **Typography fix** in `.reflect-editor` prose: **all `h1` elements** now use `--text-xl` (1.25rem) instead of `--text-2xl` (1.5rem), so the leading note title, the new-note **"Untitled"** ghost over that H1, and in-body `#` headings share the same **note title** scale as `.reflect-daily-subject` and `.reflect-note-title`. **H2/H3** rules are unchanged.
> 
> A short comment documents why H1/H2 are capped at the design-system note-title token rather than the larger prose-H1 size.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3023460b4eabdad6864447a630217833e9e32b40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->