### PR TITLE
feat: native push/pop transitions and edge back-swipe for the mobile shell

### DIFF
--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -1,9 +1,9 @@
-import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, waitFor, within } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { format } from 'date-fns'
-import type { ReactElement } from 'react'
+import { StrictMode, type ReactElement } from 'react'
 import { setBridge } from '@reflect/core'
 import { RouterProvider, useRouter } from '@/routing/router'
 import type { Route } from '@/routing/route'
@@ -161,16 +161,23 @@ beforeEach(() => {
   })
 })
 
-function mount(initialRoute: Route, probeRoute?: Route): ReturnType<typeof render> {
+function mount(
+  initialRoute: Route,
+  probeRoute?: Route,
+  options?: { strict?: boolean },
+): ReturnType<typeof render> {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  return render(
+  const tree = (
     <QueryClientProvider client={queryClient}>
       <RouterProvider initialRoute={initialRoute}>
         <MobileShell />
         {probeRoute ? <NavProbe to={probeRoute} /> : null}
       </RouterProvider>
-    </QueryClientProvider>,
+    </QueryClientProvider>
   )
+  // The app runs under StrictMode (main.tsx); opt in where a test guards
+  // against impure updaters (dev double-invocation caught a double-pop once).
+  return render(options?.strict ? <StrictMode>{tree}</StrictMode> : tree)
 }
 
 /** Stands in for a wiki-link tap: navigation arriving from inside a screen. */
@@ -181,6 +188,33 @@ function NavProbe({ to }: { to: Route }): ReactElement {
       probe-navigate
     </button>
   )
+}
+
+/** Every mounted stack layer, in DOM order (below → current → exiting). */
+function stackLayers(view: ReturnType<typeof render>): HTMLElement[] {
+  return Array.from(view.container.querySelectorAll<HTMLElement>('.mobile-stack-layer'))
+}
+
+/** The screen the user sees — the one stack layer not hidden as a11y-inert. */
+function visibleLayer(view: ReturnType<typeof render>): HTMLElement {
+  const visible = stackLayers(view).find((layer) => layer.getAttribute('aria-hidden') !== 'true')
+  if (!visible) {
+    throw new Error('no visible mobile-stack layer')
+  }
+  return visible
+}
+
+/**
+ * Dispatch a pointer event the gesture hook can read. jsdom's PointerEvent
+ * support is spotty, but React reads `pointerType`/`clientX`/… straight off
+ * the native event object, so a plain Event with the fields assigned works.
+ */
+function firePointer(element: Element, type: string, init: Record<string, unknown>): void {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.assign(event, init)
+  act(() => {
+    element.dispatchEvent(event)
+  })
 }
 
 /** The calendar strip's per-day aria-label (CalendarStrip uses this form). */
@@ -298,9 +332,12 @@ describe('MobileShell', () => {
     const view = mount({ kind: 'note', path: 'notes/source.md' })
 
     // A plain arrival (cold entry, All list, back-nav) must not focus — on
-    // touch that would raise the keyboard while browsing.
+    // touch that would raise the keyboard while browsing. (The stack keeps
+    // today's spine mounted beneath the note, so scope to the visible layer.)
     await waitFor(() => {
-      expect(view.getByTestId('fake-editor').textContent).toContain('see [[Target Note]]')
+      expect(within(visibleLayer(view)).getByTestId('fake-editor').textContent).toContain(
+        'see [[Target Note]]',
+      )
     })
     expect(editorProbe.focusCalls).toBe(0)
 
@@ -357,10 +394,267 @@ describe('MobileShell', () => {
 
     expect(view.getByRole('heading').textContent).toContain('meeting-notes')
     await waitFor(() => {
-      expect(view.getByTestId('fake-editor').textContent).toContain('agenda')
+      expect(within(visibleLayer(view)).getByTestId('fake-editor').textContent).toContain('agenda')
     })
 
     await user.click(view.getByRole('button', { name: 'Back' }))
     expect(view.getByRole('heading', { level: 1 }).textContent).toBe(monthLabel(todayIso()))
+  })
+})
+
+/**
+ * The navigation stack (V1 parity): a pushed note slides in as a card over
+ * its origin (which stays mounted, hidden, and inert beneath it), popping
+ * slides it out, tab switches stay instant, and an edge back-swipe drags the
+ * card with the finger — popping past the threshold, snapping back short of
+ * it. jsdom runs no animations, so tests drive the `animationend` /
+ * `transitionend` completions by hand.
+ */
+describe('MobileStack transitions & back-swipe', () => {
+  /** Navigate to the probe note and complete the push animation. */
+  async function pushProbeNote(view: ReturnType<typeof render>): Promise<void> {
+    const user = userEvent.setup()
+    await user.click(view.getByRole('button', { name: 'probe-navigate' }))
+    fireEvent.animationEnd(stackLayers(view).at(-1)!)
+  }
+
+  it('pushes a note as a sliding card over its origin, which stays mounted but inert', async () => {
+    const user = userEvent.setup()
+    files['notes/meeting-notes.md'] = 'agenda'
+    const view = mount({ kind: 'today' }, { kind: 'note', path: 'notes/meeting-notes.md' })
+
+    await user.click(view.getByRole('button', { name: 'probe-navigate' }))
+    const layers = stackLayers(view)
+    expect(layers).toHaveLength(2)
+    const [origin, entering] = layers
+    expect(entering!.className).toContain('mobile-stack-slide-in')
+    expect(origin!.getAttribute('aria-hidden')).toBe('true')
+    expect(
+      within(origin!).getByRole('heading', { level: 1, hidden: true }).textContent,
+    ).toBe(monthLabel(todayIso()))
+    expect(view.container.querySelector('.mobile-stack-scrim')).toBeTruthy()
+
+    fireEvent.animationEnd(entering!)
+    // The animation class clears; the origin stays mounted for the back-swipe.
+    expect(entering!.className).not.toContain('mobile-stack-slide-in')
+    expect(stackLayers(view)).toHaveLength(2)
+  })
+
+  it('pops the note with a slide-out and unmounts it when the animation ends', async () => {
+    const user = userEvent.setup()
+    files['notes/meeting-notes.md'] = 'agenda'
+    const view = mount({ kind: 'today' }, { kind: 'note', path: 'notes/meeting-notes.md' })
+    await pushProbeNote(view)
+
+    await user.click(view.getByRole('button', { name: 'Back' }))
+    // Daily is current again immediately; the note lingers only to animate out.
+    expect(view.getByRole('heading', { level: 1 }).textContent).toBe(monthLabel(todayIso()))
+    const exiting = stackLayers(view).at(-1)!
+    expect(exiting.className).toContain('mobile-stack-slide-out')
+    expect(exiting.getAttribute('aria-hidden')).toBe('true')
+
+    fireEvent.animationEnd(exiting)
+    expect(stackLayers(view)).toHaveLength(1)
+  })
+
+  it('keeps tab switches instant: one layer, no slide (V1 cross-fade at most)', async () => {
+    const user = userEvent.setup()
+    const view = mount({ kind: 'today' })
+    expect(stackLayers(view)).toHaveLength(1)
+
+    await user.click(view.getByRole('button', { name: 'All' }))
+    const layers = stackLayers(view)
+    expect(layers).toHaveLength(1)
+    expect(layers[0]!.className).not.toContain('mobile-stack-slide-in')
+    expect(view.container.querySelector('.mobile-stack-scrim')).toBeNull()
+  })
+
+  it('follows history direction within a note chain: wiki-link pushes, back pops', async () => {
+    const user = userEvent.setup()
+    files['notes/source.md'] = 'see [[Target Note]]'
+    const view = mount({ kind: 'note', path: 'notes/source.md' })
+    await waitFor(() => {
+      expect(within(visibleLayer(view)).getByTestId('fake-editor').textContent).toContain(
+        'Target Note',
+      )
+    })
+
+    await user.click(view.getByRole('button', { name: 'fake-wikilink' }))
+    // Deeper into the chain: the destination slides in over the source.
+    await waitFor(() => {
+      expect(stackLayers(view).at(-1)!.className).toContain('mobile-stack-slide-in')
+    })
+    fireEvent.animationEnd(stackLayers(view).at(-1)!)
+
+    await user.click(view.getByRole('button', { name: 'Back' }))
+    // Popping reveals the still-mounted source, re-seats today beneath it,
+    // and slides the destination out — three layers, briefly.
+    const layers = stackLayers(view)
+    expect(layers).toHaveLength(3)
+    expect(layers.at(-1)!.className).toContain('mobile-stack-slide-out')
+    expect(within(visibleLayer(view)).getByRole('heading').textContent).toContain('source')
+    fireEvent.animationEnd(layers.at(-1)!)
+    expect(stackLayers(view)).toHaveLength(2)
+  })
+
+  it('cuts instantly under prefers-reduced-motion', async () => {
+    const originalMatchMedia = globalThis.matchMedia
+    globalThis.matchMedia = ((query: string) => ({
+      matches: query.includes('prefers-reduced-motion'),
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    })) as unknown as typeof matchMedia
+    try {
+      const user = userEvent.setup()
+      files['notes/meeting-notes.md'] = 'agenda'
+      const view = mount({ kind: 'today' }, { kind: 'note', path: 'notes/meeting-notes.md' })
+
+      await user.click(view.getByRole('button', { name: 'probe-navigate' }))
+      expect(stackLayers(view).at(-1)!.className).not.toContain('mobile-stack-slide-in')
+
+      await user.click(view.getByRole('button', { name: 'Back' }))
+      // No exit animation: the note is gone the moment the route changes.
+      expect(stackLayers(view)).toHaveLength(1)
+    } finally {
+      globalThis.matchMedia = originalMatchMedia
+    }
+  })
+
+  it('pops the note when an edge swipe crosses the release threshold', async () => {
+    files['notes/meeting-notes.md'] = 'agenda'
+    const view = mount({ kind: 'today' }, { kind: 'note', path: 'notes/meeting-notes.md' })
+    await pushProbeNote(view)
+
+    const stack = view.container.querySelector('.mobile-stack')!
+    const card = stackLayers(view).at(-1)!
+    firePointer(stack, 'pointerdown', {
+      pointerId: 1,
+      isPrimary: true,
+      pointerType: 'touch',
+      clientX: 10,
+      clientY: 300,
+    })
+    firePointer(stack, 'pointermove', { pointerId: 1, clientX: 40, clientY: 304 })
+    // The card tracks the finger. (jsdom has no layout, so the gesture falls
+    // back to window.innerWidth = 1024px — the pop threshold is ~410px.)
+    expect(card.style.transform).toBe('translate3d(30px, 0, 0)')
+
+    firePointer(stack, 'pointermove', { pointerId: 1, clientX: 600, clientY: 310 })
+    firePointer(stack, 'pointerup', { pointerId: 1, clientX: 600, clientY: 310 })
+    // Released past the threshold: the card settles offscreen...
+    expect(card.style.transform).toBe('translate3d(100%, 0, 0)')
+
+    // ...and only then commits the pop.
+    fireEvent.transitionEnd(card)
+    expect(view.getByRole('heading', { level: 1 }).textContent).toBe(monthLabel(todayIso()))
+    expect(stackLayers(view)).toHaveLength(1)
+  })
+
+  it('commits a gesture pop exactly once (StrictMode + same-frame double transitionend)', async () => {
+    // Three-deep history (today → All → note): a double-committed pop would
+    // sail past All and land on today. Two real-world double-fire vectors:
+    // StrictMode's dev double-invocation (which caught an impure updater
+    // once), and the card's transform + the scrim's opacity settling in the
+    // same frame, so `transitionend` arrives twice before React re-renders.
+    const user = userEvent.setup()
+    files['notes/meeting-notes.md'] = 'agenda'
+    const view = mount({ kind: 'today' }, { kind: 'note', path: 'notes/meeting-notes.md' }, {
+      strict: true,
+    })
+    await user.click(view.getByRole('button', { name: 'All' }))
+    await pushProbeNote(view)
+
+    const stack = view.container.querySelector('.mobile-stack')!
+    const card = stackLayers(view).at(-1)!
+    firePointer(stack, 'pointerdown', {
+      pointerId: 1,
+      isPrimary: true,
+      pointerType: 'touch',
+      clientX: 10,
+      clientY: 300,
+    })
+    firePointer(stack, 'pointermove', { pointerId: 1, clientX: 40, clientY: 304 })
+    firePointer(stack, 'pointermove', { pointerId: 1, clientX: 600, clientY: 310 })
+    firePointer(stack, 'pointerup', { pointerId: 1, clientX: 600, clientY: 310 })
+
+    act(() => {
+      card.dispatchEvent(new Event('transitionend', { bubbles: true }))
+      card.dispatchEvent(new Event('transitionend', { bubbles: true }))
+    })
+    expect(view.getByRole('searchbox', { name: 'Search notes' })).toBeTruthy()
+  })
+
+  it('snaps back when the swipe releases short of the threshold', async () => {
+    files['notes/meeting-notes.md'] = 'agenda'
+    const view = mount({ kind: 'today' }, { kind: 'note', path: 'notes/meeting-notes.md' })
+    await pushProbeNote(view)
+
+    const stack = view.container.querySelector('.mobile-stack')!
+    const card = stackLayers(view).at(-1)!
+    firePointer(stack, 'pointerdown', {
+      pointerId: 1,
+      isPrimary: true,
+      pointerType: 'touch',
+      clientX: 10,
+      clientY: 300,
+    })
+    firePointer(stack, 'pointermove', { pointerId: 1, clientX: 40, clientY: 304 })
+    firePointer(stack, 'pointermove', { pointerId: 1, clientX: 120, clientY: 306 })
+    firePointer(stack, 'pointerup', { pointerId: 1, clientX: 120, clientY: 306 })
+    expect(card.style.transform).toBe('translate3d(0, 0, 0)')
+
+    fireEvent.transitionEnd(card)
+    expect(view.getByRole('heading').textContent).toContain('meeting-notes')
+    expect(stackLayers(view)).toHaveLength(2)
+  })
+
+  it('ignores mid-screen touches, mouse pointers, and vertical scrolls', async () => {
+    files['notes/meeting-notes.md'] = 'agenda'
+    const view = mount({ kind: 'today' }, { kind: 'note', path: 'notes/meeting-notes.md' })
+    await pushProbeNote(view)
+
+    const stack = view.container.querySelector('.mobile-stack')!
+    const card = stackLayers(view).at(-1)!
+
+    // Not from the edge.
+    firePointer(stack, 'pointerdown', {
+      pointerId: 1,
+      isPrimary: true,
+      pointerType: 'touch',
+      clientX: 200,
+      clientY: 300,
+    })
+    firePointer(stack, 'pointermove', { pointerId: 1, clientX: 260, clientY: 300 })
+    expect(card.style.transform).toBe('')
+    firePointer(stack, 'pointerup', { pointerId: 1, clientX: 260, clientY: 300 })
+
+    // Not a touch.
+    firePointer(stack, 'pointerdown', {
+      pointerId: 2,
+      isPrimary: true,
+      pointerType: 'mouse',
+      clientX: 10,
+      clientY: 300,
+    })
+    firePointer(stack, 'pointermove', { pointerId: 2, clientX: 80, clientY: 300 })
+    expect(card.style.transform).toBe('')
+    firePointer(stack, 'pointerup', { pointerId: 2, clientX: 80, clientY: 300 })
+
+    // Vertical intent from the edge: the scroll wins and the gesture disarms.
+    firePointer(stack, 'pointerdown', {
+      pointerId: 3,
+      isPrimary: true,
+      pointerType: 'touch',
+      clientX: 10,
+      clientY: 300,
+    })
+    firePointer(stack, 'pointermove', { pointerId: 3, clientX: 14, clientY: 360 })
+    firePointer(stack, 'pointermove', { pointerId: 3, clientX: 80, clientY: 360 })
+    expect(card.style.transform).toBe('')
   })
 })

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -594,23 +594,33 @@ describe('MobileStack transitions & back-swipe', () => {
     const view = mount({ kind: 'today' }, { kind: 'note', path: 'notes/meeting-notes.md' })
     await pushProbeNote(view)
 
-    const stack = view.container.querySelector('.mobile-stack')!
-    const card = stackLayers(view).at(-1)!
-    firePointer(stack, 'pointerdown', {
-      pointerId: 1,
-      isPrimary: true,
-      pointerType: 'touch',
-      clientX: 10,
-      clientY: 300,
-    })
-    firePointer(stack, 'pointermove', { pointerId: 1, clientX: 40, clientY: 304 })
-    firePointer(stack, 'pointermove', { pointerId: 1, clientX: 120, clientY: 306 })
-    firePointer(stack, 'pointerup', { pointerId: 1, clientX: 120, clientY: 306 })
-    expect(card.style.transform).toBe('translate3d(0, 0, 0)')
+    // A slow machine can stretch the gap between synthetic moves past the
+    // hook's velocity-sampling window, turning this short drag into a
+    // "flick" that pops. Pin the clock so the drag reads as slow and the
+    // release decision is purely distance-based.
+    let clock = 1000
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => (clock += 5))
+    try {
+      const stack = view.container.querySelector('.mobile-stack')!
+      const card = stackLayers(view).at(-1)!
+      firePointer(stack, 'pointerdown', {
+        pointerId: 1,
+        isPrimary: true,
+        pointerType: 'touch',
+        clientX: 10,
+        clientY: 300,
+      })
+      firePointer(stack, 'pointermove', { pointerId: 1, clientX: 40, clientY: 304 })
+      firePointer(stack, 'pointermove', { pointerId: 1, clientX: 120, clientY: 306 })
+      firePointer(stack, 'pointerup', { pointerId: 1, clientX: 120, clientY: 306 })
+      expect(card.style.transform).toBe('translate3d(0, 0, 0)')
 
-    fireEvent.transitionEnd(card)
-    expect(view.getByRole('heading').textContent).toContain('meeting-notes')
-    expect(stackLayers(view)).toHaveLength(2)
+      fireEvent.transitionEnd(card)
+      expect(view.getByRole('heading').textContent).toContain('meeting-notes')
+      expect(stackLayers(view)).toHaveLength(2)
+    } finally {
+      nowSpy.mockRestore()
+    }
   })
 
   it('ignores mid-screen touches, mouse pointers, and vertical scrolls', async () => {

--- a/apps/desktop/src/mobile/mobile-screen.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.tsx
@@ -4,9 +4,15 @@ import { MobileAllNotes } from '@/mobile/screens/all-notes'
 import { MobileDaily } from '@/mobile/screens/daily'
 import { MobileNote } from '@/mobile/screens/note'
 import type { AllNotesFilters } from '@/mobile/search-filters/filter-state'
-import { useRouter } from '@/routing/router'
+import type { Route } from '@/routing/route'
 
 interface MobileScreenProps {
+  /**
+   * The route this screen renders. A prop rather than `useRouter()` because
+   * the stack ({@link MobileStack}) keeps more than one screen mounted at a
+   * time — the current route plus the screen a back-swipe would reveal.
+   */
+  route: Route
   /** The All tab's search text (owned by the shell — survives navigation). */
   allQuery: string
   onAllQueryChange: (query: string) => void
@@ -17,19 +23,19 @@ interface MobileScreenProps {
 
 /**
  * The mobile route switch (Plan 19): the same typed `Route` history desktop
- * uses, rendered one screen at a time — the daily spine, notes, and the All
+ * uses, one screen per route — the daily spine, notes, and the All
  * tab (which also hosts `search` entries). Kinds without a mobile surface
  * yet (chat, settings) fall back to today. Today is `useToday()`'s **live** date, so an app left open
  * overnight rolls to the new day's note at midnight instead of editing
  * yesterday's.
  */
 export function MobileScreen({
+  route,
   allQuery,
   onAllQueryChange,
   allFilters,
   onAllFiltersChange,
 }: MobileScreenProps): ReactElement {
-  const { route } = useRouter()
   const today = useToday()
 
   switch (route.kind) {

--- a/apps/desktop/src/mobile/mobile-shell.tsx
+++ b/apps/desktop/src/mobile/mobile-shell.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ReactElement } from 'react'
-import { MobileScreen } from '@/mobile/mobile-screen'
+import { MobileStack } from '@/mobile/mobile-stack'
 import { MobileTabBar, type MobileTab } from '@/mobile/mobile-tab-bar'
 import {
   EMPTY_ALL_NOTES_FILTERS,
@@ -59,7 +59,7 @@ export function MobileShell(): ReactElement {
       style={{ height: 'calc(100dvh - var(--keyboard-height, 0px))' }}
     >
       <div className="min-h-0 flex-1">
-        <MobileScreen
+        <MobileStack
           allQuery={allQuery}
           onAllQueryChange={setAllQuery}
           allFilters={allFilters}

--- a/apps/desktop/src/mobile/mobile-stack.css
+++ b/apps/desktop/src/mobile/mobile-stack.css
@@ -1,0 +1,70 @@
+/*
+ * Push/pop choreography for the mobile navigation stack (mobile-stack.tsx).
+ * Inline styles own every resting state; these keyframes only describe the
+ * journey there, so a finished animation and a skipped one land on identical
+ * pixels. Durations mirror TRANSITION_MS in mobile-stack.tsx (the fallback
+ * timer that finishes a transition when `animationend` never fires).
+ */
+
+.mobile-stack-slide-in {
+  animation: mobile-stack-slide-in 350ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.mobile-stack-slide-out {
+  animation: mobile-stack-slide-out 350ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.mobile-stack-dim-in {
+  animation: mobile-stack-dim-in 350ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.mobile-stack-dim-out {
+  animation: mobile-stack-dim-out 350ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+@keyframes mobile-stack-slide-in {
+  from {
+    transform: translate3d(100%, 0, 0);
+  }
+  to {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes mobile-stack-slide-out {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+  to {
+    transform: translate3d(100%, 0, 0);
+  }
+}
+
+@keyframes mobile-stack-dim-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes mobile-stack-dim-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+/* Belt and braces: the stack also skips transitions in JS under reduced
+   motion, but never animate even if a code path forgets to check. */
+@media (prefers-reduced-motion: reduce) {
+  .mobile-stack-slide-in,
+  .mobile-stack-slide-out,
+  .mobile-stack-dim-in,
+  .mobile-stack-dim-out {
+    animation: none;
+  }
+}

--- a/apps/desktop/src/mobile/mobile-stack.tsx
+++ b/apps/desktop/src/mobile/mobile-stack.tsx
@@ -4,7 +4,7 @@ import type { AllNotesFilters } from '@/mobile/search-filters/filter-state'
 import { BACK_SWIPE_SETTLE_MS, useBackSwipe, type BackSwipeState } from '@/mobile/use-back-swipe'
 import { usePrefersReducedMotion } from '@/mobile/use-reduced-motion'
 import type { Route } from '@/routing/route'
-import { useRouter } from '@/routing/router'
+import { RouterFreeze, useRouter } from '@/routing/router'
 import './mobile-stack.css'
 
 /** Mirrors the animation durations in mobile-stack.css. */
@@ -247,23 +247,24 @@ export function MobileStack(props: MobileStackProps): ReactElement {
   // synthetic animation/transition events register vendor-detected names and
   // never fire in some hosts. Both events bubble; the class guard keeps
   // animations inside a screen (editor UI etc.) from ending a navigation.
+  // Layers only, never the scrim: exactly one layer animates per transition,
+  // so the layer's own end is the single source of truth — the scrim's
+  // ending first must not cut the card's slide short.
   const { finishSettle } = swipe
   useEffect(() => {
     const node = containerRef.current
     if (!node) {
       return
     }
-    const isStackChrome = (target: EventTarget | null): boolean =>
-      target instanceof HTMLElement &&
-      (target.classList.contains('mobile-stack-layer') ||
-        target.classList.contains('mobile-stack-scrim'))
+    const isStackLayer = (target: EventTarget | null): boolean =>
+      target instanceof HTMLElement && target.classList.contains('mobile-stack-layer')
     const onAnimationEnd = (event: Event): void => {
-      if (isStackChrome(event.target)) {
+      if (isStackLayer(event.target)) {
         finishTransition()
       }
     }
     const onTransitionEnd = (event: Event): void => {
-      if (isStackChrome(event.target)) {
+      if (isStackLayer(event.target)) {
         finishSettle()
       }
     }
@@ -314,7 +315,12 @@ export function MobileStack(props: MobileStackProps): ReactElement {
             aria-hidden={hidden || undefined}
             inert={hidden}
           >
-            <MobileScreen route={layer.route} {...props} />
+            {/* Background layers must not observe navigation: a push bumps
+                arrivalSeq, which the daily surface under the note would read
+                as a re-arrival and re-anchor its scroll while hidden. */}
+            <RouterFreeze frozen={hidden}>
+              <MobileScreen route={layer.route} {...props} />
+            </RouterFreeze>
           </div>
         )
       })}

--- a/apps/desktop/src/mobile/mobile-stack.tsx
+++ b/apps/desktop/src/mobile/mobile-stack.tsx
@@ -1,0 +1,330 @@
+import { useCallback, useEffect, useRef, useState, type CSSProperties, type ReactElement } from 'react'
+import { MobileScreen } from '@/mobile/mobile-screen'
+import type { AllNotesFilters } from '@/mobile/search-filters/filter-state'
+import { BACK_SWIPE_SETTLE_MS, useBackSwipe, type BackSwipeState } from '@/mobile/use-back-swipe'
+import { usePrefersReducedMotion } from '@/mobile/use-reduced-motion'
+import type { Route } from '@/routing/route'
+import { useRouter } from '@/routing/router'
+import './mobile-stack.css'
+
+/** Mirrors the animation durations in mobile-stack.css. */
+const TRANSITION_MS = 350
+const SETTLE_EASING = 'cubic-bezier(0.32, 0.72, 0, 1)'
+/** The stacked card's leading-edge shadow, visible while it slides. */
+const CARD_SHADOW = '-8px 0 24px rgb(0 0 0 / 0.18)'
+
+type StackTransition =
+  | { kind: 'none' }
+  | { kind: 'push' }
+  | { kind: 'pop'; exiting: { key: string; route: Route } }
+
+type LayerRole = 'below' | 'current' | 'exiting'
+
+interface StackLayer {
+  key: string
+  route: Route
+  role: LayerRole
+}
+
+/**
+ * Whether a route renders as a card pushed over a tab root. Only note
+ * screens stack; everything else (daily, All, search-as-All) is a root.
+ */
+function isStacked(route: Route): boolean {
+  return route.kind === 'note'
+}
+
+/**
+ * The mounted identity of a route's screen. Mirrors the keys MobileScreen's
+ * switch has always used: one persistent daily surface (a day change scrolls
+ * the carousel instead of remounting it), one All surface, one screen per
+ * note path.
+ */
+function layerKey(route: Route): string {
+  switch (route.kind) {
+    case 'note':
+      return `note:${route.path}`
+    case 'allNotes':
+    case 'search':
+      return 'all'
+    default:
+      return 'daily'
+  }
+}
+
+/**
+ * The animation an arrival deserves, V1 semantics: entering the note stack
+ * slides in, leaving it slides out, moving within it follows history order,
+ * and root-to-root moves (tab switches, date links) stay instant.
+ */
+function transitionFor(
+  from: { route: Route; entryId: number },
+  to: { route: Route; entryId: number },
+): StackTransition {
+  const fromStacked = isStacked(from.route)
+  const toStacked = isStacked(to.route)
+  const pop: StackTransition = {
+    kind: 'pop',
+    exiting: { key: layerKey(from.route), route: from.route },
+  }
+  if (toStacked && !fromStacked) {
+    return { kind: 'push' }
+  }
+  if (!toStacked && fromStacked) {
+    return pop
+  }
+  if (toStacked && fromStacked) {
+    // Note to note: entry ids grow monotonically, so a smaller id means the
+    // arrival walked back down the history stack.
+    return to.entryId > from.entryId ? { kind: 'push' } : pop
+  }
+  return { kind: 'none' }
+}
+
+interface LayerPresentation {
+  className?: string
+  style: CSSProperties
+}
+
+function presentLayer(
+  role: LayerRole,
+  layerRoute: Route,
+  transition: StackTransition,
+  swipe: BackSwipeState,
+): LayerPresentation {
+  const shadow = isStacked(layerRoute) ? CARD_SHADOW : undefined
+  if (role === 'below') {
+    return { style: { zIndex: 0 } }
+  }
+  if (role === 'exiting') {
+    return {
+      className: 'mobile-stack-slide-out',
+      style: {
+        transform: 'translate3d(100%, 0, 0)',
+        zIndex: 20,
+        boxShadow: shadow,
+        willChange: 'transform',
+      },
+    }
+  }
+  const base: CSSProperties = { zIndex: 10, boxShadow: shadow }
+  if (swipe.phase === 'dragging') {
+    return {
+      style: {
+        ...base,
+        transform: `translate3d(${swipe.deltaX}px, 0, 0)`,
+        willChange: 'transform',
+      },
+    }
+  }
+  if (swipe.phase === 'settling') {
+    return {
+      style: {
+        ...base,
+        transform: swipe.action === 'pop' ? 'translate3d(100%, 0, 0)' : 'translate3d(0, 0, 0)',
+        transition: `transform ${BACK_SWIPE_SETTLE_MS}ms ${SETTLE_EASING}`,
+        willChange: 'transform',
+      },
+    }
+  }
+  if (transition.kind === 'push') {
+    return { className: 'mobile-stack-slide-in', style: { ...base, willChange: 'transform' } }
+  }
+  // Resting layers carry no transform at all: a transform would turn the
+  // layer into the containing block for `position: fixed` descendants (the
+  // daily screen's new-note button, floating editor UI) and shift them.
+  return { style: base }
+}
+
+/**
+ * The dim scrim over whatever a sliding card reveals. It sits above the
+ * lower screen and below the moving card, fully dimmed while covered and
+ * clearing as the card departs — depth without transforming the screen
+ * underneath (see {@link presentLayer} on why roots must not transform).
+ */
+function presentScrim(transition: StackTransition, swipe: BackSwipeState): LayerPresentation {
+  // During a pop the revealed screen IS the current layer (z 10), so the
+  // scrim rises above it while staying under the exiting card (z 20).
+  const zIndex = transition.kind === 'pop' ? 15 : 5
+  if (swipe.phase === 'dragging') {
+    return { style: { zIndex, opacity: Math.max(0, 1 - swipe.deltaX / swipe.width) } }
+  }
+  if (swipe.phase === 'settling') {
+    return {
+      style: {
+        zIndex,
+        opacity: swipe.action === 'pop' ? 0 : 1,
+        transition: `opacity ${BACK_SWIPE_SETTLE_MS}ms ${SETTLE_EASING}`,
+      },
+    }
+  }
+  if (transition.kind === 'push') {
+    return { className: 'mobile-stack-dim-in', style: { zIndex, opacity: 1 } }
+  }
+  if (transition.kind === 'pop') {
+    return { className: 'mobile-stack-dim-out', style: { zIndex, opacity: 0 } }
+  }
+  return { style: { zIndex, opacity: 1 } }
+}
+
+interface MobileStackProps {
+  /** The All tab's search text (owned by the shell — survives navigation). */
+  allQuery: string
+  onAllQueryChange: (query: string) => void
+  /** The All tab's badge filters (owned by the shell — survive navigation). */
+  allFilters: AllNotesFilters
+  onAllFiltersChange: (filters: AllNotesFilters) => void
+}
+
+/**
+ * The mobile navigation stack: V1's native-feeling push/pop restored over the
+ * typed-route history. A note screen is a card over its tab root — pushing
+ * slides it in from the right, popping slides it out, and an edge back-swipe
+ * drags it with the finger ({@link useBackSwipe}). The screen underneath
+ * stays mounted (hidden and inert) while a card covers it, so a pop reveals
+ * it live with scroll intact instead of remounting it — bounded to the one
+ * screen `back()` would land on, never the whole history.
+ *
+ * Deliberately transform-based rather than the View Transitions API: view
+ * transitions commit the DOM swap before animating, which would unmount the
+ * editor at gesture start and remount it on a canceled swipe.
+ */
+export function MobileStack(props: MobileStackProps): ReactElement {
+  const { route, entryId, backRoute, canBack, back, navigate } = useRouter()
+  const reducedMotion = usePrefersReducedMotion()
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const [transition, setTransition] = useState<StackTransition>({ kind: 'none' })
+  const [arrival, setArrival] = useState({ route, entryId })
+  // Set when a completed back-swipe commits its pop: the screen is already
+  // offscreen, so the arrival it causes must not animate a second time.
+  const [poppedByGesture, setPoppedByGesture] = useState(false)
+
+  // Transition detection happens during render (the mobile-shell `lastTab`
+  // pattern) so the new screen's very first frame starts offscreen.
+  if (entryId !== arrival.entryId) {
+    setArrival({ route, entryId })
+    setPoppedByGesture(false)
+    setTransition(
+      poppedByGesture || reducedMotion
+        ? { kind: 'none' }
+        : transitionFor(arrival, { route, entryId }),
+    )
+  } else if (route !== arrival.route) {
+    // Same entry, new route object: a note move rewrote the history in
+    // place. Track it so a later pop's exiting card shows the live path.
+    setArrival({ route, entryId })
+  }
+
+  const swipe = useBackSwipe({
+    enabled: isStacked(route) && transition.kind === 'none',
+    reducedMotion,
+    containerRef,
+    onPop: () => {
+      setPoppedByGesture(true)
+      if (canBack) {
+        back()
+      } else {
+        navigate({ kind: 'today' })
+      }
+    },
+  })
+
+  const finishTransition = useCallback((): void => {
+    setTransition((current) => (current.kind === 'none' ? current : { kind: 'none' }))
+  }, [])
+
+  // `animationend` is the fast path; this backstops a missed event.
+  useEffect(() => {
+    if (transition.kind === 'none') {
+      return
+    }
+    const timer = setTimeout(finishTransition, TRANSITION_MS + 80)
+    return () => clearTimeout(timer)
+  }, [transition, finishTransition])
+
+  // Completion listeners live on the container as native listeners — React's
+  // synthetic animation/transition events register vendor-detected names and
+  // never fire in some hosts. Both events bubble; the class guard keeps
+  // animations inside a screen (editor UI etc.) from ending a navigation.
+  const { finishSettle } = swipe
+  useEffect(() => {
+    const node = containerRef.current
+    if (!node) {
+      return
+    }
+    const isStackChrome = (target: EventTarget | null): boolean =>
+      target instanceof HTMLElement &&
+      (target.classList.contains('mobile-stack-layer') ||
+        target.classList.contains('mobile-stack-scrim'))
+    const onAnimationEnd = (event: Event): void => {
+      if (isStackChrome(event.target)) {
+        finishTransition()
+      }
+    }
+    const onTransitionEnd = (event: Event): void => {
+      if (isStackChrome(event.target)) {
+        finishSettle()
+      }
+    }
+    node.addEventListener('animationend', onAnimationEnd)
+    node.addEventListener('transitionend', onTransitionEnd)
+    return () => {
+      node.removeEventListener('animationend', onAnimationEnd)
+      node.removeEventListener('transitionend', onTransitionEnd)
+    }
+  }, [finishTransition, finishSettle])
+
+  const currentKey = layerKey(route)
+  // What the back gesture reveals. A cold note entry has no history below
+  // it, so it sits over today — where its back button lands too.
+  const belowRoute: Route | null = isStacked(route) ? backRoute ?? { kind: 'today' } : null
+  const belowKey = belowRoute === null ? null : layerKey(belowRoute)
+
+  const layers: StackLayer[] = []
+  if (belowRoute !== null && belowKey !== null && belowKey !== currentKey) {
+    layers.push({ key: belowKey, route: belowRoute, role: 'below' })
+  }
+  layers.push({ key: currentKey, route, role: 'current' })
+  if (
+    transition.kind === 'pop' &&
+    transition.exiting.key !== currentKey &&
+    transition.exiting.key !== belowKey
+  ) {
+    layers.push({ key: transition.exiting.key, route: transition.exiting.route, role: 'exiting' })
+  }
+
+  const showScrim = belowRoute !== null || transition.kind === 'pop'
+  const scrim = showScrim ? presentScrim(transition, swipe.state) : null
+
+  return (
+    <div
+      ref={containerRef}
+      className="mobile-stack relative h-full overflow-hidden"
+      {...swipe.handlers}
+    >
+      {layers.map((layer) => {
+        const { className, style } = presentLayer(layer.role, layer.route, transition, swipe.state)
+        const hidden = layer.role !== 'current'
+        return (
+          <div
+            key={layer.key}
+            className={`mobile-stack-layer absolute inset-0 bg-background ${className ?? ''}`}
+            style={style}
+            aria-hidden={hidden || undefined}
+            inert={hidden}
+          >
+            <MobileScreen route={layer.route} {...props} />
+          </div>
+        )
+      })}
+      {scrim ? (
+        <div
+          aria-hidden
+          className={`mobile-stack-scrim pointer-events-none absolute inset-0 bg-black/25 ${scrim.className ?? ''}`}
+          style={scrim.style}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/apps/desktop/src/mobile/use-back-swipe.ts
+++ b/apps/desktop/src/mobile/use-back-swipe.ts
@@ -1,0 +1,272 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type RefObject,
+} from 'react'
+
+/** How far from the leading edge a touch may start and still arm the gesture. */
+const EDGE_WIDTH_PX = 32
+/** Horizontal travel that commits an armed touch to the gesture. */
+const ACTIVATE_DX_PX = 8
+/** Vertical travel that disarms an edge touch — it's a scroll, not a swipe. */
+const DISARM_DY_PX = 16
+/** Fraction of the screen width past which a release pops. */
+const POP_FRACTION = 0.4
+/** A rightward flick (px/ms) pops even short of the distance threshold... */
+const POP_VELOCITY_PX_PER_MS = 0.35
+/** ...as long as the finger actually travelled somewhere. */
+const MIN_FLICK_DX_PX = 24
+/**
+ * Velocity is sampled over windows of at least this long — instantaneous
+ * per-event velocity is far too jittery to gate a pop on.
+ */
+const VELOCITY_WINDOW_MS = 30
+/** A velocity sample older than this at release means the finger stopped. */
+const VELOCITY_STALE_MS = 4 * VELOCITY_WINDOW_MS
+
+/** How long a released screen takes to settle on- or off-screen. */
+export const BACK_SWIPE_SETTLE_MS = 300
+
+export type BackSwipeState =
+  | { phase: 'idle' }
+  /** An edge touch that hasn't shown horizontal intent yet — nothing moves. */
+  | { phase: 'armed'; pointerId: number; startX: number; startY: number }
+  /** The finger owns the screen: `deltaX` is how far it has dragged it. */
+  | {
+      phase: 'dragging'
+      pointerId: number
+      startX: number
+      width: number
+      deltaX: number
+      velocity: number
+      sampleDeltaX: number
+      sampleTime: number
+    }
+  /** Released — the screen is animating off (`pop`) or back home (`cancel`). */
+  | { phase: 'settling'; action: 'pop' | 'cancel'; width: number }
+
+const IDLE: BackSwipeState = { phase: 'idle' }
+
+export interface BackSwipeOptions {
+  /** Arm the gesture only on stacked screens with no transition running. */
+  enabled: boolean
+  /** Skip the settle animation and commit the pop on release. */
+  reducedMotion: boolean
+  /** Commit the pop once the screen has settled offscreen. */
+  onPop: () => void
+  /** The stack container — gets a non-passive scroll blocker while dragging. */
+  containerRef: RefObject<HTMLElement | null>
+}
+
+export interface BackSwipe {
+  state: BackSwipeState
+  handlers: {
+    onPointerDown: (event: ReactPointerEvent<HTMLElement>) => void
+    onPointerMove: (event: ReactPointerEvent<HTMLElement>) => void
+    onPointerUp: (event: ReactPointerEvent<HTMLElement>) => void
+    onPointerCancel: (event: ReactPointerEvent<HTMLElement>) => void
+  }
+  /** Complete a settle — call from `transitionend` (a timer backstops it). */
+  finishSettle: () => void
+}
+
+/**
+ * The iOS edge back-swipe (Plan 19 shell polish): a touch starting at the
+ * leading edge of a stacked screen drags it with the finger and pops it on
+ * release — past 40% of the width or on a rightward flick — else it snaps
+ * back. Touch-only, and inert until the finger proves horizontal intent, so
+ * edge taps (the back button) and vertical scrolling never notice it. The
+ * hook owns the pointer state machine; the stack renders `state` into
+ * transforms and calls `onPop` through its own transition suppression.
+ *
+ * The authoritative state lives in a ref and is mirrored into React state
+ * for rendering: decisions (and the `onPop` side effect) happen in plain
+ * handler code, never inside setState updaters — updaters must stay pure
+ * (StrictMode double-invokes them), and the card's and the scrim's settle
+ * `transitionend` can land in the same frame, so completion needs a
+ * synchronous once-guard.
+ */
+export function useBackSwipe({ enabled, reducedMotion, onPop, containerRef }: BackSwipeOptions): BackSwipe {
+  const stateRef = useRef<BackSwipeState>(IDLE)
+  const [state, setState] = useState<BackSwipeState>(IDLE)
+
+  const commit = useCallback((next: BackSwipeState): void => {
+    stateRef.current = next
+    setState(next)
+  }, [])
+
+  // Navigation elsewhere (or a transition starting) invalidates the gesture.
+  // Adjusted during render — the derive-state pattern — so a disabled stack
+  // never paints a dragged frame. The ref write must be visible to this same
+  // render (the router's currentId does the same; see router.tsx).
+  if (!enabled && state.phase !== 'idle') {
+    // eslint-disable-next-line react-hooks/refs
+    stateRef.current = IDLE
+    setState(IDLE)
+  }
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      if (!enabled || event.pointerType !== 'touch' || !event.isPrimary) {
+        return
+      }
+      if (stateRef.current.phase !== 'idle') {
+        return
+      }
+      const edgeX = event.clientX - event.currentTarget.getBoundingClientRect().left
+      if (edgeX > EDGE_WIDTH_PX) {
+        return
+      }
+      commit({
+        phase: 'armed',
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+      })
+    },
+    [enabled, commit],
+  )
+
+  const onPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      const current = stateRef.current
+      const { clientX, clientY, pointerId } = event
+      if (current.phase === 'armed' && current.pointerId === pointerId) {
+        const deltaX = clientX - current.startX
+        const deltaY = Math.abs(clientY - current.startY)
+        if ((deltaY > DISARM_DY_PX && deltaY >= deltaX) || deltaX < -ACTIVATE_DX_PX) {
+          commit(IDLE)
+          return
+        }
+        if (deltaX >= ACTIVATE_DX_PX && deltaX > deltaY) {
+          try {
+            event.currentTarget.setPointerCapture?.(pointerId)
+          } catch {
+            // Synthetic events (tests) have no live pointer to capture.
+          }
+          const width = event.currentTarget.getBoundingClientRect().width || window.innerWidth
+          const clamped = Math.max(0, deltaX)
+          commit({
+            phase: 'dragging',
+            pointerId,
+            startX: current.startX,
+            width,
+            deltaX: clamped,
+            velocity: 0,
+            sampleDeltaX: clamped,
+            sampleTime: performance.now(),
+          })
+        }
+        return
+      }
+      if (current.phase === 'dragging' && current.pointerId === pointerId) {
+        const deltaX = Math.max(0, clientX - current.startX)
+        const now = performance.now()
+        const elapsed = now - current.sampleTime
+        if (elapsed < VELOCITY_WINDOW_MS) {
+          commit({ ...current, deltaX })
+          return
+        }
+        commit({
+          ...current,
+          deltaX,
+          velocity: (deltaX - current.sampleDeltaX) / elapsed,
+          sampleDeltaX: deltaX,
+          sampleTime: now,
+        })
+      }
+    },
+    [commit],
+  )
+
+  const release = useCallback(
+    (event: ReactPointerEvent<HTMLElement>, interrupted: boolean) => {
+      const current = stateRef.current
+      if (
+        (current.phase !== 'armed' && current.phase !== 'dragging') ||
+        current.pointerId !== event.pointerId
+      ) {
+        return
+      }
+      if (current.phase === 'armed') {
+        commit(IDLE)
+        return
+      }
+      // A flick only counts if the finger was still moving near release —
+      // a stale sample means it stopped (holding emits no move events).
+      const flicked =
+        current.velocity > POP_VELOCITY_PX_PER_MS &&
+        current.deltaX > MIN_FLICK_DX_PX &&
+        performance.now() - current.sampleTime <= VELOCITY_STALE_MS
+      const pops =
+        !interrupted && (current.deltaX > current.width * POP_FRACTION || flicked)
+      if (reducedMotion) {
+        commit(IDLE)
+        if (pops) {
+          onPop()
+        }
+        return
+      }
+      commit({ phase: 'settling', action: pops ? 'pop' : 'cancel', width: current.width })
+    },
+    [reducedMotion, onPop, commit],
+  )
+
+  const onPointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => release(event, false),
+    [release],
+  )
+  // A cancel means the browser claimed the touch (native scroll won the
+  // race) — never pop from one, just put the screen back.
+  const onPointerCancel = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => release(event, true),
+    [release],
+  )
+
+  const finishSettle = useCallback(() => {
+    const current = stateRef.current
+    if (current.phase !== 'settling') {
+      return
+    }
+    // Commit before the side effect: the guard must be synchronous so the
+    // second same-frame `transitionend` (card + scrim) sees idle.
+    commit(IDLE)
+    if (current.action === 'pop') {
+      onPop()
+    }
+  }, [onPop, commit])
+
+  // `transitionend` is the fast path; this backstops a missed event.
+  useEffect(() => {
+    if (state.phase !== 'settling') {
+      return
+    }
+    const timer = setTimeout(finishSettle, BACK_SWIPE_SETTLE_MS + 80)
+    return () => clearTimeout(timer)
+  }, [state, finishSettle])
+
+  // React registers touch listeners passively, so blocking the page's own
+  // vertical scroll while a drag owns the screen needs a native listener.
+  useEffect(() => {
+    const node = containerRef.current
+    if (!node) {
+      return
+    }
+    const blockScroll = (event: TouchEvent): void => {
+      if (stateRef.current.phase === 'dragging') {
+        event.preventDefault()
+      }
+    }
+    node.addEventListener('touchmove', blockScroll, { passive: false })
+    return () => node.removeEventListener('touchmove', blockScroll)
+  }, [containerRef])
+
+  return {
+    state,
+    handlers: { onPointerDown, onPointerMove, onPointerUp, onPointerCancel },
+    finishSettle,
+  }
+}

--- a/apps/desktop/src/mobile/use-reduced-motion.ts
+++ b/apps/desktop/src/mobile/use-reduced-motion.ts
@@ -1,0 +1,29 @@
+import { useSyncExternalStore } from 'react'
+
+const QUERY = '(prefers-reduced-motion: reduce)'
+
+function subscribe(onChange: () => void): () => void {
+  if (typeof window.matchMedia !== 'function') {
+    return () => {}
+  }
+  const media = window.matchMedia(QUERY)
+  // Older WebKit exposes only the deprecated listener API.
+  if (typeof media.addEventListener === 'function') {
+    media.addEventListener('change', onChange)
+    return () => media.removeEventListener('change', onChange)
+  }
+  media.addListener(onChange)
+  return () => media.removeListener(onChange)
+}
+
+function getSnapshot(): boolean {
+  return typeof window.matchMedia === 'function' && window.matchMedia(QUERY).matches
+}
+
+/**
+ * Whether the user prefers reduced motion, live — navigation transitions and
+ * gesture settles switch to instant cuts while this is true.
+ */
+export function usePrefersReducedMotion(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot)
+}

--- a/apps/desktop/src/routing/router.test.tsx
+++ b/apps/desktop/src/routing/router.test.tsx
@@ -1,9 +1,9 @@
-import { act, renderHook } from '@testing-library/react'
+import { act, render, renderHook } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
-import type { ReactNode } from 'react'
+import type { ReactElement, ReactNode } from 'react'
 import { emitNoteMoved } from '@/lib/note-moves'
 import type { Route } from './route'
-import { RouterProvider, useRouter } from './router'
+import { RouterFreeze, RouterProvider, useRouter } from './router'
 
 function routerHook(initialRoute?: Route) {
   return renderHook(() => useRouter(), {
@@ -190,6 +190,42 @@ describe('router', () => {
     expect(result.current.entryId).toBe(todayId)
     act(() => result.current.forward())
     expect(result.current.entryId).toBe(noteId)
+  })
+
+  it('RouterFreeze pins what a background subtree sees until it surfaces', () => {
+    let router: ReturnType<typeof useRouter> | null = null
+    function Capture(): null {
+      router = useRouter()
+      return null
+    }
+    function Probe(): ReactElement {
+      const { route, arrivalSeq } = useRouter()
+      return <div data-testid="frozen-probe">{`${route.kind}:${arrivalSeq}`}</div>
+    }
+    function Harness({ frozen }: { frozen: boolean }): ReactElement {
+      return (
+        <RouterProvider>
+          <Capture />
+          <RouterFreeze frozen={frozen}>
+            <Probe />
+          </RouterFreeze>
+        </RouterProvider>
+      )
+    }
+
+    const view = render(<Harness frozen={false} />)
+    expect(view.getByTestId('frozen-probe').textContent).toBe('today:0')
+
+    // Covered by a pushed note (the mobile stack hides it): navigations must
+    // not reach it — the daily surface would read the arrivalSeq bump as a
+    // re-arrival and re-anchor its scroll while hidden.
+    view.rerender(<Harness frozen={true} />)
+    act(() => router!.navigate({ kind: 'note', path: 'notes/a.md' }))
+    expect(view.getByTestId('frozen-probe').textContent).toBe('today:0')
+
+    // Surfacing again resumes the live value.
+    view.rerender(<Harness frozen={false} />)
+    expect(view.getByTestId('frozen-probe').textContent).toBe('note:1')
   })
 
   it('exposes the route back() would land on (the mobile stack peeks it)', () => {

--- a/apps/desktop/src/routing/router.test.tsx
+++ b/apps/desktop/src/routing/router.test.tsx
@@ -192,6 +192,19 @@ describe('router', () => {
     expect(result.current.entryId).toBe(noteId)
   })
 
+  it('exposes the route back() would land on (the mobile stack peeks it)', () => {
+    const { result } = routerHook()
+    expect(result.current.backRoute).toBeNull()
+    act(() => result.current.navigate({ kind: 'note', path: 'notes/a.md' }))
+    expect(result.current.backRoute).toEqual({ kind: 'today' })
+    act(() => result.current.navigate({ kind: 'note', path: 'notes/b.md' }))
+    expect(result.current.backRoute).toEqual({ kind: 'note', path: 'notes/a.md' })
+    act(() => result.current.back())
+    expect(result.current.backRoute).toEqual({ kind: 'today' })
+    act(() => result.current.back())
+    expect(result.current.backRoute).toBeNull()
+  })
+
   it('normalizes a malformed daily date to the today route on navigate', () => {
     const { result } = routerHook()
     // 2026-02-31 is well-formed but impossible — dailyPath would throw on it.

--- a/apps/desktop/src/routing/router.tsx
+++ b/apps/desktop/src/routing/router.tsx
@@ -295,3 +295,32 @@ export function useRouter(): RouterValue {
   }
   return context
 }
+
+interface RouterFreezeProps {
+  /** While true, the subtree keeps the last router value it saw unfrozen. */
+  frozen: boolean
+  children: ReactNode
+}
+
+/**
+ * Pin the router value a subtree sees while it is in the background. The
+ * mobile stack keeps the screen `back()` would reveal mounted (hidden and
+ * inert) beneath a note — without this, that screen would still observe
+ * every navigation: a note push bumps `arrivalSeq`, which the daily surface
+ * reads as a re-arrival and re-anchors its scroll while nobody is looking.
+ * Frozen subtrees resume the live value the moment they surface again; the
+ * navigation callbacks in the frozen snapshot stay valid because they are
+ * stable for the provider's lifetime.
+ */
+export function RouterFreeze({ frozen, children }: RouterFreezeProps): ReactElement {
+  const live = useRouter()
+  // The capture tracks the live value only while unfrozen — state adjusted
+  // during render, so freezing pins exactly what the last unfrozen commit saw.
+  const [captured, setCaptured] = useState(live)
+  if (!frozen && captured !== live) {
+    setCaptured(live)
+  }
+  return (
+    <RouterContext.Provider value={frozen ? captured : live}>{children}</RouterContext.Provider>
+  )
+}

--- a/apps/desktop/src/routing/router.tsx
+++ b/apps/desktop/src/routing/router.tsx
@@ -53,6 +53,12 @@ interface RouterValue {
   forward: () => void
   canBack: boolean
   canForward: boolean
+  /**
+   * The route `back()` would land on — the entry just below the current one —
+   * or `null` at the bottom of the stack. The mobile stack renders it beneath
+   * a pushed note so the back-swipe gesture reveals a live screen.
+   */
+  backRoute: Route | null
   /** Record the active view's scroll offset on the current history entry. */
   saveScrollState: (offset: number) => void
   /**
@@ -261,6 +267,7 @@ export function RouterProvider({
       forward,
       canBack: history.index > 0,
       canForward: history.index < history.stack.length - 1,
+      backRoute: history.index > 0 ? history.stack[history.index - 1]!.route : null,
       saveScrollState,
       clearScrollState,
       savedScroll,

--- a/docs/porting/reflect-mobile/app-shell-and-navigation.md
+++ b/docs/porting/reflect-mobile/app-shell-and-navigation.md
@@ -91,7 +91,12 @@ not already present:
   plugin's `impact_light` command (`UIImpactFeedbackGenerator`), fired from
   `src/mobile/haptics.ts` in the tab bar and the calendar strip.
 - Wake-to-today on foreground date change.
-- Back-swipe and stack transitions on the note detail screen.
+- ~~Back-swipe and stack transitions on the note detail screen~~ — done:
+  `src/mobile/mobile-stack.tsx` renders note screens as cards over their tab
+  root (slide-in push, slide-out pop, tab switches stay instant) and
+  `src/mobile/use-back-swipe.ts` is the edge back-swipe. Transform-based on
+  purpose: the View Transitions API commits the DOM swap before animating,
+  which would remount the editor on every canceled swipe.
 - Status-bar-tap scroll-to-top, if reachable from the Tauri shell.
 
 ## V1 → v2 mapping


### PR DESCRIPTION
## Summary

The remaining shell-polish item from [app-shell-and-navigation.md](docs/porting/reflect-mobile/app-shell-and-navigation.md): V1's native-feeling navigation on the note detail screen, which Ionic used to give for free. Pushing a note slides it in from the right as a card over its tab root, popping slides it out, and the iOS edge back-swipe tracks the finger — popping past 40% of the width or on a flick, snapping back otherwise. Tab switches stay instant (no fake pushes), and `prefers-reduced-motion` cuts every animation to an instant switch.

## How it works

- **`mobile-stack.tsx`** — a small stack presenter between `MobileShell` and `MobileScreen`. While a note is on top, the screen `back()` would land on (exposed by the router's new read-only `backRoute`) stays mounted beneath it, `aria-hidden` + `inert`, so the gesture reveals a live screen and a pop restores it with scroll intact — bounded to one screen, never the whole history. Transition direction derives from route depth (only `note` routes stack) and history entry order for note→note moves. Layer keys mirror `MobileScreen`'s existing surface keys, so the day carousel never remounts.
- **`use-back-swipe.ts`** — touch-only pointer state machine. Arms within 32px of the leading edge, activates only once the finger proves horizontal intent (dx > 8px, dx > dy), so edge taps (the back button) and vertical scrolls never notice it; `pointercancel` (native scroll winning) snaps back rather than popping. Velocity is sampled over ≥30ms windows with a staleness check at release, so a drag-then-hold release doesn't count as a flick.
- **Transform-based on purpose, not the View Transitions API.** Same-document view transitions commit the DOM swap before animating: a scrubbing back-swipe would have to pop the route (unmounting the editor) at gesture start and re-push on cancel — two editor remounts per canceled swipe. Also still needs a fallback below iOS 18 (deployment target is 14.0).
- **The screen underneath is never transformed.** A transform would turn that layer into the containing block for its `position: fixed` children (the daily screen's `+` button) and visibly shift them. Depth comes from a dim scrim (opacity tied to gesture progress) and a card edge shadow instead of iOS parallax.
- **Completion via native `animationend`/`transitionend` listeners** on the container (React's synthetic versions register vendor-detected event names and don't fire in some hosts), with duration+80ms timers as backstops so a missed event can never wedge a transition.

## Bug found during verification

StrictMode's dev double-invocation of setState updaters exposed an `onPop()` side effect inside an updater — a swipe-pop fired `back()` twice and sailed past the All tab to Daily. The hook now keeps authoritative state in a ref, makes decisions in plain handler code, and commits the pop behind a synchronous once-guard (the card's and scrim's `transitionend` can land in the same frame). Covered by a StrictMode + double-`transitionend` regression test.

## Testing

- `pnpm check` clean; `mobile-screen.test.tsx` (20) and `router.test.tsx` (24) pass. New coverage: push keeps the origin mounted/inert, pop unmounts after the exit animation, tab switches stay single-layer, note-chain direction, reduced-motion instant cuts, gesture pop past threshold, short-swipe snap-back, mid-screen/mouse/vertical-scroll non-triggers, exactly-once pop commit.
- Verified live in the `?platform=ios` browser harness (PR #481): push/pop slides, finger-tracked drag with proportional scrim fade (screenshot mid-drag looked right), threshold pop landing on the correct history entry, short-swipe cancel.
- Not yet verified on a real device/simulator — Alex is taking that pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core mobile navigation and router context (multi-mounted screens, gesture-driven `back()`), with regression coverage but behavior still needs real-device verification per the PR notes.
> 
> **Overview**
> Replaces single-screen routing in the mobile shell with **`MobileStack`**: note routes slide in as cards over their tab root (Daily/All), slide out on back, and **tab switches stay instant**. The screen `back()` would reveal stays **mounted beneath** the note (`aria-hidden`, `inert`, **`RouterFreeze`**) so pops restore scroll instead of remounting.
> 
> Adds **`useBackSwipe`** (touch-only edge gesture, distance/flick thresholds, snap-back) and **`usePrefersReducedMotion`** for instant cuts. **`MobileScreen`** now takes an explicit **`route` prop** because multiple layers can be mounted. Router gains **`backRoute`** and **`RouterFreeze`** for peek-under behavior and frozen background subtrees.
> 
> Includes slide/dim **CSS**, broad **integration tests** (push/pop, gestures, StrictMode double-pop guard), and marks back-swipe/stack transitions **done** in the mobile porting doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26d32805f221b03c1ece633e0dfa693a4fe68d23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added animated mobile navigation between screens, including stacked note cards, instant tab switching, and smoother route transitions.
  * Added edge-swipe back navigation with drag, snap-back, and reduced-motion support.

* **Bug Fixes**
  * Improved handling of hidden screens so interactions stay focused on the visible layer.
  * Preserved screen state during back navigation and transition changes.
  * Added safeguards to avoid duplicate gesture commits and accidental swipes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->