### PR TITLE
fix(daily-note): standardize appended sections under H2 with a real heading scale

### DIFF
--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -341,12 +341,14 @@ html:root {
   letter-spacing: var(--tracking-snug, -0.01em);
   margin: 1.25em 0 0.4em;
 }
-/* The leading H1 is the regular-note subject, matching the daily subject.
-   Other headings stay capped at the same semantic size rather than towering
-   over the body. */
-.reflect-editor.ProseMirror h1 { @apply text-note-subject; }
-.reflect-editor.ProseMirror h2 { @apply text-note-subject; }
-.reflect-editor.ProseMirror h3 { font-size: var(--text-lg, 1.125rem); }
+/* The leading H1 is the document title — the regular-note subject, matching
+   the daily date subject. H2 and H3 step down the type scale so a section
+   heading reads as subordinate to the title, not a second one: auto-appended
+   sections (`## Links`, `## Audio memos`) land at H2, one size below the
+   subject; H3 sits at body size, carried by weight rather than scale. */
+.reflect-editor.ProseMirror h1 { @apply text-note-subject; } /* text-xl, 20px */
+.reflect-editor.ProseMirror h2 { font-size: var(--text-lg, 1.125rem); } /* 18px */
+.reflect-editor.ProseMirror h3 { font-size: var(--text-base, 1rem); } /* 16px */
 .reflect-editor h1:first-child { margin-top: 0; }
 .reflect-editor .reflect-note-title { @apply text-note-subject; }
 

--- a/packages/core/src/actions/audio-memo.test.ts
+++ b/packages/core/src/actions/audio-memo.test.ts
@@ -186,7 +186,7 @@ describe('reconcileAudioMemos', () => {
       ],
       [
         'daily/2026-06-11.md',
-        'morning thoughts\n\n[[audio-memo-2026-06-11-153022-845|Audio memo 15:30]]\n',
+        'morning thoughts\n\n## Audio memos\n\n[[audio-memo-2026-06-11-153022-845|Audio memo 15:30]]\n',
         3,
       ],
     ])
@@ -244,7 +244,7 @@ describe('reconcileAudioMemos', () => {
 
     expect(writeNoteMock).toHaveBeenCalledWith(
       'daily/2026-06-11.md',
-      '[[audio-memo-2026-06-11-153022-845|Audio memo 15:30]]\n',
+      '## Audio memos\n\n[[audio-memo-2026-06-11-153022-845|Audio memo 15:30]]\n',
       3,
     )
   })

--- a/packages/core/src/actions/audio-memo.ts
+++ b/packages/core/src/actions/audio-memo.ts
@@ -15,7 +15,7 @@ import {
 } from '../ai/transcribe'
 import { listDir, listFiles, readAsset, readNote, writeAsset, writeNote } from '../graph/commands'
 import { AUDIO_MEMOS_DIR, audioMemoPath, dailyPath, notePath } from '../graph/paths'
-import { appendBlock } from '../markdown/edit'
+import { appendUnderHeading } from '../markdown/edit'
 import { getSecret } from '../secrets/keychain'
 
 /**
@@ -275,13 +275,17 @@ async function memoNoteBody(input: {
   }
 }
 
+/** Where the memo's daily-note backlink lands (`appendUnderHeading` creates
+ * it), mirroring link capture's `## Links` so both append paths read the same. */
+const MEMOS_HEADING = 'Audio memos'
+
 /**
- * Append the memo's wikilink to its day's daily note, once — creating the
- * file when the day has none yet (capture must never depend on the note
- * already existing). The write goes straight to disk: the watcher reindexes
- * it, and an open editor session reconciles it like any external change
- * (clean buffers reload in place; dirty ones park a conflict rather than
- * being clobbered).
+ * Append the memo's wikilink to its day's daily note, once — under an
+ * `## Audio memos` section, creating the heading and the file as needed
+ * (capture must never depend on the note already existing). The write goes
+ * straight to disk: the watcher reindexes it, and an open editor session
+ * reconciles it like any external change (clean buffers reload in place;
+ * dirty ones park a conflict rather than being clobbered).
  */
 async function ensureDailyBacklink(memo: AudioMemoIdentity, generation: number): Promise<void> {
   const source = await dailyNoteSource(memo.date, generation)
@@ -289,7 +293,7 @@ async function ensureDailyBacklink(memo: AudioMemoIdentity, generation: number):
     return
   }
   const link = `[[${memo.base}|${memo.alias}]]`
-  await writeNote(dailyPath(memo.date), appendBlock(source, link), generation)
+  await writeNote(dailyPath(memo.date), appendUnderHeading(source, MEMOS_HEADING, link), generation)
 }
 
 /**

--- a/packages/core/src/markdown/edit.ts
+++ b/packages/core/src/markdown/edit.ts
@@ -246,8 +246,8 @@ function nextSectionStart(headings: Heading[], target: Heading, eof: number): nu
 /**
  * Append `block` as its own paragraph at the end of the note, one blank line
  * after the existing content (none for an empty note). The flat variant of
- * {@link appendUnderHeading} — used by audio-memo capture, where the
- * transcript reads as ordinary note content rather than a section entry.
+ * {@link appendUnderHeading}, for content that stands on its own rather than
+ * landing under a section heading.
  */
 export function appendBlock(source: string, block: string): string {
   const base = source.replace(/\s*$/, '')


### PR DESCRIPTION
## What

Standardizes the two code paths that auto-append to a day's **daily note** — audio-memo backlinks and captured links — so they read the same, and fixes the editor heading scale they rely on.

- **Audio memos** now collect under a `## Audio memos` section. Previously `ensureDailyBacklink` used `appendBlock` to drop a bare wikilink with no heading; it now uses the same `appendUnderHeading` path as link capture (`packages/core/src/actions/audio-memo.ts`).
- **Links** were already correct (`## Links`) — no code change needed; `appendUnderHeading`'s fallback already emits H2.
- **Heading type scale** (`apps/desktop/src/styles/index.css`): h1 and h2 both rendered at `text-note-subject` (20px), so an appended `## Links`/`## Audio memos` read as a *second title*. Backed the sizes out from the correct structure:
  - h1 = `text-xl` / 20px (the note subject — unchanged)
  - h2 = `text-lg` / 18px (was 20px)
  - h3 = `text-base` / 16px (was 18px; distinguished from body by weight)

## Why

The document-outline model is: one H1 = the title, H2 = top-level sections, H3 = subsections. Auto-appended sections are top-level sections, so H2 is the correct level — but the CSS collapsed h1==h2, making H2 indistinguishable from the title. Rather than bend the markdown to H3 to dodge the styling, the fix keeps the correct H2 level and gives the scale a real, monotonic hierarchy (20 → 18 → 16).

## Reviewer notes

- Dedup is unaffected: `hasBacklink` and the capture URL check both scan for the wikilink text, not heading position, so moving the link under a heading is safe.
- The daily date subject (`.reflect-daily-subject`) and regular-note title (h1) are untouched — only genuine in-body H2/H3 section headings shrink, which is the intent.
- Kept the title at 20px deliberately rather than widening to a 24/20/18/16 ramp; growing it would ripple into V1-parity title sizing everywhere.
- Updated the two exact-match audio-memo test assertions and the stale `appendBlock` docstring that claimed audio-memo used it.

## Testing

- `@reflect/core` suite passes (867 tests, incl. capture + audio-memo + markdown/edit).
- Core typechecks clean (`tsc --noEmit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized daily-note markdown shape and editor typography; backlink dedup still keys on wikilink text, not heading placement.
> 
> **Overview**
> Aligns **audio-memo** daily-note backlinks with link capture: memos now append under a **`## Audio memos`** section via `appendUnderHeading` instead of a bare wikilink at the end of the note.
> 
> Fixes the editor **heading scale** so auto-appended H2 sections don’t read like a second title: **H1** stays at the note subject size (20px); **H2** drops to 18px and **H3** to 16px (previously H1 and H2 both used `text-note-subject`). Tests and `appendBlock` docs are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfe7d6cd4967a3c621b5963469102181f8465868. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->