### PR TITLE
Release v0.4.0-beta.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4673,7 +4673,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.4.0-beta.8"
+version = "0.4.0-beta.9"
 dependencies = [
  "base64 0.22.1",
  "core-foundation 0.10.1",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.4.0-beta.8"
+version = "0.4.0-beta.9"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.4.0-beta.8",
+  "version": "0.4.0-beta.9",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.4.0-beta.9.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop app release version to **0.4.0-beta.9**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->