### PR TITLE
feat(ios): connect GitHub sync for the local graph

### DIFF
--- a/apps/desktop/src/components/settings/connect-github-dialog.tsx
+++ b/apps/desktop/src/components/settings/connect-github-dialog.tsx
@@ -1,12 +1,4 @@
-import { useState, type ReactElement } from 'react'
-import { openUrl } from '@tauri-apps/plugin-opener'
-import {
-  githubAppInstallUrl,
-  loadGithubAuth,
-  newRepoUrl,
-  type GithubRepoRef,
-  type GithubUser,
-} from '@reflect/core'
+import { type ReactElement } from 'react'
 import { InlineAlert } from '@/components/inline-alert'
 import { GithubAuthStep } from '@/components/settings/github-auth-step'
 import { Button } from '@/components/ui/button'
@@ -18,11 +10,8 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { useAsyncAction } from '@/hooks/use-async-action'
-import { usePoll } from '@/hooks/use-poll'
+import { useConnectGithubWizard, type ConnectWizardStep } from '@/hooks/use-connect-github-wizard'
 import { useRestoreFocus } from '@/hooks/use-restore-focus'
-import { parseRepoInput } from '@/lib/github-repos'
-import { useSync } from '@/providers/sync-provider'
 
 interface ConnectGithubDialogProps {
   /** A suggested name for a newly created backup repo (from the graph name). */
@@ -32,199 +21,27 @@ interface ConnectGithubDialogProps {
   pollIntervalMs?: number
 }
 
-type Step = 'repo' | 'auth' | 'finish'
-
-/** Which credential the sign-in stored — decides the can't-find-repo remedy. */
-type AuthKind = 'app' | 'pat' | null
-
-const STEP_DESCRIPTIONS: Record<Step, string> = {
+const STEP_DESCRIPTIONS: Record<ConnectWizardStep, string> = {
   repo: 'Back up this graph to a private GitHub repository.',
   auth: 'Sign in so Reflect can push your backups.',
   finish: 'Connecting your repository…',
 }
 
 /**
- * The "Connect GitHub" wizard: repository first (creating one needs no
- * credential), then the sign-in (whose instructions can name that exact
- * repository), then the connection — built from the verified sign-in, so
- * the owner is never asked for.
- *
- * Tokens that can create repositories (classic PATs, app tokens) connect in
- * one step: the finish step API-creates silently. Tokens that can't are
- * handed the prefilled github.com/new page while the dialog polls for the
- * repository and connects the moment it exists — there is no "I created it"
- * button to click. Connecting a public repo demands explicit confirmation:
- * every note in the graph, including `private: true` ones, would be
- * world-readable.
- *
- * Granting repository access is a first-class step, not an error. A GitHub App
- * user token only reaches repositories the app is installed on (authorization
- * ≠ installation), and a fresh install is on zero repos — so an app sign-in
- * that can't yet see the repo lands on a plain "grant access" step that polls
- * and connects the moment access is granted (no retry button to press). The
- * step is skipped whenever the repo is already visible, so a graph whose repo
- * the install already covers connects with no detour. The step steers users to
- * grant access to *only the backup repository* — never "All repositories",
- * which would hand the app every repo on the account for no reason. PAT users
- * reach repos by token scope, not an installation, so they get token-scope
- * guidance.
+ * The desktop "Connect GitHub" dialog — a Dialog shell over
+ * {@link useConnectGithubWizard}, which owns the whole flow (repo → sign-in →
+ * connect, with the create-handoff/grant-access polls and the public-repo
+ * consent gate). The mobile drawer renders the same hook; flow changes belong
+ * there, not here.
  */
 export function ConnectGithubDialog({
   suggestedRepoName,
   onClose,
   pollIntervalMs = 3000,
 }: ConnectGithubDialogProps): ReactElement {
-  const { connectNewRepo, connectExistingRepo } = useSync()
-  const action = useAsyncAction()
-  const [step, setStep] = useState<Step>('repo')
-  const [mode, setMode] = useState<'create' | 'existing'>('create')
-  const [repoName, setRepoName] = useState(suggestedRepoName)
-  const [existingRepo, setExistingRepo] = useState('')
-  const [user, setUser] = useState<GithubUser | null>(null)
-  const [authKind, setAuthKind] = useState<AuthKind>(null)
-  const [publicConfirm, setPublicConfirm] = useState<GithubRepoRef | null>(null)
-  /** The finish step's "create it on GitHub" handoff (create-mode only). */
-  const [showCreateGuide, setShowCreateGuide] = useState(false)
-  /**
-   * App sign-in can't see the chosen repo yet (the app isn't installed on it).
-   * Show the "grant access" step and poll until access lands. Skipped when the
-   * repo is already visible — most installs need it, returning ones don't.
-   */
-  const [showGrantAccess, setShowGrantAccess] = useState(false)
+  const wizard = useConnectGithubWizard({ suggestedRepoName, onClose, pollIntervalMs })
 
   useRestoreFocus()
-
-  function targetRef(forUser: GithubUser): GithubRepoRef | null {
-    if (mode === 'existing') {
-      return parseRepoInput(existingRepo)
-    }
-    const name = repoName.trim()
-    return name.length === 0 ? null : { owner: forUser.login, name }
-  }
-
-  // The repo we're trying to reach, resolved from the verified sign-in (the
-  // owner is never typed). Drives both the poll and the grant-access copy.
-  const targetForUser = user !== null ? targetRef(user) : null
-
-  // While the create handoff or the grant-access step is showing, poll for the
-  // repository instead of making the user click a button: the connect fires the
-  // moment the repo exists and the app can see it. A 404 just keeps waiting; a
-  // public repo stops the poll for consent.
-  const pollTarget =
-    (showCreateGuide || showGrantAccess) && publicConfirm === null ? targetForUser : null
-  usePoll(pollTarget !== null, pollIntervalMs, async () => {
-    if (pollTarget === null) {
-      return 'stop'
-    }
-    const result = await connectExistingRepo(pollTarget, { allowPublic: false })
-    if (result === 'connected') {
-      onClose()
-      return 'stop'
-    }
-    if (result === 'needsPublicConfirm') {
-      setPublicConfirm(pollTarget)
-      return 'stop'
-    }
-    return 'continue'
-  })
-
-  async function finish(
-    forUser: GithubUser,
-    options: { allowPublic?: boolean; kind?: AuthKind } = {},
-  ): Promise<void> {
-    // The credential kind is passed in on the first run — its setter fires
-    // in the same tick as the call, before the state commits.
-    const kind = options.kind ?? authKind
-    await action.run(async () => {
-      // Each attempt re-derives the guidance from its own outcome — a stale
-      // create guide or grant-access step from an earlier path must not outlive
-      // the detour (e.g. consent → choose another repo).
-      setShowCreateGuide(false)
-      setShowGrantAccess(false)
-      const ref = publicConfirm ?? targetRef(forUser)
-      if (ref === null) {
-        action.setError(
-          mode === 'existing'
-            ? 'Enter the repository as owner/name or a GitHub URL.'
-            : 'Name the repository.',
-        )
-        setStep('repo')
-        return
-      }
-      const result = await connectExistingRepo(ref, { allowPublic: options.allowPublic ?? false })
-      if (result === 'connected') {
-        onClose()
-        return
-      }
-      if (result === 'needsPublicConfirm') {
-        setPublicConfirm(ref)
-        return
-      }
-      if (mode === 'existing') {
-        // GitHub's 404 can't distinguish "doesn't exist" from "no access". App
-        // sign-ins almost always mean the latter — the app isn't installed on
-        // the repo yet — so granting access is the expected next step, not an
-        // error: show it plainly and let the poll connect the moment access
-        // lands. PAT users reach repos by token scope, not an installation, so
-        // they get token-scope guidance instead.
-        if (kind === 'app') {
-          setShowGrantAccess(true)
-        } else {
-          action.setError(
-            'Repository not found. Check the name and your token’s repository access.',
-          )
-        }
-        return
-      }
-      // A new repo that doesn't exist yet: create it — by API when the token
-      // can, by the guided handoff (plus polling) otherwise.
-      const created = await connectNewRepo(ref.name)
-      if (created === 'connected') {
-        onClose()
-        return
-      }
-      setShowCreateGuide(true)
-    })
-  }
-
-  function continueFromRepo(): void {
-    action.setError(null)
-    if (mode === 'create' && repoName.trim().length === 0) {
-      action.setError('Name the repository.')
-      return
-    }
-    if (mode === 'existing' && parseRepoInput(existingRepo) === null) {
-      action.setError('Enter the repository as owner/name or a GitHub URL.')
-      return
-    }
-    setStep('auth')
-  }
-
-  function onAuthed(authedUser: GithubUser): void {
-    setUser(authedUser)
-    setStep('finish')
-    void loadGithubAuth().then((auth) => {
-      const kind = auth?.kind ?? null
-      setAuthKind(kind)
-      return finish(authedUser, { kind })
-    })
-  }
-
-  /** Back to the repo step — every finish-step dead end must offer this. */
-  function backToRepo(): void {
-    action.setError(null)
-    setPublicConfirm(null)
-    setShowCreateGuide(false)
-    setShowGrantAccess(false)
-    setStep('repo')
-  }
-
-  /** Open in the browser; an opener failure surfaces the URL to visit by hand. */
-  function openExternal(url: string): void {
-    void openUrl(url).catch(() => {
-      action.setError(`Couldn’t open the browser — visit ${url} yourself.`)
-    })
-  }
 
   return (
     <Dialog
@@ -238,26 +55,26 @@ export function ConnectGithubDialog({
       <DialogContent showCloseButton={false} className="max-w-sm">
         <DialogHeader>
           <DialogTitle>Connect GitHub</DialogTitle>
-          <DialogDescription>{STEP_DESCRIPTIONS[step]}</DialogDescription>
+          <DialogDescription>{STEP_DESCRIPTIONS[wizard.step]}</DialogDescription>
         </DialogHeader>
 
-        {step === 'repo' ? (
+        {wizard.step === 'repo' ? (
           <div className="flex flex-col gap-3">
             <div className="flex flex-col gap-2">
               <label className="flex items-center gap-2 text-sm text-text">
                 <input
                   type="radio"
                   name="repo-mode"
-                  checked={mode === 'create'}
-                  onChange={() => setMode('create')}
+                  checked={wizard.mode === 'create'}
+                  onChange={() => wizard.setMode('create')}
                 />
                 Create a new private repository
               </label>
-              {mode === 'create' ? (
+              {wizard.mode === 'create' ? (
                 <Input
                   autoFocus
-                  value={repoName}
-                  onChange={(event) => setRepoName(event.target.value)}
+                  value={wizard.repoName}
+                  onChange={(event) => wizard.setRepoName(event.target.value)}
                   className="ml-6 w-auto"
                   aria-label="New repository name"
                 />
@@ -266,96 +83,88 @@ export function ConnectGithubDialog({
                 <input
                   type="radio"
                   name="repo-mode"
-                  checked={mode === 'existing'}
-                  onChange={() => setMode('existing')}
+                  checked={wizard.mode === 'existing'}
+                  onChange={() => wizard.setMode('existing')}
                 />
                 Use an existing repository
               </label>
-              {mode === 'existing' ? (
+              {wizard.mode === 'existing' ? (
                 <Input
                   autoFocus
-                  value={existingRepo}
-                  onChange={(event) => setExistingRepo(event.target.value)}
+                  value={wizard.existingRepo}
+                  onChange={(event) => wizard.setExistingRepo(event.target.value)}
                   placeholder="owner/name"
                   className="ml-6 w-auto"
                   aria-label="Existing repository"
                 />
               ) : null}
             </div>
-            <Button onClick={continueFromRepo} size="sm">
+            <Button onClick={wizard.continueFromRepo} size="sm">
               Continue
             </Button>
           </div>
         ) : null}
 
-        {step === 'auth' ? (
+        {wizard.step === 'auth' ? (
           <GithubAuthStep
-            onAuthed={onAuthed}
-            repoName={mode === 'create' ? repoName.trim() : undefined}
+            onAuthed={wizard.onAuthed}
+            repoName={wizard.mode === 'create' ? wizard.repoName.trim() : undefined}
           />
         ) : null}
 
-        {step === 'finish' ? (
+        {wizard.step === 'finish' ? (
           <div className="flex flex-col gap-3">
-            {user !== null ? (
+            {wizard.user !== null ? (
               <p className="text-xs text-text-muted">
-                Signed in as <strong className="text-text">{user.login}</strong>
+                Signed in as <strong className="text-text">{wizard.user.login}</strong>
               </p>
             ) : null}
 
-            {publicConfirm !== null ? (
+            {wizard.publicConfirm !== null ? (
               <>
                 <InlineAlert tone="error">
                   <strong>
-                    {publicConfirm.owner}/{publicConfirm.name} is public.
+                    {wizard.publicConfirm.owner}/{wizard.publicConfirm.name} is public.
                   </strong>{' '}
                   Anyone on the internet can read everything in this graph, including notes
                   marked private.
                 </InlineAlert>
                 <div className="flex gap-2">
-                  <Button variant="outline" size="sm" onClick={backToRepo}>
+                  <Button variant="outline" size="sm" onClick={wizard.backToRepo}>
                     Choose another repo
                   </Button>
                   <Button
                     variant="destructive"
                     size="sm"
-                    disabled={action.pending || user === null}
-                    onClick={() => {
-                      if (user !== null) {
-                        void finish(user, { allowPublic: true })
-                      }
-                    }}
+                    disabled={wizard.pending || wizard.user === null}
+                    onClick={wizard.confirmPublic}
                   >
                     Back up to a public repo
                   </Button>
                 </div>
               </>
-            ) : showCreateGuide && user !== null ? (
+            ) : wizard.showCreateGuide && wizard.user !== null ? (
               <>
                 <p className="text-sm text-text">
                   Create{' '}
                   <strong>
-                    {user.login}/{repoName.trim()}
+                    {wizard.user.login}/{wizard.repoName.trim()}
                   </strong>{' '}
                   on GitHub. Reflect will connect it as soon as it exists.
                 </p>
                 <div className="flex gap-2">
-                  <Button size="sm" onClick={() => openExternal(newRepoUrl(repoName.trim()))}>
+                  <Button size="sm" onClick={wizard.openCreatePage}>
                     Create on GitHub…
                   </Button>
-                  <Button variant="outline" size="sm" onClick={backToRepo}>
+                  <Button variant="outline" size="sm" onClick={wizard.backToRepo}>
                     Change repository
                   </Button>
                 </div>
                 <p className="text-xs text-text-muted">Waiting for the repository…</p>
-                {authKind === 'app' ? (
+                {wizard.authKind === 'app' ? (
                   <p className="text-xs text-text-muted">
                     If it doesn’t connect,{' '}
-                    <button
-                      type="button"
-                      className="underline"
-                      onClick={() => openExternal(githubAppInstallUrl())}
-                    >
+                    <button type="button" className="underline" onClick={wizard.openInstallPage}>
                       grant the Reflect app access
                     </button>{' '}
                     to just this repository.
@@ -366,20 +175,20 @@ export function ConnectGithubDialog({
                   </p>
                 )}
               </>
-            ) : showGrantAccess && targetForUser !== null ? (
+            ) : wizard.showGrantAccess && wizard.targetForUser !== null ? (
               <>
                 <p className="text-sm text-text">
                   Give Reflect access to{' '}
                   <strong>
-                    {targetForUser.owner}/{targetForUser.name}
+                    {wizard.targetForUser.owner}/{wizard.targetForUser.name}
                   </strong>{' '}
                   so it can back up here.
                 </p>
                 <div className="flex gap-2">
-                  <Button size="sm" onClick={() => openExternal(githubAppInstallUrl())}>
+                  <Button size="sm" onClick={wizard.openInstallPage}>
                     Grant access on GitHub…
                   </Button>
-                  <Button variant="outline" size="sm" onClick={backToRepo}>
+                  <Button variant="outline" size="sm" onClick={wizard.backToRepo}>
                     Change repository
                   </Button>
                 </div>
@@ -391,19 +200,21 @@ export function ConnectGithubDialog({
                 </p>
                 <p className="text-xs text-text-muted">Waiting for access…</p>
               </>
-            ) : action.pending ? (
+            ) : wizard.pending ? (
               <p className="text-sm text-text-muted">Connecting…</p>
             ) : null}
 
-            {!action.pending && action.error !== null ? (
+            {!wizard.pending && wizard.error !== null ? (
               <>
-                <InlineAlert tone="error">{action.error}</InlineAlert>
-                {publicConfirm === null && !showCreateGuide && !showGrantAccess ? (
+                <InlineAlert tone="error">{wizard.error}</InlineAlert>
+                {wizard.publicConfirm === null &&
+                !wizard.showCreateGuide &&
+                !wizard.showGrantAccess ? (
                   // A failed connect must never strand the user here — offer the
                   // way back to a different repository. (The create guide and
                   // grant-access step render their own escapes, so both are
                   // excluded.)
-                  <Button variant="outline" size="sm" onClick={backToRepo}>
+                  <Button variant="outline" size="sm" onClick={wizard.backToRepo}>
                     Change repository
                   </Button>
                 ) : null}
@@ -412,8 +223,8 @@ export function ConnectGithubDialog({
           </div>
         ) : null}
 
-        {step !== 'finish' && action.error !== null ? (
-          <InlineAlert tone="error">{action.error}</InlineAlert>
+        {wizard.step !== 'finish' && wizard.error !== null ? (
+          <InlineAlert tone="error">{wizard.error}</InlineAlert>
         ) : null}
       </DialogContent>
     </Dialog>

--- a/apps/desktop/src/components/settings/github-auth-step.tsx
+++ b/apps/desktop/src/components/settings/github-auth-step.tsx
@@ -27,9 +27,9 @@ interface GithubAuthStepProps {
 const FIELD_LABEL_CLASS = 'text-xs font-medium text-text-secondary'
 
 /**
- * The shared "sign in to GitHub" step (connect + restore dialogs): the guided
- * device flow when the GitHub App is registered, fine-grained-PAT entry
- * otherwise. Every path ends in a `GET /user` round-trip
+ * The shared "sign in to GitHub" step (desktop's connect dialog and the
+ * mobile connect drawer): the guided device flow when the GitHub App is
+ * registered, fine-grained-PAT entry otherwise. Every path ends in a `GET /user` round-trip
  * ({@link fetchSignedInUser}), so the step only completes with a credential
  * GitHub actually accepts — and the caller learns *who* signed in, which the
  * wizard uses to connect `owner/name` without ever asking for the owner.

--- a/apps/desktop/src/hooks/use-connect-github-wizard.ts
+++ b/apps/desktop/src/hooks/use-connect-github-wizard.ts
@@ -1,0 +1,265 @@
+import { useState } from 'react'
+import { openUrl } from '@tauri-apps/plugin-opener'
+import {
+  githubAppInstallUrl,
+  loadGithubAuth,
+  newRepoUrl,
+  type GithubRepoRef,
+  type GithubUser,
+} from '@reflect/core'
+import { useAsyncAction } from '@/hooks/use-async-action'
+import { usePoll } from '@/hooks/use-poll'
+import { parseRepoInput } from '@/lib/github-repos'
+import { useSync } from '@/providers/sync-provider'
+
+export type ConnectWizardStep = 'repo' | 'auth' | 'finish'
+
+/** Which credential the sign-in stored — decides the can't-find-repo remedy. */
+export type ConnectAuthKind = 'app' | 'pat' | null
+
+export interface ConnectGithubWizardOptions {
+  /** A suggested name for a newly created backup repo. */
+  suggestedRepoName: string
+  /** Called once the repository is connected (the surface dismisses itself). */
+  onClose: () => void
+  /** Delay between repo-existence polls on the create/grant handoffs (test hook). */
+  pollIntervalMs?: number
+}
+
+export interface ConnectGithubWizard {
+  step: ConnectWizardStep
+  mode: 'create' | 'existing'
+  setMode: (mode: 'create' | 'existing') => void
+  repoName: string
+  setRepoName: (name: string) => void
+  existingRepo: string
+  setExistingRepo: (value: string) => void
+  /** The verified sign-in shown on the finish step; null before auth. */
+  user: GithubUser | null
+  authKind: ConnectAuthKind
+  /** Set when the chosen repo is public and needs explicit consent. */
+  publicConfirm: GithubRepoRef | null
+  /** The finish step's "create it on GitHub" handoff (create-mode only). */
+  showCreateGuide: boolean
+  /** App sign-in can't see the repo yet — the "grant access" handoff. */
+  showGrantAccess: boolean
+  /** The repo being targeted, resolved from the verified sign-in. */
+  targetForUser: GithubRepoRef | null
+  pending: boolean
+  error: string | null
+  /** Validate the repo step and advance to sign-in. */
+  continueFromRepo: () => void
+  /** Wire to {@link GithubAuthStep}'s `onAuthed` — advances and connects. */
+  onAuthed: (user: GithubUser) => void
+  /** The public-repo consent button: retry the connect with consent given. */
+  confirmPublic: () => void
+  /** Back to the repo step — every finish-step dead end must offer this. */
+  backToRepo: () => void
+  /** Open the prefilled github.com/new page for the chosen name. */
+  openCreatePage: () => void
+  /** Open the GitHub App installation page (grant repository access). */
+  openInstallPage: () => void
+}
+
+/**
+ * The "Connect GitHub" wizard state machine: repository first (creating one
+ * needs no credential), then the sign-in (whose instructions can name that
+ * exact repository), then the connection — built from the verified sign-in,
+ * so the owner is never asked for. Extracted from rendering so desktop's
+ * dialog and mobile's drawer drive the identical flow.
+ *
+ * Tokens that can create repositories (classic PATs, app tokens) connect in
+ * one step: the finish step API-creates silently. Tokens that can't are
+ * handed the prefilled github.com/new page while the wizard polls for the
+ * repository and connects the moment it exists — there is no "I created it"
+ * button to click. Connecting a public repo demands explicit confirmation:
+ * every note in the graph, including `private: true` ones, would be
+ * world-readable.
+ *
+ * Granting repository access is a first-class step, not an error. A GitHub App
+ * user token only reaches repositories the app is installed on (authorization
+ * ≠ installation), and a fresh install is on zero repos — so an app sign-in
+ * that can't yet see the repo lands on a plain "grant access" step that polls
+ * and connects the moment access is granted (no retry button to press). The
+ * step is skipped whenever the repo is already visible, so a graph whose repo
+ * the install already covers connects with no detour. PAT users reach repos
+ * by token scope, not an installation, so they get token-scope guidance.
+ */
+export function useConnectGithubWizard({
+  suggestedRepoName,
+  onClose,
+  pollIntervalMs = 3000,
+}: ConnectGithubWizardOptions): ConnectGithubWizard {
+  const { connectNewRepo, connectExistingRepo } = useSync()
+  const action = useAsyncAction()
+  const [step, setStep] = useState<ConnectWizardStep>('repo')
+  const [mode, setMode] = useState<'create' | 'existing'>('create')
+  const [repoName, setRepoName] = useState(suggestedRepoName)
+  const [existingRepo, setExistingRepo] = useState('')
+  const [user, setUser] = useState<GithubUser | null>(null)
+  const [authKind, setAuthKind] = useState<ConnectAuthKind>(null)
+  const [publicConfirm, setPublicConfirm] = useState<GithubRepoRef | null>(null)
+  const [showCreateGuide, setShowCreateGuide] = useState(false)
+  const [showGrantAccess, setShowGrantAccess] = useState(false)
+
+  function targetRef(forUser: GithubUser): GithubRepoRef | null {
+    if (mode === 'existing') {
+      return parseRepoInput(existingRepo)
+    }
+    const name = repoName.trim()
+    return name.length === 0 ? null : { owner: forUser.login, name }
+  }
+
+  // The repo we're trying to reach, resolved from the verified sign-in (the
+  // owner is never typed). Drives both the poll and the grant-access copy.
+  const targetForUser = user !== null ? targetRef(user) : null
+
+  // While the create handoff or the grant-access step is showing, poll for the
+  // repository instead of making the user click a button: the connect fires the
+  // moment the repo exists and the app can see it. A 404 just keeps waiting; a
+  // public repo stops the poll for consent.
+  const pollTarget =
+    (showCreateGuide || showGrantAccess) && publicConfirm === null ? targetForUser : null
+  usePoll(pollTarget !== null, pollIntervalMs, async () => {
+    if (pollTarget === null) {
+      return 'stop'
+    }
+    const result = await connectExistingRepo(pollTarget, { allowPublic: false })
+    if (result === 'connected') {
+      onClose()
+      return 'stop'
+    }
+    if (result === 'needsPublicConfirm') {
+      setPublicConfirm(pollTarget)
+      return 'stop'
+    }
+    return 'continue'
+  })
+
+  async function finish(
+    forUser: GithubUser,
+    options: { allowPublic?: boolean; kind?: ConnectAuthKind } = {},
+  ): Promise<void> {
+    // The credential kind is passed in on the first run — its setter fires
+    // in the same tick as the call, before the state commits.
+    const kind = options.kind ?? authKind
+    await action.run(async () => {
+      // Each attempt re-derives the guidance from its own outcome — a stale
+      // create guide or grant-access step from an earlier path must not outlive
+      // the detour (e.g. consent → choose another repo).
+      setShowCreateGuide(false)
+      setShowGrantAccess(false)
+      const ref = publicConfirm ?? targetRef(forUser)
+      if (ref === null) {
+        action.setError(
+          mode === 'existing'
+            ? 'Enter the repository as owner/name or a GitHub URL.'
+            : 'Name the repository.',
+        )
+        setStep('repo')
+        return
+      }
+      const result = await connectExistingRepo(ref, { allowPublic: options.allowPublic ?? false })
+      if (result === 'connected') {
+        onClose()
+        return
+      }
+      if (result === 'needsPublicConfirm') {
+        setPublicConfirm(ref)
+        return
+      }
+      if (mode === 'existing') {
+        // GitHub's 404 can't distinguish "doesn't exist" from "no access". App
+        // sign-ins almost always mean the latter — the app isn't installed on
+        // the repo yet — so granting access is the expected next step, not an
+        // error: show it plainly and let the poll connect the moment access
+        // lands. PAT users reach repos by token scope, not an installation, so
+        // they get token-scope guidance instead.
+        if (kind === 'app') {
+          setShowGrantAccess(true)
+        } else {
+          action.setError(
+            'Repository not found. Check the name and your token’s repository access.',
+          )
+        }
+        return
+      }
+      // A new repo that doesn't exist yet: create it — by API when the token
+      // can, by the guided handoff (plus polling) otherwise.
+      const created = await connectNewRepo(ref.name)
+      if (created === 'connected') {
+        onClose()
+        return
+      }
+      setShowCreateGuide(true)
+    })
+  }
+
+  function continueFromRepo(): void {
+    action.setError(null)
+    if (mode === 'create' && repoName.trim().length === 0) {
+      action.setError('Name the repository.')
+      return
+    }
+    if (mode === 'existing' && parseRepoInput(existingRepo) === null) {
+      action.setError('Enter the repository as owner/name or a GitHub URL.')
+      return
+    }
+    setStep('auth')
+  }
+
+  function onAuthed(authedUser: GithubUser): void {
+    setUser(authedUser)
+    setStep('finish')
+    void loadGithubAuth().then((auth) => {
+      const kind = auth?.kind ?? null
+      setAuthKind(kind)
+      return finish(authedUser, { kind })
+    })
+  }
+
+  function confirmPublic(): void {
+    if (user !== null) {
+      void finish(user, { allowPublic: true })
+    }
+  }
+
+  function backToRepo(): void {
+    action.setError(null)
+    setPublicConfirm(null)
+    setShowCreateGuide(false)
+    setShowGrantAccess(false)
+    setStep('repo')
+  }
+
+  /** Open in the browser; an opener failure surfaces the URL to visit by hand. */
+  function openExternal(url: string): void {
+    void openUrl(url).catch(() => {
+      action.setError(`Couldn’t open the browser — visit ${url} yourself.`)
+    })
+  }
+
+  return {
+    step,
+    mode,
+    setMode,
+    repoName,
+    setRepoName,
+    existingRepo,
+    setExistingRepo,
+    user,
+    authKind,
+    publicConfirm,
+    showCreateGuide,
+    showGrantAccess,
+    targetForUser,
+    pending: action.pending,
+    error: action.error,
+    continueFromRepo,
+    onAuthed,
+    confirmPublic,
+    backToRepo,
+    openCreatePage: () => openExternal(newRepoUrl(repoName.trim())),
+    openInstallPage: () => openExternal(githubAppInstallUrl()),
+  }
+}

--- a/apps/desktop/src/mobile/connect-github-drawer.test.tsx
+++ b/apps/desktop/src/mobile/connect-github-drawer.test.tsx
@@ -1,0 +1,126 @@
+import type { ReactNode } from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setBridge } from '@reflect/core'
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
+import type { ConnectExistingResult } from '@/lib/backup-controller'
+import { ConnectGithubDrawer } from './connect-github-drawer'
+
+/**
+ * The mobile connect sheet. The wizard's flow branches (create handoff,
+ * grant access, public consent, error escapes) are specified against the
+ * shared hook by connect-github-dialog.test.tsx; this suite covers what is
+ * the drawer's own: the fixed suggested name (never the graph's), the
+ * open/close lifecycle, and a fresh wizard per open.
+ */
+
+// vaul needs browser APIs jsdom doesn't provide; passthrough so the sheet
+// content always renders (the drawer itself is verified on-device).
+vi.mock('@/components/ui/drawer', () => ({
+  Drawer: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  DrawerContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DrawerTitle: ({ children }: { children?: ReactNode }) => <h2>{children}</h2>,
+}))
+
+const sync = vi.hoisted(() => ({
+  connectNewRepo: vi.fn(async (): Promise<'connected' | 'manualCreateNeeded'> => 'connected'),
+  connectExistingRepo: vi.fn(async (): Promise<ConnectExistingResult> => 'connected'),
+}))
+vi.mock('@/providers/sync-provider', () => ({ useSync: () => sync }))
+vi.mock('@tauri-apps/plugin-http', () => ({ fetch: vi.fn() }))
+vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn() }))
+const httpFetch = vi.mocked(tauriFetch)
+
+beforeEach(() => {
+  // A stored PAT + GitHub accepting it ("alex") makes the auth step skip
+  // itself, so a Continue lands straight on the finish step.
+  setBridge({
+    invoke: async (command) =>
+      command === 'secret_get' ? JSON.stringify({ kind: 'pat', token: 'ghp_abc' }) : null,
+    listen: async () => () => {},
+  })
+  httpFetch.mockImplementation(
+    async () =>
+      new Response(JSON.stringify({ login: 'alex' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+  )
+  sync.connectNewRepo.mockResolvedValue('connected')
+  sync.connectExistingRepo.mockResolvedValue('connected')
+})
+
+afterEach(() => {
+  cleanup()
+  setBridge(null)
+  vi.resetAllMocks()
+})
+
+describe('ConnectGithubDrawer', () => {
+  it('suggests reflect-backup — never the local graph name — and connects', async () => {
+    sync.connectExistingRepo.mockResolvedValueOnce('notFound')
+    const onOpenChange = vi.fn()
+    render(<ConnectGithubDrawer open onOpenChange={onOpenChange} pollIntervalMs={15} />)
+
+    // The local graph's display name is the sandbox folder ("Documents") —
+    // the prefill must be the fixed fallback, not a graph-derived slug.
+    expect(screen.getByLabelText('Repository name')).toHaveProperty('value', 'reflect-backup')
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() =>
+      expect(sync.connectExistingRepo).toHaveBeenCalledWith(
+        { owner: 'alex', name: 'reflect-backup' },
+        { allowPublic: false },
+      ),
+    )
+    await waitFor(() => expect(sync.connectNewRepo).toHaveBeenCalledWith('reflect-backup'))
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+  })
+
+  it('connects an existing repository and closes the sheet', async () => {
+    const onOpenChange = vi.fn()
+    render(<ConnectGithubDrawer open onOpenChange={onOpenChange} pollIntervalMs={15} />)
+
+    fireEvent.click(screen.getByRole('radio', { name: /use an existing repository/i }))
+    fireEvent.change(screen.getByLabelText('Repository'), {
+      target: { value: 'alex/notes' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() =>
+      expect(sync.connectExistingRepo).toHaveBeenCalledWith(
+        { owner: 'alex', name: 'notes' },
+        { allowPublic: false },
+      ),
+    )
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+  })
+
+  it('starts a fresh wizard on every open', async () => {
+    const onOpenChange = vi.fn()
+    const view = render(<ConnectGithubDrawer open onOpenChange={onOpenChange} />)
+
+    // Leave the wizard mid-flow with a validation error showing.
+    fireEvent.click(screen.getByRole('radio', { name: /use an existing repository/i }))
+    fireEvent.change(screen.getByLabelText('Repository'), {
+      target: { value: 'not a repo!' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    expect(
+      await screen.findByText('Enter the repository as owner/name or a GitHub URL.'),
+    ).toBeTruthy()
+
+    // Close: the body unmounts entirely (which also stops any polls).
+    view.rerender(<ConnectGithubDrawer open={false} onOpenChange={onOpenChange} />)
+    expect(screen.queryByRole('button', { name: 'Continue' })).toBeNull()
+
+    // Reopen: back to the repo step defaults, no leaked error or mode.
+    view.rerender(<ConnectGithubDrawer open onOpenChange={onOpenChange} />)
+    expect(screen.getByRole('radio', { name: /create a new private repository/i })).toHaveProperty(
+      'checked',
+      true,
+    )
+    expect(screen.getByLabelText('Repository name')).toHaveProperty('value', 'reflect-backup')
+    expect(screen.queryByText('Enter the repository as owner/name or a GitHub URL.')).toBeNull()
+  })
+})

--- a/apps/desktop/src/mobile/connect-github-drawer.tsx
+++ b/apps/desktop/src/mobile/connect-github-drawer.tsx
@@ -1,0 +1,257 @@
+import { useId, type ReactElement } from 'react'
+import { InlineAlert } from '@/components/inline-alert'
+import { GithubAuthStep } from '@/components/settings/github-auth-step'
+import { Button } from '@/components/ui/button'
+import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
+import { Input } from '@/components/ui/input'
+import { useConnectGithubWizard, type ConnectWizardStep } from '@/hooks/use-connect-github-wizard'
+
+interface ConnectGithubDrawerProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Delay between repo-existence polls on the create handoff (test hook). */
+  pollIntervalMs?: number
+}
+
+const STEP_DESCRIPTIONS: Record<ConnectWizardStep, string> = {
+  repo: 'Back up this graph to a private GitHub repository and sync it with Reflect on your other devices.',
+  auth: 'Sign in so Reflect can push your backups.',
+  finish: 'Connecting your repository…',
+}
+
+const FIELD_LABEL_CLASS = 'text-xs font-medium text-text-secondary'
+
+/**
+ * The mobile "Connect GitHub" bottom sheet — a Drawer shell over
+ * {@link useConnectGithubWizard} (the same state machine as desktop's
+ * {@link ConnectGithubDialog}); flow changes belong in the hook, not here.
+ * Offered only for the local ("This device") graph: iCloud graphs sync
+ * through the container, and a Git remote and iCloud sync are mutually
+ * exclusive per graph (Plan 21).
+ *
+ * The wizard body mounts per open cycle, so a dismissed half-finished run
+ * never leaks its step/state into the next open — and unmounting also stops
+ * the wizard's repo polls and the auth step's device-flow poll.
+ */
+export function ConnectGithubDrawer({
+  open,
+  onOpenChange,
+  pollIntervalMs,
+}: ConnectGithubDrawerProps): ReactElement {
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent aria-label="Connect GitHub">
+        {open ? (
+          <ConnectWizardSheet
+            onClose={() => onOpenChange(false)}
+            {...(pollIntervalMs !== undefined ? { pollIntervalMs } : {})}
+          />
+        ) : null}
+      </DrawerContent>
+    </Drawer>
+  )
+}
+
+/** The sheet body — separate so each open starts a fresh wizard. */
+function ConnectWizardSheet({
+  onClose,
+  pollIntervalMs,
+}: {
+  onClose: () => void
+  pollIntervalMs?: number
+}): ReactElement {
+  // Never derived from the graph name: the local graph's display name is the
+  // sandbox folder's basename — literally "Documents".
+  const wizard = useConnectGithubWizard({
+    suggestedRepoName: 'reflect-backup',
+    onClose,
+    ...(pollIntervalMs !== undefined ? { pollIntervalMs } : {}),
+  })
+  const createNameId = useId()
+  const existingRepoId = useId()
+
+  return (
+    <div className="flex flex-col gap-3">
+      <DrawerTitle>Connect GitHub</DrawerTitle>
+      <p className="text-xs text-text-muted">{STEP_DESCRIPTIONS[wizard.step]}</p>
+
+      {wizard.step === 'repo' ? (
+        <>
+          <div className="flex flex-col gap-2">
+            <label className="flex min-h-11 items-center gap-3 text-[15px] text-text">
+              <input
+                type="radio"
+                name="repo-mode"
+                checked={wizard.mode === 'create'}
+                onChange={() => wizard.setMode('create')}
+              />
+              Create a new private repository
+            </label>
+            {wizard.mode === 'create' ? (
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor={createNameId} className={FIELD_LABEL_CLASS}>
+                  Repository name
+                </label>
+                <Input
+                  id={createNameId}
+                  value={wizard.repoName}
+                  enterKeyHint="go"
+                  onChange={(event) => wizard.setRepoName(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      wizard.continueFromRepo()
+                    }
+                  }}
+                />
+              </div>
+            ) : null}
+            <label className="flex min-h-11 items-center gap-3 text-[15px] text-text">
+              <input
+                type="radio"
+                name="repo-mode"
+                checked={wizard.mode === 'existing'}
+                onChange={() => wizard.setMode('existing')}
+              />
+              Use an existing repository
+            </label>
+            {wizard.mode === 'existing' ? (
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor={existingRepoId} className={FIELD_LABEL_CLASS}>
+                  Repository
+                </label>
+                <Input
+                  id={existingRepoId}
+                  value={wizard.existingRepo}
+                  placeholder="owner/name"
+                  autoCapitalize="none"
+                  autoCorrect="off"
+                  enterKeyHint="go"
+                  onChange={(event) => wizard.setExistingRepo(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      wizard.continueFromRepo()
+                    }
+                  }}
+                />
+              </div>
+            ) : null}
+          </div>
+          <Button onClick={wizard.continueFromRepo}>Continue</Button>
+        </>
+      ) : null}
+
+      {wizard.step === 'auth' ? (
+        <GithubAuthStep
+          onAuthed={wizard.onAuthed}
+          repoName={wizard.mode === 'create' ? wizard.repoName.trim() : undefined}
+        />
+      ) : null}
+
+      {wizard.step === 'finish' ? (
+        <div className="flex flex-col gap-3">
+          {wizard.user !== null ? (
+            <p className="text-xs text-text-muted">
+              Signed in as <strong className="text-text">{wizard.user.login}</strong>
+            </p>
+          ) : null}
+
+          {wizard.publicConfirm !== null ? (
+            <>
+              <InlineAlert tone="error">
+                <strong>
+                  {wizard.publicConfirm.owner}/{wizard.publicConfirm.name} is public.
+                </strong>{' '}
+                Anyone on the internet can read everything in this graph, including notes marked
+                private.
+              </InlineAlert>
+              <div className="flex flex-col gap-2">
+                <Button
+                  variant="destructive"
+                  disabled={wizard.pending || wizard.user === null}
+                  onClick={wizard.confirmPublic}
+                >
+                  Back up to a public repo
+                </Button>
+                <Button variant="outline" onClick={wizard.backToRepo}>
+                  Choose another repo
+                </Button>
+              </div>
+            </>
+          ) : wizard.showCreateGuide && wizard.user !== null ? (
+            <>
+              <p className="text-sm text-text">
+                Create{' '}
+                <strong>
+                  {wizard.user.login}/{wizard.repoName.trim()}
+                </strong>{' '}
+                on GitHub. Reflect will connect it as soon as it exists.
+              </p>
+              <div className="flex flex-col gap-2">
+                <Button onClick={wizard.openCreatePage}>Create on GitHub…</Button>
+                <Button variant="outline" onClick={wizard.backToRepo}>
+                  Change repository
+                </Button>
+              </div>
+              <p className="text-xs text-text-muted">Waiting for the repository…</p>
+              {wizard.authKind === 'app' ? (
+                <p className="text-xs text-text-muted">
+                  If it doesn’t connect,{' '}
+                  <button type="button" className="underline" onClick={wizard.openInstallPage}>
+                    grant the Reflect app access
+                  </button>{' '}
+                  to just this repository.
+                </p>
+              ) : (
+                <p className="text-xs text-text-muted">
+                  If it doesn’t connect, add it to your token’s repository access.
+                </p>
+              )}
+            </>
+          ) : wizard.showGrantAccess && wizard.targetForUser !== null ? (
+            <>
+              <p className="text-sm text-text">
+                Give Reflect access to{' '}
+                <strong>
+                  {wizard.targetForUser.owner}/{wizard.targetForUser.name}
+                </strong>{' '}
+                so it can back up here.
+              </p>
+              <div className="flex flex-col gap-2">
+                <Button onClick={wizard.openInstallPage}>Grant access on GitHub…</Button>
+                <Button variant="outline" onClick={wizard.backToRepo}>
+                  Change repository
+                </Button>
+              </div>
+              {/* Steer to per-repo selection: the backup needs exactly one
+                  repo, so "All repositories" is needless account-wide risk. */}
+              <p className="text-xs text-text-muted">
+                On GitHub, choose <strong>Only select repositories</strong> — Reflect only needs
+                this one.
+              </p>
+              <p className="text-xs text-text-muted">Waiting for access…</p>
+            </>
+          ) : wizard.pending ? (
+            <p className="text-sm text-text-muted">Connecting…</p>
+          ) : null}
+
+          {!wizard.pending && wizard.error !== null ? (
+            <>
+              <InlineAlert tone="error">{wizard.error}</InlineAlert>
+              {wizard.publicConfirm === null &&
+              !wizard.showCreateGuide &&
+              !wizard.showGrantAccess ? (
+                <Button variant="outline" onClick={wizard.backToRepo}>
+                  Change repository
+                </Button>
+              ) : null}
+            </>
+          ) : null}
+        </div>
+      ) : null}
+
+      {wizard.step !== 'finish' && wizard.error !== null ? (
+        <InlineAlert tone="error">{wizard.error}</InlineAlert>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/desktop/src/mobile/onboarding-screen.test.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.test.tsx
@@ -86,7 +86,9 @@ describe('MobileOnboardingScreen', () => {
 
     expect(screen.queryByText(/Your notes are plain markdown files/i)).toBeNull()
     expect(screen.getByRole('heading', { name: 'This device' })).toBeTruthy()
-    expect(screen.getByText('Stored locally in Reflect on this device.')).toBeTruthy()
+    expect(
+      screen.getByText('Stored locally in Reflect on this device. Sync with GitHub later from Settings.'),
+    ).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: 'Choose a folder on this device' }))
 
     await waitFor(() => expect(completeOnboarding).toHaveBeenCalledWith('local'))

--- a/apps/desktop/src/mobile/onboarding-screen.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.tsx
@@ -83,7 +83,9 @@ export function MobileOnboardingScreen(): ReactElement {
               </div>
               <div className="min-w-0 flex-1 space-y-1">
                 <h2 className="text-sm font-semibold">This device</h2>
-                <p className="text-xs text-text-muted">Stored locally in Reflect on this device.</p>
+                <p className="text-xs text-text-muted">
+                  Stored locally in Reflect on this device. Sync with GitHub later from Settings.
+                </p>
               </div>
             </div>
             <Button

--- a/apps/desktop/src/mobile/screens/graphs.tsx
+++ b/apps/desktop/src/mobile/screens/graphs.tsx
@@ -132,7 +132,7 @@ export function MobileGraphs(): ReactElement {
           </SettingsGroup>
 
           {localRoot !== null ? (
-            <SettingsGroup footer="Notes stay on this device.">
+            <SettingsGroup footer="Notes stay on this device. Sync with GitHub from Settings.">
               <SettingsSelectRow
                 label="This device"
                 selected={graph?.root === localRoot}

--- a/apps/desktop/src/mobile/screens/settings.test.tsx
+++ b/apps/desktop/src/mobile/screens/settings.test.tsx
@@ -170,6 +170,15 @@ describe('MobileSettings', () => {
     expect(await screen.findByText('connect-github-sheet')).toBeTruthy()
   })
 
+  it('hides the connect row once the local graph is connected', async () => {
+    graphState.mobileStorageKind = 'local'
+    mount()
+
+    expect(await screen.findByText('alex/notes')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Disconnect GitHub' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Connect GitHub' })).toBeNull()
+  })
+
   it('never offers connect for iCloud graphs — they sync through the container', () => {
     sync.value = {
       backup: { phase: 'disconnected' },

--- a/apps/desktop/src/mobile/screens/settings.test.tsx
+++ b/apps/desktop/src/mobile/screens/settings.test.tsx
@@ -55,6 +55,13 @@ vi.mock('@/providers/sync-provider', () => ({
   useSyncContext: () => sync.value,
 }))
 
+// The sheet itself is covered by connect-github-drawer.test.tsx; the screen
+// test only cares that Settings opens it.
+vi.mock('@/mobile/connect-github-drawer', () => ({
+  ConnectGithubDrawer: ({ open }: { open: boolean }) =>
+    open ? <div>connect-github-sheet</div> : null,
+}))
+
 function connected(status: Extract<BackupState, { phase: 'connected' }>['status']): BackupState {
   return {
     phase: 'connected',
@@ -145,6 +152,47 @@ describe('MobileSettings', () => {
       expect(sync.value?.disconnectGraph).toHaveBeenCalledTimes(1)
       expect(sync.value?.signOut).toHaveBeenCalledTimes(1)
     })
+  })
+
+  it('offers Connect GitHub for a disconnected local graph and opens the sheet', async () => {
+    const user = userEvent.setup()
+    graphState.mobileStorageKind = 'local'
+    sync.value = {
+      backup: { phase: 'disconnected' },
+      disconnectGraph: vi.fn(async () => {}),
+      signOut: vi.fn(async () => {}),
+    }
+    mount()
+
+    expect(screen.getByText('Sync notes with Reflect on your other devices.')).toBeTruthy()
+    await user.click(screen.getByRole('button', { name: 'Connect GitHub' }))
+
+    expect(await screen.findByText('connect-github-sheet')).toBeTruthy()
+  })
+
+  it('never offers connect for iCloud graphs — they sync through the container', () => {
+    sync.value = {
+      backup: { phase: 'disconnected' },
+      disconnectGraph: vi.fn(async () => {}),
+      signOut: vi.fn(async () => {}),
+    }
+    mount()
+
+    expect(screen.queryByRole('button', { name: 'Connect GitHub' })).toBeNull()
+    expect(screen.queryByText('Backup')).toBeNull()
+  })
+
+  it('waits out the loading phase — no connect row that could flash', () => {
+    graphState.mobileStorageKind = 'local'
+    sync.value = {
+      backup: { phase: 'loading' },
+      disconnectGraph: vi.fn(async () => {}),
+      signOut: vi.fn(async () => {}),
+    }
+    mount()
+
+    expect(screen.queryByRole('button', { name: 'Connect GitHub' })).toBeNull()
+    expect(screen.queryByText('Backup')).toBeNull()
   })
 
   it('degrades to the local groups where no sync lifecycle is mounted', async () => {

--- a/apps/desktop/src/mobile/screens/settings.tsx
+++ b/apps/desktop/src/mobile/screens/settings.tsx
@@ -9,6 +9,7 @@ import {
 } from '@reflect/core'
 import { useAppVersion } from '@/hooks/use-app-version'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
+import { ConnectGithubDrawer } from '@/mobile/connect-github-drawer'
 import { MobileScreenHeader } from '@/mobile/screen-header'
 import {
   SettingsActionRow,
@@ -42,8 +43,9 @@ const TEXT_SIZE_OPTIONS: readonly SegmentedOption<EditorTextSize>[] = [
  * iOS inset-grouped idiom, replacing the old bottom-sheet hodgepodge. The
  * graph row discloses into the Graphs switcher screen; appearance and editor
  * preferences edit the shared settings document (the same keys desktop
- * exposes); the backup group mirrors the status pill's engine state and can
- * disconnect GitHub (connecting happens in onboarding).
+ * exposes); the backup group mirrors the status pill's engine state, connects
+ * GitHub for the local graph (the {@link ConnectGithubDrawer} sheet — iCloud
+ * graphs sync through the container instead, Plan 21), and can disconnect.
  */
 export function MobileSettings(): ReactElement {
   const { back, canBack, navigate } = useRouter()
@@ -56,6 +58,7 @@ export function MobileSettings(): ReactElement {
   // over conflict markers already on disk and then flips.
   const status = useMobileSyncStatus()
   const [disconnecting, setDisconnecting] = useState(false)
+  const [connectOpen, setConnectOpen] = useState(false)
 
   const { data: notes } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'mobile-note-count'],
@@ -65,6 +68,11 @@ export function MobileSettings(): ReactElement {
 
   const backup = sync?.backup ?? null
   const repo = backup !== null && backup.phase === 'connected' ? backup.repo : null
+  // The connect entry point is local-graph-only (iCloud sync and a Git remote
+  // are mutually exclusive per graph, Plan 21) and waits out the controller's
+  // `loading` phase so the row never flashes on a graph that turns out to be
+  // connected.
+  const canConnect = mobileStorageKind === 'local' && backup?.phase === 'disconnected'
 
   // Stop backing this graph up and forget the GitHub credential (one graph
   // per device — unlinking is signing out). The local clone stays; the
@@ -144,12 +152,22 @@ export function MobileSettings(): ReactElement {
             />
           </SettingsGroup>
 
-          {repo !== null || status !== null ? (
-            <SettingsGroup header="Backup" footer={status?.detail ?? null}>
+          {repo !== null || status !== null || canConnect ? (
+            <SettingsGroup
+              header="Backup"
+              footer={
+                canConnect
+                  ? 'Sync notes with Reflect on your other devices.'
+                  : (status?.detail ?? null)
+              }
+            >
               {repo !== null ? (
                 <SettingsValueRow label="GitHub" value={`${repo.owner}/${repo.name}`} />
               ) : null}
               {status !== null ? <SettingsValueRow label="Status" value={status.label} /> : null}
+              {canConnect ? (
+                <SettingsActionRow label="Connect GitHub" onPress={() => setConnectOpen(true)} />
+              ) : null}
               {repo !== null ? (
                 <SettingsActionRow
                   label="Disconnect GitHub"
@@ -170,6 +188,7 @@ export function MobileSettings(): ReactElement {
           </SettingsGroup>
         </div>
       </main>
+      <ConnectGithubDrawer open={connectOpen} onOpenChange={setConnectOpen} />
     </div>
   )
 }

--- a/docs/plans/22-mobile-github-connect.md
+++ b/docs/plans/22-mobile-github-connect.md
@@ -1,0 +1,223 @@
+# Plan 22 — Mobile GitHub Connect (iOS)
+
+**Goal:** the "This device" (local) graph on iOS can connect to a GitHub backup
+repository, giving phone ↔ desktop sync for users without iCloud. The sync
+machinery already runs on mobile — the backup controller mounts, background
+flush fires on app-background, and Settings shows status and Disconnect. What's
+missing is only the front door: sign in to GitHub and pick/create a repo from
+the phone. This plan builds that connect flow and nothing else; **no new sync
+mechanism, no engine changes.**
+
+**Depends on:** Plan 12 (backup controller, merge machinery, `has_conflict`),
+Plan 19/PR #483 (SyncProvider mounted in the mobile tree, mobile quit-flush),
+Plan 21 (contract 5: iCloud sync and a Git remote are mutually exclusive per
+graph — which makes the local graph precisely the one allowed a remote).
+**Status:** implemented (Phases 0–3): the wizard hook extraction
+(`use-connect-github-wizard.ts`, dialog tests passing untouched), the
+`ConnectGithubDrawer` sheet, the Settings entry point, the copy changes, and
+the jsdom + `?platform=ios` harness coverage. Remaining: the Phase 0
+device spikes (clipboard, background-resume poll, keychain round-trip) and
+the four-item manual device pass — both need a phone/simulator build.
+
+**Explicitly not in scope:** GitHub connect for iCloud graphs (contract 5);
+sync for the local graph via any non-Git mechanism; a mobile restore-from-repo
+onboarding path (the phone joins an existing repo through the same connect
+flow — a dedicated "restore" wizard can come later); Android; SSH remotes on
+mobile (Plan 16's agent-auth transport has no phone story).
+
+## Where we stand
+
+**What already exists (and is reused unchanged):**
+
+- **Engine + lifecycle.** `SyncProvider` is mounted in the mobile tree
+  (`apps/desktop/src/mobile/mobile-app.tsx`), one backup controller per
+  (graph, index session), launch pull, resume/online triggers, and the
+  quit-flush leg. `connectNewRepo` / `connectExistingRepo` /
+  `disconnectGraph` / `signOut` are already exposed through `useSync()`
+  (`apps/desktop/src/providers/sync-provider.tsx`,
+  `apps/desktop/src/lib/backup-controller.ts`).
+- **Rust.** The `git` module (git2, vendored libssh2/openssl) already builds
+  for iOS — PR #483 shipped it. Credentials go through `secrets.rs` on
+  `keyring` with the `apple-native` feature, which backs onto the iOS
+  keychain as well as the macOS one.
+- **Core auth.** `runDeviceFlow` (poll policy included),
+  `saveGithubAuth`/`loadGithubAuth`, `createGithubRepo`/`getGithubRepo` —
+  all platform-neutral TS in `@reflect/core`. The device flow is *always*
+  configured: `GITHUB_APP_CLIENT_ID` is a hardcoded constant in
+  `packages/core/src/sync/github-auth.ts`, not a build-time env var, so iOS
+  builds need no injection.
+- **Transport (verified, not assumed).** GitHub calls ride `providerFetch` →
+  `tauri-plugin-http`, so requests leave from the Rust side and webview CORS
+  never applies — which matters because GitHub's device-flow token endpoints
+  send no CORS headers. The plugin registers unconditionally
+  (`src-tauri/src/lib.rs:105`, outside every `#[cfg(desktop)]` block), and
+  `capabilities/default.json` has no `platforms` filter, so its http scope
+  (`github.com/login/device/code`, `login/oauth/access_token`,
+  `api.github.com/*`) and the opener grant already apply on iOS.
+- **Desktop UI to mine.** `GithubAuthStep`
+  (`apps/desktop/src/components/settings/github-auth-step.tsx`) is already
+  written as the shared sign-in step (device flow leading, PAT fallback,
+  single-shot completion, verified via `GET /user`). `ConnectGithubDialog`
+  (`connect-github-dialog.tsx`) holds the full wizard: repo step → auth →
+  finish, with the create-handoff poll, the grant-access step for App
+  installs, and the public-repo consent gate.
+- **Mobile UI substrate.** The inset-grouped settings primitives
+  (`apps/desktop/src/mobile/settings-list.tsx`), the vaul bottom-sheet Drawer
+  idiom (`apps/desktop/src/mobile/new-graph-drawer.tsx` is the model), and
+  `useMobileSyncStatus` + the Backup group already in
+  `apps/desktop/src/mobile/screens/settings.tsx` (status + Disconnect; it
+  renders only when connected today).
+
+**The gap:** no mobile surface calls `GithubAuthStep` or the connect methods.
+The Backup group is invisible for a disconnected local graph, and the
+`settings.tsx` docstring still claims "connecting happens in onboarding" — a
+leftover from the pre-iCloud mobile onboarding that no longer exists.
+
+## Contracts
+
+1. **Local graphs only.** The connect entry point renders only when
+   `mobileStorageKind === 'local'` and the backup phase is `disconnected`.
+   iCloud graphs never see it (Plan 21 contract 5). The gate is the storage
+   kind, not a root-path sniff.
+2. **One wizard, two shells.** The connect state machine is extracted from
+   `ConnectGithubDialog` into a hook; desktop's Dialog and mobile's Drawer
+   are thin renderings of the same hook. No forked flow logic.
+3. **Same safety gates as desktop.** Public-repo consent stays an explicit
+   destructive-styled confirmation; the grant-access step steers to
+   "Only select repositories"; a failed connect always offers a way back to
+   the repo step.
+4. **The phone joins, it does not fork.** Connecting an existing repo aligns
+   the local branch with the repo's default branch (existing
+   `connectExistingRepo` behavior) and the launch pull merges local content
+   through the Plan 12 machinery — the near-empty phone graph (a seeded daily
+   note at most) merges into desktop history, never the reverse.
+
+## Phase 0 — extraction + spikes
+
+- **Extract `use-connect-github-wizard.ts`** (new,
+  `apps/desktop/src/hooks/`): steps (`repo`/`auth`/`finish`), create-vs-existing
+  mode, target-ref resolution from the verified user, `finish()` with the
+  public-confirm / create-guide / grant-access branches, and the
+  existence/access poll. `ConnectGithubDialog` becomes a shell over the hook
+  with **zero behavior change** — its existing tests
+  (`connect-github-dialog.test.tsx`) must pass untouched, which is the
+  refactor's acceptance test. Scope notes: `GithubAuthStep` has exactly one
+  consumer today (the dialog — its docstring's "restore dialog" is
+  aspirational), so the extraction touches one call site; `useRestoreFocus`
+  is desktop-Dialog furniture and stays in the shell, not the hook.
+- **Spike: device flow in WKWebView.** Three things to prove on a simulator
+  + device before UI work:
+  1. `navigator.clipboard.writeText` inside a tap handler (the copy-before-
+     open step). Tauri iOS serves the app over a custom scheme, and the
+     async clipboard API may be absent outside a browser-blessed secure
+     context. The `copyState === 'failed'` manual-copy fallback already
+     exists; if the API is missing, decide between touch-friendlier
+     fallback copy (long-press-select the code) and adding
+     `tauri-plugin-clipboard-manager` — prefer whichever is smaller.
+  2. `openUrl` → Safari → return-to-app: the JS poll inside `runDeviceFlow`
+     suspends while backgrounded and must simply resume and succeed on
+     foreground (GitHub device codes live ~15 min; `slow_down` handling
+     already exists in core). No code change expected — this is a
+     verify-don't-assume item.
+  3. `keyring`/`secrets.rs` round-trip on iOS (save + load a dummy entry) —
+     `apple-native` should cover it, but it has never run on the phone.
+
+  (A fourth unknown — whether GitHub API/device-flow requests can leave the
+  app at all — was checked during planning and is settled: see *Transport*
+  above.)
+
+## Phase 1 — the mobile connect surface
+
+- **`apps/desktop/src/mobile/connect-github-drawer.tsx`** (new): a vaul
+  Drawer in the `NewGraphDrawer` idiom driving the wizard hook.
+  - *Repo step:* segmented create-new (name input) vs use-existing
+    (`owner/name` input, `parseRepoInput`). **Do not feed the graph name
+    into `suggestRepoName` here:** the local graph's display name is the
+    sandbox folder's basename — literally "Documents" — so desktop's
+    `suggestRepoName(graph?.name)` would suggest `documents-backup`. Mobile
+    passes no name and takes the `reflect-backup` fallback.
+  - *Auth step:* reuse `GithubAuthStep` as-is — it is deliberately
+    surface-agnostic (device flow + PAT fallback). Touch-specific styling
+    tweaks only if something actually breaks in the sheet.
+  - *Finish step:* connecting spinner, and the three parked states from the
+    hook (public-confirm with destructive confirm, create-guide with
+    "Create on GitHub…" handoff + poll, grant-access with the
+    only-select-repositories steer + poll).
+- **Settings entry point** (`apps/desktop/src/mobile/screens/settings.tsx`):
+  render the Backup group for local graphs even when disconnected, with a
+  `SettingsActionRow` "Connect GitHub" opening the drawer. Today the group
+  is genuinely invisible in that state — `mobileSyncStatus` returns `null`
+  for every non-`connected` phase, so both `repo` and `status` are null.
+  Mind the `loading` phase: show the row disabled (or nothing) until the
+  controller reports `disconnected`, so the row never flashes on a graph
+  that turns out to be connected. Connected state keeps today's rows (repo,
+  status, Disconnect). iCloud graphs keep today's behavior exactly (group
+  appears only with status to show). Fix the stale "connecting happens in
+  onboarding" docstring while there.
+- **Gating:** `mobileStorageKind` comes from `useGraph()` — no new plumbing.
+- **Post-connect UX:** `connectRemote` awaits `gitSetup` + controller
+  restart, but the launch pull is fired non-blocking inside `start()` — so
+  the drawer closes as soon as the remote is wired and the existing status
+  pill/row shows `Syncing` while the first pull runs. No progress UI in the
+  drawer.
+
+## Phase 2 — copy
+
+Small, in the copy-simple-sparse register:
+
+- Graphs screen local-group footer (`apps/desktop/src/mobile/screens/graphs.tsx`):
+  "Notes stay on this device." → "Notes stay on this device. Sync with
+  GitHub from Settings." (drop the second sentence when a repo is connected —
+  optional polish, not required).
+- Onboarding "This device" card (`apps/desktop/src/mobile/onboarding-screen.tsx`):
+  append one line to the existing description so the option no longer reads
+  as a dead end: "You can sync with GitHub later from Settings."
+
+## Phase 3 — tests + verification
+
+- **Hook:** the dialog's existing tests already exercise the wizard paths
+  through the desktop shell; add hook-level tests only for what the shells
+  don't reach (poll stop conditions, single-shot finish).
+- **Drawer:** screen tests with the drawer mock pattern from the tasks
+  quick-edit sheet work (vaul portals don't render in jsdom): happy path
+  create-new, happy path existing, public-confirm branch, and the
+  local-only/disconnected-only visibility matrix for the settings row.
+- **Dev harness:** smoke the settings screen and drawer under
+  `?platform=ios` — new IPC on the boot/connect path must not rot the
+  browser bridge (PR #538 lesson). Rendering only: without the shell,
+  `providerFetch` falls back to plain `fetch`, and GitHub's device-flow
+  endpoints reject browser CORS — the full flow is device/simulator-only.
+- **Manual device pass (release gate for the feature):**
+  1. iPhone, local graph, device flow end-to-end (copy code → Safari →
+     authorize → return → connected).
+  2. Connect the repo an existing desktop graph backs up to; verify the
+     phone's seeded content merges (no fork, no duplicate notes) and edits
+     round-trip phone ↔ desktop.
+  3. Background the app mid-poll and resume (spike 2's scenario, on the real
+     device).
+  4. PAT fallback path once (paste from clipboard).
+
+## Risks
+
+- **Device-flow poll under iOS suspension** is the biggest remaining unknown
+  (Phase 0 spike 2). If WKWebView kills rather than suspends the fetch loop,
+  the remedy is a resume-time retry inside the auth step, not a new flow.
+- **Clipboard API availability** (spike 1) — has a working-but-clunky
+  fallback either way, so it can't block the feature, only polish.
+- **First-sync merge on a non-empty phone graph:** the local graph seeds a
+  daily note, and the repo likely has one for the same date. This is the same
+  shape as desktop's connect-existing-to-existing-graph path and goes through
+  the same merge ladder; the manual matrix (item 2) is the proof, not new
+  code.
+- **PAT entry stays as the escape hatch** (GHES, users who prefer scoped
+  tokens) — `GithubAuthStep` already renders it; the only mobile question is
+  whether the paste field behaves in the drawer, covered by manual pass
+  item 4.
+
+## Deferred
+
+- Restore-shaped onboarding ("start from your GitHub backup" as a first-run
+  option next to iCloud/This device).
+- Surfacing `backUpNow` on mobile (a "Back up now" row) — trivial once the
+  group is always visible, but not needed for the sync story.
+- Android (no keychain/keyring story validated there yet).


### PR DESCRIPTION
## Problem

On iOS, the **"This device" (local) graph is sync-capable but unreachable**: the backup controller runs, background flush fires, and Settings shows status + Disconnect for a *connected* repo — but there is no way to sign in to GitHub or connect a repository from the phone. Desktop has the whole flow; mobile has teardown with no setup. In practice the local graph reads as a dead end (the copy even said notes "stay on this device"), when it was designed as the no-iCloud sync path — Plan 21 makes a Git remote and iCloud sync mutually exclusive per graph, so the local graph is precisely the one allowed a remote.

Design + verified constraints in [docs/plans/22-mobile-github-connect.md](docs/plans/22-mobile-github-connect.md).

## What changed

**One wizard, two shells.** The connect state machine (repo step → sign-in → connect, with the create-handoff poll, the grant-access poll for App installs, and the public-repo consent gate) moves out of `ConnectGithubDialog` into a new `use-connect-github-wizard` hook. The desktop dialog becomes a thin shell over it — **its 15 existing tests pass untouched**, which is the no-behavior-change proof.

**`ConnectGithubDrawer`** (new): a vaul bottom sheet over the same hook, in the `NewGraphDrawer` idiom. Reuses `GithubAuthStep` as-is (device flow leading, PAT fallback). The sheet body mounts per open cycle, so a dismissed half-finished run never leaks state — and unmounting stops the wizard's repo polls and the device-flow poll. The suggested repo name is the fixed `reflect-backup` fallback, never graph-derived: the local graph's display name is the sandbox folder's basename, literally "Documents".

**Settings entry point:** the Backup group now renders for a disconnected local graph with a **Connect GitHub** row. Gated on `mobileStorageKind === 'local'` (iCloud graphs sync through the container) and on the controller reporting `disconnected` — the `loading` phase shows nothing, so the row can't flash on a graph that turns out to be connected. Connected state keeps today's rows.

**Copy:** the Graphs-screen local footer and the onboarding This-device card now mention GitHub sync from Settings, so the local option no longer reads as a dead end.

No Rust/IPC changes: transport (tauri-plugin-http, unconditionally registered), the GitHub endpoint capability scope (no `platforms` filter), git2 on iOS, and keyring `apple-native` all already cover mobile.

## Testing

- `connect-github-dialog.test.tsx`: 15/15 pass **without modification** against the extracted hook
- New `connect-github-drawer.test.tsx`: fixed suggested name, create + existing happy paths, fresh-wizard-per-open
- `settings.test.tsx`: visibility matrix (local+disconnected shows the row and opens the sheet; iCloud never; loading never)
- Manual smoke in the `?platform=ios` browser harness: Settings → Backup group → drawer opens with the repo step prefilled `reflect-backup` → Continue reaches the auth step (device flow leading). Full auth can't run in the harness (browser CORS on GitHub's device-flow endpoints — shell-only by design)
- `pnpm check` clean

## Risks / follow-ups

The flow-level risks need a phone build and are tracked as the plan's Phase 0 spikes + manual pass: `navigator.clipboard` under Tauri's custom scheme (a manual-copy fallback already renders if it's absent), the device-flow poll resuming after iOS suspends the webview during the Safari round-trip, and a first keychain round-trip on device. First-sync merge of the phone's seeded daily note into existing repo history rides the same Plan 12 machinery as desktop's connect-existing path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches backup onboarding and GitHub credential/repo wiring for local graphs; behavior is largely moved, not rewritten, but public-repo consent and first-sync merge still depend on existing Plan 12 paths and need device validation.
> 
> **Overview**
> **iOS local graphs can now connect a GitHub backup from the phone** — the sync engine was already there; this PR adds the UI entry point and shares one wizard between desktop and mobile.
> 
> The connect flow (repo → sign-in → connect, with create-handoff polling, grant-access for GitHub App installs, and public-repo consent) moves from `ConnectGithubDialog` into **`useConnectGithubWizard`**. Desktop’s dialog is a thin shell over that hook (existing dialog tests unchanged). **`ConnectGithubDrawer`** is the mobile bottom sheet over the same hook, reusing `GithubAuthStep`; it always suggests **`reflect-backup`** (not a graph-derived name) and remounts the wizard body on each open so state and polls don’t leak.
> 
> **Mobile Settings** shows a **Connect GitHub** row in Backup when `mobileStorageKind === 'local'` and backup is `disconnected` (hidden during `loading` and for iCloud graphs). Onboarding and Graphs copy now point users to GitHub sync from Settings.
> 
> Tests cover the drawer lifecycle and Settings visibility; Plan 22 doc records what’s left for device-only verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 980be84402a1283a6ec0a4b60308cdd01fc550a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->