### PR TITLE
Fix Task View sync after note-side task reopen

### DIFF
--- a/apps/desktop/src/components/tasks/tasks-screen.test.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.test.tsx
@@ -204,13 +204,16 @@ function RouteProbe(): ReactNode {
 
 function renderScreen() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  return render(
-    <QueryClientProvider client={client}>
-      <RouterProvider>
-        <TasksScreen />
-        <RouteProbe />
-      </RouterProvider>
-    </QueryClientProvider>,
+  return Object.assign(
+    render(
+      <QueryClientProvider client={client}>
+        <RouterProvider>
+          <TasksScreen />
+          <RouteProbe />
+        </RouterProvider>
+      </QueryClientProvider>,
+    ),
+    { client },
   )
 }
 
@@ -1373,6 +1376,36 @@ describe('TasksScreen', () => {
     // Flipped to completed in place — still on screen, now marked done.
     await view.findByRole('button', { name: 'Reopen: project task' })
     expect(view.getByText('project task')).toBeDefined()
+    view.unmount()
+  })
+
+  it('syncs a recently completed row back to open when the note reports it reopened', async () => {
+    toggleTask.mockResolvedValue(undefined)
+    let indexedOpen = task({
+      notePath: 'notes/p.md',
+      markerOffset: 5,
+      raw: '[ ] project task',
+      text: 'project task',
+      noteTitle: 'P',
+      updatedAt: 1,
+    })
+    getOpenTasks.mockImplementation(async () => [indexedOpen])
+    const view = renderScreen()
+
+    await userEvent.click(await view.findByRole('button', { name: 'Complete: project task' }))
+    await view.findByRole('button', { name: 'Reopen: project task' })
+
+    indexedOpen = { ...indexedOpen, updatedAt: 2 }
+    await view.client.invalidateQueries()
+
+    await view.findByRole('button', { name: 'Complete: project task' })
+    await userEvent.click(view.getByRole('button', { name: 'Complete: project task' }))
+
+    await waitFor(() => expect(toggleTask).toHaveBeenCalledTimes(2))
+    expect(toggleTask).toHaveBeenLastCalledWith(
+      expect.objectContaining({ notePath: 'notes/p.md', markerOffset: 5, raw: '[ ] project task' }),
+      1,
+    )
     view.unmount()
   })
 

--- a/apps/desktop/src/components/tasks/tasks-screen.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.tsx
@@ -19,7 +19,10 @@ import {
 } from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { useRecentlyCompleted } from '@/lib/tasks/recently-completed'
+import {
+  forgetRecentlyCompletedNowOpen,
+  useRecentlyCompleted,
+} from '@/lib/tasks/recently-completed'
 import { sameTask, taskKey } from '@/lib/tasks/task-identity'
 import { type InsertTaskTarget } from '@/lib/tasks/task-insert-target'
 import { scrollTaskIntoView } from '@/lib/tasks/task-navigation'
@@ -119,9 +122,16 @@ export function TasksScreen(): ReactElement {
   // tasks to show." while the completed query is still loading.
   const ready = open !== undefined && (!filters.archived || completed !== undefined)
   const { onScroll } = useScrollRestoration(scrollElement, ready)
+  const graphRoot = graph?.root ?? null
 
   // This session's completed tasks, still showing struck until archived.
-  const recentlyCompleted = useRecentlyCompleted(graph?.root ?? null)
+  const recentlyCompleted = useRecentlyCompleted(graphRoot)
+  useEffect(() => {
+    if (open === undefined) {
+      return
+    }
+    forgetRecentlyCompletedNowOpen(graphRoot, open)
+  }, [graphRoot, open])
 
   const needle = query.trim().toLowerCase()
   const groups = useMemo(() => {

--- a/apps/desktop/src/lib/tasks/recently-completed.test.ts
+++ b/apps/desktop/src/lib/tasks/recently-completed.test.ts
@@ -4,6 +4,7 @@ import { type OpenTask } from '@reflect/core'
 import {
   archiveRecentlyCompleted,
   forgetRecentlyCompleted,
+  forgetRecentlyCompletedNowOpen,
   markRecentlyCompleted,
   resetRecentlyCompleted,
   useRecentlyCompleted,
@@ -65,6 +66,22 @@ describe('recently-completed', () => {
     expect(result.current.map((t) => t.notePath)).toEqual(['b.md'])
 
     act(() => archiveRecentlyCompleted('/g'))
+    expect(result.current).toEqual([])
+  })
+
+  it('forgets session completions only when a newer open index row appears', () => {
+    const { result } = renderHook(() => useRecentlyCompleted('/g'))
+    const completed = task({ notePath: 'a.md', markerOffset: 2, updatedAt: 10 })
+    act(() => markRecentlyCompleted('/g', [completed]))
+
+    act(() => forgetRecentlyCompletedNowOpen('/g', [{ ...completed, checked: false, raw: '[ ] do it' }]))
+    expect(result.current).toHaveLength(1)
+
+    act(() =>
+      forgetRecentlyCompletedNowOpen('/g', [
+        { ...completed, checked: false, raw: '[ ] do it', updatedAt: 11 },
+      ]),
+    )
     expect(result.current).toEqual([])
   })
 

--- a/apps/desktop/src/lib/tasks/recently-completed.ts
+++ b/apps/desktop/src/lib/tasks/recently-completed.ts
@@ -71,6 +71,29 @@ export function forgetRecentlyCompleted(root: string | null, keys: readonly stri
   }
 }
 
+/**
+ * Reconcile the session-completed set after the indexed open-task query changes.
+ * If the index now reports a newer version of the same checkbox as open, the
+ * note was reopened somewhere else (for example in the daily note), so the
+ * struck Tasks-view copy must stop shadowing the real open row.
+ */
+export function forgetRecentlyCompletedNowOpen(
+  root: string | null,
+  openTasks: readonly OpenTask[],
+): void {
+  if (root !== graphRoot || tasks.length === 0 || openTasks.length === 0) {
+    return
+  }
+  const openByKey = new Map(openTasks.map((task) => [taskKey(task), task]))
+  const reopenedKeys = tasks
+    .filter((task) => {
+      const openTask = openByKey.get(taskKey(task))
+      return openTask !== undefined && openTask.updatedAt > task.updatedAt
+    })
+    .map(taskKey)
+  forgetRecentlyCompleted(root, reopenedKeys)
+}
+
 /** Whether a task is currently being kept visible by the session's struck set. */
 export function hasRecentlyCompleted(root: string | null, key: string): boolean {
   return root === graphRoot && tasks.some((task) => taskKey(task) === key)


### PR DESCRIPTION
## Context

Task View deliberately keeps a session-only middle state: after you complete a task from Task View, the row stays visible and struck through until you archive it. That mirrors the V1 workflow and gives users a quick undo path.

The support report exposed the missing reconciliation path. If the same checkbox is reopened from the source note, such as a daily note, the index eventually reports that task as open again, but Task View was still letting the session-completed `[x]` copy shadow the real `[ ]` row. The row kept offering **Reopen**, and clicking it attempted to find the old completed line in markdown that had already changed, producing the “task line no longer in note” toast.

## What Changed

- Adds `forgetRecentlyCompletedNowOpen`, which reconciles the session-completed set against the latest open-task index rows.
- Removes a struck session copy only when the indexed open row has the same task identity and a strictly newer `updatedAt`.
- Runs that reconciliation in `TasksScreen` whenever the open-task query updates, so note-side reopen wins once the index has actually caught up.
- Preserves the intended Task View middle state when an open-task refetch is stale or same-version noise.
- Adds regression coverage for both the store rule and the full screen flow.

## User-Facing Behavior

After this PR:

- Completing a task in Task View still leaves it struck through until Archive.
- Reopening the same task in its source note now makes Task View show it as open again.
- The next Task View action uses the current `[ ]` markdown row instead of a stale `[x]` row, avoiding the support-channel failure mode.

## Verification

Passed in the linked worktree:

- `./node_modules/.bin/vitest run src/components/tasks/tasks-screen.test.tsx` (57 tests)
- `./node_modules/.bin/vitest run src/lib/tasks/recently-completed.test.ts` (5 tests)
- `./node_modules/.bin/tsc --noEmit` from `apps/desktop`
- `./node_modules/.bin/oxlint apps packages` (exit 0; existing warnings only)
- `./node_modules/.bin/eslint .` from `apps/desktop` (exit 0; existing warnings only)
- `./node_modules/.bin/vite build` from `apps/desktop` (passes; existing chunk-size warnings only)
- `git diff --check`

`pnpm check` could not start in this linked worktree because pnpm attempted to remove `node_modules` without a TTY. To avoid mutating the shared dependency install, I ran the underlying typecheck, lint, and build checks directly.

## Risk and Rollout

This is a low-risk UI/session-state change:

- No markdown format changes.
- No index migrations.
- No persistence changes.
- No external service calls.

The reconciliation depends on `updatedAt` advancing when the note-side reopen is indexed. If a platform failed to advance that timestamp, Task View could keep the struck session row until a later refresh or archive, but the existing markdown write guard would still prevent data loss. Rollback is a normal revert of this branch.
