### PR TITLE
Fix chat new button shortcut and message selection

### DIFF
--- a/apps/desktop/src/components/chat/chat-input.tsx
+++ b/apps/desktop/src/components/chat/chat-input.tsx
@@ -12,6 +12,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { imageFilesFrom } from '@/lib/chat-attachments'
 import { keybindingFor } from '@/lib/commands/app-commands'
 import { useChatSession } from '@/providers/chat-provider'
@@ -191,13 +192,17 @@ export function ChatInput(): ReactElement {
           <div className="flex-1" />
           <ChatHistoryMenu />
           {turns.length > 0 && !streaming ? (
-            <Button variant="ghost" size="sm" onClick={newChat}>
-              <Plus aria-hidden data-icon="inline-start" />
-              New chat
-              {NEW_CHAT_BINDING ? (
-                <ShortcutKeys binding={NEW_CHAT_BINDING} className="ml-1 text-text-muted" />
-              ) : null}
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="ghost" size="sm" onClick={newChat}>
+                  <Plus aria-hidden data-icon="inline-start" />
+                  New chat
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                New chat {NEW_CHAT_BINDING ? <ShortcutKeys binding={NEW_CHAT_BINDING} /> : null}
+              </TooltipContent>
+            </Tooltip>
           ) : null}
           {streaming ? (
             <Button size="icon-sm" aria-label="Stop" onClick={stop}>

--- a/apps/desktop/src/components/chat/chat-screen.test.tsx
+++ b/apps/desktop/src/components/chat/chat-screen.test.tsx
@@ -15,6 +15,7 @@ import {
   type Settings,
   type StreamChatOptions,
 } from '@reflect/core'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { ChatProvider, useChatSession } from '@/providers/chat-provider'
 import { RouterProvider, useRouter } from '@/routing/router'
 
@@ -183,11 +184,13 @@ function renderChat() {
   return render(
     <QueryClientProvider client={client}>
       <RouterProvider>
-        <ChatProvider graph={GRAPH}>
-          <ChatScreen />
-          <SendProbe />
-          <RouteProbe />
-        </ChatProvider>
+        <TooltipProvider>
+          <ChatProvider graph={GRAPH}>
+            <ChatScreen />
+            <SendProbe />
+            <RouteProbe />
+          </ChatProvider>
+        </TooltipProvider>
       </RouterProvider>
     </QueryClientProvider>,
   )

--- a/apps/desktop/src/components/chat/chat-turn.tsx
+++ b/apps/desktop/src/components/chat/chat-turn.tsx
@@ -41,7 +41,7 @@ export function ChatTurn({ turn }: ChatTurnProps): ReactElement {
             />
           ))}
           {turn.userText !== '' ? (
-            <div className="rounded-2xl bg-surface-hover px-4 py-2 text-sm whitespace-pre-wrap text-text">
+            <div className="reflect-chat-message rounded-2xl bg-surface-hover px-4 py-2 text-sm whitespace-pre-wrap text-text">
               {turn.userText}
             </div>
           ) : null}
@@ -56,7 +56,10 @@ export function ChatTurn({ turn }: ChatTurnProps): ReactElement {
           switch (part.kind) {
             case 'text':
               return turn.status === 'streaming' && index === lastIndex ? (
-                <div key={index} className="text-sm whitespace-pre-wrap text-text">
+                <div
+                  key={index}
+                  className="reflect-chat-message text-sm whitespace-pre-wrap text-text"
+                >
                   {part.text}
                 </div>
               ) : (
@@ -64,7 +67,7 @@ export function ChatTurn({ turn }: ChatTurnProps): ReactElement {
                   key={index}
                   content={part.text}
                   onWikiLinkClick={navigateWikiLink}
-                  className="text-sm"
+                  className="reflect-chat-message text-sm"
                 />
               )
             case 'tool':
@@ -74,7 +77,7 @@ export function ChatTurn({ turn }: ChatTurnProps): ReactElement {
                 <p
                   key={index}
                   className={cn(
-                    'text-sm',
+                    'reflect-chat-message text-sm',
                     part.tone === 'error' ? 'text-destructive' : 'text-text-muted italic',
                   )}
                 >

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -194,6 +194,8 @@ body {
   [contenteditable] *,
   .reflect-editor,
   .reflect-editor *,
+  .reflect-chat-message,
+  .reflect-chat-message *,
   .reflect-protected-note,
   .reflect-protected-note * {
     -webkit-user-select: text;


### PR DESCRIPTION
## Summary
- Move the New chat shortcut hint into a tooltip instead of rendering it inline in the button
- Allow chat message text to be selected for copying
- Wrap chat screen tests with the tooltip provider used at runtime

## Testing
- pnpm --filter @reflect/desktop test -- src/components/chat/chat-screen.test.tsx
- pnpm check
- pnpm build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small desktop chat UI and CSS selection opt-in changes with no auth, data, or API impact; test harness only adds TooltipProvider.
> 
> **Overview**
> **New chat** no longer shows the keyboard shortcut inline on the button; the hint (including `ShortcutKeys` when configured) appears in a **top tooltip** on hover/focus, keeping the composer toolbar compact.
> 
> Chat transcript text becomes **copyable** by tagging user bubbles, streaming assistant text, settled markdown previews, and notice lines with `reflect-chat-message`, and extending the global `user-select: text` opt-in in `index.css` to match editors and protected notes.
> 
> `chat-screen.test.tsx` wraps the tree in **`TooltipProvider`** so Radix tooltips behave like production when tests click **New chat**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 265ea8c54f64cb09d66486b557c03fbfce5bd5c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->