### PR TITLE
Fix TestFlight build number defaults

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -3,10 +3,6 @@ name: TestFlight
 on:
   workflow_dispatch:
     inputs:
-      build_number:
-        description: CFBundleVersion build number. Defaults to the GitHub run number.
-        required: false
-        type: string
       export_method:
         description: Xcode export method for the IPA.
         required: true
@@ -79,12 +75,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Resolve build number
+        run: |
+          build_number="$(date -u +%Y%m%d%H%M)"
+          echo "BUILD_NUMBER=$build_number" >> "$GITHUB_ENV"
+          echo "Using TestFlight CFBundleVersion $build_number"
+
       - name: Build and upload to TestFlight
         env:
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
-          BUILD_NUMBER: ${{ inputs.build_number || github.run_number }}
           EXPORT_METHOD: ${{ inputs.export_method }}
           WAIT_FLAG: ${{ inputs.wait_for_processing && '--wait' || '' }}
         run: |

--- a/apps/desktop/scripts/release-ios.mjs
+++ b/apps/desktop/scripts/release-ios.mjs
@@ -2,7 +2,7 @@
 //
 // Usage:
 //   pnpm release:ios build --build-number=123
-//   pnpm release:ios testflight --build-number=123 --wait
+//   pnpm release:ios testflight --wait
 //   pnpm release:ios upload --ipa=apps/desktop/src-tauri/gen/apple/build/arm64/Reflect.ipa
 //
 // The App Store Connect API key is used twice when present:
@@ -137,13 +137,23 @@ function ensureTool(command, args, installHint) {
   if (result.status !== 0) fail(`${command} is not available. ${installHint}\n${result.output.trim()}`)
 }
 
-function ensureBuildNumber(buildNumber, { required }) {
+export function createTimestampBuildNumber(date = new Date()) {
+  const pad = (value) => String(value).padStart(2, '0')
+  return [
+    date.getUTCFullYear(),
+    pad(date.getUTCMonth() + 1),
+    pad(date.getUTCDate()),
+    pad(date.getUTCHours()),
+    pad(date.getUTCMinutes()),
+  ].join('')
+}
+
+function ensureBuildNumber(buildNumber, { required, now = new Date() }) {
   if (!buildNumber) {
     if (required) {
-      fail(
-        'missing build number. Pass --build-number=<number> or set BUILD_NUMBER/GITHUB_RUN_NUMBER.\n' +
-          '  TestFlight requires each upload for the same marketing version to have a new CFBundleVersion.',
-      )
+      const generatedBuildNumber = createTimestampBuildNumber(now)
+      log(`generated UTC timestamp build number: ${generatedBuildNumber}`)
+      return generatedBuildNumber
     }
     return null
   }
@@ -151,8 +161,8 @@ function ensureBuildNumber(buildNumber, { required }) {
   return buildNumber
 }
 
-function resolveBuildNumber(buildNumberFlag, { required }) {
-  return ensureBuildNumber(buildNumberFlag ?? process.env.BUILD_NUMBER ?? process.env.GITHUB_RUN_NUMBER, { required })
+export function resolveBuildNumber(buildNumberFlag, { required, now = new Date() }) {
+  return ensureBuildNumber(buildNumberFlag ?? process.env.BUILD_NUMBER, { required, now })
 }
 
 function resolveExportMethod(exportMethod) {
@@ -531,8 +541,9 @@ Commands:
 
 Flags:
   --build-number=<number>
-              CFBundleVersion build number. Required for preflight/testflight.
-              Defaults to BUILD_NUMBER or GITHUB_RUN_NUMBER when set.
+              CFBundleVersion build number. Defaults to BUILD_NUMBER when set.
+              Required preflight/testflight commands generate a UTC timestamp
+              (YYYYMMDDHHmm) when omitted.
   --export-method=<name>
               Tauri/Xcode export method: app-store-connect | release-testing |
               debugging | validation (default: app-store-connect)

--- a/apps/desktop/scripts/release-ios.test.mjs
+++ b/apps/desktop/scripts/release-ios.test.mjs
@@ -7,11 +7,13 @@ import {
   createAltoolUploadArgs,
   createAltoolValidateArgs,
   createApiKeyAltoolArgs,
+  createTimestampBuildNumber,
   createTauriIosBuildEnv,
   createTauriIosBuildArgs,
   findIpaInfoPlistPath,
   isFalsePlistValue,
   normalizeApiKeyContent,
+  resolveBuildNumber,
 } from './release-ios.mjs'
 
 test('iOS release builds pass App Store Connect export and build number through Tauri', () => {
@@ -41,6 +43,35 @@ test('iOS release builds can rely on local Xcode accounts when no API key is sup
     'release-testing',
     '--ci',
   ])
+})
+
+test('timestamp build numbers use UTC YYYYMMDDHHmm format', () => {
+  expect(createTimestampBuildNumber(new Date('2026-07-05T09:04:30Z'))).toBe('202607050904')
+})
+
+test('required iOS release commands generate timestamp build numbers instead of using GitHub run numbers', () => {
+  const previousBuildNumber = process.env.BUILD_NUMBER
+  const previousRunNumber = process.env.GITHUB_RUN_NUMBER
+
+  try {
+    delete process.env.BUILD_NUMBER
+    process.env.GITHUB_RUN_NUMBER = '10'
+
+    expect(resolveBuildNumber(null, { required: true, now: new Date('2026-07-05T09:04:30Z') })).toBe(
+      '202607050904',
+    )
+  } finally {
+    if (previousBuildNumber === undefined) {
+      delete process.env.BUILD_NUMBER
+    } else {
+      process.env.BUILD_NUMBER = previousBuildNumber
+    }
+    if (previousRunNumber === undefined) {
+      delete process.env.GITHUB_RUN_NUMBER
+    } else {
+      process.env.GITHUB_RUN_NUMBER = previousRunNumber
+    }
+  }
 })
 
 test('iOS release builds expose the staged API key path to Tauri signing', () => {

--- a/docs/ios-testflight.md
+++ b/docs/ios-testflight.md
@@ -3,9 +3,9 @@
 How to build Reflect's Tauri iOS target and upload it to TestFlight.
 
 ```bash
-pnpm release:ios preflight --build-number=123
-pnpm release:ios build --build-number=123
-pnpm release:ios testflight --build-number=123 --wait
+pnpm release:ios preflight
+pnpm release:ios build --build-number="$(date -u +%Y%m%d%H%M)"
+pnpm release:ios testflight --wait
 ```
 
 The helper lives at `apps/desktop/scripts/release-ios.mjs` and is exposed as
@@ -61,10 +61,13 @@ for `pnpm release:ios testflight`.
    through `@env:APPLE_PASSWORD`.
 
 4. **A monotonically increasing build number.** TestFlight rejects duplicate
-   `CFBundleVersion` values for the same marketing version. Pass
-   `--build-number=<number>` locally; the helper injects it as
-   `bundle.iOS.bundleVersion` so beta versions still produce a clean numeric
-   build version. The GitHub Action defaults this to the workflow run number.
+   `CFBundleVersion` values for the same marketing version. The GitHub Action
+   always generates a UTC timestamp in `YYYYMMDDHHmm` format. Local `preflight`
+   and `testflight` commands generate the same timestamp when `--build-number`
+   and `BUILD_NUMBER` are omitted. `--build-number=<number>` exists only as a
+   local debugging override. Do not use `github.run_number` for TestFlight
+   builds: a lower `CFBundleVersion` can upload successfully while TestFlight
+   still appears to show the previous timestamp build as the latest.
 
 5. **Xcode on macOS.** The workflow and local script use `xcodebuild`, Tauri's
    iOS build command, and `xcrun altool`.
@@ -72,7 +75,7 @@ for `pnpm release:ios testflight`.
 ## Commands
 
 ```bash
-pnpm release:ios preflight --build-number=123
+pnpm release:ios preflight
 ```
 
 Checks Xcode/altool, the build number, signing auth, and upload auth before
@@ -80,7 +83,7 @@ spending time on the native archive. It also verifies that App Store Connect has
 a separate app record for `app.reflect.ios`.
 
 ```bash
-pnpm release:ios build --build-number=123
+pnpm release:ios build --build-number="$(date -u +%Y%m%d%H%M)"
 ```
 
 Runs `pnpm tauri ios build --export-method app-store-connect --ci`, using the
@@ -90,11 +93,13 @@ when the key is configured. The build number is merged into the Tauri config as
 `apps/desktop/src-tauri/gen/apple/build/`.
 
 ```bash
-pnpm release:ios testflight --build-number=123 --wait
+pnpm release:ios testflight --wait
 ```
 
 Builds the IPA, uploads it with `xcrun altool --upload-package`, and optionally
-waits for App Store Connect processing to finish.
+waits for App Store Connect processing to finish. If `--build-number` and
+`BUILD_NUMBER` are both omitted, the helper generates a UTC timestamp build
+number before archiving.
 
 ```bash
 pnpm release:ios upload --ipa=apps/desktop/src-tauri/gen/apple/build/arm64/Reflect.ipa --wait
@@ -124,8 +129,11 @@ Configure these repository secrets:
 | `APPLE_API_ISSUER` | App Store Connect issuer UUID |
 | `APPLE_API_KEY_CONTENT` | Contents of `AuthKey_<KEY>.p8` |
 
-The workflow's build number defaults to `github.run_number`. Override the input
-only when retrying a run that already uploaded a build.
+The workflow does not accept a build-number input. Each run resolves one UTC
+timestamp build number, logs it, and passes the same value to both `preflight`
+and `testflight`. If you need a one-off custom value while debugging, run the
+local package command with `--build-number=<number>` instead of changing the
+workflow.
 
 ## Troubleshooting
 
@@ -137,9 +145,14 @@ only when retrying a run that already uploaded a build.
   bundle id exists for signing, but no App Store Connect app record exists yet.
   Create a new iOS app in App Store Connect for `app.reflect.ios`; do not reuse
   the old Capacitor app record (`app.reflect.ReflectMobile`).
-- **Duplicate build number**: rerun with a larger `--build-number`. TestFlight
-  build numbers are per marketing version; `0.4.0` build `123` can only be
-  uploaded once.
+- **Duplicate build number**: rerun the GitHub Action so it stamps a fresh
+  timestamp. For local debugging commands, pass a larger `--build-number`.
+  TestFlight build numbers are per marketing version; `0.4.0` build `123` can
+  only be uploaded once.
+- **TestFlight still shows an older build as latest**: inspect the GitHub Action
+  log for `bundle-version`. If the uploaded value is lower than the latest
+  TestFlight build (for example a small GitHub run number), rerun the workflow
+  so it stamps a fresh timestamp.
 - **Missing `.p8` file**: set `APPLE_API_KEY_CONTENT`, set `APPLE_API_KEY_PATH`,
   or place `AuthKey_<KEY>.p8` in `~/.appstoreconnect/private_keys/`.
 - **Multiple providers**: if using the Apple ID fallback for upload-only


### PR DESCRIPTION
## Problem

The TestFlight workflow defaulted omitted build numbers to `github.run_number`. That allowed a successful upload with a tiny `CFBundleVersion` such as `10`, while App Store Connect/TestFlight could still present the previous timestamp-style build, for example `202607050501`, as the latest build. The release looked green in GitHub Actions but did not reliably show the newly built app to testers.

## Before -> After

| Path | Before | After |
| --- | --- | --- |
| GitHub Actions TestFlight dispatch | Blank `build_number` became `github.run_number` | There is no build-number input; every run stamps itself with UTC `YYYYMMDDHHmm` |
| `pnpm release:ios preflight/testflight` | Missing build number failed unless `BUILD_NUMBER` or `GITHUB_RUN_NUMBER` was set | Missing build number generates the same UTC timestamp format |
| Docs | Recommended/mentioned the GitHub run-number default | Explains the timestamp default and the “uploaded but not latest” failure mode |

## Changes

1. Adds a `Resolve build number` workflow step that computes one timestamp build number and passes it to both `preflight` and `testflight`.
2. Removes the manual build-number input from the TestFlight GitHub Action so the release path is always timestamp-based.
3. Updates `release-ios.mjs` so required TestFlight/preflight commands generate timestamp build numbers instead of reading `GITHUB_RUN_NUMBER`.
4. Adds tests for UTC timestamp formatting and the regression where `GITHUB_RUN_NUMBER=10` must not win.
5. Updates `docs/ios-testflight.md` with the default behavior, local debug escape hatch, and troubleshooting note.

## Verification

- `pnpm --filter @reflect/desktop test --run scripts/release-ios.test.mjs` passed: 13 tests.
- `pnpm check` passed before the workflow-input simplification. It reported existing max-lines warnings in unrelated files, but no errors. The final follow-up only changed workflow/docs and the focused release-helper test was rerun successfully.

## Risk / Rollout

No data migrations or app runtime behavior changes. This only changes TestFlight release tooling and docs. Operators can still pass an explicit numeric `--build-number` to local package commands for debugging, but the GitHub Actions release path always uses the current UTC timestamp.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only iOS TestFlight release tooling and documentation; no app runtime or data migrations. Explicit `--build-number` remains for local debugging.
> 
> **Overview**
> Fixes TestFlight releases where a successful upload could still leave testers seeing an older build when `CFBundleVersion` was too low (e.g. `github.run_number` like `10` vs a prior timestamp build).
> 
> The **TestFlight** workflow drops the manual `build_number` input, adds a **Resolve build number** step that sets `BUILD_NUMBER` to UTC `YYYYMMDDHHmm`, and passes that value through `preflight` and `testflight`. **`release-ios.mjs`** adds `createTimestampBuildNumber` and makes required `preflight`/`testflight` paths auto-generate that format when `--build-number` and `BUILD_NUMBER` are missing; **`GITHUB_RUN_NUMBER` is no longer used**. Docs and tests cover the new default and the “uploaded but not latest” failure mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39b0c7ff6120c3d15b7646ec471ec4938cb1bd24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->