### PR TITLE
Combine sync settings

### DIFF
--- a/apps/desktop/src/components/settings-screen.tsx
+++ b/apps/desktop/src/components/settings-screen.tsx
@@ -5,14 +5,13 @@ import { AiPromptsSection } from './settings/ai-prompts-section'
 import { AiProvidersSection } from './settings/ai-providers-section'
 import { AllNotesSection } from './settings/all-notes-section'
 import { AppearanceSection } from './settings/appearance-section'
-import { BackupSection } from './settings/backup-section'
 import { DateTimeSection } from './settings/date-time-section'
 import { DestructiveSection } from './settings/destructive-section'
 import { EditorSection } from './settings/editor-section'
-import { IcloudSection } from './settings/icloud-section'
 import { ImportSection } from './settings/import-section'
 import { IntegrationsSection } from './settings/integrations-section'
 import { SearchSection } from './settings/search-section'
+import { SyncSection } from './settings/sync-section'
 import { TemplatesSection } from './settings/templates-section'
 
 /**
@@ -35,9 +34,8 @@ export function SettingsScreen(): ReactElement {
         <AiPromptsSection />
         <AgentsSection />
         <IntegrationsSection />
-        <IcloudSection />
+        <SyncSection />
         <ImportSection />
-        <BackupSection />
         <AboutSection />
         <DestructiveSection />
       </div>

--- a/apps/desktop/src/components/settings/backup-section.test.tsx
+++ b/apps/desktop/src/components/settings/backup-section.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-li
 import { openUrl } from '@tauri-apps/plugin-opener'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { BackupState } from '@/lib/backup-controller'
-import { BackupSection } from './backup-section'
+import { BackupSettingsField } from './backup-section'
 
 // The section's GitHub-vs-generic split (Plan 16): a hand-wired remote must
 // render host-neutrally, and its auth errors must surface the engine's
@@ -28,7 +28,7 @@ function renderSection(backup: BackupState): void {
   sync.backup = backup
   render(
     <QueryClientProvider client={new QueryClient()}>
-      <BackupSection />
+      <BackupSettingsField />
     </QueryClientProvider>,
   )
 }
@@ -39,7 +39,7 @@ const AUTH_ERROR = {
   message: 'the SSH agent offered no key this host accepts — `ssh-add` the right key',
 } as const
 
-describe('BackupSection', () => {
+describe('BackupSettingsField', () => {
   it('renders a generic remote host-neutrally with the engine’s own auth message', async () => {
     renderSection({
       phase: 'connected',

--- a/apps/desktop/src/components/settings/backup-section.tsx
+++ b/apps/desktop/src/components/settings/backup-section.tsx
@@ -5,7 +5,6 @@ import { getConflictedNotes, getDuplicateNoteIds, hasBridge } from '@reflect/cor
 import { ExternalLink } from 'lucide-react'
 import { ConnectGithubDialog } from '@/components/settings/connect-github-dialog'
 import { SettingsField } from '@/components/settings/field'
-import { SettingsSection } from '@/components/settings/section'
 import { SyncForkNotice } from '@/components/settings/sync-fork-notice'
 import { Button } from '@/components/ui/button'
 import {
@@ -47,12 +46,12 @@ function githubRepoBrowserUrl(repo: NonNullable<Extract<BackupState, { phase: 'c
 }
 
 /**
- * Settings → Backup: connect a GitHub repository, see the current backup
- * state in product language, back up on demand, and disconnect. Conflicted
- * notes ("needs review") surface here with a count; each conflicted note
- * also shows its own banner when opened.
+ * Settings → Sync → Backup: connect a GitHub repository, see the current
+ * backup state in product language, back up on demand, and disconnect.
+ * Conflicted notes ("needs review") surface here with a count; each conflicted
+ * note also shows its own banner when opened.
  */
-export function BackupSection(): ReactElement {
+export function BackupSettingsField(): ReactElement {
   const { backup, disconnectGraph, signOut, backUpNow } = useSync()
   const { graph } = useGraph()
   const [connectOpen, setConnectOpen] = useState(false)
@@ -121,7 +120,7 @@ export function BackupSection(): ReactElement {
   }
 
   return (
-    <SettingsSection id="backup">
+    <>
       <SettingsField
         legend={genericRemote ? 'Backup' : 'GitHub backup'}
         description={
@@ -246,6 +245,6 @@ export function BackupSection(): ReactElement {
           onClose={() => setConnectOpen(false)}
         />
       ) : null}
-    </SettingsSection>
+    </>
   )
 }

--- a/apps/desktop/src/components/settings/icloud-section.tsx
+++ b/apps/desktop/src/components/settings/icloud-section.tsx
@@ -1,6 +1,14 @@
 import { useState, type ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { errorMessage, hasBridge, icloudAdoptGraph, icloudStatus } from '@reflect/core'
+import {
+  errorMessage,
+  getConflictedNotes,
+  getDuplicateNoteIds,
+  hasBridge,
+  icloudAdoptGraph,
+  icloudPendingCount,
+  icloudStatus,
+} from '@reflect/core'
 import { SettingsField } from '@/components/settings/field'
 import { Button } from '@/components/ui/button'
 import {
@@ -14,10 +22,43 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { isICloudRoot } from '@/lib/icloud-controller'
-import { ICLOUD_STATUS_QUERY_KEY } from '@/lib/query-client'
+import { ICLOUD_STATUS_QUERY_KEY, INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { isMacosDesktop } from '@/lib/platform'
 import { useGraph } from '@/providers/graph-provider'
 import { useSync } from '@/providers/sync-provider'
+
+const ICLOUD_PENDING_NOTES_QUERY_KEY = 'icloud-pending-notes'
+const PENDING_NOTES_REFETCH_MS = 5_000
+
+function graphCountLine(count: number): string {
+  if (count === 0) {
+    return 'No graphs in iCloud Drive yet.'
+  }
+  return count === 1 ? '1 graph in iCloud Drive.' : `${count} graphs in iCloud Drive.`
+}
+
+function pendingNotesLine(count: number): string {
+  if (count === 0) {
+    return 'All note files are downloaded.'
+  }
+  return count === 1
+    ? '1 note is still downloading from iCloud.'
+    : `${count} notes are still downloading from iCloud.`
+}
+
+function reviewLine(conflictCount: number, forkCount: number): string {
+  if (conflictCount === 0 && forkCount === 0) {
+    return 'No notes need review.'
+  }
+  const parts: string[] = []
+  if (conflictCount > 0) {
+    parts.push(conflictCount === 1 ? '1 note needs review' : `${conflictCount} notes need review`)
+  }
+  if (forkCount > 0) {
+    parts.push(forkCount === 1 ? '1 sync fork' : `${forkCount} sync forks`)
+  }
+  return parts.join(', ')
+}
 
 /**
  * Settings → Sync → iCloud Drive (Plan 21 Phase 1, the desktop leg): see
@@ -39,10 +80,32 @@ export function IcloudSettingsField(): ReactElement | null {
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const bridgeAvailable = hasBridge()
+  const hosted = graph !== null && isICloudRoot(graph.root)
   const { data: status } = useQuery({
     queryKey: ICLOUD_STATUS_QUERY_KEY,
     queryFn: icloudStatus,
-    enabled: hasBridge() && isMacosDesktop,
+    enabled: bridgeAvailable && isMacosDesktop,
+  })
+  const pendingNotes = useQuery({
+    queryKey: [ICLOUD_PENDING_NOTES_QUERY_KEY, graph?.root],
+    queryFn: () => (graph === null ? Promise.resolve(0) : icloudPendingCount(graph.root, 'notes')),
+    enabled: bridgeAvailable && isMacosDesktop && hosted,
+    staleTime: PENDING_NOTES_REFETCH_MS,
+    refetchInterval: (query) => {
+      const count = query.state.data
+      return typeof count === 'number' && count > 0 ? PENDING_NOTES_REFETCH_MS : false
+    },
+  })
+  const conflicted = useQuery({
+    queryKey: [INDEX_QUERY_SCOPE, 'conflicted-notes', graph?.root],
+    queryFn: () => getConflictedNotes(),
+    enabled: bridgeAvailable && hosted,
+  })
+  const duplicateIds = useQuery({
+    queryKey: [INDEX_QUERY_SCOPE, 'duplicate-note-ids', graph?.root],
+    queryFn: () => getDuplicateNoteIds(),
+    enabled: bridgeAvailable && hosted,
   })
 
   // The navigator hides the entry off macOS through the same gate — the two
@@ -50,8 +113,13 @@ export function IcloudSettingsField(): ReactElement | null {
   if (!isMacosDesktop || graph === null) {
     return null
   }
-  const hosted = isICloudRoot(graph.root)
   const backupConnected = backup.phase === 'connected'
+  const conflictCount = conflicted.data?.length
+  const forkCount = duplicateIds.data?.length
+  const hasReviewIssues =
+    conflictCount !== undefined &&
+    forkCount !== undefined &&
+    (conflictCount > 0 || forkCount > 0)
 
   async function moveToICloud(): Promise<void> {
     if (graph === null) {
@@ -105,6 +173,21 @@ export function IcloudSettingsField(): ReactElement | null {
               : 'iCloud Drive isn’t reachable from this app — sign in to iCloud, or use a build with iCloud enabled.'
         }
       >
+        {hosted ? (
+          <div className="mt-3 flex flex-col gap-1 text-xs text-text-muted">
+            {pendingNotes.isPending ? <p>Checking downloaded notes...</p> : null}
+            {pendingNotes.data !== undefined ? <p>{pendingNotesLine(pendingNotes.data)}</p> : null}
+            {conflictCount !== undefined && forkCount !== undefined ? (
+              <p className={hasReviewIssues ? 'text-amber-700 dark:text-amber-300' : undefined}>
+                {reviewLine(conflictCount, forkCount)}
+              </p>
+            ) : null}
+          </div>
+        ) : status?.available === true ? (
+          <p className="mt-3 text-xs text-text-muted">
+            {graphCountLine(status.existingGraphRoots.length)}
+          </p>
+        ) : null}
         {hosted ? null : (
           <div className="mt-2">
             <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>

--- a/apps/desktop/src/components/settings/icloud-section.tsx
+++ b/apps/desktop/src/components/settings/icloud-section.tsx
@@ -2,7 +2,6 @@ import { useState, type ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { errorMessage, hasBridge, icloudAdoptGraph, icloudStatus } from '@reflect/core'
 import { SettingsField } from '@/components/settings/field'
-import { SettingsSection } from '@/components/settings/section'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -21,8 +20,8 @@ import { useGraph } from '@/providers/graph-provider'
 import { useSync } from '@/providers/sync-provider'
 
 /**
- * Settings → iCloud sync (Plan 21 Phase 1, the desktop leg): see whether the
- * graph syncs through iCloud Drive, and move a local graph into the
+ * Settings → Sync → iCloud Drive (Plan 21 Phase 1, the desktop leg): see
+ * whether the graph syncs through iCloud Drive, and move a local graph into the
  * container. The move copies (count+byte verified), then disconnects the
  * Git backup remote (iCloud sync and a Git remote are mutually exclusive per
  * graph — two merge machines over the same files would fight; the iCloud
@@ -34,7 +33,7 @@ import { useSync } from '@/providers/sync-provider'
  * macOS only — Windows/Linux have no iCloud Drive, and mobile chooses its
  * storage in onboarding.
  */
-export function IcloudSection(): ReactElement | null {
+export function IcloudSettingsField(): ReactElement | null {
   const { graph, openRecent } = useGraph()
   const { backup, disconnectGraph } = useSync()
   const [confirmOpen, setConfirmOpen] = useState(false)
@@ -95,7 +94,7 @@ export function IcloudSection(): ReactElement | null {
   }
 
   return (
-    <SettingsSection id="icloud">
+    <>
       <SettingsField
         legend="iCloud Drive"
         description={
@@ -141,6 +140,6 @@ export function IcloudSection(): ReactElement | null {
         )}
         {error !== null ? <p className="mt-2 text-xs text-destructive">{error}</p> : null}
       </SettingsField>
-    </SettingsSection>
+    </>
   )
 }

--- a/apps/desktop/src/components/settings/sections.ts
+++ b/apps/desktop/src/components/settings/sections.ts
@@ -16,10 +16,8 @@ export const SETTINGS_SECTIONS = [
   { id: 'agents', title: 'Agents' },
   // Only shown where the OS frameworks exist — see use-visible-settings-sections.
   { id: 'integrations', title: 'Integrations' },
-  // macOS only (same gate) — Windows/Linux have no iCloud Drive.
-  { id: 'icloud', title: 'iCloud sync' },
+  { id: 'sync', title: 'Sync' },
   { id: 'import', title: 'Import' },
-  { id: 'backup', title: 'Backup' },
   { id: 'about', title: 'About' },
   { id: 'destructive', title: 'Danger zone' },
 ] as const

--- a/apps/desktop/src/components/settings/settings-navigator.test.tsx
+++ b/apps/desktop/src/components/settings/settings-navigator.test.tsx
@@ -5,12 +5,11 @@ import { SETTINGS_SECTIONS, settingsSectionDomId } from './sections'
 import { SettingsNavigator } from './settings-navigator'
 
 // No bridge is installed here, so the platform-gated entries are hidden
-// (Integrations needs the Rust contacts answer; iCloud sync and Agents need
-// `isMacosDesktop`, which requires a Tauri webview) — the navigator lists the
-// sections every platform shows.
+// (Integrations needs the Rust contacts answer; Agents needs `isMacosDesktop`,
+// which requires a Tauri webview) — the navigator lists the sections every
+// platform shows.
 const VISIBLE_SECTIONS = SETTINGS_SECTIONS.filter(
-  (section) =>
-    section.id !== 'integrations' && section.id !== 'icloud' && section.id !== 'agents',
+  (section) => section.id !== 'integrations' && section.id !== 'agents',
 )
 
 // jsdom implements neither; the navigator re-measures its marker on resize,

--- a/apps/desktop/src/components/settings/sync-section.test.tsx
+++ b/apps/desktop/src/components/settings/sync-section.test.tsx
@@ -1,0 +1,72 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GraphInfo } from '@reflect/core'
+import type { BackupState } from '@/lib/backup-controller'
+import { SyncSection } from './sync-section'
+
+const graph = vi.hoisted(() => ({
+  current: null as GraphInfo | null,
+  openRecent: vi.fn<(root: string) => Promise<boolean>>(async () => true),
+}))
+
+const sync = vi.hoisted(() => ({
+  backup: { phase: 'disconnected' } as BackupState,
+  disconnectGraph: vi.fn(async () => {}),
+  signOut: vi.fn(async () => {}),
+  backUpNow: vi.fn(async () => {}),
+}))
+
+vi.mock('@/lib/platform', () => ({ isMacosDesktop: true }))
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({ graph: graph.current, openRecent: graph.openRecent }),
+}))
+vi.mock('@/providers/sync-provider', () => ({ useSync: () => sync }))
+
+function renderSection(): void {
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <SyncSection />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  graph.current = {
+    root: '/Users/alex/Documents/Notes',
+    name: 'Notes',
+    generation: 1,
+  }
+  sync.backup = { phase: 'disconnected' }
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('SyncSection', () => {
+  it('combines iCloud Drive and GitHub backup under Sync for local graphs', () => {
+    renderSection()
+
+    const section = screen.getByRole('region', { name: 'Sync' })
+    expect(within(section).getByText('iCloud Drive', { selector: 'legend' })).toBeTruthy()
+    expect(within(section).getByText('GitHub backup', { selector: 'legend' })).toBeTruthy()
+    expect(within(section).getByRole('button', { name: /connect github/i })).toBeTruthy()
+  })
+
+  it('hides GitHub backup when the graph syncs through iCloud', () => {
+    graph.current = {
+      root: '/Users/alex/Library/Mobile Documents/iCloud~app/Documents/Notes',
+      name: 'Notes',
+      generation: 1,
+    }
+
+    renderSection()
+
+    const section = screen.getByRole('region', { name: 'Sync' })
+    expect(within(section).getByText('iCloud Drive', { selector: 'legend' })).toBeTruthy()
+    expect(within(section).queryByText('GitHub backup')).toBeNull()
+    expect(within(section).queryByRole('button', { name: /connect github/i })).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/settings/sync-section.test.tsx
+++ b/apps/desktop/src/components/settings/sync-section.test.tsx
@@ -5,6 +5,17 @@ import type { GraphInfo } from '@reflect/core'
 import type { BackupState } from '@/lib/backup-controller'
 import { SyncSection } from './sync-section'
 
+const core = vi.hoisted(() => ({
+  status: {
+    available: true,
+    documentsRoot: '/Users/alex/Library/Mobile Documents/iCloud~app/Documents',
+    existingGraphRoots: [] as string[],
+  },
+  pendingNotes: 0,
+  conflictedNotes: [] as Array<{ path: string; title: string }>,
+  duplicateIds: [] as Array<{ id: string; paths: string[] }>,
+}))
+
 const graph = vi.hoisted(() => ({
   current: null as GraphInfo | null,
   openRecent: vi.fn<(root: string) => Promise<boolean>>(async () => true),
@@ -17,6 +28,14 @@ const sync = vi.hoisted(() => ({
   backUpNow: vi.fn(async () => {}),
 }))
 
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  hasBridge: () => true,
+  icloudStatus: vi.fn(async () => core.status),
+  icloudPendingCount: vi.fn(async () => core.pendingNotes),
+  getConflictedNotes: vi.fn(async () => core.conflictedNotes),
+  getDuplicateNoteIds: vi.fn(async () => core.duplicateIds),
+}))
 vi.mock('@/lib/platform', () => ({ isMacosDesktop: true }))
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({ graph: graph.current, openRecent: graph.openRecent }),
@@ -37,6 +56,14 @@ beforeEach(() => {
     name: 'Notes',
     generation: 1,
   }
+  core.status = {
+    available: true,
+    documentsRoot: '/Users/alex/Library/Mobile Documents/iCloud~app/Documents',
+    existingGraphRoots: ['/Users/alex/Library/Mobile Documents/iCloud~app/Documents/Personal'],
+  }
+  core.pendingNotes = 0
+  core.conflictedNotes = []
+  core.duplicateIds = []
   sync.backup = { phase: 'disconnected' }
 })
 
@@ -46,16 +73,17 @@ afterEach(() => {
 })
 
 describe('SyncSection', () => {
-  it('combines iCloud Drive and GitHub backup under Sync for local graphs', () => {
+  it('combines iCloud Drive and GitHub backup under Sync for local graphs', async () => {
     renderSection()
 
     const section = screen.getByRole('region', { name: 'Sync' })
     expect(within(section).getByText('iCloud Drive', { selector: 'legend' })).toBeTruthy()
+    expect(await within(section).findByText('1 graph in iCloud Drive.')).toBeTruthy()
     expect(within(section).getByText('GitHub backup', { selector: 'legend' })).toBeTruthy()
     expect(within(section).getByRole('button', { name: /connect github/i })).toBeTruthy()
   })
 
-  it('hides GitHub backup when the graph syncs through iCloud', () => {
+  it('hides GitHub backup when the graph syncs through iCloud', async () => {
     graph.current = {
       root: '/Users/alex/Library/Mobile Documents/iCloud~app/Documents/Notes',
       name: 'Notes',
@@ -66,7 +94,28 @@ describe('SyncSection', () => {
 
     const section = screen.getByRole('region', { name: 'Sync' })
     expect(within(section).getByText('iCloud Drive', { selector: 'legend' })).toBeTruthy()
+    expect(await within(section).findByText('All note files are downloaded.')).toBeTruthy()
+    expect(within(section).getByText('No notes need review.')).toBeTruthy()
     expect(within(section).queryByText('GitHub backup')).toBeNull()
     expect(within(section).queryByRole('button', { name: /connect github/i })).toBeNull()
+  })
+
+  it('surfaces iCloud download and review counts', async () => {
+    graph.current = {
+      root: '/Users/alex/Library/Mobile Documents/iCloud~app/Documents/Notes',
+      name: 'Notes',
+      generation: 1,
+    }
+    core.pendingNotes = 2
+    core.conflictedNotes = [{ path: 'notes/a.md', title: 'A' }]
+    core.duplicateIds = [{ id: 'note-1', paths: ['notes/a.md', 'notes/a 2.md'] }]
+
+    renderSection()
+
+    const section = screen.getByRole('region', { name: 'Sync' })
+    expect(
+      await within(section).findByText('2 notes are still downloading from iCloud.'),
+    ).toBeTruthy()
+    expect(within(section).getByText('1 note needs review, 1 sync fork')).toBeTruthy()
   })
 })

--- a/apps/desktop/src/components/settings/sync-section.test.tsx
+++ b/apps/desktop/src/components/settings/sync-section.test.tsx
@@ -16,6 +16,8 @@ const core = vi.hoisted(() => ({
   duplicateIds: [] as Array<{ id: string; paths: string[] }>,
 }))
 
+const platform = vi.hoisted(() => ({ isMacosDesktop: true }))
+
 const graph = vi.hoisted(() => ({
   current: null as GraphInfo | null,
   openRecent: vi.fn<(root: string) => Promise<boolean>>(async () => true),
@@ -36,7 +38,11 @@ vi.mock('@reflect/core', async (importOriginal) => ({
   getConflictedNotes: vi.fn(async () => core.conflictedNotes),
   getDuplicateNoteIds: vi.fn(async () => core.duplicateIds),
 }))
-vi.mock('@/lib/platform', () => ({ isMacosDesktop: true }))
+vi.mock('@/lib/platform', () => ({
+  get isMacosDesktop(): boolean {
+    return platform.isMacosDesktop
+  },
+}))
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({ graph: graph.current, openRecent: graph.openRecent }),
 }))
@@ -64,6 +70,7 @@ beforeEach(() => {
   core.pendingNotes = 0
   core.conflictedNotes = []
   core.duplicateIds = []
+  platform.isMacosDesktop = true
   sync.backup = { phase: 'disconnected' }
 })
 
@@ -117,5 +124,20 @@ describe('SyncSection', () => {
       await within(section).findByText('2 notes are still downloading from iCloud.'),
     ).toBeTruthy()
     expect(within(section).getByText('1 note needs review, 1 sync fork')).toBeTruthy()
+  })
+
+  it('keeps backup visible when the iCloud row is platform-hidden', () => {
+    platform.isMacosDesktop = false
+    graph.current = {
+      root: '/Users/alex/Library/Mobile Documents/iCloud~app/Documents/Notes',
+      name: 'Notes',
+      generation: 1,
+    }
+
+    renderSection()
+
+    const section = screen.getByRole('region', { name: 'Sync' })
+    expect(within(section).queryByText('iCloud Drive', { selector: 'legend' })).toBeNull()
+    expect(within(section).getByText('GitHub backup', { selector: 'legend' })).toBeTruthy()
   })
 })

--- a/apps/desktop/src/components/settings/sync-section.tsx
+++ b/apps/desktop/src/components/settings/sync-section.tsx
@@ -1,0 +1,23 @@
+import type { ReactElement } from 'react'
+import { isICloudRoot } from '@/lib/icloud-controller'
+import { useGraph } from '@/providers/graph-provider'
+import { BackupSettingsField } from './backup-section'
+import { IcloudSettingsField } from './icloud-section'
+import { SettingsSection } from './section'
+
+/**
+ * Settings → Sync: iCloud Drive and Git remote sync live together here. An
+ * iCloud-hosted graph hides the GitHub backup controls because a graph syncs
+ * through iCloud or a Git remote, not both.
+ */
+export function SyncSection(): ReactElement {
+  const { graph } = useGraph()
+  const iCloudSyncEnabled = graph !== null && isICloudRoot(graph.root)
+
+  return (
+    <SettingsSection id="sync">
+      <IcloudSettingsField />
+      {iCloudSyncEnabled ? null : <BackupSettingsField />}
+    </SettingsSection>
+  )
+}

--- a/apps/desktop/src/components/settings/sync-section.tsx
+++ b/apps/desktop/src/components/settings/sync-section.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react'
 import { isICloudRoot } from '@/lib/icloud-controller'
+import { isMacosDesktop } from '@/lib/platform'
 import { useGraph } from '@/providers/graph-provider'
 import { BackupSettingsField } from './backup-section'
 import { IcloudSettingsField } from './icloud-section'
@@ -12,7 +13,7 @@ import { SettingsSection } from './section'
  */
 export function SyncSection(): ReactElement {
   const { graph } = useGraph()
-  const iCloudSyncEnabled = graph !== null && isICloudRoot(graph.root)
+  const iCloudSyncEnabled = isMacosDesktop && graph !== null && isICloudRoot(graph.root)
 
   return (
     <SettingsSection id="sync">

--- a/apps/desktop/src/components/settings/use-visible-settings-sections.ts
+++ b/apps/desktop/src/components/settings/use-visible-settings-sections.ts
@@ -8,8 +8,9 @@ export type SettingsSectionEntry = (typeof SETTINGS_SECTIONS)[number]
 /**
  * The settings sections this platform actually shows. Integrations
  * only exists where the OS frameworks do (macOS/iOS — the Rust shell answers
- * `unavailable` elsewhere), and the navigator must agree with the page, so
- * both filter through here rather than reading the registry directly.
+ * `unavailable` elsewhere). Agents is macOS-only. The navigator must agree
+ * with the page, so both filter through here rather than reading the registry
+ * directly.
  */
 export function useVisibleSettingsSections(): readonly SettingsSectionEntry[] {
   const authorization = useContactsAuthorization()
@@ -19,7 +20,7 @@ export function useVisibleSettingsSections(): readonly SettingsSectionEntry[] {
     if (section.id === 'integrations') {
       return hasAppleIntegrations
     }
-    if (section.id === 'icloud' || section.id === 'agents') {
+    if (section.id === 'agents') {
       return isMacosDesktop
     }
     return true


### PR DESCRIPTION
## Problem

Desktop Settings showed iCloud sync and GitHub backup as separate sections even though they are mutually exclusive ways for a graph to sync. That also left the GitHub backup controls visible for graphs already hosted in iCloud Drive, while the iCloud row itself stayed static and did not surface the useful status we already have locally.

## Before -> After

| Before | After |
| --- | --- |
| Separate `iCloud sync` and `Backup` settings sections. | One `Sync` section in the settings page and navigator. |
| Local graphs showed iCloud controls in one card and GitHub backup in another. | Local graphs show iCloud Drive and GitHub backup rows together under `Sync`. |
| iCloud-hosted graphs could still see GitHub backup settings. | iCloud-hosted graphs only show the iCloud Drive row on macOS; GitHub backup is hidden there. |
| The iCloud row was static once enabled. | The iCloud row shows note download state and review-needed counts; local graphs show how many graphs already exist in iCloud Drive. |

## Changes

1. Adds `SyncSection`, which composes the iCloud Drive row and the backup row under one `SettingsSection id="sync"`.
2. Reuses the existing iCloud and backup UI as field-level components so their behavior stays intact while the section ownership moves to `SyncSection`.
3. Updates the settings section registry and navigator expectations to replace `iCloud sync` / `Backup` with `Sync`.
4. Shows iCloud status that is already available: `icloudPendingCount` for hosted graph note downloads, `getConflictedNotes` / `getDuplicateNoteIds` for review counts, and `icloudStatus().existingGraphRoots` for local graph iCloud availability context.
5. Keeps GitHub backup visible when the iCloud row is platform-hidden, so the Sync card never goes empty on non-macOS surfaces.
6. Adds coverage for local graphs versus iCloud-hosted graphs so the GitHub backup controls stay hidden when `isICloudRoot(graph.root)` is true on macOS and the new status lines render correctly.

## Tests

- `sync-section.test.tsx` covers the combined local-graph state, the iCloud-hosted hide behavior, the iCloud download/review count lines, and the platform-hidden iCloud fallback.
- `backup-section.test.tsx` still covers GitHub/generic remote backup behavior at the row level.
- `settings-navigator.test.tsx` covers the updated visible section list.

## Verification

- `pnpm test -- src/components/settings/sync-section.test.tsx src/components/settings/backup-section.test.tsx` passed. Vitest ran the desktop suite: 175 files, 1564 tests.
- `pnpm check` passed. Lint emitted the repo's existing max-lines warnings only.

## Risk / Rollout

No migrations or data shape changes. The risk is limited to desktop Settings composition and status copy. The backup and iCloud action handlers are reused unchanged; the new iCloud note-placeholder query polls only while the pending count is nonzero.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only settings reorganization reusing existing sync/backup handlers; no migrations or data model changes.
> 
> **Overview**
> Desktop **Settings** now exposes a single **Sync** section (navigator + page) instead of separate **iCloud sync** and **Backup** entries.
> 
> **`SyncSection`** composes the existing iCloud and backup UIs as field-level components (`IcloudSettingsField`, `BackupSettingsField`). For graphs hosted in iCloud Drive, **GitHub backup controls are hidden**, reflecting that a graph uses iCloud or a Git remote, not both. On non-macOS, the iCloud row stays hidden while backup remains under Sync.
> 
> The **iCloud Drive** row gains live status: pending note download counts (polling while nonzero), conflict/sync-fork review summaries for hosted graphs, and a count of graphs already in iCloud for local graphs. Backup/GitHub behavior is unchanged at the row level.
> 
> Section registry, settings screen composition, and navigator visibility logic are updated accordingly, with new **`sync-section`** tests plus adjusted backup and navigator tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb4b5403c5fd4b609da3ca8b0803062f003e623b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->