### PR TITLE
fix(desktop): open custom app URI scheme links from notes

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -11,7 +11,8 @@
     "opener:default",
     {
       "identifier": "opener:allow-open-url",
-      "allow": [{ "url": "x-apple.systempreferences:*" }]
+      "allow": [{ "url": "x-apple.systempreferences:*" }, { "url": "*://*" }],
+      "deny": [{ "url": "file://*" }]
     },
     "dialog:default",
     {

--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -523,6 +523,27 @@ describe('NoteEditor link opening', () => {
     expect(openUrl).toHaveBeenCalledWith('https://example.com')
   })
 
+  it('opens a custom app scheme link via the URL opener', () => {
+    renderEditor()
+
+    const event = new MouseEvent('click')
+    act(() =>
+      captured.props?.onLinkClick?.({ href: 'x-devonthink-item://40C88434-68B6-4DCB', event }),
+    )
+
+    expect(openUrl).toHaveBeenCalledWith('x-devonthink-item://40C88434-68B6-4DCB')
+  })
+
+  it('drops an unsafe scheme link without opening anything', () => {
+    renderEditor()
+
+    const event = new MouseEvent('click')
+    act(() => captured.props?.onLinkClick?.({ href: 'file:///etc/passwd', event }))
+
+    expect(openUrl).not.toHaveBeenCalled()
+    expect(dispatchDeepLink).not.toHaveBeenCalled()
+  })
+
   it('opens an assets/ link through the graph asset opener, not the URL opener', () => {
     const openImage = vi.fn(async () => {})
     renderEditor(openImage)

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -34,6 +34,7 @@ import {
   ImageLightbox,
   type LightboxImage,
 } from '@/editor/image-lightbox'
+import { isOpenableExternalUrl } from '@/editor/open-external-link'
 import { isTouchEditorSurface } from '@/lib/platform-surface'
 import { useLightboxTransition } from '@/editor/use-lightbox-transition'
 import { dispatchDeepLink } from '@/lib/deep-links/intake'
@@ -324,6 +325,9 @@ export function NoteEditor({
           return
         }
         dispatchDeepLink(href)
+        return
+      }
+      if (!isOpenableExternalUrl(href)) {
         return
       }
       void openUrl(href).catch((cause) => {

--- a/apps/desktop/src/editor/open-external-link.test.ts
+++ b/apps/desktop/src/editor/open-external-link.test.ts
@@ -36,8 +36,29 @@ describe('openExternalLink', () => {
     expect(openUrl).not.toHaveBeenCalled()
   })
 
-  it('drops other schemes without opening anything', () => {
-    const event = click('javascript:alert(1)')
+  it('opens a custom app scheme in its OS default app', () => {
+    const event = click('x-devonthink-item://40C88434-68B6-4DCB-A258-754679764C3C')
+
+    expect(openUrl).toHaveBeenCalledWith('x-devonthink-item://40C88434-68B6-4DCB-A258-754679764C3C')
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it.each([
+    ['javascript:alert(1)'],
+    ['JavaScript:alert(1)'],
+    ['data:text/html,<script>alert(1)</script>'],
+    ['file:///etc/passwd'],
+    ['blob:https://example.com/uuid'],
+  ])('drops the unsafe scheme %s without opening anything', (href) => {
+    const event = click(href)
+
+    expect(openUrl).not.toHaveBeenCalled()
+    expect(dispatchDeepLink).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('drops a scheme-less relative href', () => {
+    const event = click('notes/foo.md')
 
     expect(openUrl).not.toHaveBeenCalled()
     expect(dispatchDeepLink).not.toHaveBeenCalled()

--- a/apps/desktop/src/editor/open-external-link.ts
+++ b/apps/desktop/src/editor/open-external-link.ts
@@ -4,11 +4,37 @@ import { dispatchDeepLink } from '@/lib/deep-links/intake'
 import { isDeepLinkUrl } from '@/lib/deep-links/parse'
 
 /**
- * Open a rendered Markdown link in the OS browser instead of letting the click
- * navigate the app's WebView frame. The static `MarkdownView` surfaces aren't
- * contenteditable, so an `<a href>` click would otherwise unload the whole app.
- * A `reflect://` link routes through the in-app deep-link pipeline instead —
- * the OS opener denies the scheme.
+ * Schemes that must never reach the OS opener: script and data URIs carry
+ * executable content rather than an address, and `file:`/`blob:` open
+ * arbitrary local content a synced or captured note could point at.
+ */
+const BLOCKED_SCHEMES: ReadonlySet<string> = new Set([
+  'javascript',
+  'vbscript',
+  'data',
+  'blob',
+  'about',
+  'file',
+])
+
+/**
+ * Whether `href` is an absolute URL that may be handed to the OS opener.
+ * Any app scheme qualifies (`https:`, `x-devonthink-item:`, `bear:`, …) —
+ * the OS resolves the handler — but the blocked schemes and scheme-less
+ * relative hrefs never do. The opener capability mirrors this policy
+ * (`*://*` allowed, `file://*` denied) as the Rust-side backstop.
+ */
+export function isOpenableExternalUrl(href: string): boolean {
+  const scheme = /^([a-z][a-z0-9+.-]*):/i.exec(href)?.[1]
+  return scheme !== undefined && !BLOCKED_SCHEMES.has(scheme.toLowerCase())
+}
+
+/**
+ * Open a rendered Markdown link in its OS default app instead of letting the
+ * click navigate the app's WebView frame. The static `MarkdownView` surfaces
+ * aren't contenteditable, so an `<a href>` click would otherwise unload the
+ * whole app. A `reflect://` link routes through the in-app deep-link pipeline
+ * instead — the OS opener denies the scheme.
  */
 export const openExternalLink: LinkClickHandler = ({ href, event }) => {
   event.preventDefault()
@@ -16,7 +42,7 @@ export const openExternalLink: LinkClickHandler = ({ href, event }) => {
     dispatchDeepLink(href)
     return
   }
-  if (/^https?:\/\//i.test(href)) {
+  if (isOpenableExternalUrl(href)) {
     void openUrl(href)
   }
 }


### PR DESCRIPTION
## Problem

Clicking a Markdown link whose destination uses a custom app URI scheme — `x-devonthink-item://…`, `bear://…`, `obsidian://…` — did nothing. Two independent blockers:

- **Preview surfaces** (`MarkdownView` in the markdown preview and backlink snippets) route clicks through `openExternalLink`, which explicitly filtered hrefs to `^https?://` and silently dropped everything else.
- **The note editor** already forwarded any href to `openUrl`, but the Tauri opener capability only allowed `http`/`https`/`mailto`/`tel` (plus `x-apple.systempreferences:`), so the Rust layer denied the open and the click died with a console error.

## Changes

- `open-external-link.ts` gains `isOpenableExternalUrl`: an href with any absolute scheme may go to the OS opener, **except** schemes that carry executable or local content rather than an address — `javascript`, `vbscript`, `data`, `blob`, `about`, `file` (checked case-insensitively). Scheme-less relative hrefs stay dropped.
- `openExternalLink` (preview surfaces) and the note editor's `handleLinkClick` fall-through both use that one guard, so the editor and the read-only surfaces share the same policy. `reflect://` deep links and `assets/…` attachment hrefs keep their existing dedicated routing.
- `capabilities/default.json` mirrors the policy as the Rust-side backstop: `*://*` allowed, `file://*` explicitly denied. The blocked script schemes don't match `*://*` at the scope layer either (no `://`), and the frontend guard catches pathological forms like `javascript:foo://`.

## Testing

- `pnpm --filter @reflect/desktop test --run src/editor/open-external-link.test.ts src/editor/note-editor.test.tsx` — 44 passing, including new cases: custom scheme opens, `file:`/`javascript:`/`data:`/`blob:` (and case-variant `JavaScript:`) dropped, relative hrefs dropped, `reflect://` still routed in-app.
- `pnpm check` clean; `cargo check -p reflect-open` passes, which validates the capability JSON through tauri-build.
- **Not verified manually**: an end-to-end click on a real `x-devonthink-item://` link in the running app (no DEVONthink handler on this machine). Residual risk is limited to the opener scope glob; the unit tests pin the frontend policy.

## Risk / rollout

- Broadening the opener scope means any clicked link can launch whatever app owns its scheme. That is the intended behavior (parity with other Markdown apps), gated on an explicit user click, and the dangerous schemes are blocked in both layers.
- `file://` links remain non-functional by design; if file links become a feature they should route through a dedicated, prompted path rather than the opener scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broadens what user-clicked links can launch via the OS opener; mitigated by explicit click gating and dual-layer blocking of script, data, and file schemes.
> 
> **Overview**
> **Custom app links** (`x-devonthink-item:`, `bear:`, etc.) in note markdown now open in the OS default handler on explicit click, instead of being ignored in previews or denied by Tauri.
> 
> A shared **`isOpenableExternalUrl`** guard replaces the old `https?`-only check in **`openExternalLink`** (markdown preview and backlink snippets) and in the note editor’s link-click path. Any absolute scheme is allowed except **`javascript`**, **`data`**, **`file`**, **`blob`**, and related unsafe schemes (case-insensitive); scheme-less relative hrefs are still dropped. **`reflect://`** and **`assets/…`** routing is unchanged.
> 
> **Tauri `opener:allow-open-url`** is widened to **`*://*`** with an explicit **`file://*`** deny, matching the frontend policy as a Rust-side backstop.
> 
> Tests cover custom schemes, blocked schemes, and editor vs preview behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0fdcfb785244669bf372b343d66c2022cc1a9c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->