### PR TITLE
fix(desktop): honor the `timeFormat` setting in the `/now` slash command

### DIFF
--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -318,6 +318,7 @@ export function NotePaneComponent({
         onChange={document.onEditorChange}
         markMode={markModeFromSyntax(settings.editorMarkdownSyntax)}
         spellCheck={settings.editorSpellCheck}
+        timeFormat={settings.timeFormat}
         bulletAfterHeading={settings.editorBulletAfterHeading}
         // The grip drag-reorders blocks and the "+" inserts a paragraph below.
         blockHandle={true}

--- a/apps/desktop/src/components/tasks/task-editor.tsx
+++ b/apps/desktop/src/components/tasks/task-editor.tsx
@@ -216,6 +216,7 @@ export function TaskEditor({
         onChange={onChange}
         markMode={markModeFromSyntax(settings.editorMarkdownSyntax)}
         spellCheck={settings.editorSpellCheck}
+        timeFormat={settings.timeFormat}
         // A one-line editor has nothing to reorder, so keep the gutter grip off.
         blockHandle={false}
         onWikiLinkClick={navigate}

--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -13,6 +13,7 @@ interface CapturedEditorProps {
   mode?: 'hide' | 'focus' | 'show' | 'source'
   editorClassName?: string
   spellCheck?: boolean
+  timeFormat?: '12' | '24'
   children?: ReactNode
   resolveImageUrl?: (src: string) => string | undefined
   onImageClick?: (payload: { src: string; alt: string; event: MouseEvent }) => void
@@ -150,6 +151,18 @@ describe('NoteEditor markdown syntax mode', () => {
   it('passes an explicit markdown syntax mode to meowdown', () => {
     render(<NoteEditor initialContent="" markMode="show" />)
     expect(captured.props?.mode).toBe('show')
+  })
+})
+
+describe('NoteEditor time format', () => {
+  it('passes the 12-hour clock to meowdown by default', () => {
+    renderEditor()
+    expect(captured.props?.timeFormat).toBe('12')
+  })
+
+  it("maps the 24h setting to meowdown's 24-hour clock", () => {
+    render(<NoteEditor initialContent="" timeFormat="24h" />)
+    expect(captured.props?.timeFormat).toBe('24')
   })
 })
 

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -8,7 +8,7 @@ import {
   type Ref,
 } from 'react'
 import { openUrl } from '@tauri-apps/plugin-opener'
-import { errorMessage } from '@reflect/core'
+import { errorMessage, type TimeFormat } from '@reflect/core'
 import {
   type AcceptPendingReplacementOptions,
   type ExitBoundaryHandler,
@@ -101,6 +101,11 @@ interface NoteEditorProps {
   /** Whether the browser underlines misspelled words (default on). */
   spellCheck?: boolean
   /**
+   * Clock format for the time the `/now` slash command inserts (the
+   * `timeFormat` setting). Defaults to `12h`.
+   */
+  timeFormat?: TimeFormat
+  /**
    * Whether Enter at the end of a heading starts a bullet on the next line
    * (the `editorBulletAfterHeading` setting). Off by default.
    */
@@ -187,6 +192,7 @@ export function NoteEditor({
   onChange,
   markMode = 'hide',
   spellCheck = true,
+  timeFormat = '12h',
   bulletAfterHeading = false,
   blockHandle = false,
   resolveImageUrl,
@@ -379,6 +385,9 @@ export function NoteEditor({
         // syntax ([[ wiki links, code spans, --- fences) — Plan 19 gate.
         // Autocorrect is independent and stays on (EditorInputTraits).
         spellCheck={isTouchEditorSurface() ? false : spellCheck}
+        // Reflect's implementation-neutral `12h`/`24h` maps to meowdown's
+        // `12`/`24` here at the boundary, like `markModeFromSyntax`.
+        timeFormat={timeFormat === '24h' ? '24' : '12'}
         bulletAfterHeading={bulletAfterHeading}
         blockHandle={blockHandle}
         editorClassName={cn('reflect-editor', className)}

--- a/apps/desktop/src/mobile/task-edit-sheet.tsx
+++ b/apps/desktop/src/mobile/task-edit-sheet.tsx
@@ -231,6 +231,7 @@ export function MobileTaskEditSheet({
             onChange={handleChange}
             markMode={markModeFromSyntax(settings.editorMarkdownSyntax)}
             spellCheck={settings.editorSpellCheck}
+            timeFormat={settings.timeFormat}
             // A one-line editor has nothing to reorder, so keep the gutter grip off.
             blockHandle={false}
             onWikiLinkClick={openWikiLink}


### PR DESCRIPTION
Pass the `timeFormat` setting through `NoteEditor` to meowdown, so `/now` inserts `20:55` instead of `8:55pm` when the 24-hour clock is selected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Note editing now respects your chosen time format, including in desktop, task, and mobile task editing flows.
  * Inline editor commands can now display times in either 12-hour or 24-hour format based on app settings.

* **Bug Fixes**
  * Fixed inconsistent time display in the note editor when no time format was explicitly provided.
  * Improved consistency so the same time format is used across note and task entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->