### PR TITLE
Scroll focused task rows into view

### DIFF
--- a/apps/desktop/src/components/tasks/tasks-screen.test.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.test.tsx
@@ -8,8 +8,9 @@ import { resetRecentlyCompleted } from '@/lib/tasks/recently-completed'
 import { RouterProvider, useRouter } from '@/routing/router'
 import { TasksScreen } from './tasks-screen'
 
-// jsdom doesn't implement scrollIntoView; the keyboard nav scrolls the active row.
-Element.prototype.scrollIntoView ??= () => {}
+// jsdom doesn't implement scrollIntoView; the Tasks view scrolls the focused row.
+const scrollIntoView = vi.fn()
+Element.prototype.scrollIntoView = scrollIntoView
 
 const getOpenTasks = vi.hoisted(() => vi.fn())
 const getCompletedTasks = vi.hoisted(() => vi.fn())
@@ -190,6 +191,7 @@ beforeEach(() => {
   startOperation.mockClear()
   fail.mockReset()
   resetRecentlyCompleted()
+  scrollIntoView.mockClear()
 })
 
 describe('TasksScreen', () => {
@@ -309,6 +311,23 @@ describe('TasksScreen', () => {
     await userEvent.keyboard('{Escape}')
     expect(view.queryByTestId('task-editor')).toBeNull()
     expect(view.getByRole('button', { name: 'first' }).getAttribute('aria-pressed')).toBe('false')
+    view.unmount()
+  })
+
+  it('scrolls the focused task row into view after selection renders', async () => {
+    getOpenTasks.mockResolvedValue([
+      task({ notePath: 'notes/p.md', markerOffset: 2, text: 'first', noteTitle: 'Project' }),
+      task({ notePath: 'notes/p.md', markerOffset: 3, text: 'second', noteTitle: 'Project' }),
+    ])
+    const view = renderScreen()
+
+    await userEvent.click(await view.findByRole('button', { name: 'second' }))
+    const row = view.container.querySelector('[data-task-key="notes/p.md:3"]')
+
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' })
+      expect(scrollIntoView.mock.contexts).toContain(row)
+    })
     view.unmount()
   })
 

--- a/apps/desktop/src/components/tasks/tasks-screen.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+} from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Archive, CalendarClock, List, Search } from 'lucide-react'
 import {
@@ -43,6 +51,19 @@ function visibleGroups(groups: TaskGroup[], filters: TaskFilters): TaskGroup[] {
         return group.tasks[0]?.isPinned ? filters.pinned : filters.other
     }
   })
+}
+
+/** The selected task that owns keyboard focus: the cursor/anchor, else the first row left selected. */
+function focusedSelectedKey(
+  selectedTaskKeys: ReadonlySet<string>,
+  activeTaskKey: () => string | null,
+): string | null {
+  const activeKey = activeTaskKey()
+  if (activeKey !== null && selectedTaskKeys.has(activeKey)) {
+    return activeKey
+  }
+  const first = selectedTaskKeys.values().next()
+  return first.done ? null : first.value
 }
 
 /**
@@ -149,6 +170,14 @@ export function TasksScreen(): ReactElement {
     }
   }, [])
   const editHandlers = useTaskRowHandlers({ selection, actions, orderedTasks, today, scrollToKey })
+  const selectedTaskKeys = selection.selected
+  const activeTaskKey = selection.activeKey
+  // Selection opens the focused task's inline editor, often after an async insert
+  // and optimistic cache render. Scroll after the DOM reflects that selection so
+  // the focused row is always visible.
+  useLayoutEffect(() => {
+    scrollToKey(focusedSelectedKey(selectedTaskKeys, activeTaskKey))
+  }, [activeTaskKey, orderedKeys, scrollToKey, selectedTaskKeys])
   // The group headers' "+ Add" (V1): drop any search filter so the new row is
   // visible, write it, then select it so its editor opens focused.
   const onAdd = useCallback(


### PR DESCRIPTION
## Summary
- scroll the active selected task row after the Tasks screen has rendered the focused selection
- cover the behavior with a Tasks screen regression test

## Testing
- pnpm --filter @reflect/desktop test src/components/tasks/tasks-screen.test.tsx
- pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only scroll behavior on the Tasks screen with no auth, data, or persistence changes.
> 
> **Overview**
> The Tasks screen now **scrolls the focused selected row into view** after the list has painted that selection, so keyboard moves, clicks, and async inserts (e.g. optimistic new rows) don’t leave the inline editor off-screen.
> 
> A `useLayoutEffect` runs `scrollTaskIntoView` for the **keyboard-active** selected key when present, otherwise the first selected key, whenever selection or ordered task keys change. Existing immediate `scrollToKey` calls (e.g. after insert) stay in place.
> 
> Tests stub `scrollIntoView` with a spy and assert `{ block: 'nearest' }` is invoked on the correct row after selecting a task.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5a91fcdd9618f7380485e7bb8923b21fa3147f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task selection behavior to automatically scroll the focused task row into view when selections change.

* **Tests**
  * Added test coverage for task scrolling functionality with mocked `scrollIntoView` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->