### PR TITLE
fix: serve note images off the UI thread via a reflect-asset protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,12 +2386,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-range"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4763,6 +4757,7 @@ dependencies = [
  "objc2-event-kit",
  "objc2-foundation",
  "ort",
+ "percent-encoding",
  "reflect-index-schema",
  "reqwest 0.12.28",
  "rusqlite",
@@ -5871,7 +5866,6 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "http-range",
  "jni 0.21.1",
  "libc",
  "log",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -20,8 +20,11 @@ tauri-build = { version = "2.6.3", features = [] }
 [dependencies]
 # `devtools` compiles the web inspector into release builds too (it is otherwise
 # debug-only), so a shipped app stays debuggable — see `src/devtools.rs`.
-tauri = { version = "2.11.3", features = ["protocol-asset", "devtools"] }
+tauri = { version = "2.11.3", features = ["devtools"] }
 tauri-plugin-opener = "2.5.4"
+# Decodes `reflect-asset://` request paths (`fs/asset_protocol.rs`); the same
+# crate tauri itself uses for its protocol URLs.
+percent-encoding = "2.3.2"
 # `time` backs the bounded wait in `windows::close_note_windows` (tauri
 # already runs on tokio; this only makes the sleep primitive addressable).
 tokio = { version = "1.52.3", features = ["time"] }

--- a/apps/desktop/src-tauri/src/fs/asset_protocol.rs
+++ b/apps/desktop/src-tauri/src/fs/asset_protocol.rs
@@ -1,0 +1,153 @@
+//! The `reflect-asset://` custom protocol: serves graph `assets/` files to
+//! the webview **off the UI thread**.
+//!
+//! WebKit delivers custom-scheme requests on the main thread and wry invokes
+//! the handler inline, so Tauri's built-in synchronous `asset:` protocol
+//! froze the app for the duration of every uncached image read. On iOS that
+//! was seconds: a first read can also wait for iCloud to materialize a
+//! dataless file. This handler does the blocking file IO on the async
+//! runtime's blocking pool and responds when the bytes are ready, so a slow
+//! read costs the image a pop-in, never the app a freeze.
+//!
+//! URL shape: `reflect-asset://localhost/<generation>/<graph-relative path>`,
+//! built by `convertFileSrc(…, 'reflect-asset')` in the frontend (which
+//! percent-encodes the whole path into one segment). The generation pins the
+//! request to the graph session that issued it, exactly like mutating
+//! commands — a request racing a graph switch is refused, never resolved
+//! against the new graph. The path must live under `assets/` and passes the
+//! shared symlink-aware traversal guard before any IO.
+
+use std::borrow::Cow;
+
+use tauri::http::{header, Request, Response, StatusCode};
+use tauri::utils::mime_type::MimeType;
+use tauri::{AppHandle, Manager, Runtime, UriSchemeContext, UriSchemeResponder};
+
+use super::GraphState;
+
+/// The scheme name, shared with the `lib.rs` registration. The frontend and
+/// the CSP `img-src` grant in `tauri.conf.json` spell it out literally.
+pub(crate) const SCHEME: &str = "reflect-asset";
+
+/// Protocol entry point (`register_asynchronous_uri_scheme_protocol`). Runs
+/// on the webview's calling thread — on WebKit, the app's main thread — so it
+/// only moves the request onto the blocking pool; all IO happens there.
+pub(crate) fn handle<R: Runtime>(
+    ctx: UriSchemeContext<'_, R>,
+    request: Request<Vec<u8>>,
+    responder: UriSchemeResponder,
+) {
+    let app = ctx.app_handle().clone();
+    // Skip the leading `/`; the remainder is one percent-encoded segment.
+    let request_path = percent_encoding::percent_decode(&request.uri().path().as_bytes()[1..])
+        .decode_utf8_lossy()
+        .into_owned();
+    let method_allowed = request.method() == tauri::http::Method::GET;
+    tauri::async_runtime::spawn_blocking(move || {
+        if !method_allowed {
+            responder.respond(status_response(StatusCode::METHOD_NOT_ALLOWED));
+            return;
+        }
+        responder.respond(response_for(&app, &request_path));
+    });
+}
+
+fn response_for<R: Runtime>(
+    app: &AppHandle<R>,
+    request_path: &str,
+) -> Response<Cow<'static, [u8]>> {
+    match serve(app, request_path) {
+        Ok((mime, bytes)) => Response::builder()
+            .header(header::CONTENT_TYPE, mime)
+            .header(header::CONTENT_LENGTH, bytes.len())
+            .body(Cow::Owned(bytes))
+            .unwrap_or_else(|_| status_response(StatusCode::INTERNAL_SERVER_ERROR)),
+        Err(status) => {
+            tracing::warn!(path = request_path, %status, "asset protocol refused a request");
+            status_response(status)
+        }
+    }
+}
+
+fn status_response(status: StatusCode) -> Response<Cow<'static, [u8]>> {
+    Response::builder()
+        .status(status)
+        .body(Cow::Borrowed(&[][..]))
+        .expect("a status-only response always builds")
+}
+
+fn serve<R: Runtime>(app: &AppHandle<R>, request_path: &str) -> Result<(String, Vec<u8>), StatusCode> {
+    let (generation, rel) = parse_request_path(request_path)?;
+    let state = app.state::<GraphState>();
+    let root =
+        super::root_for_generation(&state, generation).map_err(|_| StatusCode::FORBIDDEN)?;
+    let abs = super::resolve::resolve(&root, rel).map_err(|_| StatusCode::FORBIDDEN)?;
+    // On an iCloud graph this read blocks until the file is materialized on
+    // the device — acceptable here on the blocking pool, and exactly the wait
+    // that must never happen on the UI thread.
+    let bytes = std::fs::read(&abs).map_err(|err| match err.kind() {
+        std::io::ErrorKind::NotFound => StatusCode::NOT_FOUND,
+        std::io::ErrorKind::PermissionDenied => StatusCode::FORBIDDEN,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    })?;
+    let mime = MimeType::parse(&bytes, rel);
+    Ok((mime, bytes))
+}
+
+/// Split `<generation>/<graph-relative path>` and vet the path shape. The
+/// `assets/` restriction mirrors `asset_open`: images in note markdown are
+/// the only consumer, and they never reference anything else.
+fn parse_request_path(request_path: &str) -> Result<(u64, &str), StatusCode> {
+    let (generation, rel) = request_path
+        .split_once('/')
+        .ok_or(StatusCode::BAD_REQUEST)?;
+    let generation: u64 = generation.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
+    super::ensure_asset_path(rel).map_err(|_| StatusCode::FORBIDDEN)?;
+    Ok((generation, rel))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_generation_pinned_asset_path() {
+        assert_eq!(
+            parse_request_path("3/assets/cat.png").unwrap(),
+            (3, "assets/cat.png"),
+        );
+        assert_eq!(
+            parse_request_path("12/assets/sub dir/photo 1.jpeg").unwrap(),
+            (12, "assets/sub dir/photo 1.jpeg"),
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_requests() {
+        assert_eq!(
+            parse_request_path("assets/cat.png").unwrap_err(),
+            StatusCode::BAD_REQUEST,
+        );
+        assert_eq!(parse_request_path("3").unwrap_err(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            parse_request_path("nope/assets/cat.png").unwrap_err(),
+            StatusCode::BAD_REQUEST,
+        );
+    }
+
+    #[test]
+    fn rejects_paths_outside_assets() {
+        assert_eq!(
+            parse_request_path("3/notes/secret.md").unwrap_err(),
+            StatusCode::FORBIDDEN,
+        );
+        assert_eq!(
+            parse_request_path("3/assets").unwrap_err(),
+            StatusCode::FORBIDDEN,
+        );
+        assert_eq!(
+            parse_request_path("3/assets/").unwrap_err(),
+            StatusCode::FORBIDDEN,
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/fs/asset_protocol.rs
+++ b/apps/desktop/src-tauri/src/fs/asset_protocol.rs
@@ -76,11 +76,13 @@ fn status_response(status: StatusCode) -> Response<Cow<'static, [u8]>> {
         .expect("a status-only response always builds")
 }
 
-fn serve<R: Runtime>(app: &AppHandle<R>, request_path: &str) -> Result<(String, Vec<u8>), StatusCode> {
+fn serve<R: Runtime>(
+    app: &AppHandle<R>,
+    request_path: &str,
+) -> Result<(String, Vec<u8>), StatusCode> {
     let (generation, rel) = parse_request_path(request_path)?;
     let state = app.state::<GraphState>();
-    let root =
-        super::root_for_generation(&state, generation).map_err(|_| StatusCode::FORBIDDEN)?;
+    let root = super::root_for_generation(&state, generation).map_err(|_| StatusCode::FORBIDDEN)?;
     let abs = super::resolve::resolve(&root, rel).map_err(|_| StatusCode::FORBIDDEN)?;
     // On an iCloud graph this read blocks until the file is materialized on
     // the device — acceptable here on the blocking pool, and exactly the wait
@@ -128,7 +130,10 @@ mod tests {
             parse_request_path("assets/cat.png").unwrap_err(),
             StatusCode::BAD_REQUEST,
         );
-        assert_eq!(parse_request_path("3").unwrap_err(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            parse_request_path("3").unwrap_err(),
+            StatusCode::BAD_REQUEST
+        );
         assert_eq!(
             parse_request_path("nope/assets/cat.png").unwrap_err(),
             StatusCode::BAD_REQUEST,

--- a/apps/desktop/src-tauri/src/fs/mod.rs
+++ b/apps/desktop/src-tauri/src/fs/mod.rs
@@ -6,6 +6,7 @@
 //! (path-traversal guard, [`resolve`]). Writes are atomic (temp file + rename,
 //! [`io`]) and deletes go to the OS trash. Parsing/indexing live in later plans.
 
+pub mod asset_protocol;
 pub mod assets;
 mod import;
 mod io;
@@ -200,28 +201,13 @@ fn ensure_asset_path(path: &str) -> AppResult<()> {
 
 // ---- commands --------------------------------------------------------------
 
-/// Let the asset protocol serve files from the graph (image rendering, Plan 05).
-/// Best-effort: a failure means images don't render, never that the open fails.
-fn allow_asset_scope(app: &tauri::AppHandle, root: &Path) {
-    use tauri::Manager;
-    if let Err(err) = app.asset_protocol_scope().allow_directory(root, true) {
-        tracing::warn!(%err, "failed to extend the asset scope");
-    }
-}
-
 /// Create a new graph at `path` (scaffolds the layout) and open it.
 #[tauri::command]
-pub fn graph_create(
-    path: String,
-    app: tauri::AppHandle,
-    state: State<GraphState>,
-) -> AppResult<GraphInfo> {
+pub fn graph_create(path: String, state: State<GraphState>) -> AppResult<GraphInfo> {
     let root = PathBuf::from(&path);
     fs::create_dir_all(&root)?;
     bootstrap(&root)?;
-    let info = activate(&state, &root)?;
-    allow_asset_scope(&app, &root);
-    Ok(info)
+    activate(&state, &root)
 }
 
 /// Import a user-selected Reflect V1 export `.zip` into the open graph. V1's
@@ -239,19 +225,13 @@ pub fn graph_import_reflect_v1_zip(
 
 /// Open an existing graph at `path`, ensuring the standard layout exists.
 #[tauri::command]
-pub fn graph_open(
-    path: String,
-    app: tauri::AppHandle,
-    state: State<GraphState>,
-) -> AppResult<GraphInfo> {
+pub fn graph_open(path: String, state: State<GraphState>) -> AppResult<GraphInfo> {
     let root = PathBuf::from(&path);
     if !root.is_dir() {
         return Err(AppError::not_found(format!("not a directory: {path}")));
     }
     bootstrap(&root)?;
-    let info = activate(&state, &root)?;
-    allow_asset_scope(&app, &root);
-    Ok(info)
+    activate(&state, &root)
 }
 
 /// Read a note's markdown by graph-relative path. `generation`, when given,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -168,6 +168,16 @@ pub fn run() {
     });
 
     builder
+        // Serves note images (`assets/…`) to the webview. Registered as an
+        // *asynchronous* protocol on purpose: WebKit delivers custom-scheme
+        // requests on the main thread, and a synchronous handler (like the
+        // built-in `asset:` protocol this replaces) freezes the whole app for
+        // the duration of every uncached read — seconds on iOS, where a first
+        // read can wait on an iCloud download.
+        .register_asynchronous_uri_scheme_protocol(
+            fs::asset_protocol::SCHEME,
+            fs::asset_protocol::handle,
+        )
         .manage(fs::GraphState::default())
         .manage(fs::assets::AssetUploads::default())
         .manage(db::IndexState::default())

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -22,11 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: asset: https:; font-src 'self' data:; frame-src 'self' https://platform.twitter.com https://platform.x.com https://syndication.twitter.com https://www.youtube-nocookie.com https://www.youtube.com; connect-src 'self' ipc: http://ipc.localhost https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://openrouter.ai https://github.com https://api.github.com",
-      "assetProtocol": {
-        "enable": true,
-        "scope": []
-      }
+      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: reflect-asset: https:; font-src 'self' data:; frame-src 'self' https://platform.twitter.com https://platform.x.com https://syndication.twitter.com https://www.youtube-nocookie.com https://www.youtube.com; connect-src 'self' ipc: http://ipc.localhost https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://openrouter.ai https://github.com https://api.github.com"
     }
   },
   "plugins": {

--- a/apps/desktop/src/components/command-palette/note-preview.tsx
+++ b/apps/desktop/src/components/command-palette/note-preview.tsx
@@ -37,7 +37,7 @@ async function readNoteForPreview(path: string): Promise<string | null> {
 export function NotePreview({ entry }: NotePreviewProps): ReactElement {
   const { graph } = useGraph()
   const { settings } = useSettings()
-  const { resolveImageUrl } = useAssetPersistence(graph?.root ?? null, graph?.generation ?? null)
+  const { resolveImageUrl } = useAssetPersistence(graph?.generation ?? null)
   const { data, isError } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'note-preview', entry.path],
     queryFn: () => readNoteForPreview(entry.path),

--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -118,7 +118,6 @@ export function NotePaneComponent({
 }: NotePaneProps): ReactElement {
   const { graph } = useGraph()
   const { settings } = useSettings()
-  const graphRoot = graph?.root ?? null
   const generation = graph?.generation ?? null
   const dailyNote = isDaily(path)
   // Templates rename via file operations only (settings, or outside the app):
@@ -156,7 +155,7 @@ export function NotePaneComponent({
     saveFile,
     resolveFileInfo,
     saveError,
-  } = useAssetPersistence(graphRoot, generation, path)
+  } = useAssetPersistence(generation, path)
   const onWikiLinkClick = useWikiLinkNavigation(generation)
   const onTagClick = useTagNavigation()
   const { onWikilinkSearch, onTagSearch } = useEditorAutocomplete()

--- a/apps/desktop/src/editor/use-asset-persistence.test.tsx
+++ b/apps/desktop/src/editor/use-asset-persistence.test.tsx
@@ -2,6 +2,13 @@ import { act, cleanup, render, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
 import { setBridge } from '@reflect/core'
+
+// jsdom has no Tauri runtime; mirror the macOS/iOS URL shape the injected
+// `convertFileSrc` produces (one percent-encoded path segment).
+vi.mock('@tauri-apps/api/core', () => ({
+  convertFileSrc: (filePath: string, protocol = 'asset') =>
+    `${protocol}://localhost/${encodeURIComponent(filePath)}`,
+}))
 import { resetOperations, useOperations, type Operation } from '@/lib/operations'
 import {
   LARGE_FILE_BYTES,
@@ -25,7 +32,7 @@ function Host({
   generation: number | null
   path?: string
 }): ReactNode {
-  persistence = useAssetPersistence('/graph', generation, path)
+  persistence = useAssetPersistence(generation, path)
   return null
 }
 
@@ -131,6 +138,37 @@ describe('useAssetPersistence saveFile', () => {
     })
     expect(saved).toBeNull()
     expect(invoke).not.toHaveBeenCalled()
+  })
+})
+
+describe('useAssetPersistence resolveImageUrl', () => {
+  it('passes remote URLs through untouched', () => {
+    installUploadBridge()
+    render(<Host generation={3} />)
+
+    expect(persistence!.resolveImageUrl('https://example.com/cat.png')).toBe(
+      'https://example.com/cat.png',
+    )
+  })
+
+  it('maps a safe assets/ path onto the generation-pinned reflect-asset URL', () => {
+    installUploadBridge()
+    render(<Host generation={3} />)
+
+    expect(persistence!.resolveImageUrl('assets/cat.png')).toBe(
+      `reflect-asset://localhost/${encodeURIComponent('3/assets/cat.png')}`,
+    )
+  })
+
+  it('declines unsafe paths and missing sessions', () => {
+    installUploadBridge()
+    render(<Host generation={3} />)
+
+    expect(persistence!.resolveImageUrl('assets/../secrets.env')).toBeNull()
+    expect(persistence!.resolveImageUrl('notes/other.md')).toBeNull()
+
+    render(<Host generation={null} />)
+    expect(persistence!.resolveImageUrl('assets/cat.png')).toBeNull()
   })
 })
 

--- a/apps/desktop/src/editor/use-asset-persistence.ts
+++ b/apps/desktop/src/editor/use-asset-persistence.ts
@@ -95,18 +95,18 @@ export interface AssetPersistence {
 
 /**
  * Asset handling for one open graph: resolve `![…](…)` sources to displayable
- * URLs (remote URLs pass through; `assets/` paths map to Tauri asset URLs),
- * open asset links in the OS viewer, and persist pasted/dropped files by
- * streaming them into the graph's `assets/` folder — Rust resolves `-2`-style
- * name collisions at write time. A save over {@link LARGE_FILE_BYTES} gets a
- * non-blocking status-line warning after it lands. `generation` pins every
- * save to the issuing graph session, so a save racing a graph switch is
- * rejected loudly instead of landing in the wrong graph; `path`, when given,
- * scopes the error banner to the note being edited (a pane is reused across
- * note switches).
+ * URLs (remote URLs pass through; `assets/` paths map to `reflect-asset://`
+ * URLs served off the UI thread by the Rust shell), open asset links in the
+ * OS viewer, and persist pasted/dropped files by streaming them into the
+ * graph's `assets/` folder — Rust resolves `-2`-style name collisions at
+ * write time. A save over {@link LARGE_FILE_BYTES} gets a non-blocking
+ * status-line warning after it lands. `generation` pins every save — and
+ * every image URL — to the issuing graph session, so a save or image load
+ * racing a graph switch is rejected loudly instead of landing in (or reading
+ * from) the wrong graph; `path`, when given, scopes the error banner to the
+ * note being edited (a pane is reused across note switches).
  */
 export function useAssetPersistence(
-  graphRoot: string | null,
   generation: number | null,
   path?: string,
 ): AssetPersistence {
@@ -143,22 +143,22 @@ export function useAssetPersistence(
       if (/^https?:\/\//.test(src)) {
         return src
       }
-      if (graphRoot && isSafeAssetSource(src)) {
-        return convertFileSrc(`${graphRoot}/${src}`)
+      if (generation !== null && isSafeAssetSource(src)) {
+        return convertFileSrc(`${generation}/${src}`, 'reflect-asset')
       }
       return null
     },
-    [graphRoot],
+    [generation],
   )
 
   const resolveAssetOpenPath = useCallback(
     (src: string): string | null => {
-      if (graphRoot && generation !== null && isSafeAssetSource(src)) {
+      if (generation !== null && isSafeAssetSource(src)) {
         return src
       }
       return null
     },
-    [graphRoot, generation],
+    [generation],
   )
 
   const openAsset = useCallback(

--- a/apps/desktop/src/hooks/use-backlink-navigation.ts
+++ b/apps/desktop/src/hooks/use-backlink-navigation.ts
@@ -72,7 +72,7 @@ export function useBacklinkNavigation(): BacklinkNavigation {
   )
 
   const navigateWikiLink = useWikiLinkNavigation(graph?.generation ?? null)
-  const { resolveImageUrl } = useAssetPersistence(graph?.root ?? null, graph?.generation ?? null)
+  const { resolveImageUrl } = useAssetPersistence(graph?.generation ?? null)
   const onWikilinkClick = useCallback<WikilinkClickHandler>(
     ({ target, event }) => navigateWikiLink(target, event),
     [navigateWikiLink],

--- a/docs/porting/assets.md
+++ b/docs/porting/assets.md
@@ -52,8 +52,9 @@ plain relative markdown, which fixes v1's export quirk: in v2 the markdown
   (`apps/desktop/src/editor/use-image-persistence.ts`): named
   `pasted-<timestamp>-<random>.<ext>` under `assets/`, written through the
   traversal-guarded `asset_write` command, pinned to the graph generation,
-  resolved for display through the Tauri asset protocol, and openable in
-  the OS viewer. Save failures surface on the pane.
+  resolved for display through the app's `reflect-asset://` protocol
+  (asynchronous — the file read happens off the webview's UI thread), and
+  openable in the OS viewer. Save failures surface on the pane.
 - Plan 20 gives every image (and, notably, **PDF**) under `assets/` an AI
   description file — PDFs are already first-class citizens of the asset
   pipeline everywhere *except* the way in.


### PR DESCRIPTION
## Problem

Opening a note with a not-yet-cached image froze the whole app for a second or more on iOS. The chain:

1. Note images resolve through Tauri's built-in `asset:` protocol (`convertFileSrc`).
2. WebKit delivers custom-scheme requests (`WKURLSchemeHandler`) on the **main thread**, and wry invokes the Tauri handler inline there.
3. The built-in handler is fully synchronous: `File::open`, an 8 KB mime sniff, then `read_to_end` of the entire image — all before the UI thread can do anything else. On an iCloud graph the first read can additionally block until iCloud materializes a dataless file.

Repeat opens were fast only because WebKit's in-memory image cache answers them without calling the handler (and the file is local by then). macOS has the identical architecture; it just hides behind fast disks.

## Change

- **New `reflect-asset://` protocol** ([apps/desktop/src-tauri/src/fs/asset_protocol.rs](apps/desktop/src-tauri/src/fs/asset_protocol.rs)), registered with `register_asynchronous_uri_scheme_protocol`: the handler moves the request straight onto the async runtime's blocking pool and responds when the bytes are ready. A slow read (large file, iCloud download) now costs the image a pop-in, never the app a freeze.
- **Tighter contract than the protocol it replaces.** The URL carries `<generation>/<graph-relative path>`; Rust re-validates with the same generation pin (`root_for_generation`) and symlink-aware traversal guard (`resolve`) as every file command, and only `assets/…` paths are served (mirroring `asset_open`). The old protocol accepted absolute filesystem paths against a graph-wide recursive scope grant.
- **Built-in asset protocol removed**: the `protocol-asset` cargo feature, the `assetProtocol` config, the `allow_asset_scope` grant in `graph_open`/`graph_create`, and `asset:` in the CSP (replaced by `reflect-asset:`). Nothing else used it.
- **Frontend**: `resolveImageUrl` builds `convertFileSrc(`${generation}/${src}`, 'reflect-asset')`. The hook's `graphRoot` parameter died with that — image URLs are session-pinned like everything else — so it's removed from the signature and the three call sites.

## Testing

- `pnpm check` (typecheck + oxlint + eslint) passes.
- `pnpm test --run` on `use-asset-persistence.test.tsx` (new `resolveImageUrl` coverage: remote passthrough, generation-pinned URL shape, unsafe-path/no-session refusals) and `note-editor.test.tsx`, plus the NotePane/NotePreview consumers (`route-content`, `mobile-screen`, `screens/note`, backlinks suites) — 99 tests green.
- `cargo test -p reflect-open` fs + asset_protocol tests pass (request-path parsing: pinning, malformed requests, non-`assets/` refusal); `cargo clippy -p reflect-open --all-targets` clean.
- **Not yet verified in a running app** — a manual pass is owed: open a note with a fresh image on desktop and on an iOS device (ideally an iCloud graph mid-sync) and confirm the image renders without freezing the UI.

## Risk / rollout

- Any image rendering regression would be loud and immediate (images 404/refuse rather than fall back). The Rust handler logs every refused request with the path and status.
- Custom-scheme responses are not disk-cached by WebKit, same as the protocol this replaces — no cache-behavior change beyond the URL shape (generation-keyed, so a graph switch naturally misses).
- `graph_open`/`graph_create` lost their unused `AppHandle` parameter; Tauri injects that server-side, so the IPC surface for the frontend is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches how every in-note image is loaded and tightens the serving contract (generation-pinned paths only); regressions would show as broken images rather than silent wrong-graph reads, but iOS/iCloud behavior still needs manual verification per the PR.
> 
> **Overview**
> Fixes UI freezes when note images load (especially first paint on iOS/iCloud) by **replacing** Tauri's built-in synchronous `asset:` protocol with a custom **`reflect-asset://`** scheme registered via `register_asynchronous_uri_scheme_protocol`. Blocking reads run on the async runtime's **blocking pool**; the webview only gets bytes when they're ready.
> 
> **Rust:** New `fs/asset_protocol.rs` serves `GET` requests for `<generation>/<graph-relative path>`, using the same **generation pin** (`root_for_generation`), **`assets/`** restriction, and traversal guard as file commands. **`protocol-asset`**, `assetProtocol` config, **`allow_asset_scope`** on graph open/create, and the unused `AppHandle` on those commands are removed.
> 
> **Frontend:** `resolveImageUrl` now builds `convertFileSrc(\`${generation}/${src}\`, 'reflect-asset')` instead of absolute paths under `graphRoot`; **`useAssetPersistence`** drops the `graphRoot` argument at all call sites. CSP **`img-src`** switches from `asset:` to `reflect-asset:`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09ca82abdf737fd2789c818d4a83ba1a14d83a1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->