### PR TITLE
Release v0.4.0-beta.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4742,7 +4742,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.4.0-beta.12"
+version = "0.4.0-beta.13"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.4.0-beta.12"
+version = "0.4.0-beta.13"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.4.0-beta.12",
+  "version": "0.4.0-beta.13",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.4.0-beta.13.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version bump with no logic or dependency changes beyond the lockfile package version field.
> 
> **Overview**
> **Release v0.4.0-beta.13** — version-only change for the desktop Tauri app.
> 
> Updates `reflect-open` from **0.4.0-beta.12** to **0.4.0-beta.13** in `apps/desktop/src-tauri/Cargo.toml`, `tauri.conf.json`, and the matching `reflect-open` entry in `Cargo.lock`. No application code or dependency changes beyond the lockfile version pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f512d92283ea06692b02515903509095a6e41ad2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->