### PR TITLE
Release v0.2.0-beta.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.2.0-beta.15"
+version = "0.2.0-beta.16"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.2.0-beta.15"
+version = "0.2.0-beta.16"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.2.0-beta.15",
+  "version": "0.2.0-beta.16",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.2.0-beta.16.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version alignment only; no runtime or security logic is modified.
> 
> **Overview**
> Bumps the desktop Reflect release from **0.2.0-beta.15** to **0.2.0-beta.16** in `apps/desktop/src-tauri/Cargo.toml`, `tauri.conf.json`, and the `reflect-open` entry in `Cargo.lock`. No application or feature code changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5192c696fc766dbaac409d987a1ff76c1530b8fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->