### PR TITLE
feat: light impact haptics for mobile date and tab taps

### DIFF
--- a/apps/desktop/src/mobile/haptics.test.ts
+++ b/apps/desktop/src/mobile/haptics.test.ts
@@ -39,11 +39,15 @@ describe('hapticImpactLight', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const hapticImpactLight = await loadHaptics()
 
+    // Two taps with both invokes in flight: only the first rejection warns.
     hapticImpactLight()
+    hapticImpactLight()
+    expect(invokeMock).toHaveBeenCalledTimes(2)
     await vi.waitFor(() => expect(warn).toHaveBeenCalledOnce())
 
     hapticImpactLight()
-    expect(invokeMock).toHaveBeenCalledTimes(1)
+    expect(invokeMock).toHaveBeenCalledTimes(2)
+    expect(warn).toHaveBeenCalledOnce()
     warn.mockRestore()
   })
 })

--- a/apps/desktop/src/mobile/haptics.test.ts
+++ b/apps/desktop/src/mobile/haptics.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * `hapticImpactLight` is fire-and-forget over the keyboard plugin's
+ * `impact_light` command, and must fail soft where the plugin isn't
+ * registered (desktop, browser dev): one warning, then no further IPC.
+ */
+
+const invokeMock = vi.fn<(command: string) => Promise<unknown>>()
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (command: string) => invokeMock(command),
+}))
+
+async function loadHaptics(): Promise<() => void> {
+  const module = await import('./haptics')
+  return module.hapticImpactLight
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  invokeMock.mockReset()
+})
+
+describe('hapticImpactLight', () => {
+  it('fires the plugin impact command on every call while the bridge works', async () => {
+    invokeMock.mockResolvedValue(null)
+    const hapticImpactLight = await loadHaptics()
+
+    hapticImpactLight()
+    hapticImpactLight()
+
+    expect(invokeMock).toHaveBeenCalledTimes(2)
+    expect(invokeMock).toHaveBeenCalledWith('plugin:keyboard|impact_light')
+  })
+
+  it('warns once and stops invoking after the bridge rejects', async () => {
+    invokeMock.mockRejectedValue(new Error('plugin keyboard not found'))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const hapticImpactLight = await loadHaptics()
+
+    hapticImpactLight()
+    await vi.waitFor(() => expect(warn).toHaveBeenCalledOnce())
+
+    hapticImpactLight()
+    expect(invokeMock).toHaveBeenCalledTimes(1)
+    warn.mockRestore()
+  })
+})

--- a/apps/desktop/src/mobile/haptics.ts
+++ b/apps/desktop/src/mobile/haptics.ts
@@ -1,0 +1,23 @@
+import { invoke } from '@tauri-apps/api/core'
+
+let bridgeAvailable = true
+
+/**
+ * Fire a light impact haptic — V1 parity for calendar-strip date taps and
+ * tab presses. WKWebView has no `navigator.vibrate`, so the tap goes through
+ * the first-party keyboard plugin's `impact_light` command
+ * (`plugins/tauri-plugin-keyboard`).
+ *
+ * Fire-and-forget and fail-soft: where the plugin isn't registered (desktop,
+ * browser dev) the first rejected invoke logs once and disables further
+ * attempts, so taps never pay for a doomed IPC round-trip.
+ */
+export function hapticImpactLight(): void {
+  if (!bridgeAvailable) {
+    return
+  }
+  void invoke('plugin:keyboard|impact_light').catch((err: unknown) => {
+    bridgeAvailable = false
+    console.warn('haptics unavailable:', err)
+  })
+}

--- a/apps/desktop/src/mobile/haptics.ts
+++ b/apps/desktop/src/mobile/haptics.ts
@@ -17,6 +17,11 @@ export function hapticImpactLight(): void {
     return
   }
   void invoke('plugin:keyboard|impact_light').catch((err: unknown) => {
+    // Re-check the latch: rapid taps can have several invokes in flight
+    // before the first rejection lands, and only one should warn.
+    if (!bridgeAvailable) {
+      return
+    }
     bridgeAvailable = false
     console.warn('haptics unavailable:', err)
   })

--- a/apps/desktop/src/mobile/mobile-tab-bar.tsx
+++ b/apps/desktop/src/mobile/mobile-tab-bar.tsx
@@ -1,6 +1,7 @@
 import { type ReactElement } from 'react'
 import { Files, SquarePen } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { hapticImpactLight } from '@/mobile/haptics'
 
 export type MobileTab = 'daily' | 'all'
 
@@ -54,7 +55,12 @@ function TabButton({
       type="button"
       aria-label={label}
       aria-current={active ? 'page' : undefined}
-      onClick={onClick}
+      // V1 parity: a light haptic on every tab press — including a re-press
+      // of the active tab, which is the jump-to-today gesture on Daily.
+      onClick={() => {
+        hapticImpactLight()
+        onClick()
+      }}
       className={cn(
         'flex flex-1 flex-col items-center gap-0.5 pb-1 pt-2 text-[11px] font-medium',
         active ? 'text-primary' : 'text-text-muted',

--- a/apps/desktop/src/mobile/week-row.tsx
+++ b/apps/desktop/src/mobile/week-row.tsx
@@ -2,6 +2,7 @@ import { memo, type ReactElement } from 'react'
 import { format } from 'date-fns'
 import { addDaysIso, parseIsoDate } from '@/lib/dates'
 import { cn } from '@/lib/utils'
+import { hapticImpactLight } from '@/mobile/haptics'
 
 interface WeekRowProps {
   /** The ISO date of this week's first day (per the week-start setting). */
@@ -37,7 +38,10 @@ function WeekRowComponent({
             type="button"
             aria-label={format(parseIsoDate(day), 'EEEE, MMMM do')}
             aria-current={selected ? 'date' : undefined}
-            onClick={() => onSelect(day)}
+            onClick={() => {
+              hapticImpactLight()
+              onSelect(day)
+            }}
             className="flex flex-1 flex-col items-center gap-0.5 py-1"
           >
             <span className="text-[11px] font-medium text-text-muted">

--- a/docs/porting/reflect-mobile/app-shell-and-navigation.md
+++ b/docs/porting/reflect-mobile/app-shell-and-navigation.md
@@ -87,8 +87,9 @@ not already present:
 - Tab-bar hide on keyboard (drive it from the `--keyboard-height` CSS
   variable set by `plugins/tauri-plugin-keyboard`).
 - Double-tap-tab → scroll-to-top (+ re-center Daily on today).
-- Light haptics on tab presses and date selection (a small addition to
-  the first-party plugin, or a Tauri haptics plugin).
+- ~~Light haptics on tab presses and date selection~~ — done: the keyboard
+  plugin's `impact_light` command (`UIImpactFeedbackGenerator`), fired from
+  `src/mobile/haptics.ts` in the tab bar and the calendar strip.
 - Wake-to-today on foreground date change.
 - Back-swipe and stack transitions on the note detail screen.
 - Status-bar-tap scroll-to-top, if reachable from the Tauri shell.

--- a/docs/porting/reflect-mobile/daily-notes.md
+++ b/docs/porting/reflect-mobile/daily-notes.md
@@ -101,7 +101,8 @@ The v2 Daily screen should have all of:
 - [x] Daily subject not editable; the date is the title.
 - [x] Collapsible incoming-backlinks section below content; daily-note
       backlinks swipe the carousel instead of pushing a screen.
-- [ ] Haptic on date selection. **Follow-up:** no haptics mechanism exists
-      in the repo yet (WKWebView has no `navigator.vibrate`); needs the
-      official `tauri-plugin-haptics` or a small addition to the first-party
-      keyboard plugin — deliberately not built as part of Daily parity.
+- [x] Haptic on date selection — a light `UIImpactFeedbackGenerator` tap
+      via the first-party keyboard plugin's `impact_light` command
+      (WKWebView has no `navigator.vibrate`), fired fail-soft from
+      `src/mobile/haptics.ts` on day-cell taps (and tab presses, per
+      [app-shell-and-navigation](./app-shell-and-navigation.md)).

--- a/plugins/tauri-plugin-keyboard/build.rs
+++ b/plugins/tauri-plugin-keyboard/build.rs
@@ -1,7 +1,12 @@
 // `registerListener`/`remove_listener` are the built-in event-channel
 // commands `@tauri-apps/api`'s `addPluginListener` invokes (those exact
 // spellings); they must be in COMMANDS for the ACL to allow them.
-const COMMANDS: &[&str] = &["current_height", "registerListener", "remove_listener"];
+const COMMANDS: &[&str] = &[
+    "current_height",
+    "impact_light",
+    "registerListener",
+    "remove_listener",
+];
 
 fn main() {
     tauri_plugin::Builder::new(COMMANDS).ios_path("ios").build();

--- a/plugins/tauri-plugin-keyboard/ios/Sources/KeyboardPlugin.swift
+++ b/plugins/tauri-plugin-keyboard/ios/Sources/KeyboardPlugin.swift
@@ -21,9 +21,17 @@ struct KeyboardState: Encodable {
 /// disabled, and the keyboard's overlap height streams to JS as
 /// `keyboardChange` events so the layout can make room (a CSS variable, a
 /// pinned toolbar, caret scroll-into-view).
+///
+/// As Reflect's only native UIKit touch bridge, it also carries the app's
+/// tiny haptics surface (`impactLight`) — WKWebView has no
+/// `navigator.vibrate`, so JS cannot fire haptics on its own.
 class KeyboardPlugin: Plugin {
   private weak var webView: WKWebView?
   private var currentState = KeyboardState(height: 0, duration: 0)
+  // Lazy so the generator is created on the main thread, inside the first
+  // `impactLight` dispatch; kept alive across taps to skip re-allocating
+  // the underlying haptic engine on every press.
+  private lazy var lightImpactGenerator = UIImpactFeedbackGenerator(style: .light)
 
   @objc public override func load(webview: WKWebView) {
     self.webView = webview
@@ -84,6 +92,18 @@ class KeyboardPlugin: Plugin {
   /// when a screen mounts and subscribes).
   @objc public func currentHeight(_ invoke: Invoke) {
     invoke.resolve(currentState)
+  }
+
+  /// Fire a light impact haptic — V1 parity for date-selection and tab
+  /// taps. `UIFeedbackGenerator` is main-thread-only; resolve immediately
+  /// rather than after the dispatch since the tap has already happened and
+  /// callers are fire-and-forget. Silently does nothing on hardware
+  /// without a haptic engine (iPads, the simulator).
+  @objc public func impactLight(_ invoke: Invoke) {
+    DispatchQueue.main.async {
+      self.lightImpactGenerator.impactOccurred()
+    }
+    invoke.resolve()
   }
 
   /// `WKContentView` (the webview's private first responder) returns the

--- a/plugins/tauri-plugin-keyboard/permissions/autogenerated/commands/impact_light.toml
+++ b/plugins/tauri-plugin-keyboard/permissions/autogenerated/commands/impact_light.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-impact-light"
+description = "Enables the impact_light command without any pre-configured scope."
+commands.allow = ["impact_light"]
+
+[[permission]]
+identifier = "deny-impact-light"
+description = "Denies the impact_light command without any pre-configured scope."
+commands.deny = ["impact_light"]

--- a/plugins/tauri-plugin-keyboard/permissions/autogenerated/reference.md
+++ b/plugins/tauri-plugin-keyboard/permissions/autogenerated/reference.md
@@ -1,10 +1,11 @@
 ## Default Permission
 
-Read the keyboard state and subscribe to keyboard-change events
+Read the keyboard state, subscribe to keyboard-change events, and fire light impact haptics
 
 #### This default permission set includes the following:
 
 - `allow-current-height`
+- `allow-impact-light`
 - `allow-registerListener`
 - `allow-remove-listener`
 
@@ -39,6 +40,32 @@ Enables the current_height command without any pre-configured scope.
 <td>
 
 Denies the current_height command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`keyboard:allow-impact-light`
+
+</td>
+<td>
+
+Enables the impact_light command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`keyboard:deny-impact-light`
+
+</td>
+<td>
+
+Denies the impact_light command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/tauri-plugin-keyboard/permissions/default.toml
+++ b/plugins/tauri-plugin-keyboard/permissions/default.toml
@@ -1,3 +1,8 @@
 [default]
-description = "Read the keyboard state and subscribe to keyboard-change events"
-permissions = ["allow-current-height", "allow-registerListener", "allow-remove-listener"]
+description = "Read the keyboard state, subscribe to keyboard-change events, and fire light impact haptics"
+permissions = [
+    "allow-current-height",
+    "allow-impact-light",
+    "allow-registerListener",
+    "allow-remove-listener",
+]

--- a/plugins/tauri-plugin-keyboard/permissions/schemas/schema.json
+++ b/plugins/tauri-plugin-keyboard/permissions/schemas/schema.json
@@ -307,6 +307,18 @@
           "markdownDescription": "Denies the current_height command without any pre-configured scope."
         },
         {
+          "description": "Enables the impact_light command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-impact-light",
+          "markdownDescription": "Enables the impact_light command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the impact_light command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-impact-light",
+          "markdownDescription": "Denies the impact_light command without any pre-configured scope."
+        },
+        {
           "description": "Enables the registerListener command without any pre-configured scope.",
           "type": "string",
           "const": "allow-registerListener",
@@ -331,10 +343,10 @@
           "markdownDescription": "Denies the remove_listener command without any pre-configured scope."
         },
         {
-          "description": "Read the keyboard state and subscribe to keyboard-change events\n#### This default permission set includes:\n\n- `allow-current-height`\n- `allow-registerListener`\n- `allow-remove-listener`",
+          "description": "Read the keyboard state, subscribe to keyboard-change events, and fire light impact haptics\n#### This default permission set includes:\n\n- `allow-current-height`\n- `allow-impact-light`\n- `allow-registerListener`\n- `allow-remove-listener`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Read the keyboard state and subscribe to keyboard-change events\n#### This default permission set includes:\n\n- `allow-current-height`\n- `allow-registerListener`\n- `allow-remove-listener`"
+          "markdownDescription": "Read the keyboard state, subscribe to keyboard-change events, and fire light impact haptics\n#### This default permission set includes:\n\n- `allow-current-height`\n- `allow-impact-light`\n- `allow-registerListener`\n- `allow-remove-listener`"
         }
       ]
     }

--- a/plugins/tauri-plugin-keyboard/src/commands.rs
+++ b/plugins/tauri-plugin-keyboard/src/commands.rs
@@ -10,3 +10,10 @@ use crate::Result;
 pub(crate) async fn current_height<R: Runtime>(app: AppHandle<R>) -> Result<KeyboardState> {
     app.keyboard().current_height()
 }
+
+/// Fire a light impact haptic — the app's single haptic strength (date
+/// selection, tab presses). A no-op wherever there is no haptic engine.
+#[command]
+pub(crate) async fn impact_light<R: Runtime>(app: AppHandle<R>) -> Result<()> {
+    app.keyboard().impact_light()
+}

--- a/plugins/tauri-plugin-keyboard/src/desktop.rs
+++ b/plugins/tauri-plugin-keyboard/src/desktop.rs
@@ -18,4 +18,9 @@ impl<R: Runtime> Keyboard<R> {
     pub fn current_height(&self) -> crate::Result<KeyboardState> {
         Ok(KeyboardState::default())
     }
+
+    /// Desktop stand-in: no haptic engine, so a successful no-op.
+    pub fn impact_light(&self) -> crate::Result<()> {
+        Ok(())
+    }
 }

--- a/plugins/tauri-plugin-keyboard/src/lib.rs
+++ b/plugins/tauri-plugin-keyboard/src/lib.rs
@@ -35,7 +35,10 @@ impl<R: Runtime, T: Manager<R>> crate::KeyboardExt<R> for T {
 /// Initializes the plugin.
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
     Builder::new("keyboard")
-        .invoke_handler(tauri::generate_handler![commands::current_height])
+        .invoke_handler(tauri::generate_handler![
+            commands::current_height,
+            commands::impact_light
+        ])
         .setup(|app, api| {
             #[cfg(mobile)]
             let keyboard = mobile::init(app, api)?;

--- a/plugins/tauri-plugin-keyboard/src/mobile.rs
+++ b/plugins/tauri-plugin-keyboard/src/mobile.rs
@@ -34,4 +34,11 @@ impl<R: Runtime> Keyboard<R> {
             .run_mobile_plugin("currentHeight", ())
             .map_err(Into::into)
     }
+
+    /// Fire a light impact haptic (`UIImpactFeedbackGenerator` on iOS).
+    pub fn impact_light(&self) -> crate::Result<()> {
+        self.0
+            .run_mobile_plugin("impactLight", ())
+            .map_err(Into::into)
+    }
 }


### PR DESCRIPTION
## Problem

V1 mobile plays a light haptic on calendar date taps and on every tab press. The Daily-tab parity PR (#475) had to leave the date-selection haptic unchecked because no haptics mechanism existed: WKWebView has no `navigator.vibrate`, so JS cannot fire haptics without a native bridge.

## Approach

Extend the first-party keyboard plugin rather than adopting the official `tauri-plugin-haptics` (the alternative both porting docs floated):

- The plugin's Swift package already builds into the Rust staticlib via swift-rs, and `UIImpactFeedbackGenerator` lives in UIKit, which the iOS project already links — so this adds **zero new Rust/Swift/npm dependencies** and needs no `ios.project.yml` edit or `gen/apple` regeneration.
- The official plugin would add three dependencies and has no `:default` permission set, and only `light` impact is needed.

## Changes

**Plugin (`plugins/tauri-plugin-keyboard`)**
- New `impact_light` command: Swift fires `UIImpactFeedbackGenerator(style: .light)` on the main thread (generator kept alive across taps; resolves immediately since callers are fire-and-forget). Desktop stub is a successful no-op.
- `impact_light` added to `COMMANDS` in `build.rs`; autogenerated permission files regenerated; `allow-impact-light` joins the plugin's `default` permission set, which `capabilities/mobile.json` already grants as `keyboard:default` — no capability change needed.

**Frontend (`apps/desktop/src/mobile`)**
- `haptics.ts`: `hapticImpactLight()` — fire-and-forget `invoke('plugin:keyboard|impact_light')`, fail-soft: where the plugin isn't registered (desktop, browser dev) the first rejection warns once and latches off, so later taps skip the doomed IPC.
- Wired into `week-row.tsx` day-cell taps (date selection) and `mobile-tab-bar.tsx` tab presses — including re-press of the active Daily tab, which is the jump-to-today gesture.

**Docs**
- Ticked the last Daily parity checkbox in `docs/porting/reflect-mobile/daily-notes.md`; marked the haptics item done in `app-shell-and-navigation.md`.

## Testing

- `pnpm check` (typecheck + lint) passes; `pnpm test --run src/mobile` passes (52 tests, including new `haptics.test.ts` covering the fires-per-tap and warn-once-then-latch-off paths).
- `cargo check -p tauri-plugin-keyboard` on host **and** `--target aarch64-apple-ios-sim` — the latter rebuilt `KeyboardPlugin.swift.o` via swift-rs, so the new Swift compiles.
- `cargo fmt --check` clean.
- **Not verified on a device/simulator**: CoreSimulator is currently wedged on this machine, so an on-device feel pass (haptic actually firing) is pending — the command path mirrors `currentHeight`, which is simulator-verified.

## Risk

Mobile-only surface; desktop builds don't compile the plugin's mobile half and the frontend helper fails soft. Worst case on iOS is a silent no-op tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mobile-only UX with desktop no-ops and frontend fail-soft; no auth, data, or capability file changes beyond autogenerated plugin permissions.
> 
> **Overview**
> Adds **V1-parity light haptics** on mobile tab presses and calendar day taps by extending the first-party **keyboard plugin** with a new `impact_light` command instead of a separate haptics dependency.
> 
> On **iOS**, Swift runs `UIImpactFeedbackGenerator(style: .light)` on the main thread; **desktop** resolves as a no-op. **`hapticImpactLight()`** in `src/mobile/haptics.ts` fire-and-forgets `plugin:keyboard|impact_light` and **fails soft** where the bridge is missing (warn once, then stop IPC). **`mobile-tab-bar`** and **`week-row`** call it before their existing handlers. **`allow-impact-light`** is in the plugin default set (existing `keyboard:default` capability). Port docs mark the haptics checklist items done; **`haptics.test.ts`** covers success and latch-off behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15959574615d487a6a535a38c8d491e9bf6d41fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->