### PR TITLE
perf(ios): overlap the mobile boot chain — warm platform/chunk/storage, dedupe the settings load

### DIFF
--- a/apps/desktop/src/lib/mobile-boot-warm.test.ts
+++ b/apps/desktop/src/lib/mobile-boot-warm.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The warm slot holds module state (the in-flight promise), so each test
+ * imports a fresh copy of the module — and installs the fake bridge on the
+ * same fresh registry, since `vi.resetModules()` resets `@reflect/core`'s
+ * bridge slot too.
+ */
+async function freshModule(
+  invoke: (command: string) => Promise<unknown>,
+): Promise<typeof import('./mobile-boot-warm')> {
+  vi.resetModules()
+  const core = await import('@reflect/core')
+  core.setBridge({ invoke: async (command) => invoke(command), listen: async () => () => {} })
+  return import('./mobile-boot-warm')
+}
+
+const STORAGE = {
+  localRoot: '/Documents',
+  icloudDocumentsRoot: '/iCloud/Documents',
+  icloudGraphRoots: [],
+}
+
+afterEach(() => {
+  vi.resetModules()
+})
+
+describe('mobile-boot-warm', () => {
+  it('starts the resolve once and hands it to exactly one taker', async () => {
+    let storageCalls = 0
+    const { warmMobileStorage, takeWarmMobileStorage } = await freshModule(async (command) => {
+      if (command === 'mobile_storage') {
+        storageCalls += 1
+        return STORAGE
+      }
+      return null
+    })
+    warmMobileStorage()
+    warmMobileStorage() // idempotent — still one IPC
+    expect(storageCalls).toBe(1)
+
+    const taken = takeWarmMobileStorage()
+    expect(taken).not.toBeNull()
+    await expect(taken).resolves.toEqual(STORAGE)
+    // Consume-once: the slot is a boot hint, not a cache — a second taker
+    // must fall back to its own fresh call.
+    expect(takeWarmMobileStorage()).toBeNull()
+    expect(storageCalls).toBe(1)
+  })
+
+  it('returns null when nothing was warmed', async () => {
+    let storageCalls = 0
+    const { takeWarmMobileStorage } = await freshModule(async () => {
+      storageCalls += 1
+      return STORAGE
+    })
+    expect(takeWarmMobileStorage()).toBeNull()
+    expect(storageCalls).toBe(0)
+  })
+
+  it('does not surface an unhandled rejection when the warm fails untaken', async () => {
+    const { warmMobileStorage } = await freshModule(async () => {
+      throw new Error('no container')
+    })
+    warmMobileStorage()
+    // Settle the rejection with no taker attached; the module's internal
+    // catch keeps it from escaping as an unhandled rejection.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+})

--- a/apps/desktop/src/lib/mobile-boot-warm.ts
+++ b/apps/desktop/src/lib/mobile-boot-warm.ts
@@ -1,0 +1,38 @@
+import { mobileStorage, type MobileStorageInfo } from '@reflect/core'
+
+/**
+ * Boot-time head start for the mobile storage resolve (Plan 21). Resolving
+ * the iCloud container (`URLForUbiquityContainerIdentifier` plus the graph
+ * scan) is the slowest IPC on the mobile boot path, and it depends on
+ * nothing else — not settings, not React. {@link warmMobileStorage} starts
+ * the call as soon as the shell reports a mobile platform, so it overlaps
+ * the mobile chunk's fetch/eval and the settings read instead of running
+ * after both; the graph bootstrap adopts the in-flight promise via
+ * {@link takeWarmMobileStorage}.
+ *
+ * Consume-once by design: the warm slot is a boot hint, not a cache.
+ * Storage roots must be derived fresh everywhere else (container paths
+ * change across restore/update), so a taken — or never-started — slot just
+ * means the consumer makes its own fresh call.
+ */
+let warmed: Promise<MobileStorageInfo> | null = null
+
+/**
+ * Start the storage resolve early (idempotent). Rejections are handled by
+ * whoever takes the promise; the guard here only silences the
+ * unhandled-rejection report when nothing ever does.
+ */
+export function warmMobileStorage(): void {
+  if (warmed === null) {
+    warmed = mobileStorage()
+    warmed.catch(() => {})
+  }
+}
+
+/** The in-flight warm resolve, or null when none was started or it was
+ * already taken. */
+export function takeWarmMobileStorage(): Promise<MobileStorageInfo> | null {
+  const pending = warmed
+  warmed = null
+  return pending
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -5,13 +5,17 @@ import { queryClient } from '@/lib/query-client'
 import { registerAppCommands } from '@/lib/commands/app-commands'
 import { installNativeMenu } from '@/lib/native-menu/menu'
 import { installTauriBridge } from '@/lib/tauri-bridge'
-import { PlatformRoot } from '@/platform-root'
+import { PlatformRoot, warmPlatformRoot } from '@/platform-root'
 import { EditorTextSizeEffect } from '@/providers/editor-text-size'
 import { SettingsProvider } from '@/providers/settings-provider'
 import { ThemeProvider } from '@/providers/theme-provider'
 import '@/styles/index.css'
 
 installTauriBridge()
+// Start the platform resolve + surface-chunk fetch (and, on mobile, the
+// iCloud-container resolve) now, ahead of React's first render — the lazy
+// gate in PlatformRoot would otherwise serialize all of it behind the mount.
+warmPlatformRoot()
 registerAppCommands()
 installNativeMenu().catch((cause: unknown) => {
   console.error('failed to install the native menu', cause)

--- a/apps/desktop/src/platform-root.tsx
+++ b/apps/desktop/src/platform-root.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useEffect, useState, type ReactElement } from 'react'
 import { getAppPlatform, hasBridge, isMobilePlatform, type AppPlatform } from '@reflect/core'
+import { warmMobileStorage } from '@/lib/mobile-boot-warm'
 
 const DesktopRoot = lazy(() =>
   import('@/desktop-root').then((module) => ({ default: module.DesktopRoot })),
@@ -19,6 +20,31 @@ let platformPromise: Promise<AppPlatform> | undefined
 function resolveAppPlatform(): Promise<AppPlatform> {
   platformPromise ??= getAppPlatform().catch(() => 'desktop' as AppPlatform)
   return platformPromise
+}
+
+/**
+ * Head start for the boot-critical path, called from `main.tsx` right after
+ * the bridge installs — before React's first render reaches the lazy gate
+ * below. Resolves the platform IPC and starts fetching the matching surface
+ * chunk immediately (the dynamic imports here and in the `lazy()` factories
+ * dedupe to one chunk load); on mobile it also kicks the slow
+ * iCloud-container resolve so it overlaps the chunk eval and the settings
+ * read (see `mobile-boot-warm.ts`). No-op in plain-browser dev: with no
+ * bridge the desktop tree renders directly, and the `?platform=ios`
+ * override installs its own bridge first.
+ */
+export function warmPlatformRoot(): void {
+  if (!hasBridge()) {
+    return
+  }
+  void resolveAppPlatform().then((platform) => {
+    if (isMobilePlatform(platform)) {
+      warmMobileStorage()
+      void import('@/mobile/mobile-root')
+    } else {
+      void import('@/desktop-root')
+    }
+  })
 }
 
 // Dev-only escape hatch: `?platform=ios` (or `android`) in a plain browser

--- a/apps/desktop/src/providers/use-mobile-graph-boot.ts
+++ b/apps/desktop/src/providers/use-mobile-graph-boot.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import {
   createGraph,
   errorMessage,
@@ -10,7 +11,8 @@ import {
   type MobileStorageInfo,
   type MobileStorageKind,
 } from '@reflect/core'
-import { useSettings } from '@/providers/settings-provider'
+import { takeWarmMobileStorage } from '@/lib/mobile-boot-warm'
+import { SETTINGS_QUERY_KEY, useSettings } from '@/providers/settings-provider'
 
 /** The graph directory created in the container for a fresh start — reads as
  * `iCloud Drive → Reflect → Notes` in Files/Finder. */
@@ -119,9 +121,11 @@ export interface MobileGraphBoot {
  * `Documents/`) and only the *kind* is persisted, with absolute paths
  * derived fresh every launch.
  *
- * Boot order is deliberate: settings load first (a local file read), and
- * anything that doesn't strictly need the iCloud container never waits on
- * it — resolving the container can take a long time on a fresh install.
+ * Boot order is deliberate: the settings read is shared with the app-wide
+ * provider's query (started before this chunk even loaded) and the container
+ * resolve runs in parallel with it, so nothing on this path waits on work
+ * that already happened or could overlap — resolving the container can take
+ * a long time on a fresh install.
  * A fresh install shows onboarding immediately (sandbox root seeded
  * instantly, iCloud section pending); an onboarded local graph opens
  * without touching the container at all. Inert on desktop.
@@ -136,28 +140,47 @@ export function useMobileGraphBoot(options: MobileGraphBootOptions): MobileGraph
   // flag through it so its cached document carries the flag too — a raw save
   // would be clobbered by the next change.
   const { updateSettings, whenSettingsLoaded } = useSettings()
+  const queryClient = useQueryClient()
 
   useEffect(() => {
     if (!isMobilePlatform(platform)) {
       return
     }
     let active = true
-    /** Fill the storage info once the container resolves — background only. */
+    // The container resolve is the slow IPC on this path and depends on
+    // nothing below — adopt the warm started at platform resolve (see
+    // mobile-boot-warm.ts) or start one now, so it overlaps the settings
+    // read instead of running after it. Every consumer below attaches its
+    // own handlers; this catch only silences the paths that never do.
+    const storagePromise = takeWarmMobileStorage() ?? mobileStorage()
+    storagePromise.catch(() => {})
+    /** Fill the storage info once the container resolves — background only.
+     * The early-started promise can hit a transient failure the old
+     * call-at-this-point wouldn't have; one fresh retry covers that. */
     const resolveStorageInBackground = (): void => {
-      void mobileStorage().then(
-        (storage) => {
-          if (active) {
-            setMobileStorageInfo(storage)
-          }
-        },
-        (err) => {
-          console.error('mobile storage resolution failed:', errorMessage(err))
-        },
-      )
+      void storagePromise
+        .catch(() => mobileStorage())
+        .then(
+          (storage) => {
+            if (active) {
+              setMobileStorageInfo(storage)
+            }
+          },
+          (err) => {
+            console.error('mobile storage resolution failed:', errorMessage(err))
+          },
+        )
     }
     void (async () => {
       try {
-        const settings = await loadSettings()
+        // The settings provider started this exact query at first render —
+        // before the mobile chunk was even fetched — so this reads the
+        // in-flight (usually settled) load instead of issuing a second
+        // settings_load round trip.
+        const settings = await queryClient.ensureQueryData({
+          queryKey: SETTINGS_QUERY_KEY,
+          queryFn: loadSettings,
+        })
         if (!active) {
           return
         }
@@ -184,8 +207,11 @@ export function useMobileGraphBoot(options: MobileGraphBootOptions): MobileGraph
               // Non-fatal: the full resolve below carries the local root too.
             },
           )
-          const resolveWithRetries = (attempt: number): void => {
-            void mobileStorage().then(
+          const resolveWithRetries = (
+            attempt: number,
+            pending: Promise<MobileStorageInfo>,
+          ): void => {
+            void pending.then(
               (storage) => {
                 if (active) {
                   setMobileStorageInfo(storage)
@@ -204,13 +230,13 @@ export function useMobileGraphBoot(options: MobileGraphBootOptions): MobileGraph
                 }
                 setTimeout(() => {
                   if (active) {
-                    resolveWithRetries(attempt + 1)
+                    resolveWithRetries(attempt + 1, mobileStorage())
                   }
                 }, delay)
               },
             )
           }
-          resolveWithRetries(0)
+          resolveWithRetries(0, storagePromise)
           return
         }
         const kind = settings.mobileStorage
@@ -227,7 +253,10 @@ export function useMobileGraphBoot(options: MobileGraphBootOptions): MobileGraph
           await openRecent(localRoot)
           return
         }
-        const storage = await mobileStorage()
+        // The early-started resolve, with one fresh retry on failure — a
+        // transient error from the head-start call must not park a graph the
+        // call-at-this-point would have opened.
+        const storage = await storagePromise.catch(() => mobileStorage())
         if (!active) {
           return
         }
@@ -254,7 +283,7 @@ export function useMobileGraphBoot(options: MobileGraphBootOptions): MobileGraph
     return () => {
       active = false
     }
-  }, [platform, openRecent, onParked])
+  }, [platform, openRecent, onParked, queryClient])
 
   const completeOnboarding = useCallback(
     async (kind: MobileStorageKind, chosenRoot?: string): Promise<void> => {


### PR DESCRIPTION
## Problem

Time-to-first-note on iOS pays for a fully serialized boot chain, even though almost nothing in it actually depends on the previous step:

1. `getAppPlatform` IPC only starts once React mounts `PlatformRoot`'s effect.
2. The mobile surface chunk (most of the app) only starts fetching/evaluating after that IPC resolves and React re-renders through the `lazy()` gate.
3. `useMobileGraphBoot` then issues a **second** `settings_load` — the settings provider started the identical query at first render, before the mobile chunk was even fetched.
4. Only after that duplicate read returns does `mobile_storage` start — the ubiquity-container resolve plus container graph scan, the slowest IPC on the boot path.

Everything after that (`graph_open` → `index_open` → ready → `note_read` → editor mount) is already lean: reconcile, downloads, sync, and capture all run post-paint (PRs #532/#539), and meowdown is statically bundled.

## Changes

Three overlaps; the open ordering, onboarding gate, and error semantics are unchanged.

- **`warmPlatformRoot()`** (new export in `platform-root.tsx`, called from `main.tsx` right after `installTauriBridge()`): starts the platform IPC before React's first render, and starts fetching the matching surface chunk as soon as it resolves — the dynamic import dedupes with the `lazy()` factory, so the chunk is warm (or in flight) by the time the gate renders. On mobile it also kicks the storage warm below. No-op in plain-browser dev (no bridge), so the `?platform=ios` override path is untouched.
- **`lib/mobile-boot-warm.ts`** (new): a consume-once slot for the `mobile_storage` resolve. Warmed at platform-resolve time, so the container resolve runs *under* the chunk eval instead of after it. Deliberately not a cache — storage roots must be derived fresh (container paths change across restore/update); a taken or never-warmed slot just means the boot hook makes its own call.
- **`useMobileGraphBoot`**: reads settings via `queryClient.ensureQueryData` on the provider's query key (shares the in-flight/settled load; drops the duplicate `settings_load` round trip), and starts/adopts the storage promise **in parallel** with the settings read. The steady iCloud path and the background info fill retry once with a fresh `mobile_storage()` call if the early-started promise failed, so a transient head-start failure can't park a graph that the old call-at-this-point would have opened. The onboarding retry ladder consumes the warm promise as attempt 0 and keeps its existing backoff for later attempts.

### Expected effect

Steady-state iCloud launch previously serialized roughly: platform IPC → chunk fetch+eval → settings IPC → container resolve → `graph_open` → `index_open`. Now the platform IPC + chunk fetch + container resolve + settings read all overlap, leaving `graph_open` → `index_open` as the only serialized pre-ready IPC. The win scales with container-resolve latency (largest on cold/fresh installs and slow iCloud accounts).

## Testing

- `pnpm check` (typecheck + oxlint + eslint) clean.
- `pnpm test --run` on `graph-provider.test.tsx` (all mobile onboarding/open-sequencing tests), `settings-provider.test.tsx`, and the new `mobile-boot-warm.test.ts` (warm idempotence, consume-once take, no unhandled rejection when a failed warm goes untaken).
- Browser smoke test per the dev-bridge convention: `?platform=ios` boots the mobile tree (today + neighbor slides, 3 editors, tab bar), and the plain-browser desktop chooser still renders. Console noise observed (`keyboard bridge unavailable`, contentEditable warning) is pre-existing dev-harness behavior.
- Not yet verified on a device/simulator — a fresh-install + steady-state launch pass on an iPhone is owed before release, same as the prior startup-perf PRs.

## Risk / rollout

- The warm imports the surface chunk earlier; `mobile-root`'s module-scope side effects (`setLocalWriteEcho`, `setPlatformSurface`) still run before any mount, just sooner. `desktop-root` has no module-scope side effects.
- `ensureQueryData` returns cached data without refetch (staleTime ∞ on the app client) and dedupes with the provider's in-flight fetch; on a failed provider load it triggers its own fetch and the boot parks on the thrown error, as before.
- Behavior under StrictMode double-effects: the second effect run finds the warm slot consumed and falls back to fresh calls (dev only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches first-launch graph bootstrap and timing of early chunk imports; behavior is guarded by consume-once warm slot, settings query dedupe, and retries on failed early storage resolves.
> 
> **Overview**
> **Overlaps the iOS boot chain** so platform IPC, surface chunk load, `settings_load`, and `mobile_storage` run in parallel instead of one after another.
> 
> `warmPlatformRoot()` runs from `main.tsx` right after the Tauri bridge installs: it starts `getAppPlatform`, prefetches the desktop or mobile root chunk (same promise as `lazy()`), and on mobile calls **`warmMobileStorage()`** so the iCloud container resolve begins early. **`mobile-boot-warm.ts`** holds a consume-once in-flight `mobile_storage` promise (not a path cache); **`useMobileGraphBoot`** adopts it via `takeWarmMobileStorage()` and falls back to a fresh call when needed, with one retry on transient warm failures.
> 
> Graph boot now loads settings through **`queryClient.ensureQueryData`** on `SETTINGS_QUERY_KEY` instead of a second `loadSettings()`, and starts storage resolution alongside that read. Onboarding/open ordering and error handling stay the same; tests cover the warm slot in **`mobile-boot-warm.test.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd5ab9d33856dd66a4b18af93b3f8a489e2dff7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->