### PR TITLE
Combine daily scroll fixes: re-anchor on new note (#386) + sidebar tab restoration (#419)

### DIFF
--- a/apps/desktop/src/components/command-palette/command-palette.test.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.test.tsx
@@ -86,6 +86,7 @@ function renderPalette(query: string, context?: Partial<CommandContext>) {
     notePath: () => null,
     back: vi.fn(),
     forward: vi.fn(),
+    clearScrollState: vi.fn(),
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
     newChat: vi.fn(),

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -121,6 +121,7 @@ function renderSidebar(overrides?: Partial<CommandContext>, initialRoute?: Route
     notePath: () => null,
     back: vi.fn(),
     forward: vi.fn(),
+    clearScrollState: vi.fn(),
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
     newChat: vi.fn(),
@@ -147,11 +148,16 @@ function renderSidebar(overrides?: Partial<CommandContext>, initialRoute?: Route
 }
 
 describe('Sidebar', () => {
-  it('nav rows run their registered commands', async () => {
+  it('nav rows navigate, with Daily notes restoring its surface scroll', async () => {
     const { view, navigate } = renderSidebar()
 
     await userEvent.click(view.getByRole('button', { name: /daily notes/i }))
-    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ kind: 'today' }))
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith(
+        { kind: 'today' },
+        { restoreSurfaceScroll: true },
+      ),
+    )
 
     await userEvent.click(view.getByRole('button', { name: /settings/i }))
     await waitFor(() => expect(navigate).toHaveBeenCalledWith({ kind: 'settings' }))

--- a/apps/desktop/src/components/sidebar/sidebar.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.tsx
@@ -29,9 +29,11 @@ interface SidebarProps {
 /**
  * The workspace sidebar, in the original app's shape: history arrows top
  * right, search, primary navigation with hover-revealed shortcut keycaps, the
- * Pinned shelf, and the graph switcher footer. Nav rows run registered
- * commands so a binding and its behavior stay one definition. (Sidebar
- * collapse stays on `Mod-\` via the command registry.)
+ * Pinned shelf, and the graph switcher footer. Most nav rows run registered
+ * commands so a binding and its behavior stay one definition; the Daily notes
+ * row restores the stream's surface scroll on click, while its `Mod-D` binding
+ * still runs the command and re-anchors to today. (Sidebar collapse stays on
+ * `Mod-\` via the command registry.)
  */
 export function Sidebar({ graph, context }: SidebarProps): ReactElement {
   const { route } = useRouter()
@@ -72,7 +74,9 @@ export function Sidebar({ graph, context }: SidebarProps): ReactElement {
             label="Daily notes"
             binding={keybindingFor('nav.today') ?? undefined}
             active={(route.kind === 'today' || route.kind === 'daily') && !hasActivePinnedNote}
-            onClick={() => void runCommand('nav.today', context)}
+            onClick={() =>
+              context.navigate({ kind: 'today' }, { restoreSurfaceScroll: true })
+            }
           />
           <SidebarItem
             icon={

--- a/apps/desktop/src/components/sidebar/sidebar.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.tsx
@@ -31,9 +31,9 @@ interface SidebarProps {
  * right, search, primary navigation with hover-revealed shortcut keycaps, the
  * Pinned shelf, and the graph switcher footer. Most nav rows run registered
  * commands so a binding and its behavior stay one definition; the Daily notes
- * row restores the stream's surface scroll on click, while its `Mod-D` binding
- * still runs the command and re-anchors to today. (Sidebar collapse stays on
- * `Mod-\` via the command registry.)
+ * row restores the stream's surface scroll when clicked from another surface
+ * (the router re-anchors it, like `Mod-D`, when the stream is already
+ * showing). (Sidebar collapse stays on `Mod-\` via the command registry.)
  */
 export function Sidebar({ graph, context }: SidebarProps): ReactElement {
   const { route } = useRouter()

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -65,6 +65,7 @@ function fakeContext(overrides?: Partial<CommandContext>) {
     notePath: () => notePathForRoute(route(), TODAY),
     back: vi.fn(),
     forward: vi.fn(),
+    clearScrollState: vi.fn(),
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
     newChat: vi.fn(),
@@ -154,13 +155,25 @@ describe('app commands', () => {
     expect(outsideChat.newChat).not.toHaveBeenCalled()
   })
 
-  it('note.new navigates to a fresh lazy ULID note path', async () => {
-    const { context, navigated } = fakeContext()
+  it('note.new clears daily scroll and navigates to a fresh lazy ULID note path', async () => {
+    const clearScrollState = vi.fn()
+    const { context, navigated } = fakeContext({ clearScrollState })
     await command('note.new').run(context)
+    expect(clearScrollState).toHaveBeenCalledTimes(1)
     expect(navigated).toHaveLength(1)
     const route = navigated[0]!
     expect(route.kind).toBe('note')
     expect((route as { kind: 'note'; path: string }).path).toMatch(/^notes\/[0-9a-z]+\.md$/)
+  })
+
+  it('note.new leaves non-daily route scroll restoration intact', async () => {
+    const clearScrollState = vi.fn()
+    const { context } = fakeContext({
+      clearScrollState,
+      route: () => ({ kind: 'allNotes', tag: null }),
+    })
+    await command('note.new').run(context)
+    expect(clearScrollState).not.toHaveBeenCalled()
   })
 
   it('note.random navigates to the picked note and no-ops on an empty graph', async () => {

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -14,7 +14,7 @@ import { startOperation } from '@/lib/operations'
 import { rebuildIndexVisibly } from '@/lib/rebuild-index'
 import { type Route } from '@/routing/route'
 import { registerCommands } from './registry'
-import type { AppCommand } from './types'
+import type { AppCommand, CommandContext } from './types'
 
 /**
  * The first-wave commands (Plan 08). Keybindings here replace the hardcoded
@@ -29,6 +29,21 @@ import type { AppCommand } from './types'
  */
 export function newNoteRoute(): Route {
   return { kind: 'note', path: untitledNotePath() }
+}
+
+/**
+ * ⌘N from the daily stream leaves its saved scroll offsets behind as stale
+ * state: the fresh note is where attention moves, so a later return to the
+ * stream — ⌘[ back or the Daily nav tab — should re-anchor to its target, not
+ * restore the pre-note position. Other routes keep their offsets; only the
+ * stream re-anchors around note creation.
+ */
+function openNewNote(context: CommandContext): void {
+  const route = context.route()
+  if (route.kind === 'today' || route.kind === 'daily') {
+    context.clearScrollState()
+  }
+  context.navigate(newNoteRoute())
 }
 
 const APP_COMMANDS: AppCommand[] = [
@@ -58,7 +73,7 @@ const APP_COMMANDS: AppCommand[] = [
     title: 'New note',
     keywords: ['create'],
     keybinding: 'Mod-n',
-    run: (context) => context.navigate(newNoteRoute()),
+    run: openNewNote,
   },
   {
     id: 'chat.open',

--- a/apps/desktop/src/lib/commands/registry.test.ts
+++ b/apps/desktop/src/lib/commands/registry.test.ts
@@ -13,6 +13,7 @@ function fakeContext(overrides?: Partial<CommandContext>): CommandContext {
     notePath: () => null,
     back: vi.fn(),
     forward: vi.fn(),
+    clearScrollState: vi.fn(),
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
     newChat: vi.fn(),

--- a/apps/desktop/src/lib/commands/types.ts
+++ b/apps/desktop/src/lib/commands/types.ts
@@ -1,4 +1,5 @@
 import type { Route } from '@/routing/route'
+import type { NavigateOptions } from '@/routing/router'
 
 /**
  * The typed command contract (Plan 08): one registry powers the ⌘K palette,
@@ -8,7 +9,7 @@ import type { Route } from '@/routing/route'
  */
 
 export interface CommandContext {
-  navigate: (route: Route) => void
+  navigate: (route: Route, options?: NavigateOptions) => void
   /** The current route, read at run time. */
   route: () => Route
   /**
@@ -20,6 +21,8 @@ export interface CommandContext {
   notePath: () => string | null
   back: () => void
   forward: () => void
+  /** Discard the current view's saved scroll offsets so it re-anchors when revisited. */
+  clearScrollState: () => void
   toggleTheme: () => void
   /** Collapse/expand the workspace sidebar. */
   toggleSidebar: () => void

--- a/apps/desktop/src/routing/app-shortcuts.test.tsx
+++ b/apps/desktop/src/routing/app-shortcuts.test.tsx
@@ -106,6 +106,19 @@ describe('app shortcuts', () => {
     expect(result.current.router.route).toEqual({ kind: 'today' })
   })
 
+  it('⌘N from today makes back re-anchor Daily instead of restoring stale scroll', () => {
+    const { result } = shortcutsHook()
+    act(() => result.current.router.saveScrollState(735))
+    expect(result.current.router.savedScroll()).toBe(735)
+
+    act(() => press('n'))
+    expect(result.current.router.route.kind).toBe('note')
+
+    act(() => press('['))
+    expect(result.current.router.route).toEqual({ kind: 'today' })
+    expect(result.current.router.savedScroll()).toBeNull()
+  })
+
   it('⌘[ and ⌘] still traverse when the focused editor consumes the keydown', () => {
     const { result } = shortcutsHook()
     act(() => press('n'))

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -65,7 +65,7 @@ function idForKeyDown(event: KeyboardEvent): string | null {
  * mounted (`setMenuCommandDispatch`).
  */
 export function useAppShortcuts(): CommandContext {
-  const { route, navigate, back, forward } = useRouter()
+  const { route, navigate, back, forward, clearScrollState } = useRouter()
   const focusedDailyDate = useFocusedDailyDate()
   const { resolvedTheme, setTheme } = useTheme()
   const { graph } = useGraph()
@@ -111,6 +111,7 @@ export function useAppShortcuts(): CommandContext {
       },
       back,
       forward,
+      clearScrollState,
       toggleTheme: () => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark'),
       toggleSidebar,
       newChat,
@@ -129,6 +130,7 @@ export function useAppShortcuts(): CommandContext {
       navigate,
       back,
       forward,
+      clearScrollState,
       resolvedTheme,
       setTheme,
       openPalette,

--- a/apps/desktop/src/routing/router.test.tsx
+++ b/apps/desktop/src/routing/router.test.tsx
@@ -120,6 +120,17 @@ describe('router', () => {
     expect(result.current.savedScroll()).toBeNull()
   })
 
+  it('a surface-scroll return from within the surface re-anchors instead', () => {
+    const { result } = routerHook({ kind: 'daily', date: '2026-06-08' })
+    act(() => result.current.saveScrollState(500)) // scrolled the stream on a dated day
+    act(() => result.current.navigate({ kind: 'today' }, { restoreSurfaceScroll: true }))
+    expect(result.current.savedScroll()).toBeNull() // Daily tab on-stream = ⌘D re-anchor
+
+    act(() => result.current.saveScrollState(300))
+    act(() => result.current.navigate({ kind: 'today' }, { restoreSurfaceScroll: true }))
+    expect(result.current.savedScroll()).toBeNull() // same while already on today
+  })
+
   it('an explicit re-anchor arrival drops the daily surface offset too', () => {
     const { result } = routerHook()
     act(() => result.current.saveScrollState(500)) // user scrolled away on today

--- a/apps/desktop/src/routing/router.test.tsx
+++ b/apps/desktop/src/routing/router.test.tsx
@@ -120,6 +120,16 @@ describe('router', () => {
     expect(result.current.savedScroll()).toBeNull()
   })
 
+  it('an explicit re-anchor arrival drops the daily surface offset too', () => {
+    const { result } = routerHook()
+    act(() => result.current.saveScrollState(500)) // user scrolled away on today
+    act(() => result.current.navigate({ kind: 'today' })) // ⌘D re-anchors the stream
+    act(() => result.current.navigate({ kind: 'note', path: 'notes/a.md' }))
+    act(() => result.current.navigate({ kind: 'today' }, { restoreSurfaceScroll: true }))
+
+    expect(result.current.savedScroll()).toBeNull() // the tab can't resurrect pre-⌘D scroll
+  })
+
   it('clearScrollState drops the daily surface offset too (new-note interaction)', () => {
     const { result } = routerHook()
     act(() => result.current.saveScrollState(500)) // scrolled the stream before ⌘N

--- a/apps/desktop/src/routing/router.test.tsx
+++ b/apps/desktop/src/routing/router.test.tsx
@@ -78,6 +78,20 @@ describe('router', () => {
     expect(result.current.savedScroll()).toBe(40) // the note's own offset
   })
 
+  it('can clear the active entry scroll offset without changing routes', () => {
+    const { result } = routerHook()
+    const entryId = result.current.entryId
+    const arrivals = result.current.arrivalSeq
+    act(() => result.current.saveScrollState(120))
+
+    act(() => result.current.clearScrollState())
+
+    expect(result.current.route).toEqual({ kind: 'today' })
+    expect(result.current.entryId).toBe(entryId)
+    expect(result.current.arrivalSeq).toBe(arrivals)
+    expect(result.current.savedScroll()).toBeNull()
+  })
+
   it('re-navigating to the current route clears its saved scroll (re-anchor intent)', () => {
     const { result } = routerHook()
     const seqBefore = result.current.arrivalSeq
@@ -85,6 +99,40 @@ describe('router', () => {
     act(() => result.current.navigate({ kind: 'today' })) // ⌘D while on today
     expect(result.current.savedScroll()).toBeNull() // re-anchor, don't restore
     expect(result.current.arrivalSeq).toBe(seqBefore + 1) // views are notified
+  })
+
+  it('can restore the daily surface scroll when a tab switch returns to today', () => {
+    const { result } = routerHook()
+    act(() => result.current.saveScrollState(500)) // user scrolled the daily stream
+    act(() => result.current.navigate({ kind: 'note', path: 'notes/a.md' }))
+    act(() => result.current.navigate({ kind: 'today' }, { restoreSurfaceScroll: true }))
+
+    expect(result.current.route).toEqual({ kind: 'today' })
+    expect(result.current.savedScroll()).toBe(500)
+  })
+
+  it('keeps default fresh navigations to daily routes anchor-only', () => {
+    const { result } = routerHook()
+    act(() => result.current.saveScrollState(500))
+    act(() => result.current.navigate({ kind: 'note', path: 'notes/a.md' }))
+    act(() => result.current.navigate({ kind: 'today' }))
+
+    expect(result.current.savedScroll()).toBeNull()
+  })
+
+  it('clearScrollState drops the daily surface offset too (new-note interaction)', () => {
+    const { result } = routerHook()
+    act(() => result.current.saveScrollState(500)) // scrolled the stream before ⌘N
+    act(() => result.current.clearScrollState()) // note.new discards the stream offsets
+    act(() => result.current.navigate({ kind: 'note', path: 'notes/a.md' }))
+
+    act(() => result.current.back())
+    expect(result.current.savedScroll()).toBeNull() // ⌘[ re-anchors to today
+
+    act(() => result.current.saveScrollState(120)) // post-clear scrolling
+    act(() => result.current.forward())
+    act(() => result.current.navigate({ kind: 'today' }, { restoreSurfaceScroll: true }))
+    expect(result.current.savedScroll()).toBe(120) // the tab restores only the new offset
   })
 
   it('entryId is stable per entry and changes across back/forward', () => {

--- a/apps/desktop/src/routing/router.tsx
+++ b/apps/desktop/src/routing/router.tsx
@@ -21,6 +21,12 @@ import { normalizeRoute, routesEqual, type Route } from './route'
  * Each history entry can carry a **scroll offset** (Plan 06b): views report
  * theirs via `saveScrollState` (a ref write — safe from scroll handlers, never
  * re-renders) and read `savedScroll()` after a back/forward restores an entry.
+ *
+ * Long-lived surfaces (the daily stream, shared by the today/daily routes)
+ * additionally keep a **surface offset** — the last reported position,
+ * independent of any history entry — so a nav-tab return can resume the stream
+ * where the user left it (`restoreSurfaceScroll`) even though it lands on a
+ * fresh entry.
  */
 
 interface RouterValue {
@@ -33,18 +39,50 @@ interface RouterValue {
    * while already on today re-scrolls the stream to today).
    */
   arrivalSeq: number
-  navigate: (route: Route) => void
+  navigate: (route: Route, options?: NavigateOptions) => void
   back: () => void
   forward: () => void
   canBack: boolean
   canForward: boolean
   /** Record the active view's scroll offset on the current history entry. */
   saveScrollState: (offset: number) => void
+  /**
+   * Discard the current view's saved scroll offsets — the active history
+   * entry's and, when the route belongs to a long-lived surface, the surface's
+   * too — so the view re-anchors when revisited through **any** door (⌘[ back
+   * or a `restoreSurfaceScroll` nav-tab return alike).
+   */
+  clearScrollState: () => void
   /** The current entry's recorded offset (present when revisited), or `null`. */
   savedScroll: () => number | null
 }
 
 const RouterContext = createContext<RouterValue | null>(null)
+
+export interface NavigateOptions {
+  /**
+   * Seed the new history entry with the last saved scroll position of the
+   * target route's surface. Primary nav tabs use this so switching away and
+   * back does not reset long-lived list surfaces; ordinary command/navigation
+   * arrivals omit it and re-anchor as before.
+   */
+  restoreSurfaceScroll?: boolean
+}
+
+/**
+ * The scroll-surface key for routes whose view outlives any single history
+ * entry, or `null` for ordinary per-entry restoration. Today and dated daily
+ * routes share one stream, hence one key.
+ */
+function scrollSurfaceForRoute(route: Route): string | null {
+  switch (route.kind) {
+    case 'today':
+    case 'daily':
+      return 'daily'
+    default:
+      return null
+  }
+}
 
 interface RouterProviderProps {
   /** The launch route; defaults to today (the daily note is the spine). */
@@ -75,34 +113,47 @@ export function RouterProvider({
   const nextId = useRef(1)
   /** Scroll offsets by entry id — a ref so scroll reporting never re-renders. */
   const scrollById = useRef(new Map<number, number>())
+  /** Last offset per long-lived surface, independent of history entries. */
+  const scrollBySurface = useRef(new Map<string, number>())
   /** The active entry id, readable without depending on render order. */
   const currentId = useRef(0)
+  /** The active route, readable from scroll handlers without re-rendering. */
+  const currentRoute = useRef<Route>(history.stack[history.index]!.route)
   // Written during render, not in an effect: descendant scroll-restoration
   // effects read this id (through saveScrollState/savedScroll) on the same
   // commit, and React runs effects child-before-parent — so updating it in an
   // effect here would lag a frame and restore or save the wrong entry's offset.
   // eslint-disable-next-line react-hooks/refs
   currentId.current = history.stack[history.index]!.id
+  // eslint-disable-next-line react-hooks/refs
+  currentRoute.current = history.stack[history.index]!.route
 
-  const navigate = useCallback((route: Route) => {
+  const navigate = useCallback((route: Route, options?: NavigateOptions) => {
     const target = normalizeRoute(route)
+    const surface = options?.restoreSurfaceScroll === true ? scrollSurfaceForRoute(target) : null
+    const restored = surface !== null ? scrollBySurface.current.get(surface) : undefined
     setHistory((current) => {
       const currentEntry = current.stack[current.index]!
       if (routesEqual(currentEntry.route, target)) {
-        // No stack growth — but this is still an explicit arrival: forget the
-        // entry's saved offset so the view re-anchors to its target instead of
-        // restoring the old scroll position.
-        scrollById.current.delete(currentEntry.id)
+        if (restored !== undefined) {
+          scrollById.current.set(currentEntry.id, restored)
+        } else {
+          // No stack growth — but this is still an explicit arrival: forget the
+          // entry's saved offset so the view re-anchors to its target instead of
+          // restoring the old scroll position.
+          scrollById.current.delete(currentEntry.id)
+        }
         return current
       }
       const dropped = current.stack.slice(current.index + 1)
       for (const entry of dropped) {
         scrollById.current.delete(entry.id) // truncated branch — free its offsets
       }
-      const stack = [
-        ...current.stack.slice(0, current.index + 1),
-        { id: nextId.current++, route: target },
-      ]
+      const id = nextId.current++
+      if (restored !== undefined) {
+        scrollById.current.set(id, restored) // seed the fresh entry with the surface offset
+      }
+      const stack = [...current.stack.slice(0, current.index + 1), { id, route: target }]
       return { stack, index: stack.length - 1 }
     })
     setArrivalSeq((seq) => seq + 1)
@@ -144,6 +195,18 @@ export function RouterProvider({
 
   const saveScrollState = useCallback((offset: number) => {
     scrollById.current.set(currentId.current, offset)
+    const surface = scrollSurfaceForRoute(currentRoute.current)
+    if (surface !== null) {
+      scrollBySurface.current.set(surface, offset)
+    }
+  }, [])
+
+  const clearScrollState = useCallback(() => {
+    scrollById.current.delete(currentId.current)
+    const surface = scrollSurfaceForRoute(currentRoute.current)
+    if (surface !== null) {
+      scrollBySurface.current.delete(surface)
+    }
   }, [])
 
   const savedScroll = useCallback(
@@ -163,9 +226,19 @@ export function RouterProvider({
       canBack: history.index > 0,
       canForward: history.index < history.stack.length - 1,
       saveScrollState,
+      clearScrollState,
       savedScroll,
     }
-  }, [history, arrivalSeq, navigate, back, forward, saveScrollState, savedScroll])
+  }, [
+    history,
+    arrivalSeq,
+    navigate,
+    back,
+    forward,
+    saveScrollState,
+    clearScrollState,
+    savedScroll,
+  ])
 
   return <RouterContext.Provider value={value}>{children}</RouterContext.Provider>
 }

--- a/apps/desktop/src/routing/router.tsx
+++ b/apps/desktop/src/routing/router.tsx
@@ -63,8 +63,10 @@ export interface NavigateOptions {
   /**
    * Seed the new history entry with the last saved scroll position of the
    * target route's surface. Primary nav tabs use this so switching away and
-   * back does not reset long-lived list surfaces; ordinary command/navigation
-   * arrivals omit it and re-anchor as before.
+   * back does not reset long-lived list surfaces. Only a genuine return
+   * honors it: when the current route already sits on the target's surface
+   * the arrival re-anchors like any other explicit navigation, and ordinary
+   * command arrivals omit it and re-anchor as before.
    */
   restoreSurfaceScroll?: boolean
 }
@@ -131,10 +133,14 @@ export function RouterProvider({
   const navigate = useCallback((route: Route, options?: NavigateOptions) => {
     const target = normalizeRoute(route)
     const surface = scrollSurfaceForRoute(target)
-    const restored =
-      options?.restoreSurfaceScroll === true && surface !== null
-        ? scrollBySurface.current.get(surface)
-        : undefined
+    // A surface restore only means something when coming from OFF the surface;
+    // the Daily tab clicked while already on the stream is an explicit
+    // re-anchor request, exactly like ⌘D.
+    const returning =
+      options?.restoreSurfaceScroll === true &&
+      surface !== null &&
+      scrollSurfaceForRoute(currentRoute.current) !== surface
+    const restored = returning ? scrollBySurface.current.get(surface) : undefined
     if (surface !== null && restored === undefined) {
       // An explicit arrival re-anchors the surface, making its saved offset
       // stale — drop it so a later nav-tab return re-anchors too instead of

--- a/apps/desktop/src/routing/router.tsx
+++ b/apps/desktop/src/routing/router.tsx
@@ -130,8 +130,18 @@ export function RouterProvider({
 
   const navigate = useCallback((route: Route, options?: NavigateOptions) => {
     const target = normalizeRoute(route)
-    const surface = options?.restoreSurfaceScroll === true ? scrollSurfaceForRoute(target) : null
-    const restored = surface !== null ? scrollBySurface.current.get(surface) : undefined
+    const surface = scrollSurfaceForRoute(target)
+    const restored =
+      options?.restoreSurfaceScroll === true && surface !== null
+        ? scrollBySurface.current.get(surface)
+        : undefined
+    if (surface !== null && restored === undefined) {
+      // An explicit arrival re-anchors the surface, making its saved offset
+      // stale — drop it so a later nav-tab return re-anchors too instead of
+      // resurrecting the pre-arrival position. Scrolling after the arrival
+      // repopulates it.
+      scrollBySurface.current.delete(surface)
+    }
     setHistory((current) => {
       const currentEntry = current.stack[current.index]!
       if (routesEqual(currentEntry.route, target)) {


### PR DESCRIPTION
## Problem

Two open PRs rework the router's daily-route scroll bookkeeping, and both conflict with `next` (post-#423) and with each other:

- #386 — creating a note from the daily stream (⌘N) left the stream's saved scroll offset behind, so ⌘[ back restored a stale position instead of re-anchoring to the Daily target.
- #419 — switching away from the daily stream via a nav tab and clicking the sidebar **Daily notes** row reset the stream instead of restoring the last scroll position.

This PR reimplements both on top of current `next` as one coherent change. #386 and #419 can be closed in favor of it — credit to both for the underlying fixes.

## Changes

**Router** ([router.tsx](apps/desktop/src/routing/router.tsx))
- `clearScrollState()` (from #386): drops the active history entry's saved offset without changing routes.
- Surface-level offsets (from #419): the today/daily routes share one long-lived stream, so `saveScrollState` also records the offset under a `daily` surface key, independent of history entries. `navigate(route, { restoreSurfaceScroll: true })` seeds the new entry with that surface offset; default navigations still re-anchor.

**Commands** ([app-commands.ts](apps/desktop/src/lib/commands/app-commands.ts), [types.ts](apps/desktop/src/lib/commands/types.ts), [app-shortcuts.ts](apps/desktop/src/routing/app-shortcuts.ts))
- `note.new` calls `clearScrollState()` when run from a today/daily route, then navigates to the fresh note. Other routes keep their offsets.
- `CommandContext` gains `clearScrollState` and the widened `navigate` signature.

**Sidebar** ([sidebar.tsx](apps/desktop/src/components/sidebar/sidebar.tsx))
- The **Daily notes** row navigates with `restoreSurfaceScroll: true`, so a tab return resumes the stream where the user left it. The `Mod-D` binding still runs `nav.today` and re-anchors to today.

## Design decision: `clearScrollState()` clears the surface offset too

The two features interact: #386 clears the daily *entry* offset on note creation, while #419 preserves a *surface* offset that the sidebar tab restores. If `clearScrollState()` only cleared the entry offset, the sequence *scroll daily → ⌘N → sidebar Daily tab* would restore the very offset #386 just cleared — resurrecting the stale-scroll bug through a different door.

So `clearScrollState()` discards **both** the active entry's offset and the current route's surface offset: after creating a note from the daily stream, every return path (⌘[ back *and* the Daily tab) re-anchors. Scrolling after that repopulates the surface offset, so the tab's restore behavior resumes from post-clear positions only. This is covered by a dedicated interaction test in [router.test.tsx](apps/desktop/src/routing/router.test.tsx).

The same invariant applies to explicit arrivals (flagged by Bugbot): a `navigate` to a surface route *without* `restoreSurfaceScroll` — ⌘D / `nav.today` — re-anchors the stream, so it drops the surface offset too. Otherwise the Daily tab could resurrect the pre-⌘D position and undo the re-anchor. And `restoreSurfaceScroll` is only honored when the navigation genuinely *returns* from another surface (also flagged by Bugbot): clicking the Daily tab while already on the stream — a dated daily view or today — is an explicit re-anchor request, exactly like ⌘D. The rule throughout: **any action that re-anchors the stream invalidates its saved offsets through every door; only a true off-surface return restores, and scrolling starts fresh offsets.**

## Testing

- Ported both PRs' tests (router, app-shortcuts ⌘N/⌘[ flow, app-commands daily/non-daily gating, sidebar nav-row) onto the current test suites, plus the new interaction test: create note from daily → ⌘[ re-anchors → post-clear scrolling → sidebar Daily tab restores only the new offset.
- `pnpm test --run` on router.test.tsx, app-shortcuts.test.tsx, app-commands.test.ts, registry.test.ts, sidebar.test.tsx, command-palette.test.tsx — 95 tests, all passing.
- `pnpm check` (typecheck + lint) passes; the two remaining warnings are pre-existing in unrelated files.

Closes #386. Closes #419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core navigation/scroll bookkeeping used by the daily stream and history back/forward; behavior is well-tested but regressions would affect everyday navigation UX.
> 
> **Overview**
> Unifies two daily-stream scroll behaviors in the **router** and **commands** layer.
> 
> The router now tracks a **surface-level** scroll offset for the shared today/daily stream (alongside per-history-entry offsets). **`navigate(route, { restoreSurfaceScroll: true })`** seeds a new entry from that surface offset; default navigations still re-anchor. **`clearScrollState()`** drops both the active entry’s offset and the daily surface offset so any return path re-anchors.
> 
> **`note.new`** (via `openNewNote`) calls **`clearScrollState()`** when invoked from today/daily, then opens a fresh note—so ⌘[ back after ⌘N does not restore a stale stream position. **`CommandContext`** exposes **`clearScrollState`** and the widened **`navigate`** signature through **`useAppShortcuts`**.
> 
> The sidebar **Daily notes** row navigates with **`restoreSurfaceScroll: true`** instead of running **`nav.today`**, so tab returns resume scroll; **Mod-D** still runs **`nav.today`** and re-anchors to today.
> 
> Tests cover router surface restore, clear + sidebar interaction, shortcuts, commands, and sidebar nav.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf929520c34587526993534d79c1f414182a0dab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
