### PR TITLE
feat: make reflect:// deep links clickable inside notes

### DIFF
--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom/vitest'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { openUrl } from '@tauri-apps/plugin-opener'
+import { dispatchDeepLink } from '@/lib/deep-links/intake'
 import { NoteEditor } from './note-editor'
 
 /** Props the mocked `<MeowdownEditor>` captures so the test can drive its callbacks. */
@@ -22,6 +23,10 @@ const captured = vi.hoisted(() => ({ props: null as CapturedEditorProps | null }
 
 vi.mock('@tauri-apps/plugin-opener', () => ({
   openUrl: vi.fn(async () => {}),
+}))
+
+vi.mock('@/lib/deep-links/intake', () => ({
+  dispatchDeepLink: vi.fn(),
 }))
 
 // Stub the editor: capture its props and render the image-preview DOM shape
@@ -240,6 +245,16 @@ describe('NoteEditor link opening', () => {
     act(() => captured.props?.onLinkClick?.({ href: 'assets/cat.png', event }))
 
     expect(openImage).toHaveBeenCalledWith('assets/cat.png')
+    expect(openUrl).not.toHaveBeenCalled()
+  })
+
+  it('routes a reflect:// link through the in-app deep-link intake, not the URL opener', () => {
+    renderEditor()
+
+    const event = new MouseEvent('click')
+    act(() => captured.props?.onLinkClick?.({ href: 'reflect://note/abc123', event }))
+
+    expect(dispatchDeepLink).toHaveBeenCalledWith('reflect://note/abc123')
     expect(openUrl).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -30,6 +30,8 @@ import {
   type LightboxImage,
 } from '@/editor/image-lightbox'
 import { useLightboxTransition } from '@/editor/use-lightbox-transition'
+import { dispatchDeepLink } from '@/lib/deep-links/intake'
+import { isDeepLinkUrl } from '@/lib/deep-links/parse'
 import { cn } from '@/lib/utils'
 
 /**
@@ -274,6 +276,13 @@ export function NoteEditor({
         void Promise.resolve(openAssetRef.current?.(assetPath)).catch((cause) => {
           console.error('open asset failed:', errorMessage(cause))
         })
+        return
+      }
+      // A `reflect://` link routes through the in-app deep-link pipeline —
+      // the OS opener would deny the scheme (and a round-trip could land on
+      // another installed flavor).
+      if (isDeepLinkUrl(href)) {
+        dispatchDeepLink(href)
         return
       }
       void openUrl(href).catch((cause) => {

--- a/apps/desktop/src/editor/open-external-link.test.ts
+++ b/apps/desktop/src/editor/open-external-link.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { openUrl } from '@tauri-apps/plugin-opener'
+import { dispatchDeepLink } from '@/lib/deep-links/intake'
+import { openExternalLink } from '@/editor/open-external-link'
+
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  openUrl: vi.fn(async () => {}),
+}))
+
+vi.mock('@/lib/deep-links/intake', () => ({
+  dispatchDeepLink: vi.fn(),
+}))
+
+function click(href: string): MouseEvent {
+  const event = new MouseEvent('click', { cancelable: true })
+  openExternalLink({ href, event })
+  return event
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('openExternalLink', () => {
+  it('opens an http(s) link in the OS browser and blocks the frame navigation', () => {
+    const event = click('https://example.com')
+
+    expect(openUrl).toHaveBeenCalledWith('https://example.com')
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('routes a reflect:// link through the in-app deep-link intake, not the URL opener', () => {
+    click('reflect://note/abc123')
+
+    expect(dispatchDeepLink).toHaveBeenCalledWith('reflect://note/abc123')
+    expect(openUrl).not.toHaveBeenCalled()
+  })
+
+  it('drops other schemes without opening anything', () => {
+    const event = click('javascript:alert(1)')
+
+    expect(openUrl).not.toHaveBeenCalled()
+    expect(dispatchDeepLink).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(true)
+  })
+})

--- a/apps/desktop/src/editor/open-external-link.ts
+++ b/apps/desktop/src/editor/open-external-link.ts
@@ -1,13 +1,21 @@
 import type { LinkClickHandler } from '@meowdown/core'
 import { openUrl } from '@tauri-apps/plugin-opener'
+import { dispatchDeepLink } from '@/lib/deep-links/intake'
+import { isDeepLinkUrl } from '@/lib/deep-links/parse'
 
 /**
  * Open a rendered Markdown link in the OS browser instead of letting the click
  * navigate the app's WebView frame. The static `MarkdownView` surfaces aren't
  * contenteditable, so an `<a href>` click would otherwise unload the whole app.
+ * A `reflect://` link routes through the in-app deep-link pipeline instead —
+ * the OS opener denies the scheme.
  */
 export const openExternalLink: LinkClickHandler = ({ href, event }) => {
   event.preventDefault()
+  if (isDeepLinkUrl(href)) {
+    dispatchDeepLink(href)
+    return
+  }
   if (/^https?:\/\//i.test(href)) {
     void openUrl(href)
   }

--- a/apps/desktop/src/lib/deep-links/intake.test.ts
+++ b/apps/desktop/src/lib/deep-links/intake.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getCurrent, onOpenUrl } from '@tauri-apps/plugin-deep-link'
 import {
+  dispatchDeepLink,
   resetDeepLinkIntakeForTests,
   setDeepLinkHandler,
   startDeepLinkListener,
@@ -103,6 +104,24 @@ describe('deep-link intake', () => {
     setDeepLinkHandler(handler)
 
     expect(handler.mock.calls).toEqual([['reflect://today'], ['reflect://tasks']])
+  })
+
+  it('delivers an in-app dispatch (a clicked note link) straight to the handler', () => {
+    const handler = vi.fn()
+    setDeepLinkHandler(handler)
+
+    dispatchDeepLink('reflect://note/from-a-note-body')
+
+    expect(handler).toHaveBeenCalledWith('reflect://note/from-a-note-body')
+  })
+
+  it('buffers an in-app dispatch when no handler is attached', () => {
+    dispatchDeepLink('reflect://today')
+
+    const handler = vi.fn()
+    setDeepLinkHandler(handler)
+
+    expect(handler).toHaveBeenCalledWith('reflect://today')
   })
 
   it('buffers again after the handler detaches (graph switch gap)', async () => {

--- a/apps/desktop/src/lib/deep-links/intake.ts
+++ b/apps/desktop/src/lib/deep-links/intake.ts
@@ -14,7 +14,15 @@ let pendingUrls: string[] = []
 let activeHandler: ((url: string) => void) | null = null
 let started = false
 
-function deliverDeepLink(url: string): void {
+/**
+ * Feed one `reflect://` URL into the intake as if the OS had delivered it —
+ * the entry point for deep links clicked *inside* the app (a link in a note
+ * body must not round-trip through the OS opener: the opener capability
+ * denies the scheme, dev builds don't register it, and macOS could hand the
+ * URL to a different installed flavor). Buffers like any OS delivery when no
+ * graph is open.
+ */
+export function dispatchDeepLink(url: string): void {
   if (activeHandler !== null) {
     activeHandler(url)
   } else {
@@ -57,11 +65,11 @@ export async function startDeepLinkListener(): Promise<void> {
   try {
     unlisten = await onOpenUrl((urls) => {
       for (const url of urls) {
-        deliverDeepLink(url)
+        dispatchDeepLink(url)
       }
     })
     for (const url of (await getCurrent()) ?? []) {
-      deliverDeepLink(url)
+      dispatchDeepLink(url)
     }
   } catch (cause) {
     // Unlatch FIRST so a later call can retry — a failed start must not

--- a/apps/desktop/src/lib/deep-links/parse.test.ts
+++ b/apps/desktop/src/lib/deep-links/parse.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { DEEP_LINK_TEXT_MAX_LENGTH } from '@/lib/deep-links/deep-link'
-import { parseDeepLink } from '@/lib/deep-links/parse'
+import { isDeepLinkUrl, parseDeepLink } from '@/lib/deep-links/parse'
 
 describe('parseDeepLink', () => {
   it('parses the bare navigation verbs', () => {
@@ -116,5 +116,25 @@ describe('parseDeepLink', () => {
     expect(parseDeepLink('reflect://edit-notes?content=evil')).toBeNull()
     expect(parseDeepLink('not a url')).toBeNull()
     expect(parseDeepLink('')).toBeNull()
+  })
+})
+
+describe('isDeepLinkUrl', () => {
+  it('matches the reflect scheme regardless of case', () => {
+    expect(isDeepLinkUrl('reflect://today')).toBe(true)
+    expect(isDeepLinkUrl('REFLECT://note/abc')).toBe(true)
+  })
+
+  it('matches scheme-only, even links the parser would reject', () => {
+    expect(isDeepLinkUrl('reflect://settings')).toBe(true)
+    expect(isDeepLinkUrl('reflect:today')).toBe(true)
+  })
+
+  it('rejects other schemes and non-URLs', () => {
+    expect(isDeepLinkUrl('https://example.com')).toBe(false)
+    expect(isDeepLinkUrl('mailto:someone@example.com')).toBe(false)
+    expect(isDeepLinkUrl('assets/cat.png')).toBe(false)
+    expect(isDeepLinkUrl('not a url')).toBe(false)
+    expect(isDeepLinkUrl('')).toBe(false)
   })
 })

--- a/apps/desktop/src/lib/deep-links/parse.ts
+++ b/apps/desktop/src/lib/deep-links/parse.ts
@@ -51,6 +51,19 @@ export function parseDeepLink(raw: string): DeepLink | null {
   }
 }
 
+/**
+ * Whether an href uses the app's `reflect:` scheme — the routing predicate
+ * for links clicked *inside* the app, which must dispatch through the in-app
+ * deep-link pipeline instead of the OS opener (the opener capability denies
+ * the scheme, dev builds don't register it, and another installed flavor
+ * could claim the OS round-trip). Scheme-only: true does not promise
+ * {@link parseDeepLink} accepts the URL — a malformed link still dispatches,
+ * so it fails on the status line like any other bad deep link.
+ */
+export function isDeepLinkUrl(href: string): boolean {
+  return tryParseUrl(href)?.protocol === `${DEEP_LINK_SCHEME}:`
+}
+
 function tryParseUrl(raw: string): URL | null {
   try {
     return new URL(raw)

--- a/docs/deep-links.md
+++ b/docs/deep-links.md
@@ -65,6 +65,10 @@ drain re-runs cleanly.
   to the running instance and focuses it; macOS does this natively.
 - A link that arrives while no graph is open (cold launch, graph chooser)
   buffers and fires once the graph opens.
+- A `reflect://` link clicked *inside* the app (a note body, chat, a backlink
+  snippet) dispatches straight into the same in-app handler — no OS
+  round-trip, so it works in dev builds and can never land on a different
+  installed flavor.
 
 ## Relationship to the CLI
 


### PR DESCRIPTION
## Problem

`reflect://` deep links work when they arrive from outside the app (other apps, scripts, launchers), but a deep link inside a note does nothing when clicked. Three things stack up against the in-note path:

- The editor's link click handler sends every non-asset href to the Tauri opener, and the opener capability only allows http(s)/mailto (plus the System Settings carve-out) — the `reflect` scheme is denied outright.
- Even if allowed, an OS round-trip only works in a bundled app (dev builds don't register the scheme), and with several flavors installed (Reflect / Beta / Dev) macOS could hand the URL to a different one.
- The static `MarkdownView` surfaces (chat, backlink snippets, note previews) use `openExternalLink`, which silently drops anything that isn't http(s).

Meanwhile "Copy deep link" (`⌥⌘L`) exists precisely so people can paste these links into notes.

## Change

Route in-app clicks on `reflect://` hrefs into the deep-link pipeline the OS intake already feeds, instead of the OS opener:

- **`lib/deep-links/parse.ts`** — new `isDeepLinkUrl(href)` predicate (scheme-only check, matching `parseDeepLink`'s protocol comparison).
- **`lib/deep-links/intake.ts`** — the private `deliverDeepLink` is now the exported `dispatchDeepLink(url)`: the entry point for links clicked inside the app, with the same buffering semantics as OS deliveries.
- **`editor/note-editor.tsx`** — `handleLinkClick` dispatches `reflect://` hrefs in-app (after the existing asset-link branch) instead of calling `openUrl`.
- **`editor/open-external-link.ts`** — same routing for the static markdown surfaces.
- **`docs/deep-links.md`** — documents the in-app click behavior.

Clicked links get identical semantics to OS-delivered ones: navigation links navigate, `note/<target>` resolves through the index, capture links spool through the inbox, and malformed links fail on the operations status line ("Unrecognized link") rather than silently.

Not in this PR: a bare *typed* `reflect://today` still isn't linkified (GFM autolink only recognizes http(s)/www/mailto). That needs a meowdown autolink extension and is tracked separately; `[label](reflect://…)` markdown links and `<reflect://…>` angle autolinks are the forms this PR makes work.

## Testing

- New unit tests: `isDeepLinkUrl` (case-insensitive scheme, scheme-only matching, rejections), `dispatchDeepLink` (direct delivery + buffering when no graph is open), note-editor click routing (reflect → intake, never `openUrl`), and a new `open-external-link.test.ts` (http opens, reflect dispatches, other schemes drop, frame navigation blocked).
- Ran the neighboring suites that transitively import the intake (chat screen, command palette, tasks screen, deep-link provider, handle) — all green.
- `pnpm check` (typecheck + lint) passes.
- Not manually exercised in a running Tauri app yet.

## Risk

Low. The opener behavior for http(s)/mailto and asset links is untouched; the new branch only diverts a scheme that previously always failed. `dispatchDeepLink` reuses the exact code path OS deliveries take, so no new handling logic was introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only diverts a scheme that previously failed or was ignored; reuses the existing OS deep-link delivery path with no change to http(s), mailto, or asset link handling.
> 
> **Overview**
> **`reflect://` links clicked inside the app** (note editor, previews, backlink snippets) now route through the same deep-link intake as OS-delivered URLs, instead of `openUrl` (which denies the scheme) or being dropped on static markdown surfaces.
> 
> Adds **`isDeepLinkUrl`** for scheme-only detection and exports **`dispatchDeepLink`** from deep-link intake so in-app clicks share buffering when no graph is open. **`NoteEditor`** `handleLinkClick` and **`openExternalLink`** branch on `reflect:` after asset links; http(s) and asset behavior is unchanged. Docs note in-app dispatch vs OS round-trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f227e67c542bb6a53728a24b15bd5d008682789d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->