### PR TITLE
fix(editor): widen spacing between task checkbox and label

### DIFF
--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -574,6 +574,15 @@ html:root {
   border-width: 1px;
   border-color: var(--text-muted); /* crisper than the pale --border at 1px */
 }
+/* Widen the gap between a task checkbox and its label, for both the square
+   (`- [ ]`) and rounded (`+ [ ]`, data-list-marker="+") markers. Both render as
+   data-list-kind="task", so this covers them together. ProseKit/meowdown size
+   the marker box at 1lh and start `.list-content` flush against it (default
+   `margin-inline-start: 1lh`); nudge the content right for more breathing room.
+   At 0-4-0 this clears both base rules (each 0-2-0). */
+.reflect-editor .prosemirror-flat-list[data-list-kind='task'] > .list-content {
+  margin-inline-start: 1.25lh;
+}
 
 /* ---- shadcn inputs (components/ui/) -------------------------------------
    shadcn form controls carry their own focus-visible ring (border + ring


### PR DESCRIPTION
## Summary

Increases the horizontal gap between a task checkbox and its text label in the note editor — the markers read cramped against the text.

The fix bumps `.list-content`'s `margin-inline-start` from the base `1lh` to `1.5lh` for `data-list-kind="task"`. Both editor checkbox styles share that list kind, so this covers them together:

- the square checkbox (`- [ ]` / `* [ ]`)
- the rounded checkbox (`+ [ ]`, `data-list-marker="+"`)

`lh` units are used (matching ProseKit/meowdown's own marker sizing) so the gap scales with the editor text-size setting rather than being a fixed pixel value. The selector lands at specificity 0-4-0, clearing both base rules (ProseKit and meowdown each define the `1lh` default at 0-2-0).

Scope is the editor only — the Tasks view is untouched.

## Testing

- `git diff` reviewed; single-file CSS change.
- Visual: not yet eyeballed in a running build — value (`1.5lh`) is easy to dial in if it reads too wide/tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single scoped stylesheet tweak with no logic, data, or auth impact; only task list layout in the note editor.
> 
> **Overview**
> Adds editor-only CSS so task list labels sit farther from their checkboxes, addressing cramped square (`- [ ]`) and rounded (`+ [ ]`) markers that both use `data-list-kind="task"`.
> 
> The change sets `.list-content` **`margin-inline-start` to `1.25lh`** (over ProseKit/meowdown’s default `1lh`), using line-height units so the gap tracks the user’s editor text size. Selector specificity is documented as clearing the bundled `1lh` defaults. The Tasks view is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7207a41cd238d8f03be63a3a6cc73ce9d735492. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Increased spacing between task list markers and their content for a cleaner, more readable layout.
  * Improved horizontal breathing room in task lists, especially for checklist-style items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->