### PR TITLE
fix(mobile): don't focus the editor when navigating between notes

### DIFF
--- a/apps/desktop/src/components/backlinks-panel.test.tsx
+++ b/apps/desktop/src/components/backlinks-panel.test.tsx
@@ -134,9 +134,9 @@ describe('BacklinksPanel', () => {
 
     await userEvent.click(view.getByText('Meeting Notes'))
     expect(view.getByTestId('route').textContent).toContain('notes/meeting.md')
-    // A backlink tap restores focus on the destination (the mobile focus
-    // contract) — the arrival carries the router's focusEditor intent.
-    expect(view.getByTestId('route').getAttribute('data-focus')).toBe('true')
+    // A backlink tap must not request focus — on mobile that would raise the
+    // keyboard mid-arrival; desktop autofocuses note arrivals on its own.
+    expect(view.getByTestId('route').getAttribute('data-focus')).toBe('false')
     view.unmount()
   })
 

--- a/apps/desktop/src/editor/use-wiki-link-navigation.test.tsx
+++ b/apps/desktop/src/editor/use-wiki-link-navigation.test.tsx
@@ -64,12 +64,12 @@ describe('useWikiLinkNavigation', () => {
     view.unmount()
   })
 
-  it('arrives at a resolved note with the focus intent (the mobile focus contract)', async () => {
+  it('arrives at a resolved note without a focus intent (no keyboard on navigation)', async () => {
     resolveWikiTarget.mockResolvedValue({ kind: 'resolved', ref: 'notes/target.md' })
     const view = renderHost()
     lastHandler?.('Target')
     await waitFor(() => expect(currentRoute(view)).toContain('notes/target.md'))
-    expect(view.getByTestId('route').getAttribute('data-focus')).toBe('true')
+    expect(view.getByTestId('route').getAttribute('data-focus')).toBe('false')
     view.unmount()
   })
 
@@ -84,14 +84,14 @@ describe('useWikiLinkNavigation', () => {
     view.unmount()
   })
 
-  it('creates and opens an unresolved title, arriving with the focus intent', async () => {
+  it('creates and opens an unresolved title, without a focus intent', async () => {
     resolveWikiTarget.mockResolvedValue({ kind: 'unresolved', text: 'Brand New' })
     createNoteWithTitle.mockResolvedValue('notes/created.md')
     const view = renderHost(7)
     lastHandler?.('Brand New')
     await waitFor(() => expect(currentRoute(view)).toContain('notes/created.md'))
     expect(createNoteWithTitle).toHaveBeenCalledWith('Brand New', 7)
-    expect(view.getByTestId('route').getAttribute('data-focus')).toBe('true')
+    expect(view.getByTestId('route').getAttribute('data-focus')).toBe('false')
     view.unmount()
   })
 

--- a/apps/desktop/src/editor/use-wiki-link-navigation.ts
+++ b/apps/desktop/src/editor/use-wiki-link-navigation.ts
@@ -45,7 +45,7 @@ export function useWikiLinkNavigation(
   return useCallback(
     (target: string, event?: MouseEvent | KeyboardEvent) => {
       const newWindow = isNewWindowClick(event)
-      const open = async (route: Route, options?: { focusEditor: boolean }): Promise<void> => {
+      const open = async (route: Route): Promise<void> => {
         if (newWindow) {
           if (await openRouteInNewWindow(route)) {
             return
@@ -56,7 +56,7 @@ export function useWikiLinkNavigation(
             return
           }
         }
-        navigate(route, options)
+        navigate(route)
       }
       void (async () => {
         try {
@@ -66,16 +66,16 @@ export function useWikiLinkNavigation(
           }
           if (resolution.kind === 'resolved') {
             const route = routeForPath(resolution.ref)
-            // A link tap is an intent to keep writing there: the arrival
-            // carries a focus request the mobile note screen consumes (Plan 19
-            // focus contract). Desktop autofocuses note arrivals anyway.
-            await open(route, { focusEditor: route.kind === 'note' })
+            // Deliberately no focus request: on mobile, focusing mid-arrival
+            // raises the keyboard through the stack animation. Desktop
+            // autofocuses note arrivals on its own.
+            await open(route)
           } else if (isIsoDate(resolution.text)) {
             await open({ kind: 'daily', date: resolution.text })
           } else if (generation !== null && resolution.text.trim() !== '') {
             const created = await createNoteWithTitle(resolution.text, generation)
             if (!unmountedRef.current) {
-              await open({ kind: 'note', path: created }, { focusEditor: true })
+              await open({ kind: 'note', path: created })
             }
           }
         } catch (err) {

--- a/apps/desktop/src/hooks/use-backlink-navigation.ts
+++ b/apps/desktop/src/hooks/use-backlink-navigation.ts
@@ -16,10 +16,10 @@ export interface BacklinkNavigation {
   /**
    * Open an already-resolved source-note path: a daily note opens the daily
    * view (on mobile that swipes the carousel to the date — the surface stays
-   * mounted), anything else opens the note. A backlink tap restores focus on
-   * the destination (the mobile focus contract); desktop autofocuses note
-   * arrivals anyway. `event` (desktop) lets ⌘-click open a new window;
-   * mobile taps omit it.
+   * mounted), anything else opens the note. The arrival never requests focus
+   * — on mobile that would raise the keyboard through the stack animation;
+   * desktop autofocuses note arrivals anyway. `event` (desktop) lets ⌘-click
+   * open a new window; mobile taps omit it.
    */
   openSource: (path: string, event?: NewWindowClickEvent) => void
   /**
@@ -55,7 +55,7 @@ export function useBacklinkNavigation(): BacklinkNavigation {
   const openSource = useCallback(
     (target: string, event?: NewWindowClickEvent) => {
       const route = routeForPath(target)
-      const arrive = (): void => navigate(route, { focusEditor: route.kind === 'note' })
+      const arrive = (): void => navigate(route)
       if (isNewWindowClick(event)) {
         // Degrade a declined/failed open to in-window navigation so the
         // modifier can never make the click do nothing.

--- a/apps/desktop/src/mobile/incoming-backlinks.test.tsx
+++ b/apps/desktop/src/mobile/incoming-backlinks.test.tsx
@@ -109,7 +109,7 @@ describe('IncomingBacklinks', () => {
     view.unmount()
   })
 
-  it('navigates an ordinary source to the note route with the focus intent', async () => {
+  it('navigates an ordinary source to the note route without a focus intent', async () => {
     getBacklinksWithContext.mockResolvedValue([
       {
         sourcePath: 'notes/meeting.md',
@@ -122,9 +122,9 @@ describe('IncomingBacklinks', () => {
 
     await userEvent.click(await view.findByText('Meeting Notes'))
     expect(view.getByTestId('route').textContent).toContain('notes/meeting.md')
-    // A backlink tap restores focus on the destination note (the mobile
-    // focus contract) — the arrival carries the router's focusEditor intent.
-    expect(view.getByTestId('route').getAttribute('data-focus')).toBe('true')
+    // A backlink tap must not request focus — that would raise the keyboard
+    // through the mobile stack animation.
+    expect(view.getByTestId('route').getAttribute('data-focus')).toBe('false')
     view.unmount()
   })
 

--- a/apps/desktop/src/mobile/incoming-backlinks.tsx
+++ b/apps/desktop/src/mobile/incoming-backlinks.tsx
@@ -22,8 +22,8 @@ interface IncomingBacklinksProps {
  * mounted surface and persisted for the session (V1 kept it in session
  * storage too). Tapping a source that is a daily note swipes the day carousel
  * to that date — the daily surface stays mounted and follows the route —
- * while other sources open the note screen with the editor focused (the
- * mobile focus contract). Renders nothing when the note has no inbound
+ * while other sources open the note screen (without focusing the editor, so
+ * the keyboard stays down). Renders nothing when the note has no inbound
  * links; a failed query surfaces as an alert, because a failing query means
  * the index is broken, not that the note is unlinked.
  */

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -334,7 +334,7 @@ describe('MobileShell', () => {
     expect(view.getByRole('heading', { level: 1 }).textContent).toBe(monthLabel(todayIso()))
   })
 
-  it('restores editor focus on the destination of a wiki-link tap, but not on plain arrivals', async () => {
+  it('never focuses the destination editor on navigation (keyboard stays down)', async () => {
     const user = userEvent.setup()
     files['notes/source.md'] = 'see [[Target Note]]'
     const view = mount({ kind: 'note', path: 'notes/source.md' })
@@ -349,18 +349,18 @@ describe('MobileShell', () => {
     })
     expect(editorProbe.focusCalls).toBe(0)
 
-    // The tap resolves (unresolved title → create-from-unresolved), navigates,
-    // and the destination consumes the focus request when its editor mounts —
-    // the whole Plan 19 focus contract, end to end through the real router,
-    // NotePane, and document pipeline.
+    // The tap resolves (unresolved title → create-from-unresolved) and
+    // navigates, but the destination must NOT focus: the keyboard raise
+    // would cut through the stack push animation — end to end through the
+    // real router, NotePane, and document pipeline.
     await user.click(view.getByRole('button', { name: 'fake-wikilink' }))
     await waitFor(() => {
       expect(view.getByRole('heading').textContent).not.toContain('source')
     })
     await waitFor(() => {
-      expect(editorProbe.focusCalls).toBe(1)
+      expect(within(visibleLayer(view)).getByTestId('fake-editor')).toBeTruthy()
     })
-    // A note arrival keeps the default caret placement (the document start).
+    expect(editorProbe.focusCalls).toBe(0)
     expect(editorProbe.selectionCalls).toEqual([])
   })
 

--- a/apps/desktop/src/mobile/screens/note.test.tsx
+++ b/apps/desktop/src/mobile/screens/note.test.tsx
@@ -103,8 +103,8 @@ describe('MobileNote focus contract', () => {
     expect(paneProps.autoFocus).toBe(true)
   })
 
-  it('consumes the focusEditor arrival intent (wiki-link / backlink taps)', () => {
+  it('ignores a focusEditor arrival intent (navigation never raises the keyboard)', () => {
     renderArrival('notes/target.md', { focusEditor: true })
-    expect(paneProps.autoFocus).toBe(true)
+    expect(paneProps.autoFocus).toBe(false)
   })
 })

--- a/apps/desktop/src/mobile/screens/note.tsx
+++ b/apps/desktop/src/mobile/screens/note.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from 'react'
+import { type ReactElement } from 'react'
 import { isUntitledNotePath } from '@reflect/core'
 import { NotePane } from '@/components/note-pane'
 import { IncomingBacklinks } from '@/mobile/incoming-backlinks'
@@ -13,19 +13,15 @@ import { useRouter } from '@/routing/router'
  * (Plan 19). Lazy like the desktop note route, so a link to a not-yet-created
  * note opens an empty editor and the file is born on the first keystroke; a
  * fresh untitled note (`+`, V1 parity) autofocuses so the keyboard is up and
- * typing names it via the ghost-title flow. A wiki-link or backlink tap
- * arrives with the router's `focusEditor` intent, so the destination restores
- * focus too (the mobile focus contract) — while a plain arrival (All list,
- * back) never raises the keyboard. Back pops the history stack; a cold entry
- * (nothing to pop) lands on today instead.
+ * typing names it via the ghost-title flow. That is the only arrival that
+ * focuses: navigating here (wiki link, backlink, All list, back) never raises
+ * the keyboard — a focus during the stack animation would pull the keyboard
+ * up mid-slide. Back pops the history stack; a cold entry (nothing to pop)
+ * lands on today instead.
  */
 export function MobileNote({ path }: { path: string }): ReactElement {
-  const { back, canBack, navigate, arrivalFocusEditor } = useRouter()
+  const { back, canBack, navigate } = useRouter()
   const untitled = isUntitledNotePath(path)
-  // Latched at mount (the screen is keyed by path, so a mount IS the
-  // arrival): the editor appears only after the document loads, and by then
-  // a background navigation could have rewritten the arrival intent.
-  const [focusRequested] = useState(arrivalFocusEditor)
 
   return (
     <div className="flex h-full w-screen flex-col" style={{ paddingTop: 'env(safe-area-inset-top)' }}>
@@ -49,7 +45,7 @@ export function MobileNote({ path }: { path: string }): ReactElement {
         <NotePane
           path={path}
           lazy
-          autoFocus={untitled || focusRequested}
+          autoFocus={untitled}
           showBacklinks={false}
           // The daily surface gets its top inset from the date header; a
           // plain note has no chrome between the header bar and the body,

--- a/apps/desktop/src/routing/router.tsx
+++ b/apps/desktop/src/routing/router.tsx
@@ -41,11 +41,12 @@ interface RouterValue {
   arrivalSeq: number
   /**
    * True when the latest arrival asked the destination to focus its editor
-   * (`navigate(route, { focusEditor: true })`) — the mobile focus contract
-   * (Plan 19): a wiki-link or backlink tap restores focus (and the keyboard)
-   * on the destination note, while plain arrivals and back/forward stay calm.
-   * One-shot by construction: the next navigate overwrites it and history
-   * moves clear it, so it can never leak onto a later, unrelated arrival.
+   * (`navigate(route, { focusEditor: true })`). Only explicit write gestures
+   * request it — today just the mobile Daily-tab double-tap — while note
+   * navigations (wiki links, backlinks, back/forward) stay calm so the
+   * keyboard never rises mid-arrival. One-shot by construction: the next
+   * navigate overwrites it and history moves clear it, so it can never leak
+   * onto a later, unrelated arrival.
    */
   arrivalFocusEditor: boolean
   navigate: (route: Route, options?: NavigateOptions) => void
@@ -86,8 +87,9 @@ export interface NavigateOptions {
   restoreSurfaceScroll?: boolean
   /**
    * Ask the destination to focus its editor on arrival — see
-   * {@link RouterValue.arrivalFocusEditor}. Consumed by the mobile note
-   * screen; desktop's note route autofocuses every arrival and ignores it.
+   * {@link RouterValue.arrivalFocusEditor}. Consumed by the mobile daily
+   * surface (Daily-tab double-tap); desktop's note route autofocuses every
+   * arrival and ignores it.
    */
   focusEditor?: boolean
 }

--- a/docs/porting/reflect-mobile/editor-and-keyboard.md
+++ b/docs/porting/reflect-mobile/editor-and-keyboard.md
@@ -15,11 +15,14 @@ toolbar — and the hard-won keyboard/focus lessons.
 > derives the keyboard's smart-quotes/smart-dashes traits from it at focus
 > time (not from `autocorrect`, which stays on for typo fixing) — and
 > `autocapitalize`/`autocorrect` are set explicitly (`EditorInputTraits`).
-> Focus contract: wiki-link taps and backlink rows navigate with the
-> router's one-shot `focusEditor` arrival intent, which the mobile note
-> screen consumes into `autoFocus`; plain arrivals and back/forward never
-> raise the keyboard; no V1-style 500 ms timer (focus fires on editor
-> mount, after the async document load). Keyboard avoidance is by
+> Focus contract (revised 2026-07-06): navigation never focuses the
+> destination editor — a focus at arrival time raises the keyboard through
+> the stack push/pop animation. Wiki-link taps, backlink rows, plain
+> arrivals, and back/forward all land with the keyboard down. Only explicit
+> write gestures focus: the `+` new-note flow (untitled autofocus) and the
+> Daily-tab double-tap (the router's one-shot `focusEditor` intent, now
+> consumed only by the daily surface); no V1-style 500 ms timer (focus
+> fires on editor mount, after the async document load). Keyboard avoidance is by
 > **layout, in one place**: the mobile shell root is
 > `calc(100dvh - var(--keyboard-height))`, so scroll containers, the
 > editor, and floating-ui's positioning boundary (`body`) all end at the


### PR DESCRIPTION
## Problem

On iOS, tapping a wiki link or backlink row navigated with the router's one-shot `focusEditor` arrival intent (the Plan 19 "mobile focus contract"), which the mobile note screen consumed into `autoFocus`. The editor focused the moment the destination mounted, so the keyboard rose right through the stack push/pop animation — e.g. navigating from a daily note to a non-daily note. Browsing shouldn't raise the keyboard at all.

Scope: this only removes the focus-on-navigation behavior. The two explicit write gestures keep their autofocus, and desktop is untouched (its note route autofocuses every arrival on its own and never read this flag).

## Before → After

| Arrival | Before | After |
|---|---|---|
| Wiki-link tap → note | Editor focused, keyboard up mid-animation | No focus, keyboard stays down |
| Backlink row tap → note | Editor focused, keyboard up mid-animation | No focus, keyboard stays down |
| Wiki link creating a new note (create-from-unresolved) | Editor focused | No focus |
| `+` new untitled note | Autofocus (ghost-title flow) | Unchanged |
| Daily-tab double-tap | Autofocus at note end | Unchanged |
| Plain arrivals, back/forward | No focus | Unchanged |

## Changes

1. `use-wiki-link-navigation.ts` and `use-backlink-navigation.ts` no longer pass `{ focusEditor: true }` when opening note routes (including the create-from-unresolved path); the `open` helper lost its options parameter.
2. `mobile/screens/note.tsx` no longer consumes `arrivalFocusEditor` — `autoFocus` is now purely `untitled` (the `+` flow).
3. `routing/router.tsx` keeps the `focusEditor` mechanism (the Daily-tab double-tap in `mobile-shell.tsx` still uses it, consumed by `mobile/screens/daily.tsx`); its docs now name that as the sole producer/consumer.
4. `docs/porting/reflect-mobile/editor-and-keyboard.md` records the revised focus contract with a dated note.

## Tests

- `mobile/screens/note.test.tsx` — a `focusEditor` arrival intent is now ignored (`autoFocus` stays false); untitled autofocus still pinned.
- `editor/use-wiki-link-navigation.test.tsx` — resolved-note and create-from-unresolved arrivals carry no focus intent.
- `mobile/incoming-backlinks.test.tsx` / `components/backlinks-panel.test.tsx` — backlink taps navigate without the focus intent.
- `mobile/mobile-screen.test.tsx` — end-to-end through the real router, NotePane, and document pipeline: `focusCalls` stays 0 across a wiki-link navigation.
- `routing/router.test.tsx` — unchanged; the one-shot `focusEditor` mechanism itself still works for the daily double-tap.

## Verification

- `pnpm check` — typecheck + lint pass.
- `pnpm test --run` on the six touched suites — 85/85 pass.
- Not run: simulator/device pass (keyboard behavior during the real stack animation).

## Risk / Rollout

Frontend-only behavior change, no data or IPC impact. Worth a quick device check that a wiki-link tap from a daily note now lands with the keyboard down, and that the `+` flow and Daily double-tap still raise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only mobile UX change with no data or IPC impact; explicit write paths (+ and Daily double-tap) are preserved and covered by tests.
> 
> **Overview**
> Stops wiki-link and backlink navigation from raising the iOS keyboard during stack transitions by **dropping** `{ focusEditor: true }` from `use-wiki-link-navigation` and `use-backlink-navigation`, and **narrowing** mobile note autofocus to the **`+` untitled flow** only (`MobileNote` no longer reads `arrivalFocusEditor`).
> 
> The router still supports `focusEditor` for the **Daily-tab double-tap**, consumed by the daily surface; desktop note autofocus is unchanged. Porting docs record the revised focus contract; tests assert navigation leaves `arrivalFocusEditor` false and editor `focusCalls` at 0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d7f7042f356d3adab97f5dcc01e018e5c3527ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->