### PR TITLE
Integrate shadcn chat components

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -28,6 +28,7 @@
     "@reflect/db": "workspace:*",
     "@reflect/design-system": "workspace:*",
     "@reflect/utils": "workspace:*",
+    "@shadcn/react": "^0.1.0",
     "@tanstack/react-query": "^5.101.1",
     "@tanstack/react-virtual": "^3.14.3",
     "@tauri-apps/api": "^2.11.1",

--- a/apps/desktop/src/components/chat/chat-assistant-part.tsx
+++ b/apps/desktop/src/components/chat/chat-assistant-part.tsx
@@ -1,0 +1,61 @@
+import type { ReactElement } from 'react'
+import type { AssistantPart, ChatTurn } from '@reflect/core'
+import { Bubble, BubbleContent } from '@/components/ui/bubble'
+import { Marker, MarkerContent } from '@/components/ui/marker'
+import { MarkdownPreview } from '@/editor/markdown-preview'
+import { cn } from '@/lib/utils'
+import { ChatToolChip } from './chat-tool-chip'
+
+interface ChatAssistantPartProps {
+  index: number
+  lastIndex: number
+  part: AssistantPart
+  status: ChatTurn['status']
+  onWikiLinkClick: (target: string) => void
+}
+
+/**
+ * One assistant transcript part: streaming text, settled markdown, tool
+ * activity, or a terminal notice.
+ */
+export function ChatAssistantPart({
+  index,
+  lastIndex,
+  part,
+  status,
+  onWikiLinkClick,
+}: ChatAssistantPartProps): ReactElement {
+  switch (part.kind) {
+    case 'text':
+      return status === 'streaming' && index === lastIndex ? (
+        <Bubble variant="ghost" className="max-w-full">
+          <BubbleContent className="reflect-chat-message max-w-full text-text">
+            <div className="whitespace-pre-wrap">{part.text}</div>
+          </BubbleContent>
+        </Bubble>
+      ) : (
+        <Bubble variant="ghost" className="max-w-full">
+          <BubbleContent className="max-w-full text-text">
+            <MarkdownPreview
+              content={part.text}
+              onWikiLinkClick={onWikiLinkClick}
+              className="reflect-chat-message text-sm"
+            />
+          </BubbleContent>
+        </Bubble>
+      )
+    case 'tool':
+      return <ChatToolChip part={part} />
+    case 'notice':
+      return (
+        <Marker
+          className={cn(
+            'reflect-chat-message text-sm',
+            part.tone === 'error' ? 'text-destructive' : 'text-text-muted italic',
+          )}
+        >
+          <MarkerContent>{part.text}</MarkerContent>
+        </Marker>
+      )
+  }
+}

--- a/apps/desktop/src/components/chat/chat-input.tsx
+++ b/apps/desktop/src/components/chat/chat-input.tsx
@@ -2,6 +2,13 @@ import { useMemo, useState, type ReactElement } from 'react'
 import { aiProvider, type AiProviderConfig, type ChatModelOption } from '@reflect/core'
 import { ArrowUp, Plus, Square, X } from 'lucide-react'
 import { ShortcutKeys } from '@/components/shortcut-keys'
+import {
+  Attachment,
+  AttachmentAction,
+  AttachmentActions,
+  AttachmentGroup,
+  AttachmentMedia,
+} from '@/components/ui/attachment'
 import { Button } from '@/components/ui/button'
 import {
   Select,
@@ -109,25 +116,29 @@ export function ChatInput(): ReactElement {
     <div className="flex-none px-6 pb-6">
       <div className="mx-auto w-full max-w-2xl rounded-xl border border-border bg-surface focus-within:border-ring">
         {attachments.length > 0 ? (
-          <div className="flex flex-wrap gap-2 px-3.5 pt-3">
+          <AttachmentGroup className="flex-wrap gap-2 overflow-visible px-3.5 pt-3 pb-0">
             {attachments.map((attachment) => (
-              <div key={attachment.id} className="relative">
-                <img
-                  src={attachment.dataUrl}
-                  alt={attachment.name}
-                  className="size-14 rounded-lg border border-border object-cover"
-                />
-                <button
-                  type="button"
-                  aria-label={`Remove ${attachment.name}`}
-                  onClick={() => removeAttachment(attachment.id)}
-                  className="absolute -top-1.5 -right-1.5 flex size-4 items-center justify-center rounded-full border border-border bg-surface text-text-muted hover:text-text"
-                >
-                  <X aria-hidden className="size-3" />
-                </button>
-              </div>
+              <Attachment
+                key={attachment.id}
+                orientation="vertical"
+                size="sm"
+                className="w-16 bg-surface"
+              >
+                <AttachmentMedia variant="image" className="w-14">
+                  <img src={attachment.dataUrl} alt={attachment.name} />
+                </AttachmentMedia>
+                <AttachmentActions className="!top-0 !right-0 -translate-y-1/2 translate-x-1/2">
+                  <AttachmentAction
+                    aria-label={`Remove ${attachment.name}`}
+                    className="size-4 rounded-full border border-border bg-surface p-0 text-text-muted hover:text-text"
+                    onClick={() => removeAttachment(attachment.id)}
+                  >
+                    <X aria-hidden className="size-3" />
+                  </AttachmentAction>
+                </AttachmentActions>
+              </Attachment>
             ))}
-          </div>
+          </AttachmentGroup>
         ) : null}
         <textarea
           value={text}

--- a/apps/desktop/src/components/chat/chat-screen.test.tsx
+++ b/apps/desktop/src/components/chat/chat-screen.test.tsx
@@ -111,6 +111,9 @@ vi.mock('@/lib/provider-fetch', () => ({ providerFetch: vi.fn() }))
 // jsdom doesn't implement this; Radix Select scrolls the selected option into
 // view when the listbox opens.
 Element.prototype.scrollIntoView ??= () => {}
+// shadcn's MessageScroller drives the viewport with scrollTo; jsdom has no
+// layout engine, so the browser API is stubbed for interaction tests.
+Element.prototype.scrollTo ??= () => {}
 
 const { ChatScreen } = await import('./chat-screen')
 

--- a/apps/desktop/src/components/chat/chat-tool-chip.tsx
+++ b/apps/desktop/src/components/chat/chat-tool-chip.tsx
@@ -1,9 +1,10 @@
 import { Fragment, type ReactElement, type ReactNode } from 'react'
 import { CalendarDays, FileText, History, Search } from 'lucide-react'
 import { isTagName, isToolPending, type AssistantPart, type NoteHitSummary } from '@reflect/core'
+import { Marker, MarkerContent, MarkerIcon } from '@/components/ui/marker'
+import { Spinner } from '@/components/ui/spinner'
 import { routeForPath } from '@/routing/route'
 import { useRouter } from '@/routing/router'
-import { Spinner } from '@/components/ui/spinner'
 
 interface ChatToolChipProps {
   part: Extract<AssistantPart, { kind: 'tool' }>
@@ -20,13 +21,13 @@ interface ChipFrameProps {
   children: ReactNode
 }
 
-/** The shared chip shell: a spinner while pending, the tool's icon after. */
+/** The shared marker shell: a spinner while pending, the tool's icon after. */
 function ChipFrame({ pending, icon, children }: ChipFrameProps): ReactElement {
   return (
-    <span className="flex items-center gap-1.5 text-xs text-text-muted">
-      {pending ? <Spinner /> : icon}
-      {children}
-    </span>
+    <Marker className="text-xs text-text-muted">
+      <MarkerIcon>{pending ? <Spinner /> : icon}</MarkerIcon>
+      <MarkerContent className="truncate">{children}</MarkerContent>
+    </Marker>
   )
 }
 
@@ -76,11 +77,9 @@ export function ChatToolChip({ part }: ChatToolChipProps): ReactElement {
     const result = part.result?.tool === 'search' ? part.result : null
     return (
       <ChipFrame pending={pending} icon={<Search aria-hidden className="size-3.5" />}>
-        <span className="truncate">
-          Searched “{call.query}”
-          {result !== null ? countSuffix(result.hits.length, 'note') : ''}
-          {result !== null ? <NoteLinks notes={result.hits} onOpen={openNote} /> : null}
-        </span>
+        Searched “{call.query}”
+        {result !== null ? countSuffix(result.hits.length, 'note') : ''}
+        {result !== null ? <NoteLinks notes={result.hits} onOpen={openNote} /> : null}
       </ChipFrame>
     )
   }
@@ -101,17 +100,15 @@ export function ChatToolChip({ part }: ChatToolChipProps): ReactElement {
       )
     return (
       <ChipFrame pending={pending} icon={<History aria-hidden className="size-3.5" />}>
-        <span className="truncate">
-          Listed {tagLabel} notes
-          {result !== null
-            ? result.error !== null
-              ? ` — ${result.error}`
-              : countSuffix(result.notes.length, 'note')
-            : ''}
-          {result !== null && result.error === null ? (
-            <NoteLinks notes={result.notes} onOpen={openNote} />
-          ) : null}
-        </span>
+        Listed {tagLabel} notes
+        {result !== null
+          ? result.error !== null
+            ? ` — ${result.error}`
+            : countSuffix(result.notes.length, 'note')
+          : ''}
+        {result !== null && result.error === null ? (
+          <NoteLinks notes={result.notes} onOpen={openNote} />
+        ) : null}
       </ChipFrame>
     )
   }
@@ -120,11 +117,9 @@ export function ChatToolChip({ part }: ChatToolChipProps): ReactElement {
     const result = part.result?.tool === 'dailies' ? part.result : null
     return (
       <ChipFrame pending={pending} icon={<CalendarDays aria-hidden className="size-3.5" />}>
-        <span className="truncate">
-          Listed daily notes {call.start} – {call.end}
-          {result !== null ? countSuffix(result.days.length, 'day') : ''}
-          {result !== null ? <NoteLinks notes={result.days} onOpen={openNote} /> : null}
-        </span>
+        Listed daily notes {call.start} – {call.end}
+        {result !== null ? countSuffix(result.days.length, 'day') : ''}
+        {result !== null ? <NoteLinks notes={result.days} onOpen={openNote} /> : null}
       </ChipFrame>
     )
   }
@@ -135,9 +130,7 @@ export function ChatToolChip({ part }: ChatToolChipProps): ReactElement {
   if (part.error !== null) {
     return (
       <ChipFrame pending={false} icon={<FileText aria-hidden className="size-3.5" />}>
-        <span className="truncate">
-          {call.paths.join(', ')} — {part.error}
-        </span>
+        {call.paths.join(', ')} — {part.error}
       </ChipFrame>
     )
   }
@@ -145,31 +138,29 @@ export function ChatToolChip({ part }: ChatToolChipProps): ReactElement {
   const notes = result?.notes ?? call.paths.map((path) => ({ path, title: null, error: null }))
   return (
     <ChipFrame pending={pending} icon={<FileText aria-hidden className="size-3.5" />}>
-      <span className="truncate">
-        Read{' '}
-        {notes.map((note, index) => {
-          const label = note.title ?? note.path
-          return (
-            <Fragment key={`${note.path}-${index}`}>
-              {index > 0 ? ', ' : ''}
-              {!pending && note.error === null ? (
-                <button
-                  type="button"
-                  onClick={() => openNote(note.path)}
-                  className="underline-offset-2 hover:text-text hover:underline"
-                >
-                  {label}
-                </button>
-              ) : (
-                <span>
-                  {label}
-                  {note.error !== null ? ` — ${note.error}` : ''}
-                </span>
-              )}
-            </Fragment>
-          )
-        })}
-      </span>
+      Read{' '}
+      {notes.map((note, index) => {
+        const label = note.title ?? note.path
+        return (
+          <Fragment key={`${note.path}-${index}`}>
+            {index > 0 ? ', ' : ''}
+            {!pending && note.error === null ? (
+              <button
+                type="button"
+                onClick={() => openNote(note.path)}
+                className="underline-offset-2 hover:text-text hover:underline"
+              >
+                {label}
+              </button>
+            ) : (
+              <span>
+                {label}
+                {note.error !== null ? ` — ${note.error}` : ''}
+              </span>
+            )}
+          </Fragment>
+        )
+      })}
     </ChipFrame>
   )
 }

--- a/apps/desktop/src/components/chat/chat-turn-list.tsx
+++ b/apps/desktop/src/components/chat/chat-turn-list.tsx
@@ -1,42 +1,40 @@
-import { useEffect, useRef, type ReactElement } from 'react'
+import type { ReactElement } from 'react'
+import {
+  MessageScroller,
+  MessageScrollerButton,
+  MessageScrollerContent,
+  MessageScrollerItem,
+  MessageScrollerProvider,
+  MessageScrollerViewport,
+} from '@/components/ui/message-scroller'
 import { useChatSession } from '@/providers/chat-provider'
 import { ChatTurn } from './chat-turn'
 
 /**
- * The conversation column: a centered, scrolling list of turns that follows
- * the stream. Auto-scroll is polite — it only sticks to the bottom while the
- * user is already there, so scrolling up to reread is never fought.
+ * The conversation column: a centered list of turns inside shadcn's chat
+ * scroller, which owns scroll anchoring while a response streams.
  */
 export function ChatTurnList(): ReactElement {
   const { turns } = useChatSession()
-  const scrollRef = useRef<HTMLDivElement | null>(null)
-  const pinnedRef = useRef(true)
-
-  useEffect(() => {
-    const container = scrollRef.current
-    if (container && pinnedRef.current) {
-      container.scrollTop = container.scrollHeight
-    }
-  }, [turns])
 
   return (
-    <div
-      ref={scrollRef}
-      onScroll={(event) => {
-        const target = event.currentTarget
-        pinnedRef.current = target.scrollHeight - target.scrollTop - target.clientHeight < 48
-      }}
-      className="min-h-0 flex-1 overflow-y-auto px-6"
-    >
-      {turns.length > 0 && (
-        <div className="mx-auto w-full max-w-2xl py-8">
-          <div className="flex flex-col gap-6">
-            {turns.map((turn) => (
-              <ChatTurn key={turn.id} turn={turn} />
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
+    <MessageScrollerProvider autoScroll defaultScrollPosition="end">
+      <MessageScroller className="min-h-0 flex-1">
+        <MessageScrollerViewport className="px-6" aria-label="Chat conversation">
+          {turns.length > 0 ? (
+            <div className="mx-auto w-full max-w-2xl">
+              <MessageScrollerContent className="gap-6 py-8">
+                {turns.map((turn) => (
+                  <MessageScrollerItem key={turn.id} messageId={turn.id} scrollAnchor>
+                    <ChatTurn turn={turn} />
+                  </MessageScrollerItem>
+                ))}
+              </MessageScrollerContent>
+            </div>
+          ) : null}
+        </MessageScrollerViewport>
+        <MessageScrollerButton className="bottom-5" />
+      </MessageScroller>
+    </MessageScrollerProvider>
   )
 }

--- a/apps/desktop/src/components/chat/chat-turn.tsx
+++ b/apps/desktop/src/components/chat/chat-turn.tsx
@@ -1,19 +1,20 @@
 import type { ReactElement } from 'react'
-import { MarkdownPreview } from '@/editor/markdown-preview'
-import { useWikiLinkNavigation } from '@/editor/use-wiki-link-navigation'
 import type { ChatTurn as ChatTurnModel } from '@reflect/core'
-import { cn } from '@/lib/utils'
-import { ChatToolChip } from './chat-tool-chip'
+import { Bubble, BubbleContent } from '@/components/ui/bubble'
+import { Marker, MarkerContent } from '@/components/ui/marker'
+import { Message, MessageContent, MessageGroup } from '@/components/ui/message'
+import { useWikiLinkNavigation } from '@/editor/use-wiki-link-navigation'
+import { ChatAssistantPart } from './chat-assistant-part'
+import { ChatUserAttachments } from './chat-user-attachments'
 
 interface ChatTurnProps {
   turn: ChatTurnModel
 }
 
 /**
- * One conversation turn: the user's message as a compact right-aligned
- * bubble — attached images above the text, which a photo-only message
- * omits — then the assistant's parts in order: text interleaved with the
- * tool activity that grounded it.
+ * One conversation turn: the user's message and images render through
+ * shadcn chat primitives, followed by assistant text, tool markers, and
+ * notices in the order the engine produced them.
  *
  * Text still streaming renders as plain text; once it settles it re-renders
  * through the same read-only markdown preview the palette uses (so
@@ -29,64 +30,39 @@ export function ChatTurn({ turn }: ChatTurnProps): ReactElement {
   const lastIndex = turn.parts.length - 1
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="flex justify-end">
-        <div className="flex max-w-[85%] flex-col items-end gap-2">
-          {turn.attachments.map((attachment) => (
-            <img
-              key={attachment.id}
-              src={attachment.dataUrl}
-              alt={attachment.name}
-              className="max-h-48 max-w-full rounded-2xl"
+    <MessageGroup className="gap-6">
+      <Message align="end">
+        <MessageContent className="items-end gap-2">
+          <ChatUserAttachments attachments={turn.attachments} />
+          {turn.userText !== '' ? (
+            <Bubble align="end" variant="muted" className="max-w-[85%]">
+              <BubbleContent className="reflect-chat-message !bg-surface-hover px-4 py-2 leading-normal whitespace-pre-wrap !text-text">
+                {turn.userText}
+              </BubbleContent>
+            </Bubble>
+          ) : null}
+        </MessageContent>
+      </Message>
+
+      <Message align="start">
+        <MessageContent className="gap-2">
+          {turn.parts.length === 0 && turn.status === 'streaming' ? (
+            <Marker className="animate-pulse text-sm text-text-muted">
+              <MarkerContent>Thinking…</MarkerContent>
+            </Marker>
+          ) : null}
+          {turn.parts.map((part, index) => (
+            <ChatAssistantPart
+              key={index}
+              index={index}
+              lastIndex={lastIndex}
+              part={part}
+              status={turn.status}
+              onWikiLinkClick={navigateWikiLink}
             />
           ))}
-          {turn.userText !== '' ? (
-            <div className="reflect-chat-message rounded-2xl bg-surface-hover px-4 py-2 text-sm whitespace-pre-wrap text-text">
-              {turn.userText}
-            </div>
-          ) : null}
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-2">
-        {turn.parts.length === 0 && turn.status === 'streaming' ? (
-          <span className="animate-pulse text-sm text-text-muted">Thinking…</span>
-        ) : null}
-        {turn.parts.map((part, index) => {
-          switch (part.kind) {
-            case 'text':
-              return turn.status === 'streaming' && index === lastIndex ? (
-                <div
-                  key={index}
-                  className="reflect-chat-message text-sm whitespace-pre-wrap text-text"
-                >
-                  {part.text}
-                </div>
-              ) : (
-                <MarkdownPreview
-                  key={index}
-                  content={part.text}
-                  onWikiLinkClick={navigateWikiLink}
-                  className="reflect-chat-message text-sm"
-                />
-              )
-            case 'tool':
-              return <ChatToolChip key={index} part={part} />
-            case 'notice':
-              return (
-                <p
-                  key={index}
-                  className={cn(
-                    'reflect-chat-message text-sm',
-                    part.tone === 'error' ? 'text-destructive' : 'text-text-muted italic',
-                  )}
-                >
-                  {part.text}
-                </p>
-              )
-          }
-        })}
-      </div>
-    </div>
+        </MessageContent>
+      </Message>
+    </MessageGroup>
   )
 }

--- a/apps/desktop/src/components/chat/chat-user-attachments.tsx
+++ b/apps/desktop/src/components/chat/chat-user-attachments.tsx
@@ -1,0 +1,43 @@
+import type { ReactElement } from 'react'
+import type { ChatAttachment } from '@reflect/core'
+import {
+  Attachment,
+  AttachmentGroup,
+  AttachmentMedia,
+} from '@/components/ui/attachment'
+
+interface ChatUserAttachmentsProps {
+  attachments: readonly ChatAttachment[]
+}
+
+/**
+ * Image attachments shown above a user's chat bubble after the turn is sent.
+ */
+export function ChatUserAttachments({
+  attachments,
+}: ChatUserAttachmentsProps): ReactElement | null {
+  if (attachments.length === 0) {
+    return null
+  }
+
+  return (
+    <AttachmentGroup className="justify-end gap-2 overflow-visible py-0">
+      {attachments.map((attachment) => (
+        <Attachment
+          key={attachment.id}
+          className="min-w-0 border-none bg-transparent p-0"
+          orientation="horizontal"
+          size="default"
+        >
+          <AttachmentMedia className="aspect-auto h-auto max-h-48 w-auto max-w-full rounded-xl bg-transparent">
+            <img
+              src={attachment.dataUrl}
+              alt={attachment.name}
+              className="max-h-48 max-w-full rounded-xl object-contain"
+            />
+          </AttachmentMedia>
+        </Attachment>
+      ))}
+    </AttachmentGroup>
+  )
+}

--- a/apps/desktop/src/components/ui/attachment.tsx
+++ b/apps/desktop/src/components/ui/attachment.tsx
@@ -1,0 +1,206 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+const attachmentVariants = cva(
+  "group/attachment relative flex w-fit max-w-full min-w-0 shrink-0 flex-wrap rounded-xl border bg-card text-card-foreground transition-colors focus-within:ring-1 focus-within:ring-ring/50 has-[>a,>button]:hover:bg-muted/50 data-[state=error]:border-destructive/30 data-[state=idle]:border-dashed",
+  {
+    variants: {
+      size: {
+        default:
+          "gap-2 text-sm has-data-[slot=attachment-content]:px-2.5 has-data-[slot=attachment-content]:py-2 has-data-[slot=attachment-media]:p-2",
+        sm: "gap-2.5 text-xs has-data-[slot=attachment-content]:px-2 has-data-[slot=attachment-content]:py-1.5 has-data-[slot=attachment-media]:p-1.5",
+        xs: "gap-1.5 rounded-lg text-xs has-data-[slot=attachment-content]:px-1.5 has-data-[slot=attachment-content]:py-1 has-data-[slot=attachment-media]:p-1",
+      },
+      orientation: {
+        horizontal: "min-w-40 items-center",
+        vertical: "w-24 flex-col has-data-[slot=attachment-content]:w-30",
+      },
+    },
+  }
+)
+
+function Attachment({
+  className,
+  state = "done",
+  size = "default",
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<"div"> &
+  VariantProps<typeof attachmentVariants> & {
+    state?: "idle" | "uploading" | "processing" | "error" | "done"
+  }) {
+  const resolvedOrientation = orientation ?? "horizontal"
+
+  return (
+    <div
+      data-slot="attachment"
+      data-state={state}
+      data-size={size}
+      data-orientation={resolvedOrientation}
+      className={cn(attachmentVariants({ size, orientation }), className)}
+      {...props}
+    />
+  )
+}
+
+const attachmentMediaVariants = cva(
+  "relative flex aspect-square w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-muted text-foreground group-data-[orientation=vertical]/attachment:w-full group-data-[size=sm]/attachment:w-8 group-data-[size=xs]/attachment:w-7 group-data-[size=xs]/attachment:rounded-md group-data-[state=error]/attachment:bg-destructive/10 group-data-[state=error]/attachment:text-destructive group-data-[orientation=vertical]/attachment:*:data-[slot=spinner]:size-6! [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 group-data-[orientation=vertical]/attachment:[&_svg:not([class*='size-'])]:size-6 group-data-[size=xs]/attachment:[&_svg:not([class*='size-'])]:size-3.5",
+  {
+    variants: {
+      variant: {
+        icon: "",
+        image:
+          "opacity-60 group-data-[state=done]/attachment:opacity-100 group-data-[state=idle]/attachment:opacity-100 *:[img]:aspect-square *:[img]:w-full *:[img]:object-cover",
+      },
+    },
+    defaultVariants: {
+      variant: "icon",
+    },
+  }
+)
+
+function AttachmentMedia({
+  className,
+  variant = "icon",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof attachmentMediaVariants>) {
+  return (
+    <div
+      data-slot="attachment-media"
+      data-variant={variant}
+      className={cn(attachmentMediaVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AttachmentContent({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="attachment-content"
+      className={cn(
+        "max-w-full min-w-0 flex-1 leading-tight group-data-[orientation=vertical]/attachment:px-1",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AttachmentTitle({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="attachment-title"
+      className={cn(
+        "block max-w-full min-w-0 truncate font-medium group-data-[state=processing]/attachment:shimmer group-data-[state=uploading]/attachment:shimmer",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AttachmentDescription({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="attachment-description"
+      className={cn(
+        "mt-0.5 block min-w-0 truncate text-xs text-muted-foreground group-data-[state=error]/attachment:text-destructive/80",
+        "max-w-full",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AttachmentActions({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="attachment-actions"
+      className={cn(
+        "relative z-20 flex shrink-0 items-center group-data-[orientation=vertical]/attachment:absolute group-data-[orientation=vertical]/attachment:top-3 group-data-[orientation=vertical]/attachment:right-3 group-data-[orientation=vertical]/attachment:gap-1",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AttachmentAction({
+  className,
+  variant,
+  size = "icon-xs",
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  return (
+    <Button
+      data-slot="attachment-action"
+      variant={variant ?? "ghost"}
+      size={size}
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function AttachmentTrigger({
+  className,
+  asChild = false,
+  type,
+  ...props
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean
+}) {
+  const Comp = asChild ? Slot.Root : "button"
+
+  return (
+    <Comp
+      data-slot="attachment-trigger"
+      type={asChild ? undefined : (type ?? "button")}
+      className={cn("absolute inset-0 z-10 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+function AttachmentGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="attachment-group"
+      className={cn(
+        "flex min-w-0 scroll-fade-x snap-x snap-mandatory scroll-px-1 scrollbar-none gap-3 overflow-x-auto overscroll-x-contain py-1 *:data-[slot=attachment]:flex-none *:data-[slot=attachment]:snap-start",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Attachment,
+  AttachmentGroup,
+  AttachmentMedia,
+  AttachmentContent,
+  AttachmentTitle,
+  AttachmentDescription,
+  AttachmentActions,
+  AttachmentAction,
+  AttachmentTrigger,
+}

--- a/apps/desktop/src/components/ui/bubble.tsx
+++ b/apps/desktop/src/components/ui/bubble.tsx
@@ -1,0 +1,125 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function BubbleGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="bubble-group"
+      className={cn("flex min-w-0 flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+const bubbleVariants = cva(
+  "group/bubble relative flex w-fit max-w-[80%] min-w-0 flex-col gap-1 group-data-[align=end]/message:self-end data-[align=end]:self-end data-[variant=ghost]:max-w-full",
+  {
+    variants: {
+      variant: {
+        default:
+          "*:data-[slot=bubble-content]:bg-primary *:data-[slot=bubble-content]:text-primary-foreground [&>[data-slot=bubble-content]:is(button,a):hover]:bg-primary/80",
+        secondary:
+          "*:data-[slot=bubble-content]:bg-secondary *:data-[slot=bubble-content]:text-secondary-foreground [&>[data-slot=bubble-content]:is(button,a):hover]:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)]",
+        muted:
+          "*:data-[slot=bubble-content]:bg-muted [&>[data-slot=bubble-content]:is(button,a):hover]:bg-[color-mix(in_oklch,var(--muted),var(--foreground)_5%)]",
+        tinted:
+          "*:data-[slot=bubble-content]:bg-[oklch(from_var(--primary)_0.93_calc(c*0.4)_h)] *:data-[slot=bubble-content]:text-foreground dark:*:data-[slot=bubble-content]:bg-[oklch(from_var(--primary)_0.3_calc(c*0.4)_h)] [&>[data-slot=bubble-content]:is(button,a):hover]:bg-[oklch(from_var(--primary)_0.88_calc(c*0.5)_h)] dark:[&>[data-slot=bubble-content]:is(button,a):hover]:bg-[oklch(from_var(--primary)_0.35_calc(c*0.5)_h)]",
+        outline:
+          "*:data-[slot=bubble-content]:border-border *:data-[slot=bubble-content]:bg-background [&>[data-slot=bubble-content]:is(button,a):hover]:bg-muted [&>[data-slot=bubble-content]:is(button,a):hover]:text-foreground dark:[&>[data-slot=bubble-content]:is(button,a):hover]:bg-input/30",
+        ghost:
+          "border-none *:data-[slot=bubble-content]:rounded-none *:data-[slot=bubble-content]:bg-transparent *:data-[slot=bubble-content]:p-0 [&>[data-slot=bubble-content]:is(button,a):hover]:bg-muted [&>[data-slot=bubble-content]:is(button,a):hover]:text-foreground dark:[&>[data-slot=bubble-content]:is(button,a):hover]:bg-muted/50",
+        destructive:
+          "*:data-[slot=bubble-content]:bg-destructive/10 *:data-[slot=bubble-content]:text-destructive dark:*:data-[slot=bubble-content]:bg-destructive/20 [&>[data-slot=bubble-content]:is(button,a):hover]:bg-destructive/20 dark:[&>[data-slot=bubble-content]:is(button,a):hover]:bg-destructive/30",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Bubble({
+  variant = "default",
+  align = "start",
+  className,
+  ...props
+}: React.ComponentProps<"div"> &
+  VariantProps<typeof bubbleVariants> & {
+    align?: "start" | "end"
+  }) {
+  return (
+    <div
+      data-slot="bubble"
+      data-variant={variant}
+      data-align={align}
+      className={cn(bubbleVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function BubbleContent({
+  asChild = false,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  asChild?: boolean
+}) {
+  const Comp = asChild ? Slot.Root : "div"
+
+  return (
+    <Comp
+      data-slot="bubble-content"
+      className={cn(
+        "w-fit max-w-full min-w-0 overflow-hidden rounded-xl border border-transparent px-3 py-2 text-sm leading-relaxed wrap-break-word group-data-[align=end]/bubble:self-end [button]:text-left [button,a]:transition-colors [button,a]:outline-none [button,a]:focus-visible:border-ring [button,a]:focus-visible:ring-3 [button,a]:focus-visible:ring-ring/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const bubbleReactionsVariants = cva(
+  "absolute z-10 flex w-fit shrink-0 items-center justify-center gap-1 rounded-full bg-muted px-1.5 py-0.5 text-sm ring-3 ring-card has-[button]:p-0",
+  {
+    variants: {
+      side: {
+        top: "top-0 -translate-y-3/4",
+        bottom: "bottom-0 translate-y-3/4",
+      },
+      align: {
+        start: "left-3",
+        end: "right-3",
+      },
+    },
+    defaultVariants: {
+      side: "bottom",
+      align: "end",
+    },
+  }
+)
+
+function BubbleReactions({
+  side = "bottom",
+  align = "end",
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  align?: "start" | "end"
+  side?: "top" | "bottom"
+}) {
+  return (
+    <div
+      data-slot="bubble-reactions"
+      data-align={align}
+      data-side={side}
+      className={cn(bubbleReactionsVariants({ side, align }), className)}
+      {...props}
+    />
+  )
+}
+
+export { BubbleGroup, Bubble, BubbleContent, BubbleReactions }

--- a/apps/desktop/src/components/ui/marker.tsx
+++ b/apps/desktop/src/components/ui/marker.tsx
@@ -1,0 +1,69 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const markerVariants = cva(
+  "group/marker relative flex min-h-4 w-full items-center gap-2 text-left text-sm text-muted-foreground [&_svg:not([class*='size-'])]:size-4 [a]:underline [a]:underline-offset-3 [a]:hover:text-foreground",
+  {
+    variants: {
+      variant: {
+        default: "",
+        separator:
+          "before:mr-1 before:h-px before:min-w-0 before:flex-1 before:bg-border after:ml-1 after:h-px after:min-w-0 after:flex-1 after:bg-border",
+        border: "border-b border-border pb-2",
+      },
+    },
+  }
+)
+
+function Marker({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> &
+  VariantProps<typeof markerVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot.Root : "div"
+
+  return (
+    <Comp
+      data-slot="marker"
+      data-variant={variant}
+      className={cn(markerVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+function MarkerIcon({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="marker-icon"
+      aria-hidden="true"
+      className={cn(
+        "size-4 shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MarkerContent({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="marker-content"
+      className={cn(
+        "min-w-0 wrap-break-word group-data-[variant=separator]/marker:flex-none group-data-[variant=separator]/marker:text-center *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Marker, MarkerIcon, MarkerContent, markerVariants }

--- a/apps/desktop/src/components/ui/message-scroller.tsx
+++ b/apps/desktop/src/components/ui/message-scroller.tsx
@@ -1,0 +1,129 @@
+import * as React from "react"
+import {
+  MessageScroller as MessageScrollerPrimitive,
+  useMessageScroller,
+  useMessageScrollerScrollable,
+  useMessageScrollerVisibility,
+} from "@shadcn/react/message-scroller"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { ArrowDownIcon } from "lucide-react"
+
+function MessageScrollerProvider(
+  props: React.ComponentProps<typeof MessageScrollerPrimitive.Provider>
+) {
+  return <MessageScrollerPrimitive.Provider {...props} />
+}
+
+function MessageScroller({
+  className,
+  ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Root>) {
+  return (
+    <MessageScrollerPrimitive.Root
+      data-slot="message-scroller"
+      className={cn(
+        "group/message-scroller relative flex size-full min-h-0 flex-col overflow-hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageScrollerViewport({
+  className,
+  ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Viewport>) {
+  return (
+    <MessageScrollerPrimitive.Viewport
+      data-slot="message-scroller-viewport"
+      className={cn(
+        "size-full min-h-0 min-w-0 scroll-fade-b scrollbar-thin scrollbar-gutter-stable overflow-y-auto overscroll-contain contain-content data-autoscrolling:scrollbar-none",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageScrollerContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Content>) {
+  return (
+    <MessageScrollerPrimitive.Content
+      data-slot="message-scroller-content"
+      className={cn("flex h-max min-h-full flex-col gap-6", className)}
+      {...props}
+    />
+  )
+}
+
+function MessageScrollerItem({
+  className,
+  scrollAnchor = false,
+  ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Item>) {
+  return (
+    <MessageScrollerPrimitive.Item
+      data-slot="message-scroller-item"
+      scrollAnchor={scrollAnchor}
+      className={cn(
+        "min-w-0 shrink-0 [contain-intrinsic-size:auto_10rem] [content-visibility:auto]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageScrollerButton({
+  direction = "end",
+  className,
+  children,
+  render,
+  variant = "secondary",
+  size = "icon-sm",
+  ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Button> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <MessageScrollerPrimitive.Button
+      data-slot="message-scroller-button"
+      data-direction={direction}
+      data-variant={variant}
+      data-size={size}
+      direction={direction}
+      className={cn(
+        "absolute inset-s-1/2 -translate-x-1/2 border-border bg-background text-foreground transition-[translate,scale,opacity] duration-200 hover:bg-muted hover:text-foreground data-[active=false]:pointer-events-none data-[active=false]:scale-95 data-[active=false]:opacity-0 data-[active=false]:duration-400 data-[active=false]:ease-[cubic-bezier(0.7,0,0.84,0)] data-[active=true]:translate-y-0 data-[active=true]:scale-100 data-[active=true]:opacity-100 data-[active=true]:ease-[cubic-bezier(0.23,1,0.32,1)] data-[direction=end]:bottom-4 data-[direction=end]:data-[active=false]:translate-y-full data-[direction=start]:top-4 data-[direction=start]:data-[active=false]:-translate-y-full rtl:translate-x-1/2 data-[direction=start]:[&_svg]:rotate-180",
+        className
+      )}
+      render={render ?? <Button variant={variant} size={size} />}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <ArrowDownIcon
+          />
+          <span className="sr-only">
+            {direction === "end" ? "Scroll to end" : "Scroll to start"}
+          </span>
+        </>
+      )}
+    </MessageScrollerPrimitive.Button>
+  )
+}
+
+export {
+  MessageScrollerProvider,
+  MessageScroller,
+  MessageScrollerViewport,
+  MessageScrollerContent,
+  MessageScrollerItem,
+  MessageScrollerButton,
+  useMessageScroller,
+  useMessageScrollerScrollable,
+  useMessageScrollerVisibility,
+}

--- a/apps/desktop/src/components/ui/message.tsx
+++ b/apps/desktop/src/components/ui/message.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function MessageGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="message-group"
+      className={cn("flex min-w-0 flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function Message({
+  className,
+  align = "start",
+  ...props
+}: React.ComponentProps<"div"> & { align?: "start" | "end" }) {
+  return (
+    <div
+      data-slot="message"
+      data-align={align}
+      className={cn(
+        "group/message relative flex w-full min-w-0 gap-2 text-sm data-[align=end]:flex-row-reverse",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageAvatar({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="message-avatar"
+      className={cn(
+        "flex w-fit min-w-8 shrink-0 items-center justify-center self-end overflow-hidden rounded-full bg-muted group-has-data-[slot=message-footer]/message:-translate-y-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="message-content"
+      className={cn(
+        "flex w-full min-w-0 flex-col gap-2.5 wrap-break-word group-data-[align=end]/message:*:data-slot:self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="message-header"
+      className={cn(
+        "flex max-w-full min-w-0 items-center px-3 text-xs font-medium text-muted-foreground group-has-data-[variant=ghost]/message:px-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="message-footer"
+      className={cn(
+        "flex max-w-full min-w-0 items-center px-3 text-xs font-medium text-muted-foreground group-has-data-[variant=ghost]/message:px-0 group-data-[align=end]/message:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  MessageGroup,
+  Message,
+  MessageAvatar,
+  MessageContent,
+  MessageFooter,
+  MessageHeader,
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@reflect/utils':
         specifier: workspace:*
         version: link:../../packages/utils
+      '@shadcn/react':
+        specifier: ^0.1.0
+        version: 0.1.0(@types/react@19.2.17)(react@19.2.7)
       '@tanstack/react-query':
         specifier: ^5.101.1
         version: 5.101.1(react@19.2.7)
@@ -2220,6 +2223,17 @@ packages:
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@shadcn/react@0.1.0':
+    resolution: {integrity: sha512-6i67TEnqValsZY7e4exJ4rkHo2OdHXmDH152YulwSpuEUnTQYumHkXzFsaje7HB7GbMTWuI9x1Jn6sSduCYdeA==}
+    peerDependencies:
+      '@types/react': '>=19'
+      react: '>=19'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
 
   '@shikijs/core@4.2.0':
     resolution: {integrity: sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==}
@@ -8175,6 +8189,11 @@ snapshots:
     optional: true
 
   '@sec-ant/readable-stream@0.4.1': {}
+
+  '@shadcn/react@0.1.0(@types/react@19.2.17)(react@19.2.7)':
+    optionalDependencies:
+      '@types/react': 19.2.17
+      react: 19.2.7
 
   '@shikijs/core@4.2.0':
     dependencies:


### PR DESCRIPTION
## Summary
- add shadcn's new chat primitives and @shadcn/react
- replace custom chat scrolling, message rows, bubbles, tool markers, and attachment previews with shadcn components
- keep chat provider, persistence, AI request flow, model picker, and markdown citation behavior unchanged

## Verification
- pnpm --filter @reflect/desktop exec vitest run src/components/chat/chat-screen.test.tsx src/providers/chat-provider.test.tsx
- pnpm check
- pnpm --filter @reflect/desktop dev; loaded http://localhost:1420/ with no browser console errors (fresh web session stopped at graph onboarding, so chat route visual pass was limited to tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large presentation-layer refactor with new scroll anchoring behavior; core AI/session logic is untouched but regressions in scroll UX or layout are possible despite existing chat-screen tests.
> 
> **Overview**
> Adds **`@shadcn/react`** and local chat UI building blocks (`message`, `bubble`, `marker`, `attachment`, plus a styled **`MessageScroller`** wrapper) so the desktop chat surface uses shared primitives instead of one-off markup.
> 
> **Conversation layout** is reworked: turns use `Message` / `MessageGroup` with user text in muted `Bubble`s, assistant output split into **`ChatAssistantPart`** (streaming plain text vs settled `MarkdownPreview`, tools, notices), and sent images in **`ChatUserAttachments`**. Tool activity chips now render through **`Marker`** instead of custom spans.
> 
> **Scrolling** drops the hand-rolled “stick to bottom only when near bottom” logic in favor of **`MessageScrollerProvider`** with auto-scroll, per-turn `MessageScrollerItem` anchors, and a jump-to-end button. Composer attachment previews use the same **`Attachment`** components as the transcript.
> 
> Tests stub **`Element.prototype.scrollTo`** for jsdom. Chat session, persistence, streaming/markdown/citation behavior, and composer controls are intended to stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6383fe2359acbdd6a3c78360a4a5a71689a38c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->