### PR TITLE
Support opening graph folders from Dock drops

### DIFF
--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -5,6 +5,21 @@
      release builds. -->
 <plist version="1.0">
 <dict>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Reflect Graph Folder</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.folder</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Reflect uses the microphone to record audio memos that are transcribed into your daily note.</string>
 </dict>

--- a/apps/desktop/src-tauri/src/graph_open_request.rs
+++ b/apps/desktop/src-tauri/src/graph_open_request.rs
@@ -9,7 +9,6 @@ use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
-use serde::Serialize;
 use tauri::{AppHandle, Emitter, State, Url};
 
 /// Event emitted when at least one graph-open request is waiting in Rust.
@@ -19,12 +18,6 @@ pub const GRAPH_OPEN_REQUESTED_EVENT: &str = "graph:open-requested";
 #[derive(Default)]
 pub struct GraphOpenRequestState(Mutex<VecDeque<String>>);
 
-#[derive(Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct GraphOpenRequestedPayload {
-    queued: usize,
-}
-
 /// Queue a graph-open request from native "open document" URLs.
 ///
 /// Exactly one item must be present and it must be a folder. Multi-item drops
@@ -32,20 +25,16 @@ struct GraphOpenRequestedPayload {
 pub fn queue_opened_urls(app: &AppHandle, state: &State<GraphOpenRequestState>, urls: &[Url]) {
     match folder_path_from_urls(urls) {
         Ok(Some(path)) => {
-            let queued = match state.0.lock() {
+            match state.0.lock() {
                 Ok(mut pending) => {
                     pending.push_back(path.to_string_lossy().into_owned());
-                    pending.len()
                 }
                 Err(err) => {
                     tracing::error!(?err, "graph open request queue lock poisoned");
                     return;
                 }
             };
-            let _ = app.emit(
-                GRAPH_OPEN_REQUESTED_EVENT,
-                GraphOpenRequestedPayload { queued },
-            );
+            let _ = app.emit(GRAPH_OPEN_REQUESTED_EVENT, ());
         }
         Ok(None) => {}
         Err(message) => tracing::warn!(%message, "ignored graph open request"),

--- a/apps/desktop/src-tauri/src/graph_open_request.rs
+++ b/apps/desktop/src-tauri/src/graph_open_request.rs
@@ -1,0 +1,135 @@
+//! App-open requests for graph folders.
+//!
+//! On macOS, dragging an item onto the Dock icon arrives as a Tauri
+//! `RunEvent::Opened`. The frontend owns the graph-open lifecycle, so Rust only
+//! validates the native payload, queues exactly one directory per open event,
+//! and nudges the webview to drain the queue.
+
+use std::collections::VecDeque;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, State, Url};
+
+/// Event emitted when at least one graph-open request is waiting in Rust.
+pub const GRAPH_OPEN_REQUESTED_EVENT: &str = "graph:open-requested";
+
+/// Pending graph-open requests not yet consumed by the frontend.
+#[derive(Default)]
+pub struct GraphOpenRequestState(Mutex<VecDeque<String>>);
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GraphOpenRequestedPayload {
+    queued: usize,
+}
+
+/// Queue a graph-open request from native "open document" URLs.
+///
+/// Exactly one item must be present and it must be a folder. Multi-item drops
+/// and files are ignored so a Dock drop cannot ambiguously switch graphs.
+pub fn queue_opened_urls(app: &AppHandle, state: &State<GraphOpenRequestState>, urls: &[Url]) {
+    match folder_path_from_urls(urls) {
+        Ok(Some(path)) => {
+            let queued = match state.0.lock() {
+                Ok(mut pending) => {
+                    pending.push_back(path.to_string_lossy().into_owned());
+                    pending.len()
+                }
+                Err(err) => {
+                    tracing::error!(?err, "graph open request queue lock poisoned");
+                    return;
+                }
+            };
+            let _ = app.emit(
+                GRAPH_OPEN_REQUESTED_EVENT,
+                GraphOpenRequestedPayload { queued },
+            );
+        }
+        Ok(None) => {}
+        Err(message) => tracing::warn!(%message, "ignored graph open request"),
+    }
+}
+
+fn folder_path_from_urls(urls: &[Url]) -> Result<Option<PathBuf>, String> {
+    if urls.is_empty() {
+        return Ok(None);
+    }
+    if urls.len() != 1 {
+        return Err(format!(
+            "expected exactly one folder, received {} items",
+            urls.len()
+        ));
+    }
+
+    let url = &urls[0];
+    if url.scheme() != "file" {
+        return Err(format!("expected a file URL, received {}", url.scheme()));
+    }
+
+    let path = url
+        .to_file_path()
+        .map_err(|_| "could not convert file URL to a path".to_string())?;
+    if !path.is_dir() {
+        return Err(format!("not a directory: {}", path.display()));
+    }
+    Ok(Some(path))
+}
+
+/// Pop the oldest queued graph-open request.
+#[tauri::command]
+pub fn graph_open_request_take(state: State<GraphOpenRequestState>) -> Option<String> {
+    match state.0.lock() {
+        Ok(mut pending) => pending.pop_front(),
+        Err(err) => {
+            tracing::error!(?err, "graph open request queue lock poisoned");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::folder_path_from_urls;
+    use tauri::Url;
+    use tempfile::tempdir;
+
+    #[test]
+    fn accepts_exactly_one_directory() {
+        let dir = tempdir().expect("tempdir");
+        let url = Url::from_directory_path(dir.path()).expect("directory url");
+
+        let path = folder_path_from_urls(&[url])
+            .expect("valid request")
+            .expect("path");
+
+        assert_eq!(path, dir.path());
+    }
+
+    #[test]
+    fn rejects_multiple_items() {
+        let first = tempdir().expect("first tempdir");
+        let second = tempdir().expect("second tempdir");
+        let urls = [
+            Url::from_directory_path(first.path()).expect("first url"),
+            Url::from_directory_path(second.path()).expect("second url"),
+        ];
+
+        let error = folder_path_from_urls(&urls).expect_err("multiple items should fail");
+
+        assert!(error.contains("expected exactly one folder"));
+    }
+
+    #[test]
+    fn rejects_files() {
+        let dir = tempdir().expect("tempdir");
+        let file = dir.path().join("note.md");
+        std::fs::write(&file, "").expect("write file");
+        let url = Url::from_file_path(&file).expect("file url");
+
+        let error = folder_path_from_urls(&[url]).expect_err("file should fail");
+
+        assert!(error.contains("not a directory"));
+    }
+}

--- a/apps/desktop/src-tauri/src/graph_open_request.rs
+++ b/apps/desktop/src-tauri/src/graph_open_request.rs
@@ -6,65 +6,121 @@
 //! and nudges the webview to drain the queue.
 
 use std::collections::VecDeque;
-use std::path::PathBuf;
 use std::sync::Mutex;
 
-use tauri::{AppHandle, Emitter, State, Url};
-
-/// Event emitted when at least one graph-open request is waiting in Rust.
-pub const GRAPH_OPEN_REQUESTED_EVENT: &str = "graph:open-requested";
+use tauri::State;
 
 /// Pending graph-open requests not yet consumed by the frontend.
 #[derive(Default)]
 pub struct GraphOpenRequestState(Mutex<VecDeque<String>>);
 
-/// Queue a graph-open request from native "open document" URLs.
-///
-/// Exactly one item must be present and it must be a folder. Multi-item drops
-/// and files are ignored so a Dock drop cannot ambiguously switch graphs.
-pub fn queue_opened_urls(app: &AppHandle, state: &State<GraphOpenRequestState>, urls: &[Url]) {
-    match folder_path_from_urls(urls) {
-        Ok(Some(path)) => {
-            match state.0.lock() {
-                Ok(mut pending) => {
-                    pending.push_back(path.to_string_lossy().into_owned());
-                }
-                Err(err) => {
-                    tracing::error!(?err, "graph open request queue lock poisoned");
-                    return;
-                }
-            };
-            let _ = app.emit(GRAPH_OPEN_REQUESTED_EVENT, ());
+#[cfg(target_os = "macos")]
+mod macos {
+    use std::path::PathBuf;
+
+    use tauri::{AppHandle, Emitter, State, Url};
+
+    use super::GraphOpenRequestState;
+
+    /// Event emitted when at least one graph-open request is waiting in Rust.
+    const GRAPH_OPEN_REQUESTED_EVENT: &str = "graph:open-requested";
+
+    /// Queue a graph-open request from native "open document" URLs.
+    ///
+    /// Exactly one item must be present and it must be a folder. Multi-item drops
+    /// and files are ignored so a Dock drop cannot ambiguously switch graphs.
+    pub fn queue_opened_urls(app: &AppHandle, state: &State<GraphOpenRequestState>, urls: &[Url]) {
+        match folder_path_from_urls(urls) {
+            Ok(Some(path)) => {
+                match state.0.lock() {
+                    Ok(mut pending) => {
+                        pending.push_back(path.to_string_lossy().into_owned());
+                    }
+                    Err(err) => {
+                        tracing::error!(?err, "graph open request queue lock poisoned");
+                        return;
+                    }
+                };
+                let _ = app.emit(GRAPH_OPEN_REQUESTED_EVENT, ());
+            }
+            Ok(None) => {}
+            Err(message) => tracing::warn!(%message, "ignored graph open request"),
         }
-        Ok(None) => {}
-        Err(message) => tracing::warn!(%message, "ignored graph open request"),
+    }
+
+    fn folder_path_from_urls(urls: &[Url]) -> Result<Option<PathBuf>, String> {
+        if urls.is_empty() {
+            return Ok(None);
+        }
+        if urls.len() != 1 {
+            return Err(format!(
+                "expected exactly one folder, received {} items",
+                urls.len()
+            ));
+        }
+
+        let url = &urls[0];
+        if url.scheme() != "file" {
+            return Err(format!("expected a file URL, received {}", url.scheme()));
+        }
+
+        let path = url
+            .to_file_path()
+            .map_err(|_| "could not convert file URL to a path".to_string())?;
+        if !path.is_dir() {
+            return Err(format!("not a directory: {}", path.display()));
+        }
+        Ok(Some(path))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::folder_path_from_urls;
+        use tauri::Url;
+        use tempfile::tempdir;
+
+        #[test]
+        fn accepts_exactly_one_directory() {
+            let dir = tempdir().expect("tempdir");
+            let url = Url::from_directory_path(dir.path()).expect("directory url");
+
+            let path = folder_path_from_urls(&[url])
+                .expect("valid request")
+                .expect("path");
+
+            assert_eq!(path, dir.path());
+        }
+
+        #[test]
+        fn rejects_multiple_items() {
+            let first = tempdir().expect("first tempdir");
+            let second = tempdir().expect("second tempdir");
+            let urls = [
+                Url::from_directory_path(first.path()).expect("first url"),
+                Url::from_directory_path(second.path()).expect("second url"),
+            ];
+
+            let error = folder_path_from_urls(&urls).expect_err("multiple items should fail");
+
+            assert!(error.contains("expected exactly one folder"));
+        }
+
+        #[test]
+        fn rejects_files() {
+            let dir = tempdir().expect("tempdir");
+            let file = dir.path().join("note.md");
+            std::fs::write(&file, "").expect("write file");
+            let url = Url::from_file_path(&file).expect("file url");
+
+            let error = folder_path_from_urls(&[url]).expect_err("file should fail");
+
+            assert!(error.contains("not a directory"));
+        }
     }
 }
 
-fn folder_path_from_urls(urls: &[Url]) -> Result<Option<PathBuf>, String> {
-    if urls.is_empty() {
-        return Ok(None);
-    }
-    if urls.len() != 1 {
-        return Err(format!(
-            "expected exactly one folder, received {} items",
-            urls.len()
-        ));
-    }
-
-    let url = &urls[0];
-    if url.scheme() != "file" {
-        return Err(format!("expected a file URL, received {}", url.scheme()));
-    }
-
-    let path = url
-        .to_file_path()
-        .map_err(|_| "could not convert file URL to a path".to_string())?;
-    if !path.is_dir() {
-        return Err(format!("not a directory: {}", path.display()));
-    }
-    Ok(Some(path))
-}
+#[cfg(target_os = "macos")]
+pub use macos::queue_opened_urls;
 
 /// Pop the oldest queued graph-open request.
 #[tauri::command]
@@ -75,50 +131,5 @@ pub fn graph_open_request_take(state: State<GraphOpenRequestState>) -> Option<St
             tracing::error!(?err, "graph open request queue lock poisoned");
             None
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::folder_path_from_urls;
-    use tauri::Url;
-    use tempfile::tempdir;
-
-    #[test]
-    fn accepts_exactly_one_directory() {
-        let dir = tempdir().expect("tempdir");
-        let url = Url::from_directory_path(dir.path()).expect("directory url");
-
-        let path = folder_path_from_urls(&[url])
-            .expect("valid request")
-            .expect("path");
-
-        assert_eq!(path, dir.path());
-    }
-
-    #[test]
-    fn rejects_multiple_items() {
-        let first = tempdir().expect("first tempdir");
-        let second = tempdir().expect("second tempdir");
-        let urls = [
-            Url::from_directory_path(first.path()).expect("first url"),
-            Url::from_directory_path(second.path()).expect("second url"),
-        ];
-
-        let error = folder_path_from_urls(&urls).expect_err("multiple items should fail");
-
-        assert!(error.contains("expected exactly one folder"));
-    }
-
-    #[test]
-    fn rejects_files() {
-        let dir = tempdir().expect("tempdir");
-        let file = dir.path().join("note.md");
-        std::fs::write(&file, "").expect("write file");
-        let url = Url::from_file_path(&file).expect("file url");
-
-        let error = folder_path_from_urls(&[url]).expect_err("file should fail");
-
-        assert!(error.contains("not a directory"));
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ mod error;
 mod fs;
 mod git;
 mod graph_gitignore;
+mod graph_open_request;
 mod quit;
 mod recents;
 mod secrets;
@@ -141,6 +142,7 @@ pub fn run() {
 
     builder
         .manage(fs::GraphState::default())
+        .manage(graph_open_request::GraphOpenRequestState::default())
         .manage(db::IndexState::default())
         .manage(watcher::WatcherState::default())
         .manage(quit::QuitState::default())
@@ -151,6 +153,7 @@ pub fn run() {
             mobile_graph_root,
             fs::graph_open,
             fs::graph_create,
+            graph_open_request::graph_open_request_take,
             fs::note_read,
             fs::note_write,
             fs::asset_write,
@@ -206,6 +209,11 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(|app, event| {
+            #[cfg(target_os = "macos")]
+            if let tauri::RunEvent::Opened { urls } = &event {
+                let state = app.state::<graph_open_request::GraphOpenRequestState>();
+                graph_open_request::queue_opened_urls(app, &state, urls);
+            }
             if let tauri::RunEvent::ExitRequested { code, api, .. } = &event {
                 // A user/OS-initiated quit (⌘Q — no exit code) with a live
                 // webview defers once so the frontend can flush dirty note

--- a/apps/desktop/src-tauri/tauri.macos.conf.json
+++ b/apps/desktop/src-tauri/tauri.macos.conf.json
@@ -5,15 +5,6 @@
       "binaries/reflect",
       "binaries/reflect-capture-host"
     ],
-    "fileAssociations": [
-      {
-        "ext": [],
-        "contentTypes": ["public.folder"],
-        "name": "Reflect Graph Folder",
-        "role": "Editor",
-        "rank": "None"
-      }
-    ],
     "macOS": {
       "entitlements": "Entitlements.plist"
     }

--- a/apps/desktop/src-tauri/tauri.macos.conf.json
+++ b/apps/desktop/src-tauri/tauri.macos.conf.json
@@ -5,6 +5,15 @@
       "binaries/reflect",
       "binaries/reflect-capture-host"
     ],
+    "fileAssociations": [
+      {
+        "ext": [],
+        "contentTypes": ["public.folder"],
+        "name": "Reflect Graph Folder",
+        "role": "Editor",
+        "rank": "None"
+      }
+    ],
     "macOS": {
       "entitlements": "Entitlements.plist"
     }

--- a/apps/desktop/src/providers/graph-provider.test.tsx
+++ b/apps/desktop/src/providers/graph-provider.test.tsx
@@ -30,6 +30,8 @@ let settingsStore: Record<string, unknown>
 /** Queued native graph-open requests, as if received from a Dock drop. */
 let queuedGraphOpenRequests: string[]
 let graphOpenRequestHandlers: Set<(payload: unknown) => void>
+let deferGraphOpenListener: boolean
+let resolveGraphOpenListener: (() => void) | null
 /** A fresh QueryClient per test — the settings provider reads through it. */
 let queryClient: QueryClient
 
@@ -46,6 +48,8 @@ function installFakeBridge(): void {
   settingsStore = {}
   queuedGraphOpenRequests = []
   graphOpenRequestHandlers = new Set()
+  deferGraphOpenListener = false
+  resolveGraphOpenListener = null
   let generation = 0
   setBridge({
     invoke: async (command, args) => {
@@ -98,6 +102,16 @@ function installFakeBridge(): void {
     },
     listen: async (event, handler) => {
       if (event === 'graph:open-requested') {
+        if (deferGraphOpenListener) {
+          return await new Promise<() => void>((resolve) => {
+            resolveGraphOpenListener = () => {
+              graphOpenRequestHandlers.add(handler)
+              resolve(() => {
+                graphOpenRequestHandlers.delete(handler)
+              })
+            }
+          })
+        }
         graphOpenRequestHandlers.add(handler)
         return () => {
           graphOpenRequestHandlers.delete(handler)
@@ -245,6 +259,25 @@ describe('GraphProvider open sequencing', () => {
 
     await waitFor(() => expect(result.current.status).toBe('ready'))
     expect(result.current.graph?.root).toBe('/live-drop')
+  })
+
+  it('drains a queued native folder once the Dock listener is ready', async () => {
+    deferGraphOpenListener = true
+    storedRecents = [{ root: '/recent', name: 'recent', openedMs: 1 }]
+    const { result } = renderHook(() => useGraph(), { wrapper })
+
+    await waitFor(() => expect(pendingOpens.has('/recent')).toBe(true))
+    queueGraphOpenRequest('/dropped-before-listener-ready')
+
+    await act(async () => {
+      resolveGraphOpenListener?.()
+      resolveOpen('/recent')
+      await waitFor(() => expect(pendingOpens.has('/dropped-before-listener-ready')).toBe(true))
+      resolveOpen('/dropped-before-listener-ready')
+    })
+
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    expect(result.current.graph?.root).toBe('/dropped-before-listener-ready')
   })
 })
 

--- a/apps/desktop/src/providers/graph-provider.test.tsx
+++ b/apps/desktop/src/providers/graph-provider.test.tsx
@@ -111,7 +111,7 @@ function installFakeBridge(): void {
 function queueGraphOpenRequest(root: string): void {
   queuedGraphOpenRequests.push(root)
   for (const handler of graphOpenRequestHandlers) {
-    handler({ queued: queuedGraphOpenRequests.length })
+    handler(null)
   }
 }
 

--- a/apps/desktop/src/providers/graph-provider.test.tsx
+++ b/apps/desktop/src/providers/graph-provider.test.tsx
@@ -27,6 +27,9 @@ let storedFiles: Array<{ path: string; size: number; modifiedMs: number }>
 let metaStore: Record<string, string>
 /** The fake settings document (`mobileOnboarded` lives here). */
 let settingsStore: Record<string, unknown>
+/** Queued native graph-open requests, as if received from a Dock drop. */
+let queuedGraphOpenRequests: string[]
+let graphOpenRequestHandlers: Set<(payload: unknown) => void>
 /** A fresh QueryClient per test — the settings provider reads through it. */
 let queryClient: QueryClient
 
@@ -41,6 +44,8 @@ function installFakeBridge(): void {
   storedFiles = []
   metaStore = {}
   settingsStore = {}
+  queuedGraphOpenRequests = []
+  graphOpenRequestHandlers = new Set()
   let generation = 0
   setBridge({
     invoke: async (command, args) => {
@@ -57,6 +62,8 @@ function installFakeBridge(): void {
           generation += 1
           return { root, name: root.slice(1), cloudSync: null, generation }
         }
+        case 'graph_open_request_take':
+          return queuedGraphOpenRequests.shift() ?? null
         case 'recent_graphs':
           return storedRecents
         case 'forget_recent':
@@ -89,8 +96,23 @@ function installFakeBridge(): void {
           return null
       }
     },
-    listen: async () => () => {},
+    listen: async (event, handler) => {
+      if (event === 'graph:open-requested') {
+        graphOpenRequestHandlers.add(handler)
+        return () => {
+          graphOpenRequestHandlers.delete(handler)
+        }
+      }
+      return () => {}
+    },
   })
+}
+
+function queueGraphOpenRequest(root: string): void {
+  queuedGraphOpenRequests.push(root)
+  for (const handler of graphOpenRequestHandlers) {
+    handler({ queued: queuedGraphOpenRequests.length })
+  }
 }
 
 function resolveOpen(root: string): void {
@@ -190,6 +212,39 @@ describe('GraphProvider open sequencing', () => {
     expect(result.current.graph).toBeNull()
     expect(result.current.indexGeneration).toBeNull()
     expect(result.current.recents).toEqual([])
+  })
+
+  it('opens a queued native folder request instead of the most recent graph on launch', async () => {
+    storedRecents = [{ root: '/recent', name: 'recent', openedMs: 1 }]
+    queueGraphOpenRequest('/dropped')
+
+    const { result } = renderHook(() => useGraph(), { wrapper })
+
+    await act(async () => {
+      await waitFor(() => expect(pendingOpens.has('/dropped')).toBe(true))
+      resolveOpen('/dropped')
+    })
+
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    expect(result.current.graph?.root).toBe('/dropped')
+    expect(invokeLog).not.toContain('graph_open:/recent')
+  })
+
+  it('opens a native folder request while the app is running', async () => {
+    const { result } = renderHook(() => useGraph(), { wrapper })
+    await waitFor(() => expect(result.current.status).toBe('choosing'))
+
+    act(() => {
+      queueGraphOpenRequest('/live-drop')
+    })
+
+    await act(async () => {
+      await waitFor(() => expect(pendingOpens.has('/live-drop')).toBe(true))
+      resolveOpen('/live-drop')
+    })
+
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    expect(result.current.graph?.root).toBe('/live-drop')
   })
 })
 

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -18,8 +18,6 @@ import {
   mobileGraphRoot,
   openGraph,
   recentGraphs,
-  subscribeGraphOpenRequested,
-  takeGraphOpenRequest,
   type AppPlatform,
   type GraphInfo,
   type RecentGraph,
@@ -30,6 +28,7 @@ import { invalidateIndexQueries } from '@/lib/query-client'
 import { ensureWelcomeNote } from '@/lib/welcome-note'
 import { useSettings } from '@/providers/settings-provider'
 import { createGraphIndex } from './graph-index'
+import { useDockGraphOpenRequests } from './use-dock-graph-open-requests'
 
 /** Lifecycle of the active graph (Plan 02 loading gate). */
 export type GraphStatus = 'loading' | 'choosing' | 'opening' | 'ready'
@@ -232,21 +231,7 @@ export function GraphProvider({
     [loadRecents],
   )
 
-  const drainGraphOpenRequests = useCallback(async (): Promise<boolean> => {
-    if (!hasBridge() || isMobilePlatform(platform)) {
-      return false
-    }
-
-    let opened = false
-    for (;;) {
-      const root = await takeGraphOpenRequest()
-      if (root === null) {
-        return opened
-      }
-      opened = true
-      await openRecent(root)
-    }
-  }, [openRecent, platform])
+  const drainDockGraphOpenRequests = useDockGraphOpenRequests({ platform, openRecent })
 
   useEffect(() => {
     let active = true
@@ -286,7 +271,7 @@ export function GraphProvider({
       if (!active) {
         return
       }
-      if (await drainGraphOpenRequests()) {
+      if (await drainDockGraphOpenRequests()) {
         return
       }
       if (list.length > 0) {
@@ -298,36 +283,7 @@ export function GraphProvider({
     return () => {
       active = false
     }
-  }, [drainGraphOpenRequests, loadRecents, openRecent, platform])
-
-  useEffect(() => {
-    if (!hasBridge() || isMobilePlatform(platform)) {
-      return
-    }
-
-    let active = true
-    let unlisten: (() => void) | null = null
-    void subscribeGraphOpenRequested(() => {
-      if (active) {
-        void drainGraphOpenRequests()
-      }
-    })
-      .then((unsubscribe) => {
-        if (active) {
-          unlisten = unsubscribe
-        } else {
-          unsubscribe()
-        }
-      })
-      .catch((err: unknown) => {
-        console.error('graph open request subscription failed:', errorMessage(err))
-      })
-
-    return () => {
-      active = false
-      unlisten?.()
-    }
-  }, [drainGraphOpenRequests, platform])
+  }, [drainDockGraphOpenRequests, loadRecents, openRecent, platform])
 
   const pickAndOpen = useCallback(async (): Promise<void> => {
     let selected: string | null = null

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -231,7 +231,11 @@ export function GraphProvider({
     [loadRecents],
   )
 
-  const drainDockGraphOpenRequests = useDockGraphOpenRequests({ platform, openRecent })
+  const { drainDockGraphOpenRequests, hasOpenedDockGraphOpenRequest } =
+    useDockGraphOpenRequests({
+      platform,
+      openRecent,
+    })
 
   useEffect(() => {
     let active = true
@@ -271,7 +275,7 @@ export function GraphProvider({
       if (!active) {
         return
       }
-      if (await drainDockGraphOpenRequests()) {
+      if ((await drainDockGraphOpenRequests()) || hasOpenedDockGraphOpenRequest()) {
         return
       }
       if (list.length > 0) {
@@ -283,7 +287,13 @@ export function GraphProvider({
     return () => {
       active = false
     }
-  }, [drainDockGraphOpenRequests, loadRecents, openRecent, platform])
+  }, [
+    drainDockGraphOpenRequests,
+    hasOpenedDockGraphOpenRequest,
+    loadRecents,
+    openRecent,
+    platform,
+  ])
 
   const pickAndOpen = useCallback(async (): Promise<void> => {
     let selected: string | null = null

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -231,11 +231,7 @@ export function GraphProvider({
     [loadRecents],
   )
 
-  const { drainDockGraphOpenRequests, hasOpenedDockGraphOpenRequest } =
-    useDockGraphOpenRequests({
-      platform,
-      openRecent,
-    })
+  const drainDockGraphOpenRequests = useDockGraphOpenRequests({ platform, openRecent })
 
   useEffect(() => {
     let active = true
@@ -275,7 +271,7 @@ export function GraphProvider({
       if (!active) {
         return
       }
-      if ((await drainDockGraphOpenRequests()) || hasOpenedDockGraphOpenRequest()) {
+      if (await drainDockGraphOpenRequests({ includeAlreadyOpened: true })) {
         return
       }
       if (list.length > 0) {
@@ -287,13 +283,7 @@ export function GraphProvider({
     return () => {
       active = false
     }
-  }, [
-    drainDockGraphOpenRequests,
-    hasOpenedDockGraphOpenRequest,
-    loadRecents,
-    openRecent,
-    platform,
-  ])
+  }, [drainDockGraphOpenRequests, loadRecents, openRecent, platform])
 
   const pickAndOpen = useCallback(async (): Promise<void> => {
     let selected: string | null = null

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -18,6 +18,8 @@ import {
   mobileGraphRoot,
   openGraph,
   recentGraphs,
+  subscribeGraphOpenRequested,
+  takeGraphOpenRequest,
   type AppPlatform,
   type GraphInfo,
   type RecentGraph,
@@ -230,6 +232,22 @@ export function GraphProvider({
     [loadRecents],
   )
 
+  const drainGraphOpenRequests = useCallback(async (): Promise<boolean> => {
+    if (!hasBridge() || isMobilePlatform(platform)) {
+      return false
+    }
+
+    let opened = false
+    for (;;) {
+      const root = await takeGraphOpenRequest()
+      if (root === null) {
+        return opened
+      }
+      opened = true
+      await openRecent(root)
+    }
+  }, [openRecent, platform])
+
   useEffect(() => {
     let active = true
     void (async () => {
@@ -268,6 +286,9 @@ export function GraphProvider({
       if (!active) {
         return
       }
+      if (await drainGraphOpenRequests()) {
+        return
+      }
       if (list.length > 0) {
         await openRecent(list[0]!.root)
       } else {
@@ -277,7 +298,36 @@ export function GraphProvider({
     return () => {
       active = false
     }
-  }, [loadRecents, openRecent, platform])
+  }, [drainGraphOpenRequests, loadRecents, openRecent, platform])
+
+  useEffect(() => {
+    if (!hasBridge() || isMobilePlatform(platform)) {
+      return
+    }
+
+    let active = true
+    let unlisten: (() => void) | null = null
+    void subscribeGraphOpenRequested(() => {
+      if (active) {
+        void drainGraphOpenRequests()
+      }
+    })
+      .then((unsubscribe) => {
+        if (active) {
+          unlisten = unsubscribe
+        } else {
+          unsubscribe()
+        }
+      })
+      .catch((err: unknown) => {
+        console.error('graph open request subscription failed:', errorMessage(err))
+      })
+
+    return () => {
+      active = false
+      unlisten?.()
+    }
+  }, [drainGraphOpenRequests, platform])
 
   const pickAndOpen = useCallback(async (): Promise<void> => {
     let selected: string | null = null

--- a/apps/desktop/src/providers/use-dock-graph-open-requests.ts
+++ b/apps/desktop/src/providers/use-dock-graph-open-requests.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import {
   errorMessage,
   hasBridge,
@@ -13,6 +13,11 @@ interface DockGraphOpenRequestsOptions {
   openRecent: (root: string) => Promise<boolean>
 }
 
+interface DockGraphOpenRequests {
+  drainDockGraphOpenRequests: () => Promise<boolean>
+  hasOpenedDockGraphOpenRequest: () => boolean
+}
+
 /**
  * Drains graph folders dropped on the macOS Dock icon.
  *
@@ -24,7 +29,9 @@ interface DockGraphOpenRequestsOptions {
 export function useDockGraphOpenRequests({
   platform,
   openRecent,
-}: DockGraphOpenRequestsOptions): () => Promise<boolean> {
+}: DockGraphOpenRequestsOptions): DockGraphOpenRequests {
+  const hasOpenedDockGraphOpenRequestRef = useRef(false)
+
   const drainDockGraphOpenRequests = useCallback(async (): Promise<boolean> => {
     if (!hasBridge() || isMobilePlatform(platform)) {
       return false
@@ -37,9 +44,14 @@ export function useDockGraphOpenRequests({
         return opened
       }
       opened = true
+      hasOpenedDockGraphOpenRequestRef.current = true
       await openRecent(root)
     }
   }, [openRecent, platform])
+
+  const hasOpenedDockGraphOpenRequest = useCallback((): boolean => {
+    return hasOpenedDockGraphOpenRequestRef.current
+  }, [])
 
   useEffect(() => {
     if (!hasBridge() || isMobilePlatform(platform)) {
@@ -56,6 +68,7 @@ export function useDockGraphOpenRequests({
       .then((unsubscribe) => {
         if (active) {
           unlisten = unsubscribe
+          void drainDockGraphOpenRequests()
         } else {
           unsubscribe()
         }
@@ -70,5 +83,8 @@ export function useDockGraphOpenRequests({
     }
   }, [drainDockGraphOpenRequests, platform])
 
-  return drainDockGraphOpenRequests
+  return useMemo(
+    () => ({ drainDockGraphOpenRequests, hasOpenedDockGraphOpenRequest }),
+    [drainDockGraphOpenRequests, hasOpenedDockGraphOpenRequest],
+  )
 }

--- a/apps/desktop/src/providers/use-dock-graph-open-requests.ts
+++ b/apps/desktop/src/providers/use-dock-graph-open-requests.ts
@@ -8,7 +8,7 @@ import {
   type AppPlatform,
 } from '@reflect/core'
 
-interface PropsUseDockGraphOpenRequests {
+interface DockGraphOpenRequestsOptions {
   platform: AppPlatform
   openRecent: (root: string) => Promise<boolean>
 }
@@ -24,7 +24,7 @@ interface PropsUseDockGraphOpenRequests {
 export function useDockGraphOpenRequests({
   platform,
   openRecent,
-}: PropsUseDockGraphOpenRequests): () => Promise<boolean> {
+}: DockGraphOpenRequestsOptions): () => Promise<boolean> {
   const drainDockGraphOpenRequests = useCallback(async (): Promise<boolean> => {
     if (!hasBridge() || isMobilePlatform(platform)) {
       return false

--- a/apps/desktop/src/providers/use-dock-graph-open-requests.ts
+++ b/apps/desktop/src/providers/use-dock-graph-open-requests.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect } from 'react'
+import {
+  errorMessage,
+  hasBridge,
+  isMobilePlatform,
+  subscribeGraphOpenRequested,
+  takeGraphOpenRequest,
+  type AppPlatform,
+} from '@reflect/core'
+
+interface PropsUseDockGraphOpenRequests {
+  platform: AppPlatform
+  openRecent: (root: string) => Promise<boolean>
+}
+
+/**
+ * Drains graph folders dropped on the macOS Dock icon.
+ *
+ * Rust queues native open-document requests because they can arrive before the
+ * React tree is mounted. This hook subscribes to later Dock drops and exposes a
+ * drain function so launch bootstrap can prioritize a queued Dock folder over
+ * reopening the most recent graph.
+ */
+export function useDockGraphOpenRequests({
+  platform,
+  openRecent,
+}: PropsUseDockGraphOpenRequests): () => Promise<boolean> {
+  const drainDockGraphOpenRequests = useCallback(async (): Promise<boolean> => {
+    if (!hasBridge() || isMobilePlatform(platform)) {
+      return false
+    }
+
+    let opened = false
+    for (;;) {
+      const root = await takeGraphOpenRequest()
+      if (root === null) {
+        return opened
+      }
+      opened = true
+      await openRecent(root)
+    }
+  }, [openRecent, platform])
+
+  useEffect(() => {
+    if (!hasBridge() || isMobilePlatform(platform)) {
+      return
+    }
+
+    let active = true
+    let unlisten: (() => void) | null = null
+    void subscribeGraphOpenRequested(() => {
+      if (active) {
+        void drainDockGraphOpenRequests()
+      }
+    })
+      .then((unsubscribe) => {
+        if (active) {
+          unlisten = unsubscribe
+        } else {
+          unsubscribe()
+        }
+      })
+      .catch((err: unknown) => {
+        console.error('dock graph open request subscription failed:', errorMessage(err))
+      })
+
+    return () => {
+      active = false
+      unlisten?.()
+    }
+  }, [drainDockGraphOpenRequests, platform])
+
+  return drainDockGraphOpenRequests
+}

--- a/apps/desktop/src/providers/use-dock-graph-open-requests.ts
+++ b/apps/desktop/src/providers/use-dock-graph-open-requests.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import {
   errorMessage,
   hasBridge,
@@ -13,9 +13,8 @@ interface DockGraphOpenRequestsOptions {
   openRecent: (root: string) => Promise<boolean>
 }
 
-interface DockGraphOpenRequests {
-  drainDockGraphOpenRequests: () => Promise<boolean>
-  hasOpenedDockGraphOpenRequest: () => boolean
+interface DockGraphOpenRequestDrainOptions {
+  includeAlreadyOpened?: boolean
 }
 
 /**
@@ -29,29 +28,33 @@ interface DockGraphOpenRequests {
 export function useDockGraphOpenRequests({
   platform,
   openRecent,
-}: DockGraphOpenRequestsOptions): DockGraphOpenRequests {
+}: DockGraphOpenRequestsOptions): (
+  options?: DockGraphOpenRequestDrainOptions,
+) => Promise<boolean> {
   const hasOpenedDockGraphOpenRequestRef = useRef(false)
 
-  const drainDockGraphOpenRequests = useCallback(async (): Promise<boolean> => {
-    if (!hasBridge() || isMobilePlatform(platform)) {
-      return false
-    }
-
-    let opened = false
-    for (;;) {
-      const root = await takeGraphOpenRequest()
-      if (root === null) {
-        return opened
+  const drainDockGraphOpenRequests = useCallback(
+    async (options?: DockGraphOpenRequestDrainOptions): Promise<boolean> => {
+      if (!hasBridge() || isMobilePlatform(platform)) {
+        return false
       }
-      opened = true
-      hasOpenedDockGraphOpenRequestRef.current = true
-      await openRecent(root)
-    }
-  }, [openRecent, platform])
 
-  const hasOpenedDockGraphOpenRequest = useCallback((): boolean => {
-    return hasOpenedDockGraphOpenRequestRef.current
-  }, [])
+      let opened = false
+      for (;;) {
+        const root = await takeGraphOpenRequest()
+        if (root === null) {
+          return (
+            opened ||
+            (options?.includeAlreadyOpened === true && hasOpenedDockGraphOpenRequestRef.current)
+          )
+        }
+        opened = true
+        hasOpenedDockGraphOpenRequestRef.current = true
+        await openRecent(root)
+      }
+    },
+    [openRecent, platform],
+  )
 
   useEffect(() => {
     if (!hasBridge() || isMobilePlatform(platform)) {
@@ -83,8 +86,5 @@ export function useDockGraphOpenRequests({
     }
   }, [drainDockGraphOpenRequests, platform])
 
-  return useMemo(
-    () => ({ drainDockGraphOpenRequests, hasOpenedDockGraphOpenRequest }),
-    [drainDockGraphOpenRequests, hasOpenedDockGraphOpenRequest],
-  )
+  return drainDockGraphOpenRequests
 }

--- a/packages/core/src/graph/open-requests.ts
+++ b/packages/core/src/graph/open-requests.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+import { call } from '../ipc/invoke'
+import { getBridge, type Unlisten } from '../ipc/bridge'
+
+/** Event emitted by the native shell when a Dock/Finder graph-open request is queued. */
+export const GRAPH_OPEN_REQUESTED_EVENT = 'graph:open-requested'
+
+const graphOpenRequestedPayloadSchema = z.object({
+  queued: z.number().int().nonnegative(),
+})
+
+/** Pop the oldest native graph-open request, or `null` when none is queued. */
+export async function takeGraphOpenRequest(): Promise<string | null> {
+  return call('graph_open_request_take', {}, z.string().nullable())
+}
+
+/** Subscribe to native graph-open request notifications. */
+export function subscribeGraphOpenRequested(handler: () => void): Promise<Unlisten> {
+  return getBridge().listen(GRAPH_OPEN_REQUESTED_EVENT, (payload) => {
+    const parsed = graphOpenRequestedPayloadSchema.safeParse(payload)
+    if (parsed.success) {
+      handler()
+    } else {
+      console.error('invalid graph:open-requested payload:', parsed.error)
+    }
+  })
+}

--- a/packages/core/src/graph/open-requests.ts
+++ b/packages/core/src/graph/open-requests.ts
@@ -5,9 +5,7 @@ import { getBridge, type Unlisten } from '../ipc/bridge'
 /** Event emitted by the native shell when a Dock/Finder graph-open request is queued. */
 export const GRAPH_OPEN_REQUESTED_EVENT = 'graph:open-requested'
 
-const graphOpenRequestedPayloadSchema = z.object({
-  queued: z.number().int().nonnegative(),
-})
+const graphOpenRequestedPayloadSchema = z.null()
 
 /** Pop the oldest native graph-open request, or `null` when none is queued. */
 export async function takeGraphOpenRequest(): Promise<string | null> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -100,6 +100,11 @@ export {
   captureMetaFetch,
   promoteCaptureScreenshot,
 } from './graph/commands'
+export {
+  GRAPH_OPEN_REQUESTED_EVENT,
+  takeGraphOpenRequest,
+  subscribeGraphOpenRequested,
+} from './graph/open-requests'
 
 // User settings (config-dir JSON document; Rust persists, this layer validates)
 export {


### PR DESCRIPTION
## Summary
- Advertise macOS folder support in the app bundle so the Dock icon accepts folder drops.
- Queue native open requests only when exactly one dropped item is a directory; ignore files and multi-item drops.
- Drain queued requests through GraphProvider so cold launches and running apps use the normal graph-open lifecycle.

## Tests
- `pnpm --filter @reflect/desktop test src/providers/graph-provider.test.tsx`
- `pnpm check`
- `pnpm --filter @reflect/desktop sidecar`
- `cargo test -p reflect-open graph_open_request`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an IPC-driven “graph open request” API and event to handle native folder opens.
  * Introduced a Dock/Finder hook to drain queued folder open requests and open the corresponding root in the app.
  * Updated macOS to declare a dedicated document type for “Reflect Graph Folder.”
* **Bug Fixes**
  * Improved launch and in-app handling so queued native folder opens are processed before falling back to the most recent graph.
* **Tests**
  * Added coverage to verify queued native folder requests are prioritized and handled correctly during startup and while running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->