### PR TITLE
Fix today shortcut after midnight

### DIFF
--- a/apps/desktop/src/components/daily-stream.test.tsx
+++ b/apps/desktop/src/components/daily-stream.test.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render } from '@testing-library/react'
+import { act, fireEvent, render } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useEffect, useLayoutEffect, useState, type ReactElement, type ReactNode } from 'react'
 import { setBridge } from '@reflect/core'
 import {
@@ -80,6 +80,10 @@ beforeEach(() => {
   scrollToSpy.mockClear()
 })
 
+afterEach(() => {
+  vi.useRealTimers()
+})
+
 function StreamProviders({ children }: { children: ReactNode }): ReactElement {
   const [client] = useState(
     () => new QueryClient({ defaultOptions: { queries: { retry: false } } }),
@@ -100,6 +104,18 @@ function SaveScrollProbe({ offset }: { offset: number }): ReactElement | null {
   return null
 }
 
+function NavigateTodayProbe({
+  onReady,
+}: {
+  onReady: (navigateToday: () => void) => void
+}): null {
+  const { navigate } = useRouter()
+  useEffect(() => {
+    onReady(() => navigate({ kind: 'today' }))
+  }, [navigate, onReady])
+  return null
+}
+
 /**
  * Runs `onLayout` in the layout phase of every commit it participates in.
  * Mounted as a sibling *after* the stream, its layout effect runs once all of
@@ -117,11 +133,42 @@ describe('DailyStream', () => {
     const today = todayIso()
     const view = render(
       <StreamProviders>
-        <DailyStream targetDate={today} />
+        <DailyStream target={{ kind: 'today' }} />
       </StreamProviders>,
     )
 
     const expected = indexOfDate(createDayWindow(today), today) * ESTIMATED_DAY_HEIGHT
+    expect(scrollToSpy.mock.calls.length).toBeGreaterThan(0)
+    expect(scrollToSpy.mock.calls[0]![0]).toMatchObject({ top: expected })
+    view.unmount()
+  })
+
+  it('re-anchors a today arrival to the stream-local day after midnight', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 5, 27, 23, 59, 0))
+    let navigateToday: () => void = () => {
+      throw new Error('navigate not ready')
+    }
+    const view = render(
+      <StreamProviders>
+        <DailyStream target={{ kind: 'today' }} />
+        <NavigateTodayProbe
+          onReady={(run) => {
+            navigateToday = run
+          }}
+        />
+      </StreamProviders>,
+    )
+
+    const dayWindow = createDayWindow('2026-06-27')
+    act(() => {
+      vi.advanceTimersByTime(2 * 60 * 1000)
+    })
+    scrollToSpy.mockClear()
+
+    act(() => navigateToday())
+
+    const expected = indexOfDate(dayWindow, '2026-06-28') * ESTIMATED_DAY_HEIGHT
     expect(scrollToSpy.mock.calls.length).toBeGreaterThan(0)
     expect(scrollToSpy.mock.calls[0]![0]).toMatchObject({ top: expected })
     view.unmount()
@@ -138,7 +185,7 @@ describe('DailyStream', () => {
     view.rerender(
       <StreamProviders>
         <SaveScrollProbe offset={4321} />
-        <DailyStream targetDate={todayIso()} />
+        <DailyStream target={{ kind: 'today' }} />
       </StreamProviders>,
     )
 
@@ -161,7 +208,7 @@ describe('DailyStream', () => {
     const today = todayIso()
     const view = render(
       <StreamProviders>
-        <DailyStream targetDate={today} />
+        <DailyStream target={{ kind: 'today' }} />
         <LayoutPhaseProbe
           onLayout={() => {
             if (commandsDuringLayout === -1) {
@@ -189,7 +236,7 @@ describe('DailyStream', () => {
     const view = render(
       <StreamProviders>
         <FocusedDailyProvider>
-          <DailyStream targetDate={today} />
+          <DailyStream target={{ kind: 'date', date: today }} />
           <FocusProbe />
         </FocusedDailyProvider>
       </StreamProviders>,
@@ -208,7 +255,7 @@ describe('DailyStream', () => {
   it('reserves the editor’s space on loading placeholders, with the hint delayed', () => {
     const view = render(
       <StreamProviders>
-        <DailyStream targetDate={todayIso()} />
+        <DailyStream target={{ kind: 'today' }} />
       </StreamProviders>,
     )
 

--- a/apps/desktop/src/components/daily-stream.tsx
+++ b/apps/desktop/src/components/daily-stream.tsx
@@ -12,8 +12,8 @@ import { useSetFocusedDailyDate } from '@/providers/focused-daily-provider'
 import { useRouter } from '@/routing/router'
 
 interface DailyStreamProps {
-  /** The day to anchor/scroll to (from the `today` or `daily/:date` route). */
-  targetDate: string
+  /** The day to anchor/scroll to, or the live local day for the `today` route. */
+  target: { kind: 'today' } | { kind: 'date'; date: string }
 }
 
 /**
@@ -63,21 +63,20 @@ function adjustScrollForResizeAboveViewport(
  * (virtual rows are free), so there is no bidirectional infinite-scroll
  * bookkeeping; index↔date is pure offset math.
  */
-export function DailyStream({ targetDate }: DailyStreamProps): ReactElement {
+export function DailyStream({ target }: DailyStreamProps): ReactElement {
   const { arrivalSeq, entryId, saveScrollState, savedScroll } = useRouter()
   const scrollRef = useRef<HTMLDivElement | null>(null)
   // The window anchors at today-on-mount and stays stable for the view's life.
   // (`dayWindow`, not `window` — shadowing the DOM global here was a footgun.)
   const [dayWindow] = useState(() => createDayWindow(todayIso()))
   const today = useToday()
+  const targetDate = target.kind === 'today' ? today : target.date
   const { settings } = useSettings()
 
-  // targetDate is read at arrival time, not reacted to: on the `today` route
-  // it drifts when local midnight passes (`todayIso()` per render), and that
-  // drift is not a navigation — re-running the anchor effect then would
-  // misread the entry's continuously-saved offset as a back/forward restore.
-  // The next real arrival (⌘D, a link) reads the fresh value and anchors to
-  // the new today.
+  // targetDate is read at arrival time, not reacted to. On the `today` route
+  // it follows this component's live clock — the same value that paints the
+  // today highlight — but midnight drift alone is not a navigation. The next
+  // real arrival (⌘D, a link) reads the fresh value and anchors to the new day.
   const targetDateRef = useRef(targetDate)
   targetDateRef.current = targetDate
 

--- a/apps/desktop/src/components/route-content.tsx
+++ b/apps/desktop/src/components/route-content.tsx
@@ -7,7 +7,6 @@ import { SearchRoute } from '@/components/search-route'
 import { SettingsNavigator } from '@/components/settings/settings-navigator'
 import { SettingsScreen } from '@/components/settings-screen'
 import { TasksScreen } from '@/components/tasks/tasks-screen'
-import { useToday } from '@/lib/use-today'
 import { useRouter } from '@/routing/router'
 import { ScrollRestored } from '@/routing/scroll-restore'
 
@@ -17,19 +16,19 @@ import { ScrollRestored } from '@/routing/scroll-restore'
  * `note` route renders one ordinary note as a first-class editable pane (lazy,
  * so ⌘N's fresh path opens before any file exists). Extracted from the
  * workspace shell so this seam — the contract that non-daily notes are just as
- * editable as daily ones — is directly testable. `today` tracks the live
- * clock — midnight re-renders it.
+ * editable as daily ones — is directly testable. The daily stream owns live
+ * today tracking so route arrivals and the highlighted current day use the
+ * same clock.
  */
 export function RouteContent(): ReactElement {
   const { route } = useRouter()
-  const today = useToday()
   switch (route.kind) {
     case 'today':
-      return <DailyStream targetDate={today} />
+      return <DailyStream target={{ kind: 'today' }} />
     case 'daily':
       // The router normalizes daily routes (see normalizeRoute), so the date
       // is a real calendar day by the time it reaches a view.
-      return <DailyStream targetDate={route.date} />
+      return <DailyStream target={{ kind: 'date', date: route.date }} />
     case 'note':
       // The vertical padding lives on the inner column (not the scroll
       // container) so `min-h-full` fills the viewport exactly; the flex chain
@@ -57,7 +56,7 @@ export function RouteContent(): ReactElement {
       // ScrollRestored wrapper — same shape as All Notes.
       return <TasksScreen />
     case 'search':
-      return <SearchRoute query={route.query} today={today} />
+      return <SearchRoute query={route.query} />
     case 'chat':
       // Owns its scroll container (the message list pins to the bottom while
       // streaming), so no ScrollRestored wrapper — same shape as All Notes.

--- a/apps/desktop/src/components/search-route.tsx
+++ b/apps/desktop/src/components/search-route.tsx
@@ -6,15 +6,13 @@ import { useRouter } from '@/routing/router'
 interface SearchRouteProps {
   /** The query carried by the `search/:query` route. */
   query: string
-  /** The current day, anchoring the stream rendered behind the palette. */
-  today: string
 }
 
 /**
  * `search/:query` is a deep-link target, not a second search surface (decided
  * 2026-06-09): arriving opens the ⌘K palette pre-filled over the stream.
  */
-export function SearchRoute({ query, today }: SearchRouteProps): ReactElement {
+export function SearchRoute({ query }: SearchRouteProps): ReactElement {
   const { openPalette } = usePalette()
   const { arrivalSeq, entryId } = useRouter()
   // Keyed on the *arrival*, not just the value (the daily stream's lesson):
@@ -24,5 +22,5 @@ export function SearchRoute({ query, today }: SearchRouteProps): ReactElement {
   useEffect(() => {
     openPalette(query)
   }, [query, arrivalSeq, entryId, openPalette])
-  return <DailyStream targetDate={today} />
+  return <DailyStream target={{ kind: 'today' }} />
 }


### PR DESCRIPTION
## Problem

If Reflect stays open across local midnight, the daily stream can highlight the new current day while the route layer still hands it an older `today` target. Pressing Command-D then re-runs “Go to today” but re-anchors the stream to yesterday, even though the current day is visibly highlighted.

## Before -> After

| Scenario | Before | After |
| --- | --- | --- |
| App left open overnight, then Command-D pressed | Stream could scroll to the previous day | Stream anchors to the same live day it highlights |
| Search route background stream | Parent route computed today separately | Daily stream resolves live today itself |

## Changes

1. Changed `DailyStream` to accept an explicit target: `{ kind: 'today' }` for live local today, or `{ kind: 'date' }` for a fixed daily route.
2. Moved “today route” resolution into `DailyStream`, so the anchor target and highlighted current day come from the same `useToday()` state.
3. Updated `RouteContent` and `SearchRoute` to stop passing a parent-computed date into today-backed streams.
4. Added a regression test that mounts the stream before midnight, advances the live clock, then re-runs today navigation and expects the anchor to land on the new day.

## Tests

- `pnpm --filter @reflect/desktop exec vitest run src/components/daily-stream.test.tsx` passed: 1 file, 6 tests.
- `pnpm --filter @reflect/desktop test -- src/components/daily-stream.test.tsx` passed: Vitest executed the desktop suite, 123 files / 1076 tests.
- `pnpm check` passed. Lint emitted existing warnings only.

## Risk / Rollout

No migrations, persistence changes, or external integrations. Risk is limited to daily stream anchoring on `today`, `daily/:date`, and search-background routes; the new regression covers the overnight Command-D path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to daily stream scroll anchoring on today, daily, and search routes; no persistence or security changes, with a targeted regression test.
> 
> **Overview**
> Fixes **Go to today (⌘D)** scrolling to yesterday when the app stays open past midnight: the stream could highlight the new day while anchoring still used a **parent-passed** `today` string from route render time.
> 
> **`DailyStream`** now takes a discriminated **`target`** (`{ kind: 'today' }` or `{ kind: 'date', date }`). For the today route it resolves the anchor date with the same **`useToday()`** hook that drives the today highlight, read at **navigation arrival** via `targetDateRef` (midnight alone still does not re-anchor). **`RouteContent`** and **`SearchRoute`** pass `target` instead of computing and threading a date string.
> 
> Adds a regression test that mounts before midnight, advances fake timers, triggers **`navigate({ kind: 'today' })`**, and asserts the first scroll lands on the new calendar day.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5447b0e154a0e22593ff8e3bf7fa4fc65059d124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily and search views now support a more flexible date anchor, including “today” and specific dates.
* **Bug Fixes**
  * Improved “today” navigation so the stream stays correctly aligned after midnight.
  * Stream positioning is now more reliable when moving between dates, reducing unexpected jumps.
* **Tests**
  * Expanded coverage for date changes and midnight transitions to help keep behavior stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->