### PR TITLE
fix: sort incoming backlinks by source recency (V1 parity)

### DIFF
--- a/apps/desktop/src/lib/group-backlinks.ts
+++ b/apps/desktop/src/lib/group-backlinks.ts
@@ -12,9 +12,9 @@ export interface BacklinkSource {
 
 /**
  * Group flat backlink rows by their source note, preserving the query's
- * source-title order. Empty snippets (a source that vanished between the
- * index query and the file read) are dropped, but the source group itself
- * still renders so the reference stays discoverable.
+ * most-recent-source-first order (V1 parity). Empty snippets (a source that
+ * vanished between the index query and the file read) are dropped, but the
+ * source group itself still renders so the reference stays discoverable.
  */
 export function groupBacklinksBySource(
   backlinks: readonly BacklinkContext[],

--- a/packages/core/src/indexing/queries.test.ts
+++ b/packages/core/src/indexing/queries.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setBridge } from '../ipc/bridge'
 import {
   dailyDatesInRange,
+  getBacklinksWithContext,
   getDuplicateNoteIds,
   getNoteIdsByPath,
   getOpenTasks,
@@ -89,6 +90,39 @@ describe('listDailyNotes', () => {
     await expect(
       listDailyNotes({ start: '2025-01-01', end: '2025-01-31', limit: 32 }),
     ).resolves.toEqual([])
+  })
+})
+
+describe('getBacklinksWithContext', () => {
+  it('orders sources most recent first — daily date for dailies, edit time otherwise (V1 parity)', async () => {
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === 'db_query') {
+        return [
+          { source_path: 'daily/2026-07-01.md', pos_from: 4, source_title: '2026-07-01' },
+          { source_path: 'notes/older.md', pos_from: 9, source_title: 'Older' },
+        ]
+      }
+      return 'a line with a [[target]] link'
+    })
+
+    const rows = await getBacklinksWithContext('notes/target.md')
+
+    expect(rows.map((row) => row.sourcePath)).toEqual([
+      'daily/2026-07-01.md',
+      'notes/older.md',
+    ])
+    const [command, args] = mockInvoke.mock.calls[0]!
+    expect(command).toBe('db_query')
+    const sql = String(args['sql'])
+    // Recency interleaves dailies (calendar date) with regular notes (edit
+    // time); title must not be the sort key.
+    expect(sql).toContain(
+      'order by coalesce(strftime(\'%s\', "notes"."daily_date") * 1000, "notes"."updated_at") desc',
+    )
+    expect(sql).not.toContain('order by "notes"."title"')
+    // Groups stay contiguous and links keep document order.
+    expect(sql).toContain('"backlinks"."source_path"')
+    expect(sql).toContain('"backlinks"."pos_from"')
   })
 })
 

--- a/packages/core/src/indexing/queries.ts
+++ b/packages/core/src/indexing/queries.ts
@@ -59,6 +59,12 @@ export interface BacklinkContext {
  * Backlinks of `path` with source titles and line snippets. One read per
  * distinct source; a source that vanished between query and read keeps its row
  * with an empty snippet (the index lags deletes only briefly).
+ *
+ * Ordered like V1's incoming backlinks: most recent source note first, where a
+ * daily note's date is its calendar date and a regular note's is its edit time
+ * (V1 used creation time, which the index does not carry — `updated_at` is the
+ * closest substrate). Links within one source keep document order, so the
+ * panel's per-source groups render snippets as they appear in the note.
  */
 export async function getBacklinksWithContext(path: string): Promise<BacklinkContext[]> {
   const rows = await db
@@ -69,7 +75,12 @@ export async function getBacklinksWithContext(path: string): Promise<BacklinkCon
     // The view's generated types are nullable (SQLite views lose NOT NULL),
     // but these columns come from NOT NULL `links` columns via an inner join.
     .$narrowType<{ sourcePath: string; posFrom: number }>()
-    .orderBy('notes.title')
+    // Daily dates are UTC-midnight seconds scaled to ms so they interleave
+    // with `updated_at` (epoch ms) on one axis.
+    .orderBy(
+      sql`coalesce(strftime('%s', "notes"."daily_date") * 1000, "notes"."updated_at")`,
+      'desc',
+    )
     .orderBy('backlinks.sourcePath')
     .orderBy('backlinks.posFrom')
     .execute()


### PR DESCRIPTION
## Problem

The incoming-backlinks panel (desktop and mobile) sorted source notes alphabetically by title. Reflect V1 orders incoming backlinks by recency: the most recent source note first, where a daily note sorts by its **calendar date** and a regular note by its timestamp (`fromNoteCreatedAt` in V1's `note-backlink-store.ts` / `groupedIncomingBacklinks`). An old daily edited today stays at its calendar position in V1; alphabetical order was a V2 invention.

## Change

- `getBacklinksWithContext` (packages/core/src/indexing/queries.ts) now orders by `coalesce(strftime('%s', daily_date) * 1000, updated_at) DESC` instead of `notes.title`:
  - Daily sources sort by calendar date (UTC-midnight seconds scaled to epoch-ms so both keys share one axis).
  - Regular sources sort by `updated_at`. The V2 index carries no creation time (dropped deliberately — see the All-tab search work), so last-edit time is the closest available substrate for V1's `createdAt`.
  - `sourcePath` remains the tiebreak (groups stay contiguous) and `posFrom` keeps links in document order within a source — matching V1, which preserves document order inside each group.
- `groupBacklinksBySource` is order-preserving and unchanged; its doc comment now states the recency contract. Both desktop (`backlinks-panel.tsx`) and mobile (`incoming-backlinks.tsx`) consume the shared `useBacklinkSources` hook, so both surfaces pick this up with no UI changes.

## Deviation from V1

V1 keys regular notes on creation time; this uses edit time, so a regular source note moves to the top of the list when edited. Exact parity would require adding a created-at column to the index, which was previously ruled out.

## Testing

- New unit test asserts the compiled ORDER BY (recency key, no title sort, document-order tiebreaks): `pnpm vitest run src/indexing/queries.test.ts` — 16 passed.
- Existing grouping/panel tests unaffected: `group-backlinks.test.ts`, `backlinks-panel.test.tsx`, `incoming-backlinks.test.tsx` — 20 passed.
- `pnpm check` (typecheck + lint) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-path ordering only in core indexing; no auth, writes, or UI logic changes.
> 
> **Overview**
> Incoming backlinks no longer sort referencing notes **alphabetically by title**. `getBacklinksWithContext` now returns rows **most recent source first**, matching V1: **daily** sources use **calendar `daily_date`** (scaled to ms), **regular** notes use **`updated_at`** (creation time isn’t indexed). **`sourcePath`** and **`posFrom`** still group sources and keep links in document order.
> 
> `groupBacklinksBySource` behavior is unchanged; its comment now documents the recency ordering. Desktop and mobile panels pick this up via the shared hook with **no UI changes**.
> 
> A new **`queries.test`** case locks the compiled SQL: recency `ORDER BY`, no title sort, and document-order tiebreaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b2ef5f58ac5dc079cb63b9c9350d262c51a6980. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->