### PR TITLE
Fix beta updater support gate

### DIFF
--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -99,6 +99,11 @@ afterEach(() => {
 })
 
 describe('SettingsScreen', () => {
+  it('shows update controls when the native bridge is available', () => {
+    renderScreen()
+    expect(screen.getByRole('button', { name: /check for updates/i })).toBeTruthy()
+  })
+
   it('reflects the persisted markdown syntax mode', async () => {
     stored = { editorMarkdownSyntax: 'show' }
     renderScreen()

--- a/apps/desktop/src/providers/update-provider.tsx
+++ b/apps/desktop/src/providers/update-provider.tsx
@@ -28,17 +28,6 @@ interface UpdateContextValue {
   restart: () => Promise<void>
 }
 
-const DESKTOP_PLATFORMS = new Set(['darwin', 'windows', 'linux'])
-
-/**
- * True when this bundle was built by the Tauri CLI for a desktop target.
- * `TAURI_ENV_PLATFORM` is the CLI's build-time platform (absent in plain Vite
- * builds and tests), so mobile bundles compile the update UI away from day one.
- */
-function isDesktopBuild(): boolean {
-  return DESKTOP_PLATFORMS.has(import.meta.env.TAURI_ENV_PLATFORM ?? '')
-}
-
 const UpdateContext = createContext<UpdateContextValue | null>(null)
 
 const IDLE: UpdateState = { phase: 'idle' }
@@ -60,7 +49,7 @@ interface UpdateProviderProps {
  * any graph is open.
  */
 export function UpdateProvider({ children, autoCheck }: UpdateProviderProps): ReactElement {
-  const supported = hasBridge() && isDesktopBuild()
+  const supported = hasBridge()
   const resolvedAutoCheck = autoCheck ?? (supported && !import.meta.env.DEV)
   const [controller, setController] = useState<UpdateController | null>(null)
 

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig(async () => ({
 
   // Expose the Tauri CLI's build-time TAURI_ENV_* vars (e.g. the target
   // platform, which gates desktop-only surfaces like the updater).
-  envPrefix: ['VITE_', 'TAURI_ENV_*'],
+  envPrefix: ['VITE_', 'TAURI_ENV_'],
 
   // Vite options tailored for Tauri development, applied in `tauri dev`/`tauri build`.
   //


### PR DESCRIPTION
## Summary
- enable the desktop updater provider whenever the native bridge is present
- correct Vite's TAURI_ENV_ prefix so Tauri env vars are exposed as intended
- add a Settings regression test for the update control

## Testing
- pnpm --filter @reflect/desktop exec vitest run src/components/settings-screen.test.tsx src/lib/update-controller.test.ts
- pnpm exec node -e "import('vite').then(({loadEnv}) => { process.env.TAURI_ENV_PLATFORM='darwin'; const env = loadEnv('production', process.cwd(), ['VITE_', 'TAURI_ENV_']); if (env.TAURI_ENV_PLATFORM !== 'darwin') throw new Error('TAURI_ENV_PLATFORM was not exposed'); console.log(env.TAURI_ENV_PLATFORM); })" (from apps/desktop)
- pnpm check
- pnpm build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to updater UI gating and Vite env exposure; no auth, data, or core graph logic.
> 
> **Overview**
> Fixes **beta/desktop builds hiding the in-app updater** by dropping the broken `TAURI_ENV_PLATFORM` build-time gate and treating updates as supported whenever the **native Tauri bridge** is available (`hasBridge()`).
> 
> **Vite** `envPrefix` is corrected from the non-working `TAURI_ENV_*` pattern to `TAURI_ENV_`, so Tauri CLI build-time variables (including platform) are actually exposed to the frontend as intended.
> 
> A **Settings** regression test asserts the **Check for updates** control appears when the test harness installs a fake bridge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8c8ea74187fd12a2ce2a0a530119a173308b6a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for update controls availability.

* **Bug Fixes**
  * Refined update detection logic to work more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->