### PR TITLE
Release v0.4.0-beta.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4743,7 +4743,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.4.0-beta.21"
+version = "0.4.0-beta.22"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.4.0-beta.21"
+version = "0.4.0-beta.22"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.4.0-beta.21",
+  "version": "0.4.0-beta.22",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.4.0-beta.22.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version bump with no logic, dependency, or config changes beyond the release number.
> 
> **Overview**
> Bumps the Reflect desktop app from **0.4.0-beta.21** to **0.4.0-beta.22** in `Cargo.toml`, `tauri.conf.json`, and `Cargo.lock` for the `reflect-open` crate. No application or dependency changes beyond the version strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b4e52ef901bdd774bd638e4370574962e18f3b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->