### PR TITLE
fix(ios): keep the hide-keyboard button visible in the formatting toolbar

### DIFF
--- a/apps/desktop/src/mobile/formatting-toolbar.tsx
+++ b/apps/desktop/src/mobile/formatting-toolbar.tsx
@@ -12,7 +12,6 @@ import {
   Slash,
 } from 'lucide-react'
 import { useFormattingToolbar } from '@/editor/formatting-toolbar-store'
-import { cn } from '@/lib/utils'
 import { hapticImpactLight } from '@/mobile/haptics'
 
 /**
@@ -30,6 +29,9 @@ import { hapticImpactLight } from '@/mobile/haptics'
  * `contenteditable` no Done key. Renders nothing while no editor is focused:
  * the All-tab search field raises the keyboard too, and formatting buttons
  * would be dead weight there.
+ *
+ * The dismiss button is pinned outside the scrollable region so it stays
+ * visible even when the formatting buttons overflow on narrow screens.
  */
 export function MobileFormattingToolbar(): ReactElement | null {
   const toolbar = useFormattingToolbar()
@@ -41,63 +43,66 @@ export function MobileFormattingToolbar(): ReactElement | null {
     <div
       role="toolbar"
       aria-label="Formatting"
-      className="flex shrink-0 items-center gap-0.5 overflow-x-auto border-t border-border px-1"
+      className="flex shrink-0 items-center border-t border-border"
     >
-      <ToolbarButton
-        label="Slash command"
-        icon={<Slash className="size-5" />}
-        onPress={() => commands.insertTrigger('/')}
-      />
-      <ToolbarButton
-        label="Bullet list"
-        icon={<List className="size-5" />}
-        onPress={commands.toggleBulletList}
-      />
-      <ToolbarButton
-        label="Task list"
-        icon={<ListTodo className="size-5" />}
-        onPress={commands.toggleTaskList}
-      />
-      <ToolbarButton
-        label="Link note"
-        icon={<Brackets className="size-5" />}
-        onPress={() => commands.insertTrigger('[[')}
-      />
-      <ToolbarButton
-        label="Tag"
-        icon={<Hash className="size-5" />}
-        onPress={() => commands.insertTrigger('#')}
-      />
-      <ToolbarButton
-        label="Outdent"
-        icon={<IndentDecrease className="size-5" />}
-        disabled={!capabilities.canDedent}
-        onPress={commands.dedent}
-      />
-      <ToolbarButton
-        label="Indent"
-        icon={<IndentIncrease className="size-5" />}
-        disabled={!capabilities.canIndent}
-        onPress={commands.indent}
-      />
-      <ToolbarButton
-        label="Move up"
-        icon={<ArrowUp className="size-5" />}
-        disabled={!capabilities.canMoveUp}
-        onPress={commands.moveUp}
-      />
-      <ToolbarButton
-        label="Move down"
-        icon={<ArrowDown className="size-5" />}
-        disabled={!capabilities.canMoveDown}
-        onPress={commands.moveDown}
-      />
-      <ToolbarButton
-        label="Hide keyboard"
-        icon={<ChevronDown className="size-5" />}
-        className="ml-auto"
-        onPress={commands.dismissKeyboard}
-      />
+      <div className="flex min-w-0 flex-1 items-center overflow-x-auto px-1">
+        <ToolbarButton
+          label="Slash command"
+          icon={<Slash className="size-5" />}
+          onPress={() => commands.insertTrigger('/')}
+        />
+        <ToolbarButton
+          label="Bullet list"
+          icon={<List className="size-5" />}
+          onPress={commands.toggleBulletList}
+        />
+        <ToolbarButton
+          label="Task list"
+          icon={<ListTodo className="size-5" />}
+          onPress={commands.toggleTaskList}
+        />
+        <ToolbarButton
+          label="Link note"
+          icon={<Brackets className="size-5" />}
+          onPress={() => commands.insertTrigger('[[')}
+        />
+        <ToolbarButton
+          label="Tag"
+          icon={<Hash className="size-5" />}
+          onPress={() => commands.insertTrigger('#')}
+        />
+        <ToolbarButton
+          label="Outdent"
+          icon={<IndentDecrease className="size-5" />}
+          disabled={!capabilities.canDedent}
+          onPress={commands.dedent}
+        />
+        <ToolbarButton
+          label="Indent"
+          icon={<IndentIncrease className="size-5" />}
+          disabled={!capabilities.canIndent}
+          onPress={commands.indent}
+        />
+        <ToolbarButton
+          label="Move up"
+          icon={<ArrowUp className="size-5" />}
+          disabled={!capabilities.canMoveUp}
+          onPress={commands.moveUp}
+        />
+        <ToolbarButton
+          label="Move down"
+          icon={<ArrowDown className="size-5" />}
+          disabled={!capabilities.canMoveDown}
+          onPress={commands.moveDown}
+        />
+      </div>
+      <div className="shrink-0 border-l border-border px-1">
+        <ToolbarButton
+          label="Hide keyboard"
+          icon={<ChevronDown className="size-5" />}
+          onPress={commands.dismissKeyboard}
+        />
+      </div>
     </div>
   )
 }
@@ -106,13 +111,11 @@ function ToolbarButton({
   label,
   icon,
   disabled = false,
-  className,
   onPress,
 }: {
   label: string
   icon: ReactElement
   disabled?: boolean
-  className?: string
   onPress: () => void
 }): ReactElement {
   return (
@@ -130,10 +133,7 @@ function ToolbarButton({
         hapticImpactLight()
         onPress()
       }}
-      className={cn(
-        'flex size-11 shrink-0 items-center justify-center rounded-md text-text-muted disabled:opacity-40',
-        className,
-      )}
+      className="flex h-11 w-10 shrink-0 items-center justify-center rounded-md text-text-muted disabled:opacity-40"
     >
       {icon}
     </button>


### PR DESCRIPTION
## Problem

The mobile formatting toolbar renders ten 44px-wide buttons in one horizontally scrollable row (~466px including gaps and padding) — wider than any iPhone screen (iPhone Air is 420pt, standard iPhones 393pt). The "Hide keyboard" button sits at the end of that scrollable row, so on every device it starts off-screen: the only way to dismiss the keyboard from the toolbar is to know to scroll the toolbar first.

## Before → After

| | Before | After |
|---|---|---|
| Hide keyboard button | scrolls with the row; off-screen by default on all devices | pinned outside the scroll region; always visible |
| Button metrics | 44×44, 2px gaps | 40 wide × 44 tall, no gaps |
| iPhone Air (420pt) | ~46px of hidden overflow | full toolbar fits, no scrolling |
| Standard iPhone (393pt) | ~73px hidden incl. dismiss | ~24px scroll among formatting buttons only; dismiss stays put |

## Changes

`apps/desktop/src/mobile/formatting-toolbar.tsx` only:

1. Split the toolbar into a scrollable region (the nine formatting buttons) and a pinned region (the dismiss button) separated by a `border-l` divider, so the dismiss button can never be scrolled out of view regardless of screen width.
2. Narrowed `ToolbarButton` from `size-11` to `h-11 w-10` and dropped the inter-button gap — touch-target height stays at Apple's 44pt, and the whole row now fits on an iPhone Air without scrolling.
3. Removed the now-unused `className` prop on `ToolbarButton` (its only consumer was the dismiss button's `ml-auto`, obsolete now that the button is pinned).

## Tests

Existing `formatting-toolbar.test.tsx` and `mobile-screen.test.tsx` pin the behavior that matters (button order, aria-labels, focus-preserving pointerdown, command routing) and pass unchanged — the restructure keeps DOM button order identical.

## Verification

- `pnpm check` — typecheck + lint pass (pre-existing max-lines warnings only)
- `pnpm test --run src/mobile/formatting-toolbar.test.tsx src/mobile/mobile-screen.test.tsx` — 26 tests pass

Not run: a device/simulator pass. The width math is static (9×40 + 8 padding + 49 pinned = 417pt ≤ 420pt), but a quick visual check on a simulator is owed.

## Risk / Rollout

Pure layout change to one mobile component; no data, IPC, or desktop impact. Worst case on very narrow screens is a slightly scrollable formatting region — the dismiss button is unaffected by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file mobile UI layout only; behavior and test expectations for button order and commands are unchanged.
> 
> **Overview**
> **Fixes the mobile formatting toolbar** so **Hide keyboard** is always reachable without scrolling the row first.
> 
> The toolbar is split into a **horizontally scrollable** block for the nine formatting actions and a **fixed trailing** block (with a left divider) for dismiss. Button width is tightened from 44×44 to **40×44** and inter-button gaps are removed so more devices fit the formatting row; **`ToolbarButton`** no longer accepts a **`className`** prop or uses **`cn`**, since **`ml-auto`** on dismiss is obsolete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 015b811abab2985b3c20cb5631f9fe3762524e11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->