### PR TITLE
Release v0.3.4-beta.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.3.4-beta.3"
+version = "0.3.4-beta.4"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.3.4-beta.3"
+version = "0.3.4-beta.4"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.3.4-beta.3",
+  "version": "0.3.4-beta.4",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.3.4-beta.4.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata changes with no application logic, security, or data-handling modifications.
> 
> **Overview**
> **Release bump** from `0.3.4-beta.3` to **`0.3.4-beta.4`** with no functional code changes.
> 
> The version string is updated in **`apps/desktop/src-tauri/Cargo.toml`**, **`tauri.conf.json`**, and the **`reflect-open`** entry in **`Cargo.lock`** so the Tauri bundle and lockfile stay aligned for tagging and the release pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9650370bd5774aa1f5338518cbb81a754deb7707. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->