### PR TITLE
Improve note backup commit messages

### DIFF
--- a/apps/desktop/src-tauri/src/git/commit.rs
+++ b/apps/desktop/src-tauri/src/git/commit.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 
 use crate::error::AppResult;
 
+use super::commit_message::message_for_commit;
 use super::repo::{ensure_clean_state, open_existing, signature};
 
 /// A file whose *changes* were withheld from staging because it is at/above
@@ -41,7 +42,7 @@ pub struct CommitOutcome {
 /// safe: pull-applied writes match HEAD and produce no-ops.
 pub(super) fn commit_all(
     root: &Path,
-    message: &str,
+    fallback_message: &str,
     max_file_bytes: u64,
 ) -> AppResult<CommitOutcome> {
     let repo = open_existing(root)?;
@@ -73,9 +74,10 @@ pub(super) fn commit_all(
     }
 
     let tree = repo.find_tree(tree_id)?;
+    let message = message_for_commit(&repo, parent.as_ref(), &tree, fallback_message)?;
     let sig = signature(&repo)?;
     let parents: Vec<&git2::Commit> = parent.iter().collect();
-    let oid = repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &parents)?;
+    let oid = repo.commit(Some("HEAD"), &sig, &sig, &message, &tree, &parents)?;
     Ok(CommitOutcome {
         committed: true,
         sha: Some(oid.to_string()),

--- a/apps/desktop/src-tauri/src/git/commit_message.rs
+++ b/apps/desktop/src-tauri/src/git/commit_message.rs
@@ -1,0 +1,295 @@
+//! Derive concise backup commit subjects from staged graph paths.
+
+use std::path::Path;
+
+use git2::{Commit, Delta, DiffOptions, Repository, Tree};
+
+use crate::error::AppResult;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ChangeAction {
+    Add,
+    Update,
+    Delete,
+    Rename,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct TreeChange {
+    action: ChangeAction,
+    path: String,
+    old_path: Option<String>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct NoteChange {
+    action: ChangeAction,
+    label: String,
+    old_label: Option<String>,
+}
+
+/// Return a path-derived commit subject, falling back when the staged tree is
+/// metadata-only or otherwise too noisy to summarize clearly.
+pub(super) fn message_for_commit(
+    repo: &Repository,
+    parent: Option<&Commit<'_>>,
+    tree: &Tree<'_>,
+    fallback: &str,
+) -> AppResult<String> {
+    let changes = tree_changes(repo, parent, tree)?;
+    Ok(describe_changes(&changes).unwrap_or_else(|| fallback.to_string()))
+}
+
+fn tree_changes(
+    repo: &Repository,
+    parent: Option<&Commit<'_>>,
+    tree: &Tree<'_>,
+) -> AppResult<Vec<TreeChange>> {
+    let parent_tree = match parent {
+        Some(parent) => Some(parent.tree()?),
+        None => None,
+    };
+    let mut options = DiffOptions::new();
+    let diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(tree), Some(&mut options))?;
+
+    let mut changes = Vec::new();
+    diff.foreach(
+        &mut |delta, _progress| {
+            if let Some(change) = tree_change_from_delta(delta.status(), &delta) {
+                changes.push(change);
+            }
+            true
+        },
+        None,
+        None,
+        None,
+    )?;
+    Ok(changes)
+}
+
+fn tree_change_from_delta(status: Delta, delta: &git2::DiffDelta<'_>) -> Option<TreeChange> {
+    let action = match status {
+        Delta::Added | Delta::Copied => ChangeAction::Add,
+        Delta::Deleted => ChangeAction::Delete,
+        Delta::Renamed => ChangeAction::Rename,
+        Delta::Modified | Delta::Typechange => ChangeAction::Update,
+        _ => return None,
+    };
+    let path = match action {
+        ChangeAction::Delete => diff_path(delta.old_file().path())?,
+        _ => diff_path(delta.new_file().path())?,
+    };
+    let old_path = (action == ChangeAction::Rename)
+        .then(|| diff_path(delta.old_file().path()))
+        .flatten();
+    Some(TreeChange {
+        action,
+        path,
+        old_path,
+    })
+}
+
+fn diff_path(path: Option<&Path>) -> Option<String> {
+    path.map(|path| path.to_string_lossy().replace('\\', "/"))
+}
+
+fn describe_changes(changes: &[TreeChange]) -> Option<String> {
+    let content_changes: Vec<&TreeChange> = changes
+        .iter()
+        .filter(|change| !is_backup_metadata_path(&change.path))
+        .collect();
+    if content_changes.is_empty() {
+        return None;
+    }
+
+    let note_changes: Vec<NoteChange> = content_changes
+        .iter()
+        .filter_map(|change| note_change(change))
+        .collect();
+    let attachment_changes: Vec<&TreeChange> = content_changes
+        .iter()
+        .copied()
+        .filter(|change| is_attachment_path(&change.path))
+        .collect();
+    let other_count = content_changes.len() - note_changes.len() - attachment_changes.len();
+
+    if note_changes.len() == content_changes.len() {
+        return describe_note_changes(&note_changes);
+    }
+    if attachment_changes.len() == content_changes.len() {
+        return describe_group(&attachment_changes, "attachment", "attachments");
+    }
+    if !note_changes.is_empty() && other_count == 0 {
+        let action = group_action(content_changes.iter().map(|change| change.action));
+        return Some(limit_subject(format!(
+            "{} {} and {}",
+            action.verb(),
+            count_phrase(note_changes.len(), "note", "notes"),
+            count_phrase(attachment_changes.len(), "attachment", "attachments")
+        )));
+    }
+    if !note_changes.is_empty() {
+        return Some(limit_subject(format!(
+            "Update {} and {}",
+            count_phrase(note_changes.len(), "note", "notes"),
+            count_phrase(content_changes.len() - note_changes.len(), "file", "files")
+        )));
+    }
+    None
+}
+
+fn describe_note_changes(changes: &[NoteChange]) -> Option<String> {
+    match changes {
+        [] => None,
+        [change] => Some(limit_subject(match change.action {
+            ChangeAction::Add => format!("Add {}", change.label),
+            ChangeAction::Update => format!("Update {}", change.label),
+            ChangeAction::Delete => format!("Delete {}", change.label),
+            ChangeAction::Rename => match &change.old_label {
+                Some(old_label) => format!("Rename {old_label} to {}", change.label),
+                None => format!("Rename {}", change.label),
+            },
+        })),
+        changes => {
+            let action = group_action(changes.iter().map(|change| change.action));
+            Some(limit_subject(format!(
+                "{} {}",
+                action.verb(),
+                count_phrase(changes.len(), "note", "notes")
+            )))
+        }
+    }
+}
+
+fn describe_group(changes: &[&TreeChange], singular: &str, plural: &str) -> Option<String> {
+    let action = group_action(changes.iter().map(|change| change.action));
+    Some(limit_subject(format!(
+        "{} {}",
+        action.verb(),
+        count_phrase(changes.len(), singular, plural)
+    )))
+}
+
+fn group_action(actions: impl Iterator<Item = ChangeAction>) -> ChangeAction {
+    let mut actions = actions.peekable();
+    let Some(first) = actions.peek().copied() else {
+        return ChangeAction::Update;
+    };
+    if actions.all(|action| action == first) {
+        first
+    } else {
+        ChangeAction::Update
+    }
+}
+
+impl ChangeAction {
+    fn verb(self) -> &'static str {
+        match self {
+            ChangeAction::Add => "Add",
+            ChangeAction::Update => "Update",
+            ChangeAction::Delete => "Delete",
+            ChangeAction::Rename => "Rename",
+        }
+    }
+}
+
+fn note_change(change: &TreeChange) -> Option<NoteChange> {
+    let label = note_label(&change.path)?;
+    let old_label = change.old_path.as_deref().and_then(note_label);
+    Some(NoteChange {
+        action: change.action,
+        label,
+        old_label,
+    })
+}
+
+fn note_label(path: &str) -> Option<String> {
+    if let Some(date) = daily_date(path) {
+        return Some(format!("daily note for {date}"));
+    }
+
+    let stem = path
+        .strip_prefix("notes/")?
+        .strip_suffix(".md")?
+        .rsplit('/')
+        .next()?;
+    let label = humanize_stem(stem);
+    (!label.is_empty()).then_some(label)
+}
+
+fn daily_date(path: &str) -> Option<&str> {
+    let date = path.strip_prefix("daily/")?.strip_suffix(".md")?;
+    is_date_shaped(date).then_some(date)
+}
+
+fn is_date_shaped(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() == 10
+        && bytes.iter().enumerate().all(|(index, byte)| match index {
+            4 | 7 => *byte == b'-',
+            _ => byte.is_ascii_digit(),
+        })
+}
+
+fn humanize_stem(stem: &str) -> String {
+    let normalized = collapse_spaces(
+        &stem
+            .chars()
+            .map(|character| match character {
+                '-' | '_' => ' ',
+                character if character.is_control() => ' ',
+                character => character,
+            })
+            .collect::<String>(),
+    );
+    if normalized.chars().any(char::is_uppercase) {
+        return normalized;
+    }
+    title_case(&normalized)
+}
+
+fn title_case(value: &str) -> String {
+    value
+        .split_whitespace()
+        .map(|word| {
+            let mut chars = word.chars();
+            let Some(first) = chars.next() else {
+                return String::new();
+            };
+            first.to_uppercase().chain(chars).collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn collapse_spaces(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn count_phrase(count: usize, singular: &str, plural: &str) -> String {
+    if count == 1 {
+        format!("1 {singular}")
+    } else {
+        format!("{count} {plural}")
+    }
+}
+
+fn is_backup_metadata_path(path: &str) -> bool {
+    matches!(path, ".gitignore" | ".gitattributes")
+}
+
+fn is_attachment_path(path: &str) -> bool {
+    path.starts_with("assets/") || path.starts_with("audio-memos/")
+}
+
+fn limit_subject(subject: String) -> String {
+    const MAX_SUBJECT_CHARS: usize = 72;
+    if subject.chars().count() <= MAX_SUBJECT_CHARS {
+        return subject;
+    }
+    subject
+        .chars()
+        .take(MAX_SUBJECT_CHARS.saturating_sub(3))
+        .chain("...".chars())
+        .collect()
+}

--- a/apps/desktop/src-tauri/src/git/commit_message.rs
+++ b/apps/desktop/src-tauri/src/git/commit_message.rs
@@ -275,10 +275,7 @@ fn note_label(path: &str) -> Option<String> {
 
 fn authored_note_title(source: &str) -> Option<String> {
     let split = split_frontmatter(source);
-    if split
-        .raw
-        .is_some_and(|frontmatter| frontmatter_private(frontmatter))
-    {
+    if split.raw.is_some_and(frontmatter_private) {
         return None;
     }
     frontmatter_title(split.raw)

--- a/apps/desktop/src-tauri/src/git/commit_message.rs
+++ b/apps/desktop/src-tauri/src/git/commit_message.rs
@@ -1,4 +1,4 @@
-//! Derive concise backup commit subjects from staged graph paths.
+//! Derive concise backup commit subjects from staged graph note metadata.
 
 use std::path::Path;
 
@@ -28,8 +28,8 @@ struct NoteChange {
     old_label: Option<String>,
 }
 
-/// Return a path-derived commit subject, falling back when the staged tree is
-/// metadata-only or otherwise too noisy to summarize clearly.
+/// Return a staged-tree-derived commit subject, falling back when the staged
+/// tree is metadata-only or otherwise too noisy to summarize clearly.
 pub(super) fn message_for_commit(
     repo: &Repository,
     parent: Option<&Commit<'_>>,
@@ -37,7 +37,7 @@ pub(super) fn message_for_commit(
     fallback: &str,
 ) -> AppResult<String> {
     let changes = tree_changes(repo, parent, tree)?;
-    Ok(describe_changes(&changes).unwrap_or_else(|| fallback.to_string()))
+    Ok(describe_changes(repo, parent, tree, &changes).unwrap_or_else(|| fallback.to_string()))
 }
 
 fn tree_changes(
@@ -93,7 +93,12 @@ fn diff_path(path: Option<&Path>) -> Option<String> {
     path.map(|path| path.to_string_lossy().replace('\\', "/"))
 }
 
-fn describe_changes(changes: &[TreeChange]) -> Option<String> {
+fn describe_changes(
+    repo: &Repository,
+    parent: Option<&Commit<'_>>,
+    tree: &Tree<'_>,
+    changes: &[TreeChange],
+) -> Option<String> {
     let content_changes: Vec<&TreeChange> = changes
         .iter()
         .filter(|change| !is_backup_metadata_path(&change.path))
@@ -104,7 +109,7 @@ fn describe_changes(changes: &[TreeChange]) -> Option<String> {
 
     let note_changes: Vec<NoteChange> = content_changes
         .iter()
-        .filter_map(|change| note_change(change))
+        .filter_map(|change| note_change(repo, parent, tree, change))
         .collect();
     let attachment_changes: Vec<&TreeChange> = content_changes
         .iter()
@@ -193,14 +198,65 @@ impl ChangeAction {
     }
 }
 
-fn note_change(change: &TreeChange) -> Option<NoteChange> {
-    let label = note_label(&change.path)?;
-    let old_label = change.old_path.as_deref().and_then(note_label);
+fn note_change(
+    repo: &Repository,
+    parent: Option<&Commit<'_>>,
+    tree: &Tree<'_>,
+    change: &TreeChange,
+) -> Option<NoteChange> {
+    let label = staged_note_label(repo, parent, tree, change)?;
+    let old_label = change
+        .old_path
+        .as_deref()
+        .and_then(|old_path| old_note_label(repo, parent, old_path));
     Some(NoteChange {
         action: change.action,
         label,
         old_label,
     })
+}
+
+fn staged_note_label(
+    repo: &Repository,
+    parent: Option<&Commit<'_>>,
+    tree: &Tree<'_>,
+    change: &TreeChange,
+) -> Option<String> {
+    match change.action {
+        ChangeAction::Delete => old_note_label(repo, parent, &change.path),
+        _ => current_note_label(repo, tree, &change.path),
+    }
+}
+
+fn current_note_label(repo: &Repository, tree: &Tree<'_>, path: &str) -> Option<String> {
+    let fallback = note_label(path)?;
+    Some(note_title_from_tree(repo, tree, path).unwrap_or(fallback))
+}
+
+fn old_note_label(repo: &Repository, parent: Option<&Commit<'_>>, path: &str) -> Option<String> {
+    let fallback = note_label(path)?;
+    let parent_tree = parent.and_then(|parent| parent.tree().ok());
+    Some(
+        parent_tree
+            .as_ref()
+            .and_then(|tree| note_title_from_tree(repo, tree, path))
+            .unwrap_or(fallback),
+    )
+}
+
+fn note_title_from_tree(repo: &Repository, tree: &Tree<'_>, path: &str) -> Option<String> {
+    if daily_date(path).is_some() {
+        return None;
+    }
+    let source = blob_text(repo, tree, path)?;
+    authored_note_title(&source)
+}
+
+fn blob_text(repo: &Repository, tree: &Tree<'_>, path: &str) -> Option<String> {
+    let entry = tree.get_path(Path::new(path)).ok()?;
+    let object = entry.to_object(repo).ok()?;
+    let blob = object.as_blob()?;
+    std::str::from_utf8(blob.content()).ok().map(str::to_string)
 }
 
 fn note_label(path: &str) -> Option<String> {
@@ -215,6 +271,171 @@ fn note_label(path: &str) -> Option<String> {
         .next()?;
     let label = humanize_stem(stem);
     (!label.is_empty()).then_some(label)
+}
+
+fn authored_note_title(source: &str) -> Option<String> {
+    let split = split_frontmatter(source);
+    if split
+        .raw
+        .is_some_and(|frontmatter| frontmatter_private(frontmatter))
+    {
+        return None;
+    }
+    frontmatter_title(split.raw)
+        .or_else(|| first_h1(split.body))
+        .map(|title| collapse_spaces(&title))
+        .filter(|title| !title.is_empty())
+}
+
+struct FrontmatterSplit<'source> {
+    raw: Option<&'source str>,
+    body: &'source str,
+}
+
+fn split_frontmatter(source: &str) -> FrontmatterSplit<'_> {
+    let no_block = FrontmatterSplit {
+        raw: None,
+        body: source,
+    };
+    let Some(open_len) = fence_line_len(source) else {
+        return no_block;
+    };
+    let rest = &source[open_len..];
+    if let Some(close_len) = fence_line_len(rest) {
+        return FrontmatterSplit {
+            raw: Some(""),
+            body: &rest[close_len..],
+        };
+    }
+
+    let mut search_from = 0;
+    while let Some(newline_at) = rest[search_from..].find('\n').map(|at| search_from + at) {
+        let line_start = newline_at + 1;
+        if let Some(close_len) = fence_line_len(&rest[line_start..]) {
+            let raw_end = if newline_at > 0 && rest.as_bytes()[newline_at - 1] == b'\r' {
+                newline_at - 1
+            } else {
+                newline_at
+            };
+            return FrontmatterSplit {
+                raw: Some(&rest[..raw_end]),
+                body: &rest[line_start + close_len..],
+            };
+        }
+        search_from = line_start;
+    }
+    no_block
+}
+
+fn fence_line_len(text: &str) -> Option<usize> {
+    let rest = text.strip_prefix("---")?;
+    let bytes = rest.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() && (bytes[index] == b' ' || bytes[index] == b'\t') {
+        index += 1;
+    }
+    match bytes.get(index) {
+        None => Some(3 + index),
+        Some(b'\n') => Some(3 + index + 1),
+        Some(b'\r') if bytes.get(index + 1) == Some(&b'\n') => Some(3 + index + 2),
+        _ => None,
+    }
+}
+
+fn frontmatter_title(raw: Option<&str>) -> Option<String> {
+    frontmatter_scalar(raw?, "title").filter(|title| !title.trim().is_empty())
+}
+
+fn frontmatter_private(raw: &str) -> bool {
+    frontmatter_scalar(raw, "private")
+        .map(|value| {
+            matches!(
+                value.trim().to_lowercase().as_str(),
+                "true" | "yes" | "on" | "1"
+            )
+        })
+        .unwrap_or(false)
+}
+
+fn frontmatter_scalar(raw: &str, key: &str) -> Option<String> {
+    for line in raw.lines() {
+        let Some((candidate, value)) = line.split_once(':') else {
+            continue;
+        };
+        if candidate.trim() == key {
+            return Some(unquote_scalar(value.trim()));
+        }
+    }
+    None
+}
+
+fn unquote_scalar(value: &str) -> String {
+    let without_comment = value
+        .split_once(" #")
+        .map(|(head, _comment)| head)
+        .unwrap_or(value)
+        .trim();
+    if without_comment.len() >= 2 {
+        let bytes = without_comment.as_bytes();
+        let first = bytes[0];
+        let last = bytes[without_comment.len() - 1];
+        if (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'') {
+            return without_comment[1..without_comment.len() - 1].to_string();
+        }
+    }
+    without_comment.to_string()
+}
+
+fn first_h1(body: &str) -> Option<String> {
+    let lines: Vec<&str> = body.lines().collect();
+    let mut in_fence = false;
+    for (index, line) in lines.iter().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        if let Some(heading) = atx_h1(trimmed) {
+            return Some(heading);
+        }
+        if index + 1 < lines.len() && is_setext_h1(lines[index + 1]) {
+            let heading = clean_heading_text(line);
+            if !heading.is_empty() {
+                return Some(heading);
+            }
+        }
+    }
+    None
+}
+
+fn atx_h1(line: &str) -> Option<String> {
+    let rest = line.strip_prefix('#')?;
+    if rest.starts_with('#') {
+        return None;
+    }
+    if !rest.is_empty() && !rest.starts_with([' ', '\t']) {
+        return None;
+    }
+    let heading = clean_heading_text(rest);
+    (!heading.is_empty()).then_some(heading)
+}
+
+fn is_setext_h1(line: &str) -> bool {
+    let trimmed = line.trim();
+    !trimmed.is_empty() && trimmed.chars().all(|character| character == '=')
+}
+
+fn clean_heading_text(raw: &str) -> String {
+    let text = raw
+        .trim()
+        .trim_end_matches('#')
+        .trim_end()
+        .trim_end_matches('#')
+        .trim();
+    text.to_string()
 }
 
 fn daily_date(path: &str) -> Option<&str> {

--- a/apps/desktop/src-tauri/src/git/commit_message.rs
+++ b/apps/desktop/src-tauri/src/git/commit_message.rs
@@ -28,6 +28,12 @@ struct NoteChange {
     old_label: Option<String>,
 }
 
+#[derive(Debug, Eq, PartialEq)]
+enum AuthoredNoteTitle {
+    Public(String),
+    Private,
+}
+
 /// Return a staged-tree-derived commit subject, falling back when the staged
 /// tree is metadata-only or otherwise too noisy to summarize clearly.
 pub(super) fn message_for_commit(
@@ -50,7 +56,8 @@ fn tree_changes(
         None => None,
     };
     let mut options = DiffOptions::new();
-    let diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(tree), Some(&mut options))?;
+    let mut diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(tree), Some(&mut options))?;
+    diff.find_similar(None)?;
 
     let mut changes = Vec::new();
     diff.foreach(
@@ -134,8 +141,10 @@ fn describe_changes(
         )));
     }
     if !note_changes.is_empty() {
+        let action = group_action(content_changes.iter().map(|change| change.action));
         return Some(limit_subject(format!(
-            "Update {} and {}",
+            "{} {} and {}",
+            action.verb(),
             count_phrase(note_changes.len(), "note", "notes"),
             count_phrase(content_changes.len() - note_changes.len(), "file", "files")
         )));
@@ -230,25 +239,40 @@ fn staged_note_label(
 
 fn current_note_label(repo: &Repository, tree: &Tree<'_>, path: &str) -> Option<String> {
     let fallback = note_label(path)?;
-    Some(note_title_from_tree(repo, tree, path).unwrap_or(fallback))
+    Some(match note_title_from_tree(repo, tree, path) {
+        Some(AuthoredNoteTitle::Public(title)) => title,
+        Some(AuthoredNoteTitle::Private) => "private note".to_string(),
+        None => fallback,
+    })
 }
 
 fn old_note_label(repo: &Repository, parent: Option<&Commit<'_>>, path: &str) -> Option<String> {
     let fallback = note_label(path)?;
     let parent_tree = parent.and_then(|parent| parent.tree().ok());
     Some(
-        parent_tree
+        match parent_tree
             .as_ref()
             .and_then(|tree| note_title_from_tree(repo, tree, path))
-            .unwrap_or(fallback),
+        {
+            Some(AuthoredNoteTitle::Public(title)) => title,
+            Some(AuthoredNoteTitle::Private) => "private note".to_string(),
+            None => fallback,
+        },
     )
 }
 
-fn note_title_from_tree(repo: &Repository, tree: &Tree<'_>, path: &str) -> Option<String> {
+fn note_title_from_tree(
+    repo: &Repository,
+    tree: &Tree<'_>,
+    path: &str,
+) -> Option<AuthoredNoteTitle> {
+    let source = blob_text(repo, tree, path)?;
+    if note_is_private(&source) {
+        return Some(AuthoredNoteTitle::Private);
+    }
     if daily_date(path).is_some() {
         return None;
     }
-    let source = blob_text(repo, tree, path)?;
     authored_note_title(&source)
 }
 
@@ -273,15 +297,19 @@ fn note_label(path: &str) -> Option<String> {
     (!label.is_empty()).then_some(label)
 }
 
-fn authored_note_title(source: &str) -> Option<String> {
+fn authored_note_title(source: &str) -> Option<AuthoredNoteTitle> {
     let split = split_frontmatter(source);
-    if split.raw.is_some_and(frontmatter_private) {
-        return None;
-    }
     frontmatter_title(split.raw)
         .or_else(|| first_h1(split.body))
         .map(|title| collapse_spaces(&title))
         .filter(|title| !title.is_empty())
+        .map(AuthoredNoteTitle::Public)
+}
+
+fn note_is_private(source: &str) -> bool {
+    split_frontmatter(source)
+        .raw
+        .is_some_and(frontmatter_private)
 }
 
 struct FrontmatterSplit<'source> {
@@ -367,20 +395,29 @@ fn frontmatter_scalar(raw: &str, key: &str) -> Option<String> {
 }
 
 fn unquote_scalar(value: &str) -> String {
-    let without_comment = value
-        .split_once(" #")
-        .map(|(head, _comment)| head)
-        .unwrap_or(value)
-        .trim();
-    if without_comment.len() >= 2 {
-        let bytes = without_comment.as_bytes();
-        let first = bytes[0];
-        let last = bytes[without_comment.len() - 1];
-        if (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'') {
-            return without_comment[1..without_comment.len() - 1].to_string();
+    let trimmed = value.trim();
+    if trimmed.len() >= 2 {
+        let bytes = trimmed.as_bytes();
+        let quote = bytes[0];
+        if quote == b'"' || quote == b'\'' {
+            if let Some(end) = trimmed[1..]
+                .bytes()
+                .position(|byte| byte == quote)
+                .map(|index| index + 1)
+            {
+                let trailing = trimmed[end + 1..].trim_start();
+                if trailing.is_empty() || trailing.starts_with('#') {
+                    return trimmed[1..end].to_string();
+                }
+            }
         }
     }
-    without_comment.to_string()
+    trimmed
+        .split_once(" #")
+        .map(|(head, _comment)| head)
+        .unwrap_or(trimmed)
+        .trim()
+        .to_string()
 }
 
 fn first_h1(body: &str) -> Option<String> {

--- a/apps/desktop/src-tauri/src/git/mod.rs
+++ b/apps/desktop/src-tauri/src/git/mod.rs
@@ -16,6 +16,7 @@
 //! The one exception is `git_clone`, which runs before any graph is open.
 
 mod commit;
+mod commit_message;
 mod merge;
 mod remote;
 mod repo;

--- a/apps/desktop/src-tauri/src/git/tests.rs
+++ b/apps/desktop/src-tauri/src/git/tests.rs
@@ -36,6 +36,12 @@ fn read(root: &Path, rel: &str) -> String {
     fs::read_to_string(root.join(rel)).unwrap()
 }
 
+fn head_message(root: &Path) -> String {
+    let repo = Repository::open(root).unwrap();
+    let commit = repo.head().unwrap().peel_to_commit().unwrap();
+    commit.message().unwrap().trim().to_string()
+}
+
 /// A bare remote + a primary graph connected to it.
 struct Fixture {
     _dir: TempDir,
@@ -132,6 +138,68 @@ fn commit_excludes_reflect_and_skips_when_clean() {
 
     let second = commit_all(root, "Update notes", MAX_FILE_BYTES).unwrap();
     assert!(!second.committed, "clean tree must not produce a commit");
+}
+
+#[test]
+fn commit_describes_single_note_changes() {
+    let fixture = fixture();
+    let root = &fixture.graph_a;
+
+    write(root, "notes/project-atlas.md", "# Project Atlas\n");
+    commit_all(root, "Update notes", MAX_FILE_BYTES).unwrap();
+    assert_eq!(head_message(root), "Add Project Atlas");
+
+    write(
+        root,
+        "notes/project-atlas.md",
+        "# Project Atlas\n\nNext step\n",
+    );
+    commit_all(root, "Update notes", MAX_FILE_BYTES).unwrap();
+    assert_eq!(head_message(root), "Update Project Atlas");
+
+    fs::remove_file(root.join("notes/project-atlas.md")).unwrap();
+    commit_all(root, "Update notes", MAX_FILE_BYTES).unwrap();
+    assert_eq!(head_message(root), "Delete Project Atlas");
+}
+
+#[test]
+fn commit_summarizes_note_batches() {
+    let fixture = fixture();
+    let root = &fixture.graph_a;
+
+    write(root, "daily/2026-06-23.md", "# Daily\n");
+    write(root, "notes/project-atlas.md", "# Project Atlas\n");
+    commit_all(root, "Update notes", MAX_FILE_BYTES).unwrap();
+    assert_eq!(head_message(root), "Add 2 notes");
+
+    write(root, "daily/2026-06-23.md", "# Daily\n\n- one\n");
+    write(
+        root,
+        "notes/project-atlas.md",
+        "# Project Atlas\n\nNext step\n",
+    );
+    commit_all(root, "Update notes", MAX_FILE_BYTES).unwrap();
+    assert_eq!(head_message(root), "Update 2 notes");
+}
+
+#[test]
+fn commit_mentions_note_and_attachment_batches() {
+    let fixture = fixture();
+    let root = &fixture.graph_a;
+
+    write(root, "notes/capture.md", "# Capture\n");
+    write(root, "assets/screenshot.png", "not really a png\n");
+    commit_all(root, "Update notes", MAX_FILE_BYTES).unwrap();
+    assert_eq!(head_message(root), "Add 1 note and 1 attachment");
+}
+
+#[test]
+fn commit_falls_back_for_metadata_only_changes() {
+    let fixture = fixture();
+    let root = &fixture.graph_a;
+
+    commit_all(root, "Update notes", MAX_FILE_BYTES).unwrap();
+    assert_eq!(head_message(root), "Update notes");
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/git/tests.rs
+++ b/apps/desktop/src-tauri/src/git/tests.rs
@@ -170,10 +170,10 @@ fn commit_uses_authored_note_subjects() {
     write(
         root,
         "notes/01arz3ndektsv4rrffq69g5fav.md",
-        "---\ntitle: Project Atlas\n---\n# Ignored H1\n",
+        "---\ntitle: \"Project #1\"\n---\n# Ignored H1\n",
     );
     commit_all(root, "Update notes", MAX_FILE_BYTES).unwrap();
-    assert_eq!(head_message(root), "Add Project Atlas");
+    assert_eq!(head_message(root), "Add Project #1");
 
     write(
         root,
@@ -189,6 +189,28 @@ fn commit_uses_authored_note_subjects() {
 }
 
 #[test]
+fn commit_describes_note_renames() {
+    let fixture = fixture();
+    let root = &fixture.graph_a;
+
+    write(
+        root,
+        "notes/original.md",
+        "# Original Name\n\n- stable body line one\n- stable body line two\n- stable body line three\n",
+    );
+    commit_all(root, "Update notes", MAX_FILE_BYTES).unwrap();
+
+    fs::remove_file(root.join("notes/original.md")).unwrap();
+    write(
+        root,
+        "notes/renamed.md",
+        "# Renamed Name\n\n- stable body line one\n- stable body line two\n- stable body line three\n",
+    );
+    commit_all(root, "Update notes", MAX_FILE_BYTES).unwrap();
+    assert_eq!(head_message(root), "Rename Original Name to Renamed Name");
+}
+
+#[test]
 fn commit_does_not_leak_private_authored_titles() {
     let fixture = fixture();
     let root = &fixture.graph_a;
@@ -199,7 +221,7 @@ fn commit_does_not_leak_private_authored_titles() {
         "---\nprivate: true\ntitle: Secret Plan\n---\n# Secret Heading\n",
     );
     commit_all(root, "Update notes", MAX_FILE_BYTES).unwrap();
-    assert_eq!(head_message(root), "Add Private Project");
+    assert_eq!(head_message(root), "Add private note");
 }
 
 #[test]
@@ -231,6 +253,17 @@ fn commit_mentions_note_and_attachment_batches() {
     write(root, "assets/screenshot.png", "not really a png\n");
     commit_all(root, "Update notes", MAX_FILE_BYTES).unwrap();
     assert_eq!(head_message(root), "Add 1 note and 1 attachment");
+}
+
+#[test]
+fn commit_describes_mixed_note_and_file_batches_by_action() {
+    let fixture = fixture();
+    let root = &fixture.graph_a;
+
+    write(root, "notes/capture.md", "# Capture\n");
+    write(root, "books/book.json", "{}\n");
+    commit_all(root, "Update notes", MAX_FILE_BYTES).unwrap();
+    assert_eq!(head_message(root), "Add 1 note and 1 file");
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/git/tests.rs
+++ b/apps/desktop/src-tauri/src/git/tests.rs
@@ -163,6 +163,46 @@ fn commit_describes_single_note_changes() {
 }
 
 #[test]
+fn commit_uses_authored_note_subjects() {
+    let fixture = fixture();
+    let root = &fixture.graph_a;
+
+    write(
+        root,
+        "notes/01arz3ndektsv4rrffq69g5fav.md",
+        "---\ntitle: Project Atlas\n---\n# Ignored H1\n",
+    );
+    commit_all(root, "Update notes", MAX_FILE_BYTES).unwrap();
+    assert_eq!(head_message(root), "Add Project Atlas");
+
+    write(
+        root,
+        "notes/01arz3ndektsv4rrffq69g5fav.md",
+        "# Launch Review\n\n- agenda\n",
+    );
+    commit_all(root, "Update notes", MAX_FILE_BYTES).unwrap();
+    assert_eq!(head_message(root), "Update Launch Review");
+
+    fs::remove_file(root.join("notes/01arz3ndektsv4rrffq69g5fav.md")).unwrap();
+    commit_all(root, "Update notes", MAX_FILE_BYTES).unwrap();
+    assert_eq!(head_message(root), "Delete Launch Review");
+}
+
+#[test]
+fn commit_does_not_leak_private_authored_titles() {
+    let fixture = fixture();
+    let root = &fixture.graph_a;
+
+    write(
+        root,
+        "notes/private-project.md",
+        "---\nprivate: true\ntitle: Secret Plan\n---\n# Secret Heading\n",
+    );
+    commit_all(root, "Update notes", MAX_FILE_BYTES).unwrap();
+    assert_eq!(head_message(root), "Add Private Project");
+}
+
+#[test]
 fn commit_summarizes_note_batches() {
     let fixture = fixture();
     let root = &fixture.graph_a;

--- a/packages/core/src/sync/commands.ts
+++ b/packages/core/src/sync/commands.ts
@@ -111,9 +111,15 @@ export async function gitClone(url: string, path: string, token: string | null):
   await call('git_clone', { url, path, token }, z.null())
 }
 
-/** Commit every pending change (no-op when the tree is clean). */
-export async function gitCommitAll(message: string, generation: number): Promise<CommitOutcome> {
-  return call('git_commit_all', { message, generation }, commitOutcomeSchema)
+/**
+ * Commit every pending change (no-op when the tree is clean). `fallbackMessage`
+ * is used only when Rust cannot derive a clearer subject from staged paths.
+ */
+export async function gitCommitAll(
+  fallbackMessage: string,
+  generation: number,
+): Promise<CommitOutcome> {
+  return call('git_commit_all', { message: fallbackMessage, generation }, commitOutcomeSchema)
 }
 
 /** Fetch `origin`; returns ahead/behind for the current branch. */


### PR DESCRIPTION
## Summary
- derive backup commit subjects from the staged Git tree before committing
- use authored note subjects from frontmatter `title` or the first H1 for single-note commits, falling back to readable paths
- keep daily notes date-based, summarize multi-note/attachment batches, and avoid authored-title extraction for `private: true` notes
- document the fallback-message contract and add Rust git tests for path, authored-title, private-note, and batch subjects

## Testing
- pnpm --filter @reflect/desktop sidecar
- cargo test -p reflect-open git::tests -- --nocapture
- pnpm check (passes with existing lint warnings)
- pnpm build (passes with existing chunk-size warning)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Commit descriptions are now automatically generated from staged changes into concise subjects (e.g., note adds/updates/deletes, renames, mixed note+attachment batches).
  * Authored note titles are used when available; private titles are omitted in favor of a safer fallback.
  * If a meaningful summary can’t be derived, your provided fallback text is used.
* **Tests**
  * Added integration coverage for note lifecycle, batching, mixed subjects, rename behavior, private-title handling, and metadata-only fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to commit message text on the backup path; sync/commit mechanics and the Tauri IPC shape are unchanged aside from clearer fallback semantics.
> 
> **Overview**
> Backup commits no longer always use the generic sync string (`Update notes`). **`commit_all`** now builds the subject from the staged tree diff via new **`commit_message`** logic, and only uses the caller’s **`fallbackMessage`** when there’s nothing meaningful to summarize (e.g. metadata-only).
> 
> **Single-note** commits get action-specific lines like `Add Project Atlas` or `Rename Original Name to Renamed Name`, using frontmatter **`title`**, else the first **H1**, else a humanized path; **daily** notes stay date-based (`daily note for …`). **`private: true`** notes never expose authored titles—subjects use **`private note`**. **Batches** collapse to phrases such as `Update 2 notes`, `Add 1 note and 1 attachment`, or mixed note/file counts; subjects are capped at **72** characters.
> 
> **`gitCommitAll`** in core documents that the message is a **fallback** only (IPC field name unchanged). Rust **integration tests** cover single-note, authored titles, renames, privacy, batches, and metadata fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f81980577f78ee9068d0220b4d072bdc45eb5b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->