### PR TITLE
Fix Intel macOS release runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,11 @@ jobs:
     needs: preflight
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
+    env:
+      # Cargo registry fetches can intermittently fail on GitHub macOS runners
+      # with curl HTTP/2 framing errors. HTTP/1.1 is slower but steadier for
+      # release builds, where determinism matters more than a small fetch win.
+      CARGO_HTTP_MULTIPLEXING: false
     strategy:
       fail-fast: false
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,6 +790,19 @@ dependencies = [
 
 [[package]]
 name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
@@ -1533,12 +1546,12 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastembed"
-version = "5.16.0"
+version = "5.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add59222e7bc3787285f993744b244cd454d78571845623606bdc45b22b23a4e"
+checksum = "1f54fc1188b7f7eac8f47be2ab7b3a79ffd842cc8ff2e38316dd59ba4858890e"
 dependencies = [
  "anyhow",
- "hf-hub",
+ "hf-hub 0.4.3",
  "image",
  "ndarray",
  "ort",
@@ -2218,13 +2231,13 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hf-hub"
-version = "0.5.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
+checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
 dependencies = [
  "dirs",
  "http",
- "indicatif",
+ "indicatif 0.17.11",
  "libc",
  "log",
  "native-tls",
@@ -2233,7 +2246,28 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "ureq",
+ "ureq 2.12.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "hf-hub"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
+dependencies = [
+ "dirs",
+ "http",
+ "indicatif 0.18.4",
+ "libc",
+ "log",
+ "native-tls",
+ "rand",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "ureq 3.3.0",
  "windows-sys 0.61.2",
 ]
 
@@ -2341,7 +2375,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2599,11 +2633,24 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console 0.15.11",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console",
+ "console 0.16.3",
  "portable-atomic",
  "unicode-width",
  "unit-prefix",
@@ -2962,7 +3009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -3013,6 +3060,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3512,6 +3569,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3851,26 +3914,27 @@ dependencies = [
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.12"
+version = "2.0.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+checksum = "4a5df903c0d2c07b56950f1058104ab0c8557159f2741782223704de9be73c3c"
 dependencies = [
+ "libloading 0.9.0",
  "ndarray",
  "ort-sys",
  "smallvec",
  "tracing",
- "ureq",
+ "ureq 3.3.0",
 ]
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.12"
+version = "2.0.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",
- "ureq",
+ "ureq 3.3.0",
 ]
 
 [[package]]
@@ -4586,11 +4650,12 @@ dependencies = [
  "dirs",
  "fastembed",
  "git2",
- "hf-hub",
+ "hf-hub 0.5.0",
  "image",
  "keyring",
  "notify",
  "notify-debouncer-full",
+ "ort",
  "reflect-index-schema",
  "reqwest 0.12.28",
  "rusqlite",
@@ -4686,7 +4751,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -6681,6 +6746,26 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "native-tls",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "ureq"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
@@ -6700,7 +6785,7 @@ dependencies = [
  "ureq-proto",
  "utf8-zero",
  "webpki-root-certs",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -7078,6 +7163,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]

--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -42,6 +42,14 @@ const UPDATER_KEYCHAIN_SERVICE = 'reflect-updater'
 const APP_SPECIFIC_PASSWORD_URL = 'https://account.apple.com'
 const BETA_UPDATER_FEED_TAG = 'updater-beta'
 const STABLE_UPDATER_ENDPOINT = 'https://github.com/team-reflect/reflect-open/releases/latest/download/latest.json'
+const INTEL_MAC_TARGET = 'x86_64-apple-darwin'
+const INTEL_ONNX_RUNTIME_VERSION = '1.23.2'
+const INTEL_ONNX_RUNTIME_ARCHIVE_ROOT = `onnxruntime-osx-x86_64-${INTEL_ONNX_RUNTIME_VERSION}`
+const INTEL_ONNX_RUNTIME_URL =
+  `https://github.com/microsoft/onnxruntime/releases/download/v${INTEL_ONNX_RUNTIME_VERSION}/` +
+  `${INTEL_ONNX_RUNTIME_ARCHIVE_ROOT}.tgz`
+const ONNX_RUNTIME_DYLIB_RESOURCE = 'libonnxruntime.dylib'
+const INTEL_ONNX_RUNTIME_RESOURCE_SOURCE = `resources/onnxruntime/${ONNX_RUNTIME_DYLIB_RESOURCE}`
 
 /**
  * Build flavors. Each ships as a distinct app (its own productName, identifier
@@ -104,7 +112,7 @@ function listUserKeychains() {
 }
 
 /** Build the Tauri CLI arguments for release packaging. */
-export function createTauriBuildArgs({ flavor, hasUpdater, target }) {
+export function createTauriBuildArgs({ flavor, hasUpdater, resourceConfig = null, target }) {
   const buildArgs = ['tauri', 'build', '--target', target, '--bundles', 'app']
   const overlay = FLAVOR_OVERLAYS[flavor]
   if (overlay) buildArgs.push('--config', overlay)
@@ -120,7 +128,60 @@ export function createTauriBuildArgs({ flavor, hasUpdater, target }) {
   if (hasUpdater) {
     buildArgs.push('--config', JSON.stringify({ bundle: { createUpdaterArtifacts: true } }))
   }
+  if (resourceConfig) {
+    buildArgs.push('--config', JSON.stringify(resourceConfig))
+  }
   return buildArgs
+}
+
+export function macosTargetResourceConfig(target) {
+  if (target !== INTEL_MAC_TARGET) return null
+  return {
+    bundle: {
+      resources: {
+        [INTEL_ONNX_RUNTIME_RESOURCE_SOURCE]: ONNX_RUNTIME_DYLIB_RESOURCE,
+        'resources/onnxruntime/LICENSE': 'onnxruntime/LICENSE',
+        'resources/onnxruntime/ThirdPartyNotices.txt': 'onnxruntime/ThirdPartyNotices.txt',
+      },
+    },
+  }
+}
+
+function stageIntelOnnxRuntime() {
+  const resourceDir = join(appDir, 'src-tauri', 'resources', 'onnxruntime')
+  const dylib = join(resourceDir, ONNX_RUNTIME_DYLIB_RESOURCE)
+  const license = join(resourceDir, 'LICENSE')
+  const notices = join(resourceDir, 'ThirdPartyNotices.txt')
+  if (existsSync(dylib) && existsSync(license) && existsSync(notices)) {
+    return
+  }
+
+  const tempDir = mkdtempSync(join(tmpdir(), 'reflect-onnxruntime-'))
+  try {
+    const archive = join(tempDir, `${INTEL_ONNX_RUNTIME_ARCHIVE_ROOT}.tgz`)
+    log(`downloading ONNX Runtime ${INTEL_ONNX_RUNTIME_VERSION} for Intel macOS…`)
+    execFileSync(
+      'curl',
+      ['-fL', '--retry', '3', '--retry-delay', '2', '-o', archive, INTEL_ONNX_RUNTIME_URL],
+      { stdio: 'inherit' },
+    )
+    execFileSync('tar', ['-xzf', archive, '-C', tempDir], { stdio: 'inherit' })
+
+    const root = join(tempDir, INTEL_ONNX_RUNTIME_ARCHIVE_ROOT)
+    mkdirSync(resourceDir, { recursive: true })
+    copyFileSync(join(root, 'lib', ONNX_RUNTIME_DYLIB_RESOURCE), dylib)
+    copyFileSync(join(root, 'LICENSE'), license)
+    copyFileSync(join(root, 'ThirdPartyNotices.txt'), notices)
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true })
+  }
+}
+
+function prepareTargetResources(target) {
+  const resourceConfig = macosTargetResourceConfig(target)
+  if (!resourceConfig) return null
+  stageIntelOnnxRuntime()
+  return resourceConfig
 }
 
 /**
@@ -693,7 +754,8 @@ function build({ artifactDir, notarize, requireUpdater = false, flavor, target }
   // script depends on Finder automation and has proven brittle on GitHub-hosted
   // macOS images; create the DMG directly below and keep the same notarization
   // and Gatekeeper checks around the final artifact.
-  const buildArgs = createTauriBuildArgs({ flavor, hasUpdater: Boolean(updater), target })
+  const resourceConfig = prepareTargetResources(target)
+  const buildArgs = createTauriBuildArgs({ flavor, hasUpdater: Boolean(updater), resourceConfig, target })
   const result = spawnSync('pnpm', buildArgs, { cwd: appDir, stdio: 'inherit', env: buildEnv })
   if (result.status !== 0) fail('tauri build failed')
 

--- a/apps/desktop/scripts/release-macos.test.mjs
+++ b/apps/desktop/scripts/release-macos.test.mjs
@@ -9,6 +9,7 @@ import {
   createReleaseArgs,
   createTauriBuildArgs,
   createUpdaterManifest,
+  macosTargetResourceConfig,
   parseKeychainList,
   signDmgArgs,
   uploadBetaFeedArgs,
@@ -114,6 +115,22 @@ test('release builds ask Tauri for the app bundle only', () => {
       },
     }),
   )
+})
+
+test('Intel release builds include the bundled ONNX Runtime resource', () => {
+  const resourceConfig = macosTargetResourceConfig('x86_64-apple-darwin')
+  const args = createTauriBuildArgs({
+    flavor: 'stable',
+    hasUpdater: true,
+    resourceConfig,
+    target: 'x86_64-apple-darwin',
+  })
+
+  expect(args).toContain(JSON.stringify(resourceConfig))
+})
+
+test('Apple Silicon release builds do not include Intel-only runtime resources', () => {
+  expect(macosTargetResourceConfig('aarch64-apple-darwin')).toBeNull()
 })
 
 test('beta release builds keep the beta flavor overlay', () => {

--- a/apps/desktop/src-tauri/.gitignore
+++ b/apps/desktop/src-tauri/.gitignore
@@ -8,3 +8,6 @@
 
 # Tauri sidecar staging (built by scripts/build-sidecar.mjs; never committed)
 /binaries
+
+# Release-only native runtime resources (downloaded by scripts/release-macos.mjs)
+/resources/onnxruntime

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -69,10 +69,27 @@ tauri-plugin-window-state = "2"
 trash = "5.2.6"
 notify = "8.2.0"
 notify-debouncer-full = "0.7.0"
-fastembed = "5"
 # Direct dependency on fastembed's own downloader, used to pre-fetch the
 # embedding model with byte-level progress (fastembed downloads silently).
 hf-hub = { version = "0.5.0", default-features = false, features = ["ureq", "native-tls"] }
+
+[target.'cfg(all(not(any(target_os = "android", target_os = "ios")), not(all(target_os = "macos", target_arch = "x86_64"))))'.dependencies]
+fastembed = "5"
+
+[target.'cfg(all(target_os = "macos", target_arch = "x86_64"))'.dependencies]
+# fastembed 5.14+ pins ONNX Runtime API 24, but upstream ONNX Runtime 1.24
+# no longer ships macOS x86_64 binaries. Stay on API 23 for Intel until the
+# upstream binary set comes back or we replace the backend.
+fastembed = { version = ">=5.13.0, <5.14.0", default-features = false, features = [
+  "hf-hub-native-tls",
+  "image-models",
+  "ort-load-dynamic",
+] }
+ort = { version = "=2.0.0-rc.11", default-features = false, features = [
+  "ndarray",
+  "std",
+  "load-dynamic",
+] }
 
 # Mobile-only capabilities (Plan 19): the first-party keyboard bridge — no
 # software keyboard on desktop. (Sharing uses the webview's Web Share API,
@@ -82,4 +99,3 @@ tauri-plugin-keyboard = { path = "../../../plugins/tauri-plugin-keyboard" }
 
 [dev-dependencies]
 tauri = { version = "2", features = ["test"] }
-

--- a/apps/desktop/src-tauri/src/embed.rs
+++ b/apps/desktop/src-tauri/src/embed.rs
@@ -32,6 +32,8 @@ const MODEL_FILES: [&str; 5] = [
     "special_tokens_map.json",
     "tokenizer_config.json",
 ];
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+const ONNX_RUNTIME_DYLIB_RESOURCE: &str = "libonnxruntime.dylib";
 
 /// Byte counts for an active model download. Absent until the download
 /// starts (cache probing, or a cached model that skips downloading); after
@@ -241,6 +243,34 @@ fn download_model_files(app: &AppHandle, cache_dir: &Path) -> Result<(), String>
     Ok(())
 }
 
+fn configure_onnx_runtime(app: &AppHandle) -> Result<(), String> {
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+    {
+        let dylib = app
+            .path()
+            .resource_dir()
+            .map_err(|err| format!("locating app resources: {err}"))?
+            .join(ONNX_RUNTIME_DYLIB_RESOURCE);
+        if !dylib.exists() {
+            return Err(format!(
+                "ONNX Runtime library is missing from app resources: {}",
+                dylib.display()
+            ));
+        }
+        let committed = ort::init_from(&dylib)
+            .map_err(|err| format!("loading ONNX Runtime from {}: {err}", dylib.display()))?
+            .commit();
+        if committed {
+            tracing::info!(path = %dylib.display(), "loaded bundled ONNX Runtime");
+        }
+    }
+    #[cfg(not(all(target_os = "macos", target_arch = "x86_64")))]
+    {
+        let _ = app;
+    }
+    Ok(())
+}
+
 /// Current runtime status (poll on startup; live changes arrive on
 /// `embed:status` events).
 #[tauri::command]
@@ -279,6 +309,7 @@ pub async fn embed_ensure(app: AppHandle, state: State<'_, EmbedState>) -> AppRe
     let app_for_progress = app.clone();
     let loaded: Result<TextEmbedding, String> =
         match tauri::async_runtime::spawn_blocking(move || {
+            configure_onnx_runtime(&app_for_progress)?;
             download_model_files(&app_for_progress, &cache_dir)?;
             TextEmbedding::try_new(
                 InitOptions::new(EmbeddingModel::AllMiniLML6V2).with_cache_dir(cache_dir),

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -52,6 +52,9 @@ can still build unsigned bundles with plain `pnpm tauri build`.
 3. Runs `pnpm tauri build --target <target> --bundles app`, which stages the `reflect`
    CLI sidecar for that target, then signs inside-out (sidecar → main binary → `.app`)
    with hardened runtime, notarizes the `.app` via `notarytool`, and staples the ticket.
+   Intel builds also download Microsoft's official ONNX Runtime macOS x86_64 archive
+   into `src-tauri/resources/onnxruntime/` and bundle `libonnxruntime.dylib` as a
+   Tauri resource before signing; that directory is generated and gitignored.
 4. Builds and signs the DMG directly from the notarized app. In CI, the release helper
    imports `APPLE_CERTIFICATE` into its own temporary keychain for this DMG signing step;
    Tauri's app-signing keychain is internal to `tauri build`. The helper avoids Tauri's


### PR DESCRIPTION
## Summary
- use a target-specific dynamic ONNX Runtime path for Intel macOS so the release build no longer asks ort-sys for missing x86_64 static binaries
- stage Microsoft ONNX Runtime 1.23.2 as a Tauri resource for Intel release builds and load it from the embedding runtime
- add Cargo HTTP/2 registry mitigation for macOS release jobs

## Testing
- pnpm --filter @reflect/desktop test scripts/release-macos.test.mjs
- TAURI_ENV_TARGET_TRIPLE=x86_64-apple-darwin pnpm --filter @reflect/desktop sidecar
- CARGO_HTTP_MULTIPLEXING=false cargo check -p reflect-open --target x86_64-apple-darwin
- CARGO_HTTP_MULTIPLEXING=false cargo check -p reflect-open --target aarch64-apple-darwin
- pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the embedding stack and release packaging for Intel macOS only, with version pins and a bundled native dylib; Apple Silicon behavior is unchanged but lockfile dependency shifts are broad.
> 
> **Overview**
> Fixes **Intel macOS** release builds where semantic search could not run because newer **fastembed** / **ort** expect ONNX Runtime binaries that Microsoft no longer ships for **x86_64** macOS.
> 
> **Intel-only dependency split:** `fastembed` is capped below 5.14 and built with dynamic ORT loading; `ort` is pinned to **2.0.0-rc.11**. Apple Silicon and other desktop targets keep the normal `fastembed = "5"` path. `Cargo.lock` reflects the downgrades and duplicate crate versions those pins pull in.
> 
> **Bundled runtime for Intel releases:** `release-macos.mjs` downloads Microsoft **ONNX Runtime 1.23.2** for `x86_64-apple-darwin`, stages it under gitignored `src-tauri/resources/onnxruntime/`, and injects Tauri bundle resources (`libonnxruntime.dylib` plus license files). `embed.rs` loads that dylib from the app resource dir before model init on Intel Macs only.
> 
> **CI reliability:** The macOS release job sets `CARGO_HTTP_MULTIPLEXING=false` to avoid intermittent registry fetch failures on GitHub runners. Docs and unit tests cover the Intel resource wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c7e1ef5cea8a48cfb825bdda7eadf22cb140b77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->