### PR TITLE
fix: remove button hover motion

### DIFF
--- a/apps/desktop/src/components/ui/button.tsx
+++ b/apps/desktop/src/components/ui/button.tsx
@@ -9,15 +9,15 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:-translate-y-0.5 hover:bg-primary/80 hover:shadow-sm",
+        default: "bg-primary text-primary-foreground hover:bg-primary/80",
         outline:
-          "border-border bg-background hover:-translate-y-0.5 hover:bg-muted hover:text-foreground hover:shadow-sm aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
-          "bg-secondary text-secondary-foreground hover:-translate-y-0.5 hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] hover:shadow-sm aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+          "bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         ghost:
-          "hover:-translate-y-0.5 hover:bg-muted hover:text-foreground hover:shadow-sm aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:
-          "bg-destructive/10 text-destructive hover:-translate-y-0.5 hover:bg-destructive/20 hover:shadow-sm focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {


### PR DESCRIPTION
## Problem
Button hover states recently started adding a small upward translate and shadow in addition to the existing color feedback. That made enabled buttons appear to lift or move on hover, which is not the desired interaction.

## Changes
- Remove `hover:-translate-y-0.5` and `hover:shadow-sm` from the default, outline, secondary, ghost, and destructive button variants.
- Keep the existing hover color states, disabled opacity/pointer handling, focus rings, aria-expanded styling, and active press behavior unchanged.

## Verification
- `pnpm check` passed. It reported existing `max-lines` warnings in unrelated files.

## Risk / Rollout
Low risk CSS utility cleanup in the shared button component. No data or API changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Tailwind class removal on the shared button component; no logic, data, or API impact.
> 
> **Overview**
> Removes the hover **lift** (`hover:-translate-y-0.5`) and **shadow** (`hover:shadow-sm`) from the shared `buttonVariants` styles for **default**, **outline**, **secondary**, **ghost**, and **destructive** variants in `button.tsx`.
> 
> Hover **color** feedback, focus rings, disabled/aria states, and **active** press (`translate-y-px`) are unchanged. **link** was already unaffected. Because this is the central `Button` component, the calmer hover applies everywhere it is used in the desktop app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abf050c71c0e0cfda4c71f29f5364be503f42bf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->