### PR TITLE
fix: make empty tasks focusable

### DIFF
--- a/apps/desktop/src/components/tasks/task-text.tsx
+++ b/apps/desktop/src/components/tasks/task-text.tsx
@@ -18,6 +18,10 @@ export function TaskText({ task }: { task: OpenTask }): ReactElement {
   const { settings } = useSettings()
   const segments = scanInlineSegments(taskContent(task.raw))
 
+  if (segments.length === 0) {
+    return <span className="text-text-muted">Empty task</span>
+  }
+
   return (
     <span>
       {segments.map((segment, index) => {

--- a/apps/desktop/src/components/tasks/tasks-screen.test.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.test.tsx
@@ -335,6 +335,17 @@ describe('TasksScreen', () => {
     view.unmount()
   })
 
+  it('opens the inline editor on an empty task selection', async () => {
+    getOpenTasks.mockResolvedValue([
+      task({ notePath: 'notes/p.md', markerOffset: 2, raw: '[ ]', text: '', noteTitle: 'Project' }),
+    ])
+    const view = renderScreen()
+
+    await userEvent.click(await view.findByRole('button', { name: 'Empty task' }))
+    expect(view.getByTestId('task-editor')).toBeDefined()
+    view.unmount()
+  })
+
   it('scrolls the focused task row into view after selection renders', async () => {
     getOpenTasks.mockResolvedValue([
       task({ notePath: 'notes/p.md', markerOffset: 2, text: 'first', noteTitle: 'Project' }),


### PR DESCRIPTION
## Summary
- Render a muted Empty task placeholder for blank task rows so they have a visible and accessible focus target.
- Add a Tasks screen regression test that selects an empty task and opens the inline editor.

## Testing
- pnpm --filter @reflect/desktop test src/components/tasks/tasks-screen.test.tsx
- pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change in task row display plus a test; no auth, data, or write-path changes.
> 
> **Overview**
> Blank task lines (`[ ]` with no body) no longer render as an empty span in **`TaskText`**. When inline parsing yields no segments, the row shows a muted **Empty task** placeholder so the row has visible text and a reliable focus/selection target.
> 
> A **Tasks screen** regression test selects that row by the **Empty task** label and asserts the inline editor opens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c21838d8e82f300848a640e67fa254e0d5f7c4ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty tasks now display a placeholder "Empty task" label instead of appearing blank, improving visibility.

* **Tests**
  * Added verification that empty task rows can be opened for editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->