### PR TITLE
Fix pinned note hover state

### DIFF
--- a/apps/desktop/src/components/sidebar/sidebar-pinned-row-preview.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar-pinned-row-preview.tsx
@@ -20,7 +20,7 @@ export function SidebarPinnedRowPreview({
       ? 'bg-white text-text-secondary'
     : active
       ? 'bg-surface-hover text-text-secondary dark:bg-transparent'
-    : 'text-text-secondary'
+    : 'text-text-secondary hover:bg-surface-hover hover:text-text'
 
   return (
     <span

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -256,6 +256,9 @@ describe('Sidebar', () => {
 
     const roadmap = await view.findByRole('button', { name: 'Roadmap' })
     expect(pinnedSection.contains(roadmap)).toBe(true)
+    const roadmapPreview = roadmap.firstElementChild
+    expect(roadmapPreview?.getAttribute('class')).toContain('hover:bg-surface-hover')
+    expect(roadmapPreview?.getAttribute('class')).toContain('hover:text-text')
     await userEvent.click(roadmap)
     await waitFor(() => expect(roadmap.getAttribute('aria-current')).toBe('page'))
   })


### PR DESCRIPTION
## Problem
Pinned note rows in the sidebar did not provide visual feedback on hover, unlike the neighboring primary nav rows and All Notes rows. That made the pinned shelf feel inactive when mousing over items.

## Changes
1. Add the inactive pinned-row hover wash and text lift in `SidebarPinnedRowPreview`.
2. Extend the sidebar pinned-section test to assert the row preview carries the hover classes.

## Verification
- `pnpm --filter @reflect/desktop test -- src/components/sidebar/sidebar.test.tsx` passed. Vitest ran 158 test files / 1400 tests.
- `pnpm check` passed. Lint reported existing max-lines warnings only.

## Risk / Rollout
Low risk: this is a Tailwind class change for inactive pinned rows only. Drag placeholders, drag overlays, active rows, data, and IPC behavior are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tailwind-only UI tweak for inactive pinned rows; no navigation, pinning, or IPC changes.
> 
> **Overview**
> Inactive pinned note rows in the sidebar now show the same hover background and text emphasis as primary nav rows (`hover:bg-surface-hover`, `hover:text-text` on `SidebarPinnedRowPreview`).
> 
> The pinned-notes sidebar test asserts those classes on the row preview element. Placeholder, overlay, and active pinned states are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89ff65f8e8c56cf89610c313a41f06304519bd15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->