### PR TITLE
chore: bump app version to v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.2.1"
+version = "0.2.2"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
## Summary
- bump Reflect desktop app metadata from 0.2.1 to 0.2.2
- update the reflect-open Cargo.lock entry to match

## Testing
- pnpm check
- pnpm --filter @reflect/desktop test --run scripts/release-bump.test.mjs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no runtime, security, or behavioral code changes.
> 
> **Overview**
> Bumps the Reflect desktop release version from **0.2.1** to **0.2.2** in `reflect-open`’s `Cargo.toml`, `tauri.conf.json`, and the matching `reflect-open` entry in the root `Cargo.lock`.
> 
> No application or dependency logic changes—only version metadata for packaging and the auto-updater release flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cecef07e88fba97c4cafbad5ae607374f1f8002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->