### PR TITLE
Build Intel macOS release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,9 @@ permissions:
   contents: write
 
 jobs:
-  macos:
-    name: Build · sign · notarize · publish (macOS)
-    runs-on: macos-latest
-    timeout-minutes: 120
+  preflight:
+    name: Preflight release
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -44,6 +43,31 @@ jobs:
             echo "::error::pushed tag ${GITHUB_REF_NAME} but tauri.conf.json says ${version} — fix the tag, or bump the version (and src-tauri/Cargo.toml)"
             exit 1
           fi
+
+      - name: Verify release can publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node apps/desktop/scripts/release-macos.mjs preflight
+
+  macos:
+    name: Build · sign · notarize (${{ matrix.name }})
+    needs: preflight
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Apple Silicon
+            runner: macos-latest
+            target: aarch64-apple-darwin
+          - name: Intel
+            runner: macos-15-intel
+            target: x86_64-apple-darwin
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Without the certificate, signing only fails at codesign time — after
       # the whole Rust build. Check every required secret up front instead.
@@ -84,6 +108,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
 
       - name: Cache cargo build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -107,11 +133,9 @@ jobs:
 
       # Tauri imports APPLE_CERTIFICATE into a temporary keychain, signs and
       # notarizes the .app, and signs the updater archive; the script then
-      # notarizes + staples the DMG, runs the Gatekeeper checks, writes
-      # latest.json, and creates the GitHub release.
-      - name: Build, sign, notarize and publish
+      # notarizes + staples the DMG and runs the Gatekeeper checks.
+      - name: Build, sign and notarize
         env:
-          GH_TOKEN: ${{ github.token }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -122,7 +146,38 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: pnpm release:macos build --target=${{ matrix.target }} --artifact-dir="$RUNNER_TEMP/release-artifacts"
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: macos-release-${{ matrix.target }}
+          path: ${{ runner.temp }}/release-artifacts/*
+          if-no-files-found: error
+
+  publish:
+    name: Publish release
+    needs: macos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history so the HEAD-is-on-an-origin-branch check passes on tag
+          # checkouts, and credentials stay for gh/git release preflights.
+          persist-credentials: true
+          fetch-depth: 0
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: macos-release-*
+          path: ${{ runner.temp }}/release-artifacts
+          merge-multiple: true
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
           # Pass the boolean flag through an env variable so the shell never
           # interpolates ${{ }} expressions directly into the run command.
           DRAFT_FLAG: ${{ inputs.draft && '--draft' || '' }}
-        run: pnpm release:macos publish $DRAFT_FLAG
+        run: node apps/desktop/scripts/release-macos.mjs publish --from-artifacts="$RUNNER_TEMP/release-artifacts" $DRAFT_FLAG

--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -21,7 +21,17 @@
 
 import { execFileSync, spawnSync } from 'node:child_process'
 import { randomBytes } from 'node:crypto'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
 import { createInterface } from 'node:readline/promises'
@@ -46,6 +56,20 @@ const FLAVOR_OVERLAYS = {
   beta: 'src-tauri/tauri.beta.conf.json',
   dev: 'src-tauri/tauri.dev.conf.json',
 }
+
+const MACOS_RELEASE_TARGETS = {
+  'aarch64-apple-darwin': {
+    arch: 'aarch64',
+    label: 'Apple Silicon',
+    platform: 'darwin-aarch64',
+  },
+  'x86_64-apple-darwin': {
+    arch: 'x86_64',
+    label: 'Intel',
+    platform: 'darwin-x86_64',
+  },
+}
+const DEFAULT_PUBLISH_TARGETS = ['aarch64-apple-darwin', 'x86_64-apple-darwin']
 
 const here = dirname(fileURLToPath(import.meta.url))
 const appDir = join(here, '..')
@@ -80,8 +104,8 @@ function listUserKeychains() {
 }
 
 /** Build the Tauri CLI arguments for release packaging. */
-export function createTauriBuildArgs({ flavor, hasUpdater }) {
-  const buildArgs = ['tauri', 'build', '--bundles', 'app']
+export function createTauriBuildArgs({ flavor, hasUpdater, target }) {
+  const buildArgs = ['tauri', 'build', '--target', target, '--bundles', 'app']
   const overlay = FLAVOR_OVERLAYS[flavor]
   if (overlay) buildArgs.push('--config', overlay)
   // The beta and dev overlays pin their own updater feed; the stable flavor has
@@ -208,15 +232,24 @@ function resolveUpdaterSigningEnv() {
   }
 }
 
+function releaseTargetConfig(target) {
+  const config = MACOS_RELEASE_TARGETS[target]
+  if (!config) {
+    fail(`unsupported macOS release target "${target}" — one of: ${Object.keys(MACOS_RELEASE_TARGETS).join(', ')}`)
+  }
+  return config
+}
+
 /**
- * The architecture segment of the host triple (e.g. "aarch64"). Taken from
- * rustc — the same source Tauri names bundle artifacts from — rather than
- * process.arch, which diverges when Node runs under Rosetta.
+ * The host triple from rustc rather than process.arch, which diverges when
+ * Node runs under Rosetta. Used as the local build default only; published
+ * releases build every target in DEFAULT_PUBLISH_TARGETS.
  */
-function hostArch() {
-  const arch = capture('rustc', ['-vV']).match(/^host: (\S+)/m)?.[1]?.split('-')[0]
-  if (!arch) fail('could not determine the host triple from rustc -vV')
-  return arch
+function hostTarget() {
+  const target = capture('rustc', ['-vV']).match(/^host: (\S+)/m)?.[1]
+  if (!target) fail('could not determine the host triple from rustc -vV')
+  releaseTargetConfig(target)
+  return target
 }
 
 /** Parse tauri.conf.json — the source of truth for the version and base bundle name. */
@@ -268,13 +301,13 @@ function resolveFlavor({ flavorFlag, version, forPublish }) {
 }
 
 /** Derive bundle output paths from the flavor's resolved config and cargo's target dir. */
-function bundlePaths(flavor) {
+function bundlePaths(flavor, target) {
   const conf = readFlavorConf(flavor)
+  const { arch } = releaseTargetConfig(target)
   const metadata = JSON.parse(
     capture('cargo', ['metadata', '--format-version', '1', '--no-deps'], { cwd: repoRoot }),
   )
-  const arch = hostArch()
-  const bundleDir = join(metadata.target_directory, 'release', 'bundle')
+  const bundleDir = join(metadata.target_directory, target, 'release', 'bundle')
   return {
     app: join(bundleDir, 'macos', `${conf.productName}.app`),
     dmg: join(bundleDir, 'dmg', `${conf.productName}_${conf.version}_${arch}.dmg`),
@@ -286,29 +319,40 @@ function bundlePaths(flavor) {
 }
 
 /**
- * Write the updater manifest next to the bundle and return its path. The stable
- * updater feed resolves `releases/latest/download/latest.json`, so every
- * published release must carry this file — it is how installed apps discover the
- * new version and verify its payload.
+ * Create the updater manifest body. The stable updater feed resolves
+ * `releases/latest/download/latest.json`, so every published release must carry
+ * this file — it is how installed apps discover the new version and verify its
+ * payload.
  */
-function writeUpdaterManifest({ version, tag, flavor }) {
-  const { updaterArchive, updaterSignature } = bundlePaths(flavor)
-  const slug = capture('gh', ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner']).trim()
-  // GitHub rewrites spaces in uploaded asset names to dots, so a flavor whose
-  // productName has a space ("Reflect Beta") is served under a dotted name. The
-  // manifest URL must match the *uploaded* name or auto-update gets a 404.
-  const assetName = basename(updaterArchive).replace(/ /g, '.')
-  const manifest = {
-    version,
-    pub_date: new Date().toISOString(),
-    platforms: {
-      [`darwin-${hostArch()}`]: {
-        signature: readFileSync(updaterSignature, 'utf8').trim(),
-        url: `https://github.com/${slug}/releases/download/${tag}/${assetName}`,
-      },
-    },
+export function createUpdaterManifest({ artifacts, pubDate, slug, tag, version }) {
+  const platforms = {}
+  for (const artifact of artifacts) {
+    // GitHub rewrites spaces in uploaded asset names to dots, so a flavor whose
+    // productName has a space ("Reflect Beta") is served under a dotted name.
+    // The manifest URL must match the uploaded name or auto-update gets a 404.
+    const assetName = basename(artifact.updaterArchive).replace(/ /g, '.')
+    platforms[artifact.platform] = {
+      signature: readFileSync(artifact.updaterSignature, 'utf8').trim(),
+      url: `https://github.com/${slug}/releases/download/${tag}/${assetName}`,
+    }
   }
-  const manifestPath = join(dirname(updaterArchive), 'latest.json')
+  return {
+    version,
+    pub_date: pubDate,
+    platforms,
+  }
+}
+
+function writeUpdaterManifest({ artifacts, outputDir, tag, version }) {
+  const slug = capture('gh', ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner']).trim()
+  const manifest = createUpdaterManifest({
+    artifacts,
+    pubDate: new Date().toISOString(),
+    slug,
+    tag,
+    version,
+  })
+  const manifestPath = join(outputDir, 'latest.json')
   writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
   return manifestPath
 }
@@ -376,9 +420,9 @@ function cleanupSigningCertificate(signingCertificate) {
   rmSync(signingCertificate.tempDir, { recursive: true, force: true })
 }
 
-function createDmg({ flavor, identity, keychain }) {
+function createDmg({ flavor, identity, keychain, target }) {
   const conf = readFlavorConf(flavor)
-  const { app, dmg } = bundlePaths(flavor)
+  const { app, dmg } = bundlePaths(flavor, target)
   if (!existsSync(app)) fail(`${app} does not exist — tauri did not produce the app bundle`)
 
   const stagingRoot = mkdtempSync(join(tmpdir(), 'reflect-dmg-'))
@@ -443,8 +487,8 @@ function expectCheck(description, command, args, expected) {
 }
 
 /** Verify the built bundles match the expected distribution state. */
-function verify({ notarized, flavor }) {
-  const { app, dmg } = bundlePaths(flavor)
+function verify({ notarized, flavor, target }) {
+  const { app, dmg } = bundlePaths(flavor, target)
   if (!existsSync(app)) fail(`${app} does not exist — run \`pnpm release:macos\` first`)
   if (!existsSync(dmg)) fail(`${dmg} does not exist — run \`pnpm release:macos\` first`)
 
@@ -472,22 +516,127 @@ function verify({ notarized, flavor }) {
   expectCheck('stapled ticket (dmg)', 'xcrun', ['stapler', 'validate', dmg], ['The validate action worked!'])
 }
 
-function printArtifacts(flavor) {
-  const { app, dmg } = bundlePaths(flavor)
+function printArtifacts(flavor, target) {
+  const { app, dmg } = bundlePaths(flavor, target)
   const dmgSizeMb = (statSync(dmg).size / (1024 * 1024)).toFixed(1)
   log('distribution bundles:')
   console.log(`  ${app}`)
   console.log(`  ${dmg} (${dmgSizeMb} MB)`)
 }
 
-function build({ notarize, requireUpdater = false, flavor }) {
+function releaseAssetName({ productName, version, target, type }) {
+  const { arch } = releaseTargetConfig(target)
+  const prefix = `${productName}_${version}_${arch}`
+  switch (type) {
+    case 'dmg':
+      return `${prefix}.dmg`
+    case 'updaterArchive':
+      return `${prefix}.app.tar.gz`
+    case 'updaterSignature':
+      return `${prefix}.app.tar.gz.sig`
+    default:
+      fail(`unknown release asset type "${type}"`)
+  }
+}
+
+function exportReleaseArtifacts({ artifactDir, flavor, target }) {
+  const conf = readFlavorConf(flavor)
+  const targetConfig = releaseTargetConfig(target)
+  const paths = bundlePaths(flavor, target)
+  const exported = {
+    dmg: join(
+      artifactDir,
+      releaseAssetName({ productName: conf.productName, version: conf.version, target, type: 'dmg' }),
+    ),
+    updaterArchive: join(
+      artifactDir,
+      releaseAssetName({ productName: conf.productName, version: conf.version, target, type: 'updaterArchive' }),
+    ),
+    updaterSignature: join(
+      artifactDir,
+      releaseAssetName({ productName: conf.productName, version: conf.version, target, type: 'updaterSignature' }),
+    ),
+  }
+
+  mkdirSync(artifactDir, { recursive: true })
+  copyFileSync(paths.dmg, exported.dmg)
+  copyFileSync(paths.updaterArchive, exported.updaterArchive)
+  copyFileSync(paths.updaterSignature, exported.updaterSignature)
+  writeFileSync(
+    join(artifactDir, `${target}.json`),
+    `${JSON.stringify(
+      {
+        version: conf.version,
+        productName: conf.productName,
+        flavor,
+        target,
+        platform: targetConfig.platform,
+        assets: {
+          dmg: basename(exported.dmg),
+          updaterArchive: basename(exported.updaterArchive),
+          updaterSignature: basename(exported.updaterSignature),
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  )
+  log(`exported ${targetConfig.label} release artifacts to ${artifactDir}`)
+}
+
+function readReleaseArtifact({ artifactDir, expectedFlavor, expectedProductName, expectedTarget, expectedVersion }) {
+  const metadataPath = join(artifactDir, `${expectedTarget}.json`)
+  if (!existsSync(metadataPath)) fail(`missing release artifact metadata ${metadataPath}`)
+
+  const metadata = JSON.parse(readFileSync(metadataPath, 'utf8'))
+  const targetConfig = releaseTargetConfig(metadata.target)
+  if (metadata.target !== expectedTarget) fail(`${metadataPath} describes ${metadata.target}, expected ${expectedTarget}`)
+  if (metadata.version !== expectedVersion) {
+    fail(`${metadataPath} describes version ${metadata.version}, expected ${expectedVersion}`)
+  }
+  if (metadata.flavor !== expectedFlavor) fail(`${metadataPath} describes flavor ${metadata.flavor}, expected ${expectedFlavor}`)
+  if (metadata.productName !== expectedProductName) {
+    fail(`${metadataPath} describes product ${metadata.productName}, expected ${expectedProductName}`)
+  }
+  if (metadata.platform !== targetConfig.platform) {
+    fail(`${metadataPath} describes platform ${metadata.platform}, expected ${targetConfig.platform}`)
+  }
+
+  const artifact = {
+    target: metadata.target,
+    platform: metadata.platform,
+    dmg: join(artifactDir, metadata.assets.dmg),
+    updaterArchive: join(artifactDir, metadata.assets.updaterArchive),
+    updaterSignature: join(artifactDir, metadata.assets.updaterSignature),
+  }
+  for (const path of [artifact.dmg, artifact.updaterArchive, artifact.updaterSignature]) {
+    if (!existsSync(path)) fail(`missing release artifact ${path}`)
+  }
+  return artifact
+}
+
+function readReleaseArtifacts({ artifactDir, flavor, productName, targets, version }) {
+  return targets.map((target) =>
+    readReleaseArtifact({
+      artifactDir,
+      expectedFlavor: flavor,
+      expectedProductName: productName,
+      expectedTarget: target,
+      expectedVersion: version,
+    }),
+  )
+}
+
+function build({ artifactDir, notarize, requireUpdater = false, flavor, target }) {
+  const targetConfig = releaseTargetConfig(target)
   const identity = findSigningIdentity()
   log(`signing identity: ${identity}`)
+  log(`release target: ${targetConfig.label} (${target})`)
 
   const updater = resolveUpdaterSigningEnv()
   if (updater) {
     log(`updater signing key: ${updater.source}`)
-  } else if (requireUpdater) {
+  } else if (requireUpdater || artifactDir) {
     fail(
       'no updater signing key found.\n' +
         '  Published releases must carry updater artifacts, or installed apps stop receiving\n' +
@@ -544,12 +693,12 @@ function build({ notarize, requireUpdater = false, flavor }) {
   // script depends on Finder automation and has proven brittle on GitHub-hosted
   // macOS images; create the DMG directly below and keep the same notarization
   // and Gatekeeper checks around the final artifact.
-  const buildArgs = createTauriBuildArgs({ flavor, hasUpdater: Boolean(updater) })
+  const buildArgs = createTauriBuildArgs({ flavor, hasUpdater: Boolean(updater), target })
   const result = spawnSync('pnpm', buildArgs, { cwd: appDir, stdio: 'inherit', env: buildEnv })
   if (result.status !== 0) fail('tauri build failed')
 
   if (updater) {
-    const { updaterArchive, updaterSignature } = bundlePaths(flavor)
+    const { updaterArchive, updaterSignature } = bundlePaths(flavor, target)
     if (!existsSync(updaterArchive) || !existsSync(updaterSignature)) {
       fail(`updater artifacts missing after build — expected ${updaterArchive} and its .sig`)
     }
@@ -557,13 +706,14 @@ function build({ notarize, requireUpdater = false, flavor }) {
 
   const signingCertificate = importSigningCertificate()
   try {
-    createDmg({ flavor, identity, keychain: signingCertificate?.keychainPath })
+    createDmg({ flavor, identity, keychain: signingCertificate?.keychainPath, target })
   } finally {
     cleanupSigningCertificate(signingCertificate)
   }
-  if (notarize) notarizeDmg(bundlePaths(flavor).dmg, credentials)
-  verify({ notarized: notarize, flavor })
-  printArtifacts(flavor)
+  if (notarize) notarizeDmg(bundlePaths(flavor, target).dmg, credentials)
+  verify({ notarized: notarize, flavor, target })
+  printArtifacts(flavor, target)
+  if (artifactDir) exportReleaseArtifacts({ artifactDir, flavor, target })
   log(notarize ? 'done — ready to distribute' : 'done — signed but NOT notarized')
 }
 
@@ -704,7 +854,7 @@ function updateBetaFeed({ commit, manifestPath }) {
  * pre-release. All preflight checks run before the build so a doomed publish
  * fails in seconds, not after notarization.
  */
-function publish({ draft, flavorFlag }) {
+function ensurePublishableRelease({ flavorFlag }) {
   ensureGhReady()
   const commit = ensurePublishableCommit()
   const { version } = readTauriConf()
@@ -713,17 +863,41 @@ function publish({ draft, flavorFlag }) {
   const tag = `v${version}`
   ensureReleaseIsNew(tag)
   ensureTagMatchesCommit(tag, commit)
+  return { commit, flavor, productName, tag, version }
+}
 
-  build({ notarize: true, requireUpdater: true, flavor })
+function preflight({ flavorFlag }) {
+  const { commit, tag } = ensurePublishableRelease({ flavorFlag })
+  log(`${tag} is publishable from ${commit.slice(0, 7)}`)
+}
 
-  const { dmg, updaterArchive, updaterSignature } = bundlePaths(flavor)
-  const manifestPath = writeUpdaterManifest({ version, tag, flavor })
+function publish({ draft, flavorFlag, fromArtifacts }) {
+  const { commit, flavor, productName, tag, version } = ensurePublishableRelease({ flavorFlag })
+  const artifactDir = fromArtifacts ?? mkdtempSync(join(tmpdir(), 'reflect-release-assets-'))
+
+  if (!fromArtifacts) {
+    for (const target of DEFAULT_PUBLISH_TARGETS) {
+      build({ artifactDir, notarize: true, requireUpdater: true, flavor, target })
+    }
+  }
+
+  const artifacts = readReleaseArtifacts({
+    artifactDir,
+    flavor,
+    productName,
+    targets: DEFAULT_PUBLISH_TARGETS,
+    version,
+  })
+  const manifestPath = writeUpdaterManifest({ artifacts, outputDir: artifactDir, tag, version })
   // Pre-releases are invisible to `releases/latest` — the stable updater feed —
   // so installed stable apps never see a beta.
   const prerelease = version.includes('-')
   log(`creating GitHub ${prerelease ? 'pre-release' : 'release'} ${tag} from commit ${commit.slice(0, 7)}…`)
   const releaseArgs = createReleaseArgs({
-    assets: [dmg, updaterArchive, updaterSignature, manifestPath],
+    assets: [
+      ...artifacts.flatMap((artifact) => [artifact.dmg, artifact.updaterArchive, artifact.updaterSignature]),
+      manifestPath,
+    ],
     commit,
     draft,
     prerelease,
@@ -815,6 +989,7 @@ const USAGE = `Usage: pnpm release:macos [command] [flags]
 
 Commands:
   build          Signed + notarized release build, then verify (default)
+  preflight      Check that the current commit can publish before CI spends macOS minutes
   setup          Store the notarization Apple ID + app-specific password in the keychain
   setup-updater  Generate the auto-update signing keypair (keychain + pubkey to commit)
   verify         Re-run signing/Gatekeeper checks on already-built bundles
@@ -823,6 +998,11 @@ Commands:
 Flags:
   --no-notarize   Skip notarization (signed-only build/verify)
   --draft         Create the GitHub release as a draft (publish only)
+  --target=<name> Build or verify one target: aarch64-apple-darwin | x86_64-apple-darwin
+  --artifact-dir=<path>
+                  Export release assets and metadata after build (build only)
+  --from-artifacts=<path>
+                  Publish already-built release assets from this directory (publish only)
   --flavor=<name> Build a flavor: stable | beta | dev (default: derived from the
                   version — prerelease → beta, else stable; publish ignores this
                   and always uses the version's channel)
@@ -834,39 +1014,63 @@ async function main() {
   const argv = process.argv.slice(2)
   const flags = argv.filter((arg) => arg.startsWith('--'))
   const commands = argv.filter((arg) => !arg.startsWith('--'))
+  const command = commands[0] ?? 'build'
   const flavorFlag = flags.find((flag) => flag.startsWith('--flavor='))?.slice('--flavor='.length)
+  const targetFlag = flags.find((flag) => flag.startsWith('--target='))?.slice('--target='.length)
+  const artifactDir = flags.find((flag) => flag.startsWith('--artifact-dir='))?.slice('--artifact-dir='.length)
+  const fromArtifacts = flags.find((flag) => flag.startsWith('--from-artifacts='))?.slice('--from-artifacts='.length)
   const unknownFlag = flags.find(
-    (flag) => !['--no-notarize', '--draft', '--help'].includes(flag) && !flag.startsWith('--flavor='),
+    (flag) =>
+      !['--no-notarize', '--draft', '--help'].includes(flag) &&
+      !flag.startsWith('--flavor=') &&
+      !flag.startsWith('--target=') &&
+      !flag.startsWith('--artifact-dir=') &&
+      !flag.startsWith('--from-artifacts='),
   )
   if (unknownFlag) fail(`unknown flag "${unknownFlag}"\n\n${USAGE}`)
   if (flavorFlag && !Object.keys(FLAVOR_OVERLAYS).includes(flavorFlag)) {
     fail(`unknown --flavor "${flavorFlag}" — one of: ${Object.keys(FLAVOR_OVERLAYS).join(', ')}`)
   }
+  if (targetFlag) releaseTargetConfig(targetFlag)
+  if (targetFlag && !['build', 'verify'].includes(command)) fail('--target only applies to build and verify')
+  if (artifactDir && command !== 'build') fail('--artifact-dir only applies to build')
+  if (fromArtifacts && command !== 'publish') fail('--from-artifacts only applies to publish')
   if (flags.includes('--help')) {
     console.log(USAGE)
     return
   }
-  if (process.platform !== 'darwin') fail('this command only runs on macOS')
 
-  const command = commands[0] ?? 'build'
+  const needsMacos =
+    ['build', 'setup', 'setup-updater', 'verify'].includes(command) || (command === 'publish' && !fromArtifacts)
+  if (needsMacos && process.platform !== 'darwin') fail('this command only runs on macOS')
+
   const notarize = !flags.includes('--no-notarize')
   if (command === 'publish' && !notarize) fail('publish always notarizes — drop --no-notarize')
   if (command !== 'publish' && flags.includes('--draft')) fail('--draft only applies to publish')
   const { version } = readTauriConf()
   switch (command) {
     case 'build':
-      return build({ notarize, flavor: resolveFlavor({ flavorFlag, version, forPublish: false }) })
+      return build({
+        artifactDir,
+        notarize,
+        requireUpdater: Boolean(artifactDir),
+        flavor: resolveFlavor({ flavorFlag, version, forPublish: false }),
+        target: targetFlag ?? hostTarget(),
+      })
+    case 'preflight':
+      return preflight({ flavorFlag })
     case 'setup':
       return setup()
     case 'setup-updater':
       return setupUpdater()
     case 'verify': {
       const flavor = resolveFlavor({ flavorFlag, version, forPublish: false })
-      verify({ notarized: notarize, flavor })
-      return printArtifacts(flavor)
+      const target = targetFlag ?? hostTarget()
+      verify({ notarized: notarize, flavor, target })
+      return printArtifacts(flavor, target)
     }
     case 'publish':
-      return publish({ draft: flags.includes('--draft'), flavorFlag })
+      return publish({ draft: flags.includes('--draft'), flavorFlag, fromArtifacts })
     default:
       fail(`unknown command "${command}"\n\n${USAGE}`)
   }

--- a/apps/desktop/scripts/release-macos.test.mjs
+++ b/apps/desktop/scripts/release-macos.test.mjs
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { expect, test } from 'vitest'
 
 import {
@@ -5,6 +8,7 @@ import {
   createDmgArgs,
   createReleaseArgs,
   createTauriBuildArgs,
+  createUpdaterManifest,
   parseKeychainList,
   signDmgArgs,
   uploadBetaFeedArgs,
@@ -96,9 +100,9 @@ test('beta feed upload replaces the moving manifest', () => {
 })
 
 test('release builds ask Tauri for the app bundle only', () => {
-  const args = createTauriBuildArgs({ flavor: 'stable', hasUpdater: true })
+  const args = createTauriBuildArgs({ flavor: 'stable', hasUpdater: true, target: 'x86_64-apple-darwin' })
 
-  expect(args.slice(0, 4)).toEqual(['tauri', 'build', '--bundles', 'app'])
+  expect(args.slice(0, 6)).toEqual(['tauri', 'build', '--target', 'x86_64-apple-darwin', '--bundles', 'app'])
   expect(args).not.toContain('dmg')
   expect(args).toContain(JSON.stringify({ bundle: { createUpdaterArtifacts: true } }))
   expect(args).toContain(
@@ -113,14 +117,62 @@ test('release builds ask Tauri for the app bundle only', () => {
 })
 
 test('beta release builds keep the beta flavor overlay', () => {
-  expect(createTauriBuildArgs({ flavor: 'beta', hasUpdater: false })).toEqual([
+  expect(createTauriBuildArgs({ flavor: 'beta', hasUpdater: false, target: 'aarch64-apple-darwin' })).toEqual([
     'tauri',
     'build',
+    '--target',
+    'aarch64-apple-darwin',
     '--bundles',
     'app',
     '--config',
     'src-tauri/tauri.beta.conf.json',
   ])
+})
+
+test('updater manifest includes both macOS release targets', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'reflect-release-test-'))
+  try {
+    const appleSignature = join(tempDir, 'Reflect Beta_0.3.4_aarch64.app.tar.gz.sig')
+    const intelSignature = join(tempDir, 'Reflect Beta_0.3.4_x86_64.app.tar.gz.sig')
+    writeFileSync(appleSignature, 'apple-signature\n')
+    writeFileSync(intelSignature, 'intel-signature\n')
+
+    expect(
+      createUpdaterManifest({
+        artifacts: [
+          {
+            platform: 'darwin-aarch64',
+            updaterArchive: join(tempDir, 'Reflect Beta_0.3.4_aarch64.app.tar.gz'),
+            updaterSignature: appleSignature,
+          },
+          {
+            platform: 'darwin-x86_64',
+            updaterArchive: join(tempDir, 'Reflect Beta_0.3.4_x86_64.app.tar.gz'),
+            updaterSignature: intelSignature,
+          },
+        ],
+        pubDate: '2026-06-26T00:00:00.000Z',
+        slug: 'team-reflect/reflect-open',
+        tag: 'v0.3.4',
+        version: '0.3.4',
+      }),
+    ).toEqual({
+      version: '0.3.4',
+      pub_date: '2026-06-26T00:00:00.000Z',
+      platforms: {
+        'darwin-aarch64': {
+          signature: 'apple-signature',
+          url: 'https://github.com/team-reflect/reflect-open/releases/download/v0.3.4/Reflect.Beta_0.3.4_aarch64.app.tar.gz',
+        },
+        'darwin-x86_64': {
+          signature: 'intel-signature',
+          url: 'https://github.com/team-reflect/reflect-open/releases/download/v0.3.4/Reflect.Beta_0.3.4_x86_64.app.tar.gz',
+        },
+      },
+    })
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true })
+  }
 })
 
 test('DMG creation uses direct hdiutil packaging', () => {

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -6,8 +6,8 @@ Mac App Store.
 ```bash
 pnpm release:macos setup           # once: store notarization credentials in the keychain
 pnpm release:macos setup-updater   # once: generate the auto-update signing keypair
-pnpm release:macos                 # signed + notarized build, verified end to end
-pnpm release:macos publish         # the above, then upload the DMG + updater artifacts to a new GitHub release
+pnpm release:macos                 # signed + notarized build for this Mac's architecture
+pnpm release:macos publish         # build Apple Silicon + Intel, then publish both DMGs
 ```
 
 The helper lives at `apps/desktop/scripts/release-macos.mjs` and is exposed as
@@ -49,9 +49,9 @@ can still build unsigned bundles with plain `pnpm tauri build`.
 1. Auto-detects the Developer ID identity from the keychain and derives the team ID.
 2. Loads notarization credentials (keychain item, or environment variables — see
    [Releasing from CI](#releasing-from-ci) below).
-3. Runs `pnpm tauri build --bundles app`, which stages the `reflect` CLI sidecar, then
-   signs inside-out (sidecar → main binary → `.app`) with hardened runtime, notarizes
-   the `.app` via `notarytool`, and staples the ticket.
+3. Runs `pnpm tauri build --target <target> --bundles app`, which stages the `reflect`
+   CLI sidecar for that target, then signs inside-out (sidecar → main binary → `.app`)
+   with hardened runtime, notarizes the `.app` via `notarytool`, and staples the ticket.
 4. Builds and signs the DMG directly from the notarized app. In CI, the release helper
    imports `APPLE_CERTIFICATE` into its own temporary keychain for this DMG signing step;
    Tauri's app-signing keychain is internal to `tauri build`. The helper avoids Tauri's
@@ -64,19 +64,24 @@ can still build unsigned bundles with plain `pnpm tauri build`.
    the app and DMG (`accepted` / `source=Notarized Developer ID`), and stapled tickets —
    and fails loudly if any check is off.
 
-Bundles land in `target/release/bundle/macos/Reflect.app` and
-`target/release/bundle/dmg/Reflect_<version>_<arch>.dmg`.
+Bundles land under `target/<target-triple>/release/bundle/`, for example
+`target/aarch64-apple-darwin/release/bundle/macos/Reflect.app` and
+`target/x86_64-apple-darwin/release/bundle/dmg/Reflect_<version>_x86_64.dmg`.
 
 ## Commands and flags
 
 ```bash
 pnpm release:macos                 # build + notarize + verify (default)
+pnpm release:macos --target=x86_64-apple-darwin  # build + notarize + verify for Intel
 pnpm release:macos setup           # store Apple ID + app-specific password in the keychain
 pnpm release:macos verify          # re-run all checks on already-built bundles
 pnpm release:macos publish         # build + notarize + verify, then create a GitHub release
 pnpm release:macos publish --draft # same, but leave the release as a draft for review
 pnpm release:macos --no-notarize   # signed-only build (runs locally; Gatekeeper rejects it elsewhere)
 ```
+
+CI uses `build --target=<triple> --artifact-dir=<dir>` for each architecture, then
+`publish --from-artifacts=<dir>` after downloading both artifact sets.
 
 ## Cutting a release (`pnpm release:bump`)
 
@@ -121,11 +126,13 @@ without tagging, for when you want the version commit but aren't ready to releas
 
 ## Publishing to GitHub Releases
 
-`pnpm release:macos publish` runs the full build above, then creates a GitHub release
-tagged `v<version>` (the `version` in `apps/desktop/src-tauri/tauri.conf.json`) with the
-notarized DMG, the updater artifacts (`Reflect.app.tar.gz` + `.sig`), and the
-`latest.json` manifest attached, plus auto-generated release notes. Stable installs poll
-`releases/latest/download/latest.json`; beta installs poll
+`pnpm release:macos publish` runs the full build above for both supported macOS targets
+(`aarch64-apple-darwin` for Apple Silicon and `x86_64-apple-darwin` for Intel), then
+creates a GitHub release tagged `v<version>` (the `version` in
+`apps/desktop/src-tauri/tauri.conf.json`). The release carries two notarized DMGs, two
+updater archives (one per architecture, each with its `.sig`), and a single
+`latest.json` manifest with both `darwin-aarch64` and `darwin-x86_64` platform entries.
+Stable installs poll `releases/latest/download/latest.json`; beta installs poll
 `releases/download/updater-beta/latest.json`, a moving feed release that points at the
 newest published beta. Publish requires the updater key and always attaches the
 manifest — a release without it would stop existing installs from seeing any future
@@ -217,13 +224,19 @@ Stable installs are unaffected (same identifier and the shipped icon).
 
 ## Releasing from CI
 
-`.github/workflows/release.yml` runs `pnpm release:macos publish` on a GitHub-hosted
-macOS runner — the same pipeline as a local release, including DMG notarization, the
-Gatekeeper checks, and the updater artifacts. Trigger it from **Actions → Release →
-Run workflow** (tick *draft* to review the release before publishing), or by pushing
-the matching `v<version>` tag. The publish preflights apply unchanged, so bump
-`version` in `tauri.conf.json` (and `src-tauri/Cargo.toml`) on the released branch
-first.
+`.github/workflows/release.yml` first runs the publish preflights, then builds two
+signed/notarized macOS artifacts in parallel:
+
+- Apple Silicon: `macos-latest`, `--target=aarch64-apple-darwin`
+- Intel: `macos-15-intel`, `--target=x86_64-apple-darwin`
+
+Each build job runs the same DMG notarization, Gatekeeper checks, and updater artifact
+signing as a local release, then uploads its artifacts to the workflow. A final publish
+job downloads both sets, writes the combined `latest.json`, and creates the GitHub
+release. Trigger it from **Actions → Release → Run workflow** (tick *draft* to review
+the release before publishing), or by pushing the matching `v<version>` tag. The publish
+preflights apply unchanged, so bump `version` in `tauri.conf.json` (and
+`src-tauri/Cargo.toml`) on the released branch first.
 
 The script reads all signing material from environment variables, which take
 precedence over the keychain (exporting them works for local releases too); the
@@ -270,10 +283,5 @@ on the runner keychain setup.
 
 ## Current limitations
 
-- Builds target the host architecture only (Apple Silicon in practice). A universal
-  build needs the `x86_64-apple-darwin` rustup target, a universal sidecar from
-  `scripts/build-sidecar.mjs`, and `pnpm tauri build --target universal-apple-darwin`.
 - The iOS project template (`src-tauri/ios.project.yml`) still uses the pre-rename bundle
   identifier and needs its own provisioning pass.
-- `latest.json` only lists the host architecture, so auto-update serves the arch that was
-  built (Apple Silicon in practice); the universal-build work above lifts both limits.


### PR DESCRIPTION
## Summary
- split the release workflow into preflight, per-architecture macOS build jobs, and a final publish job
- teach release-macos.mjs to build explicit macOS targets, export per-arch DMG/updater artifacts, and publish a combined updater manifest for Apple Silicon and Intel
- document the two-DMG release flow and add release-helper coverage for target args and multi-platform manifests

## Testing
- node --check apps/desktop/scripts/release-macos.mjs
- node apps/desktop/scripts/release-macos.mjs --help
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'release workflow yaml ok'"
- git diff --check
- node_modules/.pnpm/node_modules/.bin/vitest run apps/desktop/scripts/release-macos.test.mjs
- node_modules/oxlint/bin/oxlint apps packages (passes with existing warnings)
- ../../node_modules/.pnpm/node_modules/.bin/eslint . from apps/desktop (passes with existing warnings)

## Notes
- pnpm typecheck / turbo typecheck currently fail before running desktop typecheck because the lockfile hits ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION for @meowdown/core@0.25.0 and @meowdown/react@0.25.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline and updater manifest shape; a mistake could ship wrong or single-arch assets and break auto-update for one architecture, though metadata validation and new tests reduce that risk.
> 
> **Overview**
> macOS releases now ship **separate Apple Silicon and Intel DMGs and updater payloads**, with auto-update driven by a single `latest.json` that lists both `darwin-aarch64` and `darwin-x86_64`.
> 
> The **Release workflow** is split into a Ubuntu **preflight** job (`release-macos.mjs preflight`), **parallel macOS matrix builds** (`aarch64` on `macos-latest`, `x86_64` on `macos-15-intel`) that run `build --target=… --artifact-dir=…` and upload artifacts, and a final **publish** job that merges downloads and runs `publish --from-artifacts=…`.
> 
> **`release-macos.mjs`** gains explicit Rust targets, per-arch artifact export/metadata (`*.json`), `createUpdaterManifest` for multi-platform manifests, a **`preflight`** command, and **`publish --from-artifacts`** so publish can run on Linux without rebuilding. Local `publish` still builds both default targets when not using prebuilt artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfa64a4d188ea427738a62671c4914fc86e02afe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->