### PR TITLE
fix: render dropped file attachments as file pills

### DIFF
--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/editor/editor-handle-registry'
 import { markModeFromSyntax } from '@/editor/mark-mode'
 import { NoteEditor, type NoteEditorHandle } from '@/editor/note-editor'
-import { useAssetPersistence } from '@/editor/use-asset-persistence'
+import { resolveAssetFileLink, useAssetPersistence } from '@/editor/use-asset-persistence'
 import { useEditorAutocomplete } from '@/editor/use-editor-autocomplete'
 import { useNoteDocument } from '@/editor/use-note-document'
 import { useTagNavigation } from '@/editor/use-tag-navigation'
@@ -146,6 +146,7 @@ export function NotePaneComponent({
     resolveAssetOpenPath,
     openAsset,
     saveFile,
+    resolveFileInfo,
     saveError,
   } = useAssetPersistence(graphRoot, generation, path)
   const onWikiLinkClick = useWikiLinkNavigation(generation)
@@ -312,6 +313,11 @@ export function NotePaneComponent({
         resolveAssetOpenPath={resolveAssetOpenPath}
         openAsset={openAsset}
         saveFile={saveFile}
+        // Claims `assets/…` links (what saveFile inserts for a dropped
+        // non-image file) so they render as file pills, sized by
+        // resolveFileInfo.
+        resolveFileLink={resolveAssetFileLink}
+        resolveFileInfo={resolveFileInfo}
         onWikiLinkClick={onWikiLinkClick}
         onTagClick={onTagClick}
         onWikilinkSearch={onWikilinkSearch}

--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -19,6 +19,11 @@ interface CapturedEditorProps {
   onLinkClick?: (payload: { href: string; event: MouseEvent }) => void
   onTagClick?: (payload: { tag: string; event: MouseEvent }) => void
   onFilePaste?: (file: File) => Promise<string | undefined>
+  resolveFileLink?: (payload: { href: string; label: string; title: string }) => boolean
+  resolveFileInfo?: (
+    href: string,
+  ) => { size: number } | undefined | Promise<{ size: number } | undefined>
+  onFileClick?: (payload: { href: string; name: string; event: MouseEvent | KeyboardEvent }) => void
 }
 
 const captured = vi.hoisted(() => ({ props: null as CapturedEditorProps | null }))
@@ -310,6 +315,40 @@ describe('NoteEditor link opening', () => {
 
     expect(dispatchDeepLink).toHaveBeenCalledWith('reflect://note/abc123')
     expect(openUrl).not.toHaveBeenCalled()
+  })
+})
+
+describe('NoteEditor file pills', () => {
+  it('passes the file-link resolver through unchanged (meowdown reads it once)', () => {
+    const resolveFileLink = vi.fn(() => true)
+    render(<NoteEditor initialContent="" resolveFileLink={resolveFileLink} />)
+    expect(captured.props?.resolveFileLink).toBe(resolveFileLink)
+  })
+
+  it('omits the resolver when the host claims no file links', () => {
+    render(<NoteEditor initialContent="" />)
+    expect('resolveFileLink' in (captured.props ?? {})).toBe(false)
+  })
+
+  it('opens a clicked assets/ pill through the graph asset opener, not the URL opener', () => {
+    const openAsset = vi.fn(async () => {})
+    renderEditor(openAsset)
+
+    const event = new MouseEvent('click')
+    act(() => captured.props?.onFileClick?.({ href: 'assets/cat.png', name: 'cat.png', event }))
+
+    expect(openAsset).toHaveBeenCalledWith('assets/cat.png')
+    expect(openUrl).not.toHaveBeenCalled()
+  })
+
+  it('forwards pill size lookups to resolveFileInfo', async () => {
+    const resolveFileInfo = vi.fn(async () => ({ size: 42 }))
+    render(<NoteEditor initialContent="" resolveFileInfo={resolveFileInfo} />)
+
+    await expect(captured.props?.resolveFileInfo?.('assets/q3.pdf')).resolves.toEqual({
+      size: 42,
+    })
+    expect(resolveFileInfo).toHaveBeenCalledExactlyOnceWith('assets/q3.pdf')
   })
 })
 

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -12,6 +12,9 @@ import { errorMessage } from '@reflect/core'
 import {
   type AcceptPendingReplacementOptions,
   type ExitBoundaryHandler,
+  type FileClickHandler,
+  type FileInfoResolver,
+  type FileLinkResolver,
   type MarkMode,
   type StartPendingReplacementOptions,
 } from '@meowdown/core'
@@ -122,6 +125,15 @@ interface NoteEditorProps {
    * and `[name](dest)` for everything else.
    */
   saveFile?: (file: File) => Promise<string | null>
+  /**
+   * Claim a `[label](url)` link as a file attachment, rendered as an inline
+   * file pill instead of a plain link. Clicking a pill routes through the
+   * same href handling as a link click (asset opener, deep links, OS
+   * opener). Must be pure; read once on first render, like `initialContent`.
+   */
+  resolveFileLink?: FileLinkResolver
+  /** Resolve the file size a rendered file pill shows next to its name. */
+  resolveFileInfo?: FileInfoResolver
   /** Click on a `[[wiki link]]`. */
   onWikiLinkClick?: (target: string) => void
   /** Click on an inline `#tag`. The tag name arrives without the leading `#`. */
@@ -175,6 +187,8 @@ export function NoteEditor({
   resolveAssetOpenPath,
   openAsset,
   saveFile,
+  resolveFileLink,
+  resolveFileInfo,
   onWikiLinkClick,
   onTagClick,
   onWikilinkSearch,
@@ -201,6 +215,7 @@ export function NoteEditor({
   const resolveAssetOpenPathRef = useRef(resolveAssetOpenPath)
   const openAssetRef = useRef(openAsset)
   const saveFileRef = useRef(saveFile)
+  const resolveFileInfoRef = useRef(resolveFileInfo)
   const onExitBoundaryRef = useRef(onExitBoundary)
   useLayoutEffect(() => {
     onChangeRef.current = onChange
@@ -210,6 +225,7 @@ export function NoteEditor({
     resolveAssetOpenPathRef.current = resolveAssetOpenPath
     openAssetRef.current = openAsset
     saveFileRef.current = saveFile
+    resolveFileInfoRef.current = resolveFileInfo
     onExitBoundaryRef.current = onExitBoundary
   })
 
@@ -293,6 +309,17 @@ export function NoteEditor({
     },
     [],
   )
+  // A file pill is a claimed link, so a click on it routes exactly like a
+  // link click: `assets/…` through the asset opener, anything else through
+  // the deep-link/URL path.
+  const handleFileClick: FileClickHandler = useCallback(
+    ({ href, event }) => handleLinkClick({ href, event }),
+    [handleLinkClick],
+  )
+  const handleResolveFileInfo: FileInfoResolver = useCallback(
+    (href) => resolveFileInfoRef.current?.(href),
+    [],
+  )
   const handleImageClick = useCallback(
     ({ src, alt, event }: { src: string; alt: string; event: MouseEvent }) => {
       const displayUrl = resolveImageUrlRef.current?.(src) ?? null
@@ -352,6 +379,9 @@ export function NoteEditor({
         {...(onSlashMenuSearch !== undefined ? { onSlashMenuSearch } : {})}
         resolveImageUrl={handleResolveImageUrl}
         onFilePaste={handleFilePaste}
+        {...(resolveFileLink !== undefined ? { resolveFileLink } : {})}
+        resolveFileInfo={handleResolveFileInfo}
+        onFileClick={handleFileClick}
         onExitBoundary={handleExitBoundary}
       >
         <EditorInputTraits />

--- a/apps/desktop/src/editor/use-asset-persistence.test.tsx
+++ b/apps/desktop/src/editor/use-asset-persistence.test.tsx
@@ -223,6 +223,50 @@ describe('useAssetPersistence resolveFileInfo', () => {
     await expect(persistence!.resolveFileInfo('assets/q3.pdf')).resolves.toBeUndefined()
     expect(invoke).not.toHaveBeenCalled()
   })
+
+  it('degrades to no size when the assets listing fails', async () => {
+    setBridge({
+      invoke: async () => {
+        throw { kind: 'io', message: 'bridge down' }
+      },
+      invokeBinary: async () => null,
+      listen: async () => () => {},
+    })
+    render(<Host generation={3} />)
+
+    await expect(persistence!.resolveFileInfo('assets/q3.pdf')).resolves.toBeUndefined()
+  })
+
+  it('never serves a listing that lands after the graph session switched', async () => {
+    let resolveListing: ((entries: unknown) => void) | null = null
+    setBridge({
+      invoke: (command: string) =>
+        command === 'dir_list'
+          ? new Promise((resolve) => {
+              resolveListing = resolve
+            })
+          : Promise.resolve(null),
+      invokeBinary: async () => null,
+      listen: async () => () => {},
+    })
+    const view = render(<Host generation={3} />)
+
+    const staleLookup = persistence!.resolveFileInfo('assets/q3.pdf')
+    await waitFor(() => expect(resolveListing).not.toBeNull())
+    const resolveStale = resolveListing!
+    resolveListing = null
+
+    // The user switches graphs; the old graph's listing then lands.
+    view.rerender(<Host generation={4} />)
+    resolveStale([{ path: 'assets/q3.pdf', size: 999, modifiedMs: 0 }])
+    await staleLookup
+
+    // The new session lists afresh instead of serving the stale size.
+    const freshLookup = persistence!.resolveFileInfo('assets/q3.pdf')
+    await waitFor(() => expect(resolveListing).not.toBeNull())
+    resolveListing!([{ path: 'assets/q3.pdf', size: 111, modifiedMs: 0 }])
+    await expect(freshLookup).resolves.toEqual({ size: 111 })
+  })
 })
 
 /** A bridge whose appends fail until `heal()` is called. */

--- a/apps/desktop/src/editor/use-asset-persistence.test.tsx
+++ b/apps/desktop/src/editor/use-asset-persistence.test.tsx
@@ -5,6 +5,7 @@ import { setBridge } from '@reflect/core'
 import { resetOperations, useOperations, type Operation } from '@/lib/operations'
 import {
   LARGE_FILE_BYTES,
+  resolveAssetFileLink,
   useAssetPersistence,
   type AssetPersistence,
 } from './use-asset-persistence'
@@ -129,6 +130,97 @@ describe('useAssetPersistence saveFile', () => {
       saved = await persistence!.saveFile(fileOf('a.pdf', 'application/pdf'))
     })
     expect(saved).toBeNull()
+    expect(invoke).not.toHaveBeenCalled()
+  })
+})
+
+function fileLink(href: string): { href: string; label: string; title: string } {
+  return { href, label: 'label', title: '' }
+}
+
+describe('resolveAssetFileLink', () => {
+  it('claims safe graph-relative assets/ links only', () => {
+    expect(resolveAssetFileLink(fileLink('assets/q3-report.pdf'))).toBe(true)
+    expect(resolveAssetFileLink(fileLink('assets/sub/archive.zip'))).toBe(true)
+
+    expect(resolveAssetFileLink(fileLink('https://example.com/q3.pdf'))).toBe(false)
+    expect(resolveAssetFileLink(fileLink('notes/other.md'))).toBe(false)
+    expect(resolveAssetFileLink(fileLink('assets/../secrets.env'))).toBe(false)
+    expect(resolveAssetFileLink(fileLink('assets\\evil.pdf'))).toBe(false)
+    expect(resolveAssetFileLink(fileLink('assets/'))).toBe(false)
+  })
+})
+
+/** A bridge whose upload commands succeed and whose `dir_list` serves `entries`. */
+function installListingBridge(
+  entries: Array<{ path: string; size: number }>,
+): ReturnType<typeof vi.fn> {
+  const invoke = vi.fn(async (command: string, args: Record<string, unknown>) =>
+    command === 'dir_list'
+      ? entries.map((entry) => ({ ...entry, modifiedMs: 0 }))
+      : command === 'asset_upload_begin'
+        ? 'upload-1'
+        : command === 'asset_upload_commit'
+          ? `assets/${args['desiredName'] as string}`
+          : null,
+  )
+  setBridge({ invoke, invokeBinary: async () => null, listen: async () => () => {} })
+  return invoke
+}
+
+describe('useAssetPersistence resolveFileInfo', () => {
+  it('lists the assets directory once for a burst of pills', async () => {
+    const invoke = installListingBridge([
+      { path: 'assets/q3-report.pdf', size: 1234 },
+      { path: 'assets/archive.zip', size: 5678 },
+    ])
+    render(<Host generation={3} />)
+
+    const [report, archive] = await Promise.all([
+      persistence!.resolveFileInfo('assets/q3-report.pdf'),
+      persistence!.resolveFileInfo('assets/archive.zip'),
+    ])
+
+    expect(report).toEqual({ size: 1234 })
+    expect(archive).toEqual({ size: 5678 })
+    expect(invoke.mock.calls.filter(([command]) => command === 'dir_list')).toHaveLength(1)
+  })
+
+  it('serves a just-saved file from the save itself, without a listing', async () => {
+    const invoke = installListingBridge([])
+    render(<Host generation={3} />)
+
+    await act(async () => {
+      await persistence!.saveFile(fileOf('Q3 Report.PDF', 'application/pdf', 1234))
+    })
+
+    await expect(persistence!.resolveFileInfo('assets/q3-report.pdf')).resolves.toEqual({
+      size: 1234,
+    })
+    expect(invoke.mock.calls.filter(([command]) => command === 'dir_list')).toHaveLength(0)
+  })
+
+  it('declines remote or unsafe hrefs without touching the bridge', async () => {
+    const invoke = installListingBridge([])
+    render(<Host generation={3} />)
+
+    await expect(persistence!.resolveFileInfo('https://example.com/q3.pdf')).resolves.toBeUndefined()
+    await expect(persistence!.resolveFileInfo('assets/../secrets.env')).resolves.toBeUndefined()
+    expect(invoke).not.toHaveBeenCalled()
+  })
+
+  it('returns undefined for an asset missing from the listing', async () => {
+    installListingBridge([{ path: 'assets/other.pdf', size: 9 }])
+    render(<Host generation={3} />)
+
+    await expect(persistence!.resolveFileInfo('assets/gone.pdf')).resolves.toBeUndefined()
+  })
+
+  it('declines without a graph session', async () => {
+    const invoke = installListingBridge([{ path: 'assets/q3.pdf', size: 9 }])
+    render(<Host generation={null} />)
+
+    await expect(persistence!.resolveFileInfo('assets/q3.pdf')).resolves.toBeUndefined()
     expect(invoke).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/editor/use-asset-persistence.ts
+++ b/apps/desktop/src/editor/use-asset-persistence.ts
@@ -1,6 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { convertFileSrc } from '@tauri-apps/api/core'
-import { assetFileName, createAsset, errorMessage, openAsset as openAssetCommand } from '@reflect/core'
+import type { FileInfo, FileLinkPayload } from '@meowdown/core'
+import {
+  assetFileName,
+  createAsset,
+  errorMessage,
+  listDir,
+  openAsset as openAssetCommand,
+  type FileMeta,
+} from '@reflect/core'
 import { formatBytes } from '@/lib/format-bytes'
 import { startOperation } from '@/lib/operations'
 
@@ -42,6 +50,16 @@ function isSafeAssetSource(sourcePath: string): boolean {
     )
 }
 
+/**
+ * Claims a `[label](url)` markdown link as a file attachment when its
+ * destination is a safe graph-relative `assets/…` path, so meowdown renders
+ * it as a file pill instead of a plain link. Pure by contract (meowdown
+ * caches and diffs parse results), which a stateless path check satisfies.
+ */
+export function resolveAssetFileLink({ href }: FileLinkPayload): boolean {
+  return isSafeAssetSource(href)
+}
+
 /** The failed save the pane reports on: which banner copy, and the cause. */
 export interface AssetSaveError {
   /** 'image' for `image/*` files, 'file' for everything else. */
@@ -65,6 +83,12 @@ export interface AssetPersistence {
    * is the visible link text.
    */
   saveFile: (file: File) => Promise<string | null>
+  /**
+   * Resolve the size a file pill shows for a claimed `assets/…` link
+   * (see {@link resolveAssetFileLink}); undefined for anything else or a
+   * file that no longer exists.
+   */
+  resolveFileInfo: (href: string) => Promise<FileInfo | undefined>
   /** The most recent failed save; cleared by the next success. */
   saveError: AssetSaveError | null
 }
@@ -91,6 +115,11 @@ export function useAssetPersistence(
   // note (and graph session) it shows, so a save that finishes after a
   // switch must not put its outcome on the *next* note's banner.
   const sessionEpoch = useRef(0)
+  // File-pill sizes by graph-relative asset path, seeded by every save (the
+  // size is already in hand) and backfilled by one shared `assets/` listing,
+  // so a note full of pills stats the directory once, not once per pill.
+  const sizeByAssetPath = useRef(new Map<string, number>())
+  const pendingAssetListing = useRef<Promise<FileMeta[]> | null>(null)
 
   useEffect(() => {
     return () => {
@@ -98,6 +127,14 @@ export function useAssetPersistence(
       setSaveError(null)
     }
   }, [path, generation])
+
+  useEffect(() => {
+    const cache = sizeByAssetPath.current
+    return () => {
+      cache.clear()
+      pendingAssetListing.current = null
+    }
+  }, [generation])
 
   const resolveImageUrl = useCallback(
     (src: string): string | null => {
@@ -147,6 +184,7 @@ export function useAssetPersistence(
         : assetFileName(file.name)
       try {
         const saved = await createAsset(desiredName, file, generation)
+        sizeByAssetPath.current.set(saved, file.size)
         if (file.size > LARGE_FILE_BYTES) {
           startOperation('Large file added').warn(
             `“${file.name}” is ${formatBytes(file.size)}. Git keeps every version forever; GitHub rejects files over 100 MB.`,
@@ -174,8 +212,36 @@ export function useAssetPersistence(
     [generation],
   )
 
+  const resolveFileInfo = useCallback(
+    async (href: string): Promise<FileInfo | undefined> => {
+      if (generation === null || !isSafeAssetSource(href)) {
+        return undefined
+      }
+      const cache = sizeByAssetPath.current
+      if (!cache.has(href)) {
+        pendingAssetListing.current ??= listDir('assets', generation).finally(() => {
+          pendingAssetListing.current = null
+        })
+        const entries = await pendingAssetListing.current
+        for (const entry of entries) {
+          cache.set(entry.path, entry.size)
+        }
+      }
+      const size = cache.get(href)
+      return size === undefined ? undefined : { size }
+    },
+    [generation],
+  )
+
   return useMemo<AssetPersistence>(
-    () => ({ resolveImageUrl, resolveAssetOpenPath, openAsset, saveFile, saveError }),
-    [resolveImageUrl, resolveAssetOpenPath, openAsset, saveFile, saveError],
+    () => ({
+      resolveImageUrl,
+      resolveAssetOpenPath,
+      openAsset,
+      saveFile,
+      resolveFileInfo,
+      saveError,
+    }),
+    [resolveImageUrl, resolveAssetOpenPath, openAsset, saveFile, resolveFileInfo, saveError],
   )
 }

--- a/apps/desktop/src/editor/use-asset-persistence.ts
+++ b/apps/desktop/src/editor/use-asset-persistence.ts
@@ -129,9 +129,11 @@ export function useAssetPersistence(
   }, [path, generation])
 
   useEffect(() => {
-    const cache = sizeByAssetPath.current
     return () => {
-      cache.clear()
+      // Replace the map rather than clearing it: a listing or save still in
+      // flight for the old graph session writes into the orphaned instance,
+      // never into the next session's cache.
+      sizeByAssetPath.current = new Map()
       pendingAssetListing.current = null
     }
   }, [generation])
@@ -182,9 +184,12 @@ export function useAssetPersistence(
       const desiredName = imageExtension
         ? `pasted-${Date.now()}.${imageExtension}`
         : assetFileName(file.name)
+      // Captured before the await: a save resolving after a graph switch
+      // seeds the orphaned session's cache, not the next graph's.
+      const sizeCache = sizeByAssetPath.current
       try {
         const saved = await createAsset(desiredName, file, generation)
-        sizeByAssetPath.current.set(saved, file.size)
+        sizeCache.set(saved, file.size)
         if (file.size > LARGE_FILE_BYTES) {
           startOperation('Large file added').warn(
             `“${file.name}” is ${formatBytes(file.size)}. Git keeps every version forever; GitHub rejects files over 100 MB.`,
@@ -217,14 +222,22 @@ export function useAssetPersistence(
       if (generation === null || !isSafeAssetSource(href)) {
         return undefined
       }
+      // Captured before the await for the same session-scoping reason as in
+      // saveFile.
       const cache = sizeByAssetPath.current
       if (!cache.has(href)) {
         pendingAssetListing.current ??= listDir('assets', generation).finally(() => {
           pendingAssetListing.current = null
         })
-        const entries = await pendingAssetListing.current
-        for (const entry of entries) {
-          cache.set(entry.path, entry.size)
+        try {
+          const entries = await pendingAssetListing.current
+          for (const entry of entries) {
+            cache.set(entry.path, entry.size)
+          }
+        } catch {
+          // A failed listing degrades to a pill without a size, per the
+          // documented contract (undefined, never a rejection).
+          return undefined
         }
       }
       const size = cache.get(href)


### PR DESCRIPTION
## Problem

Dragging a file (e.g. a PDF) onto a note saved it into `assets/` and inserted a working `[name](assets/…)` link — but it rendered as an ordinary hyperlink instead of meowdown's rounded file pill. Pill rendering is opt-in: meowdown only renders a link as a pill when the host claims it via `resolveFileLink`, and Reflect never passed that hook (nor `resolveFileInfo` / `onFileClick`).

## Changes

- **`use-asset-persistence.ts`** — exports `resolveAssetFileLink`, a pure resolver that claims safe graph-relative `assets/…` links (same vetting as `resolveAssetOpenPath`), and adds `resolveFileInfo`, which supplies the size shown on a pill: seeded from each save (the size is already in hand) and backfilled by one shared `assets/` `dir_list` per burst of pills, cached per graph session.
- **`note-editor.tsx`** — new `resolveFileLink` / `resolveFileInfo` props passed through to `MeowdownEditor`, plus an `onFileClick` that routes a pill click through the same href handling as a link click (asset opener → deep link → OS opener), so attachments keep opening in the OS default app.
- **`note-pane.tsx`** — wires both into the editor.

## Testing

- `pnpm typecheck` and `pnpm lint` pass (only pre-existing warnings).
- New unit tests: `resolveAssetFileLink` vetting, `resolveFileInfo` (single listing per burst, save-seeded sizes, unsafe/remote/missing/no-session declines), and prop/click plumbing in `note-editor.test.tsx` — 36 tests pass across the two files.
- Verified in the browser preview (`?platform=ios`, in-memory bridge): an `assets/q3-report.pdf` link renders as a rounded pill (`data-file-kind="pdf"`, icon + name, 999px radius) in the daily note.

## Notes

- Read-only `MarkdownView` surfaces (backlink snippets, previews) still render asset links as plain links; claiming pills there is a possible follow-up.
- The browser dev bridge lacks `asset_upload_*`, so drag-drop itself was verified only by unit tests; pill rendering was verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor UX and asset path vetting only; reuses existing safe `assets/` checks and link-open behavior, with session-scoped caching covered by tests.
> 
> **Overview**
> Dropped or pasted non-image files already saved to `assets/` and inserted as `[name](assets/…)` links, but they still looked like plain hyperlinks because Reflect never opted into meowdown’s file-pill rendering.
> 
> **`use-asset-persistence`** now exports **`resolveAssetFileLink`** (claims only vetted graph-relative `assets/…` paths, same rules as asset open) and **`resolveFileInfo`**, which shows pill sizes from the in-flight save and otherwise batches one `assets/` directory listing per graph session, with cache reset when the graph generation changes so stale listings never leak across sessions.
> 
> **`NoteEditor`** passes **`resolveFileLink`**, **`resolveFileInfo`**, and **`onFileClick`** into **`MeowdownEditor`**; pill clicks reuse the existing link path (asset opener → deep links → OS URL). **`NotePane`** connects the persistence helpers to the editor.
> 
> Tests cover link vetting, size resolution (single listing, save-seeded sizes, unsafe/missing/session edge cases), and editor prop/click plumbing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dddcd79b127594bebaf36e107c805c38d133f34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Note attachments now render linked non-image assets as compact file pills, including file-size details when available.
  * File-pill clicks route through the same in-app link behavior as other note links (assets open the asset view).
* **Bug Fixes**
  * Attachment link resolution now accepts only safe, graph-relative `assets/...` hrefs and rejects unsafe/remote/traversal patterns.
  * Asset file metadata is cached and deduplicated per session; resolution safely degrades to unknown sizes when sessions end or lookups fail.
* **Tests**
  * Expanded coverage for file-pill prop wiring, opener routing, and asset listing/link resolution edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->