### PR TITLE
fix(mobile): let the day-swipe snap animation finish before reporting

### DIFF
--- a/apps/desktop/src/mobile/use-day-carousel.test.ts
+++ b/apps/desktop/src/mobile/use-day-carousel.test.ts
@@ -21,8 +21,8 @@ describe('reconcileCarousel', () => {
   })
 
   it('does nothing for the echo of our own swipe', () => {
-    // The route just echoed back the day we reported — re-scrolling would
-    // cancel Embla's settling animation.
+    // The route just echoed back the day we reported — the carousel already
+    // shows that slide, so re-scrolling would be a redundant jump.
     expect(reconcileCarousel({ ...base, date: '2026-06-01', reported: '2026-06-01' })).toEqual({
       action: 'none',
     })

--- a/apps/desktop/src/mobile/use-day-carousel.ts
+++ b/apps/desktop/src/mobile/use-day-carousel.ts
@@ -118,12 +118,18 @@ export interface DayCarousel {
  */
 export function useDayCarousel(date: string, onSelect: (date: string) => void): DayCarousel {
   const [dayWindow, setDayWindow] = useState<DayWindow>(() => createDayWindow(date, CAROUSEL_WINDOW))
-  const [emblaRef, emblaApi] = useEmblaCarousel({
+  // Frozen at mount: `embla-carousel-react` reinitializes whenever the options
+  // object stops comparing equal, and `reInit` snaps to `startIndex` with no
+  // animation — a render-derived `startIndex` would let every swipe's route
+  // echo cancel the settle animation and hard-switch to the landed slide.
+  // After mount, positioning belongs exclusively to the follow effect below.
+  const [emblaOptions] = useState<Parameters<typeof useEmblaCarousel>[0]>(() => ({
     startIndex: indexWithin(dayWindow, date),
     align: 'center',
     skipSnaps: false,
     watchDrag: dragAllowedWithKeyboardClosed,
-  })
+  }))
+  const [emblaRef, emblaApi] = useEmblaCarousel(emblaOptions)
   const [selectedIndex, setSelectedIndex] = useState(() => indexWithin(dayWindow, date))
   // The day we last reported via onSelect — so the route echo it produces
   // doesn't trigger a redundant (animation-cancelling) scrollTo.

--- a/apps/desktop/src/mobile/use-day-carousel.ts
+++ b/apps/desktop/src/mobile/use-day-carousel.ts
@@ -76,8 +76,9 @@ export interface ReconcileInput {
  * branchy reconciliation can be unit-tested without driving Embla:
  *
  * - `none` when the date is outside the window (`index === -1`, a re-anchor is
- *   pending) or is the echo of our own swipe (already reported) — re-scrolling
- *   then would cancel the in-flight animation.
+ *   pending) or is the echo of our own swipe (already reported) — the carousel
+ *   is already showing that slide, and the echo's redundant jump would clip an
+ *   animation the user may have restarted.
  * - `reinit` when the window was re-anchored (its start moved): Embla must
  *   reinitialize onto the rebuilt slide set at the target index.
  * - `scroll` for an ordinary in-window jump (calendar tap, Today, near link).
@@ -112,9 +113,8 @@ export interface DayCarousel {
  * A settled swipe reports its day via `onSelect` (which the parent turns into a
  * daily-route navigation); the route flows back in as `date` and scrolls the
  * carousel to match — guarded by {@link reconcileCarousel} so the swipe's own
- * echo doesn't re-scroll and cancel the animation. A `date` beyond the window
- * re-anchors it, and the follow effect then reinitializes Embla onto the new
- * slides.
+ * echo doesn't redundantly re-scroll. A `date` beyond the window re-anchors it,
+ * and the follow effect then reinitializes Embla onto the new slides.
  */
 export function useDayCarousel(date: string, onSelect: (date: string) => void): DayCarousel {
   const [dayWindow, setDayWindow] = useState<DayWindow>(() => createDayWindow(date, CAROUSEL_WINDOW))
@@ -132,7 +132,21 @@ export function useDayCarousel(date: string, onSelect: (date: string) => void): 
   // so Embla must reinitialize rather than scroll.
   const windowStartRef = useRef(dayWindow.start)
 
-  const onEmblaSelect = useCallback(
+  // Everything a swipe triggers waits for `settle` (snap animation done) —
+  // never `select`, which fires at pointer-up, exactly when the animation
+  // starts. Reporting there mounts a fresh editor slide and re-renders the
+  // whole route in the release frame, and Embla's fixed-timestep animation
+  // loop has no lag cap: the stall fast-forwards the physics to the target,
+  // so the note switches instantly instead of sliding over. The incoming
+  // slide is already mounted (it was a neighbor within the mount radius), so
+  // deferring costs nothing visually.
+  //
+  // Settling near a window edge also rebuilds the window around the current
+  // day, keeping swiping effectively infinite in both directions. The report
+  // above lands in the same batch, so the follow effect below sees the
+  // re-anchored window together with the new `date` and reinitializes Embla
+  // onto the slide the user is already looking at.
+  const onEmblaSettle = useCallback(
     (api: NonNullable<typeof emblaApi>) => {
       const index = api.selectedScrollSnap()
       setSelectedIndex(index)
@@ -141,37 +155,22 @@ export function useDayCarousel(date: string, onSelect: (date: string) => void): 
         reportedRef.current = day
         onSelect(day)
       }
-    },
-    [dayWindow, onSelect],
-  )
-
-  // Re-center the window when a settled swipe nears an edge: rebuild it around
-  // the current day so swiping stays effectively infinite in both directions.
-  // On `settle` (momentum done), never mid-drag — the rebuild reinitializes
-  // Embla (via the follow effect below), which would fight a live gesture. By
-  // settle time the swipe's day has already been reported and echoed back as
-  // `date`, so the reinit lands on the same slide the user is looking at.
-  const onEmblaSettle = useCallback(
-    (api: NonNullable<typeof emblaApi>) => {
-      const index = api.selectedScrollSnap()
       if (shouldRecenter(dayWindow, index)) {
-        setDayWindow(createDayWindow(dateAtIndex(dayWindow, index), CAROUSEL_WINDOW))
+        setDayWindow(createDayWindow(day, CAROUSEL_WINDOW))
       }
     },
-    [dayWindow],
+    [dayWindow, onSelect],
   )
 
   useEffect(() => {
     if (!emblaApi) {
       return
     }
-    emblaApi.on('select', onEmblaSelect)
     emblaApi.on('settle', onEmblaSettle)
     return () => {
-      emblaApi.off('select', onEmblaSelect)
       emblaApi.off('settle', onEmblaSettle)
     }
-  }, [emblaApi, onEmblaSelect, onEmblaSettle])
+  }, [emblaApi, onEmblaSettle])
 
   // Re-anchor only when the requested day falls outside the window (a far date
   // link): rebuild the window centered on it. The follow effect below then


### PR DESCRIPTION
## Problem

On iOS, swiping between daily notes tracks the finger, but the moment you lift it the carousel switches straight to the next note — the release snap animation never plays.

Two causes, one deterministic and one load-dependent:

1. **The options object cancelled the animation on every swipe.** The hook rebuilt Embla's options every render with `startIndex: indexWithin(dayWindow, date)`. `embla-carousel-react` calls `reInit` whenever the options stop comparing equal, and `reInit` snaps to `startIndex` with no animation. So each swipe's own route echo (`onSelect` → navigate → `date` prop) changed `startIndex` and hard-switched the carousel to the landed slide, killing the settle animation 100% of the time. (This exact failure mode was flagged as a watchlist item in the PR #475 notes.)

2. **The `select` handler stalled the release frame.** Embla fires `select` at pointer-up — exactly when the snap animation starts — and the handler did the heaviest work in the app right there: `setSelectedIndex` (mounting a fresh `DaySlide`, which mounts ProseMirror synchronously when the note is in the query cache) and the route navigation (re-rendering the whole mobile tree). Embla's animation engine replays fixed 60fps physics steps with no lag cap, so a main-thread stall fast-forwards the scroll body to its target.

## Change

- **Freeze the Embla options in mount-time state.** After mount, positioning belongs exclusively to the follow effect (`scrollTo` for in-window jumps, `reInit` on a window re-anchor via `reconcileCarousel`) — the react wrapper never auto-reinits again.
- **Move everything a swipe triggers — the day report, the selected-slide shift, and the edge re-center — from `select` to `settle`**, so nothing heavy runs while the animation plays. The incoming slide is already mounted (it sits within `MOUNT_RADIUS` of the old selection), so deferring has no visual cost. This also makes the code match the hook's own doc, which already said "a **settled** swipe reports its day".

Consequences worth knowing when reviewing:

- The route (and the calendar strip highlight) now updates when the animation settles (~a couple hundred ms after release) instead of at pointer-up.
- The report and the edge re-center land in the same React batch; the follow effect sees the re-anchored window together with the echoed `date` and reinitializes onto the slide the user is looking at — same outcome as before, exercised by the existing `reconcileCarousel` tests.
- A second swipe started mid-animation can briefly show an empty spacer (the +2 slide now mounts at settle, not at release). Previously that mount was part of the very stall that killed the animation.

## Verification

- `pnpm --filter @reflect/desktop test --run src/mobile/use-day-carousel.test.ts src/mobile/mobile-screen.test.tsx` — 33 passed
- `pnpm check` (typecheck + lint) — clean
- Not yet verified on an iOS device/simulator — a device pass of the swipe feel (single swipe, fast multi-swipe, swipe near window edges, calendar-strip taps, far date links) is owed before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mobile daily navigation timing and Embla lifecycle; behavior is localized to `useDayCarousel` with unit tests, but swipe feel and fast multi-swipe edge cases still need device verification.
> 
> **Overview**
> Fixes iOS day-carousel swipes that **jumped straight to the next note on finger release** instead of playing Embla’s snap animation. Heavy work at pointer-up (`select`)—mounting the next `DaySlide`, route navigation, and the full mobile tree—could stall the main thread while Embla’s animation loop **fast-forwards** with no lag cap, so the first painted frame was already on the destination slide.
> 
> **`useDayCarousel` now does all swipe-driven work on `settle`:** updates `selectedIndex`, reports the day via `onSelect`, and edge re-centering run only after the snap finishes. The neighbor slide is already within the mount radius, so deferring has no visual cost; route and calendar strip highlight update ~a couple hundred ms later.
> 
> Embla **options are frozen at mount** (`useState`) so a render-derived `startIndex` cannot make `embla-carousel-react` reinit on every route echo and hard-snap away from an in-flight settle. Comments in `reconcileCarousel` and tests are aligned with “redundant re-scroll” rather than “cancel animation.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b8650c20000a3fa662313226d5c27c44d832882. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->