### PR TITLE
Fix forget graph dialog overflow

### DIFF
--- a/apps/desktop/src/components/settings/destructive-section.tsx
+++ b/apps/desktop/src/components/settings/destructive-section.tsx
@@ -55,9 +55,10 @@ export function DestructiveSection(): ReactElement {
       <Dialog open={confirming} onOpenChange={(open) => !forgetting && setConfirming(open)}>
         <DialogContent>
           <DialogTitle>Forget graph?</DialogTitle>
-          <DialogDescription>
-            Remove <span className="font-mono text-text">{graphId}</span> from saved graphs. Files
-            stay on disk.
+          <DialogDescription className="min-w-0">
+            Remove{' '}
+            <span className="font-mono text-text [overflow-wrap:anywhere]">{graphId}</span> from
+            saved graphs. Files stay on disk.
           </DialogDescription>
           <DialogFooter>
             <DialogClose asChild>


### PR DESCRIPTION
## Problem
Long graph root paths in the Settings danger-zone confirmation dialog could render as one unbreakable monospace token. On narrow dialog widths, that path overflowed the modal and made the footer band appear to overrun the dialog edge.

## Changes
- Allow the graph root path in `DestructiveSection` to wrap anywhere when needed.
- Mark the dialog description as shrinkable so the existing dialog grid can stay within its max width.

## Verification
- `pnpm --filter @reflect/desktop test --run src/components/settings-screen.test.tsx` passed: 35 tests.
- `pnpm check` passed with existing max-lines warnings only.
- `pnpm --filter @reflect/desktop build` passed, confirming the Tailwind arbitrary wrapping utility compiles.

## Risk / Rollout
Low risk: this only affects text wrapping in the forget-graph confirmation dialog. No data migrations or persistence changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only layout/CSS in one settings dialog; no behavior, persistence, or API changes.
> 
> **Overview**
> Fixes layout overflow in the **Forget graph?** confirmation when `graphId` is a long filesystem path.
> 
> `DialogDescription` gets `min-w-0` so the description can shrink inside the dialog grid instead of forcing horizontal overflow. The monospace path span uses `[overflow-wrap:anywhere]` so the token can break across lines on narrow widths, keeping the footer inside the modal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01959662a8f8eb08b52aadf61479a91cc118dbed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->