### PR TITLE
feat(mobile): Tasks tab — desktop task data with a touch surface

### DIFF
--- a/apps/desktop/src/components/tasks/task-group-section.tsx
+++ b/apps/desktop/src/components/tasks/task-group-section.tsx
@@ -1,9 +1,9 @@
 import type { MutableRefObject, ReactElement } from 'react'
-import { AlarmClock, Calendar, FileText, Pin, Plus, Star } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import type { OpenTask, TaskGroup } from '@reflect/core'
+import { addTargetForGroup, taskGroupHeaderStyle } from '@/lib/tasks/task-group-presentation'
 import type { InsertTaskTarget } from '@/lib/tasks/task-insert-target'
 import { taskKey } from '@/lib/tasks/task-identity'
-import { insertTargetForTask, todaysDailyTarget } from '@/lib/tasks/task-navigation'
 import type { TaskSelection } from '@/lib/tasks/use-task-selection'
 import type { TaskRowEditHandlers } from '@/lib/tasks/use-task-row-handlers'
 import { cn } from '@/lib/utils'
@@ -28,35 +28,6 @@ interface TaskGroupSectionProps {
 }
 
 /**
- * Where this group's "+ Add" adds a task (V1: Current → today's daily, a note →
- * that note), or `null` for the aggregate Overdue/Upcoming buckets, which span
- * many notes and so show no Add button.
- */
-function addTargetForGroup(group: TaskGroup, today: string): InsertTaskTarget | null {
-  if (group.kind === 'current') {
-    return todaysDailyTarget(today)
-  }
-  const first = group.tasks[0]
-  return group.kind === 'note' && first !== undefined ? insertTargetForTask(first) : null
-}
-
-/** The icon + accent colour for a group's sticky header, V1's per-bucket styling. */
-function headerStyle(group: TaskGroup): { icon: ReactElement; colorClass: string } {
-  switch (group.kind) {
-    case 'current':
-      return { icon: <Star aria-hidden className="size-4" />, colorClass: 'text-amber-500' }
-    case 'overdue':
-      return { icon: <AlarmClock aria-hidden className="size-4" />, colorClass: 'text-red-500' }
-    case 'upcoming':
-      return { icon: <Calendar aria-hidden className="size-4" />, colorClass: 'text-green-600' }
-    case 'note':
-      return group.tasks[0]?.isPinned
-        ? { icon: <Pin aria-hidden className="size-4" />, colorClass: 'text-accent' }
-        : { icon: <FileText aria-hidden className="size-4" />, colorClass: 'text-text-secondary' }
-  }
-}
-
-/**
  * One section of the Tasks view (V1 design): a sticky, colour-coded header — a
  * date bucket (Current/Overdue/Upcoming) or a note — over its task rows. The
  * header sticks to the top of the scroll container, so the next group's header
@@ -75,7 +46,7 @@ export function TaskGroupSection({
 }: TaskGroupSectionProps): ReactElement {
   const showSource = group.kind !== 'note'
   const { notePath } = group
-  const { icon, colorClass } = headerStyle(group)
+  const { icon, colorClass } = taskGroupHeaderStyle(group)
   const addTarget = addTargetForGroup(group, today)
 
   return (

--- a/apps/desktop/src/components/tasks/tasks-screen.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.tsx
@@ -12,7 +12,6 @@ import { Archive, CalendarClock, List, Search } from 'lucide-react'
 import {
   getCompletedTasks,
   getOpenTasks,
-  groupTasks,
   hasBridge,
   type OpenTask,
   type TaskGroup,
@@ -25,7 +24,8 @@ import { type InsertTaskTarget } from '@/lib/tasks/task-insert-target'
 import { scrollTaskIntoView } from '@/lib/tasks/task-navigation'
 import { useTaskActions } from '@/lib/tasks/use-task-actions'
 import { useTaskRowHandlers } from '@/lib/tasks/use-task-row-handlers'
-import { useTaskFilters, type TaskFilters } from '@/lib/tasks/task-filters'
+import { useTaskFilters } from '@/lib/tasks/task-filters'
+import { composeVisibleTaskGroups } from '@/lib/tasks/task-visibility'
 import { useTaskKeyboard } from '@/lib/tasks/use-task-keyboard'
 import { useTaskSelection } from '@/lib/tasks/use-task-selection'
 import { completedTasksQueryKey, tasksQueryKey } from '@/lib/tasks/tasks-query'
@@ -38,22 +38,6 @@ import { TaskFiltersMenu } from './task-filters-menu'
 import { TaskGroupSection } from './task-group-section'
 import { TaskScheduleCalendar } from './task-schedule-calendar'
 import { TaskToolbarCountBadge } from './task-toolbar-count-badge'
-
-/** Keep only the groups the active filters allow (V1's per-bucket toggles). */
-function visibleGroups(groups: TaskGroup[], filters: TaskFilters): TaskGroup[] {
-  return groups.filter((group) => {
-    switch (group.kind) {
-      case 'current':
-        return filters.current
-      case 'overdue':
-        return filters.overdue
-      case 'upcoming':
-        return filters.upcoming
-      case 'note':
-        return group.tasks[0]?.isPinned ? filters.pinned : filters.other
-    }
-  })
-}
 
 /** The selected task that owns keyboard focus: the cursor/anchor, else the first row left selected. */
 function focusedSelectedKey(
@@ -125,31 +109,11 @@ export function TasksScreen(): ReactElement {
   const recentlyCompleted = useRecentlyCompleted(graph?.root ?? null)
 
   const needle = query.trim().toLowerCase()
-  const groups = useMemo(() => {
-    if (open === undefined) {
-      return []
-    }
-    // The struck "completed" rows. With archived on, the completed query is the
-    // full history — but a just-completed task may not be in it until the reindex
-    // refetches (and the query reloads blank when you first flip the filter on),
-    // so union the session set on top, deduped, to keep this run's rows visible.
-    // With archived off, the session set is the only source.
-    const completedRows = filters.archived
-      ? [
-          ...(completed ?? []),
-          ...recentlyCompleted.filter(
-            (task) => !(completed ?? []).some((row) => sameTask(row, task)),
-          ),
-        ]
-      : recentlyCompleted
-    // Drop any open row that's also present there — a refetch can briefly restore a
-    // just-completed task to the open cache before the reindex lands, and listing
-    // it both open and struck collides React keys.
-    const completedKeys = new Set(completedRows.map(taskKey))
-    const all = [...open.filter((task) => !completedKeys.has(taskKey(task))), ...completedRows]
-    const matched = needle ? all.filter((task) => task.text.toLowerCase().includes(needle)) : all
-    return visibleGroups(groupTasks(matched, today), filters)
-  }, [open, completed, recentlyCompleted, filters, needle, today])
+  const groups = useMemo(
+    () =>
+      composeVisibleTaskGroups({ open, completed, recentlyCompleted, filters, needle, today }),
+    [open, completed, recentlyCompleted, filters, needle, today],
+  )
 
   // The flat, render-order list of tasks the selection and its shortcuts act on.
   const orderedTasks = useMemo(() => groups.flatMap((group) => group.tasks), [groups])

--- a/apps/desktop/src/lib/tasks/task-group-presentation.tsx
+++ b/apps/desktop/src/lib/tasks/task-group-presentation.tsx
@@ -1,0 +1,46 @@
+import type { ReactElement } from 'react'
+import { AlarmClock, Calendar, FileText, Pin, Star } from 'lucide-react'
+import type { TaskGroup } from '@reflect/core'
+import type { InsertTaskTarget } from '@/lib/tasks/task-insert-target'
+import { insertTargetForTask, todaysDailyTarget } from '@/lib/tasks/task-navigation'
+
+/**
+ * The presentation contract a task-group section shares across surfaces —
+ * V1's per-bucket styling and add-target rule, one definition for the desktop
+ * sections and the mobile groups so the two can't drift on bucket colours or
+ * where "+ Add" writes.
+ */
+
+export interface TaskGroupHeaderStyle {
+  icon: ReactElement
+  colorClass: string
+}
+
+/** The icon + accent colour for a group's sticky header, V1's per-bucket styling. */
+export function taskGroupHeaderStyle(group: TaskGroup): TaskGroupHeaderStyle {
+  switch (group.kind) {
+    case 'current':
+      return { icon: <Star aria-hidden className="size-4" />, colorClass: 'text-amber-500' }
+    case 'overdue':
+      return { icon: <AlarmClock aria-hidden className="size-4" />, colorClass: 'text-red-500' }
+    case 'upcoming':
+      return { icon: <Calendar aria-hidden className="size-4" />, colorClass: 'text-green-600' }
+    case 'note':
+      return group.tasks[0]?.isPinned
+        ? { icon: <Pin aria-hidden className="size-4" />, colorClass: 'text-accent' }
+        : { icon: <FileText aria-hidden className="size-4" />, colorClass: 'text-text-secondary' }
+  }
+}
+
+/**
+ * Where this group's add button adds a task (V1: Current → today's daily, a
+ * note → that note), or `null` for the aggregate Overdue/Upcoming buckets,
+ * which span many notes and so show no add button.
+ */
+export function addTargetForGroup(group: TaskGroup, today: string): InsertTaskTarget | null {
+  if (group.kind === 'current') {
+    return todaysDailyTarget(today)
+  }
+  const first = group.tasks[0]
+  return group.kind === 'note' && first !== undefined ? insertTargetForTask(first) : null
+}

--- a/apps/desktop/src/lib/tasks/task-visibility.test.ts
+++ b/apps/desktop/src/lib/tasks/task-visibility.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+import type { OpenTask } from '@reflect/core'
+import type { TaskFilters } from '@/lib/tasks/task-filters'
+import { composeVisibleTaskGroups, visibleGroups } from '@/lib/tasks/task-visibility'
+
+const TODAY = '2026-06-14'
+
+const ALL_ON: TaskFilters = {
+  pinned: true,
+  current: true,
+  overdue: true,
+  upcoming: true,
+  other: true,
+  archived: false,
+}
+
+function task(overrides: Partial<OpenTask> = {}): OpenTask {
+  const text = overrides.text ?? 'do it'
+  return {
+    notePath: 'notes/n.md',
+    markerOffset: 2,
+    raw: `[ ] ${text}`,
+    checked: false,
+    text,
+    noteTitle: 'N',
+    dueDate: null,
+    dailyDate: null,
+    isPinned: false,
+    pinnedOrder: null,
+    updatedAt: 0,
+    ...overrides,
+  }
+}
+
+describe('composeVisibleTaskGroups', () => {
+  it('returns nothing while the open list is still loading', () => {
+    const groups = composeVisibleTaskGroups({
+      open: undefined,
+      completed: undefined,
+      recentlyCompleted: [task()],
+      filters: ALL_ON,
+      needle: '',
+      today: TODAY,
+    })
+    expect(groups).toEqual([])
+  })
+
+  it('groups open tasks into desktop’s buckets', () => {
+    const groups = composeVisibleTaskGroups({
+      open: [
+        task({ text: 'today', dueDate: TODAY, markerOffset: 0 }),
+        task({ text: 'late', dueDate: '2026-06-01', markerOffset: 10 }),
+        task({ text: 'later', dueDate: '2026-07-01', markerOffset: 20 }),
+        task({ text: 'undated', markerOffset: 30 }),
+      ],
+      completed: undefined,
+      recentlyCompleted: [],
+      filters: ALL_ON,
+      needle: '',
+      today: TODAY,
+    })
+    expect(groups.map((group) => group.kind)).toEqual(['current', 'overdue', 'upcoming', 'note'])
+  })
+
+  it('drops the buckets the filters turn off, honoring pinned vs other notes', () => {
+    const groups = composeVisibleTaskGroups({
+      open: [
+        task({ text: 'late', dueDate: '2026-06-01' }),
+        task({ text: 'pinned note', notePath: 'notes/p.md', noteTitle: 'P', isPinned: true }),
+        task({ text: 'plain note', notePath: 'notes/q.md', noteTitle: 'Q' }),
+      ],
+      completed: undefined,
+      recentlyCompleted: [],
+      filters: { ...ALL_ON, overdue: false, other: false },
+      needle: '',
+      today: TODAY,
+    })
+    expect(groups).toHaveLength(1)
+    expect(groups[0]).toMatchObject({ kind: 'note', label: 'P' })
+  })
+
+  it('keeps this session’s completed tasks struck, replacing their open rows', () => {
+    const done = task({ text: 'done', markerOffset: 0 })
+    const groups = composeVisibleTaskGroups({
+      // A refetch can briefly restore the completed row to the open cache; the
+      // struck copy must win or React keys collide.
+      open: [done, task({ text: 'still open', markerOffset: 10 })],
+      completed: undefined,
+      recentlyCompleted: [{ ...done, checked: true, raw: '[x] done' }],
+      filters: ALL_ON,
+      needle: '',
+      today: TODAY,
+    })
+    const rows = groups.flatMap((group) => group.tasks)
+    expect(rows).toHaveLength(2)
+    expect(rows.find((row) => row.text === 'done')?.checked).toBe(true)
+  })
+
+  it('unions the completed history and the session set when archived is on', () => {
+    const sessionDone = task({ text: 'just now', markerOffset: 0, checked: true })
+    const historical = task({ text: 'long ago', markerOffset: 10, checked: true })
+    const groups = composeVisibleTaskGroups({
+      open: [],
+      // The session row is also in the history — it must not list twice.
+      completed: [historical, sessionDone],
+      recentlyCompleted: [sessionDone],
+      filters: { ...ALL_ON, archived: true },
+      needle: '',
+      today: TODAY,
+    })
+    const rows = groups.flatMap((group) => group.tasks)
+    expect(rows.map((row) => row.text).sort()).toEqual(['just now', 'long ago'])
+  })
+
+  it('filters by the search needle across open and struck rows', () => {
+    const groups = composeVisibleTaskGroups({
+      open: [task({ text: 'buy milk', markerOffset: 0 }), task({ text: 'call mum', markerOffset: 10 })],
+      completed: undefined,
+      recentlyCompleted: [],
+      filters: ALL_ON,
+      needle: 'milk',
+      today: TODAY,
+    })
+    const rows = groups.flatMap((group) => group.tasks)
+    expect(rows.map((row) => row.text)).toEqual(['buy milk'])
+  })
+})
+
+describe('visibleGroups', () => {
+  it('keeps every group with every filter on', () => {
+    const groups = composeVisibleTaskGroups({
+      open: [task({ text: 'a', dueDate: TODAY })],
+      completed: undefined,
+      recentlyCompleted: [],
+      filters: ALL_ON,
+      needle: '',
+      today: TODAY,
+    })
+    expect(visibleGroups(groups, ALL_ON)).toEqual(groups)
+  })
+})

--- a/apps/desktop/src/lib/tasks/task-visibility.ts
+++ b/apps/desktop/src/lib/tasks/task-visibility.ts
@@ -20,16 +20,16 @@ export function visibleGroups(groups: TaskGroup[], filters: TaskFilters): TaskGr
 
 export interface TaskListSources {
   /** The open-tasks query data (`undefined` while loading). */
-  open: OpenTask[] | undefined
+  readonly open: OpenTask[] | undefined
   /** The completed-tasks query data — only read when `filters.archived` is on. */
-  completed: OpenTask[] | undefined
+  readonly completed: OpenTask[] | undefined
   /** This session's completed tasks, still showing struck until archived. */
-  recentlyCompleted: readonly OpenTask[]
-  filters: TaskFilters
+  readonly recentlyCompleted: readonly OpenTask[]
+  readonly filters: TaskFilters
   /** The search text, already trimmed and lowercased (empty = no filter). */
-  needle: string
+  readonly needle: string
   /** Today's ISO `YYYY-MM-DD` date. */
-  today: string
+  readonly today: string
 }
 
 /**

--- a/apps/desktop/src/lib/tasks/task-visibility.ts
+++ b/apps/desktop/src/lib/tasks/task-visibility.ts
@@ -1,0 +1,73 @@
+import { groupTasks, type OpenTask, type TaskGroup } from '@reflect/core'
+import { sameTask, taskKey } from '@/lib/tasks/task-identity'
+import { type TaskFilters } from '@/lib/tasks/task-filters'
+
+/** Keep only the groups the active filters allow (V1's per-bucket toggles). */
+export function visibleGroups(groups: TaskGroup[], filters: TaskFilters): TaskGroup[] {
+  return groups.filter((group) => {
+    switch (group.kind) {
+      case 'current':
+        return filters.current
+      case 'overdue':
+        return filters.overdue
+      case 'upcoming':
+        return filters.upcoming
+      case 'note':
+        return group.tasks[0]?.isPinned ? filters.pinned : filters.other
+    }
+  })
+}
+
+export interface TaskListSources {
+  /** The open-tasks query data (`undefined` while loading). */
+  open: OpenTask[] | undefined
+  /** The completed-tasks query data — only read when `filters.archived` is on. */
+  completed: OpenTask[] | undefined
+  /** This session's completed tasks, still showing struck until archived. */
+  recentlyCompleted: readonly OpenTask[]
+  filters: TaskFilters
+  /** The search text, already trimmed and lowercased (empty = no filter). */
+  needle: string
+  /** Today's ISO `YYYY-MM-DD` date. */
+  today: string
+}
+
+/**
+ * The Tasks list every surface renders (Plan 18): open rows merged with the
+ * struck "completed" rows, searched, grouped ({@link groupTasks}) and narrowed to
+ * the buckets the filters allow. Shared by the desktop screen and the mobile
+ * Tasks tab so the two can't drift on the merge rules:
+ *
+ * - With archived on, the completed query is the full history — but a
+ *   just-completed task may not be in it until the reindex refetches (and the
+ *   query reloads blank when the filter first flips on), so the session set is
+ *   unioned on top, deduped. With archived off, the session set is the only
+ *   source of struck rows.
+ * - Any open row also present struck is dropped from the open side — a refetch
+ *   can briefly restore a just-completed task to the open cache before the
+ *   reindex lands, and listing it both open and struck collides React keys.
+ */
+export function composeVisibleTaskGroups({
+  open,
+  completed,
+  recentlyCompleted,
+  filters,
+  needle,
+  today,
+}: TaskListSources): TaskGroup[] {
+  if (open === undefined) {
+    return []
+  }
+  const completedRows = filters.archived
+    ? [
+        ...(completed ?? []),
+        ...recentlyCompleted.filter(
+          (task) => !(completed ?? []).some((row) => sameTask(row, task)),
+        ),
+      ]
+    : recentlyCompleted
+  const completedKeys = new Set(completedRows.map(taskKey))
+  const all = [...open.filter((task) => !completedKeys.has(taskKey(task))), ...completedRows]
+  const matched = needle ? all.filter((task) => task.text.toLowerCase().includes(needle)) : all
+  return visibleGroups(groupTasks(matched, today), filters)
+}

--- a/apps/desktop/src/mobile/mobile-app.tsx
+++ b/apps/desktop/src/mobile/mobile-app.tsx
@@ -3,7 +3,7 @@ import { installBackgroundFlush } from '@/lib/background-flush'
 import { MobileErrorBoundary } from '@/mobile/mobile-error-boundary'
 import { MobileOnboardingScreen } from '@/mobile/onboarding-screen'
 import { MobileShell } from '@/mobile/mobile-shell'
-import { SyncStatusPill } from '@/mobile/sync-status-pill'
+import { MobileStatusLayer } from '@/mobile/status-layer'
 import { useICloudRefresh } from '@/mobile/use-icloud-refresh'
 import { useKeyboardHeightVar } from '@/mobile/use-keyboard'
 import { useTaskCheckboxHaptics } from '@/mobile/use-task-haptics'
@@ -49,7 +49,7 @@ export function MobileApp(): ReactElement {
               plain-language status pill (step 10). */}
           <SyncProvider graph={graph}>
             <MobileShell />
-            <SyncStatusPill />
+            <MobileStatusLayer />
           </SyncProvider>
         </RouterProvider>
       </MobileErrorBoundary>

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -370,6 +370,16 @@ describe('MobileShell', () => {
     expect(view.getByRole('heading', { level: 1 }).textContent).toBe(monthLabel(todayIso()))
   })
 
+  it('switches to the Tasks tab, which renders the grouped task list', async () => {
+    const user = userEvent.setup()
+    const view = mount({ kind: 'today' })
+
+    await user.click(view.getByRole('button', { name: 'Tasks' }))
+    expect(view.getByRole('searchbox', { name: 'Search tasks' })).toBeTruthy()
+    // The fake bridge's index is empty, so the tab lands on its empty state.
+    expect((await view.findByText('No tasks to show')).textContent).toBe('No tasks to show')
+  })
+
   it('hides the tab bar while the software keyboard is up (V1: the keyboard covered it)', () => {
     const view = mount({ kind: 'today' })
     expect(view.getByRole('navigation', { name: 'Sections' })).toBeTruthy()

--- a/apps/desktop/src/mobile/mobile-screen.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.tsx
@@ -3,6 +3,7 @@ import { useToday } from '@/lib/use-today'
 import { MobileAllNotes } from '@/mobile/screens/all-notes'
 import { MobileDaily } from '@/mobile/screens/daily'
 import { MobileNote } from '@/mobile/screens/note'
+import { MobileTasks } from '@/mobile/screens/tasks'
 import type { AllNotesFilters } from '@/mobile/search-filters/filter-state'
 import type { Route } from '@/routing/route'
 
@@ -23,9 +24,9 @@ interface MobileScreenProps {
 
 /**
  * The mobile route switch (Plan 19): the same typed `Route` history desktop
- * uses, one screen per route — the daily spine, notes, and the All
- * tab (which also hosts `search` entries). Kinds without a mobile surface
- * yet (chat, settings) fall back to today. Today is `useToday()`'s **live** date, so an app left open
+ * uses, one screen per route — the daily spine, notes, the All
+ * tab (which also hosts `search` entries), and the Tasks tab. Kinds without
+ * a mobile surface yet (chat, settings) fall back to today. Today is `useToday()`'s **live** date, so an app left open
  * overnight rolls to the new day's note at midnight instead of editing
  * yesterday's.
  */
@@ -68,6 +69,8 @@ export function MobileScreen({
           onFiltersChange={onAllFiltersChange}
         />
       )
+    case 'tasks':
+      return <MobileTasks key="tasks" />
     default:
       return <MobileDaily key="daily" date={today} />
   }

--- a/apps/desktop/src/mobile/mobile-shell.tsx
+++ b/apps/desktop/src/mobile/mobile-shell.tsx
@@ -42,9 +42,11 @@ export function MobileShell(): ReactElement {
   const tab: MobileTab =
     route.kind === 'allNotes' || route.kind === 'search'
       ? 'all'
-      : route.kind === 'today' || route.kind === 'daily'
-        ? 'daily'
-        : lastTab
+      : route.kind === 'tasks'
+        ? 'tasks'
+        : route.kind === 'today' || route.kind === 'daily'
+          ? 'daily'
+          : lastTab
   if (tab !== lastTab) {
     setLastTab(tab)
   }
@@ -78,7 +80,13 @@ export function MobileShell(): ReactElement {
         <MobileTabBar
           tab={tab}
           onSelect={(next) =>
-            navigate(next === 'daily' ? { kind: 'today' } : { kind: 'allNotes', tag: null })
+            navigate(
+              next === 'daily'
+                ? { kind: 'today' }
+                : next === 'tasks'
+                  ? { kind: 'tasks' }
+                  : { kind: 'allNotes', tag: null },
+            )
           }
         />
       )}

--- a/apps/desktop/src/mobile/mobile-tab-bar.tsx
+++ b/apps/desktop/src/mobile/mobile-tab-bar.tsx
@@ -1,9 +1,9 @@
 import { useLayoutEffect, useRef, type ReactElement } from 'react'
-import { Files, SquarePen } from 'lucide-react'
+import { CircleCheck, Files, SquarePen } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { hapticImpactLight } from '@/mobile/haptics'
 
-export type MobileTab = 'daily' | 'all'
+export type MobileTab = 'daily' | 'all' | 'tasks'
 
 interface MobileTabBarProps {
   tab: MobileTab
@@ -11,8 +11,9 @@ interface MobileTabBarProps {
 }
 
 /**
- * The V1-parity bottom tab bar: Daily (the chronological spine) and All
- * (every note + search). It sits at the very bottom of the shell. In V1 the
+ * The V1-parity bottom tab bar: Daily (the chronological spine), All
+ * (every note + search), and Tasks (every open checkbox, grouped). It sits at
+ * the very bottom of the shell. In V1 the
  * software keyboard simply covered it; the shell root now ends at the
  * keyboard's top, so the shell hides the bar while the keyboard is up to
  * keep that behavior.
@@ -62,6 +63,12 @@ export function MobileTabBar({ tab, onSelect }: MobileTabBarProps): ReactElement
         icon={<Files className="size-5" />}
         active={tab === 'all'}
         onClick={() => onSelect('all')}
+      />
+      <TabButton
+        label="Tasks"
+        icon={<CircleCheck className="size-5" />}
+        active={tab === 'tasks'}
+        onClick={() => onSelect('tasks')}
       />
     </nav>
   )

--- a/apps/desktop/src/mobile/operations-pill.test.tsx
+++ b/apps/desktop/src/mobile/operations-pill.test.tsx
@@ -1,0 +1,97 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resetOperations, startOperation, type OperationHandle } from '@/lib/operations'
+import { publishKeyboardHeight } from '@/mobile/use-keyboard'
+import { MobileOperationsPills } from './operations-pill'
+import { MobileStatusLayer } from './status-layer'
+
+/**
+ * The mobile face of the operations store: failed/warning background work
+ * shows as pills above the tab bar (running work stays silent), a tap
+ * dismisses, and the layer yields to the keyboard like the sync pill.
+ */
+
+// The layer renders the sync pill too; keep it quiet so these tests only see
+// operation pills (its own behavior is covered in sync-status-pill.test.tsx).
+vi.mock('@/mobile/use-sync-status', () => ({ useMobileSyncStatus: () => null }))
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  resetOperations()
+})
+
+afterEach(() => {
+  cleanup()
+  publishKeyboardHeight(0)
+  vi.useRealTimers()
+})
+
+/** Start an operation inside act so the store emit lands in a React batch. */
+function operate(run: () => OperationHandle): OperationHandle {
+  let handle: OperationHandle | undefined
+  act(() => {
+    handle = run()
+  })
+  return handle!
+}
+
+describe('MobileOperationsPills', () => {
+  it('renders nothing while operations are merely running', () => {
+    render(<MobileOperationsPills />)
+    operate(() => startOperation('Completing task'))
+
+    expect(screen.queryByRole('status')).toBeNull()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('shows a failed operation with its label and message', () => {
+    render(<MobileOperationsPills />)
+    const handle = operate(() => startOperation('Completing task'))
+    act(() => handle.fail('The note is busy.'))
+
+    const pill = screen.getByRole('alert')
+    expect(pill.textContent).toContain('Completing task')
+    expect(pill.textContent).toContain('The note is busy.')
+  })
+
+  it('shows a warning as a status pill', () => {
+    render(<MobileOperationsPills />)
+    const handle = operate(() => startOperation('Importing notes'))
+    act(() => handle.warn('2 files skipped.'))
+
+    expect(screen.getByRole('status').textContent).toContain('2 files skipped.')
+  })
+
+  it('dismisses a pill on tap', () => {
+    render(<MobileOperationsPills />)
+    const handle = operate(() => startOperation('Completing task'))
+    act(() => handle.fail('The note is busy.'))
+
+    fireEvent.click(screen.getByRole('alert'))
+
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('expires with the store’s linger window', () => {
+    render(<MobileOperationsPills />)
+    const handle = operate(() => startOperation('Completing task'))
+    act(() => handle.fail('The note is busy.'))
+
+    act(() => vi.runAllTimers())
+
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})
+
+describe('MobileStatusLayer', () => {
+  it('yields to the software keyboard', () => {
+    render(<MobileStatusLayer />)
+    const handle = operate(() => startOperation('Completing task'))
+    act(() => handle.fail('The note is busy.'))
+    expect(screen.getByRole('alert')).toBeTruthy()
+
+    act(() => publishKeyboardHeight(300))
+
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/apps/desktop/src/mobile/operations-pill.tsx
+++ b/apps/desktop/src/mobile/operations-pill.tsx
@@ -1,0 +1,50 @@
+import type { ReactElement } from 'react'
+import { dismissOperation, useOperations } from '@/lib/operations'
+import { cn } from '@/lib/utils'
+
+/**
+ * Failed and warning background operations as tappable pills (Plan 19
+ * follow-up): the mobile face of the {@link startOperation} store, which
+ * desktop mirrors into its toaster. Without this, a failed write — a task
+ * toggle refused by the stale-index guard, a busy note — would roll the
+ * optimistic UI back with no explanation. The store already lingers failures
+ * and expires them; this renders whatever needs attention, and a tap
+ * dismisses early. Running operations stay invisible here — the phone
+ * surface only speaks up when something went wrong.
+ */
+export function MobileOperationsPills(): ReactElement | null {
+  const operations = useOperations()
+  const attention = operations.filter((operation) => operation.status !== 'running')
+
+  if (attention.length === 0) {
+    return null
+  }
+
+  return (
+    <>
+      {attention.map((operation) => (
+        <button
+          key={operation.id}
+          type="button"
+          role={operation.status === 'failed' ? 'alert' : 'status'}
+          onClick={() => dismissOperation(operation.id)}
+          className="pointer-events-auto flex max-w-[85vw] items-center gap-1.5 rounded-full border border-border bg-surface px-3 py-1 text-xs font-medium shadow-sm"
+        >
+          <span
+            aria-hidden
+            className={cn(
+              'size-1.5 shrink-0 rounded-full',
+              operation.status === 'failed' ? 'bg-red-500' : 'bg-amber-500',
+            )}
+          />
+          <span className="truncate">
+            {operation.label}
+            {operation.message !== null ? (
+              <span className="font-normal text-text-muted"> — {operation.message}</span>
+            ) : null}
+          </span>
+        </button>
+      ))}
+    </>
+  )
+}

--- a/apps/desktop/src/mobile/screens/tasks.test.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.test.tsx
@@ -430,6 +430,38 @@ describe('MobileTasks', () => {
     view.unmount()
   })
 
+  it('flushes an edited draft when the screen unmounts under an open sheet', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Edit: buy milk' }))
+    const input = view.getByRole('textbox', { name: 'Task text' })
+    await user.clear(input)
+    await user.type(input, 'buy oat milk')
+
+    // A tab switch unmounts the whole screen — no dismissal callback fires.
+    view.unmount()
+
+    await waitFor(() => expect(editTask).toHaveBeenCalledTimes(1))
+    expect(editTask.mock.calls[0]?.[1]).toBe('buy oat milk')
+  })
+
+  it('deletes an abandoned "+"-added task when the screen unmounts', async () => {
+    getOpenTasks.mockResolvedValue([
+      task({ text: 'jotted today', dailyDate: '2026-06-14', notePath: 'daily/2026-06-14.md' }),
+    ])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Add a task to today' }))
+    await view.findByRole('textbox', { name: 'Task text' })
+    view.unmount()
+
+    await waitFor(() => expect(deleteTask).toHaveBeenCalledTimes(1))
+    expect(editTask).not.toHaveBeenCalled()
+  })
+
   it('hides buckets through the filter sheet', async () => {
     getOpenTasks.mockResolvedValue([
       task({ text: 'jotted today', dailyDate: '2026-06-14', notePath: 'daily/2026-06-14.md' }),

--- a/apps/desktop/src/mobile/screens/tasks.test.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.test.tsx
@@ -279,6 +279,29 @@ describe('MobileTasks', () => {
     view.unmount()
   })
 
+  it('commits edits from a sheet re-opened after an action closed it', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    // First visit ends through an action button (Complete), which skips the
+    // dismissal commit. The sheet stays mounted for the same task afterwards.
+    await user.click(await view.findByRole('button', { name: 'Edit: buy milk' }))
+    await user.click(view.getByRole('button', { name: 'Complete' }))
+    await waitFor(() => expect(toggleTask).toHaveBeenCalledTimes(1))
+
+    // Second visit (the struck row): its edits must still commit on dismiss.
+    await user.click(view.getByRole('button', { name: 'Edit: buy milk' }))
+    const input = asTextArea(view.getByRole('textbox', { name: 'Task text' }))
+    await user.clear(input)
+    await user.type(input, 'buy oat milk')
+    await user.click(view.getByRole('button', { name: 'dismiss-drawer' }))
+
+    expect(editTask).toHaveBeenCalledTimes(1)
+    expect(editTask.mock.calls[0]?.[1]).toBe('buy oat milk')
+    view.unmount()
+  })
+
   it('converts to a bullet from the sheet', async () => {
     getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
     const user = userEvent.setup()

--- a/apps/desktop/src/mobile/screens/tasks.test.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.test.tsx
@@ -366,6 +366,21 @@ describe('MobileTasks', () => {
     view.unmount()
   })
 
+  it('opens the source note of an untouched empty task without deleting it', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: '', raw: '[ ] ' })])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Edit: Empty task' }))
+    await user.click(view.getByRole('button', { name: 'Open note' }))
+
+    // Navigates to the line's note — deleting it out from under the visit
+    // would be wrong; only dismissal treats an abandoned empty row as delete.
+    expect(view.getByTestId('route').textContent).toContain('notes/n.md')
+    expect(deleteTask).not.toHaveBeenCalled()
+    view.unmount()
+  })
+
   it('deletes from the sheet', async () => {
     getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
     const user = userEvent.setup()

--- a/apps/desktop/src/mobile/screens/tasks.test.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.test.tsx
@@ -1,0 +1,425 @@
+import { type ReactNode } from 'react'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OpenTask } from '@reflect/core'
+import { resetRecentlyCompleted } from '@/lib/tasks/recently-completed'
+import { RouterProvider, useRouter } from '@/routing/router'
+import { MobileTasks } from './tasks'
+
+/**
+ * The mobile Tasks tab (V1 mobile's third tab over Plan 18 data): desktop's
+ * groups and guarded write-backs with a touch surface — checkbox toggles,
+ * the quick-edit sheet (edit / schedule / complete / convert / open note /
+ * delete), the filter sheet, and "+" add. The core getters and the note-task
+ * write layer are mocked, like the desktop screen's tests; grouping/merge
+ * rules are unit-tested in task-visibility.test.ts.
+ */
+
+const getOpenTasks = vi.hoisted(() => vi.fn())
+const getCompletedTasks = vi.hoisted(() => vi.fn())
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  hasBridge: () => true,
+  getOpenTasks,
+  getCompletedTasks,
+}))
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({ graph: { root: '/g', name: 'g', generation: 1 } }),
+}))
+vi.mock('@/lib/use-today', () => ({ useToday: () => '2026-06-14' }))
+vi.mock('@/providers/settings-provider', () => ({
+  useSettings: () => ({ settings: { dateFormat: 'mdy', weekStartDay: 'monday' } }),
+}))
+// TaskText renders through meowdown's MarkdownView, which jsdom can't mount.
+vi.mock('@/editor/markdown-preview', () => ({
+  MarkdownPreview: ({ content, className }: { content: string; className?: string }) => (
+    <span data-testid="markdown-preview" className={className}>
+      {content}
+    </span>
+  ),
+}))
+
+const toggleTask = vi.hoisted(() => vi.fn())
+const deleteTask = vi.hoisted(() => vi.fn())
+const editTask = vi.hoisted(() => vi.fn())
+const insertTask = vi.hoisted(() => vi.fn())
+const convertTaskToBullet = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/note-task', () => ({
+  toggleTask,
+  deleteTask,
+  editTask,
+  insertTask,
+  convertTaskToBullet,
+}))
+
+const fail = vi.hoisted(() => vi.fn())
+const startOperation = vi.hoisted(() => vi.fn(() => ({ fail })))
+vi.mock('@/lib/operations', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/operations')>()),
+  startOperation,
+}))
+
+// vaul needs browser APIs jsdom doesn't provide (matchMedia, pointer capture);
+// its drag/animation is verified on-device. This passthrough honours `open` and
+// exposes the dismissal path as a button, so commit-on-dismiss is testable.
+vi.mock('@/components/ui/drawer', () => ({
+  Drawer: ({
+    open,
+    onOpenChange,
+    children,
+  }: {
+    open?: boolean
+    onOpenChange?: (open: boolean) => void
+    children?: ReactNode
+  }) =>
+    open ? (
+      <div data-testid="drawer">
+        {children}
+        <button type="button" onClick={() => onOpenChange?.(false)}>
+          dismiss-drawer
+        </button>
+      </div>
+    ) : null,
+  DrawerContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DrawerTitle: ({ children }: { children?: ReactNode }) => <h2>{children}</h2>,
+}))
+
+function task(overrides: Partial<OpenTask> = {}): OpenTask {
+  const text = overrides.text ?? 'do it'
+  return {
+    notePath: 'notes/n.md',
+    markerOffset: 2,
+    raw: `[ ] ${text}`,
+    checked: false,
+    text,
+    noteTitle: 'N',
+    dueDate: null,
+    dailyDate: null,
+    isPinned: false,
+    pinnedOrder: null,
+    updatedAt: 0,
+    ...overrides,
+  }
+}
+
+/** Narrow a queried element to the sheet's textarea so `.value` typechecks. */
+function asTextArea(element: HTMLElement): HTMLTextAreaElement {
+  if (!(element instanceof HTMLTextAreaElement)) {
+    throw new Error('expected a textarea')
+  }
+  return element
+}
+
+function RouteProbe(): ReactNode {
+  const { route } = useRouter()
+  return <output data-testid="route">{JSON.stringify(route)}</output>
+}
+
+function renderScreen() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <RouterProvider>
+        <MobileTasks />
+        <RouteProbe />
+      </RouterProvider>
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  window.sessionStorage.clear()
+  getOpenTasks.mockReset()
+  getCompletedTasks.mockReset()
+  getCompletedTasks.mockResolvedValue([])
+  toggleTask.mockReset()
+  deleteTask.mockReset()
+  editTask.mockReset()
+  insertTask.mockReset()
+  insertTask.mockResolvedValue(0)
+  convertTaskToBullet.mockReset()
+  convertTaskToBullet.mockResolvedValue(undefined)
+  startOperation.mockClear()
+  fail.mockReset()
+  resetRecentlyCompleted()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('MobileTasks', () => {
+  it('renders desktop’s groups with counts and source dates', async () => {
+    getOpenTasks.mockResolvedValue([
+      task({ text: 'jotted today', dailyDate: '2026-06-14', notePath: 'daily/2026-06-14.md', markerOffset: 0 }),
+      task({ text: 'late', dueDate: '2026-06-01', dailyDate: '2026-06-01', notePath: 'daily/2026-06-01.md', markerOffset: 0 }),
+      task({ text: 'undated', markerOffset: 0 }),
+    ])
+    const view = renderScreen()
+
+    await view.findByText('Current')
+    view.getByText('Overdue')
+    // The undated task groups under its source note's title.
+    view.getByRole('button', { name: 'N' })
+    // Date buckets show the source note's compact date on the row.
+    view.getByText('6/1/2026')
+    view.unmount()
+  })
+
+  it('toggles a task from its checkbox and keeps it struck until archived', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Complete: buy milk' }))
+
+    expect(toggleTask).toHaveBeenCalledTimes(1)
+    // V1's middle state: the completed row stays visible, struck, reopenable.
+    await view.findByRole('button', { name: 'Reopen: buy milk' })
+
+    // Archive hides this session's completed rows.
+    await user.click(view.getByRole('button', { name: 'Archive 1 completed' }))
+    await waitFor(() => expect(view.queryByText('buy milk')).toBeNull())
+    view.unmount()
+  })
+
+  it('commits an edited draft when the quick-edit sheet is dismissed', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Edit: buy milk' }))
+    const input = asTextArea(view.getByRole('textbox', { name: 'Task text' }))
+    expect(input.value).toBe('buy milk')
+
+    await user.clear(input)
+    await user.type(input, 'buy oat milk')
+    await user.click(view.getByRole('button', { name: 'dismiss-drawer' }))
+
+    expect(editTask).toHaveBeenCalledTimes(1)
+    expect(editTask.mock.calls[0]?.[1]).toBe('buy oat milk')
+    view.unmount()
+  })
+
+  it('does not write when the sheet closes with an untouched draft', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Edit: buy milk' }))
+    await user.click(view.getByRole('button', { name: 'dismiss-drawer' }))
+
+    expect(editTask).not.toHaveBeenCalled()
+    expect(deleteTask).not.toHaveBeenCalled()
+    view.unmount()
+  })
+
+  it('deletes the task when the sheet is dismissed with an emptied draft', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Edit: buy milk' }))
+    await user.clear(view.getByRole('textbox', { name: 'Task text' }))
+    await user.click(view.getByRole('button', { name: 'dismiss-drawer' }))
+
+    expect(deleteTask).toHaveBeenCalledTimes(1)
+    expect(editTask).not.toHaveBeenCalled()
+    view.unmount()
+  })
+
+  it('schedules by editing the draft’s date link, committing one write', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Edit: buy milk' }))
+    await user.click(view.getByRole('button', { name: 'Tomorrow' }))
+    expect(asTextArea(view.getByRole('textbox', { name: 'Task text' })).value).toBe(
+      'buy milk [[2026-06-15]]',
+    )
+
+    await user.click(view.getByRole('button', { name: 'dismiss-drawer' }))
+    expect(editTask).toHaveBeenCalledTimes(1)
+    expect(editTask.mock.calls[0]?.[1]).toBe('buy milk [[2026-06-15]]')
+    view.unmount()
+  })
+
+  it('clears the due date from the schedule row', async () => {
+    getOpenTasks.mockResolvedValue([
+      task({ text: 'late [[2026-06-01]]', raw: '[ ] late [[2026-06-01]]', dueDate: '2026-06-01' }),
+    ])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: /^Edit: late/ }))
+    await user.click(view.getByRole('button', { name: 'Clear' }))
+    expect(asTextArea(view.getByRole('textbox', { name: 'Task text' })).value).toBe('late')
+    view.unmount()
+  })
+
+  it('completes from the sheet, saving a changed draft first', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Edit: buy milk' }))
+    const input = view.getByRole('textbox', { name: 'Task text' })
+    await user.clear(input)
+    await user.type(input, 'buy oat milk')
+    await user.click(view.getByRole('button', { name: 'Complete' }))
+
+    await waitFor(() => expect(editTask).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(toggleTask).toHaveBeenCalledTimes(1))
+    // One write path: dismissal must not commit again after the action closed
+    // the sheet.
+    expect(editTask).toHaveBeenCalledTimes(1)
+    view.unmount()
+  })
+
+  it('converts to a bullet from the sheet', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Edit: buy milk' }))
+    await user.click(view.getByRole('button', { name: 'Convert to bullet' }))
+
+    await waitFor(() => expect(convertTaskToBullet).toHaveBeenCalledTimes(1))
+    view.unmount()
+  })
+
+  it('opens the source note from the sheet', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Edit: buy milk' }))
+    await user.click(view.getByRole('button', { name: 'Open note' }))
+
+    expect(view.getByTestId('route').textContent).toContain('notes/n.md')
+    view.unmount()
+  })
+
+  it('deletes from the sheet', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Edit: buy milk' }))
+    await user.click(view.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(deleteTask).toHaveBeenCalledTimes(1))
+    view.unmount()
+  })
+
+  it('adds a task to today’s daily from the Current group and opens its sheet', async () => {
+    getOpenTasks.mockResolvedValue([
+      task({ text: 'jotted today', dailyDate: '2026-06-14', notePath: 'daily/2026-06-14.md' }),
+    ])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Add a task to today' }))
+
+    await waitFor(() => expect(insertTask).toHaveBeenCalledWith('daily/2026-06-14.md', 1))
+    // The new (empty) task's quick-edit sheet opens to type into.
+    const input = asTextArea(await view.findByRole('textbox', { name: 'Task text' }))
+    expect(input.value).toBe('')
+
+    await user.type(input, 'new thing')
+    await user.click(view.getByRole('button', { name: 'dismiss-drawer' }))
+    expect(editTask).toHaveBeenCalledTimes(1)
+    expect(editTask.mock.calls[0]?.[1]).toBe('new thing')
+    view.unmount()
+  })
+
+  it('abandoning a "+"-added task deletes it instead of ghosting an empty row', async () => {
+    getOpenTasks.mockResolvedValue([
+      task({ text: 'jotted today', dailyDate: '2026-06-14', notePath: 'daily/2026-06-14.md' }),
+    ])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Add a task to today' }))
+    await view.findByRole('textbox', { name: 'Task text' })
+    await user.click(view.getByRole('button', { name: 'dismiss-drawer' }))
+
+    await waitFor(() => expect(deleteTask).toHaveBeenCalledTimes(1))
+    expect(editTask).not.toHaveBeenCalled()
+    view.unmount()
+  })
+
+  it('hides buckets through the filter sheet', async () => {
+    getOpenTasks.mockResolvedValue([
+      task({ text: 'jotted today', dailyDate: '2026-06-14', notePath: 'daily/2026-06-14.md' }),
+      task({ text: 'undated' }),
+    ])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await view.findByText('Current')
+    await user.click(view.getByRole('button', { name: 'Task filters' }))
+    await user.click(view.getByRole('checkbox', { name: 'Current' }))
+
+    await waitFor(() => expect(view.queryByText('jotted today')).toBeNull())
+    view.getByText('undated')
+    view.unmount()
+  })
+
+  it('reveals the completed history behind “Show archived”', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'still open' })])
+    getCompletedTasks.mockResolvedValue([
+      task({ text: 'long done', markerOffset: 40, checked: true, raw: '[x] long done' }),
+    ])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await view.findByText('still open')
+    expect(view.queryByText('long done')).toBeNull()
+
+    await user.click(view.getByRole('button', { name: 'Task filters' }))
+    await user.click(view.getByRole('checkbox', { name: 'Show archived' }))
+
+    await view.findByText('long done')
+    view.unmount()
+  })
+
+  it('filters rows by the search text', async () => {
+    getOpenTasks.mockResolvedValue([
+      task({ text: 'buy milk', markerOffset: 0 }),
+      task({ text: 'call mum', markerOffset: 10 }),
+    ])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await view.findByText('buy milk')
+    await user.type(view.getByRole('searchbox', { name: 'Search tasks' }), 'milk')
+
+    await waitFor(() => expect(view.queryByText('call mum')).toBeNull())
+    view.getByText('buy milk')
+    view.unmount()
+  })
+
+  it('shows an empty state whose button adds to today’s daily', async () => {
+    getOpenTasks.mockResolvedValue([])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await view.findByText('No tasks to show')
+    await user.click(view.getByRole('button', { name: 'Add a task' }))
+
+    await waitFor(() => expect(insertTask).toHaveBeenCalledWith('daily/2026-06-14.md', 1))
+    view.unmount()
+  })
+
+  it('surfaces a failed open-tasks read', async () => {
+    getOpenTasks.mockRejectedValue(new Error('no index'))
+    const view = renderScreen()
+
+    await view.findByRole('alert')
+    view.unmount()
+  })
+})

--- a/apps/desktop/src/mobile/screens/tasks.test.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.test.tsx
@@ -314,6 +314,46 @@ describe('MobileTasks', () => {
     view.unmount()
   })
 
+  it('deletes an emptied draft on Complete instead of resurrecting the text', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Edit: buy milk' }))
+    await user.clear(view.getByRole('textbox', { name: 'Task text' }))
+    await user.click(view.getByRole('button', { name: 'Complete' }))
+
+    await waitFor(() => expect(deleteTask).toHaveBeenCalledTimes(1))
+    expect(toggleTask).not.toHaveBeenCalled()
+    view.unmount()
+  })
+
+  it('deletes an emptied draft on Convert instead of resurrecting the text', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Edit: buy milk' }))
+    await user.clear(view.getByRole('textbox', { name: 'Task text' }))
+    await user.click(view.getByRole('button', { name: 'Convert to bullet' }))
+
+    await waitFor(() => expect(deleteTask).toHaveBeenCalledTimes(1))
+    expect(convertTaskToBullet).not.toHaveBeenCalled()
+    view.unmount()
+  })
+
+  it('keeps open tasks visible while the archived history is still loading', async () => {
+    window.sessionStorage.setItem('reflect.tasks.filter.archived', 'true')
+    getOpenTasks.mockResolvedValue([task({ text: 'still open' })])
+    getCompletedTasks.mockReturnValue(new Promise<OpenTask[]>(() => {}))
+    const view = renderScreen()
+
+    // The open groups render; the pending completed query must not blank them.
+    await view.findByText('still open')
+    expect(view.queryByLabelText('Loading tasks')).toBeNull()
+    view.unmount()
+  })
+
   it('opens the source note from the sheet', async () => {
     getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
     const user = userEvent.setup()

--- a/apps/desktop/src/mobile/screens/tasks.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.tsx
@@ -144,14 +144,17 @@ export function MobileTasks(): ReactElement {
           <SlidersHorizontal />
         </Button>
       </header>
-      {enabled && !ready && !isError ? (
-        <div className="flex flex-1 items-center justify-center" aria-label="Loading tasks">
-          <Spinner className="size-5 text-text-muted" />
-        </div>
-      ) : isError ? (
+      {isError ? (
         <p role="alert" className="px-4 py-6 text-sm text-text-muted">
           Couldn’t load tasks.
         </p>
+      ) : enabled && !ready && groups.length === 0 ? (
+        // Loading only gates what would otherwise be a false empty state: with
+        // archived flipping on, the open groups keep showing while the
+        // completed history loads (desktop likewise gates only the message).
+        <div className="flex flex-1 items-center justify-center" aria-label="Loading tasks">
+          <Spinner className="size-5 text-text-muted" />
+        </div>
       ) : groups.length === 0 ? (
         <div className="flex flex-1 flex-col items-center justify-center gap-3 text-text-muted">
           <CircleCheck className="size-6" />

--- a/apps/desktop/src/mobile/screens/tasks.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.tsx
@@ -76,6 +76,22 @@ export function MobileTasks(): ReactElement {
     [open, completed, recentlyCompleted, filters, needle, today],
   )
 
+  // The sheet edits the task's *live* row, not the snapshot taken when it
+  // opened: a mutation or reindex can rewrite the row (raw, checked) while
+  // `editingTask` is set, and acting on the stale copy could flip a marker the
+  // wrong way or trip the write-back guard needlessly. Fall back to the
+  // snapshot when the row left the lists — the raw-match guard then refuses
+  // any write that no longer applies.
+  const liveEditingTask = useMemo(() => {
+    if (editingTask === null) {
+      return null
+    }
+    const key = taskKey(editingTask)
+    return (
+      groups.flatMap((group) => group.tasks).find((row) => taskKey(row) === key) ?? editingTask
+    )
+  }, [groups, editingTask])
+
   const editTask = (task: OpenTask): void => {
     setEditingTask(task)
     setSheetOpen(true)
@@ -160,10 +176,10 @@ export function MobileTasks(): ReactElement {
           ))}
         </div>
       )}
-      {editingTask !== null ? (
+      {liveEditingTask !== null ? (
         <MobileTaskEditSheet
-          key={taskKey(editingTask)}
-          task={editingTask}
+          key={taskKey(liveEditingTask)}
+          task={liveEditingTask}
           open={sheetOpen}
           onOpenChange={setSheetOpen}
           today={today}

--- a/apps/desktop/src/mobile/screens/tasks.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.tsx
@@ -1,0 +1,182 @@
+import { useDeferredValue, useMemo, useState, type ReactElement } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Archive, CircleCheck, SlidersHorizontal } from 'lucide-react'
+import {
+  getCompletedTasks,
+  getOpenTasks,
+  hasBridge,
+  type OpenTask,
+} from '@reflect/core'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Spinner } from '@/components/ui/spinner'
+import { useRecentlyCompleted } from '@/lib/tasks/recently-completed'
+import { taskKey } from '@/lib/tasks/task-identity'
+import { useTaskFilters } from '@/lib/tasks/task-filters'
+import { type InsertTaskTarget } from '@/lib/tasks/task-insert-target'
+import { todaysDailyTarget } from '@/lib/tasks/task-navigation'
+import { composeVisibleTaskGroups } from '@/lib/tasks/task-visibility'
+import { completedTasksQueryKey, tasksQueryKey } from '@/lib/tasks/tasks-query'
+import { useTaskActions } from '@/lib/tasks/use-task-actions'
+import { useToday } from '@/lib/use-today'
+import { MobileTaskEditSheet } from '@/mobile/task-edit-sheet'
+import { TaskFiltersDrawer } from '@/mobile/task-filters-drawer'
+import { MobileTaskGroup } from '@/mobile/task-group'
+import { useGraph } from '@/providers/graph-provider'
+import { routeForPath } from '@/routing/route'
+import { useRouter } from '@/routing/router'
+
+/**
+ * The Tasks tab (V1 mobile's third tab over Plan 18's shipped data layer): every
+ * open task across the graph in desktop's exact groups — Current / Overdue /
+ * Upcoming, then per-note — via the same queries, grouping
+ * ({@link composeVisibleTaskGroups}) and optimistic mutations
+ * ({@link useTaskActions}) the desktop view uses; this screen adds only the
+ * touch surface. Checkboxes toggle with a light haptic; tapping a row opens the
+ * quick-edit sheet (edit / schedule / complete / convert / open note) instead of
+ * desktop's multi-select; the filter sheet carries desktop's bucket toggles and
+ * "Show archived". Completing keeps the row struck (V1's middle state) until
+ * Archive hides this session's completed tasks.
+ */
+export function MobileTasks(): ReactElement {
+  const { graph } = useGraph()
+  const { navigate } = useRouter()
+  const today = useToday()
+  const { filters, toggle } = useTaskFilters()
+  const [query, setQuery] = useState('')
+  const [filtersOpen, setFiltersOpen] = useState(false)
+  // The sheet's task sticks around after close so the exit animation has
+  // content; `sheetOpen` alone drives visibility.
+  const [editingTask, setEditingTask] = useState<OpenTask | null>(null)
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const enabled = hasBridge() && graph !== null
+
+  const { data: open, isError: openFailed } = useQuery({
+    queryKey: tasksQueryKey(graph?.root),
+    queryFn: () => getOpenTasks(),
+    enabled,
+  })
+  const { data: completed, isError: completedFailed } = useQuery({
+    queryKey: completedTasksQueryKey(graph?.root),
+    queryFn: () => getCompletedTasks(),
+    enabled: enabled && filters.archived,
+  })
+  const isError = openFailed || (filters.archived && completedFailed)
+  const ready = open !== undefined && (!filters.archived || completed !== undefined)
+
+  const recentlyCompleted = useRecentlyCompleted(graph?.root ?? null)
+  const actions = useTaskActions()
+
+  // Defer the needle like the All tab defers its query: fast typing coalesces
+  // while the input stays live.
+  const needle = useDeferredValue(query).trim().toLowerCase()
+  const groups = useMemo(
+    () =>
+      composeVisibleTaskGroups({ open, completed, recentlyCompleted, filters, needle, today }),
+    [open, completed, recentlyCompleted, filters, needle, today],
+  )
+
+  const editTask = (task: OpenTask): void => {
+    setEditingTask(task)
+    setSheetOpen(true)
+  }
+
+  // The group headers' "+" (V1): drop any search filter so the new row is
+  // visible, write it, then open its quick-edit sheet to type into.
+  const onAdd = (target: InsertTaskTarget): void => {
+    setQuery('')
+    void actions.insert(target).then((created) => {
+      if (created !== null) {
+        editTask(created)
+      }
+    })
+  }
+
+  return (
+    <div
+      className="flex h-full w-screen flex-col"
+      style={{ paddingTop: 'env(safe-area-inset-top)' }}
+    >
+      <header className="flex shrink-0 items-center gap-1 border-b border-border px-4 pb-2 pt-1">
+        <Input
+          type="search"
+          inputMode="search"
+          placeholder="Search tasks…"
+          aria-label="Search tasks"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          className="text-base"
+        />
+        {recentlyCompleted.length > 0 ? (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-10 shrink-0"
+            aria-label={`Archive ${recentlyCompleted.length} completed`}
+            onClick={actions.archive}
+          >
+            <Archive />
+          </Button>
+        ) : null}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-10 shrink-0"
+          aria-label="Task filters"
+          onClick={() => setFiltersOpen(true)}
+        >
+          <SlidersHorizontal />
+        </Button>
+      </header>
+      {enabled && !ready && !isError ? (
+        <div className="flex flex-1 items-center justify-center" aria-label="Loading tasks">
+          <Spinner className="size-5 text-text-muted" />
+        </div>
+      ) : isError ? (
+        <p role="alert" className="px-4 py-6 text-sm text-text-muted">
+          Couldn’t load tasks.
+        </p>
+      ) : groups.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 text-text-muted">
+          <CircleCheck className="size-6" />
+          <p className="text-sm">{needle ? 'No matching tasks' : 'No tasks to show'}</p>
+          {needle === '' ? (
+            <Button variant="outline" onClick={() => onAdd(todaysDailyTarget(today))}>
+              Add a task
+            </Button>
+          ) : null}
+        </div>
+      ) : (
+        <div className="min-h-0 flex-1 overflow-y-auto pb-8">
+          {groups.map((group) => (
+            <MobileTaskGroup
+              key={group.kind === 'note' ? `note:${group.notePath}` : group.kind}
+              group={group}
+              today={today}
+              onAdd={onAdd}
+              onEdit={editTask}
+              onOpen={(path) => navigate(routeForPath(path))}
+            />
+          ))}
+        </div>
+      )}
+      {editingTask !== null ? (
+        <MobileTaskEditSheet
+          key={taskKey(editingTask)}
+          task={editingTask}
+          open={sheetOpen}
+          onOpenChange={setSheetOpen}
+          today={today}
+          actions={actions}
+          onOpenNote={(path) => navigate(routeForPath(path))}
+        />
+      ) : null}
+      <TaskFiltersDrawer
+        open={filtersOpen}
+        onOpenChange={setFiltersOpen}
+        filters={filters}
+        toggle={toggle}
+      />
+    </div>
+  )
+}

--- a/apps/desktop/src/mobile/screens/tasks.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.tsx
@@ -68,8 +68,11 @@ export function MobileTasks(): ReactElement {
   const actions = useTaskActions()
 
   // Defer the needle like the All tab defers its query: fast typing coalesces
-  // while the input stays live.
-  const needle = useDeferredValue(query).trim().toLowerCase()
+  // while the input stays live. A cleared query applies immediately — the "+"
+  // add clears it so the new row is visible, and a stale deferred needle must
+  // not keep hiding that row while it catches up.
+  const deferredQuery = useDeferredValue(query)
+  const needle = (query === '' ? '' : deferredQuery).trim().toLowerCase()
   const groups = useMemo(
     () =>
       composeVisibleTaskGroups({ open, completed, recentlyCompleted, filters, needle, today }),

--- a/apps/desktop/src/mobile/status-layer.tsx
+++ b/apps/desktop/src/mobile/status-layer.tsx
@@ -1,0 +1,33 @@
+import type { ReactElement } from 'react'
+import { MobileOperationsPills } from '@/mobile/operations-pill'
+import { SyncStatusPill } from '@/mobile/sync-status-pill'
+import { useKeyboardVisible } from '@/mobile/use-keyboard'
+
+/**
+ * The one viewport-anchored slot for mobile status pills, stacked above the
+ * tab bar: operation failures ({@link MobileOperationsPills}) over the sync
+ * pill. `position: fixed` elements are viewport-anchored — the shell root's
+ * keyboard yield doesn't apply — so the layer hides while the keyboard is up
+ * and places itself via the height the tab bar publishes (the safe-area
+ * fallback covers surfaces without one). The container ignores touches;
+ * individual pills opt back in.
+ */
+export function MobileStatusLayer(): ReactElement | null {
+  const keyboardVisible = useKeyboardVisible()
+
+  if (keyboardVisible) {
+    return null
+  }
+
+  return (
+    <div
+      className="pointer-events-none fixed inset-x-0 z-50 flex flex-col items-center gap-2"
+      style={{
+        bottom: 'calc(var(--mobile-tab-bar-height, env(safe-area-inset-bottom, 0px)) + 0.75rem)',
+      }}
+    >
+      <MobileOperationsPills />
+      <SyncStatusPill />
+    </div>
+  )
+}

--- a/apps/desktop/src/mobile/sync-status-pill.tsx
+++ b/apps/desktop/src/mobile/sync-status-pill.tsx
@@ -4,12 +4,13 @@ import { useKeyboardVisible } from '@/mobile/use-keyboard'
 import { useMobileSyncStatus } from '@/mobile/use-sync-status'
 
 /**
- * The floating sync-status pill (Plan 19, step 10): a small viewport-anchored
- * chip above the tab bar that appears only while sync has something to say —
- * `Syncing` during a cycle, `Needs review` while any note carries conflict
- * markers, `Offline`/`Needs attention` after a failed cycle. The quiet
- * `Backed up` state renders nothing (detail lives in the settings sheet), it
- * never intercepts touches, and it yields to the software keyboard.
+ * The sync-status pill (Plan 19, step 10): a small chip that appears only
+ * while sync has something to say — `Syncing` during a cycle, `Needs review`
+ * while any note carries conflict markers, `Offline`/`Needs attention` after
+ * a failed cycle. The quiet `Backed up` state renders nothing (detail lives
+ * in the settings sheet) and it never intercepts touches. Positioning above
+ * the tab bar belongs to {@link MobileStatusLayer}; the keyboard check here
+ * backstops the layer's, keeping the pill correct if ever mounted alone.
  */
 export function SyncStatusPill(): ReactElement | null {
   const status = useMobileSyncStatus()
@@ -20,31 +21,20 @@ export function SyncStatusPill(): ReactElement | null {
   }
 
   return (
-    // `position: fixed` elements are viewport-anchored, so this one places
-    // itself above the tab bar via the height the bar publishes (the shell
-    // root's keyboard yield doesn't apply — hence the keyboard check above;
-    // the safe-area fallback covers surfaces without a tab bar).
     <div
-      className="pointer-events-none fixed inset-x-0 z-50 flex justify-center"
-      style={{
-        bottom: 'calc(var(--mobile-tab-bar-height, env(safe-area-inset-bottom, 0px)) + 0.75rem)',
-      }}
+      role="status"
+      className="flex items-center gap-1.5 rounded-full border border-border bg-surface px-3 py-1 text-xs font-medium shadow-sm"
     >
-      <div
-        role="status"
-        className="flex items-center gap-1.5 rounded-full border border-border bg-surface px-3 py-1 text-xs font-medium shadow-sm"
-      >
-        <span
-          aria-hidden
-          className={cn(
-            'size-1.5 rounded-full',
-            // `ok` never reaches here — the pill hides on it above.
-            status.tone === 'active' && 'bg-accent motion-safe:animate-pulse',
-            status.tone === 'attention' && 'bg-amber-500',
-          )}
-        />
-        {status.label}
-      </div>
+      <span
+        aria-hidden
+        className={cn(
+          'size-1.5 rounded-full',
+          // `ok` never reaches here — the pill hides on it above.
+          status.tone === 'active' && 'bg-accent motion-safe:animate-pulse',
+          status.tone === 'attention' && 'bg-amber-500',
+        )}
+      />
+      {status.label}
     </div>
   )
 }

--- a/apps/desktop/src/mobile/task-draft.ts
+++ b/apps/desktop/src/mobile/task-draft.ts
@@ -1,0 +1,30 @@
+import {
+  clearTaskDueDate,
+  normalizeWikiTarget,
+  scanInlineWikiLinks,
+  setTaskDueDate,
+} from '@reflect/core'
+
+/**
+ * Draft-side due-date reads/writes for the mobile quick-edit sheet. The sheet
+ * holds the task's content as an editable markdown draft, and scheduling edits
+ * the draft rather than writing through — so text and date changes land as one
+ * write when the sheet commits. The date rule is the projection's: a task's due
+ * date is the first calendar-valid `[[YYYY-MM-DD]]` link in its content.
+ */
+
+/** The draft's due date — the first calendar-valid `[[YYYY-MM-DD]]` link, or null. */
+export function draftDueDate(content: string): string | null {
+  for (const link of scanInlineWikiLinks(content)) {
+    const { date } = normalizeWikiTarget(link.target)
+    if (date !== undefined) {
+      return date
+    }
+  }
+  return null
+}
+
+/** The draft with its due-date link set to `isoDate`, or removed when null. */
+export function withDraftDueDate(content: string, isoDate: string | null): string {
+  return isoDate === null ? clearTaskDueDate(content) : setTaskDueDate(content, isoDate)
+}

--- a/apps/desktop/src/mobile/task-edit-sheet.tsx
+++ b/apps/desktop/src/mobile/task-edit-sheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactElement } from 'react'
+import { useState, type ReactElement } from 'react'
 import {
   ArrowRight,
   CalendarDays,
@@ -13,12 +13,12 @@ import type { OpenTask } from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
 import { addDaysIso, formatDayLabel } from '@/lib/dates'
-import { taskContent, resolveTaskEdit } from '@/lib/tasks/task-content'
 import type { TaskActions } from '@/lib/tasks/use-task-actions'
 import { cn } from '@/lib/utils'
 import { hapticImpactLight } from '@/mobile/haptics'
 import { draftDueDate, withDraftDueDate } from '@/mobile/task-draft'
 import { TaskScheduleGrid } from '@/mobile/task-schedule-grid'
+import { useTaskSheetFinalizer } from '@/mobile/use-task-sheet-finalizer'
 import { useSettings } from '@/providers/settings-provider'
 
 interface MobileTaskEditSheetProps {
@@ -41,9 +41,9 @@ interface MobileTaskEditSheetProps {
  * opening the note. The draft is markdown (links and tags intact) and due-date
  * changes edit the draft's `[[YYYY-MM-DD]]` link in place, so everything lands
  * as **one** write when the sheet closes: dismissing commits a changed draft,
- * an emptied draft deletes the task (V1's empty-task rule via
- * {@link resolveTaskEdit}), and an untouched draft writes nothing. The action
- * buttons route through the same {@link TaskActions} the desktop view uses —
+ * an emptied draft deletes the task, and an untouched draft writes nothing —
+ * the exit rules live in {@link useTaskSheetFinalizer}. The action buttons
+ * route through the same {@link TaskActions} the desktop view uses —
  * save-then-act, never a racing second write path.
  */
 export function MobileTaskEditSheet({
@@ -55,90 +55,22 @@ export function MobileTaskEditSheet({
   onOpenNote,
 }: MobileTaskEditSheetProps): ReactElement {
   const { settings } = useSettings()
-  const liveContent = taskContent(task.raw)
-  // The edit baseline is frozen at open (desktop's inline editor does the
-  // same at mount): `task` is the live row, and if a reindex rewrites it while
-  // the sheet is up, comparing the untouched draft against the *new* content
-  // would read as an edit and commit stale text over the external change.
-  const [initial, setInitial] = useState(liveContent)
-  const [draft, setDraft] = useState(liveContent)
   const [showCalendar, setShowCalendar] = useState(false)
-  // Set once an action button has already written/closed, so the dismissal
-  // commit doesn't double-write on the close that follows.
-  const [handled, setHandled] = useState(false)
-  // The sheet stays mounted after closing (the exit animation needs content),
-  // so re-opening it for the same task must reseed everything: the baseline
-  // and draft from the row's current raw (an action may have rewritten it),
-  // the calendar collapsed, and the handled flag cleared — else a visit after
-  // Complete/Convert/Open note would silently drop its edits on dismiss.
-  const [wasOpen, setWasOpen] = useState(open)
-  if (open !== wasOpen) {
-    setWasOpen(open)
-    if (open) {
-      setHandled(false)
-      setInitial(liveContent)
-      setDraft(liveContent)
-      setShowCalendar(false)
-    }
-  }
+  // The commit/cancel/delete rules — baseline frozen at open, reseed on
+  // reopen, dismissal vs navigate vs unmount — live in the finalizer.
+  const { draft, setDraft, resolve, handleOpenChange, closeHandled, closeNavigate } =
+    useTaskSheetFinalizer({
+      task,
+      open,
+      onOpenChange,
+      actions,
+      onReseed: () => setShowCalendar(false),
+    })
   const dueDate = draftDueDate(draft)
-
-  const close = (): void => {
-    setHandled(true)
-    onOpenChange(false)
-  }
-
-  /** Persist the draft: a real change commits, an emptied draft deletes. */
-  const commitDraft = (): void => {
-    const result = resolveTaskEdit(initial, draft)
-    if (result.type === 'commit') {
-      actions.edit(task, result.content)
-    } else if (result.type === 'delete') {
-      actions.remove([task])
-    }
-  }
-
-  /**
-   * Finish an abandoned visit — a dismissal gesture or the sheet unmounting
-   * under an open drawer: commit a changed draft, and additionally treat a
-   * task that was already empty and stayed empty — a "+"-added row abandoned
-   * without typing — as a delete, so no bare `+ [ ]` ghosts in the note
-   * (V1's empty-task rule, desktop's editor-finalizer auto-delete). Not for
-   * "Open note": an untouched empty task must not lose the very line it
-   * navigates to.
-   */
-  const finishAbandonedVisit = (): void => {
-    if (resolveTaskEdit(initial, draft).type === 'cancel' && draft.trim() === '') {
-      actions.remove([task])
-    } else {
-      commitDraft()
-    }
-  }
-
-  const handleOpenChange = (nextOpen: boolean): void => {
-    if (!nextOpen && !handled) {
-      finishAbandonedVisit()
-    }
-    onOpenChange(nextOpen)
-  }
-
-  // A route change (tab switch, back) can unmount the whole screen while the
-  // drawer is open — no dismissal callback fires, so flush like a dismissal
-  // would (desktop's inline editor flushes on unmount the same way). The
-  // latest-closure ref keeps the unmount-only cleanup reading current state.
-  const unmountFlushRef = useRef<() => void>(() => {})
-  useEffect(() => {
-    unmountFlushRef.current = () => {
-      if (open && !handled) {
-        finishAbandonedVisit()
-      }
-    }
-  })
-  useEffect(() => () => unmountFlushRef.current(), [])
 
   const complete = (): void => {
     hapticImpactLight()
-    const result = resolveTaskEdit(initial, draft)
+    const result = resolve()
     if (result.type === 'commit') {
       actions.editAndToggle(task, result.content)
     } else if (result.type === 'delete') {
@@ -148,11 +80,11 @@ export function MobileTaskEditSheet({
     } else {
       actions.checkboxToggle(task)
     }
-    close()
+    closeHandled()
   }
 
   const convertToBullet = (): void => {
-    const result = resolveTaskEdit(initial, draft)
+    const result = resolve()
     if (result.type === 'commit') {
       actions.editAndConvertToBullet(task, result.content)
     } else if (result.type === 'delete') {
@@ -162,18 +94,17 @@ export function MobileTaskEditSheet({
     } else {
       actions.convertToBullet([task])
     }
-    close()
+    closeHandled()
   }
 
   const openNote = (): void => {
-    commitDraft()
-    close()
+    closeNavigate()
     onOpenNote(task.notePath)
   }
 
   const remove = (): void => {
     actions.remove([task])
-    close()
+    closeHandled()
   }
 
   const schedule = (isoDate: string | null): void => {

--- a/apps/desktop/src/mobile/task-edit-sheet.tsx
+++ b/apps/desktop/src/mobile/task-edit-sheet.tsx
@@ -1,0 +1,252 @@
+import { useRef, useState, type ReactElement } from 'react'
+import {
+  ArrowRight,
+  CalendarDays,
+  Check,
+  CircleCheck,
+  List,
+  Trash2,
+  Undo2,
+  X,
+} from 'lucide-react'
+import type { OpenTask } from '@reflect/core'
+import { Button } from '@/components/ui/button'
+import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
+import { addDaysIso, formatDayLabel } from '@/lib/dates'
+import { taskContent, resolveTaskEdit } from '@/lib/tasks/task-content'
+import type { TaskActions } from '@/lib/tasks/use-task-actions'
+import { cn } from '@/lib/utils'
+import { hapticImpactLight } from '@/mobile/haptics'
+import { draftDueDate, withDraftDueDate } from '@/mobile/task-draft'
+import { TaskScheduleGrid } from '@/mobile/task-schedule-grid'
+import { useSettings } from '@/providers/settings-provider'
+
+interface MobileTaskEditSheetProps {
+  /** The task being edited. Remount (key by task) to reseed the draft. */
+  task: OpenTask
+  open: boolean
+  /** Close the sheet. A user dismissal commits the draft first (V1 mobile). */
+  onOpenChange: (open: boolean) => void
+  /** Today's live ISO date, for the schedule shortcuts and the month grid. */
+  today: string
+  /** The screen's shared task actions — one optimistic-cache path for every write. */
+  actions: TaskActions
+  /** Navigate to the task's source note (the sheet commits the draft first). */
+  onOpenNote: (notePath: string) => void
+}
+
+/**
+ * The quick-edit bottom sheet (V1 mobile's edit modal over Plan 18 data): edit
+ * a task's text, schedule it, complete it, or jump to its source note — without
+ * opening the note. The draft is markdown (links and tags intact) and due-date
+ * changes edit the draft's `[[YYYY-MM-DD]]` link in place, so everything lands
+ * as **one** write when the sheet closes: dismissing commits a changed draft,
+ * an emptied draft deletes the task (V1's empty-task rule via
+ * {@link resolveTaskEdit}), and an untouched draft writes nothing. The action
+ * buttons route through the same {@link TaskActions} the desktop view uses —
+ * save-then-act, never a racing second write path.
+ */
+export function MobileTaskEditSheet({
+  task,
+  open,
+  onOpenChange,
+  today,
+  actions,
+  onOpenNote,
+}: MobileTaskEditSheetProps): ReactElement {
+  const { settings } = useSettings()
+  const initial = taskContent(task.raw)
+  const [draft, setDraft] = useState(initial)
+  const [showCalendar, setShowCalendar] = useState(false)
+  // Set once an action button has already written/closed, so the dismissal
+  // commit doesn't double-write on the close that follows.
+  const handledRef = useRef(false)
+  const dueDate = draftDueDate(draft)
+
+  const close = (): void => {
+    handledRef.current = true
+    onOpenChange(false)
+  }
+
+  const commitDraft = (): void => {
+    const result = resolveTaskEdit(initial, draft)
+    if (result.type === 'commit') {
+      actions.edit(task, result.content)
+    } else if (result.type === 'delete' || draft.trim() === '') {
+      // `delete` is an emptied draft; the second arm is a task that was already
+      // empty and stayed empty — a "+"-added row abandoned without typing.
+      // Both leave rather than ghost a bare `+ [ ]` in the note (V1's
+      // empty-task rule, desktop's editor-finalizer auto-delete).
+      actions.remove([task])
+    }
+  }
+
+  const handleOpenChange = (nextOpen: boolean): void => {
+    if (!nextOpen && !handledRef.current) {
+      commitDraft()
+    }
+    onOpenChange(nextOpen)
+  }
+
+  const complete = (): void => {
+    hapticImpactLight()
+    const result = resolveTaskEdit(initial, draft)
+    if (result.type === 'commit') {
+      actions.editAndToggle(task, result.content)
+    } else {
+      // Unchanged or emptied: toggle the task as it stands — emptying the text
+      // then completing shouldn't silently delete it.
+      actions.checkboxToggle(task)
+    }
+    close()
+  }
+
+  const convertToBullet = (): void => {
+    const result = resolveTaskEdit(initial, draft)
+    if (result.type === 'commit') {
+      actions.editAndConvertToBullet(task, result.content)
+    } else {
+      actions.convertToBullet([task])
+    }
+    close()
+  }
+
+  const openNote = (): void => {
+    commitDraft()
+    close()
+    onOpenNote(task.notePath)
+  }
+
+  const remove = (): void => {
+    actions.remove([task])
+    close()
+  }
+
+  const schedule = (isoDate: string | null): void => {
+    setDraft((current) => withDraftDueDate(current, isoDate))
+    setShowCalendar(false)
+  }
+
+  return (
+    <Drawer open={open} onOpenChange={handleOpenChange}>
+      <DrawerContent aria-label="Edit task">
+        <DrawerTitle className="sr-only">Edit task</DrawerTitle>
+        <textarea
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          rows={2}
+          aria-label="Task text"
+          // Touch-surface hygiene, like the note editor: no autocap/autocorrect
+          // rewriting markdown syntax under the user.
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
+          className="w-full resize-none rounded-md border border-border bg-surface px-3 py-2 text-base leading-6 text-text outline-none focus-visible:ring-1 focus-visible:ring-accent"
+        />
+        <div className="flex flex-wrap items-center gap-1.5" aria-label="Schedule">
+          <ScheduleChip
+            label="Today"
+            active={dueDate === today}
+            onClick={() => schedule(today)}
+          />
+          <ScheduleChip
+            label="Tomorrow"
+            active={dueDate === addDaysIso(today, 1)}
+            onClick={() => schedule(addDaysIso(today, 1))}
+          />
+          <ScheduleChip
+            label="Next week"
+            active={dueDate === addDaysIso(today, 7)}
+            onClick={() => schedule(addDaysIso(today, 7))}
+          />
+          <ScheduleChip
+            label={
+              dueDate !== null ? formatDayLabel(dueDate, settings.dateFormat) : 'Pick date'
+            }
+            icon={<CalendarDays aria-hidden className="size-3.5" />}
+            active={showCalendar}
+            onClick={() => setShowCalendar((showing) => !showing)}
+          />
+          {dueDate !== null ? (
+            <ScheduleChip
+              label="Clear"
+              icon={<X aria-hidden className="size-3.5" />}
+              active={false}
+              onClick={() => schedule(null)}
+            />
+          ) : null}
+        </div>
+        {showCalendar ? (
+          <TaskScheduleGrid today={today} selected={dueDate} onPick={schedule} />
+        ) : null}
+        <div className="flex flex-col gap-1 border-t border-border pt-2">
+          <Button
+            variant="ghost"
+            size="lg"
+            className="h-12 justify-start gap-3 text-base"
+            onClick={complete}
+          >
+            {task.checked ? <Undo2 /> : <CircleCheck />}
+            {task.checked ? 'Reopen' : 'Complete'}
+          </Button>
+          <Button
+            variant="ghost"
+            size="lg"
+            className="h-12 justify-start gap-3 text-base"
+            onClick={convertToBullet}
+          >
+            <List />
+            Convert to bullet
+          </Button>
+          <Button
+            variant="ghost"
+            size="lg"
+            className="h-12 justify-start gap-3 text-base"
+            onClick={openNote}
+          >
+            <ArrowRight />
+            Open note
+          </Button>
+          <Button
+            variant="ghost"
+            size="lg"
+            className="h-12 justify-start gap-3 text-base text-destructive hover:text-destructive"
+            onClick={remove}
+          >
+            <Trash2 />
+            Delete
+          </Button>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  )
+}
+
+function ScheduleChip({
+  label,
+  icon,
+  active,
+  onClick,
+}: {
+  label: string
+  icon?: ReactElement
+  active: boolean
+  onClick: () => void
+}): ReactElement {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={cn(
+        'flex h-8 items-center gap-1 whitespace-nowrap rounded-full border px-3 text-xs font-medium',
+        active
+          ? 'border-accent/40 bg-accent-soft text-text'
+          : 'border-border text-text-muted',
+      )}
+    >
+      {active && icon === undefined ? <Check aria-hidden className="size-3.5" /> : icon}
+      {label}
+    </button>
+  )
+}

--- a/apps/desktop/src/mobile/task-edit-sheet.tsx
+++ b/apps/desktop/src/mobile/task-edit-sheet.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type ReactElement } from 'react'
+import { useState, type ReactElement } from 'react'
 import {
   ArrowRight,
   CalendarDays,
@@ -60,11 +60,25 @@ export function MobileTaskEditSheet({
   const [showCalendar, setShowCalendar] = useState(false)
   // Set once an action button has already written/closed, so the dismissal
   // commit doesn't double-write on the close that follows.
-  const handledRef = useRef(false)
+  const [handled, setHandled] = useState(false)
+  // The sheet stays mounted after closing (the exit animation needs content),
+  // so re-opening it for the same task must reseed everything: the draft from
+  // the row's current raw (an action may have rewritten it), the calendar
+  // collapsed, and the handled flag cleared — else a visit after Complete/
+  // Convert/Open note would silently drop its edits on dismiss.
+  const [wasOpen, setWasOpen] = useState(open)
+  if (open !== wasOpen) {
+    setWasOpen(open)
+    if (open) {
+      setHandled(false)
+      setDraft(initial)
+      setShowCalendar(false)
+    }
+  }
   const dueDate = draftDueDate(draft)
 
   const close = (): void => {
-    handledRef.current = true
+    setHandled(true)
     onOpenChange(false)
   }
 
@@ -82,7 +96,7 @@ export function MobileTaskEditSheet({
   }
 
   const handleOpenChange = (nextOpen: boolean): void => {
-    if (!nextOpen && !handledRef.current) {
+    if (!nextOpen && !handled) {
       commitDraft()
     }
     onOpenChange(nextOpen)

--- a/apps/desktop/src/mobile/task-edit-sheet.tsx
+++ b/apps/desktop/src/mobile/task-edit-sheet.tsx
@@ -55,23 +55,29 @@ export function MobileTaskEditSheet({
   onOpenNote,
 }: MobileTaskEditSheetProps): ReactElement {
   const { settings } = useSettings()
-  const initial = taskContent(task.raw)
-  const [draft, setDraft] = useState(initial)
+  const liveContent = taskContent(task.raw)
+  // The edit baseline is frozen at open (desktop's inline editor does the
+  // same at mount): `task` is the live row, and if a reindex rewrites it while
+  // the sheet is up, comparing the untouched draft against the *new* content
+  // would read as an edit and commit stale text over the external change.
+  const [initial, setInitial] = useState(liveContent)
+  const [draft, setDraft] = useState(liveContent)
   const [showCalendar, setShowCalendar] = useState(false)
   // Set once an action button has already written/closed, so the dismissal
   // commit doesn't double-write on the close that follows.
   const [handled, setHandled] = useState(false)
   // The sheet stays mounted after closing (the exit animation needs content),
-  // so re-opening it for the same task must reseed everything: the draft from
-  // the row's current raw (an action may have rewritten it), the calendar
-  // collapsed, and the handled flag cleared — else a visit after Complete/
-  // Convert/Open note would silently drop its edits on dismiss.
+  // so re-opening it for the same task must reseed everything: the baseline
+  // and draft from the row's current raw (an action may have rewritten it),
+  // the calendar collapsed, and the handled flag cleared — else a visit after
+  // Complete/Convert/Open note would silently drop its edits on dismiss.
   const [wasOpen, setWasOpen] = useState(open)
   if (open !== wasOpen) {
     setWasOpen(open)
     if (open) {
       setHandled(false)
-      setDraft(initial)
+      setInitial(liveContent)
+      setDraft(liveContent)
       setShowCalendar(false)
     }
   }
@@ -82,22 +88,29 @@ export function MobileTaskEditSheet({
     onOpenChange(false)
   }
 
+  /** Persist the draft: a real change commits, an emptied draft deletes. */
   const commitDraft = (): void => {
     const result = resolveTaskEdit(initial, draft)
     if (result.type === 'commit') {
       actions.edit(task, result.content)
-    } else if (result.type === 'delete' || draft.trim() === '') {
-      // `delete` is an emptied draft; the second arm is a task that was already
-      // empty and stayed empty — a "+"-added row abandoned without typing.
-      // Both leave rather than ghost a bare `+ [ ]` in the note (V1's
-      // empty-task rule, desktop's editor-finalizer auto-delete).
+    } else if (result.type === 'delete') {
       actions.remove([task])
     }
   }
 
   const handleOpenChange = (nextOpen: boolean): void => {
     if (!nextOpen && !handled) {
-      commitDraft()
+      // Dismissal (drag down / tap outside) additionally treats a task that
+      // was already empty and stayed empty — a "+"-added row abandoned
+      // without typing — as a delete, so no bare `+ [ ]` ghosts in the note
+      // (V1's empty-task rule, desktop's editor-finalizer auto-delete).
+      // Only here: "Open note" on an untouched empty task must not delete
+      // the very line it navigates to.
+      if (resolveTaskEdit(initial, draft).type === 'cancel' && draft.trim() === '') {
+        actions.remove([task])
+      } else {
+        commitDraft()
+      }
     }
     onOpenChange(nextOpen)
   }

--- a/apps/desktop/src/mobile/task-edit-sheet.tsx
+++ b/apps/desktop/src/mobile/task-edit-sheet.tsx
@@ -107,9 +107,11 @@ export function MobileTaskEditSheet({
     const result = resolveTaskEdit(initial, draft)
     if (result.type === 'commit') {
       actions.editAndToggle(task, result.content)
+    } else if (result.type === 'delete') {
+      // Emptied then completed: delete, like desktop's ⌘↵ on an emptied row —
+      // never toggle text the user just cleared back into the note.
+      actions.remove([task])
     } else {
-      // Unchanged or emptied: toggle the task as it stands — emptying the text
-      // then completing shouldn't silently delete it.
       actions.checkboxToggle(task)
     }
     close()
@@ -119,6 +121,10 @@ export function MobileTaskEditSheet({
     const result = resolveTaskEdit(initial, draft)
     if (result.type === 'commit') {
       actions.editAndConvertToBullet(task, result.content)
+    } else if (result.type === 'delete') {
+      // Emptied then converted: delete, like desktop's ⌘⇧K on an emptied row —
+      // converting would resurrect the cleared text as a bullet.
+      actions.remove([task])
     } else {
       actions.convertToBullet([task])
     }

--- a/apps/desktop/src/mobile/task-edit-sheet.tsx
+++ b/apps/desktop/src/mobile/task-edit-sheet.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from 'react'
+import { useEffect, useRef, useState, type ReactElement } from 'react'
 import {
   ArrowRight,
   CalendarDays,
@@ -98,22 +98,43 @@ export function MobileTaskEditSheet({
     }
   }
 
+  /**
+   * Finish an abandoned visit — a dismissal gesture or the sheet unmounting
+   * under an open drawer: commit a changed draft, and additionally treat a
+   * task that was already empty and stayed empty — a "+"-added row abandoned
+   * without typing — as a delete, so no bare `+ [ ]` ghosts in the note
+   * (V1's empty-task rule, desktop's editor-finalizer auto-delete). Not for
+   * "Open note": an untouched empty task must not lose the very line it
+   * navigates to.
+   */
+  const finishAbandonedVisit = (): void => {
+    if (resolveTaskEdit(initial, draft).type === 'cancel' && draft.trim() === '') {
+      actions.remove([task])
+    } else {
+      commitDraft()
+    }
+  }
+
   const handleOpenChange = (nextOpen: boolean): void => {
     if (!nextOpen && !handled) {
-      // Dismissal (drag down / tap outside) additionally treats a task that
-      // was already empty and stayed empty — a "+"-added row abandoned
-      // without typing — as a delete, so no bare `+ [ ]` ghosts in the note
-      // (V1's empty-task rule, desktop's editor-finalizer auto-delete).
-      // Only here: "Open note" on an untouched empty task must not delete
-      // the very line it navigates to.
-      if (resolveTaskEdit(initial, draft).type === 'cancel' && draft.trim() === '') {
-        actions.remove([task])
-      } else {
-        commitDraft()
-      }
+      finishAbandonedVisit()
     }
     onOpenChange(nextOpen)
   }
+
+  // A route change (tab switch, back) can unmount the whole screen while the
+  // drawer is open — no dismissal callback fires, so flush like a dismissal
+  // would (desktop's inline editor flushes on unmount the same way). The
+  // latest-closure ref keeps the unmount-only cleanup reading current state.
+  const unmountFlushRef = useRef<() => void>(() => {})
+  useEffect(() => {
+    unmountFlushRef.current = () => {
+      if (open && !handled) {
+        finishAbandonedVisit()
+      }
+    }
+  })
+  useEffect(() => () => unmountFlushRef.current(), [])
 
   const complete = (): void => {
     hapticImpactLight()

--- a/apps/desktop/src/mobile/task-filters-drawer.tsx
+++ b/apps/desktop/src/mobile/task-filters-drawer.tsx
@@ -1,0 +1,83 @@
+import { type ReactElement } from 'react'
+import { Check } from 'lucide-react'
+import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
+import type { TaskFilters } from '@/lib/tasks/task-filters'
+import { cn } from '@/lib/utils'
+
+interface TaskFiltersDrawerProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  filters: TaskFilters
+  toggle: (key: keyof TaskFilters) => void
+}
+
+const BUCKETS: ReadonlyArray<{ key: keyof TaskFilters; label: string }> = [
+  { key: 'pinned', label: 'Pinned notes' },
+  { key: 'current', label: 'Current' },
+  { key: 'overdue', label: 'Overdue' },
+  { key: 'upcoming', label: 'Upcoming' },
+  { key: 'other', label: 'Other notes' },
+]
+
+/**
+ * The Tasks tab's filter sheet (V1 mobile's filters modal, desktop's "Task
+ * filters" menu as a bottom sheet): the five bucket toggles plus "Show
+ * archived", which reveals the whole completed history. Rows toggle without
+ * closing, so several filters flip in one visit — the drawer dismisses by
+ * drag or tapping outside, like every mobile sheet.
+ */
+export function TaskFiltersDrawer({
+  open,
+  onOpenChange,
+  filters,
+  toggle,
+}: TaskFiltersDrawerProps): ReactElement {
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent aria-label="Task filters">
+        <DrawerTitle>Task filters</DrawerTitle>
+        <div className="flex flex-col">
+          {BUCKETS.map(({ key, label }) => (
+            <FilterRow key={key} label={label} checked={filters[key]} onToggle={() => toggle(key)} />
+          ))}
+          <div className="my-1 border-t border-border" />
+          <FilterRow
+            label="Show archived"
+            checked={filters.archived}
+            onToggle={() => toggle('archived')}
+          />
+        </div>
+      </DrawerContent>
+    </Drawer>
+  )
+}
+
+function FilterRow({
+  label,
+  checked,
+  onToggle,
+}: {
+  label: string
+  checked: boolean
+  onToggle: () => void
+}): ReactElement {
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={checked}
+      onClick={onToggle}
+      className="flex h-12 items-center gap-3 text-left text-base"
+    >
+      <span
+        className={cn(
+          'flex size-5 items-center justify-center rounded border',
+          checked ? 'border-accent bg-accent text-white' : 'border-border',
+        )}
+      >
+        {checked ? <Check aria-hidden className="size-3.5" strokeWidth={3} /> : null}
+      </span>
+      {label}
+    </button>
+  )
+}

--- a/apps/desktop/src/mobile/task-group.tsx
+++ b/apps/desktop/src/mobile/task-group.tsx
@@ -72,6 +72,10 @@ export function MobileTaskGroup({
       <div className="sticky top-0 z-10 flex items-center gap-2 bg-surface-sunken px-4 py-1.5">
         <h2 className={cn('flex min-w-0 items-center gap-2 text-sm font-medium', colorClass)}>
           {icon}
+          {/* The pin icon alone is invisible to screen readers (aria-hidden). */}
+          {group.kind === 'note' && group.tasks[0]?.isPinned ? (
+            <span className="sr-only">Pinned:</span>
+          ) : null}
           {group.kind === 'note' && notePath !== null ? (
             <button type="button" onClick={() => onOpen(notePath)} className="truncate">
               {group.label}

--- a/apps/desktop/src/mobile/task-group.tsx
+++ b/apps/desktop/src/mobile/task-group.tsx
@@ -1,0 +1,102 @@
+import { type ReactElement } from 'react'
+import { AlarmClock, Calendar, FileText, Pin, Plus, Star } from 'lucide-react'
+import type { OpenTask, TaskGroup } from '@reflect/core'
+import { taskKey } from '@/lib/tasks/task-identity'
+import { insertTargetForTask, todaysDailyTarget } from '@/lib/tasks/task-navigation'
+import type { InsertTaskTarget } from '@/lib/tasks/task-insert-target'
+import { cn } from '@/lib/utils'
+import { MobileTaskRow } from '@/mobile/task-row'
+
+interface MobileTaskGroupProps {
+  group: TaskGroup
+  /** Today's ISO date — the Current group's "+" adds to today's daily. */
+  today: string
+  /** Add a task to this group and open its quick-edit sheet. */
+  onAdd: (target: InsertTaskTarget) => void
+  /** Open the quick-edit sheet for a tapped row. */
+  onEdit: (task: OpenTask) => void
+  /** Open a note group's source note from its header. */
+  onOpen: (notePath: string) => void
+}
+
+/**
+ * Where this group's "+" adds a task (V1: Current → today's daily, a note →
+ * that note), or `null` for the aggregate Overdue/Upcoming buckets, which span
+ * many notes and so show no add button — the same rule as desktop's sections.
+ */
+function addTargetForGroup(group: TaskGroup, today: string): InsertTaskTarget | null {
+  if (group.kind === 'current') {
+    return todaysDailyTarget(today)
+  }
+  const first = group.tasks[0]
+  return group.kind === 'note' && first !== undefined ? insertTargetForTask(first) : null
+}
+
+/** The icon + accent colour for a group's sticky header, V1's per-bucket styling. */
+function headerStyle(group: TaskGroup): { icon: ReactElement; colorClass: string } {
+  switch (group.kind) {
+    case 'current':
+      return { icon: <Star aria-hidden className="size-4" />, colorClass: 'text-amber-500' }
+    case 'overdue':
+      return { icon: <AlarmClock aria-hidden className="size-4" />, colorClass: 'text-red-500' }
+    case 'upcoming':
+      return { icon: <Calendar aria-hidden className="size-4" />, colorClass: 'text-green-600' }
+    case 'note':
+      return group.tasks[0]?.isPinned
+        ? { icon: <Pin aria-hidden className="size-4" />, colorClass: 'text-accent' }
+        : { icon: <FileText aria-hidden className="size-4" />, colorClass: 'text-text-secondary' }
+  }
+}
+
+/**
+ * One section of the mobile Tasks tab: a sticky, colour-coded header — a date
+ * bucket (Current/Overdue/Upcoming) or a note — with a task count (V1 mobile
+ * showed counts on its groups) over the rows. A note group's header opens the
+ * note; Current and note groups grow a "+" that adds a task there and opens
+ * its quick-edit sheet.
+ */
+export function MobileTaskGroup({
+  group,
+  today,
+  onAdd,
+  onEdit,
+  onOpen,
+}: MobileTaskGroupProps): ReactElement {
+  const showSource = group.kind !== 'note'
+  const { notePath } = group
+  const { icon, colorClass } = headerStyle(group)
+  const addTarget = addTargetForGroup(group, today)
+
+  return (
+    <section>
+      <div className="sticky top-0 z-10 flex items-center gap-2 bg-surface-sunken px-4 py-1.5">
+        <h2 className={cn('flex min-w-0 items-center gap-2 text-sm font-medium', colorClass)}>
+          {icon}
+          {group.kind === 'note' && notePath !== null ? (
+            <button type="button" onClick={() => onOpen(notePath)} className="truncate">
+              {group.label}
+            </button>
+          ) : (
+            <span className="truncate">{group.label}</span>
+          )}
+          <span className="text-xs font-normal text-text-muted">{group.tasks.length}</span>
+        </h2>
+        {addTarget !== null ? (
+          <button
+            type="button"
+            aria-label={`Add a task to ${group.kind === 'current' ? 'today' : group.label}`}
+            onClick={() => onAdd(addTarget)}
+            className="-my-1 ml-auto flex size-8 flex-none items-center justify-center text-text-muted"
+          >
+            <Plus aria-hidden className="size-4" />
+          </button>
+        ) : null}
+      </div>
+      <ul className="flex flex-col">
+        {group.tasks.map((task) => (
+          <MobileTaskRow key={taskKey(task)} task={task} showSource={showSource} onEdit={onEdit} />
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/apps/desktop/src/mobile/task-group.tsx
+++ b/apps/desktop/src/mobile/task-group.tsx
@@ -1,8 +1,8 @@
 import { type ReactElement } from 'react'
-import { AlarmClock, Calendar, FileText, Pin, Plus, Star } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import type { OpenTask, TaskGroup } from '@reflect/core'
+import { addTargetForGroup, taskGroupHeaderStyle } from '@/lib/tasks/task-group-presentation'
 import { taskKey } from '@/lib/tasks/task-identity'
-import { insertTargetForTask, todaysDailyTarget } from '@/lib/tasks/task-navigation'
 import type { InsertTaskTarget } from '@/lib/tasks/task-insert-target'
 import { cn } from '@/lib/utils'
 import { MobileTaskRow } from '@/mobile/task-row'
@@ -17,35 +17,6 @@ interface MobileTaskGroupProps {
   onEdit: (task: OpenTask) => void
   /** Open a note group's source note from its header. */
   onOpen: (notePath: string) => void
-}
-
-/**
- * Where this group's "+" adds a task (V1: Current → today's daily, a note →
- * that note), or `null` for the aggregate Overdue/Upcoming buckets, which span
- * many notes and so show no add button — the same rule as desktop's sections.
- */
-function addTargetForGroup(group: TaskGroup, today: string): InsertTaskTarget | null {
-  if (group.kind === 'current') {
-    return todaysDailyTarget(today)
-  }
-  const first = group.tasks[0]
-  return group.kind === 'note' && first !== undefined ? insertTargetForTask(first) : null
-}
-
-/** The icon + accent colour for a group's sticky header, V1's per-bucket styling. */
-function headerStyle(group: TaskGroup): { icon: ReactElement; colorClass: string } {
-  switch (group.kind) {
-    case 'current':
-      return { icon: <Star aria-hidden className="size-4" />, colorClass: 'text-amber-500' }
-    case 'overdue':
-      return { icon: <AlarmClock aria-hidden className="size-4" />, colorClass: 'text-red-500' }
-    case 'upcoming':
-      return { icon: <Calendar aria-hidden className="size-4" />, colorClass: 'text-green-600' }
-    case 'note':
-      return group.tasks[0]?.isPinned
-        ? { icon: <Pin aria-hidden className="size-4" />, colorClass: 'text-accent' }
-        : { icon: <FileText aria-hidden className="size-4" />, colorClass: 'text-text-secondary' }
-  }
 }
 
 /**
@@ -64,7 +35,7 @@ export function MobileTaskGroup({
 }: MobileTaskGroupProps): ReactElement {
   const showSource = group.kind !== 'note'
   const { notePath } = group
-  const { icon, colorClass } = headerStyle(group)
+  const { icon, colorClass } = taskGroupHeaderStyle(group)
   const addTarget = addTargetForGroup(group, today)
 
   return (

--- a/apps/desktop/src/mobile/task-row.tsx
+++ b/apps/desktop/src/mobile/task-row.tsx
@@ -1,0 +1,80 @@
+import { type ReactElement } from 'react'
+import { Circle, CircleCheck } from 'lucide-react'
+import type { OpenTask } from '@reflect/core'
+import { TaskText } from '@/components/tasks/task-text'
+import { formatShortDate } from '@/lib/dates'
+import { taskKey } from '@/lib/tasks/task-identity'
+import { useTaskCheckboxToggle } from '@/lib/tasks/use-task-checkbox-toggle'
+import { cn } from '@/lib/utils'
+import { hapticImpactLight } from '@/mobile/haptics'
+import { useSettings } from '@/providers/settings-provider'
+
+interface MobileTaskRowProps {
+  task: OpenTask
+  /** Show the source-note date — date buckets aggregate tasks from many notes. */
+  showSource: boolean
+  /** Open the quick-edit sheet for this task (V1 mobile: tap edits in place). */
+  onEdit: (task: OpenTask) => void
+}
+
+/**
+ * One task row on the mobile Tasks tab (V1 mobile design over Plan 18 data): a
+ * round checkbox that toggles the task through the same guarded write-back as
+ * desktop — with a light haptic, V1's check feedback — and the task content
+ * rendered as markdown. A completed (struck) row stays visible until archived.
+ * Tapping the row body opens the quick-edit sheet instead of desktop's
+ * multi-select; there is no inline editor on touch.
+ */
+export function MobileTaskRow({ task, showSource, onEdit }: MobileTaskRowProps): ReactElement {
+  const { settings } = useSettings()
+  const { toggle, isPending } = useTaskCheckboxToggle(task)
+  const label = task.text || 'Empty task'
+
+  return (
+    <li
+      data-task-key={taskKey(task)}
+      className="flex min-h-12 items-start border-b border-border bg-surface"
+    >
+      <button
+        type="button"
+        aria-label={task.checked ? `Reopen: ${label}` : `Complete: ${label}`}
+        disabled={isPending}
+        onClick={() => {
+          hapticImpactLight()
+          toggle()
+        }}
+        // A generous touch target around the small glyph; py-3 h-6 keeps the
+        // circle centered on the first text line when a task wraps.
+        className="flex shrink-0 items-start py-3 pl-4 pr-3 text-text-muted disabled:opacity-50"
+      >
+        {task.checked ? (
+          <CircleCheck aria-hidden className="size-5 text-accent" strokeWidth={2} />
+        ) : (
+          <Circle aria-hidden className="size-5" strokeWidth={2} />
+        )}
+      </button>
+      <button
+        type="button"
+        aria-label={`Edit: ${label}`}
+        onClick={() => onEdit(task)}
+        className="flex min-w-0 flex-1 items-start gap-3 py-3 pr-4 text-left"
+      >
+        <span
+          className={cn(
+            'min-w-0 flex-1 break-words text-sm leading-6 text-text',
+            task.checked && 'text-text-muted line-through',
+          )}
+        >
+          <TaskText task={task} />
+        </span>
+        {showSource && task.dailyDate !== null ? (
+          // The compact date, not desktop's long day label — a phone row can't
+          // spare "Mon, June 1st, 2026" (V1 mobile's small gray source label).
+          <span className="mt-0.5 shrink-0 whitespace-nowrap text-xs text-text-muted">
+            {formatShortDate(task.dailyDate, settings.dateFormat)}
+          </span>
+        ) : null}
+      </button>
+    </li>
+  )
+}

--- a/apps/desktop/src/mobile/task-row.tsx
+++ b/apps/desktop/src/mobile/task-row.tsx
@@ -53,11 +53,22 @@ export function MobileTaskRow({ task, showSource, onEdit }: MobileTaskRowProps):
           <Circle aria-hidden className="size-5" strokeWidth={2} />
         )}
       </button>
-      <button
-        type="button"
+      {/* A div with the button role, not a real <button>: the markdown inside
+          can contain links, and interactive content can't nest in a button
+          (desktop's row body makes the same trade). TaskText itself is
+          pointer-events-none, so taps land here. */}
+      <div
+        role="button"
+        tabIndex={0}
         aria-label={`Edit: ${label}`}
         onClick={() => onEdit(task)}
-        className="flex min-w-0 flex-1 items-start gap-3 py-3 pr-4 text-left"
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault()
+            onEdit(task)
+          }
+        }}
+        className="flex min-w-0 flex-1 cursor-pointer items-start gap-3 py-3 pr-4 text-left focus-visible:outline-none"
       >
         <span
           className={cn(
@@ -74,7 +85,7 @@ export function MobileTaskRow({ task, showSource, onEdit }: MobileTaskRowProps):
             {formatShortDate(task.dailyDate, settings.dateFormat)}
           </span>
         ) : null}
-      </button>
+      </div>
     </li>
   )
 }

--- a/apps/desktop/src/mobile/task-schedule-grid.tsx
+++ b/apps/desktop/src/mobile/task-schedule-grid.tsx
@@ -65,8 +65,10 @@ export function TaskScheduleGrid({ today, selected, onPick }: TaskScheduleGridPr
           </div>
         ))}
       </div>
-      {grid.weeks.map((week) => (
-        <div key={week[0]!.date} className="grid grid-cols-7 text-center">
+      {grid.weeks.map((week, weekIndex) => (
+        // buildMonthGrid always fills weeks with 7 cells; the index fallback
+        // only documents that invariant without asserting past the types.
+        <div key={week[0]?.date ?? weekIndex} className="grid grid-cols-7 text-center">
           {week.map((cell) => {
             const isToday = cell.date === today
             const isSelected = cell.date === selected

--- a/apps/desktop/src/mobile/task-schedule-grid.tsx
+++ b/apps/desktop/src/mobile/task-schedule-grid.tsx
@@ -1,0 +1,96 @@
+import { useState, type ReactElement } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { type WeekStartDay } from '@reflect/core'
+import { formatDayLabel } from '@/lib/dates'
+import { addMonths, buildMonthGrid, monthLabel, monthOf, weekdayLabels } from '@/lib/month-grid'
+import { cn } from '@/lib/utils'
+import { useSettings } from '@/providers/settings-provider'
+
+interface TaskScheduleGridProps {
+  /** Today's live ISO date — anchors the opening month and marks "today". */
+  today: string
+  /** The task's current due date, shown selected in the grid. */
+  selected: string | null
+  /** Pick a day as the task's due date (an ISO `YYYY-MM-DD`). */
+  onPick: (isoDate: string) => void
+}
+
+/** Maps the week-start setting to date-fns' numeric convention. */
+function toWeekStartsOn(weekStartDay: WeekStartDay): 0 | 1 {
+  return weekStartDay === 'sunday' ? 0 : 1
+}
+
+/**
+ * The quick-edit sheet's month grid (V1 mobile's scheduling picker, desktop's
+ * {@link TaskScheduleCalendar} restated for touch): tapping a day schedules the
+ * task for that date. Rendered inline inside the sheet rather than a popover —
+ * a popover inside a bottom sheet is two stacked overlays on a phone screen.
+ * Reuses {@link buildMonthGrid}, so it shares the daily calendar's math.
+ */
+export function TaskScheduleGrid({ today, selected, onPick }: TaskScheduleGridProps): ReactElement {
+  const { settings } = useSettings()
+  const weekStartsOn = toWeekStartsOn(settings.weekStartDay)
+  // Open on the due date's month when there is one — that's the date being
+  // rescheduled — else today's.
+  const [month, setMonth] = useState(() => monthOf(selected ?? today))
+  const grid = buildMonthGrid(month, weekStartsOn)
+
+  return (
+    <div aria-label="Pick a date">
+      <header className="flex items-center justify-between px-1 pb-1">
+        <div className="text-sm font-semibold text-text">{monthLabel(month)}</div>
+        <nav className="flex items-center gap-1 text-text-muted">
+          <button
+            type="button"
+            aria-label="Previous month"
+            onClick={() => setMonth(addMonths(month, -1))}
+            className="rounded-md p-2"
+          >
+            <ChevronLeft className="size-4" />
+          </button>
+          <button
+            type="button"
+            aria-label="Next month"
+            onClick={() => setMonth(addMonths(month, 1))}
+            className="rounded-md p-2"
+          >
+            <ChevronRight className="size-4" />
+          </button>
+        </nav>
+      </header>
+      <div className="grid grid-cols-7 text-center">
+        {weekdayLabels(weekStartsOn).map((weekday) => (
+          <div key={weekday} className="py-1 text-xs font-medium text-text-muted">
+            {weekday}
+          </div>
+        ))}
+      </div>
+      {grid.weeks.map((week) => (
+        <div key={week[0]!.date} className="grid grid-cols-7 text-center">
+          {week.map((cell) => {
+            const isToday = cell.date === today
+            const isSelected = cell.date === selected
+            return (
+              <button
+                key={cell.date}
+                type="button"
+                aria-label={formatDayLabel(cell.date, settings.dateFormat)}
+                aria-current={isToday ? 'date' : undefined}
+                aria-pressed={isSelected}
+                onClick={() => onPick(cell.date)}
+                className={cn(
+                  'mx-auto my-0.5 size-9 rounded-md text-sm tabular-nums',
+                  !cell.inMonth && !isToday && !isSelected && 'text-text-muted/40',
+                  isToday && 'font-bold text-accent',
+                  isSelected && 'bg-accent-soft ring-1 ring-inset ring-accent/30',
+                )}
+              >
+                {Number(cell.date.slice(8, 10))}
+              </button>
+            )
+          })}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/desktop/src/mobile/use-task-sheet-finalizer.test.ts
+++ b/apps/desktop/src/mobile/use-task-sheet-finalizer.test.ts
@@ -115,6 +115,19 @@ describe('useTaskSheetFinalizer', () => {
     expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 
+  it('commits once across a duplicate dismissal and the unmount flush', () => {
+    const { result, unmount } = renderHook(() => useTaskSheetFinalizer(deps()))
+
+    act(() => result.current.setDraft('alpha edited'))
+    act(() => result.current.handleOpenChange(false))
+    // A second gesture callback before the parent re-renders, then the
+    // unmount flush with the open prop still true — neither may double-write.
+    act(() => result.current.handleOpenChange(false))
+    unmount()
+
+    expect(edit).toHaveBeenCalledTimes(1)
+  })
+
   it('skips the dismissal commit after an action already handled the close', () => {
     const { result } = renderHook(() => useTaskSheetFinalizer(deps()))
 

--- a/apps/desktop/src/mobile/use-task-sheet-finalizer.test.ts
+++ b/apps/desktop/src/mobile/use-task-sheet-finalizer.test.ts
@@ -1,0 +1,175 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OpenTask } from '@reflect/core'
+import {
+  useTaskSheetFinalizer,
+  type TaskSheetFinalizerDeps,
+} from './use-task-sheet-finalizer'
+
+/**
+ * The quick-edit sheet's exit-rule state machine, tested directly — the
+ * screen tests drive it through the drawer, but a mid-open live-row change
+ * (a reindex rewriting the task) can't be staged through that harness, so
+ * the frozen-baseline rule is pinned here.
+ */
+
+function task(overrides: Partial<OpenTask> = {}): OpenTask {
+  const text = overrides.text ?? 'alpha'
+  return {
+    notePath: 'notes/n.md',
+    markerOffset: 2,
+    raw: `[ ] ${text}`,
+    checked: false,
+    text,
+    noteTitle: 'N',
+    dueDate: null,
+    dailyDate: null,
+    isPinned: false,
+    pinnedOrder: null,
+    updatedAt: 0,
+    ...overrides,
+  }
+}
+
+const edit = vi.fn()
+const remove = vi.fn()
+const onOpenChange = vi.fn()
+const onReseed = vi.fn()
+
+function deps(overrides: Partial<TaskSheetFinalizerDeps> = {}): TaskSheetFinalizerDeps {
+  return {
+    task: task(),
+    open: true,
+    onOpenChange,
+    actions: { edit, remove },
+    onReseed,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  edit.mockReset()
+  remove.mockReset()
+  onOpenChange.mockReset()
+  onReseed.mockReset()
+})
+
+describe('useTaskSheetFinalizer', () => {
+  it('keeps the baseline frozen at open: a live-row rewrite does not turn an untouched draft into an edit', () => {
+    const { result, rerender } = renderHook((props: TaskSheetFinalizerDeps) => useTaskSheetFinalizer(props), {
+      initialProps: deps(),
+    })
+
+    // A reindex rewrites the row's content while the sheet stays open.
+    rerender(deps({ task: task({ text: 'beta', raw: '[ ] beta' }) }))
+
+    act(() => result.current.handleOpenChange(false))
+
+    // The draft still reads "alpha" but so does the frozen baseline — this is
+    // a cancel, not a commit of stale text over the external change.
+    expect(edit).not.toHaveBeenCalled()
+    expect(remove).not.toHaveBeenCalled()
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('commits a changed draft on dismissal', () => {
+    const { result } = renderHook(() => useTaskSheetFinalizer(deps()))
+
+    act(() => result.current.setDraft('alpha edited'))
+    act(() => result.current.handleOpenChange(false))
+
+    expect(edit).toHaveBeenCalledTimes(1)
+    expect(edit.mock.calls[0]?.[1]).toBe('alpha edited')
+  })
+
+  it('deletes an emptied draft on dismissal', () => {
+    const { result } = renderHook(() => useTaskSheetFinalizer(deps()))
+
+    act(() => result.current.setDraft(''))
+    act(() => result.current.handleOpenChange(false))
+
+    expect(remove).toHaveBeenCalledTimes(1)
+    expect(edit).not.toHaveBeenCalled()
+  })
+
+  it('deletes an abandoned-empty task on dismissal, but not on navigate', () => {
+    const empty = task({ text: '', raw: '[ ] ' })
+
+    const navigated = renderHook(() => useTaskSheetFinalizer(deps({ task: empty })))
+    act(() => navigated.result.current.closeNavigate())
+    expect(remove).not.toHaveBeenCalled()
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+
+    const dismissed = renderHook(() => useTaskSheetFinalizer(deps({ task: empty })))
+    act(() => dismissed.result.current.handleOpenChange(false))
+    expect(remove).toHaveBeenCalledTimes(1)
+  })
+
+  it('commits a changed draft on navigate', () => {
+    const { result } = renderHook(() => useTaskSheetFinalizer(deps()))
+
+    act(() => result.current.setDraft('alpha edited'))
+    act(() => result.current.closeNavigate())
+
+    expect(edit).toHaveBeenCalledTimes(1)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('skips the dismissal commit after an action already handled the close', () => {
+    const { result } = renderHook(() => useTaskSheetFinalizer(deps()))
+
+    act(() => result.current.setDraft('alpha edited'))
+    act(() => result.current.closeHandled())
+    // A dismissal callback racing the programmatic close must not double-write.
+    act(() => result.current.handleOpenChange(false))
+
+    expect(edit).not.toHaveBeenCalled()
+    expect(remove).not.toHaveBeenCalled()
+  })
+
+  it('reseeds the draft, baseline, and presentation when the sheet reopens', () => {
+    const { result, rerender } = renderHook(
+      (props: TaskSheetFinalizerDeps) => useTaskSheetFinalizer(props),
+      { initialProps: deps() },
+    )
+
+    act(() => result.current.setDraft('scratch'))
+    act(() => result.current.closeHandled())
+    rerender(deps({ open: false }))
+
+    // Reopen for a row an action rewrote in the meantime.
+    rerender(deps({ task: task({ text: 'rewritten', raw: '[ ] rewritten' }) }))
+
+    expect(result.current.draft).toBe('rewritten')
+    expect(onReseed).toHaveBeenCalledTimes(1)
+    // The reseeded baseline makes the untouched reopen a cancel again.
+    act(() => result.current.handleOpenChange(false))
+    expect(edit).not.toHaveBeenCalled()
+  })
+
+  it('flushes like a dismissal when unmounted under an open sheet', () => {
+    const { result, unmount } = renderHook(() => useTaskSheetFinalizer(deps()))
+
+    act(() => result.current.setDraft('alpha edited'))
+    unmount()
+
+    expect(edit).toHaveBeenCalledTimes(1)
+    expect(edit.mock.calls[0]?.[1]).toBe('alpha edited')
+  })
+
+  it('does not flush on unmount when the sheet is closed', () => {
+    const { result, rerender, unmount } = renderHook(
+      (props: TaskSheetFinalizerDeps) => useTaskSheetFinalizer(props),
+      { initialProps: deps() },
+    )
+
+    act(() => result.current.setDraft('alpha edited'))
+    act(() => result.current.handleOpenChange(false))
+    edit.mockReset()
+    rerender(deps({ open: false }))
+    unmount()
+
+    expect(edit).not.toHaveBeenCalled()
+    expect(remove).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/mobile/use-task-sheet-finalizer.ts
+++ b/apps/desktop/src/mobile/use-task-sheet-finalizer.ts
@@ -100,6 +100,11 @@ export function useTaskSheetFinalizer({
 
   const handleOpenChange = (nextOpen: boolean): void => {
     if (!nextOpen && !handled) {
+      // Mark handled before finishing: a duplicate dismissal callback, or the
+      // unmount flush racing the parent's close re-render, must not run the
+      // same commit/delete twice (a second delete would trip the stale guard
+      // and surface a spurious failure).
+      setHandled(true)
       finishAbandonedVisit()
     }
     onOpenChange(nextOpen)

--- a/apps/desktop/src/mobile/use-task-sheet-finalizer.ts
+++ b/apps/desktop/src/mobile/use-task-sheet-finalizer.ts
@@ -1,0 +1,134 @@
+import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react'
+import type { OpenTask } from '@reflect/core'
+import { resolveTaskEdit, taskContent, type TaskEditResult } from '@/lib/tasks/task-content'
+
+/** The two writes the finalizer itself performs; {@link TaskActions} satisfies it. */
+export interface TaskSheetWriteActions {
+  edit: (task: OpenTask, content: string) => void
+  remove: (tasks: OpenTask[]) => void
+}
+
+export interface TaskSheetFinalizerDeps {
+  /** The task's **live** row — writes relocate by its current raw. */
+  task: OpenTask
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  actions: TaskSheetWriteActions
+  /** Reset sheet-local presentation (collapse the calendar) on reopen. */
+  onReseed: () => void
+}
+
+export interface TaskSheetFinalizer {
+  /** The editable markdown draft (the task's content after the marker). */
+  draft: string
+  setDraft: Dispatch<SetStateAction<string>>
+  /** Resolve the draft against the frozen baseline: commit / cancel / delete. */
+  resolve: () => TaskEditResult
+  /** vaul's onOpenChange — a user dismissal finishes the visit first. */
+  handleOpenChange: (open: boolean) => void
+  /** Close after an action button took over the write (no dismissal commit). */
+  closeHandled: () => void
+  /** Commit a change / delete an emptied draft, then close — "Open note"'s flush. */
+  closeNavigate: () => void
+}
+
+/**
+ * The quick-edit sheet's commit/cancel/delete state machine (the mobile
+ * analog of desktop's {@link useTaskEditorFinalizer}), pulled out of the
+ * component so the exit rules live in one place:
+ *
+ * - The edit **baseline is frozen at open**: `task` is the live row, and if a
+ *   reindex rewrites it while the sheet is up, comparing the untouched draft
+ *   against the *new* content would read as an edit and commit stale text
+ *   over the external change.
+ * - The sheet stays mounted after closing (the exit animation needs content),
+ *   so **reopening reseeds everything** — baseline and draft from the row's
+ *   current raw (an action may have rewritten it), the handled flag, and the
+ *   caller's presentation via `onReseed` — else a visit after Complete/
+ *   Convert/Open note would silently drop its edits on dismiss.
+ * - **Abandoning** (dismissal gesture, or a route change unmounting the open
+ *   sheet) commits a changed draft, and deletes an emptied *or
+ *   abandoned-empty* one — a "+"-added row left untyped must not ghost a bare
+ *   `+ [ ]` in the note (V1's empty-task rule).
+ * - **Navigating** ("Open note") commits a change and deletes an emptied
+ *   draft, but never applies the abandoned-empty rule: an untouched empty
+ *   task must not lose the very line the navigation shows.
+ */
+export function useTaskSheetFinalizer({
+  task,
+  open,
+  onOpenChange,
+  actions,
+  onReseed,
+}: TaskSheetFinalizerDeps): TaskSheetFinalizer {
+  const liveContent = taskContent(task.raw)
+  const [initial, setInitial] = useState(liveContent)
+  const [draft, setDraft] = useState(liveContent)
+  // Set once an action button has already written/closed, so the dismissal
+  // commit doesn't double-write on the close that follows.
+  const [handled, setHandled] = useState(false)
+  const [wasOpen, setWasOpen] = useState(open)
+  if (open !== wasOpen) {
+    setWasOpen(open)
+    if (open) {
+      setHandled(false)
+      setInitial(liveContent)
+      setDraft(liveContent)
+      onReseed()
+    }
+  }
+
+  const resolve = (): TaskEditResult => resolveTaskEdit(initial, draft)
+
+  /** Persist the draft: a real change commits, an emptied draft deletes. */
+  const commitDraft = (): void => {
+    const result = resolve()
+    if (result.type === 'commit') {
+      actions.edit(task, result.content)
+    } else if (result.type === 'delete') {
+      actions.remove([task])
+    }
+  }
+
+  const finishAbandonedVisit = (): void => {
+    if (resolve().type === 'cancel' && draft.trim() === '') {
+      actions.remove([task])
+    } else {
+      commitDraft()
+    }
+  }
+
+  const handleOpenChange = (nextOpen: boolean): void => {
+    if (!nextOpen && !handled) {
+      finishAbandonedVisit()
+    }
+    onOpenChange(nextOpen)
+  }
+
+  const closeHandled = (): void => {
+    setHandled(true)
+    onOpenChange(false)
+  }
+
+  const closeNavigate = (): void => {
+    commitDraft()
+    setHandled(true)
+    onOpenChange(false)
+  }
+
+  // A route change (tab switch, back) can unmount the whole screen while the
+  // drawer is open — no dismissal callback fires, so flush like a dismissal
+  // would (desktop's inline editor flushes on unmount the same way). The
+  // latest-closure ref keeps the unmount-only cleanup reading current state.
+  const unmountFlushRef = useRef<() => void>(() => {})
+  useEffect(() => {
+    unmountFlushRef.current = () => {
+      if (open && !handled) {
+        finishAbandonedVisit()
+      }
+    }
+  })
+  useEffect(() => () => unmountFlushRef.current(), [])
+
+  return { draft, setDraft, resolve, handleOpenChange, closeHandled, closeNavigate }
+}

--- a/docs/porting/reflect-mobile/README.md
+++ b/docs/porting/reflect-mobile/README.md
@@ -56,7 +56,7 @@ never lost. That behavior is what these docs pin down.
 | [Daily notes](./daily-notes.md)                                       | Day carousel + calendar strip              | **v1** — Embla carousel, V1 design parity         |
 | [Editor and keyboard](./editor-and-keyboard.md)                       | Mobile editor + native accessory toolbar   | **v1** editing; toolbar deliberately re-designed  |
 | [Search and All Notes](./search-and-all-notes.md)                     | FTS search, filters, list, AI search chat  | **v1** list+search; filters partial, chat later   |
-| [Tasks](./tasks.md)                                                   | Task groups, drag-and-drop, quick edit     | Later — follows desktop Plan 18 (shipped there)   |
+| [Tasks](./tasks.md)                                                   | Task groups, drag-and-drop, quick edit     | **Shipped** — desktop Plan 18 data + touch surface |
 | [Note actions, sharing, export](./note-actions-sharing-and-export.md) | Pin/share/publish/trash, JSON export       | **v1** pin/share/trash; publish deferred          |
 | [Audio memos](./audio-memos.md)                                       | Native recording + server transcription    | Later wave — raw-first + BYOK transcription       |
 | [Share extension](./share-extension.md)                               | Share-sheet link capture via API           | Later wave — App Group capture inbox              |

--- a/docs/porting/reflect-mobile/tasks.md
+++ b/docs/porting/reflect-mobile/tasks.md
@@ -1,9 +1,15 @@
 # Porting the Tasks tab
 
-**v2 status: post-release.** Tasks are explicitly out of mobile v1
-(Plan 19); the desktop Tasks surface (Plan 18) has shipped, so the mobile
-wave is "put a touch surface over the existing task getters" — plus the
-three genuinely mobile-native interactions V1 added, recorded here.
+**v2 status: shipped** (`apps/desktop/src/mobile/screens/tasks.tsx` and the
+`mobile/task-*` components): a third Tasks tab over the desktop (Plan 18)
+task getters, groups, and guarded write-backs — reused verbatim via the
+shared queries/actions and `composeVisibleTaskGroups`. The touch surface is
+V1 mobile's: checkbox toggles with a light haptic, tap-to-quick-edit in a
+bottom sheet (text, scheduling chips + month grid, complete, convert to
+bullet, open note, delete), a filters sheet with desktop's bucket toggles +
+"Show archived", per-group "+" add, and struck-until-archived completions.
+Drag-between-groups scheduling is **not** ported — the sheet's date picker
+covers rescheduling; revisit only if real usage misses the gesture.
 
 ## What V1 mobile does
 

--- a/docs/porting/reflect-mobile/tasks.md
+++ b/docs/porting/reflect-mobile/tasks.md
@@ -58,12 +58,13 @@ those were desktop-only or nonexistent in V1.
   screen over search getters.
 - **Reuse desktop's grouping and semantics verbatim** (V1-parity there
   was already litigated on desktop). The mobile-specific work is
-  interaction: touch checkboxes with haptics, the quick-edit modal, and
-  drag-between-groups as the touch equivalent of desktop's scheduling
-  calendar.
-- **Drag activation distance matters.** V1's 8 pt PointerSensor threshold
-  is the difference between "drag to schedule" and "every tap flickers a
-  drag" — port the constraint, whatever the DnD implementation.
+  interaction: touch checkboxes with haptics, the quick-edit sheet, and
+  scheduling — shipped as a date picker in the sheet rather than
+  drag-between-groups (see the status note above).
+- **If drag-to-schedule is ever added: activation distance matters.**
+  V1's 8 pt PointerSensor threshold is the difference between "drag to
+  schedule" and "every tap flickers a drag" — port the constraint,
+  whatever the DnD implementation.
 - Editing a task from the list writes through the same note-session write
   path as any edit (no second write path), which also keeps the
   in-process file-change seam and sync dirty-marking working for free.
@@ -74,7 +75,7 @@ those were desktop-only or nonexistent in V1.
 | ------------------------------------------- | -------------------------------------------------------------- |
 | Task nodes in ProseMirror docs              | `- [ ]` markdown lines, indexed (desktop Plan 18, shipped)     |
 | Overdue / Today / Upcoming / Done groups    | Desktop v2 buckets, reused verbatim                            |
-| Drag between groups = reschedule            | Touch scheduling over `setTaskDueDate`                         |
+| Drag between groups = reschedule            | Sheet date picker over `setTaskDueDate` (drag not ported)      |
 | Quick-edit modal (edit without opening)     | Port: bottom sheet over the task's note session                |
 | Square checkbox + haptic + strikethrough    | Port as-is                                                     |
 | Filters modal                               | Follow desktop's filter set                                    |


### PR DESCRIPTION
## What

Adds the **Tasks tab** to the mobile app (V1 mobile's third tab), mirroring the desktop Tasks view (Plan 18) on the Plan 19 shell. Follows the porting doc's call: no new data model — a touch surface over the existing task getters.


### Reused from desktop, verbatim
- Queries (`tasksQueryKey` / `completedTasksQueryKey` + core `getOpenTasks` / `getCompletedTasks`), grouping (`groupTasks` — V1-exact buckets), optimistic mutations (`useTaskActions`, `useTaskCheckboxToggle` with the guarded raw-match write-back), `useTaskFilters` session flags, the `recently-completed` struck-until-archived set, and `TaskText` markdown rendering.
- The open/completed/session-struck merge + search + bucket-filter composition is **extracted** from `TasksScreen` into `lib/tasks/task-visibility.ts` (`composeVisibleTaskGroups`) and shared by both surfaces — desktop behavior unchanged (all 56 desktop screen tests pass untouched).

### The touch surface (V1 mobile interaction model)
- **Tab + screen**: `{ kind: 'tasks' }` route (already in the Route union) wired through the tab bar, shell tab derivation, and route switch. Search input, filter sheet trigger, Archive button when this session completed tasks, colored sticky group headers with counts, per-group "+" add (Current → today's daily, note groups → that note), empty/loading/error states.
- **Rows**: round checkbox with a light haptic, strikethrough struck-until-archived; tap opens the quick-edit sheet — no multi-select on touch.
- **Quick-edit sheet** (vaul): markdown text draft; Today / Tomorrow / Next week chips + month grid — scheduling edits the draft's `[[YYYY-MM-DD]]` link so text + date land as **one write**; Complete/Reopen, Convert to bullet, Open note, Delete. Commit-on-dismiss via `resolveTaskEdit`; emptied (or abandoned-empty "+"-added) drafts delete the task rather than ghosting `+ [ ]`.
- **Filters sheet**: desktop's five bucket toggles + "Show archived".

### Deliberately not ported
Drag-between-groups scheduling (V1 mobile's dnd-kit gesture) — the sheet's date picker covers rescheduling; noted in the porting doc for a revisit only if real usage misses the gesture.

## Testing
- New: `task-visibility.test.ts` (merge/filter/search rules), `mobile/screens/tasks.test.tsx` (18 tests: groups, toggle + archive, sheet commit/dismiss/delete semantics, one-write scheduling, complete-saves-draft-first, convert, open-note, "+" add + abandon, filter sheet, archived history, search, empty state, error state), plus a shell-level tab-switch test.
- `pnpm check` clean; desktop tasks + all mobile suites pass (330 tests across 35 files).
- Verified live in the browser dev harness (`?platform=ios`): add → type → schedule Tomorrow → dismiss commits one write and re-buckets into Upcoming with the date chip; checkbox strikes with Archive appearing; filters sheet renders. On-device haptics/drawer physics still owed a device pass.

### Post-review hardening (same PR)
Review rounds converged on the quick-edit sheet's lifecycle, so its exit rules (baseline frozen at open, reseed on reopen, dismiss vs Open-note vs unmount flush, abandoned-empty delete) are now one hook — `mobile/use-task-sheet-finalizer.ts`, the mobile analog of desktop's editor finalizer — with direct unit tests including the mid-open reindex case the render harness can't stage. Group header styling and the "+" add-target rule are shared via `lib/tasks/task-group-presentation.tsx`.

**New: mobile failure surface.** Failed/warning `startOperation` entries (a task write refused by the stale guard, a busy note) now show as tappable pills — previously mobile rolled optimistic UI back silently. `MobileStatusLayer` is the one fixed slot stacking these above the sync pill, which becomes a plain chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches note write paths and optimistic task cache via the same `useTaskActions` layer; sheet finalizer and merge/dedup rules are correctness-sensitive but heavily tested.
> 
> **Overview**
> Adds a **Tasks** tab to mobile (third tab in the shell) that reuses desktop Plan 18 data—same queries, `useTaskActions`, filters, and grouping—via a new touch UI: grouped list, search, filter drawer, archive, checkbox toggles with haptics, and a quick-edit bottom sheet (text, schedule chips + month grid, complete/convert/open/delete).
> 
> **Shared desktop/mobile logic:** task list merge/search/filter/grouping moves into `composeVisibleTaskGroups` in `task-visibility.ts` (desktop `TasksScreen` now calls it); group header icons and "+" add targets move to `task-group-presentation.tsx`.
> 
> **Mobile polish:** `useTaskSheetFinalizer` owns sheet commit/dismiss/unmount rules (frozen baseline, abandoned-empty delete); `MobileStatusLayer` stacks operation failure/warning pills above the sync pill (replacing a lone fixed sync pill); porting docs mark Tasks as shipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbef8c2e9a06cab1831e5dcc748b77dd1958105d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mobile **Tasks** tab with searchable, filterable task lists, including **archived** support.
  * Implemented mobile task interactions: complete/reopen, quick-edit bottom sheet, rescheduling via date picker, convert to bullet, delete, and open the source note.
  * Added a mobile task filters drawer plus task group/row UI and per-group add actions.
* **Bug Fixes**
  * Improved task grouping and deduping to avoid duplicate rows and keep “recently completed” items behaving correctly.
* **Tests**
  * Expanded coverage for the mobile Tasks flow and task visibility logic.
* **Documentation**
  * Updated mobile Tasks porting docs to reflect the shipped touch surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
