### PR TITLE
feat(cli): reflect open <note> — navigate the app via its deep link

### DIFF
--- a/apps/cli/src/commands/mod.rs
+++ b/apps/cli/src/commands/mod.rs
@@ -1,7 +1,9 @@
-//! The four commands. Shared rules live here: stdout carries only data,
-//! warnings go to stderr, and `show`/`path` degrade to a file scan when the
-//! index is missing or unusable (`search` is the one command that requires it).
+//! The five commands. Shared rules live here: stdout carries only data,
+//! warnings go to stderr, and `show`/`path`/`open` degrade to a file scan
+//! when the index is missing or unusable (`search` is the one command that
+//! requires it).
 
+pub mod open;
 pub mod path;
 pub mod search;
 pub mod show;

--- a/apps/cli/src/commands/open.rs
+++ b/apps/cli/src/commands/open.rs
@@ -1,0 +1,212 @@
+//! `reflect open <note>` — resolve like `show`/`path`, then navigate the
+//! Reflect app there by handing the OS URL opener a `reflect://` deep link
+//! (docs/deep-links.md). The URL prefers the most durable address the note
+//! has: the date form for dailies, the frontmatter `id` form when the note
+//! carries one (it survives renames), else the graph-relative path form.
+//! `--print` emits the URL on stdout without launching anything — the
+//! scriptable half, and how the integration tests exercise this command.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use crate::commands::open_index_for_resolution;
+use crate::commands::output::{print_json, OpenJson};
+use crate::error::CliError;
+use crate::graph::Graph;
+use crate::note_file::{ensure_not_private, parse_note_meta};
+use crate::paths::{date_from_daily_path, parse_calendar_date};
+use crate::resolve::{resolve_note, ResolvedNote};
+
+pub fn run(graph: &Graph, json: bool, note_arg: &str, print: bool) -> Result<(), CliError> {
+    let index = open_index_for_resolution(&graph.root);
+    let resolved = resolve_note(note_arg, &graph.root, index.as_ref().map(|open| &open.conn))?;
+
+    // The privacy contract holds on this surface like every other: a private
+    // note is refused (exit 3, same as not-found) before its address leaks.
+    // A daily that doesn't exist yet is fine — navigation creates it lazily.
+    let rel_path = resolved.rel_path();
+    ensure_not_private(&graph.root, rel_path)?;
+
+    let url = deep_link_url(&graph.root, &resolved);
+    let launched = !print;
+    if json {
+        let date = match &resolved {
+            ResolvedNote::Daily { date, .. } => Some(date.as_str()),
+            ResolvedNote::File { rel_path } => date_from_daily_path(rel_path),
+        };
+        print_json(&OpenJson {
+            date,
+            path: rel_path,
+            url: &url,
+            launched,
+        })?;
+    } else {
+        println!("{url}");
+    }
+    if launched {
+        launch(&url)?;
+    }
+    Ok(())
+}
+
+/// The most durable `reflect://` address for a resolved note. Mirrors the
+/// desktop's "Copy deep link" preference order, minus the minting — the CLI
+/// never writes, so a note without an id gets the path form instead.
+fn deep_link_url(root: &Path, resolved: &ResolvedNote) -> String {
+    if let Some(date) = date_from_daily_path(resolved.rel_path()).and_then(parse_calendar_date) {
+        // Calendar-validated: a daily/ file with an impossible date opens as
+        // a plain note in the app, so it gets a note-form address below.
+        return format!("reflect://daily/{date}");
+    }
+    match resolved {
+        ResolvedNote::Daily { date, .. } => format!("reflect://daily/{date}"),
+        ResolvedNote::File { rel_path } => {
+            let id = fs::read_to_string(root.join(rel_path))
+                .ok()
+                .and_then(|content| parse_note_meta(rel_path, &content).id)
+                .filter(|id| !id.trim().is_empty());
+            let target = id.as_deref().unwrap_or(rel_path);
+            format!("reflect://note/{}", encode_uri_component(target))
+        }
+    }
+}
+
+/// JS `encodeURIComponent`, byte for byte — the desktop's deep-link parser
+/// decodes with `decodeURIComponent`, so the two must agree on the alphabet.
+fn encode_uri_component(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        let unreserved = byte.is_ascii_alphanumeric()
+            || matches!(
+                byte,
+                b'-' | b'_' | b'.' | b'!' | b'~' | b'*' | b'\'' | b'(' | b')'
+            );
+        if unreserved {
+            out.push(byte as char);
+        } else {
+            out.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    out
+}
+
+/// Hand the URL to the platform opener. Blocking on the opener's exit keeps
+/// failures loud (exit 1) — the opener itself returns as soon as the URL is
+/// dispatched, it does not wait on the app.
+fn launch(url: &str) -> Result<(), CliError> {
+    let status = launcher(url)
+        .status()
+        .map_err(|err| CliError::Runtime(format!("could not run the OS URL opener: {err}")))?;
+    if !status.success() {
+        return Err(CliError::Runtime(format!(
+            "the OS URL opener failed for {url}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn launcher(url: &str) -> Command {
+    let mut command = Command::new("open");
+    command.arg(url);
+    command
+}
+
+#[cfg(target_os = "linux")]
+fn launcher(url: &str) -> Command {
+    let mut command = Command::new("xdg-open");
+    command.arg(url);
+    command
+}
+
+#[cfg(windows)]
+fn launcher(url: &str) -> Command {
+    let mut command = Command::new("cmd");
+    // The empty string is `start`'s window-title slot; without it the URL
+    // itself would be consumed as the title.
+    command.args(["/C", "start", "", url]);
+    command
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encoding_matches_encode_uri_component() {
+        assert_eq!(encode_uri_component("notes/foo.md"), "notes%2Ffoo.md");
+        assert_eq!(encode_uri_component("Project X"), "Project%20X");
+        assert_eq!(
+            encode_uri_component("a-b_c.d!e~f*g'h(i)j"),
+            "a-b_c.d!e~f*g'h(i)j"
+        );
+        assert_eq!(encode_uri_component("größe"), "gr%C3%B6%C3%9Fe");
+        assert_eq!(encode_uri_component("a&b=c?d#e"), "a%26b%3Dc%3Fd%23e");
+    }
+
+    #[test]
+    fn daily_resolutions_get_the_date_form() {
+        let dir = tempfile::tempdir().unwrap();
+        let resolved = ResolvedNote::Daily {
+            date: "2026-07-01".to_string(),
+            rel_path: "daily/2026-07-01.md".to_string(),
+        };
+        assert_eq!(
+            deep_link_url(dir.path(), &resolved),
+            "reflect://daily/2026-07-01"
+        );
+    }
+
+    #[test]
+    fn a_daily_file_resolved_by_path_still_gets_the_date_form() {
+        let dir = tempfile::tempdir().unwrap();
+        let resolved = ResolvedNote::File {
+            rel_path: "daily/2026-07-01.md".to_string(),
+        };
+        assert_eq!(
+            deep_link_url(dir.path(), &resolved),
+            "reflect://daily/2026-07-01"
+        );
+    }
+
+    #[test]
+    fn an_impossible_date_daily_file_gets_the_path_form() {
+        let dir = tempfile::tempdir().unwrap();
+        let resolved = ResolvedNote::File {
+            rel_path: "daily/2026-02-31.md".to_string(),
+        };
+        assert_eq!(
+            deep_link_url(dir.path(), &resolved),
+            "reflect://note/daily%2F2026-02-31.md"
+        );
+    }
+
+    #[test]
+    fn notes_prefer_the_frontmatter_id_over_the_path() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("notes")).unwrap();
+        std::fs::write(
+            dir.path().join("notes/a.md"),
+            "---\nid: 01hzy3v9k2m4n6p8q0r2s4t6vw\n---\n# A\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("notes/b.md"), "# B, no id\n").unwrap();
+
+        let with_id = ResolvedNote::File {
+            rel_path: "notes/a.md".to_string(),
+        };
+        assert_eq!(
+            deep_link_url(dir.path(), &with_id),
+            "reflect://note/01hzy3v9k2m4n6p8q0r2s4t6vw"
+        );
+
+        let without_id = ResolvedNote::File {
+            rel_path: "notes/b.md".to_string(),
+        };
+        assert_eq!(
+            deep_link_url(dir.path(), &without_id),
+            "reflect://note/notes%2Fb.md"
+        );
+    }
+}

--- a/apps/cli/src/commands/output.rs
+++ b/apps/cli/src/commands/output.rs
@@ -30,6 +30,19 @@ pub struct PathJson<'a> {
     pub exists: bool,
 }
 
+/// `open`: the deep link handed to the OS opener (or just printed).
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenJson<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date: Option<&'a str>,
+    pub path: &'a str,
+    /// The `reflect://` URL (docs/deep-links.md).
+    pub url: &'a str,
+    /// False under `--print` — the URL was emitted, not handed to the OS.
+    pub launched: bool,
+}
+
 /// `search`: the ranked hits plus the staleness signal.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/apps/cli/src/frontmatter.rs
+++ b/apps/cli/src/frontmatter.rs
@@ -1,8 +1,8 @@
 //! Tolerant, read-only frontmatter — the Rust mirror of
 //! `packages/core/src/markdown/frontmatter.ts` (split semantics) and
 //! `model.ts` (field coercions), restricted to the fields the CLI needs:
-//! `title`, `aliases`, `private`. Broken YAML degrades to "no frontmatter",
-//! never an unreadable note. The CLI never writes frontmatter.
+//! `id`, `title`, `aliases`, `private`. Broken YAML degrades to "no
+//! frontmatter", never an unreadable note. The CLI never writes frontmatter.
 
 use saphyr::{LoadableYamlNode, Scalar, Yaml};
 
@@ -10,6 +10,8 @@ use saphyr::{LoadableYamlNode, Scalar, Yaml};
 /// rules exactly — it is the hard privacy block and must never drift.
 #[derive(Debug, Default, PartialEq)]
 pub struct Frontmatter {
+    /// The durable note identity (Plan 17's ULID); string-only, like `title`.
+    pub id: Option<String>,
     pub title: Option<String>,
     pub aliases: Vec<String>,
     pub private: bool,
@@ -131,7 +133,12 @@ pub fn parse_frontmatter(raw: Option<&str>) -> Frontmatter {
         return Frontmatter::default();
     };
     Frontmatter {
-        // `title` must be a string (the TS `stringField`); other types are ignored.
+        // `id` and `title` must be strings (the TS `stringField`); other
+        // types are ignored.
+        id: document
+            .as_mapping_get("id")
+            .and_then(|node| node.as_str())
+            .map(str::to_string),
         title: document
             .as_mapping_get("title")
             .and_then(|node| node.as_str())
@@ -152,6 +159,16 @@ mod tests {
 
     fn parse(source: &str) -> Frontmatter {
         parse_frontmatter(split_frontmatter(source).raw)
+    }
+
+    #[test]
+    fn id_is_string_only_like_title() {
+        let parsed = parse("---\nid: 01hzy3v9k2m4n6p8q0r2s4t6vw\n---\n");
+        assert_eq!(parsed.id.as_deref(), Some("01hzy3v9k2m4n6p8q0r2s4t6vw"));
+
+        // The TS `stringField` ignores non-strings; a numeric id is no id.
+        assert_eq!(parse("---\nid: 42\n---\n").id, None);
+        assert_eq!(parse("---\ntitle: no id here\n---\n").id, None);
     }
 
     #[test]

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -56,6 +56,14 @@ enum Command {
         /// A YYYY-MM-DD date, graph-relative path, note title, or alias
         note: String,
     },
+    /// Open a note in the Reflect app via its reflect:// deep link
+    Open {
+        /// A YYYY-MM-DD date, graph-relative path, note title, or alias
+        note: String,
+        /// Print the URL without launching the app
+        #[arg(long)]
+        print: bool,
+    },
 }
 
 fn run(cli: &Cli) -> Result<(), CliError> {
@@ -65,6 +73,7 @@ fn run(cli: &Cli) -> Result<(), CliError> {
         Command::Search { query, limit } => commands::search::run(&graph, cli.json, query, *limit),
         Command::Show { note } => commands::show::run(&graph, cli.json, note),
         Command::Path { note } => commands::path::run(&graph, cli.json, note),
+        Command::Open { note, print } => commands::open::run(&graph, cli.json, note, *print),
     }
 }
 

--- a/apps/cli/src/note_file.rs
+++ b/apps/cli/src/note_file.rs
@@ -16,6 +16,8 @@ use crate::paths::{date_from_daily_path, NOTE_DIRS};
 /// A note's derived metadata, as the TS indexer would compute it.
 #[derive(Debug)]
 pub struct NoteMeta {
+    /// The frontmatter `id` (Plan 17's ULID), when the note carries one.
+    pub id: Option<String>,
     pub title: String,
     pub aliases: Vec<String>,
     pub private: bool,
@@ -106,6 +108,7 @@ pub fn parse_note_meta(rel_path: &str, source: &str) -> NoteMeta {
     let frontmatter = parse_frontmatter(split.raw);
     let title = derive_title(rel_path, &frontmatter, split.body);
     NoteMeta {
+        id: frontmatter.id,
         title,
         aliases: frontmatter.aliases,
         private: frontmatter.private,

--- a/apps/cli/tests/cli.rs
+++ b/apps/cli/tests/cli.rs
@@ -43,7 +43,7 @@ impl Fixture {
             conn.execute(
                 "INSERT INTO notes(path, id, title, title_key, daily_date, is_private, is_pinned,
                                    pinned_order, file_hash, mtime, updated_at, preview)
-                 VALUES(?1, NULL, ?2, ?3, ?4, ?5, 0, NULL, ?6, ?7, ?7, '')",
+                 VALUES(?1, ?8, ?2, ?3, ?4, ?5, 0, NULL, ?6, ?7, ?7, '')",
                 params![
                     note.rel_path,
                     meta.title,
@@ -52,6 +52,7 @@ impl Fixture {
                     i64::from(meta.private),
                     hash_content(&content),
                     note.mtime_ms as i64,
+                    meta.id,
                 ],
             )
             .unwrap();
@@ -466,4 +467,117 @@ fn path_resolves_notes_and_would_be_dailies() {
     ));
     assert_eq!(existing["exists"], true);
     assert!(existing.get("date").is_none());
+}
+
+// ---- open -----------------------------------------------------------------------
+
+#[test]
+fn open_print_prefers_the_frontmatter_id() {
+    let fixture = graph();
+    fixture.write_note(
+        "notes/project-x.md",
+        "---\nid: 01hzy3v9k2m4n6p8q0r2s4t6vw\n---\n# Project X\n",
+    );
+    fixture.build_index();
+
+    let output = reflect(&fixture, &["open", "Project X", "--print"]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    assert_eq!(
+        stdout(&output),
+        "reflect://note/01hzy3v9k2m4n6p8q0r2s4t6vw\n"
+    );
+}
+
+#[test]
+fn open_print_falls_back_to_the_encoded_path_without_an_id() {
+    let fixture = graph();
+    fixture.write_note("notes/no id here.md", "# No Id Here\n");
+    fixture.build_index();
+
+    let output = reflect(&fixture, &["open", "No Id Here", "--print"]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    assert_eq!(
+        stdout(&output),
+        "reflect://note/notes%2Fno%20id%20here.md\n"
+    );
+}
+
+#[test]
+fn open_print_gives_dailies_the_date_form_even_before_the_file_exists() {
+    let fixture = graph();
+
+    let would_be = reflect(&fixture, &["open", "2099-01-01", "--print"]);
+    assert!(would_be.status.success(), "stderr: {}", stderr(&would_be));
+    assert_eq!(stdout(&would_be), "reflect://daily/2099-01-01\n");
+
+    // An existing daily resolved by explicit path gets the date form too.
+    fixture.write_note("daily/2026-01-02.md", "daily body\n");
+    let by_path = reflect(&fixture, &["open", "daily/2026-01-02.md", "--print"]);
+    assert_eq!(stdout(&by_path), "reflect://daily/2026-01-02\n");
+}
+
+#[test]
+fn open_resolves_by_title_and_alias_without_an_index() {
+    let fixture = graph();
+    fixture.write_note(
+        "notes/project-x.md",
+        "---\nid: 01hzy3v9k2m4n6p8q0r2s4t6vw\naliases: [PX]\n---\n# Project X\n",
+    );
+
+    for arg in ["project x", "PX"] {
+        let output = reflect(&fixture, &["open", arg, "--print"]);
+        assert!(output.status.success(), "open {arg}: {}", stderr(&output));
+        assert_eq!(
+            stdout(&output),
+            "reflect://note/01hzy3v9k2m4n6p8q0r2s4t6vw\n",
+            "open {arg}"
+        );
+    }
+}
+
+#[test]
+fn open_refuses_private_notes_and_unknown_targets() {
+    let fixture = graph();
+    fixture.write_note("notes/a.md", "---\nprivate: true\n---\n# Alpha\n");
+    fixture.build_index();
+
+    let private = reflect(&fixture, &["open", "notes/a.md", "--print"]);
+    assert_eq!(private.status.code(), Some(3));
+    assert_eq!(
+        stdout(&private),
+        "",
+        "a private note's address must not leak"
+    );
+    assert!(stderr(&private).contains("private"));
+
+    let unknown = reflect(&fixture, &["open", "No Such Note", "--print"]);
+    assert_eq!(unknown.status.code(), Some(3));
+    assert!(stderr(&unknown).contains("no note matching"));
+}
+
+#[test]
+fn open_json_shape() {
+    let fixture = graph();
+    fixture.write_note(
+        "notes/project-x.md",
+        "---\nid: 01hzy3v9k2m4n6p8q0r2s4t6vw\n---\n# Project X\n",
+    );
+    fixture.build_index();
+
+    let note = json(&reflect(
+        &fixture,
+        &["open", "Project X", "--print", "--json"],
+    ));
+    assert_eq!(note["path"], "notes/project-x.md");
+    assert_eq!(note["url"], "reflect://note/01hzy3v9k2m4n6p8q0r2s4t6vw");
+    assert_eq!(note["launched"], false);
+    assert!(note.get("date").is_none());
+
+    let daily = json(&reflect(
+        &fixture,
+        &["open", "2026-01-02", "--json", "--print"],
+    ));
+    assert_eq!(daily["date"], "2026-01-02");
+    assert_eq!(daily["path"], "daily/2026-01-02.md");
+    assert_eq!(daily["url"], "reflect://daily/2026-01-02");
 }

--- a/apps/cli/tests/parity.rs
+++ b/apps/cli/tests/parity.rs
@@ -63,6 +63,7 @@ fn note_derivations_match_the_ts_pipeline() {
         let content = fs::read_to_string(corpus.join(rel_path)).unwrap();
         let meta = parse_note_meta(rel_path, &content);
 
+        assert_eq!(meta.id.as_deref(), want["id"].as_str(), "{rel_path}: id");
         assert_eq!(
             meta.title,
             want["title"].as_str().unwrap(),

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,6 +11,7 @@ reflect today --path       # its absolute path (works before the file exists)
 reflect search <query>     # ranked full-text search over the index
 reflect show <note>        # print a note by date, path, title, or alias
 reflect path <note>        # resolve a note to its absolute path
+reflect open <note>        # open a note in the app (reflect:// deep link)
 ```
 
 Built from `apps/cli` (`cargo build -p reflect-cli`); bundled with the desktop
@@ -127,9 +128,28 @@ prints the would-be daily path even before the file exists.
 { "date": "2099-01-01", "path": "daily/2099-01-01.md", "absolutePath": "…", "exists": false }
 ```
 
+### `reflect open <note> [--print] [--json]`
+
+Same resolution, then navigates the Reflect app there by handing the OS URL
+opener the note's `reflect://` deep link ([docs/deep-links.md](deep-links.md)).
+The URL prefers the most durable address the note has: the date form for
+dailies (which need not exist yet — navigation creates them lazily), the
+frontmatter `id` form when the note carries one (it survives renames), else
+the graph-relative path form. The CLI never writes, so it does not mint ids —
+"Copy deep link" in the app does that.
+
+The URL is always printed to stdout; `--print` skips launching the opener —
+the scriptable half. Private notes are refused (exit `3`) like every other
+CLI surface, before their address leaks.
+
+```jsonc
+// reflect open "Project X" --json --print   ("date" only appears for dailies)
+{ "path": "notes/project-x.md", "url": "reflect://note/01hzy3…", "launched": false }
+```
+
 ## For agents
 
-The four commands plus `--json` are the supported automation surface (e.g.
+The five commands plus `--json` are the supported automation surface (e.g.
 `~/.agents` discovery workflows). The JSON field names and exit codes above
 are stable; new fields may be added, existing ones won't change meaning.
 Reading a private note is not possible through this surface by design — don't

--- a/docs/deep-links.md
+++ b/docs/deep-links.md
@@ -70,6 +70,9 @@ drain re-runs cleanly.
 
 The scheme and the [CLI](cli.md) stay complementary: the CLI reads and
 resolves for scripts (`reflect show`, `reflect path`); the scheme navigates
-and captures. The scheme's resolution is the CLI's order with the
-frontmatter `id` step in front — the CLI does not resolve ids yet; a
-`reflect open <note>` verb is the natural place for it to pick that up.
+and captures. `reflect open <note>` bridges the two — it resolves like
+`reflect show` and shells out to the scheme URL, preferring the frontmatter
+`id` form (never minting one; the CLI doesn't write), the date form for
+dailies, and the path form otherwise. `--print` emits the URL without
+launching. The scheme's own resolution is the CLI's order with the
+frontmatter `id` step in front.

--- a/fixtures/parity/expected.json
+++ b/fixtures/parity/expected.json
@@ -1,6 +1,7 @@
 {
   "notes": {
     "daily/2026-01-02.md": {
+      "id": null,
       "title": "2026-01-02",
       "titleKey": "2026-01-02",
       "aliases": [],
@@ -9,6 +10,7 @@
       "fileHash": "62fa1d37b9117ff9c8b06bbe2238e328847ee93596166a792a5b5a5320a98e2e"
     },
     "daily/not-a-date.md": {
+      "id": null,
       "title": "not-a-date",
       "titleKey": "not-a-date",
       "aliases": [],
@@ -17,6 +19,7 @@
       "fileHash": "d108c5b255bc773645f74c54f8a498c5a8d4aaf750bccb3c4e5a3569031008c3"
     },
     "notes/Fancy Name.md": {
+      "id": null,
       "title": "Fancy Name",
       "titleKey": "fancy name",
       "aliases": [],
@@ -25,6 +28,7 @@
       "fileHash": "1998e1121758efc6cde0d945f8e0c9d44dce58a972d96bd8ebc36f4f111f490d"
     },
     "notes/aliases-invalid.md": {
+      "id": null,
       "title": "Bad Aliases",
       "titleKey": "bad aliases",
       "aliases": [],
@@ -33,6 +37,7 @@
       "fileHash": "9542d8a3d64afef23223f8d1f2834a81a255f8fc305b7a67829840d3398dcc66"
     },
     "notes/aliases-nested.md": {
+      "id": null,
       "title": "Nested Aliases",
       "titleKey": "nested aliases",
       "aliases": [],
@@ -41,6 +46,7 @@
       "fileHash": "908fa211637831cc52411262f3d69d49eccd706efeb36b01f8eba7f98ff8c826"
     },
     "notes/broken-yaml.md": {
+      "id": null,
       "title": "Broken Yaml Fallback",
       "titleKey": "broken yaml fallback",
       "aliases": [],
@@ -49,6 +55,7 @@
       "fileHash": "fc884af78bfb872cfd0c3eed62903ea5f20e117fc6f2767341d7752ac00ff01f"
     },
     "notes/closing-hashes.md": {
+      "id": null,
       "title": "Spaced Out",
       "titleKey": "spaced out",
       "aliases": [],
@@ -57,6 +64,7 @@
       "fileHash": "059fbbc0b6288a7c0658c9cc853e6878c1ef6cf34eb6d047ba510122eb23a72a"
     },
     "notes/crlf.md": {
+      "id": null,
       "title": "Windows Note",
       "titleKey": "windows note",
       "aliases": [],
@@ -65,6 +73,7 @@
       "fileHash": "3b5cda541ec39c2c23eb4c8dc4632abce5da3815f9d5656b905f77336cd60937"
     },
     "notes/empty-frontmatter.md": {
+      "id": null,
       "title": "After Empty Block",
       "titleKey": "after empty block",
       "aliases": [],
@@ -73,6 +82,7 @@
       "fileHash": "f3d9caa4f93b889a114dd83a0766a1ad588537818ff8bfe5c2381387c779f4c3"
     },
     "notes/empty-h1-then-real.md": {
+      "id": null,
       "title": "Real Title",
       "titleKey": "real title",
       "aliases": [],
@@ -81,6 +91,7 @@
       "fileHash": "1d3abfd2d69d349ca1e22b30ee94803031b240d50968c791d770a235980df848"
     },
     "notes/fm-title-non-string.md": {
+      "id": null,
       "title": "Numeric Title Fallback",
       "titleKey": "numeric title fallback",
       "aliases": [],
@@ -89,6 +100,7 @@
       "fileHash": "4bd09f083ec1bd08f58c5f9a1890712908b7af157e2a60b323790667f5505018"
     },
     "notes/fm-title-whitespace.md": {
+      "id": null,
       "title": "Padded",
       "titleKey": "padded",
       "aliases": [],
@@ -97,6 +109,7 @@
       "fileHash": "dd2f361735950a0ea9cb918d6e0b2e5aa9cca391acb6728259d926e2ba19cdcf"
     },
     "notes/fm-title-wins.md": {
+      "id": null,
       "title": "FM Title",
       "titleKey": "fm title",
       "aliases": [
@@ -110,7 +123,30 @@
       "private": false,
       "fileHash": "0682cdb53f7fb3cd5cdc9df0ff653301fabed8ed82e200a6331237ba53f137af"
     },
+    "notes/frontmatter-id-number.md": {
+      "id": null,
+      "title": "Numeric Id Is No Id",
+      "titleKey": "numeric id is no id",
+      "aliases": [],
+      "aliasKeys": [],
+      "private": false,
+      "fileHash": "49a8ae9fd78d833c25f8b34058b96384ea30d5ca9d0a9b697e6d26583c970c00"
+    },
+    "notes/frontmatter-id.md": {
+      "id": "01hzy3v9k2m4n6p8q0r2s4t6vw",
+      "title": "Carries An Id",
+      "titleKey": "carries an id",
+      "aliases": [
+        "With Id"
+      ],
+      "aliasKeys": [
+        "with id"
+      ],
+      "private": false,
+      "fileHash": "3cf0d98e4c2d173ba03df92f4b9183b11627f917dc97dc409b3fed7de916bce0"
+    },
     "notes/h1-in-code-fence.md": {
+      "id": null,
       "title": "h1-in-code-fence",
       "titleKey": "h1-in-code-fence",
       "aliases": [],
@@ -119,6 +155,7 @@
       "fileHash": "2514bfc7bfd365bcd14eaf83cea441be889207510768ca51fda42c1f25031d0c"
     },
     "notes/h1-inline-markup.md": {
+      "id": null,
       "title": "The *Heading* [[Link]]",
       "titleKey": "the *heading* [[link]]",
       "aliases": [],
@@ -127,6 +164,7 @@
       "fileHash": "b6b9e67480f08bd54378318c1e8b39999cc4027cec24dcaf7b68a19afaf2c4a9"
     },
     "notes/h2-only.md": {
+      "id": null,
       "title": "h2-only",
       "titleKey": "h2-only",
       "aliases": [],
@@ -135,6 +173,7 @@
       "fileHash": "5e1864d606bce4f8f23c6d147d4d01f89ea5be325631a02f7ddbce6a2ff44281"
     },
     "notes/non-mapping-frontmatter.md": {
+      "id": null,
       "title": "List Frontmatter",
       "titleKey": "list frontmatter",
       "aliases": [],
@@ -143,6 +182,7 @@
       "fileHash": "cd7fc018e2b41b6e98a25f7241afbeb256c2df3b1adbaf31e00bed91e86a011e"
     },
     "notes/private-false.md": {
+      "id": null,
       "title": "private-false",
       "titleKey": "private-false",
       "aliases": [],
@@ -151,6 +191,7 @@
       "fileHash": "868340dff9d704b9e88435447159ca8d279a7ce775361421b3648f62a40c2d6c"
     },
     "notes/private-float-one.md": {
+      "id": null,
       "title": "private-float-one",
       "titleKey": "private-float-one",
       "aliases": [],
@@ -159,6 +200,7 @@
       "fileHash": "2264a8b6ab3094b1315a575d26c337b34667fca664354fb544f0ab2f7e52e834"
     },
     "notes/private-list.md": {
+      "id": null,
       "title": "private-list",
       "titleKey": "private-list",
       "aliases": [],
@@ -167,6 +209,7 @@
       "fileHash": "aa3910f50fbd9c4d02361468b1912be3c8ecdef2586a99c8eb5a9dc242ea176e"
     },
     "notes/private-numeric-one.md": {
+      "id": null,
       "title": "private-numeric-one",
       "titleKey": "private-numeric-one",
       "aliases": [],
@@ -175,6 +218,7 @@
       "fileHash": "ecce28254bbef7ed757f0fd134dbedeb17735d3c1f53ec8a0d8eef97b5a17bae"
     },
     "notes/private-on.md": {
+      "id": null,
       "title": "private-on",
       "titleKey": "private-on",
       "aliases": [],
@@ -183,6 +227,7 @@
       "fileHash": "0525882d00c147377fdd30d95d39f64ca4f384d160171de46565c1c6e6cdf025"
     },
     "notes/private-true.md": {
+      "id": null,
       "title": "private-true",
       "titleKey": "private-true",
       "aliases": [],
@@ -191,6 +236,7 @@
       "fileHash": "012abdcdbcbb0ea2448a12224338988d1d1980122067f0bf14015bdb02ce6231"
     },
     "notes/private-two.md": {
+      "id": null,
       "title": "private-two",
       "titleKey": "private-two",
       "aliases": [],
@@ -199,6 +245,7 @@
       "fileHash": "57f80adbe986f4f91714ba7baa8c3f1f9e1009fa535c4318b25a8d51a8d3c12f"
     },
     "notes/private-word.md": {
+      "id": null,
       "title": "private-word",
       "titleKey": "private-word",
       "aliases": [],
@@ -207,6 +254,7 @@
       "fileHash": "6226f525fdcba9cd5678d8cf8253346d93e4e2765ef15f293ac8028bc8c40cb0"
     },
     "notes/private-yes-string.md": {
+      "id": null,
       "title": "private-yes-string",
       "titleKey": "private-yes-string",
       "aliases": [],
@@ -215,6 +263,7 @@
       "fileHash": "6aab2434b92b9f9fa1e4e517573411cb57880051eb5a45f801a196e502dc3858"
     },
     "notes/setext-h1.md": {
+      "id": null,
       "title": "Setext Title",
       "titleKey": "setext title",
       "aliases": [],
@@ -223,6 +272,7 @@
       "fileHash": "f9f8e690366a9e93c182db9b49a5748de8ce921c839528a20fc532ae65c8ecbc"
     },
     "notes/sub/nested-note.md": {
+      "id": null,
       "title": "nested-note",
       "titleKey": "nested-note",
       "aliases": [],
@@ -231,6 +281,7 @@
       "fileHash": "8316729753b63c608eeb3536369bb26ea37bb3ae519b18f58c85966a8452ac8b"
     },
     "notes/unicode-title.md": {
+      "id": null,
       "title": "Café ÉTÉ",
       "titleKey": "café été",
       "aliases": [],
@@ -239,6 +290,7 @@
       "fileHash": "721130eb619d3c4a5430f9a25f36f8af4ba742f2aa056c7ffe137896fbe1516f"
     },
     "notes/unterminated-fence.md": {
+      "id": null,
       "title": "unterminated-fence",
       "titleKey": "unterminated-fence",
       "aliases": [],

--- a/fixtures/parity/notes/frontmatter-id-number.md
+++ b/fixtures/parity/notes/frontmatter-id-number.md
@@ -1,0 +1,4 @@
+---
+id: 42
+---
+# Numeric Id Is No Id

--- a/fixtures/parity/notes/frontmatter-id.md
+++ b/fixtures/parity/notes/frontmatter-id.md
@@ -1,0 +1,6 @@
+---
+id: 01hzy3v9k2m4n6p8q0r2s4t6vw
+aliases: [With Id]
+---
+# Carries An Id
+body

--- a/packages/core/src/indexing/parity.test.ts
+++ b/packages/core/src/indexing/parity.test.ts
@@ -32,6 +32,8 @@ const expectedFile = join(corpusDir, 'expected.json')
 
 /** Expectations for one fixture note — the derivations both sides must agree on. */
 interface ExpectedNote {
+  /** Frontmatter `id`, string-only like `title` (null when absent/non-string). */
+  id: string | null
   title: string
   titleKey: string
   aliases: string[]
@@ -84,6 +86,7 @@ async function deriveExpectations(): Promise<ExpectedParity> {
       source,
     })
     notes[relPath] = {
+      id: indexed.id,
       title: indexed.title,
       titleKey: indexed.titleKey,
       aliases: indexed.aliases.map((alias) => alias.alias),


### PR DESCRIPTION
**Stacked on #455** (the reflect:// deep-link scheme) — GitHub will retarget this to `next` when that merges. Implements the follow-up both deep-link docs name: one resolution routine, three front doors (palette, CLI, links).

## What this adds

`reflect open <note> [--print] [--json]` resolves `<note>` exactly like `reflect show`/`reflect path` (calendar date → explicit path → title → alias, index-backed with the file-scan fallback) and hands the OS URL opener (`open` / `xdg-open` / `start`) the note's `reflect://` deep link.

The URL prefers the most durable address the note has:

- **date form** for dailies (`reflect://daily/2026-07-01`) — the daily need not exist, navigation creates it lazily; an impossible-date `daily/` file gets the path form instead, matching the app's `routeForPath`;
- **frontmatter id form** when the note carries one (`reflect://note/<ulid>`) — rename-proof; the CLI never writes, so it doesn't mint ids ("Copy deep link" in the app does);
- **percent-encoded path form** otherwise, with a byte-exact `encodeURIComponent` mirror so the desktop parser decodes it verbatim.

`--print` emits the URL without launching — the scriptable half, and how the tests exercise the command. Output contract per docs/cli.md: stdout carries only the URL (or `--json`: `{date?, path, url, launched}`), private notes are refused with exit `3` before their address leaks, unknown targets exit `3`.

## Parity discipline

The frontmatter mirror gains `id` with the same string-only coercion as `title` (`stringField`), pinned by two new corpus fixtures (string id; numeric `id: 42` → no id) — `expected.json` regenerated by the TS side and asserted by the Rust side, per `fixtures/parity/README.md`.

## Testing

- 6 new integration tests (`apps/cli/tests/cli.rs`): id preference, encoded-path fallback, date form before the daily exists, index-free title/alias resolution, private/unknown exit codes, `--json` shape.
- 5 unit tests for URL building + encoding, plus a frontmatter id-coercion test.
- `cargo test -p reflect-cli` (54 tests), `cargo clippy --all-targets`, `cargo fmt --check`, TS parity suite, and core typecheck all green.
- Not verified live: an actual launch needs a bundled app registered for `reflect://` (same caveat as #455); everything up to the `launch()` boundary is covered by `--print`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only CLI and documentation changes with no writes or auth; privacy checks mirror existing commands before URLs are emitted.
> 
> **Overview**
> Adds **`reflect open <note> [--print] [--json]`**, which resolves notes like `show`/`path`, builds a `reflect://` deep link (daily date → frontmatter `id` → percent-encoded path, with JS-compatible `encodeURIComponent`), prints it on stdout, and optionally invokes the OS URL opener (`open` / `xdg-open` / `start`). **`--print`** skips launch for scripting; **`--json`** adds `OpenJson` (`url`, `launched`, etc.). Private notes still exit `3` with no URL on stdout.
> 
> The read-side frontmatter mirror gains string-only **`id`** on `Frontmatter` / `NoteMeta` so deep links can prefer ULIDs without minting. Parity corpus gets two fixtures and regenerated `expected.json`; TS parity test and Rust `parity.rs` assert `id`.
> 
> Docs (`cli.md`, `deep-links.md`) describe the fifth command and CLI↔scheme bridge. Integration and unit tests cover URL shapes, privacy, index-free resolution, and encoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b33ad10006847107eba5a4c34330a6f3fc32802. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->