### PR TITLE
feat(editor): enable meowdown block handle in notes

### DIFF
--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -213,6 +213,8 @@ export function NotePane({
         markMode={settings.editorMarkdownSyntax}
         spellCheck={settings.editorSpellCheck}
         bulletAfterHeading={settings.editorBulletAfterHeading}
+        // The grip drag-reorders blocks and the "+" inserts a paragraph below.
+        blockHandle={true}
         resolveImageUrl={resolveImageUrl}
         resolveImageOpenPath={resolveImageOpenPath}
         openImage={openImage}

--- a/apps/desktop/src/components/tasks/task-editor.tsx
+++ b/apps/desktop/src/components/tasks/task-editor.tsx
@@ -196,6 +196,8 @@ export function TaskEditor({
         onChange={onChange}
         markMode={settings.editorMarkdownSyntax}
         spellCheck={settings.editorSpellCheck}
+        // A one-line editor has nothing to reorder, so keep the gutter grip off.
+        blockHandle={false}
         onWikiLinkClick={navigate}
         onWikilinkSearch={onWikilinkSearch}
         onTagSearch={onTagSearch}

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -63,6 +63,13 @@ interface NoteEditorProps {
    * (the `editorBulletAfterHeading` setting). Off by default.
    */
   bulletAfterHeading?: boolean
+  /**
+   * Whether to show meowdown's per-block gutter handle: a grip to drag-reorder
+   * blocks and a "+" to insert a paragraph below. Off by default. The main note
+   * editor opts in; one-line surfaces like the inline task editor leave it off so
+   * no stray grip appears beside them.
+   */
+  blockHandle?: boolean
   /** Resolve an image `![…](…)` source to a displayable URL; unresolved images are skipped. */
   resolveImageUrl?: (src: string) => string | null
   /**
@@ -110,6 +117,7 @@ export function NoteEditor({
   markMode = 'focus',
   spellCheck = true,
   bulletAfterHeading = false,
+  blockHandle = false,
   resolveImageUrl,
   resolveImageOpenPath,
   openImage,
@@ -226,6 +234,7 @@ export function NoteEditor({
         initialMarkdown={initialContent}
         spellCheck={spellCheck}
         bulletAfterHeading={bulletAfterHeading}
+        blockHandle={blockHandle}
         editorClassName={cn('reflect-editor', className)}
         {...(titlePlaceholder !== undefined ? { placeholder: titlePlaceholder } : {})}
         onDocChange={handleDocChange}

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -271,17 +271,6 @@ body {
   font-size: inherit;
 }
 
-/* meowdown 0.8.1 ships a per-block gutter handle (a grip for drag-reordering and
-   a "+" add button). Reflect doesn't use block reordering — and the grip showed
-   up beside the Tasks inline editor — so hide the whole gutter. Matched by the
-   stable `meow_<Name>_` class prefix so a meowdown hash bump doesn't revive it.
-   (The positioner is a portal, so this is global, not scoped to one editor.) */
-[class*='meow_Add_'],
-[class*='meow_Draggable_'],
-[class*='meow_DropIndicator_'] {
-  display: none !important;
-}
-
 /* The daily stream's horizontal gutter (STREAM_GUTTER in daily-stream.tsx),
    shared by each row's day label, pane chrome, and the editor itself so they
    align. Un-layered so it beats the un-layered `padding: 0` reset above by


### PR DESCRIPTION
Enable meowdown's per-block gutter handle (drag-to-reorder grip and `+` insert) in the main note editor via a new `blockHandle` prop on `NoteEditor`, keep it off for the one-line inline task editor, and drop the global CSS that previously hid the gutter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Block handles are now visible in the note editor, enabling drag-to-reorder functionality for text blocks.
  * Block handles remain hidden in the task editor to maintain a clean, single-line interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->