### PR TITLE
Add editor image lightbox

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@meowdown/core": "0.11.0",
     "@meowdown/react": "0.11.0",
+    "@prosekit/core": "0.13.0-beta.1",
     "@reflect/core": "workspace:*",
     "@reflect/db": "workspace:*",
     "@reflect/design-system": "workspace:*",

--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -99,6 +99,7 @@ export function NotePane({
   })
   const {
     resolveImageUrl,
+    resolveImageOpenPath,
     saveImage,
     onImageSaveError,
     saveError: imageSaveError,
@@ -212,6 +213,7 @@ export function NotePane({
         spellCheck={settings.editorSpellCheck}
         bulletAfterHeading={settings.editorBulletAfterHeading}
         resolveImageUrl={resolveImageUrl}
+        resolveImageOpenPath={resolveImageOpenPath}
         saveImage={saveImage}
         onImageSaveError={onImageSaveError}
         onWikiLinkClick={onWikiLinkClick}

--- a/apps/desktop/src/components/ui/dialog.tsx
+++ b/apps/desktop/src/components/ui/dialog.tsx
@@ -47,15 +47,17 @@ function DialogOverlay({
 
 function DialogContent({
   className,
+  overlayClassName,
   children,
   showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  overlayClassName?: string
   showCloseButton?: boolean
 }) {
   return (
     <DialogPortal>
-      <DialogOverlay />
+      <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(

--- a/apps/desktop/src/editor/image-click-extension.tsx
+++ b/apps/desktop/src/editor/image-click-extension.tsx
@@ -1,0 +1,56 @@
+import { useMemo } from 'react'
+import { defineClickHandler } from '@prosekit/core'
+import { useExtension } from '@meowdown/react'
+
+interface ImageClickExtensionProps {
+  onImageClick: (image: HTMLImageElement) => void
+}
+
+function isPrimaryUnmodifiedClick(event: MouseEvent): boolean {
+  return (
+    event.button === 0 &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    !event.shiftKey
+  )
+}
+
+function getClickedMarkdownImage(event: MouseEvent): HTMLImageElement | null {
+  const target = event.target
+  if (!(target instanceof Element)) {
+    return null
+  }
+
+  const image = target.closest('img')
+  if (!(image instanceof HTMLImageElement) || image.closest('.md-image') === null) {
+    return null
+  }
+
+  return image
+}
+
+export function ImageClickExtension({ onImageClick }: ImageClickExtensionProps): null {
+  const extension = useMemo(
+    () =>
+      defineClickHandler((_view, _pos, event) => {
+        if (!isPrimaryUnmodifiedClick(event)) {
+          return false
+        }
+
+        const image = getClickedMarkdownImage(event)
+        if (image === null) {
+          return false
+        }
+
+        event.preventDefault()
+        event.stopPropagation()
+        onImageClick(image)
+        return true
+      }),
+    [onImageClick],
+  )
+
+  useExtension(extension)
+  return null
+}

--- a/apps/desktop/src/editor/image-lightbox.tsx
+++ b/apps/desktop/src/editor/image-lightbox.tsx
@@ -1,0 +1,84 @@
+import { type ReactElement } from 'react'
+import { ExternalLinkIcon } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { LightboxDialog } from '@/editor/lightbox-dialog'
+import { type LightboxTransitionItem } from '@/editor/use-lightbox-transition'
+
+export const IMAGE_LIGHTBOX_TRANSITION_NAME = 'reflect-image-lightbox'
+
+/** Image data rendered by the editor lightbox. */
+export interface LightboxImage extends LightboxTransitionItem {
+  src: string
+  alt: string
+  openPath: string | null
+}
+
+interface ImageLightboxProps {
+  image: LightboxImage | null
+  onClose: () => void
+  onOpenImage?: (image: LightboxImage) => void
+}
+
+/** Builds image lightbox state from a rendered editor image. */
+export function createLightboxImage(
+  element: HTMLImageElement,
+  transitionName: string,
+  openPathByUrl?: ReadonlyMap<string, string>,
+): LightboxImage | null {
+  const attributeSrc = element.getAttribute('src') ?? ''
+  const src = element.currentSrc || element.src || element.getAttribute('src') || ''
+  if (src.trim() === '') {
+    return null
+  }
+
+  return {
+    src,
+    alt: element.alt,
+    openPath: openPathByUrl?.get(src) ?? openPathByUrl?.get(attributeSrc) ?? null,
+    transitionName,
+  }
+}
+
+export function ImageLightbox({
+  image,
+  onClose,
+  onOpenImage,
+}: ImageLightboxProps): ReactElement | null {
+  if (image === null) {
+    return null
+  }
+  const canOpenImage = image.openPath !== null && onOpenImage !== undefined
+
+  return (
+    <LightboxDialog open title="Image preview" onClose={onClose}>
+      {canOpenImage ? (
+        <div className="absolute top-4 right-4 z-10">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="bg-white/70 text-text hover:bg-white"
+            onClick={() => onOpenImage(image)}
+          >
+            <ExternalLinkIcon data-icon="inline-start" />
+            Open
+          </Button>
+        </div>
+      ) : null}
+      <button
+        type="button"
+        aria-label="Close image preview"
+        className="flex max-h-full max-w-full cursor-zoom-out items-center justify-center bg-transparent p-0"
+        onClick={onClose}
+      >
+        <img
+          src={image.src}
+          alt={image.alt}
+          draggable={false}
+          className="max-h-full max-w-full select-none object-contain"
+          style={{ viewTransitionName: image.transitionName }}
+        />
+      </button>
+    </LightboxDialog>
+  )
+}

--- a/apps/desktop/src/editor/lightbox-dialog.tsx
+++ b/apps/desktop/src/editor/lightbox-dialog.tsx
@@ -1,0 +1,53 @@
+import { type ReactElement, type ReactNode } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+interface LightboxDialogProps {
+  open: boolean
+  title: string
+  children: ReactNode
+  onClose: () => void
+}
+
+/**
+ * Full-window, chrome-free dialog shell for editor lightbox experiences.
+ */
+export function LightboxDialog({
+  open,
+  title,
+  children,
+  onClose,
+}: LightboxDialogProps): ReactElement | null {
+  if (!open) {
+    return null
+  }
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          onClose()
+        }
+      }}
+    >
+      <DialogContent
+        aria-describedby={undefined}
+        showCloseButton={false}
+        overlayClassName="bg-white/80 backdrop-blur-0 supports-backdrop-filter:backdrop-blur-0"
+        className="fixed inset-0 top-0 left-0 z-50 flex h-dvh w-dvw max-w-none translate-x-0 translate-y-0 items-center justify-center overflow-hidden rounded-none bg-white/90 p-6 ring-0 outline-none sm:max-w-none"
+        onPointerDown={(event) => {
+          if (event.target === event.currentTarget) {
+            onClose()
+          }
+        }}
+      >
+        <DialogTitle className="sr-only">{title}</DialogTitle>
+        {children}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -1,0 +1,211 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { type ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NoteEditor } from './note-editor'
+
+const VIEW_TRANSITION_NAME = 'reflect-image-lightbox'
+
+type MockClickHandler = (view: unknown, pos: number, event: MouseEvent) => boolean | void
+
+interface MockClickExtension {
+  clickHandler: MockClickHandler
+}
+
+const proseKitMock = vi.hoisted(() => ({
+  clickHandler: null as MockClickHandler | null,
+}))
+
+const openerMock = vi.hoisted(() => ({
+  openPath: vi.fn(async () => {}),
+}))
+
+interface MockMeowdownEditorProps {
+  children?: ReactNode
+  editorClassName?: string
+  resolveImageUrl?: (src: string) => string | undefined
+}
+
+vi.mock('@prosekit/core', () => ({
+  defineClickHandler: vi.fn(
+    (clickHandler: MockClickHandler): MockClickExtension => ({ clickHandler }),
+  ),
+}))
+
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  openPath: openerMock.openPath,
+}))
+
+vi.mock('@meowdown/react', () => ({
+  useExtension: vi.fn((extension: MockClickExtension | null) => {
+    proseKitMock.clickHandler = extension?.clickHandler ?? null
+  }),
+  MeowdownEditor: ({ children, editorClassName, resolveImageUrl }: MockMeowdownEditorProps) => (
+    <div className="meowdown">
+      <div className={editorClassName}>
+        <p>Editor text</p>
+        <div className="md-image">
+          <img src={resolveImageUrl?.('assets/cat.png')} alt="Cat" />
+        </div>
+        {children}
+      </div>
+    </div>
+  ),
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+beforeEach(() => {
+  proseKitMock.clickHandler = null
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn((query: string): MediaQueryList => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+  Element.prototype.getAnimations = vi.fn(() => [])
+  Object.defineProperty(document, 'startViewTransition', {
+    configurable: true,
+    writable: true,
+    value: undefined,
+  })
+})
+
+function renderEditor(): ReturnType<typeof render> {
+  return render(
+    <NoteEditor
+      initialContent="A photo\n\n![Cat](assets/cat.png)"
+      resolveImageUrl={(src) => (src === 'assets/cat.png' ? 'asset://cat.png' : null)}
+      resolveImageOpenPath={(src) =>
+        src === 'assets/cat.png' ? '/Users/alex/notes/assets/cat.png' : null
+      }
+    />,
+  )
+}
+
+function findInlineImage(container: HTMLElement): HTMLImageElement {
+  const image = container.querySelector('.md-image img')
+  if (!(image instanceof HTMLImageElement)) {
+    throw new Error('Expected meowdown image widget to render')
+  }
+  return image
+}
+
+function installViewTransitionMock(): ReturnType<typeof vi.fn> {
+  function expectSingleNamedElement(): void {
+    const namedElements = Array.from(document.querySelectorAll<HTMLElement>('[style]'))
+      .filter((element) => element.style.viewTransitionName === VIEW_TRANSITION_NAME)
+    expect(namedElements.length).toBeLessThanOrEqual(1)
+  }
+
+  const startViewTransition = vi.fn((callback?: ViewTransitionUpdateCallback): ViewTransition => {
+    expectSingleNamedElement()
+    const update = callback?.()
+    expectSingleNamedElement()
+    return {
+      finished: Promise.resolve(),
+      ready: Promise.resolve(),
+      updateCallbackDone: Promise.resolve(update).then(() => undefined),
+      skipTransition: vi.fn(),
+      types: new Set<string>() as unknown as ViewTransitionTypeSet,
+    }
+  })
+  Object.defineProperty(document, 'startViewTransition', {
+    configurable: true,
+    writable: true,
+    value: startViewTransition,
+  })
+  return startViewTransition
+}
+
+function clickElement(element: Element): void {
+  act(() => {
+    const event = new MouseEvent('click', { bubbles: true, button: 0, cancelable: true })
+    element.dispatchEvent(event)
+    proseKitMock.clickHandler?.({}, 0, event)
+  })
+}
+
+describe('NoteEditor image lightbox', () => {
+  it('opens an image lightbox from an inline image and closes on Escape', async () => {
+    const { container } = renderEditor()
+    const image = await waitFor(() => findInlineImage(container))
+
+    clickElement(image)
+
+    const dialog = await screen.findByRole('dialog', { name: 'Image preview' })
+    const preview = dialog.querySelector('img')
+    expect(preview).toBeInstanceOf(HTMLImageElement)
+    expect((preview as HTMLImageElement).src).toBe('asset://cat.png')
+
+    await userEvent.keyboard('{Escape}')
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+  })
+
+  it('uses the native View Transition API when available', async () => {
+    const startViewTransition = installViewTransitionMock()
+    const { container } = renderEditor()
+    const image = await waitFor(() => findInlineImage(container))
+
+    clickElement(image)
+
+    expect(startViewTransition).toHaveBeenCalledTimes(1)
+    expect(await screen.findByRole('dialog', { name: 'Image preview' })).toBeTruthy()
+  })
+
+  it('closes the lightbox from the expanded image click', async () => {
+    const startViewTransition = installViewTransitionMock()
+    const { container } = renderEditor()
+    const image = await waitFor(() => findInlineImage(container))
+
+    clickElement(image)
+
+    const dialog = await screen.findByRole('dialog', { name: 'Image preview' })
+    const preview = dialog.querySelector('img')
+    if (!(preview instanceof HTMLImageElement)) {
+      throw new Error('Expected lightbox image to render')
+    }
+
+    await userEvent.click(preview)
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    expect(startViewTransition).toHaveBeenCalledTimes(2)
+  })
+
+  it('opens the lightbox image in Preview', async () => {
+    const { container } = renderEditor()
+    const image = await waitFor(() => findInlineImage(container))
+
+    clickElement(image)
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Open' }))
+
+    expect(openerMock.openPath).toHaveBeenCalledWith(
+      '/Users/alex/notes/assets/cat.png',
+      'Preview',
+    )
+  })
+
+  it('does not open the lightbox for non-image editor clicks', async () => {
+    const { container } = renderEditor()
+    const editor = container.querySelector('.reflect-editor')
+    if (!(editor instanceof HTMLElement)) {
+      throw new Error('Expected editor root to render')
+    }
+
+    fireEvent.click(editor)
+
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+})

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -3,10 +3,12 @@ import {
   useEffect,
   useImperativeHandle,
   useRef,
+  type MutableRefObject,
   type ReactElement,
   type ReactNode,
   type Ref,
 } from 'react'
+import { openPath } from '@tauri-apps/plugin-opener'
 import { type MarkMode } from '@meowdown/core'
 import {
   MeowdownEditor,
@@ -16,6 +18,13 @@ import {
 } from '@meowdown/react'
 import '@meowdown/core/style.css'
 import '@meowdown/react/style.css'
+import { ImageClickExtension } from '@/editor/image-click-extension'
+import {
+  IMAGE_LIGHTBOX_TRANSITION_NAME,
+  ImageLightbox,
+  createLightboxImage,
+} from '@/editor/image-lightbox'
+import { useLightboxTransition } from '@/editor/use-lightbox-transition'
 import { cn } from '@/lib/utils'
 
 /**
@@ -57,6 +66,8 @@ interface NoteEditorProps {
   bulletAfterHeading?: boolean
   /** Resolve an image `![…](…)` source to a displayable URL; unresolved images are skipped. */
   resolveImageUrl?: (src: string) => string | null
+  /** Resolve an image `![…](…)` source to a native file path for Preview. */
+  resolveImageOpenPath?: (src: string) => string | null
   /** Persist a pasted/dropped image file and return its markdown `src`. */
   saveImage?: (file: File) => Promise<string | null>
   /** Called when persisting a pasted/dropped image throws. */
@@ -88,6 +99,14 @@ interface NoteEditorProps {
   children?: ReactNode
 }
 
+function useLatestRef<Value>(value: Value): MutableRefObject<Value> {
+  const ref = useRef(value)
+  useEffect(() => {
+    ref.current = value
+  })
+  return ref
+}
+
 export function NoteEditor({
   initialContent,
   onChange,
@@ -95,6 +114,7 @@ export function NoteEditor({
   spellCheck = true,
   bulletAfterHeading = false,
   resolveImageUrl,
+  resolveImageOpenPath,
   saveImage,
   onImageSaveError,
   onWikiLinkClick,
@@ -106,21 +126,24 @@ export function NoteEditor({
   handleRef,
 }: NoteEditorProps): ReactElement {
   const innerRef = useRef<EditorHandle>(null)
+  const imageOpenPathByUrlRef = useRef(new Map<string, string>())
 
   // Latest callbacks, read through refs so a changing prop identity never
   // rebuilds meowdown's extensions (the uncontrolled-editor contract).
-  // TODO: This violates "Rule of hooks". Refactor this later.
-  const onChangeRef = useRef(onChange)
-  const onWikiLinkClickRef = useRef(onWikiLinkClick)
-  const resolveImageUrlRef = useRef(resolveImageUrl)
-  const saveImageRef = useRef(saveImage)
-  const onImageSaveErrorRef = useRef(onImageSaveError)
-  useEffect(() => {
-    onChangeRef.current = onChange
-    onWikiLinkClickRef.current = onWikiLinkClick
-    resolveImageUrlRef.current = resolveImageUrl
-    saveImageRef.current = saveImage
-    onImageSaveErrorRef.current = onImageSaveError
+  const onChangeRef = useLatestRef(onChange)
+  const onWikiLinkClickRef = useLatestRef(onWikiLinkClick)
+  const resolveImageUrlRef = useLatestRef(resolveImageUrl)
+  const resolveImageOpenPathRef = useLatestRef(resolveImageOpenPath)
+  const saveImageRef = useLatestRef(saveImage)
+  const onImageSaveErrorRef = useLatestRef(onImageSaveError)
+  const createImageLightboxItem = useCallback(
+    (element: HTMLImageElement, transitionName: string) =>
+      createLightboxImage(element, transitionName, imageOpenPathByUrlRef.current),
+    [],
+  )
+  const imageLightbox = useLightboxTransition({
+    transitionName: IMAGE_LIGHTBOX_TRANSITION_NAME,
+    createItem: createImageLightboxItem,
   })
 
   useImperativeHandle(
@@ -135,42 +158,66 @@ export function NoteEditor({
 
   const handleDocChange = useCallback(() => {
     onChangeRef.current?.(innerRef.current?.getMarkdown() ?? '')
-  }, [])
+  }, [onChangeRef])
   const handleWikilinkClick = useCallback(
     (payload: { target: string }) => onWikiLinkClickRef.current?.(payload.target),
-    [],
+    [onWikiLinkClickRef],
   )
   const handleResolveImageUrl = useCallback(
-    (src: string) => resolveImageUrlRef.current?.(src) ?? undefined,
-    [],
+    (src: string) => {
+      const displayUrl = resolveImageUrlRef.current?.(src) ?? undefined
+      if (displayUrl !== undefined) {
+        const openPath = resolveImageOpenPathRef.current?.(src) ?? null
+        if (openPath === null) {
+          imageOpenPathByUrlRef.current.delete(displayUrl)
+        } else {
+          imageOpenPathByUrlRef.current.set(displayUrl, openPath)
+        }
+      }
+      return displayUrl
+    },
+    [resolveImageOpenPathRef, resolveImageUrlRef],
   )
   const handleImagePaste = useCallback(
     async (file: File) => (await saveImageRef.current?.(file)) ?? undefined,
-    [],
+    [saveImageRef],
   )
   const handleImageSaveError = useCallback(
     (error: unknown, file: File) => onImageSaveErrorRef.current?.(error, file),
-    [],
+    [onImageSaveErrorRef],
   )
+  const handleOpenLightboxImage = useCallback((image: { openPath: string | null }) => {
+    if (image.openPath !== null) {
+      void openPath(image.openPath, 'Preview').catch(() => {})
+    }
+  }, [])
 
   return (
-    <MeowdownEditor
-      handleRef={innerRef}
-      mode={markMode}
-      initialMarkdown={initialContent}
-      spellCheck={spellCheck}
-      bulletAfterHeading={bulletAfterHeading}
-      editorClassName={cn('reflect-editor', className)}
-      {...(titlePlaceholder !== undefined ? { placeholder: titlePlaceholder } : {})}
-      onDocChange={handleDocChange}
-      onWikilinkClick={handleWikilinkClick}
-      {...(onWikilinkSearch !== undefined ? { onWikilinkSearch } : {})}
-      {...(onTagSearch !== undefined ? { onTagSearch } : {})}
-      resolveImageUrl={handleResolveImageUrl}
-      onImagePaste={handleImagePaste}
-      onImageSaveError={handleImageSaveError}
-    >
-      {children}
-    </MeowdownEditor>
+    <>
+      <MeowdownEditor
+        handleRef={innerRef}
+        mode={markMode}
+        initialMarkdown={initialContent}
+        spellCheck={spellCheck}
+        bulletAfterHeading={bulletAfterHeading}
+        editorClassName={cn('reflect-editor', className)}
+        {...(titlePlaceholder !== undefined ? { placeholder: titlePlaceholder } : {})}
+        onDocChange={handleDocChange}
+        onWikilinkClick={handleWikilinkClick}
+        {...(onWikilinkSearch !== undefined ? { onWikilinkSearch } : {})}
+        {...(onTagSearch !== undefined ? { onTagSearch } : {})}
+        resolveImageUrl={handleResolveImageUrl}
+        onImagePaste={handleImagePaste}
+        onImageSaveError={handleImageSaveError}
+      >
+        <ImageClickExtension onImageClick={imageLightbox.open} />
+        {children}
+      </MeowdownEditor>
+      <ImageLightbox
+        image={imageLightbox.item}
+        onClose={imageLightbox.close}
+        onOpenImage={handleOpenLightboxImage}
+      />
+    </>
   )
 }

--- a/apps/desktop/src/editor/use-image-persistence.ts
+++ b/apps/desktop/src/editor/use-image-persistence.ts
@@ -34,6 +34,8 @@ function isSafeAssetSource(sourcePath: string): boolean {
 export interface ImagePersistence {
   /** Resolve an image source to a displayable URL (or null to skip). */
   resolveImageUrl: (src: string) => string | null
+  /** Resolve an image source to a local path that can be opened natively. */
+  resolveImageOpenPath: (src: string) => string | null
   /** Persist a pasted/dropped image, returning its graph-relative path (or null). */
   saveImage: (file: File) => Promise<string | null>
   /** Report a failed image save. */
@@ -68,6 +70,15 @@ export function useImagePersistence(
     },
     [graphRoot],
   )
+  const resolveOpenPath = useCallback(
+    (src: string): string | null => {
+      if (graphRoot && isSafeAssetSource(src)) {
+        return `${graphRoot}/${src}`
+      }
+      return null
+    },
+    [graphRoot],
+  )
 
   const saveImage = useCallback(
     async (file: File): Promise<string | null> => {
@@ -94,10 +105,11 @@ export function useImagePersistence(
   return useMemo<ImagePersistence>(
     () => ({
       resolveImageUrl: resolveUrl,
+      resolveImageOpenPath: resolveOpenPath,
       saveImage,
       onImageSaveError: onSaveError,
       saveError,
     }),
-    [resolveUrl, saveImage, onSaveError, saveError],
+    [resolveUrl, resolveOpenPath, saveImage, onSaveError, saveError],
   )
 }

--- a/apps/desktop/src/editor/use-lightbox-transition.ts
+++ b/apps/desktop/src/editor/use-lightbox-transition.ts
@@ -1,0 +1,121 @@
+import { useCallback, useRef, useState } from 'react'
+import { flushSync } from 'react-dom'
+
+/** Data rendered in a lightbox with a named View Transition snapshot. */
+export interface LightboxTransitionItem {
+  readonly transitionName: string
+}
+
+interface LightboxTransitionSource<ElementType extends HTMLElement> {
+  element: ElementType
+  transitionName: string
+}
+
+interface UseLightboxTransitionOptions<
+  ElementType extends HTMLElement,
+  ItemType extends LightboxTransitionItem,
+> {
+  transitionName: string
+  createItem: (element: ElementType, transitionName: string) => ItemType | null
+}
+
+/** State and commands for a lightbox that zooms from a source element when possible. */
+export interface UseLightboxTransitionResult<
+  ElementType extends HTMLElement,
+  ItemType extends LightboxTransitionItem,
+> {
+  item: ItemType | null
+  open: (element: ElementType) => void
+  close: () => void
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  )
+}
+
+function canUseViewTransition(): boolean {
+  return typeof document.startViewTransition === 'function' && !prefersReducedMotion()
+}
+
+function clearTransitionSource<ElementType extends HTMLElement>(
+  source: LightboxTransitionSource<ElementType> | null,
+): void {
+  if (source !== null && source.element.style.viewTransitionName === source.transitionName) {
+    source.element.style.viewTransitionName = ''
+  }
+}
+
+function settleViewTransition(transition: ViewTransition, cleanup: () => void): void {
+  void transition.finished.then(cleanup, cleanup)
+}
+
+/**
+ * Opens and closes lightbox content with a native View Transition when supported.
+ */
+export function useLightboxTransition<
+  ElementType extends HTMLElement,
+  ItemType extends LightboxTransitionItem,
+>({
+  transitionName,
+  createItem,
+}: UseLightboxTransitionOptions<ElementType, ItemType>): UseLightboxTransitionResult<
+  ElementType,
+  ItemType
+> {
+  const sourceRef = useRef<LightboxTransitionSource<ElementType> | null>(null)
+  const [item, setItem] = useState<ItemType | null>(null)
+
+  const open = useCallback((element: ElementType) => {
+    const nextItem = createItem(element, transitionName)
+    if (nextItem === null) {
+      return
+    }
+
+    clearTransitionSource(sourceRef.current)
+    const source: LightboxTransitionSource<ElementType> = {
+      element,
+      transitionName,
+    }
+    sourceRef.current = source
+
+    if (!canUseViewTransition()) {
+      setItem(nextItem)
+      return
+    }
+
+    element.style.viewTransitionName = transitionName
+    const transition = document.startViewTransition(() => {
+      clearTransitionSource(source)
+      flushSync(() => setItem(nextItem))
+    })
+    settleViewTransition(transition, () => clearTransitionSource(source))
+  }, [createItem, transitionName])
+
+  const close = useCallback(() => {
+    if (item === null) {
+      return
+    }
+
+    const source = sourceRef.current
+    if (canUseViewTransition() && source?.element.isConnected) {
+      const transition = document.startViewTransition(() => {
+        flushSync(() => setItem(null))
+        source.element.style.viewTransitionName = item.transitionName
+      })
+      settleViewTransition(transition, () => {
+        clearTransitionSource(source)
+        sourceRef.current = null
+      })
+      return
+    }
+
+    setItem(null)
+    clearTransitionSource(source)
+    sourceRef.current = null
+  }, [item])
+
+  return { item, open, close }
+}

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -409,6 +409,24 @@ body {
   max-width: 100%;
   max-height: 28rem;
   border-radius: var(--radius-md, 6px);
+  cursor: zoom-in;
+}
+
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 0s;
+}
+
+::view-transition-group(reflect-image-lightbox) {
+  animation-duration: 180ms;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+::view-transition-old(reflect-image-lightbox),
+::view-transition-new(reflect-image-lightbox) {
+  height: 100%;
+  object-fit: contain;
+  overflow: clip;
 }
 
 /* Read-only view for notes the editor can't faithfully round-trip yet. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@meowdown/react':
         specifier: 0.11.0
         version: 0.11.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@prosekit/core':
+        specifier: 0.13.0-beta.1
+        version: 0.13.0-beta.1(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@reflect/core':
         specifier: workspace:*
         version: link:../../packages/core


### PR DESCRIPTION
## Summary
- add a ProseKit click extension for markdown images in the main note editor
- render a shadcn/Radix dialog-backed white image lightbox with Escape and background-click close
- use the native View Transition API for zoom open/close when available, with reduced-motion and unsupported-browser fallback

## Testing
- pnpm --filter @reflect/desktop test --run src/editor/note-editor.test.tsx
- pnpm check
- browser smoke at http://localhost:1420/ with no console errors

## Notes
- pnpm check passes with existing lint warnings in unrelated files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped editor UX with existing safe `assets/` path checks for Preview; new `@prosekit/core` beta dependency is the main integration risk, covered by tests.
> 
> **Overview**
> Adds **click-to-preview** for inline markdown images in the note editor: a ProseKit **`ImageClickExtension`** handles plain left-clicks on `.md-image` widgets and opens a full-screen **`ImageLightbox`** backed by a customized dialog shell.
> 
> Open/close uses the **View Transition API** when supported (with **reduced-motion** and no-API fallbacks), plus **Escape**, backdrop, and expanded-image click to dismiss. Local graph **`assets/`** images get an **Open** action that launches the file in **Preview** via Tauri **`openPath`**, wired through new **`resolveImageOpenPath`** on image persistence and a display-URL → path map in **`NoteEditor`**. **`DialogContent`** gains optional **`overlayClassName`** for the lightbox styling; editor CSS adds **zoom-in** cursor and transition rules. **`note-editor.test.tsx`** covers lightbox open/close, view transitions, Preview open, and non-image clicks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4e0e07087688bf065a7663e766ef69bbabef7d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an editor image preview lightbox: click images to open a full-screen dialog, with an optional “Open” action and View Transition animations when available.
  * Added image click handling to route eligible image clicks into the lightbox flow.

* **Improvements**
  * Enhanced dialog customization by allowing custom overlay styling.
  * Improved image handling with per-image “open path” resolution for safe local asset sources.

* **Tests**
  * Added React Testing Library + Vitest coverage for lightbox open/close, “Open” behavior, and View Transition invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->