### PR TITLE
fix(dev): implement mobile_storage_local in the browser dev bridge

### DIFF
--- a/apps/desktop/src/dev/dev-bridge.ts
+++ b/apps/desktop/src/dev/dev-bridge.ts
@@ -55,6 +55,8 @@ export function createDevBridge(backend: DevBridgeBackend): IpcBridge {
         // local-storage path (and, via `mobileOnboarded` above, skips
         // onboarding entirely).
         return { localRoot: DEV_GRAPH_ROOT, icloudDocumentsRoot: null, icloudGraphRoots: [] }
+      case 'mobile_storage_local':
+        return DEV_GRAPH_ROOT
       case 'icloud_download_pending':
         return 0
       case 'graph_open':
@@ -71,6 +73,9 @@ export function createDevBridge(backend: DevBridgeBackend): IpcBridge {
         return null
       case 'capture_inbox_list':
         return []
+      case 'capture_shared_inbox_relay':
+        // No share-extension App Group inbox in a browser; nothing to relay.
+        return 0
 
       case 'note_read': {
         const { path } = pathArgsSchema.parse(args)


### PR DESCRIPTION
## Problem

The mobile browser dev harness (`pnpm dev` + `/?platform=ios`, PR #481) is broken on `next`. Mobile boot now resolves the local graph root via the `mobile_storage_local` command (added in the iOS startup-perf work, #532), but the dev bridge only implements the older `mobile_storage` command. Boot rejects with `dev bridge: unimplemented command "mobile_storage_local"` and the harness parks on the "Couldn't open your notes" error screen.

## Changes

- `apps/desktop/src/dev/dev-bridge.ts`: answer `mobile_storage_local` with `DEV_GRAPH_ROOT`, the same fixed root `mobile_storage` reports (`mobileStorageLocal()` in core expects a plain string).
- Also stub `capture_shared_inbox_relay` (the share-extension inbox drain from #520, fired on every mobile boot) as `0` relayed items — it doesn't block boot, but it error-logged on every harness load. There is no App Group inbox in a plain browser.

## Verification

- `pnpm check` passes (only pre-existing max-lines warnings).
- Ran Vite and loaded `/?platform=ios` in a browser at a mobile viewport: the Daily screen renders with the seeded demo graph (daily note body, week strip, backlinks, tab bar), and neither command errors in the console anymore. Remaining console noise (keyboard plugin bridge unavailable) is pre-existing — that path talks to the Tauri keyboard plugin directly, not through the dev bridge.

## Risk

Dev-only: the bridge is browser-harness code, never bundled into the shipped app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)