### PR TITLE
Use Hide/Show markdown syntax setting

### DIFF
--- a/apps/desktop/src/components/all-notes/all-notes-screen.test.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.test.tsx
@@ -23,7 +23,7 @@ vi.mock('@/providers/graph-provider', () => ({
 vi.mock('@/providers/settings-provider', () => ({
   useSettings: () => ({
     settings: {
-      editorMarkdownSyntax: 'focus',
+      editorMarkdownSyntax: 'hide',
       theme: 'system',
       timeFormat: '12h',
       dateFormat: 'mdy',

--- a/apps/desktop/src/components/daily-stream.test.tsx
+++ b/apps/desktop/src/components/daily-stream.test.tsx
@@ -33,7 +33,7 @@ vi.mock('@/providers/graph-provider', () => ({
 }))
 vi.mock('@/providers/settings-provider', () => ({
   useSettings: () => ({
-    settings: { dateFormat: 'mdy', editorMarkdownSyntax: 'always', editorSpellCheck: true },
+    settings: { dateFormat: 'mdy', editorMarkdownSyntax: 'hide', editorSpellCheck: true },
     updateSettings: async () => {},
   }),
 }))

--- a/apps/desktop/src/components/route-content.test.tsx
+++ b/apps/desktop/src/components/route-content.test.tsx
@@ -71,7 +71,7 @@ vi.mock('@/providers/graph-provider', () => ({
 }))
 vi.mock('@/providers/settings-provider', () => ({
   useSettings: () => ({
-    settings: { editorMarkdownSyntax: 'always', allNotesFilterTags: ['book', 'link', 'person'] },
+    settings: { editorMarkdownSyntax: 'hide', allNotesFilterTags: ['book', 'link', 'person'] },
     updateSettings: async () => {},
   }),
 }))

--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -103,12 +103,12 @@ describe('SettingsScreen', () => {
     stored = { editorMarkdownSyntax: 'show' }
     renderScreen()
     await waitFor(() => expect(radio(/^show/i).checked).toBe(true))
-    expect(radio(/^focus/i).checked).toBe(false)
+    expect(radio(/^hide/i).checked).toBe(false)
   })
 
   it('selecting Show applies instantly and persists', async () => {
     renderScreen()
-    await waitFor(() => expect(radio(/^focus/i).checked).toBe(true))
+    await waitFor(() => expect(radio(/^hide/i).checked).toBe(true))
 
     fireEvent.click(radio(/^show/i))
 
@@ -135,7 +135,7 @@ describe('SettingsScreen', () => {
       ]),
     )
     expect(radio(/^show/i).checked).toBe(true)
-    expect(radio(/^focus/i).checked).toBe(false)
+    expect(radio(/^hide/i).checked).toBe(false)
   })
 
   it('reflects a persisted spell check opt-out', async () => {
@@ -157,7 +157,7 @@ describe('SettingsScreen', () => {
     await waitFor(() =>
       expect(saved).toEqual([
         {
-          editorMarkdownSyntax: 'focus',
+          editorMarkdownSyntax: 'hide',
           editorSpellCheck: false,
           editorDefaultBullet: true,
           editorBulletAfterHeading: true,
@@ -197,7 +197,7 @@ describe('SettingsScreen', () => {
     await waitFor(() =>
       expect(saved).toEqual([
         {
-          editorMarkdownSyntax: 'focus',
+          editorMarkdownSyntax: 'hide',
           editorSpellCheck: true,
           editorDefaultBullet: false,
           editorBulletAfterHeading: true,
@@ -236,7 +236,7 @@ describe('SettingsScreen', () => {
     await waitFor(() =>
       expect(saved).toEqual([
         {
-          editorMarkdownSyntax: 'focus',
+          editorMarkdownSyntax: 'hide',
           editorSpellCheck: true,
           editorDefaultBullet: true,
           editorBulletAfterHeading: false,
@@ -268,7 +268,7 @@ describe('SettingsScreen', () => {
     await waitFor(() =>
       expect(saved).toEqual([
         {
-          editorMarkdownSyntax: 'focus',
+          editorMarkdownSyntax: 'hide',
           editorSpellCheck: true,
           editorDefaultBullet: true,
           editorBulletAfterHeading: true,
@@ -313,7 +313,7 @@ describe('SettingsScreen', () => {
     await waitFor(() =>
       expect(saved).toEqual([
         {
-          editorMarkdownSyntax: 'focus',
+          editorMarkdownSyntax: 'hide',
           editorSpellCheck: true,
           editorDefaultBullet: true,
           editorBulletAfterHeading: true,
@@ -357,7 +357,7 @@ describe('SettingsScreen', () => {
     await waitFor(() =>
       expect(saved).toEqual([
         {
-          editorMarkdownSyntax: 'focus',
+          editorMarkdownSyntax: 'hide',
           editorSpellCheck: true,
           editorDefaultBullet: true,
           editorBulletAfterHeading: true,
@@ -398,7 +398,7 @@ describe('SettingsScreen', () => {
     await waitFor(() =>
       expect(saved).toEqual([
         {
-          editorMarkdownSyntax: 'focus',
+          editorMarkdownSyntax: 'hide',
           editorSpellCheck: true,
           editorDefaultBullet: true,
           editorBulletAfterHeading: true,
@@ -430,7 +430,7 @@ describe('SettingsScreen', () => {
     await waitFor(() =>
       expect(saved).toEqual([
         {
-          editorMarkdownSyntax: 'focus',
+          editorMarkdownSyntax: 'hide',
           editorSpellCheck: true,
           editorDefaultBullet: true,
           editorBulletAfterHeading: true,
@@ -494,7 +494,7 @@ describe('SettingsScreen', () => {
     await waitFor(() =>
       expect(saved).toEqual([
         {
-          editorMarkdownSyntax: 'focus',
+          editorMarkdownSyntax: 'hide',
           editorSpellCheck: true,
           editorDefaultBullet: true,
           editorBulletAfterHeading: true,
@@ -523,7 +523,7 @@ describe('SettingsScreen', () => {
 
     await waitFor(() =>
       expect(saved).toEqual([
-        { editorMarkdownSyntax: 'focus', editorSpellCheck: true, editorDefaultBullet: true, editorBulletAfterHeading: true, semanticSearchEnabled: true, describeAssets: true, mobileOnboarded: false, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], graphColors: {}, aiProviders: [], defaultAiProviderId: null, chatModelSelection: null },
+        { editorMarkdownSyntax: 'hide', editorSpellCheck: true, editorDefaultBullet: true, editorBulletAfterHeading: true, semanticSearchEnabled: true, describeAssets: true, mobileOnboarded: false, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], graphColors: {}, aiProviders: [], defaultAiProviderId: null, chatModelSelection: null },
       ]),
     )
     // The control flips to the loading state (EmbeddingsSync owns the actual
@@ -552,7 +552,7 @@ describe('SettingsScreen', () => {
 
     await waitFor(() =>
       expect(saved).toEqual([
-        { editorMarkdownSyntax: 'focus', editorSpellCheck: true, editorDefaultBullet: true, editorBulletAfterHeading: true, semanticSearchEnabled: false, describeAssets: true, mobileOnboarded: false, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], graphColors: {}, aiProviders: [], defaultAiProviderId: null, chatModelSelection: null },
+        { editorMarkdownSyntax: 'hide', editorSpellCheck: true, editorDefaultBullet: true, editorBulletAfterHeading: true, semanticSearchEnabled: false, describeAssets: true, mobileOnboarded: false, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], graphColors: {}, aiProviders: [], defaultAiProviderId: null, chatModelSelection: null },
       ]),
     )
     expect(screen.getByRole('button', { name: /enable semantic search/i })).toBeTruthy()
@@ -575,7 +575,7 @@ describe('SettingsScreen', () => {
     await waitFor(() => expect(invoked).toContain('embed_ensure'))
     await waitFor(() =>
       expect(saved).toEqual([
-        { editorMarkdownSyntax: 'focus', editorSpellCheck: true, editorDefaultBullet: true, editorBulletAfterHeading: true, semanticSearchEnabled: true, describeAssets: true, mobileOnboarded: false, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], graphColors: {}, aiProviders: [], defaultAiProviderId: null, chatModelSelection: null },
+        { editorMarkdownSyntax: 'hide', editorSpellCheck: true, editorDefaultBullet: true, editorBulletAfterHeading: true, semanticSearchEnabled: true, describeAssets: true, mobileOnboarded: false, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], graphColors: {}, aiProviders: [], defaultAiProviderId: null, chatModelSelection: null },
       ]),
     )
   })
@@ -594,7 +594,7 @@ describe('SettingsScreen', () => {
 
     await waitFor(() =>
       expect(saved).toEqual([
-        { editorMarkdownSyntax: 'focus', editorSpellCheck: true, editorDefaultBullet: true, editorBulletAfterHeading: true, semanticSearchEnabled: false, describeAssets: true, mobileOnboarded: false, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], graphColors: {}, aiProviders: [], defaultAiProviderId: null, chatModelSelection: null },
+        { editorMarkdownSyntax: 'hide', editorSpellCheck: true, editorDefaultBullet: true, editorBulletAfterHeading: true, semanticSearchEnabled: false, describeAssets: true, mobileOnboarded: false, theme: 'system', timeFormat: '12h', dateFormat: 'mdy', weekStartDay: 'monday', allNotesFilterTags: ['book', 'link', 'person'], graphColors: {}, aiProviders: [], defaultAiProviderId: null, chatModelSelection: null },
       ]),
     )
     expect(screen.getByRole('button', { name: /enable semantic search/i })).toBeTruthy()

--- a/apps/desktop/src/components/settings/editor-section.tsx
+++ b/apps/desktop/src/components/settings/editor-section.tsx
@@ -15,9 +15,9 @@ interface MarkdownSyntaxOption {
 
 const MARKDOWN_SYNTAX_OPTIONS: MarkdownSyntaxOption[] = [
   {
-    value: 'focus',
-    label: 'Focus',
-    description: 'Markdown syntax stays hidden and is revealed around your cursor as you edit.',
+    value: 'hide',
+    label: 'Hide',
+    description: 'Markdown syntax characters stay hidden while you edit.',
   },
   {
     value: 'show',

--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -8,6 +8,7 @@ import { NoteEditor } from './note-editor'
 
 /** Props the mocked `<MeowdownEditor>` captures so the test can drive its callbacks. */
 interface CapturedEditorProps {
+  mode?: 'hide' | 'focus' | 'show' | 'source'
   editorClassName?: string
   children?: ReactNode
   resolveImageUrl?: (src: string) => string | undefined
@@ -110,6 +111,18 @@ beforeEach(() => {
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
+})
+
+describe('NoteEditor markdown syntax mode', () => {
+  it('passes hide to meowdown by default', () => {
+    renderEditor()
+    expect(captured.props?.mode).toBe('hide')
+  })
+
+  it('passes an explicit markdown syntax mode to meowdown', () => {
+    render(<NoteEditor initialContent="" markMode="show" />)
+    expect(captured.props?.mode).toBe('show')
+  })
 })
 
 describe('NoteEditor image lightbox', () => {

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -54,7 +54,7 @@ interface NoteEditorProps {
   initialContent: string
   /** Called with the current markdown whenever the user edits the document. */
   onChange?: (markdown: string) => void
-  /** How markdown syntax characters are shown; `focus` reveals them near the caret. */
+  /** How markdown syntax characters are shown. */
   markMode?: MarkMode
   /** Whether the browser underlines misspelled words (default on). */
   spellCheck?: boolean
@@ -114,7 +114,7 @@ interface NoteEditorProps {
 export function NoteEditor({
   initialContent,
   onChange,
-  markMode = 'focus',
+  markMode = 'hide',
   spellCheck = true,
   bulletAfterHeading = false,
   blockHandle = false,

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -64,7 +64,7 @@ vi.mock('@/providers/graph-provider', () => ({
 }))
 vi.mock('@/providers/settings-provider', () => ({
   useSettings: () => ({
-    settings: { editorMarkdownSyntax: 'always', dateFormat: 'mdy', weekStartDay: 'monday' },
+    settings: { editorMarkdownSyntax: 'hide', dateFormat: 'mdy', weekStartDay: 'monday' },
     updateSettings: async () => {},
   }),
 }))

--- a/apps/desktop/src/providers/settings-provider.test.tsx
+++ b/apps/desktop/src/providers/settings-provider.test.tsx
@@ -93,7 +93,7 @@ describe('SettingsProvider', () => {
     stored = { editorMarkdownSyntax: 'show' }
     const { result } = renderHook(() => useSettings(), { wrapper })
     // Defaults are usable before the IPC load settles — no loading gate.
-    expect(result.current.settings.editorMarkdownSyntax).toBe('focus')
+    expect(result.current.settings.editorMarkdownSyntax).toBe('hide')
     await waitFor(() => expect(result.current.settings.editorMarkdownSyntax).toBe('show'))
     // Hydration alone must not write the store back.
     expect(saved).toEqual([])
@@ -103,7 +103,7 @@ describe('SettingsProvider', () => {
     stored = { editorMarkdownSyntax: 'sideways' }
     const { result } = renderHook(() => useSettings(), { wrapper })
     await loadSettled()
-    expect(result.current.settings.editorMarkdownSyntax).toBe('focus')
+    expect(result.current.settings.editorMarkdownSyntax).toBe('hide')
   })
 
   it('an equal-but-rebuilt array value does not trigger a save', async () => {
@@ -128,7 +128,7 @@ describe('SettingsProvider', () => {
     await waitFor(() =>
       expect(saved).toEqual([
         {
-          editorMarkdownSyntax: 'focus',
+          editorMarkdownSyntax: 'hide',
           editorSpellCheck: true,
           editorDefaultBullet: true,
           editorBulletAfterHeading: true,
@@ -174,7 +174,7 @@ describe('SettingsProvider', () => {
   })
 
   it('applies an update instantly and persists the full document', async () => {
-    stored = { editorMarkdownSyntax: 'focus', futureKey: true }
+    stored = { editorMarkdownSyntax: 'hide', futureKey: true }
     const { result } = renderHook(() => useSettings(), { wrapper })
     await loadSettled()
 
@@ -210,7 +210,7 @@ describe('SettingsProvider', () => {
   })
 
   it('an update racing the initial load wins and keeps passthrough keys', async () => {
-    stored = { editorMarkdownSyntax: 'focus', futureKey: true }
+    stored = { editorMarkdownSyntax: 'hide', futureKey: true }
     gateLoad = true
     const { result } = renderHook(() => useSettings(), { wrapper })
 
@@ -261,7 +261,7 @@ describe('SettingsProvider', () => {
 
     act(() => {
       result.current.updateSettings({ editorMarkdownSyntax: 'show' })
-      result.current.updateSettings({ editorMarkdownSyntax: 'focus' })
+      result.current.updateSettings({ editorMarkdownSyntax: 'hide' })
     })
     act(() => {
       releaseLoad()
@@ -269,7 +269,7 @@ describe('SettingsProvider', () => {
     await waitFor(() =>
       expect(saved).toEqual([
         {
-          editorMarkdownSyntax: 'focus',
+          editorMarkdownSyntax: 'hide',
           editorSpellCheck: true,
           editorDefaultBullet: true,
           editorBulletAfterHeading: true,
@@ -288,7 +288,7 @@ describe('SettingsProvider', () => {
         },
       ]),
     )
-    expect(result.current.settings.editorMarkdownSyntax).toBe('focus')
+    expect(result.current.settings.editorMarkdownSyntax).toBe('hide')
   })
 
   it('updateSettingsWith builds each patch from the latest settings, not the closure', async () => {

--- a/apps/desktop/src/routing/app-shortcuts.test.tsx
+++ b/apps/desktop/src/routing/app-shortcuts.test.tsx
@@ -19,7 +19,7 @@ vi.mock('@/providers/theme-provider', () => ({
 }))
 vi.mock('@/providers/settings-provider', () => ({
   useSettings: () => ({
-    settings: { editorMarkdownSyntax: 'focus', semanticSearchEnabled: false, theme: 'system' },
+    settings: { editorMarkdownSyntax: 'hide', semanticSearchEnabled: false, theme: 'system' },
     updateSettings: vi.fn(),
   }),
 }))

--- a/packages/core/src/settings/schema.test.ts
+++ b/packages/core/src/settings/schema.test.ts
@@ -4,7 +4,7 @@ import { DEFAULT_SETTINGS, settingsSchema } from './schema'
 describe('settingsSchema', () => {
   it('defaults every key on an empty document (fresh install)', () => {
     expect(settingsSchema.parse({})).toEqual({
-      editorMarkdownSyntax: 'focus',
+      editorMarkdownSyntax: 'hide',
       editorSpellCheck: true,
       editorDefaultBullet: true,
       editorBulletAfterHeading: true,
@@ -21,7 +21,7 @@ describe('settingsSchema', () => {
       defaultAiProviderId: null,
       chatModelSelection: null,
     })
-    expect(DEFAULT_SETTINGS.editorMarkdownSyntax).toBe('focus')
+    expect(DEFAULT_SETTINGS.editorMarkdownSyntax).toBe('hide')
     expect(DEFAULT_SETTINGS.editorSpellCheck).toBe(true)
     expect(DEFAULT_SETTINGS.editorDefaultBullet).toBe(true)
     expect(DEFAULT_SETTINGS.editorBulletAfterHeading).toBe(true)
@@ -41,7 +41,7 @@ describe('settingsSchema', () => {
 
   it('accepts valid values', () => {
     expect(settingsSchema.parse({ editorMarkdownSyntax: 'show' }).editorMarkdownSyntax).toBe('show')
-    expect(settingsSchema.parse({ editorMarkdownSyntax: 'focus' }).editorMarkdownSyntax).toBe('focus')
+    expect(settingsSchema.parse({ editorMarkdownSyntax: 'hide' }).editorMarkdownSyntax).toBe('hide')
     expect(settingsSchema.parse({ editorSpellCheck: false }).editorSpellCheck).toBe(false)
     expect(settingsSchema.parse({ editorSpellCheck: true }).editorSpellCheck).toBe(true)
     expect(settingsSchema.parse({ editorDefaultBullet: false }).editorDefaultBullet).toBe(false)
@@ -72,8 +72,8 @@ describe('settingsSchema', () => {
   })
 
   it('degrades an invalid value to its default instead of failing the load', () => {
-    expect(settingsSchema.parse({ editorMarkdownSyntax: 'sideways' }).editorMarkdownSyntax).toBe('focus')
-    expect(settingsSchema.parse({ editorMarkdownSyntax: 42 }).editorMarkdownSyntax).toBe('focus')
+    expect(settingsSchema.parse({ editorMarkdownSyntax: 'sideways' }).editorMarkdownSyntax).toBe('hide')
+    expect(settingsSchema.parse({ editorMarkdownSyntax: 42 }).editorMarkdownSyntax).toBe('hide')
     expect(settingsSchema.parse({ editorSpellCheck: 'off' }).editorSpellCheck).toBe(true)
     expect(settingsSchema.parse({ editorSpellCheck: 0 }).editorSpellCheck).toBe(true)
     expect(settingsSchema.parse({ editorDefaultBullet: 'on' }).editorDefaultBullet).toBe(true)

--- a/packages/core/src/settings/schema.ts
+++ b/packages/core/src/settings/schema.ts
@@ -12,14 +12,14 @@ import { z } from 'zod'
  */
 
 /**
- * How the editor renders markdown syntax characters. `focus` (the default)
- * hides them except near the caret; `show` always displays them.
+ * How the editor renders markdown syntax characters. `hide` (the default)
+ * hides them; `show` always displays them.
  *
  * The persisted name is implementation-neutral on purpose — it maps to
  * meowdown's "mark mode" at the editor boundary, but the settings document
  * must outlive any one editor library.
  */
-export const editorMarkdownSyntaxSchema = z.enum(['focus', 'show']).catch('focus')
+export const editorMarkdownSyntaxSchema = z.enum(['hide', 'show']).catch('hide')
 
 export type EditorMarkdownSyntax = z.infer<typeof editorMarkdownSyntaxSchema>
 


### PR DESCRIPTION
## Summary
- change editor markdown syntax settings to persist `hide`/`show`
- default unknown persisted markdown syntax values to `hide`
- pass `hide` through to Meowdown by default and cover the handoff in tests

## Tests
- `pnpm --filter @reflect/core test src/settings/schema.test.ts`
- `pnpm --filter @reflect/desktop test src/components/settings-screen.test.tsx src/providers/settings-provider.test.tsx src/editor/note-editor.test.tsx`
- `pnpm check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default editor UX and maps legacy `focus` to `hide` on load, which may surprise users who relied on caret-reveal behavior; scope is limited to display preferences, not data or auth.
> 
> **Overview**
> Replaces the editor markdown syntax setting **`focus`/`show`** with **`hide`/`show`**, aligned with Meowdown’s mark modes. Fresh installs and unset values default to **`hide`**; **`show`** is unchanged.
> 
> The settings UI renames the former **Focus** option to **Hide** and updates the copy so it describes syntax staying hidden while editing (not caret-based reveal). **`NoteEditor`** now defaults **`markMode`** to **`hide`** and passes the persisted value through to Meowdown; tests assert that default and explicit **`show`**.
> 
> Invalid or legacy persisted values (including old **`focus`**) normalize to **`hide`** on load via the settings schema. Test mocks and expectations are updated across desktop suites to match the new default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1a862f79e01a7eb24e5cb67a4f85cfb79423635. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->