### PR TITLE
feat(desktop): make Daily capture arrivals append at today's end

### DIFF
--- a/apps/desktop/src/components/daily-stream.focus.test.tsx
+++ b/apps/desktop/src/components/daily-stream.focus.test.tsx
@@ -1,0 +1,143 @@
+import { act, fireEvent, render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useEffect } from 'react'
+import { todayIso } from '@/lib/dates'
+import { RouterProvider, useRouter, type NavigateOptions } from '@/routing/router'
+import type { Route } from '@/routing/route'
+import { installVirtuaTestEnv } from '@/test-utils/virtua-jsdom'
+import { DailyStream, ESTIMATED_DAY_HEIGHT } from './daily-stream'
+
+/**
+ * The stream's arrival-focus contract: every fresh arrival autofocuses the
+ * target day, and only a capture arrival — `navigate(..., { focusEditor:
+ * true })`, i.e. ⌘D or the sidebar's Daily notes row — asks for the caret at
+ * the *end* of the day's content (append semantics, mobile double-tap
+ * parity). NotePane is replaced by a probe that just reports the focus props
+ * it was handed; the real mount-and-focus mechanics live in NotePane.
+ *
+ * Each test navigates *before* the target row exists and only then lets
+ * virtua render it, mirroring the real sequence (the arrival's imperative
+ * scroll is what brings the day's row into range, and the row reads its
+ * focus assignment as it mounts).
+ */
+
+vi.mock('@/components/note-pane', () => ({
+  NotePane: ({
+    dailyDate,
+    autoFocus = false,
+    autoFocusSelection = 'start',
+  }: {
+    dailyDate?: string
+    autoFocus?: boolean
+    autoFocusSelection?: 'start' | 'end'
+  }) => (
+    <div
+      data-testid="pane-probe"
+      data-date={dailyDate}
+      data-autofocus={String(autoFocus)}
+      data-selection={autoFocusSelection}
+    />
+  ),
+}))
+vi.mock('@/providers/settings-provider', () => ({
+  useSettings: () => ({
+    settings: { dateFormat: 'mdy' },
+    updateSettings: async () => {},
+    updateSettingsWith: () => {},
+  }),
+}))
+
+installVirtuaTestEnv((element) =>
+  element.dataset['testid'] === 'daily-stream' ? 800 : ESTIMATED_DAY_HEIGHT,
+)
+Element.prototype.scrollTo ??= () => {}
+
+// virtua anchors by assigning `scrollTop`, which jsdom ignores by default —
+// retain the value so scroll events report the anchored offset back.
+let scrollTop = 0
+Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
+  configurable: true,
+  get() {
+    return scrollTop
+  },
+  set(value: number) {
+    scrollTop = Number(value)
+  },
+})
+
+beforeEach(() => {
+  scrollTop = 0
+})
+
+type Navigate = (route: Route, options?: NavigateOptions) => void
+
+function NavigateProbe({ onReady }: { onReady: (navigate: Navigate) => void }): null {
+  const { navigate } = useRouter()
+  useEffect(() => {
+    onReady(navigate)
+  }, [navigate, onReady])
+  return null
+}
+
+function renderStream() {
+  let navigate: Navigate = () => {
+    throw new Error('navigate not ready')
+  }
+  const view = render(
+    <RouterProvider initialRoute={{ kind: 'today' }}>
+      <DailyStream target={{ kind: 'today' }} />
+      <NavigateProbe
+        onReady={(run) => {
+          navigate = run
+        }}
+      />
+    </RouterProvider>,
+  )
+  const paneFor = (date: string) =>
+    view.container.querySelector(`[data-testid="pane-probe"][data-date="${date}"]`)
+  return {
+    view,
+    navigate: (route: Route, options?: NavigateOptions) => navigate(route, options),
+    // jsdom fires no scroll events, so virtua never learns about the offset
+    // the arrival assigned — nudge it until the target day's row renders.
+    anchored: (date: string) =>
+      waitFor(() => {
+        const stream = view.container.querySelector('[data-testid="daily-stream"]')
+        expect(stream).not.toBeNull()
+        fireEvent.scroll(stream!)
+        expect(paneFor(date)).not.toBeNull()
+      }),
+    paneFor,
+  }
+}
+
+describe('DailyStream arrival focus', () => {
+  it('a capture arrival (focusEditor) focuses today with the caret at the end', async () => {
+    const today = todayIso()
+    const { view, navigate, anchored, paneFor } = renderStream()
+
+    act(() => navigate({ kind: 'today' }, { focusEditor: true }))
+    await anchored(today)
+
+    const pane = paneFor(today)
+    expect(pane?.getAttribute('data-autofocus')).toBe('true')
+    expect(pane?.getAttribute('data-selection')).toBe('end')
+    view.unmount()
+  })
+
+  it('an ordinary arrival keeps the default start-of-note focus', async () => {
+    const today = todayIso()
+    const { view, navigate, anchored, paneFor } = renderStream()
+
+    // A capture arrival first, so the follow-up proves the append intent is
+    // one-shot rather than sticky.
+    act(() => navigate({ kind: 'today' }, { focusEditor: true }))
+    act(() => navigate({ kind: 'today' }))
+    await anchored(today)
+
+    const pane = paneFor(today)
+    expect(pane?.getAttribute('data-autofocus')).toBe('true')
+    expect(pane?.getAttribute('data-selection')).toBe('start')
+    view.unmount()
+  })
+})

--- a/apps/desktop/src/components/daily-stream.tsx
+++ b/apps/desktop/src/components/daily-stream.tsx
@@ -44,7 +44,7 @@ export const ESTIMATED_DAY_HEIGHT = 220
  * bookkeeping; index↔date is pure offset math.
  */
 export function DailyStream({ target }: DailyStreamProps): ReactElement {
-  const { arrivalSeq, entryId, saveScrollState, savedScroll } = useRouter()
+  const { arrivalSeq, arrivalFocusEditor, entryId, saveScrollState, savedScroll } = useRouter()
   const virtualizerRef = useRef<VirtualizerHandle>(null)
   // The window anchors at today-on-mount and stays stable for the view's life.
   // (`dayWindow`, not `window` — shadowing the DOM global here was a footgun.)
@@ -65,12 +65,24 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
     targetDateRef.current = targetDate
   }, [targetDate])
 
+  // Mirrored like targetDate: the focus request belongs to the arrival that
+  // bumped `arrivalSeq`, so the anchor effect reads it through a ref instead
+  // of depending on it — a later flag clear without an arrival (a no-op ⌘[
+  // at the bottom of the stack) must not re-anchor a stream nobody navigated.
+  const arrivalFocusEditorRef = useRef(arrivalFocusEditor)
+  useLayoutEffect(() => {
+    arrivalFocusEditorRef.current = arrivalFocusEditor
+  }, [arrivalFocusEditor])
+
   // Only the day navigated to receives focus, once per navigation — a row that
   // scrolls offscreen and back must not steal focus from wherever the user is.
-  // The flag is consumed when the editor actually mounts and focuses (not at
+  // The entry also carries where the caret lands: capture arrivals (⌘D, the
+  // sidebar's Daily notes row — the router's `arrivalFocusEditor`) append at
+  // the end of the day's content, every other arrival keeps the note start.
+  // The slot is consumed when the editor actually mounts and focuses (not at
   // render time), so a virtualizer re-render before the lazy load completes
   // can't drop the focus.
-  const focusPending = useRef<string | null>(null)
+  const focusPending = useRef<{ date: string; selection: 'start' | 'end' } | null>(null)
   const consumeFocus = useCallback(() => {
     focusPending.current = null
   }, [])
@@ -159,7 +171,10 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
     }
     const target = targetDateRef.current
     pendingFocusRef.current = null
-    focusPending.current = target
+    focusPending.current = {
+      date: target,
+      selection: arrivalFocusEditorRef.current ? 'end' : 'start',
+    }
     virtualizerRef.current?.scrollToIndex(indexOfDate(dayWindow, target), { align: 'start' })
   }, [arrivalSeq, entryId, dayWindow, savedScroll])
 
@@ -191,7 +206,10 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
           // collapses to a short row), while today and future days reserve
           // most of a viewport of writing room. ISO dates compare lexically.
           const isPast = date < today
-          const autoFocus = focusPending.current === date
+          const pendingFocus = focusPending.current
+          const focusSelection =
+            pendingFocus !== null && pendingFocus.date === date ? pendingFocus.selection : null
+          const autoFocus = focusSelection !== null
           return (
             <section
               key={date}
@@ -215,6 +233,7 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
                 onExitBoundary={handleExitBoundary}
                 lazy
                 autoFocus={autoFocus}
+                autoFocusSelection={focusSelection ?? 'start'}
                 onAutoFocused={consumeFocus}
                 gutterClassName={CONTENT_GUTTER}
                 editorClassName={isPast ? 'min-h-[100px]' : 'min-h-[60vh]'}

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -163,11 +163,14 @@ describe('Sidebar', () => {
   it('nav rows navigate, with Daily notes restoring its surface scroll', async () => {
     const { view, navigate } = renderSidebar()
 
+    // The Daily row is a capture gesture: it asks for editor focus (the
+    // stream appends at today's end), while a genuine off-surface return
+    // still restores the stream's saved position instead.
     await userEvent.click(view.getByRole('button', { name: /daily notes/i }))
     await waitFor(() =>
       expect(navigate).toHaveBeenCalledWith(
         { kind: 'today' },
-        { restoreSurfaceScroll: true },
+        { restoreSurfaceScroll: true, focusEditor: true },
       ),
     )
 

--- a/apps/desktop/src/components/sidebar/sidebar.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.tsx
@@ -30,9 +30,11 @@ interface SidebarProps {
  * right, search, primary navigation with hover-revealed shortcut keycaps, the
  * Pinned shelf, and the graph switcher footer. Most nav rows run registered
  * commands so a binding and its behavior stay one definition; the Daily notes
- * row restores the stream's surface scroll when clicked from another surface
- * (the router re-anchors it, like `Mod-D`, when the stream is already
- * showing). (Sidebar collapse stays on `Mod-\` via the command registry.)
+ * row is a capture gesture like `Mod-D` — it asks the stream to focus today
+ * with the caret at the end, ready to append — except when clicked from
+ * another surface with a saved stream position, where the surface-scroll
+ * restore wins and focus stays put. (Sidebar collapse stays on `Mod-\` via
+ * the command registry.)
  */
 export function Sidebar({ graph, context }: SidebarProps): ReactElement {
   const { route } = useRouter()
@@ -74,7 +76,10 @@ export function Sidebar({ graph, context }: SidebarProps): ReactElement {
             binding={keybindingFor('nav.today') ?? undefined}
             active={(route.kind === 'today' || route.kind === 'daily') && !hasActivePinnedNote}
             onClick={() =>
-              context.navigate({ kind: 'today' }, { restoreSurfaceScroll: true })
+              context.navigate(
+                { kind: 'today' },
+                { restoreSurfaceScroll: true, focusEditor: true },
+              )
             }
           />
           <SidebarItem

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { EmbedStatus, NoteRow, PinnedNote } from '@reflect/core'
 import { notePathForRoute, type Route } from '@/routing/route'
+import type { NavigateOptions } from '@/routing/router'
 import { resetOperations } from '@/lib/operations'
 import type { CommandContext } from './types'
 
@@ -58,9 +59,13 @@ function command(id: string) {
 
 function fakeContext(overrides?: Partial<CommandContext>) {
   const navigated: Route[] = []
+  const navigateOptions: (NavigateOptions | undefined)[] = []
   const route: () => Route = overrides?.route ?? (() => ({ kind: 'today' }))
   const context: CommandContext = {
-    navigate: (target) => void navigated.push(target),
+    navigate: (target, options) => {
+      navigated.push(target)
+      navigateOptions.push(options)
+    },
     route,
     // Mirror the real context: note-scoped commands resolve their target from
     // the route (the focused-day branch is exercised in app-shortcuts).
@@ -80,7 +85,7 @@ function fakeContext(overrides?: Partial<CommandContext>) {
     enableSemanticSearch: vi.fn(),
     ...overrides,
   }
-  return { context, navigated }
+  return { context, navigated, navigateOptions }
 }
 
 function noteRow(isPrivate: boolean): NoteRow {
@@ -122,9 +127,12 @@ describe('keybindingFor', () => {
 
 describe('app commands', () => {
   it('nav.today, history, palette, theme, and sidebar commands hit their capabilities', async () => {
-    const { context, navigated } = fakeContext()
+    const { context, navigated, navigateOptions } = fakeContext()
     await command('nav.today').run(context)
     expect(navigated).toEqual([{ kind: 'today' }])
+    // ⌘D is a capture gesture: the arrival asks the stream to focus today's
+    // editor at the end of its content, ready to append.
+    expect(navigateOptions).toEqual([{ focusEditor: true }])
     await command('history.back').run(context)
     expect(context.back).toHaveBeenCalled()
     await command('history.forward').run(context)

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -54,7 +54,12 @@ const APP_COMMANDS: AppCommand[] = [
     title: 'Go to today',
     keywords: ['daily', 'now'],
     keybinding: 'Mod-d',
-    run: (context) => context.navigate({ kind: 'today' }),
+    // ⌘D is a capture gesture, not just navigation: the arrival asks the
+    // stream to focus today's editor with the caret at the end of its
+    // content, ready to append — the same one-shot `focusEditor` intent as
+    // the mobile Daily-tab double-tap. Ordinary daily links and history
+    // moves stay on the calm default (focus at the note start, or none).
+    run: (context) => context.navigate({ kind: 'today' }, { focusEditor: true }),
   },
   {
     id: 'nav.allNotes',

--- a/apps/desktop/src/routing/router.tsx
+++ b/apps/desktop/src/routing/router.tsx
@@ -41,12 +41,12 @@ interface RouterValue {
   arrivalSeq: number
   /**
    * True when the latest arrival asked the destination to focus its editor
-   * (`navigate(route, { focusEditor: true })`). Only explicit write gestures
-   * request it — today just the mobile Daily-tab double-tap — while note
-   * navigations (wiki links, backlinks, back/forward) stay calm so the
-   * keyboard never rises mid-arrival. One-shot by construction: the next
-   * navigate overwrites it and history moves clear it, so it can never leak
-   * onto a later, unrelated arrival.
+   * (`navigate(route, { focusEditor: true })`). Only explicit capture
+   * gestures request it — the mobile Daily-tab double-tap, desktop's ⌘D and
+   * sidebar Daily notes row — while note navigations (wiki links, backlinks,
+   * back/forward) stay calm so the keyboard never rises mid-arrival.
+   * One-shot by construction: the next navigate overwrites it and history
+   * moves clear it, so it can never leak onto a later, unrelated arrival.
    */
   arrivalFocusEditor: boolean
   navigate: (route: Route, options?: NavigateOptions) => void
@@ -87,9 +87,11 @@ export interface NavigateOptions {
   restoreSurfaceScroll?: boolean
   /**
    * Ask the destination to focus its editor on arrival — see
-   * {@link RouterValue.arrivalFocusEditor}. Consumed by the mobile daily
-   * surface (Daily-tab double-tap); desktop's note route autofocuses every
-   * arrival and ignores it.
+   * {@link RouterValue.arrivalFocusEditor}. Consumed by the daily surfaces —
+   * the mobile Daily-tab double-tap and desktop's stream (⌘D, the sidebar's
+   * Daily notes row), which land the caret at the end of the day's content
+   * (append-style capture); desktop's note route autofocuses every arrival
+   * and ignores it.
    */
   focusEditor?: boolean
 }

--- a/docs/porting/reflect-mobile/editor-and-keyboard.md
+++ b/docs/porting/reflect-mobile/editor-and-keyboard.md
@@ -20,8 +20,9 @@ toolbar — and the hard-won keyboard/focus lessons.
 > the stack push/pop animation. Wiki-link taps, backlink rows, plain
 > arrivals, and back/forward all land with the keyboard down. Only explicit
 > write gestures focus: the `+` new-note flow (untitled autofocus) and the
-> Daily-tab double-tap (the router's one-shot `focusEditor` intent, now
-> consumed only by the daily surface); no V1-style 500 ms timer (focus
+> Daily-tab double-tap (the router's one-shot `focusEditor` intent,
+> consumed by the daily surfaces — desktop's ⌘D / Daily-notes-row capture
+> shares it, appending at the note's end); no V1-style 500 ms timer (focus
 > fires on editor mount, after the async document load). Keyboard avoidance is by
 > **layout, in one place**: the mobile shell root is
 > `calc(100dvh - var(--keyboard-height))`, so scroll containers, the


### PR DESCRIPTION
## Problem

⌘D and the sidebar's Daily notes row are capture gestures — "take me to today so I can jot something down" — but the desktop stream treated them like any other daily-stream arrival: it anchored to today and let the editor autofocus fall back to its default start selection. The caret landed at the *beginning* of the daily note, which is backwards when the user is appending to a day that already has content.

The iOS Daily-tab double-tap already solved this: it navigates with the router's one-shot `focusEditor` intent, and the day slide focuses the editor with `autoFocusSelection="end"`. Desktop just never consumed that intent.

Out of scope on purpose: ordinary daily navigations (calendar clicks, daily wiki links, deep links, back/forward) and the Daily row's off-surface scroll restore keep their current behavior.

## Before → After

| Gesture | Before | After |
| --- | --- | --- |
| ⌘D (`nav.today`) | Anchor to today, caret at note start | Anchor to today, caret at the **end** of today's content |
| Sidebar Daily notes row (fresh arrival) | Anchor to today, caret at note start | Anchor to today, caret at the **end** |
| Sidebar Daily notes row (return from another surface with a saved stream position) | Restore scroll, no focus | Unchanged — the restore wins, focus stays put |
| Daily links / back-forward / history restores | Start selection (or no focus on restores) | Unchanged |

## Changes

1. **`app-commands.ts`** — `nav.today` (⌘D, palette "Go to today") navigates with `{ focusEditor: true }`, the same one-shot intent the mobile double-tap uses.
2. **`sidebar.tsx`** — the Daily notes row adds `focusEditor: true` alongside its existing `restoreSurfaceScroll: true`. When a genuine off-surface return restores the stream's saved position, `DailyStream` already cancels pending focus for restored arrivals, so the restore still wins; only fresh (re-anchoring) arrivals get the append focus.
3. **`daily-stream.tsx`** — the stream now consumes `arrivalFocusEditor`. Its pending-focus slot carries `{ date, selection }` instead of a bare date, and the row passes `autoFocusSelection` through to `NotePane` (which already supported `'end'` for mobile). The flag is read through a ref mirror at arrival time — same pattern as `targetDateRef` — so a flag clear without an arrival (a no-op ⌘[ at the bottom of the history stack) can't re-anchor the stream.
4. **`router.tsx` / porting doc** — doc-comment updates only: `focusEditor` is now consumed by the daily surfaces on both platforms.

## Tests

- `daily-stream.focus.test.tsx` (new): a `focusEditor` arrival renders today's pane with `autoFocus` + `autoFocusSelection="end"`; a follow-up plain arrival proves the intent is one-shot and falls back to `start`. NotePane is mocked to a probe; rows are created the way real arrivals create them (navigate first, then the row mounts into range).
- `app-commands.test.ts`: `nav.today` passes `{ focusEditor: true }` (the fake context now records navigate options).
- `sidebar.test.tsx`: the Daily row navigates with `{ restoreSurfaceScroll: true, focusEditor: true }`.

## Verification

- `pnpm test --run` on the five touched suites (`daily-stream.focus`, `daily-stream`, `app-commands`, `sidebar`, `router`, plus `mobile-screen`): 106 tests passed.
- `pnpm check` (typecheck + oxlint + eslint): clean.
- Not manually exercised in the running app — worth a quick desktop pass: ⌘D from a note, ⌘D while on today, Daily-row click from All Notes with and without a scrolled stream.

## Risk / Rollout

Low. The intent is one-shot by construction (next navigate overwrites, history moves clear it), so it can't leak onto later arrivals. Mobile behavior is untouched except that a hardware-keyboard ⌘D on iPad now also focuses today's end — consistent with the double-tap. No data or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation and editor-focus behavior only; the intent is one-shot and scroll-restore paths explicitly clear focus, with no data or API changes.
> 
> **Overview**
> **Capture gestures** (⌘D / `nav.today`, sidebar **Daily notes**) now navigate with `{ focusEditor: true }`, reusing the same one-shot router intent as the mobile Daily-tab double-tap.
> 
> **`DailyStream`** reads `arrivalFocusEditor` on each arrival and passes **`autoFocusSelection`** (`end` for capture, `start` otherwise) into `NotePane` via a pending-focus slot `{ date, selection }`. The flag is mirrored in a ref at anchor time so it cannot re-fire without a new navigation. Scroll restores still cancel pending focus unchanged.
> 
> Tests cover stream focus contract, command options, and sidebar navigate args; router/porting docs are comment-only updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb7a8333754e2f7a0c12d6c672d3848249d8706c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->