### PR TITLE
feat(ios): land the daily double-tap caret at the end of today's note

### DIFF
--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -33,6 +33,13 @@ interface NotePaneProps {
   lazy?: boolean
   /** Focus the editor when it mounts (the navigated-to day/note). */
   autoFocus?: boolean
+  /**
+   * Where the caret lands when {@link autoFocus} applies: the document start
+   * (default — a seeded new note's empty H1, so typing names the note) or the
+   * end of the note's content (append-style capture, e.g. the mobile daily
+   * double-tap).
+   */
+  autoFocusSelection?: 'start' | 'end'
   /** Called once the autofocus actually happened (the editor mounted). */
   onAutoFocused?: () => void
   /**
@@ -99,6 +106,7 @@ export function NotePaneComponent({
   path,
   lazy = false,
   autoFocus = false,
+  autoFocusSelection = 'start',
   onAutoFocused,
   className,
   editorClassName,
@@ -184,13 +192,17 @@ export function NotePaneComponent({
         registerHandle?.(dailyDate, handle)
       }
       if (handle && autoFocus) {
-        // The caret lands at the document start — for a seeded new note
-        // that is the empty H1, so typing names the note.
+        // By default the caret lands at the document start — for a seeded
+        // new note that is the empty H1, so typing names the note. An `end`
+        // selection moves it (and the scroll) to the note's content end.
         handle.focus()
+        if (autoFocusSelection === 'end') {
+          handle.setSelection('end')
+        }
         onAutoFocused?.()
       }
     },
-    [bindEditor, path, dailyDate, registerHandle, autoFocus, onAutoFocused],
+    [bindEditor, path, dailyDate, registerHandle, autoFocus, autoFocusSelection, onAutoFocused],
   )
 
   const aiMenu = useEditorAiMenu({

--- a/apps/desktop/src/mobile/day-slide.tsx
+++ b/apps/desktop/src/mobile/day-slide.tsx
@@ -26,7 +26,10 @@ interface DaySlideProps {
    * tapped while already there): the selected slide re-anchors to the top.
    */
   scrollResetSeq: number
-  /** True when this slide's editor should focus as soon as its handle exists. */
+  /**
+   * True when this slide's editor should focus as soon as its handle exists —
+   * caret at the end of the day's content (the double-tap capture gesture).
+   */
   focusRequested: boolean
   /** Called after the focus request has been applied. */
   onFocusConsumed: () => void
@@ -69,8 +72,14 @@ export function DaySlide({
     if (!selected) {
       return
     }
+    if (focusRequested) {
+      // A focus arrival (the Daily tab double-tap) anchors to the caret at
+      // the note's end — jumping to the top would yank the scroll away from
+      // the selection the editor just placed.
+      return
+    }
     resetToTop()
-  }, [scrollResetSeq, selected, resetToTop])
+  }, [scrollResetSeq, selected, focusRequested, resetToTop])
 
   return (
     <div
@@ -98,6 +107,9 @@ export function DaySlide({
           path={dailyPath(day)}
           lazy
           autoFocus={focusRequested}
+          // V1's double-tap-to-today is a capture gesture: the caret (and the
+          // scroll) land at the end of the day's content, ready to append.
+          autoFocusSelection="end"
           onAutoFocused={onFocusConsumed}
           showBacklinks={false}
           gutterClassName={MOBILE_CONTENT_GUTTER}

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -49,6 +49,7 @@ globalThis.matchMedia ??= ((query: string) => ({
 
 const editorProbe = vi.hoisted(() => ({
   focusCalls: 0,
+  selectionCalls: [] as Array<'start' | 'end'>,
 }))
 
 vi.mock('@/editor/note-editor', async () => {
@@ -71,7 +72,9 @@ vi.mock('@/editor/note-editor', async () => {
           focus: () => {
             editorProbe.focusCalls += 1
           },
-          setSelection: () => {},
+          setSelection: (position: 'start' | 'end') => {
+            editorProbe.selectionCalls.push(position)
+          },
           getSelectedText: () => '',
           openSelectionMenu: () => {},
           startPendingReplacement: () => false,
@@ -141,6 +144,7 @@ afterEach(() => {
 beforeEach(() => {
   files = {}
   editorProbe.focusCalls = 0
+  editorProbe.selectionCalls = []
   mockInvoke.mockReset()
   mockInvoke.mockImplementation(async (command, args) => {
     if (command === 'note_read') {
@@ -356,6 +360,8 @@ describe('MobileShell', () => {
     await waitFor(() => {
       expect(editorProbe.focusCalls).toBe(1)
     })
+    // A note arrival keeps the default caret placement (the document start).
+    expect(editorProbe.selectionCalls).toEqual([])
   })
 
   it('switches tabs: All shows the searchable list, Daily returns to the last-open day', async () => {
@@ -379,7 +385,7 @@ describe('MobileShell', () => {
     )
   })
 
-  it('double-tapping Daily opens today and focuses the daily editor', async () => {
+  it('double-tapping Daily opens today and focuses the daily editor at its end', async () => {
     const user = userEvent.setup()
     const today = todayIso()
     const other = otherDayInWeek(today)
@@ -405,9 +411,35 @@ describe('MobileShell', () => {
         view.getByRole('button', { name: dayCellLabel(today) }).getAttribute('aria-current'),
       ).toBe('date')
     })
+    // The capture gesture: focus with the caret at the end of today's content.
     await waitFor(() => {
       expect(editorProbe.focusCalls).toBe(1)
     })
+    expect(editorProbe.selectionCalls).toEqual(['end'])
+  })
+
+  it('double-tapping Daily while already on today focuses the editor at its end', async () => {
+    const today = todayIso()
+    files[`daily/${today}.md`] = 'first thought'
+    const view = mount({ kind: 'today' })
+    await waitFor(() => {
+      const editors = view.getAllByTestId('fake-editor')
+      expect(editors.some((editor) => editor.textContent?.includes('first thought'))).toBe(true)
+    })
+
+    let fakeNow = 1_000
+    const now = vi.spyOn(Date, 'now').mockImplementation(() => fakeNow)
+    fireEvent.click(view.getByRole('button', { name: 'Daily' }))
+    fakeNow = 1_100
+    fireEvent.click(view.getByRole('button', { name: 'Daily' }))
+    now.mockRestore()
+
+    // A date-preserving focus arrival: the caret lands at the end (the
+    // re-anchor-to-top of a plain re-arrival must not fire over it).
+    await waitFor(() => {
+      expect(editorProbe.focusCalls).toBe(1)
+    })
+    expect(editorProbe.selectionCalls).toEqual(['end'])
   })
 
   it('does not jump to today on a single tap of the active Daily tab', async () => {


### PR DESCRIPTION
## Problem

On iOS, double-tapping the Daily tab jumps to today and focuses the editor — but the caret landed at the *start* of the document. The double-tap is a capture gesture ("let me add to today"), so landing at the top of an already-written note meant scrolling down and tapping the end before typing.

## Before → After

| | Before | After |
|---|---|---|
| Daily tab double-tap | Focus today's note, caret at document start, view anchored to top | Focus today's note, caret at the end of the content, view scrolled to the caret |
| Wiki-link / backlink / `+` note arrivals | Caret at document start | Unchanged |

## Changes

1. **`NotePane` grows an `autoFocusSelection` prop** (`'start' | 'end'`, default `'start'`). On an autofocus arrival it calls `handle.focus()` and, for `'end'`, `handle.setSelection('end')` — the same idiom desktop's daily stream uses for cross-note arrow navigation (`setSelection` also scrolls the caret into view). The default keeps the seeded-new-note flow intact: focusing the empty H1 so typing names the note.
2. **`DaySlide` passes `autoFocusSelection="end"`.** The daily surface's only `focusEditor` arrival is the shell's double-tap, so this is exactly the capture gesture.
3. **`DaySlide` skips its re-anchor-to-top on focus arrivals.** A same-date double-tap (e.g. All tab → double-tap Daily while today was the last daily route) bumps `scrollResetSeq` *and* requests focus in the same commit; `resetToTop()` runs in a passive effect after the ref-attach focus, so without the guard it would yank the scroll back to the top and leave the caret offscreen at the bottom. The calendar strip still re-centers (the reset seq itself is untouched).

## Tests

`mobile-screen.test.tsx` (the shell integration suite, real router → shell → NotePane over a fake bridge):

- Double-tap from the All tab now also asserts `setSelection('end')` fires exactly once with focus.
- New: double-tap while already on today (the date-preserving arrival that also bumps the reset seq) focuses at the end.
- The wiki-link focus-restore test now pins that note arrivals keep the default caret placement (no `setSelection` call).

## Verification

- `pnpm vitest --run src/mobile/mobile-screen.test.tsx` — 25 passed
- `pnpm vitest --run src/components/route-content.test.tsx src/mobile/screens/note.test.tsx src/mobile/use-scroll-restore.test.ts` — 24 passed
- `pnpm check` (typecheck + oxlint + eslint) — clean

Not run: on-device pass (simulator/device check of the keyboard raise + scroll-to-end feel is owed).

## Risk / Rollout

Frontend-only, no data or IPC changes. The `'start'` default means every other `NotePane` call site is behavior-identical; the only new moving part is the reset-vs-caret guard, which is scoped to focus arrivals on the mobile daily slide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only focus/scroll behavior with a default-preserving prop; no IPC or persistence changes.
> 
> **Overview**
> **iOS Daily double-tap** is treated as append-to-today capture: when the daily editor autofocuses from that gesture, the caret (and scroll) land at the **end** of the day's content instead of the document start.
> 
> `NotePane` adds optional **`autoFocusSelection`** (`'start' | 'end'`, default `'start'`). On autofocus it still calls `focus()`; when `'end'`, it also calls `handle.setSelection('end')` (same pattern as desktop's daily stream for cross-day navigation). Other arrivals (wiki-links, new notes) stay at the start.
> 
> `DaySlide` passes **`autoFocusSelection="end"`** for its focus request and **skips the scroll re-anchor-to-top** when `focusRequested` is true, so a same-commit double-tap does not scroll back to the top after the editor places the caret at the bottom.
> 
> Integration tests record `setSelection` on the fake editor and cover double-tap from All, double-tap while already on today, and that note arrivals do not call `setSelection`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7932315b92145659f0bcaacb4148ba6a5d6ba4ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->