### PR TITLE
Reduce task toolbar icon sizes

### DIFF
--- a/apps/desktop/src/components/all-notes/all-notes-row.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-row.tsx
@@ -1,5 +1,4 @@
 import { memo, type MouseEvent, type ReactElement } from 'react'
-import { Circle, CircleCheck } from 'lucide-react'
 import type { NoteListEntry } from '@reflect/core'
 import { formatRecencyLabel } from '@/lib/dates'
 import { cn } from '@/lib/utils'
@@ -46,7 +45,9 @@ export const AllNotesRow = memo(function AllNotesRow({ note, selected, onSelect,
       className={cn(
         'group/row relative h-12 cursor-default select-none transition-colors duration-100',
         ALL_NOTES_GRID,
-        selected ? 'bg-surface-hover ring-1 ring-inset ring-accent' : 'hover:bg-surface-hover',
+        selected
+          ? 'border-y border-accent/20 bg-accent-soft text-text dark:border-accent/10 dark:text-text'
+          : 'shadow-[var(--border-hairline)] hover:bg-surface-hover',
       )}
     >
       <button
@@ -58,15 +59,17 @@ export const AllNotesRow = memo(function AllNotesRow({ note, selected, onSelect,
           onToggle(note.path, event)
         }}
         className={cn(
-          'absolute left-4 top-1/2 flex size-[18px] -translate-y-1/2 items-center justify-center text-text-muted transition-opacity duration-100 hover:text-text focus-visible:opacity-100 focus-visible:outline-none',
+          'group absolute inset-y-0 left-0 flex w-12 items-center justify-center opacity-0 transition-opacity duration-100 hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none',
           selected ? 'opacity-100' : 'opacity-0 group-hover/row:opacity-100',
         )}
       >
-        {selected ? (
-          <CircleCheck aria-hidden className="size-[18px] text-accent" strokeWidth={2} />
-        ) : (
-          <Circle aria-hidden className="size-[18px]" strokeWidth={2} />
-        )}
+        <span
+          aria-hidden
+          className={cn(
+            'size-2 rounded-full transition-transform duration-150 group-hover:scale-110',
+            selected ? 'bg-accent' : 'ring-1 ring-accent',
+          )}
+        />
       </button>
       <button
         type="button"
@@ -74,11 +77,16 @@ export const AllNotesRow = memo(function AllNotesRow({ note, selected, onSelect,
           event.stopPropagation()
           onOpen(note.path)
         }}
-        className="truncate text-left text-[13px] font-medium text-text focus-visible:outline-none"
+        className={cn(
+          'truncate text-left text-[13px] font-medium focus-visible:outline-none',
+          selected ? 'text-accent' : 'text-text',
+        )}
       >
         {note.title}
       </button>
-      <span className="truncate text-[13px] text-text-secondary">{note.snippet}</span>
+      <span className={cn('truncate text-[13px]', selected ? 'text-accent' : 'text-text-secondary')}>
+        {note.snippet}
+      </span>
       <span className="truncate text-right text-[13px] text-text-secondary">
         {note.tags.map((tag) => `#${tag}`).join(' ')}
       </span>

--- a/apps/desktop/src/components/all-notes/all-notes-screen.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } 
 import { useQuery } from '@tanstack/react-query'
 import { hasBridge, listNotes, listNoteTags } from '@reflect/core'
 import { Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import { allNotesQueryKey, allNotesTagsQueryKey } from '@/lib/notes/all-notes-query'
 import { useListSelection } from '@/lib/selection/use-list-selection'
 import { useScrollRestoration } from '@/lib/use-scroll-restoration'
@@ -121,14 +122,22 @@ export function AllNotesScreen({ tag }: AllNotesScreenProps): ReactElement {
             onSelect={handleFilterSelect}
           />
           {selection.selectedCount > 0 ? (
-            <button
+            <Button
               type="button"
+              variant="outline"
+              aria-label={`Trash (${selection.selectedCount})`}
               onClick={openTrashConfirm}
-              className="flex items-center gap-2 rounded-lg border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text-secondary shadow-sm transition-colors duration-100 hover:bg-surface-hover hover:text-destructive"
+              className="text-text-secondary hover:text-destructive"
             >
-              <Trash2 aria-hidden className="size-4" />
-              Trash ({selection.selectedCount})
-            </button>
+              <Trash2 aria-hidden className="size-3.5" />
+              <span>Trash</span>
+              <span
+                aria-hidden
+                className="flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive/10 px-1 text-[10px] font-semibold leading-none tabular-nums text-destructive"
+              >
+                {selection.selectedCount}
+              </span>
+            </Button>
           ) : null}
           <NewNoteButton />
         </div>

--- a/apps/desktop/src/components/all-notes/all-notes-table.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-table.tsx
@@ -28,7 +28,7 @@ interface AllNotesTableProps {
   registerScrollToIndex: (scrollToIndex: (index: number) => void) => void
 }
 
-const ESTIMATED_ROW_HEIGHT = 49
+const ESTIMATED_ROW_HEIGHT = 48
 
 /**
  * The All Notes table: a sticky header row over virtualized note rows. The
@@ -99,7 +99,7 @@ export function AllNotesTable({
                 key={note.path}
                 data-index={item.index}
                 ref={virtualizer.measureElement}
-                className="absolute inset-x-0 border-b border-border"
+                className="absolute inset-x-0"
                 style={{ transform: `translateY(${item.start}px)` }}
               >
                 <AllNotesRow

--- a/apps/desktop/src/components/tasks/task-filters-menu.tsx
+++ b/apps/desktop/src/components/tasks/task-filters-menu.tsx
@@ -41,7 +41,7 @@ export function TaskFiltersMenu({
     <DropdownMenu open={open} onOpenChange={onOpenChange}>
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" className="window-drag-control text-xs font-normal text-text-muted">
-          <ListFilter aria-hidden className="size-4" />
+          <ListFilter aria-hidden className="size-3.5" />
           Task filters
         </Button>
       </DropdownMenuTrigger>

--- a/apps/desktop/src/components/tasks/tasks-screen.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.tsx
@@ -231,7 +231,7 @@ export function TasksScreen(): ReactElement {
         <div className="window-drag-control min-w-0 flex-1">
           <Search
             aria-hidden
-            className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-text-muted"
+            className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-text-muted"
           />
           <Input
             value={query}
@@ -249,7 +249,7 @@ export function TasksScreen(): ReactElement {
             onSchedule={onSchedule}
           >
             <Button type="button" variant="ghost" className="window-drag-control text-xs text-text-muted">
-              <CalendarClock aria-hidden className="size-4" />
+              <CalendarClock aria-hidden className="size-3.5" />
               Schedule ({selection.selectedCount})
             </Button>
           </TaskScheduleCalendar>
@@ -262,7 +262,7 @@ export function TasksScreen(): ReactElement {
             title="Drop the checkbox, keeping the line as a plain bullet — leaves the Tasks list"
             className="window-drag-control text-xs text-text-muted"
           >
-            <List aria-hidden className="size-4" />
+            <List aria-hidden className="size-3.5" />
             Convert to bullet ({selection.selectedCount})
           </Button>
         ) : null}
@@ -273,7 +273,7 @@ export function TasksScreen(): ReactElement {
             onClick={actions.archive}
             className="window-drag-control text-xs text-text-muted"
           >
-            <Archive aria-hidden className="size-4" />
+            <Archive aria-hidden className="size-3.5" />
             Archive ({recentlyCompleted.length})
           </Button>
         ) : null}


### PR DESCRIPTION
## Summary
- Reduce the Task filters icon to match the smaller toolbar scale
- Apply the same icon size to the Tasks header search, schedule, convert, and archive controls for consistency

## Testing
- pnpm check
- pnpm --filter @reflect/desktop test src/components/tasks/tasks-screen.test.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and markup-only changes in list and toolbar components; selection and trash behavior are unchanged.
> 
> **Overview**
> Shrinks **Tasks** header toolbar icons from `size-4` to **`size-3.5`** (search, schedule, convert, archive, and the filters menu) so they match the smaller toolbar scale.
> 
> **All Notes** gets a parallel polish pass: selected rows use **accent soft background and borders** instead of an inset ring; the Lucide circle/check gutter becomes a **small dot** (filled when selected, ring when not); title and snippet pick up accent color when selected. The bulk **Trash** control moves to the shared **`Button`** (`outline`) with a destructive-tinted **count badge** and a smaller trash icon. Virtualized rows drop the list-item bottom border (rows use a hairline shadow instead) and the estimated row height is tweaked to **48px**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cbfc1da847bf2097906a3a28e081e0b2df0f08a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined icon sizing across the desktop task experience for a more consistent visual appearance, including the task filters menu, header search, and toolbar actions.
  * Updated All Notes row selection visuals (simplified selection indicator) and adjusted row divider styling for a cleaner look.
* **Refactor**
  * Updated the All Notes bulk **Trash** action to use the shared button component, improving consistency and updating the trash icon/count badge presentation (including a selection-based aria-label).
* **Bug Fixes**
  * Improved virtualized All Notes row alignment by fine-tuning the row height estimate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->