### PR TITLE
Polish editor settings layout

### DIFF
--- a/apps/desktop/src/components/settings/describe-assets-field.test.tsx
+++ b/apps/desktop/src/components/settings/describe-assets-field.test.tsx
@@ -47,19 +47,19 @@ describe('DescribeAssetsField', () => {
   it('disables the backfill until an AI provider is configured', () => {
     settingsRef.current = { ...settingsRef.current, aiProviders: [], defaultAiProviderId: null }
     render(<DescribeAssetsField />)
-    expect(screen.getByRole('button', { name: /backfill existing assets/i }).hasAttribute('disabled')).toBe(true)
+    expect(screen.getByRole('button', { name: /backfill assets/i }).hasAttribute('disabled')).toBe(true)
     expect(screen.queryByText(/add an ai provider to enable this/i)).not.toBeNull()
   })
 
   it('confirms the cost before running the backfill, then runs it pinned to the graph', () => {
     render(<DescribeAssetsField />)
-    fireEvent.click(screen.getByRole('button', { name: /backfill existing assets/i }))
+    fireEvent.click(screen.getByRole('button', { name: /backfill assets/i }))
 
     // The cost warning appears; nothing is sent until the user confirms.
-    expect(screen.queryByText(/backfill existing assets\?/i)).not.toBeNull()
+    expect(screen.queryByText(/backfill assets\?/i)).not.toBeNull()
     expect(backfill).not.toHaveBeenCalled()
 
-    fireEvent.click(screen.getByRole('button', { name: /^backfill existing assets$/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^backfill assets$/i }))
     expect(backfill).toHaveBeenCalledWith(5, {
       providers: [PROVIDER],
       defaultProviderId: 'cfg',
@@ -68,7 +68,7 @@ describe('DescribeAssetsField', () => {
 
   it('cancels without sending anything', () => {
     render(<DescribeAssetsField />)
-    fireEvent.click(screen.getByRole('button', { name: /backfill existing assets/i }))
+    fireEvent.click(screen.getByRole('button', { name: /backfill assets/i }))
     fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
     expect(backfill).not.toHaveBeenCalled()
   })

--- a/apps/desktop/src/components/settings/describe-assets-field.tsx
+++ b/apps/desktop/src/components/settings/describe-assets-field.tsx
@@ -61,7 +61,7 @@ export function DescribeAssetsField(): ReactElement {
         />
         <span className="text-xs text-text-muted">OCR new assets automatically</span>
       </div>
-      <div className="mt-3 flex flex-col items-end">
+      <div className="mt-3 flex flex-col items-start">
         <Button
           type="button"
           variant="outline"
@@ -70,7 +70,7 @@ export function DescribeAssetsField(): ReactElement {
           onClick={() => setConfirming(true)}
           className="text-text-secondary"
         >
-          {running ? 'Backfilling…' : 'Backfill existing assets'}
+          {running ? 'Backfilling…' : 'Backfill assets'}
         </Button>
         {!hasProvider ? (
           <p className="mt-2 text-xs text-text-muted">Add an AI provider to enable this.</p>
@@ -80,7 +80,7 @@ export function DescribeAssetsField(): ReactElement {
         <Dialog open onOpenChange={(isOpen) => { if (!isOpen) setConfirming(false) }}>
           <DialogContent showCloseButton={false} className="max-w-sm">
             <DialogHeader>
-              <DialogTitle>Backfill existing assets?</DialogTitle>
+              <DialogTitle>Backfill assets?</DialogTitle>
               <DialogDescription>
                 Images and PDFs in non-private notes will be sent to your AI provider so their
                 text can appear in search. Assets that already have OCR are skipped.
@@ -91,7 +91,7 @@ export function DescribeAssetsField(): ReactElement {
                 Cancel
               </Button>
               <Button type="button" size="sm" onClick={() => void runBackfill()}>
-                Backfill existing assets
+                Backfill assets
               </Button>
             </DialogFooter>
           </DialogContent>

--- a/apps/desktop/src/components/settings/editor-section.tsx
+++ b/apps/desktop/src/components/settings/editor-section.tsx
@@ -1,11 +1,11 @@
 import type { ReactElement } from 'react'
 import type { EditorMarkdownSyntax } from '@reflect/core'
-import { Switch } from '@/components/ui/switch'
 import { cn } from '@/lib/utils'
 import { useSettings } from '@/providers/settings-provider'
 import { SettingsField } from './field'
 import { SettingsOptionCard } from './option-card'
 import { SettingsSection } from './section'
+import { SettingsSwitchField } from './switch-field'
 
 interface MarkdownSyntaxOption {
   value: EditorMarkdownSyntax
@@ -35,7 +35,7 @@ export function EditorSection(): ReactElement {
         legend="Markdown syntax"
         description="How literal markdown characters (#, **, [[ ]]) are displayed while editing."
       >
-        <div className="mt-3 flex flex-col gap-2">
+        <div className="mt-3 grid grid-cols-2 gap-2">
           {MARKDOWN_SYNTAX_OPTIONS.map((option) => {
             const selected = settings.editorMarkdownSyntax === option.value
             return (
@@ -71,44 +71,26 @@ export function EditorSection(): ReactElement {
         </div>
       </SettingsField>
 
-      <SettingsField
+      <SettingsSwitchField
         legend="Spell check"
         description="Underline misspelled words while you type."
-      >
-        <div className="mt-3 flex justify-end">
-          <Switch
-            aria-label="Spell check"
-            checked={settings.editorSpellCheck}
-            onCheckedChange={(checked) => updateSettings({ editorSpellCheck: checked })}
-          />
-        </div>
-      </SettingsField>
+        checked={settings.editorSpellCheck}
+        onCheckedChange={(checked) => updateSettings({ editorSpellCheck: checked })}
+      />
 
-      <SettingsField
+      <SettingsSwitchField
         legend="Start with a bullet"
         description="New and empty notes open with a single bullet point, ready to type."
-      >
-        <div className="mt-3 flex justify-end">
-          <Switch
-            aria-label="Start with a bullet"
-            checked={settings.editorDefaultBullet}
-            onCheckedChange={(checked) => updateSettings({ editorDefaultBullet: checked })}
-          />
-        </div>
-      </SettingsField>
+        checked={settings.editorDefaultBullet}
+        onCheckedChange={(checked) => updateSettings({ editorDefaultBullet: checked })}
+      />
 
-      <SettingsField
+      <SettingsSwitchField
         legend="Bullet after a heading"
         description="Pressing Return at the end of a heading starts a new bullet."
-      >
-        <div className="mt-3 flex justify-end">
-          <Switch
-            aria-label="Bullet after a heading"
-            checked={settings.editorBulletAfterHeading}
-            onCheckedChange={(checked) => updateSettings({ editorBulletAfterHeading: checked })}
-          />
-        </div>
-      </SettingsField>
+        checked={settings.editorBulletAfterHeading}
+        onCheckedChange={(checked) => updateSettings({ editorBulletAfterHeading: checked })}
+      />
     </SettingsSection>
   )
 }

--- a/apps/desktop/src/components/settings/rebuild-index-field.tsx
+++ b/apps/desktop/src/components/settings/rebuild-index-field.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactElement } from 'react'
+import { Button } from '@/components/ui/button'
 import { rebuildIndexVisibly } from '@/lib/rebuild-index'
 import { useGraph } from '@/providers/graph-provider'
 import { SettingsField } from './field'
@@ -32,15 +33,17 @@ export function RebuildIndexField(): ReactElement {
       legend="Rebuild index"
       description="Reflect keeps a local index of your notes to power search and links. If results ever look stale or incomplete, rebuild it — your notes are never changed."
     >
-      <div className="mt-3 flex justify-end">
-        <button
+      <div className="mt-3 flex justify-start">
+        <Button
           type="button"
+          variant="outline"
+          size="sm"
           disabled={indexGeneration === null || rebuilding}
           onClick={() => void rebuild()}
-          className="shrink-0 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-text-secondary transition-colors duration-100 hover:bg-surface-hover disabled:pointer-events-none disabled:opacity-50"
+          className="text-text-secondary"
         >
           {rebuilding ? 'Rebuilding…' : 'Rebuild index'}
-        </button>
+        </Button>
       </div>
     </SettingsField>
   )

--- a/apps/desktop/src/components/settings/switch-field.tsx
+++ b/apps/desktop/src/components/settings/switch-field.tsx
@@ -1,0 +1,43 @@
+import { useId, type ReactElement } from 'react'
+import { Switch } from '@/components/ui/switch'
+
+interface SettingsSwitchFieldProps {
+  /** The setting name shown beside the switch. */
+  legend: string
+  /** One-line explanation under the setting name. */
+  description: string
+  /** Whether the switch is enabled. */
+  checked: boolean
+  /** Persist the next switch state. */
+  onCheckedChange: (checked: boolean) => void
+}
+
+/**
+ * A compact settings row for boolean options: copy on the left, switch pinned
+ * to the far right and vertically centered with the row.
+ */
+export function SettingsSwitchField({
+  legend,
+  description,
+  checked,
+  onCheckedChange,
+}: SettingsSwitchFieldProps): ReactElement {
+  const labelId = useId()
+
+  return (
+    <div className="flex items-center justify-between gap-4 px-4 py-3.5">
+      <div className="min-w-0">
+        <div id={labelId} className="text-sm font-medium text-text">
+          {legend}
+        </div>
+        <p className="mt-0.5 text-xs text-text-muted">{description}</p>
+      </div>
+      <Switch
+        aria-labelledby={labelId}
+        checked={checked}
+        onCheckedChange={onCheckedChange}
+        className="shrink-0"
+      />
+    </div>
+  )
+}

--- a/apps/desktop/src/components/sidebar/graph-footer.tsx
+++ b/apps/desktop/src/components/sidebar/graph-footer.tsx
@@ -173,6 +173,13 @@ export function GraphFooter({ graph, context }: GraphFooterProps): ReactElement 
             <FolderOpen aria-hidden strokeWidth={1.75} className="size-3.5 shrink-0" />
             <span className="min-w-0 flex-1 truncate">Open another graph…</span>
           </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => void runCommand('settings.open', context)}
+            className={MENU_ITEM_CLASS}
+          >
+            <Settings aria-hidden strokeWidth={1.75} className="size-3.5 shrink-0" />
+            <span className="min-w-0 flex-1 truncate">User settings</span>
+          </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
       <Tooltip>

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -247,6 +247,15 @@ describe('Sidebar', () => {
     expect(pickAndOpen).toHaveBeenCalled()
   })
 
+  it('the graph footer opens user settings from the graph menu', async () => {
+    const { view, navigate } = renderSidebar()
+
+    await userEvent.click(view.getByRole('button', { name: /Notes/ }))
+    await userEvent.click(view.getByRole('menuitem', { name: /user settings/i }))
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ kind: 'settings' }))
+  })
+
   it('the graph footer opens the current graph in the system file manager', async () => {
     const { view } = renderSidebar()
 


### PR DESCRIPTION
## Summary
- place Focus and Show markdown syntax choices side-by-side in the editor settings
- align editor boolean settings as compact rows with text on the left and the switch pinned right
- add a reusable settings switch row component using the existing shadcn switch

## Testing
- pnpm check
- pnpm --filter @reflect/desktop test --run src/components/settings-screen.test.tsx

Note: pnpm check completed with existing lint warnings in unrelated files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only settings and navigation changes with no persistence or security logic touched.
> 
> **Overview**
> **Editor settings** get a tighter layout: Focus vs Show markdown syntax sit in a **two-column grid**, and spell check / bullet toggles move onto a shared **`SettingsSwitchField`** row (label left, switch right) instead of right-aligned switches inside `SettingsField`.
> 
> **Action buttons** in OCR and index settings align **left** and use the shared outline **`Button`**; OCR copy shortens to **“Backfill assets”** (tests updated).
> 
> The **graph footer** dropdown adds **User settings**, wired to `settings.open` like the gear button, with a sidebar test for navigation to settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0a8aefff96e36cf1f6a5c6ed0900de4d716aa84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->