### PR TITLE
feat(ios): markdown editor + add-flow autofocus in the task quick-edit sheet

### DIFF
--- a/apps/desktop/src/mobile/screens/tasks.test.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.test.tsx
@@ -13,24 +13,34 @@ import { MobileTasks } from './tasks'
  * groups and guarded write-backs with a touch surface — checkbox toggles,
  * the quick-edit sheet (edit / schedule / complete / convert / open note /
  * delete), the filter sheet, and "+" add. The core getters and the note-task
- * write layer are mocked, like the desktop screen's tests; grouping/merge
+ * write layer are mocked, like the desktop screen's tests; the sheet's markdown
+ * editor is a textarea stand-in (jsdom can't mount ProseKit); grouping/merge
  * rules are unit-tested in task-visibility.test.ts.
  */
 
 const getOpenTasks = vi.hoisted(() => vi.fn())
 const getCompletedTasks = vi.hoisted(() => vi.fn())
+const resolveWikiTarget = vi.hoisted(() => vi.fn())
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   hasBridge: () => true,
   getOpenTasks,
   getCompletedTasks,
+  resolveWikiTarget,
 }))
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({ graph: { root: '/g', name: 'g', generation: 1 } }),
 }))
 vi.mock('@/lib/use-today', () => ({ useToday: () => '2026-06-14' }))
 vi.mock('@/providers/settings-provider', () => ({
-  useSettings: () => ({ settings: { dateFormat: 'mdy', weekStartDay: 'monday' } }),
+  useSettings: () => ({
+    settings: {
+      dateFormat: 'mdy',
+      weekStartDay: 'monday',
+      editorMarkdownSyntax: 'hide',
+      editorSpellCheck: false,
+    },
+  }),
 }))
 // TaskText renders through meowdown's MarkdownView, which jsdom can't mount.
 vi.mock('@/editor/markdown-preview', () => ({
@@ -40,6 +50,79 @@ vi.mock('@/editor/markdown-preview', () => ({
     </span>
   ),
 }))
+// The autocomplete hook reads the contacts authorization over IPC; the menus
+// themselves live inside meowdown, which is stubbed out below anyway.
+vi.mock('@/editor/use-editor-autocomplete', () => ({
+  useEditorAutocomplete: () => ({
+    onWikilinkSearch: async () => [],
+    onTagSearch: async () => [],
+  }),
+}))
+
+const editorProbe = vi.hoisted(() => ({ focusCalls: 0 }))
+
+// The sheet hosts the real markdown editor (desktop's inline task-editor
+// surface), which mounts ProseKit — jsdom can't render it. This stand-in is a
+// textarea over the same NoteEditor contract: uncontrolled seed from
+// `initialContent`, `onChange` with the markdown, a **silent** `setMarkdown`
+// (no onChange echo, matching meowdown), plus probes for focus and wiki-link
+// clicks. Children (the Enter keymap) need the ProseKit context, so they are
+// not rendered.
+vi.mock('@/editor/note-editor', async () => {
+  const { useEffect, useRef } = await import('react')
+  return {
+    NoteEditor: ({
+      initialContent,
+      onChange,
+      onWikiLinkClick,
+      handleRef,
+    }: {
+      initialContent: string
+      onChange?: (markdown: string) => void
+      onWikiLinkClick?: (target: string) => void
+      handleRef?: (handle: import('@/editor/note-editor').NoteEditorHandle | null) => void
+    }) => {
+      const areaRef = useRef<HTMLTextAreaElement | null>(null)
+      useEffect(() => {
+        handleRef?.({
+          getMarkdown: () => areaRef.current?.value ?? '',
+          setMarkdown: (markdown) => {
+            if (areaRef.current !== null) {
+              areaRef.current.value = markdown
+            }
+          },
+          insertMarkdown: () => {},
+          focus: () => {
+            editorProbe.focusCalls += 1
+          },
+          setSelection: () => {},
+          getSelectedText: () => '',
+          openSelectionMenu: () => {},
+          startPendingReplacement: () => false,
+          appendPendingReplacementText: () => {},
+          acceptPendingReplacement: () => {},
+          discardPendingReplacement: () => {},
+        })
+        return () => handleRef?.(null)
+      }, [handleRef])
+      return (
+        <>
+          <textarea
+            ref={areaRef}
+            aria-label="Task text"
+            defaultValue={initialContent}
+            onChange={(event) => onChange?.(event.target.value)}
+          />
+          {onWikiLinkClick !== undefined ? (
+            <button type="button" onClick={() => onWikiLinkClick('Other Note')}>
+              fake-wikilink
+            </button>
+          ) : null}
+        </>
+      )
+    },
+  }
+})
 
 const toggleTask = vi.hoisted(() => vi.fn())
 const deleteTask = vi.hoisted(() => vi.fn())
@@ -104,7 +187,7 @@ function task(overrides: Partial<OpenTask> = {}): OpenTask {
   }
 }
 
-/** Narrow a queried element to the sheet's textarea so `.value` typechecks. */
+/** Narrow a queried element to the editor stub's textarea so `.value` typechecks. */
 function asTextArea(element: HTMLElement): HTMLTextAreaElement {
   if (!(element instanceof HTMLTextAreaElement)) {
     throw new Error('expected a textarea')
@@ -143,6 +226,9 @@ beforeEach(() => {
   convertTaskToBullet.mockResolvedValue(undefined)
   startOperation.mockClear()
   fail.mockReset()
+  resolveWikiTarget.mockReset()
+  resolveWikiTarget.mockResolvedValue({ kind: 'resolved', ref: 'notes/other.md' })
+  editorProbe.focusCalls = 0
   resetRecentlyCompleted()
 })
 
@@ -411,6 +497,55 @@ describe('MobileTasks', () => {
     await user.click(view.getByRole('button', { name: 'dismiss-drawer' }))
     expect(editTask).toHaveBeenCalledTimes(1)
     expect(editTask.mock.calls[0]?.[1]).toBe('new thing')
+    view.unmount()
+  })
+
+  it('focuses the editor when "+" adds a new task', async () => {
+    getOpenTasks.mockResolvedValue([
+      task({ text: 'jotted today', dailyDate: '2026-06-14', notePath: 'daily/2026-06-14.md' }),
+    ])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Add a task to today' }))
+    await view.findByRole('textbox', { name: 'Task text' })
+
+    // The new task is empty — typing is the next step, so the keyboard rises.
+    await waitFor(() => expect(editorProbe.focusCalls).toBeGreaterThan(0))
+    view.unmount()
+  })
+
+  it('leaves focus alone when a row tap opens the sheet', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Edit: buy milk' }))
+    view.getByRole('textbox', { name: 'Task text' })
+
+    // A row tap is usually after an action button — the keyboard would bury them.
+    expect(editorProbe.focusCalls).toBe(0)
+    view.unmount()
+  })
+
+  it('commits the draft before a wiki link inside it navigates', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Edit: buy milk' }))
+    const input = view.getByRole('textbox', { name: 'Task text' })
+    await user.clear(input)
+    await user.type(input, 'buy oat milk')
+    await user.click(view.getByRole('button', { name: 'fake-wikilink' }))
+
+    // Commit-then-navigate, like "Open note": the edit lands exactly once, and
+    // the resolved target opens.
+    expect(editTask).toHaveBeenCalledTimes(1)
+    expect(editTask.mock.calls[0]?.[1]).toBe('buy oat milk')
+    await waitFor(() =>
+      expect(view.getByTestId('route').textContent).toContain('notes/other.md'),
+    )
     view.unmount()
   })
 

--- a/apps/desktop/src/mobile/screens/tasks.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.tsx
@@ -49,6 +49,9 @@ export function MobileTasks(): ReactElement {
   // content; `sheetOpen` alone drives visibility.
   const [editingTask, setEditingTask] = useState<OpenTask | null>(null)
   const [sheetOpen, setSheetOpen] = useState(false)
+  // Whether the current sheet visit should open with the editor focused
+  // (keyboard up) — set per visit: true for "+"-added tasks, false for row taps.
+  const [autoFocusEditor, setAutoFocusEditor] = useState(false)
   const enabled = hasBridge() && graph !== null
 
   const { data: open, isError: openFailed } = useQuery({
@@ -95,18 +98,20 @@ export function MobileTasks(): ReactElement {
     )
   }, [groups, editingTask])
 
-  const editTask = (task: OpenTask): void => {
+  const editTask = (task: OpenTask, options?: { autoFocus?: boolean }): void => {
+    setAutoFocusEditor(options?.autoFocus === true)
     setEditingTask(task)
     setSheetOpen(true)
   }
 
   // The group headers' "+" (V1): drop any search filter so the new row is
-  // visible, write it, then open its quick-edit sheet to type into.
+  // visible, write it, then open its quick-edit sheet with the editor focused
+  // so typing starts immediately.
   const onAdd = (target: InsertTaskTarget): void => {
     setQuery('')
     void actions.insert(target).then((created) => {
       if (created !== null) {
-        editTask(created)
+        editTask(created, { autoFocus: true })
       }
     })
   }
@@ -191,6 +196,7 @@ export function MobileTasks(): ReactElement {
           today={today}
           actions={actions}
           onOpenNote={(path) => navigate(routeForPath(path))}
+          autoFocusEditor={autoFocusEditor}
         />
       ) : null}
       <TaskFiltersDrawer

--- a/apps/desktop/src/mobile/task-edit-sheet.tsx
+++ b/apps/desktop/src/mobile/task-edit-sheet.tsx
@@ -89,6 +89,15 @@ export function MobileTaskEditSheet({
   // been rewritten by an action), so remount it via this seed to re-read it.
   const [editorSeed, setEditorSeed] = useState(0)
   const editorRef = useRef<NoteEditorHandle | null>(null)
+  // The editor's live markdown, or null when it can't be trusted:
+  // getMarkdown() coalesces "surface not ready" to '', indistinguishable from
+  // a genuine clear — and trusting it would delete the task (or feed the
+  // schedule rewrite an empty base). A real clear reaches the mirrored draft
+  // through onChange, so empty reads defer to the state.
+  const readLiveDraft = (): string | null => {
+    const markdown = editorRef.current?.getMarkdown()
+    return markdown === undefined || markdown === '' ? null : markdown
+  }
   // The commit/cancel/delete rules — baseline frozen at open, reseed on
   // reopen, dismissal vs navigate vs unmount — live in the finalizer. It
   // resolves against the editor's live markdown (readDraft) so a change whose
@@ -99,7 +108,7 @@ export function MobileTaskEditSheet({
       open,
       onOpenChange,
       actions,
-      readDraft: () => editorRef.current?.getMarkdown() ?? null,
+      readDraft: readLiveDraft,
       onReseed: () => {
         setShowCalendar(false)
         setEditorSeed((seed) => seed + 1)
@@ -182,7 +191,7 @@ export function MobileTaskEditSheet({
     // Derive from the editor's live markdown, not the mirrored state: a change
     // whose onChange hasn't re-rendered yet must not be clobbered by the
     // silent rewrite below.
-    const next = withDraftDueDate(editorRef.current?.getMarkdown() ?? draft, isoDate)
+    const next = withDraftDueDate(readLiveDraft() ?? draft, isoDate)
     setDraft(next)
     // setMarkdown is silent (no onChange echo), so the state write above keeps
     // the mirrored draft (chip highlights) in step.

--- a/apps/desktop/src/mobile/task-edit-sheet.tsx
+++ b/apps/desktop/src/mobile/task-edit-sheet.tsx
@@ -1,4 +1,11 @@
-import { useState, type ReactElement } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+} from 'react'
 import {
   ArrowRight,
   CalendarDays,
@@ -9,9 +16,16 @@ import {
   Undo2,
   X,
 } from 'lucide-react'
+import { Priority } from '@meowdown/core'
+import { useKeymap } from '@meowdown/react'
 import type { OpenTask } from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
+import { markModeFromSyntax } from '@/editor/mark-mode'
+import { NoteEditor, type NoteEditorHandle } from '@/editor/note-editor'
+import { useEditorAutocomplete } from '@/editor/use-editor-autocomplete'
+import { useTagNavigation } from '@/editor/use-tag-navigation'
+import { useWikiLinkNavigation } from '@/editor/use-wiki-link-navigation'
 import { addDaysIso, formatDayLabel } from '@/lib/dates'
 import type { TaskActions } from '@/lib/tasks/use-task-actions'
 import { cn } from '@/lib/utils'
@@ -19,6 +33,7 @@ import { hapticImpactLight } from '@/mobile/haptics'
 import { draftDueDate, withDraftDueDate } from '@/mobile/task-draft'
 import { TaskScheduleGrid } from '@/mobile/task-schedule-grid'
 import { useTaskSheetFinalizer } from '@/mobile/use-task-sheet-finalizer'
+import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
 
 interface MobileTaskEditSheetProps {
@@ -33,18 +48,26 @@ interface MobileTaskEditSheetProps {
   actions: TaskActions
   /** Navigate to the task's source note (the sheet commits the draft first). */
   onOpenNote: (notePath: string) => void
+  /**
+   * Focus the editor (raising the keyboard) as soon as the sheet opens — the
+   * "+"-add flow, where the task is brand new and typing is the next step.
+   * Row taps leave focus alone so the action list stays visible.
+   */
+  autoFocusEditor?: boolean
 }
 
 /**
  * The quick-edit bottom sheet (V1 mobile's edit modal over Plan 18 data): edit
  * a task's text, schedule it, complete it, or jump to its source note — without
- * opening the note. The draft is markdown (links and tags intact) and due-date
- * changes edit the draft's `[[YYYY-MM-DD]]` link in place, so everything lands
- * as **one** write when the sheet closes: dismissing commits a changed draft,
- * an emptied draft deletes the task, and an untouched draft writes nothing —
- * the exit rules live in {@link useTaskSheetFinalizer}. The action buttons
- * route through the same {@link TaskActions} the desktop view uses —
- * save-then-act, never a racing second write path.
+ * opening the note. The text is desktop's inline task editor surface — the real
+ * {@link NoteEditor}, with meowdown's `[[`/`#` menus and clickable links — over
+ * the same markdown draft, and due-date changes edit the draft's
+ * `[[YYYY-MM-DD]]` link in place, so everything lands as **one** write when the
+ * sheet closes: dismissing commits a changed draft, an emptied draft deletes
+ * the task, and an untouched draft writes nothing — the exit rules live in
+ * {@link useTaskSheetFinalizer}. The action buttons route through the same
+ * {@link TaskActions} the desktop view uses — save-then-act, never a racing
+ * second write path.
  */
 export function MobileTaskEditSheet({
   task,
@@ -53,9 +76,18 @@ export function MobileTaskEditSheet({
   today,
   actions,
   onOpenNote,
+  autoFocusEditor = false,
 }: MobileTaskEditSheetProps): ReactElement {
+  const { graph } = useGraph()
   const { settings } = useSettings()
+  const generation = graph?.generation ?? null
+  const navigateWikiLink = useWikiLinkNavigation(generation)
+  const navigateTag = useTagNavigation()
+  const { onWikilinkSearch, onTagSearch } = useEditorAutocomplete()
   const [showCalendar, setShowCalendar] = useState(false)
+  // The editor is uncontrolled; a reopen reseeds the draft (the row may have
+  // been rewritten by an action), so remount it via this seed to re-read it.
+  const [editorSeed, setEditorSeed] = useState(0)
   // The commit/cancel/delete rules — baseline frozen at open, reseed on
   // reopen, dismissal vs navigate vs unmount — live in the finalizer.
   const { draft, setDraft, resolve, handleOpenChange, closeHandled, closeNavigate } =
@@ -64,9 +96,34 @@ export function MobileTaskEditSheet({
       open,
       onOpenChange,
       actions,
-      onReseed: () => setShowCalendar(false),
+      onReseed: () => {
+        setShowCalendar(false)
+        setEditorSeed((seed) => seed + 1)
+      },
     })
   const dueDate = draftDueDate(draft)
+
+  const editorRef = useRef<NoteEditorHandle | null>(null)
+  // Stable while the editor is mounted: the flag only changes between visits
+  // (the screen sets it before opening), never mid-edit, so the ref callback
+  // can depend on it without re-attach churn.
+  const handleEditorRef = useCallback(
+    (handle: NoteEditorHandle | null) => {
+      editorRef.current = handle
+      if (handle !== null && autoFocusEditor) {
+        handle.focus()
+      }
+    },
+    [autoFocusEditor],
+  )
+
+  // Enter finishes the visit exactly like a dismissal (commit / delete-empty),
+  // read through a latest-closure ref so the keymap binds once.
+  const finishRef = useRef<() => void>(() => {})
+  useEffect(() => {
+    finishRef.current = () => handleOpenChange(false)
+  })
+  const finishEdit = useCallback(() => finishRef.current(), [])
 
   const complete = (): void => {
     hapticImpactLight()
@@ -102,32 +159,70 @@ export function MobileTaskEditSheet({
     onOpenNote(task.notePath)
   }
 
+  // A link tapped *inside* the draft navigates like "Open note": commit the
+  // draft first, then resolve the target (the shared editor hooks).
+  const openWikiLink = (target: string): void => {
+    closeNavigate()
+    navigateWikiLink(target)
+  }
+
+  const openTag = (tag: string): void => {
+    closeNavigate()
+    navigateTag(tag)
+  }
+
   const remove = (): void => {
     actions.remove([task])
     closeHandled()
   }
 
   const schedule = (isoDate: string | null): void => {
-    setDraft((current) => withDraftDueDate(current, isoDate))
+    const next = withDraftDueDate(draft, isoDate)
+    setDraft(next)
+    // setMarkdown is silent (no onChange echo), so the state write above is
+    // the one source the finalizer resolves against.
+    editorRef.current?.setMarkdown(next)
     setShowCalendar(false)
   }
 
   return (
     <Drawer open={open} onOpenChange={handleOpenChange}>
-      <DrawerContent aria-label="Edit task">
+      <DrawerContent
+        aria-label="Edit task"
+        // On the "+"-add path the editor takes focus instead of the sheet
+        // container, so typing can start immediately.
+        onOpenAutoFocus={(event) => {
+          if (autoFocusEditor) {
+            event.preventDefault()
+            editorRef.current?.focus()
+          }
+        }}
+      >
         <DrawerTitle className="sr-only">Edit task</DrawerTitle>
-        <textarea
-          value={draft}
-          onChange={(event) => setDraft(event.target.value)}
-          rows={2}
-          aria-label="Task text"
-          // Touch-surface hygiene, like the note editor: no autocap/autocorrect
-          // rewriting markdown syntax under the user.
-          autoCapitalize="off"
-          autoCorrect="off"
-          spellCheck={false}
-          className="w-full resize-none rounded-md border border-border bg-surface px-3 py-2 text-base leading-6 text-text outline-none focus-visible:ring-1 focus-visible:ring-accent"
-        />
+        {/* vaul must not turn a drag inside the editor (text selection) into a
+            sheet drag. */}
+        <div
+          data-vaul-no-drag
+          className="rounded-md border border-border bg-surface px-3 py-2 focus-within:ring-1 focus-within:ring-accent"
+        >
+          <NoteEditor
+            key={editorSeed}
+            initialContent={draft}
+            onChange={setDraft}
+            markMode={markModeFromSyntax(settings.editorMarkdownSyntax)}
+            spellCheck={settings.editorSpellCheck}
+            // A one-line editor has nothing to reorder, so keep the gutter grip off.
+            blockHandle={false}
+            onWikiLinkClick={openWikiLink}
+            onTagClick={openTag}
+            onWikilinkSearch={onWikilinkSearch}
+            onTagSearch={onTagSearch}
+            className="reflect-task-editor min-h-12 text-base leading-6"
+            handleRef={handleEditorRef}
+          >
+            <TaskSheetKeymap onDone={finishEdit} />
+          </NoteEditor>
+        </div>
         <div className="flex flex-wrap items-center gap-1.5" aria-label="Schedule">
           <ScheduleChip
             label="Today"
@@ -205,6 +300,30 @@ export function MobileTaskEditSheet({
       </DrawerContent>
     </Drawer>
   )
+}
+
+/**
+ * Enter (and Shift-Enter) finishes the edit — a task is one line, so a new
+ * block is never the right outcome. Bound at high priority inside the editor's
+ * ProseKit context, but the `[[`/`#` menus still claim Enter first while open,
+ * so accepting a suggestion never closes the sheet.
+ */
+function TaskSheetKeymap({ onDone }: { onDone: () => void }): null {
+  const keymap = useMemo(
+    () => ({
+      Enter: () => {
+        onDone()
+        return true
+      },
+      'Shift-Enter': () => {
+        onDone()
+        return true
+      },
+    }),
+    [onDone],
+  )
+  useKeymap(keymap, { priority: Priority.high })
+  return null
 }
 
 function ScheduleChip({

--- a/apps/desktop/src/mobile/task-edit-sheet.tsx
+++ b/apps/desktop/src/mobile/task-edit-sheet.tsx
@@ -88,22 +88,24 @@ export function MobileTaskEditSheet({
   // The editor is uncontrolled; a reopen reseeds the draft (the row may have
   // been rewritten by an action), so remount it via this seed to re-read it.
   const [editorSeed, setEditorSeed] = useState(0)
+  const editorRef = useRef<NoteEditorHandle | null>(null)
   // The commit/cancel/delete rules — baseline frozen at open, reseed on
-  // reopen, dismissal vs navigate vs unmount — live in the finalizer.
+  // reopen, dismissal vs navigate vs unmount — live in the finalizer. It
+  // resolves against the editor's live markdown (readDraft) so a change whose
+  // onChange hasn't re-rendered yet is never dropped by a commit.
   const { draft, setDraft, resolve, handleOpenChange, closeHandled, closeNavigate } =
     useTaskSheetFinalizer({
       task,
       open,
       onOpenChange,
       actions,
+      readDraft: () => editorRef.current?.getMarkdown() ?? null,
       onReseed: () => {
         setShowCalendar(false)
         setEditorSeed((seed) => seed + 1)
       },
     })
   const dueDate = draftDueDate(draft)
-
-  const editorRef = useRef<NoteEditorHandle | null>(null)
   // Stable while the editor is mounted: the flag only changes between visits
   // (the screen sets it before opening), never mid-edit, so the ref callback
   // can depend on it without re-attach churn.
@@ -177,10 +179,13 @@ export function MobileTaskEditSheet({
   }
 
   const schedule = (isoDate: string | null): void => {
-    const next = withDraftDueDate(draft, isoDate)
+    // Derive from the editor's live markdown, not the mirrored state: a change
+    // whose onChange hasn't re-rendered yet must not be clobbered by the
+    // silent rewrite below.
+    const next = withDraftDueDate(editorRef.current?.getMarkdown() ?? draft, isoDate)
     setDraft(next)
-    // setMarkdown is silent (no onChange echo), so the state write above is
-    // the one source the finalizer resolves against.
+    // setMarkdown is silent (no onChange echo), so the state write above keeps
+    // the mirrored draft (chip highlights) in step.
     editorRef.current?.setMarkdown(next)
     setShowCalendar(false)
   }

--- a/apps/desktop/src/mobile/use-task-sheet-finalizer.test.ts
+++ b/apps/desktop/src/mobile/use-task-sheet-finalizer.test.ts
@@ -160,6 +160,46 @@ describe('useTaskSheetFinalizer', () => {
     expect(edit).not.toHaveBeenCalled()
   })
 
+  it('resolves against the live surface when readDraft is fresher than the mirrored state', () => {
+    // An uncontrolled editor can hold a change whose onChange hasn't
+    // re-rendered into the draft state yet — the commit must not drop it.
+    const { result } = renderHook(() =>
+      useTaskSheetFinalizer(deps({ readDraft: () => 'alpha typed live' })),
+    )
+
+    act(() => result.current.handleOpenChange(false))
+
+    expect(edit).toHaveBeenCalledTimes(1)
+    expect(edit.mock.calls[0]?.[1]).toBe('alpha typed live')
+  })
+
+  it('falls back to the mirrored draft when readDraft cannot answer', () => {
+    const { result } = renderHook(() =>
+      useTaskSheetFinalizer(deps({ readDraft: () => null })),
+    )
+
+    act(() => result.current.setDraft('alpha edited'))
+    act(() => result.current.handleOpenChange(false))
+
+    expect(edit).toHaveBeenCalledTimes(1)
+    expect(edit.mock.calls[0]?.[1]).toBe('alpha edited')
+  })
+
+  it('ignores readDraft during the unmount flush — a torn-down surface can misreport empty', () => {
+    const { result, unmount } = renderHook(() =>
+      useTaskSheetFinalizer(deps({ readDraft: () => '' })),
+    )
+
+    act(() => result.current.setDraft('alpha edited'))
+    unmount()
+
+    // Trusting the misreported '' would delete a real task; the flush must
+    // resolve from the mirrored state instead.
+    expect(remove).not.toHaveBeenCalled()
+    expect(edit).toHaveBeenCalledTimes(1)
+    expect(edit.mock.calls[0]?.[1]).toBe('alpha edited')
+  })
+
   it('flushes like a dismissal when unmounted under an open sheet', () => {
     const { result, unmount } = renderHook(() => useTaskSheetFinalizer(deps()))
 

--- a/apps/desktop/src/mobile/use-task-sheet-finalizer.ts
+++ b/apps/desktop/src/mobile/use-task-sheet-finalizer.ts
@@ -16,6 +16,15 @@ export interface TaskSheetFinalizerDeps {
   actions: TaskSheetWriteActions
   /** Reset sheet-local presentation (collapse the calendar) on reopen. */
   onReseed: () => void
+  /**
+   * Read the editing surface's markdown, or null when the surface can't
+   * answer. An uncontrolled editor can hold a change whose `onChange` hasn't
+   * re-rendered into the mirrored draft yet; resolving against the live text
+   * keeps that change from being dropped. Consulted only at interactive
+   * decision points (dismissal, navigate, `resolve`) — the unmount flush uses
+   * the mirrored state, because a surface mid-teardown can misreport empty.
+   */
+  readDraft?: () => string | null
 }
 
 export interface TaskSheetFinalizer {
@@ -60,6 +69,7 @@ export function useTaskSheetFinalizer({
   onOpenChange,
   actions,
   onReseed,
+  readDraft,
 }: TaskSheetFinalizerDeps): TaskSheetFinalizer {
   const liveContent = taskContent(task.raw)
   const [initial, setInitial] = useState(liveContent)
@@ -78,11 +88,17 @@ export function useTaskSheetFinalizer({
     }
   }
 
-  const resolve = (): TaskEditResult => resolveTaskEdit(initial, draft)
+  // The freshest draft available at an *interactive* decision point (a
+  // dismissal gesture, an action button) — the surface is mounted there. The
+  // unmount flush must NOT use this: a surface mid-teardown can misreport
+  // empty, and "empty" means delete.
+  const currentDraft = (): string => readDraft?.() ?? draft
 
-  /** Persist the draft: a real change commits, an emptied draft deletes. */
-  const commitDraft = (): void => {
-    const result = resolve()
+  const resolve = (): TaskEditResult => resolveTaskEdit(initial, currentDraft())
+
+  /** Persist `current` vs the baseline: a real change commits, an emptied draft deletes. */
+  const commitCurrent = (current: string): void => {
+    const result = resolveTaskEdit(initial, current)
     if (result.type === 'commit') {
       actions.edit(task, result.content)
     } else if (result.type === 'delete') {
@@ -90,11 +106,11 @@ export function useTaskSheetFinalizer({
     }
   }
 
-  const finishAbandonedVisit = (): void => {
-    if (resolve().type === 'cancel' && draft.trim() === '') {
+  const finishAbandonedVisit = (current: string): void => {
+    if (resolveTaskEdit(initial, current).type === 'cancel' && current.trim() === '') {
       actions.remove([task])
     } else {
-      commitDraft()
+      commitCurrent(current)
     }
   }
 
@@ -105,7 +121,7 @@ export function useTaskSheetFinalizer({
       // same commit/delete twice (a second delete would trip the stale guard
       // and surface a spurious failure).
       setHandled(true)
-      finishAbandonedVisit()
+      finishAbandonedVisit(currentDraft())
     }
     onOpenChange(nextOpen)
   }
@@ -116,7 +132,7 @@ export function useTaskSheetFinalizer({
   }
 
   const closeNavigate = (): void => {
-    commitDraft()
+    commitCurrent(currentDraft())
     setHandled(true)
     onOpenChange(false)
   }
@@ -125,11 +141,13 @@ export function useTaskSheetFinalizer({
   // drawer is open — no dismissal callback fires, so flush like a dismissal
   // would (desktop's inline editor flushes on unmount the same way). The
   // latest-closure ref keeps the unmount-only cleanup reading current state.
+  // Resolve from the mirrored draft, never readDraft: the surface is tearing
+  // down with us and can misreport empty, which would delete a real task.
   const unmountFlushRef = useRef<() => void>(() => {})
   useEffect(() => {
     unmountFlushRef.current = () => {
       if (open && !handled) {
-        finishAbandonedVisit()
+        finishAbandonedVisit(draft)
       }
     }
   })


### PR DESCRIPTION
## Problem

The mobile Tasks tab's quick-edit sheet (PR #518) edited task text in a plain `<textarea>`. That was a second, poorer editing surface than the rest of the app: no `[[` backlink or `#` tag autocomplete, wiki links and tags shown as raw syntax instead of chips, the markdown-syntax setting ignored, and Enter free to insert newlines into what must stay a one-line task. On top of that, a "+"-added task opened its sheet with nothing focused — you tapped "+" to type a task and then had to tap again into the empty field before the keyboard appeared.

## Before → After

| | Before | After |
|---|---|---|
| Task text surface | plain `<textarea>` over the raw markdown | the real `NoteEditor` (meowdown) — same as desktop's inline task editor |
| `[[` / `#` typing | inert raw text | live autocomplete menus (verified to render and accept above the drawer) |
| Links/tags in the draft | raw syntax | rendered chips; tapping one commits the draft, closes the sheet, and navigates (same rule as "Open note") |
| Enter | inserted a newline into a single-line task | finishes the visit like a dismissal (commit / delete-if-emptied); the `[[`/`#` menus still claim Enter first |
| "+" add (group header, empty state, floating button) | sheet opens unfocused | editor focused, keyboard up, type immediately |
| Row tap | unfocused | unchanged — focus stays off so the action buttons stay visible |

## Changes

1. **`task-edit-sheet.tsx`** — swaps the textarea for `NoteEditor` wired exactly like desktop's `TaskEditor`: `markModeFromSyntax`, `useEditorAutocomplete`, `useWikiLinkNavigation`/`useTagNavigation` (wrapped in commit-then-navigate via the finalizer's `closeNavigate`), `blockHandle` off. The one-write draft model is untouched: the editor is uncontrolled, `onChange` feeds the existing `useTaskSheetFinalizer` draft, and schedule chips write through the **silent** `setMarkdown` handle so a date pick never echoes back as an edit. Reopen-reseed (the sheet stays mounted after close) remounts the editor via an `editorSeed` bumped in `onReseed`. A `TaskSheetKeymap` child binds Enter/Shift-Enter to the dismissal path through a latest-closure ref, so the keymap binds once. The wrapper carries `data-vaul-no-drag` so text selection can't become a sheet drag.
2. **`use-task-sheet-finalizer.ts`** — new optional `readDraft` accessor (Bugbot round 1): the uncontrolled editor can hold a change whose `onChange` hasn't re-rendered into the mirrored draft yet, so interactive decision points (dismissal, navigate, `resolve`, and the schedule chips' rewrite base) resolve against `getMarkdown()` live. Two deliberate trust boundaries on that read: the **unmount flush keeps using the mirrored state** (a surface mid-teardown can misreport empty, and empty means delete — the jsdom harness caught exactly that failure mode), and an **empty live read defers to the mirrored state everywhere** (Bugbot round 2: `getMarkdown()` coalesces "not ready" to `''`, indistinguishable from a genuine clear; a real clear reaches the mirror through `onChange` anyway).
3. **`screens/tasks.tsx`** — `editTask` takes a per-visit `autoFocus` option; every add path passes it (group-header "+", empty state, and #540's floating button, which routes through the same `onAdd`), row taps don't. The sheet focuses via the editor `handleRef` plus `onOpenAutoFocus` (preventing Radix from moving focus to the sheet container on the add path).

No changes to the write actions or desktop.

## Tests

`tasks.test.tsx` gains the repo's standard jsdom stand-in for `NoteEditor` (ProseKit can't mount in jsdom): a textarea honoring the uncontrolled `initialContent`/`onChange`/silent-`setMarkdown` contract, with focus and wiki-link probes. All pre-existing scenarios (commit-on-dismiss, delete-emptied, one-write scheduling, reseed-after-action, abandoned "+" row, unmount flush, #540's floating button…) pass, plus new ones:

- "+" add focuses the editor; a row tap doesn't
- a wiki-link tap inside the draft commits the edit exactly once, then navigates to the resolved note
- finalizer units: `readDraft` wins at interactive decision points, falls back to state when it can't answer, and is **ignored** by the unmount flush (a misreported empty must not delete a real task)

## Verification

- `pnpm test --run src/mobile/screens/tasks.test.tsx src/mobile/use-task-sheet-finalizer.test.ts` — 42 passed
- `pnpm test --run src/components/tasks/tasks-screen.test.tsx` — passed
- `pnpm check` (typecheck + oxlint + eslint) — clean
- Live smoke in the browser dev harness (`?platform=ios`, real meowdown): "+" opens the sheet with the editor focused; typing works; the `[[` menu renders above the drawer and accepting a suggestion inserts the link; the Tomorrow chip rewrites the draft's date link and lights up.

## Risk / Rollout

- The editor is a heavier surface than a textarea inside a vaul drawer; the interplay verified in the browser harness still deserves the usual on-device pass (keyboard rise on programmatic focus, drawer + keyboard geometry, no accidental sheet drags while selecting text).
- Enter behavior changed deliberately (newline → finish edit); multi-line paste remains the same exposure desktop's inline editor already has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit fd2c2db187c56c1e071c31247a116c85fd0b9f03. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
