### PR TITLE
feat(search): promote exact-title matches in lexical ranking

### DIFF
--- a/apps/cli/src/commands/search.rs
+++ b/apps/cli/src/commands/search.rs
@@ -13,6 +13,7 @@ use crate::commands::warn;
 use crate::error::CliError;
 use crate::graph::Graph;
 use crate::index::{detect_staleness, open_read_only, IndexOpen};
+use crate::keys::fold_key;
 use crate::note_file::parse_note_meta;
 use crate::search::{build_fts_match, search_index, SearchHit};
 
@@ -50,7 +51,7 @@ pub fn run(graph: &Graph, json: bool, query: &str, limit: usize) -> Result<(), C
     }
 
     let hits: Vec<SearchHit> = match build_fts_match(query) {
-        Some(match_expr) => search_index(&opened.conn, &match_expr, limit)?,
+        Some(match_expr) => search_index(&opened.conn, &match_expr, &fold_key(query), limit)?,
         None => Vec::new(),
     };
     let hits: Vec<SearchHit> = hits

--- a/apps/cli/src/search.rs
+++ b/apps/cli/src/search.rs
@@ -1,9 +1,11 @@
 //! Lexical search over the FTS index. The `MATCH` expression is built exactly
 //! like `buildFtsMatch` (`packages/core/src/indexing/search-query.ts`) and
-//! ranking matches the desktop's palette search (`filtered-search.ts`):
-//! title-boosted bm25 with the same column weights, so the same query against
-//! the same index orders the same in the CLI and the app. The CLI adds its
-//! privacy filter (`notes.is_private = 0`) and FTS5 `snippet()`.
+//! ranking matches the desktop's palette search (`filtered-search.ts`): an
+//! exact title match leads, then title-boosted bm25 with the same column
+//! weights, then pinned and recency as deterministic tiebreakers and `path`
+//! as the stable fallback — so the same query against the same index orders
+//! the same in the CLI and the app. The CLI adds its privacy filter
+//! (`notes.is_private = 0`) and FTS5 `snippet()`.
 
 use rusqlite::{params, Connection};
 
@@ -39,11 +41,16 @@ pub struct SearchHit {
 /// unranked, title boosted 10× over body. Must stay in lockstep.
 const RANK_EXPR: &str = "bm25(search_fts, 0, 10.0, 1.0)";
 
-/// Ranked, private-excluded search. The caller re-checks each hit's file
+/// Ranked, private-excluded search mirroring the desktop palette ordering
+/// (`filtered-search.ts`): exact title match first (`title_key = ?2`), then
+/// title-boosted bm25, then pinned and recency tiebreakers, then `path`. The
+/// returned `score` is the bm25 component only — it doesn't capture the
+/// exact-title or tiebreak ordering. The caller re-checks each hit's file
 /// frontmatter (the index row may lag a just-flagged note).
 pub fn search_index(
     conn: &Connection,
     match_expr: &str,
+    title_key: &str,
     limit: usize,
 ) -> Result<Vec<SearchHit>, CliError> {
     let mut statement = conn.prepare(&format!(
@@ -52,10 +59,14 @@ pub fn search_index(
          FROM search_fts
          JOIN notes ON notes.path = search_fts.path
          WHERE search_fts MATCH ?1 AND notes.is_private = 0
-         ORDER BY {RANK_EXPR}
-         LIMIT ?2",
+         ORDER BY CASE WHEN notes.title_key = ?2 THEN 0 ELSE 1 END,
+                  {RANK_EXPR},
+                  notes.is_pinned DESC,
+                  notes.mtime DESC,
+                  notes.path ASC
+         LIMIT ?3",
     ))?;
-    let rows = statement.query_map(params![match_expr, limit as i64], |row| {
+    let rows = statement.query_map(params![match_expr, title_key, limit as i64], |row| {
         Ok(SearchHit {
             path: row.get(0)?,
             title: row.get(1)?,

--- a/apps/cli/tests/cli.rs
+++ b/apps/cli/tests/cli.rs
@@ -256,6 +256,62 @@ fn search_boosts_title_matches_over_body_matches() {
     );
 }
 
+/// The V1-style exact-title boost (`filtered-search.ts`): a note whose title
+/// *is* the query ranks ahead of a louder lexical (bm25) match whose title only
+/// contains the query among other words — exact title is promoted before bm25.
+#[test]
+fn search_promotes_exact_title_over_a_stronger_lexical_match() {
+    let fixture = graph();
+    fixture.write_note("notes/exact.md", "# Zebra\na single zebra\n");
+    fixture.write_note(
+        "notes/loud.md",
+        "# Zebra Zebra Zebra Notes\nzebra zebra zebra zebra\n",
+    );
+    fixture.build_index();
+
+    let text = stdout(&reflect(&fixture, &["search", "zebra"]));
+    let exact_pos = text.find("notes/exact.md").unwrap();
+    let loud_pos = text.find("notes/loud.md").unwrap();
+    assert!(
+        exact_pos < loud_pos,
+        "expected the exact-title note ranked first:\n{text}"
+    );
+}
+
+/// Pinned and recency are tiebreakers *after* exact-title and bm25 ordering:
+/// two equally-ranked body hits order pinned-first, and pinned wins over a
+/// newer mtime (mirrors the desktop's lexical ordering).
+#[test]
+fn search_breaks_ties_by_pinned_then_recency() {
+    let fixture = graph();
+    fixture.write_note("notes/older-pinned.md", "# Notes\napricot apricot\n");
+    fixture.write_note("notes/newer-plain.md", "# Notes\napricot apricot\n");
+    fixture.build_index();
+
+    // Identical title + body → identical title-rank and bm25; only the
+    // tiebreakers differ. Pin the older note: pinned must win over recency.
+    let conn = rusqlite::Connection::open(fixture.root().join(".reflect/index.sqlite")).unwrap();
+    conn.execute(
+        "UPDATE notes SET mtime = 100, is_pinned = 1 WHERE path = 'notes/older-pinned.md'",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "UPDATE notes SET mtime = 200, is_pinned = 0 WHERE path = 'notes/newer-plain.md'",
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    let text = stdout(&reflect(&fixture, &["search", "apricot"]));
+    let pinned_pos = text.find("notes/older-pinned.md").unwrap();
+    let plain_pos = text.find("notes/newer-plain.md").unwrap();
+    assert!(
+        pinned_pos < plain_pos,
+        "expected the pinned note ranked before the newer unpinned note:\n{text}"
+    );
+}
+
 #[test]
 fn search_without_an_index_exits_4() {
     let fixture = graph();

--- a/packages/core/src/indexing/filtered-search.test.ts
+++ b/packages/core/src/indexing/filtered-search.test.ts
@@ -84,4 +84,45 @@ describe('searchWithFilters', () => {
     expect(sql).not.toContain('search_fts')
     expect(args['params']).toEqual(['work', 1, startOfLocalDay('2026-01-01'), 12])
   })
+
+  it('promotes exact title, then bm25, then pinned and recency on text search', async () => {
+    mockInvoke.mockResolvedValueOnce([
+      { path: 'notes/quokka.md', title: 'Quokka', daily_date: null, snippet: 'a …' },
+    ])
+
+    const hits = await searchWithFilters(parseSearchQuery('quokka'), 12)
+
+    expect(hits).toEqual([
+      { path: 'notes/quokka.md', title: 'Quokka', dailyDate: null, snippet: 'a …' },
+    ])
+
+    const [command, args] = mockInvoke.mock.calls[0]!
+    expect(command).toBe('db_query')
+    const sql = String(args['sql']).toLowerCase()
+    expect(sql).toContain('search_fts match')
+    // Exact-title rank leads, then title-boosted bm25, then the deterministic
+    // pinned/recency/path tiebreakers — in that order.
+    expect(sql).toContain('case when "notes"."title_key" =')
+    expect(sql).toContain('bm25(search_fts, 0, 10.0, 1.0)')
+    expect(sql).toContain('"notes"."is_pinned" desc')
+    expect(sql).toContain('"notes"."mtime" desc')
+    expect(sql).toContain('"notes"."path" asc')
+
+    const params = args['params'] as unknown[]
+    // The folded exact-title key and the literal FTS match expression.
+    expect(params).toContain('quokka')
+    expect(params).toContain('"quokka"')
+  })
+
+  it('folds the exact-title key the way titles were indexed', async () => {
+    mockInvoke.mockResolvedValueOnce([])
+
+    await searchWithFilters(parseSearchQuery('Quokka Habitat'), 12)
+
+    const [, args] = mockInvoke.mock.calls[0]!
+    const params = args['params'] as unknown[]
+    // foldKey('Quokka Habitat') — trimmed + lowercased — so it matches the
+    // stored `notes.title_key`, never the raw casing.
+    expect(params).toContain('quokka habitat')
+  })
 })

--- a/packages/core/src/indexing/filtered-search.ts
+++ b/packages/core/src/indexing/filtered-search.ts
@@ -1,4 +1,5 @@
 import { sql } from 'kysely'
+import { foldKey } from '../markdown'
 import { db } from './db'
 import type { ParsedSearchQuery } from './filter-query'
 import { resolveWikiTarget } from './queries'
@@ -8,10 +9,13 @@ import { buildFtsMatch } from './search-query'
 /**
  * The one palette search (Plan 08): parsed filter tokens become composable
  * predicates on `notes` (EXISTS subqueries against `tags` and the `backlinks`
- * view), with free text constraining and ranking through FTS (title-boosted
- * bm25, highlighted snippets). Filters may be empty — plain text search is the
- * degenerate case, so there is exactly one search path to keep correct.
- * Without text, results order by recency — a (possibly filtered) recall feed.
+ * view), with free text constraining and ranking through FTS. Free-text
+ * ranking promotes an exact title match (V1's strongest jump-to-note signal)
+ * ahead of every body hit, then orders by title-boosted bm25, with pinned and
+ * recency as deterministic tiebreakers. Filters may be empty — plain text
+ * search is the degenerate case, so there is exactly one search path to keep
+ * correct. Without text, results order by recency — a (possibly filtered)
+ * recall feed.
  */
 
 export interface FilteredSearchHit {
@@ -169,8 +173,13 @@ export async function searchWithFilters(
     return rows.map((row) => ({ ...row, snippet: null }))
   }
 
-  // Free text: constrain + rank + snippet through FTS (title-boosted bm25,
-  // same weights as the unfiltered palette search).
+  // Free text: constrain + rank + snippet through FTS. An exact title match
+  // leads (title-rank 0); within a rank class, title-boosted bm25 orders (same
+  // weights as the unfiltered palette search), then pinned and recency break
+  // ties, with `path` as the stable final fallback. The exact-title key is
+  // folded the same way titles were at index time, so it can never drift from
+  // the stored `notes.title_key`.
+  const titleKey = foldKey(parsed.text)
   const rows = await query
     .innerJoin('searchFts', 'searchFts.path', 'notes.path')
     .select(
@@ -179,7 +188,11 @@ export async function searchWithFilters(
       ),
     )
     .where(sql<boolean>`search_fts MATCH ${match}`)
+    .orderBy(sql`case when "notes"."title_key" = ${titleKey} then 0 else 1 end`)
     .orderBy(sql`bm25(search_fts, 0, 10.0, 1.0)`)
+    .orderBy('notes.isPinned', 'desc')
+    .orderBy('notes.mtime', 'desc')
+    .orderBy('notes.path', 'asc')
     .execute()
   return rows
 }

--- a/packages/core/src/indexing/pipeline.test.ts
+++ b/packages/core/src/indexing/pipeline.test.ts
@@ -229,6 +229,19 @@ describe('Kysely → db_query bridge', () => {
     expect(mockInvoke.mock.calls.length).toBe(before)
   })
 
+  it('searchNotes ranks by exact title, bm25, pinned and recency', async () => {
+    await searchNotes('hello')
+    const query = mockInvoke.mock.calls.find(([cmd]) => cmd === 'db_query')
+    const sql = String((query![1] as { sql: string }).sql).toLowerCase()
+    // Same ranked join/order contract as the palette's `searchWithFilters`.
+    expect(sql).toContain('inner join "notes"')
+    expect(sql).toContain('case when "notes"."title_key" =')
+    expect(sql).toContain('bm25(search_fts, 0, 10.0, 1.0)')
+    expect(sql).toContain('"notes"."is_pinned" desc')
+    expect(sql).toContain('"notes"."mtime" desc')
+    expect(sql).toContain('"notes"."path" asc')
+  })
+
   it('getBacklinks maps snake_case rows back to camelCase', async () => {
     const backlinks = await getBacklinks('notes/a.md')
     expect(backlinks).toEqual([

--- a/packages/core/src/indexing/queries.ts
+++ b/packages/core/src/indexing/queries.ts
@@ -2,6 +2,7 @@ import type { Database } from '@reflect/db'
 import { sql, type Selectable } from 'kysely'
 import { readNote } from '../graph/commands'
 import {
+  foldKey,
   foldTag,
   normalizeWikiTarget,
   resolveWikiLinkAsync,
@@ -520,17 +521,31 @@ export async function getIndexMeta(key: string): Promise<string | null> {
 /** A full-text search result: the note's path and title. */
 export type SearchHit = Pick<Selectable<Database['searchFts']>, 'path' | 'title'>
 
-/** Full-text search over title + body (FTS5 `MATCH`, ranked). */
+/**
+ * Full-text search over title + body (FTS5 `MATCH`), ranked like the palette's
+ * lexical search (`searchWithFilters` in `filtered-search.ts`): an exact title
+ * match leads, then title-boosted bm25, then pinned and recency as
+ * deterministic tiebreakers, with `path` as the stable final fallback. The
+ * `notes` join supplies the title-rank/pinned/recency columns; the exact-title
+ * key is folded the same way titles were at index time so it can't drift from
+ * the stored `notes.title_key`.
+ */
 export async function searchNotes(query: string, limit = 50): Promise<SearchHit[]> {
   const match = buildFtsMatch(query)
   if (match === null) {
     return [] // nothing to search (FTS5 also errors on an empty MATCH).
   }
+  const titleKey = foldKey(query)
   return db
     .selectFrom('searchFts')
-    .select(['path', 'title'])
+    .innerJoin('notes', 'notes.path', 'searchFts.path')
+    .select(['searchFts.path', 'searchFts.title'])
     .where(sql<boolean>`search_fts MATCH ${match}`)
-    .orderBy(sql`rank`)
+    .orderBy(sql`case when "notes"."title_key" = ${titleKey} then 0 else 1 end`)
+    .orderBy(sql`bm25(search_fts, 0, 10.0, 1.0)`)
+    .orderBy('notes.isPinned', 'desc')
+    .orderBy('notes.mtime', 'desc')
+    .orderBy('notes.path', 'asc')
     .limit(limit)
     .execute()
 }


### PR DESCRIPTION
## What

Restores the best part of Reflect V1's search feel — typing a note's exact title jumps it to the top — while keeping V2's architecture (literal-FTS index, typed filter grammar, hybrid semantic RRF) untouched.

Non-empty text searches now order by:

1. **exact title match** against `notes.title_key` (the V1 jump-to-note signal)
2. title-boosted FTS relevance — existing `bm25(search_fts, 0, 10.0, 1.0)`
3. `is_pinned DESC` — soft tiebreaker
4. `mtime DESC` — soft tiebreaker
5. `path ASC` — stable fallback

The exact-title key is computed with `foldKey(query)`, so it folds identically to the keys written to `notes.title_key` at index time and can never drift. Tag-only / no-text filtered recall feeds are unchanged — still recency-ordered, never touching `search_fts`.

## Why

V2's lexical ranking was bare bm25 (and a stray `ORDER BY rank` in a second helper), so an exact title match could lose to a body that merely repeats the term more often. This adds one explicit, testable hard boost — exact title — plus deterministic tiebreakers, matching V1's user-facing feel without copying its numeric multipliers.

## Changed

Applied the same ordering across all three search paths so they can't diverge:

- **`searchWithFilters`** ([`filtered-search.ts`](../blob/claude/loving-shtern-b7a9df/packages/core/src/indexing/filtered-search.ts)) — the desktop palette's one search path.
- **`searchNotes`** ([`queries.ts`](../blob/claude/loving-shtern-b7a9df/packages/core/src/indexing/queries.ts)) — the second exported helper; now joins `notes` and shares the same contract (was `ORDER BY rank`). Public `SearchHit` shape unchanged.
- **`reflect search` CLI** ([`search.rs`](../blob/claude/loving-shtern-b7a9df/apps/cli/src/search.rs) + `commands/search.rs`) — folded query key threaded into `search_index`. JSON `score` stays the bm25 component (doc-commented as such).

Hybrid semantic search benefits automatically: the improved lexical leg feeds the existing RRF fusion, with the distance cutoff and private-content stripping unchanged.

## Reviewer notes

- Pinned/recency are **soft** signals — they only order within an equal title-rank + bm25 class and never beat an exact-title or stronger-bm25 hit.
- Out of scope (follow-ups, per plan): asset FTS, title-prefix result expansion, alias joins in filtered search.
- Palette assembly (title/wiki suggestions leading unfiltered search, filtered mode = "hits are the list") is unchanged.

## Tests

- Core: `filtered-search.test.ts` (exact-title CASE + bm25 + pinned/recency/path ordering; exact-title key is the *folded* query; tag-only paths still skip `search_fts`) and `pipeline.test.ts` (`searchNotes` compiles the same ranked join/order).
- CLI: `cli.rs` — exact-title note outranks a louder body/title bm25 hit; pinned beats a newer unpinned note on a tie.

```
vitest run filtered-search.test.ts pipeline.test.ts   → 23 passed
cargo test -p reflect-cli                             → 24 passed
command-palette desktop tests                         → 30 passed
pnpm typecheck                                        → clean
pnpm lint                                             → 0 errors
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Search result ordering only; behavior is mirrored across known code paths with new regression tests and no auth, privacy, or index-write changes.
> 
> **Overview**
> Lexical search now **ranks exact title matches first** (query folded with `foldKey` against `notes.title_key`), then the existing title-boosted **bm25** weights, then **pinned → mtime → path** as tiebreakers—restoring V1-style “type the note title and it jumps to the top” without changing FTS construction or filter-only recall (still recency-ordered, no FTS).
> 
> The **same ORDER BY contract** is applied on all three paths so CLI and desktop stay aligned: palette **`searchWithFilters`**, exported **`searchNotes`** (replaces `ORDER BY rank`, adds `notes` join), and **`reflect search`** (`search_index` takes the folded title key; JSON `score` remains bm25-only).
> 
> Tests assert SQL ordering in core and end-to-end ranking in the CLI (exact title vs louder bm25; pinned vs newer on ties).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da19298a9e7f98f97ca2753e8720558a2cb4aaa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->