### PR TITLE
feat: auto-resolve daily-note append/append sync conflicts

### DIFF
--- a/apps/desktop/src-tauri/src/git/daily_merge.rs
+++ b/apps/desktop/src-tauri/src/git/daily_merge.rs
@@ -56,7 +56,8 @@ pub(super) fn merge_appends(base: &str, ours: &str, theirs: &str) -> Option<Stri
         return None;
     }
 
-    let mut merged = String::with_capacity(base.len() + ours_suffix.len() + theirs_suffix.len() + 1);
+    let mut merged =
+        String::with_capacity(base.len() + ours_suffix.len() + theirs_suffix.len() + 1);
     merged.push_str(base);
     merged.push_str(ours_suffix);
     let Some(mut theirs_kept) = dedup_against(theirs_suffix, ours_suffix) else {

--- a/apps/desktop/src-tauri/src/git/daily_merge.rs
+++ b/apps/desktop/src-tauri/src/git/daily_merge.rs
@@ -1,0 +1,308 @@
+//! Append/append auto-merge for daily notes — the one content conflict safe
+//! to resolve without review.
+//!
+//! Two devices appending to the same day's note (the canonical mobile
+//! collision: phone and Mac both capture into today while the phone was
+//! offline) produce a git conflict even though neither side touched what the
+//! other wrote. When the merge base is an untouched, line-bounded prefix of
+//! **both** sides, keeping the base plus both appended suffixes loses nothing
+//! — so [`merge_appends`] resolves it instead of parking the note behind
+//! conflict markers.
+//!
+//! Anything that is not this exact shape returns `None` and keeps the marker
+//! flow: an edit inside the base region, a frontmatter change (frontmatter
+//! lives at the top, so touching it always breaks the prefix; a side
+//! *introducing* frontmatter over an empty base is rejected explicitly),
+//! non-daily paths (the caller gates on [`is_daily_note_path`]), deletions,
+//! and binary or non-UTF-8 content (also the caller's gate). A false-positive
+//! auto-merge that loses or reorders user text is strictly worse than a
+//! parked note.
+
+use std::collections::HashSet;
+
+/// Whether a graph-relative path is a daily note (`daily/YYYY-MM-DD.md`).
+/// Shape-only, like `dateFromDailyPath` on the TS side — no calendar
+/// validation.
+pub(super) fn is_daily_note_path(path: &str) -> bool {
+    let Some(date) = path
+        .strip_prefix("daily/")
+        .and_then(|rest| rest.strip_suffix(".md"))
+    else {
+        return false;
+    };
+    date.len() == 10
+        && date.bytes().enumerate().all(|(index, byte)| match index {
+            4 | 7 => byte == b'-',
+            _ => byte.is_ascii_digit(),
+        })
+}
+
+/// Merge two pure appends onto a shared base: `base` + ours' suffix + theirs'
+/// suffix, in that fixed order (this device's entries first — the same
+/// local-first order the conflict markers use, and deterministic because only
+/// one device performs the merge; the other fast-forwards onto its result).
+///
+/// Returns `None` unless `base` is an untouched, line-bounded prefix of both
+/// sides. Suffix lines theirs shares verbatim with ours (the same capture
+/// arriving from both devices) are kept once — the whole-line,
+/// trailing-`\r`-insensitive rule the capture drain's presence guard uses.
+pub(super) fn merge_appends(base: &str, ours: &str, theirs: &str) -> Option<String> {
+    let ours_suffix = appended_suffix(base, ours)?;
+    let theirs_suffix = appended_suffix(base, theirs)?;
+    if base.is_empty() && (starts_with_frontmatter(ours) || starts_with_frontmatter(theirs)) {
+        // Both sides created the note independently and at least one opened
+        // with frontmatter: concatenating would bury a `---` block mid-file.
+        // This driver is body-only — park it for review.
+        return None;
+    }
+
+    let mut merged = String::with_capacity(base.len() + ours_suffix.len() + theirs_suffix.len() + 1);
+    merged.push_str(base);
+    merged.push_str(ours_suffix);
+    let Some(mut theirs_kept) = dedup_against(theirs_suffix, ours_suffix) else {
+        return Some(merged);
+    };
+    if !base.is_empty() && !base.ends_with('\n') && merged.ends_with('\n') {
+        // The base ended mid-line, so theirs' suffix opens with the newline
+        // that terminated it — ours' suffix already supplied one. Dropping
+        // the redundant terminator reproduces theirs' own line structure
+        // instead of inserting a blank line.
+        if let Some(rest) = theirs_kept
+            .strip_prefix("\r\n")
+            .or_else(|| theirs_kept.strip_prefix('\n'))
+        {
+            theirs_kept = rest.to_string();
+        }
+    }
+    if !merged.is_empty() && !merged.ends_with('\n') && !starts_on_new_line(&theirs_kept) {
+        // Ours ended mid-line; without a separator theirs' first line would
+        // fuse onto it.
+        merged.push('\n');
+    }
+    merged.push_str(&theirs_kept);
+    Some(merged)
+}
+
+/// The bytes `side` appended after `base`, or `None` when `side` is not a
+/// pure append. Byte-prefix alone is not enough: `"abc"` → `"abcdef"` keeps
+/// the base as a prefix but rewrites its final line, so a non-empty suffix
+/// must start at a line boundary — either the base ended with a newline or
+/// the suffix begins with one.
+fn appended_suffix<'side>(base: &str, side: &'side str) -> Option<&'side str> {
+    let suffix = side.strip_prefix(base)?;
+    if suffix.is_empty() || base.is_empty() || base.ends_with('\n') || starts_on_new_line(suffix) {
+        Some(suffix)
+    } else {
+        None
+    }
+}
+
+fn starts_on_new_line(text: &str) -> bool {
+    text.starts_with('\n') || text.starts_with("\r\n")
+}
+
+fn starts_with_frontmatter(source: &str) -> bool {
+    source.starts_with("---\n") || source.starts_with("---\r\n")
+}
+
+/// Strip a line's terminator and any trailing `\r`, the capture drain's
+/// comparison key (a CRLF daily dedupes like an LF one).
+fn line_key(line: &str) -> &str {
+    line.trim_end_matches('\n').trim_end_matches('\r')
+}
+
+/// Drop theirs-suffix lines whose exact content already appears in ours'
+/// suffix. Only lines with content participate — blank lines are structure,
+/// not entries. Returns `None` when nothing with content remains (identical
+/// appends collapse to one copy).
+fn dedup_against(theirs: &str, ours: &str) -> Option<String> {
+    let ours_lines: HashSet<&str> = ours
+        .split('\n')
+        .map(|line| line.trim_end_matches('\r'))
+        .filter(|line| !line.trim().is_empty())
+        .collect();
+    let mut kept = String::with_capacity(theirs.len());
+    let mut has_content = false;
+    for line in theirs.split_inclusive('\n') {
+        let key = line_key(line);
+        let blank = key.trim().is_empty();
+        if !blank && ours_lines.contains(key) {
+            continue;
+        }
+        if !blank {
+            has_content = true;
+        }
+        kept.push_str(line);
+    }
+    has_content.then_some(kept)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_daily_note_path, merge_appends};
+
+    #[test]
+    fn recognizes_daily_note_paths() {
+        assert!(is_daily_note_path("daily/2026-07-02.md"));
+        assert!(!is_daily_note_path("daily/2026-7-2.md"));
+        assert!(!is_daily_note_path("daily/2026-07-02.txt"));
+        assert!(!is_daily_note_path("notes/2026-07-02.md"));
+        assert!(!is_daily_note_path("daily/nested/2026-07-02.md"));
+        assert!(!is_daily_note_path("daily/someday.md"));
+    }
+
+    #[test]
+    fn merges_disjoint_appends_ours_first() {
+        let base = "# Daily\n\n- morning note\n";
+        let ours = "# Daily\n\n- morning note\n- from the mac\n";
+        let theirs = "# Daily\n\n- morning note\n- from the phone\n";
+        assert_eq!(
+            merge_appends(base, ours, theirs).as_deref(),
+            Some("# Daily\n\n- morning note\n- from the mac\n- from the phone\n"),
+        );
+    }
+
+    #[test]
+    fn identical_appends_collapse_to_one_copy() {
+        let base = "- existing\n";
+        let ours = "- existing\n- same capture\n";
+        assert_eq!(
+            merge_appends(base, ours, ours).as_deref(),
+            Some("- existing\n- same capture\n"),
+        );
+    }
+
+    #[test]
+    fn shared_capture_lines_are_not_doubled() {
+        let base = "- existing\n";
+        let ours = "- existing\n- same capture\n- only on mac\n";
+        let theirs = "- existing\n- same capture\n- only on phone\n";
+        assert_eq!(
+            merge_appends(base, ours, theirs).as_deref(),
+            Some("- existing\n- same capture\n- only on mac\n- only on phone\n"),
+        );
+    }
+
+    #[test]
+    fn crlf_lines_dedupe_against_lf_ones() {
+        let base = "- existing\n";
+        let ours = "- existing\n- same capture\n";
+        let theirs = "- existing\n- same capture\r\n- only on phone\r\n";
+        assert_eq!(
+            merge_appends(base, ours, theirs).as_deref(),
+            Some("- existing\n- same capture\n- only on phone\r\n"),
+        );
+    }
+
+    #[test]
+    fn duplicates_of_base_lines_are_kept() {
+        // The drain never appends a line already in the note, so a suffix
+        // repeating a base line was typed deliberately — keep it.
+        let base = "- existing\n";
+        let ours = "- existing\n- existing\n";
+        let theirs = "- existing\n- from the phone\n";
+        assert_eq!(
+            merge_appends(base, ours, theirs).as_deref(),
+            Some("- existing\n- existing\n- from the phone\n"),
+        );
+    }
+
+    #[test]
+    fn edit_inside_the_base_region_is_not_an_append() {
+        let base = "# Daily\n\n- original\n";
+        let edited = "# Daily\n\n- rewritten\n- extra\n";
+        let appended = "# Daily\n\n- original\n- extra\n";
+        assert_eq!(merge_appends(base, edited, appended), None);
+        assert_eq!(merge_appends(base, appended, edited), None);
+    }
+
+    #[test]
+    fn extending_the_base_final_line_is_not_an_append() {
+        // Byte-prefix holds but the last line changed ("- note" → "- note and
+        // more") — that is an edit, not an append.
+        let base = "- note";
+        let extended = "- note and more\n";
+        let appended = "- note\n- new line\n";
+        assert_eq!(merge_appends(base, extended, appended), None);
+        assert_eq!(
+            merge_appends(base, appended, "- note\n- other\n").as_deref(),
+            Some("- note\n- new line\n- other\n"),
+        );
+    }
+
+    #[test]
+    fn frontmatter_change_breaks_the_prefix_and_parks() {
+        let base = "---\npinned: false\n---\n\n- note\n";
+        let frontmatter_touched = "---\npinned: true\n---\n\n- note\n- extra\n";
+        let appended = "---\npinned: false\n---\n\n- note\n- extra\n";
+        assert_eq!(merge_appends(base, frontmatter_touched, appended), None);
+        assert_eq!(merge_appends(base, appended, frontmatter_touched), None);
+    }
+
+    #[test]
+    fn unchanged_frontmatter_inside_the_base_merges() {
+        let base = "---\npinned: true\n---\n\n- note\n";
+        let ours = "---\npinned: true\n---\n\n- note\n- from mac\n";
+        let theirs = "---\npinned: true\n---\n\n- note\n- from phone\n";
+        assert_eq!(
+            merge_appends(base, ours, theirs).as_deref(),
+            Some("---\npinned: true\n---\n\n- note\n- from mac\n- from phone\n"),
+        );
+    }
+
+    #[test]
+    fn empty_base_concatenates_both_creations() {
+        assert_eq!(
+            merge_appends("", "- from mac\n", "- from phone\n").as_deref(),
+            Some("- from mac\n- from phone\n"),
+        );
+    }
+
+    #[test]
+    fn empty_base_with_frontmatter_on_either_side_parks() {
+        let with_frontmatter = "---\npinned: true\n---\n\n- note\n";
+        assert_eq!(merge_appends("", with_frontmatter, "- plain\n"), None);
+        assert_eq!(merge_appends("", "- plain\n", with_frontmatter), None);
+    }
+
+    #[test]
+    fn unterminated_base_accepts_newline_led_suffixes() {
+        let base = "- note";
+        let ours = "- note\n- from mac\n";
+        let theirs = "- note\n- from phone\n";
+        assert_eq!(
+            merge_appends(base, ours, theirs).as_deref(),
+            Some("- note\n- from mac\n- from phone\n"),
+        );
+    }
+
+    #[test]
+    fn unterminated_ours_suffix_gets_a_separator_before_theirs() {
+        let base = "- note\n";
+        let ours = "- note\n- from mac";
+        let theirs = "- note\n- from phone\n";
+        assert_eq!(
+            merge_appends(base, ours, theirs).as_deref(),
+            Some("- note\n- from mac\n- from phone\n"),
+        );
+    }
+
+    #[test]
+    fn one_side_identical_to_base_yields_the_other() {
+        let base = "- note\n";
+        let theirs = "- note\n- from phone\n";
+        assert_eq!(merge_appends(base, base, theirs).as_deref(), Some(theirs));
+        assert_eq!(merge_appends(base, theirs, base).as_deref(), Some(theirs));
+    }
+
+    #[test]
+    fn whitespace_only_lines_are_never_deduped() {
+        let base = "- note\n";
+        let ours = "- note\n\n- from mac\n";
+        let theirs = "- note\n\n- from phone\n";
+        assert_eq!(
+            merge_appends(base, ours, theirs).as_deref(),
+            Some("- note\n\n- from mac\n\n- from phone\n"),
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/git/merge.rs
+++ b/apps/desktop/src-tauri/src/git/merge.rs
@@ -3,6 +3,10 @@
 //! Git markers with readable labels), commit the merge anyway, and let the
 //! user resolve by editing the file.
 //!
+//! One narrow exception skips the markers entirely: a **daily note both sides
+//! purely appended to** (the canonical two-device collision) auto-resolves to
+//! base + both suffixes — see [`daily_merge`].
+//!
 //! The repository is never left mid-merge: committing the conflict keeps sync
 //! flowing for every other note, both devices converge on the same marked-up
 //! file, and the raw versions stay recoverable from history (the merge commit
@@ -28,6 +32,7 @@ use serde::Serialize;
 
 use crate::error::AppResult;
 
+use super::daily_merge;
 use super::repo::{current_branch, ensure_clean_state, open_existing, signature};
 
 /// Conflict-marker labels. "this device" is the local side, "other device"
@@ -260,6 +265,8 @@ fn stamp_modified_times(root: &Path, changes: &mut [ChangedFile]) {
 
 /// Turn every index conflict into committed working-tree content:
 ///
+/// - **daily note, both sides pure appends** — auto-resolve to base plus both
+///   suffixes ([`daily_merge::merge_appends`]); the note is *not* conflicted;
 /// - **text vs text** — the merge checkout already wrote labeled markers into
 ///   the file; stage it as-is (the user resolves by editing the note);
 /// - **edit vs delete** — keep the edited version, never silently delete;
@@ -290,7 +297,14 @@ fn resolve_conflicts(repo: &Repository, root: &Path, index: &mut Index) -> AppRe
     for conflict in conflicts {
         match (conflict.our, conflict.their) {
             (Some(our), Some(their)) => {
-                conflicted_paths.extend(resolve_both_edited(repo, root, index, our, their)?);
+                conflicted_paths.extend(resolve_both_edited(
+                    repo,
+                    root,
+                    index,
+                    our,
+                    their,
+                    conflict.ancestor,
+                )?);
             }
             (Some(edited), None) | (None, Some(edited)) => {
                 conflicted_paths.push(resolve_edit_vs_delete(repo, root, index, edited)?);
@@ -305,19 +319,28 @@ fn resolve_conflicts(repo: &Repository, root: &Path, index: &mut Index) -> AppRe
     Ok(conflicted_paths)
 }
 
-/// Both sides changed the file. Text: the merge checkout already wrote the
-/// labeled marker file, so staging the working copy clears the conflict
-/// entries. Binary: markers would corrupt the bytes — keep ours in place and
-/// write the other device's version alongside (`name (conflict).ext`).
+/// Both sides changed the file. Text: try the daily append/append
+/// auto-resolve first; otherwise the merge checkout already wrote the labeled
+/// marker file, so staging the working copy clears the conflict entries.
+/// Binary: markers would corrupt the bytes — keep ours in place and write the
+/// other device's version alongside (`name (conflict).ext`).
 fn resolve_both_edited(
     repo: &Repository,
     root: &Path,
     index: &mut Index,
     our: ConflictSide,
     their: ConflictSide,
+    ancestor: Option<ConflictSide>,
 ) -> AppResult<Vec<String>> {
     let binary = repo.find_blob(our.id)?.is_binary() || repo.find_blob(their.id)?.is_binary();
     if !binary {
+        if let Some(merged) = daily_auto_merge(repo, &our, &their, ancestor.as_ref())? {
+            // Overwrite the marker file the merge checkout wrote and stage
+            // the resolution — a clean merge, nothing left to review.
+            fs::write(root.join(&our.path), merged)?;
+            index.add_path(Path::new(&our.path))?;
+            return Ok(Vec::new());
+        }
         index.add_path(Path::new(&our.path))?;
         return Ok(vec![our.path]);
     }
@@ -327,6 +350,47 @@ fn resolve_both_edited(
     index.add_path(Path::new(&our.path))?;
     index.add_path(Path::new(&copy))?;
     Ok(vec![our.path, copy])
+}
+
+/// The daily-note append/append auto-resolve, gated as narrowly as the shape
+/// allows: same daily path on every side, text that decodes as UTF-8, and a
+/// merge base (empty when both devices created the file) that both sides kept
+/// as an untouched prefix. Everything else returns `None` and takes the
+/// marker path — parking a note is recoverable, a wrong auto-merge is not.
+fn daily_auto_merge(
+    repo: &Repository,
+    our: &ConflictSide,
+    their: &ConflictSide,
+    ancestor: Option<&ConflictSide>,
+) -> AppResult<Option<String>> {
+    if our.path != their.path || !daily_merge::is_daily_note_path(&our.path) {
+        return Ok(None);
+    }
+    if ancestor.is_some_and(|side| side.path != our.path) {
+        return Ok(None);
+    }
+    let base = match ancestor {
+        Some(side) => match utf8_blob(repo, side.id)? {
+            Some(text) => text,
+            None => return Ok(None),
+        },
+        None => String::new(),
+    };
+    let Some(ours) = utf8_blob(repo, our.id)? else {
+        return Ok(None);
+    };
+    let Some(theirs) = utf8_blob(repo, their.id)? else {
+        return Ok(None);
+    };
+    Ok(daily_merge::merge_appends(&base, &ours, &theirs))
+}
+
+/// A blob's content as text, or `None` when it does not decode as UTF-8.
+fn utf8_blob(repo: &Repository, id: git2::Oid) -> AppResult<Option<String>> {
+    let blob = repo.find_blob(id)?;
+    Ok(std::str::from_utf8(blob.content())
+        .ok()
+        .map(str::to_string))
 }
 
 /// One side edited what the other deleted (either direction): restore and

--- a/apps/desktop/src-tauri/src/git/merge.rs
+++ b/apps/desktop/src-tauri/src/git/merge.rs
@@ -388,9 +388,7 @@ fn daily_auto_merge(
 /// A blob's content as text, or `None` when it does not decode as UTF-8.
 fn utf8_blob(repo: &Repository, id: git2::Oid) -> AppResult<Option<String>> {
     let blob = repo.find_blob(id)?;
-    Ok(std::str::from_utf8(blob.content())
-        .ok()
-        .map(str::to_string))
+    Ok(std::str::from_utf8(blob.content()).ok().map(str::to_string))
 }
 
 /// One side edited what the other deleted (either direction): restore and

--- a/apps/desktop/src-tauri/src/git/mod.rs
+++ b/apps/desktop/src-tauri/src/git/mod.rs
@@ -17,6 +17,7 @@
 
 mod commit;
 mod commit_message;
+mod daily_merge;
 mod merge;
 mod remote;
 mod repo;

--- a/apps/desktop/src-tauri/src/git/tests.rs
+++ b/apps/desktop/src-tauri/src/git/tests.rs
@@ -572,6 +572,255 @@ fn conflicting_edits_are_committed_with_labeled_markers() {
     assert_eq!(read(&root_b, "notes/shared.md"), content);
 }
 
+// ---- the daily append/append driver ------------------------------------------
+// The canonical mobile collision: phone and Mac both append to today's daily
+// note while the phone is offline. These run the engine's real cycle shape
+// (commit → fetch → merge → push) and pin that the trivially-safe case
+// auto-resolves — merged file, no markers, nothing for the indexer to park —
+// while everything adjacent still takes the marker path.
+
+#[test]
+fn daily_append_append_auto_merges_without_markers() {
+    let fixture = fixture();
+    let root_a = &fixture.graph_a;
+    write(root_a, "daily/2026-07-02.md", "# Daily\n\n- morning note\n");
+    commit_all(root_a, "base", MAX_FILE_BYTES).unwrap();
+    push(root_a, None).unwrap();
+
+    let root_b = second_device(&fixture);
+    write(
+        &root_b,
+        "daily/2026-07-02.md",
+        "# Daily\n\n- morning note\n- from the phone\n",
+    );
+    commit_all(&root_b, "b append", MAX_FILE_BYTES).unwrap();
+    push(&root_b, None).unwrap();
+
+    write(
+        root_a,
+        "daily/2026-07-02.md",
+        "# Daily\n\n- morning note\n- from the mac\n",
+    );
+    commit_all(root_a, "a append", MAX_FILE_BYTES).unwrap();
+    fetch(root_a, None).unwrap();
+    let merged = merge_remote(root_a).unwrap();
+
+    // A clean merge: not a conflict, nothing to review, nothing parked.
+    assert!(matches!(merged.kind, MergeKind::Merged), "{merged:?}");
+    assert!(merged.conflicted_paths.is_empty(), "{merged:?}");
+    let content = read(root_a, "daily/2026-07-02.md");
+    assert_eq!(
+        content,
+        "# Daily\n\n- morning note\n- from the mac\n- from the phone\n"
+    );
+    assert!(!content.contains("<<<<<<<"), "{content}");
+
+    // The merged file reaches the reindex path like any pull-applied write.
+    let change = merged
+        .changed_files
+        .iter()
+        .find(|change| change.path == "daily/2026-07-02.md")
+        .expect("the merged daily note is reported for reindexing");
+    assert!(change.modified_ms.is_some(), "{merged:?}");
+
+    // The resolution is a clean commit: repo not wedged, nothing dirty (the
+    // no-loop invariant — the next cycle finds nothing to commit), and the
+    // push converges the other device onto the same content.
+    let repo = Repository::open(root_a).unwrap();
+    assert_eq!(repo.state(), git2::RepositoryState::Clean);
+    drop(repo);
+    let noop = commit_all(root_a, "noop", MAX_FILE_BYTES).unwrap();
+    assert!(!noop.committed, "auto-merge left the working tree dirty");
+    assert!(push(root_a, None).unwrap().pushed);
+
+    fetch(&root_b, None).unwrap();
+    let converged = merge_remote(&root_b).unwrap();
+    assert!(
+        matches!(converged.kind, MergeKind::FastForward),
+        "{converged:?}"
+    );
+    assert_eq!(read(&root_b, "daily/2026-07-02.md"), content);
+}
+
+#[test]
+fn daily_append_of_the_same_capture_is_not_doubled() {
+    let fixture = fixture();
+    let root_a = &fixture.graph_a;
+    write(root_a, "daily/2026-07-02.md", "- existing\n");
+    commit_all(root_a, "base", MAX_FILE_BYTES).unwrap();
+    push(root_a, None).unwrap();
+
+    // The same capture drains on both devices (plus one device-local line
+    // each), e.g. the extension spooled it to both while they were online.
+    let root_b = second_device(&fixture);
+    write(
+        &root_b,
+        "daily/2026-07-02.md",
+        "- existing\n- shared capture\n- only on phone\n",
+    );
+    commit_all(&root_b, "b append", MAX_FILE_BYTES).unwrap();
+    push(&root_b, None).unwrap();
+
+    write(
+        root_a,
+        "daily/2026-07-02.md",
+        "- existing\n- shared capture\n- only on mac\n",
+    );
+    commit_all(root_a, "a append", MAX_FILE_BYTES).unwrap();
+    fetch(root_a, None).unwrap();
+    let merged = merge_remote(root_a).unwrap();
+
+    assert!(matches!(merged.kind, MergeKind::Merged), "{merged:?}");
+    assert_eq!(
+        read(root_a, "daily/2026-07-02.md"),
+        "- existing\n- shared capture\n- only on mac\n- only on phone\n"
+    );
+}
+
+#[test]
+fn daily_created_on_both_devices_concatenates() {
+    let fixture = fixture();
+    let root_a = &fixture.graph_a;
+    write(root_a, "notes/seed.md", "# Seed\n");
+    commit_all(root_a, "base", MAX_FILE_BYTES).unwrap();
+    push(root_a, None).unwrap();
+
+    // No merge base at all: today's note did not exist yet and both devices
+    // created it — the commonest real shape of the collision.
+    let root_b = second_device(&fixture);
+    write(&root_b, "daily/2026-07-02.md", "- from the phone\n");
+    commit_all(&root_b, "b creates", MAX_FILE_BYTES).unwrap();
+    push(&root_b, None).unwrap();
+
+    write(root_a, "daily/2026-07-02.md", "- from the mac\n");
+    commit_all(root_a, "a creates", MAX_FILE_BYTES).unwrap();
+    fetch(root_a, None).unwrap();
+    let merged = merge_remote(root_a).unwrap();
+
+    assert!(matches!(merged.kind, MergeKind::Merged), "{merged:?}");
+    assert!(merged.conflicted_paths.is_empty(), "{merged:?}");
+    assert_eq!(
+        read(root_a, "daily/2026-07-02.md"),
+        "- from the mac\n- from the phone\n"
+    );
+    assert!(push(root_a, None).unwrap().pushed);
+}
+
+#[test]
+fn daily_edit_inside_the_base_still_parks_with_markers() {
+    let fixture = fixture();
+    let root_a = &fixture.graph_a;
+    write(root_a, "daily/2026-07-02.md", "# Daily\n\n- original\n");
+    commit_all(root_a, "base", MAX_FILE_BYTES).unwrap();
+    push(root_a, None).unwrap();
+
+    let root_b = second_device(&fixture);
+    write(
+        &root_b,
+        "daily/2026-07-02.md",
+        "# Daily\n\n- original\n- from the phone\n",
+    );
+    commit_all(&root_b, "b append", MAX_FILE_BYTES).unwrap();
+    push(&root_b, None).unwrap();
+
+    // The mac rewrote an existing line — not a pure append; review it.
+    write(
+        root_a,
+        "daily/2026-07-02.md",
+        "# Daily\n\n- original, edited\n- from the mac\n",
+    );
+    commit_all(root_a, "a edit", MAX_FILE_BYTES).unwrap();
+    fetch(root_a, None).unwrap();
+    let merged = merge_remote(root_a).unwrap();
+
+    assert!(
+        matches!(merged.kind, MergeKind::MergedWithConflicts),
+        "{merged:?}"
+    );
+    assert_eq!(
+        merged.conflicted_paths,
+        vec!["daily/2026-07-02.md".to_string()]
+    );
+    let content = read(root_a, "daily/2026-07-02.md");
+    assert!(content.contains("<<<<<<< this device"), "{content}");
+}
+
+#[test]
+fn daily_frontmatter_change_still_parks_with_markers() {
+    let fixture = fixture();
+    let root_a = &fixture.graph_a;
+    write(
+        root_a,
+        "daily/2026-07-02.md",
+        "---\npinned: false\n---\n\n- original\n",
+    );
+    commit_all(root_a, "base", MAX_FILE_BYTES).unwrap();
+    push(root_a, None).unwrap();
+
+    let root_b = second_device(&fixture);
+    write(
+        &root_b,
+        "daily/2026-07-02.md",
+        "---\npinned: false\n---\n\n- original\n- from the phone\n",
+    );
+    commit_all(&root_b, "b append", MAX_FILE_BYTES).unwrap();
+    push(&root_b, None).unwrap();
+
+    // The mac flipped a frontmatter flag *and* appended: the driver is
+    // body-only, so this is a review conflict even though the body change is
+    // an append.
+    write(
+        root_a,
+        "daily/2026-07-02.md",
+        "---\npinned: true\n---\n\n- original\n- from the mac\n",
+    );
+    commit_all(root_a, "a frontmatter + append", MAX_FILE_BYTES).unwrap();
+    fetch(root_a, None).unwrap();
+    let merged = merge_remote(root_a).unwrap();
+
+    assert!(
+        matches!(merged.kind, MergeKind::MergedWithConflicts),
+        "{merged:?}"
+    );
+    let content = read(root_a, "daily/2026-07-02.md");
+    assert!(content.contains("<<<<<<< this device"), "{content}");
+}
+
+#[test]
+fn append_append_on_a_non_daily_note_still_parks_with_markers() {
+    let fixture = fixture();
+    let root_a = &fixture.graph_a;
+    write(root_a, "notes/shared.md", "# Shared\n\n- original\n");
+    commit_all(root_a, "base", MAX_FILE_BYTES).unwrap();
+    push(root_a, None).unwrap();
+
+    let root_b = second_device(&fixture);
+    write(
+        &root_b,
+        "notes/shared.md",
+        "# Shared\n\n- original\n- from the phone\n",
+    );
+    commit_all(&root_b, "b append", MAX_FILE_BYTES).unwrap();
+    push(&root_b, None).unwrap();
+
+    write(
+        root_a,
+        "notes/shared.md",
+        "# Shared\n\n- original\n- from the mac\n",
+    );
+    commit_all(root_a, "a append", MAX_FILE_BYTES).unwrap();
+    fetch(root_a, None).unwrap();
+    let merged = merge_remote(root_a).unwrap();
+
+    // Deliberately narrow: append/append is only auto-safe where appends are
+    // the editing model (daily notes). Ordinary notes keep the review flow.
+    assert!(
+        matches!(merged.kind, MergeKind::MergedWithConflicts),
+        "{merged:?}"
+    );
+    assert_eq!(merged.conflicted_paths, vec!["notes/shared.md".to_string()]);
+}
+
 #[test]
 fn edit_vs_delete_keeps_the_edit() {
     let fixture = fixture();

--- a/docs/plans/12-backup-and-sync.md
+++ b/docs/plans/12-backup-and-sync.md
@@ -133,8 +133,13 @@ present) · `Backup failed` (action needed). Git mechanics never surface.
      watch start). A pull rewriting an **open** note goes through Plan 05's
      external-change reconciliation (clean buffer reloads; dirty buffer prompts).
    - **Daily notes are the common collision** (two devices, same day). Markers +
-     keep-both cover it first wave; future: a custom merge driver (libgit2 registers
-     them in code) for append-friendly merging of `daily/*.md`.
+     keep-both covered it first wave; since 2026-07 the **append/append driver**
+     (`git/daily_merge.rs`) auto-resolves the trivially-safe shape — the merge base
+     is an untouched, line-bounded prefix of *both* sides of a `daily/YYYY-MM-DD.md`
+     conflict — to base + this device's suffix + the other's (exact-duplicate suffix
+     lines kept once, matching the capture drain's presence guard). Body-only:
+     frontmatter changes, base edits, non-daily notes, and deletions all still park
+     with markers.
 
 5. **Guardrails:**
    - Default to **creating a private repo**; choosing a public repo blocks on an explicit
@@ -210,7 +215,10 @@ present) · `Backup failed` (action needed). Git mechanics never surface.
 - meowdown conflict widget (parse marker blocks → keep-mine/keep-theirs UI).
 - AI-assisted resolution via the Plan 10 copilot (markers parse to base/ours/theirs;
   `private: true` notes never go to cloud AI).
-- Custom merge driver for daily notes; Git LFS / asset offload; background sync on
+- ~~Custom merge driver for daily notes~~ → shipped 2026-07 as the narrow
+  append/append auto-resolve (step 4); widening it (e.g. append + unrelated base
+  edit) stays deferred.
+- Git LFS / asset offload; background sync on
   mobile; "purge history" escape hatch; stale-`index.lock` recovery on startup.
 - ~~Generic-remote UX toggle~~ → became [Plan 16](16-generic-git-remotes.md): any git
   host via a hand-wired `origin`, no UI (V1 ships SSH-agent auth + path remotes).

--- a/docs/porting/reflect-mobile/sync-offline-and-data.md
+++ b/docs/porting/reflect-mobile/sync-offline-and-data.md
@@ -91,8 +91,8 @@ section is the mapping, not a proposal:
   protected note view and offers the same raw-marker mine/theirs/both
   resolution actions as desktop. Conflicts never block sync of other notes.
   The canonical case is phone + Mac both appending to today's daily note; the
-  daily-note append/append merge driver (Plan 12 future work) is the lever if
-  it hurts in practice.
+  daily-note append/append merge driver (Plan 12 step 4, shipped 2026-07)
+  auto-resolves that shape, so only genuinely overlapping edits park.
 - **Contract 5 maps to first clone**: cloning a years-old graph over
   cellular, foregrounded, with progress UI; shallow/partial clone is the
   noted follow-up.


### PR DESCRIPTION
## Problem

The canonical two-device sync collision is phone and Mac both appending to **today's daily note** while the phone was offline. Today that parks the note behind conflict markers ("Needs review", protected editor) even though neither side touched anything the other wrote — and Plan 19's foreground-only mobile sync makes it the *common* case, not the rare one. Plan 12 listed a custom daily-note merge driver as future work; this ships it.

## What changed

**`apps/desktop/src-tauri/src/git/daily_merge.rs` (new)** — the pure merge:

- `merge_appends(base, ours, theirs)` returns a merged note **only** when the merge base is an untouched, **line-bounded** prefix of *both* sides (byte-prefix alone isn't enough — `"- note"` → `"- note and more"` keeps the prefix but rewrites the final line, so a non-empty suffix must start at a line boundary). Result: `base` + this device's suffix + the other device's suffix. Deterministic order: only one device performs the merge; the other fast-forwards onto its commit — same convergence story as markers today.
- **Duplicate-capture dedup:** theirs-suffix lines that appear verbatim in ours' suffix are kept once, using the capture drain's exact rule (whole-line equality, trailing `\r` stripped — a CRLF daily dedupes like an LF one). Blank lines are structural and never deduped; a suffix line duplicating a *base* line is kept (the drain would never have appended it, so it was typed deliberately).
- **Empty base** (both devices created today's note — no ancestor in the conflict) concatenates both creations, unless either side opens with frontmatter (concatenation would bury a `---` block mid-file → park).

**`git/merge.rs`** — `resolve_both_edited` now receives the ancestor side and tries the auto-resolve first, gated hard: same `daily/YYYY-MM-DD.md` path on all sides, non-binary, valid UTF-8. On success the merged content overwrites the marker file the merge checkout wrote and is staged into the same merge commit; the path is **not** reported as conflicted.

**Everything not this exact shape keeps the marker flow**: edits inside the base region, frontmatter changes (the driver is body-only — v1 decision per the task brief: a frontmatter touch breaks the prefix, so it parks), non-daily notes, deletions, binary conflicts. When in doubt, park.

**No TypeScript changes.** An auto-merged note comes back as `kind: merged` with empty `conflictedPaths`; the merged file rides `changedFiles` → `onRemoteChanges`, so reindex + open-editor reconciliation fire like any pull-applied write, and the indexer never sees markers so nothing parks. The no-loop invariant holds: the resolution is committed, the working tree stays clean (pinned by a no-op-commit assertion in the test).

**Docs**: Plan 12 step 4 + Deferred updated (driver shipped, widening stays deferred); mobile porting doc's "future work" pointer updated.

## Tests

- **15 unit tests** on the pure function: append/append, identical appends collapse, shared-capture dedup (incl. CRLF-vs-LF), base-region edit parks, final-line extension parks, frontmatter change parks, unchanged frontmatter in base merges, empty base (plain + frontmatter park), trailing-newline variants, one-side-identical-to-base, blank lines never deduped, daily-path shape.
- **6 two-clone integration tests** running the engine's real cycle (commit → fetch → merge → push): auto-merge with no markers / empty `conflicted_paths` / `MergeKind::Merged`, merged file reported with real mtime for reindex, repo clean + nothing dirty afterwards, second device converges by fast-forward; same-capture-not-doubled; both-created concatenation; and the narrowness pins — base edit, frontmatter flip, and non-daily append/append all still park with markers.

`cargo test -p reflect-open git::` → 61 passed. `cargo clippy -p reflect-open --all-targets` clean. `pnpm check` passes (0 errors; 3 pre-existing warnings). `pnpm vitest run src/sync/engine.test.ts` → 21 passed.

## Risks

- A false-positive auto-merge would be worse than a parked note; the gates (path shape, UTF-8, line-bounded prefix on *both* sides, ancestor path match) are each tested to fall back to markers.
- If both devices race the *merge itself* (both merge, both push, one loses), the loser merges two merge commits with identical parents — that lands in the normal marker flow, same as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pull-time merge behavior for daily notes; incorrect auto-merge could lose or reorder user text, though narrow gates and fallbacks to markers limit exposure.
> 
> **Overview**
> **Auto-resolves the common two-device daily-note collision** (both sides only appended after a shared merge base) during `git_merge_remote`, so those pulls finish as a clean merge with **no conflict markers** and **empty `conflictedPaths`** instead of "Needs review."
> 
> New **`git/daily_merge.rs`** implements `merge_appends`: result is merge base + this device's suffix + the other's (ours first), with duplicate capture lines deduped on whole-line keys (CRLF/LF insensitive). It only applies when the base is an **untouched line-bounded prefix** of both sides; mid-line edits, frontmatter changes, empty-base + frontmatter, and non-daily paths return `None`.
> 
> **`git/merge.rs`** passes the ancestor into `resolve_both_edited`, runs `daily_auto_merge` for UTF-8 text on matching `daily/*.md` paths, overwrites the checkout's marker file with the merged body, and stages it. Unchanged TypeScript path: outcomes still surface as `merged` + `changedFiles` for reindex.
> 
> **Tests:** unit coverage on the pure merge plus six two-clone integration scenarios (auto-merge, dedup, dual-create, and cases that still park). Plan 12 and mobile porting docs mark the driver as shipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70a58e772113db2371409811306f88b216d0351e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->