### PR TITLE
Add Chrome Web Store extension ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ public key compiled into the app.
 
 Or [build from source](#building-from-source).
 
+## Browser capture
+
+Install
+[Reflect Capture from the Chrome Web Store](https://chromewebstore.google.com/detail/reflect-capture/ccabifmooehighoonjeiololjfofkhkd)
+to save the current page into Reflect from Chrome. The extension captures the
+page URL, title, selected text, screenshot, and optional page text, then hands
+the capture to the installed Mac app through a local native-messaging host.
+
+No Reflect server is in the path. If Reflect is closed, the host queues the
+capture in your graph's local `.reflect/inbox/` folder and the app imports it
+the next time it runs.
+
 ## Your notes are just files
 
 Reflect calls a notes folder a **graph**. Point it at any folder and it
@@ -157,8 +169,9 @@ contributor guide.
 ## Status & roadmap
 
 Reflect is early (`v0.2.2`) but used daily. Shipped today: everything
-listed above, plus browser link capture through the Chrome extension/native
-host pipeline described in the
+listed above, plus browser link capture through the
+[Reflect Capture Chrome extension](https://chromewebstore.google.com/detail/reflect-capture/ccabifmooehighoonjeiololjfofkhkd)
+and native host pipeline described in the
 [link capture design](docs/plans/11-link-capture.md).
 
 Designed or in progress, each with a written plan:

--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -27,11 +27,13 @@ const HOST_NAME: &str = "app.reflect.capture";
 const HOST_BINARY: &str = "reflect-capture-host";
 
 /// Extension IDs allowed to launch the host. The first is the dev/unpacked ID,
-/// pinned by the `key` field in `apps/extension/wxt.config.ts` — the Chrome
-/// Web Store ID joins this list after first publish (the store derives the
-/// same ID when the manifest keeps that key).
+/// pinned by the `key` field in `apps/extension/wxt.config.ts`; the second is
+/// the published Chrome Web Store listing.
 #[cfg(any(target_os = "macos", test))]
-const EXTENSION_ORIGINS: [&str; 1] = ["chrome-extension://dlbliojklpickgimjdmjjdnbjdiomjik/"];
+const EXTENSION_ORIGINS: [&str; 2] = [
+    "chrome-extension://dlbliojklpickgimjdmjjdnbjdiomjik/",
+    "chrome-extension://ccabifmooehighoonjeiololjfofkhkd/",
+];
 
 /// Graph-relative spool directory the host writes and the drain reads.
 const INBOX_DIR: &str = ".reflect/inbox";
@@ -410,8 +412,11 @@ mod tests {
             "/Applications/Reflect.app/Contents/MacOS/reflect-capture-host"
         );
         assert_eq!(
-            parsed["allowed_origins"][0],
-            "chrome-extension://dlbliojklpickgimjdmjjdnbjdiomjik/"
+            parsed["allowed_origins"],
+            serde_json::json!([
+                "chrome-extension://dlbliojklpickgimjdmjjdnbjdiomjik/",
+                "chrome-extension://ccabifmooehighoonjeiololjfofkhkd/"
+            ])
         );
     }
 

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -10,6 +10,9 @@ app is closed: the host spools into the graph's capture inbox
 (`<graph>/.reflect/inbox/`), and the app drains it on next launch.
 [Plan 11](../../docs/plans/11-link-capture.md) is the design doc.
 
+Install the published extension from the
+[Chrome Web Store](https://chromewebstore.google.com/detail/reflect-capture/ccabifmooehighoonjeiololjfofkhkd).
+
 ## Architecture in one breath
 
 popup → `chrome.storage` queue → background `sendNativeMessage` →
@@ -42,12 +45,14 @@ restart Chrome so it re-reads the manifests.
 That message is the `no-host` state — Chrome could not reach (or was not
 allowlisted by) the native-messaging host. Check, in order:
 
-1. **The extension's ID.** In `chrome://extensions`, the card must read
-   `dlbliojklpickgimjdmjjdnbjdiomjik`. Any other ID means you loaded a
-   **keyless** build (typically `.output/chrome-mv3` right after `pnpm zip`,
-   which builds with `WXT_STORE_BUILD=true`). Rebuild with `pnpm … dev` or
-   `pnpm … build`, then **Reload** the extension. The host allowlists only the
-   pinned ID, so a wrong ID is rejected as "forbidden" → this message.
+1. **The extension's ID.** In `chrome://extensions`, the card must read either
+   `ccabifmooehighoonjeiololjfofkhkd` for the Chrome Web Store listing or
+   `dlbliojklpickgimjdmjjdnbjdiomjik` for an unpacked development build. Any
+   other ID means you loaded a **keyless** local build (typically
+   `.output/chrome-mv3` right after `pnpm zip`, which builds with
+   `WXT_STORE_BUILD=true`). Rebuild with `pnpm … dev` or `pnpm … build`, then
+   **Reload** the extension. The host allowlists only the store and pinned dev
+   IDs, so a wrong ID is rejected as "forbidden" → this message.
 2. **The desktop app has run at least once** on this machine, so it has written
    `~/Library/Application Support/<browser>/NativeMessagingHosts/app.reflect.capture.json`.
    If Chrome was already open when that file appeared, restart Chrome.
@@ -69,14 +74,15 @@ updating that constant silently breaks it. The private half of the key is
 deliberately discarded; unpacked loads only need the public key.
 
 **The Chrome Web Store does not use this key.** It rejects a `key` field in the
-uploaded package (`key field is not allowed in manifest`) and mints its own
-permanent ID for the listing — which will *not* be the ID above. So:
+uploaded package (`key field is not allowed in manifest`) and minted the live
+listing ID `ccabifmooehighoonjeiololjfofkhkd`. So:
 
 - The store artifact must **omit** `key`. `pnpm zip` sets `WXT_STORE_BUILD=true`,
   which drops it; every other build keeps it. (`manifest-key.test.ts` still pins
   the dev key against `EXTENSION_ORIGINS`.)
-- After the listing is created, the native hop will **not** reach store-installed
-  users until the store's assigned ID is allowlisted too — see step 4 below.
+- `apps/desktop/src-tauri/src/capture.rs` must keep both the store ID and the
+  pinned dev ID in `EXTENSION_ORIGINS`, or the native hop will fail for one of
+  the two install modes.
 
 To derive an ID from a key (if it ever has to change):
 
@@ -87,13 +93,13 @@ openssl rsa -in key.pem -pubout -outform DER | shasum -a 256 \
   | head -c 32 | tr '0123456789abcdef' 'abcdefghijklmnop'    # extension ID
 ```
 
-## Releasing to the Chrome Web Store
+## Releasing updates to the Chrome Web Store
 
-The build is store-ready: `pnpm --filter @reflect/extension zip` produces a
-key-stripped, signed-on-upload package whose manifest declares only the permissions
-the code uses (see the justifications below). The remaining work is the listing — the
-copy and disclosures below are written to be pasted straight into the
-[Developer Dashboard](https://chrome.google.com/webstore/devconsole).
+`pnpm --filter @reflect/extension zip` produces a key-stripped,
+signed-on-upload package whose manifest declares only the permissions the code
+uses (see the justifications below). Upload updates to the existing
+[Reflect Capture listing](https://chromewebstore.google.com/detail/reflect-capture/ccabifmooehighoonjeiololjfofkhkd)
+in the [Developer Dashboard](https://chrome.google.com/webstore/devconsole).
 
 ### Build & upload
 
@@ -102,12 +108,9 @@ copy and disclosures below are written to be pasted straight into the
 2. `pnpm --filter @reflect/extension zip` → upload
    `.output/reflect-capture-<version>-chrome.zip`. This artifact omits the manifest
    `key` (the store rejects it); a plain `wxt build` keeps it for unpacked loads.
-3. After the listing is created, copy its **assigned item ID** from the dashboard
-   (it will not be `dlbliojklpickgimjdmjjdnbjdiomjik`).
-4. Append `chrome-extension://<store-id>/` to `EXTENSION_ORIGINS` in
-   `apps/desktop/src-tauri/src/capture.rs` (keep the dev ID) and ship a desktop
-   release — the native-messaging host manifests rewrite themselves on next launch.
-   Until that ships, capture works for unpacked dev loads but not for store installs.
+3. Keep `chrome-extension://ccabifmooehighoonjeiololjfofkhkd/` in
+   `EXTENSION_ORIGINS` in `apps/desktop/src-tauri/src/capture.rs`; the
+   native-messaging host manifests rewrite themselves on each desktop launch.
 
 ### Listing copy
 

--- a/apps/extension/manifest-key.test.ts
+++ b/apps/extension/manifest-key.test.ts
@@ -6,11 +6,12 @@ import { describe, expect, it } from 'vitest'
 /**
  * Drift guard for the pinned extension identity. The manifest `key` in
  * `wxt.config.ts` determines the extension ID everywhere (unpacked dev, CI,
- * the Chrome Web Store), and the desktop app's native-messaging manifests
+ * but not the Chrome Web Store), and the desktop app's native-messaging manifests
  * (`apps/desktop/src-tauri/src/capture.rs`, `EXTENSION_ORIGINS`) must
- * allowlist exactly that ID — they are coupled only by convention, so this
- * test recomputes the derivation (SHA-256 of the DER key, first 16 bytes,
- * hex mapped onto a–p) and pins the two files together.
+ * allowlist that ID for development alongside the published store ID. They
+ * are coupled only by convention, so this test recomputes the derivation
+ * (SHA-256 of the DER key, first 16 bytes, hex mapped onto a-p) and pins the
+ * two files together.
  */
 
 const here = resolve(import.meta.dirname)
@@ -37,8 +38,8 @@ describe('pinned extension identity', () => {
     )
     expect(originMatches.length, 'no extension origins found in capture.rs').toBeGreaterThan(0)
 
-    // The dev/unpacked ID derived from the committed key must be among the
-    // allowlisted origins (the store ID joins the list after first publish).
+    // The dev/unpacked ID derived from the committed key must stay among the
+    // allowlisted origins even though the Chrome Web Store listing has its own ID.
     expect(originMatches).toContain(extensionIdFromKey(keyMatch![1]!))
   })
 })

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -11,10 +11,9 @@ import { SAVE_CURRENT_PAGE_COMMAND } from './lib/commands'
  *
  * The Chrome Web Store is different: it **rejects** a `key` in the uploaded
  * package ("key field is not allowed in manifest") and mints its own permanent
- * ID for the listing — which will NOT be the ID above. So the store artifact
- * must omit `key` (see `WXT_STORE_BUILD` below), and once the listing exists
- * its assigned ID has to be added to `EXTENSION_ORIGINS` for the native hop to
- * work for store-installed users.
+ * ID for the listing: `ccabifmooehighoonjeiololjfofkhkd`. So the store
+ * artifact must omit `key` (see `WXT_STORE_BUILD` below), while the desktop
+ * native-messaging allowlist keeps both IDs.
  */
 const PUBLIC_KEY =
   'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7EMDbrG/PhZAaAz9GauuPizNI+98ua2aaI5yDgDEbXMk86Wm6LByEVD/ZVAJCa+Ic8xXeLw4GEDyNPPxM940eeoeDbU3KHWp1jl99WroEhMXFl1uYyXQ/0yFhZwIolDEt02uDCF+fDS93UMP8AJQKYxtLO2NH4wsv66gdRP1CEA82VUXiJV0R9b1BvIVVr8HJFHR4zmA9YsNbBTUQtkOGYuSz4mWrSZ7QKWP7RDdQcHFI6t9Y58+Bk8/4Ps1gmbGHPCWy5iURQ37m8ibPaVvrGOrAoS3n09E/4jP2OeCa2oM2gH3AcEz7T6daTdk+rzJ0VMbR4PNKLOiLYknxsigDQIDAQAB'

--- a/docs/plans/11-link-capture.md
+++ b/docs/plans/11-link-capture.md
@@ -77,8 +77,9 @@ the inbox *is* the IPC:
 - The desktop app **rewrites user-level host manifests on every launch**, for **detected
   browsers only** (Chrome channels, Chromium, Edge, Brave, Vivaldi, Opera, Arc — Arc has
   its own dir; Windows uses HKCU keys). Launch-time rewrite self-heals macOS app
-  translocation and app moves. `allowed_origins` pins both the Chrome Web Store and Edge
-  Add-ons extension IDs; dev builds share the store ID via the manifest `key` trick.
+  translocation and app moves. `allowed_origins` pins both the Chrome Web Store
+  listing ID and the key-derived unpacked dev ID; a future Edge Add-ons listing
+  would add its own ID too.
 - **Fallback: loopback HTTP** only if native-messaging **packaging** proves unshippable
   (payload size is not a reason). If ever built, copy Joplin's model: loopback-only
   bind, `/ping` discovery, accept/reject pairing dialog minting a token, Host-header

--- a/docs/spikes/link-capture-bridge.md
+++ b/docs/spikes/link-capture-bridge.md
@@ -87,8 +87,9 @@ must-be-running flaw) is pure cost. Instead:
     Chrome/Brave/Vivaldi/Opera, and Edge falls back to it by documented search order; add
     an explicit Edge key for completeness.
   - The manifest `path` may point inside the .app bundle (standard practice).
-- **Stable extension IDs:** pin the Chrome Web Store ID via the manifest `key` trick so
-  dev builds share it; list both CWS and Edge Add-ons IDs in `allowed_origins`
+- **Stable extension IDs:** the Chrome Web Store mints the listing ID, while unpacked
+  dev builds keep a separate key-derived ID via the manifest `key` trick. List both in
+  `allowed_origins`; add the Edge Add-ons ID there too if/when an Edge listing ships
   (wildcards are not allowed). Firefox later: different manifest (`allowed_extensions` +
   fixed gecko ID); Safari: a wholly different pipeline (extension inside a containing
   app, `SFSafariWebExtensionHandler`) — out of first wave, but see §6.


### PR DESCRIPTION
## Summary
- Allowlist the published Reflect Capture Chrome Web Store ID in the native-messaging host origins.
- Update extension and repo docs to point at the live Chrome Web Store listing.
- Correct launch-era docs that said the manifest key could pin the Store ID.

## Testing
- PATH="/Users/alex/.nvm/versions/node/v24.14.0/bin:/opt/homebrew/opt/rustup/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/opt/rustup/bin:/Users/alex/.codex/tmp/arg0/codex-arg0Rj4e8o:/Users/alex/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/alex/.nvm/versions/node/v24.14.0/bin:/Users/alex/.local/bin:/opt/homebrew/share/google-cloud-sdk/bin:/Users/alex/.lmstudio/bin:/Applications/Codex.app/Contents/Resources" pnpm check
- corepack pnpm --filter @reflect/extension test -- --run manifest-key.test.ts
- PATH="/Users/alex/.nvm/versions/node/v24.14.0/bin:/opt/homebrew/opt/rustup/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/opt/rustup/bin:/Users/alex/.codex/tmp/arg0/codex-arg0Rj4e8o:/Users/alex/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/alex/.nvm/versions/node/v24.14.0/bin:/Users/alex/.local/bin:/opt/homebrew/share/google-cloud-sdk/bin:/Users/alex/.lmstudio/bin:/Applications/Codex.app/Contents/Resources" pnpm --filter @reflect/desktop sidecar
- cargo test -p reflect-open
- cargo test -p reflect-open capture::tests::manifest_pins_name_path_and_origins

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the native-messaging `allowed_origins` security boundary; incorrect IDs would block capture, but the change is additive and covered by Rust/TS tests.
> 
> **Overview**
> **Store-installed Reflect Capture can talk to the desktop native-messaging host.** `EXTENSION_ORIGINS` in `capture.rs` now allowlists both the key-pinned unpacked dev ID (`dlbliojklpickgimjdmjjdnbjdiomjik`) and the live Chrome Web Store listing (`ccabifmooehighoonjeiololjfofkhkd`); the manifest unit test expects both origins.
> 
> **Docs are aligned with how Chrome actually assigns IDs.** Root and extension READMEs add the Web Store install link and a **Browser capture** section; troubleshooting and release steps describe two valid extension IDs instead of “add the store ID after first publish.” Comments in `wxt.config.ts`, `manifest-key.test.ts`, and link-capture design/spike docs state that the store mints its own ID and does not use the manifest `key`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6186caa2f87c14f5f931feea38e12ea0a2a64ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->