### PR TITLE
perf(mobile): native reconcile scan + work-gated index-progress pill

### DIFF
--- a/apps/desktop/src-tauri/src/db/mod.rs
+++ b/apps/desktop/src-tauri/src/db/mod.rs
@@ -15,6 +15,7 @@ mod chat_write;
 mod embed_write;
 mod migrations;
 mod query;
+mod scan;
 #[cfg(test)]
 mod tests;
 mod write;
@@ -294,6 +295,32 @@ pub fn index_move<R: tauri::Runtime>(
     emit_index_written(&app);
     emit_note_moved(&app, &from, &to);
     Ok(())
+}
+
+/// Compute the open-path reconcile delta natively (see [`scan`]): list the
+/// graph's notes, compare against the stored rows, and return only what
+/// needs work. The listing happens **before** the index lock is taken, so
+/// thousands of stats never block concurrent reads. A stale generation
+/// returns the empty scan — that pass is superseded and its writes would be
+/// dropped anyway, so "nothing to do" is the honest answer.
+#[tauri::command]
+pub fn index_reconcile_scan(
+    generation: u64,
+    graph: State<GraphState>,
+    index: State<IndexState>,
+) -> AppResult<scan::ReconcileScan> {
+    let root = crate::fs::current_root(&graph)?;
+    let files = crate::fs::note_files(&root)?;
+    let state = lock_state(&index)?;
+    if state.generation != generation {
+        return Ok(scan::ReconcileScan::empty());
+    }
+    let conn = state.conn.as_ref().ok_or_else(AppError::no_graph)?;
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_millis() as u64)
+        .unwrap_or(0);
+    scan::scan_reconcile(conn, &files, now_ms)
 }
 
 /// One `index_touch` entry: re-stamp `path`'s stored mtime to `mtime`

--- a/apps/desktop/src-tauri/src/db/scan.rs
+++ b/apps/desktop/src-tauri/src/db/scan.rs
@@ -1,0 +1,135 @@
+//! The native half of the open-path reconcile (`index_reconcile_scan`).
+//!
+//! Comparing the file listing against the stored index rows used to happen in
+//! the webview: `list_files` serialized every entry over IPC, TS loaded every
+//! stored row through the query bridge, and a JS loop with event-loop yields
+//! crawled the listing — seconds of overhead on a large graph to conclude,
+//! almost always, "nothing changed". This module does the same comparison in
+//! native code and returns only the **delta**, so the TS reconcile touches
+//! exactly the files that need work (typically none).
+
+use std::collections::{HashMap, HashSet};
+
+use rusqlite::Connection;
+use serde::Serialize;
+
+use crate::error::AppResult;
+use crate::fs::FileMeta;
+
+/// Mirrors `MTIME_TRUST_AGE_MS` in `packages/core/src/indexing/hash.ts`: an
+/// mtime match may only skip the read once the file has settled — local write
+/// echoes stamp rows at write time, so two same-millisecond saves could
+/// otherwise read as "unchanged".
+const MTIME_TRUST_AGE_MS: u64 = 5_000;
+
+/// One file the TS reconcile must read: its listed mtime doesn't match the
+/// stored row (or is too fresh to trust), or it has no row at all. Stored
+/// facts ride along so the reconcile needs no follow-up query — a `None`
+/// hash marks an arrival (move-healing candidate).
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScanCandidate {
+    pub path: String,
+    /// The file's listed on-disk mtime (epoch ms).
+    pub modified_ms: u64,
+    /// The stored row's mtime, or `None` when the path has no row.
+    pub stored_mtime: Option<i64>,
+    /// The stored row's content hash, or `None` when the path has no row.
+    pub stored_hash: Option<String>,
+}
+
+/// A stored row whose file vanished from disk. Facts ride along because
+/// id-based move healing pairs orphans with arrivals and, on a heal, the
+/// moved row's hash decides whether the new path needs a re-index at all.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScanOrphan {
+    pub path: String,
+    pub stored_mtime: i64,
+    pub stored_hash: String,
+}
+
+/// The reconcile delta: what changed on disk relative to the index.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReconcileScan {
+    /// Markdown files listed (eviction placeholders included).
+    pub total: u64,
+    pub candidates: Vec<ScanCandidate>,
+    pub orphans: Vec<ScanOrphan>,
+}
+
+impl ReconcileScan {
+    /// The "nothing to do" scan a superseded generation reports.
+    pub fn empty() -> Self {
+        ReconcileScan {
+            total: 0,
+            candidates: Vec::new(),
+            orphans: Vec::new(),
+        }
+    }
+}
+
+/// Compare `files` (the note listing) against the stored `notes` rows.
+///
+/// Classification mirrors the TS reconcile it replaces: an eviction
+/// placeholder is present-but-unreadable (never a candidate, never orphaned);
+/// a row whose mtime equals the listing and has settled past
+/// [`MTIME_TRUST_AGE_MS`] is skipped without a read; everything else — moved
+/// mtimes, too-fresh mtimes, and rowless arrivals — is a candidate the TS
+/// side reads and hashes (hashes stay the authority for "did content
+/// change"). Rows with no listed file are orphans.
+pub(super) fn scan_reconcile(
+    conn: &Connection,
+    files: &[FileMeta],
+    now_ms: u64,
+) -> AppResult<ReconcileScan> {
+    let mut stored: HashMap<String, (i64, String)> = HashMap::new();
+    let mut stmt = conn.prepare_cached("SELECT path, mtime, file_hash FROM notes")?;
+    let rows = stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, (row.get(1)?, row.get(2)?)))
+    })?;
+    for row in rows {
+        let (path, facts) = row?;
+        stored.insert(path, facts);
+    }
+
+    let mut candidates = Vec::new();
+    let mut on_disk: HashSet<&str> = HashSet::with_capacity(files.len());
+    for file in files {
+        on_disk.insert(file.path.as_str());
+        if file.placeholder {
+            continue; // evicted to iCloud — unreadable until re-download
+        }
+        let facts = stored.get(&file.path);
+        let settled = now_ms.saturating_sub(file.modified_ms) >= MTIME_TRUST_AGE_MS;
+        if settled && facts.is_some_and(|(mtime, _)| *mtime == file.modified_ms as i64) {
+            continue; // untouched since it was indexed
+        }
+        candidates.push(ScanCandidate {
+            path: file.path.clone(),
+            modified_ms: file.modified_ms,
+            stored_mtime: facts.map(|(mtime, _)| *mtime),
+            stored_hash: facts.map(|(_, hash)| hash.clone()),
+        });
+    }
+
+    let mut orphans: Vec<ScanOrphan> = stored
+        .into_iter()
+        .filter(|(path, _)| !on_disk.contains(path.as_str()))
+        .map(|(path, (stored_mtime, stored_hash))| ScanOrphan {
+            path,
+            stored_mtime,
+            stored_hash,
+        })
+        .collect();
+    // HashMap iteration order is arbitrary; a stable order keeps move-healing
+    // pairing and removal deterministic across runs.
+    orphans.sort_by(|first, second| first.path.cmp(&second.path));
+
+    Ok(ReconcileScan {
+        total: files.len() as u64,
+        candidates,
+        orphans,
+    })
+}

--- a/apps/desktop/src-tauri/src/db/tests.rs
+++ b/apps/desktop/src-tauri/src/db/tests.rs
@@ -9,6 +9,7 @@ use super::chat_write::{delete_conversation, save_message, ChatConversation, Cha
 use super::embed_write::{apply_chunks, remove_chunks, EmbeddedChunk};
 use super::migrations::{migrate, migrate_to, open_in_memory, open_index_at, validate_migrations};
 use super::query::run_query;
+use super::scan::scan_reconcile;
 use super::write::{
     apply_note, clear_index, move_note, touch_note, IndexedEmail, IndexedLink, IndexedNote,
     IndexedTag, IndexedTask,
@@ -407,6 +408,64 @@ fn reapplying_a_note_replaces_its_rows() {
     let rows = run_query(&conn, "SELECT target_key FROM links", &[]).unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0]["target_key"], Value::from("z"));
+}
+
+#[test]
+fn reconcile_scan_classifies_candidates_orphans_and_skips() {
+    let conn = migrated();
+    let now: u64 = 100_000;
+    let indexed = |path: &str, mtime: i64, hash: &str| {
+        let mut row = note(path, "T", vec![]);
+        row.mtime = mtime;
+        row.file_hash = hash.to_string();
+        apply_note(&conn, &row).unwrap();
+    };
+    indexed("notes/settled.md", 1_000, "settled-hash");
+    indexed("notes/moved.md", 1_000, "moved-hash");
+    indexed("notes/fresh.md", (now - 1_000) as i64, "fresh-hash");
+    indexed("notes/evicted.md", 1_000, "evicted-hash");
+    indexed("notes/gone.md", 1_000, "gone-hash");
+
+    let meta = |path: &str, modified_ms: u64, placeholder: bool| crate::fs::FileMeta {
+        path: path.to_string(),
+        size: 1,
+        modified_ms,
+        placeholder,
+    };
+    let files = [
+        meta("notes/settled.md", 1_000, false), // row matches, settled → skipped
+        meta("notes/moved.md", 2_000, false),   // mtime moved → candidate with facts
+        meta("notes/fresh.md", now - 1_000, false), // matches but too fresh to trust → candidate
+        meta("notes/new.md", 3_000, false),     // no row → arrival candidate
+        meta("notes/evicted.md", 9_000, true),  // placeholder → never a candidate, never orphaned
+    ];
+
+    let scan = scan_reconcile(&conn, &files, now).unwrap();
+
+    assert_eq!(scan.total, 5);
+    let paths: Vec<&str> = scan
+        .candidates
+        .iter()
+        .map(|candidate| candidate.path.as_str())
+        .collect();
+    assert_eq!(paths, ["notes/moved.md", "notes/fresh.md", "notes/new.md"]);
+    let moved = &scan.candidates[0];
+    assert_eq!(moved.modified_ms, 2_000);
+    assert_eq!(moved.stored_mtime, Some(1_000));
+    assert_eq!(moved.stored_hash.as_deref(), Some("moved-hash"));
+    let arrival = &scan.candidates[2];
+    assert_eq!(arrival.stored_mtime, None);
+    assert_eq!(arrival.stored_hash, None);
+
+    // Only the vanished row is an orphan — eviction must not read as deletion.
+    let orphan_paths: Vec<&str> = scan
+        .orphans
+        .iter()
+        .map(|orphan| orphan.path.as_str())
+        .collect();
+    assert_eq!(orphan_paths, ["notes/gone.md"]);
+    assert_eq!(scan.orphans[0].stored_hash, "gone-hash");
+    assert_eq!(scan.orphans[0].stored_mtime, 1_000);
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -221,6 +221,7 @@ pub fn run() {
             db::index_remove,
             db::index_clear,
             db::index_move,
+            db::index_reconcile_scan,
             db::index_touch,
             db::note_move_indexed,
             db::index_meta_set,

--- a/apps/desktop/src/dev/dev-bridge.test.ts
+++ b/apps/desktop/src/dev/dev-bridge.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import type { IndexedNote } from '@reflect/core'
+import { createDevBridge } from '@/dev/dev-bridge'
+import { createDevFileStore } from '@/dev/dev-file-store'
+import { createDevIndexDb } from '@/dev/dev-index-db'
+
+/**
+ * The dev bridge's `index_reconcile_scan` mirrors the native scan in
+ * `src-tauri/src/db/scan.rs`; the mobile boot path calls it on every open,
+ * so a drifted stand-in would rot the `?platform=ios` harness loudly.
+ */
+
+function projection(path: string, mtime: number, fileHash: string): IndexedNote {
+  return {
+    path,
+    id: null,
+    title: path,
+    titleKey: path,
+    kind: 'note',
+    dailyDate: null,
+    isPrivate: false,
+    isPinned: false,
+    pinnedOrder: null,
+    hasConflict: false,
+    gistUrl: null,
+    gistStale: false,
+    fileHash,
+    mtime,
+    text: 'body',
+    assetText: '',
+    preview: 'body',
+    links: [],
+    tags: [],
+    aliases: [],
+    emails: [],
+    assets: [],
+    tasks: [],
+  }
+}
+
+describe('dev bridge index_reconcile_scan', () => {
+  it('classifies candidates and orphans like the native scan', async () => {
+    const files = createDevFileStore({ 'notes/settled.md': '# Settled' })
+    const index = await createDevIndexDb()
+    const bridge = createDevBridge({ platform: 'ios', files, index })
+
+    // The seeded file's row matches its listed mtime and has settled.
+    const settledMtime = files.list()[0]!.modifiedMs
+    index.applyNote(projection('notes/settled.md', settledMtime, 'settled-hash'))
+    // A row whose file is gone is an orphan.
+    index.applyNote(projection('notes/gone.md', 1_000, 'gone-hash'))
+    // A file with no row is an arrival candidate (fresh mtime, so it would be
+    // a candidate on both grounds).
+    files.write('notes/new.md', '# New')
+
+    const scan = (await bridge.invoke('index_reconcile_scan', { generation: 1 })) as {
+      total: number
+      candidates: Array<{ path: string; storedHash: string | null }>
+      orphans: Array<{ path: string; storedHash: string }>
+    }
+
+    expect(scan.total).toBe(2)
+    expect(scan.candidates.map((candidate) => candidate.path)).toEqual(['notes/new.md'])
+    expect(scan.candidates[0]!.storedHash).toBeNull()
+    expect(scan.orphans).toEqual([
+      { path: 'notes/gone.md', storedMtime: 1_000, storedHash: 'gone-hash' },
+    ])
+  })
+})

--- a/apps/desktop/src/dev/dev-bridge.ts
+++ b/apps/desktop/src/dev/dev-bridge.ts
@@ -190,6 +190,8 @@ export function createDevBridge(backend: DevBridgeBackend): IpcBridge {
         }
         return null
       }
+      case 'index_reconcile_scan':
+        return reconcileScan(files, index)
       case 'index_clear': {
         index.clear()
         return null
@@ -260,4 +262,42 @@ export function createDevBridge(backend: DevBridgeBackend): IpcBridge {
     // refresh the UI through core's in-process local-write echo.
     listen: async () => () => {},
   }
+}
+
+/** Mirrors `MTIME_TRUST_AGE_MS` in core's hash.ts and Rust's scan.rs. */
+const MTIME_TRUST_AGE_MS = 5_000
+
+/**
+ * The `index_reconcile_scan` stand-in: the same listing-vs-rows comparison
+ * `src-tauri/src/db/scan.rs` runs natively, over the in-memory store. The
+ * dev store never lists placeholders, so that arm has no mirror here.
+ */
+function reconcileScan(files: DevFileStore, index: DevIndexDb) {
+  const stored = new Map(
+    index
+      .query('SELECT path, mtime, file_hash FROM notes', [])
+      .map((row) => [String(row['path']), { mtime: Number(row['mtime']), hash: String(row['file_hash']) }]),
+  )
+  const now = Date.now()
+  const listing = files.list()
+  const onDisk = new Set(listing.map((file) => file.path))
+  const candidates = []
+  for (const file of listing) {
+    const facts = stored.get(file.path)
+    const settled = now - file.modifiedMs >= MTIME_TRUST_AGE_MS
+    if (settled && facts !== undefined && facts.mtime === file.modifiedMs) {
+      continue
+    }
+    candidates.push({
+      path: file.path,
+      modifiedMs: file.modifiedMs,
+      storedMtime: facts?.mtime ?? null,
+      storedHash: facts?.hash ?? null,
+    })
+  }
+  const orphans = [...stored.entries()]
+    .filter(([path]) => !onDisk.has(path))
+    .map(([path, facts]) => ({ path, storedMtime: facts.mtime, storedHash: facts.hash }))
+    .sort((first, second) => first.path.localeCompare(second.path))
+  return { total: listing.length, candidates, orphans }
 }

--- a/apps/desktop/src/lib/index-progress.test.ts
+++ b/apps/desktop/src/lib/index-progress.test.ts
@@ -10,9 +10,9 @@ describe('index progress store', () => {
     const listener = vi.fn()
     const unsubscribe = subscribeIndexProgress(listener)
 
-    setIndexProgress({ done: 16, total: 3000 })
+    setIndexProgress({ done: 16, total: 3000, worked: 16 })
     expect(listener).toHaveBeenCalledTimes(1)
-    expect(getIndexProgress()).toEqual({ done: 16, total: 3000 })
+    expect(getIndexProgress()).toEqual({ done: 16, total: 3000, worked: 16 })
 
     setIndexProgress(null)
     expect(listener).toHaveBeenCalledTimes(2)
@@ -24,8 +24,8 @@ describe('index progress store', () => {
     const listener = vi.fn()
     const unsubscribe = subscribeIndexProgress(listener)
 
-    setIndexProgress({ done: 16, total: 3000 })
-    setIndexProgress({ done: 16, total: 3000 }) // same values, new object
+    setIndexProgress({ done: 16, total: 3000, worked: 0 })
+    setIndexProgress({ done: 16, total: 3000, worked: 0 }) // same values, new object
     expect(listener).toHaveBeenCalledTimes(1)
 
     setIndexProgress(null)
@@ -38,7 +38,7 @@ describe('index progress store', () => {
     const listener = vi.fn()
     subscribeIndexProgress(listener)()
 
-    setIndexProgress({ done: 1, total: 200 })
+    setIndexProgress({ done: 1, total: 200, worked: 1 })
     expect(listener).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/lib/index-progress.ts
+++ b/apps/desktop/src/lib/index-progress.ts
@@ -12,6 +12,12 @@ export interface IndexProgress {
   readonly done: number
   /** Files in the listing. */
   readonly total: number
+  /**
+   * Files the pass has actually read so far (not skipped read-free). The
+   * pill gates on this: a routine pass skips everything (`worked` stays 0)
+   * and must never surface, no matter how large the graph.
+   */
+  readonly worked: number
 }
 
 let current: IndexProgress | null = null
@@ -19,7 +25,11 @@ const listeners = new Set<() => void>()
 
 /** Publish the running pass's progress; `null` clears it (pass finished). */
 export function setIndexProgress(progress: IndexProgress | null): void {
-  if (progress?.done === current?.done && progress?.total === current?.total) {
+  if (
+    progress?.done === current?.done &&
+    progress?.total === current?.total &&
+    progress?.worked === current?.worked
+  ) {
     return
   }
   current = progress

--- a/apps/desktop/src/mobile/index-progress-pill.test.tsx
+++ b/apps/desktop/src/mobile/index-progress-pill.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { setIndexProgress } from '@/lib/index-progress'
+import { publishKeyboardHeight } from '@/mobile/use-keyboard'
+import { IndexProgressPill } from './index-progress-pill'
+
+/**
+ * The "Preparing notes…" pill gates on the pass doing real work (`worked` =
+ * files actually read), not on graph size: a reconcile sweeps the whole
+ * listing on every open and resume, so `done`/`total` alone would show the
+ * pill every single time even when everything skips read-free.
+ */
+
+beforeEach(() => {
+  publishKeyboardHeight(0)
+})
+
+afterEach(() => {
+  setIndexProgress(null)
+  cleanup()
+})
+
+describe('IndexProgressPill', () => {
+  it('stays hidden for a skip-everything pass, however large the graph', () => {
+    setIndexProgress({ done: 3_500, total: 7_000, worked: 0 })
+    render(<IndexProgressPill />)
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('appears once a pass has actually read enough files (a first index)', () => {
+    setIndexProgress({ done: 160, total: 7_000, worked: 160 })
+    render(<IndexProgressPill />)
+    expect(screen.getByRole('status').textContent).toContain('160 of 7,000')
+  })
+
+  it('stays hidden below the work threshold — a routine sync of a few notes', () => {
+    setIndexProgress({ done: 6_900, total: 7_000, worked: 40 })
+    render(<IndexProgressPill />)
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('stays hidden on a small graph even when every file is read', () => {
+    setIndexProgress({ done: 90, total: 90, worked: 90 })
+    render(<IndexProgressPill />)
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('yields to the keyboard', () => {
+    setIndexProgress({ done: 500, total: 7_000, worked: 500 })
+    publishKeyboardHeight(300)
+    render(<IndexProgressPill />)
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+})

--- a/apps/desktop/src/mobile/index-progress-pill.tsx
+++ b/apps/desktop/src/mobile/index-progress-pill.tsx
@@ -9,17 +9,32 @@ import { useKeyboardVisible } from '@/mobile/use-keyboard'
 const MIN_TOTAL = 100
 
 /**
+ * Files the pass must have actually *read* before the pill appears. A pass
+ * runs on every open and every resume, and even a healthy one sweeps the
+ * whole listing (`done` counts skips) — so graph size alone would show the
+ * pill every single time. Real reads are what make a pass long: a first
+ * index crosses this within its first second; a skip-everything repeat pass
+ * stays at zero and never surfaces.
+ */
+const MIN_WORKED = 100
+
+/**
  * Progress for the running index pass, in the sync pill's shape. Appears only
- * during a pass over a large graph — the first open of a synced-down graph
- * indexes every note, which on a big graph takes long enough that a silent
- * shell reads as frozen. Subscribes to the module store directly (not graph
- * context) so per-tick updates re-render this pill alone.
+ * during a pass doing real work over a large graph — the first open of a
+ * synced-down graph reads every note, which on a big graph takes long enough
+ * that a silent shell reads as frozen. Subscribes to the module store
+ * directly (not graph context) so per-tick updates re-render this pill alone.
  */
 export function IndexProgressPill(): ReactElement | null {
   const progress = useSyncExternalStore(subscribeIndexProgress, getIndexProgress)
   const keyboardVisible = useKeyboardVisible()
 
-  if (progress === null || progress.total < MIN_TOTAL || keyboardVisible) {
+  if (
+    progress === null ||
+    progress.total < MIN_TOTAL ||
+    progress.worked < MIN_WORKED ||
+    keyboardVisible
+  ) {
     return null
   }
 

--- a/apps/desktop/src/providers/graph-index.test.ts
+++ b/apps/desktop/src/providers/graph-index.test.ts
@@ -213,15 +213,15 @@ describe('createGraphIndex', () => {
     const onFileProgress = vi.fn()
     let stale = false
     mockSync.mockImplementation(async (options) => {
-      options.onFileProgress?.(10, 100)
+      options.onFileProgress?.(10, 100, 10)
       stale = true
-      options.onFileProgress?.(20, 100) // a superseded pass must go quiet
+      options.onFileProgress?.(20, 100, 20) // a superseded pass must go quiet
     })
     const index = createGraphIndex({ onFileProgress })
     index.sync(5, () => stale)
     await index.stop()
 
     expect(onFileProgress).toHaveBeenCalledTimes(1)
-    expect(onFileProgress).toHaveBeenCalledWith(10, 100)
+    expect(onFileProgress).toHaveBeenCalledWith(10, 100, 10)
   })
 })

--- a/apps/desktop/src/providers/graph-index.ts
+++ b/apps/desktop/src/providers/graph-index.ts
@@ -94,10 +94,12 @@ export interface GraphIndexOptions {
   onMoved?: (from: string, to: string) => void
   /**
    * Called as a sync pass advances through the file listing (`done`,
-   * `total`) — the substrate for a "Preparing your notes… 400 of 3,000"
-   * surface during a first index. Superseded passes stop reporting.
+   * `total`, `worked`) — the substrate for a "Preparing your notes… 400 of
+   * 3,000" surface during a first index. `worked` counts files the pass has
+   * actually read (vs skipped read-free); the UI gates on it so a routine
+   * skip-everything pass never surfaces. Superseded passes stop reporting.
    */
-  onFileProgress?: (done: number, total: number) => void
+  onFileProgress?: (done: number, total: number, worked: number) => void
 }
 
 /**
@@ -160,9 +162,9 @@ export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
           ...(onMoved !== undefined ? { onMoved } : {}),
           ...(onFileProgress !== undefined
             ? {
-                onFileProgress: (progressDone: number, total: number) => {
+                onFileProgress: (progressDone: number, total: number, worked: number) => {
                   if (!isStale()) {
-                    onFileProgress(progressDone, total)
+                    onFileProgress(progressDone, total, worked)
                   }
                 },
               }

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -157,7 +157,7 @@ export function GraphProvider({
       // sync — the throttled variant collapses them to one refetch round per
       // window (an isolated batch still invalidates immediately).
       onApplied: throttledInvalidateIndexQueries,
-      onFileProgress: (done, total) => setIndexProgress({ done, total }),
+      onFileProgress: (done, total, worked) => setIndexProgress({ done, total, worked }),
       // External renames healed by id follow through to sessions and routes,
       // exactly as for an in-app rename (Plan 17).
       onMoved: followHealedMove,

--- a/packages/core/src/indexing/commands.ts
+++ b/packages/core/src/indexing/commands.ts
@@ -69,6 +69,47 @@ export async function moveNoteIndexed(
   await call('note_move_indexed', { from, to, generation }, voidSchema)
 }
 
+const scanCandidateSchema = z.object({
+  path: z.string(),
+  modifiedMs: z.number(),
+  storedMtime: z.number().nullable(),
+  storedHash: z.string().nullable(),
+})
+
+const scanOrphanSchema = z.object({
+  path: z.string(),
+  storedMtime: z.number(),
+  storedHash: z.string(),
+})
+
+const reconcileScanSchema = z.object({
+  total: z.number(),
+  candidates: z.array(scanCandidateSchema),
+  orphans: z.array(scanOrphanSchema),
+})
+
+/** One file the reconcile must read — see {@link reconcileScan}. */
+export type ScanCandidate = z.infer<typeof scanCandidateSchema>
+
+/** A stored row whose file vanished from disk — see {@link reconcileScan}. */
+export type ScanOrphan = z.infer<typeof scanOrphanSchema>
+
+/** The reconcile delta: what changed on disk relative to the index. */
+export type ReconcileScan = z.infer<typeof reconcileScanSchema>
+
+/**
+ * Compute the open-path reconcile delta natively: Rust lists the graph's
+ * notes and compares mtimes against the stored rows, returning only the
+ * files that need a read (with their stored facts riding along) and the
+ * rows whose files vanished. One IPC round-trip replaces the full-listing
+ * `listFiles` + stored-facts sweep the webview used to crawl on every open —
+ * on a healthy graph the delta is empty and the pass costs nothing. A stale
+ * `generation` reports an empty scan.
+ */
+export async function reconcileScan(generation: number): Promise<ReconcileScan> {
+  return call('index_reconcile_scan', { generation }, reconcileScanSchema)
+}
+
 /** One {@link touchIndexedNotes} entry: re-stamp `path`'s stored mtime. */
 export interface IndexedNoteTouch {
   /** Graph-relative markdown path. */

--- a/packages/core/src/indexing/indexer.ts
+++ b/packages/core/src/indexing/indexer.ts
@@ -6,6 +6,7 @@ import {
   applyIndexedNotes,
   clearIndex,
   moveIndexedRows,
+  reconcileScan,
   removeFromIndex,
   setIndexMeta,
   touchIndexedNotes,
@@ -13,11 +14,11 @@ import {
 } from './commands'
 import { assetReferencingNotePaths } from './asset-refs'
 import { gatherAssetDescriptionText } from './asset-description-text'
-import { hashContent, matchesTrustedMtime } from './hash'
+import { hashContent } from './hash'
 import { buildIndexedNote, PROJECTION_VERSION, type IndexedNote } from './indexed-note'
 import { detectExternalMoves } from './move-healing'
 import { INDEX_PASS_YIELD_EVERY, yieldToEventLoop } from './pacing'
-import { getIndexedFileFacts, getIndexMeta } from './queries'
+import { getIndexMeta } from './queries'
 
 /**
  * The indexing pipeline (Plan 04): read (Plan 02) → parse/extract in TS
@@ -346,41 +347,48 @@ export async function syncIndex(options: IndexPassOptions): Promise<void> {
  * carry `generation`, so even a pass that races a connection swap can't corrupt
  * the newly-opened index — Rust drops its stale writes.
  *
- * Two skip layers keep a repeat pass over a large, mostly-unchanged graph
- * cheap: a file whose listed mtime matches its indexed row is never even read
- * ({@link matchesTrustedMtime}), and a read whose hash matches skips the
- * write — re-stamping the row's mtime when it disagreed with the listing, so
- * the mismatch (e.g. an echo-time stamp from a local write) can't cost a
- * re-read on every future pass. Changed notes apply in shared
- * `index_apply_batch` transactions rather than one round-trip each.
+ * The full-listing comparison lives in Rust ({@link reconcileScan}): one IPC
+ * round-trip returns only the files needing a read — mtime moved, mtime too
+ * fresh to trust, or no row yet — with their stored facts riding along, plus
+ * the rows whose files vanished. On a healthy graph the delta is empty and
+ * the whole pass is that single call. Hashes stay the authority for "did
+ * content change": a read whose hash matches skips the write, re-stamping the
+ * row's mtime when it disagreed with the listing (an echo-time stamp, or a
+ * provider rewrote it) so the mismatch can't cost a re-read on every future
+ * pass. Changed notes apply in shared `index_apply_batch` transactions.
  */
 export async function reconcileIndex(options: IndexPassOptions): Promise<void> {
   const { generation, signal, onMoved, onSkippedNote, onFileProgress } = options
-  const files = await listFiles()
+  const scan = await reconcileScan(generation)
   if (signal?.aborted) {
     return
   }
-  const onDisk = new Set(files.map((file) => file.path))
-  const stored = await getIndexedFileFacts()
+  /** Stored facts per candidate path; healed moves graft the orphan's in. */
+  const facts = new Map<string, { mtime: number; fileHash: string }>()
+  for (const candidate of scan.candidates) {
+    if (candidate.storedMtime !== null && candidate.storedHash !== null) {
+      facts.set(candidate.path, { mtime: candidate.storedMtime, fileHash: candidate.storedHash })
+    }
+  }
+  /** Rows to drop at the end: scan orphans, minus heals, plus TOCTOU ghosts. */
+  const removals = new Map(scan.orphans.map((orphan) => [orphan.path, orphan]))
 
   // Id-based move healing (Plan 17): a row whose file vanished plus a new
   // file carrying the same frontmatter id is a rename observed after the
   // fact — an external tool or a sync pull moved it while Reflect wasn't
   // looking. Move the rows instead of delete+create, so embedding vectors
   // survive. Best-effort throughout: any failure degrades to the plain pass
-  // below (the arrival is indexed fresh, the cleanup loop drops the orphan).
-  const orphanPaths = [...stored.keys()].filter((path) => !onDisk.has(path))
-  // Placeholders can't be arrivals: their content is unreadable until iCloud
-  // re-downloads them, so move pairing has nothing to match on.
-  const arrivalPaths = files
-    .filter((file) => !stored.has(file.path) && file.placeholder !== true)
-    .map((file) => file.path)
+  // below (the arrival is indexed fresh, the removal loop drops the orphan).
+  // Placeholders can't be arrivals: Rust never lists them as candidates.
+  const arrivalPaths = scan.candidates
+    .filter((candidate) => candidate.storedHash === null)
+    .map((candidate) => candidate.path)
   /** Arrival content read for pairing — the main pass below reuses it. */
   let arrivalContent = new Map<string, string>()
   try {
-    const scan = await detectExternalMoves(orphanPaths, arrivalPaths, { signal })
-    arrivalContent = scan.content
-    for (const move of scan.moves) {
+    const healScan = await detectExternalMoves([...removals.keys()], arrivalPaths, { signal })
+    arrivalContent = healScan.content
+    for (const move of healScan.moves) {
       if (signal?.aborted) {
         return
       }
@@ -394,10 +402,10 @@ export async function reconcileIndex(options: IndexPassOptions): Promise<void> {
       }
       // The moved row carries the old path's facts: the main pass re-indexes
       // at the new path only if the content actually changed in transit.
-      const facts = stored.get(move.from)
-      stored.delete(move.from)
-      if (facts !== undefined) {
-        stored.set(move.to, facts)
+      const orphan = removals.get(move.from)
+      removals.delete(move.from)
+      if (orphan !== undefined) {
+        facts.set(move.to, { mtime: orphan.storedMtime, fileHash: orphan.storedHash })
       }
       onMoved?.(move.from, move.to)
     }
@@ -409,71 +417,65 @@ export async function reconcileIndex(options: IndexPassOptions): Promise<void> {
     return
   }
 
-  const now = Date.now()
   const batch = createIndexApplyBatch(generation, onSkippedNote)
   const touches = createMtimeTouchBatch(generation)
+  const total = scan.candidates.length
   let done = 0
   let worked = 0
-  for (const file of files) {
+  for (const candidate of scan.candidates) {
     if (signal?.aborted) {
       return
     }
     done += 1
     if (done % INDEX_PASS_YIELD_EVERY === 0) {
-      onFileProgress?.(done, files.length, worked)
+      onFileProgress?.(done, total, worked)
       await yieldToEventLoop()
     }
-    if (file.placeholder === true) {
-      // Evicted to iCloud: present but unreadable until re-download. Keep the
-      // stored row (its path is in `onDisk`, so the cleanup loop skips it) —
-      // reading would land in the notFound arm below and delete the note from
-      // the index, turning eviction into disappearance.
-      continue
-    }
-    const facts = stored.get(file.path)
-    if (matchesTrustedMtime(facts?.mtime, file.modifiedMs, now)) {
-      continue // untouched since it was indexed — skip the read entirely
-    }
+    const stored = facts.get(candidate.path)
     worked += 1
-    let content = arrivalContent.get(file.path)
+    let content = arrivalContent.get(candidate.path)
     if (content === undefined) {
       try {
-        content = await readNote(file.path)
+        content = await readNote(candidate.path)
       } catch (err) {
-        // The file moved/was deleted/locked between listFiles() and here (TOCTOU).
-        // If it's gone, drop it from `onDisk` so the cleanup loop removes its
-        // now-ghost row this pass; for a transient error keep the row and retry.
-        if (isAppError(err) && err.kind === 'notFound') {
-          onDisk.delete(file.path)
+        // The file moved/was deleted/locked between the scan and here (TOCTOU).
+        // If it's gone and had a row, that row is now a ghost — remove it this
+        // pass; for a transient error keep the row and retry next pass.
+        if (isAppError(err) && err.kind === 'notFound' && stored !== undefined) {
+          removals.set(candidate.path, {
+            path: candidate.path,
+            storedMtime: stored.mtime,
+            storedHash: stored.fileHash,
+          })
         }
         continue
       }
     }
     const fileHash = await hashContent(content)
-    if (facts?.fileHash === fileHash) {
+    if (stored?.fileHash === fileHash) {
       // Content unchanged. If the stored mtime doesn't match the listing (an
       // echo-time stamp, or a provider rewrote it), re-stamp it so the next
       // pass takes the read-free path — left alone it mismatches forever.
-      if (facts.mtime !== file.modifiedMs) {
-        await touches.add({ path: file.path, mtime: file.modifiedMs })
+      if (stored.mtime !== candidate.modifiedMs) {
+        await touches.add({ path: candidate.path, mtime: candidate.modifiedMs })
       }
       continue // unchanged
     }
     if (signal?.aborted) {
       return // re-check after the awaits — don't write for a superseded pass
     }
-    await batch.add(await buildNoteProjection(file.path, content, { fileHash, mtime: file.modifiedMs }))
+    await batch.add(
+      await buildNoteProjection(candidate.path, content, { fileHash, mtime: candidate.modifiedMs }),
+    )
   }
   await batch.flush()
   await touches.flush()
-  onFileProgress?.(files.length, files.length, worked)
+  onFileProgress?.(total, total, worked)
 
-  for (const path of stored.keys()) {
+  for (const path of removals.keys()) {
     if (signal?.aborted) {
       return
     }
-    if (!onDisk.has(path)) {
-      await removeFromIndex(path, generation)
-    }
+    await removeFromIndex(path, generation)
   }
 }

--- a/packages/core/src/indexing/indexer.ts
+++ b/packages/core/src/indexing/indexer.ts
@@ -143,9 +143,13 @@ export interface IndexPassOptions {
    * break and once at the end — so a first index over thousands of notes can
    * show real progress instead of a frozen shell. `done` counts every listed
    * file the pass has moved past (skipped or indexed); `total` is the listing
-   * size.
+   * size; `worked` counts the files actually *read* so far (not skipped
+   * read-free by the mtime layer). `worked` is what distinguishes a genuine
+   * first index from a routine repeat pass that skips everything — the
+   * progress UI must gate on it, or a healthy sub-second pass flashes a
+   * "preparing" surface on every open.
    */
-  onFileProgress?: (done: number, total: number) => void
+  onFileProgress?: (done: number, total: number, worked: number) => void
 }
 
 /** One note omitted from a rebuild because its projection could not be written. */
@@ -288,21 +292,23 @@ export async function rebuildIndex(options: IndexPassOptions): Promise<void> {
   const files = await listFiles()
   const batch = createIndexApplyBatch(generation, onSkippedNote)
   let done = 0
+  let worked = 0
   for (const file of files) {
     done += 1
     if (done % INDEX_PASS_YIELD_EVERY === 0) {
-      onFileProgress?.(done, files.length)
+      onFileProgress?.(done, files.length, worked)
       await yieldToEventLoop()
     }
     if (file.placeholder === true) {
       continue // evicted to iCloud — unreadable until re-download, indexed then
     }
+    worked += 1
     const content = await readNote(file.path)
     const fileHash = await hashContent(content)
     await batch.add(await buildNoteProjection(file.path, content, { fileHash, mtime: file.modifiedMs }))
   }
   await batch.flush()
-  onFileProgress?.(files.length, files.length)
+  onFileProgress?.(files.length, files.length, worked)
   // The rows now match the current projection — stamp it so `syncIndex` can
   // reconcile cheaply from here on. A superseded pass stamps into a stale
   // generation, which Rust drops: the next open then rebuilds again, which is
@@ -323,6 +329,13 @@ export async function syncIndex(options: IndexPassOptions): Promise<void> {
   if (stamped === String(PROJECTION_VERSION)) {
     return reconcileIndex(options)
   }
+  // Loud on purpose: a rebuild is expected once per projection bump or fresh
+  // graph. Seeing this on *every* open means the stamp (or the whole index
+  // file) isn't persisting between launches — a pathology that would
+  // otherwise be indistinguishable from a slow reconcile.
+  console.warn(
+    `index: stored projection version ${stamped === null ? 'none' : `"${stamped}"`} ≠ ${PROJECTION_VERSION} — full rebuild`,
+  )
   return rebuildIndex(options)
 }
 
@@ -400,13 +413,14 @@ export async function reconcileIndex(options: IndexPassOptions): Promise<void> {
   const batch = createIndexApplyBatch(generation, onSkippedNote)
   const touches = createMtimeTouchBatch(generation)
   let done = 0
+  let worked = 0
   for (const file of files) {
     if (signal?.aborted) {
       return
     }
     done += 1
     if (done % INDEX_PASS_YIELD_EVERY === 0) {
-      onFileProgress?.(done, files.length)
+      onFileProgress?.(done, files.length, worked)
       await yieldToEventLoop()
     }
     if (file.placeholder === true) {
@@ -420,6 +434,7 @@ export async function reconcileIndex(options: IndexPassOptions): Promise<void> {
     if (matchesTrustedMtime(facts?.mtime, file.modifiedMs, now)) {
       continue // untouched since it was indexed — skip the read entirely
     }
+    worked += 1
     let content = arrivalContent.get(file.path)
     if (content === undefined) {
       try {
@@ -451,7 +466,7 @@ export async function reconcileIndex(options: IndexPassOptions): Promise<void> {
   }
   await batch.flush()
   await touches.flush()
-  onFileProgress?.(files.length, files.length)
+  onFileProgress?.(files.length, files.length, worked)
 
   for (const path of stored.keys()) {
     if (signal?.aborted) {

--- a/packages/core/src/indexing/pipeline.test.ts
+++ b/packages/core/src/indexing/pipeline.test.ts
@@ -24,6 +24,13 @@ beforeEach(() => {
         return '# Hello\n\n[[World]]'
       case 'list_files':
         return [{ path: 'notes/a.md', size: 1, modifiedMs: 5 }]
+      case 'index_reconcile_scan':
+        // Mirrors the default list_files: one arrival needing a read.
+        return {
+          total: 1,
+          candidates: [{ path: 'notes/a.md', modifiedMs: 5, storedMtime: null, storedHash: null }],
+          orphans: [],
+        }
       case 'index_apply':
       case 'index_apply_batch':
       case 'index_clear':
@@ -171,7 +178,7 @@ describe('syncIndex', () => {
     metaRows = [{ value: String(PROJECTION_VERSION) }]
     await syncIndex({ generation: 2 })
     const commands = mockInvoke.mock.calls.map(([cmd]) => cmd)
-    expect(commands).toContain('list_files')
+    expect(commands).toContain('index_reconcile_scan')
     expect(commands).not.toContain('index_clear')
     expect(commands).not.toContain('index_meta_set')
   })
@@ -370,9 +377,12 @@ describe('reconcileIndex move healing (Plan 17)', () => {
     const calls: Array<[string, Record<string, unknown>]> = []
     mockInvoke.mockImplementation(async (command, args) => {
       calls.push([command, args])
-      const sql = String(args['sql'] ?? '')
-      if (command === 'list_files') {
-        return [{ path: NEW, size: 1, modifiedMs: 9 }]
+      if (command === 'index_reconcile_scan') {
+        return {
+          total: 1,
+          candidates: [{ path: NEW, modifiedMs: 9, storedMtime: null, storedHash: null }],
+          orphans: [{ path: OLD, storedMtime: 1, storedHash: options.storedHash }],
+        }
       }
       if (command === 'note_read') {
         if (args['path'] === NEW) {
@@ -381,9 +391,6 @@ describe('reconcileIndex move healing (Plan 17)', () => {
         throw { kind: 'notFound', message: 'missing' }
       }
       if (command === 'db_query') {
-        if (sql.includes('file_hash')) {
-          return [{ path: OLD, file_hash: options.storedHash }]
-        }
         if (((args['params'] as unknown[]) ?? []).includes(OLD)) {
           return [{ path: OLD, id: '01abcdefghjkmnpqrstvwxyz00' }]
         }
@@ -448,21 +455,20 @@ describe('reconcileIndex move healing (Plan 17)', () => {
   })
 })
 
-describe('reconcileIndex mtime skip', () => {
-  it('never reads a file whose indexed row matches its settled mtime', async () => {
-    mockInvoke.mockImplementation(async (command, args) => {
-      const sql = String(args['sql'] ?? '')
-      if (command === 'list_files') {
-        return [{ path: 'notes/a.md', size: 1, modifiedMs: 1_000 }]
+describe('reconcileIndex over the native scan delta', () => {
+  it('does nothing when the scan reports no delta — the healthy-open path', async () => {
+    // Mtime-matched files never leave Rust (the scan's own tests cover the
+    // classification); an empty delta must cost no reads, no writes, and no
+    // visible progress.
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === 'index_reconcile_scan') {
+        return { total: 7_000, candidates: [], orphans: [] }
       }
-      if (command === 'db_query' && sql.includes('file_hash')) {
-        return [{ path: 'notes/a.md', file_hash: 'stored', mtime: 1_000 }]
+      if (command === 'note_read') {
+        throw new Error('must not read without a candidate')
       }
       if (command === 'db_query') {
         return []
-      }
-      if (command === 'note_read') {
-        throw new Error('must not read an mtime-matched file')
       }
       return null
     })
@@ -474,29 +480,28 @@ describe('reconcileIndex mtime skip', () => {
     })
 
     const commands = mockInvoke.mock.calls.map(([cmd]) => cmd)
-    expect(commands).not.toContain('note_read')
-    expect(commands).not.toContain('index_apply_batch')
-    expect(commands).not.toContain('index_touch')
-    // A skip-everything pass reports zero worked files — the pill gates on
-    // this, so a routine open never flashes "Preparing notes".
-    expect(progress.at(-1)).toEqual([1, 1, 0])
+    expect(commands).toEqual(['index_reconcile_scan'])
+    // Zero worked files, and the total is the delta (0), not the graph size —
+    // the pill stays hidden on every routine open.
+    expect(progress).toEqual([[0, 0, 0]])
   })
 
-  it('reads (and hash-skips) when the stored mtime differs — providers rewrite mtimes', async () => {
+  it('reads (and hash-skips) a candidate whose stored mtime differs — providers rewrite mtimes', async () => {
     const content = '# Hello\n'
-    mockInvoke.mockImplementation(async (command, args) => {
-      const sql = String(args['sql'] ?? '')
-      if (command === 'list_files') {
-        return [{ path: 'notes/a.md', size: 1, modifiedMs: 2_000 }]
-      }
-      if (command === 'db_query' && sql.includes('file_hash')) {
-        return [{ path: 'notes/a.md', file_hash: await hashContent(content), mtime: 1_000 }]
-      }
-      if (command === 'db_query') {
-        return []
+    const storedHash = await hashContent(content)
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === 'index_reconcile_scan') {
+        return {
+          total: 1,
+          candidates: [{ path: 'notes/a.md', modifiedMs: 2_000, storedMtime: 1_000, storedHash }],
+          orphans: [],
+        }
       }
       if (command === 'note_read') {
         return content
+      }
+      if (command === 'db_query') {
+        return []
       }
       return null
     })
@@ -513,7 +518,7 @@ describe('reconcileIndex mtime skip', () => {
     // Identical content under a rewritten mtime: the hash still gates the write.
     expect(commands).not.toContain('index_apply_batch')
     // The self-heal: the row is re-stamped with the listed mtime, so the next
-    // pass skips the read entirely instead of re-hashing forever.
+    // scan skips it entirely instead of re-reading forever.
     const touch = mockInvoke.mock.calls.find(([cmd]) => cmd === 'index_touch')
     expect(touch![1]).toEqual({
       entries: [{ path: 'notes/a.md', mtime: 2_000 }],
@@ -522,59 +527,69 @@ describe('reconcileIndex mtime skip', () => {
     // The read counts as worked even though nothing was re-applied.
     expect(progress.at(-1)).toEqual([1, 1, 1])
   })
-})
 
-describe('iCloud eviction placeholders (Plan 21)', () => {
-  /** A graph whose listing carries `files`; every note_read throws notFound. */
-  function evictedFake(files: Array<Record<string, unknown>>, storedPaths: string[]) {
+  it('re-indexes changed candidates and drops orphans', async () => {
     mockInvoke.mockImplementation(async (command, args) => {
-      const sql = String(args['sql'] ?? '')
-      if (command === 'list_files') {
-        return files
+      if (command === 'index_reconcile_scan') {
+        return {
+          total: 2,
+          candidates: [
+            { path: 'notes/changed.md', modifiedMs: 2_000, storedMtime: 1_000, storedHash: 'old' },
+          ],
+          orphans: [{ path: 'notes/gone.md', storedMtime: 1_000, storedHash: 'gone' }],
+        }
       }
       if (command === 'note_read') {
-        throw { kind: 'notFound', message: 'evicted' }
+        return `# ${String(args['path'])}\n`
       }
       if (command === 'db_query') {
-        if (sql.includes('file_hash')) {
-          return storedPaths.map((path) => ({ path, file_hash: 'stored-hash' }))
-        }
         return []
       }
       return null
     })
-  }
 
-  it('reconcile keeps the stored row for an evicted note instead of deleting it', async () => {
-    evictedFake([{ path: 'notes/a.md', size: 1, modifiedMs: 5, placeholder: true }], ['notes/a.md'])
+    await reconcileIndex({ generation: 4 })
 
-    await reconcileIndex({ generation: 5 })
-
-    const commands = mockInvoke.mock.calls.map(([cmd]) => cmd)
-    // Present-but-offloaded: never read (unreadable), never removed (not deleted).
-    expect(commands).not.toContain('note_read')
-    expect(commands).not.toContain('index_remove')
-    expect(commands).not.toContain('index_apply')
-    expect(commands).not.toContain('index_apply_batch')
-  })
-
-  it('placeholders are not move-healing arrivals, and true orphans still drop', async () => {
-    evictedFake(
-      [{ path: 'notes/arrived.md', size: 1, modifiedMs: 5, placeholder: true }],
-      ['notes/gone-for-real.md'],
-    )
-
-    await reconcileIndex({ generation: 5 })
-
-    const commands = mockInvoke.mock.calls.map(([cmd]) => cmd)
-    // Nothing pairs against unreadable content…
-    expect(commands).not.toContain('note_read')
-    expect(commands).not.toContain('index_move')
-    // …and a row whose file is gone *without* a placeholder is still removed.
+    const apply = mockInvoke.mock.calls.find(([cmd]) => cmd === 'index_apply_batch')
+    const notes = (apply![1] as { notes: Array<{ path: string; mtime: number }> }).notes
+    expect(notes.map((note) => note.path)).toEqual(['notes/changed.md'])
+    expect(notes[0]!.mtime).toBe(2_000)
     const remove = mockInvoke.mock.calls.find(([cmd]) => cmd === 'index_remove')
-    expect(remove?.[1]).toMatchObject({ path: 'notes/gone-for-real.md', generation: 5 })
+    expect(remove![1]).toMatchObject({ path: 'notes/gone.md', generation: 4 })
   })
 
+  it('removes the row for a candidate that vanished between the scan and the read', async () => {
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === 'index_reconcile_scan') {
+        return {
+          total: 1,
+          candidates: [
+            { path: 'notes/ghost.md', modifiedMs: 2_000, storedMtime: 1_000, storedHash: 'h' },
+          ],
+          orphans: [],
+        }
+      }
+      if (command === 'note_read') {
+        throw { kind: 'notFound', message: 'vanished' }
+      }
+      if (command === 'db_query') {
+        return []
+      }
+      return null
+    })
+
+    await reconcileIndex({ generation: 4 })
+
+    const remove = mockInvoke.mock.calls.find(([cmd]) => cmd === 'index_remove')
+    expect(remove![1]).toMatchObject({ path: 'notes/ghost.md', generation: 4 })
+  })
+})
+
+describe('iCloud eviction placeholders (Plan 21)', () => {
+  /** A graph whose listing carries `files`; every note_read throws notFound. */
+  // Reconcile-side placeholder rules (never a candidate, never an orphan)
+  // now live in the Rust scan — `reconcile_scan_classifies_candidates_orphans_and_skips`
+  // in src-tauri covers them. Only the rebuild path still walks the listing here.
   it('rebuild indexes readable files and skips evicted ones', async () => {
     mockInvoke.mockImplementation(async (command, args) => {
       if (command === 'list_files') {

--- a/packages/core/src/indexing/pipeline.test.ts
+++ b/packages/core/src/indexing/pipeline.test.ts
@@ -63,7 +63,13 @@ describe('indexNote', () => {
 
 describe('rebuildIndex', () => {
   it('clears, lists, applies every file in one batch, then stamps the projection version', async () => {
-    await rebuildIndex({ generation: 1 })
+    const progress: Array<[number, number, number]> = []
+    await rebuildIndex({
+      generation: 1,
+      onFileProgress: (done, total, worked) => progress.push([done, total, worked]),
+    })
+    // A rebuild reads everything: worked tracks done, so the pill surfaces.
+    expect(progress.at(-1)).toEqual([1, 1, 1])
     const commands = mockInvoke.mock.calls.map(([cmd]) => cmd)
     expect(commands[0]).toBe('index_clear')
     expect(commands).toContain('list_files')
@@ -460,13 +466,20 @@ describe('reconcileIndex mtime skip', () => {
       }
       return null
     })
+    const progress: Array<[number, number, number]> = []
 
-    await reconcileIndex({ generation: 4 })
+    await reconcileIndex({
+      generation: 4,
+      onFileProgress: (done, total, worked) => progress.push([done, total, worked]),
+    })
 
     const commands = mockInvoke.mock.calls.map(([cmd]) => cmd)
     expect(commands).not.toContain('note_read')
     expect(commands).not.toContain('index_apply_batch')
     expect(commands).not.toContain('index_touch')
+    // A skip-everything pass reports zero worked files — the pill gates on
+    // this, so a routine open never flashes "Preparing notes".
+    expect(progress.at(-1)).toEqual([1, 1, 0])
   })
 
   it('reads (and hash-skips) when the stored mtime differs — providers rewrite mtimes', async () => {
@@ -488,7 +501,12 @@ describe('reconcileIndex mtime skip', () => {
       return null
     })
 
-    await reconcileIndex({ generation: 4 })
+    const progress: Array<[number, number, number]> = []
+
+    await reconcileIndex({
+      generation: 4,
+      onFileProgress: (done, total, worked) => progress.push([done, total, worked]),
+    })
 
     const commands = mockInvoke.mock.calls.map(([cmd]) => cmd)
     expect(commands).toContain('note_read')
@@ -501,6 +519,8 @@ describe('reconcileIndex mtime skip', () => {
       entries: [{ path: 'notes/a.md', mtime: 2_000 }],
       generation: 4,
     })
+    // The read counts as worked even though nothing was re-applied.
+    expect(progress.at(-1)).toEqual([1, 1, 1])
   })
 })
 


### PR DESCRIPTION
## Problem

Follow-up to #555, which fixed the redundant re-reads but not the visible symptom: the "Preparing notes… N of 7,000" pill still appears on every open and resume, counting through the whole graph.

Root cause of the *symptom* (as opposed to the wasted I/O): a reconcile pass runs on every graph open and every foreground resume (plus the post-open iCloud poll), `done` counts every file the pass moves past — **including read-free mtime skips** — and the pill rendered for any pass over 100 files for as long as it ran. On a 7k-note graph, even a pass that reads *nothing* had seconds of fixed overhead: `list_files` serializing 7k entries over IPC, the full stored-facts query through the db bridge, and ~437 event-loop yields at WKWebView's ~4ms chained-`setTimeout` clamp. So the pill faithfully swept 0→7,000 on every launch no matter how healthy the index was.

## Changes

**1. The reconcile delta is computed natively (`index_reconcile_scan`).** Rust lists the graph and compares mtimes against the `notes` table (the listing is taken *before* the index lock, so thousands of stats never block concurrent reads), returning only what needs work: candidates (mtime moved, mtime too fresh to trust, or no row — stored facts ride along) and structured orphans (for move healing and removal). `reconcileIndex` loops candidates only; a healthy open is **one IPC round-trip returning an empty delta**. Hashes stay the authority for "did content change", and the mtime trust guard + eviction-placeholder rules move into the scan with their own Rust tests. The dev bridge mirrors the scan so the `?platform=ios` harness boots the same path.

**2. The passes report `worked`** — files actually read — alongside `done`/`total` through `onFileProgress`, and the pill requires `worked ≥ 100` in addition to `total ≥ 100`. A genuine first index crosses the threshold within its first second; a skip-everything pass stays at zero. With the native scan, the pill's `total` is also now the delta size, not the graph size.

**3. `syncIndex` warns loudly on the full-rebuild fallback** (stored projection stamp missing/stale). A rebuild is expected once per projection bump or fresh graph — seeing the warning on *every* open would mean the stamp or the index file isn't persisting between launches, a pathology previously indistinguishable from a slow reconcile (devtools ship in release, so this is checkable on-device via Safari Web Inspector).

## Testing

- Rust: scan classification test (settled match skipped, moved mtime / too-fresh / arrival are candidates with correct facts, placeholders never candidates nor orphans, vanished rows are orphans); 249 crate tests pass, fmt clean.
- Core: reconcile-over-delta tests (empty delta → single IPC call, zero progress; hash-skip re-stamps; changed candidates re-apply; orphans and TOCTOU ghosts removed); move-healing suite reworked onto the scan contract.
- Desktop: new pill component test (hidden for skip passes and below the work threshold, visible during a real first index, yields to the keyboard); dev-bridge scan parity test; full desktop suite 1,595 tests pass; `pnpm check` clean.
- Pre-existing unrelated failure on `next`: `src/ai/language-model.test.ts` expects `/v1/messages` (fails on a clean checkout too — dependency drift, not this PR).

## Verification on device

Force-close → reopen should show **no pill** and the open-path pass should be a single sub-100ms native scan. If the pill still appears counting through everything, the pass is genuinely reading every file — check Safari Web Inspector for the new `index: stored projection version … — full rebuild` warning to confirm the rebuild-every-open pathology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more accurate indexing progress reporting, including how many files were actually read.
  * Improved the mobile indexing status display so it appears only after meaningful indexing work has started.

* **Bug Fixes**
  * Made index reconciliation more reliable when files are moved, renamed, deleted, or newly added.
  * Reduced unnecessary progress updates and improved stability when indexing results are already up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->