### PR TITLE
fix(chooser): drop cached iCloud listing after graph delete

### DIFF
--- a/apps/desktop/src/components/graph-chooser.tsx
+++ b/apps/desktop/src/components/graph-chooser.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input'
 import { Spinner } from '@/components/ui/spinner'
 import { useGraphColors } from '@/hooks/use-graph-colors'
 import { cleanGraphName, graphNameFromRoot, isGraphNameTaken } from '@/lib/graph-names'
+import { ICLOUD_STATUS_QUERY_KEY } from '@/lib/query-client'
 import { graphColorCss } from '@/lib/graph-colors'
 import { cn } from '@/lib/utils'
 import { useGraph } from '@/providers/graph-provider'
@@ -198,7 +199,7 @@ function IcloudCard({
   const [busy, setBusy] = useState<IcloudBusy>(null)
   const nameId = useId()
   const { data: status } = useQuery({
-    queryKey: ['icloud-status'],
+    queryKey: ICLOUD_STATUS_QUERY_KEY,
     queryFn: icloudStatus,
     enabled: hasBridge(),
   })

--- a/apps/desktop/src/components/settings/icloud-section.tsx
+++ b/apps/desktop/src/components/settings/icloud-section.tsx
@@ -15,6 +15,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { isICloudRoot } from '@/lib/icloud-controller'
+import { ICLOUD_STATUS_QUERY_KEY } from '@/lib/query-client'
 import { isMacosDesktop } from '@/lib/platform'
 import { useGraph } from '@/providers/graph-provider'
 import { useSync } from '@/providers/sync-provider'
@@ -40,7 +41,7 @@ export function IcloudSection(): ReactElement | null {
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const { data: status } = useQuery({
-    queryKey: ['icloud-status'],
+    queryKey: ICLOUD_STATUS_QUERY_KEY,
     queryFn: icloudStatus,
     enabled: hasBridge() && isMacosDesktop,
   })

--- a/apps/desktop/src/lib/query-client.ts
+++ b/apps/desktop/src/lib/query-client.ts
@@ -28,6 +28,19 @@ export function invalidateIndexQueries(): void {
   void queryClient.invalidateQueries({ queryKey: [INDEX_QUERY_SCOPE] })
 }
 
+/** The iCloud container listing (`icloud_status`) — read by the graph chooser and Settings → iCloud. */
+export const ICLOUD_STATUS_QUERY_KEY = ['icloud-status'] as const
+
+/**
+ * Forget the cached iCloud container listing after its contents change (a
+ * graph delete trashes a container directory). Removal rather than
+ * invalidation: with an invalidated cache the chooser would render the stale
+ * list — deleted graph included — while the refetch runs.
+ */
+export function dropIcloudStatusQuery(): void {
+  queryClient.removeQueries({ queryKey: ICLOUD_STATUS_QUERY_KEY })
+}
+
 /** Chat-history queries nest under this key (e.g. `['chat', 'conversations', root]`). */
 export const CHAT_QUERY_SCOPE = 'chat'
 

--- a/apps/desktop/src/providers/graph-provider.test.tsx
+++ b/apps/desktop/src/providers/graph-provider.test.tsx
@@ -6,6 +6,7 @@ import { open } from '@tauri-apps/plugin-dialog'
 import { setBridge } from '@reflect/core'
 import { GraphProvider, useGraph } from './graph-provider'
 import { SettingsProvider } from './settings-provider'
+import { ICLOUD_STATUS_QUERY_KEY, queryClient as appQueryClient } from '@/lib/query-client'
 
 vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn() }))
 
@@ -209,6 +210,33 @@ describe('GraphProvider open sequencing', () => {
     expect(result.current.graph).toBeNull()
     expect(result.current.indexGeneration).toBeNull()
     expect(result.current.recents).toEqual([])
+  })
+
+  it('drops the cached iCloud listing when the graph is deleted', async () => {
+    storedRecents = [{ root: '/known', name: 'known', openedMs: 1 }]
+    const { result } = renderHook(() => useGraph(), { wrapper })
+
+    await act(async () => {
+      await waitFor(() => expect(pendingOpens.has('/known')).toBe(true))
+      resolveOpen('/known')
+    })
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+
+    // The chooser's listing was cached before the delete; without the drop it
+    // would keep showing the deleted graph (queries never go stale on their own).
+    appQueryClient.setQueryData(ICLOUD_STATUS_QUERY_KEY, {
+      available: true,
+      documentsRoot: '/icloud/Documents',
+      existingGraphRoots: ['/known'],
+    })
+
+    await act(async () => {
+      await result.current.deleteGraph()
+    })
+
+    expect(invokeLog).toContain('graph_delete')
+    expect(result.current.status).toBe('choosing')
+    expect(appQueryClient.getQueryData(ICLOUD_STATUS_QUERY_KEY)).toBeUndefined()
   })
 
   it('returns to the graph chooser without opening the folder picker', async () => {

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -29,7 +29,7 @@ import {
 } from '@reflect/core'
 import { followHealedMove } from '@/editor/move-note'
 import { resetNoteRowOverlays } from '@/hooks/note-row-overlay'
-import { invalidateIndexQueries } from '@/lib/query-client'
+import { dropIcloudStatusQuery, invalidateIndexQueries } from '@/lib/query-client'
 import { ensureWelcomeNote } from '@/lib/welcome-note'
 import { useSettings } from '@/providers/settings-provider'
 import { createGraphIndex } from './graph-index'
@@ -486,6 +486,10 @@ export function GraphProvider({
       }
       throw err
     }
+    // The delete trashed a directory the chooser may list — drop the cached
+    // iCloud listing so the chooser refetches it rather than showing the
+    // deleted graph (queries never go stale on their own, see query-client).
+    dropIcloudStatusQuery()
     if (seq === openSeq.current) {
       await closeActiveGraph()
     }


### PR DESCRIPTION
## Problem

Deleting an iCloud graph from Settings → Danger zone pushed the user back to the graph chooser — with the just-deleted graph still listed under iCloud graphs. Clicking it would try to open a trashed directory.

The chooser's `IcloudCard` reads the container listing from the `['icloud-status']` query, and the app's query client uses `staleTime: Infinity` (freshness is event-driven by design). No event invalidated this query on delete, so the chooser rendered the pre-delete cache for the rest of the session.

## Changes

- **`lib/query-client.ts`** — new shared `ICLOUD_STATUS_QUERY_KEY` constant and `dropIcloudStatusQuery()` helper, following the existing `invalidateIndexQueries` pattern. It uses `removeQueries` rather than `invalidateQueries`: invalidation would still render the stale list — deleted graph included — while the refetch runs; removal shows the chooser's "Checking iCloud…" state, then the fresh list.
- **`providers/graph-provider.tsx`** — `deleteGraph` drops the cached listing right after `graph_delete` succeeds, before returning to the chooser. Unconditional (not gated on the root being an iCloud path): the refetch is a cheap local listing and the iCloud path heuristic differs across platforms.
- **`graph-chooser.tsx` / `settings/icloud-section.tsx`** — use the shared key constant instead of duplicated `['icloud-status']` literals.

## Testing

- New regression test in `graph-provider.test.tsx`: seeds the cached listing, deletes the open graph, asserts the cache entry is removed and the provider lands on the chooser.
- `graph-provider`, `graph-chooser`, and `settings-screen` suites pass (65 tests); `pnpm check` exits 0.
- Not re-verified in the running app; the delete flow itself is unchanged, only the cache side-effect is new.

## Notes for review

Same staleness class still exists for other container changes (e.g. "Move graph to iCloud", or a graph created on another device mid-session won't appear on a later chooser visit). Left out of scope here — say the word if the chooser should refetch on every mount instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, event-driven cache fix on graph lifecycle; no auth or data-model changes beyond avoiding stale UI after delete.
> 
> **Overview**
> Fixes the graph chooser still listing an iCloud graph after **Settings → Danger zone** delete, because the `icloud-status` query stayed cached under `staleTime: Infinity` with no invalidation on delete.
> 
> Adds **`ICLOUD_STATUS_QUERY_KEY`** and **`dropIcloudStatusQuery()`** in `query-client.ts`, using **`removeQueries`** (not `invalidateQueries`) so the chooser does not briefly show the stale list while a refetch runs. **`deleteGraph`** in `graph-provider` calls this after a successful `graph_delete`, before returning to the chooser. The graph chooser and Settings iCloud section share the constant instead of inline `['icloud-status']` keys.
> 
> A regression test seeds the cache, deletes the graph, and asserts the cache entry is cleared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9d17c1fee435b9bb34ca009c7c3f7455405fd51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved iCloud graph handling so deleted graphs no longer keep appearing in the chooser.
  - Updated cached iCloud status to refresh correctly after graph deletion, reducing stale or incorrect chooser results.
  - Added coverage to ensure the app clears outdated iCloud listing data when a graph is removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->