### PR TITLE
feat(mobile): month picker sheet and rolling month title on the daily strip

### DIFF
--- a/apps/desktop/src/lib/month-grid.test.ts
+++ b/apps/desktop/src/lib/month-grid.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { addMonths, buildMonthGrid, monthLabel, monthOf, weekdayLabels } from './month-grid'
+import {
+  addMonths,
+  buildMonthGrid,
+  monthLabel,
+  monthOf,
+  monthShortLabel,
+  weekdayLabels,
+} from './month-grid'
 
 describe('monthOf', () => {
   it('extracts the YYYY-MM month of an ISO date', () => {
@@ -12,6 +19,13 @@ describe('monthLabel', () => {
   it('formats a human month label', () => {
     expect(monthLabel('2026-06')).toBe('June 2026')
     expect(monthLabel('2026-01')).toBe('January 2026')
+  })
+})
+
+describe('monthShortLabel', () => {
+  it('formats the abbreviated month name', () => {
+    expect(monthShortLabel('2026-06')).toBe('Jun')
+    expect(monthShortLabel('2026-01')).toBe('Jan')
   })
 })
 

--- a/apps/desktop/src/lib/month-grid.ts
+++ b/apps/desktop/src/lib/month-grid.ts
@@ -59,6 +59,11 @@ export function monthLabel(month: string): string {
   return format(parseMonth(month), 'MMMM yyyy')
 }
 
+/** Short label for a `YYYY-MM` month, e.g. `Jun` — month-picker grid cells. */
+export function monthShortLabel(month: string): string {
+  return format(parseMonth(month), 'MMM')
+}
+
 /** The `YYYY-MM` month `delta` months after `month` (negative for before). */
 export function addMonths(month: string, delta: number): string {
   return format(addMonthsToDate(parseMonth(month), delta), MONTH_FORMAT)

--- a/apps/desktop/src/mobile/calendar-strip.tsx
+++ b/apps/desktop/src/mobile/calendar-strip.tsx
@@ -1,9 +1,12 @@
-import { useEffect, useRef, type ReactElement } from 'react'
-import { Settings } from 'lucide-react'
+import { useEffect, useRef, useState, type ReactElement } from 'react'
+import { ChevronDown, Settings } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { addDaysIso } from '@/lib/dates'
-import { monthLabel, weekAtIndex, weekStartOf } from '@/mobile/calendar'
+import { monthOf } from '@/lib/month-grid'
+import { monthPickTarget, weekAtIndex, weekStartOf } from '@/mobile/calendar'
 import { hapticImpactLight } from '@/mobile/haptics'
+import { MonthPickerDrawer } from '@/mobile/month-picker-drawer'
+import { MonthTitle } from '@/mobile/month-title'
 import { useWeekStrip } from '@/mobile/use-week-strip'
 import { WeekRow } from '@/mobile/week-row'
 import { useSettings } from '@/providers/settings-provider'
@@ -16,7 +19,7 @@ interface CalendarStripProps {
    *  parent's select logic share one value (no midnight-rollover skew). */
   today: string
   /**
-   * Bumped on an explicit re-arrival at the shown day (Daily tab / title tap
+   * Bumped on an explicit re-arrival at the shown day (Daily tab tapped
    * while already there): re-center the strip on the selection even though
    * `date` didn't change.
    */
@@ -31,9 +34,10 @@ interface CalendarStripProps {
  * weeks, tap a cell to select that day. Browsing moves the header month with
  * the visible week; the strip snaps back to the selection's week whenever the
  * selection itself changes, so strip and carousel stay in lockstep through
- * the parent's `date`. The tappable month title jumps back to today (V1), and
- * a **Today** affordance appears in the header when the selection has
- * wandered off today.
+ * the parent's `date`. Month changes roll through {@link MonthTitle} rather
+ * than swapping. The tappable month title opens {@link MonthPickerDrawer} to
+ * jump across months, and a **Today** affordance appears in the header when
+ * the selection has wandered off today.
  */
 export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStripProps): ReactElement {
   const { settings } = useSettings()
@@ -60,6 +64,20 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
   const openSettings = (): void => {
     hapticImpactLight()
     navigate({ kind: 'settings' })
+  }
+
+  const [monthPickerOpen, setMonthPickerOpen] = useState(false)
+  const openMonthPicker = (): void => {
+    hapticImpactLight()
+    setMonthPickerOpen(true)
+  }
+  const pickMonth = (picked: string): void => {
+    setMonthPickerOpen(false)
+    const target = monthPickTarget(picked, date, today)
+    onSelect(target)
+    // Selecting the target only moves the strip when `date` changes — picking
+    // the selection's own month must still snap a browsed-away strip back.
+    showWeekOf(target)
   }
 
   // An explicit re-arrival doesn't change `date`, so the follow effect won't
@@ -92,9 +110,15 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
             <Settings />
           </Button>
         </div>
-        <h1 className="min-w-0 truncate text-center text-base font-semibold">
-          <button type="button" aria-label="Jump to today" onClick={jumpToToday}>
-            {monthLabel(headerDate)}
+        <h1 className="min-w-0 text-center text-base font-semibold">
+          <button
+            type="button"
+            aria-label="Change month"
+            className="flex min-w-0 items-center gap-1"
+            onClick={openMonthPicker}
+          >
+            <MonthTitle month={monthOf(headerDate)} />
+            <ChevronDown aria-hidden className="size-4 shrink-0 text-text-muted" />
           </button>
         </h1>
         <div className="justify-self-end">
@@ -123,6 +147,14 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
           })}
         </div>
       </div>
+      <MonthPickerDrawer
+        open={monthPickerOpen}
+        onOpenChange={setMonthPickerOpen}
+        month={monthOf(headerDate)}
+        selected={monthOf(date)}
+        today={monthOf(today)}
+        onPick={pickMonth}
+      />
     </header>
   )
 }

--- a/apps/desktop/src/mobile/calendar.test.ts
+++ b/apps/desktop/src/mobile/calendar.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   createWeekWindow,
-  monthLabel,
+  monthPickTarget,
   weekAtIndex,
   weekIndexOf,
   weekOf,
@@ -55,9 +55,18 @@ describe('weekOf', () => {
   })
 })
 
-describe('monthLabel', () => {
-  it('formats the month and year', () => {
-    expect(monthLabel('2026-06-12')).toBe('June 2026')
+describe('monthPickTarget', () => {
+  it('keeps the selection when its own month is picked', () => {
+    expect(monthPickTarget('2026-06', '2026-06-12', '2026-06-20')).toBe('2026-06-12')
+  })
+
+  it('lands on today when today’s month is picked', () => {
+    expect(monthPickTarget('2026-07', '2026-06-12', '2026-07-04')).toBe('2026-07-04')
+  })
+
+  it('opens any other month on its first day', () => {
+    expect(monthPickTarget('2026-09', '2026-06-12', '2026-07-04')).toBe('2026-09-01')
+    expect(monthPickTarget('2025-12', '2026-06-12', '2026-07-04')).toBe('2025-12-01')
   })
 })
 

--- a/apps/desktop/src/mobile/calendar.ts
+++ b/apps/desktop/src/mobile/calendar.ts
@@ -1,6 +1,7 @@
-import { differenceInCalendarDays, format, getDay } from 'date-fns'
+import { differenceInCalendarDays, getDay } from 'date-fns'
 import type { WeekStartDay } from '@reflect/core'
 import { addDaysIso, parseIsoDate } from '@/lib/dates'
+import { monthOf } from '@/lib/month-grid'
 
 /**
  * Date math for the V1-parity Daily surface's **calendar strip** — the month
@@ -24,9 +25,19 @@ export function weekOf(date: string, weekStart: WeekStartDay): string[] {
   return Array.from({ length: 7 }, (_, index) => addDaysIso(first, index))
 }
 
-/** The strip's month header, e.g. `June 2026`. */
-export function monthLabel(date: string): string {
-  return format(parseIsoDate(date), 'MMMM yyyy')
+/**
+ * Where the month picker lands when a `YYYY-MM` month is picked: the
+ * selection's own month keeps the selection, today's month goes to today,
+ * and any other month opens on its first day.
+ */
+export function monthPickTarget(month: string, selected: string, today: string): string {
+  if (monthOf(selected) === month) {
+    return selected
+  }
+  if (monthOf(today) === month) {
+    return today
+  }
+  return `${month}-01`
 }
 
 /**

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -12,7 +12,8 @@ import {
 import { RouterProvider, useRouter } from '@/routing/router'
 import type { Route } from '@/routing/route'
 import { addDaysIso, formatDayLabel, parseIsoDate, todayIso } from '@/lib/dates'
-import { monthLabel, weekOf } from './calendar'
+import { monthLabel, monthOf } from '@/lib/month-grid'
+import { weekOf } from './calendar'
 import { MobileShell } from './mobile-shell'
 import { publishKeyboardHeight } from './use-keyboard'
 
@@ -110,6 +111,18 @@ vi.mock('@reflect/core', async (importOriginal) => ({
   hasBridge: () => true,
   getBacklinksWithContext: indexFns.getBacklinksWithContext,
 }))
+// vaul needs browser APIs jsdom doesn't provide (matchMedia, pointer
+// capture); its drag/animation is verified on-device. This passthrough
+// honours `open`, so the month-picker sheet renders only once the title
+// opens it.
+vi.mock('@/components/ui/drawer', () => ({
+  Drawer: ({ open, children }: { open?: boolean; children?: import('react').ReactNode }) =>
+    open ? <div data-testid="drawer">{children}</div> : null,
+  DrawerContent: ({ children }: { children?: import('react').ReactNode }) => <div>{children}</div>,
+  DrawerTitle: ({ children }: { children?: import('react').ReactNode }) => <h2>{children}</h2>,
+  DrawerTrigger: ({ children }: { children?: import('react').ReactNode }) => <>{children}</>,
+}))
+
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({
     graph: { root: '/g', name: 'g', generation: 1 },
@@ -235,6 +248,18 @@ function dayCellLabel(date: string): string {
   return format(parseIsoDate(date), 'EEEE, MMMM do')
 }
 
+/**
+ * The strip header's settled month label — a month change rolls the old
+ * label out, so the heading's whole textContent briefly holds both.
+ */
+function shownMonth(view: ReturnType<typeof render>): string | null {
+  return (
+    view
+      .getByRole('heading', { level: 1 })
+      .querySelector('[data-slot="month-title"]')?.textContent ?? null
+  )
+}
+
 /** A day in `date`'s week that isn't `date` itself (always present). */
 function otherDayInWeek(date: string): string {
   const week = weekOf(date, 'monday')
@@ -249,7 +274,7 @@ describe('MobileShell', () => {
 
     // The header is the month; the carousel mounts today's slide (±1
     // neighbours), each carrying its formatted date as the note's subject.
-    expect(view.getByRole('heading', { level: 1 }).textContent).toBe(monthLabel(today))
+    expect(shownMonth(view)).toBe(monthLabel(monthOf(today)))
     expect(view.getByText(formatDayLabel(today, 'mdy'))).toBeTruthy()
     await waitFor(() => {
       const editors = view.getAllByTestId('fake-editor')
@@ -289,24 +314,40 @@ describe('MobileShell', () => {
     expect(
       view.getByRole('button', { name: dayCellLabel(nextFortnight) }).getAttribute('aria-current'),
     ).toBe('date')
-    expect(view.getByRole('heading', { level: 1 }).textContent).toBe(monthLabel(nextFortnight))
+    expect(shownMonth(view)).toBe(monthLabel(monthOf(nextFortnight)))
     expect(view.getByRole('button', { name: 'Today' })).toBeTruthy()
   })
 
-  it('jumps back to today from the tappable month title', async () => {
+  it('jumps to a picked month from the month title’s picker sheet', async () => {
     const user = userEvent.setup()
     const today = todayIso()
-    const other = otherDayInWeek(today)
     const view = mount({ kind: 'today' })
 
-    await user.click(view.getByRole('button', { name: dayCellLabel(other) }))
-    expect(view.getByRole('button', { name: dayCellLabel(other) }).getAttribute('aria-current')).toBe(
-      'date',
-    )
+    await user.click(view.getByRole('button', { name: 'Change month' }))
+    await user.click(view.getByRole('button', { name: 'Next year' }))
+    // January next year: always a different month, and (unlike a fixed
+    // offset) always the same distance shape from today — date-agnostic.
+    const pickedMonth = `${Number(monthOf(today).slice(0, 4)) + 1}-01`
+    await user.click(view.getByRole('button', { name: monthLabel(pickedMonth) }))
 
-    hapticImpactLight.mockClear()
-    await user.click(view.getByRole('button', { name: 'Jump to today' }))
-    expect(hapticImpactLight).toHaveBeenCalledTimes(1)
+    expect(view.queryByTestId('drawer')).toBeNull()
+    expect(shownMonth(view)).toBe(monthLabel(pickedMonth))
+    const firstDay = `${pickedMonth}-01`
+    expect(
+      view.getByRole('button', { name: dayCellLabel(firstDay) }).getAttribute('aria-current'),
+    ).toBe('date')
+    expect(view.getByRole('button', { name: 'Today' })).toBeTruthy()
+  })
+
+  it('keeps the selection when its own month is picked from the sheet', async () => {
+    const user = userEvent.setup()
+    const today = todayIso()
+    const view = mount({ kind: 'today' })
+
+    await user.click(view.getByRole('button', { name: 'Change month' }))
+    await user.click(view.getByRole('button', { name: monthLabel(monthOf(today)) }))
+
+    expect(view.queryByTestId('drawer')).toBeNull()
     expect(view.getByRole('button', { name: dayCellLabel(today) }).getAttribute('aria-current')).toBe(
       'date',
     )
@@ -339,7 +380,7 @@ describe('MobileShell', () => {
     const view = mount({ kind: 'today' }, { kind: 'daily', date: farDay })
 
     await user.click(view.getByRole('button', { name: 'probe-navigate' }))
-    expect(view.getByRole('heading', { level: 1 }).textContent).toBe(monthLabel(farDay))
+    expect(shownMonth(view)).toBe(monthLabel(monthOf(farDay)))
     await waitFor(() => {
       const editors = view.getAllByTestId('fake-editor')
       expect(editors.some((editor) => editor.textContent?.includes('far future plans'))).toBe(true)
@@ -355,7 +396,7 @@ describe('MobileShell', () => {
     expect(view.getByRole('heading').textContent).toBe('Edit note')
 
     await user.click(view.getByRole('button', { name: 'Back' }))
-    expect(view.getByRole('heading', { level: 1 }).textContent).toBe(monthLabel(todayIso()))
+    expect(shownMonth(view)).toBe(monthLabel(monthOf(todayIso())))
   })
 
   it('never focuses the destination editor on navigation (keyboard stays down)', async () => {
@@ -559,7 +600,7 @@ describe('MobileShell', () => {
     })
 
     await user.click(view.getByRole('button', { name: 'Back' }))
-    expect(view.getByRole('heading', { level: 1 }).textContent).toBe(monthLabel(todayIso()))
+    expect(shownMonth(view)).toBe(monthLabel(monthOf(todayIso())))
   })
 })
 
@@ -591,8 +632,10 @@ describe('MobileStack transitions & back-swipe', () => {
     expect(entering!.className).toContain('mobile-stack-slide-in')
     expect(origin!.getAttribute('aria-hidden')).toBe('true')
     expect(
-      within(origin!).getByRole('heading', { level: 1, hidden: true }).textContent,
-    ).toBe(monthLabel(todayIso()))
+      within(origin!)
+        .getByRole('heading', { level: 1, hidden: true })
+        .querySelector('[data-slot="month-title"]')?.textContent,
+    ).toBe(monthLabel(monthOf(todayIso())))
     expect(view.container.querySelector('.mobile-stack-scrim')).toBeTruthy()
 
     fireEvent.animationEnd(entering!)
@@ -609,7 +652,7 @@ describe('MobileStack transitions & back-swipe', () => {
 
     await user.click(view.getByRole('button', { name: 'Back' }))
     // Daily is current again immediately; the note lingers only to animate out.
-    expect(view.getByRole('heading', { level: 1 }).textContent).toBe(monthLabel(todayIso()))
+    expect(shownMonth(view)).toBe(monthLabel(monthOf(todayIso())))
     const exiting = stackLayers(view).at(-1)!
     expect(exiting.className).toContain('mobile-stack-slide-out')
     expect(exiting.getAttribute('aria-hidden')).toBe('true')
@@ -712,7 +755,7 @@ describe('MobileStack transitions & back-swipe', () => {
 
     // ...and only then commits the pop.
     fireEvent.transitionEnd(card)
-    expect(view.getByRole('heading', { level: 1 }).textContent).toBe(monthLabel(todayIso()))
+    expect(shownMonth(view)).toBe(monthLabel(monthOf(todayIso())))
     expect(stackLayers(view)).toHaveLength(1)
   })
 

--- a/apps/desktop/src/mobile/month-picker-drawer.test.tsx
+++ b/apps/desktop/src/mobile/month-picker-drawer.test.tsx
@@ -1,0 +1,108 @@
+import type { ReactNode } from 'react'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MonthPickerDrawer } from './month-picker-drawer'
+
+/**
+ * The month title's picker sheet: a year pager over a twelve-month grid.
+ * Year browsing must never navigate, each open must start from the header's
+ * month, and the selection/today months carry the strip's markings.
+ */
+
+// vaul needs browser APIs jsdom doesn't provide (matchMedia, pointer
+// capture); its drag/animation is verified on-device. This passthrough
+// honours `open` so open/close behavior stays testable.
+vi.mock('@/components/ui/drawer', () => ({
+  Drawer: ({ open, children }: { open?: boolean; children?: ReactNode }) =>
+    open ? <div data-testid="drawer">{children}</div> : null,
+  DrawerContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DrawerTitle: ({ children }: { children?: ReactNode }) => <h2>{children}</h2>,
+}))
+
+afterEach(cleanup)
+
+function mount(overrides: Partial<Parameters<typeof MonthPickerDrawer>[0]> = {}) {
+  const onPick = vi.fn()
+  const view = render(
+    <MonthPickerDrawer
+      open
+      onOpenChange={() => {}}
+      month="2026-06"
+      selected="2026-06"
+      today="2026-07"
+      onPick={onPick}
+      {...overrides}
+    />,
+  )
+  return { view, onPick }
+}
+
+describe('MonthPickerDrawer', () => {
+  it('opens on the header month’s year with the selection and today marked', () => {
+    mount()
+
+    expect(screen.getByText('2026')).toBeTruthy()
+    const months = screen.getAllByRole('button', { name: /2026$/ })
+    expect(months).toHaveLength(12)
+    expect(
+      screen.getByRole('button', { name: 'June 2026' }).getAttribute('aria-pressed'),
+    ).toBe('true')
+    expect(
+      screen.getByRole('button', { name: 'July 2026' }).getAttribute('aria-current'),
+    ).toBe('date')
+  })
+
+  it('picks a month of the shown year', async () => {
+    const user = userEvent.setup()
+    const { onPick } = mount()
+
+    await user.click(screen.getByRole('button', { name: 'September 2026' }))
+    expect(onPick).toHaveBeenCalledWith('2026-09')
+  })
+
+  it('pages years without navigating, then picks in the browsed year', async () => {
+    const user = userEvent.setup()
+    const { onPick } = mount()
+
+    await user.click(screen.getByRole('button', { name: 'Previous year' }))
+    await user.click(screen.getByRole('button', { name: 'Previous year' }))
+    expect(screen.getByText('2024')).toBeTruthy()
+    expect(onPick).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: 'March 2024' }))
+    expect(onPick).toHaveBeenCalledWith('2024-03')
+  })
+
+  it('reopens on the header month’s year, not the last browsed one', async () => {
+    const user = userEvent.setup()
+    const { view } = mount()
+
+    await user.click(screen.getByRole('button', { name: 'Next year' }))
+    expect(screen.getByText('2027')).toBeTruthy()
+
+    view.rerender(
+      <MonthPickerDrawer
+        open={false}
+        onOpenChange={() => {}}
+        month="2026-06"
+        selected="2026-06"
+        today="2026-07"
+        onPick={() => {}}
+      />,
+    )
+    expect(screen.queryByTestId('drawer')).toBeNull()
+
+    view.rerender(
+      <MonthPickerDrawer
+        open
+        onOpenChange={() => {}}
+        month="2026-06"
+        selected="2026-06"
+        today="2026-07"
+        onPick={() => {}}
+      />,
+    )
+    expect(screen.getByText('2026')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/mobile/month-picker-drawer.tsx
+++ b/apps/desktop/src/mobile/month-picker-drawer.tsx
@@ -1,0 +1,111 @@
+import { useState, type ReactElement } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
+import { monthLabel, monthShortLabel } from '@/lib/month-grid'
+import { cn } from '@/lib/utils'
+import { hapticImpactLight } from '@/mobile/haptics'
+
+interface MonthPickerDrawerProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** The strip header's `YYYY-MM` month — the year the sheet opens on. */
+  month: string
+  /** The selection's `YYYY-MM` month, shown filled like the strip's day. */
+  selected: string
+  /** Today's `YYYY-MM` month, marked like the strip's today cell. */
+  today: string
+  /** Pick a `YYYY-MM` month — the strip navigates and closes the sheet. */
+  onPick: (month: string) => void
+}
+
+function yearOf(month: string): number {
+  return Number(month.slice(0, 4))
+}
+
+/**
+ * The month title's picker sheet: a year pager over a tap-to-jump grid of its
+ * twelve months (iOS's compact date-picker idiom as a bottom sheet). Browsing
+ * years never navigates — only tapping a month does; the sheet dismisses by
+ * drag or tapping outside, like every mobile sheet.
+ */
+export function MonthPickerDrawer({
+  open,
+  onOpenChange,
+  month,
+  selected,
+  today,
+  onPick,
+}: MonthPickerDrawerProps): ReactElement {
+  const [year, setYear] = useState(() => yearOf(month))
+  // Each open starts from the currently displayed month's year, not wherever
+  // the previous visit browsed to. Adjust-on-render, mirroring MonthTitle.
+  const [wasOpen, setWasOpen] = useState(open)
+  if (open !== wasOpen) {
+    setWasOpen(open)
+    if (open) {
+      setYear(yearOf(month))
+    }
+  }
+
+  const months = Array.from(
+    { length: 12 },
+    (_, index) => `${year}-${String(index + 1).padStart(2, '0')}`,
+  )
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent aria-label="Change month">
+        <DrawerTitle className="sr-only">Change month</DrawerTitle>
+        <div className="flex items-center justify-between">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-9"
+            aria-label="Previous year"
+            onClick={() => setYear(year - 1)}
+          >
+            <ChevronLeft />
+          </Button>
+          <div className="text-base font-semibold tabular-nums">{year}</div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-9"
+            aria-label="Next year"
+            onClick={() => setYear(year + 1)}
+          >
+            <ChevronRight />
+          </Button>
+        </div>
+        <div className="grid grid-cols-3 gap-2">
+          {months.map((candidate) => {
+            const isSelected = candidate === selected
+            const isThisMonth = candidate === today
+            return (
+              <button
+                key={candidate}
+                type="button"
+                aria-label={monthLabel(candidate)}
+                aria-pressed={isSelected}
+                aria-current={isThisMonth ? 'date' : undefined}
+                onClick={() => {
+                  hapticImpactLight()
+                  onPick(candidate)
+                }}
+                className={cn(
+                  'h-11 rounded-lg text-sm',
+                  isSelected && 'bg-primary font-semibold text-primary-foreground',
+                  !isSelected && isThisMonth && 'font-semibold text-primary',
+                  !isSelected && !isThisMonth && 'text-text',
+                )}
+              >
+                {monthShortLabel(candidate)}
+              </button>
+            )
+          })}
+        </div>
+      </DrawerContent>
+    </Drawer>
+  )
+}

--- a/apps/desktop/src/mobile/month-title.css
+++ b/apps/desktop/src/mobile/month-title.css
@@ -1,0 +1,63 @@
+/*
+ * The calendar strip's month-label roll (month-title.tsx). Inline rendering
+ * owns the resting state (a single plain label); these keyframes only
+ * describe the journey there — moving to a later month both labels drift up,
+ * to an earlier month both drift down, cross-fading either way. Durations
+ * mirror MONTH_TITLE_TRANSITION_MS in month-title.tsx (the fallback timer
+ * that removes the outgoing label when `animationend` never fires).
+ */
+
+.month-title-enter-up {
+  animation: month-title-enter-up 200ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.month-title-enter-down {
+  animation: month-title-enter-down 200ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.month-title-exit-up {
+  animation: month-title-exit-up 200ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+}
+
+.month-title-exit-down {
+  animation: month-title-exit-down 200ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+}
+
+@keyframes month-title-enter-up {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 45%, 0);
+  }
+}
+
+@keyframes month-title-enter-down {
+  from {
+    opacity: 0;
+    transform: translate3d(0, -45%, 0);
+  }
+}
+
+@keyframes month-title-exit-up {
+  to {
+    opacity: 0;
+    transform: translate3d(0, -45%, 0);
+  }
+}
+
+@keyframes month-title-exit-down {
+  to {
+    opacity: 0;
+    transform: translate3d(0, 45%, 0);
+  }
+}
+
+/* Belt and braces: the component also skips the roll in JS under reduced
+   motion, but never animate even if a code path forgets to check. */
+@media (prefers-reduced-motion: reduce) {
+  .month-title-enter-up,
+  .month-title-enter-down,
+  .month-title-exit-up,
+  .month-title-exit-down {
+    animation: none;
+  }
+}

--- a/apps/desktop/src/mobile/month-title.test.tsx
+++ b/apps/desktop/src/mobile/month-title.test.tsx
@@ -1,0 +1,96 @@
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MONTH_TITLE_TRANSITION_MS, MonthTitle } from './month-title'
+
+/**
+ * The month header's ticker roll: later months roll up, earlier months roll
+ * down, the outgoing label leaves on animationend (with a timer fallback),
+ * and reduced motion swaps instantly. jsdom runs no animations, so tests
+ * drive `animationend` by hand.
+ */
+
+function stubMatchMedia(matches: boolean): () => void {
+  const original = window.matchMedia
+  window.matchMedia = ((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia
+  return () => {
+    window.matchMedia = original
+  }
+}
+
+afterEach(cleanup)
+
+describe('MonthTitle', () => {
+  it('renders the settled label alone', () => {
+    const view = render(<MonthTitle month="2026-06" />)
+    const settled = view.container.querySelector('[data-slot="month-title"]')
+    expect(settled?.textContent).toBe('June 2026')
+    expect(view.container.textContent).toBe('June 2026')
+  })
+
+  it('rolls up to a later month and clears the outgoing label on animationend', () => {
+    const view = render(<MonthTitle month="2026-06" />)
+    view.rerender(<MonthTitle month="2026-07" />)
+
+    const settled = view.container.querySelector('[data-slot="month-title"]')!
+    expect(settled.textContent).toBe('July 2026')
+    expect(settled.className).toContain('month-title-enter-up')
+    const outgoing = view.container.querySelector('.month-title-exit-up')!
+    expect(outgoing.textContent).toBe('June 2026')
+    expect(outgoing.getAttribute('aria-hidden')).toBe('true')
+
+    fireEvent.animationEnd(outgoing)
+    expect(view.container.querySelector('.month-title-exit-up')).toBeNull()
+    expect(settled.className).not.toContain('month-title-enter-up')
+  })
+
+  it('rolls down to an earlier month, across the year boundary', () => {
+    const view = render(<MonthTitle month="2027-01" />)
+    view.rerender(<MonthTitle month="2026-12" />)
+
+    expect(view.container.querySelector('[data-slot="month-title"]')?.className).toContain(
+      'month-title-enter-down',
+    )
+    expect(view.container.querySelector('.month-title-exit-down')?.textContent).toBe('January 2027')
+  })
+
+  it('removes the outgoing label by timer when animationend never fires', () => {
+    vi.useFakeTimers()
+    try {
+      const view = render(<MonthTitle month="2026-06" />)
+      view.rerender(<MonthTitle month="2026-07" />)
+      expect(view.container.querySelector('.month-title-exit-up')).toBeTruthy()
+
+      act(() => {
+        vi.advanceTimersByTime(MONTH_TITLE_TRANSITION_MS + 100)
+      })
+      expect(view.container.querySelector('.month-title-exit-up')).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('swaps instantly under reduced motion', () => {
+    const restore = stubMatchMedia(true)
+    try {
+      const view = render(<MonthTitle month="2026-06" />)
+      view.rerender(<MonthTitle month="2026-07" />)
+
+      expect(view.container.textContent).toBe('July 2026')
+      expect(view.container.querySelector('.month-title-exit-up')).toBeNull()
+      expect(view.container.querySelector('[data-slot="month-title"]')?.className).not.toContain(
+        'month-title-enter-up',
+      )
+    } finally {
+      restore()
+    }
+  })
+})

--- a/apps/desktop/src/mobile/month-title.tsx
+++ b/apps/desktop/src/mobile/month-title.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useState, type ReactElement } from 'react'
+import { monthLabel } from '@/lib/month-grid'
+import { cn } from '@/lib/utils'
+import { usePrefersReducedMotion } from '@/mobile/use-reduced-motion'
+import './month-title.css'
+
+/** Mirrors the animation durations in month-title.css (the fallback timer). */
+export const MONTH_TITLE_TRANSITION_MS = 200
+
+interface OutgoingMonth {
+  month: string
+  /** `up` toward a later month, `down` toward an earlier one. */
+  direction: 'up' | 'down'
+}
+
+interface MonthTitleProps {
+  /** The `YYYY-MM` month to show. */
+  month: string
+}
+
+/**
+ * The calendar strip's month label, changed with a ticker roll instead of an
+ * instant swap: moving to a later month the old label fades up and out while
+ * the new one fades up in from beneath it; earlier months roll the other way.
+ * Under reduced motion the label just swaps. The settled label carries
+ * `data-slot="month-title"` so callers (and tests) can read it without
+ * catching a mid-roll outgoing label.
+ */
+export function MonthTitle({ month }: MonthTitleProps): ReactElement {
+  const reducedMotion = usePrefersReducedMotion()
+  const [shown, setShown] = useState(month)
+  const [outgoing, setOutgoing] = useState<OutgoingMonth | null>(null)
+  // Adjust-on-render rather than an effect: the outgoing and incoming labels
+  // must appear in the same paint or the roll flickers.
+  if (shown !== month) {
+    setShown(month)
+    setOutgoing(
+      reducedMotion ? null : { month: shown, direction: month > shown ? 'up' : 'down' },
+    )
+  }
+
+  // The outgoing label leaves on `animationend` — a native listener, like
+  // the navigation stack's (React's synthetic animation events misfire in
+  // some WebKit/jsdom environments). The timer is the fallback for when the
+  // animation never runs (the reduced-motion media block).
+  const outgoingRef = useRef<HTMLSpanElement | null>(null)
+  useEffect(() => {
+    if (!outgoing) {
+      return
+    }
+    const element = outgoingRef.current
+    const clear = (): void => setOutgoing(null)
+    element?.addEventListener('animationend', clear)
+    const timer = window.setTimeout(clear, MONTH_TITLE_TRANSITION_MS + 80)
+    return () => {
+      element?.removeEventListener('animationend', clear)
+      window.clearTimeout(timer)
+    }
+  }, [outgoing])
+
+  return (
+    <span className="relative block min-w-0">
+      <span
+        key={shown}
+        data-slot="month-title"
+        className={cn(
+          'block truncate',
+          outgoing && (outgoing.direction === 'up' ? 'month-title-enter-up' : 'month-title-enter-down'),
+        )}
+      >
+        {monthLabel(shown)}
+      </span>
+      {outgoing ? (
+        <span
+          ref={outgoingRef}
+          aria-hidden
+          className={cn(
+            'absolute inset-x-0 top-0 block truncate',
+            outgoing.direction === 'up' ? 'month-title-exit-up' : 'month-title-exit-down',
+          )}
+        >
+          {monthLabel(outgoing.month)}
+        </span>
+      ) : null}
+    </span>
+  )
+}

--- a/apps/desktop/src/mobile/screens/daily.tsx
+++ b/apps/desktop/src/mobile/screens/daily.tsx
@@ -32,9 +32,9 @@ export function MobileDaily({ date }: { date: string }): ReactElement {
     [navigate, today],
   )
 
-  // An explicit re-arrival at the day already shown — the Daily tab or the
-  // month title tapped while on today (V1's double-tap-to-today lands here as
-  // two such arrivals) — re-anchors the surface: the selected slide scrolls
+  // An explicit re-arrival at the day already shown — the Daily tab tapped
+  // while on today (V1's double-tap-to-today lands here as two such
+  // arrivals) — re-anchors the surface: the selected slide scrolls
   // to the top and the strip re-centers. The router bumps `arrivalSeq` for
   // every navigate, but a swipe's own echo also changes `date`, so only
   // date-preserving arrivals count.


### PR DESCRIPTION
## Problem

The daily strip's month header was static text with one hidden behavior: tapping it jumped to today — redundant with the header's **Today** affordance. There was no way to jump the daily spine to another month without swiping the week strip one page at a time, and when swiping between days crossed a month boundary the header label swapped instantly, giving no spatial feedback for which direction time moved.

## Before → After

| Interaction | Before | After |
| --- | --- | --- |
| Tap the month title | Jumps to today (duplicate of **Today**) | Opens a bottom-sheet month picker (year pager + 12-month grid) |
| Pick a month | — | Selection's own month keeps the selection; today's month goes to today; any other month opens on its 1st |
| Month changes while swiping days / browsing weeks | Instant label swap | Ticker roll: later months fade up, earlier months fade down; reduced motion swaps instantly |

## Changes

1. **`month-picker-drawer.tsx`** — a vaul bottom sheet (the established mobile-sheet pattern): chevron year pager over a 3×4 month grid, iOS compact-date-picker idiom. The selected month is filled like the strip's selected day, today's month tinted like the strip's today cell; picks fire `hapticImpactLight` like day taps. Each open resets to the header month's year.
2. **`month-title.tsx` / `month-title.css`** — the header label as a ticker: on a month change the old label animates out while the new animates in (direction from `YYYY-MM` comparison). The outgoing label leaves on a **native** `animationend` listener (React's synthetic animation events misfire in some WebKit/jsdom environments — same reason `mobile-stack` listens natively) with a timer fallback; `usePrefersReducedMotion` skips the roll entirely. The settled label carries `data-slot="month-title"` so tests never read a mid-roll double label.
3. **`calendar-strip.tsx`** — the title button now opens the picker (with a small chevron-down affordance, and a light haptic matching the header's other taps after #581) instead of calling `jumpToToday`; picking routes through `monthPickTarget` + `showWeekOf` so the strip snaps even when the date didn't change. Jump-to-today remains via the **Today** button.
4. **`mobile/calendar.ts`** — new pure `monthPickTarget(month, selected, today)` policy; the strip-local `monthLabel` was dropped in favor of `lib/month-grid`'s (plus a new `monthShortLabel` there for grid cells).
5. **`screens/daily.tsx`** — comment-only: the re-arrival reset no longer flows from title taps.

Note: this deliberately diverges from V1's title-tap-to-today interaction (per request); the today shortcut survives as the **Today** button.

## Tests

- `month-picker-drawer.test.tsx` — opens on the header month's year with selection/today marked; picking fires `onPick`; year paging never navigates; reopening resets the browsed year.
- `month-title.test.tsx` — up-roll and down-roll (across a year boundary), outgoing cleanup on `animationend` and by fallback timer, instant swap under reduced motion.
- `calendar.test.ts` / `month-grid.test.ts` — `monthPickTarget` policy and `monthShortLabel`.
- `mobile-screen.test.tsx` — end-to-end through the real router: picking January-next-year from the sheet selects its 1st and re-anchors the strip; picking the selection's own month keeps the selection; the old title-tap-to-today test is replaced. A gated drawer mock (the `tasks.test.tsx` pattern) stands in for vaul.

## Verification

- `pnpm test --run src/mobile src/lib/month-grid.test.ts` — 38 files, 272 tests pass.
- `pnpm check` (typecheck + oxlint + eslint) — clean.
- Manually exercised in the `?platform=ios` browser harness: opened the sheet, picked months forward/back and across years, confirmed enter/exit roll classes in both directions, outgoing label cleanup, Today round-trip, and the strip following far picks. Not yet run on an iOS device/simulator.

## Risk / Rollout

- Mobile-only surface; no data, IPC, or desktop changes.
- The roll animation is purely presentational; if `animationend` never fires the fallback timer removes the outgoing label, and reduced motion bypasses it in both JS and CSS.
- Owed: a quick pass on a real device for sheet drag-dismiss feel and haptics (browser harness can't verify either).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mobile-only UI and routing for daily navigation; no data, auth, or desktop paths. Main behavioral change is intentional loss of title-tap-to-today in favor of the picker.
> 
> **Overview**
> Replaces the daily calendar strip’s **tap month → jump to today** behavior with a **month picker bottom sheet** (year pager + 12-month grid) and adds a **directional roll animation** when the header month changes while swiping days or weeks.
> 
> **Month picker:** Tapping the title (with chevron) opens `MonthPickerDrawer`; picks route through new `monthPickTarget` (keep selection in its month, today’s month → today, else month’s 1st) and `showWeekOf` so the week strip recenters even when the date unchanged. **Today** remains the only jump-to-today control.
> 
> **Header UX:** `MonthTitle` animates month changes (up/down by `YYYY-MM` comparison) with reduced-motion instant swap; shared `monthShortLabel` / `monthOf` from `lib/month-grid` replace strip-local `monthLabel`.
> 
> **Tests:** Unit tests for picker, title roll, `monthPickTarget`, and mobile shell flows; drawer mocked in jsdom like other mobile sheets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54db1090aee0387b1167d0defb559f1b818e4234. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

