### PR TITLE
Fix mobile editor gutter

### DIFF
--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<!-- Merged into the bundle's Info.plist by tauri-build (and embedded into dev
-     binaries), so the macOS microphone prompt works in both `tauri dev` and
-     release builds. -->
+<!-- Merged into platform bundle Info.plists by tauri-build (and embedded into
+     dev binaries), so permission prompts work in dev and release builds. -->
 <plist version="1.0">
 <dict>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Reflect uses the microphone to record audio memos that are transcribed into your daily note.</string>
 	<key>NSCalendarsFullAccessUsageDescription</key>
-	<string>Reflect reads your calendar to show the day's meetings beside your daily note. Access is read-only and stays on this Mac.</string>
+	<string>Reflect reads your calendar to show the day's meetings beside your daily note. Access is read-only and stays on this device.</string>
 	<!-- Pre-Sonoma systems prompt with the legacy key. -->
 	<key>NSCalendarsUsageDescription</key>
-	<string>Reflect reads your calendar to show the day's meetings beside your daily note. Access is read-only and stays on this Mac.</string>
+	<string>Reflect reads your calendar to show the day's meetings beside your daily note. Access is read-only and stays on this device.</string>
 	<key>NSContactsUsageDescription</key>
 	<string>Reflect reads your contacts to suggest details for person notes. Nothing is stored or sent anywhere.</string>
 </dict>

--- a/apps/desktop/src-tauri/gen/apple/reflect-open.xcodeproj/project.pbxproj
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open.xcodeproj/project.pbxproj
@@ -394,7 +394,7 @@
 				CODE_SIGN_ENTITLEMENTS = "reflect-open_iOS/reflect-open_iOS.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 789ULN5MZB;
+				DEVELOPMENT_TEAM = "789ULN5MZB";
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -409,7 +409,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = app.reflect.ios;
-				PRODUCT_NAME = Reflect;
+				PRODUCT_NAME = "Reflect";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = arm64;
@@ -490,7 +490,7 @@
 				CODE_SIGN_ENTITLEMENTS = "reflect-open_iOS/reflect-open_iOS.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 789ULN5MZB;
+				DEVELOPMENT_TEAM = "789ULN5MZB";
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -505,7 +505,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = app.reflect.ios;
-				PRODUCT_NAME = Reflect;
+				PRODUCT_NAME = "Reflect";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = arm64;

--- a/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/Info.plist
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/Info.plist
@@ -46,5 +46,11 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Reflect uses the microphone to record audio memos that are transcribed into your daily note.</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>Reflect reads your calendar to show the day&apos;s meetings beside your daily note. Access is read-only and stays on this device.</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>Reflect reads your calendar to show the day&apos;s meetings beside your daily note. Access is read-only and stays on this device.</string>
 </dict>
 </plist>

--- a/apps/desktop/src/mobile/day-slide.tsx
+++ b/apps/desktop/src/mobile/day-slide.tsx
@@ -4,6 +4,7 @@ import { NotePane } from '@/components/note-pane'
 import { formatDayLabel } from '@/lib/dates'
 import { cn } from '@/lib/utils'
 import { IncomingBacklinks } from '@/mobile/incoming-backlinks'
+import { MOBILE_CONTENT_GUTTER } from '@/mobile/mobile-content-gutter'
 import { useScrollRestore } from '@/mobile/use-scroll-restore'
 import { useSettings } from '@/providers/settings-provider'
 
@@ -77,21 +78,27 @@ export function DaySlide({
       <div ref={contentRef}>
         {/* The date is the daily note's subject (V1 / desktop parity) —
             chrome above the editor, formatted per the user's setting,
-            tinted on today. Shares the note body's px-4 gutter. */}
-        <h2 className={cn('reflect-daily-subject px-4 pt-4 pb-1', day === today && 'text-accent')}>
+            tinted on today. Shares the note body's gutter. */}
+        <h2
+          className={cn(
+            'reflect-daily-subject pt-4 pb-1',
+            MOBILE_CONTENT_GUTTER,
+            day === today && 'text-accent',
+          )}
+        >
           {formatDayLabel(day, settings.dateFormat)}
         </h2>
         <NotePane
           path={dailyPath(day)}
           lazy
           showBacklinks={false}
-          gutterClassName="px-4"
+          gutterClassName={MOBILE_CONTENT_GUTTER}
           editorClassName="min-h-[60dvh]"
         />
         {/* The mobile section (touch chrome) replaces NotePane's built-in
             desktop panel; a daily-note backlink swipes the carousel to that
             date rather than pushing a screen. */}
-        <IncomingBacklinks path={dailyPath(day)} className="px-4 pb-4" />
+        <IncomingBacklinks path={dailyPath(day)} className={cn(MOBILE_CONTENT_GUTTER, 'pb-4')} />
       </div>
     </div>
   )

--- a/apps/desktop/src/mobile/mobile-content-gutter.ts
+++ b/apps/desktop/src/mobile/mobile-content-gutter.ts
@@ -1,0 +1,2 @@
+/** Mobile note-body gutter that out-cascades the editor padding reset. */
+export const MOBILE_CONTENT_GUTTER = 'reflect-mobile-content-gutter'

--- a/apps/desktop/src/mobile/screens/note.test.tsx
+++ b/apps/desktop/src/mobile/screens/note.test.tsx
@@ -5,11 +5,15 @@ import { untitledNotePath } from '@reflect/core'
 import { RouterProvider, useRouter, type NavigateOptions } from '@/routing/router'
 import { MobileNote } from './note'
 
-const paneProps = vi.hoisted(() => ({ autoFocus: null as boolean | null }))
+const paneProps = vi.hoisted(() => ({
+  autoFocus: null as boolean | null,
+  gutterClassName: null as string | null,
+}))
 
 vi.mock('@/components/note-pane', () => ({
-  NotePane: ({ autoFocus }: { autoFocus?: boolean }) => {
+  NotePane: ({ autoFocus, gutterClassName }: { autoFocus?: boolean; gutterClassName?: string }) => {
     paneProps.autoFocus = autoFocus ?? false
+    paneProps.gutterClassName = gutterClassName ?? null
     return <div data-testid="fake-pane" />
   },
 }))
@@ -58,12 +62,18 @@ function renderArrival(path: string, options?: NavigateOptions): ReturnType<type
 afterEach(() => {
   cleanup()
   paneProps.autoFocus = null
+  paneProps.gutterClassName = null
 })
 
 describe('MobileNote focus contract', () => {
   it('does not autofocus a plain arrival (no keyboard on browse)', () => {
     renderArrival('notes/target.md')
     expect(paneProps.autoFocus).toBe(false)
+  })
+
+  it('uses the mobile note-body gutter for the editor surface', () => {
+    renderArrival('notes/target.md')
+    expect(paneProps.gutterClassName).toBe('reflect-mobile-content-gutter')
   })
 
   it('autofocuses a fresh untitled note (the + flow)', () => {

--- a/apps/desktop/src/mobile/screens/note.tsx
+++ b/apps/desktop/src/mobile/screens/note.tsx
@@ -4,7 +4,9 @@ import { ChevronLeft } from 'lucide-react'
 import { NotePane } from '@/components/note-pane'
 import { Button } from '@/components/ui/button'
 import { IncomingBacklinks } from '@/mobile/incoming-backlinks'
+import { MOBILE_CONTENT_GUTTER } from '@/mobile/mobile-content-gutter'
 import { NoteActionsMenu } from '@/mobile/note-actions-menu'
+import { cn } from '@/lib/utils'
 import { useRouter } from '@/routing/router'
 
 /**
@@ -58,13 +60,13 @@ export function MobileNote({ path }: { path: string }): ReactElement {
           lazy
           autoFocus={untitled || focusRequested}
           showBacklinks={false}
-          gutterClassName="px-4"
+          gutterClassName={MOBILE_CONTENT_GUTTER}
           editorClassName="min-h-[60dvh]"
         />
         {/* The mobile section (touch chrome) replaces NotePane's built-in
             desktop panel; a daily-note backlink opens the Daily surface at
             that date rather than pushing another note screen. */}
-        <IncomingBacklinks path={path} className="px-4 pb-4" />
+        <IncomingBacklinks path={path} className={cn(MOBILE_CONTENT_GUTTER, 'pb-4')} />
       </main>
     </div>
   )

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -329,6 +329,13 @@ html:root {
   padding-inline: max(2rem, calc((100% - 42rem) / 2));
 }
 
+/* Mobile note-body gutter. This mirrors `.reflect-content-gutter`'s cascade
+   role with a fixed phone-sized inset: the class must be un-layered so it beats
+   `.reflect-editor { padding: 0; }` on the contenteditable itself. */
+.reflect-mobile-content-gutter {
+  padding-inline: max(1rem, env(safe-area-inset-left)) max(1rem, env(safe-area-inset-right));
+}
+
 /* Block spacing comes from the element margins below, not the theme's
    uniform sibling gap. */
 .reflect-editor > * + * {

--- a/docs/contributing/mobile-simulator.md
+++ b/docs/contributing/mobile-simulator.md
@@ -1,0 +1,38 @@
+# Running the iOS simulator
+
+Reflect mobile is the iOS target of `apps/desktop`, so the simulator dev loop
+uses Tauri's iOS command rather than a separate app package.
+
+From the repo root:
+
+```bash
+pnpm tauri ios dev "iPhone 17 Pro"
+```
+
+The root `tauri` script delegates to `apps/desktop`, so the command runs the
+usual sidecar step and starts Vite through Tauri's `beforeDevCommand`.
+
+To see simulator names:
+
+```bash
+xcrun simctl list devices available
+```
+
+The first run can be quiet for a while because Xcode is compiling the Rust
+crate, the Swift keyboard plugin, and native dependencies for
+`aarch64-apple-ios-sim`. A healthy launch eventually prints the Plan 19 probe
+lines from `spike_mobile.rs`:
+
+```text
+[plan19-spike] PASS: keychain round-trip
+[plan19-spike] PASS: sqlite fts5
+[plan19-spike] PASS: documents file io
+[plan19-spike] PASS: libgit2 init+commit
+```
+
+`tauri ios dev` may normalize generated files under
+`apps/desktop/src-tauri/gen/apple/`, including `project.pbxproj` quoting and
+merged `Info.plist` usage descriptions. Inspect those diffs before committing;
+when the generated output is intentionally refreshed, update the source
+template in `apps/desktop/src-tauri/ios.project.yml` or
+`apps/desktop/src-tauri/Info.plist` first.

--- a/docs/plans/19-mobile.md
+++ b/docs/plans/19-mobile.md
@@ -381,8 +381,9 @@ Steps 1 and 2 are the existential gates; nothing else starts until both pass.
 ## Acceptance criteria
 
 - `pnpm tauri ios dev` runs the mobile app in the simulator from a clean
-  checkout; `pnpm tauri dev` (desktop) is unaffected; `cargo test -p
-  reflect-open` and the TS suites stay green.
+  checkout (see [the simulator runbook](../contributing/mobile-simulator.md));
+  `pnpm tauri dev` (desktop) is unaffected; `cargo test -p reflect-open` and
+  the TS suites stay green.
 - Fresh install → Start fresh → today's note exists on disk under
   `Documents/`, visible in the Files app; capture appends markdown that
   desktop later pulls intact.


### PR DESCRIPTION
## Problem

The mobile note editor was rendering flush to the screen edge even though the mobile screens passed `px-4` through `gutterClassName`. Desktop avoids this by using an unlayered `.reflect-content-gutter`, because `.reflect-editor { padding: 0; }` intentionally beats normal utility classes on the contenteditable surface. Mobile needed the same cascade shape instead of a Tailwind utility.

While validating the iOS simulator path, the command flow also lacked a short runbook for contributors and Tauri refreshed the generated iOS project/plist output.

## Before -> After

| Area | Before | After |
| --- | --- | --- |
| Mobile editor body | Text could sit flush against the left edge because `px-4` lost to the editor padding reset | Daily and note screens use `reflect-mobile-content-gutter`, which wins the same way the desktop gutter does |
| Mobile date/backlinks alignment | Date heading, editor, and backlinks each carried local `px-4` classes | All three share the same named mobile gutter |
| Simulator docs | Plan 19 mentioned the command, but there was no focused runbook | `docs/contributing/mobile-simulator.md` documents the Tauri iOS dev loop, simulator discovery, expected probe logs, and generated-file side effects |
| Permission copy | Shared calendar prompt said access stays on "this Mac" | Shared prompt is device-neutral for iOS and desktop bundles |

## Changes

1. Added `MOBILE_CONTENT_GUTTER` and the unlayered `.reflect-mobile-content-gutter` CSS rule so the mobile editor gets a stable inline inset even on the contenteditable root.
2. Replaced mobile `px-4` note-body gutters in `DaySlide` and `MobileNote` with the shared gutter constant, keeping headings, editor content, and backlinks aligned.
3. Added a mobile note regression test that asserts the mobile screen passes the named gutter to `NotePane`.
4. Added the iOS simulator runbook and linked it from Plan 19 acceptance criteria.
5. Updated shared permission wording and the generated iOS plist/project output produced by the Tauri iOS dev flow.

## Tests

- `src/mobile/screens/note.test.tsx` now pins the mobile note-body gutter contract in addition to the existing autofocus behavior.
- `src/mobile/note-conflict.test.tsx` was rerun to cover the protected mobile note path after the gutter changes.

## Verification

- `pnpm --filter @reflect/desktop test --run src/mobile/screens/note.test.tsx src/mobile/note-conflict.test.tsx` passed.
- `pnpm check` passed. The command still reports existing warnings in unrelated files, but no errors.
- iPhone 17 Pro simulator smoke: Tauri iOS dev built/deployed the app, Plan 19 probes passed, HMR applied the padding fix, and a simulator screenshot confirmed the note body is inset.

## Risk / Rollout

Low risk. This is a CSS/class wiring change for mobile note surfaces plus docs and generated iOS metadata refresh. No migrations or data-shape changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS/class wiring on mobile layouts plus docs and generated iOS metadata; no data or auth changes.
> 
> **Overview**
> Fixes **mobile note text sitting flush to the screen edge** by replacing per-screen `px-4` with a shared **`reflect-mobile-content-gutter`** class (via `MOBILE_CONTENT_GUTTER`), matching desktop’s unlayered gutter pattern so padding wins over **`.reflect-editor { padding: 0; }`**. **Daily carousel** and **note** screens apply it to the date heading, `NotePane`, and backlinks so one column stays aligned.
> 
> Adds a **regression test** that `MobileNote` passes the named gutter to `NotePane`, plus **`docs/contributing/mobile-simulator.md`** and a Plan 19 link for the **`pnpm tauri ios dev`** workflow.
> 
> **iOS bundle metadata:** calendar usage strings say **“this device”** instead of “this Mac”; generated **iOS `Info.plist`** gains microphone/calendar usage keys; **`project.pbxproj`** picks up Tauri-normalized quoting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3db4decb449738f1dbb19c8a4250725f7a6b1a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved mobile note layout with consistent side spacing for the note editor, headings, and backlinks.

* **Bug Fixes**
  * Refined macOS permission messaging for calendars to better reflect read-only access on the device.
  * Updated mobile note spacing behavior to work more reliably across different screen sizes and safe areas.

* **Documentation**
  * Added guidance for running the iOS simulator and updated the mobile plan with the new setup reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->