### PR TITLE
feat(desktop): open All Notes filtered by tag on `#tag` click

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,8 +19,8 @@
     "tauri:build:beta": "tauri build --config src-tauri/tauri.beta.conf.json"
   },
   "dependencies": {
-    "@meowdown/core": "0.21.1",
-    "@meowdown/react": "0.21.1",
+    "@meowdown/core": "0.22.0",
+    "@meowdown/react": "0.22.0",
     "@reflect/core": "workspace:*",
     "@reflect/db": "workspace:*",
     "@reflect/design-system": "workspace:*",

--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -11,6 +11,7 @@ import { NoteEditor, type NoteEditorHandle } from '@/editor/note-editor'
 import { useEditorAutocomplete } from '@/editor/use-editor-autocomplete'
 import { useImagePersistence } from '@/editor/use-image-persistence'
 import { useNoteDocument } from '@/editor/use-note-document'
+import { useTagNavigation } from '@/editor/use-tag-navigation'
 import { useWikiLinkNavigation } from '@/editor/use-wiki-link-navigation'
 import { untitledNoteSeed } from '@/lib/create-note'
 import { cn } from '@/lib/utils'
@@ -107,6 +108,7 @@ export function NotePaneComponent({
     saveError: imageSaveError,
   } = useImagePersistence(graphRoot, generation)
   const onWikiLinkClick = useWikiLinkNavigation(generation)
+  const onTagClick = useTagNavigation()
   const { onWikilinkSearch, onTagSearch } = useEditorAutocomplete()
 
   const bindEditor = document.bindEditor
@@ -222,6 +224,7 @@ export function NotePaneComponent({
         saveImage={saveImage}
         onImageSaveError={onImageSaveError}
         onWikiLinkClick={onWikiLinkClick}
+        onTagClick={onTagClick}
         onWikilinkSearch={onWikilinkSearch}
         onTagSearch={onTagSearch}
         // Daily notes carry no title semantics (the date is their subject),

--- a/apps/desktop/src/components/tasks/task-editor.tsx
+++ b/apps/desktop/src/components/tasks/task-editor.tsx
@@ -12,6 +12,7 @@ import { type OpenTask } from '@reflect/core'
 import { markModeFromSyntax } from '@/editor/mark-mode'
 import { NoteEditor, type NoteEditorHandle } from '@/editor/note-editor'
 import { useEditorAutocomplete } from '@/editor/use-editor-autocomplete'
+import { useTagNavigation } from '@/editor/use-tag-navigation'
 import { useWikiLinkNavigation } from '@/editor/use-wiki-link-navigation'
 import { taskContent } from '@/lib/tasks/task-content'
 import { useTaskEditorFinalizer, type TaskEditorApi } from '@/lib/tasks/use-task-editor-finalizer'
@@ -162,6 +163,7 @@ export function TaskEditor({
   const { settings } = useSettings()
   const generation = graph?.generation ?? null
   const navigate = useWikiLinkNavigation(generation)
+  const onTagClick = useTagNavigation()
   const { onWikilinkSearch, onTagSearch } = useEditorAutocomplete()
 
   // Frozen at mount: the editor is seeded once (uncontrolled), so the commit
@@ -217,6 +219,7 @@ export function TaskEditor({
         // A one-line editor has nothing to reorder, so keep the gutter grip off.
         blockHandle={false}
         onWikiLinkClick={navigate}
+        onTagClick={onTagClick}
         onWikilinkSearch={onWikilinkSearch}
         onTagSearch={onTagSearch}
         className="reflect-task-editor text-sm leading-6"

--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -14,6 +14,7 @@ interface CapturedEditorProps {
   resolveImageUrl?: (src: string) => string | undefined
   onImageClick?: (payload: { src: string; alt: string; event: MouseEvent }) => void
   onLinkClick?: (payload: { href: string; event: MouseEvent }) => void
+  onTagClick?: (payload: { tag: string; event: MouseEvent }) => void
 }
 
 const captured = vi.hoisted(() => ({ props: null as CapturedEditorProps | null }))
@@ -122,6 +123,18 @@ describe('NoteEditor markdown syntax mode', () => {
   it('passes an explicit markdown syntax mode to meowdown', () => {
     render(<NoteEditor initialContent="" markMode="show" />)
     expect(captured.props?.mode).toBe('show')
+  })
+})
+
+describe('NoteEditor tag click', () => {
+  it('forwards a clicked tag name, without the leading #', () => {
+    const onTagClick = vi.fn()
+    render(<NoteEditor initialContent="" onTagClick={onTagClick} />)
+    expect(captured.props?.onTagClick).toBeTypeOf('function')
+
+    const event = new MouseEvent('click', { bubbles: true })
+    act(() => captured.props?.onTagClick?.({ tag: 'book', event }))
+    expect(onTagClick).toHaveBeenCalledWith('book')
   })
 })
 

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -86,6 +86,8 @@ interface NoteEditorProps {
   onImageSaveError?: (error: unknown, file: File) => void
   /** Click on a `[[wiki link]]`. */
   onWikiLinkClick?: (target: string) => void
+  /** Click on an inline `#tag`. The tag name arrives without the leading `#`. */
+  onTagClick?: (tag: string) => void
   /** Search notes for the `[[` autocomplete menu. */
   onWikilinkSearch?: WikilinkSearchHandler
   /** Search tags for the `#` autocomplete menu. */
@@ -124,6 +126,7 @@ export function NoteEditor({
   saveImage,
   onImageSaveError,
   onWikiLinkClick,
+  onTagClick,
   onWikilinkSearch,
   onTagSearch,
   children,
@@ -138,6 +141,7 @@ export function NoteEditor({
   // TODO: This violates "Rule of hooks". Refactor this later.
   const onChangeRef = useRef(onChange)
   const onWikiLinkClickRef = useRef(onWikiLinkClick)
+  const onTagClickRef = useRef(onTagClick)
   const resolveImageUrlRef = useRef(resolveImageUrl)
   const resolveImageOpenPathRef = useRef(resolveImageOpenPath)
   const openImageRef = useRef(openImage)
@@ -146,6 +150,7 @@ export function NoteEditor({
   useEffect(() => {
     onChangeRef.current = onChange
     onWikiLinkClickRef.current = onWikiLinkClick
+    onTagClickRef.current = onTagClick
     resolveImageUrlRef.current = resolveImageUrl
     resolveImageOpenPathRef.current = resolveImageOpenPath
     openImageRef.current = openImage
@@ -174,6 +179,10 @@ export function NoteEditor({
   }, [])
   const handleWikilinkClick = useCallback(
     (payload: { target: string }) => onWikiLinkClickRef.current?.(payload.target),
+    [],
+  )
+  const handleTagClick = useCallback(
+    (payload: { tag: string }) => onTagClickRef.current?.(payload.tag),
     [],
   )
   const handleResolveImageUrl = useCallback(
@@ -239,6 +248,7 @@ export function NoteEditor({
         {...(titlePlaceholder !== undefined ? { placeholder: titlePlaceholder } : {})}
         onDocChange={handleDocChange}
         onWikilinkClick={handleWikilinkClick}
+        onTagClick={handleTagClick}
         onLinkClick={handleLinkClick}
         onImageClick={handleImageClick}
         {...(onWikilinkSearch !== undefined ? { onWikilinkSearch } : {})}

--- a/apps/desktop/src/editor/use-tag-navigation.test.tsx
+++ b/apps/desktop/src/editor/use-tag-navigation.test.tsx
@@ -1,0 +1,39 @@
+import { act, render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import type { ReactNode } from 'react'
+import { RouterProvider, useRouter } from '@/routing/router'
+import { useTagNavigation } from './use-tag-navigation'
+
+let lastHandler: ((tag: string) => void) | null = null
+
+function Host(): ReactNode {
+  lastHandler = useTagNavigation()
+  return null
+}
+
+function RouteProbe(): ReactNode {
+  const { route } = useRouter()
+  return <output data-testid="route">{JSON.stringify(route)}</output>
+}
+
+function renderHost() {
+  return render(
+    <RouterProvider>
+      <Host />
+      <RouteProbe />
+    </RouterProvider>,
+  )
+}
+
+function currentRoute(view: ReturnType<typeof renderHost>): string {
+  return view.getByTestId('route').textContent ?? ''
+}
+
+describe('useTagNavigation', () => {
+  it('opens All Notes filtered by the clicked tag', () => {
+    const view = renderHost()
+    act(() => lastHandler?.('book'))
+    expect(JSON.parse(currentRoute(view))).toEqual({ kind: 'allNotes', tag: 'book' })
+    view.unmount()
+  })
+})

--- a/apps/desktop/src/editor/use-tag-navigation.ts
+++ b/apps/desktop/src/editor/use-tag-navigation.ts
@@ -1,0 +1,21 @@
+import { useCallback } from 'react'
+import { useRouter } from '@/routing/router'
+
+/**
+ * Navigation for a clicked inline `#tag`: open the All Notes screen filtered by
+ * that tag. The tag name arrives without its leading `#` (meowdown strips it),
+ * and feeds straight into the `allNotes` route's tag facet — the same route the
+ * All Notes filter tabs and the chat tag chips already drive.
+ *
+ * @returns a stable click handler for the note editor's tag extension.
+ */
+export function useTagNavigation(): (tag: string) => void {
+  const { navigate } = useRouter()
+
+  return useCallback(
+    (tag: string) => {
+      navigate({ kind: 'allNotes', tag })
+    },
+    [navigate],
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,11 +21,11 @@ importers:
   apps/desktop:
     dependencies:
       '@meowdown/core':
-        specifier: 0.21.1
-        version: 0.21.1(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+        specifier: 0.22.0
+        version: 0.22.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       '@meowdown/react':
-        specifier: 0.21.1
-        version: 0.21.1(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 0.22.0
+        version: 0.22.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@reflect/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -1008,11 +1008,11 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
-  '@meowdown/core@0.21.1':
-    resolution: {integrity: sha512-XAEYaQsCrCaxyEmHde9zwVyF8QtRNvB+xhf5O5KSH3wa8pvMuzp38BBRYXQWGmVDhTObAPrw/EzF5KMVKkaAnw==}
+  '@meowdown/core@0.22.0':
+    resolution: {integrity: sha512-bkkr/q/OeE9nKUH6mOMiwYnBku3NrqPOQWrb6ax5Zwk4579uN3vuxAXyI/XpOx5ZvYxBa1Fcsdf3yEJswMhCdQ==}
 
-  '@meowdown/react@0.21.1':
-    resolution: {integrity: sha512-IgZ1xPSphv7+3I9/LCmhWx2BVHzLqHObLLps1vrZu9VQUU13vZ93EAycA2LnENXKJ2XlIMxC3VXgj8VQMTNJRA==}
+  '@meowdown/react@0.22.0':
+    resolution: {integrity: sha512-1XT86+6zVk8XaxSX36jrEwZXeuKL+U1nvybyYH2CXyyb0PzpiwsPKI5dPf17vMCacr8eajJjXdnFwzjQoeG7jA==}
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
@@ -6913,7 +6913,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@meowdown/core@0.21.1(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
+  '@meowdown/core@0.22.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
     dependencies:
       '@codemirror/language': 6.12.3
       '@codemirror/language-data': 6.5.2
@@ -6948,7 +6948,7 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@meowdown/react@0.21.1(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@meowdown/react@0.22.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@base-ui/react': 1.6.0(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@codemirror/commands': 6.10.3
@@ -6956,7 +6956,7 @@ snapshots:
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.43.1
-      '@meowdown/core': 0.21.1(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+      '@meowdown/core': 0.22.0(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       '@ocavue/utils': 1.7.0
       '@prosekit/core': 0.13.0-beta.3(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosekit/pm': 0.1.19-beta.0


### PR DESCRIPTION
Clicking an inline `#tag` in the note or task editor now opens the All Notes screen filtered by that tag, via meowdown v0.22.0's new `onTagClick` prop (wired through the same `allNotes` route the filter tabs and chat tag chips already use).

This restores the tag-link behavior that existed before `MarkdownPreview` moved to meowdown's `MarkdownView`. Scope note: it covers the live editor (note + task); read-only chat answer previews render via `MarkdownView`, which does not expose `onTagClick` yet, so they are not included here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Clicking on tags (`#tag`) within the note editor now navigates to the all notes view filtered by that tag.

* **Chores**
  * Updated `@meowdown/core` and `@meowdown/react` dependencies to v0.22.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->