### PR TITLE
docs: true up the mobile grounding brief after Plan 21

### DIFF
--- a/docs/plans/00-overview.md
+++ b/docs/plans/00-overview.md
@@ -69,7 +69,7 @@ before the editor, and the editor lands before search/AI.
 | 09 | [Semantic search & local embeddings](09-semantic-search-and-embeddings.md) | Local embedding runtime (Rust), chunking, `sqlite-vec`, incremental re-embed, retrieval layer |
 | 10 | [AI copilot sidebar](10-ai-copilot-sidebar.md) | BYOK providers, keychain secrets, read-only chat route over `search_notes`/`read_note`, durable chat history, `private: true` hard-block; patchsets deferred |
 | 11 | [Link capture](11-link-capture.md) | Chrome extension → native-messaging sidecar → desktop capture inbox, screenshots, meta/BYOK enrichment, dedicated capture notes + daily-note `[[Links]]` |
-| 12 | [Backup & sync (GitHub-only)](12-backup-and-sync.md) | GitHub/Git backup + restore (the only supported remote), Git-native conflict surface, manual review, checkpoints; file-sync providers unsupported |
+| 12 | [Backup & sync (GitHub-only)](12-backup-and-sync.md) | GitHub/Git backup + restore, Git-native conflict surface, manual review, checkpoints. Written when file-sync providers were unsupported — Plan 21 later shipped iCloud Drive as the primary sync path; Git remains the self-managed alternative (never both on one graph) |
 | 13 | [Import / export / portability](13-import-export-portability.md) | **Closed by decision.** Markdown files are the portability surface; no JSON/HTML/ZIP export or Obsidian/folder import suite is planned |
 | 14 | [CLI (read/discovery)](14-cli-read-discovery.md) | `reflect today`, `reflect search`, `reflect show`, path lookup |
 | 15 | [Hardening, packaging & OSS release](15-hardening-packaging-release.md) | a11y, perf budgets, signing/notarization, MIT + docs, onboarding, release pipeline |
@@ -78,7 +78,7 @@ before the editor, and the editor lands before search/AI.
 | 18 | [Tasks](18-tasks.md) | **Post-release add-on.** Round-checkbox (`+ [ ]`) tasks as a rebuildable projection: interactive editor checkboxes, Tasks view (Overdue/Today/Upcoming), `[[date]]`/daily scheduling, guarded toggle write-back, square checklists excluded |
 | 19 | [Mobile companion](19-mobile.md) | **In progress.** iOS target of the existing Tauri app: mobile root gate, fixed graph root, onboarding, Daily/All shell, editable notes, keyboard plugin; device validation + store hardening remain |
 | 20 | [Asset descriptions](20-asset-descriptions.md) | **Post-release add-on.** AI-generated `.reflect.md` description files for referenced, non-private images/PDFs under `assets/`; BYOK, privacy-gated, manual backfill |
-| 21 | [iCloud Drive sync](21-icloud-drive-sync.md) | **In progress.** iCloud Drive as the primary consumer sync path: graphs in the app's iCloud container, one marker-based conflict surface with a deterministic resolution ladder, `.reflect/`/`.git/` sync-exclusion, iCloud-first mobile onboarding; git remotes stay the power-user/backup path |
+| 21 | [iCloud Drive sync](21-icloud-drive-sync.md) | **Shipped (2026-07-04).** iCloud Drive as the primary consumer sync path: graphs in the app's iCloud container, deterministic resolution ladder over per-device shadow bases (markers as the fallback), `.reflect/`/`.git/` sync-exclusion, iCloud-first onboarding on both platforms with multi-graph lists + the mobile switcher; git remotes stay the self-managed path. AI-assisted resolution deferred |
 
 ## Milestone map
 
@@ -125,12 +125,13 @@ The highest-severity risks surfaced reviewing this plan, with where they're hand
    ([docs/spikes/meowdown-wiki-links.md](../spikes/meowdown-wiki-links.md)). Residual: it's
    pre-1.0 (we own the extension code, pin versions); CodeMirror-6 live-preview stays the
    documented fallback. *Licensing is resolved — meowdown is first-party MIT.*
-2. **A graph inside a cloud-sync folder corrupts the index and fights GitHub.** Remote
-   sync is **GitHub-only** (file-sync providers are unsupported by design — Plan 12); but a
-   user may still *place* their graph in iCloud/Dropbox, which can replace the SQLite
-   `-wal`/`-shm` mid-write. Mitigation: detect cloud roots + warn/recommend a non-synced
-   path, exclude `.reflect/`, and relocate the index to app-data as an escape hatch
-   (Plan 04; detection in Plan 02).
+2. **A cloud-sync folder can corrupt the index or fight a Git remote.** Originally
+   mitigated by refusing file-sync providers outright; since Plan 21 shipped, iCloud
+   Drive is the *supported primary* path and the risk is managed instead of avoided:
+   `.reflect/` (and `.git/`) are sync-excluded so the SQLite `-wal`/`-shm` never ride
+   the provider, atomic-write temps stage inside `.reflect/tmp/`, and **iCloud and a
+   Git remote are mutually exclusive per graph**. Third-party folder sync (Dropbox et
+   al.) remains unsupported: same hazards, none of Plan 21's machinery.
 3. **Durable macOS folder access** (TCC prompts; security-scoped bookmarks if sandboxed) —
    the in-graph decision depends on it; spike + handle in Plans 01/02/15.
 4. **Bespoke Kysely-over-IPC dialect** is non-trivial; keep zod to real boundaries and keep
@@ -152,8 +153,8 @@ they are not re-litigated per phase:
 - **Secrets live in the OS keychain.** Never in markdown, Git, or `.reflect/`.
 - **Keyboard-native.** Every core workflow reachable from the keyboard.
 - **Portable data from day one.** The graph folder itself is the export; backup must be
-  free, via **GitHub only**. File-sync providers (iCloud/Dropbox/Drive) are unsupported
-  for sync by design.
+  free. Sync is iCloud Drive (the primary path since Plan 21) or a Git remote — one per
+  graph, never both; other file-sync providers (Dropbox/Drive) remain unsupported.
 - **No Electron, no web app, Mac-first.** Tauri shell; iOS/Windows later.
 - **MIT open-source core.** Write as if the code is public and will be critiqued. The
   editor [meowdown](https://github.com/prosekit/meowdown) is **first-party** (owned by the

--- a/docs/plans/12-backup-and-sync.md
+++ b/docs/plans/12-backup-and-sync.md
@@ -134,7 +134,9 @@ present) · `Backup failed` (action needed). Git mechanics never surface.
      external-change reconciliation (clean buffer reloads; dirty buffer prompts).
    - **Daily notes are the common collision** (two devices, same day). Markers +
      keep-both cover it first wave; future: a custom merge driver (libgit2 registers
-     them in code) for append-friendly merging of `daily/*.md`.
+     them in code) for append-friendly merging of `daily/*.md`. *(That future work
+     shipped via [Plan 21](./21-icloud-drive-sync.md) as the resolution ladder's
+     append-union rung — on the iCloud path, not as a libgit2 merge driver.)*
 
 5. **Guardrails:**
    - Default to **creating a private repo**; choosing a public repo blocks on an explicit

--- a/docs/plans/16-generic-git-remotes.md
+++ b/docs/plans/16-generic-git-remotes.md
@@ -23,8 +23,10 @@ started.
 
 **Explicitly not in scope:** host pickers, a "custom remote" wizard, per-host settings
 UI, or per-host REST sugar (repo creation, visibility checks, install links — those
-stay GitHub-only conveniences). File-sync providers (iCloud/Dropbox) remain unsupported
-by design; this plan is about other *git hosts*, not other *sync mechanisms*.
+stay GitHub-only conveniences). File-sync providers were unsupported by design when
+this was written — [Plan 21](./21-icloud-drive-sync.md) has since shipped iCloud Drive
+as the primary sync path (Dropbox et al. remain unsupported); either way, this plan is
+about other *git hosts*, not other *sync mechanisms*.
 
 ## Where we stand (why it doesn't work today)
 

--- a/docs/plans/19-mobile.md
+++ b/docs/plans/19-mobile.md
@@ -24,6 +24,16 @@ fallback with explicit triggers.
 > note actions, share helper, and settings sheet exist. Still open: physical-device
 > editing validation, full GitHub-connect restore polish on mobile, foreground-sync
 > product hardening, TestFlight/App Store packaging, and Android follow-through.
+>
+> **Update (2026-07-05):** several scope lines below were superseded by later ships.
+> [Plan 21](./21-icloud-drive-sync.md) made iCloud Drive the primary storage/sync
+> path: onboarding is now iCloud-first (lists every container graph; keep-on-device
+> and GitHub behind it), `mobile_storage` replaced `mobile_graph_root`, and the
+> settings sheet grew a **Switch graph** section — so "one graph per device / no
+> iCloud containers" no longer holds (one graph *open* at a time still does). The
+> formatting toolbar shipped **webview-drawn** (decision 8), spike B passed with
+> meowdown on device, mobile conflict resolution shipped (mine/theirs/both), and
+> the TestFlight flow exists ([docs/ios-testflight.md](../ios-testflight.md)).
 
 **Depends on:** Plans 02–05 (graph/storage, document model, index, **editor**),
 06 (daily notes/route model), 07 (backlinks/autocomplete), 08 (lexical

--- a/docs/porting/reflect-mobile/app-shell-and-navigation.md
+++ b/docs/porting/reflect-mobile/app-shell-and-navigation.md
@@ -75,9 +75,11 @@ export, recovery-kit creation, sign out, delete account.
   clone, and initial index progress) and graph open.
 - **Settings sheet replaces the profile modal**
   (`apps/desktop/src/mobile/settings-sheet.tsx`), in V1's avatar spot:
-  graph name, note count, GitHub connect/disconnect, sync status, version.
-  No graph switcher (one graph per device in v1), no account rows, no JSON
-  export (the workspace is already Files-app-visible markdown).
+  graph name, storage kind, note count, GitHub connect/disconnect, sync
+  status, version — and, since Plan 21, a **Switch graph** section (other
+  iCloud-container graphs + the on-device root; one graph open at a time).
+  No account rows, no JSON export (the workspace is already
+  Files-app-visible markdown).
 
 ## Worth porting deliberately
 
@@ -108,6 +110,6 @@ not already present:
 | FAB → create note / record                  | `+` button → untitled note; record arrives with audio wave   |
 | Boot gates (auth/unlock/version/sync)       | Onboarding (fresh / GitHub clone) + graph open only          |
 | Profile card modal                          | Settings sheet (graph, GitHub, sync status, version)         |
-| Graph switcher                              | Dropped in v1 — one graph per device                         |
+| Graph switcher                              | Shipped via Plan 21 — settings-sheet Switch graph across container graphs |
 | `useHideTabBar` (Capacitor keyboard events) | `--keyboard-height` from the first-party keyboard plugin     |
 | Sync spinner badge on the avatar            | Sync status pill / settings-sheet status ("Backed up …")     |

--- a/docs/reflect-v2-mobile-grounding-brief.md
+++ b/docs/reflect-v2-mobile-grounding-brief.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Provide a broad, product-oriented overview of what the Reflect V2 mobile app should be, so a mobile-implementation agent understands the product model, the inherited V2 constraints, the lessons from V1 mobile, and the shape of the later waves — before and while working through the implementation plan.
 
-**Decision status:** This brief is grounding material, not the source of truth. The implementation plan is [Plan 19 (mobile companion)](./plans/19-mobile.md) and the shell decision is [TDR 0003 (Tauri 2 mobile)](./decisions/0003-mobile-shell.md) — when this brief conflicts with either, they win, along with [Reflect V2 Product Vision](./reflect-v2-product-vision.md), [Reflect V2 Indexing Strategy](./reflect-v2-indexing-strategy.md), and [Reflect V2 Sync Strategy](./reflect-v2-sync-strategy.md). First-release scope calls recorded in section 3 were confirmed with the product owner on 2026-06-12.
+**Decision status:** This brief is grounding material, not the source of truth. The implementation plan is [Plan 19 (mobile companion)](./plans/19-mobile.md) and the shell decision is [TDR 0003 (Tauri 2 mobile)](./decisions/0003-mobile-shell.md) — when this brief conflicts with either, they win, along with [Reflect V2 Product Vision](./reflect-v2-product-vision.md), [Reflect V2 Indexing Strategy](./reflect-v2-indexing-strategy.md), [Reflect V2 Sync Strategy](./reflect-v2-sync-strategy.md), and — for storage and sync — [Plan 21 (iCloud Drive sync)](./plans/21-icloud-drive-sync.md) with its user contract in [iCloud Drive Sync](./icloud-sync.md). First-release scope calls recorded in section 3 were confirmed with the product owner on 2026-06-12; the brief was last trued up on 2026-07-05, after Plan 21 shipped iCloud Drive as the primary sync backend.
 
 **Primary sources:** [Reflect V1 Mobile Overview](./reflect-v1-mobile-overview.md) (from exploration of the `reflect-mobile` repo), Plan 19 and TDR 0003, and the V2 decision docs above.
 
@@ -13,7 +13,7 @@
 Reflect V2 mobile is **the same app as desktop, on a phone** — not a second product.
 
 - **One codebase, three platforms.** V2 mobile is a build target of the existing Tauri 2 app (`apps/desktop`): the same Rust core (git2 sync, rusqlite/FTS5 index, keychain), the same `@reflect/core` business logic, the same React frontend behind a lazy platform gate with a mobile surface tree (`src/mobile/`). This is the single largest improvement over V1, where mobile was a separate Capacitor repo kept alive by rsyncing code from the web app. TDR 0003 records why (the Rust core is the deciding asset) and names Capacitor as the documented fallback with explicit triggers.
-- **Same graph, same files.** The phone holds a real markdown workspace (`daily/`, `notes/`, `assets/`, ignored `.reflect/`) in the app's `Documents/` directory — visible in the iOS Files app, so portability holds on mobile — synced with desktop through the same GitHub device-flow + libgit2 layer. There is no server, no account, no encryption password: onboarding is "Start fresh" or "Connect GitHub".
+- **Same graph, same files.** The phone holds a real markdown workspace (`daily/`, `notes/`, `assets/`, ignored `.reflect/`) — visible in the iOS Files app, so portability holds on mobile. The primary home is the app's iCloud Drive container (**iCloud Drive → Reflect → <graph>** in Files/Finder, Plan 21), where the OS itself moves the markdown between iPhone and Mac; the app-sandbox `Documents/` root (device-only, optionally GitHub-synced through the same device-flow + libgit2 layer) is the self-managed alternative. There is no server, no account, no encryption password: onboarding is iCloud-first — open a graph already in the container, or store fresh notes there — with keep-on-device and Connect-GitHub behind it.
 - **Capture-and-edit product scope, deliberately narrow.** Open to today's daily note, swipe through days, **edit notes in place with the real editor**, quick-capture into today, create notes, lexical search, minimal settings. Editing is a hard requirement — Plan 19 is explicit that a read-only browser is not a shippable v1.
 - **The V1 reliability lesson carries over, re-solved locally.** V1 mobile's defining design was that critical capture paths survived webview death — but it achieved that by POSTing to Reflect servers, which V2 forbids. V2's equivalents are local: flush-on-background with a local commit, raw-first artifacts, and (in later waves) an App Group capture inbox instead of a server.
 - **Mobile must not distort desktop.** Desktop avoids choices that make mobile impossible (libgit2 over system git, SQLite everywhere), and mobile reuses desktop seams rather than forking them — the in-process file-change channel replaces the watcher, the document stack is reused wholesale, and there is no second write path.
@@ -33,9 +33,9 @@ A capture-and-recall companion to the desktop app, sharing one product identity:
 ### 2.2 What it is not
 
 - Not a viewer. Editing ships in v1, on the same document machinery as desktop (sessions, debounced atomic saves, title rename, round-trip protection).
-- Not a parity port. No copilot, no semantic search, no ⌘K palette, no CLI sidecar, no map, no publishing, no multiple graphs in the first release.
+- Not a parity port. No copilot, no semantic search, no ⌘K palette, no CLI sidecar, no map, no publishing. (The container can hold several graphs — the settings sheet switches between them — but only one graph is open at a time; there is no desktop-style chooser.)
 - Not a separate codebase, schema, or design system.
-- Not a cloud client. The phone is a peer device operating on its own copy of the graph; network egress in v1 is GitHub sync only.
+- Not a cloud client. The phone is a peer device operating on its own copy of the graph; network egress *from the app* is GitHub sync only — iCloud document sync happens OS-side, below the app.
 
 ---
 
@@ -46,20 +46,20 @@ Plan 19 defines the binding scope. Summarized, with the product-owner calls of 2
 | Capability | First mobile release | Notes |
 | --- | --- | --- |
 | Today + day pager, daily notes | **In** | The default screen; open-to-today. V1 design parity (product call 2026-06-12): month header + week calendar strip + touch-swipeable day carousel (Embla), in a Daily / All tab shell. |
-| Full editing (meowdown; CM6 live-preview fallback) | **In** | Hard requirement. The editor choice is locked by an on-device gate spike before screens are built (Plan 19, decision 7 / step 2). |
+| Full editing (meowdown) | **In** | Hard requirement. The on-device gate spike (Plan 19, decision 7 / step 2) passed with meowdown; the CM6 fallback rung was never needed. |
 | New note (`+` button) | **In** | V1 parity (product call 2026-06-12): there is **no capture sheet** — the daily note is the capture surface; `+` opens a fresh untitled note via desktop's ⌘N seed/ghost-title flow. |
 | All notes + lexical search (FTS5) | **In** | Same index schema and getters as desktop; search embedded in the All tab with filter badges, V1-style. |
 | Note actions (pin, share, trash) | **In** | Product call 2026-06-12: full V1 parity — pin/unpin (frontmatter flag), share via the Web Share API (`navigator.share`, verified working in the Tauri iOS WKWebView — no native plugin needed), trash to `.reflect/trash/`. |
-| Settings sheet | **In** | V1's avatar spot: graph name, note count, GitHub connect/disconnect, sync status, version. |
-| GitHub sync (device flow, HTTPS) | **In** | Foreground-only; cycle on resume, after debounced edits, and on network regain. |
-| Onboarding: Start fresh / Connect GitHub | **In** | One graph per device, fixed root in `Documents/`, Files-app visible. |
-| Minimal settings | **In** | GitHub connect/disconnect, version. No graph chooser. |
+| Settings sheet | **In** | V1's avatar spot: graph name, storage (iCloud Drive / This device), **Switch graph** (other container graphs + the on-device root), note count, GitHub connect/disconnect, sync status, version. |
+| iCloud Drive sync (Plan 21) | **In** | The primary transport: the graph lives in the app's iCloud container; the OS moves files; conflicts resolve on-device through the deterministic ladder (see section 6). iCloud and a Git remote are mutually exclusive per graph. |
+| GitHub sync (device flow, HTTPS) | **In** | For self-managed (on-device) graphs. Foreground-only; cycle on resume, after debounced edits, and on network regain. |
+| Onboarding: iCloud-first | **In** | Lists every graph already in the container (one-tap open) or stores fresh notes there; **Keep notes on this device** and a **Sync with GitHub instead** link behind it. Roots re-derived every launch; the chosen iCloud graph persists by *name*. |
 | Conflict **resolution** UI | **In** | Conflicted notes open protected with the same raw-marker mine/theirs/both resolution actions as desktop. |
 | Audio memos | **Later wave** | Product owner: first post-release wave, reusing desktop's raw-first + async BYOK transcription pipeline; OS entry points (widget, Siri, Live Activity) come with it. |
 | Share-sheet capture | **Later wave** | Product owner: defer until the mobile share-target plugin can reuse the Plan 11 capture envelope/inbox model. Desktop Chrome capture has shipped; mobile still needs App Group ingestion. |
 | AI copilot (BYOK) | **Later wave** | Architecture holds (keys would live in the iOS keychain via the same secrets module); the surface is deferred. |
 | Semantic search / embeddings | **Later** | `fastembed`/ORT is desktop-only; mobile is lexical-first per the indexing strategy. |
-| Tasks, widgets, push, background sync, multiple graphs | **Out of v1** | Per Plan 19's explicit out-of-scope list; tasks follow desktop's Plan 18. |
+| Tasks, widgets, push, background sync | **Out of v1** | Per Plan 19's explicit out-of-scope list; tasks follow desktop's Plan 18. |
 | Android | **Fast follow** | Same architecture, last step of Plan 19 (Kotlin keyboard-plugin half, Play submission). No new product surface. |
 
 The later-wave rows matter in v1 even though they ship nothing: the workspace layout, privacy enforcement points, and native-target provisioning should not need rework when audio and share-sheet capture arrive (section 7).
@@ -74,7 +74,7 @@ Settled in the decision docs; not mobile-negotiable:
 - **SQLite under `.reflect/` is a rebuildable projection** — with the durable `chat_*` exception. `.reflect/` is per-device and never synced: the phone builds its own index, and desktop chat history does not appear on mobile. Mobile adds one graph-local convention: deleted notes move to sync-ignored `.reflect/trash/` instead of the OS trash.
 - **No Reflect-hosted APIs.** Every V1 mobile flow that depended on a Reflect endpoint (share extension, link enrichment, audio upload/transcription, OAuth token exchange, push) is unavailable in that form. External calls go directly to user-approved providers; in mobile v1 that means GitHub only.
 - **BYOK AI with `private: true` as a hard block.** Mobile v1 sidesteps the question by making no AI or transcription calls at all — an acceptance criterion, not an accident. When audio and AI arrive, provider calls use user keys from the iOS keychain and `private: true` is enforced at every call site, including the capture inbox boundary.
-- **Git-only sync, libgit2.** Chosen partly *because* system git is impossible on iOS. GitHub over HTTPS with device-flow tokens is the mobile transport (SSH-agent flows stay desktop-only). File-sync providers (iCloud Drive, Dropbox) are **unsupported for sync by design**, not deferred — even though iCloud would feel native on iOS. Do not reopen this.
+- **Two sync backends, never both on one graph.** The original "file-sync providers are unsupported by design" rule was **superseded by Plan 21** (2026-07-04): iCloud Drive is now the *primary* sync backend, made safe by first-class conflict handling — `NSFileVersion` conflict versions resolved on-device through a deterministic ladder over per-device shadow bases, with every consumed version archived first (see [icloud-sync.md](./icloud-sync.md)). Git sync (GitHub over HTTPS with device-flow tokens; libgit2, since system git is impossible on iOS) remains the self-managed path. The load-bearing residue of the old rule survives as two invariants: **a graph syncs through iCloud *or* a Git remote, never both** (two engines merging the same files fight each other), and **`.git/`/`.reflect/` never ride a file-sync provider** (they're always sync-excluded).
 - **Secrets in the OS keychain.** The GitHub token (and later AI keys) go in the iOS keychain via the same `keyring` module (`apple-native` covers macOS and iOS); never in markdown, Git, or `.reflect/`.
 - **Design system and conventions.** Same `design-system/` tokens (including safe-area tokens), Tailwind + shadcn, AGENTS.md conventions, MIT open-source core — the mobile shell and its Swift plugins are public, critiqued code.
 
@@ -87,29 +87,28 @@ Plan 19 owns the implementation detail; this is the mental model:
 - **Shell:** Tauri 2's iOS target generated from `ios.project.yml` (XcodeGen) into `gen/apple/`. Template edits require `tauri ios init` regeneration. The CLI sidecar is excluded from mobile bundles by the platform overlays. App identity is `app.reflect.ios` / product name "Reflect".
 - **Rust crate:** compiles to `aarch64-apple-ios` with desktop-only capabilities target-gated (watcher, embeddings, OS trash, window-state, updater). The index, document model, and fs modules need no mobile fork. Gate spike A passed on the simulator on 2026-06-12 (keychain, FTS5, file IO, libgit2 probes all green); physical-device verification remains.
 - **Frontend:** one bundle, a lazy platform gate at the root (`PlatformRoot`), and a mobile surface tree under `src/mobile/` — screens over a subset of the typed `Route` union, no URL router. Desktop chrome (sidebars, titlebar, palette) stays in desktop-only chunks. The Today screen already mounts the real editor through the shared save pipeline (verified end-to-end on the simulator).
-- **No watcher on mobile:** every local write emits its file-change batch in-process (`emitFileChanges` — the seam the backup controller already used for pull-applied writes). Incremental reindex, query invalidation, sync dirty-marking, and open-editor reconciliation all hang off that one channel. This is the contract that keeps mobile from growing its own index or sync logic.
-- **Keyboard:** Tauri iOS has no keyboard handling, so a small first-party Swift plugin (`plugins/tauri-plugin-keyboard`) streams keyboard height to JS and keeps the caret visible above the keyboard. Notably, V1 mobile's native accessory-bar approach (class-swizzling) is deliberately **not** ported — it was brittle; if mobile grows a formatting toolbar it will be webview-drawn, positioned via the plugin's height events.
+- **No notify watcher on mobile:** every local write emits its file-change batch in-process (`emitFileChanges` — the seam the backup controller already used for pull-applied writes). Incremental reindex, query invalidation, sync dirty-marking, and open-editor reconciliation all hang off that one channel. For iCloud graphs, an `NSMetadataQuery` watch (Plan 21) is the *external*-change source: it feeds the same channel when the OS lands files behind the app's back, requests downloads for non-current items the moment they're reported (iOS never downloads content unasked), and carries the conflict signal. This split — one in-process channel, one container watch — is the contract that keeps mobile from growing its own index or sync logic.
+- **Keyboard:** Tauri iOS has no keyboard handling, so a small first-party Swift plugin (`plugins/tauri-plugin-keyboard`) streams keyboard height to JS and keeps the caret visible above the keyboard. Notably, V1 mobile's native accessory-bar approach (class-swizzling) is deliberately **not** ported — it was brittle; the formatting toolbar shipped **webview-drawn** (Plan 19 decision 8), positioned via the plugin's height events.
 - **Lifecycle:** iOS suspends quickly and can kill the WebContent process. The contract: flush open documents + settings and make a local commit on background (never a push); on resume, run a sync cycle and survive a dead webview. A relaunch must land back on the last route with no buffer loss.
 
-### The two existential gates
+### The two existential gates (both passed)
 
-Plan 19 front-loads its risk into two timeboxed spikes, and nothing else proceeds until both pass:
+Plan 19 front-loaded its risk into two timeboxed spikes, and nothing else proceeded until both passed:
 
-1. **The crate on iOS** (spike A — simulator half passed).
-2. **Editing on a real iPhone** (spike B — pending). Editing markdown in WKWebView was V1 mobile's deepest scar (ProseMirror focus/selection/keyboard timing, patched selection crashes). The ladder is meowdown → CodeMirror 6 live-preview (Obsidian mobile's proven approach) → product-level escalation. Read-only is not a rung.
+1. **The crate on iOS** (spike A — passed on the simulator 2026-06-12: keychain, FTS5, file IO, libgit2 probes all green).
+2. **Editing on a real iPhone** (spike B — **meowdown passed**; the CM6 fallback rung was never needed). Editing markdown in WKWebView was V1 mobile's deepest scar (ProseMirror focus/selection/keyboard timing, patched selection crashes); the surviving lessons are encoded in the touch editor surface — `spellCheck=false` pins iOS smart punctuation, the shell yields by height so popups end at the keyboard, and WKScrollView's caret-reveal scroll is pinned out natively.
 
 ---
 
 ## 6. Sync on Mobile
 
-The heart of the mobile product, and where mobile differs most from desktop in daily feel:
+The heart of the mobile product, and where mobile differs most from desktop in daily feel. Since Plan 21 there are two transports; a graph uses exactly one:
 
-- **Same engine, same contracts.** libgit2 commit/fetch/merge, conflict markers, the no-loop invariant — unchanged. Pull-applied changes flow through the existing `onRemoteChanges` reindex path.
-- **Foreground-only.** Sync cycles run on app resume, after debounced edits, and on network regain. Background sync (BGTaskScheduler) is explicitly out of v1. The phone therefore spends much of its life in "not yet pushed" — the plain-language status surface ("Backed up / Syncing / Needs review") is more prominent on mobile than desktop because the user consciously opens the app to sync.
-- **Capture latency is the contract.** "Open app, type a thought, lock phone" must always be safe: local commit never blocks on the network; push is opportunistic; flush-on-background protects the save debounce window. Plan 19's acceptance criteria pin this (kill the app mid-debounce; the edit is on disk).
-- **Conflicts are contained and resolvable on mobile.** A conflicted note opens protected, never blocks sync of other notes, and offers the same raw-marker mine/theirs/both resolution actions as desktop.
-- **The canonical conflict** is phone and Mac both appending to **today's daily note** while the phone was offline. It is mostly an append/append merge, and Plan 12 already lists a custom daily-note merge driver as future work — mobile multiplies that future work's value. Treat daily-note append/append as a first-class test scenario even with on-device mine/theirs/both resolution.
-- **First sync is onboarding.** Cloning a years-old graph with assets over cellular, foregrounded, is a V1-power-user's first experience. v1 accepts slow clones with progress UI; shallow/partial clone is a noted follow-up that must not casually fork the desktop sync contract.
+- **iCloud Drive is the primary transport.** The OS moves the markdown; the app's job is intake and conflicts. The `NSMetadataQuery` watch reports external changes live, nudges downloads for non-current items the moment they appear (iOS never downloads unasked — this nudge is what makes a Mac edit land on an open iPhone in seconds), and the resume path polls pending downloads so notes appear as they arrive. Residual latency is iCloud's own propagation, which the app can't control.
+- **Conflicts mostly resolve themselves.** iCloud edit conflicts surface as `NSFileVersion` conflict versions, and the deterministic ladder (identical/whitespace → three-way merge over a per-device shadow base → key-wise frontmatter → daily append-union → labeled markers) resolves them on-device — both devices independently produce *byte-identical* results, so they converge instead of ping-ponging. Every consumed version is archived to `.reflect/conflict-archive/` first. Only the marker fallback reaches the user, as a protected note with the same mine/theirs/both resolution actions as desktop. The once-canonical daily append/append conflict now **auto-merges** (the append-union rung — Plan 12's "future work" merge driver, shipped by Plan 21); keep it as a first-class test scenario anyway.
+- **Git is the self-managed transport, same engine, same contracts.** libgit2 commit/fetch/merge, conflict markers, the no-loop invariant — unchanged. Pull-applied changes flow through the existing `onRemoteChanges` reindex path. Foreground-only: cycles on resume, after debounced edits, and on network regain; background sync (BGTaskScheduler) stays out. The plain-language status surface ("Backed up / Syncing / Needs review") is more prominent on mobile than desktop.
+- **Capture latency is the contract** on both transports. "Open app, type a thought, lock phone" must always be safe: local writes never block on the network; flush-on-background protects the save debounce window. Plan 19's acceptance criteria pin this (kill the app mid-debounce; the edit is on disk).
+- **First sync is onboarding.** For iCloud, opening a container graph downloads content on demand (with the nudge-and-poll loop above) — no clone step. For Git, cloning a years-old graph with assets over cellular, foregrounded, is still the first experience: slow clones with progress UI are accepted; shallow/partial clone remains the follow-up lever.
 
 ---
 
@@ -129,8 +128,8 @@ From the [V1 Mobile Overview](./reflect-v1-mobile-overview.md), translated into 
 
 - **Background capture without a server.** V1's share extension and voice memos worked when the app was dead *because a server received the payload*. The V2 equivalent for the later waves is local: a share-target/extension writes pending items (raw audio, shared URLs/text) into an App Group container as a capture inbox; the main app ingests into markdown on next launch and syncs. Extensions must not touch the Git repo or SQLite directly. `private: true` enforcement applies at the inbox boundary.
 - **Transcription.** V1 transcribed server-side after upload. The V2 audio wave reuses desktop's decision: raw-first recordings are the durable, sync-safe artifact; async BYOK cloud transcription with explicit privacy UX and `private: true` lockout.
-- **The native accessory toolbar.** V1's signature editor affordance was a native keyboard accessory bar — but its implementation (input-accessory swizzling) was brittle, and Plan 19 explicitly does not port it. The keyboard-height plugin is the stable primitive; a webview-drawn toolbar can be layered on later if editing on touch demands it.
-- **Onboarding.** V1 mobile gated entry behind account auth → graph selection → encryption unlock → initial Firestore sync. V2 has no accounts and no encryption password: Start fresh or Connect GitHub, then land on Today. Most of V1's loading-gate machinery simply has no V2 equivalent — don't rebuild it.
+- **The native accessory toolbar.** V1's signature editor affordance was a native keyboard accessory bar — but its implementation (input-accessory swizzling) was brittle, and Plan 19 explicitly did not port it. The keyboard-height plugin is the stable primitive, and the formatting toolbar shipped **webview-drawn** on top of it — the re-solve worked.
+- **Onboarding.** V1 mobile gated entry behind account auth → graph selection → encryption unlock → initial Firestore sync. V2 has no accounts and no encryption password: open (or create) an iCloud graph, keep notes on-device, or connect GitHub — then land on Today. Most of V1's loading-gate machinery simply has no V2 equivalent — don't rebuild it.
 
 ### 7.3 Dropped
 
@@ -143,11 +142,11 @@ Push notifications (no server), OAuth token exchange, Firebase everything, App-S
 | V1 mobile capability | V2 mobile direction |
 | --- | --- |
 | Daily tab (swiper carousel, calendar strip) | **v1**: Today screen + day pager |
-| Full rich editor + native keyboard toolbar | **v1**: meowdown (or CM6 fallback) + keyboard-height plugin; formatting toolbar webview-drawn, later |
+| Full rich editor + native keyboard toolbar | **v1**: meowdown + keyboard-height plugin; formatting toolbar webview-drawn (shipped, Plan 19 decision 8) |
 | All Notes list + FTS search | **v1**: virtualized list + FTS5 search screen |
 | Quick capture into today | **v1**: the daily note itself (open-to-today + editing); `+` = new untitled note — the V2 append-to-today sheet was removed by the 2026-06-12 product call |
-| Auth (Apple/Google/OTP), encryption unlock | **Dropped** — no accounts, no E2EE; onboarding = Start fresh / Connect GitHub |
-| Graph switcher | **Dropped in v1** — one graph per device, fixed root |
+| Auth (Apple/Google/OTP), encryption unlock | **Dropped** — no accounts, no E2EE; onboarding = iCloud graph / keep on device / Connect GitHub |
+| Graph switcher | **v1** — the settings sheet switches between container graphs and the on-device root (Plan 21); one graph open at a time |
 | Trash / delete | **v1** — to graph-local `.reflect/trash/` (recoverable, sync-ignored) |
 | Pin, publish, share-as-text note actions | **v1**: pin + share + trash (product call 2026-06-12); publishing stays deferred product-wide |
 | JSON export via share sheet | Superseded: the workspace is Files-app-visible markdown |
@@ -158,7 +157,7 @@ Push notifications (no server), OAuth token exchange, Firebase everything, App-S
 | Note history UI | Git history exists; history UI deferred product-wide |
 | Push notifications | Dropped — no server |
 | Deep links (`reflect://`) | Tauri's deep-link plugin exists; not a v1 surface — revisit with the command registry |
-| TestFlight automation, timestamp build numbers | Carry the shape into this repo's CI (Plan 19 step 11 mirrors the macOS release workflow) |
+| TestFlight automation, timestamp build numbers | **Done** — `pnpm release:ios` + the TestFlight workflow ([docs/ios-testflight.md](./ios-testflight.md)), timestamp `CFBundleVersion`s carried over |
 
 ---
 
@@ -166,13 +165,13 @@ Push notifications (no server), OAuth token exchange, Firebase everything, App-S
 
 Aligned with Plan 19's risks, ordered by product impact:
 
-1. **Editing quality in WKWebView** — the headline risk by construction; mitigated by gate spike B, the keyboard plugin as prerequisite, and the CM6 rung with independent large-scale proof (Obsidian mobile). Both rungs failing escalates to a product-level re-decision (native-editor territory), per TDR 0003's triggers.
+1. **Editing quality in WKWebView** — was the headline risk by construction; **retired**: spike B passed with meowdown on device (the CM6 rung was never needed), and the sharp edges found on the way are pinned in code (smart-punctuation gating, keyboard-height yielding, caret-scroll suppression). Regressions here remain the thing to watch on iOS updates.
 2. **Tauri mobile early-adopter risk** — no marquee consumer iOS app ships Tauri mobile today; keyboard and lifecycle gaps are known and budgeted, unknown unknowns are not. Capacitor fallback documented with triggers.
-3. **Editor divergence if the CM6 rung ships** — two editors to maintain; accepted consciously at the gate decision, with the document stack shared either way.
-4. **Cross-compiling the vendored stack** (OpenSSL/libssh2/libgit2; later Android NDK) — known-workable but fiddly; isolated in spike A. One landed example: cargo link directives don't reach the Xcode link, so libgit2's zlib/iconv live in `ios.project.yml`.
+3. **Cross-compiling the vendored stack** (OpenSSL/libssh2/libgit2; later Android NDK) — known-workable but fiddly; isolated in spike A. One landed example: cargo link directives don't reach the Xcode link, so libgit2's zlib/iconv live in `ios.project.yml`.
+4. **iCloud propagation opacity** — the primary transport's latency and delivery are OS-controlled and unobservable beyond the metadata query; the app is at the paradigm's latency floor (live download nudges), so remaining slowness has no app-side lever. The two-device conflict matrix is the standing verification burden for every change to the ladder or watch.
 5. **App Store review** — 4.2 minimal-functionality risk is low for an offline-capable local-first editor but nonzero for webview shells; the reviewer story (fully usable with no account, demo graph) ships with submission.
-6. **Clone size on mobile networks** — accepted in v1 with progress UI; shallow/partial clone is the follow-up lever.
-7. **Webview memory on huge graphs / very large notes** — editing is the new pressure point; the step-11 memory pass is the checkpoint, with note-size guardrails as the lever.
+6. **Clone size on mobile networks** (Git path) — accepted with progress UI; shallow/partial clone is the follow-up lever. The iCloud path sidesteps this: content downloads on demand.
+7. **Webview memory on huge graphs / very large notes** — editing is the new pressure point; the step-11 memory pass is the checkpoint, with note-size guardrails as the lever. The iCloud path adds a cousin: the graph is fully downloaded by policy (the index needs the bytes), so "the graph must fit on the phone" is an assumption, not a guarantee.
 
 ---
 
@@ -181,7 +180,7 @@ Aligned with Plan 19's risks, ordered by product impact:
 Keyboard-native is desktop identity; mobile translates it rather than imports it:
 
 - **Touch-native, capture-first.** Thumb-reachable core actions; search as a visible surface, not a chord; the keyboard never occludes the caret. Full shortcut surfaces (⌘K palette) are explicitly out of v1 — hardware-keyboard iPad users fall back to visible affordances for now.
-- **Minimal UI applies double.** Six screens, a tab/stack shell, a sync-status pill. No settings sprawl: GitHub connect/disconnect and version.
+- **Minimal UI applies double.** Six screens, a tab/stack shell, a sync-status pill. No settings sprawl: storage, switch graph, GitHub connect/disconnect, and version.
 - **Same visual language.** Design-system tokens, safe-area-aware layout (`viewport-fit=cover`), 16px minimum input font (blocks iOS auto-zoom), dark mode. iPad ships as "a big phone" in v1; a desktop-class iPad layout is an explicit later decision.
 - **Plain-language sync.** "Backed up / Syncing / Needs review" — never commits, branches, or merges. Conflict language points users to open the note and choose what to keep.
 
@@ -191,7 +190,7 @@ Keyboard-native is desktop identity; mobile translates it rather than imports it
 
 Plan 19's acceptance criteria are the binding list. The product-level summary: a user succeeds if they can
 
-1. Install the iOS app and either start fresh or connect their GitHub graph in minutes.
+1. Install the iOS app and, in minutes, open the graph already in their iCloud Drive — or start fresh there, keep notes on-device, or connect a GitHub graph.
 2. See today's daily note instantly, offline or online.
 3. Edit any note — including inserting a `[[wiki link]]` via autocomplete — with no markdown corruption, and find the edit in search and backlinks without restarting.
 4. Lock the phone mid-thought and lose nothing, even if iOS kills the app.
@@ -207,12 +206,13 @@ And the codebase succeeds if audio memos, share-sheet capture, and the AI copilo
 Beyond Plan 19's settled scope, these remain genuinely open:
 
 1. **App Group + capture-inbox schema** for the audio/share waves: file layout, ingest semantics, `private: true` handling at the inbox boundary, and when to provision the App Group + extension targets in the Xcode template (cheap early, annoying to retrofit — but not needed for v1).
-2. **Daily-note merge driver timing**: when does append/append auto-merge graduate from Plan 12 "future work" to required, given foreground-only mobile sync multiplies conflict frequency?
-3. **Semantic search graduation** (inherited from the indexing strategy): what battery/storage/latency evidence gates local embeddings on iOS, and does sqlite-vec/fastembed ever run there or does mobile stay lexical until a different runtime appears?
-4. **AI-assisted conflict resolution**: if AI-assisted merge arrives, how does mobile apply resolutions that require BYOK calls (the sync strategy's open question)?
-5. **iPad posture**: how long does "big phone" hold before a two-pane layout is worth building?
-6. **Deep links and the command registry**: when external automation (shortcuts, widgets) arrives, does `reflect://` map onto the same typed command layer as desktop?
-7. **A formatting toolbar**: does on-device editing (spike B and beyond) demonstrate the need for a webview-drawn accessory bar, and what minimal item set earns its place?
+2. **Semantic search graduation** (inherited from the indexing strategy): what battery/storage/latency evidence gates local embeddings on iOS, and does sqlite-vec/fastembed ever run there or does mobile stay lexical until a different runtime appears?
+3. **AI-assisted conflict resolution**: Plan 21 defers it by design — the ladder hands AI the same base/local/remote triple it uses itself. When it arrives, how does mobile apply resolutions that require BYOK calls (the sync strategy's open question)?
+4. **iPad posture**: how long does "big phone" hold before a two-pane layout is worth building?
+5. **Deep links and the command registry**: when external automation (shortcuts, widgets) arrives, does `reflect://` map onto the same typed command layer as desktop?
+6. **Graph-at-scale on iCloud**: full-download-by-policy plus O(all-notes) watch diffing and pending-walks are fine at today's graph sizes; what size forces delta-based intake or selective download?
+
+Two of the original questions closed since the first draft: the daily-note append/append merge driver shipped as Plan 21's append-union rung, and the formatting toolbar shipped webview-drawn (Plan 19 decision 8).
 
 ---
 
@@ -220,8 +220,8 @@ Beyond Plan 19's settled scope, these remain genuinely open:
 
 Reflect V2 mobile is best understood as:
 
-> The same local-first markdown app, recompiled for the pocket: today's note on open, real editing under a keyboard that finally behaves, instant offline search, and Git sync that hides behind three plain words — with voice, share-sheet, and AI capture waves arriving behind it on the same foundations.
+> The same local-first markdown app, recompiled for the pocket: today's note on open, real editing under a keyboard that finally behaves, instant offline search, and sync that hides behind three plain words — iCloud moving the files by default, Git for the self-managed — with voice, share-sheet, and AI capture waves arriving behind it on the same foundations.
 
-Build it from the constraints that make V2 distinct: one codebase, markdown files the user can see in the Files app, a rebuildable per-device index, no servers, no accounts, `private: true` as a hard line when AI arrives — and V1 mobile's hardest-won lessons applied: gate the editor on a real device before building screens, keep canonical state below the webview, and make "lock the phone mid-thought" always safe.
+Build it from the constraints that make V2 distinct: one codebase, markdown files the user can see in the Files app, a rebuildable per-device index, deterministic on-device conflict resolution, no servers, no accounts, `private: true` as a hard line when AI arrives — and V1 mobile's hardest-won lessons applied: gate the editor on a real device before building screens, keep canonical state below the webview, and make "lock the phone mid-thought" always safe.
 
 Plan 19 is the route; this brief is the map of why.

--- a/docs/reflect-v2-product-vision.md
+++ b/docs/reflect-v2-product-vision.md
@@ -445,6 +445,13 @@ Windows and Android should remain possible. The implementation should avoid choi
 > (see Plan 12); the adapter list below is the long-term direction. AI-assisted conflict
 > resolution did not ship — conflicts surface as reviewable conflict markers with
 > mine/theirs/both resolution.
+>
+> **Update (2026-07-04):** [Plan 21](./plans/21-icloud-drive-sync.md) shipped
+> **iCloud Drive as the primary consumer sync path** — the app's own container,
+> iCloud-first onboarding on macOS and iOS, and deterministic on-device conflict
+> resolution (see [icloud-sync.md](./icloud-sync.md)). Git remains the
+> self-managed adapter; a graph syncs via iCloud *or* a Git remote, never both.
+> AI-assisted resolution stays deferred.
 
 V2 should make backup free and understandable.
 

--- a/docs/reflect-v2-sync-strategy.md
+++ b/docs/reflect-v2-sync-strategy.md
@@ -16,9 +16,13 @@ It complements [Reflect V2 Product Vision](./reflect-v2-product-vision.md).
 >   sync by design** in the first wave — not adapters-in-waiting. The adapter
 >   sections below are preserved as long-term direction only.
 >   **Update (2026-07-04):** [Plan 21](./plans/21-icloud-drive-sync.md)
->   revises this — iCloud Drive is promoted to the primary consumer sync
->   path (app container + iCloud-first onboarding, marker-based conflict
->   surface); the AI-assisted resolution below remains deferred.
+>   revises this — iCloud Drive **shipped** as the primary consumer sync
+>   path (app container, iCloud-first onboarding on both platforms, and a
+>   deterministic on-device resolution ladder over per-device shadow bases
+>   with labeled markers as the fallback — see
+>   [icloud-sync.md](./icloud-sync.md)). A graph syncs via iCloud *or* a
+>   Git remote, never both. The AI-assisted resolution below remains
+>   deferred.
 > - **AI-assisted conflict resolution did not ship.** Conflicts surface as standard
 >   conflict markers; conflicted notes open protected, with a reviewable
 >   mine/theirs/both resolution flow and a `has_conflict` "Needs review" projection.
@@ -186,6 +190,8 @@ Reflect should create automatic checkpoints opportunistically after meaningful c
 GitHub credentials should live in per-device OS keychain or secure storage. They must not be written to markdown files, committed to Git, or stored in the ignored `.reflect/` directory unless a later security design explicitly replaces this default.
 
 ## iCloud Drive Adapter
+
+> **Shipped (2026-07-04):** this section's direction became [Plan 21](./plans/21-icloud-drive-sync.md), now merged — the shipped design resolves most conflicts deterministically on-device (diff3 over shadow bases, daily append-union) before falling back to the marker surface, with the AI layer still deferred. [icloud-sync.md](./icloud-sync.md) is the current contract; this section is preserved as the original reasoning.
 
 iCloud Drive is attractive for Apple-first sync because it works with normal files and is built into macOS and iOS. Its conflict behavior is file-level, not markdown-aware.
 


### PR DESCRIPTION
## Summary

PR #501 (Plan 21 — iCloud Drive sync) invalidated several load-bearing claims in [docs/reflect-v2-mobile-grounding-brief.md](docs/reflect-v2-mobile-grounding-brief.md). This trues the brief up against what actually shipped:

- **Sync model**: the "Git-only sync — file-sync providers unsupported by design, do not reopen" decision is marked **superseded by Plan 21**, with the two invariants that survive it (iCloud XOR Git remote per graph; `.git`/`.reflect` never ride a file-sync provider). Section 6 now describes both transports: the NSMetadataQuery watch + live download nudges, and the deterministic conflict ladder — including that the once-canonical daily append/append conflict now auto-merges (the append-union rung closed that open question).
- **Onboarding & graphs**: iCloud-first onboarding with the container-graph list, the settings-sheet graph switcher, and graph-persisted-by-name replace "Start fresh / Connect GitHub, one graph per device, no switcher".
- **Shipped facts**: spike B passed with meowdown (CM6 rung never needed), the formatting toolbar shipped webview-drawn, and the TestFlight release flow exists — the risk register and V1→V2 mapping table now say so.
- **Open questions** trimmed to the ones still open, with a note on the two that closed; added a graph-at-scale-on-iCloud question (full-download policy + O(all-notes) intake).

Follows #513's conflict-resolution corrections; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown documentation updates only; no runtime, sync, or mobile behavior changes.
> 
> **Overview**
> Documentation-only PR that **reconciles V2 docs with Plan 21 (iCloud Drive sync shipped 2026-07-04)** and the current mobile reality—no application code changes.
> 
> **`reflect-v2-mobile-grounding-brief.md`** is the largest update: it replaces Git-only / “file-sync unsupported” framing with **iCloud as the primary transport** (container graphs, iCloud-first onboarding, settings **Switch graph**) and **Git as the self-managed path**, including the invariants **one sync backend per graph** and **`.reflect`/`.git` never on file-sync**. Sync section now covers **`NSMetadataQuery`**, download nudges, and the **deterministic conflict ladder** (including daily **append-union** auto-merge). It also records **spike B (meowdown) passed**, **webview formatting toolbar shipped**, **TestFlight** docs, retired editor risks, and trimmed/updated open questions.
> 
> **Cross-cutting doc edits:** `00-overview` (Plan 21 status, cloud-sync risk/guardrails), `12-backup-and-sync` (append-merge “future work” → Plan 21), `16-generic-git-remotes` and `19-mobile` (Plan 21 supersessions + 2026-07-05 status), `reflect-v2-product-vision` and `reflect-v2-sync-strategy` (iCloud primary + shipped notes), and `porting/.../app-shell-and-navigation` (graph switcher in settings).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0736370cd009e817d95752da8143976a67123df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Docs-tree sweep (second commit)

An audit of the rest of the docs tree found six more files still carrying pre-Plan-21 claims; all harmonized:

- [reflect-v2-sync-strategy.md](docs/reflect-v2-sync-strategy.md) — status-block update sharpened (shipped, deterministic ladder, iCloud-XOR-Git); the iCloud Drive Adapter section marked **shipped** with a pointer to the current contract.
- [reflect-v2-product-vision.md](docs/reflect-v2-product-vision.md) — Plan 21 update appended to the Backup/Sync status block.
- [plans/00-overview.md](docs/plans/00-overview.md) — Plan 12/21 roadmap rows, the cloud-sync-folder risk (managed, not avoided), and the portability guardrail reframed; Dropbox/Drive stay unsupported.
- [plans/12-backup-and-sync.md](docs/plans/12-backup-and-sync.md) — the daily merge-driver "future work" line notes it shipped as Plan 21's append-union rung.
- [plans/16-generic-git-remotes.md](docs/plans/16-generic-git-remotes.md) — "unsupported by design" softened to a dated supersession.
- [plans/19-mobile.md](docs/plans/19-mobile.md) — status block gains a 2026-07-05 update (iCloud-first onboarding, mobile_storage, Switch graph, toolbar shipped, spike B passed, TestFlight flow).
- [porting/reflect-mobile/app-shell-and-navigation.md](docs/porting/reflect-mobile/app-shell-and-navigation.md) — settings-sheet description + graph-switcher table row corrected.