### PR TITLE
Polish mobile image lightbox interactions

### DIFF
--- a/apps/desktop/src/editor/image-lightbox.tsx
+++ b/apps/desktop/src/editor/image-lightbox.tsx
@@ -63,7 +63,6 @@ interface ImageLightboxProps {
 }
 
 interface ImageDismissDrag {
-  backdropStyle: CSSProperties | undefined
   previewStyle: CSSProperties | undefined
   handlers: {
     onPointerDown: (event: ReactPointerEvent<HTMLButtonElement>) => void
@@ -277,7 +276,6 @@ function useImageDismissDrag({
   )
 
   return {
-    backdropStyle: backdropStyleForState(state),
     previewStyle: previewStyleForState(state),
     handlers: { onPointerDown, onPointerMove, onPointerUp, onPointerCancel, onClick },
     finishSettle,
@@ -311,23 +309,6 @@ function previewStyleForState(state: DragState): CSSProperties | undefined {
   return undefined
 }
 
-function backdropStyleForState(state: DragState): CSSProperties | undefined {
-  if (state.phase === 'dragging') {
-    const progress = dragProgress(state.deltaY, state.height)
-    return {
-      opacity: 1 - progress * 0.58,
-      transition: 'none',
-    }
-  }
-  if (state.phase === 'settling') {
-    return {
-      opacity: state.action === 'close' ? 0 : 1,
-      transition: `opacity ${SETTLE_MS}ms ${SETTLE_EASING}`,
-    }
-  }
-  return undefined
-}
-
 export function ImageLightbox({
   image,
   onClose,
@@ -348,11 +329,6 @@ export function ImageLightbox({
 
   return (
     <LightboxDialog open title="Image preview" onClose={onClose}>
-      <div
-        aria-hidden
-        className={cn('absolute inset-0', mobileSurface ? 'bg-black' : 'bg-transparent')}
-        style={mobileSurface ? dismissDrag.backdropStyle : undefined}
-      />
       {mobileSurface ? (
         <div className="absolute top-[max(env(safe-area-inset-top),1rem)] left-[max(env(safe-area-inset-left),1rem)] z-10">
           <Button
@@ -391,7 +367,7 @@ export function ImageLightbox({
         aria-label="Close image preview"
         className={cn(
           'absolute inset-0 flex cursor-zoom-out items-center justify-center overflow-hidden bg-transparent',
-          mobileSurface ? 'touch-none p-0' : 'p-6',
+          mobileSurface ? 'touch-none bg-black p-0' : 'p-6',
         )}
         {...dismissDrag.handlers}
       >

--- a/apps/desktop/src/editor/image-lightbox.tsx
+++ b/apps/desktop/src/editor/image-lightbox.tsx
@@ -223,10 +223,11 @@ function useImageDismissDrag({
         performance.now() - current.sampleTime <= VELOCITY_STALE_MS
       const shouldClose =
         !interrupted && (current.deltaY > current.height * DISMISS_FRACTION || flicked)
+      const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
       suppressClickUntilRef.current =
-        performance.now() + (shouldClose ? SETTLE_MS + 80 : CLICK_SUPPRESSION_MS)
+        performance.now() + (reducedMotion ? CLICK_SUPPRESSION_MS : SETTLE_MS + 80)
 
-      if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      if (reducedMotion) {
         commit(IDLE)
         if (shouldClose) {
           onClose()
@@ -251,8 +252,14 @@ function useImageDismissDrag({
 
   const onClick = useCallback(
     (event: ReactMouseEvent<HTMLButtonElement>): void => {
-      if (suppressClickUntilRef.current > 0 && performance.now() <= suppressClickUntilRef.current) {
-        suppressClickUntilRef.current = 0
+      const settling = stateRef.current.phase === 'settling'
+      const suppressClick =
+        settling ||
+        (suppressClickUntilRef.current > 0 && performance.now() <= suppressClickUntilRef.current)
+      if (suppressClick) {
+        if (!settling) {
+          suppressClickUntilRef.current = 0
+        }
         event.preventDefault()
         event.stopPropagation()
         return

--- a/apps/desktop/src/editor/image-lightbox.tsx
+++ b/apps/desktop/src/editor/image-lightbox.tsx
@@ -217,15 +217,22 @@ function useImageDismissDrag({
         return
       }
 
+      const releaseDeltaY = Math.max(0, event.clientY - current.startY)
+      const now = performance.now()
+      const elapsed = now - current.sampleTime
+      const releaseVelocity =
+        elapsed >= VELOCITY_WINDOW_MS
+          ? (releaseDeltaY - current.sampleDeltaY) / elapsed
+          : current.velocity
       const flicked =
-        current.velocity > DISMISS_VELOCITY_PX_PER_MS &&
-        current.deltaY > MIN_FLICK_DY_PX &&
-        performance.now() - current.sampleTime <= VELOCITY_STALE_MS
+        releaseVelocity > DISMISS_VELOCITY_PX_PER_MS &&
+        releaseDeltaY > MIN_FLICK_DY_PX &&
+        elapsed <= VELOCITY_STALE_MS
       const shouldClose =
-        !interrupted && (current.deltaY > current.height * DISMISS_FRACTION || flicked)
+        !interrupted && (releaseDeltaY > current.height * DISMISS_FRACTION || flicked)
       const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
       suppressClickUntilRef.current =
-        performance.now() + (reducedMotion ? CLICK_SUPPRESSION_MS : SETTLE_MS + 80)
+        now + (reducedMotion ? CLICK_SUPPRESSION_MS : SETTLE_MS + 80)
 
       if (reducedMotion) {
         commit(IDLE)

--- a/apps/desktop/src/editor/image-lightbox.tsx
+++ b/apps/desktop/src/editor/image-lightbox.tsx
@@ -26,6 +26,7 @@ const VELOCITY_WINDOW_MS = 30
 const VELOCITY_STALE_MS = 120
 const SETTLE_MS = 220
 const SETTLE_EASING = 'cubic-bezier(0.22, 1, 0.36, 1)'
+const CLICK_SUPPRESSION_MS = 100
 
 type DragState =
   | { phase: 'idle' }
@@ -85,7 +86,7 @@ function useImageDismissDrag({
 }): ImageDismissDrag {
   const stateRef = useRef<DragState>(IDLE)
   const [state, setState] = useState<DragState>(IDLE)
-  const suppressNextClickRef = useRef(false)
+  const suppressClickUntilRef = useRef(0)
 
   const commit = useCallback((next: DragState): void => {
     stateRef.current = next
@@ -99,7 +100,7 @@ function useImageDismissDrag({
     }
     commit(IDLE)
     if (current.action === 'cancel') {
-      suppressNextClickRef.current = false
+      suppressClickUntilRef.current = 0
     }
     if (current.action === 'close') {
       onClose()
@@ -108,7 +109,7 @@ function useImageDismissDrag({
 
   useEffect(() => {
     if ((!active || !enabled) && stateRef.current.phase !== 'idle') {
-      suppressNextClickRef.current = false
+      suppressClickUntilRef.current = 0
       commit(IDLE)
     }
   }, [active, enabled, commit])
@@ -171,7 +172,6 @@ function useImageDismissDrag({
         }
 
         const height = event.currentTarget.getBoundingClientRect().height || window.innerHeight
-        suppressNextClickRef.current = true
         commit({
           phase: 'dragging',
           pointerId: event.pointerId,
@@ -223,6 +223,8 @@ function useImageDismissDrag({
         performance.now() - current.sampleTime <= VELOCITY_STALE_MS
       const shouldClose =
         !interrupted && (current.deltaY > current.height * DISMISS_FRACTION || flicked)
+      suppressClickUntilRef.current =
+        performance.now() + (shouldClose ? SETTLE_MS + 80 : CLICK_SUPPRESSION_MS)
 
       if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
         commit(IDLE)
@@ -249,8 +251,8 @@ function useImageDismissDrag({
 
   const onClick = useCallback(
     (event: ReactMouseEvent<HTMLButtonElement>): void => {
-      if (suppressNextClickRef.current) {
-        suppressNextClickRef.current = false
+      if (suppressClickUntilRef.current > 0 && performance.now() <= suppressClickUntilRef.current) {
+        suppressClickUntilRef.current = 0
         event.preventDefault()
         event.stopPropagation()
         return

--- a/apps/desktop/src/editor/image-lightbox.tsx
+++ b/apps/desktop/src/editor/image-lightbox.tsx
@@ -1,10 +1,48 @@
-import { type ReactElement } from 'react'
-import { ExternalLinkIcon } from 'lucide-react'
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactElement,
+} from 'react'
+import { ExternalLinkIcon, XIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { LightboxDialog } from '@/editor/lightbox-dialog'
 import { type LightboxTransitionItem } from '@/editor/use-lightbox-transition'
+import { isMobileSurface } from '@/lib/platform-surface'
+import { cn } from '@/lib/utils'
 
 export const IMAGE_LIGHTBOX_TRANSITION_NAME = 'reflect-image-lightbox'
+
+const DRAG_ACTIVATE_Y_PX = 8
+const DRAG_DISARM_X_PX = 18
+const DISMISS_FRACTION = 0.22
+const DISMISS_VELOCITY_PX_PER_MS = 0.45
+const MIN_FLICK_DY_PX = 40
+const VELOCITY_WINDOW_MS = 30
+const VELOCITY_STALE_MS = 120
+const SETTLE_MS = 220
+const SETTLE_EASING = 'cubic-bezier(0.22, 1, 0.36, 1)'
+
+type DragState =
+  | { phase: 'idle' }
+  | { phase: 'armed'; pointerId: number; startX: number; startY: number }
+  | {
+      phase: 'dragging'
+      pointerId: number
+      startY: number
+      height: number
+      deltaY: number
+      velocity: number
+      sampleDeltaY: number
+      sampleTime: number
+    }
+  | { phase: 'settling'; action: 'close' | 'cancel'; height: number }
+
+const IDLE: DragState = { phase: 'idle' }
 
 /** Image data rendered by the editor lightbox. */
 export interface LightboxImage extends LightboxTransitionItem {
@@ -23,11 +61,269 @@ interface ImageLightboxProps {
   onOpenImage?: (image: LightboxImage) => void
 }
 
+interface ImageDismissDrag {
+  backdropStyle: CSSProperties | undefined
+  previewStyle: CSSProperties | undefined
+  handlers: {
+    onPointerDown: (event: ReactPointerEvent<HTMLButtonElement>) => void
+    onPointerMove: (event: ReactPointerEvent<HTMLButtonElement>) => void
+    onPointerUp: (event: ReactPointerEvent<HTMLButtonElement>) => void
+    onPointerCancel: (event: ReactPointerEvent<HTMLButtonElement>) => void
+    onClick: (event: ReactMouseEvent<HTMLButtonElement>) => void
+  }
+  finishSettle: () => void
+}
+
+function useImageDismissDrag({
+  active,
+  enabled,
+  onClose,
+}: {
+  active: boolean
+  enabled: boolean
+  onClose: () => void
+}): ImageDismissDrag {
+  const stateRef = useRef<DragState>(IDLE)
+  const [state, setState] = useState<DragState>(IDLE)
+  const suppressNextClickRef = useRef(false)
+
+  const commit = useCallback((next: DragState): void => {
+    stateRef.current = next
+    setState(next)
+  }, [])
+
+  const finishSettle = useCallback((): void => {
+    const current = stateRef.current
+    if (current.phase !== 'settling') {
+      return
+    }
+    commit(IDLE)
+    if (current.action === 'cancel') {
+      suppressNextClickRef.current = false
+    }
+    if (current.action === 'close') {
+      onClose()
+    }
+  }, [commit, onClose])
+
+  useEffect(() => {
+    if ((!active || !enabled) && stateRef.current.phase !== 'idle') {
+      suppressNextClickRef.current = false
+      commit(IDLE)
+    }
+  }, [active, enabled, commit])
+
+  useEffect(() => {
+    if (state.phase !== 'settling') {
+      return
+    }
+    const timer = window.setTimeout(finishSettle, SETTLE_MS + 80)
+    return () => window.clearTimeout(timer)
+  }, [state, finishSettle])
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>): void => {
+      if (!enabled || event.pointerType !== 'touch' || !event.isPrimary) {
+        return
+      }
+      if (stateRef.current.phase !== 'idle') {
+        return
+      }
+      commit({
+        phase: 'armed',
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+      })
+    },
+    [enabled, commit],
+  )
+
+  const onPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>): void => {
+      const current = stateRef.current
+      if (
+        (current.phase !== 'armed' && current.phase !== 'dragging') ||
+        current.pointerId !== event.pointerId
+      ) {
+        return
+      }
+
+      if (current.phase === 'armed') {
+        const deltaX = Math.abs(event.clientX - current.startX)
+        const deltaY = event.clientY - current.startY
+        if (deltaX > DRAG_DISARM_X_PX && deltaX > Math.abs(deltaY)) {
+          commit(IDLE)
+          return
+        }
+        if (deltaY < -DRAG_ACTIVATE_Y_PX) {
+          commit(IDLE)
+          return
+        }
+        if (deltaY < DRAG_ACTIVATE_Y_PX || deltaY <= deltaX) {
+          return
+        }
+
+        try {
+          event.currentTarget.setPointerCapture?.(event.pointerId)
+        } catch {
+          // Synthetic tests do not have a live pointer to capture.
+        }
+
+        const height = event.currentTarget.getBoundingClientRect().height || window.innerHeight
+        suppressNextClickRef.current = true
+        commit({
+          phase: 'dragging',
+          pointerId: event.pointerId,
+          startY: current.startY,
+          height,
+          deltaY,
+          velocity: 0,
+          sampleDeltaY: deltaY,
+          sampleTime: performance.now(),
+        })
+        return
+      }
+
+      const deltaY = Math.max(0, event.clientY - current.startY)
+      const now = performance.now()
+      const elapsed = now - current.sampleTime
+      if (elapsed < VELOCITY_WINDOW_MS) {
+        commit({ ...current, deltaY })
+        return
+      }
+      commit({
+        ...current,
+        deltaY,
+        velocity: (deltaY - current.sampleDeltaY) / elapsed,
+        sampleDeltaY: deltaY,
+        sampleTime: now,
+      })
+    },
+    [commit],
+  )
+
+  const release = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>, interrupted: boolean): void => {
+      const current = stateRef.current
+      if (
+        (current.phase !== 'armed' && current.phase !== 'dragging') ||
+        current.pointerId !== event.pointerId
+      ) {
+        return
+      }
+      if (current.phase === 'armed') {
+        commit(IDLE)
+        return
+      }
+
+      const flicked =
+        current.velocity > DISMISS_VELOCITY_PX_PER_MS &&
+        current.deltaY > MIN_FLICK_DY_PX &&
+        performance.now() - current.sampleTime <= VELOCITY_STALE_MS
+      const shouldClose =
+        !interrupted && (current.deltaY > current.height * DISMISS_FRACTION || flicked)
+
+      if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        commit(IDLE)
+        if (shouldClose) {
+          onClose()
+        }
+        return
+      }
+
+      commit({ phase: 'settling', action: shouldClose ? 'close' : 'cancel', height: current.height })
+    },
+    [commit, onClose],
+  )
+
+  const onPointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>): void => release(event, false),
+    [release],
+  )
+
+  const onPointerCancel = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>): void => release(event, true),
+    [release],
+  )
+
+  const onClick = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement>): void => {
+      if (suppressNextClickRef.current) {
+        suppressNextClickRef.current = false
+        event.preventDefault()
+        event.stopPropagation()
+        return
+      }
+      onClose()
+    },
+    [onClose],
+  )
+
+  return {
+    backdropStyle: backdropStyleForState(state),
+    previewStyle: previewStyleForState(state),
+    handlers: { onPointerDown, onPointerMove, onPointerUp, onPointerCancel, onClick },
+    finishSettle,
+  }
+}
+
+function dragProgress(deltaY: number, height: number): number {
+  return Math.min(1, deltaY / Math.max(height * 0.55, 1))
+}
+
+function previewStyleForState(state: DragState): CSSProperties | undefined {
+  if (state.phase === 'dragging') {
+    const progress = dragProgress(state.deltaY, state.height)
+    const scale = 1 - progress * 0.06
+    return {
+      opacity: 1 - progress * 0.12,
+      transform: `translate3d(0, ${state.deltaY}px, 0) scale(${scale})`,
+      transition: 'none',
+    }
+  }
+  if (state.phase === 'settling') {
+    const closing = state.action === 'close'
+    return {
+      opacity: closing ? 0 : 1,
+      transform: closing
+        ? `translate3d(0, ${state.height}px, 0) scale(0.94)`
+        : 'translate3d(0, 0, 0) scale(1)',
+      transition: `transform ${SETTLE_MS}ms ${SETTLE_EASING}, opacity ${SETTLE_MS}ms ${SETTLE_EASING}`,
+    }
+  }
+  return undefined
+}
+
+function backdropStyleForState(state: DragState): CSSProperties | undefined {
+  if (state.phase === 'dragging') {
+    const progress = dragProgress(state.deltaY, state.height)
+    return {
+      opacity: 1 - progress * 0.58,
+      transition: 'none',
+    }
+  }
+  if (state.phase === 'settling') {
+    return {
+      opacity: state.action === 'close' ? 0 : 1,
+      transition: `opacity ${SETTLE_MS}ms ${SETTLE_EASING}`,
+    }
+  }
+  return undefined
+}
+
 export function ImageLightbox({
   image,
   onClose,
   onOpenImage,
 }: ImageLightboxProps): ReactElement | null {
+  const mobileSurface = isMobileSurface()
+  const dismissDrag = useImageDismissDrag({
+    active: image !== null,
+    enabled: mobileSurface,
+    onClose,
+  })
+
   if (image === null) {
     return null
   }
@@ -36,13 +332,37 @@ export function ImageLightbox({
 
   return (
     <LightboxDialog open title="Image preview" onClose={onClose}>
+      <div
+        aria-hidden
+        className={cn('absolute inset-0', mobileSurface ? 'bg-black' : 'bg-transparent')}
+        style={mobileSurface ? dismissDrag.backdropStyle : undefined}
+      />
+      {mobileSurface ? (
+        <div className="absolute top-[max(env(safe-area-inset-top),1rem)] left-[max(env(safe-area-inset-left),1rem)] z-10">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-lg"
+            aria-label="Close"
+            className="rounded-full bg-white/15 text-white shadow-sm backdrop-blur-xl hover:bg-white/25 active:bg-white/20"
+            onClick={onClose}
+          >
+            <XIcon />
+          </Button>
+        </div>
+      ) : null}
       {canOpenImage ? (
         <div className="absolute top-[max(env(safe-area-inset-top),1rem)] right-[max(env(safe-area-inset-right),1rem)] z-10">
           <Button
             type="button"
             variant="ghost"
             size="sm"
-            className="bg-white/70 text-text hover:bg-white"
+            className={cn(
+              'shadow-sm',
+              mobileSurface
+                ? 'h-9 rounded-full bg-white/15 px-3 text-white backdrop-blur-xl hover:bg-white/25 active:bg-white/20'
+                : 'bg-white/70 text-text hover:bg-white',
+            )}
             onClick={() => onOpenImage(image)}
           >
             <ExternalLinkIcon data-icon="inline-start" />
@@ -53,15 +373,19 @@ export function ImageLightbox({
       <button
         type="button"
         aria-label="Close image preview"
-        className="flex h-full w-full cursor-zoom-out items-center justify-center overflow-hidden bg-transparent p-0"
-        onClick={onClose}
+        className={cn(
+          'absolute inset-0 flex cursor-zoom-out items-center justify-center overflow-hidden bg-transparent',
+          mobileSurface ? 'touch-none p-0' : 'p-6',
+        )}
+        {...dismissDrag.handlers}
       >
         <img
           src={image.src}
           alt={image.alt}
           draggable={false}
           className="h-full w-full select-none object-contain"
-          style={{ viewTransitionName: image.transitionName }}
+          onTransitionEnd={dismissDrag.finishSettle}
+          style={{ ...dismissDrag.previewStyle, viewTransitionName: image.transitionName }}
         />
       </button>
     </LightboxDialog>

--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -367,9 +367,12 @@ describe('NoteEditor image lightbox', () => {
     expect(image?.style.transform).toBe('translate3d(0, 0, 0) scale(1)')
     fireEvent.click(preview)
     expect(screen.getByRole('dialog', { name: 'Image preview' })).toBeInTheDocument()
+    fireEvent.click(preview)
+    expect(screen.getByRole('dialog', { name: 'Image preview' })).toBeInTheDocument()
 
     fireEvent.transitionEnd(image!)
-    expect(screen.getByRole('dialog', { name: 'Image preview' })).toBeInTheDocument()
+    fireEvent.click(preview)
+    expect(screen.queryByRole('dialog')).toBeNull()
   })
 
   it('clears mobile drag click suppression when reduced motion skips the snap animation', async () => {
@@ -395,7 +398,6 @@ describe('NoteEditor image lightbox', () => {
     act(() => captured.props?.onImageClick?.(imageClick('assets/cat.png', 'Cat')))
 
     const preview = await screen.findByRole('button', { name: 'Close image preview' })
-    vi.useFakeTimers()
     try {
       firePointer(preview, 'pointerdown', {
         pointerId: 1,
@@ -417,12 +419,9 @@ describe('NoteEditor image lightbox', () => {
 
       fireEvent.click(preview)
       expect(screen.getByRole('dialog', { name: 'Image preview' })).toBeInTheDocument()
-
-      act(() => vi.advanceTimersByTime(101))
       fireEvent.click(preview)
       expect(screen.queryByRole('dialog')).toBeNull()
     } finally {
-      vi.useRealTimers()
       Object.defineProperty(window, 'matchMedia', {
         configurable: true,
         writable: true,

--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react'
-import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom/vitest'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -113,6 +113,14 @@ function installViewTransitionMock(): ReturnType<typeof vi.fn> {
   return startViewTransition
 }
 
+function firePointer(element: Element, type: string, init: Record<string, unknown>): void {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.assign(event, init)
+  act(() => {
+    element.dispatchEvent(event)
+  })
+}
+
 beforeEach(() => {
   captured.props = null
   Object.defineProperty(window, 'matchMedia', {
@@ -139,6 +147,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup()
+  setPlatformSurface({ touchEditor: false, mobileApp: false })
   vi.clearAllMocks()
 })
 
@@ -270,6 +279,97 @@ describe('NoteEditor image lightbox', () => {
     expect(opener.parentElement?.className).toContain(
       'right-[max(env(safe-area-inset-right),1rem)]',
     )
+  })
+
+  it('shows mobile close chrome inside iOS safe-area bounds', async () => {
+    setPlatformSurface({ mobileApp: true })
+    renderEditor()
+
+    act(() => captured.props?.onImageClick?.(imageClick('assets/cat.png', 'Cat')))
+
+    const close = await screen.findByRole('button', { name: 'Close' })
+    expect(close.parentElement?.className).toContain(
+      'top-[max(env(safe-area-inset-top),1rem)]',
+    )
+    expect(close.parentElement?.className).toContain(
+      'left-[max(env(safe-area-inset-left),1rem)]',
+    )
+  })
+
+  it('dismisses the mobile image lightbox with a downward drag', async () => {
+    setPlatformSurface({ mobileApp: true })
+    renderEditor()
+
+    act(() => captured.props?.onImageClick?.(imageClick('assets/cat.png', 'Cat')))
+
+    const preview = await screen.findByRole('button', { name: 'Close image preview' })
+    const image = preview.querySelector('img')
+    expect(image).toBeInstanceOf(HTMLImageElement)
+
+    firePointer(preview, 'pointerdown', {
+      pointerId: 1,
+      isPrimary: true,
+      pointerType: 'touch',
+      clientX: 180,
+      clientY: 120,
+    })
+    firePointer(preview, 'pointermove', {
+      pointerId: 1,
+      clientX: 182,
+      clientY: 180,
+    })
+    expect(image?.style.transform).toContain('translate3d(0, 60px, 0)')
+
+    firePointer(preview, 'pointermove', {
+      pointerId: 1,
+      clientX: 184,
+      clientY: 360,
+    })
+    firePointer(preview, 'pointerup', {
+      pointerId: 1,
+      clientX: 184,
+      clientY: 360,
+    })
+
+    expect(image?.style.transform).toContain(`translate3d(0, ${window.innerHeight}px, 0)`)
+    fireEvent.transitionEnd(image!)
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+  })
+
+  it('snaps the mobile lightbox back after a short drag without tap-closing it', async () => {
+    setPlatformSurface({ mobileApp: true })
+    renderEditor()
+
+    act(() => captured.props?.onImageClick?.(imageClick('assets/cat.png', 'Cat')))
+
+    const preview = await screen.findByRole('button', { name: 'Close image preview' })
+    const image = preview.querySelector('img')
+    expect(image).toBeInstanceOf(HTMLImageElement)
+
+    firePointer(preview, 'pointerdown', {
+      pointerId: 1,
+      isPrimary: true,
+      pointerType: 'touch',
+      clientX: 180,
+      clientY: 120,
+    })
+    firePointer(preview, 'pointermove', {
+      pointerId: 1,
+      clientX: 182,
+      clientY: 150,
+    })
+    firePointer(preview, 'pointerup', {
+      pointerId: 1,
+      clientX: 182,
+      clientY: 150,
+    })
+
+    expect(image?.style.transform).toBe('translate3d(0, 0, 0) scale(1)')
+    fireEvent.click(preview)
+    expect(screen.getByRole('dialog', { name: 'Image preview' })).toBeInTheDocument()
+
+    fireEvent.transitionEnd(image!)
+    expect(screen.getByRole('dialog', { name: 'Image preview' })).toBeInTheDocument()
   })
 
   it('uses the opener captured when the lightbox opens', async () => {

--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -372,6 +372,65 @@ describe('NoteEditor image lightbox', () => {
     expect(screen.getByRole('dialog', { name: 'Image preview' })).toBeInTheDocument()
   })
 
+  it('clears mobile drag click suppression when reduced motion skips the snap animation', async () => {
+    const originalMatchMedia = window.matchMedia
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: vi.fn((query: string): MediaQueryList => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+
+    setPlatformSurface({ mobileApp: true })
+    renderEditor()
+
+    act(() => captured.props?.onImageClick?.(imageClick('assets/cat.png', 'Cat')))
+
+    const preview = await screen.findByRole('button', { name: 'Close image preview' })
+    vi.useFakeTimers()
+    try {
+      firePointer(preview, 'pointerdown', {
+        pointerId: 1,
+        isPrimary: true,
+        pointerType: 'touch',
+        clientX: 180,
+        clientY: 120,
+      })
+      firePointer(preview, 'pointermove', {
+        pointerId: 1,
+        clientX: 182,
+        clientY: 150,
+      })
+      firePointer(preview, 'pointerup', {
+        pointerId: 1,
+        clientX: 182,
+        clientY: 150,
+      })
+
+      fireEvent.click(preview)
+      expect(screen.getByRole('dialog', { name: 'Image preview' })).toBeInTheDocument()
+
+      act(() => vi.advanceTimersByTime(101))
+      fireEvent.click(preview)
+      expect(screen.queryByRole('dialog')).toBeNull()
+    } finally {
+      vi.useRealTimers()
+      Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        writable: true,
+        value: originalMatchMedia,
+      })
+    }
+  })
+
   it('uses the opener captured when the lightbox opens', async () => {
     const firstOpenImage = vi.fn(async () => {})
     const secondOpenImage = vi.fn(async () => {})

--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -336,6 +336,39 @@ describe('NoteEditor image lightbox', () => {
     await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
   })
 
+  it('uses the release position when the final mobile drag move is coalesced', async () => {
+    setPlatformSurface({ mobileApp: true })
+    renderEditor()
+
+    act(() => captured.props?.onImageClick?.(imageClick('assets/cat.png', 'Cat')))
+
+    const preview = await screen.findByRole('button', { name: 'Close image preview' })
+    const image = preview.querySelector('img')
+    expect(image).toBeInstanceOf(HTMLImageElement)
+
+    firePointer(preview, 'pointerdown', {
+      pointerId: 1,
+      isPrimary: true,
+      pointerType: 'touch',
+      clientX: 180,
+      clientY: 120,
+    })
+    firePointer(preview, 'pointermove', {
+      pointerId: 1,
+      clientX: 182,
+      clientY: 180,
+    })
+    firePointer(preview, 'pointerup', {
+      pointerId: 1,
+      clientX: 184,
+      clientY: 360,
+    })
+
+    expect(image?.style.transform).toContain(`translate3d(0, ${window.innerHeight}px, 0)`)
+    fireEvent.transitionEnd(image!)
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+  })
+
   it('snaps the mobile lightbox back after a short drag without tap-closing it', async () => {
     setPlatformSurface({ mobileApp: true })
     renderEditor()

--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -294,6 +294,9 @@ describe('NoteEditor image lightbox', () => {
     expect(close.parentElement?.className).toContain(
       'left-[max(env(safe-area-inset-left),1rem)]',
     )
+    expect(screen.getByRole('button', { name: 'Close image preview' }).className).toContain(
+      'bg-black',
+    )
   })
 
   it('dismisses the mobile image lightbox with a downward drag', async () => {


### PR DESCRIPTION
## Problem

The editor image lightbox worked on mobile, but it still felt like a desktop/web dialog: a white preview surface, no visible close chrome when there was no opener action, and tap-to-close as the only touch dismissal path.

## Before -> After

| Before | After |
| --- | --- |
| Mobile lightbox used the same pale, desktop-feeling preview surface. | Mobile lightbox gets an immersive dark photo-viewer backdrop while desktop stays unchanged. |
| Closing relied on tapping the preview or Escape. | Mobile adds safe-area close chrome and a native-feeling swipe-down dismiss gesture. |
| Short touch drags could fall through to the tap-close path. | Drag state suppresses the synthetic click and snaps the image back when the gesture does not pass the dismiss threshold. |

## Changes

1. Adds a mobile-gated `useImageDismissDrag` interaction in `ImageLightbox` that tracks a downward touch drag, keeps the preview surface dark while scaling/translating the image, and either dismisses or settles back.
2. Adds mobile-only safe-area close chrome and restyles the image opener as translucent mobile controls while preserving the existing desktop opener styling.
3. Extends `note-editor.test.tsx` coverage for mobile close chrome, swipe-down dismiss, and short-drag cancellation.

## Verification

- `pnpm --filter @reflect/desktop test -- src/editor/note-editor.test.tsx` passed. Vitest reported 191 files and 1679 tests passing.
- `pnpm check` passed.

## Risk / Rollout

No migrations or data changes. The visual and gesture changes are gated to the mobile surface; desktop keeps the existing tap-to-close and opener behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and gesture handling gated to `isMobileSurface()` with no data, auth, or API changes; desktop paths preserved.
> 
> **Overview**
> On **mobile surfaces only**, the editor image lightbox shifts from a desktop-style pale overlay to a dark full-screen viewer with safe-area **Close** chrome and translucent controls for **Open**.
> 
> Touch dismissal adds a **`useImageDismissDrag`** flow on the preview: downward drags translate/scale the image and fade opacity; release past a distance or flick threshold closes the lightbox, otherwise it animates back. Synthetic taps are suppressed during and right after drags so short gestures do not accidentally tap-close; **`prefers-reduced-motion`** skips the settle animation and closes immediately when appropriate.
> 
> Desktop behavior (tap-to-close, existing opener styling) is unchanged. **`note-editor.test.tsx`** gains coverage for mobile chrome, swipe dismiss, coalesced pointer release, snap-back, and reduced-motion click suppression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c09168cc261afc890835371fda733a4b6baf2fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



