### PR TITLE
Browser dev harness for the mobile tree (?platform=ios + in-memory bridge)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,8 @@ All UI work should follow the Reflect design system documented in [`design-syste
 
 ```bash
 pnpm dev              # turbo dev across packages (Vite on http://localhost:1420)
+                      #   add ?platform=ios to the URL to preview the MOBILE tree in a
+                      #   plain browser (dev-only in-memory bridge + seeded demo graph)
 pnpm tauri dev        # Full Tauri app with hot reload (stages the CLI sidecar first)
 pnpm tauri:dev        # `pnpm tauri dev` with the dev overlay → the "Reflect Dev" flavor (green icon, own identifier; coexists with Reflect / Reflect Beta)
 pnpm build            # turbo build pipeline → apps/desktop/dist/

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -56,6 +56,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
+    "@sqlite.org/sqlite-wasm": "3.53.0-build1",
     "@tailwindcss/vite": "^4.3.1",
     "@tauri-apps/cli": "^2.11.3",
     "@testing-library/jest-dom": "^6.9.1",

--- a/apps/desktop/src/dev/dev-bridge.ts
+++ b/apps/desktop/src/dev/dev-bridge.ts
@@ -1,0 +1,209 @@
+import {
+  indexedNoteSchema,
+  ReflectError,
+  type AppPlatform,
+  type IpcBridge,
+} from '@reflect/core'
+import { z } from 'zod'
+import type { DevFileStore } from '@/dev/dev-file-store'
+import type { DevIndexDb } from '@/dev/dev-index-db'
+
+/** The fixed fake graph root the dev bridge reports (mirrors `mobile_graph_root`). */
+export const DEV_GRAPH_ROOT = '/dev-graph'
+
+/** Everything the command router needs; assembled by `installDevBridge`. */
+export interface DevBridgeBackend {
+  /** The platform `app_platform` reports (the `?platform=` override value). */
+  platform: AppPlatform
+  files: DevFileStore
+  index: DevIndexDb
+}
+
+const dbQueryArgsSchema = z.object({ sql: z.string(), params: z.array(z.unknown()) })
+const pathArgsSchema = z.object({ path: z.string() })
+const writeArgsSchema = z.object({ path: z.string(), contents: z.string() })
+const moveArgsSchema = z.object({ from: z.string(), to: z.string() })
+const metaArgsSchema = z.object({ key: z.string(), value: z.string() })
+const applyArgsSchema = z.object({ note: indexedNoteSchema })
+const applyBatchArgsSchema = z.object({ notes: z.array(indexedNoteSchema) })
+const settingsArgsSchema = z.object({ settings: z.record(z.string(), z.unknown()) })
+
+/**
+ * The in-browser stand-in for the Rust shell (dev builds only): answers the
+ * command surface the mobile tree exercises from an in-memory file map and the
+ * wasm SQLite index. Filesystem generations are meaningless with one immortal
+ * in-memory graph, so `generation` args are accepted and ignored (always 1).
+ *
+ * Anything unimplemented rejects loudly with the command name — a surface
+ * quietly rendering empty because a stub answered wrong is worse than an
+ * error naming the gap.
+ */
+export function createDevBridge(backend: DevBridgeBackend): IpcBridge {
+  const { platform, files, index } = backend
+  const graphInfo = { root: DEV_GRAPH_ROOT, name: 'Dev Graph', generation: 1 }
+  let settingsDocument: Record<string, unknown> = { mobileOnboarded: true }
+  const assets = new Map<string, string>()
+
+  async function invoke(command: string, args: Record<string, unknown>): Promise<unknown> {
+    switch (command) {
+      case 'app_version':
+        return '0.0.0-dev'
+      case 'app_platform':
+        return platform
+      case 'mobile_graph_root':
+        return DEV_GRAPH_ROOT
+      case 'graph_open':
+      case 'graph_create':
+        return graphInfo
+      case 'recent_graphs':
+        return []
+      case 'forget_recent':
+      case 'capture_host_register':
+      case 'watch_start':
+      case 'watch_stop':
+      case 'quit_confirm':
+      case 'toggle_devtools':
+        return null
+      case 'capture_inbox_list':
+        return []
+
+      case 'note_read': {
+        const { path } = pathArgsSchema.parse(args)
+        const contents = files.read(path)
+        if (contents === null) {
+          throw new ReflectError('notFound', `no such note: ${path}`)
+        }
+        return contents
+      }
+      case 'note_write': {
+        const { path, contents } = writeArgsSchema.parse(args)
+        files.write(path, contents)
+        return null
+      }
+      case 'note_exists':
+        return files.exists(pathArgsSchema.parse(args).path)
+      case 'note_delete': {
+        files.remove(pathArgsSchema.parse(args).path)
+        return null
+      }
+      case 'list_files':
+        return files.list()
+      case 'dir_list':
+        return files.listDir(z.object({ dir: z.string() }).parse(args).dir)
+      case 'note_move_indexed': {
+        const { from, to } = moveArgsSchema.parse(args)
+        if (!files.exists(from)) {
+          throw new ReflectError('notFound', `cannot move note: ${from} does not exist`)
+        }
+        if (files.exists(to)) {
+          throw new ReflectError('io', `cannot move note: ${to} already exists`)
+        }
+        // Index first: it can refuse (occupied path), and a refused move must
+        // leave the file untouched — the in-memory stand-in for Rust's
+        // file+rows transaction.
+        index.moveNote(from, to)
+        files.move(from, to)
+        return null
+      }
+
+      case 'asset_write': {
+        const { path, contentsBase64 } = z
+          .object({ path: z.string(), contentsBase64: z.string() })
+          .parse(args)
+        assets.set(path, contentsBase64)
+        return null
+      }
+      case 'asset_read': {
+        const { path } = pathArgsSchema.parse(args)
+        const contents = assets.get(path)
+        if (contents === undefined) {
+          throw new ReflectError('notFound', `asset not found: ${path}`)
+        }
+        return contents
+      }
+      case 'asset_open':
+        return null
+
+      case 'db_query': {
+        const { sql, params } = dbQueryArgsSchema.parse(args)
+        return index.query(sql, params)
+      }
+      case 'index_open':
+        return 1
+      case 'index_apply': {
+        index.applyNote(applyArgsSchema.parse(args).note)
+        return null
+      }
+      case 'index_apply_batch': {
+        for (const note of applyBatchArgsSchema.parse(args).notes) {
+          index.applyNote(note)
+        }
+        return null
+      }
+      case 'index_remove': {
+        index.removeNote(pathArgsSchema.parse(args).path)
+        return null
+      }
+      case 'index_move': {
+        const { from, to } = moveArgsSchema.parse(args)
+        index.moveNote(from, to)
+        return null
+      }
+      case 'index_clear': {
+        index.clear()
+        return null
+      }
+      case 'index_meta_set': {
+        const { key, value } = metaArgsSchema.parse(args)
+        index.setMeta(key, value)
+        return null
+      }
+
+      case 'settings_load':
+        return settingsDocument
+      case 'settings_save': {
+        settingsDocument = settingsArgsSchema.parse(args).settings
+        return null
+      }
+      case 'secret_get':
+        return null
+      case 'secret_set':
+      case 'secret_delete':
+        return null
+
+      case 'git_status':
+        return {
+          initialized: false,
+          branch: null,
+          remoteUrl: null,
+          ahead: 0,
+          behind: 0,
+          inProgress: false,
+        }
+
+      case 'calendar_authorization_status':
+      case 'contacts_authorization_status':
+        return 'denied'
+      case 'calendar_list_calendars':
+      case 'calendar_list_events':
+      case 'contacts_lookup_by_email':
+      case 'contacts_lookup_by_name':
+        return []
+
+      case 'chat_conversation_delete':
+        return null
+
+      default:
+        console.error(`[dev-bridge] unimplemented command "${command}"`, args)
+        throw new ReflectError('unknown', `dev bridge: unimplemented command "${command}"`)
+    }
+  }
+
+  return {
+    invoke,
+    // Native event streams (watcher, embeddings, EventKit) don't exist in the
+    // browser; subscriptions succeed and simply never fire. Local writes still
+    // refresh the UI through core's in-process local-write echo.
+    listen: async () => () => {},
+  }
+}

--- a/apps/desktop/src/dev/dev-file-store.ts
+++ b/apps/desktop/src/dev/dev-file-store.ts
@@ -1,0 +1,85 @@
+import type { FileMeta } from '@reflect/core'
+
+/** One in-memory markdown file: contents plus a last-modified stamp. */
+interface DevFile {
+  contents: string
+  modifiedMs: number
+}
+
+/**
+ * The dev bridge's filesystem: a plain in-memory map of graph-relative paths
+ * to markdown, standing in for the Rust shell's `fs` commands. Mutations stamp
+ * `modifiedMs` with the current time so recency sorts and the indexer's
+ * hash-reconcile behave like real files.
+ */
+export interface DevFileStore {
+  /** Every markdown note under `daily/` and `notes/` (the `list_files` view). */
+  list: () => FileMeta[]
+  /** Files under a graph-relative directory prefix (the `dir_list` view). */
+  listDir: (dir: string) => FileMeta[]
+  /** A note's markdown, or `null` when the path doesn't exist. */
+  read: (path: string) => string | null
+  exists: (path: string) => boolean
+  write: (path: string, contents: string) => void
+  /** Delete a path; a missing path is a no-op (mirrors trashing semantics). */
+  remove: (path: string) => void
+  /** Rename a file; refuses (returns false) when the destination exists. */
+  move: (from: string, to: string) => boolean
+}
+
+/** UTF-8 byte length — `FileMeta.size` parity with the Rust listing. */
+function byteSize(contents: string): number {
+  return new TextEncoder().encode(contents).length
+}
+
+/**
+ * Create the in-memory file store, pre-populated with `seed` (path →
+ * markdown). Seeded files get staggered past mtimes so recency ordering is
+ * visibly non-uniform in list surfaces.
+ */
+export function createDevFileStore(seed: Record<string, string>): DevFileStore {
+  const files = new Map<string, DevFile>()
+  const seedEntries = Object.entries(seed)
+  seedEntries.forEach(([path, contents], position) => {
+    // Older seeds get older stamps, one minute apart, ending "now".
+    const modifiedMs = Date.now() - (seedEntries.length - position) * 60_000
+    files.set(path, { contents, modifiedMs })
+  })
+
+  const toMeta = ([path, file]: [string, DevFile]): FileMeta => ({
+    path,
+    size: byteSize(file.contents),
+    modifiedMs: file.modifiedMs,
+  })
+
+  return {
+    list: () =>
+      [...files.entries()]
+        .filter(
+          ([path]) =>
+            (path.startsWith('daily/') || path.startsWith('notes/')) && path.endsWith('.md'),
+        )
+        .map(toMeta),
+    listDir: (dir) => {
+      const prefix = dir.endsWith('/') ? dir : `${dir}/`
+      return [...files.entries()].filter(([path]) => path.startsWith(prefix)).map(toMeta)
+    },
+    read: (path) => files.get(path)?.contents ?? null,
+    exists: (path) => files.has(path),
+    write: (path, contents) => {
+      files.set(path, { contents, modifiedMs: Date.now() })
+    },
+    remove: (path) => {
+      files.delete(path)
+    },
+    move: (from, to) => {
+      const file = files.get(from)
+      if (file === undefined || files.has(to)) {
+        return false
+      }
+      files.delete(from)
+      files.set(to, file)
+      return true
+    },
+  }
+}

--- a/apps/desktop/src/dev/dev-index-db.test.ts
+++ b/apps/desktop/src/dev/dev-index-db.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import type { IndexedNote } from '@reflect/core'
+import { createDevIndexDb, type DevIndexDb } from '@/dev/dev-index-db'
+
+function sampleNote(overrides: Partial<IndexedNote> = {}): IndexedNote {
+  return {
+    path: 'notes/sample.md',
+    id: '01hv3xq7c2dm8k4t9w5e6r1n99',
+    title: 'Sample Note',
+    titleKey: 'sample note',
+    kind: 'note',
+    dailyDate: null,
+    isPrivate: false,
+    isPinned: false,
+    pinnedOrder: null,
+    hasConflict: false,
+    gistUrl: null,
+    gistStale: false,
+    fileHash: 'hash-1',
+    mtime: 1_700_000_000_000,
+    text: 'Sample Note body about local-first sync',
+    assetText: '',
+    preview: 'body about local-first sync',
+    links: [
+      {
+        kind: 'wiki',
+        targetRaw: 'Other Note',
+        targetKey: 'other note',
+        alias: null,
+        posFrom: 3,
+        posTo: 16,
+      },
+    ],
+    tags: [{ tag: 'book', tagKey: 'book' }],
+    aliases: [],
+    assets: [],
+    tasks: [{ markerOffset: 40, text: 'Do the thing', raw: '- [ ] Do the thing', checked: false, dueDate: null }],
+    ...overrides,
+  }
+}
+
+async function openDb(): Promise<DevIndexDb> {
+  return createDevIndexDb()
+}
+
+describe('createDevIndexDb', () => {
+  it('applies the real migrations and answers db_query-style reads', async () => {
+    const db = await openDb()
+    const tables = db.query(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('notes', 'tags', 'tasks', 'search_fts') ORDER BY name",
+      [],
+    )
+    expect(tables.map((row) => row['name'])).toEqual(['notes', 'search_fts', 'tags', 'tasks'])
+  })
+
+  it('applies a note projection across notes, tags, tasks, and FTS', async () => {
+    const db = await openDb()
+    db.applyNote(sampleNote())
+
+    const notes = db.query('SELECT path, title, is_pinned FROM notes', [])
+    expect(notes).toEqual([{ path: 'notes/sample.md', title: 'Sample Note', is_pinned: 0 }])
+
+    const tags = db.query('SELECT tag FROM tags WHERE note_path = ?', ['notes/sample.md'])
+    expect(tags).toEqual([{ tag: 'book' }])
+
+    const tasks = db.query('SELECT text, checked FROM tasks', [])
+    expect(tasks).toEqual([{ text: 'Do the thing', checked: 0 }])
+
+    const hits = db.query("SELECT path FROM search_fts WHERE search_fts MATCH 'sync'", [])
+    expect(hits).toEqual([{ path: 'notes/sample.md' }])
+  })
+
+  it('re-applying a note replaces its rows instead of duplicating them', async () => {
+    const db = await openDb()
+    db.applyNote(sampleNote())
+    db.applyNote(sampleNote({ title: 'Renamed Title', titleKey: 'renamed title' }))
+
+    const notes = db.query('SELECT title FROM notes', [])
+    expect(notes).toEqual([{ title: 'Renamed Title' }])
+    const fts = db.query('SELECT count(*) AS hits FROM search_fts', [])
+    expect(fts).toEqual([{ hits: 1 }])
+  })
+
+  it('moves every row to the new path and refuses an occupied destination', async () => {
+    const db = await openDb()
+    db.applyNote(sampleNote())
+    db.moveNote('notes/sample.md', 'notes/renamed.md')
+
+    expect(db.query('SELECT path FROM notes', [])).toEqual([{ path: 'notes/renamed.md' }])
+    expect(db.query('SELECT note_path FROM tags', [])).toEqual([
+      { note_path: 'notes/renamed.md' },
+    ])
+
+    db.applyNote(sampleNote({ path: 'notes/sample.md', id: '01hv3xq7c2dm8k4t9w5e6r1n98' }))
+    expect(() => db.moveNote('notes/sample.md', 'notes/renamed.md')).toThrowError(
+      /already indexed/,
+    )
+    // The refused move must leave both notes' rows untouched.
+    const paths = db.query('SELECT path FROM notes ORDER BY path', [])
+    expect(paths).toEqual([{ path: 'notes/renamed.md' }, { path: 'notes/sample.md' }])
+  })
+
+  it('removes a note and its FTS row', async () => {
+    const db = await openDb()
+    db.applyNote(sampleNote())
+    db.removeNote('notes/sample.md')
+
+    expect(db.query('SELECT count(*) AS rows FROM notes', [])).toEqual([{ rows: 0 }])
+    expect(db.query('SELECT count(*) AS rows FROM tags', [])).toEqual([{ rows: 0 }])
+    expect(db.query('SELECT count(*) AS rows FROM search_fts', [])).toEqual([{ rows: 0 }])
+  })
+
+  it('binds boolean parameters as integers (the json_to_sql contract)', async () => {
+    const db = await openDb()
+    db.applyNote(sampleNote({ isPinned: true, pinnedOrder: 1 }))
+    const pinned = db.query('SELECT path FROM notes WHERE is_pinned = ?', [true])
+    expect(pinned).toEqual([{ path: 'notes/sample.md' }])
+  })
+})

--- a/apps/desktop/src/dev/dev-index-db.ts
+++ b/apps/desktop/src/dev/dev-index-db.ts
@@ -1,0 +1,200 @@
+import sqlite3InitModule, { type Database, type SqlValue } from '@sqlite.org/sqlite-wasm'
+import { ReflectError, type IndexedNote } from '@reflect/core'
+
+/**
+ * The dev bridge's SQLite index: the real `crates/index-schema` migrations
+ * running in the browser via the official SQLite wasm build, so `db_query`
+ * executes the exact SQL Kysely compiles — FTS5 search included. Write
+ * commands mirror `src-tauri/src/db/write.rs` statement-for-statement.
+ */
+export interface DevIndexDb {
+  /** Execute a read query (the `db_query` contract): rows as column-keyed objects. */
+  query: (sql: string, params: readonly unknown[]) => Record<string, SqlValue>[]
+  /** Replace all rows for `note.path` with its projection (`index_apply`). */
+  applyNote: (note: IndexedNote) => void
+  /** Drop every row belonging to `path` (`index_remove`). */
+  removeNote: (path: string) => void
+  /** Re-key every row from `from` to `to` (`index_move`); throws when `to` is occupied. */
+  moveNote: (from: string, to: string) => void
+  /** Wipe derived tables, preserving `index_meta` (`index_clear`). */
+  clear: () => void
+  /** Upsert one `index_meta` key (`index_meta_set`). */
+  setMeta: (key: string, value: string) => void
+}
+
+// The real migrations, inlined at build time. This chunk only loads behind the
+// DEV platform override, so the raw SQL never reaches production bundles.
+const migrationSources = import.meta.glob<string>(
+  '../../../../crates/index-schema/migrations/*.sql',
+  { query: '?raw', import: 'default', eager: true },
+)
+
+/**
+ * `vec0` is the sqlite-vec native extension, absent from the wasm build. The
+ * mobile surfaces never touch embedding vectors (semantic search is desktop-
+ * only and off by default), so a plain single-column table keeps the DDL —
+ * and 0003's copy-and-drop migration dance — valid without the module.
+ */
+function stubVectorTables(sql: string): string {
+  return sql.replace(
+    /CREATE VIRTUAL TABLE (\S+) USING vec0\([^)]*\)/g,
+    'CREATE TABLE $1 (embedding BLOB)',
+  )
+}
+
+/** Coerce a Kysely-bound parameter to something SQLite can bind (mirrors `json_to_sql`). */
+function bindValue(value: unknown): SqlValue {
+  if (value === null || value === undefined) {
+    return null
+  }
+  if (typeof value === 'boolean') {
+    return value ? 1 : 0
+  }
+  if (typeof value === 'number' || typeof value === 'string' || typeof value === 'bigint') {
+    return value
+  }
+  if (value instanceof Uint8Array) {
+    return value
+  }
+  return JSON.stringify(value)
+}
+
+function run(db: Database, sql: string, params: readonly unknown[] = []): void {
+  db.exec({ sql, bind: params.map(bindValue) })
+}
+
+/** Open an in-memory index database and apply every migration in order. */
+export async function createDevIndexDb(): Promise<DevIndexDb> {
+  const sqlite3 = await sqlite3InitModule()
+  const db = new sqlite3.oo1.DB()
+  // The schema relies on ON DELETE CASCADE (removing a `notes` row clears its
+  // child tables); SQLite ships with foreign keys off per connection.
+  db.exec('PRAGMA foreign_keys = ON')
+  const migrations = Object.entries(migrationSources).sort(([a], [b]) => a.localeCompare(b))
+  for (const [, source] of migrations) {
+    db.exec(stubVectorTables(source))
+  }
+
+  return {
+    query: (sql, params) => {
+      const resultRows: Record<string, SqlValue>[] = []
+      db.exec({ sql, bind: params.map(bindValue), rowMode: 'object', resultRows })
+      return resultRows
+    },
+
+    applyNote: (note) => {
+      removeNote(db, note.path)
+      run(
+        db,
+        `INSERT INTO notes(path, id, title, title_key, kind, daily_date, is_private, is_pinned, pinned_order, has_conflict, gist_url, gist_stale, file_hash, mtime, updated_at, preview)
+         VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          note.path,
+          note.id,
+          note.title,
+          note.titleKey,
+          note.kind,
+          note.dailyDate,
+          note.isPrivate,
+          note.isPinned,
+          note.pinnedOrder,
+          note.hasConflict,
+          note.gistUrl,
+          note.gistStale,
+          note.fileHash,
+          note.mtime,
+          note.mtime,
+          note.preview,
+        ],
+      )
+      run(db, 'INSERT INTO note_text(note_path, text) VALUES(?, ?)', [note.path, note.text])
+      for (const link of note.links) {
+        run(
+          db,
+          `INSERT INTO links(source_path, kind, target_raw, target_key, alias, pos_from, pos_to)
+           VALUES(?, ?, ?, ?, ?, ?, ?)`,
+          [note.path, link.kind, link.targetRaw, link.targetKey, link.alias, link.posFrom, link.posTo],
+        )
+      }
+      for (const tag of note.tags) {
+        run(db, 'INSERT INTO tags(note_path, tag, tag_key) VALUES(?, ?, ?)', [
+          note.path,
+          tag.tag,
+          tag.tagKey,
+        ])
+      }
+      for (const alias of note.aliases) {
+        run(db, 'INSERT INTO aliases(note_path, alias, alias_key) VALUES(?, ?, ?)', [
+          note.path,
+          alias.alias,
+          alias.aliasKey,
+        ])
+      }
+      for (const asset of note.assets) {
+        run(db, 'INSERT INTO assets(note_path, asset_path) VALUES(?, ?)', [note.path, asset])
+      }
+      for (const task of note.tasks) {
+        run(
+          db,
+          'INSERT INTO tasks(note_path, marker_offset, text, raw, checked, due_date) VALUES(?, ?, ?, ?, ?, ?)',
+          [note.path, task.markerOffset, task.text, task.raw, task.checked, task.dueDate],
+        )
+      }
+      const searchBody = note.assetText === '' ? note.text : `${note.text}\n${note.assetText}`
+      run(db, 'INSERT INTO search_fts(path, title, body) VALUES(?, ?, ?)', [
+        note.path,
+        note.title,
+        searchBody,
+      ])
+    },
+
+    removeNote: (path) => removeNote(db, path),
+
+    moveNote: (from, to) => {
+      const occupied = db.selectValue('SELECT 1 FROM notes WHERE path = ?', [to])
+      if (occupied !== undefined) {
+        throw new ReflectError('io', `cannot move note: ${to} is already indexed`)
+      }
+      // Mirrors the Rust caller: the child tables reference `notes(path)`, so
+      // the parent-key update needs deferred FK checks — which only apply
+      // inside a transaction (the pragma resets at COMMIT).
+      db.exec('BEGIN')
+      try {
+        db.exec('PRAGMA defer_foreign_keys = ON')
+        run(db, 'UPDATE notes SET path = ? WHERE path = ?', [to, from])
+        run(db, 'UPDATE note_text SET note_path = ? WHERE note_path = ?', [to, from])
+        run(db, 'UPDATE links SET source_path = ? WHERE source_path = ?', [to, from])
+        run(db, 'UPDATE tags SET note_path = ? WHERE note_path = ?', [to, from])
+        run(db, 'UPDATE aliases SET note_path = ? WHERE note_path = ?', [to, from])
+        run(db, 'UPDATE assets SET note_path = ? WHERE note_path = ?', [to, from])
+        run(db, 'UPDATE tasks SET note_path = ? WHERE note_path = ?', [to, from])
+        run(db, 'UPDATE embedding_chunks SET note_path = ? WHERE note_path = ?', [to, from])
+        run(db, 'UPDATE search_fts SET path = ? WHERE path = ?', [to, from])
+        db.exec('COMMIT')
+      } catch (cause) {
+        db.exec('ROLLBACK')
+        throw cause
+      }
+    },
+
+    clear: () => {
+      db.exec(
+        `DELETE FROM notes; DELETE FROM search_fts;
+         DELETE FROM embedding_vectors; DELETE FROM embedding_chunks;`,
+      )
+    },
+
+    setMeta: (key, value) => {
+      run(
+        db,
+        'INSERT INTO index_meta(key, value) VALUES(?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value',
+        [key, value],
+      )
+    },
+  }
+}
+
+function removeNote(db: Database, path: string): void {
+  run(db, 'DELETE FROM notes WHERE path = ?', [path])
+  run(db, 'DELETE FROM search_fts WHERE path = ?', [path])
+}

--- a/apps/desktop/src/dev/install-dev-bridge.ts
+++ b/apps/desktop/src/dev/install-dev-bridge.ts
@@ -1,0 +1,33 @@
+import { setBridge, type AppPlatform } from '@reflect/core'
+import { createDevBridge } from '@/dev/dev-bridge'
+import { createDevFileStore } from '@/dev/dev-file-store'
+import { createDevIndexDb } from '@/dev/dev-index-db'
+import { seedGraphFiles } from '@/dev/seed-graph'
+
+let installation: Promise<void> | null = null
+
+/**
+ * Install the in-browser dev bridge (dev builds only): an in-memory graph
+ * seeded with demo notes, backed by the real index schema in wasm SQLite.
+ * Loaded lazily by `PlatformRoot` when `?platform=ios` (or `android`) is in
+ * the URL and no native shell is present — the mobile tree then boots through
+ * its ordinary path: graph open, full index rebuild from the seeded files,
+ * queries over `db_query`.
+ *
+ * Idempotent: React 19 StrictMode double-fires the installing effect, and the
+ * second call must not re-seed or swap the bridge mid-boot.
+ */
+export function installDevBridge(platform: AppPlatform): Promise<void> {
+  installation ??= install(platform)
+  return installation
+}
+
+async function install(platform: AppPlatform): Promise<void> {
+  const index = await createDevIndexDb()
+  const files = createDevFileStore(seedGraphFiles())
+  setBridge(createDevBridge({ platform, files, index }))
+  // A console handle for poking the shim while debugging mobile surfaces:
+  // `__reflectDev.query('select path, title from notes')`, `.files.read(...)`.
+  Object.assign(window, { __reflectDev: { query: index.query, files } })
+  console.info(`[dev-bridge] installed: platform=${platform}, in-memory graph + wasm SQLite index`)
+}

--- a/apps/desktop/src/dev/seed-graph.ts
+++ b/apps/desktop/src/dev/seed-graph.ts
@@ -1,0 +1,136 @@
+/**
+ * The demo graph the dev bridge boots with: enough daily notes, tagged notes,
+ * wiki links, pins, tasks, and a private note that every mobile surface — the
+ * Daily carousel, the All tab with its filter badges, drawers, and search —
+ * renders with believable data. Dates are computed relative to "today" so the
+ * daily stream always lands on the current week.
+ */
+
+/** Local-time `YYYY-MM-DD` for `offsetDays` before today. */
+function isoDay(offsetDays: number): string {
+  const date = new Date()
+  date.setDate(date.getDate() - offsetDays)
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+/** Frontmatter block for a seeded note. Ids are fixed Crockford-base32 ULIDs. */
+function frontmatter(entries: Record<string, string>): string {
+  const lines = Object.entries(entries).map(([key, value]) => `${key}: ${value}`)
+  return `---\n${lines.join('\n')}\n---\n`
+}
+
+/** The demo graph: graph-relative path → markdown source. */
+export function seedGraphFiles(): Record<string, string> {
+  const today = isoDay(0)
+  const yesterday = isoDay(1)
+  const nextWeek = isoDay(-7)
+
+  return {
+    [`daily/${today}.md`]: [
+      `- Morning review with [[Sarah Chen]] about the [[Reflect V2]] launch`,
+      `- [ ] Ship the mobile filter badges [[${today}]]`,
+      `- [ ] Reply to the beta feedback thread`,
+      `- Started reading [[Atomic Habits]] on the train #book`,
+      ``,
+    ].join('\n'),
+    [`daily/${yesterday}.md`]: [
+      `- Pairing session on the day carousel swipe physics`,
+      `- [x] Fix the week-strip echo guard`,
+      `- Lunch with [[James Clear]] — talked habit loops #person`,
+      ``,
+    ].join('\n'),
+    [`daily/${isoDay(2)}.md`]: [
+      `- Sketched the [[Quarterly Goals]] doc`,
+      `- [ ] Book flights for the offsite [[${nextWeek}]]`,
+      ``,
+    ].join('\n'),
+    [`daily/${isoDay(4)}.md`]: [
+      `- Deep-work day on sync conflict handling`,
+      `- Saved [Local-first software](https://www.inkandswitch.com/local-first/) #link`,
+      ``,
+    ].join('\n'),
+    [`daily/${isoDay(7)}.md`]: [
+      `- Weekly planning: reviewed [[Reading List]]`,
+      `- [x] Cut the 0.2 beta release`,
+      ``,
+    ].join('\n'),
+    'notes/reflect-v2.md': [
+      frontmatter({ id: '01hv3xq7c2dm8k4t9w5e6r1n0a', pinned: '1' }),
+      `# Reflect V2`,
+      ``,
+      `The offline-first rewrite. Markdown on disk, SQLite as a rebuildable`,
+      `projection, sync over Git.`,
+      ``,
+      `- Owner: [[Sarah Chen]]`,
+      `- [ ] Mobile parity pass [[${nextWeek}]]`,
+      `- [x] Ship the All tab search`,
+      ``,
+    ].join('\n'),
+    'notes/sarah-chen.md': [
+      frontmatter({ id: '01hv3xq7c2dm8k4t9w5e6r1n0b' }),
+      `# Sarah Chen`,
+      ``,
+      `- Type: #person`,
+      `- Engineering lead on [[Reflect V2]]`,
+      `- Prefers async updates, Tuesday 1:1s`,
+      ``,
+    ].join('\n'),
+    'notes/james-clear.md': [
+      frontmatter({ id: '01hv3xq7c2dm8k4t9w5e6r1n0c' }),
+      `# James Clear`,
+      ``,
+      `- Type: #person`,
+      `- Author of [[Atomic Habits]]`,
+      ``,
+    ].join('\n'),
+    'notes/atomic-habits.md': [
+      frontmatter({ id: '01hv3xq7c2dm8k4t9w5e6r1n0d' }),
+      `# Atomic Habits`,
+      ``,
+      `- Type: #book`,
+      `- Author: [[James Clear]]`,
+      ``,
+      `Systems over goals. Make it obvious, attractive, easy, satisfying.`,
+      ``,
+    ].join('\n'),
+    'notes/local-first-software.md': [
+      frontmatter({ id: '01hv3xq7c2dm8k4t9w5e6r1n0e' }),
+      `# Local-first software`,
+      ``,
+      `- Type: #link`,
+      `- URL: https://www.inkandswitch.com/local-first/`,
+      ``,
+      `Seven ideals for software that keeps data on the device and syncs`,
+      `without a server owning it. Core inspiration for [[Reflect V2]].`,
+      ``,
+    ].join('\n'),
+    'notes/reading-list.md': [
+      frontmatter({ id: '01hv3xq7c2dm8k4t9w5e6r1n0f' }),
+      `# Reading List`,
+      ``,
+      `- [[Atomic Habits]] #book`,
+      `- [[Local-first software]] #link`,
+      `- How Buildings Learn #book`,
+      ``,
+    ].join('\n'),
+    'notes/quarterly-goals.md': [
+      frontmatter({ id: '01hv3xq7c2dm8k4t9w5e6r1n0g' }),
+      `# Quarterly Goals`,
+      ``,
+      `- [ ] Mobile app in TestFlight [[${nextWeek}]]`,
+      `- [ ] 1k beta signups`,
+      `- [x] Open-source the core`,
+      ``,
+    ].join('\n'),
+    'notes/private-journal.md': [
+      frontmatter({ id: '01hv3xq7c2dm8k4t9w5e6r1n0h', private: 'true' }),
+      `# Private Journal`,
+      ``,
+      `Marked private — content here must never reach an external service.`,
+      ``,
+    ].join('\n'),
+  }
+}

--- a/apps/desktop/src/platform-root.tsx
+++ b/apps/desktop/src/platform-root.tsx
@@ -55,12 +55,21 @@ export function PlatformRoot(): ReactElement {
   useEffect(() => {
     let active = true
     if (import.meta.env.DEV && devPlatformOverride !== null && !hasBridge()) {
-      void import('@/dev/install-dev-bridge').then(async (module) => {
-        await module.installDevBridge(devPlatformOverride)
-        if (active) {
-          setPlatform(devPlatformOverride)
-        }
-      })
+      void import('@/dev/install-dev-bridge')
+        .then(async (module) => {
+          await module.installDevBridge(devPlatformOverride)
+          if (active) {
+            setPlatform(devPlatformOverride)
+          }
+        })
+        .catch((cause: unknown) => {
+          // Dev-only path: fail loud (the screen would otherwise stay blank)
+          // and fall back to the desktop tree rather than hanging.
+          console.error('[dev-bridge] install failed:', cause)
+          if (active) {
+            setPlatform('desktop')
+          }
+        })
       return () => {
         active = false
       }

--- a/apps/desktop/src/platform-root.tsx
+++ b/apps/desktop/src/platform-root.tsx
@@ -8,34 +8,67 @@ const MobileRoot = lazy(() =>
   import('@/mobile/mobile-root').then((module) => ({ default: module.MobileRoot })),
 )
 
-// Eagerly start the platform IPC call at module evaluation time — this is a
-// build-time constant (the Rust shell's compile-time platform tag) that never
-// changes within a session. Hoisting it here makes the round-trip concurrent
-// with JS parse/React mount rather than serial after the first paint.
-const platformPromise: Promise<AppPlatform> = hasBridge()
-  ? getAppPlatform().catch(() => 'desktop' as AppPlatform)
-  : Promise.resolve('desktop' as AppPlatform)
+// The platform IPC round-trip is a build-time constant (the Rust shell's
+// compile-time platform tag), so it is resolved once and memoized. It must be
+// created lazily — at module-evaluation time `installTauriBridge()` in
+// main.tsx has not run yet (imports evaluate before the importing module's
+// body), so a module-scope `hasBridge()` check is always false and would pin
+// every shell, including iOS, to the desktop tree.
+let platformPromise: Promise<AppPlatform> | undefined
+
+function resolveAppPlatform(): Promise<AppPlatform> {
+  platformPromise ??= getAppPlatform().catch(() => 'desktop' as AppPlatform)
+  return platformPromise
+}
+
+// Dev-only escape hatch: `?platform=ios` (or `android`) in a plain browser
+// forces the mobile tree, backed by the in-memory dev bridge, so mobile UI
+// work is visible without an iOS build. Statically false in production
+// builds, so the check and the dev-bridge chunk are both dead code there.
+const devPlatformOverride: AppPlatform | null = import.meta.env.DEV
+  ? readDevPlatformOverride()
+  : null
+
+function readDevPlatformOverride(): AppPlatform | null {
+  const requested = new URLSearchParams(window.location.search).get('platform')
+  return requested === 'ios' || requested === 'android' ? requested : null
+}
 
 /**
  * The Plan 19 root gate: one bundle, two surface trees. The shell reports
  * which platform it was built for and the matching tree loads as a lazy
  * chunk — desktop chrome never reaches the mobile critical path, and vice
- * versa. Plain-browser dev (no Tauri bridge) gets the desktop tree.
+ * versa. Plain-browser dev (no Tauri bridge) gets the desktop tree, unless
+ * `?platform=ios` forces the mobile tree over the dev bridge (dev builds only).
  */
 export function PlatformRoot(): ReactElement {
-  // Plain-browser dev has no bridge — start on the desktop tree directly. With a
-  // bridge, resolve the real platform from the already-in-flight module-scope
-  // promise so the IPC call started before React mounted.
-  const [platform, setPlatform] = useState<AppPlatform | null>(() =>
-    hasBridge() ? null : 'desktop',
-  )
+  // Plain-browser dev has no bridge — start on the desktop tree directly
+  // (or hold the blank frame while the dev bridge chunk loads when a dev
+  // platform override is active). With a bridge, resolve the real platform.
+  const [platform, setPlatform] = useState<AppPlatform | null>(() => {
+    if (import.meta.env.DEV && devPlatformOverride !== null && !hasBridge()) {
+      return null
+    }
+    return hasBridge() ? null : 'desktop'
+  })
 
   useEffect(() => {
+    let active = true
+    if (import.meta.env.DEV && devPlatformOverride !== null && !hasBridge()) {
+      void import('@/dev/install-dev-bridge').then(async (module) => {
+        await module.installDevBridge(devPlatformOverride)
+        if (active) {
+          setPlatform(devPlatformOverride)
+        }
+      })
+      return () => {
+        active = false
+      }
+    }
     if (!hasBridge()) {
       return
     }
-    let active = true
-    void platformPromise.then((resolved) => {
+    void resolveAppPlatform().then((resolved) => {
       if (active) {
         setPlatform(resolved)
       }

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -23,6 +23,13 @@ export default defineConfig(async () => ({
   // platform, which gates desktop-only surfaces like the updater).
   envPrefix: ['VITE_', 'TAURI_ENV_'],
 
+  // The dev bridge's SQLite (dev-only, behind `?platform=ios`) locates its
+  // .wasm relative to its own module URL; esbuild pre-bundling would relocate
+  // the module into .vite/deps and break that lookup.
+  optimizeDeps: {
+    exclude: ['@sqlite.org/sqlite-wasm'],
+  },
+
   // Vite options tailored for Tauri development, applied in `tauri dev`/`tauri build`.
   //
   // 1. prevent Vite from obscuring Rust errors

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
     devDependencies:
+      '@sqlite.org/sqlite-wasm':
+        specifier: 3.53.0-build1
+        version: 3.53.0-build1
       '@tailwindcss/vite':
         specifier: ^4.3.1
         version: 4.3.1(vite@8.1.0)
@@ -2272,6 +2275,10 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@sqlite.org/sqlite-wasm@3.53.0-build1':
+    resolution: {integrity: sha512-PfWPWN2n+/37doa8oh2/oUXk4OOsRYZsxc1W1sDXIGb/Pu5Yrb+f2eyYpgQMGITVX7HVgxhs9P18Rc6I97ym/g==}
+    engines: {node: '>=22'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -8242,6 +8249,8 @@ snapshots:
   '@shikijs/vscode-textmate@10.0.2': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@sqlite.org/sqlite-wasm@3.53.0-build1': {}
 
   '@standard-schema/spec@1.1.0': {}
 


### PR DESCRIPTION
## Problem

The mobile surface tree (`apps/desktop/src/mobile/`) can only be seen on a real iOS build: plain-browser dev has no Tauri bridge, so `PlatformRoot` routes to the desktop tree and the mobile GraphProvider parks at "Loading…". With CoreSimulator wedged, mobile PRs (e.g. #476's filter badges) have had no visual-verification path — and no way for browser-based review tooling to see mobile screens.

## What this adds

**Dev-only platform override.** In dev builds, `?platform=ios` (or `android`) on the Vite URL forces the mobile tree. The check is behind `import.meta.env.DEV`, and the bridge ships as a dynamic import — production bundles contain no dev-bridge code, no wasm asset, no migration SQL (verified against `dist/`).

**An in-browser bridge shim** (`apps/desktop/src/dev/`), installed via the existing `setBridge` seam:

- `dev-file-store` — in-memory file map seeded with a demo graph: daily notes across the last week, tagged (#book/#link/#person), pinned, and private notes, wiki links, tasks with due dates.
- `dev-index-db` — the **real `crates/index-schema` migrations** running on the official SQLite wasm build (FTS5 included). `vec0` virtual tables are stubbed to plain tables (sqlite-vec is a native extension; semantic search is desktop-only and off by default). `db_query` executes the exact SQL Kysely compiles; `index_apply`/`index_move`/etc. mirror `src-tauri/src/db/write.rs` statement-for-statement, including the deferred-FK transaction around a path move.
- `dev-bridge` — routes the command surface the mobile tree exercises (graph/note/index/settings, plus cheap stubs for git/calendar/contacts). Unimplemented commands reject loudly with the command name rather than degrading silently.

Because indexing is TS-driven, the app boots through its **ordinary path** — graph open, full index rebuild from the seeded files, queries over `db_query` — so what renders is the real pipeline, not fixtures. A `window.__reflectDev` handle exposes `query()`/`files` for console debugging.

## Root-gate fix (latent iOS bug)

#233 hoisted the `app_platform` IPC call to module scope in `platform-root.tsx` for startup perf — but ES imports evaluate before `main.tsx`'s body runs `installTauriBridge()`, so `hasBridge()` was always false there and the promise resolved `'desktop'` unconditionally. **An iOS build would render the desktop tree.** The platform now resolves through a lazily-created memoized promise (first effect run, after the bridge exists). Worth a simulator/device pass once CoreSimulator recovers.

## Verified

- `pnpm check` clean; new vitest coverage for the wasm index (migrations, FTS5 MATCH, apply/replace, move-refuses-occupied, boolean binding).
- In the browser at `http://localhost:1420/?platform=ios`: Daily carousel + week strip with seeded content; All tab with #476's filter badges (tag counts in the vaul sheet, combined FTS + tag filtering, Reset chip, pinned-first list); settings sheet (graph stats over `db_query`); new-note FAB through the birth rename (`flush → note_move_indexed`) landing on the title slug.
- Production build: `grep` over `dist/` finds no dev-bridge strings, no sqlite wasm asset, no migration SQL.

## Usage

```
pnpm dev   # then open http://localhost:1420/?platform=ios
```

(Also noted in AGENTS.md. If 1420 is taken by another vite, override the port via --config per the usual rule.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The lazy `app_platform` resolution fixes a latent bug that could force iOS to the desktop tree; dev bridge code is DEV-gated but touches core boot routing and index write parity with Rust.
> 
> **Overview**
> Adds a **dev-only** way to run the **mobile** React tree in a plain browser: `?platform=ios` or `android` on the Vite URL dynamically installs an in-memory **IPC bridge** (seeded demo graph + wasm SQLite using real `index-schema` migrations) so mobile UI boots through the normal graph/index/`db_query` path without Tauri.
> 
> **`PlatformRoot`** no longer resolves `app_platform` at module load (when `hasBridge()` was always false before `main.tsx` installs the Tauri bridge); it memoizes the IPC call lazily and, in dev without a bridge, loads the dev bridge then selects the overridden platform—with fallback to desktop on install failure.
> 
> Also documents the URL in **AGENTS.md**, adds **`@sqlite.org/sqlite-wasm`** as a dev dependency with Vite **`optimizeDeps.exclude`**, and **vitest** coverage for the wasm index layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e59750383f980d087a7d056e7a56d04b34f2d38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a browser-based desktop dev preview for the mobile tree via a URL override.
  * Included an in-memory dev bridge with a seeded demo graph for exploring notes, indexing, and settings without a backend.

* **Bug Fixes**
  * Improved platform/layout loading so the correct tree renders reliably once the bridge is installed.
  * Enhanced dev-preview note move/delete/search behavior with conflict checks and consistent updates.

* **Chores**
  * Updated the development setup for the SQLite WASM runtime used by the preview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->