### PR TITLE
Fix iOS onboarding storage choices

### DIFF
--- a/apps/desktop/src-tauri/src/icloud/storage.rs
+++ b/apps/desktop/src-tauri/src/icloud/storage.rs
@@ -108,8 +108,8 @@ pub async fn icloud_download_pending(root: String) -> AppResult<u32> {
 /// [`mobile_storage`]. Resolving the iCloud container can take a long time on
 /// a fresh install (the first `URLForUbiquityContainerIdentifier` call
 /// provisions it and may touch the network); the local root needs none of
-/// that, and the onboarding screen's on-device and GitHub paths only need
-/// this. Same persistence rule as every container path: derive fresh, never
+/// that, and the onboarding screen's on-device fallback only needs this. Same
+/// persistence rule as every container path: derive fresh, never
 /// persist.
 #[tauri::command]
 pub fn mobile_storage_local(app: tauri::AppHandle) -> AppResult<String> {

--- a/apps/desktop/src/mobile/onboarding-icloud-section.tsx
+++ b/apps/desktop/src/mobile/onboarding-icloud-section.tsx
@@ -77,63 +77,63 @@ export function OnboardingIcloudSection(props: OnboardingIcloudSectionProps): Re
       ) : (
         <>
           {graphs.length > 0 ? (
-            <>
-              <ul className="flex flex-col gap-1.5">
-                {graphs.map((root) => (
-                  <li key={root}>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      className="w-full justify-start"
-                      onClick={() => onOpen(root)}
-                      disabled={busy}
-                    >
-                      {pendingChoice === root ? (
-                        <Spinner />
-                      ) : (
-                        <FolderOpen aria-hidden strokeWidth={1.75} />
-                      )}
-                      <span className="truncate">{graphNameFromRoot(root, root)}</span>
-                    </Button>
-                  </li>
-                ))}
-              </ul>
-              <MobileDivider>or create new graph</MobileDivider>
-            </>
+            <ul className="flex flex-col gap-1.5">
+              {graphs.map((root) => (
+                <li key={root}>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="w-full justify-start"
+                    onClick={() => onOpen(root)}
+                    disabled={busy}
+                  >
+                    {pendingChoice === root ? (
+                      <Spinner />
+                    ) : (
+                      <FolderOpen aria-hidden strokeWidth={1.75} />
+                    )}
+                    <span className="truncate">{graphNameFromRoot(root, root)}</span>
+                  </Button>
+                </li>
+              ))}
+            </ul>
           ) : null}
 
-          <div className="flex flex-col gap-1.5">
-            <label htmlFor={nameId} className="text-xs font-medium text-text-secondary">
-              Name
-            </label>
-            <div className="flex gap-2">
-              <Input
-                id={nameId}
-                value={name}
-                placeholder={graphs.length > 0 ? 'New name' : undefined}
-                enterKeyHint="go"
-                onChange={(event) => setTypedName(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key === 'Enter') {
-                    create()
-                  }
-                }}
-                aria-invalid={nameTaken}
-                disabled={busy}
-              />
-              <Button
-                type="button"
-                className="shrink-0"
-                onClick={create}
-                disabled={busy || cleanName === null || nameTaken}
-              >
-                {pendingChoice === 'icloud-create' ? (
-                  <Spinner />
-                ) : (
-                  <Plus aria-hidden strokeWidth={1.75} />
-                )}
-                {pendingChoice === 'icloud-create' ? 'Setting up…' : 'Create'}
-              </Button>
+          <div className="space-y-2">
+            {graphs.length > 0 ? <MobileDivider>or create new graph</MobileDivider> : null}
+            <div className="flex flex-col gap-1.5">
+              <label htmlFor={nameId} className="text-xs font-medium text-text-secondary">
+                Name
+              </label>
+              <div className="flex gap-2">
+                <Input
+                  id={nameId}
+                  value={name}
+                  placeholder={graphs.length > 0 ? 'New name' : undefined}
+                  enterKeyHint="go"
+                  onChange={(event) => setTypedName(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      create()
+                    }
+                  }}
+                  aria-invalid={nameTaken}
+                  disabled={busy}
+                />
+                <Button
+                  type="button"
+                  className="shrink-0"
+                  onClick={create}
+                  disabled={busy || cleanName === null || nameTaken}
+                >
+                  {pendingChoice === 'icloud-create' ? (
+                    <Spinner />
+                  ) : (
+                    <Plus aria-hidden strokeWidth={1.75} />
+                  )}
+                  {pendingChoice === 'icloud-create' ? 'Setting up…' : 'Create'}
+                </Button>
+              </div>
             </div>
           </div>
           {nameTaken ? (

--- a/apps/desktop/src/mobile/onboarding-screen.test.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.test.tsx
@@ -84,6 +84,8 @@ describe('MobileOnboardingScreen', () => {
   it('keeps notes on this device without cloning', async () => {
     render(<MobileOnboardingScreen />)
 
+    expect(screen.getByRole('heading', { name: 'This device' })).toBeTruthy()
+    expect(screen.getByText('Stored locally in Reflect on this device.')).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: 'Keep notes on this device' }))
 
     await waitFor(() => expect(completeOnboarding).toHaveBeenCalledWith('local'))
@@ -114,6 +116,7 @@ describe('MobileOnboardingScreen', () => {
     expect(
       screen.getByText('Sign in to iCloud on this device to sync notes with iCloud Drive.'),
     ).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'This device' })).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Keep notes on this device' })).toBeTruthy()
   })
 

--- a/apps/desktop/src/mobile/onboarding-screen.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.tsx
@@ -21,7 +21,7 @@ type PendingChoice = string | 'icloud-create' | 'local' | null
  * iPhone and Mac, so the hero block ({@link OnboardingIcloudSection}) lists
  * every graph already in the app's iCloud container plus a create row.
  * **Keep notes on this device** opens the app-sandbox root instead (and is
- * promoted to the only storage button when iCloud is unavailable). Every
+ * promoted to the only storage card when iCloud is unavailable). Every
  * path ends in `completeOnboarding(kind, root)`, which opens the chosen root
  * and records the flag + storage kind + graph name.
  *
@@ -79,18 +79,30 @@ export function MobileOnboardingScreen(): ReactElement {
             />
           ) : null}
 
-          <Button
-            variant={icloudReady || icloudPending ? 'outline' : 'default'}
-            onClick={() => runChoice('local', () => completeOnboarding('local'))}
-            disabled={action.pending || mobileStorageInfo === null}
-          >
-            {pendingChoice === 'local' ? (
-              <Spinner />
-            ) : (
-              <HardDrive aria-hidden strokeWidth={1.75} />
-            )}
-            {pendingChoice === 'local' ? 'Setting up…' : 'Keep notes on this device'}
-          </Button>
+          <section className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-4">
+            <div className="flex items-start gap-3">
+              <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-text-secondary">
+                <HardDrive aria-hidden className="size-4" strokeWidth={1.75} />
+              </div>
+              <div className="min-w-0 flex-1 space-y-1">
+                <h2 className="text-sm font-semibold">This device</h2>
+                <p className="text-xs text-text-muted">Stored locally in Reflect on this device.</p>
+              </div>
+            </div>
+            <Button
+              variant={icloudReady || icloudPending ? 'outline' : 'default'}
+              className="w-full"
+              onClick={() => runChoice('local', () => completeOnboarding('local'))}
+              disabled={action.pending || mobileStorageInfo === null}
+            >
+              {pendingChoice === 'local' ? (
+                <Spinner />
+              ) : (
+                <HardDrive aria-hidden strokeWidth={1.75} />
+              )}
+              {pendingChoice === 'local' ? 'Setting up…' : 'Keep notes on this device'}
+            </Button>
+          </section>
           {!icloudReady && !icloudPending ? (
             <p className="text-center text-xs text-text-muted">
               Sign in to iCloud on this device to sync notes with iCloud Drive.

--- a/packages/core/src/settings/schema.ts
+++ b/packages/core/src/settings/schema.ts
@@ -132,11 +132,10 @@ export const describeAssetsSchema = z.boolean().catch(true)
 
 /**
  * Whether the user has finished the mobile onboarding choice (Plan 19, step
- * 6): "Start fresh" or "Connect to GitHub". Off by default — a fresh install
- * shows the onboarding screen, which (for the GitHub path) clones into the
- * still-empty graph root before anything seeds it. Once set, later launches
- * open the fixed root directly. Mobile-only; desktop has its own chooser, so
- * this key is simply never read there.
+ * 6): iCloud Drive or this device. Off by default — a fresh install shows
+ * the onboarding screen before anything seeds a graph. Once set, later
+ * launches open the chosen storage root directly. Mobile-only; desktop has
+ * its own chooser, so this key is simply never read there.
  */
 export const mobileOnboardedSchema = z.boolean().catch(false)
 


### PR DESCRIPTION
## Problem

The iOS first-run Welcome to Reflect screen needed to make the current storage choices unmistakable. Existing iCloud graphs and the create-new form should read as separate actions, and the on-device path should have the same card treatment as the desktop graph picker. The old GitHub onboarding flow is no longer part of this screen, so stale source comments describing it were also misleading.

## Before -> After

| Before | After |
| --- | --- |
| The on-device option was a standalone button below the iCloud card. | The on-device option is a full card with an icon chip, heading, explanatory copy, and the action button. |
| The create-new iCloud form was visually adjacent to existing iCloud graph buttons. | The divider is grouped with the create form so `or create new graph` clearly marks a separate action. |
| Source comments still referenced the removed mobile GitHub onboarding path. | Onboarding comments now describe the current iCloud Drive vs this-device choice. |

## Changes

1. Updated `MobileOnboardingScreen` so "Keep notes on this device" renders inside a `This device` storage card matching the mobile iCloud card language.
2. Restructured `OnboardingIcloudSection` so the existing-graph list and create-new form are separated by a desktop-style `or create new graph` divider.
3. Expanded the onboarding regression test to pin the on-device card structure while retaining the existing no-GitHub/repository setup assertions.
4. Removed stale onboarding GitHub references from nearby settings/iCloud source comments.

## Tests

- `pnpm --dir apps/desktop exec vitest run src/mobile/onboarding-screen.test.tsx` passed: 1 file, 7 tests.
- `pnpm check` passed: typecheck plus lint. Lint still reports the repo's existing `max-lines` warnings.

## Risk / Rollout

No data migrations or storage behavior changes. This is a first-run mobile UI clarification plus comment cleanup; the existing `completeOnboarding` calls and storage roots are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> First-run mobile layout and comment-only Rust/settings updates; onboarding completion and storage paths are unchanged.
> 
> **Overview**
> **Clarifies the mobile first-run picker** so iCloud vs on-device storage reads like two parallel choices, without changing `completeOnboarding` or storage roots.
> 
> **This device** is no longer a lone button under the iCloud block. It uses the same bordered card pattern as iCloud Drive: icon chip, **This device** heading, short local-storage copy, and a full-width **Keep notes on this device** action (still `outline` when iCloud is shown, `default` when iCloud is unavailable).
> 
> In **OnboardingIcloudSection**, the **or create new graph** divider moves next to the name/create form instead of sitting between the existing-graph list and that form, so opening an existing graph vs creating one is visually separated.
> 
> Tests now assert the on-device card heading and copy. Rust and settings comments drop stale **GitHub** onboarding wording in favor of iCloud Drive vs this device.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2c6971735fea30b82f1e98a1b72de3184bd34a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The onboarding flow now presents local storage as a dedicated “This device” card, making the option clearer and more visually distinct.
  * The iCloud onboarding section now shows the “create new graph” divider only when existing graphs are available.

* **Bug Fixes**
  * Improved onboarding messaging and checks so the “This device” section is consistently shown in device-only and iCloud-unavailable cases.

* **Documentation**
  * Updated onboarding-related descriptions to better reflect the available storage choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->