### PR TITLE
Fix iOS Daily tab tap behavior

### DIFF
--- a/apps/desktop/src/mobile/day-carousel.tsx
+++ b/apps/desktop/src/mobile/day-carousel.tsx
@@ -13,6 +13,10 @@ interface DayCarouselProps {
    * while already there): the selected slide re-anchors to the top.
    */
   scrollResetSeq: number
+  /** The selected daily note that should receive editor focus, if any. */
+  focusDate: string | null
+  /** Called once the requested daily editor has focused. */
+  onFocusConsumed: () => void
   /** Settle on a day — the parent turns this into a daily-route navigation. */
   onSelect: (date: string) => void
 }
@@ -33,6 +37,8 @@ export function DayCarousel({
   date,
   today,
   scrollResetSeq,
+  focusDate,
+  onFocusConsumed,
   onSelect,
 }: DayCarouselProps): ReactElement {
   const { emblaRef, dayWindow, selectedIndex } = useDayCarousel(date, onSelect)
@@ -55,6 +61,8 @@ export function DayCarousel({
                   selected={index === selectedIndex}
                   scrollMemory={scrollMemory}
                   scrollResetSeq={scrollResetSeq}
+                  focusRequested={focusDate === day && index === selectedIndex}
+                  onFocusConsumed={onFocusConsumed}
                 />
               ) : null}
             </div>

--- a/apps/desktop/src/mobile/day-slide.tsx
+++ b/apps/desktop/src/mobile/day-slide.tsx
@@ -1,7 +1,6 @@
-import { useCallback, useEffect, useRef, type ReactElement } from 'react'
+import { useEffect, useRef, type ReactElement } from 'react'
 import { dailyPath } from '@reflect/core'
 import { NotePane } from '@/components/note-pane'
-import type { NoteEditorHandle } from '@/editor/note-editor'
 import { formatDayLabel } from '@/lib/dates'
 import { cn } from '@/lib/utils'
 import { IncomingBacklinks } from '@/mobile/incoming-backlinks'
@@ -54,8 +53,6 @@ export function DaySlide({
   const { settings } = useSettings()
   const containerRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
-  const editorHandleRef = useRef<NoteEditorHandle | null>(null)
-  const focusConsumedRef = useRef(false)
   const { handleScroll, resetToTop } = useScrollRestore({
     key: day,
     memory: scrollMemory,
@@ -74,37 +71,6 @@ export function DaySlide({
     }
     resetToTop()
   }, [scrollResetSeq, selected, resetToTop])
-
-  const focusIfRequested = useCallback(
-    (handle: NoteEditorHandle | null = editorHandleRef.current): void => {
-      if (!focusRequested || focusConsumedRef.current || handle === null) {
-        return
-      }
-      focusConsumedRef.current = true
-      handle.focus()
-      onFocusConsumed()
-    },
-    [focusRequested, onFocusConsumed],
-  )
-
-  useEffect(() => {
-    if (!focusRequested) {
-      focusConsumedRef.current = false
-      return
-    }
-    focusIfRequested()
-  }, [focusRequested, focusIfRequested])
-
-  const registerEditorHandle = useCallback(
-    (registeredDay: string, handle: NoteEditorHandle | null): void => {
-      if (registeredDay !== day) {
-        return
-      }
-      editorHandleRef.current = handle
-      focusIfRequested(handle)
-    },
-    [day, focusIfRequested],
-  )
 
   return (
     <div
@@ -130,9 +96,9 @@ export function DaySlide({
         </h2>
         <NotePane
           path={dailyPath(day)}
-          dailyDate={day}
-          registerHandle={registerEditorHandle}
           lazy
+          autoFocus={focusRequested}
+          onAutoFocused={onFocusConsumed}
           showBacklinks={false}
           gutterClassName={MOBILE_CONTENT_GUTTER}
           editorClassName="min-h-[60dvh]"

--- a/apps/desktop/src/mobile/day-slide.tsx
+++ b/apps/desktop/src/mobile/day-slide.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, type ReactElement } from 'react'
+import { useCallback, useEffect, useRef, type ReactElement } from 'react'
 import { dailyPath } from '@reflect/core'
 import { NotePane } from '@/components/note-pane'
+import type { NoteEditorHandle } from '@/editor/note-editor'
 import { formatDayLabel } from '@/lib/dates'
 import { cn } from '@/lib/utils'
 import { IncomingBacklinks } from '@/mobile/incoming-backlinks'
@@ -26,6 +27,10 @@ interface DaySlideProps {
    * tapped while already there): the selected slide re-anchors to the top.
    */
   scrollResetSeq: number
+  /** True when this slide's editor should focus as soon as its handle exists. */
+  focusRequested: boolean
+  /** Called after the focus request has been applied. */
+  onFocusConsumed: () => void
 }
 
 /**
@@ -43,10 +48,14 @@ export function DaySlide({
   selected,
   scrollMemory,
   scrollResetSeq,
+  focusRequested,
+  onFocusConsumed,
 }: DaySlideProps): ReactElement {
   const { settings } = useSettings()
   const containerRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
+  const editorHandleRef = useRef<NoteEditorHandle | null>(null)
+  const focusConsumedRef = useRef(false)
   const { handleScroll, resetToTop } = useScrollRestore({
     key: day,
     memory: scrollMemory,
@@ -65,6 +74,37 @@ export function DaySlide({
     }
     resetToTop()
   }, [scrollResetSeq, selected, resetToTop])
+
+  const focusIfRequested = useCallback(
+    (handle: NoteEditorHandle | null = editorHandleRef.current): void => {
+      if (!focusRequested || focusConsumedRef.current || handle === null) {
+        return
+      }
+      focusConsumedRef.current = true
+      handle.focus()
+      onFocusConsumed()
+    },
+    [focusRequested, onFocusConsumed],
+  )
+
+  useEffect(() => {
+    if (!focusRequested) {
+      focusConsumedRef.current = false
+      return
+    }
+    focusIfRequested()
+  }, [focusRequested, focusIfRequested])
+
+  const registerEditorHandle = useCallback(
+    (registeredDay: string, handle: NoteEditorHandle | null): void => {
+      if (registeredDay !== day) {
+        return
+      }
+      editorHandleRef.current = handle
+      focusIfRequested(handle)
+    },
+    [day, focusIfRequested],
+  )
 
   return (
     <div
@@ -90,6 +130,8 @@ export function DaySlide({
         </h2>
         <NotePane
           path={dailyPath(day)}
+          dailyDate={day}
+          registerHandle={registerEditorHandle}
           lazy
           showBacklinks={false}
           gutterClassName={MOBILE_CONTENT_GUTTER}

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -389,15 +389,22 @@ describe('MobileShell', () => {
     await user.click(view.getByRole('button', { name: 'All' }))
     await view.findByRole('searchbox', { name: 'Search notes' })
 
-    await user.click(view.getByRole('button', { name: 'Daily' }))
+    let fakeNow = 1_000
+    const now = vi.spyOn(Date, 'now').mockImplementation(() => fakeNow)
+
+    fireEvent.click(view.getByRole('button', { name: 'Daily' }))
     expect(view.getByRole('button', { name: dayCellLabel(other) }).getAttribute('aria-current')).toBe(
       'date',
     )
 
-    await user.click(view.getByRole('button', { name: 'Daily' }))
-    expect(view.getByRole('button', { name: dayCellLabel(today) }).getAttribute('aria-current')).toBe(
-      'date',
-    )
+    fakeNow = 1_100
+    fireEvent.click(view.getByRole('button', { name: 'Daily' }))
+    now.mockRestore()
+    await waitFor(() => {
+      expect(
+        view.getByRole('button', { name: dayCellLabel(today) }).getAttribute('aria-current'),
+      ).toBe('date')
+    })
     await waitFor(() => {
       expect(editorProbe.focusCalls).toBe(1)
     })

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -358,16 +358,65 @@ describe('MobileShell', () => {
     })
   })
 
-  it('switches tabs: All shows the searchable list, Daily returns to today', async () => {
+  it('switches tabs: All shows the searchable list, Daily returns to the last-open day', async () => {
     const user = userEvent.setup()
+    const today = todayIso()
+    const other = otherDayInWeek(today)
     const view = mount({ kind: 'today' })
+
+    await user.click(view.getByRole('button', { name: dayCellLabel(other) }))
+    expect(view.getByRole('button', { name: dayCellLabel(other) }).getAttribute('aria-current')).toBe(
+      'date',
+    )
 
     await user.click(view.getByRole('button', { name: 'All' }))
     expect(view.getByRole('searchbox', { name: 'Search notes' })).toBeTruthy()
     expect((await view.findByText('No notes yet')).textContent).toBe('No notes yet')
 
     await user.click(view.getByRole('button', { name: 'Daily' }))
-    expect(view.getByRole('heading', { level: 1 }).textContent).toBe(monthLabel(todayIso()))
+    expect(view.getByRole('button', { name: dayCellLabel(other) }).getAttribute('aria-current')).toBe(
+      'date',
+    )
+  })
+
+  it('double-tapping Daily opens today and focuses the daily editor', async () => {
+    const user = userEvent.setup()
+    const today = todayIso()
+    const other = otherDayInWeek(today)
+    const view = mount({ kind: 'today' })
+
+    await user.click(view.getByRole('button', { name: dayCellLabel(other) }))
+    await user.click(view.getByRole('button', { name: 'All' }))
+    await view.findByRole('searchbox', { name: 'Search notes' })
+
+    await user.click(view.getByRole('button', { name: 'Daily' }))
+    expect(view.getByRole('button', { name: dayCellLabel(other) }).getAttribute('aria-current')).toBe(
+      'date',
+    )
+
+    await user.click(view.getByRole('button', { name: 'Daily' }))
+    expect(view.getByRole('button', { name: dayCellLabel(today) }).getAttribute('aria-current')).toBe(
+      'date',
+    )
+    await waitFor(() => {
+      expect(editorProbe.focusCalls).toBe(1)
+    })
+  })
+
+  it('does not jump to today on a single tap of the active Daily tab', async () => {
+    const user = userEvent.setup()
+    const today = todayIso()
+    const other = otherDayInWeek(today)
+    const view = mount({ kind: 'daily', date: other })
+
+    await user.click(view.getByRole('button', { name: 'Daily' }))
+    expect(view.getByRole('button', { name: dayCellLabel(other) }).getAttribute('aria-current')).toBe(
+      'date',
+    )
+    expect(view.getByRole('button', { name: dayCellLabel(today) }).getAttribute('aria-current')).not.toBe(
+      'date',
+    )
+    expect(editorProbe.focusCalls).toBe(0)
   })
 
   it('switches to the Tasks tab, which renders the grouped task list', async () => {

--- a/apps/desktop/src/mobile/mobile-shell.tsx
+++ b/apps/desktop/src/mobile/mobile-shell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactElement } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, type ReactElement } from 'react'
 import { MobileFormattingToolbar } from '@/mobile/formatting-toolbar'
 import { MobileStack } from '@/mobile/mobile-stack'
 import { MobileTabBar, type MobileTab } from '@/mobile/mobile-tab-bar'
@@ -66,7 +66,7 @@ export function MobileShell(): ReactElement {
     setLastDailyRoute(currentDailyRoute)
   }
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (currentDailyRoute === null) {
       lastDailyTapAt.current = null
     }

--- a/apps/desktop/src/mobile/mobile-shell.tsx
+++ b/apps/desktop/src/mobile/mobile-shell.tsx
@@ -8,7 +8,16 @@ import {
 } from '@/mobile/search-filters/filter-state'
 import { useKeyboardVisible } from '@/mobile/use-keyboard'
 import { useWakeToToday } from '@/mobile/use-wake-to-today'
+import { routesEqual, type Route } from '@/routing/route'
 import { useRouter } from '@/routing/router'
+
+const DAILY_DOUBLE_TAP_MS = 450
+
+type DailyRoute = Extract<Route, { kind: 'today' }> | Extract<Route, { kind: 'daily' }>
+
+function dailyRouteFrom(route: Route): DailyRoute | null {
+  return route.kind === 'today' || route.kind === 'daily' ? route : null
+}
 
 /**
  * The tabbed mobile shell (Plan 19, V1 parity): screens above, the
@@ -22,6 +31,8 @@ export function MobileShell(): ReactElement {
   const [allQuery, setAllQuery] = useState('')
   const [allFilters, setAllFilters] = useState<AllNotesFilters>(EMPTY_ALL_NOTES_FILTERS)
   const [lastTab, setLastTab] = useState<MobileTab>('daily')
+  const [lastDailyRoute, setLastDailyRoute] = useState<DailyRoute>({ kind: 'today' })
+  const lastDailyTapAt = useRef<number | null>(null)
   const keyboardVisible = useKeyboardVisible()
   // V1's wake-to-today: foregrounding on a new calendar date lands on today.
   useWakeToToday()
@@ -47,8 +58,45 @@ export function MobileShell(): ReactElement {
         : route.kind === 'today' || route.kind === 'daily'
           ? 'daily'
           : lastTab
+  const currentDailyRoute = dailyRouteFrom(route)
   if (tab !== lastTab) {
     setLastTab(tab)
+  }
+  if (currentDailyRoute !== null && !routesEqual(currentDailyRoute, lastDailyRoute)) {
+    setLastDailyRoute(currentDailyRoute)
+  }
+
+  useEffect(() => {
+    if (currentDailyRoute === null) {
+      lastDailyTapAt.current = null
+    }
+  }, [currentDailyRoute])
+
+  const handleTabSelect = (next: MobileTab): void => {
+    if (next !== 'daily') {
+      lastDailyTapAt.current = null
+      navigate(
+        next === 'tasks'
+          ? { kind: 'tasks' }
+          : { kind: 'allNotes', tag: null },
+      )
+      return
+    }
+
+    const now = Date.now()
+    const doubleTap =
+      lastDailyTapAt.current !== null && now - lastDailyTapAt.current <= DAILY_DOUBLE_TAP_MS
+    lastDailyTapAt.current = now
+
+    if (doubleTap) {
+      navigate({ kind: 'today' }, { focusEditor: true })
+      return
+    }
+
+    if (currentDailyRoute !== null) {
+      return
+    }
+    navigate(lastDailyRoute, { restoreSurfaceScroll: true })
   }
 
   return (
@@ -77,18 +125,7 @@ export function MobileShell(): ReactElement {
       {keyboardVisible ? (
         <MobileFormattingToolbar />
       ) : (
-        <MobileTabBar
-          tab={tab}
-          onSelect={(next) =>
-            navigate(
-              next === 'daily'
-                ? { kind: 'today' }
-                : next === 'tasks'
-                  ? { kind: 'tasks' }
-                  : { kind: 'allNotes', tag: null },
-            )
-          }
-        />
+        <MobileTabBar tab={tab} onSelect={handleTabSelect} />
       )}
     </div>
   )

--- a/apps/desktop/src/mobile/mobile-tab-bar.tsx
+++ b/apps/desktop/src/mobile/mobile-tab-bar.tsx
@@ -90,8 +90,8 @@ function TabButton({
       type="button"
       aria-label={label}
       aria-current={active ? 'page' : undefined}
-      // V1 parity: a light haptic on every tab press — including a re-press
-      // of the active tab, which is the jump-to-today gesture on Daily.
+      // V1 parity: a light haptic on every tab press, including the two taps
+      // that make Daily's double-tap-to-today gesture.
       onClick={() => {
         hapticImpactLight()
         onClick()

--- a/apps/desktop/src/mobile/screens/daily.tsx
+++ b/apps/desktop/src/mobile/screens/daily.tsx
@@ -19,7 +19,7 @@ import { useRouter } from '@/routing/router'
  * day change scrolls the carousel rather than remounting it.
  */
 export function MobileDaily({ date }: { date: string }): ReactElement {
-  const { navigate, arrivalSeq } = useRouter()
+  const { navigate, arrivalSeq, arrivalFocusEditor } = useRouter()
   // One live `today` for the whole surface: the strip marks today's cell and
   // the `select` below decide "is this today?" from the *same* value, so they
   // can't disagree across the midnight rollover (which would otherwise route a
@@ -39,19 +39,36 @@ export function MobileDaily({ date }: { date: string }): ReactElement {
   // every navigate, but a swipe's own echo also changes `date`, so only
   // date-preserving arrivals count.
   const [resetSeq, setResetSeq] = useState(0)
+  const [focusDate, setFocusDate] = useState<string | null>(null)
   const lastArrival = useRef({ seq: arrivalSeq, date })
   useEffect(() => {
     const last = lastArrival.current
     lastArrival.current = { seq: arrivalSeq, date }
+    if (arrivalSeq !== last.seq && arrivalFocusEditor) {
+      setFocusDate(date)
+    } else if (arrivalSeq !== last.seq) {
+      setFocusDate(null)
+    }
     if (arrivalSeq !== last.seq && date === last.date) {
       setResetSeq((seq) => seq + 1)
     }
-  }, [arrivalSeq, date])
+  }, [arrivalSeq, arrivalFocusEditor, date])
+
+  const consumeFocus = useCallback((): void => {
+    setFocusDate(null)
+  }, [])
 
   return (
     <div className="flex h-full w-screen flex-col">
       <CalendarStrip date={date} today={today} resetSeq={resetSeq} onSelect={select} />
-      <DayCarousel date={date} today={today} scrollResetSeq={resetSeq} onSelect={select} />
+      <DayCarousel
+        date={date}
+        today={today}
+        scrollResetSeq={resetSeq}
+        focusDate={focusDate}
+        onFocusConsumed={consumeFocus}
+        onSelect={select}
+      />
       <Button
         size="icon"
         aria-label="New note"


### PR DESCRIPTION
## Problem

The iOS Daily tab treated every tap as an explicit "go to today" command. That diverged from Reflect V1: switching back to Daily should restore the daily screen where the user last left it, and only a double-tap should jump to today's daily note and focus the editor.

## Before -> After

| Gesture | Before | After |
| --- | --- | --- |
| Single tap Daily from another tab | Opened today | Opens the last daily route, even if it is not today |
| Single tap active Daily | Re-anchored toward today semantics | Leaves the current daily note alone |
| Double tap Daily | Same as repeated single taps | Opens today's daily note and focuses its editor |

## Changes

1. `MobileShell` now remembers the last `today` / `daily` route separately from the active tab and detects a quick second Daily tap.
2. `MobileDaily`, `DayCarousel`, and `DaySlide` carry a one-shot focus request down to the selected daily note and apply it when the lazy `NotePane` editor handle is available.
3. `mobile-screen.test.tsx` covers the V1 tab contract: single tap restores the last-open daily note, double tap jumps to today and focuses, and active Daily does not jump on a single tap.

## Verification

- `pnpm --filter @reflect/desktop test src/mobile/mobile-screen.test.tsx` passed: 24 tests.
- `pnpm check` passed. Oxlint printed existing max-lines warnings in unrelated files.

## Risk / Rollout

No migrations or persistence changes. The risk is limited to mobile tab navigation and daily-editor focus behavior; the added tests cover the intended tap cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is mobile tab routing and one-shot daily editor focus; existing router `focusEditor` contract is reused and new integration tests cover the tap gestures.
> 
> **Overview**
> Aligns **iOS Daily tab** behavior with Reflect V1: a single tap no longer always jumps to today.
> 
> **`MobileShell`** tracks the last `today` / `daily` route and routes Daily tab presses through **`handleTabSelect`**. From another tab, one tap restores that last daily day (with `restoreSurfaceScroll`). While already on Daily, a single tap does nothing. Two taps within **450ms** navigate to today with `{ focusEditor: true }`.
> 
> **`MobileDaily` → `DayCarousel` → `DaySlide`** pass a one-shot focus request when `arrivalFocusEditor` is set; the selected slide’s lazy **`NotePane`** uses `autoFocus` / `onAutoFocused` so double-tap-to-today raises the keyboard.
> 
> **`mobile-screen.test.tsx`** asserts restore-last-day, double-tap-to-today + focus, and no jump on a single tap while Daily is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 628013128ef90eec93af689574013dc347462f1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->