### PR TITLE
Align All Notes subject column

### DIFF
--- a/apps/desktop/src/components/all-notes/all-notes-row.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-row.tsx
@@ -6,12 +6,12 @@ import { cn } from '@/lib/utils'
 import { useSettings } from '@/providers/settings-provider'
 
 /**
- * The shared column template (Indicator · Subject · Snippet · Tags · Updated) —
- * the header row in {@link AllNotesTable} uses the same classes so the columns
- * line up. The leading column is the selection-indicator gutter.
+ * The shared column template (Subject · Snippet · Tags · Updated) — the header
+ * row in {@link AllNotesTable} uses the same classes so the columns line up.
+ * The selection indicator is positioned beside the row, outside the column flow.
  */
 export const ALL_NOTES_GRID =
-  'grid grid-cols-[1.25rem_15rem_minmax(0,1fr)_minmax(0,8rem)_5rem] items-center gap-4 pl-4 pr-7 lg:pl-12'
+  'grid grid-cols-[minmax(0,15rem)_minmax(0,1fr)_minmax(0,8rem)_5rem] items-center gap-4 pl-12 pr-7'
 
 interface AllNotesRowProps {
   note: NoteListEntry
@@ -44,7 +44,7 @@ export const AllNotesRow = memo(function AllNotesRow({ note, selected, onSelect,
       }}
       onDoubleClick={() => onOpen(note.path)}
       className={cn(
-        'group/row h-12 cursor-default select-none transition-colors duration-100',
+        'group/row relative h-12 cursor-default select-none transition-colors duration-100',
         ALL_NOTES_GRID,
         selected ? 'bg-surface-hover ring-1 ring-inset ring-accent' : 'hover:bg-surface-hover',
       )}
@@ -58,7 +58,7 @@ export const AllNotesRow = memo(function AllNotesRow({ note, selected, onSelect,
           onToggle(note.path, event)
         }}
         className={cn(
-          'flex size-[18px] items-center justify-center text-text-muted transition-opacity duration-100 hover:text-text focus-visible:opacity-100 focus-visible:outline-none',
+          'absolute left-4 top-1/2 flex size-[18px] -translate-y-1/2 items-center justify-center text-text-muted transition-opacity duration-100 hover:text-text focus-visible:opacity-100 focus-visible:outline-none',
           selected ? 'opacity-100' : 'opacity-0 group-hover/row:opacity-100',
         )}
       >

--- a/apps/desktop/src/components/all-notes/all-notes-screen.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.tsx
@@ -112,7 +112,7 @@ export function AllNotesScreen({ tag }: AllNotesScreenProps): ReactElement {
       aria-label="All notes"
       className="flex h-full min-h-0 flex-col outline-none"
     >
-      <header className="flex flex-none flex-wrap items-center justify-between gap-3 border-b border-border py-4 pl-4 pr-7 lg:pl-12">
+      <header className="flex flex-none flex-wrap items-center justify-between gap-3 border-b border-border py-4 pl-12 pr-7">
         <h1 className="text-[15px] font-semibold text-text">Notes</h1>
         <div className="flex flex-wrap items-center gap-3">
           <AllNotesFilters

--- a/apps/desktop/src/components/all-notes/all-notes-table.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-table.tsx
@@ -81,14 +81,13 @@ export function AllNotesTable({
           'sticky top-0 z-10 border-b border-border bg-surface py-3 text-[13px] font-medium leading-none text-text-secondary shadow-sm',
         )}
       >
-        <span aria-hidden />
         <span>Subject</span>
         <span>Snippet</span>
         <span className="text-right">Tags</span>
         <span className="text-right">Updated</span>
       </div>
       {notes.length === 0 ? (
-        <p className="py-8 pl-4 pr-7 text-sm text-text-muted lg:pl-12">
+        <p className="py-8 pl-12 pr-7 text-sm text-text-muted">
           {tag === null ? 'No notes yet.' : `No notes tagged #${tag}.`}
         </p>
       ) : (


### PR DESCRIPTION
## Summary
- align the All Notes subject column with the Notes header
- position the row selection indicator outside the table column flow
- keep empty-state padding on the same content inset

## Testing
- pnpm --filter @reflect/desktop test -- --run src/components/all-notes/all-notes-screen.test.tsx
- pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout and CSS-only changes to the All Notes list; selection behavior is unchanged.
> 
> **Overview**
> **Aligns the All Notes table** so the **Subject** column lines up with the **Notes** title and drops the selection control from the grid.
> 
> `ALL_NOTES_GRID` is now four columns (Subject · Snippet · Tags · Updated) instead of a dedicated indicator column. The row checkbox is **absolutely positioned** at `left-4` on a `relative` row, so it sits in the gutter without shifting Subject. The sticky header no longer needs a blank leading cell.
> 
> **Padding is unified** to `pl-12` on the screen header, table rows/header, and empty state (replacing `pl-4` / `lg:pl-12`), so content inset matches across the view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 914ea52d195e91b556ef3fecf109fc30935b655a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved table layout alignment and spacing consistency in the notes view, including adjusted header positioning, selection indicator placement, and padding values across the notes display components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->