### PR TITLE
feat(mobile): slide the calendar strip's selection circle between days

### DIFF
--- a/apps/desktop/src/mobile/week-row.tsx
+++ b/apps/desktop/src/mobile/week-row.tsx
@@ -17,9 +17,11 @@ interface WeekRowProps {
 
 /**
  * One week slide of the calendar strip: seven day-of-week / day-number cells,
- * the selected day circled, today dotted (V1's presentation). Memoized on the
- * narrowed `selectedDay`/`todayDay` props so the dozens of off-screen week
- * slides skip re-rendering when the selection moves within another week.
+ * the selected day circled, today dotted (V1's presentation). The selection
+ * circle is a single shared element that slides between the row's days.
+ * Memoized on the narrowed `selectedDay`/`todayDay` props so the dozens of
+ * off-screen week slides skip re-rendering when the selection moves within
+ * another week.
  */
 function WeekRowComponent({
   weekStart,
@@ -27,9 +29,32 @@ function WeekRowComponent({
   todayDay,
   onSelect,
 }: WeekRowProps): ReactElement {
+  const days = Array.from({ length: 7 }, (_, index) => addDaysIso(weekStart, index))
+  const selectedIndex = selectedDay ? days.indexOf(selectedDay) : -1
   return (
-    <div className="flex min-w-0 flex-[0_0_100%]">
-      {Array.from({ length: 7 }, (_, index) => addDaysIso(weekStart, index)).map((day) => {
+    <div className="relative flex min-w-0 flex-[0_0_100%]">
+      {selectedIndex >= 0 && (
+        /* One circle per row, translated to the selected column, so moving
+           within the week slides it behind the day numbers (the buttons are
+           `relative` and paint above). It mounts only when the selection
+           enters this week — the cross-week case, where the strip is paging
+           anyway — and a mount-time transform doesn't transition, so the
+           circle pops in at the right column instead of sliding from a stale
+           one. The wrapper mirrors a cell's column structure (invisible
+           weekday glyph, then the circle) so it lands exactly behind the
+           number for any font metrics. */
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-y-0 left-0 flex w-[calc(100%/7)] flex-col items-center gap-0.5 py-1 transition-transform duration-200 ease-out motion-reduce:transition-none"
+          style={{ transform: `translateX(${selectedIndex * 100}%)` }}
+        >
+          <span aria-hidden className="invisible text-[11px] font-medium">
+            M
+          </span>
+          <span className="size-8 animate-in rounded-full bg-primary duration-200 fade-in zoom-in-75 motion-reduce:animate-none" />
+        </span>
+      )}
+      {days.map((day) => {
         const selected = day === selectedDay
         const isToday = day === todayDay
         return (
@@ -42,15 +67,15 @@ function WeekRowComponent({
               hapticImpactLight()
               onSelect(day)
             }}
-            className="flex flex-1 flex-col items-center gap-0.5 py-1"
+            className="relative flex flex-1 flex-col items-center gap-0.5 py-1"
           >
             <span className="text-[11px] font-medium text-text-muted">
               {format(parseIsoDate(day), 'EEEEE')}
             </span>
             <span
               className={cn(
-                'flex size-8 items-center justify-center rounded-full text-sm tabular-nums',
-                selected && 'bg-primary font-semibold text-primary-foreground',
+                'flex size-8 items-center justify-center rounded-full text-sm tabular-nums transition-colors duration-200',
+                selected && 'font-semibold text-primary-foreground',
                 !selected && isToday && 'font-semibold text-primary',
                 !selected && !isToday && 'text-text',
               )}


### PR DESCRIPTION
## Problem

The calendar strip's purple selection circle was painted per day cell — moving the selection just unfilled one cell and filled another, with no motion tying the two together.

## Change

`week-row.tsx` now renders **one shared circle per week row**, absolutely positioned behind the cells and translated to the selected column:

- **Within a week** (tap another day, or a day-carousel swipe that stays in the week): the circle slides to the new column (`transition-transform`, 200ms ease-out), and the day-number text colors cross-fade in step (`transition-colors`).
- **Across weeks / months** (swipe over a week boundary, calendar-strip page + tap, Today from afar, month picker): the strip pages as before, and the circle pops into the incoming row (`animate-in fade-in zoom-in-75`, via the already-bundled tw-animate-css). The indicator mounts only when the selection enters the row — and mount-time transforms don't transition — so it can never slide in from a stale column; the outgoing row is simultaneously paging offscreen, so its circle simply goes with it.
- The indicator mirrors a cell's column structure (invisible weekday glyph above the circle), so it lands exactly behind the day number for any font metrics; the cell buttons are `relative` and paint above it. `motion-reduce:` disables both animations.

The circle is presentational (`aria-hidden`, `pointer-events-none`); selection semantics remain on the buttons' `aria-current`, which the existing integration tests pin.

## Verification

- `pnpm --filter @reflect/desktop test --run src/mobile/mobile-screen.test.tsx src/mobile/use-week-strip.test.ts` — 36 passed
- `pnpm check` (typecheck + lint) — clean
- Alex is doing the manual visual pass (simulator/device) — the browser dev harness misplaces the strip's initial Embla position under viewport resizing, so it wasn't a reliable venue for judging the motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in the mobile calendar strip; selection semantics and routing behavior are unchanged.
> 
> **Overview**
> The mobile calendar week row no longer paints a **per-day** `bg-primary` circle on the selected cell. It uses **one shared indicator** per row, absolutely positioned behind the day buttons and moved with `translateX` to the selected column.
> 
> **Within the same week**, tapping or swiping to another day slides that circle (200ms transform) while day-number colors cross-fade (`transition-colors`). **When selection jumps to another week** (strip paging, month picker, etc.), the indicator only mounts for the row that contains the selection so mount-time transforms avoid a bogus slide; it appears with a short fade/zoom-in. Cells stay `relative` above the presentational layer; `aria-current` on buttons is unchanged.
> 
> `motion-reduce:` turns off the motion. Scope is limited to `week-row.tsx` presentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 863aa06de7f77297c912f203872b12deee5187fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->