### PR TITLE
feat(ios): save links from the share sheet (App Group capture inbox)

### DIFF
--- a/apps/desktop/src-tauri/gen/apple/ShareExtension/CaptureInbox.swift
+++ b/apps/desktop/src-tauri/gen/apple/ShareExtension/CaptureInbox.swift
@@ -84,12 +84,16 @@ enum CaptureInbox {
         )
         // The URL is the one uncapped field (truncating it would save a
         // broken link): a pathological one can outgrow the spool cap. Shed
-        // the biggest optional field first; past that the share fails
+        // the optional fields biggest-first; past that the share fails
         // honestly rather than claiming "Saved" for a file the relay can
         // only quarantine.
         var data = try JSONEncoder().encode(envelope)
         if data.count > spoolMaxBytes, envelope.selection != nil {
             envelope.selection = nil
+            data = try JSONEncoder().encode(envelope)
+        }
+        if data.count > spoolMaxBytes, envelope.metaDescription != nil {
+            envelope.metaDescription = nil
             data = try JSONEncoder().encode(envelope)
         }
         guard data.count <= spoolMaxBytes else {

--- a/apps/desktop/src-tauri/gen/apple/ShareExtension/CaptureInbox.swift
+++ b/apps/desktop/src-tauri/gen/apple/ShareExtension/CaptureInbox.swift
@@ -37,7 +37,9 @@ enum CaptureInboxError: Error {
     case containerUnavailable
 }
 
-/// Field caps, applied at the producer so an envelope can never exceed the
+/// Field caps in UTF-16 code units — the unit zod's `.max()` counts on the
+/// drain side, so a capped value here can never be quarantined over length
+/// there. Applied at the producer so an envelope also stays inside the
 /// relay's 64 KiB spool cap. `textMax` mirrors `TEXT_CAPTURE_MAX_LENGTH`.
 private enum FieldCap {
     static let title = 1_000
@@ -143,9 +145,20 @@ enum CaptureInbox {
         return formatter.string(from: Date())
     }
 
+    /// Trim, then cap by UTF-16 code units (what the drain's zod `.max()`
+    /// counts — `String.count` counts grapheme clusters, and an emoji-heavy
+    /// share could pass a character cap yet fail the drain's). Backing off by
+    /// whole `Character`s keeps the cut on a grapheme boundary.
     private static func capped(_ value: String, at limit: Int) -> String {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.count > limit ? String(trimmed.prefix(limit)) : trimmed
+        guard trimmed.utf16.count > limit else {
+            return trimmed
+        }
+        var prefix = String(trimmed.prefix(limit))
+        while prefix.utf16.count > limit {
+            prefix.removeLast()
+        }
+        return prefix
     }
 
     private static func nonEmpty(_ value: String?) -> String? {

--- a/apps/desktop/src-tauri/gen/apple/ShareExtension/CaptureInbox.swift
+++ b/apps/desktop/src-tauri/gen/apple/ShareExtension/CaptureInbox.swift
@@ -35,6 +35,10 @@ enum CaptureInboxError: Error {
     /// The App Group container is unreachable — an entitlements mismatch, not
     /// a user-fixable state.
     case containerUnavailable
+    /// The encoded envelope exceeds the relay's spool cap even after
+    /// shedding optional fields — spooling it would only feed the
+    /// quarantine, so the share fails honestly instead.
+    case envelopeTooLarge
 }
 
 /// Field caps in UTF-16 code units — the unit zod's `.max()` counts on the
@@ -57,6 +61,10 @@ enum CaptureInbox {
     /// same directory name (`SHARED_INBOX_DIR`).
     static let inboxDir = "inbox"
 
+    /// The relay's spool cap (`INBOX_SPOOL_MAX_BYTES` in `capture.rs`) — an
+    /// envelope over it is quarantined unread, so it must never be spooled.
+    static let spoolMaxBytes = 64 * 1024
+
     /// Spool a link capture. Empty titles are allowed (the drain falls back
     /// to the URL's host); empty selections and descriptions are dropped.
     static func spoolLink(
@@ -66,7 +74,7 @@ enum CaptureInbox {
         metaDescription: String?
     ) throws {
         let id = envelopeId()
-        let envelope = LinkCaptureEnvelope(
+        var envelope = LinkCaptureEnvelope(
             id: id,
             url: url,
             title: capped(title, at: FieldCap.title),
@@ -74,7 +82,20 @@ enum CaptureInbox {
             metaDescription: nonEmpty(capped(metaDescription ?? "", at: FieldCap.description)),
             capturedAt: capturedAt()
         )
-        try spool(try JSONEncoder().encode(envelope), id: id)
+        // The URL is the one uncapped field (truncating it would save a
+        // broken link): a pathological one can outgrow the spool cap. Shed
+        // the biggest optional field first; past that the share fails
+        // honestly rather than claiming "Saved" for a file the relay can
+        // only quarantine.
+        var data = try JSONEncoder().encode(envelope)
+        if data.count > spoolMaxBytes, envelope.selection != nil {
+            envelope.selection = nil
+            data = try JSONEncoder().encode(envelope)
+        }
+        guard data.count <= spoolMaxBytes else {
+            throw CaptureInboxError.envelopeTooLarge
+        }
+        try spool(data, id: id)
     }
 
     /// Spool shared text as an append capture — the daily note gets a bullet.

--- a/apps/desktop/src-tauri/gen/apple/ShareExtension/CaptureInbox.swift
+++ b/apps/desktop/src-tauri/gen/apple/ShareExtension/CaptureInbox.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+/// The capture envelopes this extension produces and the App Group inbox it
+/// spools them into — the iOS half of Plan 11's platform-agnostic capture
+/// contract. The TypeScript zod schema
+/// (`packages/core/src/actions/capture-envelope.ts`) is the source of truth;
+/// these structs must stay in sync with it. The extension never opens the
+/// graph, the Git repo, or SQLite: the inbox is the only contract, and the
+/// main app relays + drains it on next launch/foreground.
+
+/// A shared web page or URL, as `capture-envelope.ts`'s `captureEnvelopeSchema`.
+struct LinkCaptureEnvelope: Encodable {
+    var version = 1
+    var id: String
+    var url: String
+    var title: String
+    var selection: String?
+    var metaDescription: String?
+    var capturedAt: String
+    var source = "ios-share"
+}
+
+/// Shared non-URL text, as `textCaptureEnvelopeSchema`: one folded line the
+/// drain appends to the capture-day daily note as a bullet.
+struct TextCaptureEnvelope: Encodable {
+    var version = 1
+    var id: String
+    var kind = "append"
+    var text: String
+    var capturedAt: String
+    var source = "ios-share"
+}
+
+enum CaptureInboxError: Error {
+    /// The App Group container is unreachable — an entitlements mismatch, not
+    /// a user-fixable state.
+    case containerUnavailable
+}
+
+/// Field caps, applied at the producer so an envelope can never exceed the
+/// relay's 64 KiB spool cap. `textMax` mirrors `TEXT_CAPTURE_MAX_LENGTH`.
+private enum FieldCap {
+    static let title = 1_000
+    static let selection = 10_000
+    static let description = 2_000
+    static let textMax = 10_000
+}
+
+enum CaptureInbox {
+    /// Must match the `com.apple.security.application-groups` entitlement on
+    /// both targets, and `SHARED_GROUP_ID` in the app's Rust relay.
+    static let groupId = "group.app.reflect"
+
+    /// Where envelopes spool inside the container; the Rust relay reads the
+    /// same directory name (`SHARED_INBOX_DIR`).
+    static let inboxDir = "inbox"
+
+    /// Spool a link capture. Empty titles are allowed (the drain falls back
+    /// to the URL's host); empty selections and descriptions are dropped.
+    static func spoolLink(
+        url: String,
+        title: String,
+        selection: String?,
+        metaDescription: String?
+    ) throws {
+        let id = envelopeId()
+        let envelope = LinkCaptureEnvelope(
+            id: id,
+            url: url,
+            title: capped(title, at: FieldCap.title),
+            selection: nonEmpty(capped(selection ?? "", at: FieldCap.selection)),
+            metaDescription: nonEmpty(capped(metaDescription ?? "", at: FieldCap.description)),
+            capturedAt: capturedAt()
+        )
+        try spool(try JSONEncoder().encode(envelope), id: id)
+    }
+
+    /// Spool shared text as an append capture — the daily note gets a bullet.
+    /// Returns false (spooling nothing) when the text folds to empty.
+    static func spoolText(_ text: String) throws -> Bool {
+        guard let line = foldedLine(text) else {
+            return false
+        }
+        let id = envelopeId()
+        let envelope = TextCaptureEnvelope(id: id, text: line, capturedAt: capturedAt())
+        try spool(try JSONEncoder().encode(envelope), id: id)
+        return true
+    }
+
+    /// Only web pages are capturable as links — everything else shares as text.
+    static func isHttpUrl(_ candidate: String) -> Bool {
+        candidate.hasPrefix("https://") || candidate.hasPrefix("http://")
+    }
+
+    /// Whitespace runs (including newlines) fold to single spaces, capped to
+    /// the schema's single-line limit — the same normalization the desktop's
+    /// deep-link parser applies. Nil when nothing printable remains.
+    static func foldedLine(_ text: String) -> String? {
+        let folded = text
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        return nonEmpty(capped(folded, at: FieldCap.textMax))
+    }
+
+    // MARK: - spooling
+
+    /// Write one envelope atomically: a `.json.tmp` sibling first, then a
+    /// same-volume rename to `<id>.json` — the relay only picks up committed
+    /// `.json` files, so it can never see a half-written envelope.
+    private static func spool(_ data: Data, id: String) throws {
+        let inbox = try inboxUrl()
+        try FileManager.default.createDirectory(at: inbox, withIntermediateDirectories: true)
+        let tmp = inbox.appendingPathComponent("\(id).json.tmp")
+        let committed = inbox.appendingPathComponent("\(id).json")
+        try data.write(to: tmp)
+        try FileManager.default.moveItem(at: tmp, to: committed)
+    }
+
+    private static func inboxUrl() throws -> URL {
+        guard
+            let container = FileManager.default.containerURL(
+                forSecurityApplicationGroupIdentifier: groupId)
+        else {
+            throw CaptureInboxError.containerUnavailable
+        }
+        return container.appendingPathComponent(inboxDir, isDirectory: true)
+    }
+
+    // MARK: - field shaping
+
+    /// Lowercased to match the producer convention (the drain's identity
+    /// slice and the spool filename both derive from it).
+    private static func envelopeId() -> String {
+        UUID().uuidString.lowercased()
+    }
+
+    /// ISO-8601 with milliseconds — what `Date.toISOString()` produces, and
+    /// what the drain's zod schema validates.
+    private static func capturedAt() -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: Date())
+    }
+
+    private static func capped(_ value: String, at limit: Int) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.count > limit ? String(trimmed.prefix(limit)) : trimmed
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+}

--- a/apps/desktop/src-tauri/gen/apple/ShareExtension/ExtensionClass.js
+++ b/apps/desktop/src-tauri/gen/apple/ShareExtension/ExtensionClass.js
@@ -1,0 +1,39 @@
+// Safari's NSExtensionJavaScriptPreprocessingFile: runs in the shared page
+// and hands the extension the richest capture available in-page — title,
+// URL, the user's text selection, and the meta/OpenGraph description. The
+// description lands in the envelope's `metaDescription`, so an offline
+// capture still saves with one; the app's enrichment pass replaces it later.
+//
+// Keys with null/undefined values must be omitted entirely: they break the
+// NSSecureCoding → NSDictionary bridge on the Swift side (V1 hit this on
+// pages with no description).
+
+var ExtensionClass = function () {}
+
+ExtensionClass.prototype = {
+  run: function (args) {
+    var pick = function (selector) {
+      var tag = document.querySelector(selector)
+      return (tag && tag.content) || null
+    }
+    var description =
+      pick('meta[property="og:description"]') ||
+      pick('meta[name="og:description"]') ||
+      pick('meta[name="description"]')
+
+    var content = {
+      title: document.title,
+      url: window.location.href,
+      selection: window.getSelection().toString(),
+    }
+    if (description) {
+      content.description = description
+    }
+
+    args.completionFunction(content)
+  },
+}
+
+// The global Safari looks up by name to run the preprocessor.
+// eslint-disable-next-line no-unused-vars
+var ExtensionPreprocessingJS = new ExtensionClass()

--- a/apps/desktop/src-tauri/gen/apple/ShareExtension/ExtensionClass.js
+++ b/apps/desktop/src-tauri/gen/apple/ShareExtension/ExtensionClass.js
@@ -21,10 +21,14 @@ ExtensionClass.prototype = {
       pick('meta[name="og:description"]') ||
       pick('meta[name="description"]')
 
+    // getSelection() can be null (e.g. in some frame contexts); a throw here
+    // would skip completionFunction and fail the whole share.
+    var selection = window.getSelection()
+
     var content = {
       title: document.title,
       url: window.location.href,
-      selection: window.getSelection().toString(),
+      selection: (selection && selection.toString()) || '',
     }
     if (description) {
       content.description = description

--- a/apps/desktop/src-tauri/gen/apple/ShareExtension/Info.plist
+++ b/apps/desktop/src-tauri/gen/apple/ShareExtension/Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Reflect</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.4.0</string>
+	<key>CFBundleVersion</key>
+	<string>0.4.0.17</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationDictionaryVersion</key>
+				<integer>2</integer>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
+				<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+			</dict>
+			<key>NSExtensionJavaScriptPreprocessingFile</key>
+			<string>ExtensionClass</string>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>ShareViewController</string>
+	</dict>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/gen/apple/ShareExtension/ShareExtension.entitlements
+++ b/apps/desktop/src-tauri/gen/apple/ShareExtension/ShareExtension.entitlements
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- The extension's only capability: the App Group container it spools
+	     capture envelopes into. It must match the main app's entry — the app
+	     reads the same container to relay envelopes into the graph. -->
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.app.reflect</string>
+	</array>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/gen/apple/ShareExtension/ShareState.swift
+++ b/apps/desktop/src-tauri/gen/apple/ShareExtension/ShareState.swift
@@ -26,11 +26,21 @@ final class ShareState: ObservableObject {
 
     var extensionContext: NSExtensionContext?
 
+    /// Single-flight: SwiftUI can fire `onAppear` more than once, and a
+    /// second pass would mint a fresh envelope id — a duplicate capture.
+    /// (The drain would dedup an identical re-share anyway, but the spool
+    /// should never carry one in the first place.)
+    private var started = false
+
     /// How long the "Saved" confirmation stays up before the sheet dismisses
     /// itself — long enough to read, short enough to keep the flow two-tap.
     private static let dismissDelay: TimeInterval = 0.9
 
     func save() {
+        guard !started else {
+            return
+        }
+        started = true
         guard let context = extensionContext else {
             return update(.failed)
         }

--- a/apps/desktop/src-tauri/gen/apple/ShareExtension/ShareState.swift
+++ b/apps/desktop/src-tauri/gen/apple/ShareExtension/ShareState.swift
@@ -1,0 +1,194 @@
+import Foundation
+import UniformTypeIdentifiers
+
+/// What one share-sheet invocation extracted, ready to spool.
+enum SharedCapture {
+    /// A web page or URL — from Safari's JS preprocessor (rich: title,
+    /// selection, meta description) or a bare URL item (title best-effort
+    /// from a plain-text sibling, the way Chrome shares).
+    case link(url: String, title: String, selection: String?, metaDescription: String?)
+    /// Non-URL text: becomes a bullet on today's daily note.
+    case text(String)
+}
+
+enum ShareStatus {
+    case saving
+    case saved
+    case failed
+}
+
+/// The extension's one flow: extract the shared item, spool an envelope into
+/// the App Group inbox, report. Entirely offline — saving never waits on the
+/// network, which is the point of the envelope model (the main app relays,
+/// drains, and enriches later; see `docs/porting/reflect-mobile/share-extension.md`).
+final class ShareState: ObservableObject {
+    @Published var status = ShareStatus.saving
+
+    var extensionContext: NSExtensionContext?
+
+    /// How long the "Saved" confirmation stays up before the sheet dismisses
+    /// itself — long enough to read, short enough to keep the flow two-tap.
+    private static let dismissDelay: TimeInterval = 0.9
+
+    func save() {
+        guard let context = extensionContext else {
+            return update(.failed)
+        }
+        Self.extract(from: context) { [weak self] capture in
+            guard let self else {
+                return
+            }
+            guard let capture else {
+                return self.update(.failed)
+            }
+            self.spool(capture)
+        }
+    }
+
+    func dismiss() {
+        extensionContext?.completeRequest(returningItems: [], completionHandler: nil)
+    }
+
+    private func spool(_ capture: SharedCapture) {
+        do {
+            switch capture {
+            case let .link(url, title, selection, metaDescription):
+                try CaptureInbox.spoolLink(
+                    url: url,
+                    title: title,
+                    selection: selection,
+                    metaDescription: metaDescription
+                )
+            case let .text(text):
+                guard try CaptureInbox.spoolText(text) else {
+                    return update(.failed) // nothing printable to save
+                }
+            }
+            update(.saved)
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.dismissDelay) { [weak self] in
+                self?.dismiss()
+            }
+        } catch {
+            update(.failed)
+        }
+    }
+
+    private func update(_ status: ShareStatus) {
+        DispatchQueue.main.async {
+            self.status = status
+        }
+    }
+
+    // MARK: - extraction
+
+    /// Pull the shared content out of the extension context. Provider load
+    /// callbacks arrive on arbitrary queues; `completion` may too.
+    private static func extract(
+        from context: NSExtensionContext,
+        completion: @escaping (SharedCapture?) -> Void
+    ) {
+        let attachments = context.inputItems
+            .compactMap { $0 as? NSExtensionItem }
+            .flatMap { $0.attachments ?? [] }
+        guard !attachments.isEmpty else {
+            return completion(nil)
+        }
+
+        // Safari web pages: the JS preprocessor's property-list results carry
+        // the richest capture (title, selection, meta description).
+        if let provider = first(of: attachments, conformingTo: UTType.propertyList.identifier) {
+            provider.loadItem(forTypeIdentifier: UTType.propertyList.identifier, options: nil) {
+                item, _ in
+                completion(pageCapture(from: item))
+            }
+            return
+        }
+
+        // A URL item; Chrome and friends share the page title as a separate
+        // plain-text attachment (why the activation rule needs dictionary
+        // version 2), so read it best-effort.
+        if let provider = first(of: attachments, conformingTo: UTType.url.identifier) {
+            let titleProvider = attachments.first {
+                $0 !== provider && $0.hasItemConformingToTypeIdentifier(UTType.plainText.identifier)
+            }
+            provider.loadItem(forTypeIdentifier: UTType.url.identifier, options: nil) { item, _ in
+                guard let url = sharedUrlString(item) else {
+                    return completion(nil)
+                }
+                guard CaptureInbox.isHttpUrl(url) else {
+                    // Not a web page (mailto:, an app URL): keep it as text
+                    // rather than dropping the share.
+                    return completion(.text(url))
+                }
+                guard let titleProvider else {
+                    return completion(.link(url: url, title: "", selection: nil, metaDescription: nil))
+                }
+                titleProvider.loadItem(forTypeIdentifier: UTType.plainText.identifier, options: nil) {
+                    titleItem, _ in
+                    let title = titleItem as? String ?? ""
+                    completion(.link(url: url, title: title, selection: nil, metaDescription: nil))
+                }
+            }
+            return
+        }
+
+        // Plain text: a pasted URL saves as a link, anything else as a bullet.
+        if let provider = first(of: attachments, conformingTo: UTType.plainText.identifier) {
+            provider.loadItem(forTypeIdentifier: UTType.plainText.identifier, options: nil) {
+                item, _ in
+                guard let text = item as? String else {
+                    return completion(nil)
+                }
+                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                if CaptureInbox.isHttpUrl(trimmed), !trimmed.contains(" "),
+                    URL(string: trimmed) != nil
+                {
+                    completion(.link(url: trimmed, title: "", selection: nil, metaDescription: nil))
+                } else {
+                    completion(.text(text))
+                }
+            }
+            return
+        }
+
+        completion(nil)
+    }
+
+    private static func first(
+        of attachments: [NSItemProvider],
+        conformingTo identifier: String
+    ) -> NSItemProvider? {
+        attachments.first { $0.hasItemConformingToTypeIdentifier(identifier) }
+    }
+
+    private static func sharedUrlString(_ item: NSSecureCoding?) -> String? {
+        if let url = item as? URL {
+            return url.absoluteString
+        }
+        if let url = item as? NSURL {
+            return url.absoluteString
+        }
+        return nil
+    }
+
+    /// Decode the JS preprocessor's results. A malformed dictionary (or a
+    /// non-web page the preprocessor couldn't run on) is a failed capture —
+    /// the URL fallback path never reaches here because property-list items
+    /// are checked first.
+    private static func pageCapture(from item: NSSecureCoding?) -> SharedCapture? {
+        guard
+            let dict = item as? NSDictionary,
+            let results = dict[NSExtensionJavaScriptPreprocessingResultsKey] as? NSDictionary,
+            let url = results["url"] as? String,
+            CaptureInbox.isHttpUrl(url)
+        else {
+            return nil
+        }
+        return .link(
+            url: url,
+            title: results["title"] as? String ?? "",
+            selection: results["selection"] as? String,
+            metaDescription: results["description"] as? String
+        )
+    }
+}

--- a/apps/desktop/src-tauri/gen/apple/ShareExtension/ShareState.swift
+++ b/apps/desktop/src-tauri/gen/apple/ShareExtension/ShareState.swift
@@ -99,11 +99,25 @@ final class ShareState: ObservableObject {
         if let provider = first(of: attachments, conformingTo: UTType.propertyList.identifier) {
             provider.loadItem(forTypeIdentifier: UTType.propertyList.identifier, options: nil) {
                 item, _ in
-                completion(pageCapture(from: item))
+                if let capture = pageCapture(from: item) {
+                    completion(capture)
+                } else {
+                    // Malformed preprocessing results must not fail a share
+                    // that also carries a plain URL or text attachment.
+                    extractPlain(from: attachments, completion: completion)
+                }
             }
             return
         }
+        extractPlain(from: attachments, completion: completion)
+    }
 
+    /// The non-Safari extraction paths: a URL attachment (title best-effort
+    /// from a plain-text sibling), else plain text.
+    private static func extractPlain(
+        from attachments: [NSItemProvider],
+        completion: @escaping (SharedCapture?) -> Void
+    ) {
         // A URL item; Chrome and friends share the page title as a separate
         // plain-text attachment (why the activation rule needs dictionary
         // version 2), so read it best-effort.
@@ -171,10 +185,9 @@ final class ShareState: ObservableObject {
         return nil
     }
 
-    /// Decode the JS preprocessor's results. A malformed dictionary (or a
-    /// non-web page the preprocessor couldn't run on) is a failed capture —
-    /// the URL fallback path never reaches here because property-list items
-    /// are checked first.
+    /// Decode the JS preprocessor's results. `nil` for a malformed dictionary
+    /// (or a page the preprocessor couldn't run on) — the caller then falls
+    /// back to the plain URL/text attachments instead of failing the share.
     private static func pageCapture(from item: NSSecureCoding?) -> SharedCapture? {
         guard
             let dict = item as? NSDictionary,

--- a/apps/desktop/src-tauri/gen/apple/ShareExtension/ShareView.swift
+++ b/apps/desktop/src-tauri/gen/apple/ShareExtension/ShareView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+/// The share sheet's content: saving spinner → "Saved to Reflect" (then the
+/// sheet dismisses itself) or a failure with a Dismiss button. Copy stays
+/// short and action-free — the save starts on appear, no confirm step.
+struct ShareView: View {
+    @EnvironmentObject var state: ShareState
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            switch state.status {
+            case .saving:
+                ProgressView()
+                Text("Saving to Reflect…")
+                    .font(.body.weight(.medium))
+                    .foregroundColor(.secondary)
+            case .saved:
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 44))
+                    .foregroundColor(.green)
+                Text("Saved to Reflect")
+                    .font(.body.weight(.medium))
+            case .failed:
+                Image(systemName: "exclamationmark.circle.fill")
+                    .font(.system(size: 44))
+                    .foregroundColor(.secondary)
+                Text("Couldn’t save")
+                    .font(.body.weight(.medium))
+            }
+            Spacer()
+            if case .failed = state.status {
+                Button(action: { state.dismiss() }) {
+                    Text("Dismiss")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(Color.secondary.opacity(0.4), lineWidth: 1)
+                        )
+                }
+                .foregroundColor(.primary)
+            }
+        }
+        .padding(24)
+        .onAppear {
+            state.save()
+        }
+    }
+}

--- a/apps/desktop/src-tauri/gen/apple/ShareExtension/ShareViewController.swift
+++ b/apps/desktop/src-tauri/gen/apple/ShareExtension/ShareViewController.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+import UIKit
+
+/// The extension's principal class (`NSExtensionPrincipalClass` — the
+/// `@objc` name pins what the Info.plist references). Storyboard-less: it
+/// hosts the SwiftUI `ShareView`, and the save flow starts as soon as the
+/// sheet appears.
+@objc(ShareViewController)
+final class ShareViewController: UIViewController {
+    private let state = ShareState()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        state.extensionContext = extensionContext
+        view.backgroundColor = .systemBackground
+
+        let hosting = UIHostingController(rootView: ShareView().environmentObject(state))
+        addChild(hosting)
+        hosting.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(hosting.view)
+        NSLayoutConstraint.activate([
+            hosting.view.topAnchor.constraint(equalTo: view.topAnchor),
+            hosting.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            hosting.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            hosting.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+        ])
+        hosting.didMove(toParent: self)
+    }
+}

--- a/apps/desktop/src-tauri/gen/apple/project.yml
+++ b/apps/desktop/src-tauri/gen/apple/project.yml
@@ -81,7 +81,7 @@ targets:
         # tag is stripped — Apple requires three dot-separated integers), so the
         # version lives in one place and never drifts. Do not hardcode a literal.
         CFBundleShortVersionString: 0.4.0
-        CFBundleVersion: 0.4.0.13
+        CFBundleVersion: 0.4.0.17
     entitlements:
       path: reflect-open_iOS/reflect-open_iOS.entitlements
     scheme:
@@ -99,6 +99,10 @@ targets:
         EXCLUDED_ARCHS[sdk=iphoneos*]: x86_64
       groups: [app]
     dependencies:
+      # The share-sheet capture extension (Plan 11's iOS producer): embedded
+      # into the app bundle and signed with it.
+      - target: ShareExtension
+        embed: true
       - framework: libapp.a
         embed: false
       # libgit2 (vendored into libapp.a) needs zlib and iconv at the final
@@ -122,3 +126,51 @@ targets:
         outputFiles:
           - $(SRCROOT)/Externals/x86_64/${CONFIGURATION}/libapp.a
           - $(SRCROOT)/Externals/arm64/${CONFIGURATION}/libapp.a
+  # The share-sheet capture extension: saves links/text shared from any app
+  # into the App Group inbox (`group.app.reflect`), entirely offline; the main
+  # app relays + drains on next launch/foreground (Plan 11's envelope model).
+  # Swift only — no Rust, no webview, no network.
+  ShareExtension:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: ShareExtension/ShareViewController.swift
+      - path: ShareExtension/ShareState.swift
+      - path: ShareExtension/ShareView.swift
+      - path: ShareExtension/CaptureInbox.swift
+      # The Safari preprocessor (title/URL/selection/meta description); a
+      # bundle resource the NSExtension attributes reference by base name.
+      - path: ShareExtension/ExtensionClass.js
+        buildPhase: resources
+    info:
+      path: ShareExtension/Info.plist
+      properties:
+        # The share sheet's row label (the icon comes from the host app).
+        CFBundleDisplayName: Reflect
+        CFBundleShortVersionString: 0.4.0
+        CFBundleVersion: 0.4.0.17
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.share-services
+          # Storyboard-less principal class; `@objc(ShareViewController)`
+          # pins the runtime name the plist references.
+          NSExtensionPrincipalClass: ShareViewController
+          NSExtensionAttributes:
+            # Dictionary version 2 allows subset matching — Chrome shares a
+            # URL *and* text, which version 1's exact match would refuse
+            # (V1 parity; see the porting doc).
+            NSExtensionActivationRule:
+              NSExtensionActivationDictionaryVersion: 2
+              NSExtensionActivationSupportsText: true
+              NSExtensionActivationSupportsWebPageWithMaxCount: 1
+              NSExtensionActivationSupportsWebURLWithMaxCount: 1
+            NSExtensionJavaScriptPreprocessingFile: ExtensionClass
+    entitlements:
+      path: ShareExtension/ShareExtension.entitlements
+    settings:
+      base:
+        PRODUCT_NAME: ShareExtension
+        PRODUCT_BUNDLE_IDENTIFIER: app.reflect.ios.share
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: 789ULN5MZB
+        SWIFT_VERSION: "5.0"
+        TARGETED_DEVICE_FAMILY: 1,2

--- a/apps/desktop/src-tauri/gen/apple/project.yml
+++ b/apps/desktop/src-tauri/gen/apple/project.yml
@@ -82,6 +82,9 @@ targets:
         # version lives in one place and never drifts. Do not hardcode a literal.
         CFBundleShortVersionString: 0.4.0
         CFBundleVersion: 0.4.0.17
+    # CAUTION: `tauri ios init` rewrites BOTH committed .entitlements files
+    # to empty dicts — after a regen, restore the iCloud + App Group entries
+    # before committing (see docs/porting/reflect-mobile/share-extension.md).
     entitlements:
       path: reflect-open_iOS/reflect-open_iOS.entitlements
     scheme:

--- a/apps/desktop/src-tauri/gen/apple/reflect-open.xcodeproj/project.pbxproj
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open.xcodeproj/project.pbxproj
@@ -7,15 +7,21 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1C8847A7F1C163FBA53373F9 /* ExtensionClass.js in Resources */ = {isa = PBXBuildFile; fileRef = 536E4F5E21B7DCC3C7ECDC1A /* ExtensionClass.js */; };
 		266B3807E809464C8FC14146 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FDC9BB81FAB5AF8D65160799 /* Metal.framework */; };
 		319EDF8F46AB05DFBA9D674F /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 80E05926405BFDA2A3BC70BC /* libz.tbd */; };
+		495C9E97530FC781EB5645D6 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A58A746A41B6BF1D50A8547 /* ShareViewController.swift */; };
 		5693613DE956199D6486EA26 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D0D6D72E614086946EBF890 /* LaunchScreen.storyboard */; };
 		5C88834F22D37FFC49CBD2F1 /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 38829A9D2116D0D324C18C4B /* main.mm */; };
 		74275EAEFEA922B7D8A2C78F /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5249E1475DBD7CCB817F7D1B /* CoreGraphics.framework */; };
+		93F2A1181D6BC7832338EE9C /* ShareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93EF89A222208D739ABC00B8 /* ShareView.swift */; };
 		961AA49623F0DDC7AB09B777 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39269153EFAD0C2FEFBE6696 /* UIKit.framework */; };
 		9C05940F9725363AAB9131D3 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C94374B175075AF3AA7DE586 /* Security.framework */; };
 		9D7F5A94048CECBFC3D89BBA /* libapp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F28F8A628D32337E04C0CBC0 /* libapp.a */; };
 		A2E5A9558E714E679520EA9E /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E66BC7105426B91F03659B53 /* MetalKit.framework */; };
+		B109D161D258110DC703F97C /* ShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 51006DE1482D28D9562253A1 /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		B6B5B091EADAF6EAEC6E2EDA /* ShareState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89342C7501B47DBB934B2D27 /* ShareState.swift */; };
+		BEA09DBDD61413051FFEB9E3 /* CaptureInbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = D357D2D54012FD394DF9423E /* CaptureInbox.swift */; };
 		C1FBC0B57C41A13D88225DFB /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 3ED6411036D50396010D935D /* assets */; };
 		C4FAE42D7B978D8330E5D6DC /* Contacts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D182B9445129EC2433F8218 /* Contacts.framework */; };
 		DD1AE73F867F4264272EFED2 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 68D1FDE7F099CA5F909105EB /* QuartzCore.framework */; };
@@ -24,17 +30,45 @@
 		F00F5EAED90E34102F9AE651 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A86D201016958E2276806466 /* Assets.xcassets */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		E15A48A368A368CDA2B5A070 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5489219F37B2885D5C3112F4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 85FC564C07724F1F4E282538;
+			remoteInfo = ShareExtension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		BD3D981F03353195982EBCE6 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				B109D161D258110DC703F97C /* ShareExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		05ABE058940EC4D96B7CA5D9 /* mod.rs */ = {isa = PBXFileReference; path = mod.rs; sourceTree = "<group>"; };
 		088536D8F462855DCFDA7B06 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		08B3817A23175E584BA6FD8D /* error.rs */ = {isa = PBXFileReference; path = error.rs; sourceTree = "<group>"; };
 		152767D3A95549268E140D0F /* graph_gitignore.rs */ = {isa = PBXFileReference; path = graph_gitignore.rs; sourceTree = "<group>"; };
 		18A732A38CD75FF514E4CF86 /* settings.rs */ = {isa = PBXFileReference; path = settings.rs; sourceTree = "<group>"; };
+		1A58A746A41B6BF1D50A8547 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		1EB2845C34150F5FE04A33D3 /* write.rs */ = {isa = PBXFileReference; path = write.rs; sourceTree = "<group>"; };
-		2090398BADEFF8597C73DEF4 /* libapp.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libapp.a; sourceTree = "<group>"; };
 		2130029E77013461A501E644 /* devtools.rs */ = {isa = PBXFileReference; path = devtools.rs; sourceTree = "<group>"; };
+		21F0526713DAC48C777B2D4C /* union.rs */ = {isa = PBXFileReference; path = union.rs; sourceTree = "<group>"; };
 		2490DACB2171344E8D9A8807 /* capture.rs */ = {isa = PBXFileReference; path = capture.rs; sourceTree = "<group>"; };
+		28AF2C553C3E42F07C4AF0DD /* shadow.rs */ = {isa = PBXFileReference; path = shadow.rs; sourceTree = "<group>"; };
+		28B078410B4B4507A763E297 /* ladder.rs */ = {isa = PBXFileReference; path = ladder.rs; sourceTree = "<group>"; };
 		2EDECD14A0418A8D4AA04512 /* remote.rs */ = {isa = PBXFileReference; path = remote.rs; sourceTree = "<group>"; };
+		32B7D9FD2081133899440765 /* mod.rs */ = {isa = PBXFileReference; path = mod.rs; sourceTree = "<group>"; };
 		3779A211A168AE84C5573923 /* merge.rs */ = {isa = PBXFileReference; path = merge.rs; sourceTree = "<group>"; };
 		37EF719F509C3A532C0E0114 /* main.rs */ = {isa = PBXFileReference; path = main.rs; sourceTree = "<group>"; };
 		383CB9669208178C6B235BE6 /* io.rs */ = {isa = PBXFileReference; path = io.rs; sourceTree = "<group>"; };
@@ -47,23 +81,32 @@
 		48F8214D2C537DF115410CC0 /* resolve.rs */ = {isa = PBXFileReference; path = resolve.rs; sourceTree = "<group>"; };
 		491E4F680A58FFBD620237F9 /* commit.rs */ = {isa = PBXFileReference; path = commit.rs; sourceTree = "<group>"; };
 		4EE64B671C831953394179E2 /* watcher.rs */ = {isa = PBXFileReference; path = watcher.rs; sourceTree = "<group>"; };
+		51006DE1482D28D9562253A1 /* ShareExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		5249E1475DBD7CCB817F7D1B /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		5306360328A772EEE5EDDD87 /* versions.rs */ = {isa = PBXFileReference; path = versions.rs; sourceTree = "<group>"; };
+		536E4F5E21B7DCC3C7ECDC1A /* ExtensionClass.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = ExtensionClass.js; sourceTree = "<group>"; };
 		560C7C23BE58D7EA845F1170 /* lib.rs */ = {isa = PBXFileReference; path = lib.rs; sourceTree = "<group>"; };
 		5C56D455FF36B2FFA8189246 /* repo.rs */ = {isa = PBXFileReference; path = repo.rs; sourceTree = "<group>"; };
 		5F2E1B8E7D79BDAFFCD2DCDE /* assets.rs */ = {isa = PBXFileReference; path = assets.rs; sourceTree = "<group>"; };
 		5F605BA8949402DAE91B9243 /* embed_write.rs */ = {isa = PBXFileReference; path = embed_write.rs; sourceTree = "<group>"; };
 		65C0E213C54BBE2152AA5DF2 /* chat_write.rs */ = {isa = PBXFileReference; path = chat_write.rs; sourceTree = "<group>"; };
 		68D1FDE7F099CA5F909105EB /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		6BB60C6D34C4AFB61F084B4D /* mod.rs */ = {isa = PBXFileReference; path = mod.rs; sourceTree = "<group>"; };
 		73D6C2FDB2DD7919E24C4533 /* mod.rs */ = {isa = PBXFileReference; path = mod.rs; sourceTree = "<group>"; };
 		772B62ED093A33BDCD1864D8 /* calendar.rs */ = {isa = PBXFileReference; path = calendar.rs; sourceTree = "<group>"; };
 		777653BF3E38355A5F6B6EF9 /* bindings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bindings.h; sourceTree = "<group>"; };
 		80E05926405BFDA2A3BC70BC /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		88ED38A3B3D14839B5066255 /* embed.rs */ = {isa = PBXFileReference; path = embed.rs; sourceTree = "<group>"; };
+		89342C7501B47DBB934B2D27 /* ShareState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareState.swift; sourceTree = "<group>"; };
 		89B314CA06450414E4537033 /* query.rs */ = {isa = PBXFileReference; path = query.rs; sourceTree = "<group>"; };
+		8A676086DFF0C50E4E5C77A5 /* archive.rs */ = {isa = PBXFileReference; path = archive.rs; sourceTree = "<group>"; };
 		8C04E40F02C9B4AE9A24A9A4 /* recents.rs */ = {isa = PBXFileReference; path = recents.rs; sourceTree = "<group>"; };
 		8D0D6D72E614086946EBF890 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		93EF89A222208D739ABC00B8 /* ShareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareView.swift; sourceTree = "<group>"; };
+		A67279D745DF48458936735A /* storage.rs */ = {isa = PBXFileReference; path = storage.rs; sourceTree = "<group>"; };
 		A86D201016958E2276806466 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A8921CA643078550A7A02536 /* embed_mobile.rs */ = {isa = PBXFileReference; path = embed_mobile.rs; sourceTree = "<group>"; };
+		AABA262BFCEDA2C43E343A31 /* sweep.rs */ = {isa = PBXFileReference; path = sweep.rs; sourceTree = "<group>"; };
 		ADB23521181EEB9EF095D4AB /* contacts.rs */ = {isa = PBXFileReference; path = contacts.rs; sourceTree = "<group>"; };
 		B667667E9C6C141128493B00 /* quit.rs */ = {isa = PBXFileReference; path = quit.rs; sourceTree = "<group>"; };
 		BC3901740F3A40252C3750C7 /* reflect-open_iOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "reflect-open_iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -71,12 +114,17 @@
 		C7BE8291B337F95D913C6AE9 /* commit_message.rs */ = {isa = PBXFileReference; path = commit_message.rs; sourceTree = "<group>"; };
 		C94374B175075AF3AA7DE586 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		CF582FB0094C95210BE919F7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		D05B757D9AB841897576F256 /* merge3.rs */ = {isa = PBXFileReference; path = merge3.rs; sourceTree = "<group>"; };
+		D357D2D54012FD394DF9423E /* CaptureInbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureInbox.swift; sourceTree = "<group>"; };
 		D3691D8F671B7FA21D1E7BD7 /* mod.rs */ = {isa = PBXFileReference; path = mod.rs; sourceTree = "<group>"; };
 		D7DA2E13EA6655A16DFDE015 /* secrets.rs */ = {isa = PBXFileReference; path = secrets.rs; sourceTree = "<group>"; };
 		D8F1F4787BA60FD05FD83FD1 /* spike_mobile.rs */ = {isa = PBXFileReference; path = spike_mobile.rs; sourceTree = "<group>"; };
 		DBD22A8C59FD8892E5F139EC /* tests.rs */ = {isa = PBXFileReference; path = tests.rs; sourceTree = "<group>"; };
 		DD5CA5DD1A0A2C6898BF16AE /* tests.rs */ = {isa = PBXFileReference; path = tests.rs; sourceTree = "<group>"; };
+		E1940DEB1B975598A69CA93F /* frontmatter.rs */ = {isa = PBXFileReference; path = frontmatter.rs; sourceTree = "<group>"; };
 		E66BC7105426B91F03659B53 /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
+		E8031FEC080EBAF422BEE44C /* markers.rs */ = {isa = PBXFileReference; path = markers.rs; sourceTree = "<group>"; };
+		EC45808CD3D13DD431212EAE /* watch.rs */ = {isa = PBXFileReference; path = watch.rs; sourceTree = "<group>"; };
 		F28F8A628D32337E04C0CBC0 /* libapp.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libapp.a; sourceTree = "<group>"; };
 		F3173A0D7E498896FAC5A43E /* watcher_mobile.rs */ = {isa = PBXFileReference; path = watcher_mobile.rs; sourceTree = "<group>"; };
 		FDC9BB81FAB5AF8D65160799 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
@@ -104,10 +152,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		064330CA0617C1F023B33371 /* ShareExtension */ = {
+			isa = PBXGroup;
+			children = (
+				D357D2D54012FD394DF9423E /* CaptureInbox.swift */,
+				536E4F5E21B7DCC3C7ECDC1A /* ExtensionClass.js */,
+				89342C7501B47DBB934B2D27 /* ShareState.swift */,
+				93EF89A222208D739ABC00B8 /* ShareView.swift */,
+				1A58A746A41B6BF1D50A8547 /* ShareViewController.swift */,
+			);
+			path = ShareExtension;
+			sourceTree = "<group>";
+		};
 		085B9B9F8FF6A8514F9F4511 /* Products */ = {
 			isa = PBXGroup;
 			children = (
 				BC3901740F3A40252C3750C7 /* reflect-open_iOS.app */,
+				51006DE1482D28D9562253A1 /* ShareExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -134,6 +195,7 @@
 				8D0D6D72E614086946EBF890 /* LaunchScreen.storyboard */,
 				59A902E5FAB9324234886822 /* Externals */,
 				D93D4C46C491FF3654305D76 /* reflect-open_iOS */,
+				064330CA0617C1F023B33371 /* ShareExtension */,
 				3644284E3067EA5E39E59FDA /* Sources */,
 				55421F1EE94451C6C2F0F2F6 /* src */,
 				B6C98802589FDB7BF4EC3F7C /* Frameworks */,
@@ -147,6 +209,21 @@
 				504E678B5FB1E7386811074E /* reflect-open */,
 			);
 			path = Sources;
+			sourceTree = "<group>";
+		};
+		3F54925F5E584B8E6578AFAD /* conflict */ = {
+			isa = PBXGroup;
+			children = (
+				8A676086DFF0C50E4E5C77A5 /* archive.rs */,
+				E1940DEB1B975598A69CA93F /* frontmatter.rs */,
+				28B078410B4B4507A763E297 /* ladder.rs */,
+				E8031FEC080EBAF422BEE44C /* markers.rs */,
+				D05B757D9AB841897576F256 /* merge3.rs */,
+				6BB60C6D34C4AFB61F084B4D /* mod.rs */,
+				28AF2C553C3E42F07C4AF0DD /* shadow.rs */,
+				21F0526713DAC48C777B2D4C /* union.rs */,
+			);
+			path = conflict;
 			sourceTree = "<group>";
 		};
 		504E678B5FB1E7386811074E /* reflect-open */ = {
@@ -178,9 +255,11 @@
 				D8F1F4787BA60FD05FD83FD1 /* spike_mobile.rs */,
 				F3173A0D7E498896FAC5A43E /* watcher_mobile.rs */,
 				4EE64B671C831953394179E2 /* watcher.rs */,
+				3F54925F5E584B8E6578AFAD /* conflict */,
 				9E54DCC255F04D51453CC522 /* db */,
 				C0FD50680AFE75D524EF47A4 /* fs */,
 				1D9398A0E5F4DDC402E05E94 /* git */,
+				6DD6A3F991A69D4F41B1410B /* icloud */,
 			);
 			name = src;
 			path = ../../src;
@@ -189,17 +268,20 @@
 		59A902E5FAB9324234886822 /* Externals */ = {
 			isa = PBXGroup;
 			children = (
-				B08490267F4622BEF663A1E8 /* arm64 */,
 			);
 			path = Externals;
 			sourceTree = "<group>";
 		};
-		9C4DCBE0B2A7049257446433 /* debug */ = {
+		6DD6A3F991A69D4F41B1410B /* icloud */ = {
 			isa = PBXGroup;
 			children = (
-				2090398BADEFF8597C73DEF4 /* libapp.a */,
+				32B7D9FD2081133899440765 /* mod.rs */,
+				A67279D745DF48458936735A /* storage.rs */,
+				AABA262BFCEDA2C43E343A31 /* sweep.rs */,
+				5306360328A772EEE5EDDD87 /* versions.rs */,
+				EC45808CD3D13DD431212EAE /* watch.rs */,
 			);
-			path = debug;
+			path = icloud;
 			sourceTree = "<group>";
 		};
 		9E54DCC255F04D51453CC522 /* db */ = {
@@ -222,14 +304,6 @@
 				777653BF3E38355A5F6B6EF9 /* bindings.h */,
 			);
 			path = bindings;
-			sourceTree = "<group>";
-		};
-		B08490267F4622BEF663A1E8 /* arm64 */ = {
-			isa = PBXGroup;
-			children = (
-				9C4DCBE0B2A7049257446433 /* debug */,
-			);
-			path = arm64;
 			sourceTree = "<group>";
 		};
 		B6C98802589FDB7BF4EC3F7C /* Frameworks */ = {
@@ -270,16 +344,27 @@
 			path = "reflect-open_iOS";
 			sourceTree = "<group>";
 		};
-		"TEMP_A7BBCD47-E811-454F-80D4-E567BEF5E016" /* x86_64 */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = x86_64;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		85FC564C07724F1F4E282538 /* ShareExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 85C256481A6DA4978244EF0C /* Build configuration list for PBXNativeTarget "ShareExtension" */;
+			buildPhases = (
+				6C4170AF0104E2BB23FF2992 /* Sources */,
+				D66D7A4411695309647B6A04 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ShareExtension;
+			packageProductDependencies = (
+			);
+			productName = ShareExtension;
+			productReference = 51006DE1482D28D9562253A1 /* ShareExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		E2CEE6E5CCFA69CBA5F9AA3F /* reflect-open_iOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 10FFF2E018E94EEF95D56337 /* Build configuration list for PBXNativeTarget "reflect-open_iOS" */;
@@ -288,10 +373,12 @@
 				B34A0474C6B6B9C6508E3011 /* Sources */,
 				85955AB12D745102D2B8C7AD /* Resources */,
 				EA5FF361D672FCDD65A1742F /* Frameworks */,
+				BD3D981F03353195982EBCE6 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				4117F1E82CF9953D0AD38F11 /* PBXTargetDependency */,
 			);
 			name = "reflect-open_iOS";
 			packageProductDependencies = (
@@ -309,6 +396,10 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
+					85FC564C07724F1F4E282538 = {
+						DevelopmentTeam = 789ULN5MZB;
+						ProvisioningStyle = Automatic;
+					};
 					E2CEE6E5CCFA69CBA5F9AA3F = {
 						DevelopmentTeam = 789ULN5MZB;
 						ProvisioningStyle = Automatic;
@@ -329,6 +420,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				85FC564C07724F1F4E282538 /* ShareExtension */,
 				E2CEE6E5CCFA69CBA5F9AA3F /* reflect-open_iOS */,
 			);
 		};
@@ -342,6 +434,14 @@
 				F00F5EAED90E34102F9AE651 /* Assets.xcassets in Resources */,
 				5693613DE956199D6486EA26 /* LaunchScreen.storyboard in Resources */,
 				C1FBC0B57C41A13D88225DFB /* assets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D66D7A4411695309647B6A04 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1C8847A7F1C163FBA53373F9 /* ExtensionClass.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -372,6 +472,17 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		6C4170AF0104E2BB23FF2992 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BEA09DBDD61413051FFEB9E3 /* CaptureInbox.swift in Sources */,
+				B6B5B091EADAF6EAEC6E2EDA /* ShareState.swift in Sources */,
+				93F2A1181D6BC7832338EE9C /* ShareView.swift in Sources */,
+				495C9E97530FC781EB5645D6 /* ShareViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B34A0474C6B6B9C6508E3011 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -382,7 +493,35 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		4117F1E82CF9953D0AD38F11 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 85FC564C07724F1F4E282538 /* ShareExtension */;
+			targetProxy = E15A48A368A368CDA2B5A070 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		045CAFDCB110568CC41B98CF /* release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 789ULN5MZB;
+				INFOPLIST_FILE = ShareExtension/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = app.reflect.ios.share;
+				PRODUCT_NAME = ShareExtension;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = release;
+		};
 		30A46A347AF8452DE397F2BE /* release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -476,6 +615,26 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+			};
+			name = debug;
+		};
+		ABFF23DB75DCB9354EA41A14 /* debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 789ULN5MZB;
+				INFOPLIST_FILE = ShareExtension/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = app.reflect.ios.share;
+				PRODUCT_NAME = ShareExtension;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = debug;
 		};
@@ -585,6 +744,15 @@
 			buildConfigurations = (
 				335E5B85056C0A6D68E52006 /* debug */,
 				E6D1AD905464771F14459628 /* release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = debug;
+		};
+		85C256481A6DA4978244EF0C /* Build configuration list for PBXNativeTarget "ShareExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ABFF23DB75DCB9354EA41A14 /* debug */,
+				045CAFDCB110568CC41B98CF /* release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = debug;

--- a/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/Info.plist
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/Info.plist
@@ -17,13 +17,13 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.4.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.4.0.13</string>
+	<string>0.4.0.17</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
 	<true/>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
 	<key>NSContactsUsageDescription</key>
 	<string>Reflect reads your contacts to suggest details for person notes. Nothing is stored or sent anywhere.</string>
 	<key>NSUbiquitousContainers</key>

--- a/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/reflect-open_iOS.entitlements
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/reflect-open_iOS.entitlements
@@ -18,5 +18,12 @@
 	<array>
 		<string>iCloud.app.reflect</string>
 	</array>
+	<!-- Shared with the ShareExtension target: the share sheet spools capture
+	     envelopes into this container's inbox/, and the app relays them into
+	     the graph's .reflect/inbox/ on launch/foreground (Plan 11). -->
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.app.reflect</string>
+	</array>
 </dict>
 </plist>

--- a/apps/desktop/src-tauri/ios.project.yml
+++ b/apps/desktop/src-tauri/ios.project.yml
@@ -99,6 +99,10 @@ targets:
         EXCLUDED_ARCHS[sdk=iphoneos*]: x86_64
       groups: [app]
     dependencies:
+      # The share-sheet capture extension (Plan 11's iOS producer): embedded
+      # into the app bundle and signed with it.
+      - target: ShareExtension
+        embed: true
       - framework: libapp.a
         embed: false
       # libgit2 (vendored into libapp.a) needs zlib and iconv at the final
@@ -122,3 +126,51 @@ targets:
         outputFiles:
           - $(SRCROOT)/Externals/x86_64/${CONFIGURATION}/libapp.a
           - $(SRCROOT)/Externals/arm64/${CONFIGURATION}/libapp.a
+  # The share-sheet capture extension: saves links/text shared from any app
+  # into the App Group inbox (`group.app.reflect`), entirely offline; the main
+  # app relays + drains on next launch/foreground (Plan 11's envelope model).
+  # Swift only — no Rust, no webview, no network.
+  ShareExtension:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: ShareExtension/ShareViewController.swift
+      - path: ShareExtension/ShareState.swift
+      - path: ShareExtension/ShareView.swift
+      - path: ShareExtension/CaptureInbox.swift
+      # The Safari preprocessor (title/URL/selection/meta description); a
+      # bundle resource the NSExtension attributes reference by base name.
+      - path: ShareExtension/ExtensionClass.js
+        buildPhase: resources
+    info:
+      path: ShareExtension/Info.plist
+      properties:
+        # The share sheet's row label (the icon comes from the host app).
+        CFBundleDisplayName: Reflect
+        CFBundleShortVersionString: {{apple.bundle-version-short}}
+        CFBundleVersion: {{apple.bundle-version}}
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.share-services
+          # Storyboard-less principal class; `@objc(ShareViewController)`
+          # pins the runtime name the plist references.
+          NSExtensionPrincipalClass: ShareViewController
+          NSExtensionAttributes:
+            # Dictionary version 2 allows subset matching — Chrome shares a
+            # URL *and* text, which version 1's exact match would refuse
+            # (V1 parity; see the porting doc).
+            NSExtensionActivationRule:
+              NSExtensionActivationDictionaryVersion: 2
+              NSExtensionActivationSupportsText: true
+              NSExtensionActivationSupportsWebPageWithMaxCount: 1
+              NSExtensionActivationSupportsWebURLWithMaxCount: 1
+            NSExtensionJavaScriptPreprocessingFile: ExtensionClass
+    entitlements:
+      path: ShareExtension/ShareExtension.entitlements
+    settings:
+      base:
+        PRODUCT_NAME: ShareExtension
+        PRODUCT_BUNDLE_IDENTIFIER: app.reflect.ios.share
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: 789ULN5MZB
+        SWIFT_VERSION: "5.0"
+        TARGETED_DEVICE_FAMILY: 1,2

--- a/apps/desktop/src-tauri/ios.project.yml
+++ b/apps/desktop/src-tauri/ios.project.yml
@@ -82,6 +82,9 @@ targets:
         # version lives in one place and never drifts. Do not hardcode a literal.
         CFBundleShortVersionString: {{apple.bundle-version-short}}
         CFBundleVersion: {{apple.bundle-version}}
+    # CAUTION: `tauri ios init` rewrites BOTH committed .entitlements files
+    # to empty dicts — after a regen, restore the iCloud + App Group entries
+    # before committing (see docs/porting/reflect-mobile/share-extension.md).
     entitlements:
       path: reflect-open_iOS/reflect-open_iOS.entitlements
     scheme:

--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -58,12 +58,16 @@ fn pointer_json(root: &Path) -> String {
 
 // Also used by `skill.rs` for the agent-skill files under `~/.agents/`.
 pub(crate) fn atomic_write_to(path: &Path, contents: &str) -> AppResult<()> {
+    atomic_write_bytes_to(path, contents.as_bytes())
+}
+
+fn atomic_write_bytes_to(path: &Path, contents: &[u8]) -> AppResult<()> {
     let dir = path
         .parent()
         .ok_or_else(|| AppError::io(format!("no parent directory for {}", path.display())))?;
     fs::create_dir_all(dir)?;
     let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
-    tmp.write_all(contents.as_bytes())?;
+    tmp.write_all(contents)?;
     tmp.flush()?;
     tmp.persist(path)
         .map_err(|err| AppError::io(err.to_string()))?;
@@ -302,6 +306,99 @@ pub fn capture_inbox_reject(
     quarantine_spool(&root_for_generation(&state, generation)?, &name)
 }
 
+// ---- iOS App Group shared inbox ---------------------------------------------
+
+/// The App Group the iOS share extension spools into. Must match the
+/// `com.apple.security.application-groups` entitlement on the app and the
+/// extension targets (`ios.project.yml`).
+#[cfg(target_os = "ios")]
+const SHARED_GROUP_ID: &str = "group.app.reflect";
+
+/// The envelope spool directory inside the App Group container. The extension
+/// creates it lazily; a missing directory relays as zero.
+const SHARED_INBOX_DIR: &str = "inbox";
+
+/// Where oversized shared spools are quarantined, beside the shared inbox —
+/// moved, never deleted, mirroring the drain's `.reflect/inbox-rejected/`.
+const SHARED_REJECTED_DIR: &str = "inbox-rejected";
+
+/// Move every spooled `.json` envelope from the shared inbox into the graph's
+/// capture inbox. Copy + atomic write + delete-source, because the App Group
+/// container and the graph root (app sandbox or iCloud container) are
+/// different volumes where a rename cannot cross. A crash between the copy
+/// and the source delete re-relays the same envelope later — the drain's
+/// deterministic identity makes that idempotent. Bytes only: unparseable
+/// envelopes still relay, and the drain quarantines them with the rest.
+fn relay_shared_spools(shared_inbox: &Path, root: &Path) -> AppResult<u32> {
+    let entries = match fs::read_dir(shared_inbox) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(err) => return Err(err.into()),
+    };
+    let mut relayed = 0;
+    for entry in entries {
+        let entry = entry?;
+        let name = entry.file_name().to_string_lossy().into_owned();
+        // Extension tmp files (`<id>.json.tmp`) and hidden files are not
+        // spool entries; only committed `.json` envelopes relay.
+        if !entry.metadata()?.is_file() || name.starts_with('.') || !name.ends_with(".json") {
+            continue;
+        }
+        let Ok(target) = inbox_file(root, &name) else {
+            continue; // not a spool filename this app would ever address
+        };
+        if entry.metadata()?.len() > INBOX_SPOOL_MAX_BYTES as u64 {
+            // Anything near the cap is not a capture. Quarantined beside the
+            // shared inbox so it can't wedge the relay forever.
+            let rejected = shared_inbox
+                .parent()
+                .ok_or_else(|| AppError::io("shared inbox has no parent directory"))?
+                .join(SHARED_REJECTED_DIR);
+            fs::create_dir_all(&rejected)?;
+            fs::rename(entry.path(), rejected.join(&name))?;
+            continue;
+        }
+        let bytes = fs::read(entry.path())?;
+        atomic_write_bytes_to(&target, &bytes)?;
+        fs::remove_file(entry.path())?;
+        relayed += 1;
+    }
+    Ok(relayed)
+}
+
+/// The shared inbox the iOS share extension writes: `<App Group>/inbox`.
+/// `None` when the container is unavailable (non-iOS platforms; a build
+/// without the App Group entitlement).
+#[cfg(target_os = "ios")]
+fn shared_inbox_dir() -> Option<PathBuf> {
+    use objc2_foundation::{NSFileManager, NSString};
+    let manager = NSFileManager::defaultManager();
+    let group = NSString::from_str(SHARED_GROUP_ID);
+    let container = manager.containerURLForSecurityApplicationGroupIdentifier(&group)?;
+    let path = container.path()?.to_string();
+    Some(PathBuf::from(path).join(SHARED_INBOX_DIR))
+}
+
+/// Only iOS has a share-extension producer; every other platform's capture
+/// producers write the graph inbox directly.
+#[cfg(not(target_os = "ios"))]
+fn shared_inbox_dir() -> Option<PathBuf> {
+    None
+}
+
+/// Relay envelopes the iOS share extension spooled into the App Group inbox
+/// into the open graph's capture inbox, where the normal drain materializes
+/// them. Returns how many envelopes moved; zero without a shared container.
+/// Called by the mobile capture controller on launch and every foreground.
+#[tauri::command]
+pub fn capture_shared_inbox_relay(generation: u64, state: State<GraphState>) -> AppResult<u32> {
+    let root = root_for_generation(&state, generation)?;
+    match shared_inbox_dir() {
+        Some(shared) => relay_shared_spools(&shared, &root),
+        None => Ok(0),
+    }
+}
+
 // ---- screenshot promote ---------------------------------------------------------
 
 /// Decode, downscale to `max_dim` on the long edge, re-encode as JPEG. Pure —
@@ -527,6 +624,84 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         fs::create_dir_all(dir.path().join(INBOX_DIR)).unwrap();
         assert!(quarantine_spool(dir.path(), "gone.json").is_ok());
+    }
+
+    #[test]
+    fn relay_moves_committed_envelopes_into_the_graph_inbox() {
+        let shared = tempfile::tempdir().unwrap();
+        let graph = tempfile::tempdir().unwrap();
+        let shared_inbox = shared.path().join(SHARED_INBOX_DIR);
+        fs::create_dir_all(&shared_inbox).unwrap();
+        fs::write(shared_inbox.join("7c9e6679.json"), r#"{"version":1}"#).unwrap();
+        fs::write(shared_inbox.join("aabbccdd.json"), r#"{"version":1}"#).unwrap();
+        // Not spool entries: a mid-write tmp file and a hidden file.
+        fs::write(shared_inbox.join("eeff0011.json.tmp"), "partial").unwrap();
+        fs::write(shared_inbox.join(".DS_Store"), "junk").unwrap();
+
+        let relayed = relay_shared_spools(&shared_inbox, graph.path()).unwrap();
+
+        assert_eq!(relayed, 2);
+        let inbox = graph.path().join(INBOX_DIR);
+        assert_eq!(
+            fs::read_to_string(inbox.join("7c9e6679.json")).unwrap(),
+            r#"{"version":1}"#
+        );
+        assert!(inbox.join("aabbccdd.json").is_file());
+        assert!(!shared_inbox.join("7c9e6679.json").exists());
+        assert!(!shared_inbox.join("aabbccdd.json").exists());
+        assert!(shared_inbox.join("eeff0011.json.tmp").exists());
+        assert!(shared_inbox.join(".DS_Store").exists());
+    }
+
+    #[test]
+    fn relay_of_a_missing_shared_inbox_is_zero() {
+        let graph = tempfile::tempdir().unwrap();
+        let relayed =
+            relay_shared_spools(Path::new("/nonexistent/shared/inbox"), graph.path()).unwrap();
+        assert_eq!(relayed, 0);
+    }
+
+    #[test]
+    fn relay_overwrites_a_crash_duplicate_instead_of_failing() {
+        let shared = tempfile::tempdir().unwrap();
+        let graph = tempfile::tempdir().unwrap();
+        let shared_inbox = shared.path().join(SHARED_INBOX_DIR);
+        fs::create_dir_all(&shared_inbox).unwrap();
+        let inbox = graph.path().join(INBOX_DIR);
+        fs::create_dir_all(&inbox).unwrap();
+        // A crash between the copy and the source delete leaves both sides.
+        fs::write(shared_inbox.join("7c9e6679.json"), r#"{"version":1}"#).unwrap();
+        fs::write(inbox.join("7c9e6679.json"), r#"{"version":1}"#).unwrap();
+
+        let relayed = relay_shared_spools(&shared_inbox, graph.path()).unwrap();
+
+        assert_eq!(relayed, 1);
+        assert!(!shared_inbox.join("7c9e6679.json").exists());
+        assert!(inbox.join("7c9e6679.json").is_file());
+    }
+
+    #[test]
+    fn relay_quarantines_oversized_spools_beside_the_shared_inbox() {
+        let shared = tempfile::tempdir().unwrap();
+        let graph = tempfile::tempdir().unwrap();
+        let shared_inbox = shared.path().join(SHARED_INBOX_DIR);
+        fs::create_dir_all(&shared_inbox).unwrap();
+        fs::write(
+            shared_inbox.join("big.json"),
+            "x".repeat(INBOX_SPOOL_MAX_BYTES + 1),
+        )
+        .unwrap();
+
+        let relayed = relay_shared_spools(&shared_inbox, graph.path()).unwrap();
+
+        assert_eq!(relayed, 0);
+        assert!(!shared_inbox.join("big.json").exists());
+        assert!(shared
+            .path()
+            .join(SHARED_REJECTED_DIR)
+            .join("big.json")
+            .is_file());
+        assert!(!graph.path().join(INBOX_DIR).join("big.json").exists());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -316,11 +316,17 @@ const SHARED_GROUP_ID: &str = "group.app.reflect";
 
 /// The envelope spool directory inside the App Group container. The extension
 /// creates it lazily; a missing directory relays as zero.
+#[cfg(any(target_os = "ios", test))]
 const SHARED_INBOX_DIR: &str = "inbox";
 
 /// Where oversized shared spools are quarantined, beside the shared inbox —
 /// moved, never deleted, mirroring the drain's `.reflect/inbox-rejected/`.
 const SHARED_REJECTED_DIR: &str = "inbox-rejected";
+
+/// A `.json.tmp` older than this is debris from an extension crash between
+/// its write and its commit rename — swept so the container can't accrete
+/// junk (the drain applies the same rule to orphan screenshots).
+const SHARED_TMP_MAX_AGE: Duration = Duration::from_secs(60 * 60);
 
 /// Move every spooled `.json` envelope from the shared inbox into the graph's
 /// capture inbox. Copy + atomic write + delete-source, because the App Group
@@ -339,15 +345,28 @@ fn relay_shared_spools(shared_inbox: &Path, root: &Path) -> AppResult<u32> {
     for entry in entries {
         let entry = entry?;
         let name = entry.file_name().to_string_lossy().into_owned();
+        let metadata = entry.metadata()?;
         // Extension tmp files (`<id>.json.tmp`) and hidden files are not
-        // spool entries; only committed `.json` envelopes relay.
-        if !entry.metadata()?.is_file() || name.starts_with('.') || !name.ends_with(".json") {
+        // spool entries; only committed `.json` envelopes relay. Old tmp
+        // files are crash debris (write happened, commit rename didn't) —
+        // swept; the age guard covers an extension writing right now.
+        if !metadata.is_file() || name.starts_with('.') || !name.ends_with(".json") {
+            if metadata.is_file()
+                && name.ends_with(".json.tmp")
+                && metadata
+                    .modified()
+                    .ok()
+                    .and_then(|at| at.elapsed().ok())
+                    .is_some_and(|age| age > SHARED_TMP_MAX_AGE)
+            {
+                fs::remove_file(entry.path())?;
+            }
             continue;
         }
         let Ok(target) = inbox_file(root, &name) else {
             continue; // not a spool filename this app would ever address
         };
-        if entry.metadata()?.len() > INBOX_SPOOL_MAX_BYTES as u64 {
+        if metadata.len() > INBOX_SPOOL_MAX_BYTES as u64 {
             // Anything near the cap is not a capture. Quarantined beside the
             // shared inbox so it can't wedge the relay forever.
             let rejected = shared_inbox
@@ -634,7 +653,7 @@ mod tests {
         fs::create_dir_all(&shared_inbox).unwrap();
         fs::write(shared_inbox.join("7c9e6679.json"), r#"{"version":1}"#).unwrap();
         fs::write(shared_inbox.join("aabbccdd.json"), r#"{"version":1}"#).unwrap();
-        // Not spool entries: a mid-write tmp file and a hidden file.
+        // Not spool entries: a fresh mid-write tmp file and a hidden file.
         fs::write(shared_inbox.join("eeff0011.json.tmp"), "partial").unwrap();
         fs::write(shared_inbox.join(".DS_Store"), "junk").unwrap();
 
@@ -651,6 +670,28 @@ mod tests {
         assert!(!shared_inbox.join("aabbccdd.json").exists());
         assert!(shared_inbox.join("eeff0011.json.tmp").exists());
         assert!(shared_inbox.join(".DS_Store").exists());
+    }
+
+    #[test]
+    fn relay_sweeps_old_tmp_debris_but_never_young_tmp_files() {
+        let shared = tempfile::tempdir().unwrap();
+        let graph = tempfile::tempdir().unwrap();
+        let shared_inbox = shared.path().join(SHARED_INBOX_DIR);
+        fs::create_dir_all(&shared_inbox).unwrap();
+        let old = shared_inbox.join("dead.json.tmp");
+        let young = shared_inbox.join("live.json.tmp");
+        fs::write(&old, "crash debris").unwrap();
+        fs::write(&young, "being written").unwrap();
+        let file = fs::File::options().write(true).open(&old).unwrap();
+        let stale = std::time::SystemTime::now() - (SHARED_TMP_MAX_AGE + Duration::from_secs(60));
+        file.set_times(fs::FileTimes::new().set_modified(stale))
+            .unwrap();
+
+        let relayed = relay_shared_spools(&shared_inbox, graph.path()).unwrap();
+
+        assert_eq!(relayed, 0);
+        assert!(!old.exists());
+        assert!(young.exists());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -236,6 +236,7 @@ pub fn run() {
             capture::capture_inbox_read,
             capture::capture_inbox_remove,
             capture::capture_inbox_reject,
+            capture::capture_shared_inbox_relay,
             capture::capture_screenshot_promote,
             capture::capture_meta_fetch,
             git::git_status,

--- a/apps/desktop/src/lib/capture-controller.test.ts
+++ b/apps/desktop/src/lib/capture-controller.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  DrainCaptureInboxInput,
+  DrainCaptureInboxOutcome,
+  FileChange,
+  ReconcileCaptureEnrichmentInput,
+  ReconcileCaptureEnrichmentOutcome,
+} from '@reflect/core'
+import { createCaptureController, type CaptureController } from './capture-controller'
+
+const drainCaptureInbox = vi.hoisted(() =>
+  vi.fn<(input: DrainCaptureInboxInput) => Promise<DrainCaptureInboxOutcome>>(),
+)
+const reconcileCaptureEnrichment = vi.hoisted(() =>
+  vi.fn<(input: ReconcileCaptureEnrichmentInput) => Promise<ReconcileCaptureEnrichmentOutcome>>(),
+)
+const subscribeFileChanges = vi.hoisted(() =>
+  vi.fn<(handler: (changes: readonly FileChange[]) => void) => Promise<() => void>>(),
+)
+const failOperation = vi.hoisted(() => vi.fn<(message: string) => void>())
+
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  drainCaptureInbox,
+  reconcileCaptureEnrichment,
+  subscribeFileChanges,
+  hasBridge: () => true,
+}))
+vi.mock('@/lib/provider-fetch', () => ({
+  providerFetch: vi.fn(),
+}))
+vi.mock('@/lib/operations', () => ({
+  startOperation: () => ({ progress: vi.fn(), done: vi.fn(), fail: failOperation }),
+}))
+
+const NO_PROVIDERS = { providers: [], defaultProviderId: null }
+
+function drained(overrides: Partial<DrainCaptureInboxOutcome> = {}): DrainCaptureInboxOutcome {
+  return { pending: 0, drained: 0, deduped: 0, invalid: 0, stopped: null, ...overrides }
+}
+
+function enriched(
+  overrides: Partial<ReconcileCaptureEnrichmentOutcome> = {},
+): ReconcileCaptureEnrichmentOutcome {
+  return { pending: 0, enriched: 0, skipped: 0, stopped: null, ...overrides }
+}
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+let controller: CaptureController | null = null
+
+function create(relaySharedInbox?: () => Promise<number>): CaptureController {
+  controller = createCaptureController({
+    generation: 3,
+    getProviders: () => NO_PROVIDERS,
+    ...(relaySharedInbox ? { relaySharedInbox } : {}),
+  })
+  return controller
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  drainCaptureInbox.mockResolvedValue(drained())
+  reconcileCaptureEnrichment.mockResolvedValue(enriched())
+  subscribeFileChanges.mockResolvedValue(vi.fn())
+})
+
+afterEach(() => {
+  controller?.dispose()
+  controller = null
+})
+
+describe('createCaptureController (shared-inbox relay)', () => {
+  it('relays the shared inbox BEFORE the drain, every pass', async () => {
+    const order: string[] = []
+    const relay = vi.fn(async () => {
+      order.push('relay')
+      return 1
+    })
+    drainCaptureInbox.mockImplementation(async () => {
+      order.push('drain')
+      return drained()
+    })
+
+    create(relay).start()
+    await flush()
+
+    expect(order).toEqual(['relay', 'drain'])
+
+    controller?.schedule()
+    await flush()
+    expect(order).toEqual(['relay', 'drain', 'relay', 'drain'])
+  })
+
+  it('still drains when the relay fails, surfacing the failure once', async () => {
+    const relay = vi.fn<() => Promise<number>>().mockRejectedValue(new Error('container gone'))
+
+    create(relay).start()
+    await flush()
+
+    expect(drainCaptureInbox).toHaveBeenCalledTimes(1)
+    expect(failOperation).toHaveBeenCalledTimes(1)
+
+    // The same failure on a retry pass must not re-toast.
+    controller?.schedule()
+    await flush()
+    expect(drainCaptureInbox).toHaveBeenCalledTimes(2)
+    expect(failOperation).toHaveBeenCalledTimes(1)
+  })
+
+  it('without a relay, passes run drain-then-enrich only', async () => {
+    create().start()
+    await flush()
+
+    expect(drainCaptureInbox).toHaveBeenCalledTimes(1)
+    expect(reconcileCaptureEnrichment).toHaveBeenCalledTimes(1)
+    expect(failOperation).not.toHaveBeenCalled()
+  })
+
+  it('schedules a pass when the app becomes visible again (mobile resume)', async () => {
+    const relay = vi.fn(async () => 0)
+    create(relay).start()
+    await flush()
+    expect(drainCaptureInbox).toHaveBeenCalledTimes(1)
+
+    document.dispatchEvent(new Event('visibilitychange'))
+    await flush()
+
+    expect(drainCaptureInbox).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not listen for visibility without a relay (desktop)', async () => {
+    create().start()
+    await flush()
+    expect(drainCaptureInbox).toHaveBeenCalledTimes(1)
+
+    document.dispatchEvent(new Event('visibilitychange'))
+    await flush()
+
+    expect(drainCaptureInbox).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops listening for visibility after dispose', async () => {
+    const relay = vi.fn(async () => 0)
+    create(relay).start()
+    await flush()
+    controller?.dispose()
+
+    document.dispatchEvent(new Event('visibilitychange'))
+    await flush()
+
+    expect(drainCaptureInbox).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/lib/capture-controller.ts
+++ b/apps/desktop/src/lib/capture-controller.ts
@@ -1,10 +1,12 @@
 import {
   drainCaptureInbox,
+  errorMessage,
   hasBridge,
   isCaptureSpoolPath,
   isSilentStop,
   reconcileCaptureEnrichment,
   subscribeFileChanges,
+  toAppError,
   type AiProvidersState,
   type ReconcileStop,
 } from '@reflect/core'
@@ -41,25 +43,37 @@ export interface CaptureControllerOptions {
    * added in Settings mid-session must be seen by the very next pass.
    */
   getProviders: () => AiProvidersState
+  /**
+   * Mobile only: move envelopes the iOS share extension spooled into the App
+   * Group inbox into the graph's capture inbox, ahead of every drain.
+   * Providing it also arms the resume trigger (`visibilitychange` → visible):
+   * the mobile shell has no file watcher, so returning to the app is the
+   * arrival signal for captures shared while it was backgrounded.
+   */
+  relaySharedInbox?: () => Promise<number>
 }
 
 /** Build the controller for one graph session. `dispose()` is terminal. */
 export function createCaptureController(options: CaptureControllerOptions): CaptureController {
-  /** Last surfaced stop message — retries must not re-toast it. */
-  let surfacedStop: string | null = null
+  /**
+   * Last surfaced stop message per phase label — retries must not re-toast
+   * it. Keyed by label so one phase succeeding (which clears its own entry)
+   * cannot make another phase's persistent failure re-toast every pass.
+   */
+  const surfacedStops = new Map<string, string>()
 
   function surfaceStop(label: string, stopped: ReconcileStop | null): void {
     if (stopped === null) {
-      surfacedStop = null
+      surfacedStops.delete(label)
       return
     }
     // Self-healing stops (network/config/stale) stay silent: offline retries on
     // the next trigger, config means no provider/key (enrichment waits; the raw
     // save is done), stale is a graph switch tearing the pass down.
-    if (isSilentStop(stopped) || surfacedStop === stopped.message) {
+    if (isSilentStop(stopped) || surfacedStops.get(label) === stopped.message) {
       return
     }
-    surfacedStop = stopped.message
+    surfacedStops.set(label, stopped.message)
     startOperation(label).fail(stopped.message)
   }
 
@@ -67,6 +81,20 @@ export function createCaptureController(options: CaptureControllerOptions): Capt
   const reconcile = async (isStale: () => boolean): Promise<void> => {
     if (!hasBridge()) {
       return // browser dev: no inbox commands to drain against
+    }
+    if (options.relaySharedInbox) {
+      let relayStop: ReconcileStop | null = null
+      try {
+        await options.relaySharedInbox()
+      } catch (cause) {
+        // Already-relayed envelopes must still drain, so a relay failure
+        // surfaces like a drain stop instead of aborting the pass.
+        relayStop = { reason: toAppError(cause).kind, message: errorMessage(cause) }
+      }
+      surfaceStop('Saving shared capture', relayStop)
+      if (isStale()) {
+        return
+      }
     }
     const drained = await drainCaptureInbox({ generation: options.generation, isStale })
     surfaceStop('Saving link capture', drained.stopped)
@@ -90,6 +118,17 @@ export function createCaptureController(options: CaptureControllerOptions): Capt
     }
     loop.schedule() // the launch pass: captures spooled while the app was closed
     loop.retryOnWake() // the network's natural retry signals (enrichment)
+    if (options.relaySharedInbox) {
+      // Mobile resume: `focus` alone is unreliable in the iOS webview (the
+      // iCloud refresh hook listens to both for the same reason).
+      const onVisible = (): void => {
+        if (document.visibilityState === 'visible') {
+          loop.schedule()
+        }
+      }
+      document.addEventListener('visibilitychange', onVisible)
+      loop.onDispose(() => document.removeEventListener('visibilitychange', onVisible))
+    }
     if (!hasBridge()) {
       return // browser dev: no watcher to follow
     }

--- a/apps/desktop/src/mobile/mobile-app.tsx
+++ b/apps/desktop/src/mobile/mobile-app.tsx
@@ -7,6 +7,7 @@ import { MobileStatusLayer } from '@/mobile/status-layer'
 import { useICloudRefresh } from '@/mobile/use-icloud-refresh'
 import { useKeyboardHeightVar } from '@/mobile/use-keyboard'
 import { useTaskCheckboxHaptics } from '@/mobile/use-task-haptics'
+import { CaptureProvider } from '@/providers/capture-provider'
 import { useGraph } from '@/providers/graph-provider'
 import { SyncProvider } from '@/providers/sync-provider'
 import { RouterProvider } from '@/routing/router'
@@ -48,8 +49,12 @@ export function MobileApp(): ReactElement {
               controller owns resume/edit/online; mobile adds only the
               plain-language status pill (step 10). */}
           <SyncProvider graph={graph}>
-            <MobileShell />
-            <MobileStatusLayer />
+            {/* Link capture (Plan 11, iOS share extension): relay the App
+                Group inbox + drain on launch and on every resume. */}
+            <CaptureProvider graph={graph}>
+              <MobileShell />
+              <MobileStatusLayer />
+            </CaptureProvider>
           </SyncProvider>
         </RouterProvider>
       </MobileErrorBoundary>

--- a/apps/desktop/src/providers/capture-provider.test.tsx
+++ b/apps/desktop/src/providers/capture-provider.test.tsx
@@ -8,12 +8,17 @@ const controller = vi.hoisted(() => ({
   schedule: vi.fn(),
   dispose: vi.fn(),
 }))
-const createCaptureController = vi.hoisted(() => vi.fn(() => controller))
+const createCaptureController = vi.hoisted(() =>
+  vi.fn((_options: { relaySharedInbox?: () => Promise<number> }) => controller),
+)
 const captureHostRegister = vi.hoisted(() => vi.fn<() => Promise<void>>())
+const captureSharedInboxRelay = vi.hoisted(() => vi.fn<() => Promise<number>>())
 const hasBridge = vi.hoisted(() => vi.fn(() => true))
+const isMobileSurface = vi.hoisted(() => vi.fn(() => false))
 
 vi.mock('@/lib/capture-controller', () => ({ createCaptureController }))
-vi.mock('@reflect/core', () => ({ captureHostRegister, hasBridge }))
+vi.mock('@reflect/core', () => ({ captureHostRegister, captureSharedInboxRelay, hasBridge }))
+vi.mock('@/lib/platform-surface', () => ({ isMobileSurface }))
 vi.mock('@/providers/settings-provider', () => ({
   useSettings: () => ({
     settings: { aiProviders: [], defaultAiProviderId: null },
@@ -31,7 +36,9 @@ function mount(children: ReactNode = null) {
 beforeEach(() => {
   vi.clearAllMocks()
   hasBridge.mockReturnValue(true)
+  isMobileSurface.mockReturnValue(false)
   captureHostRegister.mockResolvedValue(undefined)
+  captureSharedInboxRelay.mockResolvedValue(0)
 })
 
 afterEach(cleanup)
@@ -81,5 +88,24 @@ describe('CaptureProvider', () => {
     await waitFor(() => expect(controller.start).toHaveBeenCalled())
     view.unmount()
     expect(controller.dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('on mobile, skips host registration and wires the shared-inbox relay', async () => {
+    isMobileSurface.mockReturnValue(true)
+
+    mount()
+
+    await waitFor(() => expect(controller.start).toHaveBeenCalledTimes(1))
+    expect(captureHostRegister).not.toHaveBeenCalled()
+    const options = createCaptureController.mock.calls[0]?.[0]
+    expect(options?.relaySharedInbox).toBeDefined()
+    await options?.relaySharedInbox?.()
+    expect(captureSharedInboxRelay).toHaveBeenCalledWith(GRAPH.generation)
+  })
+
+  it('on desktop, passes no shared-inbox relay', async () => {
+    mount()
+    await waitFor(() => expect(controller.start).toHaveBeenCalledTimes(1))
+    expect(createCaptureController.mock.calls[0]?.[0]?.relaySharedInbox).toBeUndefined()
   })
 })

--- a/apps/desktop/src/providers/capture-provider.tsx
+++ b/apps/desktop/src/providers/capture-provider.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useRef, type ReactElement, type ReactNode } from 'react'
-import { captureHostRegister, hasBridge, type AiProvidersState, type GraphInfo } from '@reflect/core'
+import {
+  captureHostRegister,
+  captureSharedInboxRelay,
+  hasBridge,
+  type AiProvidersState,
+  type GraphInfo,
+} from '@reflect/core'
 import { createCaptureController } from '@/lib/capture-controller'
+import { isMobileSurface } from '@/lib/platform-surface'
 import { useSettings } from '@/providers/settings-provider'
 
 /**
@@ -8,8 +15,12 @@ import { useSettings } from '@/providers/settings-provider'
  * the native-messaging host (pointer file + browser manifests, rewritten on
  * every graph open so app moves self-heal) and runs the
  * {@link createCaptureController} drain/enrich loop. No UI — capture has no
- * in-app surface; the Chrome extension is the front end and the daily note
- * is the output.
+ * in-app surface; the capture front end is the Chrome extension on desktop
+ * and the share extension on iOS, and the daily note is the output.
+ *
+ * On the mobile surface there is no native-messaging host to register;
+ * instead every pass first relays the App Group inbox the iOS share
+ * extension spools into, and the controller re-runs on app resume.
  */
 
 interface CaptureProviderProps {
@@ -34,9 +45,13 @@ export function CaptureProvider({ graph, children }: CaptureProviderProps): Reac
   })
 
   useEffect(() => {
+    const mobile = isMobileSurface()
     const controller = createCaptureController({
       generation: graph.generation,
       getProviders: () => providersRef.current,
+      ...(mobile
+        ? { relaySharedInbox: () => captureSharedInboxRelay(graph.generation) }
+        : {}),
     })
     // Registration (the pointer-file rewrite) completes BEFORE the first
     // drain: on a graph switch this repoints the host at the new graph as
@@ -46,8 +61,9 @@ export function CaptureProvider({ graph, children }: CaptureProviderProps): Reac
     // previous graph's inbox — it drains when that graph next opens.)
     // Best-effort: a failed registration must not block the drain — captures
     // already spooled must land regardless, and the extension surfaces
-    // "host not found" with install guidance on its side.
-    const registered = hasBridge()
+    // "host not found" with install guidance on its side. Mobile has no host
+    // process at all: the share extension finds the App Group inbox itself.
+    const registered = hasBridge() && !mobile
       ? captureHostRegister().catch((cause: unknown) => {
           console.error('capture host registration failed:', cause)
         })

--- a/apps/native-host/src/envelope.rs
+++ b/apps/native-host/src/envelope.rs
@@ -22,6 +22,10 @@ pub struct Envelope {
     pub selection: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content_text: Option<String>,
+    /// In-page meta description; only the iOS share extension sets it, so a
+    /// Chrome wire message carrying one passes through untouched.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub meta_description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/docs/plans/11-link-capture.md
+++ b/docs/plans/11-link-capture.md
@@ -1,5 +1,11 @@
 # Plan 11 — Link Capture
 
+> **Update (2026-07-05):** the deferred iOS share half has landed — a
+> `ShareExtension` target spools the same envelopes (plus non-URL text as
+> `kind: append` captures) into the App Group inbox, and the mobile app
+> relays + drains them on launch/foreground. See
+> [the porting doc](../porting/reflect-mobile/share-extension.md).
+>
 > **Status (2026-06-14): Implemented.** The pipeline below is built end-to-end:
 > `apps/extension` (WXT MV3, popup + queue + ⌘⇧K), `apps/native-host`
 > (`reflect-capture-host`, bundled as a second sidecar), the capture inbox +

--- a/docs/porting/reflect-mobile/README.md
+++ b/docs/porting/reflect-mobile/README.md
@@ -59,7 +59,7 @@ never lost. That behavior is what these docs pin down.
 | [Tasks](./tasks.md)                                                   | Task groups, drag-and-drop, quick edit     | **Shipped** — desktop Plan 18 data + touch surface |
 | [Note actions, sharing, export](./note-actions-sharing-and-export.md) | Pin/share/publish/trash, JSON export       | **v1** pin/share/trash; publish deferred          |
 | [Audio memos](./audio-memos.md)                                       | Native recording + server transcription    | Later wave — raw-first + BYOK transcription       |
-| [Share extension](./share-extension.md)                               | Share-sheet link capture via API           | Later wave — App Group capture inbox              |
+| [Share extension](./share-extension.md)                               | Share-sheet link capture via API           | **Done** — App Group inbox → relay → shared drain |
 | [Native entry points](./native-entry-points.md)                       | Widgets, Siri, quick actions, deep links   | Later waves / partially dropped                   |
 | [Sync, offline, and data](./sync-offline-and-data.md)                 | Firestore↔SQLite sync, Yjs, job queue      | Replaced — behavior ports, architecture doesn't   |
 | [Assets and images](./assets-and-images.md)                           | Encrypted asset cache + custom scheme      | Replaced — assets are plain files                 |

--- a/docs/porting/reflect-mobile/share-extension.md
+++ b/docs/porting/reflect-mobile/share-extension.md
@@ -1,10 +1,21 @@
 # Porting the share extension
 
-**v2 status: later wave.** Deferred until the mobile share target can
-reuse the Plan 11 capture envelope/inbox model (desktop Chrome capture has
-shipped; the App Group ingestion half is the open work). V1's extension is
-the behavioral spec: save a link from any app in two taps, working even
-when the main app isn't running.
+**v2 status: implemented.** The `ShareExtension` target
+(`gen/apple/ShareExtension/`, declared in `ios.project.yml`) accepts URLs,
+web pages, and text from the share sheet and spools Plan 11 capture
+envelopes into the App Group inbox (`group.app.reflect/inbox/`) — entirely
+offline, no network, no graph access. The main app relays them into
+`.reflect/inbox/` (`capture_shared_inbox_relay`, `src-tauri/src/capture.rs`)
+and the shared drain/enrich pipeline materializes them; the mobile tree
+mounts `CaptureProvider`, which relays + drains on graph open and on every
+foreground (`visibilitychange`). Safari captures carry title, selection,
+and the meta description in-page (`ExtensionClass.js` →
+`metaDescription`), so an offline save still reads complete; enrichment
+replaces the description later when online. Non-URL text saves as a
+daily-note bullet (`kind: append`, `source: ios-share`). Remaining
+release-gate work: a device pass, and confirming automatic signing
+provisions the new `app.reflect.ios.share` App ID + App Group for
+TestFlight.
 
 ## What V1 mobile does
 
@@ -69,11 +80,21 @@ There is no API to POST to — the design inverts from *send to server* to
 | Errors queued in App Group defaults           | Same pattern: queue in the container, surface in-app            |
 | Daily-note `[[Links]]` entry (applied later)  | Same product shape, written locally at ingest                   |
 
-## Open questions
+## Resolved decisions
 
-- Envelope schema versioning shared between the desktop capture path and
-  the iOS extension (one format, two producers).
-- When to provision the extension target + App Group in
-  `ios.project.yml` (with the audio wave, most likely — same container).
-- Whether ingest should run on a background refresh or strictly on
-  foreground (v1 posture: foreground-only, like sync).
+- **One envelope schema, two producers**: the extension mirrors
+  `capture-envelope.ts` (`LinkCaptureEnvelope`/`TextCaptureEnvelope` in
+  `CaptureInbox.swift`); provenance is the widened `source: 'ios-share'`
+  member, never a new envelope variant. Safari's in-page description rides
+  the new optional `metaDescription` field, which the drain writes into the
+  raw save and enrichment replaces in place.
+- **App Group provisioned with this wave**: `group.app.reflect` on both
+  targets; the extension writes `<uuid>.json` atomically (tmp + same-volume
+  rename), the app-side Rust relay moves committed `.json` files into the
+  graph inbox (copy + atomic write + delete — the containers are different
+  volumes), quarantining oversized files beside the shared inbox.
+- **Ingest is foreground-only** (v1 posture, like sync): graph open, window
+  focus/online, and `visibilitychange` → visible all schedule the
+  relay+drain pass; no background refresh task.
+- **Regen caution**: `tauri ios init` rewrites both `.entitlements` files to
+  empty dicts — restore the iCloud + App Group entries before committing.

--- a/packages/core/src/actions/capture-envelope.test.ts
+++ b/packages/core/src/actions/capture-envelope.test.ts
@@ -33,6 +33,15 @@ describe('captureEnvelopeSchema', () => {
     expect(captureEnvelopeSchema.parse(full)).toEqual(full)
   })
 
+  it('accepts an iOS share capture with its in-page meta description', () => {
+    const shared = {
+      ...VALID,
+      source: 'ios-share',
+      metaDescription: 'A page about examples.',
+    }
+    expect(captureEnvelopeSchema.parse(shared)).toEqual(shared)
+  })
+
   it('accepts an offset timestamp', () => {
     const parsed = captureEnvelopeSchema.safeParse({
       ...VALID,
@@ -103,6 +112,12 @@ describe('textCaptureEnvelopeSchema', () => {
     expect(textCaptureEnvelopeSchema.parse(VALID_TEXT)).toEqual(VALID_TEXT)
     expect(
       textCaptureEnvelopeSchema.safeParse({ ...VALID_TEXT, kind: 'task' }).success,
+    ).toBe(true)
+  })
+
+  it('accepts the iOS share sheet as a text producer', () => {
+    expect(
+      textCaptureEnvelopeSchema.safeParse({ ...VALID_TEXT, source: 'ios-share' }).success,
     ).toBe(true)
   })
 

--- a/packages/core/src/actions/capture-envelope.test.ts
+++ b/packages/core/src/actions/capture-envelope.test.ts
@@ -143,4 +143,26 @@ describe('inboxEnvelopeSchema', () => {
   it('rejects a hybrid that satisfies neither shape fully', () => {
     expect(inboxEnvelopeSchema.safeParse({ ...VALID_TEXT, kind: undefined }).success).toBe(false)
   })
+
+  // Literal producer output from the iOS share extension's Swift structs
+  // (`gen/apple/ShareExtension/CaptureInbox.swift` — JSONEncoder, lowercased
+  // UUID, ISO-8601 with fractional seconds). The Swift side has no test
+  // harness, so this is what pins the third producer to the zod contract;
+  // update BOTH sides together.
+  it('accepts the Swift producer shapes verbatim', () => {
+    const swiftLink = JSON.parse(
+      '{"capturedAt":"2026-07-05T07:12:30.123Z","id":"7c9e6679-7425-40de-944b-e07fc1f90ae7",' +
+        '"metaDescription":"A page about examples.","selection":"quoted text",' +
+        '"source":"ios-share","title":"An article","url":"https://example.com/article","version":1}',
+    ) as unknown
+    const swiftText = JSON.parse(
+      '{"capturedAt":"2026-07-05T07:12:30.123Z","id":"7c9e6679-7425-40de-944b-e07fc1f90ae7",' +
+        '"kind":"append","source":"ios-share","text":"call the bank","version":1}',
+    ) as unknown
+
+    const link = inboxEnvelopeSchema.parse(swiftLink)
+    expect('kind' in link).toBe(false)
+    const text = inboxEnvelopeSchema.parse(swiftText)
+    expect('kind' in text && text.kind).toBe('append')
+  })
 })

--- a/packages/core/src/actions/capture-envelope.ts
+++ b/packages/core/src/actions/capture-envelope.ts
@@ -2,11 +2,11 @@ import { z } from 'zod'
 
 /**
  * The platform-agnostic capture envelope (Plan 11): the contract between
- * every capture producer and the desktop drain. The Chrome extension's
+ * every capture producer and the app's drain. The Chrome extension's
  * native-messaging host writes one `<id>.json` envelope (plus an optional
- * sibling screenshot) into the graph's capture inbox today; the future iOS
- * share extension and Android intent handler write the same shape into their
- * own inboxes. This module is deliberately browser-safe — it imports nothing
+ * sibling screenshot) into the graph's capture inbox; the iOS share
+ * extension writes the same shape into the App Group inbox the main app
+ * relays on foreground. This module is deliberately browser-safe — it imports nothing
  * but zod, and the extension consumes it through the package's
  * `./capture-envelope` subpath without pulling the rest of core.
  *
@@ -14,8 +14,13 @@ import { z } from 'zod'
  * (`apps/native-host`) mirror it and must be kept in sync.
  */
 
-/** Where a capture originated. Widens when mobile capture lands. */
-export const captureSourceSchema = z.literal('extension')
+/**
+ * Where a link capture originated: the Chrome extension (through the
+ * native-messaging host) or the iOS share extension (through the App Group
+ * inbox the main app relays on foreground). Provenance only — every source
+ * produces the same envelope shape.
+ */
+export const captureSourceSchema = z.enum(['extension', 'ios-share'])
 
 /** Only web pages are capturable — `chrome://`, `file://` etc. never spool. */
 function isHttpUrl(value: string): boolean {
@@ -44,6 +49,13 @@ export const captureEnvelopeSchema = z.object({
   selection: z.string().optional(),
   /** Plain text paragraphs extracted from the captured page. */
   contentText: z.string().optional(),
+  /**
+   * The page's own meta/OpenGraph description, extracted in-page at capture
+   * time (the iOS share extension's Safari preprocessor). The drain writes it
+   * into the raw save so an offline capture still lands with a description;
+   * enrichment later replaces it in place with the scraped/AI one.
+   */
+  metaDescription: z.string().optional(),
   /** A comment the user typed into the capture UI. */
   note: z.string().optional(),
   /**
@@ -91,11 +103,11 @@ export const textCaptureKindSchema = z.enum(['append', 'task'])
 /**
  * Where a text capture originated. Deliberately separate from
  * {@link captureSourceSchema} and from the envelope *shape*: provenance and
- * shape are different axes, so a future producer (an iOS share sheet, a
- * widget) joins by adding a member here — never by growing a new envelope
- * variant.
+ * shape are different axes, so a future producer (a widget, an Android
+ * intent) joins by adding a member here — never by growing a new envelope
+ * variant. `ios-share` is non-URL text shared through the iOS share sheet.
  */
-export const textCaptureSourceSchema = z.enum(['deep-link'])
+export const textCaptureSourceSchema = z.enum(['deep-link', 'ios-share'])
 
 /**
  * A text write (`reflect://append?text=…` / `reflect://task?text=…`),

--- a/packages/core/src/actions/capture.test.ts
+++ b/packages/core/src/actions/capture.test.ts
@@ -255,6 +255,23 @@ describe('drainCaptureInbox', () => {
     )
   })
 
+  it('writes an iOS share capture with its in-page description into the raw save', async () => {
+    addSpool(
+      envelope({ source: 'ios-share', metaDescription: '  A page\nabout examples.  ' }),
+      { screenshot: false },
+    )
+
+    const outcome = await drain()
+
+    expect(outcome).toEqual({ pending: 1, drained: 1, deduped: 0, invalid: 0, stopped: null })
+    const note = files.get(IDENTITY.notePath)
+    expect(note).toContain('captureSource: ios-share')
+    // Whitespace-folded onto the one metadata line, right where enrichment
+    // will replace it in place.
+    expect(note).toContain('- Type: #link\n- Description: A page about examples.')
+    expect(note).toContain('captureStatus: pending')
+  })
+
   it('removes the spool only after the note and daily entry are written', async () => {
     addSpool(envelope())
     await drain()
@@ -618,6 +635,17 @@ describe('reconcileCaptureEnrichment', () => {
     )
     // Enriched means no longer pending: a second pass finds nothing.
     expect((await reconcile()).pending).toBe(0)
+  })
+
+  it('replaces the drain-written in-page description in place, never duplicating it', async () => {
+    await drainOne({ source: 'ios-share', metaDescription: 'The in-page description.' })
+
+    const outcome = await reconcile()
+
+    expect(outcome.enriched).toBe(1)
+    const note = files.get(IDENTITY.notePath) ?? ''
+    expect(note).toContain('- Description: An AI description of the page.')
+    expect(note).not.toContain('The in-page description.')
   })
 
   it('enriches with the scraped description alone when no provider is configured', async () => {

--- a/packages/core/src/actions/capture.test.ts
+++ b/packages/core/src/actions/capture.test.ts
@@ -648,6 +648,23 @@ describe('reconcileCaptureEnrichment', () => {
     expect(note).not.toContain('The in-page description.')
   })
 
+  it('meta-only enrichment keeps a drain-written in-page description (never truncates)', async () => {
+    await drainOne({ source: 'ios-share', metaDescription: 'The full in-page description.' })
+    scrapeMock.mockResolvedValue({
+      title: 'An article',
+      description: 'A shorter scraped description.',
+      siteName: null,
+    })
+
+    const outcome = await reconcile({ providers: NO_PROVIDERS })
+
+    expect(outcome.enriched).toBe(1)
+    const note = files.get(IDENTITY.notePath) ?? ''
+    expect(note).toContain('- Description: The full in-page description.')
+    expect(note).not.toContain('A shorter scraped description.')
+    expect(note).toContain('captureStatus: done')
+  })
+
   it('enriches with the scraped description alone when no provider is configured', async () => {
     await drainOne()
     scrapeMock.mockResolvedValue({

--- a/packages/core/src/actions/capture.ts
+++ b/packages/core/src/actions/capture.ts
@@ -216,10 +216,15 @@ function captureNoteBody(
   hasScreenshot: boolean,
 ): string {
   const title = displayTitle(envelope)
-  const parts = [
-    `# ${title}`,
-    [`- URL: ${envelope.url}`, '- Type: #link'].join('\n'),
-  ]
+  const metadata = [`- URL: ${envelope.url}`, '- Type: #link']
+  // The in-page meta description (iOS share captures) lands in the raw save,
+  // so an offline capture still reads complete; enrichment later replaces
+  // this exact line in place (`withDescription`) with the scraped/AI one.
+  const metaDescription = envelope.metaDescription?.trim()
+  if (metaDescription) {
+    metadata.push(`- Description: ${metadataValue(metaDescription)}`)
+  }
+  const parts = [`# ${title}`, metadata.join('\n')]
   const note = envelope.note?.trim()
   if (note) {
     parts.push(`## Note\n\n${note}`)

--- a/packages/core/src/actions/capture.ts
+++ b/packages/core/src/actions/capture.ts
@@ -654,6 +654,15 @@ function metadataValue(text: string): string {
   return text.replace(/\s+/g, ' ').trim()
 }
 
+function descriptionLineIndex(metadataLines: readonly string[]): number {
+  return metadataLines.findIndex((candidate) => candidate.startsWith('- Description: '))
+}
+
+/** Does the raw body already carry a description metadata bullet? */
+function hasDescription(body: string): boolean {
+  return descriptionLineIndex(body.slice(0, firstSectionStart(body)).split('\n')) !== -1
+}
+
 /**
  * Insert or replace the single visible generated-text surface for link
  * captures. The raw body has a `- Type: #link` anchor.
@@ -662,9 +671,7 @@ function withDescription(body: string, description: string): string {
   const line = `- Description: ${metadataValue(description)}`
   const metadataEnd = firstSectionStart(body)
   const metadataLines = body.slice(0, metadataEnd).split('\n')
-  const descriptionLine = metadataLines.findIndex((candidate) =>
-    candidate.startsWith('- Description: '),
-  )
+  const descriptionLine = descriptionLineIndex(metadataLines)
   if (descriptionLine !== -1) {
     metadataLines[descriptionLine] = line
     return `${metadataLines.join('\n')}${body.slice(metadataEnd)}`
@@ -832,7 +839,14 @@ export async function reconcileCaptureEnrichment(
 
       const usedAi =
         description !== null && metadataValue(description) !== '' && config !== null
-      const text = usedAi ? description : pageMeta?.description ?? null
+      // An AI description always replaces the drain-written in-page one, but
+      // the scraped fallback never does: it is the same page's meta text,
+      // hard-capped by the scraper — replacing could only ever lose content.
+      const text = usedAi
+        ? description
+        : hasDescription(split.body)
+          ? null
+          : pageMeta?.description ?? null
       const newBody = text !== null ? withDescription(split.body, text) : split.body
       const reassembled = source.slice(0, split.bodyOffset) + newBody
       await writeNote(

--- a/packages/core/src/graph/commands.ts
+++ b/packages/core/src/graph/commands.ts
@@ -176,6 +176,16 @@ export async function captureInboxRemove(name: string, generation: number): Prom
 }
 
 /**
+ * Relay envelopes the iOS share extension spooled into the App Group inbox
+ * into the graph's capture inbox, returning how many moved. iOS-only in
+ * effect (elsewhere there is no shared container and the relay is zero);
+ * called by the mobile capture controller before every drain pass.
+ */
+export async function captureSharedInboxRelay(generation: number): Promise<number> {
+  return call('capture_shared_inbox_relay', { generation }, z.number())
+}
+
+/**
  * Quarantine an unparseable spool file into `.reflect/inbox-rejected/` —
  * moved, never deleted: "the raw link is never lost" holds even for an
  * envelope a newer extension wrote that this app version can't read yet.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -125,6 +125,7 @@ export {
   captureInboxReject,
   captureInboxRemove,
   captureMetaFetch,
+  captureSharedInboxRelay,
   promoteCaptureScreenshot,
 } from './graph/commands'
 export { createAsset, importAsset } from './graph/assets'


### PR DESCRIPTION
## Problem

V1's headline mobile capture flow — save a link from any app in two taps, even with no connection — had no V2 equivalent. Desktop Chrome capture shipped in Plan 11 with a deliberately platform-agnostic envelope/inbox design; the iOS half (App Group ingestion) was the deferred open work tracked in `docs/porting/reflect-mobile/share-extension.md`.

## What this does

Adds a `ShareExtension` target to the iOS app. Sharing a page from Safari (or a URL/text from any app) spools a Plan 11 capture envelope into the App Group inbox (`group.app.reflect/inbox/`) — entirely offline, no keys, no network, no graph access. The main app relays those envelopes into the graph's `.reflect/inbox/` and the **existing** drain/enrich pipeline does the rest: a capture note + `## Links` bullet on the capture-day daily note immediately, BYOK enrichment later when online.

Inverted from V1 (which POSTed to a Reflect API with OAuth tokens): there is no auth, no signed-out state, and captures spooled before the app ever opens a graph simply land on first open.

### The pieces

- **Envelope contract** (`packages/core/src/actions/capture-envelope.ts`): `captureSourceSchema` widens to `['extension', 'ios-share']`; new optional `metaDescription` field carries Safari's in-page og:description so an offline capture still saves with a description — the drain writes it as the `- Description:` metadata bullet and enrichment replaces that exact line in place. Non-URL text becomes a text capture (`kind: append`, source `ios-share`) → a bullet on today's daily note. The native-host serde mirror gains the matching optional field; the host still only accepts `source: extension`, so the shared parity fixtures are unchanged.
- **Rust relay** (`src-tauri/src/capture.rs`): `capture_shared_inbox_relay` resolves the App Group container (objc2 `NSFileManager`) and moves committed `.json` spools into the graph inbox — copy + atomic write + delete-source because the containers are different volumes; oversized files quarantine beside the shared inbox; crash-duplicate relays are idempotent (the drain's deterministic identity). No-op stand-in off iOS, so the command surface stays platform-uniform.
- **Mobile wiring**: `CaptureProvider` now mounts in the mobile tree. On the mobile surface it skips native-messaging host registration, relays the shared inbox ahead of every drain, and schedules a pass on `visibilitychange → visible` (mobile has no file watcher — foreground *is* the arrival signal), on top of the existing launch/focus/online triggers. Fixed a latent surfaced-stop bug while here: dedup is now per-phase-label, so one phase succeeding can't make another phase's persistent failure re-toast every pass.
- **Extension** (`gen/apple/ShareExtension/`, declared in `ios.project.yml`): SwiftUI two-tap UI (auto-saves on appear → "Saved to Reflect" → auto-dismiss; failure state with Dismiss), V1's activation rules (dictionary version 2 for Chrome's URL+text shares), `ExtensionClass.js` preprocessor (title/URL/selection/description), atomic tmp+rename spooling, producer-side field caps under the 64 KiB spool cap. App Group entitlements on both targets.

## Verification

- `pnpm check` clean; `cargo test -p reflect-open` (220) and `-p reflect-capture-host` (22) pass, including 4 new relay tests.
- New/extended vitest suites pass: envelope widening + drain description bullet + enrichment replace-in-place (`capture.test.ts`, `capture-envelope.test.ts`), relay-first pass ordering / relay-failure-still-drains / visibility trigger + dispose (`capture-controller.test.ts`, new), mobile vs desktop provider wiring (`capture-provider.test.tsx`).
- `pnpm tauri ios build --debug --target aarch64-sim --ci` succeeds end-to-end; the built `Reflect.app` embeds `PlugIns/ShareExtension.appex` with the JS resource, correct activation rules, and the principal class symbol present (`nm`).
- One pre-existing core test (`language-model.test.ts`) fails only under Claude Code's exported `ANTHROPIC_BASE_URL`; passes with the var unset — unrelated to this change.

## Risks / rollout

- **Provisioning (release gate)**: the new `app.reflect.ios.share` App ID and the `group.app.reflect` App Group must be provisioned for device/TestFlight builds. Signing is `Automatic` with the same team, so Xcode/`-allowProvisioningUpdates` should create both on the first entitled build — needs confirming on the next TestFlight run. A manual device pass (share from Safari on iPhone) is still owed.
- **Regen gotcha (documented in the porting doc)**: `tauri ios init` rewrites both `.entitlements` files to empty dicts and drops the merged usage descriptions from the generated Info.plist; this PR restores them and records the procedure.
- Desktop behavior is unchanged: no relay is passed, host registration and watcher triggers are exactly as before.

## Post-review hardening (second commit)

Reflection pass + both Bugbot findings, all verified locally (fmt/clippy/tests, extension rebuild):

- **Bugbot:** null `window.getSelection()` guard in the Safari preprocessor; malformed preprocessing results now fall back to the plain URL/text attachments instead of failing the share.
- Extension field caps now count UTF-16 code units (what zod's `.max()` counts) so an emoji-heavy share can't be quarantined after the UI said "Saved".
- The relay sweeps hour-old `.json.tmp` crash debris (mirrors the drain's orphan-screenshot sweep).
- A literal TS fixture test pins the Swift producer's envelope shapes (the third copy of the contract has no test harness of its own).
- cfg-gated `SHARED_INBOX_DIR` (CI clippy dead-code on non-iOS builds) and a regen warning comment in `ios.project.yml`.

## Bugbot round 2 (third commit)

Two of Bugbot's four comments were stale re-anchors of the pre-rebase commit (already fixed); the two real ones are addressed:

- `spoolLink` now bounds the encoded envelope against the relay's 64 KiB cap — a pathological URL sheds the selection first, then fails the share visibly instead of claiming "Saved" for a file the relay could only quarantine unread.
- Meta-only enrichment keeps a drain-written in-page description instead of replacing it with the scraper's 500-char-capped one (same source text, only ever shorter). AI descriptions still replace in place. Test-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New App Group + extension provisioning and cross-volume relay logic must stay aligned with envelope schema; desktop capture path is unchanged but mobile ingest depends on entitlements and foreground relay.
> 
> **Overview**
> Adds an iOS **ShareExtension** that spools Plan 11 capture envelopes offline into `group.app.reflect/inbox/` (links with Safari JS metadata, plain text as `append` bullets). The main app **relays** those `.json` files into the graph inbox via new Rust command `capture_shared_inbox_relay`, then the existing drain/enrich path runs unchanged.
> 
> **Contract:** `capture-envelope.ts` widens sources to `ios-share`, adds optional `metaDescription` (drain writes `- Description:`; enrichment replaces in place; scraped meta no longer overwrites an in-page description). Swift producer shapes are test-pinned against zod.
> 
> **Mobile wiring:** `CaptureProvider` mounts on mobile, skips Chrome host registration, relays before every drain, and re-schedules on `visibilitychange` when visible. Per-phase stop toasts fix duplicate failure noise.
> 
> **Xcode:** `ShareExtension` target embedded in `ios.project.yml` / `project.pbxproj`; App Group on both app and extension entitlements; bundle bump to `0.4.0.17`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09b9310140ebb08ecb0945f367e059e63361db53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



