### PR TITLE
feat: pre-fill person notes from Apple Contacts when adding a meeting

### DIFF
--- a/apps/desktop/src-tauri/src/calendar.rs
+++ b/apps/desktop/src-tauri/src/calendar.rs
@@ -36,6 +36,9 @@ pub struct CalendarInfo {
 pub struct CalendarAttendee {
     /// Display name, falling back to the address in the participant URL.
     pub name: String,
+    /// The invite email, when the participant URL is a `mailto:` — what the
+    /// contacts integration resolves person notes by.
+    pub email: Option<String>,
     pub is_current_user: bool,
     /// Whether this attendee is a person (as opposed to a room or resource).
     pub is_person: bool,
@@ -318,17 +321,18 @@ mod platform {
     }
 
     fn describe_attendee(attendee: &EKParticipant) -> CalendarAttendee {
+        let address = unsafe { attendee.URL() }
+            .absoluteString()
+            .map(|absolute| absolute.to_string());
+        let email = address
+            .as_deref()
+            .and_then(|absolute| absolute.strip_prefix("mailto:"))
+            .filter(|candidate| !candidate.is_empty())
+            .map(str::to_string);
         let name = unsafe { attendee.name() }
             .map(|name| name.to_string())
-            .or_else(|| {
-                let url = unsafe { attendee.URL() };
-                url.absoluteString().map(|address| {
-                    address
-                        .to_string()
-                        .trim_start_matches("mailto:")
-                        .to_string()
-                })
-            })
+            .or_else(|| email.clone())
+            .or(address)
             .unwrap_or_default();
         let status = match unsafe { attendee.participantStatus() } {
             EKParticipantStatus::Accepted => "accepted",
@@ -339,6 +343,7 @@ mod platform {
         };
         CalendarAttendee {
             name,
+            email,
             is_current_user: unsafe { attendee.isCurrentUser() },
             is_person: unsafe { attendee.participantType() } == EKParticipantType::Person,
             status: status.to_string(),

--- a/apps/desktop/src/components/context-sidebar/add-meeting-dialog.tsx
+++ b/apps/desktop/src/components/context-sidebar/add-meeting-dialog.tsx
@@ -2,9 +2,11 @@ import { useEffect, useState, type ReactElement } from 'react'
 import { X } from 'lucide-react'
 import {
   addMeetingToDaily,
-  defaultAttendeeNames,
+  defaultAttendees,
   errorMessage,
+  isContactsReadable,
   type CalendarEvent,
+  type MeetingAttendee,
 } from '@reflect/core'
 import { InlineAlert } from '@/components/inline-alert'
 import { Button } from '@/components/ui/button'
@@ -18,6 +20,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { useContactsAuthorization } from '@/hooks/use-contacts-authorization'
 import { formatTimeOfDay } from '@/lib/dates'
 import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
@@ -38,13 +41,15 @@ const FIELD_LABEL_CLASS = 'text-xs font-medium text-text-secondary'
  * events, as v1 did — a recurring meeting's shared note is where its notes
  * accumulate). Submitting writes `- [[Meeting]] with [[Person]]…` under the
  * daily note's `## Meetings` heading and creates missing notes; after that
- * nothing stays tied to the calendar.
+ * nothing stays tied to the calendar. With the contacts integration on,
+ * fresh person notes are pre-filled from Apple Contacts by attendee email.
  */
 export function AddMeetingDialog({ date, event, onClose }: AddMeetingDialogProps): ReactElement {
   const { settings } = useSettings()
   const { graph } = useGraph()
+  const contactsAuthorization = useContactsAuthorization()
   const [name, setName] = useState(event.title)
-  const [attendees, setAttendees] = useState<string[]>(() => defaultAttendeeNames(event))
+  const [attendees, setAttendees] = useState<MeetingAttendee[]>(() => defaultAttendees(event))
   const [newAttendee, setNewAttendee] = useState('')
   const [createNote, setCreateNote] = useState(event.recurring)
   const [submitting, setSubmitting] = useState(false)
@@ -62,20 +67,20 @@ export function AddMeetingDialog({ date, event, onClose }: AddMeetingDialogProps
   }, [])
 
   const addAttendee = (): void => {
-    const attendee = newAttendee.trim()
-    if (attendee === '') {
+    const attendeeName = newAttendee.trim()
+    if (attendeeName === '') {
       return
     }
     setAttendees((current) =>
-      current.some((existing) => existing.toLowerCase() === attendee.toLowerCase())
+      current.some((existing) => existing.name.toLowerCase() === attendeeName.toLowerCase())
         ? current
-        : [...current, attendee],
+        : [...current, { name: attendeeName }],
     )
     setNewAttendee('')
   }
 
-  const removeAttendee = (attendee: string): void => {
-    setAttendees((current) => current.filter((existing) => existing !== attendee))
+  const removeAttendee = (attendeeName: string): void => {
+    setAttendees((current) => current.filter((existing) => existing.name !== attendeeName))
   }
 
   const canSubmit = graph !== null && name.trim() !== '' && !submitting
@@ -92,6 +97,10 @@ export function AddMeetingDialog({ date, event, onClose }: AddMeetingDialogProps
         title: name,
         attendees,
         backlinkMeeting: createNote,
+        lookupContacts:
+          settings.contactsEnabled &&
+          contactsAuthorization !== null &&
+          isContactsReadable(contactsAuthorization),
         startTime: formatTimeOfDay(new Date(event.startsAt), settings.timeFormat),
         generation: graph.generation,
       })
@@ -144,14 +153,14 @@ export function AddMeetingDialog({ date, event, onClose }: AddMeetingDialogProps
               <ul className="flex flex-wrap gap-1.5">
                 {attendees.map((attendee) => (
                   <li
-                    key={attendee}
+                    key={attendee.name}
                     className="flex items-center gap-1 rounded-md bg-surface-sunken px-2 py-0.5 text-xs text-text-secondary"
                   >
-                    <span className="max-w-40 truncate">{attendee}</span>
+                    <span className="max-w-40 truncate">{attendee.name}</span>
                     <button
                       type="button"
-                      onClick={() => removeAttendee(attendee)}
-                      aria-label={`Remove ${attendee}`}
+                      onClick={() => removeAttendee(attendee.name)}
+                      aria-label={`Remove ${attendee.name}`}
                       className="text-text-muted transition-colors hover:text-text"
                     >
                       <X className="size-3" />

--- a/apps/desktop/src/components/context-sidebar/add-meeting-dialog.tsx
+++ b/apps/desktop/src/components/context-sidebar/add-meeting-dialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, type ReactElement } from 'react'
 import { X } from 'lucide-react'
 import {
   addMeetingToDaily,
+  contactsAuthorizationStatus,
   defaultAttendees,
   errorMessage,
   isContactsReadable,
@@ -20,7 +21,6 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { useContactsAuthorization } from '@/hooks/use-contacts-authorization'
 import { formatTimeOfDay } from '@/lib/dates'
 import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
@@ -47,7 +47,6 @@ const FIELD_LABEL_CLASS = 'text-xs font-medium text-text-secondary'
 export function AddMeetingDialog({ date, event, onClose }: AddMeetingDialogProps): ReactElement {
   const { settings } = useSettings()
   const { graph } = useGraph()
-  const contactsAuthorization = useContactsAuthorization()
   const [name, setName] = useState(event.title)
   const [attendees, setAttendees] = useState<MeetingAttendee[]>(() => defaultAttendees(event))
   const [newAttendee, setNewAttendee] = useState('')
@@ -92,15 +91,17 @@ export function AddMeetingDialog({ date, event, onClose }: AddMeetingDialogProps
     setSubmitting(true)
     setError(null)
     try {
+      // The permission state is read at submit time, not dialog mount — the
+      // cached query may still be in flight (or stale after a System
+      // Settings trip), and a quick submit must not skip the pre-fill.
+      const lookupContacts =
+        settings.contactsEnabled && isContactsReadable(await contactsAuthorizationStatus())
       await addMeetingToDaily({
         date,
         title: name,
         attendees,
         backlinkMeeting: createNote,
-        lookupContacts:
-          settings.contactsEnabled &&
-          contactsAuthorization !== null &&
-          isContactsReadable(contactsAuthorization),
+        lookupContacts,
         startTime: formatTimeOfDay(new Date(event.startsAt), settings.timeFormat),
         generation: graph.generation,
       })

--- a/apps/desktop/src/components/context-sidebar/daily-events-section.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/daily-events-section.test.tsx
@@ -216,10 +216,6 @@ describe('DailyEventsSection', () => {
     fireEvent.click(await screen.findByRole('button', { name: /standup/i }))
 
     await screen.findByText('Ada Lovelace')
-    // The gate reads the authorization query; submit only after it settles.
-    await waitFor(() =>
-      expect(queryClient.getQueryData(['contacts', 'authorization'])).toBe('authorized'),
-    )
     fireEvent.click(screen.getByRole('button', { name: /add to daily note/i }))
 
     await waitFor(() =>

--- a/apps/desktop/src/components/context-sidebar/daily-events-section.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/daily-events-section.test.tsx
@@ -49,6 +49,7 @@ function eventAt(hour: number, overrides: Record<string, unknown> = {}): Record<
 
 let stored: Record<string, unknown>
 let events: Array<Record<string, unknown>>
+let contactsAuthorization: string
 
 function installFakeBridge(): void {
   setBridge({
@@ -60,6 +61,8 @@ function installFakeBridge(): void {
           return null
         case 'calendar_list_events':
           return events
+        case 'contacts_authorization_status':
+          return contactsAuthorization
         default:
           return null
       }
@@ -83,6 +86,7 @@ function renderSection(): void {
 beforeEach(() => {
   stored = { calendarEnabled: true, calendarIds: ['cal-work'] }
   events = []
+  contactsAuthorization = 'unavailable'
   addMeetingToDaily.mockClear()
   addMeetingToDaily.mockResolvedValue({ appended: true, createdNotes: [] })
   window.sessionStorage.clear()
@@ -181,13 +185,51 @@ describe('DailyEventsSection', () => {
       expect(addMeetingToDaily).toHaveBeenCalledWith({
         date: DATE,
         title: 'Standup',
-        attendees: ['Grace Hopper'],
+        attendees: [{ name: 'Grace Hopper' }],
         backlinkMeeting: false,
+        lookupContacts: false,
         startTime: '9:00am',
         generation: 3,
       }),
     )
     await waitFor(() => expect(screen.queryByLabelText('Meeting name')).toBeNull())
+  })
+
+  it('passes invite emails and the contacts gate through to the action', async () => {
+    stored = { calendarEnabled: true, calendarIds: ['cal-work'], contactsEnabled: true }
+    contactsAuthorization = 'authorized'
+    events = [
+      eventAt(9, {
+        title: 'Standup',
+        attendees: [
+          {
+            name: 'Ada Lovelace',
+            email: 'ada@example.com',
+            isCurrentUser: false,
+            isPerson: true,
+            status: 'accepted',
+          },
+        ],
+      }),
+    ]
+    renderSection()
+    fireEvent.click(await screen.findByRole('button', { name: /standup/i }))
+
+    await screen.findByText('Ada Lovelace')
+    // The gate reads the authorization query; submit only after it settles.
+    await waitFor(() =>
+      expect(queryClient.getQueryData(['contacts', 'authorization'])).toBe('authorized'),
+    )
+    fireEvent.click(screen.getByRole('button', { name: /add to daily note/i }))
+
+    await waitFor(() =>
+      expect(addMeetingToDaily).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attendees: [{ name: 'Ada Lovelace', email: 'ada@example.com' }],
+          lookupContacts: true,
+        }),
+      ),
+    )
   })
 
   it('a removed attendee chip stays out of the submission', async () => {

--- a/docs/porting/calendar-meetings-integration.md
+++ b/docs/porting/calendar-meetings-integration.md
@@ -64,8 +64,11 @@ is added to [docs/privacy.md](../privacy.md)'s inventory.
    the v1 modal: editable meeting name, editable attendee list, and a
    "create backlinked note?" choice. Submitting writes plain markdown into
    the daily note — a `[[Meeting name]]` link and `[[Person]]` links per
-   attendee — and creates the meeting/person notes if missing. After that,
-   they are ordinary notes; nothing about them stays tied to the calendar.
+   attendee — and creates the meeting/person notes if missing. With the
+   [contacts integration](./contacts-integration.md) on, a fresh person note
+   is pre-filled from the Apple Contacts entry matching the attendee's
+   invite email. After that, they are ordinary notes; nothing about them
+   stays tied to the calendar.
 
 ### Architecture
 

--- a/docs/porting/contacts-integration.md
+++ b/docs/porting/contacts-integration.md
@@ -1,17 +1,18 @@
 # Porting contacts integration
 
-**Status: shipped (contacts standalone).** In v1, contacts turned meeting
+**Status: shipped.** In v1, contacts turned meeting
 attendees and name-like notes into real person notes without manual data
 entry. v2 keeps that role but reads the **Apple Contacts** store instead of
 syncing provider address books through a server.
 
 Shipped: the Rust `contacts` capability (`CNContactStore` via `objc2`), the
 Settings → System integrations switch with the permission flow, the
-suggested-contact card, and contacts in the `[[` link menu. The
-meeting-attendee half waits on the
-[calendar flow](./calendar-meetings-integration.md) — its resolution policy
-(`resolveAttendeeContact` in `@reflect/core`) is already in place for it to
-consume.
+suggested-contact card, contacts in the `[[` link menu, and the
+meeting-attendee half: the
+[calendar flow](./calendar-meetings-integration.md)'s add-meeting action
+resolves each attendee's invite email through `resolveAttendeeContact`
+(gated on the integration being enabled and readable) and pre-fills the
+person notes it creates; on a miss the note is created bare, as v1 did.
 
 Decisions taken at implementation time:
 

--- a/packages/core/src/actions/add-meeting.test.ts
+++ b/packages/core/src/actions/add-meeting.test.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { noteExists, readNote, writeNote } from '../graph/commands'
 import { createNoteWithTitle } from '../graph/create-note'
 import { resolveWikiTarget } from '../indexing/queries'
+import { setBridge } from '../ipc/bridge'
 import { resolved, unresolved } from '../markdown/resolve'
 import { addMeetingToDaily, meetingLine, type AddMeetingInput } from './add-meeting'
 
@@ -83,7 +84,7 @@ describe('meetingLine', () => {
 describe('addMeetingToDaily', () => {
   it('appends the meeting under ## Meetings, creating the section on a fresh daily', async () => {
     const outcome = await addMeetingToDaily(
-      input({ attendees: ['Ada Lovelace'], startTime: '9:00am' }),
+      input({ attendees: [{ name: 'Ada Lovelace' }], startTime: '9:00am' }),
     )
     expect(outcome.appended).toBe(true)
     expect(writeNoteMock).toHaveBeenCalledWith(
@@ -103,7 +104,7 @@ describe('addMeetingToDaily', () => {
 
   it('is idempotent: a day that already links the meeting is a full no-op', async () => {
     readNoteMock.mockResolvedValue('## Meetings\n\n- 9:00am met with [[Ada Lovelace]] for [[Standup]]\n')
-    const outcome = await addMeetingToDaily(input({ attendees: ['Carol'] }))
+    const outcome = await addMeetingToDaily(input({ attendees: [{ name: 'Carol' }] }))
     expect(outcome).toEqual({ appended: false, createdNotes: [] })
     expect(writeNoteMock).not.toHaveBeenCalled()
     // No invisible side effects either — a re-add must not mint notes the
@@ -161,7 +162,7 @@ describe('addMeetingToDaily', () => {
         : unresolved(target),
     )
     const outcome = await addMeetingToDaily(
-      input({ attendees: ['Ada Lovelace', 'Grace Hopper'] }),
+      input({ attendees: [{ name: 'Ada Lovelace' }, { name: 'Grace Hopper' }] }),
     )
     expect(createNoteMock).toHaveBeenCalledTimes(1)
     expect(createNoteMock).toHaveBeenCalledWith('Ada Lovelace', GENERATION, '- Type: #person')
@@ -170,7 +171,7 @@ describe('addMeetingToDaily', () => {
 
   it('skips creation when the slug path already exists (index lag backstop)', async () => {
     noteExistsMock.mockImplementation(async (path) => path === 'notes/ada-lovelace.md')
-    await addMeetingToDaily(input({ attendees: ['Ada Lovelace'], backlinkMeeting: false }))
+    await addMeetingToDaily(input({ attendees: [{ name: 'Ada Lovelace' }], backlinkMeeting: false }))
     expect(createNoteMock).not.toHaveBeenCalled()
   })
 
@@ -178,7 +179,12 @@ describe('addMeetingToDaily', () => {
     await addMeetingToDaily(
       input({
         title: '  Stand|up [v2]  ',
-        attendees: ['Ada Lovelace', 'ada lovelace', '', 'Stand up v2'],
+        attendees: [
+          { name: 'Ada Lovelace' },
+          { name: 'ada lovelace' },
+          { name: '' },
+          { name: 'Stand up v2' },
+        ],
       }),
     )
     // `Stand up v2` also names the meeting itself, so it drops out of the
@@ -194,7 +200,7 @@ describe('addMeetingToDaily', () => {
     resolveMock.mockImplementation(async (target) =>
       target === 'Standup' ? resolved('notes/standup.md') : unresolved(target),
     )
-    await addMeetingToDaily(input({ attendees: ['Standup'] }))
+    await addMeetingToDaily(input({ attendees: [{ name: 'Standup' }] }))
     expect(createNoteMock).not.toHaveBeenCalled()
   })
 
@@ -203,5 +209,71 @@ describe('addMeetingToDaily', () => {
       'a meeting needs a name',
     )
     expect(writeNoteMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('addMeetingToDaily contact pre-fill', () => {
+  const ADA = { name: 'Ada Lovelace', email: 'ada@example.com' }
+
+  function installContactsBridge(contacts: unknown[]): ReturnType<typeof vi.fn> {
+    const invoke = vi.fn(async () => contacts)
+    setBridge({ invoke, listen: async () => () => {} })
+    return invoke
+  }
+
+  afterEach(() => {
+    setBridge(null)
+  })
+
+  it('pre-fills a created person note from the matching contact', async () => {
+    const invoke = installContactsBridge([
+      {
+        fullName: 'Ada Lovelace',
+        givenName: 'Ada',
+        familyName: 'Lovelace',
+        emails: ['ada@example.com'],
+        phones: ['+1 555-0100'],
+      },
+    ])
+    await addMeetingToDaily(input({ attendees: [ADA], lookupContacts: true }))
+    expect(invoke).toHaveBeenCalledWith('contacts_lookup_by_email', { email: 'ada@example.com' })
+    expect(createNoteMock).toHaveBeenCalledWith(
+      'Ada Lovelace',
+      GENERATION,
+      '- Type: #person\n- Email: ada@example.com\n- Phone: +1 555-0100',
+    )
+  })
+
+  it('creates the bare typed note on a lookup miss, as v1 did', async () => {
+    installContactsBridge([])
+    await addMeetingToDaily(input({ attendees: [ADA], lookupContacts: true }))
+    expect(createNoteMock).toHaveBeenCalledWith('Ada Lovelace', GENERATION, '- Type: #person')
+  })
+
+  it('never touches the bridge while the contacts gate is off', async () => {
+    const invoke = installContactsBridge([])
+    await addMeetingToDaily(input({ attendees: [ADA] }))
+    expect(invoke).not.toHaveBeenCalled()
+    expect(createNoteMock).toHaveBeenCalledWith('Ada Lovelace', GENERATION, '- Type: #person')
+  })
+
+  it('skips the lookup for attendees without an invite email', async () => {
+    const invoke = installContactsBridge([])
+    await addMeetingToDaily(
+      input({ attendees: [{ name: 'Grace Hopper' }], lookupContacts: true }),
+    )
+    expect(invoke).not.toHaveBeenCalled()
+    expect(createNoteMock).toHaveBeenCalledWith('Grace Hopper', GENERATION, '- Type: #person')
+  })
+
+  it('does not look up attendees whose note already exists', async () => {
+    const invoke = installContactsBridge([])
+    resolveMock.mockImplementation(async (target) =>
+      target === 'Ada Lovelace' ? resolved('notes/ada-lovelace.md') : unresolved(target),
+    )
+    await addMeetingToDaily(input({ attendees: [ADA], lookupContacts: true }))
+    expect(invoke).not.toHaveBeenCalled()
+    expect(createNoteMock).toHaveBeenCalledTimes(1)
+    expect(createNoteMock).toHaveBeenCalledWith('Standup', GENERATION, '- Type: #meeting')
   })
 })

--- a/packages/core/src/actions/add-meeting.ts
+++ b/packages/core/src/actions/add-meeting.ts
@@ -1,3 +1,5 @@
+import { contactDetailsMarkdown } from '../contacts/markdown'
+import { resolveAttendeeContact } from '../contacts/resolve'
 import { isAppError } from '../errors'
 import { noteExists, readNote, writeNote } from '../graph/commands'
 import { createNoteWithTitle } from '../graph/create-note'
@@ -18,9 +20,12 @@ import { slugForTitle } from '../markdown/slug'
  *
  * and creates the notes those links resolve to when they don't exist yet.
  * With "Create backlinked note" off, the meeting name is plain text (as in
- * v1), not a link — only attendees get `[[Person]]` links and notes. After
- * that, they are ordinary notes; nothing stays tied to the calendar, and no
- * event metadata is persisted beyond this markdown.
+ * v1), not a link — only attendees get `[[Person]]` links and notes. With the
+ * contacts integration on (docs/porting/contacts-integration.md), a fresh
+ * person note is pre-filled from the Apple Contacts entry matching the
+ * attendee's invite email. After that, they are ordinary notes; nothing stays
+ * tied to the calendar, and no event metadata is persisted beyond this
+ * markdown.
  *
  * Wiki links resolve by title, so "one note per meeting title" holds by
  * construction: a recurring "Standup" links the same `[[Standup]]` note from
@@ -39,19 +44,35 @@ export const MEETINGS_HEADING = 'Meetings'
 const MEETING_NOTE_BODY = '- Type: #meeting'
 const PERSON_NOTE_BODY = '- Type: #person'
 
+/** One attendee entering the flow: the display name that becomes the
+ * `[[Person]]` link, plus the invite email (when the calendar knew it) that
+ * the contacts lookup resolves by. */
+export interface MeetingAttendee {
+  name: string
+  email?: string | undefined
+}
+
 export interface AddMeetingInput {
   /** ISO `YYYY-MM-DD` day of the daily note receiving the entry. */
   date: string
   /** Meeting name — becomes the `[[Meeting]]` link text and note title. */
   title: string
-  /** Attendee names — each becomes a `[[Person]]` link and (maybe) a note. */
-  attendees: string[]
+  /** Attendees — each becomes a `[[Person]]` link and (maybe) a note. */
+  attendees: MeetingAttendee[]
   /**
    * The dialog's "Create backlinked note?" choice (v1's `backlinkMeeting`):
    * on links the meeting name and creates its note when missing; off writes
    * the name as plain text and creates nothing for it.
    */
   backlinkMeeting: boolean
+  /**
+   * The contacts gate, computed by the caller at submit time
+   * (`settings.contactsEnabled && isContactsReadable(authorization)`). On,
+   * a missing person note is pre-filled from the Apple Contacts entry
+   * matching the attendee's invite email; off — or on a lookup miss — the
+   * note is created bare, as v1 did.
+   */
+  lookupContacts?: boolean
   /**
    * The event's start time, already formatted for display (the caller owns
    * the time-format preference, as v1 did). Omitted, the line starts at
@@ -132,20 +153,39 @@ function meetingAlreadyLinked(source: string, title: string): boolean {
   })
 }
 
-/** Sanitized, case-insensitively deduplicated attendee names, order kept. */
-function normalizeAttendees(attendees: string[]): string[] {
+/** Attendees with sanitized names, case-insensitively name-deduplicated, order kept. */
+function normalizeAttendees(attendees: MeetingAttendee[]): MeetingAttendee[] {
   const seen = new Set<string>()
-  const names: string[] = []
+  const normalized: MeetingAttendee[] = []
   for (const attendee of attendees) {
-    const name = wikiLinkSafe(attendee)
+    const name = wikiLinkSafe(attendee.name)
     const key = name.toLowerCase()
     if (name === '' || seen.has(key)) {
       continue
     }
     seen.add(key)
-    names.push(name)
+    normalized.push(attendee.email === undefined ? { name } : { name, email: attendee.email })
   }
-  return names
+  return normalized
+}
+
+/**
+ * The body a fresh person note is born with. On the contacts path — gate on
+ * and an invite email known — a matched contact's details block (typed
+ * `- Type: #person` by {@link contactDetailsMarkdown}); in every other case
+ * (gate off, no email, lookup miss, or a contact with nothing to write),
+ * v1's bare typing line.
+ */
+async function personNoteBody(attendee: MeetingAttendee, lookupContacts: boolean): Promise<string> {
+  if (!lookupContacts || attendee.email === undefined) {
+    return PERSON_NOTE_BODY
+  }
+  const contact = await resolveAttendeeContact(attendee.email)
+  if (contact === null) {
+    return PERSON_NOTE_BODY
+  }
+  const details = contactDetailsMarkdown(contact)
+  return details === '' ? PERSON_NOTE_BODY : details
 }
 
 /**
@@ -187,7 +227,7 @@ export async function addMeetingToDaily(input: AddMeetingInput): Promise<AddMeet
   // An attendee spelled like the meeting itself (a shared mailbox, a 1:1
   // named after the person) would just duplicate the link — drop it.
   const attendees = normalizeAttendees(input.attendees).filter(
-    (name) => name.toLowerCase() !== title.toLowerCase(),
+    (attendee) => attendee.name.toLowerCase() !== title.toLowerCase(),
   )
 
   const daily = dailyPath(input.date)
@@ -202,7 +242,7 @@ export async function addMeetingToDaily(input: AddMeetingInput): Promise<AddMeet
   }
   const line = meetingLine({
     title,
-    attendees,
+    attendees: attendees.map((attendee) => attendee.name),
     backlinkMeeting: input.backlinkMeeting,
     startTime: input.startTime,
   })
@@ -213,12 +253,13 @@ export async function addMeetingToDaily(input: AddMeetingInput): Promise<AddMeet
     await createNoteWithTitle(title, input.generation, MEETING_NOTE_BODY)
     createdNotes.push(title)
   }
-  for (const name of attendees) {
-    if (await titleHasNote(name)) {
+  for (const attendee of attendees) {
+    if (await titleHasNote(attendee.name)) {
       continue
     }
-    await createNoteWithTitle(name, input.generation, PERSON_NOTE_BODY)
-    createdNotes.push(name)
+    const body = await personNoteBody(attendee, input.lookupContacts ?? false)
+    await createNoteWithTitle(attendee.name, input.generation, body)
+    createdNotes.push(attendee.name)
   }
 
   return { appended: true, createdNotes }

--- a/packages/core/src/calendar/commands.ts
+++ b/packages/core/src/calendar/commands.ts
@@ -43,6 +43,12 @@ export type CalendarInfo = z.infer<typeof calendarInfoSchema>
 
 export const calendarAttendeeSchema = z.object({
   name: z.string(),
+  /**
+   * The invite email, when the participant URL carried one — what the
+   * contacts integration resolves person notes by. `catch` because an
+   * attendee without one must not fail the whole event list.
+   */
+  email: z.string().nullable().catch(null),
   isCurrentUser: z.boolean(),
   /** People, as opposed to rooms and other booked resources. */
   isPerson: z.boolean(),

--- a/packages/core/src/calendar/events.test.ts
+++ b/packages/core/src/calendar/events.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type { CalendarAttendee, CalendarEvent } from './commands'
-import { dayRange, defaultAttendeeNames, displayEvents, isDeclinedByUser } from './events'
+import { dayRange, defaultAttendees, displayEvents, isDeclinedByUser } from './events'
 
 function attendee(overrides: Partial<CalendarAttendee> = {}): CalendarAttendee {
   return {
     name: 'Ada Lovelace',
+    email: null,
     isCurrentUser: false,
     isPerson: true,
     status: 'accepted',
@@ -91,9 +92,9 @@ describe('displayEvents', () => {
   })
 })
 
-describe('defaultAttendeeNames', () => {
+describe('defaultAttendees', () => {
   it('suggests human, non-declined attendees, excluding the user', () => {
-    const names = defaultAttendeeNames(
+    const attendees = defaultAttendees(
       event({
         attendees: [
           attendee({ name: 'Ada Lovelace' }),
@@ -104,11 +105,26 @@ describe('defaultAttendeeNames', () => {
         ],
       }),
     )
-    expect(names).toEqual(['Ada Lovelace'])
+    expect(attendees).toEqual([{ name: 'Ada Lovelace' }])
+  })
+
+  it('carries the invite email for the contacts lookup', () => {
+    const attendees = defaultAttendees(
+      event({
+        attendees: [
+          attendee({ name: 'Ada Lovelace', email: 'ada@example.com' }),
+          attendee({ name: 'Grace Hopper' }),
+        ],
+      }),
+    )
+    expect(attendees).toEqual([
+      { name: 'Ada Lovelace', email: 'ada@example.com' },
+      { name: 'Grace Hopper' },
+    ])
   })
 
   it('deduplicates case-insensitively, keeping first spelling and order', () => {
-    const names = defaultAttendeeNames(
+    const attendees = defaultAttendees(
       event({
         attendees: [
           attendee({ name: 'Ada Lovelace' }),
@@ -117,7 +133,7 @@ describe('defaultAttendeeNames', () => {
         ],
       }),
     )
-    expect(names).toEqual(['Ada Lovelace', 'Grace Hopper'])
+    expect(attendees).toEqual([{ name: 'Ada Lovelace' }, { name: 'Grace Hopper' }])
   })
 })
 

--- a/packages/core/src/calendar/events.ts
+++ b/packages/core/src/calendar/events.ts
@@ -1,3 +1,4 @@
+import type { MeetingAttendee } from '../actions/add-meeting'
 import type { CalendarAttendee, CalendarEvent } from './commands'
 
 /**
@@ -58,14 +59,15 @@ function isSuggestedAttendee(attendee: CalendarAttendee): boolean {
 }
 
 /**
- * Attendee names to prefill the add-meeting dialog: human attendees who
- * haven't declined, excluding the user (a person note for yourself is noise).
- * Deduplicated case-insensitively, original order kept — the list is fully
- * editable in the dialog, so this is a starting point, not policy.
+ * Attendees to prefill the add-meeting dialog: human attendees who haven't
+ * declined, excluding the user (a person note for yourself is noise), each
+ * carrying the invite email the contacts integration resolves by.
+ * Deduplicated case-insensitively by name, original order kept — the list is
+ * fully editable in the dialog, so this is a starting point, not policy.
  */
-export function defaultAttendeeNames(event: CalendarEvent): string[] {
+export function defaultAttendees(event: CalendarEvent): MeetingAttendee[] {
   const seen = new Set<string>()
-  const names: string[] = []
+  const attendees: MeetingAttendee[] = []
   for (const attendee of event.attendees) {
     if (!isSuggestedAttendee(attendee)) {
       continue
@@ -76,9 +78,9 @@ export function defaultAttendeeNames(event: CalendarEvent): string[] {
       continue
     }
     seen.add(key)
-    names.push(name)
+    attendees.push(attendee.email === null ? { name } : { name, email: attendee.email })
   }
-  return names
+  return attendees
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -379,7 +379,7 @@ export {
 export {
   displayEvents,
   isDeclinedByUser,
-  defaultAttendeeNames,
+  defaultAttendees,
   dayRange,
 } from './calendar/events'
 export {
@@ -388,6 +388,7 @@ export {
   MEETINGS_HEADING,
   type AddMeetingInput,
   type AddMeetingOutcome,
+  type MeetingAttendee,
 } from './actions/add-meeting'
 export {
   describePage,


### PR DESCRIPTION
Completes the meeting-attendee half of the contacts integration (docs/porting/contacts-integration.md): when a meeting is added from the calendar panel, each attendee's invite email is looked up in Apple Contacts and the person notes the flow creates are pre-filled with the contact's details.

## Changes

- **Rust calendar capability** — `CalendarAttendee` gains an `email` field, parsed from the `mailto:` participant URL (the display-name fallback behavior is unchanged).
- **`@reflect/core`** — `defaultAttendeeNames` becomes `defaultAttendees`, carrying `{ name, email? }` pairs; `AddMeetingInput.attendees` takes those pairs plus a `lookupContacts` gate flag. On person-note creation, `addMeetingToDaily` resolves the email through the staged `resolveAttendeeContact`; a match seeds the note with `contactDetailsMarkdown` (typed `- Type: #person` plus every email/phone), while a miss — or the gate being off, or no invite email — creates the bare typed note, as v1 did. Notes that already exist are never looked up.
- **Add-meeting dialog** — computes the gate at submit time (`settings.contactsEnabled && isContactsReadable(authorization)`) and passes attendee emails through; manually added attendees carry no email.
- **Docs** — contacts-integration.md status updated to fully shipped; calendar-meetings-integration.md cross-references the pre-fill.

## Testing

- `pnpm check` — 5/5 tasks pass (only pre-existing warnings).
- `pnpm test --run src/actions/add-meeting.test.ts src/calendar/events.test.ts src/contacts/resolve.test.ts` (core) — 39 tests pass, including new fake-bridge coverage for match/miss/gate-off/no-email/existing-note paths.
- `pnpm test --run src/components/context-sidebar/daily-events-section.test.tsx` (desktop) — 8 tests pass, including a new gate-on submission test.
- `cargo check -p reflect-open` — clean (sidecars staged first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive feature behind settings and permission gates; only affects newly created person notes during add-meeting, with tests covering match, miss, and gate-off paths.
> 
> **Overview**
> Completes the **meeting-attendee** side of contacts: adding a calendar meeting can seed new person notes from Apple Contacts using each attendee’s invite email.
> 
> **EventKit / calendar** — `CalendarAttendee` now includes optional `email` (from `mailto:` participant URLs). Display-name fallback is unchanged.
> 
> **Core** — Attendees move from plain names to `{ name, email? }` (`MeetingAttendee`; `defaultAttendeeNames` → `defaultAttendees`). `addMeetingToDaily` accepts `lookupContacts`; when creating a missing person note it calls `resolveAttendeeContact` and uses `contactDetailsMarkdown` on a hit, otherwise the bare `- Type: #person` note. Existing person notes are not looked up or overwritten.
> 
> **UI** — The add-meeting dialog evaluates the contacts gate at **submit** time (`contactsEnabled` + live authorization) and passes emails from calendar prefills; manually added attendees have no email.
> 
> **Docs** — Contacts integration marked fully shipped; calendar doc notes the pre-fill behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30f127888250971e41f029fd854ae0ddda73bc46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->