### PR TITLE
V1 parity for the mobile Daily tab

### DIFF
--- a/apps/desktop/src/mobile/calendar-strip.tsx
+++ b/apps/desktop/src/mobile/calendar-strip.tsx
@@ -1,10 +1,10 @@
-import { useMemo, type ReactElement } from 'react'
-import { format } from 'date-fns'
+import { useEffect, useRef, type ReactElement } from 'react'
 import { Button } from '@/components/ui/button'
-import { parseIsoDate } from '@/lib/dates'
-import { monthLabel, weekOf } from '@/mobile/calendar'
+import { addDaysIso } from '@/lib/dates'
+import { monthLabel, weekAtIndex, weekStartOf } from '@/mobile/calendar'
 import { SettingsSheet } from '@/mobile/settings-sheet'
-import { cn } from '@/lib/utils'
+import { useWeekStrip } from '@/mobile/use-week-strip'
+import { WeekRow } from '@/mobile/week-row'
 import { useSettings } from '@/providers/settings-provider'
 
 interface CalendarStripProps {
@@ -13,20 +13,56 @@ interface CalendarStripProps {
   /** Today's live ISO date — owned by the parent so the strip and the
    *  parent's select logic share one value (no midnight-rollover skew). */
   today: string
+  /**
+   * Bumped on an explicit re-arrival at the shown day (Daily tab / title tap
+   * while already there): re-center the strip on the selection even though
+   * `date` didn't change.
+   */
+  resetSeq: number
   /** Select a day — drives the carousel and the route. */
   onSelect: (date: string) => void
 }
 
 /**
- * V1's calendar strip: a month header and the selected day's week as seven
- * day-of-week / day-number cells, the selected day circled. Tapping a cell
- * selects that day; the week shown always contains the selection, so the
- * strip and the carousel stay in lockstep through the parent's `date`. A
- * **Today** affordance appears in the header when the selection has wandered.
+ * V1's calendar strip: a month header over a **pageable** week row — seven
+ * day-of-week / day-number cells per week, swipe left/right to browse whole
+ * weeks, tap a cell to select that day. Browsing moves the header month with
+ * the visible week; the strip snaps back to the selection's week whenever the
+ * selection itself changes, so strip and carousel stay in lockstep through
+ * the parent's `date`. The tappable month title jumps back to today (V1), and
+ * a **Today** affordance appears in the header when the selection has
+ * wandered off today.
  */
-export function CalendarStrip({ date, today, onSelect }: CalendarStripProps): ReactElement {
+export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStripProps): ReactElement {
   const { settings } = useSettings()
-  const week = useMemo(() => weekOf(date, settings.weekStartDay), [date, settings.weekStartDay])
+  const { emblaRef, weekWindow, displayedWeekStart, showWeekOf } = useWeekStrip(
+    date,
+    settings.weekStartDay,
+  )
+
+  // Header month: the selection's own month while its week is on screen;
+  // while browsing, the visible week's dominant (middle-day) month.
+  const selectionWeekStart = weekStartOf(date, settings.weekStartDay)
+  const headerDate =
+    displayedWeekStart === selectionWeekStart ? date : addDaysIso(displayedWeekStart, 3)
+
+  const jumpToToday = (): void => {
+    onSelect(today)
+    // Selecting today only moves the strip when `date` changes — re-center
+    // explicitly so a browse-away strip snaps back even when already on today.
+    showWeekOf(today)
+  }
+
+  // An explicit re-arrival doesn't change `date`, so the follow effect won't
+  // move a browsed-away strip — re-center it here.
+  const lastResetSeq = useRef(resetSeq)
+  useEffect(() => {
+    if (resetSeq === lastResetSeq.current) {
+      return
+    }
+    lastResetSeq.current = resetSeq
+    showWeekOf(date)
+  }, [resetSeq, date, showWeekOf])
 
   return (
     <header
@@ -39,53 +75,36 @@ export function CalendarStrip({ date, today, onSelect }: CalendarStripProps): Re
         <div className="justify-self-start">
           <SettingsSheet />
         </div>
-        <h1 className="min-w-0 truncate text-center text-base font-semibold">{monthLabel(date)}</h1>
+        <h1 className="min-w-0 truncate text-center text-base font-semibold">
+          <button type="button" aria-label="Jump to today" onClick={jumpToToday}>
+            {monthLabel(headerDate)}
+          </button>
+        </h1>
         <div className="justify-self-end">
           {date !== today && (
-            <Button variant="ghost" size="sm" onClick={() => onSelect(today)}>
+            <Button variant="ghost" size="sm" onClick={jumpToToday}>
               Today
             </Button>
           )}
         </div>
       </div>
-      <div className="flex">
-        {week.map((day) => {
-          const selected = day === date
-          const isToday = day === today
-          return (
-            <button
-              key={day}
-              type="button"
-              aria-label={format(parseIsoDate(day), 'EEEE, MMMM do')}
-              aria-current={selected ? 'date' : undefined}
-              onClick={() => onSelect(day)}
-              className="flex flex-1 flex-col items-center gap-0.5 py-1"
-            >
-              <span className="text-[11px] font-medium text-text-muted">
-                {format(parseIsoDate(day), 'EEEEE')}
-              </span>
-              <span
-                className={cn(
-                  'flex size-8 items-center justify-center rounded-full text-sm tabular-nums',
-                  selected && 'bg-primary font-semibold text-primary-foreground',
-                  !selected && isToday && 'font-semibold text-primary',
-                  !selected && !isToday && 'text-text',
-                )}
-              >
-                {format(parseIsoDate(day), 'd')}
-              </span>
-              {/* Today dot (V1) — a fixed-height slot so cells stay aligned;
-                  shown only when today isn't the selected (circled) day. */}
-              <span
-                aria-hidden
-                className={cn(
-                  'size-1 rounded-full',
-                  !selected && isToday ? 'bg-primary' : 'bg-transparent',
-                )}
+      <div className="overflow-hidden" ref={emblaRef}>
+        <div className="flex">
+          {Array.from({ length: weekWindow.count }, (_, index) => {
+            const weekStart = weekAtIndex(weekWindow, index)
+            const weekEnd = addDaysIso(weekStart, 6)
+            const contains = (day: string): boolean => day >= weekStart && day <= weekEnd
+            return (
+              <WeekRow
+                key={weekStart}
+                weekStart={weekStart}
+                selectedDay={contains(date) ? date : null}
+                todayDay={contains(today) ? today : null}
+                onSelect={onSelect}
               />
-            </button>
-          )
-        })}
+            )
+          })}
+        </div>
       </div>
     </header>
   )

--- a/apps/desktop/src/mobile/calendar.test.ts
+++ b/apps/desktop/src/mobile/calendar.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { monthLabel, weekOf } from './calendar'
+import {
+  createWeekWindow,
+  monthLabel,
+  weekAtIndex,
+  weekIndexOf,
+  weekOf,
+  weekStartOf,
+} from './calendar'
 
 /**
  * 2026-06-12 is a Friday; 2026-06-14 a Sunday — fixed anchors for the
@@ -51,5 +58,52 @@ describe('weekOf', () => {
 describe('monthLabel', () => {
   it('formats the month and year', () => {
     expect(monthLabel('2026-06-12')).toBe('June 2026')
+  })
+})
+
+describe('weekStartOf', () => {
+  it('finds the Monday of a mid-week date', () => {
+    expect(weekStartOf('2026-06-12', 'monday')).toBe('2026-06-08')
+  })
+
+  it('keeps a Sunday in its own Monday-first week', () => {
+    expect(weekStartOf('2026-06-14', 'monday')).toBe('2026-06-08')
+  })
+
+  it('finds the Sunday of a Sunday-first week', () => {
+    expect(weekStartOf('2026-06-12', 'sunday')).toBe('2026-06-07')
+  })
+
+  it('is a fixed point on the week-start day itself', () => {
+    expect(weekStartOf('2026-06-08', 'monday')).toBe('2026-06-08')
+    expect(weekStartOf('2026-06-07', 'sunday')).toBe('2026-06-07')
+  })
+})
+
+describe('week windows', () => {
+  const window = createWeekWindow('2026-06-12', 'monday', 4)
+
+  it('centers the anchor date’s week', () => {
+    expect(window).toEqual({ start: '2026-05-11', count: 9, anchorIndex: 4 })
+    expect(weekAtIndex(window, window.anchorIndex)).toBe('2026-06-08')
+  })
+
+  it('maps indices to week starts and back', () => {
+    expect(weekAtIndex(window, 0)).toBe('2026-05-11')
+    expect(weekAtIndex(window, 8)).toBe('2026-07-06')
+    expect(weekIndexOf(window, '2026-06-14', 'monday')).toBe(4) // Sunday, same week
+    expect(weekIndexOf(window, '2026-05-11', 'monday')).toBe(0)
+    expect(weekIndexOf(window, '2026-07-12', 'monday')).toBe(8)
+  })
+
+  it('reports -1 for dates beyond the window', () => {
+    expect(weekIndexOf(window, '2026-05-10', 'monday')).toBe(-1)
+    expect(weekIndexOf(window, '2026-07-13', 'monday')).toBe(-1)
+  })
+
+  it('reports -1 when the week-start setting no longer aligns (rebuild signal)', () => {
+    // The window's weeks start on Mondays; a Sunday-first lookup lands
+    // mid-week and must force a rebuild rather than mislabel slides.
+    expect(weekIndexOf(window, '2026-06-12', 'sunday')).toBe(-1)
   })
 })

--- a/apps/desktop/src/mobile/calendar.ts
+++ b/apps/desktop/src/mobile/calendar.ts
@@ -1,24 +1,81 @@
-import { format, getDay } from 'date-fns'
+import { differenceInCalendarDays, format, getDay } from 'date-fns'
 import type { WeekStartDay } from '@reflect/core'
 import { addDaysIso, parseIsoDate } from '@/lib/dates'
 
 /**
  * Date math for the V1-parity Daily surface's **calendar strip** — the month
- * header and week row above the day carousel. Pure; the strip component stays
- * thin over it. The carousel's own slide-window math is the shared
+ * header and pageable week row above the day carousel. Pure; the strip
+ * component and {@link module:@/mobile/use-week-strip} stay thin over it. The
+ * carousel's own slide-window math is the shared
  * {@link module:@/lib/day-window} (the desktop daily stream uses the same
  * module), so day-paging stays consistent across surfaces.
  */
 
-/** The seven ISO dates of `date`'s week, honoring the week-start setting. */
-export function weekOf(date: string, weekStart: WeekStartDay): string[] {
+/** The first day of `date`'s week, honoring the week-start setting. */
+export function weekStartOf(date: string, weekStart: WeekStartDay): string {
   const weekday = getDay(parseIsoDate(date)) // 0 = Sunday … 6 = Saturday
   const offsetToFirst = weekStart === 'monday' ? (weekday === 0 ? -6 : 1 - weekday) : -weekday
-  const first = addDaysIso(date, offsetToFirst)
+  return addDaysIso(date, offsetToFirst)
+}
+
+/** The seven ISO dates of `date`'s week, honoring the week-start setting. */
+export function weekOf(date: string, weekStart: WeekStartDay): string[] {
+  const first = weekStartOf(date, weekStart)
   return Array.from({ length: 7 }, (_, index) => addDaysIso(first, index))
 }
 
 /** The strip's month header, e.g. `June 2026`. */
 export function monthLabel(date: string): string {
   return format(parseIsoDate(date), 'MMMM yyyy')
+}
+
+/**
+ * The week strip's slide window: a fixed run of consecutive weeks (each one
+ * strip slide), identified by their week-start dates. The strip re-centers it
+ * when paging nears an edge — the same virtual-window pattern as the day
+ * carousel's {@link module:@/lib/day-window}, in units of weeks.
+ */
+export interface WeekWindow {
+  /** Week-start ISO date of index 0 (the oldest week in the window). */
+  start: string
+  /** Total number of weeks (strip slides). */
+  count: number
+  /** Index of the anchor week (the window was centered on it). */
+  anchorIndex: number
+}
+
+/** Weeks either side of the strip's anchor (~half a year each way). */
+export const WEEK_WINDOW_RADIUS = 26
+
+/** Build the window centered on the week containing `date`. */
+export function createWeekWindow(
+  date: string,
+  weekStart: WeekStartDay,
+  radius: number = WEEK_WINDOW_RADIUS,
+): WeekWindow {
+  return {
+    start: addDaysIso(weekStartOf(date, weekStart), -radius * 7),
+    count: radius * 2 + 1,
+    anchorIndex: radius,
+  }
+}
+
+/** The week-start ISO date at `index` (0 = oldest). */
+export function weekAtIndex(window: WeekWindow, index: number): string {
+  return addDaysIso(window.start, index * 7)
+}
+
+/**
+ * The index of the week containing `date`, or `-1` when it lies outside the
+ * window — including when the window was built for a **different week-start
+ * day** (its weeks no longer align), the strip's signal to rebuild it.
+ */
+export function weekIndexOf(window: WeekWindow, date: string, weekStart: WeekStartDay): number {
+  const target = weekStartOf(date, weekStart)
+  const offset = differenceInCalendarDays(parseIsoDate(target), parseIsoDate(window.start))
+  if (offset % 7 !== 0) {
+    return -1
+  }
+  const index = offset / 7
+  return index >= 0 && index < window.count ? index : -1
 }

--- a/apps/desktop/src/mobile/day-carousel.tsx
+++ b/apps/desktop/src/mobile/day-carousel.tsx
@@ -1,17 +1,18 @@
-import { type ReactElement } from 'react'
-import { dailyPath } from '@reflect/core'
-import { NotePane } from '@/components/note-pane'
-import { formatDayLabel } from '@/lib/dates'
+import { useState, type ReactElement } from 'react'
 import { dateAtIndex } from '@/lib/day-window'
-import { cn } from '@/lib/utils'
+import { DaySlide } from '@/mobile/day-slide'
 import { useDayCarousel } from '@/mobile/use-day-carousel'
-import { useSettings } from '@/providers/settings-provider'
 
 interface DayCarouselProps {
   /** The selected day (from the route). Drives the carousel position. */
   date: string
   /** Today's live ISO date — tints today's date heading, as on desktop. */
   today: string
+  /**
+   * Bumped on an explicit re-arrival at the shown day (Daily tab / title tap
+   * while already there): the selected slide re-anchors to the top.
+   */
+  scrollResetSeq: number
   /** Settle on a day — the parent turns this into a daily-route navigation. */
   onSelect: (date: string) => void
 }
@@ -23,12 +24,21 @@ const MOUNT_RADIUS = 1
 /**
  * V1's swipeable day carousel: horizontal paging between daily notes. The slide
  * window, Embla wiring, and route↔slide sync all live in {@link useDayCarousel};
- * this component just renders the slides, mounting a `NotePane` only near the
- * selection and leaving the rest as empty spacers.
+ * this component just renders the slides, mounting a {@link DaySlide} only near
+ * the selection and leaving the rest as empty spacers. Each day's scroll offset
+ * lives in a carousel-owned map so it survives its slide unmounting (V1's
+ * per-slide scroll preservation).
  */
-export function DayCarousel({ date, today, onSelect }: DayCarouselProps): ReactElement {
+export function DayCarousel({
+  date,
+  today,
+  scrollResetSeq,
+  onSelect,
+}: DayCarouselProps): ReactElement {
   const { emblaRef, dayWindow, selectedIndex } = useDayCarousel(date, onSelect)
-  const { settings } = useSettings()
+  // One mutable map for the carousel's life; the identity never changes, so
+  // holding it in state (read during render) rather than a ref is safe.
+  const [scrollMemory] = useState(() => new Map<string, number>())
 
   return (
     <div className="min-h-0 flex-1 overflow-hidden" ref={emblaRef}>
@@ -39,25 +49,13 @@ export function DayCarousel({ date, today, onSelect }: DayCarouselProps): ReactE
           return (
             <div key={day} className="min-w-0 flex-[0_0_100%]">
               {mounted ? (
-                <div
-                  className="h-full overflow-y-auto"
-                  style={{
-                    paddingBottom: 'max(env(safe-area-inset-bottom), var(--keyboard-height, 0px))',
-                  }}
-                >
-                  {/* The date is the daily note's subject (V1 / desktop parity) —
-                      chrome above the editor, formatted per the user's setting,
-                      tinted on today. Shares the note body's px-4 gutter. */}
-                  <h2 className={cn('reflect-daily-subject px-4 pt-4 pb-1', day === today && 'text-accent')}>
-                    {formatDayLabel(day, settings.dateFormat)}
-                  </h2>
-                  <NotePane
-                    path={dailyPath(day)}
-                    lazy
-                    gutterClassName="px-4"
-                    editorClassName="min-h-[60dvh]"
-                  />
-                </div>
+                <DaySlide
+                  day={day}
+                  today={today}
+                  selected={index === selectedIndex}
+                  scrollMemory={scrollMemory}
+                  scrollResetSeq={scrollResetSeq}
+                />
               ) : null}
             </div>
           )

--- a/apps/desktop/src/mobile/day-slide.tsx
+++ b/apps/desktop/src/mobile/day-slide.tsx
@@ -25,13 +25,18 @@ interface DaySlideProps {
   scrollResetSeq: number
 }
 
+/** How long a remount keeps chasing its saved scroll offset. Local note reads
+ *  resolve in milliseconds; past this the offset is treated as unreachable
+ *  (the note shrank since it was saved) and the user's scrolling takes over. */
+const RESTORE_DEADLINE_MS = 2000
+
 /**
  * One mounted day of the carousel: the date heading (the daily note's subject —
  * chrome, not content, so it is never editable) over the note editor, in its
  * own scroll container. The container records its offset into the carousel's
  * {@link DaySlideProps.scrollMemory} and restores it on remount — the note
  * body loads asynchronously, so restoration re-applies on content growth until
- * the saved offset is reachable or the user takes over.
+ * the saved offset is reachable, the user takes over, or the deadline passes.
  */
 export function DaySlide({
   day,
@@ -59,8 +64,12 @@ export function DaySlide({
     }
     restoringRef.current = true
     let observer: ResizeObserver | null = null
+    let deadline: ReturnType<typeof setTimeout> | null = null
     const stop = (): void => {
       restoringRef.current = false
+      if (deadline !== null) {
+        clearTimeout(deadline)
+      }
       observer?.disconnect()
       container.removeEventListener('pointerdown', stop)
     }
@@ -75,6 +84,7 @@ export function DaySlide({
       observer = new ResizeObserver(apply)
       observer.observe(content)
       container.addEventListener('pointerdown', stop, { passive: true })
+      deadline = setTimeout(stop, RESTORE_DEADLINE_MS)
     }
     return stop
   }, [day, scrollMemory])

--- a/apps/desktop/src/mobile/day-slide.tsx
+++ b/apps/desktop/src/mobile/day-slide.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useLayoutEffect, useRef, type ReactElement } from 'react'
+import { dailyPath } from '@reflect/core'
+import { NotePane } from '@/components/note-pane'
+import { formatDayLabel } from '@/lib/dates'
+import { cn } from '@/lib/utils'
+import { useSettings } from '@/providers/settings-provider'
+
+interface DaySlideProps {
+  /** The slide's ISO day — its daily note path and scroll-memory key. */
+  day: string
+  /** Today's live ISO date — tints today's date heading, as on desktop. */
+  today: string
+  /** Whether this slide is the carousel's centered (selected) one. */
+  selected: boolean
+  /**
+   * Shared per-day scroll offsets, owned by the carousel so they outlive this
+   * slide (slides beyond the mount radius unmount; V1 preserves each day's
+   * scroll position across swipes).
+   */
+  scrollMemory: Map<string, number>
+  /**
+   * Bumped on an explicit re-arrival at the shown day (Daily tab or title
+   * tapped while already there): the selected slide re-anchors to the top.
+   */
+  scrollResetSeq: number
+}
+
+/**
+ * One mounted day of the carousel: the date heading (the daily note's subject —
+ * chrome, not content, so it is never editable) over the note editor, in its
+ * own scroll container. The container records its offset into the carousel's
+ * {@link DaySlideProps.scrollMemory} and restores it on remount — the note
+ * body loads asynchronously, so restoration re-applies on content growth until
+ * the saved offset is reachable or the user takes over.
+ */
+export function DaySlide({
+  day,
+  today,
+  selected,
+  scrollMemory,
+  scrollResetSeq,
+}: DaySlideProps): ReactElement {
+  const { settings } = useSettings()
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const contentRef = useRef<HTMLDivElement | null>(null)
+  // True while a remount restore is converging on the saved offset — scroll
+  // events it causes must not overwrite the memory with clamped values.
+  const restoringRef = useRef(false)
+
+  useLayoutEffect(() => {
+    const container = containerRef.current
+    const content = contentRef.current
+    if (container === null || content === null) {
+      return
+    }
+    const saved = scrollMemory.get(day) ?? 0
+    if (saved <= 0) {
+      return
+    }
+    restoringRef.current = true
+    let observer: ResizeObserver | null = null
+    const stop = (): void => {
+      restoringRef.current = false
+      observer?.disconnect()
+      container.removeEventListener('pointerdown', stop)
+    }
+    const apply = (): void => {
+      container.scrollTop = saved
+      if (container.scrollTop >= saved - 1) {
+        stop()
+      }
+    }
+    apply()
+    if (restoringRef.current) {
+      observer = new ResizeObserver(apply)
+      observer.observe(content)
+      container.addEventListener('pointerdown', stop, { passive: true })
+    }
+    return stop
+  }, [day, scrollMemory])
+
+  const lastResetSeq = useRef(scrollResetSeq)
+  useEffect(() => {
+    if (scrollResetSeq === lastResetSeq.current) {
+      return
+    }
+    lastResetSeq.current = scrollResetSeq
+    if (!selected) {
+      return
+    }
+    scrollMemory.delete(day)
+    if (containerRef.current) {
+      containerRef.current.scrollTop = 0
+    }
+  }, [scrollResetSeq, selected, day, scrollMemory])
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-full overflow-y-auto"
+      style={{
+        paddingBottom: 'max(env(safe-area-inset-bottom), var(--keyboard-height, 0px))',
+      }}
+      onScroll={(event) => {
+        if (!restoringRef.current) {
+          scrollMemory.set(day, event.currentTarget.scrollTop)
+        }
+      }}
+    >
+      <div ref={contentRef}>
+        {/* The date is the daily note's subject (V1 / desktop parity) —
+            chrome above the editor, formatted per the user's setting,
+            tinted on today. Shares the note body's px-4 gutter. */}
+        <h2 className={cn('reflect-daily-subject px-4 pt-4 pb-1', day === today && 'text-accent')}>
+          {formatDayLabel(day, settings.dateFormat)}
+        </h2>
+        <NotePane
+          path={dailyPath(day)}
+          lazy
+          gutterClassName="px-4"
+          editorClassName="min-h-[60dvh]"
+        />
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/mobile/day-slide.tsx
+++ b/apps/desktop/src/mobile/day-slide.tsx
@@ -51,6 +51,9 @@ export function DaySlide({
   // True while a remount restore is converging on the saved offset — scroll
   // events it causes must not overwrite the memory with clamped values.
   const restoringRef = useRef(false)
+  // Cancels the in-flight restore, if any — a jump-to-top reset must not race
+  // an observer still re-applying the old offset as content grows.
+  const stopRestoringRef = useRef<(() => void) | null>(null)
 
   useLayoutEffect(() => {
     const container = containerRef.current
@@ -67,12 +70,16 @@ export function DaySlide({
     let deadline: ReturnType<typeof setTimeout> | null = null
     const stop = (): void => {
       restoringRef.current = false
+      if (stopRestoringRef.current === stop) {
+        stopRestoringRef.current = null
+      }
       if (deadline !== null) {
         clearTimeout(deadline)
       }
       observer?.disconnect()
       container.removeEventListener('pointerdown', stop)
     }
+    stopRestoringRef.current = stop
     const apply = (): void => {
       container.scrollTop = saved
       if (container.scrollTop >= saved - 1) {
@@ -98,6 +105,7 @@ export function DaySlide({
     if (!selected) {
       return
     }
+    stopRestoringRef.current?.()
     scrollMemory.delete(day)
     if (containerRef.current) {
       containerRef.current.scrollTop = 0

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -180,6 +180,40 @@ describe('MobileShell', () => {
     )
   })
 
+  it('selects a day in another week straight from the pageable strip', async () => {
+    const user = userEvent.setup()
+    const today = todayIso()
+    // Two weeks out: its cell lives on a different week slide of the strip,
+    // which the strip renders (and Embla pages) rather than a single week.
+    const nextFortnight = addDaysIso(today, 14)
+    const view = mount({ kind: 'today' })
+
+    await user.click(view.getByRole('button', { name: dayCellLabel(nextFortnight) }))
+    expect(
+      view.getByRole('button', { name: dayCellLabel(nextFortnight) }).getAttribute('aria-current'),
+    ).toBe('date')
+    expect(view.getByRole('heading', { level: 1 }).textContent).toBe(monthLabel(nextFortnight))
+    expect(view.getByRole('button', { name: 'Today' })).toBeTruthy()
+  })
+
+  it('jumps back to today from the tappable month title', async () => {
+    const user = userEvent.setup()
+    const today = todayIso()
+    const other = otherDayInWeek(today)
+    const view = mount({ kind: 'today' })
+
+    await user.click(view.getByRole('button', { name: dayCellLabel(other) }))
+    expect(view.getByRole('button', { name: dayCellLabel(other) }).getAttribute('aria-current')).toBe(
+      'date',
+    )
+
+    await user.click(view.getByRole('button', { name: 'Jump to today' }))
+    expect(view.getByRole('button', { name: dayCellLabel(today) }).getAttribute('aria-current')).toBe(
+      'date',
+    )
+    expect(view.queryByRole('button', { name: 'Today' })).toBeNull()
+  })
+
   it('re-anchors the carousel when a date link lands outside its window', async () => {
     const user = userEvent.setup()
     // Beyond the ±366-day window — only reachable as a date-link navigation,

--- a/apps/desktop/src/mobile/mobile-shell.tsx
+++ b/apps/desktop/src/mobile/mobile-shell.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type ReactElement } from 'react'
 import { MobileScreen } from '@/mobile/mobile-screen'
 import { MobileTabBar, type MobileTab } from '@/mobile/mobile-tab-bar'
+import { useWakeToToday } from '@/mobile/use-wake-to-today'
 import { useRouter } from '@/routing/router'
 
 /**
@@ -14,6 +15,8 @@ export function MobileShell(): ReactElement {
   const { route, navigate, entryId } = useRouter()
   const [allQuery, setAllQuery] = useState('')
   const [lastTab, setLastTab] = useState<MobileTab>('daily')
+  // V1's wake-to-today: foregrounding on a new calendar date lands on today.
+  useWakeToToday()
 
   // A `search` history entry seeds the live query — once per entry, so the
   // user can keep typing without the effect snapping the text back.

--- a/apps/desktop/src/mobile/screens/daily.tsx
+++ b/apps/desktop/src/mobile/screens/daily.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement } from 'react'
+import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react'
 import { untitledNotePath } from '@reflect/core'
 import { Plus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -19,20 +19,39 @@ import { useRouter } from '@/routing/router'
  * day change scrolls the carousel rather than remounting it.
  */
 export function MobileDaily({ date }: { date: string }): ReactElement {
-  const { navigate } = useRouter()
+  const { navigate, arrivalSeq } = useRouter()
   // One live `today` for the whole surface: the strip marks today's cell and
   // the `select` below decide "is this today?" from the *same* value, so they
   // can't disagree across the midnight rollover (which would otherwise route a
   // tap on the highlighted today cell to a frozen `daily` date). Selecting
   // today routes to the live `today` route, keeping the spine rolling over.
   const today = useToday()
-  const select = (day: string): void =>
-    navigate(day === today ? { kind: 'today' } : { kind: 'daily', date: day })
+  const select = useCallback(
+    (day: string): void =>
+      navigate(day === today ? { kind: 'today' } : { kind: 'daily', date: day }),
+    [navigate, today],
+  )
+
+  // An explicit re-arrival at the day already shown — the Daily tab or the
+  // month title tapped while on today (V1's double-tap-to-today lands here as
+  // two such arrivals) — re-anchors the surface: the selected slide scrolls
+  // to the top and the strip re-centers. The router bumps `arrivalSeq` for
+  // every navigate, but a swipe's own echo also changes `date`, so only
+  // date-preserving arrivals count.
+  const [resetSeq, setResetSeq] = useState(0)
+  const lastArrival = useRef({ seq: arrivalSeq, date })
+  useEffect(() => {
+    const last = lastArrival.current
+    lastArrival.current = { seq: arrivalSeq, date }
+    if (arrivalSeq !== last.seq && date === last.date) {
+      setResetSeq((seq) => seq + 1)
+    }
+  }, [arrivalSeq, date])
 
   return (
     <div className="flex h-full w-screen flex-col">
-      <CalendarStrip date={date} today={today} onSelect={select} />
-      <DayCarousel date={date} today={today} onSelect={select} />
+      <CalendarStrip date={date} today={today} resetSeq={resetSeq} onSelect={select} />
+      <DayCarousel date={date} today={today} scrollResetSeq={resetSeq} onSelect={select} />
       <Button
         size="icon"
         aria-label="New note"

--- a/apps/desktop/src/mobile/use-day-carousel.test.ts
+++ b/apps/desktop/src/mobile/use-day-carousel.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { reconcileCarousel, type ReconcileInput } from './use-day-carousel'
+import { createDayWindow } from '@/lib/day-window'
+import { reconcileCarousel, shouldRecenter, type ReconcileInput } from './use-day-carousel'
 
 /**
  * The carousel's follow-the-route decision in isolation — Embla pointer
@@ -57,5 +58,23 @@ describe('reconcileCarousel', () => {
     expect(reconcileCarousel({ ...base, index: -1, lastWindowStart: '2024-01-01' })).toEqual({
       action: 'none',
     })
+  })
+})
+
+describe('shouldRecenter', () => {
+  // 21 slides around the anchor; margin 5 → indices 0–4 and 16–20 trigger.
+  const window = createDayWindow('2026-06-12', { past: 10, future: 10 })
+
+  it('leaves the middle of the window alone', () => {
+    expect(shouldRecenter(window, 10, 5)).toBe(false)
+    expect(shouldRecenter(window, 5, 5)).toBe(false)
+    expect(shouldRecenter(window, 15, 5)).toBe(false)
+  })
+
+  it('re-centers within the margin of either edge', () => {
+    expect(shouldRecenter(window, 4, 5)).toBe(true)
+    expect(shouldRecenter(window, 0, 5)).toBe(true)
+    expect(shouldRecenter(window, 16, 5)).toBe(true)
+    expect(shouldRecenter(window, 20, 5)).toBe(true)
   })
 })

--- a/apps/desktop/src/mobile/use-day-carousel.ts
+++ b/apps/desktop/src/mobile/use-day-carousel.ts
@@ -1,22 +1,54 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import useEmblaCarousel from 'embla-carousel-react'
 import { createDayWindow, dateAtIndex, indexWithin, type DayWindow } from '@/lib/day-window'
+import { getKeyboardHeight } from '@/mobile/use-keyboard'
 
 /**
  * Days either side of the carousel anchor. A generous fixed **symmetric**
  * window (~1 year each way) lets Embla page between days without runtime
- * re-anchoring; only the slides near the selection mount an editor, so the
- * empty ones are cheap spacers. A date-link beyond it (the rare case)
- * re-anchors the window around the new day. The desktop daily stream shares the
- * window math ({@link createDayWindow}) with a wider, asymmetric reach — but it
- * truly virtualizes its rows, where the carousel renders every slide spacer and
+ * re-anchoring in ordinary use; only the slides near the selection mount an
+ * editor, so the empty ones are cheap spacers. Swiping within
+ * {@link RECENTER_MARGIN} of an edge (or a date-link beyond the window)
+ * re-anchors it around the current day, so both directions stay effectively
+ * infinite (V1 parity). The desktop daily stream shares the window math
+ * ({@link createDayWindow}) with a wider, asymmetric reach — but it truly
+ * virtualizes its rows, where the carousel renders every slide spacer and
  * only mounts the editors near the selection.
  */
 export const CAROUSEL_RADIUS = 366
 
+/**
+ * How close (in slides) a settled swipe may get to a window edge before the
+ * window re-centers around the current day. Generous enough that a swipe
+ * burst never lands on the hard edge between settles.
+ */
+export const RECENTER_MARGIN = 30
+
 const CAROUSEL_WINDOW: Readonly<{ past: number; future: number }> = {
   past: CAROUSEL_RADIUS,
   future: CAROUSEL_RADIUS,
+}
+
+/**
+ * True when `index` sits within `margin` slides of either edge of the window —
+ * the signal to rebuild it centered on the current day. Pure for testing.
+ */
+export function shouldRecenter(
+  window: DayWindow,
+  index: number,
+  margin: number = RECENTER_MARGIN,
+): boolean {
+  return index < margin || index >= window.count - margin
+}
+
+/**
+ * Embla's `watchDrag` predicate: swiping between days is disabled while the
+ * software keyboard is up (V1 parity — horizontal drags would fight text
+ * selection and the caret). Module-level so the options object stays stable
+ * across renders; Embla evaluates it at drag start.
+ */
+function dragAllowedWithKeyboardClosed(): boolean {
+  return getKeyboardHeight() === 0
 }
 
 /** What the carousel should do when the external target `date` changes. */
@@ -90,6 +122,7 @@ export function useDayCarousel(date: string, onSelect: (date: string) => void): 
     startIndex: indexWithin(dayWindow, date),
     align: 'center',
     skipSnaps: false,
+    watchDrag: dragAllowedWithKeyboardClosed,
   })
   const [selectedIndex, setSelectedIndex] = useState(() => indexWithin(dayWindow, date))
   // The day we last reported via onSelect — so the route echo it produces
@@ -112,15 +145,33 @@ export function useDayCarousel(date: string, onSelect: (date: string) => void): 
     [dayWindow, onSelect],
   )
 
+  // Re-center the window when a settled swipe nears an edge: rebuild it around
+  // the current day so swiping stays effectively infinite in both directions.
+  // On `settle` (momentum done), never mid-drag — the rebuild reinitializes
+  // Embla (via the follow effect below), which would fight a live gesture. By
+  // settle time the swipe's day has already been reported and echoed back as
+  // `date`, so the reinit lands on the same slide the user is looking at.
+  const onEmblaSettle = useCallback(
+    (api: NonNullable<typeof emblaApi>) => {
+      const index = api.selectedScrollSnap()
+      if (shouldRecenter(dayWindow, index)) {
+        setDayWindow(createDayWindow(dateAtIndex(dayWindow, index), CAROUSEL_WINDOW))
+      }
+    },
+    [dayWindow],
+  )
+
   useEffect(() => {
     if (!emblaApi) {
       return
     }
     emblaApi.on('select', onEmblaSelect)
+    emblaApi.on('settle', onEmblaSettle)
     return () => {
       emblaApi.off('select', onEmblaSelect)
+      emblaApi.off('settle', onEmblaSettle)
     }
-  }, [emblaApi, onEmblaSelect])
+  }, [emblaApi, onEmblaSelect, onEmblaSettle])
 
   // Re-anchor only when the requested day falls outside the window (a far date
   // link): rebuild the window centered on it. The follow effect below then

--- a/apps/desktop/src/mobile/use-keyboard.test.ts
+++ b/apps/desktop/src/mobile/use-keyboard.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { getKeyboardHeight, publishKeyboardHeight } from './use-keyboard'
+
+/**
+ * The keyboard-height store behind `--keyboard-height`: imperative consumers
+ * (the day carousel's drag guard fires at drag start, outside React) read the
+ * last published overlap through {@link getKeyboardHeight}.
+ */
+describe('keyboard height store', () => {
+  afterEach(() => {
+    publishKeyboardHeight(0)
+  })
+
+  it('starts closed and reflects the last published height', () => {
+    expect(getKeyboardHeight()).toBe(0)
+    publishKeyboardHeight(316)
+    expect(getKeyboardHeight()).toBe(316)
+    publishKeyboardHeight(0)
+    expect(getKeyboardHeight()).toBe(0)
+  })
+})

--- a/apps/desktop/src/mobile/use-keyboard.ts
+++ b/apps/desktop/src/mobile/use-keyboard.ts
@@ -4,18 +4,41 @@ import { z } from 'zod'
 
 const keyboardStateSchema = z.object({ height: z.number(), duration: z.number() })
 
+let currentKeyboardHeight = 0
+
+/**
+ * The last published keyboard overlap in px — `0` when the keyboard is closed.
+ * A plain getter (not a hook) so imperative call sites — Embla's `watchDrag`
+ * predicate fires at drag start, outside React — can read the live value.
+ */
+export function getKeyboardHeight(): number {
+  return currentKeyboardHeight
+}
+
+/**
+ * Record the keyboard overlap height. Called by {@link useKeyboardHeightVar}
+ * as the plugin's events arrive; exported so tests can drive keyboard state
+ * without the Tauri bridge.
+ */
+export function publishKeyboardHeight(height: number): void {
+  currentKeyboardHeight = height
+}
+
 /**
  * Mirrors the software keyboard's overlap height into `--keyboard-height` on
  * the document root (Plan 19, decision 8). The Swift half of
  * `tauri-plugin-keyboard` keeps the webview at its full-screen frame and
  * disables the system's scroll nudging, so layout owns keyboard avoidance:
- * containers pad their bottom by the variable to keep content reachable.
+ * containers pad their bottom by the variable to keep content reachable. The
+ * height is also published to {@link getKeyboardHeight} for non-layout
+ * consumers (the day carousel disables swiping while the keyboard is up).
  */
 export function useKeyboardHeightVar(): void {
   useEffect(() => {
     const root = document.documentElement
     const apply = (height: number): void => {
       root.style.setProperty('--keyboard-height', `${Math.round(height)}px`)
+      publishKeyboardHeight(height)
     }
     let disposed = false
     let unlisten: (() => void) | null = null
@@ -48,6 +71,7 @@ export function useKeyboardHeightVar(): void {
       disposed = true
       unlisten?.()
       root.style.removeProperty('--keyboard-height')
+      publishKeyboardHeight(0)
     }
   }, [])
 }

--- a/apps/desktop/src/mobile/use-wake-to-today.test.tsx
+++ b/apps/desktop/src/mobile/use-wake-to-today.test.tsx
@@ -1,0 +1,73 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactElement } from 'react'
+import { RouterProvider, useRouter } from '@/routing/router'
+import { useWakeToToday } from './use-wake-to-today'
+
+/**
+ * V1's wake-to-today: foregrounding the app on a later calendar date than it
+ * was backgrounded on navigates to today; a same-day foreground stays put.
+ * Visibility is simulated by overriding `document.visibilityState` and
+ * dispatching `visibilitychange`; the clock via fake timers.
+ */
+
+let visibility: DocumentVisibilityState = 'visible'
+
+function setVisibility(state: DocumentVisibilityState): void {
+  visibility = state
+  act(() => {
+    document.dispatchEvent(new Event('visibilitychange'))
+  })
+}
+
+function Probe(): ReactElement {
+  useWakeToToday()
+  const { route } = useRouter()
+  return <output>{route.kind === 'daily' ? `daily:${route.date}` : route.kind}</output>
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(2026, 5, 12, 22, 0, 0)) // 2026-06-12, late evening
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => visibility,
+  })
+  visibility = 'visible'
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+function mountOn(date: string): ReturnType<typeof render> {
+  return render(
+    <RouterProvider initialRoute={{ kind: 'daily', date }}>
+      <Probe />
+    </RouterProvider>,
+  )
+}
+
+describe('useWakeToToday', () => {
+  it('navigates to today when the app foregrounds on a new date', () => {
+    const view = mountOn('2026-06-10')
+    expect(view.getByRole('status').textContent).toBe('daily:2026-06-10')
+
+    setVisibility('hidden')
+    vi.setSystemTime(new Date(2026, 5, 13, 8, 0, 0)) // overnight in the background
+    setVisibility('visible')
+
+    expect(view.getByRole('status').textContent).toBe('today')
+  })
+
+  it('stays put when the app foregrounds on the same date', () => {
+    const view = mountOn('2026-06-10')
+
+    setVisibility('hidden')
+    vi.setSystemTime(new Date(2026, 5, 12, 23, 30, 0)) // later the same evening
+    setVisibility('visible')
+
+    expect(view.getByRole('status').textContent).toBe('daily:2026-06-10')
+  })
+})

--- a/apps/desktop/src/mobile/use-wake-to-today.ts
+++ b/apps/desktop/src/mobile/use-wake-to-today.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react'
+import { todayIso } from '@/lib/dates'
+import { useRouter } from '@/routing/router'
+
+/**
+ * V1's wake-to-today: when the app returns to the foreground on a later
+ * calendar date than it was last seen on, navigate to today — open the app,
+ * see today. Driven by the document's visibility (WKWebView fires it on
+ * background/foreground); an app left *open* across midnight rolls over via
+ * `useToday` instead, so this only handles the backgrounded case.
+ */
+export function useWakeToToday(): void {
+  const { navigate } = useRouter()
+  useEffect(() => {
+    let lastSeen = todayIso()
+    const onVisibilityChange = (): void => {
+      if (document.visibilityState !== 'visible') {
+        lastSeen = todayIso()
+        return
+      }
+      const now = todayIso()
+      if (now !== lastSeen) {
+        lastSeen = now
+        navigate({ kind: 'today' })
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [navigate])
+}

--- a/apps/desktop/src/mobile/use-week-strip.test.ts
+++ b/apps/desktop/src/mobile/use-week-strip.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { createWeekWindow } from './calendar'
+import { shouldRecenterWeeks } from './use-week-strip'
+
+describe('shouldRecenterWeeks', () => {
+  // 9 week slides around the anchor; margin 2 → indices 0–1 and 7–8 trigger.
+  const window = createWeekWindow('2026-06-12', 'monday', 4)
+
+  it('leaves the middle of the window alone', () => {
+    expect(shouldRecenterWeeks(window, 4, 2)).toBe(false)
+    expect(shouldRecenterWeeks(window, 2, 2)).toBe(false)
+    expect(shouldRecenterWeeks(window, 6, 2)).toBe(false)
+  })
+
+  it('re-centers within the margin of either edge', () => {
+    expect(shouldRecenterWeeks(window, 1, 2)).toBe(true)
+    expect(shouldRecenterWeeks(window, 0, 2)).toBe(true)
+    expect(shouldRecenterWeeks(window, 7, 2)).toBe(true)
+    expect(shouldRecenterWeeks(window, 8, 2)).toBe(true)
+  })
+})

--- a/apps/desktop/src/mobile/use-week-strip.ts
+++ b/apps/desktop/src/mobile/use-week-strip.ts
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import useEmblaCarousel from 'embla-carousel-react'
+import type { WeekStartDay } from '@reflect/core'
+import {
+  createWeekWindow,
+  weekAtIndex,
+  weekIndexOf,
+  type WeekWindow,
+} from '@/mobile/calendar'
+
+/**
+ * How close (in weeks) a settled page may get to a window edge before the
+ * window re-centers around the displayed week.
+ */
+export const WEEK_RECENTER_MARGIN = 3
+
+/**
+ * True when `index` sits within `margin` weeks of either window edge — the
+ * signal to rebuild the window centered on the displayed week. Pure for
+ * testing.
+ */
+export function shouldRecenterWeeks(
+  window: WeekWindow,
+  index: number,
+  margin: number = WEEK_RECENTER_MARGIN,
+): boolean {
+  return index < margin || index >= window.count - margin
+}
+
+export interface WeekStrip {
+  /** Attach to the strip's Embla viewport element. */
+  emblaRef: ReturnType<typeof useEmblaCarousel>[0]
+  /** The current window of week slides. */
+  weekWindow: WeekWindow
+  /** Week-start of the visible (possibly browsed-to) week — the month header. */
+  displayedWeekStart: string
+  /**
+   * Bring `target`'s week into view. For arrivals that don't change the
+   * selected `date` (Today / title taps while already on today, tab
+   * re-arrivals) — a changed `date` re-centers the strip by itself.
+   */
+  showWeekOf: (target: string) => void
+}
+
+/**
+ * Drives the calendar strip's week paging (V1 parity): an Embla carousel of
+ * week slides over a re-centering {@link WeekWindow}. Paging **browses** —
+ * it moves the visible week (and the month header) without changing the
+ * selection; tapping a day navigates, and the strip follows the selected
+ * `date` back whenever it changes (a carousel swipe, a date link, Today).
+ *
+ * Window rebuilds — a far `date` jump, a week-start setting change, or paging
+ * near an edge — always land the rebuilt window's **anchor** week on screen:
+ * every rebuild centers the window on the week it needs to show, so the
+ * follow effect reinitializes Embla onto the anchor index uniformly.
+ */
+export function useWeekStrip(date: string, weekStartDay: WeekStartDay): WeekStrip {
+  const [weekWindow, setWeekWindow] = useState<WeekWindow>(() =>
+    createWeekWindow(date, weekStartDay),
+  )
+  const [emblaRef, emblaApi] = useEmblaCarousel({ startIndex: weekWindow.anchorIndex })
+  const [displayedIndex, setDisplayedIndex] = useState(weekWindow.anchorIndex)
+  // The window start we last reconciled against — a change means a rebuild,
+  // so Embla must reinitialize onto the new slides at the anchor.
+  const windowStartRef = useRef(weekWindow.start)
+  // The `date` the strip last followed — browsing must not snap back to it.
+  const followedDateRef = useRef(date)
+
+  const onEmblaSelect = useCallback((api: NonNullable<typeof emblaApi>) => {
+    setDisplayedIndex(api.selectedScrollSnap())
+  }, [])
+
+  // Re-center the window when paging settles near an edge, keeping the
+  // browsed week on screen (it becomes the rebuilt window's anchor).
+  const onEmblaSettle = useCallback(
+    (api: NonNullable<typeof emblaApi>) => {
+      const index = api.selectedScrollSnap()
+      if (shouldRecenterWeeks(weekWindow, index)) {
+        setWeekWindow(createWeekWindow(weekAtIndex(weekWindow, index), weekStartDay))
+      }
+    },
+    [weekWindow, weekStartDay],
+  )
+
+  useEffect(() => {
+    if (!emblaApi) {
+      return
+    }
+    emblaApi.on('select', onEmblaSelect)
+    emblaApi.on('settle', onEmblaSettle)
+    return () => {
+      emblaApi.off('select', onEmblaSelect)
+      emblaApi.off('settle', onEmblaSettle)
+    }
+  }, [emblaApi, onEmblaSelect, onEmblaSettle])
+
+  // A week-start change re-aligns every week: rebuild around the selection.
+  const weekStartDayRef = useRef(weekStartDay)
+  useLayoutEffect(() => {
+    if (weekStartDayRef.current === weekStartDay) {
+      return
+    }
+    weekStartDayRef.current = weekStartDay
+    setWeekWindow(createWeekWindow(date, weekStartDay))
+  }, [weekStartDay, date])
+
+  // Follow the selection and finish rebuilds. Layout effect so the strip's
+  // position lands in the same frame as the day carousel's (no visible lag).
+  useLayoutEffect(() => {
+    if (!emblaApi) {
+      return
+    }
+    if (weekWindow.start !== windowStartRef.current) {
+      // Any rebuild centers the window on the week to show — land on it.
+      windowStartRef.current = weekWindow.start
+      followedDateRef.current = date
+      emblaApi.reInit({ startIndex: weekWindow.anchorIndex })
+      setDisplayedIndex(weekWindow.anchorIndex)
+      return
+    }
+    if (followedDateRef.current === date) {
+      return
+    }
+    followedDateRef.current = date
+    const index = weekIndexOf(weekWindow, date, weekStartDay)
+    if (index === -1) {
+      // A far jump: rebuild around the new date; the branch above lands on
+      // it. Runs only on that rare miss, and the rebuilt window contains the
+      // date, so it cannot loop.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setWeekWindow(createWeekWindow(date, weekStartDay))
+      return
+    }
+    emblaApi.scrollTo(index)
+    setDisplayedIndex(index)
+  }, [emblaApi, date, weekWindow, weekStartDay])
+
+  const showWeekOf = useCallback(
+    (target: string) => {
+      const index = weekIndexOf(weekWindow, target, weekStartDay)
+      if (index === -1) {
+        setWeekWindow(createWeekWindow(target, weekStartDay))
+        return
+      }
+      emblaApi?.scrollTo(index)
+      setDisplayedIndex(index)
+    },
+    [emblaApi, weekWindow, weekStartDay],
+  )
+
+  return {
+    emblaRef,
+    weekWindow,
+    displayedWeekStart: weekAtIndex(weekWindow, displayedIndex),
+    showWeekOf,
+  }
+}

--- a/apps/desktop/src/mobile/week-row.tsx
+++ b/apps/desktop/src/mobile/week-row.tsx
@@ -1,0 +1,72 @@
+import { memo, type ReactElement } from 'react'
+import { format } from 'date-fns'
+import { addDaysIso, parseIsoDate } from '@/lib/dates'
+import { cn } from '@/lib/utils'
+
+interface WeekRowProps {
+  /** The ISO date of this week's first day (per the week-start setting). */
+  weekStart: string
+  /** The selected day when it falls in this week, else `null`. */
+  selectedDay: string | null
+  /** Today when it falls in this week, else `null`. */
+  todayDay: string | null
+  /** Select a day — drives the carousel and the route. */
+  onSelect: (date: string) => void
+}
+
+/**
+ * One week slide of the calendar strip: seven day-of-week / day-number cells,
+ * the selected day circled, today dotted (V1's presentation). Memoized on the
+ * narrowed `selectedDay`/`todayDay` props so the dozens of off-screen week
+ * slides skip re-rendering when the selection moves within another week.
+ */
+function WeekRowComponent({
+  weekStart,
+  selectedDay,
+  todayDay,
+  onSelect,
+}: WeekRowProps): ReactElement {
+  return (
+    <div className="flex min-w-0 flex-[0_0_100%]">
+      {Array.from({ length: 7 }, (_, index) => addDaysIso(weekStart, index)).map((day) => {
+        const selected = day === selectedDay
+        const isToday = day === todayDay
+        return (
+          <button
+            key={day}
+            type="button"
+            aria-label={format(parseIsoDate(day), 'EEEE, MMMM do')}
+            aria-current={selected ? 'date' : undefined}
+            onClick={() => onSelect(day)}
+            className="flex flex-1 flex-col items-center gap-0.5 py-1"
+          >
+            <span className="text-[11px] font-medium text-text-muted">
+              {format(parseIsoDate(day), 'EEEEE')}
+            </span>
+            <span
+              className={cn(
+                'flex size-8 items-center justify-center rounded-full text-sm tabular-nums',
+                selected && 'bg-primary font-semibold text-primary-foreground',
+                !selected && isToday && 'font-semibold text-primary',
+                !selected && !isToday && 'text-text',
+              )}
+            >
+              {format(parseIsoDate(day), 'd')}
+            </span>
+            {/* Today dot (V1) — a fixed-height slot so cells stay aligned;
+                shown only when today isn't the selected (circled) day. */}
+            <span
+              aria-hidden
+              className={cn(
+                'size-1 rounded-full',
+                !selected && isToday ? 'bg-primary' : 'bg-transparent',
+              )}
+            />
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+export const WeekRow = memo(WeekRowComponent)

--- a/docs/porting/reflect-mobile/daily-notes.md
+++ b/docs/porting/reflect-mobile/daily-notes.md
@@ -85,17 +85,23 @@ Very little, by design — this surface is the one V1 got most right:
 
 The v2 Daily screen should have all of:
 
-- [ ] Virtual day window, re-centered near edges; past and future both
+- [x] Virtual day window, re-centered near edges; past and future both
       reachable; swiping past a day creates no file.
-- [ ] Carousel ↔ calendar-strip two-way sync; week paging on the strip;
+- [x] Carousel ↔ calendar-strip two-way sync; week paging on the strip;
       month header.
-- [ ] Per-slide scroll preservation; screen never remounts on a date
+- [x] Per-slide scroll preservation; screen never remounts on a date
       change.
-- [ ] Swipe disabled while the keyboard is up.
-- [ ] Open-to-today; re-navigate to today on foreground date change;
-      title-tap and Daily-tab double-tap jump to today.
-- [ ] Week-start setting respected; today visibly marked.
-- [ ] Daily subject not editable; the date is the title.
-- [ ] Collapsible incoming-backlinks section below content; daily-note
+- [x] Swipe disabled while the keyboard is up.
+- [x] Open-to-today; re-navigate to today on foreground date change;
+      title-tap and Daily-tab double-tap jump to today. (v2 note: *any*
+      Daily-tab tap navigates to today; a repeat arrival on the shown day —
+      V1's double-tap — re-anchors the slide's scroll and re-centers the
+      strip, via the router's `arrivalSeq` explicit-intent signal.)
+- [x] Week-start setting respected; today visibly marked.
+- [x] Daily subject not editable; the date is the title.
+- [x] Collapsible incoming-backlinks section below content; daily-note
       backlinks swipe the carousel instead of pushing a screen.
-- [ ] Haptic on date selection.
+- [ ] Haptic on date selection. **Follow-up:** no haptics mechanism exists
+      in the repo yet (WKWebView has no `navigator.vibrate`); needs the
+      official `tauri-plugin-haptics` or a small addition to the first-party
+      keyboard plugin — deliberately not built as part of Daily parity.


### PR DESCRIPTION
## Summary

Implements the remaining [Daily-tab parity checklist](docs/porting/reflect-mobile/daily-notes.md) items for the mobile app (Plan 19, step 9), plus the shell behaviors that belong to Daily (wake-to-today, tab re-tap).

### What was already in place (verified, unchanged)

- Open-to-today (router default), strip ↔ carousel two-way sync, month header, today marking, week-start setting, lazy daily placeholders (swiping past a day creates no file), and the stable-key mount so the screen never remounts on a date change.
- Daily subject not editable — the date heading is chrome above `NotePane`, never note content.
- Incoming backlinks: `NotePane` already renders the collapsible `BacklinksPanel` below content, and a daily-note backlink navigates the daily route, which swipes the mounted carousel instead of pushing a screen.

### What this PR adds

- **Edge re-centering** (`use-day-carousel.ts`): when a settled swipe lands within `RECENTER_MARGIN` of the ±366-day window's edge, the window rebuilds centered on the current day, so past and future stay effectively infinite. Pure `shouldRecenter` is unit-tested; the rebuild rides the existing reinit reconciliation.
- **Swipe disabled while the keyboard is up**: the `--keyboard-height` bridge now also publishes into a module store (`getKeyboardHeight`), and the carousel passes a stable `watchDrag` predicate to Embla (checked at drag start; Embla's `reInit` merges options so the predicate survives window re-anchors).
- **Week paging on the calendar strip** (`use-week-strip.ts`, `week-row.tsx`): the strip is now an Embla carousel of week slides over a re-centering week window. Paging browses (moves the visible week and the month header) without changing the selection; tapping selects; the strip follows the selected date whenever it changes; a week-start setting change realigns the window (`weekIndexOf` returns `-1` on misalignment as the rebuild signal).
- **Per-slide scroll preservation** (`day-slide.tsx`): each mounted day records its scroll offset into a carousel-owned map and restores it on remount — the note body loads asynchronously, so restoration re-applies on content growth (ResizeObserver) until the saved offset is reachable or the user touches the slide.
- **Jump-to-today**: the month title is a tap target. A repeat arrival on the day already shown — Daily tab tapped while on today (V1's double-tap), title tap, a same-date navigate — re-anchors the selected slide to the top and re-centers a browsed-away strip, derived from the router's `arrivalSeq` explicit-intent signal (the same semantics as desktop's ⌘D re-anchor). A swipe's own echo changes the date, so it never trips this.
- **Wake-to-today** (`use-wake-to-today.ts`, mounted in `MobileShell`): foregrounding on a later calendar date navigates to today, via `visibilitychange`. An app left open across midnight already rolls over through `useToday`.

### Deliberate divergences / follow-ups

- **Double-tap**: implemented as "repeat arrival on the shown day" rather than a timed double-tap detector in the tab bar — any Daily-tab tap navigates to today (existing shell behavior), and the second tap of a V1-style double-tap triggers the scroll/strip re-anchor. No `mobile-tab-bar.tsx` change was needed.
- **Haptics on date selection**: left as a follow-up, noted in the porting checklist — the repo has no haptics mechanism (WKWebView lacks `navigator.vibrate`), and the scope call was to not build a plugin for this. The official `tauri-plugin-haptics` or a small addition to the first-party keyboard plugin are the candidates.

## Testing

- `pnpm check` passes (the 3 remaining lint warnings are pre-existing react-hook-form ones in settings dialogs).
- `pnpm --filter @reflect/desktop test --run src/mobile` — 11 files, 50 tests pass: new unit tests for the week-window math (including the week-start misalignment rebuild signal), `shouldRecenter`/`shouldRecenterWeeks`, the keyboard store, and wake-to-today (fake timers + visibility); new `MobileShell` integration tests for cross-week day selection from the pageable strip and title-tap jump-to-today.
- **Not yet verified on the iOS simulator** — swipe-gesture behavior (re-centering feel, keyboard drag lock, scroll restoration timing) needs a manual `pnpm tauri ios dev` pass, which I couldn't do meaningfully headless. Logic is covered by tests; flagging for the usual manual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large mobile UX surface (dual Embla carousels, scroll restore, routing edge cases); logic is unit/integration tested but gesture feel still needs manual iOS verification.
> 
> **Overview**
> Brings the mobile **Daily** tab to V1 parity: the calendar strip becomes an Embla **week pager** (browse weeks without changing selection; month title follows the visible week and is tappable to jump to today), backed by new **week-window** math and `useWeekStrip`.
> 
> The **day carousel** gains edge **re-centering** on settle for effectively infinite paging, **horizontal swipe disabled while the keyboard is open** via `getKeyboardHeight` + Embla `watchDrag`, and **per-day scroll preservation** in a new `DaySlide` (ResizeObserver restore on remount).
> 
> **Shell / navigation**: `useWakeToToday` foregrounds to today when the calendar date changes; `MobileDaily` derives `resetSeq` from router `arrivalSeq` so repeat arrivals (Daily tab / title while already on that day) scroll the slide to top and re-center a browsed-away strip.
> 
> Tests and the daily-notes parity checklist are updated; date-selection haptics remain a documented follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86e3bb8045fcdaa11be1f9bd8d2cb51dad170fd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar navigation now supports swipeable week strips and smoother day-by-day browsing.
  * The app now jumps back to today when reopened on a different date.
  * Daily views preserve your scroll position when you return to them.

* **Bug Fixes**
  * Month labels now match the week currently in view.
  * “Today” actions and same-day re-entry now re-center the calendar correctly.
  * Swiping is disabled while the on-screen keyboard is open for better interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->