### PR TITLE
Add haptics to mobile daily and task interactions

### DIFF
--- a/apps/desktop/src/mobile/calendar-strip.tsx
+++ b/apps/desktop/src/mobile/calendar-strip.tsx
@@ -3,6 +3,7 @@ import { Settings } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { addDaysIso } from '@/lib/dates'
 import { monthLabel, weekAtIndex, weekStartOf } from '@/mobile/calendar'
+import { hapticImpactLight } from '@/mobile/haptics'
 import { useWeekStrip } from '@/mobile/use-week-strip'
 import { WeekRow } from '@/mobile/week-row'
 import { useSettings } from '@/providers/settings-provider'
@@ -49,10 +50,16 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
     displayedWeekStart === selectionWeekStart ? date : addDaysIso(displayedWeekStart, 3)
 
   const jumpToToday = (): void => {
+    hapticImpactLight()
     onSelect(today)
     // Selecting today only moves the strip when `date` changes — re-center
     // explicitly so a browse-away strip snaps back even when already on today.
     showWeekOf(today)
+  }
+
+  const openSettings = (): void => {
+    hapticImpactLight()
+    navigate({ kind: 'settings' })
   }
 
   // An explicit re-arrival doesn't change `date`, so the follow effect won't
@@ -80,7 +87,7 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
             size="icon"
             className="size-9"
             aria-label="Settings"
-            onClick={() => navigate({ kind: 'settings' })}
+            onClick={openSettings}
           >
             <Settings />
           </Button>

--- a/apps/desktop/src/mobile/haptics.ts
+++ b/apps/desktop/src/mobile/haptics.ts
@@ -4,8 +4,9 @@ let bridgeAvailable = true
 
 /**
  * Fire a light impact haptic — V1 parity for calendar-strip date taps and
- * tab presses. WKWebView has no `navigator.vibrate`, so the tap goes through
- * the first-party keyboard plugin's `impact_light` command
+ * tab presses, plus task-surface confirmations. WKWebView has no
+ * `navigator.vibrate`, so the tap goes through the first-party keyboard plugin's
+ * `impact_light` command
  * (`plugins/tauri-plugin-keyboard`).
  *
  * Fire-and-forget and fail-soft: where the plugin isn't registered (desktop,

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -51,6 +51,7 @@ const editorProbe = vi.hoisted(() => ({
   focusCalls: 0,
   selectionCalls: [] as Array<'start' | 'end'>,
 }))
+const hapticImpactLight = vi.hoisted(() => vi.fn())
 
 vi.mock('@/editor/note-editor', async () => {
   const { useEffect } = await import('react')
@@ -97,6 +98,9 @@ vi.mock('@/editor/note-editor', async () => {
     },
   }
 })
+vi.mock('@/mobile/haptics', () => ({
+  hapticImpactLight,
+}))
 
 const indexFns = vi.hoisted(() => ({
   getBacklinksWithContext: vi.fn(async () => []),
@@ -146,6 +150,7 @@ beforeEach(() => {
   editorProbe.focusCalls = 0
   editorProbe.selectionCalls = []
   mockInvoke.mockReset()
+  hapticImpactLight.mockClear()
   mockInvoke.mockImplementation(async (command, args) => {
     if (command === 'note_read') {
       const content = files[(args as { path: string }).path]
@@ -299,11 +304,30 @@ describe('MobileShell', () => {
       'date',
     )
 
+    hapticImpactLight.mockClear()
     await user.click(view.getByRole('button', { name: 'Jump to today' }))
+    expect(hapticImpactLight).toHaveBeenCalledTimes(1)
     expect(view.getByRole('button', { name: dayCellLabel(today) }).getAttribute('aria-current')).toBe(
       'date',
     )
     expect(view.queryByRole('button', { name: 'Today' })).toBeNull()
+  })
+
+  it('fires haptics from the Daily header Today and Settings buttons', async () => {
+    const user = userEvent.setup()
+    const today = todayIso()
+    const other = otherDayInWeek(today)
+    const view = mount({ kind: 'today' })
+
+    await user.click(view.getByRole('button', { name: dayCellLabel(other) }))
+    hapticImpactLight.mockClear()
+
+    await user.click(view.getByRole('button', { name: 'Today' }))
+    expect(hapticImpactLight).toHaveBeenCalledTimes(1)
+
+    await user.click(view.getByRole('button', { name: 'Settings' }))
+    expect(hapticImpactLight).toHaveBeenCalledTimes(2)
+    expect(view.getByRole('heading', { name: 'Settings' })).toBeTruthy()
   })
 
   it('re-anchors the carousel when a date link lands outside its window', async () => {

--- a/apps/desktop/src/mobile/screens/tasks.test.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.test.tsx
@@ -21,6 +21,7 @@ import { MobileTasks } from './tasks'
 const getOpenTasks = vi.hoisted(() => vi.fn())
 const getCompletedTasks = vi.hoisted(() => vi.fn())
 const resolveWikiTarget = vi.hoisted(() => vi.fn())
+const hapticImpactLight = vi.hoisted(() => vi.fn())
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   hasBridge: () => true,
@@ -57,6 +58,9 @@ vi.mock('@/editor/use-editor-autocomplete', () => ({
     onWikilinkSearch: async () => [],
     onTagSearch: async () => [],
   }),
+}))
+vi.mock('@/mobile/haptics', () => ({
+  hapticImpactLight,
 }))
 
 const editorProbe = vi.hoisted(() => ({ focusCalls: 0 }))
@@ -228,6 +232,7 @@ beforeEach(() => {
   fail.mockReset()
   resolveWikiTarget.mockReset()
   resolveWikiTarget.mockResolvedValue({ kind: 'resolved', ref: 'notes/other.md' })
+  hapticImpactLight.mockClear()
   editorProbe.focusCalls = 0
   resetRecentlyCompleted()
 })
@@ -261,13 +266,36 @@ describe('MobileTasks', () => {
 
     await user.click(await view.findByRole('button', { name: 'Complete: buy milk' }))
 
+    expect(hapticImpactLight).toHaveBeenCalledTimes(1)
     expect(toggleTask).toHaveBeenCalledTimes(1)
     // V1's middle state: the completed row stays visible, struck, reopenable.
     await view.findByRole('button', { name: 'Reopen: buy milk' })
 
     // Archive hides this session's completed rows.
     await user.click(view.getByRole('button', { name: 'Archive 1 completed' }))
+    expect(hapticImpactLight).toHaveBeenCalledTimes(2)
     await waitFor(() => expect(view.queryByText('buy milk')).toBeNull())
+    view.unmount()
+  })
+
+  it('fires light haptics for task list controls', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Edit: buy milk' }))
+    expect(hapticImpactLight).toHaveBeenCalledTimes(1)
+
+    await user.click(view.getByRole('button', { name: 'dismiss-drawer' }))
+    await user.click(view.getByRole('button', { name: 'Task filters' }))
+    expect(hapticImpactLight).toHaveBeenCalledTimes(2)
+
+    await user.click(view.getByRole('checkbox', { name: 'Current' }))
+    expect(hapticImpactLight).toHaveBeenCalledTimes(3)
+
+    await user.click(view.getByRole('button', { name: 'dismiss-drawer' }))
+    await user.click(view.getByRole('button', { name: 'New task' }))
+    expect(hapticImpactLight).toHaveBeenCalledTimes(4)
     view.unmount()
   })
 
@@ -330,6 +358,29 @@ describe('MobileTasks', () => {
     await user.click(view.getByRole('button', { name: 'dismiss-drawer' }))
     expect(editTask).toHaveBeenCalledTimes(1)
     expect(editTask.mock.calls[0]?.[1]).toBe('buy milk [[2026-06-15]]')
+    view.unmount()
+  })
+
+  it('fires light haptics for task sheet scheduling and actions', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const user = userEvent.setup()
+    const view = renderScreen()
+
+    await user.click(await view.findByRole('button', { name: 'Edit: buy milk' }))
+    hapticImpactLight.mockClear()
+
+    await user.click(view.getByRole('button', { name: 'Pick date' }))
+    expect(hapticImpactLight).toHaveBeenCalledTimes(1)
+
+    await user.click(view.getByRole('button', { name: 'Tomorrow' }))
+    expect(hapticImpactLight).toHaveBeenCalledTimes(2)
+
+    await user.click(view.getByRole('button', { name: 'Clear' }))
+    expect(hapticImpactLight).toHaveBeenCalledTimes(3)
+
+    await user.click(view.getByRole('button', { name: 'Convert to bullet' }))
+    expect(hapticImpactLight).toHaveBeenCalledTimes(4)
+    await waitFor(() => expect(convertTaskToBullet).toHaveBeenCalledTimes(1))
     view.unmount()
   })
 

--- a/apps/desktop/src/mobile/screens/tasks.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.tsx
@@ -19,6 +19,7 @@ import { composeVisibleTaskGroups } from '@/lib/tasks/task-visibility'
 import { completedTasksQueryKey, tasksQueryKey } from '@/lib/tasks/tasks-query'
 import { useTaskActions } from '@/lib/tasks/use-task-actions'
 import { useToday } from '@/lib/use-today'
+import { hapticImpactLight } from '@/mobile/haptics'
 import { MobileTaskEditSheet } from '@/mobile/task-edit-sheet'
 import { TaskFiltersDrawer } from '@/mobile/task-filters-drawer'
 import { MobileTaskGroup } from '@/mobile/task-group'
@@ -32,11 +33,12 @@ import { useRouter } from '@/routing/router'
  * Upcoming, then per-note — via the same queries, grouping
  * ({@link composeVisibleTaskGroups}) and optimistic mutations
  * ({@link useTaskActions}) the desktop view uses; this screen adds only the
- * touch surface. Checkboxes toggle with a light haptic; tapping a row opens the
- * quick-edit sheet (edit / schedule / complete / convert / open note) instead of
- * desktop's multi-select; the filter sheet carries desktop's bucket toggles and
- * "Show archived". Completing keeps the row struck (V1's middle state) until
- * Archive hides this session's completed tasks.
+ * touch surface. Task taps, toggles, adds, filters, scheduling, and archival
+ * get light haptics; tapping a row opens the quick-edit sheet (edit / schedule /
+ * complete / convert / open note) instead of desktop's multi-select; the filter
+ * sheet carries desktop's bucket toggles and "Show archived". Completing keeps
+ * the row struck (V1's middle state) until Archive hides this session's completed
+ * tasks.
  */
 export function MobileTasks(): ReactElement {
   const { graph } = useGraph()
@@ -98,7 +100,10 @@ export function MobileTasks(): ReactElement {
     )
   }, [groups, editingTask])
 
-  const editTask = (task: OpenTask, options?: { autoFocus?: boolean }): void => {
+  const editTask = (task: OpenTask, options?: { autoFocus?: boolean; haptic?: boolean }): void => {
+    if (options?.haptic !== false) {
+      hapticImpactLight()
+    }
     setAutoFocusEditor(options?.autoFocus === true)
     setEditingTask(task)
     setSheetOpen(true)
@@ -108,12 +113,18 @@ export function MobileTasks(): ReactElement {
   // visible, write it, then open its quick-edit sheet with the editor focused
   // so typing starts immediately.
   const onAdd = (target: InsertTaskTarget): void => {
+    hapticImpactLight()
     setQuery('')
     void actions.insert(target).then((created) => {
       if (created !== null) {
-        editTask(created, { autoFocus: true })
+        editTask(created, { autoFocus: true, haptic: false })
       }
     })
+  }
+
+  const archiveCompleted = (): void => {
+    hapticImpactLight()
+    actions.archive()
   }
 
   return (
@@ -137,7 +148,7 @@ export function MobileTasks(): ReactElement {
             size="icon"
             className="size-10 shrink-0"
             aria-label={`Archive ${recentlyCompleted.length} completed`}
-            onClick={actions.archive}
+            onClick={archiveCompleted}
           >
             <Archive />
           </Button>
@@ -147,7 +158,10 @@ export function MobileTasks(): ReactElement {
           size="icon"
           className="size-10 shrink-0"
           aria-label="Task filters"
-          onClick={() => setFiltersOpen(true)}
+          onClick={() => {
+            hapticImpactLight()
+            setFiltersOpen(true)
+          }}
         >
           <SlidersHorizontal />
         </Button>

--- a/apps/desktop/src/mobile/task-edit-sheet.tsx
+++ b/apps/desktop/src/mobile/task-edit-sheet.tsx
@@ -159,6 +159,7 @@ export function MobileTaskEditSheet({
   }
 
   const convertToBullet = (): void => {
+    hapticImpactLight()
     const result = resolve()
     if (result.type === 'commit') {
       actions.editAndConvertToBullet(task, result.content)
@@ -173,6 +174,7 @@ export function MobileTaskEditSheet({
   }
 
   const openNote = (): void => {
+    hapticImpactLight()
     closeNavigate()
     onOpenNote(task.notePath)
   }
@@ -190,11 +192,13 @@ export function MobileTaskEditSheet({
   }
 
   const remove = (): void => {
+    hapticImpactLight()
     actions.remove([task])
     closeHandled()
   }
 
   const schedule = (isoDate: string | null): void => {
+    hapticImpactLight()
     // Base the rewrite on the freshest draft, then keep every mirror in step
     // by hand: setMarkdown is silent (no onChange echo), so neither the live
     // mirror nor the state (chip highlights) updates on its own.
@@ -203,6 +207,11 @@ export function MobileTaskEditSheet({
     setDraft(next)
     editorRef.current?.setMarkdown(next)
     setShowCalendar(false)
+  }
+
+  const toggleCalendar = (): void => {
+    hapticImpactLight()
+    setShowCalendar((showing) => !showing)
   }
 
   return (
@@ -266,7 +275,7 @@ export function MobileTaskEditSheet({
             }
             icon={<CalendarDays aria-hidden className="size-3.5" />}
             active={showCalendar}
-            onClick={() => setShowCalendar((showing) => !showing)}
+            onClick={toggleCalendar}
           />
           {dueDate !== null ? (
             <ScheduleChip

--- a/apps/desktop/src/mobile/task-filters-drawer.tsx
+++ b/apps/desktop/src/mobile/task-filters-drawer.tsx
@@ -3,6 +3,7 @@ import { Check } from 'lucide-react'
 import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
 import type { TaskFilters } from '@/lib/tasks/task-filters'
 import { cn } from '@/lib/utils'
+import { hapticImpactLight } from '@/mobile/haptics'
 
 interface TaskFiltersDrawerProps {
   open: boolean
@@ -66,7 +67,10 @@ function FilterRow({
       type="button"
       role="checkbox"
       aria-checked={checked}
-      onClick={onToggle}
+      onClick={() => {
+        hapticImpactLight()
+        onToggle()
+      }}
       className="flex h-12 items-center gap-3 text-left text-base"
     >
       <span

--- a/apps/desktop/src/mobile/task-group.tsx
+++ b/apps/desktop/src/mobile/task-group.tsx
@@ -5,6 +5,7 @@ import { addTargetForGroup, taskGroupHeaderStyle } from '@/lib/tasks/task-group-
 import { taskKey } from '@/lib/tasks/task-identity'
 import type { InsertTaskTarget } from '@/lib/tasks/task-insert-target'
 import { cn } from '@/lib/utils'
+import { hapticImpactLight } from '@/mobile/haptics'
 import { MobileTaskRow } from '@/mobile/task-row'
 
 interface MobileTaskGroupProps {
@@ -48,7 +49,14 @@ export function MobileTaskGroup({
             <span className="sr-only">Pinned:</span>
           ) : null}
           {group.kind === 'note' && notePath !== null ? (
-            <button type="button" onClick={() => onOpen(notePath)} className="truncate">
+            <button
+              type="button"
+              onClick={() => {
+                hapticImpactLight()
+                onOpen(notePath)
+              }}
+              className="truncate"
+            >
               {group.label}
             </button>
           ) : (

--- a/apps/desktop/src/mobile/task-row.tsx
+++ b/apps/desktop/src/mobile/task-row.tsx
@@ -22,13 +22,15 @@ interface MobileTaskRowProps {
  * round checkbox that toggles the task through the same guarded write-back as
  * desktop — with a light haptic, V1's check feedback — and the task content
  * rendered as markdown. A completed (struck) row stays visible until archived.
- * Tapping the row body opens the quick-edit sheet instead of desktop's
- * multi-select; there is no inline editor on touch.
+ * Tapping the row body gives the same light confirmation and opens the
+ * quick-edit sheet instead of desktop's multi-select; there is no inline editor
+ * on touch.
  */
 export function MobileTaskRow({ task, showSource, onEdit }: MobileTaskRowProps): ReactElement {
   const { settings } = useSettings()
   const { toggle, isPending } = useTaskCheckboxToggle(task)
   const label = task.text || 'Empty task'
+  const edit = (): void => onEdit(task)
 
   return (
     <li
@@ -61,11 +63,11 @@ export function MobileTaskRow({ task, showSource, onEdit }: MobileTaskRowProps):
         role="button"
         tabIndex={0}
         aria-label={`Edit: ${label}`}
-        onClick={() => onEdit(task)}
+        onClick={edit}
         onKeyDown={(event) => {
           if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault()
-            onEdit(task)
+            edit()
           }
         }}
         className="flex min-w-0 flex-1 cursor-pointer items-start gap-3 py-3 pr-4 text-left focus-visible:outline-none"

--- a/plugins/tauri-plugin-keyboard/ios/Sources/KeyboardPlugin.swift
+++ b/plugins/tauri-plugin-keyboard/ios/Sources/KeyboardPlugin.swift
@@ -108,8 +108,8 @@ class KeyboardPlugin: Plugin {
     invoke.resolve(currentState)
   }
 
-  /// Fire a light impact haptic — V1 parity for date-selection and tab
-  /// taps. `UIFeedbackGenerator` is main-thread-only; resolve immediately
+  /// Fire a light impact haptic — V1 parity for date-selection, task controls,
+  /// and tab taps. `UIFeedbackGenerator` is main-thread-only; resolve immediately
   /// rather than after the dispatch since the tap has already happened and
   /// callers are fire-and-forget. Silently does nothing on hardware
   /// without a haptic engine (iPads, the simulator).

--- a/plugins/tauri-plugin-keyboard/src/commands.rs
+++ b/plugins/tauri-plugin-keyboard/src/commands.rs
@@ -12,7 +12,8 @@ pub(crate) async fn current_height<R: Runtime>(app: AppHandle<R>) -> Result<Keyb
 }
 
 /// Fire a light impact haptic — the app's single haptic strength (date
-/// selection, tab presses). A no-op wherever there is no haptic engine.
+/// selection, task controls, tab presses). A no-op wherever there is no haptic
+/// engine.
 #[command]
 pub(crate) async fn impact_light<R: Runtime>(app: AppHandle<R>) -> Result<()> {
     app.keyboard().impact_light()


### PR DESCRIPTION
## Problem

The iOS mobile surfaces used light haptics inconsistently. The Tasks surface only buzzed on checkbox toggles and the quick-edit Complete action, while other high-intent touch paths such as opening a task, adding a task, changing filters, scheduling, archiving, converting, deleting, or jumping to the source note felt flat. The Daily header also lacked feedback on the Today jump and Settings gear, even though nearby calendar day cells and tab presses already confirm taps through the same light haptic bridge.

This PR intentionally does not add new native haptic strengths or commands. It broadens use of the existing fail-soft `hapticImpactLight()` path.

## Before -> After

| Surface | Before | After |
| --- | --- | --- |
| Daily header | Day cells buzzed; Today/month-title jump and Settings were silent | Today jump, month-title jump, and Settings gear get light feedback |
| Task list | Checkbox toggles buzzed; row taps, add, archive, and filters were silent | Row open, add, archive, filter-open, and filter-toggle actions get light feedback |
| Quick-edit sheet | Complete/Reopen buzzed | Scheduling, calendar toggle, convert, open note, and delete also get light feedback |
| Native bridge | Light-impact comments named date/tab usage only | Comments now include task controls, with no behavior or permission changes |

## Changes

1. Routes Daily header Today/month-title jumps and the Settings gear through `hapticImpactLight()` in `CalendarStrip`.
2. Routes list-level task interactions through `hapticImpactLight()` in `MobileTasks`, including sheet opening, new-task creation, archive, and filter opening.
3. Suppresses a duplicate tick on the async “+” task flow: the tap itself vibrates immediately, and the auto-opened edit sheet stays quiet.
4. Adds light feedback to task filter toggles, note-group source navigation, and quick-edit sheet schedule/action buttons.
5. Mocks the haptics bridge in mobile shell/task tests and pins the newly covered Daily and task interactions.

## Tests

- `src/mobile/mobile-screen.test.tsx` covers Daily header Today/month-title/Settings haptics.
- `src/mobile/screens/tasks.test.tsx` covers checkbox/archive haptics, list controls, filter toggles, new task, and sheet scheduling/actions.
- Existing haptics bridge and editor-task checkbox hook tests still pass.

## Verification

- `pnpm --filter @reflect/desktop test src/mobile/mobile-screen.test.tsx src/mobile/screens/tasks.test.tsx src/mobile/haptics.test.ts src/mobile/use-task-haptics.test.ts` -> 4 files passed, 64 tests passed
- `pnpm check` -> passed

## Risk / Rollout

No migrations, storage changes, or new native commands. The calls reuse the existing fire-and-forget haptics bridge, which already no-ops or disables itself when unavailable, such as in desktop/browser dev or on hardware without a haptic engine.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-only additions through the existing fail-soft haptics bridge; no data, auth, or native behavior changes beyond comment updates.
> 
> **Overview**
> Extends the existing **`hapticImpactLight()`** bridge so more mobile task and daily-header taps get the same light confirmation as tabs and calendar date picks—without new native APIs or haptic strengths.
> 
> On **Tasks**, light feedback now fires for opening the quick-edit sheet, archive, filter drawer and bucket toggles, group **+** / note-header navigation, checkbox toggles (unchanged path), and sheet actions including schedule chips, calendar toggle, convert, open note, and delete. The **+** add path haptics once on tap and skips a second pulse when the sheet auto-opens via **`editTask(..., { haptic: false })`**.
> 
> **Daily** calendar strip adds haptics on **Settings** (and documents/tests **Jump to today** / **Today** alongside existing month-title behavior). **`haptics.ts`** and keyboard-plugin comments note task-surface usage. Tests mock **`@/mobile/haptics`** in **`tasks.test.tsx`** and **`mobile-screen.test.tsx`** and assert call counts for the new touch paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f35be1510b5be8e9eb07921569063a48231df459. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->