### PR TITLE
feat(onboarding): surface iCloud folder hint

### DIFF
--- a/apps/desktop/src/components/graph-chooser.tsx
+++ b/apps/desktop/src/components/graph-chooser.tsx
@@ -71,6 +71,12 @@ export function GraphChooser(): ReactElement {
                 Pick a folder on your computer and Reflect will keep all of your notes
                 there. An empty folder is perfect.
               </p>
+              {showIcloudDriveTip ? (
+                <p className="flex gap-2 text-xs leading-5 text-text-muted">
+                  <Lightbulb aria-hidden className="mt-0.5 size-3.5 shrink-0" strokeWidth={1.75} />
+                  <span>For sync across Apple devices, choose a folder in iCloud Drive.</span>
+                </p>
+              ) : null}
             </div>
             <Button type="button" className="mt-auto w-full" onClick={() => void pickAndOpen()}>
               <FolderPlus aria-hidden strokeWidth={1.75} />
@@ -110,16 +116,6 @@ export function GraphChooser(): ReactElement {
             </Button>
           </section>
         </div>
-
-        {showIcloudDriveTip ? (
-          <div className="mx-auto flex max-w-xl gap-2.5 text-sm leading-5 text-text-secondary">
-            <Lightbulb aria-hidden className="mt-0.5 size-4 shrink-0 text-text-muted" />
-            <p>
-              <span className="font-medium text-text">Tip:</span> choose a folder in iCloud Drive
-              if you want your notes backed up automatically.
-            </p>
-          </div>
-        ) : null}
 
         {error ? (
           <p role="alert" className="text-center text-sm text-destructive">


### PR DESCRIPTION
## Problem

The new-graph onboarding already had a macOS-only iCloud Drive suggestion, but it appeared as a detached tip below both onboarding paths. That made it feel less tied to the moment where a new user is deciding which folder to choose.

## Before -> After

| Before | After |
| --- | --- |
| iCloud Drive tip sat below the full chooser and said it could back up notes automatically. | The hint appears inside the “New to Reflect” panel and frames iCloud Drive as the Apple-device sync folder choice. |

## Changes

1. Move the macOS-only `showIcloudDriveTip` rendering into the new-user folder chooser section.
2. Tighten the copy to: “For sync across Apple devices, choose a folder in iCloud Drive.”
3. Remove the detached global tip so onboarding only shows one iCloud suggestion.

## Verification

- `pnpm --filter @reflect/desktop test -- src/components/graph-chooser.test.tsx`
- `pnpm check`

## Risk / Rollout

Docs/UI-copy only. The existing platform guard keeps the hint macOS-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding UI/copy only; macOS guard is unchanged and existing tests still match the new text.
> 
> **Overview**
> The macOS-only iCloud Drive hint is **moved** from a standalone block below both onboarding cards into the **“New to Reflect”** section, right above **Choose a folder…**, so it appears at the moment new users pick a folder.
> 
> Copy is **tightened** to: “For sync across Apple devices, choose a folder in iCloud Drive.” (replacing the former “Tip:” / automatic backup wording). Styling is slightly smaller (`text-xs`, smaller icon). The **detached global tip is removed**; `shouldShowIcloudDriveTip()` behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c043feda46d845327791710e95035af98fda3c2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the onboarding card to show the iCloud Drive tip in a more compact, streamlined format.
  * Removed the duplicate tip section elsewhere on the page, reducing repetition and improving layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->