### PR TITLE
fix: keep shortcuts dialog readable

### DIFF
--- a/apps/desktop/src/components/shortcut-list.tsx
+++ b/apps/desktop/src/components/shortcut-list.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react'
 import { ShortcutKeys } from '@/components/shortcut-keys'
 import { formatBindingLabel } from '@/lib/keybindings'
 import type { Shortcut } from '@/lib/shortcuts'
+import { cn } from '@/lib/utils'
 
 interface ShortcutListProps {
   /** Group heading (a keymap scope: "App", "Editor"). */
@@ -9,6 +10,8 @@ interface ShortcutListProps {
   shortcuts: Shortcut[]
   /** Wrapper spacing — the settings card and the ⌘/ dialog pad differently. */
   className?: string
+  /** Responsive column utilities for dense surfaces such as the ⌘/ dialog. */
+  listClassName?: string
 }
 
 /**
@@ -16,17 +19,22 @@ interface ShortcutListProps {
  * by the Keyboard settings section and the ⌘/ cheat-sheet so the two surfaces
  * can't drift in either content or idiom.
  */
-export function ShortcutList({ heading, shortcuts, className }: ShortcutListProps): ReactElement {
+export function ShortcutList({
+  heading,
+  shortcuts,
+  className,
+  listClassName,
+}: ShortcutListProps): ReactElement {
   return (
     <div className={className}>
       <h3 className="text-[11px] font-semibold tracking-[0.08em] text-text-muted uppercase">
         {heading}
       </h3>
-      <ul className="mt-1.5">
+      <ul className={cn('mt-1.5', listClassName)}>
         {shortcuts.map(({ binding, description }) => (
           <li
             key={binding}
-            className="flex items-center justify-between gap-4 py-1.5 text-sm text-text-secondary"
+            className="flex break-inside-avoid items-center justify-between gap-4 py-1.5 text-sm text-text-secondary"
           >
             <span className="min-w-0 truncate">{description}</span>
             {/* The keycaps are aria-hidden decoration; this carries the binding for AT. */}

--- a/apps/desktop/src/components/shortcuts-dialog.test.tsx
+++ b/apps/desktop/src/components/shortcuts-dialog.test.tsx
@@ -42,6 +42,15 @@ describe('ShortcutsDialog', () => {
     expect(screen.getByText('Keyboard shortcuts', { selector: 'li *' })).toBeTruthy()
   })
 
+  it('keeps the sheet within the viewport and scrolls the shortcut rows', async () => {
+    renderDialog()
+    await userEvent.click(screen.getByRole('button', { name: 'open' }))
+    const dialog = await screen.findByRole('dialog', { name: 'Keyboard shortcuts' })
+    expect(dialog.className).toContain('max-h-[calc(100dvh-2rem)]')
+    expect(dialog.className).toContain('overflow-hidden')
+    expect(dialog.querySelector('.overflow-y-auto')).toBeTruthy()
+  })
+
   it('closes on Escape', async () => {
     renderDialog()
     await userEvent.click(screen.getByRole('button', { name: 'open' }))

--- a/apps/desktop/src/components/shortcuts-dialog.test.tsx
+++ b/apps/desktop/src/components/shortcuts-dialog.test.tsx
@@ -51,6 +51,17 @@ describe('ShortcutsDialog', () => {
     expect(dialog.querySelector('.overflow-y-auto')).toBeTruthy()
   })
 
+  it('uses extra desktop width for additional shortcut columns', async () => {
+    renderDialog()
+    await userEvent.click(screen.getByRole('button', { name: 'open' }))
+    const dialog = await screen.findByRole('dialog', { name: 'Keyboard shortcuts' })
+    expect(dialog.className).toContain('lg:max-w-5xl')
+    expect(dialog.className).toContain('xl:max-w-6xl')
+    const editorList = screen.getByRole('heading', { name: 'Editor' }).parentElement?.querySelector('ul')
+    expect(editorList?.className).toContain('lg:columns-2')
+    expect(editorList?.className).toContain('xl:columns-3')
+  })
+
   it('closes on Escape', async () => {
     renderDialog()
     await userEvent.click(screen.getByRole('button', { name: 'open' }))

--- a/apps/desktop/src/components/shortcuts-dialog.tsx
+++ b/apps/desktop/src/components/shortcuts-dialog.tsx
@@ -24,15 +24,19 @@ export function ShortcutsDialog(): ReactElement {
       {/* No description: the title + lists are the whole content. */}
       <DialogContent
         aria-describedby={undefined}
-        className="grid max-h-[calc(100dvh-2rem)] grid-rows-[auto_minmax(0,1fr)] overflow-hidden sm:max-w-3xl"
+        className="grid max-h-[calc(100dvh-2rem)] grid-rows-[auto_minmax(0,1fr)] overflow-hidden sm:max-w-3xl lg:max-w-5xl xl:max-w-6xl"
       >
         <DialogHeader className="pr-8">
           <DialogTitle>Keyboard shortcuts</DialogTitle>
         </DialogHeader>
         <div className="min-h-0 overflow-y-auto pr-1">
-          <div className="grid gap-6 sm:grid-cols-2">
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-[minmax(14rem,1fr)_minmax(0,2fr)] xl:grid-cols-[minmax(14rem,1fr)_minmax(0,3fr)]">
             <ShortcutList heading="App" shortcuts={APP_SHORTCUTS} />
-            <ShortcutList heading="Editor" shortcuts={EDITOR_SHORTCUTS} />
+            <ShortcutList
+              heading="Editor"
+              shortcuts={EDITOR_SHORTCUTS}
+              listClassName="lg:columns-2 xl:columns-3 lg:gap-8"
+            />
           </div>
         </div>
       </DialogContent>

--- a/apps/desktop/src/components/shortcuts-dialog.tsx
+++ b/apps/desktop/src/components/shortcuts-dialog.tsx
@@ -22,13 +22,18 @@ export function ShortcutsDialog(): ReactElement {
       }}
     >
       {/* No description: the title + lists are the whole content. */}
-      <DialogContent aria-describedby={undefined} className="sm:max-w-xl">
-        <DialogHeader>
+      <DialogContent
+        aria-describedby={undefined}
+        className="grid max-h-[calc(100dvh-2rem)] grid-rows-[auto_minmax(0,1fr)] overflow-hidden sm:max-w-3xl"
+      >
+        <DialogHeader className="pr-8">
           <DialogTitle>Keyboard shortcuts</DialogTitle>
         </DialogHeader>
-        <div className="grid gap-6 sm:grid-cols-2">
-          <ShortcutList heading="App" shortcuts={APP_SHORTCUTS} />
-          <ShortcutList heading="Editor" shortcuts={EDITOR_SHORTCUTS} />
+        <div className="min-h-0 overflow-y-auto pr-1">
+          <div className="grid gap-6 sm:grid-cols-2">
+            <ShortcutList heading="App" shortcuts={APP_SHORTCUTS} />
+            <ShortcutList heading="Editor" shortcuts={EDITOR_SHORTCUTS} />
+          </div>
         </div>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Problem

Pressing `Command-/` could render the keyboard shortcuts sheet taller than the visible Tauri window. On shorter windows, the top of the dialog, including the title, was clipped and lower shortcut rows disappeared off-screen, making the cheat sheet hard to read.

The safe version also needed to make better use of desktop width: the shortcut list is dense, and a tall narrow dialog makes users scroll through rows even when there is plenty of horizontal space available.

## Before -> After

| Before | After |
| --- | --- |
| The shortcuts dialog used its natural content height, so long shortcut lists could extend beyond the viewport. | The dialog is capped to the visible viewport, keeps the title and close control reachable, and scrolls the shortcut rows internally only when needed. |
| The sheet stayed relatively narrow, leaving desktop space unused. | The sheet widens at desktop breakpoints and splits the longer Editor shortcut group into two or three columns. |
| Medium windows got a simple two-scope layout. | Medium windows keep the familiar App / Editor columns, while wide windows use a denser App + multi-column Editor layout. |

## Changes

1. Updated `ShortcutsDialog` so `DialogContent` uses a viewport-safe max height, a header/list grid, and hidden outer overflow.
2. Wrapped the shortcut sections in a `min-h-0 overflow-y-auto` region so only the rows scroll when the list exceeds the available height.
3. Added wider desktop max widths and responsive grid tracks so the dialog uses available horizontal space.
4. Extended `ShortcutList` with a `listClassName` hook for dense surfaces and used CSS columns for the Editor shortcut rows in the dialog.
5. Added regression tests for the viewport cap, internal scroll region, wider desktop sizing, and additional columns.

## Verification

- `pnpm --filter @reflect/desktop test -- src/components/shortcuts-dialog.test.tsx src/components/shortcut-keys.test.tsx` passed.
- `pnpm check` passed. It reported existing lint warnings in unrelated files.
- `pnpm build` passed. Vite reported the existing large chunk warning.

## Risk / Rollout

Low risk. This is a layout-only change scoped to the shortcuts dialog and shared shortcut list styling; it does not change shortcut registration or command behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only changes to the shortcuts dialog and shared list styling; shortcut registration and behavior are untouched.
> 
> **Overview**
> Fixes the ⌘/ **keyboard shortcuts** dialog clipping on short Tauri windows by capping **`DialogContent`** height to the viewport (`max-h-[calc(100dvh-2rem)]`), using a fixed header + scrollable body (`overflow-y-auto`), and widening the sheet at larger breakpoints (`sm:max-w-3xl` through `xl:max-w-6xl`).
> 
> The **Editor** list can flow into **2–3 CSS columns** on large screens via a new optional **`listClassName`** on **`ShortcutList`** (with **`break-inside-avoid`** on rows); settings keyboard UI is unchanged.
> 
> Adds regression tests that assert the viewport cap, internal scroll region, and responsive width/column classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d324685ec4c8fedcbceade9b8cdc8a0b6995ad3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
