### PR TITLE
chore(desktop): update meowdown to 0.11.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,10 +16,8 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@meowdown/core": "0.10.0",
-    "@meowdown/react": "0.10.0",
-    "@prosekit/core": "^0.13.0-beta.1",
-    "@prosekit/react": "^0.8.0-beta.2",
+    "@meowdown/core": "0.11.0",
+    "@meowdown/react": "0.11.0",
     "@reflect/core": "workspace:*",
     "@reflect/db": "workspace:*",
     "@reflect/design-system": "workspace:*",

--- a/apps/desktop/src/components/tasks/task-editor.tsx
+++ b/apps/desktop/src/components/tasks/task-editor.tsx
@@ -6,8 +6,8 @@ import {
   type MutableRefObject,
   type ReactElement,
 } from 'react'
-import { Priority } from '@prosekit/core'
-import { useKeymap } from '@prosekit/react'
+import { Priority } from '@meowdown/core'
+import { useKeymap } from '@meowdown/react'
 import { type OpenTask } from '@reflect/core'
 import { NoteEditor, type NoteEditorHandle } from '@/editor/note-editor'
 import { useEditorAutocomplete } from '@/editor/use-editor-autocomplete'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,17 +21,11 @@ importers:
   apps/desktop:
     dependencies:
       '@meowdown/core':
-        specifier: 0.10.0
-        version: 0.10.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
+        specifier: 0.11.0
+        version: 0.11.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
       '@meowdown/react':
-        specifier: 0.10.0
-        version: 0.10.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@prosekit/core':
-        specifier: ^0.13.0-beta.1
-        version: 0.13.0-beta.1(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      '@prosekit/react':
-        specifier: ^0.8.0-beta.2
-        version: 0.8.0-beta.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 0.11.0
+        version: 0.11.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@reflect/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -1014,11 +1008,11 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
-  '@meowdown/core@0.10.0':
-    resolution: {integrity: sha512-yAuZhqtdDyHeO/OU0LQwOFbfoaBqrZSd/1EHxcQk6G9jB4+or/XB/D5nMj69WScmSbiDIpex25XdthO0FhFQeQ==}
+  '@meowdown/core@0.11.0':
+    resolution: {integrity: sha512-euWrkOwbGWTLW2Y8MVf5QKKsQEgc+QH8VeYE3LX+5j3nPdCWbQG5K11bwQFtJ57kciqYlcmfxjq39ba50ZQy3w==}
 
-  '@meowdown/react@0.10.0':
-    resolution: {integrity: sha512-A4r2nDnrnsY3tEbAaT9XP2XH7PLMXDZYW/H0uA8M5IBhun7msHvvx2Ztx1rl6/PzTelcaKeCr5qFut57uDT5rA==}
+  '@meowdown/react@0.11.0':
+    resolution: {integrity: sha512-F5PQAHq7E5enaXdV6nboP/Ujk4cRS1mkHRb0Rx8rkMhF8RYn+1qKdmuNjINYvO4IjyPOd0d7dEdZzUF6tUtz5A==}
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
@@ -6711,7 +6705,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@meowdown/core@0.10.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)':
+  '@meowdown/core@0.11.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)':
     dependencies:
       '@codemirror/language': 6.12.3
       '@codemirror/language-data': 6.5.2
@@ -6739,7 +6733,7 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@meowdown/react@0.10.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@meowdown/react@0.11.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@base-ui/react': 1.5.0(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@codemirror/commands': 6.10.3
@@ -6747,7 +6741,7 @@ snapshots:
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.43.1
-      '@meowdown/core': 0.10.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
+      '@meowdown/core': 0.11.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
       '@ocavue/utils': 1.7.0
       '@prosekit/core': 0.13.0-beta.1(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosekit/pm': 0.1.18


### PR DESCRIPTION
Update `@meowdown/*` to **0.11.0** and drop the direct `@prosekit/*` dependencies.

meowdown 0.11.0 re-exports the ProseKit primitives the task editor needs, so `task-editor.tsx` imports `Priority` from `@meowdown/core` and `useKeymap` from `@meowdown/react` instead of `@prosekit/*`. With that, `apps/desktop` no longer pins any ProseKit package directly; meowdown owns the version, which removes the duplicate-copy / version-skew risk.

### Changes
- Bump `@meowdown/core` and `@meowdown/react` `0.10.0` -> `0.11.0`.
- `task-editor.tsx`: import `Priority` / `useKeymap` from `@meowdown/*`.
- Remove `@prosekit/core` and `@prosekit/react` from `apps/desktop/package.json`.

`apps/desktop` now depends on `@meowdown/core` + `@meowdown/react` only; ProseKit is purely transitive.

### Verification
- `pnpm typecheck` passes.
- Tasks + editor tests pass (208).
- `pnpm dedupe` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core editor framework dependencies to version 0.11.0.
  * Reorganized internal module imports to improve code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->