### PR TITLE
Fix image lightbox cropping

### DIFF
--- a/apps/desktop/src/editor/image-lightbox.tsx
+++ b/apps/desktop/src/editor/image-lightbox.tsx
@@ -53,14 +53,14 @@ export function ImageLightbox({
       <button
         type="button"
         aria-label="Close image preview"
-        className="flex max-h-full max-w-full cursor-zoom-out items-center justify-center bg-transparent p-0"
+        className="flex h-full w-full cursor-zoom-out items-center justify-center overflow-hidden bg-transparent p-0"
         onClick={onClose}
       >
         <img
           src={image.src}
           alt={image.alt}
           draggable={false}
-          className="max-h-full max-w-full select-none object-contain"
+          className="h-full w-full select-none object-contain"
           style={{ viewTransitionName: image.transitionName }}
         />
       </button>


### PR DESCRIPTION
## Summary
- Make the image lightbox click target fill the available viewport space
- Render expanded images with full-size object containment so tall images are not clipped

## Verification
- pnpm --filter @reflect/desktop test -- apps/desktop/src/editor/note-editor.test.tsx
- pnpm check
- pnpm build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tailwind-only layout tweaks in the image lightbox; no logic, data, or security impact.
> 
> **Overview**
> Fixes **tall images appearing cropped** in the editor image lightbox by changing layout from max-size constraints to filling the dialog content area.
> 
> The zoom-out close **button** now uses `h-full w-full` with `overflow-hidden` instead of `max-h-full max-w-full`, so the click-to-dismiss target covers the full lightbox viewport. The **image** similarly uses `h-full w-full` with `object-contain` so scaling is relative to the available space rather than being limited in a way that clipped vertical content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c4882db2e46d66320a96716c2dd70dcfd44b1e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved image lightbox layout with better full-screen utilization and responsive centering. Enhanced user feedback with zoom-out cursor indication when interacting with the lightbox.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->