### PR TITLE
Fix task parsing to exclude checklists

### DIFF
--- a/apps/desktop/src/components/tasks/tasks-screen.test.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.test.tsx
@@ -664,7 +664,7 @@ describe('TasksScreen', () => {
     await userEvent.keyboard('{Enter}')
     await view.findByTestId('task-editor')
     // An empty Return-to-add row, left untouched, is removed rather than left as a
-    // blank `- [ ] ` line — the real editor routes that empty exit to delete (see
+    // blank `+ [ ] ` line — the real editor routes that empty exit to delete (see
     // the finalizer unit test); here we check the optimistic row's identity flows
     // through, deleting the freshly written daily-note line, not some other row.
     await userEvent.click(view.getByRole('button', { name: 'delete-edit' }))
@@ -744,7 +744,7 @@ describe('TasksScreen', () => {
     await userEvent.click(await view.findByRole('button', { name: 'first' }))
     await view.findByTestId('task-editor')
     await userEvent.click(view.getByRole('button', { name: 'continue-empty' }))
-    // The cleared row is deleted (not edited to `- [ ]`); editTask is never called.
+    // The cleared row is deleted (not edited to `+ [ ]`); editTask is never called.
     await waitFor(() =>
       expect(deleteTask).toHaveBeenCalledWith(expect.objectContaining({ notePath: 'notes/a.md' }), 1),
     )

--- a/apps/desktop/src/editor/note-session.test.ts
+++ b/apps/desktop/src/editor/note-session.test.ts
@@ -184,17 +184,17 @@ describe('createNoteSession', () => {
 
   it('re-gates protection when external content stops being representable', async () => {
     const lossyWhenTasks = (markdown: string): RoundTripFidelity =>
-      markdown.includes('- [ ]') ? 'lossy' : 'exact'
+      markdown.includes('+ [ ]') ? 'lossy' : 'exact'
     const { session, snapshots, setDisk } = harness({ classify: lossyWhenTasks })
     session.load()
     await settled()
     expect(snapshots.at(-1)?.protected).toBe(false)
 
-    setDisk('- [ ] now has tasks\n')
+    setDisk('+ [ ] now has tasks\n')
     session.externalChanged()
     await settled()
     expect(snapshots.at(-1)?.protected).toBe(true)
-    expect(snapshots.at(-1)?.initialContent).toBe('- [ ] now has tasks\n')
+    expect(snapshots.at(-1)?.initialContent).toBe('+ [ ] now has tasks\n')
   })
 })
 
@@ -218,8 +218,8 @@ describe('frontmatter ownership (Plan 07b)', () => {
 
   it('a protected note shows the full file, frontmatter included', async () => {
     const h = harness({
-      disk: `${FM}- [ ] lossy body\n`,
-      classify: (markdown) => (markdown.includes('- [ ]') ? 'lossy' : 'exact'),
+      disk: `${FM}+ [ ] lossy body\n`,
+      classify: (markdown) => (markdown.includes('+ [ ]') ? 'lossy' : 'exact'),
     })
     h.session.load()
     await vi.runAllTimersAsync()
@@ -227,7 +227,7 @@ describe('frontmatter ownership (Plan 07b)', () => {
     expect(ready?.protected).toBe(true)
     // The read-only view's job is honest display of a file we refuse to
     // touch — hiding the frontmatter would misrepresent it.
-    expect(ready?.initialContent).toBe(`${FM}- [ ] lossy body\n`)
+    expect(ready?.initialContent).toBe(`${FM}+ [ ] lossy body\n`)
   })
 
   it('saves rejoin the exact header bytes around the edited body', async () => {
@@ -705,50 +705,50 @@ describe('retarget (Plan 17)', () => {
 
 describe('commitTaskToggle', () => {
   it('toggles the marker while preserving unsaved edits, and reflects it in the editor', async () => {
-    const source = '# Todo\n\n- [ ] buy milk\n'
+    const source = '# Todo\n\n+ [ ] buy milk\n'
     const h = harness({ disk: source })
     h.session.load()
     await settled()
 
     // The user appends a line below the task — unsaved when the toggle arrives.
-    h.session.editorChanged('# Todo\n\n- [ ] buy milk\n\njot\n')
+    h.session.editorChanged('# Todo\n\n+ [ ] buy milk\n\njot\n')
     expect(h.snapshots.at(-1)?.dirty).toBe(true)
 
     const applied = await h.session.commitTaskToggle(firstTask(source))
     expect(applied).toBe(true)
     // The write carries both the unsaved edit and the toggled marker.
-    expect(h.writes.at(-1)?.contents).toBe('# Todo\n\n- [x] buy milk\n\njot\n')
+    expect(h.writes.at(-1)?.contents).toBe('# Todo\n\n+ [x] buy milk\n\njot\n')
     // The open editor was updated to show the toggled checkbox.
-    expect(h.applied.at(-1)).toBe('# Todo\n\n- [x] buy milk\n\njot\n')
+    expect(h.applied.at(-1)).toBe('# Todo\n\n+ [x] buy milk\n\njot\n')
   })
 
   it('toggles a clean note (frontmatter offset intact) and writes only the marker', async () => {
-    const source = '---\nid: 01abc\n---\n- [ ] ship it\n'
+    const source = '---\nid: 01abc\n---\n+ [ ] ship it\n'
     const h = harness({ disk: source })
     h.session.load()
     await settled()
 
     expect(await h.session.commitTaskToggle(firstTask(source))).toBe(true)
-    expect(h.writes.at(-1)?.contents).toBe('---\nid: 01abc\n---\n- [x] ship it\n')
+    expect(h.writes.at(-1)?.contents).toBe('---\nid: 01abc\n---\n+ [x] ship it\n')
   })
 
   it('refuses (returns false) a protected note rather than write', async () => {
-    const h = harness({ disk: '- [ ] x\n', classify: () => 'lossy' })
+    const h = harness({ disk: '+ [ ] x\n', classify: () => 'lossy' })
     h.session.load()
     await settled()
 
-    expect(await h.session.commitTaskToggle(firstTask('- [ ] x\n'))).toBe(false)
+    expect(await h.session.commitTaskToggle(firstTask('+ [ ] x\n'))).toBe(false)
     expect(h.writes).toEqual([])
   })
 
   it('refuses (returns false) while a conflict is parked', async () => {
-    const source = '- [ ] x\n'
+    const source = '+ [ ] x\n'
     const h = harness({ disk: source })
     h.session.load()
     await settled()
 
-    h.session.editorChanged('- [ ] x edited\n') // dirty
-    h.setDisk('- [ ] x external\n')
+    h.session.editorChanged('+ [ ] x edited\n') // dirty
+    h.setDisk('+ [ ] x external\n')
     h.session.externalChanged() // parks a conflict (dirty + divergent disk)
     await settled()
 
@@ -756,7 +756,7 @@ describe('commitTaskToggle', () => {
   })
 
   it('reverts the toggle and surfaces the error when the write fails', async () => {
-    const source = '- [ ] x\n'
+    const source = '+ [ ] x\n'
     const h = harness({ disk: source })
     h.session.load()
     await settled()
@@ -765,74 +765,74 @@ describe('commitTaskToggle', () => {
     await expect(h.session.commitTaskToggle(firstTask(source))).rejects.toThrow('disk full')
     // Transactional: nothing persisted, so the buffer and the editor revert to
     // the un-toggled line (no divergence with the rolled-back Tasks list).
-    expect(h.session.content()).toBe('- [ ] x\n')
-    expect(h.applied.at(-1)).toBe('- [ ] x\n')
+    expect(h.session.content()).toBe('+ [ ] x\n')
+    expect(h.applied.at(-1)).toBe('+ [ ] x\n')
     expect(h.snapshots.at(-1)?.error).toBeNull()
   })
 
   it('propagates TaskStaleError when the task line is gone', async () => {
-    const source = '- [ ] gone\n'
+    const source = '+ [ ] gone\n'
     const h = harness({ disk: source })
     h.session.load()
     await settled()
 
-    h.session.editorChanged('- [ ] something else entirely\n')
+    h.session.editorChanged('+ [ ] something else entirely\n')
     await expect(h.session.commitTaskToggle(firstTask(source))).rejects.toBeInstanceOf(TaskStaleError)
   })
 })
 
 describe('commitTaskEdit', () => {
   it('rewrites the content while preserving unsaved edits, reflected in the editor', async () => {
-    const source = '# Todo\n\n- [ ] buy milk\n'
+    const source = '# Todo\n\n+ [ ] buy milk\n'
     const h = harness({ disk: source })
     h.session.load()
     await settled()
 
-    h.session.editorChanged('# Todo\n\n- [ ] buy milk\n\njot\n') // unsaved when the edit arrives
+    h.session.editorChanged('# Todo\n\n+ [ ] buy milk\n\njot\n') // unsaved when the edit arrives
     expect(await h.session.commitTaskEdit(firstTask(source), 'buy oat milk')).toBe(true)
-    expect(h.writes.at(-1)?.contents).toBe('# Todo\n\n- [ ] buy oat milk\n\njot\n')
-    expect(h.applied.at(-1)).toBe('# Todo\n\n- [ ] buy oat milk\n\njot\n')
+    expect(h.writes.at(-1)?.contents).toBe('# Todo\n\n+ [ ] buy oat milk\n\njot\n')
+    expect(h.applied.at(-1)).toBe('# Todo\n\n+ [ ] buy oat milk\n\njot\n')
   })
 
   it('keeps a checked marker when editing a completed task', async () => {
-    const source = '- [x] done\n'
+    const source = '+ [x] done\n'
     const h = harness({ disk: source })
     h.session.load()
     await settled()
 
     expect(await h.session.commitTaskEdit(firstTask(source), 'really done')).toBe(true)
-    expect(h.writes.at(-1)?.contents).toBe('- [x] really done\n')
+    expect(h.writes.at(-1)?.contents).toBe('+ [x] really done\n')
   })
 
   it('refuses (returns false) a protected note rather than write', async () => {
-    const h = harness({ disk: '- [ ] x\n', classify: () => 'lossy' })
+    const h = harness({ disk: '+ [ ] x\n', classify: () => 'lossy' })
     h.session.load()
     await settled()
 
-    expect(await h.session.commitTaskEdit(firstTask('- [ ] x\n'), 'y')).toBe(false)
+    expect(await h.session.commitTaskEdit(firstTask('+ [ ] x\n'), 'y')).toBe(false)
     expect(h.writes).toEqual([])
   })
 
   it('reverts and surfaces the error when the write fails', async () => {
-    const source = '- [ ] x\n'
+    const source = '+ [ ] x\n'
     const h = harness({ disk: source })
     h.session.load()
     await settled()
 
     h.failWrites('disk full')
     await expect(h.session.commitTaskEdit(firstTask(source), 'y')).rejects.toThrow('disk full')
-    expect(h.session.content()).toBe('- [ ] x\n')
-    expect(h.applied.at(-1)).toBe('- [ ] x\n')
+    expect(h.session.content()).toBe('+ [ ] x\n')
+    expect(h.applied.at(-1)).toBe('+ [ ] x\n')
     expect(h.snapshots.at(-1)?.error).toBeNull()
   })
 
   it('propagates TaskStaleError when the task line is gone', async () => {
-    const source = '- [ ] gone\n'
+    const source = '+ [ ] gone\n'
     const h = harness({ disk: source })
     h.session.load()
     await settled()
 
-    h.session.editorChanged('- [ ] something else entirely\n')
+    h.session.editorChanged('+ [ ] something else entirely\n')
     await expect(h.session.commitTaskEdit(firstTask(source), 'y')).rejects.toBeInstanceOf(
       TaskStaleError,
     )
@@ -841,24 +841,24 @@ describe('commitTaskEdit', () => {
 
 describe('commitTaskRemove', () => {
   it('removes the task line while preserving unsaved edits, reflected in the editor', async () => {
-    const source = '- [ ] buy milk\n- [ ] call mum\n'
+    const source = '+ [ ] buy milk\n+ [ ] call mum\n'
     const h = harness({ disk: source })
     h.session.load()
     await settled()
 
     expect(await h.session.commitTaskRemove(firstTask(source))).toBe(true)
-    expect(h.writes.at(-1)?.contents).toBe('- [ ] call mum\n')
-    expect(h.applied.at(-1)).toBe('- [ ] call mum\n')
+    expect(h.writes.at(-1)?.contents).toBe('+ [ ] call mum\n')
+    expect(h.applied.at(-1)).toBe('+ [ ] call mum\n')
   })
 
   it('refuses (returns false) while a conflict is parked', async () => {
-    const source = '- [ ] x\n'
+    const source = '+ [ ] x\n'
     const h = harness({ disk: source })
     h.session.load()
     await settled()
 
-    h.session.editorChanged('- [ ] x edited\n')
-    h.setDisk('- [ ] x external\n')
+    h.session.editorChanged('+ [ ] x edited\n')
+    h.setDisk('+ [ ] x external\n')
     h.session.externalChanged()
     await settled()
 
@@ -866,48 +866,48 @@ describe('commitTaskRemove', () => {
   })
 
   it('reverts and surfaces the error when the write fails', async () => {
-    const source = '- [ ] x\n'
+    const source = '+ [ ] x\n'
     const h = harness({ disk: source })
     h.session.load()
     await settled()
 
     h.failWrites('disk full')
     await expect(h.session.commitTaskRemove(firstTask(source))).rejects.toThrow('disk full')
-    expect(h.session.content()).toBe('- [ ] x\n')
-    expect(h.applied.at(-1)).toBe('- [ ] x\n')
+    expect(h.session.content()).toBe('+ [ ] x\n')
+    expect(h.applied.at(-1)).toBe('+ [ ] x\n')
   })
 })
 
 describe('commitTaskToBullet', () => {
   it('strips the marker to a plain bullet while preserving unsaved edits', async () => {
-    const source = '- [ ] buy milk\n- [ ] call mum\n'
+    const source = '+ [ ] buy milk\n+ [ ] call mum\n'
     const h = harness({ disk: source })
     h.session.load()
     await settled()
 
-    h.session.editorChanged('- [ ] buy milk\n- [ ] call mum\n\njot\n') // unsaved when it arrives
+    h.session.editorChanged('+ [ ] buy milk\n+ [ ] call mum\n\njot\n') // unsaved when it arrives
     expect(await h.session.commitTaskToBullet(firstTask(source))).toBe(true)
-    expect(h.writes.at(-1)?.contents).toBe('- buy milk\n- [ ] call mum\n\njot\n')
-    expect(h.applied.at(-1)).toBe('- buy milk\n- [ ] call mum\n\njot\n')
+    expect(h.writes.at(-1)?.contents).toBe('+ buy milk\n+ [ ] call mum\n\njot\n')
+    expect(h.applied.at(-1)).toBe('+ buy milk\n+ [ ] call mum\n\njot\n')
   })
 
   it('drops a checked marker too', async () => {
-    const source = '- [x] done\n'
+    const source = '+ [x] done\n'
     const h = harness({ disk: source })
     h.session.load()
     await settled()
 
     expect(await h.session.commitTaskToBullet(firstTask(source))).toBe(true)
-    expect(h.writes.at(-1)?.contents).toBe('- done\n')
+    expect(h.writes.at(-1)?.contents).toBe('+ done\n')
   })
 
   it('propagates TaskStaleError when the task line is gone', async () => {
-    const source = '- [ ] gone\n'
+    const source = '+ [ ] gone\n'
     const h = harness({ disk: source })
     h.session.load()
     await settled()
 
-    h.session.editorChanged('- [ ] something else entirely\n')
+    h.session.editorChanged('+ [ ] something else entirely\n')
     await expect(h.session.commitTaskToBullet(firstTask(source))).rejects.toBeInstanceOf(
       TaskStaleError,
     )

--- a/apps/desktop/src/lib/note-task.test.ts
+++ b/apps/desktop/src/lib/note-task.test.ts
@@ -1,6 +1,13 @@
 import { TaskStaleError } from '@reflect/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { convertTaskToBullet, deleteTask, editTask, NoteBusyError, toggleTask } from './note-task'
+import {
+  convertTaskToBullet,
+  deleteTask,
+  editTask,
+  insertTask,
+  NoteBusyError,
+  toggleTask,
+} from './note-task'
 
 const openSession = vi.hoisted(() => vi.fn())
 vi.mock('@/editor/open-documents', () => ({ openSession }))
@@ -13,7 +20,7 @@ vi.mock('@reflect/core', async (importOriginal) => ({
   writeNote,
 }))
 
-// The marker `[` sits at offset 2 of `- [ ] do it`.
+// The marker `[` sits at offset 2 of `+ [ ] do it`.
 const task = { notePath: 'notes/a.md', markerOffset: 2, raw: '[ ] do it' }
 
 beforeEach(() => {
@@ -27,7 +34,7 @@ const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0))
 describe('write serialization', () => {
   it('serializes concurrent writes to the same note — no read/write interleave', async () => {
     openSession.mockReturnValue(null)
-    readNote.mockResolvedValue('- [ ] do it\n')
+    readNote.mockResolvedValue('+ [ ] do it\n')
     let releaseFirstWrite: () => void = () => {}
     let writes = 0
     writeNote.mockImplementation(() => {
@@ -56,7 +63,7 @@ describe('write serialization', () => {
 
   it('keeps the chain alive when a write fails', async () => {
     openSession.mockReturnValue(null)
-    readNote.mockResolvedValue('- [ ] do it\n')
+    readNote.mockResolvedValue('+ [ ] do it\n')
     writeNote.mockRejectedValueOnce(new Error('disk full')).mockResolvedValue(undefined)
 
     const first = toggleTask(task, 7)
@@ -69,11 +76,11 @@ describe('write serialization', () => {
 describe('toggleTask', () => {
   it('writes the toggled marker to disk when the note is not open', async () => {
     openSession.mockReturnValue(null)
-    readNote.mockResolvedValue('- [ ] do it\n')
+    readNote.mockResolvedValue('+ [ ] do it\n')
     writeNote.mockResolvedValue(undefined)
 
     await toggleTask(task, 7)
-    expect(writeNote).toHaveBeenCalledWith('notes/a.md', '- [x] do it\n', 7)
+    expect(writeNote).toHaveBeenCalledWith('notes/a.md', '+ [x] do it\n', 7)
   })
 
   it('routes through the live session whenever the note is open — never disk', async () => {
@@ -98,7 +105,7 @@ describe('toggleTask', () => {
 
   it('propagates TaskStaleError from the disk path when the index is stale', async () => {
     openSession.mockReturnValue(null)
-    readNote.mockResolvedValue('- [ ] something else entirely\n')
+    readNote.mockResolvedValue('+ [ ] something else entirely\n')
 
     await expect(toggleTask(task, 7)).rejects.toBeInstanceOf(TaskStaleError)
     expect(writeNote).not.toHaveBeenCalled()
@@ -108,11 +115,11 @@ describe('toggleTask', () => {
 describe('editTask', () => {
   it('writes the rewritten content to disk when the note is not open', async () => {
     openSession.mockReturnValue(null)
-    readNote.mockResolvedValue('- [ ] do it\n')
+    readNote.mockResolvedValue('+ [ ] do it\n')
     writeNote.mockResolvedValue(undefined)
 
     await editTask(task, 'do it well', 7)
-    expect(writeNote).toHaveBeenCalledWith('notes/a.md', '- [ ] do it well\n', 7)
+    expect(writeNote).toHaveBeenCalledWith('notes/a.md', '+ [ ] do it well\n', 7)
   })
 
   it('routes the new content through the live session when the note is open', async () => {
@@ -132,7 +139,7 @@ describe('editTask', () => {
 
   it('propagates TaskStaleError from the disk path when the index is stale', async () => {
     openSession.mockReturnValue(null)
-    readNote.mockResolvedValue('- [ ] something else entirely\n')
+    readNote.mockResolvedValue('+ [ ] something else entirely\n')
     await expect(editTask(task, 'x', 7)).rejects.toBeInstanceOf(TaskStaleError)
     expect(writeNote).not.toHaveBeenCalled()
   })
@@ -141,11 +148,11 @@ describe('editTask', () => {
 describe('deleteTask', () => {
   it('removes the task line on disk when the note is not open', async () => {
     openSession.mockReturnValue(null)
-    readNote.mockResolvedValue('- [ ] do it\n- [ ] keep\n')
+    readNote.mockResolvedValue('+ [ ] do it\n+ [ ] keep\n')
     writeNote.mockResolvedValue(undefined)
 
     await deleteTask(task, 7)
-    expect(writeNote).toHaveBeenCalledWith('notes/a.md', '- [ ] keep\n', 7)
+    expect(writeNote).toHaveBeenCalledWith('notes/a.md', '+ [ ] keep\n', 7)
   })
 
   it('routes through the live session when the note is open', async () => {
@@ -167,11 +174,11 @@ describe('deleteTask', () => {
 describe('convertTaskToBullet', () => {
   it('strips the marker to a plain bullet on disk when the note is not open', async () => {
     openSession.mockReturnValue(null)
-    readNote.mockResolvedValue('- [ ] do it\n- [ ] keep\n')
+    readNote.mockResolvedValue('+ [ ] do it\n+ [ ] keep\n')
     writeNote.mockResolvedValue(undefined)
 
     await convertTaskToBullet(task, 7)
-    expect(writeNote).toHaveBeenCalledWith('notes/a.md', '- do it\n- [ ] keep\n', 7)
+    expect(writeNote).toHaveBeenCalledWith('notes/a.md', '+ do it\n+ [ ] keep\n', 7)
   })
 
   it('routes through the live session when the note is open', async () => {
@@ -191,8 +198,28 @@ describe('convertTaskToBullet', () => {
 
   it('propagates TaskStaleError from the disk path when the index is stale', async () => {
     openSession.mockReturnValue(null)
-    readNote.mockResolvedValue('- [ ] something else entirely\n')
+    readNote.mockResolvedValue('+ [ ] something else entirely\n')
     await expect(convertTaskToBullet(task, 7)).rejects.toBeInstanceOf(TaskStaleError)
     expect(writeNote).not.toHaveBeenCalled()
+  })
+})
+
+describe('insertTask', () => {
+  it('writes round task syntax to an empty note', async () => {
+    openSession.mockReturnValue(null)
+    readNote.mockResolvedValue('')
+    writeNote.mockResolvedValue(undefined)
+
+    await expect(insertTask('notes/a.md', 7)).resolves.toBe(2)
+    expect(writeNote).toHaveBeenCalledWith('notes/a.md', '+ [ ] \n', 7)
+  })
+
+  it('appends round task syntax after existing content', async () => {
+    openSession.mockReturnValue(null)
+    readNote.mockResolvedValue('# Notes\n\nbody\n')
+    writeNote.mockResolvedValue(undefined)
+
+    await expect(insertTask('notes/a.md', 7)).resolves.toBe('# Notes\n\nbody\n+ '.length)
+    expect(writeNote).toHaveBeenCalledWith('notes/a.md', '# Notes\n\nbody\n+ [ ] \n', 7)
   })
 })

--- a/apps/desktop/src/lib/note-task.ts
+++ b/apps/desktop/src/lib/note-task.ts
@@ -149,7 +149,7 @@ export function convertTaskToBullet(task: TaskRef, generation: number): Promise<
 }
 
 /**
- * Insert a new empty `- [ ] ` task at the end of `notePath` (Plan 18's Return-to-
+ * Insert a new empty `+ [ ] ` task at the end of `notePath` (Plan 18's Return-to-
  * add) and return its marker offset, so the Tasks view can select the new row and
  * open its inline editor. A missing note — today's daily not yet created — starts
  * empty. Refuses an **open** note via {@link NoteBusyError}: appending through

--- a/apps/desktop/src/lib/tasks/task-cache.ts
+++ b/apps/desktop/src/lib/tasks/task-cache.ts
@@ -78,7 +78,7 @@ export function taskRawWithContent(task: OpenTask, content: string): string {
  * reindex will store, not the raw markdown the editor produced.
  */
 function plainTextOfTaskLine(raw: string): string {
-  return parseNote({ path: '', source: `- ${raw}` }).tasks[0]?.text ?? ''
+  return parseNote({ path: '', source: `+ ${raw}` }).tasks[0]?.text ?? ''
 }
 
 /**

--- a/apps/desktop/src/lib/tasks/use-task-actions.ts
+++ b/apps/desktop/src/lib/tasks/use-task-actions.ts
@@ -428,7 +428,7 @@ export function useTaskActions(): TaskActions {
       // Resolve the current row first and *await* it, so the append reads the
       // settled source — the new offset can't drift when the line above resized.
       // Emptied content (the row was cleared) deletes that row rather than leaving
-      // a bare `- [ ]` ghost; a real change persists; null (unchanged) is left be.
+      // a bare `+ [ ]` ghost; a real change persists; null (unchanged) is left be.
       try {
         if (content === '') {
           await deleteMutation.mutateAsync([task])

--- a/docs/plans/00-overview.md
+++ b/docs/plans/00-overview.md
@@ -75,7 +75,7 @@ before the editor, and the editor lands before search/AI.
 | 15 | [Hardening, packaging & OSS release](15-hardening-packaging-release.md) | a11y, perf budgets, signing/notarization, MIT + docs, onboarding, release pipeline |
 | 16 | [Generic git remotes](16-generic-git-remotes.md) | Any git host (GitLab/Gitea/GHES/NAS) via hand-wired `origin`, zero new UI — V1 SSH (agent) + path remotes, V2 HTTPS (credential helpers) |
 | 17 | [Readable filenames](17-readable-filenames.md) | Title-derived note filenames (slug + collision suffix), frontmatter `id` adoption, rename-on-settled-title file moves, id-healed external renames |
-| 18 | [Tasks](18-tasks.md) | **Post-release add-on.** GFM-checkbox tasks as a rebuildable projection: interactive editor checkboxes, Tasks view (Overdue/Today/Upcoming), `[[date]]`/daily scheduling, guarded toggle write-back, `checklist: true` opt-out |
+| 18 | [Tasks](18-tasks.md) | **Post-release add-on.** Round-checkbox (`+ [ ]`) tasks as a rebuildable projection: interactive editor checkboxes, Tasks view (Overdue/Today/Upcoming), `[[date]]`/daily scheduling, guarded toggle write-back, square checklists excluded |
 | 19 | [Mobile companion](19-mobile.md) | **In progress.** iOS target of the existing Tauri app: mobile root gate, fixed graph root, onboarding, Daily/All shell, editable notes, keyboard plugin; device validation + store hardening remain |
 
 ## Milestone map

--- a/docs/plans/05-markdown-editor.md
+++ b/docs/plans/05-markdown-editor.md
@@ -87,7 +87,7 @@ they are Reflect's organizing primitive.
 - **05b** — step 7 (images/assets, incl. a Rust binary asset-write command), heading
   toggles from step 9, a **round-trip safety guard** (see below), and the step 10
   basics. **Task checkboxes (step 8) were blocked upstream** — meowdown's converter
-  *lost task-item text entirely* (`- [ ] todo` → empty list), discovered while
+  *lost task-item text entirely* (`+ [ ] todo` → empty list), discovered while
   building 05b. **The blocker is cleared:** meowdown 0.3.0 round-trips task lists
   byte-faithfully (verified 2026-06-12) and models them as `list` nodes with
   `kind: "task"` + `checked`. Interactive checkboxes now land with
@@ -142,9 +142,11 @@ they are Reflect's organizing primitive.
    `Image`). Paste/drop an image → write to `assets/` (Plan 02) → insert a relative
    markdown link → render inline. Large-file guardrail hook for Plan 12.
 
-8. **Task checkboxes.** Add an interactive checkbox node mapped to `- [ ]`/`- [x]` (Lezer
-   emits `Task`/`TaskMarker`) that toggles the underlying markdown. (This step now
-   ships as [Plan 18 (Tasks)](18-tasks.md) step 1, where tasks-as-a-feature land too.)
+8. **Task checkboxes.** Add an interactive checkbox node mapped to `+ [ ]`/`+ [x]`
+   tasks (Lezer emits `Task`/`TaskMarker`) that toggles the underlying markdown.
+   Square `- [ ]` checklist checkboxes may render through the same editor affordance
+   but do not aggregate into Tasks. (This step now ships as
+   [Plan 18 (Tasks)](18-tasks.md) step 1, where tasks-as-a-feature land too.)
 
 9. **Keyboard ergonomics (product identity).** meowdown ships base keymap/commands/
    history. Layer Reflect shortcuts (bold/italic, toggle heading, toggle checkbox, indent/

--- a/docs/plans/18-tasks.md
+++ b/docs/plans/18-tasks.md
@@ -3,8 +3,9 @@
 **Goal:** Port V1's third center of gravity — tasks embedded in notes, collected into
 one view — as a **lightweight markdown-backed projection**, per the decision docs
 (grounding brief §9.7 Option A: aggregate, schedule, complete; never a task manager).
-A task is a plain GFM checkbox in a note; the Tasks view is a projection over them,
-exactly like backlinks are a projection over `[[links]]`.
+A task is a round Meowdown checkbox in a note (`+ [ ]` / `+ [x]`); the Tasks view is
+a projection over those rows, exactly like backlinks are a projection over `[[links]]`.
+Square checklist checkboxes (`- [ ]` / `- [x]`) stay in the note and do not aggregate.
 
 **Status:** Add-on — not part of the first macOS release. Build after launch.
 
@@ -17,8 +18,8 @@ dates), Plan 08 (commands/palette), Plan 17 (path-keyed projections survive move
 ## What changed since tasks were deferred
 
 Tasks were deferred partly because meowdown's converter **lost task-item text**
-(`- [ ] todo` → empty list; Plan 05 step 8). That fix shipped: **meowdown 0.3.0
-round-trips task lists byte-faithfully** (verified 2026-06-12 — `- [ ] buy milk\n- [x]
+(`+ [ ] todo` → empty list; Plan 05 step 8). That fix shipped: **meowdown 0.3.0
+round-trips task lists byte-faithfully** (verified 2026-06-12 — `+ [ ] buy milk\n+ [x]
 call mum\n` round-trips unchanged, including wiki links and tags inside the item), and
 its ProseMirror schema already models tasks first-class: a `list` node with
 `kind: "task"` and a `checked` attr. Task notes no longer open protected. What's
@@ -30,7 +31,7 @@ missing is purely Reflect-side: interactivity, extraction, projection, and the v
 rebuildable `tasks` projection; a Tasks route/view grouping open tasks across the
 graph (Overdue / Today / Upcoming / Unscheduled, collapsed Completed); toggle-complete
 from the view with a guarded surgical write-back; date scheduling via `[[YYYY-MM-DD]]`
-links and daily-note inheritance; per-note `checklist: true` opt-out.
+links and daily-note inheritance; square checklist syntax excluded from aggregation.
 **Out (explicitly — grounding brief §9.7 calls half-building this the worst path):**
 recurrence, reminders, priorities, projects, statuses, dependencies, calendar sync,
 external task integrations, editing task *text* inside the Tasks view, archived-state
@@ -39,18 +40,14 @@ markers in markdown, AI task extraction (later, over this projection), CLI
 
 ## Key decisions / contracts
 
-- **A task is a GFM checkbox item.** `- [ ] text` / `- [x] text`. No invented syntax,
-  no typed-entity layer: the files stay meaningful in GitHub, Obsidian, and any
-  markdown tool. Lezer already parses these (`Task`/`TaskMarker` via the GFM
-  extension in `grammar.ts`).
-- **V1's task-vs-checklist distinction maps to note granularity.** V1 used round vs
-  square checkboxes — unrepresentable in GFM. Instead: every checkbox is a task by
-  default; a note flagged `checklist: true` in frontmatter keeps **all** its checkboxes
-  out of the Tasks view (shopping lists, packing lists). Reuses the established
-  frontmatter-flag machinery end-to-end: `model.ts` schema + coercion, indexer column,
-  `NoteToggleAction` + `toggleNoteChecklist` in the context sidebar (the
-  `note-private.ts` / `note-pin.ts` pattern), `commitFrontmatter` for the land-now
-  patch. Item-level opt-out is rejected — it would require invented syntax.
+- **A task is a round Meowdown checkbox item.** `+ [ ] text` / `+ [x] text`. No
+  typed-entity layer: the files stay meaningful in Meowdown and any markdown tool
+  that preserves list markers. Lezer parses these as `Task`/`TaskMarker` via the
+  GFM extension in `grammar.ts`; Reflect additionally checks the physical list marker.
+- **V1's task-vs-checklist distinction maps to marker shape.** Round task checkboxes
+  (`+ [ ]`) aggregate into Tasks. Square checklist checkboxes (`- [ ]`, `* [ ]`, and
+  ordered checkbox items) remain ordinary note checklists and are excluded from the
+  projection. No frontmatter opt-out or markdown migration is needed.
 - **Scheduling is association, not metadata** — V1's own mechanism (scheduling a task
   inserted a daily-note backlink) restated in markdown. Scheduled date resolution, in
   order: (1) the first `[[YYYY-MM-DD]]` wiki link inside the item; (2) for tasks in a
@@ -132,19 +129,18 @@ CREATE INDEX tasks_open_by_date ON tasks (checked, scheduled);
    here: first `[[YYYY-MM-DD]]` in the item, else `dateFromDailyPath`, else null.
 
 3. **Projection.** Migration `0009_tasks.sql` (above) + Kysely schema regen + the
-   Rust `index_apply` payload/write path (`db/write.rs`) + the `checklist` flag column
-   on `notes` (extracted in step 5; flagged notes index zero task rows — the flag
-   filters at *index* time so the view query stays trivial).
+   Rust `index_apply` payload/write path (`db/write.rs`). Only extracted `+ [ ]` task
+   rows enter the table; square checklist rows never reach the projection.
 
 4. **Toggle write path.** `toggleTaskMarker` in `markdown/edit.ts` (pure, tested);
    a core command (`indexing/commands.ts` family) doing read → toggle → `note_write`
    → reindex, surfacing `TaskStaleError` as a reviewable refusal. If the note is open
    in the editor, the existing external-change reconciliation picks the write up.
 
-5. **`checklist: true` flag.** Frontmatter schema + coercion in `model.ts`
-   (`.catch()` tolerance like `private`/`pinned`), `NoteToggleAction` entry
-   ("Mark as checklist" — short, action-first copy), `toggleNoteChecklist` via
-   `commitFrontmatter`, palette command, indexer respect (step 3).
+5. **Task vs checklist marker contract.** Extraction accepts only task-list rows whose
+   physical marker is `+`; `-`, `*`, ordered checkbox items, and fenced-code examples
+   stay out of `ParsedNote.tasks`. Bump extraction/projection versions whenever this
+   contract changes so unchanged notes rebuild correctly.
 
 6. **Tasks route + view.** `{ kind: 'tasks' }` route; sidebar entry; `⌘T` (free) +
    "Go to tasks" palette command. The view: TanStack Query over the projection,
@@ -162,12 +158,12 @@ CREATE INDEX tasks_open_by_date ON tasks (checked, scheduled);
 
 ## Acceptance criteria
 
-- `- [ ]` renders as a clickable checkbox in the editor; click and `⌘⏎` toggle it;
+- `+ [ ]` renders as a clickable task checkbox in the editor; click and `⌘⏎` toggle it;
   the file changes by exactly the marker characters; `pnpm typecheck` + targeted
   tests pass.
-- `⌘T` opens Tasks: every open checkbox across the graph except `checklist: true`
-  notes, grouped Overdue / Today / Upcoming / Unscheduled, with source-note context;
-  completed tasks sit collapsed below; the whole flow works without the mouse.
+- `⌘T` opens Tasks: every open `+ [ ]` task across the graph, excluding square
+  checklists, grouped Overdue / Today / Upcoming / Unscheduled, with source-note
+  context; completed tasks sit collapsed below; the whole flow works without the mouse.
 - A task containing `[[2026-07-01]]` schedules for that date; a bare task in
   `daily/2026-06-12.md` schedules for 2026-06-12 and turns Overdue the next day; a
   bare task in a regular note is Unscheduled.
@@ -196,6 +192,7 @@ CREATE INDEX tasks_open_by_date ON tasks (checked, scheduled);
 - **Scope creep is the historical failure mode** (grounding brief §9.7): V1 grew
   task editing inside the view, pending inline task documents, and archive state.
   Everything in **Out** stays out until a deliberate later plan.
-- **Daily-date inheritance might over-schedule** for users who journal checkboxes in
-  daily notes without meaning "due today". Escape hatches: `checklist: true` on the
-  note, or an explicit future `[[date]]` on the item. Revisit only with real usage.
+- **Daily-date inheritance might over-schedule** for users who journal tasks in daily
+  notes without meaning "due today". Escape hatches: use square checklist syntax for
+  non-task lists, or an explicit future `[[date]]` on the item. Revisit only with real
+  usage.

--- a/docs/reflect-v2-product-vision.md
+++ b/docs/reflect-v2-product-vision.md
@@ -521,7 +521,7 @@ These may come later, but should not define the first wave:
 
 | Feature                  | V2 stance                                                                                                          |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------ |
-| Tasks                    | Defer from the first release; now planned as a post-release add-on (Plan 18): GFM-checkbox tasks as a lightweight markdown-backed projection. |
+| Tasks                    | Defer from the first release; now planned as a post-release add-on (Plan 18): round-checkbox (`+ [ ]`) tasks as a lightweight markdown-backed projection. |
 | Audio transcription      | **Shipped early** (despite this table): raw-first audio memos with async BYOK cloud transcription and `private: true` lockouts. |
 | Full browser clipper     | Defer beyond launch link capture. Article extraction, read-later state, and broad clipping can come later.         |
 | Graph/map view           | Defer. Keep backlink graph data, but visual map is not first-wave.                                                 |

--- a/package.json
+++ b/package.json
@@ -23,11 +23,5 @@
     "oxlint": "^1.70.0",
     "turbo": "^2.9.18",
     "typescript": "~5.8.3"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild"
-    ]
   }
 }

--- a/packages/core/src/indexing/indexed-note.test.ts
+++ b/packages/core/src/indexing/indexed-note.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { gistBodyHash, parseNote } from '../markdown'
-import { buildIndexedNote, indexedNoteSchema } from './indexed-note'
+import { buildIndexedNote, indexedNoteSchema, PROJECTION_VERSION } from './indexed-note'
 
 describe('buildIndexedNote', () => {
+  it('carries the projection version that rebuilds task/checklist rows', () => {
+    expect(PROJECTION_VERSION).toBe(11)
+  })
+
   it('flattens a parsed note into the index payload', () => {
     const source =
       '---\nid: 01H\naliases: [PJX, "Proj X"]\nprivate: true\npinned: true\n---\n' +
@@ -144,8 +148,9 @@ describe('buildIndexedNote', () => {
     expect(indexed.gistStale).toBe(false)
   })
 
-  it('maps GFM checkboxes into task rows', () => {
-    const source = '# Todo\n\n- [ ] buy milk\n- [x] call mum\n'
+  it('maps only round task checkboxes into task rows', () => {
+    const source =
+      '# Todo\n\n+ [ ] buy milk\n- [ ] checklist\n* [x] checklist\n1. [ ] ordered\n+ [x] call mum\n'
     const indexed = buildIndexedNote(parseNote({ path: 'notes/n.md', source }), {
       fileHash: 'h',
       mtime: 0,
@@ -153,12 +158,12 @@ describe('buildIndexedNote', () => {
     })
     expect(indexed.tasks).toEqual([
       { markerOffset: source.indexOf('[ ]'), text: 'buy milk', raw: '[ ] buy milk', checked: false, dueDate: null },
-      { markerOffset: source.indexOf('[x]'), text: 'call mum', raw: '[x] call mum', checked: true, dueDate: null },
+      { markerOffset: source.indexOf('[x] call'), text: 'call mum', raw: '[x] call mum', checked: true, dueDate: null },
     ])
   })
 
   it('maps an explicit task due date from a [[YYYY-MM-DD]] link', () => {
-    const source = '# Todo\n\n- [ ] pay bill [[2026-06-20]]\n'
+    const source = '# Todo\n\n+ [ ] pay bill [[2026-06-20]]\n'
     const indexed = buildIndexedNote(parseNote({ path: 'notes/n.md', source }), {
       fileHash: 'h',
       mtime: 0,

--- a/packages/core/src/indexing/indexed-note.ts
+++ b/packages/core/src/indexing/indexed-note.ts
@@ -50,8 +50,10 @@ import { previewSnippet } from './snippet'
  * collapsed, not just percent-decoded): the `assets` projection's keys change,
  * so the bump rebuilds them — the privacy gate matches them against the
  * canonical on-disk path.
+ * 11 — `tasks` projection limited to round Meowdown task checkboxes (`+ [ ]` /
+ * `+ [x]`), excluding square checklist checkboxes from the aggregate Tasks view.
  */
-export const PROJECTION_VERSION = 10
+export const PROJECTION_VERSION = 11
 
 export const indexedLinkSchema = z.object({
   kind: z.enum(['wiki', 'md']),
@@ -122,7 +124,7 @@ export const indexedNoteSchema = z.object({
   tags: z.array(indexedTagSchema),
   aliases: z.array(indexedAliasSchema),
   assets: z.array(z.string()),
-  /** GFM checkbox rows for the Tasks projection (Plan 18). */
+  /** Reflect task rows for the Tasks projection (Plan 18). */
   tasks: z.array(indexedTaskSchema),
 })
 export type IndexedNote = z.infer<typeof indexedNoteSchema>

--- a/packages/core/src/indexing/queries.ts
+++ b/packages/core/src/indexing/queries.ts
@@ -151,7 +151,7 @@ function toTaskRow(row: {
 }
 
 /**
- * Every open checkbox across the graph, with note context, for the Tasks view.
+ * Every open task across the graph, with note context, for the Tasks view.
  * `private: true` notes' tasks **are** included: the Tasks view is a local-only
  * surface that never sends content anywhere — exactly like local search and the
  * daily stream — so the `private` hard-block (content never leaves the device)
@@ -168,7 +168,7 @@ export async function getOpenTasks(): Promise<OpenTask[]> {
 }
 
 /**
- * Completed checkboxes across the graph, most-recently-edited note first — the
+ * Completed tasks across the graph, most-recently-edited note first — the
  * Tasks view's "show archived" surface. Same shape as {@link getOpenTasks}, so
  * the view groups and renders both the same way (completed rows struck through).
  */

--- a/packages/core/src/markdown/edit.test.ts
+++ b/packages/core/src/markdown/edit.test.ts
@@ -92,56 +92,56 @@ describe('toggleTaskMarker', () => {
   }
 
   it('checks an open task, changing only the marker', () => {
-    const source = '# Todo\n\n- [ ] buy milk\n- [ ] call mum\n'
+    const source = '# Todo\n\n+ [ ] buy milk\n+ [ ] call mum\n'
     const result = toggleTaskMarker(source, indexedTask(source))
     expect(result.checked).toBe(true)
-    expect(result.source).toBe('# Todo\n\n- [x] buy milk\n- [ ] call mum\n')
+    expect(result.source).toBe('# Todo\n\n+ [x] buy milk\n+ [ ] call mum\n')
   })
 
   it('unchecks a completed task', () => {
-    const source = '- [x] done\n'
+    const source = '+ [x] done\n'
     const result = toggleTaskMarker(source, indexedTask(source))
     expect(result.checked).toBe(false)
-    expect(result.source).toBe('- [ ] done\n')
+    expect(result.source).toBe('+ [ ] done\n')
   })
 
   it('relocates the task by its line when an edit above shifted the offset', () => {
-    const source = '- [ ] buy milk\n'
+    const source = '+ [ ] buy milk\n'
     const stale = indexedTask(source)
     // A paragraph was inserted above the task, so the recorded offset is wrong;
     // the raw line still locates it uniquely.
     const edited = `Some new intro.\n\n${source}`
     const result = toggleTaskMarker(edited, stale)
-    expect(result.source).toBe('Some new intro.\n\n- [x] buy milk\n')
+    expect(result.source).toBe('Some new intro.\n\n+ [x] buy milk\n')
   })
 
   it('refuses loudly when the task line is gone', () => {
-    const source = '- [ ] buy milk\n'
+    const source = '+ [ ] buy milk\n'
     const task = indexedTask(source)
-    expect(() => toggleTaskMarker('- [ ] something else\n', task)).toThrow(TaskStaleError)
+    expect(() => toggleTaskMarker('+ [ ] something else\n', task)).toThrow(TaskStaleError)
   })
 
   it('refuses loudly when the task line is ambiguous and the offset is stale', () => {
-    const source = '- [ ] dup\n'
+    const source = '+ [ ] dup\n'
     const task = indexedTask(source)
     // Two identical lines and a stale offset: which one is unknowable.
-    expect(() => toggleTaskMarker('intro\n\n- [ ] dup\n- [ ] dup\n', task)).toThrow(TaskStaleError)
+    expect(() => toggleTaskMarker('intro\n\n+ [ ] dup\n+ [ ] dup\n', task)).toThrow(TaskStaleError)
   })
 
   it('relocates to the real task line, not a coincidental inline match', () => {
-    const task = indexedTask('- [ ] dup\n')
+    const task = indexedTask('+ [ ] dup\n')
     // The same text appears inline (not a task) and as a task, and the recorded
     // offset is stale. Relocation re-extracts tasks, so it can only toggle the
     // real list item — the inline mention is untouched.
-    const result = toggleTaskMarker('mention [ ] dup inline\n\n- [ ] dup\n', task)
-    expect(result.source).toBe('mention [ ] dup inline\n\n- [x] dup\n')
+    const result = toggleTaskMarker('mention [ ] dup inline\n\n+ [ ] dup\n', task)
+    expect(result.source).toBe('mention [ ] dup inline\n\n+ [x] dup\n')
   })
 
   it('never toggles a marker that only appears inside a code block', () => {
-    const task = indexedTask('- [ ] incode\n')
+    const task = indexedTask('+ [ ] incode\n')
     // The line moved into a fenced code block, so it is no longer a task; a raw
     // string search would have spliced it, but re-extraction sees no task.
-    expect(() => toggleTaskMarker('```\n- [ ] incode\n```\n', task)).toThrow(TaskStaleError)
+    expect(() => toggleTaskMarker('```\n+ [ ] incode\n```\n', task)).toThrow(TaskStaleError)
   })
 
   it('refuses the offset fast-path when its byte-matching line is no longer a task', () => {
@@ -153,7 +153,7 @@ describe('toggleTaskMarker', () => {
   })
 
   it('round-trips back to the original after two toggles', () => {
-    const source = '- [ ] task [[2026-07-01]] #tag\n'
+    const source = '+ [ ] task [[2026-07-01]] #tag\n'
     const once = toggleTaskMarker(source, indexedTask(source))
     const twice = toggleTaskMarker(once.source, indexedTask(once.source))
     expect(twice.source).toBe(source)
@@ -168,68 +168,68 @@ describe('editTaskLine', () => {
   }
 
   it('replaces the content after the marker, keeping bullet and marker', () => {
-    const source = '# Todo\n\n- [ ] buy milk\n- [ ] call mum\n'
+    const source = '# Todo\n\n+ [ ] buy milk\n+ [ ] call mum\n'
     expect(editTaskLine(source, indexedTask(source), 'buy oat milk')).toBe(
-      '# Todo\n\n- [ ] buy oat milk\n- [ ] call mum\n',
+      '# Todo\n\n+ [ ] buy oat milk\n+ [ ] call mum\n',
     )
   })
 
   it('preserves a checked marker and the line ending', () => {
-    const source = '- [x] done\n'
-    expect(editTaskLine(source, indexedTask(source), 'really done')).toBe('- [x] really done\n')
+    const source = '+ [x] done\n'
+    expect(editTaskLine(source, indexedTask(source), 'really done')).toBe('+ [x] really done\n')
   })
 
   it('keeps the indentation and bullet style of a nested item', () => {
-    const source = '  * [ ] nested task\n'
-    expect(editTaskLine(source, indexedTask(source), 'edited')).toBe('  * [ ] edited\n')
+    const source = '  + [ ] nested task\n'
+    expect(editTaskLine(source, indexedTask(source), 'edited')).toBe('  + [ ] edited\n')
   })
 
   it('trims surrounding whitespace from the new content', () => {
-    const source = '- [ ] a\n'
-    expect(editTaskLine(source, indexedTask(source), '  spaced  ')).toBe('- [ ] spaced\n')
+    const source = '+ [ ] a\n'
+    expect(editTaskLine(source, indexedTask(source), '  spaced  ')).toBe('+ [ ] spaced\n')
   })
 
   it('rewrites links and tags in the new content verbatim', () => {
-    const source = '- [ ] plain\n'
+    const source = '+ [ ] plain\n'
     expect(editTaskLine(source, indexedTask(source), 'ship [[2026-07-01]] #release')).toBe(
-      '- [ ] ship [[2026-07-01]] #release\n',
+      '+ [ ] ship [[2026-07-01]] #release\n',
     )
   })
 
   it('clears to a bare marker when the content is empty', () => {
-    const source = '- [ ] gone soon\n'
-    expect(editTaskLine(source, indexedTask(source), '   ')).toBe('- [ ]\n')
+    const source = '+ [ ] gone soon\n'
+    expect(editTaskLine(source, indexedTask(source), '   ')).toBe('+ [ ]\n')
   })
 
   it('relocates by the raw line when an edit above shifted the offset', () => {
-    const source = '- [ ] buy milk\n'
+    const source = '+ [ ] buy milk\n'
     const stale = indexedTask(source)
     expect(editTaskLine(`Intro.\n\n${source}`, stale, 'buy oat milk')).toBe(
-      'Intro.\n\n- [ ] buy oat milk\n',
+      'Intro.\n\n+ [ ] buy oat milk\n',
     )
   })
 
   it('refuses content with an embedded newline (would split the item)', () => {
-    const source = '- [ ] one\n'
-    expect(() => editTaskLine(source, indexedTask(source), 'one\n- [ ] two')).toThrow(TaskStaleError)
+    const source = '+ [ ] one\n'
+    expect(() => editTaskLine(source, indexedTask(source), 'one\n+ [ ] two')).toThrow(TaskStaleError)
   })
 
   it('refuses content with a carriage return too', () => {
-    const source = '- [ ] one\n'
-    expect(() => editTaskLine(source, indexedTask(source), 'one\r- [ ] two')).toThrow(TaskStaleError)
+    const source = '+ [ ] one\n'
+    expect(() => editTaskLine(source, indexedTask(source), 'one\r+ [ ] two')).toThrow(TaskStaleError)
   })
 
   it('refuses loudly when the task line is gone', () => {
-    const source = '- [ ] buy milk\n'
+    const source = '+ [ ] buy milk\n'
     const task = indexedTask(source)
-    expect(() => editTaskLine('- [ ] something else\n', task, 'x')).toThrow(TaskStaleError)
+    expect(() => editTaskLine('+ [ ] something else\n', task, 'x')).toThrow(TaskStaleError)
   })
 })
 
 describe('appendTaskLine', () => {
   it('starts the note with a single empty task', () => {
     const { source, markerOffset } = appendTaskLine('')
-    expect(source).toBe('- [ ] \n')
+    expect(source).toBe('+ [ ] \n')
     const task = parseNote({ path: 'n.md', source }).tasks[0]!
     expect(task.markerOffset).toBe(markerOffset)
     expect(task.text).toBe('')
@@ -237,8 +237,8 @@ describe('appendTaskLine', () => {
   })
 
   it('continues an existing task list and reports the new marker offset', () => {
-    const { source, markerOffset } = appendTaskLine('- [ ] buy milk\n')
-    expect(source).toBe('- [ ] buy milk\n- [ ] \n')
+    const { source, markerOffset } = appendTaskLine('+ [ ] buy milk\n')
+    expect(source).toBe('+ [ ] buy milk\n+ [ ] \n')
     const tasks = parseNote({ path: 'n.md', source }).tasks
     expect(tasks).toHaveLength(2)
     expect(tasks[1]!.markerOffset).toBe(markerOffset)
@@ -305,32 +305,32 @@ describe('removeTaskLine', () => {
   }
 
   it('removes a middle task line and closes the gap', () => {
-    const source = '- [ ] a\n- [ ] b\n- [ ] c\n'
-    expect(removeTaskLine(source, indexedTask(source, 1))).toBe('- [ ] a\n- [ ] c\n')
+    const source = '+ [ ] a\n+ [ ] b\n+ [ ] c\n'
+    expect(removeTaskLine(source, indexedTask(source, 1))).toBe('+ [ ] a\n+ [ ] c\n')
   })
 
   it('removes the first task line', () => {
-    const source = '- [ ] a\n- [ ] b\n'
-    expect(removeTaskLine(source, indexedTask(source, 0))).toBe('- [ ] b\n')
+    const source = '+ [ ] a\n+ [ ] b\n'
+    expect(removeTaskLine(source, indexedTask(source, 0))).toBe('+ [ ] b\n')
   })
 
   it('empties a note whose only line was the task', () => {
-    expect(removeTaskLine('- [ ] only\n', indexedTask('- [ ] only\n'))).toBe('')
+    expect(removeTaskLine('+ [ ] only\n', indexedTask('+ [ ] only\n'))).toBe('')
   })
 
   it('removes a final task with no trailing newline, keeping the line above', () => {
-    const source = 'intro\n- [ ] last'
+    const source = 'intro\n+ [ ] last'
     expect(removeTaskLine(source, indexedTask(source))).toBe('intro\n')
   })
 
   it('leaves surrounding prose intact', () => {
-    const source = '# Notes\n\n- [ ] task\n\nMore prose.\n'
+    const source = '# Notes\n\n+ [ ] task\n\nMore prose.\n'
     expect(removeTaskLine(source, indexedTask(source))).toBe('# Notes\n\n\nMore prose.\n')
   })
 
   it('refuses loudly when the task line is gone', () => {
-    const task = indexedTask('- [ ] buy milk\n')
-    expect(() => removeTaskLine('- [ ] something else\n', task)).toThrow(TaskStaleError)
+    const task = indexedTask('+ [ ] buy milk\n')
+    expect(() => removeTaskLine('+ [ ] something else\n', task)).toThrow(TaskStaleError)
   })
 })
 
@@ -341,43 +341,43 @@ describe('taskLineToBullet', () => {
   }
 
   it('drops the marker, leaving the bullet and content', () => {
-    const source = '- [ ] buy milk\n'
-    expect(taskLineToBullet(source, indexedTask(source))).toBe('- buy milk\n')
+    const source = '+ [ ] buy milk\n'
+    expect(taskLineToBullet(source, indexedTask(source))).toBe('+ buy milk\n')
   })
 
   it('drops a checked marker too', () => {
-    const source = '- [x] done\n'
-    expect(taskLineToBullet(source, indexedTask(source))).toBe('- done\n')
+    const source = '+ [x] done\n'
+    expect(taskLineToBullet(source, indexedTask(source))).toBe('+ done\n')
   })
 
   it('preserves the bullet character and indentation', () => {
-    const source = '  * [ ] sub\n'
-    expect(taskLineToBullet(source, indexedTask(source))).toBe('  * sub\n')
+    const source = '  + [ ] sub\n'
+    expect(taskLineToBullet(source, indexedTask(source))).toBe('  + sub\n')
   })
 
   it('collapses an empty task to a bare bullet', () => {
-    const source = '- [ ] \n'
-    expect(taskLineToBullet(source, indexedTask(source))).toBe('- \n')
+    const source = '+ [ ] \n'
+    expect(taskLineToBullet(source, indexedTask(source))).toBe('+ \n')
   })
 
   it('keeps wiki links and tags in the content', () => {
-    const source = '- [ ] ship [[2026-07-01]] #release\n'
-    expect(taskLineToBullet(source, indexedTask(source))).toBe('- ship [[2026-07-01]] #release\n')
+    const source = '+ [ ] ship [[2026-07-01]] #release\n'
+    expect(taskLineToBullet(source, indexedTask(source))).toBe('+ ship [[2026-07-01]] #release\n')
   })
 
   it('converts a middle task, leaving its neighbours as tasks', () => {
-    const source = '- [ ] a\n- [ ] b\n- [ ] c\n'
-    expect(taskLineToBullet(source, indexedTask(source, 1))).toBe('- [ ] a\n- b\n- [ ] c\n')
+    const source = '+ [ ] a\n+ [ ] b\n+ [ ] c\n'
+    expect(taskLineToBullet(source, indexedTask(source, 1))).toBe('+ [ ] a\n+ b\n+ [ ] c\n')
   })
 
   it('relocates by raw when an edit above drifts the offset', () => {
-    const source = '- [ ] buy milk\n'
+    const source = '+ [ ] buy milk\n'
     const stale = indexedTask(source)
-    expect(taskLineToBullet(`Intro.\n\n${source}`, stale)).toBe('Intro.\n\n- buy milk\n')
+    expect(taskLineToBullet(`Intro.\n\n${source}`, stale)).toBe('Intro.\n\n+ buy milk\n')
   })
 
   it('refuses loudly when the task line is gone', () => {
-    const task = indexedTask('- [ ] buy milk\n')
-    expect(() => taskLineToBullet('- [ ] something else\n', task)).toThrow(TaskStaleError)
+    const task = indexedTask('+ [ ] buy milk\n')
+    expect(() => taskLineToBullet('+ [ ] something else\n', task)).toThrow(TaskStaleError)
   })
 })

--- a/packages/core/src/markdown/edit.ts
+++ b/packages/core/src/markdown/edit.ts
@@ -116,7 +116,7 @@ export function removeTaskLine(source: string, task: TaskMarker): string {
 }
 
 /**
- * Append a new empty task — a `- [ ] ` line — to the end of `source`, returning
+ * Append a new empty task — a `+ [ ] ` line — to the end of `source`, returning
  * the new source and the marker's offset (the `[`). The Tasks view's Return-to-add
  * (Plan 18) writes the empty line, then the inline editor on the new row fills it.
  * A single newline separates it from existing content (continuing a trailing
@@ -126,13 +126,13 @@ export function removeTaskLine(source: string, task: TaskMarker): string {
  */
 export function appendTaskLine(source: string): { source: string; markerOffset: number } {
   const base = source.replace(/\s*$/, '')
-  const prefix = base.length > 0 ? `${base}\n- ` : '- '
+  const prefix = base.length > 0 ? `${base}\n+ ` : '+ '
   return { source: `${prefix}[ ] \n`, markerOffset: prefix.length }
 }
 
 /**
  * Demote a task back to a plain bullet by removing exactly its `[ ]`/`[x]` marker
- * and the run of horizontal whitespace after it — `- [ ] text` becomes `- text`,
+ * and the run of horizontal whitespace after it — `+ [ ] text` becomes `+ text`,
  * the list bullet, indentation, and content all untouched. This is the Tasks
  * view's "Convert to bullet" (Plan 18 follow-up): a GFM checkbox is the only
  * thing the projection treats as a task, so dropping the marker lifts the item
@@ -141,7 +141,7 @@ export function appendTaskLine(source: string): { source: string; markerOffset: 
  * locateTaskMarker}, the same staleness guard the toggle uses, so a drifted or
  * ambiguous line — or a position that no longer holds a marker — refuses loudly
  * with {@link TaskStaleError} rather than rewriting the wrong line. An empty task
- * (`- [ ] `) collapses to a bare bullet (`- `).
+ * (`+ [ ] `) collapses to a bare bullet (`+ `).
  */
 export function taskLineToBullet(source: string, task: TaskMarker): string {
   const offset = locateTaskMarker(source, task.markerOffset, task.raw)

--- a/packages/core/src/markdown/extract.test.ts
+++ b/packages/core/src/markdown/extract.test.ts
@@ -143,8 +143,8 @@ describe('parseNote — links, assets, tags, text', () => {
 })
 
 describe('parseNote — tasks', () => {
-  it('extracts open and checked checkboxes with text, raw, marker offset', () => {
-    const note = parse('- [ ] buy milk\n- [x] call mum\n')
+  it('extracts open and checked round task checkboxes with text, raw, marker offset', () => {
+    const note = parse('+ [ ] buy milk\n+ [x] call mum\n')
     expect(note.tasks).toEqual([
       { text: 'buy milk', raw: '[ ] buy milk', checked: false, markerOffset: 2, dueDate: null },
       { text: 'call mum', raw: '[x] call mum', checked: true, markerOffset: 17, dueDate: null },
@@ -152,14 +152,14 @@ describe('parseNote — tasks', () => {
   })
 
   it('treats an uppercase [X] marker as checked', () => {
-    const note = parse('- [X] done\n')
+    const note = parse('+ [X] done\n')
     expect(note.tasks).toEqual([
       { text: 'done', raw: '[X] done', checked: true, markerOffset: 2, dueDate: null },
     ])
   })
 
   it('strips inline syntax from text but keeps it verbatim in raw', () => {
-    const note = parse('- [ ] call [[Bob]] about **billing**\n')
+    const note = parse('+ [ ] call [[Bob]] about **billing**\n')
     const item = note.tasks[0]!
     expect(item.text).toBe('call Bob about billing')
     expect(item.raw).toBe('[ ] call [[Bob]] about **billing**')
@@ -169,7 +169,7 @@ describe('parseNote — tasks', () => {
   })
 
   it('offsets the marker past frontmatter', () => {
-    const source = '---\nid: abc\n---\n- [ ] later\n'
+    const source = '---\nid: abc\n---\n+ [ ] later\n'
     const note = parse(source)
     const item = note.tasks[0]!
     expect(item.markerOffset).toBe(source.indexOf('[ ]'))
@@ -177,7 +177,7 @@ describe('parseNote — tasks', () => {
   })
 
   it('captures nested sub-tasks as their own rows', () => {
-    const note = parse('- [ ] parent\n  - [x] child\n')
+    const note = parse('+ [ ] parent\n  + [x] child\n')
     expect(note.tasks.map((task) => ({ text: task.text, checked: task.checked }))).toEqual([
       { text: 'parent', checked: false },
       { text: 'child', checked: true },
@@ -185,10 +185,15 @@ describe('parseNote — tasks', () => {
   })
 
   it('ignores checkboxes inside fenced code', () => {
-    const note = parse('- [ ] real\n\n```\n- [ ] not a task\n```\n')
+    const note = parse('+ [ ] real\n\n```\n+ [ ] not a task\n```\n')
     expect(note.tasks).toEqual([
       { text: 'real', raw: '[ ] real', checked: false, markerOffset: 2, dueDate: null },
     ])
+  })
+
+  it('ignores square checklist and ordered checkbox items', () => {
+    const note = parse('- [ ] checklist\n* [x] checklist\n1. [ ] ordered\n')
+    expect(note.tasks).toEqual([])
   })
 
   it('yields no tasks for a plain bullet list', () => {
@@ -197,17 +202,17 @@ describe('parseNote — tasks', () => {
   })
 
   it('reads the first calendar [[YYYY-MM-DD]] link in the item as the due date', () => {
-    const note = parse('- [ ] ship it [[2026-07-01]] and review [[2026-08-01]]\n')
+    const note = parse('+ [ ] ship it [[2026-07-01]] and review [[2026-08-01]]\n')
     expect(note.tasks[0]!.dueDate).toBe('2026-07-01') // first date link wins
   })
 
   it('ignores an impossible date as a due date', () => {
-    const note = parse('- [ ] not a real day [[2026-02-31]]\n')
+    const note = parse('+ [ ] not a real day [[2026-02-31]]\n')
     expect(note.tasks[0]!.dueDate).toBeNull()
   })
 
   it('does not borrow a due-date link from a neighbouring task', () => {
-    const note = parse('- [ ] no date here\n- [ ] dated [[2026-07-01]]\n')
+    const note = parse('+ [ ] no date here\n+ [ ] dated [[2026-07-01]]\n')
     expect(note.tasks.map((task) => task.dueDate)).toEqual([null, '2026-07-01'])
   })
 })

--- a/packages/core/src/markdown/extract.ts
+++ b/packages/core/src/markdown/extract.ts
@@ -167,10 +167,20 @@ function readLink(body: string, from: number, to: number, offset: number): Markd
 }
 
 /**
+ * A Reflect task is the round Meowdown checkbox syntax: optional indentation,
+ * then `+`, then whitespace, then the GFM marker. Square checklist items
+ * (`- [ ]`/`* [ ]`) are intentionally not projected into Tasks.
+ */
+function hasRoundTaskListMarker(body: string, markerStart: number): boolean {
+  const lineStart = body.lastIndexOf('\n', markerStart - 1) + 1
+  return /^[\t ]*\+[\t ]+$/.test(body.slice(lineStart, markerStart))
+}
+
+/**
  * Resolve a `Task` Lezer node (the marker starts at `from`) into a
- * {@link ParsedTask}, or `null` when the marker shape isn't a real GFM checkbox
- * (a defensive guard against parser surprises). `text` is the marker line minus
- * its syntax; `raw` is that physical line verbatim for the write-back guard.
+ * {@link ParsedTask}, or `null` when the marker shape isn't Reflect's task
+ * syntax. `text` is the marker line minus its syntax; `raw` is that physical
+ * line verbatim from the marker onward for the write-back guard.
  */
 function readTask(
   body: string,
@@ -181,6 +191,9 @@ function readTask(
   wikiLinks: WikiLink[],
 ): ParsedTask | null {
   const { from, to } = range
+  if (!hasRoundTaskListMarker(body, from)) {
+    return null
+  }
   const marker = parseTaskMarker(body.slice(from, from + 3))
   if (marker === null) {
     return null

--- a/packages/core/src/markdown/model.ts
+++ b/packages/core/src/markdown/model.ts
@@ -171,9 +171,9 @@ export interface TaskMarker {
 }
 
 /**
- * A GFM checkbox item (`- [ ] text` / `- [x] text`) — the unit the Tasks view
- * (Plan 18) projects across the graph. Every checkbox is a task; there is no
- * invented syntax, so the files stay meaningful in any markdown tool.
+ * A Reflect task item (`+ [ ] text` / `+ [x] text`) — the unit the Tasks view
+ * (Plan 18) projects across the graph. Square checklist checkboxes stay in the
+ * note only and are intentionally excluded from the aggregate Tasks view.
  */
 export interface ParsedTask extends TaskMarker {
   /** Inline text of the item's marker line, markdown stripped, for display + search. */
@@ -191,8 +191,10 @@ export interface ParsedTask extends TaskMarker {
 }
 
 /** Version of the extraction contract; bump on breaking shape changes.
- * 1 — Plan 03 baseline · 2 — `tasks: ParsedTask[]` (with `dueDate`) added (Plan 18). */
-export const PARSED_NOTE_VERSION = 2
+ * 1 — Plan 03 baseline · 2 — `tasks: ParsedTask[]` (with `dueDate`) added (Plan 18) ·
+ * 3 — tasks limited to round Meowdown `+ [ ]` / `+ [x]` syntax; square checklist
+ * checkboxes are excluded. */
+export const PARSED_NOTE_VERSION = 3
 
 /** The full parse of one note — the stable contract downstream plans depend on. */
 export interface ParsedNote {
@@ -211,7 +213,7 @@ export interface ParsedNote {
   tags: string[]
   headings: Heading[]
   assets: AssetRef[]
-  /** GFM checkbox items in document order — the Tasks projection (Plan 18). */
+  /** Reflect task items in document order — the Tasks projection (Plan 18). */
   tasks: ParsedTask[]
   /** Plain-text rendering of the body for FTS (Plan 08) + AI context (Plan 10). */
   text: string

--- a/packages/core/src/markdown/task-marker.ts
+++ b/packages/core/src/markdown/task-marker.ts
@@ -1,10 +1,8 @@
 /**
- * The GFM checkbox marker (Plan 18) — the one definition of "what is a task
- * marker", shared by extraction ({@link parseNote}, which finds task lines) and
- * the toggle ({@link toggleTaskMarker}, which rewrites them). Keeping it here
- * means the two can never disagree about which `[ ]`/`[x]` lines are tasks: a
- * marker the extractor accepts but the toggle rejects (or vice versa) would be a
- * silent stale read or a no-op write.
+ * The GFM checkbox state marker (Plan 18), shared by extraction ({@link parseNote})
+ * and the toggle ({@link toggleTaskMarker}). Extraction decides which list markers
+ * are Reflect tasks; this helper decides whether the three-character checkbox
+ * marker itself is valid and whether it is checked.
  */
 
 /** The three GFM checkbox markers a task line can carry (`[X]` is GitHub-valid). */

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,10 @@ packages:
   - apps/*
   - packages/*
   - design-system
+allowBuilds:
+  better-sqlite3: true
+  esbuild: true
+  spawn-sync: true
+minimumReleaseAgeExclude:
+  - '@meowdown/core@0.25.0'
+  - '@meowdown/react@0.25.0'


### PR DESCRIPTION
## Summary
- parse only round Meowdown `+ [ ]` / `+ [x]` checkbox rows into `ParsedNote.tasks`
- update task insertion/edit caches/tests/docs to use round task syntax and keep square checklists out of the aggregate
- bump parsed-note and projection versions so existing indexes rebuild
- add exact pnpm policy exclusions for the fresh Meowdown lockfile entries and move build approvals to `pnpm-workspace.yaml` for pnpm 11

## Tests
- `pnpm --filter @reflect/core test -- src/markdown/extract.test.ts src/markdown/edit.test.ts src/indexing/indexed-note.test.ts`
- `pnpm --filter @reflect/desktop test -- src/lib/note-task.test.ts src/components/tasks/tasks-screen.test.tsx src/editor/note-session.test.ts`
- `pnpm typecheck && pnpm lint && pnpm test`

Lint completed with existing warnings only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which markdown lines appear in the Tasks projection and bumps index versions (users may see task lists shrink until reindex); core parsing/write paths are heavily tested but behavior shifts for notes that used `- [ ]` as tasks.
> 
> **Overview**
> **Tasks are defined by list-marker shape, not every GFM checkbox.** Extraction adds a `+`-bullet guard so only round Meowdown task lines (`+ [ ]` / `+ [x]`) become `ParsedNote.tasks`; square `-`/`*`/ordered checkbox rows are ignored. Plan 18 docs drop the `checklist: true` frontmatter opt-out in favor of this marker contract.
> 
> **Writes and UI follow the same syntax.** `appendTaskLine` / `insertTask` append `+ [ ] ` instead of `- [ ] `; desktop tests, task cache reparsing, and comments are aligned. `PARSED_NOTE_VERSION` (3) and `PROJECTION_VERSION` (11) bump so existing graphs reproject task rows correctly.
> 
> **Tooling:** `pnpm.onlyBuiltDependencies` moves from `package.json` into `pnpm-workspace.yaml` (`allowBuilds`, Meowdown release-age exclusions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74a4ccb01794e6cf5916bcbbcae70f2108e9e05c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->