### PR TITLE
feat: update meowdown to 0.12.0 with image lightbox and link opening

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,8 +16,8 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@meowdown/core": "0.11.1",
-    "@meowdown/react": "0.11.1",
+    "@meowdown/core": "0.12.0",
+    "@meowdown/react": "0.12.0",
     "@reflect/core": "workspace:*",
     "@reflect/db": "workspace:*",
     "@reflect/design-system": "workspace:*",

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
     "core:window:allow-start-dragging",
     "core:window:allow-destroy",
     "opener:default",
+    "opener:allow-open-path",
     "dialog:default",
     {
       "identifier": "http:default",

--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -99,6 +99,7 @@ export function NotePane({
   })
   const {
     resolveImageUrl,
+    resolveImageOpenPath,
     saveImage,
     onImageSaveError,
     saveError: imageSaveError,
@@ -212,6 +213,7 @@ export function NotePane({
         spellCheck={settings.editorSpellCheck}
         bulletAfterHeading={settings.editorBulletAfterHeading}
         resolveImageUrl={resolveImageUrl}
+        resolveImageOpenPath={resolveImageOpenPath}
         saveImage={saveImage}
         onImageSaveError={onImageSaveError}
         onWikiLinkClick={onWikiLinkClick}

--- a/apps/desktop/src/components/ui/dialog.tsx
+++ b/apps/desktop/src/components/ui/dialog.tsx
@@ -47,15 +47,17 @@ function DialogOverlay({
 
 function DialogContent({
   className,
+  overlayClassName,
   children,
   showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  overlayClassName?: string
   showCloseButton?: boolean
 }) {
   return (
     <DialogPortal>
-      <DialogOverlay />
+      <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(

--- a/apps/desktop/src/editor/image-lightbox.tsx
+++ b/apps/desktop/src/editor/image-lightbox.tsx
@@ -1,0 +1,66 @@
+import { type ReactElement } from 'react'
+import { ExternalLinkIcon } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { LightboxDialog } from '@/editor/lightbox-dialog'
+import { type LightboxTransitionItem } from '@/editor/use-lightbox-transition'
+
+export const IMAGE_LIGHTBOX_TRANSITION_NAME = 'reflect-image-lightbox'
+
+/** Image data rendered by the editor lightbox. */
+export interface LightboxImage extends LightboxTransitionItem {
+  /** Displayable URL, already resolved from the markdown `src`. */
+  src: string
+  alt: string
+  /** Local file path to open natively, or null for a remote image. */
+  openPath: string | null
+}
+
+interface ImageLightboxProps {
+  image: LightboxImage | null
+  onClose: () => void
+  onOpenImage?: (image: LightboxImage) => void
+}
+
+export function ImageLightbox({
+  image,
+  onClose,
+  onOpenImage,
+}: ImageLightboxProps): ReactElement | null {
+  if (image === null) {
+    return null
+  }
+  const canOpenImage = image.openPath !== null && onOpenImage !== undefined
+
+  return (
+    <LightboxDialog open title="Image preview" onClose={onClose}>
+      {canOpenImage ? (
+        <div className="absolute top-4 right-4 z-10">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="bg-white/70 text-text hover:bg-white"
+            onClick={() => onOpenImage(image)}
+          >
+            <ExternalLinkIcon data-icon="inline-start" />
+            Open
+          </Button>
+        </div>
+      ) : null}
+      <button
+        type="button"
+        aria-label="Close image preview"
+        className="flex max-h-full max-w-full cursor-zoom-out items-center justify-center bg-transparent p-0"
+        onClick={onClose}
+      >
+        <img
+          src={image.src}
+          alt={image.alt}
+          draggable={false}
+          className="max-h-full max-w-full select-none object-contain"
+          style={{ viewTransitionName: image.transitionName }}
+        />
+      </button>
+    </LightboxDialog>
+  )
+}

--- a/apps/desktop/src/editor/lightbox-dialog.tsx
+++ b/apps/desktop/src/editor/lightbox-dialog.tsx
@@ -1,0 +1,49 @@
+import { type ReactElement, type ReactNode } from 'react'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+
+interface LightboxDialogProps {
+  open: boolean
+  title: string
+  children: ReactNode
+  onClose: () => void
+}
+
+/**
+ * Full-window, chrome-free dialog shell for editor lightbox experiences.
+ */
+export function LightboxDialog({
+  open,
+  title,
+  children,
+  onClose,
+}: LightboxDialogProps): ReactElement | null {
+  if (!open) {
+    return null
+  }
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          onClose()
+        }
+      }}
+    >
+      <DialogContent
+        aria-describedby={undefined}
+        showCloseButton={false}
+        overlayClassName="bg-white/80 backdrop-blur-0 supports-backdrop-filter:backdrop-blur-0"
+        className="fixed inset-0 top-0 left-0 z-50 flex h-dvh w-dvw max-w-none translate-x-0 translate-y-0 items-center justify-center overflow-hidden rounded-none bg-white/90 p-6 ring-0 outline-none sm:max-w-none"
+        onPointerDown={(event) => {
+          if (event.target === event.currentTarget) {
+            onClose()
+          }
+        }}
+      >
+        <DialogTitle className="sr-only">{title}</DialogTitle>
+        {children}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -1,0 +1,167 @@
+import { type ReactNode } from 'react'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom/vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { openPath, openUrl } from '@tauri-apps/plugin-opener'
+import { NoteEditor } from './note-editor'
+
+/** Props the mocked `<MeowdownEditor>` captures so the test can drive its callbacks. */
+interface CapturedEditorProps {
+  editorClassName?: string
+  children?: ReactNode
+  resolveImageUrl?: (src: string) => string | undefined
+  onImageClick?: (payload: { src: string; alt: string; event: MouseEvent }) => void
+  onLinkClick?: (payload: { href: string; event: MouseEvent }) => void
+}
+
+const captured = vi.hoisted(() => ({ props: null as CapturedEditorProps | null }))
+
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  openPath: vi.fn(async () => {}),
+  openUrl: vi.fn(async () => {}),
+}))
+
+// Stub the editor: capture its props and render the image-preview DOM shape
+// meowdown produces, so the source element lookup in `onImageClick` resolves.
+vi.mock('@meowdown/react', () => ({
+  MeowdownEditor: (props: CapturedEditorProps) => {
+    captured.props = props
+    return (
+      <div className={props.editorClassName}>
+        <span className="md-image-preview md-image-preview-img">
+          <img
+            src={props.resolveImageUrl?.('assets/cat.png') ?? ''}
+            alt="Cat"
+            data-testid="inline-image"
+          />
+        </span>
+        {props.children}
+      </div>
+    )
+  },
+}))
+
+function renderEditor(): ReturnType<typeof render> {
+  return render(
+    <NoteEditor
+      initialContent={'A photo\n\n![Cat](assets/cat.png)'}
+      resolveImageUrl={(src) => (src === 'assets/cat.png' ? 'asset://cat.png' : null)}
+      resolveImageOpenPath={(src) =>
+        src === 'assets/cat.png' ? '/graph/assets/cat.png' : null
+      }
+    />,
+  )
+}
+
+/** A click payload as meowdown's `onImageClick` would deliver it. */
+function imageClick(src: string, alt: string): { src: string; alt: string; event: MouseEvent } {
+  const image = screen.getByTestId('inline-image')
+  const event = new MouseEvent('click', { bubbles: true })
+  Object.defineProperty(event, 'target', { value: image, configurable: true })
+  return { src, alt, event }
+}
+
+function installViewTransitionMock(): ReturnType<typeof vi.fn> {
+  const startViewTransition = vi.fn((callback?: () => unknown): ViewTransition => {
+    const update = callback?.()
+    return {
+      finished: Promise.resolve(),
+      ready: Promise.resolve(),
+      updateCallbackDone: Promise.resolve(update).then(() => undefined),
+      skipTransition: vi.fn(),
+      types: new Set<string>() as unknown as ViewTransitionTypeSet,
+    }
+  })
+  Object.defineProperty(document, 'startViewTransition', {
+    configurable: true,
+    writable: true,
+    value: startViewTransition,
+  })
+  return startViewTransition
+}
+
+beforeEach(() => {
+  captured.props = null
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn((query: string): MediaQueryList => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+  Element.prototype.getAnimations = vi.fn(() => [])
+  Object.defineProperty(document, 'startViewTransition', {
+    configurable: true,
+    writable: true,
+    value: undefined,
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('NoteEditor image lightbox', () => {
+  it('opens a lightbox from an inline image and closes on Escape', async () => {
+    renderEditor()
+    expect(captured.props?.onImageClick).toBeTypeOf('function')
+
+    act(() => captured.props?.onImageClick?.(imageClick('assets/cat.png', 'Cat')))
+
+    const dialog = await screen.findByRole('dialog', { name: 'Image preview' })
+    const preview = dialog.querySelector('img')
+    expect(preview).toBeInstanceOf(HTMLImageElement)
+    expect(preview?.src).toBe('asset://cat.png')
+
+    await userEvent.keyboard('{Escape}')
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+  })
+
+  it('uses the native View Transition API when available', async () => {
+    const startViewTransition = installViewTransitionMock()
+    renderEditor()
+
+    act(() => captured.props?.onImageClick?.(imageClick('assets/cat.png', 'Cat')))
+
+    expect(startViewTransition).toHaveBeenCalledTimes(1)
+    expect(await screen.findByRole('dialog', { name: 'Image preview' })).toBeInTheDocument()
+  })
+
+  it('opens a local image in Preview', async () => {
+    renderEditor()
+
+    act(() => captured.props?.onImageClick?.(imageClick('assets/cat.png', 'Cat')))
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Open' }))
+    expect(openPath).toHaveBeenCalledWith('/graph/assets/cat.png', 'Preview')
+  })
+
+  it('does not open a lightbox when the source cannot be resolved', () => {
+    renderEditor()
+
+    act(() => captured.props?.onImageClick?.(imageClick('https://blocked.example/x.png', 'X')))
+
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+})
+
+describe('NoteEditor link opening', () => {
+  it('opens external links via onLinkClick', () => {
+    renderEditor()
+    expect(captured.props?.onLinkClick).toBeTypeOf('function')
+
+    const event = new MouseEvent('click')
+    act(() => captured.props?.onLinkClick?.({ href: 'https://example.com', event }))
+
+    expect(openUrl).toHaveBeenCalledWith('https://example.com')
+  })
+})

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -7,6 +7,7 @@ import {
   type ReactNode,
   type Ref,
 } from 'react'
+import { openUrl } from '@tauri-apps/plugin-opener'
 import { type MarkMode } from '@meowdown/core'
 import {
   MeowdownEditor,
@@ -152,6 +153,12 @@ export function NoteEditor({
     (error: unknown, file: File) => onImageSaveErrorRef.current?.(error, file),
     [],
   )
+  const handleLinkClick = useCallback(
+    ({ href }: { href: string; event: MouseEvent }) => {
+      void openUrl(href).catch(() => {})
+    },
+    [],
+  )
 
   return (
     <MeowdownEditor
@@ -164,6 +171,7 @@ export function NoteEditor({
       {...(titlePlaceholder !== undefined ? { placeholder: titlePlaceholder } : {})}
       onDocChange={handleDocChange}
       onWikilinkClick={handleWikilinkClick}
+      onLinkClick={handleLinkClick}
       {...(onWikilinkSearch !== undefined ? { onWikilinkSearch } : {})}
       {...(onTagSearch !== undefined ? { onTagSearch } : {})}
       resolveImageUrl={handleResolveImageUrl}

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -8,6 +8,7 @@ import {
   type Ref,
 } from 'react'
 import { openPath, openUrl } from '@tauri-apps/plugin-opener'
+import { errorMessage } from '@reflect/core'
 import { type MarkMode } from '@meowdown/core'
 import {
   MeowdownEditor,
@@ -175,7 +176,9 @@ export function NoteEditor({
   )
   const handleLinkClick = useCallback(
     ({ href }: { href: string; event: MouseEvent }) => {
-      void openUrl(href).catch(() => {})
+      void openUrl(href).catch((cause) => {
+        console.error('open link failed:', errorMessage(cause))
+      })
     },
     [],
   )
@@ -202,7 +205,9 @@ export function NoteEditor({
   )
   const handleOpenLightboxImage = useCallback((image: LightboxImage) => {
     if (image.openPath !== null) {
-      void openPath(image.openPath, 'Preview').catch(() => {})
+      void openPath(image.openPath, 'Preview').catch((cause) => {
+        console.error('open image in Preview failed:', errorMessage(cause))
+      })
     }
   }, [])
 

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -7,7 +7,7 @@ import {
   type ReactNode,
   type Ref,
 } from 'react'
-import { openUrl } from '@tauri-apps/plugin-opener'
+import { openPath, openUrl } from '@tauri-apps/plugin-opener'
 import { type MarkMode } from '@meowdown/core'
 import {
   MeowdownEditor,
@@ -17,6 +17,12 @@ import {
 } from '@meowdown/react'
 import '@meowdown/core/style.css'
 import '@meowdown/react/style.css'
+import {
+  IMAGE_LIGHTBOX_TRANSITION_NAME,
+  ImageLightbox,
+  type LightboxImage,
+} from '@/editor/image-lightbox'
+import { useLightboxTransition } from '@/editor/use-lightbox-transition'
 import { cn } from '@/lib/utils'
 
 /**
@@ -58,6 +64,11 @@ interface NoteEditorProps {
   bulletAfterHeading?: boolean
   /** Resolve an image `![…](…)` source to a displayable URL; unresolved images are skipped. */
   resolveImageUrl?: (src: string) => string | null
+  /**
+   * Resolve an image `![…](…)` source to a native file path, so the lightbox
+   * can offer to open it in the OS image viewer. Returns null for remote images.
+   */
+  resolveImageOpenPath?: (src: string) => string | null
   /** Persist a pasted/dropped image file and return its markdown `src`. */
   saveImage?: (file: File) => Promise<string | null>
   /** Called when persisting a pasted/dropped image throws. */
@@ -96,6 +107,7 @@ export function NoteEditor({
   spellCheck = true,
   bulletAfterHeading = false,
   resolveImageUrl,
+  resolveImageOpenPath,
   saveImage,
   onImageSaveError,
   onWikiLinkClick,
@@ -114,15 +126,23 @@ export function NoteEditor({
   const onChangeRef = useRef(onChange)
   const onWikiLinkClickRef = useRef(onWikiLinkClick)
   const resolveImageUrlRef = useRef(resolveImageUrl)
+  const resolveImageOpenPathRef = useRef(resolveImageOpenPath)
   const saveImageRef = useRef(saveImage)
   const onImageSaveErrorRef = useRef(onImageSaveError)
   useEffect(() => {
     onChangeRef.current = onChange
     onWikiLinkClickRef.current = onWikiLinkClick
     resolveImageUrlRef.current = resolveImageUrl
+    resolveImageOpenPathRef.current = resolveImageOpenPath
     saveImageRef.current = saveImage
     onImageSaveErrorRef.current = onImageSaveError
   })
+
+  const {
+    item: lightboxImage,
+    open: openLightbox,
+    close: closeLightbox,
+  } = useLightboxTransition<HTMLImageElement, LightboxImage>()
 
   useImperativeHandle(
     handleRef,
@@ -159,26 +179,60 @@ export function NoteEditor({
     },
     [],
   )
+  const handleImageClick = useCallback(
+    ({ src, alt, event }: { src: string; alt: string; event: MouseEvent }) => {
+      const displayUrl = resolveImageUrlRef.current?.(src) ?? null
+      if (displayUrl === null) {
+        return
+      }
+      // The clicked target is the `<img>` or its `.md-image-preview` wrapper;
+      // the source element drives the View Transition zoom.
+      const sourceImage =
+        event.target instanceof HTMLElement
+          ? event.target.closest('.md-image-preview')?.querySelector('img') ?? null
+          : null
+      openLightbox(sourceImage, {
+        src: displayUrl,
+        alt,
+        openPath: resolveImageOpenPathRef.current?.(src) ?? null,
+        transitionName: IMAGE_LIGHTBOX_TRANSITION_NAME,
+      })
+    },
+    [openLightbox],
+  )
+  const handleOpenLightboxImage = useCallback((image: LightboxImage) => {
+    if (image.openPath !== null) {
+      void openPath(image.openPath, 'Preview').catch(() => {})
+    }
+  }, [])
 
   return (
-    <MeowdownEditor
-      handleRef={innerRef}
-      mode={markMode}
-      initialMarkdown={initialContent}
-      spellCheck={spellCheck}
-      bulletAfterHeading={bulletAfterHeading}
-      editorClassName={cn('reflect-editor', className)}
-      {...(titlePlaceholder !== undefined ? { placeholder: titlePlaceholder } : {})}
-      onDocChange={handleDocChange}
-      onWikilinkClick={handleWikilinkClick}
-      onLinkClick={handleLinkClick}
-      {...(onWikilinkSearch !== undefined ? { onWikilinkSearch } : {})}
-      {...(onTagSearch !== undefined ? { onTagSearch } : {})}
-      resolveImageUrl={handleResolveImageUrl}
-      onImagePaste={handleImagePaste}
-      onImageSaveError={handleImageSaveError}
-    >
-      {children}
-    </MeowdownEditor>
+    <>
+      <MeowdownEditor
+        handleRef={innerRef}
+        mode={markMode}
+        initialMarkdown={initialContent}
+        spellCheck={spellCheck}
+        bulletAfterHeading={bulletAfterHeading}
+        editorClassName={cn('reflect-editor', className)}
+        {...(titlePlaceholder !== undefined ? { placeholder: titlePlaceholder } : {})}
+        onDocChange={handleDocChange}
+        onWikilinkClick={handleWikilinkClick}
+        onLinkClick={handleLinkClick}
+        onImageClick={handleImageClick}
+        {...(onWikilinkSearch !== undefined ? { onWikilinkSearch } : {})}
+        {...(onTagSearch !== undefined ? { onTagSearch } : {})}
+        resolveImageUrl={handleResolveImageUrl}
+        onImagePaste={handleImagePaste}
+        onImageSaveError={handleImageSaveError}
+      >
+        {children}
+      </MeowdownEditor>
+      <ImageLightbox
+        image={lightboxImage}
+        onClose={closeLightbox}
+        onOpenImage={handleOpenLightboxImage}
+      />
+    </>
   )
 }

--- a/apps/desktop/src/editor/use-image-persistence.ts
+++ b/apps/desktop/src/editor/use-image-persistence.ts
@@ -34,6 +34,8 @@ function isSafeAssetSource(sourcePath: string): boolean {
 export interface ImagePersistence {
   /** Resolve an image source to a displayable URL (or null to skip). */
   resolveImageUrl: (src: string) => string | null
+  /** Resolve an image source to a native file path for the OS viewer (null for remote). */
+  resolveImageOpenPath: (src: string) => string | null
   /** Persist a pasted/dropped image, returning its graph-relative path (or null). */
   saveImage: (file: File) => Promise<string | null>
   /** Report a failed image save. */
@@ -69,6 +71,16 @@ export function useImagePersistence(
     [graphRoot],
   )
 
+  const resolveOpenPath = useCallback(
+    (src: string): string | null => {
+      if (graphRoot && isSafeAssetSource(src)) {
+        return `${graphRoot}/${src}`
+      }
+      return null
+    },
+    [graphRoot],
+  )
+
   const saveImage = useCallback(
     async (file: File): Promise<string | null> => {
       const extension = EXTENSION_BY_MIME[file.type]
@@ -94,10 +106,11 @@ export function useImagePersistence(
   return useMemo<ImagePersistence>(
     () => ({
       resolveImageUrl: resolveUrl,
+      resolveImageOpenPath: resolveOpenPath,
       saveImage,
       onImageSaveError: onSaveError,
       saveError,
     }),
-    [resolveUrl, saveImage, onSaveError, saveError],
+    [resolveUrl, resolveOpenPath, saveImage, onSaveError, saveError],
   )
 }

--- a/apps/desktop/src/editor/use-lightbox-transition.ts
+++ b/apps/desktop/src/editor/use-lightbox-transition.ts
@@ -1,0 +1,108 @@
+import { useCallback, useRef, useState } from 'react'
+import { flushSync } from 'react-dom'
+
+/** Data rendered in a lightbox with a named View Transition snapshot. */
+export interface LightboxTransitionItem {
+  readonly transitionName: string
+}
+
+interface LightboxTransitionSource<ElementType extends HTMLElement> {
+  element: ElementType
+  transitionName: string
+}
+
+/** State and commands for a lightbox that zooms from a source element when possible. */
+export interface UseLightboxTransitionResult<
+  ElementType extends HTMLElement,
+  ItemType extends LightboxTransitionItem,
+> {
+  item: ItemType | null
+  /** Open `item`, zooming from `element` when a View Transition is available. */
+  open: (element: ElementType | null, item: ItemType) => void
+  close: () => void
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  )
+}
+
+function canUseViewTransition(): boolean {
+  return typeof document.startViewTransition === 'function' && !prefersReducedMotion()
+}
+
+function clearTransitionSource<ElementType extends HTMLElement>(
+  source: LightboxTransitionSource<ElementType> | null,
+): void {
+  if (source !== null && source.element.style.viewTransitionName === source.transitionName) {
+    source.element.style.viewTransitionName = ''
+  }
+}
+
+function settleViewTransition(transition: ViewTransition, cleanup: () => void): void {
+  void transition.finished.then(cleanup, cleanup)
+}
+
+/**
+ * Opens and closes lightbox content with a native View Transition when
+ * supported, zooming from the source element (when given) and back to it on
+ * close. Falls back to an instant swap under reduced-motion or unsupported
+ * browsers, and when no source element is provided.
+ */
+export function useLightboxTransition<
+  ElementType extends HTMLElement,
+  ItemType extends LightboxTransitionItem,
+>(): UseLightboxTransitionResult<ElementType, ItemType> {
+  const sourceRef = useRef<LightboxTransitionSource<ElementType> | null>(null)
+  const [item, setItem] = useState<ItemType | null>(null)
+
+  const open = useCallback((element: ElementType | null, nextItem: ItemType) => {
+    clearTransitionSource(sourceRef.current)
+
+    if (element === null || !canUseViewTransition()) {
+      sourceRef.current = null
+      setItem(nextItem)
+      return
+    }
+
+    const source: LightboxTransitionSource<ElementType> = {
+      element,
+      transitionName: nextItem.transitionName,
+    }
+    sourceRef.current = source
+
+    element.style.viewTransitionName = nextItem.transitionName
+    const transition = document.startViewTransition(() => {
+      clearTransitionSource(source)
+      flushSync(() => setItem(nextItem))
+    })
+    settleViewTransition(transition, () => clearTransitionSource(source))
+  }, [])
+
+  const close = useCallback(() => {
+    if (item === null) {
+      return
+    }
+
+    const source = sourceRef.current
+    if (canUseViewTransition() && source?.element.isConnected) {
+      const transition = document.startViewTransition(() => {
+        flushSync(() => setItem(null))
+        source.element.style.viewTransitionName = item.transitionName
+      })
+      settleViewTransition(transition, () => {
+        clearTransitionSource(source)
+        sourceRef.current = null
+      })
+      return
+    }
+
+    setItem(null)
+    clearTransitionSource(source)
+    sourceRef.current = null
+  }, [item])
+
+  return { item, open, close }
+}

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -400,17 +400,12 @@ body {
   padding: 0;
 }
 
-/* Inline images: the literal `![alt](src)` text keeps a widget-rendered
-   preview directly beneath it (Plan 05b). */
-.reflect-editor .md-image {
-  -webkit-user-select: none;
-  user-select: none;
-  margin: 0.25em 0 0.5em;
-}
-.reflect-editor .md-image img {
-  max-width: 100%;
-  max-height: 28rem;
-  border-radius: var(--radius-md, 6px);
+/* Inline images: meowdown renders `![alt](src)` through a mark view
+   (`.md-image-preview`). Cap the height and round corners to Reflect's scale
+   via meowdown's theming variables. */
+.reflect-editor {
+  --meowdown-image-max-height: 28rem;
+  --meowdown-image-radius: var(--radius-md, 6px);
 }
 
 /* Read-only view for notes the editor can't faithfully round-trip yet. */

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -407,6 +407,27 @@ body {
   --meowdown-image-max-height: 28rem;
   --meowdown-image-radius: var(--radius-md, 6px);
 }
+.reflect-editor .md-image-preview-img img {
+  cursor: zoom-in;
+}
+
+/* Editor image lightbox: zoom the clicked image into the full-window preview
+   and back via the View Transition API (an instant swap where unsupported).
+   The root snapshot is suppressed so only the image animates. */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 0s;
+}
+::view-transition-group(reflect-image-lightbox) {
+  animation-duration: 180ms;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+}
+::view-transition-old(reflect-image-lightbox),
+::view-transition-new(reflect-image-lightbox) {
+  height: 100%;
+  object-fit: contain;
+  overflow: clip;
+}
 
 /* Read-only view for notes the editor can't faithfully round-trip yet. */
 .reflect-protected-note {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,11 +21,11 @@ importers:
   apps/desktop:
     dependencies:
       '@meowdown/core':
-        specifier: 0.11.1
-        version: 0.11.1(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+        specifier: 0.12.0
+        version: 0.12.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       '@meowdown/react':
-        specifier: 0.11.1
-        version: 0.11.1(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 0.12.0
+        version: 0.12.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@reflect/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -1008,11 +1008,11 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
-  '@meowdown/core@0.11.1':
-    resolution: {integrity: sha512-sbKceTdnefAtAgCpteEvISUCTl2BABGxR61Ybi3p604pfVIIqHyGaSX95QqNWG0JeI09ErzW5ovcriDM8XHBMA==}
+  '@meowdown/core@0.12.0':
+    resolution: {integrity: sha512-PBnoBZ3mg4qMvMwQjc3Fsz4MS6rcmGNS3jiqWRSRgN1JgUlSIwkdQRe72FXn1x6fX4/mZmumbqGnvkZ2DSs66Q==}
 
-  '@meowdown/react@0.11.1':
-    resolution: {integrity: sha512-Hv5tcYdzSQ6HQ5nD6zm5KvvPDRLEtlTGxmmqRzTeuq4/dB8tEc96VfM+9qmWck3c09Ai+QdEjGxfA66rFi/zFw==}
+  '@meowdown/react@0.12.0':
+    resolution: {integrity: sha512-1YqnCGQTHRN9K7+ra/1ltVTfhw7KKRJUf71eLguU1owglCF+XRBIMBlpUboO7sJ58vBjRBvDnDYxZpLwaYbe8Q==}
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
@@ -1209,11 +1209,11 @@ packages:
     resolution: {integrity: sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==}
     engines: {node: '>=12'}
 
-  '@prosekit/core@0.13.0-beta.1':
-    resolution: {integrity: sha512-EbeGlJwJmulRECahMKaKsHcGHOOFCYOu0hjHOgc0dBLFmhk1m64LOYdE4zC5Ek9KlSnt5DPq6y7T8UakdsnS8Q==}
+  '@prosekit/core@0.13.0-beta.3':
+    resolution: {integrity: sha512-QMBZGDtLDpOkagZ8xhDsbXvYJG9+VQEr+rsI1nAbGw7yMHFO3qF5PqaDm1SMju9QTKW3GaXFr7ztAkDXOP4lOA==}
 
-  '@prosekit/extensions@0.17.5-beta.2':
-    resolution: {integrity: sha512-Clr9AFdT6IG/XrJlCYUeLChsEkj83q8uka6InbkFIKwmxlADUc7SgZyOjeteG7Hv7+pyOVzKdrlU4KTbZYEaPQ==}
+  '@prosekit/extensions@0.17.5-beta.4':
+    resolution: {integrity: sha512-XxnTsk7VKPCJ3R2LcCRjXdZGWY0qWAN2QO0PObLnR+MN2APXVS99/7l3xaLJIZTQCFXkyrotqe2cXQLIiICwPg==}
     peerDependencies:
       loro-crdt: '>= 1.10.0'
       loro-prosemirror: '>= 0.4.1'
@@ -1229,11 +1229,11 @@ packages:
       yjs:
         optional: true
 
-  '@prosekit/pm@0.1.18':
-    resolution: {integrity: sha512-K00S6TY4gIlkWo1Y53h9STePNSPZ6UroHaIiKTkJvfMnwBBUZEc7+CUpmtNMzLtUqjmVAoaCTnW6VDBJaEXqWg==}
+  '@prosekit/pm@0.1.19-beta.0':
+    resolution: {integrity: sha512-7vkxSf8byvR1XNIxCShdtK6UXTGgGix2lrzuA2RwvDBwz2eeqRuxjwuVN2r2EopXCJS/v4V05UXv/DuOXDULhw==}
 
-  '@prosekit/react@0.8.0-beta.2':
-    resolution: {integrity: sha512-4q6PtB+RrmS+aZryr2fZA0w0MfY0BEWesyvpt7pqd1Dn5jKu/ri9sGdHZnKdDILlaIZ3tAMQce1dUmfs+iUqeg==}
+  '@prosekit/react@0.8.0-beta.4':
+    resolution: {integrity: sha512-+Iu8Q+rIUIMeF5gNzpDrn0dKi/3wIY2kHa+1xaZTgnHe+zgC7PyYzcsHXQryWQnhACmWJMdNQSo+IjPjBg8Efw==}
     peerDependencies:
       react: '>= 18.2.0'
       react-dom: '>= 18.2.0'
@@ -1243,8 +1243,8 @@ packages:
       react-dom:
         optional: true
 
-  '@prosekit/web@0.9.0-beta.2':
-    resolution: {integrity: sha512-pXS+g5gvLX4Pi4eddbTBwTKOhpYBCXRyED3xc+xv/sc7Y3uPuvdwh6xl1rD5MCqTWp+fNAs8PKycoBCwMK1VNg==}
+  '@prosekit/web@0.9.0-beta.4':
+    resolution: {integrity: sha512-vC6RXU06s7tYcBfVqrczQcKUfvDmR5CY/oOs19I0u9f64Yq707RSyqMaWtUuyzVKOSgJY5fRFpE01EMZu6FjTA==}
 
   '@prosemirror-adapter/core@0.5.3':
     resolution: {integrity: sha512-jGcI/eq3USFqf1fCaejgCmifmXYDyFco6/5KjyyNBnuEhLqyLjD+020CtcduEOsnN4xPZr5ikclgHIR6kEFkQg==}
@@ -6705,7 +6705,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@meowdown/core@0.11.1(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
+  '@meowdown/core@0.12.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
     dependencies:
       '@codemirror/language': 6.12.3
       '@codemirror/language-data': 6.5.2
@@ -6713,9 +6713,9 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@lezer/markdown': 1.6.4
       '@ocavue/utils': 1.7.0
-      '@prosekit/core': 0.13.0-beta.1(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      '@prosekit/extensions': 0.17.5-beta.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
-      '@prosekit/pm': 0.1.18
+      '@prosekit/core': 0.13.0-beta.3(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/extensions': 0.17.5-beta.4(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+      '@prosekit/pm': 0.1.19-beta.0
       prosemirror-highlight: 0.15.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
     transitivePeerDependencies:
       - '@shikijs/types'
@@ -6733,7 +6733,7 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@meowdown/react@0.11.1(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@meowdown/react@0.12.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@base-ui/react': 1.5.0(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@codemirror/commands': 6.10.3
@@ -6741,11 +6741,11 @@ snapshots:
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.43.1
-      '@meowdown/core': 0.11.1(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+      '@meowdown/core': 0.12.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       '@ocavue/utils': 1.7.0
-      '@prosekit/core': 0.13.0-beta.1(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      '@prosekit/pm': 0.1.18
-      '@prosekit/react': 0.8.0-beta.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@prosekit/core': 0.13.0-beta.3(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/pm': 0.1.19-beta.0
+      '@prosekit/react': 0.8.0-beta.4(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       clsx: 2.1.1
     optionalDependencies:
       react: 19.2.7
@@ -6898,10 +6898,10 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
-  '@prosekit/core@0.13.0-beta.1(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)':
+  '@prosekit/core@0.13.0-beta.3(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)':
     dependencies:
       '@ocavue/utils': 1.7.0
-      '@prosekit/pm': 0.1.18
+      '@prosekit/pm': 0.1.19-beta.0
       orderedmap: 2.1.1
       prosemirror-splittable: 0.1.1(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       type-fest: 5.7.0
@@ -6910,11 +6910,11 @@ snapshots:
       - prosemirror-state
       - prosemirror-transform
 
-  '@prosekit/extensions@0.17.5-beta.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
+  '@prosekit/extensions@0.17.5-beta.4(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
     dependencies:
       '@ocavue/utils': 1.7.0
-      '@prosekit/core': 0.13.0-beta.1(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      '@prosekit/pm': 0.1.18
+      '@prosekit/core': 0.13.0-beta.3(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/pm': 0.1.19-beta.0
       prosemirror-changeset: 2.4.1
       prosemirror-drop-indicator: 0.1.4
       prosemirror-dropcursor: 1.8.2
@@ -6941,7 +6941,7 @@ snapshots:
       - refractor
       - sugar-high
 
-  '@prosekit/pm@0.1.18':
+  '@prosekit/pm@0.1.19-beta.0':
     dependencies:
       prosemirror-commands: 1.7.1
       prosemirror-history: 1.5.0
@@ -6952,11 +6952,11 @@ snapshots:
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.9
 
-  '@prosekit/react@0.8.0-beta.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@prosekit/react@0.8.0-beta.4(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@prosekit/core': 0.13.0-beta.1(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      '@prosekit/pm': 0.1.18
-      '@prosekit/web': 0.9.0-beta.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+      '@prosekit/core': 0.13.0-beta.3(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/pm': 0.1.19-beta.0
+      '@prosekit/web': 0.9.0-beta.4(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       '@prosemirror-adapter/core': 0.5.3
       '@prosemirror-adapter/react': 0.5.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     optionalDependencies:
@@ -6980,16 +6980,16 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@prosekit/web@0.9.0-beta.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
+  '@prosekit/web@0.9.0-beta.4(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
     dependencies:
       '@aria-ui/core': 0.2.1
       '@aria-ui/elements': 0.1.10
       '@aria-ui/utils': 0.1.6
       '@floating-ui/dom': 1.7.6
       '@ocavue/utils': 1.7.0
-      '@prosekit/core': 0.13.0-beta.1(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      '@prosekit/extensions': 0.17.5-beta.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
-      '@prosekit/pm': 0.1.18
+      '@prosekit/core': 0.13.0-beta.3(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/extensions': 0.17.5-beta.4(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+      '@prosekit/pm': 0.1.19-beta.0
       prosemirror-tables: 1.8.5
     transitivePeerDependencies:
       - '@lezer/common'


### PR DESCRIPTION
Bump `@meowdown/*` to 0.12.0 and adopt its new `onImageClick` / `onLinkClick` props. Image clicks now open a View-Transition lightbox (with an "Open" action that launches local assets in Preview) and Markdown links open in the system browser. This drives the lightbox through meowdown's prop instead of the custom ProseKit click extension from #261, so the editor keeps zero direct `@prosekit/*` dependencies and supersedes that PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full-window image lightbox in the editor with smooth open/close transitions.
  * For locally-resolved images, the lightbox now offers an **“Open”** action to view the image in the OS.
* **Bug Fixes**
  * Improved inline image lightbox/open-path handling reliability and styling.
* **Tests**
  * Added coverage for lightbox interactions, link opening, and conditional View Transition behavior.
* **Chores**
  * Updated desktop core/react dependency versions and added the needed opener permission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->