### PR TITLE
Release v0.4.0-beta.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4742,7 +4742,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.4.0-beta.17"
+version = "0.4.0-beta.18"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.4.0-beta.17"
+version = "0.4.0-beta.18"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.4.0-beta.17",
+  "version": "0.4.0-beta.18",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.4.0-beta.18.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version-only changes with no functional code edits.
> 
> **Overview**
> **Release version bump** from `0.4.0-beta.17` to **`0.4.0-beta.18`** for the desktop Tauri app.
> 
> The same version string is updated in **`apps/desktop/src-tauri/Cargo.toml`** (`reflect-open`), **`apps/desktop/src-tauri/tauri.conf.json`** (`productName` / bundle metadata), and **`Cargo.lock`** for the `reflect-open` package entry. No application logic or dependency changes beyond the lockfile reflecting the crate version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fff53eddf72c6718b58ebcd8d3deead21e1d22b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->