### PR TITLE
Fix graph switcher open-another flow

### DIFF
--- a/apps/desktop/src/components/sidebar/graph-footer.tsx
+++ b/apps/desktop/src/components/sidebar/graph-footer.tsx
@@ -62,7 +62,7 @@ interface GraphFooterProps {
 }
 
 export function GraphFooter({ graph, context }: GraphFooterProps): ReactElement {
-  const { recents, indexing, openRecent, pickAndOpen } = useGraph()
+  const { recents, indexing, openRecent, chooseGraph } = useGraph()
   const { colorFor, setColor } = useGraphColors()
   const currentColor = colorFor(graph.root) ?? DEFAULT_GRAPH_COLOR
   const { backup } = useSync()
@@ -167,7 +167,7 @@ export function GraphFooter({ graph, context }: GraphFooterProps): ReactElement 
             <span className="min-w-0 flex-1 truncate">Reveal graph in Finder</span>
           </DropdownMenuItem>
           <DropdownMenuItem
-            onSelect={() => void pickAndOpen()}
+            onSelect={() => void chooseGraph()}
             className={MENU_ITEM_CLASS}
           >
             <FolderOpen aria-hidden strokeWidth={1.75} className="size-3.5 shrink-0" />

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -19,6 +19,7 @@ const getPinnedNotes = vi.hoisted(() => vi.fn<() => Promise<PinnedNote[]>>(async
 const revealItemInDir = vi.hoisted(() => vi.fn<(path: string) => Promise<void>>(async () => {}))
 const openRecent = vi.hoisted(() => vi.fn())
 const pickAndOpen = vi.hoisted(() => vi.fn())
+const chooseGraph = vi.hoisted(() => vi.fn())
 interface NativeContextMenuItemForTest {
   text: string
   action: () => void
@@ -59,6 +60,7 @@ vi.mock('@/providers/graph-provider', () => ({
     indexing: false,
     openRecent,
     pickAndOpen,
+    chooseGraph,
   }),
 }))
 vi.mock('@/providers/settings-provider', () => ({
@@ -111,6 +113,9 @@ beforeEach(() => {
   audioMemo.unavailableReason = null
   audioMemo.toggle.mockReset()
   revealItemInDir.mockClear()
+  openRecent.mockClear()
+  pickAndOpen.mockClear()
+  chooseGraph.mockClear()
   openNativeContextMenu.mockClear()
   unpinNote.mockClear()
 })
@@ -349,7 +354,8 @@ describe('Sidebar', () => {
 
     await userEvent.click(view.getByRole('button', { name: /Notes/ }))
     await userEvent.click(view.getByRole('menuitem', { name: /open another graph/i }))
-    expect(pickAndOpen).toHaveBeenCalled()
+    expect(chooseGraph).toHaveBeenCalled()
+    expect(pickAndOpen).not.toHaveBeenCalled()
   })
 
   it('the graph footer opens user settings from the graph menu', async () => {

--- a/apps/desktop/src/providers/graph-provider.test.tsx
+++ b/apps/desktop/src/providers/graph-provider.test.tsx
@@ -201,6 +201,28 @@ describe('GraphProvider open sequencing', () => {
     expect(result.current.indexGeneration).toBeNull()
     expect(result.current.recents).toEqual([])
   })
+
+  it('returns to the graph chooser without opening the folder picker', async () => {
+    storedRecents = [{ root: '/known', name: 'known', openedMs: 1 }]
+    const { result } = renderHook(() => useGraph(), { wrapper })
+
+    await act(async () => {
+      await waitFor(() => expect(pendingOpens.has('/known')).toBe(true))
+      resolveOpen('/known')
+    })
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+
+    vi.mocked(open).mockClear()
+    await act(async () => {
+      await result.current.chooseGraph()
+    })
+
+    expect(result.current.status).toBe('choosing')
+    expect(result.current.graph).toBeNull()
+    expect(result.current.indexGeneration).toBeNull()
+    expect(open).not.toHaveBeenCalled()
+    expect(result.current.recents).toEqual(storedRecents)
+  })
 })
 
 describe('GraphProvider welcome seeding', () => {

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -53,6 +53,8 @@ interface GraphContextValue {
   error: string | null
   /** Show the OS folder picker, then open (and bootstrap) the chosen graph. */
   pickAndOpen: () => Promise<void>
+  /** Close the active graph and show the desktop graph chooser. */
+  chooseGraph: () => Promise<void>
   /**
    * Create (and open) a graph at an app-chosen absolute path — desktop
    * onboarding's iCloud path names the folder inside the container instead
@@ -436,6 +438,11 @@ export function GraphProvider({
     setStatus('choosing')
   }, [])
 
+  const chooseGraph = useCallback(async (): Promise<void> => {
+    await closeActiveGraph()
+    await loadRecents({ surfaceErrors: true })
+  }, [closeActiveGraph, loadRecents])
+
   const forget = useCallback(
     async (root: string): Promise<void> => {
       try {
@@ -522,6 +529,7 @@ export function GraphProvider({
       indexing,
       error,
       pickAndOpen,
+      chooseGraph,
       createAt,
       openRecent,
       forget,
@@ -539,6 +547,7 @@ export function GraphProvider({
       indexing,
       error,
       pickAndOpen,
+      chooseGraph,
       createAt,
       openRecent,
       forget,


### PR DESCRIPTION
## Problem
The graph switcher footer's “Open another graph…” action opened the native folder picker immediately. That skipped the initial `GraphChooser` surface where users can pick iCloud graphs, create another container graph, choose a folder, or reopen recents.

## Before -> After
| Action | Before | After |
| --- | --- | --- |
| Graph menu -> Open another graph | Opens native choose-folder dialog | Closes the current graph and shows `GraphChooser` |

## Changes
1. Added `chooseGraph()` to `GraphProvider` to close the current graph lifecycle, clear active graph state, reload recents, and set `status` back to `choosing`.
2. Updated `GraphFooter` to call `chooseGraph()` instead of `pickAndOpen()`.
3. Added provider/sidebar tests covering the chooser route and preventing a native picker regression.

## Verification
- `pnpm --filter @reflect/desktop test --run src/providers/graph-provider.test.tsx`
- `pnpm --filter @reflect/desktop test --run src/components/sidebar/sidebar.test.tsx`
- `pnpm check` passes; existing max-lines warnings remain.

## Risk / Rollout
Low risk: no migrations or data shape changes. The action closes the active graph before showing the chooser, matching the existing `choosing` route state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI routing only: reuses existing `closeActiveGraph` / `choosing` state with no migrations or data shape changes; users briefly leave the workspace before picking another graph.
> 
> **Overview**
> **Open another graph…** in the sidebar graph menu no longer jumps straight to the native folder picker. It now calls **`chooseGraph()`**, which tears down the active graph (index close, cleared graph state) and sets **`status`** to **`choosing`** so users land on **`GraphChooser`**—same surface as first run, with iCloud options, recents, and folder pick from there.
> 
> **`GraphProvider`** exposes **`chooseGraph`** alongside existing **`pickAndOpen`**; **`pickAndOpen`** is unchanged for flows like **Choose a folder…** on the chooser itself. Tests cover the footer wiring and that **`chooseGraph`** does not invoke the dialog **`open`** API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdab69509e1cd4ed4f2229c41962c45b6560e1c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The “Open another graph…” action now returns you to the graph chooser, instead of immediately launching the folder picker.
* **Bug Fixes**
  * Switching graphs now preserves your recent graphs list and properly closes the current graph before reopening.
  * Updated sidebar behavior so the correct action is triggered when selecting “Open another graph…”.
* **Tests**
  * Added and updated coverage for graph switching and sidebar dropdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->