### PR TITLE
Let iOS create iCloud graphs

### DIFF
--- a/apps/desktop/src/components/graph-chooser.tsx
+++ b/apps/desktop/src/components/graph-chooser.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useGraphColors } from '@/hooks/use-graph-colors'
+import { cleanGraphName, graphNameFromRoot, isGraphNameTaken } from '@/lib/graph-names'
 import { graphColorCss } from '@/lib/graph-colors'
 import { cn } from '@/lib/utils'
 import { useGraph } from '@/providers/graph-provider'
@@ -13,26 +14,6 @@ import { useGraph } from '@/providers/graph-provider'
 /** iCloud is a real option only in the macOS shell. */
 function isIcloudCapablePlatform(): boolean {
   return import.meta.env.TAURI_ENV_PLATFORM === 'darwin'
-}
-
-/** `/…/Documents/My Notes` → `My Notes`. */
-function graphNameFromRoot(root: string): string {
-  return root.split('/').filter(Boolean).at(-1) ?? 'your notes'
-}
-
-/**
- * A folder name safe to create inside the container: no separators, no
- * leading dot, trimmed. Anything else disables Create rather than guessing.
- */
-function cleanGraphName(raw: string): string | null {
-  const trimmed = raw.trim()
-  if (trimmed.length === 0 || trimmed.startsWith('.')) {
-    return null
-  }
-  if (/[/\\:]/.test(trimmed)) {
-    return null
-  }
-  return trimmed
 }
 
 /**
@@ -182,9 +163,7 @@ function IcloudCard({
   const cleanName = cleanGraphName(name)
   // macOS folder names are case-insensitive — a same-named create would
   // land inside the existing graph instead of next to it.
-  const nameTaken =
-    cleanName !== null &&
-    existing.some((root) => graphNameFromRoot(root).toLowerCase() === cleanName.toLowerCase())
+  const nameTaken = cleanName !== null && isGraphNameTaken(cleanName, existing)
 
   async function create(): Promise<void> {
     if (status?.documentsRoot == null || cleanName === null || nameTaken) {
@@ -232,7 +211,7 @@ function IcloudCard({
                 onClick={() => open(root)}
               >
                 <Cloud aria-hidden strokeWidth={1.75} />
-                <span className="truncate">{graphNameFromRoot(root)}</span>
+                <span className="truncate">{graphNameFromRoot(root, 'your notes')}</span>
               </Button>
             </li>
           ))}

--- a/apps/desktop/src/lib/graph-names.ts
+++ b/apps/desktop/src/lib/graph-names.ts
@@ -1,0 +1,29 @@
+/** `/.../Documents/My Notes` -> `My Notes`. */
+export function graphNameFromRoot(root: string, fallback = ''): string {
+  return root.split('/').filter(Boolean).at(-1) ?? fallback
+}
+
+/**
+ * A graph folder name safe to create inside an app-owned container: no
+ * separators, no leading dot, trimmed.
+ */
+export function cleanGraphName(raw: string): string | null {
+  const trimmed = raw.trim()
+  if (trimmed.length === 0 || trimmed.startsWith('.')) {
+    return null
+  }
+  if (/[/\\:]/.test(trimmed)) {
+    return null
+  }
+  return trimmed
+}
+
+/** Case-insensitive graph-name collision check for macOS/iOS containers. */
+export function isGraphNameTaken(cleanName: string, roots: readonly string[]): boolean {
+  return roots.some((root) => graphNameFromRoot(root).toLowerCase() === cleanName.toLowerCase())
+}
+
+/** Absolute graph root for a cleaned folder name inside a container's Documents directory. */
+export function graphRootForName(documentsRoot: string, cleanName: string): string {
+  return `${documentsRoot}/${cleanName}`
+}

--- a/apps/desktop/src/mobile/onboarding-screen.test.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.test.tsx
@@ -7,7 +7,7 @@ import { MobileOnboardingScreen } from './onboarding-screen'
 vi.mock('@tauri-apps/plugin-http', () => ({ fetch: vi.fn() }))
 const httpFetch = vi.mocked(tauriFetch)
 
-const completeOnboarding = vi.hoisted(() => vi.fn(async (_kind: string) => {}))
+const completeOnboarding = vi.hoisted(() => vi.fn(async (_kind: string, _root?: string) => {}))
 const storageInfo = vi.hoisted<{ current: unknown }>(() => ({ current: null }))
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({ mobileStorageInfo: storageInfo.current, completeOnboarding }),
@@ -62,16 +62,19 @@ afterEach(() => {
 })
 
 describe('MobileOnboardingScreen', () => {
-  it('leads with iCloud Drive and creates the container graph', async () => {
+  it('leads with iCloud Drive and creates the named container graph', async () => {
     render(<MobileOnboardingScreen />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Store in iCloud Drive' }))
+    expect(screen.getByRole('heading', { name: 'iCloud Drive' })).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
 
-    await waitFor(() => expect(completeOnboarding).toHaveBeenCalledWith('icloud'))
+    await waitFor(() =>
+      expect(completeOnboarding).toHaveBeenCalledWith('icloud', '/iCloud/Documents/Notes'),
+    )
     expect(cloned).toEqual([])
   })
 
-  it('lists every container graph and opens the tapped one', async () => {
+  it('lists every container graph while keeping create available', async () => {
     setStorage({
       localRoot: '/Documents',
       icloudDocumentsRoot: '/iCloud/Documents',
@@ -79,14 +82,31 @@ describe('MobileOnboardingScreen', () => {
     })
     render(<MobileOnboardingScreen />)
 
-    expect(screen.getByText('We found these notes in your iCloud Drive.')).toBeTruthy()
-    // Existing graphs replace the create action — a fresh directory next to
-    // your notes is a desktop decision, not a first-run tap.
-    expect(screen.queryByRole('button', { name: 'Store in iCloud Drive' })).toBeNull()
-    fireEvent.click(screen.getByRole('button', { name: 'Open “Work”' }))
+    expect(screen.getByText('Open an existing set of notes, or create another.')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Notes' })).toBeTruthy()
+    expect((screen.getByRole('button', { name: 'Create' }) as HTMLButtonElement).disabled).toBe(
+      true,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Work' }))
 
     await waitFor(() =>
       expect(completeOnboarding).toHaveBeenCalledWith('icloud', '/iCloud/Documents/Work'),
+    )
+  })
+
+  it('creates a new iCloud graph alongside existing ones', async () => {
+    setStorage({
+      localRoot: '/Documents',
+      icloudDocumentsRoot: '/iCloud/Documents',
+      icloudGraphRoots: ['/iCloud/Documents/Notes'],
+    })
+    render(<MobileOnboardingScreen />)
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Journal' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() =>
+      expect(completeOnboarding).toHaveBeenCalledWith('icloud', '/iCloud/Documents/Journal'),
     )
   })
 
@@ -103,7 +123,7 @@ describe('MobileOnboardingScreen', () => {
     setStorage({ localRoot: '/Documents', icloudDocumentsRoot: null, icloudGraphRoots: [] })
     render(<MobileOnboardingScreen />)
 
-    expect(screen.queryByRole('button', { name: 'Store in iCloud Drive' })).toBeNull()
+    expect(screen.queryByRole('heading', { name: 'iCloud Drive' })).toBeNull()
     expect(
       screen.getByText('Sign in to iCloud on this device to sync notes with iCloud Drive.'),
     ).toBeTruthy()

--- a/apps/desktop/src/mobile/onboarding-screen.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from 'react'
+import { useId, useState, type ReactElement } from 'react'
 import {
   getGithubToken,
   githubRemoteUrl,
@@ -6,11 +6,18 @@ import {
   ReflectError,
   type GithubUser,
 } from '@reflect/core'
+import { Cloud, FolderOpen, GitBranch, HardDrive, Plus } from 'lucide-react'
 import { InlineAlert } from '@/components/inline-alert'
 import { GithubAuthStep } from '@/components/settings/github-auth-step'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useAsyncAction } from '@/hooks/use-async-action'
+import {
+  cleanGraphName,
+  graphNameFromRoot,
+  graphRootForName,
+  isGraphNameTaken,
+} from '@/lib/graph-names'
 import { parseRepoInput } from '@/lib/github-repos'
 import { providerFetch } from '@/lib/provider-fetch'
 import { useGraph } from '@/providers/graph-provider'
@@ -24,33 +31,44 @@ type Step = 'choose' | 'auth' | 'repo'
  *
  * iCloud Drive leads (Plan 21): it is the primary way a graph syncs between
  * iPhone and Mac, so the hero block lists every graph already in the app's
- * iCloud container (one tap opens it — the container can hold several), or a
- * single "Store in iCloud Drive" when the container is empty. **Keep notes
- * on this device** opens the app-sandbox root instead (and is promoted to
- * the only storage button when iCloud is unavailable). Git users can still
- * connect from the **Sync with GitHub instead** link: the shared device flow
- * ({@link GithubAuthStep}), then a clone *straight into* the local root —
- * `git_clone` refuses a non-empty directory, so this only works while that
- * root is untouched, which is exactly why the provider defers opening until
- * now. Every path ends in `completeOnboarding(kind, root)`, which opens the
- * chosen root and records the flag + storage kind + graph name.
+ * iCloud container (one tap opens it — the container can hold several), plus
+ * a create row for a new container graph. **Keep notes on this device** opens
+ * the app-sandbox root instead (and is promoted to the only storage button
+ * when iCloud is unavailable). Git users can still connect from the **Sync
+ * with GitHub instead** link: the shared device flow ({@link GithubAuthStep}),
+ * then a clone *straight into* the local root — `git_clone` refuses a
+ * non-empty directory, so this only works while that root is untouched, which
+ * is exactly why the provider defers opening until now. Every path ends in
+ * `completeOnboarding(kind, root)`, which opens the chosen root and records
+ * the flag + storage kind + graph name.
  */
 export function MobileOnboardingScreen(): ReactElement {
   const { mobileStorageInfo, completeOnboarding } = useGraph()
   const action = useAsyncAction()
   const [step, setStep] = useState<Step>('choose')
+  const [icloudName, setIcloudName] = useState('Notes')
   const [repoInput, setRepoInput] = useState('')
   const [user, setUser] = useState<GithubUser | null>(null)
+  const icloudNameId = useId()
 
-  const icloudReady = mobileStorageInfo?.icloudDocumentsRoot != null
+  const icloudDocumentsRoot = mobileStorageInfo?.icloudDocumentsRoot ?? null
+  const icloudReady = icloudDocumentsRoot !== null
   const icloudGraphs = mobileStorageInfo?.icloudGraphRoots ?? []
+  const cleanIcloudName = cleanGraphName(icloudName)
+  const icloudNameTaken =
+    cleanIcloudName !== null && isGraphNameTaken(cleanIcloudName, icloudGraphs)
 
   function openIcloudGraph(root: string): void {
     void action.run(() => completeOnboarding('icloud', root))
   }
 
-  function storeInIcloud(): void {
-    void action.run(() => completeOnboarding('icloud'))
+  function createIcloudGraph(): void {
+    if (icloudDocumentsRoot === null || cleanIcloudName === null || icloudNameTaken) {
+      return
+    }
+    void action.run(() =>
+      completeOnboarding('icloud', graphRootForName(icloudDocumentsRoot, cleanIcloudName)),
+    )
   }
 
   function keepOnDevice(): void {
@@ -88,98 +106,158 @@ export function MobileOnboardingScreen(): ReactElement {
 
   return (
     <div
-      className="flex h-dvh w-screen flex-col justify-center gap-6 px-8"
+      className="flex min-h-dvh w-screen overflow-auto bg-surface-app px-5 text-text"
       style={{
-        paddingTop: 'env(safe-area-inset-top)',
+        paddingTop: 'max(env(safe-area-inset-top), 1.5rem)',
         paddingBottom: 'max(env(safe-area-inset-bottom), 1rem)',
       }}
     >
-      <div className="flex flex-col gap-1.5 text-center">
-        <h1 className="text-lg font-semibold">Welcome to Reflect</h1>
-        <p className="text-sm text-text-muted">
-          {step === 'choose'
-            ? 'Your notes are plain markdown files. Choose where to keep them.'
-            : 'Sign in to GitHub, then choose the repository to download.'}
-        </p>
-      </div>
+      <div className="my-auto flex w-full flex-col gap-6">
+        <div className="flex flex-col gap-1.5 text-center">
+          <h1 className="text-lg font-semibold">Welcome to Reflect</h1>
+          <p className="text-sm text-text-muted">
+            {step === 'choose'
+              ? 'Your notes are plain markdown files. Choose where to keep them.'
+              : 'Sign in to GitHub, then choose the repository to download.'}
+          </p>
+        </div>
 
-      {step === 'choose' ? (
-        <div className="flex flex-col gap-3">
-          {icloudReady && icloudGraphs.length > 0 ? (
-            <div className="flex flex-col gap-1.5">
-              {icloudGraphs.map((root) => {
-                const name = root.split('/').filter(Boolean).at(-1) ?? root
-                return (
-                  <Button key={root} onClick={() => openIcloudGraph(root)} disabled={action.pending}>
-                    {action.pending ? 'Setting up…' : `Open “${name}”`}
-                  </Button>
-                )
-              })}
+        {step === 'choose' ? (
+          <div className="flex flex-col gap-3">
+            {icloudReady ? (
+              <section className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-4">
+                <div className="flex items-start gap-3">
+                  <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                    <Cloud aria-hidden className="size-4" strokeWidth={1.75} />
+                  </div>
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <div className="flex items-center gap-2">
+                      <h2 className="text-sm font-semibold">iCloud Drive</h2>
+                      <span className="rounded-full bg-secondary px-2 py-0.5 text-[11px] font-medium text-secondary-foreground">
+                        Recommended
+                      </span>
+                    </div>
+                    <p className="text-xs text-text-muted">
+                      {icloudGraphs.length > 0
+                        ? 'Open an existing set of notes, or create another.'
+                        : 'Syncs with Reflect on your other devices.'}
+                    </p>
+                  </div>
+                </div>
+
+                {icloudGraphs.length > 0 ? (
+                  <ul className="flex flex-col gap-1.5">
+                    {icloudGraphs.map((root) => (
+                      <li key={root}>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          className="w-full justify-start"
+                          onClick={() => openIcloudGraph(root)}
+                          disabled={action.pending}
+                        >
+                          <FolderOpen aria-hidden strokeWidth={1.75} />
+                          <span className="truncate">{graphNameFromRoot(root, root)}</span>
+                        </Button>
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+
+                <div className="flex flex-col gap-1.5">
+                  <label htmlFor={icloudNameId} className="text-xs font-medium text-text-secondary">
+                    Name
+                  </label>
+                  <div className="flex gap-2">
+                    <Input
+                      id={icloudNameId}
+                      value={icloudName}
+                      onChange={(event) => setIcloudName(event.target.value)}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter') {
+                          createIcloudGraph()
+                        }
+                      }}
+                      aria-invalid={icloudNameTaken}
+                      disabled={action.pending}
+                    />
+                    <Button
+                      type="button"
+                      className="shrink-0"
+                      onClick={createIcloudGraph}
+                      disabled={action.pending || cleanIcloudName === null || icloudNameTaken}
+                    >
+                      <Plus aria-hidden strokeWidth={1.75} />
+                      {action.pending ? 'Setting up…' : 'Create'}
+                    </Button>
+                  </div>
+                </div>
+                {icloudNameTaken ? (
+                  <p className="text-xs text-destructive">
+                    That name already exists in iCloud Drive.
+                  </p>
+                ) : null}
+              </section>
+            ) : null}
+
+            <Button
+              variant={icloudReady ? 'outline' : 'default'}
+              onClick={keepOnDevice}
+              disabled={action.pending}
+            >
+              <HardDrive aria-hidden strokeWidth={1.75} />
+              {action.pending ? 'Setting up…' : 'Keep notes on this device'}
+            </Button>
+            {!icloudReady ? (
               <p className="text-center text-xs text-text-muted">
-                {icloudGraphs.length > 1
-                  ? 'We found these notes in your iCloud Drive.'
-                  : 'We found notes in your iCloud Drive.'}
+                Sign in to iCloud on this device to sync notes with iCloud Drive.
               </p>
-            </div>
-          ) : icloudReady ? (
-            <div className="flex flex-col gap-1.5">
-              <Button onClick={storeInIcloud} disabled={action.pending}>
-                {action.pending ? 'Setting up…' : 'Store in iCloud Drive'}
-              </Button>
-              <p className="text-center text-xs text-text-muted">
-                Recommended — syncs with Reflect on your other devices.
-              </p>
-            </div>
-          ) : null}
-          <Button
-            variant={icloudReady ? 'outline' : 'default'}
-            onClick={keepOnDevice}
-            disabled={action.pending}
-          >
-            {action.pending ? 'Setting up…' : 'Keep notes on this device'}
-          </Button>
-          {!icloudReady ? (
-            <p className="text-center text-xs text-text-muted">
-              Sign in to iCloud on this device to sync notes with iCloud Drive.
-            </p>
-          ) : null}
-          <LinkButton onClick={() => setStep('auth')} disabled={action.pending}>
-            Sync with GitHub instead
-          </LinkButton>
-        </div>
-      ) : step === 'auth' ? (
-        <div className="flex flex-col gap-3">
-          <GithubAuthStep
-            onAuthed={(authedUser) => {
-              setUser(authedUser)
-              setStep('repo')
-            }}
-          />
-          <LinkButton onClick={() => setStep('choose')} disabled={action.pending}>
-            Back
-          </LinkButton>
-        </div>
-      ) : (
-        <div className="flex flex-col gap-3">
-          <label className="flex flex-col gap-1">
-            <span className="text-xs font-medium text-text-secondary">Backup repository</span>
-            <Input
-              autoFocus
-              value={repoInput}
-              onChange={(event) => setRepoInput(event.target.value)}
-              placeholder={user !== null ? `${user.login}/…` : 'owner/name'}
+            ) : null}
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setStep('auth')}
+              disabled={action.pending}
+            >
+              <GitBranch aria-hidden strokeWidth={1.75} />
+              Sync with GitHub instead
+            </Button>
+          </div>
+        ) : step === 'auth' ? (
+          <div className="flex flex-col gap-3">
+            <GithubAuthStep
+              onAuthed={(authedUser) => {
+                setUser(authedUser)
+                setStep('repo')
+              }}
             />
-          </label>
-          <Button onClick={downloadAndOpen} disabled={action.pending}>
-            {action.pending ? 'Downloading…' : 'Download & open'}
-          </Button>
-          <LinkButton onClick={() => setStep('choose')} disabled={action.pending}>
-            Back
-          </LinkButton>
-        </div>
-      )}
+            <LinkButton onClick={() => setStep('choose')} disabled={action.pending}>
+              Back
+            </LinkButton>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <label className="flex flex-col gap-1">
+              <span className="text-xs font-medium text-text-secondary">Backup repository</span>
+              <Input
+                autoFocus
+                value={repoInput}
+                onChange={(event) => setRepoInput(event.target.value)}
+                placeholder={user !== null ? `${user.login}/…` : 'owner/name'}
+              />
+            </label>
+            <Button onClick={downloadAndOpen} disabled={action.pending}>
+              <GitBranch aria-hidden strokeWidth={1.75} />
+              {action.pending ? 'Downloading…' : 'Download & open'}
+            </Button>
+            <LinkButton onClick={() => setStep('choose')} disabled={action.pending}>
+              Back
+            </LinkButton>
+          </div>
+        )}
 
-      {action.error !== null ? <InlineAlert tone="error">{action.error}</InlineAlert> : null}
+        {action.error !== null ? <InlineAlert tone="error">{action.error}</InlineAlert> : null}
+      </div>
     </div>
   )
 }

--- a/apps/desktop/src/mobile/settings-sheet.test.tsx
+++ b/apps/desktop/src/mobile/settings-sheet.test.tsx
@@ -182,6 +182,26 @@ describe('SettingsSheet', () => {
     )
   })
 
+  it('creates a new iCloud graph through the switcher', async () => {
+    graphState.mobileStorageKind = 'local'
+    storageInfo.current = {
+      localRoot: '/Documents',
+      icloudDocumentsRoot: '/iCloud/Documents',
+      icloudGraphRoots: [],
+    }
+    const user = userEvent.setup()
+    mount()
+
+    expect(await screen.findByText('Switch graph')).toBeTruthy()
+    await user.clear(screen.getByLabelText('New iCloud graph'))
+    await user.type(screen.getByLabelText('New iCloud graph'), 'Journal')
+    await user.click(screen.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() =>
+      expect(completeOnboarding).toHaveBeenCalledWith('icloud', '/iCloud/Documents/Journal'),
+    )
+  })
+
   it('offers no switcher when there is nowhere else to go', async () => {
     // A local graph with an empty container: the open graph is the only one.
     graphState.mobileStorageKind = 'local'

--- a/apps/desktop/src/mobile/settings-sheet.tsx
+++ b/apps/desktop/src/mobile/settings-sheet.tsx
@@ -1,6 +1,6 @@
-import { useState, type ReactElement } from 'react'
+import { useId, useState, type ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Settings } from 'lucide-react'
+import { Plus, Settings } from 'lucide-react'
 import {
   errorMessage,
   hasBridge,
@@ -11,7 +11,14 @@ import {
 import { InlineAlert } from '@/components/inline-alert'
 import { Button } from '@/components/ui/button'
 import { Drawer, DrawerContent, DrawerTitle, DrawerTrigger } from '@/components/ui/drawer'
+import { Input } from '@/components/ui/input'
 import { useAppVersion } from '@/hooks/use-app-version'
+import {
+  cleanGraphName,
+  graphNameFromRoot,
+  graphRootForName,
+  isGraphNameTaken,
+} from '@/lib/graph-names'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useMobileSyncStatus } from '@/mobile/use-sync-status'
 import { useGraph } from '@/providers/graph-provider'
@@ -32,8 +39,9 @@ interface SwitchTarget {
  * status (the same engine state the pill shows), and a Disconnect. Initial
  * connecting happens in onboarding. **Switch graph** lists every other graph
  * this device can open — the container can hold several, plus the on-device
- * root — and reuses the onboarding open-and-persist flow; storage roots are
- * re-derived when the sheet opens (container paths must never be cached).
+ * root — and can create another iCloud graph through the same
+ * open-and-persist flow; storage roots are re-derived when the sheet opens
+ * (container paths must never be cached).
  */
 export function SettingsSheet(): ReactElement {
   const { graph, mobileStorageKind, completeOnboarding } = useGraph()
@@ -43,6 +51,8 @@ export function SettingsSheet(): ReactElement {
   const [disconnecting, setDisconnecting] = useState(false)
   const [switching, setSwitching] = useState(false)
   const [switchError, setSwitchError] = useState<string | null>(null)
+  const [newGraphName, setNewGraphName] = useState('Notes')
+  const newGraphNameId = useId()
 
   const { data: notes } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'mobile-note-count'],
@@ -63,7 +73,7 @@ export function SettingsSheet(): ReactElement {
         targets.push({
           kind: 'icloud',
           root,
-          label: root.split('/').filter(Boolean).at(-1) ?? root,
+          label: graphNameFromRoot(root, root),
         })
       }
     }
@@ -71,6 +81,14 @@ export function SettingsSheet(): ReactElement {
       targets.push({ kind: 'local', root: storage.localRoot, label: 'This device' })
     }
   }
+  const icloudDocumentsRoot = storage?.icloudDocumentsRoot ?? null
+  const icloudGraphRoots = storage?.icloudGraphRoots ?? []
+  const cleanNewGraphName = cleanGraphName(newGraphName)
+  const newGraphNameTaken =
+    cleanNewGraphName !== null && isGraphNameTaken(cleanNewGraphName, icloudGraphRoots)
+  const canCreateIcloudGraph =
+    icloudDocumentsRoot !== null && cleanNewGraphName !== null && !newGraphNameTaken
+  const showGraphSwitcher = targets.length > 0 || icloudDocumentsRoot !== null
 
   function switchTo(target: SwitchTarget): void {
     setSwitching(true)
@@ -85,6 +103,17 @@ export function SettingsSheet(): ReactElement {
         setSwitchError(errorMessage(err))
       },
     )
+  }
+
+  function createIcloudGraph(): void {
+    if (icloudDocumentsRoot === null || !canCreateIcloudGraph || cleanNewGraphName === null) {
+      return
+    }
+    switchTo({
+      kind: 'icloud',
+      root: graphRootForName(icloudDocumentsRoot, cleanNewGraphName),
+      label: cleanNewGraphName,
+    })
   }
 
   const backup = sync?.backup ?? null
@@ -131,7 +160,7 @@ export function SettingsSheet(): ReactElement {
               value={mobileStorageKind === 'icloud' ? 'iCloud Drive' : 'This device'}
             />
           ) : null}
-          {targets.length > 0 ? (
+          {showGraphSwitcher ? (
             <div className="py-2.5">
               <dt className="text-text-muted">Switch graph</dt>
               <dd className="mt-2 flex flex-col gap-1.5">
@@ -146,6 +175,45 @@ export function SettingsSheet(): ReactElement {
                     {switching ? 'Switching…' : target.label}
                   </Button>
                 ))}
+                {icloudDocumentsRoot !== null ? (
+                  <div className="flex flex-col gap-1.5 pt-1">
+                    <label
+                      htmlFor={newGraphNameId}
+                      className="text-xs font-medium text-text-secondary"
+                    >
+                      New iCloud graph
+                    </label>
+                    <div className="flex gap-2">
+                      <Input
+                        id={newGraphNameId}
+                        value={newGraphName}
+                        onChange={(event) => setNewGraphName(event.target.value)}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter') {
+                            createIcloudGraph()
+                          }
+                        }}
+                        aria-invalid={newGraphNameTaken}
+                        disabled={switching}
+                      />
+                      <Button
+                        type="button"
+                        size="sm"
+                        className="shrink-0"
+                        disabled={switching || !canCreateIcloudGraph}
+                        onClick={createIcloudGraph}
+                      >
+                        <Plus aria-hidden strokeWidth={1.75} />
+                        {switching ? 'Creating…' : 'Create'}
+                      </Button>
+                    </div>
+                    {newGraphNameTaken ? (
+                      <span className="text-xs text-destructive">
+                        That name already exists in iCloud Drive.
+                      </span>
+                    ) : null}
+                  </div>
+                ) : null}
               </dd>
               {switchError !== null ? (
                 <InlineAlert tone="error">{switchError}</InlineAlert>

--- a/apps/desktop/src/providers/graph-provider.test.tsx
+++ b/apps/desktop/src/providers/graph-provider.test.tsx
@@ -54,8 +54,17 @@ function installFakeBridge(): void {
   let generation = 0
   setBridge({
     invoke: async (command, args) => {
-      invokeLog.push(command === 'graph_open' ? `graph_open:${String(args['path'])}` : command)
+      invokeLog.push(
+        command === 'graph_open' || command === 'graph_create'
+          ? `${command}:${String(args['path'])}`
+          : command,
+      )
       switch (command) {
+        case 'graph_create': {
+          const root = String(args['path'])
+          generation += 1
+          return { root, name: root.split('/').filter(Boolean).at(-1) ?? '', generation }
+        }
         case 'graph_open': {
           if (failOpens) {
             throw { kind: 'io', message: 'cannot open graph' }
@@ -269,6 +278,7 @@ describe('GraphProvider mobile onboarding (Plans 19/21)', () => {
     // directory), and opening the iCloud one would bootstrap + seed it.
     expect(invokeLog).not.toContain(`graph_open:${MOBILE_ROOT}`)
     expect(invokeLog).not.toContain(`graph_open:${ICLOUD_GRAPH}`)
+    expect(invokeLog).not.toContain(`graph_create:${ICLOUD_GRAPH}`)
   })
 
   it('opens the local root and records flag + kind on completeOnboarding(local)', async () => {
@@ -306,6 +316,7 @@ describe('GraphProvider mobile onboarding (Plans 19/21)', () => {
     await waitFor(() => expect(result.current.status).toBe('ready'))
     expect(result.current.graph?.root).toBe(ICLOUD_GRAPH)
     expect(result.current.mobileStorageKind).toBe('icloud')
+    expect(invokeLog).toContain(`graph_create:${ICLOUD_GRAPH}`)
     await waitFor(() => expect(settingsStore['mobileOnboarded']).toBe(true))
     expect(settingsStore['mobileStorage']).toBe('icloud')
     // WHICH graph is remembered by name — never by container path.
@@ -330,7 +341,30 @@ describe('GraphProvider mobile onboarding (Plans 19/21)', () => {
 
     await waitFor(() => expect(result.current.status).toBe('ready'))
     expect(result.current.graph?.root).toBe(`${ICLOUD_ROOT}/Work`)
+    expect(invokeLog).not.toContain(`graph_create:${ICLOUD_ROOT}/Work`)
     await waitFor(() => expect(settingsStore['mobileGraphName']).toBe('Work'))
+  })
+
+  it('creates an explicitly named iCloud graph when it is not already known', async () => {
+    const journalRoot = `${ICLOUD_ROOT}/Journal`
+    storedStorage = {
+      localRoot: MOBILE_ROOT,
+      icloudDocumentsRoot: ICLOUD_ROOT,
+      icloudGraphRoots: [`${ICLOUD_ROOT}/Notes`],
+    }
+    const { result } = renderHook(() => useGraph(), { wrapper: mobileWrapper })
+    await waitFor(() => expect(result.current.needsOnboarding).toBe(true))
+
+    await act(async () => {
+      const done = result.current.completeOnboarding('icloud', journalRoot)
+      await waitFor(() => expect(pendingOpens.has(journalRoot)).toBe(true))
+      resolveOpen(journalRoot)
+      await done
+    })
+
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    expect(invokeLog).toContain(`graph_create:${journalRoot}`)
+    await waitFor(() => expect(settingsStore['mobileGraphName']).toBe('Journal'))
   })
 
   it('rejects completeOnboarding(icloud) when iCloud is unavailable', async () => {

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -467,6 +467,11 @@ export function GraphProvider({
             : 'No graph folder available.',
         )
       }
+      const shouldCreateIcloudRoot =
+        kind === 'icloud' && mobileStorageInfo?.icloudGraphRoots.includes(root) !== true
+      if (shouldCreateIcloudRoot) {
+        await createGraph(root)
+      }
       // Keep the onboarding gate up while the open runs — `openRecent` moves the
       // status to 'opening' synchronously and the onboarding screen shows its own
       // pending state, so the shell never flashes. On failure throw rather than


### PR DESCRIPTION
## Problem

iOS could open known iCloud graphs during first-run setup, but it did not offer a way to create another graph once iCloud already contained notes. The mobile settings graph switcher had the same gap after onboarding. The lower-level mobile completion path also only opened a target root, so a fresh iCloud graph path could point at a directory that did not exist yet.

## Before -> After

| Area | Before | After |
| --- | --- | --- |
| iOS onboarding | Existing iCloud graphs replaced the create action | Existing iCloud graphs remain one-tap, with a name field and Create action below them |
| iOS settings | Switcher listed other existing graphs only | Switcher can create and open a new iCloud graph |
| Mobile graph lifecycle | `completeOnboarding('icloud', root)` assumed the root existed | Unknown iCloud roots are scaffolded with `graph_create` before opening |
| Desktop chooser | Had its own graph-name parsing and validation helpers | Reuses the shared graph-name helper used by iOS |

## Changes

1. Adds `apps/desktop/src/lib/graph-names.ts` for shared graph name parsing, safe-name validation, duplicate checks, and container root construction.
2. Reworks `MobileOnboardingScreen` so iCloud is a compact setup panel: existing container graphs are listed as direct buttons, and a `Name` + `Create` row is always available when iCloud is reachable.
3. Extends the mobile settings sheet graph switcher with a `New iCloud graph` create row.
4. Updates `GraphProvider.completeOnboarding` to call `createGraph` for iCloud roots that are not already known in `mobileStorageInfo.icloudGraphRoots`, then opens and persists the selected graph as before.
5. Updates desktop graph chooser to use the shared name helper without changing its behavior.

## Tests

- `src/mobile/onboarding-screen.test.tsx` now covers creating the default iCloud graph, keeping Create visible beside existing graphs, and creating another named graph.
- `src/mobile/settings-sheet.test.tsx` covers creating a new iCloud graph through the post-onboarding switcher.
- `src/providers/graph-provider.test.tsx` covers `graph_create` for default and explicitly named unknown iCloud roots, and avoids creating known existing roots.
- Existing desktop graph chooser tests still pass against the shared helper.

## Verification

- `pnpm test --run src/mobile/onboarding-screen.test.tsx` from `apps/desktop` passed.
- `pnpm test --run src/mobile/settings-sheet.test.tsx` from `apps/desktop` passed.
- `pnpm test --run src/providers/graph-provider.test.tsx` from `apps/desktop` passed.
- `pnpm test --run src/components/graph-chooser.test.tsx` from `apps/desktop` passed.
- `pnpm check` passed. Existing max-lines warnings remain in pre-existing large files.
- Vite dev server started on `http://127.0.0.1:1421/` because `1420` was already in use; `curl -I 'http://127.0.0.1:1421/?platform=ios'` returned `200 OK`.

## Risk / Rollout

No migrations or data-shape changes. The main behavior change is that iOS now creates an iCloud graph directory before opening unknown iCloud roots. Existing iCloud graphs still open without an extra create call when they are present in the mobile storage listing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mobile graph onboarding lifecycle (create-then-open for new iCloud paths) but is gated on the storage listing and covered by provider/UI tests; no schema migrations.
> 
> **Overview**
> **iOS** can now **create** iCloud container graphs—not only open ones already listed. Onboarding shows an iCloud panel with existing graphs as buttons plus a **Name** + **Create** row (even when notes already exist). The settings **Switch graph** section adds the same create flow for post-onboarding.
> 
> `completeOnboarding('icloud', root)` now calls **`graph_create`** when `root` is not in `mobileStorageInfo.icloudGraphRoots`, then opens as before. Known roots skip create.
> 
> Graph naming helpers move to **`lib/graph-names.ts`** (`cleanGraphName`, `isGraphNameTaken`, `graphRootForName`, etc.); desktop **graph chooser** imports them with unchanged behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2629eb1af77ee0ecfff5eb9699bed4ba8096edf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->