### PR TITLE
fix(git): auto-recover from a stale .git/index.lock

### DIFF
--- a/apps/desktop/src-tauri/src/git/commit.rs
+++ b/apps/desktop/src-tauri/src/git/commit.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 
 use crate::error::AppResult;
 
-use super::repo::{ensure_clean_state, open_existing, signature};
+use super::repo::{ensure_clean_state, open_for_write, signature};
 
 /// A file whose *changes* were withheld from staging because it is at/above
 /// the size guardrail. Oversized-but-unchanged files are not reported — their
@@ -44,7 +44,7 @@ pub(super) fn commit_all(
     message: &str,
     max_file_bytes: u64,
 ) -> AppResult<CommitOutcome> {
-    let repo = open_existing(root)?;
+    let repo = open_for_write(root)?;
     ensure_clean_state(&repo)?;
 
     let mut index = repo.index()?;

--- a/apps/desktop/src-tauri/src/git/lock.rs
+++ b/apps/desktop/src-tauri/src/git/lock.rs
@@ -1,0 +1,121 @@
+//! Stale `.git/index.lock` recovery.
+//!
+//! libgit2 stages a commit by writing the new index into `.git/index.lock` and
+//! atomically renaming it over `.git/index`. A process killed mid-commit — a
+//! `tauri dev` reload, an OS kill, a hard crash — leaves that lock behind, and
+//! every later commit or merge then fails with libgit2's `Locked` error ("the
+//! index is locked; this might be due to a concurrent or crashed process").
+//! Backup stays silently broken until the file is deleted by hand.
+//!
+//! Reflect serializes its own git operations and only one app instance writes a
+//! given graph, so a lock that has sat untouched far longer than any commit
+//! takes can only be such a leftover. We remove it before a write and let
+//! libgit2 reacquire it cleanly. A *fresh* lock is never touched: deleting one a
+//! live writer just created would corrupt that write, so the age gate always
+//! errs toward leaving it — a still-live lock simply fails this cycle and is
+//! reconsidered, now older, on the next.
+
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+use crate::error::AppResult;
+
+/// A healthy commit holds `.git/index.lock` for milliseconds; a lock older than
+/// this is a leftover, not an in-flight write. Deliberately generous — waiting
+/// one extra sync cycle to clear a truly stale lock costs nothing next to the
+/// risk of deleting a live one.
+const STALE_LOCK_AGE: Duration = Duration::from_secs(60);
+
+/// Remove `<git_dir>/index.lock` if it is present and provably stale (its mtime
+/// is at least [`STALE_LOCK_AGE`] in the past). Returns whether a lock was
+/// removed. `git_dir` is the repository's git directory (`repo.path()`), so this
+/// is correct whatever the `.git` layout.
+///
+/// Best-effort by design: a missing lock, a fresh lock, an unreadable mtime, or
+/// a lock another recovery removed first all return `Ok(false)` without error.
+/// Recovery must never turn a transient filesystem hiccup into a backup failure;
+/// only an unexpected delete error propagates.
+pub(super) fn clear_stale_index_lock(git_dir: &Path) -> AppResult<bool> {
+    let lock_path = git_dir.join("index.lock");
+    let Ok(metadata) = std::fs::metadata(&lock_path) else {
+        return Ok(false); // no lock (or unreadable) — nothing to recover
+    };
+    let Ok(modified) = metadata.modified() else {
+        return Ok(false); // platform without mtime — refuse to guess
+    };
+    if !is_stale(modified, SystemTime::now()) {
+        return Ok(false);
+    }
+    match std::fs::remove_file(&lock_path) {
+        Ok(()) => {
+            tracing::warn!(
+                ?lock_path,
+                "cleared a stale git index lock left by an interrupted backup"
+            );
+            Ok(true)
+        }
+        // The owner (or a concurrent recovery) winning the delete race lands on
+        // the same end state we wanted: the lock is gone.
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Whether a lock last modified at `modified` is old enough to be a leftover. A
+/// future mtime (clock skew, an odd filesystem clock) reads as fresh — we only
+/// ever remove a lock we can prove is old.
+fn is_stale(modified: SystemTime, now: SystemTime) -> bool {
+    now.duration_since(modified)
+        .map(|age| age >= STALE_LOCK_AGE)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::time::{Duration, SystemTime};
+
+    use tempfile::tempdir;
+
+    use super::{clear_stale_index_lock, is_stale, STALE_LOCK_AGE};
+
+    /// Write a `<dir>/index.lock` whose mtime is `age` in the past. The file
+    /// handle is dropped before we return, so the recovery under test can remove
+    /// it on every platform.
+    fn write_lock_with_age(git_dir: &std::path::Path, age: Duration) {
+        let lock_path = git_dir.join("index.lock");
+        fs::write(&lock_path, b"").unwrap();
+        let file = fs::File::options().write(true).open(&lock_path).unwrap();
+        file.set_modified(SystemTime::now() - age).unwrap();
+    }
+
+    #[test]
+    fn removes_a_stale_lock() {
+        let dir = tempdir().unwrap();
+        write_lock_with_age(dir.path(), STALE_LOCK_AGE + Duration::from_secs(5));
+
+        assert!(clear_stale_index_lock(dir.path()).unwrap());
+        assert!(!dir.path().join("index.lock").exists());
+    }
+
+    #[test]
+    fn leaves_a_fresh_lock() {
+        let dir = tempdir().unwrap();
+        write_lock_with_age(dir.path(), Duration::from_secs(1));
+
+        assert!(!clear_stale_index_lock(dir.path()).unwrap());
+        assert!(dir.path().join("index.lock").exists());
+    }
+
+    #[test]
+    fn no_lock_is_a_noop() {
+        let dir = tempdir().unwrap();
+        assert!(!clear_stale_index_lock(dir.path()).unwrap());
+    }
+
+    #[test]
+    fn future_mtime_reads_as_fresh() {
+        let now = SystemTime::now();
+        assert!(!is_stale(now + Duration::from_secs(120), now));
+    }
+}

--- a/apps/desktop/src-tauri/src/git/merge.rs
+++ b/apps/desktop/src-tauri/src/git/merge.rs
@@ -28,7 +28,7 @@ use serde::Serialize;
 
 use crate::error::AppResult;
 
-use super::repo::{current_branch, ensure_clean_state, open_existing, signature};
+use super::repo::{current_branch, ensure_clean_state, open_for_write, signature};
 
 /// Conflict-marker labels. "this device" is the local side, "other device"
 /// the remote one — product language, not branch names.
@@ -97,7 +97,7 @@ fn side_of(entry: Option<IndexEntry>) -> Option<ConflictSide> {
 /// Merge the fetched `origin/<branch>` into the local branch. Pre-condition
 /// (the sync engine guarantees it): local changes are already committed.
 pub(super) fn merge_remote(root: &Path) -> AppResult<MergeOutcome> {
-    let repo = open_existing(root)?;
+    let repo = open_for_write(root)?;
     ensure_clean_state(&repo)?;
     let branch = current_branch(&repo)?;
     let Ok(remote_oid) = repo.refname_to_id(&format!("refs/remotes/origin/{branch}")) else {

--- a/apps/desktop/src-tauri/src/git/mod.rs
+++ b/apps/desktop/src-tauri/src/git/mod.rs
@@ -16,6 +16,7 @@
 //! The one exception is `git_clone`, which runs before any graph is open.
 
 mod commit;
+mod lock;
 mod merge;
 mod remote;
 mod repo;

--- a/apps/desktop/src-tauri/src/git/repo.rs
+++ b/apps/desktop/src-tauri/src/git/repo.rs
@@ -31,6 +31,16 @@ pub(super) fn open_existing(root: &Path) -> AppResult<Repository> {
     Ok(Repository::open(root)?)
 }
 
+/// Open the graph's repository for a *write* (commit/merge), first clearing a
+/// stale `.git/index.lock` so a backup an earlier crash interrupted can't wedge
+/// every future one. See [`super::lock`]. Read-only callers use
+/// [`open_existing`], which never touches the lock.
+pub(super) fn open_for_write(root: &Path) -> AppResult<Repository> {
+    let repo = open_existing(root)?;
+    super::lock::clear_stale_index_lock(repo.path())?;
+    Ok(repo)
+}
+
 /// Refuse to operate on a repository mid-operation (a rebase/merge the user
 /// started with the git CLI). Guessing here could destroy their state.
 pub(super) fn ensure_clean_state(repo: &Repository) -> AppResult<()> {

--- a/apps/desktop/src-tauri/src/git/tests.rs
+++ b/apps/desktop/src-tauri/src/git/tests.rs
@@ -4,6 +4,7 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
 
 use git2::{Repository, RepositoryInitOptions};
 use tempfile::{tempdir, TempDir};
@@ -145,6 +146,40 @@ fn commit_records_deletions() {
     let outcome = commit_all(root, "delete", MAX_FILE_BYTES).unwrap();
     assert!(outcome.committed);
     assert!(!head_tree_paths(root).contains(&"notes/gone.md".to_string()));
+}
+
+/// Plant a `.git/index.lock` whose mtime is `age` in the past, standing in for
+/// one a crashed or force-quit process left behind.
+fn plant_index_lock(root: &Path, age: Duration) {
+    let lock_path = root.join(".git").join("index.lock");
+    fs::write(&lock_path, b"").unwrap();
+    let file = fs::File::options().write(true).open(&lock_path).unwrap();
+    file.set_modified(SystemTime::now() - age).unwrap();
+}
+
+#[test]
+fn commit_recovers_from_a_stale_index_lock() {
+    let fixture = fixture();
+    let root = &fixture.graph_a;
+    write(root, "notes/a.md", "# A\n");
+    plant_index_lock(root, Duration::from_secs(120));
+
+    let outcome = commit_all(root, "Update notes", MAX_FILE_BYTES).unwrap();
+    assert!(outcome.committed, "a stale lock must not block the commit");
+    assert!(!root.join(".git/index.lock").exists());
+}
+
+#[test]
+fn commit_leaves_a_fresh_index_lock_alone() {
+    let fixture = fixture();
+    let root = &fixture.graph_a;
+    write(root, "notes/a.md", "# A\n");
+    // A lock this young could belong to a live writer; removing it would corrupt
+    // that write, so the commit must fail rather than steal the lock.
+    plant_index_lock(root, Duration::from_secs(1));
+
+    assert!(commit_all(root, "Update notes", MAX_FILE_BYTES).is_err());
+    assert!(root.join(".git/index.lock").exists());
 }
 
 #[test]


### PR DESCRIPTION
## What

Backup fails with **"backup failed. The index is locked. This might be due to concurrent or crash process"** when a previous backup was interrupted mid-commit. Despite the wording, this is the **git** index, not the SQLite one: libgit2 writes the new index into `.git/index.lock` and atomically renames it over `.git/index`, and a process killed mid-commit (a `tauri dev` reload, an OS kill, a crash) leaves the lock behind. Every later `commit_all`/`merge_remote` then fails with libgit2's `Locked` error, and backup stays **silently broken until the file is deleted by hand**.

There was no stale-lock recovery anywhere in the backup code.

## How

- New `git::lock` module: `clear_stale_index_lock(git_dir)` removes `index.lock` **only if provably stale** — its mtime is ≥ 60s old. A healthy commit holds the lock for milliseconds, so 60s can only be a leftover.
- New `repo::open_for_write(root)`: `open_existing` + clear-stale-lock. `commit_all` and `merge_remote` route through it; read-only paths (`status`, `disconnect`) keep using `open_existing` and never touch the lock.
- A **fresh** lock (a possibly-live concurrent writer) is deliberately left alone — removing one a live writer just created would corrupt that write. It fails this cycle and is reconsidered, now older, on the next. The sync engine already classifies a `Locked` error as a retryable `other`, so it self-heals once the lock ages past the threshold.

## Why this is safe

The removal gate is age-only and generous: we never delete a lock we can't prove is old (missing lock, fresh lock, unreadable/future mtime → no-op). Reflect serializes its own git operations and only one app instance writes a given graph, so a long-untouched lock can't be a live one.

## Testing

- `cargo test -p reflect-open git::` — 37 passed (4 new).
  - `git::lock::tests`: stale lock removed, fresh lock kept, no-lock no-op, future-mtime reads fresh.
  - `git::tests::commit_recovers_from_a_stale_index_lock` / `commit_leaves_a_fresh_index_lock_alone` — end-to-end through `commit_all`.
- `cargo clippy -p reflect-open --all-targets` — clean.

Rust-only change, so TS typecheck/lint is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches backup write paths and deletes lock files based on age; conservative gates limit corruption risk, but mistaken stale detection could still interfere with a rare long-running git operation.
> 
> **Overview**
> Fixes backup wedging after an interrupted commit leaves **`.git/index.lock`** behind, which makes every later commit/merge fail until the file is removed manually.
> 
> Adds **`git::lock`** with **`clear_stale_index_lock`**: deletes `index.lock` only when its mtime is at least **60 seconds** old; missing, fresh, or unreadable mtimes are left alone so a possibly live writer is not disturbed. **`repo::open_for_write`** runs that recovery before writes; **`commit_all`** and **`merge_remote`** use it, while read-only paths (**`status`**, **`disconnect`**) still use **`open_existing`**.
> 
> Unit and integration tests cover stale vs fresh locks end-to-end through **`commit_all`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19b65394daa6e6c3930b1320a39f46282c93fe9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->