### PR TITLE
feat: update meowdown to 0.13.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,8 +16,8 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@meowdown/core": "0.12.0",
-    "@meowdown/react": "0.12.0",
+    "@meowdown/core": "0.13.0",
+    "@meowdown/react": "0.13.0",
     "@reflect/core": "workspace:*",
     "@reflect/db": "workspace:*",
     "@reflect/design-system": "workspace:*",

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -450,8 +450,12 @@ body {
 }
 
 /* Wiki links: chips over the engine's native `[[…]]` marks (the theme's
-   dashed underline reads as a draft affordance; V1 renders chips). */
-.reflect-editor .md-wikilink {
+   dashed underline reads as a draft affordance; V1 renders chips). meowdown
+   0.13.0 renders wikilinks as a mark view: the immutable `.md-wikilink-label`
+   stands in for the raw `.md-wikilink-source`, so chip both (one shows per
+   mark mode). */
+.reflect-editor .md-wikilink-label,
+.reflect-editor .md-wikilink-source {
   text-decoration: none;
   color: var(--accent-soft-text, var(--accent));
   background: var(--accent-soft, rgb(99 102 241 / 12%));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,11 +21,11 @@ importers:
   apps/desktop:
     dependencies:
       '@meowdown/core':
-        specifier: 0.12.0
-        version: 0.12.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+        specifier: 0.13.0
+        version: 0.13.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       '@meowdown/react':
-        specifier: 0.12.0
-        version: 0.12.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 0.13.0
+        version: 0.13.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@reflect/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -1008,11 +1008,11 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
-  '@meowdown/core@0.12.0':
-    resolution: {integrity: sha512-PBnoBZ3mg4qMvMwQjc3Fsz4MS6rcmGNS3jiqWRSRgN1JgUlSIwkdQRe72FXn1x6fX4/mZmumbqGnvkZ2DSs66Q==}
+  '@meowdown/core@0.13.0':
+    resolution: {integrity: sha512-jVmjg7Qa6930riKolp6ssIoGQw+Syqmgv3RtdObXHt2gRFZlQTRLqs41re1eo4urmm7e2yI8N2A6uYQ4t/mj+w==}
 
-  '@meowdown/react@0.12.0':
-    resolution: {integrity: sha512-1YqnCGQTHRN9K7+ra/1ltVTfhw7KKRJUf71eLguU1owglCF+XRBIMBlpUboO7sJ58vBjRBvDnDYxZpLwaYbe8Q==}
+  '@meowdown/react@0.13.0':
+    resolution: {integrity: sha512-7PkP8VxAU4OO8N/mBdXWxkseIcINt/dbYubdC2u23L5lfGSQtUefKlKzlk6kSW1g81CwKow2duz5KmCc7dGq3Q==}
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
@@ -6705,7 +6705,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@meowdown/core@0.12.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
+  '@meowdown/core@0.13.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
     dependencies:
       '@codemirror/language': 6.12.3
       '@codemirror/language-data': 6.5.2
@@ -6733,7 +6733,7 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@meowdown/react@0.12.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@meowdown/react@0.13.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@base-ui/react': 1.5.0(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@codemirror/commands': 6.10.3
@@ -6741,7 +6741,7 @@ snapshots:
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.43.1
-      '@meowdown/core': 0.12.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+      '@meowdown/core': 0.13.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       '@ocavue/utils': 1.7.0
       '@prosekit/core': 0.13.0-beta.3(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosekit/pm': 0.1.19-beta.0


### PR DESCRIPTION
Bumps `@meowdown/core` and `@meowdown/react` to 0.13.0, which renders wikilinks as an immutable mark view and autolinks bare domains. Migrates the wikilink chip CSS from the removed `.md-wikilink` class to the new `.md-wikilink-label` / `.md-wikilink-source` mark-view classes so chips render in both focus and hide modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Meowdown dependencies to version 0.13.0.

* **Style**
  * Updated wiki-link styling to align with the latest rendering structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->