### PR TITLE
refactor(release): make releases branch-independent

### DIFF
--- a/apps/desktop/scripts/release-bump.mjs
+++ b/apps/desktop/scripts/release-bump.mjs
@@ -25,9 +25,11 @@
 //   --yes       Skip the confirmation prompt
 //   --help
 //
-// Stable releases ship from `master`, betas from `next`; the script refuses to
-// create a stable (non-prerelease) version while on `next` so a beta branch
-// can't accidentally publish to the stable auto-update channel.
+// Releases are tag-driven and branch-independent: the version string picks the
+// channel (a `-beta.N` prerelease publishes to the beta feed, a plain version to
+// the stable feed) and the build pins the matching updater feed for that channel
+// (release-macos.mjs), so a release can be cut from any branch. By convention
+// betas come from `next` and stable from `master`, but neither is enforced here.
 
 import { execFileSync, spawnSync } from 'node:child_process'
 import { readFileSync, writeFileSync } from 'node:fs'
@@ -49,8 +51,6 @@ const PREID = 'beta'
 /** Branches a release is normally cut from. */
 const STABLE_BRANCH = 'master'
 const BETA_BRANCH = 'next'
-const STABLE_UPDATER_ENDPOINT = 'https://github.com/team-reflect/reflect-open/releases/latest/download/latest.json'
-const BETA_UPDATER_ENDPOINT = 'https://github.com/team-reflect/reflect-open/releases/download/updater-beta/latest.json'
 
 /** Named bump levels; anything else on the command line is an explicit version. */
 const LEVELS = ['beta', 'stable', 'patch', 'minor', 'major', 'prepatch', 'preminor', 'premajor']
@@ -129,11 +129,6 @@ export function computeNextVersion(current, bump) {
   }
 }
 
-/** The updater feed this version should poll once shipped. */
-export function updaterEndpointForVersion(version) {
-  return parseVersion(version).prerelease ? BETA_UPDATER_ENDPOINT : STABLE_UPDATER_ENDPOINT
-}
-
 // ---------------------------------------------------------------------------
 // Git + filesystem side effects.
 // ---------------------------------------------------------------------------
@@ -195,12 +190,6 @@ function replaceOnce(path, find, replace, label) {
 /** Edit all three version sites to `next` (from `current`). */
 function writeVersion(current, next) {
   replaceOnce(tauriConfPath, `"version": "${current}"`, `"version": "${next}"`, 'tauri.conf.json')
-  replaceOnce(
-    tauriConfPath,
-    `"${updaterEndpointForVersion(current)}"`,
-    `"${updaterEndpointForVersion(next)}"`,
-    'tauri.conf.json updater endpoint',
-  )
   replaceOnce(cargoTomlPath, `version = "${current}"`, `version = "${next}"`, 'Cargo.toml')
   // cargo rewrites the lockfile's reflect-open entry from the new Cargo.toml.
   // --offline keeps it a pure version edit with no registry round-trip.
@@ -234,11 +223,6 @@ async function pushTagOnly({ skipPrompt }) {
   const tag = `v${current}`
   const isPrerelease = current.includes('-')
   const branch = currentBranch()
-  const requiredBranch = isPrerelease ? BETA_BRANCH : STABLE_BRANCH
-  if (branch !== requiredBranch) {
-    const channel = isPrerelease ? 'pre-release' : 'stable'
-    fail(`refusing to tag ${channel} ${current} from "${branch}" — switch to ${requiredBranch} first`)
-  }
   if (git(['status', '--porcelain']) !== '') {
     fail('the working tree has uncommitted changes — commit or stash them first')
   }
@@ -382,19 +366,9 @@ async function main() {
   const isPrerelease = next.includes('-')
   const tag = `v${next}`
 
-  // Guardrail: releases are locked to their branch. A stable version reaches
-  // `releases/latest` and auto-updates every stable install, so it must come
-  // from master and nowhere else — keying on the *required* branch (not just
-  // excluding next) stops a stable tag being pushed from any other synced
-  // branch whose code never landed on master. Betas come from next.
-  const requiredBranch = isPrerelease ? BETA_BRANCH : STABLE_BRANCH
-  if (branch !== requiredBranch) {
-    const channel = isPrerelease ? 'pre-release' : 'stable'
-    const hint = isPrerelease
-      ? `Betas ship from ${BETA_BRANCH} — switch there and run this.`
-      : `Stable releases ship from ${STABLE_BRANCH} — merge ${BETA_BRANCH} → ${STABLE_BRANCH} and run this there.`
-    fail(`refusing to cut ${channel} ${next} from "${branch}".\n  ${hint}`)
-  }
+  // Releases are branch-independent: the version's channel decides the updater
+  // feed (release-macos.mjs pins it at build time), so a release can be cut from
+  // any branch. The bump still goes through a PR into the current branch.
   const releaseBranch = releaseBranchName(tag)
 
   if (git(['status', '--porcelain']) !== '') {
@@ -523,7 +497,8 @@ Flags:
   --yes       skip the confirmation prompt
   --help      show this help
 
-Betas ship from ${BETA_BRANCH}; stable releases from ${STABLE_BRANCH}.
+By convention betas come from ${BETA_BRANCH} and stable from ${STABLE_BRANCH}, but a
+release can be cut from any branch — the version string picks the channel.
 Docs: docs/macos-distribution.md`
 
 // Only run when invoked directly (`node release-bump.mjs`), not when imported

--- a/apps/desktop/scripts/release-bump.test.mjs
+++ b/apps/desktop/scripts/release-bump.test.mjs
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 
-import { computeNextVersion, formatVersion, parseVersion, updaterEndpointForVersion } from './release-bump.mjs'
+import { computeNextVersion, formatVersion, parseVersion } from './release-bump.mjs'
 
 test('parseVersion splits a stable and a prerelease version', () => {
   expect(parseVersion('0.2.0')).toEqual({ major: 0, minor: 2, patch: 0, prerelease: null })
@@ -58,13 +58,4 @@ test('an explicit garbage version is rejected', () => {
 
 test('beta on a non-beta prerelease is rejected', () => {
   expect(() => computeNextVersion('0.2.0-rc.1', 'beta')).toThrow(/beta\.N/)
-})
-
-test('updater endpoint follows the release channel', () => {
-  expect(updaterEndpointForVersion('0.2.0')).toBe(
-    'https://github.com/team-reflect/reflect-open/releases/latest/download/latest.json',
-  )
-  expect(updaterEndpointForVersion('0.3.0-beta.1')).toBe(
-    'https://github.com/team-reflect/reflect-open/releases/download/updater-beta/latest.json',
-  )
 })

--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -31,7 +31,6 @@ const UPDATER_KEYCHAIN_SERVICE = 'reflect-updater'
 const APP_SPECIFIC_PASSWORD_URL = 'https://account.apple.com'
 const BETA_UPDATER_FEED_TAG = 'updater-beta'
 const STABLE_UPDATER_ENDPOINT = 'https://github.com/team-reflect/reflect-open/releases/latest/download/latest.json'
-const BETA_UPDATER_ENDPOINT = `https://github.com/team-reflect/reflect-open/releases/download/${BETA_UPDATER_FEED_TAG}/latest.json`
 
 /**
  * Build flavors. Each ships as a distinct app (its own productName, identifier
@@ -257,10 +256,10 @@ function bundlePaths(flavor) {
 }
 
 /**
- * Write the updater manifest next to the bundle and return its path. The
- * committed updater endpoint resolves `releases/latest/download/latest.json`,
- * so every published release must carry this file — it is how installed apps
- * discover the new version and verify its payload.
+ * Write the updater manifest next to the bundle and return its path. The stable
+ * updater feed resolves `releases/latest/download/latest.json`, so every
+ * published release must carry this file — it is how installed apps discover the
+ * new version and verify its payload.
  */
 function writeUpdaterManifest({ version, tag, flavor }) {
   const { updaterArchive, updaterSignature } = bundlePaths(flavor)
@@ -282,23 +281,6 @@ function writeUpdaterManifest({ version, tag, flavor }) {
   const manifestPath = join(dirname(updaterArchive), 'latest.json')
   writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
   return manifestPath
-}
-
-function updaterEndpointForVersion(version) {
-  return version.includes('-') ? BETA_UPDATER_ENDPOINT : STABLE_UPDATER_ENDPOINT
-}
-
-function ensureUpdaterEndpointMatchesVersion({ version }) {
-  const endpoint = readTauriConf().plugins?.updater?.endpoints?.[0]
-  const expected = updaterEndpointForVersion(version)
-  if (endpoint !== expected) {
-    fail(
-      `tauri.conf.json updater endpoint does not match version ${version}.\n` +
-        `  expected: ${expected}\n` +
-        `  found:    ${endpoint ?? '(missing)'}\n` +
-        '  Run `pnpm release:bump` for the target channel so installed apps poll the right feed.',
-    )
-  }
 }
 
 /**
@@ -441,6 +423,15 @@ function build({ notarize, requireUpdater = false, flavor }) {
   const buildArgs = ['tauri', 'build']
   const overlay = FLAVOR_OVERLAYS[flavor]
   if (overlay) buildArgs.push('--config', overlay)
+  // The beta and dev overlays pin their own updater feed; the stable flavor has
+  // no overlay, so without this it would inherit whatever endpoint is committed
+  // in the base tauri.conf.json — which on the `next` branch is the *beta* feed.
+  // Pin it at build time so a stable build always polls the stable feed, no
+  // matter which branch it was cut from. This is what makes releases
+  // branch-independent (release-bump.mjs no longer ties the channel to a branch).
+  if (flavor === 'stable') {
+    buildArgs.push('--config', JSON.stringify({ plugins: { updater: { endpoints: [STABLE_UPDATER_ENDPOINT] } } }))
+  }
   if (updater) {
     buildArgs.push('--config', JSON.stringify({ bundle: { createUpdaterArtifacts: true } }))
   }
@@ -604,7 +595,6 @@ function publish({ draft, flavorFlag }) {
   const flavor = resolveFlavor({ flavorFlag, version, forPublish: true })
   const { productName } = readFlavorConf(flavor)
   const tag = `v${version}`
-  ensureUpdaterEndpointMatchesVersion({ version })
   ensureReleaseIsNew(tag)
   ensureTagMatchesCommit(tag, commit)
 
@@ -612,8 +602,8 @@ function publish({ draft, flavorFlag }) {
 
   const { dmg, updaterArchive, updaterSignature } = bundlePaths(flavor)
   const manifestPath = writeUpdaterManifest({ version, tag, flavor })
-  // Pre-releases are invisible to `releases/latest` — the committed updater
-  // endpoint — so installed stable apps never see a beta.
+  // Pre-releases are invisible to `releases/latest` — the stable updater feed —
+  // so installed stable apps never see a beta.
   const prerelease = version.includes('-')
   log(`creating GitHub ${prerelease ? 'pre-release' : 'release'} ${tag} from commit ${commit.slice(0, 7)}…`)
   const releaseArgs = createReleaseArgs({

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -94,20 +94,20 @@ pnpm release:bump --tag-only     # recovery: push the tag for an already-merged 
 ```
 
 Default (no argument) is `beta`, the common case on `next`. The script refuses to run on
-a dirty tree or a branch out of sync with origin, refuses a version whose tag already
-exists, and locks each release to its branch — betas only from `next`, and stable
-versions only from `master` (a stable tag reaches `releases/latest` and auto-updates
-every stable install, so it must never be pushed from a branch whose code hasn't landed
-on `master`). It requires the GitHub CLI (`gh`) for the protected-branch PR flow, merges
-the release PR immediately with admin bypass instead of waiting for CI, prints the plan,
-and asks for confirmation (skip with `--yes`).
+a dirty tree or a branch out of sync with origin, and refuses a version whose tag already
+exists. Releases are branch-independent: the version string picks the channel (a
+`-beta.N` prerelease publishes to the beta feed, a plain version to the stable feed) and
+the build pins the matching updater feed (`release-macos.mjs`), so a stable release can be
+cut straight from `next` without ever polling the wrong feed. It requires the GitHub CLI
+(`gh`) for the protected-branch PR flow, merges the release PR immediately with admin
+bypass instead of waiting for CI, prints the plan, and asks for confirmation (skip with
+`--yes`).
 
-The typical flows:
+The typical flows, both on `next`:
 
-- **Beta** (on `next`): `pnpm release:bump`.
-- **Stable** (on `master`, after merging `next` → `master`): `pnpm release:bump stable`,
-  then switch back to `next` and use `pnpm release:bump preminor` to open the next beta
-  cycle.
+- **Beta**: `pnpm release:bump`.
+- **Stable**: `pnpm release:bump minor` (or `patch`/`major`), then `pnpm release:bump
+  preminor` to open the next beta cycle.
 
 `--direct` keeps the old direct-push behavior for repositories or maintainers that have
 an explicit ruleset bypass. With `--direct`, `--no-tag` bumps and pushes the branch


### PR DESCRIPTION
## What

Makes `pnpm release:bump` work from any branch by pinning the **stable** updater feed at build time, then removing the branch guardrail that forced stable releases through `master`.

## Why

The stable build flavor has no Tauri config overlay (`FLAVOR_OVERLAYS.stable = null`), so it inherited the updater endpoint committed in the base `tauri.conf.json`. On `next` that endpoint is the **beta** feed — so cutting a stable build from `next` would have shipped an app pointed at the beta feed. To prevent that, releases were locked to a branch (stable only from `master`), which required a painful `next` → `master` merge before every stable release (and `master` has diverged via squash merges, so that merge conflicts).

The beta and dev flavors never had this problem: their overlays (`tauri.beta.conf.json`, `tauri.dev.conf.json`) already pin their own updater feed via `--config`. Only stable fell through to the committed base config.

## How

- **`release-macos.mjs`**: for the `stable` flavor, inject `plugins.updater.endpoints` = the stable feed via `--config` at build time. A stable build now always polls the stable feed regardless of which branch's `tauri.conf.json` it was built from. Removed the now-obsolete `ensureUpdaterEndpointMatchesVersion` preflight (it asserted the committed endpoint matched the version's channel — no longer relevant).
- **`release-bump.mjs`**: dropped the `stable-only-from-master` guardrail and the per-branch updater-endpoint rewrite in `writeVersion`. The bump now only touches the three version sites.
- **docs + tests** updated to match.

## Result

`pnpm release:bump minor` (and `patch`/`major`/`stable`) now works directly on `next`. The version string alone decides the channel; the build bakes the matching feed in. By convention betas still come from `next` and stable can track `master`, but neither is enforced.

## Testing

- `vitest run scripts/` — 16 passed
- `oxlint` on the changed scripts — clean
- `node --check` on both scripts — valid

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how stable builds select the updater feed and removes branch enforcement before tagging; a mistake in build-time config could misroute auto-updates, but behavior is more explicit than relying on per-branch committed endpoints.
> 
> **Overview**
> **Releases no longer require cutting stable from `master` or betas only from `next`.** Channel is chosen by the version string; `release-macos.mjs` pins the correct auto-update feed when the app is built.
> 
> **`release-macos.mjs`** injects the **stable** updater endpoint via Tauri `--config` for `stable` builds so they always poll `releases/latest`, even when the committed `tauri.conf.json` on `next` still points at the beta feed. The publish-time check that the committed endpoint matched the version channel (`ensureUpdaterEndpointForVersion`) is removed.
> 
> **`release-bump.mjs`** drops branch guardrails on bump/tag and stops rewriting `plugins.updater.endpoints` in `tauri.conf.json` during version bumps—only version fields in `tauri.conf.json`, `Cargo.toml`, and `Cargo.lock` are updated. Docs and tests are aligned with tag-driven, branch-independent releases; stable cuts can run on `next` without a `next` → `master` merge first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae7c6ab5e4e9eca9573d0fb9c75cda7c26f4d569. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->