### PR TITLE
Update iOS onboarding folder copy

### DIFF
--- a/apps/desktop/src/mobile/onboarding-screen.test.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.test.tsx
@@ -81,12 +81,13 @@ describe('MobileOnboardingScreen', () => {
     )
   })
 
-  it('keeps notes on this device without cloning', async () => {
+  it('chooses a folder on this device without cloning', async () => {
     render(<MobileOnboardingScreen />)
 
+    expect(screen.queryByText(/Your notes are plain markdown files/i)).toBeNull()
     expect(screen.getByRole('heading', { name: 'This device' })).toBeTruthy()
     expect(screen.getByText('Stored locally in Reflect on this device.')).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: 'Keep notes on this device' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Choose a folder on this device' }))
 
     await waitFor(() => expect(completeOnboarding).toHaveBeenCalledWith('local'))
   })
@@ -104,7 +105,7 @@ describe('MobileOnboardingScreen', () => {
     expect(screen.queryByRole('button', { name: 'Create' })).toBeNull()
     expect(screen.queryByText(/Sign in to iCloud/)).toBeNull()
     // The on-device path stays live — its root is already known.
-    const local = screen.getByRole('button', { name: 'Keep notes on this device' })
+    const local = screen.getByRole('button', { name: 'Choose a folder on this device' })
     expect((local as HTMLButtonElement).disabled).toBe(false)
   })
 
@@ -117,7 +118,7 @@ describe('MobileOnboardingScreen', () => {
       screen.getByText('Sign in to iCloud on this device to sync notes with iCloud Drive.'),
     ).toBeTruthy()
     expect(screen.getByRole('heading', { name: 'This device' })).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Keep notes on this device' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Choose a folder on this device' })).toBeTruthy()
   })
 
   it('does not offer repository setup from the first-run picker', () => {

--- a/apps/desktop/src/mobile/onboarding-screen.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.tsx
@@ -20,7 +20,7 @@ type PendingChoice = string | 'icloud-create' | 'local' | null
  * iCloud Drive leads (Plan 21): it is the primary way a graph syncs between
  * iPhone and Mac, so the hero block ({@link OnboardingIcloudSection}) lists
  * every graph already in the app's iCloud container plus a create row.
- * **Keep notes on this device** opens the app-sandbox root instead (and is
+ * **Choose a folder on this device** opens the app-sandbox root instead (and is
  * promoted to the only storage card when iCloud is unavailable). Every
  * path ends in `completeOnboarding(kind, root)`, which opens the chosen root
  * and records the flag + storage kind + graph name.
@@ -57,11 +57,8 @@ export function MobileOnboardingScreen(): ReactElement {
       }}
     >
       <div className="my-auto flex w-full flex-col gap-6">
-        <div className="flex flex-col gap-1.5 text-center">
+        <div className="text-center">
           <h1 className="text-xl font-semibold tracking-tight">Welcome to Reflect</h1>
-          <p className="text-sm text-text-muted">
-            Your notes are plain markdown files. Choose where to keep them.
-          </p>
         </div>
 
         <div className="flex flex-col gap-3">
@@ -91,7 +88,7 @@ export function MobileOnboardingScreen(): ReactElement {
             </div>
             <Button
               variant={icloudReady || icloudPending ? 'outline' : 'default'}
-              className="w-full"
+              className="w-full justify-start text-left"
               onClick={() => runChoice('local', () => completeOnboarding('local'))}
               disabled={action.pending || mobileStorageInfo === null}
             >
@@ -100,7 +97,7 @@ export function MobileOnboardingScreen(): ReactElement {
               ) : (
                 <HardDrive aria-hidden strokeWidth={1.75} />
               )}
-              {pendingChoice === 'local' ? 'Setting up…' : 'Keep notes on this device'}
+              {pendingChoice === 'local' ? 'Setting up…' : 'Choose a folder on this device'}
             </Button>
           </section>
           {!icloudReady && !icloudPending ? (


### PR DESCRIPTION
## Problem

The iOS first-run welcome screen still described the on-device path as “Keep notes on this device” and included extra explanatory copy under “Welcome to Reflect.” That wording no longer matched the desired folder-choice framing for the local storage option.

## Before -> After

| Area | Before | After |
| --- | --- | --- |
| Welcome subtitle | “Your notes are plain markdown files. Choose where to keep them.” | Removed on iOS |
| On-device button | “Keep notes on this device” | “Choose a folder on this device” |
| On-device button alignment | Centered label | Left-aligned label |

## Changes

1. Updated `MobileOnboardingScreen` to remove the iOS welcome subtitle, rename the local storage button, and left-align its contents.
2. Updated the mobile onboarding tests to assert the new accessible button name and guard against reintroducing the removed subtitle.

## Verification

- `pnpm --filter @reflect/desktop exec vitest run src/mobile/onboarding-screen.test.tsx` passed.
- `pnpm check` passed.

## Risk / Rollout

Low risk: this is an iOS onboarding copy and button layout change only. No data shape, persistence, or platform bridge behavior changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and button layout only on `MobileOnboardingScreen`; no changes to onboarding logic, storage APIs, or persistence.
> 
> **Overview**
> Updates the **mobile first-run** screen so the local storage path reads as choosing a folder, not “keeping notes” on the device.
> 
> The welcome block under **Welcome to Reflect** no longer shows the subtitle about plain markdown files. The **This device** action is renamed to **Choose a folder on this device**, and its button uses left-aligned label styling (`justify-start text-left`). Onboarding tests now target the new accessible name and assert the removed subtitle stays gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f49ad752cebf7889fdabb7c79ece879acc284d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the onboarding screen wording from “Keep notes on this device” to “Choose a folder on this device.”
  * Simplified the welcome area and adjusted the local storage button alignment for a cleaner layout.

* **Tests**
  * Updated onboarding tests to match the new local-device flow and refreshed expected copy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->