### PR TITLE
Fix backlink menu background

### DIFF
--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -471,9 +471,12 @@ body {
   cursor: pointer;
 }
 
-/* ---- [[ autocomplete (Plan 07) ---------------------------------------------
-   The popup is a prosekit custom element (positioned by its positioner); all
-   visual treatment is ours. Items carry `data-highlighted` while traversed. */
+/* ---- Editor autocomplete (Plan 07) -----------------------------------------
+   meowdown renders ProseKit custom elements for its floating editor menus.
+   Reflect owns the app-theme surface fallback because WebViews that drop
+   `light-dark()` otherwise render the popup chrome without a painted fill.
+   Items carry `data-highlighted` while traversed. */
+prosekit-autocomplete-popup[class],
 .reflect-autocomplete {
   /* Custom elements default to display:inline; an inline box fragments around
      block children, painting stray border/corner artifacts above and below the
@@ -488,7 +491,11 @@ body {
   border: 1px solid var(--border, rgb(0 0 0 / 10%));
   border-radius: 0.5rem;
   background: var(--surface, var(--background, #fff));
+  color: var(--text);
   box-shadow: 0 8px 24px rgb(0 0 0 / 12%);
+}
+prosekit-autocomplete-item[data-highlighted][class] {
+  background: var(--accent-soft, rgb(99 102 241 / 12%));
 }
 .reflect-autocomplete-item {
   display: block;


### PR DESCRIPTION
## Summary
- add Reflect-owned surface/color fallbacks for ProseKit autocomplete popups rendered by meowdown
- use semantic custom-element selectors instead of generated CSS module hashes or test IDs
- keep highlighted autocomplete rows on Reflect accent tokens with stronger non-important selectors

## Testing
- pnpm check

## Notes
- pnpm check passed with existing lint warnings only (max-lines, unsafe optional chaining, and React compiler warnings around TanStack Virtual / React Hook Form).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only presentation changes for editor autocomplete chrome; no logic, auth, or data paths touched.
> 
> **Overview**
> Fixes **backlink / wikilink, tag, and slash** editor autocomplete menus rendering with a missing or transparent background in desktop WebViews when `light-dark()` isn’t applied.
> 
> Reflect now styles **ProseKit** `prosekit-autocomplete-popup` alongside the existing `.reflect-autocomplete` rules: same surface/border/shadow chrome with **`color: var(--text)`** and **`background: var(--surface, …)`** fallbacks so menus stay opaque and on-theme.
> 
> Highlighted rows use a dedicated **`prosekit-autocomplete-item[data-highlighted][class]`** rule (stronger selector) so keyboard focus keeps the **accent-soft** wash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a25979c52cc713441ade1b0f88e58dd8eea129a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated editor autocomplete styling to better support ProseKit custom elements, ensuring the popup and highlighted items render consistently.
  * Adjusted autocomplete container text color to use the standard `--text` token.
  * Extended highlighted-item styling with the accent-soft background so selections look correct across related autocomplete menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->