### PR TITLE
fix: target mobile link-filter badges by picked path, not title

### DIFF
--- a/apps/desktop/src/mobile/search-filters/filter-state.test.ts
+++ b/apps/desktop/src/mobile/search-filters/filter-state.test.ts
@@ -65,11 +65,20 @@ describe('buildAllNotesSearch', () => {
       tags: ['book'],
       dailyOnly: true,
       pinnedOnly: true,
-      linksTo: 'Project X',
-      linkedFrom: 'Hub',
+      linksTo: null,
+      linksToPath: 'notes/project.md',
+      linkedFrom: null,
+      linkedFromPath: 'notes/hub.md',
       updatedAfterMs: 1000,
       updatedBeforeMs: null,
     })
+  })
+
+  it('targets link badges by picked path, so a duplicated title cannot retarget them', () => {
+    const filters = filtersWith({ linkedTo: { path: 'notes/alpha-2.md', title: 'Alpha' } })
+    const parsed = buildAllNotesSearch('', filters, null)
+    expect(parsed.filters.linksTo).toBeNull()
+    expect(parsed.filters.linksToPath).toBe('notes/alpha-2.md')
   })
 
   it('folds the route tag in without duplicating a typed #tag', () => {
@@ -82,6 +91,7 @@ describe('buildAllNotesSearch', () => {
     const filters = filtersWith({ linkedTo: { path: 'notes/a.md', title: 'A' } })
     const parsed = buildAllNotesSearch('links:B', filters, null)
     expect(parsed.filters.linksTo).toBe('B')
+    expect(parsed.filters.linksToPath).toBeNull()
   })
 
   it('intersects typed and badge date bounds (AND semantics)', () => {

--- a/apps/desktop/src/mobile/search-filters/filter-state.ts
+++ b/apps/desktop/src/mobile/search-filters/filter-state.ts
@@ -18,12 +18,9 @@ import {
 
 /** A note chosen in a link-filter picker. */
 export interface NoteFilterRef {
+  /** The picked note's exact path — what the link filter targets, so a duplicated title can never retarget it. */
   path: string
-  /**
-   * The note's title — how the link filter names its target. Resolution runs
-   * through the wiki-link resolver, so a duplicated title picks the same note
-   * a `[[Title]]` link would.
-   */
+  /** The note's title — the chip's label. */
   title: string
 }
 
@@ -142,8 +139,12 @@ export function buildAllNotesSearch(
       tags,
       dailyOnly: parsed.filters.dailyOnly || filters.daily,
       pinnedOnly: parsed.filters.pinnedOnly || filters.pinned,
-      linksTo: parsed.filters.linksTo ?? filters.linkedTo?.title ?? null,
-      linkedFrom: parsed.filters.linkedFrom ?? filters.linkedBy?.title ?? null,
+      // Badges carry the picked note's exact path (a typed token still wins
+      // the dimension); titles resolve, and duplicates could retarget.
+      linksTo: parsed.filters.linksTo,
+      linksToPath: parsed.filters.linksTo === null ? (filters.linkedTo?.path ?? null) : null,
+      linkedFrom: parsed.filters.linkedFrom,
+      linkedFromPath: parsed.filters.linkedFrom === null ? (filters.linkedBy?.path ?? null) : null,
       updatedAfterMs: laterBound(parsed.filters.updatedAfterMs, filters.updated?.afterMs ?? null),
       updatedBeforeMs: earlierBound(
         parsed.filters.updatedBeforeMs,

--- a/packages/core/src/indexing/filter-query.ts
+++ b/packages/core/src/indexing/filter-query.ts
@@ -29,6 +29,18 @@ export interface SearchFilters {
   linksTo: string | null
   /** Title/alias/date of the note results must be linked from. */
   linkedFrom: string | null
+  /**
+   * Exact path of the note results must link to. Never produced by the parser
+   * (there is no token for it) — set by UI pickers that already hold the note,
+   * so the filter targets that exact note even when titles are duplicated.
+   * When set it takes precedence over {@link linksTo}.
+   */
+  linksToPath?: string | null
+  /**
+   * Exact path of the note results must be linked from — the picker-set
+   * counterpart of {@link linkedFrom} (see {@link linksToPath}).
+   */
+  linkedFromPath?: string | null
   /** Inclusive lower bound on `mtime`, epoch ms (local day start). */
   updatedAfterMs: number | null
   /** Exclusive upper bound on `mtime`, epoch ms (local day start). */

--- a/packages/core/src/indexing/filtered-search.test.ts
+++ b/packages/core/src/indexing/filtered-search.test.ts
@@ -216,6 +216,79 @@ describe('searchWithFilters', () => {
     )
   })
 
+  it('resolves links: tokens by title before filtering (token behavior unchanged)', async () => {
+    mockInvoke.mockResolvedValueOnce([{ path: 'notes/alpha-1.md' }])
+    mockInvoke.mockResolvedValueOnce([])
+
+    await searchWithFilters(parseSearchQuery('links:Alpha'))
+
+    expect(mockInvoke).toHaveBeenCalledTimes(2)
+    const [, args] = mockInvoke.mock.calls[1]!
+    const sql = String(args['sql'])
+    expect(sql).toContain('"backlinks"."source_path" = "notes"."path"')
+    expect(sql).toContain('"backlinks"."target_path" = ?')
+    expect(args['params']).toContain('notes/alpha-1.md')
+  })
+
+  it('filters by a picker-exact link target without resolving titles', async () => {
+    mockInvoke.mockResolvedValueOnce([])
+
+    const parsed = parseSearchQuery('')
+    parsed.filters.linksToPath = 'notes/project-2.md'
+    await searchWithFilters(parsed)
+
+    // One query only: the exact path never round-trips through the resolver.
+    expect(mockInvoke).toHaveBeenCalledTimes(1)
+    const [, args] = mockInvoke.mock.calls[0]!
+    const sql = String(args['sql'])
+    expect(sql).toContain('"backlinks"."source_path" = "notes"."path"')
+    expect(sql).toContain('"backlinks"."target_path" = ?')
+    expect(args['params']).toContain('notes/project-2.md')
+  })
+
+  it('filters by a picker-exact link source without resolving titles', async () => {
+    mockInvoke.mockResolvedValueOnce([])
+
+    const parsed = parseSearchQuery('')
+    parsed.filters.linkedFromPath = 'notes/hub-2.md'
+    await searchWithFilters(parsed)
+
+    expect(mockInvoke).toHaveBeenCalledTimes(1)
+    const [, args] = mockInvoke.mock.calls[0]!
+    const sql = String(args['sql'])
+    expect(sql).toContain('"backlinks"."target_path" = "notes"."path"')
+    expect(sql).toContain('"backlinks"."source_path" = ?')
+    expect(args['params']).toContain('notes/hub-2.md')
+  })
+
+  it('lets an exact path win over a title target (duplicate titles cannot retarget)', async () => {
+    mockInvoke.mockResolvedValueOnce([])
+
+    const parsed = parseSearchQuery('links:Alpha')
+    parsed.filters.linksToPath = 'notes/alpha-2.md'
+    await searchWithFilters(parsed)
+
+    expect(mockInvoke).toHaveBeenCalledTimes(1)
+    const [, args] = mockInvoke.mock.calls[0]!
+    expect(args['params']).toContain('notes/alpha-2.md')
+    expect(args['params']).not.toContain('notes/alpha-1.md')
+  })
+
+  it('applies picker-exact link targets on the tag-first recall path', async () => {
+    mockInvoke.mockResolvedValueOnce([])
+
+    const parsed = parseSearchQuery('#Work')
+    parsed.filters.linkedFromPath = 'notes/hub.md'
+    await searchWithFilters(parsed)
+
+    expect(mockInvoke).toHaveBeenCalledTimes(1)
+    const [, args] = mockInvoke.mock.calls[0]!
+    const sql = String(args['sql'])
+    expect(sql).toContain('from "tags"')
+    expect(sql).toContain('"backlinks"."source_path" = ?')
+    expect(args['params']).toContain('notes/hub.md')
+  })
+
   it('restricts the population to regular notes with notesOnly', async () => {
     mockInvoke.mockResolvedValueOnce([])
 

--- a/packages/core/src/indexing/filtered-search.ts
+++ b/packages/core/src/indexing/filtered-search.ts
@@ -89,17 +89,19 @@ export async function searchWithFilters(
 
   // Link filters name a note by title/alias/date; resolve it once up front.
   // An unresolvable target matches nothing (the filter is explicit — silently
-  // ignoring it would show results the user just excluded).
-  let linksToPath: string | null = null
-  if (filters.linksTo !== null) {
+  // ignoring it would show results the user just excluded). Picker-set exact
+  // paths skip resolution entirely — the caller already holds the note, and
+  // resolving its title could land on a duplicate.
+  let linksToPath: string | null = filters.linksToPath ?? null
+  if (linksToPath === null && filters.linksTo !== null) {
     const resolution = await resolveWikiTarget(filters.linksTo)
     if (resolution.kind !== 'resolved') {
       return []
     }
     linksToPath = resolution.ref
   }
-  let linkedFromPath: string | null = null
-  if (filters.linkedFrom !== null) {
+  let linkedFromPath: string | null = filters.linkedFromPath ?? null
+  if (linkedFromPath === null && filters.linkedFrom !== null) {
     const resolution = await resolveWikiTarget(filters.linkedFrom)
     if (resolution.kind !== 'resolved') {
       return []


### PR DESCRIPTION
## Problem

The mobile All tab's *Linked to* / *Linked by* badges pick a concrete note in `note-picker-drawer.tsx`, but only the note's **title** flowed into `ParsedSearchQuery.filters.linksTo`/`linkedFrom`. `searchWithFilters` then re-resolved that title through `resolveWikiTarget`, which picks the first path in order when several notes share a title-key. So with duplicate titles ("Alpha" at `notes/alpha-1.md` and `notes/alpha-2.md`), picking the second note silently filtered by the first — the picker's whole point (choosing an exact note) was lost on the way to the query.

Typed `links:` / `linked-from:` tokens are intentionally unchanged: a typed title has nothing better than resolution, and it must keep behaving like a `[[Title]]` link.

## Before → After

| Scenario | Before | After |
|---|---|---|
| Badge picker, unique title | Filters by the picked note (via title resolution) | Same result, no resolver round-trip |
| Badge picker, duplicate title | Could filter by a *different* note with the same title | Filters by exactly the picked note's path |
| Typed `links:X` / `linked-from:X` token | Resolves title/alias/date | Unchanged |

## Changes

1. **`packages/core/src/indexing/filter-query.ts`** — `SearchFilters` gains optional `linksToPath` / `linkedFromPath`: exact-path variants the parser never produces (there is no token for them); documented to win over their title counterparts.
2. **`packages/core/src/indexing/filtered-search.ts`** — `searchWithFilters` seeds its resolved-path locals from the new fields and only calls `resolveWikiTarget` when no exact path was given. Both the tag-first recall branch and the main branch already consume those locals, so the predicate SQL is untouched.
3. **`apps/desktop/src/mobile/search-filters/filter-state.ts`** — `buildAllNotesSearch` passes `filters.linkedTo?.path` / `linkedBy?.path` as the path-exact filters instead of smuggling the title into `linksTo`/`linkedFrom`. A typed token still wins the dimension (path stays null then). `NoteFilterRef`'s doc no longer claims resolution semantics — the title is just the chip label.

## Tests

- `filtered-search.test.ts`: picker-exact target/source filter without any resolver query (single `db_query` call, `backlinks` predicate carries the path); exact path wins when a title target is also set; path filter applies on the tag-first recall path; and a pin that `links:` tokens still resolve by title first.
- `filter-state.test.ts`: badge merge now emits `linksToPath`/`linkedFromPath` with null titles; duplicate-title scenario targets the picked path; typed-token-wins case asserts the path stays null.

## Verification

- `pnpm vitest --run` on `filtered-search.test.ts`, `filter-query.test.ts`, `retrieve.test.ts` (core) and `src/mobile/search-filters`, `all-notes.test.ts` (desktop) — all pass.
- `pnpm check` (typecheck + lint) — clean; the 3 react-compiler warnings are pre-existing.

## Risk / Rollout

Pure query-layer change, no schema or migration. The new fields are optional, so existing `SearchFilters` constructors (parser, `retrieve.ts`) are unaffected. If a picked note is later deleted/renamed, the badge now matches nothing instead of falling back to a same-titled note — that's the intended explicit-filter semantics (`resolveWikiTarget` failure already returned zero results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional query-layer fields with no schema migration; behavior change is limited to mobile badge link filters and duplicate-title edge cases.
> 
> **Overview**
> **Fixes mobile *Linked to* / *Linked by* badges** so they filter by the note the user picked in the picker, not by re-resolving the chip title (which could hit a different note when titles duplicate).
> 
> `SearchFilters` gains optional **`linksToPath`** / **`linkedFromPath`**. **`searchWithFilters`** uses those paths directly and only calls **`resolveWikiTarget`** when no exact path is set; path wins over a concurrent **`links:`** title. **`buildAllNotesSearch`** maps badge picks to the path fields instead of stuffing titles into **`linksTo`**/**`linkedFrom`**; typed **`links:`** / **`linked-from:`** tokens still win and behave as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbc856efc26543d90bc1bfa1568546b9e119461a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->