### PR TITLE
fix(extension): strip manifest key from the Chrome Web Store build

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -34,16 +34,25 @@ For the native hop to work, run the desktop app once (it writes the host
 manifests for detected browsers and the active-graph pointer file), then
 restart Chrome so it re-reads the manifests.
 
-## The extension ID is pinned — don't regenerate it casually
+## The unpacked ID is pinned — and the store ID is not the same
 
-`wxt.config.ts` carries a public `key`, which makes the extension ID
-`dlbliojklpickgimjdmjjdnbjdiomjik` everywhere: unpacked dev builds, CI, and
-the Chrome Web Store (the store keeps a key-pinned ID on first upload). The
-desktop app's host manifests (`apps/desktop/src-tauri/src/capture.rs`,
-`EXTENSION_ORIGINS`) allowlist exactly this origin — changing the key without
-updating that constant silently breaks the native hop. The private half of
-the key is deliberately discarded: unpacked loads and store uploads only need
-the public key, and the store re-signs every upload.
+`wxt.config.ts` carries a public `key`, which fixes the extension ID to
+`dlbliojklpickgimjdmjjdnbjdiomjik` for **unpacked** loads — `wxt dev`, CI, and a
+`wxt build` you load by hand. The desktop app's host manifests
+(`apps/desktop/src-tauri/src/capture.rs`, `EXTENSION_ORIGINS`) allowlist exactly
+this origin, so during development the native hop works. Changing the key without
+updating that constant silently breaks it. The private half of the key is
+deliberately discarded; unpacked loads only need the public key.
+
+**The Chrome Web Store does not use this key.** It rejects a `key` field in the
+uploaded package (`key field is not allowed in manifest`) and mints its own
+permanent ID for the listing — which will *not* be the ID above. So:
+
+- The store artifact must **omit** `key`. `pnpm zip` sets `WXT_STORE_BUILD=true`,
+  which drops it; every other build keeps it. (`manifest-key.test.ts` still pins
+  the dev key against `EXTENSION_ORIGINS`.)
+- After the listing is created, the native hop will **not** reach store-installed
+  users until the store's assigned ID is allowlisted too — see step 4 below.
 
 To derive an ID from a key (if it ever has to change):
 
@@ -56,24 +65,25 @@ openssl rsa -in key.pem -pubout -outform DER | shasum -a 256 \
 
 ## Releasing to the Chrome Web Store
 
-The build is store-ready as-is: `pnpm --filter @reflect/extension zip` produces a
-signed-on-upload package, the manifest declares only the permissions the code uses
-(see the justifications below), and the extension ID is pinned. The remaining work
-is the listing — the copy and disclosures below are written to be pasted straight
-into the [Developer Dashboard](https://chrome.google.com/webstore/devconsole).
+The build is store-ready: `pnpm --filter @reflect/extension zip` produces a
+key-stripped, signed-on-upload package whose manifest declares only the permissions
+the code uses (see the justifications below). The remaining work is the listing — the
+copy and disclosures below are written to be pasted straight into the
+[Developer Dashboard](https://chrome.google.com/webstore/devconsole).
 
 ### Build & upload
 
 1. `pnpm --filter @reflect/extension check` (typecheck + lint) and
    `pnpm --filter @reflect/extension test` — both must be green.
 2. `pnpm --filter @reflect/extension zip` → upload
-   `.output/reflect-capture-<version>-chrome.zip`.
-3. Confirm the store item ID matches `dlbliojklpickgimjdmjjdnbjdiomjik`
-   (it will, while the manifest `key` is unchanged).
-4. If the store ever assigns a different ID, append
-   `chrome-extension://<store-id>/` to `EXTENSION_ORIGINS` in
-   `apps/desktop/src-tauri/src/capture.rs` and ship a desktop release —
-   the native-messaging host manifests rewrite themselves on next launch.
+   `.output/reflect-capture-<version>-chrome.zip`. This artifact omits the manifest
+   `key` (the store rejects it); a plain `wxt build` keeps it for unpacked loads.
+3. After the listing is created, copy its **assigned item ID** from the dashboard
+   (it will not be `dlbliojklpickgimjdmjjdnbjdiomjik`).
+4. Append `chrome-extension://<store-id>/` to `EXTENSION_ORIGINS` in
+   `apps/desktop/src-tauri/src/capture.rs` (keep the dev ID) and ship a desktop
+   release — the native-messaging host manifests rewrite themselves on next launch.
+   Until that ships, capture works for unpacked dev loads but not for store installs.
 
 ### Listing copy
 

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "wxt",
     "build": "wxt build",
-    "zip": "wxt zip",
+    "zip": "WXT_STORE_BUILD=true wxt zip",
     "typecheck": "wxt prepare && tsc --noEmit",
     "test": "vitest run --passWithNoTests",
     "postinstall": "wxt prepare"

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -3,16 +3,27 @@ import { defineConfig } from 'wxt'
 import { SAVE_CURRENT_PAGE_COMMAND } from './lib/commands'
 
 /**
- * Pins the extension ID (`dlbliojklpickgimjdmjjdnbjdiomjik`) for unpacked dev
- * builds AND the Chrome Web Store: the ID is the SHA-256 of this public key,
- * and the store keeps a `key`-pinned ID on first upload. The matching private
- * key is deliberately not kept — the store re-signs uploads, so only the
- * public half matters. The native-messaging host manifests written by the
- * desktop app (`src-tauri/src/capture.rs`, `EXTENSION_ORIGINS`) allowlist
- * this ID; the two must move together.
+ * Pins the extension ID (`dlbliojklpickgimjdmjjdnbjdiomjik`) for **unpacked**
+ * loads — `wxt dev` and a `wxt build` loaded by hand — so it matches the
+ * native-messaging host manifests the desktop app writes
+ * (`src-tauri/src/capture.rs`, `EXTENSION_ORIGINS`). The ID is the SHA-256 of
+ * this public key; the private half is deliberately not kept.
+ *
+ * The Chrome Web Store is different: it **rejects** a `key` in the uploaded
+ * package ("key field is not allowed in manifest") and mints its own permanent
+ * ID for the listing — which will NOT be the ID above. So the store artifact
+ * must omit `key` (see `WXT_STORE_BUILD` below), and once the listing exists
+ * its assigned ID has to be added to `EXTENSION_ORIGINS` for the native hop to
+ * work for store-installed users.
  */
 const PUBLIC_KEY =
   'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7EMDbrG/PhZAaAz9GauuPizNI+98ua2aaI5yDgDEbXMk86Wm6LByEVD/ZVAJCa+Ic8xXeLw4GEDyNPPxM940eeoeDbU3KHWp1jl99WroEhMXFl1uYyXQ/0yFhZwIolDEt02uDCF+fDS93UMP8AJQKYxtLO2NH4wsv66gdRP1CEA82VUXiJV0R9b1BvIVVr8HJFHR4zmA9YsNbBTUQtkOGYuSz4mWrSZ7QKWP7RDdQcHFI6t9Y58+Bk8/4Ps1gmbGHPCWy5iURQ37m8ibPaVvrGOrAoS3n09E/4jP2OeCa2oM2gH3AcEz7T6daTdk+rzJ0VMbR4PNKLOiLYknxsigDQIDAQAB'
+
+/**
+ * `pnpm zip` sets this to strip the forbidden `key` from the store artifact.
+ * Every other build keeps the key so unpacked loads hold the pinned dev ID.
+ */
+const isStoreBuild = process.env['WXT_STORE_BUILD'] === 'true'
 
 export default defineConfig({
   modules: ['@wxt-dev/module-react'],
@@ -23,7 +34,8 @@ export default defineConfig({
     name: 'Reflect Capture',
     description: 'Save the page you are reading into Reflect.',
     homepage_url: 'https://github.com/team-reflect/reflect-open',
-    key: PUBLIC_KEY,
+    // Unpacked dev/CI loads pin the ID; the store rejects `key`, so drop it there.
+    ...(isStoreBuild ? {} : { key: PUBLIC_KEY }),
     // `activeTab` (granted by the action click / shortcut) covers the
     // screenshot and the selection grab — no broad host permissions.
     permissions: [


### PR DESCRIPTION
## What

The Chrome Web Store upload was failing with **"key field is not allowed in manifest."** Google forbids a `key` field in uploaded packages and mints its own permanent listing ID, so our store zip — which carried the dev `key` — was rejected.

This gates the `key`:
- `pnpm zip` now sets `WXT_STORE_BUILD=true`, which drops `key` from the store artifact.
- Every other build (`wxt dev`, `wxt build`) keeps `key`, so unpacked loads still pin `dlbliojklpickgimjdmjjdnbjdiomjik` and the desktop native-messaging hop works during development.

## Why the docs were also wrong

The README/config claimed the store "keeps a key-pinned ID on first upload." It does not — it assigns its **own** ID. Corrected both, and documented the real consequence:

> After the listing is created, the store's assigned ID must be appended to `EXTENSION_ORIGINS` in `apps/desktop/src-tauri/src/capture.rs` (keeping the dev ID) and a desktop release shipped, or capture won't reach **store-installed** users. Unpacked dev installs are unaffected.

## Verification

- `pnpm zip` artifact manifest: **`key` absent** (checked both the built and the zipped `manifest.json`).
- `wxt build` (dev) manifest: **`key` present**.
- typecheck ✓, test ✓ (28, incl. the unchanged `manifest-key.test.ts` drift guard), oxlint ✓.

## Follow-up (separate, needs the real store ID)

Once the listing exists, add `chrome-extension://<assigned-id>/` to `EXTENSION_ORIGINS` and ship a desktop release. Happy to do that PR when you have the ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-flag and manifest packaging change plus documentation; no runtime capture logic changes.
> 
> **Overview**
> Fixes Chrome Web Store uploads by **omitting the manifest `key`** from the zip artifact only: `pnpm zip` now sets `WXT_STORE_BUILD=true`, and `wxt.config.ts` includes `key` for dev/CI `wxt build` loads but drops it for store zips.
> 
> **Docs** now state that unpacked builds stay pinned to `dlbliojklpickgimjdmjjdnbjdiomjik` (still aligned with desktop `EXTENSION_ORIGINS`), while the store assigns a **different** listing ID — store-installed users need that ID allowlisted in `capture.rs` in a follow-up desktop release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19eb8772615415af50ff503edea797ec0a333bba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Chrome Web Store extension builds so they no longer include the pinned ID field, avoiding upload issues and matching the store-assigned extension ID.
  * Clarified the release process for store installs, including updating the desktop app’s allowed extension origin so native messaging works after release.

* **Documentation**
  * Updated the extension release guide with the new build, upload, and rollout steps for unpacked and store-installed builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->