### PR TITLE
chore: add iOS TestFlight release flow

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -1,0 +1,92 @@
+name: TestFlight
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_number:
+        description: CFBundleVersion build number. Defaults to the GitHub run number.
+        required: false
+        type: string
+      export_method:
+        description: Xcode export method for the IPA.
+        required: true
+        type: choice
+        default: app-store-connect
+        options:
+          - app-store-connect
+          - release-testing
+      wait_for_processing:
+        description: Wait for App Store Connect processing before finishing.
+        required: true
+        type: boolean
+        default: true
+
+# TestFlight uploads should be serialized so build numbers and App Store
+# Connect processing don't race each other.
+concurrency:
+  group: testflight
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  testflight:
+    name: Build and upload iOS
+    runs-on: macos-latest
+    timeout-minutes: 120
+    env:
+      CARGO_HTTP_MULTIPLEXING: false
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Verify TestFlight secrets are configured
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
+        run: |
+          missing=()
+          for name in APPLE_API_KEY APPLE_API_ISSUER APPLE_API_KEY_CONTENT; do
+            [ -n "${!name}" ] || missing+=("$name")
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::missing TestFlight secret(s): ${missing[*]} — see docs/ios-testflight.md"
+            exit 1
+          fi
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Install Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: aarch64-apple-ios
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-on-failure: true
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build and upload to TestFlight
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
+          BUILD_NUMBER: ${{ inputs.build_number || github.run_number }}
+          EXPORT_METHOD: ${{ inputs.export_method }}
+          WAIT_FLAG: ${{ inputs.wait_for_processing && '--wait' || '' }}
+        run: |
+          pnpm release:ios preflight --build-number="$BUILD_NUMBER"
+          pnpm release:ios testflight --build-number="$BUILD_NUMBER" --export-method="$EXPORT_METHOD" $WAIT_FLAG

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,34 @@ pnpm tauri build      # Native app bundle, incl. the reflect CLI sidecar
 pnpm release:bump     # Bump the version everywhere + push the release tag (docs/macos-distribution.md)
 pnpm release:macos    # Signed + notarized macOS build for distribution (docs/macos-distribution.md)
 pnpm release:macos publish  # The above, then upload the DMG to a new GitHub release
+pnpm tauri ios dev "iPhone 17 Pro"  # Run the Tauri iOS target in the simulator (docs/contributing/mobile-simulator.md)
+pnpm release:ios preflight --build-number=123  # Check iOS/TestFlight signing, App Store Connect app record, and upload auth
+pnpm release:ios testflight --build-number=123 --wait  # Build and upload the iOS app to TestFlight
 ```
+
+**iOS simulator**
+
+The mobile app is the Tauri iOS target of `apps/desktop`, not a separate
+package. Use `pnpm tauri ios dev "iPhone 17 Pro"` from the repo root; list
+available simulator names with `xcrun simctl list devices available`. The first
+run can be quiet while Xcode compiles Rust, Swift plugin code, and native
+dependencies. See `docs/contributing/mobile-simulator.md` before committing
+changes under `apps/desktop/src-tauri/gen/apple/`, because Tauri/Xcode may
+normalize generated project and plist files.
+
+**iOS TestFlight**
+
+Use `pnpm release:ios` for TestFlight work; do not hand-roll `tauri ios build`
+and `altool` unless debugging the helper itself. Start with
+`pnpm release:ios preflight --build-number=<number>`, then run
+`pnpm release:ios testflight --build-number=<number> --wait` or upload an
+existing IPA with `pnpm release:ios upload --ipa=<path> --wait`.
+
+The iOS bundle identifier is `app.reflect.ios`, intentionally separate from the
+old Capacitor TestFlight app (`app.reflect.ReflectMobile`). The release helper
+verifies the IPA bundle identifier and `ITSAppUsesNonExemptEncryption=false`
+before upload. See `docs/ios-testflight.md` for App Store Connect setup, local
+keychain fallback (`reflect-notary`), API key CI secrets, and troubleshooting.
 
 # Code Conventions
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,30 @@ pnpm --filter @reflect/desktop sidecar
 cargo test --workspace
 ```
 
+### iOS development and TestFlight
+
+Reflect's iOS app is the Tauri mobile target inside `apps/desktop`, not a
+separate package. To run the mobile app in the simulator:
+
+```bash
+pnpm tauri ios dev "iPhone 17 Pro"
+```
+
+See [docs/contributing/mobile-simulator.md](docs/contributing/mobile-simulator.md)
+for simulator names, first-run expectations, and generated Xcode file notes.
+
+TestFlight builds use the dedicated release helper:
+
+```bash
+pnpm release:ios preflight --build-number=123
+pnpm release:ios testflight --build-number=123 --wait
+```
+
+The TestFlight app is `app.reflect.ios`, intentionally separate from the old
+Capacitor mobile app (`app.reflect.ReflectMobile`). See
+[docs/ios-testflight.md](docs/ios-testflight.md) for signing credentials, App
+Store Connect setup, CI secrets, and troubleshooting.
+
 See [CONTRIBUTING.md](CONTRIBUTING.md) for conventions, the step-by-step
 guides in [docs/contributing/](docs/contributing/) (adding a command, adding a
 setting, editor architecture), and [AGENTS.md](AGENTS.md) for the full
@@ -202,8 +226,8 @@ Designed or in progress, each with a written plan:
 
 - **Mobile companion** ([mobile design](docs/plans/19-mobile.md)): iOS is in
   progress in the Tauri app, with Daily/All surfaces and editing foundations
-  landed; device validation, sync hardening, and TestFlight/App Store release
-  remain.
+  landed; simulator and TestFlight release paths are documented, while device
+  validation, sync hardening, and App Store submission remain.
 
 Windows, Android, and a plugin API are out of scope for now; the
 [product vision](docs/reflect-v2-product-vision.md) explains the long-term

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "sidecar": "node scripts/build-sidecar.mjs",
     "release:bump": "node scripts/release-bump.mjs",
+    "release:ios": "node scripts/release-ios.mjs",
     "release:macos": "node scripts/release-macos.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/apps/desktop/scripts/release-ios.mjs
+++ b/apps/desktop/scripts/release-ios.mjs
@@ -1,0 +1,615 @@
+// Build and upload Reflect's iOS app to TestFlight.
+//
+// Usage:
+//   pnpm release:ios build --build-number=123
+//   pnpm release:ios testflight --build-number=123 --wait
+//   pnpm release:ios upload --ipa=apps/desktop/src-tauri/gen/apple/build/arm64/Reflect.ipa
+//
+// The App Store Connect API key is used twice when present:
+//   1. xcodebuild provisioning/export auth via -authenticationKey*
+//   2. altool IPA upload auth via --api-key/--api-issuer
+//
+// Set APPLE_API_KEY, APPLE_API_ISSUER, and either APPLE_API_KEY_CONTENT or
+// APPLE_API_KEY_PATH. See docs/ios-testflight.md.
+
+import { execFileSync, spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { basename, dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const DEFAULT_EXPORT_METHOD = 'app-store-connect'
+const EXPORT_METHODS = new Set(['app-store-connect', 'release-testing', 'debugging', 'validation'])
+const IOS_BUNDLE_IDENTIFIER = 'app.reflect.ios'
+const OLD_CAPACITOR_BUNDLE_IDENTIFIER = 'app.reflect.ReflectMobile'
+const NON_EXEMPT_ENCRYPTION_KEY = 'ITSAppUsesNonExemptEncryption'
+const KEYCHAIN_SERVICE = 'reflect-notary'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const appDir = join(here, '..')
+const repoRoot = join(here, '..', '..', '..')
+const iosBuildDir = join(appDir, 'src-tauri', 'gen', 'apple', 'build')
+
+function log(message) {
+  console.log(`release-ios: ${message}`)
+}
+
+function fail(message) {
+  console.error(`release-ios: error: ${message}`)
+  process.exit(1)
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, { encoding: 'utf8' })
+  return { status: result.status, output: `${result.stdout ?? ''}${result.stderr ?? ''}` }
+}
+
+function capture(command, args) {
+  return execFileSync(command, args, { encoding: 'utf8' })
+}
+
+/** Build the runner authentication args xcodebuild needs for automatic provisioning. */
+export function createXcodeAuthenticationArgs({ issuerId, keyId, keyPath }) {
+  return [
+    '-authenticationKeyPath',
+    keyPath,
+    '-authenticationKeyID',
+    keyId,
+    '-authenticationKeyIssuerID',
+    issuerId,
+  ]
+}
+
+/** Build the altool authentication args for an App Store Connect API key. */
+export function createApiKeyAltoolArgs({ issuerId, keyId, keyPath }) {
+  const args = ['--api-key', keyId, '--api-issuer', issuerId]
+  if (keyPath) args.push('--p8-file-path', keyPath)
+  return args
+}
+
+/** Build the Tauri iOS archive/export command. */
+export function createTauriIosBuildArgs({
+  buildNumber = null,
+  exportMethod = DEFAULT_EXPORT_METHOD,
+  verbose = false,
+  xcodeAuthenticationArgs = [],
+}) {
+  const args = ['tauri', 'ios', 'build', '--export-method', exportMethod, '--ci']
+  if (buildNumber) args.push('--config', JSON.stringify({ bundle: { iOS: { bundleVersion: buildNumber } } }))
+  if (verbose) args.push('--verbose')
+  if (xcodeAuthenticationArgs.length > 0) args.push('--', ...xcodeAuthenticationArgs)
+  return args
+}
+
+/** Build the altool command that uploads an IPA to App Store Connect/TestFlight. */
+export function createAltoolUploadArgs({ authArgs, ipa, wait }) {
+  const args = ['altool', '--upload-package', ipa, ...authArgs, '--output-format', 'json', '--show-progress']
+  if (wait) args.push('--wait')
+  return args
+}
+
+/** Build the altool command that validates an IPA before upload. */
+export function createAltoolValidateArgs({ authArgs, ipa }) {
+  return ['altool', '--validate-app', ipa, ...authArgs, '--output-format', 'json']
+}
+
+/** Build the altool command that checks for an App Store Connect app record. */
+export function createAltoolListAppsArgs({ authArgs, bundleIdentifier }) {
+  return ['altool', '--list-apps', '--filter-bundle-id', bundleIdentifier, ...authArgs, '--output-format', 'json']
+}
+
+/** Return the standard App Store Connect API key lookup locations for altool. */
+export function appStoreConnectPrivateKeySearchPaths({ cwd, homeDir, keyId }) {
+  const fileName = `AuthKey_${keyId}.p8`
+  return [
+    join(cwd, 'private_keys', fileName),
+    join(homeDir, 'private_keys', fileName),
+    join(homeDir, '.private_keys', fileName),
+    join(homeDir, '.appstoreconnect', 'private_keys', fileName),
+  ]
+}
+
+/** Normalize API key secret content from either raw .p8 text or base64-wrapped text. */
+export function normalizeApiKeyContent(content) {
+  const trimmed = content.trim()
+  if (trimmed.includes('BEGIN PRIVATE KEY')) return `${trimmed}\n`
+
+  const decoded = Buffer.from(trimmed, 'base64').toString('utf8').trim()
+  if (decoded.includes('BEGIN PRIVATE KEY')) return `${decoded}\n`
+
+  return `${trimmed}\n`
+}
+
+/** Find the app Info.plist inside an IPA's unzip listing. */
+export function findIpaInfoPlistPath(listing) {
+  const matches = listing
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => /^Payload\/[^/]+\.app\/Info\.plist$/.test(line))
+  if (matches.length !== 1) {
+    throw new Error(`expected exactly one app Info.plist in IPA, found ${matches.length}`)
+  }
+  return matches[0]
+}
+
+/** Return true when an Info.plist raw value represents boolean false. */
+export function isFalsePlistValue(value) {
+  return ['false', 'no', '0'].includes(value.trim().toLowerCase())
+}
+
+function ensureMacos() {
+  if (process.platform !== 'darwin') fail('iOS release commands only run on macOS')
+}
+
+function ensureTool(command, args, installHint) {
+  const result = run(command, args)
+  if (result.status !== 0) fail(`${command} is not available. ${installHint}\n${result.output.trim()}`)
+}
+
+function ensureBuildNumber(buildNumber, { required }) {
+  if (!buildNumber) {
+    if (required) {
+      fail(
+        'missing build number. Pass --build-number=<number> or set BUILD_NUMBER/GITHUB_RUN_NUMBER.\n' +
+          '  TestFlight requires each upload for the same marketing version to have a new CFBundleVersion.',
+      )
+    }
+    return null
+  }
+  if (!/^[0-9]+$/.test(buildNumber)) fail(`invalid build number "${buildNumber}" — use digits only`)
+  return buildNumber
+}
+
+function resolveBuildNumber(buildNumberFlag, { required }) {
+  return ensureBuildNumber(buildNumberFlag ?? process.env.BUILD_NUMBER ?? process.env.GITHUB_RUN_NUMBER, { required })
+}
+
+function resolveExportMethod(exportMethod) {
+  if (!EXPORT_METHODS.has(exportMethod)) {
+    fail(`unknown export method "${exportMethod}" — one of: ${[...EXPORT_METHODS].join(', ')}`)
+  }
+  return exportMethod
+}
+
+function firstExistingPath(paths) {
+  return paths.find((path) => existsSync(path)) ?? null
+}
+
+function stageApiKeyContent({ keyId, rawContent }) {
+  const tempDir = mkdtempSync(join(tmpdir(), 'reflect-ios-api-key-'))
+  const keyPath = join(tempDir, `AuthKey_${keyId}.p8`)
+  writeFileSync(keyPath, normalizeApiKeyContent(rawContent), { mode: 0o600 })
+  return {
+    keyPath,
+    cleanup: () => rmSync(tempDir, { recursive: true, force: true }),
+  }
+}
+
+function resolveApiKeyCredentials({ requirePrivateKey }) {
+  const { APPLE_API_ISSUER, APPLE_API_KEY, APPLE_API_KEY_CONTENT, APPLE_API_KEY_PATH } = process.env
+  if (!APPLE_API_KEY || !APPLE_API_ISSUER) return null
+
+  let cleanup = null
+  let keyPath = APPLE_API_KEY_PATH ? resolve(APPLE_API_KEY_PATH) : null
+  if (APPLE_API_KEY_CONTENT) {
+    const staged = stageApiKeyContent({ keyId: APPLE_API_KEY, rawContent: APPLE_API_KEY_CONTENT })
+    cleanup = staged.cleanup
+    keyPath = staged.keyPath
+  } else if (!keyPath) {
+    keyPath = firstExistingPath(
+      appStoreConnectPrivateKeySearchPaths({ cwd: process.cwd(), homeDir: homedir(), keyId: APPLE_API_KEY }),
+    )
+  }
+
+  if (keyPath && !existsSync(keyPath)) {
+    cleanup?.()
+    fail(`APPLE_API_KEY_PATH points to ${keyPath}, but that file does not exist`)
+  }
+  if (requirePrivateKey && !keyPath) {
+    fail(
+      'APPLE_API_KEY/APPLE_API_ISSUER are set, but xcodebuild also needs the .p8 file.\n' +
+        '  Set APPLE_API_KEY_CONTENT, set APPLE_API_KEY_PATH, or place AuthKey_<KEY>.p8 in\n' +
+        '  ~/.appstoreconnect/private_keys.',
+    )
+  }
+
+  return {
+    altoolArgs: createApiKeyAltoolArgs({ issuerId: APPLE_API_ISSUER, keyId: APPLE_API_KEY, keyPath }),
+    cleanup,
+    source: keyPath
+      ? `App Store Connect API key ${APPLE_API_KEY} (${keyPath})`
+      : `App Store Connect API key ${APPLE_API_KEY} (altool standard key search path)`,
+    xcodeAuthenticationArgs: keyPath
+      ? createXcodeAuthenticationArgs({ issuerId: APPLE_API_ISSUER, keyId: APPLE_API_KEY, keyPath })
+      : [],
+  }
+}
+
+function resolveUploadCredentials() {
+  const apiKey = resolveApiKeyCredentials({ requirePrivateKey: false })
+  if (apiKey) return apiKey
+
+  const { APPLE_ID, APPLE_PASSWORD, APPLE_PROVIDER_PUBLIC_ID } = process.env
+  if (APPLE_ID && APPLE_PASSWORD) {
+    const args = ['--username', APPLE_ID, '--password', '@env:APPLE_PASSWORD']
+    if (APPLE_PROVIDER_PUBLIC_ID) args.push('--provider-public-id', APPLE_PROVIDER_PUBLIC_ID)
+    return {
+      altoolArgs: args,
+      cleanup: null,
+      env: {},
+      source: `Apple ID ${APPLE_ID} (APPLE_PASSWORD from environment)`,
+      xcodeAuthenticationArgs: [],
+    }
+  }
+
+  const stored = readKeychainCredentials()
+  if (stored) {
+    const args = ['--username', stored.account, '--password', '@env:APPLE_PASSWORD']
+    if (APPLE_PROVIDER_PUBLIC_ID) args.push('--provider-public-id', APPLE_PROVIDER_PUBLIC_ID)
+    return {
+      altoolArgs: args,
+      cleanup: null,
+      env: { APPLE_PASSWORD: stored.password },
+      source: `Apple ID ${stored.account} (keychain item "${KEYCHAIN_SERVICE}")`,
+      xcodeAuthenticationArgs: [],
+    }
+  }
+
+  fail(
+    'no App Store Connect upload credentials found.\n' +
+      '  Preferred: APPLE_API_KEY + APPLE_API_ISSUER + APPLE_API_KEY_CONTENT (or APPLE_API_KEY_PATH).\n' +
+      `  Fallback for upload-only: APPLE_ID + APPLE_PASSWORD, or keychain item "${KEYCHAIN_SERVICE}".`,
+  )
+}
+
+function readKeychainCredentials() {
+  const meta = run('security', ['find-generic-password', '-s', KEYCHAIN_SERVICE])
+  if (meta.status !== 0) return null
+  const account = meta.output.match(/"acct"<blob>="([^"]+)"/)?.[1]
+  const password = run('security', ['find-generic-password', '-s', KEYCHAIN_SERVICE, '-w'])
+  if (!account || password.status !== 0) return null
+  return { account, password: password.output.trim() }
+}
+
+function listFilesRecursive(root) {
+  if (!existsSync(root)) return []
+  const entries = []
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const path = join(root, entry.name)
+    if (entry.isDirectory()) entries.push(...listFilesRecursive(path))
+    else entries.push(path)
+  }
+  return entries
+}
+
+function newestIpa() {
+  const candidates = listFilesRecursive(iosBuildDir)
+    .filter((path) => path.endsWith('.ipa'))
+    .map((path) => ({ mtimeMs: statSync(path).mtimeMs, path }))
+    .sort((left, right) => right.mtimeMs - left.mtimeMs)
+  return candidates[0]?.path ?? null
+}
+
+function resolveInputPath(path) {
+  const direct = resolve(path)
+  if (existsSync(direct)) return direct
+  const repoRelative = resolve(repoRoot, path)
+  if (existsSync(repoRelative)) return repoRelative
+  return direct
+}
+
+function readIpaInfoPlistRawValue(ipa, key) {
+  const listing = capture('unzip', ['-Z1', ipa])
+  const infoPlistPath = findIpaInfoPlistPath(listing)
+  const tempDir = mkdtempSync(join(tmpdir(), 'reflect-ios-ipa-'))
+  const infoPlist = join(tempDir, 'Info.plist')
+  try {
+    const plist = execFileSync('unzip', ['-p', ipa, infoPlistPath])
+    writeFileSync(infoPlist, plist)
+    return capture('plutil', ['-extract', key, 'raw', '-o', '-', infoPlist]).trim()
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true })
+  }
+}
+
+function assertIpaBundleIdentifier(ipa) {
+  const bundleIdentifier = readIpaInfoPlistRawValue(ipa, 'CFBundleIdentifier')
+  if (bundleIdentifier !== IOS_BUNDLE_IDENTIFIER) {
+    const oldAppHint =
+      bundleIdentifier === OLD_CAPACITOR_BUNDLE_IDENTIFIER
+        ? ' This is the old Capacitor mobile app bundle id; refusing to upload over its TestFlight app.'
+        : ''
+    fail(
+      `IPA bundle identifier is ${bundleIdentifier}, expected ${IOS_BUNDLE_IDENTIFIER}.${oldAppHint}\n` +
+        '  Check apps/desktop/src-tauri/tauri.ios.conf.json and ios.project.yml before uploading.',
+    )
+  }
+  log(`IPA bundle identifier: ${bundleIdentifier}`)
+}
+
+function assertIpaExportCompliance(ipa) {
+  let value
+  try {
+    value = readIpaInfoPlistRawValue(ipa, NON_EXEMPT_ENCRYPTION_KEY)
+  } catch {
+    fail(
+      `IPA Info.plist is missing ${NON_EXEMPT_ENCRYPTION_KEY}.\n` +
+        '  Set it to false in apps/desktop/src-tauri/ios.project.yml before uploading so\n' +
+        '  App Store Connect can skip repeated export-compliance questions.',
+    )
+  }
+
+  if (!isFalsePlistValue(value)) {
+    fail(
+      `IPA Info.plist has ${NON_EXEMPT_ENCRYPTION_KEY}=${value}, expected false.\n` +
+        '  Reflect iOS currently uses only exempt encryption; update export-compliance\n' +
+        '  docs and App Store Connect answers before uploading if that changes.',
+    )
+  }
+  log(`${NON_EXEMPT_ENCRYPTION_KEY}: false`)
+}
+
+function assertIpaAppStoreMetadata(ipa) {
+  assertIpaBundleIdentifier(ipa)
+  assertIpaExportCompliance(ipa)
+}
+
+function ensureReleaseTools() {
+  ensureMacos()
+  ensureTool('xcodebuild', ['-version'], 'Install Xcode and select it with `xcode-select`.')
+  ensureTool('xcrun', ['--find', 'altool'], 'Install Xcode; altool is bundled with it.')
+}
+
+function runTauriIosBuild({ apiKeyCredentials, buildNumber, exportMethod, verbose }) {
+  ensureReleaseTools()
+  const args = createTauriIosBuildArgs({
+    buildNumber,
+    exportMethod,
+    verbose,
+    xcodeAuthenticationArgs: apiKeyCredentials?.xcodeAuthenticationArgs ?? [],
+  })
+  log(`building ${IOS_BUNDLE_IDENTIFIER} with export method ${exportMethod}${buildNumber ? `, build ${buildNumber}` : ''}…`)
+  if (apiKeyCredentials?.xcodeAuthenticationArgs.length) {
+    log(`xcodebuild provisioning auth: ${apiKeyCredentials.source}`)
+  } else {
+    log('xcodebuild provisioning auth: local Xcode account/profiles')
+  }
+  const result = spawnSync('pnpm', args, { cwd: appDir, stdio: 'inherit', env: process.env })
+  if (result.status !== 0) {
+    fail(
+      'tauri ios build failed.\n' +
+        '  If the Xcode export log says "No Accounts" or "No profiles", configure the\n' +
+        '  App Store Connect API key env vars or sign into Xcode with a team that can\n' +
+        `  provision ${IOS_BUNDLE_IDENTIFIER}.`,
+    )
+  }
+
+  const ipa = newestIpa()
+  if (!ipa) fail(`tauri build succeeded, but no .ipa was found under ${iosBuildDir}`)
+  assertIpaAppStoreMetadata(ipa)
+  log(`IPA: ${ipa} (${(statSync(ipa).size / (1024 * 1024)).toFixed(1)} MB)`)
+  return ipa
+}
+
+function uploadIpaWithCredentials({ credentials, ipa, wait }) {
+  assertIpaAppStoreMetadata(ipa)
+  try {
+    log(`uploading ${basename(ipa)} to App Store Connect as ${credentials.source}…`)
+    const args = createAltoolUploadArgs({ authArgs: credentials.altoolArgs, ipa, wait })
+    const result = spawnSync('xcrun', args, {
+      cwd: repoRoot,
+      stdio: 'inherit',
+      env: { ...process.env, ...credentials.env },
+    })
+    if (result.status !== 0) fail('altool upload failed')
+    log(wait ? 'upload accepted and processing completed' : 'upload submitted to App Store Connect/TestFlight')
+  } finally {
+    credentials.cleanup?.()
+  }
+}
+
+function uploadIpa({ ipa, wait }) {
+  ensureReleaseTools()
+  const credentials = resolveUploadCredentials()
+  uploadIpaWithCredentials({ credentials, ipa, wait })
+}
+
+function validateIpa({ ipa }) {
+  ensureReleaseTools()
+  assertIpaAppStoreMetadata(ipa)
+  const credentials = resolveUploadCredentials()
+  try {
+    log(`validating ${basename(ipa)} with App Store Connect…`)
+    const args = createAltoolValidateArgs({ authArgs: credentials.altoolArgs, ipa })
+    const result = spawnSync('xcrun', args, {
+      cwd: repoRoot,
+      stdio: 'inherit',
+      env: { ...process.env, ...credentials.env },
+    })
+    if (result.status !== 0) fail('altool validation failed')
+    log('validation passed')
+  } finally {
+    credentials.cleanup?.()
+  }
+}
+
+function parseAltoolJsonArray(output) {
+  const jsonStart = output.indexOf('[')
+  const jsonEnd = output.lastIndexOf(']')
+  if (jsonStart === -1 || jsonEnd === -1 || jsonEnd < jsonStart) {
+    fail(`altool response did not include a JSON array:\n${output.trim()}`)
+  }
+  const parsed = JSON.parse(output.slice(jsonStart, jsonEnd + 1))
+  if (!Array.isArray(parsed)) fail('altool response was not a JSON array')
+  return parsed
+}
+
+function verifyAppStoreConnectAppRecord(credentials) {
+  const args = createAltoolListAppsArgs({
+    authArgs: credentials.altoolArgs,
+    bundleIdentifier: IOS_BUNDLE_IDENTIFIER,
+  })
+  const result = spawnSync('xcrun', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: { ...process.env, ...credentials.env },
+  })
+  const output = `${result.stdout ?? ''}${result.stderr ?? ''}`
+  if (result.status !== 0) fail(`checking App Store Connect apps failed:\n${output.trim()}`)
+
+  const apps = parseAltoolJsonArray(output)
+  if (apps.length === 0) {
+    fail(
+      `no App Store Connect app record exists for ${IOS_BUNDLE_IDENTIFIER}.\n` +
+        `  Create a new App Store Connect app for ${IOS_BUNDLE_IDENTIFIER} before uploading.\n` +
+        `  Do not reuse the old Capacitor app (${OLD_CAPACITOR_BUNDLE_IDENTIFIER}).`,
+    )
+  }
+  if (apps.length > 1) fail(`expected one App Store Connect app for ${IOS_BUNDLE_IDENTIFIER}, found ${apps.length}`)
+
+  const [app] = apps
+  const appleId = app && typeof app === 'object' && 'id' in app ? String(app.id) : 'unknown'
+  const name = app && typeof app === 'object' && 'name' in app ? String(app.name) : 'unknown'
+  log(`App Store Connect app record: ${name} (${appleId})`)
+}
+
+function build({ buildNumberFlag, exportMethod, verbose }) {
+  const apiKeyCredentials = resolveApiKeyCredentials({ requirePrivateKey: false })
+  try {
+    return runTauriIosBuild({
+      apiKeyCredentials,
+      buildNumber: resolveBuildNumber(buildNumberFlag, { required: false }),
+      exportMethod,
+      verbose,
+    })
+  } finally {
+    apiKeyCredentials?.cleanup?.()
+  }
+}
+
+function testflight({ buildNumberFlag, exportMethod, wait, verbose }) {
+  const apiKeyCredentials = resolveApiKeyCredentials({ requirePrivateKey: false })
+  const uploadCredentials = resolveUploadCredentials()
+  try {
+    const ipa = runTauriIosBuild({
+      apiKeyCredentials,
+      buildNumber: resolveBuildNumber(buildNumberFlag, { required: true }),
+      exportMethod,
+      verbose,
+    })
+    uploadIpaWithCredentials({ credentials: uploadCredentials, ipa, wait })
+  } finally {
+    apiKeyCredentials?.cleanup?.()
+    if (uploadCredentials !== apiKeyCredentials) uploadCredentials.cleanup?.()
+  }
+}
+
+function preflight({ buildNumberFlag }) {
+  ensureReleaseTools()
+  resolveBuildNumber(buildNumberFlag, { required: true })
+  const apiKeyCredentials = resolveApiKeyCredentials({ requirePrivateKey: false })
+  const uploadCredentials = resolveUploadCredentials()
+  try {
+    log(`bundle identifier: ${IOS_BUNDLE_IDENTIFIER}`)
+    log(
+      `xcodebuild provisioning auth: ${
+        apiKeyCredentials?.source ?? 'local Xcode account/profiles (no App Store Connect API key configured)'
+      }`,
+    )
+    log(`altool upload auth: ${uploadCredentials.source}`)
+    log(`xcodebuild: ${capture('xcodebuild', ['-version']).trim().replace(/\n/g, ' / ')}`)
+    verifyAppStoreConnectAppRecord(uploadCredentials)
+    log('preflight passed')
+  } finally {
+    apiKeyCredentials?.cleanup?.()
+    if (uploadCredentials !== apiKeyCredentials) uploadCredentials.cleanup?.()
+  }
+}
+
+function flagValue(flags, name) {
+  return flags.find((flag) => flag.startsWith(`${name}=`))?.slice(name.length + 1) ?? null
+}
+
+const USAGE = `Usage: pnpm release:ios [command] [flags]
+
+Commands:
+  build       Build an App Store Connect IPA (default)
+  preflight   Check TestFlight credentials and local Xcode tooling
+  testflight  Build an IPA, then upload it to App Store Connect/TestFlight
+  upload      Upload an existing IPA
+  validate    Validate an existing IPA with App Store Connect
+
+Flags:
+  --build-number=<number>
+              CFBundleVersion build number. Required for preflight/testflight.
+              Defaults to BUILD_NUMBER or GITHUB_RUN_NUMBER when set.
+  --export-method=<name>
+              Tauri/Xcode export method: app-store-connect | release-testing |
+              debugging | validation (default: app-store-connect)
+  --ipa=<path> Existing IPA for upload/validate
+  --wait      Wait for App Store Connect processing (testflight/upload)
+  --verbose   Verbose Tauri build output
+  --help      Show this help
+
+Docs: docs/ios-testflight.md`
+
+async function main() {
+  const argv = process.argv.slice(2)
+  const flags = argv.filter((arg) => arg.startsWith('--'))
+  const commands = argv.filter((arg) => !arg.startsWith('--'))
+  const command = commands[0] ?? 'build'
+  const unknownFlag = flags.find(
+    (flag) =>
+      !['--help', '--wait', '--verbose'].includes(flag) &&
+      !flag.startsWith('--build-number=') &&
+      !flag.startsWith('--export-method=') &&
+      !flag.startsWith('--ipa='),
+  )
+  if (unknownFlag) fail(`unknown flag "${unknownFlag}"\n\n${USAGE}`)
+  if (flags.includes('--help')) {
+    console.log(USAGE)
+    return
+  }
+
+  const buildNumberFlag = flagValue(flags, '--build-number')
+  const exportMethod = resolveExportMethod(flagValue(flags, '--export-method') ?? DEFAULT_EXPORT_METHOD)
+  const ipaFlag = flagValue(flags, '--ipa')
+  const wait = flags.includes('--wait')
+  const verbose = flags.includes('--verbose')
+
+  switch (command) {
+    case 'build':
+      if (ipaFlag) fail('--ipa only applies to upload and validate')
+      if (wait) fail('--wait only applies to testflight and upload')
+      build({ buildNumberFlag, exportMethod, verbose })
+      return
+    case 'preflight':
+      if (ipaFlag) fail('--ipa does not apply to preflight')
+      if (wait) fail('--wait only applies to testflight and upload')
+      preflight({ buildNumberFlag })
+      return
+    case 'testflight':
+      if (ipaFlag) fail('--ipa only applies to upload and validate')
+      testflight({ buildNumberFlag, exportMethod, wait, verbose })
+      return
+    case 'upload': {
+      const ipa = ipaFlag ? resolveInputPath(ipaFlag) : newestIpa()
+      if (!ipa || !existsSync(ipa)) fail('--ipa is required, or build an IPA first')
+      uploadIpa({ ipa, wait })
+      return
+    }
+    case 'validate': {
+      if (wait) fail('--wait only applies to testflight and upload')
+      const ipa = ipaFlag ? resolveInputPath(ipaFlag) : newestIpa()
+      if (!ipa || !existsSync(ipa)) fail('--ipa is required, or build an IPA first')
+      validateIpa({ ipa })
+      return
+    }
+    default:
+      fail(`unknown command "${command}"\n\n${USAGE}`)
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main()
+}

--- a/apps/desktop/scripts/release-ios.test.mjs
+++ b/apps/desktop/scripts/release-ios.test.mjs
@@ -1,0 +1,165 @@
+import { join } from 'node:path'
+import { expect, test } from 'vitest'
+
+import {
+  appStoreConnectPrivateKeySearchPaths,
+  createAltoolListAppsArgs,
+  createAltoolUploadArgs,
+  createAltoolValidateArgs,
+  createApiKeyAltoolArgs,
+  createTauriIosBuildArgs,
+  createXcodeAuthenticationArgs,
+  findIpaInfoPlistPath,
+  isFalsePlistValue,
+  normalizeApiKeyContent,
+} from './release-ios.mjs'
+
+test('iOS release builds pass App Store Connect export and xcodebuild API key auth through Tauri', () => {
+  const xcodeAuthenticationArgs = createXcodeAuthenticationArgs({
+    issuerId: 'issuer-uuid',
+    keyId: 'ABC123DEFG',
+    keyPath: '/tmp/AuthKey_ABC123DEFG.p8',
+  })
+
+  expect(
+    createTauriIosBuildArgs({
+      buildNumber: '492',
+      exportMethod: 'app-store-connect',
+      xcodeAuthenticationArgs,
+    }),
+  ).toEqual([
+    'tauri',
+    'ios',
+    'build',
+    '--export-method',
+    'app-store-connect',
+    '--ci',
+    '--config',
+    JSON.stringify({ bundle: { iOS: { bundleVersion: '492' } } }),
+    '--',
+    '-authenticationKeyPath',
+    '/tmp/AuthKey_ABC123DEFG.p8',
+    '-authenticationKeyID',
+    'ABC123DEFG',
+    '-authenticationKeyIssuerID',
+    'issuer-uuid',
+  ])
+})
+
+test('iOS release builds can rely on local Xcode accounts when no API key is supplied', () => {
+  expect(createTauriIosBuildArgs({ exportMethod: 'release-testing' })).toEqual([
+    'tauri',
+    'ios',
+    'build',
+    '--export-method',
+    'release-testing',
+    '--ci',
+  ])
+})
+
+test('altool upload uses package upload with API key auth and optional processing wait', () => {
+  const authArgs = createApiKeyAltoolArgs({
+    issuerId: 'issuer-uuid',
+    keyId: 'ABC123DEFG',
+    keyPath: '/tmp/AuthKey_ABC123DEFG.p8',
+  })
+
+  expect(createAltoolUploadArgs({ authArgs, ipa: '/tmp/Reflect.ipa', wait: true })).toEqual([
+    'altool',
+    '--upload-package',
+    '/tmp/Reflect.ipa',
+    '--api-key',
+    'ABC123DEFG',
+    '--api-issuer',
+    'issuer-uuid',
+    '--p8-file-path',
+    '/tmp/AuthKey_ABC123DEFG.p8',
+    '--output-format',
+    'json',
+    '--show-progress',
+    '--wait',
+  ])
+})
+
+test('altool validation uses the same upload credentials', () => {
+  const authArgs = ['--username', 'release@example.com', '--password', '@env:APPLE_PASSWORD']
+
+  expect(createAltoolValidateArgs({ authArgs, ipa: '/tmp/Reflect.ipa' })).toEqual([
+    'altool',
+    '--validate-app',
+    '/tmp/Reflect.ipa',
+    '--username',
+    'release@example.com',
+    '--password',
+    '@env:APPLE_PASSWORD',
+    '--output-format',
+    'json',
+  ])
+})
+
+test('altool app lookup filters by bundle identifier', () => {
+  const authArgs = ['--api-key', 'ABC123DEFG', '--api-issuer', 'issuer-uuid']
+
+  expect(createAltoolListAppsArgs({ authArgs, bundleIdentifier: 'app.reflect.ios' })).toEqual([
+    'altool',
+    '--list-apps',
+    '--filter-bundle-id',
+    'app.reflect.ios',
+    '--api-key',
+    'ABC123DEFG',
+    '--api-issuer',
+    'issuer-uuid',
+    '--output-format',
+    'json',
+  ])
+})
+
+test('standard App Store Connect private key paths match altool lookup locations', () => {
+  expect(
+    appStoreConnectPrivateKeySearchPaths({
+      cwd: '/repo',
+      homeDir: '/Users/alex',
+      keyId: 'ABC123DEFG',
+    }),
+  ).toEqual([
+    join('/repo', 'private_keys', 'AuthKey_ABC123DEFG.p8'),
+    join('/Users/alex', 'private_keys', 'AuthKey_ABC123DEFG.p8'),
+    join('/Users/alex', '.private_keys', 'AuthKey_ABC123DEFG.p8'),
+    join('/Users/alex', '.appstoreconnect', 'private_keys', 'AuthKey_ABC123DEFG.p8'),
+  ])
+})
+
+test('API key content accepts raw p8 text and base64-wrapped p8 text', () => {
+  const raw = '-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----'
+  expect(normalizeApiKeyContent(raw)).toBe(`${raw}\n`)
+  expect(normalizeApiKeyContent(Buffer.from(raw).toString('base64'))).toBe(`${raw}\n`)
+})
+
+test('IPA Info.plist lookup targets the app payload plist', () => {
+  expect(
+    findIpaInfoPlistPath(
+      [
+        'Payload/',
+        'Payload/Reflect.app/',
+        'Payload/Reflect.app/Info.plist',
+        'Payload/Reflect.app/LaunchScreen.storyboardc/Info.plist',
+        'Symbols/Reflect.symbols',
+      ].join('\n'),
+    ),
+  ).toBe('Payload/Reflect.app/Info.plist')
+})
+
+test('IPA Info.plist lookup rejects ambiguous payloads', () => {
+  expect(() =>
+    findIpaInfoPlistPath(
+      ['Payload/Reflect.app/Info.plist', 'Payload/Other.app/Info.plist'].join('\n'),
+    ),
+  ).toThrow('expected exactly one app Info.plist')
+})
+
+test('Info.plist export-compliance false values are normalized', () => {
+  expect(isFalsePlistValue('false')).toBe(true)
+  expect(isFalsePlistValue('NO')).toBe(true)
+  expect(isFalsePlistValue('0')).toBe(true)
+  expect(isFalsePlistValue('true')).toBe(false)
+})

--- a/apps/desktop/src-tauri/gen/apple/project.yml
+++ b/apps/desktop/src-tauri/gen/apple/project.yml
@@ -50,6 +50,10 @@ targets:
         # user can see, copy, and back up their markdown (Plan 19).
         UIFileSharingEnabled: true
         LSSupportsOpeningDocumentsInPlace: true
+        # Reflect only uses exempt encryption (standard HTTPS/Git transport and
+        # OS keychain storage), so App Store Connect should not ask for export
+        # compliance answers on every TestFlight upload.
+        ITSAppUsesNonExemptEncryption: false
         # Apple Contacts integration: read-only CNContactStore lookups for
         # person notes; the string is shown on the iOS permission prompt.
         NSContactsUsageDescription: Reflect reads your contacts to suggest details for person notes. Nothing is stored or sent anywhere.

--- a/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/Info.plist
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/Info.plist
@@ -22,6 +22,8 @@
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
 	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>NSContactsUsageDescription</key>
 	<string>Reflect reads your contacts to suggest details for person notes. Nothing is stored or sent anywhere.</string>
 	<key>UIFileSharingEnabled</key>

--- a/apps/desktop/src-tauri/ios.project.yml
+++ b/apps/desktop/src-tauri/ios.project.yml
@@ -50,6 +50,10 @@ targets:
         # user can see, copy, and back up their markdown (Plan 19).
         UIFileSharingEnabled: true
         LSSupportsOpeningDocumentsInPlace: true
+        # Reflect only uses exempt encryption (standard HTTPS/Git transport and
+        # OS keychain storage), so App Store Connect should not ask for export
+        # compliance answers on every TestFlight upload.
+        ITSAppUsesNonExemptEncryption: false
         # Apple Contacts integration: read-only CNContactStore lookups for
         # person notes; the string is shown on the iOS permission prompt.
         NSContactsUsageDescription: Reflect reads your contacts to suggest details for person notes. Nothing is stored or sent anywhere.

--- a/docs/ios-testflight.md
+++ b/docs/ios-testflight.md
@@ -1,0 +1,148 @@
+# iOS TestFlight Builds
+
+How to build Reflect's Tauri iOS target and upload it to TestFlight.
+
+```bash
+pnpm release:ios preflight --build-number=123
+pnpm release:ios build --build-number=123
+pnpm release:ios testflight --build-number=123 --wait
+```
+
+The helper lives at `apps/desktop/scripts/release-ios.mjs` and is exposed as
+`pnpm release:ios` from the repo root. `pnpm release:testflight` is a shorthand
+for `pnpm release:ios testflight`.
+
+## What You Need
+
+1. **An App Store Connect app for `app.reflect.ios`.** The iOS template already
+   sets `PRODUCT_BUNDLE_IDENTIFIER` to `app.reflect.ios` and `DEVELOPMENT_TEAM`
+   to `789ULN5MZB`. This is intentionally separate from the old Capacitor mobile
+   app (`app.reflect.ReflectMobile`), so TestFlight uploads from this repo do not
+   replace the existing mobile app record. The release helper verifies the IPA
+   bundle identifier before upload.
+
+   The same iOS template sets `ITSAppUsesNonExemptEncryption` to `false`.
+   Reflect iOS currently uses only exempt encryption (standard HTTPS/Git
+   transport and OS keychain storage), so App Store Connect can skip the
+   repeated export-compliance questionnaire on later builds. If the mobile app
+   grows non-exempt cryptography, update the Info.plist value and the App Store
+   Connect encryption answers before uploading.
+
+2. **Signing access for `app.reflect.ios`.** For local builds, signing into Xcode
+   with a team account that can provision `app.reflect.ios` is enough for
+   `pnpm release:ios build`. For CI, use an App Store Connect API key with
+   permission to manage signing and upload builds. When the API key is present,
+   the release helper uses it for both xcodebuild provisioning and altool upload:
+
+   ```bash
+   export APPLE_API_KEY=ABC123DEFG
+   export APPLE_API_ISSUER=00000000-0000-0000-0000-000000000000
+   export APPLE_API_KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_ABC123DEFG.p8"
+   ```
+
+   In CI, use `APPLE_API_KEY_CONTENT` instead of a path; the script writes it to
+   a temporary file outside the workspace. `APPLE_API_KEY_CONTENT` may be the raw
+   `.p8` file contents or base64-wrapped text.
+
+3. **Upload credentials.** `pnpm release:ios testflight`, `upload`, and
+   `validate` call `xcrun altool`, which still needs explicit authentication
+   even when Xcode is signed in. Prefer the App Store Connect API key above.
+   Upload-only commands can also use:
+
+   ```bash
+   export APPLE_ID=release@example.com
+   export APPLE_PASSWORD=xxxx-xxxx-xxxx-xxxx
+   ```
+
+   `APPLE_PASSWORD` must be an app-specific password, not the Apple ID's normal
+   password. Locally, the helper also reuses the `reflect-notary` keychain item
+   created by `pnpm release:macos setup`, passing the stored password to altool
+   through `@env:APPLE_PASSWORD`.
+
+4. **A monotonically increasing build number.** TestFlight rejects duplicate
+   `CFBundleVersion` values for the same marketing version. Pass
+   `--build-number=<number>` locally; the helper injects it as
+   `bundle.iOS.bundleVersion` so beta versions still produce a clean numeric
+   build version. The GitHub Action defaults this to the workflow run number.
+
+5. **Xcode on macOS.** The workflow and local script use `xcodebuild`, Tauri's
+   iOS build command, and `xcrun altool`.
+
+## Commands
+
+```bash
+pnpm release:ios preflight --build-number=123
+```
+
+Checks Xcode/altool, the build number, signing auth, and upload auth before
+spending time on the native archive. It also verifies that App Store Connect has
+a separate app record for `app.reflect.ios`.
+
+```bash
+pnpm release:ios build --build-number=123
+```
+
+Runs `pnpm tauri ios build --export-method app-store-connect --ci`, using the
+signed-in Xcode account locally or passing the App Store Connect API key through
+to xcodebuild when the key is configured. The build number is merged into the
+Tauri config as `bundle.iOS.bundleVersion`. The IPA lands under
+`apps/desktop/src-tauri/gen/apple/build/`.
+
+```bash
+pnpm release:ios testflight --build-number=123 --wait
+```
+
+Builds the IPA, uploads it with `xcrun altool --upload-package`, and optionally
+waits for App Store Connect processing to finish.
+
+```bash
+pnpm release:ios upload --ipa=apps/desktop/src-tauri/gen/apple/build/arm64/Reflect.ipa --wait
+pnpm release:ios validate --ipa=apps/desktop/src-tauri/gen/apple/build/arm64/Reflect.ipa
+```
+
+Uploads or validates an existing IPA. These commands support `APPLE_ID` +
+`APPLE_PASSWORD` (app-specific password), or the local `reflect-notary`
+keychain item, as a fallback to the API key.
+
+Pass `--export-method=release-testing` if App Store Connect or Xcode starts
+requiring the TestFlight-specific export method. The default remains
+`app-store-connect`, matching Tauri's App Store Connect distribution docs and
+the upload flow.
+
+## GitHub Action
+
+Use **Actions -> TestFlight -> Run workflow**. The workflow builds on
+`macos-latest`, uploads the IPA to App Store Connect, and serializes runs so two
+uploads do not race each other.
+
+Configure these repository secrets:
+
+| Secret | Value |
+| --- | --- |
+| `APPLE_API_KEY` | App Store Connect API key ID |
+| `APPLE_API_ISSUER` | App Store Connect issuer UUID |
+| `APPLE_API_KEY_CONTENT` | Contents of `AuthKey_<KEY>.p8` |
+
+The workflow's build number defaults to `github.run_number`. Override the input
+only when retrying a run that already uploaded a build.
+
+## Troubleshooting
+
+- **`exportArchive No Accounts`** or **`No profiles for 'app.reflect.ios' were
+  found`**: xcodebuild could not provision the App Store build. Sign into Xcode
+  with a team account that can create an App Store provisioning profile for
+  `app.reflect.ios`, or set the App Store Connect API key env vars.
+- **`Cannot determine the Apple ID from Bundle ID 'app.reflect.ios'`**: the
+  bundle id exists for signing, but no App Store Connect app record exists yet.
+  Create a new iOS app in App Store Connect for `app.reflect.ios`; do not reuse
+  the old Capacitor app record (`app.reflect.ReflectMobile`).
+- **Duplicate build number**: rerun with a larger `--build-number`. TestFlight
+  build numbers are per marketing version; `0.4.0` build `123` can only be
+  uploaded once.
+- **Missing `.p8` file**: set `APPLE_API_KEY_CONTENT`, set `APPLE_API_KEY_PATH`,
+  or place `AuthKey_<KEY>.p8` in `~/.appstoreconnect/private_keys/`.
+- **Multiple providers**: if using the Apple ID fallback for upload-only
+  commands, set `APPLE_PROVIDER_PUBLIC_ID`.
+- **Export-compliance prompt appears again**: rebuild from an Xcode project that
+  includes `ITSAppUsesNonExemptEncryption=false` in the iOS Info.plist. The
+  release helper refuses to upload IPAs that are missing this key.

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -289,5 +289,5 @@ on the runner keychain setup.
 
 ## Current limitations
 
-- The iOS project template (`src-tauri/ios.project.yml`) still uses the pre-rename bundle
-  identifier and needs its own provisioning pass.
+- iOS/TestFlight distribution is handled separately by `pnpm release:ios`; see
+  [iOS TestFlight Builds](ios-testflight.md).

--- a/docs/plans/19-mobile.md
+++ b/docs/plans/19-mobile.md
@@ -266,11 +266,12 @@ later on the height events.
 
 ### 9. App identity & store
 
-The bundle identifier and `ios.project.yml` predate this plan
-(`com.alex.reflect-open` prefix, placeholder product name) — step 3 normalizes
-them to the product identity (`app.reflect.*`, product name "Reflect") before
-anything ships to TestFlight. Versioning tracks the desktop `version` in
-`tauri.conf.json`. Store metadata, privacy nutrition labels
+The iOS template now carries the product identity (`app.reflect.ios`, product
+name "Reflect", team `789ULN5MZB`) and `tauri.ios.conf.json` keeps the mobile
+bundle identifier separate from the desktop app. Versioning tracks the desktop
+`version` in `tauri.conf.json`; TestFlight builds use `pnpm release:ios` to add
+the per-upload build number and pass App Store Connect API key authentication
+through to xcodebuild/altool. Store metadata, privacy nutrition labels
 (`PrivacyInfo.xcprivacy` is required for fs access), and a review-account
 story (a demo graph — the app is fully usable with no account; reviewers must
 see that) land with the submission step.
@@ -371,9 +372,8 @@ Steps 1 and 2 are the existential gates; nothing else starts until both pass.
     protected with "Needs review on desktop", status pill live.
 11. **Harden + ship.** Memory pass on a large graph (webview process limits;
     editing a very large note), resume-after-process-death recovery check,
-    a11y labels, TestFlight build (`tauri ios build --export-method
-    app-store-connect`, App Store Connect API key in CI mirroring the macOS
-    release workflow), then App Store submission with the review story.
+    a11y labels, TestFlight build (`pnpm release:ios testflight`; see
+    `docs/ios-testflight.md`), then App Store submission with the review story.
 12. **Android (fast follow, same shape).** `tauri android init`, Kotlin half
     of the keyboard plugin, keystore signing, the same frontend gate already
     matching `'android'`, Play submission. No new product surface.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "check": "pnpm typecheck && pnpm lint",
     "tauri": "pnpm --filter @reflect/desktop tauri",
     "release:bump": "pnpm --filter @reflect/desktop release:bump",
+    "release:ios": "pnpm --filter @reflect/desktop release:ios",
     "release:macos": "pnpm --filter @reflect/desktop release:macos",
+    "release:testflight": "pnpm --filter @reflect/desktop release:ios testflight",
     "tauri:dev": "pnpm --filter @reflect/desktop tauri:dev",
     "tauri:build:dev": "pnpm --filter @reflect/desktop tauri:build:dev",
     "tauri:build:beta": "pnpm --filter @reflect/desktop tauri:build:beta"


### PR DESCRIPTION
## Problem

Reflect's Tauri iOS target could be built locally, but there was no repeatable release path for TestFlight. Uploads were easy to point at the wrong App Store Connect record, build numbers could drift into invalid `CFBundleVersion` values, and App Store Connect export-compliance prompts had to be answered manually after each upload.

This PR keeps the new Tauri iOS app separate from the old Capacitor app by pinning and checking `app.reflect.ios`; it does not change the already-shipped old TestFlight app (`app.reflect.ReflectMobile`). It also gives future contributors and agents top-level pointers for the simulator and TestFlight workflows.

## Before -> After

| Before | After |
| --- | --- |
| Manual `tauri ios build` / `altool` commands | `pnpm release:ios` wraps preflight, build, validation, and upload |
| App Store Connect record mismatch failed late | Preflight verifies `app.reflect.ios` exists before archiving |
| IPA identity relied on manual inspection | Upload/validate refuse IPAs whose bundle ID is not `app.reflect.ios` |
| Export-compliance questions repeated in App Store Connect | iOS Info.plist includes `ITSAppUsesNonExemptEncryption=false`, and the helper enforces it |
| No CI entrypoint for TestFlight | Manual GitHub Action builds and uploads with App Store Connect API key secrets |
| Simulator/TestFlight docs lived only in focused runbooks | `README.md` and `AGENTS.md` now point humans and agents to the right commands and docs |

## Changes

1. Add `apps/desktop/scripts/release-ios.mjs` with `preflight`, `build`, `validate`, `upload`, and `testflight` commands.
2. Add root and desktop package scripts for `pnpm release:ios` and `pnpm release:testflight`.
3. Add IPA metadata checks for the new bundle ID and export-compliance plist key before validation/upload.
4. Add `.github/workflows/testflight.yml` for manual TestFlight uploads using `APPLE_API_KEY`, `APPLE_API_ISSUER`, and `APPLE_API_KEY_CONTENT`.
5. Add `docs/ios-testflight.md` and update the macOS/mobile docs to point at the new iOS release path.
6. Add `ITSAppUsesNonExemptEncryption=false` to the iOS XcodeGen template and generated project files.
7. Add README and AGENTS guidance for `pnpm tauri ios dev "iPhone 17 Pro"`, `pnpm release:ios`, and the simulator/TestFlight runbooks.

## Tests

- `apps/desktop/scripts/release-ios.test.mjs` covers command construction, App Store Connect key handling, IPA plist lookup, and export-compliance false-value normalization.

## Verification

- `pnpm --filter @reflect/desktop exec vitest run scripts/release-ios.test.mjs` passed.
- `pnpm check` passed. Existing lint warnings remain for max-lines / React compiler diagnostics in unrelated files.
- `pnpm release:ios preflight --build-number=17` passed against App Store Connect app `Reflect Open (6787385615)`.
- `pnpm release:ios validate --ipa=apps/desktop/src-tauri/gen/apple/build/arm64/Reflect.ipa` passed.
- `pnpm release:ios upload --ipa=apps/desktop/src-tauri/gen/apple/build/arm64/Reflect.ipa --wait` uploaded `0.4.0` build `17`; Apple reported `BETA_INTERNAL_TESTING`.
- `pnpm release:ios build --build-number=18` produced a fresh local IPA with `CFBundleIdentifier=app.reflect.ios`, `CFBundleVersion=18`, and `ITSAppUsesNonExemptEncryption=false`. Build `18` was not uploaded.
- After adding README/AGENTS docs, `pnpm check` passed again with the same unrelated warnings.

## Risk / Rollout

This adds release automation, docs, and a manual CI workflow; normal app runtime code is not changed. CI uploads require the App Store Connect API key secrets documented in `docs/ios-testflight.md`. If Reflect iOS later adds non-exempt cryptography, the Info.plist value and App Store Connect export-compliance answers must be revisited before upload.
