### PR TITLE
fix(desktop): stop the window-state jump on launch

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -108,7 +108,10 @@ pub fn run() {
     // in tauri.conf.json (`plugins.updater`), and `process` provides the
     // post-install relaunch. Mobile updates go through the app stores.
     // Window-state restore is likewise meaningless on mobile (one fullscreen
-    // webview, no window frames to remember).
+    // webview, no window frames to remember). The main window starts hidden
+    // (`visible: false` in tauri.conf.json) so this plugin can restore its
+    // geometry before first paint — avoiding a visible jump — and then reveal
+    // it; mobile shows the window itself in the setup hook below.
     #[cfg(desktop)]
     let builder = builder
         .plugin(tauri_plugin_updater::Builder::new().build())
@@ -121,10 +124,17 @@ pub fn run() {
     #[cfg(mobile)]
     let builder = builder.plugin(tauri_plugin_keyboard::init());
 
-    // TEMPORARY (Plan 19 spike A): probe the native capabilities on startup;
-    // verdicts land in the dev console as `[plan19-spike]` lines.
+    // The main window starts hidden (`visible: false`); on desktop the
+    // window-state plugin reveals it after restoring geometry, but mobile has
+    // no such plugin, so show it here or the UI would never appear.
+    //
+    // (Also runs the TEMPORARY Plan 19 spike-A capability probe — delete that
+    // line with the spike, but keep the window show.)
     #[cfg(mobile)]
     let builder = builder.setup(|app| {
+        if let Some(window) = app.get_webview_window("main") {
+            window.show()?;
+        }
         spike_mobile::run_self_check(app.handle());
         Ok(())
     });

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "height": 650,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "dragDropEnabled": false
+        "dragDropEnabled": false,
+        "visible": false
       }
     ],
     "security": {


### PR DESCRIPTION
## What

Add `"visible": false` to the main window in `tauri.conf.json` so the window starts hidden and is revealed by `tauri-plugin-window-state` only after its saved geometry has been restored.

## Why

On launch the main window visibly **jumps**: it appears at the config geometry (1300×650, OS default position) and then snaps to its remembered position/size.

This is a timing artifact of the plugin (v2.4.1). Tauri creates the window *visible* from the config and paints it at the default geometry. Only afterward does the plugin's `on_window_ready` hook fire and call `restore_state()`, which `set_position()` + `set_size()` to the saved values — so the move happens on screen, after first paint.

The plugin is built to reveal the window itself: the end of `restore_state` calls `show()` + `set_focus()` when the `VISIBLE` flag is set, and the default `StateFlags::all()` includes it. Starting the window hidden lets the plugin restore geometry *before* the window is ever shown, eliminating the jump.

## Behavior

- **Repeat launches:** created hidden → geometry restored while hidden → plugin shows + focuses. No jump.
- **First launch (no saved state):** the plugin's no-state branch leaves `should_show = true`, so the window still shows at the config geometry.

## Notes for reviewers

- No capability change needed — the plugin's `show()` is a Rust-side runtime call; capabilities only gate frontend IPC invokes. The existing `window-state:default` grant is untouched.
- Trade-off: the window now relies on the plugin to reveal it. If `restore_state` ever errored before its `show()` call, the window would stay hidden — but the plugin ignores restore errors and this is the upstream-recommended pattern, so it's not a practical concern.
- Can't be covered by unit tests (native window-paint timing). To verify manually: `pnpm tauri dev`, move/resize, quit, relaunch — the window should appear directly at its last geometry with no snap. State lives at `~/Library/Application Support/app.reflect.desktop/.window-state.json`, so one prior run is needed to reproduce the original jump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small startup/visibility change with no auth, data, or IPC surface changes; desktop depends on the window-state plugin to reveal the window as before.
> 
> **Overview**
> The main window now starts **hidden** (`visible: false` in `tauri.conf.json`) so desktop launch no longer paints at default geometry and then snaps to saved position/size.
> 
> On **desktop**, `tauri-plugin-window-state` restores geometry while the window is still hidden, then shows and focuses it (its default `VISIBLE` flag behavior). On **mobile**, the same hidden default would leave the UI invisible without that plugin, so the mobile `setup` hook explicitly calls `show()` on the `"main"` webview before the Plan 19 spike probe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 124961d1974117a099c89c440c169903b33eab7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->