### PR TITLE
feat: delete a graph to the trash from settings

### DIFF
--- a/apps/desktop/src-tauri/src/fs/mod.rs
+++ b/apps/desktop/src-tauri/src/fs/mod.rs
@@ -391,6 +391,38 @@ pub fn note_delete(path: String, generation: u64, state: State<GraphState>) -> A
     Ok(())
 }
 
+/// Move the open graph's **entire directory** to the OS trash (recoverable)
+/// and drop it from recents, then invalidate the open session so a straggler
+/// write pinned to the deleted graph fails loudly instead of recreating the
+/// directory. Pinned to `generation` — a delete enqueued before a graph
+/// switch must never trash the newly opened graph. Desktop-only: mobile's
+/// fixed roots have no OS trash and no delete UI.
+#[tauri::command]
+pub fn graph_delete(generation: u64, state: State<GraphState>) -> AppResult<()> {
+    let root = root_for_generation(&state, generation)?;
+    #[cfg(desktop)]
+    {
+        os_trash_delete(&root)?;
+        // Recents is a convenience cache (same stance as `activate`): the
+        // directory is already in the trash, so a failure to persist must not
+        // report the delete as failed. A stale entry fails loudly on open.
+        if let Err(err) = crate::recents::forget(&root.to_string_lossy()) {
+            tracing::warn!(?err, "failed to forget deleted graph");
+        }
+        let mut inner = lock_graph(&state)?;
+        if inner.generation == generation {
+            inner.root = None;
+            inner.generation += 1;
+        }
+        Ok(())
+    }
+    #[cfg(mobile)]
+    {
+        let _ = root;
+        Err(AppError::io("deleting a graph is not supported on this platform"))
+    }
+}
+
 /// Send a file to the OS trash. On macOS, use `NSFileManager.trashItemAtURL`
 /// (`DeleteMethod::NsFileManager`) instead of the `trash` crate default, which
 /// drives Finder over AppleScript and fails with `-10010` ("Handler can't

--- a/apps/desktop/src-tauri/src/fs/mod.rs
+++ b/apps/desktop/src-tauri/src/fs/mod.rs
@@ -406,16 +406,33 @@ pub fn note_delete(path: String, generation: u64, state: State<GraphState>) -> A
 }
 
 /// Move the open graph's **entire directory** to the OS trash (recoverable)
-/// and drop it from recents, then invalidate the open session so a straggler
-/// write pinned to the deleted graph fails loudly instead of recreating the
-/// directory. Pinned to `generation` — a delete enqueued before a graph
-/// switch must never trash the newly opened graph. Desktop-only: mobile's
-/// fixed roots have no OS trash and no delete UI.
+/// and drop it from recents. The session is invalidated (root cleared,
+/// generation bumped) **before** the filesystem is touched: a concurrent
+/// write pinned to this generation must fail its root check instead of
+/// `create_dir_all`-recreating directories under a path being trashed. If
+/// the trash move itself then fails, the session stays invalidated and the
+/// frontend re-opens the intact directory to restore a writable session.
+/// Pinned to `generation` — a delete enqueued before a graph switch must
+/// never trash the newly opened graph. Desktop-only: mobile's fixed roots
+/// have no OS trash and no delete UI.
 #[tauri::command]
 pub fn graph_delete(generation: u64, state: State<GraphState>) -> AppResult<()> {
-    let root = root_for_generation(&state, generation)?;
     #[cfg(desktop)]
     {
+        // Check-and-invalidate under one lock hold — `root_for_generation`
+        // followed by a separate invalidation would leave a window where a
+        // pinned write still resolves the doomed root.
+        let root = {
+            let mut inner = lock_graph(&state)?;
+            if inner.generation != generation {
+                return Err(AppError::io(
+                    "the graph changed since this command was issued; dropping it",
+                ));
+            }
+            let root = inner.root.take().ok_or_else(AppError::no_graph)?;
+            inner.generation += 1;
+            root
+        };
         os_trash_delete(&root)?;
         // Recents is a convenience cache (same stance as `activate`): the
         // directory is already in the trash, so a failure to persist must not
@@ -423,16 +440,11 @@ pub fn graph_delete(generation: u64, state: State<GraphState>) -> AppResult<()> 
         if let Err(err) = crate::recents::forget(&root.to_string_lossy()) {
             tracing::warn!(?err, "failed to forget deleted graph");
         }
-        let mut inner = lock_graph(&state)?;
-        if inner.generation == generation {
-            inner.root = None;
-            inner.generation += 1;
-        }
         Ok(())
     }
     #[cfg(mobile)]
     {
-        let _ = root;
+        let _ = (generation, &state);
         Err(AppError::io(
             "deleting a graph is not supported on this platform",
         ))

--- a/apps/desktop/src-tauri/src/fs/mod.rs
+++ b/apps/desktop/src-tauri/src/fs/mod.rs
@@ -419,7 +419,9 @@ pub fn graph_delete(generation: u64, state: State<GraphState>) -> AppResult<()> 
     #[cfg(mobile)]
     {
         let _ = root;
-        Err(AppError::io("deleting a graph is not supported on this platform"))
+        Err(AppError::io(
+            "deleting a graph is not supported on this platform",
+        ))
     }
 }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -176,6 +176,7 @@ pub fn run() {
             icloud::watch::icloud_watch_stop,
             fs::graph_open,
             fs::graph_create,
+            fs::graph_delete,
             fs::note_read,
             fs::note_write,
             fs::asset_write,

--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -19,12 +19,14 @@ const graph = vi.hoisted(() => ({
   current: null as GraphInfo | null,
   indexGeneration: 7 as number | null,
   forget: vi.fn<(root: string) => Promise<void>>(async () => {}),
+  deleteGraph: vi.fn<() => Promise<void>>(async () => {}),
 }))
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({
     graph: graph.current,
     indexGeneration: graph.indexGeneration,
     forget: graph.forget,
+    deleteGraph: graph.deleteGraph,
   }),
 }))
 vi.mock('@/providers/sync-provider', () => ({
@@ -111,6 +113,7 @@ beforeEach(() => {
   graph.current = null
   graph.indexGeneration = 7
   graph.forget.mockClear()
+  graph.deleteGraph.mockClear()
   queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: Infinity } },
   })
@@ -144,6 +147,32 @@ describe('SettingsScreen', () => {
     fireEvent.click(within(dialog).getByRole('button', { name: /forget graph/i }))
 
     await waitFor(() => expect(graph.forget).toHaveBeenCalledWith('/graphs/work'))
+  })
+
+  it('requires typing the graph name before deleting the graph', async () => {
+    graph.current = { root: '/graphs/work', name: 'Work', generation: 1 }
+    renderScreen()
+
+    const section = screen.getByRole('region', { name: 'Danger zone' })
+    fireEvent.click(within(section).getByRole('button', { name: /delete graph/i }))
+
+    const dialog = screen.getByRole('dialog', { name: /delete graph/i })
+    expect(within(dialog).getByText('/graphs/work')).toBeTruthy()
+    const confirm = within(dialog).getByRole('button', { name: /delete graph/i })
+    expect(confirm.hasAttribute('disabled')).toBe(true)
+
+    const nameInput = within(dialog).getByLabelText('Graph name')
+    fireEvent.change(nameInput, { target: { value: 'Wor' } })
+    expect(confirm.hasAttribute('disabled')).toBe(true)
+    // Enter with a mismatched name must not delete either.
+    fireEvent.keyDown(nameInput, { key: 'Enter' })
+    expect(graph.deleteGraph).not.toHaveBeenCalled()
+
+    fireEvent.change(nameInput, { target: { value: 'Work' } })
+    expect(confirm.hasAttribute('disabled')).toBe(false)
+    fireEvent.click(confirm)
+
+    await waitFor(() => expect(graph.deleteGraph).toHaveBeenCalledTimes(1))
   })
 
   it('reflects the persisted markdown syntax mode', async () => {

--- a/apps/desktop/src/components/settings/destructive-section.tsx
+++ b/apps/desktop/src/components/settings/destructive-section.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactElement } from 'react'
+import { errorMessage } from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -8,15 +9,24 @@ import {
   DialogFooter,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
 import { useGraph } from '@/providers/graph-provider'
 import { SettingsField } from './field'
 import { SettingsSection } from './section'
 
 export function DestructiveSection(): ReactElement {
-  const { graph, forget } = useGraph()
+  const { graph, forget, deleteGraph } = useGraph()
   const [confirming, setConfirming] = useState(false)
   const [forgetting, setForgetting] = useState(false)
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [deleteName, setDeleteName] = useState('')
+  const [deleteError, setDeleteError] = useState<string | null>(null)
   const graphId = graph?.root ?? 'this graph'
+  const graphName = graph?.name ?? ''
+  // GitHub-style guard: the delete button stays dead until the typed name
+  // matches the graph's folder name exactly.
+  const nameConfirmed = graph !== null && deleteName === graph.name
 
   const forgetGraph = async (): Promise<void> => {
     if (graph === null || forgetting) {
@@ -28,6 +38,28 @@ export function DestructiveSection(): ReactElement {
       setConfirming(false)
     } finally {
       setForgetting(false)
+    }
+  }
+
+  const openDeleteDialog = (): void => {
+    setDeleteName('')
+    setDeleteError(null)
+    setConfirmingDelete(true)
+  }
+
+  const deleteGraphToTrash = async (): Promise<void> => {
+    if (!nameConfirmed || deleting) {
+      return
+    }
+    setDeleting(true)
+    setDeleteError(null)
+    try {
+      await deleteGraph()
+      setConfirmingDelete(false)
+    } catch (err) {
+      setDeleteError(errorMessage(err))
+    } finally {
+      setDeleting(false)
     }
   }
 
@@ -50,6 +82,22 @@ export function DestructiveSection(): ReactElement {
             </Button>
           </div>
         </SettingsField>
+        <SettingsField
+          legend="Delete graph"
+          description="Move this graph and all of its notes to the trash."
+        >
+          <div className="mt-3 flex justify-start">
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              disabled={graph === null || deleting}
+              onClick={openDeleteDialog}
+            >
+              Delete graph
+            </Button>
+          </div>
+        </SettingsField>
       </SettingsSection>
 
       <Dialog open={confirming} onOpenChange={(open) => !forgetting && setConfirming(open)}>
@@ -67,6 +115,53 @@ export function DestructiveSection(): ReactElement {
             </DialogClose>
             <Button variant="destructive" disabled={forgetting} onClick={() => void forgetGraph()}>
               {forgetting ? 'Forgetting…' : 'Forget graph'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={confirmingDelete}
+        onOpenChange={(open) => !deleting && setConfirmingDelete(open)}
+      >
+        <DialogContent>
+          <DialogTitle>Delete graph?</DialogTitle>
+          <DialogDescription>
+            Move <span className="font-mono text-text">{graphId}</span> and all of its notes to
+            the trash. Type <span className="font-mono text-text">{graphName}</span> to confirm.
+          </DialogDescription>
+          <Input
+            aria-label="Graph name"
+            placeholder={graphName}
+            value={deleteName}
+            autoComplete="off"
+            spellCheck={false}
+            disabled={deleting}
+            onChange={(event) => setDeleteName(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault()
+                void deleteGraphToTrash()
+              }
+            }}
+          />
+          {deleteError !== null && (
+            <p role="alert" className="text-xs text-destructive">
+              {deleteError}
+            </p>
+          )}
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="ghost" disabled={deleting}>
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button
+              variant="destructive"
+              disabled={!nameConfirmed || deleting}
+              onClick={() => void deleteGraphToTrash()}
+            >
+              {deleting ? 'Deleting…' : 'Delete graph'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -469,12 +469,28 @@ export function GraphProvider({
     if (graph === null) {
       return
     }
-    // Trash + forget happen in Rust while the session pin is still valid;
-    // only a confirmed delete tears the UI down to the chooser.
-    await deleteGraphCommand(graph.generation)
-    await closeActiveGraph()
+    const { root, generation } = graph
+    // A newer open while the delete is in flight supersedes it (the Rust
+    // side already refuses the stale generation) — never tear down or
+    // re-open the graph the user switched to.
+    const seq = openSeq.current
+    try {
+      await deleteGraphCommand(generation)
+    } catch (err) {
+      // The command invalidates the Rust session before touching the
+      // filesystem, so a failed trash leaves the directory intact but the
+      // session pin dead — re-open the graph to restore a writable session,
+      // then let the confirm dialog surface the error.
+      if (seq === openSeq.current) {
+        await openRecent(root)
+      }
+      throw err
+    }
+    if (seq === openSeq.current) {
+      await closeActiveGraph()
+    }
     await loadRecents()
-  }, [closeActiveGraph, graph, loadRecents])
+  }, [closeActiveGraph, graph, loadRecents, openRecent])
 
   const completeOnboarding = useCallback(
     async (kind: MobileStorageKind, chosenRoot?: string): Promise<void> => {

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -11,6 +11,7 @@ import {
 import { homeDir, join } from '@tauri-apps/api/path'
 import { open } from '@tauri-apps/plugin-dialog'
 import {
+  deleteGraph as deleteGraphCommand,
   errorMessage,
   forgetRecent,
   hasBridge,
@@ -65,6 +66,12 @@ interface GraphContextValue {
   openRecent: (root: string) => Promise<boolean>
   /** Drop a graph from the recents list. */
   forget: (root: string) => Promise<void>
+  /**
+   * Move the open graph's directory to the OS trash (recoverable), drop it
+   * from recents, and return to the chooser. Throws when the delete fails so
+   * the settings confirm dialog can surface the error. Desktop-only.
+   */
+  deleteGraph: () => Promise<void>
   /**
    * Mobile only (Plan 19, step 6): the user hasn't yet chosen how to start
    * (iCloud Drive / this device / GitHub), so both fixed roots are left
@@ -458,6 +465,17 @@ export function GraphProvider({
     [closeActiveGraph, graph, loadRecents],
   )
 
+  const deleteGraph = useCallback(async (): Promise<void> => {
+    if (graph === null) {
+      return
+    }
+    // Trash + forget happen in Rust while the session pin is still valid;
+    // only a confirmed delete tears the UI down to the chooser.
+    await deleteGraphCommand(graph.generation)
+    await closeActiveGraph()
+    await loadRecents()
+  }, [closeActiveGraph, graph, loadRecents])
+
   const completeOnboarding = useCallback(
     async (kind: MobileStorageKind, chosenRoot?: string): Promise<void> => {
       // An explicit root comes from the onboarding graph list or the settings
@@ -538,6 +556,7 @@ export function GraphProvider({
       createAt,
       openRecent,
       forget,
+      deleteGraph,
       needsOnboarding,
       mobileStorageInfo,
       mobileStorageKind,
@@ -556,6 +575,7 @@ export function GraphProvider({
       createAt,
       openRecent,
       forget,
+      deleteGraph,
       needsOnboarding,
       mobileStorageInfo,
       mobileStorageKind,

--- a/packages/core/src/graph/commands.ts
+++ b/packages/core/src/graph/commands.ts
@@ -188,3 +188,12 @@ export async function recentGraphs(): Promise<RecentGraph[]> {
 export async function forgetRecent(root: string): Promise<void> {
   await call('forget_recent', { root }, voidSchema)
 }
+
+/**
+ * Move the open graph's whole directory to the OS trash (recoverable) and
+ * drop it from recents. Pinned to `generation` so a delete can never race a
+ * graph switch and trash the newly opened graph. Desktop-only.
+ */
+export async function deleteGraph(generation: number): Promise<void> {
+  await call('graph_delete', { generation }, voidSchema)
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,6 +106,7 @@ export {
   listFiles,
   recentGraphs,
   forgetRecent,
+  deleteGraph,
   captureHostRegister,
   captureInboxList,
   captureInboxRead,


### PR DESCRIPTION
## Problem

There is no way to delete a graph from inside the app. The Danger zone only offers "Forget graph", which drops the graph from recents but leaves every file on disk — fine for detaching a local folder, but useless when you actually want the data gone. For iCloud graphs this matters most: the directory lives in the iCloud Drive container, so leftover data keeps syncing to every device with no in-app way to remove it.

Scope: desktop settings only. Mobile's settings sheet has no delete UI, and the `graph_delete` command refuses on mobile (fixed roots, no OS trash).

## Before → After

| | Before | After |
|---|---|---|
| Danger zone | "Forget graph" only | "Forget graph" + "Delete graph" |
| Deleting a graph's data | Manually in Finder | Moves the whole graph directory to the OS trash (recoverable), including iCloud graphs (deletion propagates to iCloud Drive) |
| Confirmation | — | GitHub-style: the delete button stays disabled until the graph's exact name is typed |
| After delete | — | Graph is dropped from recents and the app returns to the graph chooser |

## Changes

1. **Rust `graph_delete` command** ([fs/mod.rs](apps/desktop/src-tauri/src/fs/mod.rs)) — invalidates the open session first (generation check + root cleared + generation bumped under a single lock hold), so a concurrent generation-pinned `note_write` fails its root check instead of `create_dir_all`-recreating directories under a path being trashed. Only then does it trash the graph root via the existing `os_trash_delete` (NSFileManager on macOS, so cloud-synced volumes work without Automation permission) and forget recents (best-effort, same stance as `activate`). The command is generation-pinned: a delete enqueued before a graph switch can never trash the newly opened graph. Mobile compiles but returns an error.
2. **Core IPC wrapper** (`deleteGraph` in [commands.ts](packages/core/src/graph/commands.ts)) — thin generation-pinned call, exported from `@reflect/core`.
3. **Graph provider action** ([graph-provider.tsx](apps/desktop/src/providers/graph-provider.tsx)) — `deleteGraph()` calls the command, then closes the active graph (index/watcher teardown) and reloads recents, landing on the chooser. Teardown is guarded on `openSeq`, so a newer open racing the delete is never torn down. On a failed trash the Rust session is already invalidated, so the provider re-opens the intact directory to restore a writable session, then rethrows so the dialog surfaces the error.
4. **Danger zone UI** ([destructive-section.tsx](apps/desktop/src/components/settings/destructive-section.tsx)) — new "Delete graph" field and confirm dialog: shows the graph's path, requires typing the graph name (Enter submits once it matches), shows a `role="alert"` error inline on failure, and disables dismissal while the delete runs.

## Tests

- [settings-screen.test.tsx](apps/desktop/src/components/settings-screen.test.tsx): the confirm button stays disabled for an empty and a partially-typed name, Enter with a mismatched name does not delete, and typing the exact name enables the button and fires `deleteGraph` once.

## Verification

- Desktop settings + provider tests — 131 passed (`pnpm --filter @reflect/desktop test --run src/components/settings-screen.test.tsx src/providers`).
- `pnpm check` — typecheck + oxlint + eslint pass (pre-existing max-lines warnings only).
- `cargo fmt --check`, `cargo clippy -p reflect-open -- -D warnings`, `cargo check -p reflect-open` — clean.
- Not manually exercised in a running Tauri app.

## Risk / Rollout

- The trash move is recoverable by design (OS Trash / iCloud "Recently Deleted"), so a mistaken confirm is not data loss.
- The directory is trashed while the index connection and watcher are still open; on macOS the rename-into-trash keeps open handles valid, and teardown follows immediately. A write already past the root check when invalidation lands can still race the trash — that window is microseconds (versus the whole trash duration before the Bugbot fix) and closing it fully would need a `GraphState` rwlock redesign.
- If the trash call itself fails, the Rust session is already invalidated; the provider re-opens the same directory (files intact) so editing keeps working, and the error surfaces in settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Destructive whole-directory trash with generation pinning and session invalidation; recoverable via OS Trash but affects iCloud-synced graph folders; index/watcher may still be open briefly during trash on macOS.
> 
> **Overview**
> Desktop settings **Danger zone** gains **Delete graph** alongside forget: the whole graph directory goes to **OS trash** (recoverable), recents is cleared, and the app returns to the graph chooser.
> 
> **Backend:** New generation-pinned `graph_delete` Tauri command trashes the open graph root via existing `os_trash_delete`, best-effort `recents::forget`, then clears `GraphState` and bumps generation so stale `note_write` calls fail instead of recreating the folder. Mobile compiles but returns an error.
> 
> **Frontend:** `@reflect/core` exposes `deleteGraph(generation)`; `GraphProvider.deleteGraph()` invokes it while the session pin is valid, then tears down the index and reloads recents (errors propagate to the dialog). The confirm flow requires typing the graph **name** exactly (Enter only when it matches); failures show inline.
> 
> **Tests:** Settings screen test covers disabled confirm, partial name, mismatched Enter, and successful delete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb8a13bba161d6b1793356fae51fcbaea32cf5f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
