### PR TITLE
fix: correct cascade layer order

### DIFF
--- a/apps/desktop/src/components/backlink-snippet.tsx
+++ b/apps/desktop/src/components/backlink-snippet.tsx
@@ -1,7 +1,6 @@
 import type { ReactElement } from 'react'
 import { MarkdownView } from '@meowdown/react'
 import type { WikilinkClickHandler } from '@meowdown/core'
-import '@meowdown/core/style.css'
 import { openExternalLink } from '@/editor/open-external-link'
 
 interface BacklinkSnippetProps {

--- a/apps/desktop/src/editor/markdown-preview.tsx
+++ b/apps/desktop/src/editor/markdown-preview.tsx
@@ -1,7 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react'
 import { MarkdownView } from '@meowdown/react'
-import '@meowdown/core/style.css'
-import '@meowdown/react/style.css'
 import { openExternalLink } from '@/editor/open-external-link'
 import { cn } from '@/lib/utils'
 

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -16,8 +16,6 @@ import {
   type TagSearchHandler,
   type WikilinkSearchHandler,
 } from '@meowdown/react'
-import '@meowdown/core/style.css'
-import '@meowdown/react/style.css'
 import {
   IMAGE_LIGHTBOX_TRANSITION_NAME,
   ImageLightbox,

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -1,10 +1,20 @@
 /* Design-system tokens + fonts (the single source of truth for theme), then
    Tailwind v4. The DS sets :root / .dark CSS variables that utilities and
    components read; keep Tailwind layered on top so shadcn and the DS agree. */
-@import '@reflect/design-system/styles.css';
-@import 'tailwindcss';
+
+/*
+Cascade layer order, low to high priority.
+"theme", "base", "components", "utilities" are Tailwind v4 layers;
+"meowdown" last so editor styles beat the design-system resets.
+*/
+@layer theme, base, components, utilities, design, meowdown;
+
+@import 'tailwindcss' ;
+@import '@reflect/design-system/styles.css' layer(design);
 @import 'tw-animate-css';
 @import 'shadcn/tailwind.css';
+@import "@meowdown/core/style.css";
+@import "@meowdown/react/style.css";
 
 /* Tailwind v4 dark variant keyed to the design-system `.dark` scope set by the
    ThemeProvider on <html>. */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the desktop app’s style loading order to improve consistency across the note editor, preview, and backlink snippets.
  * Added broader support for Meowdown styling in the app shell, helping markdown content render more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->