### PR TITLE
fix(desktop): stop checkbox text shifting on bullet conversion

### DIFF
--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -576,14 +576,28 @@ html:root {
   border-width: 1px;
   border-color: var(--text-muted); /* crisper than the pale --border at 1px */
 }
-/* Widen the gap between a task checkbox and its label, for both the square
-   (`- [ ]`) and rounded (`+ [ ]`, data-list-marker="+") markers. Both render as
-   data-list-kind="task", so this covers them together. ProseKit/meowdown size
-   the marker box at 1lh and start `.list-content` flush against it (default
-   `margin-inline-start: 1lh`); nudge the content right for more breathing room.
-   At 0-4-0 this clears both base rules (each 0-2-0). */
+/* Task checkbox spacing. Two rules work together to give the checkbox breathing
+   room from its label (PR #373's goal) WITHOUT moving the label — moving it
+   misaligns the label from sibling bullets and makes bullet<->task conversion
+   jump sideways (the `1.25lh` content nudge #373 originally shipped did exactly
+   that).
+
+   1. Content keeps meowdown's default 1lh (the value bullets use), so a
+      checkbox's label lines up with bullet text and converting a line between
+      bullet (`- `) and task (`- [ ]`) doesn't shift it.
+   2. The checkbox is pinned to the start of its 1lh marker box instead of
+      centered (meowdown defaults task markers to `justify-content: center`). A
+      `.95rem` checkbox flush-left lands its right edge ~where a centered bullet
+      dot's sits, so the checkbox<->label gap matches a bullet's. The breathing
+      room comes from the marker, not from indenting the text.
+
+   Both selectors add `.reflect-editor` to reach 0-4-0, clearing meowdown's
+   0-3-0 base rules (which inject after this file). */
 .reflect-editor .prosemirror-flat-list[data-list-kind='task'] > .list-content {
-  margin-inline-start: 1.25lh;
+  margin-inline-start: 1lh;
+}
+.reflect-editor .prosemirror-flat-list[data-list-kind='task'] > .list-marker {
+  justify-content: start;
 }
 
 /* ---- shadcn inputs (components/ui/) -------------------------------------


### PR DESCRIPTION
## What

Converting an editor list item between a bullet (`- `) and a checkbox/task (`- [ ]`) shifted the text horizontally, and checkbox labels sat misaligned from sibling bullet text in the same list.

## Why

[#373](https://github.com/team-reflect/reflect-open/pull/373) intentionally bumped task `.list-content` from meowdown's default `margin-inline-start: 1lh` to `1.25lh` to give the checkbox breathing room from its label. But the bullet dot and the checkbox share the same `1lh`-wide marker box, so that extra `0.25lh`:

- pushed checkbox labels right of sibling bullet labels, and
- nudged the text sideways when a line was converted between bullet and task.

(#373's testing note — *"not yet eyeballed in a running build"* — suggests the side effect was never seen.)

## Change

Keep #373's breathing room **without** the misalignment by splitting the two concerns across the marker and the content (`apps/desktop/src/styles/index.css`):

1. **Content returns to `1lh`** — checkbox labels line up with bullet labels, and converting a line between bullet and task no longer shifts the text.
2. **The checkbox is pinned to the start of its marker box** (`justify-content: start`) instead of centered. A `0.95rem` checkbox flush-left lands its right edge ~where a centered bullet dot's sits, so the checkbox→label gap is preserved — the breathing room now comes from the marker, not from indenting the text.

## Verification

Built a mock from meowdown's own list rules and measured the rendered geometry:

| | checkbox text x | bullet text x | checkbox→label gap |
|---|---|---|---|
| Before (#373) | 76px | 68.8px | 14px |
| After (this fix) | **68.8px** | **68.8px** | **13.6px** |

Text is now perfectly aligned (no shift on convert) while ~97% of #373's breathing room is retained.

## Notes for reviewers

- CSS-only, scoped to `.reflect-editor` task lists — `pnpm typecheck`/`lint` don't cover it.
- Covers both the square (`- [ ]`) and rounded (`+ [ ]`, `data-list-marker="+"`) markers, since both render as `data-list-kind='task'`.
- Trade-off: the checkbox now sits flush to the text margin rather than centered in its marker column, so in a mixed bullet+checkbox list the checkbox's left edge is slightly left of the bullet dot. Its right edge (the side facing the text) still aligns, and the text columns match — which is the alignment the bug was about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)