### PR TITLE
Render unfocused task rows as markdown

### DIFF
--- a/apps/desktop/src/components/tasks/task-row.tsx
+++ b/apps/desktop/src/components/tasks/task-row.tsx
@@ -1,4 +1,10 @@
-import { useRef, type MouseEvent, type MutableRefObject, type ReactElement } from 'react'
+import {
+  useRef,
+  type KeyboardEvent,
+  type MouseEvent,
+  type MutableRefObject,
+  type ReactElement,
+} from 'react'
 import { ArrowRight, Circle, CircleCheck } from 'lucide-react'
 import type { OpenTask } from '@reflect/core'
 import { formatDayLabel } from '@/lib/dates'
@@ -20,7 +26,7 @@ interface TaskRowProps {
   /** Whether a Tasks-view write is already in flight. */
   taskActionPending: boolean
   /** Select the row, honoring ⌘/Ctrl (toggle) and Shift (range) modifiers. */
-  onSelect: (event: MouseEvent) => void
+  onSelect: (event: Pick<MouseEvent, 'metaKey' | 'ctrlKey' | 'shiftKey'>) => void
   /** Persist an inline edit (content after the marker) and exit edit mode. */
   onEditCommit: (content: string) => void
   /** Enter in the editor: persist this row then add the next task (V1 continuous entry). */
@@ -81,12 +87,32 @@ export function TaskRow({
   const checkboxPending = isPending || taskActionPending
   const done = task.checked
   const label = task.text || 'Empty task'
+  const selectFromKeyboard = (event: KeyboardEvent<HTMLDivElement>): void => {
+    if (event.key !== 'Enter' && event.key !== ' ') {
+      return
+    }
+    event.preventDefault()
+    onSelect({ metaKey: event.metaKey, ctrlKey: event.ctrlKey, shiftKey: event.shiftKey })
+  }
+  const selectFromRow = (event: MouseEvent<HTMLLIElement>): void => {
+    if (editing) {
+      return
+    }
+    // Shift-click selects a range; stop the browser turning that into a text
+    // selection across the rows.
+    if (event.shiftKey) {
+      event.preventDefault()
+    }
+    onSelect(event)
+  }
 
   return (
     <li
       data-task-key={taskKey(task)}
+      onClick={selectFromRow}
       className={cn(
         'group/task flex min-h-10 items-start gap-3 border-b border-border bg-surface px-4 py-2 transition-colors duration-100 lg:px-12',
+        !editing && 'cursor-pointer',
         selected
           ? 'bg-accent-soft ring-1 ring-inset ring-accent/20 dark:ring-accent/10'
           : 'hover:bg-surface-hover dark:bg-surface dark:hover:bg-surface-hover',
@@ -97,7 +123,8 @@ export function TaskRow({
         data-task-row
         aria-label={task.checked ? `Reopen: ${label}` : `Complete: ${label}`}
         disabled={checkboxPending}
-        onClick={() => {
+        onClick={(event) => {
+          event.stopPropagation()
           if (editing) {
             checkboxToggleControllerRef.current?.()
             return
@@ -131,24 +158,18 @@ export function TaskRow({
           convertControllerRef={convertControllerRef}
         />
       ) : (
-        <button
-          type="button"
+        <div
+          role="button"
+          tabIndex={0}
           aria-pressed={selected}
-          onClick={(event) => {
-            // Shift-click selects a range; stop the browser turning that into a
-            // text selection across the rows.
-            if (event.shiftKey) {
-              event.preventDefault()
-            }
-            onSelect(event)
-          }}
+          onKeyDown={selectFromKeyboard}
           className={cn(
             'min-w-0 flex-1 break-words text-left text-sm leading-6 text-text focus-visible:outline-none',
             task.checked && 'text-text-muted line-through',
           )}
         >
           <TaskText task={task} />
-        </button>
+        </div>
       )}
       {showSource && task.dailyDate !== null ? (
         <span className="mt-0.5 shrink-0 whitespace-nowrap text-xs text-text-muted">
@@ -160,7 +181,10 @@ export function TaskRow({
         aria-label={`Open ${task.noteTitle}`}
         // Hidden while editing: keep focus on the editor (Esc first to leave).
         disabled={editing}
-        onClick={() => onOpen(task.notePath)}
+        onClick={(event) => {
+          event.stopPropagation()
+          onOpen(task.notePath)
+        }}
         className={cn(
           'mt-0.5 shrink-0 text-text-muted/60 opacity-0 transition-opacity hover:text-text focus-visible:opacity-100 focus-visible:outline-none',
           !editing && 'group-hover/task:opacity-100',

--- a/apps/desktop/src/components/tasks/task-text.tsx
+++ b/apps/desktop/src/components/tasks/task-text.tsx
@@ -1,47 +1,19 @@
 import type { ReactElement } from 'react'
-import { scanInlineSegments, type OpenTask } from '@reflect/core'
-import { formatShortDate, isIsoDate } from '@/lib/dates'
+import type { OpenTask } from '@reflect/core'
+import { MarkdownPreview } from '@/editor/markdown-preview'
 import { taskContent } from '@/lib/tasks/task-content'
-import { useSettings } from '@/providers/settings-provider'
 
 /**
- * Render a task's inline content (its source line minus the checkbox marker) for
- * the Tasks view. The marker is stripped through the shared parseTaskMarker
- * grammar ({@link taskContent}), and inline structure comes from the shared Lezer
- * grammar via {@link scanInlineSegments} — neither uses a regex — so a
- * `[[YYYY-MM-DD]]` link renders as a blue short date (V1's due chip), other
- * `[[wiki]]` links and markdown/bare-URL links render as blue text, and a
- * `[[link]]`/URL inside a code span stays literal, exactly as the editor and
- * indexer see it.
+ * Render a task's content (its source line minus the checkbox marker) through
+ * Reflect's read-only markdown preview. The focused row swaps this for the
+ * inline editor; unfocused rows should look like rendered markdown, not raw
+ * source text.
  */
 export function TaskText({ task }: { task: OpenTask }): ReactElement {
-  const { settings } = useSettings()
-  const segments = scanInlineSegments(taskContent(task.raw))
-
   return (
-    <span>
-      {segments.map((segment, index) => {
-        if (segment.kind === 'text') {
-          return segment.text
-        }
-        if (segment.kind === 'wikiLink') {
-          const label =
-            segment.alias ||
-            (isIsoDate(segment.target)
-              ? formatShortDate(segment.target, settings.dateFormat)
-              : segment.target)
-          return (
-            <span key={index} className="text-accent">
-              {label}
-            </span>
-          )
-        }
-        return (
-          <span key={index} className="text-accent">
-            {segment.text || segment.href}
-          </span>
-        )
-      })}
-    </span>
+    <MarkdownPreview
+      content={taskContent(task.raw)}
+      className="reflect-task-preview pointer-events-none text-sm leading-6"
+    />
   )
 }

--- a/apps/desktop/src/components/tasks/tasks-screen.test.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.test.tsx
@@ -27,6 +27,27 @@ vi.mock('@/lib/use-today', () => ({ useToday: () => '2026-06-14' }))
 vi.mock('@/providers/settings-provider', () => ({
   useSettings: () => ({ settings: { dateFormat: 'mdy' } }),
 }))
+vi.mock('@/editor/markdown-preview', () => ({
+  MarkdownPreview: ({ content, className }: { content: string; className?: string }) => {
+    const strong = /^(.*)\*\*([^*]+)\*\*(.*)$/u.exec(content)
+    const before = strong?.[1] ?? ''
+    const label = strong?.[2] ?? ''
+    const after = strong?.[3] ?? ''
+    return (
+      <span data-testid="markdown-preview" className={className}>
+        {strong === null ? (
+          content
+        ) : (
+          <>
+            {before}
+            <strong>{label}</strong>
+            {after}
+          </>
+        )}
+      </span>
+    )
+  },
+}))
 
 const toggleTask = vi.hoisted(() => vi.fn())
 const deleteTask = vi.hoisted(() => vi.fn())
@@ -310,6 +331,38 @@ describe('TasksScreen', () => {
     await view.findByText('project task')
     await userEvent.click(view.getByRole('button', { name: 'Open Project' }))
     expect(view.getByTestId('route').textContent).toContain('notes/p.md')
+    view.unmount()
+  })
+
+  it('renders unfocused task content through the markdown preview', async () => {
+    getOpenTasks.mockResolvedValue([
+      task({
+        notePath: 'notes/p.md',
+        raw: '[ ] ship **bold** text',
+        text: 'ship bold text',
+        noteTitle: 'Project',
+      }),
+    ])
+    const view = renderScreen()
+
+    const row = await view.findByRole('button', { name: 'ship bold text' })
+    expect(row.querySelector('strong')?.textContent).toBe('bold')
+    expect(row.textContent).not.toContain('**bold**')
+    view.unmount()
+  })
+
+  it('selects a task when clicking the row outside the text control', async () => {
+    getOpenTasks.mockResolvedValue([
+      task({ notePath: 'notes/p.md', markerOffset: 2, text: 'full row', noteTitle: 'Project' }),
+    ])
+    const view = renderScreen()
+
+    await view.findByRole('button', { name: 'full row' })
+    const row = view.container.querySelector('[data-task-key="notes/p.md:2"]')
+    expect(row).toBeInstanceOf(HTMLElement)
+    await userEvent.click(row as HTMLElement)
+
+    expect(view.getByTestId('task-editor').textContent).toContain('full row')
     view.unmount()
   })
 

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -366,6 +366,37 @@ html:root {
   margin: 0;
 }
 
+/* Unfocused task rows use the read-only markdown preview, but the row still owns
+   selection and checked styling. Keep the preview visually in the same compact
+   line box as the inline editor. */
+.reflect-task-preview {
+  color: inherit;
+  font-size: var(--text-sm, 0.875rem);
+  line-height: 1.5rem;
+}
+.reflect-task-preview p,
+.reflect-task-preview h1,
+.reflect-task-preview h2,
+.reflect-task-preview h3,
+.reflect-task-preview h4,
+.reflect-task-preview h5,
+.reflect-task-preview h6,
+.reflect-task-preview blockquote,
+.reflect-task-preview pre {
+  margin: 0;
+}
+.reflect-task-preview h1,
+.reflect-task-preview h2,
+.reflect-task-preview h3,
+.reflect-task-preview h4,
+.reflect-task-preview h5,
+.reflect-task-preview h6 {
+  color: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  letter-spacing: 0;
+}
+
 .reflect-editor blockquote {
   border-left: 2px solid var(--accent-soft, var(--border));
   color: var(--text-secondary);

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -396,6 +396,12 @@ html:root {
   line-height: inherit;
   letter-spacing: 0;
 }
+.line-through .reflect-task-preview .md-link,
+.line-through .reflect-task-preview .md-wikilink-label,
+.line-through .reflect-task-preview .md-wikilink-source,
+.line-through .reflect-task-preview .reflect-tag-link {
+  text-decoration-line: line-through;
+}
 
 .reflect-editor blockquote {
   border-left: 2px solid var(--accent-soft, var(--border));


### PR DESCRIPTION
## Summary
- render unfocused Tasks rows through the shared read-only markdown preview instead of the bespoke inline scanner
- make the full task row clickable while keeping checkbox and open-arrow actions separate
- add regression coverage for markdown rendering and padded-row selection

## Testing
- pnpm --filter @reflect/desktop test src/components/tasks/tasks-screen.test.tsx
- pnpm check
- pnpm build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tasks UI and selection hit-testing only; no persistence or auth changes. Preview rendering is a behavioral swap that should stay read-only via pointer-events-none on the preview.
> 
> **Overview**
> Unfocused Tasks rows now show task text through the shared **`MarkdownPreview`** instead of the custom **`scanInlineSegments`** path, so bold, links, and other inline markdown match the rest of the app while the focused row still uses the inline editor.
> 
> **Row interaction** is reworked: the whole **`<li>`** selects the task (with pointer cursor when not editing), while the checkbox and “open note” controls **`stopPropagation`** so they keep their own behavior. The text area is a focusable **`role="button"`** with **Enter** / **Space** selection (same ⌘/Ctrl/Shift rules as click). **`onSelect`** only needs modifier keys, so keyboard and mouse share one path.
> 
> **`.reflect-task-preview`** CSS keeps the preview in the same single-line box as the editor and applies **line-through** to preview links when a task is completed. Tests mock **`MarkdownPreview`** and cover rendered markdown plus selection from a click on row padding outside the text control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67e0fbb509e7c430cd930f8ec96fdc54d8f06aca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard support for task selection (Enter/Space) for non-editing rows.

* **Improvements**
  * Updated task text rendering to use the shared markdown preview for more consistent display.
  * Enhanced visual styling for read-only task previews to match row typography and checked-state behavior.

* **Bug Fixes**
  * Prevented row-selection from triggering when interacting with the checkbox or open-note controls.
  * Improved shift-click behavior to avoid unwanted browser text selection.

* **Tests**
  * Added/updated tests for markdown-rendered task content and selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->