### PR TITLE
Release v0.4.0-beta.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4742,7 +4742,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.4.0-beta.13"
+version = "0.4.0-beta.14"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.4.0-beta.13"
+version = "0.4.0-beta.14"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.4.0-beta.13",
+  "version": "0.4.0-beta.14",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.4.0-beta.14.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version string updates only; no runtime, security, or behavioral code changes.
> 
> **Overview**
> **Release version bump** from `0.4.0-beta.13` to `0.4.0-beta.14` with no application or dependency logic changes in this diff.
> 
> The `reflect-open` crate version in `apps/desktop/src-tauri/Cargo.toml` and the matching entry in `Cargo.lock` are updated, and `apps/desktop/src-tauri/tauri.conf.json` `version` is aligned so packaged builds and the auto-updater see the new beta label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a316bd7ebba8884a5d4deee6279b03fd87c3ee1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->