### PR TITLE
Support v1 // title aliases

### DIFF
--- a/apps/cli/src/note_file.rs
+++ b/apps/cli/src/note_file.rs
@@ -101,7 +101,7 @@ fn split_alias_parts(title: &str) -> Vec<&str> {
             break;
         };
         let split_at = search_from + relative_split_at;
-        if title[..split_at].chars().next_back() == Some(':') {
+        if title[..split_at].ends_with(':') {
             search_from = split_at + 2;
             continue;
         }

--- a/apps/cli/src/note_file.rs
+++ b/apps/cli/src/note_file.rs
@@ -3,6 +3,7 @@
 //! `packages/core/src/markdown/extract.ts`; the walk mirrors the desktop's
 //! `collect_markdown` (`apps/desktop/src-tauri/src/fs/io.rs`).
 
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 use std::time::UNIX_EPOCH;
@@ -11,6 +12,7 @@ use pulldown_cmark::{Event, HeadingLevel, Parser, Tag};
 
 use crate::error::CliError;
 use crate::frontmatter::{parse_frontmatter, split_frontmatter, Frontmatter};
+use crate::keys::fold_key;
 use crate::paths::{date_from_daily_path, NOTE_DIRS};
 
 /// A note's derived metadata, as the TS indexer would compute it.
@@ -35,6 +37,11 @@ pub struct DiskNote {
     pub rel_path: String,
     /// Last-modified time in epoch milliseconds (the `notes.mtime` unit).
     pub mtime_ms: u64,
+}
+
+struct DerivedTitle {
+    title: String,
+    aliases: Vec<String>,
 }
 
 /// Filename without directories or the `.md` extension (the TS `basename`).
@@ -84,22 +91,107 @@ fn first_h1(body: &str) -> Option<String> {
     None
 }
 
+fn split_alias_parts(title: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut search_from = 0;
+
+    while search_from < title.len() {
+        let Some(relative_split_at) = title[search_from..].find("//") else {
+            break;
+        };
+        let split_at = search_from + relative_split_at;
+        if title[..split_at].chars().next_back() == Some(':') {
+            search_from = split_at + 2;
+            continue;
+        }
+        parts.push(&title[start..split_at]);
+        start = split_at + 2;
+        search_from = start;
+    }
+
+    if parts.is_empty() {
+        return vec![title];
+    }
+    parts.push(&title[start..]);
+    parts
+}
+
+fn split_title_aliases(title: &str) -> DerivedTitle {
+    let parts = split_alias_parts(title);
+    let canonical = parts.first().map(|part| part.trim()).unwrap_or(title);
+    if canonical.is_empty() {
+        return DerivedTitle {
+            title: title.to_string(),
+            aliases: Vec::new(),
+        };
+    }
+
+    let mut seen = HashSet::new();
+    seen.insert(fold_key(canonical));
+    let mut aliases = Vec::new();
+    for part in parts.iter().skip(1) {
+        let alias = part.trim();
+        let key = fold_key(alias);
+        if key.is_empty() || seen.contains(&key) {
+            continue;
+        }
+        seen.insert(key);
+        aliases.push(alias.to_string());
+    }
+
+    DerivedTitle {
+        title: canonical.to_string(),
+        aliases,
+    }
+}
+
 /// The TS `deriveTitle` chain: frontmatter `title` → first H1 → daily date →
-/// filename.
-fn derive_title(rel_path: &str, frontmatter: &Frontmatter, body: &str) -> String {
+/// filename. Authored titles also derive v1-style `//` aliases.
+fn derive_title(rel_path: &str, frontmatter: &Frontmatter, body: &str) -> DerivedTitle {
     if let Some(title) = frontmatter.title.as_deref() {
         let title = title.trim();
         if !title.is_empty() {
-            return title.to_string();
+            return split_title_aliases(title);
         }
     }
     if let Some(heading) = first_h1(body) {
-        return heading;
+        return split_title_aliases(&heading);
     }
     if let Some(date) = date_from_daily_path(rel_path) {
-        return date.to_string();
+        return DerivedTitle {
+            title: date.to_string(),
+            aliases: Vec::new(),
+        };
     }
-    basename(rel_path).to_string()
+    DerivedTitle {
+        title: basename(rel_path).to_string(),
+        aliases: Vec::new(),
+    }
+}
+
+fn merge_aliases(
+    title: &str,
+    frontmatter_aliases: Vec<String>,
+    title_aliases: Vec<String>,
+) -> Vec<String> {
+    let mut aliases = frontmatter_aliases;
+    let mut seen = HashSet::new();
+    seen.insert(fold_key(title));
+    for alias in &aliases {
+        seen.insert(fold_key(alias));
+    }
+
+    for alias in title_aliases {
+        let trimmed = alias.trim();
+        let key = fold_key(trimmed);
+        if key.is_empty() || seen.contains(&key) {
+            continue;
+        }
+        seen.insert(key);
+        aliases.push(trimmed.to_string());
+    }
+    aliases
 }
 
 /// Derive a note's metadata from its source, as the TS indexer would.
@@ -107,10 +199,11 @@ pub fn parse_note_meta(rel_path: &str, source: &str) -> NoteMeta {
     let split = split_frontmatter(source);
     let frontmatter = parse_frontmatter(split.raw);
     let title = derive_title(rel_path, &frontmatter, split.body);
+    let aliases = merge_aliases(&title.title, frontmatter.aliases, title.aliases);
     NoteMeta {
         id: frontmatter.id,
-        title,
-        aliases: frontmatter.aliases,
+        title: title.title,
+        aliases,
         private: frontmatter.private,
     }
 }
@@ -214,6 +307,31 @@ mod tests {
 
         let meta = parse_note_meta("notes/Fancy Name.md", "no headings\n");
         assert_eq!(meta.title, "Fancy Name");
+    }
+
+    #[test]
+    fn title_slash_aliases_match_the_ts_extractor() {
+        let meta = parse_note_meta(
+            "notes/charlotte.md",
+            "---\naliases: [Manual, Mum]\n---\n# Charlotte MacCaw // Mum // Lottie\n",
+        );
+        assert_eq!(meta.title, "Charlotte MacCaw");
+        assert_eq!(meta.aliases, vec!["Manual", "Mum", "Lottie"]);
+
+        let meta = parse_note_meta("notes/project.md", "---\ntitle: Project X // PX\n---\n");
+        assert_eq!(meta.title, "Project X");
+        assert_eq!(meta.aliases, vec!["PX"]);
+
+        let meta = parse_note_meta("notes/superman.md", "# Superman//Clark Kent\n");
+        assert_eq!(meta.title, "Superman");
+        assert_eq!(meta.aliases, vec!["Clark Kent"]);
+    }
+
+    #[test]
+    fn protocol_slashes_are_not_title_aliases() {
+        let meta = parse_note_meta("notes/url.md", "# https://example.com/page\n");
+        assert_eq!(meta.title, "https://example.com/page");
+        assert!(meta.aliases.is_empty());
     }
 
     #[test]

--- a/apps/cli/tests/cli.rs
+++ b/apps/cli/tests/cli.rs
@@ -425,6 +425,36 @@ fn show_resolves_by_title_and_alias_without_an_index() {
 }
 
 #[test]
+fn show_resolves_slash_title_aliases_with_and_without_an_index() {
+    let fixture = graph();
+    fixture.write_note(
+        "notes/charlotte.md",
+        "# Charlotte MacCaw // Mum\nfamily notes\n",
+    );
+
+    for arg in ["Charlotte MacCaw", "Mum"] {
+        let output = reflect(&fixture, &["show", arg]);
+        assert!(output.status.success(), "show {arg}: {}", stderr(&output));
+        assert!(stdout(&output).contains("family notes"), "show {arg}");
+    }
+
+    fixture.build_index();
+
+    for arg in ["Charlotte MacCaw", "Mum"] {
+        let output = reflect(&fixture, &["show", arg]);
+        assert!(
+            output.status.success(),
+            "indexed show {arg}: {}",
+            stderr(&output)
+        );
+        assert!(
+            stdout(&output).contains("family notes"),
+            "indexed show {arg}"
+        );
+    }
+}
+
+#[test]
 fn show_blocks_a_private_note_even_when_the_index_says_public() {
     let fixture = graph();
     let note = fixture.write_note("notes/a.md", "# Alpha\npublic at index time\n");

--- a/apps/desktop/src/lib/note-templates.test.ts
+++ b/apps/desktop/src/lib/note-templates.test.ts
@@ -145,6 +145,19 @@ describe('renameTemplate', () => {
     )
   })
 
+  it('rewrites a v1-style aliased H1 instead of adding frontmatter title', async () => {
+    templateSlugPathForTitle.mockResolvedValueOnce('templates/log.md')
+    readNote.mockResolvedValueOnce('# Journal // Daily Review\n\n- Mood:\n')
+
+    await renameTemplate('templates/journal.md', 'Log', 7)
+
+    expect(writeNote).toHaveBeenCalledWith(
+      'templates/log.md',
+      '# Log\n\n- Mood:\n',
+      7,
+    )
+  })
+
   it('updates a frontmatter title when that is what names the template', async () => {
     templateSlugPathForTitle.mockResolvedValueOnce('templates/journal.md')
     readNote.mockResolvedValueOnce('---\ntitle: Journal\n---\nMood:\n')

--- a/apps/desktop/src/lib/note-templates.ts
+++ b/apps/desktop/src/lib/note-templates.ts
@@ -2,6 +2,7 @@ import {
   availableTemplatePath,
   errorMessage,
   hasAuthoredTitle,
+  hasFrontmatterTitle,
   parseNote,
   readNote,
   slugForTitle,
@@ -100,8 +101,8 @@ async function retitleTemplate(path: string, title: string, generation: number):
   const source = await readNote(path)
   const parsed = parseNote({ path, source })
   const h1 = parsed.headings.find((heading) => heading.level === 1 && heading.text)
-  if (h1 !== undefined && h1.text === parsed.title) {
-    if (h1.text === title) {
+  if (h1 !== undefined && !hasFrontmatterTitle(parsed)) {
+    if (parsed.title === title) {
       return
     }
     await writeNote(path, `${source.slice(0, h1.from)}# ${title}${source.slice(h1.to)}`, generation)

--- a/packages/core/src/exports/sync-markdown-indexing.ts
+++ b/packages/core/src/exports/sync-markdown-indexing.ts
@@ -90,6 +90,7 @@ export {
   foldTag,
   isTagName,
   hasAuthoredTitle,
+  hasFrontmatterTitle,
   normalizeWikiTarget,
   slugForTitle,
   type ConflictResolution,

--- a/packages/core/src/indexing/indexed-note.test.ts
+++ b/packages/core/src/indexing/indexed-note.test.ts
@@ -3,8 +3,8 @@ import { gistBodyHash, parseNote } from '../markdown'
 import { buildIndexedNote, indexedNoteSchema, PROJECTION_VERSION } from './indexed-note'
 
 describe('buildIndexedNote', () => {
-  it('carries the projection version that backfills the note email rows', () => {
-    expect(PROJECTION_VERSION).toBe(13)
+  it('carries the projection version that backfills v1 title aliases', () => {
+    expect(PROJECTION_VERSION).toBe(14)
   })
 
   it('flattens a parsed note into the index payload', () => {
@@ -44,6 +44,24 @@ describe('buildIndexedNote', () => {
       true,
     )
     expect(indexed.assets).toEqual(['assets/p.png'])
+  })
+
+  it('projects v1-style // title aliases beside explicit frontmatter aliases', () => {
+    const source =
+      '---\naliases: [Manual, Mum]\n---\n# Charlotte MacCaw // Mum // Lottie\n\nbody'
+    const indexed = buildIndexedNote(parseNote({ path: 'notes/charlotte.md', source }), {
+      fileHash: 'h',
+      mtime: 0,
+      source,
+    })
+
+    expect(indexed.title).toBe('Charlotte MacCaw')
+    expect(indexed.titleKey).toBe('charlotte maccaw')
+    expect(indexed.aliases).toEqual([
+      { alias: 'Manual', aliasKey: 'manual' },
+      { alias: 'Mum', aliasKey: 'mum' },
+      { alias: 'Lottie', aliasKey: 'lottie' },
+    ])
   })
 
   it('projects Email field bullets with folded keys, ignoring prose mentions', () => {

--- a/packages/core/src/indexing/indexed-note.ts
+++ b/packages/core/src/indexing/indexed-note.ts
@@ -59,8 +59,11 @@ import { previewSnippet } from './snippet'
  * 13 — `note_emails` projection (`- Email:` contact-field bullets): existing
  * person notes carry no email rows until reprojected, and attendee → note
  * resolution in the calendar flow needs them, so the bump backfills them.
+ * 14 — v1-style `Title // Alias` authored titles project the suffixes into the
+ * aliases table, so old Reflect subjects resolve and autocomplete like
+ * frontmatter aliases.
  */
-export const PROJECTION_VERSION = 13
+export const PROJECTION_VERSION = 14
 
 export const indexedLinkSchema = z.object({
   kind: z.enum(['wiki', 'md']),
@@ -152,6 +155,30 @@ export const indexedNoteSchema = z.object({
 })
 export type IndexedNote = z.infer<typeof indexedNoteSchema>
 
+function indexedAliases(parsed: ParsedNote): IndexedAlias[] {
+  const frontmatterAliases = parsed.frontmatter.aliases.map((alias) => ({
+    alias,
+    aliasKey: foldKey(alias),
+  }))
+  const seen = new Set([
+    foldKey(parsed.title),
+    ...frontmatterAliases.map((alias) => alias.aliasKey),
+  ])
+  const titleAliases: IndexedAlias[] = []
+
+  for (const alias of parsed.titleAliases) {
+    const trimmed = alias.trim()
+    const aliasKey = foldKey(trimmed)
+    if (aliasKey === '' || seen.has(aliasKey)) {
+      continue
+    }
+    seen.add(aliasKey)
+    titleAliases.push({ alias: trimmed, aliasKey })
+  }
+
+  return [...frontmatterAliases, ...titleAliases]
+}
+
 /**
  * Flatten a parsed note into the index payload. `meta.source` is the raw
  * markdown the note was parsed from — conflict markers are detected on it
@@ -203,10 +230,7 @@ export function buildIndexedNote(
     preview: previewSnippet(parsed.text, parsed.title),
     links: [...wikiLinks, ...mdLinks],
     tags: parsed.tags.map((tag) => ({ tag, tagKey: foldTag(tag) })),
-    aliases: parsed.frontmatter.aliases.map((alias) => ({
-      alias,
-      aliasKey: foldKey(alias),
-    })),
+    aliases: indexedAliases(parsed),
     emails: extractEmailFields(body).map((email) => ({ email, emailKey: foldEmail(email) })),
     assets: parsed.assets.map((asset) => asset.path),
     tasks: parsed.tasks.map((task) => ({

--- a/packages/core/src/markdown/extract.test.ts
+++ b/packages/core/src/markdown/extract.test.ts
@@ -63,6 +63,26 @@ describe('parseNote — headings & title', () => {
     expect(parse('no heading', 'daily/2026-06-09.md').title).toBe('2026-06-09')
   })
 
+  it('derives v1-style // aliases from authored titles', () => {
+    const fromHeading = parse('# Charlotte MacCaw // Mum // mum\n\nbody')
+    expect(fromHeading.title).toBe('Charlotte MacCaw')
+    expect(fromHeading.titleAliases).toEqual(['Mum'])
+
+    const fromFrontmatter = parse('---\ntitle: Project X // PX\n---\n# Ignored')
+    expect(fromFrontmatter.title).toBe('Project X')
+    expect(fromFrontmatter.titleAliases).toEqual(['PX'])
+
+    const compact = parse('# Superman//Clark Kent\n')
+    expect(compact.title).toBe('Superman')
+    expect(compact.titleAliases).toEqual(['Clark Kent'])
+  })
+
+  it('does not treat URL protocol slashes as title aliases', () => {
+    const note = parse('# https://example.com/page\n\nbody')
+    expect(note.title).toBe('https://example.com/page')
+    expect(note.titleAliases).toEqual([])
+  })
+
   it('hasAuthoredTitle mirrors the derivation: true iff the title is not a path fallback', () => {
     expect(hasAuthoredTitle(parse('---\ntitle: From FM\n---\nbody'))).toBe(true)
     expect(hasAuthoredTitle(parse('# The H1\n\nbody'))).toBe(true)

--- a/packages/core/src/markdown/extract.test.ts
+++ b/packages/core/src/markdown/extract.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { hasAuthoredTitle, isTagName, parseNote } from './extract'
+import { hasAuthoredTitle, hasFrontmatterTitle, isTagName, parseNote } from './extract'
 
 function parse(source: string, path = 'notes/test.md') {
   return parseNote({ path, source })
@@ -90,6 +90,12 @@ describe('parseNote — headings & title', () => {
     expect(hasAuthoredTitle(parse('## only a section', 'notes/x.md'))).toBe(false)
     expect(hasAuthoredTitle(parse('---\ntitle: "  "\n---\nbody'))).toBe(false)
     expect(hasAuthoredTitle(parse('no heading', 'daily/2026-06-09.md'))).toBe(false)
+  })
+
+  it('hasFrontmatterTitle identifies only the frontmatter-owned title source', () => {
+    expect(hasFrontmatterTitle(parse('---\ntitle: From FM // Alias\n---\n# Ignored'))).toBe(true)
+    expect(hasFrontmatterTitle(parse('# The H1 // Alias\n\nbody'))).toBe(false)
+    expect(hasFrontmatterTitle(parse('---\ntitle: "  "\n---\n# The H1'))).toBe(false)
   })
 })
 

--- a/packages/core/src/markdown/extract.ts
+++ b/packages/core/src/markdown/extract.ts
@@ -324,6 +324,16 @@ export function hasAuthoredTitle(note: Pick<ParsedNote, 'frontmatter' | 'heading
   return authoredTitle(note.frontmatter, note.headings) !== null
 }
 
+/**
+ * Does the note carry an explicit frontmatter `title:`? This is the first title
+ * source in {@link deriveTitle}; callers that rewrite the authored title use it
+ * to distinguish frontmatter-owned titles from H1-owned titles.
+ */
+export function hasFrontmatterTitle(note: Pick<ParsedNote, 'frontmatter'>): boolean {
+  const title = stringField(note.frontmatter, 'title')
+  return title !== undefined && title.trim() !== ''
+}
+
 function deriveTitle(frontmatter: Frontmatter, headings: Heading[], path: string): AuthoredTitle {
   const authored = authoredTitle(frontmatter, headings)
   if (authored !== null) {

--- a/packages/core/src/markdown/extract.ts
+++ b/packages/core/src/markdown/extract.ts
@@ -1,7 +1,7 @@
 import { dateFromDailyPath, isDaily } from '../graph/paths'
 import { parseFrontmatter, splitFrontmatter } from './frontmatter'
 import { parseBody } from './grammar'
-import { foldTag } from './keys'
+import { foldKey, foldTag } from './keys'
 import { parseInlineLink } from './link-syntax'
 import { buildPlainText, plainTextOfRange, unescapeMarkdownText } from './plain-text'
 import { normalizeWikiTarget } from './resolve'
@@ -248,6 +248,57 @@ function collectTags(body: string, excluded: Span[], into: Map<string, string>):
   }
 }
 
+interface AuthoredTitle {
+  title: string
+  aliases: string[]
+}
+
+function splitAliasParts(title: string): string[] {
+  const parts: string[] = []
+  let start = 0
+  let searchFrom = 0
+
+  while (searchFrom < title.length) {
+    const splitAt = title.indexOf('//', searchFrom)
+    if (splitAt === -1) {
+      break
+    }
+    if (splitAt > 0 && title[splitAt - 1] === ':') {
+      searchFrom = splitAt + 2
+      continue
+    }
+    parts.push(title.slice(start, splitAt))
+    start = splitAt + 2
+    searchFrom = start
+  }
+
+  if (parts.length === 0) {
+    return [title]
+  }
+  parts.push(title.slice(start))
+  return parts
+}
+
+function splitTitleAliases(title: string): AuthoredTitle {
+  const parts = splitAliasParts(title).map((part) => part.trim())
+  const canonical = parts[0] ?? title
+  if (canonical === '') {
+    return { title, aliases: [] }
+  }
+
+  const seen = new Set([foldKey(canonical)])
+  const aliases: string[] = []
+  for (const alias of parts.slice(1)) {
+    const key = foldKey(alias)
+    if (key === '' || seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    aliases.push(alias)
+  }
+  return { title: canonical, aliases }
+}
+
 /**
  * The title the note's *content* authors — explicit frontmatter `title:`,
  * else the first non-empty H1 — or `null` when {@link deriveTitle} would fall
@@ -255,13 +306,13 @@ function collectTags(body: string, excluded: Span[], into: Map<string, string>):
  * derivation and the {@link hasAuthoredTitle} predicate share, so "is this
  * note titled?" can never drift from how the title is actually derived.
  */
-function authoredTitle(frontmatter: Frontmatter, headings: Heading[]): string | null {
+function authoredTitle(frontmatter: Frontmatter, headings: Heading[]): AuthoredTitle | null {
   const fmTitle = stringField(frontmatter, 'title')
   if (fmTitle && fmTitle.trim()) {
-    return fmTitle.trim()
+    return splitTitleAliases(fmTitle.trim())
   }
   const h1 = headings.find((heading) => heading.level === 1 && heading.text)
-  return h1 ? h1.text : null
+  return h1 ? splitTitleAliases(h1.text) : null
 }
 
 /**
@@ -273,7 +324,7 @@ export function hasAuthoredTitle(note: Pick<ParsedNote, 'frontmatter' | 'heading
   return authoredTitle(note.frontmatter, note.headings) !== null
 }
 
-function deriveTitle(frontmatter: Frontmatter, headings: Heading[], path: string): string {
+function deriveTitle(frontmatter: Frontmatter, headings: Heading[], path: string): AuthoredTitle {
   const authored = authoredTitle(frontmatter, headings)
   if (authored !== null) {
     return authored
@@ -281,10 +332,10 @@ function deriveTitle(frontmatter: Frontmatter, headings: Heading[], path: string
   if (isDaily(path)) {
     const date = dateFromDailyPath(path)
     if (date) {
-      return date
+      return { title: date, aliases: [] }
     }
   }
-  return basename(path)
+  return { title: basename(path), aliases: [] }
 }
 
 /** Parse one note's full source into the stable {@link ParsedNote} contract. */
@@ -362,11 +413,13 @@ export function parseNote(input: { path: string; source: string }): ParsedNote {
       tasks.push(task)
     }
   }
+  const title = deriveTitle(frontmatter, headings, path)
 
   return {
     path,
     id: stringField(frontmatter, 'id'),
-    title: deriveTitle(frontmatter, headings, path),
+    title: title.title,
+    titleAliases: title.aliases,
     frontmatter,
     frontmatterWarning: warning,
     wikiLinks,

--- a/packages/core/src/markdown/index.ts
+++ b/packages/core/src/markdown/index.ts
@@ -27,7 +27,7 @@ export {
   type ParsedFrontmatter,
 } from './frontmatter'
 export { parseBody, reflectMarkdownParser, wikiLinkExtension } from './grammar'
-export { parseNote, isTagName, hasAuthoredTitle } from './extract'
+export { parseNote, isTagName, hasAuthoredTitle, hasFrontmatterTitle } from './extract'
 export {
   scanInlineWikiLinks,
   scanInlineImages,

--- a/packages/core/src/markdown/model.ts
+++ b/packages/core/src/markdown/model.ts
@@ -202,8 +202,9 @@ export interface ParsedTask extends TaskMarker {
 /** Version of the extraction contract; bump on breaking shape changes.
  * 1 — Plan 03 baseline · 2 — `tasks: ParsedTask[]` (with `dueDate`) added (Plan 18) ·
  * 3 — tasks limited to round Meowdown `+ [ ]` / `+ [x]` syntax; square checklist
- * checkboxes are excluded. */
-export const PARSED_NOTE_VERSION = 3
+ * checkboxes are excluded · 4 — `titleAliases`, derived from v1-style `//`
+ * aliases in authored titles. */
+export const PARSED_NOTE_VERSION = 4
 
 /** The full parse of one note — the stable contract downstream plans depend on. */
 export interface ParsedNote {
@@ -211,8 +212,13 @@ export interface ParsedNote {
   path: string
   /** Stable id from frontmatter, if the note carries one (else identity = path). */
   id?: string | undefined
-  /** `frontmatter.title` → first H1 → filename (or the date for daily notes). */
+  /**
+   * `frontmatter.title` → first H1 → filename (or the date for daily notes);
+   * v1-style `//` suffixes are removed.
+   */
   title: string
+  /** Alternative names derived from v1-style `Title // Alias` authored titles. */
+  titleAliases: string[]
   frontmatter: Frontmatter
   /** Set when YAML frontmatter failed to parse; the note is still usable. */
   frontmatterWarning?: string | undefined


### PR DESCRIPTION
## Problem

Reflect v1 let users write aliases directly in the note subject with `//`, for example `Charlotte MacCaw // Mum`. Reflect Open already has a frontmatter-backed alias system, but imported or newly-authored v1-style titles were treated as one literal title. That meant `[[Mum]]` would not resolve to `# Charlotte MacCaw // Mum`, and autocomplete could not offer the shorthand.

This PR restores the v1 shorthand as a derived compatibility layer. It does not migrate notes into frontmatter or introduce a new alias table shape.

## Before -> After

| Case | Before | After |
| --- | --- | --- |
| `# Charlotte MacCaw // Mum` | Title indexed as `Charlotte MacCaw // Mum`; `Mum` unresolved | Title indexed as `Charlotte MacCaw`; `Mum` indexed as an alias |
| `---\ntitle: Project X // PX\n---` | Full title string used literally | `Project X` is canonical, `PX` resolves as an alias |
| `# https://example.com/page` | Title was a URL | Still a URL; protocol `//` is not treated as an alias separator |

## Changes

1. Added `titleAliases` to the markdown parse contract and bumped `PARSED_NOTE_VERSION`.
2. Split authored titles (`frontmatter.title` or first H1) on v1-style `//`, using the first segment as canonical title and later segments as derived aliases.
3. Project derived title aliases into the existing `aliases` index rows beside explicit frontmatter aliases, deduping derived aliases against the canonical title and explicit aliases.
4. Bumped `PROJECTION_VERSION` to force existing graphs to rebuild alias rows for unchanged notes.
5. Mirrored the same title/alias derivation in the Rust CLI metadata reader so no-index CLI resolution and test index fixtures behave like the desktop indexer.
6. Taught template renaming to distinguish frontmatter-owned titles from H1-owned titles, so an aliased H1 is rewritten instead of adding a redundant frontmatter title.

## Tests

Added coverage for:

- H1 and frontmatter `//` alias derivation, including compact `Superman//Clark Kent` form.
- Avoiding accidental alias splitting for URL protocol slashes.
- Projection of derived aliases alongside explicit frontmatter aliases.
- CLI resolution of slash title aliases with and without an index.
- Template rename behavior for a v1-style aliased H1.

## Verification

- `pnpm --filter @reflect/core test --run src/markdown/extract.test.ts src/indexing/indexed-note.test.ts` passed.
- `pnpm --filter @reflect/core test --run src/indexing/pipeline.test.ts` passed.
- `pnpm --filter @reflect/desktop test --run src/lib/note-templates.test.ts` passed.
- `pnpm check` passed.
- `cargo test -p reflect-cli note_file` passed.
- `cargo test -p reflect-cli show_resolves_slash_title_aliases_with_and_without_an_index` passed.
- `cargo test -p reflect-cli` passed.
- `cargo clippy -p reflect-cli --all-targets -- -D warnings` passed.
- `cargo fmt --all --check` passed.
- `git diff --check` passed.

## Risk / Rollout

No schema migration is required. The projection version bump causes Reflect Open to rebuild the local index so existing notes gain the derived alias rows. The main behavior change is that authored titles containing `//` now use the first segment as the canonical note title; protocol URLs are explicitly guarded so common URL titles do not regress.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Canonical titles change for notes whose authored title contained `//`, and the projection bump rebuilds alias rows graph-wide; behavior is guarded for URL titles but any other intentional `//` in a title will split differently than before.
> 
> **Overview**
> Restores Reflect v1’s `Title // Alias` shorthand as a **derived** compatibility layer—notes are not migrated into frontmatter; suffixes after `//` become resolvable aliases alongside explicit `aliases:`.
> 
> **Parsing & indexing:** `parseNote` now exposes `titleAliases` (contract bump to `PARSED_NOTE_VERSION` 4). Authored titles from frontmatter `title:` or the first H1 are split on `//` (first segment canonical); `:` before `//` is ignored so URLs like `https://…` stay intact. `buildIndexedNote` merges derived aliases into existing `aliases` rows with deduping; `PROJECTION_VERSION` 14 forces a local index rebuild.
> 
> **CLI & desktop:** Rust `note_file` mirrors the same derivation for no-index `show` resolution. Template rename uses `hasFrontmatterTitle` so v1-style aliased H1s are rewritten in place instead of gaining a frontmatter `title:`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d18f715228542e007c0ade0590b53150bde5da8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->