### PR TITLE
Release v0.4.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4644,7 +4644,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.3.6"
+version = "0.4.0-beta.1"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.3.6"
+version = "0.4.0-beta.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.3.6",
+  "version": "0.4.0-beta.1",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.4.0-beta.1.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version alignment with no runtime or dependency changes in the diff.
> 
> **Overview**
> Bumps the desktop app release version from **0.3.6** to **0.4.0-beta.1** in `apps/desktop/src-tauri/Cargo.toml`, `tauri.conf.json`, and the locked `reflect-open` entry in `Cargo.lock`.
> 
> No application logic, dependencies, or config beyond the version strings change—this aligns the Tauri package and bundle metadata for the beta release workflow described in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27ee860a9efc387fba0794e6a7bf2424d08a73c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop app’s version to `0.4.0-beta.1` in the app package and configuration.
  * No user-facing features or behavior changes were included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->