### PR TITLE
feat(backup): make "grant repo access" a first-class connect step

### DIFF
--- a/apps/desktop/src/components/settings/connect-github-dialog.test.tsx
+++ b/apps/desktop/src/components/settings/connect-github-dialog.test.tsx
@@ -268,12 +268,15 @@ describe('ConnectGithubDialog', () => {
     expect(screen.getByText(/github\.com\/new\?name=g-backup/)).toBeTruthy()
   })
 
-  it('routes an app sign-in that cannot see the repo to the install flow', async () => {
-    // GitHub's 404 can't distinguish "doesn't exist" from "no access", and
-    // for app sign-ins it's almost always the latter — so granting access
-    // is the remedy, with no token language anywhere.
+  it('routes an app sign-in that cannot see the repo to the grant-access step, then polls', async () => {
+    // A GitHub App user token only reaches repos the app is installed on, so a
+    // 404 for an app sign-in almost always means "not installed here": granting
+    // access is the expected step (not an error), and the poll connects once it
+    // lands — no retry button, no token language.
     storeCredential(appCredential())
-    sync.connectExistingRepo.mockResolvedValueOnce('notFound')
+    sync.connectExistingRepo
+      .mockResolvedValueOnce('notFound') // initial lookup: app can't see it yet
+      .mockResolvedValueOnce('notFound') // poll: access still not granted
     const onClose = renderWizard()
 
     fireEvent.click(screen.getByRole('radio', { name: /use an existing repository/i }))
@@ -282,23 +285,44 @@ describe('ConnectGithubDialog', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
 
-    expect(await screen.findByText(/grant it access/i)).toBeTruthy()
+    // A plain "give access" step that names the repo and steers to a per-repo
+    // grant (never "All repositories").
+    expect(await screen.findByText(/give reflect access to/i)).toBeTruthy()
+    expect(screen.getByText(/only select repositories/i)).toBeTruthy()
+    expect(screen.queryByText(/all repositories/i)).toBeNull()
     expect(screen.queryByText(/token/i)).toBeNull()
+    expect(screen.queryByRole('button', { name: /try again/i })).toBeNull()
 
     fireEvent.click(screen.getByRole('button', { name: 'Grant access on GitHub…' }))
     expect(openedUrls).toHaveBeenCalledWith(
       'https://github.com/apps/reflect-github-app/installations/new',
     )
 
-    // Back from the browser with access granted: the retry connects.
-    fireEvent.click(screen.getByRole('button', { name: 'I granted it — try again' }))
+    // Back from the browser with access granted — the poll connects, no click.
     await waitFor(() =>
       expect(sync.connectExistingRepo).toHaveBeenLastCalledWith(
         { owner: 'alex', name: 'notes' },
         { allowPublic: false },
       ),
     )
-    expect(onClose).toHaveBeenCalled()
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+    expect(sync.connectExistingRepo.mock.calls.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('skips the grant-access step when an app sign-in can already see the repo', async () => {
+    // A returning user whose install already covers the repo: the first lookup
+    // succeeds, so there's no grant-access detour — the dialog just connects.
+    storeCredential(appCredential())
+    const onClose = renderWizard()
+
+    fireEvent.click(screen.getByRole('radio', { name: /use an existing repository/i }))
+    fireEvent.change(screen.getByLabelText('Existing repository'), {
+      target: { value: 'alex/notes' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+    expect(screen.queryByText(/give reflect access/i)).toBeNull()
   })
 
   it('points the app create guide at granting access, not token scope', async () => {

--- a/apps/desktop/src/components/settings/connect-github-dialog.tsx
+++ b/apps/desktop/src/components/settings/connect-github-dialog.tsx
@@ -57,10 +57,17 @@ const STEP_DESCRIPTIONS: Record<Step, string> = {
  * every note in the graph, including `private: true` ones, would be
  * world-readable.
  *
- * "Can't find the repo" keeps one remedy per credential kind: app sign-ins
- * route to the GitHub App install page (authorization ≠ installation — the
- * token only reaches repositories the app is installed on), PAT users get
- * token-scope guidance.
+ * Granting repository access is a first-class step, not an error. A GitHub App
+ * user token only reaches repositories the app is installed on (authorization
+ * ≠ installation), and a fresh install is on zero repos — so an app sign-in
+ * that can't yet see the repo lands on a plain "grant access" step that polls
+ * and connects the moment access is granted (no retry button to press). The
+ * step is skipped whenever the repo is already visible, so a graph whose repo
+ * the install already covers connects with no detour. The step steers users to
+ * grant access to *only the backup repository* — never "All repositories",
+ * which would hand the app every repo on the account for no reason. PAT users
+ * reach repos by token scope, not an installation, so they get token-scope
+ * guidance.
  */
 export function ConnectGithubDialog({
   suggestedRepoName,
@@ -78,20 +85,33 @@ export function ConnectGithubDialog({
   const [publicConfirm, setPublicConfirm] = useState<GithubRepoRef | null>(null)
   /** The finish step's "create it on GitHub" handoff (create-mode only). */
   const [showCreateGuide, setShowCreateGuide] = useState(false)
-  /** App sign-in couldn't see an existing repo → offer the install remedy. */
-  const [showGrantHint, setShowGrantHint] = useState(false)
+  /**
+   * App sign-in can't see the chosen repo yet (the app isn't installed on it).
+   * Show the "grant access" step and poll until access lands. Skipped when the
+   * repo is already visible — most installs need it, returning ones don't.
+   */
+  const [showGrantAccess, setShowGrantAccess] = useState(false)
 
   useRestoreFocus()
 
-  // While the create handoff is showing, poll for the repository instead of
-  // making the user click "I created it": the connect fires the moment the
-  // repo exists. A 404 just keeps waiting (for app sign-ins it can also mean
-  // access not granted yet — the guide's hint covers that); a public repo
-  // stops the poll for consent.
+  function targetRef(forUser: GithubUser): GithubRepoRef | null {
+    if (mode === 'existing') {
+      return parseRepoInput(existingRepo)
+    }
+    const name = repoName.trim()
+    return name.length === 0 ? null : { owner: forUser.login, name }
+  }
+
+  // The repo we're trying to reach, resolved from the verified sign-in (the
+  // owner is never typed). Drives both the poll and the grant-access copy.
+  const targetForUser = user !== null ? targetRef(user) : null
+
+  // While the create handoff or the grant-access step is showing, poll for the
+  // repository instead of making the user click a button: the connect fires the
+  // moment the repo exists and the app can see it. A 404 just keeps waiting; a
+  // public repo stops the poll for consent.
   const pollTarget =
-    showCreateGuide && publicConfirm === null && user !== null
-      ? { owner: user.login, name: repoName.trim() }
-      : null
+    (showCreateGuide || showGrantAccess) && publicConfirm === null ? targetForUser : null
   usePoll(pollTarget !== null, pollIntervalMs, async () => {
     if (pollTarget === null) {
       return 'stop'
@@ -108,14 +128,6 @@ export function ConnectGithubDialog({
     return 'continue'
   })
 
-  function targetRef(forUser: GithubUser): GithubRepoRef | null {
-    if (mode === 'existing') {
-      return parseRepoInput(existingRepo)
-    }
-    const name = repoName.trim()
-    return name.length === 0 ? null : { owner: forUser.login, name }
-  }
-
   async function finish(
     forUser: GithubUser,
     options: { allowPublic?: boolean; kind?: AuthKind } = {},
@@ -125,10 +137,10 @@ export function ConnectGithubDialog({
     const kind = options.kind ?? authKind
     await action.run(async () => {
       // Each attempt re-derives the guidance from its own outcome — a stale
-      // create guide or grant hint from an earlier path must not outlive the
-      // detour (e.g. consent → choose another repo).
+      // create guide or grant-access step from an earlier path must not outlive
+      // the detour (e.g. consent → choose another repo).
       setShowCreateGuide(false)
-      setShowGrantHint(false)
+      setShowGrantAccess(false)
       const ref = publicConfirm ?? targetRef(forUser)
       if (ref === null) {
         action.setError(
@@ -149,12 +161,14 @@ export function ConnectGithubDialog({
         return
       }
       if (mode === 'existing') {
-        // GitHub's 404 can't distinguish "doesn't exist" from "no access".
-        // App sign-ins almost always mean the latter (the app isn't
-        // installed on the repo), so that's the remedy they get.
+        // GitHub's 404 can't distinguish "doesn't exist" from "no access". App
+        // sign-ins almost always mean the latter — the app isn't installed on
+        // the repo yet — so granting access is the expected next step, not an
+        // error: show it plainly and let the poll connect the moment access
+        // lands. PAT users reach repos by token scope, not an installation, so
+        // they get token-scope guidance instead.
         if (kind === 'app') {
-          setShowGrantHint(true)
-          action.setError('Reflect can’t see that repository. Grant it access or check the name.')
+          setShowGrantAccess(true)
         } else {
           action.setError(
             'Repository not found. Check the name and your token’s repository access.',
@@ -201,7 +215,7 @@ export function ConnectGithubDialog({
     action.setError(null)
     setPublicConfirm(null)
     setShowCreateGuide(false)
-    setShowGrantHint(false)
+    setShowGrantAccess(false)
     setStep('repo')
   }
 
@@ -344,13 +358,38 @@ export function ConnectGithubDialog({
                     >
                       grant the Reflect app access
                     </button>{' '}
-                    to it.
+                    to just this repository.
                   </p>
                 ) : (
                   <p className="text-xs text-text-muted">
                     If it doesn’t connect, add it to your token’s repository access.
                   </p>
                 )}
+              </>
+            ) : showGrantAccess && targetForUser !== null ? (
+              <>
+                <p className="text-sm text-text">
+                  Give Reflect access to{' '}
+                  <strong>
+                    {targetForUser.owner}/{targetForUser.name}
+                  </strong>{' '}
+                  so it can back up here.
+                </p>
+                <div className="flex gap-2">
+                  <Button size="sm" onClick={() => openExternal(githubAppInstallUrl())}>
+                    Grant access on GitHub…
+                  </Button>
+                  <Button variant="outline" size="sm" onClick={backToRepo}>
+                    Change repository
+                  </Button>
+                </div>
+                {/* Steer to per-repo selection: the backup needs exactly one
+                    repo, so "All repositories" is needless account-wide risk. */}
+                <p className="text-xs text-text-muted">
+                  On GitHub, choose <strong>Only select repositories</strong> — Reflect only needs
+                  this one.
+                </p>
+                <p className="text-xs text-text-muted">Waiting for access…</p>
               </>
             ) : action.pending ? (
               <p className="text-sm text-text-muted">Connecting…</p>
@@ -359,26 +398,14 @@ export function ConnectGithubDialog({
             {!action.pending && action.error !== null ? (
               <>
                 <InlineAlert tone="error">{action.error}</InlineAlert>
-                {publicConfirm === null && !showCreateGuide ? (
-                  // A failed connect must never strand the user here: change
-                  // the repository, or — for app sign-ins that can't see the
-                  // repo — grant the app access. (The create guide renders
-                  // its own escape, so it is excluded.)
-                  <div className="flex flex-wrap gap-2">
-                    {showGrantHint && user !== null ? (
-                      <>
-                        <Button size="sm" onClick={() => openExternal(githubAppInstallUrl())}>
-                          Grant access on GitHub…
-                        </Button>
-                        <Button variant="outline" size="sm" onClick={() => void finish(user)}>
-                          I granted it — try again
-                        </Button>
-                      </>
-                    ) : null}
-                    <Button variant="outline" size="sm" onClick={backToRepo}>
-                      Change repository
-                    </Button>
-                  </div>
+                {publicConfirm === null && !showCreateGuide && !showGrantAccess ? (
+                  // A failed connect must never strand the user here — offer the
+                  // way back to a different repository. (The create guide and
+                  // grant-access step render their own escapes, so both are
+                  // excluded.)
+                  <Button variant="outline" size="sm" onClick={backToRepo}>
+                    Change repository
+                  </Button>
                 ) : null}
               </>
             ) : null}


### PR DESCRIPTION
## Summary

The Connect-GitHub flow treated **granting repository access** as error recovery, not a step — so first-time setup always felt like hitting a wall.

A GitHub App user token only reaches repos the app is **installed** on (authorization ≠ installation), and a fresh install covers **zero** repos. So a first-time app sign-in could never see its backup repo: `getGithubRepo` returned 404 → the wizard showed a red *"Reflect can't see that repository. Grant it access or check the name."* with a `[Grant access on GitHub…]` **and** a manual `[I granted it — try again]` button. The happy path was disguised as a failure that fired on essentially every first connect.

This makes granting access an **expected, guided step**:

- **App sign-ins that can't yet see the repo** land on a plain *"Give Reflect access to `owner/name` so it can back up here"* step that **polls and auto-connects** the moment access is granted — no retry button to press (reuses the existing repo-creation poll).
- **Auto-skipped when access already exists** — a graph whose repo the install already covers connects straight through, no detour.
- **Least privilege:** steers users to *"Only select repositories"* scoped to the single backup repo, **never "All repositories"** (which would hand the app every repo on the account for no reason). A code + doc comment records this so it isn't "helpfully" re-broadened later.
- **PAT sign-ins unchanged** — they reach repos by token scope, not an app installation, so they keep token-scope guidance.

## Before / after (app sign-in, repo not yet accessible)

**Before:** ⚠️ error + `[Grant access on GitHub…]` + `[I granted it — try again]`

**After:**
```
Give Reflect access to alex/notes so it can back up here.
[ Grant access on GitHub… ]   <Change repository>
On GitHub, choose Only select repositories — Reflect only needs this one.
⌛ Waiting for access…   ← polls; connects with no click
```

## Tradeoff

Per-repo (not account-wide) access means a brand-new repo for a future graph will hit this step again — that's the deliberate least-privilege choice. The step now handles it gracefully (expected, polled, auto-connecting) rather than as a 404 dead-end. Repos already in the installation auto-skip it entirely.

## Testing

- `pnpm --filter @reflect/desktop test --run src/components/settings/connect-github-dialog.test.tsx` — 15/15 pass (updated the app-sign-in case to assert the polled grant-access step; added auto-skip + per-repo-steer coverage).
- `pnpm --filter @reflect/desktop typecheck` — clean.
- `pnpm lint` — 0 errors (only pre-existing warnings in unrelated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the Connect GitHub dialog UX and polling; backup/sync APIs are unchanged and tests cover the new paths.
> 
> **Overview**
> For **GitHub App** sign-ins connecting an **existing** repo the wizard no longer treats “can’t see the repo” as a red error with **Grant access** plus **I granted it — try again**. It shows a dedicated **grant access** step that names `owner/name`, opens the app install flow, steers users toward **Only select repositories** (not account-wide access), and **polls** until `connectExistingRepo` succeeds—same pattern as the create-on-GitHub handoff.
> 
> Polling now runs when either the create guide or grant-access step is active, driven by a shared `targetForUser` / `targetRef` helper. App users who already have repo visibility **skip** the step and connect on the first lookup; **PAT** users still get token-scope errors only.
> 
> Tests were updated for the polled grant flow and extended with auto-skip and per-repo steering coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c0aa5dc3f2e22ababce5b6734173c05648961f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->