### PR TITLE
docs(editor): correct stale frontmatter comment in note-session

### DIFF
--- a/apps/desktop/src/editor/note-session.ts
+++ b/apps/desktop/src/editor/note-session.ts
@@ -34,13 +34,16 @@ import type { RoundTripFidelity } from './roundtrip'
  * imperatively, and **never clobbers a dirty one** — it parks as `conflict` for
  * the user to resolve.
  *
- * **Frontmatter is the session's, not the editor's** (Plan 07b): meowdown
- * mangles a `---` block (it reads as thematic breaks/setext), so the editor
- * sees only the body — the session splits every disk read, keeps the exact
- * header bytes aside, and rejoins them on every write. This is also what makes
- * frontmatter notes editable at all (a joined round-trip classifies lossy),
- * and gives metadata writes ({@link NoteSession.updateFrontmatter}) a channel
- * that never disturbs the editor view.
+ * **Frontmatter is the session's, not the editor's** (Plan 07b): meowdown can
+ * now round-trip a `---` block, but only by normalizing it (it keeps the body
+ * as an opaque doc attribute, rewrites CRLF to LF, drops fence whitespace, and
+ * forces a blank line after the block), which would lose our exact header bytes
+ * and bloat git diffs. So the editor still sees only the body: the session
+ * splits every disk read, keeps the exact header bytes aside, and rejoins them
+ * on every write. This is also what keeps frontmatter notes editable at all (a
+ * joined round-trip classifies lossy) and gives metadata writes
+ * ({@link NoteSession.updateFrontmatter}) a channel that never disturbs the
+ * editor view.
  */
 
 const DEFAULT_SAVE_DEBOUNCE_MS = 800


### PR DESCRIPTION
## What

Updates the `NoteSession` JSDoc that explained why frontmatter is owned by the session and never handed to the editor.

The old comment claimed:

> meowdown mangles a `---` block (it reads as thematic breaks/setext)

That is no longer true. Since `@meowdown/core@0.16.2` (the version this app depends on), meowdown *does* handle a leading `---` block. But it only round-trips it by **normalizing**: it stores the body as an opaque `doc` attribute, rewrites CRLF to LF, drops fence whitespace, and forces a blank line after the block. That would lose our exact header bytes and bloat git diffs, so the session still owns frontmatter for byte-exact preservation and the metadata-write channel.

The architectural decision is unchanged; only the rationale in the comment is corrected.

## Notes

- No behavior change. Comment-only.
- The `console.warn("DEBUG 3")` line that exists in a local working copy is **not** present on `next`, so there is nothing to delete here.
- A few pre-existing em-dashes elsewhere in the same JSDoc block were left untouched to keep this diff scoped to the stale claim. Happy to strip them in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation for improved clarity on editor behavior and data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->