### PR TITLE
Show task toolbar counts as badges

### DIFF
--- a/apps/desktop/src/components/tasks/task-toolbar-count-badge.tsx
+++ b/apps/desktop/src/components/tasks/task-toolbar-count-badge.tsx
@@ -1,0 +1,19 @@
+import { type ReactElement } from 'react'
+import { Badge } from '@/components/ui/badge'
+
+interface TaskToolbarCountBadgeProps {
+  /** Number of tasks affected by the adjacent toolbar action. */
+  readonly count: number
+}
+
+/** Compact neutral count badge for task toolbar actions. */
+export function TaskToolbarCountBadge({ count }: TaskToolbarCountBadgeProps): ReactElement {
+  return (
+    <Badge
+      variant="outline"
+      className="h-4 min-w-4 rounded-full border-transparent bg-muted px-1 text-[10px] font-medium leading-none text-muted-foreground tabular-nums"
+    >
+      {count}
+    </Badge>
+  )
+}

--- a/apps/desktop/src/components/tasks/tasks-screen.test.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.test.tsx
@@ -804,7 +804,7 @@ describe('TasksScreen', () => {
 
     await view.findByText('plan')
     await userEvent.keyboard('{Meta>}a{/Meta}') // select both (no editor)
-    await userEvent.click(view.getByRole('button', { name: /Schedule \(2\)/ }))
+    await userEvent.click(view.getByRole('button', { name: /Schedule 2/ }))
     // Pick June 20 in the calendar (today mock = 2026-06-14, so it opens on June).
     await userEvent.click(await view.findByText('20'))
 
@@ -826,7 +826,7 @@ describe('TasksScreen', () => {
 
     await view.findByText('plan')
     await userEvent.keyboard('{Meta>}a{/Meta}') // select both (no editor mounts)
-    await userEvent.click(view.getByRole('button', { name: /Convert to bullet \(2\)/ }))
+    await userEvent.click(view.getByRole('button', { name: /Convert to bullet 2/ }))
 
     await waitFor(() => expect(convertTaskToBullet).toHaveBeenCalledTimes(2))
     expect(convertTaskToBullet).toHaveBeenCalledWith(expect.objectContaining({ notePath: 'notes/a.md' }), 1)
@@ -863,7 +863,7 @@ describe('TasksScreen', () => {
     const view = renderScreen()
 
     await userEvent.click(await view.findByRole('button', { name: 'plan' })) // sole → editor mounts
-    await userEvent.click(view.getByRole('button', { name: /Convert to bullet \(1\)/ }))
+    await userEvent.click(view.getByRole('button', { name: /Convert to bullet 1/ }))
 
     // Edit first (persist the draft), then convert the rewritten line.
     await waitFor(() =>
@@ -1384,8 +1384,8 @@ describe('TasksScreen', () => {
     const view = renderScreen()
 
     await userEvent.click(await view.findByRole('button', { name: 'Complete: project task' }))
-    // The row lingers struck and an Archive (1) action appears.
-    const archive = await view.findByRole('button', { name: /Archive \(1\)/ })
+    // The row lingers struck and an Archive 1 action appears.
+    const archive = await view.findByRole('button', { name: /Archive 1/ })
     expect(view.getByText('project task')).toBeDefined()
 
     await userEvent.click(archive)

--- a/apps/desktop/src/components/tasks/tasks-screen.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.tsx
@@ -37,6 +37,7 @@ import { useRouter } from '@/routing/router'
 import { TaskFiltersMenu } from './task-filters-menu'
 import { TaskGroupSection } from './task-group-section'
 import { TaskScheduleCalendar } from './task-schedule-calendar'
+import { TaskToolbarCountBadge } from './task-toolbar-count-badge'
 
 /** Keep only the groups the active filters allow (V1's per-bucket toggles). */
 function visibleGroups(groups: TaskGroup[], filters: TaskFilters): TaskGroup[] {
@@ -293,9 +294,15 @@ export function TasksScreen(): ReactElement {
             today={today}
             onSchedule={onSchedule}
           >
-            <Button type="button" variant="ghost" className="window-drag-control text-xs text-text-muted">
+            <Button
+              type="button"
+              variant="ghost"
+              aria-label={`Schedule ${selection.selectedCount}`}
+              className="window-drag-control text-xs text-text-muted"
+            >
               <CalendarClock aria-hidden className="size-3.5" />
-              Schedule ({selection.selectedCount})
+              Schedule
+              <TaskToolbarCountBadge count={selection.selectedCount} />
             </Button>
           </TaskScheduleCalendar>
         ) : null}
@@ -303,23 +310,27 @@ export function TasksScreen(): ReactElement {
           <Button
             type="button"
             variant="ghost"
+            aria-label={`Convert to bullet ${selection.selectedCount}`}
             onClick={onConvertToBullet}
             title="Drop the checkbox, keeping the line as a plain bullet — leaves the Tasks list"
             className="window-drag-control text-xs text-text-muted"
           >
             <List aria-hidden className="size-3.5" />
-            Convert to bullet ({selection.selectedCount})
+            Convert to bullet
+            <TaskToolbarCountBadge count={selection.selectedCount} />
           </Button>
         ) : null}
         {recentlyCompleted.length > 0 ? (
           <Button
             type="button"
             variant="ghost"
+            aria-label={`Archive ${recentlyCompleted.length}`}
             onClick={actions.archive}
             className="window-drag-control text-xs text-text-muted"
           >
             <Archive aria-hidden className="size-3.5" />
-            Archive ({recentlyCompleted.length})
+            Archive
+            <TaskToolbarCountBadge count={recentlyCompleted.length} />
           </Button>
         ) : null}
         <TaskFiltersMenu

--- a/apps/desktop/src/components/ui/badge.tsx
+++ b/apps/desktop/src/components/ui/badge.tsx
@@ -1,0 +1,51 @@
+import { type ComponentProps } from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+/** Style variants for the local shadcn badge primitive. */
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+/** Small status/count marker primitive. */
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }


### PR DESCRIPTION
## Problem
Task toolbar actions showed counts as parenthesized text, e.g. `Schedule (2)`, `Convert to bullet (2)`, and `Archive (1)`. The count read like part of the label instead of a compact status indicator, and the app did not yet have a local shadcn `Badge` primitive to reuse for this UI.

## Before -> After
| Action | Before | After |
| --- | --- | --- |
| Schedule | `Schedule (2)` | `Schedule` plus a compact muted count badge |
| Convert to bullet | `Convert to bullet (2)` | `Convert to bullet` plus a compact muted count badge |
| Archive | `Archive (1)` | `Archive` plus a compact muted count badge |

## Changes
1. Generated the local shadcn `Badge` primitive in `apps/desktop/src/components/ui/badge.tsx`.
2. Added `TaskToolbarCountBadge` for the task toolbar count style: small, rounded, muted, and tabular.
3. Updated the Schedule, Convert to bullet, and Archive toolbar buttons to render counts as badges while keeping explicit accessible labels like `Schedule 2`.
4. Updated the Tasks screen tests to assert the new accessible names.

## Verification
- `pnpm test --run src/components/tasks/tasks-screen.test.tsx` from `apps/desktop` passed.
- `pnpm check` passed; it reported only pre-existing warnings in unrelated files.
- `pnpm build` passed; Vite reported the existing chunk-size warning.

## Risk / Rollout
Low risk. This is a visual/accessibility adjustment in the Tasks toolbar only, with no data migrations or background behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tasks toolbar presentation and accessibility only; no task data or action behavior changes.
> 
> **Overview**
> Task toolbar counts move from parenthesized label text (e.g. `Schedule (2)`) to a **compact muted badge** beside the action label, so the number reads as a status indicator rather than part of the button copy.
> 
> Adds a local shadcn **`Badge`** primitive and **`TaskToolbarCountBadge`** for the toolbar styling. **Schedule**, **Convert to bullet**, and **Archive** buttons now render the label plus the badge; **`aria-label`** values carry the count (e.g. `Schedule 2`) for assistive tech. **`tasks-screen.test.tsx`** assertions were updated to match those accessible names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1a67d5e887268581e3a6c5668726c52f8920526. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compact neutral outline count badges to the tasks toolbar (Schedule, Convert to bullet, and Archive) to make selection counts quicker to scan.
  * Updated the buttons’ accessibility text to include the current counts.
  * Introduced a reusable Badge UI component for consistent badge styling.

* **Tests**
  * Updated tasks screen assertions to match the revised toolbar label formatting for count displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->