### PR TITLE
feat: render incoming backlink snippets as rich text

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,8 +16,8 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@meowdown/core": "0.20.0",
-    "@meowdown/react": "0.20.0",
+    "@meowdown/core": "0.21.0",
+    "@meowdown/react": "0.21.0",
     "@reflect/core": "workspace:*",
     "@reflect/db": "workspace:*",
     "@reflect/design-system": "workspace:*",

--- a/apps/desktop/src/components/backlink-snippet.tsx
+++ b/apps/desktop/src/components/backlink-snippet.tsx
@@ -1,0 +1,40 @@
+import type { ReactElement } from 'react'
+import { MarkdownView } from '@meowdown/react'
+import type { WikilinkClickHandler } from '@meowdown/core'
+import '@meowdown/core/style.css'
+import { openExternalLink } from '@/editor/open-external-link'
+
+interface BacklinkSnippetProps {
+  /** The referencing line's Markdown source. */
+  text: string
+  /** Navigate a clicked `[[wiki link]]` to its target. Pass a stable function. */
+  onWikilinkClick: WikilinkClickHandler
+  /** Resolve `![…](…)` sources to displayable URLs. Pass a stable function. */
+  resolveImageUrl: (src: string) => string | undefined
+}
+
+/**
+ * One referencing line in the incoming-backlinks panel, rendered as rich text
+ * through meowdown's editor-free `MarkdownView`: wiki links become the editor's
+ * clickable chips and inline marks render instead of raw `[[…]]` / `**…**`
+ * source. The `reflect-editor` class shares the editor's chip styling; the
+ * `reflect-backlink-snippet` wrapper keeps it in the panel's compact line box and
+ * clamps a long or block-level line so it never towers.
+ */
+export function BacklinkSnippet({
+  text,
+  onWikilinkClick,
+  resolveImageUrl,
+}: BacklinkSnippetProps): ReactElement {
+  return (
+    <div className="reflect-backlink-snippet line-clamp-2 select-text text-xs text-text">
+      <MarkdownView
+        className="reflect-editor"
+        markdown={text}
+        onWikilinkClick={onWikilinkClick}
+        onLinkClick={openExternalLink}
+        resolveImageUrl={resolveImageUrl}
+      />
+    </div>
+  )
+}

--- a/apps/desktop/src/components/backlink-source-group.tsx
+++ b/apps/desktop/src/components/backlink-source-group.tsx
@@ -1,5 +1,7 @@
 import { useState, type ReactElement } from 'react'
 import { ChevronRight } from 'lucide-react'
+import type { WikilinkClickHandler } from '@meowdown/core'
+import { BacklinkSnippet } from '@/components/backlink-snippet'
 import type { BacklinkSource } from '@/lib/group-backlinks'
 
 interface BacklinkSourceGroupProps {
@@ -13,6 +15,10 @@ interface BacklinkSourceGroupProps {
   expanded: boolean
   /** Open the source note (the panel wires this to the router). */
   onOpen: (path: string) => void
+  /** Navigate a clicked `[[wiki link]]` inside a snippet to its target. */
+  onWikilinkClick: WikilinkClickHandler
+  /** Resolve `![…](…)` sources inside a snippet to displayable URLs. */
+  resolveImageUrl: (src: string) => string | undefined
 }
 
 /**
@@ -30,6 +36,8 @@ export function BacklinkSourceGroup({
   first,
   expanded: expandedOverride,
   onOpen,
+  onWikilinkClick,
+  resolveImageUrl,
 }: BacklinkSourceGroupProps): ReactElement {
   const [expanded, setExpanded] = useState(expandedOverride)
 
@@ -79,9 +87,12 @@ export function BacklinkSourceGroup({
       {expanded ? (
         <div className="mt-1 space-y-1">
           {source.snippets.map((snippet) => (
-            <p key={snippet.key} className="select-text text-xs text-text">
-              {snippet.text}
-            </p>
+            <BacklinkSnippet
+              key={snippet.key}
+              text={snippet.text}
+              onWikilinkClick={onWikilinkClick}
+              resolveImageUrl={resolveImageUrl}
+            />
           ))}
         </div>
       ) : null}

--- a/apps/desktop/src/components/backlinks-panel.test.tsx
+++ b/apps/desktop/src/components/backlinks-panel.test.tsx
@@ -7,10 +7,12 @@ import { RouterProvider, useRouter } from '@/routing/router'
 import { BacklinksPanel } from './backlinks-panel'
 
 const getBacklinksWithContext = vi.hoisted(() => vi.fn())
+const resolveWikiTarget = vi.hoisted(() => vi.fn())
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   hasBridge: () => true,
   getBacklinksWithContext,
+  resolveWikiTarget,
 }))
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({ graph: { root: '/g', name: 'g', cloudSync: false, generation: 1 } }),
@@ -36,6 +38,7 @@ function renderPanel(path: string) {
 beforeEach(() => {
   window.sessionStorage.clear()
   getBacklinksWithContext.mockReset()
+  resolveWikiTarget.mockReset()
 })
 
 describe('BacklinksPanel', () => {
@@ -69,6 +72,30 @@ describe('BacklinksPanel', () => {
     view.unmount()
   })
 
+  it('renders a snippet wiki link as a clickable chip that navigates to its target', async () => {
+    getBacklinksWithContext.mockResolvedValue([
+      {
+        sourcePath: 'notes/meeting.md',
+        sourceTitle: 'Meeting Notes',
+        snippet: 'discussed [[Roadmap]] follow-ups',
+        posFrom: 12,
+      },
+    ])
+    resolveWikiTarget.mockResolvedValue({ kind: 'resolved', ref: 'notes/roadmap.md' })
+    const view = renderPanel('notes/source.md')
+
+    // The [[Roadmap]] source renders as a chip whose label is the bare target,
+    // not the raw bracket syntax.
+    const chip = await view.findByTestId('wikilink')
+    expect(chip.textContent).toBe('Roadmap')
+
+    await userEvent.click(chip)
+    await waitFor(() =>
+      expect(view.getByTestId('route').textContent).toContain('notes/roadmap.md'),
+    )
+    view.unmount()
+  })
+
   it('groups references by source note and navigates on title click', async () => {
     getBacklinksWithContext.mockResolvedValue([
       {
@@ -94,9 +121,12 @@ describe('BacklinksPanel', () => {
 
     await view.findByText('Incoming backlinks (3)')
     expect(view.getAllByText('Meeting Notes')).toHaveLength(1)
-    expect(view.getByText('discussed [[Roadmap]] follow-ups')).toBeDefined()
-    expect(view.getByText('revisit [[Roadmap]] next week')).toBeDefined()
-    expect(view.getByText('ship the [[Roadmap]]')).toBeDefined()
+    // Snippets render as rich text: the leading prose survives, the [[…]] source
+    // becomes a chip whose label shows the bare target.
+    expect(view.getByText(/discussed/)).toBeDefined()
+    expect(view.getByText(/revisit/)).toBeDefined()
+    expect(view.getByText(/ship the/)).toBeDefined()
+    expect(view.getAllByTestId('wikilink')).toHaveLength(3)
 
     await userEvent.click(view.getByText('Meeting Notes'))
     expect(view.getByTestId('route').textContent).toContain('notes/meeting.md')
@@ -120,7 +150,7 @@ describe('BacklinksPanel', () => {
     await userEvent.click(header)
     expect(header.getAttribute('aria-expanded')).toBe('false')
     expect(view.getByText('Meeting Notes')).toBeDefined()
-    expect(view.queryByText('discussed [[Roadmap]] follow-ups')).toBeNull()
+    expect(view.queryByText(/discussed/)).toBeNull()
     view.unmount()
 
     const reopened = renderPanel('notes/roadmap.md')
@@ -150,14 +180,14 @@ describe('BacklinksPanel', () => {
     )
     const view = render(panelFor('notes/a.md'))
 
-    await view.findByText('links [[A]] and [[B]]')
+    await view.findByText(/links and/)
     await userEvent.click(
       view.getByRole('button', { name: 'Collapse references from Shared Source' }),
     )
-    expect(view.queryByText('links [[A]] and [[B]]')).toBeNull()
+    expect(view.queryByText(/links and/)).toBeNull()
 
     view.rerender(panelFor('notes/b.md'))
-    await view.findByText('links [[A]] and [[B]]')
+    await view.findByText(/links and/)
     view.unmount()
   })
 
@@ -188,7 +218,7 @@ describe('BacklinksPanel', () => {
     await userEvent.click(headers[0]!)
     expect(headers[0]!.getAttribute('aria-expanded')).toBe('false')
     expect(headers[1]!.getAttribute('aria-expanded')).toBe('false')
-    expect(view.queryByText('discussed [[Roadmap]] follow-ups')).toBeNull()
+    expect(view.queryByText(/discussed/)).toBeNull()
     view.unmount()
   })
 
@@ -211,17 +241,17 @@ describe('BacklinksPanel', () => {
 
     const header = await view.findByRole('button', { name: /Incoming backlinks \(2\)/ })
     await userEvent.click(header)
-    expect(view.queryByText('discussed [[Roadmap]] follow-ups')).toBeNull()
-    expect(view.queryByText('ship the [[Roadmap]]')).toBeNull()
+    expect(view.queryByText(/discussed/)).toBeNull()
+    expect(view.queryByText(/ship the/)).toBeNull()
 
     await userEvent.click(
       view.getByRole('button', { name: 'Expand references from Meeting Notes' }),
     )
-    expect(view.getByText('discussed [[Roadmap]] follow-ups')).toBeDefined()
-    expect(view.queryByText('ship the [[Roadmap]]')).toBeNull()
+    expect(view.getByText(/discussed/)).toBeDefined()
+    expect(view.queryByText(/ship the/)).toBeNull()
 
     await userEvent.click(header)
-    expect(view.getByText('ship the [[Roadmap]]')).toBeDefined()
+    expect(view.getByText(/ship the/)).toBeDefined()
     view.unmount()
   })
 
@@ -246,8 +276,8 @@ describe('BacklinksPanel', () => {
     await userEvent.click(
       view.getByRole('button', { name: 'Collapse references from Meeting Notes' }),
     )
-    expect(view.queryByText('discussed [[Roadmap]] follow-ups')).toBeNull()
-    expect(view.getByText('ship the [[Roadmap]]')).toBeDefined()
+    expect(view.queryByText(/discussed/)).toBeNull()
+    expect(view.getByText(/ship the/)).toBeDefined()
     view.unmount()
   })
 })

--- a/apps/desktop/src/components/backlinks-panel.tsx
+++ b/apps/desktop/src/components/backlinks-panel.tsx
@@ -1,8 +1,11 @@
 import { useCallback, useMemo, type ReactElement } from 'react'
 import { ChevronRight } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
+import type { WikilinkClickHandler } from '@meowdown/core'
 import { getBacklinksWithContext, hasBridge } from '@reflect/core'
 import { BacklinkSourceGroup } from '@/components/backlink-source-group'
+import { useImagePersistence } from '@/editor/use-image-persistence'
+import { useWikiLinkNavigation } from '@/editor/use-wiki-link-navigation'
 import { groupBacklinksBySource } from '@/lib/group-backlinks'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useSessionFlag } from '@/lib/use-session-flag'
@@ -47,6 +50,21 @@ export function BacklinksPanel({ path }: BacklinksPanelProps): ReactElement | nu
   const [expanded, setExpanded] = useSessionFlag(EXPANDED_STORAGE_KEY, true)
   const groups = useMemo(() => (data ? groupBacklinksBySource(data) : []), [data])
   const handleOpen = useCallback((target: string) => navigate(routeForPath(target)), [navigate])
+
+  // A wiki link clicked *inside* a snippet resolves its target the same way the
+  // editor does, distinct from `handleOpen` which opens an already-resolved
+  // source-note path. Images resolve through the same asset pipeline as the
+  // editor; both callbacks are stable so they never rebuild the snippet trees.
+  const navigateWikiLink = useWikiLinkNavigation(graph?.generation ?? null)
+  const { resolveImageUrl } = useImagePersistence(graph?.root ?? null, graph?.generation ?? null)
+  const handleWikilinkClick = useCallback<WikilinkClickHandler>(
+    ({ target }) => navigateWikiLink(target),
+    [navigateWikiLink],
+  )
+  const resolveImageUrlStable = useCallback(
+    (src: string) => resolveImageUrl(src) ?? undefined,
+    [resolveImageUrl],
+  )
 
   if (isError) {
     return (
@@ -103,6 +121,8 @@ export function BacklinksPanel({ path }: BacklinksPanelProps): ReactElement | nu
             first={index === 0}
             expanded={expanded}
             onOpen={handleOpen}
+            onWikilinkClick={handleWikilinkClick}
+            resolveImageUrl={resolveImageUrlStable}
           />
         ))}
       </div>

--- a/apps/desktop/src/editor/markdown-preview.tsx
+++ b/apps/desktop/src/editor/markdown-preview.tsx
@@ -1,19 +1,19 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactElement } from 'react'
-import { MeowdownEditor, type EditorHandle } from '@meowdown/react'
+import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react'
+import { MarkdownView } from '@meowdown/react'
 import '@meowdown/core/style.css'
 import '@meowdown/react/style.css'
+import { openExternalLink } from '@/editor/open-external-link'
 import { cn } from '@/lib/utils'
 
 /**
- * A read-only rendering of note markdown via @meowdown/react's
- * `<MeowdownEditor>` in `hide` mark mode, so previews look exactly like the
- * note would in the editor — wiki-link chips, images, and headings included.
- * The view is never editable, so this can render any note (protected ones
- * included) without ever writing.
+ * A read-only rendering of note markdown via @meowdown/react's `<MarkdownView>`
+ * in `hide` mark mode, so previews look exactly like the note would in the
+ * editor (wiki-link chips, images, and headings included) but without mounting a
+ * ProseMirror editor. The view is never editable, so this can render any note
+ * (protected ones included) without ever writing.
  *
- * Unlike the uncontrolled note editor, `content` is **live**: the document is
- * replaced whenever it changes (silently, via the handle), so one mounted
- * preview can follow a moving selection (the ⌘K palette's preview pane).
+ * `content` is live: changing it re-renders the preview, so one mounted preview
+ * can follow a moving selection (the palette's preview pane).
  */
 
 interface MarkdownPreviewProps {
@@ -36,10 +36,9 @@ export function MarkdownPreview({
   onWikiLinkClick,
   className,
 }: MarkdownPreviewProps): ReactElement {
-  const handleRef = useRef<EditorHandle>(null)
-
   // The resolver and click handler are read through refs so a changing prop
-  // never rebuilds the editor's extensions.
+  // never gives MarkdownView a new callback identity (which would re-render its
+  // whole tree).
   const resolveRef = useRef(resolveImageUrl)
   const navigateRef = useRef(onWikiLinkClick)
   useEffect(() => {
@@ -47,10 +46,10 @@ export function MarkdownPreview({
     navigateRef.current = onWikiLinkClick
   })
 
-  // Whether wiki links navigate at all is fixed by the first render — hosts
+  // Whether wiki links navigate at all is fixed by the first render: hosts
   // either always pass the handler (chat) or never do (palette preview). An
-  // inert preview must not register a click handler, which would swallow chip
-  // clicks.
+  // inert preview omits the handler so a chip click is a no-op rather than a
+  // dead navigation.
   const [navigates] = useState(() => onWikiLinkClick != null)
 
   const resolveImageUrlStable = useCallback(
@@ -62,21 +61,14 @@ export function MarkdownPreview({
     [],
   )
 
-  // `content` is live; replace the document whenever it changes. `setMarkdown`
-  // is silent and applies to the read-only editor.
-  useLayoutEffect(() => {
-    handleRef.current?.setMarkdown(content)
-  }, [content])
-
   return (
-    <MeowdownEditor
-      handleRef={handleRef}
-      mode="hide"
-      readOnly
-      initialMarkdown={content}
+    <MarkdownView
+      markdown={content}
+      markMode="hide"
       resolveImageUrl={resolveImageUrlStable}
+      onLinkClick={openExternalLink}
       {...(navigates ? { onWikilinkClick: onWikilinkClickStable } : {})}
-      editorClassName={cn('reflect-editor', className)}
+      className={cn('reflect-editor', className)}
     />
   )
 }

--- a/apps/desktop/src/editor/open-external-link.ts
+++ b/apps/desktop/src/editor/open-external-link.ts
@@ -1,0 +1,14 @@
+import type { LinkClickHandler } from '@meowdown/core'
+import { openUrl } from '@tauri-apps/plugin-opener'
+
+/**
+ * Open a rendered Markdown link in the OS browser instead of letting the click
+ * navigate the app's WebView frame. The static `MarkdownView` surfaces aren't
+ * contenteditable, so an `<a href>` click would otherwise unload the whole app.
+ */
+export const openExternalLink: LinkClickHandler = ({ href, event }) => {
+  event.preventDefault()
+  if (/^https?:\/\//i.test(href)) {
+    void openUrl(href)
+  }
+}

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -403,6 +403,23 @@ html:root {
   text-decoration-line: line-through;
 }
 
+/* Incoming-backlink snippet (BacklinkSnippet): one referencing line rendered as
+   rich text through MarkdownView. The view carries `reflect-editor` so chips and
+   inline marks share the editor's styling; these rules keep it in the panel's
+   compact 12px line box (the wrapper clamps it to two lines). The `.ProseMirror`
+   compound matches meowdown's heading-rule specificity so our caps win the
+   later-source-order tie, the same trick as `.reflect-stream-gutter`. */
+.reflect-backlink-snippet .reflect-editor :is(p, ul, ol, blockquote, pre) {
+  margin: 0;
+}
+.reflect-backlink-snippet .reflect-editor.ProseMirror :is(h1, h2, h3, h4, h5, h6) {
+  margin: 0;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  letter-spacing: 0;
+}
+
 .reflect-editor blockquote {
   border-left: 2px solid var(--accent-soft, var(--border));
   color: var(--text-secondary);

--- a/packages/core/src/indexing/index.ts
+++ b/packages/core/src/indexing/index.ts
@@ -110,7 +110,7 @@ export {
   HIGHLIGHT_END,
   type HighlightSegment,
 } from './search'
-export { lineSnippet, previewSnippet } from './snippet'
+export { lineAt, lineSnippet, previewSnippet } from './snippet'
 export { parseSearchQuery, type ParsedSearchQuery, type SearchFilters } from './filter-query'
 export { searchWithFilters, type FilteredSearchHit } from './filtered-search'
 export {

--- a/packages/core/src/indexing/queries.ts
+++ b/packages/core/src/indexing/queries.ts
@@ -12,7 +12,7 @@ import {
 import { generateDateSuggestions, type DateSuggestionContext } from './date-suggestions'
 import { db } from './db'
 import { buildFtsMatch } from './search-query'
-import { lineSnippet } from './snippet'
+import { lineAt } from './snippet'
 import {
   mergeDateSuggestions,
   rankWikiSuggestions,
@@ -46,7 +46,11 @@ export function getBacklinks(path: string): Promise<Backlink[]> {
 export interface BacklinkContext {
   sourcePath: string
   sourceTitle: string
-  /** The line of the source around the link (empty when the file is unreadable). */
+  /**
+   * The whole source line containing the link, as rich-text-renderable Markdown
+   * (empty when the file is unreadable). Not windowed: a half-cut Markdown token
+   * would garble the rendered snippet, so the panel clamps the line visually.
+   */
   snippet: string
   posFrom: number
 }
@@ -86,7 +90,7 @@ export async function getBacklinksWithContext(path: string): Promise<BacklinkCon
     return {
       sourcePath: row.sourcePath,
       sourceTitle: row.sourceTitle,
-      snippet: content == null ? '' : lineSnippet(content, row.posFrom),
+      snippet: content == null ? '' : lineAt(content, row.posFrom),
       posFrom: row.posFrom,
     }
   })

--- a/packages/core/src/indexing/snippet.test.ts
+++ b/packages/core/src/indexing/snippet.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { lineSnippet, previewSnippet } from './snippet'
+import { lineAt, lineSnippet, previewSnippet } from './snippet'
 
 /** True when `text` contains a UTF-16 surrogate without its pair. */
 function hasLoneSurrogate(text: string): boolean {
@@ -50,6 +50,32 @@ describe('lineSnippet', () => {
   it('clamps an out-of-range position instead of throwing', () => {
     expect(lineSnippet('only line', 999)).toBe('only line')
     expect(lineSnippet('', 5)).toBe('')
+  })
+})
+
+describe('lineAt', () => {
+  it('returns the whole trimmed line containing the position', () => {
+    const content = 'first line\n   see [[Target]] here   \nlast line\n'
+    expect(lineAt(content, content.indexOf('[[Target]]'))).toBe('see [[Target]] here')
+  })
+
+  it('returns the full line untruncated even when very long', () => {
+    // A link past the 160-char window would be windowed (and possibly cut) by
+    // lineSnippet; lineAt keeps the whole line so the [[…]] token stays balanced.
+    const left = 'a'.repeat(300)
+    const content = `${left} [[Target]] tail`
+    const line = lineAt(content, content.indexOf('[[Target]]'))
+    expect(line).toBe(`${left} [[Target]] tail`)
+    expect(line).toContain('[[Target]]')
+    expect(line.startsWith('…')).toBe(false)
+  })
+
+  it('picks the correct line for first, last, and out-of-range positions', () => {
+    const content = 'alpha [[X]]\nomega [[Y]]'
+    expect(lineAt(content, content.indexOf('[[X]]'))).toBe('alpha [[X]]')
+    expect(lineAt(content, content.indexOf('[[Y]]'))).toBe('omega [[Y]]')
+    expect(lineAt('only line', 999)).toBe('only line')
+    expect(lineAt('', 5)).toBe('')
   })
 })
 

--- a/packages/core/src/indexing/snippet.ts
+++ b/packages/core/src/indexing/snippet.ts
@@ -25,13 +25,28 @@ function sliceWithoutSplittingSurrogate(text: string, maxLength: number): string
   return text.slice(0, isLoneHighSurrogate ? end - 1 : end)
 }
 
-/** The single line of `content` containing `pos`, windowed to `maxLength`. */
-export function lineSnippet(content: string, pos: number, maxLength = DEFAULT_MAX_LENGTH): string {
+/** The raw line of `content` containing `pos`, with that line's start offset. */
+function rawLineAt(content: string, pos: number): { lineStart: number; rawLine: string } {
   const at = Math.max(0, Math.min(pos, content.length))
   const lineStart = content.lastIndexOf('\n', Math.max(0, at - 1)) + 1
   const lineEndRaw = content.indexOf('\n', at)
   const lineEnd = lineEndRaw === -1 ? content.length : lineEndRaw
-  const rawLine = content.slice(lineStart, lineEnd)
+  return { lineStart, rawLine: content.slice(lineStart, lineEnd) }
+}
+
+/**
+ * The whole trimmed line of `content` containing `pos`, never windowed. The
+ * backlinks panel renders this through meowdown, which needs balanced Markdown;
+ * windowing (see `lineSnippet`) can cut a `[[wiki link]]` or `**bold**` token in
+ * half. The line is bounded by `\n`, so a renderer clamps it visually instead.
+ */
+export function lineAt(content: string, pos: number): string {
+  return rawLineAt(content, pos).rawLine.trim()
+}
+
+/** The single line of `content` containing `pos`, windowed to `maxLength`. */
+export function lineSnippet(content: string, pos: number, maxLength = DEFAULT_MAX_LENGTH): string {
+  const { lineStart, rawLine } = rawLineAt(content, pos)
   const line = rawLine.trim()
   if (line.length <= maxLength) {
     return line
@@ -39,6 +54,7 @@ export function lineSnippet(content: string, pos: number, maxLength = DEFAULT_MA
   // Window around the link's position within the *trimmed* line — the trim
   // shifted offsets by the leading whitespace, and on a long indented line an
   // unadjusted position could window the link right out of the snippet.
+  const at = Math.max(0, Math.min(pos, content.length))
   const startTrim = rawLine.length - rawLine.trimStart().length
   const posInLine = Math.max(0, Math.min(at - lineStart - startTrim, line.length))
   const half = Math.floor(maxLength / 2)

--- a/packages/core/src/indexing/snippet.ts
+++ b/packages/core/src/indexing/snippet.ts
@@ -51,7 +51,7 @@ export function lineSnippet(content: string, pos: number, maxLength = DEFAULT_MA
   if (line.length <= maxLength) {
     return line
   }
-  // Window around the link's position within the *trimmed* line — the trim
+  // Window around the link's position within the *trimmed* line: the trim
   // shifted offsets by the leading whitespace, and on a long indented line an
   // unadjusted position could window the link right out of the snippet.
   const at = Math.max(0, Math.min(pos, content.length))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,11 +21,11 @@ importers:
   apps/desktop:
     dependencies:
       '@meowdown/core':
-        specifier: 0.20.0
-        version: 0.20.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+        specifier: 0.21.0
+        version: 0.21.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       '@meowdown/react':
-        specifier: 0.20.0
-        version: 0.20.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 0.21.0
+        version: 0.21.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@reflect/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -1008,11 +1008,11 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
-  '@meowdown/core@0.20.0':
-    resolution: {integrity: sha512-dfon/3xhQtz8AUbbvwlssdpJQtbfxfLWtgyi9whGamyMb1u9U1bO/fWfCa3AmQLXFmSR9Dm53TMYvDGb1Ce0Sg==}
+  '@meowdown/core@0.21.0':
+    resolution: {integrity: sha512-DPyWkNUWrReoB8Q+3KN13BENDt95e1sUoAxXKNn4jM1KF8fnejzEadcgH5Eh7nE8u1YgKrfuqtwu6hviA1awOw==}
 
-  '@meowdown/react@0.20.0':
-    resolution: {integrity: sha512-UB6sVX9JD3SVUKFk737VsyFpl8YTc2nOi0Lglzi+igs2dKqAKOISky5EFk3Bu5kYcVii2b9299t+dHihwpyEDA==}
+  '@meowdown/react@0.21.0':
+    resolution: {integrity: sha512-8Tl4efEpMrQo8OKdaJWxmu/xOiAh2acvrYeb1BYQK1RwaSACPf8FTzPsGc+cYKNOpVR1xoIlFfWrbnNWlykDQA==}
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
@@ -1212,8 +1212,8 @@ packages:
   '@prosekit/core@0.13.0-beta.3':
     resolution: {integrity: sha512-QMBZGDtLDpOkagZ8xhDsbXvYJG9+VQEr+rsI1nAbGw7yMHFO3qF5PqaDm1SMju9QTKW3GaXFr7ztAkDXOP4lOA==}
 
-  '@prosekit/extensions@0.17.5-beta.7':
-    resolution: {integrity: sha512-Nsa7UO4sXYhswQO89ZVxams+AJsKz3xLaLj4fBO+lqVCnqktNHpY1PjWAZT2W1Voi1yO1cDO9bnOUp7x76u4ow==}
+  '@prosekit/extensions@0.18.0-beta.9':
+    resolution: {integrity: sha512-i7g0wJSj9d5PNK/5UjAdwI27bVkGRUJigpOoXsGVXO6sjAWHYAZL7Ea/VdAdEnr0NacH8z5mhvE1NxOsQYTz6Q==}
     peerDependencies:
       loro-crdt: '>= 1.10.0'
       loro-prosemirror: '>= 0.4.1'
@@ -1232,8 +1232,8 @@ packages:
   '@prosekit/pm@0.1.19-beta.0':
     resolution: {integrity: sha512-7vkxSf8byvR1XNIxCShdtK6UXTGgGix2lrzuA2RwvDBwz2eeqRuxjwuVN2r2EopXCJS/v4V05UXv/DuOXDULhw==}
 
-  '@prosekit/react@0.8.0-beta.9':
-    resolution: {integrity: sha512-G0Pndo5XtkwgxLm3Nl7U8XipXofjYsWteni11H3CFzsfhzWwuljKEEXKnkKp9aGjA04sSiHmkb3XVXbR9clcQQ==}
+  '@prosekit/react@0.8.0-beta.11':
+    resolution: {integrity: sha512-oMMNE5RM99O7oO1OLqf4LTneDuppVxLy85fhIGmyIcbT/EwI+cwBjh4kcuD+/Qqk/MhO+25oCu25OUkM54YJAg==}
     peerDependencies:
       react: '>= 18.2.0'
       react-dom: '>= 18.2.0'
@@ -1243,8 +1243,8 @@ packages:
       react-dom:
         optional: true
 
-  '@prosekit/web@0.9.0-beta.9':
-    resolution: {integrity: sha512-Wv++vna6uETfQ588f77qDTBRh8kIPW7kK/B91h8p6KqoOzzGHGtcMZ88YWGpkvfFupctRRNxiEMCznKae2tLTA==}
+  '@prosekit/web@0.9.0-beta.11':
+    resolution: {integrity: sha512-c7Dn8ZOiBXEAKM+PwRu62x9nr+h99SMpjI5VQa3LUzq3twU8xs9m2+aAgWdbrhQc4svwaGfwLekB4KocpD1TZQ==}
 
   '@prosemirror-adapter/core@0.5.3':
     resolution: {integrity: sha512-jGcI/eq3USFqf1fCaejgCmifmXYDyFco6/5KjyyNBnuEhLqyLjD+020CtcduEOsnN4xPZr5ikclgHIR6kEFkQg==}
@@ -6910,7 +6910,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@meowdown/core@0.20.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
+  '@meowdown/core@0.21.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
     dependencies:
       '@codemirror/language': 6.12.3
       '@codemirror/language-data': 6.5.2
@@ -6919,7 +6919,7 @@ snapshots:
       '@lezer/markdown': 1.6.4
       '@ocavue/utils': 1.7.0
       '@prosekit/core': 0.13.0-beta.3(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      '@prosekit/extensions': 0.17.5-beta.7(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+      '@prosekit/extensions': 0.18.0-beta.9(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       '@prosekit/pm': 0.1.19-beta.0
       prosemirror-flat-list: 0.6.0
       prosemirror-highlight: 0.15.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
@@ -6945,7 +6945,7 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@meowdown/react@0.20.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@meowdown/react@0.21.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@base-ui/react': 1.6.0(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@codemirror/commands': 6.10.3
@@ -6953,11 +6953,11 @@ snapshots:
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.43.1
-      '@meowdown/core': 0.20.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+      '@meowdown/core': 0.21.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       '@ocavue/utils': 1.7.0
       '@prosekit/core': 0.13.0-beta.3(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosekit/pm': 0.1.19-beta.0
-      '@prosekit/react': 0.8.0-beta.9(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@prosekit/react': 0.8.0-beta.11(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       clsx: 2.1.1
       lucide-react: 1.21.0(react@19.2.7)
     optionalDependencies:
@@ -7124,7 +7124,7 @@ snapshots:
       - prosemirror-state
       - prosemirror-transform
 
-  '@prosekit/extensions@0.17.5-beta.7(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
+  '@prosekit/extensions@0.18.0-beta.9(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
     dependencies:
       '@ocavue/utils': 1.7.0
       '@prosekit/core': 0.13.0-beta.3(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
@@ -7166,11 +7166,11 @@ snapshots:
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.9
 
-  '@prosekit/react@0.8.0-beta.9(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@prosekit/react@0.8.0-beta.11(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@prosekit/core': 0.13.0-beta.3(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosekit/pm': 0.1.19-beta.0
-      '@prosekit/web': 0.9.0-beta.9(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+      '@prosekit/web': 0.9.0-beta.11(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       '@prosemirror-adapter/core': 0.5.3
       '@prosemirror-adapter/react': 0.5.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     optionalDependencies:
@@ -7194,7 +7194,7 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@prosekit/web@0.9.0-beta.9(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
+  '@prosekit/web@0.9.0-beta.11(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
     dependencies:
       '@aria-ui/core': 0.2.1
       '@aria-ui/elements': 0.1.10
@@ -7202,7 +7202,7 @@ snapshots:
       '@floating-ui/dom': 1.7.6
       '@ocavue/utils': 1.7.0
       '@prosekit/core': 0.13.0-beta.3(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      '@prosekit/extensions': 0.17.5-beta.7(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+      '@prosekit/extensions': 0.18.0-beta.9(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       '@prosekit/pm': 0.1.19-beta.0
       prosemirror-tables: 1.8.5
     transitivePeerDependencies:


### PR DESCRIPTION
Incoming-backlink snippets rendered as raw Markdown source (`[[Wiki Link]]` with the brackets); they now render through meowdown 0.21.0's editor-free `MarkdownView`, so wiki links become clickable chips and inline marks render. The backlink query returns the full source line instead of a windowed one (mid-token windowing could garble a chip), and the panel clamps it visually. `MarkdownPreview` is re-based on `MarkdownView` too, so the ⌘K preview, task text, and chat turns drop their per-instance read-only editors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backlink snippets now render with interactive wiki-link chips for quick navigation
  * External links now open in your system browser
  * Images in backlink snippets are now displayed

* **Style**
  * Improved backlink snippet text rendering and spacing for better readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->