### PR TITLE
Fix relative date unit prefixes

### DIFF
--- a/packages/core/src/indexing/date-suggestions.test.ts
+++ b/packages/core/src/indexing/date-suggestions.test.ts
@@ -48,6 +48,17 @@ describe('generateDateSuggestions', () => {
       ])
     })
 
+    it('prefix-matches relative units as they are typed', () => {
+      expect(gen('3 d')).toEqual([
+        { date: '2020-01-04', phrase: '3 days from now' },
+        { date: '2019-12-29', phrase: '3 days ago' },
+      ])
+      expect(gen('3 w')).toEqual([
+        { date: '2020-01-22', phrase: '3 weeks from now' },
+        { date: '2019-12-11', phrase: '3 weeks ago' },
+      ])
+    })
+
     it('drops offsets beyond the ~15-year sanity limit', () => {
       expect(gen('17 years')).toEqual([])
       expect(gen('1000 years')).toEqual([])

--- a/packages/core/src/indexing/date-suggestions.ts
+++ b/packages/core/src/indexing/date-suggestions.ts
@@ -77,17 +77,6 @@ const SPELLED_NUMBERS: Record<string, number> = {
   ten: 10,
 }
 
-const UNIT_WORDS: Record<string, Unit> = {
-  day: 'day',
-  days: 'day',
-  week: 'week',
-  weeks: 'week',
-  month: 'month',
-  months: 'month',
-  year: 'year',
-  years: 'year',
-}
-
 function extractNumber(tokens: readonly string[]): number | null {
   for (const token of tokens) {
     if (/^\d+$/.test(token)) {
@@ -103,7 +92,7 @@ function extractNumber(tokens: readonly string[]): number | null {
 
 function extractUnit(tokens: readonly string[]): Unit | null {
   for (const token of tokens) {
-    const unit = UNIT_WORDS[token]
+    const unit = UNITS.find((candidate) => candidate.startsWith(token) || `${candidate}s`.startsWith(token))
     if (unit !== undefined) {
       return unit
     }


### PR DESCRIPTION
## Summary
- Prefix-match relative date units so partial queries like `3 d` generate day offsets
- Add regression coverage for day and week unit prefixes

## Testing
- `pnpm --filter @reflect/core exec vitest run src/indexing/date-suggestions.test.ts`
- `pnpm check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to date-suggestion parsing in `@reflect/core` with targeted tests and no auth or data-path impact.
> 
> **Overview**
> **Relative date autocomplete** now recognizes **partial unit tokens** (e.g. `3 d`, `3 w`) instead of requiring full words like `days` or `weeks`.
> 
> `extractUnit` drops the `UNIT_WORDS` map and **prefix-matches** each token against the canonical `UNITS` list (`day`/`days`, `week`/`weeks`, etc.), so in-progress typing still resolves to the right offset and shows both directions when no `ago` / `from now` is given. Regression tests cover day and week prefixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb8665fda7f0d5db4f4cddd1f2cc8e196cf9d5e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Date suggestions now recognize abbreviated relative date units (e.g., "3 d", "3 w").

<!-- end of auto-generated comment: release notes by coderabbit.ai -->