### PR TITLE
chore: disable renovate updates for `fastembed` and `ort`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,13 @@
   "extends": ["github>ocavue/config-renovate"],
   "packageRules": [
     {
+      "description": "fastembed 5.14+ pins ONNX Runtime API 24, but upstream ONNX Runtime 1.24 no longer ships macOS x86_64 binaries. Keep fastembed and ort pinned until upstream binary support returns or we replace the backend.",
+      "matchManagers": ["cargo"],
+      "matchDatasources": ["crate"],
+      "matchPackageNames": ["fastembed", "ort"],
+      "enabled": false
+    },
+    {
       "matchPackageNames": ["@meowdown/*"],
       "groupName": "meowdown",
       "groupSlug": "meowdown",


### PR DESCRIPTION
## Summary

- Add a Renovate package rule that disables Cargo updates for `fastembed` and `ort`.
- Document the reason in the rule description: `fastembed` 5.14+ moves to ONNX Runtime API 24, while upstream ONNX Runtime 1.24 does not ship macOS x86_64 binaries.

## Impact

This keeps Renovate from opening dependency updates that would break the current Intel macOS embedding runtime setup until upstream binary support returns or the backend changes.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('renovate.json','utf8')); console.log('renovate.json is valid JSON')"`
- `pnpm check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted update automation to skip certain Cargo package upgrades for `fastembed` and `ort`.
  * This helps avoid problematic dependency updates related to runtime compatibility and missing macOS Intel release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->