### PR TITLE
Fix daily tab scroll restoration

### DIFF
--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -124,11 +124,16 @@ function renderSidebar(overrides?: Partial<CommandContext>, initialRoute?: Route
 }
 
 describe('Sidebar', () => {
-  it('nav rows run their registered commands', async () => {
+  it('nav rows navigate, with Daily notes preserving its tab scroll', async () => {
     const { view, navigate } = renderSidebar()
 
     await userEvent.click(view.getByRole('button', { name: /daily notes/i }))
-    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ kind: 'today' }))
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith(
+        { kind: 'today' },
+        { restoreSurfaceScroll: true },
+      ),
+    )
 
     await userEvent.click(view.getByRole('button', { name: /settings/i }))
     await waitFor(() => expect(navigate).toHaveBeenCalledWith({ kind: 'settings' }))

--- a/apps/desktop/src/components/sidebar/sidebar.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.tsx
@@ -26,9 +26,11 @@ interface SidebarProps {
 /**
  * The workspace sidebar, in the original app's shape: history arrows top
  * right, search, primary navigation with hover-revealed shortcut keycaps, the
- * Pinned shelf, and the graph switcher footer. Nav rows run registered
- * commands so a binding and its behavior stay one definition. (Sidebar
- * collapse stays on `Mod-\` via the command registry.)
+ * Pinned shelf, and the graph switcher footer. Most nav rows run registered
+ * commands so a binding and its behavior stay one definition; the Daily notes
+ * row preserves the stream's tab scroll on click, while its `Mod-D` binding
+ * still runs the command and jumps to today. (Sidebar collapse stays on
+ * `Mod-\` via the command registry.)
  */
 export function Sidebar({ graph, context }: SidebarProps): ReactElement {
   const { route } = useRouter()
@@ -64,7 +66,9 @@ export function Sidebar({ graph, context }: SidebarProps): ReactElement {
             label="Daily notes"
             binding={keybindingFor('nav.today') ?? undefined}
             active={route.kind === 'today' || route.kind === 'daily'}
-            onClick={() => void runCommand('nav.today', context)}
+            onClick={() =>
+              context.navigate({ kind: 'today' }, { restoreSurfaceScroll: true })
+            }
           />
           <SidebarItem
             icon={

--- a/apps/desktop/src/lib/commands/types.ts
+++ b/apps/desktop/src/lib/commands/types.ts
@@ -1,4 +1,5 @@
 import type { Route } from '@/routing/route'
+import type { NavigateOptions } from '@/routing/router'
 
 /**
  * The typed command contract (Plan 08): one registry powers the ⌘K palette,
@@ -8,7 +9,7 @@ import type { Route } from '@/routing/route'
  */
 
 export interface CommandContext {
-  navigate: (route: Route) => void
+  navigate: (route: Route, options?: NavigateOptions) => void
   /** The current route, read at run time. */
   route: () => Route
   /**

--- a/apps/desktop/src/routing/router.test.tsx
+++ b/apps/desktop/src/routing/router.test.tsx
@@ -87,6 +87,25 @@ describe('router', () => {
     expect(result.current.arrivalSeq).toBe(seqBefore + 1) // views are notified
   })
 
+  it('can restore the daily surface scroll when a tab switch returns to today', () => {
+    const { result } = routerHook()
+    act(() => result.current.saveScrollState(500)) // user scrolled the daily stream
+    act(() => result.current.navigate({ kind: 'note', path: 'notes/a.md' }))
+    act(() => result.current.navigate({ kind: 'today' }, { restoreSurfaceScroll: true }))
+
+    expect(result.current.route).toEqual({ kind: 'today' })
+    expect(result.current.savedScroll()).toBe(500)
+  })
+
+  it('keeps default fresh navigations to daily routes anchor-only', () => {
+    const { result } = routerHook()
+    act(() => result.current.saveScrollState(500))
+    act(() => result.current.navigate({ kind: 'note', path: 'notes/a.md' }))
+    act(() => result.current.navigate({ kind: 'today' }))
+
+    expect(result.current.savedScroll()).toBeNull()
+  })
+
   it('entryId is stable per entry and changes across back/forward', () => {
     const { result } = routerHook()
     const todayId = result.current.entryId

--- a/apps/desktop/src/routing/router.tsx
+++ b/apps/desktop/src/routing/router.tsx
@@ -33,7 +33,7 @@ interface RouterValue {
    * while already on today re-scrolls the stream to today).
    */
   arrivalSeq: number
-  navigate: (route: Route) => void
+  navigate: (route: Route, options?: NavigateOptions) => void
   back: () => void
   forward: () => void
   canBack: boolean
@@ -45,6 +45,16 @@ interface RouterValue {
 }
 
 const RouterContext = createContext<RouterValue | null>(null)
+
+export interface NavigateOptions {
+  /**
+   * Restore the last saved scroll position for this route's surface into the
+   * new history entry. Primary nav tabs use this so switching away and back
+   * does not reset long-lived list surfaces; ordinary command/navigation
+   * arrivals omit it and re-anchor as before.
+   */
+  restoreSurfaceScroll?: boolean
+}
 
 interface RouterProviderProps {
   /** The launch route; defaults to today (the daily note is the spine). */
@@ -63,6 +73,16 @@ interface HistoryState {
   index: number
 }
 
+function scrollSurfaceForRoute(route: Route): string | null {
+  switch (route.kind) {
+    case 'today':
+    case 'daily':
+      return 'daily'
+    default:
+      return null
+  }
+}
+
 export function RouterProvider({
   initialRoute = { kind: 'today' },
   children,
@@ -75,33 +95,57 @@ export function RouterProvider({
   const nextId = useRef(1)
   /** Scroll offsets by entry id — a ref so scroll reporting never re-renders. */
   const scrollById = useRef(new Map<number, number>())
+  /** Last scroll offset for long-lived route surfaces, independent of history. */
+  const scrollBySurface = useRef(new Map<string, number>())
   /** The active entry id, readable without depending on render order. */
   const currentId = useRef(0)
+  /** The active route, readable from scroll handlers without re-rendering. */
+  const currentRoute = useRef<Route>(history.stack[history.index]!.route)
   // Written during render, not in an effect: descendant scroll-restoration
   // effects read this id (through saveScrollState/savedScroll) on the same
   // commit, and React runs effects child-before-parent — so updating it in an
   // effect here would lag a frame and restore or save the wrong entry's offset.
   // eslint-disable-next-line react-hooks/refs
   currentId.current = history.stack[history.index]!.id
+  // eslint-disable-next-line react-hooks/refs
+  currentRoute.current = history.stack[history.index]!.route
 
-  const navigate = useCallback((route: Route) => {
+  const navigate = useCallback((route: Route, options?: NavigateOptions) => {
     const target = normalizeRoute(route)
     setHistory((current) => {
       const currentEntry = current.stack[current.index]!
       if (routesEqual(currentEntry.route, target)) {
-        // No stack growth — but this is still an explicit arrival: forget the
-        // entry's saved offset so the view re-anchors to its target instead of
-        // restoring the old scroll position.
-        scrollById.current.delete(currentEntry.id)
+        const surface = scrollSurfaceForRoute(target)
+        const restored =
+          options?.restoreSurfaceScroll === true && surface !== null
+            ? scrollBySurface.current.get(surface)
+            : undefined
+        if (restored !== undefined) {
+          scrollById.current.set(currentEntry.id, restored)
+        } else {
+          // No stack growth — but this is still an explicit arrival: forget the
+          // entry's saved offset so the view re-anchors to its target instead of
+          // restoring the old scroll position.
+          scrollById.current.delete(currentEntry.id)
+        }
         return current
       }
       const dropped = current.stack.slice(current.index + 1)
       for (const entry of dropped) {
         scrollById.current.delete(entry.id) // truncated branch — free its offsets
       }
+      const id = nextId.current++
+      const surface = scrollSurfaceForRoute(target)
+      const restored =
+        options?.restoreSurfaceScroll === true && surface !== null
+          ? scrollBySurface.current.get(surface)
+          : undefined
+      if (restored !== undefined) {
+        scrollById.current.set(id, restored)
+      }
       const stack = [
         ...current.stack.slice(0, current.index + 1),
-        { id: nextId.current++, route: target },
+        { id, route: target },
       ]
       return { stack, index: stack.length - 1 }
     })
@@ -144,6 +188,10 @@ export function RouterProvider({
 
   const saveScrollState = useCallback((offset: number) => {
     scrollById.current.set(currentId.current, offset)
+    const surface = scrollSurfaceForRoute(currentRoute.current)
+    if (surface !== null) {
+      scrollBySurface.current.set(surface, offset)
+    }
   }, [])
 
   const savedScroll = useCallback(


### PR DESCRIPTION
## Summary
- preserve the daily stream's last saved scroll offset when switching back through the Daily notes sidebar tab
- keep ordinary Go to Today navigation anchoring to today by default
- add router and sidebar regression coverage

## Tests
- CI=true pnpm --filter @reflect/desktop test -- apps/desktop/src/routing/router.test.tsx apps/desktop/src/components/sidebar/sidebar.test.tsx
- CI=true pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized routing and sidebar navigation behavior with regression tests; no auth, data, or security surface changes.
> 
> **Overview**
> Fixes the daily notes stream losing scroll when you leave and come back through the **Daily notes** sidebar tab.
> 
> The router now tracks a **surface-level** scroll offset for the shared `daily` surface (`today` / `daily` routes), alongside per-history-entry offsets. `navigate` accepts optional `{ restoreSurfaceScroll: true }` to copy that surface offset into the active entry; without it, behavior is unchanged (re-anchor on explicit arrivals like **Go to today** / `Mod-D`).
> 
> The **Daily notes** row calls `navigate({ kind: 'today' }, { restoreSurfaceScroll: true })` instead of `nav.today`, so tab clicks restore scroll while the `nav.today` command still jumps to today with anchor-only navigation. `CommandContext.navigate` is updated to pass through these options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3a1e40d2ca7b51aa5609961a2db09dea2fa8a65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily notes navigation now restores the previous scroll position when you return to it from the sidebar.
  * Keyboard navigation for Daily notes continues to work, with improved scroll behavior on return.

* **Bug Fixes**
  * Fixed Daily notes so clicking it no longer loses your place in the stream.
  * Updated navigation behavior to better preserve scroll state when switching between views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->