### PR TITLE
feat: enforce the notes kind/daily_date invariant at the schema level

### DIFF
--- a/apps/cli/tests/cli.rs
+++ b/apps/cli/tests/cli.rs
@@ -40,7 +40,11 @@ impl Fixture {
             let content = fs::read_to_string(self.root().join(&note.rel_path)).unwrap();
             let meta = parse_note_meta(&note.rel_path, &content);
             let daily_date = reflect_cli::paths::date_from_daily_path(&note.rel_path);
-            let kind = if daily_date.is_some() { "daily" } else { "note" };
+            let kind = if daily_date.is_some() {
+                "daily"
+            } else {
+                "note"
+            };
             conn.execute(
                 "INSERT INTO notes(path, id, title, title_key, kind, daily_date, is_private,
                                    is_pinned, pinned_order, file_hash, mtime, updated_at, preview)

--- a/apps/cli/tests/cli.rs
+++ b/apps/cli/tests/cli.rs
@@ -40,10 +40,11 @@ impl Fixture {
             let content = fs::read_to_string(self.root().join(&note.rel_path)).unwrap();
             let meta = parse_note_meta(&note.rel_path, &content);
             let daily_date = reflect_cli::paths::date_from_daily_path(&note.rel_path);
+            let kind = if daily_date.is_some() { "daily" } else { "note" };
             conn.execute(
-                "INSERT INTO notes(path, id, title, title_key, daily_date, is_private, is_pinned,
-                                   pinned_order, file_hash, mtime, updated_at, preview)
-                 VALUES(?1, ?8, ?2, ?3, ?4, ?5, 0, NULL, ?6, ?7, ?7, '')",
+                "INSERT INTO notes(path, id, title, title_key, kind, daily_date, is_private,
+                                   is_pinned, pinned_order, file_hash, mtime, updated_at, preview)
+                 VALUES(?1, ?8, ?2, ?3, ?9, ?4, ?5, 0, NULL, ?6, ?7, ?7, '')",
                 params![
                     note.rel_path,
                     meta.title,
@@ -53,6 +54,7 @@ impl Fixture {
                     hash_content(&content),
                     note.mtime_ms as i64,
                     meta.id,
+                    kind,
                 ],
             )
             .unwrap();

--- a/apps/desktop/src-tauri/src/db/tests.rs
+++ b/apps/desktop/src-tauri/src/db/tests.rs
@@ -78,7 +78,7 @@ fn migrations_are_valid_and_idempotent() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 14); // applied migrations (0001 through 0014)
+    assert_eq!(version, 15); // applied migrations (0001 through 0015)
     migrate(&mut conn).expect("re-running to_latest is a no-op");
 }
 
@@ -497,7 +497,8 @@ fn open_tasks_read_includes_private_notes_and_excludes_completed() {
     // to note context, completed tasks excluded, and `private: true` notes' tasks
     // INCLUDED (the Tasks view is a local-only surface, like local search).
     let conn = migrated();
-    let mut public = note("notes/a.md", "A", vec![]);
+    let mut public = note("daily/2026-06-10.md", "A", vec![]);
+    public.kind = "daily".to_string();
     public.daily_date = Some("2026-06-10".to_string());
     public.tasks = vec![task(2, "open a", false)];
     apply_note(&conn, &public).unwrap();
@@ -517,7 +518,7 @@ fn open_tasks_read_includes_private_notes_and_excludes_completed() {
     .unwrap();
 
     assert_eq!(rows.len(), 2); // both open tasks; the completed one is gone
-    assert_eq!(rows[0]["note_path"], Value::from("notes/a.md"));
+    assert_eq!(rows[0]["note_path"], Value::from("daily/2026-06-10.md"));
     assert_eq!(rows[0]["text"], Value::from("open a"));
     assert_eq!(rows[0]["note_title"], Value::from("A"));
     assert_eq!(rows[0]["daily_date"], Value::from("2026-06-10"));
@@ -542,6 +543,129 @@ fn link_kind_check_rejects_unknown_kinds() {
 }
 
 #[test]
+fn note_kind_daily_date_invariant_is_enforced() {
+    // `kind` and `daily_date` both derive from the path in `buildIndexedNote`,
+    // so they agree by construction — the 0015 CHECK makes SQLite reject any
+    // writer that drifts: kind = 'daily' iff daily_date is set.
+    let conn = migrated();
+
+    let note_with_date = conn.execute(
+        "INSERT INTO notes(path, title, title_key, kind, daily_date, file_hash)
+         VALUES('notes/a.md', 'A', 'a', 'note', '2026-07-01', 'h')",
+        [],
+    );
+    assert!(
+        note_with_date.is_err(),
+        "CHECK should reject kind='note' with a daily_date"
+    );
+
+    let daily_without_date = conn.execute(
+        "INSERT INTO notes(path, title, title_key, kind, daily_date, file_hash)
+         VALUES('daily/2026-07-01.md', 'July 1st, 2026', 'july 1st, 2026', 'daily', NULL, 'h')",
+        [],
+    );
+    assert!(
+        daily_without_date.is_err(),
+        "CHECK should reject kind='daily' without a daily_date"
+    );
+
+    let template_with_date = conn.execute(
+        "INSERT INTO notes(path, title, title_key, kind, daily_date, file_hash)
+         VALUES('templates/j.md', 'J', 'j', 'template', '2026-07-01', 'h')",
+        [],
+    );
+    assert!(
+        template_with_date.is_err(),
+        "CHECK should reject kind='template' with a daily_date"
+    );
+
+    // The three shapes buildIndexedNote actually emits all pass.
+    conn.execute_batch(
+        "INSERT INTO notes(path, title, title_key, kind, daily_date, file_hash) VALUES
+           ('daily/2026-07-01.md', 'July 1st, 2026', 'july 1st, 2026', 'daily', '2026-07-01', 'h'),
+           ('notes/a.md', 'A', 'a', 'note', NULL, 'h'),
+           ('templates/j.md', 'J', 'j', 'template', NULL, 'h');",
+    )
+    .expect("consistent rows insert");
+}
+
+#[test]
+fn kind_invariant_rebuild_preserves_rows_and_schema() {
+    // The 0015 table rebuild drops and recreates `notes` while six child
+    // tables reference it ON DELETE CASCADE. Migrations run with foreign keys
+    // off precisely so that DROP cannot cascade — staged rows in both parent
+    // and children must come out the other side intact.
+    let mut conn = open_in_memory().expect("open");
+    conn.execute_batch("PRAGMA foreign_keys=ON;").expect("fk");
+    migrate_to(&mut conn, 14).expect("migrate to v14");
+    conn.execute_batch(
+        "INSERT INTO notes(path, title, title_key, kind, daily_date, file_hash) VALUES
+           ('daily/2026-07-01.md', 'July 1st, 2026', 'july 1st, 2026', 'daily', '2026-07-01', 'h1'),
+           ('notes/a.md', 'A', 'a', 'note', NULL, 'h2');
+         INSERT INTO note_text(note_path, text) VALUES('notes/a.md', 'A body');
+         INSERT INTO links(source_path, kind, target_raw, target_key, pos_from, pos_to)
+           VALUES('notes/a.md', 'wiki', 'July 1st, 2026', 'july 1st, 2026', 0, 0);
+         INSERT INTO tags(note_path, tag, tag_key) VALUES('notes/a.md', 'X', 'x');
+         INSERT INTO tasks(note_path, marker_offset, text, raw, checked)
+           VALUES('notes/a.md', 0, 'buy milk', '[ ] buy milk', 0);",
+    )
+    .expect("stage v14 rows");
+
+    migrate(&mut conn).expect("migrate to latest");
+
+    for (table, expected) in [("notes", 2), ("note_text", 1), ("links", 1), ("tags", 1), ("tasks", 1)]
+    {
+        let count: i64 = conn
+            .query_row(&format!("SELECT count(*) FROM {table}"), [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(count, expected, "{table} rows must survive the rebuild");
+    }
+
+    // The recreated views resolve over the new table (wiki link → daily date).
+    let backlink_sources: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM backlinks WHERE target_path = 'daily/2026-07-01.md'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(backlink_sources, 1);
+
+    // Every notes index came back with the rebuild.
+    for index in [
+        "notes_title_key",
+        "notes_daily_date",
+        "notes_id",
+        "notes_daily_date_mtime_path",
+        "notes_non_daily_mtime",
+        "notes_pinned",
+        "notes_has_conflict",
+    ] {
+        let exists: bool = conn
+            .prepare("SELECT 1 FROM pragma_index_list('notes') WHERE name = ?1")
+            .unwrap()
+            .exists([index])
+            .unwrap();
+        assert!(exists, "index {index} must be recreated by the rebuild");
+    }
+
+    // Foreign-key enforcement is restored after the migration run, and the
+    // child cascades still point at the rebuilt table.
+    let enforced: i64 = conn
+        .query_row("PRAGMA foreign_keys", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(enforced, 1, "migrate() must restore PRAGMA foreign_keys");
+    conn.execute("DELETE FROM notes WHERE path = 'notes/a.md'", [])
+        .unwrap();
+    let orphans: i64 = conn
+        .query_row("SELECT count(*) FROM tasks", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(orphans, 0, "ON DELETE CASCADE must survive the rebuild");
+}
+
+#[test]
 fn open_index_at_creates_migrates_and_reopens() {
     let dir = tempfile::tempdir().expect("tempdir");
     let root = dir.path();
@@ -551,7 +675,7 @@ fn open_index_at_creates_migrates_and_reopens() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 14);
+    assert_eq!(version, 15);
     let journal: String = conn
         .query_row("PRAGMA journal_mode", [], |row| row.get(0))
         .unwrap();

--- a/apps/desktop/src-tauri/src/db/tests.rs
+++ b/apps/desktop/src-tauri/src/db/tests.rs
@@ -590,11 +590,11 @@ fn note_kind_daily_date_invariant_is_enforced() {
 }
 
 #[test]
-fn kind_invariant_rebuild_preserves_rows_and_schema() {
-    // The 0015 table rebuild drops and recreates `notes` while six child
-    // tables reference it ON DELETE CASCADE. Migrations run with foreign keys
-    // off precisely so that DROP cannot cascade — staged rows in both parent
-    // and children must come out the other side intact.
+fn kind_invariant_migration_wipes_the_projection_for_reindex() {
+    // 0015 drops and recreates `notes` (a table-level CHECK cannot be ADDed)
+    // while six child tables reference it ON DELETE CASCADE. The projection
+    // is wiped children-first (so the DROP's implicit DELETE cascades over
+    // empty tables even with enforcement on) and the next open re-indexes.
     let mut conn = open_in_memory().expect("open");
     conn.execute_batch("PRAGMA foreign_keys=ON;").expect("fk");
     migrate_to(&mut conn, 14).expect("migrate to v14");
@@ -607,38 +607,29 @@ fn kind_invariant_rebuild_preserves_rows_and_schema() {
            VALUES('notes/a.md', 'wiki', 'July 1st, 2026', 'july 1st, 2026', 0, 0);
          INSERT INTO tags(note_path, tag, tag_key) VALUES('notes/a.md', 'X', 'x');
          INSERT INTO tasks(note_path, marker_offset, text, raw, checked)
-           VALUES('notes/a.md', 0, 'buy milk', '[ ] buy milk', 0);",
+           VALUES('notes/a.md', 0, 'buy milk', '[ ] buy milk', 0);
+         INSERT INTO search_fts(path, title, body) VALUES('notes/a.md', 'A', 'A body');
+         INSERT INTO index_meta(key, value) VALUES('k', 'v');",
     )
     .expect("stage v14 rows");
 
     migrate(&mut conn).expect("migrate to latest");
 
-    for (table, expected) in [
-        ("notes", 2),
-        ("note_text", 1),
-        ("links", 1),
-        ("tags", 1),
-        ("tasks", 1),
-    ] {
+    for table in ["notes", "note_text", "links", "tags", "tasks", "search_fts"] {
         let count: i64 = conn
             .query_row(&format!("SELECT count(*) FROM {table}"), [], |row| {
                 row.get(0)
             })
             .unwrap();
-        assert_eq!(count, expected, "{table} rows must survive the rebuild");
+        assert_eq!(count, 0, "{table} should be wiped for the re-index");
     }
-
-    // The recreated views resolve over the new table (wiki link → daily date).
-    let backlink_sources: i64 = conn
-        .query_row(
-            "SELECT count(*) FROM backlinks WHERE target_path = 'daily/2026-07-01.md'",
-            [],
-            |row| row.get(0),
-        )
+    // Bookkeeping outlives the wipe (same contract as index_clear).
+    let meta: i64 = conn
+        .query_row("SELECT count(*) FROM index_meta", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(backlink_sources, 1);
+    assert_eq!(meta, 1);
 
-    // Every notes index came back with the rebuild.
+    // Every notes index came back with the recreated table.
     for index in [
         "notes_title_key",
         "notes_daily_date",
@@ -653,21 +644,30 @@ fn kind_invariant_rebuild_preserves_rows_and_schema() {
             .unwrap()
             .exists([index])
             .unwrap();
-        assert!(exists, "index {index} must be recreated by the rebuild");
+        assert!(exists, "index {index} must be recreated with the table");
     }
 
-    // Foreign-key enforcement is restored after the migration run, and the
-    // child cascades still point at the rebuilt table.
-    let enforced: i64 = conn
-        .query_row("PRAGMA foreign_keys", [], |row| row.get(0))
+    // The write path, the views, and the child cascades all bind to `notes`
+    // by name — prove they resolve against the recreated table.
+    apply_note(&conn, &note("notes/a.md", "A", vec![wiki("Target")])).unwrap();
+    apply_note(&conn, &note("notes/target.md", "Target", vec![])).unwrap();
+    let backlink_sources: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM backlinks WHERE target_path = 'notes/target.md'",
+            [],
+            |row| row.get(0),
+        )
         .unwrap();
-    assert_eq!(enforced, 1, "migrate() must restore PRAGMA foreign_keys");
+    assert_eq!(backlink_sources, 1);
     conn.execute("DELETE FROM notes WHERE path = 'notes/a.md'", [])
         .unwrap();
     let orphans: i64 = conn
-        .query_row("SELECT count(*) FROM tasks", [], |row| row.get(0))
+        .query_row("SELECT count(*) FROM links", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(orphans, 0, "ON DELETE CASCADE must survive the rebuild");
+    assert_eq!(
+        orphans, 0,
+        "ON DELETE CASCADE must target the recreated table"
+    );
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/db/tests.rs
+++ b/apps/desktop/src-tauri/src/db/tests.rs
@@ -613,8 +613,13 @@ fn kind_invariant_rebuild_preserves_rows_and_schema() {
 
     migrate(&mut conn).expect("migrate to latest");
 
-    for (table, expected) in [("notes", 2), ("note_text", 1), ("links", 1), ("tags", 1), ("tasks", 1)]
-    {
+    for (table, expected) in [
+        ("notes", 2),
+        ("note_text", 1),
+        ("links", 1),
+        ("tags", 1),
+        ("tasks", 1),
+    ] {
         let count: i64 = conn
             .query_row(&format!("SELECT count(*) FROM {table}"), [], |row| {
                 row.get(0)

--- a/crates/index-schema/migrations/0015_note_kind_invariant.sql
+++ b/crates/index-schema/migrations/0015_note_kind_invariant.sql
@@ -1,0 +1,74 @@
+-- Enforce the kind/daily_date invariant at the schema level: kind = 'daily'
+-- iff daily_date is set. Both columns are derived from the path at index time
+-- (`buildIndexedNote`), so every row written by the indexer agrees by
+-- construction — but nothing made SQLite reject a drifted writer, and surfaces
+-- filter on one column or the other interchangeably.
+--
+-- SQLite cannot ADD a table-level CHECK to an existing table, so this is the
+-- documented table-rebuild recipe (lang_altertable.html#otheralter). Six child
+-- tables reference notes(path) ON DELETE CASCADE; `migrate()` in lib.rs runs
+-- the whole set with `PRAGMA foreign_keys` OFF so the DROP below cannot fire
+-- their cascades, and this migration's foreign-key check re-verifies every
+-- child reference against the rebuilt table before the transaction commits.
+
+CREATE TABLE notes_new (
+  path TEXT PRIMARY KEY NOT NULL,
+  id TEXT,
+  title TEXT NOT NULL,
+  title_key TEXT NOT NULL,
+  daily_date TEXT,
+  is_private INTEGER NOT NULL DEFAULT 0,
+  file_hash TEXT NOT NULL,
+  mtime INTEGER NOT NULL DEFAULT 0,
+  updated_at INTEGER NOT NULL DEFAULT 0,
+  is_pinned INTEGER NOT NULL DEFAULT 0,
+  pinned_order REAL,
+  preview TEXT NOT NULL DEFAULT '',
+  has_conflict INTEGER NOT NULL DEFAULT 0,
+  gist_url TEXT,
+  gist_stale INTEGER NOT NULL DEFAULT 0,
+  kind TEXT NOT NULL DEFAULT 'note' CHECK (kind IN ('daily', 'note', 'template')),
+  CHECK ((kind = 'daily') = (daily_date IS NOT NULL))
+);
+
+-- Existing rows satisfy the invariant by construction; a violation here means
+-- real corruption and must fail the migration loudly rather than be rewritten.
+INSERT INTO notes_new (path, id, title, title_key, daily_date, is_private, file_hash,
+                       mtime, updated_at, is_pinned, pinned_order, preview,
+                       has_conflict, gist_url, gist_stale, kind)
+  SELECT path, id, title, title_key, daily_date, is_private, file_hash,
+         mtime, updated_at, is_pinned, pinned_order, preview,
+         has_conflict, gist_url, gist_stale, kind
+  FROM notes;
+
+-- The views name `notes`; drop them so the rename below never has to re-parse
+-- a statement that references the just-dropped table, then recreate them
+-- verbatim from 0014.
+DROP VIEW backlinks;
+DROP VIEW note_keys;
+
+DROP TABLE notes;
+ALTER TABLE notes_new RENAME TO notes;
+
+-- Recreate every index the DROP took with it (0001, 0007, 0010, 0013).
+CREATE INDEX notes_title_key ON notes(title_key);
+CREATE INDEX notes_daily_date ON notes(daily_date);
+CREATE INDEX notes_id ON notes(id) WHERE id IS NOT NULL;
+CREATE INDEX notes_daily_date_mtime_path ON notes(daily_date, mtime DESC, path);
+CREATE INDEX notes_non_daily_mtime ON notes(mtime DESC, path) WHERE daily_date IS NULL;
+CREATE INDEX notes_pinned ON notes(is_pinned, pinned_order, title_key, path) WHERE is_pinned = 1;
+CREATE INDEX notes_has_conflict ON notes(path) WHERE has_conflict = 1;
+
+CREATE VIEW note_keys AS
+  SELECT path AS note_path, title_key AS key FROM notes WHERE kind != 'template'
+  UNION
+  SELECT note_path, alias_key AS key FROM aliases
+    JOIN notes ON notes.path = aliases.note_path AND notes.kind != 'template'
+  UNION
+  SELECT path AS note_path, daily_date AS key FROM notes WHERE daily_date IS NOT NULL;
+
+CREATE VIEW backlinks AS
+  SELECT k.note_path AS target_path, l.source_path, l.kind, l.target_raw, l.alias, l.pos_from, l.pos_to
+  FROM links l JOIN note_keys k ON k.key = l.target_key
+  JOIN notes source ON source.path = l.source_path AND source.kind != 'template'
+  WHERE l.kind = 'wiki';

--- a/crates/index-schema/migrations/0015_note_kind_invariant.sql
+++ b/crates/index-schema/migrations/0015_note_kind_invariant.sql
@@ -4,14 +4,27 @@
 -- construction — but nothing made SQLite reject a drifted writer, and surfaces
 -- filter on one column or the other interchangeably.
 --
--- SQLite cannot ADD a table-level CHECK to an existing table, so this is the
--- documented table-rebuild recipe (lang_altertable.html#otheralter). Six child
--- tables reference notes(path) ON DELETE CASCADE; `migrate()` in lib.rs runs
--- the whole set with `PRAGMA foreign_keys` OFF so the DROP below cannot fire
--- their cascades, and this migration's foreign-key check re-verifies every
--- child reference against the rebuilt table before the transaction commits.
+-- SQLite cannot ADD a table-level CHECK to an existing table, so `notes` is
+-- dropped and recreated with the constraint — and, like 0004/0006/0014, the
+-- projection is wiped rather than copied so the next open re-indexes from
+-- markdown. Wiping the children first also keeps the DROP safe under the
+-- app's runtime `PRAGMA foreign_keys = ON`: DROP TABLE runs an implicit
+-- DELETE FROM, and the child tables' ON DELETE CASCADE clauses have nothing
+-- left to fire on. `index_meta` is bookkeeping and the embedding tables are
+-- content-hash-keyed, so they survive; `chat_*` is durable history and must
+-- never be touched.
+DELETE FROM note_text;
+DELETE FROM links;
+DELETE FROM tags;
+DELETE FROM aliases;
+DELETE FROM assets;
+DELETE FROM tasks;
+DELETE FROM notes;
+DELETE FROM search_fts;
 
-CREATE TABLE notes_new (
+DROP TABLE notes;
+
+CREATE TABLE notes (
   path TEXT PRIMARY KEY NOT NULL,
   id TEXT,
   title TEXT NOT NULL,
@@ -31,26 +44,10 @@ CREATE TABLE notes_new (
   CHECK ((kind = 'daily') = (daily_date IS NOT NULL))
 );
 
--- Existing rows satisfy the invariant by construction; a violation here means
--- real corruption and must fail the migration loudly rather than be rewritten.
-INSERT INTO notes_new (path, id, title, title_key, daily_date, is_private, file_hash,
-                       mtime, updated_at, is_pinned, pinned_order, preview,
-                       has_conflict, gist_url, gist_stale, kind)
-  SELECT path, id, title, title_key, daily_date, is_private, file_hash,
-         mtime, updated_at, is_pinned, pinned_order, preview,
-         has_conflict, gist_url, gist_stale, kind
-  FROM notes;
-
--- The views name `notes`; drop them so the rename below never has to re-parse
--- a statement that references the just-dropped table, then recreate them
--- verbatim from 0014.
-DROP VIEW backlinks;
-DROP VIEW note_keys;
-
-DROP TABLE notes;
-ALTER TABLE notes_new RENAME TO notes;
-
--- Recreate every index the DROP took with it (0001, 0007, 0010, 0013).
+-- Recreate every index the DROP took with it (0001, 0007, 0010, 0013). The
+-- child tables' REFERENCES clauses and the `note_keys`/`backlinks` views
+-- (0014) bind to `notes` by name, so they resolve against the recreated
+-- table unchanged.
 CREATE INDEX notes_title_key ON notes(title_key);
 CREATE INDEX notes_daily_date ON notes(daily_date);
 CREATE INDEX notes_id ON notes(id) WHERE id IS NOT NULL;
@@ -58,17 +55,3 @@ CREATE INDEX notes_daily_date_mtime_path ON notes(daily_date, mtime DESC, path);
 CREATE INDEX notes_non_daily_mtime ON notes(mtime DESC, path) WHERE daily_date IS NULL;
 CREATE INDEX notes_pinned ON notes(is_pinned, pinned_order, title_key, path) WHERE is_pinned = 1;
 CREATE INDEX notes_has_conflict ON notes(path) WHERE has_conflict = 1;
-
-CREATE VIEW note_keys AS
-  SELECT path AS note_path, title_key AS key FROM notes WHERE kind != 'template'
-  UNION
-  SELECT note_path, alias_key AS key FROM aliases
-    JOIN notes ON notes.path = aliases.note_path AND notes.kind != 'template'
-  UNION
-  SELECT path AS note_path, daily_date AS key FROM notes WHERE daily_date IS NOT NULL;
-
-CREATE VIEW backlinks AS
-  SELECT k.note_path AS target_path, l.source_path, l.kind, l.target_raw, l.alias, l.pos_from, l.pos_to
-  FROM links l JOIN note_keys k ON k.key = l.target_key
-  JOIN notes source ON source.path = l.source_path AND source.kind != 'template'
-  WHERE l.kind = 'wiki';

--- a/crates/index-schema/src/lib.rs
+++ b/crates/index-schema/src/lib.rs
@@ -57,9 +57,7 @@ mod schema {
             M::up(include_str!("../migrations/0012_task_due_date.sql")),
             M::up(include_str!("../migrations/0013_perf_indexes.sql")),
             M::up(include_str!("../migrations/0014_note_kind.sql")),
-            // The table rebuild drops and recreates `notes`; verify every
-            // child-table reference against the new table before committing.
-            M::up(include_str!("../migrations/0015_note_kind_invariant.sql")).foreign_key_check(),
+            M::up(include_str!("../migrations/0015_note_kind_invariant.sql")),
         ])
     });
 
@@ -138,45 +136,19 @@ mod schema {
         Ok(Connection::open_in_memory()?)
     }
 
-    /// Runs `operation` with `PRAGMA foreign_keys` OFF, restoring the previous
-    /// value afterwards — the SQLite table-rebuild recipe (0015) drops and
-    /// recreates `notes` while six child tables reference it ON DELETE CASCADE,
-    /// and with enforcement on, the DROP would run an implicit DELETE that
-    /// cascade-wipes them. The pragma is a no-op inside a transaction (each
-    /// migration runs in one), so it has to be toggled out here; rebuild
-    /// migrations carry `foreign_key_check()` to keep references honest.
-    fn with_foreign_keys_off<T>(
-        conn: &mut Connection,
-        operation: impl FnOnce(&mut Connection) -> Result<T, SchemaError>,
-    ) -> Result<T, SchemaError> {
-        let enforced: bool = conn.query_row("PRAGMA foreign_keys", [], |row| row.get(0))?;
-        conn.pragma_update(None, "foreign_keys", false)?;
-        let outcome = operation(conn);
-        let restored = conn.pragma_update(None, "foreign_keys", enforced);
-        match (outcome, restored) {
-            (Ok(value), Ok(())) => Ok(value),
-            (Ok(_), Err(err)) => Err(err.into()),
-            (Err(err), _) => Err(err),
-        }
-    }
-
     /// Bring the connection up to the latest schema version (no-op if current).
     pub fn migrate(conn: &mut Connection) -> Result<(), SchemaError> {
-        with_foreign_keys_off(conn, |conn| {
-            MIGRATIONS
-                .to_latest(conn)
-                .map_err(|err| SchemaError::Migration(err.to_string()))
-        })
+        MIGRATIONS
+            .to_latest(conn)
+            .map_err(|err| SchemaError::Migration(err.to_string()))
     }
 
     /// Stop at schema `version`, so schema-evolution tests can stage data in an
     /// older shape and assert what a later migration does with it.
     pub fn migrate_to(conn: &mut Connection, version: usize) -> Result<(), SchemaError> {
-        with_foreign_keys_off(conn, |conn| {
-            MIGRATIONS
-                .to_version(conn, version)
-                .map_err(|err| SchemaError::Migration(format!("to version {version}: {err}")))
-        })
+        MIGRATIONS
+            .to_version(conn, version)
+            .map_err(|err| SchemaError::Migration(format!("to version {version}: {err}")))
     }
 
     /// Open (creating if needed) and migrate `<root>/.reflect/index.sqlite`.

--- a/crates/index-schema/src/lib.rs
+++ b/crates/index-schema/src/lib.rs
@@ -23,7 +23,7 @@ pub const INDEX_FILE: &str = "index.sqlite";
 /// `user_version` after every migration has run. Read-only consumers compare
 /// this against `PRAGMA user_version` to detect an index written by a newer
 /// (or older) app than they were built for.
-pub const LATEST_SCHEMA_VERSION: usize = 14;
+pub const LATEST_SCHEMA_VERSION: usize = 15;
 
 /// The `index_meta` key holding the TS-owned projection version (the rows'
 /// derivation version, distinct from the schema version above).
@@ -57,6 +57,9 @@ mod schema {
             M::up(include_str!("../migrations/0012_task_due_date.sql")),
             M::up(include_str!("../migrations/0013_perf_indexes.sql")),
             M::up(include_str!("../migrations/0014_note_kind.sql")),
+            // The table rebuild drops and recreates `notes`; verify every
+            // child-table reference against the new table before committing.
+            M::up(include_str!("../migrations/0015_note_kind_invariant.sql")).foreign_key_check(),
         ])
     });
 
@@ -135,19 +138,45 @@ mod schema {
         Ok(Connection::open_in_memory()?)
     }
 
+    /// Runs `operation` with `PRAGMA foreign_keys` OFF, restoring the previous
+    /// value afterwards — the SQLite table-rebuild recipe (0015) drops and
+    /// recreates `notes` while six child tables reference it ON DELETE CASCADE,
+    /// and with enforcement on, the DROP would run an implicit DELETE that
+    /// cascade-wipes them. The pragma is a no-op inside a transaction (each
+    /// migration runs in one), so it has to be toggled out here; rebuild
+    /// migrations carry `foreign_key_check()` to keep references honest.
+    fn with_foreign_keys_off<T>(
+        conn: &mut Connection,
+        operation: impl FnOnce(&mut Connection) -> Result<T, SchemaError>,
+    ) -> Result<T, SchemaError> {
+        let enforced: bool = conn.query_row("PRAGMA foreign_keys", [], |row| row.get(0))?;
+        conn.pragma_update(None, "foreign_keys", false)?;
+        let outcome = operation(conn);
+        let restored = conn.pragma_update(None, "foreign_keys", enforced);
+        match (outcome, restored) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Ok(_), Err(err)) => Err(err.into()),
+            (Err(err), _) => Err(err),
+        }
+    }
+
     /// Bring the connection up to the latest schema version (no-op if current).
     pub fn migrate(conn: &mut Connection) -> Result<(), SchemaError> {
-        MIGRATIONS
-            .to_latest(conn)
-            .map_err(|err| SchemaError::Migration(err.to_string()))
+        with_foreign_keys_off(conn, |conn| {
+            MIGRATIONS
+                .to_latest(conn)
+                .map_err(|err| SchemaError::Migration(err.to_string()))
+        })
     }
 
     /// Stop at schema `version`, so schema-evolution tests can stage data in an
     /// older shape and assert what a later migration does with it.
     pub fn migrate_to(conn: &mut Connection, version: usize) -> Result<(), SchemaError> {
-        MIGRATIONS
-            .to_version(conn, version)
-            .map_err(|err| SchemaError::Migration(format!("to version {version}: {err}")))
+        with_foreign_keys_off(conn, |conn| {
+            MIGRATIONS
+                .to_version(conn, version)
+                .map_err(|err| SchemaError::Migration(format!("to version {version}: {err}")))
+        })
     }
 
     /// Open (creating if needed) and migrate `<root>/.reflect/index.sqlite`.


### PR DESCRIPTION
## Problem

Migration 0014 added `notes.kind` (`'daily' | 'note' | 'template'`), which redundantly encodes "is this a daily note" alongside the older `daily_date` column — both are derived from the path in `buildIndexedNote`, so they agree only by construction. Nothing made SQLite reject a drifted writer: a row with `kind = 'note'` and a `daily_date`, or `kind = 'daily'` with none, would be silently accepted and then surface inconsistently, because queries filter on one column or the other interchangeably (All Notes uses `kind`, the daily-date indexes and `note_keys` use `daily_date`).

0014 already shipped in the tagged v0.4.0-beta.12, so the constraint lands as an appended migration 0015 rather than a rewrite of 0014.

## Changes

1. **Migration `0015_note_kind_invariant.sql`** — adds `CHECK ((kind = 'daily') = (daily_date IS NOT NULL))` to `notes`. SQLite cannot `ADD` a table-level CHECK, so the table is dropped and recreated with the constraint, following the same wipe-for-reindex pattern as 0004/0006/0014: the projection rows are deleted children-first, then `notes` is dropped and recreated under its own name, and the seven `notes` indexes (0001/0007/0010/0013) are recreated. Deleting the children first is what makes the `DROP TABLE` safe under the app's runtime `PRAGMA foreign_keys = ON` — the drop's implicit `DELETE FROM` cascades over already-empty tables. The child tables' `REFERENCES` clauses and the `note_keys`/`backlinks` views bind to `notes` by name, so they resolve against the recreated table unchanged. `index_meta`, the content-hash-keyed embedding tables, and the durable `chat_*` tables are untouched; the next open re-indexes everything, exactly like the previous wipe migrations.
2. **`crates/index-schema/src/lib.rs`** — appends the 0015 migration and bumps `LATEST_SCHEMA_VERSION` to 15. No behavioral changes to the migration runner.
3. **Fixture fixes** — two raw-insert fixtures wrote rows the CHECK now rejects: the CLI's `build_index` (`apps/cli/tests/cli.rs`) inserted daily rows while leaving `kind` at its `'note'` default and now derives `kind` from the daily date, and the desktop open-tasks test staged a `notes/a.md` row with a `daily_date` and now stages a real daily note.

No TS changes: `PROJECTION_VERSION` only moves when row derivation changes, and it doesn't — this constrains what SQLite accepts, not what the indexer writes.

## Tests

- `note_kind_daily_date_invariant_is_enforced` (`db/tests.rs`) — the CHECK rejects `kind='note'` with a `daily_date`, `kind='daily'` without one, and `kind='template'` with one; the three shapes `buildIndexedNote` actually emits all insert cleanly.
- `kind_invariant_migration_wipes_the_projection_for_reindex` (`db/tests.rs`) — stages parent + child + FTS + `index_meta` rows at schema v14 with foreign keys ON, migrates to latest, and asserts: the projection is wiped (so the DROP ran without FK errors), `index_meta` survives, all seven indexes exist on the recreated table, and `apply_note`/`backlinks`/`ON DELETE CASCADE` all resolve against it.
- Existing version pins updated (14 → 15) in `migrations_are_valid_and_idempotent` and `open_index_at_creates_migrates_and_reopens`.

## Verification

```
cargo test -p reflect-index-schema   # 2 passed
cargo test -p reflect-open           # 139 passed (sidecars staged first)
cargo test -p reflect-cli            # 54 passed
cargo clippy -p reflect-index-schema -p reflect-open -p reflect-cli --all-targets   # clean
cargo fmt --check                    # clean
```

## Risk / Rollout

- The migration wipes the note projection, so every graph pays a full re-index on next open — the same cost 0014 charged in this release train, and the standard recovery path (0004/0006/0009/0014 all do this). `chat_*` history and the content-hash-keyed embeddings survive, so nothing durable is lost and unchanged notes are not re-embedded.
- Unlike a copy-based rebuild, the migration cannot fail on a pre-existing inconsistent row — there is no path where a drifted row bricks graph-open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)