### PR TITLE
test: extract mobile scroll restore into a hook and cover the Daily carousel wiring

### DIFF
--- a/apps/desktop/src/mobile/day-slide.tsx
+++ b/apps/desktop/src/mobile/day-slide.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useLayoutEffect, useRef, type ReactElement } from 'react'
+import { useEffect, useRef, type ReactElement } from 'react'
 import { dailyPath } from '@reflect/core'
 import { NotePane } from '@/components/note-pane'
 import { formatDayLabel } from '@/lib/dates'
 import { cn } from '@/lib/utils'
+import { useScrollRestore } from '@/mobile/use-scroll-restore'
 import { useSettings } from '@/providers/settings-provider'
 
 interface DaySlideProps {
@@ -25,18 +26,14 @@ interface DaySlideProps {
   scrollResetSeq: number
 }
 
-/** How long a remount keeps chasing its saved scroll offset. Local note reads
- *  resolve in milliseconds; past this the offset is treated as unreachable
- *  (the note shrank since it was saved) and the user's scrolling takes over. */
-const RESTORE_DEADLINE_MS = 2000
-
 /**
  * One mounted day of the carousel: the date heading (the daily note's subject —
  * chrome, not content, so it is never editable) over the note editor, in its
  * own scroll container. The container records its offset into the carousel's
- * {@link DaySlideProps.scrollMemory} and restores it on remount — the note
- * body loads asynchronously, so restoration re-applies on content growth until
- * the saved offset is reachable, the user takes over, or the deadline passes.
+ * {@link DaySlideProps.scrollMemory} and restores it on remount via
+ * {@link useScrollRestore} — the note body loads asynchronously, so
+ * restoration re-applies on content growth until the saved offset is
+ * reachable, the user takes over, or the deadline passes.
  */
 export function DaySlide({
   day,
@@ -48,53 +45,12 @@ export function DaySlide({
   const { settings } = useSettings()
   const containerRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
-  // True while a remount restore is converging on the saved offset — scroll
-  // events it causes must not overwrite the memory with clamped values.
-  const restoringRef = useRef(false)
-  // Cancels the in-flight restore, if any — a jump-to-top reset must not race
-  // an observer still re-applying the old offset as content grows.
-  const stopRestoringRef = useRef<(() => void) | null>(null)
-
-  useLayoutEffect(() => {
-    const container = containerRef.current
-    const content = contentRef.current
-    if (container === null || content === null) {
-      return
-    }
-    const saved = scrollMemory.get(day) ?? 0
-    if (saved <= 0) {
-      return
-    }
-    restoringRef.current = true
-    let observer: ResizeObserver | null = null
-    let deadline: ReturnType<typeof setTimeout> | null = null
-    const stop = (): void => {
-      restoringRef.current = false
-      if (stopRestoringRef.current === stop) {
-        stopRestoringRef.current = null
-      }
-      if (deadline !== null) {
-        clearTimeout(deadline)
-      }
-      observer?.disconnect()
-      container.removeEventListener('pointerdown', stop)
-    }
-    stopRestoringRef.current = stop
-    const apply = (): void => {
-      container.scrollTop = saved
-      if (container.scrollTop >= saved - 1) {
-        stop()
-      }
-    }
-    apply()
-    if (restoringRef.current) {
-      observer = new ResizeObserver(apply)
-      observer.observe(content)
-      container.addEventListener('pointerdown', stop, { passive: true })
-      deadline = setTimeout(stop, RESTORE_DEADLINE_MS)
-    }
-    return stop
-  }, [day, scrollMemory])
+  const { handleScroll, resetToTop } = useScrollRestore({
+    key: day,
+    memory: scrollMemory,
+    containerRef,
+    contentRef,
+  })
 
   const lastResetSeq = useRef(scrollResetSeq)
   useEffect(() => {
@@ -105,12 +61,8 @@ export function DaySlide({
     if (!selected) {
       return
     }
-    stopRestoringRef.current?.()
-    scrollMemory.delete(day)
-    if (containerRef.current) {
-      containerRef.current.scrollTop = 0
-    }
-  }, [scrollResetSeq, selected, day, scrollMemory])
+    resetToTop()
+  }, [scrollResetSeq, selected, resetToTop])
 
   return (
     <div
@@ -119,11 +71,7 @@ export function DaySlide({
       style={{
         paddingBottom: 'max(env(safe-area-inset-bottom), var(--keyboard-height, 0px))',
       }}
-      onScroll={(event) => {
-        if (!restoringRef.current) {
-          scrollMemory.set(day, event.currentTarget.scrollTop)
-        }
-      }}
+      onScroll={handleScroll}
     >
       <div ref={contentRef}>
         {/* The date is the daily note's subject (V1 / desktop parity) —

--- a/apps/desktop/src/mobile/use-scroll-restore.test.ts
+++ b/apps/desktop/src/mobile/use-scroll-restore.test.ts
@@ -1,0 +1,230 @@
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { UIEvent } from 'react'
+import { RESTORE_DEADLINE_MS, useScrollRestore } from './use-scroll-restore'
+
+/**
+ * The remount scroll-restore loop in isolation (extracted from DaySlide).
+ * jsdom has no layout, so both moving parts are faked and driven by hand: a
+ * container whose `scrollTop` clamps to a controllable maximum (the real
+ * reason a one-shot restore fails while content is still loading), and a
+ * ResizeObserver the tests fire to simulate content growth. Both PR #475
+ * review findings — a restore that never finishes, and a jump-to-top reset
+ * racing an in-flight restore — live in this contract.
+ */
+
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = []
+
+  readonly observed: Element[] = []
+  disconnected = false
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    FakeResizeObserver.instances.push(this)
+  }
+
+  observe(target: Element): void {
+    this.observed.push(target)
+  }
+
+  unobserve(): void {}
+
+  disconnect(): void {
+    this.disconnected = true
+  }
+
+  takeRecords(): [] {
+    return []
+  }
+
+  /** Simulate a content-growth notification (real observers go quiet once disconnected). */
+  resize(): void {
+    if (!this.disconnected) {
+      this.callback([], this as unknown as ResizeObserver)
+    }
+  }
+}
+
+/** The single observer the mounted restore created, or `undefined`. */
+function observer(): FakeResizeObserver | undefined {
+  return FakeResizeObserver.instances[0]
+}
+
+interface FakeScrollable {
+  element: HTMLDivElement
+  /** Raise (or lower) the reachable scroll range, as content growth would. */
+  setMaxScrollTop: (value: number) => void
+}
+
+function createScrollable(maxScrollTop: number): FakeScrollable {
+  const element = document.createElement('div')
+  let max = maxScrollTop
+  let top = 0
+  Object.defineProperty(element, 'scrollTop', {
+    get: () => top,
+    set: (value: number) => {
+      top = Math.min(Math.max(value, 0), max)
+    },
+  })
+  return {
+    element,
+    setMaxScrollTop: (value: number) => {
+      max = value
+      top = Math.min(top, max)
+    },
+  }
+}
+
+function scrollEventOn(element: HTMLElement): UIEvent<HTMLElement> {
+  return { currentTarget: element } as unknown as UIEvent<HTMLElement>
+}
+
+const KEY = '2026-06-12'
+
+interface MountOptions {
+  /** The remembered offset to restore; omitted = a fresh, never-scrolled day. */
+  saved?: number
+  /** The initially reachable scroll range (content still loading). */
+  maxScrollTop?: number
+}
+
+function mountRestore(options: MountOptions = {}) {
+  const memory = new Map<string, number>()
+  if (options.saved !== undefined) {
+    memory.set(KEY, options.saved)
+  }
+  const scrollable = createScrollable(options.maxScrollTop ?? 0)
+  const content = document.createElement('div')
+  scrollable.element.appendChild(content)
+  const containerRef = { current: scrollable.element }
+  const contentRef = { current: content }
+  const hook = renderHook(() => useScrollRestore({ key: KEY, memory, containerRef, contentRef }))
+  return { memory, scrollable, content, hook }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  FakeResizeObserver.instances = []
+  vi.stubGlobal('ResizeObserver', FakeResizeObserver)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('useScrollRestore', () => {
+  it('re-applies the saved offset as content grows until it is reachable', () => {
+    const { memory, scrollable, content, hook } = mountRestore({ saved: 500, maxScrollTop: 100 })
+
+    // The mount-time apply was clamped, so the restore stays armed: watching
+    // the content, offset untouched in memory.
+    expect(scrollable.element.scrollTop).toBe(100)
+    expect(observer()?.observed).toContain(content)
+    expect(observer()?.disconnected).toBe(false)
+
+    scrollable.setMaxScrollTop(300)
+    observer()?.resize()
+    expect(scrollable.element.scrollTop).toBe(300)
+    expect(observer()?.disconnected).toBe(false)
+
+    scrollable.setMaxScrollTop(1200)
+    observer()?.resize()
+    expect(scrollable.element.scrollTop).toBe(500)
+    expect(observer()?.disconnected).toBe(true)
+    expect(memory.get(KEY)).toBe(500)
+
+    // With the restore finished, ordinary scrolling records again.
+    scrollable.element.scrollTop = 320
+    hook.result.current.handleScroll(scrollEventOn(scrollable.element))
+    expect(memory.get(KEY)).toBe(320)
+  })
+
+  it('does not let the restore’s clamped scrolls overwrite the saved offset', () => {
+    const { memory, scrollable, hook } = mountRestore({ saved: 500, maxScrollTop: 100 })
+
+    // The browser fires a scroll event for the clamped mount-time apply —
+    // recording it would truncate the memory to 100 and the restore would
+    // converge on the wrong offset.
+    hook.result.current.handleScroll(scrollEventOn(scrollable.element))
+    expect(memory.get(KEY)).toBe(500)
+  })
+
+  it('gives up at the deadline when the offset never becomes reachable', () => {
+    const { memory, scrollable, hook } = mountRestore({ saved: 500, maxScrollTop: 100 })
+
+    vi.advanceTimersByTime(RESTORE_DEADLINE_MS)
+    expect(observer()?.disconnected).toBe(true)
+    expect(scrollable.element.scrollTop).toBe(100)
+
+    // The user's scrolling takes over — and late content growth must not
+    // yank the container back to the stale offset.
+    scrollable.element.scrollTop = 40
+    hook.result.current.handleScroll(scrollEventOn(scrollable.element))
+    expect(memory.get(KEY)).toBe(40)
+    scrollable.setMaxScrollTop(1000)
+    observer()?.resize()
+    expect(scrollable.element.scrollTop).toBe(40)
+  })
+
+  it('hands control to the user on pointerdown', () => {
+    const { memory, scrollable, hook } = mountRestore({ saved: 500, maxScrollTop: 100 })
+
+    scrollable.element.dispatchEvent(new Event('pointerdown'))
+    expect(observer()?.disconnected).toBe(true)
+
+    // The touch's drag records immediately, and the deadline timer is dead.
+    scrollable.element.scrollTop = 40
+    hook.result.current.handleScroll(scrollEventOn(scrollable.element))
+    expect(memory.get(KEY)).toBe(40)
+    vi.advanceTimersByTime(RESTORE_DEADLINE_MS)
+    expect(scrollable.element.scrollTop).toBe(40)
+  })
+
+  it('resetToTop cancels an in-flight restore before jumping to the top', () => {
+    const { memory, scrollable, hook } = mountRestore({ saved: 500, maxScrollTop: 100 })
+
+    hook.result.current.resetToTop()
+    expect(scrollable.element.scrollTop).toBe(0)
+    expect(memory.has(KEY)).toBe(false)
+
+    // The observer must already be dead: content growth after the reset would
+    // otherwise re-apply the forgotten offset and undo the jump.
+    scrollable.setMaxScrollTop(1000)
+    observer()?.resize()
+    expect(scrollable.element.scrollTop).toBe(0)
+
+    scrollable.element.scrollTop = 10
+    hook.result.current.handleScroll(scrollEventOn(scrollable.element))
+    expect(memory.get(KEY)).toBe(10)
+  })
+
+  it('restores a reachable offset synchronously without arming the machinery', () => {
+    const { scrollable } = mountRestore({ saved: 80, maxScrollTop: 100 })
+
+    expect(scrollable.element.scrollTop).toBe(80)
+    expect(FakeResizeObserver.instances).toHaveLength(0)
+  })
+
+  it('does nothing on a fresh mount with no saved offset', () => {
+    const { memory, scrollable, hook } = mountRestore({ maxScrollTop: 100 })
+
+    expect(scrollable.element.scrollTop).toBe(0)
+    expect(FakeResizeObserver.instances).toHaveLength(0)
+
+    scrollable.element.scrollTop = 25
+    hook.result.current.handleScroll(scrollEventOn(scrollable.element))
+    expect(memory.get(KEY)).toBe(25)
+  })
+
+  it('stops the restore on unmount', () => {
+    const { scrollable, hook } = mountRestore({ saved: 500, maxScrollTop: 100 })
+
+    hook.unmount()
+    expect(observer()?.disconnected).toBe(true)
+    scrollable.setMaxScrollTop(1000)
+    observer()?.resize()
+    expect(scrollable.element.scrollTop).toBe(100)
+  })
+})

--- a/apps/desktop/src/mobile/use-scroll-restore.ts
+++ b/apps/desktop/src/mobile/use-scroll-restore.ts
@@ -1,0 +1,114 @@
+import { useCallback, useLayoutEffect, useRef, type RefObject, type UIEvent } from 'react'
+
+/** How long a remount keeps chasing its saved scroll offset. Local note reads
+ *  resolve in milliseconds; past this the offset is treated as unreachable
+ *  (the content shrank since it was saved) and the user's scrolling takes over. */
+export const RESTORE_DEADLINE_MS = 2000
+
+export interface ScrollRestoreOptions {
+  /** The saved offset's key in `memory` (e.g. the slide's ISO day). */
+  key: string
+  /**
+   * Shared offset store, owned by the caller so it outlives this container
+   * (carousel slides beyond the mount radius unmount; V1 preserves each day's
+   * scroll position across swipes).
+   */
+  memory: Map<string, number>
+  /** The scroll container whose offset is recorded and restored. */
+  containerRef: RefObject<HTMLElement | null>
+  /** The container's content, observed so the restore re-applies as it grows. */
+  contentRef: RefObject<HTMLElement | null>
+}
+
+export interface ScrollRestore {
+  /**
+   * Attach as the container's `onScroll`: records the offset into `memory` —
+   * except while a restore is converging, whose clamped intermediate scrolls
+   * must not overwrite the saved offset.
+   */
+  handleScroll: (event: UIEvent<HTMLElement>) => void
+  /** Cancel any in-flight restore, forget the saved offset, and jump to the top. */
+  resetToTop: () => void
+}
+
+/**
+ * Remount scroll restoration for an asynchronously-filling container: on mount
+ * the saved offset is re-applied on every content growth until it is reachable
+ * — a single scroll would be clamped away while the content is still short.
+ * The chase ends when the offset is reached, the user touches the container
+ * (pointerdown), {@link ScrollRestore.resetToTop} intervenes, or
+ * {@link RESTORE_DEADLINE_MS} passes.
+ */
+export function useScrollRestore({
+  key,
+  memory,
+  containerRef,
+  contentRef,
+}: ScrollRestoreOptions): ScrollRestore {
+  // True while a remount restore is converging on the saved offset — scroll
+  // events it causes must not overwrite the memory with clamped values.
+  const restoringRef = useRef(false)
+  // Cancels the in-flight restore, if any — a jump-to-top reset must not race
+  // an observer still re-applying the old offset as content grows.
+  const stopRestoringRef = useRef<(() => void) | null>(null)
+
+  useLayoutEffect(() => {
+    const container = containerRef.current
+    const content = contentRef.current
+    if (container === null || content === null) {
+      return
+    }
+    const saved = memory.get(key) ?? 0
+    if (saved <= 0) {
+      return
+    }
+    restoringRef.current = true
+    let observer: ResizeObserver | null = null
+    let deadline: ReturnType<typeof setTimeout> | null = null
+    const stop = (): void => {
+      restoringRef.current = false
+      if (stopRestoringRef.current === stop) {
+        stopRestoringRef.current = null
+      }
+      if (deadline !== null) {
+        clearTimeout(deadline)
+      }
+      observer?.disconnect()
+      container.removeEventListener('pointerdown', stop)
+    }
+    stopRestoringRef.current = stop
+    const apply = (): void => {
+      container.scrollTop = saved
+      if (container.scrollTop >= saved - 1) {
+        stop()
+      }
+    }
+    apply()
+    if (restoringRef.current) {
+      observer = new ResizeObserver(apply)
+      observer.observe(content)
+      container.addEventListener('pointerdown', stop, { passive: true })
+      deadline = setTimeout(stop, RESTORE_DEADLINE_MS)
+    }
+    return stop
+  }, [key, memory, containerRef, contentRef])
+
+  const handleScroll = useCallback(
+    (event: UIEvent<HTMLElement>) => {
+      if (!restoringRef.current) {
+        memory.set(key, event.currentTarget.scrollTop)
+      }
+    },
+    [key, memory],
+  )
+
+  const resetToTop = useCallback(() => {
+    stopRestoringRef.current?.()
+    memory.delete(key)
+    if (containerRef.current) {
+      containerRef.current.scrollTop = 0
+    }
+  }, [key, memory, containerRef])
+
+  return { handleScroll, resetToTop }
+}

--- a/apps/desktop/src/mobile/use-week-strip.test.ts
+++ b/apps/desktop/src/mobile/use-week-strip.test.ts
@@ -1,6 +1,180 @@
-import { describe, expect, it } from 'vitest'
-import { createWeekWindow } from './calendar'
-import { shouldRecenterWeeks } from './use-week-strip'
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { WeekStartDay } from '@reflect/core'
+import { createWeekWindow, weekAtIndex, weekIndexOf, weekStartOf } from './calendar'
+import { shouldRecenterWeeks, useWeekStrip } from './use-week-strip'
+
+/**
+ * The strip's Embla wiring — window rebuilds landing on the anchor, the
+ * browse-vs-follow echo guard, and the week-start realignment — driven through
+ * a fake Embla API: jsdom can't host the carousel's pointer gestures, so the
+ * fake exposes the settled-swipe events the real one would fire.
+ */
+
+const embla = vi.hoisted(() => {
+  const handlers = new Map<string, Set<(api: unknown) => void>>()
+  let selected = 0
+
+  const api = {
+    selectedScrollSnap: (): number => selected,
+    on: (event: string, handler: (api: unknown) => void) => {
+      let registered = handlers.get(event)
+      if (!registered) {
+        registered = new Set()
+        handlers.set(event, registered)
+      }
+      registered.add(handler)
+      return api
+    },
+    off: (event: string, handler: (api: unknown) => void) => {
+      handlers.get(event)?.delete(handler)
+      return api
+    },
+    scrollTo: vi.fn((index: number) => {
+      selected = index
+    }),
+    reInit: vi.fn((options?: { startIndex?: number }) => {
+      if (options?.startIndex !== undefined) {
+        selected = options.startIndex
+      }
+    }),
+  }
+
+  function emit(event: string): void {
+    for (const handler of [...(handlers.get(event) ?? [])]) {
+      handler(api)
+    }
+  }
+
+  return {
+    api,
+    /** Land on `index` and fire select + settle, as a finished swipe would. */
+    settleAt(index: number): void {
+      selected = index
+      emit('select')
+      emit('settle')
+    },
+    reset(): void {
+      handlers.clear()
+      selected = 0
+      api.scrollTo.mockClear()
+      api.reInit.mockClear()
+    },
+  }
+})
+
+vi.mock('embla-carousel-react', () => ({
+  default: () => [() => {}, embla.api],
+}))
+
+afterEach(() => {
+  cleanup()
+  embla.reset()
+})
+
+/** 2026-06-12 is a Friday; its Monday-start week (2026-06-08) anchors the window. */
+const DATE = '2026-06-12'
+const WEEK_START: WeekStartDay = 'monday'
+const initialWindow = createWeekWindow(DATE, WEEK_START)
+
+function mountStrip(date: string = DATE, weekStart: WeekStartDay = WEEK_START) {
+  return renderHook(
+    ({ date: currentDate, weekStart: currentWeekStart }) =>
+      useWeekStrip(currentDate, currentWeekStart),
+    { initialProps: { date, weekStart } },
+  )
+}
+
+describe('useWeekStrip', () => {
+  it('rebuilds the window when a swipe settles near an edge and reinits onto the anchor', () => {
+    const { result } = mountStrip()
+
+    act(() => embla.settleAt(1))
+
+    const browsedWeek = weekAtIndex(initialWindow, 1)
+    const rebuilt = createWeekWindow(browsedWeek, WEEK_START)
+    expect(result.current.weekWindow).toEqual(rebuilt)
+    expect(embla.api.reInit).toHaveBeenCalledWith({ startIndex: rebuilt.anchorIndex })
+    // The browsed week became the rebuilt window's anchor — still on screen.
+    expect(result.current.displayedWeekStart).toBe(browsedWeek)
+    expect(embla.api.scrollTo).not.toHaveBeenCalled()
+  })
+
+  it('leaves a mid-window settle alone', () => {
+    const { result } = mountStrip()
+
+    act(() => embla.settleAt(28))
+
+    expect(result.current.weekWindow).toEqual(initialWindow)
+    expect(result.current.displayedWeekStart).toBe(weekAtIndex(initialWindow, 28))
+    expect(embla.api.reInit).not.toHaveBeenCalled()
+  })
+
+  it('follows an in-window date change without snapping back while browsing', () => {
+    const { result, rerender } = mountStrip()
+
+    // Browse two weeks ahead of the selection: the echo guard must keep the
+    // re-render from scrolling the strip back to the (unchanged) date's week.
+    act(() => embla.settleAt(28))
+    expect(embla.api.scrollTo).not.toHaveBeenCalled()
+
+    // A real date change is followed with a plain scroll — no rebuild.
+    rerender({ date: '2026-06-19', weekStart: WEEK_START })
+    expect(embla.api.scrollTo).toHaveBeenCalledWith(27)
+    expect(result.current.displayedWeekStart).toBe(weekAtIndex(initialWindow, 27))
+    expect(result.current.weekWindow).toEqual(initialWindow)
+    expect(embla.api.reInit).not.toHaveBeenCalled()
+  })
+
+  it('showWeekOf scrolls to an in-window target', () => {
+    const { result } = mountStrip()
+
+    act(() => result.current.showWeekOf('2026-06-19'))
+
+    expect(embla.api.scrollTo).toHaveBeenCalledWith(27)
+    expect(result.current.displayedWeekStart).toBe(weekAtIndex(initialWindow, 27))
+    expect(result.current.weekWindow).toEqual(initialWindow)
+  })
+
+  it('showWeekOf rebuilds the window around an out-of-window target', () => {
+    const { result } = mountStrip()
+    const target = '2027-06-12'
+    expect(weekIndexOf(initialWindow, target, WEEK_START)).toBe(-1)
+
+    act(() => result.current.showWeekOf(target))
+
+    const rebuilt = createWeekWindow(target, WEEK_START)
+    expect(result.current.weekWindow).toEqual(rebuilt)
+    expect(embla.api.reInit).toHaveBeenCalledWith({ startIndex: rebuilt.anchorIndex })
+    expect(result.current.displayedWeekStart).toBe(weekStartOf(target, WEEK_START))
+    expect(embla.api.scrollTo).not.toHaveBeenCalled()
+  })
+
+  it('rebuilds around a far date change that falls outside the window', () => {
+    const { result, rerender } = mountStrip()
+
+    rerender({ date: '2027-06-12', weekStart: WEEK_START })
+
+    const rebuilt = createWeekWindow('2027-06-12', WEEK_START)
+    expect(result.current.weekWindow).toEqual(rebuilt)
+    expect(embla.api.reInit).toHaveBeenCalledWith({ startIndex: rebuilt.anchorIndex })
+    expect(result.current.displayedWeekStart).toBe(weekStartOf('2027-06-12', WEEK_START))
+  })
+
+  it('rebuilds when the week-start setting re-aligns the weeks', () => {
+    const { result, rerender } = mountStrip()
+    // The old window's Monday-aligned weeks no longer contain any
+    // Sunday-start week — the misalignment signal a rebuild answers.
+    expect(weekIndexOf(initialWindow, DATE, 'sunday')).toBe(-1)
+
+    rerender({ date: DATE, weekStart: 'sunday' })
+
+    const rebuilt = createWeekWindow(DATE, 'sunday')
+    expect(result.current.weekWindow).toEqual(rebuilt)
+    expect(embla.api.reInit).toHaveBeenCalledWith({ startIndex: rebuilt.anchorIndex })
+    expect(result.current.displayedWeekStart).toBe(weekStartOf(DATE, 'sunday'))
+  })
+})
 
 describe('shouldRecenterWeeks', () => {
   // 9 week slides around the anchor; margin 2 → indices 0–1 and 7–8 trigger.


### PR DESCRIPTION
## Problem

Test-hardening follow-up to #475. Both review findings on that PR — a restore that never finishes when the saved offset stays unreachable, and a jump-to-top reset racing an in-flight restore — lived inside `DaySlide`'s inline scroll-restoration effect, where nothing could unit-test them: the ResizeObserver re-apply loop, the deadline, the pointerdown cancel, and the suppress-recording-while-restoring contract were only reachable indirectly through the full shell integration test. The week strip's Embla wiring (`use-week-strip.ts`) had the same gap: only the pure `shouldRecenterWeeks` helper was tested, while the rebuild/follow/echo-guard effects — where a regression would show up as a visible snap-back or a strip landing on the wrong week — had no direct coverage.

## Changes

1. **`use-scroll-restore.ts` (new):** `DaySlide`'s restore machinery, extracted verbatim — the `restoringRef`/`stopRestoringRef` refs, the `ResizeObserver` re-apply loop, the `RESTORE_DEADLINE_MS` deadline, and the pointerdown cancel. The hook takes the memory key, the shared offset map, and the container/content refs, and returns `handleScroll` (records offsets, except while a restore is converging) and `resetToTop` (cancels any in-flight restore, forgets the offset, jumps to the top). Behavior is unchanged.
2. **`day-slide.tsx`:** now mostly declarative — it wires the hook's `handleScroll` to the container and calls `resetToTop` from the (unchanged) `scrollResetSeq`/`selected` effect.

## Tests

- **`use-scroll-restore.test.ts` (new):** drives the hook directly with `renderHook`, a fake container whose `scrollTop` clamps to a controllable maximum (the reason a one-shot restore fails while content loads), a hand-fired fake `ResizeObserver`, and fake timers. Pins: re-apply across content growth until the offset is reachable; clamped restore scrolls never overwriting the saved offset; giving up at the deadline (with late growth not yanking the user back); pointerdown handing control to the user; `resetToTop` killing an in-flight restore before jumping (the observer must be dead so later growth can't re-apply the forgotten offset); the no-machinery fast paths; unmount cleanup.
- **`use-week-strip.test.ts`:** adds `renderHook` suites over a mocked `embla-carousel-react` (jsdom can't drive gestures) exposing settled-swipe events. Pins: an edge settle rebuilding the window and `reInit`-ing onto `anchorIndex` with the browsed week still on screen; a mid-window settle left alone; browsing not snapping back on re-render (`followedDateRef` echo guard) while a real in-window date change gets a plain `scrollTo`; `showWeekOf` scrolling in-window and rebuilding out-of-window; a far date change rebuilding via the follow effect; a week-start change rebuilding off the `weekIndexOf` misalignment signal.

## Verification

- `pnpm --filter @reflect/desktop test --run src/mobile` — 12 files, 65 tests passed (17 in the two touched suites).
- `pnpm check` — passes (0 errors; 3 pre-existing React Compiler warnings in unrelated settings dialogs).

## Risk / Rollout

Refactor-plus-tests only; no behavior change intended. The restore logic moved verbatim, and the existing `mobile-screen.test.tsx` integration suite still passes over the extracted hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-plus-tests with intended behavior parity; risk is limited to subtle scroll/carousel UX regressions if extraction diverged from the inline logic.
> 
> **Overview**
> Moves **DaySlide**’s remount scroll-restore logic into a new **`useScrollRestore`** hook (ResizeObserver re-apply, deadline, pointerdown cancel, suppress recording while restoring, **`resetToTop`**). **DaySlide** now delegates to **`handleScroll`** / **`resetToTop`** instead of inline **`useLayoutEffect`** machinery.
> 
> Adds **`use-scroll-restore.test.ts`** with faked scroll clamping, ResizeObserver, and timers to lock in restore-until-reachable, deadline give-up, clamped scroll not corrupting memory, **`resetToTop`** vs in-flight restore, and unmount cleanup.
> 
> Expands **`use-week-strip.test.ts`** with a mocked Embla API to cover edge settle window rebuilds, browse echo guard vs date follow, **`showWeekOf`**, far date changes, and week-start realignment (existing **`shouldRecenterWeeks`** tests stay).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 634ec073f1bd266232719ec3e2f03023d7df865e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->