### PR TITLE
fix(ios): align mobile screen headers

### DIFF
--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -324,7 +324,7 @@ describe('MobileShell', () => {
     const view = mount({ kind: 'today' }, { kind: 'note', path: 'notes/meeting-notes.md' })
 
     await user.click(view.getByRole('button', { name: 'probe-navigate' }))
-    expect(view.getByRole('heading').textContent).toContain('meeting-notes')
+    expect(view.getByRole('heading').textContent).toBe('Edit note')
 
     await user.click(view.getByRole('button', { name: 'Back' }))
     expect(view.getByRole('heading', { level: 1 }).textContent).toBe(monthLabel(todayIso()))
@@ -441,7 +441,7 @@ describe('MobileShell', () => {
     files['notes/meeting-notes.md'] = 'agenda'
     const view = mount({ kind: 'note', path: 'notes/meeting-notes.md' })
 
-    expect(view.getByRole('heading').textContent).toContain('meeting-notes')
+    expect(view.getByRole('heading').textContent).toBe('Edit note')
     await waitFor(() => {
       expect(within(visibleLayer(view)).getByTestId('fake-editor').textContent).toContain('agenda')
     })
@@ -541,7 +541,7 @@ describe('MobileStack transitions & back-swipe', () => {
     const layers = stackLayers(view)
     expect(layers).toHaveLength(3)
     expect(layers.at(-1)!.className).toContain('mobile-stack-slide-out')
-    expect(within(visibleLayer(view)).getByRole('heading').textContent).toContain('source')
+    expect(within(visibleLayer(view)).getByRole('heading').textContent).toBe('Edit note')
     fireEvent.animationEnd(layers.at(-1)!)
     expect(stackLayers(view)).toHaveLength(2)
   })
@@ -665,7 +665,7 @@ describe('MobileStack transitions & back-swipe', () => {
       expect(card.style.transform).toBe('translate3d(0, 0, 0)')
 
       fireEvent.transitionEnd(card)
-      expect(view.getByRole('heading').textContent).toContain('meeting-notes')
+      expect(view.getByRole('heading').textContent).toBe('Edit note')
       expect(stackLayers(view)).toHaveLength(2)
     } finally {
       nowSpy.mockRestore()

--- a/apps/desktop/src/mobile/screen-header.test.tsx
+++ b/apps/desktop/src/mobile/screen-header.test.tsx
@@ -1,0 +1,37 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MobileScreenHeader } from './screen-header'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('MobileScreenHeader', () => {
+  it('centers the title between balanced header action slots', () => {
+    const view = render(
+      <MobileScreenHeader
+        title="Roadmap"
+        onBack={vi.fn()}
+        trailing={<button type="button" aria-label="More actions" />}
+      />,
+    )
+
+    const header = view.container.querySelector('header')
+    if (header === null) {
+      throw new Error('expected a header')
+    }
+    expect(Array.from(header.classList)).toContain('grid')
+    expect(Array.from(header.classList)).toContain('h-11')
+    expect(Array.from(header.classList)).toContain(
+      'grid-cols-[2.5rem_minmax(0,1fr)_2.5rem]',
+    )
+    expect(Array.from(header.classList)).toContain('items-center')
+
+    expect(Array.from(screen.getByRole('button', { name: 'Back' }).classList)).toContain(
+      'justify-self-center',
+    )
+    expect(Array.from(screen.getByRole('heading', { name: 'Roadmap' }).classList)).toContain(
+      'text-center',
+    )
+  })
+})

--- a/apps/desktop/src/mobile/screen-header.tsx
+++ b/apps/desktop/src/mobile/screen-header.tsx
@@ -17,18 +17,18 @@ interface MobileScreenHeaderProps {
  */
 export function MobileScreenHeader({ title, onBack, trailing }: MobileScreenHeaderProps): ReactElement {
   return (
-    <header className="flex shrink-0 items-center gap-1 border-b border-border px-1 pb-1">
+    <header className="grid h-11 shrink-0 grid-cols-[2.5rem_minmax(0,1fr)_2.5rem] items-center border-b border-border px-1">
       <Button
         variant="ghost"
         size="icon"
-        className="size-10"
+        className="size-10 justify-self-center"
         aria-label="Back"
         onClick={onBack}
       >
         <ChevronLeft />
       </Button>
-      <h1 className="min-w-0 flex-1 truncate text-base font-semibold">{title}</h1>
-      {trailing}
+      <h1 className="min-w-0 truncate text-center text-base font-semibold">{title}</h1>
+      <div className="flex size-10 items-center justify-center justify-self-center">{trailing}</div>
     </header>
   )
 }

--- a/apps/desktop/src/mobile/screens/note.test.tsx
+++ b/apps/desktop/src/mobile/screens/note.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useEffect, useRef, type ReactElement } from 'react'
 import { untitledNotePath } from '@reflect/core'
@@ -77,6 +77,11 @@ afterEach(() => {
 })
 
 describe('MobileNote focus contract', () => {
+  it('labels an existing note screen as edit note', () => {
+    renderArrival('notes/target.md')
+    expect(screen.getByRole('heading', { name: 'Edit note' })).toBeTruthy()
+  })
+
   it('does not autofocus a plain arrival (no keyboard on browse)', () => {
     renderArrival('notes/target.md')
     expect(paneProps.autoFocus).toBe(false)
@@ -94,6 +99,7 @@ describe('MobileNote focus contract', () => {
 
   it('autofocuses a fresh untitled note (the + flow)', () => {
     renderArrival(untitledNotePath())
+    expect(screen.getByRole('heading', { name: 'New note' })).toBeTruthy()
     expect(paneProps.autoFocus).toBe(true)
   })
 

--- a/apps/desktop/src/mobile/screens/note.tsx
+++ b/apps/desktop/src/mobile/screens/note.tsx
@@ -30,7 +30,7 @@ export function MobileNote({ path }: { path: string }): ReactElement {
   return (
     <div className="flex h-full w-screen flex-col" style={{ paddingTop: 'env(safe-area-inset-top)' }}>
       <MobileScreenHeader
-        title={untitled ? 'New note' : noteTitleFromPath(path)}
+        title={untitled ? 'New note' : 'Edit note'}
         onBack={() => (canBack ? back() : navigate({ kind: 'today' }))}
         trailing={
           <NoteActionsMenu
@@ -65,10 +65,4 @@ export function MobileNote({ path }: { path: string }): ReactElement {
       </main>
     </div>
   )
-}
-
-/** Readable filenames (Plan 17) make the basename the working title. */
-function noteTitleFromPath(path: string): string {
-  const base = path.slice(path.lastIndexOf('/') + 1)
-  return base.endsWith('.md') ? base.slice(0, -'.md'.length) : base
 }

--- a/apps/desktop/src/mobile/screens/note.tsx
+++ b/apps/desktop/src/mobile/screens/note.tsx
@@ -1,10 +1,9 @@
 import { useState, type ReactElement } from 'react'
 import { isUntitledNotePath } from '@reflect/core'
-import { ChevronLeft } from 'lucide-react'
 import { NotePane } from '@/components/note-pane'
-import { Button } from '@/components/ui/button'
 import { IncomingBacklinks } from '@/mobile/incoming-backlinks'
 import { MOBILE_CONTENT_GUTTER } from '@/mobile/mobile-content-gutter'
+import { MobileScreenHeader } from '@/mobile/screen-header'
 import { NoteActionsMenu } from '@/mobile/note-actions-menu'
 import { cn } from '@/lib/utils'
 import { useRouter } from '@/routing/router'
@@ -30,24 +29,16 @@ export function MobileNote({ path }: { path: string }): ReactElement {
 
   return (
     <div className="flex h-full w-screen flex-col" style={{ paddingTop: 'env(safe-area-inset-top)' }}>
-      <header className="flex shrink-0 items-center gap-1 border-b border-border px-1 pb-1">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-10"
-          aria-label="Back"
-          onClick={() => (canBack ? back() : navigate({ kind: 'today' }))}
-        >
-          <ChevronLeft />
-        </Button>
-        <h1 className="min-w-0 flex-1 truncate text-base font-semibold">
-          {untitled ? 'New note' : noteTitleFromPath(path)}
-        </h1>
-        <NoteActionsMenu
-          path={path}
-          onDeleted={() => (canBack ? back() : navigate({ kind: 'today' }))}
-        />
-      </header>
+      <MobileScreenHeader
+        title={untitled ? 'New note' : noteTitleFromPath(path)}
+        onBack={() => (canBack ? back() : navigate({ kind: 'today' }))}
+        trailing={
+          <NoteActionsMenu
+            path={path}
+            onDeleted={() => (canBack ? back() : navigate({ kind: 'today' }))}
+          />
+        }
+      />
       <main
         className="min-h-0 flex-1 overflow-y-auto"
         // Keyboard avoidance is the shell root's job (it ends at the


### PR DESCRIPTION
## Problem

Mobile pushed-screen headers were using a flex row where the title consumed whatever space remained after the back button and trailing actions. On note screens, that made the title read as left-aligned instead of visually centered in the iOS title bar. The existing-note screen also exposed the filename-derived note subject in the header, but the requested iOS chrome should use the generic `Edit note` title instead.

## Before -> After

| Before | After |
| --- | --- |
| Note subjects sat in the leftover flex space between the back button and actions. | Pushed-screen titles render in a centered middle slot with equal leading/trailing action slots. |
| Existing note screens displayed the note subject/filename in the header. | Existing note screens display `Edit note`; fresh untitled notes still display `New note`. |
| The note screen carried its own duplicate header markup. | Notes reuse `MobileScreenHeader`, matching Settings and Graphs. |
| Header height came from button height plus bottom padding. | Header uses a fixed `h-11` row with centered icon slots. |

## Changes

1. Updates `MobileScreenHeader` to use a three-column grid: 40px back slot, centered title, and 40px trailing slot.
2. Centers the header title text and vertically centers both header action slots.
3. Routes `MobileNote` through `MobileScreenHeader` so note screens get the same title-bar geometry as the other pushed mobile screens.
4. Changes existing-note screen titles to `Edit note`, while preserving `New note` for the untitled creation flow.
5. Adds and updates mobile tests for the centered header structure, note-screen copy, and stack navigation expectations.

## Verification

- `pnpm --filter @reflect/desktop test -- src/mobile/screen-header.test.tsx src/mobile/screens/note.test.tsx` passed. Vitest expanded to the desktop test set: 174 files / 1554 tests.
- `pnpm check` passed. It reported existing max-lines warnings in unrelated files.
- `git diff --check` passed.

## Risk / Rollout

Low-risk mobile layout/copy change. The centered title bar is shared by note/settings/graphs pushed screens; search-heavy tab headers are unchanged.