### PR TITLE
Release v0.4.0-beta.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4743,7 +4743,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.4.0-beta.24"
+version = "0.4.0-beta.25"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.4.0-beta.24"
+version = "0.4.0-beta.25"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.4.0-beta.24",
+  "version": "0.4.0-beta.25",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.4.0-beta.25.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version string updates only; no application logic or dependency changes.
> 
> **Overview**
> Bumps the desktop **Reflect** release from `0.4.0-beta.24` to **`0.4.0-beta.25`** so Cargo, the Tauri app config, and the lockfile stay aligned for packaging and auto-update.
> 
> Version strings are updated in `reflect-open`’s `Cargo.toml`, `tauri.conf.json`, and the `reflect-open` entry in `Cargo.lock`. There are no functional or dependency changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 287782601e9935b7b067adedfdca33b9abcced30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->