### PR TITLE
Move All Notes trash action before filters

### DIFF
--- a/apps/desktop/src/components/all-notes/all-notes-screen.test.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.test.tsx
@@ -383,7 +383,9 @@ describe('AllNotesScreen — selection and bulk trash', () => {
     // Clicking the row body (the snippet, not a button) selects without opening.
     fireEvent.click(view.getByText('Shop your health goals.'))
     expect(probedRoute(view)).toEqual({ kind: 'allNotes', tag: null })
-    expect(view.getByRole('button', { name: /Trash \(1\)/ })).toBeDefined()
+    const trashButton = view.getByRole('button', { name: /Trash \(1\)/ })
+    expect(trashButton).toBeDefined()
+    expect(view.getByRole('group', { name: 'Filter by tag' }).previousElementSibling).toBe(trashButton)
 
     // ⌘-click a second row extends the selection.
     fireEvent.click(view.getByText('Dandelion chocolate.'), { metaKey: true })

--- a/apps/desktop/src/components/all-notes/all-notes-screen.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.tsx
@@ -116,11 +116,6 @@ export function AllNotesScreen({ tag }: AllNotesScreenProps): ReactElement {
       <header className="flex flex-none flex-wrap items-center justify-between gap-3 border-b border-border py-4 pl-12 pr-7">
         <h1 className="text-[15px] font-semibold text-text">Notes</h1>
         <div className="flex flex-wrap items-center gap-3">
-          <AllNotesFilters
-            tag={tag}
-            facets={facets ?? []}
-            onSelect={handleFilterSelect}
-          />
           {selection.selectedCount > 0 ? (
             <Button
               type="button"
@@ -139,6 +134,11 @@ export function AllNotesScreen({ tag }: AllNotesScreenProps): ReactElement {
               </span>
             </Button>
           ) : null}
+          <AllNotesFilters
+            tag={tag}
+            facets={facets ?? []}
+            onSelect={handleFilterSelect}
+          />
           <NewNoteButton />
         </div>
       </header>


### PR DESCRIPTION
## Summary
- Move the All Notes bulk Trash button to the left of the tag filter group
- Add a focused regression assertion for the header control order

## Testing
- pnpm --filter @reflect/desktop test --run src/components/all-notes/all-notes-screen.test.tsx
- pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Header-only DOM order change with no logic or data-path impact; covered by an existing selection test.
> 
> **Overview**
> Reorders the **All Notes** header so the bulk **Trash** control appears **immediately left of** the tag filter group (`AllNotesFilters`), instead of after it. **New note** stays on the right; trash behavior is unchanged and still only shows when rows are selected.
> 
> Adds a regression check that the trash button is the `previousElementSibling` of the `Filter by tag` group after selecting a row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e692beecd9a6777951c636133c60968a96e9cc50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Adjustments**
  * Reorganized the All Notes screen header layout for improved component ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->