### PR TITLE
fix(windows): seed the note window's first route — no daily-note flash

### DIFF
--- a/apps/desktop/src/components/graph-workspace.tsx
+++ b/apps/desktop/src/components/graph-workspace.tsx
@@ -3,6 +3,7 @@ import type { GraphInfo } from '@reflect/core'
 import { PaletteProvider } from '@/components/command-palette/palette-provider'
 import { NoteWindowContent } from '@/components/note-window-content'
 import { WorkspaceContent } from '@/components/workspace-content'
+import { getInitialWindowRoute } from '@/lib/windows/initial-window-route'
 import { isMainWindow } from '@/lib/windows/window-role'
 import { AssetDescribeProvider } from '@/providers/asset-describe-provider'
 import { AudioMemoProvider } from '@/providers/audio-memo-provider'
@@ -28,8 +29,12 @@ interface GraphWorkspaceProps {
  * fresh history.
  */
 export function GraphWorkspace({ graph }: GraphWorkspaceProps): ReactElement {
+  // A note window's first route is its ⌘-clicked target (seeded by the boot
+  // hook) — starting on the default today route would flash the daily note
+  // until the deep link navigated.
+  const initialRoute = isMainWindow() ? null : getInitialWindowRoute()
   return (
-    <RouterProvider key={graph.root}>
+    <RouterProvider key={graph.root} {...(initialRoute !== null ? { initialRoute } : {})}>
       <SyncProvider graph={graph}>
         <PaletteProvider>
           <ShortcutsProvider>

--- a/apps/desktop/src/lib/windows/initial-window-route.test.ts
+++ b/apps/desktop/src/lib/windows/initial-window-route.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  getInitialWindowRoute,
+  initialRouteForDeepLink,
+  resetInitialWindowRouteForTests,
+  setInitialWindowRoute,
+} from './initial-window-route'
+
+beforeEach(resetInitialWindowRouteForTests)
+
+describe('initialRouteForDeepLink', () => {
+  it('derives navigate links directly', () => {
+    expect(initialRouteForDeepLink('reflect://daily/2026-07-05')).toEqual({
+      kind: 'daily',
+      date: '2026-07-05',
+    })
+    expect(initialRouteForDeepLink('reflect://today')).toEqual({ kind: 'today' })
+  })
+
+  it('derives path-shaped note targets without the index', () => {
+    // ⌘-click builds these via deepLinkForRoute, so the target IS the path.
+    expect(initialRouteForDeepLink('reflect://note/notes%2Ffoo.md')).toEqual({
+      kind: 'note',
+      path: 'notes/foo.md',
+    })
+    // A daily path routes to the daily view, same as routeForPath everywhere.
+    expect(initialRouteForDeepLink('reflect://note/daily%2F2026-07-04.md')).toEqual({
+      kind: 'daily',
+      date: '2026-07-04',
+    })
+  })
+
+  it('declines targets only the index can answer', () => {
+    expect(initialRouteForDeepLink('reflect://note/Meeting%20Notes')).toBeNull()
+    expect(initialRouteForDeepLink('reflect://note/01hzx4abc')).toBeNull()
+  })
+
+  it('declines capture links, garbage, and absence', () => {
+    expect(initialRouteForDeepLink('reflect://append?text=hi')).toBeNull()
+    expect(initialRouteForDeepLink('not a url')).toBeNull()
+    expect(initialRouteForDeepLink(null)).toBeNull()
+  })
+})
+
+describe('the initial-route slot', () => {
+  it('holds the seeded route for the workspace mount', () => {
+    expect(getInitialWindowRoute()).toBeNull()
+    setInitialWindowRoute({ kind: 'note', path: 'notes/foo.md' })
+    expect(getInitialWindowRoute()).toEqual({ kind: 'note', path: 'notes/foo.md' })
+    // Idempotent reads: StrictMode double-invokes initializers.
+    expect(getInitialWindowRoute()).toEqual({ kind: 'note', path: 'notes/foo.md' })
+  })
+})

--- a/apps/desktop/src/lib/windows/initial-window-route.ts
+++ b/apps/desktop/src/lib/windows/initial-window-route.ts
@@ -1,0 +1,53 @@
+import { isDaily, isNotePath } from '@reflect/core'
+import { parseDeepLink } from '@/lib/deep-links/parse'
+import { routeForPath, type Route } from '@/routing/route'
+
+/**
+ * A note window's first route, derived from its initial deep link BEFORE the
+ * router mounts — so the window's first workspace render is already the
+ * ⌘-clicked note instead of flashing today's daily note while the link rides
+ * the async intake. Set by the boot hook, read by the workspace when it
+ * mounts the router. Plain slot, not consume-once: a webview boots once, and
+ * idempotent reads survive StrictMode's double-invoked initializers.
+ */
+
+let initialRoute: Route | null = null
+
+/** Record the derived first route (the boot hook, before status flips ready). */
+export function setInitialWindowRoute(route: Route): void {
+  initialRoute = route
+}
+
+/** The derived first route, or null (main window, reload, unresolvable link). */
+export function getInitialWindowRoute(): Route | null {
+  return initialRoute
+}
+
+/**
+ * Derive a route from a `reflect://` link synchronously, or null when only
+ * the index can answer. ⌘-click builds links with `deepLinkForRoute`, so its
+ * note targets are path-shaped and resolve right here; id/title-shaped
+ * targets (hand-written links) fall back to the intake's async resolution —
+ * those windows briefly show today, the price of an index round-trip.
+ */
+export function initialRouteForDeepLink(link: string | null): Route | null {
+  if (link === null) {
+    return null
+  }
+  const parsed = parseDeepLink(link)
+  if (parsed === null) {
+    return null
+  }
+  if (parsed.kind === 'navigate') {
+    return parsed.route
+  }
+  if (parsed.kind === 'openNote' && (isNotePath(parsed.target) || isDaily(parsed.target))) {
+    return routeForPath(parsed.target)
+  }
+  return null
+}
+
+/** Test-only: reset the slot between cases. */
+export function resetInitialWindowRouteForTests(): void {
+  initialRoute = null
+}

--- a/apps/desktop/src/providers/use-note-window-boot.test.ts
+++ b/apps/desktop/src/providers/use-note-window-boot.test.ts
@@ -23,6 +23,10 @@ vi.mock('@/lib/windows/window-role', () => ({ isMainWindow }))
 vi.mock('@/lib/deep-links/intake', () => ({ dispatchDeepLink }))
 vi.mock('@/lib/query-client', () => ({ throttledInvalidateIndexQueries }))
 
+import {
+  getInitialWindowRoute,
+  resetInitialWindowRouteForTests,
+} from '@/lib/windows/initial-window-route'
 import { useNoteWindowBoot } from './use-note-window-boot'
 
 const BOOT: WindowBootstrap = {
@@ -42,6 +46,7 @@ function mount() {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  resetInitialWindowRouteForTests()
   isMainWindow.mockReturnValue(false)
   windowBootstrap.mockResolvedValue(BOOT)
   subscribeIndexWritten.mockResolvedValue(() => {})
@@ -49,16 +54,27 @@ beforeEach(() => {
 })
 
 describe('useNoteWindowBoot', () => {
-  it('adopts the open sessions and dispatches the initial deep link', async () => {
+  it('adopts the open sessions and seeds the router from a path-shaped link', async () => {
     const { onAdopted, onFailed } = mount()
     await waitFor(() => expect(onAdopted).toHaveBeenCalledWith(BOOT))
-    expect(dispatchDeepLink).toHaveBeenCalledWith(BOOT.initialDeepLink)
+    // ⌘-click links resolve synchronously — the route slot is seeded and the
+    // intake is bypassed, so the window never flashes today's daily note.
+    expect(getInitialWindowRoute()).toEqual({ kind: 'note', path: 'notes/foo.md' })
+    expect(dispatchDeepLink).not.toHaveBeenCalled()
     expect(onFailed).not.toHaveBeenCalled()
     // The adopted window refetches on committed index writes — never its own
     // indexer — and honors focus-renavigate requests from a repeat ⌘-click
     // on its target. (Rename follow-through is desktop-root's, all windows.)
     expect(subscribeIndexWritten).toHaveBeenCalledWith(throttledInvalidateIndexQueries)
     expect(subscribeWindowNavigate).toHaveBeenCalledWith(dispatchDeepLink)
+  })
+
+  it('falls back to the intake for a target only the index can answer', async () => {
+    windowBootstrap.mockResolvedValue({ ...BOOT, initialDeepLink: 'reflect://note/Meeting%20Notes' })
+    const { onAdopted } = mount()
+    await waitFor(() => expect(onAdopted).toHaveBeenCalled())
+    expect(getInitialWindowRoute()).toBeNull()
+    expect(dispatchDeepLink).toHaveBeenCalledWith('reflect://note/Meeting%20Notes')
   })
 
   it('skips the deep-link dispatch when none is pending (a reload)', async () => {

--- a/apps/desktop/src/providers/use-note-window-boot.ts
+++ b/apps/desktop/src/providers/use-note-window-boot.ts
@@ -11,6 +11,10 @@ import {
 import { dispatchDeepLink } from '@/lib/deep-links/intake'
 import { throttledInvalidateIndexQueries } from '@/lib/query-client'
 import { trackSubscriptions } from '@/lib/subscriptions'
+import {
+  initialRouteForDeepLink,
+  setInitialWindowRoute,
+} from '@/lib/windows/initial-window-route'
 import { isMainWindow } from '@/lib/windows/window-role'
 
 /** The graph provider's channels for the note-window boot leg. */
@@ -28,9 +32,13 @@ export interface NoteWindowBootOptions {
  * whose generation bumps would strand every command the main window has
  * pinned — and runs no index lifecycle of its own. The Rust `index:written`
  * broadcast (fired after the main window's applies commit) keeps this
- * window's index-backed queries fresh, and the window's initial deep link
- * rides the ordinary intake, buffering until the workspace's
- * DeepLinkProvider attaches.
+ * window's index-backed queries fresh.
+ *
+ * The initial deep link seeds the router directly whenever it resolves
+ * synchronously (⌘-click builds path-shaped links), so the window's first
+ * workspace render is already the clicked note — no flash of today's daily
+ * note. Only a target that needs the index (an id/title-shaped link) rides
+ * the ordinary intake, buffering until DeepLinkProvider attaches.
  *
  * A no-op everywhere else (main window, mobile, browser dev).
  */
@@ -45,9 +53,13 @@ export function useNoteWindowBoot({ platform, onAdopted, onFailed }: NoteWindowB
       try {
         const boot = await windowBootstrap()
         // The pending deep link is drained server-side by the bootstrap, so
-        // dispatch it even if this effect was superseded (StrictMode's probe
-        // mount) — the intake buffers it for whichever mount survives.
-        if (boot.initialDeepLink !== null) {
+        // act on it even if this effect was superseded (StrictMode's probe
+        // mount) — the route slot and the intake both outlive the effect,
+        // serving whichever mount survives.
+        const seeded = initialRouteForDeepLink(boot.initialDeepLink)
+        if (seeded !== null) {
+          setInitialWindowRoute(seeded)
+        } else if (boot.initialDeepLink !== null) {
           dispatchDeepLink(boot.initialDeepLink)
         }
         await subscriptions.add(subscribeIndexWritten(throttledInvalidateIndexQueries))

--- a/docs/multi-window.md
+++ b/docs/multi-window.md
@@ -67,10 +67,14 @@ under every window at once.
    non-main label and takes the adoption leg (`useNoteWindowBoot`):
    `window_bootstrap` returns the graph info + index generation (unbumped —
    pinned by the `session_adoption_reads_never_bump_generations` test) and
-   drains the pending deep link, which is fed through the normal deep-link
-   intake. It buffers until the workspace's `DeepLinkProvider` attaches,
-   then navigates — the same path an OS-delivered `reflect://` URL takes,
-   including `openNote` resolution and error surfacing.
+   drains the pending deep link. Because ⌘-click builds **path-shaped**
+   links, the route usually derives synchronously
+   (`initialRouteForDeepLink`) and seeds the router directly — the window's
+   first workspace render is already the clicked note, no flash of today's
+   daily note. Only a target that needs the index (an id/title-shaped link)
+   rides the normal deep-link intake, buffering until the workspace's
+   `DeepLinkProvider` attaches — the same path an OS-delivered `reflect://`
+   URL takes, including `openNote` resolution and error surfacing.
 4. The window renders `NoteWindowContent`: the routed view only, with daily
    targets shown as a single lazy `NotePane` (a daily is treated like any
    other note here, day label standing in for the title). The OS window


### PR DESCRIPTION
## Problem

⌘-clicking a backlink opened the new window with a visible three-beat flash: the boot loading state, then **today's daily note**, then the clicked note. The router seeded at its default (`today`) while the initial deep link rode the async intake — buffer until `DeepLinkProvider` attaches, resolve `openNote` through the index, navigate.

## Fix

The middle beat is unnecessary for every link ⌘-click actually produces: they're built by `deepLinkForRoute`, so `navigate`-kind links (`reflect://daily/<date>`, `today`, …) parse straight to a route and `openNote` targets are **path-shaped** (`reflect://note/notes%2Ffoo.md`) — no index round-trip needed.

- `initialRouteForDeepLink` (new, `lib/windows/initial-window-route.ts`) derives the route synchronously: navigate kinds directly, path-shaped note targets via `routeForPath` (a daily path still routes to the daily view, matching navigation everywhere else).
- `useNoteWindowBoot` seeds a per-webview slot with the derived route **instead of** dispatching through the intake; `GraphWorkspace` passes it as `RouterProvider`'s existing `initialRoute` prop. The window's first workspace render is the clicked note.
- Targets only the index can answer (hand-written id/title-shaped links arriving via `window:navigate` bootstraps) keep the old intake path and may still show today briefly — the price of an index round-trip, now confined to that rare case.
- The slot is a plain get/set (not consume-once): idempotent reads survive StrictMode's double-invoked initializers, and a webview boots once.

The remaining "Loading…" beat is the webview boot + bootstrap IPC — inherent, and no longer followed by a wrong note.

## Testing

- New suite for the derivation (navigate kinds, path-shaped notes, daily paths, index-only targets, capture links, garbage) and the slot's idempotent reads.
- Boot-hook tests updated: path-shaped link → slot seeded and intake bypassed; index-only target → intake fallback.
- `pnpm check` clean; 49 tests green across the touched suites (windows libs, boot hook, graph provider, deep-link provider).
- Manual: ⌘-click a backlink from a fresh `pnpm tauri:dev` — the window should go straight from Loading to the clicked note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop-only first-render routing UX; main window unchanged, and async intake remains for unresolvable deep links.
> 
> **Overview**
> **Fixes the ⌘-click note window flash** where the workspace briefly showed today's daily note before the intended note loaded.
> 
> Secondary windows now derive an initial route **synchronously** from the pending `reflect://` link (`initialRouteForDeepLink`): navigate-style links map directly; path-shaped `openNote` targets use `routeForPath` without an index lookup. `useNoteWindowBoot` writes that route into a per-webview slot; `GraphWorkspace` passes it to `RouterProvider` as `initialRoute` on non-main windows. Path-shaped ⌘-click links skip the deep-link intake entirely.
> 
> **Index-only targets** (id/title-shaped `openNote` links) still go through `dispatchDeepLink` and may briefly show today. The slot uses plain get/set (not consume-once) for StrictMode-safe reads. Tests cover derivation, the slot, and boot-hook branching; `docs/multi-window.md` documents the new boot path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7da15b3721a22ad8bf73399dc079ae8d3eb23ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->