### PR TITLE
fix: pin AI provider base URLs against ambient environment variables

### DIFF
--- a/packages/core/src/ai/language-model.test.ts
+++ b/packages/core/src/ai/language-model.test.ts
@@ -1,5 +1,5 @@
 import { generateText } from 'ai'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { AiProviderConfig } from '../settings/schema'
 import {
   ANTHROPIC_DIRECT_BROWSER_ACCESS_HEADER,
@@ -41,6 +41,10 @@ function recordingAnthropicFetch(calls: RecordedCall[]): typeof fetch {
   }
 }
 
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
 describe('languageModel', () => {
   it('adds Anthropic direct-browser access to model calls', async () => {
     const calls: RecordedCall[] = []
@@ -56,5 +60,21 @@ describe('languageModel', () => {
     expect(calls[0]!.headers.get(ANTHROPIC_DIRECT_BROWSER_ACCESS_HEADER)).toBe(
       ANTHROPIC_DIRECT_BROWSER_ACCESS_VALUE,
     )
+  })
+
+  it('ignores ambient *_BASE_URL environment variables', async () => {
+    // The SDK factories read these when no baseURL is passed — a stray
+    // variable in whatever shell launched the app (Claude Code exports
+    // ANTHROPIC_BASE_URL, for one) must not reroute BYOK traffic.
+    vi.stubEnv('ANTHROPIC_BASE_URL', 'https://reroute.example')
+    const calls: RecordedCall[] = []
+
+    await generateText({
+      model: languageModel(ANTHROPIC_CONFIG, 'sk-ant-test', recordingAnthropicFetch(calls)),
+      prompt: 'hello',
+      maxRetries: 0,
+    })
+
+    expect(calls[0]!.url).toBe('https://api.anthropic.com/v1/messages')
   })
 })

--- a/packages/core/src/ai/language-model.ts
+++ b/packages/core/src/ai/language-model.ts
@@ -6,6 +6,19 @@ import type { AiProviderConfig } from '../settings/schema'
 import { anthropicDirectBrowserAccessHeaders } from './anthropic-headers'
 
 /**
+ * Endpoints pinned to each SDK's documented default. Passing them explicitly
+ * is load-bearing: left unset, the SDK factories read `ANTHROPIC_BASE_URL` /
+ * `OPENAI_BASE_URL` from the environment, and a stray variable in whatever
+ * shell launched the app would silently reroute BYOK traffic — against the
+ * principle that LLM calls go directly to the user-approved provider, and a
+ * quiet way for every call to start failing (a bare `https://api.anthropic.com`
+ * without the `/v1` 404s). Pinning keeps the app hermetic to ambient env.
+ */
+const OPENAI_BASE_URL = 'https://api.openai.com/v1'
+const ANTHROPIC_BASE_URL = 'https://api.anthropic.com/v1'
+const GOOGLE_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta'
+
+/**
  * Build the AI SDK model instance for a configured BYOK entry — the one place
  * provider ids map to SDK factories. Shared by the chat engine
  * (`chat/stream-chat`) and one-shot calls like the link-capture page
@@ -18,14 +31,17 @@ export function languageModel(
 ): LanguageModel {
   switch (config.provider) {
     case 'openai':
-      return createOpenAI({ apiKey, fetch: fetchFn })(config.model)
+      return createOpenAI({ apiKey, baseURL: OPENAI_BASE_URL, fetch: fetchFn })(config.model)
     case 'anthropic':
       return createAnthropic({
         apiKey,
+        baseURL: ANTHROPIC_BASE_URL,
         fetch: fetchFn,
         headers: anthropicDirectBrowserAccessHeaders(),
       })(config.model)
     case 'google':
-      return createGoogleGenerativeAI({ apiKey, fetch: fetchFn })(config.model)
+      return createGoogleGenerativeAI({ apiKey, baseURL: GOOGLE_BASE_URL, fetch: fetchFn })(
+        config.model,
+      )
   }
 }


### PR DESCRIPTION
## What

`languageModel()` now passes each AI SDK factory its own documented default `baseURL` explicitly (`api.anthropic.com/v1`, `api.openai.com/v1`, `generativelanguage.googleapis.com/v1beta`) instead of leaving the option unset.

## Why

Left unset, `@ai-sdk/anthropic` and `@ai-sdk/openai` read `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` from the environment. A stray variable in whatever shell launched the app silently rerouted BYOK traffic — against the principle that LLM calls go directly to the user-approved provider — and could quietly break every call: a bare `https://api.anthropic.com` (no `/v1`) 404s the messages endpoint.

That exact value is what Claude Code exports, which solved a small mystery: `language-model.test.ts` failed on any machine running the suite under a Claude Code session while CI stayed green the whole time. Not a stale assertion, not a production-URL bug for normally-launched apps — an environment leak, now closed for the app and pinned by a regression test (`vi.stubEnv('ANTHROPIC_BASE_URL', …)` must not change the request URL).

Google's factory doesn't read env today; it's pinned anyway so all three are hermetic against future SDK changes.

## Testing

- `language-model.test.ts`: both tests pass, including in a shell with `ANTHROPIC_BASE_URL` set (the previously failing environment).
- Full `src/ai` suite (18 files, 163 tests) and `pnpm check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted wiring change to official provider endpoints; behavior is more predictable and does not alter auth or key handling.
> 
> **Overview**
> **`languageModel()`** now passes explicit documented **`baseURL`** values into each AI SDK factory (OpenAI, Anthropic, Google) instead of relying on SDK defaults that can read **`ANTHROPIC_BASE_URL`** / **`OPENAI_BASE_URL`** from the process environment.
> 
> That prevents BYOK requests from being silently rerouted when the app is launched from a shell that exports those variables (e.g. Claude Code), which could break calls or send traffic away from the user’s chosen provider.
> 
> A regression test stubs **`ANTHROPIC_BASE_URL`** and asserts Anthropic traffic still hits **`https://api.anthropic.com/v1/messages`**; **`afterEach`** clears stubbed env via Vitest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beb389756790de13d1076b1eb9a2dea9766211b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI provider request routing so language model calls always use the intended service endpoints, even when environment variables are present.
  * Added test coverage to verify requests are not redirected by ambient base URL settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->