### PR TITLE
Fix mobile conflict resolution

### DIFF
--- a/apps/desktop/src/components/sync-conflict-notice.test.tsx
+++ b/apps/desktop/src/components/sync-conflict-notice.test.tsx
@@ -86,15 +86,15 @@ describe('SyncConflictNotice', () => {
     expect(resolution.resolve).toHaveBeenCalledWith('both')
   })
 
-  it('contains, not resolves, on mobile: needs-review copy and no actions', async () => {
-    // Plan 19: the resolution UI stays desktop-side — the mobile banner
-    // points at desktop and offers nothing else.
+  it('offers the same resolution actions on mobile', async () => {
     setPlatformSurface({ mobileApp: true })
     vi.mocked(getNote).mockResolvedValue(NOTE)
     renderNotice()
 
-    expect(await screen.findByText(/review on desktop/i)).toBeTruthy()
-    expect(screen.queryByRole('button')).toBeNull()
+    expect(await screen.findByText(/choose what to keep/i)).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /keep this device’s version/i }))
+    expect(resolution.resolve).toHaveBeenCalledWith('ours')
   })
 
   it('pluralizes the buttons for a stacked three-plus-way conflict', async () => {

--- a/apps/desktop/src/components/sync-conflict-notice.tsx
+++ b/apps/desktop/src/components/sync-conflict-notice.tsx
@@ -35,9 +35,8 @@ interface SyncConflictNoticeProps {
  * projection of the file content, so the banner clears itself once the
  * resolved file reindexes.
  *
- * On mobile, conflicts are contained, not resolved (Plan 19): the same
- * protected session contract, but the resolution actions stay desktop-side —
- * the banner says the note needs review on desktop and offers nothing else.
+ * Mobile uses the same protected session contract and raw-text resolution
+ * actions. The buttons are touch-sized there, but still call the same resolver.
  */
 export function SyncConflictNotice({ path, className }: SyncConflictNoticeProps): ReactElement | null {
   const { graph } = useGraph()
@@ -71,15 +70,8 @@ export function SyncConflictNotice({ path, className }: SyncConflictNoticeProps)
   const labels = markerInfo?.labels ?? null
   const manySided = (markerInfo?.blocks ?? 0) > 1
   const named = labels != null && labels.ours !== 'this device'
-
-  if (isMobileSurface()) {
-    return (
-      <InlineAlert tone="warning" className={className}>
-        Edited on two devices at once — review on desktop. Every version stays in the backup
-        history.
-      </InlineAlert>
-    )
-  }
+  const mobile = isMobileSurface()
+  const actionClassName = mobile ? 'h-9 justify-center px-3' : undefined
 
   return (
     <InlineAlert tone="warning" className={className}>
@@ -88,18 +80,36 @@ export function SyncConflictNotice({ path, className }: SyncConflictNoticeProps)
         conflict markers. Choose what to keep — every version stays recoverable in the backup
         history either way.
       </p>
-      <div className="mt-2 flex flex-wrap gap-2">
-        <Button size="xs" variant="outline" disabled={busy} onClick={() => void resolve('ours')}>
+      <div className={mobile ? 'mt-3 grid gap-2' : 'mt-2 flex flex-wrap gap-2'}>
+        <Button
+          size="xs"
+          variant="outline"
+          className={actionClassName}
+          disabled={busy}
+          onClick={() => void resolve('ours')}
+        >
           {named ? `Keep “${labels.ours}”` : 'Keep this device’s version'}
         </Button>
-        <Button size="xs" variant="outline" disabled={busy} onClick={() => void resolve('theirs')}>
+        <Button
+          size="xs"
+          variant="outline"
+          className={actionClassName}
+          disabled={busy}
+          onClick={() => void resolve('theirs')}
+        >
           {manySided
             ? 'Keep the other versions'
             : named
               ? `Keep “${labels.theirs}”`
               : 'Keep the other device’s'}
         </Button>
-        <Button size="xs" variant="outline" disabled={busy} onClick={() => void resolve('both')}>
+        <Button
+          size="xs"
+          variant="outline"
+          className={actionClassName}
+          disabled={busy}
+          onClick={() => void resolve('both')}
+        >
           {manySided ? 'Keep all' : 'Keep both'}
         </Button>
       </div>

--- a/apps/desktop/src/lib/platform-surface.ts
+++ b/apps/desktop/src/lib/platform-surface.ts
@@ -10,9 +10,8 @@
  *   `spellcheck=false`: WebKit derives the keyboard's smart-punctuation
  *   traits from it, and smart punctuation corrupts markdown syntax) and
  *   explicit input traits — see `EditorInputTraits` (Plan 19, decision 7).
- * - `mobileApp` — shared components render their mobile-v1 variants, e.g.
- *   sync-conflict resolution stays desktop-side so the conflict notice
- *   points at desktop instead of offering actions (Plan 19).
+ * - `mobileApp` — shared components render their mobile variants, e.g.
+ *   touch-sized conflict-resolution actions in the protected note notice.
  */
 export interface PlatformSurface {
   touchEditor: boolean

--- a/apps/desktop/src/mobile/note-conflict.test.tsx
+++ b/apps/desktop/src/mobile/note-conflict.test.tsx
@@ -10,9 +10,9 @@ import { RouterProvider } from '@/routing/router'
  * Conflict containment on the mobile note screen (Plan 19, step 10): a note
  * whose file carries sync conflict markers opens **protected** — the same
  * session contract as desktop (markers classify as lossy through the real
- * round-trip check) — with the needs-review-on-desktop banner, the raw file
- * visible, and no editor and no resolution actions anywhere. Only the
- * ProseMirror view is stubbed (jsdom can't host contenteditable).
+ * round-trip check) — with the raw file visible and the same marker-resolution
+ * actions desktop offers. Only the ProseMirror view is stubbed (jsdom can't
+ * host contenteditable).
  */
 
 vi.mock('@/editor/note-editor', () => ({
@@ -25,11 +25,11 @@ vi.mock('@/mobile/note-actions-menu', () => ({
 
 const CONFLICTED = [
   '# Standup',
-  '<<<<<<< HEAD',
+  '<<<<<<< this device',
   '- phone line',
   '=======',
   '- desktop line',
-  '>>>>>>> origin/main',
+  '>>>>>>> other device',
   '',
 ].join('\n')
 
@@ -95,7 +95,7 @@ afterEach(() => {
 })
 
 describe('MobileNote with a conflicted note', () => {
-  it('opens protected with the needs-review-on-desktop banner and no actions', async () => {
+  it('opens protected with raw markers and conflict resolution actions', async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <RouterProvider initialRoute={{ kind: 'note', path: 'notes/standup.md' }}>
@@ -104,11 +104,12 @@ describe('MobileNote with a conflicted note', () => {
       </QueryClientProvider>,
     )
 
-    expect(await screen.findByText(/review on desktop/i)).toBeTruthy()
+    expect(await screen.findByText(/choose what to keep/i)).toBeTruthy()
     // Protected: raw file shown verbatim, no live editor mounted.
     expect(screen.getByText(/desktop line/)).toBeTruthy()
     expect(screen.queryByTestId('fake-editor')).toBeNull()
-    // Resolution stays desktop-side — no keep-mine/theirs/both actions.
-    expect(screen.queryByRole('button', { name: /keep/i })).toBeNull()
+    expect(screen.getByRole('button', { name: /keep this device’s version/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /keep the other device’s/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /keep both/i })).toBeTruthy()
   })
 })

--- a/apps/desktop/src/mobile/settings-sheet.test.tsx
+++ b/apps/desktop/src/mobile/settings-sheet.test.tsx
@@ -132,12 +132,12 @@ describe('SettingsSheet', () => {
     expect(screen.queryByText('Backed up')).toBeNull()
   })
 
-  it('shows Needs review with its desktop pointer when notes conflict', async () => {
+  it('shows Needs review with its mobile resolution pointer when notes conflict', async () => {
     vi.mocked(getConflictedNotes).mockResolvedValue([{ path: 'notes/a.md', title: 'A' }])
     mount()
 
     expect(await screen.findByText('Needs review')).toBeTruthy()
-    expect(screen.getByText(/open it on desktop/i)).toBeTruthy()
+    expect(screen.getByText(/open it to choose what to keep/i)).toBeTruthy()
   })
 
   it('routes Disconnect through the backup controller and signs out', async () => {

--- a/apps/desktop/src/mobile/sync-status.test.ts
+++ b/apps/desktop/src/mobile/sync-status.test.ts
@@ -37,10 +37,11 @@ describe('mobileSyncStatus', () => {
     const one = mobileSyncStatus(connected({ state: 'idle' }), 1)
     expect(one?.label).toBe('Needs review')
     expect(one?.tone).toBe('attention')
-    expect(one?.detail).toMatch(/open it on desktop/i)
+    expect(one?.detail).toMatch(/open it to choose what to keep/i)
 
     const many = mobileSyncStatus(connected({ state: 'idle' }), 3)
     expect(many?.detail).toMatch(/^3 notes/)
+    expect(many?.detail).toMatch(/open them to choose what to keep/i)
   })
 
   it('conflicts outrank a failed cycle (the actionable state leads)', () => {

--- a/apps/desktop/src/mobile/sync-status.ts
+++ b/apps/desktop/src/mobile/sync-status.ts
@@ -46,8 +46,8 @@ export function mobileSyncStatus(
       tone: 'attention',
       detail:
         conflictCount === 1
-          ? 'A note was edited on two devices at once — open it on desktop to resolve.'
-          : `${conflictCount} notes were edited on two devices at once — open them on desktop to resolve.`,
+          ? 'A note was edited on two devices at once — open it to choose what to keep.'
+          : `${conflictCount} notes were edited on two devices at once — open them to choose what to keep.`,
     }
   }
   if (status.state === 'error') {

--- a/docs/plans/19-mobile.md
+++ b/docs/plans/19-mobile.md
@@ -76,9 +76,6 @@ filenames — the title-rename machinery rides along with editing).
 - Audio memos, link capture, share-sheet capture (share *target* needs its own
   native plugin — later).
 - Multiple graphs, graph chooser, folder pickers, iCloud Drive containers.
-- Conflict *resolution*: conflicted notes surface as "Needs review on desktop"
-  and open protected (read-only) — exactly the desktop session contract; only
-  the mine/theirs/both resolution UI stays desktop in v1.
 - Background sync (BGTaskScheduler), push notifications, widgets, auto-update
   (app stores own updates; the updater plugin is already desktop-gated).
 - Full keyboard-shortcut surfaces (⌘K palette), a native formatting accessory
@@ -369,7 +366,7 @@ Steps 1 and 2 are the existential gates; nothing else starts until both pass.
    iOS WKWebView, so no native plugin — and trash).
 10. **Sync wiring.** Resume/edit/online triggers, background-flush + local
     commit on pause, `onRemoteChanges` reindex (unchanged), conflicted notes
-    protected with "Needs review on desktop", status pill live.
+    protected with raw-marker resolution actions, status pill live.
 11. **Harden + ship.** Memory pass on a large graph (webview process limits;
     editing a very large note), resume-after-process-death recovery check,
     a11y labels, TestFlight build (`pnpm release:ios testflight`; see
@@ -400,9 +397,9 @@ Steps 1 and 2 are the existential gates; nothing else starts until both pass.
 - The keyboard never permanently occludes the editor or capture input, and
   the caret stays visible above the keyboard while typing (notched device,
   portrait + landscape).
-- A conflicted note opens protected with its "Needs review" state and never
-  blocks sync of other notes; a lossy-round-trip note opens protected, same
-  as desktop.
+- A conflicted note opens protected with its "Needs review" state, offers
+  mine/theirs/both resolution actions, and never blocks sync of other notes; a
+  lossy-round-trip note opens protected, same as desktop.
 - No `private: true` content leaves the device: mobile v1 makes **no** AI or
   transcription calls at all; network egress is GitHub (sync) only.
 - A TestFlight build installs and survives backgrounding/resume without a

--- a/docs/porting/reflect-mobile/sync-offline-and-data.md
+++ b/docs/porting/reflect-mobile/sync-offline-and-data.md
@@ -87,12 +87,12 @@ section is the mapping, not a proposal:
   (Plan 19 decision 6 and its acceptance criterion: kill the app
   mid-debounce, the edit is on disk).
 - **Conflicts become visible instead of merged.** V1's CRDT silently
-  merged concurrent edits; git does not. Mobile v1 *contains* conflicts —
-  a conflicted note opens protected ("Needs review on desktop") and never
-  blocks sync of other notes; resolution UI stays desktop-side. The
-  canonical case is phone + Mac both appending to today's daily note; the
-  daily-note append/append merge driver (Plan 12 future work) is the
-  lever if it hurts in practice.
+  merged concurrent edits; git does not. Mobile v1 contains conflicts in a
+  protected note view and offers the same raw-marker mine/theirs/both
+  resolution actions as desktop. Conflicts never block sync of other notes.
+  The canonical case is phone + Mac both appending to today's daily note; the
+  daily-note append/append merge driver (Plan 12 future work) is the lever if
+  it hurts in practice.
 - **Contract 5 maps to first clone**: cloning a years-old graph over
   cellular, foregrounded, with progress UI; shallow/partial clone is the
   noted follow-up.

--- a/docs/reflect-v2-mobile-grounding-brief.md
+++ b/docs/reflect-v2-mobile-grounding-brief.md
@@ -54,7 +54,7 @@ Plan 19 defines the binding scope. Summarized, with the product-owner calls of 2
 | GitHub sync (device flow, HTTPS) | **In** | Foreground-only; cycle on resume, after debounced edits, and on network regain. |
 | Onboarding: Start fresh / Connect GitHub | **In** | One graph per device, fixed root in `Documents/`, Files-app visible. |
 | Minimal settings | **In** | GitHub connect/disconnect, version. No graph chooser. |
-| Conflict **resolution** UI | **Out** | Conflicted notes open protected with "Needs review on desktop" — the same session contract as desktop; mine/theirs/both stays desktop-only in v1. |
+| Conflict **resolution** UI | **In** | Conflicted notes open protected with the same raw-marker mine/theirs/both resolution actions as desktop. |
 | Audio memos | **Later wave** | Product owner: first post-release wave, reusing desktop's raw-first + async BYOK transcription pipeline; OS entry points (widget, Siri, Live Activity) come with it. |
 | Share-sheet capture | **Later wave** | Product owner: defer until the mobile share-target plugin can reuse the Plan 11 capture envelope/inbox model. Desktop Chrome capture has shipped; mobile still needs App Group ingestion. |
 | AI copilot (BYOK) | **Later wave** | Architecture holds (keys would live in the iOS keychain via the same secrets module); the surface is deferred. |
@@ -107,8 +107,8 @@ The heart of the mobile product, and where mobile differs most from desktop in d
 - **Same engine, same contracts.** libgit2 commit/fetch/merge, conflict markers, the no-loop invariant — unchanged. Pull-applied changes flow through the existing `onRemoteChanges` reindex path.
 - **Foreground-only.** Sync cycles run on app resume, after debounced edits, and on network regain. Background sync (BGTaskScheduler) is explicitly out of v1. The phone therefore spends much of its life in "not yet pushed" — the plain-language status surface ("Backed up / Syncing / Needs review") is more prominent on mobile than desktop because the user consciously opens the app to sync.
 - **Capture latency is the contract.** "Open app, type a thought, lock phone" must always be safe: local commit never blocks on the network; push is opportunistic; flush-on-background protects the save debounce window. Plan 19's acceptance criteria pin this (kill the app mid-debounce; the edit is on disk).
-- **Conflicts are contained, not resolved, on mobile v1.** A conflicted note opens protected ("Needs review on desktop") and never blocks sync of other notes. This is the same session contract desktop uses; only the resolution UI stays desktop-side.
-- **The canonical conflict** is phone and Mac both appending to **today's daily note** while the phone was offline. It is mostly an append/append merge, and Plan 12 already lists a custom daily-note merge driver as future work — mobile multiplies that future work's value. Treat daily-note append/append as a first-class test scenario from day one even while resolution remains desktop-bound.
+- **Conflicts are contained and resolvable on mobile.** A conflicted note opens protected, never blocks sync of other notes, and offers the same raw-marker mine/theirs/both resolution actions as desktop.
+- **The canonical conflict** is phone and Mac both appending to **today's daily note** while the phone was offline. It is mostly an append/append merge, and Plan 12 already lists a custom daily-note merge driver as future work — mobile multiplies that future work's value. Treat daily-note append/append as a first-class test scenario even with on-device mine/theirs/both resolution.
 - **First sync is onboarding.** Cloning a years-old graph with assets over cellular, foregrounded, is a V1-power-user's first experience. v1 accepts slow clones with progress UI; shallow/partial clone is a noted follow-up that must not casually fork the desktop sync contract.
 
 ---
@@ -183,7 +183,7 @@ Keyboard-native is desktop identity; mobile translates it rather than imports it
 - **Touch-native, capture-first.** Thumb-reachable core actions; search as a visible surface, not a chord; the keyboard never occludes the caret. Full shortcut surfaces (⌘K palette) are explicitly out of v1 — hardware-keyboard iPad users fall back to visible affordances for now.
 - **Minimal UI applies double.** Six screens, a tab/stack shell, a sync-status pill. No settings sprawl: GitHub connect/disconnect and version.
 - **Same visual language.** Design-system tokens, safe-area-aware layout (`viewport-fit=cover`), 16px minimum input font (blocks iOS auto-zoom), dark mode. iPad ships as "a big phone" in v1; a desktop-class iPad layout is an explicit later decision.
-- **Plain-language sync.** "Backed up / Syncing / Needs review" — never commits, branches, or merges. Conflict language on mobile is "Needs review on desktop".
+- **Plain-language sync.** "Backed up / Syncing / Needs review" — never commits, branches, or merges. Conflict language points users to open the note and choose what to keep.
 
 ---
 
@@ -195,7 +195,7 @@ Plan 19's acceptance criteria are the binding list. The product-level summary: a
 2. See today's daily note instantly, offline or online.
 3. Edit any note — including inserting a `[[wiki link]]` via autocomplete — with no markdown corruption, and find the edit in search and backlinks without restarting.
 4. Lock the phone mid-thought and lose nothing, even if iOS kills the app.
-5. See the edit on their Mac after the next sync — and when the rare conflict happens, keep working on everything else while the conflicted note waits for desktop review.
+5. See the edit on their Mac after the next sync — and when the rare conflict happens, choose what to keep on the phone while everything else keeps syncing.
 6. Open the Files app and see their notes as portable markdown.
 
 And the codebase succeeds if audio memos, share-sheet capture, and the AI copilot can be added in later waves **without** re-architecting the workspace, sync, privacy enforcement, or navigation.
@@ -209,7 +209,7 @@ Beyond Plan 19's settled scope, these remain genuinely open:
 1. **App Group + capture-inbox schema** for the audio/share waves: file layout, ingest semantics, `private: true` handling at the inbox boundary, and when to provision the App Group + extension targets in the Xcode template (cheap early, annoying to retrofit — but not needed for v1).
 2. **Daily-note merge driver timing**: when does append/append auto-merge graduate from Plan 12 "future work" to required, given foreground-only mobile sync multiplies conflict frequency?
 3. **Semantic search graduation** (inherited from the indexing strategy): what battery/storage/latency evidence gates local embeddings on iOS, and does sqlite-vec/fastembed ever run there or does mobile stay lexical until a different runtime appears?
-4. **Mobile conflict resolution**: how long is "resolve on desktop" acceptable — and if AI-assisted merge arrives first, how does mobile apply resolutions that require BYOK calls (the sync strategy's open question)?
+4. **AI-assisted conflict resolution**: if AI-assisted merge arrives, how does mobile apply resolutions that require BYOK calls (the sync strategy's open question)?
 5. **iPad posture**: how long does "big phone" hold before a two-pane layout is worth building?
 6. **Deep links and the command registry**: when external automation (shortcuts, widgets) arrives, does `reflect://` map onto the same typed command layer as desktop?
 7. **A formatting toolbar**: does on-device editing (spike B and beyond) demonstrate the need for a webview-drawn accessory bar, and what minimal item set earns its place?


### PR DESCRIPTION
## Problem

Conflicted notes on iOS opened in the same protected raw-marker view as desktop, but the mobile branch of `SyncConflictNotice` hid the resolver actions and told users to review the note on desktop. The mobile sync status copy reinforced that by saying conflicted notes had to be opened on desktop to resolve.

That meant the safe raw-marker resolver already used by desktop was unavailable on mobile even though it is not desktop-specific.

## Before -> After

| Surface | Before | After |
| --- | --- | --- |
| Conflicted mobile note | Protected raw source plus “review on desktop” copy | Protected raw source plus mine/theirs/both buttons |
| Mobile backup status | “open it/them on desktop to resolve” | “open it/them to choose what to keep” |
| Mobile docs/tests | Conflict resolution documented and asserted as desktop-only | Mobile resolution documented and asserted as supported |

## Changes

1. Removed the mobile-only no-action branch in `SyncConflictNotice` so iOS uses the same `useConflictResolution` path as desktop.
2. Kept the protected raw-note display for conflict markers, but render the resolver controls as touch-sized stacked buttons on mobile.
3. Updated mobile sync status/settings copy so it points users to open the conflicted note instead of leaving for desktop.
4. Updated mobile conflict tests and product docs that previously encoded “desktop-only” as the intended behavior.

## Tests

- `pnpm --filter @reflect/desktop test src/components/sync-conflict-notice.test.tsx src/mobile/note-conflict.test.tsx src/mobile/sync-status.test.ts src/mobile/settings-sheet.test.tsx`
  - Pins desktop resolver buttons, mobile resolver buttons, the protected mobile note flow, and the revised mobile status/settings copy.
- `pnpm check`
  - Passed typecheck and lint. Lint still reports the repo’s existing max-lines warnings.

## Risk / Rollout

No migrations or sync engine changes. The mobile UI now calls the same raw-marker read/write/reindex path already used on desktop, so the main risk is presentation on small screens; the buttons are rendered as a stacked touch layout on mobile while preserving the protected raw source view.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and copy only; resolution still uses the existing desktop raw-marker write/reindex path with no sync-engine or migration changes.
> 
> **Overview**
> **Enables on-device sync conflict resolution on mobile** by removing the `SyncConflictNotice` branch that showed a “review on desktop” banner with no actions. Mobile now uses the same `useConflictResolution` path as desktop, with **touch-sized stacked buttons** (`h-9`, grid layout) while keeping the protected raw-marker view.
> 
> **Mobile sync copy** in `mobileSyncStatus` and settings now says to open conflicted notes and **choose what to keep**, not to resolve on desktop.
> 
> **Tests and product docs** (Plan 19, mobile grounding brief, porting notes) are updated so conflict resolution is documented as **in scope on mobile**, not desktop-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85c233ec1c194ea0f2dd881da040c96fc97fc7b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->