### PR TITLE
Name audio memos from transcripts

### DIFF
--- a/packages/core/src/actions/audio-memo.test.ts
+++ b/packages/core/src/actions/audio-memo.test.ts
@@ -37,7 +37,8 @@ vi.mock('../ai/transcribe', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../ai/transcribe')>()),
   transcribeAudio: vi.fn(),
 }))
-vi.mock('../ai/audio-memo-title', () => ({
+vi.mock('../ai/audio-memo-title', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../ai/audio-memo-title')>()),
   generateAudioMemoTitle: generateAudioMemoTitleMock,
 }))
 vi.mock('../secrets/keychain', () => ({
@@ -57,6 +58,13 @@ const PROVIDERS: AiProvidersState = {
   providers: [{ id: 'cfg-openai', provider: 'openai', model: 'gpt-5.1', keyHint: 'wxyz1' }],
   defaultProviderId: 'cfg-openai',
 }
+
+const ANTHROPIC_CONFIG = {
+  id: 'cfg-anthropic',
+  provider: 'anthropic',
+  model: 'claude-sonnet-4-6',
+  keyHint: 'wxyz1',
+} as const
 
 /** 2026-06-11 15:30:22.845 local — every derived name is asserted from it. */
 const RECORDED_AT = new Date(2026, 5, 11, 15, 30, 22, 845)
@@ -200,8 +208,36 @@ describe('reconcileAudioMemos', () => {
       ],
     ])
     expect(generateAudioMemoTitleMock).toHaveBeenCalledWith({
-      config: PROVIDERS.providers[0],
-      apiKey: 'sk-live-key',
+      credentials: {
+        config: { ...PROVIDERS.providers[0], model: 'gpt-5.4-nano' },
+        apiKey: 'sk-live-key',
+      },
+      fetchFn: undefined,
+      transcript: 'memo transcript',
+      fallbackTitle: 'Audio memo 2026-06-11 15:30:22',
+    })
+  })
+
+  it('uses the default Anthropic Haiku entry to name a memo when configured', async () => {
+    listDirMock.mockResolvedValue([fileMeta(MEMO.audioPath)])
+    getSecretMock.mockImplementation(async (name) =>
+      name === 'ai-api-key:cfg-anthropic' ? 'sk-ant-live-key' : 'sk-live-key',
+    )
+
+    await reconcile({
+      providers: {
+        providers: [...PROVIDERS.providers, ANTHROPIC_CONFIG],
+        defaultProviderId: ANTHROPIC_CONFIG.id,
+      },
+    })
+
+    expect(getSecretMock).toHaveBeenCalledWith('ai-api-key:cfg-openai')
+    expect(getSecretMock).toHaveBeenCalledWith('ai-api-key:cfg-anthropic')
+    expect(generateAudioMemoTitleMock).toHaveBeenCalledWith({
+      credentials: {
+        config: { ...ANTHROPIC_CONFIG, model: 'claude-haiku-4-5' },
+        apiKey: 'sk-ant-live-key',
+      },
       fetchFn: undefined,
       transcript: 'memo transcript',
       fallbackTitle: 'Audio memo 2026-06-11 15:30:22',

--- a/packages/core/src/actions/audio-memo.test.ts
+++ b/packages/core/src/actions/audio-memo.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AiProvidersState } from '../ai/provider-config'
+import type { GenerateAudioMemoTitleRequest } from '../ai/audio-memo-title'
 import {
   audioMemoFromPath,
   audioMemoIdentity,
@@ -20,6 +21,10 @@ import {
 import { transcribeAudio, TranscriptionRejectedError } from '../ai/transcribe'
 import { getSecret } from '../secrets/keychain'
 
+const generateAudioMemoTitleMock = vi.hoisted(() =>
+  vi.fn<(request: GenerateAudioMemoTitleRequest) => Promise<string>>(),
+)
+
 vi.mock('../graph/commands', () => ({
   listDir: vi.fn(),
   listFiles: vi.fn(),
@@ -31,6 +36,9 @@ vi.mock('../graph/commands', () => ({
 vi.mock('../ai/transcribe', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../ai/transcribe')>()),
   transcribeAudio: vi.fn(),
+}))
+vi.mock('../ai/audio-memo-title', () => ({
+  generateAudioMemoTitle: generateAudioMemoTitleMock,
 }))
 vi.mock('../secrets/keychain', () => ({
   getSecret: vi.fn(),
@@ -72,6 +80,7 @@ beforeEach(() => {
   writeNoteMock.mockResolvedValue(undefined)
   getSecretMock.mockResolvedValue('sk-live-key')
   transcribeMock.mockResolvedValue('memo transcript')
+  generateAudioMemoTitleMock.mockResolvedValue('Memo Transcript')
 })
 
 describe('audioMemoIdentity', () => {
@@ -181,15 +190,22 @@ describe('reconcileAudioMemos', () => {
     expect(writeNoteMock.mock.calls).toEqual([
       [
         MEMO.notePath,
-        '---\naliases: [audio-memo-2026-06-11-153022-845]\n---\n\n# Audio memo 2026-06-11 15:30:22\n\n[Recording](audio-memos/audio-memo-2026-06-11-153022-845.webm)\n\nmemo transcript\n',
+        '---\naliases: [audio-memo-2026-06-11-153022-845]\n---\n\n# Memo Transcript\n\n[Recording](audio-memos/audio-memo-2026-06-11-153022-845.webm)\n\nmemo transcript\n',
         3,
       ],
       [
         'daily/2026-06-11.md',
-        'morning thoughts\n\n## Audio memos\n\n[[audio-memo-2026-06-11-153022-845|Audio memo 15:30]]\n',
+        'morning thoughts\n\n## Audio memos\n\n- [[audio-memo-2026-06-11-153022-845|Memo Transcript]]\n',
         3,
       ],
     ])
+    expect(generateAudioMemoTitleMock).toHaveBeenCalledWith({
+      config: PROVIDERS.providers[0],
+      apiKey: 'sk-live-key',
+      fetchFn: undefined,
+      transcript: 'memo transcript',
+      fallbackTitle: 'Audio memo 2026-06-11 15:30:22',
+    })
   })
 
   it('a provider-refused recording is tombstoned with a failure note; the pass continues', async () => {
@@ -244,7 +260,7 @@ describe('reconcileAudioMemos', () => {
 
     expect(writeNoteMock).toHaveBeenCalledWith(
       'daily/2026-06-11.md',
-      '## Audio memos\n\n[[audio-memo-2026-06-11-153022-845|Audio memo 15:30]]\n',
+      '## Audio memos\n\n- [[audio-memo-2026-06-11-153022-845|Memo Transcript]]\n',
       3,
     )
   })
@@ -347,7 +363,27 @@ describe('reconcileAudioMemos', () => {
     )
     expect(writeNoteMock).toHaveBeenCalledWith(
       'daily/2026-06-11.md',
-      expect.stringContaining('[[audio-memo-2026-06-11-153022-845|Audio memo 15:30]]'),
+      expect.stringContaining('- [[audio-memo-2026-06-11-153022-845|Memo Transcript]]'),
+      3,
+    )
+  })
+
+  it('uses the timestamp fallback name for silence', async () => {
+    listDirMock.mockResolvedValue([fileMeta(MEMO.audioPath)])
+    transcribeMock.mockResolvedValue('')
+
+    const outcome = await reconcile()
+
+    expect(outcome).toEqual({ pending: 1, transcribed: 1, rejected: 0, stopped: null })
+    expect(generateAudioMemoTitleMock).not.toHaveBeenCalled()
+    expect(writeNoteMock).toHaveBeenCalledWith(
+      MEMO.notePath,
+      expect.stringContaining('# Audio memo 2026-06-11 15:30:22'),
+      3,
+    )
+    expect(writeNoteMock).toHaveBeenCalledWith(
+      'daily/2026-06-11.md',
+      expect.stringContaining('- [[audio-memo-2026-06-11-153022-845|Audio memo 2026-06-11 15:30:22]]'),
       3,
     )
   })

--- a/packages/core/src/actions/audio-memo.ts
+++ b/packages/core/src/actions/audio-memo.ts
@@ -2,9 +2,10 @@ import { errorMessage, isAppError, toAppError, type AppError } from '../errors'
 import {
   pickTranscriptionConfig,
   type AiProvidersState,
-  type TranscriptionProvider,
+  type TranscriptionConfig,
 } from '../ai/provider-config'
 import { aiKeySecretName } from '../ai/secrets'
+import { generateAudioMemoTitle } from '../ai/audio-memo-title'
 import {
   AUDIO_EXTENSION_BY_MIME,
   base64ToBytes,
@@ -15,7 +16,7 @@ import {
 } from '../ai/transcribe'
 import { listDir, listFiles, readAsset, readNote, writeAsset, writeNote } from '../graph/commands'
 import { AUDIO_MEMOS_DIR, audioMemoPath, dailyPath, notePath } from '../graph/paths'
-import { appendUnderHeading } from '../markdown/edit'
+import { appendUnderHeading, wikiLinkSafe } from '../markdown/edit'
 import { getSecret } from '../secrets/keychain'
 
 /**
@@ -30,10 +31,11 @@ import { getSecret } from '../secrets/keychain'
  *    network. The sync engine commits it like any other change.
  * 2. **Reconcile** ({@link reconcileAudioMemos}): a memo's transcription is a
  *    note with the **same basename** (`notes/<base>.md`). Any memo without
- *    one is transcribed (BYOK provider), its transcription note written, and
- *    a backlink appended to its day's daily note — note first, because it
- *    carries the transcript: a failure between the two writes leaves an
- *    unlinked note, never a tombstoned memo whose transcript was dropped. A
+ *    one is transcribed (BYOK provider), named from that transcript, its
+ *    transcription note written, and a backlink appended to its day's daily
+ *    note — note first, because it carries the transcript: a failure between
+ *    the two writes leaves an unlinked note, never a tombstoned memo whose
+ *    transcript was dropped. A
  *    failed pass (offline, bad key) leaves the memo pending; the next
  *    trigger retries. Nothing is ever lost to a network error. A recording
  *    the provider *refuses* (oversized, unsupported container) is tombstoned
@@ -64,9 +66,9 @@ export interface AudioMemoIdentity {
   base: string
   /** Local ISO day it was recorded — the daily note that backlinks it. */
   date: string
-  /** The transcription note's title (its H1). Not unique within a second. */
+  /** The timestamp fallback title, before the transcript-derived name exists. */
   title: string
-  /** Short display alias for the daily-note link, e.g. `Audio memo 15:30`. */
+  /** Timestamp fallback alias for the daily-note link, e.g. `Audio memo 15:30`. */
   alias: string
   /** Graph-relative path of the recording under `audio-memos/`. */
   audioPath: string
@@ -241,8 +243,8 @@ export async function listPendingAudioMemos(generation: number): Promise<AudioMe
  * (`[[<base>|…]]`) resolves through the index — and keeps resolving if the
  * user renames the title.
  */
-function transcriptionNote(memo: AudioMemoIdentity, body: string): string {
-  return `---\naliases: [${memo.base}]\n---\n\n# ${memo.title}\n\n[Recording](${memo.audioPath})\n\n${body}\n`
+function transcriptionNote(memo: AudioMemoIdentity, title: string, body: string): string {
+  return `---\naliases: [${memo.base}]\n---\n\n# ${title}\n\n[Recording](${memo.audioPath})\n\n${body}\n`
 }
 
 /**
@@ -254,24 +256,38 @@ function transcriptionNote(memo: AudioMemoIdentity, body: string): string {
 async function memoNoteBody(input: {
   audio: Blob
   memo: AudioMemoIdentity
-  provider: TranscriptionProvider
+  config: TranscriptionConfig
   apiKey: string
   fetchFn?: typeof fetch | undefined
-}): Promise<{ body: string; rejected: boolean }> {
+}): Promise<{ body: string; title: string; rejected: boolean }> {
   try {
     const text = await transcribeAudio({
-      provider: input.provider,
+      provider: input.config.provider,
       apiKey: input.apiKey,
       audio: input.audio,
       mimeType: input.memo.mimeType,
       fetchFn: input.fetchFn,
     })
-    return { body: text === '' ? 'No speech detected.' : text, rejected: false }
+    const title =
+      text === ''
+        ? input.memo.title
+        : await generateAudioMemoTitle({
+            config: input.config,
+            apiKey: input.apiKey,
+            fetchFn: input.fetchFn,
+            transcript: text,
+            fallbackTitle: input.memo.title,
+          })
+    return { body: text === '' ? 'No speech detected.' : text, title, rejected: false }
   } catch (cause) {
     if (!isTranscriptionRejected(cause)) {
       throw cause
     }
-    return { body: `Transcription failed: ${errorMessage(cause)}`, rejected: true }
+    return {
+      body: `Transcription failed: ${errorMessage(cause)}`,
+      title: input.memo.title,
+      rejected: true,
+    }
   }
 }
 
@@ -287,12 +303,17 @@ const MEMOS_HEADING = 'Audio memos'
  * reconciles it like any external change (clean buffers reload in place;
  * dirty ones park a conflict rather than being clobbered).
  */
-async function ensureDailyBacklink(memo: AudioMemoIdentity, generation: number): Promise<void> {
+async function ensureDailyBacklink(
+  memo: AudioMemoIdentity,
+  title: string,
+  generation: number,
+): Promise<void> {
   const source = await dailyNoteSource(memo.date, generation)
   if (hasBacklink(source, memo)) {
     return
   }
-  const link = `[[${memo.base}|${memo.alias}]]`
+  const displayTitle = wikiLinkSafe(title) || memo.title
+  const link = `- [[${memo.base}|${displayTitle}]]`
   await writeNote(dailyPath(memo.date), appendUnderHeading(source, MEMOS_HEADING, link), generation)
 }
 
@@ -424,15 +445,15 @@ export async function reconcileAudioMemos(
       const note = await memoNoteBody({
         audio,
         memo,
-        provider: config.provider,
+        config,
         apiKey,
         fetchFn: input.fetchFn,
       })
       if (stale()) {
         return stalled()
       }
-      await writeNote(memo.notePath, transcriptionNote(memo, note.body), input.generation)
-      await ensureDailyBacklink(memo, input.generation)
+      await writeNote(memo.notePath, transcriptionNote(memo, note.title, note.body), input.generation)
+      await ensureDailyBacklink(memo, note.title, input.generation)
       if (note.rejected) {
         rejected += 1
       } else {

--- a/packages/core/src/actions/audio-memo.ts
+++ b/packages/core/src/actions/audio-memo.ts
@@ -5,7 +5,7 @@ import {
   type TranscriptionConfig,
 } from '../ai/provider-config'
 import { aiKeySecretName } from '../ai/secrets'
-import { generateAudioMemoTitle } from '../ai/audio-memo-title'
+import { generateAudioMemoTitle, pickAudioMemoTitleConfig } from '../ai/audio-memo-title'
 import {
   AUDIO_EXTENSION_BY_MIME,
   base64ToBytes,
@@ -18,6 +18,7 @@ import { listDir, listFiles, readAsset, readNote, writeAsset, writeNote } from '
 import { AUDIO_MEMOS_DIR, audioMemoPath, dailyPath, notePath } from '../graph/paths'
 import { appendUnderHeading, wikiLinkSafe } from '../markdown/edit'
 import { getSecret } from '../secrets/keychain'
+import type { AiProviderConfig } from '../settings/schema'
 
 /**
  * Capture actions for audio memos (the first of the `actions/` capture
@@ -258,6 +259,7 @@ async function memoNoteBody(input: {
   memo: AudioMemoIdentity
   config: TranscriptionConfig
   apiKey: string
+  titleCredentials: { config: AiProviderConfig; apiKey: string } | null
   fetchFn?: typeof fetch | undefined
 }): Promise<{ body: string; title: string; rejected: boolean }> {
   try {
@@ -272,8 +274,14 @@ async function memoNoteBody(input: {
       text === ''
         ? input.memo.title
         : await generateAudioMemoTitle({
-            config: input.config,
-            apiKey: input.apiKey,
+            ...(input.titleCredentials !== null
+              ? {
+                  credentials: {
+                    config: input.titleCredentials.config,
+                    apiKey: input.titleCredentials.apiKey,
+                  },
+                }
+              : {}),
             fetchFn: input.fetchFn,
             transcript: text,
             fallbackTitle: input.memo.title,
@@ -416,6 +424,15 @@ export async function reconcileAudioMemos(
       },
     }
   }
+  const titleConfig = pickAudioMemoTitleConfig(input.providers)
+  const titleApiKey =
+    titleConfig === null
+      ? null
+      : titleConfig.id === config.id
+        ? apiKey
+        : await getSecret(aiKeySecretName(titleConfig.id)).catch(() => null)
+  const titleCredentials =
+    titleConfig !== null && titleApiKey !== null ? { config: titleConfig, apiKey: titleApiKey } : null
 
   let transcribed = 0
   let rejected = 0
@@ -447,6 +464,7 @@ export async function reconcileAudioMemos(
         memo,
         config,
         apiKey,
+        titleCredentials,
         fetchFn: input.fetchFn,
       })
       if (stale()) {

--- a/packages/core/src/ai/audio-memo-title.test.ts
+++ b/packages/core/src/ai/audio-memo-title.test.ts
@@ -52,7 +52,7 @@ function modelAnswering(text: string): void {
   languageModelMock.mockReturnValue(
     new MockLanguageModelV3({
       doGenerate: async () => ({
-        content: [{ type: 'text', text }],
+        content: [{ type: 'text', text: JSON.stringify({ title: text }) }],
         finishReason: { unified: 'stop' as const, raw: undefined },
         usage: USAGE,
         warnings: [],

--- a/packages/core/src/ai/audio-memo-title.test.ts
+++ b/packages/core/src/ai/audio-memo-title.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MockLanguageModelV3 } from 'ai/test'
+import type { LanguageModelV3Usage } from '@ai-sdk/provider'
+import type { AiProviderConfig } from '../settings/schema'
+import { generateAudioMemoTitle } from './audio-memo-title'
+import { languageModel } from './language-model'
+
+vi.mock('./language-model', () => ({
+  languageModel: vi.fn(),
+}))
+
+const languageModelMock = vi.mocked(languageModel)
+
+const USAGE: LanguageModelV3Usage = {
+  inputTokens: { total: 1, noCache: 1, cacheRead: undefined, cacheWrite: undefined },
+  outputTokens: { total: 1, text: 1, reasoning: undefined },
+}
+
+const CONFIG: AiProviderConfig = {
+  id: 'cfg-openai',
+  provider: 'openai',
+  model: 'gpt-5.5',
+  keyHint: 'wxyz1',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+function modelAnswering(text: string): void {
+  languageModelMock.mockReturnValue(
+    new MockLanguageModelV3({
+      doGenerate: async () => ({
+        content: [{ type: 'text', text }],
+        finishReason: { unified: 'stop' as const, raw: undefined },
+        usage: USAGE,
+        warnings: [],
+      }),
+    }),
+  )
+}
+
+function modelThrowing(error: unknown): void {
+  languageModelMock.mockReturnValue(
+    new MockLanguageModelV3({
+      doGenerate: async () => {
+        throw error
+      },
+    }),
+  )
+}
+
+function request(transcript = 'talked about planning the Rome trip'): Promise<string> {
+  return generateAudioMemoTitle({
+    config: CONFIG,
+    apiKey: 'sk-live-key',
+    transcript,
+    fallbackTitle: 'Audio memo 2026-06-11 15:30:22',
+  })
+}
+
+describe('generateAudioMemoTitle', () => {
+  it('returns a sanitized generated title', async () => {
+    modelAnswering('  - [[Rome itinerary|Rome itinerary!]]  ')
+
+    await expect(request()).resolves.toBe('Rome itinerary')
+  })
+
+  it('falls back to the transcript when the provider returns nothing useful', async () => {
+    modelAnswering('[]')
+
+    await expect(request('first idea. second idea')).resolves.toBe('First idea')
+  })
+
+  it('falls back to the transcript when the provider call fails', async () => {
+    modelThrowing(new Error('model unavailable'))
+
+    await expect(request('review launch checklist and beta feedback')).resolves.toBe(
+      'Review launch checklist and beta feedback',
+    )
+  })
+
+  it('uses the timestamp fallback for empty transcripts', async () => {
+    modelAnswering('Ignored')
+
+    await expect(request('')).resolves.toBe('Audio memo 2026-06-11 15:30:22')
+    expect(languageModelMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/ai/audio-memo-title.test.ts
+++ b/packages/core/src/ai/audio-memo-title.test.ts
@@ -81,7 +81,7 @@ function request(transcript = 'talked about planning the Rome trip'): Promise<st
 
 describe('generateAudioMemoTitle', () => {
   it('returns a sanitized generated title', async () => {
-    modelAnswering('  - [[Rome itinerary|Rome itinerary!]]  ')
+    modelAnswering('  Rome itinerary!  ')
 
     await expect(request()).resolves.toBe('Rome itinerary')
   })

--- a/packages/core/src/ai/audio-memo-title.test.ts
+++ b/packages/core/src/ai/audio-memo-title.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { MockLanguageModelV3 } from 'ai/test'
 import type { LanguageModelV3Usage } from '@ai-sdk/provider'
 import type { AiProviderConfig } from '../settings/schema'
-import { generateAudioMemoTitle } from './audio-memo-title'
+import { generateAudioMemoTitle, pickAudioMemoTitleConfig } from './audio-memo-title'
 import { languageModel } from './language-model'
 
 vi.mock('./language-model', () => ({
@@ -20,6 +20,27 @@ const CONFIG: AiProviderConfig = {
   id: 'cfg-openai',
   provider: 'openai',
   model: 'gpt-5.5',
+  keyHint: 'wxyz1',
+}
+
+const ANTHROPIC_CONFIG: AiProviderConfig = {
+  id: 'cfg-anthropic',
+  provider: 'anthropic',
+  model: 'claude-sonnet-4-6',
+  keyHint: 'wxyz1',
+}
+
+const GOOGLE_CONFIG: AiProviderConfig = {
+  id: 'cfg-google',
+  provider: 'google',
+  model: 'gemini-3.1-pro-preview',
+  keyHint: 'wxyz1',
+}
+
+const OPENROUTER_CONFIG: AiProviderConfig = {
+  id: 'cfg-openrouter',
+  provider: 'openrouter',
+  model: 'openrouter/auto',
   keyHint: 'wxyz1',
 }
 
@@ -52,8 +73,7 @@ function modelThrowing(error: unknown): void {
 
 function request(transcript = 'talked about planning the Rome trip'): Promise<string> {
   return generateAudioMemoTitle({
-    config: CONFIG,
-    apiKey: 'sk-live-key',
+    credentials: { config: CONFIG, apiKey: 'sk-live-key' },
     transcript,
     fallbackTitle: 'Audio memo 2026-06-11 15:30:22',
   })
@@ -64,6 +84,27 @@ describe('generateAudioMemoTitle', () => {
     modelAnswering('  - [[Rome itinerary|Rome itinerary!]]  ')
 
     await expect(request()).resolves.toBe('Rome itinerary')
+  })
+
+  it.each([
+    [CONFIG, 'gpt-5.5', 'gpt-5.4-nano'],
+    [ANTHROPIC_CONFIG, 'claude-sonnet-4-6', 'claude-haiku-4-5'],
+    [GOOGLE_CONFIG, 'gemini-3.1-pro-preview', 'gemini-3.1-flash-lite'],
+  ])('uses the fixed small model for %s', async (config, originalModel, titleModel) => {
+    modelAnswering('Planning notes')
+
+    await generateAudioMemoTitle({
+      credentials: { config, apiKey: 'sk-live-key' },
+      transcript: 'planning notes',
+      fallbackTitle: 'Audio memo 2026-06-11 15:30:22',
+    })
+
+    expect(config.model).toBe(originalModel)
+    expect(languageModelMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: config.id, provider: config.provider, model: titleModel }),
+      'sk-live-key',
+      expect.any(Function),
+    )
   })
 
   it('falls back to the transcript when the provider returns nothing useful', async () => {
@@ -85,5 +126,43 @@ describe('generateAudioMemoTitle', () => {
 
     await expect(request('')).resolves.toBe('Audio memo 2026-06-11 15:30:22')
     expect(languageModelMock).not.toHaveBeenCalled()
+  })
+
+  it('uses the transcript fallback when title credentials are absent', async () => {
+    modelAnswering('Ignored')
+
+    await expect(
+      generateAudioMemoTitle({
+        transcript: 'review launch checklist',
+        fallbackTitle: 'Audio memo 2026-06-11 15:30:22',
+      }),
+    ).resolves.toBe('Review launch checklist')
+    expect(languageModelMock).not.toHaveBeenCalled()
+  })
+
+  it('prefers the default supported provider for title generation', () => {
+    expect(
+      pickAudioMemoTitleConfig({
+        providers: [CONFIG, ANTHROPIC_CONFIG],
+        defaultProviderId: ANTHROPIC_CONFIG.id,
+      }),
+    ).toMatchObject({
+      id: ANTHROPIC_CONFIG.id,
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5',
+    })
+  })
+
+  it('skips OpenRouter because it does not guarantee a small model', () => {
+    expect(
+      pickAudioMemoTitleConfig({
+        providers: [OPENROUTER_CONFIG, GOOGLE_CONFIG],
+        defaultProviderId: OPENROUTER_CONFIG.id,
+      }),
+    ).toMatchObject({
+      id: GOOGLE_CONFIG.id,
+      provider: 'google',
+      model: 'gemini-3.1-flash-lite',
+    })
   })
 })

--- a/packages/core/src/ai/audio-memo-title.ts
+++ b/packages/core/src/ai/audio-memo-title.ts
@@ -14,20 +14,20 @@ const GOOGLE_AUDIO_MEMO_TITLE_MODEL = 'gemini-3.1-flash-lite'
 
 interface AudioMemoTitleCredentials {
   /** The provider entry whose provider selects the fixed small title model. */
-  config: AiProviderConfig
+  readonly config: AiProviderConfig
   /** The BYOK API key, read from the OS keychain by the caller. */
-  apiKey: string
+  readonly apiKey: string
 }
 
 export interface GenerateAudioMemoTitleRequest {
   /** Optional title-generation credentials; omitted means local fallback only. */
-  credentials?: AudioMemoTitleCredentials | undefined
+  readonly credentials?: AudioMemoTitleCredentials | undefined
   /** Host transport (the Tauri HTTP plugin's fetch; tests pass a stub). */
-  fetchFn?: typeof fetch | undefined
+  readonly fetchFn?: typeof fetch | undefined
   /** The memo transcript to name. */
-  transcript: string
+  readonly transcript: string
   /** Timestamp-derived fallback when the transcript cannot produce a title. */
-  fallbackTitle: string
+  readonly fallbackTitle: string
 }
 
 function audioMemoTitleConfig(config: AiProviderConfig): AiProviderConfig | null {

--- a/packages/core/src/ai/audio-memo-title.ts
+++ b/packages/core/src/ai/audio-memo-title.ts
@@ -1,0 +1,105 @@
+import { generateText } from 'ai'
+import type { AiProviderConfig } from '../settings/schema'
+import { wikiLinkSafe } from '../markdown/edit'
+import { languageModel } from './language-model'
+
+const TITLE_TIMEOUT_MS = 30_000
+const MAX_TRANSCRIPT_CHARS = 4_000
+const MAX_TITLE_CHARS = 80
+const MAX_FALLBACK_WORDS = 8
+
+export interface GenerateAudioMemoTitleRequest {
+  /** The provider entry used for the memo's transcription pass. */
+  config: AiProviderConfig
+  /** The BYOK API key, read from the OS keychain by the caller. */
+  apiKey: string
+  /** Host transport (the Tauri HTTP plugin's fetch; tests pass a stub). */
+  fetchFn?: typeof fetch | undefined
+  /** The memo transcript to name. */
+  transcript: string
+  /** Timestamp-derived fallback when the transcript cannot produce a title. */
+  fallbackTitle: string
+}
+
+function clipTitle(title: string): string {
+  if (title.length <= MAX_TITLE_CHARS) {
+    return title
+  }
+  const clipped = title.slice(0, MAX_TITLE_CHARS).replace(/\s+\S*$/, '').trim()
+  return clipped === '' ? title.slice(0, MAX_TITLE_CHARS).trim() : clipped
+}
+
+function firstContentLine(text: string): string {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line !== '') ?? ''
+}
+
+function normalizedTitle(candidate: string): string | null {
+  const line = firstContentLine(candidate)
+    .replace(/^```[a-z0-9_-]*\s*/i, '')
+    .replace(/```$/u, '')
+    .replace(/^(?:[-*#]\s*|\d+[.)]\s*)/u, '')
+    .replace(/\[\[([^\]|]+)\|([^\]]+)\]\]/gu, '$2')
+    .replace(/\[\[([^\]]+)\]\]/gu, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/gu, '$1')
+    .replace(/^["'`]+|["'`]+$/gu, '')
+  const safe = wikiLinkSafe(line).replace(/[.!?]+$/u, '').trim()
+  const clipped = clipTitle(safe)
+  return clipped === '' ? null : clipped
+}
+
+function titleCaseFallback(text: string): string {
+  return text
+    .split(/\s+/)
+    .filter((word) => word !== '')
+    .slice(0, MAX_FALLBACK_WORDS)
+    .map((word, index) => {
+      const lower = word.toLocaleLowerCase()
+      return index === 0 ? lower.charAt(0).toLocaleUpperCase() + lower.slice(1) : lower
+    })
+    .join(' ')
+}
+
+function transcriptFallbackTitle(transcript: string, fallbackTitle: string): string {
+  const firstSentence = firstContentLine(transcript).split(/[.!?]/u)[0] ?? ''
+  const normalized = normalizedTitle(titleCaseFallback(firstSentence))
+  return normalized ?? fallbackTitle
+}
+
+function titlePrompt(transcript: string): string {
+  return [
+    'Name this audio memo from its transcript.',
+    'Return a short human title, 3 to 7 words.',
+    'Use the language of the transcript.',
+    'Return only the title: no quotes, no markdown, no punctuation unless it is part of a name.',
+    '',
+    `Transcript:\n${transcript.slice(0, MAX_TRANSCRIPT_CHARS)}`,
+  ].join('\n')
+}
+
+/**
+ * Generate a concise, content-derived memo title. Provider failures are
+ * non-fatal because the transcript is already durable; callers still get a
+ * deterministic title from the transcript before falling back to the timestamp.
+ */
+export async function generateAudioMemoTitle(
+  request: GenerateAudioMemoTitleRequest,
+): Promise<string> {
+  const fallback = transcriptFallbackTitle(request.transcript, request.fallbackTitle)
+  if (request.transcript.trim() === '') {
+    return request.fallbackTitle
+  }
+  try {
+    const result = await generateText({
+      model: languageModel(request.config, request.apiKey, request.fetchFn ?? fetch),
+      prompt: titlePrompt(request.transcript),
+      abortSignal: AbortSignal.timeout(TITLE_TIMEOUT_MS),
+      maxRetries: 0,
+    })
+    return normalizedTitle(result.text) ?? fallback
+  } catch {
+    return fallback
+  }
+}

--- a/packages/core/src/ai/audio-memo-title.ts
+++ b/packages/core/src/ai/audio-memo-title.ts
@@ -1,4 +1,5 @@
-import { generateText } from 'ai'
+import { generateObject } from 'ai'
+import { z } from 'zod'
 import type { AiProvidersState } from './provider-config'
 import type { AiProviderConfig } from '../settings/schema'
 import { wikiLinkSafe } from '../markdown/edit'
@@ -11,6 +12,10 @@ const MAX_FALLBACK_WORDS = 8
 const OPENAI_AUDIO_MEMO_TITLE_MODEL = 'gpt-5.4-nano'
 const ANTHROPIC_AUDIO_MEMO_TITLE_MODEL = 'claude-haiku-4-5'
 const GOOGLE_AUDIO_MEMO_TITLE_MODEL = 'gemini-3.1-flash-lite'
+
+const audioMemoTitleSchema = z.object({
+  title: z.string(),
+})
 
 interface AudioMemoTitleCredentials {
   /** The provider entry whose provider selects the fixed small title model. */
@@ -142,17 +147,18 @@ export async function generateAudioMemoTitle(
     return fallback
   }
   try {
-    const result = await generateText({
+    const result = await generateObject({
       model: languageModel(
         titleConfig,
         request.credentials.apiKey,
         request.fetchFn ?? fetch,
       ),
+      schema: audioMemoTitleSchema,
       prompt: titlePrompt(request.transcript),
       abortSignal: AbortSignal.timeout(TITLE_TIMEOUT_MS),
       maxRetries: 0,
     })
-    return normalizedTitle(result.text) ?? fallback
+    return normalizedTitle(result.object.title) ?? fallback
   } catch {
     return fallback
   }

--- a/packages/core/src/ai/audio-memo-title.ts
+++ b/packages/core/src/ai/audio-memo-title.ts
@@ -85,15 +85,7 @@ function firstContentLine(text: string): string {
 }
 
 function normalizedTitle(candidate: string): string | null {
-  const line = firstContentLine(candidate)
-    .replace(/^```[a-z0-9_-]*\s*/i, '')
-    .replace(/```$/u, '')
-    .replace(/^(?:[-*#]\s*|\d+[.)]\s*)/u, '')
-    .replace(/\[\[([^\]|]+)\|([^\]]+)\]\]/gu, '$2')
-    .replace(/\[\[([^\]]+)\]\]/gu, '$1')
-    .replace(/\[([^\]]+)\]\([^)]+\)/gu, '$1')
-    .replace(/^["'`]+|["'`]+$/gu, '')
-  const safe = wikiLinkSafe(line).replace(/[.!?]+$/u, '').trim()
+  const safe = wikiLinkSafe(firstContentLine(candidate)).replace(/[.!?]+$/u, '').trim()
   const clipped = clipTitle(safe)
   return clipped === '' ? null : clipped
 }

--- a/packages/core/src/ai/audio-memo-title.ts
+++ b/packages/core/src/ai/audio-memo-title.ts
@@ -1,4 +1,5 @@
 import { generateText } from 'ai'
+import type { AiProvidersState } from './provider-config'
 import type { AiProviderConfig } from '../settings/schema'
 import { wikiLinkSafe } from '../markdown/edit'
 import { languageModel } from './language-model'
@@ -7,18 +8,60 @@ const TITLE_TIMEOUT_MS = 30_000
 const MAX_TRANSCRIPT_CHARS = 4_000
 const MAX_TITLE_CHARS = 80
 const MAX_FALLBACK_WORDS = 8
+const OPENAI_AUDIO_MEMO_TITLE_MODEL = 'gpt-5.4-nano'
+const ANTHROPIC_AUDIO_MEMO_TITLE_MODEL = 'claude-haiku-4-5'
+const GOOGLE_AUDIO_MEMO_TITLE_MODEL = 'gemini-3.1-flash-lite'
 
-export interface GenerateAudioMemoTitleRequest {
-  /** The provider entry used for the memo's transcription pass. */
+interface AudioMemoTitleCredentials {
+  /** The provider entry whose provider selects the fixed small title model. */
   config: AiProviderConfig
   /** The BYOK API key, read from the OS keychain by the caller. */
   apiKey: string
+}
+
+export interface GenerateAudioMemoTitleRequest {
+  /** Optional title-generation credentials; omitted means local fallback only. */
+  credentials?: AudioMemoTitleCredentials | undefined
   /** Host transport (the Tauri HTTP plugin's fetch; tests pass a stub). */
   fetchFn?: typeof fetch | undefined
   /** The memo transcript to name. */
   transcript: string
   /** Timestamp-derived fallback when the transcript cannot produce a title. */
   fallbackTitle: string
+}
+
+function audioMemoTitleConfig(config: AiProviderConfig): AiProviderConfig | null {
+  switch (config.provider) {
+    case 'openai':
+      return { ...config, model: OPENAI_AUDIO_MEMO_TITLE_MODEL }
+    case 'anthropic':
+      return { ...config, model: ANTHROPIC_AUDIO_MEMO_TITLE_MODEL }
+    case 'google':
+      return { ...config, model: GOOGLE_AUDIO_MEMO_TITLE_MODEL }
+    case 'openrouter':
+      return null
+  }
+}
+
+/**
+ * Pick the small-model provider for audio memo title generation. The user's
+ * default provider wins when it has a fixed small title model; otherwise the
+ * first supported configured provider is used. OpenRouter is skipped because
+ * `openrouter/auto` is not a small-model guarantee.
+ */
+export function pickAudioMemoTitleConfig(state: AiProvidersState): AiProviderConfig | null {
+  const preferred = state.providers.find((provider) => provider.id === state.defaultProviderId)
+  const ordered =
+    preferred === undefined
+      ? state.providers
+      : [preferred, ...state.providers.filter((provider) => provider.id !== preferred.id)]
+  for (const provider of ordered) {
+    const titleConfig = audioMemoTitleConfig(provider)
+    if (titleConfig !== null) {
+      return titleConfig
+    }
+  }
+  return null
 }
 
 function clipTitle(title: string): string {
@@ -91,9 +134,20 @@ export async function generateAudioMemoTitle(
   if (request.transcript.trim() === '') {
     return request.fallbackTitle
   }
+  if (request.credentials === undefined) {
+    return fallback
+  }
+  const titleConfig = audioMemoTitleConfig(request.credentials.config)
+  if (titleConfig === null) {
+    return fallback
+  }
   try {
     const result = await generateText({
-      model: languageModel(request.config, request.apiKey, request.fetchFn ?? fetch),
+      model: languageModel(
+        titleConfig,
+        request.credentials.apiKey,
+        request.fetchFn ?? fetch,
+      ),
       prompt: titlePrompt(request.transcript),
       abortSignal: AbortSignal.timeout(TITLE_TIMEOUT_MS),
       maxRetries: 0,


### PR DESCRIPTION
## Problem

Audio memo transcription notes were titled only from the recording timestamp, and the daily-note backlink used the generic `Audio memo HH:MM` alias. That made several memos from the same day hard to scan, even after the transcript existed. The daily-note insertion also differed from the other inserters by adding a bare wikilink rather than a list item.

## Before -> After

| Surface | Before | After |
| --- | --- | --- |
| Transcription note title | `# Audio memo 2026-06-11 15:30:22` | `# <content-derived title>` |
| Daily-note entry | `[[audio-memo-...|Audio memo 15:30]]` | `- [[audio-memo-...|<content-derived title>]]` |
| Title model | User's configured transcription/chat model | Fixed small model: OpenAI nano, Claude Haiku, or Gemini Flash Lite |
| Title output parsing | Free-form text only | `generateObject` with a Zod `{ title: string }` schema, plus sanitizer/fallback |
| Empty or failed title generation | Timestamp-only title | Transcript-derived local fallback, then timestamp fallback when there is no speech/content |

## Changes

1. Added `generateAudioMemoTitle`, a BYOK title helper that names the memo from the transcript using `generateObject` and a Zod `{ title: string }` schema. It caps prompt input, times out quickly, strips markdown/link syntax after schema validation, and never blocks reconciliation if title generation fails.
2. Added `pickAudioMemoTitleConfig`, which prefers the user's default supported title provider and rewrites it to a fixed small model: `gpt-5.4-nano`, `claude-haiku-4-5`, or `gemini-3.1-flash-lite`. OpenRouter is skipped because `openrouter/auto` is not a small-model guarantee.
3. Updated `reconcileAudioMemos` so transcription still uses the existing OpenAI/Gemini transcription path, while title generation can use a separate small configured provider such as Anthropic Haiku when that is the default. Missing title-provider keys fall back locally instead of stopping reconciliation.
4. Changed daily-note audio memo insertions to list items under `## Audio memos`, matching the other daily-note inserters.
5. Expanded action and title-helper tests for small-model routing, Anthropic Haiku selection, structured title responses, sanitization, missing credentials, transcript fallback, and silence handling.

## Tests

- `pnpm --filter @reflect/core test -- src/actions/audio-memo.test.ts src/ai/audio-memo-title.test.ts`
- `pnpm check`

## Risk / Rollout

No migration or backfill is included; existing audio memo notes remain as-is. New non-empty memos make one additional BYOK model call after transcription to generate the title. That call uses a fixed small model and may use a different configured provider than transcription when, for example, Anthropic is the default provider. If the title call fails, the key is missing, structured output validation fails, or the model returns unusable text, reconciliation still completes with a deterministic transcript/title fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an extra BYOK LLM call and keychain lookup during reconcile, but failures are non-blocking and transcription/reconcile semantics are otherwise preserved.
> 
> **Overview**
> Audio memo reconciliation now **derives note titles and daily-note link text from the transcript** instead of only the recording timestamp, so multiple memos on one day are easier to scan.
> 
> A new **`generateAudioMemoTitle`** helper runs after transcription (structured `generateObject` + Zod schema, fixed small models per provider, sanitization, 30s timeout). **`pickAudioMemoTitleConfig`** can use a different configured provider than transcription (e.g. Anthropic Haiku when default); missing keys or failures fall back to a local transcript-based title, then the timestamp. **Silent/empty transcripts** skip the LLM and keep the timestamp title.
> 
> Daily **`## Audio memos`** entries are now **list items** (`- [[base|title]]`) with **`wikiLinkSafe`** display text, aligned with other daily inserters. Existing notes are not backfilled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 010ce54107127cbfedb0b2e61221b46f58953436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

