### PR TITLE
Release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.2.0-beta.34"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.2.0-beta.34"
+version = "0.2.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.2.0-beta.34",
+  "version": "0.2.0",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",
@@ -33,7 +33,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDREQ0RBRkJBN0ZDODdDMzkKUldRNWZNaC91cS9OVFhtTHdrSWVOV3p2cEdhc3RZbmtXM0g0bnpxUnZXVjlQMjZRNXFlWUdPNWMK",
       "endpoints": [
-        "https://github.com/team-reflect/reflect-open/releases/download/updater-beta/latest.json"
+        "https://github.com/team-reflect/reflect-open/releases/latest/download/latest.json"
       ]
     }
   },


### PR DESCRIPTION
Bumps Reflect to 0.2.0.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version metadata and updater URL only; no application logic changes, though clients must receive a valid `latest.json` at the new stable URL for updates to work.
> 
> **Overview**
> This PR finalizes the **0.2.0** release by dropping the beta suffix everywhere the shipped version is defined.
> 
> **reflect-open** is set to `0.2.0` in `Cargo.toml`, `Cargo.lock`, and `tauri.conf.json` so the desktop bundle and lockfile stay in sync.
> 
> The Tauri **updater** endpoint moves from the beta updater URL (`releases/download/updater-beta/latest.json`) to the standard GitHub release asset path (`releases/latest/download/latest.json`), so in-app updates follow the main **0.2.0** release channel instead of the beta updater feed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 077d9552f3125b67cfecf41acf0ea4dfa7c734f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->