### PR TITLE
Close capture popup immediately after save

### DIFF
--- a/apps/extension/entrypoints/popup/app.tsx
+++ b/apps/extension/entrypoints/popup/app.tsx
@@ -12,20 +12,18 @@ import { useCapturedPage } from './use-captured-page'
 
 /**
  * The capture popup: a snapshot of the page, an optional note, one Save.
- * Status is honest — the extension can only ever claim **queued** (spooled
- * for Reflect, or held for retry), never "saved": it cannot observe the
- * desktop app draining the inbox.
+ * On success it closes as soon as the native host has accepted the capture.
+ * Hold and failure states stay visible because they require the user's
+ * attention.
  */
 
 type SaveState =
   | { phase: 'idle' }
   | { phase: 'saving' }
-  | { phase: 'queued' }
   | { phase: 'held'; result: FlushResult }
   | { phase: 'failed'; message: string }
 
 const RELEASES_URL = 'https://github.com/team-reflect/reflect-open/releases/latest'
-const CLOSE_DELAY_MS = 900
 
 function holdMessage(result: FlushResult): string {
   switch (result.holdReason) {
@@ -74,21 +72,12 @@ export function CapturePopup(): ReactElement {
     }
   }, [])
 
-  useEffect(() => {
-    if (save.phase !== 'queued') {
-      return
-    }
-    const timer = window.setTimeout(() => window.close(), CLOSE_DELAY_MS)
-    return () => window.clearTimeout(timer)
-  }, [save.phase])
-
   async function onSubmit(event: FormEvent): Promise<void> {
     event.preventDefault()
     if (
       captured.status !== 'ready' ||
       !includePageTextPreferenceLoaded ||
-      save.phase === 'saving' ||
-      save.phase === 'queued'
+      save.phase === 'saving'
     ) {
       return
     }
@@ -108,7 +97,7 @@ export function CapturePopup(): ReactElement {
         () => browser.runtime.sendMessage({ type: 'flush' }),
       )
       if (outcome.fate === 'queued') {
-        setSave({ phase: 'queued' })
+        window.close()
       } else if (outcome.fate === 'held') {
         setSave({ phase: 'held', result: outcome.result })
         setHeldCount(outcome.result.held)
@@ -129,8 +118,7 @@ export function CapturePopup(): ReactElement {
 
   const { page } = captured
   const host = new URL(page.url).host
-  const busy =
-    save.phase === 'saving' || save.phase === 'queued' || !includePageTextPreferenceLoaded
+  const busy = save.phase === 'saving' || !includePageTextPreferenceLoaded
 
   function onIncludePageTextChange(checked: boolean): void {
     includePageTextTouched.current = true
@@ -183,7 +171,7 @@ export function CapturePopup(): ReactElement {
         disabled={busy}
         className="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-text-on-brand hover:bg-accent-hover disabled:opacity-60"
       >
-        {save.phase === 'queued' ? 'Queued' : save.phase === 'saving' ? 'Saving…' : 'Save to Reflect'}
+        {save.phase === 'saving' ? 'Saving…' : 'Save to Reflect'}
       </button>
       {save.phase === 'held' ? (
         <p className="text-xs text-text-muted">


### PR DESCRIPTION
## Problem

The Chrome extension popup showed a `Queued` success state for 900ms after Reflect accepted a capture. That confirmation was technically accurate, but it made the `Save to Reflect` flow feel slower than the underlying capture path.

## Before -> After

| Before | After |
| --- | --- |
| Successful captures set the popup to `Queued`, disable controls, then close after 900ms. | Successful captures close the popup immediately after the native host accepts the capture. |
| Held and rejected captures still surface inline feedback. | Held and rejected captures still surface inline feedback. |

## Changes

1. Removed the popup `queued` UI state and delayed close timer from `CapturePopup`.
2. Call `window.close()` directly when `saveCapture` reports that the current capture was accepted by the host.
3. Kept `held` and `failed` states visible so install/no-graph/IO/rejection cases continue to explain what happened.

## Verification

- `pnpm --filter @reflect/extension test -- lib/save-capture.test.ts lib/flush.test.ts` passed.
- `pnpm --filter @reflect/extension typecheck` passed.
- `pnpm check` passed; it reported existing warnings in unrelated files.

## Risk / Rollout

Low risk. This only changes the popup success affordance after the existing durable queue and host acknowledgement path completes; retry and failure behavior are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Popup-only success affordance; queue, flush, and retry behavior are unchanged.
> 
> **Overview**
> Successful saves no longer show a **Queued** state or wait **900ms** before closing. When `saveCapture` returns `fate: 'queued'` (native host accepted the capture), the popup calls **`window.close()`** right away.
> 
> The **`queued`** save phase, delayed-close `useEffect`, and **Queued** button label are removed. **`held`** and **`failed`** flows are unchanged so install/no-graph/rejection messaging still stays on screen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6a7614561a51fb647476b8743410d4895782275. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->