### PR TITLE
Fix note title body sizing

### DIFF
--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -307,15 +307,17 @@ body {
   letter-spacing: var(--tracking-snug, -0.01em);
   margin: 1.25em 0 0.4em;
 }
-/* Cap headings at --text-xl: the leading H1 is the note title and in-prose
-   `# headings` shouldn't tower over the body, so neither H1 nor H2 exceeds the
-   design-system "note title" size, matching the daily date heading
-   (.reflect-daily-subject) and the new-note "Untitled" ghost. */
+/* Keep the leading H1 note title at body size so regular note titles and the
+   new-note "Untitled" ghost match daily-note prose. Other headings stay capped
+   at the design-system note-title size rather than towering over the body. */
 .reflect-editor h1 { font-size: var(--text-xl, 1.25rem); }
 .reflect-editor h2 { font-size: var(--text-xl, 1.25rem); }
 .reflect-editor h3 { font-size: var(--text-lg, 1.125rem); }
-.reflect-editor h1:first-child { margin-top: 0; }
-.reflect-editor .reflect-note-title { font-size: var(--text-xl, 1.25rem); }
+.reflect-editor h1:first-child {
+  margin-top: 0;
+  font-size: var(--text-base, 1rem);
+}
+.reflect-editor .reflect-note-title { font-size: var(--text-base, 1rem); }
 
 /* The new-note flow's name field: ghost "Untitled" over the seeded empty H1
    (`editor/title-placeholder.ts`) without occupying layout, so the caret


### PR DESCRIPTION
## Summary
- Reduce regular note H1/title sizing to the editor body token so authored titles match daily-note prose
- Keep the separate daily date subject styling unchanged

## Testing
- pnpm check (passes; existing lint warnings only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only typography tweaks in the desktop editor stylesheet with no logic or data changes.
> 
> **Overview**
> **Regular note titles** in the reflect editor no longer use the larger note-title token: the **first `h1`** and **`.reflect-note-title`** now use **`--text-base`** so authored titles and the new-note “Untitled” ghost align with **daily-note body prose**.
> 
> **In-editor `h2`/`h3`** stay capped at **`--text-xl`** / **`--text-lg`**; **`reflect-daily-subject`** (date heading outside the editor) is **unchanged** at **`--text-xl`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dfbcfb0a28a51b3ecdd151f7ebed0f2d92285f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated editor heading typography, adjusting the visual sizing of note titles and secondary headings to improve consistency across the editor interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->