### PR TITLE
Release v0.2.3-beta.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.2.3-beta.2"
+version = "0.2.3-beta.3"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.2.3-beta.2"
+version = "0.2.3-beta.3"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.2.3-beta.2",
+  "version": "0.2.3-beta.3",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.2.3-beta.3.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version string updates only; no runtime, security, or behavioral changes.
> 
> **Overview**
> Bumps the desktop app release version from **0.2.3-beta.2** to **0.2.3-beta.3** in `reflect-open`’s `Cargo.toml`, the matching `reflect-open` entry in `Cargo.lock`, and Tauri’s `version` in `tauri.conf.json`.
> 
> No application or dependency logic changes—this is the version alignment step ahead of tagging and shipping **0.2.3-beta.3**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3adb4c4d11fe7755bc78833241c50402111d650. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->