### PR TITLE
Add mobile tasks floating add button

### DIFF
--- a/apps/desktop/src/mobile/screens/tasks.test.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.test.tsx
@@ -414,6 +414,20 @@ describe('MobileTasks', () => {
     view.unmount()
   })
 
+  it('adds a task to today’s daily from the floating plus button', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await view.findByText('buy milk')
+    await user.click(view.getByRole('button', { name: 'New task' }))
+
+    await waitFor(() => expect(insertTask).toHaveBeenCalledWith('daily/2026-06-14.md', 1))
+    const input = asTextArea(await view.findByRole('textbox', { name: 'Task text' }))
+    expect(input.value).toBe('')
+    view.unmount()
+  })
+
   it('abandoning a "+"-added task deletes it instead of ghosting an empty row', async () => {
     getOpenTasks.mockResolvedValue([
       task({ text: 'jotted today', dailyDate: '2026-06-14', notePath: 'daily/2026-06-14.md' }),

--- a/apps/desktop/src/mobile/screens/tasks.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.tsx
@@ -1,6 +1,6 @@
 import { useDeferredValue, useMemo, useState, type ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Archive, CircleCheck, SlidersHorizontal } from 'lucide-react'
+import { Archive, CircleCheck, Plus, SlidersHorizontal } from 'lucide-react'
 import {
   getCompletedTasks,
   getOpenTasks,
@@ -169,7 +169,7 @@ export function MobileTasks(): ReactElement {
           ) : null}
         </div>
       ) : (
-        <div className="min-h-0 flex-1 overflow-y-auto pb-8">
+        <div className="min-h-0 flex-1 overflow-y-auto pb-24">
           {groups.map((group) => (
             <MobileTaskGroup
               key={group.kind === 'note' ? `note:${group.notePath}` : group.kind}
@@ -182,6 +182,15 @@ export function MobileTasks(): ReactElement {
           ))}
         </div>
       )}
+      <Button
+        size="icon"
+        aria-label="New task"
+        className="fixed right-4 z-40 size-12 rounded-full shadow-lg"
+        style={{ bottom: 'calc(max(env(safe-area-inset-bottom), var(--keyboard-height, 0px)) + 4.25rem)' }}
+        onClick={() => onAdd(todaysDailyTarget(today))}
+      >
+        <Plus className="size-6" />
+      </Button>
       {liveEditingTask !== null ? (
         <MobileTaskEditSheet
           key={taskKey(liveEditingTask)}


### PR DESCRIPTION
## Problem

The iOS Tasks tab had task creation available from group headers and the empty state, but it did not have the always-visible bottom-right plus button that the daily note screen already provides. When the list had tasks, creating a new task required finding a group-specific add control instead of using the primary mobile create affordance.

## Before -> After

| Before | After |
| --- | --- |
| Tasks screen had no bottom-right plus button. | Tasks screen has a fixed bottom-right `New task` button matching the daily note FAB placement and styling. |
| Last rows had only small bottom padding. | The task list has enough bottom padding for the floating button. |

## Changes

1. Adds a `Plus` FAB to `MobileTasks` that calls the existing `onAdd(todaysDailyTarget(today))` path, so new tasks are inserted into today’s daily note and open in the quick-edit sheet.
2. Increases the scroll list bottom padding so task rows are not obscured by the new floating button.
3. Adds a mobile tasks regression test for creating a task from the new floating button.

## Verification

- `pnpm --filter @reflect/desktop test --run src/mobile/screens/tasks.test.tsx` passed: 1 file, 26 tests.
- `pnpm check` passed: typecheck and lint completed successfully. Existing `max-lines` lint warnings were reported in unrelated files.

## Risk / Rollout

Low risk. This reuses the existing task insertion and quick-edit sheet flow; no data shape, migration, or sync behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change reusing existing insert and edit-sheet flows; no data, sync, or auth changes.
> 
> **Overview**
> Adds an always-visible **New task** floating action button on the mobile Tasks screen so users can create a task without hunting for a group-level add control when the list is non-empty.
> 
> The FAB mirrors the daily note screen’s fixed bottom-right `Plus` placement (safe-area/keyboard offset) and calls the existing `onAdd(todaysDailyTarget(today))` path—insert into today’s daily and open the quick-edit sheet. List bottom padding increases from `pb-8` to `pb-24` so rows aren’t covered by the button.
> 
> A regression test asserts tapping **New task** triggers `insertTask` for today’s daily and opens an empty task sheet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d42c6573cc41771b2c48d7c4024bd97e52cce5f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a persistent floating **New task** button on the mobile Tasks screen for quicker task creation.
  * Opening it now starts a new daily task and brings up the quick-edit drawer with an empty task field.

* **Bug Fixes**
  * Updated list spacing so the floating button no longer overlaps the task list content.
  * Added test coverage for the new task-creation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->