### PR TITLE
Release v0.2.3-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.2.2"
+version = "0.2.3-beta.1"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.2.2"
+version = "0.2.3-beta.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.2.2",
+  "version": "0.2.3-beta.1",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",
@@ -33,7 +33,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDREQ0RBRkJBN0ZDODdDMzkKUldRNWZNaC91cS9OVFhtTHdrSWVOV3p2cEdhc3RZbmtXM0g0bnpxUnZXVjlQMjZRNXFlWUdPNWMK",
       "endpoints": [
-        "https://github.com/team-reflect/reflect-open/releases/latest/download/latest.json"
+        "https://github.com/team-reflect/reflect-open/releases/download/updater-beta/latest.json"
       ]
     }
   },


### PR DESCRIPTION
Bumps Reflect to 0.2.3-beta.1.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and updater URL metadata only; no application logic changes in this diff.
> 
> **Overview**
> Cuts a **beta** desktop release by bumping the app version from **0.2.2** to **0.2.3-beta.1** in `Cargo.toml`, `tauri.conf.json`, and the `reflect-open` entry in `Cargo.lock`.
> 
> The Tauri updater is pointed at the **beta** channel: the endpoint changes from `releases/latest/download/latest.json` to `releases/download/updater-beta/latest.json`, so in-app updates for this build track beta artifacts instead of stable `latest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0e6badfe15e7f49f8b96db69f1c6d1abcfae138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the desktop app version to `0.2.3-beta.1`.
  * Switched update delivery to the beta release feed, so beta builds will receive the appropriate updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->