### PR TITLE
fix(editor): match note title size to the daily subject

### DIFF
--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -302,9 +302,16 @@ body {
   margin-top: 0;
 }
 
-.reflect-editor h1,
-.reflect-editor h2,
-.reflect-editor h3 {
+/* Heading weight and size compete with meowdown's `.ProseMirror h*` theme
+   rules. That stylesheet is injected dynamically when the editor lazy-loads, so
+   it cascades *after* this file and wins equal-specificity (0-1-1) ties — left
+   plain, our H1 lost to the theme's 1.75rem and towered over the daily subject.
+   The `.ProseMirror` compound bumps these to 0-2-1 so our values hold; see the
+   note on `.reflect-stream-gutter`. (Margin and letter-spacing ride along; only
+   the size and weight actually clash with the theme.) */
+.reflect-editor.ProseMirror h1,
+.reflect-editor.ProseMirror h2,
+.reflect-editor.ProseMirror h3 {
   font-weight: 650;
   letter-spacing: var(--tracking-snug, -0.01em);
   margin: 1.25em 0 0.4em;
@@ -312,9 +319,9 @@ body {
 /* The leading H1 is the regular-note subject, matching the daily subject.
    Other headings stay capped at the same semantic size rather than towering
    over the body. */
-.reflect-editor h1 { @apply text-note-subject; }
-.reflect-editor h2 { @apply text-note-subject; }
-.reflect-editor h3 { font-size: var(--text-lg, 1.125rem); }
+.reflect-editor.ProseMirror h1 { @apply text-note-subject; }
+.reflect-editor.ProseMirror h2 { @apply text-note-subject; }
+.reflect-editor.ProseMirror h3 { font-size: var(--text-lg, 1.125rem); }
 .reflect-editor h1:first-child { margin-top: 0; }
 .reflect-editor .reflect-note-title { @apply text-note-subject; }
 


### PR DESCRIPTION
## What changed

The non-daily note **title** and the **daily-note subject** now render at the same size. Both are meant to be `text-note-subject` (`var(--text-xl)`, 1.25rem), but the note title was rendering at **1.75rem**.

The fix bumps the editor's competing heading rules to the `.reflect-editor.ProseMirror` (0-2-1) compound in `apps/desktop/src/styles/index.css`.

## Why

meowdown's editor theme ships `.ProseMirror h1 { font-size: 1.75rem }` at the same **0-1-1** specificity as our `.reflect-editor h1`. Because that theme stylesheet is **injected dynamically when the editor lazy-loads**, it cascades *after* `index.css` and wins the equal-specificity tie — so the note title used 1.75rem instead of our 1.25rem.

The daily subject (`.reflect-daily-subject`) lives outside `.ProseMirror`, so it was never overridden — which is exactly why the two looked different.

This uses the pattern the file already documents and applies elsewhere (the `padding`/`font-size` reset at `.reflect-editor.ProseMirror`, and `.reflect-stream-gutter.ProseMirror`): raise specificity to 0-2-1 so our values reliably beat the dynamically-injected theme.

## Reviewer notes

- The whole heading block was losing the same tie, so this also restores the **documented intent** for the other editor headings: `h2` → subject size, `h3` → `text-lg`, and the **650** weight (previously falling through to the theme's 1.4rem / 1.2rem at weight 600). Restoring this keeps a consistent hierarchy — fixing only `h1` would leave an in-body `##` (1.4rem) larger than the `#` title (1.25rem).
- Pure CSS specificity change; no TS/JS impact. Not yet visually verified in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure CSS selector specificity in `index.css` with no runtime or data-path changes.
> 
> **Overview**
> **Editor headings** now use the `.reflect-editor.ProseMirror h1/h2/h3` compound selectors so Reflect’s `text-note-subject` sizing and weight win over meowdown’s dynamically injected `.ProseMirror h*` theme (which was overriding at equal specificity and rendering note titles at 1.75rem instead of the daily subject’s 1.25rem).
> 
> The change follows the same specificity pattern already used for padding on `.reflect-stream-gutter.ProseMirror` and `.reflect-editor.ProseMirror`, with an inline comment explaining the cascade. **h2** and **h3** rules move with **h1** so in-body headings stay below the title in the hierarchy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd0dd0c57cba072f3b8048dec15936d118bf6ad8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved heading styling consistency in the editor. Enhanced CSS rules governing heading display to ensure proper text formatting, visual hierarchy, and consistent cascading of styles across all heading levels. These updates result in better readability and a more polished appearance throughout documents when editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->