### PR TITLE
Add forget graph settings action

### DIFF
--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { setBridge, type EmbedStatus } from '@reflect/core'
+import { setBridge, type EmbedStatus, type GraphInfo } from '@reflect/core'
 import { formatFullDate } from '@/lib/dates'
 import { resetOperations } from '@/lib/operations'
 import { SettingsProvider } from '@/providers/settings-provider'
@@ -10,10 +10,18 @@ import { SettingsScreen } from './settings-screen'
 
 // The rebuild-index field reads the open index generation — and the Backup
 // section the open graph + sync state — from per-graph providers the screen
-// tests don't mount, so stub both hooks (no graph open, backup disconnected).
-const graph = vi.hoisted(() => ({ indexGeneration: 7 as number | null }))
+// tests don't mount, so stub both hooks (backup disconnected).
+const graph = vi.hoisted(() => ({
+  current: null as GraphInfo | null,
+  indexGeneration: 7 as number | null,
+  forget: vi.fn<(root: string) => Promise<void>>(async () => {}),
+}))
 vi.mock('@/providers/graph-provider', () => ({
-  useGraph: () => ({ graph: null, indexGeneration: graph.indexGeneration }),
+  useGraph: () => ({
+    graph: graph.current,
+    indexGeneration: graph.indexGeneration,
+    forget: graph.forget,
+  }),
 }))
 vi.mock('@/providers/sync-provider', () => ({
   useSync: () => ({
@@ -85,7 +93,9 @@ function radio(name: RegExp): HTMLInputElement {
 beforeEach(() => {
   stored = {}
   embedStatus = { status: 'uninitialized' }
+  graph.current = null
   graph.indexGeneration = 7
+  graph.forget.mockClear()
   queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: Infinity } },
   })
@@ -102,6 +112,16 @@ describe('SettingsScreen', () => {
   it('shows update controls when the native bridge is available', () => {
     renderScreen()
     expect(screen.getByRole('button', { name: /check for updates/i })).toBeTruthy()
+  })
+
+  it('forgets the open graph from saved graphs', async () => {
+    graph.current = { root: '/graphs/work', name: 'Work', cloudSync: null, generation: 1 }
+    renderScreen()
+
+    const section = screen.getByRole('region', { name: 'Destructive' })
+    fireEvent.click(within(section).getByRole('button', { name: /forget graph/i }))
+
+    await waitFor(() => expect(graph.forget).toHaveBeenCalledWith('/graphs/work'))
   })
 
   it('reflects the persisted markdown syntax mode', async () => {

--- a/apps/desktop/src/components/settings-screen.tsx
+++ b/apps/desktop/src/components/settings-screen.tsx
@@ -5,6 +5,7 @@ import { AllNotesSection } from './settings/all-notes-section'
 import { AppearanceSection } from './settings/appearance-section'
 import { BackupSection } from './settings/backup-section'
 import { DateTimeSection } from './settings/date-time-section'
+import { DestructiveSection } from './settings/destructive-section'
 import { EditorSection } from './settings/editor-section'
 import { KeyboardSection } from './settings/keyboard-section'
 import { SearchSection } from './settings/search-section'
@@ -28,6 +29,7 @@ export function SettingsScreen(): ReactElement {
         <AiProvidersSection />
         <KeyboardSection />
         <AboutSection />
+        <DestructiveSection />
       </div>
     </div>
   )

--- a/apps/desktop/src/components/settings/destructive-section.tsx
+++ b/apps/desktop/src/components/settings/destructive-section.tsx
@@ -1,0 +1,43 @@
+import { useState, type ReactElement } from 'react'
+import { Button } from '@/components/ui/button'
+import { useGraph } from '@/providers/graph-provider'
+import { SettingsField } from './field'
+import { SettingsSection } from './section'
+
+export function DestructiveSection(): ReactElement {
+  const { graph, forget } = useGraph()
+  const [forgetting, setForgetting] = useState(false)
+
+  const forgetGraph = async (): Promise<void> => {
+    if (graph === null || forgetting) {
+      return
+    }
+    setForgetting(true)
+    try {
+      await forget(graph.root)
+    } finally {
+      setForgetting(false)
+    }
+  }
+
+  return (
+    <SettingsSection id="destructive">
+      <SettingsField
+        legend="Saved graph"
+        description="Forget this graph. Files stay on disk."
+      >
+        <div className="mt-3 flex justify-start">
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            disabled={graph === null || forgetting}
+            onClick={() => void forgetGraph()}
+          >
+            {forgetting ? 'Forgetting…' : 'Forget graph'}
+          </Button>
+        </div>
+      </SettingsField>
+    </SettingsSection>
+  )
+}

--- a/apps/desktop/src/components/settings/sections.ts
+++ b/apps/desktop/src/components/settings/sections.ts
@@ -13,6 +13,7 @@ export const SETTINGS_SECTIONS = [
   { id: 'ai-providers', title: 'AI providers' },
   { id: 'keyboard', title: 'Keyboard shortcuts' },
   { id: 'about', title: 'About' },
+  { id: 'destructive', title: 'Destructive' },
 ] as const
 
 /** Identifier of one {@link SETTINGS_SECTIONS} entry. */

--- a/apps/desktop/src/components/settings/settings-navigator.test.tsx
+++ b/apps/desktop/src/components/settings/settings-navigator.test.tsx
@@ -113,9 +113,9 @@ describe('SettingsNavigator', () => {
   it('hands the last section the marker at the very bottom of the page', () => {
     const scroller = renderNavigatorPage()
     scrollPageTo(scroller, CONTENT_PX - VIEWPORT_PX)
-    // About's top never crosses the reading line, but the page can scroll no
+    // Destructive's top never crosses the reading line, but the page can scroll no
     // further — the bottom override keeps the last entry reachable.
-    expect(activeEntry()).toBe('About')
+    expect(activeEntry()).toBe('Destructive')
   })
 
   it('clicking an entry scrolls its section to the top of the page', () => {


### PR DESCRIPTION
## Summary
- Add a final Destructive settings section with a single Forget graph action
- Wire the action to the existing graph recents removal flow without deleting files
- Update settings screen and navigator tests for the new final section

## Testing
- pnpm --filter @reflect/desktop test -- apps/desktop/src/components/settings-screen.test.tsx apps/desktop/src/components/settings/settings-navigator.test.tsx
- pnpm check

Note: the desktop test command ran the full desktop Vitest suite in this package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only wiring to an existing recents-removal API with no new persistence or file-deletion paths.
> 
> **Overview**
> Adds a new **Destructive** settings section at the bottom of the settings page with a **Forget graph** control that removes the open graph from saved recents via the existing `forget` / `forgetRecent` flow; copy clarifies that files on disk are not deleted.
> 
> The section is registered in `SETTINGS_SECTIONS` so the sticky navigator lists and highlights **Destructive** as the last entry when scrolled to the bottom. Settings screen tests stub `forget` and assert the button calls it with the current graph root; navigator tests expect **Destructive** instead of **About** as the bottom-scroll active section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 956e8e1c30c9e19b08a55e8fb733d53d99cb9711. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Destructive" settings section with a "Forget graph" button to clear saved graphs from the application.

* **Tests**
  * Updated test coverage for the new settings section and graph deletion functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->