### PR TITLE
fix(desktop): lift task toolbar above drag region

### DIFF
--- a/apps/desktop/src/components/context-sidebar/day-calendar.tsx
+++ b/apps/desktop/src/components/context-sidebar/day-calendar.tsx
@@ -76,10 +76,9 @@ export function DayCalendar({ selectedDate, today }: DayCalendarProps): ReactEle
         <div className="cursor-default text-sm font-semibold text-text">
           {monthLabel(month)}
         </div>
-        {/* z-40 lifts the buttons above the WindowDragRegion strip overlaying
-            the title-bar band, so clicks land instead of dragging the window
-            (see NavigateArrows for the stacking contract). */}
-        <nav className="relative z-40 flex items-center justify-center space-x-1 text-text-muted">
+        {/* window-drag-control lifts the buttons above the WindowDragRegion strip
+            overlaying the title-bar band (see NavigateArrows for the contract). */}
+        <nav className="window-drag-control flex items-center justify-center space-x-1 text-text-muted">
           <button
             type="button"
             aria-label="Previous month"

--- a/apps/desktop/src/components/sidebar/navigate-arrows.tsx
+++ b/apps/desktop/src/components/sidebar/navigate-arrows.tsx
@@ -23,11 +23,10 @@ export function NavigateArrows(): ReactElement {
 
   return (
     // The arrows sit inside the overlaid macOS title-bar band, where the
-    // WindowDragRegion strip (z-40, mounted before the app) would otherwise
-    // swallow their clicks into a window drag. Matching its z-index puts the
-    // buttons above it by tree order while same-z overlays mounted later
-    // (the command palette) still cover them.
-    <div className="relative z-40 flex items-center">
+    // WindowDragRegion strip would otherwise swallow their clicks into a
+    // window drag; window-drag-control keeps them above it without outranking
+    // same-z overlays mounted later, such as the command palette.
+    <div className="window-drag-control flex items-center">
       <Tooltip>
         {/* Span wrapper keeps pointer events alive when the button is disabled,
             so the tooltip still opens at the start of the history stack. */}

--- a/apps/desktop/src/components/tasks/task-filters-menu.tsx
+++ b/apps/desktop/src/components/tasks/task-filters-menu.tsx
@@ -40,7 +40,7 @@ export function TaskFiltersMenu({
   return (
     <DropdownMenu open={open} onOpenChange={onOpenChange}>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="font-normal text-text-muted">
+        <Button variant="ghost" className="window-drag-control font-normal text-text-muted">
           <ListFilter aria-hidden className="size-4" />
           Task filters
         </Button>

--- a/apps/desktop/src/components/tasks/tasks-screen.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.tsx
@@ -228,7 +228,7 @@ export function TasksScreen(): ReactElement {
       className="flex h-full min-h-0 flex-col outline-none"
     >
       <header className="flex flex-none items-center gap-2 border-b border-border py-2.5 pl-2 pr-3 lg:pl-10">
-        <div className="relative min-w-0 flex-1">
+        <div className="window-drag-control min-w-0 flex-1">
           <Search
             aria-hidden
             className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-text-muted"
@@ -248,7 +248,7 @@ export function TasksScreen(): ReactElement {
             today={today}
             onSchedule={onSchedule}
           >
-            <Button type="button" variant="ghost" className="text-text-muted">
+            <Button type="button" variant="ghost" className="window-drag-control text-text-muted">
               <CalendarClock aria-hidden className="size-4" />
               Schedule ({selection.selectedCount})
             </Button>
@@ -260,14 +260,19 @@ export function TasksScreen(): ReactElement {
             variant="ghost"
             onClick={onConvertToBullet}
             title="Drop the checkbox, keeping the line as a plain bullet — leaves the Tasks list"
-            className="text-text-muted"
+            className="window-drag-control text-text-muted"
           >
             <List aria-hidden className="size-4" />
             Convert to bullet ({selection.selectedCount})
           </Button>
         ) : null}
         {recentlyCompleted.length > 0 ? (
-          <Button type="button" variant="ghost" onClick={actions.archive} className="text-text-muted">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={actions.archive}
+            className="window-drag-control text-text-muted"
+          >
             <Archive aria-hidden className="size-4" />
             Archive ({recentlyCompleted.length})
           </Button>

--- a/apps/desktop/src/components/window-drag-region.tsx
+++ b/apps/desktop/src/components/window-drag-region.tsx
@@ -8,12 +8,11 @@ import { hasMacosTitleBarOverlay } from '@/lib/window-chrome'
  * double-click toggle zoom, matching native title-bar behavior.
  *
  * Mouse events on the strip never reach content beneath it, so interactive
- * elements within its 28px height (`h-7`) must raise themselves above it
- * with `relative z-40`: the strip mounts before the app, so at equal
- * z-index the app's controls win by tree order, while same-z overlays
- * mounted later (the command palette) still cover those controls. See
- * `NavigateArrows` and the `DayCalendar` header. Renders nothing outside
- * the macOS desktop webview, where the native title bar still exists.
+ * elements within its 28px height (`h-7`) must raise themselves with the
+ * `window-drag-control` utility: the strip mounts before the app, so at equal
+ * z-index the app's controls win by tree order, while same-z overlays mounted
+ * later (the command palette) still cover those controls. Renders nothing
+ * outside the macOS desktop webview, where the native title bar still exists.
  */
 export function WindowDragRegion(): ReactElement | null {
   if (!hasMacosTitleBarOverlay) {

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -10,6 +10,13 @@
    ThemeProvider on <html>. */
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* Controls that sit inside the overlaid macOS title-bar drag strip must share
+   the strip's z-index so they win by tree order without jumping above overlays. */
+@utility window-drag-control {
+  position: relative;
+  z-index: 40;
+}
+
 /* Design-system tokens exposed as Tailwind theme keys, 1:1 by name, so
    product code writes `text-text-muted` / `bg-surface-hover` instead of
    arbitrary `text-[color:var(--text-muted)]` escapes. `inline` makes the


### PR DESCRIPTION
## Summary
- add a reusable `window-drag-control` utility for controls in the macOS titlebar drag band
- apply it to the Tasks search field, task filter trigger, and selection toolbar buttons
- update the existing sidebar/calendar drag-region examples to use the shared utility

## Testing
- pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop-only z-index/class refactor for title-bar hit testing; no auth, data, or business-logic changes.
> 
> **Overview**
> Fixes **Tasks toolbar controls** (search, filters, schedule/convert/archive actions) being swallowed by the overlaid macOS **title-bar drag strip** by lifting them into the same stacking layer as existing sidebar/calendar chrome.
> 
> Introduces a shared Tailwind **`window-drag-control`** utility (`relative` + `z-index: 40`, matching `WindowDragRegion`) and **replaces scattered `relative z-40`** on `NavigateArrows`, `DayCalendar` header nav, and the Tasks header. Comments in **`window-drag-region.tsx`** now document the utility instead of ad-hoc classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 322c34c84bc1fea53015ada236c5f086db3476f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->