### PR TITLE
Promote exact-title matches in search ordering

### DIFF
--- a/apps/cli/src/commands/output.rs
+++ b/apps/cli/src/commands/output.rs
@@ -46,7 +46,8 @@ pub struct HitJson {
     pub path: String,
     pub title: String,
     pub snippet: String,
-    /// bm25 rank (more negative = better match).
+    /// bm25 rank component (more negative = better match); final ordering also
+    /// considers exact-title, pinned, recency, and path.
     pub score: f64,
 }
 

--- a/apps/cli/src/commands/search.rs
+++ b/apps/cli/src/commands/search.rs
@@ -13,6 +13,7 @@ use crate::commands::warn;
 use crate::error::CliError;
 use crate::graph::Graph;
 use crate::index::{detect_staleness, open_read_only, IndexOpen};
+use crate::keys::fold_key;
 use crate::note_file::parse_note_meta;
 use crate::search::{build_fts_match, search_index, SearchHit};
 
@@ -49,8 +50,9 @@ pub fn run(graph: &Graph, json: bool, query: &str, limit: usize) -> Result<(), C
         ));
     }
 
+    let title_key = fold_key(query);
     let hits: Vec<SearchHit> = match build_fts_match(query) {
-        Some(match_expr) => search_index(&opened.conn, &match_expr, limit)?,
+        Some(match_expr) => search_index(&opened.conn, &match_expr, &title_key, limit)?,
         None => Vec::new(),
     };
     let hits: Vec<SearchHit> = hits

--- a/apps/cli/src/search.rs
+++ b/apps/cli/src/search.rs
@@ -1,9 +1,9 @@
 //! Lexical search over the FTS index. The `MATCH` expression is built exactly
 //! like `buildFtsMatch` (`packages/core/src/indexing/search-query.ts`) and
 //! ranking matches the desktop's palette search (`filtered-search.ts`):
-//! title-boosted bm25 with the same column weights, so the same query against
-//! the same index orders the same in the CLI and the app. The CLI adds its
-//! privacy filter (`notes.is_private = 0`) and FTS5 `snippet()`.
+//! exact-title promotion, title-boosted bm25, pinned, recency, and stable path
+//! ordering. The CLI adds its privacy filter (`notes.is_private = 0`) and FTS5
+//! `snippet()`.
 
 use rusqlite::{params, Connection};
 
@@ -31,7 +31,8 @@ pub struct SearchHit {
     pub title: String,
     /// FTS5 `snippet()` over the indexed plain-text body.
     pub snippet: String,
-    /// Title-boosted bm25 score (more negative = better match).
+    /// Title-boosted bm25 component (more negative = better match); final
+    /// ordering also considers exact-title, pinned, recency, and path.
     pub score: f64,
 }
 
@@ -44,6 +45,7 @@ const RANK_EXPR: &str = "bm25(search_fts, 0, 10.0, 1.0)";
 pub fn search_index(
     conn: &Connection,
     match_expr: &str,
+    title_key: &str,
     limit: usize,
 ) -> Result<Vec<SearchHit>, CliError> {
     let mut statement = conn.prepare(&format!(
@@ -52,10 +54,14 @@ pub fn search_index(
          FROM search_fts
          JOIN notes ON notes.path = search_fts.path
          WHERE search_fts MATCH ?1 AND notes.is_private = 0
-         ORDER BY {RANK_EXPR}
-         LIMIT ?2",
+         ORDER BY CASE WHEN notes.title_key = ?2 THEN 0 ELSE 1 END,
+                  {RANK_EXPR},
+                  notes.is_pinned DESC,
+                  notes.mtime DESC,
+                  notes.path
+         LIMIT ?3",
     ))?;
-    let rows = statement.query_map(params![match_expr, limit as i64], |row| {
+    let rows = statement.query_map(params![match_expr, title_key, limit as i64], |row| {
         Ok(SearchHit {
             path: row.get(0)?,
             title: row.get(1)?,

--- a/apps/cli/tests/cli.rs
+++ b/apps/cli/tests/cli.rs
@@ -257,6 +257,61 @@ fn search_boosts_title_matches_over_body_matches() {
 }
 
 #[test]
+fn search_promotes_exact_title_matches_before_body_strength() {
+    let fixture = graph();
+    fixture.write_note("notes/title-hit.md", "# Quokka\nplain note\n");
+    fixture.write_note(
+        "notes/body-hit.md",
+        "# Unrelated\nquokka quokka quokka quokka quokka\n",
+    );
+    fixture.build_index();
+
+    let text = stdout(&reflect(&fixture, &["search", "quokka"]));
+    let title_pos = text.find("notes/title-hit.md").unwrap();
+    let body_pos = text.find("notes/body-hit.md").unwrap();
+    assert!(
+        title_pos < body_pos,
+        "expected the exact title match ranked first:\n{text}"
+    );
+}
+
+#[test]
+fn search_uses_pinned_and_recency_after_bm25_ties() {
+    let fixture = graph();
+    fixture.write_note("notes/alpha.md", "# Same\nquokka\n");
+    fixture.write_note("notes/pinned.md", "# Same\nquokka\n");
+    fixture.write_note("notes/recent.md", "# Same\nquokka\n");
+    fixture.build_index();
+
+    let conn = rusqlite::Connection::open(fixture.root().join(".reflect/index.sqlite")).unwrap();
+    conn.execute(
+        "UPDATE notes SET is_pinned = 1, mtime = 1 WHERE path = 'notes/pinned.md'",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "UPDATE notes SET is_pinned = 0, mtime = 100 WHERE path = 'notes/recent.md'",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "UPDATE notes SET is_pinned = 0, mtime = 10 WHERE path = 'notes/alpha.md'",
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    let text = stdout(&reflect(&fixture, &["search", "quokka"]));
+    let pinned_pos = text.find("notes/pinned.md").unwrap();
+    let recent_pos = text.find("notes/recent.md").unwrap();
+    let alpha_pos = text.find("notes/alpha.md").unwrap();
+    assert!(
+        pinned_pos < recent_pos && recent_pos < alpha_pos,
+        "expected pinned before recent before older when bm25 ties:\n{text}"
+    );
+}
+
+#[test]
 fn search_without_an_index_exits_4() {
     let fixture = graph();
     fixture.write_note("notes/a.md", "anything\n");

--- a/packages/core/src/indexing/filtered-search.test.ts
+++ b/packages/core/src/indexing/filtered-search.test.ts
@@ -84,4 +84,25 @@ describe('searchWithFilters', () => {
     expect(sql).not.toContain('search_fts')
     expect(args['params']).toEqual(['work', 1, startOfLocalDay('2026-01-01'), 12])
   })
+
+  it('ranks text searches by exact title, bm25, pinned, recency, then path', async () => {
+    mockInvoke.mockResolvedValueOnce([
+      { path: 'notes/rust.md', title: 'Rust Notes', daily_date: null, snippet: 'about rust' },
+    ])
+
+    await searchWithFilters(parseSearchQuery('Rust Notes'), 12)
+
+    const [command, args] = mockInvoke.mock.calls[0]!
+    expect(command).toBe('db_query')
+    const query = String(args['sql'])
+    expect(query).toContain('inner join "search_fts"')
+    expect(query).toContain('CASE WHEN notes.title_key =')
+    expect(query).toContain('bm25(search_fts, 0, 10.0, 1.0)')
+    expect(query).toContain('"notes"."is_pinned" desc')
+    expect(query).toContain('"notes"."mtime" desc')
+    expect(query).toContain('"notes"."path"')
+    expect(args['params']).toEqual(
+      expect.arrayContaining(['rust notes', '"Rust" "Notes"', 12]),
+    )
+  })
 })

--- a/packages/core/src/indexing/filtered-search.ts
+++ b/packages/core/src/indexing/filtered-search.ts
@@ -1,6 +1,7 @@
 import { sql } from 'kysely'
 import { db } from './db'
 import type { ParsedSearchQuery } from './filter-query'
+import { foldKey } from '../markdown'
 import { resolveWikiTarget } from './queries'
 import { HIGHLIGHT_END, HIGHLIGHT_START } from './search'
 import { buildFtsMatch } from './search-query'
@@ -8,9 +9,10 @@ import { buildFtsMatch } from './search-query'
 /**
  * The one palette search (Plan 08): parsed filter tokens become composable
  * predicates on `notes` (EXISTS subqueries against `tags` and the `backlinks`
- * view), with free text constraining and ranking through FTS (title-boosted
- * bm25, highlighted snippets). Filters may be empty — plain text search is the
- * degenerate case, so there is exactly one search path to keep correct.
+ * view), with free text constraining and ranking through FTS (exact-title
+ * promotion, title-boosted bm25, highlighted snippets). Filters may be empty —
+ * plain text search is the degenerate case, so there is exactly one search path
+ * to keep correct.
  * Without text, results order by recency — a (possibly filtered) recall feed.
  */
 
@@ -169,8 +171,12 @@ export async function searchWithFilters(
     return rows.map((row) => ({ ...row, snippet: null }))
   }
 
-  // Free text: constrain + rank + snippet through FTS (title-boosted bm25,
-  // same weights as the unfiltered palette search).
+  // Free text: constrain + rank + snippet through FTS. The exact-title
+  // promotion mirrors V1's strongest useful signal without expanding recall:
+  // prefix/typeahead still belongs to suggestWikiTargets.
+  const titleKey = foldKey(parsed.text)
+  const titleRank = sql<number>`CASE WHEN notes.title_key = ${titleKey} THEN 0 ELSE 1 END`
+  const bm25Rank = sql<number>`bm25(search_fts, 0, 10.0, 1.0)`
   const rows = await query
     .innerJoin('searchFts', 'searchFts.path', 'notes.path')
     .select(
@@ -179,7 +185,11 @@ export async function searchWithFilters(
       ),
     )
     .where(sql<boolean>`search_fts MATCH ${match}`)
-    .orderBy(sql`bm25(search_fts, 0, 10.0, 1.0)`)
+    .orderBy(titleRank)
+    .orderBy(bm25Rank)
+    .orderBy('notes.isPinned', 'desc')
+    .orderBy('notes.mtime', 'desc')
+    .orderBy('notes.path')
     .execute()
   return rows
 }

--- a/packages/core/src/indexing/pipeline.test.ts
+++ b/packages/core/src/indexing/pipeline.test.ts
@@ -218,8 +218,16 @@ describe('Kysely → db_query bridge', () => {
     const hits = await searchNotes('hello')
     const query = mockInvoke.mock.calls.find(([cmd]) => cmd === 'db_query')
     const sql = (query![1] as { sql: string }).sql
+    const params = (query![1] as { params: unknown[] }).params
     expect(sql).toContain('search_fts')
     expect(sql.toLowerCase()).toContain('match')
+    expect(sql).toContain('inner join "notes"')
+    expect(sql).toContain('CASE WHEN notes.title_key =')
+    expect(sql).toContain('bm25(search_fts, 0, 10.0, 1.0)')
+    expect(sql).toContain('"notes"."is_pinned" desc')
+    expect(sql).toContain('"notes"."mtime" desc')
+    expect(sql).toContain('"notes"."path"')
+    expect(params).toEqual(expect.arrayContaining(['hello', '"hello"', 50]))
     expect(hits).toEqual([{ path: 'notes/a.md', title: 'A' }])
   })
 

--- a/packages/core/src/indexing/queries.ts
+++ b/packages/core/src/indexing/queries.ts
@@ -2,6 +2,7 @@ import type { Database } from '@reflect/db'
 import { sql, type Selectable } from 'kysely'
 import { readNote } from '../graph/commands'
 import {
+  foldKey,
   foldTag,
   normalizeWikiTarget,
   resolveWikiLinkAsync,
@@ -526,11 +527,19 @@ export async function searchNotes(query: string, limit = 50): Promise<SearchHit[
   if (match === null) {
     return [] // nothing to search (FTS5 also errors on an empty MATCH).
   }
+  const titleKey = foldKey(query)
+  const titleRank = sql<number>`CASE WHEN notes.title_key = ${titleKey} THEN 0 ELSE 1 END`
+  const bm25Rank = sql<number>`bm25(search_fts, 0, 10.0, 1.0)`
   return db
     .selectFrom('searchFts')
-    .select(['path', 'title'])
+    .innerJoin('notes', 'notes.path', 'searchFts.path')
+    .select(['searchFts.path as path', 'searchFts.title as title'])
     .where(sql<boolean>`search_fts MATCH ${match}`)
-    .orderBy(sql`rank`)
+    .orderBy(titleRank)
+    .orderBy(bm25Rank)
+    .orderBy('notes.isPinned', 'desc')
+    .orderBy('notes.mtime', 'desc')
+    .orderBy('notes.path')
     .limit(limit)
     .execute()
 }


### PR DESCRIPTION
## Summary
- promote exact title matches in V2 lexical search before bm25 ranking
- add pinned, recency, and path tie-breakers across core search and CLI search
- cover the ranking contract with core and CLI tests

## Testing
- pnpm --filter @reflect/core test -- src/indexing/filtered-search.test.ts src/indexing/pipeline.test.ts
- pnpm --filter @reflect/desktop test -- apps/desktop/src/components/command-palette/command-palette.test.tsx apps/desktop/src/components/command-palette/entries.test.ts
- cargo test -p reflect-cli search
- cargo test -p reflect-cli
- pnpm typecheck
- pnpm lint
- pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Search result ordering changes across the desktop palette, core FTS API, and CLI; behavior is covered by tests but users may see different hit order for the same query.
> 
> **Overview**
> Lexical search **ordering** is updated so free-text queries rank notes whose folded title equals the query ahead of bm25 strength alone, then break ties with **pinned**, **mtime**, and **path**—matching V1’s strongest title signal without changing recall.
> 
> The same `ORDER BY` contract is applied in **`searchWithFilters`** (palette), **`searchNotes`**, and the **CLI** `search_index` SQL (with `foldKey` / `fold_key` on the query text). JSON/human CLI output docs now clarify that `score` is only the bm25 component.
> 
> **Tests** lock the SQL shape in core and add CLI integration cases for exact-title promotion and pinned/recency tie-breaking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8899f29a9669ceb3efcecc7bdba96c016baaa75e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->