### PR TITLE
Derive v1 subject aliases from // note titles

### DIFF
--- a/apps/cli/src/note_file.rs
+++ b/apps/cli/src/note_file.rs
@@ -302,8 +302,14 @@ mod tests {
             vec!["Charlotte MacCaw", "Mum"]
         );
         assert_eq!(subject_aliases("Charlotte//Mum"), vec!["Charlotte", "Mum"]);
-        assert_eq!(subject_aliases("Charlotte MacCaw // "), vec!["Charlotte MacCaw"]);
-        assert_eq!(subject_aliases("Mum //  // MUM // Mother"), vec!["Mum", "Mother"]);
+        assert_eq!(
+            subject_aliases("Charlotte MacCaw // "),
+            vec!["Charlotte MacCaw"]
+        );
+        assert_eq!(
+            subject_aliases("Mum //  // MUM // Mother"),
+            vec!["Mum", "Mother"]
+        );
         assert_eq!(subject_aliases("Charlotte MacCaw"), Vec::<String>::new());
         assert_eq!(subject_aliases("https://reflect.app"), Vec::<String>::new());
         assert_eq!(subject_aliases("a///b"), Vec::<String>::new());

--- a/apps/cli/src/note_file.rs
+++ b/apps/cli/src/note_file.rs
@@ -11,6 +11,7 @@ use pulldown_cmark::{Event, HeadingLevel, Parser, Tag};
 
 use crate::error::CliError;
 use crate::frontmatter::{parse_frontmatter, split_frontmatter, Frontmatter};
+use crate::keys::fold_key;
 use crate::paths::{date_from_daily_path, NOTE_DIRS};
 
 /// A note's derived metadata, as the TS indexer would compute it.
@@ -84,6 +85,53 @@ fn first_h1(body: &str) -> Option<String> {
     None
 }
 
+/// Split positions of v1 subject-alias separators: exactly two slashes, not
+/// preceded by `:` or `/` and not followed by `/`, so URL schemes
+/// (`https://…`) and slash runs never split. Mirrors the TS
+/// `SUBJECT_ALIAS_SEPARATOR` regex (`subject-aliases.ts`); the bytes checked
+/// are ASCII, so the indices are always UTF-8 char boundaries.
+fn split_subject_segments(title: &str) -> Vec<&str> {
+    let bytes = title.as_bytes();
+    let mut segments = Vec::new();
+    let mut start = 0;
+    let mut index = 0;
+    while index + 1 < bytes.len() {
+        let separator = bytes[index] == b'/'
+            && bytes[index + 1] == b'/'
+            && (index == 0 || (bytes[index - 1] != b':' && bytes[index - 1] != b'/'))
+            && bytes.get(index + 2) != Some(&b'/');
+        if separator {
+            segments.push(&title[start..index]);
+            start = index + 2;
+            index += 2;
+        } else {
+            index += 1;
+        }
+    }
+    segments.push(&title[start..]);
+    segments
+}
+
+/// The TS `subjectAliases` (`subject-aliases.ts`): Reflect V1's `//` title
+/// convention (`Charlotte MacCaw // Mum`) derived as aliases — each segment
+/// trimmed, empties dropped, deduplicated by fold key, first segment included.
+fn subject_aliases(title: &str) -> Vec<String> {
+    let segments = split_subject_segments(title);
+    if segments.len() < 2 {
+        return Vec::new();
+    }
+    let mut seen = std::collections::HashSet::new();
+    let mut aliases = Vec::new();
+    for segment in segments {
+        let alias = segment.trim();
+        if alias.is_empty() || !seen.insert(fold_key(alias)) {
+            continue;
+        }
+        aliases.push(alias.to_string());
+    }
+    aliases
+}
+
 /// The TS `deriveTitle` chain: frontmatter `title` → first H1 → daily date →
 /// filename.
 fn derive_title(rel_path: &str, frontmatter: &Frontmatter, body: &str) -> String {
@@ -102,15 +150,26 @@ fn derive_title(rel_path: &str, frontmatter: &Frontmatter, body: &str) -> String
     basename(rel_path).to_string()
 }
 
-/// Derive a note's metadata from its source, as the TS indexer would.
+/// Derive a note's metadata from its source, as the TS indexer would:
+/// `aliases:` frontmatter verbatim, then the v1 subject aliases derived from
+/// the title, skipping segments a frontmatter alias already claims (the TS
+/// `noteAliases`, `indexed-note.ts`).
 pub fn parse_note_meta(rel_path: &str, source: &str) -> NoteMeta {
     let split = split_frontmatter(source);
     let frontmatter = parse_frontmatter(split.raw);
     let title = derive_title(rel_path, &frontmatter, split.body);
+    let mut aliases = frontmatter.aliases;
+    let mut claimed: std::collections::HashSet<String> =
+        aliases.iter().map(|alias| fold_key(alias)).collect();
+    for alias in subject_aliases(&title) {
+        if claimed.insert(fold_key(&alias)) {
+            aliases.push(alias);
+        }
+    }
     NoteMeta {
         id: frontmatter.id,
         title,
-        aliases: frontmatter.aliases,
+        aliases,
         private: frontmatter.private,
     }
 }
@@ -232,5 +291,37 @@ mod tests {
     fn empty_h1_is_skipped_for_a_later_one() {
         let meta = parse_note_meta("notes/a.md", "#\n\n# Real Title\n");
         assert_eq!(meta.title, "Real Title");
+    }
+
+    /// Parity with `subjectAliases` (`subject-aliases.ts`): v1 `//` titles
+    /// derive every trimmed segment, first included, deduplicated by fold key.
+    #[test]
+    fn subject_aliases_match_the_ts_derivation() {
+        assert_eq!(
+            subject_aliases("Charlotte MacCaw // Mum"),
+            vec!["Charlotte MacCaw", "Mum"]
+        );
+        assert_eq!(subject_aliases("Charlotte//Mum"), vec!["Charlotte", "Mum"]);
+        assert_eq!(subject_aliases("Charlotte MacCaw // "), vec!["Charlotte MacCaw"]);
+        assert_eq!(subject_aliases("Mum //  // MUM // Mother"), vec!["Mum", "Mother"]);
+        assert_eq!(subject_aliases("Charlotte MacCaw"), Vec::<String>::new());
+        assert_eq!(subject_aliases("https://reflect.app"), Vec::<String>::new());
+        assert_eq!(subject_aliases("a///b"), Vec::<String>::new());
+        assert_eq!(subject_aliases("file:///etc/hosts"), Vec::<String>::new());
+        assert_eq!(
+            subject_aliases("Reflect // https://reflect.app"),
+            vec!["Reflect", "https://reflect.app"]
+        );
+    }
+
+    /// Parity with `noteAliases` (`indexed-note.ts`): frontmatter aliases stay
+    /// verbatim and first; derived segments they already claim are skipped.
+    #[test]
+    fn subject_aliases_merge_after_frontmatter_aliases() {
+        let meta = parse_note_meta(
+            "notes/charlotte.md",
+            "---\naliases: [MUM]\n---\n# Charlotte MacCaw // Mum\n",
+        );
+        assert_eq!(meta.aliases, vec!["MUM", "Charlotte MacCaw"]);
     }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -106,7 +106,8 @@ Resolves `<note>` and prints the raw markdown. Resolution order:
 2. An explicit path (graph-relative like `notes/foo.md`, or absolute inside
    the graph).
 3. A title match (case-insensitive, trimmed).
-4. An alias match (from `aliases:` frontmatter).
+4. An alias match (from `aliases:` frontmatter, or a v1 subject-alias
+   segment of a `//` title like `Charlotte MacCaw // Mum`).
 
 Works with or without the index — when the index is missing, titles/aliases
 are derived by scanning the files. Ambiguous matches resolve to the first path

--- a/docs/deep-links.md
+++ b/docs/deep-links.md
@@ -23,7 +23,8 @@ reflect://tasks                     the tasks view
 2. a calendar-valid ISO date → that daily note
 3. an explicit graph-relative path (`notes/foo.md`)
 4. a title match (case-folded)
-5. an alias match (`aliases:` frontmatter)
+5. an alias match (`aliases:` frontmatter, or a v1 subject-alias segment of
+   a `//` title like `Charlotte MacCaw // Mum`)
 
 Ambiguity resolves to the first path alphabetically — the CLI's rule. Links
 resolve **in the open graph**; there is no cross-graph addressing.

--- a/fixtures/parity/expected.json
+++ b/fixtures/parity/expected.json
@@ -280,6 +280,47 @@
       "private": false,
       "fileHash": "8316729753b63c608eeb3536369bb26ea37bb3ae519b18f58c85966a8452ac8b"
     },
+    "notes/subject-alias-merged.md": {
+      "id": null,
+      "title": "Charlotte MacCaw // Mum",
+      "titleKey": "charlotte maccaw // mum",
+      "aliases": [
+        "MUM",
+        "Mummy",
+        "Charlotte MacCaw"
+      ],
+      "aliasKeys": [
+        "mum",
+        "mummy",
+        "charlotte maccaw"
+      ],
+      "private": false,
+      "fileHash": "6e89dc425f9d10e8dd246644303d81d90124859c5d8d3d8dfea8fe6ddd1ac8e6"
+    },
+    "notes/subject-alias-url.md": {
+      "id": null,
+      "title": "https://reflect.app",
+      "titleKey": "https://reflect.app",
+      "aliases": [],
+      "aliasKeys": [],
+      "private": false,
+      "fileHash": "c7c8c9420c2dbecb56c5c2edafd835ac43043310f0786107430e543a7539f94f"
+    },
+    "notes/subject-alias.md": {
+      "id": null,
+      "title": "Charlotte MacCaw // Mum",
+      "titleKey": "charlotte maccaw // mum",
+      "aliases": [
+        "Charlotte MacCaw",
+        "Mum"
+      ],
+      "aliasKeys": [
+        "charlotte maccaw",
+        "mum"
+      ],
+      "private": false,
+      "fileHash": "67a57675ef27537774388b78f2b2df8a9cdc404db8fb59e03a25ddb440d6547e"
+    },
     "notes/unicode-title.md": {
       "id": null,
       "title": "Café ÉTÉ",

--- a/fixtures/parity/notes/subject-alias-merged.md
+++ b/fixtures/parity/notes/subject-alias-merged.md
@@ -1,0 +1,8 @@
+---
+aliases: [MUM, Mummy]
+---
+
+# Charlotte MacCaw // Mum
+
+Frontmatter aliases stay verbatim and first; a segment they already claim
+(case-insensitively) is not derived twice.

--- a/fixtures/parity/notes/subject-alias-url.md
+++ b/fixtures/parity/notes/subject-alias-url.md
@@ -1,0 +1,3 @@
+# https://reflect.app
+
+A URL scheme's `//` is not a subject-alias separator.

--- a/fixtures/parity/notes/subject-alias.md
+++ b/fixtures/parity/notes/subject-alias.md
@@ -1,0 +1,3 @@
+# Charlotte MacCaw // Mum
+
+A v1-style subject: every `//` segment must derive as an alias.

--- a/packages/core/src/indexing/indexed-note.test.ts
+++ b/packages/core/src/indexing/indexed-note.test.ts
@@ -3,8 +3,8 @@ import { gistBodyHash, parseNote } from '../markdown'
 import { buildIndexedNote, indexedNoteSchema, PROJECTION_VERSION } from './indexed-note'
 
 describe('buildIndexedNote', () => {
-  it('carries the projection version that backfills the note email rows', () => {
-    expect(PROJECTION_VERSION).toBe(13)
+  it('carries the projection version that backfills the derived subject-alias rows', () => {
+    expect(PROJECTION_VERSION).toBe(14)
   })
 
   it('flattens a parsed note into the index payload', () => {
@@ -44,6 +44,35 @@ describe('buildIndexedNote', () => {
       true,
     )
     expect(indexed.assets).toEqual(['assets/p.png'])
+  })
+
+  it('derives v1 subject aliases from a `//` title, after frontmatter aliases', () => {
+    const source = '---\naliases: [Mummy]\n---\n# Charlotte MacCaw // Mum\n\nHi.'
+    const indexed = buildIndexedNote(parseNote({ path: 'notes/charlotte.md', source }), {
+      fileHash: 'h',
+      mtime: 0,
+      source,
+    })
+    expect(indexed.title).toBe('Charlotte MacCaw // Mum')
+    expect(indexed.titleKey).toBe('charlotte maccaw // mum')
+    expect(indexed.aliases).toEqual([
+      { alias: 'Mummy', aliasKey: 'mummy' },
+      { alias: 'Charlotte MacCaw', aliasKey: 'charlotte maccaw' },
+      { alias: 'Mum', aliasKey: 'mum' },
+    ])
+  })
+
+  it('skips derived subject aliases a frontmatter alias already claims', () => {
+    const source = '---\naliases: [MUM]\n---\n# Charlotte MacCaw // Mum\n\nHi.'
+    const indexed = buildIndexedNote(parseNote({ path: 'notes/charlotte.md', source }), {
+      fileHash: 'h',
+      mtime: 0,
+      source,
+    })
+    expect(indexed.aliases).toEqual([
+      { alias: 'MUM', aliasKey: 'mum' },
+      { alias: 'Charlotte MacCaw', aliasKey: 'charlotte maccaw' },
+    ])
   })
 
   it('projects Email field bullets with folded keys, ignoring prose mentions', () => {

--- a/packages/core/src/indexing/indexed-note.ts
+++ b/packages/core/src/indexing/indexed-note.ts
@@ -11,6 +11,7 @@ import {
   normalizeWikiTarget,
   pinnedOrder,
   splitFrontmatter,
+  subjectAliases,
   type ParsedNote,
 } from '../markdown'
 import { previewSnippet } from './snippet'
@@ -59,8 +60,11 @@ import { previewSnippet } from './snippet'
  * 13 — `note_emails` projection (`- Email:` contact-field bullets): existing
  * person notes carry no email rows until reprojected, and attendee → note
  * resolution in the calendar flow needs them, so the bump backfills them.
+ * 14 — v1 subject aliases (`//` segments of the title) folded into the
+ * `aliases` projection: existing v1-style titles carry no derived alias rows
+ * until reprojected, so the bump backfills them.
  */
-export const PROJECTION_VERSION = 13
+export const PROJECTION_VERSION = 14
 
 export const indexedLinkSchema = z.object({
   kind: z.enum(['wiki', 'md']),
@@ -153,6 +157,29 @@ export const indexedNoteSchema = z.object({
 export type IndexedNote = z.infer<typeof indexedNoteSchema>
 
 /**
+ * The `aliases` projection: `aliases:` frontmatter verbatim, then the v1
+ * subject aliases derived from the title (`Charlotte MacCaw // Mum`), skipping
+ * segments a frontmatter alias already claims. The derived rows are index-only
+ * compatibility — the file's frontmatter is never rewritten to hold them.
+ */
+function noteAliases(parsed: ParsedNote): IndexedAlias[] {
+  const aliases: IndexedAlias[] = parsed.frontmatter.aliases.map((alias) => ({
+    alias,
+    aliasKey: foldKey(alias),
+  }))
+  const claimed = new Set(aliases.map((row) => row.aliasKey))
+  for (const alias of subjectAliases(parsed.title)) {
+    const aliasKey = foldKey(alias)
+    if (claimed.has(aliasKey)) {
+      continue
+    }
+    claimed.add(aliasKey)
+    aliases.push({ alias, aliasKey })
+  }
+  return aliases
+}
+
+/**
  * Flatten a parsed note into the index payload. `meta.source` is the raw
  * markdown the note was parsed from — conflict markers are detected on it
  * (not on the extracted plain text, which may reshape marker lines).
@@ -203,10 +230,7 @@ export function buildIndexedNote(
     preview: previewSnippet(parsed.text, parsed.title),
     links: [...wikiLinks, ...mdLinks],
     tags: parsed.tags.map((tag) => ({ tag, tagKey: foldTag(tag) })),
-    aliases: parsed.frontmatter.aliases.map((alias) => ({
-      alias,
-      aliasKey: foldKey(alias),
-    })),
+    aliases: noteAliases(parsed),
     emails: extractEmailFields(body).map((email) => ({ email, emailKey: foldEmail(email) })),
     assets: parsed.assets.map((asset) => asset.path),
     tasks: parsed.tasks.map((task) => ({

--- a/packages/core/src/indexing/resolve-target.ts
+++ b/packages/core/src/indexing/resolve-target.ts
@@ -16,7 +16,8 @@ import { db } from './db'
  *    exists yet (dailies are created lazily, same as in-app navigation);
  * 3. an explicit graph-relative path;
  * 4. a title match (case-folded like wiki-link resolution);
- * 5. an alias match (`aliases:` frontmatter, same folding).
+ * 5. an alias match (`aliases:` frontmatter or a derived v1 subject alias —
+ *    a `//` segment of the title — same folding).
  *
  * Ambiguity (two paths claiming one id after a sync fork, duplicate titles)
  * resolves to the first path alphabetically — the CLI's rule. Private notes

--- a/packages/core/src/markdown/index.ts
+++ b/packages/core/src/markdown/index.ts
@@ -63,6 +63,7 @@ export { extractEmailFields, foldEmail } from './email-fields'
 export { foldKey, foldTag } from './keys'
 export { gistBodyHash, gistFilename } from './gist'
 export { slugForTitle } from './slug'
+export { subjectAliases } from './subject-aliases'
 export {
   normalizeWikiTarget,
   resolved,

--- a/packages/core/src/markdown/subject-aliases.test.ts
+++ b/packages/core/src/markdown/subject-aliases.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { subjectAliases } from './subject-aliases'
+
+describe('subjectAliases', () => {
+  it('derives every segment of a v1 subject, first included', () => {
+    expect(subjectAliases('Charlotte MacCaw // Mum')).toEqual(['Charlotte MacCaw', 'Mum'])
+  })
+
+  it('handles more than two segments', () => {
+    expect(subjectAliases('Acme Inc // Acme // The A')).toEqual(['Acme Inc', 'Acme', 'The A'])
+  })
+
+  it('splits without surrounding spaces', () => {
+    expect(subjectAliases('Charlotte//Mum')).toEqual(['Charlotte', 'Mum'])
+  })
+
+  it('derives nothing from a plain title', () => {
+    expect(subjectAliases('Charlotte MacCaw')).toEqual([])
+  })
+
+  it('keeps the remaining segment of a trailing separator', () => {
+    expect(subjectAliases('Charlotte MacCaw // ')).toEqual(['Charlotte MacCaw'])
+  })
+
+  it('drops empty and duplicate segments (case-insensitively)', () => {
+    expect(subjectAliases('Mum //  // MUM // Mother')).toEqual(['Mum', 'Mother'])
+  })
+
+  it('never splits a URL scheme', () => {
+    expect(subjectAliases('https://reflect.app')).toEqual([])
+    expect(subjectAliases('Reflect // https://reflect.app')).toEqual([
+      'Reflect',
+      'https://reflect.app',
+    ])
+  })
+
+  it('never splits slash runs', () => {
+    expect(subjectAliases('a///b')).toEqual([])
+    expect(subjectAliases('file:///etc/hosts')).toEqual([])
+  })
+})

--- a/packages/core/src/markdown/subject-aliases.ts
+++ b/packages/core/src/markdown/subject-aliases.ts
@@ -1,0 +1,50 @@
+/**
+ * Reflect V1 subject aliases — the `//` convention inside note titles
+ * (`Charlotte MacCaw // Mum`), where every segment matches or is suggested
+ * like an alias (see docs/reflect-v1-overview.md, "Backlinks and Aliases").
+ *
+ * V2's canonical alias mechanism is `aliases:` frontmatter; this module is a
+ * derived compatibility layer for imported or v1-style-authored titles. The
+ * segments are computed at index time and land in the same `aliases`
+ * projection — nothing is migrated into frontmatter, and the title itself
+ * stays the literal `//` string.
+ *
+ * Mirrored by `subject_aliases` in the CLI (`apps/cli/src/note_file.rs`);
+ * the parity corpus (`fixtures/parity/`) keeps the two in lockstep.
+ */
+
+import { foldKey } from './keys'
+
+/**
+ * A `//` separator: exactly two slashes, not preceded by `:` or `/` and not
+ * followed by `/`, so URL schemes (`https://…`) and slash runs never split.
+ */
+const SUBJECT_ALIAS_SEPARATOR = /(?<![:/])\/\/(?!\/)/
+
+/**
+ * The v1 subject aliases derived from `title`, in title order: each `//`
+ * segment, trimmed, empty segments dropped, deduplicated by {@link foldKey}.
+ * A title with no separator has none. The first segment is included —
+ * `[[Charlotte MacCaw]]` must resolve to `Charlotte MacCaw // Mum` too.
+ */
+export function subjectAliases(title: string): string[] {
+  const segments = title.split(SUBJECT_ALIAS_SEPARATOR)
+  if (segments.length < 2) {
+    return []
+  }
+  const seen = new Set<string>()
+  const aliases: string[] = []
+  for (const segment of segments) {
+    const alias = segment.trim()
+    if (alias === '') {
+      continue
+    }
+    const key = foldKey(alias)
+    if (seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    aliases.push(alias)
+  }
+  return aliases
+}


### PR DESCRIPTION
## Problem

Reflect V1 has a small but load-bearing convention: aliases live inline in the note subject, split by `//`. A note titled `Charlotte MacCaw // Mum` matches or is suggested by either name. V2's canonical alias mechanism is `aliases:` frontmatter, so imported or newly authored v1-style titles were treated as one literal string — `[[Mum]]` did not resolve to `# Charlotte MacCaw // Mum`, backlinks written as `[[Mum]]` never attached to the note, and `[[` autocomplete could not offer the shorthand.

This is deliberately a **derived compatibility layer**: no notes are migrated into frontmatter, no new alias table shape is introduced, and files are never rewritten.

## Before → After

| Given a note titled `Charlotte MacCaw // Mum` | Before | After |
| --- | --- | --- |
| `[[Mum]]` / `[[Charlotte MacCaw]]` | unresolved | resolve to the note |
| Backlinks panel for the note | misses `[[Mum]]` mentions | includes them |
| `[[mu` autocomplete | no match | offers `Mum → Charlotte MacCaw // Mum` |
| `reflect show Mum`, `reflect://note/Mum` | not found | print/open the note |
| The note's title and file on disk | literal `//` string | unchanged (still literal) |

## Changes

1. **`subjectAliases(title)`** (`packages/core/src/markdown/subject-aliases.ts`): pure v1 derivation — split the title on `//`, trim, drop empties, dedupe by `foldKey`, first segment included. A separator is exactly two slashes not preceded by `:` or `/` and not followed by `/`, so URL titles (`https://reflect.app`) and slash runs never split.
2. **`aliases` projection** (`packages/core/src/indexing/indexed-note.ts`): `noteAliases` appends the derived segments after `aliases:` frontmatter (frontmatter stays verbatim and first; segments it already claims are skipped). Because the `note_keys` SQL view already unions `aliases` into wiki resolution, backlinks, deep links, and `[[` autocomplete, everything downstream lights up with **no schema change**. `PROJECTION_VERSION` bumps to 14 so existing graphs reproject and backfill the derived rows.
3. **Rust CLI mirror** (`apps/cli/src/note_file.rs`): `subject_aliases` + the same merge in `parse_note_meta`, so the index-free file-scan path of `reflect show <note>` resolves subject aliases identically.
4. **Parity corpus** (`fixtures/parity/`): three new fixtures (plain `//` subject, frontmatter-overlap merge, URL title) and regenerated `expected.json` pin the TS and Rust derivations in lockstep.
5. **Docs** (`docs/cli.md`, `docs/deep-links.md`, `resolve-target.ts` docstring): the alias resolution step now names the v1 subject-alias form.

## Tests

- `subject-aliases.test.ts` — split semantics: multi-segment, no-space `//`, trailing separator, case-insensitive dedupe, URL schemes, slash runs.
- `indexed-note.test.ts` — projection order (frontmatter first, derived after), frontmatter-claimed segments skipped, `PROJECTION_VERSION` 14.
- `note_file.rs` unit tests + `tests/parity.rs` — the Rust mirror matches the TS derivation on the shared corpus.

## Verification

- `pnpm --filter @reflect/core test --run src/indexing src/markdown` — 40 files, 534 tests pass.
- `cargo test -p reflect-cli` — all pass, including the 4 parity tests against the regenerated `expected.json`.
- `pnpm check` (typecheck + lint) and `cargo clippy -p reflect-cli --all-targets` — clean.
- End-to-end against a scratch graph: `reflect show "Mum"`, `"charlotte maccaw"`, and the full literal title all print the note via the index-free scan path.

## Risk / Rollout

- The projection bump reprojects graphs whose rows predate v14 on next open (the established backfill mechanism; `chat_*` untouched).
- Titles that legitimately contain `//` now mint aliases — the guard excludes URL schemes and slash runs, and a derived alias never shadows a real title match (title lookup runs first everywhere).
- Derived aliases exist only in the rebuildable index; reverting the PR and reprojecting removes them completely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Projection v14 triggers a full reproject on next open; derived aliases can change wiki/backlink resolution for titles that contain `//`, though URL/slash guards limit false splits.
> 
> **Overview**
> Adds **v1 `//` title compatibility** so segments like `Mum` in `Charlotte MacCaw // Mum` behave as index aliases without rewriting frontmatter or on-disk titles.
> 
> **Core:** New `subjectAliases(title)` splits on `//` with guards for URL schemes and slash runs; `noteAliases` in indexing merges frontmatter `aliases:` first, then derived segments (skipping fold-key duplicates). **`PROJECTION_VERSION` → 14** backfills existing graphs.
> 
> **CLI:** Rust `subject_aliases` + the same merge in `parse_note_meta` keeps index-free `reflect show` in parity with TS.
> 
> **Docs & fixtures:** CLI/deep-link alias resolution docs updated; parity corpus adds three fixtures and regenerated `expected.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f89472daec9e76e05eee8d5cb4f969301de0f31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notes can now derive aliases from `//` title segments in addition to frontmatter aliases.
  * Alias matching now works more consistently for legacy “subject” note titles, while avoiding URL-style `//` text.

* **Bug Fixes**
  * Duplicate or empty derived aliases are ignored, and frontmatter aliases are not added twice when already claimed.

* **Documentation**
  * Updated CLI and deep-link docs to explain the expanded alias resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->