### PR TITLE
Update meowdown to 0.15.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,8 +16,8 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@meowdown/core": "0.14.0",
-    "@meowdown/react": "0.14.0",
+    "@meowdown/core": "0.15.0",
+    "@meowdown/react": "0.15.0",
     "@reflect/core": "workspace:*",
     "@reflect/db": "workspace:*",
     "@reflect/design-system": "workspace:*",

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -471,50 +471,11 @@ body {
   cursor: pointer;
 }
 
-/* ---- [[ autocomplete (Plan 07) ---------------------------------------------
-   The popup is a prosekit custom element (positioned by its positioner); all
-   visual treatment is ours. Items carry `data-highlighted` while traversed. */
-.reflect-autocomplete {
-  /* Custom elements default to display:inline; an inline box fragments around
-     block children, painting stray border/corner artifacts above and below the
-     list and ignoring min-width/max-height/overflow. */
-  display: block;
-  z-index: 50;
-  min-width: 16rem;
-  max-width: 24rem;
-  max-height: 18rem;
-  overflow-y: auto;
-  padding: 0.25rem;
-  border: 1px solid var(--border, rgb(0 0 0 / 10%));
-  border-radius: 0.5rem;
-  background: var(--surface, var(--background, #fff));
-  box-shadow: 0 8px 24px rgb(0 0 0 / 12%);
-}
-.reflect-autocomplete-item {
-  display: block;
-  width: 100%;
-  padding: 0.375rem 0.5rem;
-  border-radius: 0.375rem;
-  cursor: pointer;
-}
-.reflect-autocomplete-item[data-highlighted] {
-  background: var(--accent-soft, rgb(99 102 241 / 12%));
-}
-.reflect-autocomplete-title {
-  display: block;
-  font-size: 0.875rem;
-  font-weight: 500;
-}
-.reflect-autocomplete-detail {
-  display: block;
-  font-size: 0.75rem;
-  color: var(--text-muted);
-}
-.reflect-autocomplete-empty {
-  display: block;
-  padding: 0.375rem 0.5rem;
-  font-size: 0.875rem;
-  color: var(--text-muted);
+/* meowdown hoists autocomplete popups out of the editor tree, so root-scoped
+   variables theme the floating menu without targeting generated DOM. */
+html:root {
+  --meowdown-autocomplete-bg: var(--surface);
+  --meowdown-autocomplete-highlight-bg: var(--accent-soft);
 }
 
 /* ---- shadcn inputs (components/ui/) -------------------------------------

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,11 +21,11 @@ importers:
   apps/desktop:
     dependencies:
       '@meowdown/core':
-        specifier: 0.14.0
-        version: 0.14.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+        specifier: 0.15.0
+        version: 0.15.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       '@meowdown/react':
-        specifier: 0.14.0
-        version: 0.14.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 0.15.0
+        version: 0.15.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@reflect/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -1008,11 +1008,11 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
-  '@meowdown/core@0.14.0':
-    resolution: {integrity: sha512-smGHtM70q799dWaXbAwG3XeK25SXQGFmVu3R4LI9o56dTE1d/rKfjDfhkXB7p9cd0JMiBOvRrhoC4D8QlJuCgQ==}
+  '@meowdown/core@0.15.0':
+    resolution: {integrity: sha512-GyUUzwjTVmKaXLUsCzuCDhYVaZDGzMVm65p0cxIjbDI+GkGmViMllsy+niLikz6ZKbtFeYpt8cWblQBAap2qFQ==}
 
-  '@meowdown/react@0.14.0':
-    resolution: {integrity: sha512-NCyMib4OWo6GkGC4cALZcngHcAv/7vWocySuIfeeM+h7CxlumKP0ByeHWexhEhJBYhnUY3Rtzt8Xs9gZ09PXlw==}
+  '@meowdown/react@0.15.0':
+    resolution: {integrity: sha512-VdQbzy5+/5hZdEtOWgqE0IqHew72u1mFiqGnRXyTqQQwypeVmSjuJ5sr0lSlfWR9RlenaJSbkFzMqjOxcJb9gw==}
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
@@ -6705,7 +6705,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@meowdown/core@0.14.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
+  '@meowdown/core@0.15.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
     dependencies:
       '@codemirror/language': 6.12.3
       '@codemirror/language-data': 6.5.2
@@ -6733,7 +6733,7 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@meowdown/react@0.14.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@meowdown/react@0.15.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@base-ui/react': 1.5.0(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@codemirror/commands': 6.10.3
@@ -6741,7 +6741,7 @@ snapshots:
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.43.1
-      '@meowdown/core': 0.14.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+      '@meowdown/core': 0.15.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       '@ocavue/utils': 1.7.0
       '@prosekit/core': 0.13.0-beta.3(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosekit/pm': 0.1.19-beta.0


### PR DESCRIPTION
## Summary
- update @meowdown/core and @meowdown/react to 0.15.0
- remove Reflect's old local autocomplete menu structural CSS
- use meowdown's new root-scoped autocomplete theme variables for Reflect popup surfaces

## Testing
- pnpm check
- pnpm --filter @reflect/desktop test --run src/editor/wiki-autocomplete-entries.test.ts src/editor/note-editor.test.tsx
- pnpm build
- local Vite smoke test at http://127.0.0.1:1431/: app loaded with no console errors and autocomplete theme variables resolved to Reflect tokens

## Notes
- 
> @reflect/monorepo@0.1.0 check /Users/alex/.codex/worktrees/meowdown-015/reflect-open
> pnpm typecheck && pnpm lint


> @reflect/monorepo@0.1.0 typecheck /Users/alex/.codex/worktrees/meowdown-015/reflect-open
> turbo run typecheck


   • Packages in scope: @reflect/core, @reflect/db, @reflect/design-system, @reflect/desktop, @reflect/extension, @reflect/utils
   • Running typecheck in 6 packages
   • Remote caching disabled, using shared worktree cache

@reflect/db:typecheck: cache hit, replaying logs 65039cc46478e30b
@reflect/core:typecheck: cache hit, replaying logs ec81ec8df90a45d4
@reflect/utils:typecheck: cache hit, replaying logs 133e21ac1f4d3960
@reflect/desktop:typecheck: cache hit, replaying logs 8dac1ab51b212069
@reflect/core:typecheck: 
@reflect/utils:typecheck: 
@reflect/db:typecheck: 
@reflect/core:typecheck: > @reflect/core@0.1.0 typecheck /Users/alex/.codex/worktrees/e4fe/reflect-open/packages/core
@reflect/core:typecheck: > tsc --noEmit
@reflect/utils:typecheck: > @reflect/utils@0.1.0 typecheck /Users/alex/repos/reflect-open/.claude/worktrees/date-utils-cleanup/packages/utils
@reflect/utils:typecheck: > tsc --noEmit
@reflect/utils:typecheck: 
@reflect/core:typecheck: 
@reflect/db:typecheck: > @reflect/db@0.1.0 typecheck /Users/alex/.codex/worktrees/dc62/reflect-open/packages/db
@reflect/db:typecheck: > tsc --noEmit
@reflect/db:typecheck: 
@reflect/desktop:typecheck: 
@reflect/desktop:typecheck: > @reflect/desktop@0.1.0 typecheck /Users/alex/.codex/worktrees/meowdown-015/reflect-open/apps/desktop
@reflect/desktop:typecheck: > tsc --noEmit
@reflect/desktop:typecheck: 
@reflect/extension:typecheck: cache hit, replaying logs 2bfd5a89f56190aa
@reflect/extension:typecheck: 
@reflect/extension:typecheck: > @reflect/extension@0.1.0 typecheck /Users/alex/repos/reflect-open/.claude/worktrees/festive-meninsky-a743e2/apps/extension
@reflect/extension:typecheck: > wxt prepare && tsc --noEmit
@reflect/extension:typecheck: 
@reflect/extension:typecheck: 
@reflect/extension:typecheck: WXT 0.20.26
@reflect/extension:typecheck: ℹ Generating types...
@reflect/extension:typecheck: ✔ Finished in 375 ms

 Tasks:    5 successful, 5 total
Cached:    5 cached, 5 total
  Time:    52ms >>> FULL TURBO


> @reflect/monorepo@0.1.0 lint /Users/alex/.codex/worktrees/meowdown-015/reflect-open
> oxlint apps packages && pnpm --filter @reflect/desktop lint:react

packages/core/src/index.ts:529:20: warning eslint(max-lines): File has too many lines (529). help: Maximum allowed is 500.
apps/desktop/src/editor/note-session.ts:798:2: warning eslint(max-lines): File has too many lines (798). help: Maximum allowed is 500.
packages/core/src/actions/asset-description.ts:531:2: warning eslint(max-lines): File has too many lines (531). help: Maximum allowed is 500.
packages/core/src/sync/github.ts:564:2: warning eslint(max-lines): File has too many lines (564). help: Maximum allowed is 500.
packages/core/src/actions/capture.ts:797:2: warning eslint(max-lines): File has too many lines (797). help: Maximum allowed is 500.
packages/core/src/indexing/queries.ts:624:2: warning eslint(max-lines): File has too many lines (624). help: Maximum allowed is 500.
apps/desktop/src/providers/chat-provider.tsx:507:2: warning eslint(max-lines): File has too many lines (507). help: Maximum allowed is 500.
packages/core/src/indexing/live.test.ts:285:13: warning eslint(no-unsafe-optional-chaining): Unsafe usage of optional chaining help: If this short-circuits with 'undefined' the evaluation will throw TypeError
packages/core/src/indexing/live.test.ts:286:13: warning eslint(no-unsafe-optional-chaining): Unsafe usage of optional chaining help: If this short-circuits with 'undefined' the evaluation will throw TypeError

> @reflect/desktop@0.1.0 lint:react /Users/alex/.codex/worktrees/meowdown-015/reflect-open/apps/desktop
> eslint .


/Users/alex/.codex/worktrees/meowdown-015/reflect-open/apps/desktop/src/components/all-notes/all-notes-table.tsx
  56:5   warning  React Hook useCallback has a missing dependency: 'selection'. Either include it or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        react-hooks/exhaustive-deps
  58:23  warning  Compilation Skipped: Use of incompatible library

This API returns functions which cannot be memoized without leading to stale UI. To prevent this, by default React Compiler will skip memoizing this component/hook. However, you may see issues if values from this API are passed to other components/hooks that are memoized.

/Users/alex/.codex/worktrees/meowdown-015/reflect-open/apps/desktop/src/components/all-notes/all-notes-table.tsx:58:23
  56 |     [selection.clickSelect],
  57 |   )
> 58 |   const virtualizer = useVirtualizer({
     |                       ^^^^^^^^^^^^^^ TanStack Virtual's `useVirtualizer()` API returns functions that cannot be memoized safely
  59 |     count: rows.length,
  60 |     getScrollElement: () => scrollElement,
  61 |     estimateSize: () => ESTIMATED_ROW_HEIGHT,  react-hooks/incompatible-library

/Users/alex/.codex/worktrees/meowdown-015/reflect-open/apps/desktop/src/components/daily-stream.tsx
  83:23  warning  Compilation Skipped: Use of incompatible library

This API returns functions which cannot be memoized without leading to stale UI. To prevent this, by default React Compiler will skip memoizing this component/hook. However, you may see issues if values from this API are passed to other components/hooks that are memoized.

/Users/alex/.codex/worktrees/meowdown-015/reflect-open/apps/desktop/src/components/daily-stream.tsx:83:23
  81 |   targetDateRef.current = targetDate
  82 |
> 83 |   const virtualizer = useVirtualizer({
     |                       ^^^^^^^^^^^^^^ TanStack Virtual's `useVirtualizer()` API returns functions that cannot be memoized safely
  84 |     count: dayWindow.count,
  85 |     getScrollElement: () => scrollRef.current,
  86 |     estimateSize: () => ESTIMATED_DAY_HEIGHT,  react-hooks/incompatible-library

/Users/alex/.codex/worktrees/meowdown-015/reflect-open/apps/desktop/src/components/settings/add-ai-provider-dialog.tsx
  85:31  warning  Compilation Skipped: Use of incompatible library

This API returns functions which cannot be memoized without leading to stale UI. To prevent this, by default React Compiler will skip memoizing this component/hook. However, you may see issues if values from this API are passed to other components/hooks that are memoized.

/Users/alex/.codex/worktrees/meowdown-015/reflect-open/apps/desktop/src/components/settings/add-ai-provider-dialog.tsx:85:31
  83 |   }, [])
  84 |
> 85 |   const provider = aiProvider(watch('provider'))
     |                               ^^^^^ React Hook Form's `useForm()` API returns a `watch()` function which cannot be memoized safely.
  86 |
  87 |   const submit = handleSubmit(async (values) => {
  88 |     setSubmitError(null)  react-hooks/incompatible-library

/Users/alex/.codex/worktrees/meowdown-015/reflect-open/apps/desktop/src/mobile/screens/all-notes.tsx
  148:23  warning  Compilation Skipped: Use of incompatible library

This API returns functions which cannot be memoized without leading to stale UI. To prevent this, by default React Compiler will skip memoizing this component/hook. However, you may see issues if values from this API are passed to other components/hooks that are memoized.

/Users/alex/.codex/worktrees/meowdown-015/reflect-open/apps/desktop/src/mobile/screens/all-notes.tsx:148:23
  146 |   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null)
  147 |   const rows = useMemo(() => notes ?? [], [notes])
> 148 |   const virtualizer = useVirtualizer({
      |                       ^^^^^^^^^^^^^^ TanStack Virtual's `useVirtualizer()` API returns functions that cannot be memoized safely
  149 |     count: rows.length,
  150 |     getScrollElement: () => scrollElement,
  151 |     estimateSize: () => 64,  react-hooks/incompatible-library

✖ 5 problems (0 errors, 5 warnings) passed with existing warnings only (max-lines, unsafe optional chaining, React compiler/TanStack Virtual/React Hook Form warnings).
- 
> @reflect/monorepo@0.1.0 build /Users/alex/.codex/worktrees/meowdown-015/reflect-open
> turbo run build


   • Packages in scope: @reflect/core, @reflect/db, @reflect/design-system, @reflect/desktop, @reflect/extension, @reflect/utils
   • Running build in 6 packages
   • Remote caching disabled, using shared worktree cache

@reflect/extension:build: cache hit, replaying logs 1c8d8457b7d359d6
@reflect/extension:build: 
@reflect/extension:build: > @reflect/extension@0.1.0 build /Users/alex/.codex/worktrees/meowdown-015/reflect-open/apps/extension
@reflect/extension:build: > wxt build
@reflect/extension:build: 
@reflect/extension:build: 
@reflect/extension:build: WXT 0.20.26
@reflect/extension:build: ℹ Building chrome-mv3 for production with Vite 8.0.16
@reflect/extension:build: - Preparing...
@reflect/extension:build: ✔ Built extension in 356 ms
@reflect/extension:build:   ├─ .output/chrome-mv3/manifest.json                               1 kB     
@reflect/extension:build:   ├─ .output/chrome-mv3/popup.html                                  396 B    
@reflect/extension:build:   ├─ .output/chrome-mv3/background.js                               76.01 kB 
@reflect/extension:build:   ├─ .output/chrome-mv3/chunks/popup-MkYjOn2R.js                    266.39 kB
@reflect/extension:build:   ├─ .output/chrome-mv3/content-scripts/capture-content.js          337.35 kB
@reflect/extension:build:   ├─ .output/chrome-mv3/assets/popup-BvmhzSfF.css                   13.34 kB 
@reflect/extension:build:   ├─ .output/chrome-mv3/assets/InterVariable-CWi-zmRD.woff2         345.59 kB
@reflect/extension:build:   ├─ .output/chrome-mv3/assets/InterVariable-Italic-d6KXgdvN.woff2  380.9 kB 
@reflect/extension:build:   ├─ .output/chrome-mv3/icon/128.png                                28.78 kB 
@reflect/extension:build:   ├─ .output/chrome-mv3/icon/16.png                                 1.49 kB  
@reflect/extension:build:   ├─ .output/chrome-mv3/icon/32.png                                 3.17 kB  
@reflect/extension:build:   └─ .output/chrome-mv3/icon/48.png                                 5.86 kB  
@reflect/extension:build: Σ Total size: 1.46 MB                                             
@reflect/extension:build: ✔ Finished in 656 ms
@reflect/extension:build: [1G
@reflect/desktop:build: cache hit, replaying logs 8acd18dcd263e28a
@reflect/desktop:build: 
@reflect/desktop:build: > @reflect/desktop@0.1.0 build /Users/alex/.codex/worktrees/meowdown-015/reflect-open/apps/desktop
@reflect/desktop:build: > vite build
@reflect/desktop:build: 
@reflect/desktop:build: vite v8.0.16 building client environment for production...
@reflect/desktop:build: [2K@reflect/desktop:build: transforming...✓ 3936 modules transformed.
@reflect/desktop:build: rendering chunks...
@reflect/desktop:build: computing gzip size...
@reflect/desktop:build: dist/index.html                                      0.83 kB │ gzip:   0.47 kB
@reflect/desktop:build: dist/assets/InterVariable-CWi-zmRD.woff2           345.58 kB
@reflect/desktop:build: dist/assets/InterVariable-Italic-d6KXgdvN.woff2    380.90 kB
@reflect/desktop:build: dist/assets/use-app-version-CaukQbhI.css            21.77 kB │ gzip:   4.30 kB
@reflect/desktop:build: dist/assets/index-CVJmnkQK.css                      91.06 kB │ gzip:  16.26 kB
@reflect/desktop:build: dist/assets/diff-ChtP43wD.js                         0.30 kB │ gzip:   0.23 kB
@reflect/desktop:build: dist/assets/brainfuck-D5EjA2JK.js                    0.59 kB │ gzip:   0.32 kB
@reflect/desktop:build: dist/assets/properties-C357ku5U.js                   0.66 kB │ gzip:   0.34 kB
@reflect/desktop:build: dist/assets/cmake-CyVbuzPu.js                        0.78 kB │ gzip:   0.46 kB
@reflect/desktop:build: dist/assets/asciiarmor-qTkVPQu6.js                   0.79 kB │ gzip:   0.40 kB
@reflect/desktop:build: dist/assets/protobuf-D1ij_kNL.js                     0.80 kB │ gzip:   0.51 kB
@reflect/desktop:build: dist/assets/http-CLVgA2GD.js                         0.84 kB │ gzip:   0.42 kB
@reflect/desktop:build: dist/assets/solr-BBopId9w.js                         0.86 kB │ gzip:   0.45 kB
@reflect/desktop:build: dist/assets/troff-C2dAgh7P.js                        0.95 kB │ gzip:   0.43 kB
@reflect/desktop:build: dist/assets/spreadsheet-CTIncYxj.js                  1.13 kB │ gzip:   0.53 kB
@reflect/desktop:build: dist/assets/toml-LvoKBwCs.js                         1.19 kB │ gzip:   0.53 kB
@reflect/desktop:build: dist/assets/mbox-BEMVcqjs.js                         1.38 kB │ gzip:   0.65 kB
@reflect/desktop:build: dist/assets/rpm-gpDK5sbt.js                          1.59 kB │ gzip:   0.81 kB
@reflect/desktop:build: dist/assets/sieve-BAxa3IjF.js                        1.61 kB │ gzip:   0.77 kB
@reflect/desktop:build: dist/assets/factor-D7LVTn2l.js                       1.66 kB │ gzip:   0.60 kB
@reflect/desktop:build: dist/assets/eiffel-BEjRio4Q.js                       1.69 kB │ gzip:   0.90 kB
@reflect/desktop:build: dist/assets/z80-CL1naaMV.js                          1.75 kB │ gzip:   0.79 kB
@reflect/desktop:build: dist/assets/mumps-CW_TBmxz.js                        1.83 kB │ gzip:   0.95 kB
@reflect/desktop:build: dist/assets/elm-Cshzl8qu.js                          1.86 kB │ gzip:   0.81 kB
@reflect/desktop:build: dist/assets/mathematica-u8YMmbU0.js                  1.89 kB │ gzip:   0.80 kB
@reflect/desktop:build: dist/assets/dockerfile-BLkNEvjs.js                   1.90 kB │ gzip:   0.64 kB
@reflect/desktop:build: dist/assets/turtle-Cx3rYX2g.js                       1.95 kB │ gzip:   0.89 kB
@reflect/desktop:build: dist/assets/ebnf-D4c0_ac3.js                         1.97 kB │ gzip:   0.80 kB
@reflect/desktop:build: dist/assets/dist-2sBOx6-y.js                         1.99 kB │ gzip:   1.26 kB
@reflect/desktop:build: dist/assets/smalltalk-BLp5-jwC.js                    1.99 kB │ gzip:   0.85 kB
@reflect/desktop:build: dist/assets/fcl-ClOhbFR7.js                          2.02 kB │ gzip:   0.95 kB
@reflect/desktop:build: dist/assets/ntriples-d28e9m0E.js                     2.07 kB │ gzip:   0.73 kB
@reflect/desktop:build: dist/assets/dtd-DTF72YNO.js                          2.09 kB │ gzip:   0.87 kB
@reflect/desktop:build: dist/assets/octave-D2Q8cUp1.js                       2.10 kB │ gzip:   1.07 kB
@reflect/desktop:build: dist/assets/yacas-CXXgtw0p.js                        2.14 kB │ gzip:   1.08 kB
@reflect/desktop:build: dist/assets/pascal-Dp_KdFgX.js                       2.25 kB │ gzip:   1.17 kB
@reflect/desktop:build: dist/assets/apl-CnwPGSsG.js                          2.29 kB │ gzip:   1.22 kB
@reflect/desktop:build: dist/assets/simple-mode-DRpGK0lJ.js                  2.29 kB │ gzip:   1.09 kB
@reflect/desktop:build: dist/assets/commonlisp-CcllspGY.js                   2.32 kB │ gzip:   1.10 kB
@reflect/desktop:build: dist/assets/tcl-BGfruO1u.js                          2.35 kB │ gzip:   1.22 kB
@reflect/desktop:build: dist/assets/shell-Du5Qg9im.js                        2.44 kB │ gzip:   1.20 kB
@reflect/desktop:build: dist/assets/webidl-D5jiJvOU.js                       2.44 kB │ gzip:   1.24 kB
@reflect/desktop:build: dist/assets/pig-AF4Hwhju.js                          2.51 kB │ gzip:   1.37 kB
@reflect/desktop:build: dist/assets/puppet-B4hC2X4m.js                       2.54 kB │ gzip:   1.20 kB
@reflect/desktop:build: dist/assets/forth-Cezjo90N.js                        2.54 kB │ gzip:   1.32 kB
@reflect/desktop:build: dist/assets/dist-l7vdVMmW.js                         2.60 kB │ gzip:   1.49 kB
@reflect/desktop:build: dist/assets/velocity-CqftRsjg.js                     2.70 kB │ gzip:   1.11 kB
@reflect/desktop:build: dist/assets/tiddlywiki-VlUiK86J.js                   2.76 kB │ gzip:   1.07 kB
@reflect/desktop:build: dist/assets/modelica-CqHI_q-D.js                     2.79 kB │ gzip:   1.28 kB
@reflect/desktop:build: dist/assets/oz-BwTct_5T.js                           2.88 kB │ gzip:   1.27 kB
@reflect/desktop:build: dist/assets/r-DADKenSm.js                            3.00 kB │ gzip:   1.34 kB
@reflect/desktop:build: dist/assets/stex-sDrdk2BW.js                         3.12 kB │ gzip:   1.18 kB
@reflect/desktop:build: dist/assets/lua-CiA1ziua.js                          3.13 kB │ gzip:   1.40 kB
@reflect/desktop:build: dist/assets/cypher-p9eYesGn.js                       3.18 kB │ gzip:   1.49 kB
@reflect/desktop:build: dist/assets/tiki-CxVlf5KZ.js                         3.23 kB │ gzip:   1.26 kB
@reflect/desktop:build: dist/assets/vhdl-CMrOq2q1.js                         3.31 kB │ gzip:   1.49 kB
@reflect/desktop:build: dist/assets/dist-COU9gNNq.js                         3.32 kB │ gzip:   1.69 kB
@reflect/desktop:build: dist/assets/sparql-Dz-mlCAC.js                       3.33 kB │ gzip:   1.59 kB
@reflect/desktop:build: dist/assets/mscgen-qgSLujhx.js                       3.49 kB │ gzip:   0.97 kB
@reflect/desktop:build: dist/assets/vb-BthdM_4N.js                           3.65 kB │ gzip:   1.81 kB
@reflect/desktop:build: dist/assets/d-BhMjBjQP.js                            3.67 kB │ gzip:   1.67 kB
@reflect/desktop:build: dist/assets/q-B9NhS7L_.js                            3.69 kB │ gzip:   1.69 kB
@reflect/desktop:build: dist/assets/swift-DKB6_1j6.js                        3.76 kB │ gzip:   1.81 kB
@reflect/desktop:build: dist/assets/coffeescript-B2pKbFk8.js                 3.85 kB │ gzip:   1.69 kB
@reflect/desktop:build: dist/assets/fortran-Bt6PBEDR.js                      3.86 kB │ gzip:   1.93 kB
@reflect/desktop:build: dist/assets/asn1-Dr8qZg38.js                         3.95 kB │ gzip:   1.95 kB
@reflect/desktop:build: dist/assets/dylan-C6jEEEk-.js                        4.04 kB │ gzip:   1.63 kB
@reflect/desktop:build: dist/assets/ttcn-cfg-CY0aot7Q.js                     4.07 kB │ gzip:   1.72 kB
@reflect/desktop:build: dist/assets/asterisk-Bja0s6e1.js                     4.07 kB │ gzip:   1.74 kB
@reflect/desktop:build: dist/assets/livescript-BXxG0Yva.js                   4.08 kB │ gzip:   1.62 kB
@reflect/desktop:build: dist/assets/groovy-BC3IOsC8.js                       4.10 kB │ gzip:   1.74 kB
@reflect/desktop:build: dist/assets/haskell-BRsoo5mP.js                      4.15 kB │ gzip:   1.91 kB
@reflect/desktop:build: dist/assets/gas-BHEdbvp9.js                          4.55 kB │ gzip:   1.27 kB
@reflect/desktop:build: dist/assets/mllike-B45xgp2S.js                       4.82 kB │ gzip:   1.57 kB
@reflect/desktop:build: dist/assets/ttcn-BePYh-hG.js                         4.82 kB │ gzip:   2.13 kB
@reflect/desktop:build: dist/assets/dist-_Mg5JR9H.js                         4.93 kB │ gzip:   2.34 kB
@reflect/desktop:build: dist/assets/crystal-M5-qzICs.js                      5.02 kB │ gzip:   2.10 kB
@reflect/desktop:build: dist/assets/ecl-BSZaIHnp.js                          5.09 kB │ gzip:   2.30 kB
@reflect/desktop:build: dist/assets/ruby-DsYpTuWg.js                         5.10 kB │ gzip:   2.15 kB
@reflect/desktop:build: dist/assets/julia-CQfgDRfP.js                        5.26 kB │ gzip:   2.16 kB
@reflect/desktop:build: dist/assets/vbscript-D9f6rSsU.js                     5.43 kB │ gzip:   2.56 kB
@reflect/desktop:build: dist/assets/mirc-C9zpzAZU.js                         5.91 kB │ gzip:   2.70 kB
@reflect/desktop:build: dist/assets/cobol-B_OZ4V-R.js                        6.22 kB │ gzip:   3.01 kB
@reflect/desktop:build: dist/assets/xquery-fj_R-kMw.js                       6.22 kB │ gzip:   2.57 kB
@reflect/desktop:build: dist/assets/python-BqYw9LYJ.js                       6.28 kB │ gzip:   2.67 kB
@reflect/desktop:build: dist/assets/scheme-CyDdOh7e.js                       6.36 kB │ gzip:   2.38 kB
@reflect/desktop:build: dist/assets/pug-DyBTKFx8.js                          6.67 kB │ gzip:   1.99 kB
@reflect/desktop:build: dist/assets/textile-DWBqthVk.js                      6.77 kB │ gzip:   2.44 kB
@reflect/desktop:build: dist/assets/nsis-AQ_alPln.js                         6.80 kB │ gzip:   2.99 kB
@reflect/desktop:build: dist/assets/nginx-BMaDbqW3.js                        7.40 kB │ gzip:   2.73 kB
@reflect/desktop:build: dist/assets/powershell-CzG71I4L.js                   7.69 kB │ gzip:   3.29 kB
@reflect/desktop:build: dist/assets/erlang-DaB2Rkuy.js                       7.84 kB │ gzip:   2.89 kB
@reflect/desktop:build: dist/assets/haxe-DjVOVvNP.js                         7.86 kB │ gzip:   2.94 kB
@reflect/desktop:build: dist/assets/dist-DS_TWsCm.js                         8.43 kB │ gzip:   3.58 kB
@reflect/desktop:build: dist/assets/verilog-D-x6ne0Z.js                      8.43 kB │ gzip:   3.53 kB
@reflect/desktop:build: dist/assets/sas-C2OyD2Y6.js                          9.33 kB │ gzip:   4.11 kB
@reflect/desktop:build: dist/assets/clojure-BflJGmDX.js                      9.40 kB │ gzip:   4.02 kB
@reflect/desktop:build: dist/assets/perl-CdEHsPfU.js                         9.75 kB │ gzip:   3.51 kB
@reflect/desktop:build: dist/assets/idl-BUZw3wgd.js                          9.82 kB │ gzip:   4.40 kB
@reflect/desktop:build: dist/assets/gherkin-oBAE_ms0.js                     10.15 kB │ gzip:   5.09 kB
@reflect/desktop:build: dist/assets/dist-D7VqAm16.js                        11.55 kB │ gzip:   5.17 kB
@reflect/desktop:build: dist/assets/dist-D-TiAqcu.js                        14.33 kB │ gzip:   5.78 kB
@reflect/desktop:build: dist/assets/dist-B7_dy15i.js                        16.23 kB │ gzip:   7.47 kB
@reflect/desktop:build: dist/assets/javascript-8HiN0ThV.js                  17.02 kB │ gzip:   5.74 kB
@reflect/desktop:build: dist/assets/dist-C6HhLruf.js                        20.69 kB │ gzip:   9.33 kB
@reflect/desktop:build: dist/assets/dist-B1vGLWRh.js                        20.95 kB │ gzip:   9.66 kB
@reflect/desktop:build: dist/assets/clike-DHH8Ad3s.js                       22.06 kB │ gzip:   7.75 kB
@reflect/desktop:build: dist/assets/dist-D-hn_Y8H.js                        22.95 kB │ gzip:  10.41 kB
@reflect/desktop:build: dist/assets/stylus-DLLZ8dgm.js                      23.52 kB │ gzip:   8.56 kB
@reflect/desktop:build: dist/assets/css-CYpP4FRV.js                         24.70 kB │ gzip:   8.25 kB
@reflect/desktop:build: dist/assets/dist-DDtkXO3h.js                        25.79 kB │ gzip:  12.20 kB
@reflect/desktop:build: dist/assets/dist-CgH7ZgZa.js                        28.40 kB │ gzip:  11.56 kB
@reflect/desktop:build: dist/assets/dist-Cw4QMExU.js                        30.71 kB │ gzip:  12.73 kB
@reflect/desktop:build: dist/assets/dist-DbYn-MIl.js                        34.44 kB │ gzip:  11.81 kB
@reflect/desktop:build: dist/assets/sql-DcCJ9jop.js                         36.85 kB │ gzip:  10.90 kB
@reflect/desktop:build: dist/assets/dist-Cr190Dvp.js                        40.70 kB │ gzip:  16.93 kB
@reflect/desktop:build: dist/assets/dist-BdLVl9K1.js                        44.57 kB │ gzip:  19.32 kB
@reflect/desktop:build: dist/assets/dist-0-fO7WVG.js                        46.95 kB │ gzip:  13.42 kB
@reflect/desktop:build: dist/assets/mobile-root-CUNA09A3.js                 68.81 kB │ gzip:  22.67 kB
@reflect/desktop:build: dist/assets/dist-BWOrGeBt.js                        70.78 kB │ gzip:  26.09 kB
@reflect/desktop:build: dist/assets/dist-BDWdbJ3_.js                        84.61 kB │ gzip:  33.74 kB
@reflect/desktop:build: dist/assets/dist-C3JEQv32.js                        97.73 kB │ gzip:  28.63 kB
@reflect/desktop:build: dist/assets/dist-DDTpK2Sc.js                       103.89 kB │ gzip:  34.75 kB
@reflect/desktop:build: dist/assets/dist-F2GAkF6K.js                       253.08 kB │ gzip:  82.10 kB
@reflect/desktop:build: dist/assets/desktop-root-CxcBolzW.js               295.51 kB │ gzip:  87.15 kB
@reflect/desktop:build: dist/assets/use-app-version-BJI-Rume.js            774.77 kB │ gzip: 243.83 kB
@reflect/desktop:build: dist/assets/index-AFWbpakW.js                    1,288.06 kB │ gzip: 339.85 kB
@reflect/desktop:build: 
@reflect/desktop:build: ✓ built in 575ms
@reflect/desktop:build: [plugin builtin:vite-reporter] 
@reflect/desktop:build: (!) Some chunks are larger than 500 kB after minification. Consider:
@reflect/desktop:build: - Using dynamic import() to code-split the application
@reflect/desktop:build: - Use build.rolldownOptions.output.codeSplitting to improve chunking: https://rolldown.rs/reference/OutputOptions.codeSplitting
@reflect/desktop:build: - Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.

 Tasks:    2 successful, 2 total
Cached:    2 cached, 2 total
  Time:    48ms >>> FULL TURBO passed with existing Vite chunk-size and Turbo extension-output warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and editor autocomplete theming only; no auth, data, or API changes.
> 
> **Overview**
> Bumps **`@meowdown/core`** and **`@meowdown/react`** from **0.14.0** to **0.15.0** in the desktop app (lockfile included).
> 
> Autocomplete styling moves off Reflect’s custom **`.reflect-autocomplete*`** rules and onto meowdown’s **root-scoped** theme variables: **`--meowdown-autocomplete-bg`** and **`--meowdown-autocomplete-highlight-bg`** are wired to **`--surface`** and **`--accent-soft`** so hoisted popup menus still match Reflect without styling generated DOM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62ca5b7402497978e9da51f213fe7774d593a230. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->