### PR TITLE
feat: incoming-backlinks section on mobile note surfaces

### DIFF
--- a/apps/desktop/src/components/backlinks-panel.tsx
+++ b/apps/desktop/src/components/backlinks-panel.tsx
@@ -1,25 +1,14 @@
-import { useCallback, useMemo, type ReactElement } from 'react'
+import { type ReactElement } from 'react'
 import { ChevronRight } from 'lucide-react'
-import { useQuery } from '@tanstack/react-query'
-import type { WikilinkClickHandler } from '@meowdown/core'
-import { getBacklinksWithContext, hasBridge } from '@reflect/core'
 import { BacklinkSourceGroup } from '@/components/backlink-source-group'
-import { useAssetPersistence } from '@/editor/use-asset-persistence'
-import { useWikiLinkNavigation } from '@/editor/use-wiki-link-navigation'
-import { groupBacklinksBySource } from '@/lib/group-backlinks'
-import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
-import { useSessionFlag } from '@/lib/use-session-flag'
-import { useGraph } from '@/providers/graph-provider'
-import { routeForPath } from '@/routing/route'
-import { useRouter } from '@/routing/router'
+import { useBacklinkNavigation } from '@/hooks/use-backlink-navigation'
+import { useBacklinkSources } from '@/hooks/use-backlink-sources'
+import { useBacklinksExpanded } from '@/hooks/use-backlinks-expanded'
 
 interface BacklinksPanelProps {
   /** Graph-relative path of the note whose inbound links to show. */
   path: string
 }
-
-/** Session-wide (all notes) expanded state, old Reflect's `backlinks-expanded`. */
-const EXPANDED_STORAGE_KEY = 'reflect.backlinks-expanded'
 
 /**
  * Incoming backlinks at the bottom of every note — daily and ordinary — in
@@ -28,51 +17,18 @@ const EXPANDED_STORAGE_KEY = 'reflect.backlinks-expanded'
  * dividers between groups. The header toggle collapses the linking lines while the
  * source titles stay visible, and the choice persists for the session
  * across all notes. Ambient and always-available — the associative recall
- * the product is built on — and cheap: one indexed query per visible note,
- * kept fresh by the index invalidation hook (no polling). Renders nothing
- * when the note has no inbound links, but a failed query surfaces as an
- * alert — this is the only backlinks surface, and a failing query means the
+ * the product is built on — and cheap: one indexed query per visible note
+ * ({@link useBacklinkSources}). Renders nothing when the note has no inbound
+ * links, but a failed query surfaces as an alert — a failing query means the
  * index is broken, not that the note is unlinked.
+ *
+ * Desktop chrome (hover-revealed group chevrons, hover-sized targets); the
+ * mobile surfaces render `IncomingBacklinks` over the same data layer.
  */
 export function BacklinksPanel({ path }: BacklinksPanelProps): ReactElement | null {
-  const { navigate } = useRouter()
-  const { graph } = useGraph()
-  // The graph root is part of the key: index rows belong to one graph, and a
-  // graph switch must never serve the previous graph's cached rows (the cache
-  // outlives the workspace remount; invalidation alone lags the reconcile).
-  const { data, isError } = useQuery({
-    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'backlinks', path],
-    queryFn: () => getBacklinksWithContext(path),
-    enabled: hasBridge() && graph !== null,
-  })
-  // Shared across every mounted panel: the daily stream shows one per day,
-  // and the header toggle must move them together, not just this instance.
-  const [expanded, setExpanded] = useSessionFlag(EXPANDED_STORAGE_KEY, true)
-  const groups = useMemo(() => (data ? groupBacklinksBySource(data) : []), [data])
-  const handleOpen = useCallback(
-    (target: string) => {
-      const route = routeForPath(target)
-      // A backlink tap restores focus on the destination (the mobile focus
-      // contract); desktop autofocuses note arrivals anyway.
-      navigate(route, { focusEditor: route.kind === 'note' })
-    },
-    [navigate],
-  )
-
-  // A wiki link clicked *inside* a snippet resolves its target the same way the
-  // editor does, distinct from `handleOpen` which opens an already-resolved
-  // source-note path. Images resolve through the same asset pipeline as the
-  // editor; both callbacks are stable so they never rebuild the snippet trees.
-  const navigateWikiLink = useWikiLinkNavigation(graph?.generation ?? null)
-  const { resolveImageUrl } = useAssetPersistence(graph?.root ?? null, graph?.generation ?? null)
-  const handleWikilinkClick = useCallback<WikilinkClickHandler>(
-    ({ target }) => navigateWikiLink(target),
-    [navigateWikiLink],
-  )
-  const resolveImageUrlStable = useCallback(
-    (src: string) => resolveImageUrl(src) ?? undefined,
-    [resolveImageUrl],
-  )
+  const { groups, count, isError } = useBacklinkSources(path)
+  const [expanded, setExpanded] = useBacklinksExpanded()
+  const { openSource, onWikilinkClick, resolveImageUrl } = useBacklinkNavigation()
 
   if (isError) {
     return (
@@ -84,15 +40,13 @@ export function BacklinksPanel({ path }: BacklinksPanelProps): ReactElement | nu
     )
   }
 
-  if (!data || data.length === 0) {
+  if (count === 0) {
     return null
   }
 
   const toggleExpanded = (): void => {
     setExpanded(!expanded)
   }
-
-  const count = data.length
 
   return (
     <section aria-label="Incoming backlinks" className="mt-8">
@@ -128,9 +82,9 @@ export function BacklinksPanel({ path }: BacklinksPanelProps): ReactElement | nu
             source={group}
             first={index === 0}
             expanded={expanded}
-            onOpen={handleOpen}
-            onWikilinkClick={handleWikilinkClick}
-            resolveImageUrl={resolveImageUrlStable}
+            onOpen={openSource}
+            onWikilinkClick={onWikilinkClick}
+            resolveImageUrl={resolveImageUrl}
           />
         ))}
       </div>

--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -58,6 +58,12 @@ interface NotePaneProps {
    */
   gutterClassName?: string
   /**
+   * Render the built-in desktop backlinks panel below the note (default).
+   * The mobile surfaces pass `false` and mount their own touch-chrome
+   * `IncomingBacklinks` section over the same data layer.
+   */
+  showBacklinks?: boolean
+  /**
    * The daily stream's day key for this pane (omitted by non-daily callers).
    * Required for {@link registerHandle} and {@link onExitBoundary} to identify
    * which day fired.
@@ -97,6 +103,7 @@ export function NotePaneComponent({
   className,
   editorClassName,
   gutterClassName,
+  showBacklinks = true,
   dailyDate,
   registerHandle,
   onExitBoundary,
@@ -242,7 +249,7 @@ export function NotePaneComponent({
       <div className={cn(gutterClassName, className)}>
         <SyncConflictNotice path={path} className="mb-4" />
         <ProtectedNoteView content={document.initialContent} />
-        <BacklinksPanel path={path} />
+        {showBacklinks ? <BacklinksPanel path={path} /> : null}
       </div>
     )
   }
@@ -328,9 +335,11 @@ export function NotePaneComponent({
         <EditorAiKeymap onTrigger={aiMenu.openMenu} />
       </NoteEditor>
 
-      <div className={gutterClassName}>
-        <BacklinksPanel path={path} />
-      </div>
+      {showBacklinks ? (
+        <div className={gutterClassName}>
+          <BacklinksPanel path={path} />
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/apps/desktop/src/hooks/use-backlink-navigation.ts
+++ b/apps/desktop/src/hooks/use-backlink-navigation.ts
@@ -1,0 +1,58 @@
+import { useCallback } from 'react'
+import type { WikilinkClickHandler } from '@meowdown/core'
+import { useAssetPersistence } from '@/editor/use-asset-persistence'
+import { useWikiLinkNavigation } from '@/editor/use-wiki-link-navigation'
+import { useGraph } from '@/providers/graph-provider'
+import { routeForPath } from '@/routing/route'
+import { useRouter } from '@/routing/router'
+
+/** The click plumbing a backlinks surface wires into its rows and snippets. */
+export interface BacklinkNavigation {
+  /**
+   * Open an already-resolved source-note path: a daily note opens the daily
+   * view (on mobile that swipes the carousel to the date — the surface stays
+   * mounted), anything else opens the note. A backlink tap restores focus on
+   * the destination (the mobile focus contract); desktop autofocuses note
+   * arrivals anyway.
+   */
+  openSource: (path: string) => void
+  /**
+   * Navigate a `[[wiki link]]` clicked *inside* a snippet — resolves its
+   * target the same way the editor does, distinct from {@link openSource}.
+   * Stable, so it never rebuilds the snippet trees.
+   */
+  onWikilinkClick: WikilinkClickHandler
+  /** Resolve `![…](…)` sources inside a snippet to displayable URLs. Stable. */
+  resolveImageUrl: (src: string) => string | undefined
+}
+
+/**
+ * Navigation for an incoming-backlinks surface, shared by the desktop panel
+ * and the mobile section. Wiki links and images inside snippets resolve
+ * through the same pipelines as the editor.
+ */
+export function useBacklinkNavigation(): BacklinkNavigation {
+  const { navigate } = useRouter()
+  const { graph } = useGraph()
+
+  const openSource = useCallback(
+    (target: string) => {
+      const route = routeForPath(target)
+      navigate(route, { focusEditor: route.kind === 'note' })
+    },
+    [navigate],
+  )
+
+  const navigateWikiLink = useWikiLinkNavigation(graph?.generation ?? null)
+  const { resolveImageUrl } = useAssetPersistence(graph?.root ?? null, graph?.generation ?? null)
+  const onWikilinkClick = useCallback<WikilinkClickHandler>(
+    ({ target }) => navigateWikiLink(target),
+    [navigateWikiLink],
+  )
+  const resolveImageUrlStable = useCallback(
+    (src: string) => resolveImageUrl(src) ?? undefined,
+    [resolveImageUrl],
+  )
+
+  return { openSource, onWikilinkClick, resolveImageUrl: resolveImageUrlStable }
+}

--- a/apps/desktop/src/hooks/use-backlink-sources.ts
+++ b/apps/desktop/src/hooks/use-backlink-sources.ts
@@ -1,0 +1,43 @@
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { getBacklinksWithContext, hasBridge } from '@reflect/core'
+import { groupBacklinksBySource, type BacklinkSource } from '@/lib/group-backlinks'
+import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
+import { useGraph } from '@/providers/graph-provider'
+
+/** What a backlinks surface needs to render: grouped rows plus the states. */
+export interface BacklinkSources {
+  /** Inbound references grouped by source note, in the query's title order. */
+  groups: BacklinkSource[]
+  /** Total inbound references (the "(N)" in the section header). */
+  count: number
+  /** True while the first load is in flight (`groups` is empty then). */
+  isLoading: boolean
+  /**
+   * True when the index query failed. This is the only backlinks source, so a
+   * failure means the index is broken, not that the note is unlinked — render
+   * it loudly, never as an empty section.
+   */
+  isError: boolean
+}
+
+/**
+ * The incoming-backlinks data layer, shared by the desktop panel and the
+ * mobile section: one indexed query per visible note, kept fresh by the index
+ * invalidation hook (no polling), grouped by source note. The graph root is
+ * part of the key: index rows belong to one graph, and a graph switch must
+ * never serve the previous graph's cached rows (the cache outlives the
+ * workspace remount; invalidation alone lags the reconcile).
+ *
+ * @param path graph-relative path of the note whose inbound links to load.
+ */
+export function useBacklinkSources(path: string): BacklinkSources {
+  const { graph } = useGraph()
+  const { data, isPending, isError } = useQuery({
+    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'backlinks', path],
+    queryFn: () => getBacklinksWithContext(path),
+    enabled: hasBridge() && graph !== null,
+  })
+  const groups = useMemo(() => (data ? groupBacklinksBySource(data) : []), [data])
+  return { groups, count: data?.length ?? 0, isLoading: isPending, isError }
+}

--- a/apps/desktop/src/hooks/use-backlinks-expanded.ts
+++ b/apps/desktop/src/hooks/use-backlinks-expanded.ts
@@ -1,0 +1,15 @@
+import { useSessionFlag } from '@/lib/use-session-flag'
+
+/** Session-wide (all notes) expanded state, old Reflect's `backlinks-expanded`. */
+const EXPANDED_STORAGE_KEY = 'reflect.backlinks-expanded'
+
+/**
+ * The incoming-backlinks section's expanded state: one flag for the whole
+ * session, shared live across every mounted surface — the desktop daily
+ * stream shows one panel per day (and the mobile carousel one per mounted
+ * slide), and the header toggle must move them together, not just the
+ * instance that was tapped.
+ */
+export function useBacklinksExpanded(): [boolean, (next: boolean) => void] {
+  return useSessionFlag(EXPANDED_STORAGE_KEY, true)
+}

--- a/apps/desktop/src/mobile/day-slide.tsx
+++ b/apps/desktop/src/mobile/day-slide.tsx
@@ -3,6 +3,7 @@ import { dailyPath } from '@reflect/core'
 import { NotePane } from '@/components/note-pane'
 import { formatDayLabel } from '@/lib/dates'
 import { cn } from '@/lib/utils'
+import { IncomingBacklinks } from '@/mobile/incoming-backlinks'
 import { useScrollRestore } from '@/mobile/use-scroll-restore'
 import { useSettings } from '@/providers/settings-provider'
 
@@ -83,9 +84,14 @@ export function DaySlide({
         <NotePane
           path={dailyPath(day)}
           lazy
+          showBacklinks={false}
           gutterClassName="px-4"
           editorClassName="min-h-[60dvh]"
         />
+        {/* The mobile section (touch chrome) replaces NotePane's built-in
+            desktop panel; a daily-note backlink swipes the carousel to that
+            date rather than pushing a screen. */}
+        <IncomingBacklinks path={dailyPath(day)} className="px-4 pb-4" />
       </div>
     </div>
   )

--- a/apps/desktop/src/mobile/incoming-backlink-group.tsx
+++ b/apps/desktop/src/mobile/incoming-backlink-group.tsx
@@ -1,0 +1,99 @@
+import { useState, type ReactElement } from 'react'
+import { ChevronRight } from 'lucide-react'
+import type { WikilinkClickHandler } from '@meowdown/core'
+import { BacklinkSnippet } from '@/components/backlink-snippet'
+import type { BacklinkSource } from '@/lib/group-backlinks'
+import { cn } from '@/lib/utils'
+
+interface IncomingBacklinkGroupProps {
+  source: BacklinkSource
+  /** The first group renders without the leading hairline divider. */
+  first: boolean
+  /**
+   * Section-level toggle. Each change resets the group's own state, which the
+   * group chevron can then override until the next section toggle.
+   */
+  expanded: boolean
+  /** Open the source note (the section wires this to the router). */
+  onOpen: (path: string) => void
+  /** Navigate a clicked `[[wiki link]]` inside a snippet to its target. */
+  onWikilinkClick: WikilinkClickHandler
+  /** Resolve `![…](…)` sources inside a snippet to displayable URLs. */
+  resolveImageUrl: (src: string) => string | undefined
+}
+
+/**
+ * One referencing note in the mobile incoming-backlinks section: an
+ * accent-colored title that opens the note, the linking lines beneath as
+ * selectable text, and an always-visible chevron on the row's trailing edge
+ * that toggles just this group — desktop reveals it on hover, which doesn't
+ * exist on touch, and both the title and the chevron are full-height (44px)
+ * touch targets. The group chevron deliberately overrides the section-level
+ * toggle (old Reflect's behavior): collapsing the section collapses every
+ * group, after which one source can be peeked at without re-expanding the
+ * rest. Groups are separated by hairline rules rather than boxed rows.
+ */
+export function IncomingBacklinkGroup({
+  source,
+  first,
+  expanded: expandedOverride,
+  onOpen,
+  onWikilinkClick,
+  resolveImageUrl,
+}: IncomingBacklinkGroupProps): ReactElement {
+  const [expanded, setExpanded] = useState(expandedOverride)
+
+  // Reset to the section-level toggle whenever it changes; the group chevron
+  // can then locally override again until the next section toggle. Adjusting
+  // state during render (React applies it before paint, no wasted re-render)
+  // is the recommended alternative to a prop-syncing effect.
+  const [appliedOverride, setAppliedOverride] = useState(expandedOverride)
+  if (appliedOverride !== expandedOverride) {
+    setAppliedOverride(expandedOverride)
+    setExpanded(expandedOverride)
+  }
+
+  return (
+    <div>
+      {first ? null : <div className="border-t border-border" />}
+
+      <div className="flex items-center">
+        <button
+          type="button"
+          onClick={() => onOpen(source.path)}
+          className="flex min-h-11 min-w-0 flex-1 items-center text-left text-sm text-accent"
+        >
+          <span className="truncate">{source.title}</span>
+        </button>
+
+        {source.snippets.length > 0 ? (
+          <button
+            type="button"
+            aria-expanded={expanded}
+            aria-label={`${expanded ? 'Collapse' : 'Expand'} references from ${source.title}`}
+            onClick={() => setExpanded(!expanded)}
+            className="flex size-11 shrink-0 items-center justify-center text-text-muted"
+          >
+            <ChevronRight
+              aria-hidden
+              className={cn('size-4 transition-transform', expanded && 'rotate-90')}
+            />
+          </button>
+        ) : null}
+      </div>
+
+      {expanded ? (
+        <div className="space-y-1.5 pb-3">
+          {source.snippets.map((snippet) => (
+            <BacklinkSnippet
+              key={snippet.key}
+              text={snippet.text}
+              onWikilinkClick={onWikilinkClick}
+              resolveImageUrl={resolveImageUrl}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/desktop/src/mobile/incoming-backlinks.test.tsx
+++ b/apps/desktop/src/mobile/incoming-backlinks.test.tsx
@@ -1,0 +1,221 @@
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import { RouterProvider, useRouter } from '@/routing/router'
+import { IncomingBacklinks } from './incoming-backlinks'
+
+const getBacklinksWithContext = vi.hoisted(() => vi.fn())
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  hasBridge: () => true,
+  getBacklinksWithContext,
+}))
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({ graph: { root: '/g', name: 'g', generation: 1 } }),
+}))
+
+function RouteProbe(): ReactNode {
+  const { route, arrivalFocusEditor } = useRouter()
+  return (
+    <output data-testid="route" data-focus={String(arrivalFocusEditor)}>
+      {JSON.stringify(route)}
+    </output>
+  )
+}
+
+function renderSection(path: string) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <RouterProvider>
+        <IncomingBacklinks path={path} />
+        <RouteProbe />
+      </RouterProvider>
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  window.sessionStorage.clear()
+  getBacklinksWithContext.mockReset()
+})
+
+describe('IncomingBacklinks', () => {
+  it('renders nothing when the note has no inbound links (no empty chrome)', async () => {
+    getBacklinksWithContext.mockResolvedValue([])
+    const view = renderSection('daily/2026-07-02.md')
+    await waitFor(() => expect(getBacklinksWithContext).toHaveBeenCalled())
+    expect(view.queryByText(/Incoming backlink/)).toBeNull()
+    view.unmount()
+  })
+
+  it('surfaces a failed query as an alert instead of rendering nothing', async () => {
+    getBacklinksWithContext.mockRejectedValue(new Error('index unavailable'))
+    const view = renderSection('daily/2026-07-02.md')
+    const alert = await view.findByRole('alert')
+    expect(alert.textContent).toContain('Couldn’t load backlinks.')
+    view.unmount()
+  })
+
+  it('groups references by source note under a counted header', async () => {
+    getBacklinksWithContext.mockResolvedValue([
+      {
+        sourcePath: 'notes/meeting.md',
+        sourceTitle: 'Meeting Notes',
+        snippet: 'discussed [[2026-07-02]] follow-ups',
+        posFrom: 12,
+      },
+      {
+        sourcePath: 'notes/meeting.md',
+        sourceTitle: 'Meeting Notes',
+        snippet: 'revisit on [[2026-07-02]]',
+        posFrom: 80,
+      },
+      {
+        sourcePath: 'notes/planning.md',
+        sourceTitle: 'Planning',
+        snippet: 'ship by [[2026-07-02]]',
+        posFrom: 3,
+      },
+    ])
+    const view = renderSection('daily/2026-07-02.md')
+
+    await view.findByText('Incoming backlinks (3)')
+    expect(view.getAllByText('Meeting Notes')).toHaveLength(1)
+    expect(view.getByText(/discussed/)).toBeDefined()
+    expect(view.getByText(/revisit on/)).toBeDefined()
+    expect(view.getByText(/ship by/)).toBeDefined()
+    view.unmount()
+  })
+
+  it('navigates a daily-note source to the daily route (the carousel follows it)', async () => {
+    getBacklinksWithContext.mockResolvedValue([
+      {
+        sourcePath: 'daily/2026-06-01.md',
+        sourceTitle: 'June 1st, 2026',
+        snippet: 'planned [[Roadmap]] here',
+        posFrom: 4,
+      },
+    ])
+    const view = renderSection('notes/roadmap.md')
+
+    await userEvent.click(await view.findByText('June 1st, 2026'))
+    expect(view.getByTestId('route').textContent).toContain('"kind":"daily"')
+    expect(view.getByTestId('route').textContent).toContain('2026-06-01')
+    // The daily surface stays mounted and swipes; no editor focus is raised.
+    expect(view.getByTestId('route').getAttribute('data-focus')).toBe('false')
+    view.unmount()
+  })
+
+  it('navigates an ordinary source to the note route with the focus intent', async () => {
+    getBacklinksWithContext.mockResolvedValue([
+      {
+        sourcePath: 'notes/meeting.md',
+        sourceTitle: 'Meeting Notes',
+        snippet: 'discussed [[2026-07-02]] follow-ups',
+        posFrom: 12,
+      },
+    ])
+    const view = renderSection('daily/2026-07-02.md')
+
+    await userEvent.click(await view.findByText('Meeting Notes'))
+    expect(view.getByTestId('route').textContent).toContain('notes/meeting.md')
+    // A backlink tap restores focus on the destination note (the mobile
+    // focus contract) — the arrival carries the router's focusEditor intent.
+    expect(view.getByTestId('route').getAttribute('data-focus')).toBe('true')
+    view.unmount()
+  })
+
+  it('collapses snippets but keeps source titles on header toggle, for the session', async () => {
+    getBacklinksWithContext.mockResolvedValue([
+      {
+        sourcePath: 'notes/meeting.md',
+        sourceTitle: 'Meeting Notes',
+        snippet: 'discussed [[2026-07-02]] follow-ups',
+        posFrom: 12,
+      },
+    ])
+    const view = renderSection('daily/2026-07-02.md')
+
+    const header = await view.findByRole('button', { name: /Incoming backlink \(1\)/ })
+    expect(header.getAttribute('aria-expanded')).toBe('true')
+
+    await userEvent.click(header)
+    expect(header.getAttribute('aria-expanded')).toBe('false')
+    expect(view.getByText('Meeting Notes')).toBeDefined()
+    expect(view.queryByText(/discussed/)).toBeNull()
+    view.unmount()
+
+    const reopened = renderSection('daily/2026-07-02.md')
+    const persistedHeader = await reopened.findByRole('button', {
+      name: /Incoming backlink \(1\)/,
+    })
+    expect(persistedHeader.getAttribute('aria-expanded')).toBe('false')
+    reopened.unmount()
+  })
+
+  it('shares the toggle with the desktop panel key across mounted sections', async () => {
+    getBacklinksWithContext.mockResolvedValue([
+      {
+        sourcePath: 'notes/meeting.md',
+        sourceTitle: 'Meeting Notes',
+        snippet: 'discussed follow-ups',
+        posFrom: 12,
+      },
+    ])
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const view = render(
+      <QueryClientProvider client={client}>
+        <RouterProvider>
+          <IncomingBacklinks path="daily/2026-07-01.md" />
+          <IncomingBacklinks path="daily/2026-07-02.md" />
+        </RouterProvider>
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() =>
+      expect(view.getAllByRole('button', { name: /Incoming backlink \(1\)/ })).toHaveLength(2),
+    )
+    const headers = view.getAllByRole('button', { name: /Incoming backlink \(1\)/ })
+
+    await userEvent.click(headers[0]!)
+    expect(headers[0]!.getAttribute('aria-expanded')).toBe('false')
+    expect(headers[1]!.getAttribute('aria-expanded')).toBe('false')
+    view.unmount()
+  })
+
+  it('lets one group be peeked at via its always-visible chevron after a header collapse', async () => {
+    getBacklinksWithContext.mockResolvedValue([
+      {
+        sourcePath: 'notes/meeting.md',
+        sourceTitle: 'Meeting Notes',
+        snippet: 'discussed follow-ups',
+        posFrom: 12,
+      },
+      {
+        sourcePath: 'notes/planning.md',
+        sourceTitle: 'Planning',
+        snippet: 'ship the roadmap',
+        posFrom: 3,
+      },
+    ])
+    const view = renderSection('daily/2026-07-02.md')
+
+    const header = await view.findByRole('button', { name: /Incoming backlinks \(2\)/ })
+    await userEvent.click(header)
+    expect(view.queryByText(/discussed/)).toBeNull()
+    expect(view.queryByText(/ship the/)).toBeNull()
+
+    await userEvent.click(
+      view.getByRole('button', { name: 'Expand references from Meeting Notes' }),
+    )
+    expect(view.getByText(/discussed/)).toBeDefined()
+    expect(view.queryByText(/ship the/)).toBeNull()
+
+    await userEvent.click(header)
+    expect(view.getByText(/ship the/)).toBeDefined()
+    view.unmount()
+  })
+})

--- a/apps/desktop/src/mobile/incoming-backlinks.tsx
+++ b/apps/desktop/src/mobile/incoming-backlinks.tsx
@@ -1,0 +1,88 @@
+import { type ReactElement } from 'react'
+import { ChevronRight } from 'lucide-react'
+import { useBacklinkNavigation } from '@/hooks/use-backlink-navigation'
+import { useBacklinkSources } from '@/hooks/use-backlink-sources'
+import { useBacklinksExpanded } from '@/hooks/use-backlinks-expanded'
+import { IncomingBacklinkGroup } from '@/mobile/incoming-backlink-group'
+import { cn } from '@/lib/utils'
+
+interface IncomingBacklinksProps {
+  /** Graph-relative path of the note whose inbound links to show. */
+  path: string
+  /** Extra classes for the section root (the host surface's gutter). */
+  className?: string
+}
+
+/**
+ * Incoming backlinks below a mobile note — the day slide and the note screen —
+ * over the same data layer as desktop's `BacklinksPanel` but with touch
+ * chrome: a full-width 44px header toggle and always-visible per-group
+ * chevrons instead of hover-revealed ones. The header collapses the linking
+ * lines while the source titles stay visible, shared live across every
+ * mounted surface and persisted for the session (V1 kept it in session
+ * storage too). Tapping a source that is a daily note swipes the day carousel
+ * to that date — the daily surface stays mounted and follows the route —
+ * while other sources open the note screen with the editor focused (the
+ * mobile focus contract). Renders nothing when the note has no inbound
+ * links; a failed query surfaces as an alert, because a failing query means
+ * the index is broken, not that the note is unlinked.
+ */
+export function IncomingBacklinks({ path, className }: IncomingBacklinksProps): ReactElement | null {
+  const { groups, count, isError } = useBacklinkSources(path)
+  const [expanded, setExpanded] = useBacklinksExpanded()
+  const { openSource, onWikilinkClick, resolveImageUrl } = useBacklinkNavigation()
+
+  if (isError) {
+    return (
+      <section aria-label="Incoming backlinks" className={cn('mt-6', className)}>
+        <p role="alert" className="text-sm text-text-muted">
+          Couldn’t load backlinks.
+        </p>
+      </section>
+    )
+  }
+
+  if (count === 0) {
+    return null
+  }
+
+  return (
+    <section aria-label="Incoming backlinks" className={cn('mt-6', className)}>
+      <h3 className="text-sm font-medium text-text-muted">
+        <button
+          type="button"
+          aria-expanded={expanded}
+          onClick={() => setExpanded(!expanded)}
+          className="flex min-h-11 w-full items-center gap-2 text-left"
+        >
+          <ChevronRight
+            aria-hidden
+            className={cn('size-4 shrink-0 transition-transform', expanded && 'rotate-90')}
+          />
+          <span>
+            Incoming backlink{count === 1 ? '' : 's'} ({count})
+          </span>
+        </button>
+      </h3>
+
+      {/* pl-6 = the header's 16px chevron + 8px gap, so group titles line up
+          with the header label. */}
+      <div className="pl-6">
+        {groups.map((group, index) => (
+          <IncomingBacklinkGroup
+            // Scoped to the open note: a source shared by two notes must not
+            // carry its peeked or collapsed state from one note's section to
+            // the other's.
+            key={`${path}:${group.path}`}
+            source={group}
+            first={index === 0}
+            expanded={expanded}
+            onOpen={openSource}
+            onWikilinkClick={onWikilinkClick}
+            resolveImageUrl={resolveImageUrl}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/apps/desktop/src/mobile/screens/note.test.tsx
+++ b/apps/desktop/src/mobile/screens/note.test.tsx
@@ -18,6 +18,12 @@ vi.mock('@/mobile/note-actions-menu', () => ({
   NoteActionsMenu: () => null,
 }))
 
+// The backlinks section has its own suite (incoming-backlinks.test.tsx) and
+// needs the query/graph providers this focus-contract harness doesn't mount.
+vi.mock('@/mobile/incoming-backlinks', () => ({
+  IncomingBacklinks: () => null,
+}))
+
 /**
  * Navigates to the note once (a real arrival, so the router's focus intent
  * is set exactly as a wiki-link tap would) and renders the screen the way

--- a/apps/desktop/src/mobile/screens/note.tsx
+++ b/apps/desktop/src/mobile/screens/note.tsx
@@ -3,6 +3,7 @@ import { isUntitledNotePath } from '@reflect/core'
 import { ChevronLeft } from 'lucide-react'
 import { NotePane } from '@/components/note-pane'
 import { Button } from '@/components/ui/button'
+import { IncomingBacklinks } from '@/mobile/incoming-backlinks'
 import { NoteActionsMenu } from '@/mobile/note-actions-menu'
 import { useRouter } from '@/routing/router'
 
@@ -56,9 +57,14 @@ export function MobileNote({ path }: { path: string }): ReactElement {
           path={path}
           lazy
           autoFocus={untitled || focusRequested}
+          showBacklinks={false}
           gutterClassName="px-4"
           editorClassName="min-h-[60dvh]"
         />
+        {/* The mobile section (touch chrome) replaces NotePane's built-in
+            desktop panel; a daily-note backlink opens the Daily surface at
+            that date rather than pushing another note screen. */}
+        <IncomingBacklinks path={path} className="px-4 pb-4" />
       </main>
     </div>
   )


### PR DESCRIPTION
## Problem

The one open item from the Daily parity checklist ([daily-notes.md](docs/porting/reflect-mobile/daily-notes.md), deferred from #475): V1 mobile renders a collapsible "Incoming backlinks (N)" section below the note, grouped by source note, with session-persisted expansion — and a backlink to a daily note swipes the day carousel to that date instead of pushing a screen.

V2 mobile technically showed backlinks already, but only because `NotePane` embeds the desktop `BacklinksPanel`: its per-group chevrons are hover-revealed (`group-hover:opacity-100` — invisible on touch) and its tap targets are pointer-sized.

## Changes

**Shared data layer** (extracted from `BacklinksPanel`, no behavior change — its test suite passes untouched):
- `hooks/use-backlink-sources.ts` — the indexed `getBacklinksWithContext` query (graph-root-scoped key, index-invalidation freshness) + `groupBacklinksBySource`.
- `hooks/use-backlink-navigation.ts` — source-open via `routeForPath` (+ `focusEditor` intent for note targets), snippet wiki-link clicks, and snippet image resolution through the editor's pipelines.
- `hooks/use-backlinks-expanded.ts` — the session-wide `reflect.backlinks-expanded` flag (V1 kept this in session storage too), shared live across mounted surfaces.

**Mobile section (touch chrome):**
- `mobile/incoming-backlinks.tsx` — collapsible "Incoming backlinks (N)" header (full-width, 44px), renders nothing when the note has no inbound links, fails loud (alert) on a broken index query.
- `mobile/incoming-backlink-group.tsx` — source title + always-visible 44px chevron; the group toggle overrides the section toggle for per-source peeking (desktop/V1 semantics). Snippets reuse `BacklinkSnippet` (rich `MarkdownView` lines).

**Wiring:**
- `NotePane` gains a `showBacklinks` opt-out (default `true`; desktop unchanged). The day slide and mobile note screen pass `false` and mount `IncomingBacklinks` below the editor.
- Daily-note backlinks navigate `{kind:'daily', date}` — the daily surface is mounted once (`key="daily"`), so the carousel scrolls (or re-anchors its window for far dates) rather than a screen push. Other sources open the note screen with the router's `focusEditor` arrival intent.

No virtualization: backlink lists are small in practice and desktop doesn't virtualize either — the simplest thing matching V1's presentation.

The note screen is included: #477 merged before this started, and this branch is rebased on `next` past #481.

## Testing

- New `mobile/incoming-backlinks.test.tsx` (8 tests): empty → no chrome, error → alert, grouping + count header, daily target → daily route without focus intent, note target → note route with focus intent, header collapse persisted for the session, cross-mounted-section sync, per-group peek.
- `backlinks-panel.test.tsx` (desktop, 10 tests) passes unchanged after the extraction.
- Full `src/mobile` + `route-content` suites: 133 passed. `pnpm check` clean (only pre-existing react-hook-form compiler warnings in untouched files).
- Not covered: an on-device pass (simulator/manual) of the touch targets and carousel swipe-on-tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI refactor plus shared hooks with existing query/navigation paths; desktop backlinks covered by unchanged tests, main risk is mobile interaction edge cases not exercised on device.
> 
> **Overview**
> Adds a proper **mobile incoming-backlinks** section (day carousel + note screen) and pulls desktop/mobile onto the **same data and navigation layer**.
> 
> **Refactor:** `BacklinksPanel` now delegates to `useBacklinkSources` (indexed query + grouping), `useBacklinkNavigation` (open source, snippet wikilinks, images), and `useBacklinksExpanded` (session `reflect.backlinks-expanded`). Desktop presentation stays on `BacklinkSourceGroup`; behavior is intended unchanged.
> 
> **Mobile:** New `IncomingBacklinks` / `IncomingBacklinkGroup` use **44px touch targets** and **always-visible** per-group chevrons (replacing hover-only desktop chrome). Section collapse still hides snippets but keeps source titles; per-group peek matches V1/desktop semantics. `NotePane` gains **`showBacklinks`** (default `true`); mobile sets `false` and mounts `IncomingBacklinks` below the editor.
> 
> **Navigation:** Tapping a daily source routes to `{ kind: 'daily' }` (carousel follows, no `focusEditor`); other sources open the note with **`focusEditor`** for the mobile focus contract.
> 
> **Tests:** New `incoming-backlinks.test.tsx`; `note.test.tsx` mocks the section to keep the focus harness lean.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6167a03dfb4ea86bd797fcb45e1f86b9386955ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Incoming backlinks” section on mobile note and daily views, with expandable backlink groups and snippet previews.
  * Backlinks can now be opened from the mobile UI, and linked images/snippets render consistently.

* **Bug Fixes**
  * Notes with no backlinks now hide the backlinks area entirely.
  * Backlink loading failures continue to show a clear error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->