### PR TITLE
Show GitHub backup settings for iCloud graphs

### DIFF
--- a/apps/desktop/src/components/settings/icloud-section.tsx
+++ b/apps/desktop/src/components/settings/icloud-section.tsx
@@ -63,13 +63,11 @@ function reviewLine(conflictCount: number, forkCount: number): string {
 /**
  * Settings → Sync → iCloud Drive (Plan 21 Phase 1, the desktop leg): see
  * whether the graph syncs through iCloud Drive, and move a local graph into the
- * container. The move copies (count+byte verified), then disconnects the
- * Git backup remote (iCloud sync and a Git remote are mutually exclusive per
- * graph — two merge machines over the same files would fight; the iCloud
- * copy carries no `.git`, so the exclusion holds structurally), then reopens
- * the graph at its iCloud home. Ordered copy-first so a failed copy leaves
- * everything — including the backup — exactly as it was; the original folder
- * stays on disk untouched as the recovery copy either way.
+ * container. The move copies (count+byte verified), then disconnects the old
+ * folder's Git backup remote before reopening the graph at its iCloud home.
+ * Ordered copy-first so a failed copy leaves everything — including the backup
+ * — exactly as it was; the original folder stays on disk untouched as the
+ * recovery copy either way.
  *
  * macOS only — Windows/Linux have no iCloud Drive, and mobile chooses its
  * storage in onboarding.
@@ -203,7 +201,7 @@ export function IcloudSettingsField(): ReactElement | null {
                     Your notes are copied into iCloud Drive and the graph reopens there. The
                     current folder stays on disk, untouched, as a recovery copy.
                     {backupConnected
-                      ? ' GitHub backup is disconnected first — a graph syncs through iCloud or a Git remote, not both.'
+                      ? ' GitHub backup is disconnected from the recovery copy; you can reconnect backup after the iCloud graph opens.'
                       : ''}
                   </DialogDescription>
                 </DialogHeader>

--- a/apps/desktop/src/components/settings/sync-section.test.tsx
+++ b/apps/desktop/src/components/settings/sync-section.test.tsx
@@ -90,7 +90,7 @@ describe('SyncSection', () => {
     expect(within(section).getByRole('button', { name: /connect github/i })).toBeTruthy()
   })
 
-  it('hides GitHub backup when the graph syncs through iCloud', async () => {
+  it('keeps GitHub backup visible when the graph syncs through iCloud', async () => {
     graph.current = {
       root: '/Users/alex/Library/Mobile Documents/iCloud~app/Documents/Notes',
       name: 'Notes',
@@ -103,8 +103,8 @@ describe('SyncSection', () => {
     expect(within(section).getByText('iCloud Drive', { selector: 'legend' })).toBeTruthy()
     expect(await within(section).findByText('All note files are downloaded.')).toBeTruthy()
     expect(within(section).getByText('No notes need review.')).toBeTruthy()
-    expect(within(section).queryByText('GitHub backup')).toBeNull()
-    expect(within(section).queryByRole('button', { name: /connect github/i })).toBeNull()
+    expect(within(section).getByText('GitHub backup', { selector: 'legend' })).toBeTruthy()
+    expect(within(section).getByRole('button', { name: /connect github/i })).toBeTruthy()
   })
 
   it('surfaces iCloud download and review counts', async () => {

--- a/apps/desktop/src/components/settings/sync-section.tsx
+++ b/apps/desktop/src/components/settings/sync-section.tsx
@@ -1,24 +1,18 @@
 import type { ReactElement } from 'react'
-import { isICloudRoot } from '@/lib/icloud-controller'
-import { isMacosDesktop } from '@/lib/platform'
-import { useGraph } from '@/providers/graph-provider'
 import { BackupSettingsField } from './backup-section'
 import { IcloudSettingsField } from './icloud-section'
 import { SettingsSection } from './section'
 
 /**
- * Settings → Sync: iCloud Drive and Git remote sync live together here. An
- * iCloud-hosted graph hides the GitHub backup controls because a graph syncs
- * through iCloud or a Git remote, not both.
+ * Settings → Sync: iCloud Drive and Git remote sync live together here. Keep
+ * both controls visible so an iCloud-hosted graph can still manage its GitHub
+ * backup.
  */
 export function SyncSection(): ReactElement {
-  const { graph } = useGraph()
-  const iCloudSyncEnabled = isMacosDesktop && graph !== null && isICloudRoot(graph.root)
-
   return (
     <SettingsSection id="sync">
       <IcloudSettingsField />
-      {iCloudSyncEnabled ? null : <BackupSettingsField />}
+      <BackupSettingsField />
     </SettingsSection>
   )
 }


### PR DESCRIPTION
## Problem

When a graph lived in iCloud Drive, Settings -> Sync hid the GitHub backup controls entirely. That made it impossible to connect, inspect, disconnect, or sign out of GitHub backup from the normal settings surface once iCloud sync was active.

This PR keeps the change scoped to settings visibility and copy. It does not change the existing iCloud move flow that copies into iCloud and disconnects the old local recovery folder's backup remote.

## Before -> After

| State | Before | After |
| --- | --- | --- |
| Local graph | iCloud Drive and GitHub backup settings both showed | Same |
| iCloud-hosted graph | GitHub backup settings were hidden | iCloud Drive status and GitHub backup settings both show |
| Move-to-iCloud dialog with backup connected | Claimed iCloud and Git remote sync were mutually exclusive | Explains the old recovery copy is disconnected and backup can be reconnected after opening the iCloud graph |

## Changes

1. `SyncSection` now always renders `BackupSettingsField` beside `IcloudSettingsField`, removing the iCloud-root visibility gate.
2. `sync-section.test.tsx` now pins that an iCloud-hosted graph still shows the GitHub backup legend and Connect GitHub action.
3. `icloud-section.tsx` updates the move dialog/comment copy so it no longer says iCloud and GitHub backup cannot coexist in settings.

## Verification

- `pnpm --filter @reflect/desktop test src/components/settings/sync-section.test.tsx` passed.
- `pnpm check` passed.

## Risk / Rollout

Low-risk UI/settings change. No migrations, sync engine changes, or stored data shape changes. The main behavioral risk is user confusion around the move-to-iCloud flow, which is why the dialog copy now describes the recovery-copy disconnect more precisely.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only visibility and wording changes; no sync engine or data migrations, with minor risk of users misunderstanding the move-to-iCloud backup disconnect step.
> 
> **Overview**
> **Settings → Sync** no longer hides **GitHub backup** when the open graph lives in iCloud Drive. `SyncSection` always renders `BackupSettingsField` next to the iCloud field, so connect/disconnect/sign-out remain available for iCloud graphs.
> 
> Copy in the **move to iCloud** dialog and related comments is updated: it no longer states that iCloud and Git backup are mutually exclusive in settings. It now says backup is disconnected from the **recovery copy** of the old folder and can be **reconnected after** the graph opens in iCloud (the move flow itself is unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 120732e9cb306fa2dea0fdfde5b37629c6739dbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->