### PR TITLE
Confirm and close forgotten graph

### DIFF
--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -114,12 +114,18 @@ describe('SettingsScreen', () => {
     expect(screen.getByRole('button', { name: /check for updates/i })).toBeTruthy()
   })
 
-  it('forgets the open graph from saved graphs', async () => {
+  it('confirms before forgetting the open graph from saved graphs', async () => {
     graph.current = { root: '/graphs/work', name: 'Work', cloudSync: null, generation: 1 }
     renderScreen()
 
-    const section = screen.getByRole('region', { name: 'Destructive' })
+    const section = screen.getByRole('region', { name: 'Danger zone' })
     fireEvent.click(within(section).getByRole('button', { name: /forget graph/i }))
+
+    const dialog = screen.getByRole('dialog', { name: /forget graph/i })
+    expect(within(dialog).getByText('/graphs/work')).toBeTruthy()
+    expect(graph.forget).not.toHaveBeenCalled()
+
+    fireEvent.click(within(dialog).getByRole('button', { name: /forget graph/i }))
 
     await waitFor(() => expect(graph.forget).toHaveBeenCalledWith('/graphs/work'))
   })

--- a/apps/desktop/src/components/settings/destructive-section.tsx
+++ b/apps/desktop/src/components/settings/destructive-section.tsx
@@ -1,12 +1,22 @@
 import { useState, type ReactElement } from 'react'
 import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { useGraph } from '@/providers/graph-provider'
 import { SettingsField } from './field'
 import { SettingsSection } from './section'
 
 export function DestructiveSection(): ReactElement {
   const { graph, forget } = useGraph()
+  const [confirming, setConfirming] = useState(false)
   const [forgetting, setForgetting] = useState(false)
+  const graphId = graph?.root ?? 'this graph'
 
   const forgetGraph = async (): Promise<void> => {
     if (graph === null || forgetting) {
@@ -15,29 +25,52 @@ export function DestructiveSection(): ReactElement {
     setForgetting(true)
     try {
       await forget(graph.root)
+      setConfirming(false)
     } finally {
       setForgetting(false)
     }
   }
 
   return (
-    <SettingsSection id="destructive">
-      <SettingsField
-        legend="Saved graph"
-        description="Forget this graph. Files stay on disk."
-      >
-        <div className="mt-3 flex justify-start">
-          <Button
-            type="button"
-            variant="destructive"
-            size="sm"
-            disabled={graph === null || forgetting}
-            onClick={() => void forgetGraph()}
-          >
-            {forgetting ? 'Forgetting…' : 'Forget graph'}
-          </Button>
-        </div>
-      </SettingsField>
-    </SettingsSection>
+    <>
+      <SettingsSection id="destructive">
+        <SettingsField
+          legend="Saved graph"
+          description="Forget this graph. Files stay on disk."
+        >
+          <div className="mt-3 flex justify-start">
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              disabled={graph === null || forgetting}
+              onClick={() => setConfirming(true)}
+            >
+              Forget graph
+            </Button>
+          </div>
+        </SettingsField>
+      </SettingsSection>
+
+      <Dialog open={confirming} onOpenChange={(open) => !forgetting && setConfirming(open)}>
+        <DialogContent>
+          <DialogTitle>Forget graph?</DialogTitle>
+          <DialogDescription>
+            Remove <span className="font-mono text-text">{graphId}</span> from saved graphs. Files
+            stay on disk.
+          </DialogDescription>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="ghost" disabled={forgetting}>
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button variant="destructive" disabled={forgetting} onClick={() => void forgetGraph()}>
+              {forgetting ? 'Forgetting…' : 'Forget graph'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }

--- a/apps/desktop/src/components/settings/sections.ts
+++ b/apps/desktop/src/components/settings/sections.ts
@@ -13,7 +13,7 @@ export const SETTINGS_SECTIONS = [
   { id: 'ai-providers', title: 'AI providers' },
   { id: 'keyboard', title: 'Keyboard shortcuts' },
   { id: 'about', title: 'About' },
-  { id: 'destructive', title: 'Destructive' },
+  { id: 'destructive', title: 'Danger zone' },
 ] as const
 
 /** Identifier of one {@link SETTINGS_SECTIONS} entry. */

--- a/apps/desktop/src/components/settings/settings-navigator.test.tsx
+++ b/apps/desktop/src/components/settings/settings-navigator.test.tsx
@@ -113,9 +113,9 @@ describe('SettingsNavigator', () => {
   it('hands the last section the marker at the very bottom of the page', () => {
     const scroller = renderNavigatorPage()
     scrollPageTo(scroller, CONTENT_PX - VIEWPORT_PX)
-    // Destructive's top never crosses the reading line, but the page can scroll no
+    // Danger zone's top never crosses the reading line, but the page can scroll no
     // further — the bottom override keeps the last entry reachable.
-    expect(activeEntry()).toBe('Destructive')
+    expect(activeEntry()).toBe('Danger zone')
   })
 
   it('clicking an entry scrolls its section to the top of the page', () => {

--- a/apps/desktop/src/providers/graph-index.test.ts
+++ b/apps/desktop/src/providers/graph-index.test.ts
@@ -46,10 +46,9 @@ describe('createGraphIndex', () => {
     expect(onError).toHaveBeenCalledWith('open', expect.any(Error))
   })
 
-  it('sync(null) stops the watcher and does not reconcile', async () => {
+  it('close() stops the watcher and does not reconcile', async () => {
     const index = createGraphIndex()
-    index.sync(null, () => false)
-    await index.stop()
+    await index.close()
     expect(mockWatchStop).toHaveBeenCalledTimes(1)
     expect(mockSync).not.toHaveBeenCalled()
   })
@@ -84,7 +83,7 @@ describe('createGraphIndex', () => {
     expect(unlisten).not.toHaveBeenCalled() // retained as the active subscription
   })
 
-  it('reports progress: reconciling → live; idle when there is no index', async () => {
+  it('reports progress: reconciling → live; idle when closed', async () => {
     const onProgress = vi.fn()
     const index = createGraphIndex({ onProgress })
     index.sync(5, () => false)
@@ -92,7 +91,7 @@ describe('createGraphIndex', () => {
     expect(onProgress.mock.calls.map(([stage]) => stage)).toEqual(['reconciling', 'live'])
 
     onProgress.mockClear()
-    index.sync(null, () => false)
+    await index.close()
     expect(onProgress).toHaveBeenCalledWith('idle')
   })
 
@@ -160,5 +159,18 @@ describe('createGraphIndex', () => {
 
   it('stop() before any sync resolves immediately', async () => {
     await expect(createGraphIndex().stop()).resolves.toBeUndefined()
+  })
+
+  it('close() drops an active subscription', async () => {
+    const unlisten = vi.fn()
+    mockSubscribe.mockResolvedValue(unlisten)
+    const index = createGraphIndex()
+    index.sync(5, () => false)
+    await index.stop()
+
+    await index.close()
+
+    expect(unlisten).toHaveBeenCalledTimes(1)
+    expect(mockWatchStop).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/providers/graph-index.ts
+++ b/apps/desktop/src/providers/graph-index.ts
@@ -18,6 +18,7 @@ import {
  * const generation = await index.open()    // open the new graph's index
  * if (stale) return
  * index.sync(generation, () => stale)      // background reconcile + live watch
+ * await index.close()                      // no graph/index remains active
  * ```
  *
  * Every write carries the index `generation` returned by {@link GraphIndex.open};
@@ -31,6 +32,11 @@ export interface GraphIndex {
    */
   stop: () => Promise<void>
   /**
+   * Fully close the active index lifecycle: abort any reconcile, drop the live
+   * subscription, stop the file watcher, and report idle progress.
+   */
+  close: () => Promise<void>
+  /**
    * Open + migrate the index for the now-active graph and return its generation.
    * Best-effort: returns `null` (and reports via `onError`) if the open fails, so
    * a broken index never blocks editing.
@@ -42,11 +48,9 @@ export interface GraphIndex {
    * stale — `syncIndex` decides), then subscribe to live `index:changed`
    * events, then start the Rust watcher — sequenced so the passes never write
    * concurrently. `isStale` is checked between steps and bails when a newer
-   * open supersedes this one. When `generation` is `null` (open failed / no
-   * index), any previous watcher is stopped instead. Call only after the graph
-   * row is committed.
+   * open supersedes this one. Call only after the graph row is committed.
    */
-  sync: (generation: number | null, isStale: () => boolean) => void
+  sync: (generation: number, isStale: () => boolean) => void
 }
 
 /** Stage of the index lifecycle that failed, for `onError` reporting. */
@@ -97,6 +101,14 @@ export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
     await done.catch(() => {})
   }
 
+  async function close(): Promise<void> {
+    await stop()
+    live.unlisten?.()
+    live.unlisten = null
+    onProgress?.('idle')
+    await watchStop().catch(() => {})
+  }
+
   async function open(): Promise<number | null> {
     try {
       return await openIndex()
@@ -106,18 +118,11 @@ export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
     }
   }
 
-  function sync(generation: number | null, isStale: () => boolean): void {
+  function sync(generation: number, isStale: () => boolean): void {
     // Tear down the previous graph's live subscription unconditionally, so a
     // failed/absent open can't leave it bound to a different graph.
     live.unlisten?.()
     live.unlisten = null
-
-    if (generation === null) {
-      // No index for this graph — stop any watcher left from the previous one.
-      onProgress?.('idle')
-      void watchStop().catch(() => {})
-      return
-    }
 
     onProgress?.('reconciling')
     const controller = new AbortController()
@@ -159,5 +164,5 @@ export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
     })()
   }
 
-  return { stop, open, sync }
+  return { stop, close, open, sync }
 }

--- a/apps/desktop/src/providers/graph-provider.test.tsx
+++ b/apps/desktop/src/providers/graph-provider.test.tsx
@@ -59,6 +59,9 @@ function installFakeBridge(): void {
         }
         case 'recent_graphs':
           return storedRecents
+        case 'forget_recent':
+          storedRecents = storedRecents.filter((recent) => recent.root !== String(args['root']))
+          return null
         case 'mobile_graph_root':
           return MOBILE_ROOT
         case 'settings_load':
@@ -167,6 +170,26 @@ describe('GraphProvider open sequencing', () => {
 
     expect(result.current.status).toBe('choosing')
     expect(result.current.error).toMatch(/cannot open graph/)
+  })
+
+  it('forgets the open graph and returns to the chooser', async () => {
+    storedRecents = [{ root: '/known', name: 'known', openedMs: 1 }]
+    const { result } = renderHook(() => useGraph(), { wrapper })
+
+    await act(async () => {
+      await waitFor(() => expect(pendingOpens.has('/known')).toBe(true))
+      resolveOpen('/known')
+    })
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+
+    await act(async () => {
+      await result.current.forget('/known')
+    })
+
+    expect(result.current.status).toBe('choosing')
+    expect(result.current.graph).toBeNull()
+    expect(result.current.indexGeneration).toBeNull()
+    expect(result.current.recents).toEqual([])
   })
 })
 

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -203,8 +203,8 @@ export function GraphProvider({
                 }
               })
           } else {
-            // No index — sync with null generation immediately.
-            index.sync(generation, () => seq !== openSeq.current)
+            // No index — tear down any live lifecycle left from the prior graph.
+            void index.close()
           }
         } catch (err) {
           if (seq !== openSeq.current) {
@@ -297,16 +297,30 @@ export function GraphProvider({
     }
   }, [openRecent])
 
+  const closeActiveGraph = useCallback(async (): Promise<void> => {
+    ++openSeq.current
+    await indexRef.current.close()
+    resetNoteRowOverlays()
+    setGraph(null)
+    setIndexGeneration(null)
+    setIndexing(false)
+    setError(null)
+    setStatus('choosing')
+  }, [])
+
   const forget = useCallback(
     async (root: string): Promise<void> => {
       try {
         await forgetRecent(root)
         await loadRecents()
+        if (graph?.root === root) {
+          await closeActiveGraph()
+        }
       } catch {
         // best-effort
       }
     },
-    [loadRecents],
+    [closeActiveGraph, graph, loadRecents],
   )
 
   const completeOnboarding = useCallback(async (): Promise<void> => {


### PR DESCRIPTION
## Summary
- Add a confirmation dialog before forgetting the current graph
- When the forgotten root is the open graph, stop the index lifecycle and return to the graph chooser immediately
- Cover the confirmation flow and active graph invalidation in tests

## Testing
- pnpm --filter @reflect/desktop test -- apps/desktop/src/components/settings-screen.test.tsx apps/desktop/src/providers/graph-provider.test.tsx
- pnpm check

Note: the desktop test command ran the full desktop Vitest suite in this package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches graph provider state and index lifecycle teardown when forgetting the active graph; mistakes could leave watchers/subscriptions running or strand UI state, though changes are covered by new tests.
> 
> **Overview**
> **Forget graph** now requires a confirmation dialog that shows the graph path, with cancel/confirm and a loading state while forgetting runs. The settings section label is renamed from **Destructive** to **Danger zone**.
> 
> When the forgotten root is the **currently open** graph, `forget` calls a new **`closeActiveGraph`** path: bump the open sequence, **`index.close()`** (abort reconcile, drop live subscription, stop watcher, idle progress), clear graph/index UI state, and return to the graph chooser.
> 
> **`GraphIndex`** gains **`close()`** and **`sync`** no longer accepts `null`—failed/missing index teardown uses **`close()`** instead of `sync(null, …)`. Tests cover the dialog flow, forgetting the open graph, and index `close()` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7cce4ec7eb97be5c7adaa9484d7f17a1c21efb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->