### PR TITLE
feat: resolve meeting attendees by invite email

### DIFF
--- a/apps/desktop/src-tauri/src/db/tests.rs
+++ b/apps/desktop/src-tauri/src/db/tests.rs
@@ -168,7 +168,12 @@ fn note_emails_apply_move_and_cascade() {
     apply_note(&conn, &person).unwrap();
 
     // Display casing and the folded match key are stored side by side, like tags.
-    let rows = run_query(&conn, "SELECT note_path, email, email_key FROM note_emails", &[]).unwrap();
+    let rows = run_query(
+        &conn,
+        "SELECT note_path, email, email_key FROM note_emails",
+        &[],
+    )
+    .unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0]["email"], Value::from("Jane@Corp.com"));
     assert_eq!(rows[0]["email_key"], Value::from("jane@corp.com"));

--- a/apps/desktop/src-tauri/src/db/tests.rs
+++ b/apps/desktop/src-tauri/src/db/tests.rs
@@ -10,7 +10,8 @@ use super::embed_write::{apply_chunks, remove_chunks, EmbeddedChunk};
 use super::migrations::{migrate, migrate_to, open_in_memory, open_index_at, validate_migrations};
 use super::query::run_query;
 use super::write::{
-    apply_note, clear_index, move_note, IndexedLink, IndexedNote, IndexedTag, IndexedTask,
+    apply_note, clear_index, move_note, IndexedEmail, IndexedLink, IndexedNote, IndexedTag,
+    IndexedTask,
 };
 
 fn migrated() -> Connection {
@@ -44,6 +45,7 @@ fn note(path: &str, title: &str, links: Vec<IndexedLink>) -> IndexedNote {
         links,
         tags: vec![],
         aliases: vec![],
+        emails: vec![],
         assets: vec![],
         tasks: vec![],
     }
@@ -78,7 +80,7 @@ fn migrations_are_valid_and_idempotent() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 15); // applied migrations (0001 through 0015)
+    assert_eq!(version, 16); // applied migrations (0001 through 0016)
     migrate(&mut conn).expect("re-running to_latest is a no-op");
 }
 
@@ -153,6 +155,39 @@ fn preview_and_tag_keys_round_trip() {
     let tags = run_query(&conn, "SELECT tag, tag_key FROM tags", &[]).unwrap();
     assert_eq!(tags[0]["tag"], Value::from("Café"));
     assert_eq!(tags[0]["tag_key"], Value::from("café"));
+}
+
+#[test]
+fn note_emails_apply_move_and_cascade() {
+    let conn = migrated();
+    let mut person = note("notes/jane-doe.md", "Jane Doe", vec![]);
+    person.emails = vec![IndexedEmail {
+        email: "Jane@Corp.com".to_string(),
+        email_key: "jane@corp.com".to_string(),
+    }];
+    apply_note(&conn, &person).unwrap();
+
+    // Display casing and the folded match key are stored side by side, like tags.
+    let rows = run_query(&conn, "SELECT note_path, email, email_key FROM note_emails", &[]).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["email"], Value::from("Jane@Corp.com"));
+    assert_eq!(rows[0]["email_key"], Value::from("jane@corp.com"));
+
+    // A rename carries the rows to the new path (inside the same deferred-FK
+    // transaction the command layer would open).
+    conn.execute_batch("BEGIN; PRAGMA defer_foreign_keys = ON;")
+        .unwrap();
+    move_note(&conn, "notes/jane-doe.md", "notes/jane.md").unwrap();
+    conn.execute_batch("COMMIT;").unwrap();
+    let moved = run_query(&conn, "SELECT note_path FROM note_emails", &[]).unwrap();
+    assert_eq!(moved[0]["note_path"], Value::from("notes/jane.md"));
+
+    // Re-applying with no emails replaces the rows rather than accreting.
+    let mut renamed = note("notes/jane.md", "Jane Doe", vec![]);
+    renamed.emails = vec![];
+    apply_note(&conn, &renamed).unwrap();
+    let cleared = run_query(&conn, "SELECT note_path FROM note_emails", &[]).unwrap();
+    assert!(cleared.is_empty());
 }
 
 #[test]
@@ -680,7 +715,7 @@ fn open_index_at_creates_migrates_and_reopens() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 15);
+    assert_eq!(version, 16);
     let journal: String = conn
         .query_row("PRAGMA journal_mode", [], |row| row.get(0))
         .unwrap();

--- a/apps/desktop/src-tauri/src/db/write.rs
+++ b/apps/desktop/src-tauri/src/db/write.rs
@@ -44,6 +44,8 @@ pub struct IndexedNote {
     pub(super) links: Vec<IndexedLink>,
     pub(super) tags: Vec<IndexedTag>,
     pub(super) aliases: Vec<IndexedAlias>,
+    /// Emails the note owns via `- Email:` contact-field bullets.
+    pub(super) emails: Vec<IndexedEmail>,
     pub(super) assets: Vec<String>,
     pub(super) tasks: Vec<IndexedTask>,
 }
@@ -71,6 +73,13 @@ pub(super) struct IndexedTag {
 pub(super) struct IndexedAlias {
     pub(super) alias: String,
     pub(super) alias_key: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct IndexedEmail {
+    pub(super) email: String,
+    pub(super) email_key: String,
 }
 
 /// One GFM checkbox (Plan 18). `marker_offset` is the `[`'s character offset in
@@ -153,6 +162,14 @@ pub(super) fn apply_note(conn: &Connection, note: &IndexedNote) -> AppResult<()>
         }
     }
     {
+        let mut stmt = conn.prepare_cached(
+            "INSERT INTO note_emails(note_path, email, email_key) VALUES(?1, ?2, ?3)",
+        )?;
+        for email in &note.emails {
+            stmt.execute(params![note.path, email.email, email.email_key])?;
+        }
+    }
+    {
         let mut stmt =
             conn.prepare_cached("INSERT INTO assets(note_path, asset_path) VALUES(?1, ?2)")?;
         for asset in &note.assets {
@@ -222,6 +239,8 @@ pub(super) fn move_note(conn: &Connection, from: &str, to: &str) -> AppResult<()
     conn.prepare_cached("UPDATE tags SET note_path = ?2 WHERE note_path = ?1")?
         .execute(params![from, to])?;
     conn.prepare_cached("UPDATE aliases SET note_path = ?2 WHERE note_path = ?1")?
+        .execute(params![from, to])?;
+    conn.prepare_cached("UPDATE note_emails SET note_path = ?2 WHERE note_path = ?1")?
         .execute(params![from, to])?;
     conn.prepare_cached("UPDATE assets SET note_path = ?2 WHERE note_path = ?1")?
         .execute(params![from, to])?;

--- a/apps/desktop/src/components/context-sidebar/add-meeting-dialog.tsx
+++ b/apps/desktop/src/components/context-sidebar/add-meeting-dialog.tsx
@@ -6,6 +6,7 @@ import {
   defaultAttendees,
   errorMessage,
   isContactsReadable,
+  resolveMeetingAttendees,
   type CalendarEvent,
   type MeetingAttendee,
 } from '@reflect/core'
@@ -65,6 +66,48 @@ export function AddMeetingDialog({ date, event, onClose }: AddMeetingDialogProps
       }
     }
   }, [])
+
+  // Upgrade the prefilled chips once attendee resolution answers: an invite
+  // email an existing note owns swaps the calendar's spelling for the note
+  // title, so the chip shows exactly what submit will link. Chips are merged
+  // by their prefill name — anything the user removed stays removed, anything
+  // they added is untouched. Submit re-resolves authoritatively either way,
+  // so a failure (or a submit that beats this) only costs display polish.
+  useEffect(() => {
+    let cancelled = false
+    const upgradeAttendees = async (): Promise<void> => {
+      const lookupContacts =
+        settings.contactsEnabled && isContactsReadable(await contactsAuthorizationStatus())
+      const prefilled = defaultAttendees(event)
+      const resolved = await resolveMeetingAttendees(prefilled, lookupContacts)
+      if (cancelled) {
+        return
+      }
+      const upgrades = new Map(
+        prefilled.map((original, index) => [original.name, resolved[index] ?? original]),
+      )
+      setAttendees((current) => {
+        const seen = new Set<string>()
+        const merged: MeetingAttendee[] = []
+        for (const attendee of current) {
+          const upgraded = upgrades.get(attendee.name) ?? attendee
+          const key = upgraded.name.toLowerCase()
+          if (seen.has(key)) {
+            continue
+          }
+          seen.add(key)
+          merged.push(upgraded)
+        }
+        return merged
+      })
+    }
+    upgradeAttendees().catch((cause: unknown) => {
+      console.error('attendee resolution failed:', cause)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [event, settings.contactsEnabled])
 
   const addAttendee = (attendee: MeetingAttendee): void => {
     setAttendees((current) =>

--- a/apps/desktop/src/components/context-sidebar/daily-events-section.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/daily-events-section.test.tsx
@@ -30,11 +30,17 @@ window.HTMLElement.prototype.scrollIntoView = () => {}
 const addMeetingToDaily = vi.hoisted(() => vi.fn(async () => ({ appended: true, createdNotes: [] })))
 const suggestWikiTargets = vi.hoisted(() => vi.fn(async () => []))
 const contactLinkSuggestions = vi.hoisted(() => vi.fn(async () => []))
+// Identity by default: the email → note-title canonicalization is covered in
+// @reflect/core; here it is the seam the chip-upgrade effect renders through.
+const resolveMeetingAttendees = vi.hoisted(() =>
+  vi.fn(async (attendees: readonly unknown[]) => [...attendees]),
+)
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   addMeetingToDaily,
   suggestWikiTargets,
   contactLinkSuggestions,
+  resolveMeetingAttendees,
 }))
 
 const DATE = '2026-07-01'
@@ -97,6 +103,7 @@ beforeEach(() => {
   contactsAuthorization = 'unavailable'
   addMeetingToDaily.mockClear()
   addMeetingToDaily.mockResolvedValue({ appended: true, createdNotes: [] })
+  resolveMeetingAttendees.mockClear()
   window.sessionStorage.clear()
   queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   installFakeBridge()
@@ -231,6 +238,40 @@ describe('DailyEventsSection', () => {
         expect.objectContaining({
           attendees: [{ name: 'Ada Lovelace', email: 'ada@example.com' }],
           lookupContacts: true,
+        }),
+      ),
+    )
+  })
+
+  it('upgrades a prefilled chip to the note that owns its invite email', async () => {
+    resolveMeetingAttendees.mockResolvedValueOnce([
+      { name: 'Ada Lovelace', email: 'ada@example.com' },
+    ])
+    events = [
+      eventAt(9, {
+        title: 'Standup',
+        attendees: [
+          {
+            name: 'ada@example.com',
+            email: 'ada@example.com',
+            isCurrentUser: false,
+            isPerson: true,
+            status: 'accepted',
+          },
+        ],
+      }),
+    ]
+    renderSection()
+    fireEvent.click(await screen.findByRole('button', { name: /standup/i }))
+
+    await screen.findByText('Ada Lovelace')
+    expect(screen.queryByText('ada@example.com')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /add to daily note/i }))
+    await waitFor(() =>
+      expect(addMeetingToDaily).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attendees: [{ name: 'Ada Lovelace', email: 'ada@example.com' }],
         }),
       ),
     )

--- a/apps/desktop/src/dev/dev-index-db.test.ts
+++ b/apps/desktop/src/dev/dev-index-db.test.ts
@@ -33,6 +33,7 @@ function sampleNote(overrides: Partial<IndexedNote> = {}): IndexedNote {
     ],
     tags: [{ tag: 'book', tagKey: 'book' }],
     aliases: [],
+    emails: [{ email: 'Sample@Example.com', emailKey: 'sample@example.com' }],
     assets: [],
     tasks: [{ markerOffset: 40, text: 'Do the thing', raw: '- [ ] Do the thing', checked: false, dueDate: null }],
     ...overrides,
@@ -66,6 +67,11 @@ describe('createDevIndexDb', () => {
     const tasks = db.query('SELECT text, checked FROM tasks', [])
     expect(tasks).toEqual([{ text: 'Do the thing', checked: 0 }])
 
+    const emails = db.query('SELECT email, email_key FROM note_emails', [])
+    expect(emails).toEqual([
+      { email: 'Sample@Example.com', email_key: 'sample@example.com' },
+    ])
+
     const hits = db.query("SELECT path FROM search_fts WHERE search_fts MATCH 'sync'", [])
     expect(hits).toEqual([{ path: 'notes/sample.md' }])
   })
@@ -88,6 +94,9 @@ describe('createDevIndexDb', () => {
 
     expect(db.query('SELECT path FROM notes', [])).toEqual([{ path: 'notes/renamed.md' }])
     expect(db.query('SELECT note_path FROM tags', [])).toEqual([
+      { note_path: 'notes/renamed.md' },
+    ])
+    expect(db.query('SELECT note_path FROM note_emails', [])).toEqual([
       { note_path: 'notes/renamed.md' },
     ])
 

--- a/apps/desktop/src/dev/dev-index-db.ts
+++ b/apps/desktop/src/dev/dev-index-db.ts
@@ -130,6 +130,13 @@ export async function createDevIndexDb(): Promise<DevIndexDb> {
           alias.aliasKey,
         ])
       }
+      for (const email of note.emails) {
+        run(db, 'INSERT INTO note_emails(note_path, email, email_key) VALUES(?, ?, ?)', [
+          note.path,
+          email.email,
+          email.emailKey,
+        ])
+      }
       for (const asset of note.assets) {
         run(db, 'INSERT INTO assets(note_path, asset_path) VALUES(?, ?)', [note.path, asset])
       }
@@ -166,6 +173,7 @@ export async function createDevIndexDb(): Promise<DevIndexDb> {
         run(db, 'UPDATE links SET source_path = ? WHERE source_path = ?', [to, from])
         run(db, 'UPDATE tags SET note_path = ? WHERE note_path = ?', [to, from])
         run(db, 'UPDATE aliases SET note_path = ? WHERE note_path = ?', [to, from])
+        run(db, 'UPDATE note_emails SET note_path = ? WHERE note_path = ?', [to, from])
         run(db, 'UPDATE assets SET note_path = ? WHERE note_path = ?', [to, from])
         run(db, 'UPDATE tasks SET note_path = ? WHERE note_path = ?', [to, from])
         run(db, 'UPDATE embedding_chunks SET note_path = ? WHERE note_path = ?', [to, from])

--- a/crates/index-schema/migrations/0016_note_emails.sql
+++ b/crates/index-schema/migrations/0016_note_emails.sql
@@ -1,0 +1,19 @@
+-- Emails a note owns through `- Email:` contact-field bullets (v1's person
+-- template shape, also written by the contacts integration and the meeting
+-- flow's person-note pre-fill). A pure projection like tags/aliases: rebuilt
+-- per note write, ON DELETE CASCADE, moved explicitly on rename, rebuildable —
+-- nothing durable here, so no chat_* concerns.
+--
+-- This is the substrate for attendee → person-note resolution in the calendar
+-- flow: an invite email finds the note that owns it even when the calendar's
+-- display name (often the bare address) doesn't match the note title.
+CREATE TABLE note_emails (
+  note_path TEXT NOT NULL REFERENCES notes(path) ON DELETE CASCADE,
+  email     TEXT NOT NULL,
+  email_key TEXT NOT NULL,
+  PRIMARY KEY (note_path, email_key)
+);
+
+-- Resolution looks up by address and joins to notes for the title; the
+-- covering key index serves that read directly.
+CREATE INDEX note_emails_email_key ON note_emails(email_key);

--- a/crates/index-schema/src/lib.rs
+++ b/crates/index-schema/src/lib.rs
@@ -23,7 +23,7 @@ pub const INDEX_FILE: &str = "index.sqlite";
 /// `user_version` after every migration has run. Read-only consumers compare
 /// this against `PRAGMA user_version` to detect an index written by a newer
 /// (or older) app than they were built for.
-pub const LATEST_SCHEMA_VERSION: usize = 15;
+pub const LATEST_SCHEMA_VERSION: usize = 16;
 
 /// The `index_meta` key holding the TS-owned projection version (the rows'
 /// derivation version, distinct from the schema version above).
@@ -58,6 +58,7 @@ mod schema {
             M::up(include_str!("../migrations/0013_perf_indexes.sql")),
             M::up(include_str!("../migrations/0014_note_kind.sql")),
             M::up(include_str!("../migrations/0015_note_kind_invariant.sql")),
+            M::up(include_str!("../migrations/0016_note_emails.sql")),
         ])
     });
 

--- a/packages/core/src/actions/add-meeting.test.ts
+++ b/packages/core/src/actions/add-meeting.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { noteExists, readNote, writeNote } from '../graph/commands'
 import { createNoteWithTitle } from '../graph/create-note'
-import { resolveWikiTarget } from '../indexing/queries'
+import { noteTitleOwningEmail, resolveWikiTarget } from '../indexing/queries'
 import { setBridge } from '../ipc/bridge'
 import { resolved, unresolved } from '../markdown/resolve'
 import { addMeetingToDaily, meetingLine, type AddMeetingInput } from './add-meeting'
@@ -15,6 +15,7 @@ vi.mock('../graph/create-note', () => ({
   createNoteWithTitle: vi.fn(),
 }))
 vi.mock('../indexing/queries', () => ({
+  noteTitleOwningEmail: vi.fn(),
   resolveWikiTarget: vi.fn(),
 }))
 
@@ -23,6 +24,7 @@ const readNoteMock = vi.mocked(readNote)
 const writeNoteMock = vi.mocked(writeNote)
 const createNoteMock = vi.mocked(createNoteWithTitle)
 const resolveMock = vi.mocked(resolveWikiTarget)
+const owningNoteMock = vi.mocked(noteTitleOwningEmail)
 
 const DAILY = 'daily/2026-07-01.md'
 const GENERATION = 3
@@ -46,6 +48,7 @@ beforeEach(() => {
   noteExistsMock.mockResolvedValue(false)
   createNoteMock.mockImplementation(async (title: string) => `notes/${title.toLowerCase()}.md`)
   resolveMock.mockImplementation(async (target) => unresolved(target))
+  owningNoteMock.mockResolvedValue(null)
 })
 
 describe('meetingLine', () => {
@@ -212,6 +215,59 @@ describe('addMeetingToDaily', () => {
   })
 })
 
+describe('addMeetingToDaily attendee resolution', () => {
+  it('links the note owning the invite email instead of minting a duplicate', async () => {
+    owningNoteMock.mockImplementation(async (email) =>
+      email === 'jane@corp.com' ? 'Jane Doe' : null,
+    )
+    resolveMock.mockImplementation(async (target) =>
+      target === 'Jane Doe' ? resolved('notes/jane-doe.md') : unresolved(target),
+    )
+    const outcome = await addMeetingToDaily(
+      input({
+        attendees: [{ name: 'jane@corp.com', email: 'jane@corp.com' }],
+        backlinkMeeting: false,
+      }),
+    )
+    expect(writeNoteMock).toHaveBeenCalledWith(
+      DAILY,
+      '## Meetings\n\n- Met with [[Jane Doe]] for Standup\n',
+      GENERATION,
+    )
+    expect(createNoteMock).not.toHaveBeenCalled()
+    expect(outcome.createdNotes).toEqual([])
+  })
+
+  it('collapses two spellings of one person once their emails resolve to the same note', async () => {
+    owningNoteMock.mockResolvedValue('Jane Doe')
+    resolveMock.mockImplementation(async (target) =>
+      target === 'Jane Doe' ? resolved('notes/jane-doe.md') : unresolved(target),
+    )
+    await addMeetingToDaily(
+      input({
+        attendees: [
+          { name: 'jane@corp.com', email: 'jane@corp.com' },
+          { name: 'Doe, Jane', email: 'jane.doe@home.example' },
+        ],
+        backlinkMeeting: false,
+      }),
+    )
+    expect(writeNoteMock).toHaveBeenCalledWith(
+      DAILY,
+      '## Meetings\n\n- Met with [[Jane Doe]] for Standup\n',
+      GENERATION,
+    )
+  })
+
+  it('resolution errors fail the call loudly rather than writing a duplicate-prone line', async () => {
+    owningNoteMock.mockRejectedValue(new Error('index unavailable'))
+    await expect(
+      addMeetingToDaily(input({ attendees: [{ name: 'Jane', email: 'jane@corp.com' }] })),
+    ).rejects.toThrow('index unavailable')
+    expect(createNoteMock).not.toHaveBeenCalled()
+  })
+})
+
 describe('addMeetingToDaily contact pre-fill', () => {
   const ADA = { name: 'Ada Lovelace', email: 'ada@example.com' }
 
@@ -242,6 +298,35 @@ describe('addMeetingToDaily contact pre-fill', () => {
       GENERATION,
       '- Type: #person\n- Email: ada@example.com\n- Phone: +1 555-0100',
     )
+  })
+
+  it('names and pre-fills the created note from the contact when the calendar only knew the address', async () => {
+    installContactsBridge([
+      {
+        fullName: 'Ada Lovelace',
+        givenName: 'Ada',
+        familyName: 'Lovelace',
+        emails: ['ada@example.com'],
+        phones: [],
+      },
+    ])
+    const outcome = await addMeetingToDaily(
+      input({
+        attendees: [{ name: 'ada@example.com', email: 'ada@example.com' }],
+        lookupContacts: true,
+      }),
+    )
+    expect(writeNoteMock).toHaveBeenCalledWith(
+      DAILY,
+      expect.stringContaining('[[Ada Lovelace]]'),
+      GENERATION,
+    )
+    expect(createNoteMock).toHaveBeenCalledWith(
+      'Ada Lovelace',
+      GENERATION,
+      '- Type: #person\n- Email: ada@example.com',
+    )
+    expect(outcome.createdNotes).toContain('Ada Lovelace')
   })
 
   it('creates the bare typed note on a lookup miss, as v1 did', async () => {

--- a/packages/core/src/actions/add-meeting.ts
+++ b/packages/core/src/actions/add-meeting.ts
@@ -24,8 +24,9 @@ import { resolveMeetingAttendees } from './resolve-attendees'
  * v1), not a link — only attendees get `[[Person]]` links and notes.
  *
  * Attendees resolve by invite email first ({@link resolveMeetingAttendees}):
- * a note owning the address via a `- Email:` bullet supplies the link name,
- * so a person keeps one note however the calendar spelled them. With the
+ * a `#person`-tagged note owning the address via a `- Email:` bullet supplies
+ * the link name, so a person keeps one note however the calendar spelled
+ * them. With the
  * contacts integration on (docs/porting/contacts-integration.md), a fresh
  * person note is named and pre-filled from the Apple Contacts entry matching
  * the attendee's invite email. After that, they are ordinary notes; nothing

--- a/packages/core/src/actions/add-meeting.ts
+++ b/packages/core/src/actions/add-meeting.ts
@@ -9,6 +9,7 @@ import { appendUnderHeading, wikiLinkSafe } from '../markdown/edit'
 import { parseNote } from '../markdown/extract'
 import { foldKey } from '../markdown/keys'
 import { slugForTitle } from '../markdown/slug'
+import { resolveMeetingAttendees } from './resolve-attendees'
 
 /**
  * "Add to daily note" for a calendar event — the write half of the calendar
@@ -20,11 +21,15 @@ import { slugForTitle } from '../markdown/slug'
  *
  * and creates the notes those links resolve to when they don't exist yet.
  * With "Create backlinked note" off, the meeting name is plain text (as in
- * v1), not a link — only attendees get `[[Person]]` links and notes. With the
+ * v1), not a link — only attendees get `[[Person]]` links and notes.
+ *
+ * Attendees resolve by invite email first ({@link resolveMeetingAttendees}):
+ * a note owning the address via a `- Email:` bullet supplies the link name,
+ * so a person keeps one note however the calendar spelled them. With the
  * contacts integration on (docs/porting/contacts-integration.md), a fresh
- * person note is pre-filled from the Apple Contacts entry matching the
- * attendee's invite email. After that, they are ordinary notes; nothing stays
- * tied to the calendar, and no event metadata is persisted beyond this
+ * person note is named and pre-filled from the Apple Contacts entry matching
+ * the attendee's invite email. After that, they are ordinary notes; nothing
+ * stays tied to the calendar, and no event metadata is persisted beyond this
  * markdown.
  *
  * Wiki links resolve by title, so "one note per meeting title" holds by
@@ -224,11 +229,7 @@ export async function addMeetingToDaily(input: AddMeetingInput): Promise<AddMeet
   if (title === '') {
     throw new Error('a meeting needs a name')
   }
-  // An attendee spelled like the meeting itself (a shared mailbox, a 1:1
-  // named after the person) would just duplicate the link — drop it.
-  const attendees = normalizeAttendees(input.attendees).filter(
-    (attendee) => attendee.name.toLowerCase() !== title.toLowerCase(),
-  )
+  const lookupContacts = input.lookupContacts ?? false
 
   const daily = dailyPath(input.date)
   const source = await noteSource(daily, input.generation)
@@ -240,6 +241,14 @@ export async function addMeetingToDaily(input: AddMeetingInput): Promise<AddMeet
   if (input.backlinkMeeting && meetingAlreadyLinked(source, title)) {
     return { appended: false, createdNotes: [] }
   }
+  // Canonicalize by invite email before deduplicating: an attendee whose
+  // address an existing note owns takes that note's title, so two spellings
+  // of one person collapse here and the link below lands on their note. An
+  // attendee spelled like the meeting itself (a shared mailbox, a 1:1 named
+  // after the person) would just duplicate the link — drop it.
+  const attendees = normalizeAttendees(
+    await resolveMeetingAttendees(input.attendees, lookupContacts),
+  ).filter((attendee) => attendee.name.toLowerCase() !== title.toLowerCase())
   const line = meetingLine({
     title,
     attendees: attendees.map((attendee) => attendee.name),
@@ -257,7 +266,7 @@ export async function addMeetingToDaily(input: AddMeetingInput): Promise<AddMeet
     if (await titleHasNote(attendee.name)) {
       continue
     }
-    const body = await personNoteBody(attendee, input.lookupContacts ?? false)
+    const body = await personNoteBody(attendee, lookupContacts)
     await createNoteWithTitle(attendee.name, input.generation, body)
     createdNotes.push(attendee.name)
   }

--- a/packages/core/src/actions/resolve-attendees.test.ts
+++ b/packages/core/src/actions/resolve-attendees.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { resolveAttendeeContact } from '../contacts/resolve'
+import { noteTitleOwningEmail } from '../indexing/queries'
+import { resolveMeetingAttendees } from './resolve-attendees'
+
+vi.mock('../indexing/queries', () => ({
+  noteTitleOwningEmail: vi.fn(),
+}))
+vi.mock('../contacts/resolve', () => ({
+  resolveAttendeeContact: vi.fn(),
+}))
+
+const owningNoteMock = vi.mocked(noteTitleOwningEmail)
+const contactMock = vi.mocked(resolveAttendeeContact)
+
+function contact(fullName: string): Awaited<ReturnType<typeof resolveAttendeeContact>> {
+  return { fullName, givenName: '', familyName: '', emails: [], phones: [] }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  owningNoteMock.mockResolvedValue(null)
+  contactMock.mockResolvedValue(null)
+})
+
+describe('resolveMeetingAttendees', () => {
+  it('renames an attendee to the note that owns their invite email', async () => {
+    owningNoteMock.mockResolvedValue('Jane Doe')
+    const resolved = await resolveMeetingAttendees(
+      [{ name: 'jane@corp.com', email: 'jane@corp.com' }],
+      false,
+    )
+    expect(resolved).toEqual([{ name: 'Jane Doe', email: 'jane@corp.com' }])
+  })
+
+  it('the graph outranks Apple Contacts — a note owner wins even with the gate on', async () => {
+    owningNoteMock.mockResolvedValue('Jane Doe')
+    contactMock.mockResolvedValue(contact('Jane A. Doe'))
+    const resolved = await resolveMeetingAttendees(
+      [{ name: 'jane@corp.com', email: 'jane@corp.com' }],
+      true,
+    )
+    expect(resolved).toEqual([{ name: 'Jane Doe', email: 'jane@corp.com' }])
+    expect(contactMock).not.toHaveBeenCalled()
+  })
+
+  it('names an email-only attendee from Apple Contacts when no note owns the address', async () => {
+    contactMock.mockResolvedValue(contact('Jane Doe'))
+    const resolved = await resolveMeetingAttendees(
+      [{ name: 'Jane@Corp.com', email: 'jane@corp.com' }],
+      true,
+    )
+    expect(resolved).toEqual([{ name: 'Jane Doe', email: 'jane@corp.com' }])
+  })
+
+  it('leaves a calendar-named attendee alone — contacts only fill in for a bare address', async () => {
+    contactMock.mockResolvedValue(contact('Jane Doe'))
+    const resolved = await resolveMeetingAttendees(
+      [{ name: 'Doe, Jane', email: 'jane@corp.com' }],
+      true,
+    )
+    expect(resolved).toEqual([{ name: 'Doe, Jane', email: 'jane@corp.com' }])
+    expect(contactMock).not.toHaveBeenCalled()
+  })
+
+  it('never reaches Contacts while the gate is off', async () => {
+    const resolved = await resolveMeetingAttendees(
+      [{ name: 'jane@corp.com', email: 'jane@corp.com' }],
+      false,
+    )
+    expect(resolved).toEqual([{ name: 'jane@corp.com', email: 'jane@corp.com' }])
+    expect(contactMock).not.toHaveBeenCalled()
+  })
+
+  it('passes attendees without an email straight through, no lookups', async () => {
+    const resolved = await resolveMeetingAttendees([{ name: 'Grace Hopper' }], true)
+    expect(resolved).toEqual([{ name: 'Grace Hopper' }])
+    expect(owningNoteMock).not.toHaveBeenCalled()
+    expect(contactMock).not.toHaveBeenCalled()
+  })
+
+  it('falls through on a nameless contact or blank-titled owner', async () => {
+    owningNoteMock.mockResolvedValue('   ')
+    contactMock.mockResolvedValue(contact('  '))
+    const resolved = await resolveMeetingAttendees(
+      [{ name: 'jane@corp.com', email: 'jane@corp.com' }],
+      true,
+    )
+    expect(resolved).toEqual([{ name: 'jane@corp.com', email: 'jane@corp.com' }])
+  })
+})

--- a/packages/core/src/actions/resolve-attendees.test.ts
+++ b/packages/core/src/actions/resolve-attendees.test.ts
@@ -79,6 +79,18 @@ describe('resolveMeetingAttendees', () => {
     expect(contactMock).not.toHaveBeenCalled()
   })
 
+  it('skips an owner whose title cannot be wiki-linked verbatim', async () => {
+    // `[[Jane [Doe]]]` would corrupt the link, and the sanitized form would
+    // miss the owner in the index — so the rename must not happen at all.
+    owningNoteMock.mockResolvedValue('Jane [Doe]')
+    contactMock.mockResolvedValue(contact('Jane Doe'))
+    const resolved = await resolveMeetingAttendees(
+      [{ name: 'jane@corp.com', email: 'jane@corp.com' }],
+      true,
+    )
+    expect(resolved).toEqual([{ name: 'Jane Doe', email: 'jane@corp.com' }])
+  })
+
   it('falls through on a nameless contact or blank-titled owner', async () => {
     owningNoteMock.mockResolvedValue('   ')
     contactMock.mockResolvedValue(contact('  '))

--- a/packages/core/src/actions/resolve-attendees.ts
+++ b/packages/core/src/actions/resolve-attendees.ts
@@ -1,0 +1,57 @@
+import { resolveAttendeeContact } from '../contacts/resolve'
+import { noteTitleOwningEmail } from '../indexing/queries'
+import { foldEmail } from '../markdown/email-fields'
+import type { MeetingAttendee } from './add-meeting'
+
+/**
+ * Canonicalize meeting attendees against what the graph already knows, so
+ * one person keeps one note no matter how the calendar spelled them.
+ *
+ * Calendars are unreliable about names: EventKit reports many participants
+ * by bare address (no display name), and the ones it does name can differ
+ * from the note title ("Doe, Jane" vs "Jane Doe"). Matching by name alone
+ * therefore mints duplicate person notes. The invite email is the stable
+ * identity, so each attendee that carries one resolves in order:
+ *
+ * 1. **The graph.** A note owning the address via a `- Email:` contact-field
+ *    bullet (the `note_emails` projection) wins outright — the attendee is
+ *    renamed to that note's title, so the `[[Person]]` link lands on the
+ *    existing note.
+ * 2. **Apple Contacts** (gate on), only when the attendee's name *is* the
+ *    address — the calendar knew no better. The contact's full name becomes
+ *    the attendee, so the note the flow then creates (pre-filled with the
+ *    contact's details, including this email) is born under the person's
+ *    real name — and step 1 finds it next time.
+ * 3. Otherwise the attendee passes through unchanged, and the flow behaves
+ *    as v1 did: title match or a fresh note.
+ *
+ * Both the add-meeting dialog (prefilling chips) and `addMeetingToDaily`
+ * (authoritatively, at write time) run this, so what the user sees is what
+ * gets linked — and a quick submit can't skip the resolution.
+ */
+export async function resolveMeetingAttendees(
+  attendees: readonly MeetingAttendee[],
+  lookupContacts: boolean,
+): Promise<MeetingAttendee[]> {
+  return Promise.all(attendees.map((attendee) => resolveAttendee(attendee, lookupContacts)))
+}
+
+async function resolveAttendee(
+  attendee: MeetingAttendee,
+  lookupContacts: boolean,
+): Promise<MeetingAttendee> {
+  if (attendee.email === undefined || foldEmail(attendee.email) === '') {
+    return attendee
+  }
+  const ownerTitle = await noteTitleOwningEmail(attendee.email)
+  if (ownerTitle !== null && ownerTitle.trim() !== '') {
+    return { name: ownerTitle, email: attendee.email }
+  }
+  if (lookupContacts && foldEmail(attendee.name) === foldEmail(attendee.email)) {
+    const contact = await resolveAttendeeContact(attendee.email)
+    if (contact !== null && contact.fullName.trim() !== '') {
+      return { name: contact.fullName.trim(), email: attendee.email }
+    }
+  }
+  return attendee
+}

--- a/packages/core/src/actions/resolve-attendees.ts
+++ b/packages/core/src/actions/resolve-attendees.ts
@@ -13,10 +13,10 @@ import type { MeetingAttendee } from './add-meeting'
  * therefore mints duplicate person notes. The invite email is the stable
  * identity, so each attendee that carries one resolves in order:
  *
- * 1. **The graph.** A note owning the address via a `- Email:` contact-field
- *    bullet (the `note_emails` projection) wins outright — the attendee is
- *    renamed to that note's title, so the `[[Person]]` link lands on the
- *    existing note.
+ * 1. **The graph.** A `#person`-tagged note owning the address via a
+ *    `- Email:` contact-field bullet (the `note_emails` projection) wins
+ *    outright — the attendee is renamed to that note's title, so the
+ *    `[[Person]]` link lands on the existing note.
  * 2. **Apple Contacts** (gate on), only when the attendee's name *is* the
  *    address — the calendar knew no better. The contact's full name becomes
  *    the attendee, so the note the flow then creates (pre-filled with the

--- a/packages/core/src/actions/resolve-attendees.ts
+++ b/packages/core/src/actions/resolve-attendees.ts
@@ -1,5 +1,6 @@
 import { resolveAttendeeContact } from '../contacts/resolve'
 import { noteTitleOwningEmail } from '../indexing/queries'
+import { wikiLinkSafe } from '../markdown/edit'
 import { foldEmail } from '../markdown/email-fields'
 import type { MeetingAttendee } from './add-meeting'
 
@@ -44,7 +45,12 @@ async function resolveAttendee(
     return attendee
   }
   const ownerTitle = await noteTitleOwningEmail(attendee.email)
-  if (ownerTitle !== null && ownerTitle.trim() !== '') {
+  // The rename must be lossless: `[[…]]` has no escaping, so a title that
+  // wikiLinkSafe would alter (brackets, pipes, doubled spaces) can't be
+  // linked verbatim — the sanitized form would miss the owner in the index
+  // and mint the very duplicate this resolution exists to prevent. Such an
+  // owner falls through to the later steps instead.
+  if (ownerTitle !== null && ownerTitle !== '' && wikiLinkSafe(ownerTitle) === ownerTitle) {
     return { name: ownerTitle, email: attendee.email }
   }
   if (lookupContacts && foldEmail(attendee.name) === foldEmail(attendee.email)) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -401,6 +401,7 @@ export {
   type AddMeetingOutcome,
   type MeetingAttendee,
 } from './actions/add-meeting'
+export { resolveMeetingAttendees } from './actions/resolve-attendees'
 export {
   describePage,
   isDescriptionRejected,

--- a/packages/core/src/indexing/indexed-note.test.ts
+++ b/packages/core/src/indexing/indexed-note.test.ts
@@ -3,8 +3,8 @@ import { gistBodyHash, parseNote } from '../markdown'
 import { buildIndexedNote, indexedNoteSchema, PROJECTION_VERSION } from './indexed-note'
 
 describe('buildIndexedNote', () => {
-  it('carries the projection version that backfills the note kind', () => {
-    expect(PROJECTION_VERSION).toBe(12)
+  it('carries the projection version that backfills the note email rows', () => {
+    expect(PROJECTION_VERSION).toBe(13)
   })
 
   it('flattens a parsed note into the index payload', () => {
@@ -44,6 +44,27 @@ describe('buildIndexedNote', () => {
       true,
     )
     expect(indexed.assets).toEqual(['assets/p.png'])
+  })
+
+  it('projects Email field bullets with folded keys, ignoring prose mentions', () => {
+    const source =
+      '# Ada Lovelace\n\n- Type: #person\n- Email: Ada@Example.com\n\nIntro via bob@corp.example.'
+    const indexed = buildIndexedNote(parseNote({ path: 'notes/ada.md', source }), {
+      fileHash: 'h',
+      mtime: 0,
+      source,
+    })
+    expect(indexed.emails).toEqual([{ email: 'Ada@Example.com', emailKey: 'ada@example.com' }])
+  })
+
+  it('reads email fields from the body with frontmatter split off', () => {
+    const source = '---\nid: 01H\n---\n# Ada\n\n- Email: ada@example.com'
+    const indexed = buildIndexedNote(parseNote({ path: 'notes/ada.md', source }), {
+      fileHash: 'h',
+      mtime: 0,
+      source,
+    })
+    expect(indexed.emails).toEqual([{ email: 'ada@example.com', emailKey: 'ada@example.com' }])
   })
 
   it('derives the list preview and folded tag keys at index time', () => {

--- a/packages/core/src/indexing/indexed-note.ts
+++ b/packages/core/src/indexing/indexed-note.ts
@@ -2,6 +2,8 @@ import { z } from 'zod'
 import { dateFromDailyPath, isDaily, isTemplatePath } from '../graph/paths'
 import {
   detectConflictMarkers,
+  extractEmailFields,
+  foldEmail,
   foldKey,
   foldTag,
   gistBodyHash,
@@ -54,8 +56,11 @@ import { previewSnippet } from './snippet'
  * `+ [x]`), excluding square checklist checkboxes from the aggregate Tasks view.
  * 12 — `notes.kind` (daily / note / template): templates are indexed but
  * excluded from note surfaces, so rows must carry the kind.
+ * 13 — `note_emails` projection (`- Email:` contact-field bullets): existing
+ * person notes carry no email rows until reprojected, and attendee → note
+ * resolution in the calendar flow needs them, so the bump backfills them.
  */
-export const PROJECTION_VERSION = 12
+export const PROJECTION_VERSION = 13
 
 export const indexedLinkSchema = z.object({
   kind: z.enum(['wiki', 'md']),
@@ -81,6 +86,14 @@ export const indexedAliasSchema = z.object({
   aliasKey: z.string(),
 })
 export type IndexedAlias = z.infer<typeof indexedAliasSchema>
+
+export const indexedEmailSchema = z.object({
+  /** Display casing (as written in the field bullet). */
+  email: z.string(),
+  /** Case-folded match key ({@link foldEmail}) — what resolution compares against. */
+  emailKey: z.string(),
+})
+export type IndexedEmail = z.infer<typeof indexedEmailSchema>
 
 export const indexedTaskSchema = z.object({
   /** Character offset of the marker's `[` in the file (UTF-16 units) — the row PK with `path`. */
@@ -131,6 +144,8 @@ export const indexedNoteSchema = z.object({
   links: z.array(indexedLinkSchema),
   tags: z.array(indexedTagSchema),
   aliases: z.array(indexedAliasSchema),
+  /** Emails the note owns via `- Email:` contact-field bullets. */
+  emails: z.array(indexedEmailSchema),
   assets: z.array(z.string()),
   /** Reflect task rows for the Tasks projection (Plan 18). */
   tasks: z.array(indexedTaskSchema),
@@ -162,6 +177,7 @@ export function buildIndexedNote(
     posFrom: link.from,
     posTo: link.to,
   }))
+  const body = splitFrontmatter(meta.source).body
 
   return {
     path: parsed.path,
@@ -179,8 +195,7 @@ export function buildIndexedNote(
     // writes the `gist` block itself, and a pin/private toggle is not an edit
     // worth a "republish" nudge.
     gistStale:
-      parsed.frontmatter.gist !== undefined &&
-      gistBodyHash(splitFrontmatter(meta.source).body) !== parsed.frontmatter.gist.hash,
+      parsed.frontmatter.gist !== undefined && gistBodyHash(body) !== parsed.frontmatter.gist.hash,
     fileHash: meta.fileHash,
     mtime: meta.mtime,
     text: parsed.text,
@@ -192,6 +207,7 @@ export function buildIndexedNote(
       alias,
       aliasKey: foldKey(alias),
     })),
+    emails: extractEmailFields(body).map((email) => ({ email, emailKey: foldEmail(email) })),
     assets: parsed.assets.map((asset) => asset.path),
     tasks: parsed.tasks.map((task) => ({
       markerOffset: task.markerOffset,

--- a/packages/core/src/indexing/queries.test.ts
+++ b/packages/core/src/indexing/queries.test.ts
@@ -7,6 +7,7 @@ import {
   getOpenTasks,
   getPinnedNotes,
   listDailyNotes,
+  noteTitleOwningEmail,
   suggestWikiTargets,
 } from './queries'
 
@@ -45,6 +46,33 @@ describe('dailyDatesInRange', () => {
   it('returns an empty list when no daily notes exist in the range', async () => {
     mockInvoke.mockResolvedValue([])
     await expect(dailyDatesInRange('2025-01-01', '2025-01-31')).resolves.toEqual([])
+  })
+})
+
+describe('noteTitleOwningEmail', () => {
+  it('joins note_emails to notes by folded key, regular notes only, first path wins', async () => {
+    mockInvoke.mockResolvedValue([{ title: 'Jane Doe' }])
+
+    await expect(noteTitleOwningEmail('  Jane@Corp.com ')).resolves.toBe('Jane Doe')
+
+    const [command, args] = mockInvoke.mock.calls[0]!
+    expect(command).toBe('db_query')
+    const sql = String(args['sql'])
+    expect(sql).toContain('note_emails')
+    expect(sql).toContain('email_key')
+    expect(sql).toContain('kind')
+    expect(sql).toContain('order by')
+    expect(args['params']).toEqual(['jane@corp.com', 'note'])
+  })
+
+  it('answers null for an unowned address without guessing', async () => {
+    mockInvoke.mockResolvedValue([])
+    await expect(noteTitleOwningEmail('nobody@corp.com')).resolves.toBeNull()
+  })
+
+  it('short-circuits a blank address before touching the bridge', async () => {
+    await expect(noteTitleOwningEmail('   ')).resolves.toBeNull()
+    expect(mockInvoke).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/core/src/indexing/queries.test.ts
+++ b/packages/core/src/indexing/queries.test.ts
@@ -50,7 +50,7 @@ describe('dailyDatesInRange', () => {
 })
 
 describe('noteTitleOwningEmail', () => {
-  it('joins note_emails to notes by folded key, regular notes only, first path wins', async () => {
+  it('joins note_emails to #person-tagged regular notes by folded key, first path wins', async () => {
     mockInvoke.mockResolvedValue([{ title: 'Jane Doe' }])
 
     await expect(noteTitleOwningEmail('  Jane@Corp.com ')).resolves.toBe('Jane Doe')
@@ -60,9 +60,10 @@ describe('noteTitleOwningEmail', () => {
     const sql = String(args['sql'])
     expect(sql).toContain('note_emails')
     expect(sql).toContain('email_key')
+    expect(sql).toContain('tag_key')
     expect(sql).toContain('kind')
     expect(sql).toContain('order by')
-    expect(args['params']).toEqual(['jane@corp.com', 'note'])
+    expect(args['params']).toEqual(['jane@corp.com', 'person', 'note'])
   })
 
   it('answers null for an unowned address without guessing', async () => {

--- a/packages/core/src/indexing/queries.ts
+++ b/packages/core/src/indexing/queries.ts
@@ -2,6 +2,7 @@ import type { Database } from '@reflect/db'
 import { sql, type Selectable } from 'kysely'
 import { readNote } from '../graph/commands'
 import {
+  foldEmail,
   foldKey,
   foldTag,
   normalizeWikiTarget,
@@ -597,6 +598,29 @@ export async function getNoteIdsByPath(paths: string[]): Promise<Map<string, str
     }
   }
   return ids
+}
+
+/**
+ * The title of the note that owns `email` through a `- Email:` contact-field
+ * bullet (the `note_emails` projection), or null. Regular notes only: a daily
+ * note or template quoting an address must never become a `[[Person]]` link
+ * target. Several notes claiming one address resolve to the first path
+ * alphabetically, the resolver's rule everywhere else.
+ */
+export async function noteTitleOwningEmail(email: string): Promise<string | null> {
+  const key = foldEmail(email)
+  if (key === '') {
+    return null
+  }
+  const owner = await db
+    .selectFrom('noteEmails')
+    .innerJoin('notes', 'notes.path', 'noteEmails.notePath')
+    .where('noteEmails.emailKey', '=', key)
+    .where('notes.kind', '=', 'note')
+    .select('notes.title as title')
+    .orderBy('notes.path')
+    .executeTakeFirst()
+  return owner?.title ?? null
 }
 
 /**

--- a/packages/core/src/indexing/queries.ts
+++ b/packages/core/src/indexing/queries.ts
@@ -600,11 +600,16 @@ export async function getNoteIdsByPath(paths: string[]): Promise<Map<string, str
   return ids
 }
 
+/** The folded tag key marking person notes (`- Type: #person`, v1's typing). */
+const PERSON_TAG_KEY = 'person'
+
 /**
  * The title of the note that owns `email` through a `- Email:` contact-field
- * bullet (the `note_emails` projection), or null. Regular notes only: a daily
- * note or template quoting an address must never become a `[[Person]]` link
- * target. Several notes claiming one address resolve to the first path
+ * bullet (the `note_emails` projection), or null. Only `#person`-tagged
+ * regular notes qualify: a daily note, template, or non-person note quoting
+ * an address must never become a `[[Person]]` link target — the projection
+ * records every field bullet, and this query is where the ownership policy
+ * lives. Several notes claiming one address resolve to the first path
  * alphabetically, the resolver's rule everywhere else.
  */
 export async function noteTitleOwningEmail(email: string): Promise<string | null> {
@@ -615,7 +620,9 @@ export async function noteTitleOwningEmail(email: string): Promise<string | null
   const owner = await db
     .selectFrom('noteEmails')
     .innerJoin('notes', 'notes.path', 'noteEmails.notePath')
+    .innerJoin('tags', 'tags.notePath', 'notes.path')
     .where('noteEmails.emailKey', '=', key)
+    .where('tags.tagKey', '=', PERSON_TAG_KEY)
     .where('notes.kind', '=', 'note')
     .select('notes.title as title')
     .orderBy('notes.path')

--- a/packages/core/src/markdown/email-fields.test.ts
+++ b/packages/core/src/markdown/email-fields.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { extractEmailFields, foldEmail } from './email-fields'
+
+describe('foldEmail', () => {
+  it('trims and lowercases', () => {
+    expect(foldEmail('  Ada@Example.COM ')).toBe('ada@example.com')
+  })
+})
+
+describe('extractEmailFields', () => {
+  it('extracts addresses from Email field bullets, keeping document order and casing', () => {
+    const body = [
+      '# Ada Lovelace',
+      '',
+      '- Type: #person',
+      '- Email: Ada@Example.com',
+      '- Email: ada.lovelace@work.example',
+      '- Phone: +1 555-0100',
+    ].join('\n')
+    expect(extractEmailFields(body)).toEqual(['Ada@Example.com', 'ada.lovelace@work.example'])
+  })
+
+  it('accepts any list marker and any field casing', () => {
+    expect(extractEmailFields('* EMAIL: ada@example.com')).toEqual(['ada@example.com'])
+    expect(extractEmailFields('+ email: ada@example.com')).toEqual(['ada@example.com'])
+    expect(extractEmailFields('  - Email: ada@example.com')).toEqual(['ada@example.com'])
+  })
+
+  it('reads several addresses from one bullet and dedups case-insensitively', () => {
+    expect(extractEmailFields('- Email: a@x.com, B@Y.com\n- Email: b@y.com')).toEqual([
+      'a@x.com',
+      'B@Y.com',
+    ])
+  })
+
+  it('unwraps a mailto link, collapsing the text/href pair', () => {
+    expect(extractEmailFields('- Email: [ada@example.com](mailto:ada@example.com)')).toEqual([
+      'ada@example.com',
+    ])
+  })
+
+  it('strips sentence-final punctuation glued to an address', () => {
+    expect(extractEmailFields('- Email: reach her at ada@example.com.')).toEqual([
+      'ada@example.com',
+    ])
+  })
+
+  it('ignores addresses outside Email field bullets — prose is a mention, not ownership', () => {
+    const body = [
+      '# Meeting notes',
+      '',
+      'Thread from ada@example.com about the launch.',
+      '- Ask ada@example.com about timing',
+      '- Phone: +1 555-0100',
+    ].join('\n')
+    expect(extractEmailFields(body)).toEqual([])
+  })
+
+  it('yields nothing for a bullet with no parseable address', () => {
+    expect(extractEmailFields('- Email:\n- Email: ask reception')).toEqual([])
+  })
+})

--- a/packages/core/src/markdown/email-fields.ts
+++ b/packages/core/src/markdown/email-fields.ts
@@ -1,0 +1,53 @@
+/**
+ * Contact-field emails — the `- Email: ada@example.com` bullet shape of v1's
+ * person template, written today by the contacts integration
+ * (`contactDetailsMarkdown`) and the meeting flow's person-note pre-fill.
+ * The indexer projects these into `note_emails` so an invite email can find
+ * the person note that owns it (attendee resolution in the calendar flow).
+ *
+ * Ownership is deliberately narrow: only an explicit `Email:` field bullet
+ * counts. A bare address in prose — a daily note quoting an email, a meeting
+ * note pasting a thread — is a mention, not ownership, and must not capture
+ * the address.
+ */
+
+/** An `Email:` field bullet (any list marker, any case), capturing its value. */
+const EMAIL_FIELD_PATTERN = /^[ \t]*[-+*][ \t]+email:(.*)$/gim
+
+/**
+ * An address inside a field value (tolerates `mailto:` links and commas —
+ * excluding `:` keeps the scheme out of the local part).
+ */
+const EMAIL_PATTERN = /[^\s@<>(),;:[\]]+@[^\s@<>(),;:[\]]+\.[^\s@<>(),;:[\]]+/g
+
+/** Normalize an email for matching: trimmed, lowercased. */
+export function foldEmail(email: string): string {
+  return email.trim().toLowerCase()
+}
+
+/**
+ * Every email a note body owns via `- Email:` field bullets, in document
+ * order, case-insensitively deduplicated (first casing kept). One bullet may
+ * carry several addresses (comma-separated, or a `mailto:` link whose text
+ * repeats the address — the dedup collapses that pair). Run this on the
+ * body, frontmatter split off.
+ */
+export function extractEmailFields(body: string): string[] {
+  const seen = new Set<string>()
+  const emails: string[] = []
+  for (const field of body.matchAll(EMAIL_FIELD_PATTERN)) {
+    const value = field[1] ?? ''
+    for (const match of value.matchAll(EMAIL_PATTERN)) {
+      // The field value is free-form prose; a sentence-final dot glued to an
+      // address is punctuation, not domain.
+      const email = match[0].replace(/\.+$/, '')
+      const key = foldEmail(email)
+      if (seen.has(key)) {
+        continue
+      }
+      seen.add(key)
+      emails.push(email)
+    }
+  }
+  return emails
+}

--- a/packages/core/src/markdown/index.ts
+++ b/packages/core/src/markdown/index.ts
@@ -59,6 +59,7 @@ export {
   type ConflictMarkerLabels,
   type ConflictResolution,
 } from './conflict-markers'
+export { extractEmailFields, foldEmail } from './email-fields'
 export { foldKey, foldTag } from './keys'
 export { gistBodyHash, gistFilename } from './gist'
 export { slugForTitle } from './slug'

--- a/packages/db/src/schema.gen.ts
+++ b/packages/db/src/schema.gen.ts
@@ -74,6 +74,12 @@ export interface Links {
   targetRaw: string;
 }
 
+export interface NoteEmails {
+  email: string;
+  emailKey: string;
+  notePath: string;
+}
+
 export interface NoteKeys {
   key: string | null;
   notePath: string | null;
@@ -133,6 +139,7 @@ export interface DB {
   embeddingChunks: EmbeddingChunks;
   indexMeta: IndexMeta;
   links: Links;
+  noteEmails: NoteEmails;
   noteKeys: NoteKeys;
   notes: Notes;
   noteText: NoteText;


### PR DESCRIPTION
## Problem

Adding a calendar meeting resolves each attendee to a person note by **display name only** (`titleHasNote(attendee.name)` in `add-meeting.ts`). But the name EventKit reports is unreliable: participants without an address-book entry come through as the bare email (`describe_attendee` falls back to the `mailto:` URL), and named ones can be formatted differently than the note title ("Doe, Jane" vs "Jane Doe"). Any mismatch minted a duplicate person note — often one *titled with the email address* — even when a note for that person (with their email in its body) already existed. Large meetings made this worse, since more attendees arrive address-only.

## Approach

The invite email is the stable identity, so make it the primary resolution key — which first requires the graph to know which note owns which address.

**1. `note_emails` projection (the substrate)**
- `- Email: …` field bullets — v1's person-template shape, already written by the contacts integration and the meeting flow's pre-fill — are extracted per note (`extractEmailFields`, ownership is *explicitly the field bullet*; a bare address in prose is a mention, not ownership).
- New migration `0016_note_emails` (`note_path`, `email`, `email_key`, keyed index); schema version 15 → 16.
- Rows flow through all three writers in lockstep: TS payload (`buildIndexedNote`, zod contract), Rust `apply_note`/`move_note`, and the browser dev bridge. `PROJECTION_VERSION` 12 → 13 so existing graphs reproject and backfill rows for notes indexed before this change.
- Kysely `schema.gen.ts` regenerated (`db:codegen`).

**2. Email-first attendee resolution (the behavior)**
`resolveMeetingAttendees` canonicalizes each attendee that carries an invite email, in order:
1. **Graph wins**: a `#person`-tagged regular note owning the address (`noteTitleOwningEmail`: kind `note` + `tags.tag_key = 'person'`, first-path-alphabetically on collision) renames the attendee to that note's title — the `[[Person]]` link lands on the existing note. The projection records every `- Email:` bullet; the *query* is where the ownership policy lives, so a stray Email bullet on a non-person note can't capture an attendee link. The rename only happens when the owner's title is linkable verbatim (`wikiLinkSafe` fixed point) — an unlinkable title falls through rather than being sanitized into a near-miss duplicate.
2. **Contacts fill in**: gate on and the attendee's name *is* the address (calendar knew no better) → the Apple Contacts full name, so the freshly created note is born under the person's real name (and step 1 finds it next time).
3. Otherwise unchanged — v1 behavior.

`addMeetingToDaily` runs this authoritatively before dedup (two spellings of one person now collapse to one link), and the add-meeting dialog upgrades its prefilled chips through the same seam so the user sees exactly what submit will link. Chip upgrades merge by prefill name — removed chips stay removed, user-added chips are untouched.

## Notes for review

- Attendee normalization moved *after* the already-linked idempotence check in `addMeetingToDaily`, so a no-op re-add does no lookups; a resolution failure now fails the whole action before the daily write (fail-loud) instead of writing a line that would re-create the duplicate on click.
- `note_emails` rows are a pure rebuildable projection (CASCADE delete, explicit move on rename) — no durable data, `chat_*` untouched.
- Existing person notes without `- Email:` bullets still resolve by name/contacts as before; the suggested-contact card's **Add** is the path that grants them email ownership.

## Testing

- New: `email-fields.test.ts` (extraction/folding), `resolve-attendees.test.ts` (precedence, gates), canonicalization cases in `add-meeting.test.ts`, `noteTitleOwningEmail` SQL in `queries.test.ts`, projection cases in `indexed-note.test.ts`, chip-upgrade test in `daily-events-section.test.tsx`, `note_emails` apply/move/cascade in Rust `db/tests.rs`.
- Ran: `pnpm check` (typecheck + oxlint + eslint) clean; core indexing/actions/contacts/calendar suites (458 tests) and desktop dev-bridge/dialog/combobox suites (22 tests) green; `cargo test -p reflect-index-schema -p reflect-open db:: -p reflect-cli` green.
- Not run: a manual in-app pass of the add-meeting dialog against a live calendar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches index schema, projection rebuild, and meeting write path; behavior is well-tested but existing graphs need reprojection for email lookups to work.
> 
> **Overview**
> **Indexes `- Email:` bullets** into a new `note_emails` table (migration 0016, schema 16, `PROJECTION_VERSION` 13) with TS/Rust/dev-bridge writers and `extractEmailFields` / `foldEmail` parsing.
> 
> **Resolves attendees by invite email** via `resolveMeetingAttendees` and `noteTitleOwningEmail`: graph-owned addresses win, then Apple Contacts when the calendar only showed the address; `addMeetingToDaily` runs this before dedup and fails loud on index errors. The add-meeting dialog **upgrades prefilled chips** through the same path so UI matches what gets linked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d61193126e168bf539670145d7b31eb7b0944118. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
