### PR TITLE
docs(extension): native-host troubleshooting + keyless-build warning

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -27,12 +27,36 @@ pnpm --filter @reflect/extension build   # production build → .output/chrome-m
 pnpm --filter @reflect/extension test    # vitest over lib/
 ```
 
-Load the production build via `chrome://extensions` → Developer mode →
-**Load unpacked** → `apps/extension/.output/chrome-mv3`.
+Load a build via `chrome://extensions` → Developer mode → **Load unpacked**.
+Prefer `pnpm … dev` (`.output/chrome-mv3-dev`) for development — it auto-reloads
+and always keeps the pinned `key`. You can also load the `pnpm … build` output
+(`.output/chrome-mv3`), but **do not load the `pnpm zip` output**: the store
+artifact omits `key`, so it loads under a random ID the host won't allowlist.
 
 For the native hop to work, run the desktop app once (it writes the host
 manifests for detected browsers and the active-graph pointer file), then
 restart Chrome so it re-reads the manifests.
+
+### Troubleshooting: "Install Reflect to finish saving…" while Reflect is installed
+
+That message is the `no-host` state — Chrome could not reach (or was not
+allowlisted by) the native-messaging host. Check, in order:
+
+1. **The extension's ID.** In `chrome://extensions`, the card must read
+   `dlbliojklpickgimjdmjjdnbjdiomjik`. Any other ID means you loaded a
+   **keyless** build (typically `.output/chrome-mv3` right after `pnpm zip`,
+   which builds with `WXT_STORE_BUILD=true`). Rebuild with `pnpm … dev` or
+   `pnpm … build`, then **Reload** the extension. The host allowlists only the
+   pinned ID, so a wrong ID is rejected as "forbidden" → this message.
+2. **The desktop app has run at least once** on this machine, so it has written
+   `~/Library/Application Support/<browser>/NativeMessagingHosts/app.reflect.capture.json`.
+   If Chrome was already open when that file appeared, restart Chrome.
+3. **A graph is selected** in the app. The `no-graph` variant of this message
+   ("Open Reflect and pick a graph first") means the host ran but has no active
+   graph to spool into.
+
+The capture is never lost while held — it stays queued and retries automatically
+once the host is reachable.
 
 ## The unpacked ID is pinned — and the store ID is not the same
 


### PR DESCRIPTION
## What

Adds a **Troubleshooting** section to the extension README for the `no-host` state — the *"Install Reflect to finish saving…"* message that appears even when the desktop app is installed.

The common cause (hit during dev): loading the **keyless** `pnpm zip` output as the unpacked extension. The store artifact omits `key` (the store rejects it), so it loads under a random ID the desktop host doesn't allowlist → Chrome rejects the native message as "forbidden".

## Contents

- Clarifies **Load unpacked** guidance: prefer `pnpm … dev`; you may load `pnpm … build`; **do not** load the `pnpm zip` output.
- Troubleshooting checklist: verify the ID is `dlbliojklpickgimjdmjjdnbjdiomjik`, confirm the desktop app has run (host manifest written) and restart Chrome if it was open, and check a graph is selected (`no-graph` variant).

Docs-only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only changes with no runtime, security, or data-handling impact.
> 
> **Overview**
> Updates the extension **Develop** section so **Load unpacked** guidance distinguishes `pnpm … dev` / `pnpm … build` from the **`pnpm zip`** store artifact, which omits the manifest `key` and loads under a random extension ID the desktop native host does not allowlist.
> 
> Adds a **Troubleshooting** subsection for the **`no-host`** *"Install Reflect to finish saving…"* state: verify the pinned extension ID `dlbliojklpickgimjdmjjdnbjdiomjik`, avoid keyless builds after `pnpm zip`, ensure the desktop app wrote the native-messaging manifest (restart Chrome if needed), and distinguish **`no-graph`** when no graph is selected. Notes that queued captures retry once the host is reachable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc1ec488f6eafaa13b56047f5b7b3deb5cf649e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->