### PR TITLE
Fix bulk checkbox toggles in Tasks selection

### DIFF
--- a/apps/desktop/src/components/tasks/task-group-section.tsx
+++ b/apps/desktop/src/components/tasks/task-group-section.tsx
@@ -16,6 +16,8 @@ interface TaskGroupSectionProps {
   editHandlers: (task: OpenTask) => TaskRowEditHandlers
   /** Whether a Tasks-view write is already in flight. */
   taskActionPending: boolean
+  /** Complete/reopen the selected rows using the clicked task's next checkbox state. */
+  onSelectionCheckboxToggle: (task: OpenTask) => void
   /** Today's ISO date — the Current group's "+ Add" targets today's daily. */
   today: string
   /** Add a task to this group and open its editor (the header's "+ Add", V1). */
@@ -65,6 +67,7 @@ export function TaskGroupSection({
   selection,
   editHandlers,
   taskActionPending,
+  onSelectionCheckboxToggle,
   today,
   onAdd,
   convertControllerRef,
@@ -110,15 +113,18 @@ export function TaskGroupSection({
         ) : (
           group.tasks.map((task) => {
             const key = taskKey(task)
+            const selected = selection.isSelected(key)
             return (
               <TaskRow
                 key={key}
                 task={task}
                 showSource={showSource}
-                selected={selection.isSelected(key)}
+                selected={selected}
                 editing={selection.isSoleSelected(key)}
                 taskActionPending={taskActionPending}
+                togglesSelection={selected && selection.selectedCount > 1}
                 onSelect={(event) => selection.clickSelect(key, event)}
+                onSelectionCheckboxToggle={() => onSelectionCheckboxToggle(task)}
                 {...editHandlers(task)}
                 convertControllerRef={convertControllerRef}
                 onOpen={onOpen}

--- a/apps/desktop/src/components/tasks/task-row.tsx
+++ b/apps/desktop/src/components/tasks/task-row.tsx
@@ -25,8 +25,12 @@ interface TaskRowProps {
   editing: boolean
   /** Whether a Tasks-view write is already in flight. */
   taskActionPending: boolean
+  /** Whether this checkbox click should apply to the whole multi-selection. */
+  togglesSelection: boolean
   /** Select the row, honoring ⌘/Ctrl (toggle) and Shift (range) modifiers. */
   onSelect: (event: Pick<MouseEvent, 'metaKey' | 'ctrlKey' | 'shiftKey'>) => void
+  /** Checkbox click while part of a multi-selection: apply this row's next state to it. */
+  onSelectionCheckboxToggle: () => void
   /** Persist an inline edit (content after the marker) and exit edit mode. */
   onEditCommit: (content: string) => void
   /** Enter in the editor: persist this row then add the next task (V1 continuous entry). */
@@ -59,7 +63,8 @@ interface TaskRowProps {
  * arrow that opens the source note. Clicking the row body **selects** it (V1's
  * multi-select); a plain click selects exclusively, ⌘/Ctrl toggles, Shift
  * extends a range. Completing optimistically drops the row; an archived
- * (completed) row shows struck through.
+ * (completed) row shows struck through. A checkbox click on any selected row in
+ * a multi-selection completes or reopens the selected rows together.
  */
 export function TaskRow({
   task,
@@ -67,7 +72,9 @@ export function TaskRow({
   selected,
   editing,
   taskActionPending,
+  togglesSelection,
   onSelect,
+  onSelectionCheckboxToggle,
   onEditCommit,
   onEditContinue,
   onEditDelete,
@@ -127,6 +134,10 @@ export function TaskRow({
           event.stopPropagation()
           if (editing) {
             checkboxToggleControllerRef.current?.()
+            return
+          }
+          if (togglesSelection) {
+            onSelectionCheckboxToggle()
             return
           }
           toggle()

--- a/apps/desktop/src/components/tasks/tasks-screen.test.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.test.tsx
@@ -991,6 +991,85 @@ describe('TasksScreen', () => {
     view.unmount()
   })
 
+  it('completes every selected open task when a selected checkbox is clicked', async () => {
+    toggleTask.mockResolvedValue(undefined)
+    getOpenTasks.mockResolvedValue([
+      task({
+        notePath: 'notes/a.md',
+        markerOffset: 5,
+        raw: '[ ] first task',
+        text: 'first task',
+        noteTitle: 'A',
+      }),
+      task({
+        notePath: 'notes/b.md',
+        markerOffset: 9,
+        raw: '[ ] second task',
+        text: 'second task',
+        noteTitle: 'B',
+      }),
+    ])
+    const view = renderScreen()
+
+    await view.findByRole('button', { name: 'first task' })
+    await userEvent.keyboard('{Meta>}a{/Meta}')
+    await userEvent.click(view.getByRole('button', { name: 'Complete: first task' }))
+
+    await waitFor(() => expect(toggleTask).toHaveBeenCalledTimes(2))
+    expect(toggleTask).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ notePath: 'notes/a.md', markerOffset: 5, raw: '[ ] first task' }),
+      1,
+    )
+    expect(toggleTask).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ notePath: 'notes/b.md', markerOffset: 9, raw: '[ ] second task' }),
+      1,
+    )
+    await view.findByRole('button', { name: 'Reopen: first task' })
+    await view.findByRole('button', { name: 'Reopen: second task' })
+    view.unmount()
+  })
+
+  it('reopens selected checked tasks when a checked selected checkbox is clicked', async () => {
+    window.sessionStorage.setItem('reflect.tasks.filter.archived', 'true')
+    toggleTask.mockResolvedValue(undefined)
+    getOpenTasks.mockResolvedValue([
+      task({
+        notePath: 'notes/a.md',
+        markerOffset: 5,
+        raw: '[ ] open task',
+        text: 'open task',
+        noteTitle: 'A',
+      }),
+    ])
+    getCompletedTasks.mockResolvedValue([
+      task({
+        notePath: 'notes/b.md',
+        markerOffset: 9,
+        raw: '[x] done task',
+        text: 'done task',
+        checked: true,
+        noteTitle: 'B',
+      }),
+    ])
+    const view = renderScreen()
+
+    await view.findByRole('button', { name: 'open task' })
+    await view.findByRole('button', { name: 'done task' })
+    await userEvent.keyboard('{Meta>}a{/Meta}')
+    await userEvent.click(view.getByRole('button', { name: 'Reopen: done task' }))
+
+    await waitFor(() => expect(toggleTask).toHaveBeenCalledTimes(1))
+    expect(toggleTask).toHaveBeenCalledWith(
+      expect.objectContaining({ notePath: 'notes/b.md', markerOffset: 9, raw: '[x] done task' }),
+      1,
+    )
+    await view.findByRole('button', { name: 'Complete: open task' })
+    await view.findByRole('button', { name: 'Complete: done task' })
+    view.unmount()
+  })
+
   it('saves an edited selected task before completing it from the checkbox', async () => {
     editTask.mockResolvedValue(undefined)
     toggleTask.mockResolvedValue(undefined)

--- a/apps/desktop/src/components/tasks/tasks-screen.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.tsx
@@ -204,6 +204,21 @@ export function TasksScreen(): ReactElement {
         .filter((task): task is OpenTask => task !== undefined),
     [selection, tasksByKey],
   )
+  const onSelectionCheckboxToggle = useCallback(
+    (task: OpenTask) => {
+      const tasks = selectedTasks()
+      if (tasks.length <= 1 || !tasks.some((selectedTask) => sameTask(selectedTask, task))) {
+        actions.checkboxToggle(task)
+        return
+      }
+      if (task.checked) {
+        actions.toggle(tasks.filter((selectedTask) => selectedTask.checked))
+      } else {
+        actions.complete(tasks)
+      }
+    },
+    [actions, selectedTasks],
+  )
   // Schedule the current selection (the calendar / ⌘⇧S), then deselect (V1).
   const onSchedule = useCallback(
     (isoDate: string | null) => {
@@ -336,6 +351,7 @@ export function TasksScreen(): ReactElement {
                 selection={selection}
                 editHandlers={editHandlers}
                 taskActionPending={actions.isPending}
+                onSelectionCheckboxToggle={onSelectionCheckboxToggle}
                 today={today}
                 onAdd={onAdd}
                 convertControllerRef={convertControllerRef}


### PR DESCRIPTION
## Summary
- Apply a selected task checkbox click to the whole multi-selection
- Use the clicked row's next checked state so mixed selections complete open rows or reopen checked rows correctly
- Add Tasks view coverage for bulk complete and mixed-selection reopen behavior

## Testing
- pnpm --filter @reflect/desktop exec vitest run src/components/tasks/tasks-screen.test.tsx
- pnpm --filter @reflect/desktop typecheck
- pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI behavior in the Tasks view with regression tests; reuses existing `complete`/`toggle` write paths.
> 
> **Overview**
> **Checkbox clicks on a multi-selected row now apply to the whole selection**, not only the row you clicked.
> 
> `TasksScreen` adds `onSelectionCheckboxToggle`: when more than one row is selected, an open clicked checkbox runs **`complete`** on all selected open tasks; a checked clicked checkbox runs **`toggle`** on only the selected completed rows (so mixed open+done selections behave like ⌘↵). Single-row and sole-edit paths are unchanged.
> 
> `TaskRow` gets `togglesSelection` and routes the checkbox through the new callback instead of the per-row `toggle` hook. Tests cover select-all + complete and mixed-selection reopen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d340b78b0e88b3b6de2e5fdd346b564debb6db3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->