### PR TITLE
ci: shard desktop vitest suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   node:
-    name: Lint · typecheck · test · build (Node)
+    name: Lint · typecheck · non-desktop tests · build (Node)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -49,11 +49,38 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
-      - name: Test
-        run: pnpm test
+      - name: Test non-desktop packages
+        run: pnpm turbo run test --filter='!@reflect/desktop'
 
       - name: Build
         run: pnpm build
+
+  desktop-tests:
+    name: Desktop tests (${{ matrix.shard }}/3)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Install Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test desktop shard
+        run: pnpm --filter @reflect/desktop exec vitest run --shard=${{ matrix.shard }}/3
 
   rust:
     name: fmt · clippy · test (Rust)

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**", ".output/**"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
## Summary
- split the desktop Vitest suite into a 3-way GitHub Actions matrix
- keep the existing Node job focused on lint, typecheck, non-desktop tests, and build
- add WXT `.output/**` to Turbo build outputs so extension builds can be cached without missing-output warnings

## Why
Recent CI logs showed `@reflect/desktop` Vitest dominating the Node job: about 115s on a warm-ish PR run and 192s on a slower one, while Rust was usually around 2 minutes. Sharding the desktop suite should put PR wall time closer to the Rust job instead of waiting on one long Node test step.

## Verification
- `pnpm check`
- `pnpm turbo run test --filter='!@reflect/desktop'`\n- `pnpm --filter @reflect/desktop exec vitest run --shard=1/3`\n- `pnpm --filter @reflect/desktop exec vitest run --shard=2/3`\n- `pnpm --filter @reflect/desktop exec vitest run --shard=3/3`\n- `pnpm build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and Turbo caching configuration only; no application runtime or security-sensitive code paths change.
> 
> **Overview**
> Splits **`@reflect/desktop`** Vitest out of the main Node CI job into a new **`desktop-tests`** job that runs the suite in **three parallel shards** (`vitest run --shard=N/3`), with `fail-fast: false` so one shard failing does not cancel the others.
> 
> The Node job now runs **lint, typecheck, build, and tests for every package except desktop** via `pnpm turbo run test --filter='!@reflect/desktop'`, and its display name reflects that scope.
> 
> **`turbo.json`** adds **`.output/**`** to the **`build`** task outputs so WXT/extension build artifacts are included in Turbo’s cache and avoid missing-output warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3dabc0f60c9b9ed1b4273bff5c63275bf239495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->