### PR TITLE
Append Mac download guidance to release notes

### DIFF
--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -42,6 +42,7 @@ const UPDATER_KEYCHAIN_SERVICE = 'reflect-updater'
 const APP_SPECIFIC_PASSWORD_URL = 'https://account.apple.com'
 const BETA_UPDATER_FEED_TAG = 'updater-beta'
 const STABLE_UPDATER_ENDPOINT = 'https://github.com/team-reflect/reflect-open/releases/latest/download/latest.json'
+const APPLE_SILICON_MAC_TARGET = 'aarch64-apple-darwin'
 const INTEL_MAC_TARGET = 'x86_64-apple-darwin'
 const INTEL_ONNX_RUNTIME_VERSION = '1.23.2'
 const INTEL_ONNX_RUNTIME_ARCHIVE_ROOT = `onnxruntime-osx-x86_64-${INTEL_ONNX_RUNTIME_VERSION}`
@@ -50,6 +51,8 @@ const INTEL_ONNX_RUNTIME_URL =
   `${INTEL_ONNX_RUNTIME_ARCHIVE_ROOT}.tgz`
 const ONNX_RUNTIME_DYLIB_RESOURCE = 'libonnxruntime.dylib'
 const INTEL_ONNX_RUNTIME_RESOURCE_SOURCE = `resources/onnxruntime/${ONNX_RUNTIME_DYLIB_RESOURCE}`
+const RELEASE_NOTES_FILENAME = 'release-notes.md'
+const MAC_DOWNLOAD_NOTICE_HEADING = '## Which Mac download should I choose?'
 
 /**
  * Build flavors. Each ships as a distinct app (its own productName, identifier
@@ -66,18 +69,18 @@ const FLAVOR_OVERLAYS = {
 }
 
 const MACOS_RELEASE_TARGETS = {
-  'aarch64-apple-darwin': {
+  [APPLE_SILICON_MAC_TARGET]: {
     arch: 'aarch64',
     label: 'Apple Silicon',
     platform: 'darwin-aarch64',
   },
-  'x86_64-apple-darwin': {
+  [INTEL_MAC_TARGET]: {
     arch: 'x86_64',
     label: 'Intel',
     platform: 'darwin-x86_64',
   },
 }
-const DEFAULT_PUBLISH_TARGETS = ['aarch64-apple-darwin', 'x86_64-apple-darwin']
+const DEFAULT_PUBLISH_TARGETS = [APPLE_SILICON_MAC_TARGET, INTEL_MAC_TARGET]
 
 const here = dirname(fileURLToPath(import.meta.url))
 const appDir = join(here, '..')
@@ -391,7 +394,7 @@ export function createUpdaterManifest({ artifacts, pubDate, slug, tag, version }
     // GitHub rewrites spaces in uploaded asset names to dots, so a flavor whose
     // productName has a space ("Reflect Beta") is served under a dotted name.
     // The manifest URL must match the uploaded name or auto-update gets a 404.
-    const assetName = basename(artifact.updaterArchive).replace(/ /g, '.')
+    const assetName = githubAssetName(basename(artifact.updaterArchive))
     platforms[artifact.platform] = {
       signature: readFileSync(artifact.updaterSignature, 'utf8').trim(),
       url: `https://github.com/${slug}/releases/download/${tag}/${assetName}`,
@@ -598,6 +601,10 @@ function releaseAssetName({ productName, version, target, type }) {
     default:
       fail(`unknown release asset type "${type}"`)
   }
+}
+
+function githubAssetName(fileName) {
+  return fileName.replace(/ /g, '.')
 }
 
 function exportReleaseArtifacts({ artifactDir, flavor, target }) {
@@ -838,8 +845,77 @@ function ensureTagMatchesCommit(tag, commit) {
   }
 }
 
+/** Build the GitHub API args that generate the standard release notes body. */
+export function createGenerateReleaseNotesArgs({ commit, tag }) {
+  return [
+    'api',
+    'repos/{owner}/{repo}/releases/generate-notes',
+    '--method',
+    'POST',
+    '-f',
+    `tag_name=${tag}`,
+    '-f',
+    `target_commitish=${commit}`,
+  ]
+}
+
+/** Create the release-note footer that maps Mac CPU families to the right DMG. */
+export function createMacDownloadNotice({ productName, version }) {
+  const appleSiliconDmg = githubAssetName(
+    releaseAssetName({ productName, version, target: APPLE_SILICON_MAC_TARGET, type: 'dmg' }),
+  )
+  const intelDmg = githubAssetName(releaseAssetName({ productName, version, target: INTEL_MAC_TARGET, type: 'dmg' }))
+
+  return [
+    MAC_DOWNLOAD_NOTICE_HEADING,
+    '',
+    `- **Apple Silicon (M-series Macs):** download \`${appleSiliconDmg}\`.`,
+    `- **Intel Macs:** download \`${intelDmg}\`.`,
+    '',
+    'To check your Mac, open **Apple menu -> About This Mac**. If it shows **Chip** with M1, M2, M3, M4, or newer, choose Apple Silicon. If it shows **Processor** with Intel, choose Intel.',
+  ].join('\n')
+}
+
+/** Append Reflect's Mac download guidance after GitHub's generated notes. */
+export function appendMacDownloadNotice({ body, productName, version }) {
+  const trimmedBody = body.trimEnd()
+  if (trimmedBody.includes(MAC_DOWNLOAD_NOTICE_HEADING)) return `${trimmedBody}\n`
+
+  const notice = createMacDownloadNotice({ productName, version })
+  return `${trimmedBody ? `${trimmedBody}\n\n` : ''}${notice}\n`
+}
+
+function generateReleaseNotesBody({ commit, tag }) {
+  const result = spawnSync('gh', createGenerateReleaseNotesArgs({ commit, tag }), { encoding: 'utf8' })
+  if (result.status !== 0) {
+    const output = `${result.stdout ?? ''}${result.stderr ?? ''}`.trim()
+    fail(`generating GitHub release notes failed${output ? `\n${output}` : ''}`)
+  }
+
+  let generated
+  try {
+    generated = JSON.parse(result.stdout)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    fail(`GitHub release notes response was not JSON: ${message}`)
+  }
+
+  if (!generated || typeof generated !== 'object' || typeof generated.body !== 'string') {
+    fail('GitHub release notes response did not include a markdown body')
+  }
+  return generated.body
+}
+
+function writeReleaseNotes({ commit, outputDir, productName, tag, version }) {
+  log('generating GitHub release notes…')
+  const body = generateReleaseNotesBody({ commit, tag })
+  const releaseNotesPath = join(outputDir, RELEASE_NOTES_FILENAME)
+  writeFileSync(releaseNotesPath, appendMacDownloadNotice({ body, productName, version }))
+  return releaseNotesPath
+}
+
 /** Build the GitHub CLI args that publish the release and upload artifacts. */
-export function createReleaseArgs({ assets, commit, draft, prerelease, productName, tag, version }) {
+export function createReleaseArgs({ assets, commit, draft, notesPath, prerelease, productName, tag, version }) {
   const releaseArgs = [
     'release',
     'create',
@@ -849,7 +925,8 @@ export function createReleaseArgs({ assets, commit, draft, prerelease, productNa
     `${productName} ${version}`,
     '--target',
     commit,
-    '--generate-notes',
+    '--notes-file',
+    notesPath,
   ]
   if (prerelease) {
     releaseArgs.push('--prerelease', '--latest=false')
@@ -951,6 +1028,13 @@ function publish({ draft, flavorFlag, fromArtifacts }) {
     version,
   })
   const manifestPath = writeUpdaterManifest({ artifacts, outputDir: artifactDir, tag, version })
+  const releaseNotesPath = writeReleaseNotes({
+    commit,
+    outputDir: artifactDir,
+    productName,
+    tag,
+    version,
+  })
   // Pre-releases are invisible to `releases/latest` — the stable updater feed —
   // so installed stable apps never see a beta.
   const prerelease = version.includes('-')
@@ -962,6 +1046,7 @@ function publish({ draft, flavorFlag, fromArtifacts }) {
     ],
     commit,
     draft,
+    notesPath: releaseNotesPath,
     prerelease,
     productName,
     tag,

--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -603,6 +603,7 @@ function releaseAssetName({ productName, version, target, type }) {
   }
 }
 
+/** Match GitHub's release asset URL/display rewrite for uploaded file names. */
 function githubAssetName(fileName) {
   return fileName.replace(/ /g, '.')
 }
@@ -885,6 +886,7 @@ export function appendMacDownloadNotice({ body, productName, version }) {
   return `${trimmedBody ? `${trimmedBody}\n\n` : ''}${notice}\n`
 }
 
+/** Fetch GitHub's generated release notes body before creating the release. */
 function generateReleaseNotesBody({ commit, tag }) {
   const result = spawnSync('gh', createGenerateReleaseNotesArgs({ commit, tag }), { encoding: 'utf8' })
   if (result.status !== 0) {
@@ -906,6 +908,7 @@ function generateReleaseNotesBody({ commit, tag }) {
   return generated.body
 }
 
+/** Write generated release notes plus Reflect's Mac download footer to disk. */
 function writeReleaseNotes({ commit, outputDir, productName, tag, version }) {
   log('generating GitHub release notes…')
   const body = generateReleaseNotesBody({ commit, tag })

--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -588,6 +588,7 @@ function printArtifacts(flavor, target) {
   console.log(`  ${dmg} (${dmgSizeMb} MB)`)
 }
 
+/** Build the uploaded file name for a target-specific release artifact. */
 function releaseAssetName({ productName, version, target, type }) {
   const { arch } = releaseTargetConfig(target)
   const prefix = `${productName}_${version}_${arch}`
@@ -1013,6 +1014,7 @@ function preflight({ flavorFlag }) {
   log(`${tag} is publishable from ${commit.slice(0, 7)}`)
 }
 
+/** Create the GitHub release from freshly built or pre-staged macOS artifacts. */
 function publish({ draft, flavorFlag, fromArtifacts }) {
   const { commit, flavor, productName, tag, version } = ensurePublishableRelease({ flavorFlag })
   const artifactDir = fromArtifacts ?? mkdtempSync(join(tmpdir(), 'reflect-release-assets-'))

--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -1009,6 +1009,7 @@ function ensurePublishableRelease({ flavorFlag }) {
   return { commit, flavor, productName, tag, version }
 }
 
+/** Run release publish checks without building artifacts or creating a release. */
 function preflight({ flavorFlag }) {
   const { commit, tag } = ensurePublishableRelease({ flavorFlag })
   log(`${tag} is publishable from ${commit.slice(0, 7)}`)

--- a/apps/desktop/scripts/release-macos.test.mjs
+++ b/apps/desktop/scripts/release-macos.test.mjs
@@ -4,8 +4,11 @@ import { join } from 'node:path'
 import { expect, test } from 'vitest'
 
 import {
+  appendMacDownloadNotice,
   createBetaFeedReleaseArgs,
   createDmgArgs,
+  createGenerateReleaseNotesArgs,
+  createMacDownloadNotice,
   createReleaseArgs,
   createTauriBuildArgs,
   createUpdaterManifest,
@@ -19,10 +22,11 @@ const baseInput = {
   assets: ['Reflect.dmg', 'Reflect.app.tar.gz', 'Reflect.app.tar.gz.sig', 'latest.json'],
   commit: 'abc123',
   draft: false,
+  notesPath: 'release-notes.md',
   productName: 'Reflect',
 }
 
-test('pre-release publish opts out of GitHub latest heuristics', () => {
+test('pre-release publish uses prepared notes and opts out of GitHub latest heuristics', () => {
   const args = createReleaseArgs({
     ...baseInput,
     prerelease: true,
@@ -42,7 +46,8 @@ test('pre-release publish opts out of GitHub latest heuristics', () => {
     'Reflect 0.2.0-beta.14',
     '--target',
     'abc123',
-    '--generate-notes',
+    '--notes-file',
+    'release-notes.md',
     '--prerelease',
     '--latest=false',
   ])
@@ -59,6 +64,7 @@ test('stable publish marks the release as latest', () => {
   expect(args).toContain('--latest')
   expect(args).not.toContain('--prerelease')
   expect(args).not.toContain('--latest=false')
+  expect(args).not.toContain('--generate-notes')
 })
 
 test('draft publish keeps the draft flag last', () => {
@@ -71,6 +77,56 @@ test('draft publish keeps the draft flag last', () => {
   })
 
   expect(args.at(-1)).toBe('--draft')
+})
+
+test('generated release notes API targets the release tag and commit', () => {
+  expect(createGenerateReleaseNotesArgs({ commit: 'abc123', tag: 'v0.4.0' })).toEqual([
+    'api',
+    'repos/{owner}/{repo}/releases/generate-notes',
+    '--method',
+    'POST',
+    '-f',
+    'tag_name=v0.4.0',
+    '-f',
+    'target_commitish=abc123',
+  ])
+})
+
+test('Mac download notice points each processor at the matching DMG', () => {
+  const notice = createMacDownloadNotice({ productName: 'Reflect Beta', version: '0.4.0-beta.8' })
+
+  expect(notice).toContain('`Reflect.Beta_0.4.0-beta.8_aarch64.dmg`')
+  expect(notice).toContain('`Reflect.Beta_0.4.0-beta.8_x86_64.dmg`')
+  expect(notice).toContain('Apple Silicon (M-series Macs)')
+  expect(notice).toContain('Apple menu -> About This Mac')
+})
+
+test('Mac download notice is appended after generated release notes', () => {
+  const notes = appendMacDownloadNotice({
+    body: "## What's Changed\n\n- Fixed sync\n\n**Full Changelog**: v0.3.6...v0.3.7\n",
+    productName: 'Reflect',
+    version: '0.3.7',
+  })
+
+  expect(notes).toBe(
+    "## What's Changed\n\n" +
+      '- Fixed sync\n\n' +
+      '**Full Changelog**: v0.3.6...v0.3.7\n\n' +
+      '## Which Mac download should I choose?\n\n' +
+      '- **Apple Silicon (M-series Macs):** download `Reflect_0.3.7_aarch64.dmg`.\n' +
+      '- **Intel Macs:** download `Reflect_0.3.7_x86_64.dmg`.\n\n' +
+      'To check your Mac, open **Apple menu -> About This Mac**. If it shows **Chip** with M1, M2, M3, M4, or newer, choose Apple Silicon. If it shows **Processor** with Intel, choose Intel.\n',
+  )
+})
+
+test('Mac download notice is not duplicated when release notes are regenerated', () => {
+  const notes = appendMacDownloadNotice({
+    body: createMacDownloadNotice({ productName: 'Reflect', version: '0.3.7' }),
+    productName: 'Reflect',
+    version: '0.3.7',
+  })
+
+  expect(notes.match(/Which Mac download should I choose/g)).toHaveLength(1)
 })
 
 test('beta feed release is a non-latest prerelease pointer', () => {

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -236,7 +236,10 @@ signed/notarized macOS artifacts in parallel:
 Each build job runs the same DMG notarization, Gatekeeper checks, and updater artifact
 signing as a local release, then uploads its artifacts to the workflow. A final publish
 job downloads both sets, writes the combined `latest.json`, and creates the GitHub
-release. Trigger it from **Actions → Release → Run workflow** (tick *draft* to review
+release. The publish step asks GitHub for generated release notes, appends the Mac
+download chooser that maps Apple Silicon to `_aarch64.dmg` and Intel to
+`_x86_64.dmg`, then creates the release with that complete notes file. Trigger it from
+**Actions → Release → Run workflow** (tick *draft* to review
 the release before publishing), or by pushing the matching `v<version>` tag. The publish
 preflights apply unchanged, so bump `version` in `tauri.conf.json` (and
 `src-tauri/Cargo.toml`) on the released branch first.


### PR DESCRIPTION
## Problem

People can currently land on a GitHub release with both Apple Silicon and Intel DMGs but no guidance in the release notes about which processor family maps to which asset. That makes it easy for M-series Mac users to download the Intel build, or for Intel users to grab the Apple Silicon build.

## Before -> After

| Before | After |
| --- | --- |
| `gh release create --generate-notes` let GitHub generate the body with no project-specific download guidance. | The release script asks GitHub for the generated notes, appends a "Which Mac download should I choose?" section, and creates the release from that complete notes file. |
| Release assets exposed `_aarch64.dmg` and `_x86_64.dmg` without explanation. | Release notes explicitly map Apple Silicon / M-series Macs to `_aarch64.dmg` and Intel Macs to `_x86_64.dmg`, with an About This Mac check. |

## Changes

1. Added release-note helpers in `apps/desktop/scripts/release-macos.mjs` that call GitHub's generated-notes API, append the Mac download chooser, and pass `--notes-file` to `gh release create`.
2. Reused the existing release asset naming path, including GitHub's space-to-dot behavior for beta asset names.
3. Expanded release helper tests to cover the generated-notes API args, appended notice placement, duplicate prevention, and prepared notes file usage.
4. Documented the release-note behavior in `docs/macos-distribution.md` for future release maintainers.

## Verification

- `pnpm --filter @reflect/desktop test --run scripts/release-macos.test.mjs` passed: 18 tests.
- `git diff --check` passed.
- `pnpm check` passed. It still reports existing warnings for max-lines, unsafe optional chaining in an existing test, and existing React hook/compiler warnings; no errors.

## Risk / Rollout

No app runtime or updater manifest behavior changes. The release publish path now depends on the GitHub generated-notes API before creating the release; if that API fails, publishing fails before assets are uploaded rather than creating a release without the chooser guidance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release tooling only; publish now fails early if GitHub’s generate-notes API errors, with no change to shipped app or updater behavior beyond clearer release notes.
> 
> **Overview**
> **macOS GitHub publish** no longer relies on `gh release create --generate-notes`. It calls GitHub’s **generate-notes API**, writes `release-notes.md`, appends a **“Which Mac download should I choose?”** section that names the correct `_aarch64.dmg` and `_x86_64.dmg` (including GitHub’s space→dot naming for beta assets), and passes **`--notes-file`** when creating the release.
> 
> **Supporting tweaks:** shared `githubAssetName` for updater manifest URLs; named constants for Mac targets; tests for API args, notice content, deduplication, and release CLI args; **docs/macos-distribution.md** updated for the CI publish flow.
> 
> **No app runtime or updater manifest shape changes** beyond reusing the same asset naming helper for updater URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b6d098a1017d55238c53f1b2bafa2085e4ad4b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub releases now fetch generated release notes via the GitHub API, save them locally as `release-notes.md`, and then append a macOS download chooser mapping Apple Silicon and Intel to the correct installers.
* **Bug Fixes**
  * macOS updater/download links and referenced installer names now match GitHub’s uploaded asset naming, reducing mismatches; the download chooser is not duplicated on subsequent regenerations.
* **Tests**
  * Expanded coverage for release-notes generation and macOS download chooser composition.
* **Documentation**
  * Updated “Releasing from CI” guidance to reflect the notes generation/append flow and draft-review step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->