### PR TITLE
fix(desktop): prevent transparent table menu background color

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -10,6 +10,9 @@ const host = process.env.TAURI_DEV_HOST
 export default defineConfig(async () => ({
   plugins: [reactWithCompiler(), tailwindcss()],
 
+  // If the target is below Safari 17.5, Lightning CSS downlevels `light-dark()` to a broken polyfill.
+  build: { cssTarget: 'safari17.5' },
+
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSS rendering compatibility for Safari 17.5+

<!-- end of auto-generated comment: release notes by coderabbit.ai -->