### PR TITLE
Port V1 block-level backlink snippet context

### DIFF
--- a/apps/desktop/src/components/backlink-snippet.tsx
+++ b/apps/desktop/src/components/backlink-snippet.tsx
@@ -4,7 +4,7 @@ import type { WikilinkClickHandler } from '@meowdown/core'
 import { openExternalLink } from '@/editor/open-external-link'
 
 interface BacklinkSnippetProps {
-  /** The referencing line's Markdown source. */
+  /** The referencing block context's Markdown source (may span several lines). */
   text: string
   /** Navigate a clicked `[[wiki link]]` to its target. Pass a stable function. */
   onWikilinkClick: WikilinkClickHandler
@@ -13,12 +13,14 @@ interface BacklinkSnippetProps {
 }
 
 /**
- * One referencing line in the incoming-backlinks panel, rendered as rich text
- * through meowdown's editor-free `MarkdownView`: wiki links become the editor's
+ * One reference in the incoming-backlinks panel, rendered as rich text through
+ * meowdown's editor-free `MarkdownView`: wiki links become the editor's
  * clickable chips and inline marks render instead of raw `[[…]]` / `**…**`
- * source. The `reflect-editor` class shares the editor's chip styling; the
- * `reflect-backlink-snippet` wrapper keeps it in the panel's compact line box and
- * clamps a long or block-level line so it never towers.
+ * source. The context is a whole block (old Reflect's rules — a paragraph, the
+ * containing list item with its children, or a heading's section), so it
+ * renders unclamped: truncating would cut the nested structure the context
+ * exists to show. The `reflect-editor` class shares the editor's chip styling;
+ * the `reflect-backlink-snippet` wrapper keeps it in the panel's compact line box.
  */
 export function BacklinkSnippet({
   text,
@@ -26,7 +28,7 @@ export function BacklinkSnippet({
   resolveImageUrl,
 }: BacklinkSnippetProps): ReactElement {
   return (
-    <div className="reflect-backlink-snippet line-clamp-2 select-text text-xs text-text">
+    <div className="reflect-backlink-snippet select-text text-xs text-text">
       <MarkdownView
         className="reflect-editor"
         markdown={text}

--- a/packages/core/src/indexing/block-context.test.ts
+++ b/packages/core/src/indexing/block-context.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+import { blockContextAt } from './block-context'
+
+/** Offset of the first `[[target]]` occurrence — the index's `pos_from`. */
+function posOf(content: string, link: string): number {
+  const pos = content.indexOf(link)
+  if (pos === -1) {
+    throw new Error(`link ${link} not in fixture`)
+  }
+  return pos
+}
+
+describe('blockContextAt', () => {
+  it('returns the whole paragraph, not just the physical line', () => {
+    const content = 'intro line\n\nfirst wrapped line with [[Target]]\nsecond wrapped line\n\nafter\n'
+    expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(
+      'first wrapped line with [[Target]]\nsecond wrapped line',
+    )
+  })
+
+  it('maps whole-file offsets across frontmatter', () => {
+    const content = '---\ntitle: Note\n---\n\na paragraph with [[Target]] inside\n'
+    expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(
+      'a paragraph with [[Target]] inside',
+    )
+  })
+
+  it('returns the heading plus its section, stopping at the next heading of any level', () => {
+    const content = [
+      '# Title',
+      '',
+      'intro',
+      '',
+      '## Meeting [[Target]]',
+      '',
+      'notes for the meeting',
+      '',
+      '- a bullet',
+      '',
+      '### Sub',
+      '',
+      'unrelated',
+      '',
+    ].join('\n')
+    expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(
+      '## Meeting [[Target]]\n\nnotes for the meeting\n\n- a bullet',
+    )
+  })
+
+  it('runs a trailing heading section to the end of the document', () => {
+    const content = '## Heading [[Target]]\n\nlast paragraph\n'
+    expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(
+      '## Heading [[Target]]\n\nlast paragraph',
+    )
+  })
+
+  it('returns a top-level list item with all its children, mentioning or not', () => {
+    const content = [
+      '- kickoff with [[Target]]',
+      '  - prep the agenda',
+      '  - book the room',
+      '- unrelated sibling',
+      '',
+    ].join('\n')
+    expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(
+      '- kickoff with [[Target]]\n  - prep the agenda\n  - book the room',
+    )
+  })
+
+  it('keeps task children inside a top-level item', () => {
+    const content = '- [[Target]] kickoff\n  + [ ] prep agenda\n  + [x] send invite\n'
+    expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(
+      '- [[Target]] kickoff\n  + [ ] prep agenda\n  + [x] send invite',
+    )
+  })
+
+  it('shows a nested mention under its parent line, dropping mention-less siblings', () => {
+    const content = [
+      '- parent line',
+      '  - mention of [[Target]]',
+      '    - grandchild detail',
+      '  - unrelated sibling',
+      '',
+    ].join('\n')
+    expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(
+      '- parent line\n  - mention of [[Target]]\n    - grandchild detail',
+    )
+  })
+
+  it('keeps sibling branches that mention the same target', () => {
+    const content = [
+      '- parent line',
+      '  - first [[Target]] mention',
+      '  - also [[Target]] here',
+      '  - nothing relevant',
+      '',
+    ].join('\n')
+    expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(
+      '- parent line\n  - first [[Target]] mention\n  - also [[Target]] here',
+    )
+  })
+
+  it('matches sibling mentions case-insensitively, like link resolution', () => {
+    const content = '- parent line\n  - one [[Target]]\n  - two [[target]]\n'
+    expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(
+      '- parent line\n  - one [[Target]]\n  - two [[target]]',
+    )
+  })
+
+  it('climbs exactly one ancestor level for a deeply nested mention', () => {
+    const content = [
+      '- top item',
+      '  - middle item',
+      '    - deep [[Target]] mention',
+      '  - other branch',
+      '',
+    ].join('\n')
+    expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(
+      '- middle item\n  - deep [[Target]] mention',
+    )
+  })
+
+  it('strips blockquote chrome from a quoted paragraph', () => {
+    const content = '> quoted [[Target]] mention\n> second quoted line\n'
+    expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(
+      'quoted [[Target]] mention\nsecond quoted line',
+    )
+  })
+
+  it('returns the whole table for a mention in a cell', () => {
+    const content = '| a | b |\n| --- | --- |\n| [[Target]] | y |\n'
+    expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(
+      '| a | b |\n| --- | --- |\n| [[Target]] | y |',
+    )
+  })
+
+  it('falls back to the bare line when the offset drifted between blocks', () => {
+    const content = 'first paragraph\n\nsecond paragraph\n'
+    expect(blockContextAt(content, content.indexOf('\n\n') + 1)).toBe('')
+  })
+})

--- a/packages/core/src/indexing/block-context.test.ts
+++ b/packages/core/src/indexing/block-context.test.ts
@@ -70,6 +70,13 @@ describe('blockContextAt', () => {
     )
   })
 
+  it('keeps the section rule for an H1 when frontmatter authors the title', () => {
+    const content = '---\ntitle: Custom\n---\n\n# Heading [[Target]]\n\nsection body\n'
+    expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(
+      '# Heading [[Target]]\n\nsection body',
+    )
+  })
+
   it('treats a setext H1 title the same as an ATX title', () => {
     const content = 'With [[Target]]\n====\n\nbody paragraph\n'
     expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe('With [[Target]]\n====')

--- a/packages/core/src/indexing/block-context.test.ts
+++ b/packages/core/src/indexing/block-context.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { blockContextAt } from './block-context'
+import { blockContextAt, prepareBlockContext } from './block-context'
 
 /** Offset of the first `[[target]]` occurrence — the index's `pos_from`. */
 function posOf(content: string, link: string): number {
@@ -52,6 +52,27 @@ describe('blockContextAt', () => {
     expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(
       '## Heading [[Target]]\n\nlast paragraph',
     )
+  })
+
+  it('shows only the heading line for a mention in the note title H1', () => {
+    // Divergence from old Reflect, where titles lived outside the document: the
+    // section rule would inline the entire note for a title mention.
+    const content = '# Meeting with [[Target]]\n\nagenda item one\n\nagenda item two\n'
+    expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(
+      '# Meeting with [[Target]]',
+    )
+  })
+
+  it('keeps the section rule for a non-title H1', () => {
+    const content = '# Title\n\nintro\n\n# Second [[Target]]\n\nsection body\n'
+    expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(
+      '# Second [[Target]]\n\nsection body',
+    )
+  })
+
+  it('treats a setext H1 title the same as an ATX title', () => {
+    const content = 'With [[Target]]\n====\n\nbody paragraph\n'
+    expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe('With [[Target]]\n====')
   })
 
   it('returns a top-level list item with all its children, mentioning or not', () => {
@@ -107,6 +128,27 @@ describe('blockContextAt', () => {
     )
   })
 
+  it('handles ordered lists, keeping source numbering', () => {
+    const content = '1. parent line\n   2. mention of [[Target]]\n   3. unrelated\n'
+    expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(
+      '1. parent line\n   2. mention of [[Target]]',
+    )
+  })
+
+  it('keeps both paragraphs of a loose list item', () => {
+    const content = '- first paragraph\n\n  second [[Target]] paragraph\n'
+    expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(
+      '- first paragraph\n\n  second [[Target]] paragraph',
+    )
+  })
+
+  it('dedents tab-indented nesting by the parent indent only', () => {
+    const content = '- top\n\t- middle\n\t\t- deep [[Target]]\n'
+    expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(
+      '- middle\n\t- deep [[Target]]',
+    )
+  })
+
   it('climbs exactly one ancestor level for a deeply nested mention', () => {
     const content = [
       '- top item',
@@ -137,5 +179,12 @@ describe('blockContextAt', () => {
   it('falls back to the bare line when the offset drifted between blocks', () => {
     const content = 'first paragraph\n\nsecond paragraph\n'
     expect(blockContextAt(content, content.indexOf('\n\n') + 1)).toBe('')
+  })
+
+  it('extracts several contexts from one prepared source', () => {
+    const content = '---\ntitle: Note\n---\n\nfirst [[Target]] mention\n\n- second [[Target]]\n'
+    const source = prepareBlockContext(content)
+    expect(blockContextAt(source, posOf(content, '[[Target]]'))).toBe('first [[Target]] mention')
+    expect(blockContextAt(source, content.lastIndexOf('[[Target]]'))).toBe('- second [[Target]]')
   })
 })

--- a/packages/core/src/indexing/block-context.test.ts
+++ b/packages/core/src/indexing/block-context.test.ts
@@ -121,6 +121,20 @@ describe('blockContextAt', () => {
     )
   })
 
+  it('co-groups sibling branches through any of the target keys, like V1 id matching', () => {
+    const content = [
+      '- parent line',
+      '  - one [[Project X]]',
+      '  - two [[projx]]',
+      '  - three [[Other Note]]',
+      '',
+    ].join('\n')
+    const targetKeys = new Set(['project x', 'projx'])
+    expect(blockContextAt(content, posOf(content, '[[Project X]]'), targetKeys)).toBe(
+      '- parent line\n  - one [[Project X]]\n  - two [[projx]]',
+    )
+  })
+
   it('matches sibling mentions case-insensitively, like link resolution', () => {
     const content = '- parent line\n  - one [[Target]]\n  - two [[target]]\n'
     expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(

--- a/packages/core/src/indexing/block-context.ts
+++ b/packages/core/src/indexing/block-context.ts
@@ -1,0 +1,235 @@
+import type { SyntaxNode } from '@lezer/common'
+import { splitFrontmatter } from '../markdown/frontmatter'
+import { parseBody } from '../markdown/grammar'
+import { unescapeMarkdownText } from '../markdown/plain-text'
+import { normalizeWikiTarget } from '../markdown/resolve'
+import { lineAt } from './snippet'
+
+/**
+ * Block-level context extraction for the backlinks panel, ported from old
+ * Reflect's `getBacklinkContextHtml`. Where {@link lineAt} returns only the
+ * physical line around a link, this walks the parsed block structure and
+ * returns the whole unit of meaning the mention sits in:
+ *
+ * - **Paragraph** — the whole paragraph (which may wrap across lines).
+ * - **Heading** — the heading plus every following sibling block up to the
+ *   next heading (of any level) or the end of the section's parent.
+ * - **Top-level list item** — the entire item including all of its nested
+ *   children (sub-bullets, task lists), mentioning or not.
+ * - **Nested list item** — the parent item's own text line for context, plus
+ *   each sibling branch under that parent that also mentions the same target;
+ *   branches that don't mention it are dropped. Only one ancestor level is
+ *   climbed, exactly like old Reflect.
+ *
+ * The result is Markdown sliced from the source (full lines, dedented to the
+ * context's own indentation) so nested structure survives rendering, and is
+ * never truncated — old Reflect showed the full context and clamped the panel,
+ * not the snippet.
+ */
+
+const HEADING_NODE_RE = /^(?:ATXHeading|SetextHeading)[1-6]$/
+
+function isHeadingName(name: string): boolean {
+  return HEADING_NODE_RE.test(name)
+}
+
+/** Leaf blocks that hold inline content (GFM turns a task item's paragraph into `Task`). */
+function isTextblockName(name: string): boolean {
+  return name === 'Paragraph' || name === 'Task'
+}
+
+function isListName(name: string): boolean {
+  return name === 'BulletList' || name === 'OrderedList'
+}
+
+function selfOrAncestor(
+  node: SyntaxNode | null,
+  matches: (node: SyntaxNode) => boolean,
+): SyntaxNode | null {
+  for (let current = node; current; current = current.parent) {
+    if (matches(current)) {
+      return current
+    }
+  }
+  return null
+}
+
+/** The normalized match key of a `[[…]]` node, or `null` for a blank target. */
+function wikiTargetKeyOf(body: string, link: SyntaxNode): string | null {
+  const inner = body.slice(link.from + 2, link.to - 2)
+  const pipe = inner.indexOf('|')
+  const target = unescapeMarkdownText((pipe === -1 ? inner : inner.slice(0, pipe)).trim())
+  return target === '' ? null : normalizeWikiTarget(target).key
+}
+
+/** Does the textblock's inline content hold a wiki link with this match key? */
+function textblockMentions(body: string, block: SyntaxNode, targetKey: string): boolean {
+  for (let child = block.firstChild; child; child = child.nextSibling) {
+    if (child.name === 'WikiLink') {
+      if (wikiTargetKeyOf(body, child) === targetKey) {
+        return true
+      }
+    } else if (textblockMentions(body, child, targetKey)) {
+      return true // links nested in emphasis/strikethrough still count
+    }
+  }
+  return false
+}
+
+/**
+ * Does a candidate branch (a sibling list item or block under the parent item)
+ * mention the target in its *direct* text blocks? Deeper descendants don't
+ * qualify the branch — old Reflect's `nodeHasDirectBacklink` looked exactly one
+ * block deep, and each mention deeper down produces its own context anyway.
+ */
+function branchMentions(body: string, branch: SyntaxNode, targetKey: string | null): boolean {
+  if (targetKey === null) {
+    return false
+  }
+  if (isTextblockName(branch.name)) {
+    return textblockMentions(body, branch, targetKey)
+  }
+  for (let child = branch.firstChild; child; child = child.nextSibling) {
+    if (isTextblockName(child.name) && textblockMentions(body, child, targetKey)) {
+      return true
+    }
+  }
+  return false
+}
+
+function lineStartAt(body: string, pos: number): number {
+  return body.lastIndexOf('\n', Math.max(0, pos - 1)) + 1
+}
+
+function lineEndAt(body: string, pos: number): number {
+  const next = body.indexOf('\n', pos)
+  return next === -1 ? body.length : next
+}
+
+/**
+ * The full lines covering `[from, to)`, with the first line's prefix (the text
+ * before `from` — indentation, or `> ` inside a blockquote) stripped from every
+ * line it also leads. Keeps deeper indentation relative, so a sliced list still
+ * renders nested.
+ */
+function sliceLines(body: string, from: number, to: number): string {
+  const prefix = body.slice(lineStartAt(body, from), from)
+  const end = to > from && body[to - 1] === '\n' ? to - 1 : to
+  const lines = body.slice(from, lineEndAt(body, end)).split('\n')
+  const dedented = lines.map((line, index) => {
+    if (index === 0) {
+      return line // starts at `from`, already past the prefix
+    }
+    return prefix !== '' && line.startsWith(prefix) ? line.slice(prefix.length) : line
+  })
+  return dedented.join('\n').trimEnd()
+}
+
+/** The heading's section: itself plus siblings until the next heading of any level. */
+function headingSectionEnd(heading: SyntaxNode): number {
+  let end = heading.to
+  for (let sibling = heading.nextSibling; sibling; sibling = sibling.nextSibling) {
+    if (isHeadingName(sibling.name)) {
+      break
+    }
+    end = sibling.to
+  }
+  return end
+}
+
+/** The item's first block child when it is a text block (its own bullet line). */
+function leadTextblock(item: SyntaxNode): SyntaxNode | null {
+  for (let child = item.firstChild; child; child = child.nextSibling) {
+    if (child.name === 'ListMark' || child.name === 'TaskMarker') {
+      continue
+    }
+    return isTextblockName(child.name) ? child : null
+  }
+  return null
+}
+
+function containsPos(node: SyntaxNode, pos: number): boolean {
+  return node.from <= pos && pos < node.to
+}
+
+/**
+ * Context for a mention inside a list item, per old Reflect's rules: a
+ * top-level item yields its whole subtree; a nested item yields the parent
+ * item's own line plus the branches under it that mention the same target
+ * (always including the branch the mention itself sits in).
+ */
+function listItemContext(
+  body: string,
+  item: SyntaxNode,
+  targetKey: string | null,
+  bodyPos: number,
+): string {
+  const parentItem = selfOrAncestor(item.parent, (node) => node.name === 'ListItem')
+  const lead = parentItem ? leadTextblock(parentItem) : null
+  if (!parentItem || !lead) {
+    return sliceLines(body, item.from, item.to)
+  }
+
+  const indent = body.slice(lineStartAt(body, parentItem.from), parentItem.from)
+  const pieces: string[] = [sliceLines(body, parentItem.from, lead.to)]
+  for (let child = lead.nextSibling; child; child = child.nextSibling) {
+    const branches = isListName(child.name) ? child.getChildren('ListItem') : [child]
+    for (const branch of branches) {
+      if (branchMentions(body, branch, targetKey) || containsPos(branch, bodyPos)) {
+        pieces.push(dedentBranch(body, branch, indent))
+      }
+    }
+  }
+  return pieces.join('\n')
+}
+
+/** A branch's full lines with the *parent* item's indentation stripped, keeping one nesting level. */
+function dedentBranch(body: string, branch: SyntaxNode, indent: string): string {
+  const from = lineStartAt(body, branch.from)
+  const end = branch.to > branch.from && body[branch.to - 1] === '\n' ? branch.to - 1 : branch.to
+  const lines = body.slice(from, lineEndAt(body, end)).split('\n')
+  const dedented = lines.map((line) =>
+    indent !== '' && line.startsWith(indent) ? line.slice(indent.length) : line,
+  )
+  return dedented.join('\n').trimEnd()
+}
+
+/**
+ * The Markdown block context around the link at whole-file offset `pos` (the
+ * index's `pos_from`, frontmatter offset included) — see the module doc for
+ * the shape per mention location. Falls back to the physical line when the
+ * offset has drifted out of any block (the source changed between the index
+ * write and this read).
+ */
+export function blockContextAt(content: string, pos: number): string {
+  const { body, bodyOffset } = splitFrontmatter(content)
+  const bodyPos = Math.max(0, Math.min(pos - bodyOffset, body.length))
+  const tree = parseBody(body)
+  const leaf: SyntaxNode = tree.resolveInner(bodyPos, 1)
+
+  const link = selfOrAncestor(leaf, (node) => node.name === 'WikiLink')
+  const targetKey = link ? wikiTargetKeyOf(body, link) : null
+
+  const heading = selfOrAncestor(leaf, (node) => isHeadingName(node.name))
+  if (heading) {
+    return sliceLines(body, heading.from, headingSectionEnd(heading))
+  }
+
+  const item = selfOrAncestor(leaf, (node) => node.name === 'ListItem')
+  if (item) {
+    return listItemContext(body, item, targetKey, bodyPos)
+  }
+
+  const block = selfOrAncestor(leaf, (node) => isTextblockName(node.name))
+  if (block) {
+    return sliceLines(body, block.from, block.to)
+  }
+
+  // Not inside a text block: a table cell, or an offset drifted into the gap
+  // between blocks. Use the nearest top-level block, else the bare line.
+  const top = selfOrAncestor(leaf, (node) => node.parent?.name === 'Document')
+  if (top) {
+    return sliceLines(body, top.from, top.to)
+  }
+  return lineAt(content, pos)
+}

--- a/packages/core/src/indexing/block-context.ts
+++ b/packages/core/src/indexing/block-context.ts
@@ -1,4 +1,4 @@
-import type { SyntaxNode } from '@lezer/common'
+import type { SyntaxNode, Tree } from '@lezer/common'
 import { splitFrontmatter } from '../markdown/frontmatter'
 import { parseBody } from '../markdown/grammar'
 import { unescapeMarkdownText } from '../markdown/plain-text'
@@ -14,6 +14,10 @@ import { lineAt } from './snippet'
  * - **Paragraph** — the whole paragraph (which may wrap across lines).
  * - **Heading** — the heading plus every following sibling block up to the
  *   next heading (of any level) or the end of the section's parent.
+ * - **Title heading** — just the heading line. A deliberate divergence from
+ *   old Reflect, where titles lived outside the document: in V2 the note's
+ *   title *is* its first H1, so the section rule would inline the entire note
+ *   into the panel for a mention that just says "this note is about you".
  * - **Top-level list item** — the entire item including all of its nested
  *   children (sub-bullets, task lists), mentioning or not.
  * - **Nested list item** — the parent item's own text line for context, plus
@@ -28,6 +32,7 @@ import { lineAt } from './snippet'
  */
 
 const HEADING_NODE_RE = /^(?:ATXHeading|SetextHeading)[1-6]$/
+const H1_NODE_RE = /^(?:ATXHeading|SetextHeading)1$/
 
 function isHeadingName(name: string): boolean {
   return HEADING_NODE_RE.test(name)
@@ -107,22 +112,26 @@ function lineEndAt(body: string, pos: number): number {
 }
 
 /**
- * The full lines covering `[from, to)`, with the first line's prefix (the text
- * before `from` — indentation, or `> ` inside a blockquote) stripped from every
- * line it also leads. Keeps deeper indentation relative, so a sliced list still
- * renders nested.
+ * The full lines covering `[from, to)`, with `prefix` stripped from every line
+ * it leads. Deeper indentation stays relative, so a sliced list still renders
+ * nested.
  */
-function sliceLines(body: string, from: number, to: number): string {
-  const prefix = body.slice(lineStartAt(body, from), from)
+function dedentedSlice(body: string, from: number, to: number, prefix: string): string {
+  const start = lineStartAt(body, from)
   const end = to > from && body[to - 1] === '\n' ? to - 1 : to
-  const lines = body.slice(from, lineEndAt(body, end)).split('\n')
-  const dedented = lines.map((line, index) => {
-    if (index === 0) {
-      return line // starts at `from`, already past the prefix
-    }
-    return prefix !== '' && line.startsWith(prefix) ? line.slice(prefix.length) : line
-  })
+  const lines = body.slice(start, lineEndAt(body, end)).split('\n')
+  const dedented = lines.map((line) =>
+    prefix !== '' && line.startsWith(prefix) ? line.slice(prefix.length) : line,
+  )
   return dedented.join('\n').trimEnd()
+}
+
+/**
+ * A block's full lines dedented by its own first-line prefix — the text before
+ * `from` on its line: indentation, or `> ` inside a blockquote.
+ */
+function dedentedBlockAt(body: string, from: number, to: number): string {
+  return dedentedSlice(body, from, to, body.slice(lineStartAt(body, from), from))
 }
 
 /** The heading's section: itself plus siblings until the next heading of any level. */
@@ -135,6 +144,33 @@ function headingSectionEnd(heading: SyntaxNode): number {
     end = sibling.to
   }
   return end
+}
+
+/** Does the heading's text line carry anything beyond ATX `#` marks? */
+function headingHasText(body: string, heading: SyntaxNode): boolean {
+  const firstLine = body.slice(heading.from, lineEndAt(body, heading.from))
+  return (
+    firstLine
+      .replace(/^#{1,6}[ \t]*/, '')
+      .replace(/[ \t]*#*[ \t]*$/, '')
+      .trim() !== ''
+  )
+}
+
+/**
+ * Is this heading the note's title — the document's first non-empty top-level
+ * H1, the same heading {@link parseNote}'s title derivation picks?
+ */
+function isTitleHeading(body: string, heading: SyntaxNode): boolean {
+  if (!H1_NODE_RE.test(heading.name) || heading.parent?.name !== 'Document') {
+    return false
+  }
+  for (let child = heading.parent.firstChild; child; child = child.nextSibling) {
+    if (H1_NODE_RE.test(child.name) && headingHasText(body, child)) {
+      return child.from === heading.from
+    }
+  }
+  return false
 }
 
 /** The item's first block child when it is a text block (its own bullet line). */
@@ -167,44 +203,57 @@ function listItemContext(
   const parentItem = selfOrAncestor(item.parent, (node) => node.name === 'ListItem')
   const lead = parentItem ? leadTextblock(parentItem) : null
   if (!parentItem || !lead) {
-    return sliceLines(body, item.from, item.to)
+    return dedentedBlockAt(body, item.from, item.to)
   }
 
   const indent = body.slice(lineStartAt(body, parentItem.from), parentItem.from)
-  const pieces: string[] = [sliceLines(body, parentItem.from, lead.to)]
+  const pieces: string[] = [dedentedBlockAt(body, parentItem.from, lead.to)]
   for (let child = lead.nextSibling; child; child = child.nextSibling) {
     const branches = isListName(child.name) ? child.getChildren('ListItem') : [child]
     for (const branch of branches) {
       if (branchMentions(body, branch, targetKey) || containsPos(branch, bodyPos)) {
-        pieces.push(dedentBranch(body, branch, indent))
+        pieces.push(dedentedSlice(body, branch.from, branch.to, indent))
       }
     }
   }
   return pieces.join('\n')
 }
 
-/** A branch's full lines with the *parent* item's indentation stripped, keeping one nesting level. */
-function dedentBranch(body: string, branch: SyntaxNode, indent: string): string {
-  const from = lineStartAt(body, branch.from)
-  const end = branch.to > branch.from && body[branch.to - 1] === '\n' ? branch.to - 1 : branch.to
-  const lines = body.slice(from, lineEndAt(body, end)).split('\n')
-  const dedented = lines.map((line) =>
-    indent !== '' && line.startsWith(indent) ? line.slice(indent.length) : line,
-  )
-  return dedented.join('\n').trimEnd()
+/**
+ * A note's source prepared for repeated {@link blockContextAt} calls: the
+ * frontmatter carved off once and the body parsed once. The backlinks query
+ * extracts a context per *mention*, and a well-linked source contributes many
+ * mentions — re-parsing per mention would make the panel's cost scale with
+ * link count instead of source count.
+ */
+export interface BlockContextSource {
+  /** Markdown body with the frontmatter carved off. */
+  readonly body: string
+  /** Character offset of `body` within the original file. */
+  readonly bodyOffset: number
+  /** `body` parsed with the canonical Reflect grammar. */
+  readonly tree: Tree
+}
+
+/** Parse a note's full source once for repeated {@link blockContextAt} calls. */
+export function prepareBlockContext(content: string): BlockContextSource {
+  const { body, bodyOffset } = splitFrontmatter(content)
+  return { body, bodyOffset, tree: parseBody(body) }
 }
 
 /**
  * The Markdown block context around the link at whole-file offset `pos` (the
  * index's `pos_from`, frontmatter offset included) — see the module doc for
- * the shape per mention location. Falls back to the physical line when the
- * offset has drifted out of any block (the source changed between the index
- * write and this read).
+ * the shape per mention location. Accepts either raw source (parsed on the
+ * spot) or a {@link prepareBlockContext} handle when extracting several
+ * contexts from one note. Falls back to the physical line when the offset has
+ * drifted out of any block (the source changed between the index write and
+ * this read).
  */
-export function blockContextAt(content: string, pos: number): string {
-  const { body, bodyOffset } = splitFrontmatter(content)
+export function blockContextAt(source: string | BlockContextSource, pos: number): string {
+  const { body, bodyOffset, tree } =
+    typeof source === 'string' ? prepareBlockContext(source) : source
   const bodyPos = Math.max(0, Math.min(pos - bodyOffset, body.length))
-  const tree = parseBody(body)
   const leaf: SyntaxNode = tree.resolveInner(bodyPos, 1)
 
   const link = selfOrAncestor(leaf, (node) => node.name === 'WikiLink')
@@ -212,7 +261,8 @@ export function blockContextAt(content: string, pos: number): string {
 
   const heading = selfOrAncestor(leaf, (node) => isHeadingName(node.name))
   if (heading) {
-    return sliceLines(body, heading.from, headingSectionEnd(heading))
+    const end = isTitleHeading(body, heading) ? heading.to : headingSectionEnd(heading)
+    return dedentedBlockAt(body, heading.from, end)
   }
 
   const item = selfOrAncestor(leaf, (node) => node.name === 'ListItem')
@@ -222,14 +272,14 @@ export function blockContextAt(content: string, pos: number): string {
 
   const block = selfOrAncestor(leaf, (node) => isTextblockName(node.name))
   if (block) {
-    return sliceLines(body, block.from, block.to)
+    return dedentedBlockAt(body, block.from, block.to)
   }
 
   // Not inside a text block: a table cell, or an offset drifted into the gap
   // between blocks. Use the nearest top-level block, else the bare line.
   const top = selfOrAncestor(leaf, (node) => node.parent?.name === 'Document')
   if (top) {
-    return sliceLines(body, top.from, top.to)
+    return dedentedBlockAt(body, top.from, top.to)
   }
-  return lineAt(content, pos)
+  return lineAt(body, bodyPos)
 }

--- a/packages/core/src/indexing/block-context.ts
+++ b/packages/core/src/indexing/block-context.ts
@@ -1,5 +1,5 @@
 import type { SyntaxNode, Tree } from '@lezer/common'
-import { splitFrontmatter } from '../markdown/frontmatter'
+import { parseFrontmatter, splitFrontmatter } from '../markdown/frontmatter'
 import { parseBody } from '../markdown/grammar'
 import { unescapeMarkdownText } from '../markdown/plain-text'
 import { normalizeWikiTarget } from '../markdown/resolve'
@@ -18,6 +18,8 @@ import { lineAt } from './snippet'
  *   old Reflect, where titles lived outside the document: in V2 the note's
  *   title *is* its first H1, so the section rule would inline the entire note
  *   into the panel for a mention that just says "this note is about you".
+ *   Follows {@link parseNote}'s derivation exactly: a frontmatter `title:`
+ *   owns the title, and then every H1 is an ordinary section heading.
  * - **Top-level list item** — the entire item including all of its nested
  *   children (sub-bullets, task lists), mentioning or not.
  * - **Nested list item** — the parent item's own text line for context, plus
@@ -160,9 +162,14 @@ function headingHasText(body: string, heading: SyntaxNode): boolean {
 
 /**
  * Is this heading the note's title — the document's first non-empty top-level
- * H1, the same heading {@link parseNote}'s title derivation picks?
+ * H1, the same heading {@link parseNote}'s title derivation picks? When
+ * frontmatter authors a `title:`, that derivation never promotes an H1, so no
+ * heading is the title and every H1 keeps the section rule.
  */
-function isTitleHeading(body: string, heading: SyntaxNode): boolean {
+function isTitleHeading(body: string, heading: SyntaxNode, frontmatterTitled: boolean): boolean {
+  if (frontmatterTitled) {
+    return false
+  }
   if (!H1_NODE_RE.test(heading.name) || heading.parent?.name !== 'Document') {
     return false
   }
@@ -234,12 +241,16 @@ export interface BlockContextSource {
   readonly bodyOffset: number
   /** `body` parsed with the canonical Reflect grammar. */
   readonly tree: Tree
+  /** Frontmatter authors a `title:`, so no H1 is the note's title. */
+  readonly frontmatterTitled: boolean
 }
 
 /** Parse a note's full source once for repeated {@link blockContextAt} calls. */
 export function prepareBlockContext(content: string): BlockContextSource {
-  const { body, bodyOffset } = splitFrontmatter(content)
-  return { body, bodyOffset, tree: parseBody(body) }
+  const { raw, body, bodyOffset } = splitFrontmatter(content)
+  const title = (parseFrontmatter(raw).data as Record<string, unknown>)['title']
+  const frontmatterTitled = typeof title === 'string' && title.trim() !== ''
+  return { body, bodyOffset, tree: parseBody(body), frontmatterTitled }
 }
 
 /**
@@ -262,7 +273,7 @@ export function blockContextAt(
   pos: number,
   targetKeys?: ReadonlySet<string>,
 ): string {
-  const { body, bodyOffset, tree } =
+  const { body, bodyOffset, tree, frontmatterTitled } =
     typeof source === 'string' ? prepareBlockContext(source) : source
   const bodyPos = Math.max(0, Math.min(pos - bodyOffset, body.length))
   const leaf: SyntaxNode = tree.resolveInner(bodyPos, 1)
@@ -276,7 +287,9 @@ export function blockContextAt(
 
   const heading = selfOrAncestor(leaf, (node) => isHeadingName(node.name))
   if (heading) {
-    const end = isTitleHeading(body, heading) ? heading.to : headingSectionEnd(heading)
+    const end = isTitleHeading(body, heading, frontmatterTitled)
+      ? heading.to
+      : headingSectionEnd(heading)
     return dedentedBlockAt(body, heading.from, end)
   }
 

--- a/packages/core/src/indexing/block-context.ts
+++ b/packages/core/src/indexing/block-context.ts
@@ -67,14 +67,15 @@ function wikiTargetKeyOf(body: string, link: SyntaxNode): string | null {
   return target === '' ? null : normalizeWikiTarget(target).key
 }
 
-/** Does the textblock's inline content hold a wiki link with this match key? */
-function textblockMentions(body: string, block: SyntaxNode, targetKey: string): boolean {
+/** Does the textblock's inline content hold a wiki link with one of these match keys? */
+function textblockMentions(body: string, block: SyntaxNode, keys: ReadonlySet<string>): boolean {
   for (let child = block.firstChild; child; child = child.nextSibling) {
     if (child.name === 'WikiLink') {
-      if (wikiTargetKeyOf(body, child) === targetKey) {
+      const key = wikiTargetKeyOf(body, child)
+      if (key !== null && keys.has(key)) {
         return true
       }
-    } else if (textblockMentions(body, child, targetKey)) {
+    } else if (textblockMentions(body, child, keys)) {
       return true // links nested in emphasis/strikethrough still count
     }
   }
@@ -87,15 +88,15 @@ function textblockMentions(body: string, block: SyntaxNode, targetKey: string): 
  * qualify the branch — old Reflect's `nodeHasDirectBacklink` looked exactly one
  * block deep, and each mention deeper down produces its own context anyway.
  */
-function branchMentions(body: string, branch: SyntaxNode, targetKey: string | null): boolean {
-  if (targetKey === null) {
+function branchMentions(body: string, branch: SyntaxNode, keys: ReadonlySet<string>): boolean {
+  if (keys.size === 0) {
     return false
   }
   if (isTextblockName(branch.name)) {
-    return textblockMentions(body, branch, targetKey)
+    return textblockMentions(body, branch, keys)
   }
   for (let child = branch.firstChild; child; child = child.nextSibling) {
-    if (isTextblockName(child.name) && textblockMentions(body, child, targetKey)) {
+    if (isTextblockName(child.name) && textblockMentions(body, child, keys)) {
       return true
     }
   }
@@ -197,7 +198,7 @@ function containsPos(node: SyntaxNode, pos: number): boolean {
 function listItemContext(
   body: string,
   item: SyntaxNode,
-  targetKey: string | null,
+  targetKeys: ReadonlySet<string>,
   bodyPos: number,
 ): string {
   const parentItem = selfOrAncestor(item.parent, (node) => node.name === 'ListItem')
@@ -211,7 +212,7 @@ function listItemContext(
   for (let child = lead.nextSibling; child; child = child.nextSibling) {
     const branches = isListName(child.name) ? child.getChildren('ListItem') : [child]
     for (const branch of branches) {
-      if (branchMentions(body, branch, targetKey) || containsPos(branch, bodyPos)) {
+      if (branchMentions(body, branch, targetKeys) || containsPos(branch, bodyPos)) {
         pieces.push(dedentedSlice(body, branch.from, branch.to, indent))
       }
     }
@@ -249,15 +250,29 @@ export function prepareBlockContext(content: string): BlockContextSource {
  * contexts from one note. Falls back to the physical line when the offset has
  * drifted out of any block (the source changed between the index write and
  * this read).
+ *
+ * `targetKeys` is every match key that resolves to the target note (title,
+ * aliases, daily date — the `note_keys` view). Sibling branches co-group when
+ * they mention the target under *any* spelling, the way old Reflect compared
+ * resolved note ids; without it, matching falls back to the exact spelling of
+ * the link at `pos`.
  */
-export function blockContextAt(source: string | BlockContextSource, pos: number): string {
+export function blockContextAt(
+  source: string | BlockContextSource,
+  pos: number,
+  targetKeys?: ReadonlySet<string>,
+): string {
   const { body, bodyOffset, tree } =
     typeof source === 'string' ? prepareBlockContext(source) : source
   const bodyPos = Math.max(0, Math.min(pos - bodyOffset, body.length))
   const leaf: SyntaxNode = tree.resolveInner(bodyPos, 1)
 
   const link = selfOrAncestor(leaf, (node) => node.name === 'WikiLink')
-  const targetKey = link ? wikiTargetKeyOf(body, link) : null
+  const posKey = link ? wikiTargetKeyOf(body, link) : null
+  const keys = new Set(targetKeys)
+  if (posKey !== null) {
+    keys.add(posKey) // a stale index entry still anchors its own branch
+  }
 
   const heading = selfOrAncestor(leaf, (node) => isHeadingName(node.name))
   if (heading) {
@@ -267,7 +282,7 @@ export function blockContextAt(source: string | BlockContextSource, pos: number)
 
   const item = selfOrAncestor(leaf, (node) => node.name === 'ListItem')
   if (item) {
-    return listItemContext(body, item, targetKey, bodyPos)
+    return listItemContext(body, item, keys, bodyPos)
   }
 
   const block = selfOrAncestor(leaf, (node) => isTextblockName(node.name))

--- a/packages/core/src/indexing/index.ts
+++ b/packages/core/src/indexing/index.ts
@@ -122,6 +122,7 @@ export {
   type HighlightSegment,
 } from './search'
 export { lineAt, lineSnippet, previewSnippet } from './snippet'
+export { blockContextAt } from './block-context'
 export { parseSearchQuery, type ParsedSearchQuery, type SearchFilters } from './filter-query'
 export {
   searchWithFilters,

--- a/packages/core/src/indexing/index.ts
+++ b/packages/core/src/indexing/index.ts
@@ -122,7 +122,7 @@ export {
   type HighlightSegment,
 } from './search'
 export { lineAt, lineSnippet, previewSnippet } from './snippet'
-export { blockContextAt } from './block-context'
+export { blockContextAt, prepareBlockContext, type BlockContextSource } from './block-context'
 export { parseSearchQuery, type ParsedSearchQuery, type SearchFilters } from './filter-query'
 export {
   searchWithFilters,

--- a/packages/core/src/indexing/queries-backlinks.ts
+++ b/packages/core/src/indexing/queries-backlinks.ts
@@ -1,8 +1,8 @@
 import type { Database } from '@reflect/db'
 import { sql, type Selectable } from 'kysely'
 import { readNote } from '../graph/commands'
+import { blockContextAt } from './block-context'
 import { db } from './db'
-import { lineAt } from './snippet'
 
 export type Backlink = Pick<
   Selectable<Database['backlinks']>,
@@ -24,18 +24,22 @@ export interface BacklinkContext {
   sourcePath: string
   sourceTitle: string
   /**
-   * The whole source line containing the link, as rich-text-renderable Markdown
-   * (empty when the file is unreadable). Not windowed: a half-cut Markdown token
-   * would garble the rendered snippet, so the panel clamps the line visually.
+   * The Markdown block context around the link (old Reflect's rules — see
+   * {@link blockContextAt}): the whole paragraph, the containing list item with
+   * its children, or the heading's section. Empty when the file is unreadable.
+   * Never windowed: a half-cut Markdown token would garble the rendered snippet.
    */
   snippet: string
   posFrom: number
 }
 
 /**
- * Backlinks of `path` with source titles and line snippets. One read per
- * distinct source; a source that vanished between query and read keeps its row
- * with an empty snippet (the index lags deletes only briefly).
+ * Backlinks of `path` with source titles and block-context snippets. One read
+ * per distinct source; a source that vanished between query and read keeps its
+ * row with an empty snippet (the index lags deletes only briefly). Mentions of
+ * one source that produce an identical context collapse into one row — two
+ * links to `path` in the same paragraph read as a single reference, exactly as
+ * old Reflect deduplicated on `[target, contextHtml]`.
  */
 export async function getBacklinksWithContext(path: string): Promise<BacklinkContext[]> {
   const rows = await db
@@ -63,13 +67,24 @@ export async function getBacklinksWithContext(path: string): Promise<BacklinkCon
     }),
   )
 
-  return rows.map((row) => {
+  const seen = new Set<string>()
+  const results: BacklinkContext[] = []
+  for (const row of rows) {
     const content = contents.get(row.sourcePath)
-    return {
+    const snippet = content == null ? '' : blockContextAt(content, row.posFrom)
+    if (snippet !== '') {
+      const key = `${row.sourcePath}\u0000${snippet}`
+      if (seen.has(key)) {
+        continue
+      }
+      seen.add(key)
+    }
+    results.push({
       sourcePath: row.sourcePath,
       sourceTitle: row.sourceTitle,
-      snippet: content == null ? '' : lineAt(content, row.posFrom),
+      snippet,
       posFrom: row.posFrom,
-    }
-  })
+    })
+  }
+  return results
 }

--- a/packages/core/src/indexing/queries-backlinks.ts
+++ b/packages/core/src/indexing/queries-backlinks.ts
@@ -56,6 +56,15 @@ export async function getBacklinksWithContext(path: string): Promise<BacklinkCon
     .orderBy('backlinks.posFrom')
     .execute()
 
+  // Every spelling that resolves to the target (title, aliases, daily date),
+  // so sibling branches co-group under any of them — old Reflect compared
+  // resolved note ids, not link text.
+  const targetKeys = new Set(
+    (await db.selectFrom('noteKeys').where('notePath', '=', path).select('key').execute())
+      .map((row) => row.key)
+      .filter((key): key is string => typeof key === 'string'),
+  )
+
   // One read *and one parse* per distinct source: a well-linked source
   // contributes many rows, and context extraction walks the parsed body.
   const sources = new Map<string, BlockContextSource | null>()
@@ -73,7 +82,7 @@ export async function getBacklinksWithContext(path: string): Promise<BacklinkCon
   const results: BacklinkContext[] = []
   for (const row of rows) {
     const source = sources.get(row.sourcePath)
-    const snippet = source == null ? '' : blockContextAt(source, row.posFrom)
+    const snippet = source == null ? '' : blockContextAt(source, row.posFrom, targetKeys)
     if (snippet !== '') {
       const key = `${row.sourcePath}\u0000${snippet}`
       if (seen.has(key)) {

--- a/packages/core/src/indexing/queries-backlinks.ts
+++ b/packages/core/src/indexing/queries-backlinks.ts
@@ -1,7 +1,7 @@
 import type { Database } from '@reflect/db'
 import { sql, type Selectable } from 'kysely'
 import { readNote } from '../graph/commands'
-import { blockContextAt } from './block-context'
+import { blockContextAt, prepareBlockContext, type BlockContextSource } from './block-context'
 import { db } from './db'
 
 export type Backlink = Pick<
@@ -56,13 +56,15 @@ export async function getBacklinksWithContext(path: string): Promise<BacklinkCon
     .orderBy('backlinks.posFrom')
     .execute()
 
-  const contents = new Map<string, string | null>()
+  // One read *and one parse* per distinct source: a well-linked source
+  // contributes many rows, and context extraction walks the parsed body.
+  const sources = new Map<string, BlockContextSource | null>()
   await Promise.all(
     [...new Set(rows.map((row) => row.sourcePath))].map(async (sourcePath) => {
       try {
-        contents.set(sourcePath, await readNote(sourcePath))
+        sources.set(sourcePath, prepareBlockContext(await readNote(sourcePath)))
       } catch {
-        contents.set(sourcePath, null)
+        sources.set(sourcePath, null)
       }
     }),
   )
@@ -70,8 +72,8 @@ export async function getBacklinksWithContext(path: string): Promise<BacklinkCon
   const seen = new Set<string>()
   const results: BacklinkContext[] = []
   for (const row of rows) {
-    const content = contents.get(row.sourcePath)
-    const snippet = content == null ? '' : blockContextAt(content, row.posFrom)
+    const source = sources.get(row.sourcePath)
+    const snippet = source == null ? '' : blockContextAt(source, row.posFrom)
     if (snippet !== '') {
       const key = `${row.sourcePath}\u0000${snippet}`
       if (seen.has(key)) {

--- a/packages/core/src/indexing/queries.test.ts
+++ b/packages/core/src/indexing/queries.test.ts
@@ -176,6 +176,32 @@ describe('getBacklinksWithContext', () => {
     ])
   })
 
+  it('co-groups sibling branches through the target aliases, not just the clicked spelling', async () => {
+    const content = '- parent line\n  - one [[Project X]]\n  - two [[projx]]\n'
+    mockInvoke.mockImplementation(async (command, args) => {
+      if (command !== 'db_query') {
+        return content
+      }
+      const sql = String(args['sql'])
+      if (sql.includes('note_keys')) {
+        return [{ key: 'project x' }, { key: 'projx' }]
+      }
+      return [
+        {
+          source_path: 'notes/source.md',
+          pos_from: content.indexOf('[[Project X]]'),
+          source_title: 'Source',
+        },
+      ]
+    })
+
+    const rows = await getBacklinksWithContext('notes/target.md')
+
+    expect(rows.map((row) => row.snippet)).toEqual([
+      '- parent line\n  - one [[Project X]]\n  - two [[projx]]',
+    ])
+  })
+
   it('collapses mentions with an identical context into one row (V1 parity)', async () => {
     const content = 'both [[target]] links on one [[target]] line\n\nanother [[target]] mention\n'
     mockInvoke.mockImplementation(async (command) => {

--- a/packages/core/src/indexing/queries.test.ts
+++ b/packages/core/src/indexing/queries.test.ts
@@ -153,6 +153,57 @@ describe('getBacklinksWithContext', () => {
     expect(sql).toContain('"backlinks"."source_path"')
     expect(sql).toContain('"backlinks"."pos_from"')
   })
+
+  it('extracts the block context around the link — a list item keeps its children', async () => {
+    const content = '- kickoff with [[target]]\n  - prep the agenda\n- unrelated\n'
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === 'db_query') {
+        return [
+          {
+            source_path: 'notes/source.md',
+            pos_from: content.indexOf('[[target]]'),
+            source_title: 'Source',
+          },
+        ]
+      }
+      return content
+    })
+
+    const rows = await getBacklinksWithContext('notes/target.md')
+
+    expect(rows.map((row) => row.snippet)).toEqual([
+      '- kickoff with [[target]]\n  - prep the agenda',
+    ])
+  })
+
+  it('collapses mentions with an identical context into one row (V1 parity)', async () => {
+    const content = 'both [[target]] links on one [[target]] line\n\nanother [[target]] mention\n'
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === 'db_query') {
+        return [
+          { source_path: 'notes/source.md', pos_from: 5, source_title: 'Source' },
+          {
+            source_path: 'notes/source.md',
+            pos_from: content.lastIndexOf('[[target]] line'),
+            source_title: 'Source',
+          },
+          {
+            source_path: 'notes/source.md',
+            pos_from: content.indexOf('another'),
+            source_title: 'Source',
+          },
+        ]
+      }
+      return content
+    })
+
+    const rows = await getBacklinksWithContext('notes/target.md')
+
+    expect(rows.map((row) => row.snippet)).toEqual([
+      'both [[target]] links on one [[target]] line',
+      'another [[target]] mention',
+    ])
+  })
 })
 
 describe('getPinnedNotes', () => {


### PR DESCRIPTION
## Problem

The incoming-backlinks panel shows only the single physical line around each link. Old Reflect (V1) showed the whole *unit of meaning* — its `getBacklinkContextHtml` walked the block structure around the mention, which matters most inside lists: a mention bullet brought its sub-bullets and task children along, and a nested mention carried its parent bullet's line for context. This ports those exact rules to Reflect Open.

## What changed

New `blockContextAt(content | preparedSource, pos)` in `@reflect/core` (`packages/core/src/indexing/block-context.ts`), built on the canonical Lezer grammar, replaces `lineAt` in `getBacklinksWithContext`. Context per mention location, matching V1's algorithm:

| Mention location | Snippet (before → after) |
|---|---|
| Paragraph | one physical line → the whole paragraph |
| Heading | the heading line → heading + section up to the next heading (any level) |
| **Title H1** | the heading line → **still just the heading line** (see divergence note) |
| Top-level list item | the bullet's line → the entire item incl. all nested children |
| Nested list item | the bullet's line → parent bullet's own line + every branch under it mentioning the same target under *any* of its keys — title, aliases, daily date — like V1's resolved-id comparison (unrelated siblings dropped; exactly one ancestor level, like V1) |
| Blockquote | the raw `> ` line → the quoted paragraph, chrome stripped |
| Table cell | the row's raw line → the whole table |

Also ported:

- **Dedup (V1 parity):** mentions of one source that produce an identical context collapse into a single row, mirroring V1's `uniqBy([target, contextHtml])` — two links to the same note in one paragraph read as one reference.
- **No snippet truncation:** `BacklinkSnippet` drops its `line-clamp-2`; contexts are block-shaped and V1 never truncated them (it clamped the panel, not the snippet). Mobile shares the same component and data layer, so both surfaces pick this up.

**Deliberate divergence — title H1:** V1 stored note titles outside the document, so its heading rule never saw a title. In V2 the title *is* the body's first H1, and V1's section rule would inline the entire note into the panel for `# Meeting with [[Alice]]`. A mention in the document's first non-empty top-level H1 therefore yields just the heading line; every other heading keeps the V1 section rule.

**Performance:** `prepareBlockContext` parses each source note once for all of its mentions (read *and* parse are per distinct source, not per row), so panel cost scales with source count, matching the old `lineAt` behavior in spirit.

Snippets are still computed at query time from the markdown source — the SQLite index schema and the `links` table are untouched, so no projection bump and no CLI ripple.

## Testing

- 21 unit tests for `blockContextAt` covering every rule above plus frontmatter offset mapping, case-insensitive sibling matching, deep nesting (one-ancestor climb), round task children, ordered-list numbering, setext titles, loose list items, tab-indented nesting, prepared-source reuse, and drifted-offset fallback.
- 2 `getBacklinksWithContext` tests: list-context extraction through the query, and identical-context dedup.
- Existing desktop panel, mobile, grouping, and snippet suites pass unchanged; `pnpm check` (typecheck + oxlint + eslint) green.
- Not yet manually verified in the running app — a visual pass over a graph with list-heavy notes is owed.

## Risks / follow-ups

- Non-title heading mentions can still produce large snippets (V1 behaved the same). V1 bounded the *panel* at 600px/80vh with virtualization past 100 backlinks; that container behavior is not ported here and is a candidate follow-up if panels get tall.
- V1 let you toggle task checkboxes inside a snippet (writing through to the source note); snippets here remain read-only (follow-up task spawned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Query-time parsing and richer snippets change backlink panel output and cost for heavily linked notes, but indexing and auth/data paths are untouched.
> 
> **Overview**
> Incoming backlinks now show **block-level Markdown context** (paragraph, list subtree, heading section, etc.) instead of a single physical line, matching old Reflect’s rules via new `blockContextAt` / `prepareBlockContext` in `@reflect/core`.
> 
> `getBacklinksWithContext` uses that extraction (one parse per source note), loads target `note_keys` so nested list siblings co-group across aliases, and **dedupes** rows when the same source yields identical context. **Title H1** mentions intentionally return only the heading line so the whole note isn’t inlined.
> 
> `BacklinkSnippet` drops `line-clamp-2` so multi-line nested context can render fully. Index schema is unchanged; snippets are still computed at query time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00bae86024ec85f62ec5721a8b925f2bdaaf28b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

