### PR TITLE
fix(release): bypass brittle Tauri DMG bundling

### DIFF
--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -20,7 +20,7 @@
 // Full procedure and troubleshooting: docs/macos-distribution.md
 
 import { execFileSync, spawnSync } from 'node:child_process'
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
 import { createInterface } from 'node:readline/promises'
@@ -67,6 +67,26 @@ function capture(command, args, options = {}) {
 function run(command, args) {
   const result = spawnSync(command, args, { encoding: 'utf8' })
   return { status: result.status, output: `${result.stdout ?? ''}${result.stderr ?? ''}` }
+}
+
+/** Build the Tauri CLI arguments for release packaging. */
+export function createTauriBuildArgs({ flavor, hasUpdater }) {
+  const buildArgs = ['tauri', 'build', '--bundles', 'app']
+  const overlay = FLAVOR_OVERLAYS[flavor]
+  if (overlay) buildArgs.push('--config', overlay)
+  // The beta and dev overlays pin their own updater feed; the stable flavor has
+  // no overlay, so without this it would inherit whatever endpoint is committed
+  // in the base tauri.conf.json — which on the `next` branch is the *beta* feed.
+  // Pin it at build time so a stable build always polls the stable feed, no
+  // matter which branch it was cut from. This is what makes releases
+  // branch-independent (release-bump.mjs no longer ties the channel to a branch).
+  if (flavor === 'stable') {
+    buildArgs.push('--config', JSON.stringify({ plugins: { updater: { endpoints: [STABLE_UPDATER_ENDPOINT] } } }))
+  }
+  if (hasUpdater) {
+    buildArgs.push('--config', JSON.stringify({ bundle: { createUpdaterArtifacts: true } }))
+  }
+  return buildArgs
 }
 
 /**
@@ -283,6 +303,42 @@ function writeUpdaterManifest({ version, tag, flavor }) {
   return manifestPath
 }
 
+/** Build the hdiutil arguments used to create the release DMG. */
+export function createDmgArgs({ dmg, sourceFolder, volumeName }) {
+  return ['create', '-volname', volumeName, '-srcfolder', sourceFolder, '-ov', '-format', 'UDZO', dmg]
+}
+
+/** Build the codesign arguments used for the DMG container. */
+export function signDmgArgs({ dmg, identity }) {
+  return ['--force', '--sign', identity, '--timestamp', dmg]
+}
+
+function createDmg({ flavor, identity }) {
+  const conf = readFlavorConf(flavor)
+  const { app, dmg } = bundlePaths(flavor)
+  if (!existsSync(app)) fail(`${app} does not exist — tauri did not produce the app bundle`)
+
+  const stagingRoot = mkdtempSync(join(tmpdir(), 'reflect-dmg-'))
+  const stagingDir = join(stagingRoot, `${conf.productName}-dmg`)
+  const stagedApp = join(stagingDir, basename(app))
+  try {
+    mkdirSync(stagingDir, { recursive: true })
+    execFileSync('ditto', [app, stagedApp], { stdio: 'inherit' })
+    symlinkSync('/Applications', join(stagingDir, 'Applications'))
+
+    mkdirSync(dirname(dmg), { recursive: true })
+    if (existsSync(dmg)) rmSync(dmg)
+    log(`creating ${basename(dmg)} from ${basename(app)}…`)
+    execFileSync('hdiutil', createDmgArgs({ dmg, sourceFolder: stagingDir, volumeName: conf.productName }), {
+      stdio: 'inherit',
+    })
+    log(`signing ${basename(dmg)}…`)
+    execFileSync('codesign', signDmgArgs({ dmg, identity }), { stdio: 'inherit' })
+  } finally {
+    rmSync(stagingRoot, { recursive: true, force: true })
+  }
+}
+
 /**
  * Notarize and staple the DMG. Tauri notarizes the .app during the build but
  * not the DMG wrapped around it afterwards; without its own ticket the DMG is
@@ -420,21 +476,12 @@ function build({ notarize, requireUpdater = false, flavor }) {
   // createUpdaterArtifacts stays out of the committed config: with it on,
   // `tauri build` hard-fails without the private key, which would break plain
   // contributor builds. The release script turns it on only when it can sign.
-  const buildArgs = ['tauri', 'build']
-  const overlay = FLAVOR_OVERLAYS[flavor]
-  if (overlay) buildArgs.push('--config', overlay)
-  // The beta and dev overlays pin their own updater feed; the stable flavor has
-  // no overlay, so without this it would inherit whatever endpoint is committed
-  // in the base tauri.conf.json — which on the `next` branch is the *beta* feed.
-  // Pin it at build time so a stable build always polls the stable feed, no
-  // matter which branch it was cut from. This is what makes releases
-  // branch-independent (release-bump.mjs no longer ties the channel to a branch).
-  if (flavor === 'stable') {
-    buildArgs.push('--config', JSON.stringify({ plugins: { updater: { endpoints: [STABLE_UPDATER_ENDPOINT] } } }))
-  }
-  if (updater) {
-    buildArgs.push('--config', JSON.stringify({ bundle: { createUpdaterArtifacts: true } }))
-  }
+  //
+  // Build only the signed/notarized .app with Tauri. The generated Tauri DMG
+  // script depends on Finder automation and has proven brittle on GitHub-hosted
+  // macOS images; create the DMG directly below and keep the same notarization
+  // and Gatekeeper checks around the final artifact.
+  const buildArgs = createTauriBuildArgs({ flavor, hasUpdater: Boolean(updater) })
   const result = spawnSync('pnpm', buildArgs, { cwd: appDir, stdio: 'inherit', env: buildEnv })
   if (result.status !== 0) fail('tauri build failed')
 
@@ -445,6 +492,7 @@ function build({ notarize, requireUpdater = false, flavor }) {
     }
   }
 
+  createDmg({ flavor, identity })
   if (notarize) notarizeDmg(bundlePaths(flavor).dmg, credentials)
   verify({ notarized: notarize, flavor })
   printArtifacts(flavor)

--- a/apps/desktop/scripts/release-macos.test.mjs
+++ b/apps/desktop/scripts/release-macos.test.mjs
@@ -1,6 +1,13 @@
 import { expect, test } from 'vitest'
 
-import { createBetaFeedReleaseArgs, createReleaseArgs, uploadBetaFeedArgs } from './release-macos.mjs'
+import {
+  createBetaFeedReleaseArgs,
+  createDmgArgs,
+  createReleaseArgs,
+  createTauriBuildArgs,
+  signDmgArgs,
+  uploadBetaFeedArgs,
+} from './release-macos.mjs'
 
 const baseInput = {
   assets: ['Reflect.dmg', 'Reflect.app.tar.gz', 'Reflect.app.tar.gz.sig', 'latest.json'],
@@ -85,4 +92,52 @@ test('beta feed upload replaces the moving manifest', () => {
     'latest.json',
     '--clobber',
   ])
+})
+
+test('release builds ask Tauri for the app bundle only', () => {
+  const args = createTauriBuildArgs({ flavor: 'stable', hasUpdater: true })
+
+  expect(args.slice(0, 4)).toEqual(['tauri', 'build', '--bundles', 'app'])
+  expect(args).not.toContain('dmg')
+  expect(args).toContain(JSON.stringify({ bundle: { createUpdaterArtifacts: true } }))
+  expect(args).toContain(
+    JSON.stringify({
+      plugins: {
+        updater: {
+          endpoints: ['https://github.com/team-reflect/reflect-open/releases/latest/download/latest.json'],
+        },
+      },
+    }),
+  )
+})
+
+test('beta release builds keep the beta flavor overlay', () => {
+  expect(createTauriBuildArgs({ flavor: 'beta', hasUpdater: false })).toEqual([
+    'tauri',
+    'build',
+    '--bundles',
+    'app',
+    '--config',
+    'src-tauri/tauri.beta.conf.json',
+  ])
+})
+
+test('DMG creation uses direct hdiutil packaging', () => {
+  expect(createDmgArgs({ dmg: 'Reflect.dmg', sourceFolder: '/tmp/stage', volumeName: 'Reflect' })).toEqual([
+    'create',
+    '-volname',
+    'Reflect',
+    '-srcfolder',
+    '/tmp/stage',
+    '-ov',
+    '-format',
+    'UDZO',
+    'Reflect.dmg',
+  ])
+})
+
+test('DMG signing timestamps the container', () => {
+  expect(signDmgArgs({ dmg: 'Reflect.dmg', identity: 'Developer ID Application: Reflect App, LLC (789ULN5MZB)' })).toEqual(
+    ['--force', '--sign', 'Developer ID Application: Reflect App, LLC (789ULN5MZB)', '--timestamp', 'Reflect.dmg'],
+  )
 })

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -49,13 +49,16 @@ can still build unsigned bundles with plain `pnpm tauri build`.
 1. Auto-detects the Developer ID identity from the keychain and derives the team ID.
 2. Loads notarization credentials (keychain item, or environment variables — see
    [Releasing from CI](#releasing-from-ci) below).
-3. Runs `pnpm tauri build`, which stages the `reflect` CLI sidecar, then signs inside-out
-   (sidecar → main binary → `.app`) with hardened runtime, notarizes the `.app` via
-   `notarytool`, staples the ticket, and builds + signs the DMG.
-4. Notarizes and staples the **DMG** itself. Tauri only notarizes the `.app`; without its
+3. Runs `pnpm tauri build --bundles app`, which stages the `reflect` CLI sidecar, then
+   signs inside-out (sidecar → main binary → `.app`) with hardened runtime, notarizes
+   the `.app` via `notarytool`, and staples the ticket.
+4. Builds and signs the DMG directly from the notarized app. The release helper avoids
+   Tauri's generated Finder-layout DMG script because that script is brittle on
+   GitHub-hosted macOS images.
+5. Notarizes and staples the **DMG** itself. Tauri only notarizes the `.app`; without its
    own ticket the DMG container fails `spctl --type open` and downloads can hit
    Gatekeeper friction.
-5. Verifies everything — `codesign --verify --deep --strict`, Gatekeeper assessment of
+6. Verifies everything — `codesign --verify --deep --strict`, Gatekeeper assessment of
    the app and DMG (`accepted` / `source=Notarized Developer ID`), and stapled tickets —
    and fails loudly if any check is off.
 


### PR DESCRIPTION
## Summary
- build only the signed/notarized Tauri app bundle during macOS releases
- create the release DMG directly with hdiutil from a staged app plus /Applications symlink, then sign/notarize/verify it with the existing release checks
- cover the app-only Tauri args and direct DMG command shape in release helper tests
- update the macOS distribution docs to describe the new packaging flow

## Context
The v0.3.1 Release workflow failed on GitHub's macos-15-arm64 20260623 image after app notarization, inside Tauri's generated bundle_dmg.sh. The previous v0.3.0 release passed earlier on the 20260610 runner image with the same release machinery, and the v0.3.1 diff did not touch packaging inputs beyond the version bump. This avoids that fragile Finder-layout DMG script while keeping the same published artifacts.

## Verification
- pnpm --filter @reflect/desktop test --run scripts/release-macos.test.mjs
- pnpm oxlint apps/desktop/scripts/release-macos.mjs apps/desktop/scripts/release-macos.test.mjs
- app-only Tauri packaging smoke test with ad-hoc app signing and a throwaway updater key produced Reflect.app.tar.gz and Reflect.app.tar.gz.sig
- direct hdiutil smoke test produced target/release/bundle/dmg/Reflect_0.3.1_aarch64.dmg from the staged Reflect.app
- pnpm check

## Notes
The local smoke tests did not use Reflect's Developer ID or notarization secrets; CI still exercises the real signing/notarization path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release packaging path for a critical distribution artifact; behavior is covered by tests and keeps the same signing/notarization/verify pipeline, but any DMG staging mistake could break GitHub releases.
> 
> **Overview**
> macOS releases no longer ask Tauri to build the DMG. **`pnpm tauri build` is limited to `--bundles app`** (via new **`createTauriBuildArgs`**) so CI stops failing on Tauri’s Finder-based **`bundle_dmg.sh`**.
> 
> After the signed/notarized **`.app`** is produced, **`release-macos.mjs`** stages the app with **`ditto`**, adds an **`/Applications`** symlink, builds a compressed DMG with **`hdiutil`**, and **`codesign`**s the container—then the existing DMG notarization, stapling, and Gatekeeper checks still run on the same output paths.
> 
> Tests lock in the Tauri CLI args and **`hdiutil`/`codesign`** command shapes; **`docs/macos-distribution.md`** documents the split app-then-DMG flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efbab954526b7c968e84828616a4d9010e088450. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->