### PR TITLE
Release v0.3.4-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.3.3"
+version = "0.3.4-beta.1"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.3.3"
+version = "0.3.4-beta.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.3.3",
+  "version": "0.3.4-beta.1",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.3.4-beta.1.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version string updates with no runtime or logic changes.
> 
> **Overview**
> Bumps the desktop app release version from **0.3.3** to **0.3.4-beta.1** in `Cargo.toml`, `tauri.conf.json`, and the lockfile entry for `reflect-open`.
> 
> No application or feature code changes—this is a version-only release prep PR intended to be merged and tagged by the release bump script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97e9b8e1fd36888547c82bb595cd30ee420293b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop app version to `0.3.4-beta.1` across release configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->