### PR TITLE
Fix JIS bracket history shortcuts

### DIFF
--- a/apps/desktop/src/routing/app-shortcuts.test.tsx
+++ b/apps/desktop/src/routing/app-shortcuts.test.tsx
@@ -144,6 +144,23 @@ describe('app shortcuts', () => {
     }
   })
 
+  it('matches bracket history shortcuts by produced key on non-US layouts', () => {
+    const { result } = shortcutsHook()
+    act(() => press('n'))
+    const opened = result.current.router.route
+    act(() => press('d'))
+    expect(result.current.router.route).toEqual({ kind: 'today' })
+
+    // On JIS keyboards the key labeled `[` can report a physical BracketRight
+    // code. The user-facing shortcut is character-based, so event.key wins.
+    act(() => press('[', { code: 'BracketRight' }))
+    expect(result.current.router.route).toEqual(opened)
+
+    act(() => press(']', { code: 'BracketLeft' }))
+    expect(result.current.router.route).toEqual({ kind: 'today' })
+    expect(result.current.router.canForward).toBe(false)
+  })
+
   it('⌘K opens the palette', () => {
     const { result } = shortcutsHook()
     expect(result.current.palette.open).toBe(false)

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -50,6 +50,9 @@ function isModKey(event: KeyboardEvent): boolean {
 }
 
 function bindingKeyFor(event: KeyboardEvent): string {
+  if (!event.altKey && event.key.length === 1) {
+    return event.key.toLowerCase()
+  }
   const fromCode = CODE_TO_BINDING_KEY[event.code]
   if (fromCode !== undefined) {
     return fromCode


### PR DESCRIPTION
## Problem
The View menu advertises Back/Forward as Cmd+[ and Cmd+], but the app-level shortcut normalizer treated bracket bindings by physical `KeyboardEvent.code`. On JIS keyboards the key that produces `[` can report `BracketRight`, so the shortcut could miss or map to the wrong history command.

## Changes
1. Prefer the produced printable `event.key` for non-Alt app shortcuts before falling back to physical bracket codes for consumed/editor events.
2. Add a regression test covering mismatched bracket key/code pairs like a JIS layout while preserving the editor-consumed fallback.

## Verification
- `pnpm --filter @reflect/desktop test -- src/routing/app-shortcuts.test.tsx` (passed; Vitest reported 191 files / 1675 tests)
- `pnpm check` (passed)

## Risk / Rollout
Low risk; this only changes app shortcut normalization. The existing Alt shortcut path and physical-code fallback for `Unidentified` editor events remain in place.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only app-level shortcut normalization changes; Alt handling and physical-code fallback for unidentified editor keys remain.
> 
> **Overview**
> **Cmd+[ / Cmd+]** back/forward were resolved from physical `KeyboardEvent.code` first, so on JIS layouts the key that prints `[` or `]` could map to the wrong bracket binding.
> 
> `bindingKeyFor` in `app-shortcuts.ts` now uses the produced single-character `event.key` (lowercased) when Alt is not held, before the `BracketLeft`/`BracketRight` code fallback. Alt chords and the existing `Unidentified` + code path for editor-consumed history keys are unchanged.
> 
> A regression test simulates mismatched bracket key/code pairs (JIS-style) and asserts history navigation still follows the printed characters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55e0aadfe63f9138ccfb6a7fddad0c6781b08ae5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->