### PR TITLE
fix(mobile): refine month title roll animation

### DIFF
--- a/apps/desktop/src/mobile/month-title.css
+++ b/apps/desktop/src/mobile/month-title.css
@@ -8,46 +8,46 @@
  */
 
 .month-title-enter-up {
-  animation: month-title-enter-up 200ms cubic-bezier(0.32, 0.72, 0, 1);
+  animation: month-title-enter-up 320ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .month-title-enter-down {
-  animation: month-title-enter-down 200ms cubic-bezier(0.32, 0.72, 0, 1);
+  animation: month-title-enter-down 320ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .month-title-exit-up {
-  animation: month-title-exit-up 200ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+  animation: month-title-exit-up 320ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
 .month-title-exit-down {
-  animation: month-title-exit-down 200ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+  animation: month-title-exit-down 320ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
 @keyframes month-title-enter-up {
   from {
     opacity: 0;
-    transform: translate3d(0, 45%, 0);
+    transform: translate3d(0, 28%, 0);
   }
 }
 
 @keyframes month-title-enter-down {
   from {
     opacity: 0;
-    transform: translate3d(0, -45%, 0);
+    transform: translate3d(0, -28%, 0);
   }
 }
 
 @keyframes month-title-exit-up {
   to {
     opacity: 0;
-    transform: translate3d(0, -45%, 0);
+    transform: translate3d(0, -28%, 0);
   }
 }
 
 @keyframes month-title-exit-down {
   to {
     opacity: 0;
-    transform: translate3d(0, 45%, 0);
+    transform: translate3d(0, 28%, 0);
   }
 }
 

--- a/apps/desktop/src/mobile/month-title.tsx
+++ b/apps/desktop/src/mobile/month-title.tsx
@@ -5,7 +5,7 @@ import { usePrefersReducedMotion } from '@/mobile/use-reduced-motion'
 import './month-title.css'
 
 /** Mirrors the animation durations in month-title.css (the fallback timer). */
-export const MONTH_TITLE_TRANSITION_MS = 200
+export const MONTH_TITLE_TRANSITION_MS = 320
 
 interface OutgoingMonth {
   month: string
@@ -59,12 +59,12 @@ export function MonthTitle({ month }: MonthTitleProps): ReactElement {
   }, [outgoing])
 
   return (
-    <span className="relative block min-w-0">
+    <span className="relative block h-[1.5em] min-w-0 overflow-hidden">
       <span
         key={shown}
         data-slot="month-title"
         className={cn(
-          'block truncate',
+          'block truncate leading-[1.5]',
           outgoing && (outgoing.direction === 'up' ? 'month-title-enter-up' : 'month-title-enter-down'),
         )}
       >
@@ -75,7 +75,7 @@ export function MonthTitle({ month }: MonthTitleProps): ReactElement {
           ref={outgoingRef}
           aria-hidden
           className={cn(
-            'absolute inset-x-0 top-0 block truncate',
+            'absolute inset-x-0 top-0 block truncate leading-[1.5]',
             outgoing.direction === 'up' ? 'month-title-exit-up' : 'month-title-exit-down',
           )}
         >


### PR DESCRIPTION
## Problem

The Daily tab month title roll felt a little too abrupt for a small piece of persistent chrome. The label moved a long distance over a short 200ms animation, which made month changes read more like a jump than a quiet ticker.

## Before -> After

| Before | After |
| --- | --- |
| 200ms roll with 45% vertical travel | 320ms roll with 28% vertical travel |
| Sharper easing | Softer ease-out curve |
| Label could visually travel beyond its line box | Fixed-height clipped label wrapper |

## Changes

1. Updates `MonthTitle` to clip the rolling labels inside a stable 1.5em line box.
2. Slows `MONTH_TITLE_TRANSITION_MS` and the CSS animations to 320ms so the fallback timer continues to mirror the actual transition.
3. Reduces the enter/exit travel and softens the cubic-bezier curve for a calmer month switch.

## Verification

- `pnpm --filter @reflect/desktop test -- --run apps/desktop/src/mobile/month-title.test.tsx` passed. This command ran the full desktop Vitest suite in this workspace: 191 files / 1674 tests passed.
- `pnpm check` passed.

## Risk / Rollout

Low risk: this is a visual-only animation adjustment with the existing reduced-motion instant-swap behavior preserved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only CSS and layout tweaks on mobile month chrome; reduced-motion behavior is preserved.
> 
> **Overview**
> Softens the Daily tab **month title** roll so month changes feel less jumpy.
> 
> Animation duration moves from **200ms to 320ms** (including `MONTH_TITLE_TRANSITION_MS` for the fallback cleanup timer), vertical travel shrinks from **45% to 28%**, and easing switches to a softer ease-out curve in `month-title.css`.
> 
> `MonthTitle` now wraps labels in a **fixed 1.5em, overflow-hidden** container with consistent **line-height**, so the roll stays clipped inside the header line box instead of drifting past it. Reduced-motion instant swap is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad6bbc685ab7c4506cd6b504a5998ea7b196d7e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the mobile month label transition animation for a smoother, more consistent visual experience.
  * Adjusted the transition timing and movement so month changes feel less abrupt.
  * Kept reduced-motion behavior intact for users who prefer it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->