### PR TITLE
Fix iOS lightbox image opener

### DIFF
--- a/apps/desktop/src-tauri/src/fs/mod.rs
+++ b/apps/desktop/src-tauri/src/fs/mod.rs
@@ -321,9 +321,32 @@ pub fn asset_open(
     if !abs.is_file() {
         return Err(AppError::not_found(format!("asset not found: {path}")));
     }
+    open_asset_path(&app, &abs)
+}
+
+#[cfg(target_os = "ios")]
+fn open_asset_path(app: &tauri::AppHandle, path: &Path) -> AppResult<()> {
+    let url = asset_file_url(path)?;
     app.opener()
-        .open_path(abs.to_string_lossy().into_owned(), None::<&str>)
+        .open_url(url.as_str(), None::<&str>)
         .map_err(|err| AppError::io(err.to_string()))
+}
+
+#[cfg(not(target_os = "ios"))]
+fn open_asset_path(app: &tauri::AppHandle, path: &Path) -> AppResult<()> {
+    app.opener()
+        .open_path(path.to_string_lossy().into_owned(), None::<&str>)
+        .map_err(|err| AppError::io(err.to_string()))
+}
+
+#[cfg(any(target_os = "ios", test))]
+fn asset_file_url(path: &Path) -> AppResult<tauri::Url> {
+    tauri::Url::from_file_path(path).map_err(|()| {
+        AppError::io(format!(
+            "failed to convert asset path to file URL: {}",
+            path.display()
+        ))
+    })
 }
 
 /// List every file (any extension) under a graph-relative directory, e.g.
@@ -536,7 +559,7 @@ pub(crate) fn note_files(root: &Path) -> AppResult<Vec<FileMeta>> {
 
 #[cfg(test)]
 mod move_tests {
-    use super::{ensure_asset_path, move_note_file};
+    use super::{asset_file_url, ensure_asset_path, move_note_file};
     use std::fs;
 
     fn graph() -> tempfile::TempDir {
@@ -593,5 +616,14 @@ mod move_tests {
         assert!(ensure_asset_path("notes/cat.png").is_err());
         assert!(ensure_asset_path("assets/").is_err());
         assert!(ensure_asset_path("assets").is_err());
+    }
+
+    #[test]
+    fn asset_file_url_percent_encodes_local_paths() {
+        let path = std::env::temp_dir().join("Reflect Cat Photo.png");
+        let url = asset_file_url(&path).unwrap();
+
+        assert_eq!(url.scheme(), "file");
+        assert!(url.as_str().contains("Reflect%20Cat%20Photo.png"));
     }
 }


### PR DESCRIPTION
## Problem

The image lightbox's Open button routes through `asset_open`, which used `tauri-plugin-opener`'s `open_path` path on every platform. On iOS, the opener plugin bridge expects URL-shaped arguments for its native `open` method, so a local filesystem path can be rejected before anything visible happens. The user experience is a tap that appears to do nothing.

## Before -> After

| Before | After |
| --- | --- |
| `asset_open` passed the resolved asset path to `open_path` on iOS. | iOS converts the resolved asset path to an encoded `file://` URL and opens it via the plugin's URL opener. |
| Desktop and other platforms opened assets through the OS path opener. | Desktop and other non-iOS platforms keep the existing `open_path` behavior. |

## Changes

1. Split `asset_open` through a small `open_asset_path` helper with an iOS-specific implementation.
2. Added `asset_file_url` to convert local paths through `tauri::Url::from_file_path`, preserving spaces and other characters as valid file URL escapes.
3. Added a focused Rust regression test for encoded local file URLs.

## Verification

- `pnpm --filter @reflect/desktop sidecar` passed.
- `cargo test -p reflect-open asset_file_url_percent_encodes_local_paths` passed.
- `cargo check -p reflect-open --target aarch64-apple-ios-sim` passed.
- `pnpm --filter @reflect/desktop test -- src/editor/note-editor.test.tsx` passed.
- `pnpm check` passed.
- `git diff --check` passed.

## Risk / Rollout

Low risk. The behavior change is scoped to iOS asset opening, with non-iOS platforms preserving the existing path opener. No migrations or data changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Change is limited to iOS asset opening in fs/mod.rs; non-iOS behavior is unchanged and there are no data or auth implications.
> 
> **Overview**
> Fixes the image lightbox **Open** action on iOS, where `asset_open` previously passed a raw filesystem path to `tauri-plugin-opener`'s `open_path` and the native bridge rejected it so taps did nothing.
> 
> `asset_open` now delegates to **`open_asset_path`**, which on **iOS** builds a percent-encoded `file://` URL via **`asset_file_url`** (`tauri::Url::from_file_path`) and calls **`open_url`**. **Desktop and other platforms** still use **`open_path`** unchanged.
> 
> Adds a Rust test that paths with spaces encode correctly in the file URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99a46072c707222ae24efc8263860e3400665154. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how assets are opened on iOS so local files now launch reliably using a proper file URL.
  * Fixed path handling so spaces and other special characters are correctly percent-encoded when opening local files.
  * Non-iOS platforms continue to open assets as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->