### PR TITLE
Simplify graph picker onboarding

### DIFF
--- a/apps/desktop/src/components/graph-chooser.test.tsx
+++ b/apps/desktop/src/components/graph-chooser.test.tsx
@@ -124,7 +124,8 @@ describe('GraphChooser', () => {
     render(<GraphChooser />, { wrapper })
 
     await screen.findByRole('button', { name: 'Notes' })
-    expect(screen.getByText('Your notes are already in iCloud.')).toBeInTheDocument()
+    expect(screen.getByText('Open an existing graph from iCloud Drive.')).toBeInTheDocument()
+    expect(screen.getByText('or create new graph')).toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: 'Work' }))
 
     await waitFor(() =>

--- a/apps/desktop/src/components/graph-chooser.tsx
+++ b/apps/desktop/src/components/graph-chooser.tsx
@@ -13,6 +13,9 @@ import { graphColorCss } from '@/lib/graph-colors'
 import { cn } from '@/lib/utils'
 import { useGraph } from '@/providers/graph-provider'
 
+const CHOOSER_BUTTON_CLASS =
+  'transition-[background-color,border-color,box-shadow,transform,color] duration-150 hover:-translate-y-0.5 hover:border-primary/30 hover:bg-surface-hover hover:shadow-sm'
+
 /** iCloud is a real option only in the macOS shell. */
 function isIcloudCapablePlatform(): boolean {
   return import.meta.env.TAURI_ENV_PLATFORM === 'darwin'
@@ -23,10 +26,11 @@ function isIcloudCapablePlatform(): boolean {
  * plainly: where do your notes live? iCloud is the recommended default —
  * every graph already in the container is listed to open, and a name field
  * creates a new one right there. Choosing a folder yourself is the
- * self-managed path (Git sync, local-only).
+ * self-managed path.
  *
- * "Graph" is deliberately absent — newcomers don't know the word yet; the
- * iCloud card asks for a "name" and the folder card talks about folders.
+ * The iCloud card uses "graph" only where the user is deciding between
+ * existing containers and creating another one; the folder card talks about
+ * folders.
  */
 export function GraphChooser(): ReactElement {
   const { recents, error, pickAndOpen, openRecent, createAt, forget } = useGraph()
@@ -56,13 +60,12 @@ export function GraphChooser(): ReactElement {
             icon={<Folder aria-hidden className="size-4" strokeWidth={1.75} />}
             title="A folder you choose"
           >
-            Keep notes in any folder on this {icloudCapable ? 'Mac' : 'computer'}. Sync with
-            GitHub from Settings, or keep them local.
+            Keep notes in any folder on this {icloudCapable ? 'Mac' : 'computer'}.
           </CardHeader>
           <Button
             type="button"
             variant={icloudCapable ? 'outline' : 'default'}
-            className="mt-auto w-full"
+            className={cn('mt-auto w-full', CHOOSER_BUTTON_CLASS)}
             onClick={() => void pickAndOpen()}
           >
             <FolderPlus aria-hidden strokeWidth={1.75} />
@@ -242,7 +245,7 @@ function IcloudCard({
         tinted
       >
         {existing.length > 0
-          ? 'Your notes are already in iCloud.'
+          ? 'Open an existing graph from iCloud Drive.'
           : available
             ? 'Syncs across your Mac and iPhone. Backed up automatically.'
             : status === undefined
@@ -256,7 +259,7 @@ function IcloudCard({
               <Button
                 type="button"
                 variant="outline"
-                className="w-full justify-start"
+                className={cn('w-full justify-start', CHOOSER_BUTTON_CLASS)}
                 disabled={pending}
                 onClick={() => open(root)}
               >
@@ -274,7 +277,8 @@ function IcloudCard({
       {existing.length > 0 ? (
         // Compact create row under the list: a new graph next to the
         // existing ones is the secondary action here, not the headline.
-        <div className="mt-auto space-y-1.5">
+        <div className="mt-auto space-y-2">
+          <ChooserDivider>or create new graph</ChooserDivider>
           <div className="flex gap-2">
             <Input
               aria-label="Name"
@@ -292,7 +296,7 @@ function IcloudCard({
             <Button
               type="button"
               variant="outline"
-              className="shrink-0"
+              className={cn('shrink-0', CHOOSER_BUTTON_CLASS)}
               disabled={pending || cleanName === null || nameTaken}
               onClick={() => void create()}
             >
@@ -324,7 +328,7 @@ function IcloudCard({
           </div>
           <Button
             type="button"
-            className="w-full"
+            className={cn('w-full', CHOOSER_BUTTON_CLASS)}
             disabled={!available || pending || cleanName === null}
             onClick={() => void create()}
           >
@@ -334,5 +338,15 @@ function IcloudCard({
         </div>
       )}
     </section>
+  )
+}
+
+function ChooserDivider({ children }: { children: string }): ReactElement {
+  return (
+    <div className="flex items-center gap-3 py-1">
+      <span aria-hidden className="h-px flex-1 bg-border" />
+      <span className="text-2xs font-medium text-text-muted">{children}</span>
+      <span aria-hidden className="h-px flex-1 bg-border" />
+    </div>
   )
 }

--- a/apps/desktop/src/components/graph-chooser.tsx
+++ b/apps/desktop/src/components/graph-chooser.tsx
@@ -13,9 +13,6 @@ import { graphColorCss } from '@/lib/graph-colors'
 import { cn } from '@/lib/utils'
 import { useGraph } from '@/providers/graph-provider'
 
-const CHOOSER_BUTTON_CLASS =
-  'transition-[background-color,border-color,box-shadow,transform,color] duration-150 hover:-translate-y-0.5 hover:border-primary/30 hover:bg-surface-hover hover:shadow-sm'
-
 /** iCloud is a real option only in the macOS shell. */
 function isIcloudCapablePlatform(): boolean {
   return import.meta.env.TAURI_ENV_PLATFORM === 'darwin'
@@ -65,7 +62,7 @@ export function GraphChooser(): ReactElement {
           <Button
             type="button"
             variant={icloudCapable ? 'outline' : 'default'}
-            className={cn('mt-auto w-full', CHOOSER_BUTTON_CLASS)}
+            className="mt-auto w-full"
             onClick={() => void pickAndOpen()}
           >
             <FolderPlus aria-hidden strokeWidth={1.75} />
@@ -259,7 +256,7 @@ function IcloudCard({
               <Button
                 type="button"
                 variant="outline"
-                className={cn('w-full justify-start', CHOOSER_BUTTON_CLASS)}
+                className="w-full justify-start"
                 disabled={pending}
                 onClick={() => open(root)}
               >
@@ -296,7 +293,7 @@ function IcloudCard({
             <Button
               type="button"
               variant="outline"
-              className={cn('shrink-0', CHOOSER_BUTTON_CLASS)}
+              className="shrink-0"
               disabled={pending || cleanName === null || nameTaken}
               onClick={() => void create()}
             >
@@ -328,7 +325,7 @@ function IcloudCard({
           </div>
           <Button
             type="button"
-            className={cn('w-full', CHOOSER_BUTTON_CLASS)}
+            className="w-full"
             disabled={!available || pending || cleanName === null}
             onClick={() => void create()}
           >

--- a/apps/desktop/src/components/sidebar/graph-footer.tsx
+++ b/apps/desktop/src/components/sidebar/graph-footer.tsx
@@ -76,9 +76,10 @@ export function GraphFooter({ graph, context }: GraphFooterProps): ReactElement 
         <Tooltip delayDuration={700}>
           <TooltipTrigger asChild>
             <DropdownMenuTrigger asChild>
-              <button
+              <Button
                 type="button"
-                className="group flex min-w-0 flex-1 items-center space-x-2.5 rounded-md px-1.5 py-1 text-left transition-colors duration-100 hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                variant="ghost"
+                className="group h-auto min-w-0 flex-1 justify-start gap-2.5 px-1.5 py-1 text-left"
               >
                 <GraphSwatch
                   color={colorFor(graph.root)}
@@ -103,7 +104,7 @@ export function GraphFooter({ graph, context }: GraphFooterProps): ReactElement 
                     Indexing
                   </span>
                 ) : null}
-              </button>
+              </Button>
             </DropdownMenuTrigger>
           </TooltipTrigger>
           <TooltipContent>{graph.root}</TooltipContent>

--- a/apps/desktop/src/components/sidebar/graph-footer.tsx
+++ b/apps/desktop/src/components/sidebar/graph-footer.tsx
@@ -78,13 +78,13 @@ export function GraphFooter({ graph, context }: GraphFooterProps): ReactElement 
             <DropdownMenuTrigger asChild>
               <button
                 type="button"
-                className="flex min-w-0 flex-1 items-center space-x-2.5 text-left"
+                className="group flex min-w-0 flex-1 items-center space-x-2.5 rounded-md px-1.5 py-1 text-left transition-colors duration-100 hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
               >
                 <GraphSwatch
                   color={colorFor(graph.root)}
                   className={cn('h-5 w-5', indexing && 'motion-safe:animate-pulse')}
                 />
-                <span className="min-w-0 truncate text-xs font-medium text-text-secondary">
+                <span className="min-w-0 truncate text-xs font-medium text-text-secondary transition-colors duration-100 group-hover:text-text">
                   {graph.name}
                 </span>
                 {dot !== null ? (

--- a/apps/desktop/src/components/ui/button.tsx
+++ b/apps/desktop/src/components/ui/button.tsx
@@ -9,15 +9,15 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/80",
+        default: "bg-primary text-primary-foreground hover:-translate-y-0.5 hover:bg-primary/80 hover:shadow-sm",
         outline:
-          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+          "border-border bg-background hover:-translate-y-0.5 hover:bg-muted hover:text-foreground hover:shadow-sm aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+          "bg-secondary text-secondary-foreground hover:-translate-y-0.5 hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] hover:shadow-sm aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         ghost:
-          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+          "hover:-translate-y-0.5 hover:bg-muted hover:text-foreground hover:shadow-sm aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:
-          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+          "bg-destructive/10 text-destructive hover:-translate-y-0.5 hover:bg-destructive/20 hover:shadow-sm focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/apps/desktop/src/mobile/onboarding-screen.test.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.test.tsx
@@ -1,11 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { setBridge, type MobileStorageInfo } from '@reflect/core'
-import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
+import type { MobileStorageInfo } from '@reflect/core'
 import { MobileOnboardingScreen } from './onboarding-screen'
-
-vi.mock('@tauri-apps/plugin-http', () => ({ fetch: vi.fn() }))
-const httpFetch = vi.mocked(tauriFetch)
 
 const completeOnboarding = vi.hoisted(() => vi.fn(async (_kind: string, _root?: string) => {}))
 const storageInfo = vi.hoisted<{ current: unknown }>(() => ({ current: null }))
@@ -17,47 +13,16 @@ function setStorage(info: MobileStorageInfo): void {
   storageInfo.current = info
 }
 
-let cloned: Array<Record<string, unknown>>
-/** When set, `git_clone` never resolves — to exercise the in-flight UI. */
-let hangClone: boolean
-
 beforeEach(() => {
-  cloned = []
-  hangClone = false
   setStorage({
     localRoot: '/Documents',
     icloudDocumentsRoot: '/iCloud/Documents',
     icloudGraphRoots: [],
   })
-  setBridge({
-    invoke: async (command, args) => {
-      if (command === 'secret_get') {
-        // A stored credential lets the auth step advance straight to the repo step.
-        return JSON.stringify({ kind: 'pat', token: 'ghp_abc' })
-      }
-      if (command === 'git_clone') {
-        cloned.push(args)
-        if (hangClone) {
-          return new Promise(() => {}) // stays pending
-        }
-        return null
-      }
-      return null
-    },
-    listen: async () => () => {},
-  })
-  // GET /user accepts the stored token and identifies the account.
-  httpFetch.mockResolvedValue(
-    new Response(JSON.stringify({ login: 'alex' }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    }),
-  )
 })
 
 afterEach(() => {
   cleanup()
-  setBridge(null)
   vi.clearAllMocks()
 })
 
@@ -71,7 +36,6 @@ describe('MobileOnboardingScreen', () => {
     await waitFor(() =>
       expect(completeOnboarding).toHaveBeenCalledWith('icloud', '/iCloud/Documents/Notes'),
     )
-    expect(cloned).toEqual([])
   })
 
   it('lists every container graph while keeping create available', async () => {
@@ -82,7 +46,8 @@ describe('MobileOnboardingScreen', () => {
     })
     render(<MobileOnboardingScreen />)
 
-    expect(screen.getByText('Open an existing set of notes, or create another.')).toBeTruthy()
+    expect(screen.getByText('Open an existing graph from iCloud Drive.')).toBeTruthy()
+    expect(screen.getByText('or create new graph')).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Notes' })).toBeTruthy()
     expect((screen.getByRole('button', { name: 'Create' }) as HTMLButtonElement).disabled).toBe(
       true,
@@ -116,7 +81,6 @@ describe('MobileOnboardingScreen', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Keep notes on this device' }))
 
     await waitFor(() => expect(completeOnboarding).toHaveBeenCalledWith('local'))
-    expect(cloned).toEqual([])
   })
 
   it('hides the iCloud action and explains why when iCloud is unavailable', () => {
@@ -130,92 +94,11 @@ describe('MobileOnboardingScreen', () => {
     expect(screen.getByRole('button', { name: 'Keep notes on this device' })).toBeTruthy()
   })
 
-  it('clones the chosen repo into the local root, then completes onboarding', async () => {
+  it('does not offer repository setup from the first-run picker', () => {
     render(<MobileOnboardingScreen />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Sync with GitHub instead' }))
-    // The stored credential auto-advances past auth to the repo step.
-    await waitFor(() => expect(screen.getByLabelText('Backup repository')).toBeTruthy())
-
-    fireEvent.change(screen.getByLabelText('Backup repository'), {
-      target: { value: 'notes' }, // bare name → the signed-in account
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Download & open' }))
-
-    await waitFor(() =>
-      expect(cloned).toEqual([
-        { url: 'https://github.com/alex/notes.git', path: '/Documents', token: 'ghp_abc' },
-      ]),
-    )
-    expect(completeOnboarding).toHaveBeenCalledWith('local')
-  })
-
-  it('submits the repo step from the keyboard (Enter in the input)', async () => {
-    render(<MobileOnboardingScreen />)
-
-    fireEvent.click(screen.getByRole('button', { name: 'Sync with GitHub instead' }))
-    await waitFor(() => expect(screen.getByLabelText('Backup repository')).toBeTruthy())
-
-    const repoInput = screen.getByLabelText('Backup repository')
-    fireEvent.change(repoInput, { target: { value: 'notes' } })
-    fireEvent.keyDown(repoInput, { key: 'Enter' })
-
-    await waitFor(() =>
-      expect(cloned).toEqual([
-        { url: 'https://github.com/alex/notes.git', path: '/Documents', token: 'ghp_abc' },
-      ]),
-    )
-    expect(completeOnboarding).toHaveBeenCalledWith('local')
-  })
-
-  it('ignores Enter while a clone is already in flight (no overlapping clones)', async () => {
-    hangClone = true
-    render(<MobileOnboardingScreen />)
-
-    fireEvent.click(screen.getByRole('button', { name: 'Sync with GitHub instead' }))
-    await waitFor(() => expect(screen.getByLabelText('Backup repository')).toBeTruthy())
-
-    const repoInput = screen.getByLabelText('Backup repository')
-    fireEvent.change(repoInput, { target: { value: 'notes' } })
-    fireEvent.keyDown(repoInput, { key: 'Enter' })
-    await waitFor(() => expect(cloned).toHaveLength(1))
-
-    fireEvent.keyDown(repoInput, { key: 'Enter' })
-    fireEvent.keyDown(repoInput, { key: 'Enter' })
-    expect(cloned).toHaveLength(1)
-  })
-
-  it('disables Back while a clone is in flight (can’t leave it running)', async () => {
-    hangClone = true
-    render(<MobileOnboardingScreen />)
-
-    fireEvent.click(screen.getByRole('button', { name: 'Sync with GitHub instead' }))
-    await waitFor(() => expect(screen.getByLabelText('Backup repository')).toBeTruthy())
-
-    fireEvent.change(screen.getByLabelText('Backup repository'), { target: { value: 'notes' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Download & open' }))
-
-    // The clone is pending, so Back must be disabled — leaving would let the
-    // clone finish and open the graph after the user returned to the choice.
-    await waitFor(() =>
-      expect((screen.getByRole('button', { name: 'Back' }) as HTMLButtonElement).disabled).toBe(
-        true,
-      ),
-    )
-  })
-
-  it('rejects an empty repo name instead of cloning', async () => {
-    render(<MobileOnboardingScreen />)
-
-    fireEvent.click(screen.getByRole('button', { name: 'Sync with GitHub instead' }))
-    await waitFor(() => expect(screen.getByLabelText('Backup repository')).toBeTruthy())
-
-    fireEvent.click(screen.getByRole('button', { name: 'Download & open' }))
-
-    expect(
-      await screen.findByText('Enter the repository name (or owner/name for another account).'),
-    ).toBeTruthy()
-    expect(cloned).toEqual([])
-    expect(completeOnboarding).not.toHaveBeenCalled()
+    expect(screen.queryByRole('button', { name: /github/i })).toBeNull()
+    expect(screen.queryByText(/backup repository/i)).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Download & open' })).toBeNull()
   })
 })

--- a/apps/desktop/src/mobile/onboarding-screen.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.tsx
@@ -1,14 +1,6 @@
 import { useId, useState, type ReactElement } from 'react'
-import {
-  getGithubToken,
-  githubRemoteUrl,
-  gitClone,
-  ReflectError,
-  type GithubUser,
-} from '@reflect/core'
-import { Cloud, FolderOpen, GitBranch, HardDrive, Plus } from 'lucide-react'
+import { Cloud, FolderOpen, HardDrive, Plus } from 'lucide-react'
 import { InlineAlert } from '@/components/inline-alert'
-import { GithubAuthStep } from '@/components/settings/github-auth-step'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Spinner } from '@/components/ui/spinner'
@@ -19,16 +11,15 @@ import {
   graphRootForName,
   isGraphNameTaken,
 } from '@/lib/graph-names'
-import { parseRepoInput } from '@/lib/github-repos'
-import { providerFetch } from '@/lib/provider-fetch'
 import { useGraph } from '@/providers/graph-provider'
 
-type Step = 'choose' | 'auth' | 'repo'
+const MOBILE_ACTION_BUTTON_CLASS =
+  'transition-[background-color,border-color,box-shadow,transform,color] duration-150 hover:-translate-y-0.5 hover:border-primary/30 hover:bg-surface-hover hover:shadow-sm'
 
 /** Which control kicked off the in-flight choice, so only that one shows the
  * spinner/pending label (every button still disables). Container graph roots
  * are absolute paths, so the fixed tags can never collide with one. */
-type PendingChoice = string | 'icloud-create' | 'local' | 'clone' | null
+type PendingChoice = string | 'icloud-create' | 'local' | null
 
 /**
  * The mobile first-run screen (Plans 19/21) — shown until the user picks
@@ -40,22 +31,15 @@ type PendingChoice = string | 'icloud-create' | 'local' | 'clone' | null
  * iCloud container (one tap opens it — the container can hold several), plus
  * a create row for a new container graph. **Keep notes on this device** opens
  * the app-sandbox root instead (and is promoted to the only storage button
- * when iCloud is unavailable). Git users can still connect from the **Sync
- * with GitHub instead** link: the shared device flow ({@link GithubAuthStep}),
- * then a clone *straight into* the local root — `git_clone` refuses a
- * non-empty directory, so this only works while that root is untouched, which
- * is exactly why the provider defers opening until now. Every path ends in
+ * when iCloud is unavailable). Every path ends in
  * `completeOnboarding(kind, root)`, which opens the chosen root and records
  * the flag + storage kind + graph name.
  */
 export function MobileOnboardingScreen(): ReactElement {
   const { mobileStorageInfo, completeOnboarding } = useGraph()
   const action = useAsyncAction()
-  const [step, setStep] = useState<Step>('choose')
   const [pendingChoice, setPendingChoice] = useState<PendingChoice>(null)
   const [typedIcloudName, setTypedIcloudName] = useState<string | null>(null)
-  const [repoInput, setRepoInput] = useState('')
-  const [user, setUser] = useState<GithubUser | null>(null)
   const icloudNameId = useId()
 
   const icloudDocumentsRoot = mobileStorageInfo?.icloudDocumentsRoot ?? null
@@ -91,38 +75,6 @@ export function MobileOnboardingScreen(): ReactElement {
     runChoice('local', () => completeOnboarding('local'))
   }
 
-  function downloadAndOpen(): void {
-    if (action.pending) {
-      return // Enter in the repo field must not overlap a running clone.
-    }
-    // A bare name belongs to the signed-in account — the common case never
-    // needs the owner typed (mirrors the desktop restore dialog).
-    const trimmed = repoInput.trim()
-    const normalized =
-      !trimmed.includes('/') && trimmed.length > 0 && user !== null
-        ? `${user.login}/${trimmed}`
-        : trimmed
-    const ref = parseRepoInput(normalized)
-    if (ref === null) {
-      action.setError('Enter the repository name (or owner/name for another account).')
-      return
-    }
-    const localRoot = mobileStorageInfo?.localRoot ?? null
-    if (localRoot === null) {
-      action.setError('No graph folder available.')
-      return
-    }
-    runChoice('clone', async () => {
-      const token = await getGithubToken(providerFetch)
-      if (token === null) {
-        throw new ReflectError('auth', 'Sign in to GitHub first')
-      }
-      await gitClone(githubRemoteUrl(ref), localRoot, token)
-      // Opens the clone (a 'local' graph); the index rebuilds from the files.
-      await completeOnboarding('local')
-    })
-  }
-
   return (
     <div
       className="flex min-h-dvh w-screen overflow-auto bg-surface-app px-5 text-text"
@@ -135,43 +87,41 @@ export function MobileOnboardingScreen(): ReactElement {
         <div className="flex flex-col gap-1.5 text-center">
           <h1 className="text-xl font-semibold tracking-tight">Welcome to Reflect</h1>
           <p className="text-sm text-text-muted">
-            {step === 'choose'
-              ? 'Your notes are plain markdown files. Choose where to keep them.'
-              : 'Sign in to GitHub, then choose the repository to download.'}
+            Your notes are plain markdown files. Choose where to keep them.
           </p>
         </div>
 
-        {step === 'choose' ? (
-          <div className="flex flex-col gap-3">
-            {icloudReady ? (
-              <section className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-4">
-                <div className="flex items-start gap-3">
-                  <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                    <Cloud aria-hidden className="size-4" strokeWidth={1.75} />
-                  </div>
-                  <div className="min-w-0 flex-1 space-y-1">
-                    <div className="flex items-center gap-2">
-                      <h2 className="text-sm font-semibold">iCloud Drive</h2>
-                      <span className="rounded-full bg-secondary px-2 py-0.5 text-[11px] font-medium text-secondary-foreground">
-                        Recommended
-                      </span>
-                    </div>
-                    <p className="text-xs text-text-muted">
-                      {icloudGraphs.length > 0
-                        ? 'Open an existing set of notes, or create another.'
-                        : 'Syncs with Reflect on your other devices.'}
-                    </p>
-                  </div>
+        <div className="flex flex-col gap-3">
+          {icloudReady ? (
+            <section className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-4">
+              <div className="flex items-start gap-3">
+                <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                  <Cloud aria-hidden className="size-4" strokeWidth={1.75} />
                 </div>
+                <div className="min-w-0 flex-1 space-y-1">
+                  <div className="flex items-center gap-2">
+                    <h2 className="text-sm font-semibold">iCloud Drive</h2>
+                    <span className="rounded-full bg-secondary px-2 py-0.5 text-[11px] font-medium text-secondary-foreground">
+                      Recommended
+                    </span>
+                  </div>
+                  <p className="text-xs text-text-muted">
+                    {icloudGraphs.length > 0
+                      ? 'Open an existing graph from iCloud Drive.'
+                      : 'Syncs with Reflect on your other devices.'}
+                  </p>
+                </div>
+              </div>
 
-                {icloudGraphs.length > 0 ? (
+              {icloudGraphs.length > 0 ? (
+                <>
                   <ul className="flex flex-col gap-1.5">
                     {icloudGraphs.map((root) => (
                       <li key={root}>
                         <Button
                           type="button"
                           variant="outline"
-                          className="w-full justify-start"
+                          className={`w-full justify-start ${MOBILE_ACTION_BUTTON_CLASS}`}
                           onClick={() => openIcloudGraph(root)}
                           disabled={action.pending}
                         >
@@ -185,123 +135,71 @@ export function MobileOnboardingScreen(): ReactElement {
                       </li>
                     ))}
                   </ul>
-                ) : null}
+                  <MobileDivider>or create new graph</MobileDivider>
+                </>
+              ) : null}
 
-                <div className="flex flex-col gap-1.5">
-                  <label htmlFor={icloudNameId} className="text-xs font-medium text-text-secondary">
-                    Name
-                  </label>
-                  <div className="flex gap-2">
-                    <Input
-                      id={icloudNameId}
-                      value={icloudName}
-                      placeholder={icloudGraphs.length > 0 ? 'New name' : undefined}
-                      enterKeyHint="go"
-                      onChange={(event) => setTypedIcloudName(event.target.value)}
-                      onKeyDown={(event) => {
-                        if (event.key === 'Enter') {
-                          createIcloudGraph()
-                        }
-                      }}
-                      aria-invalid={icloudNameTaken}
-                      disabled={action.pending}
-                    />
-                    <Button
-                      type="button"
-                      className="shrink-0"
-                      onClick={createIcloudGraph}
-                      disabled={action.pending || cleanIcloudName === null || icloudNameTaken}
-                    >
-                      {pendingChoice === 'icloud-create' ? (
-                        <Spinner />
-                      ) : (
-                        <Plus aria-hidden strokeWidth={1.75} />
-                      )}
-                      {pendingChoice === 'icloud-create' ? 'Setting up…' : 'Create'}
-                    </Button>
-                  </div>
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor={icloudNameId} className="text-xs font-medium text-text-secondary">
+                  Name
+                </label>
+                <div className="flex gap-2">
+                  <Input
+                    id={icloudNameId}
+                    value={icloudName}
+                    placeholder={icloudGraphs.length > 0 ? 'New name' : undefined}
+                    enterKeyHint="go"
+                    onChange={(event) => setTypedIcloudName(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') {
+                        createIcloudGraph()
+                      }
+                    }}
+                    aria-invalid={icloudNameTaken}
+                    disabled={action.pending}
+                  />
+                  <Button
+                    type="button"
+                    className={`shrink-0 ${MOBILE_ACTION_BUTTON_CLASS}`}
+                    onClick={createIcloudGraph}
+                    disabled={action.pending || cleanIcloudName === null || icloudNameTaken}
+                  >
+                    {pendingChoice === 'icloud-create' ? (
+                      <Spinner />
+                    ) : (
+                      <Plus aria-hidden strokeWidth={1.75} />
+                    )}
+                    {pendingChoice === 'icloud-create' ? 'Setting up…' : 'Create'}
+                  </Button>
                 </div>
-                {icloudNameTaken ? (
-                  <p className="text-xs text-destructive">
-                    That name already exists in iCloud Drive.
-                  </p>
-                ) : null}
-              </section>
-            ) : null}
+              </div>
+              {icloudNameTaken ? (
+                <p className="text-xs text-destructive">
+                  That name already exists in iCloud Drive.
+                </p>
+              ) : null}
+            </section>
+          ) : null}
 
-            <Button
-              variant={icloudReady ? 'outline' : 'default'}
-              onClick={keepOnDevice}
-              disabled={action.pending}
-            >
-              {pendingChoice === 'local' ? (
-                <Spinner />
-              ) : (
-                <HardDrive aria-hidden strokeWidth={1.75} />
-              )}
-              {pendingChoice === 'local' ? 'Setting up…' : 'Keep notes on this device'}
-            </Button>
-            {!icloudReady ? (
-              <p className="text-center text-xs text-text-muted">
-                Sign in to iCloud on this device to sync notes with iCloud Drive.
-              </p>
-            ) : null}
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={() => setStep('auth')}
-              disabled={action.pending}
-            >
-              <GitBranch aria-hidden strokeWidth={1.75} />
-              Sync with GitHub instead
-            </Button>
-          </div>
-        ) : step === 'auth' ? (
-          <div className="flex flex-col gap-3">
-            <GithubAuthStep
-              onAuthed={(authedUser) => {
-                setUser(authedUser)
-                setStep('repo')
-              }}
-            />
-            <LinkButton onClick={() => setStep('choose')} disabled={action.pending}>
-              Back
-            </LinkButton>
-          </div>
-        ) : (
-          <div className="flex flex-col gap-3">
-            <label className="flex flex-col gap-1">
-              <span className="text-xs font-medium text-text-secondary">Backup repository</span>
-              <Input
-                autoFocus
-                value={repoInput}
-                disabled={action.pending}
-                onChange={(event) => setRepoInput(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key === 'Enter') {
-                    downloadAndOpen()
-                  }
-                }}
-                placeholder={user !== null ? `${user.login}/…` : 'owner/name'}
-                enterKeyHint="go"
-                autoCapitalize="none"
-                autoCorrect="off"
-                spellCheck={false}
-              />
-            </label>
-            <Button onClick={downloadAndOpen} disabled={action.pending}>
-              {pendingChoice === 'clone' ? (
-                <Spinner />
-              ) : (
-                <GitBranch aria-hidden strokeWidth={1.75} />
-              )}
-              {pendingChoice === 'clone' ? 'Downloading…' : 'Download & open'}
-            </Button>
-            <LinkButton onClick={() => setStep('choose')} disabled={action.pending}>
-              Back
-            </LinkButton>
-          </div>
-        )}
+          <Button
+            variant={icloudReady ? 'outline' : 'default'}
+            className={MOBILE_ACTION_BUTTON_CLASS}
+            onClick={keepOnDevice}
+            disabled={action.pending}
+          >
+            {pendingChoice === 'local' ? (
+              <Spinner />
+            ) : (
+              <HardDrive aria-hidden strokeWidth={1.75} />
+            )}
+            {pendingChoice === 'local' ? 'Setting up…' : 'Keep notes on this device'}
+          </Button>
+          {!icloudReady ? (
+            <p className="text-center text-xs text-text-muted">
+              Sign in to iCloud on this device to sync notes with iCloud Drive.
+            </p>
+          ) : null}
+        </div>
 
         {action.error !== null ? <InlineAlert tone="error">{action.error}</InlineAlert> : null}
       </div>
@@ -309,23 +207,12 @@ export function MobileOnboardingScreen(): ReactElement {
   )
 }
 
-function LinkButton({
-  children,
-  onClick,
-  disabled,
-}: {
-  children: string
-  onClick: () => void
-  disabled?: boolean
-}): ReactElement {
+function MobileDivider({ children }: { children: string }): ReactElement {
   return (
-    <button
-      type="button"
-      className="text-center text-xs text-text-muted underline disabled:opacity-50"
-      onClick={onClick}
-      disabled={disabled}
-    >
-      {children}
-    </button>
+    <div className="flex items-center gap-3 py-1">
+      <span aria-hidden className="h-px flex-1 bg-border" />
+      <span className="text-[11px] font-medium text-text-muted">{children}</span>
+      <span aria-hidden className="h-px flex-1 bg-border" />
+    </div>
   )
 }

--- a/apps/desktop/src/mobile/onboarding-screen.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.tsx
@@ -13,9 +13,6 @@ import {
 } from '@/lib/graph-names'
 import { useGraph } from '@/providers/graph-provider'
 
-const MOBILE_ACTION_BUTTON_CLASS =
-  'transition-[background-color,border-color,box-shadow,transform,color] duration-150 hover:-translate-y-0.5 hover:border-primary/30 hover:bg-surface-hover hover:shadow-sm'
-
 /** Which control kicked off the in-flight choice, so only that one shows the
  * spinner/pending label (every button still disables). Container graph roots
  * are absolute paths, so the fixed tags can never collide with one. */
@@ -121,7 +118,7 @@ export function MobileOnboardingScreen(): ReactElement {
                         <Button
                           type="button"
                           variant="outline"
-                          className={`w-full justify-start ${MOBILE_ACTION_BUTTON_CLASS}`}
+                          className="w-full justify-start"
                           onClick={() => openIcloudGraph(root)}
                           disabled={action.pending}
                         >
@@ -160,7 +157,7 @@ export function MobileOnboardingScreen(): ReactElement {
                   />
                   <Button
                     type="button"
-                    className={`shrink-0 ${MOBILE_ACTION_BUTTON_CLASS}`}
+                    className="shrink-0"
                     onClick={createIcloudGraph}
                     disabled={action.pending || cleanIcloudName === null || icloudNameTaken}
                   >
@@ -183,7 +180,6 @@ export function MobileOnboardingScreen(): ReactElement {
 
           <Button
             variant={icloudReady ? 'outline' : 'default'}
-            className={MOBILE_ACTION_BUTTON_CLASS}
             onClick={keepOnDevice}
             disabled={action.pending}
           >


### PR DESCRIPTION
## Problem

The graph picker/onboarding surfaces still mentioned GitHub in places where the user is only choosing where notes live. On iOS first run this showed up as a `Sync with GitHub instead` path, and on desktop the folder option pointed users at GitHub from the picker. The desktop iCloud card also used the confusing copy `Your notes are already in iCloud.` when it was really presenting a list of existing graphs.

The picker buttons also needed a hover treatment, but that belongs in the shared button primitive rather than being patched screen-by-screen.

This PR intentionally leaves the Settings backup flow alone; it only removes GitHub/Git references from graph picker/onboarding surfaces.

## Before -> After

| Surface | Before | After |
| --- | --- | --- |
| iOS first-run picker | iCloud, this-device, and GitHub clone path | iCloud and this-device only |
| Desktop folder option | Mentions syncing with GitHub from Settings | Neutral local-folder copy |
| Desktop existing iCloud graphs | `Your notes are already in iCloud.` | `Open an existing graph from iCloud Drive.` |
| iCloud list/create layout | Existing graphs and create form ran together | Divider copy: `or create new graph` |
| Button hover treatment | Patched locally in picker controls | Shared across non-link `Button` variants |

## Changes

1. Updates `GraphChooser` copy and separates the existing iCloud graph list from the create form.
2. Adds lift/shadow hover treatment to the shared `Button` variants, excluding link-style buttons.
3. Moves the desktop sidebar graph switcher trigger onto `Button` so it uses the shared hover behavior instead of a local raw-button patch.
4. Removes the GitHub auth/repo clone branch from `MobileOnboardingScreen`, including the `GitBranch` button and related state/imports.
5. Updates desktop and mobile onboarding tests to assert the new copy and that repository setup is no longer offered from the first-run picker.

## Tests

- `pnpm --filter @reflect/desktop test -- src/components/graph-chooser.test.tsx src/mobile/onboarding-screen.test.tsx` passed before the shared-button follow-up. Vitest reported 170 files / 1518 tests passed for the desktop package run.
- `pnpm --filter @reflect/desktop test -- src/components/graph-chooser.test.tsx src/mobile/onboarding-screen.test.tsx src/components/sidebar/sidebar.test.tsx` passed after the shared-button follow-up. Vitest again reported 170 files / 1518 tests passed.
- `pnpm check` passed after each commit. Lint emitted existing max-lines warnings only.

## Risk / Rollout

Low risk: this is UI copy/layout plus removal of the first-run GitHub clone affordance. No migrations or data changes. GitHub backup/settings code remains available outside the picker.

The hover treatment is intentionally centralized in `Button`, so reviewers should sanity-check dense button surfaces where the new lift/shadow applies globally to non-link variants.
