### PR TITLE
Release v0.4.0-beta.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4673,7 +4673,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.4.0-beta.6"
+version = "0.4.0-beta.7"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.4.0-beta.6"
+version = "0.4.0-beta.7"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.4.0-beta.6",
+  "version": "0.4.0-beta.7",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.4.0-beta.7.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version-only release bump with no logic, config, or dependency manifest changes.
> 
> **Overview**
> **Release version bump** from `0.4.0-beta.6` to `0.4.0-beta.7` with no application or dependency changes beyond the version string.
> 
> The same version is updated in `apps/desktop/src-tauri/Cargo.toml` (crate `reflect-open`), `apps/desktop/src-tauri/tauri.conf.json` (Tauri app/bundle version), and the root `Cargo.lock` entry for `reflect-open`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 876730d28644dcb73f70e406260b9fc901ec06f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop app release version to `0.4.0-beta.7` in the app metadata and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->