### PR TITLE
perf(index): stamp echoes with real mtimes and self-heal stored ones

### DIFF
--- a/apps/desktop/src-tauri/src/conflict/archive.rs
+++ b/apps/desktop/src-tauri/src/conflict/archive.rs
@@ -39,7 +39,8 @@ pub fn archive_version(
         attempt += 1;
         target = dir.join(format!("{stem}-{attempt}.{ext}"));
     }
-    crate::fs::atomic_write_bytes(root, &target, bytes)
+    crate::fs::atomic_write_bytes(root, &target, bytes)?;
+    Ok(())
 }
 
 /// Prune the archive: per note, keep the newest [`MAX_PER_NOTE`] versions and

--- a/apps/desktop/src-tauri/src/conflict/shadow.rs
+++ b/apps/desktop/src-tauri/src/conflict/shadow.rs
@@ -65,7 +65,8 @@ impl ShadowStore {
         let path = self
             .entry_path(rel, "")
             .ok_or_else(|| AppError::io(format!("invalid shadow path: {rel}")))?;
-        crate::fs::atomic_write_bytes(&self.root, &path, content.as_bytes())
+        crate::fs::atomic_write_bytes(&self.root, &path, content.as_bytes())?;
+        Ok(())
     }
 
     /// Drop a note's base and merge-pair record (deletion, or corrupt state).
@@ -112,7 +113,8 @@ impl ShadowStore {
             .entry_path(rel, ".pair")
             .ok_or_else(|| AppError::io(format!("invalid shadow path: {rel}")))?;
         let (low, high) = if a <= b { (a, b) } else { (b, a) };
-        crate::fs::atomic_write_bytes(&self.root, &path, format!("{low}\n{high}\n").as_bytes())
+        crate::fs::atomic_write_bytes(&self.root, &path, format!("{low}\n{high}\n").as_bytes())?;
+        Ok(())
     }
 
     /// Does the incoming conflict repeat the last auto-merged pair?

--- a/apps/desktop/src-tauri/src/db/mod.rs
+++ b/apps/desktop/src-tauri/src/db/mod.rs
@@ -229,6 +229,39 @@ pub fn index_move(
     move_rows(conn, &from, &to)
 }
 
+/// One `index_touch` entry: re-stamp `path`'s stored mtime to `mtime`
+/// (epoch ms, as listed by `list_files`).
+#[derive(Debug, serde::Deserialize)]
+pub struct IndexTouch {
+    path: String,
+    mtime: i64,
+}
+
+/// Re-stamp stored mtimes for notes whose content already matches disk (the
+/// reconcile's hash-match skip, no-op if stale). Rows written from a local
+/// write echo carry an echo-time stamp that never equals the listed on-disk
+/// mtime, so without this repair those files are re-read and re-hashed on
+/// every pass forever. One transaction for the batch; a path whose row
+/// vanished in between updates nothing.
+#[tauri::command]
+pub fn index_touch(
+    entries: Vec<IndexTouch>,
+    generation: u64,
+    index: State<IndexState>,
+) -> AppResult<()> {
+    let mut state = lock_state(&index)?;
+    if state.generation != generation {
+        return Ok(());
+    }
+    let conn = state.conn.as_mut().ok_or_else(AppError::no_graph)?;
+    let tx = conn.transaction()?;
+    for entry in &entries {
+        write::touch_note(&tx, &entry.path, entry.mtime)?;
+    }
+    tx.commit()?;
+    Ok(())
+}
+
 /// Upsert one `index_meta` key (no-op if stale). The table is bookkeeping the
 /// TS policy layer owns — e.g. `syncIndex` stamps the projection version after
 /// a rebuild — and `index_clear` deliberately preserves it, so a marker can

--- a/apps/desktop/src-tauri/src/db/tests.rs
+++ b/apps/desktop/src-tauri/src/db/tests.rs
@@ -10,8 +10,8 @@ use super::embed_write::{apply_chunks, remove_chunks, EmbeddedChunk};
 use super::migrations::{migrate, migrate_to, open_in_memory, open_index_at, validate_migrations};
 use super::query::run_query;
 use super::write::{
-    apply_note, clear_index, move_note, IndexedEmail, IndexedLink, IndexedNote, IndexedTag,
-    IndexedTask,
+    apply_note, clear_index, move_note, touch_note, IndexedEmail, IndexedLink, IndexedNote,
+    IndexedTag, IndexedTask,
 };
 
 fn migrated() -> Connection {
@@ -407,6 +407,28 @@ fn reapplying_a_note_replaces_its_rows() {
     let rows = run_query(&conn, "SELECT target_key FROM links", &[]).unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0]["target_key"], Value::from("z"));
+}
+
+#[test]
+fn touch_note_restamps_mtime_and_updated_at_without_creating_rows() {
+    let conn = migrated();
+    apply_note(&conn, &note("notes/a.md", "A", vec![])).unwrap();
+
+    touch_note(&conn, "notes/a.md", 4_200).unwrap();
+    let rows = run_query(
+        &conn,
+        "SELECT mtime, updated_at FROM notes WHERE path = ?1",
+        &[Value::from("notes/a.md")],
+    )
+    .unwrap();
+    assert_eq!(rows[0]["mtime"], Value::from(4_200));
+    assert_eq!(rows[0]["updated_at"], Value::from(4_200));
+
+    // A path with no row updates nothing — a touch must never resurrect a
+    // removed note.
+    touch_note(&conn, "notes/gone.md", 4_200).unwrap();
+    let count = run_query(&conn, "SELECT COUNT(*) AS n FROM notes", &[]).unwrap();
+    assert_eq!(count[0]["n"], Value::from(1));
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/db/write.rs
+++ b/apps/desktop/src-tauri/src/db/write.rs
@@ -264,6 +264,17 @@ pub(super) fn clear_index(conn: &Connection) -> AppResult<()> {
     Ok(())
 }
 
+/// Re-stamp a note row's stored `mtime` (and `updated_at`, which `apply_note`
+/// keeps equal to it) without touching the projection. The reconcile calls
+/// this when a file's content hash still matches but its listed mtime doesn't
+/// — otherwise the stale stamp costs a re-read on every future pass. A path
+/// with no row matches nothing: a touch must never resurrect a removed note.
+pub(super) fn touch_note(conn: &Connection, path: &str, mtime: i64) -> AppResult<()> {
+    conn.prepare_cached("UPDATE notes SET mtime = ?2, updated_at = ?2 WHERE path = ?1")?
+        .execute(params![path, mtime])?;
+    Ok(())
+}
+
 /// Drop every row belonging to `path` (the `notes` row cascades to child
 /// tables; `search_fts` is standalone).
 pub(super) fn remove_note(conn: &Connection, path: &str) -> AppResult<()> {

--- a/apps/desktop/src-tauri/src/fs/io.rs
+++ b/apps/desktop/src-tauri/src/fs/io.rs
@@ -152,18 +152,27 @@ fn set_local_only_xattrs(dir: &Path) -> Vec<String> {
 }
 
 /// Atomically write `contents` to `target` inside the graph at `root`.
-pub(super) fn atomic_write(root: &Path, target: &Path, contents: &str) -> AppResult<()> {
+/// Returns the persisted file's mtime (see [`atomic_write_bytes`]).
+pub(super) fn atomic_write(root: &Path, target: &Path, contents: &str) -> AppResult<Option<u64>> {
     atomic_write_bytes(root, target, contents.as_bytes())
 }
 
 /// Byte-level atomic write — shared by notes (text) and assets (binary).
+/// Returns the persisted file's mtime in epoch milliseconds (`None` when the
+/// platform can't provide one), read from the file handle itself — the index
+/// stamps its rows with this so a later listing compares equal and skips the
+/// re-read.
 ///
 /// The temp file is staged under `.reflect/tmp/`, not next to `target`: the
 /// note directories may live inside a file-sync folder (iCloud Drive —
 /// Plan 21), and a temp created there is synced and, after a crash, stranded
 /// on every device. `.reflect/` is excluded from sync and swept on graph open,
 /// and it shares `target`'s volume, so the final rename stays atomic.
-pub(crate) fn atomic_write_bytes(root: &Path, target: &Path, contents: &[u8]) -> AppResult<()> {
+pub(crate) fn atomic_write_bytes(
+    root: &Path,
+    target: &Path,
+    contents: &[u8],
+) -> AppResult<Option<u64>> {
     let dir = target
         .parent()
         .ok_or_else(|| AppError::io(format!("no parent directory for {}", target.display())))?;
@@ -173,9 +182,10 @@ pub(crate) fn atomic_write_bytes(root: &Path, target: &Path, contents: &[u8]) ->
     let mut tmp = tempfile::NamedTempFile::new_in(&staging)?;
     tmp.write_all(contents)?;
     tmp.as_file().sync_all()?;
-    tmp.persist(target)
+    let file = tmp
+        .persist(target)
         .map_err(|err| AppError::io(err.to_string()))?;
-    Ok(())
+    Ok(file.metadata().ok().as_ref().and_then(modified_ms))
 }
 
 /// Last-modified time in epoch milliseconds, or `None` when the platform

--- a/apps/desktop/src-tauri/src/fs/mod.rs
+++ b/apps/desktop/src-tauri/src/fs/mod.rs
@@ -258,13 +258,17 @@ pub fn note_read(
 
 /// Atomically write a note's markdown by graph-relative path. `generation` pins
 /// the write to the graph it was issued for (see `root_for_generation`).
+/// Returns the written file's on-disk mtime (epoch ms, `None` when the
+/// platform can't provide one) so the caller's index echo can stamp the row
+/// with the value a later `list_files` will report — a `Date.now()` stamp
+/// never matches and costs a re-read on every reconcile.
 #[tauri::command]
 pub fn note_write(
     path: String,
     contents: String,
     generation: u64,
     state: State<GraphState>,
-) -> AppResult<()> {
+) -> AppResult<Option<u64>> {
     let root = root_for_generation(&state, generation)?;
     atomic_write(&root, &resolve(&root, &path)?, &contents)
 }
@@ -284,7 +288,8 @@ pub fn asset_write(
     let bytes = base64::engine::general_purpose::STANDARD
         .decode(contents_base64.as_bytes())
         .map_err(|err| AppError::io(format!("invalid base64 asset payload: {err}")))?;
-    atomic_write_bytes(&root, &resolve(&root, &path)?, &bytes)
+    atomic_write_bytes(&root, &resolve(&root, &path)?, &bytes)?;
+    Ok(())
 }
 
 /// Read a binary asset's bytes, base64-encoded for the JSON IPC (e.g. audio

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -212,6 +212,7 @@ pub fn run() {
             db::index_remove,
             db::index_clear,
             db::index_move,
+            db::index_touch,
             db::note_move_indexed,
             db::index_meta_set,
             db::db_query,

--- a/apps/desktop/src/dev/dev-bridge.ts
+++ b/apps/desktop/src/dev/dev-bridge.ts
@@ -24,6 +24,9 @@ const pathArgsSchema = z.object({ path: z.string() })
 const writeArgsSchema = z.object({ path: z.string(), contents: z.string() })
 const moveArgsSchema = z.object({ from: z.string(), to: z.string() })
 const metaArgsSchema = z.object({ key: z.string(), value: z.string() })
+const touchArgsSchema = z.object({
+  entries: z.array(z.object({ path: z.string(), mtime: z.number() })),
+})
 const applyArgsSchema = z.object({ note: indexedNoteSchema })
 const applyBatchArgsSchema = z.object({ notes: z.array(indexedNoteSchema) })
 const settingsArgsSchema = z.object({ settings: z.record(z.string(), z.unknown()) })
@@ -87,8 +90,7 @@ export function createDevBridge(backend: DevBridgeBackend): IpcBridge {
       }
       case 'note_write': {
         const { path, contents } = writeArgsSchema.parse(args)
-        files.write(path, contents)
-        return null
+        return files.write(path, contents)
       }
       case 'note_exists':
         return files.exists(pathArgsSchema.parse(args).path)
@@ -157,6 +159,12 @@ export function createDevBridge(backend: DevBridgeBackend): IpcBridge {
       case 'index_move': {
         const { from, to } = moveArgsSchema.parse(args)
         index.moveNote(from, to)
+        return null
+      }
+      case 'index_touch': {
+        for (const entry of touchArgsSchema.parse(args).entries) {
+          index.touchNote(entry.path, entry.mtime)
+        }
         return null
       }
       case 'index_clear': {

--- a/apps/desktop/src/dev/dev-file-store.ts
+++ b/apps/desktop/src/dev/dev-file-store.ts
@@ -20,7 +20,9 @@ export interface DevFileStore {
   /** A note's markdown, or `null` when the path doesn't exist. */
   read: (path: string) => string | null
   exists: (path: string) => boolean
-  write: (path: string, contents: string) => void
+  /** Write a file and return the `modifiedMs` it was stamped with (the
+   * `note_write` contract: the caller's index echo carries this stamp). */
+  write: (path: string, contents: string) => number
   /** Delete a path; a missing path is a no-op (mirrors trashing semantics). */
   remove: (path: string) => void
   /** Rename a file; refuses (returns false) when the destination exists. */
@@ -67,7 +69,9 @@ export function createDevFileStore(seed: Record<string, string>): DevFileStore {
     read: (path) => files.get(path)?.contents ?? null,
     exists: (path) => files.has(path),
     write: (path, contents) => {
-      files.set(path, { contents, modifiedMs: Date.now() })
+      const modifiedMs = Date.now()
+      files.set(path, { contents, modifiedMs })
+      return modifiedMs
     },
     remove: (path) => {
       files.delete(path)

--- a/apps/desktop/src/dev/dev-index-db.ts
+++ b/apps/desktop/src/dev/dev-index-db.ts
@@ -16,6 +16,8 @@ export interface DevIndexDb {
   removeNote: (path: string) => void
   /** Re-key every row from `from` to `to` (`index_move`); throws when `to` is occupied. */
   moveNote: (from: string, to: string) => void
+  /** Re-stamp a row's `mtime`/`updated_at` (one `index_touch` entry). */
+  touchNote: (path: string, mtime: number) => void
   /** Wipe derived tables, preserving `index_meta` (`index_clear`). */
   clear: () => void
   /** Upsert one `index_meta` key (`index_meta_set`). */
@@ -183,6 +185,10 @@ export async function createDevIndexDb(): Promise<DevIndexDb> {
         db.exec('ROLLBACK')
         throw cause
       }
+    },
+
+    touchNote: (path, mtime) => {
+      run(db, 'UPDATE notes SET mtime = ?, updated_at = ? WHERE path = ?', [mtime, mtime, path])
     },
 
     clear: () => {

--- a/apps/desktop/src/mobile/index-progress-pill.tsx
+++ b/apps/desktop/src/mobile/index-progress-pill.tsx
@@ -26,7 +26,7 @@ export function IndexProgressPill(): ReactElement | null {
   return (
     <div
       role="status"
-      className="flex items-center gap-1.5 rounded-full border border-border bg-surface px-3 py-1 text-xs font-medium shadow-sm"
+      className="flex items-center gap-1.5 rounded-full border border-border bg-surface px-3 py-1 text-xs font-medium tabular-nums shadow-sm"
     >
       <span aria-hidden className="size-1.5 rounded-full bg-accent motion-safe:animate-pulse" />
       Preparing notes… {progress.done.toLocaleString()} of {progress.total.toLocaleString()}

--- a/packages/core/src/graph/commands.ts
+++ b/packages/core/src/graph/commands.ts
@@ -63,10 +63,16 @@ export async function readNote(path: string, generation?: number): Promise<strin
  * Atomically write a note's markdown by graph-relative path. `generation` (from
  * `GraphInfo`) pins the write to the graph it was issued for — Rust rejects it
  * if the graph switched in between.
+ *
+ * The echo carries the file's on-disk mtime, which Rust returns from the
+ * write: the index row it produces must compare equal to a later `listFiles`
+ * mtime, or the reconcile's read-free skip never fires and the note is
+ * re-read on every pass. `Date.now()` is a fallback for a platform that
+ * can't report one.
  */
 export async function writeNote(path: string, contents: string, generation: number): Promise<void> {
-  await call('note_write', { path, contents, generation }, voidSchema)
-  echoLocalWrite({ path, kind: 'upsert', modifiedMs: Date.now() })
+  const modifiedMs = await call('note_write', { path, contents, generation }, z.number().nullable())
+  echoLocalWrite({ path, kind: 'upsert', modifiedMs: modifiedMs ?? Date.now() })
 }
 
 /**

--- a/packages/core/src/indexing/commands.ts
+++ b/packages/core/src/indexing/commands.ts
@@ -69,6 +69,32 @@ export async function moveNoteIndexed(
   await call('note_move_indexed', { from, to, generation }, voidSchema)
 }
 
+/** One {@link touchIndexedNotes} entry: re-stamp `path`'s stored mtime. */
+export interface IndexedNoteTouch {
+  /** Graph-relative markdown path. */
+  readonly path: string
+  /** The file's listed on-disk mtime (epoch ms). */
+  readonly mtime: number
+}
+
+/**
+ * Re-stamp stored mtimes for notes whose content already matches disk (for
+ * `generation`). The reconcile's self-heal: a row written from a local write
+ * echo carries an echo-time stamp that never equals the listed mtime, and a
+ * hash-match skip leaves it in place — without this repair the file is
+ * re-read and re-hashed on every future pass. One Rust transaction per call;
+ * an empty batch never touches the backend.
+ */
+export async function touchIndexedNotes(
+  entries: readonly IndexedNoteTouch[],
+  generation: number,
+): Promise<void> {
+  if (entries.length === 0) {
+    return
+  }
+  await call('index_touch', { entries, generation }, voidSchema)
+}
+
 /** Wipe all derived tables (precedes a full rebuild; for `generation`). */
 export async function clearIndex(generation: number): Promise<void> {
   await call('index_clear', { generation }, voidSchema)

--- a/packages/core/src/indexing/indexer.ts
+++ b/packages/core/src/indexing/indexer.ts
@@ -8,6 +8,8 @@ import {
   moveIndexedRows,
   removeFromIndex,
   setIndexMeta,
+  touchIndexedNotes,
+  type IndexedNoteTouch,
 } from './commands'
 import { assetReferencingNotePaths } from './asset-refs'
 import { gatherAssetDescriptionText } from './asset-description-text'
@@ -229,6 +231,47 @@ export function createIndexApplyBatch(
   }
 }
 
+/** A shared accumulator for mtime re-stamps — see {@link createMtimeTouchBatch}. */
+export interface MtimeTouchBatch {
+  /** Queue a re-stamp; flushes automatically at the transaction cap. */
+  add: (entry: IndexedNoteTouch) => Promise<void>
+  /** Apply everything still queued. Safe to call repeatedly. */
+  flush: () => Promise<void>
+  /** Re-stamps actually written so far. */
+  applied: () => number
+}
+
+/**
+ * Accumulate mtime re-stamps for hash-match skips (the self-heal for rows
+ * whose stored mtime was an echo-time stamp — see {@link touchIndexedNotes})
+ * and apply them in shared `index_touch` transactions of
+ * {@link INDEX_APPLY_BATCH_SIZE}. Both bulk skip paths (reconcile, watcher
+ * batch) share this shape, mirroring {@link createIndexApplyBatch}.
+ */
+export function createMtimeTouchBatch(generation: number): MtimeTouchBatch {
+  let batch: IndexedNoteTouch[] = []
+  let appliedCount = 0
+  async function flush(): Promise<void> {
+    if (batch.length === 0) {
+      return
+    }
+    const entries = batch
+    batch = []
+    await touchIndexedNotes(entries, generation)
+    appliedCount += entries.length
+  }
+  return {
+    add: async (entry) => {
+      batch.push(entry)
+      if (batch.length >= INDEX_APPLY_BATCH_SIZE) {
+        await flush()
+      }
+    },
+    flush,
+    applied: () => appliedCount,
+  }
+}
+
 /**
  * Full rebuild: wipe derived tables and re-index every markdown file. Used for
  * explicit repair / schema-bump triggers, not the hot graph-switch path (that's
@@ -293,8 +336,10 @@ export async function syncIndex(options: IndexPassOptions): Promise<void> {
  * Two skip layers keep a repeat pass over a large, mostly-unchanged graph
  * cheap: a file whose listed mtime matches its indexed row is never even read
  * ({@link matchesTrustedMtime}), and a read whose hash matches skips the
- * write. Changed notes apply in shared `index_apply_batch` transactions
- * rather than one round-trip each.
+ * write — re-stamping the row's mtime when it disagreed with the listing, so
+ * the mismatch (e.g. an echo-time stamp from a local write) can't cost a
+ * re-read on every future pass. Changed notes apply in shared
+ * `index_apply_batch` transactions rather than one round-trip each.
  */
 export async function reconcileIndex(options: IndexPassOptions): Promise<void> {
   const { generation, signal, onMoved, onSkippedNote, onFileProgress } = options
@@ -353,6 +398,7 @@ export async function reconcileIndex(options: IndexPassOptions): Promise<void> {
 
   const now = Date.now()
   const batch = createIndexApplyBatch(generation, onSkippedNote)
+  const touches = createMtimeTouchBatch(generation)
   let done = 0
   for (const file of files) {
     if (signal?.aborted) {
@@ -390,6 +436,12 @@ export async function reconcileIndex(options: IndexPassOptions): Promise<void> {
     }
     const fileHash = await hashContent(content)
     if (facts?.fileHash === fileHash) {
+      // Content unchanged. If the stored mtime doesn't match the listing (an
+      // echo-time stamp, or a provider rewrote it), re-stamp it so the next
+      // pass takes the read-free path — left alone it mismatches forever.
+      if (facts.mtime !== file.modifiedMs) {
+        await touches.add({ path: file.path, mtime: file.modifiedMs })
+      }
       continue // unchanged
     }
     if (signal?.aborted) {
@@ -398,6 +450,7 @@ export async function reconcileIndex(options: IndexPassOptions): Promise<void> {
     await batch.add(await buildNoteProjection(file.path, content, { fileHash, mtime: file.modifiedMs }))
   }
   await batch.flush()
+  await touches.flush()
   onFileProgress?.(files.length, files.length)
 
   for (const path of stored.keys()) {

--- a/packages/core/src/indexing/live.ts
+++ b/packages/core/src/indexing/live.ts
@@ -5,7 +5,12 @@ import { moveIndexedRows, removeFromIndex } from './commands'
 import { subscribeFileChanges, type FileChange } from './file-changes'
 import { hashContent, matchesTrustedMtime } from './hash'
 import { emitIndexApplied } from './index-applied'
-import { buildNoteProjection, createIndexApplyBatch, indexNote } from './indexer'
+import {
+  buildNoteProjection,
+  createIndexApplyBatch,
+  createMtimeTouchBatch,
+  indexNote,
+} from './indexer'
 import { detectExternalMoves } from './move-healing'
 import { INDEX_PASS_YIELD_EVERY, yieldToEventLoop } from './pacing'
 import { getIndexedFileFactsByPath, getNoteIdsByPath, type IndexedFileFacts } from './queries'
@@ -163,6 +168,7 @@ export async function applyIndexChanges(
       changeByPath.get(skipped.path) ?? { path: skipped.path, kind: 'upsert' },
     )
   })
+  const touches = createMtimeTouchBatch(generation)
 
   let done = 0
   for (const change of notes) {
@@ -189,7 +195,13 @@ export async function applyIndexChanges(
       const content = await readNote(change.path)
       const fileHash = await hashContent(content)
       if (facts?.fileHash === fileHash) {
-        continue // content unchanged; only the mtime moved
+        // Content unchanged; only the mtime moved. Re-stamp the row so the
+        // next pass skips the read — a stored echo-time stamp never matches
+        // and would cost this read on every reconcile and every batch.
+        if (change.modifiedMs !== undefined && facts.mtime !== change.modifiedMs) {
+          await touches.add({ path: change.path, mtime: change.modifiedMs })
+        }
+        continue
       }
       await batch.add(
         await buildNoteProjection(change.path, content, {
@@ -202,7 +214,10 @@ export async function applyIndexChanges(
     }
   }
   await batch.flush()
-  return mutations + batch.applied()
+  await touches.flush()
+  // Re-stamps count as mutations: `updated_at` moved, so recency-ordered
+  // queries may return different rows and the caller must invalidate.
+  return mutations + batch.applied() + touches.applied()
 }
 
 /**

--- a/packages/core/src/indexing/local-write-echo.test.ts
+++ b/packages/core/src/indexing/local-write-echo.test.ts
@@ -48,6 +48,25 @@ describe('local write echo (Plan 19, decision 5)', () => {
     unlisten()
   })
 
+  it('stamps the echo with the on-disk mtime the write returned', async () => {
+    // The reconcile's read-free skip compares the stored row's mtime against
+    // the file listing — only the write's own on-disk stamp can ever match.
+    setBridge({
+      invoke: async (command) => (command === 'note_write' ? 1_234 : null),
+      listen: async () => () => {},
+    })
+    setLocalWriteEcho(true)
+    const seen: FileChange[][] = []
+    const unlisten = await subscribeFileChanges((changes) => {
+      seen.push(changes)
+    })
+
+    await writeNote('notes/a.md', 'hello', 1)
+
+    expect(seen).toEqual([[{ path: 'notes/a.md', kind: 'upsert', modifiedMs: 1_234 }]])
+    unlisten()
+  })
+
   it('stays silent when disabled (the desktop default — the watcher covers it)', async () => {
     fakeBridge()
     const handler = vi.fn()

--- a/packages/core/src/indexing/pipeline.test.ts
+++ b/packages/core/src/indexing/pipeline.test.ts
@@ -242,6 +242,39 @@ describe('applyIndexChanges (watcher dispatch)', () => {
     const commands = mockInvoke.mock.calls.map(([cmd]) => cmd)
     expect(commands).not.toContain('note_read')
     expect(commands).not.toContain('index_apply_batch')
+    expect(commands).not.toContain('index_touch')
+  })
+
+  it('re-stamps the stored mtime when content is unchanged but the mtime moved', async () => {
+    const content = '# same content\n'
+    mockInvoke.mockImplementation(async (command, args) => {
+      const sql = String(args['sql'] ?? '')
+      if (command === 'db_query' && sql.includes('file_hash')) {
+        return [{ path: 'notes/a.md', file_hash: await hashContent(content), mtime: 1_000 }]
+      }
+      if (command === 'db_query') {
+        return []
+      }
+      if (command === 'note_read') {
+        return content
+      }
+      return null
+    })
+
+    const mutations = await applyIndexChanges(
+      [{ path: 'notes/a.md', kind: 'upsert', modifiedMs: 2_000 }],
+      9,
+    )
+
+    // The re-stamp counts as a mutation: `updated_at` moved, so
+    // recency-ordered queries must be invalidated.
+    expect(mutations).toBe(1)
+    const touch = mockInvoke.mock.calls.find(([cmd]) => cmd === 'index_touch')
+    expect(touch![1]).toEqual({
+      entries: [{ path: 'notes/a.md', mtime: 2_000 }],
+      generation: 9,
+    })
+    expect(mockInvoke.mock.calls.map(([cmd]) => cmd)).not.toContain('index_apply_batch')
   })
 
   it('still reads when the reported mtime is too fresh to trust', async () => {
@@ -433,6 +466,7 @@ describe('reconcileIndex mtime skip', () => {
     const commands = mockInvoke.mock.calls.map(([cmd]) => cmd)
     expect(commands).not.toContain('note_read')
     expect(commands).not.toContain('index_apply_batch')
+    expect(commands).not.toContain('index_touch')
   })
 
   it('reads (and hash-skips) when the stored mtime differs — providers rewrite mtimes', async () => {
@@ -460,6 +494,13 @@ describe('reconcileIndex mtime skip', () => {
     expect(commands).toContain('note_read')
     // Identical content under a rewritten mtime: the hash still gates the write.
     expect(commands).not.toContain('index_apply_batch')
+    // The self-heal: the row is re-stamped with the listed mtime, so the next
+    // pass skips the read entirely instead of re-hashing forever.
+    const touch = mockInvoke.mock.calls.find(([cmd]) => cmd === 'index_touch')
+    expect(touch![1]).toEqual({
+      entries: [{ path: 'notes/a.md', mtime: 2_000 }],
+      generation: 4,
+    })
   })
 })
 


### PR DESCRIPTION
## Problem

Every open (and every foreground resume) of the iOS app shows the "Preparing notes… N of M" pill, counting through the entire graph. The pill is wired to every index pass, and the design assumed a repeat pass would skip everything via the mtime fast-path and finish before it's noticeable. It doesn't, because the fast-path is permanently broken for any note edited in-app:

- `writeNote`'s local write echo stamped the index row with JS `Date.now()`, not the file's on-disk mtime — the values essentially never match the next `list_files` listing.
- When a pass then re-reads the file and finds the content hash unchanged, it skipped **without repairing the stored mtime** — so the mismatch survives forever, and every previously-edited note is re-read and re-hashed over IPC on every launch, every resume, and every watcher batch.

## Changes

- **`note_write` returns the persisted file's on-disk mtime** (from the persisted file handle; `None` when the platform can't provide one). `writeNote` stamps its echo with it, so freshly-written rows match the next listing and take the read-free skip.
- **New `index_touch` command** (generation-gated, one transaction per batch): when a pass finds a file's hash unchanged but the stored mtime differing from the listing, it re-stamps `mtime`/`updated_at` instead of skipping silently. Wired into both bulk skip paths — the open-path reconcile and watcher batches — via a shared `createMtimeTouchBatch` accumulator (mirrors `createIndexApplyBatch`). Existing mismatches self-heal on the first pass after upgrade. In the live path a re-stamp counts as a mutation, since `updated_at` feeds recency-ordered queries.
- **Browser dev bridge** mirrors both: `note_write` returns the store's stamp, `index_touch` updates the wasm index (keeps the `?platform=ios` harness from rotting).
- **The progress pill uses `tabular-nums`** so the incrementing count doesn't change width.

`atomic_write_bytes` now returns the mtime; call sites that used it as a tail expression (`shadow.rs`, `archive.rs`, `asset_write`) discard it explicitly.

## Testing

- New/extended vitest coverage: echo carries the returned mtime (null falls back to `Date.now()`); reconcile hash-skip issues `index_touch` with the listed mtime and pure mtime-skips don't; watcher-batch hash-skip re-stamps and counts a mutation.
- New Rust test: `touch_note` re-stamps `mtime`/`updated_at` and never resurrects a removed row.
- `cargo test -p reflect-open` (241 passed), core indexing+graph vitest suites (273 passed), `pnpm check` clean, all after rebasing onto `next`.
- Browser smoke test of the `?platform=ios` harness: boots, index populates, no unknown-command errors.

## Risk

The touch runs only when content already hashes identical to the stored row, and an `UPDATE` on a missing path is a no-op, so it can't resurrect deletions or clobber newer projections — a racing write that lands after the touch re-heals on the next pass. Worst case on failure is the status quo (re-read next pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core index reconcile/live paths and IPC contracts (`note_write` return type); behavior is gated on hash equality and no-op UPDATEs for missing rows, but incorrect touch logic could affect recency-ordered UI until the next full apply.
> 
> **Overview**
> Fixes repeat index passes (e.g. iOS “Preparing notes…”) re-reading every in-app-edited note because stored `mtime` never matched `list_files`.
> 
> **`note_write`** now returns the persisted file’s on-disk mtime (from the write handle); **`writeNote`** stamps the local write echo with that value instead of `Date.now()`, so new rows can take the read-free mtime skip on the next pass.
> 
> Adds generation-gated **`index_touch`** / **`touch_note`** to update `mtime` and `updated_at` only (no projection change). When reconcile or watcher batches find unchanged content by hash but a mismatched stored mtime, they batch re-stamps via **`createMtimeTouchBatch`**—healing legacy echo-time stamps and provider mtime rewrites. Live watcher path counts touches as mutations so recency queries invalidate.
> 
> **`atomic_write_bytes`** returns `Option<u64>` mtime; conflict/archive callers propagate errors explicitly. Dev bridge mirrors `note_write` return + `index_touch`. Progress pill gets **`tabular-nums`** for stable width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe97d908414a615185586d2bbbe073513f0c6ae6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->