### PR TITLE
fix(mobile): mount the swipe target's neighbor while the day snap animates

### DIFF
--- a/apps/desktop/src/mobile/calendar-strip.tsx
+++ b/apps/desktop/src/mobile/calendar-strip.tsx
@@ -13,7 +13,11 @@ import { useSettings } from '@/providers/settings-provider'
 import { useRouter } from '@/routing/router'
 
 interface CalendarStripProps {
-  /** The selected day (the centered carousel slide). */
+  /**
+   * The day the strip should highlight — the route's selected day, or the
+   * destination of an in-flight carousel swipe (the parent hands the swipe
+   * target over at pointer-up so the strip and month title lead the route).
+   */
   date: string
   /** Today's live ISO date — owned by the parent so the strip and the
    *  parent's select logic share one value (no midnight-rollover skew). */

--- a/apps/desktop/src/mobile/day-carousel.tsx
+++ b/apps/desktop/src/mobile/day-carousel.tsx
@@ -19,6 +19,12 @@ interface DayCarouselProps {
   onFocusConsumed: () => void
   /** Settle on a day — the parent turns this into a daily-route navigation. */
   onSelect: (date: string) => void
+  /**
+   * A swipe's destination day, announced at pointer-up while the snap
+   * animation still plays — for chrome (the calendar strip and its month
+   * title) that should move with the gesture, ahead of the route.
+   */
+  onTarget: (date: string) => void
 }
 
 /** Slides within this many of the selection mount an editor; the rest are
@@ -40,8 +46,9 @@ export function DayCarousel({
   focusDate,
   onFocusConsumed,
   onSelect,
+  onTarget,
 }: DayCarouselProps): ReactElement {
-  const { emblaRef, dayWindow, selectedIndex } = useDayCarousel(date, onSelect)
+  const { emblaRef, dayWindow, selectedIndex } = useDayCarousel(date, onSelect, onTarget)
   // One mutable map for the carousel's life; the identity never changes, so
   // holding it in state (read during render) rather than a ref is safe.
   const [scrollMemory] = useState(() => new Map<string, number>())

--- a/apps/desktop/src/mobile/screens/daily.tsx
+++ b/apps/desktop/src/mobile/screens/daily.tsx
@@ -11,7 +11,8 @@ import { useRouter } from '@/routing/router'
  * The mobile spine (Plan 19, V1 parity): a month header + week calendar strip
  * over a swipeable day carousel of daily notes. The strip and the carousel
  * stay in lockstep through `date` — tapping a strip day or swiping the
- * carousel both navigate a daily route, which flows back as `date`. The
+ * carousel both navigate a daily route, which flows back as `date` (though
+ * mid-swipe the strip briefly leads, following the gesture's target day). The
  * new-note button floats above it all (V1: the daily note is the capture
  * surface; `+` opens a fresh untitled note via desktop's ⌘N seed flow).
  *
@@ -26,9 +27,16 @@ export function MobileDaily({ date }: { date: string }): ReactElement {
   // tap on the highlighted today cell to a frozen `daily` date). Selecting
   // today routes to the live `today` route, keeping the spine rolling over.
   const today = useToday()
+  // The day a swipe is heading toward, announced at pointer-up — the strip
+  // (and its rolling month title) follows it while the carousel's snap
+  // animation plays, instead of waiting for the settle-time route change.
+  // Any actual selection clears it: by then the route is the truth again.
+  const [targetDate, setTargetDate] = useState<string | null>(null)
   const select = useCallback(
-    (day: string): void =>
-      navigate(day === today ? { kind: 'today' } : { kind: 'daily', date: day }),
+    (day: string): void => {
+      setTargetDate(null)
+      navigate(day === today ? { kind: 'today' } : { kind: 'daily', date: day })
+    },
     [navigate, today],
   )
 
@@ -60,7 +68,7 @@ export function MobileDaily({ date }: { date: string }): ReactElement {
 
   return (
     <div className="flex h-full w-screen flex-col">
-      <CalendarStrip date={date} today={today} resetSeq={resetSeq} onSelect={select} />
+      <CalendarStrip date={targetDate ?? date} today={today} resetSeq={resetSeq} onSelect={select} />
       <DayCarousel
         date={date}
         today={today}
@@ -68,6 +76,7 @@ export function MobileDaily({ date }: { date: string }): ReactElement {
         focusDate={focusDate}
         onFocusConsumed={consumeFocus}
         onSelect={select}
+        onTarget={setTargetDate}
       />
       <Button
         size="icon"

--- a/apps/desktop/src/mobile/screens/daily.tsx
+++ b/apps/desktop/src/mobile/screens/daily.tsx
@@ -30,8 +30,17 @@ export function MobileDaily({ date }: { date: string }): ReactElement {
   // The day a swipe is heading toward, announced at pointer-up — the strip
   // (and its rolling month title) follows it while the carousel's snap
   // animation plays, instead of waiting for the settle-time route change.
-  // Any actual selection clears it: by then the route is the truth again.
   const [targetDate, setTargetDate] = useState<string | null>(null)
+  // Any route move — the swipe's own settle, a strip tap, a date link, back —
+  // supersedes the override: the route is the truth again. Cleared on the
+  // `date` change itself (the render-phase previous-value pattern) rather
+  // than in `select`, because navigations from elsewhere (a daily backlink,
+  // history) never pass through `select`.
+  const [lastDate, setLastDate] = useState(date)
+  if (date !== lastDate) {
+    setLastDate(date)
+    setTargetDate(null)
+  }
   const select = useCallback(
     (day: string): void => {
       setTargetDate(null)

--- a/apps/desktop/src/mobile/use-day-carousel.test.ts
+++ b/apps/desktop/src/mobile/use-day-carousel.test.ts
@@ -1,12 +1,87 @@
-import { describe, expect, it } from 'vitest'
-import { createDayWindow } from '@/lib/day-window'
-import { reconcileCarousel, shouldRecenter, type ReconcileInput } from './use-day-carousel'
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createDayWindow, dateAtIndex } from '@/lib/day-window'
+import {
+  CAROUSEL_RADIUS,
+  reconcileCarousel,
+  shouldRecenter,
+  useDayCarousel,
+  type ReconcileInput,
+} from './use-day-carousel'
 
 /**
  * The carousel's follow-the-route decision in isolation — Embla pointer
  * gestures can't be driven under jsdom, so the branchy reconciliation that the
- * integration test can only reach indirectly is pinned here as pure logic.
+ * integration test can only reach indirectly is pinned here as pure logic —
+ * plus the hook's swipe wiring driven through a fake Embla API firing the
+ * events a real gesture would.
  */
+const embla = vi.hoisted(() => {
+  const handlers = new Map<string, Set<(api: unknown) => void>>()
+  let selected = 0
+
+  const api = {
+    selectedScrollSnap: (): number => selected,
+    on: (event: string, handler: (api: unknown) => void) => {
+      let registered = handlers.get(event)
+      if (!registered) {
+        registered = new Set()
+        handlers.set(event, registered)
+      }
+      registered.add(handler)
+      return api
+    },
+    off: (event: string, handler: (api: unknown) => void) => {
+      handlers.get(event)?.delete(handler)
+      return api
+    },
+    scrollTo: vi.fn((index: number) => {
+      selected = index
+    }),
+    reInit: vi.fn((options?: { startIndex?: number }) => {
+      if (options?.startIndex !== undefined) {
+        selected = options.startIndex
+      }
+    }),
+  }
+
+  function emit(event: string): void {
+    for (const handler of [...(handlers.get(event) ?? [])]) {
+      handler(api)
+    }
+  }
+
+  return {
+    api,
+    /** Target `index` and fire select, as pointer-up does mid-animation. */
+    selectAt(index: number): void {
+      selected = index
+      emit('select')
+    },
+    /** Land on `index` and fire select + settle, as a finished swipe would. */
+    settleAt(index: number): void {
+      selected = index
+      emit('select')
+      emit('settle')
+    },
+    reset(): void {
+      handlers.clear()
+      selected = 0
+      api.scrollTo.mockClear()
+      api.reInit.mockClear()
+    },
+  }
+})
+
+vi.mock('embla-carousel-react', () => ({
+  default: () => [() => {}, embla.api],
+}))
+
+afterEach(() => {
+  cleanup()
+  embla.reset()
+})
+
 const base: ReconcileInput = {
   index: 10,
   windowStart: '2025-06-11',
@@ -76,5 +151,75 @@ describe('shouldRecenter', () => {
     expect(shouldRecenter(window, 0, 5)).toBe(true)
     expect(shouldRecenter(window, 16, 5)).toBe(true)
     expect(shouldRecenter(window, 20, 5)).toBe(true)
+  })
+})
+
+describe('useDayCarousel', () => {
+  /** The anchor day sits at {@link CAROUSEL_RADIUS} — the window's center. */
+  const DATE = '2026-06-12'
+  const CENTER = CAROUSEL_RADIUS
+  const initialWindow = createDayWindow(DATE, {
+    past: CAROUSEL_RADIUS,
+    future: CAROUSEL_RADIUS,
+  })
+
+  function mountCarousel() {
+    const onSelect = vi.fn()
+    const hook = renderHook(({ date }) => useDayCarousel(date, onSelect), {
+      initialProps: { date: DATE },
+    })
+    return { ...hook, onSelect }
+  }
+
+  it('follows the swipe target at select, so the next neighbor mounts mid-animation', () => {
+    const { result, onSelect } = mountCarousel()
+
+    // Pointer-up: the target is known but the snap animation is still playing.
+    act(() => embla.selectAt(CENTER + 1))
+
+    expect(result.current.selectedIndex).toBe(CENTER + 1)
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('reports the landed day only when the swipe settles', () => {
+    const { result, onSelect } = mountCarousel()
+
+    act(() => embla.settleAt(CENTER + 1))
+
+    expect(onSelect).toHaveBeenCalledExactlyOnceWith('2026-06-13')
+    expect(result.current.selectedIndex).toBe(CENTER + 1)
+  })
+
+  it('leaves the carousel alone when the settled swipe echoes back as `date`', () => {
+    const { rerender } = mountCarousel()
+    act(() => embla.settleAt(CENTER + 1))
+
+    rerender({ date: '2026-06-13' })
+
+    expect(embla.api.scrollTo).not.toHaveBeenCalled()
+    expect(embla.api.reInit).not.toHaveBeenCalled()
+  })
+
+  it('scrolls to an external in-window selection without reporting it back', () => {
+    const { result, rerender, onSelect } = mountCarousel()
+
+    rerender({ date: '2026-06-20' })
+
+    expect(embla.api.scrollTo).toHaveBeenCalledExactlyOnceWith(CENTER + 8, true)
+    expect(result.current.selectedIndex).toBe(CENTER + 8)
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('re-centers the window when a swipe settles near an edge', () => {
+    const { result, onSelect } = mountCarousel()
+    const nearEnd = initialWindow.count - 10
+
+    act(() => embla.settleAt(nearEnd))
+
+    const landed = dateAtIndex(initialWindow, nearEnd)
+    expect(onSelect).toHaveBeenCalledExactlyOnceWith(landed)
+    expect(result.current.dayWindow).toEqual(
+      createDayWindow(landed, { past: CAROUSEL_RADIUS, future: CAROUSEL_RADIUS }),
+    )
   })
 })

--- a/apps/desktop/src/mobile/use-day-carousel.test.ts
+++ b/apps/desktop/src/mobile/use-day-carousel.test.ts
@@ -165,10 +165,11 @@ describe('useDayCarousel', () => {
 
   function mountCarousel() {
     const onSelect = vi.fn()
-    const hook = renderHook(({ date }) => useDayCarousel(date, onSelect), {
+    const onTarget = vi.fn()
+    const hook = renderHook(({ date }) => useDayCarousel(date, onSelect, onTarget), {
       initialProps: { date: DATE },
     })
-    return { ...hook, onSelect }
+    return { ...hook, onSelect, onTarget }
   }
 
   it('follows the swipe target at select, so the next neighbor mounts mid-animation', () => {
@@ -178,6 +179,17 @@ describe('useDayCarousel', () => {
     act(() => embla.selectAt(CENTER + 1))
 
     expect(result.current.selectedIndex).toBe(CENTER + 1)
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('announces the target day at select, ahead of the settle-time report', () => {
+    const { onTarget, onSelect } = mountCarousel()
+
+    act(() => embla.selectAt(CENTER + 1))
+
+    // The strip (and its month title) follow this while the snap animates;
+    // the route only moves at settle.
+    expect(onTarget).toHaveBeenCalledExactlyOnceWith('2026-06-13')
     expect(onSelect).not.toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/mobile/use-day-carousel.ts
+++ b/apps/desktop/src/mobile/use-day-carousel.ts
@@ -110,13 +110,20 @@ export interface DayCarousel {
  * and the bidirectional `date ↔ slide` sync, leaving {@link DayCarousel} (the
  * component) purely declarative.
  *
- * A settled swipe reports its day via `onSelect` (which the parent turns into a
- * daily-route navigation); the route flows back in as `date` and scrolls the
+ * A swipe's destination is announced twice: `onTarget` fires at pointer-up
+ * with the day the swipe will land on (for lightweight chrome — the calendar
+ * strip and its month title — to follow while the snap animation plays), and
+ * `onSelect` fires once the swipe settles (which the parent turns into a
+ * daily-route navigation). The route flows back in as `date` and scrolls the
  * carousel to match — guarded by {@link reconcileCarousel} so the swipe's own
  * echo doesn't redundantly re-scroll. A `date` beyond the window re-anchors it,
  * and the follow effect then reinitializes Embla onto the new slides.
  */
-export function useDayCarousel(date: string, onSelect: (date: string) => void): DayCarousel {
+export function useDayCarousel(
+  date: string,
+  onSelect: (date: string) => void,
+  onTarget: (date: string) => void,
+): DayCarousel {
   const [dayWindow, setDayWindow] = useState<DayWindow>(() => createDayWindow(date, CAROUSEL_WINDOW))
   // Frozen at mount: `embla-carousel-react` reinitializes whenever the options
   // object stops comparing equal, and `reInit` snaps to `startIndex` with no
@@ -138,18 +145,24 @@ export function useDayCarousel(date: string, onSelect: (date: string) => void): 
   // so Embla must reinitialize rather than scroll.
   const windowStartRef = useRef(dayWindow.start)
 
-  // The swipe's target is known at pointer-up (`select`), and the slide
-  // window follows it from there: the mount radius tracks `selectedIndex`,
-  // and a second swipe started mid-animation must land on a mounted slide,
-  // not a blank spacer (the quick double-swipe). Only the index moves here —
-  // and in a transition, so React fits the incoming neighbor's editor mount
-  // around the snap animation's frames instead of blocking its first ones.
-  const onEmblaSelect = useCallback((api: NonNullable<typeof emblaApi>) => {
-    const index = api.selectedScrollSnap()
-    startTransition(() => {
-      setSelectedIndex(index)
-    })
-  }, [])
+  // The swipe's target is known at pointer-up (`select`), and two light
+  // things follow it from there. The slide window: the mount radius tracks
+  // `selectedIndex`, and a second swipe started mid-animation must land on a
+  // mounted slide, not a blank spacer (the quick double-swipe). And
+  // `onTarget`: the calendar strip — month title included — moves with the
+  // gesture rather than after it. Both inside a transition, so React fits
+  // the work around the snap animation's frames instead of blocking its
+  // first ones.
+  const onEmblaSelect = useCallback(
+    (api: NonNullable<typeof emblaApi>) => {
+      const index = api.selectedScrollSnap()
+      startTransition(() => {
+        setSelectedIndex(index)
+        onTarget(dateAtIndex(dayWindow, index))
+      })
+    },
+    [dayWindow, onTarget],
+  )
 
   // The swipe's heavy consequence — reporting the day, which the parent turns
   // into a route navigation re-rendering the whole surface — waits for

--- a/apps/desktop/src/mobile/use-day-carousel.ts
+++ b/apps/desktop/src/mobile/use-day-carousel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { startTransition, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import useEmblaCarousel from 'embla-carousel-react'
 import { createDayWindow, dateAtIndex, indexWithin, type DayWindow } from '@/lib/day-window'
 import { getKeyboardHeight } from '@/mobile/use-keyboard'
@@ -138,14 +138,25 @@ export function useDayCarousel(date: string, onSelect: (date: string) => void): 
   // so Embla must reinitialize rather than scroll.
   const windowStartRef = useRef(dayWindow.start)
 
-  // Everything a swipe triggers waits for `settle` (snap animation done) —
-  // never `select`, which fires at pointer-up, exactly when the animation
-  // starts. Reporting there mounts a fresh editor slide and re-renders the
-  // whole route in the release frame, and Embla's fixed-timestep animation
-  // loop has no lag cap: the stall fast-forwards the physics to the target,
-  // so the note switches instantly instead of sliding over. The incoming
-  // slide is already mounted (it was a neighbor within the mount radius), so
-  // deferring costs nothing visually.
+  // The swipe's target is known at pointer-up (`select`), and the slide
+  // window follows it from there: the mount radius tracks `selectedIndex`,
+  // and a second swipe started mid-animation must land on a mounted slide,
+  // not a blank spacer (the quick double-swipe). Only the index moves here —
+  // and in a transition, so React fits the incoming neighbor's editor mount
+  // around the snap animation's frames instead of blocking its first ones.
+  const onEmblaSelect = useCallback((api: NonNullable<typeof emblaApi>) => {
+    const index = api.selectedScrollSnap()
+    startTransition(() => {
+      setSelectedIndex(index)
+    })
+  }, [])
+
+  // The swipe's heavy consequence — reporting the day, which the parent turns
+  // into a route navigation re-rendering the whole surface — waits for
+  // `settle` (snap animation done). Embla's fixed-timestep animation loop has
+  // no lag cap, so paying that cost in the release frame would fast-forward
+  // the physics to the target: the note would switch instantly instead of
+  // sliding over.
   //
   // Settling near a window edge also rebuilds the window around the current
   // day, keeping swiping effectively infinite in both directions. The report
@@ -172,11 +183,13 @@ export function useDayCarousel(date: string, onSelect: (date: string) => void): 
     if (!emblaApi) {
       return
     }
+    emblaApi.on('select', onEmblaSelect)
     emblaApi.on('settle', onEmblaSettle)
     return () => {
+      emblaApi.off('select', onEmblaSelect)
       emblaApi.off('settle', onEmblaSettle)
     }
-  }, [emblaApi, onEmblaSettle])
+  }, [emblaApi, onEmblaSelect, onEmblaSettle])
 
   // Re-anchor only when the requested day falls outside the window (a far date
   // link): rebuild the window centered on it. The follow effect below then


### PR DESCRIPTION
## Problem

Two follow-ups to #576, which fixed the day-swipe snap animation by deferring everything a swipe triggers to Embla's `settle` event. That deferral swept up two things it shouldn't have:

1. **`selectedIndex`**, which the carousel's mount radius follows — so the slide beyond the swipe target only mounted after the animation finished, and a quick double swipe dragged onto a still-empty spacer (blank note until the animation settled). Single swipes were unaffected.
2. **The calendar strip**, which follows the route `date` — so the strip's selection highlight and the rolling month title (#585) waited out the snap animation instead of moving with the gesture.

## Change

Split the swipe's consequences across the two Embla events, in `use-day-carousel.ts`:

- **`select` (pointer-up):** two light things follow the swipe target immediately, wrapped in one `startTransition` so React fits the work around the animation's frames instead of blocking the release frame (Embla's fixed-timestep loop has no lag cap — a long stall there fast-forwards the animation, the original #576 bug):
  - `selectedIndex` — the incoming neighbor's `DaySlide` mounts while the animation plays, so a second swipe lands on real content;
  - a new `onTarget` callback announcing the destination day — the daily screen holds it as `targetDate` and passes `targetDate ?? date` to the calendar strip, so the month title rolls and the strip highlight moves at pointer-up, ahead of the route. The override expires whenever the route `date` moves (render-phase previous-value pattern), so navigations that bypass `select` — daily backlinks, history — supersede it too (Bugbot caught the stale-override case).
- **`settle`:** unchanged — the day report (route navigation, full-surface re-render) and the edge re-center stay deferred until the animation is done.

Also adds hook-level tests for the swipe wiring, driven through a fake Embla API (the harness pattern from the week-strip tests): target-follow and `onTarget` at `select` without reporting, report-on-`settle`, the route-echo guard, external in-window jumps, and edge re-centering.

## Verification

- `pnpm --filter @reflect/desktop test --run src/mobile/use-day-carousel.test.ts src/mobile/mobile-screen.test.tsx` — 41 passed (6 new)
- `pnpm check` (typecheck + lint) — clean
- Not verified on-device — the swipe feel needs the owed device pass: quick double-swipe (no blank slide), cross-month swipe (title rolls during the gesture), and single-swipe smoothness. Worst case a heavy editor mount mid-animation costs a frame or two, which is the deliberate trade against blank content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mobile daily navigation and carousel/route sync; behavior is localized and covered by new hook tests, but swipe feel and double-swipe edge cases still need on-device validation.
> 
> **Overview**
> After deferring all swipe work to Embla `settle` (#576), the calendar strip and `selectedIndex` (slide mount radius) lagged the gesture—causing blank slides on quick double-swipes and a delayed month title.
> 
> **`useDayCarousel`** now listens to **`select`** (pointer-up) for lightweight updates inside `startTransition`: bump `selectedIndex` so the target neighbor’s editor mounts during the snap, and call a new **`onTarget`** with the destination day. **Route navigation** via **`onSelect`** still runs only on **`settle`**, preserving smooth snap animation.
> 
> **`MobileDaily`** holds `targetDate` from `onTarget` and feeds **`CalendarStrip`** `targetDate ?? date` so highlight and month title move with the swipe; any real `date` change or explicit `select` clears the override.
> 
> Hook tests use a fake Embla API to assert `select` vs `settle` behavior, echo guard, and edge re-centering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f954a3aa2fea8750dbb5d313ac50849933e28bea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

