### PR TITLE
Fix backup index lock recovery

### DIFF
--- a/apps/desktop/src-tauri/src/git/commit.rs
+++ b/apps/desktop/src-tauri/src/git/commit.rs
@@ -1,14 +1,26 @@
 //! Stage-everything commit with the large-file guardrail.
 
 use std::cell::RefCell;
+use std::fs;
 use std::path::Path;
+use std::thread;
+use std::time::Duration;
 
 use git2::{Index, IndexAddOption};
 use serde::Serialize;
 
-use crate::error::AppResult;
+use crate::error::{AppError, AppResult};
 
 use super::repo::{ensure_clean_state, open_existing, signature};
+
+const LOCK_RETRY_DELAY: Duration = Duration::from_millis(250);
+const LOCK_RETRIES: usize = 3;
+
+#[cfg(not(test))]
+const STALE_INDEX_LOCK_AGE: Duration = Duration::from_secs(30);
+
+#[cfg(test)]
+const STALE_INDEX_LOCK_AGE: Duration = Duration::from_secs(0);
 
 /// A file whose *changes* were withheld from staging because it is at/above
 /// the size guardrail. Oversized-but-unchanged files are not reported — their
@@ -44,6 +56,26 @@ pub(super) fn commit_all(
     message: &str,
     max_file_bytes: u64,
 ) -> AppResult<CommitOutcome> {
+    for attempt in 0..=LOCK_RETRIES {
+        match commit_all_once(root, message, max_file_bytes) {
+            Ok(outcome) => return Ok(outcome),
+            Err(error) if is_index_lock_error(&error) => {
+                if remove_stale_index_lock(root)? {
+                    continue;
+                }
+                if attempt < LOCK_RETRIES {
+                    thread::sleep(LOCK_RETRY_DELAY);
+                    continue;
+                }
+                return Err(index_lock_error(root));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Err(index_lock_error(root))
+}
+
+fn commit_all_once(root: &Path, message: &str, max_file_bytes: u64) -> AppResult<CommitOutcome> {
     let repo = open_existing(root)?;
     ensure_clean_state(&repo)?;
 
@@ -82,6 +114,50 @@ pub(super) fn commit_all(
         ahead: ahead_of_remote(&repo),
         skipped_large_files: skipped,
     })
+}
+
+fn is_index_lock_error(error: &AppError) -> bool {
+    match error {
+        AppError::Io { message } => {
+            let message = message.to_lowercase();
+            message.contains("index is locked") || message.contains("index.lock")
+        }
+        _ => false,
+    }
+}
+
+fn remove_stale_index_lock(root: &Path) -> AppResult<bool> {
+    let repo = open_existing(root)?;
+    let lock_path = repo.path().join("index.lock");
+    let metadata = match fs::metadata(&lock_path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    let Ok(modified) = metadata.modified() else {
+        return Ok(false);
+    };
+    let Ok(age) = modified.elapsed() else {
+        return Ok(false);
+    };
+    if age < STALE_INDEX_LOCK_AGE {
+        return Ok(false);
+    }
+    match fs::remove_file(&lock_path) {
+        Ok(()) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn index_lock_error(root: &Path) -> AppError {
+    let lock_path = open_existing(root)
+        .map(|repo| repo.path().join("index.lock"))
+        .unwrap_or_else(|_| root.join(".git/index.lock"));
+    AppError::io(format!(
+        "Git is still holding the backup index lock. Close any Git command using this graph and try again. If Reflect crashed earlier, remove {} once no Git command is running.",
+        lock_path.display()
+    ))
 }
 
 /// Stage every change (adds, edits, deletes — `.gitignore` respected) into

--- a/apps/desktop/src-tauri/src/git/mod.rs
+++ b/apps/desktop/src-tauri/src/git/mod.rs
@@ -23,6 +23,7 @@ mod repo;
 mod tests;
 
 use std::path::Path;
+use std::sync::{Mutex, OnceLock};
 
 use serde::Serialize;
 use tauri::State;
@@ -36,6 +37,8 @@ use self::remote::{PushOutcome, RemoteDelta};
 
 /// GitHub rejects files over 100 MB, failing the whole push; stop just under.
 const MAX_FILE_BYTES: u64 = 95 * 1024 * 1024;
+
+static GIT_COMMAND_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 /// Snapshot of the graph's backup repository for the UI and the sync engine.
 /// Deliberately cheap — refs and config only, no working-tree scan.
@@ -125,6 +128,22 @@ where
         .map_err(|err| AppError::io(format!("git task panicked: {err}")))?
 }
 
+async fn run_serialized_blocking<T, F>(task: F) -> AppResult<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> AppResult<T> + Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(move || {
+        let _guard = GIT_COMMAND_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .map_err(|err| AppError::io(format!("git command lock poisoned: {err}")))?;
+        task()
+    })
+    .await
+    .map_err(|err| AppError::io(format!("git task panicked: {err}")))?
+}
+
 /// Snapshot the backup repository (cheap, no network).
 #[tauri::command]
 pub async fn git_status(generation: u64, state: State<'_, GraphState>) -> AppResult<GitStatus> {
@@ -145,7 +164,7 @@ pub async fn git_setup(
     state: State<'_, GraphState>,
 ) -> AppResult<GitStatus> {
     let root = crate::fs::root_for_generation(&state, generation)?;
-    run_blocking(move || setup(&root, remote_url, branch)).await
+    run_serialized_blocking(move || setup(&root, remote_url, branch)).await
 }
 
 /// Stop backing this graph up (drop `origin`; repo, history, and the
@@ -153,7 +172,7 @@ pub async fn git_setup(
 #[tauri::command]
 pub async fn git_disconnect(generation: u64, state: State<'_, GraphState>) -> AppResult<GitStatus> {
     let root = crate::fs::root_for_generation(&state, generation)?;
-    run_blocking(move || disconnect(&root)).await
+    run_serialized_blocking(move || disconnect(&root)).await
 }
 
 /// Clone a backup repository into `path` (restore on a fresh machine). Runs
@@ -161,7 +180,7 @@ pub async fn git_disconnect(generation: u64, state: State<'_, GraphState>) -> Ap
 /// a graph-relative path; the caller opens the result as a graph afterwards.
 #[tauri::command]
 pub async fn git_clone(url: String, path: String, token: Option<String>) -> AppResult<()> {
-    run_blocking(move || remote::clone(&url, Path::new(&path), token)).await
+    run_serialized_blocking(move || remote::clone(&url, Path::new(&path), token)).await
 }
 
 /// Commit every pending change (no-op when clean). See [`commit::commit_all`].
@@ -172,7 +191,7 @@ pub async fn git_commit_all(
     state: State<'_, GraphState>,
 ) -> AppResult<CommitOutcome> {
     let root = crate::fs::root_for_generation(&state, generation)?;
-    run_blocking(move || commit::commit_all(&root, &message, MAX_FILE_BYTES)).await
+    run_serialized_blocking(move || commit::commit_all(&root, &message, MAX_FILE_BYTES)).await
 }
 
 /// Fetch `origin` and report ahead/behind for the current branch.
@@ -183,7 +202,7 @@ pub async fn git_fetch(
     state: State<'_, GraphState>,
 ) -> AppResult<RemoteDelta> {
     let root = crate::fs::root_for_generation(&state, generation)?;
-    run_blocking(move || remote::fetch(&root, token)).await
+    run_serialized_blocking(move || remote::fetch(&root, token)).await
 }
 
 /// Merge the fetched remote branch; conflicts are committed into the notes as
@@ -194,7 +213,7 @@ pub async fn git_merge_remote(
     state: State<'_, GraphState>,
 ) -> AppResult<MergeOutcome> {
     let root = crate::fs::root_for_generation(&state, generation)?;
-    run_blocking(move || merge::merge_remote(&root)).await
+    run_serialized_blocking(move || merge::merge_remote(&root)).await
 }
 
 /// Push the current branch to `origin`; rejections come back as data so the
@@ -206,5 +225,5 @@ pub async fn git_push(
     state: State<'_, GraphState>,
 ) -> AppResult<PushOutcome> {
     let root = crate::fs::root_for_generation(&state, generation)?;
-    run_blocking(move || remote::push(&root, token)).await
+    run_serialized_blocking(move || remote::push(&root, token)).await
 }

--- a/apps/desktop/src-tauri/src/git/tests.rs
+++ b/apps/desktop/src-tauri/src/git/tests.rs
@@ -135,6 +135,20 @@ fn commit_excludes_reflect_and_skips_when_clean() {
 }
 
 #[test]
+fn commit_recovers_a_stale_index_lock() {
+    let fixture = fixture();
+    let root = &fixture.graph_a;
+    fs::write(root.join(".git/index.lock"), "stale lock").unwrap();
+    write(root, "notes/a.md", "# A\n");
+
+    let outcome = commit_all(root, "Update notes", MAX_FILE_BYTES).unwrap();
+
+    assert!(outcome.committed);
+    assert!(!root.join(".git/index.lock").exists());
+    assert!(head_tree_paths(root).contains(&"notes/a.md".to_string()));
+}
+
+#[test]
 fn commit_records_deletions() {
     let fixture = fixture();
     let root = &fixture.graph_a;


### PR DESCRIPTION
## Summary
- Serialize mutating Git backup commands at the native boundary so Reflect does not race its own backup operations.
- Retry transient Git index-lock failures and recover stale .git/index.lock files after a conservative age.
- Add coverage for stale index-lock recovery during backup commits.

## Verification
- pnpm --filter @reflect/desktop sidecar
- cargo test -p reflect-open git::tests
- pnpm check
- pnpm build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes backup commit/sync concurrency and can remove `index.lock` after a timeout; low risk of corrupting an active Git process if the age gate is wrong, but scope is limited to the desktop backup layer.
> 
> **Overview**
> Backup Git operations no longer run concurrently from the desktop app: mutating Tauri commands (`git_setup`, `git_commit_all`, fetch/merge/push, clone, etc.) go through a process-wide mutex via **`run_serialized_blocking`**, while read-only **`git_status`** stays on the old blocking path.
> 
> **`commit_all`** now retries when the index is locked—up to three waits with a short delay—and can delete a **stale** `.git/index.lock` (30s threshold in production, immediate in tests) before retrying. Persistent locks surface a clearer IO error that points users at the lock file and external Git usage.
> 
> Adds **`commit_recovers_a_stale_index_lock`** to assert commits succeed after a leftover lock file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b40f806e5073759d1ee55b1a2dc23e5a7f4bffbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->