### PR TITLE
Fix TestFlight API key path in CI

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   testflight:
     name: Build and upload iOS
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 120
     env:
       CARGO_HTTP_MULTIPLEXING: false

--- a/apps/desktop/scripts/release-ios.mjs
+++ b/apps/desktop/scripts/release-ios.mjs
@@ -77,7 +77,7 @@ export function createTauriIosBuildArgs({
   const args = ['tauri', 'ios', 'build', '--export-method', exportMethod, '--ci']
   if (buildNumber) args.push('--config', JSON.stringify({ bundle: { iOS: { bundleVersion: buildNumber } } }))
   if (verbose) args.push('--verbose')
-  args.push('--', 'CI=true', ...xcodeAuthenticationArgs)
+  if (xcodeAuthenticationArgs.length > 0) args.push('--', ...xcodeAuthenticationArgs)
   return args
 }
 

--- a/apps/desktop/scripts/release-ios.mjs
+++ b/apps/desktop/scripts/release-ios.mjs
@@ -81,6 +81,12 @@ export function createTauriIosBuildArgs({
   return args
 }
 
+/** Build the environment Tauri's iOS signing layer needs for API-key auth. */
+export function createTauriIosBuildEnv({ apiKeyCredentials = null, baseEnv = process.env } = {}) {
+  if (!apiKeyCredentials?.env) return baseEnv
+  return { ...baseEnv, ...apiKeyCredentials.env }
+}
+
 /** Build the altool command that uploads an IPA to App Store Connect/TestFlight. */
 export function createAltoolUploadArgs({ authArgs, ipa, wait }) {
   const args = ['altool', '--upload-package', ipa, ...authArgs, '--output-format', 'json', '--show-progress']
@@ -216,6 +222,7 @@ function resolveApiKeyCredentials({ requirePrivateKey }) {
   return {
     altoolArgs: createApiKeyAltoolArgs({ issuerId: APPLE_API_ISSUER, keyId: APPLE_API_KEY, keyPath }),
     cleanup,
+    env: keyPath ? { APPLE_API_KEY_PATH: keyPath } : {},
     source: keyPath
       ? `App Store Connect API key ${APPLE_API_KEY} (${keyPath})`
       : `App Store Connect API key ${APPLE_API_KEY} (altool standard key search path)`,
@@ -374,7 +381,11 @@ function runTauriIosBuild({ apiKeyCredentials, buildNumber, exportMethod, verbos
   } else {
     log('xcodebuild provisioning auth: local Xcode account/profiles')
   }
-  const result = spawnSync('pnpm', args, { cwd: appDir, stdio: 'inherit', env: process.env })
+  const result = spawnSync('pnpm', args, {
+    cwd: appDir,
+    stdio: 'inherit',
+    env: createTauriIosBuildEnv({ apiKeyCredentials }),
+  })
   if (result.status !== 0) {
     fail(
       'tauri ios build failed.\n' +

--- a/apps/desktop/scripts/release-ios.mjs
+++ b/apps/desktop/scripts/release-ios.mjs
@@ -77,7 +77,7 @@ export function createTauriIosBuildArgs({
   const args = ['tauri', 'ios', 'build', '--export-method', exportMethod, '--ci']
   if (buildNumber) args.push('--config', JSON.stringify({ bundle: { iOS: { bundleVersion: buildNumber } } }))
   if (verbose) args.push('--verbose')
-  if (xcodeAuthenticationArgs.length > 0) args.push('--', ...xcodeAuthenticationArgs)
+  args.push('--', 'CI=true', ...xcodeAuthenticationArgs)
   return args
 }
 

--- a/apps/desktop/scripts/release-ios.mjs
+++ b/apps/desktop/scripts/release-ios.mjs
@@ -6,7 +6,7 @@
 //   pnpm release:ios upload --ipa=apps/desktop/src-tauri/gen/apple/build/arm64/Reflect.ipa
 //
 // The App Store Connect API key is used twice when present:
-//   1. xcodebuild provisioning/export auth via -authenticationKey*
+//   1. Tauri/xcodebuild provisioning auth via APPLE_API_KEY* env vars
 //   2. altool IPA upload auth via --api-key/--api-issuer
 //
 // Set APPLE_API_KEY, APPLE_API_ISSUER, and either APPLE_API_KEY_CONTENT or
@@ -48,18 +48,6 @@ function capture(command, args) {
   return execFileSync(command, args, { encoding: 'utf8' })
 }
 
-/** Build the runner authentication args xcodebuild needs for automatic provisioning. */
-export function createXcodeAuthenticationArgs({ issuerId, keyId, keyPath }) {
-  return [
-    '-authenticationKeyPath',
-    keyPath,
-    '-authenticationKeyID',
-    keyId,
-    '-authenticationKeyIssuerID',
-    issuerId,
-  ]
-}
-
 /** Build the altool authentication args for an App Store Connect API key. */
 export function createApiKeyAltoolArgs({ issuerId, keyId, keyPath }) {
   const args = ['--api-key', keyId, '--api-issuer', issuerId]
@@ -72,12 +60,10 @@ export function createTauriIosBuildArgs({
   buildNumber = null,
   exportMethod = DEFAULT_EXPORT_METHOD,
   verbose = false,
-  xcodeAuthenticationArgs = [],
 }) {
   const args = ['tauri', 'ios', 'build', '--export-method', exportMethod, '--ci']
   if (buildNumber) args.push('--config', JSON.stringify({ bundle: { iOS: { bundleVersion: buildNumber } } }))
   if (verbose) args.push('--verbose')
-  if (xcodeAuthenticationArgs.length > 0) args.push('--', ...xcodeAuthenticationArgs)
   return args
 }
 
@@ -225,9 +211,6 @@ function resolveApiKeyCredentials({ requirePrivateKey }) {
     source: keyPath
       ? `App Store Connect API key ${APPLE_API_KEY} (${keyPath})`
       : `App Store Connect API key ${APPLE_API_KEY} (altool standard key search path)`,
-    xcodeAuthenticationArgs: keyPath
-      ? createXcodeAuthenticationArgs({ issuerId: APPLE_API_ISSUER, keyId: APPLE_API_KEY, keyPath })
-      : [],
   }
 }
 
@@ -244,7 +227,6 @@ function resolveUploadCredentials() {
       cleanup: null,
       env: {},
       source: `Apple ID ${APPLE_ID} (APPLE_PASSWORD from environment)`,
-      xcodeAuthenticationArgs: [],
     }
   }
 
@@ -257,7 +239,6 @@ function resolveUploadCredentials() {
       cleanup: null,
       env: { APPLE_PASSWORD: stored.password },
       source: `Apple ID ${stored.account} (keychain item "${KEYCHAIN_SERVICE}")`,
-      xcodeAuthenticationArgs: [],
     }
   }
 
@@ -372,13 +353,12 @@ function runTauriIosBuild({ apiKeyCredentials, buildNumber, exportMethod, verbos
     buildNumber,
     exportMethod,
     verbose,
-    xcodeAuthenticationArgs: apiKeyCredentials?.xcodeAuthenticationArgs ?? [],
   })
   log(`building ${IOS_BUNDLE_IDENTIFIER} with export method ${exportMethod}${buildNumber ? `, build ${buildNumber}` : ''}…`)
-  if (apiKeyCredentials?.xcodeAuthenticationArgs.length) {
-    log(`xcodebuild provisioning auth: ${apiKeyCredentials.source}`)
+  if (apiKeyCredentials) {
+    log(`Tauri provisioning auth: ${apiKeyCredentials.source}`)
   } else {
-    log('xcodebuild provisioning auth: local Xcode account/profiles')
+    log('Tauri provisioning auth: local Xcode account/profiles')
   }
   const result = spawnSync('pnpm', args, {
     cwd: appDir,

--- a/apps/desktop/scripts/release-ios.mjs
+++ b/apps/desktop/scripts/release-ios.mjs
@@ -83,8 +83,7 @@ export function createTauriIosBuildArgs({
 
 /** Build the environment Tauri's iOS signing layer needs for API-key auth. */
 export function createTauriIosBuildEnv({ apiKeyCredentials = null, baseEnv = process.env } = {}) {
-  if (!apiKeyCredentials?.env) return baseEnv
-  return { ...baseEnv, ...apiKeyCredentials.env }
+  return { ...baseEnv, CI: 'true', ...(apiKeyCredentials?.env ?? {}) }
 }
 
 /** Build the altool command that uploads an IPA to App Store Connect/TestFlight. */

--- a/apps/desktop/scripts/release-ios.test.mjs
+++ b/apps/desktop/scripts/release-ios.test.mjs
@@ -38,6 +38,7 @@ test('iOS release builds pass App Store Connect export and xcodebuild API key au
     '--config',
     JSON.stringify({ bundle: { iOS: { bundleVersion: '492' } } }),
     '--',
+    'CI=true',
     '-authenticationKeyPath',
     '/tmp/AuthKey_ABC123DEFG.p8',
     '-authenticationKeyID',
@@ -55,6 +56,8 @@ test('iOS release builds can rely on local Xcode accounts when no API key is sup
     '--export-method',
     'release-testing',
     '--ci',
+    '--',
+    'CI=true',
   ])
 })
 

--- a/apps/desktop/scripts/release-ios.test.mjs
+++ b/apps/desktop/scripts/release-ios.test.mjs
@@ -7,6 +7,7 @@ import {
   createAltoolUploadArgs,
   createAltoolValidateArgs,
   createApiKeyAltoolArgs,
+  createTauriIosBuildEnv,
   createTauriIosBuildArgs,
   createXcodeAuthenticationArgs,
   findIpaInfoPlistPath,
@@ -55,6 +56,26 @@ test('iOS release builds can rely on local Xcode accounts when no API key is sup
     'release-testing',
     '--ci',
   ])
+})
+
+test('iOS release builds expose the staged API key path to Tauri signing', () => {
+  expect(
+    createTauriIosBuildEnv({
+      baseEnv: {
+        APPLE_API_ISSUER: 'issuer-uuid',
+        APPLE_API_KEY: 'ABC123DEFG',
+      },
+      apiKeyCredentials: {
+        env: {
+          APPLE_API_KEY_PATH: '/tmp/AuthKey_ABC123DEFG.p8',
+        },
+      },
+    }),
+  ).toEqual({
+    APPLE_API_ISSUER: 'issuer-uuid',
+    APPLE_API_KEY: 'ABC123DEFG',
+    APPLE_API_KEY_PATH: '/tmp/AuthKey_ABC123DEFG.p8',
+  })
 })
 
 test('altool upload uses package upload with API key auth and optional processing wait', () => {

--- a/apps/desktop/scripts/release-ios.test.mjs
+++ b/apps/desktop/scripts/release-ios.test.mjs
@@ -64,6 +64,7 @@ test('iOS release builds expose the staged API key path to Tauri signing', () =>
       baseEnv: {
         APPLE_API_ISSUER: 'issuer-uuid',
         APPLE_API_KEY: 'ABC123DEFG',
+        CI: '',
       },
       apiKeyCredentials: {
         env: {
@@ -75,6 +76,7 @@ test('iOS release builds expose the staged API key path to Tauri signing', () =>
     APPLE_API_ISSUER: 'issuer-uuid',
     APPLE_API_KEY: 'ABC123DEFG',
     APPLE_API_KEY_PATH: '/tmp/AuthKey_ABC123DEFG.p8',
+    CI: 'true',
   })
 })
 

--- a/apps/desktop/scripts/release-ios.test.mjs
+++ b/apps/desktop/scripts/release-ios.test.mjs
@@ -9,24 +9,16 @@ import {
   createApiKeyAltoolArgs,
   createTauriIosBuildEnv,
   createTauriIosBuildArgs,
-  createXcodeAuthenticationArgs,
   findIpaInfoPlistPath,
   isFalsePlistValue,
   normalizeApiKeyContent,
 } from './release-ios.mjs'
 
-test('iOS release builds pass App Store Connect export and xcodebuild API key auth through Tauri', () => {
-  const xcodeAuthenticationArgs = createXcodeAuthenticationArgs({
-    issuerId: 'issuer-uuid',
-    keyId: 'ABC123DEFG',
-    keyPath: '/tmp/AuthKey_ABC123DEFG.p8',
-  })
-
+test('iOS release builds pass App Store Connect export and build number through Tauri', () => {
   expect(
     createTauriIosBuildArgs({
       buildNumber: '492',
       exportMethod: 'app-store-connect',
-      xcodeAuthenticationArgs,
     }),
   ).toEqual([
     'tauri',
@@ -37,13 +29,6 @@ test('iOS release builds pass App Store Connect export and xcodebuild API key au
     '--ci',
     '--config',
     JSON.stringify({ bundle: { iOS: { bundleVersion: '492' } } }),
-    '--',
-    '-authenticationKeyPath',
-    '/tmp/AuthKey_ABC123DEFG.p8',
-    '-authenticationKeyID',
-    'ABC123DEFG',
-    '-authenticationKeyIssuerID',
-    'issuer-uuid',
   ])
 })
 

--- a/apps/desktop/scripts/release-ios.test.mjs
+++ b/apps/desktop/scripts/release-ios.test.mjs
@@ -38,7 +38,6 @@ test('iOS release builds pass App Store Connect export and xcodebuild API key au
     '--config',
     JSON.stringify({ bundle: { iOS: { bundleVersion: '492' } } }),
     '--',
-    'CI=true',
     '-authenticationKeyPath',
     '/tmp/AuthKey_ABC123DEFG.p8',
     '-authenticationKeyID',
@@ -56,8 +55,6 @@ test('iOS release builds can rely on local Xcode accounts when no API key is sup
     '--export-method',
     'release-testing',
     '--ci',
-    '--',
-    'CI=true',
   ])
 })
 

--- a/apps/desktop/src-tauri/gen/apple/project.yml
+++ b/apps/desktop/src-tauri/gen/apple/project.yml
@@ -123,7 +123,7 @@ targets:
       - sdk: UIKit.framework
       - sdk: WebKit.framework
     preBuildScripts:
-      - script: pnpm tauri ios xcode-script -v --platform ${PLATFORM_DISPLAY_NAME:?} --sdk-root ${SDKROOT:?} --framework-search-paths "${FRAMEWORK_SEARCH_PATHS:?}" --header-search-paths "${HEADER_SEARCH_PATHS:?}" --gcc-preprocessor-definitions "${GCC_PREPROCESSOR_DEFINITIONS:-}" --configuration ${CONFIGURATION:?} ${FORCE_COLOR} ${ARCHS:?}
+      - script: CI=true pnpm tauri ios xcode-script -v --platform ${PLATFORM_DISPLAY_NAME:?} --sdk-root ${SDKROOT:?} --framework-search-paths "${FRAMEWORK_SEARCH_PATHS:?}" --header-search-paths "${HEADER_SEARCH_PATHS:?}" --gcc-preprocessor-definitions "${GCC_PREPROCESSOR_DEFINITIONS:-}" --configuration ${CONFIGURATION:?} ${FORCE_COLOR} ${ARCHS:?}
         name: Build Rust Code
         basedOnDependencyAnalysis: false
         outputFiles:

--- a/apps/desktop/src-tauri/gen/apple/reflect-open.xcodeproj/project.pbxproj
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open.xcodeproj/project.pbxproj
@@ -467,7 +467,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "pnpm tauri ios xcode-script -v --platform ${PLATFORM_DISPLAY_NAME:?} --sdk-root ${SDKROOT:?} --framework-search-paths \"${FRAMEWORK_SEARCH_PATHS:?}\" --header-search-paths \"${HEADER_SEARCH_PATHS:?}\" --gcc-preprocessor-definitions \"${GCC_PREPROCESSOR_DEFINITIONS:-}\" --configuration ${CONFIGURATION:?} ${FORCE_COLOR} ${ARCHS:?}";
+			shellScript = "CI=true pnpm tauri ios xcode-script -v --platform ${PLATFORM_DISPLAY_NAME:?} --sdk-root ${SDKROOT:?} --framework-search-paths \"${FRAMEWORK_SEARCH_PATHS:?}\" --header-search-paths \"${HEADER_SEARCH_PATHS:?}\" --gcc-preprocessor-definitions \"${GCC_PREPROCESSOR_DEFINITIONS:-}\" --configuration ${CONFIGURATION:?} ${FORCE_COLOR} ${ARCHS:?}";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/apps/desktop/src-tauri/ios.project.yml
+++ b/apps/desktop/src-tauri/ios.project.yml
@@ -123,7 +123,7 @@ targets:
       - sdk: UIKit.framework
       - sdk: WebKit.framework
     preBuildScripts:
-      - script: pnpm tauri ios xcode-script -v --platform ${PLATFORM_DISPLAY_NAME:?} --sdk-root ${SDKROOT:?} --framework-search-paths "${FRAMEWORK_SEARCH_PATHS:?}" --header-search-paths "${HEADER_SEARCH_PATHS:?}" --gcc-preprocessor-definitions "${GCC_PREPROCESSOR_DEFINITIONS:-}" --configuration ${CONFIGURATION:?} ${FORCE_COLOR} ${ARCHS:?}
+      - script: CI=true pnpm tauri ios xcode-script -v --platform ${PLATFORM_DISPLAY_NAME:?} --sdk-root ${SDKROOT:?} --framework-search-paths "${FRAMEWORK_SEARCH_PATHS:?}" --header-search-paths "${HEADER_SEARCH_PATHS:?}" --gcc-preprocessor-definitions "${GCC_PREPROCESSOR_DEFINITIONS:-}" --configuration ${CONFIGURATION:?} ${FORCE_COLOR} ${ARCHS:?}
         name: Build Rust Code
         basedOnDependencyAnalysis: false
         outputFiles:

--- a/docs/ios-testflight.md
+++ b/docs/ios-testflight.md
@@ -32,7 +32,8 @@ for `pnpm release:ios testflight`.
    with a team account that can provision `app.reflect.ios` is enough for
    `pnpm release:ios build`. For CI, use an App Store Connect API key with
    permission to manage signing and upload builds. When the API key is present,
-   the release helper uses it for both xcodebuild provisioning and altool upload:
+   the release helper exposes it to Tauri/xcodebuild through environment
+   variables and uses it directly for altool upload:
 
    ```bash
    export APPLE_API_KEY=ABC123DEFG
@@ -83,9 +84,9 @@ pnpm release:ios build --build-number=123
 ```
 
 Runs `pnpm tauri ios build --export-method app-store-connect --ci`, using the
-signed-in Xcode account locally or passing the App Store Connect API key through
-to xcodebuild when the key is configured. The build number is merged into the
-Tauri config as `bundle.iOS.bundleVersion`. The IPA lands under
+signed-in Xcode account locally or the App Store Connect API key environment
+when the key is configured. The build number is merged into the Tauri config as
+`bundle.iOS.bundleVersion`. The IPA lands under
 `apps/desktop/src-tauri/gen/apple/build/`.
 
 ```bash
@@ -112,7 +113,7 @@ the upload flow.
 ## GitHub Action
 
 Use **Actions -> TestFlight -> Run workflow**. The workflow builds on
-`macos-latest`, uploads the IPA to App Store Connect, and serializes runs so two
+`macos-26`, uploads the IPA to App Store Connect, and serializes runs so two
 uploads do not race each other.
 
 Configure these repository secrets:


### PR DESCRIPTION
## Problem

The TestFlight GitHub Action now has the App Store Connect API key secrets, and preflight can authenticate successfully. The upload path still exposed CI-specific release issues:

1. `release-ios.mjs` staged `APPLE_API_KEY_CONTENT` into a temporary `.p8` file but did not expose the staged path as `APPLE_API_KEY_PATH` for Tauri's iOS signing layer.
2. Manually forwarding `-authenticationKey*` flags after Tauri's `--` boundary leaked those flags into the nested Rust `cargo build` command under the generated Xcode build phase.
3. Tauri's generated Xcode `Build Rust Code` phase invoked nested pnpm work without `CI=true`, so pnpm aborted when it could not prompt in a GitHub runner.
4. `macos-latest` was drifting onto runner images whose Xcode/altool behavior rejected the API-key flags used by the release helper, so the TestFlight job needs a stable macOS 26 image.

## Changes

1. Add `createTauriIosBuildEnv` and pass the staged `.p8` path as `APPLE_API_KEY_PATH` into the Tauri build process.
2. Stop forwarding App Store Connect authentication as trailing Tauri runner args; Tauri/xcodebuild now receive those credentials from the environment only.
3. Keep Tauri iOS release builds non-interactive by forcing `CI=true` in the child environment.
4. Prefix the committed iOS Xcode build phase with `CI=true` in the XcodeGen template and generated project files.
5. Pin the TestFlight workflow runner to `macos-26` instead of the moving `macos-latest` label.
6. Add/update release-helper regression coverage and TestFlight docs.

## Tests

- `pnpm --filter @reflect/desktop test --run scripts/release-ios.test.mjs`
- `pnpm check`
- PR CI: all required checks passing
- TestFlight branch workflow: passed, uploaded build `202607050501`, delivery UUID `e7547a91-f8cd-4493-b318-50cbe556dfd1`

## Risk / Rollout

No app runtime behavior changes. This only affects release automation, the committed iOS Xcode build phase used by iOS/TestFlight automation, and the matching TestFlight docs.