### PR TITLE
Sort incoming backlinks newest first

### DIFF
--- a/apps/desktop/src/hooks/use-backlink-sources.ts
+++ b/apps/desktop/src/hooks/use-backlink-sources.ts
@@ -7,7 +7,7 @@ import { useGraph } from '@/providers/graph-provider'
 
 /** What a backlinks surface needs to render: grouped rows plus the states. */
 export interface BacklinkSources {
-  /** Inbound references grouped by source note, in the query's title order. */
+  /** Inbound references grouped by source note, newest edited source first. */
   groups: BacklinkSource[]
   /** Total inbound references (the "(N)" in the section header). */
   count: number

--- a/apps/desktop/src/lib/group-backlinks.ts
+++ b/apps/desktop/src/lib/group-backlinks.ts
@@ -12,7 +12,7 @@ export interface BacklinkSource {
 
 /**
  * Group flat backlink rows by their source note, preserving the query's
- * source-title order. Empty snippets (a source that vanished between the
+ * source order. Empty snippets (a source that vanished between the
  * index query and the file read) are dropped, but the source group itself
  * still renders so the reference stays discoverable.
  */

--- a/packages/core/src/indexing/queries.test.ts
+++ b/packages/core/src/indexing/queries.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setBridge } from '../ipc/bridge'
 import {
   dailyDatesInRange,
+  getBacklinksWithContext,
   getDuplicateNoteIds,
   getNoteIdsByPath,
   getOpenTasks,
@@ -245,5 +246,24 @@ describe('getOpenTasks', () => {
     const [, args] = mockInvoke.mock.calls[0]!
     expect(String(args['sql'])).toContain('"notes"."kind" != ?')
     expect(args['params']).toContain('template')
+  })
+})
+
+describe('getBacklinksWithContext', () => {
+  it('queries incoming backlinks newest source first, then document order', async () => {
+    mockInvoke.mockResolvedValue([])
+
+    await getBacklinksWithContext('notes/target.md')
+
+    const [, args] = mockInvoke.mock.calls[0]!
+    const sql = String(args['sql']).toLowerCase()
+    const orderBy = sql.slice(sql.indexOf('order by'))
+    const mtimeOrder = orderBy.indexOf('"notes"."mtime" desc')
+    const sourcePathOrder = orderBy.indexOf('"backlinks"."source_path"')
+    const posOrder = orderBy.indexOf('"backlinks"."pos_from"')
+
+    expect(mtimeOrder).toBeGreaterThanOrEqual(0)
+    expect(sourcePathOrder).toBeGreaterThan(mtimeOrder)
+    expect(posOrder).toBeGreaterThan(sourcePathOrder)
   })
 })

--- a/packages/core/src/indexing/queries.ts
+++ b/packages/core/src/indexing/queries.ts
@@ -36,9 +36,12 @@ export type Backlink = Pick<
 export function getBacklinks(path: string): Promise<Backlink[]> {
   return db
     .selectFrom('backlinks')
+    .innerJoin('notes', 'notes.path', 'backlinks.sourcePath')
     .where('targetPath', '=', path)
     .select(['sourcePath', 'targetRaw', 'alias', 'posFrom', 'posTo'])
+    .orderBy('notes.mtime', 'desc')
     .orderBy('sourcePath')
+    .orderBy('posFrom')
     .execute()
 }
 
@@ -69,7 +72,7 @@ export async function getBacklinksWithContext(path: string): Promise<BacklinkCon
     // The view's generated types are nullable (SQLite views lose NOT NULL),
     // but these columns come from NOT NULL `links` columns via an inner join.
     .$narrowType<{ sourcePath: string; posFrom: number }>()
-    .orderBy('notes.title')
+    .orderBy('notes.mtime', 'desc')
     .orderBy('backlinks.sourcePath')
     .orderBy('backlinks.posFrom')
     .execute()


### PR DESCRIPTION
## Problem

Incoming backlinks were ordered by source title/path before snippet position. For daily-note sources this made older references appear first, so opening a note surfaced stale context above newer work.

## Before -> After

| Before | After |
| --- | --- |
| Incoming backlink source groups followed title/path order. | Incoming backlink source groups show the most recently edited source notes first. |
| Multiple links from the same source still followed document position. | Multiple links from the same source still follow document position. |

## Changes

1. Orders both `getBacklinks()` and `getBacklinksWithContext()` by source `notes.mtime DESC`, with source path and link position as stable tie-breakers.
2. Keeps the desktop/mobile grouping helpers order-preserving, but updates their comments to describe the new source order.
3. Adds a core query test that pins the incoming-backlinks SQL order.

## Verification

- `pnpm --filter @reflect/core test -- src/indexing/queries.test.ts src/indexing/pipeline.test.ts` passed.
- `pnpm --filter @reflect/desktop test -- src/components/backlinks-panel.test.tsx src/mobile/incoming-backlinks.test.tsx src/lib/group-backlinks.test.ts` passed.
- `pnpm --filter @reflect/core test -- src/indexing/queries.test.ts` passed on the clean branch.
- `pnpm check` passed. Oxlint reported existing max-lines warnings only.

## Risk / Rollout

No migration or backfill is required. This changes read ordering only; backlink rows and snippets are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-path ordering only; no schema, migration, or backlink data changes.
> 
> **Overview**
> Incoming backlink lists now rank **source note groups** by most recently edited (`notes.mtime` descending) instead of alphabetical title order, so newer references (e.g. from daily notes) surface above older ones.
> 
> `getBacklinks()` and `getBacklinksWithContext()` both join `notes` for `mtime` and use **source path** and **link position** as tie-breakers; multiple links from the same note still appear in document order. Desktop grouping stays order-preserving; comments now describe the new sort. A core test asserts the compiled SQL `ORDER BY` clause.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c28b997cd32ebee3b713d7b028007b35aaa745dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->