### PR TITLE
Update Meowdown packages to 0.13.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,8 +16,8 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@meowdown/core": "0.12.0",
-    "@meowdown/react": "0.12.0",
+    "@meowdown/core": "0.13.0",
+    "@meowdown/react": "0.13.0",
     "@reflect/core": "workspace:*",
     "@reflect/db": "workspace:*",
     "@reflect/design-system": "workspace:*",
@@ -59,11 +59,11 @@
     "eslint": "^10.5.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "jsdom": "^29.1.1",
+    "shadcn": "^4.11.0",
     "tailwindcss": "^4.3.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.61.1",
     "vite": "^8.0.16",
-    "shadcn": "^4.11.0",
     "vitest": "^4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,11 +21,11 @@ importers:
   apps/desktop:
     dependencies:
       '@meowdown/core':
-        specifier: 0.12.0
-        version: 0.12.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+        specifier: 0.13.0
+        version: 0.13.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       '@meowdown/react':
-        specifier: 0.12.0
-        version: 0.12.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 0.13.0
+        version: 0.13.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@reflect/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -1008,11 +1008,11 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
-  '@meowdown/core@0.12.0':
-    resolution: {integrity: sha512-PBnoBZ3mg4qMvMwQjc3Fsz4MS6rcmGNS3jiqWRSRgN1JgUlSIwkdQRe72FXn1x6fX4/mZmumbqGnvkZ2DSs66Q==}
+  '@meowdown/core@0.13.0':
+    resolution: {integrity: sha512-jVmjg7Qa6930riKolp6ssIoGQw+Syqmgv3RtdObXHt2gRFZlQTRLqs41re1eo4urmm7e2yI8N2A6uYQ4t/mj+w==}
 
-  '@meowdown/react@0.12.0':
-    resolution: {integrity: sha512-1YqnCGQTHRN9K7+ra/1ltVTfhw7KKRJUf71eLguU1owglCF+XRBIMBlpUboO7sJ58vBjRBvDnDYxZpLwaYbe8Q==}
+  '@meowdown/react@0.13.0':
+    resolution: {integrity: sha512-7PkP8VxAU4OO8N/mBdXWxkseIcINt/dbYubdC2u23L5lfGSQtUefKlKzlk6kSW1g81CwKow2duz5KmCc7dGq3Q==}
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
@@ -6705,7 +6705,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@meowdown/core@0.12.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
+  '@meowdown/core@0.13.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
     dependencies:
       '@codemirror/language': 6.12.3
       '@codemirror/language-data': 6.5.2
@@ -6733,7 +6733,7 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@meowdown/react@0.12.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@meowdown/react@0.13.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@base-ui/react': 1.5.0(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@codemirror/commands': 6.10.3
@@ -6741,7 +6741,7 @@ snapshots:
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.43.1
-      '@meowdown/core': 0.12.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+      '@meowdown/core': 0.13.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       '@ocavue/utils': 1.7.0
       '@prosekit/core': 0.13.0-beta.3(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosekit/pm': 0.1.19-beta.0


### PR DESCRIPTION
## Summary
- update `@meowdown/core` and `@meowdown/react` from 0.12.0 to 0.13.0
- refresh the pnpm lockfile for Meowdown/ProseKit transitive dependencies

## Testing
- `pnpm check`
- `pnpm --filter @reflect/desktop test -- src/editor/roundtrip.test.ts src/editor/keymap.test.ts src/editor/default-bullet.test.ts src/editor/note-session.test.ts src/editor/use-note-document.test.tsx src/components/tasks/task-item.test.tsx src/components/tasks/task-editor.test.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with lockfile refresh; editor behavior may shift with Meowdown 0.13.0 but no in-repo code was modified.
> 
> **Overview**
> Bumps the desktop app’s Meowdown stack from **0.12.0** to **0.13.0** by updating `@meowdown/core` and `@meowdown/react` in `apps/desktop/package.json` and refreshing `pnpm-lock.yaml` for the new package resolutions (including transitive ProseKit-related deps).
> 
> There are **no application source changes** in this PR—only the version pins and lockfile. `shadcn` is reordered among devDependencies in `package.json` without a version change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 127573b8515ab8488f768201475194aa00f0b9a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependencies to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->