### PR TITLE
fix(chat): align search prompt with semantic setting

### DIFF
--- a/apps/desktop/src/providers/chat-provider.test.tsx
+++ b/apps/desktop/src/providers/chat-provider.test.tsx
@@ -41,6 +41,7 @@ const settingsState = vi.hoisted(() => ({
   models: [] as AiProviderConfig[],
   defaultId: null as string | null,
   selection: null as ChatModelSelection | null,
+  semanticSearchEnabled: false,
 }))
 const updateSettings = vi.hoisted(() => vi.fn<(patch: Partial<Settings>) => void>())
 // Stateful like the real provider: a chatModelSelection patch re-renders with
@@ -55,6 +56,7 @@ vi.mock('@/providers/settings-provider', async () => {
           aiProviders: settingsState.models,
           defaultAiProviderId: settingsState.defaultId,
           chatModelSelection: selection,
+          semanticSearchEnabled: settingsState.semanticSearchEnabled,
         },
         updateSettings: (patch: Partial<Settings>) => {
           updateSettings(patch)
@@ -121,6 +123,7 @@ beforeEach(() => {
   settingsState.models = [MODEL]
   settingsState.defaultId = 'm1'
   settingsState.selection = null
+  settingsState.semanticSearchEnabled = false
   core.hasBridge.mockReturnValue(true)
   core.getSecret.mockResolvedValue('sk-test')
   core.loadChatGraphContext.mockResolvedValue(null)
@@ -214,6 +217,19 @@ describe('ChatProvider persistence', () => {
       conversation: { id: 'conv-1', title: 'what did I write yesterday?' },
       turn: { userText: 'and today?' },
     })
+  })
+
+  it('passes the semantic search setting into chat turns', async () => {
+    settingsState.semanticSearchEnabled = true
+    scriptTurn([{ type: 'complete', messages: [{ role: 'assistant', content: 'Hi.' }] }])
+    renderProvider()
+    await waitFor(() => expect(core.listChatConversations).toHaveBeenCalled())
+
+    await act(() => session?.send('hello'))
+
+    expect(core.streamChat).toHaveBeenCalledWith(
+      expect.objectContaining({ semanticSearchEnabled: true }),
+    )
   })
 
   it('opens a past conversation and switches the active id', async () => {

--- a/apps/desktop/src/providers/chat-provider.tsx
+++ b/apps/desktop/src/providers/chat-provider.tsx
@@ -144,12 +144,14 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
   const activeModelRef = useRef<AiProviderConfig | null>(activeModel)
   const conversationIdRef = useRef(conversationId)
   const generationRef = useRef<number | null>(indexGeneration)
+  const semanticSearchEnabledRef = useRef(settings.semanticSearchEnabled)
   useEffect(() => {
     turnsRef.current = turns
     attachmentsRef.current = attachments
     activeModelRef.current = activeModel
     conversationIdRef.current = conversationId
     generationRef.current = indexGeneration
+    semanticSearchEnabledRef.current = settings.semanticSearchEnabled
   })
 
   // The in-flight send, tracked synchronously — the no-concurrent-sends
@@ -338,6 +340,7 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
           fetchFn: providerFetch,
           messages,
           today: todayIso(),
+          semanticSearchEnabled: semanticSearchEnabledRef.current,
           context,
           signal: controller.signal,
         })

--- a/packages/core/src/ai/chat/stream-chat.test.ts
+++ b/packages/core/src/ai/chat/stream-chat.test.ts
@@ -102,6 +102,7 @@ describe('streamChatTurn', () => {
       streamChatTurn(model, {
         messages: [{ role: 'user', content: 'where is the launch plan?' }],
         today: '2026-06-11',
+        semanticSearchEnabled: true,
         context: null,
         toolDeps: { retrieveFn: async () => [PUBLIC_HIT, PRIVATE_HIT], readNoteFn: async () => 'launch plan\n' },
       }),
@@ -140,6 +141,7 @@ describe('streamChatTurn', () => {
       streamChatTurn(model, {
         messages: [{ role: 'user', content: 'what do my notes say?' }],
         today: '2026-06-11',
+        semanticSearchEnabled: true,
         context: null,
         toolDeps: { retrieveFn: async () => [PUBLIC_HIT, PRIVATE_HIT], readNoteFn: async () => 'launch plan\n' },
       }),
@@ -160,6 +162,7 @@ describe('streamChatTurn', () => {
       streamChatTurn(model, {
         messages: [{ role: 'user', content: 'hi' }],
         today: '2026-06-11',
+        semanticSearchEnabled: true,
         context: cloudSafeGraphContext({
           graphName: 'atlas-graph',
           noteCount: 7,
@@ -191,6 +194,7 @@ describe('streamChatTurn', () => {
       streamChatTurn(model, {
         messages: [{ role: 'user', content: 'hi' }],
         today: '2026-06-11',
+        semanticSearchEnabled: true,
         context: null,
       }),
     )
@@ -214,6 +218,7 @@ describe('streamChatTurn', () => {
       streamChatTurn(model, {
         messages: [{ role: 'user', content: 'where is the launch plan?' }],
         today: '2026-06-11',
+        semanticSearchEnabled: true,
         context: null,
         toolDeps: { retrieveFn: async () => [PUBLIC_HIT], readNoteFn: async () => 'launch plan\n' },
       }),
@@ -251,6 +256,7 @@ describe('streamChatTurn', () => {
       streamChatTurn(model, {
         messages: [{ role: 'user', content: 'plan and budget?' }],
         today: '2026-06-11',
+        semanticSearchEnabled: true,
         context: null,
         toolDeps: { retrieveFn: async () => [PUBLIC_HIT], readNoteFn: async () => 'launch plan\n' },
       }),
@@ -286,6 +292,7 @@ describe('streamChatTurn', () => {
       streamChatTurn(model, {
         messages: [{ role: 'user', content: 'summarize everything' }],
         today: '2026-06-11',
+        semanticSearchEnabled: true,
         context: null,
         toolDeps: { retrieveFn: async () => [PUBLIC_HIT], readNoteFn: async () => 'body\n' },
       }),

--- a/packages/core/src/ai/chat/stream-chat.ts
+++ b/packages/core/src/ai/chat/stream-chat.ts
@@ -47,6 +47,8 @@ export interface StreamChatOptions {
   messages: ModelMessage[]
   /** Local ISO date for the system prompt (daily-note key space). */
   today: string
+  /** Whether note search can use embeddings for meaning-based recall. */
+  semanticSearchEnabled: boolean
   /**
    * Graph overview for the system prompt (`loadChatGraphContext`), or
    * `null` to send the prompt without it — required so call sites decide
@@ -77,11 +79,16 @@ export type ChatStreamEvent =
 export function streamChat(options: StreamChatOptions): AsyncGenerator<ChatStreamEvent> {
   const messages = fitToContextWindow(options.messages, {
     contextWindow: modelContextWindow(options.config.provider, options.config.model),
-    systemPrompt: chatSystemPrompt({ today: options.today, context: options.context }),
+    systemPrompt: chatSystemPrompt({
+      today: options.today,
+      context: options.context,
+      semanticSearchEnabled: options.semanticSearchEnabled,
+    }),
   })
   return streamChatTurn(languageModel(options.config, options.apiKey, options.fetchFn), {
     messages,
     today: options.today,
+    semanticSearchEnabled: options.semanticSearchEnabled,
     context: options.context,
     signal: options.signal,
   })
@@ -93,6 +100,8 @@ export interface ChatTurnOptions {
   messages: ModelMessage[]
   /** Local ISO date for the system prompt (daily-note key space). */
   today: string
+  /** Whether note search can use embeddings for meaning-based recall. */
+  semanticSearchEnabled: boolean
   /** Graph overview for the system prompt, or `null` to omit the block. */
   context: CloudSafe<CloudGraphContext> | null
   /** Aborts the provider call mid-stream (the UI's stop button). */
@@ -115,7 +124,10 @@ export async function* streamChatTurn(
   model: LanguageModel,
   options: ChatTurnOptions,
 ): AsyncGenerator<ChatStreamEvent> {
-  const tools = buildNoteTools(options.toolDeps)
+  const tools = buildNoteTools({
+    ...options.toolDeps,
+    semanticSearchEnabled: options.semanticSearchEnabled,
+  })
 
   // Messages for all *completed* steps (cumulative, assistant/tool pairs)…
   let stepMessages: ModelMessage[] = []
@@ -129,7 +141,11 @@ export async function* streamChatTurn(
   try {
     const result = streamText({
       model,
-      system: chatSystemPrompt({ today: options.today, context: options.context }),
+      system: chatSystemPrompt({
+        today: options.today,
+        context: options.context,
+        semanticSearchEnabled: options.semanticSearchEnabled,
+      }),
       messages: options.messages,
       tools,
       stopWhen: stepCountIs(MAX_STEPS),

--- a/packages/core/src/ai/chat/system-prompt.test.ts
+++ b/packages/core/src/ai/chat/system-prompt.test.ts
@@ -20,22 +20,45 @@ function context(overrides: Partial<CloudGraphContext> = {}) {
 
 describe('chatSystemPrompt', () => {
   it('renders the date and grounding rules without an overview when context is null', () => {
-    const prompt = chatSystemPrompt({ today: '2026-06-12', context: null })
+    const prompt = chatSystemPrompt({
+      today: '2026-06-12',
+      context: null,
+      semanticSearchEnabled: true,
+    })
     expect(prompt).toContain('Today’s date is 2026-06-12.')
     expect(prompt).toContain('Grounding rules:')
     expect(prompt).not.toContain('Graph overview')
   })
 
   it('steers the model away from redundant searches and serial reads', () => {
-    const prompt = chatSystemPrompt({ today: '2026-06-12', context: null })
+    const prompt = chatSystemPrompt({
+      today: '2026-06-12',
+      context: null,
+      semanticSearchEnabled: true,
+    })
     expect(prompt).toContain('search_notes matches on both keywords and meaning')
     expect(prompt).toContain('raise its “limit” (up to 20) in one call')
     expect(prompt).toContain('pass all their paths to read_notes in one call')
     expect(prompt).toContain('limited number of tool rounds')
   })
 
+  it('describes lexical search when semantic search is disabled', () => {
+    const prompt = chatSystemPrompt({
+      today: '2026-06-12',
+      context: null,
+      semanticSearchEnabled: false,
+    })
+    expect(prompt).toContain('search_notes uses lexical full-text search')
+    expect(prompt).toContain('try one broader lexical query')
+    expect(prompt).not.toContain('search_notes matches on both keywords and meaning')
+  })
+
   it('renders the graph name, sizes, daily span, and the full tag vocabulary', () => {
-    const prompt = chatSystemPrompt({ today: '2026-06-12', context: context() })
+    const prompt = chatSystemPrompt({
+      today: '2026-06-12',
+      context: context(),
+      semanticSearchEnabled: true,
+    })
     expect(prompt).toContain('Graph overview (private notes are excluded from every figure):')
     expect(prompt).toContain('“atlas-graph” — 12 notes and 4 daily notes')
     expect(prompt).toContain('Daily notes span 2026-01-02 to 2026-06-10.')
@@ -48,6 +71,7 @@ describe('chatSystemPrompt', () => {
     const prompt = chatSystemPrompt({
       today: '2026-06-12',
       context: context({ tagsTruncated: true }),
+      semanticSearchEnabled: true,
     })
     expect(prompt).toContain('Most-used tags')
     expect(prompt).toContain('More tags exist beyond these.')
@@ -55,7 +79,11 @@ describe('chatSystemPrompt', () => {
   })
 
   it('tells the model outright when no tags exist', () => {
-    const prompt = chatSystemPrompt({ today: '2026-06-12', context: context({ tags: [] }) })
+    const prompt = chatSystemPrompt({
+      today: '2026-06-12',
+      context: context({ tags: [] }),
+      semanticSearchEnabled: true,
+    })
     expect(prompt).toContain('No tags are in use — never pass a tag filter.')
   })
 
@@ -63,6 +91,7 @@ describe('chatSystemPrompt', () => {
     const prompt = chatSystemPrompt({
       today: '2026-06-12',
       context: context({ dailyNoteCount: 0, earliestDailyDate: null, latestDailyDate: null }),
+      semanticSearchEnabled: true,
     })
     expect(prompt).toContain('0 daily notes')
     expect(prompt).not.toContain('Daily notes span')

--- a/packages/core/src/ai/chat/system-prompt.ts
+++ b/packages/core/src/ai/chat/system-prompt.ts
@@ -10,6 +10,12 @@ export interface SystemPromptInput {
   /** Local ISO date (`YYYY-MM-DD`) — daily notes live under this key space. */
   today: string
   /**
+   * Whether `search_notes` can use embeddings for meaning-based recall.
+   * Disabled chats stay strictly lexical, so the prompt must not promise
+   * semantic matching.
+   */
+  semanticSearchEnabled: boolean
+  /**
    * Graph-level grounding block ({@link CloudGraphContext}), or `null` when
    * it could not be loaded — the prompt then simply omits the overview.
    */
@@ -17,7 +23,11 @@ export interface SystemPromptInput {
 }
 
 /** Build the system prompt for one chat session. */
-export function chatSystemPrompt({ today, context }: SystemPromptInput): string {
+export function chatSystemPrompt({
+  today,
+  context,
+  semanticSearchEnabled,
+}: SystemPromptInput): string {
   return [
     'You are Reflect’s assistant, embedded in the user’s personal note graph.',
     `Today’s date is ${today}. Daily notes are markdown files named daily/YYYY-MM-DD.md; other notes live under notes/.`,
@@ -25,7 +35,7 @@ export function chatSystemPrompt({ today, context }: SystemPromptInput): string 
     '',
     'Grounding rules:',
     '- When a question could be answered by the user’s notes, look them up before answering: search_notes finds notes by topic or keyword, list_daily_notes finds daily notes in a date range (questions like “yesterday” or “last week”), and list_recent_notes shows what was edited lately. Call read_notes when you need notes’ full content.',
-    '- search_notes matches on both keywords and meaning, so it finds relevant notes even when your wording differs from theirs — repeating a search with reordered or reworded terms returns the same notes. To widen the net, raise its “limit” (up to 20) in one call instead of searching again. When you need the full text of several notes, pass all their paths to read_notes in one call rather than reading them one at a time.',
+    searchNotesGuidance(semanticSearchEnabled),
     '- You have a limited number of tool rounds per question, so gather efficiently: once the results cover the question, stop searching and write the answer.',
     '- For “what have I written or worked on lately?”, call list_recent_notes with no tag — pass a tag only when the user names one. Tool inputs are plain values; there is no wildcard or operator syntax (never pass “*”).',
     '- Ground answers in what the tools return. If the notes don’t cover something, say so plainly instead of guessing.',
@@ -34,6 +44,16 @@ export function chatSystemPrompt({ today, context }: SystemPromptInput): string 
     '',
     'Style: answer in concise markdown. Prefer short paragraphs and lists over headings.',
   ].join('\n')
+}
+
+/** The search-specific prompt rule, matching the active retrieval mode. */
+function searchNotesGuidance(semanticSearchEnabled: boolean): string {
+  const shared =
+    'To widen the net, raise its “limit” (up to 20) in one call instead of searching again. When you need the full text of several notes, pass all their paths to read_notes in one call rather than reading them one at a time.'
+  if (semanticSearchEnabled) {
+    return `- search_notes matches on both keywords and meaning, so it finds relevant notes even when your wording differs from theirs — repeating a search with reordered or reworded terms returns the same notes. ${shared}`
+  }
+  return `- search_notes uses lexical full-text search over titles and note bodies. Choose the user’s own likely wording, names, and keywords; if the first search is too narrow, try one broader lexical query before reading notes. ${shared}`
 }
 
 /**

--- a/packages/core/src/ai/chat/tools.test.ts
+++ b/packages/core/src/ai/chat/tools.test.ts
@@ -146,7 +146,20 @@ describe('search_notes', () => {
       },
     })
     await runSearch(tools, { query: 'atlas' })
-    expect(seen).toEqual([{ limit: 8, excludePrivateContent: true }])
+    expect(seen).toEqual([{ limit: 8, mode: 'hybrid', excludePrivateContent: true }])
+  })
+
+  it('uses lexical retrieval when semantic search is disabled', async () => {
+    const seen: Array<RetrieveOptions | undefined> = []
+    const tools = buildNoteTools({
+      semanticSearchEnabled: false,
+      retrieveFn: async (_query, options) => {
+        seen.push(options)
+        return []
+      },
+    })
+    await runSearch(tools, { query: 'atlas' })
+    expect(seen).toEqual([{ limit: 8, mode: 'lexical', excludePrivateContent: true }])
   })
 
   it('drops private hits entirely — not even the title goes out', async () => {

--- a/packages/core/src/ai/chat/tools.ts
+++ b/packages/core/src/ai/chat/tools.ts
@@ -61,6 +61,14 @@ export interface NoteToolDeps {
   listDailyNotesFn?: (range: DailyNotesRange) => Promise<DailyNoteRow[]>
 }
 
+export interface BuildNoteToolsOptions extends NoteToolDeps {
+  /**
+   * Whether note search can use embeddings for meaning-based recall. When
+   * false, `search_notes` stays lexical so disabled semantic search is honored.
+   */
+  semanticSearchEnabled?: boolean
+}
+
 export interface SearchNotesOutput {
   hits: CloudSafe<CloudSearchHit>[]
 }
@@ -156,14 +164,17 @@ function listingCandidate(
 }
 
 /**
- * Build the chat tool set. `deps` is a test seam; production callers omit it
- * and the tools run over the shared retrieval layer and the live filesystem.
+ * Build the chat tool set. Optional effect overrides are a test seam;
+ * production callers omit them and the tools run over the shared retrieval
+ * layer and the live filesystem.
  */
-export function buildNoteTools(deps: NoteToolDeps = {}) {
-  const retrieveFn = deps.retrieveFn ?? retrieve
-  const readNoteFn = deps.readNoteFn ?? readNote
-  const listRecentNotesFn = deps.listRecentNotesFn ?? listRecentNotes
-  const listDailyNotesFn = deps.listDailyNotesFn ?? listDailyNotes
+export function buildNoteTools(options: BuildNoteToolsOptions = {}) {
+  const retrieveFn = options.retrieveFn ?? retrieve
+  const readNoteFn = options.readNoteFn ?? readNote
+  const listRecentNotesFn = options.listRecentNotesFn ?? listRecentNotes
+  const listDailyNotesFn = options.listDailyNotesFn ?? listDailyNotes
+  const searchMode: RetrieveOptions['mode'] =
+    options.semanticSearchEnabled === false ? 'lexical' : 'hybrid'
 
   // The gate's live privacy probe: the index flag on a hit can lag a
   // just-saved `private: true`, so each candidate's frontmatter is re-read
@@ -215,14 +226,12 @@ export function buildNoteTools(deps: NoteToolDeps = {}) {
 
   return {
     search_notes: tool({
-      description:
-        'Search the user’s notes by meaning and keywords. Returns the best-matching ' +
-        'notes with short snippets. Queries are plain language — there is no wildcard ' +
-        'or operator syntax. Private notes are excluded.',
+      description: searchNotesDescription(options.semanticSearchEnabled !== false),
       inputSchema: searchNotesInput,
       execute: async ({ query, limit }): Promise<SearchNotesOutput> => {
         const hits = await retrieveFn(query, {
           limit: limit ?? DEFAULT_SEARCH_LIMIT,
+          mode: searchMode,
           excludePrivateContent: true,
         })
         return { hits: await cloudSafeSearchHits(hits, isPrivateLive) }
@@ -280,6 +289,16 @@ export function buildNoteTools(deps: NoteToolDeps = {}) {
       },
     }),
   }
+}
+
+/** Tool description for the active search mode. */
+function searchNotesDescription(semanticSearchEnabled: boolean): string {
+  const suffix =
+    'Returns the best-matching notes with short snippets. Queries are plain language — there is no wildcard or operator syntax. Private notes are excluded.'
+  if (semanticSearchEnabled) {
+    return `Search the user’s notes by meaning and keywords. ${suffix}`
+  }
+  return `Search the user’s notes with lexical full-text search over titles and note bodies. ${suffix}`
 }
 
 /** The tool set type, for typed stream parts in the chat engine. */


### PR DESCRIPTION
## Summary
- Thread the semantic search setting into chat turns.
- Switch the chat system prompt and search_notes tool description between semantic and lexical guidance.
- Force chat search retrieval to lexical mode when semantic search is disabled.

## Verification
- pnpm --filter @reflect/core test -- --run src/ai/chat/system-prompt.test.ts src/ai/chat/tools.test.ts src/ai/chat/stream-chat.test.ts
- pnpm --filter @reflect/desktop test -- --run src/providers/chat-provider.test.tsx
- pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted wiring of an existing settings flag through chat retrieval and prompt text; behavior change is intentional when semantic search is off, with tests covering the paths.
> 
> **Overview**
> Chat now respects the user’s **semantic search** setting end-to-end instead of always behaving as if hybrid/semantic recall were on.
> 
> The desktop **ChatProvider** reads `settings.semanticSearchEnabled` at send time (via a ref) and passes it into `streamChat`. **Core** threads that flag through `streamChat` / `streamChatTurn` into `chatSystemPrompt` and `buildNoteTools`: when semantic search is off, the system prompt and `search_notes` tool description describe **lexical** full-text search only, and retrieval runs with `mode: 'lexical'` instead of `hybrid`. When it’s on, behavior and copy stay aligned with keyword-plus-meaning hybrid search.
> 
> Tests cover the new prompt branches, lexical vs hybrid retrieve options, and that the provider forwards the setting into `streamChat`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31796dd213a32a1d007de50240c42845d5df1304. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->