### PR TITLE
Make chat note references clickable

### DIFF
--- a/apps/desktop/src/components/chat/chat-screen.test.tsx
+++ b/apps/desktop/src/components/chat/chat-screen.test.tsx
@@ -226,6 +226,8 @@ describe('ChatScreen', () => {
     await waitFor(() =>
       expect(view.getByTestId('markdown-preview').textContent).toContain('It ships in June.'),
     )
+    await userEvent.click(view.getByRole('button', { name: 'Atlas' }))
+    expect(probedRoute).toEqual({ kind: 'note', path: 'notes/atlas.md' })
 
     // The turn went out with the keychain key and the full derived history.
     expect(getSecret).toHaveBeenCalledWith('ai-api-key:m1')
@@ -375,9 +377,13 @@ describe('ChatScreen', () => {
 
     await userEvent.click(await view.findByRole('button', { name: '#book' }))
     expect(probedRoute).toEqual({ kind: 'allNotes', tag: 'book' })
+    await userEvent.click(view.getByRole('button', { name: 'Atlas' }))
+    expect(probedRoute).toEqual({ kind: 'note', path: 'notes/atlas.md' })
     // A refused listing shows the refusal, not a misleading count.
     await view.findByText(/Listed #\* notes — Not a tag/)
     await view.findByText(/Listed daily notes 2026-06-01 – 2026-06-11 · 2 days/)
+    await userEvent.click(view.getByRole('button', { name: '2026-06-10' }))
+    expect(probedRoute).toEqual({ kind: 'daily', date: '2026-06-10' })
   })
 
   it('renders streaming text as plain text until the turn settles', async () => {

--- a/apps/desktop/src/components/chat/chat-tool-chip.tsx
+++ b/apps/desktop/src/components/chat/chat-tool-chip.tsx
@@ -1,6 +1,6 @@
 import { Fragment, type ReactElement, type ReactNode } from 'react'
 import { CalendarDays, FileText, History, Search } from 'lucide-react'
-import { isTagName, isToolPending, type AssistantPart } from '@reflect/core'
+import { isTagName, isToolPending, type AssistantPart, type NoteHitSummary } from '@reflect/core'
 import { routeForPath } from '@/routing/route'
 import { useRouter } from '@/routing/router'
 import { Spinner } from '@/components/ui/spinner'
@@ -30,6 +30,35 @@ function ChipFrame({ pending, icon, children }: ChipFrameProps): ReactElement {
   )
 }
 
+interface NoteLinksProps {
+  notes: readonly NoteHitSummary[]
+  onOpen: (path: string) => void
+}
+
+function NoteLinks({ notes, onOpen }: NoteLinksProps): ReactElement | null {
+  if (notes.length === 0) {
+    return null
+  }
+
+  return (
+    <>
+      {': '}
+      {notes.map((note, index) => (
+        <Fragment key={`${note.path}-${index}`}>
+          {index > 0 ? ', ' : ''}
+          <button
+            type="button"
+            onClick={() => onOpen(note.path)}
+            className="underline-offset-2 hover:text-text hover:underline"
+          >
+            {note.title}
+          </button>
+        </Fragment>
+      ))}
+    </>
+  )
+}
+
 /**
  * The transparent-context chip for one tool call: what the assistant searched
  * for or listed (and how many notes came back), or which note it read.
@@ -39,6 +68,7 @@ function ChipFrame({ pending, icon, children }: ChipFrameProps): ReactElement {
  */
 export function ChatToolChip({ part }: ChatToolChipProps): ReactElement {
   const { navigate } = useRouter()
+  const openNote = (path: string) => navigate(routeForPath(path))
   const pending = isToolPending(part)
   const call = part.call
 
@@ -49,6 +79,7 @@ export function ChatToolChip({ part }: ChatToolChipProps): ReactElement {
         <span className="truncate">
           Searched “{call.query}”
           {result !== null ? countSuffix(result.hits.length, 'note') : ''}
+          {result !== null ? <NoteLinks notes={result.hits} onOpen={openNote} /> : null}
         </span>
       </ChipFrame>
     )
@@ -77,6 +108,9 @@ export function ChatToolChip({ part }: ChatToolChipProps): ReactElement {
               ? ` — ${result.error}`
               : countSuffix(result.notes.length, 'note')
             : ''}
+          {result !== null && result.error === null ? (
+            <NoteLinks notes={result.notes} onOpen={openNote} />
+          ) : null}
         </span>
       </ChipFrame>
     )
@@ -89,6 +123,7 @@ export function ChatToolChip({ part }: ChatToolChipProps): ReactElement {
         <span className="truncate">
           Listed daily notes {call.start} – {call.end}
           {result !== null ? countSuffix(result.days.length, 'day') : ''}
+          {result !== null ? <NoteLinks notes={result.days} onOpen={openNote} /> : null}
         </span>
       </ChipFrame>
     )
@@ -120,7 +155,7 @@ export function ChatToolChip({ part }: ChatToolChipProps): ReactElement {
               {!pending && note.error === null ? (
                 <button
                   type="button"
-                  onClick={() => navigate(routeForPath(note.path))}
+                  onClick={() => openNote(note.path)}
                   className="underline-offset-2 hover:text-text hover:underline"
                 >
                   {label}


### PR DESCRIPTION
## Summary
- render note references returned by chat search, recent-note, and daily-note tools as clickable buttons
- route clicked chat note references through the existing note/daily route helper
- cover clickable search, recent, and daily note references in chat screen tests

## Testing
- pnpm --filter @reflect/desktop test -- src/components/chat/chat-screen.test.tsx
- pnpm check

Note: pnpm check still reports existing lint warnings unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only navigation in chat tool chips reusing existing routing; no auth or data-layer changes.
> 
> **Overview**
> Chat **search**, **recent-notes**, and **daily-range** tool chips now show returned notes as inline **clickable titles** (after the existing count), using the same navigation path as read-note chips via `routeForPath`.
> 
> A shared **`NoteLinks`** helper renders comma-separated buttons; **recents** only links notes when the listing succeeded (no links on error). **Chat screen tests** assert navigation to note and daily routes when clicking chip titles such as **Atlas** and **2026-06-10**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d3b64e175243a30966105f8c954f29d069f8cc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->