### PR TITLE
feat: one-click agent-skill install under Settings → Agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4767,6 +4767,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,5 @@ rusqlite_migration = "2.6.0"
 sqlite-vec = "0.1.9"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
+sha2 = "0.11.0"
 tempfile = "3.27.0"

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 reflect-index-schema = { path = "../../crates/index-schema", default-features = false }
 clap = { version = "4.6.1", features = ["derive"] }
 jiff = "0.2.28"
-sha2 = "0.11.0"
+sha2 = { workspace = true }
 pulldown-cmark = "0.13.4"
 saphyr = "0.0.6"
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = { workspace = true }
 rusqlite = { workspace = true, features = ["hooks"] }
 reflect-index-schema = { path = "../../../crates/index-schema" }
 tempfile = { workspace = true }
+sha2 = { workspace = true }
 dirs = "6.0.0"
 tauri-plugin-dialog = "2.7.1"
 base64 = "0.22.1"

--- a/apps/desktop/src-tauri/skills/graph-skill.md
+++ b/apps/desktop/src-tauri/skills/graph-skill.md
@@ -1,0 +1,64 @@
+---
+name: {{SKILL_NAME}}
+description: Read, search, and open notes in the user's "{{GRAPH_NAME}}" Reflect graph via the `reflect` CLI. Use when the user asks about their notes, daily notes, journal, or anything they may have written down in Reflect.
+---
+
+# Reflect graph: {{GRAPH_NAME}}
+
+Reflect is a local-first, markdown-backed note-taking app. This skill targets
+one graph (a folder of notes):
+
+    {{GRAPH_ROOT}}
+
+Read it through the `reflect` CLI rather than scanning the files — the CLI
+resolves titles, aliases, and daily dates, searches the graph's ranked index,
+and enforces the privacy contract.
+
+## The CLI
+
+Use `reflect` from PATH when available; the app also bundles the binary at:
+
+    {{CLI_PATH}}
+
+Always target the graph explicitly so calls stay deterministic:
+
+    reflect --graph "{{GRAPH_ROOT}}" <command>
+
+or export `REFLECT_GRAPH="{{GRAPH_ROOT}}"` for a sequence of calls.
+
+## Commands
+
+    reflect today              # print today's daily note
+    reflect today --path       # its absolute path (works before the file exists)
+    reflect search <query>     # ranked full-text search over the graph
+    reflect show <note>        # print a note by date, path, title, or alias
+    reflect path <note>        # resolve a note to its absolute path
+    reflect open <note>        # open the note in the Reflect app
+
+- Add `--json` to any command for stable machine-readable output — the field
+  names and exit codes are the supported automation contract.
+- `<note>` resolves in order: `YYYY-MM-DD` date, graph-relative path, title,
+  then alias (case-insensitive).
+- stdout carries only data; warnings and errors go to stderr.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | success |
+| 1 | runtime error (no graph, IO failure) |
+| 2 | usage error |
+| 3 | note not found, or note is private |
+| 4 | search index missing — open the graph in Reflect once to build it |
+
+## Rules
+
+1. **Respect privacy.** Notes with `private: true` frontmatter are invisible
+   through the CLI by design — no content, no paths, no search hits. Never
+   work around this by reading graph files directly unless the user
+   explicitly asks for that.
+2. **The CLI never writes.** Notes are plain markdown under the graph root
+   (`daily/YYYY-MM-DD.md`, `notes/*.md`). To change a note, edit the file the
+   CLI resolves (`reflect path <note>`); the running app picks the edit up.
+3. **Prefer search over enumeration.** `reflect search` uses the app's own
+   ranked index; don't grep the whole graph when a search will do.

--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -56,7 +56,8 @@ fn pointer_json(root: &Path) -> String {
     .to_string()
 }
 
-fn atomic_write_to(path: &Path, contents: &str) -> AppResult<()> {
+// Also used by `skill.rs` for the agent-skill files under `~/.agents/`.
+pub(crate) fn atomic_write_to(path: &Path, contents: &str) -> AppResult<()> {
     let dir = path
         .parent()
         .ok_or_else(|| AppError::io(format!("no parent directory for {}", path.display())))?;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@
 //! [`recents`] (recent-graphs store), [`settings`] (user settings store),
 //! [`secrets`] (OS keychain), [`git`] (backup/sync primitives),
 //! [`capture`] (link-capture inbox + native-messaging host plumbing),
+//! [`skill`] (per-graph agent-skill install under `~/.agents/skills/`),
 //! [`calendar`] (read-only Apple Calendar access),
 //! [`contacts`] (live Apple Contacts lookups),
 //! [`error`] (the shared error contract).
@@ -27,6 +28,7 @@ mod quit;
 mod recents;
 mod secrets;
 mod settings;
+mod skill;
 
 // The watcher and the embedding runtime are desktop capabilities (Plan 19):
 // mobile swaps in stand-ins with the identical command surface, so the
@@ -194,6 +196,9 @@ pub fn run() {
             recents::forget_recent,
             settings::settings_load,
             settings::settings_save,
+            skill::skill_status,
+            skill::skill_install,
+            skill::skill_uninstall,
             secrets::secret_set,
             secrets::secret_get,
             secrets::secret_delete,

--- a/apps/desktop/src-tauri/src/skill.rs
+++ b/apps/desktop/src-tauri/src/skill.rs
@@ -1,0 +1,383 @@
+//! Agent-skill install (Settings → Agents): writes a per-graph `SKILL.md`
+//! under `~/.agents/skills/` so coding agents (Claude Code and friends)
+//! discover the open graph and read it through the bundled `reflect` CLI.
+//!
+//! The skill is named after the graph (`reflect-<slug>`), and the rendered
+//! content bakes in the graph root and the CLI's on-disk path. A managed
+//! marker — an HTML comment carrying the sha256 of the rendered template —
+//! makes updates safe: a file without the marker (or with the right marker
+//! but edited content) was not written by us and is never overwritten or
+//! deleted.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use tauri::State;
+
+use crate::capture::atomic_write_to;
+use crate::error::{AppError, AppResult};
+use crate::fs::{current_root, root_for_generation, GraphState};
+
+/// The bundled template; placeholders are `{{SKILL_NAME}}`, `{{GRAPH_NAME}}`,
+/// `{{GRAPH_ROOT}}`, and `{{CLI_PATH}}`.
+const SKILL_TEMPLATE: &str = include_str!("../skills/graph-skill.md");
+
+const MANAGED_PREFIX: &str = "<!-- reflect-managed: sha256=";
+const MANAGED_SUFFIX: &str = " -->";
+
+/// The CLI sidecar, staged beside the app binary by the Tauri bundler (and
+/// beside the dev binary by `tauri dev`) — same layout as the capture host.
+const CLI_BINARY: &str = if cfg!(windows) { "reflect.exe" } else { "reflect" };
+
+/// Where the installed skill file stands relative to what this app would
+/// write today.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SkillInstallState {
+    /// No file at the target path.
+    Missing,
+    /// Byte-identical to what we would write.
+    Current,
+    /// Ours (marker present) but rendered from older inputs — a template
+    /// change, an app move, or a graph rename/move. Safe to rewrite.
+    Stale,
+    /// A file we don't manage: no marker, or marker with edited content.
+    /// Never overwritten, never deleted.
+    Conflict,
+}
+
+/// Answer for the settings card: where the skill goes, what it's called, and
+/// whether the file on disk is ours.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillStatus {
+    pub skill_name: String,
+    pub skill_path: String,
+    pub cli_path: String,
+    pub install_state: SkillInstallState,
+}
+
+/// Everything derived from the open graph that the three commands share.
+struct SkillContext {
+    skill_name: String,
+    dir: PathBuf,
+    target: PathBuf,
+    cli_path: PathBuf,
+    rendered_hash: String,
+    managed_content: String,
+}
+
+/// Kebab-case ASCII slug of a graph name; `"graph"` when nothing survives.
+fn slugify(name: &str) -> String {
+    let mut slug = String::new();
+    let mut gap = false;
+    for character in name.chars() {
+        if character.is_ascii_alphanumeric() {
+            if gap && !slug.is_empty() {
+                slug.push('-');
+            }
+            gap = false;
+            slug.push(character.to_ascii_lowercase());
+        } else {
+            gap = true;
+        }
+    }
+    if slug.is_empty() {
+        "graph".to_string()
+    } else {
+        slug
+    }
+}
+
+fn render_skill(skill_name: &str, graph_name: &str, graph_root: &str, cli_path: &str) -> String {
+    SKILL_TEMPLATE
+        .replace("{{SKILL_NAME}}", skill_name)
+        .replace("{{GRAPH_NAME}}", graph_name)
+        .replace("{{GRAPH_ROOT}}", graph_root)
+        .replace("{{CLI_PATH}}", cli_path)
+}
+
+/// Lowercase hex sha256 (same encoding as the CLI's `hash.rs`).
+fn content_hash(content: &str) -> String {
+    use std::fmt::Write;
+    let digest = Sha256::digest(content.as_bytes());
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
+}
+
+/// Insert the managed marker after the YAML frontmatter (agent runtimes parse
+/// the frontmatter block first, so the marker must not sit above it).
+fn insert_marker(source: &str, hash: &str) -> String {
+    let marker = format!("{MANAGED_PREFIX}{hash}{MANAGED_SUFFIX}");
+    if let Some(rest) = source.strip_prefix("---\n") {
+        if let Some(index) = rest.find("\n---\n") {
+            let split = "---\n".len() + index + "\n---\n".len();
+            let (frontmatter, body) = source.split_at(split);
+            return format!("{frontmatter}{marker}\n{body}");
+        }
+    }
+    format!("{marker}\n{source}")
+}
+
+fn managed_hash(content: &str) -> Option<&str> {
+    content.lines().find_map(|line| {
+        line.trim()
+            .strip_prefix(MANAGED_PREFIX)?
+            .strip_suffix(MANAGED_SUFFIX)
+    })
+}
+
+fn classify(
+    installed: Option<&str>,
+    rendered_hash: &str,
+    managed_content: &str,
+) -> SkillInstallState {
+    let Some(installed) = installed else {
+        return SkillInstallState::Missing;
+    };
+    let Some(hash) = managed_hash(installed) else {
+        return SkillInstallState::Conflict;
+    };
+    if hash != rendered_hash {
+        return SkillInstallState::Stale;
+    }
+    if installed == managed_content {
+        SkillInstallState::Current
+    } else {
+        SkillInstallState::Conflict
+    }
+}
+
+/// The staged CLI sidecar, next to the running executable in both dev
+/// (`target/debug/`) and the bundle (`Reflect.app/Contents/MacOS/`).
+fn cli_path() -> AppResult<PathBuf> {
+    let exe = std::env::current_exe().map_err(|err| AppError::io(err.to_string()))?;
+    let dir = exe
+        .parent()
+        .ok_or_else(|| AppError::io("executable has no parent directory"))?;
+    Ok(dir.join(CLI_BINARY))
+}
+
+fn context_for(root: &Path, skills_root: &Path, cli: PathBuf) -> SkillContext {
+    let graph_name = root
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let skill_name = format!("reflect-{}", slugify(&graph_name));
+    let rendered = render_skill(
+        &skill_name,
+        &graph_name,
+        &root.to_string_lossy(),
+        &cli.to_string_lossy(),
+    );
+    let rendered_hash = content_hash(&rendered);
+    let managed_content = insert_marker(&rendered, &rendered_hash);
+    let dir = skills_root.join(&skill_name);
+    let target = dir.join("SKILL.md");
+    SkillContext {
+        skill_name,
+        dir,
+        target,
+        cli_path: cli,
+        rendered_hash,
+        managed_content,
+    }
+}
+
+fn context_for_graph(root: &Path) -> AppResult<SkillContext> {
+    let home = dirs::home_dir().ok_or_else(|| AppError::io("no home directory"))?;
+    let skills_root = home.join(".agents").join("skills");
+    Ok(context_for(root, &skills_root, cli_path()?))
+}
+
+fn status_of(context: &SkillContext) -> AppResult<SkillStatus> {
+    let installed = match fs::read_to_string(&context.target) {
+        Ok(content) => Some(content),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+        Err(err) => return Err(err.into()),
+    };
+    Ok(SkillStatus {
+        skill_name: context.skill_name.clone(),
+        skill_path: context.target.to_string_lossy().into_owned(),
+        cli_path: context.cli_path.to_string_lossy().into_owned(),
+        install_state: classify(
+            installed.as_deref(),
+            &context.rendered_hash,
+            &context.managed_content,
+        ),
+    })
+}
+
+/// Command: the skill's name, target path, and install state for the open
+/// graph. Read-only.
+#[tauri::command]
+pub fn skill_status(state: State<GraphState>) -> AppResult<SkillStatus> {
+    let root = current_root(&state)?;
+    status_of(&context_for_graph(&root)?)
+}
+
+/// Command: write (or refresh) the graph's skill file. Generation-pinned so
+/// an install racing a graph switch can't write the wrong graph's skill.
+/// Refuses to touch a file we don't manage.
+#[tauri::command]
+pub fn skill_install(generation: u64, state: State<GraphState>) -> AppResult<SkillStatus> {
+    let root = root_for_generation(&state, generation)?;
+    let context = context_for_graph(&root)?;
+    let status = status_of(&context)?;
+    match status.install_state {
+        SkillInstallState::Conflict => Err(AppError::io(format!(
+            "{} exists but was not written by Reflect — move it aside first",
+            context.target.display()
+        ))),
+        SkillInstallState::Current => Ok(status),
+        SkillInstallState::Missing | SkillInstallState::Stale => {
+            atomic_write_to(&context.target, &context.managed_content)?;
+            status_of(&context)
+        }
+    }
+}
+
+/// Command: remove the graph's skill file (and its directory when that leaves
+/// it empty). Only removes files carrying our managed marker.
+#[tauri::command]
+pub fn skill_uninstall(generation: u64, state: State<GraphState>) -> AppResult<SkillStatus> {
+    let root = root_for_generation(&state, generation)?;
+    let context = context_for_graph(&root)?;
+    let status = status_of(&context)?;
+    match status.install_state {
+        SkillInstallState::Missing => Ok(status),
+        SkillInstallState::Conflict => Err(AppError::io(format!(
+            "{} was not written by Reflect — not removing it",
+            context.target.display()
+        ))),
+        SkillInstallState::Current | SkillInstallState::Stale => {
+            fs::remove_file(&context.target)?;
+            // Only removes an empty directory — anything else the user put
+            // beside the skill file survives.
+            let _ = fs::remove_dir(&context.dir);
+            status_of(&context)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slugify_kebab_cases_graph_names() {
+        assert_eq!(slugify("Personal"), "personal");
+        assert_eq!(slugify("Alex's Notes"), "alex-s-notes");
+        assert_eq!(slugify("  Work 2026  "), "work-2026");
+        assert_eq!(slugify("日本語"), "graph");
+        assert_eq!(slugify(""), "graph");
+    }
+
+    fn test_context(dir: &Path, graph: &Path) -> SkillContext {
+        context_for(graph, dir, PathBuf::from("/Applications/Reflect.app/Contents/MacOS/reflect"))
+    }
+
+    #[test]
+    fn render_bakes_in_the_graph_and_cli() {
+        let context = test_context(Path::new("/skills"), Path::new("/graphs/Personal"));
+        assert_eq!(context.skill_name, "reflect-personal");
+        assert_eq!(
+            context.target,
+            Path::new("/skills/reflect-personal/SKILL.md")
+        );
+        assert!(context.managed_content.contains("name: reflect-personal"));
+        assert!(context.managed_content.contains("/graphs/Personal"));
+        assert!(context
+            .managed_content
+            .contains("/Applications/Reflect.app/Contents/MacOS/reflect"));
+        assert!(!context.managed_content.contains("{{"));
+    }
+
+    #[test]
+    fn marker_sits_after_the_frontmatter() {
+        let context = test_context(Path::new("/skills"), Path::new("/graphs/Personal"));
+        let close = context
+            .managed_content
+            .find("\n---\n")
+            .expect("frontmatter closes");
+        let marker = context
+            .managed_content
+            .find(MANAGED_PREFIX)
+            .expect("marker present");
+        assert!(marker > close, "marker must not sit above the frontmatter");
+        assert_eq!(
+            managed_hash(&context.managed_content),
+            Some(context.rendered_hash.as_str())
+        );
+    }
+
+    #[test]
+    fn classify_walks_the_state_machine() {
+        let context = test_context(Path::new("/skills"), Path::new("/graphs/Personal"));
+        let hash = &context.rendered_hash;
+        let managed = &context.managed_content;
+
+        assert_eq!(classify(None, hash, managed), SkillInstallState::Missing);
+        assert_eq!(
+            classify(Some(managed), hash, managed),
+            SkillInstallState::Current
+        );
+        // No marker → not ours.
+        assert_eq!(
+            classify(Some("# hand-written skill"), hash, managed),
+            SkillInstallState::Conflict
+        );
+        // Right marker, edited body → not ours either.
+        let edited = format!("{managed}\nuser addition\n");
+        assert_eq!(
+            classify(Some(&edited), hash, managed),
+            SkillInstallState::Conflict
+        );
+        // Rendered from other inputs (graph moved, template changed) → stale.
+        let moved = test_context(Path::new("/skills"), Path::new("/elsewhere/Personal"));
+        assert_eq!(
+            classify(Some(&moved.managed_content), hash, managed),
+            SkillInstallState::Stale
+        );
+    }
+
+    #[test]
+    fn install_round_trip_on_disk() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let context = test_context(temp.path(), Path::new("/graphs/Personal"));
+
+        assert_eq!(
+            status_of(&context).expect("status").install_state,
+            SkillInstallState::Missing
+        );
+
+        atomic_write_to(&context.target, &context.managed_content).expect("write");
+        assert_eq!(
+            status_of(&context).expect("status").install_state,
+            SkillInstallState::Current
+        );
+
+        // A graph rename changes the slug-independent inputs → stale, and a
+        // rewrite with the new context heals it.
+        let renamed = context_for(
+            Path::new("/graphs/Personal Renamed"),
+            temp.path(),
+            PathBuf::from("/Applications/Reflect.app/Contents/MacOS/reflect"),
+        );
+        assert_eq!(renamed.skill_name, "reflect-personal-renamed");
+
+        // User edits below the marker turn the file into a conflict.
+        let mut edited = context.managed_content.clone();
+        edited.push_str("\n## My notes\n");
+        std::fs::write(&context.target, &edited).expect("edit");
+        assert_eq!(
+            status_of(&context).expect("status").install_state,
+            SkillInstallState::Conflict
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/skill.rs
+++ b/apps/desktop/src-tauri/src/skill.rs
@@ -29,7 +29,11 @@ const MANAGED_SUFFIX: &str = " -->";
 
 /// The CLI sidecar, staged beside the app binary by the Tauri bundler (and
 /// beside the dev binary by `tauri dev`) — same layout as the capture host.
-const CLI_BINARY: &str = if cfg!(windows) { "reflect.exe" } else { "reflect" };
+const CLI_BINARY: &str = if cfg!(windows) {
+    "reflect.exe"
+} else {
+    "reflect"
+};
 
 /// Where the installed skill file stands relative to what this app would
 /// write today.
@@ -279,7 +283,11 @@ mod tests {
     }
 
     fn test_context(dir: &Path, graph: &Path) -> SkillContext {
-        context_for(graph, dir, PathBuf::from("/Applications/Reflect.app/Contents/MacOS/reflect"))
+        context_for(
+            graph,
+            dir,
+            PathBuf::from("/Applications/Reflect.app/Contents/MacOS/reflect"),
+        )
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/skill.rs
+++ b/apps/desktop/src-tauri/src/skill.rs
@@ -136,6 +136,24 @@ fn managed_hash(content: &str) -> Option<&str> {
     })
 }
 
+/// `content` with the marker's whole line removed — the inverse of
+/// [`insert_marker`], so a clean install restores the exact rendered text.
+fn without_marker_line(content: &str) -> Option<String> {
+    let start = content.find(MANAGED_PREFIX)?;
+    let line_start = content[..start].rfind('\n').map_or(0, |index| index + 1);
+    let line_end = content[start..]
+        .find('\n')
+        .map_or(content.len(), |index| start + index + 1);
+    let mut rest = String::with_capacity(content.len());
+    rest.push_str(&content[..line_start]);
+    rest.push_str(&content[line_end..]);
+    Some(rest)
+}
+
+/// The marker is self-validating: it records the sha256 of the content it was
+/// inserted into, so an edit anywhere in the file breaks the match and the
+/// file classifies as [`SkillInstallState::Conflict`] — even when the app's
+/// current inputs have also changed. Only a clean old install may be `Stale`.
 fn classify(
     installed: Option<&str>,
     rendered_hash: &str,
@@ -144,17 +162,23 @@ fn classify(
     let Some(installed) = installed else {
         return SkillInstallState::Missing;
     };
-    let Some(hash) = managed_hash(installed) else {
+    if installed == managed_content {
+        return SkillInstallState::Current;
+    }
+    let (Some(hash), Some(body)) = (managed_hash(installed), without_marker_line(installed)) else {
         return SkillInstallState::Conflict;
     };
+    if content_hash(&body) != hash {
+        // Edited since we wrote it — the recorded hash no longer matches the
+        // file's own body. Never overwrite, regardless of staleness.
+        return SkillInstallState::Conflict;
+    }
     if hash != rendered_hash {
         return SkillInstallState::Stale;
     }
-    if installed == managed_content {
-        SkillInstallState::Current
-    } else {
-        SkillInstallState::Conflict
-    }
+    // Self-consistent and current by hash, yet not byte-identical (e.g. a
+    // moved marker line): treat any deviation we can't explain as not ours.
+    SkillInstallState::Conflict
 }
 
 /// The staged CLI sidecar, next to the running executable in both dev
@@ -239,11 +263,33 @@ pub fn skill_install(generation: u64, state: State<GraphState>) -> AppResult<Ski
             context.target.display()
         ))),
         SkillInstallState::Current => Ok(status),
-        SkillInstallState::Missing | SkillInstallState::Stale => {
+        SkillInstallState::Missing => {
+            // No-clobber create: a file appearing between the classify above
+            // and this write fails loudly instead of being replaced.
+            atomic_create_new(&context.target, &context.managed_content)?;
+            status_of(&context)
+        }
+        SkillInstallState::Stale => {
             atomic_write_to(&context.target, &context.managed_content)?;
             status_of(&context)
         }
     }
+}
+
+/// Atomic create that refuses to replace an existing file (the missing-state
+/// counterpart of `capture::atomic_write_to`).
+fn atomic_create_new(path: &Path, contents: &str) -> AppResult<()> {
+    use std::io::Write;
+    let dir = path
+        .parent()
+        .ok_or_else(|| AppError::io(format!("no parent directory for {}", path.display())))?;
+    fs::create_dir_all(dir)?;
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
+    tmp.write_all(contents.as_bytes())?;
+    tmp.flush()?;
+    tmp.persist_noclobber(path)
+        .map_err(|err| AppError::io(err.to_string()))?;
+    Ok(())
 }
 
 /// Command: remove the graph's skill file (and its directory when that leaves
@@ -346,12 +392,29 @@ mod tests {
             classify(Some(&edited), hash, managed),
             SkillInstallState::Conflict
         );
-        // Rendered from other inputs (graph moved, template changed) → stale.
+        // Rendered from other inputs (graph moved, template changed) → stale,
+        // but only while the old install is untouched.
         let moved = test_context(Path::new("/skills"), Path::new("/elsewhere/Personal"));
         assert_eq!(
             classify(Some(&moved.managed_content), hash, managed),
             SkillInstallState::Stale
         );
+        // A user-edited old install must stay a conflict — staleness never
+        // downgrades edit protection (the marker validates its own body).
+        let stale_edited = format!("{}\nuser addition\n", moved.managed_content);
+        assert_eq!(
+            classify(Some(&stale_edited), hash, managed),
+            SkillInstallState::Conflict
+        );
+    }
+
+    #[test]
+    fn create_new_refuses_to_replace_an_existing_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let target = temp.path().join("SKILL.md");
+        atomic_create_new(&target, "first").expect("create");
+        assert!(atomic_create_new(&target, "second").is_err());
+        assert_eq!(std::fs::read_to_string(&target).expect("read"), "first");
     }
 
     #[test]

--- a/apps/desktop/src/components/settings-screen.tsx
+++ b/apps/desktop/src/components/settings-screen.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react'
 import { AboutSection } from './settings/about-section'
+import { AgentsSection } from './settings/agents-section'
 import { AiPromptsSection } from './settings/ai-prompts-section'
 import { AiProvidersSection } from './settings/ai-providers-section'
 import { AllNotesSection } from './settings/all-notes-section'
@@ -31,6 +32,7 @@ export function SettingsScreen(): ReactElement {
         <SearchSection />
         <AiProvidersSection />
         <AiPromptsSection />
+        <AgentsSection />
         <IntegrationsSection />
         <IcloudSection />
         <BackupSection />

--- a/apps/desktop/src/components/settings/agents-section.test.tsx
+++ b/apps/desktop/src/components/settings/agents-section.test.tsx
@@ -1,0 +1,115 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setBridge } from '@reflect/core'
+import { AgentsSection } from './agents-section'
+
+const platform = vi.hoisted(() => ({ isMacosDesktop: true }))
+vi.mock('@/lib/platform', () => ({
+  get isMacosDesktop() {
+    return platform.isMacosDesktop
+  },
+}))
+
+const GRAPH = { root: '/graphs/Personal', name: 'Personal', generation: 7 }
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({ graph: GRAPH }),
+}))
+
+type InstallState = 'missing' | 'current' | 'stale' | 'conflict'
+
+let installState: InstallState
+let installCalls: Array<Record<string, unknown>>
+let uninstallCalls: Array<Record<string, unknown>>
+
+function statusPayload(): Record<string, unknown> {
+  return {
+    skillName: 'reflect-personal',
+    skillPath: '/Users/me/.agents/skills/reflect-personal/SKILL.md',
+    cliPath: '/Applications/Reflect.app/Contents/MacOS/reflect',
+    installState,
+  }
+}
+
+function installFakeBridge(): void {
+  installCalls = []
+  uninstallCalls = []
+  setBridge({
+    invoke: async (command, args) => {
+      switch (command) {
+        case 'skill_status':
+          return statusPayload()
+        case 'skill_install': {
+          installCalls.push(args ?? {})
+          installState = 'current'
+          return statusPayload()
+        }
+        case 'skill_uninstall': {
+          uninstallCalls.push(args ?? {})
+          installState = 'missing'
+          return statusPayload()
+        }
+        default:
+          throw new Error(`unexpected command ${command}`)
+      }
+    },
+    listen: async () => () => {},
+  })
+}
+
+function renderSection(): void {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <AgentsSection />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  platform.isMacosDesktop = true
+  installState = 'missing'
+  installFakeBridge()
+})
+
+afterEach(() => {
+  cleanup()
+  setBridge(null)
+})
+
+describe('AgentsSection', () => {
+  it('installs the skill with the graph generation pinned', async () => {
+    renderSection()
+    fireEvent.click(await screen.findByRole('button', { name: 'Install skill' }))
+
+    await waitFor(() => expect(screen.getByText('Installed')).toBeTruthy())
+    expect(installCalls).toEqual([{ generation: GRAPH.generation }])
+    expect(screen.getByText('/Users/me/.agents/skills/reflect-personal/SKILL.md')).toBeTruthy()
+  })
+
+  it('offers an update for a stale install and removal for any managed one', async () => {
+    installState = 'stale'
+    renderSection()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove' }))
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Install skill' })).toBeTruthy(),
+    )
+    expect(uninstallCalls).toEqual([{ generation: GRAPH.generation }])
+  })
+
+  it('refuses to touch an unmanaged file', async () => {
+    installState = 'conflict'
+    renderSection()
+
+    await screen.findByText(/Reflect doesn’t manage/)
+    expect(screen.queryByRole('button', { name: 'Install skill' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Remove' })).toBeNull()
+  })
+
+  it('renders nothing off macOS desktop', () => {
+    platform.isMacosDesktop = false
+    renderSection()
+    expect(screen.queryByText('Agent skill')).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/settings/agents-section.tsx
+++ b/apps/desktop/src/components/settings/agents-section.tsx
@@ -1,0 +1,102 @@
+import { useState, type ReactElement } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { Check } from 'lucide-react'
+import {
+  agentSkillInstall,
+  agentSkillStatus,
+  agentSkillUninstall,
+  errorMessage,
+  hasBridge,
+  type AgentSkillStatus,
+} from '@reflect/core'
+import { SettingsField } from '@/components/settings/field'
+import { SettingsSection } from '@/components/settings/section'
+import { Button } from '@/components/ui/button'
+import { isMacosDesktop } from '@/lib/platform'
+import { useGraph } from '@/providers/graph-provider'
+
+/**
+ * Settings → Agents: one-click install of a per-graph agent skill under
+ * `~/.agents/skills/`. The skill is named after the graph and teaches coding
+ * agents (Claude Code and friends) to read this graph through the bundled
+ * `reflect` CLI. macOS desktop only, like the iCloud section — the navigator
+ * hides the entry through the same gate (see use-visible-settings-sections).
+ */
+export function AgentsSection(): ReactElement | null {
+  const { graph } = useGraph()
+  const queryClient = useQueryClient()
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const queryKey = ['agent-skill', graph?.root]
+  const { data: status } = useQuery({
+    queryKey,
+    queryFn: agentSkillStatus,
+    enabled: hasBridge() && isMacosDesktop && graph !== null,
+  })
+
+  if (!isMacosDesktop || graph === null) {
+    return null
+  }
+
+  async function run(action: (generation: number) => Promise<AgentSkillStatus>): Promise<void> {
+    if (graph === null) {
+      return
+    }
+    setBusy(true)
+    setError(null)
+    try {
+      queryClient.setQueryData(queryKey, await action(graph.generation))
+    } catch (caught) {
+      setError(errorMessage(caught))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const installed = status?.installState === 'current'
+  return (
+    <SettingsSection id="agents">
+      <SettingsField
+        legend="Agent skill"
+        description={`Teach Claude Code and other agents to read “${graph.name}” with the reflect CLI.`}
+      >
+        {status !== undefined ? (
+          <div className="mt-2 flex flex-col gap-2">
+            <p className="truncate font-mono text-xs text-text-muted" title={status.skillPath}>
+              {status.skillPath}
+            </p>
+            {status.installState === 'conflict' ? (
+              <p className="text-xs text-destructive">
+                A file Reflect doesn’t manage already exists there. Move it aside to install.
+              </p>
+            ) : (
+              <div className="flex items-center gap-2">
+                {installed ? (
+                  <span className="inline-flex items-center gap-1 text-xs text-text-secondary">
+                    <Check aria-hidden className="size-3.5" />
+                    Installed
+                  </span>
+                ) : (
+                  <Button size="xs" disabled={busy} onClick={() => void run(agentSkillInstall)}>
+                    {status.installState === 'stale' ? 'Update skill' : 'Install skill'}
+                  </Button>
+                )}
+                {status.installState !== 'missing' ? (
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    disabled={busy}
+                    onClick={() => void run(agentSkillUninstall)}
+                  >
+                    Remove
+                  </Button>
+                ) : null}
+              </div>
+            )}
+            {error !== null ? <p className="text-xs text-destructive">{error}</p> : null}
+          </div>
+        ) : null}
+      </SettingsField>
+    </SettingsSection>
+  )
+}

--- a/apps/desktop/src/components/settings/sections.ts
+++ b/apps/desktop/src/components/settings/sections.ts
@@ -12,6 +12,8 @@ export const SETTINGS_SECTIONS = [
   { id: 'search', title: 'Search' },
   { id: 'ai-providers', title: 'AI providers' },
   { id: 'ai-prompts', title: 'AI prompts' },
+  // macOS only — installs files under ~/.agents for terminal coding agents.
+  { id: 'agents', title: 'Agents' },
   // Only shown where the OS frameworks exist — see use-visible-settings-sections.
   { id: 'integrations', title: 'Integrations' },
   // macOS only (same gate) — Windows/Linux have no iCloud Drive.

--- a/apps/desktop/src/components/settings/settings-navigator.test.tsx
+++ b/apps/desktop/src/components/settings/settings-navigator.test.tsx
@@ -5,11 +5,12 @@ import { SETTINGS_SECTIONS, settingsSectionDomId } from './sections'
 import { SettingsNavigator } from './settings-navigator'
 
 // No bridge is installed here, so the platform-gated entries are hidden
-// (Integrations needs the Rust contacts answer; iCloud sync needs
+// (Integrations needs the Rust contacts answer; iCloud sync and Agents need
 // `isMacosDesktop`, which requires a Tauri webview) — the navigator lists the
 // sections every platform shows.
 const VISIBLE_SECTIONS = SETTINGS_SECTIONS.filter(
-  (section) => section.id !== 'integrations' && section.id !== 'icloud',
+  (section) =>
+    section.id !== 'integrations' && section.id !== 'icloud' && section.id !== 'agents',
 )
 
 // jsdom implements neither; the navigator re-measures its marker on resize,

--- a/apps/desktop/src/components/settings/use-visible-settings-sections.ts
+++ b/apps/desktop/src/components/settings/use-visible-settings-sections.ts
@@ -19,7 +19,7 @@ export function useVisibleSettingsSections(): readonly SettingsSectionEntry[] {
     if (section.id === 'integrations') {
       return hasAppleIntegrations
     }
-    if (section.id === 'icloud') {
+    if (section.id === 'icloud' || section.id === 'agents') {
       return isMacosDesktop
     }
     return true

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -155,6 +155,13 @@ are stable; new fields may be added, existing ones won't change meaning.
 Reading a private note is not possible through this surface by design — don't
 work around it by reading graph files directly unless the user asked for that.
 
+Settings → Agents installs a per-graph agent skill
+(`~/.agents/skills/reflect-<graph-slug>/SKILL.md`) that teaches coding agents
+this contract: the graph's root, the bundled CLI's path, the commands, and
+the privacy rules. The file carries a `reflect-managed` sha256 marker so the
+app can refresh its own installs without ever overwriting a hand-edited one
+(`apps/desktop/src-tauri/src/skill.rs`).
+
 ## Development notes
 
 - The CLI deliberately duplicates a thin read-side contract from

--- a/packages/core/src/app/agent-skill.ts
+++ b/packages/core/src/app/agent-skill.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod'
+import { call } from '../ipc/invoke'
+
+const agentSkillInstallStateSchema = z.enum(['missing', 'current', 'stale', 'conflict'])
+
+/**
+ * Where the installed skill file stands relative to what the app would write
+ * today: `missing` (no file), `current` (byte-identical), `stale` (ours, but
+ * rendered from older inputs — safe to rewrite), or `conflict` (a file the
+ * app doesn't manage; never overwritten or deleted).
+ */
+export type AgentSkillInstallState = z.infer<typeof agentSkillInstallStateSchema>
+
+const agentSkillStatusSchema = z.object({
+  /** The skill's directory name, derived from the graph (`reflect-<slug>`). */
+  skillName: z.string(),
+  /** Absolute path of the target `SKILL.md` under `~/.agents/skills/`. */
+  skillPath: z.string(),
+  /** Absolute path of the bundled `reflect` CLI the skill references. */
+  cliPath: z.string(),
+  installState: agentSkillInstallStateSchema,
+})
+
+/** Install status of the open graph's agent skill (Settings → Agents). */
+export type AgentSkillStatus = z.infer<typeof agentSkillStatusSchema>
+
+/** The open graph's agent-skill install status. Read-only. */
+export async function agentSkillStatus(): Promise<AgentSkillStatus> {
+  return call('skill_status', {}, agentSkillStatusSchema)
+}
+
+/**
+ * Write (or refresh) the open graph's `SKILL.md` under `~/.agents/skills/`.
+ * Generation-pinned like every mutating command; rejects `conflict` files.
+ */
+export async function agentSkillInstall(generation: number): Promise<AgentSkillStatus> {
+  return call('skill_install', { generation }, agentSkillStatusSchema)
+}
+
+/** Remove the open graph's managed skill file. Rejects `conflict` files. */
+export async function agentSkillUninstall(generation: number): Promise<AgentSkillStatus> {
+  return call('skill_uninstall', { generation }, agentSkillStatusSchema)
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,13 @@ export {
 } from './ipc/commands'
 export { confirmQuit, subscribeQuitRequested } from './app/quit'
 export { toggleDevtools } from './app/devtools'
+export {
+  agentSkillStatus,
+  agentSkillInstall,
+  agentSkillUninstall,
+  type AgentSkillInstallState,
+  type AgentSkillStatus,
+} from './app/agent-skill'
 
 // Embeddings & retrieval (Plan 09)
 export { chunkNote, type NoteChunk } from './embeddings/chunk'


### PR DESCRIPTION
## Problem

The `reflect` CLI is the supported automation surface for coding agents (docs/cli.md "For agents"), but nothing teaches an agent that a graph exists, where it lives, or how to talk to the CLI. Local Brain solved this with a one-click skill install from settings; Reflect should offer the same.

## What this does

Adds **Settings → Agents** (macOS desktop, gated like the iCloud section) with a one-click install of a per-graph agent skill:

- **Target:** `~/.agents/skills/reflect-<graph-slug>/SKILL.md` — the skill is named after the open graph (e.g. `reflect-personal`), matching Local Brain's `~/.agents/skills` convention so existing skill-sync tooling picks it up.
- **Content:** rendered from a bundled template (`apps/desktop/src-tauri/skills/graph-skill.md`) with the graph name, graph root, and the bundled CLI's on-disk path baked in. It documents the five CLI commands, `--graph`/`REFLECT_GRAPH` targeting, the `--json` contract, exit codes, and the `private: true` rule.
- **Safe updates:** a `<!-- reflect-managed: sha256=… -->` marker (inserted after the frontmatter) classifies the file on disk as `missing` / `current` / `stale` / `conflict`. Stale files (template change, app move, graph rename) get an **Update skill** button; files without the marker — or marker-carrying files the user edited — are conflicts and are never overwritten or deleted.
- **Generation-pinned writes:** `skill_install` / `skill_uninstall` take the graph generation like every other mutating command, so an install racing a graph switch fails loudly instead of writing the wrong graph's skill.

## Implementation

- `apps/desktop/src-tauri/src/skill.rs` — new module: slug/render/marker/classify helpers + `skill_status`/`skill_install`/`skill_uninstall` commands; reuses `capture.rs`'s atomic home-dir write and its `current_exe()`-sibling sidecar path resolution.
- `packages/core/src/app/agent-skill.ts` — typed zod bindings.
- `apps/desktop/src/components/settings/agents-section.tsx` — the settings card; registry + macOS gate + navigator test updated.
- `sha2` promoted to a workspace dependency (was declared directly in `apps/cli`).
- docs/cli.md: short note under "For agents".

## Testing

- `cargo test -p reflect-open skill::` — 5 tests: slugify, render substitution, marker placement, the classify state machine, and an on-disk round trip (install → current, edit → conflict).
- `pnpm vitest run` on `agents-section.test.tsx` (install pins the generation, stale offers update/remove, conflict shows no buttons, non-macOS renders nothing) and `settings-navigator.test.tsx` — 8 passed.
- `pnpm check` clean; `cargo clippy -p reflect-open --all-targets` clean.
- Not manually exercised in a running app yet — the card's states come from the same status command the tests cover, but a quick click-through on a real graph is worth doing before merge.

## Known limits

- Two graphs sharing a folder name share a skill id; the second graph's card shows **Update skill** rather than silently retargeting.
- macOS-only for now (same posture as the CLI sidecar registration); Linux can join when Plan 15 packaging lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to optional home-directory skill files with explicit conflict protection and generation-pinned writes; no changes to auth, indexing, or note content paths.
> 
> **Overview**
> Adds **Settings → Agents** on macOS desktop so users can install a per-graph agent skill at `~/.agents/skills/reflect-<slug>/SKILL.md`. The skill is rendered from a bundled template with the graph root and bundled `reflect` CLI path, and documents CLI usage plus privacy rules.
> 
> The desktop shell gains a new `skill` module with `skill_status`, `skill_install`, and `skill_uninstall` Tauri commands. Installs are classified via a `reflect-managed` sha256 marker (`missing` / `current` / `stale` / `conflict`); only managed files are updated or removed, with atomic create on first install and generation-pinned mutating calls. `capture::atomic_write_to` is shared for writes.
> 
> `@reflect/core` exposes typed IPC helpers; the settings UI adds `AgentsSection`, registry/navigator gating (macOS, like iCloud), and tests. `sha2` is promoted to a workspace dependency for the desktop crate; `docs/cli.md` notes the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb041de9b65992c5a54a02c40809160e87ab0262. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->