### PR TITLE
Fix Daily back navigation after creating a note

### DIFF
--- a/apps/desktop/src/components/command-palette/command-palette.test.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.test.tsx
@@ -86,6 +86,7 @@ function renderPalette(query: string, context?: Partial<CommandContext>) {
     notePath: () => null,
     back: vi.fn(),
     forward: vi.fn(),
+    clearScrollState: vi.fn(),
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
     newChat: vi.fn(),

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -98,6 +98,7 @@ function renderSidebar(overrides?: Partial<CommandContext>, initialRoute?: Route
     notePath: () => null,
     back: vi.fn(),
     forward: vi.fn(),
+    clearScrollState: vi.fn(),
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
     newChat: vi.fn(),

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -65,6 +65,7 @@ function fakeContext(overrides?: Partial<CommandContext>) {
     notePath: () => notePathForRoute(route(), TODAY),
     back: vi.fn(),
     forward: vi.fn(),
+    clearScrollState: vi.fn(),
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
     newChat: vi.fn(),
@@ -154,13 +155,25 @@ describe('app commands', () => {
     expect(outsideChat.newChat).not.toHaveBeenCalled()
   })
 
-  it('note.new navigates to a fresh lazy ULID note path', async () => {
-    const { context, navigated } = fakeContext()
+  it('note.new clears daily scroll and navigates to a fresh lazy ULID note path', async () => {
+    const clearScrollState = vi.fn()
+    const { context, navigated } = fakeContext({ clearScrollState })
     await command('note.new').run(context)
+    expect(clearScrollState).toHaveBeenCalledTimes(1)
     expect(navigated).toHaveLength(1)
     const route = navigated[0]!
     expect(route.kind).toBe('note')
     expect((route as { kind: 'note'; path: string }).path).toMatch(/^notes\/[0-9a-z]+\.md$/)
+  })
+
+  it('note.new leaves non-daily route scroll restoration intact', async () => {
+    const clearScrollState = vi.fn()
+    const { context } = fakeContext({
+      clearScrollState,
+      route: () => ({ kind: 'allNotes', tag: null }),
+    })
+    await command('note.new').run(context)
+    expect(clearScrollState).not.toHaveBeenCalled()
   })
 
   it('note.random navigates to the picked note and no-ops on an empty graph', async () => {

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -14,7 +14,7 @@ import { startOperation } from '@/lib/operations'
 import { rebuildIndexVisibly } from '@/lib/rebuild-index'
 import { type Route } from '@/routing/route'
 import { registerCommands } from './registry'
-import type { AppCommand } from './types'
+import type { AppCommand, CommandContext } from './types'
 
 /**
  * The first-wave commands (Plan 08). Keybindings here replace the hardcoded
@@ -29,6 +29,14 @@ import type { AppCommand } from './types'
  */
 export function newNoteRoute(): Route {
   return { kind: 'note', path: untitledNotePath() }
+}
+
+function openNewNote(context: CommandContext): void {
+  const route = context.route()
+  if (route.kind === 'today' || route.kind === 'daily') {
+    context.clearScrollState()
+  }
+  context.navigate(newNoteRoute())
 }
 
 const APP_COMMANDS: AppCommand[] = [
@@ -58,7 +66,7 @@ const APP_COMMANDS: AppCommand[] = [
     title: 'New note',
     keywords: ['create'],
     keybinding: 'Mod-n',
-    run: (context) => context.navigate(newNoteRoute()),
+    run: openNewNote,
   },
   {
     id: 'chat.open',

--- a/apps/desktop/src/lib/commands/registry.test.ts
+++ b/apps/desktop/src/lib/commands/registry.test.ts
@@ -13,6 +13,7 @@ function fakeContext(overrides?: Partial<CommandContext>): CommandContext {
     notePath: () => null,
     back: vi.fn(),
     forward: vi.fn(),
+    clearScrollState: vi.fn(),
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
     newChat: vi.fn(),

--- a/apps/desktop/src/lib/commands/types.ts
+++ b/apps/desktop/src/lib/commands/types.ts
@@ -20,6 +20,8 @@ export interface CommandContext {
   notePath: () => string | null
   back: () => void
   forward: () => void
+  /** Discard the current route's saved scroll offset. */
+  clearScrollState: () => void
   toggleTheme: () => void
   /** Collapse/expand the workspace sidebar. */
   toggleSidebar: () => void

--- a/apps/desktop/src/routing/app-shortcuts.test.tsx
+++ b/apps/desktop/src/routing/app-shortcuts.test.tsx
@@ -94,6 +94,19 @@ describe('app shortcuts', () => {
     expect(result.current.router.route).toEqual({ kind: 'today' })
   })
 
+  it('⌘N from today makes back re-anchor Daily instead of restoring stale scroll', () => {
+    const { result } = shortcutsHook()
+    act(() => result.current.router.saveScrollState(735))
+    expect(result.current.router.savedScroll()).toBe(735)
+
+    act(() => press('n'))
+    expect(result.current.router.route.kind).toBe('note')
+
+    act(() => press('['))
+    expect(result.current.router.route).toEqual({ kind: 'today' })
+    expect(result.current.router.savedScroll()).toBeNull()
+  })
+
   it('⌘K opens the palette', () => {
     const { result } = shortcutsHook()
     expect(result.current.palette.open).toBe(false)

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -50,7 +50,7 @@ function isModKey(event: KeyboardEvent): boolean {
  * mounted (`setMenuCommandDispatch`).
  */
 export function useAppShortcuts(): CommandContext {
-  const { route, navigate, back, forward } = useRouter()
+  const { route, navigate, back, forward, clearScrollState } = useRouter()
   const focusedDailyDate = useFocusedDailyDate()
   const { resolvedTheme, setTheme } = useTheme()
   const { graph } = useGraph()
@@ -96,6 +96,7 @@ export function useAppShortcuts(): CommandContext {
       },
       back,
       forward,
+      clearScrollState,
       toggleTheme: () => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark'),
       toggleSidebar,
       newChat,
@@ -114,6 +115,7 @@ export function useAppShortcuts(): CommandContext {
       navigate,
       back,
       forward,
+      clearScrollState,
       resolvedTheme,
       setTheme,
       openPalette,

--- a/apps/desktop/src/routing/router.test.tsx
+++ b/apps/desktop/src/routing/router.test.tsx
@@ -78,6 +78,20 @@ describe('router', () => {
     expect(result.current.savedScroll()).toBe(40) // the note's own offset
   })
 
+  it('can clear the active entry scroll offset without changing routes', () => {
+    const { result } = routerHook()
+    const entryId = result.current.entryId
+    const arrivals = result.current.arrivalSeq
+    act(() => result.current.saveScrollState(120))
+
+    act(() => result.current.clearScrollState())
+
+    expect(result.current.route).toEqual({ kind: 'today' })
+    expect(result.current.entryId).toBe(entryId)
+    expect(result.current.arrivalSeq).toBe(arrivals)
+    expect(result.current.savedScroll()).toBeNull()
+  })
+
   it('re-navigating to the current route clears its saved scroll (re-anchor intent)', () => {
     const { result } = routerHook()
     const seqBefore = result.current.arrivalSeq

--- a/apps/desktop/src/routing/router.tsx
+++ b/apps/desktop/src/routing/router.tsx
@@ -40,6 +40,8 @@ interface RouterValue {
   canForward: boolean
   /** Record the active view's scroll offset on the current history entry. */
   saveScrollState: (offset: number) => void
+  /** Discard the active history entry's scroll offset so it re-anchors when revisited. */
+  clearScrollState: () => void
   /** The current entry's recorded offset (present when revisited), or `null`. */
   savedScroll: () => number | null
 }
@@ -146,6 +148,10 @@ export function RouterProvider({
     scrollById.current.set(currentId.current, offset)
   }, [])
 
+  const clearScrollState = useCallback(() => {
+    scrollById.current.delete(currentId.current)
+  }, [])
+
   const savedScroll = useCallback(
     () => scrollById.current.get(currentId.current) ?? null,
     [],
@@ -163,9 +169,19 @@ export function RouterProvider({
       canBack: history.index > 0,
       canForward: history.index < history.stack.length - 1,
       saveScrollState,
+      clearScrollState,
       savedScroll,
     }
-  }, [history, arrivalSeq, navigate, back, forward, saveScrollState, savedScroll])
+  }, [
+    history,
+    arrivalSeq,
+    navigate,
+    back,
+    forward,
+    saveScrollState,
+    clearScrollState,
+    savedScroll,
+  ])
 
   return <RouterContext.Provider value={value}>{children}</RouterContext.Provider>
 }


### PR DESCRIPTION
## Summary
- Add a router capability to clear the current history entry's saved scroll offset
- Clear Daily-route scroll memory before opening a new note so Cmd+[ re-anchors to the Daily route target instead of an old stream offset
- Cover the command and keyboard path with focused tests

## Testing
- pnpm --filter @reflect/desktop test src/routing/router.test.tsx src/routing/app-shortcuts.test.tsx src/lib/commands/app-commands.test.ts
- pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized navigation/scroll bookkeeping with explicit route gating and solid test coverage; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **back navigation to Daily** after **⌘N** from Today/Daily: returning with **⌘[** no longer jumps to an old stream scroll position.
> 
> The router gains **`clearScrollState()`**, which drops the **current history entry’s** saved offset without changing route or stack. **`note.new`** calls it when the active route is **`today`** or **`daily`**, then navigates to a fresh note as before; other routes (e.g. All notes) keep their scroll restoration.
> 
> **`CommandContext`** and **`useAppShortcuts`** expose the router hook; tests cover the router API, command gating, and the full **⌘N → ⌘[** keyboard path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 929b9e7048890b901905b12281d32bcae0878e0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved new-note navigation so it clears saved scroll state when coming from today/daily views, helping return navigation land in the right place.
  * Fixed shortcut flow so moving between today and a note no longer restores outdated scroll positions.
  * Added coverage for router and shortcut behavior to ensure scroll state is handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->