### PR TITLE
Release v0.4.0-beta.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4743,7 +4743,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.4.0-beta.18"
+version = "0.4.0-beta.19"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.4.0-beta.18"
+version = "0.4.0-beta.19"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.4.0-beta.18",
+  "version": "0.4.0-beta.19",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.4.0-beta.19.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version bump with no logic or dependency changes; typical low-risk release housekeeping.
> 
> **Overview**
> Bumps the desktop **Reflect** release from `0.4.0-beta.18` to **`0.4.0-beta.19`** so the Tauri app, Rust crate, and lockfile stay aligned for tagging and distribution.
> 
> Updates `version` in `apps/desktop/src-tauri/Cargo.toml` (`reflect-open`), `apps/desktop/src-tauri/tauri.conf.json`, and the matching `reflect-open` entry in `Cargo.lock`. No application or dependency changes beyond the version string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e113ff0b07c9883bdb56715ad9a9e02f8fac5a84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->