### PR TITLE
Fix image lightbox open action

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -8,7 +8,6 @@
     "core:window:allow-start-dragging",
     "core:window:allow-destroy",
     "opener:default",
-    "opener:allow-open-path",
     "dialog:default",
     {
       "identifier": "http:default",

--- a/apps/desktop/src-tauri/src/fs/mod.rs
+++ b/apps/desktop/src-tauri/src/fs/mod.rs
@@ -15,6 +15,7 @@ use std::sync::Mutex;
 
 use serde::Serialize;
 use tauri::State;
+use tauri_plugin_opener::OpenerExt;
 
 use crate::error::{AppError, AppResult};
 
@@ -150,6 +151,18 @@ fn root_for(state: &State<GraphState>, generation: Option<u64>) -> AppResult<Pat
     }
 }
 
+fn ensure_asset_path(path: &str) -> AppResult<()> {
+    if path
+        .strip_prefix("assets/")
+        .is_some_and(|rest| !rest.is_empty())
+    {
+        return Ok(());
+    }
+    Err(AppError::traversal(format!(
+        "asset path must be under assets/: {path}"
+    )))
+}
+
 // ---- commands --------------------------------------------------------------
 
 /// Let the asset protocol serve files from the graph (image rendering, Plan 05).
@@ -247,6 +260,27 @@ pub fn asset_read(path: String, generation: u64, state: State<GraphState>) -> Ap
     let root = root_for_generation(&state, generation)?;
     let bytes = fs::read(resolve(&root, &path)?)?;
     Ok(base64::engine::general_purpose::STANDARD.encode(bytes))
+}
+
+/// Open a graph asset in the OS default application. The frontend supplies the
+/// graph-relative `assets/...` path from markdown; Rust resolves it inside the
+/// generation-pinned graph so the JS opener never gets broad filesystem access.
+#[tauri::command]
+pub fn asset_open(
+    path: String,
+    generation: u64,
+    app: tauri::AppHandle,
+    state: State<GraphState>,
+) -> AppResult<()> {
+    ensure_asset_path(&path)?;
+    let root = root_for_generation(&state, generation)?;
+    let abs = resolve(&root, &path)?;
+    if !abs.is_file() {
+        return Err(AppError::not_found(format!("asset not found: {path}")));
+    }
+    app.opener()
+        .open_path(abs.to_string_lossy().into_owned(), None::<&str>)
+        .map_err(|err| AppError::io(err.to_string()))
 }
 
 /// List every file (any extension) under a graph-relative directory, e.g.
@@ -366,7 +400,7 @@ pub fn list_files(generation: Option<u64>, state: State<GraphState>) -> AppResul
 
 #[cfg(test)]
 mod move_tests {
-    use super::move_note_file;
+    use super::{ensure_asset_path, move_note_file};
     use std::fs;
 
     fn graph() -> tempfile::TempDir {
@@ -403,5 +437,13 @@ mod move_tests {
             fs::read_to_string(root.path().join("notes/b.md")).unwrap(),
             "# Theirs\n"
         );
+    }
+
+    #[test]
+    fn asset_open_paths_must_stay_under_assets() {
+        assert!(ensure_asset_path("assets/cat.png").is_ok());
+        assert!(ensure_asset_path("notes/cat.png").is_err());
+        assert!(ensure_asset_path("assets/").is_err());
+        assert!(ensure_asset_path("assets").is_err());
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -155,6 +155,7 @@ pub fn run() {
             fs::note_write,
             fs::asset_write,
             fs::asset_read,
+            fs::asset_open,
             fs::dir_list,
             fs::note_exists,
             fs::note_delete,

--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -100,6 +100,7 @@ export function NotePane({
   const {
     resolveImageUrl,
     resolveImageOpenPath,
+    openImage,
     saveImage,
     onImageSaveError,
     saveError: imageSaveError,
@@ -214,6 +215,7 @@ export function NotePane({
         bulletAfterHeading={settings.editorBulletAfterHeading}
         resolveImageUrl={resolveImageUrl}
         resolveImageOpenPath={resolveImageOpenPath}
+        openImage={openImage}
         saveImage={saveImage}
         onImageSaveError={onImageSaveError}
         onWikiLinkClick={onWikiLinkClick}

--- a/apps/desktop/src/editor/image-lightbox.tsx
+++ b/apps/desktop/src/editor/image-lightbox.tsx
@@ -11,8 +11,10 @@ export interface LightboxImage extends LightboxTransitionItem {
   /** Displayable URL, already resolved from the markdown `src`. */
   src: string
   alt: string
-  /** Local file path to open natively, or null for a remote image. */
+  /** Resolved image path to pass to `openImage`, or null for a remote image. */
   openPath: string | null
+  /** Opener captured from the graph session that produced this preview. */
+  openImage: ((path: string) => Promise<void> | void) | null
 }
 
 interface ImageLightboxProps {
@@ -29,7 +31,8 @@ export function ImageLightbox({
   if (image === null) {
     return null
   }
-  const canOpenImage = image.openPath !== null && onOpenImage !== undefined
+  const canOpenImage =
+    image.openPath !== null && image.openImage !== null && onOpenImage !== undefined
 
   return (
     <LightboxDialog open title="Image preview" onClose={onClose}>

--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -3,7 +3,7 @@ import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom/vitest'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { openPath, openUrl } from '@tauri-apps/plugin-opener'
+import { openUrl } from '@tauri-apps/plugin-opener'
 import { NoteEditor } from './note-editor'
 
 /** Props the mocked `<MeowdownEditor>` captures so the test can drive its callbacks. */
@@ -18,7 +18,6 @@ interface CapturedEditorProps {
 const captured = vi.hoisted(() => ({ props: null as CapturedEditorProps | null }))
 
 vi.mock('@tauri-apps/plugin-opener', () => ({
-  openPath: vi.fn(async () => {}),
   openUrl: vi.fn(async () => {}),
 }))
 
@@ -42,14 +41,17 @@ vi.mock('@meowdown/react', () => ({
   },
 }))
 
-function renderEditor(): ReturnType<typeof render> {
+function renderEditor(
+  openImage: (path: string) => Promise<void> | void = vi.fn(async () => {}),
+): ReturnType<typeof render> {
   return render(
     <NoteEditor
       initialContent={'A photo\n\n![Cat](assets/cat.png)'}
       resolveImageUrl={(src) => (src === 'assets/cat.png' ? 'asset://cat.png' : null)}
       resolveImageOpenPath={(src) =>
-        src === 'assets/cat.png' ? '/graph/assets/cat.png' : null
+        src === 'assets/cat.png' ? 'assets/cat.png' : null
       }
+      openImage={openImage}
     />,
   )
 }
@@ -136,13 +138,51 @@ describe('NoteEditor image lightbox', () => {
     expect(await screen.findByRole('dialog', { name: 'Image preview' })).toBeInTheDocument()
   })
 
-  it('opens a local image in Preview', async () => {
-    renderEditor()
+  it('opens a local image through the graph asset opener', async () => {
+    const openImage = vi.fn(async () => {})
+    renderEditor(openImage)
 
     act(() => captured.props?.onImageClick?.(imageClick('assets/cat.png', 'Cat')))
 
     await userEvent.click(await screen.findByRole('button', { name: 'Open' }))
-    expect(openPath).toHaveBeenCalledWith('/graph/assets/cat.png', 'Preview')
+    expect(openImage).toHaveBeenCalledWith('assets/cat.png')
+  })
+
+  it('uses the opener captured when the lightbox opens', async () => {
+    const firstOpenImage = vi.fn(async () => {})
+    const secondOpenImage = vi.fn(async () => {})
+    const view = renderEditor(firstOpenImage)
+
+    act(() => captured.props?.onImageClick?.(imageClick('assets/cat.png', 'Cat')))
+    await screen.findByRole('dialog', { name: 'Image preview' })
+
+    view.rerender(
+      <NoteEditor
+        initialContent={'A photo\n\n![Cat](assets/cat.png)'}
+        resolveImageUrl={(src) => (src === 'assets/cat.png' ? 'asset://cat.png' : null)}
+        resolveImageOpenPath={(src) => (src === 'assets/cat.png' ? 'assets/cat.png' : null)}
+        openImage={secondOpenImage}
+      />,
+    )
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Open' }))
+    expect(firstOpenImage).toHaveBeenCalledWith('assets/cat.png')
+    expect(secondOpenImage).not.toHaveBeenCalled()
+  })
+
+  it('hides the Open button when no opener is provided', async () => {
+    render(
+      <NoteEditor
+        initialContent={'A photo\n\n![Cat](assets/cat.png)'}
+        resolveImageUrl={(src) => (src === 'assets/cat.png' ? 'asset://cat.png' : null)}
+        resolveImageOpenPath={(src) => (src === 'assets/cat.png' ? 'assets/cat.png' : null)}
+      />,
+    )
+
+    act(() => captured.props?.onImageClick?.(imageClick('assets/cat.png', 'Cat')))
+
+    expect(await screen.findByRole('dialog', { name: 'Image preview' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Open' })).toBeNull()
   })
 
   it('does not open a lightbox when the source cannot be resolved', () => {

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -7,7 +7,7 @@ import {
   type ReactNode,
   type Ref,
 } from 'react'
-import { openPath, openUrl } from '@tauri-apps/plugin-opener'
+import { openUrl } from '@tauri-apps/plugin-opener'
 import { errorMessage } from '@reflect/core'
 import { type MarkMode } from '@meowdown/core'
 import {
@@ -66,10 +66,13 @@ interface NoteEditorProps {
   /** Resolve an image `![…](…)` source to a displayable URL; unresolved images are skipped. */
   resolveImageUrl?: (src: string) => string | null
   /**
-   * Resolve an image `![…](…)` source to a native file path, so the lightbox
-   * can offer to open it in the OS image viewer. Returns null for remote images.
+   * Resolve an image `![…](…)` source to the path passed to {@link openImage},
+   * so the lightbox can offer to open it in the OS image viewer. Returns null
+   * for remote images.
    */
   resolveImageOpenPath?: (src: string) => string | null
+  /** Open a resolved image path in the OS default viewer. */
+  openImage?: (path: string) => Promise<void> | void
   /** Persist a pasted/dropped image file and return its markdown `src`. */
   saveImage?: (file: File) => Promise<string | null>
   /** Called when persisting a pasted/dropped image throws. */
@@ -109,6 +112,7 @@ export function NoteEditor({
   bulletAfterHeading = false,
   resolveImageUrl,
   resolveImageOpenPath,
+  openImage,
   saveImage,
   onImageSaveError,
   onWikiLinkClick,
@@ -128,6 +132,7 @@ export function NoteEditor({
   const onWikiLinkClickRef = useRef(onWikiLinkClick)
   const resolveImageUrlRef = useRef(resolveImageUrl)
   const resolveImageOpenPathRef = useRef(resolveImageOpenPath)
+  const openImageRef = useRef(openImage)
   const saveImageRef = useRef(saveImage)
   const onImageSaveErrorRef = useRef(onImageSaveError)
   useEffect(() => {
@@ -135,6 +140,7 @@ export function NoteEditor({
     onWikiLinkClickRef.current = onWikiLinkClick
     resolveImageUrlRef.current = resolveImageUrl
     resolveImageOpenPathRef.current = resolveImageOpenPath
+    openImageRef.current = openImage
     saveImageRef.current = saveImage
     onImageSaveErrorRef.current = onImageSaveError
   })
@@ -198,15 +204,16 @@ export function NoteEditor({
         src: displayUrl,
         alt,
         openPath: resolveImageOpenPathRef.current?.(src) ?? null,
+        openImage: openImageRef.current ?? null,
         transitionName: IMAGE_LIGHTBOX_TRANSITION_NAME,
       })
     },
     [openLightbox],
   )
   const handleOpenLightboxImage = useCallback((image: LightboxImage) => {
-    if (image.openPath !== null) {
-      void openPath(image.openPath, 'Preview').catch((cause) => {
-        console.error('open image in Preview failed:', errorMessage(cause))
+    if (image.openPath !== null && image.openImage !== null) {
+      void Promise.resolve(image.openImage(image.openPath)).catch((cause) => {
+        console.error('open image failed:', errorMessage(cause))
       })
     }
   }, [])

--- a/apps/desktop/src/editor/use-image-persistence.ts
+++ b/apps/desktop/src/editor/use-image-persistence.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react'
 import { convertFileSrc } from '@tauri-apps/api/core'
-import { assetPath, errorMessage, writeAsset } from '@reflect/core'
+import { assetPath, errorMessage, openAsset, writeAsset } from '@reflect/core'
 import { base64Of } from '@/lib/base64'
 
 /** Asset file extension for each image MIME type the editor accepts on paste/drop. */
@@ -34,8 +34,10 @@ function isSafeAssetSource(sourcePath: string): boolean {
 export interface ImagePersistence {
   /** Resolve an image source to a displayable URL (or null to skip). */
   resolveImageUrl: (src: string) => string | null
-  /** Resolve an image source to a native file path for the OS viewer (null for remote). */
+  /** Resolve an image source to a graph-relative asset path for the OS viewer (null for remote). */
   resolveImageOpenPath: (src: string) => string | null
+  /** Open a graph-relative asset path in the OS default viewer. */
+  openImage: (path: string) => Promise<void>
   /** Persist a pasted/dropped image, returning its graph-relative path (or null). */
   saveImage: (file: File) => Promise<string | null>
   /** Report a failed image save. */
@@ -73,12 +75,22 @@ export function useImagePersistence(
 
   const resolveOpenPath = useCallback(
     (src: string): string | null => {
-      if (graphRoot && isSafeAssetSource(src)) {
-        return `${graphRoot}/${src}`
+      if (graphRoot && generation !== null && isSafeAssetSource(src)) {
+        return src
       }
       return null
     },
-    [graphRoot],
+    [graphRoot, generation],
+  )
+
+  const openImage = useCallback(
+    async (path: string): Promise<void> => {
+      if (generation === null) {
+        return
+      }
+      await openAsset(path, generation)
+    },
+    [generation],
   )
 
   const saveImage = useCallback(
@@ -107,10 +119,11 @@ export function useImagePersistence(
     () => ({
       resolveImageUrl: resolveUrl,
       resolveImageOpenPath: resolveOpenPath,
+      openImage,
       saveImage,
       onImageSaveError: onSaveError,
       saveError,
     }),
-    [resolveUrl, resolveOpenPath, saveImage, onSaveError, saveError],
+    [resolveUrl, resolveOpenPath, openImage, saveImage, onSaveError, saveError],
   )
 }

--- a/packages/core/src/graph/commands.test.ts
+++ b/packages/core/src/graph/commands.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { setBridge } from '../ipc/bridge'
+import { openAsset } from './commands'
+
+afterEach(() => {
+  setBridge(null)
+})
+
+describe('graph commands', () => {
+  it('opens assets through the generation-pinned native command', async () => {
+    const invoke = vi.fn(async () => null)
+    setBridge({ invoke, listen: async () => () => {} })
+
+    await openAsset('assets/cat.png', 7)
+
+    expect(invoke).toHaveBeenCalledWith('asset_open', {
+      path: 'assets/cat.png',
+      generation: 7,
+    })
+  })
+})

--- a/packages/core/src/graph/commands.ts
+++ b/packages/core/src/graph/commands.ts
@@ -66,6 +66,16 @@ export async function readAsset(path: string, generation: number): Promise<strin
 }
 
 /**
+ * Open an asset by graph-relative path in the system default application.
+ * `generation` pins the request to the graph whose markdown produced the
+ * image, so a delayed click after a graph switch cannot open another graph's
+ * same-named file.
+ */
+export async function openAsset(path: string, generation: number): Promise<void> {
+  await call('asset_open', { path, generation }, voidSchema)
+}
+
+/**
  * List every file (any extension) under a graph-relative directory, e.g.
  * `audio-memos`. A missing directory lists as empty. Pinned to `generation`
  * for the same reason as {@link readAsset}.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -85,6 +85,7 @@ export {
   writeNote,
   writeAsset,
   readAsset,
+  openAsset,
   listDir,
   noteExists,
   deleteNote,


### PR DESCRIPTION
## Summary
- Route lightbox image opening through a graph-scoped Rust `asset_open` command instead of the broad JS opener path command
- Pass graph-relative asset paths through the image persistence hook and hide the Open button when no opener is available
- Add coverage for the editor button behavior, the core IPC binding, and the Rust asset path gate

## Verification
- `pnpm --filter @reflect/desktop test -- apps/desktop/src/editor/note-editor.test.tsx`
- `pnpm --filter @reflect/core test -- packages/core/src/graph/commands.test.ts`
- `pnpm check`
- `pnpm --filter @reflect/desktop sidecar`
- `cargo test -p reflect-open`

Note: the package-scoped Vitest commands ran the full desktop/core package suites rather than only the named files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches filesystem access boundaries and graph-generation pinning; scope is limited to local asset opening with explicit path guards and stale-generation rejection.
> 
> **Overview**
> **Routes image lightbox “Open” through Rust instead of the JS opener**, so the webview never receives broad `openPath` access (the `opener:allow-open-path` capability is removed).
> 
> Adds a generation-pinned **`asset_open`** command: it accepts graph-relative `assets/…` paths, enforces an `assets/` prefix, resolves inside the pinned graph root, and opens the file with the OS default app. **`openAsset`** in `@reflect/core` wraps the IPC call.
> 
> The editor now passes **graph-relative paths** and an **`openImage`** callback from `useImagePersistence` (pinned to the open graph’s `generation`). The lightbox **snapshots the opener when it opens**, so a delayed click after a graph switch still targets the graph that produced the preview; the **Open** button is hidden when no opener is available.
> 
> Tests cover the editor behavior, the core invoke binding, and Rust path gating for `assets/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5806f1a0bd20f62e608b47490d451c483768c16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->