### PR TITLE
feat: webview-drawn mobile formatting toolbar

### DIFF
--- a/apps/desktop/src/editor/formatting-toolbar-bridge.test.tsx
+++ b/apps/desktop/src/editor/formatting-toolbar-bridge.test.tsx
@@ -1,0 +1,194 @@
+import { act, cleanup, render, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setPlatformSurface } from '@/lib/platform-surface'
+import { FormattingToolbarBridge } from './formatting-toolbar-bridge'
+import { useFormattingToolbar } from './formatting-toolbar-store'
+
+/**
+ * The bridge publishes a focused editor's command surface and `canExec`
+ * capabilities to the formatting-toolbar store, and keeps them fresh across
+ * caret moves and its own commands. The ProseKit editor is faked: `canExec`
+ * results are the fixture knobs, and command dispatch is observed directly.
+ */
+
+interface FakeCommand {
+  (...args: unknown[]): void
+  canExec: ReturnType<typeof vi.fn>
+}
+
+function makeCommand(): FakeCommand {
+  return Object.assign(vi.fn(), { canExec: vi.fn(() => true) })
+}
+
+function makeFakeEditor() {
+  const dom = document.createElement('div')
+  document.body.appendChild(dom)
+  const insertedText = Object.assign(vi.fn(), { scrollIntoView: vi.fn() })
+  const transaction = {
+    insertText: vi.fn(() => {
+      return { scrollIntoView: () => 'dispatched-transaction' }
+    }),
+  }
+  return {
+    mounted: true,
+    focused: false,
+    blur: vi.fn(),
+    insertedText,
+    view: {
+      dom,
+      dispatch: vi.fn(),
+      state: {
+        get tr() {
+          return transaction
+        },
+      },
+    },
+    commands: {
+      toggleList: makeCommand(),
+      indentList: makeCommand(),
+      dedentList: makeCommand(),
+      moveList: makeCommand(),
+    },
+    transaction,
+  }
+}
+
+const fake = vi.hoisted(() => ({ editor: null as unknown }))
+
+vi.mock('@meowdown/react', () => ({
+  useEditor: () => fake.editor,
+}))
+
+let editor: ReturnType<typeof makeFakeEditor>
+
+beforeEach(() => {
+  setPlatformSurface({ touchEditor: true })
+  editor = makeFakeEditor()
+  fake.editor = editor
+})
+
+afterEach(() => {
+  cleanup()
+  editor.view.dom.remove()
+  setPlatformSurface({ touchEditor: false })
+  vi.clearAllMocks()
+})
+
+function focusIn(): void {
+  act(() => {
+    editor.focused = true
+    editor.view.dom.dispatchEvent(new Event('focusin', { bubbles: true }))
+  })
+}
+
+describe('FormattingToolbarBridge', () => {
+  it('publishes commands and capabilities when the editor gains focus', () => {
+    const store = renderHook(() => useFormattingToolbar())
+    render(<FormattingToolbarBridge />)
+    expect(store.result.current).toBeNull()
+
+    editor.commands.dedentList.canExec.mockReturnValue(false)
+    focusIn()
+
+    const toolbar = store.result.current
+    expect(toolbar).not.toBeNull()
+    expect(toolbar?.capabilities).toEqual({
+      canIndent: true,
+      canDedent: false,
+      canMoveUp: true,
+      canMoveDown: true,
+    })
+    expect(editor.commands.moveList.canExec).toHaveBeenCalledWith('up')
+    expect(editor.commands.moveList.canExec).toHaveBeenCalledWith('down')
+  })
+
+  it('does nothing off the touch surface', () => {
+    setPlatformSurface({ touchEditor: false })
+    const store = renderHook(() => useFormattingToolbar())
+    render(<FormattingToolbarBridge />)
+    focusIn()
+    expect(store.result.current).toBeNull()
+  })
+
+  it('publishes immediately when the editor is already focused on mount (autoFocus arrivals)', () => {
+    editor.focused = true
+    const store = renderHook(() => useFormattingToolbar())
+    render(<FormattingToolbarBridge />)
+    expect(store.result.current).not.toBeNull()
+  })
+
+  it('recomputes capabilities on selectionchange while focused, and only then', () => {
+    const store = renderHook(() => useFormattingToolbar())
+    render(<FormattingToolbarBridge />)
+    focusIn()
+    const before = store.result.current
+
+    editor.commands.indentList.canExec.mockReturnValue(false)
+    act(() => document.dispatchEvent(new Event('selectionchange')))
+    expect(store.result.current).not.toBe(before)
+    expect(store.result.current?.capabilities.canIndent).toBe(false)
+
+    // Blurred editors ignore selection churn elsewhere in the page.
+    act(() => {
+      editor.focused = false
+      editor.view.dom.dispatchEvent(new Event('focusout', { bubbles: true }))
+    })
+    expect(store.result.current).toBeNull()
+    act(() => document.dispatchEvent(new Event('selectionchange')))
+    expect(store.result.current).toBeNull()
+  })
+
+  it('runs editor commands and refreshes capabilities after each', () => {
+    const store = renderHook(() => useFormattingToolbar())
+    render(<FormattingToolbarBridge />)
+    focusIn()
+    const commands = store.result.current!.commands
+
+    commands.toggleBulletList()
+    expect(editor.commands.toggleList).toHaveBeenCalledWith({ kind: 'bullet' })
+    commands.toggleTaskList()
+    expect(editor.commands.toggleList).toHaveBeenCalledWith({ kind: 'task' })
+    commands.indent()
+    expect(editor.commands.indentList).toHaveBeenCalledWith()
+    commands.dedent()
+    expect(editor.commands.dedentList).toHaveBeenCalledWith()
+    commands.moveUp()
+    expect(editor.commands.moveList).toHaveBeenCalledWith('up')
+
+    // A structural command can change enablement without moving the DOM
+    // selection, so the run itself must republish.
+    editor.commands.dedentList.canExec.mockReturnValue(false)
+    act(() => commands.moveDown())
+    expect(editor.commands.moveList).toHaveBeenCalledWith('down')
+    expect(store.result.current?.capabilities.canDedent).toBe(false)
+  })
+
+  it('types autocomplete triggers through a dispatched transaction', () => {
+    const store = renderHook(() => useFormattingToolbar())
+    render(<FormattingToolbarBridge />)
+    focusIn()
+
+    store.result.current!.commands.insertTrigger('[[')
+    expect(editor.transaction.insertText).toHaveBeenCalledWith('[[')
+    expect(editor.view.dispatch).toHaveBeenCalledWith('dispatched-transaction')
+  })
+
+  it('dismisses the keyboard by blurring the editor', () => {
+    const store = renderHook(() => useFormattingToolbar())
+    render(<FormattingToolbarBridge />)
+    focusIn()
+
+    store.result.current!.commands.dismissKeyboard()
+    expect(editor.blur).toHaveBeenCalled()
+  })
+
+  it('clears its published toolbar on unmount', () => {
+    const store = renderHook(() => useFormattingToolbar())
+    const view = render(<FormattingToolbarBridge />)
+    focusIn()
+    expect(store.result.current).not.toBeNull()
+
+    view.unmount()
+    expect(store.result.current).toBeNull()
+  })
+})

--- a/apps/desktop/src/editor/formatting-toolbar-bridge.tsx
+++ b/apps/desktop/src/editor/formatting-toolbar-bridge.tsx
@@ -1,0 +1,121 @@
+import { useEffect } from 'react'
+import { useEditor } from '@meowdown/react'
+import type { EditorExtension } from '@meowdown/core'
+import { isTouchEditorSurface } from '@/lib/platform-surface'
+import {
+  clearFormattingToolbar,
+  publishFormattingToolbar,
+  type FormattingToolbarCapabilities,
+  type FormattingToolbarCommands,
+  type FormattingTriggerText,
+} from './formatting-toolbar-store'
+
+/**
+ * Publishes this editor's formatting-toolbar surface while it holds focus
+ * (Plan 19, decision 8: the toolbar is webview-drawn, and V1's item set with
+ * selection-aware enablement is the spec). Mounted inside the editor's
+ * ProseKit context like `EditorInputTraits`; a no-op off the touch surface.
+ *
+ * Deliberately not `useEditor({ update: true })` — that option is
+ * incompatible with the React Compiler — nor a widening of
+ * `NoteEditorHandle`: commands close over the ProseKit editor instance and
+ * flow out through the module store, so the toolbar never needs to know
+ * which of the carousel's mounted editors is focused.
+ *
+ * Capabilities recompute on DOM `selectionchange` (WebKit fires it for every
+ * caret move in the contenteditable) and after each toolbar command, whose
+ * own document change is not guaranteed to move the DOM selection.
+ */
+export function FormattingToolbarBridge(): null {
+  const editor = useEditor<EditorExtension>()
+
+  useEffect(() => {
+    if (!isTouchEditorSurface()) {
+      return
+    }
+    const owner = Symbol('formatting-toolbar')
+    let frame: number | null = null
+    let teardown: (() => void) | null = null
+
+    // Same mount dance as EditorInputTraits: ProseKit attaches the view via
+    // ref before effects run, so this attaches immediately in practice — but
+    // the timing is ProseKit's, so a not-yet-mounted editor retries per frame.
+    const attach = (): void => {
+      if (!editor.mounted) {
+        frame = requestAnimationFrame(attach)
+        return
+      }
+      frame = null
+      const dom = editor.view.dom
+
+      function readCapabilities(): FormattingToolbarCapabilities {
+        return {
+          canIndent: editor.commands.indentList.canExec(),
+          canDedent: editor.commands.dedentList.canExec(),
+          canMoveUp: editor.commands.moveList.canExec('up'),
+          canMoveDown: editor.commands.moveList.canExec('down'),
+        }
+      }
+
+      function publish(): void {
+        publishFormattingToolbar(owner, { capabilities: readCapabilities(), commands })
+      }
+
+      function run(command: () => void): void {
+        command()
+        publish()
+      }
+
+      const commands: FormattingToolbarCommands = {
+        toggleBulletList: () => run(() => editor.commands.toggleList({ kind: 'bullet' })),
+        toggleTaskList: () => run(() => editor.commands.toggleList({ kind: 'task' })),
+        indent: () => run(() => editor.commands.indentList()),
+        dedent: () => run(() => editor.commands.dedentList()),
+        moveUp: () => run(() => editor.commands.moveList('up')),
+        moveDown: () => run(() => editor.commands.moveList('down')),
+        insertTrigger: (text: FormattingTriggerText) =>
+          run(() => {
+            const view = editor.view
+            view.dispatch(view.state.tr.insertText(text).scrollIntoView())
+          }),
+        dismissKeyboard: () => editor.blur(),
+      }
+
+      function handleFocusIn(): void {
+        publish()
+      }
+      function handleFocusOut(): void {
+        clearFormattingToolbar(owner)
+      }
+      function handleSelectionChange(): void {
+        if (editor.focused) {
+          publish()
+        }
+      }
+
+      dom.addEventListener('focusin', handleFocusIn)
+      dom.addEventListener('focusout', handleFocusOut)
+      document.addEventListener('selectionchange', handleSelectionChange)
+      // autoFocus can land before these listeners attach (the arrival-intent
+      // focus fires on editor mount) — an already-focused editor publishes now.
+      if (editor.focused) {
+        publish()
+      }
+      teardown = () => {
+        dom.removeEventListener('focusin', handleFocusIn)
+        dom.removeEventListener('focusout', handleFocusOut)
+        document.removeEventListener('selectionchange', handleSelectionChange)
+        clearFormattingToolbar(owner)
+      }
+    }
+    attach()
+    return () => {
+      if (frame !== null) {
+        cancelAnimationFrame(frame)
+      }
+      teardown?.()
+    }
+  }, [editor])
+
+  return null
+}

--- a/apps/desktop/src/editor/formatting-toolbar-store.test.ts
+++ b/apps/desktop/src/editor/formatting-toolbar-store.test.ts
@@ -1,0 +1,102 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearFormattingToolbar,
+  publishFormattingToolbar,
+  useFormattingToolbar,
+  type FormattingToolbar,
+} from './formatting-toolbar-store'
+
+function makeToolbar(overrides: Partial<FormattingToolbar['capabilities']> = {}): FormattingToolbar {
+  return {
+    capabilities: {
+      canIndent: false,
+      canDedent: false,
+      canMoveUp: false,
+      canMoveDown: false,
+      ...overrides,
+    },
+    commands: {
+      toggleBulletList: vi.fn(),
+      toggleTaskList: vi.fn(),
+      indent: vi.fn(),
+      dedent: vi.fn(),
+      moveUp: vi.fn(),
+      moveDown: vi.fn(),
+      insertTrigger: vi.fn(),
+      dismissKeyboard: vi.fn(),
+    },
+  }
+}
+
+const owners: symbol[] = []
+function makeOwner(): symbol {
+  const owner = Symbol('test-owner')
+  owners.push(owner)
+  return owner
+}
+
+afterEach(() => {
+  // The store is module-scope; release every owner a test may have left active.
+  for (const owner of owners.splice(0)) {
+    clearFormattingToolbar(owner)
+  }
+})
+
+describe('formatting toolbar store', () => {
+  it('publishes and clears the active toolbar', () => {
+    const view = renderHook(() => useFormattingToolbar())
+    expect(view.result.current).toBeNull()
+
+    const owner = makeOwner()
+    const toolbar = makeToolbar()
+    act(() => publishFormattingToolbar(owner, toolbar))
+    expect(view.result.current).toBe(toolbar)
+
+    act(() => clearFormattingToolbar(owner))
+    expect(view.result.current).toBeNull()
+  })
+
+  it('drops a refresh with equal capabilities and the same commands', () => {
+    const view = renderHook(() => useFormattingToolbar())
+    const owner = makeOwner()
+    const toolbar = makeToolbar()
+    act(() => publishFormattingToolbar(owner, toolbar))
+
+    // A caret move that changes nothing must keep the same snapshot object,
+    // so the toolbar component never re-renders for it.
+    act(() =>
+      publishFormattingToolbar(owner, {
+        capabilities: { ...toolbar.capabilities },
+        commands: toolbar.commands,
+      }),
+    )
+    expect(view.result.current).toBe(toolbar)
+
+    act(() =>
+      publishFormattingToolbar(owner, {
+        capabilities: { ...toolbar.capabilities, canIndent: true },
+        commands: toolbar.commands,
+      }),
+    )
+    expect(view.result.current).not.toBe(toolbar)
+    expect(view.result.current?.capabilities.canIndent).toBe(true)
+  })
+
+  it('ignores a stale clear after another editor took over', () => {
+    const view = renderHook(() => useFormattingToolbar())
+    const first = makeOwner()
+    const second = makeOwner()
+    act(() => publishFormattingToolbar(first, makeToolbar()))
+
+    const takeover = makeToolbar({ canIndent: true })
+    act(() => publishFormattingToolbar(second, takeover))
+    expect(view.result.current).toBe(takeover)
+
+    act(() => clearFormattingToolbar(first))
+    expect(view.result.current).toBe(takeover)
+
+    act(() => clearFormattingToolbar(second))
+    expect(view.result.current).toBeNull()
+  })
+})

--- a/apps/desktop/src/editor/formatting-toolbar-store.ts
+++ b/apps/desktop/src/editor/formatting-toolbar-store.ts
@@ -1,0 +1,123 @@
+import { useSyncExternalStore } from 'react'
+
+/**
+ * Enable/disable state for the toolbar's structural buttons, recomputed from
+ * the editor selection (ProseKit `canExec`). Selection-aware enablement is
+ * what made V1's native accessory bar feel native — the porting doc calls it
+ * the load-bearing behavior, not the buttons themselves.
+ */
+export interface FormattingToolbarCapabilities {
+  canIndent: boolean
+  canDedent: boolean
+  canMoveUp: boolean
+  canMoveDown: boolean
+}
+
+/** Autocomplete-trigger characters the toolbar can type into the editor. */
+export type FormattingTriggerText = '/' | '[[' | '#'
+
+/**
+ * The command surface a focused editor offers the toolbar. Each closes over
+ * the live ProseKit editor instance; none require the caller to know the
+ * editor's identity or path.
+ */
+export interface FormattingToolbarCommands {
+  toggleBulletList: () => void
+  toggleTaskList: () => void
+  indent: () => void
+  dedent: () => void
+  moveUp: () => void
+  moveDown: () => void
+  /** Type an autocomplete trigger at the caret, opening its menu. */
+  insertTrigger: (text: FormattingTriggerText) => void
+  /** Blur the editor, dropping the software keyboard (and this toolbar). */
+  dismissKeyboard: () => void
+}
+
+/** What the mobile shell's toolbar renders for the focused editor. */
+export interface FormattingToolbar {
+  capabilities: FormattingToolbarCapabilities
+  commands: FormattingToolbarCommands
+}
+
+/**
+ * Module-scope store for "the focused editor's toolbar", in the same
+ * external-store shape as `use-keyboard.ts`. The daily carousel keeps up to
+ * three editors mounted at once, so ownership is claimed per bridge instance
+ * (an opaque token) on focus and released on blur — a stale release from a
+ * blurring editor can never clobber the one that just took focus, because
+ * focusout always precedes the next editor's focusin.
+ */
+let active: FormattingToolbar | null = null
+let activeOwner: symbol | null = null
+const listeners = new Set<() => void>()
+
+function notify(): void {
+  for (const listener of listeners) {
+    listener()
+  }
+}
+
+function capabilitiesEqual(
+  left: FormattingToolbarCapabilities,
+  right: FormattingToolbarCapabilities,
+): boolean {
+  return (
+    left.canIndent === right.canIndent &&
+    left.canDedent === right.canDedent &&
+    left.canMoveUp === right.canMoveUp &&
+    left.canMoveDown === right.canMoveDown
+  )
+}
+
+/**
+ * Claim (or refresh) the active toolbar for `owner`. A refresh with equal
+ * capabilities and the same command surface is dropped without notifying, so
+ * caret moves that don't change enablement never re-render the toolbar.
+ */
+export function publishFormattingToolbar(owner: symbol, toolbar: FormattingToolbar): void {
+  if (
+    activeOwner === owner &&
+    active !== null &&
+    active.commands === toolbar.commands &&
+    capabilitiesEqual(active.capabilities, toolbar.capabilities)
+  ) {
+    return
+  }
+  activeOwner = owner
+  active = toolbar
+  notify()
+}
+
+/**
+ * Release the active toolbar, but only if `owner` still holds it — a blurred
+ * editor unpublishing after another editor already took over is a no-op.
+ */
+export function clearFormattingToolbar(owner: symbol): void {
+  if (activeOwner !== owner) {
+    return
+  }
+  activeOwner = null
+  active = null
+  notify()
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+function snapshot(): FormattingToolbar | null {
+  return active
+}
+
+/**
+ * The focused editor's toolbar as reactive state — `null` when no editor is
+ * focused (e.g. the keyboard was raised by the All-tab search field, where a
+ * formatting toolbar would be nine dead buttons).
+ */
+export function useFormattingToolbar(): FormattingToolbar | null {
+  return useSyncExternalStore(subscribe, snapshot, snapshot)
+}

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -28,6 +28,7 @@ import {
   type WikilinkSearchHandler,
 } from '@meowdown/react'
 import { EditorInputTraits } from '@/editor/editor-input-traits'
+import { FormattingToolbarBridge } from '@/editor/formatting-toolbar-bridge'
 import {
   IMAGE_LIGHTBOX_TRANSITION_NAME,
   ImageLightbox,
@@ -385,6 +386,7 @@ export function NoteEditor({
         onExitBoundary={handleExitBoundary}
       >
         <EditorInputTraits />
+        <FormattingToolbarBridge />
         {children}
       </MeowdownEditor>
       <ImageLightbox

--- a/apps/desktop/src/mobile/formatting-toolbar.test.tsx
+++ b/apps/desktop/src/mobile/formatting-toolbar.test.tsx
@@ -1,0 +1,110 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearFormattingToolbar,
+  publishFormattingToolbar,
+  type FormattingToolbar,
+} from '@/editor/formatting-toolbar-store'
+import { MobileFormattingToolbar } from './formatting-toolbar'
+
+vi.mock('@/mobile/haptics', () => ({ hapticImpactLight: vi.fn() }))
+
+function makeToolbar(
+  capabilities: Partial<FormattingToolbar['capabilities']> = {},
+): FormattingToolbar {
+  return {
+    capabilities: {
+      canIndent: true,
+      canDedent: true,
+      canMoveUp: true,
+      canMoveDown: true,
+      ...capabilities,
+    },
+    commands: {
+      toggleBulletList: vi.fn(),
+      toggleTaskList: vi.fn(),
+      indent: vi.fn(),
+      dedent: vi.fn(),
+      moveUp: vi.fn(),
+      moveDown: vi.fn(),
+      insertTrigger: vi.fn(),
+      dismissKeyboard: vi.fn(),
+    },
+  }
+}
+
+const owner = Symbol('toolbar-test')
+
+afterEach(() => {
+  cleanup()
+  clearFormattingToolbar(owner)
+  vi.clearAllMocks()
+})
+
+describe('MobileFormattingToolbar', () => {
+  it('renders nothing while no editor is focused (the search keyboard case)', () => {
+    const view = render(<MobileFormattingToolbar />)
+    expect(view.container.firstChild).toBeNull()
+  })
+
+  it('renders V1 item order plus the dismiss button, with canExec-driven enablement', () => {
+    const toolbar = makeToolbar({ canDedent: false, canMoveUp: false })
+    render(<MobileFormattingToolbar />)
+    act(() => publishFormattingToolbar(owner, toolbar))
+
+    const buttons = screen.getAllByRole('button')
+    expect(buttons.map((button) => button.getAttribute('aria-label'))).toEqual([
+      'Slash command',
+      'Bullet list',
+      'Task list',
+      'Link note',
+      'Tag',
+      'Outdent',
+      'Indent',
+      'Move up',
+      'Move down',
+      'Hide keyboard',
+    ])
+    expect((screen.getByRole('button', { name: 'Outdent' }) as HTMLButtonElement).disabled).toBe(
+      true,
+    )
+    expect((screen.getByRole('button', { name: 'Move up' }) as HTMLButtonElement).disabled).toBe(
+      true,
+    )
+    expect((screen.getByRole('button', { name: 'Indent' }) as HTMLButtonElement).disabled).toBe(
+      false,
+    )
+  })
+
+  it('never lets a tap move focus out of the editor', () => {
+    render(<MobileFormattingToolbar />)
+    act(() => publishFormattingToolbar(owner, makeToolbar()))
+
+    const bullet = screen.getByRole('button', { name: 'Bullet list' })
+    // fireEvent returns false when a handler called preventDefault — the
+    // contract that keeps the editor focused (and the keyboard up) mid-tap.
+    expect(fireEvent.pointerDown(bullet)).toBe(false)
+    expect(fireEvent.mouseDown(bullet)).toBe(false)
+  })
+
+  it('routes taps to the published commands', () => {
+    const toolbar = makeToolbar()
+    render(<MobileFormattingToolbar />)
+    act(() => publishFormattingToolbar(owner, toolbar))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Bullet list' }))
+    expect(toolbar.commands.toggleBulletList).toHaveBeenCalledOnce()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Link note' }))
+    expect(toolbar.commands.insertTrigger).toHaveBeenCalledWith('[[')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tag' }))
+    expect(toolbar.commands.insertTrigger).toHaveBeenCalledWith('#')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Slash command' }))
+    expect(toolbar.commands.insertTrigger).toHaveBeenCalledWith('/')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide keyboard' }))
+    expect(toolbar.commands.dismissKeyboard).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/mobile/formatting-toolbar.tsx
+++ b/apps/desktop/src/mobile/formatting-toolbar.tsx
@@ -1,0 +1,141 @@
+import type { ReactElement } from 'react'
+import {
+  ArrowDown,
+  ArrowUp,
+  Brackets,
+  ChevronDown,
+  Hash,
+  IndentDecrease,
+  IndentIncrease,
+  List,
+  ListTodo,
+  Slash,
+} from 'lucide-react'
+import { useFormattingToolbar } from '@/editor/formatting-toolbar-store'
+import { cn } from '@/lib/utils'
+import { hapticImpactLight } from '@/mobile/haptics'
+
+/**
+ * The webview-drawn formatting toolbar (Plan 19, decision 8 — V1's native
+ * accessory bar deliberately not ported). It takes the tab bar's slot at the
+ * bottom of the shell root while the keyboard is up, which with the root
+ * sized to `calc(100dvh - var(--keyboard-height))` puts it exactly on the
+ * keyboard's top edge: no fixed positioning, no safe-area math (the keyboard
+ * covers the home-indicator region), and hardware keyboards suppress it for
+ * free because the plugin reports their overlap as 0.
+ *
+ * Item set and order are V1's toolbar spec (the porting doc's requirements
+ * list) minus AI prediction and image capture, which have no v2 substrate
+ * yet — plus a dismiss button, which V1 never needed because iOS gives a
+ * `contenteditable` no Done key. Renders nothing while no editor is focused:
+ * the All-tab search field raises the keyboard too, and formatting buttons
+ * would be dead weight there.
+ */
+export function MobileFormattingToolbar(): ReactElement | null {
+  const toolbar = useFormattingToolbar()
+  if (toolbar === null) {
+    return null
+  }
+  const { capabilities, commands } = toolbar
+  return (
+    <div
+      role="toolbar"
+      aria-label="Formatting"
+      className="flex shrink-0 items-center gap-0.5 overflow-x-auto border-t border-border px-1"
+    >
+      <ToolbarButton
+        label="Slash command"
+        icon={<Slash className="size-5" />}
+        onPress={() => commands.insertTrigger('/')}
+      />
+      <ToolbarButton
+        label="Bullet list"
+        icon={<List className="size-5" />}
+        onPress={commands.toggleBulletList}
+      />
+      <ToolbarButton
+        label="Task list"
+        icon={<ListTodo className="size-5" />}
+        onPress={commands.toggleTaskList}
+      />
+      <ToolbarButton
+        label="Link note"
+        icon={<Brackets className="size-5" />}
+        onPress={() => commands.insertTrigger('[[')}
+      />
+      <ToolbarButton
+        label="Tag"
+        icon={<Hash className="size-5" />}
+        onPress={() => commands.insertTrigger('#')}
+      />
+      <ToolbarButton
+        label="Outdent"
+        icon={<IndentDecrease className="size-5" />}
+        disabled={!capabilities.canDedent}
+        onPress={commands.dedent}
+      />
+      <ToolbarButton
+        label="Indent"
+        icon={<IndentIncrease className="size-5" />}
+        disabled={!capabilities.canIndent}
+        onPress={commands.indent}
+      />
+      <ToolbarButton
+        label="Move up"
+        icon={<ArrowUp className="size-5" />}
+        disabled={!capabilities.canMoveUp}
+        onPress={commands.moveUp}
+      />
+      <ToolbarButton
+        label="Move down"
+        icon={<ArrowDown className="size-5" />}
+        disabled={!capabilities.canMoveDown}
+        onPress={commands.moveDown}
+      />
+      <ToolbarButton
+        label="Hide keyboard"
+        icon={<ChevronDown className="size-5" />}
+        className="ml-auto"
+        onPress={commands.dismissKeyboard}
+      />
+    </div>
+  )
+}
+
+function ToolbarButton({
+  label,
+  icon,
+  disabled = false,
+  className,
+  onPress,
+}: {
+  label: string
+  icon: ReactElement
+  disabled?: boolean
+  className?: string
+  onPress: () => void
+}): ReactElement {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      disabled={disabled}
+      // Focus must never leave the editor: cancelling pointerdown (and the
+      // compatibility mousedown) stops the tap from moving focus, so the
+      // keyboard — and with it this toolbar — can't dismiss mid-tap. The
+      // dismiss button drops the keyboard explicitly via `editor.blur()`.
+      onPointerDown={(event) => event.preventDefault()}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={() => {
+        hapticImpactLight()
+        onPress()
+      }}
+      className={cn(
+        'flex size-11 shrink-0 items-center justify-center rounded-md text-text-muted disabled:opacity-40',
+        className,
+      )}
+    >
+      {icon}
+    </button>
+  )
+}

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -5,6 +5,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { format } from 'date-fns'
 import { StrictMode, type ReactElement } from 'react'
 import { setBridge } from '@reflect/core'
+import {
+  clearFormattingToolbar,
+  publishFormattingToolbar,
+} from '@/editor/formatting-toolbar-store'
 import { RouterProvider, useRouter } from '@/routing/router'
 import type { Route } from '@/routing/route'
 import { addDaysIso, formatDayLabel, parseIsoDate, todayIso } from '@/lib/dates'
@@ -374,6 +378,41 @@ describe('MobileShell', () => {
     expect(view.queryByRole('navigation', { name: 'Sections' })).toBeNull()
 
     act(() => publishKeyboardHeight(0))
+    expect(view.getByRole('navigation', { name: 'Sections' })).toBeTruthy()
+  })
+
+  it('gives the tab bar slot to the formatting toolbar only while an editor is focused', () => {
+    const view = mount({ kind: 'today' })
+    const owner = Symbol('shell-test')
+
+    // Keyboard up with no focused editor (the All-tab search field): neither
+    // the tab bar nor a dead-button toolbar.
+    act(() => publishKeyboardHeight(316))
+    expect(view.queryByRole('toolbar', { name: 'Formatting' })).toBeNull()
+
+    act(() =>
+      publishFormattingToolbar(owner, {
+        capabilities: { canIndent: true, canDedent: false, canMoveUp: true, canMoveDown: true },
+        commands: {
+          toggleBulletList: vi.fn(),
+          toggleTaskList: vi.fn(),
+          indent: vi.fn(),
+          dedent: vi.fn(),
+          moveUp: vi.fn(),
+          moveDown: vi.fn(),
+          insertTrigger: vi.fn(),
+          dismissKeyboard: vi.fn(),
+        },
+      }),
+    )
+    expect(view.getByRole('toolbar', { name: 'Formatting' })).toBeTruthy()
+    expect(view.queryByRole('navigation', { name: 'Sections' })).toBeNull()
+
+    act(() => {
+      clearFormattingToolbar(owner)
+      publishKeyboardHeight(0)
+    })
+    expect(view.queryByRole('toolbar', { name: 'Formatting' })).toBeNull()
     expect(view.getByRole('navigation', { name: 'Sections' })).toBeTruthy()
   })
 

--- a/apps/desktop/src/mobile/mobile-shell.tsx
+++ b/apps/desktop/src/mobile/mobile-shell.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, type ReactElement } from 'react'
+import { MobileFormattingToolbar } from '@/mobile/formatting-toolbar'
 import { MobileStack } from '@/mobile/mobile-stack'
 import { MobileTabBar, type MobileTab } from '@/mobile/mobile-tab-bar'
 import {
@@ -67,8 +68,13 @@ export function MobileShell(): ReactElement {
         />
       </div>
       {/* V1 lets the keyboard cover the tab bar; with the root shrunk it
-          would ride above the keyboard instead, so it hides while typing. */}
-      {keyboardVisible ? null : (
+          would ride above the keyboard instead, so it hides while typing.
+          Its slot goes to the formatting toolbar, which — sitting at the
+          bottom of a root that ends at the keyboard's top — lands exactly
+          on the keyboard edge with no fixed positioning. */}
+      {keyboardVisible ? (
+        <MobileFormattingToolbar />
+      ) : (
         <MobileTabBar
           tab={tab}
           onSelect={(next) =>

--- a/docs/porting/reflect-mobile/editor-and-keyboard.md
+++ b/docs/porting/reflect-mobile/editor-and-keyboard.md
@@ -43,6 +43,27 @@ toolbar — and the hard-won keyboard/focus lessons.
 > In the simulator, note that the software keyboard stays hidden while
 > "Connect Hardware Keyboard" is on (⇧⌘K; ⌘K toggles the software
 > keyboard) — that is a simulator setting, not an app bug.
+>
+> **Status (2026-07-04): the webview-drawn toolbar shipped.** It takes the
+> tab bar's slot at the bottom of the shell root while the keyboard is up —
+> with the root sized to end at the keyboard's top, that lands it exactly on
+> the keyboard edge with no fixed positioning, and hardware keyboards
+> suppress it for free (their reported overlap is 0, so `keyboardVisible`
+> never flips). Item set is V1's spec below minus AI prediction and image
+> (no v2 substrate yet), plus a dismiss button (V1 never needed one; iOS
+> gives a `contenteditable` no Done key). Selection-aware enablement is live
+> ProseKit `canExec`, recomputed on DOM `selectionchange` and republished
+> through a module store (`formatting-toolbar-store.ts`) by a bridge child
+> mounted inside the editor's ProseKit context
+> (`formatting-toolbar-bridge.tsx`) — the store renders `null` when the
+> keyboard belongs to a non-editor field (the All-tab search box), and
+> per-bridge ownership tokens keep the carousel's multiple mounted editors
+> from clobbering each other. Buttons cancel `pointerdown`/`mousedown` so a
+> tap never steals editor focus. **Owed to the device pass:** whether the
+> programmatic `[[`/`#`/`/` inserts open their autocomplete menus (they
+> insert correctly; if the menus don't open, the fallback is a small
+> upstream meowdown command to open them explicitly), plus haptic feel and
+> per-button focus retention on real WebKit.
 
 ## What V1 mobile does
 


### PR DESCRIPTION
## Problem

Editing on mobile has no formatting affordances. V1's signature editor feature was a native keyboard accessory toolbar, but its implementation (input-accessory swizzling) was brittle and Plan 19 decision 8 explicitly does not port it: the keyboard plugin's height events are the stable primitive, and any toolbar is to be webview-drawn on top of them, with V1's item set as the spec and selection-aware enablement as the load-bearing behavior ([porting doc](docs/porting/reflect-mobile/editor-and-keyboard.md)).

## What this does

**Placement — the tab bar's keyboard-mode sibling.** The shell root already ends at the keyboard's top (`calc(100dvh - var(--keyboard-height))`), and the tab bar already hides while typing. The toolbar takes that vacated slot, which puts it exactly on the keyboard's top edge with no fixed positioning, no safe-area math, and no transform hazards from stack transitions. Hardware keyboards suppress it for free: the plugin reports their overlap as 0, so `keyboardVisible` never flips (V1 needed a `GCKeyboard` observer for this).

**Item set — V1's spec, adjusted for v2 substrate.** Slash, bullet list, task list, `[[` wiki-link, `#` tag, outdent, indent, move up, move down — V1's order — plus a keyboard-dismiss button (new: iOS gives a `contenteditable` no Done key). AI prediction and image capture are omitted until their v2 substrate exists.

**Enablement — live `canExec`.** A bridge child (`FormattingToolbarBridge`) mounts inside the editor's ProseKit context (same pattern as `EditorInputTraits`, no-op off the touch surface) and publishes the focused editor's command closures plus `canIndent`/`canDedent`/`canMoveUp`/`canMoveDown` through a module store, recomputing on DOM `selectionchange` and after each command. Notably *not* `useEditor({update: true})` (incompatible with the React Compiler) and not a widening of `NoteEditorHandle`.

**Multi-editor correctness.** The daily carousel keeps up to three editors mounted; ownership tokens per bridge mean a blurring editor can never clobber the one that just took focus. The store stays `null` when the keyboard belongs to a non-editor field, so the All-tab search box gets no dead-button toolbar.

**Focus retention.** Buttons cancel `pointerdown`/`mousedown` so a tap never moves focus out of the editor — the keyboard (and the toolbar itself) can't dismiss mid-tap. Dismiss drops the keyboard explicitly via `editor.blur()`.

## Testing

- 36 tests across four suites: store semantics (dedupe, ownership), bridge behavior (publish on focus/autoFocus, selectionchange recompute, command dispatch, trigger transactions, unmount cleanup), toolbar rendering (item order, enablement, focus-preservation contract, command routing), and the shell swap (including the search-keyboard case) in the existing `mobile-screen.test.tsx` harness.
- `pnpm check` clean.
- Verified against the real editor in the `?platform=ios` browser harness: swap, live enablement from real `canExec`, focus retention on tap, and trigger-text insertion all confirmed.

## Owed to the device pass

- Whether programmatic `[[`/`#`/`/` inserts open their autocomplete menus on real WebKit — the insert itself is confirmed, the menu did not open in the (artificially-carreted) browser check. If it genuinely doesn't trigger, the fallback is a small upstream meowdown command to open the menus explicitly.
- Haptic feel, per-button focus retention on device, iPad floating/split keyboard behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mobile editor focus/keyboard UX and multi-editor carousel ownership; mistakes could dismiss the keyboard mid-edit or show dead toolbar buttons, but changes are isolated to touch surfaces with extensive tests.
> 
> **Overview**
> Adds a **webview-drawn mobile formatting toolbar** that replaces the hidden tab bar while the software keyboard is up, sitting on the keyboard’s top edge via the existing shell height layout.
> 
> A **module store** (`formatting-toolbar-store`) exposes the focused editor’s commands and **selection-aware** indent/outdent/move enablement from ProseKit `canExec`, with per-editor ownership so the daily carousel’s multiple mounted editors don’t clobber each other. **`FormattingToolbarBridge`** mounts in `NoteEditor`’s ProseKit context (touch-only), publishes on focus/`selectionchange`, and clears when blurred or unmounted.
> 
> **`MobileFormattingToolbar`** renders V1’s item order (slash, lists, `[[`, `#`, structure, dismiss) with `pointerdown`/`mousedown` prevented so taps don’t steal editor focus. Shell wiring shows the toolbar only when the keyboard is visible **and** an editor has published state (search keyboard stays toolbar-free). Port doc updated; broad test coverage across store, bridge, toolbar UI, and shell swap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d89f80e83ec072163615871e08760d170a4b652a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->