### PR TITLE
docs: add v1 → v2 feature porting plans

### DIFF
--- a/docs/porting/README.md
+++ b/docs/porting/README.md
@@ -1,0 +1,66 @@
+# Porting Reflect v1 features to Reflect v2
+
+This directory holds high-level porting plans for the major user-facing
+features of Reflect v1 (the closed-source, cloud-backed app). Each doc
+describes what the feature did in v1, what must change in v2 and why, and how
+the feature is going to work here — at the level of user experience and
+architectural direction, not implementation detail. The v1 behavior these
+docs port from is documented in the v1 repository under
+`docs/user-feature-behavior/`.
+
+## Why features can't be ported directly
+
+Reflect v2 is built on a different set of constraints than v1, and several v1
+designs simply don't survive the move:
+
+- **No server, no accounts.** v1 stored prompts, templates, contacts, and
+  credentials in a cloud account. v2 has no backend: everything lives in
+  plain files in the graph, in the local settings file, or in the OS
+  keychain.
+- **No provider OAuth.** v1 connected to Google and Microsoft via OAuth,
+  which requires a confidential client secret held on a server. An
+  open-source, client-only app cannot ship one. Instead, v2 integrates with
+  the **OS-native stores** — Apple Calendar (EventKit) and Apple Contacts —
+  which already aggregate the user's Google, Microsoft, and iCloud accounts
+  if they are added to macOS.
+- **Bring your own key.** v1 bundled metered AI access with per-plan quotas.
+  v2 talks directly to OpenAI, Anthropic, or Google with the user's own key
+  (stored in the keychain), so quota tiers, upgrade prompts, and usage
+  metering disappear entirely.
+- **Files first.** Anything that is user content (templates, notes created
+  from meetings) is markdown in the graph, versioned by git backup like
+  everything else. Derived data lives in the rebuildable SQLite index or is
+  fetched live from the OS; it is never a second source of truth.
+- **The privacy flag is law.** `private: true` notes can never have their
+  content sent to any AI or online service. Every ported AI surface must go
+  through the same `CloudSafe` enforcement as the copilot
+  (`packages/core/src/ai/checkers.ts`).
+
+## The docs
+
+| Doc                                                                 | v1 feature               | v2 status                                        |
+| ------------------------------------------------------------------- | ------------------------ | ------------------------------------------------ |
+| [Note aliases](./note-aliases.md)                                   | `//` title aliases       | **Ported** (frontmatter `aliases`) — mapping doc |
+| [Audio memos](./audio-memos.md)                                     | Voice notes + transcript | **Ported** (BYOK transcription) — mapping doc    |
+| [AI menu and prompts](./ai-menu-and-prompts.md)                     | Selection AI + prompts   | Planned — needs meowdown + app work              |
+| [Note templates](./note-templates.md)                               | Per-graph templates      | Planned — markdown files in the graph            |
+| [Calendar / meetings](./calendar-meetings-integration.md)           | Google/MS/iCloud OAuth   | Planned — Apple Calendar (EventKit)              |
+| [Contacts](./contacts-integration.md)                               | Google/MS/iCloud OAuth   | Planned — Apple Contacts                         |
+| [Assets](./assets.md)                                               | Encrypted uploads + CDN  | Half ported — images done; attachments planned   |
+| [Deep links](./deep-links.md)                                       | `reflect://` + web URLs  | Planned — route-shaped `reflect://` scheme       |
+| [Editor keyboard shortcuts](./editor-keyboard-shortcuts.md)         | reflect-editor keymaps   | Planned — gap list for meowdown + app            |
+
+## Conventions
+
+- "Graph" is a notes folder; "daily note" is `daily/YYYY-MM-DD.md`.
+- `mod` is ⌘ on macOS and Ctrl elsewhere; v2 currently ships on macOS only.
+- Architecture references use real paths in this repo, following the
+  load-bearing rule from the top-level README: **TypeScript owns policy,
+  Rust owns capabilities.** New OS integrations arrive as Tauri commands in
+  `apps/desktop/src-tauri/src/`, are consumed through the injected bridge
+  (`packages/core/src/ipc/bridge.ts`), and keep `@reflect/core` free of
+  Tauri imports.
+- Editor-level UI (menus, selection affordances) belongs upstream in
+  [meowdown](https://github.com/prosekit/meowdown); Reflect supplies the
+  items and behavior through props, the same way wikilink and tag
+  autocomplete work today.

--- a/docs/porting/ai-menu-and-prompts.md
+++ b/docs/porting/ai-menu-and-prompts.md
@@ -1,0 +1,90 @@
+# Porting the AI menu and prompts
+
+**Status: planned.** v2 has the ⌘J copilot (chat grounded in your notes) but
+no way to act on **selected text** inside the editor. This doc plans that
+port: select text, pick a prompt ("Fix spelling and grammar", "Write a short
+summary", or one you saved), and the transformation streams in.
+
+## What v1 did
+
+- A prompt picker in the editor ran a chosen prompt against the current
+  selection and streamed the reply into the note.
+- A library of 23 built-in prompt templates, plus user-created ones (with a
+  `{{selectedText}}` placeholder), managed in preferences and synced to the
+  account.
+- Provider choice (Anthropic / OpenAI / Google) with bundled metered access;
+  personal API keys lifted the quotas.
+
+## How it will work in v2
+
+### User experience
+
+1. Select text in a note and invoke the AI menu — via a keyboard shortcut
+   registered in the editor keymap, and via a small affordance on the
+   selection.
+2. A picker lists prompts: a curated built-in set (the most-used v1
+   transformations — fix grammar, summarize, rephrase, simplify, continue
+   writing, list action items) followed by the user's saved prompts, with
+   fuzzy filtering.
+3. The result streams into view with explicit **Accept / Discard / Retry**
+   controls. Nothing is written to the markdown file until the user accepts;
+   a discarded run leaves the note byte-identical.
+4. Saved prompts are managed in **Settings → AI**, next to the provider
+   configuration that already exists. A prompt has a label and a body with a
+   `{{selectedText}}` placeholder (same syntax as v1, so saved v1 prompts
+   port over verbatim).
+
+### What changes from v1, and why
+
+| v1                                        | v2                                                      |
+| ----------------------------------------- | ------------------------------------------------------- |
+| Bundled AI with free/paid daily quotas    | BYOK only — no quotas, no upgrade prompts, no metering  |
+| Prompts synced to the cloud account       | Prompts in the user settings file (`reflect.json`), global across graphs |
+| Streamed straight into the note           | Preview with Accept/Discard — a save must never surprise the file on disk |
+| 23 built-in templates                     | A smaller curated set; the long tail is user-saved      |
+| Worked in any note                        | Disabled in `private: true` notes — the selection is note content and can never be sent to a provider |
+
+### Architecture
+
+The work splits cleanly along the existing seams:
+
+- **meowdown** (upstream) grows the editor-level primitives, keeping them
+  host-agnostic the way the slash/wikilink/tag menus already are:
+  - a selection affordance / command hook the host can populate with items
+    (Reflect passes the prompt list, exactly as it passes wikilink
+    suggestions today);
+  - a "pending replacement" UI: render streamed text as an overlay or
+    preview decoration over the selection, with accept (apply as a single
+    ProseMirror transaction) / discard (no-op) — this is also the natural
+    home for future copilot-driven edits.
+- **`@reflect/core`** owns policy: the prompt library schema (zod, in
+  `settings/schema.ts` per
+  [adding-a-setting](../contributing/adding-a-setting.md)), placeholder
+  substitution, and the provider call — reusing the existing AI layer
+  (`packages/core/src/ai/`), the provider catalog, keychain-stored keys, and
+  the Vercel AI SDK streaming plumbing the copilot already uses.
+- **Privacy enforcement** reuses the `CloudSafe` pattern
+  (`packages/core/src/ai/checkers.ts`): the selection text must pass the
+  same structural check as copilot context, so a private note's content
+  cannot typecheck its way to a provider. The UI reflects this by disabling
+  the menu in private notes with an explanatory tooltip.
+
+## Explicitly not ported
+
+- Usage limits, quota error messages, and the free/paid distinction — there
+  is no metered tier to enforce.
+- The "Default (Anthropic)" bundled provider — v2 always uses the user's
+  configured provider and key; with no key, the menu is disabled with a
+  pointer to Settings (same pattern as audio memos).
+- Automatic context beyond the selection (unchanged from v1: prompts see the
+  selection only; broader context is the copilot's job).
+
+## Open questions
+
+- Whether the picker is a dedicated selection popover or a filtered mode of
+  the command palette (`mod+k`) — leaning popover, since the palette closes
+  over the editor and loses the selection visual.
+- Whether "Retry" offers a one-shot model switch (cheap to add given the
+  provider catalog, but more UI).
+- Ordering between the meowdown release and the app work — the meowdown
+  primitives land first and independently.

--- a/docs/porting/assets.md
+++ b/docs/porting/assets.md
@@ -1,0 +1,121 @@
+# Porting assets (images and file attachments)
+
+**Status: half ported.** Pasting or dropping an **image** into a v2 note
+already works: it's written into the graph's `assets/` folder and linked
+relatively. What's missing is the other half of v1's story — **arbitrary
+file attachments** (PDFs, docs, archives) via drag/drop and paste, and
+dropping files straight from Finder without a round-trip through browser
+memory.
+
+## What v1 did
+
+Uploading was a genuine *upload*, with all the machinery that implies:
+
+- **Entry points.** Drag-and-drop and clipboard paste in the editor
+  (`image-extension.ts`, `copy-paste-extension.ts` in reflect-editor),
+  plus a programmatic `uploadImages` command.
+- **Two node types.** Images became resizable inline nodes (spinner while
+  uploading, `settled` flag, retry-on-error). Every other file type — the
+  MIME map covered 80+ — became an **attachment card**: file-type badge,
+  filename, size, download icon, and a progress bar.
+- **Pipeline.** Client-side encryption (`@team-reflect/file-crypto`) →
+  Cloudflare Worker → `reflect-assets.app` CDN, under `users/{uid}/{id}`.
+  Three automatic retries ("Error uploading file. Please try again and
+  ensure you are online."), an unload warning ("Files are currently
+  uploading."), and background re-upload on reconnect.
+- **Limits.** 50 MB per file ("File is too large. 50mb is the max allowed
+  size."); no plan-based storage quota; no garbage collection — orphaned
+  uploads lived forever.
+- **Export quirk.** Attachments exported to markdown as `[name](url)`;
+  images didn't export at all.
+
+## What changes in v2, and why
+
+There is no upload. An asset is a **local file write** into `assets/`,
+so the entire lifecycle apparatus — encryption, CDN, progress bars,
+retries, settled flags, background re-upload, unload warnings — has
+nothing to attach to and is not ported. What remains is exactly the part
+users touch: *drop a file on a note and get a working link*. Backup rides
+git like everything else, and both image and attachment references are
+plain relative markdown, which fixes v1's export quirk: in v2 the markdown
+**is** the note.
+
+## What v2 already has (images)
+
+- meowdown's image extension handles paste and drop of image files and
+  calls the host's `onImagePaste`; the host returns the markdown `src`.
+- reflect-open persists them
+  (`apps/desktop/src/editor/use-image-persistence.ts`): named
+  `pasted-<timestamp>-<random>.<ext>` under `assets/`, written through the
+  traversal-guarded `asset_write` command, pinned to the graph generation,
+  resolved for display through the Tauri asset protocol, and openable in
+  the OS viewer. Save failures surface on the pane.
+- Plan 20 gives every image (and, notably, **PDF**) under `assets/` an AI
+  description file — PDFs are already first-class citizens of the asset
+  pipeline everywhere *except* the way in.
+
+## How attachments will work
+
+### Editor side (meowdown)
+
+Generalize the paste/drop pipeline past `filterImageFiles`: a file that
+isn't an image flows to a new host callback (`onFilePaste`, mirroring
+`onImagePaste`) and is inserted as a plain markdown link —
+`[Q3 report.pdf](assets/q3-report.pdf)` — at the caret or drop position.
+Multi-file drops insert one link per line (images as `![](…)`, everything
+else as `[…](…)`, in one drop). Rendering needs nothing new: it's a link;
+`link-click` and round-trip fidelity already handle it. A richer chip
+(size, type badge, à la v1's card) is a later cosmetic, and must stay a
+*view* of the plain link, never a different serialization.
+
+### Host side (reflect-open)
+
+- **Naming.** Images keep the `pasted-…` scheme (screenshots have no
+  meaningful name). Attachments keep their **original filename** —
+  it's the visible link text — sanitized to the graph's readable-filename
+  rules, with `-2`-style suffixes on collision.
+- **Finder drops bypass the browser.** Today's path reads the file into
+  JS and ships base64 over IPC — fine for a pasted screenshot, wrong for
+  a 300 MB video. Tauri's native drag-drop event carries real OS paths, so
+  dropped files take a new Rust command (`asset_import(sourcePath, …)`)
+  that copies file-to-file under the same traversal/generation guards.
+  Clipboard data (no OS path exists) keeps the base64 route.
+- **Size is a warning, not a wall.** It's the user's disk, but git backup
+  is the quiet constraint: every large binary lives in history forever,
+  and GitHub hard-rejects files over 100 MB. Above a threshold
+  (~25 MB), confirm with that context instead of refusing; v1's flat
+  "50mb is the max" alert is not ported.
+- **No type policing.** v1 accepted effectively everything; v2 does too.
+  Nothing executes an asset — links open through the OS.
+
+## v1 → v2 mapping
+
+| v1                                              | v2                                                 |
+| ----------------------------------------------- | -------------------------------------------------- |
+| Encrypted upload → Cloudflare → CDN URL         | Local write into `assets/`, relative link          |
+| Image node with `settled`/spinner/retry         | Plain `![](assets/…)`; a write either lands or errors — no pending state |
+| Attachment card (badge, size, progress)         | Plain `[name](assets/…)` link; chip view later     |
+| 50 MB hard cap                                  | Soft warning tied to git-host reality              |
+| Retries, background upload, unload warning      | Not applicable — no network                        |
+| Orphaned uploads invisible on a server          | Orphans are visible files in `assets/`             |
+| Images absent from markdown export              | Markdown is the source of truth                    |
+
+## Explicitly not ported
+
+- The entire upload lifecycle (encryption, CDN, progress, retries,
+  settled/pending states) — removed by architecture, not deferred.
+- `reflect-assets://` URL rewriting and signed download proxying.
+- v1's attachment download flow — "download" is meaningless for a file
+  already on disk; "open" and "reveal in Finder" replace it.
+
+## Open questions
+
+- **Orphan report.** Deleting a link leaves the file (v1 behaved the same,
+  invisibly). A palette command listing unreferenced `assets/` files —
+  with delete as an explicit choice — fits the files-first ethos; decide
+  whether it's part of this work or a follow-up.
+- **Paste-of-copied-file** from Finder (clipboard carries a file
+  reference, not bytes) — worth verifying what the Tauri webview exposes
+  on macOS; if it surfaces as a path, route it through `asset_import` too.
+- **Inline PDF preview** (v1 had none; Plan 20 descriptions may be enough
+  context) — explicitly out of scope here.

--- a/docs/porting/audio-memos.md
+++ b/docs/porting/audio-memos.md
@@ -1,0 +1,48 @@
+# Porting audio memos
+
+**Status: ported.** Audio memos are shipped in v2; this doc records how the
+v1 feature maps onto the v2 implementation and what deliberately changed.
+
+## What v1 did
+
+v1 let users record a voice memo from the app; the audio was uploaded and
+transcribed on Reflect's servers, and the transcript landed in the daily
+note. Transcription capacity was part of the paid plan.
+
+## How v2 does it
+
+Recording is local and transcription is bring-your-own-key — no audio ever
+touches a Reflect server, because there isn't one.
+
+- **Entry point.** The microphone control in the sidebar, with a global
+  shortcut (`mod+\`). Lifecycle lives in
+  `apps/desktop/src/providers/audio-memo-provider.tsx`.
+- **Capture is durable first.** The recording (max 10 minutes) is saved
+  immediately into the graph's `audio-memos/` folder. Transcription is a
+  separate, retryable step — a failed or missing transcription never loses
+  the audio.
+- **Transcription.** Runs against the user's own OpenAI or Gemini key
+  (chosen by `pickTranscriptionConfig` in `@reflect/core`; keys in the OS
+  keychain via `apps/desktop/src-tauri/src/secrets.rs`). The reconciler
+  (`apps/desktop/src/lib/transcription-reconciler.ts`) writes the transcript
+  into the daily note and retries pending memos in the background.
+- **No key configured.** The mic button is disabled with a tooltip pointing
+  at Settings — there is no metered fallback tier to fall back to.
+
+## v1 → v2 mapping
+
+| v1                                       | v2                                                    |
+| ---------------------------------------- | ----------------------------------------------------- |
+| Upload to Reflect servers for transcription | Direct provider call with the user's own key       |
+| Transcription quota tied to plan         | No quotas; provider bills the user directly           |
+| Audio stored in the cloud account        | Audio is a file in the graph (`audio-memos/`), backed up by git like everything else |
+| Works only online                        | Recording works offline; transcription catches up later |
+
+## Notes and follow-ups
+
+- Sending audio to a provider is an explicit, user-initiated network call
+  and is documented in [docs/privacy.md](../privacy.md).
+- The `private: true` flag applies to note content; audio memos are captured
+  before they belong to any note, so the flag has no bite at record time.
+  If memos ever gain a "transcribe into a specific note" flow targeting a
+  private note, the transcript-insertion step must respect the flag.

--- a/docs/porting/calendar-meetings-integration.md
+++ b/docs/porting/calendar-meetings-integration.md
@@ -1,0 +1,110 @@
+# Porting calendar / meetings integration
+
+**Status: planned.** The v1 feature — the day's meetings beside the daily
+note, one action to turn a meeting into a backlinked note — is one of
+Reflect's defining loops and ports to v2 with the same shape. What changes
+completely is how calendars are reached.
+
+## What v1 did
+
+- Connected Google, Microsoft, or iCloud calendars via OAuth / app-specific
+  passwords, with credentials held server-side.
+- Daily notes showed an **Events** sidebar (auto-refreshing) with the day's
+  meetings from the calendars the user enabled.
+- Clicking a meeting opened an **Add event** modal; submitting created or
+  found a meeting note, created person notes for attendees, and backlinked
+  all of them from the daily note.
+
+## Why the v1 approach can't port
+
+Provider OAuth requires a confidential client secret and redirect endpoints
+held on a server. v2 is open-source and client-only: there is no server to
+hold secrets, and a client secret shipped in an open-source binary is
+public. Per-provider API integrations (Google Calendar API, Microsoft Graph,
+CalDAV) are therefore out.
+
+## How it will work in v2
+
+### Apple Calendar via EventKit
+
+v2 reads the calendars macOS already has, through the EventKit framework.
+This is a smaller integration than it sounds like a regression:
+**macOS Calendar already aggregates Google, Microsoft/Exchange, and iCloud
+accounts.** A user who adds their Google account in System Settings →
+Internet Accounts sees those events in Reflect with zero OAuth — Apple
+maintains the sync. Access is read-only and entirely local; no network call
+is added to [docs/privacy.md](../privacy.md)'s inventory.
+
+### User experience
+
+1. **Enabling.** A **Calendar** section in Settings with a single switch.
+   Turning it on triggers the standard macOS permission prompt ("Reflect
+   would like to access your calendar"). Denied or revoked permission shows
+   an inline explanation with a button to System Settings — no error badges
+   or revoke-and-reconnect loops, because there are no credentials to go
+   stale.
+2. **Choosing calendars.** Once granted, the section lists every calendar
+   on the Mac (across all accounts) with checkboxes, mirroring v1's
+   "2/5 calendars" selector. Enabled calendar identifiers are stored in the
+   user settings file.
+3. **Events on the daily note.** Today's events from enabled calendars
+   appear in a panel on the daily note: title and start time (respecting the
+   existing time-format setting), declined and all-day/busy-placeholder
+   events filtered out, as in v1.
+4. **Add to daily note.** Each event has one primary action, carrying over
+   the v1 modal: editable meeting name, editable attendee list, and a
+   "create backlinked note?" choice. Submitting writes plain markdown into
+   the daily note — a `[[Meeting name]]` link and `[[Person]]` links per
+   attendee — and creates the meeting/person notes if missing. After that,
+   they are ordinary notes; nothing about them stays tied to the calendar.
+
+### Architecture
+
+- **Rust owns the capability.** A `calendar` module in
+  `apps/desktop/src-tauri/src/` binds EventKit through the `objc2` /
+  `objc2-event-kit` crates (the codebase is pure Rust today and stays that
+  way — no Swift). Commands: request access, list calendars, list events
+  for a date range.
+- **TypeScript owns policy.** `@reflect/core` gets bridge methods (via
+  `packages/core/src/ipc/bridge.ts`) and the note-writing action for "add
+  meeting"; the daily-note panel consumes them. Events are **fetched live,
+  not indexed** — EventKit is fast and local, the SQLite index stays a
+  projection of markdown only, and no calendar data is ever persisted
+  except the markdown the user explicitly creates.
+- **Packaging.** The hardened-runtime entitlement
+  (`com.apple.security.personal-information.calendars`) and an
+  `NSCalendarsFullAccessUsageDescription` string join the bundle config;
+  notarization is already in place
+  ([docs/macos-distribution.md](../macos-distribution.md)).
+- **iOS.** EventKit is the same API on iOS, so the mobile companion
+  ([plans/19-mobile.md](../plans/19-mobile.md)) inherits this integration
+  rather than needing a separate "mobile sync" story like v1's Capacitor
+  builds did.
+
+## v1 → v2 mapping
+
+| v1                                            | v2                                                  |
+| --------------------------------------------- | --------------------------------------------------- |
+| OAuth per provider, tokens on Reflect servers | One OS permission prompt; Apple holds the accounts  |
+| Connected-accounts page, error badges, revoke | A Settings switch + calendar checkboxes             |
+| Server polls providers; 10-min refresh        | Live local reads + EventKit change notifications    |
+| Meeting metadata in the cloud database        | Only user-created markdown persists                 |
+| Attendee names written back to contacts       | Read-only; see [contacts](./contacts-integration.md) |
+
+## Explicitly not ported
+
+- Direct Google/Microsoft/CalDAV connections and the whole credential
+  lifecycle (connect, revoke, token refresh, error recovery).
+- Any write access to calendars (v1 was read-only too; v2 keeps that).
+- Meeting location / organizer / conference links (v1 didn't surface them
+  either; can be revisited since EventKit exposes them).
+
+## Open questions
+
+- Whether the events panel is a sidebar section or part of the daily-note
+  header area — a design decision once the daily surface's layout settles.
+- Recurring-event default for "create backlinked note?" (v1 defaulted it on
+  for recurring events; worth keeping, but needs EventKit's recurrence
+  info plumbed through).
+- Whether to surface a subtle "connect your work calendar in macOS" hint
+  for users expecting a Google OAuth button.

--- a/docs/porting/contacts-integration.md
+++ b/docs/porting/contacts-integration.md
@@ -1,0 +1,98 @@
+# Porting contacts integration
+
+**Status: planned.** In v1, contacts turned meeting attendees and name-like
+notes into real person notes without manual data entry. v2 keeps that role
+but reads the **Apple Contacts** store instead of syncing provider address
+books through a server.
+
+## What v1 did
+
+- Synced contacts (names, emails, phones, photos) from connected Google,
+  Microsoft, or iCloud accounts — the same credentials as calendar.
+- Showed a **Suggested contact** card on notes whose subject looked like a
+  person's name, with one action to merge the contact's details into the
+  note.
+- Resolved meeting attendees against the contact store so "add meeting to
+  daily note" produced pre-populated person notes.
+
+## Why the v1 approach can't port
+
+Same reason as calendar: provider contact APIs require OAuth with
+server-held secrets, and v2 has no server. The OS-native replacement is the
+Contacts framework (`CNContactStore`), which — like EventKit — already
+aggregates Google, Exchange, and iCloud contacts the user has added to
+macOS.
+
+## How it will work in v2
+
+### User experience
+
+1. **Enabling.** A **Contacts** switch in Settings (paired with Calendar —
+   likely one "Apple integrations" section). Turning it on triggers the
+   macOS contacts permission prompt; denial shows an inline pointer to
+   System Settings.
+2. **Meeting attendees become person notes.** When a meeting is added from
+   the [calendar flow](./calendar-meetings-integration.md), each attendee
+   email is looked up in Apple Contacts. On a match, the created person note
+   is pre-filled (name, email, phone); on a miss, a person note is still
+   created from the attendee email, as in v1.
+3. **Suggested contact.** On a note whose title matches a contact's name, a
+   card offers the contact's details (photo, primary email, phone) with
+   **Add** — writes the fields into the note as plain markdown — and
+   **Ignore** — dismisses the suggestion for that note.
+4. **Nothing syncs anywhere.** Contact data appears in a note only when the
+   user explicitly adds it, at which point it is ordinary markdown owned by
+   the graph. Reflect never writes back to the address book.
+
+### Architecture
+
+- **Rust owns the capability.** A `contacts` module in
+  `apps/desktop/src-tauri/src/` binds the Contacts framework via `objc2`
+  bindings. Commands: request access, look up by email, look up by name.
+- **Lookups are live queries, not a mirror.** v1 copied the whole address
+  book into its local store and showed "N contacts" sync status. v2 queries
+  `CNContactStore` on demand (attendee resolution, title match) and persists
+  nothing: the address book never enters `.reflect/index.sqlite`, so the
+  index remains a pure projection of markdown and deleting it still loses
+  nothing. No sync state means no `Syncing contacts...`, no stale counts,
+  no error badges.
+- **TypeScript owns policy.** `@reflect/core` exposes bridge methods and
+  the matching logic (which note titles count as person-like, how attendee
+  emails map to person notes); the suggested-contact card and the meeting
+  flow consume them. Per-note "ignore" dismissals persist in the note's
+  frontmatter or the settings file — small, explicit state either way.
+- **Packaging.** `com.apple.security.personal-information.addressbook`
+  entitlement plus an `NSContactsUsageDescription` string. iOS uses the
+  same framework, so mobile inherits the integration (v1 had contact sync
+  disabled on mobile entirely).
+
+## v1 → v2 mapping
+
+| v1                                             | v2                                               |
+| ---------------------------------------------- | ------------------------------------------------ |
+| OAuth-synced copy of provider address books    | Live, on-demand reads of Apple Contacts          |
+| "N contacts" sync status and error badges      | No sync, no status — permission on/off only      |
+| Custom-name edits stored in Reflect's store    | Corrections live in the person note's markdown   |
+| Attendee names written back to contact entries | Strictly read-only                               |
+| Mobile background sync disabled                | Same framework on iOS; no separate sync story    |
+
+## Explicitly not ported
+
+- The provider credential lifecycle and the contacts side of
+  "Connected third-party accounts".
+- The local contact mirror and its sync machinery.
+- v1's non-features stay non-features: no CSV/vCard bulk import, no AI
+  enrichment, no write-back to providers.
+
+## Open questions
+
+- **Person-note matching.** v1 matched "notes whose subject looks like a
+  person's name". v2 needs a concrete rule — likely a `#person` tag and/or
+  a fuzzy title match against contacts, tuned to avoid false positives on
+  two-word note titles.
+- **Photos.** Contact photos are binary; if person notes should show them,
+  they'd be written into `assets/` on explicit add (never automatically).
+- **Privacy-doc wording.** Nothing leaves the device, but reading the
+  address book is exactly the kind of access
+  [docs/privacy.md](../privacy.md) exists to spell out; it needs a section
+  even though the network inventory is unchanged.

--- a/docs/porting/deep-links.md
+++ b/docs/porting/deep-links.md
@@ -1,0 +1,127 @@
+# Porting deep links
+
+**Status: planned.** v1 was addressable from outside: a `reflect://` URL
+scheme for actions, web URLs for every note, and a "copy link" action. v2
+has none of that yet — but the seams were built for it: the typed route
+model (`apps/desktop/src/routing/route.ts`) and the command registry's
+stable ids (`apps/desktop/src/lib/commands/types.ts`) both name "later deep
+links" as their integration point. This doc is that later.
+
+## What v1 did
+
+- **Action scheme** — `reflect://?command=<name>&…` handled by the app:
+  `append-to-daily-note` (text into today's list), `create-task`,
+  `create-note`, and `edit-notes` (open by id or subject, optionally with
+  content and a second split-pane note).
+- **Web URLs** — every note, daily note, tag, search, and the task view had
+  a `reflect.app/g/<graphId>/…` URL; "Copy link to note" (`alt+mod+l`,
+  toast: "Note link copied to clipboard") put one on the clipboard.
+- **Published URLs** — paid users could publish a note to a public
+  `reflect.site` URL.
+- **REST API** — authenticated endpoints to create notes and append to the
+  daily note.
+
+## What changes in v2, and why
+
+There is no server, so anything whose address *is* a server dies with it:
+web URLs, published pages, and the REST API are not portable. What remains
+— and what mattered — is **local addressability**: other apps, scripts,
+launchers, and your own notes elsewhere being able to say "open this note"
+or "add this to today". v2 already half-solves this from two directions:
+
+- the **CLI** ([docs/cli.md](../cli.md)) answers reads (`reflect show`,
+  `reflect search`, `reflect path`) for scripts and agents;
+- the **capture inbox** (`.reflect/inbox/`, from the link-capture pipeline)
+  is the sanctioned way for outside software to hand Reflect content
+  without talking to a live app.
+
+Deep links complete the triangle: a clickable way to **navigate** the
+running app.
+
+## How it will work in v2
+
+### A `reflect://` scheme that mirrors the route model
+
+The Tauri app registers the `reflect://` scheme (deep-link plugin +
+`CFBundleURLTypes`; single-instance so a link focuses the running app or
+launches it). URLs map one-to-one onto the existing `Route` union rather
+than inventing a second grammar:
+
+```text
+reflect://today                     { kind: 'today' }
+reflect://daily/2026-07-01          { kind: 'daily', date }
+reflect://note/<target>             { kind: 'note', path }  — see resolution
+reflect://search?q=meeting          { kind: 'search', query }
+reflect://tasks                     { kind: 'tasks' }
+```
+
+`<target>` resolves exactly like the CLI's `<note>` argument and the
+`note_keys` view: frontmatter `id` first (stable across renames — the
+reason ids exist), then date, title, or alias. "Copy deep link" therefore
+prefers the id form, so a link outlives any rename; a human-written
+`reflect://note/Project%20X` still works via title resolution.
+
+A "Copy deep link" entry joins the command palette and the note context
+menu, porting v1's `alt+mod+l`.
+
+### Write actions go through the inbox, not straight into notes
+
+v1's `append-to-daily-note` and `create-task` are the automation hooks
+worth keeping (launchers, Shortcuts, "quick add" scripts). But a URL scheme
+is an unauthenticated, world-invokable surface — any web page can attempt
+`reflect://` — so v2 splits by risk:
+
+- **Navigation links** (everything above) act immediately: worst case, the
+  wrong screen is shown.
+- **Write links** — `reflect://append?text=…`, `reflect://task?text=…` —
+  reuse the capture-inbox pattern: the payload lands as a pending capture
+  with visible provenance and is imported through the same reviewed path as
+  browser captures, never silently spliced into a note. Size-limited,
+  text-only, no format smuggling.
+- **No remote-control surface.** v1's `edit-notes` could inject `content`
+  into arbitrary subjects; v2 does not take content or execute registry
+  commands from URLs. The command ids stay the vocabulary for the palette
+  and a future `reflect open` CLI verb, where invocation is local and
+  deliberate.
+
+### Relationship to the CLI
+
+The scheme and the CLI stay complementary, not duplicative: the CLI reads
+and resolves (`reflect path` already gives scripts a *file* address); the
+scheme navigates and captures. A natural follow-up is `reflect open
+<note>`, which just shells out to the scheme URL — one resolution routine,
+three front doors (palette, CLI, links).
+
+## v1 → v2 mapping
+
+| v1                                              | v2                                                    |
+| ----------------------------------------------- | ----------------------------------------------------- |
+| `reflect://?command=edit-notes&id=…`            | `reflect://note/<id>` (route-shaped, id-first)        |
+| `reflect://?command=append-to-daily-note`       | `reflect://append?text=…` via the capture inbox       |
+| `reflect://?command=create-task`                | `reflect://task?text=…` via the capture inbox         |
+| Web URLs (`reflect.app/g/…`)                    | Not ported — no server; `reflect://` + file paths     |
+| "Copy link to note" (`alt+mod+l`)               | "Copy deep link" (palette + context menu)             |
+| Published `reflect.site` pages                  | Not ported here (a publishing story is separate)      |
+| REST API create/append                          | CLI + capture inbox + plain files                     |
+| `DDMMYYYY` daily ids                            | ISO `YYYY-MM-DD`, as everywhere in v2                 |
+
+## Explicitly not ported
+
+- Anything requiring Reflect-hosted infrastructure: shareable web URLs,
+  public publishing, authenticated REST endpoints.
+- Split-pane parameters (`splitPaneSubject`, …) — v2 has no split editor;
+  if it grows one, the URL grammar can gain a parameter then.
+- URL-initiated note **creation with content** (`edit-notes` with
+  `subject` + `content`) — creation stays a deliberate in-app/inbox act.
+
+## Open questions
+
+- **Graph addressing.** URLs above assume the current graph. Multi-graph
+  users need either a `?graph=` parameter (matched against the recents
+  store) or the rule "links resolve in the open graph" — start with the
+  latter, it's honest about what the app can safely do.
+- **x-callback-url.** Automation tools (Shortcuts, Raycast) like
+  success/error callbacks. Worth deciding once real integrations ask.
+- **Block/heading anchors.** v1 never had them; markdown has no stable
+  block ids. Heading anchors (`reflect://note/<id>#heading`) are feasible
+  later without breaking the grammar.

--- a/docs/porting/editor-keyboard-shortcuts.md
+++ b/docs/porting/editor-keyboard-shortcuts.md
@@ -1,0 +1,125 @@
+# Porting editor keyboard shortcuts
+
+**Status: planned (incremental).** This doc catalogs the keyboard behaviors
+of the v1 editor (`@team-reflect/reflect-editor`, Remirror/ProseMirror-based)
+against what v2 already has, and calls out which gaps are worth porting.
+Editor-level bindings belong upstream in meowdown; note-to-note navigation
+belongs in the app.
+
+Where v2 already binds something, the v2 combo wins — this is about porting
+**behaviors**, not v1's exact keystrokes.
+
+## Already covered in v2
+
+No action needed; listed so nobody re-ports them. meowdown's bindings live
+in `packages/core/src/extensions/key-bindings.ts` (meowdown repo); app-scope
+bindings in `apps/desktop/src/lib/commands/app-commands.ts`.
+
+| Behavior                          | v1                    | v2                                   |
+| --------------------------------- | --------------------- | ------------------------------------ |
+| Bold / italic / inline code       | `mod+b/i/\``          | `mod+b/i/e`                          |
+| Strikethrough / highlight         | `mod+shift+x/h`       | Same                                 |
+| Headings                          | `mod+alt+1…6`         | `mod+1…6`                            |
+| Insert/edit link on selection     | `mod+k`               | Same                                 |
+| Indent / outdent list item        | `Tab` / `shift+Tab`   | Same (prosekit list keymap)          |
+| Collapse/expand a bullet          | `mod+alt+[` / `]`     | `mod+.` (single toggle)              |
+| Cycle bullet → task → done        | `mod+enter`           | `mod+enter` (`rotateSquareTask`)     |
+| Markdown input rules              | `- `, `1. `, `[ ] `, ```` ``` ````, `**` … | Same family |
+| Undo / redo                       | PM defaults           | PM defaults                          |
+
+## Recommended ports
+
+Ordered by value. The first item is the reason this doc exists.
+
+1. **Move list item up / down — `alt+↑` / `alt+↓`.**
+   v1: `flat-list-extension.ts`. The single most-missed structural edit:
+   reorder a bullet (with its nested children) without cut/paste. v2 has no
+   binding for it; `prosemirror-flat-list`, which meowdown's list extension
+   already builds on, ships the move commands — this is keymap wiring plus
+   round-trip tests, in meowdown. Should also move a plain paragraph/block
+   when the cursor isn't in a list, so the shortcut behaves uniformly.
+
+2. **Wrap selection into a wikilink — `[` with a selection.**
+   v1 (`backlink-extension.ts`, `handleSquareBracketInsert`): typing `[`
+   over a selected word replaces it with `[[word` — brackets left open,
+   cursor at the end — so the wikilink autocomplete opens immediately with
+   the selection as the query; accepting a suggestion (or typing `]]`)
+   completes the link. The "intelligent" part is the guards, which make
+   `[[` a safe two-tap gesture rather than a modal state:
+   - selection already starts with `[[` → do nothing (never `[[[`);
+   - selection starts with a single `[` → strip it, so the result is
+     exactly `[[…` (a second `[` tap converges instead of stacking);
+   - only fires on a non-empty text selection within one block — a bare
+     `[` keystroke types a literal bracket.
+
+   v1 also bound `mod+shift+k` to the same insert with an empty selection
+   allowed (drops an open `[[` at the cursor). Port both to meowdown next
+   to the existing `wikilink-trigger.ts`, preserving open-ended insertion
+   (autocomplete-with-query) rather than closing the brackets around the
+   selection — that is what feeds the link-first workflow.
+
+3. **Open link/wikilink/tag under the cursor from the keyboard —
+   `mod+enter` on the node.** v1 let `Enter`/`mod+enter` follow backlinks
+   and tags without the mouse. v2 has click handlers (`wikilink-click.ts`,
+   `tag-click.ts`, `link-click.ts`) but no keyboard path. One binding in
+   meowdown that resolves "the link unit at the cursor"
+   (`get-link-unit-at.ts` already exists) and emits the same event clicks
+   do. Plain `Enter` stays split-block; only the modified form follows.
+
+4. **List-type toggles — `mod+shift+7/8/9`** (ordered / bullet / task,
+   Google-Docs muscle memory). v2 can only reach these via input rules or
+   the task-rotate cycle. Low cost in meowdown's list extension.
+
+5. **Edge-of-note arrow navigation.** In v1, `↑` at the very start /
+   `↓` at the very end of a note moved focus to the previous/next note.
+   This is **app-level**, not meowdown: in the daily stream it should walk
+   across days. Needs a small editor hook ("cursor tried to leave the
+   document") that the host handles — same host/editor split as everything
+   else.
+
+6. **`Escape` collapses the selection.** Tiny quality-of-life v1 behavior
+   (deselect without touching the mouse); verify it doesn't fight
+   meowdown's menus, which also use `Escape` to dismiss.
+
+## Deliberately not ported
+
+- **`mod+u` underline** — not markdown; v2 has no underline mark and
+  shouldn't grow one.
+- **Checklist vs. task as distinct node types** (`mod+shift+enter` cycle).
+  v1 had two checkbox-flavored list kinds; markdown has one (`- [ ]`). The
+  single `mod+enter` rotation covers it.
+- **`mod+j` prediction menu and its result keys** (`mod+enter` replace,
+  `i` insert, `r` re-run, `c` copy, `esc` stop). `mod+j` is the copilot in
+  v2, and selection AI is designed in
+  [ai-menu-and-prompts.md](./ai-menu-and-prompts.md) — but v1's
+  single-key accept/insert/retry/copy vocabulary is good prior art for that
+  doc's Accept/Discard/Retry controls.
+- **Slash menu trigger** — v2 inserts via the command palette and meowdown
+  insert menus; see [note-templates.md](./note-templates.md).
+- **Transcription keys** — audio memos have their own v2 surface
+  ([audio-memos.md](./audio-memos.md)); `esc`-to-stop is worth mirroring
+  there if it isn't already.
+- **PageUp/PageDown note navigation** — covered by app navigation history
+  (`mod+[`/`mod+]`) and the palette; low demand.
+
+## Conflicts to watch
+
+- `mod+[` / `mod+]` are **back/forward** at app scope, while the prosekit
+  list keymap also binds `mod+[` to outdent inside the editor. Today the
+  editor wins when focused; any new bindings must go through the keymap
+  registry (`apps/desktop/src/editor/keymap.ts`), which rejects duplicates,
+  and be listed in the `mod+/` cheat-sheet.
+- v1 resolved `alt`-combos through `keyboard-layout-map` for non-US
+  layouts; `alt+↑`/`alt+↓` are layout-safe (no printable character), which
+  is another reason to prefer them for list moves.
+
+## Open questions
+
+- Whether `alt+↑/↓` should also swap table rows when inside a table (nice,
+  but tables have their own selection rules — decide in meowdown).
+- Wrap-selection-on-`[` triggers on the **first** `[` in v1 (the guards
+  make a second tap converge to the same `[[…` state). That means a user
+  who wanted a literal `[word]` can't get it by typing over a selection;
+  v1 accepted that trade. Decide whether meowdown keeps it, or reserves
+  the wrap for the second tap and lets a single `[` type literally —
+  stricter markdown fidelity, slightly slower linking.

--- a/docs/porting/note-aliases.md
+++ b/docs/porting/note-aliases.md
@@ -1,0 +1,66 @@
+# Porting note aliases
+
+**Status: ported.** Aliases shipped with the readable-filenames work
+([docs/readable-filenames.md](../readable-filenames.md)); this doc records
+how the v1 concept maps onto what v2 does, and the one open porting task
+(import).
+
+## What v1 did
+
+In v1, aliases were part of the note's title: editing the H1 to
+`Superman // Clark Kent // Kal‑El` made everything after each `//` an alias.
+`[[` autocomplete matched aliases, links through any spelling resolved to the
+canonical note, and backlinks aggregated under the canonical title. Renaming
+a note did **not** rewrite existing links — old links kept working only as
+long as their spelling still appeared somewhere in the title.
+
+## How v2 does it
+
+The concept survives intact; the mechanism moves out of the title and into
+frontmatter, where it belongs in a files-first app:
+
+```yaml
+---
+id: 01J9ZK...
+aliases:
+  - Clark Kent
+  - Kal-El
+---
+
+# Superman
+```
+
+- The `aliases` field is a plain YAML string array
+  (`packages/core/src/markdown/model.ts`); malformed values degrade to an
+  empty list rather than breaking the note.
+- `[[` autocomplete and link resolution treat titles, aliases, and daily
+  dates uniformly through the `note_keys` view in the SQLite index
+  (`crates/index-schema/migrations/0001_initial.sql`).
+- Renames are **stronger than v1**: the rename coordinator
+  (`apps/desktop/src/editor/rename-coordinator.ts`) rewrites known
+  `[[old title]]` links across the graph, then records the old title as an
+  alias so unindexed or external references keep resolving too.
+- Markdown wikilinks additionally support display text via
+  `[[target|shown text]]` — a per-link cosmetic that v1 didn't have, distinct
+  from aliases (which affect resolution).
+
+## v1 → v2 mapping
+
+| v1                                               | v2                                                     |
+| ------------------------------------------------ | ------------------------------------------------------ |
+| `Title // Alias1 // Alias2` in the H1            | `aliases:` array in frontmatter                        |
+| Rename keeps old links only via title spelling   | Rename rewrites links **and** preserves title as alias |
+| No alias UI beyond the title bar                 | Frontmatter is directly editable (in-app or any tool)  |
+| Daily notes cannot be renamed or aliased         | Same: daily notes are keyed by date                    |
+| Alias collisions: first match wins, silently     | Same at resolution time (open question below)          |
+
+## Open porting tasks
+
+- **Import.** When importing a v1 export
+  ([plans/13-import-export-portability.md](../plans/13-import-export-portability.md)),
+  titles containing `//` should be split: the first segment becomes the
+  title, the rest become frontmatter `aliases`. Without this, v1 alias-heavy
+  graphs arrive with `//` baked into titles and every aliased link breaks.
+- **Collision surfacing.** Neither v1 nor v2 warns when two notes claim the
+  same alias. Worth a lint-style indicator eventually, but not a porting
+  blocker.

--- a/docs/porting/note-templates.md
+++ b/docs/porting/note-templates.md
@@ -1,0 +1,96 @@
+# Porting note templates
+
+**Status: planned.** v2 has no template feature; daily notes start blank.
+The [product vision](../reflect-v2-product-vision.md) deferred templates
+with "markdown snippets may be enough" — and that is exactly the design:
+templates are markdown files in the graph.
+
+## What v1 did
+
+Templates were per-graph named blocks of rich content, managed in
+**Preferences → Note Templates**, stored in the cloud account, and inserted
+via the editor's slash menu. New graphs were seeded with three starter
+templates (**journal**, **person**, **company**). There was no variable
+substitution — bodies were inserted verbatim.
+
+## How it will work in v2
+
+### Templates are files
+
+A `templates/` folder at the graph root, as a sibling of `daily/` and
+`notes/`:
+
+```text
+my-graph/
+├── daily/
+├── notes/
+├── templates/
+│   ├── journal.md
+│   └── person.md
+└── .reflect/
+```
+
+Each markdown file is one template; its title (H1 or filename) is the name
+shown when inserting. That single decision buys almost everything v1 had to
+build:
+
+- **Editable anywhere** — in Reflect or any text editor; the file watcher
+  picks up changes like any other file.
+- **Per-graph scope and sync for free** — templates live in the graph and
+  ride the git backup, so every device sees them; no account storage, no
+  separate sync path.
+- **Versioned** — template history is git history.
+
+### Inserting a template
+
+- **Command palette** (`mod+k`): an "Insert template…" command lists the
+  templates in the current graph and inserts the chosen body at the cursor.
+- **Editor slash/insert menu**: meowdown's insert affordances (slash menu,
+  block-handle `+`) gain host-provided items so templates appear alongside
+  built-in blocks — same host-supplies-the-items pattern as wikilink
+  autocomplete.
+
+Insertion is verbatim, matching v1: links, tags, tasks, and headings paste
+in as written. Frontmatter in a template file (if any) is not inserted.
+
+### Managing templates
+
+No dedicated management UI to start. "New template" is creating a file in
+`templates/`; renaming and deleting are file operations, doable in-app
+(templates open in the normal editor) or outside it. A settings section can
+come later if file management proves too raw.
+
+## v1 → v2 mapping
+
+| v1                                          | v2                                                 |
+| ------------------------------------------- | -------------------------------------------------- |
+| Stored in the cloud account, per graph      | Markdown files in `templates/`, per graph          |
+| Managed in a preferences page               | Managed as files; edited in the normal editor      |
+| Inserted via the editor slash menu          | Command palette + meowdown insert menus            |
+| Seeded starter templates on graph creation  | None seeded (no-litter contract); docs show examples |
+| No variable substitution                    | Same — verbatim insertion, at least initially      |
+| Newest-first list in prefs, A→Z in menu     | A→Z everywhere                                     |
+
+## Explicitly not ported
+
+- Starter templates written into every new graph — scaffolding stays
+  minimal; the docs carry copy-pasteable **journal**/**person**/**company**
+  examples instead.
+- Duplicate-name tolerance quirks: filenames make names unique per graph by
+  construction.
+
+## Open questions
+
+- **Indexing.** Templates should not pollute All Notes, search, backlinks,
+  or AI retrieval. Recommended: index `templates/` as a distinct kind
+  (excluded from note surfaces but openable/editable in-app) rather than
+  skipping it entirely — skipping would make templates uneditable inside
+  Reflect. Needs a small decision in the indexer and `notes` projection.
+- **Daily-note templates.** v1 never auto-applied a template to daily notes
+  and users asked for it constantly. A designated `templates/daily.md`
+  applied to new daily notes is a natural v2 extension, but it interacts
+  with the lazy "no file until first keystroke" contract — deferred to its
+  own decision.
+- **Variables.** `{{date}}`-style substitution is deliberately out for
+  parity, but the files-first design leaves room for it later without
+  migration.


### PR DESCRIPTION
## Why

Reflect v1's major features can't be imported into v2 directly — v2 has no server, no accounts, no provider OAuth, and a files-first privacy model, so each feature needs a deliberate porting decision rather than a translation. Until now those decisions lived nowhere; the product-vision doc explicitly deferred templates and contacts/calendar without saying what they should become.

This PR adds `docs/porting/`: ten high-level porting docs, one per major v1 feature, each grounded in the actual v1 behavior (from the v1 repo's `docs/user-feature-behavior/` docs and direct source inspection of `reflect` / `reflect-editor`) and in v2's real architecture (route model, command registry, capture inbox, `CloudSafe` privacy enforcement, keychain, meowdown extension points).

## What's inside

Each doc follows the same shape: what v1 did → what changes in v2 and why → how it will work (UX + architecture split) → what's explicitly not ported → open questions.

| Doc | Verdict |
| --- | --- |
| `note-aliases.md` | Already ported (frontmatter `aliases`); records the mapping + an importer follow-up for v1's `Title // Alias` syntax |
| `audio-memos.md` | Already ported (BYOK transcription); mapping doc |
| `ai-menu-and-prompts.md` | Planned: selection-based prompts with a saved-prompt library; meowdown grows the selection/streaming primitives, core reuses the copilot's provider stack; disabled in `private: true` notes |
| `note-templates.md` | Planned: templates are markdown files in a `templates/` folder — per-graph scope, git sync, and edit-anywhere for free |
| `calendar-meetings-integration.md` | Planned: EventKit instead of OAuth — macOS already aggregates Google/Microsoft/iCloud accounts; events fetched live, never indexed |
| `contacts-integration.md` | Planned: Apple Contacts via live on-demand lookups; no local mirror, address book never enters the index |
| `deep-links.md` | Planned: `reflect://` scheme mapped 1:1 onto the existing `Route` union, id-first note targets; write actions routed through the capture inbox since URL schemes are world-invokable |
| `editor-keyboard-shortcuts.md` | Gap list vs meowdown: `alt+↑/↓` list reordering first, plus the v1 `[`-over-selection wikilink wrap (documented from `backlink-extension.ts` source) |
| `assets.md` | Half ported: image paste/drop shipped; plan for attachment drag/drop as plain markdown links, with a Rust `asset_import` path so Finder drops never ship base64 through the webview |
| `README.md` | Index, the v1→v2 constraint shift, and conventions |

## Verification

Docs-only change — no code, config, or types touched. Internal relative links point at existing files (`docs/privacy.md`, `docs/cli.md`, `docs/readable-filenames.md`, `docs/plans/*`, `docs/contributing/*`). Architecture claims were checked against the current source (e.g. `use-image-persistence.ts`, `routing/route.ts`, `lib/commands/types.ts`, prosekit's list keymap) rather than written from memory.

## Notes for review

These are direction-setting docs, not specs: each ends with open questions where a real decision is still owed (template indexing, deep-link graph addressing, `[`-wrap fidelity trade-off, asset orphan reporting). Disagreeing with a verdict in review is cheap now and expensive after implementation starts — that's the point of the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, config, or type changes.
> 
> **Overview**
> Adds **`docs/porting/`** — a README plus ten direction-setting porting docs that capture how major Reflect v1 features should land in v2 under the no-server, files-first, BYOK, and **`CloudSafe`** constraints.
> 
> The index explains why direct ports fail (no accounts/OAuth, OS-native calendar/contacts, markdown in the graph) and links each feature doc with a **ported / planned / half-ported** verdict. Per-feature writeups follow a shared shape: v1 behavior → v2 deltas and rationale → planned UX and architecture (**TypeScript policy**, **Rust/Tauri capabilities**, **meowdown** editor hooks) → explicit non-goals → open questions.
> 
> Coverage spans already-shipped mappings (**aliases**, **audio memos**), planned work (**selection AI prompts**, **`templates/`** files, **EventKit** meetings, **Apple Contacts**, **`reflect://`** deep links aligned to **`Route`**, editor shortcut gaps), and **assets** (images done; attachments via plain links and planned **`asset_import`** for Finder drops).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 298542656587ea5e31e49c5421eaf57c3e28e11a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a set of new porting guides covering AI prompts, assets, audio memos, calendar and contacts integration, deep links, keyboard shortcuts, note aliases, and note templates.
  * Documented the expected v2 user experience, including local-first workflows, privacy controls, note linking, template insertion, and device permission-based integrations.
  * Added clear v1-to-v2 mapping tables, non-ported behavior notes, and open questions to help track feature parity progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->