### PR TITLE
Document proactive PR creation for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,9 @@ into it for a stable release. Versions on `next` carry a prerelease suffix
 (`0.2.0-beta.1`), which the release pipeline publishes as GitHub pre-releases — see
 [docs/macos-distribution.md](docs/macos-distribution.md).
 
+When a requested change is complete and verified, proactively create a PR unless
+the user has asked you not to.
+
 1. Make your changes
 2. Run typecheck (`pnpm typecheck`)
 3. Run lint (`pnpm lint`) — fix any errors; `pnpm lint:fix` auto-fixes where possible


### PR DESCRIPTION
## Summary
- Add AGENTS guidance for agents to proactively create a PR after completing and verifying requested changes

## Testing
- Not run (docs-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent workflow guidance; no runtime or product code affected.
> 
> **Overview**
> Adds a **Development workflow** rule in `AGENTS.md`: after a requested change is complete and verified, agents should **proactively open a PR**, unless the user asked not to.
> 
> This sits alongside the existing branch/PR guidance (`next` vs `master`) and does not change build, test, or lint steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c350d1b7ac1db3e86b925c8680c8d5741c18c6e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->