### PR TITLE
Release v0.2.0-beta.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.2.0-beta.23"
+version = "0.2.0-beta.24"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.2.0-beta.23"
+version = "0.2.0-beta.24"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.2.0-beta.23",
+  "version": "0.2.0-beta.24",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.2.0-beta.24.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version string updates only; no runtime, security, or behavioral code changes.
> 
> **Overview**
> **Release v0.2.0-beta.24** — version-only bump with no application or dependency logic changes in this diff.
> 
> `reflect-open` is updated from **0.2.0-beta.23** to **0.2.0-beta.24** in `apps/desktop/src-tauri/Cargo.toml`, `tauri.conf.json`, and the corresponding `Cargo.lock` entry so desktop builds, Tauri bundle metadata, and the lockfile stay aligned for tagging and distribution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c019f6e4b4486f9cac103117413758ede96aad06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.2.0-beta.24

<!-- end of auto-generated comment: release notes by coderabbit.ai -->