### PR TITLE
fix(ai): add Anthropic browser access header

### DIFF
--- a/packages/core/src/ai/anthropic-headers.ts
+++ b/packages/core/src/ai/anthropic-headers.ts
@@ -1,0 +1,13 @@
+/** Header Anthropic requires when its API is called directly from browser code. */
+export const ANTHROPIC_DIRECT_BROWSER_ACCESS_HEADER =
+  'anthropic-dangerous-direct-browser-access'
+
+/** Opt-in value for {@link ANTHROPIC_DIRECT_BROWSER_ACCESS_HEADER}. */
+export const ANTHROPIC_DIRECT_BROWSER_ACCESS_VALUE = 'true'
+
+/** Headers shared by Anthropic validation and model calls. */
+export function anthropicDirectBrowserAccessHeaders(): Record<string, string> {
+  return {
+    [ANTHROPIC_DIRECT_BROWSER_ACCESS_HEADER]: ANTHROPIC_DIRECT_BROWSER_ACCESS_VALUE,
+  }
+}

--- a/packages/core/src/ai/language-model.test.ts
+++ b/packages/core/src/ai/language-model.test.ts
@@ -1,0 +1,60 @@
+import { generateText } from 'ai'
+import { describe, expect, it } from 'vitest'
+import type { AiProviderConfig } from '../settings/schema'
+import {
+  ANTHROPIC_DIRECT_BROWSER_ACCESS_HEADER,
+  ANTHROPIC_DIRECT_BROWSER_ACCESS_VALUE,
+} from './anthropic-headers'
+import { languageModel } from './language-model'
+
+interface RecordedCall {
+  readonly url: string
+  readonly headers: Headers
+}
+
+const ANTHROPIC_CONFIG: AiProviderConfig = {
+  id: 'cfg-anthropic',
+  provider: 'anthropic',
+  model: 'claude-opus-4-8',
+  keyHint: 'wxyz1',
+}
+
+function recordingAnthropicFetch(calls: RecordedCall[]): typeof fetch {
+  return async (input, init) => {
+    calls.push({
+      url: String(input),
+      headers: new Headers(init?.headers),
+    })
+    return new Response(
+      JSON.stringify({
+        id: 'msg_123',
+        type: 'message',
+        role: 'assistant',
+        model: ANTHROPIC_CONFIG.model,
+        content: [{ type: 'text', text: 'ok' }],
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+}
+
+describe('languageModel', () => {
+  it('adds Anthropic direct-browser access to model calls', async () => {
+    const calls: RecordedCall[] = []
+
+    await generateText({
+      model: languageModel(ANTHROPIC_CONFIG, 'sk-ant-test', recordingAnthropicFetch(calls)),
+      prompt: 'hello',
+      maxRetries: 0,
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.url).toBe('https://api.anthropic.com/v1/messages')
+    expect(calls[0]!.headers.get(ANTHROPIC_DIRECT_BROWSER_ACCESS_HEADER)).toBe(
+      ANTHROPIC_DIRECT_BROWSER_ACCESS_VALUE,
+    )
+  })
+})

--- a/packages/core/src/ai/language-model.ts
+++ b/packages/core/src/ai/language-model.ts
@@ -3,6 +3,7 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import { createOpenAI } from '@ai-sdk/openai'
 import type { LanguageModel } from 'ai'
 import type { AiProviderConfig } from '../settings/schema'
+import { anthropicDirectBrowserAccessHeaders } from './anthropic-headers'
 
 /**
  * Build the AI SDK model instance for a configured BYOK entry — the one place
@@ -19,7 +20,11 @@ export function languageModel(
     case 'openai':
       return createOpenAI({ apiKey, fetch: fetchFn })(config.model)
     case 'anthropic':
-      return createAnthropic({ apiKey, fetch: fetchFn })(config.model)
+      return createAnthropic({
+        apiKey,
+        fetch: fetchFn,
+        headers: anthropicDirectBrowserAccessHeaders(),
+      })(config.model)
     case 'google':
       return createGoogleGenerativeAI({ apiKey, fetch: fetchFn })(config.model)
   }

--- a/packages/core/src/ai/validate-key.ts
+++ b/packages/core/src/ai/validate-key.ts
@@ -1,4 +1,5 @@
 import type { AiProviderId } from '../settings/schema'
+import { anthropicDirectBrowserAccessHeaders } from './anthropic-headers'
 
 /**
  * BYOK key validation (Plan 10): one cheap authenticated probe against the
@@ -32,8 +33,7 @@ const PROBES: Record<AiProviderId, KeyProbe> = {
     headers: (key) => ({
       'x-api-key': key,
       'anthropic-version': '2023-06-01',
-      // Required for direct-from-browser calls; harmless elsewhere.
-      'anthropic-dangerous-direct-browser-access': 'true',
+      ...anthropicDirectBrowserAccessHeaders(),
     }),
     invalidStatuses: [401, 403],
   },


### PR DESCRIPTION
## Summary
- add a shared Anthropic direct-browser access header helper
- pass the header through the AI SDK Anthropic provider used by chat and description calls
- add a regression test for Anthropic model-call headers

## Testing
- pnpm --filter @reflect/core test src/ai/language-model.test.ts src/ai/validate-key.test.ts src/ai/provider-config.test.ts src/ai/transcribe.test.ts
- pnpm --filter @reflect/desktop test src/providers/audio-memo-provider.test.tsx
- pnpm check

Note: audio memo transcription remains intentionally limited to OpenAI or Google Gemini; Anthropic entries are not selected for transcription.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted HTTP header change for existing BYOK Anthropic flows; no auth or data-model changes.
> 
> **Overview**
> Anthropic requires `anthropic-dangerous-direct-browser-access: true` when the API is called from browser (or browser-like) code. This PR centralizes that in `anthropicDirectBrowserAccessHeaders()` and uses it everywhere Anthropic is hit from the client.
> 
> **`languageModel`** now passes those headers into `createAnthropic`, so chat, page/asset description, and other SDK calls get the header—previously only key validation had it inline. **`validate-key`** switches to the same helper instead of a duplicated literal.
> 
> A **`language-model.test.ts`** regression test records outbound `/v1/messages` requests and asserts the header is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baa2e26bb462fe81bbc9ed65238d84c3faa0ec08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->