### PR TITLE
Fix non-max-lines check warnings

### DIFF
--- a/apps/desktop/src/components/all-notes/all-notes-table.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-table.tsx
@@ -40,16 +40,17 @@ export function AllNotesTable({
   registerScrollToIndex,
 }: AllNotesTableProps): ReactElement | null {
   const rows = notes ?? []
+  const { clickSelect, isSelected } = selection
   const virtualizerRef = useRef<VirtualizerHandle>(null)
   const handleToggle = useCallback(
     (path: string, event: Pick<MouseEvent, 'shiftKey'>) =>
-      selection.clickSelect(
+      clickSelect(
         path,
         event.shiftKey
           ? { metaKey: false, ctrlKey: false, shiftKey: true }
           : { metaKey: true, ctrlKey: false, shiftKey: false },
       ),
-    [selection.clickSelect],
+    [clickSelect],
   )
 
   useEffect(() => {
@@ -93,8 +94,8 @@ export function AllNotesTable({
             <AllNotesRow
               key={note.path}
               note={note}
-              selected={selection.isSelected(note.path)}
-              onSelect={selection.clickSelect}
+              selected={isSelected(note.path)}
+              onSelect={clickSelect}
               onToggle={handleToggle}
               onOpen={onOpen}
             />

--- a/apps/desktop/src/components/settings/add-ai-provider-dialog.tsx
+++ b/apps/desktop/src/components/settings/add-ai-provider-dialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactElement } from 'react'
-import { useForm } from 'react-hook-form'
+import { useForm, useWatch } from 'react-hook-form'
 import {
   AI_PROVIDERS,
   aiProvider,
@@ -55,7 +55,7 @@ const FIELD_LABEL_CLASS = 'text-xs font-medium text-text-secondary'
  * dialog open with the typed key intact so the user can retry.
  */
 export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps): ReactElement {
-  const { register, handleSubmit, watch, setValue, formState } = useForm<AddAiProviderForm>({
+  const { register, control, handleSubmit, setValue, formState } = useForm<AddAiProviderForm>({
     defaultValues: {
       provider: AI_PROVIDERS[0].id,
       model: AI_PROVIDERS[0].models[0].id,
@@ -82,7 +82,9 @@ export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps
     }
   }, [])
 
-  const provider = aiProvider(watch('provider'))
+  const providerId = useWatch({ control, name: 'provider' })
+  const selectedModel = useWatch({ control, name: 'model' })
+  const provider = aiProvider(providerId)
 
   const submit = handleSubmit(async (values) => {
     setSubmitError(null)
@@ -153,7 +155,7 @@ export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps
           <div className="flex flex-col gap-1">
             <span className={FIELD_LABEL_CLASS}>Default model</span>
             <ModelCombobox
-              value={watch('model')}
+              value={selectedModel}
               provider={provider.id}
               models={provider.models}
               onChange={(modelId) => setValue('model', modelId)}

--- a/apps/desktop/src/components/settings/ai-prompt-dialog.tsx
+++ b/apps/desktop/src/components/settings/ai-prompt-dialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, type ReactElement } from 'react'
-import { useForm } from 'react-hook-form'
+import { useForm, useWatch } from 'react-hook-form'
 import type { AiPrompt, AiPromptMode } from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import {
@@ -37,13 +37,14 @@ const FIELD_LABEL_CLASS = 'text-xs font-medium text-text-secondary'
  * or is inserted below it.
  */
 export function AiPromptDialog({ prompt, onSave, onClose }: AiPromptDialogProps): ReactElement {
-  const { register, handleSubmit, watch, setValue, formState } = useForm<AiPromptDraft>({
+  const { register, control, handleSubmit, setValue, formState } = useForm<AiPromptDraft>({
     defaultValues: {
       label: prompt?.label ?? '',
       body: prompt?.body ?? '',
       mode: prompt?.mode ?? 'replace',
     },
   })
+  const mode = useWatch({ control, name: 'mode' })
 
   // The dialog is conditionally mounted by its parent, so Radix's close-focus
   // path is bypassed when Cancel or a successful submit calls onClose()
@@ -105,7 +106,7 @@ export function AiPromptDialog({ prompt, onSave, onClose }: AiPromptDialogProps)
           <label className="flex flex-col gap-1.5">
             <span className={FIELD_LABEL_CLASS}>Result</span>
             <Select
-              value={watch('mode')}
+              value={mode}
               onValueChange={(value) => setValue('mode', value as AiPromptMode)}
             >
               <SelectTrigger>

--- a/packages/core/src/indexing/live.test.ts
+++ b/packages/core/src/indexing/live.test.ts
@@ -282,8 +282,13 @@ describe('applyIndexChanges move healing (Plan 17)', () => {
     const move = calls.find(([command]) => command === 'index_move')
     expect(move?.[1]).toEqual({ from: OLD, to: NEW, generation: 7 })
     const apply = calls.find(([command]) => command === 'index_apply')
-    expect((apply?.[1]['note'] as { path: string; mtime: number }).path).toBe(NEW)
-    expect((apply?.[1]['note'] as { path: string; mtime: number }).mtime).toBe(42)
+    expect(apply).toBeDefined()
+    if (apply === undefined) {
+      throw new Error('Expected rename heal to apply the renamed note')
+    }
+    const note = apply[1]['note'] as { path: string; mtime: number }
+    expect(note.path).toBe(NEW)
+    expect(note.mtime).toBe(42)
   })
 
   it('announces the heal via onMoved so the app can follow', async () => {


### PR DESCRIPTION
## Problem

`pnpm check` was passing, but it still reported actionable warnings beyond the accepted `eslint(max-lines)` file-length warnings:

- unsafe optional chaining in the live indexing rename-heal test
- a missing React hook dependency in the All Notes table
- React Compiler warnings from reading React Hook Form values with `watch()` during render

This PR clears those warnings while intentionally leaving the existing max-lines warnings untouched.

## Before -> After

| Area | Before | After |
| --- | --- | --- |
| Live indexing test | Read through an optional chained `index_apply` call payload | Proves the call exists before reading its note payload |
| All Notes table | Callback closed over `selection` while only depending on `selection.clickSelect` | Destructures the selection helpers and depends on the callback directly |
| AI settings dialogs | Rendered selected form values with `watch()` | Uses `useWatch()` for render-time provider, model, and mode values |

## Changes

1. Update `packages/core/src/indexing/live.test.ts` to make the `index_apply` assertion explicit before reading the renamed note payload.
2. Update `AllNotesTable` to destructure `clickSelect` and `isSelected`, clearing the hook dependency warning without changing selection behavior.
3. Update the AI provider and prompt dialogs to use React Hook Form's `useWatch()` for values consumed by rendered controls.

## Verification

- `pnpn check` fails locally because `pnpn` is not installed (`zsh: command not found: pnpn`).
- `pnpm check` passes; the remaining warnings are only `eslint(max-lines)` warnings.
- `pnpm --filter @reflect/core test -- src/indexing/live.test.ts` passes; Vitest ran the core suite (82 files, 1031 tests).

## Risk / Rollout

Low risk. The changes are lint/test assertion cleanup only and do not alter data formats, migrations, external services, or runtime feature behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-safe refactors and a stricter test assertion only; no changes to indexing logic, selection behavior, or form submit paths.
> 
> **Overview**
> Clears **non–max-lines** warnings from `pnpm check` without changing runtime behavior.
> 
> **All Notes table** destructures `clickSelect` and `isSelected` from `selection` so the toggle callback’s dependency array matches what it uses, fixing the exhaustive-deps warning.
> 
> **Add AI provider** and **AI prompt** dialogs stop calling `watch()` during render (which triggered React Compiler warnings) and instead subscribe with `useWatch({ control, name: … })` for provider, model, and mode values bound to the UI.
> 
> **Live indexing rename-heal test** asserts `index_apply` is present before reading its payload, replacing optional chaining on a possibly missing call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bb81ef84bf8a9fa2f8a8cdd39d5032d697a30c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->