### PR TITLE
fix(mobile): align task checkboxes

### DIFF
--- a/apps/desktop/src/mobile/task-row.tsx
+++ b/apps/desktop/src/mobile/task-row.tsx
@@ -43,9 +43,9 @@ export function MobileTaskRow({ task, showSource, onEdit }: MobileTaskRowProps):
           hapticImpactLight()
           toggle()
         }}
-        // A generous touch target around the small glyph; py-3 h-6 keeps the
-        // circle centered on the first text line when a task wraps.
-        className="flex shrink-0 items-start py-3 pl-4 pr-3 text-text-muted disabled:opacity-50"
+        // A generous touch target around the small glyph; self-stretch keeps
+        // the circle vertically centered in the row as task text wraps.
+        className="flex shrink-0 self-stretch items-center pl-4 pr-3 text-text-muted disabled:opacity-50"
       >
         {task.checked ? (
           <CircleCheck aria-hidden className="size-5 text-accent" strokeWidth={2} />

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -551,7 +551,7 @@ html:root {
    dot is a lighter gray via `--meowdown-bullet` on `html:root` above; a collapsed
    bullet keeps meowdown's themed purple dot. */
 
-/* Task checkbox spacing. Two rules work together to give the checkbox breathing
+/* Task checkbox spacing. These rules work together to give the checkbox breathing
    room from its label (PR #373's goal) WITHOUT moving the label (moving it
    misaligns the label from sibling bullets and makes bullet<->task conversion
    jump sideways, the way the `1.25lh` content nudge #373 originally shipped did).
@@ -564,6 +564,9 @@ html:root {
       `.95rem` checkbox flush-left lands its right edge ~where a centered bullet
       dot's sits, so the checkbox<->label gap matches a bullet's. The breathing
       room comes from the marker, not from indenting the text.
+   3. The input itself is raised slightly to optically center both square
+      checklist boxes (`- [ ]`) and round task boxes (`+ [ ]`) against the text
+      baseline.
 
    meowdown does not fold this gap into its default yet, so it stays a Reflect
    override; meowdown is layered, so the unlayered `.reflect-editor` rules win. */
@@ -572,6 +575,9 @@ html:root {
 }
 .reflect-editor .prosemirror-flat-list[data-list-kind='task'] > .list-marker {
   justify-content: start;
+}
+.reflect-editor .prosemirror-flat-list[data-list-kind='task'] > .list-marker input[type='checkbox'] {
+  transform: translateY(-0.06em);
 }
 
 /* ---- shadcn inputs (components/ui/) -------------------------------------


### PR DESCRIPTION
## Problem

In the iOS surfaces, task controls were visually drifting against their text. The Tasks tab checkbox sat slightly high in its row, while editor-rendered Meowdown checkboxes sat a little low for both square checklist boxes and round task boxes.

## Changes

1. Center the mobile Tasks row checkbox by stretching the tap target to the row height and aligning the icon in the middle, so the glyph lines up with the task text even as rows wrap.
2. Add a small editor-scoped checkbox input nudge (`translateY(-0.06em)`) for Meowdown task list markers, covering both square checklist boxes (`- [ ]`) and round task boxes (`+ [ ]`) without changing the existing task label spacing.

## Verification

- `pnpm --filter @reflect/desktop test --run src/mobile/screens/tasks.test.tsx`
- `pnpm check`
- Verified the iOS preview at `http://localhost:1420/?platform=ios` with Playwright/Chrome: measured the Tasks row icon, body, and text line sharing the same vertical center, and confirmed the editor nudge applies to both square and round checkbox inputs.

## Risk / Rollout

Low risk. This is a scoped visual alignment change in the mobile task row component and the editor checkbox CSS; it does not change markdown parsing, task indexing, or persistence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS and mobile layout tweaks only; no changes to task write-back, markdown parsing, or data paths.
> 
> **Overview**
> Fixes **iOS task checkbox vertical drift** in two places without changing task parsing, indexing, or persistence.
> 
> On the **mobile Tasks tab**, the checkbox tap target now **stretches to the full row height** (`self-stretch` + `items-center`) instead of top-padding a fixed-height control, so the round glyph stays **vertically centered** when task text wraps.
> 
> In the **Meowdown editor**, task list marker checkboxes get a small **`translateY(-0.06em)`** on the input so square (`- [ ]`) and round (`+ [ ]`) boxes **optically align** with the text baseline. Existing PR #373 spacing rules (label alignment, marker pinning) are unchanged; the CSS comment documents the new third rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c22265f6e4da7c3f4be82cece5dc941f2a21d9e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->