### PR TITLE
Soften sidebar graph name color

### DIFF
--- a/apps/desktop/src/components/sidebar/graph-footer.tsx
+++ b/apps/desktop/src/components/sidebar/graph-footer.tsx
@@ -164,7 +164,7 @@ export function GraphFooter({ graph, context }: GraphFooterProps): ReactElement 
             className={MENU_ITEM_CLASS}
           >
             <LocateFixed aria-hidden strokeWidth={1.75} className="size-3.5 shrink-0" />
-            <span className="min-w-0 flex-1 truncate">Open graph in Finder</span>
+            <span className="min-w-0 flex-1 truncate">Reveal graph in Finder</span>
           </DropdownMenuItem>
           <DropdownMenuItem
             onSelect={() => void pickAndOpen()}

--- a/apps/desktop/src/components/sidebar/graph-footer.tsx
+++ b/apps/desktop/src/components/sidebar/graph-footer.tsx
@@ -84,7 +84,7 @@ export function GraphFooter({ graph, context }: GraphFooterProps): ReactElement 
                   color={colorFor(graph.root)}
                   className={cn('h-5 w-5', indexing && 'motion-safe:animate-pulse')}
                 />
-                <span className="min-w-0 truncate text-xs font-medium text-text">
+                <span className="min-w-0 truncate text-xs font-medium text-text-secondary">
                   {graph.name}
                 </span>
                 {dot !== null ? (


### PR DESCRIPTION
## Summary
- Use the secondary text token for the sidebar footer graph name so it reads less dark.

## Testing
- pnpm check

## Notes
- pnpm check passed with existing warnings only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic class change and menu label copy only; no logic, auth, or data paths touched.
> 
> **Overview**
> **Sidebar graph footer** styling and copy tweaks only.
> 
> The active graph name next to the swatch now uses **`text-text-secondary`** instead of **`text-text`**, so the label reads lighter and less prominent in the footer.
> 
> The graph dropdown renames **“Open graph in Finder”** to **“Reveal graph in Finder”**, matching the underlying `revealItemInDir` behavior and typical macOS wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c507d4db48db8a7c3d9e6078fd2b125525fc07f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted graph name text styling for improved visual hierarchy.

* **Chores**
  * Updated menu item label from "Open graph in Finder" to "Reveal graph in Finder" for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->