### PR TITLE
Fix task wikilink preview alignment

### DIFF
--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -445,6 +445,11 @@ html:root {
   line-height: inherit;
   letter-spacing: 0;
 }
+/* meowdown bottoms atom previews; in compact task rows that drops wiki-link text
+   below the surrounding task copy. */
+.reflect-task-preview .md-wikilink-view-preview {
+  vertical-align: baseline;
+}
 .line-through .reflect-task-preview .md-link,
 .line-through .reflect-task-preview .md-wikilink-view-label,
 .line-through .reflect-task-preview .md-tag {


### PR DESCRIPTION
## Problem
Unfocused task rows render their text through the read-only markdown preview. meowdown bottom-aligns atom previews there, which makes wiki-link chips sit lower than the surrounding task copy.

## Change
Set wiki-link previews inside compact task previews back to baseline alignment, leaving the focused inline editor and other markdown preview surfaces unchanged.

## Verification
- pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single scoped CSS override in task preview styling; no logic, auth, or data changes.
> 
> **Overview**
> Unfocused task rows show markdown through `.reflect-task-preview`; meowdown’s default **bottom** alignment on atom previews (`.md-wikilink-view-preview`) made wiki-link chips sit lower than the rest of the line.
> 
> This adds a scoped override: **`vertical-align: baseline`** only under `.reflect-task-preview`, so wiki links line up with surrounding task text without changing the focused inline editor or other markdown preview surfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 813fbad8e8797f24adf552843f0b4f95a72014a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->