### PR TITLE
Release v0.4.0-beta.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4673,7 +4673,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.4.0-beta.2"
+version = "0.4.0-beta.3"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.4.0-beta.2"
+version = "0.4.0-beta.3"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.4.0-beta.2",
+  "version": "0.4.0-beta.3",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.4.0-beta.3.

The release bump script will merge this PR, pull the merged commit, and push the release tag.