### PR TITLE
Group calendar settings under integrations

### DIFF
--- a/apps/desktop/src/components/settings-screen.tsx
+++ b/apps/desktop/src/components/settings-screen.tsx
@@ -5,7 +5,6 @@ import { AiProvidersSection } from './settings/ai-providers-section'
 import { AllNotesSection } from './settings/all-notes-section'
 import { AppearanceSection } from './settings/appearance-section'
 import { BackupSection } from './settings/backup-section'
-import { CalendarSection } from './settings/calendar-section'
 import { DateTimeSection } from './settings/date-time-section'
 import { DestructiveSection } from './settings/destructive-section'
 import { EditorSection } from './settings/editor-section'
@@ -31,7 +30,6 @@ export function SettingsScreen(): ReactElement {
         <SearchSection />
         <AiProvidersSection />
         <AiPromptsSection />
-        <CalendarSection />
         <IntegrationsSection />
         <BackupSection />
         <AboutSection />

--- a/apps/desktop/src/components/settings/calendar-integration-field.test.tsx
+++ b/apps/desktop/src/components/settings/calendar-integration-field.test.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setBridge } from '@reflect/core'
 import { SettingsProvider } from '@/providers/settings-provider'
-import { CalendarSection } from './calendar-section'
+import { CalendarIntegrationField } from './calendar-integration-field'
 
 // The section renders only in the macOS desktop webview; jsdom is neither.
 vi.mock('@/lib/platform', () => ({ isMacosDesktop: true }))
@@ -57,7 +57,7 @@ function renderSection(): void {
   render(
     <QueryClientProvider client={queryClient}>
       <SettingsProvider>
-        <CalendarSection />
+        <CalendarIntegrationField />
       </SettingsProvider>
     </QueryClientProvider>,
   )
@@ -84,7 +84,7 @@ afterEach(() => {
   queryClient.clear()
 })
 
-describe('CalendarSection', () => {
+describe('CalendarIntegrationField', () => {
   it('starts switched off with no calendar detail', async () => {
     renderSection()
     await waitFor(() => expect(calendarSwitch().getAttribute('aria-checked')).toBe('false'))

--- a/apps/desktop/src/components/settings/calendar-integration-field.test.tsx
+++ b/apps/desktop/src/components/settings/calendar-integration-field.test.tsx
@@ -91,7 +91,7 @@ describe('CalendarIntegrationField', () => {
     expect(screen.queryByText(/calendars/i)).toBeNull()
   })
 
-  it('enabling requests access, persists the setting, and lists calendars by account', async () => {
+  it('enabling requests access, persists the setting, and opens the calendar chooser dialog', async () => {
     renderSection()
     await waitFor(() => expect(calendarSwitch().getAttribute('aria-checked')).toBe('false'))
 
@@ -100,7 +100,13 @@ describe('CalendarIntegrationField', () => {
     await waitFor(() =>
       expect(saved.at(-1)).toMatchObject({ calendarEnabled: true, calendarIds: [] }),
     )
-    await waitFor(() => expect(screen.getByText('0/2 calendars')).toBeTruthy())
+    await waitFor(() => expect(screen.getByText('0/2 calendars selected')).toBeTruthy())
+    expect(screen.queryByText('Google')).toBeNull()
+    expect(screen.queryByText('iCloud')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /choose calendars/i }))
+
+    expect(await screen.findByRole('dialog', { name: 'Choose calendars' })).toBeTruthy()
     expect(screen.getByText('Google')).toBeTruthy()
     expect(screen.getByText('iCloud')).toBeTruthy()
     expect(screen.getByRole('checkbox', { name: 'Work' })).toBeTruthy()
@@ -130,12 +136,14 @@ describe('CalendarIntegrationField', () => {
     stored = { calendarEnabled: true }
     authStatus = 'fullAccess'
     renderSection()
+    await screen.findByText('0/2 calendars selected')
+    fireEvent.click(screen.getByRole('button', { name: /choose calendars/i }))
     const work = await screen.findByRole('checkbox', { name: 'Work' })
 
     fireEvent.click(work)
 
     await waitFor(() => expect(saved.at(-1)).toMatchObject({ calendarIds: ['cal-work'] }))
-    await waitFor(() => expect(screen.getByText('1/2 calendars')).toBeTruthy())
+    await waitFor(() => expect(screen.getByText('1/2 calendars selected')).toBeTruthy())
   })
 
   it('counts only ids the Mac still knows, ignoring stale ones', async () => {
@@ -143,7 +151,7 @@ describe('CalendarIntegrationField', () => {
     authStatus = 'fullAccess'
     renderSection()
 
-    await waitFor(() => expect(screen.getByText('1/2 calendars')).toBeTruthy())
+    await waitFor(() => expect(screen.getByText('1/2 calendars selected')).toBeTruthy())
   })
 
   it('denied access shows the explanation and deep-links to System Settings', async () => {
@@ -174,6 +182,6 @@ describe('CalendarIntegrationField', () => {
     await waitFor(() => expect(invoked).toContain('calendar_request_access'))
     // The grant resolved and the invalidated auth query re-ran: the calendar
     // list replaces the permission explanation.
-    await waitFor(() => expect(screen.getByText('0/2 calendars')).toBeTruthy())
+    await waitFor(() => expect(screen.getByText('0/2 calendars selected')).toBeTruthy())
   })
 })

--- a/apps/desktop/src/components/settings/calendar-integration-field.tsx
+++ b/apps/desktop/src/components/settings/calendar-integration-field.tsx
@@ -12,7 +12,6 @@ import {
   useCalendars,
 } from '@/lib/use-calendar'
 import { useSettings } from '@/providers/settings-provider'
-import { SettingsSection } from './section'
 import { SettingsSwitchField } from './switch-field'
 
 /** The macOS privacy pane where a revoked calendar grant is flipped back on. */
@@ -23,15 +22,15 @@ const ACTION_BUTTON_CLASS =
   'rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-text-secondary transition-colors duration-100 hover:bg-surface-hover'
 
 /**
- * The calendar integration settings (docs/porting/calendar-meetings-integration.md):
+ * The calendar integration field (docs/porting/calendar-meetings-integration.md):
  * one switch, then — once macOS grants access — every calendar on the Mac as
  * checkboxes, grouped by account. There are no credentials here and none to
  * go stale: macOS Calendar owns the accounts (Google, iCloud, Exchange), so a
  * denied or revoked grant shows one explanation with a System Settings
- * button, not an error-badge-and-reconnect loop. macOS-only; the section
+ * button, not an error-badge-and-reconnect loop. macOS-only; the field
  * renders nothing elsewhere.
  */
-export function CalendarSection(): ReactElement | null {
+export function CalendarIntegrationField(): ReactElement | null {
   const { settings, updateSettings, updateSettingsWith } = useSettings()
   const queryClient = useQueryClient()
   const status = useCalendarAuthorization(settings.calendarEnabled)
@@ -162,16 +161,14 @@ export function CalendarSection(): ReactElement | null {
   }
 
   return (
-    <SettingsSection id="calendar">
-      <div>
-        <SettingsSwitchField
-          legend="Calendar events"
-          description="Show the day's meetings from Apple Calendar beside the daily note."
-          checked={settings.calendarEnabled}
-          onCheckedChange={handleToggle}
-        />
-        {detail !== null && <div className="px-4 pb-3.5">{detail}</div>}
-      </div>
-    </SettingsSection>
+    <div>
+      <SettingsSwitchField
+        legend="Calendar events"
+        description="Show the day's meetings from Apple Calendar beside the daily note."
+        checked={settings.calendarEnabled}
+        onCheckedChange={handleToggle}
+      />
+      {detail !== null && <div className="px-4 pb-3.5">{detail}</div>}
+    </div>
   )
 }

--- a/apps/desktop/src/components/settings/calendar-integration-field.tsx
+++ b/apps/desktop/src/components/settings/calendar-integration-field.tsx
@@ -3,7 +3,17 @@ import { useQueryClient } from '@tanstack/react-query'
 import { openUrl } from '@tauri-apps/plugin-opener'
 import { canReadCalendars, requestCalendarAccess, type CalendarInfo } from '@reflect/core'
 import { InlineAlert } from '@/components/inline-alert'
+import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
 import { isMacosDesktop } from '@/lib/platform'
 import {
   CALENDAR_QUERY_PREFIX,
@@ -23,12 +33,12 @@ const ACTION_BUTTON_CLASS =
 
 /**
  * The calendar integration field (docs/porting/calendar-meetings-integration.md):
- * one switch, then — once macOS grants access — every calendar on the Mac as
- * checkboxes, grouped by account. There are no credentials here and none to
- * go stale: macOS Calendar owns the accounts (Google, iCloud, Exchange), so a
- * denied or revoked grant shows one explanation with a System Settings
- * button, not an error-badge-and-reconnect loop. macOS-only; the field
- * renders nothing elsewhere.
+ * one switch, then a compact calendar count with the full per-calendar
+ * chooser in a dialog. There are no credentials here and none to go stale:
+ * macOS Calendar owns the accounts (Google, iCloud, Exchange), so a denied
+ * or revoked grant shows one explanation with a System Settings button, not
+ * an error-badge-and-reconnect loop. macOS-only; the field renders nothing
+ * elsewhere.
  */
 export function CalendarIntegrationField(): ReactElement | null {
   const { settings, updateSettings, updateSettingsWith } = useSettings()
@@ -124,38 +134,58 @@ export function CalendarIntegrationField(): ReactElement | null {
           No calendars found. Add accounts in System Settings → Internet Accounts.
         </p>
       ) : (
-        <div>
+        <div className="flex flex-wrap items-center justify-between gap-2">
           <p className="text-xs text-text-muted">
-            {enabledCount}/{calendars.length} calendars
+            {enabledCount}/{calendars.length} calendars selected
           </p>
-          <div className="mt-2 space-y-3">
-            {groups.map(([source, group]) => (
-              <div key={source}>
-                <p className="text-2xs font-medium text-text-muted">{source}</p>
-                <ul className="mt-1 space-y-1.5">
-                  {group.map((calendar) => (
-                    <li key={calendar.id}>
-                      <label className="flex cursor-pointer items-center gap-2 text-sm text-text-secondary">
-                        <Checkbox
-                          checked={settings.calendarIds.includes(calendar.id)}
-                          onCheckedChange={(checked) => toggleCalendar(calendar.id, checked === true)}
-                          aria-label={calendar.title}
-                        />
-                        {calendar.color !== null && (
-                          <span
-                            aria-hidden
-                            className="size-2 shrink-0 rounded-full"
-                            style={{ backgroundColor: calendar.color }}
-                          />
-                        )}
-                        <span className="truncate">{calendar.title}</span>
-                      </label>
-                    </li>
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button type="button" variant="outline" size="sm">
+                Choose calendars…
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-md">
+              <DialogHeader>
+                <DialogTitle>Choose calendars</DialogTitle>
+                <DialogDescription>
+                  Select the calendars Reflect shows beside your daily note.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="max-h-[min(28rem,70vh)] overflow-y-auto pr-1">
+                <div className="space-y-4">
+                  {groups.map(([source, group]) => (
+                    <div key={source}>
+                      <p className="text-2xs font-medium text-text-muted">{source}</p>
+                      <ul className="mt-2 space-y-2">
+                        {group.map((calendar) => (
+                          <li key={calendar.id}>
+                            <label className="flex cursor-pointer items-center gap-2 text-sm text-text-secondary">
+                              <Checkbox
+                                checked={settings.calendarIds.includes(calendar.id)}
+                                onCheckedChange={(checked) =>
+                                  toggleCalendar(calendar.id, checked === true)
+                                }
+                                aria-label={calendar.title}
+                              />
+                              {calendar.color !== null && (
+                                <span
+                                  aria-hidden
+                                  className="size-2 shrink-0 rounded-full"
+                                  style={{ backgroundColor: calendar.color }}
+                                />
+                              )}
+                              <span className="truncate">{calendar.title}</span>
+                            </label>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
                   ))}
-                </ul>
+                </div>
               </div>
-            ))}
-          </div>
+              <DialogFooter showCloseButton />
+            </DialogContent>
+          </Dialog>
         </div>
       )
   }

--- a/apps/desktop/src/components/settings/integrations-section.test.tsx
+++ b/apps/desktop/src/components/settings/integrations-section.test.tsx
@@ -104,6 +104,6 @@ describe('IntegrationsSection', () => {
     authorization = 'unavailable'
     renderSection()
     await waitFor(() => expect(screen.queryByRole('switch')).toBeNull())
-    expect(screen.queryByText('System integrations')).toBeNull()
+    expect(screen.queryByText('Integrations')).toBeNull()
   })
 })

--- a/apps/desktop/src/components/settings/integrations-section.test.tsx
+++ b/apps/desktop/src/components/settings/integrations-section.test.tsx
@@ -7,6 +7,17 @@ import { IntegrationsSection } from './integrations-section'
 const openUrl = vi.hoisted(() => vi.fn(async () => {}))
 vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl }))
 
+const platform = vi.hoisted(() => ({ isMacosDesktop: false }))
+vi.mock('@/lib/platform', () => ({
+  get isMacosDesktop() {
+    return platform.isMacosDesktop
+  },
+}))
+
+vi.mock('./calendar-integration-field', () => ({
+  CalendarIntegrationField: () => <div>Calendar events</div>,
+}))
+
 const settings = vi.hoisted(() => ({
   current: { contactsEnabled: false },
   update: vi.fn((patch: Record<string, unknown>) => {
@@ -51,6 +62,7 @@ function renderSection(): void {
 
 beforeEach(() => {
   authorization = 'notDetermined'
+  platform.isMacosDesktop = false
   settings.current = { contactsEnabled: false }
   settings.update.mockClear()
   openUrl.mockClear()
@@ -105,5 +117,14 @@ describe('IntegrationsSection', () => {
     renderSection()
     await waitFor(() => expect(screen.queryByRole('switch')).toBeNull())
     expect(screen.queryByText('Integrations')).toBeNull()
+  })
+
+  it('keeps calendar visible on macOS when contacts are unavailable', async () => {
+    authorization = 'unavailable'
+    platform.isMacosDesktop = true
+    renderSection()
+
+    expect(await screen.findByText('Calendar events')).toBeTruthy()
+    expect(screen.queryByRole('switch', { name: 'Contacts' })).toBeNull()
   })
 })

--- a/apps/desktop/src/components/settings/integrations-section.tsx
+++ b/apps/desktop/src/components/settings/integrations-section.tsx
@@ -7,6 +7,7 @@ import {
   useRefreshContactsAuthorization,
 } from '@/hooks/use-contacts-authorization'
 import { useSettings } from '@/providers/settings-provider'
+import { CalendarIntegrationField } from './calendar-integration-field'
 import { SettingsSection } from './section'
 import { SettingsSwitchField } from './switch-field'
 
@@ -20,12 +21,13 @@ const CONTACTS_PRIVACY_PANE =
   'x-apple.systempreferences:com.apple.preference.security?Privacy_Contacts'
 
 /**
- * The System integrations section (the contacts-integration port): a Contacts
- * switch backed by live `CNContactStore` reads — permission on/off is the
- * whole state, so there is no sync status to show. Turning it on triggers the
- * OS permission prompt; a denial keeps the switch on and points at System
- * Settings, since the app cannot re-prompt once the user has decided. The
- * section renders only where the framework exists (macOS/iOS) — see
+ * The Integrations section: Apple Contacts and Calendar live together here
+ * because both are OS-backed context sources. The Contacts switch is backed
+ * by live `CNContactStore` reads — permission on/off is the whole state, so
+ * there is no sync status to show. Turning it on triggers the OS permission
+ * prompt; a denial keeps the switch on and points at System Settings, since
+ * the app cannot re-prompt once the user has decided. The section renders
+ * only where the framework exists (macOS/iOS) — see
  * {@link useVisibleSettingsSections}.
  */
 export function IntegrationsSection(): ReactElement | null {
@@ -133,6 +135,7 @@ export function IntegrationsSection(): ReactElement | null {
           </div>
         ) : null}
       </div>
+      <CalendarIntegrationField />
     </SettingsSection>
   )
 }

--- a/apps/desktop/src/components/settings/integrations-section.tsx
+++ b/apps/desktop/src/components/settings/integrations-section.tsx
@@ -6,6 +6,7 @@ import {
   useContactsAuthorization,
   useRefreshContactsAuthorization,
 } from '@/hooks/use-contacts-authorization'
+import { isMacosDesktop } from '@/lib/platform'
 import { useSettings } from '@/providers/settings-provider'
 import { CalendarIntegrationField } from './calendar-integration-field'
 import { SettingsSection } from './section'
@@ -50,7 +51,10 @@ export function IntegrationsSection(): ReactElement | null {
     return () => window.removeEventListener('focus', onFocus)
   }, [contactsEnabled, refreshAuthorization])
 
-  if (authorization === null || authorization === 'unavailable') {
+  const contactsAvailable = authorization !== null && authorization !== 'unavailable'
+  const calendarAvailable = isMacosDesktop
+
+  if (!contactsAvailable && !calendarAvailable) {
     return null
   }
 
@@ -85,56 +89,58 @@ export function IntegrationsSection(): ReactElement | null {
 
   return (
     <SettingsSection id="integrations">
-      <div>
-        <SettingsSwitchField
-          legend="Contacts"
-          description="Suggest a contact's email and phone when a note's title matches their name."
-          checked={settings.contactsEnabled}
-          onCheckedChange={(checked) => {
-            if (checked) {
-              void enableContacts()
-            } else {
-              updateSettings({ contactsEnabled: false })
-            }
-          }}
-        />
-        {showDenied ? (
-          <div className="px-4 pb-3.5">
-            <InlineAlert tone="warning">
-              Reflect doesn’t have contacts access.{' '}
-              <button
-                type="button"
-                className="font-medium underline underline-offset-2"
-                onClick={() => {
-                  // A rejection here is a capability-scope bug (the ACL must
-                  // allow x-apple.systempreferences:*) — surface it, don't
-                  // swallow it into a dead link.
-                  openUrl(CONTACTS_PRIVACY_PANE).catch((cause: unknown) => {
-                    console.error('failed to open System Settings', cause)
-                  })
-                }}
-              >
-                Open System Settings
-              </button>{' '}
-              to allow it, then return here.
-            </InlineAlert>
-          </div>
-        ) : null}
-        {showPrompt ? (
-          <div className="px-4 pb-3.5">
-            <InlineAlert tone="warning">
-              Reflect hasn’t asked for contacts access yet.{' '}
-              <button
-                type="button"
-                className="font-medium underline underline-offset-2"
-                onClick={() => void promptForAccess()}
-              >
-                Allow contacts access
-              </button>
-            </InlineAlert>
-          </div>
-        ) : null}
-      </div>
+      {contactsAvailable ? (
+        <div>
+          <SettingsSwitchField
+            legend="Contacts"
+            description="Suggest a contact's email and phone when a note's title matches their name."
+            checked={settings.contactsEnabled}
+            onCheckedChange={(checked) => {
+              if (checked) {
+                void enableContacts()
+              } else {
+                updateSettings({ contactsEnabled: false })
+              }
+            }}
+          />
+          {showDenied ? (
+            <div className="px-4 pb-3.5">
+              <InlineAlert tone="warning">
+                Reflect doesn’t have contacts access.{' '}
+                <button
+                  type="button"
+                  className="font-medium underline underline-offset-2"
+                  onClick={() => {
+                    // A rejection here is a capability-scope bug (the ACL must
+                    // allow x-apple.systempreferences:*) — surface it, don't
+                    // swallow it into a dead link.
+                    openUrl(CONTACTS_PRIVACY_PANE).catch((cause: unknown) => {
+                      console.error('failed to open System Settings', cause)
+                    })
+                  }}
+                >
+                  Open System Settings
+                </button>{' '}
+                to allow it, then return here.
+              </InlineAlert>
+            </div>
+          ) : null}
+          {showPrompt ? (
+            <div className="px-4 pb-3.5">
+              <InlineAlert tone="warning">
+                Reflect hasn’t asked for contacts access yet.{' '}
+                <button
+                  type="button"
+                  className="font-medium underline underline-offset-2"
+                  onClick={() => void promptForAccess()}
+                >
+                  Allow contacts access
+                </button>
+              </InlineAlert>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
       <CalendarIntegrationField />
     </SettingsSection>
   )

--- a/apps/desktop/src/components/settings/sections.ts
+++ b/apps/desktop/src/components/settings/sections.ts
@@ -12,9 +12,8 @@ export const SETTINGS_SECTIONS = [
   { id: 'search', title: 'Search' },
   { id: 'ai-providers', title: 'AI providers' },
   { id: 'ai-prompts', title: 'AI prompts' },
-  { id: 'calendar', title: 'Calendar' },
   // Only shown where the OS frameworks exist — see use-visible-settings-sections.
-  { id: 'integrations', title: 'System integrations' },
+  { id: 'integrations', title: 'Integrations' },
   { id: 'backup', title: 'Backup' },
   { id: 'about', title: 'About' },
   { id: 'destructive', title: 'Danger zone' },

--- a/apps/desktop/src/components/settings/settings-navigator.test.tsx
+++ b/apps/desktop/src/components/settings/settings-navigator.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { SETTINGS_SECTIONS, settingsSectionDomId } from './sections'
 import { SettingsNavigator } from './settings-navigator'
 
-// No bridge is installed here, so the platform-gated System integrations entry
+// No bridge is installed here, so the platform-gated Integrations entry
 // is hidden — the navigator lists the sections every platform shows.
 const VISIBLE_SECTIONS = SETTINGS_SECTIONS.filter((section) => section.id !== 'integrations')
 

--- a/apps/desktop/src/components/settings/use-visible-settings-sections.ts
+++ b/apps/desktop/src/components/settings/use-visible-settings-sections.ts
@@ -5,7 +5,7 @@ import { SETTINGS_SECTIONS } from './sections'
 export type SettingsSectionEntry = (typeof SETTINGS_SECTIONS)[number]
 
 /**
- * The settings sections this platform actually shows. System integrations
+ * The settings sections this platform actually shows. Integrations
  * only exists where the OS frameworks do (macOS/iOS — the Rust shell answers
  * `unavailable` elsewhere), and the navigator must agree with the page, so
  * both filter through here rather than reading the registry directly.

--- a/apps/desktop/src/components/settings/use-visible-settings-sections.ts
+++ b/apps/desktop/src/components/settings/use-visible-settings-sections.ts
@@ -1,4 +1,5 @@
 import { useContactsAuthorization } from '@/hooks/use-contacts-authorization'
+import { isMacosDesktop } from '@/lib/platform'
 import { SETTINGS_SECTIONS } from './sections'
 
 /** One registered settings section (see {@link SETTINGS_SECTIONS}). */
@@ -12,7 +13,8 @@ export type SettingsSectionEntry = (typeof SETTINGS_SECTIONS)[number]
  */
 export function useVisibleSettingsSections(): readonly SettingsSectionEntry[] {
   const authorization = useContactsAuthorization()
-  const hasAppleIntegrations = authorization !== null && authorization !== 'unavailable'
+  const hasAppleIntegrations =
+    isMacosDesktop || (authorization !== null && authorization !== 'unavailable')
   return SETTINGS_SECTIONS.filter(
     (section) => section.id !== 'integrations' || hasAppleIntegrations,
   )


### PR DESCRIPTION
## Problem
Contacts and calendars are both OS-backed context integrations, but Settings presented them in two different places: Contacts under `System integrations`, and Calendars as a separate top-level `Calendar` section. That made the settings navigation split closely related permissions and account context.

Also, the calendar section listed every calendar directly on the settings page, which made the Integrations section too dense once calendar moved there.

## Before -> After
| Before | After |
| --- | --- |
| `Calendar` appeared as its own settings section. | Calendar controls appear inside `Integrations`. |
| Contacts lived under `System integrations`. | Contacts and calendar settings share one `Integrations` section. |
| The settings navigator had separate `Calendar` and `System integrations` entries. | The navigator has a single `Integrations` entry for both. |
| Enabled calendars were listed inline in Settings. | Settings shows a compact selected-count row with a `Choose calendars` dialog for the full list. |

## Changes
1. Removed the standalone `calendar` section from the settings registry and stopped rendering it directly from `SettingsScreen`.
2. Renamed `CalendarSection` to `CalendarIntegrationField` so the existing calendar permission/listing behavior can live inside `IntegrationsSection` without changing the stored settings keys.
3. Renamed the section label from `System integrations` to `Integrations` and updated navigator/test comments around the platform-gated section.
4. Kept calendar visibility independent from contacts authorization so macOS calendar settings can render even while Contacts is loading or unavailable.
5. Moved the grouped calendar checkbox list into a shadcn dialog; the Settings page now only shows the selected calendar count and chooser trigger.

## Verification
- `CI=true pnpm --filter @reflect/desktop test --run src/components/settings/calendar-integration-field.test.tsx src/components/settings/integrations-section.test.tsx src/components/settings/settings-navigator.test.tsx src/components/settings-screen.test.tsx` passed: 4 files, 53 tests.
- `CI=true pnpm check` passed. Existing lint warnings remain in unrelated files.

## Risk / Rollout
No settings schema or persistence changes. Existing `calendarEnabled`, `calendarIds`, and `contactsEnabled` behavior stays intact; this only changes where the controls are associated in Settings and where the per-calendar chooser is displayed.
