### PR TITLE
Import Reflect V1 exports from Settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,6 +1685,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -4783,6 +4784,7 @@ dependencies = [
  "tracing-subscriber",
  "trash",
  "xattr",
+ "zip",
 ]
 
 [[package]]
@@ -8162,9 +8164,16 @@ checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "arbitrary",
  "crc32fast",
+ "flate2",
  "indexmap 2.14.0",
  "memchr",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -55,6 +55,9 @@ tauri-plugin-http = "2.5.9"
 # reqwest 0.12 rides the exact version tauri-plugin-http already compiles.
 image = { version = "0.25.10", default-features = false, features = ["jpeg", "png"] }
 reqwest = { version = "0.12.28", default-features = false, features = ["rustls-tls"] }
+# Reflect V1 exports are zip archives of the graph-folder layout. Keep the
+# reader lean: stored entries plus the usual deflate method are enough here.
+zip = { version = "4.6.1", default-features = false, features = ["deflate-flate2-zlib-rs"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 xattr = "1.6.1"

--- a/apps/desktop/src-tauri/src/fs/import.rs
+++ b/apps/desktop/src-tauri/src/fs/import.rs
@@ -1,0 +1,478 @@
+//! Reflect V1 export import.
+//!
+//! Reflect V1 now exports the same markdown graph layout Reflect Open reads:
+//! `daily/`, `notes/`, optional `assets/`, plus ignorable local metadata. The
+//! import path is therefore a bounded archive extraction into the active graph,
+//! not a content migration.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::Read;
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::error::{AppError, AppResult};
+
+use super::io::{atomic_write_bytes, file_occupied};
+use super::resolve::resolve;
+
+/// Summary returned to the settings UI after an import completes.
+#[derive(Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportSummary {
+    /// Files newly written to the open graph.
+    pub imported_files: usize,
+    /// Files already present with identical bytes, left untouched.
+    pub skipped_files: usize,
+    /// Graph-relative paths newly written to the open graph.
+    pub changed_paths: Vec<String>,
+}
+
+struct ImportEntry {
+    relative: String,
+    bytes: Vec<u8>,
+}
+
+/// Import a user-selected Reflect V1 export zip into `root`.
+pub(super) fn import_zip_into_graph(root: &Path, zip_path: &Path) -> AppResult<ImportSummary> {
+    let entries = read_zip_entries(zip_path)?;
+    import_entries_into_graph(root, entries)
+}
+
+fn import_entries_into_graph(root: &Path, entries: Vec<ImportEntry>) -> AppResult<ImportSummary> {
+    let entries = dedupe_entries(entries)?;
+    if !entries
+        .iter()
+        .any(|entry| is_note_markdown(&entry.relative))
+    {
+        return Err(AppError::not_found(
+            "that doesn't look like a Reflect V1 export — no notes found under daily/ or notes/",
+        ));
+    }
+
+    let collisions = entries
+        .iter()
+        .map(|entry| collision(root, entry))
+        .collect::<AppResult<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    if !collisions.is_empty() {
+        return Err(AppError::io(format!(
+            "import would overwrite existing files: {}",
+            collisions
+                .iter()
+                .take(5)
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )));
+    }
+
+    let mut imported_files = 0;
+    let mut skipped_files = 0;
+    let mut changed_paths = Vec::new();
+    for entry in entries {
+        let target = resolve(root, &entry.relative)?;
+        if let Some(path) = collision(root, &entry)? {
+            return Err(AppError::io(format!(
+                "import would overwrite existing files: {path}"
+            )));
+        }
+        if target.is_file() && fs::read(&target)? == entry.bytes {
+            skipped_files += 1;
+            continue;
+        }
+        atomic_write_bytes(root, &target, &entry.bytes)?;
+        imported_files += 1;
+        changed_paths.push(entry.relative);
+    }
+
+    Ok(ImportSummary {
+        imported_files,
+        skipped_files,
+        changed_paths,
+    })
+}
+
+fn dedupe_entries(entries: Vec<ImportEntry>) -> AppResult<Vec<ImportEntry>> {
+    let mut positions = HashMap::<String, usize>::new();
+    let mut unique = Vec::<ImportEntry>::new();
+    for entry in entries {
+        if let Some(existing) = positions.get(&entry.relative) {
+            if unique[*existing].bytes != entry.bytes {
+                return Err(AppError::io(format!(
+                    "import zip contains conflicting entries for {}",
+                    entry.relative
+                )));
+            }
+            continue;
+        }
+        positions.insert(entry.relative.clone(), unique.len());
+        unique.push(entry);
+    }
+    Ok(unique)
+}
+
+fn collision(root: &Path, entry: &ImportEntry) -> AppResult<Option<String>> {
+    let target = resolve(root, &entry.relative)?;
+    if !target.exists() && !file_occupied(&target) {
+        return Ok(None);
+    }
+    if target.is_file() && fs::read(&target)? == entry.bytes {
+        return Ok(None);
+    }
+    Ok(Some(entry.relative.clone()))
+}
+
+fn read_zip_entries(path: &Path) -> AppResult<Vec<ImportEntry>> {
+    let file = fs::File::open(path).map_err(|err| {
+        AppError::io(format!(
+            "could not open Reflect V1 export {}: {err}",
+            path.display()
+        ))
+    })?;
+    let mut archive = zip::ZipArchive::new(file)
+        .map_err(|err| AppError::io(format!("could not read the zip: {err}")))?;
+
+    let mut names = Vec::new();
+    for index in 0..archive.len() {
+        let file = archive
+            .by_index(index)
+            .map_err(|err| AppError::io(format!("could not read a zip entry: {err}")))?;
+        if file.is_dir() {
+            continue;
+        }
+        if let Some(name) = file.enclosed_name() {
+            names.push(normalize_zip_path(&name.to_string_lossy()));
+        }
+    }
+
+    let prefix = wrapper_prefix(&names);
+    let mut entries = Vec::new();
+    for index in 0..archive.len() {
+        let mut file = archive
+            .by_index(index)
+            .map_err(|err| AppError::io(format!("could not read a zip entry: {err}")))?;
+        if file.is_dir() {
+            continue;
+        }
+        let Some(name) = file.enclosed_name() else {
+            continue;
+        };
+        let name = normalize_zip_path(&name.to_string_lossy());
+        let Some(relative) = sanitized_relative(&name, prefix.as_deref()) else {
+            continue;
+        };
+        let mut bytes = Vec::with_capacity(file.size() as usize);
+        file.read_to_end(&mut bytes)
+            .map_err(|err| AppError::io(format!("could not extract {relative}: {err}")))?;
+        entries.push(ImportEntry { relative, bytes });
+    }
+    Ok(entries)
+}
+
+fn normalize_zip_path(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+/// A single wrapping directory commonly added by zip tools:
+/// `export/notes/a.md` should import as `notes/a.md`.
+fn wrapper_prefix(paths: &[String]) -> Option<String> {
+    let mut shared: Option<&str> = None;
+    for path in paths {
+        let parts = parts(path);
+        if is_ignored_wrapper_noise(&parts) {
+            continue;
+        }
+        let first = *parts.first()?;
+        match shared {
+            None => shared = Some(first),
+            Some(existing) if existing == first => {}
+            Some(_) => return None,
+        }
+    }
+    let shared = shared?;
+    if matches!(shared, "daily" | "notes" | "assets" | ".reflect") {
+        return None;
+    }
+    Some(shared.to_string())
+}
+
+fn sanitized_relative(raw: &str, prefix: Option<&str>) -> Option<String> {
+    if raw.starts_with('/') || raw.contains('\0') {
+        return None;
+    }
+    let normalized = normalize_zip_path(raw);
+    let mut parts = parts(&normalized);
+    if parts.contains(&"..") {
+        return None;
+    }
+    if let Some(prefix) = prefix {
+        if parts.first() == Some(&prefix) {
+            parts.remove(0);
+        }
+    }
+    if is_ignored_wrapper_noise(&parts) {
+        return None;
+    }
+    let first = *parts.first()?;
+    let last = *parts.last()?;
+    if matches!(first, ".reflect" | ".git" | "__MACOSX") || is_junk(last) {
+        return None;
+    }
+    Some(parts.join("/"))
+}
+
+fn parts(path: &str) -> Vec<&str> {
+    path.split('/')
+        .filter(|part| !part.is_empty() && *part != ".")
+        .collect()
+}
+
+fn is_ignored_wrapper_noise(parts: &[&str]) -> bool {
+    match parts {
+        [] => true,
+        [".gitignore"] => true,
+        [name] if is_junk(name) => true,
+        [first, ..] if *first == "__MACOSX" => true,
+        _ => false,
+    }
+}
+
+fn is_junk(name: &str) -> bool {
+    name == ".DS_Store"
+        || name == "Thumbs.db"
+        || name == "Desktop.ini"
+        || name.ends_with(".swp")
+        || name.ends_with(".swo")
+        || name.ends_with('~')
+}
+
+fn is_note_markdown(relative: &str) -> bool {
+    let mut parts = relative.split('/');
+    let Some(first) = parts.next() else {
+        return false;
+    };
+    matches!(first, "daily" | "notes")
+        && Path::new(relative)
+            .extension()
+            .and_then(|value| value.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("md"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::tempdir;
+    use zip::write::SimpleFileOptions;
+
+    fn entries(pairs: &[(&str, &str)]) -> Vec<ImportEntry> {
+        pairs
+            .iter()
+            .filter_map(|(path, contents)| {
+                sanitized_relative(path, None).map(|relative| ImportEntry {
+                    relative,
+                    bytes: contents.as_bytes().to_vec(),
+                })
+            })
+            .collect()
+    }
+
+    fn write_zip(path: &Path, pairs: &[(&str, &str)]) {
+        let file = fs::File::create(path).unwrap();
+        let mut writer = zip::ZipWriter::new(file);
+        let options = SimpleFileOptions::default();
+        for (name, contents) in pairs {
+            writer.start_file(*name, options).unwrap();
+            writer.write_all(contents.as_bytes()).unwrap();
+        }
+        writer.finish().unwrap();
+    }
+
+    #[test]
+    fn imports_notes_into_the_open_graph() {
+        let root = tempdir().unwrap();
+        fs::create_dir_all(root.path().join("notes")).unwrap();
+
+        let summary = import_entries_into_graph(
+            root.path(),
+            entries(&[
+                ("notes/a.md", "# A\n"),
+                ("daily/2026-07-04.md", "Today\n"),
+                ("assets/pic.bin", "raw"),
+            ]),
+        )
+        .unwrap();
+
+        assert_eq!(
+            summary,
+            ImportSummary {
+                imported_files: 3,
+                skipped_files: 0,
+                changed_paths: vec![
+                    "notes/a.md".to_string(),
+                    "daily/2026-07-04.md".to_string(),
+                    "assets/pic.bin".to_string()
+                ],
+            }
+        );
+        assert_eq!(
+            fs::read_to_string(root.path().join("notes/a.md")).unwrap(),
+            "# A\n"
+        );
+        assert_eq!(
+            fs::read_to_string(root.path().join("daily/2026-07-04.md")).unwrap(),
+            "Today\n"
+        );
+        assert_eq!(
+            fs::read(root.path().join("assets/pic.bin")).unwrap(),
+            b"raw"
+        );
+    }
+
+    #[test]
+    fn skips_metadata_and_strips_a_wrapper_directory() {
+        let root = tempdir().unwrap();
+        let zip_path = root.path().join("export.zip");
+        write_zip(
+            &zip_path,
+            &[
+                ("Reflect/.gitignore", "ignored"),
+                ("Reflect/.reflect/index.sqlite", "stale"),
+                ("Reflect/.git/config", "git"),
+                ("Reflect/notes/.DS_Store", "junk"),
+                ("Reflect/notes/a.md", "# A\n"),
+            ],
+        );
+
+        let summary = import_zip_into_graph(root.path(), &zip_path).unwrap();
+
+        assert_eq!(summary.imported_files, 1);
+        assert!(root.path().join("notes/a.md").is_file());
+        assert!(!root.path().join(".reflect/index.sqlite").exists());
+        assert!(!root.path().join(".git/config").exists());
+        assert!(!root.path().join("notes/.DS_Store").exists());
+    }
+
+    #[test]
+    fn refuses_to_overwrite_existing_files() {
+        let root = tempdir().unwrap();
+        fs::create_dir_all(root.path().join("notes")).unwrap();
+        fs::write(root.path().join("notes/a.md"), "# Mine\n").unwrap();
+
+        let result = import_entries_into_graph(root.path(), entries(&[("notes/a.md", "# V1\n")]));
+
+        match result.unwrap_err() {
+            AppError::Io { message } => assert!(message.contains("notes/a.md")),
+            other => panic!("expected an IO collision error, got {other:?}"),
+        }
+        assert_eq!(
+            fs::read_to_string(root.path().join("notes/a.md")).unwrap(),
+            "# Mine\n"
+        );
+    }
+
+    #[test]
+    fn identical_existing_files_are_skipped() {
+        let root = tempdir().unwrap();
+        fs::create_dir_all(root.path().join("notes")).unwrap();
+        fs::write(root.path().join("notes/a.md"), "# Same\n").unwrap();
+
+        let summary =
+            import_entries_into_graph(root.path(), entries(&[("notes/a.md", "# Same\n")])).unwrap();
+
+        assert_eq!(
+            summary,
+            ImportSummary {
+                imported_files: 0,
+                skipped_files: 1,
+                changed_paths: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn identical_duplicate_entries_import_once() {
+        let root = tempdir().unwrap();
+
+        let summary = import_entries_into_graph(
+            root.path(),
+            entries(&[("notes/a.md", "# Same\n"), ("notes/a.md", "# Same\n")]),
+        )
+        .unwrap();
+
+        assert_eq!(
+            summary,
+            ImportSummary {
+                imported_files: 1,
+                skipped_files: 0,
+                changed_paths: vec!["notes/a.md".to_string()],
+            }
+        );
+        assert_eq!(
+            fs::read_to_string(root.path().join("notes/a.md")).unwrap(),
+            "# Same\n"
+        );
+    }
+
+    #[test]
+    fn conflicting_duplicate_entries_reject_before_writing() {
+        let root = tempdir().unwrap();
+
+        let result = import_entries_into_graph(
+            root.path(),
+            entries(&[("notes/a.md", "# First\n"), ("notes/a.md", "# Second\n")]),
+        );
+
+        match result.unwrap_err() {
+            AppError::Io { message } => assert!(message.contains("conflicting entries")),
+            other => panic!("expected a duplicate-entry IO error, got {other:?}"),
+        }
+        assert!(!root.path().join("notes/a.md").exists());
+    }
+
+    #[test]
+    fn evicted_icloud_placeholder_blocks_import() {
+        let root = tempdir().unwrap();
+        fs::create_dir_all(root.path().join("notes")).unwrap();
+        fs::write(root.path().join("notes/.a.md.icloud"), "placeholder").unwrap();
+
+        let result = import_entries_into_graph(root.path(), entries(&[("notes/a.md", "# V1\n")]));
+
+        match result.unwrap_err() {
+            AppError::Io { message } => assert!(message.contains("notes/a.md")),
+            other => panic!("expected a placeholder collision error, got {other:?}"),
+        }
+        assert!(!root.path().join("notes/a.md").exists());
+        assert!(root.path().join("notes/.a.md.icloud").exists());
+    }
+
+    #[test]
+    fn rejects_archives_without_notes() {
+        let root = tempdir().unwrap();
+
+        let result = import_entries_into_graph(root.path(), entries(&[("assets/pic.bin", "raw")]));
+
+        assert!(result.is_err());
+        assert!(!root.path().join("assets/pic.bin").exists());
+    }
+
+    #[test]
+    fn wrapper_prefix_ignores_root_metadata_noise() {
+        assert_eq!(
+            wrapper_prefix(&[
+                ".DS_Store".to_string(),
+                ".gitignore".to_string(),
+                "export/notes/a.md".to_string()
+            ]),
+            Some("export".to_string())
+        );
+        assert_eq!(
+            wrapper_prefix(&["notes/a.md".to_string(), "daily/2026-07-04.md".to_string()]),
+            None
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/fs/mod.rs
+++ b/apps/desktop/src-tauri/src/fs/mod.rs
@@ -7,6 +7,7 @@
 //! [`io`]) and deletes go to the OS trash. Parsing/indexing live in later plans.
 
 pub mod assets;
+mod import;
 mod io;
 mod resolve;
 
@@ -211,6 +212,19 @@ pub fn graph_create(
     let info = activate(&state, &root)?;
     allow_asset_scope(&app, &root);
     Ok(info)
+}
+
+/// Import a user-selected Reflect V1 export `.zip` into the open graph. V1's
+/// export is already the graph folder shape, so this extracts safe entries
+/// directly under the current root and refuses to overwrite existing files.
+#[tauri::command]
+pub fn graph_import_reflect_v1_zip(
+    path: String,
+    generation: u64,
+    state: State<GraphState>,
+) -> AppResult<import::ImportSummary> {
+    let root = root_for_generation(&state, generation)?;
+    import::import_zip_into_graph(&root, Path::new(&path))
 }
 
 /// Open an existing graph at `path`, ensuring the standard layout exists.

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -176,6 +176,7 @@ pub fn run() {
             icloud::watch::icloud_watch_stop,
             fs::graph_open,
             fs::graph_create,
+            fs::graph_import_reflect_v1_zip,
             fs::note_read,
             fs::note_write,
             fs::asset_write,

--- a/apps/desktop/src/components/settings-screen.tsx
+++ b/apps/desktop/src/components/settings-screen.tsx
@@ -9,6 +9,7 @@ import { DateTimeSection } from './settings/date-time-section'
 import { DestructiveSection } from './settings/destructive-section'
 import { EditorSection } from './settings/editor-section'
 import { IcloudSection } from './settings/icloud-section'
+import { ImportSection } from './settings/import-section'
 import { IntegrationsSection } from './settings/integrations-section'
 import { SearchSection } from './settings/search-section'
 import { TemplatesSection } from './settings/templates-section'
@@ -33,6 +34,7 @@ export function SettingsScreen(): ReactElement {
         <AiPromptsSection />
         <IntegrationsSection />
         <IcloudSection />
+        <ImportSection />
         <BackupSection />
         <AboutSection />
         <DestructiveSection />

--- a/apps/desktop/src/components/settings/import-section.test.tsx
+++ b/apps/desktop/src/components/settings/import-section.test.tsx
@@ -1,0 +1,140 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const open = vi.hoisted(() => vi.fn<() => Promise<string | null>>())
+const importReflectV1Zip = vi.hoisted(() =>
+  vi.fn<() => Promise<{ importedFiles: number; skippedFiles: number; changedPaths: string[] }>>(),
+)
+const markReflectV1ImportOwnWrites = vi.hoisted(() => vi.fn())
+const graphState = vi.hoisted(() => ({
+  graph: { root: '/graphs/notes', name: 'Notes', generation: 42 } as {
+    root: string
+    name: string
+    generation: number
+  } | null,
+  refreshIndex: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open }))
+vi.mock('@reflect/core', () => ({
+  importReflectV1Zip,
+  markReflectV1ImportOwnWrites,
+  errorMessage: (error: unknown) => (error instanceof Error ? error.message : String(error)),
+}))
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({ graph: graphState.graph, refreshIndex: graphState.refreshIndex }),
+}))
+
+const { ImportSection } = await import('./import-section')
+
+beforeEach(() => {
+  open.mockResolvedValue('/Users/alex/Downloads/reflect-v1.zip')
+  importReflectV1Zip.mockResolvedValue({
+    importedFiles: 2,
+    skippedFiles: 1,
+    changedPaths: ['notes/a.md', 'daily/2026-07-04.md'],
+  })
+  graphState.graph = { root: '/graphs/notes', name: 'Notes', generation: 42 }
+  graphState.refreshIndex.mockClear()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+function importButton(): HTMLButtonElement {
+  const element = screen.getByRole('button', { name: /import zip/i })
+  if (!(element instanceof HTMLButtonElement)) {
+    throw new Error('expected button')
+  }
+  return element
+}
+
+describe('ImportSection', () => {
+  it('imports the selected Reflect V1 zip into the open graph', async () => {
+    render(<ImportSection />)
+
+    fireEvent.click(importButton())
+
+    await waitFor(() =>
+      expect(open).toHaveBeenCalledWith({
+        multiple: false,
+        directory: false,
+        title: 'Import Reflect V1 export',
+        filters: [{ name: 'Zip archives', extensions: ['zip'] }],
+      }),
+    )
+    await waitFor(() =>
+      expect(importReflectV1Zip).toHaveBeenCalledWith(
+        '/Users/alex/Downloads/reflect-v1.zip',
+        42,
+      ),
+    )
+    expect(markReflectV1ImportOwnWrites).toHaveBeenCalledWith({
+      importedFiles: 2,
+      skippedFiles: 1,
+      changedPaths: ['notes/a.md', 'daily/2026-07-04.md'],
+    })
+    expect(graphState.refreshIndex).toHaveBeenCalledTimes(1)
+    expect((await screen.findByRole('status')).textContent).toBe(
+      '2 files imported, 1 already present.',
+    )
+  })
+
+  it('does nothing when the picker is cancelled', async () => {
+    open.mockResolvedValueOnce(null)
+    render(<ImportSection />)
+
+    fireEvent.click(importButton())
+
+    await waitFor(() => expect(open).toHaveBeenCalledTimes(1))
+    expect(importReflectV1Zip).not.toHaveBeenCalled()
+    expect(graphState.refreshIndex).not.toHaveBeenCalled()
+  })
+
+  it('surfaces import failures inline', async () => {
+    importReflectV1Zip.mockRejectedValueOnce(new Error('import would overwrite notes/a.md'))
+    render(<ImportSection />)
+
+    fireEvent.click(importButton())
+
+    expect((await screen.findByRole('alert')).textContent).toBe(
+      'import would overwrite notes/a.md',
+    )
+  })
+
+  it('does not show success after the user switches graphs mid-import', async () => {
+    let finishImport: (summary: {
+      importedFiles: number
+      skippedFiles: number
+      changedPaths: string[]
+    }) => void = () => {}
+    importReflectV1Zip.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishImport = resolve
+        }),
+    )
+    const view = render(<ImportSection />)
+
+    fireEvent.click(importButton())
+    await waitFor(() => expect(importReflectV1Zip).toHaveBeenCalledTimes(1))
+
+    graphState.graph = { root: '/graphs/other', name: 'Other', generation: 43 }
+    view.rerender(<ImportSection />)
+    finishImport({ importedFiles: 7, skippedFiles: 0, changedPaths: ['notes/a.md'] })
+
+    await screen.findByRole('button', { name: /import zip/i })
+    expect(markReflectV1ImportOwnWrites).not.toHaveBeenCalled()
+    expect(screen.queryByRole('status')).toBeNull()
+    expect(graphState.refreshIndex).not.toHaveBeenCalled()
+  })
+
+  it('is disabled until a graph is open', () => {
+    graphState.graph = null
+    render(<ImportSection />)
+
+    expect(importButton().hasAttribute('disabled')).toBe(true)
+  })
+})

--- a/apps/desktop/src/components/settings/import-section.tsx
+++ b/apps/desktop/src/components/settings/import-section.tsx
@@ -1,0 +1,104 @@
+import { useLayoutEffect, useRef, useState, type ReactElement } from 'react'
+import { open } from '@tauri-apps/plugin-dialog'
+import { FileArchive } from 'lucide-react'
+import {
+  importReflectV1Zip,
+  markReflectV1ImportOwnWrites,
+  type GraphImportSummary,
+} from '@reflect/core'
+import { SettingsField } from '@/components/settings/field'
+import { SettingsSection } from '@/components/settings/section'
+import { Button } from '@/components/ui/button'
+import { useAsyncAction } from '@/hooks/use-async-action'
+import { useGraph } from '@/providers/graph-provider'
+
+function summaryText(summary: GraphImportSummary): string {
+  const imported = `${summary.importedFiles} ${
+    summary.importedFiles === 1 ? 'file' : 'files'
+  } imported`
+  if (summary.skippedFiles === 0) {
+    return `${imported}.`
+  }
+  return `${imported}, ${summary.skippedFiles} already present.`
+}
+
+/**
+ * Settings -> Import: copy a Reflect V1 export zip into the currently open
+ * graph. V1 exports are graph-shaped now, which makes this a native unzip into
+ * `daily/`, `notes/`, and `assets/` rather than a migration transform.
+ */
+export function ImportSection(): ReactElement {
+  const { graph, refreshIndex } = useGraph()
+  const action = useAsyncAction()
+  const [summary, setSummary] = useState<GraphImportSummary | null>(null)
+  const graphRef = useRef(graph)
+
+  useLayoutEffect(() => {
+    graphRef.current = graph
+  }, [graph])
+
+  async function chooseAndImport(): Promise<void> {
+    setSummary(null)
+    if (graph === null) {
+      action.setError('Open or create a graph before importing a Reflect V1 export.')
+      return
+    }
+    const currentGraph = graph
+    await action.run(async () => {
+      const result = await open({
+        multiple: false,
+        directory: false,
+        title: 'Import Reflect V1 export',
+        filters: [{ name: 'Zip archives', extensions: ['zip'] }],
+      })
+      const path = typeof result === 'string' ? result : null
+      if (path === null) {
+        return
+      }
+      const imported = await importReflectV1Zip(path, currentGraph.generation)
+      const latestGraph = graphRef.current
+      if (
+        latestGraph === null ||
+        latestGraph.root !== currentGraph.root ||
+        latestGraph.generation !== currentGraph.generation
+      ) {
+        return
+      }
+      markReflectV1ImportOwnWrites(imported)
+      setSummary(imported)
+      refreshIndex()
+    })
+  }
+
+  return (
+    <SettingsSection id="import">
+      <SettingsField
+        legend="Reflect V1"
+        description="Choose the .zip export from Reflect V1. Its markdown files are copied into this graph without replacing different existing files."
+      >
+        <div className="mt-2">
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            disabled={action.pending || graph === null}
+            onClick={() => void chooseAndImport()}
+          >
+            <FileArchive aria-hidden strokeWidth={1.75} />
+            {action.pending ? 'Importing...' : 'Import zip...'}
+          </Button>
+        </div>
+        {summary !== null ? (
+          <p role="status" className="mt-2 text-xs text-text-muted">
+            {summaryText(summary)}
+          </p>
+        ) : null}
+        {action.error !== null ? (
+          <p role="alert" className="mt-2 text-xs text-destructive">
+            {action.error}
+          </p>
+        ) : null}
+      </SettingsField>
+    </SettingsSection>
+  )
+}

--- a/apps/desktop/src/components/settings/sections.ts
+++ b/apps/desktop/src/components/settings/sections.ts
@@ -16,6 +16,7 @@ export const SETTINGS_SECTIONS = [
   { id: 'integrations', title: 'Integrations' },
   // macOS only (same gate) — Windows/Linux have no iCloud Drive.
   { id: 'icloud', title: 'iCloud sync' },
+  { id: 'import', title: 'Import' },
   { id: 'backup', title: 'Backup' },
   { id: 'about', title: 'About' },
   { id: 'destructive', title: 'Danger zone' },

--- a/packages/core/src/graph/commands.test.ts
+++ b/packages/core/src/graph/commands.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { subscribeOwnWrites } from '../indexing/local-write-echo'
 import { setBridge } from '../ipc/bridge'
-import { openAsset } from './commands'
+import { importReflectV1Zip, markReflectV1ImportOwnWrites, openAsset } from './commands'
 
 afterEach(() => {
   setBridge(null)
@@ -17,5 +18,43 @@ describe('graph commands', () => {
       path: 'assets/cat.png',
       generation: 7,
     })
+  })
+
+  it('imports Reflect V1 zips through the generation-pinned native command', async () => {
+    const invoke = vi.fn(async () => ({
+      importedFiles: 2,
+      skippedFiles: 0,
+      changedPaths: ['notes/a.md', 'daily/2026-07-04.md'],
+    }))
+    setBridge({ invoke, listen: async () => () => {} })
+    const summary = await importReflectV1Zip('/tmp/reflect-v1.zip', 7)
+
+    expect(invoke).toHaveBeenCalledWith('graph_import_reflect_v1_zip', {
+      path: '/tmp/reflect-v1.zip',
+      generation: 7,
+    })
+    expect(summary).toEqual({
+      importedFiles: 2,
+      skippedFiles: 0,
+      changedPaths: ['notes/a.md', 'daily/2026-07-04.md'],
+    })
+  })
+
+  it('marks completed import files as this device’s own writes', () => {
+    const seen: string[] = []
+    const unlisten = subscribeOwnWrites((path) => {
+      seen.push(path)
+    })
+    try {
+      markReflectV1ImportOwnWrites({
+        importedFiles: 2,
+        skippedFiles: 0,
+        changedPaths: ['notes/a.md', 'daily/2026-07-04.md'],
+      })
+
+      expect(seen).toEqual(['notes/a.md', 'daily/2026-07-04.md'])
+    } finally {
+      unlisten()
+    }
   })
 })

--- a/packages/core/src/graph/commands.ts
+++ b/packages/core/src/graph/commands.ts
@@ -3,9 +3,11 @@ import { echoLocalWrite } from '../indexing/local-write-echo'
 import { call } from '../ipc/invoke'
 import {
   fileMetaSchema,
+  graphImportSummarySchema,
   graphInfoSchema,
   recentGraphSchema,
   type FileMeta,
+  type GraphImportSummary,
   type GraphInfo,
   type RecentGraph,
 } from './schemas'
@@ -21,6 +23,31 @@ export async function openGraph(path: string): Promise<GraphInfo> {
 /** Create a new graph at `path` and open it. */
 export async function createGraph(path: string): Promise<GraphInfo> {
   return call('graph_create', { path }, graphInfoSchema)
+}
+
+/**
+ * Import a Reflect V1 export `.zip` into the open graph. V1 exports already use
+ * Reflect Open's graph-folder layout; Rust extracts safe entries under the
+ * active graph root and refuses to overwrite different existing files.
+ */
+export async function importReflectV1Zip(
+  path: string,
+  generation: number,
+): Promise<GraphImportSummary> {
+  return call('graph_import_reflect_v1_zip', { path, generation }, graphImportSummarySchema)
+}
+
+/**
+ * Mark files imported by {@link importReflectV1Zip} as this device's writes.
+ * Call only after the UI confirms the imported graph is still the active graph:
+ * these paths are graph-relative and the own-write channel is scoped to the
+ * currently running iCloud controller.
+ */
+export function markReflectV1ImportOwnWrites(summary: GraphImportSummary): void {
+  const modifiedMs = Date.now()
+  for (const changedPath of summary.changedPaths) {
+    echoLocalWrite({ path: changedPath, kind: 'upsert', modifiedMs })
+  }
 }
 
 /**

--- a/packages/core/src/graph/schemas.ts
+++ b/packages/core/src/graph/schemas.ts
@@ -40,3 +40,14 @@ export const fileMetaSchema = z.object({
   placeholder: z.boolean().optional(),
 })
 export type FileMeta = z.infer<typeof fileMetaSchema>
+
+/** Result of importing a Reflect V1 graph-shaped zip into the open graph. */
+export const graphImportSummarySchema = z.object({
+  /** Files newly written to the open graph. */
+  importedFiles: z.number(),
+  /** Files already present with identical bytes, left untouched. */
+  skippedFiles: z.number(),
+  /** Graph-relative paths newly written to the open graph. */
+  changedPaths: z.array(z.string()),
+})
+export type GraphImportSummary = z.infer<typeof graphImportSummarySchema>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,13 +88,17 @@ export {
   graphInfoSchema,
   recentGraphSchema,
   fileMetaSchema,
+  graphImportSummarySchema,
   type GraphInfo,
   type RecentGraph,
   type FileMeta,
+  type GraphImportSummary,
 } from './graph/schemas'
 export {
   openGraph,
   createGraph,
+  importReflectV1Zip,
+  markReflectV1ImportOwnWrites,
   readNote,
   writeNote,
   writeAsset,


### PR DESCRIPTION
## Problem

Reflect V1 exports now use Reflect Open's graph-folder shape, so the old first-run V1 importer was removed. That left a gap for the new iCloud flow: after someone creates or moves into an iCloud-backed graph, there was no Settings path to pick the V1 export zip and copy those markdown files into the active graph.

This PR restores that migration surface without bringing back a content transform or separate graph-creation flow.

## Before -> After

| Before | After |
| --- | --- |
| Settings had no Import area for V1 exports. | Settings includes Import -> Reflect V1 with a zip picker. |
| V1-compatible exports had to be manually unzipped/copied into the graph folder. | The app imports the selected `.zip` into the open graph and refreshes that graph's index. |
| Importing into an existing/iCloud graph had no overwrite policy. | Native import refuses to replace different existing files, blocks unreadable iCloud placeholders, skips identical files, and rejects conflicting duplicate archive entries before writing. |

## Changes

1. Added `graph_import_reflect_v1_zip`, a Tauri command that reads a user-selected zip, strips a single wrapper folder, skips `.reflect/`, `.git/`, `.gitignore`, and OS/editor junk, validates that notes exist under `daily/` or `notes/`, dedupes identical archive paths, and writes safe entries into the generation-pinned active graph.
2. Added a typed `importReflectV1Zip` wrapper, `markReflectV1ImportOwnWrites` helper, and `GraphImportSummary` schema in `@reflect/core`; Settings marks written paths as this device's own writes only after confirming the same graph is still active, so iCloud-hosted graphs do not classify the import watcher events as external ingests.
3. Added Settings -> Import -> Reflect V1 with a zip picker, pending/error/success state, stale graph-switch guarding, and an index refresh after import only when the same graph is still open.
4. Added Rust coverage for valid imports, wrapper stripping, metadata skips, overwrite refusal, identical-file skips, duplicate archive entries, iCloud placeholder collisions, and non-note archive rejection; added core coverage for import own-write markers; added UI coverage for picker/import/cancel/error/disabled/stale-graph states.

## Verification

- `pnpm --filter @reflect/desktop sidecar` passed.
- `cargo test -p reflect-open import::tests --locked` passed.
- `pnpm --filter @reflect/core exec vitest run src/graph/commands.test.ts` passed.
- `pnpm --filter @reflect/desktop exec vitest run src/components/settings/import-section.test.tsx` passed.
- `pnpm check` passed. It still reports existing `max-lines` warnings in unrelated large files.
- Verified the sample export at `/Users/alex/Downloads/reflect-maccman-20260704-2352-v1.0.zip` with `unzip -t`; it is valid and contains top-level `.gitignore`, `daily/`, and `notes/` with 7,339 markdown files under `daily/`/`notes/`.

## Risk / Rollout

No database migration or external service call. The importer writes into the active graph, so the main data risk is accidental overwrite; this is mitigated by generation pinning, traversal checks, iCloud-placeholder-aware occupancy checks, duplicate-entry preflight, and refusing to replace different existing files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Writes directly into the active graph filesystem; mitigations include generation pinning, traversal guards, no-overwrite policy, and placeholder-aware collision checks, but large imports can still affect user data at scale.
> 
> **Overview**
> Restores a **Settings → Import** path for copying Reflect V1 `.zip` exports into the currently open graph (no content migration—V1 exports already match the graph-folder layout).
> 
> **Rust** adds `graph_import_reflect_v1_zip`: generation-pinned extraction with path sanitization, optional single wrapper-folder strip, skips for `.reflect`/`.git`/junk, validation that `daily/` or `notes/` contain markdown, duplicate-entry checks, refusal to overwrite differing files (including iCloud eviction placeholders), and atomic writes with identical-byte skips. **`@reflect/core`** exposes `importReflectV1Zip`, `GraphImportSummary`, and `markReflectV1ImportOwnWrites` so imported paths are treated as local writes on iCloud graphs.
> 
> **UI** wires a zip picker, pending/error/success state, mid-import graph-switch guard, and index refresh only when the same graph is still open. Tests cover Rust import edge cases, core IPC/own-write echo, and the settings section behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afeb39fa60d61869f81ca7d45a3843b4b10e178c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->