### PR TITLE
Fix note subject sizing regression

### DIFF
--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -54,10 +54,12 @@
   --shadow-pop: var(--ds-shadow-pop);
   --shadow-app-input: var(--ds-shadow-app-input);
 
-  /* 12px chrome text (V1's `text-xs`; the DS `--text-xs` is 13px) and the
-     shortcut-glyph font, via the same --ds-* indirection as the shadows. */
+  /* 12px chrome text (V1's `text-xs`; the DS `--text-xs` is 13px). */
   --text-2xs: var(--ds-text-2xs);
   --text-2xs--line-height: 1.25;
+  /* Shared subject size for regular-note titles and daily-note dates. */
+  --text-note-subject: var(--text-xl);
+  /* Shortcut-glyph font, via the same --ds-* indirection as the shadows. */
   --font-shortcut: var(--ds-font-shortcut);
 
   /* shadcn semantic tokens (added by `shadcn init`, values rewired below in
@@ -307,17 +309,14 @@ body {
   letter-spacing: var(--tracking-snug, -0.01em);
   margin: 1.25em 0 0.4em;
 }
-/* Keep the leading H1 note title at body size so regular note titles and the
-   new-note "Untitled" ghost match daily-note prose. Other headings stay capped
-   at the design-system note-title size rather than towering over the body. */
-.reflect-editor h1 { font-size: var(--text-xl, 1.25rem); }
-.reflect-editor h2 { font-size: var(--text-xl, 1.25rem); }
+/* The leading H1 is the regular-note subject, matching the daily subject.
+   Other headings stay capped at the same semantic size rather than towering
+   over the body. */
+.reflect-editor h1 { @apply text-note-subject; }
+.reflect-editor h2 { @apply text-note-subject; }
 .reflect-editor h3 { font-size: var(--text-lg, 1.125rem); }
-.reflect-editor h1:first-child {
-  margin-top: 0;
-  font-size: var(--text-base, 1rem);
-}
-.reflect-editor .reflect-note-title { font-size: var(--text-base, 1rem); }
+.reflect-editor h1:first-child { margin-top: 0; }
+.reflect-editor .reflect-note-title { @apply text-note-subject; }
 
 /* The new-note flow's name field: ghost "Untitled" over the seeded empty H1
    (`editor/title-placeholder.ts`) without occupying layout, so the caret
@@ -333,8 +332,8 @@ body {
 /* The daily note's date heading (V1 renders the date as the note's subject)
    without living inside the editor DOM. */
 .reflect-daily-subject {
+  @apply text-note-subject;
   font-family: var(--font-reading, var(--font-sans));
-  font-size: var(--text-xl, 1.25rem);
   font-weight: 650;
   letter-spacing: var(--tracking-snug, -0.01em);
 }


### PR DESCRIPTION
## Summary
- Add a semantic Tailwind text token, `text-note-subject`, for regular-note titles and daily-note date subjects
- Apply that token to the generated editor subject/title path and the daily subject so they cannot drift by accident
- Update the editor typography comment to distinguish subject sizing from body prose sizing

## Testing
- pnpm check (passes; existing warning-only lint output remains)
- pnpm --filter @reflect/desktop build (passes; existing large chunk warning remains)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only typography changes in `index.css` with no logic, data, or auth impact.
> 
> **Overview**
> Fixes a **note subject sizing regression** where regular-note titles and new-note “Untitled” subjects had been pulled down to body (`--text-base`) while daily dates stayed at `--text-xl`.
> 
> Introduces a shared Tailwind theme token **`--text-note-subject`** (mapped to `--text-xl`) and applies **`text-note-subject`** to editor **h1/h2**, **`.reflect-note-title`**, and **`.reflect-daily-subject`**, removing the first-child/body-size overrides. Comments are updated to describe subject vs body prose sizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2594280d7197d7388103de664a4f3f4ea7dd7e81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated editor typography to use a shared “note subject” text size token for consistent heading and note-title appearance.
  * Editor heading sizing is now standardized across H1/H2/H3 (with H3 kept smaller), and the first heading behavior no longer affects font size.
  * Daily subject text now derives its sizing from the same shared token for uniform visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->