### PR TITLE
Fix release latest flags

### DIFF
--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -23,7 +23,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync 
 import { tmpdir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
 import { createInterface } from 'node:readline/promises'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const KEYCHAIN_SERVICE = 'reflect-notary'
 const UPDATER_KEYCHAIN_SERVICE = 'reflect-updater'
@@ -435,6 +435,28 @@ function ensureTagMatchesCommit(tag, commit) {
   }
 }
 
+/** Build the GitHub CLI args that publish the release and upload artifacts. */
+export function createReleaseArgs({ assets, commit, draft, prerelease, productName, tag, version }) {
+  const releaseArgs = [
+    'release',
+    'create',
+    tag,
+    ...assets,
+    '--title',
+    `${productName} ${version}`,
+    '--target',
+    commit,
+    '--generate-notes',
+  ]
+  if (prerelease) {
+    releaseArgs.push('--prerelease', '--latest=false')
+  } else {
+    releaseArgs.push('--latest')
+  }
+  if (draft) releaseArgs.push('--draft')
+  return releaseArgs
+}
+
 /**
  * Build a signed + notarized DMG and upload it to a new GitHub release tagged
  * v<version> (from tauri.conf.json). A version with a prerelease segment
@@ -458,22 +480,15 @@ function publish({ draft }) {
   // endpoint — so installed stable apps never see a beta.
   const prerelease = version.includes('-')
   log(`creating GitHub ${prerelease ? 'pre-release' : 'release'} ${tag} from commit ${commit.slice(0, 7)}…`)
-  const releaseArgs = [
-    'release',
-    'create',
-    tag,
-    dmg,
-    updaterArchive,
-    updaterSignature,
-    manifestPath,
-    '--title',
-    `${productName} ${version}`,
-    '--target',
+  const releaseArgs = createReleaseArgs({
+    assets: [dmg, updaterArchive, updaterSignature, manifestPath],
     commit,
-    '--generate-notes',
-  ]
-  if (prerelease) releaseArgs.push('--prerelease')
-  if (draft) releaseArgs.push('--draft')
+    draft,
+    prerelease,
+    productName,
+    tag,
+    version,
+  })
   const result = spawnSync('gh', releaseArgs, { encoding: 'utf8', stdio: ['inherit', 'pipe', 'inherit'] })
   if (result.status !== 0) fail(`creating the GitHub release failed${result.stdout ? `\n${result.stdout.trim()}` : ''}`)
   log(`${draft ? 'draft release created' : 'release published'}: ${result.stdout.trim()}`)
@@ -598,4 +613,6 @@ async function main() {
   }
 }
 
-await main()
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main()
+}

--- a/apps/desktop/scripts/release-macos.test.mjs
+++ b/apps/desktop/scripts/release-macos.test.mjs
@@ -1,0 +1,61 @@
+import { expect, test } from 'vitest'
+
+import { createReleaseArgs } from './release-macos.mjs'
+
+const baseInput = {
+  assets: ['Reflect.dmg', 'Reflect.app.tar.gz', 'Reflect.app.tar.gz.sig', 'latest.json'],
+  commit: 'abc123',
+  draft: false,
+  productName: 'Reflect',
+}
+
+test('pre-release publish opts out of GitHub latest heuristics', () => {
+  const args = createReleaseArgs({
+    ...baseInput,
+    prerelease: true,
+    tag: 'v0.2.0-beta.14',
+    version: '0.2.0-beta.14',
+  })
+
+  expect(args).toEqual([
+    'release',
+    'create',
+    'v0.2.0-beta.14',
+    'Reflect.dmg',
+    'Reflect.app.tar.gz',
+    'Reflect.app.tar.gz.sig',
+    'latest.json',
+    '--title',
+    'Reflect 0.2.0-beta.14',
+    '--target',
+    'abc123',
+    '--generate-notes',
+    '--prerelease',
+    '--latest=false',
+  ])
+})
+
+test('stable publish marks the release as latest', () => {
+  const args = createReleaseArgs({
+    ...baseInput,
+    prerelease: false,
+    tag: 'v0.2.0',
+    version: '0.2.0',
+  })
+
+  expect(args).toContain('--latest')
+  expect(args).not.toContain('--prerelease')
+  expect(args).not.toContain('--latest=false')
+})
+
+test('draft publish keeps the draft flag last', () => {
+  const args = createReleaseArgs({
+    ...baseInput,
+    draft: true,
+    prerelease: true,
+    tag: 'v0.2.0-beta.15',
+    version: '0.2.0-beta.15',
+  })
+
+  expect(args.at(-1)).toBe('--draft')
+})


### PR DESCRIPTION
## Summary
- make macOS prerelease publishing pass `--latest=false` to GitHub
- make stable release publishing pass `--latest` explicitly
- add tests for the generated `gh release create` arguments

## Testing
- `pnpm --filter @reflect/desktop test --run scripts/release-macos.test.mjs scripts/release-bump.test.mjs`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- `pnpm build`
- `pnpm check` (passes with existing warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-script and test-only changes; no runtime app or auth logic, with behavior covered by unit tests.
> 
> **Overview**
> macOS **publish** now builds `gh release create` arguments through a shared **`createReleaseArgs`** helper instead of inline flags.
> 
> **Pre-releases** (versions with a `-` segment) pass **`--prerelease`** and **`--latest=false`** so GitHub does not treat a beta as the repository’s latest release—important because the updater uses **`releases/latest`**.
> 
> **Stable** releases pass **`--latest`** explicitly. **Draft** releases still append **`--draft`** last.
> 
> The script only runs **`main()`** when executed as the entry file (via **`pathToFileURL`**), so the module can be imported in tests. New **Vitest** coverage locks in the expected CLI argument shapes for prerelease, stable, and draft publishes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e768d0429430b75590ad74ef490fd16ed6bfd545. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->