### PR TITLE
Fix bracket history shortcuts in editor

### DIFF
--- a/apps/desktop/src/routing/app-shortcuts.test.tsx
+++ b/apps/desktop/src/routing/app-shortcuts.test.tsx
@@ -116,13 +116,15 @@ describe('app shortcuts', () => {
     document.body.append(editor)
     editor.addEventListener('keydown', (event) => event.preventDefault())
 
-    act(() => pressFrom(editor, 'Unidentified', { code: 'BracketLeft' }))
-    expect(result.current.router.route.kind).toBe('note')
+    try {
+      act(() => pressFrom(editor, 'Unidentified', { code: 'BracketLeft' }))
+      expect(result.current.router.route.kind).toBe('note')
 
-    act(() => pressFrom(editor, 'Unidentified', { code: 'BracketRight' }))
-    expect(result.current.router.route).toEqual({ kind: 'today' })
-
-    editor.remove()
+      act(() => pressFrom(editor, 'Unidentified', { code: 'BracketRight' }))
+      expect(result.current.router.route).toEqual({ kind: 'today' })
+    } finally {
+      editor.remove()
+    }
   })
 
   it('⌘K opens the palette', () => {

--- a/apps/desktop/src/routing/app-shortcuts.test.tsx
+++ b/apps/desktop/src/routing/app-shortcuts.test.tsx
@@ -60,6 +60,18 @@ function press(key: string, options: KeyboardEventInit = {}) {
   )
 }
 
+function pressFrom(target: EventTarget, key: string, options: KeyboardEventInit = {}) {
+  target.dispatchEvent(
+    new KeyboardEvent('keydown', {
+      key,
+      metaKey: true,
+      cancelable: true,
+      bubbles: true,
+      ...options,
+    }),
+  )
+}
+
 describe('app shortcuts', () => {
   it('registers the command keybindings in the central keymap registry', () => {
     const bindings = listRegisteredBindings()
@@ -92,6 +104,25 @@ describe('app shortcuts', () => {
 
     act(() => press(']'))
     expect(result.current.router.route).toEqual({ kind: 'today' })
+  })
+
+  it('⌘[ and ⌘] still traverse when the focused editor consumes the keydown', () => {
+    const { result } = shortcutsHook()
+    act(() => press('n'))
+    act(() => press('d'))
+    expect(result.current.router.route).toEqual({ kind: 'today' })
+
+    const editor = document.createElement('div')
+    document.body.append(editor)
+    editor.addEventListener('keydown', (event) => event.preventDefault())
+
+    act(() => pressFrom(editor, 'Unidentified', { code: 'BracketLeft' }))
+    expect(result.current.router.route.kind).toBe('note')
+
+    act(() => pressFrom(editor, 'Unidentified', { code: 'BracketRight' }))
+    expect(result.current.router.route).toEqual({ kind: 'today' })
+
+    editor.remove()
   })
 
   it('⌘K opens the palette', () => {

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -37,9 +37,24 @@ export const APP_BINDINGS = registerKeymap(
 )
 
 const BINDING_TO_ID = new Map(BOUND_COMMANDS.map(({ binding, command }) => [binding, command.id]))
+const HISTORY_COMMAND_IDS = new Set(['history.back', 'history.forward'])
+
+const CODE_TO_BINDING_KEY: Record<string, string> = {
+  BracketLeft: '[',
+  BracketRight: ']',
+}
 
 function isModKey(event: KeyboardEvent): boolean {
   return event.metaKey || event.ctrlKey
+}
+
+function idForKeyDown(event: KeyboardEvent): string | null {
+  if (!isModKey(event) || event.altKey || event.repeat) {
+    return null // held keys must not spam navigations (e.g. a stack of new notes)
+  }
+  const key = CODE_TO_BINDING_KEY[event.code] ?? event.key.toLowerCase()
+  const bindingKey = event.shiftKey ? `Mod-Shift-${key}` : `Mod-${key}`
+  return BINDING_TO_ID.get(bindingKey) ?? null
 }
 
 /**
@@ -145,6 +160,18 @@ export function useAppShortcuts(): CommandContext {
       return true
     }
 
+    function onHistoryKeyDownCapture(event: KeyboardEvent) {
+      const id = idForKeyDown(event)
+      if (id === null || !HISTORY_COMMAND_IDS.has(id)) {
+        return
+      }
+      if (triggerCommand(id)) {
+        // History navigation is app chrome, so it wins even when the focused
+        // editor would otherwise consume the bracket chord while bubbling.
+        event.preventDefault()
+      }
+    }
+
     function onKeyDown(event: KeyboardEvent) {
       if (event.defaultPrevented) {
         // The focused editor gets first refusal. meowdown's `Mod-k` consumes the
@@ -153,14 +180,8 @@ export function useAppShortcuts(): CommandContext {
         // has nothing to do it leaves the event alone and `Mod-k` falls through.
         return
       }
-      if (!isModKey(event) || event.altKey || event.repeat) {
-        return // held keys must not spam navigations (e.g. a stack of new notes)
-      }
-      const bindingKey = event.shiftKey
-        ? `Mod-Shift-${event.key.toLowerCase()}`
-        : `Mod-${event.key.toLowerCase()}`
-      const id = BINDING_TO_ID.get(bindingKey)
-      if (id === undefined) {
+      const id = idForKeyDown(event)
+      if (id === null) {
         return
       }
       if (triggerCommand(id)) {
@@ -171,9 +192,11 @@ export function useAppShortcuts(): CommandContext {
     }
 
     setMenuCommandDispatch(triggerCommand)
+    window.addEventListener('keydown', onHistoryKeyDownCapture, true)
     window.addEventListener('keydown', onKeyDown)
     return () => {
       setMenuCommandDispatch(null)
+      window.removeEventListener('keydown', onHistoryKeyDownCapture, true)
       window.removeEventListener('keydown', onKeyDown)
     }
   }, [context, closeShortcuts])


### PR DESCRIPTION
## Problem

`Cmd+[` / `Cmd+]` were registered as history back/forward commands, but they could fail while the note editor had focus. The app-level shortcut listener ran during bubbling and returned early once the editor had already called `preventDefault()`, which is right for shared editor shortcuts like `Cmd+K` but wrong for app-chrome history navigation.

## Before -> After

| Before | After |
| --- | --- |
| Focused editor could consume the bracket keydown before history saw it. | History back/forward run from a narrow capture-phase path before the editor can consume the chord. |
| Shortcut matching depended only on `event.key`. | Bracket shortcuts also normalize `BracketLeft` / `BracketRight` physical codes. |

## Changes

1. Added `idForKeyDown()` in `useAppShortcuts` so app shortcut matching is shared between the normal bubble listener and the new history capture listener.
2. Added a capture-phase listener only for `history.back` and `history.forward`, preserving editor-first behavior for other shortcuts.
3. Added a regression test that dispatches bracket shortcuts from an editor-like element that calls `preventDefault()`.

## Tests

- `pnpm --filter @reflect/desktop test --run src/routing/app-shortcuts.test.tsx src/lib/native-menu/accelerator.test.ts src/lib/commands/app-commands.test.ts`
- `pnpm check`

## Risk / Rollout

Low risk: this only changes handling for the two history commands. Modal guards still apply, repeat/alt-modified chords are still ignored, and other app shortcuts keep the existing editor-first `defaultPrevented` behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is limited to two history commands; modal guards, repeat/alt-modifier filtering, and editor-first behavior for other shortcuts are unchanged.
> 
> **Overview**
> **⌘[** and **⌘]** history navigation now works while the note editor has focus, where bubbling shortcuts previously bailed out after the editor called `preventDefault()`.
> 
> Shortcut resolution is centralized in `idForKeyDown()`, including mapping physical **`BracketLeft` / `BracketRight`** codes when `event.key` is unreliable (e.g. `Unidentified`). A **capture-phase** `keydown` handler runs only for `history.back` and `history.forward`, so those chords are handled as app chrome before the editor can swallow them; other bindings (like **⌘K**) still defer when the editor already handled the event.
> 
> A regression test dispatches bracket chords from a focused element that `preventDefault()`s on keydown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a164adba93bccb2bf2ca3c9d16cae349a33615c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop keyboard shortcut handling so `⌘[` and `⌘]` continue to navigate between views even when a focused editor intercepts key presses.
  * Added stronger handling for browser-style back/forward navigation shortcuts, making route changes more reliable.
  * Expanded automated coverage for shortcut navigation to verify the behavior from within an active editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->