### PR TITLE
refactor(ios): feed the task sheet's live draft from onChange, not getMarkdown

### DIFF
--- a/apps/desktop/src/mobile/task-edit-sheet.tsx
+++ b/apps/desktop/src/mobile/task-edit-sheet.tsx
@@ -89,19 +89,21 @@ export function MobileTaskEditSheet({
   // been rewritten by an action), so remount it via this seed to re-read it.
   const [editorSeed, setEditorSeed] = useState(0)
   const editorRef = useRef<NoteEditorHandle | null>(null)
-  // The editor's live markdown, or null when it can't be trusted:
-  // getMarkdown() coalesces "surface not ready" to '', indistinguishable from
-  // a genuine clear — and trusting it would delete the task (or feed the
-  // schedule rewrite an empty base). A real clear reaches the mirrored draft
-  // through onChange, so empty reads defer to the state.
-  const readLiveDraft = (): string | null => {
-    const markdown = editorRef.current?.getMarkdown()
-    return markdown === undefined || markdown === '' ? null : markdown
-  }
+  // The editor's live markdown, mirrored from its own onChange stream (the
+  // desktop task editor's currentRef pattern) so an edit the state hasn't
+  // re-rendered yet is never dropped or clobbered. Tagged with the editor
+  // instance: after a reseed remount the previous instance's leftovers read
+  // as null. Never an imperative getMarkdown() — that coalesces "not ready"
+  // and "torn down" into '', indistinguishable from a genuine clear, and an
+  // empty draft means delete.
+  const liveDraftRef = useRef<{ seed: number; markdown: string } | null>(null)
+  const readLiveDraft = (): string | null =>
+    liveDraftRef.current !== null && liveDraftRef.current.seed === editorSeed
+      ? liveDraftRef.current.markdown
+      : null
   // The commit/cancel/delete rules — baseline frozen at open, reseed on
   // reopen, dismissal vs navigate vs unmount — live in the finalizer. It
-  // resolves against the editor's live markdown (readDraft) so a change whose
-  // onChange hasn't re-rendered yet is never dropped by a commit.
+  // resolves against the live mirror (readDraft) with the state as fallback.
   const { draft, setDraft, resolve, handleOpenChange, closeHandled, closeNavigate } =
     useTaskSheetFinalizer({
       task,
@@ -115,6 +117,11 @@ export function MobileTaskEditSheet({
       },
     })
   const dueDate = draftDueDate(draft)
+
+  const handleChange = (markdown: string): void => {
+    liveDraftRef.current = { seed: editorSeed, markdown }
+    setDraft(markdown)
+  }
   // Stable while the editor is mounted: the flag only changes between visits
   // (the screen sets it before opening), never mid-edit, so the ref callback
   // can depend on it without re-attach churn.
@@ -188,13 +195,12 @@ export function MobileTaskEditSheet({
   }
 
   const schedule = (isoDate: string | null): void => {
-    // Derive from the editor's live markdown, not the mirrored state: a change
-    // whose onChange hasn't re-rendered yet must not be clobbered by the
-    // silent rewrite below.
+    // Base the rewrite on the freshest draft, then keep every mirror in step
+    // by hand: setMarkdown is silent (no onChange echo), so neither the live
+    // mirror nor the state (chip highlights) updates on its own.
     const next = withDraftDueDate(readLiveDraft() ?? draft, isoDate)
+    liveDraftRef.current = { seed: editorSeed, markdown: next }
     setDraft(next)
-    // setMarkdown is silent (no onChange echo), so the state write above keeps
-    // the mirrored draft (chip highlights) in step.
     editorRef.current?.setMarkdown(next)
     setShowCalendar(false)
   }
@@ -222,7 +228,7 @@ export function MobileTaskEditSheet({
           <NoteEditor
             key={editorSeed}
             initialContent={draft}
-            onChange={setDraft}
+            onChange={handleChange}
             markMode={markModeFromSyntax(settings.editorMarkdownSyntax)}
             spellCheck={settings.editorSpellCheck}
             // A one-line editor has nothing to reorder, so keep the gutter grip off.

--- a/apps/desktop/src/mobile/use-task-sheet-finalizer.test.ts
+++ b/apps/desktop/src/mobile/use-task-sheet-finalizer.test.ts
@@ -185,19 +185,33 @@ describe('useTaskSheetFinalizer', () => {
     expect(edit.mock.calls[0]?.[1]).toBe('alpha edited')
   })
 
-  it('ignores readDraft during the unmount flush — a torn-down surface can misreport empty', () => {
+  it('trusts readDraft during the unmount flush — a change-stream mirror has no teardown window', () => {
+    // readDraft is contractually fed by the surface's own onChange stream
+    // (never an imperative editor read), so its value — including a genuine
+    // clear — is authoritative even while the tree unmounts.
     const { result, unmount } = renderHook(() =>
-      useTaskSheetFinalizer(deps({ readDraft: () => '' })),
+      useTaskSheetFinalizer(deps({ readDraft: () => 'alpha typed live' })),
     )
 
     act(() => result.current.setDraft('alpha edited'))
     unmount()
 
-    // Trusting the misreported '' would delete a real task; the flush must
-    // resolve from the mirrored state instead.
-    expect(remove).not.toHaveBeenCalled()
     expect(edit).toHaveBeenCalledTimes(1)
-    expect(edit.mock.calls[0]?.[1]).toBe('alpha edited')
+    expect(edit.mock.calls[0]?.[1]).toBe('alpha typed live')
+  })
+
+  it('treats an empty readDraft as a genuine clear', () => {
+    // Under the change-stream contract '' can only mean the user emptied the
+    // draft, so an abandoning dismissal deletes rather than resurrecting text.
+    const { result } = renderHook(() =>
+      useTaskSheetFinalizer(deps({ readDraft: () => '' })),
+    )
+
+    act(() => result.current.setDraft('alpha edited'))
+    act(() => result.current.handleOpenChange(false))
+
+    expect(remove).toHaveBeenCalledTimes(1)
+    expect(edit).not.toHaveBeenCalled()
   })
 
   it('flushes like a dismissal when unmounted under an open sheet', () => {

--- a/apps/desktop/src/mobile/use-task-sheet-finalizer.ts
+++ b/apps/desktop/src/mobile/use-task-sheet-finalizer.ts
@@ -17,12 +17,15 @@ export interface TaskSheetFinalizerDeps {
   /** Reset sheet-local presentation (collapse the calendar) on reopen. */
   onReseed: () => void
   /**
-   * Read the editing surface's markdown, or null when the surface can't
-   * answer. An uncontrolled editor can hold a change whose `onChange` hasn't
-   * re-rendered into the mirrored draft yet; resolving against the live text
-   * keeps that change from being dropped. Consulted only at interactive
-   * decision points (dismissal, navigate, `resolve`) — the unmount flush uses
-   * the mirrored state, because a surface mid-teardown can misreport empty.
+   * Read the caller's live draft mirror, or null when it has nothing for the
+   * current surface. An uncontrolled editor can hold a change whose
+   * `onChange` hasn't re-rendered into the draft state yet; resolving against
+   * this mirror keeps that change from being dropped. The implementation must
+   * be fed by the surface's own change stream (a ref written in `onChange`),
+   * never an imperative editor read: a surface not yet ready or mid-teardown
+   * misreports empty, and an empty draft means delete. A change-stream mirror
+   * has no such window, so it is trusted everywhere — including the unmount
+   * flush.
    */
   readDraft?: () => string | null
 }
@@ -88,17 +91,14 @@ export function useTaskSheetFinalizer({
     }
   }
 
-  // The freshest draft available at an *interactive* decision point (a
-  // dismissal gesture, an action button) — the surface is mounted there. The
-  // unmount flush must NOT use this: a surface mid-teardown can misreport
-  // empty, and "empty" means delete.
+  /** The freshest draft available: the caller's live mirror, else the state. */
   const currentDraft = (): string => readDraft?.() ?? draft
 
   const resolve = (): TaskEditResult => resolveTaskEdit(initial, currentDraft())
 
-  /** Persist `current` vs the baseline: a real change commits, an emptied draft deletes. */
-  const commitCurrent = (current: string): void => {
-    const result = resolveTaskEdit(initial, current)
+  /** Persist the draft: a real change commits, an emptied draft deletes. */
+  const commitDraft = (): void => {
+    const result = resolve()
     if (result.type === 'commit') {
       actions.edit(task, result.content)
     } else if (result.type === 'delete') {
@@ -106,11 +106,11 @@ export function useTaskSheetFinalizer({
     }
   }
 
-  const finishAbandonedVisit = (current: string): void => {
-    if (resolveTaskEdit(initial, current).type === 'cancel' && current.trim() === '') {
+  const finishAbandonedVisit = (): void => {
+    if (resolve().type === 'cancel' && currentDraft().trim() === '') {
       actions.remove([task])
     } else {
-      commitCurrent(current)
+      commitDraft()
     }
   }
 
@@ -121,7 +121,7 @@ export function useTaskSheetFinalizer({
       // same commit/delete twice (a second delete would trip the stale guard
       // and surface a spurious failure).
       setHandled(true)
-      finishAbandonedVisit(currentDraft())
+      finishAbandonedVisit()
     }
     onOpenChange(nextOpen)
   }
@@ -132,7 +132,7 @@ export function useTaskSheetFinalizer({
   }
 
   const closeNavigate = (): void => {
-    commitCurrent(currentDraft())
+    commitDraft()
     setHandled(true)
     onOpenChange(false)
   }
@@ -141,13 +141,11 @@ export function useTaskSheetFinalizer({
   // drawer is open — no dismissal callback fires, so flush like a dismissal
   // would (desktop's inline editor flushes on unmount the same way). The
   // latest-closure ref keeps the unmount-only cleanup reading current state.
-  // Resolve from the mirrored draft, never readDraft: the surface is tearing
-  // down with us and can misreport empty, which would delete a real task.
   const unmountFlushRef = useRef<() => void>(() => {})
   useEffect(() => {
     unmountFlushRef.current = () => {
       if (open && !handled) {
-        finishAbandonedVisit(draft)
+        finishAbandonedVisit()
       }
     }
   })


### PR DESCRIPTION
## Problem

Follow-up to #547 (the mobile task sheet's markdown editor). The `readDraft` accessor — added there so commits never drop an editor change the mirrored React state hadn't re-rendered yet — was backed by an imperative `NoteEditorHandle.getMarkdown()` read. That handle coalesces "surface not ready" and "surface torn down" into `''`, the same value as a genuinely cleared draft, and an empty draft means **delete**. Keeping that safe required two hand-tuned trust boundaries, each carrying a paragraph of justification and each probed by a Bugbot round on #547:

- empty live reads had to defer to the mirrored state (else an early dismiss deletes a real task), which in turn meant a real clear-then-dismiss could only delete via the state mirror;
- the unmount flush had to skip the accessor entirely (a mid-teardown surface misreports empty).

Two sources of truth reconciled by heuristics is the wrong shape — and desktop's inline task editor already solved this differently.

## The change

Adopt desktop's `useTaskEditorFinalizer` pattern (`currentRef`), adapted for the sheet's remount-on-reseed: the sheet mirrors the editor's **own `onChange` stream** into a ref tagged with the editor instance (`editorSeed`), and `readDraft` serves from that mirror. The mirror is only ever written with real editor output, so:

- `''` can only mean the user cleared the draft — a clear-then-dismiss now deletes through the live mirror, no state-render race;
- there is no not-ready/teardown window — the finalizer trusts `readDraft` everywhere, **including the unmount flush**;
- both heuristics, their comments, and the parametrized `finishAbandonedVisit`/`commitCurrent` threading in the finalizer are deleted. `schedule()` keeps the mirror in step by hand alongside its silent `setMarkdown`, and a reseed remount invalidates the previous instance's leftovers via the seed tag.

Behavior is unchanged in every scenario the #547 tests pin; the two edge cases above (clear-then-dismiss freshness, unmount freshness) get strictly better.

## Tests

- Finalizer units updated to the new contract: `readDraft` wins at interactive decision points, falls back when null, **is trusted at unmount** (change-stream mirrors have no teardown window), and an empty read is a genuine clear → delete.
- All 43 tests across `use-task-sheet-finalizer.test.ts` and `screens/tasks.test.tsx` pass; the screen suite (commit-on-dismiss, one-write scheduling, reseed-after-action, abandoned "+" row, unmount flush, autofocus) is untouched.

## Verification

- `pnpm test --run src/mobile/use-task-sheet-finalizer.test.ts src/mobile/screens/tasks.test.tsx` — 43 passed
- `pnpm check` (typecheck + oxlint + eslint) — clean

## Risk

Pure refactor of the draft-freshness mechanism; no UI, write-path, or data changes. The residual gap is unchanged from #547: text still inside an uncommitted iOS IME composition isn't in the ProseMirror doc either, so no read strategy can see it — the OS commits it when focus leaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal draft-freshness refactor with no UI or write-path changes; behavior is pinned by existing and updated unit tests.
> 
> **Overview**
> **Replaces imperative `getMarkdown()` draft reads** with an `onChange`-fed ref (desktop’s `currentRef` pattern), tagged by `editorSeed` so remounts ignore stale mirror data.
> 
> The mobile task sheet finalizer **no longer splits trust** between interactive dismiss/navigate and unmount flush: `readDraft` is authoritative everywhere, including teardown, so empty string reliably means a real clear → delete. **`schedule()`** manually updates the mirror when `setMarkdown` runs silently.
> 
> Finalizer helpers are simplified (`commitDraft` / `finishAbandonedVisit` without threading draft strings). **Tests** reflect the new contract: unmount trusts `readDraft`; empty `readDraft` on dismiss deletes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb0682996f42eb389eb195376bbd0f9cc7201a33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->