### PR TITLE
fix(mobile): slow the month-title roll to a full-height ticker

### DIFF
--- a/apps/desktop/src/mobile/month-title.css
+++ b/apps/desktop/src/mobile/month-title.css
@@ -1,53 +1,70 @@
 /*
  * The calendar strip's month-label roll (month-title.tsx). Inline rendering
  * owns the resting state (a single plain label); these keyframes only
- * describe the journey there — moving to a later month both labels drift up,
- * to an earlier month both drift down, cross-fading either way. Durations
- * mirror MONTH_TITLE_TRANSITION_MS in month-title.tsx (the fallback timer
- * that removes the outgoing label when `animationend` never fires).
+ * describe the journey there — moving to a later month both labels roll up
+ * one full line box, to an earlier month they roll down. The container clips
+ * to a single line, so the labels travel their full height (100%) and move
+ * in lockstep like a ticker: same duration and curve on both, or the strip
+ * shears apart. Opacity only softens the clip edges — the incoming label is
+ * fully opaque well before it settles, the outgoing one holds full opacity
+ * until it is mostly out. Durations mirror MONTH_TITLE_TRANSITION_MS in
+ * month-title.tsx (the fallback timer that removes the outgoing label when
+ * `animationend` never fires).
  */
 
 .month-title-enter-up {
-  animation: month-title-enter-up 320ms cubic-bezier(0.22, 1, 0.36, 1);
+  animation: month-title-enter-up 500ms var(--ease-standard);
 }
 
 .month-title-enter-down {
-  animation: month-title-enter-down 320ms cubic-bezier(0.22, 1, 0.36, 1);
+  animation: month-title-enter-down 500ms var(--ease-standard);
 }
 
 .month-title-exit-up {
-  animation: month-title-exit-up 320ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: month-title-exit-up 500ms var(--ease-standard) forwards;
 }
 
 .month-title-exit-down {
-  animation: month-title-exit-down 320ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: month-title-exit-down 500ms var(--ease-standard) forwards;
 }
 
 @keyframes month-title-enter-up {
   from {
     opacity: 0;
-    transform: translate3d(0, 28%, 0);
+    transform: translate3d(0, 100%, 0);
+  }
+  40% {
+    opacity: 1;
   }
 }
 
 @keyframes month-title-enter-down {
   from {
     opacity: 0;
-    transform: translate3d(0, -28%, 0);
+    transform: translate3d(0, -100%, 0);
+  }
+  40% {
+    opacity: 1;
   }
 }
 
 @keyframes month-title-exit-up {
+  60% {
+    opacity: 1;
+  }
   to {
     opacity: 0;
-    transform: translate3d(0, -28%, 0);
+    transform: translate3d(0, -100%, 0);
   }
 }
 
 @keyframes month-title-exit-down {
+  60% {
+    opacity: 1;
+  }
   to {
     opacity: 0;
-    transform: translate3d(0, 28%, 0);
+    transform: translate3d(0, 100%, 0);
   }
 }
 

--- a/apps/desktop/src/mobile/month-title.tsx
+++ b/apps/desktop/src/mobile/month-title.tsx
@@ -5,7 +5,7 @@ import { usePrefersReducedMotion } from '@/mobile/use-reduced-motion'
 import './month-title.css'
 
 /** Mirrors the animation durations in month-title.css (the fallback timer). */
-export const MONTH_TITLE_TRANSITION_MS = 320
+export const MONTH_TITLE_TRANSITION_MS = 500
 
 interface OutgoingMonth {
   month: string
@@ -72,6 +72,10 @@ export function MonthTitle({ month }: MonthTitleProps): ReactElement {
       </span>
       {outgoing ? (
         <span
+          // Keyed so back-to-back month changes in the same direction remount
+          // the label — reusing the element would keep the same animation
+          // class and never restart the exit roll.
+          key={outgoing.month}
           ref={outgoingRef}
           aria-hidden
           className={cn(


### PR DESCRIPTION
## Problem

Swiping the Daily tab's week strip across a month boundary rolls the header month title, but the roll read as a blurry flicker rather than a ticker:

- **320ms** on `cubic-bezier(0.22, 1, 0.36, 1)` (an aggressive ease-out) front-loads ~80% of the motion into the first ~130ms — perceptually near-instant.
- The labels only traveled **28% of the line height** while cross-fading, so the outgoing and incoming text spent the whole animation overlapping in nearly the same spot at half opacity.
- Opacity interpolated across the full duration, leaving the incoming label translucent even as it settled.
- On fast consecutive swipes in the same direction, the outgoing `<span>` was reused by React (no key), so the exit-animation class never changed, the CSS animation never restarted, and the second outgoing label vanished instantly at the `forwards` end state.

## Changes

`apps/desktop/src/mobile/month-title.css`:
- Duration 320ms → **500ms**, easing → the design system's `var(--ease-standard)`.
- Travel 28% → **100% of the line box**. The container already clips to one line (`h-[1.5em]` + `overflow-hidden`), so both labels now roll in lockstep like a real ticker — the outgoing label leaves the clip box entirely instead of fading in place.
- Opacity now only softens the clip edges: the incoming label is fully opaque by 40% of the roll, the outgoing one holds full opacity until 60%.

`apps/desktop/src/mobile/month-title.tsx`:
- `MONTH_TITLE_TRANSITION_MS` 320 → 500 (the fallback-timer mirror of the CSS duration).
- The outgoing label is now keyed by its month, so back-to-back rolls in the same direction remount it and the exit animation restarts.

Reduced-motion behavior is unchanged (instant swap, both the JS gate and the CSS media block).

## Testing

- `pnpm test --run src/mobile/month-title.test.tsx src/mobile/mobile-screen.test.tsx src/mobile/month-picker-drawer.test.tsx` — 36 tests pass.
- `pnpm check` (typecheck + lint) passes.
- Verified in the `?platform=ios` browser harness that the roll triggers with the correct direction, the enter label starts exactly one line box away (-24px on a 24px line), the 0.5s duration and `--ease-standard` token resolve, and the fallback timer still cleans up when animations never fire. Note the harness WebView pauses CSS animations when backgrounded, so the *feel* of the retune still needs an on-device/simulator pass.

## Risk

Low — scoped to the month-title roll. The exported timing constant is only consumed by the component and its tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only month-title animation and a React remount key; timing constant is local to the component and its tests.
> 
> **Overview**
> Retunes the Daily tab **month header roll** so it reads as a one-line ticker instead of a fast blur.
> 
> Animation duration goes from **320ms** to **500ms** with **`var(--ease-standard)`**, and enter/exit labels move **100% of the line box** (was 28%) inside the existing clip. Opacity is staged so the incoming label is fully opaque by **40%** of the roll and the outgoing label stays opaque until **60%**, reducing mid-roll overlap.
> 
> **`MONTH_TITLE_TRANSITION_MS`** is updated to match the CSS for the fallback cleanup timer. The outgoing label **`span`** is **`key={outgoing.month}`** so consecutive swipes in the same direction remount and restart the exit animation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80c983dfd756dd3b8a68420da4c1e1e3a3aa480d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->