### PR TITLE
fix(ios): keep the double-tap caret visible through the keyboard raise

### DIFF
--- a/apps/desktop/src/mobile/day-slide.tsx
+++ b/apps/desktop/src/mobile/day-slide.tsx
@@ -64,7 +64,7 @@ export function DaySlide({
     contentRef,
   })
 
-  const { revealEnd } = useCaretReveal({ containerRef, contentRef })
+  const { revealEnd, cancelReveal } = useCaretReveal({ containerRef, contentRef })
 
   // The end-of-note autofocus scrolls the caret into view against the
   // full-height viewport; the keyboard then raises and shrinks the shell by
@@ -90,8 +90,11 @@ export function DaySlide({
       // the selection the editor just placed.
       return
     }
+    // A reveal still settling from a recent double-tap must die first, or
+    // its next re-pin would undo this jump to the top.
+    cancelReveal()
     resetToTop()
-  }, [scrollResetSeq, selected, focusRequested, resetToTop])
+  }, [scrollResetSeq, selected, focusRequested, cancelReveal, resetToTop])
 
   return (
     <div

--- a/apps/desktop/src/mobile/day-slide.tsx
+++ b/apps/desktop/src/mobile/day-slide.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useRef, type ReactElement } from 'react'
+import { useCallback, useEffect, useRef, type ReactElement } from 'react'
 import { dailyPath } from '@reflect/core'
 import { NotePane } from '@/components/note-pane'
 import { formatDayLabel } from '@/lib/dates'
 import { cn } from '@/lib/utils'
 import { IncomingBacklinks } from '@/mobile/incoming-backlinks'
 import { MOBILE_CONTENT_GUTTER } from '@/mobile/mobile-content-gutter'
+import { useCaretReveal } from '@/mobile/use-caret-reveal'
 import { useScrollRestore } from '@/mobile/use-scroll-restore'
 import { useSettings } from '@/providers/settings-provider'
 
@@ -63,6 +64,17 @@ export function DaySlide({
     contentRef,
   })
 
+  const { revealEnd } = useCaretReveal({ containerRef, contentRef })
+
+  // The end-of-note autofocus scrolls the caret into view against the
+  // full-height viewport; the keyboard then raises and shrinks the shell by
+  // its height, dropping the note's end below the fold. The reveal holds the
+  // container at its end while that settles (see use-caret-reveal.ts).
+  const handleAutoFocused = useCallback(() => {
+    revealEnd()
+    onFocusConsumed()
+  }, [revealEnd, onFocusConsumed])
+
   const lastResetSeq = useRef(scrollResetSeq)
   useEffect(() => {
     if (scrollResetSeq === lastResetSeq.current) {
@@ -110,7 +122,7 @@ export function DaySlide({
           // V1's double-tap-to-today is a capture gesture: the caret (and the
           // scroll) land at the end of the day's content, ready to append.
           autoFocusSelection="end"
-          onAutoFocused={onFocusConsumed}
+          onAutoFocused={handleAutoFocused}
           showBacklinks={false}
           gutterClassName={MOBILE_CONTENT_GUTTER}
           editorClassName="min-h-[60dvh]"

--- a/apps/desktop/src/mobile/use-caret-reveal.test.ts
+++ b/apps/desktop/src/mobile/use-caret-reveal.test.ts
@@ -1,0 +1,180 @@
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { REVEAL_WINDOW_MS, useCaretReveal } from './use-caret-reveal'
+
+/**
+ * The end-of-note reveal in isolation (extracted from DaySlide). jsdom has no
+ * layout, so the container is faked with a controllable scroll range and a
+ * hand-fired ResizeObserver — the same harness as use-scroll-restore. The
+ * contract under test: the double-tap's caret lands at the note's end before
+ * the iOS keyboard reports its height, so the reveal must re-pin the
+ * container to its end as it shrinks, then get out of the user's way.
+ */
+
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = []
+
+  readonly observed: Element[] = []
+  disconnected = false
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    FakeResizeObserver.instances.push(this)
+  }
+
+  observe(target: Element): void {
+    this.observed.push(target)
+  }
+
+  unobserve(): void {}
+
+  disconnect(): void {
+    this.disconnected = true
+  }
+
+  takeRecords(): [] {
+    return []
+  }
+
+  /** Simulate a resize notification (real observers go quiet once disconnected). */
+  resize(): void {
+    if (!this.disconnected) {
+      this.callback([], this as unknown as ResizeObserver)
+    }
+  }
+}
+
+/** The single observer the active reveal created, or `undefined`. */
+function observer(): FakeResizeObserver | undefined {
+  return FakeResizeObserver.instances[0]
+}
+
+interface FakeScrollable {
+  element: HTMLDivElement
+  /** Change the scrollable range, as a keyboard raise (shrink) would. */
+  setScrollRange: (options: { scrollHeight: number; maxScrollTop: number }) => void
+}
+
+function createScrollable(scrollHeight: number, maxScrollTop: number): FakeScrollable {
+  const element = document.createElement('div')
+  let height = scrollHeight
+  let max = maxScrollTop
+  let top = 0
+  Object.defineProperty(element, 'scrollHeight', {
+    get: () => height,
+  })
+  Object.defineProperty(element, 'scrollTop', {
+    get: () => top,
+    set: (value: number) => {
+      top = Math.min(Math.max(value, 0), max)
+    },
+  })
+  return {
+    element,
+    setScrollRange: (options) => {
+      height = options.scrollHeight
+      max = options.maxScrollTop
+      top = Math.min(top, max)
+    },
+  }
+}
+
+function mountReveal(options: { scrollHeight: number; maxScrollTop: number }) {
+  const scrollable = createScrollable(options.scrollHeight, options.maxScrollTop)
+  const content = document.createElement('div')
+  scrollable.element.appendChild(content)
+  const containerRef = { current: scrollable.element }
+  const contentRef = { current: content }
+  const hook = renderHook(() => useCaretReveal({ containerRef, contentRef }))
+  return { scrollable, content, hook }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  FakeResizeObserver.instances = []
+  vi.stubGlobal('ResizeObserver', FakeResizeObserver)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('useCaretReveal', () => {
+  it('pins the container to its end immediately and re-pins as it shrinks', () => {
+    const { scrollable, content, hook } = mountReveal({ scrollHeight: 900, maxScrollTop: 400 })
+
+    hook.result.current.revealEnd()
+    expect(scrollable.element.scrollTop).toBe(400)
+    expect(observer()?.observed).toContain(scrollable.element)
+    expect(observer()?.observed).toContain(content)
+
+    // The keyboard raises: the shell (and the container) shrink by its
+    // height, so the reachable range grows and the end drops out of view.
+    scrollable.setScrollRange({ scrollHeight: 900, maxScrollTop: 716 })
+    observer()?.resize()
+    expect(scrollable.element.scrollTop).toBe(716)
+  })
+
+  it('re-pins on late content growth (images sizing in)', () => {
+    const { scrollable, hook } = mountReveal({ scrollHeight: 900, maxScrollTop: 400 })
+
+    hook.result.current.revealEnd()
+    scrollable.setScrollRange({ scrollHeight: 1300, maxScrollTop: 800 })
+    observer()?.resize()
+    expect(scrollable.element.scrollTop).toBe(800)
+  })
+
+  it('ends the reveal at the deadline — later resizes leave the user alone', () => {
+    const { scrollable, hook } = mountReveal({ scrollHeight: 900, maxScrollTop: 400 })
+
+    hook.result.current.revealEnd()
+    vi.advanceTimersByTime(REVEAL_WINDOW_MS)
+    expect(observer()?.disconnected).toBe(true)
+
+    scrollable.element.scrollTop = 100
+    scrollable.setScrollRange({ scrollHeight: 900, maxScrollTop: 716 })
+    observer()?.resize()
+    expect(scrollable.element.scrollTop).toBe(100)
+  })
+
+  it('hands control to the user on pointerdown', () => {
+    const { scrollable, hook } = mountReveal({ scrollHeight: 900, maxScrollTop: 400 })
+
+    hook.result.current.revealEnd()
+    scrollable.element.dispatchEvent(new Event('pointerdown'))
+    expect(observer()?.disconnected).toBe(true)
+
+    scrollable.element.scrollTop = 100
+    scrollable.setScrollRange({ scrollHeight: 900, maxScrollTop: 716 })
+    observer()?.resize()
+    expect(scrollable.element.scrollTop).toBe(100)
+  })
+
+  it('restarts the window when called again, replacing the old reveal', () => {
+    const { scrollable, hook } = mountReveal({ scrollHeight: 900, maxScrollTop: 400 })
+
+    hook.result.current.revealEnd()
+    const first = observer()
+    hook.result.current.revealEnd()
+    expect(first?.disconnected).toBe(true)
+    expect(FakeResizeObserver.instances).toHaveLength(2)
+
+    scrollable.setScrollRange({ scrollHeight: 900, maxScrollTop: 716 })
+    FakeResizeObserver.instances[1]?.resize()
+    expect(scrollable.element.scrollTop).toBe(716)
+  })
+
+  it('stops the reveal on unmount', () => {
+    const { scrollable, hook } = mountReveal({ scrollHeight: 900, maxScrollTop: 400 })
+
+    hook.result.current.revealEnd()
+    hook.unmount()
+    expect(observer()?.disconnected).toBe(true)
+
+    scrollable.element.scrollTop = 100
+    scrollable.setScrollRange({ scrollHeight: 900, maxScrollTop: 716 })
+    observer()?.resize()
+    expect(scrollable.element.scrollTop).toBe(100)
+  })
+})

--- a/apps/desktop/src/mobile/use-caret-reveal.test.ts
+++ b/apps/desktop/src/mobile/use-caret-reveal.test.ts
@@ -165,6 +165,25 @@ describe('useCaretReveal', () => {
     expect(scrollable.element.scrollTop).toBe(716)
   })
 
+  it('cancelReveal ends an active reveal without touching the scroll position', () => {
+    const { scrollable, hook } = mountReveal({ scrollHeight: 900, maxScrollTop: 400 })
+
+    hook.result.current.revealEnd()
+    expect(scrollable.element.scrollTop).toBe(400)
+    hook.result.current.cancelReveal()
+    expect(observer()?.disconnected).toBe(true)
+    expect(scrollable.element.scrollTop).toBe(400)
+
+    // An explicit jump-to-top after the cancel must stick: no late re-pin
+    // when the keyboard dismisses or content grows, and no live deadline.
+    scrollable.element.scrollTop = 0
+    scrollable.setScrollRange({ scrollHeight: 900, maxScrollTop: 716 })
+    observer()?.resize()
+    expect(scrollable.element.scrollTop).toBe(0)
+    vi.advanceTimersByTime(REVEAL_WINDOW_MS)
+    expect(scrollable.element.scrollTop).toBe(0)
+  })
+
   it('stops the reveal on unmount', () => {
     const { scrollable, hook } = mountReveal({ scrollHeight: 900, maxScrollTop: 400 })
 

--- a/apps/desktop/src/mobile/use-caret-reveal.ts
+++ b/apps/desktop/src/mobile/use-caret-reveal.ts
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, useRef, type RefObject } from 'react'
+
+/** How long a reveal keeps re-pinning the container to its end. The iOS
+ *  keyboard raise (and the shell shrinking by its height) settles well within
+ *  a second; past this the user's scrolling owns the position. */
+export const REVEAL_WINDOW_MS = 1500
+
+export interface CaretRevealOptions {
+  /** The scroll container to hold at its end while the reveal is active. */
+  containerRef: RefObject<HTMLElement | null>
+  /** The container's content, observed so late growth re-pins too. */
+  contentRef: RefObject<HTMLElement | null>
+}
+
+export interface CaretReveal {
+  /**
+   * Scroll the container to its end now and keep it there while the layout
+   * settles. The reveal ends when the user touches the container
+   * (pointerdown), {@link REVEAL_WINDOW_MS} passes, or the component
+   * unmounts; calling it again restarts the window.
+   */
+  revealEnd: () => void
+}
+
+/**
+ * Keeps an end-of-note caret visible through the iOS keyboard raise. The
+ * editor's own scroll-into-view runs at focus time — against the full-height
+ * viewport — but the keyboard reports its height only once it animates up,
+ * and the shell then shrinks by that height (Plan 19, decision 8), dropping
+ * the note's end below the fold again with nothing re-scrolling. A reveal
+ * pins the container to its end and re-pins on every container resize (the
+ * keyboard raise, a rotation) or content growth (images sizing in) until the
+ * window closes or the user takes over.
+ */
+export function useCaretReveal({ containerRef, contentRef }: CaretRevealOptions): CaretReveal {
+  const stopRef = useRef<(() => void) | null>(null)
+
+  useEffect(() => () => stopRef.current?.(), [])
+
+  const revealEnd = useCallback(() => {
+    const container = containerRef.current
+    const content = contentRef.current
+    if (container === null || content === null) {
+      return
+    }
+    stopRef.current?.()
+    let observer: ResizeObserver | null = null
+    let deadline: ReturnType<typeof setTimeout> | null = null
+    const stop = (): void => {
+      if (stopRef.current === stop) {
+        stopRef.current = null
+      }
+      if (deadline !== null) {
+        clearTimeout(deadline)
+      }
+      observer?.disconnect()
+      container.removeEventListener('pointerdown', stop)
+    }
+    stopRef.current = stop
+    const pin = (): void => {
+      container.scrollTop = container.scrollHeight
+    }
+    pin()
+    observer = new ResizeObserver(pin)
+    observer.observe(container)
+    observer.observe(content)
+    container.addEventListener('pointerdown', stop, { passive: true })
+    deadline = setTimeout(stop, REVEAL_WINDOW_MS)
+  }, [containerRef, contentRef])
+
+  return { revealEnd }
+}

--- a/apps/desktop/src/mobile/use-caret-reveal.ts
+++ b/apps/desktop/src/mobile/use-caret-reveal.ts
@@ -20,6 +20,12 @@ export interface CaretReveal {
    * unmounts; calling it again restarts the window.
    */
   revealEnd: () => void
+  /**
+   * End an active reveal without touching the scroll position. An explicit
+   * re-anchor (the slide's jump-to-top) must call this first — a live reveal
+   * would otherwise re-pin to the end on the next resize and undo it.
+   */
+  cancelReveal: () => void
 }
 
 /**
@@ -68,5 +74,9 @@ export function useCaretReveal({ containerRef, contentRef }: CaretRevealOptions)
     deadline = setTimeout(stop, REVEAL_WINDOW_MS)
   }, [containerRef, contentRef])
 
-  return { revealEnd }
+  const cancelReveal = useCallback(() => {
+    stopRef.current?.()
+  }, [])
+
+  return { revealEnd, cancelReveal }
 }


### PR DESCRIPTION
## Problem

Follow-up to #557. The Daily-tab double-tap places the caret at the end of today's note, but on a note longer than the screen the view doesn't end up showing it. The sequencing is the culprit:

1. `setSelection('end')` fires at focus time and scrolls the caret into view — against the **full-height** viewport, because the keyboard hasn't animated up yet.
2. The keyboard then reports its height and the mobile shell shrinks by it (`calc(100dvh - var(--keyboard-height))`, Plan 19 decision 8 — the Swift plugin keeps the webview full-frame and layout owns keyboard avoidance).
3. The day slide's scroll container shrinks by ~300px, the note's end drops below the fold, and nothing re-scrolls.

Short notes never scroll far enough to expose this, which is why the caret placement itself looked correct.

## Before → After

| | Before | After |
|---|---|---|
| Double-tap on a long daily note | Caret at the end, but hidden below the keyboard | Caret at the end and visible above the keyboard |
| Double-tap on a short note | Worked (nothing to scroll) | Unchanged |

## Changes

1. **New `useCaretReveal` hook** (`mobile/use-caret-reveal.ts`): `revealEnd()` pins the container to its end immediately and re-pins on every container resize (the keyboard raise, a rotation) or content growth (images sizing in), via one ResizeObserver on both nodes. The reveal ends when the user touches the container (`pointerdown`), a 1.5s window (`REVEAL_WINDOW_MS`) passes, or the component unmounts — the same stop-conditions shape as `useScrollRestore`, so it never fights the user's own scrolling. `cancelReveal()` ends an active reveal without touching the scroll position.
2. **`DaySlide` wires it into the focus arrival**: `onAutoFocused` now runs `revealEnd()` before consuming the focus request. Pinning to the container's end is exact here because the double-tap caret is by definition at the content end. The slide's jump-to-top path (`resetToTop()`) calls `cancelReveal()` first — a reveal still settling would otherwise re-pin to the end on the next resize and undo the jump (Bugbot finding on the first commit).

The reveal deliberately observes the container rather than subscribing to the keyboard store: it corrects any late layout change during the window, and it stays decoupled from how the height is delivered.

## Tests

- `use-caret-reveal.test.ts` (same fake-ResizeObserver / clamped-scrollTop harness as `use-scroll-restore.test.ts`): immediate pin + re-pin on container shrink (the keyboard raise), re-pin on late content growth, deadline hand-off, pointerdown hand-off, restart-on-second-call, cancel-then-jump-to-top staying put, and stop-on-unmount.
- `mobile-screen.test.tsx` (shell integration, unchanged) still pins the double-tap focus + `setSelection('end')` contract.

## Verification

- `pnpm vitest --run src/mobile/use-caret-reveal.test.ts src/mobile/use-scroll-restore.test.ts src/mobile/mobile-screen.test.tsx` — all passing
- `pnpm check` (typecheck + oxlint + eslint) — clean

Not run: on-device confirmation of the fix (the failure needs a real keyboard raise; jsdom can't reproduce it). Worth a quick TestFlight/simulator check on a long daily note.

## Risk / Rollout

Frontend-only, scoped to the mobile daily slide's focus arrival. Failure mode if the window ever misjudges: the view sits at the note's end for up to 1.5s — a touch immediately hands control back to the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)