### PR TITLE
perf(ios): pace the first-sync burst — sequenced downloads, throttled refetches, spaced sweeps

### DIFF
--- a/apps/desktop/src-tauri/src/icloud/storage.rs
+++ b/apps/desktop/src-tauri/src/icloud/storage.rs
@@ -97,11 +97,20 @@ pub async fn mobile_storage(app: tauri::AppHandle) -> AppResult<MobileStorage> {
 /// `.name.md.icloud` stub until something requests it. The frontend calls
 /// this once per open/resume for iCloud graphs; while the count stays above
 /// zero it polls [`icloud_pending_count`], which never re-requests.
+///
+/// `notes_only` restricts the request (and the count) to markdown under the
+/// note directories. A first sync sequences its downloads through this:
+/// requesting everything at once puts thousands of concurrent downloads —
+/// assets are most of the bytes — under the first index pass, and the app
+/// crawls until they drain. Notes first, then one `notes_only: false` call
+/// for the rest once the note count reaches zero.
 #[tauri::command]
-pub async fn icloud_download_pending(root: String) -> AppResult<u32> {
-    tauri::async_runtime::spawn_blocking(move || Ok(platform::pending_walk(Path::new(&root), true)))
-        .await
-        .map_err(|err| AppError::io(err.to_string()))?
+pub async fn icloud_download_pending(root: String, notes_only: bool) -> AppResult<u32> {
+    tauri::async_runtime::spawn_blocking(move || {
+        Ok(platform::pending_walk(Path::new(&root), true, notes_only))
+    })
+    .await
+    .map_err(|err| AppError::io(err.to_string()))?
 }
 
 /// Command: the app-sandbox `Documents/` root alone — the cheap half of
@@ -134,14 +143,31 @@ pub fn mobile_storage_local(app: tauri::AppHandle) -> AppResult<String> {
 /// anything. The poll loop that waits for a download burst to settle calls
 /// this every second — re-*requesting* thousands of in-flight downloads on
 /// every tick is wasted `NSFileManager` traffic (the open/resume nudge and
-/// the metadata watch already own the requests).
+/// the metadata watch already own the requests). `notes_only` matches the
+/// scope the nudge requested, so the poll drains when the *notes* are in.
 #[tauri::command]
-pub async fn icloud_pending_count(root: String) -> AppResult<u32> {
+pub async fn icloud_pending_count(root: String, notes_only: bool) -> AppResult<u32> {
     tauri::async_runtime::spawn_blocking(move || {
-        Ok(platform::pending_walk(Path::new(&root), false))
+        Ok(platform::pending_walk(Path::new(&root), false, notes_only))
     })
     .await
     .map_err(|err| AppError::io(err.to_string()))?
+}
+
+/// The graph's note directories — the download-scope filter and the
+/// graph-detection probe share one list.
+const NOTE_DIRS: [&str; 3] = ["daily", "notes", "templates"];
+
+/// Whether a placeholder found under `rel_dir` (the stub's directory,
+/// graph-relative) standing for `target` falls in the notes-only download
+/// scope: markdown under one of the note directories. Assets, audio memos,
+/// and anything else wait for the follow-up full-scope request.
+fn placeholder_in_note_scope(rel_dir: &Path, target: &str) -> bool {
+    let Some(first) = rel_dir.components().next() else {
+        return false; // a stray placeholder at the graph root is not a note
+    };
+    let first = first.as_os_str().to_string_lossy();
+    NOTE_DIRS.iter().any(|dir| *dir == first) && target.ends_with(".md")
 }
 
 /// Every existing graph among the container `Documents/` subdirectories
@@ -169,7 +195,6 @@ fn find_graph_dirs(documents: &Path) -> Vec<PathBuf> {
 /// `.reflect/meta.json`: the index directory is excluded from sync on
 /// purpose, so a synced-down graph arrives as bare `daily/`/`notes/` content.
 fn dir_has_notes(root: &Path) -> bool {
-    const NOTE_DIRS: [&str; 3] = ["daily", "notes", "templates"];
     NOTE_DIRS.iter().any(|dir| {
         let Ok(entries) = std::fs::read_dir(root.join(dir)) else {
             return false;
@@ -214,9 +239,11 @@ mod platform {
     }
 
     /// Walk `root` counting `.icloud` placeholders; with `nudge`, request a
-    /// download for each. Individual failures are logged and skipped — one
-    /// undownloadable file must not stop the rest.
-    pub fn pending_walk(root: &Path, nudge: bool) -> u32 {
+    /// download for each. `notes_only` restricts both the count and the
+    /// requests to markdown under the note directories
+    /// ([`super::placeholder_in_note_scope`]). Individual failures are logged
+    /// and skipped — one undownloadable file must not stop the rest.
+    pub fn pending_walk(root: &Path, nudge: bool, notes_only: bool) -> u32 {
         let manager = NSFileManager::defaultManager();
         let mut pending = 0;
         let mut stack = vec![root.to_path_buf()];
@@ -244,6 +271,14 @@ mod platform {
                 let Some(target) = crate::fs::icloud_placeholder_target(&name) else {
                     continue;
                 };
+                if notes_only {
+                    let in_scope = dir
+                        .strip_prefix(root)
+                        .is_ok_and(|rel_dir| super::placeholder_in_note_scope(rel_dir, target));
+                    if !in_scope {
+                        continue;
+                    }
+                }
                 pending += 1;
                 if nudge && !start_download(&manager, &path) {
                     // Some iOS releases want the logical URL, not the stub.
@@ -277,7 +312,7 @@ mod platform {
     }
 
     /// Nothing to download without a container.
-    pub fn pending_walk(_root: &Path, _nudge: bool) -> u32 {
+    pub fn pending_walk(_root: &Path, _nudge: bool, _notes_only: bool) -> u32 {
         0
     }
 }
@@ -591,5 +626,32 @@ mod tests {
         std::fs::create_dir_all(downloaded.path().join("notes")).expect("mkdir");
         std::fs::write(downloaded.path().join("notes/idea.md"), b"# hi").expect("write");
         assert!(dir_has_notes(downloaded.path()));
+    }
+
+    #[test]
+    fn note_scope_covers_markdown_under_note_dirs_only() {
+        // Markdown in the tracked directories (nested included) is in scope.
+        assert!(placeholder_in_note_scope(
+            Path::new("daily"),
+            "2026-07-04.md"
+        ));
+        assert!(placeholder_in_note_scope(Path::new("notes"), "idea.md"));
+        assert!(placeholder_in_note_scope(
+            Path::new("templates"),
+            "meeting.md"
+        ));
+        assert!(placeholder_in_note_scope(
+            Path::new("notes/archive"),
+            "old.md"
+        ));
+        // Assets, recordings, non-markdown, and root strays wait for the
+        // full-scope follow-up request.
+        assert!(!placeholder_in_note_scope(Path::new("assets"), "photo.png"));
+        assert!(!placeholder_in_note_scope(
+            Path::new("audio-memos"),
+            "memo.m4a"
+        ));
+        assert!(!placeholder_in_note_scope(Path::new("notes"), "photo.png"));
+        assert!(!placeholder_in_note_scope(Path::new(""), "stray.md"));
     }
 }

--- a/apps/desktop/src-tauri/src/icloud/storage.rs
+++ b/apps/desktop/src-tauri/src/icloud/storage.rs
@@ -162,6 +162,10 @@ const NOTE_DIRS: [&str; 3] = ["daily", "notes", "templates"];
 /// graph-relative) standing for `target` falls in the notes-only download
 /// scope: markdown under one of the note directories. Assets, audio memos,
 /// and anything else wait for the follow-up full-scope request.
+///
+/// Compiled off Apple targets only for tests: its sole production caller is
+/// the platform walk, which has no non-Apple twin.
+#[cfg(any(target_os = "ios", target_os = "macos", test))]
 fn placeholder_in_note_scope(rel_dir: &Path, target: &str) -> bool {
     let Some(first) = rel_dir.components().next() else {
         return false; // a stray placeholder at the graph root is not a note

--- a/apps/desktop/src/lib/backup-controller.ts
+++ b/apps/desktop/src/lib/backup-controller.ts
@@ -30,7 +30,7 @@ import { invalidateGithubAuth } from '@/lib/github-auth-state'
 import { startOperation } from '@/lib/operations'
 import { isMobileSurface } from '@/lib/platform-surface'
 import { providerFetch } from '@/lib/provider-fetch'
-import { invalidateIndexQueries } from '@/lib/query-client'
+import { throttledInvalidateIndexQueries } from '@/lib/query-client'
 
 /**
  * Backup state as the UI sees it. `connected` means the graph has a repo and
@@ -171,7 +171,7 @@ export function createBackupController(options: BackupControllerOptions): Backup
     if (indexGeneration !== null && indexable.length > 0) {
       void applyIndexChanges(indexable, indexGeneration).then((mutations) => {
         if (mutations > 0) {
-          invalidateIndexQueries()
+          throttledInvalidateIndexQueries()
         }
       })
     }

--- a/apps/desktop/src/lib/icloud-controller.test.ts
+++ b/apps/desktop/src/lib/icloud-controller.test.ts
@@ -14,10 +14,12 @@ import { createIcloudController, isICloudRoot } from './icloud-controller'
 const seams = vi.hoisted(() => ({
   dirtyOpenPaths: vi.fn<() => string[]>(() => []),
   invalidateIndexQueries: vi.fn(),
+  throttledInvalidateIndexQueries: vi.fn(),
 }))
 vi.mock('@/editor/open-documents', () => ({ dirtyOpenPaths: seams.dirtyOpenPaths }))
 vi.mock('@/lib/query-client', () => ({
   invalidateIndexQueries: seams.invalidateIndexQueries,
+  throttledInvalidateIndexQueries: seams.throttledInvalidateIndexQueries,
 }))
 
 interface ScanCall {
@@ -95,9 +97,13 @@ function controller(overrides: { emit?: boolean } = {}) {
   return active
 }
 
+/** Covers the arrival-driven path end to end: the 5s ingest debounce plus
+ * the 30s minimum spacing from the previous sweep's end. */
+const INGEST_SETTLE_MS = 31_000
+
 /** Fire the debounce and let the async scan settle. Signal-triggered scans
- * fire on the 1s window (the default); arrival-driven ingest scans use the
- * wide 5s window — pass `5_100` to fire those. */
+ * fire on the 1s window (the default); arrival-driven ingest scans need
+ * {@link INGEST_SETTLE_MS}. */
 async function settleScan(advanceMs = 1_100): Promise<void> {
   await vi.advanceTimersByTimeAsync(advanceMs)
   // The post-scan fan-out (emit → reindex → invalidate) continues past the
@@ -146,7 +152,7 @@ describe('createIcloudController', () => {
       { path: 'notes/external.md', kind: 'upsert', modifiedMs: 2 },
       { path: 'notes/gone.md', kind: 'remove' },
     ])
-    await settleScan(5_100) // arrival-driven: the wide ingest window
+    await settleScan(INGEST_SETTLE_MS) // arrival-driven: debounce + minimum spacing
 
     expect(scanCalls).toHaveLength(2)
     expect(scanCalls[1]?.ingestedPaths).toEqual(['notes/external.md'])
@@ -179,7 +185,7 @@ describe('createIcloudController', () => {
       { path: 'notes/merged.md', kind: 'upsert', modifiedMs: 6 }, // watcher echo
       { path: 'notes/other.md', kind: 'upsert', modifiedMs: 9 },
     ])
-    await settleScan(5_100) // arrival-driven: the wide ingest window
+    await settleScan(INGEST_SETTLE_MS) // arrival-driven: debounce + minimum spacing
     expect(scanCalls[1]?.ingestedPaths).toEqual(['notes/other.md'])
   })
 
@@ -192,12 +198,34 @@ describe('createIcloudController', () => {
     await settleScan() // scan #1 (the sooner baseline timer wins): baseline + ingest — fails
 
     emitFileChanges([{ path: 'notes/external.md', kind: 'upsert', modifiedMs: 3 }])
-    await settleScan(5_100) // scan #2 retries both, on the ingest window
+    await settleScan(INGEST_SETTLE_MS) // scan #2 retries both, on the ingest window
 
     expect(scanCalls).toHaveLength(2)
     expect(scanCalls[0]?.recordBaseline).toBe(true)
     expect(scanCalls[1]?.recordBaseline).toBe(true)
     expect(scanCalls[1]?.ingestedPaths).toContain('notes/external.md')
+  })
+
+  it('spaces arrival-driven sweeps apart during a download stream', async () => {
+    const icloud = controller()
+    await icloud.start()
+    await settleScan() // baseline ends ≈ t1
+
+    // A first-sync shape: batches keep arriving. The first arrival lands
+    // just after the baseline sweep — the debounce alone would sweep again
+    // at +5s, but the minimum spacing holds it back…
+    emitFileChanges([{ path: 'notes/one.md', kind: 'upsert', modifiedMs: 1 }])
+    await settleScan(5_100)
+    expect(scanCalls).toHaveLength(1)
+
+    // …so a later batch folds into the SAME deferred sweep, which fires once
+    // the spacing from the baseline's end has elapsed, carrying both ingests.
+    emitFileChanges([{ path: 'notes/two.md', kind: 'upsert', modifiedMs: 2 }])
+    await settleScan(26_000)
+    expect(scanCalls).toHaveLength(2)
+    expect(scanCalls[1]?.ingestedPaths).toEqual(
+      expect.arrayContaining(['notes/one.md', 'notes/two.md']),
+    )
   })
 
   it('conflict signals and resume events schedule deduped sweeps', async () => {

--- a/apps/desktop/src/lib/icloud-controller.test.ts
+++ b/apps/desktop/src/lib/icloud-controller.test.ts
@@ -32,7 +32,9 @@ const GRAPH = { root: '/Users/alex/Library/Mobile Documents/iCloud~app/Documents
 
 let invoked: Array<[string, Record<string, unknown>]>
 let scanCalls: ScanCall[]
-let scanResults: Array<Record<string, unknown> | Error>
+/** Scripted sweep outcomes; `'hang'` parks the sweep until {@link releaseScan}. */
+let scanResults: Array<Record<string, unknown> | Error | 'hang'>
+let releaseScan: (() => void) | null
 let listeners: Map<string, (payload: unknown) => void>
 
 beforeEach(() => {
@@ -45,6 +47,7 @@ beforeEach(() => {
   invoked = []
   scanCalls = []
   scanResults = []
+  releaseScan = null
   listeners = new Map()
   seams.dirtyOpenPaths.mockReturnValue([])
   setBridge({
@@ -60,6 +63,12 @@ beforeEach(() => {
           const scripted = scanResults.shift()
           if (scripted instanceof Error) {
             throw scripted
+          }
+          if (scripted === 'hang') {
+            return new Promise((resolve) => {
+              releaseScan = () =>
+                resolve({ changed: [], needsReview: [], deferred: [], autoResolved: 0 })
+            })
           }
           return (
             scripted ?? { changed: [], needsReview: [], deferred: [], autoResolved: 0 }
@@ -226,6 +235,43 @@ describe('createIcloudController', () => {
     expect(scanCalls[1]?.ingestedPaths).toEqual(
       expect.arrayContaining(['notes/one.md', 'notes/two.md']),
     )
+  })
+
+  it('a conflict signal caught mid-sweep replays on the prompt window', async () => {
+    scanResults.push('hang')
+    const icloud = controller()
+    await icloud.start()
+    await settleScan() // the baseline sweep starts — and hangs
+    expect(scanCalls).toHaveLength(1)
+
+    // A conflict arrives while the sweep is still running: no timer arms,
+    // the class is remembered.
+    listeners.get('icloud:conflicts')?.(['notes/a.md'])
+    await settleScan()
+    expect(scanCalls).toHaveLength(1)
+
+    // The sweep ends → the queued conflict replays promptly (1s), never on
+    // the wide ingest window.
+    releaseScan?.()
+    await settleScan()
+    expect(scanCalls).toHaveLength(2)
+  })
+
+  it('an arrival caught mid-sweep replays on the ingest spacing', async () => {
+    scanResults.push('hang')
+    const icloud = controller()
+    await icloud.start()
+    await settleScan() // the baseline sweep starts — and hangs
+    expect(scanCalls).toHaveLength(1)
+
+    emitFileChanges([{ path: 'notes/late.md', kind: 'upsert', modifiedMs: 2 }])
+    releaseScan?.()
+    await settleScan() // prompt window only — a long sweep must not chain
+    expect(scanCalls).toHaveLength(1)
+
+    await settleScan(INGEST_SETTLE_MS)
+    expect(scanCalls).toHaveLength(2)
+    expect(scanCalls[1]?.ingestedPaths).toEqual(['notes/late.md'])
   })
 
   it('conflict signals and resume events schedule deduped sweeps', async () => {

--- a/apps/desktop/src/lib/icloud-controller.ts
+++ b/apps/desktop/src/lib/icloud-controller.ts
@@ -13,7 +13,7 @@ import {
   type GraphInfo,
 } from '@reflect/core'
 import { dirtyOpenPaths } from '@/editor/open-documents'
-import { invalidateIndexQueries } from '@/lib/query-client'
+import { throttledInvalidateIndexQueries } from '@/lib/query-client'
 
 /**
  * Whether a graph root lives under iCloud Drive: the app's container and the
@@ -36,6 +36,16 @@ const SCAN_DEBOUNCE_MS = 1_000
  * the shorter window — and an earlier-due request always wins.
  */
 const INGEST_SCAN_DEBOUNCE_MS = 5_000
+/**
+ * Minimum gap between the end of one sweep and the start of the next
+ * *arrival-triggered* one. The debounce alone still ran a full-graph sweep
+ * every ~5s for the length of an initial download — each one a tree walk
+ * plus a per-file version query, contending with the downloads themselves.
+ * Base advances are not latency-sensitive (the ingest set just accumulates),
+ * so a bulk sync gets a handful of sweeps instead of dozens. Conflict
+ * signals and resumes are unaffected.
+ */
+const INGEST_SCAN_MIN_SPACING_MS = 30_000
 /**
  * Resume-trigger dedupe: one transition can fire `focus` and
  * `visibilitychange` together (the backup controller's window, same value).
@@ -96,6 +106,7 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
   let scanTimerDue = 0
   let scanRunning = false
   let scanQueued = false
+  let lastScanEndedAt = 0
 
   function scheduleScan(delayMs: number = SCAN_DEBOUNCE_MS): void {
     if (disposed) {
@@ -113,6 +124,13 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
       scanTimer = null
       void runScan()
     }, delayMs)
+  }
+
+  /** Arrival-triggered sweeps: the wide debounce, stretched further to keep
+   * {@link INGEST_SCAN_MIN_SPACING_MS} from the previous sweep's end. */
+  function scheduleIngestScan(): void {
+    const sinceLastScan = Date.now() - lastScanEndedAt
+    scheduleScan(Math.max(INGEST_SCAN_DEBOUNCE_MS, INGEST_SCAN_MIN_SPACING_MS - sinceLastScan))
   }
 
   async function runScan(): Promise<void> {
@@ -148,6 +166,7 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
         baselinePending = true // the adoption baseline must survive a failed first sweep
       }
     } finally {
+      lastScanEndedAt = Date.now()
       scanRunning = false
       if (scanQueued) {
         scanQueued = false
@@ -183,7 +202,7 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
     if (indexGeneration !== null && indexable.length > 0) {
       void applyIndexChanges(indexable, indexGeneration).then((mutations) => {
         if (mutations > 0) {
-          invalidateIndexQueries()
+          throttledInvalidateIndexQueries()
         }
       })
     }
@@ -233,9 +252,10 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
             }
             pendingIngest.add(change.path)
           }
-          // Arrival-driven: the wide window, so a download burst folds into
-          // few sweeps instead of one per watch batch.
-          scheduleScan(INGEST_SCAN_DEBOUNCE_MS)
+          // Arrival-driven: the wide window plus the minimum spacing, so a
+          // download burst folds into a handful of sweeps rather than one
+          // per watch batch.
+          scheduleIngestScan()
         }),
       )
       disposers.push(

--- a/apps/desktop/src/lib/icloud-controller.ts
+++ b/apps/desktop/src/lib/icloud-controller.ts
@@ -105,11 +105,25 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
   let scanTimer: ReturnType<typeof setTimeout> | null = null
   let scanTimerDue = 0
   let scanRunning = false
-  let scanQueued = false
+  /**
+   * The most urgent trigger class that arrived while a sweep was running,
+   * replayed on its own window once the sweep ends: `'prompt'` (conflict
+   * signal, resume) reschedules on {@link SCAN_DEBOUNCE_MS}; `'ingest'`
+   * (arrival batches) respects the full ingest spacing. Requests that land
+   * mid-sweep don't arm a timer — the class survives instead, so a long
+   * sweep neither chains straight into the next one (ingest) nor delays
+   * conflict handling by the wide window (prompt).
+   */
+  let queuedScan: 'prompt' | 'ingest' | null = null
   let lastScanEndedAt = 0
 
   function scheduleScan(delayMs: number = SCAN_DEBOUNCE_MS): void {
     if (disposed) {
+      return
+    }
+    if (scanRunning) {
+      const requested = delayMs <= SCAN_DEBOUNCE_MS ? 'prompt' : 'ingest'
+      queuedScan = requested === 'prompt' ? 'prompt' : (queuedScan ?? 'ingest')
       return
     }
     const due = Date.now() + delayMs
@@ -138,7 +152,9 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
       return
     }
     if (scanRunning) {
-      scanQueued = true
+      // Unreachable in the current shape (mid-run requests never arm a
+      // timer), kept as a safe fallback: replay promptly.
+      queuedScan = 'prompt'
       return
     }
     scanRunning = true
@@ -168,13 +184,14 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
     } finally {
       lastScanEndedAt = Date.now()
       scanRunning = false
-      if (scanQueued) {
-        scanQueued = false
-        // A trigger fired while this sweep ran. During a bulk sync that is
-        // almost always another arrival batch — respect the ingest spacing,
-        // or a long sweep chains straight into the next one. Conflict
-        // signals caught in this window are backstopped by resume sweeps.
-        scheduleIngestScan()
+      if (queuedScan !== null) {
+        const replay = queuedScan
+        queuedScan = null
+        if (replay === 'prompt') {
+          scheduleScan()
+        } else {
+          scheduleIngestScan()
+        }
       }
     }
   }

--- a/apps/desktop/src/lib/icloud-controller.ts
+++ b/apps/desktop/src/lib/icloud-controller.ts
@@ -170,7 +170,11 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
       scanRunning = false
       if (scanQueued) {
         scanQueued = false
-        scheduleScan()
+        // A trigger fired while this sweep ran. During a bulk sync that is
+        // almost always another arrival batch — respect the ingest spacing,
+        // or a long sweep chains straight into the next one. Conflict
+        // signals caught in this window are backstopped by resume sweeps.
+        scheduleIngestScan()
       }
     }
   }

--- a/apps/desktop/src/lib/query-client.test.ts
+++ b/apps/desktop/src/lib/query-client.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { queryClient, throttledInvalidateIndexQueries } from './query-client'
+
+const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+/** Grows per test: the throttle keeps module-level state, so each case must
+ * start well past the previous one's window to begin on a cold leading edge. */
+let clockOffsetMs = 0
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  clockOffsetMs += 120_000
+  vi.setSystemTime(Date.now() + clockOffsetMs)
+  invalidateSpy.mockClear()
+  invalidateSpy.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  // Drain any armed trailing edge so it can't leak into the next test.
+  vi.runOnlyPendingTimers()
+  vi.useRealTimers()
+})
+
+describe('throttledInvalidateIndexQueries', () => {
+  it('fires the first call immediately — a single save keeps its instant refresh', () => {
+    throttledInvalidateIndexQueries()
+    expect(invalidateSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('collapses a burst into one trailing refetch, none dropped', () => {
+    // The initial-sync shape: an applied watch batch every ~2s for minutes.
+    throttledInvalidateIndexQueries() // leading
+    throttledInvalidateIndexQueries()
+    throttledInvalidateIndexQueries()
+    throttledInvalidateIndexQueries()
+    expect(invalidateSpy).toHaveBeenCalledTimes(1)
+
+    // The trailing edge runs once the window elapses — the last batch's
+    // rows are never left stale.
+    vi.advanceTimersByTime(3_000)
+    expect(invalidateSpy).toHaveBeenCalledTimes(2)
+
+    // Quiet afterwards: nothing further scheduled.
+    vi.advanceTimersByTime(10_000)
+    expect(invalidateSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('spaces sustained streams to one refetch per window', () => {
+    for (let tick = 0; tick < 12; tick += 1) {
+      throttledInvalidateIndexQueries()
+      vi.advanceTimersByTime(1_000) // a batch per second for 12s
+    }
+    // Leading + one trailing per 3s window: ~4 rounds, not 12.
+    expect(invalidateSpy.mock.calls.length).toBeLessThanOrEqual(5)
+    expect(invalidateSpy.mock.calls.length).toBeGreaterThanOrEqual(4)
+  })
+
+  it('an isolated call after a quiet period fires immediately again', () => {
+    throttledInvalidateIndexQueries()
+    vi.advanceTimersByTime(10_000)
+    invalidateSpy.mockClear()
+
+    throttledInvalidateIndexQueries()
+    expect(invalidateSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/lib/query-client.ts
+++ b/apps/desktop/src/lib/query-client.ts
@@ -28,6 +28,43 @@ export function invalidateIndexQueries(): void {
   void queryClient.invalidateQueries({ queryKey: [INDEX_QUERY_SCOPE] })
 }
 
+/**
+ * Minimum spacing between full index-query refetch rounds on the batch
+ * paths. During an initial iCloud sync the watch applies a batch every
+ * couple of seconds for minutes; refetching every mounted index query per
+ * batch is a large share of what makes a first sync feel slow.
+ */
+const INVALIDATE_THROTTLE_MS = 3_000
+
+let lastInvalidateAt = 0
+let invalidateTimer: ReturnType<typeof setTimeout> | null = null
+
+/**
+ * {@link invalidateIndexQueries} with leading+trailing throttling, for the
+ * *streaming* callers (applied watcher batches, sweep/pull reindexes): an
+ * isolated call fires immediately — a single save keeps its instant refresh
+ * — while a burst collapses to one refetch per window, none dropped (the
+ * trailing edge always runs). Direct user-action invalidations should keep
+ * calling the unthrottled function.
+ */
+export function throttledInvalidateIndexQueries(): void {
+  const now = Date.now()
+  const elapsed = now - lastInvalidateAt
+  if (elapsed >= INVALIDATE_THROTTLE_MS) {
+    lastInvalidateAt = now
+    invalidateIndexQueries()
+    return
+  }
+  if (invalidateTimer !== null) {
+    return // a trailing refetch is already on its way
+  }
+  invalidateTimer = setTimeout(() => {
+    invalidateTimer = null
+    lastInvalidateAt = Date.now()
+    invalidateIndexQueries()
+  }, INVALIDATE_THROTTLE_MS - elapsed)
+}
+
 /** The iCloud container listing (`icloud_status`) — read by the graph chooser and Settings → iCloud. */
 export const ICLOUD_STATUS_QUERY_KEY = ['icloud-status'] as const
 

--- a/apps/desktop/src/mobile/use-icloud-refresh.test.tsx
+++ b/apps/desktop/src/mobile/use-icloud-refresh.test.tsx
@@ -159,6 +159,29 @@ describe('useICloudRefresh', () => {
     expect(allScopeDownloadCalls).toHaveLength(0)
   })
 
+  it('a failed nudge never starts the bulk download', async () => {
+    // `pending` defaulting to 0 on error must not read as "notes are in".
+    setBridge({
+      invoke: async (command) => {
+        if (command === 'icloud_download_pending') {
+          throw { kind: 'io', message: 'container hiccup' }
+        }
+        return null
+      },
+      listen: async () => () => {},
+    })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      renderHook(() => useICloudRefresh())
+      await flush()
+
+      expect(allScopeDownloadCalls).toHaveLength(0)
+      expect(errorSpy).toHaveBeenCalled()
+    } finally {
+      errorSpy.mockRestore()
+    }
+  })
+
   it('collapses the resume event burst into one refresh — which reconciles', async () => {
     renderHook(() => useICloudRefresh())
     await flush()

--- a/apps/desktop/src/mobile/use-icloud-refresh.test.tsx
+++ b/apps/desktop/src/mobile/use-icloud-refresh.test.tsx
@@ -18,7 +18,9 @@ vi.mock('@/providers/graph-provider', () => ({
 
 let downloadCalls: string[]
 let countCalls: string[]
-/** What the fake pending commands report — placeholders remaining. */
+/** Full-scope (assets included) download requests — the deferred bulk. */
+let allScopeDownloadCalls: string[]
+/** What the fake pending commands report — note placeholders remaining. */
 let pendingCount: number
 let refreshIndex: ReturnType<typeof vi.fn<() => void>>
 
@@ -26,6 +28,7 @@ beforeEach(() => {
   vi.useFakeTimers()
   downloadCalls = []
   countCalls = []
+  allScopeDownloadCalls = []
   pendingCount = 0
   refreshIndex = vi.fn<() => void>()
   graphState.current = {
@@ -36,10 +39,15 @@ beforeEach(() => {
   setBridge({
     invoke: async (command, args) => {
       if (command === 'icloud_download_pending') {
-        downloadCalls.push(String(args['root']))
+        if (args['notesOnly'] === true) {
+          downloadCalls.push(String(args['root']))
+          return pendingCount
+        }
+        allScopeDownloadCalls.push(String(args['root']))
         return pendingCount
       }
       if (command === 'icloud_pending_count') {
+        expect(args['notesOnly']).toBe(true) // the poll gates on the notes
         countCalls.push(String(args['root']))
         return pendingCount
       }
@@ -78,7 +86,7 @@ describe('useICloudRefresh', () => {
     expect(refreshIndex).not.toHaveBeenCalled()
   })
 
-  it('nudges downloads on mount without repeating the open-time reconcile', async () => {
+  it('nudges note downloads on mount without repeating the open-time reconcile', async () => {
     renderHook(() => useICloudRefresh())
     await flush()
 
@@ -86,14 +94,18 @@ describe('useICloudRefresh', () => {
     // The graph open just synced the index against local disk; an immediate
     // second full pass would repeat that work on a large first sync.
     expect(refreshIndex).not.toHaveBeenCalled()
+    // No notes pending — the deferred bulk (assets) may start right away.
+    expect(allScopeDownloadCalls).toEqual(['/iCloud/Documents'])
   })
 
-  it('polls the count while placeholders are pending and reconciles when they land', async () => {
+  it('polls the note count while pending and reconciles + starts assets when they land', async () => {
     pendingCount = 3
     renderHook(() => useICloudRefresh())
     await flush()
     expect(downloadCalls).toHaveLength(1)
     expect(refreshIndex).not.toHaveBeenCalled()
+    // Notes still pending — the bulk (assets) must wait its turn.
+    expect(allScopeDownloadCalls).toHaveLength(0)
 
     // Still pending after one poll: no reconcile yet, keep waiting — and the
     // poll only counts, it never re-requests the downloads.
@@ -105,8 +117,8 @@ describe('useICloudRefresh', () => {
     expect(downloadCalls).toHaveLength(1)
     expect(refreshIndex).not.toHaveBeenCalled()
 
-    // Downloads finished: the next poll reconciles immediately — the Mac
-    // edit appears seconds after it lands, not on the next resume.
+    // Notes finished: the next poll reconciles immediately — and only now
+    // does the full-scope (assets) request fire.
     pendingCount = 0
     await act(async () => {
       vi.runOnlyPendingTimers()
@@ -114,6 +126,7 @@ describe('useICloudRefresh', () => {
     await flush()
     expect(countCalls).toHaveLength(2)
     expect(refreshIndex).toHaveBeenCalledTimes(1)
+    expect(allScopeDownloadCalls).toHaveLength(1)
 
     // Settled — no further polling.
     await act(async () => {
@@ -141,6 +154,9 @@ describe('useICloudRefresh', () => {
     // Well-bounded: one nudge, then at most limit/interval count polls.
     expect(downloadCalls).toHaveLength(1)
     expect(countCalls.length).toBeLessThanOrEqual(21)
+    // Notes never drained, so the bulk request stays deferred — it would
+    // compete with the notes still downloading on the slow link.
+    expect(allScopeDownloadCalls).toHaveLength(0)
   })
 
   it('collapses the resume event burst into one refresh — which reconciles', async () => {

--- a/apps/desktop/src/mobile/use-icloud-refresh.ts
+++ b/apps/desktop/src/mobile/use-icloud-refresh.ts
@@ -37,6 +37,11 @@ const PENDING_POLL_LIMIT_MS = 20_000
  * against local disk, so an immediate second full pass would repeat that
  * work — on a first sync of a large graph, at the worst possible moment.
  *
+ * Downloads are sequenced notes-first: the nudge and the poll cover only
+ * markdown under the note directories, and the full-scope request (assets,
+ * recordings) fires once the note count drains — so a first sync's bulk
+ * bytes never compete with the first index pass.
+ *
  * Inert unless an iCloud graph is open (`mobileStorageKind === 'icloud'`).
  */
 export function useICloudRefresh(): void {
@@ -51,6 +56,19 @@ export function useICloudRefresh(): void {
     let lastRefreshAt = 0
     let retryTimer: ReturnType<typeof setTimeout> | null = null
 
+    // Notes download first; everything else (assets are most of the bytes)
+    // is requested only once the note placeholders drain. Kicking thousands
+    // of concurrent downloads at open put the whole first sync — network,
+    // disk, file coordination — under the first index pass, and the app
+    // crawled until it finished. Fire-and-forget: nothing polls or
+    // reconciles for assets (they aren't indexed; images appear as they
+    // land), and a failed request is retried by the next resume's drain.
+    const requestRemainingDownloads = (): void => {
+      void icloudDownloadPending(root, 'all').catch((err: unknown) => {
+        console.error('iCloud asset download request failed:', errorMessage(err))
+      })
+    }
+
     const pollPending = (startedAt: number): void => {
       if (retryTimer !== null) {
         return
@@ -60,14 +78,22 @@ export function useICloudRefresh(): void {
         if (disposed) {
           return
         }
-        void icloudPendingCount(root).then(
+        void icloudPendingCount(root, 'notes').then(
           (pending) => {
             if (disposed) {
               return
             }
-            if (pending === 0 || Date.now() - startedAt >= PENDING_POLL_LIMIT_MS) {
-              // Everything landed (or we're done waiting) — one reconcile
-              // picks the batch up together.
+            if (pending === 0) {
+              // The notes landed — one reconcile picks the batch up
+              // together, and the deferred bulk (assets) may start.
+              refreshIndex()
+              requestRemainingDownloads()
+              return
+            }
+            if (Date.now() - startedAt >= PENDING_POLL_LIMIT_MS) {
+              // Done waiting (a slow link): index what landed. The asset
+              // request stays deferred — it would compete with the notes
+              // still downloading; the next resume retries the sequence.
               refreshIndex()
               return
             }
@@ -86,7 +112,7 @@ export function useICloudRefresh(): void {
     const refresh = async (options: { reconcile: boolean }): Promise<void> => {
       let pending = 0
       try {
-        pending = await icloudDownloadPending(root)
+        pending = await icloudDownloadPending(root, 'notes')
       } catch (err) {
         // Best-effort: reconcile anyway — already-downloaded changes still land.
         console.error('iCloud download nudge failed:', errorMessage(err))
@@ -99,6 +125,8 @@ export function useICloudRefresh(): void {
       }
       if (pending > 0) {
         pollPending(Date.now())
+      } else {
+        requestRemainingDownloads()
       }
     }
 

--- a/apps/desktop/src/mobile/use-icloud-refresh.ts
+++ b/apps/desktop/src/mobile/use-icloud-refresh.ts
@@ -111,8 +111,10 @@ export function useICloudRefresh(): void {
 
     const refresh = async (options: { reconcile: boolean }): Promise<void> => {
       let pending = 0
+      let nudged = false
       try {
         pending = await icloudDownloadPending(root, 'notes')
+        nudged = true
       } catch (err) {
         // Best-effort: reconcile anyway — already-downloaded changes still land.
         console.error('iCloud download nudge failed:', errorMessage(err))
@@ -125,7 +127,10 @@ export function useICloudRefresh(): void {
       }
       if (pending > 0) {
         pollPending(Date.now())
-      } else {
+      } else if (nudged) {
+        // A confirmed-empty note count — never a failed nudge, which would
+        // start the bulk while notes may still be pending. The next resume
+        // retries the whole sequence.
         requestRemainingDownloads()
       }
     }

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -26,7 +26,7 @@ import {
 import { followHealedMove } from '@/editor/move-note'
 import { resetNoteRowOverlays } from '@/hooks/note-row-overlay'
 import { setIndexProgress } from '@/lib/index-progress'
-import { dropIcloudStatusQuery, invalidateIndexQueries } from '@/lib/query-client'
+import { dropIcloudStatusQuery, throttledInvalidateIndexQueries } from '@/lib/query-client'
 import { ensureWelcomeNote } from '@/lib/welcome-note'
 import { createGraphIndex } from './graph-index'
 import { useMobileGraphBoot, type MobileGraphBoot } from './use-mobile-graph-boot'
@@ -151,7 +151,10 @@ export function GraphProvider({
           setIndexProgress(null) // the pass finished (or went idle) — clear the pill
         }
       },
-      onApplied: invalidateIndexQueries,
+      // Applied watcher batches stream every couple of seconds during a bulk
+      // sync — the throttled variant collapses them to one refetch round per
+      // window (an isolated batch still invalidates immediately).
+      onApplied: throttledInvalidateIndexQueries,
       onFileProgress: (done, total) => setIndexProgress({ done, total }),
       // External renames healed by id follow through to sessions and routes,
       // exactly as for an in-app rename (Plan 17).

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,7 @@ export {
   icloudWatchStart,
   icloudWatchStop,
   type AppPlatform,
+  type IcloudDownloadScope,
   type IcloudScanOptions,
   type IcloudStatus,
   type IcloudSweepOutcome,

--- a/packages/core/src/ipc/commands.ts
+++ b/packages/core/src/ipc/commands.ts
@@ -64,22 +64,45 @@ export async function mobileStorage(): Promise<MobileStorageInfo> {
 const icloudDownloadPendingSchema = z.number().int().nonnegative()
 
 /**
- * Asks iCloud to download every not-yet-local file under `root`, returning
- * how many placeholders were found. iOS does not pull container files down
- * eagerly; call this once per open/resume for iCloud graphs, then poll
- * {@link icloudPendingCount} while the count stays above zero.
+ * Which placeholders a pending-download call covers: `'notes'` is markdown
+ * under the note directories — what an open/resume requests first, so a
+ * first sync isn't crushed under thousands of concurrent asset downloads —
+ * and `'all'` is everything, requested once the notes have drained.
  */
-export async function icloudDownloadPending(root: string): Promise<number> {
-  return call('icloud_download_pending', { root }, icloudDownloadPendingSchema)
+export type IcloudDownloadScope = 'notes' | 'all'
+
+/**
+ * Asks iCloud to download every not-yet-local file in `scope` under `root`,
+ * returning how many placeholders were found. iOS does not pull container
+ * files down eagerly; call this once per open/resume for iCloud graphs, then
+ * poll {@link icloudPendingCount} while the count stays above zero.
+ */
+export async function icloudDownloadPending(
+  root: string,
+  scope: IcloudDownloadScope,
+): Promise<number> {
+  return call(
+    'icloud_download_pending',
+    { root, notesOnly: scope === 'notes' },
+    icloudDownloadPendingSchema,
+  )
 }
 
 /**
- * Counts the not-yet-local placeholders under `root` without requesting
- * anything — the poll half of {@link icloudDownloadPending}: re-requesting
- * thousands of in-flight downloads every tick is wasted traffic.
+ * Counts the not-yet-local placeholders in `scope` under `root` without
+ * requesting anything — the poll half of {@link icloudDownloadPending}:
+ * re-requesting thousands of in-flight downloads every tick is wasted
+ * traffic.
  */
-export async function icloudPendingCount(root: string): Promise<number> {
-  return call('icloud_pending_count', { root }, icloudDownloadPendingSchema)
+export async function icloudPendingCount(
+  root: string,
+  scope: IcloudDownloadScope,
+): Promise<number> {
+  return call(
+    'icloud_pending_count',
+    { root, notesOnly: scope === 'notes' },
+    icloudDownloadPendingSchema,
+  )
 }
 
 /**


### PR DESCRIPTION
## Problem

Follow-up to #532. After a fresh install opens a large iCloud graph, the app is very slow for roughly the length of the initial download (~2 minutes), then snaps back to normal. The freeze/crash from #532 is gone, but four systems still run flat out **concurrently** during the download window:

1. The open-time nudge requested **every** placeholder at once — all notes *and* all of `assets/` (usually most of the bytes) — so iOS ran thousands of concurrent downloads under everything else.
2. Every ~2s watch batch that indexed newly-landed notes triggered a **full index-query refetch** (`invalidateIndexQueries`) — ~60 refetch/re-render rounds over the window.
3. Every arrival batch scheduled a **full-graph conflict sweep** on the 5s debounce — a tree walk plus an `NSFileVersion` query per file, ~24 times, contending with the downloads for disk.
4. The necessary work — parse + index each note once — rode on top.

## Changes

- **Notes-first download sequencing.** `icloud_download_pending` / `icloud_pending_count` gain a `notesOnly` scope (pure `placeholder_in_note_scope` filter: markdown under `daily/`, `notes/`, `templates/`). The open/resume nudge and the pending poll cover notes only; once the note count drains to zero, one full-scope request kicks off the deferred bulk (assets, recordings) in the background — nothing polls or reconciles for it. If the poll caps out on a slow link, the bulk request stays deferred to the next resume rather than competing with the notes still downloading.
- **Throttled streaming invalidation.** New `throttledInvalidateIndexQueries` (leading + trailing, 3s window) used by the applied-watcher-batch path and both controllers' sweep/pull reindexes. An isolated batch still refetches instantly (a single save keeps its immediate refresh, desktop unaffected in normal use); a sync stream collapses to one refetch round per window with the trailing edge guaranteeing the last batch is never left stale. Direct user-action invalidations keep the unthrottled call.
- **Spaced ingest sweeps.** Arrival-triggered conflict sweeps now enforce a 30s minimum spacing from the previous sweep's end on top of the 5s debounce (`scheduleIngestScan`). Base advances aren't latency-sensitive — the ingest set just accumulates and the next sweep carries all of it. Conflict-signal and resume sweeps keep their 1s window, and an earlier-due request still wins the timer.

## Verification

- `pnpm check` clean; 761 desktop tests and 1077 core tests pass (the one "failing" core test, `language-model.test.ts`, is the known local-env artifact — Claude Code exports a `/v1`-less `ANTHROPIC_BASE_URL` the SDK picks up; it passes with the var unset and is unaffected by this diff).
- New coverage: note-scope filter (Rust), notes-first nudge → poll → asset-kickoff sequencing incl. the capped-poll deferral (`use-icloud-refresh.test`), throttle leading/trailing/spacing (`query-client.test`), and sweep spacing folding two arrival bursts into one sweep (`icloud-controller.test`).
- `cargo fmt --check`/clippy/tests clean (240 pass); `cargo check --target aarch64-apple-ios-sim` clean.
- Rebased over #535/#536; all suites re-run green on the new base.
- The real acceptance test remains a fresh-install device pass with a large graph — expected result: the app stays responsive during the first sync, notes appear quickly, images fill in afterwards.

## Risk & rollout

- Asset downloads now start after the notes finish instead of immediately — images deep in old notes appear a little later on a fresh install. The watch never nudged assets, so eviction re-downloads behave as before (on-demand via resume/drain).
- The throttle delays *batch-driven* refetches by up to 3s during storms only; the leading edge keeps normal interactive behavior. Conflict handling is unaffected by the sweep spacing (conflict signals keep the fast path; deferred base advances accumulate losslessly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-sync timing (assets download later; batch UI refetches up to ~3s delayed) and conflict base-advance spacing, but conflict signals keep the fast path and ingest paths accumulate losslessly.
> 
> **Overview**
> **Paces the iCloud first-sync window** so notes, indexing, and conflict work no longer all hammer the device at once on a large graph.
> 
> **Notes-first iCloud downloads.** Rust `icloud_download_pending` / `icloud_pending_count` take `notes_only`; only markdown under `daily/`, `notes/`, and `templates/` is nudged and polled initially. Mobile `useICloudRefresh` kicks off a full-scope (`'all'`) request only after the note placeholder count hits zero (or immediately when there are none), and skips bulk downloads on nudge failure or when the poll cap is hit with notes still pending.
> 
> **Throttled index invalidation.** New `throttledInvalidateIndexQueries` (3s leading + trailing) replaces direct `invalidateIndexQueries` on streaming paths: applied watcher batches in `GraphProvider`, and sweep/pull reindexes in the backup and iCloud controllers. User-driven invalidations stay unthrottled.
> 
> **Spaced ingest conflict sweeps.** Arrival-driven sweeps add a **30s minimum gap** after the previous sweep ends (on top of the 5s debounce). Mid-sweep triggers queue as `'prompt'` (conflicts/resume → 1s) or `'ingest'` (arrivals → full spacing) instead of chaining immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e8d6b86ee8593bf6847d5bdd31d05d93f7774b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->