### PR TITLE
feat(desktop): download Firebase attachments during Reflect V1 import

### DIFF
--- a/apps/desktop/src-tauri/src/fs/assets.rs
+++ b/apps/desktop/src-tauri/src/fs/assets.rs
@@ -114,10 +114,11 @@ fn persist_unique(
     )))
 }
 
-/// The staging directory for in-flight uploads: inside the graph (so the
-/// commit rename stays on one filesystem) but under `.reflect/` (so the
-/// watcher, indexer, and sync never see a partial file).
-fn staging_dir(root: &Path) -> AppResult<std::path::PathBuf> {
+/// The staging directory for in-flight uploads (and the V1 import's asset
+/// downloads): inside the graph (so the commit rename stays on one
+/// filesystem) but under `.reflect/` (so the watcher, indexer, and sync never
+/// see a partial file).
+pub(super) fn staging_dir(root: &Path) -> AppResult<std::path::PathBuf> {
     let dir = root.join(".reflect").join("tmp");
     fs::create_dir_all(&dir)?;
     Ok(dir)

--- a/apps/desktop/src-tauri/src/fs/import.rs
+++ b/apps/desktop/src-tauri/src/fs/import.rs
@@ -3,17 +3,25 @@
 //! Reflect V1 now exports the same markdown graph layout Reflect Open reads:
 //! `daily/`, `notes/`, optional `assets/`, plus ignorable local metadata. The
 //! import path is therefore a bounded archive extraction into the active graph,
-//! not a content migration.
+//! not a content migration — with one addition: attachments the notes link
+//! straight to Firebase Storage are downloaded into `assets/` and the links
+//! rewritten (see [`super::import_assets`]).
+//!
+//! The flow is three phases so nothing lands in the graph until everything is
+//! in hand: [`prepare_zip_import`] (read + validate, no writes), the async
+//! [`PreparedImport::download_assets`] (network, staging writes only), then
+//! [`finalize_import`] (rewrite, collision-check, atomic writes).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
 use crate::error::{AppError, AppResult};
 
+use super::import_assets::{self, DownloadOutcome};
 use super::io::{atomic_write_bytes, file_occupied};
 use super::resolve::resolve;
 
@@ -21,10 +29,16 @@ use super::resolve::resolve;
 #[derive(Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ImportSummary {
-    /// Files newly written to the open graph.
+    /// Zip files newly written to the open graph.
     pub imported_files: usize,
-    /// Files already present with identical bytes, left untouched.
+    /// Zip files already present with identical bytes, left untouched.
     pub skipped_files: usize,
+    /// Remote attachments now stored locally under `assets/` (whether newly
+    /// written or already present from an earlier import).
+    pub downloaded_assets: usize,
+    /// Remote attachments that are permanently gone (4xx); their notes keep
+    /// the remote link.
+    pub failed_asset_downloads: usize,
     /// Graph-relative paths newly written to the open graph.
     pub changed_paths: Vec<String>,
 }
@@ -34,14 +48,64 @@ struct ImportEntry {
     bytes: Vec<u8>,
 }
 
-/// Import a user-selected Reflect V1 export zip into `root`.
-pub(super) fn import_zip_into_graph(root: &Path, zip_path: &Path) -> AppResult<ImportSummary> {
-    let entries = read_zip_entries(zip_path)?;
-    import_entries_into_graph(root, entries)
+/// A validated export, read out of the zip but not yet written anywhere.
+pub struct PreparedImport {
+    entries: Vec<ImportEntry>,
+    staging: PathBuf,
+    /// Unique remote-asset URLs across all notes, in first-seen order (which
+    /// also fixes collision-suffix assignment).
+    urls: Vec<String>,
+    prefix: String,
 }
 
-fn import_entries_into_graph(root: &Path, entries: Vec<ImportEntry>) -> AppResult<ImportSummary> {
-    let entries = dedupe_entries(entries)?;
+impl PreparedImport {
+    /// Download every remote attachment into the graph's staging directory.
+    /// Transient failures abort (nothing has been written to the graph yet);
+    /// permanent 4xx failures come back as [`DownloadOutcome::Gone`].
+    pub async fn download_assets(&self) -> AppResult<HashMap<String, DownloadOutcome>> {
+        import_assets::download_remote_assets(&self.staging, self.urls.clone()).await
+    }
+}
+
+/// Read and validate a user-selected Reflect V1 export zip against `root`,
+/// without writing anything.
+pub(super) fn prepare_zip_import(root: &Path, zip_path: &Path) -> AppResult<PreparedImport> {
+    prepare_zip_import_from(root, zip_path, import_assets::V1_ASSET_URL_PREFIX)
+}
+
+/// [`prepare_zip_import`] with the remote-asset URL prefix injectable, so
+/// tests can point it at a local server.
+fn prepare_zip_import_from(
+    root: &Path,
+    zip_path: &Path,
+    prefix: &str,
+) -> AppResult<PreparedImport> {
+    let entries = dedupe_entries(read_zip_entries(zip_path)?)?;
+    ensure_has_notes(&entries)?;
+    let mut seen = HashSet::new();
+    let mut urls = Vec::new();
+    for entry in &entries {
+        if !is_note_markdown(&entry.relative) {
+            continue;
+        }
+        let Ok(text) = std::str::from_utf8(&entry.bytes) else {
+            continue;
+        };
+        for span in import_assets::scan_remote_spans(text, prefix) {
+            if seen.insert(span.url.clone()) {
+                urls.push(span.url);
+            }
+        }
+    }
+    Ok(PreparedImport {
+        entries,
+        staging: super::assets::staging_dir(root)?,
+        urls,
+        prefix: prefix.to_string(),
+    })
+}
+
+fn ensure_has_notes(entries: &[ImportEntry]) -> AppResult<()> {
     if !entries
         .iter()
         .any(|entry| is_note_markdown(&entry.relative))
@@ -49,6 +113,63 @@ fn import_entries_into_graph(root: &Path, entries: Vec<ImportEntry>) -> AppResul
         return Err(AppError::not_found(
             "that doesn't look like a Reflect V1 export — no notes found under daily/ or notes/",
         ));
+    }
+    Ok(())
+}
+
+/// Localize the downloaded attachments, rewrite the notes' remote links to
+/// `assets/…` paths, then write everything into the graph with the same
+/// collision policy as before: never overwrite a differing existing file,
+/// skip identical ones.
+pub(super) fn finalize_import(
+    root: &Path,
+    prepared: PreparedImport,
+    mut outcomes: HashMap<String, DownloadOutcome>,
+) -> AppResult<ImportSummary> {
+    let PreparedImport {
+        mut entries,
+        urls,
+        prefix,
+        ..
+    } = prepared;
+
+    let assets_dir = root.join("assets");
+    let mut replacements = HashMap::new();
+    let mut planned = Vec::new();
+    let mut taken = HashSet::new();
+    let mut failed_asset_downloads = 0;
+    for url in &urls {
+        match outcomes.remove(url) {
+            Some(DownloadOutcome::Fetched(fetched)) => {
+                let plan = import_assets::plan_asset_name(
+                    &assets_dir,
+                    &fetched.desired_name,
+                    fetched.file.path(),
+                    &taken,
+                )?;
+                taken.insert(plan.name.clone());
+                replacements.insert(url.clone(), format!("assets/{}", plan.name));
+                planned.push((fetched, plan));
+            }
+            Some(DownloadOutcome::Gone) => failed_asset_downloads += 1,
+            None => {}
+        }
+    }
+    let downloaded_assets = planned.len();
+
+    if !replacements.is_empty() {
+        for entry in &mut entries {
+            if !is_note_markdown(&entry.relative) {
+                continue;
+            }
+            let Ok(text) = std::str::from_utf8(&entry.bytes) else {
+                continue;
+            };
+            let rewritten = import_assets::rewrite_markdown(text, &prefix, &replacements);
+            if rewritten != text {
+                entry.bytes = rewritten.into_bytes();
+            }
+        }
     }
 
     let collisions = entries
@@ -73,6 +194,13 @@ fn import_entries_into_graph(root: &Path, entries: Vec<ImportEntry>) -> AppResul
     let mut imported_files = 0;
     let mut skipped_files = 0;
     let mut changed_paths = Vec::new();
+    for (fetched, plan) in planned {
+        if plan.reuse {
+            continue;
+        }
+        import_assets::persist_planned(fetched, &assets_dir, &plan.name)?;
+        changed_paths.push(format!("assets/{}", plan.name));
+    }
     for entry in entries {
         let target = resolve(root, &entry.relative)?;
         if let Some(path) = collision(root, &entry)? {
@@ -92,6 +220,8 @@ fn import_entries_into_graph(root: &Path, entries: Vec<ImportEntry>) -> AppResul
     Ok(ImportSummary {
         imported_files,
         skipped_files,
+        downloaded_assets,
+        failed_asset_downloads,
         changed_paths,
     })
 }
@@ -265,7 +395,8 @@ fn is_note_markdown(relative: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::TcpListener;
     use tempfile::tempdir;
     use zip::write::SimpleFileOptions;
 
@@ -281,6 +412,28 @@ mod tests {
             .collect()
     }
 
+    /// The old single-call import shape, for tests that exercise extraction
+    /// and collision policy without remote assets.
+    fn import_entries_into_graph(
+        root: &Path,
+        entries: Vec<ImportEntry>,
+    ) -> AppResult<ImportSummary> {
+        let entries = dedupe_entries(entries)?;
+        ensure_has_notes(&entries)?;
+        let prepared = PreparedImport {
+            entries,
+            staging: super::super::assets::staging_dir(root)?,
+            urls: Vec::new(),
+            prefix: import_assets::V1_ASSET_URL_PREFIX.to_string(),
+        };
+        finalize_import(root, prepared, HashMap::new())
+    }
+
+    fn import_zip_into_graph(root: &Path, zip_path: &Path) -> AppResult<ImportSummary> {
+        let prepared = prepare_zip_import(root, zip_path)?;
+        finalize_import(root, prepared, HashMap::new())
+    }
+
     fn write_zip(path: &Path, pairs: &[(&str, &str)]) {
         let file = fs::File::create(path).unwrap();
         let mut writer = zip::ZipWriter::new(file);
@@ -290,6 +443,54 @@ mod tests {
             writer.write_all(contents.as_bytes()).unwrap();
         }
         writer.finish().unwrap();
+    }
+
+    /// Serve canned HTTP responses on a local port: each entry is
+    /// `(path, status line, extra headers, body)`. Handles connections until
+    /// the expected request count is reached.
+    fn serve(
+        responses: Vec<(&'static str, &'static str, &'static str, &'static [u8])>,
+        expected_requests: usize,
+    ) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let base = format!("http://{}/", listener.local_addr().unwrap());
+        std::thread::spawn(move || {
+            for _ in 0..expected_requests {
+                let Ok((stream, _)) = listener.accept() else {
+                    return;
+                };
+                let mut reader = BufReader::new(stream);
+                let mut request_line = String::new();
+                if reader.read_line(&mut request_line).is_err() {
+                    continue;
+                }
+                loop {
+                    let mut header = String::new();
+                    if reader.read_line(&mut header).is_err() || header.trim().is_empty() {
+                        break;
+                    }
+                }
+                let requested = request_line.split_whitespace().nth(1).unwrap_or("");
+                let mut stream = reader.into_inner();
+                match responses.iter().find(|(path, ..)| *path == requested) {
+                    Some((_, status, headers, body)) => {
+                        let _ = write!(
+                            stream,
+                            "HTTP/1.1 {status}\r\nConnection: close\r\nContent-Length: {}\r\n{headers}\r\n",
+                            body.len()
+                        );
+                        let _ = stream.write_all(body);
+                    }
+                    None => {
+                        let _ = write!(
+                            stream,
+                            "HTTP/1.1 404 Not Found\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"
+                        );
+                    }
+                }
+            }
+        });
+        base
     }
 
     #[test]
@@ -312,6 +513,8 @@ mod tests {
             ImportSummary {
                 imported_files: 3,
                 skipped_files: 0,
+                downloaded_assets: 0,
+                failed_asset_downloads: 0,
                 changed_paths: vec![
                     "notes/a.md".to_string(),
                     "daily/2026-07-04.md".to_string(),
@@ -389,6 +592,8 @@ mod tests {
             ImportSummary {
                 imported_files: 0,
                 skipped_files: 1,
+                downloaded_assets: 0,
+                failed_asset_downloads: 0,
                 changed_paths: Vec::new(),
             }
         );
@@ -409,6 +614,8 @@ mod tests {
             ImportSummary {
                 imported_files: 1,
                 skipped_files: 0,
+                downloaded_assets: 0,
+                failed_asset_downloads: 0,
                 changed_paths: vec!["notes/a.md".to_string()],
             }
         );
@@ -458,6 +665,139 @@ mod tests {
 
         assert!(result.is_err());
         assert!(!root.path().join("assets/pic.bin").exists());
+    }
+
+    fn import_zip_downloading_from(
+        root: &Path,
+        zip_path: &Path,
+        prefix: &str,
+    ) -> AppResult<ImportSummary> {
+        let prepared = prepare_zip_import_from(root, zip_path, prefix)?;
+        let downloads = tauri::async_runtime::block_on(prepared.download_assets())?;
+        finalize_import(root, prepared, downloads)
+    }
+
+    #[test]
+    fn downloads_remote_assets_and_rewrites_links() {
+        let root = tempdir().unwrap();
+        let base = serve(
+            vec![
+                (
+                    "/photo?alt=media&token=t",
+                    "200 OK",
+                    "Content-Type: image/webp\r\nContent-Disposition: inline; filename=\"Trip Photo.webp\"\r\n",
+                    b"webp bytes",
+                ),
+                (
+                    "/memo?alt=media&token=u",
+                    "200 OK",
+                    "Content-Type: audio/mp4\r\n",
+                    b"audio bytes",
+                ),
+                (
+                    "/users%2Fabc%2F9c2c28?alt=media&token=v",
+                    "200 OK",
+                    "Content-Type: image/png\r\nContent-Disposition: inline; filename*=utf-8''9c2c28\r\n",
+                    b"png bytes",
+                ),
+            ],
+            3,
+        );
+        let zip_path = root.path().join("export.zip");
+        let markdown = format!(
+            "![]({base}photo?alt=media\\&token=t)\n\n[memo.m4a]({base}memo?alt=media\\&token=u)\n\n![]({base}users%2Fabc%2F9c2c28?alt=media\\&token=v)\n"
+        );
+        write_zip(&zip_path, &[("daily/2026-07-04.md", markdown.as_str())]);
+
+        let summary = import_zip_downloading_from(root.path(), &zip_path, &base).unwrap();
+
+        assert_eq!(summary.imported_files, 1);
+        assert_eq!(summary.downloaded_assets, 3);
+        assert_eq!(summary.failed_asset_downloads, 0);
+        assert!(summary
+            .changed_paths
+            .contains(&"assets/trip-photo.webp".to_string()));
+        assert!(summary.changed_paths.contains(&"assets/memo.m4a".to_string()));
+        assert_eq!(
+            fs::read(root.path().join("assets/trip-photo.webp")).unwrap(),
+            b"webp bytes"
+        );
+        assert_eq!(
+            fs::read(root.path().join("assets/memo.m4a")).unwrap(),
+            b"audio bytes"
+        );
+        assert_eq!(
+            fs::read(root.path().join("assets/9c2c28.png")).unwrap(),
+            b"png bytes"
+        );
+        let note = fs::read_to_string(root.path().join("daily/2026-07-04.md")).unwrap();
+        assert_eq!(
+            note,
+            "![](assets/trip-photo.webp)\n\n[memo.m4a](assets/memo.m4a)\n\n![](assets/9c2c28.png)\n"
+        );
+    }
+
+    #[test]
+    fn gone_assets_keep_their_remote_links() {
+        let root = tempdir().unwrap();
+        let base = serve(vec![], 1);
+        let zip_path = root.path().join("export.zip");
+        let markdown = format!("![]({base}deleted?alt=media\\&token=t)\n");
+        write_zip(&zip_path, &[("daily/2026-07-04.md", markdown.as_str())]);
+
+        let summary = import_zip_downloading_from(root.path(), &zip_path, &base).unwrap();
+
+        assert_eq!(summary.imported_files, 1);
+        assert_eq!(summary.downloaded_assets, 0);
+        assert_eq!(summary.failed_asset_downloads, 1);
+        let note = fs::read_to_string(root.path().join("daily/2026-07-04.md")).unwrap();
+        assert_eq!(note, markdown);
+        assert!(!root.path().join("assets").join("deleted").exists());
+    }
+
+    #[test]
+    fn unreachable_asset_host_aborts_before_any_write() {
+        let root = tempdir().unwrap();
+        // Bind then drop, so the port refuses connections.
+        let dead = TcpListener::bind("127.0.0.1:0").unwrap();
+        let base = format!("http://{}/", dead.local_addr().unwrap());
+        drop(dead);
+        let zip_path = root.path().join("export.zip");
+        let markdown = format!("![]({base}photo?alt=media\\&token=t)\n");
+        write_zip(&zip_path, &[("daily/2026-07-04.md", markdown.as_str())]);
+
+        let result = import_zip_downloading_from(root.path(), &zip_path, &base);
+
+        assert!(matches!(result.unwrap_err(), AppError::Network { .. }));
+        assert!(!root.path().join("daily/2026-07-04.md").exists());
+    }
+
+    #[test]
+    fn reimporting_the_same_export_reuses_downloaded_assets() {
+        let root = tempdir().unwrap();
+        let base = serve(
+            vec![(
+                "/photo?alt=media&token=t",
+                "200 OK",
+                "Content-Type: image/png\r\nContent-Disposition: inline; filename=\"pic.png\"\r\n",
+                b"png bytes",
+            )],
+            2,
+        );
+        let zip_path = root.path().join("export.zip");
+        let markdown = format!("![]({base}photo?alt=media\\&token=t)\n");
+        write_zip(&zip_path, &[("daily/2026-07-04.md", markdown.as_str())]);
+
+        let first = import_zip_downloading_from(root.path(), &zip_path, &base).unwrap();
+        assert_eq!(first.imported_files, 1);
+        assert_eq!(first.downloaded_assets, 1);
+
+        let second = import_zip_downloading_from(root.path(), &zip_path, &base).unwrap();
+        assert_eq!(second.imported_files, 0);
+        assert_eq!(second.skipped_files, 1);
+        assert_eq!(second.downloaded_assets, 1);
+        assert!(second.changed_paths.is_empty());
+        assert!(!root.path().join("assets/pic-2.png").exists());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/fs/import.rs
+++ b/apps/desktop/src-tauri/src/fs/import.rs
@@ -717,7 +717,9 @@ mod tests {
         assert!(summary
             .changed_paths
             .contains(&"assets/trip-photo.webp".to_string()));
-        assert!(summary.changed_paths.contains(&"assets/memo.m4a".to_string()));
+        assert!(summary
+            .changed_paths
+            .contains(&"assets/memo.m4a".to_string()));
         assert_eq!(
             fs::read(root.path().join("assets/trip-photo.webp")).unwrap(),
             b"webp bytes"

--- a/apps/desktop/src-tauri/src/fs/import.rs
+++ b/apps/desktop/src-tauri/src/fs/import.rs
@@ -105,6 +105,23 @@ fn prepare_zip_import_from(
     })
 }
 
+/// Two distinct URLs can serve the same attachment (V1 stored one upload per
+/// link). When a download matches an already-planned asset's name and bytes,
+/// both links share that one file instead of persisting a `-2` duplicate.
+fn planned_duplicate(
+    planned: &[(import_assets::FetchedAsset, import_assets::PlannedAssetName)],
+    fetched: &import_assets::FetchedAsset,
+) -> AppResult<Option<String>> {
+    for (prior, plan) in planned {
+        if prior.desired_name == fetched.desired_name
+            && import_assets::same_file_bytes(prior.file.path(), fetched.file.path())?
+        {
+            return Ok(Some(plan.name.clone()));
+        }
+    }
+    Ok(None)
+}
+
 fn ensure_has_notes(entries: &[ImportEntry]) -> AppResult<()> {
     if !entries
         .iter()
@@ -135,12 +152,19 @@ pub(super) fn finalize_import(
 
     let assets_dir = root.join("assets");
     let mut replacements = HashMap::new();
-    let mut planned = Vec::new();
+    let mut planned: Vec<(import_assets::FetchedAsset, import_assets::PlannedAssetName)> =
+        Vec::new();
     let mut taken = HashSet::new();
+    let mut downloaded_assets = 0;
     let mut failed_asset_downloads = 0;
     for url in &urls {
         match outcomes.remove(url) {
             Some(DownloadOutcome::Fetched(fetched)) => {
+                downloaded_assets += 1;
+                if let Some(name) = planned_duplicate(&planned, &fetched)? {
+                    replacements.insert(url.clone(), format!("assets/{name}"));
+                    continue;
+                }
                 let plan = import_assets::plan_asset_name(
                     &assets_dir,
                     &fetched.desired_name,
@@ -155,7 +179,6 @@ pub(super) fn finalize_import(
             None => {}
         }
     }
-    let downloaded_assets = planned.len();
 
     if !replacements.is_empty() {
         for entry in &mut entries {
@@ -737,6 +760,41 @@ mod tests {
             note,
             "![](assets/trip-photo.webp)\n\n[memo.m4a](assets/memo.m4a)\n\n![](assets/9c2c28.png)\n"
         );
+    }
+
+    #[test]
+    fn identical_assets_under_one_name_share_one_file() {
+        let root = tempdir().unwrap();
+        let response: (&str, &str, &str, &[u8]) = (
+            "",
+            "200 OK",
+            "Content-Type: image/png\r\nContent-Disposition: inline; filename=\"pic.png\"\r\n",
+            b"png bytes",
+        );
+        let base = serve(
+            vec![
+                ("/a?alt=media&token=t", response.1, response.2, response.3),
+                ("/b?alt=media&token=u", response.1, response.2, response.3),
+            ],
+            2,
+        );
+        let zip_path = root.path().join("export.zip");
+        let markdown =
+            format!("![]({base}a?alt=media\\&token=t)\n\n![]({base}b?alt=media\\&token=u)\n");
+        write_zip(&zip_path, &[("daily/2026-07-04.md", markdown.as_str())]);
+
+        let summary = import_zip_downloading_from(root.path(), &zip_path, &base).unwrap();
+
+        assert_eq!(summary.downloaded_assets, 2);
+        let asset_paths: Vec<_> = summary
+            .changed_paths
+            .iter()
+            .filter(|path| path.starts_with("assets/"))
+            .collect();
+        assert_eq!(asset_paths, ["assets/pic.png"]);
+        assert!(!root.path().join("assets/pic-2.png").exists());
+        let note = fs::read_to_string(root.path().join("daily/2026-07-04.md")).unwrap();
+        assert_eq!(note, "![](assets/pic.png)\n\n![](assets/pic.png)\n");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/fs/import_assets.rs
+++ b/apps/desktop/src-tauri/src/fs/import_assets.rs
@@ -230,7 +230,10 @@ async fn fetch_asset(
         file.as_file_mut().write_all(&chunk)?;
     }
     file.as_file().sync_all()?;
-    Ok(DownloadOutcome::Fetched(FetchedAsset { file, desired_name }))
+    Ok(DownloadOutcome::Fetched(FetchedAsset {
+        file,
+        desired_name,
+    }))
 }
 
 /// The best original filename available: the `Content-Disposition` filename
@@ -602,7 +605,10 @@ mod tests {
         assert_eq!(sanitize_asset_file_name(".env"), "env");
         assert_eq!(sanitize_asset_file_name("???"), "untitled");
         assert_eq!(sanitize_asset_file_name("con.pdf"), "con-note.pdf");
-        assert_eq!(sanitize_asset_file_name("日本語 メモ.png"), "日本語-メモ.png");
+        assert_eq!(
+            sanitize_asset_file_name("日本語 メモ.png"),
+            "日本語-メモ.png"
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/fs/import_assets.rs
+++ b/apps/desktop/src-tauri/src/fs/import_assets.rs
@@ -1,0 +1,643 @@
+//! Remote-asset localization for the Reflect V1 import.
+//!
+//! V1 notes link attachments straight at Firebase Storage download URLs. An
+//! import must not leave a graph depending on Reflect V1's infrastructure, so
+//! every such URL is downloaded into the graph's `assets/` directory and the
+//! markdown link is rewritten to the relative `assets/…` path.
+//!
+//! Download failures split by permanence: a 4xx means the asset is gone (or
+//! the token was revoked) and no retry will help, so the note keeps its remote
+//! link and the failure is counted; a network-level failure or 5xx is
+//! transient, so the whole import aborts *before any graph write* and the user
+//! can simply retry.
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use crate::error::{AppError, AppResult};
+
+/// Only asset links on Reflect V1's storage host are localized; every other
+/// URL in the export is an ordinary link and imports untouched.
+pub(super) const V1_ASSET_URL_PREFIX: &str = "https://firebasestorage.googleapis.com/";
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+/// Per-read stall timeout. There is deliberately no whole-request timeout so
+/// a large video on a slow connection still finishes.
+const READ_TIMEOUT: Duration = Duration::from_secs(60);
+const CONCURRENT_DOWNLOADS: usize = 6;
+/// Collision probes before giving up, mirroring `persist_unique`'s cap.
+const MAX_NAME_PROBES: u32 = 1000;
+
+/// One remote-asset URL occurrence inside a markdown file.
+pub(super) struct RemoteSpan {
+    /// Byte offset of the first URL character in the markdown.
+    pub start: usize,
+    /// Byte offset one past the last URL character.
+    pub end: usize,
+    /// The URL with markdown escapes removed (`\&` → `&`), ready to fetch.
+    pub url: String,
+}
+
+/// What a download attempt produced for one URL.
+pub(super) enum DownloadOutcome {
+    /// Bytes staged in `.reflect/tmp`, waiting for the import to persist them.
+    Fetched(FetchedAsset),
+    /// The remote answered a permanent 4xx; the note keeps the remote link.
+    Gone,
+}
+
+pub(super) struct FetchedAsset {
+    pub file: tempfile::NamedTempFile,
+    /// Sanitized filename the asset would like under `assets/` (collision
+    /// suffixes are decided later, against the live graph).
+    pub desired_name: String,
+}
+
+/// Find every remote-asset URL in `markdown` that starts with `prefix`.
+///
+/// V1 exports escape URL punctuation the CommonMark way (`?alt=media\&token=`),
+/// so the span keeps the escaped bytes (for splicing) while `url` holds the
+/// unescaped form (for fetching). A span ends at whitespace or any character
+/// that terminates a markdown link destination.
+pub(super) fn scan_remote_spans(markdown: &str, prefix: &str) -> Vec<RemoteSpan> {
+    let mut spans = Vec::new();
+    let mut from = 0;
+    while let Some(found) = markdown[from..].find(prefix) {
+        let start = from + found;
+        let mut url = String::new();
+        let mut cursor = start;
+        let mut chars = markdown[start..].char_indices().peekable();
+        while let Some((offset, ch)) = chars.next() {
+            cursor = start + offset;
+            if ch == '\\' {
+                match chars.peek() {
+                    Some(&(_, next)) if next.is_ascii_punctuation() => {
+                        url.push(next);
+                        let (next_offset, _) = chars.next().expect("peeked");
+                        cursor = start + next_offset + next.len_utf8() - 1;
+                        continue;
+                    }
+                    // A lone trailing backslash is markdown's hard line
+                    // break, not part of the URL.
+                    _ => {
+                        cursor -= 1;
+                        break;
+                    }
+                }
+            }
+            if ch.is_whitespace() || matches!(ch, ')' | ']' | '<' | '>' | '"' | '\'' | '`') {
+                cursor -= 1;
+                break;
+            }
+            url.push(ch);
+            cursor = start + offset + ch.len_utf8() - 1;
+        }
+        let end = cursor + 1;
+        if url.len() > prefix.len() {
+            spans.push(RemoteSpan { start, end, url });
+        }
+        from = end.max(start + 1);
+    }
+    spans
+}
+
+/// Replace the remote spans of `markdown` whose URL has a localized path in
+/// `replacements` (URL → `assets/…`). URLs without a replacement (permanent
+/// download failures) keep their remote form.
+pub(super) fn rewrite_markdown(
+    markdown: &str,
+    prefix: &str,
+    replacements: &HashMap<String, String>,
+) -> String {
+    let mut result = markdown.to_string();
+    for span in scan_remote_spans(markdown, prefix).into_iter().rev() {
+        if let Some(local) = replacements.get(&span.url) {
+            result.replace_range(span.start..span.end, local);
+        }
+    }
+    result
+}
+
+/// Download every URL into `staging`, a few at a time. Returns the outcome
+/// per URL, or the first transient error — in which case nothing survives
+/// (the staged temp files delete on drop) and the import can be retried.
+pub(super) async fn download_remote_assets(
+    staging: &Path,
+    urls: Vec<String>,
+) -> AppResult<HashMap<String, DownloadOutcome>> {
+    if urls.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::limited(5))
+        .connect_timeout(CONNECT_TIMEOUT)
+        .read_timeout(READ_TIMEOUT)
+        .user_agent(concat!("Reflect/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|err| AppError::io(err.to_string()))?;
+
+    let queue = Arc::new(Mutex::new(urls));
+    let results = Arc::new(Mutex::new(Ok(HashMap::new())));
+    let workers = CONCURRENT_DOWNLOADS.min(lock(&queue)?.len());
+    let mut handles = Vec::with_capacity(workers);
+    for _ in 0..workers {
+        let queue = Arc::clone(&queue);
+        let results = Arc::clone(&results);
+        let client = client.clone();
+        let staging = staging.to_path_buf();
+        handles.push(tauri::async_runtime::spawn(async move {
+            loop {
+                let Some(url) = next_url(&queue, &results) else {
+                    return;
+                };
+                let outcome = fetch_asset(&client, &url, &staging).await;
+                let Ok(mut results) = results.lock() else {
+                    return;
+                };
+                match outcome {
+                    Ok(outcome) => {
+                        if let Ok(map) = results.as_mut() {
+                            map.insert(url, outcome);
+                        }
+                    }
+                    Err(err) => *results = Err(err),
+                }
+            }
+        }));
+    }
+    for handle in handles {
+        handle
+            .await
+            .map_err(|err| AppError::io(format!("asset download task failed: {err}")))?;
+    }
+    Arc::into_inner(results)
+        .and_then(|mutex| mutex.into_inner().ok())
+        .ok_or_else(|| AppError::io("asset download state lock poisoned"))?
+}
+
+fn lock<T>(mutex: &Arc<Mutex<T>>) -> AppResult<std::sync::MutexGuard<'_, T>> {
+    mutex
+        .lock()
+        .map_err(|_| AppError::io("asset download state lock poisoned"))
+}
+
+/// Pop the next URL, or `None` once the queue is drained *or* another worker
+/// already recorded an error — no point downloading into an aborted import.
+fn next_url(
+    queue: &Arc<Mutex<Vec<String>>>,
+    results: &Arc<Mutex<AppResult<HashMap<String, DownloadOutcome>>>>,
+) -> Option<String> {
+    if results.lock().ok()?.is_err() {
+        return None;
+    }
+    queue.lock().ok()?.pop()
+}
+
+fn classify_fetch_error(err: reqwest::Error) -> AppError {
+    if err.is_timeout() || err.is_connect() || err.is_request() {
+        AppError::Network {
+            message: err.to_string(),
+        }
+    } else {
+        AppError::io(err.to_string())
+    }
+}
+
+async fn fetch_asset(
+    client: &reqwest::Client,
+    url: &str,
+    staging: &Path,
+) -> AppResult<DownloadOutcome> {
+    let response = client.get(url).send().await.map_err(classify_fetch_error)?;
+    let status = response.status();
+    if status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        return Err(AppError::Network {
+            message: format!("asset download answered {status}: {url}"),
+        });
+    }
+    if !status.is_success() {
+        tracing::warn!(%url, %status, "V1 asset is gone; keeping the remote link");
+        return Ok(DownloadOutcome::Gone);
+    }
+
+    let desired_name = sanitize_asset_file_name(&original_name(&response, url));
+    let mut file = tempfile::NamedTempFile::new_in(staging)?;
+    let mut response = response;
+    while let Some(chunk) = response.chunk().await.map_err(classify_fetch_error)? {
+        file.as_file_mut().write_all(&chunk)?;
+    }
+    file.as_file().sync_all()?;
+    Ok(DownloadOutcome::Fetched(FetchedAsset { file, desired_name }))
+}
+
+/// The best original filename available: the `Content-Disposition` filename
+/// Firebase Storage serves (the name the attachment was uploaded with), else
+/// the object id from the URL path. Either way, a name without an extension
+/// gets one inferred from the response's `Content-Type` — V1 stored many
+/// attachments under their bare content id.
+fn original_name(response: &reqwest::Response, url: &str) -> String {
+    let name = response
+        .headers()
+        .get(reqwest::header::CONTENT_DISPOSITION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(content_disposition_filename)
+        .or_else(|| url_object_id(url))
+        .unwrap_or_else(|| "asset".to_string());
+    if has_extension(&name) {
+        return name;
+    }
+    let extension = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(extension_for_content_type);
+    match extension {
+        Some(extension) => format!("{name}.{extension}"),
+        None => name,
+    }
+}
+
+fn has_extension(name: &str) -> bool {
+    matches!(name.rfind('.'), Some(index) if index > 0 && index < name.len() - 1)
+}
+
+/// Parse the filename out of a `Content-Disposition` header, preferring the
+/// RFC 5987 `filename*` form over the plain `filename` fallback.
+fn content_disposition_filename(value: &str) -> Option<String> {
+    let mut plain = None;
+    for part in value.split(';') {
+        let part = part.trim();
+        let lower = part.to_ascii_lowercase();
+        if let Some(rest) = lower
+            .strip_prefix("filename*=")
+            .map(|_| &part["filename*=".len()..])
+        {
+            let encoded = rest.split_once("''").map_or(rest, |(_, encoded)| encoded);
+            let decoded = percent_decode(encoded.trim_matches('"'));
+            if !decoded.is_empty() {
+                return Some(decoded);
+            }
+        } else if let Some(rest) = lower
+            .strip_prefix("filename=")
+            .map(|_| &part["filename=".len()..])
+        {
+            let name = rest.trim_matches('"').to_string();
+            if !name.is_empty() {
+                plain = Some(name);
+            }
+        }
+    }
+    plain
+}
+
+fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' && index + 2 < bytes.len() {
+            let hex = std::str::from_utf8(&bytes[index + 1..index + 3]).ok();
+            if let Some(byte) = hex.and_then(|hex| u8::from_str_radix(hex, 16).ok()) {
+                decoded.push(byte);
+                index += 3;
+                continue;
+            }
+        }
+        decoded.push(bytes[index]);
+        index += 1;
+    }
+    String::from_utf8_lossy(&decoded).into_owned()
+}
+
+/// The last path segment of the storage object, percent-decoded: Firebase
+/// URLs encode the object path as one segment (`users%2F<uid>%2F<id>`), so
+/// decoding first yields the trailing content id.
+fn url_object_id(url: &str) -> Option<String> {
+    let path = url.split(['?', '#']).next()?;
+    let decoded = percent_decode(path);
+    let segment = decoded.rsplit('/').next()?.trim();
+    if segment.is_empty() {
+        return None;
+    }
+    Some(segment.to_string())
+}
+
+fn extension_for_content_type(content_type: &str) -> Option<&'static str> {
+    let mime = content_type
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+    match mime.as_str() {
+        "image/png" => Some("png"),
+        "image/jpeg" => Some("jpg"),
+        "image/gif" => Some("gif"),
+        "image/webp" => Some("webp"),
+        "image/svg+xml" => Some("svg"),
+        "image/heic" => Some("heic"),
+        "video/mp4" => Some("mp4"),
+        "video/quicktime" => Some("mov"),
+        "video/webm" => Some("webm"),
+        "audio/mp4" | "audio/x-m4a" => Some("m4a"),
+        "audio/mpeg" => Some("mp3"),
+        "audio/wav" | "audio/x-wav" => Some("wav"),
+        "application/pdf" => Some("pdf"),
+        "text/plain" => Some("txt"),
+        "application/json" => Some("json"),
+        "application/zip" => Some("zip"),
+        _ => None,
+    }
+}
+
+/// Windows reserved device names (case-insensitive, extension-less); mirrors
+/// the frozen list in `packages/core/src/markdown/slug.ts`.
+fn is_windows_reserved(stem: &str) -> bool {
+    matches!(
+        stem,
+        "con"
+            | "prn"
+            | "aux"
+            | "nul"
+            | "com1"
+            | "com2"
+            | "com3"
+            | "com4"
+            | "com5"
+            | "com6"
+            | "com7"
+            | "com8"
+            | "com9"
+            | "lpt1"
+            | "lpt2"
+            | "lpt3"
+            | "lpt4"
+            | "lpt5"
+            | "lpt6"
+            | "lpt7"
+            | "lpt8"
+            | "lpt9"
+    )
+}
+
+const MAX_STEM_CHARS: usize = 60;
+const MAX_EXTENSION_CHARS: usize = 12;
+
+/// Rust mirror of `assetFileName` in `packages/core/src/graph/asset-names.ts`
+/// (minus NFC normalization, which needs no dependency for the ASCII names
+/// Firebase serves): slugged lowercase stem, inner dots to dashes, extension
+/// kept but reduced to short lowercase alphanumerics.
+pub(super) fn sanitize_asset_file_name(original: &str) -> String {
+    let trimmed = original.trim();
+    let (stem, extension) = match trimmed.rfind('.') {
+        Some(index) if index > 0 && index < trimmed.len() - 1 => (
+            &trimmed[..index],
+            trimmed[index + 1..]
+                .to_lowercase()
+                .chars()
+                .filter(char::is_ascii_alphanumeric)
+                .take(MAX_EXTENSION_CHARS)
+                .collect::<String>(),
+        ),
+        _ => (trimmed, String::new()),
+    };
+
+    let mut slug = String::new();
+    let mut pending_separator = false;
+    for ch in stem.replace('.', "-").to_lowercase().chars() {
+        if ch.is_alphanumeric() {
+            if pending_separator && !slug.is_empty() {
+                slug.push('-');
+            }
+            pending_separator = false;
+            slug.push(ch);
+        } else if ch.is_whitespace() || ch == '-' || ch == '_' {
+            pending_separator = true;
+        }
+    }
+    let mut slug: String = slug.chars().take(MAX_STEM_CHARS).collect();
+    while slug.ends_with('-') {
+        slug.pop();
+    }
+    if slug.is_empty() {
+        slug = "untitled".to_string();
+    }
+    if is_windows_reserved(&slug) {
+        slug.push_str("-note");
+    }
+    if extension.is_empty() {
+        slug
+    } else {
+        format!("{slug}.{extension}")
+    }
+}
+
+/// Decide the on-disk name a fetched asset will persist under, *without*
+/// claiming it: probing here (instead of `persist_unique`) lets the import
+/// rewrite markdown and run its collision checks before any graph write.
+/// A candidate already holding identical bytes is reused instead of written —
+/// re-importing the same export must not duplicate every attachment.
+pub(super) struct PlannedAssetName {
+    pub name: String,
+    /// True when `assets/<name>` already holds these exact bytes.
+    pub reuse: bool,
+}
+
+pub(super) fn plan_asset_name(
+    assets_dir: &Path,
+    desired: &str,
+    staged: &Path,
+    taken: &std::collections::HashSet<String>,
+) -> AppResult<PlannedAssetName> {
+    let (stem, extension) = match desired.rfind('.') {
+        Some(index) if index > 0 => desired.split_at(index),
+        _ => (desired, ""),
+    };
+    for attempt in 1..=MAX_NAME_PROBES {
+        let candidate = if attempt == 1 {
+            desired.to_string()
+        } else {
+            format!("{stem}-{attempt}{extension}")
+        };
+        if taken.contains(&candidate) {
+            continue;
+        }
+        let target = assets_dir.join(&candidate);
+        if !target.exists() && !super::io::file_occupied(&target) {
+            return Ok(PlannedAssetName {
+                name: candidate,
+                reuse: false,
+            });
+        }
+        if target.is_file() && same_file_bytes(&target, staged)? {
+            return Ok(PlannedAssetName {
+                name: candidate,
+                reuse: true,
+            });
+        }
+    }
+    Err(AppError::io(format!(
+        "no free asset name after {MAX_NAME_PROBES} probes for {desired}"
+    )))
+}
+
+fn same_file_bytes(existing: &Path, staged: &Path) -> AppResult<bool> {
+    let existing_meta = std::fs::metadata(existing)?;
+    let staged_meta = std::fs::metadata(staged)?;
+    if existing_meta.len() != staged_meta.len() {
+        return Ok(false);
+    }
+    Ok(std::fs::read(existing)? == std::fs::read(staged)?)
+}
+
+/// Persist a staged download at its planned name. The plan already verified
+/// the name was free; `persist_noclobber` keeps a concurrent claim from
+/// silently clobbering — losing that race is a loud error, not a rename.
+pub(super) fn persist_planned(
+    fetched: FetchedAsset,
+    assets_dir: &Path,
+    name: &str,
+) -> AppResult<()> {
+    std::fs::create_dir_all(assets_dir)?;
+    fetched
+        .file
+        .persist_noclobber(assets_dir.join(name))
+        .map_err(|err| AppError::io(err.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::fs;
+    use tempfile::tempdir;
+
+    const PREFIX: &str = "https://firebasestorage.googleapis.com/";
+
+    #[test]
+    fn scan_finds_escaped_urls_in_link_destinations() {
+        let markdown = "![](https://firebasestorage.googleapis.com/v0/b/x/o/a?alt=media\\&token=t)\nplain text\n[memo.m4a](https://firebasestorage.googleapis.com/v0/b/x/o/b?alt=media\\&token=u)";
+        let spans = scan_remote_spans(markdown, PREFIX);
+        assert_eq!(spans.len(), 2);
+        assert_eq!(
+            spans[0].url,
+            "https://firebasestorage.googleapis.com/v0/b/x/o/a?alt=media&token=t"
+        );
+        assert_eq!(
+            &markdown[spans[0].start..spans[0].end],
+            "https://firebasestorage.googleapis.com/v0/b/x/o/a?alt=media\\&token=t"
+        );
+        assert_eq!(
+            spans[1].url,
+            "https://firebasestorage.googleapis.com/v0/b/x/o/b?alt=media&token=u"
+        );
+    }
+
+    #[test]
+    fn scan_ignores_other_hosts() {
+        let markdown = "[a](https://example.com/file.png)";
+        assert!(scan_remote_spans(markdown, PREFIX).is_empty());
+    }
+
+    #[test]
+    fn scan_stops_at_terminators() {
+        let markdown = "see https://firebasestorage.googleapis.com/v0/o/a?alt=media end";
+        let spans = scan_remote_spans(markdown, PREFIX);
+        assert_eq!(spans.len(), 1);
+        assert_eq!(
+            spans[0].url,
+            "https://firebasestorage.googleapis.com/v0/o/a?alt=media"
+        );
+    }
+
+    #[test]
+    fn rewrite_replaces_only_resolved_urls() {
+        let markdown = "![](https://firebasestorage.googleapis.com/o/a?alt=media\\&token=t) and [f](https://firebasestorage.googleapis.com/o/b?alt=media\\&token=u)";
+        let replacements = HashMap::from([(
+            "https://firebasestorage.googleapis.com/o/a?alt=media&token=t".to_string(),
+            "assets/photo.webp".to_string(),
+        )]);
+        assert_eq!(
+            rewrite_markdown(markdown, PREFIX, &replacements),
+            "![](assets/photo.webp) and [f](https://firebasestorage.googleapis.com/o/b?alt=media\\&token=u)"
+        );
+    }
+
+    #[test]
+    fn content_disposition_prefers_rfc5987() {
+        assert_eq!(
+            content_disposition_filename(
+                "inline; filename*=UTF-8''caf%C3%A9%20menu.pdf; filename=\"fallback.pdf\""
+            ),
+            Some("café menu.pdf".to_string())
+        );
+        assert_eq!(
+            content_disposition_filename("inline; filename=\"photo.webp\""),
+            Some("photo.webp".to_string())
+        );
+        assert_eq!(content_disposition_filename("inline"), None);
+    }
+
+    #[test]
+    fn object_id_decodes_the_firebase_path() {
+        assert_eq!(
+            url_object_id(
+                "https://firebasestorage.googleapis.com/v0/b/x/o/users%2Fabc%2Fd8fbbe?alt=media"
+            ),
+            Some("d8fbbe".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_mirrors_the_typescript_rules() {
+        assert_eq!(
+            sanitize_asset_file_name("Q3 Report (final).PDF"),
+            "q3-report-final.pdf"
+        );
+        assert_eq!(sanitize_asset_file_name("archive.tar.gz"), "archive-tar.gz");
+        assert_eq!(sanitize_asset_file_name(".env"), "env");
+        assert_eq!(sanitize_asset_file_name("???"), "untitled");
+        assert_eq!(sanitize_asset_file_name("con.pdf"), "con-note.pdf");
+        assert_eq!(sanitize_asset_file_name("日本語 メモ.png"), "日本語-メモ.png");
+    }
+
+    #[test]
+    fn plan_reuses_identical_bytes_and_probes_conflicts() {
+        let dir = tempdir().unwrap();
+        let assets = dir.path().join("assets");
+        fs::create_dir_all(&assets).unwrap();
+        fs::write(assets.join("photo.webp"), b"same").unwrap();
+        fs::write(dir.path().join("staged"), b"same").unwrap();
+        fs::write(dir.path().join("other"), b"different").unwrap();
+
+        let planned = plan_asset_name(
+            &assets,
+            "photo.webp",
+            &dir.path().join("staged"),
+            &HashSet::new(),
+        )
+        .unwrap();
+        assert_eq!(planned.name, "photo.webp");
+        assert!(planned.reuse);
+
+        let planned = plan_asset_name(
+            &assets,
+            "photo.webp",
+            &dir.path().join("other"),
+            &HashSet::new(),
+        )
+        .unwrap();
+        assert_eq!(planned.name, "photo-2.webp");
+        assert!(!planned.reuse);
+
+        let taken = HashSet::from(["photo-2.webp".to_string()]);
+        let planned =
+            plan_asset_name(&assets, "photo.webp", &dir.path().join("other"), &taken).unwrap();
+        assert_eq!(planned.name, "photo-3.webp");
+        assert!(!planned.reuse);
+    }
+}

--- a/apps/desktop/src-tauri/src/fs/import_assets.rs
+++ b/apps/desktop/src-tauri/src/fs/import_assets.rs
@@ -487,7 +487,9 @@ pub(super) fn plan_asset_name(
     )))
 }
 
-fn same_file_bytes(existing: &Path, staged: &Path) -> AppResult<bool> {
+/// Whether two files hold identical bytes (length check first, so comparing
+/// large attachments is cheap in the common differing case).
+pub(super) fn same_file_bytes(existing: &Path, staged: &Path) -> AppResult<bool> {
     let existing_meta = std::fs::metadata(existing)?;
     let staged_meta = std::fs::metadata(staged)?;
     if existing_meta.len() != staged_meta.len() {

--- a/apps/desktop/src-tauri/src/fs/mod.rs
+++ b/apps/desktop/src-tauri/src/fs/mod.rs
@@ -9,6 +9,7 @@
 pub mod asset_protocol;
 pub mod assets;
 mod import;
+mod import_assets;
 mod io;
 mod resolve;
 
@@ -213,14 +214,22 @@ pub fn graph_create(path: String, state: State<GraphState>) -> AppResult<GraphIn
 /// Import a user-selected Reflect V1 export `.zip` into the open graph. V1's
 /// export is already the graph folder shape, so this extracts safe entries
 /// directly under the current root and refuses to overwrite existing files.
+/// Attachments the notes link to on Firebase Storage are downloaded into
+/// `assets/` first and the links rewritten, so the imported graph doesn't
+/// depend on Reflect V1's infrastructure staying up.
 #[tauri::command]
-pub fn graph_import_reflect_v1_zip(
+pub async fn graph_import_reflect_v1_zip(
     path: String,
     generation: u64,
-    state: State<GraphState>,
+    state: State<'_, GraphState>,
 ) -> AppResult<import::ImportSummary> {
     let root = root_for_generation(&state, generation)?;
-    import::import_zip_into_graph(&root, Path::new(&path))
+    let prepared = import::prepare_zip_import(&root, Path::new(&path))?;
+    let downloads = prepared.download_assets().await?;
+    // The downloads can take a while; refuse to write into a graph the user
+    // has switched away from in the meantime.
+    root_for_generation(&state, generation)?;
+    import::finalize_import(&root, prepared, downloads)
 }
 
 /// Open an existing graph at `path`, ensuring the standard layout exists.

--- a/apps/desktop/src/components/settings/import-section.test.tsx
+++ b/apps/desktop/src/components/settings/import-section.test.tsx
@@ -2,9 +2,15 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const open = vi.hoisted(() => vi.fn<() => Promise<string | null>>())
-const importReflectV1Zip = vi.hoisted(() =>
-  vi.fn<() => Promise<{ importedFiles: number; skippedFiles: number; changedPaths: string[] }>>(),
-)
+interface SummaryFixture {
+  importedFiles: number
+  skippedFiles: number
+  downloadedAssets: number
+  failedAssetDownloads: number
+  changedPaths: string[]
+}
+
+const importReflectV1Zip = vi.hoisted(() => vi.fn<() => Promise<SummaryFixture>>())
 const markReflectV1ImportOwnWrites = vi.hoisted(() => vi.fn())
 const graphState = vi.hoisted(() => ({
   graph: { root: '/graphs/notes', name: 'Notes', generation: 42 } as {
@@ -32,6 +38,8 @@ beforeEach(() => {
   importReflectV1Zip.mockResolvedValue({
     importedFiles: 2,
     skippedFiles: 1,
+    downloadedAssets: 0,
+    failedAssetDownloads: 0,
     changedPaths: ['notes/a.md', 'daily/2026-07-04.md'],
   })
   graphState.graph = { root: '/graphs/notes', name: 'Notes', generation: 42 }
@@ -74,11 +82,30 @@ describe('ImportSection', () => {
     expect(markReflectV1ImportOwnWrites).toHaveBeenCalledWith({
       importedFiles: 2,
       skippedFiles: 1,
+      downloadedAssets: 0,
+      failedAssetDownloads: 0,
       changedPaths: ['notes/a.md', 'daily/2026-07-04.md'],
     })
     expect(graphState.refreshIndex).toHaveBeenCalledTimes(1)
     expect((await screen.findByRole('status')).textContent).toBe(
       '2 files imported, 1 already present.',
+    )
+  })
+
+  it('summarizes downloaded and failed attachments', async () => {
+    importReflectV1Zip.mockResolvedValueOnce({
+      importedFiles: 12,
+      skippedFiles: 0,
+      downloadedAssets: 140,
+      failedAssetDownloads: 1,
+      changedPaths: ['notes/a.md'],
+    })
+    render(<ImportSection />)
+
+    fireEvent.click(importButton())
+
+    expect((await screen.findByRole('status')).textContent).toBe(
+      "12 files imported, 140 attachments downloaded. 1 attachment couldn't be downloaded and still links to Reflect V1.",
     )
   })
 
@@ -105,11 +132,7 @@ describe('ImportSection', () => {
   })
 
   it('does not show success after the user switches graphs mid-import', async () => {
-    let finishImport: (summary: {
-      importedFiles: number
-      skippedFiles: number
-      changedPaths: string[]
-    }) => void = () => {}
+    let finishImport: (summary: SummaryFixture) => void = () => {}
     importReflectV1Zip.mockImplementationOnce(
       () =>
         new Promise((resolve) => {
@@ -123,7 +146,13 @@ describe('ImportSection', () => {
 
     graphState.graph = { root: '/graphs/other', name: 'Other', generation: 43 }
     view.rerender(<ImportSection />)
-    finishImport({ importedFiles: 7, skippedFiles: 0, changedPaths: ['notes/a.md'] })
+    finishImport({
+      importedFiles: 7,
+      skippedFiles: 0,
+      downloadedAssets: 0,
+      failedAssetDownloads: 0,
+      changedPaths: ['notes/a.md'],
+    })
 
     await screen.findByRole('button', { name: /import zip/i })
     expect(markReflectV1ImportOwnWrites).not.toHaveBeenCalled()

--- a/apps/desktop/src/components/settings/import-section.tsx
+++ b/apps/desktop/src/components/settings/import-section.tsx
@@ -12,20 +12,34 @@ import { Button } from '@/components/ui/button'
 import { useAsyncAction } from '@/hooks/use-async-action'
 import { useGraph } from '@/providers/graph-provider'
 
+function count(quantity: number, singular: string, plural: string): string {
+  return `${quantity} ${quantity === 1 ? singular : plural}`
+}
+
 function summaryText(summary: GraphImportSummary): string {
-  const imported = `${summary.importedFiles} ${
-    summary.importedFiles === 1 ? 'file' : 'files'
-  } imported`
-  if (summary.skippedFiles === 0) {
-    return `${imported}.`
+  const parts = [`${count(summary.importedFiles, 'file', 'files')} imported`]
+  if (summary.skippedFiles > 0) {
+    parts.push(`${summary.skippedFiles} already present`)
   }
-  return `${imported}, ${summary.skippedFiles} already present.`
+  if (summary.downloadedAssets > 0) {
+    parts.push(`${count(summary.downloadedAssets, 'attachment', 'attachments')} downloaded`)
+  }
+  const text = `${parts.join(', ')}.`
+  if (summary.failedAssetDownloads === 0) {
+    return text
+  }
+  if (summary.failedAssetDownloads === 1) {
+    return `${text} 1 attachment couldn't be downloaded and still links to Reflect V1.`
+  }
+  return `${text} ${summary.failedAssetDownloads} attachments couldn't be downloaded and still link to Reflect V1.`
 }
 
 /**
  * Settings -> Import: copy a Reflect V1 export zip into the currently open
  * graph. V1 exports are graph-shaped now, which makes this a native unzip into
- * `daily/`, `notes/`, and `assets/` rather than a migration transform.
+ * `daily/`, `notes/`, and `assets/` rather than a migration transform — plus
+ * downloading the attachments V1 notes link straight to Firebase Storage, so
+ * the imported graph is self-contained.
  */
 export function ImportSection(): ReactElement {
   const { graph, refreshIndex } = useGraph()
@@ -74,7 +88,7 @@ export function ImportSection(): ReactElement {
     <SettingsSection id="import">
       <SettingsField
         legend="Reflect V1"
-        description="Choose the .zip export from Reflect V1. Its markdown files are copied into this graph without replacing different existing files."
+        description="Choose the .zip export from Reflect V1. Its markdown files are copied into this graph without replacing different existing files, and attachments are downloaded into the graph."
       >
         <div className="mt-2">
           <Button

--- a/packages/core/src/graph/commands.test.ts
+++ b/packages/core/src/graph/commands.test.ts
@@ -24,6 +24,8 @@ describe('graph commands', () => {
     const invoke = vi.fn(async () => ({
       importedFiles: 2,
       skippedFiles: 0,
+      downloadedAssets: 0,
+      failedAssetDownloads: 0,
       changedPaths: ['notes/a.md', 'daily/2026-07-04.md'],
     }))
     setBridge({ invoke, listen: async () => () => {} })
@@ -36,6 +38,8 @@ describe('graph commands', () => {
     expect(summary).toEqual({
       importedFiles: 2,
       skippedFiles: 0,
+      downloadedAssets: 0,
+      failedAssetDownloads: 0,
       changedPaths: ['notes/a.md', 'daily/2026-07-04.md'],
     })
   })
@@ -49,6 +53,8 @@ describe('graph commands', () => {
       markReflectV1ImportOwnWrites({
         importedFiles: 2,
         skippedFiles: 0,
+        downloadedAssets: 0,
+        failedAssetDownloads: 0,
         changedPaths: ['notes/a.md', 'daily/2026-07-04.md'],
       })
 

--- a/packages/core/src/graph/commands.ts
+++ b/packages/core/src/graph/commands.ts
@@ -60,6 +60,9 @@ export async function createGraph(path: string): Promise<GraphInfo> {
  * Import a Reflect V1 export `.zip` into the open graph. V1 exports already use
  * Reflect Open's graph-folder layout; Rust extracts safe entries under the
  * active graph root and refuses to overwrite different existing files.
+ * Attachments the notes link to on Firebase Storage are downloaded into
+ * `assets/` and the links rewritten, so the call can take a while on
+ * attachment-heavy graphs.
  */
 export async function importReflectV1Zip(
   path: string,

--- a/packages/core/src/graph/schemas.ts
+++ b/packages/core/src/graph/schemas.ts
@@ -58,10 +58,14 @@ export type WindowBootstrap = z.infer<typeof windowBootstrapSchema>
 
 /** Result of importing a Reflect V1 graph-shaped zip into the open graph. */
 export const graphImportSummarySchema = z.object({
-  /** Files newly written to the open graph. */
+  /** Zip files newly written to the open graph. */
   importedFiles: z.number(),
-  /** Files already present with identical bytes, left untouched. */
+  /** Zip files already present with identical bytes, left untouched. */
   skippedFiles: z.number(),
+  /** Remote attachments now stored locally under `assets/`. */
+  downloadedAssets: z.number(),
+  /** Attachments that are permanently gone; their notes keep the remote link. */
+  failedAssetDownloads: z.number(),
   /** Graph-relative paths newly written to the open graph. */
   changedPaths: z.array(z.string()),
 })


### PR DESCRIPTION
## Problem

The Settings → Import flow copies a Reflect V1 export zip into the open graph, but the notes inside still link every attachment straight to Firebase Storage (`https://firebasestorage.googleapis.com/...?alt=media&token=...`). An "imported" graph therefore silently depends on Reflect V1's infrastructure staying up: images and audio memos break the day those URLs stop resolving, and nothing about the import tells the user that happened. A real export (7,398 notes) carries 140 such attachment links.

## Before → After

| | Before | After |
|---|---|---|
| Attachment links in imported notes | Remote Firebase Storage URLs | Relative `assets/…` paths |
| Attachment bytes | Never fetched | Downloaded into the graph's `assets/` during import |
| Deleted/revoked remote asset | Silent, link breaks later | Link kept, counted in the summary: "1 attachment couldn't be downloaded and still links to Reflect V1." |
| Offline / server error mid-import | n/a | Whole import aborts before any graph write; retry works |
| Success summary | "12 files imported." | "12 files imported, 140 attachments downloaded." |

## Changes

1. **`fs/import_assets.rs` (new)** — the localization machinery: `scan_remote_spans` finds Firebase URLs in link destinations (handling the `\&` escaping V1 exports emit), `download_remote_assets` streams them into `.reflect/tmp` with bounded concurrency (6 workers, connect/read timeouts, no whole-request timeout so large files finish), and `rewrite_markdown` splices in the local paths. Local filenames come from the `Content-Disposition` filename Firebase serves, falling back to the storage object id; names without an extension get one inferred from `Content-Type` (V1 stored many attachments under bare content ids). Sanitization is a Rust mirror of `assetFileName`'s slug rules.
2. **`fs/import.rs`** — the import is now three phases so nothing lands in the graph until everything is in hand: `prepare_zip_import` (read + validate + scan, no writes) → `PreparedImport::download_assets` (network, staging writes only) → `finalize_import` (plan collision-free asset names *without claiming them*, rewrite links, then the existing collision-checked atomic writes). Failure policy is split by permanence: a 4xx keeps the remote link and is counted (`failed_asset_downloads`); network errors and 5xx abort the still-retryable import. Re-importing the same export reuses byte-identical existing assets instead of duplicating them with `-2` suffixes, and two distinct URLs serving identical bytes under one filename share a single asset file (`planned_duplicate`, from Bugbot's review).
3. **`fs/mod.rs`** — `graph_import_reflect_v1_zip` becomes async and re-verifies the graph generation after the downloads, so a graph switch during a long download can't land writes in the wrong graph.
4. **`@reflect/core` + settings UI** — `graphImportSummarySchema` gains `downloadedAssets` / `failedAssetDownloads`; the import section's summary line and description surface them. Downloaded assets ride the existing `changedPaths` own-write marking.

## Tests

- `fs/import_assets.rs`: URL scanning with escapes / foreign hosts / terminators, rewrite selectivity, RFC 5987 `Content-Disposition` parsing, object-id extraction, filename sanitization parity with the TS examples, name planning (reuse identical bytes, probe suffixes, respect names planned earlier in the same import).
- `fs/import.rs`: end-to-end against a local HTTP server — downloads + link rewriting (including an extension-less disposition name getting `.png` from `Content-Type`), 404 keeps the remote link and counts it, connection-refused aborts before any write, re-import reuses assets and writes nothing, identical downloads wanting the same name share one file, and downloads never claim a name the zip's own `assets/` entries need. Staged-byte comparisons stream in fixed-size chunks (attachments can be videos).
- `import-section.test.tsx`: new summary wording incl. the failed-attachment sentence; existing fixtures extended.

## Verification

- `cargo test -p reflect-open --lib fs::` — 54 passed.
- `cargo clippy -p reflect-open --lib` — clean.
- `pnpm check` (typecheck + oxlint + eslint) — clean; `pnpm --filter @reflect/core test src/graph/commands.test.ts` and `pnpm --filter @reflect/desktop test src/components/settings/import-section.test.tsx` — 9 passed.
- Manual run against a real V1 export (7,398 files, 142 links / 140 unique URLs): all 140 downloaded with correct extensions, zero remaining `firebasestorage` links in the imported notes, rewritten links verified by inspection, second import skipped everything and duplicated nothing.

## Risk / Rollout

- The import now performs network fetches and can take noticeably longer on attachment-heavy graphs; the UI shows its existing pending state. No progress indicator yet — reasonable follow-up.
- Downloads are restricted to the `https://firebasestorage.googleapis.com/` prefix; other URLs import untouched.
- Users offline at import time now get a retryable network error instead of a link-rotted import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, network-driven writes to the graph filesystem with new failure modes (offline abort vs partial 4xx), though generation pinning and staging-before-finalize limit wrong-graph and half-imported state.
> 
> **Overview**
> Reflect V1 import no longer leaves notes pointing at **Firebase Storage** URLs. During import, links on `https://firebasestorage.googleapis.com/` are fetched into the graph’s **`assets/`** folder and rewritten to relative paths so the graph does not depend on V1 infrastructure.
> 
> The Rust path is split into **prepare → async download → finalize**: validate the zip and scan notes (no graph writes), download into **`.reflect/tmp`** staging only, then plan filenames, rewrite markdown, and apply the existing no-overwrite collision rules. **4xx** responses keep the remote link and increment **`failedAssetDownloads`**; **network/5xx** errors abort before any graph write so the user can retry. Re-imports **reuse** byte-identical assets instead of duplicating files.
> 
> **`graph_import_reflect_v1_zip`** is **async** and re-checks **graph generation** after downloads so a graph switch mid-import cannot write to the wrong graph. **`import_assets.rs`** holds scanning (including markdown `\&` escapes), concurrent downloads, filename sanitization, and persistence.
> 
> **`GraphImportSummary`** gains **`downloadedAssets`** and **`failedAssetDownloads`**; Settings import copy and tests reflect attachment download success and partial failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24c6ae461db83602d2f841e40ce4d34ccb762e4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reflect V1 zip imports now download linked attachments into the graph’s `assets/` folder and update markdown links automatically.
  * Import results now show counts for downloaded attachments and any attachments that could not be fetched.

* **Bug Fixes**
  * Imports are now safer during long attachment downloads, reducing the chance of writing into the wrong graph.
  * Existing files are preserved when a matching asset is already present, avoiding unnecessary duplicates.

* **UI**
  * Import status messages now better explain skipped files and attachment download failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
