### PR TITLE
Release v0.4.0-beta.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4742,7 +4742,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.4.0-beta.14"
+version = "0.4.0-beta.15"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.4.0-beta.14"
+version = "0.4.0-beta.15"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.4.0-beta.14",
+  "version": "0.4.0-beta.15",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.4.0-beta.15.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only release bump with no application logic, security, or data-handling changes.
> 
> **Overview**
> **Release version bump** from `0.4.0-beta.14` to **`0.4.0-beta.15`** with no functional code changes.
> 
> The same version string is updated in `apps/desktop/src-tauri/Cargo.toml`, `apps/desktop/src-tauri/tauri.conf.json`, and the `reflect-open` entry in `Cargo.lock` so the built app and lockfile stay aligned for tagging and the updater flow described in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dae9acb41f28810af5720790cc3f74317bee0281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->