### PR TITLE
Add OpenRouter AI provider

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -19,6 +19,7 @@
         { "url": "https://api.openai.com/*" },
         { "url": "https://api.anthropic.com/*" },
         { "url": "https://generativelanguage.googleapis.com/*" },
+        { "url": "https://openrouter.ai/*" },
         { "url": "https://github.com/login/device/code" },
         { "url": "https://github.com/login/oauth/access_token" },
         { "url": "https://api.github.com/*" }

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: asset: https:; font-src 'self' data:; frame-src 'self' https://platform.twitter.com https://platform.x.com https://syndication.twitter.com https://www.youtube-nocookie.com https://www.youtube.com; connect-src 'self' ipc: http://ipc.localhost https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://github.com https://api.github.com",
+      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: asset: https:; font-src 'self' data:; frame-src 'self' https://platform.twitter.com https://platform.x.com https://syndication.twitter.com https://www.youtube-nocookie.com https://www.youtube.com; connect-src 'self' ipc: http://ipc.localhost https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://openrouter.ai https://github.com https://api.github.com",
       "assetProtocol": {
         "enable": true,
         "scope": []

--- a/apps/desktop/src/components/settings/ai-providers-section.test.tsx
+++ b/apps/desktop/src/components/settings/ai-providers-section.test.tsx
@@ -174,6 +174,16 @@ describe('AiProvidersSection', () => {
     expect(screen.queryByRole('dialog')).toBeNull()
   })
 
+  it('offers OpenRouter in the provider picker', async () => {
+    renderSection()
+    await waitFor(() => expect(screen.getByText(/No AI providers configured/)).toBeTruthy())
+
+    const dialog = openDialog()
+    fireEvent.keyDown(dialog.getByRole('combobox', { name: 'Provider' }), { key: 'ArrowDown' })
+
+    expect(await screen.findByRole('option', { name: 'OpenRouter' })).toBeTruthy()
+  })
+
   it('rejects a key the provider turns down, storing nothing', async () => {
     providerFetchMock.mockResolvedValue(new Response(null, { status: 401 }))
     renderSection()

--- a/docs/decisions/0002-index-bridge-followups.md
+++ b/docs/decisions/0002-index-bridge-followups.md
@@ -37,13 +37,14 @@ through the **Rust** HTTP plugin, not webview `fetch`:
   ([`apps/desktop/src/lib/provider-fetch.ts`](../../apps/desktop/src/lib/provider-fetch.ts)),
   which is `@tauri-apps/plugin-http`'s `fetch`, wired into the AI SDK as
   `fetchFn` ([`apps/desktop/src/providers/chat-provider.tsx:307`](../../apps/desktop/src/providers/chat-provider.tsx)
-  → `createOpenAI/Anthropic/GoogleGenerativeAI({ fetch })` in
+  → `createOpenAI/Anthropic/GoogleGenerativeAI({ fetch })`, with OpenRouter using
+  the OpenAI-compatible provider at a custom base URL, in
   [`packages/core/src/ai/chat/stream-chat.ts`](../../packages/core/src/ai/chat/stream-chat.ts)).
 - GitHub calls use the same plugin.
 - The allowed hosts are already enumerated in
   [`capabilities/default.json`](../../apps/desktop/src-tauri/capabilities/default.json)
   (`api.openai.com`, `api.anthropic.com`, `generativelanguage.googleapis.com`,
-  `github.com`, `api.github.com`).
+  `openrouter.ai`, `github.com`, `api.github.com`).
 
 Because the webview itself doesn't need to reach those hosts directly, its
 `connect-src` can be **very tight**. A policy roughly like:

--- a/docs/porting/README.md
+++ b/docs/porting/README.md
@@ -24,7 +24,7 @@ designs simply don't survive the move:
   which already aggregate the user's Google, Microsoft, and iCloud accounts
   if they are added to macOS.
 - **Bring your own key.** v1 bundled metered AI access with per-plan quotas.
-  v2 talks directly to OpenAI, Anthropic, or Google with the user's own key
+  v2 talks directly to OpenAI, Anthropic, Google, or OpenRouter with the user's own key
   (stored in the keychain), so quota tiers, upgrade prompts, and usage
   metering disappear entirely.
 - **Files first.** Anything that is user content (templates, notes created

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -13,8 +13,8 @@ disk at call time), and it is covered by tests.
 
 ## AI chat (off until you add a key)
 
-- **Where:** directly to the provider whose API key *you* added — OpenAI, Anthropic, or
-  Google. Keys are bring-your-own; Reflect proxies nothing.
+- **Where:** directly to the provider whose API key *you* added — OpenAI, Anthropic,
+  Google, or OpenRouter. Keys are bring-your-own; Reflect proxies nothing.
 - **What:** your chat messages, plus what the model's tools read from your graph:
   search snippets, note content, and note listings. Private notes are dropped from
   every tool result, and reading one is refused outright — the model sees a refusal,
@@ -86,8 +86,8 @@ disk at call time), and it is covered by tests.
 
 ## Housekeeping calls
 
-- **API key validation:** adding a provider key sends one `GET /v1/models` to that
-  provider to test it. No content.
+- **API key validation:** adding a provider key sends one cheap authenticated probe to
+  that provider to test it. No content.
 - **Update check:** the packaged app fetches a release manifest (`latest.json`) from
   this repository's GitHub Releases on launch and every six hours. Stable builds check
   the latest stable release; beta builds check the beta feed. The app downloads the

--- a/docs/reflect-v2-product-vision.md
+++ b/docs/reflect-v2-product-vision.md
@@ -315,7 +315,7 @@ Notes with `private: true` are hard-blocked from cloud AI. They may remain local
 
 ### BYOK First
 
-V2 should start with bring-your-own-key AI. (As shipped: OpenAI, Anthropic, and Google keys, stored in the OS keychain.)
+V2 should start with bring-your-own-key AI. (As shipped: OpenAI, Anthropic, Google, and OpenRouter keys, stored in the OS keychain.)
 
 The architecture should leave room for:
 

--- a/docs/security-pass/findings.md
+++ b/docs/security-pass/findings.md
@@ -24,7 +24,7 @@ BYOK API keys, or calls `invoke('note_write', ...)` to overwrite arbitrary notes
 - `script-src 'self'` blocks `javascript:` URI execution (W3C spec: CSP applies to `javascript:` navigation)
 - `style-src 'self' 'unsafe-inline'` allows ProseMirror/meowdown's inline styles
 - `img-src 'self' blob: data: asset: https:` allows graph images via the asset protocol
-- `connect-src` restricted to Tauri IPC and the four AI/GitHub endpoints already gated by the HTTP capability
+- `connect-src` restricted to Tauri IPC and the AI/GitHub endpoints already gated by the HTTP capability
 
 ---
 

--- a/docs/security-pass/plan.md
+++ b/docs/security-pass/plan.md
@@ -63,7 +63,7 @@ Reflect Open is a local-first, open-source Tauri 2 note-taking app.  Notes are p
 `script-src 'self'` (without `'unsafe-inline'`) blocks `javascript:` href execution in WKWebView/WebView2/webkitgtk per the W3C spec. The IPC, asset protocol, external fetch (via the HTTP plugin), and inline styles are all allowed.
 
 ```json
-"csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: asset: https:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://github.com https://api.github.com"
+"csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: asset: https:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://openrouter.ai https://github.com https://api.github.com"
 ```
 
 **Regression risk:** Low. The app's bundled JS is served from `'self'`; the HTTP plugin's fetch is already capability-gated at the Rust level; inline styles (`'unsafe-inline'` in `style-src`) are preserved for ProseMirror/meowdown.

--- a/packages/core/src/ai/language-model.test.ts
+++ b/packages/core/src/ai/language-model.test.ts
@@ -19,6 +19,13 @@ const ANTHROPIC_CONFIG: AiProviderConfig = {
   keyHint: 'wxyz1',
 }
 
+const OPENROUTER_CONFIG: AiProviderConfig = {
+  id: 'cfg-openrouter',
+  provider: 'openrouter',
+  model: 'openrouter/auto',
+  keyHint: 'wxyz1',
+}
+
 function recordingAnthropicFetch(calls: RecordedCall[]): typeof fetch {
   return async (input, init) => {
     calls.push({
@@ -41,6 +48,32 @@ function recordingAnthropicFetch(calls: RecordedCall[]): typeof fetch {
   }
 }
 
+function recordingOpenRouterFetch(calls: RecordedCall[]): typeof fetch {
+  return async (input, init) => {
+    calls.push({
+      url: String(input),
+      headers: new Headers(init?.headers),
+    })
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl_123',
+        object: 'chat.completion',
+        created: 0,
+        model: OPENROUTER_CONFIG.model,
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'ok' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+}
+
 describe('languageModel', () => {
   it('adds Anthropic direct-browser access to model calls', async () => {
     const calls: RecordedCall[] = []
@@ -56,5 +89,21 @@ describe('languageModel', () => {
     expect(calls[0]!.headers.get(ANTHROPIC_DIRECT_BROWSER_ACCESS_HEADER)).toBe(
       ANTHROPIC_DIRECT_BROWSER_ACCESS_VALUE,
     )
+  })
+
+  it('routes OpenRouter through its OpenAI-compatible chat endpoint', async () => {
+    const calls: RecordedCall[] = []
+
+    await generateText({
+      model: languageModel(OPENROUTER_CONFIG, 'sk-or-v1-test', recordingOpenRouterFetch(calls)),
+      prompt: 'hello',
+      maxRetries: 0,
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.url).toBe('https://openrouter.ai/api/v1/chat/completions')
+    expect(calls[0]!.headers.get('Authorization')).toBe('Bearer sk-or-v1-test')
+    expect(calls[0]!.headers.get('HTTP-Referer')).toBe('https://reflect.app')
+    expect(calls[0]!.headers.get('X-OpenRouter-Title')).toBe('Reflect')
   })
 })

--- a/packages/core/src/ai/language-model.ts
+++ b/packages/core/src/ai/language-model.ts
@@ -4,6 +4,7 @@ import { createOpenAI } from '@ai-sdk/openai'
 import type { LanguageModel } from 'ai'
 import type { AiProviderConfig } from '../settings/schema'
 import { anthropicDirectBrowserAccessHeaders } from './anthropic-headers'
+import { OPENROUTER_BASE_URL, openRouterAttributionHeaders } from './openrouter'
 
 /**
  * Build the AI SDK model instance for a configured BYOK entry — the one place
@@ -27,5 +28,13 @@ export function languageModel(
       })(config.model)
     case 'google':
       return createGoogleGenerativeAI({ apiKey, fetch: fetchFn })(config.model)
+    case 'openrouter':
+      return createOpenAI({
+        apiKey,
+        fetch: fetchFn,
+        baseURL: OPENROUTER_BASE_URL,
+        headers: openRouterAttributionHeaders(),
+        name: 'openrouter',
+      }).chat(config.model)
   }
 }

--- a/packages/core/src/ai/openrouter.ts
+++ b/packages/core/src/ai/openrouter.ts
@@ -1,0 +1,10 @@
+/** The OpenAI-compatible OpenRouter API root. */
+export const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1'
+
+/** Optional attribution headers OpenRouter uses for app identification. */
+export function openRouterAttributionHeaders(): Record<string, string> {
+  return {
+    'HTTP-Referer': 'https://reflect.app',
+    'X-OpenRouter-Title': 'Reflect',
+  }
+}

--- a/packages/core/src/ai/provider-catalog.test.ts
+++ b/packages/core/src/ai/provider-catalog.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it } from 'vitest'
-import { AI_PROVIDERS, DEFAULT_CONTEXT_WINDOW, modelContextWindow } from './provider-catalog'
+import {
+  AI_PROVIDERS,
+  DEFAULT_CONTEXT_WINDOW,
+  aiProvider,
+  modelContextWindow,
+} from './provider-catalog'
+
+describe('AI_PROVIDERS', () => {
+  it('includes OpenRouter in the settings catalog', () => {
+    expect(aiProvider('openrouter')).toMatchObject({
+      id: 'openrouter',
+      label: 'OpenRouter',
+      keyPlaceholder: 'sk-or-v1-…',
+    })
+  })
+})
 
 describe('modelContextWindow', () => {
   it('every curated model declares a usable context window', () => {
@@ -14,6 +29,7 @@ describe('modelContextWindow', () => {
 
   it('resolves a curated model and falls back for unknown ids', () => {
     expect(modelContextWindow('anthropic', 'claude-haiku-4-5')).toBe(200_000)
+    expect(modelContextWindow('openrouter', 'openrouter/auto')).toBe(128_000)
     // Settings may carry ids added by a newer app version.
     expect(modelContextWindow('anthropic', 'claude-fable-6')).toBe(DEFAULT_CONTEXT_WINDOW)
   })

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -70,6 +70,21 @@ export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
       { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', contextWindow: 1_000_000 },
     ],
   },
+  {
+    id: 'openrouter',
+    label: 'OpenRouter',
+    keyPlaceholder: 'sk-or-v1-…',
+    models: [
+      { id: 'openrouter/auto', label: 'Auto Router', contextWindow: 128_000 },
+      { id: '~openai/gpt-latest', label: 'OpenAI GPT Latest', contextWindow: 128_000 },
+      {
+        id: '~anthropic/claude-sonnet-latest',
+        label: 'Claude Sonnet Latest',
+        contextWindow: 128_000,
+      },
+      { id: 'openai/gpt-5.2', label: 'GPT-5.2', contextWindow: 400_000 },
+    ],
+  },
 ]
 
 /** The catalog entry for `id` (every `AiProviderId` is in the catalog). */

--- a/packages/core/src/ai/provider-config.test.ts
+++ b/packages/core/src/ai/provider-config.test.ts
@@ -93,8 +93,11 @@ describe('pickTranscriptionConfig', () => {
     expect(pickTranscriptionConfig(state(providers, 'claude'))?.id).toBe('gemini')
   })
 
-  it('returns null when only anthropic entries exist', () => {
-    const providers = [config({ id: 'claude', provider: 'anthropic', model: 'claude-fable-5' })]
+  it('returns null when only non-transcription providers exist', () => {
+    const providers = [
+      config({ id: 'claude', provider: 'anthropic', model: 'claude-fable-5' }),
+      config({ id: 'openrouter', provider: 'openrouter', model: 'openrouter/auto' }),
+    ]
     expect(pickTranscriptionConfig(state(providers, 'claude'))).toBeNull()
   })
 

--- a/packages/core/src/ai/provider-config.ts
+++ b/packages/core/src/ai/provider-config.ts
@@ -70,8 +70,8 @@ export function defaultAiProvider(state: AiProvidersState): AiProviderConfig | n
 }
 
 /**
- * Providers with a speech-to-text path, in preference order (Anthropic has
- * no audio API).
+ * Providers with a speech-to-text path, in preference order. Anthropic and
+ * OpenRouter have no dedicated transcription path in this app.
  */
 export const TRANSCRIPTION_PROVIDERS = ['openai', 'google'] as const
 

--- a/packages/core/src/ai/validate-key.test.ts
+++ b/packages/core/src/ai/validate-key.test.ts
@@ -23,6 +23,7 @@ describe('validateApiKey', () => {
     await validateApiKey('openai', 'sk-test', recordingFetch)
     await validateApiKey('anthropic', 'sk-ant-test', recordingFetch)
     await validateApiKey('google', 'AIza-test', recordingFetch)
+    await validateApiKey('openrouter', 'sk-or-v1-test', recordingFetch)
 
     expect(calls[0]!.url).toBe('https://api.openai.com/v1/models')
     expect(calls[0]!.headers['Authorization']).toBe('Bearer sk-test')
@@ -31,6 +32,8 @@ describe('validateApiKey', () => {
     expect(calls[1]!.headers['anthropic-version']).toBe('2023-06-01')
     expect(calls[2]!.url).toBe('https://generativelanguage.googleapis.com/v1beta/models')
     expect(calls[2]!.headers['x-goog-api-key']).toBe('AIza-test')
+    expect(calls[3]!.url).toBe('https://openrouter.ai/api/v1/key')
+    expect(calls[3]!.headers['Authorization']).toBe('Bearer sk-or-v1-test')
   })
 
   it('reads an ok response as valid', async () => {
@@ -42,6 +45,9 @@ describe('validateApiKey', () => {
     expect(await validateApiKey('anthropic', 'sk-test', fetchReturning(403))).toBe('invalid')
     // Gemini reports malformed keys as 400.
     expect(await validateApiKey('google', 'bad', fetchReturning(400))).toBe('invalid')
+    expect(await validateApiKey('openrouter', 'sk-or-v1-test', fetchReturning(401))).toBe(
+      'invalid',
+    )
   })
 
   it('reads anything that is not an auth decision as unreachable', async () => {

--- a/packages/core/src/ai/validate-key.ts
+++ b/packages/core/src/ai/validate-key.ts
@@ -1,11 +1,12 @@
 import type { AiProviderId } from '../settings/schema'
 import { anthropicDirectBrowserAccessHeaders } from './anthropic-headers'
+import { OPENROUTER_BASE_URL } from './openrouter'
 
 /**
  * BYOK key validation (Plan 10): one cheap authenticated probe against the
- * provider's model-listing endpoint, so a typo'd or wrong-provider key is
- * caught at entry instead of failing later inside an AI call. Only the
- * response status is read — no body parsing, no data retained.
+ * provider, so a typo'd or wrong-provider key is caught at entry instead of
+ * failing later inside an AI call. Only the response status is read — no body
+ * parsing, no data retained.
  */
 
 /**
@@ -42,6 +43,11 @@ const PROBES: Record<AiProviderId, KeyProbe> = {
     headers: (key) => ({ 'x-goog-api-key': key }),
     // Gemini reports a malformed key as 400 INVALID_ARGUMENT.
     invalidStatuses: [400, 401, 403],
+  },
+  openrouter: {
+    url: `${OPENROUTER_BASE_URL}/key`,
+    headers: (key) => ({ Authorization: `Bearer ${key}` }),
+    invalidStatuses: [401, 403],
   },
 }
 

--- a/packages/core/src/settings/schema.test.ts
+++ b/packages/core/src/settings/schema.test.ts
@@ -199,6 +199,16 @@ describe('settingsSchema', () => {
       expect(settingsSchema.parse({ aiProviders: [valid] }).aiProviders).toEqual([valid])
     })
 
+    it('accepts OpenRouter entries', () => {
+      const entry = {
+        id: 'openrouter',
+        provider: 'openrouter',
+        model: 'openrouter/auto',
+        keyHint: 'wxyz1',
+      }
+      expect(settingsSchema.parse({ aiProviders: [entry] }).aiProviders).toEqual([entry])
+    })
+
     it('defaults the per-entry display fields', () => {
       const entry = { id: 'abc', provider: 'openai', model: 'gpt-5.1' }
       expect(settingsSchema.parse({ aiProviders: [entry] }).aiProviders).toEqual([

--- a/packages/core/src/settings/schema.ts
+++ b/packages/core/src/settings/schema.ts
@@ -215,7 +215,7 @@ export const graphColorsSchema = z
  * The cloud AI providers Reflect can call directly (BYOK — the user's own
  * keys, no Reflect-hosted proxy).
  */
-export const aiProviderIdSchema = z.enum(['openai', 'anthropic', 'google'])
+export const aiProviderIdSchema = z.enum(['openai', 'anthropic', 'google', 'openrouter'])
 
 export type AiProviderId = z.infer<typeof aiProviderIdSchema>
 


### PR DESCRIPTION
## Problem

Reflect's BYOK AI provider plumbing only recognized OpenAI, Anthropic, and Google. Users could not add an OpenRouter key in Settings, persisted settings with an OpenRouter entry would be dropped by the schema, and the desktop shell did not allow egress to OpenRouter even if a provider entry were hand-edited in.

This PR adds OpenRouter for AI chat/editor/capture/asset-description paths. It intentionally does not enable audio memo transcription through OpenRouter; the current transcription code uses provider-specific OpenAI and Google speech endpoints.

## Before -> After

| Surface | Before | After |
| --- | --- | --- |
| Settings provider picker | OpenAI, Anthropic, Google | OpenAI, Anthropic, Google, OpenRouter |
| Settings schema | Dropped `provider: "openrouter"` entries | Preserves OpenRouter entries |
| Runtime model factory | No OpenRouter branch | Uses OpenRouter's OpenAI-compatible chat endpoint |
| Key validation | No OpenRouter probe | Probes `GET https://openrouter.ai/api/v1/key` |
| Tauri egress | `openrouter.ai` blocked | `openrouter.ai` allowed in HTTP capability and CSP |
| Audio memos | OpenAI/Google only | Still OpenAI/Google only |

## Changes

1. Added `openrouter` to `aiProviderIdSchema` and the Settings provider catalog, including a `sk-or-v1-...` key placeholder and curated starter model IDs while preserving the existing custom-model combobox behavior.
2. Added `packages/core/src/ai/openrouter.ts` for the shared base URL and attribution headers.
3. Routed OpenRouter model calls through `createOpenAI({ baseURL: "https://openrouter.ai/api/v1" }).chat(...)`, matching OpenRouter's chat-completions compatibility surface while leaving native OpenAI on the existing Responses path.
4. Added OpenRouter key validation against `/api/v1/key`, and updated docs to describe provider validation generically rather than claiming every provider uses `/v1/models`.
5. Extended the Tauri HTTP allowlist and webview CSP for `https://openrouter.ai`, plus updated privacy/security docs that enumerate provider destinations.
6. Added tests for settings schema round-trip, provider catalog exposure, runtime endpoint selection/headers, key validation, transcription gating, and the Settings provider picker.

## Tests

- Core provider/settings tests cover schema acceptance, catalog lookup, key validation, OpenRouter chat endpoint routing, and the non-transcription-provider behavior.
- Desktop Settings test covers OpenRouter appearing in the Add Provider dialog.

## Verification

- `pnpm --filter @reflect/core test --run src/ai/provider-catalog.test.ts src/ai/validate-key.test.ts src/ai/language-model.test.ts src/ai/provider-config.test.ts src/settings/schema.test.ts` passed.
- `pnpm --filter @reflect/desktop test --run src/components/settings/ai-providers-section.test.tsx` passed.
- `pnpm typecheck` passed.
- `pnpm lint` passed with warnings only (existing max-lines/no-unsafe-optional-chaining warnings plus existing React Hook Form compiler warnings in settings dialogs).
- `pnpm check` passed with the same warning set.
- `pnpm build` passed with the existing Vite large-chunk warning.
- After label polish, `pnpm --filter @reflect/core test --run src/ai/provider-catalog.test.ts` passed.

## Risk / Rollout

No migration is needed. Existing settings continue to parse, and OpenRouter keys are stored in the same OS keychain flow as other AI providers. The main risk is model capability variance across OpenRouter models; the existing custom model entry and provider refusal handling remain the fallback paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive provider wiring with tests and aligned egress/CSP; main caveat is varied model behavior on OpenRouter, same as other BYOK paths.
> 
> **Overview**
> Adds **OpenRouter** as a fourth BYOK AI provider alongside OpenAI, Anthropic, and Google.
> 
> **Core:** `openrouter` is added to settings schema and the provider catalog (starter models, `sk-or-v1-…` placeholder). Chat and other generative paths route through OpenAI-compatible `createOpenAI` at `https://openrouter.ai/api/v1` with Reflect attribution headers; key validation probes `GET /api/v1/key`. **Audio transcription is unchanged** — still OpenAI/Google only.
> 
> **Desktop:** Tauri HTTP allowlist and webview CSP `connect-src` now include `https://openrouter.ai`.
> 
> **Docs:** Privacy, product vision, porting, security, and decision docs list OpenRouter and describe key validation generically (not every provider uses `/v1/models`).
> 
> Tests cover schema, catalog, `languageModel` routing/headers, `validateApiKey`, transcription gating, and the Settings provider picker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a607c894a302c0756a0342228a345ff6dd597f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->