### PR TITLE
Add ISO date display option

### DIFF
--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -104,6 +104,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup() // `globals: false` disables testing-library's automatic cleanup
+  vi.useRealTimers()
   setBridge(null)
   queryClient.clear()
 })
@@ -412,10 +413,14 @@ describe('SettingsScreen', () => {
   })
 
   it('selecting ISO persists the date format', async () => {
+    const now = new Date(2026, 5, 10, 12, 0, 0)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(now)
+
     renderScreen()
     const trigger = screen.getByRole('combobox', { name: 'Date format' })
-    const isoLabel = formatFullDate(new Date(), 'iso')
-    await waitFor(() => expect(trigger.textContent).toContain(formatFullDate(new Date(), 'mdy')))
+    const isoLabel = formatFullDate(now, 'iso')
+    await waitFor(() => expect(trigger.textContent).toContain(formatFullDate(now, 'mdy')))
 
     fireEvent.keyDown(trigger, { key: 'ArrowDown' })
     fireEvent.keyDown(await screen.findByRole('option', { name: isoLabel }), { key: 'Enter' })

--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -411,6 +411,41 @@ describe('SettingsScreen', () => {
     )
   })
 
+  it('selecting ISO persists the date format', async () => {
+    renderScreen()
+    const trigger = screen.getByRole('combobox', { name: 'Date format' })
+    const isoLabel = formatFullDate(new Date(), 'iso')
+    await waitFor(() => expect(trigger.textContent).toContain(formatFullDate(new Date(), 'mdy')))
+
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+    fireEvent.keyDown(await screen.findByRole('option', { name: isoLabel }), { key: 'Enter' })
+
+    expect(trigger.textContent).toContain(isoLabel)
+    await waitFor(() =>
+      expect(saved).toEqual([
+        {
+          editorMarkdownSyntax: 'hide',
+          editorSpellCheck: true,
+          editorDefaultBullet: true,
+          editorBulletAfterHeading: true,
+          editorTextSize: 'small',
+          semanticSearchEnabled: false,
+          describeAssets: true,
+          mobileOnboarded: false,
+          theme: 'system',
+          timeFormat: '12h',
+          dateFormat: 'iso',
+          weekStartDay: 'monday',
+          allNotesFilterTags: ['book', 'link', 'person'],
+          graphColors: {},
+          aiProviders: [],
+          defaultAiProviderId: null,
+          chatModelSelection: null,
+        },
+      ]),
+    )
+  })
+
   it('shows the week start setting in Date & time', async () => {
     renderScreen()
     const dateTime = screen.getByRole('region', { name: 'Date & time' })

--- a/apps/desktop/src/components/settings/date-time-section.tsx
+++ b/apps/desktop/src/components/settings/date-time-section.tsx
@@ -41,7 +41,7 @@ const WEEK_START_OPTIONS: WeekStartOption[] = [
 
 // The options demonstrate themselves: each shows today's date in its format,
 // so the day/month order is visible rather than described.
-const DATE_FORMAT_VALUES: DateFormat[] = ['mdy', 'dmy']
+const DATE_FORMAT_VALUES: DateFormat[] = ['mdy', 'dmy', 'iso']
 
 /**
  * Date & time display preferences. Both formats feed every date and time the
@@ -57,7 +57,7 @@ export function DateTimeSection(): ReactElement {
     <SettingsSection id="date-time">
       <SettingsField
         legend="Date format"
-        description="The day and month order for dates shown throughout Reflect."
+        description="The style for dates shown throughout Reflect, including daily note titles."
       >
         <div className="mt-3">
           <Select

--- a/apps/desktop/src/lib/dates.test.ts
+++ b/apps/desktop/src/lib/dates.test.ts
@@ -4,6 +4,7 @@ import {
   formatDayLabel,
   formatFullDate,
   formatRecencyLabel,
+  formatShortDate,
   formatTimeOfDay,
   isIsoDate,
   todayIso,
@@ -34,14 +35,22 @@ describe('dates', () => {
   it('formatDayLabel renders the V1 daily-subject format per the date format', () => {
     expect(formatDayLabel('2026-06-09', 'mdy')).toBe('Tue, June 9th, 2026')
     expect(formatDayLabel('2026-06-09', 'dmy')).toBe('Tue, 9th June, 2026')
+    expect(formatDayLabel('2026-06-09', 'iso')).toBe('2026-06-09')
     expect(formatDayLabel('2026-05-31', 'mdy')).toBe('Sun, May 31st, 2026')
   })
 
   it('formatFullDate spells the date out per the date format', () => {
     expect(formatFullDate(new Date(2026, 5, 10), 'mdy')).toBe('June 10th, 2026')
     expect(formatFullDate(new Date(2026, 5, 10), 'dmy')).toBe('10th June, 2026')
+    expect(formatFullDate(new Date(2026, 5, 10), 'iso')).toBe('2026-06-10')
     expect(formatFullDate(new Date(2026, 0, 1), 'mdy')).toBe('January 1st, 2026')
     expect(formatFullDate(new Date(2026, 0, 22), 'dmy')).toBe('22nd January, 2026')
+  })
+
+  it('formatShortDate renders compact dates per the date format', () => {
+    expect(formatShortDate('2026-06-09', 'mdy')).toBe('6/9/2026')
+    expect(formatShortDate('2026-06-09', 'dmy')).toBe('9/6/2026')
+    expect(formatShortDate('2026-06-09', 'iso')).toBe('2026-06-09')
   })
 
   describe('formatTimeOfDay', () => {
@@ -63,6 +72,7 @@ describe('dates', () => {
     const now = new Date(2026, 5, 10, 21, 0)
     const mdy = { timeFormat: '12h', dateFormat: 'mdy' } as const
     const dmy = { timeFormat: '24h', dateFormat: 'dmy' } as const
+    const iso = { timeFormat: '24h', dateFormat: 'iso' } as const
 
     it('shows the time for a timestamp today, honoring the time format', () => {
       expect(formatRecencyLabel(new Date(2026, 5, 10, 20, 22).getTime(), mdy, now)).toBe('8:22pm')
@@ -74,11 +84,15 @@ describe('dates', () => {
     it('shows the weekday within the current week', () => {
       expect(formatRecencyLabel(new Date(2026, 5, 8, 13, 0).getTime(), mdy, now)).toBe('Mon')
       expect(formatRecencyLabel(new Date(2026, 5, 8, 13, 0).getTime(), dmy, now)).toBe('Mon')
+      expect(formatRecencyLabel(new Date(2026, 5, 8, 13, 0).getTime(), iso, now)).toBe('Mon')
     })
 
     it('shows the short date beyond the current week, honoring the date format', () => {
       expect(formatRecencyLabel(new Date(2026, 5, 3, 13, 0).getTime(), mdy, now)).toBe('6/3/2026')
       expect(formatRecencyLabel(new Date(2026, 5, 3, 13, 0).getTime(), dmy, now)).toBe('3/6/2026')
+      expect(formatRecencyLabel(new Date(2026, 5, 3, 13, 0).getTime(), iso, now)).toBe(
+        '2026-06-03',
+      )
       expect(formatRecencyLabel(new Date(2025, 11, 31, 13, 0).getTime(), mdy, now)).toBe(
         '12/31/2025',
       )

--- a/apps/desktop/src/lib/dates.ts
+++ b/apps/desktop/src/lib/dates.ts
@@ -25,33 +25,51 @@ export function todayIso(): string {
 }
 
 /**
- * Human label for an ISO date per the user's date-format setting, in the
- * original app's daily-subject form: `Tue, June 9th, 2026` for `mdy`
- * (V1's `weekMonthDayYear`), `Tue, 9th June, 2026` for `dmy`
- * (V1's `weekDayMonthYear`).
+ * Label for an ISO date per the user's date-format setting. `mdy` and `dmy`
+ * keep the original app's daily-subject form (`Tue, June 9th, 2026` /
+ * `Tue, 9th June, 2026`); `iso` renders the daily-note key itself.
  */
 export function formatDayLabel(date: string, dateFormat: DateFormat): string {
-  return format(
-    parseIsoDate(date),
-    dateFormat === 'dmy' ? 'EEE, do MMMM, yyyy' : 'EEE, MMMM do, yyyy',
-  )
+  switch (dateFormat) {
+    case 'dmy':
+      return format(parseIsoDate(date), 'EEE, do MMMM, yyyy')
+    case 'iso':
+      return date
+    case 'mdy':
+      return format(parseIsoDate(date), 'EEE, MMMM do, yyyy')
+  }
 }
 
 /**
- * Compact numeric date for inline chips (the Tasks view's `[[YYYY-MM-DD]]` due
- * link, V1's blue date): `12/31/2025` for `mdy`, `31/12/2025` for `dmy`.
+ * Compact date for inline chips (the Tasks view's `[[YYYY-MM-DD]]` due link,
+ * V1's blue date): `12/31/2025` for `mdy`, `31/12/2025` for `dmy`, and
+ * `2025-12-31` for `iso`.
  */
 export function formatShortDate(date: string, dateFormat: DateFormat): string {
-  return format(parseIsoDate(date), dateFormat === 'dmy' ? 'd/M/yyyy' : 'M/d/yyyy')
+  switch (dateFormat) {
+    case 'dmy':
+      return format(parseIsoDate(date), 'd/M/yyyy')
+    case 'iso':
+      return date
+    case 'mdy':
+      return format(parseIsoDate(date), 'M/d/yyyy')
+  }
 }
 
 /**
- * A date spelled out in full per the date-format setting: `June 10th, 2026`
- * for `mdy`, `10th June, 2026` for `dmy` (the forms the settings screen shows
- * as the options themselves).
+ * A date label per the date-format setting: `June 10th, 2026` for `mdy`,
+ * `10th June, 2026` for `dmy`, and `2026-06-10` for `iso` (the forms the
+ * settings screen shows as the options themselves).
  */
 export function formatFullDate(date: Date, dateFormat: DateFormat): string {
-  return format(date, dateFormat === 'dmy' ? 'do MMMM, yyyy' : 'MMMM do, yyyy')
+  switch (dateFormat) {
+    case 'dmy':
+      return format(date, 'do MMMM, yyyy')
+    case 'iso':
+      return format(date, ISO_DATE_FORMAT)
+    case 'mdy':
+      return format(date, 'MMMM do, yyyy')
+  }
 }
 
 /**
@@ -74,8 +92,8 @@ export interface DateTimePrefs {
 /**
  * Compact recency label for list rows (the original app's Updated column):
  * the time for today (per `timeFormat`), the weekday within the current week
- * (`Mon`), the short date otherwise (`6/3/2026`, or `3/6/2026` for `dmy`).
- * `now` is injectable for tests.
+ * (`Mon`), the short date otherwise (`6/3/2026`, `3/6/2026`, or
+ * `2026-06-03`). `now` is injectable for tests.
  */
 export function formatRecencyLabel(
   epochMs: number,
@@ -89,5 +107,12 @@ export function formatRecencyLabel(
   if (isSameWeek(date, now)) {
     return format(date, 'EEE')
   }
-  return format(date, prefs.dateFormat === 'dmy' ? 'd/M/yyyy' : 'M/d/yyyy')
+  switch (prefs.dateFormat) {
+    case 'dmy':
+      return format(date, 'd/M/yyyy')
+    case 'iso':
+      return format(date, ISO_DATE_FORMAT)
+    case 'mdy':
+      return format(date, 'M/d/yyyy')
+  }
 }

--- a/packages/core/src/indexing/date-suggestions.test.ts
+++ b/packages/core/src/indexing/date-suggestions.test.ts
@@ -135,6 +135,13 @@ describe('generateDateSuggestions', () => {
       expect(gen('12/25', 'dmy')).toEqual([{ date: '2020-12-25', phrase: '12/25' }])
     })
 
+    it('keeps month-day slash shorthand first for ISO display', () => {
+      expect(gen('1/2', 'iso')).toEqual([
+        { date: '2020-01-02', phrase: '1/2' },
+        { date: '2020-02-01', phrase: '1/2' },
+      ])
+    })
+
     it('parses a full slash date and offers only the valid reading', () => {
       expect(gen('23/2/2023', 'dmy')).toEqual([{ date: '2023-02-23', phrase: '23/2/2023' }])
     })

--- a/packages/core/src/indexing/date-suggestions.ts
+++ b/packages/core/src/indexing/date-suggestions.ts
@@ -30,7 +30,10 @@ export interface DateSuggestion {
 export interface DateSuggestionContext {
   /** Today's local calendar date, ISO `YYYY-MM-DD`. */
   today: string
-  /** Reading order for ambiguous typed slash-dates (`mdy` → M/D, `dmy` → D/M). */
+  /**
+   * Reading order for ambiguous typed slash-dates (`mdy` → M/D, `dmy` → D/M).
+   * `iso` has no slash-date order, so it keeps the default M/D reading.
+   */
   dateFormat: DateFormat
   /** Which day "this/next/last week" (and weekend) anchor to. */
   weekStartDay: WeekStartDay
@@ -344,7 +347,8 @@ function typedDateSuggestions(
   const first = Number(firstPart)
   const second = Number(secondPart)
   const year = yearPart !== undefined ? Number(yearPart) : Number(context.today.slice(0, 4))
-  // The preferred reading follows the date-format setting; the swapped reading
+  // The preferred reading follows the date-format setting; ISO display has no
+  // slash-date order, so it keeps the default M/D reading. The swapped reading
   // is offered only for bare shorthand, where "12/10" is genuinely ambiguous.
   const readings =
     context.dateFormat === 'dmy'

--- a/packages/core/src/settings/schema.test.ts
+++ b/packages/core/src/settings/schema.test.ts
@@ -63,6 +63,7 @@ describe('settingsSchema', () => {
     expect(settingsSchema.parse({ theme: 'system' }).theme).toBe('system')
     expect(settingsSchema.parse({ timeFormat: '24h' }).timeFormat).toBe('24h')
     expect(settingsSchema.parse({ timeFormat: '12h' }).timeFormat).toBe('12h')
+    expect(settingsSchema.parse({ dateFormat: 'iso' }).dateFormat).toBe('iso')
     expect(settingsSchema.parse({ dateFormat: 'dmy' }).dateFormat).toBe('dmy')
     expect(settingsSchema.parse({ dateFormat: 'mdy' }).dateFormat).toBe('mdy')
     expect(settingsSchema.parse({ weekStartDay: 'monday' }).weekStartDay).toBe('monday')

--- a/packages/core/src/settings/schema.ts
+++ b/packages/core/src/settings/schema.ts
@@ -85,12 +85,12 @@ export const timeFormatSchema = z.enum(['12h', '24h']).catch('12h')
 export type TimeFormat = z.infer<typeof timeFormatSchema>
 
 /**
- * How calendar dates are ordered when displayed throughout the app:
- * `mdy` (the default) renders `June 10th, 2026`; `dmy` renders
- * `10th June 2026`. Display-only — daily-note filenames and stored dates
+ * How calendar dates are displayed throughout the app: `mdy` (the default)
+ * renders `June 10th, 2026`, `dmy` renders `10th June 2026`, and `iso`
+ * renders `2026-06-10`. Display-only — daily-note filenames and stored dates
  * stay ISO `YYYY-MM-DD` regardless.
  */
-export const dateFormatSchema = z.enum(['mdy', 'dmy']).catch('mdy')
+export const dateFormatSchema = z.enum(['mdy', 'dmy', 'iso']).catch('mdy')
 
 export type DateFormat = z.infer<typeof dateFormatSchema>
 


### PR DESCRIPTION
## Problem

Users could choose month-day-year or day-month-year display, but there was no way to show daily note titles in the canonical `YYYY-MM-DD` form even though daily note files are already keyed that way.

## Before -> After

| Area | Before | After |
| --- | --- | --- |
| Date format setting | `June 10th, 2026` / `10th June, 2026` | Adds `2026-06-10` as a selectable option |
| Daily note labels | Long localized date labels only | `formatDayLabel(..., 'iso')` renders the ISO day key directly |
| Compact date displays | Month/day or day/month numeric display | ISO preference also renders compact dates as `YYYY-MM-DD` |

## Changes

1. Extend `dateFormatSchema` with the persisted `iso` value while keeping `mdy` as the default and invalid-value fallback.
2. Update the shared date formatters in `apps/desktop/src/lib/dates.ts` to handle all three formats explicitly for daily labels, full settings labels, compact dates, and recency labels.
3. Add `iso` to the Date & time settings select using the existing shadcn Select, with the option self-labeling as today’s ISO date.
4. Clarify that autocomplete slash-date parsing keeps the existing month/day fallback when the display preference is ISO, since ISO itself does not define slash-date ordering.

## Tests

- `packages/core/src/settings/schema.test.ts` covers accepting the persisted `iso` date format.
- `packages/core/src/indexing/date-suggestions.test.ts` covers slash-date autocomplete ordering under ISO display.
- `apps/desktop/src/lib/dates.test.ts` covers ISO daily labels, settings labels, compact dates, and recency labels.
- `apps/desktop/src/components/settings-screen.test.tsx` covers selecting and persisting the ISO option in Settings, with time frozen so the self-labeled option cannot flap around midnight.

## Verification

- `pnpm --filter @reflect/core exec vitest run src/settings/schema.test.ts src/indexing/date-suggestions.test.ts` passed.
- `pnpm --filter @reflect/desktop exec vitest run src/lib/dates.test.ts src/components/settings-screen.test.tsx` passed.
- `pnpm --filter @reflect/desktop exec vitest run src/components/settings-screen.test.tsx` passed after the CodeRabbit test-stability follow-up.
- `pnpm check` passed with existing warnings only after the follow-up commit.
- Note: an earlier desktop test command (`pnpm --filter @reflect/desktop test -- ...`) forwarded args incorrectly, ran the broader desktop suite, and hit two unrelated existing test timeouts; the focused desktop command above passed.

## Risk / Rollout

No migration is needed. Existing settings documents continue to default to `mdy`; users only see ISO formatting after choosing the new option.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only preference with no migration; stored dates and daily-note keys are untouched, and existing users keep `mdy` until they opt in.
> 
> **Overview**
> Adds a third **date format** preference, **`iso`**, so users can show dates as **`YYYY-MM-DD`** (including daily note titles) while stored daily-note keys stay unchanged.
> 
> **`dateFormatSchema`** now accepts **`iso`** (default remains **`mdy`**). Desktop **`lib/dates.ts`** formatters handle **`iso`** in **`formatDayLabel`**, **`formatFullDate`**, **`formatShortDate`**, and **`formatRecencyLabel`**—mostly returning the raw ISO string where appropriate. **Date & time** settings expose the new option (self-labeled with today’s ISO date) and the field copy mentions daily note titles.
> 
> For **`[[`** date autocomplete, **`iso`** does not define slash-date order, so ambiguous shorthand keeps the existing **month/day-first** behavior (documented + tested).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30e2d88ba1f08f99c5dcb550a3a77743d1382794. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **ISO** option for date display in settings.
  * Dates shown throughout the app, including daily note titles, can now use ISO formatting.
  * Typed date suggestions and date formatting now handle ISO consistently.

* **Bug Fixes**
  * Improved handling of slash-style date input when ISO display is selected.

* **Tests**
  * Expanded coverage for ISO date formatting and settings persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
