### PR TITLE
fix(release): sign DMG with CI certificate keychain

### DIFF
--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -20,6 +20,7 @@
 // Full procedure and troubleshooting: docs/macos-distribution.md
 
 import { execFileSync, spawnSync } from 'node:child_process'
+import { randomBytes } from 'node:crypto'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
@@ -67,6 +68,15 @@ function capture(command, args, options = {}) {
 function run(command, args) {
   const result = spawnSync(command, args, { encoding: 'utf8' })
   return { status: result.status, output: `${result.stdout ?? ''}${result.stderr ?? ''}` }
+}
+
+/** Parse `security list-keychains` output into keychain paths. */
+export function parseKeychainList(output) {
+  return [...output.matchAll(/"([^"]+)"/g)].map((match) => match[1])
+}
+
+function listUserKeychains() {
+  return parseKeychainList(capture('security', ['list-keychains', '-d', 'user']))
 }
 
 /** Build the Tauri CLI arguments for release packaging. */
@@ -309,11 +319,64 @@ export function createDmgArgs({ dmg, sourceFolder, volumeName }) {
 }
 
 /** Build the codesign arguments used for the DMG container. */
-export function signDmgArgs({ dmg, identity }) {
-  return ['--force', '--sign', identity, '--timestamp', dmg]
+export function signDmgArgs({ dmg, identity, keychain }) {
+  const args = ['--force', '--sign', identity, '--timestamp']
+  if (keychain) args.push('--keychain', keychain)
+  args.push(dmg)
+  return args
 }
 
-function createDmg({ flavor, identity }) {
+function importSigningCertificate() {
+  const { APPLE_CERTIFICATE, APPLE_CERTIFICATE_PASSWORD } = process.env
+  if (!APPLE_CERTIFICATE) return null
+  if (!APPLE_CERTIFICATE_PASSWORD) fail('APPLE_CERTIFICATE is set but APPLE_CERTIFICATE_PASSWORD is not')
+
+  const tempDir = mkdtempSync(join(tmpdir(), 'reflect-signing-'))
+  const certificatePath = join(tempDir, 'certificate.p12')
+  const keychainPath = join(tempDir, 'reflect-signing.keychain-db')
+  const keychainPassword = randomBytes(24).toString('hex')
+  const previousKeychains = listUserKeychains()
+
+  try {
+    writeFileSync(certificatePath, Buffer.from(APPLE_CERTIFICATE, 'base64'), { mode: 0o600 })
+    execFileSync('security', ['create-keychain', '-p', keychainPassword, keychainPath], { stdio: 'inherit' })
+    execFileSync('security', ['set-keychain-settings', '-lut', '21600', keychainPath], { stdio: 'inherit' })
+    execFileSync('security', ['unlock-keychain', '-p', keychainPassword, keychainPath], { stdio: 'inherit' })
+    execFileSync('security', ['list-keychains', '-d', 'user', '-s', keychainPath, ...previousKeychains], {
+      stdio: 'inherit',
+    })
+    execFileSync(
+      'security',
+      ['import', certificatePath, '-k', keychainPath, '-P', APPLE_CERTIFICATE_PASSWORD, '-T', '/usr/bin/codesign'],
+      { stdio: 'inherit' },
+    )
+    execFileSync(
+      'security',
+      ['set-key-partition-list', '-S', 'apple-tool:,apple:,codesign:', '-s', '-k', keychainPassword, keychainPath],
+      { stdio: 'inherit' },
+    )
+    rmSync(certificatePath, { force: true })
+    return { keychainPath, previousKeychains, tempDir }
+  } catch (error) {
+    cleanupSigningCertificate({ keychainPath, previousKeychains, tempDir })
+    throw error
+  }
+}
+
+function cleanupSigningCertificate(signingCertificate) {
+  if (!signingCertificate) return
+  if (signingCertificate.previousKeychains?.length) {
+    spawnSync('security', ['list-keychains', '-d', 'user', '-s', ...signingCertificate.previousKeychains], {
+      stdio: 'ignore',
+    })
+  }
+  if (existsSync(signingCertificate.keychainPath)) {
+    spawnSync('security', ['delete-keychain', signingCertificate.keychainPath], { stdio: 'ignore' })
+  }
+  rmSync(signingCertificate.tempDir, { recursive: true, force: true })
+}
+
+function createDmg({ flavor, identity, keychain }) {
   const conf = readFlavorConf(flavor)
   const { app, dmg } = bundlePaths(flavor)
   if (!existsSync(app)) fail(`${app} does not exist — tauri did not produce the app bundle`)
@@ -333,7 +396,7 @@ function createDmg({ flavor, identity }) {
       stdio: 'inherit',
     })
     log(`signing ${basename(dmg)}…`)
-    execFileSync('codesign', signDmgArgs({ dmg, identity }), { stdio: 'inherit' })
+    execFileSync('codesign', signDmgArgs({ dmg, identity, keychain }), { stdio: 'inherit' })
   } finally {
     rmSync(stagingRoot, { recursive: true, force: true })
   }
@@ -492,7 +555,12 @@ function build({ notarize, requireUpdater = false, flavor }) {
     }
   }
 
-  createDmg({ flavor, identity })
+  const signingCertificate = importSigningCertificate()
+  try {
+    createDmg({ flavor, identity, keychain: signingCertificate?.keychainPath })
+  } finally {
+    cleanupSigningCertificate(signingCertificate)
+  }
   if (notarize) notarizeDmg(bundlePaths(flavor).dmg, credentials)
   verify({ notarized: notarize, flavor })
   printArtifacts(flavor)

--- a/apps/desktop/scripts/release-macos.test.mjs
+++ b/apps/desktop/scripts/release-macos.test.mjs
@@ -5,6 +5,7 @@ import {
   createDmgArgs,
   createReleaseArgs,
   createTauriBuildArgs,
+  parseKeychainList,
   signDmgArgs,
   uploadBetaFeedArgs,
 } from './release-macos.mjs'
@@ -140,4 +141,30 @@ test('DMG signing timestamps the container', () => {
   expect(signDmgArgs({ dmg: 'Reflect.dmg', identity: 'Developer ID Application: Reflect App, LLC (789ULN5MZB)' })).toEqual(
     ['--force', '--sign', 'Developer ID Application: Reflect App, LLC (789ULN5MZB)', '--timestamp', 'Reflect.dmg'],
   )
+})
+
+test('DMG signing can target a temporary CI keychain', () => {
+  expect(
+    signDmgArgs({
+      dmg: 'Reflect.dmg',
+      identity: 'Developer ID Application: Reflect App, LLC (789ULN5MZB)',
+      keychain: '/tmp/reflect-signing.keychain-db',
+    }),
+  ).toEqual([
+    '--force',
+    '--sign',
+    'Developer ID Application: Reflect App, LLC (789ULN5MZB)',
+    '--timestamp',
+    '--keychain',
+    '/tmp/reflect-signing.keychain-db',
+    'Reflect.dmg',
+  ])
+})
+
+test('macOS keychain list output is parsed as paths', () => {
+  expect(
+    parseKeychainList(`    "/Users/runner/Library/Keychains/login.keychain-db"
+    "/Library/Keychains/System.keychain"
+`),
+  ).toEqual(['/Users/runner/Library/Keychains/login.keychain-db', '/Library/Keychains/System.keychain'])
 })

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -52,9 +52,11 @@ can still build unsigned bundles with plain `pnpm tauri build`.
 3. Runs `pnpm tauri build --bundles app`, which stages the `reflect` CLI sidecar, then
    signs inside-out (sidecar → main binary → `.app`) with hardened runtime, notarizes
    the `.app` via `notarytool`, and staples the ticket.
-4. Builds and signs the DMG directly from the notarized app. The release helper avoids
-   Tauri's generated Finder-layout DMG script because that script is brittle on
-   GitHub-hosted macOS images.
+4. Builds and signs the DMG directly from the notarized app. In CI, the release helper
+   imports `APPLE_CERTIFICATE` into its own temporary keychain for this DMG signing step;
+   Tauri's app-signing keychain is internal to `tauri build`. The helper avoids Tauri's
+   generated Finder-layout DMG script because that script is brittle on GitHub-hosted
+   macOS images.
 5. Notarizes and staples the **DMG** itself. Tauri only notarizes the `.app`; without its
    own ticket the DMG container fails `spctl --type open` and downloads can hit
    Gatekeeper friction.
@@ -231,7 +233,7 @@ under **Settings → Secrets and variables → Actions**:
 | Secret | Value |
 | --- | --- |
 | `APPLE_SIGNING_IDENTITY` | Full identity string, e.g. `Developer ID Application: … (TEAMID)` — from `security find-identity -v -p codesigning` |
-| `APPLE_CERTIFICATE` | The Developer ID certificate + private key: export a `.p12` from Keychain Access, then `base64 -i certificate.p12`. Tauri imports it into a temporary keychain on the runner |
+| `APPLE_CERTIFICATE` | The Developer ID certificate + private key: export a `.p12` from Keychain Access, then `base64 -i certificate.p12`. Tauri imports it for the `.app`; the release helper imports it again into a temporary keychain for DMG signing |
 | `APPLE_CERTIFICATE_PASSWORD` | The password set on that `.p12` export |
 | `APPLE_API_KEY` | App Store Connect API key ID, for notarization (preferred in CI — not tied to a personal Apple ID) |
 | `APPLE_API_ISSUER` | The API key's issuer UUID |


### PR DESCRIPTION
## Summary
- import APPLE_CERTIFICATE into a release-owned temporary keychain before manually signing the DMG
- pass that keychain to codesign and restore the previous keychain search list during cleanup
- cover keychain-aware DMG signing args and keychain-list parsing in release helper tests
- update macOS release docs for the separate app and DMG signing keychains

## Context
The v0.3.2 Release workflow got past the previous Tauri bundle_dmg.sh failure. It built, signed, notarized, and stapled the app, produced the updater archive and signature, and created the direct hdiutil DMG. It then failed at the manual DMG codesign step because Tauri's temporary app-signing keychain is internal to tauri build, so the release helper could not find the Developer ID identity afterward.

## Verification
- pnpm --filter @reflect/desktop test --run scripts/release-macos.test.mjs
- pnpm oxlint apps/desktop/scripts/release-macos.mjs apps/desktop/scripts/release-macos.test.mjs
- git diff --check
- pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release signing and keychain mutation on CI runners; scoped to DMG signing when APPLE_CERTIFICATE is set, with restore/cleanup on failure paths.
> 
> **Overview**
> Fixes **macOS release CI** failing at manual **DMG `codesign`** after `tauri build` succeeds: Tauri’s app-signing keychain is internal to the build and isn’t available for the separate hdiutil DMG step.
> 
> When **`APPLE_CERTIFICATE`** is set, the release helper now **imports the `.p12` into its own temporary keychain** (with partition list / search-path setup), passes **`--keychain`** into **`signDmgArgs`**, and **restores the prior user keychain list** in cleanup. Local releases without those env vars behave as before.
> 
> Docs clarify that **`APPLE_CERTIFICATE` is used twice in CI**—by Tauri for the `.app` and again by the helper for DMG signing—with tests for keychain-aware signing args and **`parseKeychainList`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 822b351ad2930a2cd459b9e82d668bea657df173. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->