### PR TITLE
fix(tasks): reconcile Task View's struck rows with tasks reopened at the source note

### DIFF
--- a/apps/desktop/src/components/tasks/tasks-screen.test.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { OpenTask } from '@reflect/core'
 import { useEffect, useState, type MutableRefObject, type ReactNode } from 'react'
+import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { resetRecentlyCompleted } from '@/lib/tasks/recently-completed'
 import { RouterProvider, useRouter } from '@/routing/router'
 import { TasksScreen } from './tasks-screen'
@@ -202,8 +203,9 @@ function RouteProbe(): ReactNode {
   return <output data-testid="route">{JSON.stringify(route)}</output>
 }
 
-function renderScreen() {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+function renderScreen(
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+) {
   return render(
     <QueryClientProvider client={client}>
       <RouterProvider>
@@ -962,6 +964,72 @@ describe('TasksScreen', () => {
     // V1's middle state: the row stays visible, struck, until archived.
     await view.findByRole('button', { name: 'Reopen: project task' })
     expect(view.getByText('project task')).toBeDefined()
+    view.unmount()
+  })
+
+  it('yields the struck row to the index when the task is reopened at its source note', async () => {
+    toggleTask.mockResolvedValue(undefined)
+    getOpenTasks.mockResolvedValue([
+      task({
+        notePath: 'notes/p.md',
+        markerOffset: 5,
+        raw: '[ ] project task',
+        text: 'project task',
+        noteTitle: 'Project',
+        updatedAt: 100,
+      }),
+    ])
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const view = renderScreen(client)
+
+    await userEvent.click(await view.findByRole('button', { name: 'Complete: project task' }))
+    await view.findByRole('button', { name: 'Reopen: project task' })
+
+    // The checkbox is flipped back to [ ] in the note itself; the reindex
+    // reports the task open again with the note's newer updatedAt. The session's
+    // struck copy must yield — keeping it would shadow the live row and its
+    // Reopen would fail (the [x] line is no longer in the note).
+    getOpenTasks.mockResolvedValue([
+      task({
+        notePath: 'notes/p.md',
+        markerOffset: 5,
+        raw: '[ ] project task',
+        text: 'project task',
+        noteTitle: 'Project',
+        updatedAt: 200,
+      }),
+    ])
+    await client.invalidateQueries({ queryKey: [INDEX_QUERY_SCOPE] })
+
+    await view.findByRole('button', { name: 'Complete: project task' })
+    expect(view.queryByRole('button', { name: 'Reopen: project task' })).toBeNull()
+    view.unmount()
+  })
+
+  it('keeps the struck row when a refetch races the completion’s reindex', async () => {
+    toggleTask.mockResolvedValue(undefined)
+    const staleRow = task({
+      notePath: 'notes/p.md',
+      markerOffset: 5,
+      raw: '[ ] project task',
+      text: 'project task',
+      noteTitle: 'Project',
+      updatedAt: 100,
+    })
+    getOpenTasks.mockResolvedValue([staleRow])
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const view = renderScreen(client)
+
+    await userEvent.click(await view.findByRole('button', { name: 'Complete: project task' }))
+    await view.findByRole('button', { name: 'Reopen: project task' })
+
+    // An unrelated invalidation refetches before the completion's reindex lands:
+    // the index still returns the pre-completion row (same updatedAt). The row
+    // must stay struck rather than flicker back to open.
+    await client.invalidateQueries({ queryKey: [INDEX_QUERY_SCOPE] })
+
+    await view.findByRole('button', { name: 'Reopen: project task' })
+    expect(view.queryByRole('button', { name: 'Complete: project task' })).toBeNull()
     view.unmount()
   })
 

--- a/apps/desktop/src/components/tasks/tasks-screen.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.tsx
@@ -105,8 +105,10 @@ export function TasksScreen(): ReactElement {
   const ready = open !== undefined && (!filters.archived || completed !== undefined)
   const { onScroll } = useScrollRestoration(scrollElement, ready)
 
-  // This session's completed tasks, still showing struck until archived.
-  const recentlyCompleted = useRecentlyCompleted(graph?.root ?? null)
+  // This session's completed tasks, still showing struck until archived —
+  // reconciled against the open read so a task reopened at its source note
+  // sheds its struck shadow instead of masking the live row.
+  const recentlyCompleted = useRecentlyCompleted(graph?.root ?? null, open)
 
   const needle = query.trim().toLowerCase()
   const groups = useMemo(

--- a/apps/desktop/src/lib/tasks/recently-completed.test.ts
+++ b/apps/desktop/src/lib/tasks/recently-completed.test.ts
@@ -5,6 +5,7 @@ import {
   archiveRecentlyCompleted,
   forgetRecentlyCompleted,
   markRecentlyCompleted,
+  reconcileRecentlyCompleted,
   resetRecentlyCompleted,
   useRecentlyCompleted,
 } from './recently-completed'
@@ -34,7 +35,7 @@ afterEach(() => {
 
 describe('recently-completed', () => {
   it('keeps session completions showing, as checked', () => {
-    const { result } = renderHook(() => useRecentlyCompleted('/g'))
+    const { result } = renderHook(() => useRecentlyCompleted('/g', undefined))
     expect(result.current).toEqual([])
 
     act(() => markRecentlyCompleted('/g', [task({ notePath: 'a.md', markerOffset: 2 })]))
@@ -46,7 +47,7 @@ describe('recently-completed', () => {
   })
 
   it('dedupes by task key', () => {
-    const { result } = renderHook(() => useRecentlyCompleted('/g'))
+    const { result } = renderHook(() => useRecentlyCompleted('/g', undefined))
     const t = task({ notePath: 'a.md', markerOffset: 2 })
     act(() => markRecentlyCompleted('/g', [t]))
     act(() => markRecentlyCompleted('/g', [t]))
@@ -54,7 +55,7 @@ describe('recently-completed', () => {
   })
 
   it('forgets dropped keys and clears on archive', () => {
-    const { result } = renderHook(() => useRecentlyCompleted('/g'))
+    const { result } = renderHook(() => useRecentlyCompleted('/g', undefined))
     act(() =>
       markRecentlyCompleted('/g', [
         task({ notePath: 'a.md', markerOffset: 2 }),
@@ -68,8 +69,74 @@ describe('recently-completed', () => {
     expect(result.current).toEqual([])
   })
 
+  it('drops a struck copy when the index reports the task open again with a newer updatedAt', () => {
+    const { result } = renderHook(() => useRecentlyCompleted('/g', undefined))
+    act(() => markRecentlyCompleted('/g', [task({ notePath: 'a.md', markerOffset: 2, updatedAt: 100 })]))
+    expect(result.current).toHaveLength(1)
+
+    // The source note was rewritten (checkbox flipped back to [ ]) and reindexed:
+    // the live open row supersedes the session's struck shadow.
+    act(() =>
+      reconcileRecentlyCompleted('/g', [
+        task({ notePath: 'a.md', markerOffset: 2, updatedAt: 200 }),
+      ]),
+    )
+    expect(result.current).toEqual([])
+  })
+
+  it('keeps the struck copy when the open row is the pre-completion index state', () => {
+    const { result } = renderHook(() => useRecentlyCompleted('/g', undefined))
+    act(() => markRecentlyCompleted('/g', [task({ notePath: 'a.md', markerOffset: 2, updatedAt: 100 })]))
+
+    // A refetch racing the completion's reindex restores the row unchanged
+    // (same updatedAt) — the shadow must hold or the row flickers back open.
+    act(() =>
+      reconcileRecentlyCompleted('/g', [
+        task({ notePath: 'a.md', markerOffset: 2, updatedAt: 100 }),
+      ]),
+    )
+    expect(result.current).toHaveLength(1)
+  })
+
+  it('reconciles only the active graph root, and leaves unrelated struck tasks alone', () => {
+    const { result } = renderHook(() => useRecentlyCompleted('/g', undefined))
+    act(() =>
+      markRecentlyCompleted('/g', [
+        task({ notePath: 'a.md', markerOffset: 2, updatedAt: 100 }),
+        task({ notePath: 'b.md', markerOffset: 2, updatedAt: 100 }),
+      ]),
+    )
+
+    act(() =>
+      reconcileRecentlyCompleted('/other', [
+        task({ notePath: 'a.md', markerOffset: 2, updatedAt: 200 }),
+      ]),
+    )
+    expect(result.current).toHaveLength(2)
+
+    act(() =>
+      reconcileRecentlyCompleted('/g', [
+        task({ notePath: 'a.md', markerOffset: 2, updatedAt: 200 }),
+      ]),
+    )
+    expect(result.current.map((row) => row.notePath)).toEqual(['b.md'])
+  })
+
+  it('useRecentlyCompleted reconciles against the open rows it is given', () => {
+    const { result, rerender } = renderHook(
+      ({ open }: { open: readonly OpenTask[] | undefined }) => useRecentlyCompleted('/g', open),
+      { initialProps: { open: undefined as readonly OpenTask[] | undefined } },
+    )
+    act(() => markRecentlyCompleted('/g', [task({ notePath: 'a.md', markerOffset: 2, updatedAt: 100 })]))
+    expect(result.current).toHaveLength(1)
+
+    // A fresh open read carrying the reopened row (newer updatedAt) sheds the shadow.
+    rerender({ open: [task({ notePath: 'a.md', markerOffset: 2, updatedAt: 200 })] })
+    expect(result.current).toEqual([])
+  })
+
   it('is scoped to a graph root — switching graphs yields an empty set', () => {
-    const { result, rerender } = renderHook(({ root }) => useRecentlyCompleted(root), {
+    const { result, rerender } = renderHook(({ root }) => useRecentlyCompleted(root, undefined), {
       initialProps: { root: '/g' },
     })
     act(() => markRecentlyCompleted('/g', [task({ notePath: 'a.md', markerOffset: 2 })]))

--- a/apps/desktop/src/lib/tasks/recently-completed.test.ts
+++ b/apps/desktop/src/lib/tasks/recently-completed.test.ts
@@ -49,9 +49,9 @@ describe('recently-completed', () => {
 
   it('dedupes by task key', () => {
     const { result } = renderHook(() => useRecentlyCompleted('/g', undefined))
-    const t = task({ notePath: 'a.md', markerOffset: 2 })
-    act(() => markRecentlyCompleted('/g', [t]))
-    act(() => markRecentlyCompleted('/g', [t]))
+    const taskRow = task({ notePath: 'a.md', markerOffset: 2 })
+    act(() => markRecentlyCompleted('/g', [taskRow]))
+    act(() => markRecentlyCompleted('/g', [taskRow]))
     expect(result.current).toHaveLength(1)
   })
 
@@ -64,7 +64,7 @@ describe('recently-completed', () => {
       ]),
     )
     act(() => forgetRecentlyCompleted('/g', ['a.md:2']))
-    expect(result.current.map((t) => t.notePath)).toEqual(['b.md'])
+    expect(result.current.map((row) => row.notePath)).toEqual(['b.md'])
 
     act(() => archiveRecentlyCompleted('/g'))
     expect(result.current).toEqual([])

--- a/apps/desktop/src/lib/tasks/recently-completed.test.ts
+++ b/apps/desktop/src/lib/tasks/recently-completed.test.ts
@@ -4,6 +4,7 @@ import { type OpenTask } from '@reflect/core'
 import {
   archiveRecentlyCompleted,
   forgetRecentlyCompleted,
+  hasRecentlyCompleted,
   markRecentlyCompleted,
   reconcileRecentlyCompleted,
   resetRecentlyCompleted,
@@ -130,9 +131,33 @@ describe('recently-completed', () => {
     act(() => markRecentlyCompleted('/g', [task({ notePath: 'a.md', markerOffset: 2, updatedAt: 100 })]))
     expect(result.current).toHaveLength(1)
 
-    // A fresh open read carrying the reopened row (newer updatedAt) sheds the shadow.
+    // A fresh open read carrying the reopened row (newer updatedAt) sheds the
+    // shadow from the view AND prunes the store, so the Archive count and
+    // hasRecentlyCompleted agree with what renders.
     rerender({ open: [task({ notePath: 'a.md', markerOffset: 2, updatedAt: 200 })] })
     expect(result.current).toEqual([])
+    expect(hasRecentlyCompleted('/g', 'a.md:2')).toBe(false)
+  })
+
+  it('excludes a reopened task during the render that sees it, before the store prune', () => {
+    // Render-phase capture: each entry is what a render (not an effect) returned,
+    // so a superseded shadow surviving into the first fresh-data render would
+    // record a 1 here even though a later effect prunes it.
+    const lengths: number[] = []
+    const { rerender } = renderHook(
+      ({ open }: { open: readonly OpenTask[] | undefined }) => {
+        const rows = useRecentlyCompleted('/g', open)
+        lengths.push(rows.length)
+        return rows
+      },
+      { initialProps: { open: undefined as readonly OpenTask[] | undefined } },
+    )
+    act(() => markRecentlyCompleted('/g', [task({ notePath: 'a.md', markerOffset: 2, updatedAt: 100 })]))
+    const renders = lengths.length
+
+    rerender({ open: [task({ notePath: 'a.md', markerOffset: 2, updatedAt: 200 })] })
+    expect(lengths.slice(renders)).not.toContain(1)
+    expect(lengths.at(-1)).toBe(0)
   })
 
   it('is scoped to a graph root — switching graphs yields an empty set', () => {

--- a/apps/desktop/src/lib/tasks/recently-completed.ts
+++ b/apps/desktop/src/lib/tasks/recently-completed.ts
@@ -1,4 +1,4 @@
-import { useCallback, useSyncExternalStore } from 'react'
+import { useCallback, useEffect, useSyncExternalStore } from 'react'
 import { type OpenTask } from '@reflect/core'
 import { withCheckedMarker } from '@/lib/tasks/task-cache'
 import { taskKey } from '@/lib/tasks/task-identity'
@@ -15,6 +15,11 @@ import { taskKey } from '@/lib/tasks/task-identity'
  * Tracking the session's completions — rather than every `[x]` task — is what
  * keeps a fresh launch clean: only what you checked *this run* lingers struck;
  * the whole historical pile stays behind the "show archived" filter.
+ *
+ * The set yields to the index when it disagrees: a task reopened at its source
+ * note (the checkbox flipped back to `[ ]` in the editor) comes back through the
+ * open-tasks read, and {@link reconcileRecentlyCompleted} drops the struck copy
+ * so the live row shows instead of a stale `[x]` shadow.
  *
  * Scoped to a graph root: switching graphs (whose task paths differ) yields an
  * empty set rather than the previous graph's rows.
@@ -76,6 +81,31 @@ export function hasRecentlyCompleted(root: string | null, key: string): boolean 
   return root === graphRoot && tasks.some((task) => taskKey(task) === key)
 }
 
+/**
+ * Reconcile the struck set against a fresh open-tasks read. A struck task the
+ * index reports open again with a **newer** `updatedAt` was reopened at the
+ * source note — its file was rewritten and reindexed since we completed it — so
+ * the struck copy is dropped and the live open row shows instead of a stale
+ * `[x]` shadow (whose reopen write-back would fail: the `[x]` line is no longer
+ * in the note). An open row with an *unchanged* `updatedAt` is the
+ * pre-completion index state — a refetch racing the completion's reindex — and
+ * keeps its shadow, so a just-checked row can't flicker back to open.
+ */
+export function reconcileRecentlyCompleted(root: string | null, open: readonly OpenTask[]): void {
+  if (root !== graphRoot || tasks.length === 0 || open.length === 0) {
+    return
+  }
+  const liveByKey = new Map(open.map((row) => [taskKey(row), row]))
+  const next = tasks.filter((struck) => {
+    const live = liveByKey.get(taskKey(struck))
+    return live === undefined || live.updatedAt <= struck.updatedAt
+  })
+  if (next.length !== tasks.length) {
+    tasks = next
+    emit()
+  }
+}
+
 /** Archive: stop showing the session's completed tasks (they stay `[x]` on disk). */
 export function archiveRecentlyCompleted(root: string | null): void {
   adopt(root)
@@ -90,8 +120,22 @@ function subscribe(listener: () => void): () => void {
   return () => listeners.delete(listener)
 }
 
-/** The session's recently-completed tasks for `root` (empty for any other graph). */
-export function useRecentlyCompleted(root: string | null): readonly OpenTask[] {
+/**
+ * The session's recently-completed tasks for `root` (empty for any other graph),
+ * reconciled against the live open-tasks read: passing the open query's data in
+ * is what lets a task reopened at its source note shed its struck shadow here
+ * ({@link reconcileRecentlyCompleted}), so every surface that renders the set
+ * gets that reconciliation for free.
+ */
+export function useRecentlyCompleted(
+  root: string | null,
+  open: readonly OpenTask[] | undefined,
+): readonly OpenTask[] {
+  useEffect(() => {
+    if (open !== undefined) {
+      reconcileRecentlyCompleted(root, open)
+    }
+  }, [root, open])
   const getSnapshot = useCallback(() => (root === graphRoot ? tasks : EMPTY), [root])
   return useSyncExternalStore(subscribe, getSnapshot)
 }

--- a/apps/desktop/src/lib/tasks/recently-completed.ts
+++ b/apps/desktop/src/lib/tasks/recently-completed.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useSyncExternalStore } from 'react'
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react'
 import { type OpenTask } from '@reflect/core'
 import { withCheckedMarker } from '@/lib/tasks/task-cache'
 import { taskKey } from '@/lib/tasks/task-identity'
@@ -82,25 +82,46 @@ export function hasRecentlyCompleted(root: string | null, key: string): boolean 
 }
 
 /**
- * Reconcile the struck set against a fresh open-tasks read. A struck task the
+ * The struck rows not superseded by a live open row — the pure core of the
+ * reconciliation, shared by the store prune ({@link reconcileRecentlyCompleted})
+ * and the render-time view in {@link useRecentlyCompleted}. A struck task the
  * index reports open again with a **newer** `updatedAt` was reopened at the
  * source note — its file was rewritten and reindexed since we completed it — so
  * the struck copy is dropped and the live open row shows instead of a stale
  * `[x]` shadow (whose reopen write-back would fail: the `[x]` line is no longer
  * in the note). An open row with an *unchanged* `updatedAt` is the
  * pre-completion index state — a refetch racing the completion's reindex — and
- * keeps its shadow, so a just-checked row can't flicker back to open.
+ * keeps its shadow, so a just-checked row can't flicker back to open. Returns
+ * the input array itself when nothing is dropped, so callers can compare by
+ * reference.
  */
-export function reconcileRecentlyCompleted(root: string | null, open: readonly OpenTask[]): void {
-  if (root !== graphRoot || tasks.length === 0 || open.length === 0) {
-    return
+function withoutReopened(
+  struck: readonly OpenTask[],
+  open: readonly OpenTask[],
+): readonly OpenTask[] {
+  if (struck.length === 0 || open.length === 0) {
+    return struck
   }
   const liveByKey = new Map(open.map((row) => [taskKey(row), row]))
-  const next = tasks.filter((struck) => {
-    const live = liveByKey.get(taskKey(struck))
-    return live === undefined || live.updatedAt <= struck.updatedAt
+  const next = struck.filter((task) => {
+    const live = liveByKey.get(taskKey(task))
+    return live === undefined || live.updatedAt <= task.updatedAt
   })
-  if (next.length !== tasks.length) {
+  return next.length === struck.length ? struck : next
+}
+
+/**
+ * Reconcile the struck set against a fresh open-tasks read, dropping every
+ * struck copy whose task was reopened at its source note ({@link
+ * withoutReopened}) — so `hasRecentlyCompleted` and the Archive count agree
+ * with what the surfaces render.
+ */
+export function reconcileRecentlyCompleted(root: string | null, open: readonly OpenTask[]): void {
+  if (root !== graphRoot) {
+    return
+  }
+  const next = withoutReopened(tasks, open)
+  if (next !== tasks) {
     tasks = next
     emit()
   }
@@ -123,9 +144,14 @@ function subscribe(listener: () => void): () => void {
 /**
  * The session's recently-completed tasks for `root` (empty for any other graph),
  * reconciled against the live open-tasks read: passing the open query's data in
- * is what lets a task reopened at its source note shed its struck shadow here
- * ({@link reconcileRecentlyCompleted}), so every surface that renders the set
- * gets that reconciliation for free.
+ * is what lets a task reopened at its source note shed its struck shadow, so
+ * every surface that renders the set gets that reconciliation for free.
+ *
+ * The returned view filters superseded rows **during render** — the very first
+ * render with the fresh open data already shows the live row, leaving no frame
+ * where the stale `[x]` shadow could still offer a doomed Reopen. The store
+ * itself is pruned in an effect ({@link reconcileRecentlyCompleted}) so
+ * `hasRecentlyCompleted` and the Archive count catch up right after.
  */
 export function useRecentlyCompleted(
   root: string | null,
@@ -137,7 +163,8 @@ export function useRecentlyCompleted(
     }
   }, [root, open])
   const getSnapshot = useCallback(() => (root === graphRoot ? tasks : EMPTY), [root])
-  return useSyncExternalStore(subscribe, getSnapshot)
+  const struck = useSyncExternalStore(subscribe, getSnapshot)
+  return useMemo(() => (open === undefined ? struck : withoutReopened(struck, open)), [struck, open])
 }
 
 /** Test-only: clear the singleton between cases. */

--- a/apps/desktop/src/lib/tasks/task-visibility.ts
+++ b/apps/desktop/src/lib/tasks/task-visibility.ts
@@ -46,6 +46,9 @@ export interface TaskListSources {
  * - Any open row also present struck is dropped from the open side — a refetch
  *   can briefly restore a just-completed task to the open cache before the
  *   reindex lands, and listing it both open and struck collides React keys.
+ *   That shadow is only ever transient: a task genuinely reopened at its source
+ *   note leaves the session set via `reconcileRecentlyCompleted` (its reindexed
+ *   row carries a newer `updatedAt`), so the live open row takes over.
  */
 export function composeVisibleTaskGroups({
   open,

--- a/apps/desktop/src/mobile/screens/tasks.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.tsx
@@ -64,7 +64,7 @@ export function MobileTasks(): ReactElement {
   const isError = openFailed || (filters.archived && completedFailed)
   const ready = open !== undefined && (!filters.archived || completed !== undefined)
 
-  const recentlyCompleted = useRecentlyCompleted(graph?.root ?? null)
+  const recentlyCompleted = useRecentlyCompleted(graph?.root ?? null, open)
   const actions = useTaskActions()
 
   // Defer the needle like the All tab defers its query: fast typing coalesces


### PR DESCRIPTION
## Problem

Task View deliberately keeps a session-only middle state: a task completed there stays visible, struck through, until you archive it (V1's workflow, with a quick undo path). A support report exposed the missing reconciliation path: if the same checkbox is flipped back to `[ ]` in the source note (e.g. a daily note), the index reports the task open again — but the session's `[x]` copy kept shadowing the real open row. The row kept offering **Reopen**, and clicking it tried to locate the old `[x]` line in markdown that had already changed, producing the "task line no longer in note" toast.

## Change

The struck set now yields to the index when they disagree, using `updatedAt` (the note's indexed mtime, epoch ms) to tell a genuine reopen apart from a stale read:

- **`reconcileRecentlyCompleted(root, open)`** (`apps/desktop/src/lib/tasks/recently-completed.ts`): a live open row with the same task key and a **strictly newer** `updatedAt` means the note was rewritten and reindexed since the completion — the struck shadow is dropped and the live row shows.
- An open row with an **unchanged** `updatedAt` is the pre-completion index state — a refetch racing the completion's reindex — and keeps its shadow, preserving the existing guarantee that a just-checked row can't flicker back to open (`tasks-screen.test.tsx` covers both directions).
- `useRecentlyCompleted(root)` → `useRecentlyCompleted(root, open)`: the hook reconciles against the open query's data internally, so the desktop screen and the mobile Tasks tab get the fix through the one shared path and future surfaces can't skip it.
- The reconciliation applies at two layers (second commit, after a Bugbot finding): the returned view filters superseded rows **during render** — the very first render that sees the fresh open data shows the live row, leaving no frame where the stale shadow could still offer a doomed Reopen — while an effect prunes the store singleton so `hasRecentlyCompleted` and the Archive count agree immediately after. Both layers share one pure core (`withoutReopened`).

No write-path changes; this is purely view-state reconciliation. The completed-on-disk `[x]` history behind "show archived" is untouched.

## Why `updatedAt` is the right discriminator

`notes.updated_at` is stamped from the file's mtime on every reindex (`apply_note` in `src-tauri/src/db/write.rs`). A reopened task can only reappear in the open read after its note was rewritten and reindexed, so its row necessarily carries a newer `updatedAt` than the copy captured at completion time. The stale-refetch race returns the pre-completion row with the original `updatedAt`, so strict `>` separates the two cases exactly.

## Testing

- New unit tests for `reconcileRecentlyCompleted` (drop on newer `updatedAt`, hold on equal, graph-root scoping, hook-level reconcile + store prune agreement).
- A render-phase capture test proves the superseded shadow is excluded in the same render that sees the fresh open data, before any effect runs.
- New `TasksScreen` integration tests: external reopen sheds the struck row and offers **Complete** again; a refetch racing the completion's reindex keeps the row struck.
- `pnpm check` (typecheck + oxlint + eslint) clean; full task + mobile suites pass (36 files, 345 tests).

## Risk

Low. The reconcile only ever *removes* entries from the ephemeral session set, and only when the index reports the task open with a newer note mtime. Worst case on a pathological mtime tie (sub-millisecond complete-then-reopen) is the current behavior, not a new failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> View-only reconciliation that only removes ephemeral session entries when open index data disagrees; no persistence or write-path changes.
> 
> **Overview**
> Fixes Task View keeping a session **struck** `[x]` row after the same checkbox is unchecked in the source note, which masked the live open row and made **Reopen** fail against markdown that no longer had that line.
> 
> **`useRecentlyCompleted(root, open)`** now takes the open-tasks query data. Shared logic **`withoutReopened`** drops a struck copy when the index reports the same task key open with a **strictly newer** `updatedAt` (genuine reopen after reindex); equal `updatedAt` keeps the shadow so a refetch racing completion does not flicker the row back to open. **`reconcileRecentlyCompleted`** prunes the module store in an effect; the hook also filters superseded rows **during render** so the first frame with fresh open data shows **Complete**, not a doomed **Reopen**. Desktop **`TasksScreen`** and mobile **`MobileTasks`** pass `open`; **`task-visibility`** docs note that reopened tasks leave the session set this way.
> 
> New unit and **`TasksScreen`** integration tests cover both reconciliation directions; no task write-path changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c039d871f25aa1fef24ac51eb588b4138e66574. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reopened tasks now update correctly, so completed items no longer linger in the recent-completed list.
  * Task status updates are more stable during refreshes, reducing brief flickers between completed and open states.
  * Task lists now stay consistent across desktop and mobile when items are reopened or reindexed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->