### PR TITLE
fix: pin the iOS webview scroll offset so keyboard focus can't push the app off-screen

### DIFF
--- a/apps/desktop/src/mobile/screens/note.test.tsx
+++ b/apps/desktop/src/mobile/screens/note.test.tsx
@@ -7,12 +7,22 @@ import { MobileNote } from './note'
 
 const paneProps = vi.hoisted(() => ({
   autoFocus: null as boolean | null,
+  className: null as string | null,
   gutterClassName: null as string | null,
 }))
 
 vi.mock('@/components/note-pane', () => ({
-  NotePane: ({ autoFocus, gutterClassName }: { autoFocus?: boolean; gutterClassName?: string }) => {
+  NotePane: ({
+    autoFocus,
+    className,
+    gutterClassName,
+  }: {
+    autoFocus?: boolean
+    className?: string
+    gutterClassName?: string
+  }) => {
     paneProps.autoFocus = autoFocus ?? false
+    paneProps.className = className ?? null
     paneProps.gutterClassName = gutterClassName ?? null
     return <div data-testid="fake-pane" />
   },
@@ -62,6 +72,7 @@ function renderArrival(path: string, options?: NavigateOptions): ReturnType<type
 afterEach(() => {
   cleanup()
   paneProps.autoFocus = null
+  paneProps.className = null
   paneProps.gutterClassName = null
 })
 
@@ -74,6 +85,11 @@ describe('MobileNote focus contract', () => {
   it('uses the mobile note-body gutter for the editor surface', () => {
     renderArrival('notes/target.md')
     expect(paneProps.gutterClassName).toBe('reflect-mobile-content-gutter')
+  })
+
+  it('gives the pane a top inset (no date header above a plain note)', () => {
+    renderArrival('notes/target.md')
+    expect(paneProps.className).toContain('pt-4')
   })
 
   it('autofocuses a fresh untitled note (the + flow)', () => {

--- a/apps/desktop/src/mobile/screens/note.tsx
+++ b/apps/desktop/src/mobile/screens/note.tsx
@@ -60,6 +60,10 @@ export function MobileNote({ path }: { path: string }): ReactElement {
           lazy
           autoFocus={untitled || focusRequested}
           showBacklinks={false}
+          // The daily surface gets its top inset from the date header; a
+          // plain note has no chrome between the header bar and the body,
+          // so the pane carries the vertical breathing room itself.
+          className="pt-4"
           gutterClassName={MOBILE_CONTENT_GUTTER}
           editorClassName="min-h-[60dvh]"
         />

--- a/docs/contributing/mobile-simulator.md
+++ b/docs/contributing/mobile-simulator.md
@@ -30,6 +30,15 @@ lines from `spike_mobile.rs`:
 [plan19-spike] PASS: libgit2 init+commit
 ```
 
+## The software keyboard
+
+The simulator hides the software keyboard whenever "Connect Hardware
+Keyboard" is enabled (I/O → Keyboard, ⇧⌘K) — focusing the editor then
+types through the Mac keyboard with no on-screen keyboard and no
+`keyboardChange` events, which looks like a keyboard bug but isn't. Turn
+that setting off (or press ⌘K with the app focused) to exercise the real
+keyboard-avoidance path.
+
 `tauri ios dev` may normalize generated files under
 `apps/desktop/src-tauri/gen/apple/`, including `project.pbxproj` quoting and
 merged `Info.plist` usage descriptions. Inspect those diffs before committing;

--- a/docs/porting/reflect-mobile/editor-and-keyboard.md
+++ b/docs/porting/reflect-mobile/editor-and-keyboard.md
@@ -33,6 +33,16 @@ toolbar — and the hard-won keyboard/focus lessons.
 > `focus()` raises the keyboard in wry's WKWebView, menu tappability,
 > caret visibility, haptic feel — plus focus restore for wiki links
 > resolving to *daily* notes (the daily surface owns that).
+>
+> **On-device finding (2026-07-04):** `contentInsetAdjustmentBehavior =
+> .never` was not enough — on focus, WebKit still scrolls the *native*
+> scroll view to reveal the caret (it cannot know the page layout already
+> made room), pushing the entire app upward out of the window. The plugin
+> now pins `scrollView.contentOffset` to zero via KVO; the page is always
+> exactly viewport-sized on mobile, so any native offset is that nudge.
+> In the simulator, note that the software keyboard stays hidden while
+> "Connect Hardware Keyboard" is on (⇧⌘K; ⌘K toggles the software
+> keyboard) — that is a simulator setting, not an app bug.
 
 ## What V1 mobile does
 

--- a/plugins/tauri-plugin-keyboard/ios/Sources/KeyboardPlugin.swift
+++ b/plugins/tauri-plugin-keyboard/ios/Sources/KeyboardPlugin.swift
@@ -18,7 +18,9 @@ struct KeyboardState: Encodable {
 /// nudges the webview's scroll view around when the keyboard animates in,
 /// occluding whatever the caret is in. This plugin takes manual control —
 /// the webview keeps its full-screen frame, scroll-view auto-adjustment is
-/// disabled, and the keyboard's overlap height streams to JS as
+/// disabled, its scroll offset is pinned to zero (WebKit's caret-reveal
+/// scroll would otherwise push the page out of the window on focus), and
+/// the keyboard's overlap height streams to JS as
 /// `keyboardChange` events so the layout can make room (a CSS variable, a
 /// pinned toolbar, caret scroll-into-view).
 ///
@@ -28,6 +30,7 @@ struct KeyboardState: Encodable {
 class KeyboardPlugin: Plugin {
   private weak var webView: WKWebView?
   private var currentState = KeyboardState(height: 0, duration: 0)
+  private var scrollOffsetObservation: NSKeyValueObservation?
   // Lazy so the generator is created on the main thread, inside the first
   // `impactLight` dispatch; kept alive across taps to skip re-allocating
   // the underlying haptic engine on every press.
@@ -38,6 +41,17 @@ class KeyboardPlugin: Plugin {
     // The system's automatic inset adjustment is the source of the jump:
     // page layout owns keyboard avoidance instead (via the events below).
     webview.scrollView.contentInsetAdjustmentBehavior = .never
+    // That flag alone doesn't stop WebKit's own keyboard avoidance: on focus
+    // it scrolls the *native* scroll view to reveal the caret, not knowing
+    // the page layout already made room — shoving the whole app upward out
+    // of the window. The page is always exactly viewport-sized here (inner
+    // elements own all scrolling, pinch zoom is disabled by the viewport
+    // meta), so any native offset is that nudge. Pin it back to zero.
+    scrollOffsetObservation = webview.scrollView.observe(\.contentOffset, options: [.new]) {
+      scrollView, _ in
+      guard scrollView.contentOffset != .zero else { return }
+      scrollView.setContentOffset(.zero, animated: false)
+    }
     // iOS injects a form-assistant bar (‹ › field stepper + Done) above the
     // keyboard for any focused field or contenteditable. Reflect edits one
     // continuous document, so the bar is meaningless chrome — strip it.


### PR DESCRIPTION
## Problem

On a real iPhone, focusing a note scrolls the entire app out of the viewport: the daily calendar strip disappears above the screen and the caret ends up over the status bar (TestFlight beta.16).

`contentInsetAdjustmentBehavior = .never` (PR #477) stops the system's inset adjustment, but it does **not** stop WebKit's own keyboard avoidance: on focus, WebKit scrolls the **native** `WKScrollView` to reveal the caret. It can't know the page layout already made room (the mobile shell root ends at the keyboard's top), so the whole page gets shoved upward. This was exactly the "caret visibility on device" item still owed to the spike-B gate.

## Fix

- **`KeyboardPlugin.swift`**: KVO-observe `scrollView.contentOffset` and pin it to zero. The page is always exactly viewport-sized on mobile (inner elements own all scrolling, pinch zoom is disabled by the viewport meta), so any native offset is WebKit's nudge. wry sets no scroll-view delegate, so nothing is displaced.
- **Note screen top inset**: the daily surface gets its vertical breathing room from the date header's `pt-4`; a plain note had nothing between the header bar and the body (#492 only added the horizontal gutter). The pane now carries `pt-4`.
- **Docs**: recorded the on-device finding in the porting doc; documented the simulator's "Connect Hardware Keyboard" trap (⇧⌘K) in `docs/contributing/mobile-simulator.md` — with it on, the software keyboard never appears in the simulator, which reads as an app bug but isn't.

## Testing

- `pnpm vitest --run src/mobile/screens/note.test.tsx` — 5 passing (new assertion for the pane top inset).
- `pnpm typecheck` and `pnpm lint` clean (3 pre-existing warnings).
- Swift change parse-checked; **needs an on-device pass** — the native scroll clamp can't be exercised in jsdom, and the simulator needs the hardware-keyboard setting off to show the keyboard at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Native scroll clamping affects all iOS keyboard focus paths and needs on-device validation; the layout change is localized to mobile notes.
> 
> **Overview**
> Fixes on-device keyboard focus pushing the whole app above the viewport by **pinning the iOS webview’s native `scrollView.contentOffset` to zero** in `KeyboardPlugin` (KVO), on top of existing `contentInsetAdjustmentBehavior = .never`, so WebKit’s caret-reveal scroll can’t shove the page out of the window.
> 
> **Mobile plain notes** now pass `className="pt-4"` on `NotePane` so spacing matches the daily surface (which gets top inset from its date header). Tests assert the inset contract.
> 
> **Docs** record the on-device finding in the porting keyboard doc and explain the simulator “Connect Hardware Keyboard” trap in `mobile-simulator.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f96d6c149480da0b34acab5900679549e31293c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile notes now keep consistent top spacing when opened, improving layout on arrival.
  * Keyboard handling on iOS now better preserves the page position when focusing inputs.

* **Bug Fixes**
  * Reduced unwanted page shifting caused by the on-screen keyboard and caret focus behavior.

* **Documentation**
  * Added guidance for using the iOS simulator keyboard and clarified mobile keyboard/scroll behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->