### PR TITLE
Add beta updater channel

### DIFF
--- a/apps/desktop/scripts/release-bump.mjs
+++ b/apps/desktop/scripts/release-bump.mjs
@@ -49,6 +49,8 @@ const PREID = 'beta'
 /** Branches a release is normally cut from. */
 const STABLE_BRANCH = 'master'
 const BETA_BRANCH = 'next'
+const STABLE_UPDATER_ENDPOINT = 'https://github.com/team-reflect/reflect-open/releases/latest/download/latest.json'
+const BETA_UPDATER_ENDPOINT = 'https://github.com/team-reflect/reflect-open/releases/download/updater-beta/latest.json'
 
 /** Named bump levels; anything else on the command line is an explicit version. */
 const LEVELS = ['beta', 'stable', 'patch', 'minor', 'major', 'prepatch', 'preminor', 'premajor']
@@ -127,6 +129,11 @@ export function computeNextVersion(current, bump) {
   }
 }
 
+/** The updater feed this version should poll once shipped. */
+export function updaterEndpointForVersion(version) {
+  return parseVersion(version).prerelease ? BETA_UPDATER_ENDPOINT : STABLE_UPDATER_ENDPOINT
+}
+
 // ---------------------------------------------------------------------------
 // Git + filesystem side effects.
 // ---------------------------------------------------------------------------
@@ -188,6 +195,12 @@ function replaceOnce(path, find, replace, label) {
 /** Edit all three version sites to `next` (from `current`). */
 function writeVersion(current, next) {
   replaceOnce(tauriConfPath, `"version": "${current}"`, `"version": "${next}"`, 'tauri.conf.json')
+  replaceOnce(
+    tauriConfPath,
+    `"${updaterEndpointForVersion(current)}"`,
+    `"${updaterEndpointForVersion(next)}"`,
+    'tauri.conf.json updater endpoint',
+  )
   replaceOnce(cargoTomlPath, `version = "${current}"`, `version = "${next}"`, 'Cargo.toml')
   // cargo rewrites the lockfile's reflect-open entry from the new Cargo.toml.
   // --offline keeps it a pure version edit with no registry round-trip.
@@ -423,6 +436,7 @@ async function main() {
   log('plan:')
   if (!direct) console.log(`  - create ${releaseBranch} from ${branch}`)
   console.log('  - update tauri.conf.json, Cargo.toml, Cargo.lock')
+  console.log(`  - set updater feed to ${isPrerelease ? 'beta' : 'stable'}`)
   console.log(`  - commit "Release ${tag}"`)
   if (direct) {
     console.log(`  - push ${branch} to origin`)

--- a/apps/desktop/scripts/release-bump.test.mjs
+++ b/apps/desktop/scripts/release-bump.test.mjs
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 
-import { computeNextVersion, formatVersion, parseVersion } from './release-bump.mjs'
+import { computeNextVersion, formatVersion, parseVersion, updaterEndpointForVersion } from './release-bump.mjs'
 
 test('parseVersion splits a stable and a prerelease version', () => {
   expect(parseVersion('0.2.0')).toEqual({ major: 0, minor: 2, patch: 0, prerelease: null })
@@ -58,4 +58,13 @@ test('an explicit garbage version is rejected', () => {
 
 test('beta on a non-beta prerelease is rejected', () => {
   expect(() => computeNextVersion('0.2.0-rc.1', 'beta')).toThrow(/beta\.N/)
+})
+
+test('updater endpoint follows the release channel', () => {
+  expect(updaterEndpointForVersion('0.2.0')).toBe(
+    'https://github.com/team-reflect/reflect-open/releases/latest/download/latest.json',
+  )
+  expect(updaterEndpointForVersion('0.3.0-beta.1')).toBe(
+    'https://github.com/team-reflect/reflect-open/releases/download/updater-beta/latest.json',
+  )
 })

--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -28,6 +28,9 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 const KEYCHAIN_SERVICE = 'reflect-notary'
 const UPDATER_KEYCHAIN_SERVICE = 'reflect-updater'
 const APP_SPECIFIC_PASSWORD_URL = 'https://account.apple.com'
+const BETA_UPDATER_FEED_TAG = 'updater-beta'
+const STABLE_UPDATER_ENDPOINT = 'https://github.com/team-reflect/reflect-open/releases/latest/download/latest.json'
+const BETA_UPDATER_ENDPOINT = `https://github.com/team-reflect/reflect-open/releases/download/${BETA_UPDATER_FEED_TAG}/latest.json`
 
 const here = dirname(fileURLToPath(import.meta.url))
 const appDir = join(here, '..')
@@ -217,6 +220,23 @@ function writeUpdaterManifest({ version, tag }) {
   const manifestPath = join(dirname(updaterArchive), 'latest.json')
   writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
   return manifestPath
+}
+
+function updaterEndpointForVersion(version) {
+  return version.includes('-') ? BETA_UPDATER_ENDPOINT : STABLE_UPDATER_ENDPOINT
+}
+
+function ensureUpdaterEndpointMatchesVersion({ version }) {
+  const endpoint = readTauriConf().plugins?.updater?.endpoints?.[0]
+  const expected = updaterEndpointForVersion(version)
+  if (endpoint !== expected) {
+    fail(
+      `tauri.conf.json updater endpoint does not match version ${version}.\n` +
+        `  expected: ${expected}\n` +
+        `  found:    ${endpoint ?? '(missing)'}\n` +
+        '  Run `pnpm release:bump` for the target channel so installed apps poll the right feed.',
+    )
+  }
 }
 
 /**
@@ -457,6 +477,55 @@ export function createReleaseArgs({ assets, commit, draft, prerelease, productNa
   return releaseArgs
 }
 
+/** Build the `gh release create` arguments for the moving beta updater feed. */
+export function createBetaFeedReleaseArgs({ commit, manifestPath }) {
+  return [
+    'release',
+    'create',
+    BETA_UPDATER_FEED_TAG,
+    manifestPath,
+    '--title',
+    'Reflect beta updater feed',
+    '--target',
+    commit,
+    '--prerelease',
+    '--latest=false',
+    '--notes',
+    'Moving updater feed for beta builds. Do not install this release directly.',
+  ]
+}
+
+/** Build the `gh release upload` arguments that replace the beta feed manifest. */
+export function uploadBetaFeedArgs({ manifestPath }) {
+  return ['release', 'upload', BETA_UPDATER_FEED_TAG, manifestPath, '--clobber']
+}
+
+function updateBetaFeed({ commit, manifestPath }) {
+  const existing = run('gh', ['release', 'view', BETA_UPDATER_FEED_TAG])
+  if (existing.status === 0) {
+    log(`updating ${BETA_UPDATER_FEED_TAG} updater feed…`)
+    const upload = spawnSync('gh', uploadBetaFeedArgs({ manifestPath }), {
+      encoding: 'utf8',
+      stdio: ['inherit', 'pipe', 'inherit'],
+    })
+    if (upload.status !== 0) {
+      fail(`updating the beta updater feed failed${upload.stdout ? `\n${upload.stdout.trim()}` : ''}`)
+    }
+    return
+  }
+  if (!/release not found/i.test(existing.output)) {
+    fail(`could not check GitHub for the ${BETA_UPDATER_FEED_TAG} updater feed:\n${existing.output.trim()}`)
+  }
+  log(`creating ${BETA_UPDATER_FEED_TAG} updater feed…`)
+  const create = spawnSync('gh', createBetaFeedReleaseArgs({ commit, manifestPath }), {
+    encoding: 'utf8',
+    stdio: ['inherit', 'pipe', 'inherit'],
+  })
+  if (create.status !== 0) {
+    fail(`creating the beta updater feed failed${create.stdout ? `\n${create.stdout.trim()}` : ''}`)
+  }
+}
+
 /**
  * Build a signed + notarized DMG and upload it to a new GitHub release tagged
  * v<version> (from tauri.conf.json). A version with a prerelease segment
@@ -469,6 +538,7 @@ function publish({ draft }) {
   const commit = ensurePublishableCommit()
   const { productName, version } = readTauriConf()
   const tag = `v${version}`
+  ensureUpdaterEndpointMatchesVersion({ version })
   ensureReleaseIsNew(tag)
   ensureTagMatchesCommit(tag, commit)
 
@@ -492,6 +562,11 @@ function publish({ draft }) {
   const result = spawnSync('gh', releaseArgs, { encoding: 'utf8', stdio: ['inherit', 'pipe', 'inherit'] })
   if (result.status !== 0) fail(`creating the GitHub release failed${result.stdout ? `\n${result.stdout.trim()}` : ''}`)
   log(`${draft ? 'draft release created' : 'release published'}: ${result.stdout.trim()}`)
+  if (prerelease && !draft) {
+    updateBetaFeed({ commit, manifestPath })
+  } else if (prerelease) {
+    log(`draft pre-release created — ${BETA_UPDATER_FEED_TAG} feed not updated`)
+  }
 }
 
 async function setup() {

--- a/apps/desktop/scripts/release-macos.test.mjs
+++ b/apps/desktop/scripts/release-macos.test.mjs
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 
-import { createReleaseArgs } from './release-macos.mjs'
+import { createBetaFeedReleaseArgs, createReleaseArgs, uploadBetaFeedArgs } from './release-macos.mjs'
 
 const baseInput = {
   assets: ['Reflect.dmg', 'Reflect.app.tar.gz', 'Reflect.app.tar.gz.sig', 'latest.json'],
@@ -58,4 +58,31 @@ test('draft publish keeps the draft flag last', () => {
   })
 
   expect(args.at(-1)).toBe('--draft')
+})
+
+test('beta feed release is a non-latest prerelease pointer', () => {
+  expect(createBetaFeedReleaseArgs({ commit: 'abc123', manifestPath: 'latest.json' })).toEqual([
+    'release',
+    'create',
+    'updater-beta',
+    'latest.json',
+    '--title',
+    'Reflect beta updater feed',
+    '--target',
+    'abc123',
+    '--prerelease',
+    '--latest=false',
+    '--notes',
+    'Moving updater feed for beta builds. Do not install this release directly.',
+  ])
+})
+
+test('beta feed upload replaces the moving manifest', () => {
+  expect(uploadBetaFeedArgs({ manifestPath: 'latest.json' })).toEqual([
+    'release',
+    'upload',
+    'updater-beta',
+    'latest.json',
+    '--clobber',
+  ])
 })

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -33,7 +33,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDREQ0RBRkJBN0ZDODdDMzkKUldRNWZNaC91cS9OVFhtTHdrSWVOV3p2cEdhc3RZbmtXM0g0bnpxUnZXVjlQMjZRNXFlWUdPNWMK",
       "endpoints": [
-        "https://github.com/team-reflect/reflect-open/releases/latest/download/latest.json"
+        "https://github.com/team-reflect/reflect-open/releases/download/updater-beta/latest.json"
       ]
     }
   },

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -119,10 +119,12 @@ without tagging, for when you want the version commit but aren't ready to releas
 `pnpm release:macos publish` runs the full build above, then creates a GitHub release
 tagged `v<version>` (the `version` in `apps/desktop/src-tauri/tauri.conf.json`) with the
 notarized DMG, the updater artifacts (`Reflect.app.tar.gz` + `.sig`), and the
-`latest.json` manifest attached, plus auto-generated release notes. Installed apps poll
-`releases/latest/download/latest.json` (the committed `plugins.updater.endpoints` URL),
-so publish requires the updater key and always attaches the manifest — a release without
-it would stop existing installs from seeing any future updates. Beyond the signing
+`latest.json` manifest attached, plus auto-generated release notes. Stable installs poll
+`releases/latest/download/latest.json`; beta installs poll
+`releases/download/updater-beta/latest.json`, a moving feed release that points at the
+newest published beta. Publish requires the updater key and always attaches the
+manifest — a release without it would stop existing installs from seeing any future
+updates. Beyond the signing
 requirements, it needs the [GitHub CLI](https://cli.github.com) authenticated with
 `gh auth login`.
 
@@ -144,12 +146,17 @@ from the GitHub UI.
 Development happens on `next` (the repo default branch); `master` only advances when
 `next` is merged into it for a public release. On `next`, `version` in
 `tauri.conf.json` carries a prerelease suffix (e.g. `0.2.0-beta.1`), and `publish`
-turns that suffix into a GitHub **pre-release** automatically. `releases/latest` — the
-committed updater endpoint — ignores pre-releases, so stable installs never see a
-beta.
+turns that suffix into a GitHub **pre-release** automatically. `releases/latest` ignores
+pre-releases, so stable installs never see a beta.
 
-Beta installs poll that same stable endpoint: they get offered the next stable release
-when it ships, but not newer betas. A dedicated beta updater channel is future work.
+Beta builds use the dedicated `updater-beta` feed instead. Every non-draft beta publish
+uploads the beta's `latest.json` to that fixed release with `--clobber`; the manifest
+still points at the immutable versioned release artifacts for the actual download. Draft
+beta releases do not update the feed.
+
+`pnpm release:bump` keeps the channel endpoint in `tauri.conf.json` in sync with the
+version it writes: prerelease versions poll the beta feed, stable versions poll
+`releases/latest`.
 
 Cutting a beta is the normal release flow on `next`: `pnpm release:bump` (see
 [Cutting a release](#cutting-a-release-pnpm-releasebump) above) bumps the prerelease

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -53,8 +53,9 @@ disk at call time), and it is covered by tests.
 - **API key validation:** adding a provider key sends one `GET /v1/models` to that
   provider to test it. No content.
 - **Update check:** the packaged app fetches a release manifest (`latest.json`) from
-  this repository's GitHub Releases on launch and every six hours, and downloads the
-  update archive when you ask it to install. No user data is sent; payloads are
+  this repository's GitHub Releases on launch and every six hours. Stable builds check
+  the latest stable release; beta builds check the beta feed. The app downloads the
+  update archive only when you ask it to install. No user data is sent; payloads are
   verified against a public key compiled into the app before installing. Offline, the
   check fails silently and the app carries on.
 


### PR DESCRIPTION
## Summary
- point beta builds at a dedicated updater-beta feed instead of GitHub releases/latest
- keep release:bump switching updater endpoints between beta and stable by version
- update beta publish flow to create/update the moving beta manifest release and guard publish against endpoint/channel mismatches
- document stable vs beta updater behavior in release and privacy docs

## Testing
- pnpm --filter @reflect/desktop test --run scripts/release-macos.test.mjs scripts/release-bump.test.mjs
- pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-update channel routing and release publish behavior; mistakes could strand beta users on the wrong feed or skip updates, but stable/latest behavior is unchanged and publish has an endpoint/version guard.
> 
> **Overview**
> Introduces a **separate auto-update feed for beta builds** so prerelease installs can receive newer betas without stable users ever seeing them.
> 
> **`release:bump`** now flips `plugins.updater.endpoints` in `tauri.conf.json` when the version changes channel (prerelease → `updater-beta` URL, stable → `releases/latest`).
> 
> **`release:macos publish`** refuses to ship if the committed endpoint doesn’t match the version, and on non-draft beta publishes it **creates or clobbers** the fixed GitHub release `updater-beta` with the beta `latest.json` (downloads still come from the version-tagged release assets).
> 
> The in-tree beta config and **macOS distribution / privacy** docs are updated to describe stable vs beta polling behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f53916f7bb9bbd0e22bd157e39df121b09fcc82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Beta and stable app versions now use separate update feeds. Beta versions check a dedicated beta feed for updates, while stable versions use the standard feed.

* **Documentation**
  * Updated macOS distribution and privacy documentation to clarify how stable and beta versions check for updates from their respective feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->