### PR TITLE
Fix iOS image lightbox opener safe area

### DIFF
--- a/apps/desktop/src/editor/image-lightbox.tsx
+++ b/apps/desktop/src/editor/image-lightbox.tsx
@@ -37,7 +37,7 @@ export function ImageLightbox({
   return (
     <LightboxDialog open title="Image preview" onClose={onClose}>
       {canOpenImage ? (
-        <div className="absolute top-4 right-4 z-10">
+        <div className="absolute top-[max(env(safe-area-inset-top),1rem)] right-[max(env(safe-area-inset-right),1rem)] z-10">
           <Button
             type="button"
             variant="ghost"

--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -239,6 +239,20 @@ describe('NoteEditor image lightbox', () => {
     expect(openImage).toHaveBeenCalledWith('assets/cat.png')
   })
 
+  it('keeps the image opener inside iOS safe-area bounds', async () => {
+    renderEditor()
+
+    act(() => captured.props?.onImageClick?.(imageClick('assets/cat.png', 'Cat')))
+
+    const opener = await screen.findByRole('button', { name: 'Open' })
+    expect(opener.parentElement?.className).toContain(
+      'top-[max(env(safe-area-inset-top),1rem)]',
+    )
+    expect(opener.parentElement?.className).toContain(
+      'right-[max(env(safe-area-inset-right),1rem)]',
+    )
+  })
+
   it('uses the opener captured when the lightbox opens', async () => {
     const firstOpenImage = vi.fn(async () => {})
     const secondOpenImage = vi.fn(async () => {})


### PR DESCRIPTION
## Problem

On iOS, the image lightbox opener sat at a fixed `top-4 right-4` offset. With `viewport-fit=cover`, the lightbox spans the full device viewport, so the top-right action could land under unsafe screen edges and be clipped.

## Changes

1. Move the lightbox Open action to `max(env(safe-area-inset-top), 1rem)` and `max(env(safe-area-inset-right), 1rem)` so it keeps the existing desktop spacing while respecting iOS safe-area insets.
2. Add a focused NoteEditor regression test that pins the safe-area placement contract for the image opener.

## Verification

- `pnpm --filter @reflect/desktop test src/editor/note-editor.test.tsx` passed.
- `pnpm check` passed. The command reported existing max-lines warnings only.

## Risk / Rollout

Low risk. This only adjusts the image lightbox opener position and leaves the image preview, close behavior, and opener callback unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only positioning change for one lightbox button; preview, close, and open callbacks are unchanged.
> 
> **Overview**
> Positions the image lightbox **Open** control using `max(env(safe-area-inset-top), 1rem)` and `max(env(safe-area-inset-right), 1rem)` instead of fixed `top-4` / `right-4`, so it stays tappable on full-bleed iOS viewports while keeping at least 1rem inset on desktop.
> 
> Adds a **NoteEditor** test that asserts the opener wrapper carries those Tailwind classes when the lightbox is shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ab271006b346f7f8cb08e7ff260f176978e9c5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->