### PR TITLE
[codex] fix sidebar pinned selection state

### DIFF
--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -81,6 +81,7 @@ registerAppCommands()
 beforeEach(() => {
   // The hoisted mock is shared module state — restore it so mic-related cases
   // can't inherit mutations from earlier tests.
+  getPinnedNotes.mockReset().mockResolvedValue([])
   audioMemo.available = true
   audioMemo.unavailableReason = null
   audioMemo.toggle.mockReset()
@@ -222,6 +223,19 @@ describe('Sidebar', () => {
     expect(pinnedSection.contains(roadmap)).toBe(true)
     await userEvent.click(roadmap)
     await waitFor(() => expect(roadmap.getAttribute('aria-current')).toBe('page'))
+  })
+
+  it('All notes is inactive while the active note is pinned', async () => {
+    getPinnedNotes.mockResolvedValue([
+      { path: 'notes/roadmap.md', title: 'Roadmap', dailyDate: null },
+    ])
+    const { view } = renderSidebar(undefined, { kind: 'note', path: 'notes/roadmap.md' })
+
+    const roadmap = await view.findByRole('button', { name: 'Roadmap' })
+    await waitFor(() => expect(roadmap.getAttribute('aria-current')).toBe('page'))
+    expect(
+      view.getByRole('button', { name: /all notes/i }).getAttribute('aria-current'),
+    ).toBeNull()
   })
 
   it('the pinned section is hidden while nothing is pinned', async () => {

--- a/apps/desktop/src/components/sidebar/sidebar.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.tsx
@@ -4,12 +4,15 @@ import { ListChecks, MessageSquare, SquarePen } from 'lucide-react'
 import { AudioMemoButton } from '@/components/audio-memo/audio-memo-button'
 import { ListIcon } from '@/components/icons/list-icon'
 import { PencilIcon } from '@/components/icons/pencil-icon'
+import { usePinnedNotes } from '@/hooks/use-pinned-notes'
 import { keybindingFor } from '@/lib/commands/app-commands'
 import { runCommand } from '@/lib/commands/registry'
 import { isUntitledNotePath } from '@/lib/create-note'
+import { useToday } from '@/lib/use-today'
 import type { CommandContext } from '@/lib/commands/types'
 import { hasMacosTitleBarOverlay } from '@/lib/window-chrome'
 import { cn } from '@/lib/utils'
+import { notePathForRoute } from '@/routing/route'
 import { useRouter } from '@/routing/router'
 import { GraphFooter } from './graph-footer'
 import { NavigateArrows } from './navigate-arrows'
@@ -32,6 +35,11 @@ interface SidebarProps {
  */
 export function Sidebar({ graph, context }: SidebarProps): ReactElement {
   const { route } = useRouter()
+  const today = useToday()
+  const pinned = usePinnedNotes()
+  const currentNotePath = notePathForRoute(route, today)
+  const hasActivePinnedNote =
+    currentNotePath !== null && pinned.some((note) => note.path === currentNotePath)
 
   // Wrap the 16px Lucide glyphs in the custom icons' 24px box so nav rows
   // share one icon footprint.
@@ -63,7 +71,7 @@ export function Sidebar({ graph, context }: SidebarProps): ReactElement {
             icon={<PencilIcon className="shrink-0" />}
             label="Daily notes"
             binding={keybindingFor('nav.today') ?? undefined}
-            active={route.kind === 'today' || route.kind === 'daily'}
+            active={(route.kind === 'today' || route.kind === 'daily') && !hasActivePinnedNote}
             onClick={() => void runCommand('nav.today', context)}
           />
           <SidebarItem
@@ -91,7 +99,7 @@ export function Sidebar({ graph, context }: SidebarProps): ReactElement {
             // highlight until the birth rename — so the two never light at once.
             active={
               route.kind === 'allNotes' ||
-              (route.kind === 'note' && !isUntitledNotePath(route.path))
+              (route.kind === 'note' && !isUntitledNotePath(route.path) && !hasActivePinnedNote)
             }
             onClick={() => void runCommand('nav.allNotes', context)}
           />


### PR DESCRIPTION
## Summary
- Suppress the primary sidebar selection when the current note path is already selected in pinned notes.
- Add a regression test covering the pinned note vs All notes active state.

## Validation
- CI=true pnpm --filter @reflect/desktop test -- apps/desktop/src/components/sidebar/sidebar.test.tsx
- CI=true pnpm check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar active states now better reflect the currently open note, including pinned notes.
  * “All notes” and “Daily notes” will no longer appear active in situations where another pinned note is currently selected.

* **Tests**
  * Added coverage for pinned-note sidebar behavior.
  * Improved test setup to avoid leftover mock state between runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->