### PR TITLE
fix(update): clear stale Install action while update downloads

### DIFF
--- a/apps/desktop/src/components/update-toast.test.tsx
+++ b/apps/desktop/src/components/update-toast.test.tsx
@@ -77,6 +77,13 @@ describe('UpdateToast', () => {
       ),
     )
 
+    // The downloading toast must explicitly clear the action: Sonner merges
+    // options into the same-id toast, so without this the "Install" button
+    // from the `available` phase would linger as a clickable control.
+    const downloadingOptions = toast.loading.mock.lastCall?.[1]
+    expect(Object.hasOwn(downloadingOptions ?? {}, 'action')).toBe(true)
+    expect(downloadingOptions?.action).toBeUndefined()
+
     update.state = { phase: 'ready', version: '1.2.3' }
     rerender(<UpdateToast />)
     await waitFor(() =>

--- a/apps/desktop/src/components/update-toast.tsx
+++ b/apps/desktop/src/components/update-toast.tsx
@@ -38,6 +38,12 @@ export function UpdateToast(): ReactElement | null {
           id: UPDATE_TOAST_ID,
           description: state.percent !== null ? `${state.percent}%` : 'Preparing…',
           duration: PERSISTENT_TOAST_MS,
+          // Sonner merges options into the existing toast by id, so the
+          // "Install" action from the `available` phase persists unless we
+          // clear it — otherwise a clickable Install button lingers over the
+          // download progress. The update only becomes installable once it has
+          // fully downloaded, surfaced as "Restart" in the `ready` phase.
+          action: undefined,
           ...NON_DISMISSIBLE_UPDATE_OPTIONS,
         })
         break


### PR DESCRIPTION
## What

The update toast kept a clickable **Install** button on screen while an update was downloading. This removes it — the action only exists in `available` (before download) and the **Restart** button appears in `ready` (once the update has fully downloaded and is installable).

## Why

Sonner updates a same-`id` toast by merging new options into the existing one (`{ ...oldToast, ...newOptions }`). The `downloading` branch called `toast.loading(...)` **without** an `action` key, so the `action: { label: 'Install' }` set during the `available` phase persisted across the merge. The button looked enabled even though `install()` early-returns while `phase === 'downloading'`, so clicking it did nothing — confusing UX.

## Fix

Explicitly pass `action: undefined` when entering the `downloading` phase so Sonner's merge clears the stale Install action. A comment documents the merge gotcha to prevent regression.

Resulting lifecycle:
- `available` (before download) → **Install** button
- `downloading` → progress only, no action button
- `ready` (fully downloaded) → **Restart** button

## Notes for reviewer

- This codebase uses Tauri's `downloadAndInstall`, which couples download + install — so the "installable when fully downloaded" moment surfaces as **Restart** in `ready`, not a second Install button. Splitting download/install into two distinct states would be a larger flow change and is out of scope here.

## Testing

- Extended `update-toast.test.tsx` to assert the downloading toast explicitly sets `action: undefined`.
- `vitest run update-toast.test.tsx` → 3/3 pass
- `pnpm --filter @reflect/desktop typecheck` → clean
- `oxlint` on changed files → clean; `lint:react` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small desktop UI-only change to toast options; no auth, data, or update signing logic touched.
> 
> **Overview**
> Fixes the desktop update toast showing a stale **Install** button during download. Sonner reuses the same toast by `id` and merges options, so omitting `action` in the `downloading` phase left the **Install** control from `available` on screen even though install is not valid until download completes.
> 
> `UpdateToast` now passes **`action: undefined`** when entering `downloading`, with a short comment on the merge behavior. The test asserts the downloading call includes an explicit `action` key set to `undefined`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a507b3e42712cf15b118dc60be7aae763df18412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the update notification so the install action no longer remains visible or clickable once an update starts downloading.
  * Improved the update progress toast to correctly reset its action state during the downloading phase.
* **Tests**
  * Added coverage to verify the downloading update toast clears any previous action state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->