### PR TITLE
fix(macos): restore system window-management shortcuts by assigning NSApp menu roles after install

### DIFF
--- a/apps/desktop/src/lib/native-menu/menu.ts
+++ b/apps/desktop/src/lib/native-menu/menu.ts
@@ -175,20 +175,31 @@ export async function installNativeMenu(): Promise<void> {
   if (!isMacosDesktop()) {
     return
   }
+  const layouts = appMenuLayout()
   const submenus = await Promise.all(
-    appMenuLayout().map(async (layout) => {
-      const submenu = await Submenu.new({
+    layouts.map((layout) =>
+      Submenu.new({
         text: layout.text,
         items: layout.entries.map(entryOptions),
-      })
-      if (layout.nsAppRole === 'windows') {
-        await submenu.setAsWindowsMenuForNSApp()
-      } else if (layout.nsAppRole === 'help') {
-        await submenu.setAsHelpMenuForNSApp()
-      }
-      return submenu
-    }),
+      }),
+    ),
   )
   const menu = await Menu.new({ items: submenus })
   await menu.setAsAppMenu()
+  // NSApp roles must be assigned after setAsAppMenu: attaching the menu
+  // clones each submenu's NSMenu, and muda resolves the role against the
+  // instance inside the installed main menu — assigned earlier, the role
+  // silently no-ops and macOS never adds its automatic items (the window
+  // list and Move & Resize/tiling with their system shortcuts; Help search).
+  for (const [index, layout] of layouts.entries()) {
+    const submenu = submenus[index]
+    if (!submenu) {
+      continue
+    }
+    if (layout.nsAppRole === 'windows') {
+      await submenu.setAsWindowsMenuForNSApp()
+    } else if (layout.nsAppRole === 'help') {
+      await submenu.setAsHelpMenuForNSApp()
+    }
+  }
 }


### PR DESCRIPTION
## Problem

On macOS, the system window-management keyboard shortcuts (Move & Resize, Fill, Centre, tiling) stopped working in Reflect, and the Window menu was missing the automatic entries AppKit gives every app (the open-window list, the Move & Resize submenu). The Help menu was also missing the system Search field.

Root cause: `installNativeMenu` called `setAsWindowsMenuForNSApp()` / `setAsHelpMenuForNSApp()` on each submenu **before** `menu.setAsAppMenu()`. When muda attaches a menu to NSApp it clones each submenu's `NSMenu`, and since muda 0.17.2 (tauri-apps/muda#335, included in our 0.19.3) the role setters resolve against the instance inside the *installed* main menu — called earlier, they silently no-op. So macOS never recognized our Window/Help menus and never injected its automatic items; the tiling shortcuts are key equivalents of those injected items, which is why they died with the menu.

## Change

Reorder `installNativeMenu` (`apps/desktop/src/lib/native-menu/menu.ts`): build the submenus, install the menu with `setAsAppMenu()`, **then** assign the `windows`/`help` NSApp roles. A comment documents the ordering constraint. The menu layout itself is unchanged.

## Verification

- `pnpm check` (typecheck + oxlint + eslint) passes; `menu.test.ts` (3 tests) passes.
- Root cause verified against muda 0.19.3 source: `set_as_windows_menu_for_nsapp` returns early when the submenu can't be resolved inside `NSApp.mainMenu`.
- **Owed:** a manual pass in the built app — open the Window menu and confirm the window list + Move & Resize entries appear and the system tiling shortcuts work, and confirm the Help menu gains the Search field.

## Risk

Low: a pure reordering inside the macOS-only menu install path, executed once at startup. If a role assignment still failed, behavior degrades to exactly what ships today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> macOS-only startup reorder in the native menu install path; failure mode matches prior broken behavior.
> 
> **Overview**
> Fixes macOS **Window** and **Help** menus not getting AppKit’s automatic items (open-window list, Move & Resize/tiling shortcuts, Help search) by changing when NSApp roles are applied in `installNativeMenu`.
> 
> **Before:** `setAsWindowsMenuForNSApp()` / `setAsHelpMenuForNSApp()` ran while building each submenu, then `menu.setAsAppMenu()` installed the menu. With current muda behavior, role setters must target the submenu instance inside the installed main menu; calling them earlier silently no-ops.
> 
> **After:** Submenus are created without role assignment, `setAsAppMenu()` runs, then a loop assigns `windows` / `help` roles from `appMenuLayout()`. An inline comment documents this ordering constraint. Menu layout and entries are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a754eb2025707746ea0cfef0733878b462cc9fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->