### PR TITLE
feat: attendee autocomplete in the add-meeting dialog; Events below Note actions

### DIFF
--- a/apps/desktop/src/components/context-sidebar/add-meeting-dialog.tsx
+++ b/apps/desktop/src/components/context-sidebar/add-meeting-dialog.tsx
@@ -24,6 +24,7 @@ import { Input } from '@/components/ui/input'
 import { formatTimeOfDay } from '@/lib/dates'
 import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
+import { AttendeeCombobox } from './attendee-combobox'
 
 interface AddMeetingDialogProps {
   /** The daily note receiving the entry — a validated ISO date. */
@@ -37,19 +38,19 @@ const FIELD_LABEL_CLASS = 'text-xs font-medium text-text-secondary'
 
 /**
  * v1's "Add event" modal: an editable meeting name, an editable attendee
- * list, and the create-backlinked-note choice (defaulted on for recurring
- * events, as v1 did — a recurring meeting's shared note is where its notes
- * accumulate). Submitting writes `- [[Meeting]] with [[Person]]…` under the
- * daily note's `## Meetings` heading and creates missing notes; after that
- * nothing stays tied to the calendar. With the contacts integration on,
- * fresh person notes are pre-filled from Apple Contacts by attendee email.
+ * list (with note/contact autocomplete — {@link AttendeeCombobox}), and the
+ * create-backlinked-note choice (defaulted on for recurring events, as v1
+ * did — a recurring meeting's shared note is where its notes accumulate).
+ * Submitting writes `- [[Meeting]] with [[Person]]…` under the daily note's
+ * `## Meetings` heading and creates missing notes; after that nothing stays
+ * tied to the calendar. With the contacts integration on, fresh person notes
+ * are pre-filled from Apple Contacts by attendee email.
  */
 export function AddMeetingDialog({ date, event, onClose }: AddMeetingDialogProps): ReactElement {
   const { settings } = useSettings()
   const { graph } = useGraph()
   const [name, setName] = useState(event.title)
   const [attendees, setAttendees] = useState<MeetingAttendee[]>(() => defaultAttendees(event))
-  const [newAttendee, setNewAttendee] = useState('')
   const [createNote, setCreateNote] = useState(event.recurring)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -65,17 +66,12 @@ export function AddMeetingDialog({ date, event, onClose }: AddMeetingDialogProps
     }
   }, [])
 
-  const addAttendee = (): void => {
-    const attendeeName = newAttendee.trim()
-    if (attendeeName === '') {
-      return
-    }
+  const addAttendee = (attendee: MeetingAttendee): void => {
     setAttendees((current) =>
-      current.some((existing) => existing.name.toLowerCase() === attendeeName.toLowerCase())
+      current.some((existing) => existing.name.toLowerCase() === attendee.name.toLowerCase())
         ? current
-        : [...current, { name: attendeeName }],
+        : [...current, attendee],
     )
-    setNewAttendee('')
   }
 
   const removeAttendee = (attendeeName: string): void => {
@@ -147,9 +143,11 @@ export function AddMeetingDialog({ date, event, onClose }: AddMeetingDialogProps
             />
           </div>
           <div className="space-y-1.5">
-            <label htmlFor="add-meeting-attendee" className={FIELD_LABEL_CLASS}>
+            {/* The combobox input's real label is cmdk's hidden one (same
+                text); an htmlFor can't reach a cmdk input. */}
+            <div aria-hidden className={FIELD_LABEL_CLASS}>
               Attendees
-            </label>
+            </div>
             {attendees.length > 0 && (
               <ul className="flex flex-wrap gap-1.5">
                 {attendees.map((attendee) => (
@@ -170,19 +168,7 @@ export function AddMeetingDialog({ date, event, onClose }: AddMeetingDialogProps
                 ))}
               </ul>
             )}
-            <Input
-              id="add-meeting-attendee"
-              value={newAttendee}
-              onChange={(changeEvent) => setNewAttendee(changeEvent.target.value)}
-              onKeyDown={(keyEvent) => {
-                if (keyEvent.key === 'Enter') {
-                  keyEvent.preventDefault()
-                  addAttendee()
-                }
-              }}
-              onBlur={addAttendee}
-              placeholder="Add attendee"
-            />
+            <AttendeeCombobox attendees={attendees} onAdd={addAttendee} />
           </div>
           <label className="flex cursor-pointer items-center gap-2 text-sm text-text-secondary">
             <Checkbox

--- a/apps/desktop/src/components/context-sidebar/attendee-combobox.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/attendee-combobox.test.tsx
@@ -105,6 +105,23 @@ describe('AttendeeCombobox', () => {
     expect(input.value).toBe('')
   })
 
+  it('Enter during a pending refetch adds the typed text, not a stale row', async () => {
+    suggestWikiTargets.mockResolvedValue([noteSuggestion('Ada Lovelace')])
+    const input = renderCombobox()
+
+    fireEvent.change(input, { target: { value: 'ada' } })
+    await findHighlighted('Ada Lovelace')
+
+    // Keep typing: the popover still shows the previous query's rows
+    // (keepPreviousData) while the new fetch hangs. Enter must take the
+    // live text, not the stale highlighted suggestion.
+    suggestWikiTargets.mockReturnValue(new Promise(() => {}))
+    fireEvent.change(input, { target: { value: 'Adam Smith' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onAdd).toHaveBeenCalledWith({ name: 'Adam Smith' })
+  })
+
   it('offers an Add row for a name that matches nothing exactly', async () => {
     suggestWikiTargets.mockResolvedValue([noteSuggestion('Ada Lovelace')])
     const input = renderCombobox()

--- a/apps/desktop/src/components/context-sidebar/attendee-combobox.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/attendee-combobox.test.tsx
@@ -1,0 +1,140 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ContactMatch, MeetingAttendee, WikiSuggestion } from '@reflect/core'
+import { AttendeeCombobox } from './attendee-combobox'
+
+// jsdom can't scroll or observe resizes; cmdk scrolls the highlighted row
+// into view and Radix's popper observes the anchor.
+window.HTMLElement.prototype.scrollIntoView = () => {}
+class NoopResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+window.ResizeObserver ??= NoopResizeObserver as unknown as typeof ResizeObserver
+
+const suggestWikiTargets = vi.hoisted(() => vi.fn<() => Promise<WikiSuggestion[]>>(async () => []))
+const contactLinkSuggestions = vi.hoisted(() =>
+  vi.fn<() => Promise<ContactMatch[]>>(async () => []),
+)
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  hasBridge: () => true,
+  suggestWikiTargets,
+  contactLinkSuggestions,
+}))
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({ graph: { root: '/g', name: 'g', generation: 1 } }),
+}))
+vi.mock('@/providers/settings-provider', () => ({
+  useSettings: () => ({ settings: { contactsEnabled: true }, updateSettings: () => {} }),
+}))
+vi.mock('@/hooks/use-contacts-authorization', () => ({
+  useContactsAuthorization: () => 'authorized',
+}))
+
+function noteSuggestion(title: string, overrides: Partial<WikiSuggestion> = {}): WikiSuggestion {
+  return { target: title, path: `notes/${title}.md`, title, alias: null, date: null, ...overrides }
+}
+
+function contact(fullName: string, email: string): ContactMatch {
+  return { fullName, givenName: '', familyName: '', emails: [email], phones: [] }
+}
+
+const onAdd = vi.fn<(attendee: MeetingAttendee) => void>()
+
+function renderCombobox(attendees: MeetingAttendee[] = []): HTMLInputElement {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={client}>
+      <AttendeeCombobox attendees={attendees} onAdd={onAdd} />
+    </QueryClientProvider>,
+  )
+  return screen.getByPlaceholderText<HTMLInputElement>('Add attendee')
+}
+
+/** cmdk highlights the first row in an effect — selection isn't synchronous. */
+async function findHighlighted(text: string): Promise<HTMLElement> {
+  const row = await screen.findByText(text)
+  const item = row.closest('[cmdk-item]')
+  await waitFor(() => expect(item?.getAttribute('aria-selected')).toBe('true'))
+  return row
+}
+
+beforeEach(() => {
+  suggestWikiTargets.mockReset().mockResolvedValue([])
+  contactLinkSuggestions.mockReset().mockResolvedValue([])
+  onAdd.mockClear()
+})
+
+afterEach(cleanup)
+
+describe('AttendeeCombobox', () => {
+  it('Enter adds the highlighted note suggestion by its canonical title', async () => {
+    suggestWikiTargets.mockResolvedValue([noteSuggestion('Ada Lovelace')])
+    const input = renderCombobox()
+
+    fireEvent.change(input, { target: { value: 'ada' } })
+    await findHighlighted('Ada Lovelace')
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onAdd).toHaveBeenCalledWith({ name: 'Ada Lovelace' })
+    expect(input.value).toBe('')
+  })
+
+  it('a picked contact carries its invite email for the note pre-fill', async () => {
+    contactLinkSuggestions.mockResolvedValue([contact('Grace Hopper', 'grace@example.com')])
+    const input = renderCombobox()
+
+    fireEvent.change(input, { target: { value: 'gra' } })
+    await findHighlighted('Grace Hopper')
+    expect(screen.getByText('grace@example.com')).toBeTruthy()
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onAdd).toHaveBeenCalledWith({ name: 'Grace Hopper', email: 'grace@example.com' })
+  })
+
+  it('Enter with no suggestions adds the typed name verbatim', async () => {
+    const input = renderCombobox()
+
+    fireEvent.change(input, { target: { value: 'Brand New Person' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onAdd).toHaveBeenCalledWith({ name: 'Brand New Person' })
+    expect(input.value).toBe('')
+  })
+
+  it('offers an Add row for a name that matches nothing exactly', async () => {
+    suggestWikiTargets.mockResolvedValue([noteSuggestion('Ada Lovelace')])
+    const input = renderCombobox()
+
+    fireEvent.change(input, { target: { value: 'Ada L' } })
+    const addRow = await screen.findByText('Add “Ada L”')
+    fireEvent.click(addRow)
+
+    expect(onAdd).toHaveBeenCalledWith({ name: 'Ada L' })
+  })
+
+  it('keeps already-added attendees out of the suggestions', async () => {
+    suggestWikiTargets.mockResolvedValue([noteSuggestion('Ada Lovelace')])
+    const input = renderCombobox([{ name: 'Ada Lovelace' }])
+
+    fireEvent.change(input, { target: { value: 'Ada Lovelace' } })
+    await waitFor(() => expect(suggestWikiTargets).toHaveBeenCalled())
+
+    expect(screen.queryByText('Ada Lovelace')).toBeNull()
+  })
+
+  it('Escape dismisses the suggestions without bubbling to the dialog', async () => {
+    suggestWikiTargets.mockResolvedValue([noteSuggestion('Ada Lovelace')])
+    const input = renderCombobox()
+
+    fireEvent.change(input, { target: { value: 'ada' } })
+    await findHighlighted('Ada Lovelace')
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    await waitFor(() => expect(screen.queryByText('Ada Lovelace')).toBeNull())
+    expect(input.value).toBe('ada')
+  })
+})

--- a/apps/desktop/src/components/context-sidebar/attendee-combobox.tsx
+++ b/apps/desktop/src/components/context-sidebar/attendee-combobox.tsx
@@ -1,0 +1,223 @@
+import { useDeferredValue, useState, type KeyboardEvent, type ReactElement } from 'react'
+import { Command as CommandPrimitive } from 'cmdk'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import {
+  contactLinkSuggestions,
+  foldKey,
+  hasBridge,
+  isContactsReadable,
+  suggestWikiTargets,
+  type MeetingAttendee,
+} from '@reflect/core'
+import { CommandItem, CommandList } from '@/components/ui/command'
+import { INPUT_CLASS_NAME } from '@/components/ui/input'
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
+import {
+  buildAutocompleteEntries,
+  type AutocompleteEntry,
+} from '@/editor/wiki-autocomplete-entries'
+import { useContactsAuthorization } from '@/hooks/use-contacts-authorization'
+import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
+import { useGraph } from '@/providers/graph-provider'
+import { useSettings } from '@/providers/settings-provider'
+
+const SUGGESTION_LIMIT = 6
+
+interface AttendeeComboboxProps {
+  /** Attendees already chosen — kept out of the suggestion list. */
+  attendees: readonly MeetingAttendee[]
+  /** Adds one attendee. The caller owns dedup and the chip list. */
+  onAdd: (attendee: MeetingAttendee) => void
+}
+
+/** cmdk item values are matched lowercased, so the key is minted that way. */
+function entryKey(entry: AutocompleteEntry): string {
+  return `${entry.kind}:${entryName(entry)}`.toLowerCase()
+}
+
+/** The attendee name selecting this entry would add. */
+function entryName(entry: AutocompleteEntry): string {
+  switch (entry.kind) {
+    case 'suggestion':
+      return entry.suggestion.target
+    case 'contact':
+      return entry.contact.fullName
+    case 'create':
+      return entry.title
+  }
+}
+
+function entryAttendee(entry: AutocompleteEntry): MeetingAttendee {
+  // A contact's invite email rides along so the submit-time contacts lookup
+  // can pre-fill the person note, exactly like calendar-sourced attendees.
+  return entry.kind === 'contact'
+    ? { name: entry.contact.fullName, email: entry.contact.emails[0] }
+    : { name: entryName(entry) }
+}
+
+/**
+ * The add-meeting dialog's attendee field: a combobox over the same sources
+ * as the editor's `[[` menu — ranked note titles, Apple Contacts (when the
+ * integration is on and readable), and a trailing `Add "…"` row for names
+ * that match nothing. Enter picks the highlighted row, or adds the typed
+ * text verbatim when no suggestion is highlighted; Escape dismisses the
+ * suggestions without closing the dialog. Daily-note suggestions are
+ * filtered out — an attendee is a person, not a date.
+ *
+ * The input's accessible name comes from cmdk's own `label` mechanism (a
+ * visually-hidden `<label>`): cmdk overrides any `id`/`aria-labelledby`
+ * passed to its Input, so an external `htmlFor` can never reach it.
+ */
+export function AttendeeCombobox({ attendees, onAdd }: AttendeeComboboxProps): ReactElement {
+  const { graph } = useGraph()
+  const { settings } = useSettings()
+  const authorization = useContactsAuthorization()
+  const contactsInMenu =
+    settings.contactsEnabled && authorization !== null && isContactsReadable(authorization)
+
+  const [query, setQuery] = useState('')
+  const [dismissed, setDismissed] = useState(false)
+  const [highlighted, setHighlighted] = useState('')
+  const deferredQuery = useDeferredValue(query)
+  const searchTerm = deferredQuery.trim()
+
+  const { data: fetched } = useQuery({
+    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'attendee-suggestions', searchTerm, contactsInMenu],
+    queryFn: async () => {
+      const [suggestions, contacts] = await Promise.all([
+        suggestWikiTargets(searchTerm, SUGGESTION_LIMIT),
+        // A contacts hiccup must cost only its own rows, never the note
+        // suggestions (the same containment as the editor's `[[` menu).
+        contactsInMenu
+          ? contactLinkSuggestions(searchTerm).catch((error: unknown) => {
+              console.error('contact link suggestions failed:', error)
+              return []
+            })
+          : Promise.resolve([]),
+      ])
+      return buildAutocompleteEntries(
+        searchTerm,
+        suggestions.filter((suggestion) => suggestion.date === null),
+        { offerCreate: true, contacts },
+      )
+    },
+    enabled: hasBridge() && graph !== null && searchTerm !== '',
+    // Typing re-keys the query as the deferred value settles; holding the
+    // previous rows avoids the list flashing closed between keystrokes.
+    placeholderData: keepPreviousData,
+  })
+
+  const chosen = new Set(attendees.map((attendee) => foldKey(attendee.name)))
+  const entries = (searchTerm === '' ? [] : (fetched ?? [])).filter(
+    (entry) => !chosen.has(foldKey(entryName(entry))),
+  )
+  const open = !dismissed && query.trim() !== '' && entries.length > 0
+
+  const select = (entry: AutocompleteEntry): void => {
+    onAdd(entryAttendee(entry))
+    setQuery('')
+    setDismissed(false)
+  }
+
+  const addTyped = (): void => {
+    const name = query.trim()
+    if (name === '') {
+      return
+    }
+    onAdd({ name })
+    setQuery('')
+    setDismissed(false)
+  }
+
+  const onKeyDown = (keyEvent: KeyboardEvent<HTMLInputElement>): void => {
+    if (keyEvent.key === 'Enter') {
+      // Ours alone: preventDefault stops the dialog form submitting,
+      // stopPropagation keeps cmdk's root handler from double-selecting.
+      keyEvent.preventDefault()
+      keyEvent.stopPropagation()
+      const entry = open
+        ? entries.find((candidate) => entryKey(candidate) === highlighted)
+        : undefined
+      if (entry !== undefined) {
+        select(entry)
+      } else {
+        addTyped()
+      }
+      return
+    }
+    if (keyEvent.key === 'Escape' && open) {
+      // Dismiss the suggestions only — the dialog must survive this Escape.
+      keyEvent.preventDefault()
+      keyEvent.stopPropagation()
+      setDismissed(true)
+    }
+  }
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          setDismissed(true)
+        }
+      }}
+    >
+      <CommandPrimitive
+        label="Attendees"
+        shouldFilter={false}
+        loop
+        value={highlighted}
+        onValueChange={setHighlighted}
+      >
+        <PopoverAnchor asChild>
+          <CommandPrimitive.Input
+            value={query}
+            onValueChange={(value) => {
+              setQuery(value)
+              setDismissed(false)
+            }}
+            onKeyDown={onKeyDown}
+            onBlur={addTyped}
+            placeholder="Add attendee"
+            className={INPUT_CLASS_NAME}
+          />
+        </PopoverAnchor>
+        <PopoverContent
+          align="start"
+          sideOffset={4}
+          className="w-(--radix-popover-trigger-width) p-1"
+          // The input keeps focus for the popover's whole life: no focus
+          // steal on open/close, and no blur when a row is clicked (blur
+          // would add the half-typed text before onSelect adds the row's).
+          onOpenAutoFocus={(focusEvent) => focusEvent.preventDefault()}
+          onCloseAutoFocus={(focusEvent) => focusEvent.preventDefault()}
+          onMouseDown={(mouseEvent) => mouseEvent.preventDefault()}
+        >
+          <CommandList>
+            {entries.map((entry) => (
+              <CommandItem
+                key={entryKey(entry)}
+                value={entryKey(entry)}
+                onSelect={() => select(entry)}
+              >
+                <span className="min-w-0 flex-1 truncate">
+                  {entry.kind === 'create' ? `Add “${entry.title}”` : entryName(entry)}
+                </span>
+                {entry.kind === 'suggestion' && entry.suggestion.alias !== null && (
+                  <span className="truncate text-xs text-text-muted">
+                    {entry.suggestion.alias} → {entry.suggestion.title}
+                  </span>
+                )}
+                {entry.kind === 'contact' && (
+                  <span className="truncate text-xs text-text-muted">
+                    {entry.contact.emails[0] ?? entry.contact.phones[0] ?? 'Contact'}
+                  </span>
+                )}
+              </CommandItem>
+            ))}
+          </CommandList>
+        </PopoverContent>
+      </CommandPrimitive>
+    </Popover>
+  )
+}

--- a/apps/desktop/src/components/context-sidebar/attendee-combobox.tsx
+++ b/apps/desktop/src/components/context-sidebar/attendee-combobox.tsx
@@ -81,7 +81,7 @@ export function AttendeeCombobox({ attendees, onAdd }: AttendeeComboboxProps): R
   const deferredQuery = useDeferredValue(query)
   const searchTerm = deferredQuery.trim()
 
-  const { data: fetched } = useQuery({
+  const { data: fetched, isPlaceholderData } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'attendee-suggestions', searchTerm, contactsInMenu],
     queryFn: async () => {
       const [suggestions, contacts] = await Promise.all([
@@ -112,6 +112,11 @@ export function AttendeeCombobox({ attendees, onAdd }: AttendeeComboboxProps): R
     (entry) => !chosen.has(foldKey(entryName(entry))),
   )
   const open = !dismissed && query.trim() !== '' && entries.length > 0
+  // The list lags the input twice over (the deferred value, then the fetch —
+  // keepPreviousData shows the prior query's rows meanwhile). Enter may only
+  // take the highlighted row when the rows answer exactly what's typed;
+  // anything staler falls back to the typed text, like blur always does.
+  const entriesMatchInput = !isPlaceholderData && searchTerm === query.trim()
 
   const select = (entry: AutocompleteEntry): void => {
     onAdd(entryAttendee(entry))
@@ -135,9 +140,10 @@ export function AttendeeCombobox({ attendees, onAdd }: AttendeeComboboxProps): R
       // stopPropagation keeps cmdk's root handler from double-selecting.
       keyEvent.preventDefault()
       keyEvent.stopPropagation()
-      const entry = open
-        ? entries.find((candidate) => entryKey(candidate) === highlighted)
-        : undefined
+      const entry =
+        open && entriesMatchInput
+          ? entries.find((candidate) => entryKey(candidate) === highlighted)
+          : undefined
       if (entry !== undefined) {
         select(entry)
       } else {

--- a/apps/desktop/src/components/context-sidebar/daily-context-sidebar.tsx
+++ b/apps/desktop/src/components/context-sidebar/daily-context-sidebar.tsx
@@ -17,9 +17,10 @@ interface DailyContextSidebarProps {
 /**
  * The daily note's contextual sidebar (modeled on the old app's note context
  * sidebar): the month calendar up top — itself the day-navigation surface,
- * with a jump-to-today button — then note actions and semantic neighbors.
- * Inbound links live under the note itself (the incoming-backlinks section),
- * not here. Rendered in the AppShell's right region on daily routes only.
+ * with a jump-to-today button — then note actions, the day's calendar
+ * events, and semantic neighbors. Inbound links live under the note itself
+ * (the incoming-backlinks section), not here. Rendered in the AppShell's
+ * right region on daily routes only.
  */
 export function DailyContextSidebar({ date }: DailyContextSidebarProps): ReactElement {
   const today = useToday()
@@ -35,8 +36,8 @@ export function DailyContextSidebar({ date }: DailyContextSidebarProps): ReactEl
     >
       <DayCalendar selectedDate={date} today={today} />
       <div className="my-4 space-y-4 pb-4">
-        <DailyEventsSection date={date} />
         <NoteActionsSection path={dailyPath(date)} />
+        <DailyEventsSection date={date} />
         <PublishedUrlSection path={dailyPath(date)} />
         <SimilarNotesSection path={dailyPath(date)} />
       </div>

--- a/apps/desktop/src/components/context-sidebar/daily-events-section.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/daily-events-section.test.tsx
@@ -21,12 +21,20 @@ vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({ graph: { root: '/graph', generation: 3 } }),
 }))
 
+// jsdom can't scroll; cmdk scrolls the highlighted suggestion into view.
+window.HTMLElement.prototype.scrollIntoView = () => {}
+
 // The action itself is covered in @reflect/core; here it is the seam the
-// dialog submits through.
+// dialog submits through. The attendee combobox's suggestion sources are
+// stubbed empty — the combobox itself is covered by its own test file.
 const addMeetingToDaily = vi.hoisted(() => vi.fn(async () => ({ appended: true, createdNotes: [] })))
+const suggestWikiTargets = vi.hoisted(() => vi.fn(async () => []))
+const contactLinkSuggestions = vi.hoisted(() => vi.fn(async () => []))
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   addMeetingToDaily,
+  suggestWikiTargets,
+  contactLinkSuggestions,
 }))
 
 const DATE = '2026-07-01'

--- a/apps/desktop/src/components/ui/input.tsx
+++ b/apps/desktop/src/components/ui/input.tsx
@@ -2,18 +2,20 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
+// Shared with inputs that must render the same field without this wrapper
+// (e.g. a cmdk-driven combobox input, which has to be `CommandPrimitive.Input`).
+const INPUT_CLASS_NAME =
+  "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40"
+
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (
     <input
       type={type}
       data-slot="input"
-      className={cn(
-        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
-        className
-      )}
+      className={cn(INPUT_CLASS_NAME, className)}
       {...props}
     />
   )
 }
 
-export { Input }
+export { Input, INPUT_CLASS_NAME }


### PR DESCRIPTION
## Problem

The add-meeting dialog's attendee field was a bare text input: no suggestions, no connection to the graph or the address book. Typing an attendee meant re-typing a person's name exactly right, from memory — even though the editor's `[[` menu already knows how to complete people from note titles and Apple Contacts. Misspelling a name silently mints a duplicate person note at submit.

Separately, the daily sidebar showed Events above Note actions, so the note-scoped actions shifted down on days with meetings.

## Before → After

| | Before | After |
|---|---|---|
| Attendee field | Plain text input; Enter/blur adds the raw text | Combobox: ranked note-title suggestions, Apple Contacts rows (when the integration is on and readable), and a trailing `Add "…"` row; Enter picks the highlighted row, free text still works |
| Contact attendees | Only calendar-sourced attendees carried an email | A picked contact carries its email, so the submit-time contacts lookup pre-fills the person note |
| Daily sidebar order | Events, Note actions, Published URL, Similar notes | Note actions, Events, Published URL, Similar notes |

## Changes

1. **`attendee-combobox.tsx`** (new) — a combobox on the shadcn `Command` + `Popover` primitives, reusing the editor's `[[` sources: `suggestWikiTargets` (daily-note suggestions filtered out — an attendee is a person, not a date), `contactLinkSuggestions` behind the same enabled+readable gate as the editor menu, assembled by the existing `buildAutocompleteEntries` (so contact-vs-note dedup and exact-match suppression stay identical). Already-added attendees are kept out of the list. Enter is handled by the combobox alone (`preventDefault` stops the form submit, `stopPropagation` stops cmdk double-selecting); Escape dismisses the suggestions without closing the dialog; clicking a row suppresses the input blur so the half-typed text isn't added alongside the selection. Enter only takes the highlighted row when the visible rows answer exactly what's typed (`isPlaceholderData` + deferred-value check) — while a refetch is pending it falls back to the typed text, so a stale highlight can never be added (Bugbot finding on the first commit).
2. **`add-meeting-dialog.tsx`** — swaps the input for the combobox; `addAttendee` now takes a full `MeetingAttendee` so contact emails flow through to `addMeetingToDaily`'s person-note pre-fill. The visible "Attendees" label becomes a plain element: cmdk overrides any `id`/`aria-labelledby` on its Input, so the accessible name comes from cmdk's own hidden label mechanism instead.
3. **`daily-context-sidebar.tsx`** — Events moves below Note actions.
4. **`ui/input.tsx`** — exports `INPUT_CLASS_NAME` so the cmdk input renders identically to `Input` without duplicating the class string.

## Tests

- `attendee-combobox.test.tsx` (new): Enter adds the highlighted note suggestion by canonical title; a picked contact carries its invite email; Enter with no suggestions adds the typed name verbatim; the `Add "…"` row appears for inexact names and adds on click; already-added attendees stay out of the list; Escape dismisses without clearing the input; Enter during a pending refetch adds the typed text, not a stale highlighted row.
- `daily-events-section.test.tsx`: existing dialog flows (free-text attendee, chip removal, submit payload, contacts gate) pass unchanged with the suggestion sources stubbed empty.

## Verification

- `pnpm vitest run src/components/context-sidebar/` — 10 files, 68 tests, all passing.
- `pnpm check` — typecheck + lint clean (remaining warnings pre-existing, unrelated files).
- Not manually exercised in the running Tauri app.

## Risk / Rollout

UI-only; no data or schema changes. The suggestion query is read-only against the index and contacts, gated exactly like the editor's `[[` menu, and a contacts failure costs only its own rows. Free-text entry (the old behavior) still works via Enter and blur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
