### PR TITLE
Release v0.2.3-beta.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.2.3-beta.1"
+version = "0.2.3-beta.2"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.2.3-beta.1"
+version = "0.2.3-beta.2"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.2.3-beta.1",
+  "version": "0.2.3-beta.2",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.2.3-beta.2.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime, security, or behavioral changes—only synchronized version strings for the beta release.
> 
> **Overview**
> Bumps the Reflect desktop app from **0.2.3-beta.1** to **0.2.3-beta.2** by aligning the version in `apps/desktop/src-tauri/Cargo.toml`, `tauri.conf.json`, and the `reflect-open` entry in `Cargo.lock`. There are no application or library code changes in this diff—only the release metadata needed for builds, packaging, and the automated tag flow described in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 076c2f0dfb27cdea572373a8c6fa5dfde2e2b176. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->