### PR TITLE
feat(desktop): polish the graph chooser and mobile onboarding UX

### DIFF
--- a/apps/desktop/src/components/graph-chooser.test.tsx
+++ b/apps/desktop/src/components/graph-chooser.test.tsx
@@ -141,13 +141,25 @@ describe('GraphChooser', () => {
     const user = userEvent.setup()
     render(<GraphChooser />, { wrapper })
 
-    const nameInput = await screen.findByRole('textbox', { name: 'Name' })
-    // The default "Notes" collides (case-insensitively) with the existing
-    // graph — creating it would land inside that folder, so Create refuses.
+    // Wait for the status to land (the existing graph is listed) so the
+    // compact create row — not the pre-status empty-container form — is the
+    // input under test. Next to an existing list the row starts empty.
+    await screen.findByRole('button', { name: 'Notes' })
+    const nameInput = screen.getByRole('textbox', { name: 'Name' })
+    expect(nameInput).toHaveValue('')
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled()
+
+    // "notes" collides (case-insensitively) with the existing graph —
+    // creating it would land inside that folder, so Create refuses and the
+    // field says why.
+    await user.type(nameInput, 'notes')
+    expect(nameInput).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByText('That name already exists in iCloud Drive.')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled()
 
     await user.clear(nameInput)
     await user.type(nameInput, 'Journal')
+    expect(screen.queryByText('That name already exists in iCloud Drive.')).not.toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: 'Create' }))
 
     await waitFor(() =>
@@ -164,7 +176,7 @@ describe('GraphChooser', () => {
     expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled()
   })
 
-  it('hides the iCloud card outside macOS builds', async () => {
+  it('hides the iCloud card outside macOS builds and drops the Mac-specific copy', async () => {
     vi.stubEnv('TAURI_ENV_PLATFORM', 'windows')
     render(<GraphChooser />, { wrapper })
 
@@ -172,6 +184,7 @@ describe('GraphChooser', () => {
       expect(screen.getByRole('heading', { name: 'A folder you choose' })).toBeInTheDocument(),
     )
     expect(screen.queryByRole('heading', { name: 'iCloud' })).not.toBeInTheDocument()
+    expect(screen.getByText(/any folder on this computer/)).toBeInTheDocument()
   })
 
   // The provider auto-opens the most recent graph on mount, so the chooser's

--- a/apps/desktop/src/components/graph-chooser.tsx
+++ b/apps/desktop/src/components/graph-chooser.tsx
@@ -1,10 +1,12 @@
-import { useState, type ReactElement, type ReactNode } from 'react'
+import { useId, useState, type ReactElement, type ReactNode } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { hasBridge, icloudStatus } from '@reflect/core'
 import { Cloud, Folder, FolderPlus } from 'lucide-react'
+import { InlineAlert } from '@/components/inline-alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Spinner } from '@/components/ui/spinner'
 import { useGraphColors } from '@/hooks/use-graph-colors'
 import { cleanGraphName, graphNameFromRoot, isGraphNameTaken } from '@/lib/graph-names'
 import { graphColorCss } from '@/lib/graph-colors'
@@ -34,7 +36,7 @@ export function GraphChooser(): ReactElement {
   return (
     <ChooserShell>
       <div className="space-y-1.5 text-center">
-        <h1 className="text-2xl font-semibold text-text">Welcome to Reflect</h1>
+        <h1 className="text-2xl font-semibold tracking-tight text-text">Welcome to Reflect</h1>
         <p className="text-sm text-text-secondary">
           Your notes are plain markdown files. Choose where to keep them.
         </p>
@@ -50,13 +52,13 @@ export function GraphChooser(): ReactElement {
 
         {/* The self-managed path: any folder, synced however the user likes. */}
         <section className="flex flex-col gap-4 rounded-xl border border-border bg-surface p-5 shadow-sm">
-          <div className="space-y-1.5">
-            <h2 className="text-base font-semibold text-text">A folder you choose</h2>
-            <p className="text-sm text-text-secondary">
-              Keep notes in any folder on this Mac. Sync with GitHub from Settings, or keep them
-              local.
-            </p>
-          </div>
+          <CardHeader
+            icon={<Folder aria-hidden className="size-4" strokeWidth={1.75} />}
+            title="A folder you choose"
+          >
+            Keep notes in any folder on this {icloudCapable ? 'Mac' : 'computer'}. Sync with
+            GitHub from Settings, or keep them local.
+          </CardHeader>
           <Button
             type="button"
             variant={icloudCapable ? 'outline' : 'default'}
@@ -70,16 +72,14 @@ export function GraphChooser(): ReactElement {
       </div>
 
       {error ? (
-        <p role="alert" className="text-center text-sm text-destructive">
+        <InlineAlert tone="error" className="mx-auto w-full max-w-sm text-center">
           {error}
-        </p>
+        </InlineAlert>
       ) : null}
 
       {recents.length > 0 ? (
         <div className="mx-auto w-full max-w-sm space-y-2">
-          <p className="px-2 text-[11px] font-semibold tracking-[0.08em] text-text-muted uppercase">
-            Recent
-          </p>
+          <p className="px-2 text-2xs font-medium tracking-wide text-text-muted">Recent</p>
           <ul className="space-y-px">
             {recents.map((recent) => {
               const color = colorFor(recent.root)
@@ -138,6 +138,50 @@ function ChooserShell({ children }: { children: ReactNode }): ReactElement {
 }
 
 /**
+ * The icon-chip card header shared by both storage cards — the same visual
+ * language as the mobile onboarding screen. A primary-tinted chip marks the
+ * recommended path; the neutral chip is the default.
+ */
+function CardHeader({
+  icon,
+  title,
+  badge,
+  tinted = false,
+  children,
+}: {
+  icon: ReactNode
+  title: string
+  badge?: ReactNode
+  tinted?: boolean
+  children: ReactNode
+}): ReactElement {
+  return (
+    <div className="flex items-start gap-3">
+      <div
+        className={cn(
+          'flex size-9 shrink-0 items-center justify-center rounded-lg',
+          tinted ? 'bg-primary/10 text-primary' : 'bg-muted text-text-secondary',
+        )}
+      >
+        {icon}
+      </div>
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="flex items-center gap-2">
+          <h2 className="text-base font-semibold text-text">{title}</h2>
+          {badge}
+        </div>
+        <p className="text-sm text-text-secondary">{children}</p>
+      </div>
+    </div>
+  )
+}
+
+/** What the iCloud card is busy doing: opening one listed graph (its root) or
+ * creating a new one — so only the pressed control shows the spinner. Roots
+ * are absolute paths, so `'create'` can never collide with one. */
+type IcloudBusy = string | 'create' | null
+
+/**
  * The recommended path. Lists every graph already in the container (a user
  * can keep several) with one-click Open, plus a name field to create a new
  * one; with no container (signed out / unentitled build) the copy is honest
@@ -150,16 +194,23 @@ function IcloudCard({
   openRecent: (root: string) => Promise<boolean>
   createAt: (root: string) => Promise<boolean>
 }): ReactElement {
-  const [name, setName] = useState('Notes')
-  const [busy, setBusy] = useState(false)
+  const [typedName, setTypedName] = useState<string | null>(null)
+  const [busy, setBusy] = useState<IcloudBusy>(null)
+  const nameId = useId()
   const { data: status } = useQuery({
     queryKey: ['icloud-status'],
     queryFn: icloudStatus,
     enabled: hasBridge(),
   })
 
+  const pending = busy !== null
   const available = status?.available === true
   const existing = status?.existingGraphRoots ?? []
+  // "Notes" pre-fills only the fresh-container form. Next to an existing
+  // list the row starts empty — a prefilled default would collide with the
+  // usual first graph ("Notes") and paint the screen invalid before the
+  // user touched it.
+  const name = typedName ?? (existing.length > 0 ? '' : 'Notes')
   const cleanName = cleanGraphName(name)
   // macOS folder names are case-insensitive — a same-named create would
   // land inside the existing graph instead of next to it.
@@ -169,36 +220,35 @@ function IcloudCard({
     if (status?.documentsRoot == null || cleanName === null || nameTaken) {
       return
     }
-    setBusy(true)
+    setBusy('create')
     try {
       await createAt(`${status.documentsRoot}/${cleanName}`)
     } finally {
-      setBusy(false)
+      setBusy(null)
     }
   }
 
   function open(root: string): void {
-    setBusy(true)
-    void openRecent(root).finally(() => setBusy(false))
+    setBusy(root)
+    void openRecent(root).finally(() => setBusy(null))
   }
 
   return (
     <section className="flex flex-col gap-4 rounded-xl border border-border bg-surface p-5 shadow-sm">
-      <div className="space-y-1.5">
-        <div className="flex items-center gap-2">
-          <h2 className="text-base font-semibold text-text">iCloud</h2>
-          <Badge variant="secondary">Recommended</Badge>
-        </div>
-        <p className="text-sm text-text-secondary">
-          {existing.length > 0
-            ? 'Your notes are already in iCloud.'
-            : available
-              ? 'Syncs across your Mac and iPhone. Backed up automatically.'
-              : status === undefined
-                ? 'Checking iCloud…'
-                : 'Sign in to iCloud on this Mac to sync your notes across devices.'}
-        </p>
-      </div>
+      <CardHeader
+        icon={<Cloud aria-hidden className="size-4" strokeWidth={1.75} />}
+        title="iCloud"
+        badge={<Badge variant="secondary">Recommended</Badge>}
+        tinted
+      >
+        {existing.length > 0
+          ? 'Your notes are already in iCloud.'
+          : available
+            ? 'Syncs across your Mac and iPhone. Backed up automatically.'
+            : status === undefined
+              ? 'Checking iCloud…'
+              : 'Sign in to iCloud on this Mac to sync your notes across devices.'}
+      </CardHeader>
       {existing.length > 0 ? (
         <ul className="space-y-1.5">
           {existing.map((root) => (
@@ -207,10 +257,14 @@ function IcloudCard({
                 type="button"
                 variant="outline"
                 className="w-full justify-start"
-                disabled={busy}
+                disabled={pending}
                 onClick={() => open(root)}
               >
-                <Cloud aria-hidden strokeWidth={1.75} />
+                {busy === root ? (
+                  <Spinner />
+                ) : (
+                  <Cloud aria-hidden strokeWidth={1.75} />
+                )}
                 <span className="truncate">{graphNameFromRoot(root, 'your notes')}</span>
               </Button>
             </li>
@@ -220,50 +274,62 @@ function IcloudCard({
       {existing.length > 0 ? (
         // Compact create row under the list: a new graph next to the
         // existing ones is the secondary action here, not the headline.
-        <div className="mt-auto flex gap-2">
-          <Input
-            aria-label="Name"
-            placeholder="New name"
-            value={name}
-            disabled={busy}
-            onChange={(event) => setName(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter') {
-                void create()
-              }
-            }}
-          />
-          <Button
-            type="button"
-            variant="outline"
-            className="shrink-0"
-            disabled={busy || cleanName === null || nameTaken}
-            onClick={() => void create()}
-          >
-            Create
-          </Button>
+        <div className="mt-auto space-y-1.5">
+          <div className="flex gap-2">
+            <Input
+              aria-label="Name"
+              placeholder="New name"
+              value={name}
+              disabled={pending}
+              aria-invalid={nameTaken}
+              onChange={(event) => setTypedName(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  void create()
+                }
+              }}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              className="shrink-0"
+              disabled={pending || cleanName === null || nameTaken}
+              onClick={() => void create()}
+            >
+              {busy === 'create' ? <Spinner /> : null}
+              Create
+            </Button>
+          </div>
+          {nameTaken ? (
+            <p className="text-xs text-destructive">That name already exists in iCloud Drive.</p>
+          ) : null}
         </div>
       ) : (
         <div className="mt-auto space-y-2">
-          <Input
-            aria-label="Name"
-            value={name}
-            disabled={!available || busy}
-            onChange={(event) => setName(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter') {
-                void create()
-              }
-            }}
-          />
+          <div className="space-y-1.5">
+            <label htmlFor={nameId} className="text-xs font-medium text-text-secondary">
+              Name
+            </label>
+            <Input
+              id={nameId}
+              value={name}
+              disabled={!available || pending}
+              onChange={(event) => setTypedName(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  void create()
+                }
+              }}
+            />
+          </div>
           <Button
             type="button"
             className="w-full"
-            disabled={!available || busy || cleanName === null}
+            disabled={!available || pending || cleanName === null}
             onClick={() => void create()}
           >
-            <Cloud aria-hidden strokeWidth={1.75} />
-            Create
+            {busy === 'create' ? <Spinner /> : <Cloud aria-hidden strokeWidth={1.75} />}
+            {busy === 'create' ? 'Setting up…' : 'Create'}
           </Button>
         </div>
       )}

--- a/apps/desktop/src/mobile/onboarding-screen.test.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.test.tsx
@@ -168,6 +168,23 @@ describe('MobileOnboardingScreen', () => {
     expect(completeOnboarding).toHaveBeenCalledWith('local')
   })
 
+  it('ignores Enter while a clone is already in flight (no overlapping clones)', async () => {
+    hangClone = true
+    render(<MobileOnboardingScreen />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sync with GitHub instead' }))
+    await waitFor(() => expect(screen.getByLabelText('Backup repository')).toBeTruthy())
+
+    const repoInput = screen.getByLabelText('Backup repository')
+    fireEvent.change(repoInput, { target: { value: 'notes' } })
+    fireEvent.keyDown(repoInput, { key: 'Enter' })
+    await waitFor(() => expect(cloned).toHaveLength(1))
+
+    fireEvent.keyDown(repoInput, { key: 'Enter' })
+    fireEvent.keyDown(repoInput, { key: 'Enter' })
+    expect(cloned).toHaveLength(1)
+  })
+
   it('disables Back while a clone is in flight (can’t leave it running)', async () => {
     hangClone = true
     render(<MobileOnboardingScreen />)

--- a/apps/desktop/src/mobile/onboarding-screen.test.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.test.tsx
@@ -150,6 +150,24 @@ describe('MobileOnboardingScreen', () => {
     expect(completeOnboarding).toHaveBeenCalledWith('local')
   })
 
+  it('submits the repo step from the keyboard (Enter in the input)', async () => {
+    render(<MobileOnboardingScreen />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sync with GitHub instead' }))
+    await waitFor(() => expect(screen.getByLabelText('Backup repository')).toBeTruthy())
+
+    const repoInput = screen.getByLabelText('Backup repository')
+    fireEvent.change(repoInput, { target: { value: 'notes' } })
+    fireEvent.keyDown(repoInput, { key: 'Enter' })
+
+    await waitFor(() =>
+      expect(cloned).toEqual([
+        { url: 'https://github.com/alex/notes.git', path: '/Documents', token: 'ghp_abc' },
+      ]),
+    )
+    expect(completeOnboarding).toHaveBeenCalledWith('local')
+  })
+
   it('disables Back while a clone is in flight (can’t leave it running)', async () => {
     hangClone = true
     render(<MobileOnboardingScreen />)

--- a/apps/desktop/src/mobile/onboarding-screen.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.tsx
@@ -11,6 +11,7 @@ import { InlineAlert } from '@/components/inline-alert'
 import { GithubAuthStep } from '@/components/settings/github-auth-step'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Spinner } from '@/components/ui/spinner'
 import { useAsyncAction } from '@/hooks/use-async-action'
 import {
   cleanGraphName,
@@ -23,6 +24,11 @@ import { providerFetch } from '@/lib/provider-fetch'
 import { useGraph } from '@/providers/graph-provider'
 
 type Step = 'choose' | 'auth' | 'repo'
+
+/** Which control kicked off the in-flight choice, so only that one shows the
+ * spinner/pending label (every button still disables). Container graph roots
+ * are absolute paths, so the fixed tags can never collide with one. */
+type PendingChoice = string | 'icloud-create' | 'local' | 'clone' | null
 
 /**
  * The mobile first-run screen (Plans 19/21) — shown until the user picks
@@ -46,7 +52,8 @@ export function MobileOnboardingScreen(): ReactElement {
   const { mobileStorageInfo, completeOnboarding } = useGraph()
   const action = useAsyncAction()
   const [step, setStep] = useState<Step>('choose')
-  const [icloudName, setIcloudName] = useState('Notes')
+  const [pendingChoice, setPendingChoice] = useState<PendingChoice>(null)
+  const [typedIcloudName, setTypedIcloudName] = useState<string | null>(null)
   const [repoInput, setRepoInput] = useState('')
   const [user, setUser] = useState<GithubUser | null>(null)
   const icloudNameId = useId()
@@ -54,25 +61,34 @@ export function MobileOnboardingScreen(): ReactElement {
   const icloudDocumentsRoot = mobileStorageInfo?.icloudDocumentsRoot ?? null
   const icloudReady = icloudDocumentsRoot !== null
   const icloudGraphs = mobileStorageInfo?.icloudGraphRoots ?? []
+  // "Notes" pre-fills only a fresh container. Next to an existing list the
+  // row starts empty — a prefilled default would collide with the usual
+  // first graph ("Notes") and paint the screen invalid before any input.
+  const icloudName = typedIcloudName ?? (icloudGraphs.length > 0 ? '' : 'Notes')
   const cleanIcloudName = cleanGraphName(icloudName)
   const icloudNameTaken =
     cleanIcloudName !== null && isGraphNameTaken(cleanIcloudName, icloudGraphs)
 
+  function runChoice(choice: Exclude<PendingChoice, null>, task: () => Promise<void>): void {
+    setPendingChoice(choice)
+    void action.run(task).finally(() => setPendingChoice(null))
+  }
+
   function openIcloudGraph(root: string): void {
-    void action.run(() => completeOnboarding('icloud', root))
+    runChoice(root, () => completeOnboarding('icloud', root))
   }
 
   function createIcloudGraph(): void {
     if (icloudDocumentsRoot === null || cleanIcloudName === null || icloudNameTaken) {
       return
     }
-    void action.run(() =>
+    runChoice('icloud-create', () =>
       completeOnboarding('icloud', graphRootForName(icloudDocumentsRoot, cleanIcloudName)),
     )
   }
 
   function keepOnDevice(): void {
-    void action.run(() => completeOnboarding('local'))
+    runChoice('local', () => completeOnboarding('local'))
   }
 
   function downloadAndOpen(): void {
@@ -93,7 +109,7 @@ export function MobileOnboardingScreen(): ReactElement {
       action.setError('No graph folder available.')
       return
     }
-    void action.run(async () => {
+    runChoice('clone', async () => {
       const token = await getGithubToken(providerFetch)
       if (token === null) {
         throw new ReflectError('auth', 'Sign in to GitHub first')
@@ -114,7 +130,7 @@ export function MobileOnboardingScreen(): ReactElement {
     >
       <div className="my-auto flex w-full flex-col gap-6">
         <div className="flex flex-col gap-1.5 text-center">
-          <h1 className="text-lg font-semibold">Welcome to Reflect</h1>
+          <h1 className="text-xl font-semibold tracking-tight">Welcome to Reflect</h1>
           <p className="text-sm text-text-muted">
             {step === 'choose'
               ? 'Your notes are plain markdown files. Choose where to keep them.'
@@ -156,7 +172,11 @@ export function MobileOnboardingScreen(): ReactElement {
                           onClick={() => openIcloudGraph(root)}
                           disabled={action.pending}
                         >
-                          <FolderOpen aria-hidden strokeWidth={1.75} />
+                          {pendingChoice === root ? (
+                            <Spinner />
+                          ) : (
+                            <FolderOpen aria-hidden strokeWidth={1.75} />
+                          )}
                           <span className="truncate">{graphNameFromRoot(root, root)}</span>
                         </Button>
                       </li>
@@ -172,7 +192,9 @@ export function MobileOnboardingScreen(): ReactElement {
                     <Input
                       id={icloudNameId}
                       value={icloudName}
-                      onChange={(event) => setIcloudName(event.target.value)}
+                      placeholder={icloudGraphs.length > 0 ? 'New name' : undefined}
+                      enterKeyHint="go"
+                      onChange={(event) => setTypedIcloudName(event.target.value)}
                       onKeyDown={(event) => {
                         if (event.key === 'Enter') {
                           createIcloudGraph()
@@ -187,8 +209,12 @@ export function MobileOnboardingScreen(): ReactElement {
                       onClick={createIcloudGraph}
                       disabled={action.pending || cleanIcloudName === null || icloudNameTaken}
                     >
-                      <Plus aria-hidden strokeWidth={1.75} />
-                      {action.pending ? 'Setting up…' : 'Create'}
+                      {pendingChoice === 'icloud-create' ? (
+                        <Spinner />
+                      ) : (
+                        <Plus aria-hidden strokeWidth={1.75} />
+                      )}
+                      {pendingChoice === 'icloud-create' ? 'Setting up…' : 'Create'}
                     </Button>
                   </div>
                 </div>
@@ -205,8 +231,12 @@ export function MobileOnboardingScreen(): ReactElement {
               onClick={keepOnDevice}
               disabled={action.pending}
             >
-              <HardDrive aria-hidden strokeWidth={1.75} />
-              {action.pending ? 'Setting up…' : 'Keep notes on this device'}
+              {pendingChoice === 'local' ? (
+                <Spinner />
+              ) : (
+                <HardDrive aria-hidden strokeWidth={1.75} />
+              )}
+              {pendingChoice === 'local' ? 'Setting up…' : 'Keep notes on this device'}
             </Button>
             {!icloudReady ? (
               <p className="text-center text-xs text-text-muted">
@@ -243,12 +273,25 @@ export function MobileOnboardingScreen(): ReactElement {
                 autoFocus
                 value={repoInput}
                 onChange={(event) => setRepoInput(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    downloadAndOpen()
+                  }
+                }}
                 placeholder={user !== null ? `${user.login}/…` : 'owner/name'}
+                enterKeyHint="go"
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
               />
             </label>
             <Button onClick={downloadAndOpen} disabled={action.pending}>
-              <GitBranch aria-hidden strokeWidth={1.75} />
-              {action.pending ? 'Downloading…' : 'Download & open'}
+              {pendingChoice === 'clone' ? (
+                <Spinner />
+              ) : (
+                <GitBranch aria-hidden strokeWidth={1.75} />
+              )}
+              {pendingChoice === 'clone' ? 'Downloading…' : 'Download & open'}
             </Button>
             <LinkButton onClick={() => setStep('choose')} disabled={action.pending}>
               Back

--- a/apps/desktop/src/mobile/onboarding-screen.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.tsx
@@ -92,6 +92,9 @@ export function MobileOnboardingScreen(): ReactElement {
   }
 
   function downloadAndOpen(): void {
+    if (action.pending) {
+      return // Enter in the repo field must not overlap a running clone.
+    }
     // A bare name belongs to the signed-in account — the common case never
     // needs the owner typed (mirrors the desktop restore dialog).
     const trimmed = repoInput.trim()
@@ -272,6 +275,7 @@ export function MobileOnboardingScreen(): ReactElement {
               <Input
                 autoFocus
                 value={repoInput}
+                disabled={action.pending}
                 onChange={(event) => setRepoInput(event.target.value)}
                 onKeyDown={(event) => {
                   if (event.key === 'Enter') {


### PR DESCRIPTION
## Problem

The desktop graph chooser and the mobile onboarding screen are the same decision ("where do your notes live?") but didn't share a visual language, and both had small UX holes:

- When the iCloud container already held a graph named **Notes**, the name field — pre-filled with "Notes" — painted the screen invalid (or, on desktop, just silently disabled **Create**) before the user had touched anything, with no explanation on desktop at all.
- The desktop folder card said "any folder on this Mac" on Windows/Linux builds too.
- Pending states were coarse: on mobile, *every* choice button flipped to "Setting up…" regardless of which one was tapped; on desktop there was no pending feedback at all.
- The mobile GitHub repo step couldn't be submitted from the keyboard, and iOS autocorrect/auto-capitalize mangled repo names.
- Assorted design-system drift: uppercase "RECENT" header (sentence case is the rule), bare red error text instead of the shared `InlineAlert`.

## Changes

**Desktop `graph-chooser.tsx`**
- Icon-chip card headers (shared `CardHeader` helper), primary-tinted for the recommended iCloud path — the same visual language as mobile onboarding.
- Inline "That name already exists in iCloud Drive." + `aria-invalid` when the typed name collides, instead of a silently disabled button.
- The create row next to an existing graph list starts **empty** (placeholder "New name"); "Notes" pre-fills only the fresh-container form, so the default can never render pre-invalidated.
- Per-control busy state (`IcloudBusy`): only the pressed Open/Create control shows a spinner; Create swaps to "Setting up…".
- Platform-correct copy ("Mac" only on macOS), visible **Name** label on the fresh-container form, errors through `InlineAlert`, sentence-case "Recent" header, `tracking-tight` heading.

**Mobile `onboarding-screen.tsx`**
- Same empty-default + collision-message behavior for the container name field.
- Per-choice pending (`PendingChoice`): only the tapped control shows the spinner/pending label — previously "Keep notes on this device" and "Create" both said "Setting up…" whichever one was running.
- Repo input submits on Enter, with `enterKeyHint="go"`, `autoCapitalize="none"`, `autoCorrect="off"`, `spellCheck={false}`.
- iCloud name field gets `enterKeyHint="go"`; heading aligned with desktop (`text-xl tracking-tight`).

## Verification

- `pnpm test --run` on `graph-chooser.test.tsx`, `onboarding-screen.test.tsx`, `graph-provider.test.tsx` — 37 passed, including new coverage for the collision message/`aria-invalid`, the empty-default create row, the non-Mac folder copy, and Enter-submit on the repo step.
- `pnpm check` (typecheck + lint) clean.
- Visually verified both screens in the browser dev harness (light + dark, iCloud list / fresh-container / recents / error states) via temporary preview scaffolding that is not part of this diff.

## Risk

UI-only; no data-shape, IPC, or provider changes. The one behavioral nuance: the create-name default next to an existing list changed from "Notes" to empty — `cleanGraphName` already refuses empty names, so Create stays disabled until a valid name is typed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to onboarding/chooser screens; graph creation still uses the same name validation helpers with no IPC or provider contract changes.
> 
> **Overview**
> Aligns the desktop **graph chooser** and **mobile onboarding** first-run flows with shared icon-chip card headers, clearer iCloud name handling, and finer-grained loading feedback.
> 
> **iCloud create naming:** When graphs already exist in the container, the create field starts **empty** (placeholder “New name”) instead of defaulting to “Notes”, avoiding a pre-invalid state. Collisions now show **“That name already exists in iCloud Drive.”** with `aria-invalid` on desktop (mobile already had similar messaging).
> 
> **Pending UI:** Desktop tracks which iCloud action is in flight (`IcloudBusy` / mobile `PendingChoice`) so only the tapped Open/Create/clone control shows a **Spinner** and pending label; other controls stay disabled without misleading copy.
> 
> **Other UX:** Desktop folder card copy uses **“computer”** on non-macOS; errors use **`InlineAlert`**; GitHub repo step on mobile submits on **Enter**, blocks duplicate clones while pending, and disables autocorrect/capitalize on repo input. Tests cover collision UI, platform copy, Enter submit, and overlapping clone guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e629da12e678288bcc5562fc2fd7fb78e4ebfbc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->