### PR TITLE
Shrink Tasks header action text

### DIFF
--- a/apps/desktop/src/components/tasks/task-filters-menu.tsx
+++ b/apps/desktop/src/components/tasks/task-filters-menu.tsx
@@ -40,7 +40,7 @@ export function TaskFiltersMenu({
   return (
     <DropdownMenu open={open} onOpenChange={onOpenChange}>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="window-drag-control font-normal text-text-muted">
+        <Button variant="ghost" className="window-drag-control text-xs font-normal text-text-muted">
           <ListFilter aria-hidden className="size-4" />
           Task filters
         </Button>

--- a/apps/desktop/src/components/tasks/tasks-screen.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.tsx
@@ -248,7 +248,7 @@ export function TasksScreen(): ReactElement {
             today={today}
             onSchedule={onSchedule}
           >
-            <Button type="button" variant="ghost" className="window-drag-control text-text-muted">
+            <Button type="button" variant="ghost" className="window-drag-control text-xs text-text-muted">
               <CalendarClock aria-hidden className="size-4" />
               Schedule ({selection.selectedCount})
             </Button>
@@ -260,7 +260,7 @@ export function TasksScreen(): ReactElement {
             variant="ghost"
             onClick={onConvertToBullet}
             title="Drop the checkbox, keeping the line as a plain bullet — leaves the Tasks list"
-            className="window-drag-control text-text-muted"
+            className="window-drag-control text-xs text-text-muted"
           >
             <List aria-hidden className="size-4" />
             Convert to bullet ({selection.selectedCount})
@@ -271,7 +271,7 @@ export function TasksScreen(): ReactElement {
             type="button"
             variant="ghost"
             onClick={actions.archive}
-            className="window-drag-control text-text-muted"
+            className="window-drag-control text-xs text-text-muted"
           >
             <Archive aria-hidden className="size-4" />
             Archive ({recentlyCompleted.length})


### PR DESCRIPTION
## Summary
- Add `text-xs` to the Tasks header action buttons
- Match the Task filters trigger text size with the other header actions

## Testing
- `pnpm check`
- `pnpm build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class changes on Tasks header buttons with no logic or data impact.
> 
> **Overview**
> Adds **`text-xs`** to the Tasks header ghost buttons so Schedule, Convert to bullet, Archive, and **Task filters** use the same smaller label size.
> 
> No behavior, layout structure, or interaction changes—only typography on those toolbar actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca2e9dbeddbbddcb39cdb675080338f587bc47ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->