### PR TITLE
Upgrade meowdown packages for the desktop editor

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,8 +18,8 @@
   "dependencies": {
     "@lezer/common": "^1.5.2",
     "@lezer/markdown": "^1.6.4",
-    "@meowdown/core": "0.8.1",
-    "@meowdown/react": "0.8.1",
+    "@meowdown/core": "0.9.0",
+    "@meowdown/react": "0.9.0",
     "@prosekit/core": "^0.12.3",
     "@prosekit/pm": "^0.1.18",
     "@prosekit/react": "^0.8.0-beta.0",

--- a/apps/desktop/src/editor/bullet-after-heading-keymap.test.ts
+++ b/apps/desktop/src/editor/bullet-after-heading-keymap.test.ts
@@ -14,7 +14,7 @@ const editor = createEditor({ extension: defineEditorExtension() })
 
 /** A state holding `md`, with the caret at `pos(doc)`. */
 function stateAt(markdown: string, pos: (doc: ReturnType<typeof markdownToDoc>) => number): EditorState {
-  const doc = markdownToDoc(editor, markdown)
+  const doc = markdownToDoc(markdown)
   const base = EditorState.create({ schema: editor.schema, doc })
   return base.apply(base.tr.setSelection(TextSelection.create(doc, pos(doc))))
 }

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -269,7 +269,7 @@ body {
   font-size: inherit;
 }
 
-/* meowdown 0.8.1 ships a per-block gutter handle (a grip for drag-reordering and
+/* meowdown ships a per-block gutter handle (a grip for drag-reordering and
    a "+" add button). Reflect doesn't use block reordering — and the grip showed
    up beside the Tasks inline editor — so hide the whole gutter. Matched by the
    stable `meow_<Name>_` class prefix so a meowdown hash bump doesn't revive it.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,11 +27,11 @@ importers:
         specifier: ^1.6.4
         version: 1.6.4
       '@meowdown/core':
-        specifier: 0.8.1
-        version: 0.8.1(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
+        specifier: 0.9.0
+        version: 0.9.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
       '@meowdown/react':
-        specifier: 0.8.1
-        version: 0.8.1(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 0.9.0
+        version: 0.9.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@prosekit/core':
         specifier: ^0.12.3
         version: 0.12.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
@@ -1023,11 +1023,11 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
-  '@meowdown/core@0.8.1':
-    resolution: {integrity: sha512-/ajxLHtnpf35C2Bj5FsK3/U+ZO9mmC9z1QHMD1dNYT+tKWyEk0VfjR/7XhnHLncXhrJMiNnSNLnvVpd9E73COA==}
+  '@meowdown/core@0.9.0':
+    resolution: {integrity: sha512-A1e+c4+vcdS5hkfqxuUPMObTljaNSwYsQtwOGKRUk3ZZJ84S7M4nIerQ8rSKkPGAjwcSIOeyMPbXgdTW17XCuQ==}
 
-  '@meowdown/react@0.8.1':
-    resolution: {integrity: sha512-DU8GAZfBGDG3Z7u11Qu8eSc/PZn73QknLpV0vXWwtShash5cYRZZ2rl4lfRw7e1tKsy4q6LCKjxGR+P2/f3cOw==}
+  '@meowdown/react@0.9.0':
+    resolution: {integrity: sha512-sgcu91o+mEKa50/sFaFiZk2BIj0yy8+sxO0vMxLIoc6Brm4xD5of29NJ8SxtDBuqnZex9pqY2Bmfe86hvtamsw==}
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
@@ -1227,8 +1227,28 @@ packages:
   '@prosekit/core@0.12.3':
     resolution: {integrity: sha512-FjiGhs7s7Wqyuf8h5X9x6OnfhOu2F6Z9IvJ0Bcy4p6VRQR6WeFZGMcV5zTTr+AVETfdvmnlkYILFmCzfcWl0dA==}
 
+  '@prosekit/core@0.13.0-beta.1':
+    resolution: {integrity: sha512-EbeGlJwJmulRECahMKaKsHcGHOOFCYOu0hjHOgc0dBLFmhk1m64LOYdE4zC5Ek9KlSnt5DPq6y7T8UakdsnS8Q==}
+
   '@prosekit/extensions@0.17.5-beta.0':
     resolution: {integrity: sha512-6hafNoTMZlxPixhGd+SJ6o7P6ZnG6GNuIk3TrYqcSUbTd1IihQoqK1ufG4Fejq3ZUstqzfTGCqRhr75G5tPjHQ==}
+    peerDependencies:
+      loro-crdt: '>= 1.10.0'
+      loro-prosemirror: '>= 0.4.1'
+      y-prosemirror: '>= 1.2.9'
+      yjs: '>= 13.6.18'
+    peerDependenciesMeta:
+      loro-crdt:
+        optional: true
+      loro-prosemirror:
+        optional: true
+      y-prosemirror:
+        optional: true
+      yjs:
+        optional: true
+
+  '@prosekit/extensions@0.17.5-beta.2':
+    resolution: {integrity: sha512-Clr9AFdT6IG/XrJlCYUeLChsEkj83q8uka6InbkFIKwmxlADUc7SgZyOjeteG7Hv7+pyOVzKdrlU4KTbZYEaPQ==}
     peerDependencies:
       loro-crdt: '>= 1.10.0'
       loro-prosemirror: '>= 0.4.1'
@@ -1258,8 +1278,22 @@ packages:
       react-dom:
         optional: true
 
+  '@prosekit/react@0.8.0-beta.2':
+    resolution: {integrity: sha512-4q6PtB+RrmS+aZryr2fZA0w0MfY0BEWesyvpt7pqd1Dn5jKu/ri9sGdHZnKdDILlaIZ3tAMQce1dUmfs+iUqeg==}
+    peerDependencies:
+      react: '>= 18.2.0'
+      react-dom: '>= 18.2.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   '@prosekit/web@0.9.0-beta.0':
     resolution: {integrity: sha512-oZVCWas1IKy3akItS+PvCYhZcsk3kFWjgg3IyfbEEzeOpYqicB3UGRydA+10GGqQn0+VupMc6ruBx7DOLgk96Q==}
+
+  '@prosekit/web@0.9.0-beta.2':
+    resolution: {integrity: sha512-pXS+g5gvLX4Pi4eddbTBwTKOhpYBCXRyED3xc+xv/sc7Y3uPuvdwh6xl1rD5MCqTWp+fNAs8PKycoBCwMK1VNg==}
 
   '@prosemirror-adapter/core@0.5.3':
     resolution: {integrity: sha512-jGcI/eq3USFqf1fCaejgCmifmXYDyFco6/5KjyyNBnuEhLqyLjD+020CtcduEOsnN4xPZr5ikclgHIR6kEFkQg==}
@@ -6723,18 +6757,18 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@meowdown/core@0.8.1(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)':
+  '@meowdown/core@0.9.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)':
     dependencies:
       '@codemirror/language': 6.12.3
       '@codemirror/language-data': 6.5.2
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/markdown': 1.6.4
-      '@prosekit/core': 0.12.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      '@prosekit/extensions': 0.17.5-beta.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
+      '@ocavue/utils': 1.7.0
+      '@prosekit/core': 0.13.0-beta.1(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/extensions': 0.17.5-beta.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
       '@prosekit/pm': 0.1.18
       prosemirror-highlight: 0.15.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
-      prosemirror-tables: 1.8.5
     transitivePeerDependencies:
       - '@shikijs/types'
       - '@types/hast'
@@ -6751,7 +6785,7 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@meowdown/react@0.8.1(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@meowdown/react@0.9.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@base-ui/react': 1.5.0(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@codemirror/commands': 6.10.3
@@ -6759,11 +6793,11 @@ snapshots:
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.43.1
-      '@meowdown/core': 0.8.1(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
+      '@meowdown/core': 0.9.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
       '@ocavue/utils': 1.7.0
-      '@prosekit/core': 0.12.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/core': 0.13.0-beta.1(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosekit/pm': 0.1.18
-      '@prosekit/react': 0.8.0-beta.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@prosekit/react': 0.8.0-beta.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       clsx: 2.1.1
     optionalDependencies:
       react: 19.2.7
@@ -6928,10 +6962,53 @@ snapshots:
       - prosemirror-state
       - prosemirror-transform
 
+  '@prosekit/core@0.13.0-beta.1(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)':
+    dependencies:
+      '@ocavue/utils': 1.7.0
+      '@prosekit/pm': 0.1.18
+      orderedmap: 2.1.1
+      prosemirror-splittable: 0.1.1(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      type-fest: 5.7.0
+    transitivePeerDependencies:
+      - prosemirror-model
+      - prosemirror-state
+      - prosemirror-transform
+
   '@prosekit/extensions@0.17.5-beta.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)':
     dependencies:
       '@ocavue/utils': 1.7.0
       '@prosekit/core': 0.12.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/pm': 0.1.18
+      prosemirror-changeset: 2.4.1
+      prosemirror-drop-indicator: 0.1.3
+      prosemirror-dropcursor: 1.8.2
+      prosemirror-enter-rules: 0.1.5
+      prosemirror-flat-list: 0.6.0
+      prosemirror-gapcursor: 1.4.1
+      prosemirror-highlight: 0.15.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
+      prosemirror-math: 0.2.2
+      prosemirror-search: 1.1.1
+      prosemirror-tables: 1.8.5
+      server-dom-shim: 1.1.0
+      shiki: 4.2.0
+    transitivePeerDependencies:
+      - '@lezer/common'
+      - '@lezer/highlight'
+      - '@shikijs/types'
+      - '@types/hast'
+      - highlight.js
+      - lowlight
+      - prosemirror-model
+      - prosemirror-state
+      - prosemirror-transform
+      - prosemirror-view
+      - refractor
+      - sugar-high
+
+  '@prosekit/extensions@0.17.5-beta.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)':
+    dependencies:
+      '@ocavue/utils': 1.7.0
+      '@prosekit/core': 0.13.0-beta.1(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosekit/pm': 0.1.18
       prosemirror-changeset: 2.4.1
       prosemirror-drop-indicator: 0.1.3
@@ -6998,6 +7075,34 @@ snapshots:
       - y-prosemirror
       - yjs
 
+  '@prosekit/react@0.8.0-beta.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@prosekit/core': 0.13.0-beta.1(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/pm': 0.1.18
+      '@prosekit/web': 0.9.0-beta.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
+      '@prosemirror-adapter/core': 0.5.3
+      '@prosemirror-adapter/react': 0.5.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    optionalDependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@lezer/common'
+      - '@lezer/highlight'
+      - '@shikijs/types'
+      - '@types/hast'
+      - highlight.js
+      - loro-crdt
+      - loro-prosemirror
+      - lowlight
+      - prosemirror-model
+      - prosemirror-state
+      - prosemirror-transform
+      - prosemirror-view
+      - refractor
+      - sugar-high
+      - y-prosemirror
+      - yjs
+
   '@prosekit/web@0.9.0-beta.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)':
     dependencies:
       '@aria-ui/core': 0.2.1
@@ -7007,6 +7112,35 @@ snapshots:
       '@ocavue/utils': 1.7.0
       '@prosekit/core': 0.12.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosekit/extensions': 0.17.5-beta.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
+      '@prosekit/pm': 0.1.18
+      prosemirror-tables: 1.8.5
+    transitivePeerDependencies:
+      - '@lezer/common'
+      - '@lezer/highlight'
+      - '@shikijs/types'
+      - '@types/hast'
+      - highlight.js
+      - loro-crdt
+      - loro-prosemirror
+      - lowlight
+      - prosemirror-model
+      - prosemirror-state
+      - prosemirror-transform
+      - prosemirror-view
+      - refractor
+      - sugar-high
+      - y-prosemirror
+      - yjs
+
+  '@prosekit/web@0.9.0-beta.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)':
+    dependencies:
+      '@aria-ui/core': 0.2.1
+      '@aria-ui/elements': 0.1.10
+      '@aria-ui/utils': 0.1.6
+      '@floating-ui/dom': 1.7.6
+      '@ocavue/utils': 1.7.0
+      '@prosekit/core': 0.13.0-beta.1(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/extensions': 0.17.5-beta.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
       '@prosekit/pm': 0.1.18
       prosemirror-tables: 1.8.5
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- Upgrade `@meowdown/core` and `@meowdown/react` to `0.9.0`
- Refresh the lockfile for the updated ProseKit and Meowdown dependency graph
- Update the editor test helper to use the new `markdownToDoc` signature
- Adjust the gutter-handle CSS comment to match the new package versioning

## Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Editor behavior depends on a major-ish meowdown bump and beta ProseKit transitives; risk is moderate though the app change surface is small.
> 
> **Overview**
> Bumps **`@meowdown/core`** and **`@meowdown/react`** from **0.8.1** to **0.9.0** in the desktop app and refreshes **`pnpm-lock.yaml`**, which pulls in newer transitive **ProseKit** beta builds used by meowdown 0.9.0.
> 
> The only in-repo API follow-up is in **`bullet-after-heading-keymap.test.ts`**: **`markdownToDoc`** is now called with markdown only (the editor argument was dropped). A comment in **`index.css`** about hiding meowdown gutter handles no longer pins the old **0.8.1** version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73536d6f6750c054484cfa12fe76f3afc9b08e6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->