### PR TITLE
fix(release): drop stale "set updater feed" plan line

### DIFF
--- a/apps/desktop/scripts/release-bump.mjs
+++ b/apps/desktop/scripts/release-bump.mjs
@@ -410,7 +410,6 @@ async function main() {
   log('plan:')
   if (!direct) console.log(`  - create ${releaseBranch} from ${branch}`)
   console.log('  - update tauri.conf.json, Cargo.toml, Cargo.lock')
-  console.log(`  - set updater feed to ${isPrerelease ? 'beta' : 'stable'}`)
   console.log(`  - commit "Release ${tag}"`)
   if (direct) {
     console.log(`  - push ${branch} to origin`)


### PR DESCRIPTION
Follow-up to #379. The bump no longer rewrites the updater endpoint (the build pins the feed per channel via `release-macos.mjs`), so the printed plan step "set updater feed to …" was misleading. Removes that one line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Console-only plan text change; no release or updater behavior is modified.
> 
> **Overview**
> Removes the **"set updater feed to beta/stable"** step from the `release-bump.mjs` dry-run and confirmation **plan** output.
> 
> That step no longer matches what the bump script does after #379: version bumps only touch `tauri.conf.json`, `Cargo.toml`, and `Cargo.lock`, while **`release-macos.mjs`** pins the updater endpoint per channel at build time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5d804fad5c59198cda9ec8ee2f640298e165dcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->