### PR TITLE
Match v1 task row focus styling

### DIFF
--- a/apps/desktop/src/components/tasks/task-group-section.tsx
+++ b/apps/desktop/src/components/tasks/task-group-section.tsx
@@ -101,7 +101,7 @@ export function TaskGroupSection({
           </button>
         ) : null}
       </div>
-      <ul className="px-4 py-1 lg:px-12">
+      <ul className="flex flex-col gap-1.5 px-4 py-1 lg:px-12">
         {group.tasks.length === 0 ? (
           <li className="px-2 py-1.5 text-sm text-text-muted">No tasks</li>
         ) : (

--- a/apps/desktop/src/components/tasks/task-row.tsx
+++ b/apps/desktop/src/components/tasks/task-row.tsx
@@ -78,8 +78,10 @@ export function TaskRow({
     <li
       data-task-key={taskKey(task)}
       className={cn(
-        'group/task flex items-start gap-3 rounded-md px-2 py-1.5',
-        selected ? 'bg-surface-hover ring-1 ring-inset ring-accent' : 'hover:bg-surface-hover',
+        'group/task flex min-h-10 items-start gap-3 rounded-md bg-surface px-2 py-2 shadow-sm',
+        selected
+          ? 'ring-2 ring-inset ring-purple-400'
+          : 'hover:bg-surface-hover dark:bg-surface dark:hover:bg-surface-hover',
       )}
     >
       <button


### PR DESCRIPTION
## Summary
- Port V1 task row selection styling: white task surface, subtle shadow, 40px row height, and inset purple focus ring
- Add V1-style vertical spacing between task rows in the Tasks view

## Testing
- pnpm check
- pnpm build

Notes: both commands pass. Existing lint warnings remain unrelated (max-lines, TanStack Virtual/React Compiler, React Hook Form watch), and build still reports the existing large chunk / turbo output warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only Tailwind class changes in the Tasks UI with no logic, data, or API impact.
> 
> **Overview**
> Updates Tasks view row chrome to match v1: each row gets a **surface background**, **subtle shadow**, **~40px min height** (`min-h-10`), and **inset purple focus ring** (`ring-2 ring-purple-400`) when selected instead of the previous accent ring and flat hover-only styling.
> 
> Task lists in `TaskGroupSection` now use **vertical gap** between rows (`flex flex-col gap-1.5`) for v1-style spacing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46584dd0ab9c9d08ac36f828433c029c573a7904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Task items have been updated with refined styling, improved spacing, and enhanced visual treatment for better hierarchy and clarity.
  * Task list layout has been optimized with improved spacing and organization, providing a more cohesive and visually consistent interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->