### PR TITLE
fix(desktop): focus Daily capture at note end

### DIFF
--- a/apps/desktop/src/components/daily-stream.test.tsx
+++ b/apps/desktop/src/components/daily-stream.test.tsx
@@ -7,7 +7,8 @@ import {
   FocusedDailyProvider,
   useFocusedDailyDate,
 } from '@/providers/focused-daily-provider'
-import { RouterProvider, useRouter } from '@/routing/router'
+import type { Route } from '@/routing/route'
+import { RouterProvider, useRouter, type NavigateOptions } from '@/routing/router'
 import { todayIso } from '@/lib/dates'
 import { createDayWindow, dateAtIndex, indexOfDate } from '@/lib/day-window'
 import { installVirtuaTestEnv } from '@/test-utils/virtua-jsdom'
@@ -23,9 +24,45 @@ import { DailyStream, ESTIMATED_DAY_HEIGHT } from './daily-stream'
  * loading-placeholder contract (reserved editor space, delayed hint).
  */
 
-vi.mock('@/editor/note-editor', () => ({
-  NoteEditor: () => <div data-testid="fake-editor" />,
+const editorProbe = vi.hoisted(() => ({
+  focusCalls: 0,
+  selectionCalls: [] as Array<'start' | 'end'>,
 }))
+
+vi.mock('@/editor/note-editor', async () => {
+  const { useEffect } = await import('react')
+  return {
+    NoteEditor: ({
+      initialContent,
+      handleRef,
+    }: {
+      initialContent: string
+      handleRef?: (handle: import('@/editor/note-editor').NoteEditorHandle | null) => void
+    }) => {
+      useEffect(() => {
+        handleRef?.({
+          setMarkdown: () => {},
+          getMarkdown: () => '',
+          insertMarkdown: () => {},
+          focus: () => {
+            editorProbe.focusCalls += 1
+          },
+          setSelection: (position: 'start' | 'end') => {
+            editorProbe.selectionCalls.push(position)
+          },
+          getSelectedText: () => '',
+          openSelectionMenu: () => {},
+          startPendingReplacement: () => false,
+          appendPendingReplacementText: () => {},
+          acceptPendingReplacement: () => {},
+          discardPendingReplacement: () => {},
+        })
+        return () => handleRef?.(null)
+      }, [handleRef])
+      return <div data-testid="fake-editor">{initialContent}</div>
+    },
+  }
+})
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({
     graph: { root: '/g', name: 'g', generation: 1 },
@@ -70,14 +107,20 @@ Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
   },
 })
 
+const mockInvoke = vi.fn<(command: string, args: Record<string, unknown>) => Promise<unknown>>()
+
 setBridge({
-  // Reads never resolve: every day stays a loading placeholder.
-  invoke: () => new Promise(() => {}),
+  invoke: mockInvoke,
   listen: async () => () => {},
 })
 
 beforeEach(() => {
   scrollTops.length = 0
+  editorProbe.focusCalls = 0
+  editorProbe.selectionCalls = []
+  mockInvoke.mockReset()
+  // Reads never resolve by default: every day stays a loading placeholder.
+  mockInvoke.mockImplementation(() => new Promise(() => {}))
 })
 
 afterEach(() => {
@@ -107,13 +150,49 @@ function SaveScrollProbe({ offset }: { offset: number }): ReactElement | null {
 function NavigateTodayProbe({
   onReady,
 }: {
-  onReady: (navigateToday: () => void) => void
+  onReady: (navigateToday: (options?: NavigateOptions) => void) => void
 }): null {
   const { navigate } = useRouter()
   useEffect(() => {
-    onReady(() => navigate({ kind: 'today' }))
+    onReady((options) => navigate({ kind: 'today' }, options))
   }, [navigate, onReady])
   return null
+}
+
+function NavigateRouteProbe({
+  onReady,
+}: {
+  onReady: (navigateRoute: (route: Route, options?: NavigateOptions) => void) => void
+}): null {
+  const { navigate } = useRouter()
+  useEffect(() => {
+    onReady((route, options) => navigate(route, options))
+  }, [navigate, onReady])
+  return null
+}
+
+function installReadableNotes(files: Record<string, string>): void {
+  mockInvoke.mockImplementation(async (command, args) => {
+    if (command === 'note_read') {
+      const content = files[(args as { path: string }).path]
+      if (content === undefined) {
+        throw { kind: 'notFound', message: 'missing' }
+      }
+      return content
+    }
+    if (command === 'note_write') {
+      const { path, contents } = args as { path: string; contents: string }
+      files[path] = contents
+      return null
+    }
+    if (command === 'note_exists') {
+      return (args as { path: string }).path in files
+    }
+    if (command === 'db_query') {
+      return []
+    }
+    return null
+  })
 }
 
 describe('DailyStream', () => {
@@ -214,6 +293,43 @@ describe('DailyStream', () => {
     fireEvent.focusIn(row)
 
     expect(focused).toBe(date)
+    view.unmount()
+  })
+
+  it('focuses a focused daily arrival at the end of the daily note', async () => {
+    const dayWindow = createDayWindow(todayIso())
+    const target = dateAtIndex(dayWindow, 2)
+    installReadableNotes({ [`daily/${target}.md`]: 'first thought\nsecond thought\n' })
+    let navigateRoute: (route: Route, options?: NavigateOptions) => void = () => {
+      throw new Error('navigate route not ready')
+    }
+    const view = render(
+      <StreamProviders>
+        <DailyStream target={{ kind: 'date', date: target }} />
+        <NavigateRouteProbe
+          onReady={(run) => {
+            navigateRoute = run
+          }}
+        />
+      </StreamProviders>,
+    )
+
+    await waitFor(() => {
+      expect(view.getAllByTestId('fake-editor').length).toBeGreaterThan(0)
+    })
+    editorProbe.focusCalls = 0
+    editorProbe.selectionCalls = []
+    scrollTops.length = 0
+
+    await act(async () => {
+      navigateRoute({ kind: 'daily', date: target }, { focusEditor: true })
+    })
+
+    const expected = indexOfDate(dayWindow, target) * ESTIMATED_DAY_HEIGHT
+    expect(scrollTops.length).toBeGreaterThan(0)
+    expect(scrollTops[0]).toBe(expected)
+    await waitFor(() => expect(editorProbe.focusCalls).toBeGreaterThan(0))
+    expect(editorProbe.selectionCalls).toContain('end')
     view.unmount()
   })
 

--- a/apps/desktop/src/components/daily-stream.tsx
+++ b/apps/desktop/src/components/daily-stream.tsx
@@ -34,6 +34,35 @@ const CONTENT_GUTTER = 'reflect-content-gutter'
 /** The size guess virtua uses for a row it has not measured yet. */
 export const ESTIMATED_DAY_HEIGHT = 220
 
+type PendingAutoFocus = {
+  readonly date: string
+  readonly selection: 'start' | 'end'
+}
+
+interface PendingAutoFocusState {
+  readonly arrivalSeq: number
+  readonly entryId: number
+  readonly request: PendingAutoFocus | null
+}
+
+function autoFocusRequestForArrival({
+  targetDate,
+  arrivalFocusEditor,
+  restored,
+}: {
+  targetDate: string
+  arrivalFocusEditor: boolean
+  restored: number | null
+}): PendingAutoFocus | null {
+  if (restored !== null && !arrivalFocusEditor) {
+    return null
+  }
+  return {
+    date: targetDate,
+    selection: arrivalFocusEditor ? 'end' : 'start',
+  }
+}
+
 /**
  * The daily stream (Plan 06b): a virtualized chronological run of days — past
  * above, future below — where **every day is a virtual note**. Each visible row
@@ -44,7 +73,7 @@ export const ESTIMATED_DAY_HEIGHT = 220
  * bookkeeping; index↔date is pure offset math.
  */
 export function DailyStream({ target }: DailyStreamProps): ReactElement {
-  const { arrivalSeq, entryId, saveScrollState, savedScroll } = useRouter()
+  const { arrivalSeq, arrivalFocusEditor, entryId, saveScrollState, savedScroll } = useRouter()
   const virtualizerRef = useRef<VirtualizerHandle>(null)
   // The window anchors at today-on-mount and stays stable for the view's life.
   // (`dayWindow`, not `window` — shadowing the DOM global here was a footgun.)
@@ -67,12 +96,36 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
 
   // Only the day navigated to receives focus, once per navigation — a row that
   // scrolls offscreen and back must not steal focus from wherever the user is.
-  // The flag is consumed when the editor actually mounts and focuses (not at
-  // render time), so a virtualizer re-render before the lazy load completes
-  // can't drop the focus.
-  const focusPending = useRef<string | null>(null)
+  // Kept in state rather than a ref so a same-row arrival still re-renders the
+  // mounted NotePane with a fresh autofocus prop.
+  const [pendingAutoFocusState, setPendingAutoFocusState] = useState<PendingAutoFocusState>(() => ({
+    arrivalSeq,
+    entryId,
+    request: autoFocusRequestForArrival({
+      targetDate,
+      arrivalFocusEditor,
+      restored: savedScroll(),
+    }),
+  }))
+  if (
+    pendingAutoFocusState.arrivalSeq !== arrivalSeq ||
+    pendingAutoFocusState.entryId !== entryId
+  ) {
+    setPendingAutoFocusState({
+      arrivalSeq,
+      entryId,
+      request: autoFocusRequestForArrival({
+        targetDate,
+        arrivalFocusEditor,
+        restored: savedScroll(),
+      }),
+    })
+  }
+  const pendingAutoFocus = pendingAutoFocusState.request
   const consumeFocus = useCallback(() => {
-    focusPending.current = null
+    setPendingAutoFocusState((current) =>
+      current.request === null ? current : { ...current, request: null },
+    )
   }, [])
 
   // Report the day the user is editing to the context sidebar: the route stays
@@ -85,7 +138,7 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
   // is virtualized, so the neighbor day's editor may not be mounted: we keep a
   // registry of mounted day handles plus a single pending-focus slot that
   // carries the target caret position, applied when the neighbor row mounts and
-  // registers. This is independent of the `⌘D` autofocus path (`focusPending`).
+  // registers. This is independent of the Daily-arrival autofocus path.
   const dayHandlesRef = useRef(new Map<string, NoteEditorHandle>())
   const pendingFocusRef = useRef<{ date: string; position: 'start' | 'end' } | null>(null)
 
@@ -139,7 +192,10 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
   // pressed while already on today — the router clears the entry's saved
   // offset for that case; `entryId` covers back/forward between entries whose
   // routes resolve to the same day). A back/forward-restored entry carries its
-  // offset; a fresh navigation anchors to the target day.
+  // offset; a fresh navigation anchors to the target day. Focus arrivals are
+  // append/capture gestures (⌘D, Daily sidebar row, mobile Daily double-tap):
+  // they focus the target editor at the document end so meowdown reveals the
+  // caret after the row itself is anchored.
   //
   // A layout effect, not a passive one: virtua applies an imperative scroll in a
   // pre-paint microtask, so anchoring here pins the target day to the viewport
@@ -147,21 +203,19 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
   // five-year window and then lurching down.
   useLayoutEffect(() => {
     const restored = savedScroll()
-    if (restored !== null) {
+    if (restored !== null && !arrivalFocusEditor) {
       // A restored arrival also cancels any focus still pending from a prior
       // navigation the user backed out of before that day's editor mounted (both
       // the ⌘D autofocus and a queued cross-note boundary focus). The day would
       // otherwise steal focus when its row scrolls into view.
-      focusPending.current = null
       pendingFocusRef.current = null
       virtualizerRef.current?.scrollTo(restored)
       return
     }
     const target = targetDateRef.current
     pendingFocusRef.current = null
-    focusPending.current = target
     virtualizerRef.current?.scrollToIndex(indexOfDate(dayWindow, target), { align: 'start' })
-  }, [arrivalSeq, entryId, dayWindow, savedScroll])
+  }, [arrivalSeq, arrivalFocusEditor, entryId, dayWindow, savedScroll])
 
   return (
     <div
@@ -173,7 +227,9 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
       // caret later. Typing is deliberately not a cancel: ⌘D-then-type should
       // still land focus in today once its editor mounts.
       onPointerDownCapture={() => {
-        focusPending.current = null
+        setPendingAutoFocusState((current) =>
+          current.request === null ? current : { ...current, request: null },
+        )
         pendingFocusRef.current = null
       }}
     >
@@ -191,7 +247,8 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
           // collapses to a short row), while today and future days reserve
           // most of a viewport of writing room. ISO dates compare lexically.
           const isPast = date < today
-          const autoFocus = focusPending.current === date
+          const pendingFocus = pendingAutoFocus
+          const autoFocus = pendingFocus?.date === date
           return (
             <section
               key={date}
@@ -215,6 +272,7 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
                 onExitBoundary={handleExitBoundary}
                 lazy
                 autoFocus={autoFocus}
+                autoFocusSelection={pendingFocus?.selection ?? 'start'}
                 onAutoFocused={consumeFocus}
                 gutterClassName={CONTENT_GUTTER}
                 editorClassName={isPast ? 'min-h-[100px]' : 'min-h-[60vh]'}

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -160,14 +160,14 @@ function renderSidebar(overrides?: Partial<CommandContext>, initialRoute?: Route
 }
 
 describe('Sidebar', () => {
-  it('nav rows navigate, with Daily notes restoring its surface scroll', async () => {
+  it('nav rows navigate, with Daily notes focusing the editor for capture', async () => {
     const { view, navigate } = renderSidebar()
 
     await userEvent.click(view.getByRole('button', { name: /daily notes/i }))
     await waitFor(() =>
       expect(navigate).toHaveBeenCalledWith(
         { kind: 'today' },
-        { restoreSurfaceScroll: true },
+        { focusEditor: true },
       ),
     )
 

--- a/apps/desktop/src/components/sidebar/sidebar.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.tsx
@@ -29,10 +29,8 @@ interface SidebarProps {
  * The workspace sidebar, in the original app's shape: history arrows top
  * right, search, primary navigation with hover-revealed shortcut keycaps, the
  * Pinned shelf, and the graph switcher footer. Most nav rows run registered
- * commands so a binding and its behavior stay one definition; the Daily notes
- * row restores the stream's surface scroll when clicked from another surface
- * (the router re-anchors it, like `Mod-D`, when the stream is already
- * showing). (Sidebar collapse stays on `Mod-\` via the command registry.)
+ * commands so a binding and its behavior stay one definition. (Sidebar
+ * collapse stays on `Mod-\` via the command registry.)
  */
 export function Sidebar({ graph, context }: SidebarProps): ReactElement {
   const { route } = useRouter()
@@ -73,9 +71,7 @@ export function Sidebar({ graph, context }: SidebarProps): ReactElement {
             label="Daily notes"
             binding={keybindingFor('nav.today') ?? undefined}
             active={(route.kind === 'today' || route.kind === 'daily') && !hasActivePinnedNote}
-            onClick={() =>
-              context.navigate({ kind: 'today' }, { restoreSurfaceScroll: true })
-            }
+            onClick={() => void runCommand('nav.today', context)}
           />
           <SidebarItem
             icon={

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { EmbedStatus, NoteRow, PinnedNote } from '@reflect/core'
 import { notePathForRoute, type Route } from '@/routing/route'
+import type { NavigateOptions } from '@/routing/router'
 import { resetOperations } from '@/lib/operations'
 import type { CommandContext } from './types'
 
@@ -58,9 +59,13 @@ function command(id: string) {
 
 function fakeContext(overrides?: Partial<CommandContext>) {
   const navigated: Route[] = []
+  const navigations: Array<{ route: Route; options: NavigateOptions | undefined }> = []
   const route: () => Route = overrides?.route ?? (() => ({ kind: 'today' }))
   const context: CommandContext = {
-    navigate: (target) => void navigated.push(target),
+    navigate: (target, options) => {
+      navigated.push(target)
+      navigations.push({ route: target, options })
+    },
     route,
     // Mirror the real context: note-scoped commands resolve their target from
     // the route (the focused-day branch is exercised in app-shortcuts).
@@ -80,7 +85,7 @@ function fakeContext(overrides?: Partial<CommandContext>) {
     enableSemanticSearch: vi.fn(),
     ...overrides,
   }
-  return { context, navigated }
+  return { context, navigated, navigations }
 }
 
 function noteRow(isPrivate: boolean): NoteRow {
@@ -122,9 +127,10 @@ describe('keybindingFor', () => {
 
 describe('app commands', () => {
   it('nav.today, history, palette, theme, and sidebar commands hit their capabilities', async () => {
-    const { context, navigated } = fakeContext()
+    const { context, navigated, navigations } = fakeContext()
     await command('nav.today').run(context)
     expect(navigated).toEqual([{ kind: 'today' }])
+    expect(navigations).toEqual([{ route: { kind: 'today' }, options: { focusEditor: true } }])
     await command('history.back').run(context)
     expect(context.back).toHaveBeenCalled()
     await command('history.forward').run(context)

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -54,7 +54,7 @@ const APP_COMMANDS: AppCommand[] = [
     title: 'Go to today',
     keywords: ['daily', 'now'],
     keybinding: 'Mod-d',
-    run: (context) => context.navigate({ kind: 'today' }),
+    run: (context) => context.navigate({ kind: 'today' }, { focusEditor: true }),
   },
   {
     id: 'nav.allNotes',

--- a/apps/desktop/src/routing/app-shortcuts.test.tsx
+++ b/apps/desktop/src/routing/app-shortcuts.test.tsx
@@ -102,9 +102,11 @@ describe('app shortcuts', () => {
 
     act(() => press('d'))
     expect(result.current.router.route).toEqual({ kind: 'today' })
+    expect(result.current.router.arrivalFocusEditor).toBe(true)
 
     act(() => press('['))
     expect(result.current.router.route.kind).toBe('note')
+    expect(result.current.router.arrivalFocusEditor).toBe(false)
 
     act(() => press(']'))
     expect(result.current.router.route).toEqual({ kind: 'today' })

--- a/apps/desktop/src/routing/router.tsx
+++ b/apps/desktop/src/routing/router.tsx
@@ -42,11 +42,11 @@ interface RouterValue {
   /**
    * True when the latest arrival asked the destination to focus its editor
    * (`navigate(route, { focusEditor: true })`). Only explicit write gestures
-   * request it — today just the mobile Daily-tab double-tap — while note
-   * navigations (wiki links, backlinks, back/forward) stay calm so the
-   * keyboard never rises mid-arrival. One-shot by construction: the next
-   * navigate overwrites it and history moves clear it, so it can never leak
-   * onto a later, unrelated arrival.
+   * request it — Daily capture via ⌘D/sidebar and the mobile Daily-tab
+   * double-tap — while note navigations (wiki links, backlinks, back/forward)
+   * stay calm so the keyboard never rises mid-arrival. One-shot by
+   * construction: the next navigate overwrites it and history moves clear it,
+   * so it can never leak onto a later, unrelated arrival.
    */
   arrivalFocusEditor: boolean
   navigate: (route: Route, options?: NavigateOptions) => void
@@ -87,9 +87,8 @@ export interface NavigateOptions {
   restoreSurfaceScroll?: boolean
   /**
    * Ask the destination to focus its editor on arrival — see
-   * {@link RouterValue.arrivalFocusEditor}. Consumed by the mobile daily
-   * surface (Daily-tab double-tap); desktop's note route autofocuses every
-   * arrival and ignores it.
+   * {@link RouterValue.arrivalFocusEditor}. Consumed by daily surfaces to
+   * distinguish append/capture arrivals from ordinary navigation.
    */
   focusEditor?: boolean
 }


### PR DESCRIPTION
## Problem

Pressing `Command-D` or clicking the desktop sidebar's Daily notes row was treated like an ordinary daily-stream arrival: the stream anchored to today, but the editor autofocus used its default start selection. That put the caret at the beginning of the daily note, which is backwards for a capture gesture where the user is usually appending to today.

The iOS Daily double-tap path already uses an explicit `focusEditor` arrival and selects the note end. Desktop Daily capture needed to share that append semantics without making ordinary daily links/history restores unexpectedly raise focus.

## Before -> After

| Path | Before | After |
| --- | --- | --- |
| `Command-D` | Opens today and focuses the daily editor at the start | Opens today and focuses the daily editor at the end |
| Sidebar Daily notes row | Used a sidebar-only surface-scroll restore path | Runs the same `nav.today` command as the shortcut and focuses at the end |
| Restored daily history entries | Restore saved scroll and cancel stale pending focus | Same behavior |
| Mobile Daily double-tap | Already selected the end | Still selects the end |

## Changes

1. `nav.today` now calls `navigate({ kind: 'today' }, { focusEditor: true })`, making `Command-D` an explicit append/capture arrival.
2. The sidebar Daily notes row now runs `nav.today` instead of maintaining a separate `restoreSurfaceScroll` navigation path.
3. `DailyStream` carries pending autofocus as state keyed by `arrivalSeq`/`entryId`, so same-row arrivals still re-render the mounted `NotePane`; focused arrivals pass `autoFocusSelection="end"`, while non-focused arrivals keep the existing start-selection behavior.
4. Router docs now describe `focusEditor` as the shared Daily capture intent across desktop and mobile.

## Tests

- Added daily-stream coverage for focused daily arrivals selecting the editor end after anchoring.
- Updated command/sidebar/app-shortcut tests to assert the `focusEditor` intent.
- Re-ran existing mobile Daily shell coverage to ensure the iOS double-tap path still focuses the end.

## Verification

- `pnpm --filter @reflect/desktop exec vitest run src/components/daily-stream.test.tsx` — passed
- `pnpm --filter @reflect/desktop exec vitest run src/lib/commands/app-commands.test.ts src/components/sidebar/sidebar.test.tsx src/routing/app-shortcuts.test.tsx src/mobile/mobile-screen.test.tsx` — passed
- `pnpm check` — passed

## Risk / Rollout

No migrations or data-shape changes. The main behavior change is intentional: the desktop Daily sidebar row now behaves like `Command-D` capture and anchors/focuses today instead of restoring the previous daily surface scroll when returning from another surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes primary navigation and editor focus/scroll behavior for the daily stream and sidebar; intentional UX shift away from surface-scroll restore on Daily sidebar clicks.
> 
> **Overview**
> Desktop **Daily capture** (`⌘D` and the sidebar Daily row) now navigates with `{ focusEditor: true }`, aligning with mobile double-tap append semantics instead of autofocusing at the **start** of the note.
> 
> **`nav.today`** passes `focusEditor: true`; the sidebar **Daily notes** row runs that command instead of a separate `restoreSurfaceScroll` navigation, so returning from another surface re-anchors/focuses like a capture gesture rather than only restoring stream scroll.
> 
> **`DailyStream`** tracks pending editor autofocus in **state** keyed by `arrivalSeq` / `entryId` (so repeat arrivals on the same day still refresh `NotePane`), reads **`arrivalFocusEditor`** from the router, and passes **`autoFocusSelection`** (`end` for capture, `start` otherwise). History restores without `focusEditor` still restore scroll and skip unwanted focus; focus arrivals still re-anchor the stream when a saved offset exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03f542b2574c9744a46219e5f195598c51c053aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->