### PR TITLE
Suggest iCloud Drive during onboarding

### DIFF
--- a/apps/desktop/src/components/graph-chooser.test.tsx
+++ b/apps/desktop/src/components/graph-chooser.test.tsx
@@ -75,6 +75,7 @@ describe('GraphChooser', () => {
       expect(screen.getByRole('heading', { name: 'New to Reflect' })).toBeInTheDocument(),
     )
     expect(screen.getByRole('button', { name: /Choose a folder/ })).toBeInTheDocument()
+    expect(screen.getByText(/choose a folder in iCloud Drive/)).toBeInTheDocument()
 
     // The V1 path keeps the export → unzip → open guidance, now as numbered steps.
     expect(screen.getByRole('heading', { name: 'Coming from Reflect v1' })).toBeInTheDocument()

--- a/apps/desktop/src/components/graph-chooser.test.tsx
+++ b/apps/desktop/src/components/graph-chooser.test.tsx
@@ -26,6 +26,7 @@ const wrapper = ({ children }: { children: ReactNode }) => (
 )
 
 beforeEach(() => {
+  vi.stubEnv('TAURI_ENV_PLATFORM', 'darwin')
   invokeLog = []
   recents = [
     { root: '/graphs/work', name: 'work', openedMs: 2 },
@@ -63,6 +64,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup() // `globals: false` disables testing-library's automatic cleanup
+  vi.unstubAllEnvs()
   setBridge(null)
   queryClient.clear()
 })
@@ -82,6 +84,16 @@ describe('GraphChooser', () => {
     expect(screen.getByText(/Settings → Graph → Export/)).toBeInTheDocument()
     expect(screen.getByText(/Unzip the file and move the folder/)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Open exported folder/ })).toBeInTheDocument()
+  })
+
+  it('hides the iCloud Drive tip outside macOS builds', async () => {
+    vi.stubEnv('TAURI_ENV_PLATFORM', 'windows')
+    render(<GraphChooser />, { wrapper })
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'New to Reflect' })).toBeInTheDocument(),
+    )
+    expect(screen.queryByText(/choose a folder in iCloud Drive/)).not.toBeInTheDocument()
   })
 
   // The provider auto-opens the most recent graph on mount, so the chooser's

--- a/apps/desktop/src/components/graph-chooser.tsx
+++ b/apps/desktop/src/components/graph-chooser.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement, type ReactNode } from 'react'
-import { Folder, FolderInput, FolderPlus } from 'lucide-react'
+import { Folder, FolderInput, FolderPlus, Lightbulb } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useGraphColors } from '@/hooks/use-graph-colors'
 import { graphColorCss } from '@/lib/graph-colors'
@@ -104,6 +104,14 @@ export function GraphChooser(): ReactElement {
               Open exported folder…
             </Button>
           </section>
+        </div>
+
+        <div className="mx-auto flex max-w-xl gap-2.5 text-sm leading-5 text-text-secondary">
+          <Lightbulb aria-hidden className="mt-0.5 size-4 shrink-0 text-text-muted" />
+          <p>
+            <span className="font-medium text-text">Tip:</span> choose a folder in iCloud Drive if
+            you want your notes backed up automatically.
+          </p>
         </div>
 
         {error ? (

--- a/apps/desktop/src/components/graph-chooser.tsx
+++ b/apps/desktop/src/components/graph-chooser.tsx
@@ -27,6 +27,10 @@ function Emphasis({ children }: { children: ReactNode }): ReactElement {
   return <span className="font-medium text-text">{children}</span>
 }
 
+function shouldShowIcloudDriveTip(): boolean {
+  return import.meta.env.TAURI_ENV_PLATFORM === 'darwin'
+}
+
 /**
  * First-run / no-graph screen. Splits the two audiences the old single button
  * blurred together — people new to Reflect (pick a folder, start fresh) and
@@ -43,6 +47,7 @@ function Emphasis({ children }: { children: ReactNode }): ReactElement {
 export function GraphChooser(): ReactElement {
   const { recents, error, pickAndOpen, openRecent, forget } = useGraph()
   const { colorFor } = useGraphColors()
+  const showIcloudDriveTip = shouldShowIcloudDriveTip()
 
   return (
     <div className="flex h-screen w-screen overflow-auto bg-surface-app p-8">
@@ -106,13 +111,15 @@ export function GraphChooser(): ReactElement {
           </section>
         </div>
 
-        <div className="mx-auto flex max-w-xl gap-2.5 text-sm leading-5 text-text-secondary">
-          <Lightbulb aria-hidden className="mt-0.5 size-4 shrink-0 text-text-muted" />
-          <p>
-            <span className="font-medium text-text">Tip:</span> choose a folder in iCloud Drive if
-            you want your notes backed up automatically.
-          </p>
-        </div>
+        {showIcloudDriveTip ? (
+          <div className="mx-auto flex max-w-xl gap-2.5 text-sm leading-5 text-text-secondary">
+            <Lightbulb aria-hidden className="mt-0.5 size-4 shrink-0 text-text-muted" />
+            <p>
+              <span className="font-medium text-text">Tip:</span> choose a folder in iCloud Drive
+              if you want your notes backed up automatically.
+            </p>
+          </div>
+        ) : null}
 
         {error ? (
           <p role="alert" className="text-center text-sm text-destructive">


### PR DESCRIPTION
## Problem

The first-run folder picker tells people to choose a folder, but it does not nudge them toward a location that gives them automatic backups. Since Reflect stores notes as regular files, choosing iCloud Drive is a useful default for macOS users who want their notes backed up without configuring Git first. The tip is macOS-only so Windows and Linux users do not see platform-specific guidance.

## Before -> After

| Before | After |
| --- | --- |
| Onboarding only said to pick a folder on the computer. | macOS onboarding includes a small tip suggesting iCloud Drive for automatic note backups. |

## Changes

1. Adds a lightweight macOS-only tip below the two folder-selection paths in `GraphChooser`.
2. Uses `TAURI_ENV_PLATFORM` to avoid showing iCloud-specific copy on Windows or Linux builds.
3. Uses a `Lightbulb` icon from `lucide-react` to keep the note visually quiet but scannable.
4. Adds test coverage so the iCloud Drive backup tip appears on macOS and stays hidden elsewhere.

## Tests

- `GraphChooser` coverage now asserts that the iCloud Drive tip renders on macOS builds and stays hidden on non-macOS builds.

## Verification

- `pnpm --filter @reflect/desktop test -- src/components/graph-chooser.test.tsx` passed after the macOS-only update; Vitest ran the desktop suite: 123 files / 1081 tests.
- `pnpm check` passed with existing warnings only.
- `git diff --check` passed.

## Risk / Rollout

Low risk: this is copy and layout only on the no-graph onboarding screen, gated to macOS builds. It does not change folder-picker behavior or storage semantics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and conditional UI on the no-graph onboarding screen only; folder picker behavior and storage are unchanged.
> 
> **Overview**
> Adds a **macOS-only** onboarding tip on the first-run `GraphChooser` screen, below the “New to Reflect” and V1 migration sections, suggesting users pick a folder in **iCloud Drive** for automatic backups. The tip uses a `Lightbulb` icon and is gated by `shouldShowIcloudDriveTip()` (`import.meta.env.TAURI_ENV_PLATFORM === 'darwin'`).
> 
> Tests stub `TAURI_ENV_PLATFORM` as `darwin` by default, assert the tip copy is present in the existing new-user flow test, and add a case that stubs `windows` and expects the tip **not** to render. `afterEach` now calls `vi.unstubAllEnvs()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31f4a80246963796536ceb5c06d8fa05403d7935. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the first-run onboarding screen with an iCloud Drive tip explaining how to choose an iCloud folder for automatic backup (shown only on macOS).
* **Bug Fixes**
  * Prevented the iCloud Drive tip from appearing on non-macOS platforms.
* **Tests**
  * Added/updated platform-stubbing coverage to verify the iCloud tip is present in the “New to Reflect” flow on macOS and hidden on Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->