### PR TITLE
Make mobile lightbox drag-to-dismiss feel native

### DIFF
--- a/apps/desktop/src/editor/image-lightbox.test.tsx
+++ b/apps/desktop/src/editor/image-lightbox.test.tsx
@@ -246,15 +246,17 @@ describe('ImageLightbox mobile drag-to-dismiss', () => {
 })
 
 describe('ImageLightbox desktop surface', () => {
-  it('ignores touch drags and closes on click without a black backdrop', () => {
+  it('ignores touch drags and closes on click without a drag backdrop', () => {
     const onClose = vi.fn()
     render(<ImageLightbox image={makeImage()} onClose={onClose} onOpenImage={vi.fn()} />)
 
     const dialog = screen.getByRole('dialog', { name: 'Image preview' })
     expect(dialog.querySelector('.bg-black')).toBeNull()
+    expect(dialog.className).toContain('bg-black/80')
 
     const preview = screen.getByRole('button', { name: 'Close image preview' })
     const image = preview.querySelector('img')
+    expect(image?.className).toContain('max-h-full max-w-full')
 
     touchDown(preview, 100, 100)
     firePointer(preview, 'pointermove', { pointerId: 1, clientX: 100, clientY: 200 })

--- a/apps/desktop/src/editor/image-lightbox.test.tsx
+++ b/apps/desktop/src/editor/image-lightbox.test.tsx
@@ -1,0 +1,267 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ImageLightbox, type LightboxImage } from './image-lightbox'
+import { setPlatformSurface } from '@/lib/platform-surface'
+
+function installMatchMedia(reducedMotion: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn((query: string): MediaQueryList => ({
+      matches: reducedMotion && query === '(prefers-reduced-motion: reduce)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+}
+
+function makeImage(): LightboxImage {
+  return {
+    src: 'asset://cat.png',
+    alt: 'Cat',
+    openPath: 'assets/cat.png',
+    openImage: vi.fn(async () => {}),
+    transitionName: 'reflect-image-lightbox-1',
+  }
+}
+
+interface RenderedLightbox {
+  onClose: ReturnType<typeof vi.fn>
+  preview: HTMLElement
+  image: HTMLImageElement
+  backdrop: HTMLElement | null
+  closeChrome: HTMLElement
+}
+
+function renderMobileLightbox(): RenderedLightbox {
+  setPlatformSurface({ mobileApp: true })
+  const onClose = vi.fn()
+  render(<ImageLightbox image={makeImage()} onClose={onClose} onOpenImage={vi.fn()} />)
+
+  const dialog = screen.getByRole('dialog', { name: 'Image preview' })
+  const preview = screen.getByRole('button', { name: 'Close image preview' })
+  const image = preview.querySelector('img')
+  if (!(image instanceof HTMLImageElement)) {
+    throw new Error('lightbox image missing')
+  }
+  const closeChrome = screen.getByRole('button', { name: 'Close' }).parentElement
+  if (!(closeChrome instanceof HTMLElement)) {
+    throw new Error('close chrome missing')
+  }
+  return {
+    onClose,
+    preview,
+    image,
+    backdrop: dialog.querySelector('.bg-black'),
+    closeChrome,
+  }
+}
+
+function firePointer(element: Element, type: string, init: Record<string, unknown>): void {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.assign(event, init)
+  act(() => {
+    element.dispatchEvent(event)
+  })
+}
+
+function touchDown(element: Element, clientX: number, clientY: number): void {
+  firePointer(element, 'pointerdown', {
+    pointerId: 1,
+    isPrimary: true,
+    pointerType: 'touch',
+    clientX,
+    clientY,
+  })
+}
+
+beforeEach(() => {
+  installMatchMedia(false)
+  Element.prototype.getAnimations = vi.fn(() => [])
+})
+
+afterEach(() => {
+  cleanup()
+  setPlatformSurface({ touchEditor: false, mobileApp: false })
+  vi.restoreAllMocks()
+})
+
+describe('ImageLightbox mobile drag-to-dismiss', () => {
+  it('rebases at activation and follows the finger on both axes', () => {
+    const { preview, image } = renderMobileLightbox()
+
+    touchDown(preview, 180, 120)
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 182, clientY: 180 })
+    expect(image.style.transform).toContain('translate3d(0px, 0px, 0)')
+
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 190, clientY: 260 })
+    expect(image.style.transform).toContain('translate3d(8px, 80px, 0)')
+  })
+
+  it('fades the backdrop and chrome with drag progress', () => {
+    const { preview, backdrop, closeChrome } = renderMobileLightbox()
+    expect(backdrop).not.toBeNull()
+
+    touchDown(preview, 180, 120)
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 182, clientY: 180 })
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 190, clientY: 260 })
+
+    const progress = 80 / (window.innerHeight * 0.5)
+    expect(Number.parseFloat(backdrop!.style.opacity)).toBeCloseTo(1 - progress * 0.85, 5)
+    expect(Number.parseFloat(closeChrome.style.opacity)).toBeCloseTo(1 - progress * 2, 5)
+    expect(closeChrome.style.pointerEvents).toBe('none')
+  })
+
+  it('dismisses past the distance threshold, sliding out along the drag vector', () => {
+    const { preview, image, backdrop, onClose } = renderMobileLightbox()
+
+    touchDown(preview, 180, 120)
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 182, clientY: 180 })
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 190, clientY: 260 })
+    firePointer(preview, 'pointerup', { pointerId: 1, clientX: 190, clientY: 360 })
+
+    expect(image.style.transform).toContain(`, ${window.innerHeight}px, 0) scale(0.9)`)
+    expect(backdrop!.style.opacity).toBe('0')
+    expect(onClose).not.toHaveBeenCalled()
+
+    fireEvent.transitionEnd(image)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('dismisses a fast flick before the distance threshold', () => {
+    const { preview, image, onClose } = renderMobileLightbox()
+    const nowSpy = vi.spyOn(performance, 'now')
+
+    nowSpy.mockReturnValue(1_000)
+    touchDown(preview, 100, 100)
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 100, clientY: 120 })
+
+    nowSpy.mockReturnValue(1_040)
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 100, clientY: 170 })
+
+    nowSpy.mockReturnValue(1_060)
+    firePointer(preview, 'pointerup', { pointerId: 1, clientX: 100, clientY: 180 })
+    nowSpy.mockRestore()
+
+    expect(image.style.transform).toContain(`, ${window.innerHeight}px, 0)`)
+    fireEvent.transitionEnd(image)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('springs back after a short drag and suppresses the trailing tap', () => {
+    const { preview, image, backdrop, onClose } = renderMobileLightbox()
+
+    touchDown(preview, 100, 100)
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 102, clientY: 130 })
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 102, clientY: 160 })
+    firePointer(preview, 'pointerup', { pointerId: 1, clientX: 102, clientY: 160 })
+
+    expect(image.style.transform).toBe('translate3d(0, 0, 0) scale(1)')
+    expect(backdrop!.style.opacity).toBe('1')
+
+    fireEvent.click(preview)
+    fireEvent.click(preview)
+    expect(onClose).not.toHaveBeenCalled()
+
+    fireEvent.transitionEnd(image)
+    fireEvent.click(preview)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('rubber-bands upward travel and never dismisses upward', () => {
+    const { preview, image, onClose } = renderMobileLightbox()
+
+    touchDown(preview, 100, 100)
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 100, clientY: 120 })
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 100, clientY: 60 })
+
+    const match = /translate3d\(0px, (-[\d.]+)px, 0\)/.exec(image.style.transform)
+    const offsetY = Number.parseFloat(match?.[1] ?? 'NaN')
+    expect(offsetY).toBeGreaterThan(-48)
+    expect(offsetY).toBeLessThan(-20)
+
+    firePointer(preview, 'pointerup', { pointerId: 1, clientX: 100, clientY: 60 })
+    expect(image.style.transform).toBe('translate3d(0, 0, 0) scale(1)')
+    fireEvent.transitionEnd(image)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('snaps back without closing when the drag is interrupted', () => {
+    const { preview, image, onClose } = renderMobileLightbox()
+
+    touchDown(preview, 180, 120)
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 182, clientY: 180 })
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 182, clientY: 380 })
+    firePointer(preview, 'pointercancel', { pointerId: 1, clientX: 182, clientY: 380 })
+
+    expect(image.style.transform).toBe('translate3d(0, 0, 0) scale(1)')
+    fireEvent.transitionEnd(image)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not treat a horizontal wiggle as a tap-to-close', () => {
+    const { preview, onClose } = renderMobileLightbox()
+
+    touchDown(preview, 100, 100)
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 140, clientY: 102 })
+    firePointer(preview, 'pointerup', { pointerId: 1, clientX: 140, clientY: 102 })
+
+    fireEvent.click(preview)
+    expect(onClose).not.toHaveBeenCalled()
+
+    fireEvent.click(preview)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips the settle animation under reduced motion and clears suppression', () => {
+    installMatchMedia(true)
+    const { preview, image, onClose } = renderMobileLightbox()
+
+    touchDown(preview, 100, 100)
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 102, clientY: 130 })
+    firePointer(preview, 'pointerup', { pointerId: 1, clientX: 102, clientY: 130 })
+
+    expect(image.style.transform).toBe('')
+
+    fireEvent.click(preview)
+    expect(onClose).not.toHaveBeenCalled()
+    fireEvent.click(preview)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('still closes on a plain tap', () => {
+    const { preview, onClose } = renderMobileLightbox()
+
+    touchDown(preview, 100, 100)
+    firePointer(preview, 'pointerup', { pointerId: 1, clientX: 100, clientY: 100 })
+    fireEvent.click(preview)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('ImageLightbox desktop surface', () => {
+  it('ignores touch drags and closes on click without a black backdrop', () => {
+    const onClose = vi.fn()
+    render(<ImageLightbox image={makeImage()} onClose={onClose} onOpenImage={vi.fn()} />)
+
+    const dialog = screen.getByRole('dialog', { name: 'Image preview' })
+    expect(dialog.querySelector('.bg-black')).toBeNull()
+
+    const preview = screen.getByRole('button', { name: 'Close image preview' })
+    const image = preview.querySelector('img')
+
+    touchDown(preview, 100, 100)
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 100, clientY: 200 })
+    expect(image?.style.transform).toBe('')
+
+    firePointer(preview, 'pointerup', { pointerId: 1, clientX: 100, clientY: 200 })
+    fireEvent.click(preview)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/editor/image-lightbox.tsx
+++ b/apps/desktop/src/editor/image-lightbox.tsx
@@ -75,12 +75,7 @@ export function ImageLightbox({
             type="button"
             variant="ghost"
             size="sm"
-            className={cn(
-              'shadow-sm',
-              mobileSurface
-                ? 'h-9 rounded-full bg-white/15 px-3 text-white backdrop-blur-xl hover:bg-white/25 active:bg-white/20'
-                : 'bg-white/70 text-text hover:bg-white',
-            )}
+            className="h-9 rounded-full bg-white/15 px-3 text-white shadow-sm backdrop-blur-xl hover:bg-white/25 active:bg-white/20"
             onClick={() => onOpenImage(image)}
           >
             <ExternalLinkIcon data-icon="inline-start" />
@@ -101,7 +96,7 @@ export function ImageLightbox({
           src={image.src}
           alt={image.alt}
           draggable={false}
-          className="h-full w-full select-none object-contain"
+          className="max-h-full max-w-full select-none"
           onTransitionEnd={dismissDrag.finishSettle}
           style={{ ...dismissDrag.imageStyle, viewTransitionName: image.transitionName }}
         />

--- a/apps/desktop/src/editor/image-lightbox.tsx
+++ b/apps/desktop/src/editor/image-lightbox.tsx
@@ -1,49 +1,13 @@
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type CSSProperties,
-  type MouseEvent as ReactMouseEvent,
-  type PointerEvent as ReactPointerEvent,
-  type ReactElement,
-} from 'react'
+import { type ReactElement } from 'react'
 import { ExternalLinkIcon, XIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { LightboxDialog } from '@/editor/lightbox-dialog'
+import { useImageDismissDrag } from '@/editor/use-image-dismiss-drag'
 import { type LightboxTransitionItem } from '@/editor/use-lightbox-transition'
 import { isMobileSurface } from '@/lib/platform-surface'
 import { cn } from '@/lib/utils'
 
 export const IMAGE_LIGHTBOX_TRANSITION_NAME = 'reflect-image-lightbox'
-
-const DRAG_ACTIVATE_Y_PX = 8
-const DRAG_DISARM_X_PX = 18
-const DISMISS_FRACTION = 0.22
-const DISMISS_VELOCITY_PX_PER_MS = 0.45
-const MIN_FLICK_DY_PX = 40
-const VELOCITY_WINDOW_MS = 30
-const VELOCITY_STALE_MS = 120
-const SETTLE_MS = 220
-const SETTLE_EASING = 'cubic-bezier(0.22, 1, 0.36, 1)'
-const CLICK_SUPPRESSION_MS = 100
-
-type DragState =
-  | { phase: 'idle' }
-  | { phase: 'armed'; pointerId: number; startX: number; startY: number }
-  | {
-      phase: 'dragging'
-      pointerId: number
-      startY: number
-      height: number
-      deltaY: number
-      velocity: number
-      sampleDeltaY: number
-      sampleTime: number
-    }
-  | { phase: 'settling'; action: 'close' | 'cancel'; height: number }
-
-const IDLE: DragState = { phase: 'idle' }
 
 /** Image data rendered by the editor lightbox. */
 export interface LightboxImage extends LightboxTransitionItem {
@@ -60,253 +24,6 @@ interface ImageLightboxProps {
   image: LightboxImage | null
   onClose: () => void
   onOpenImage?: (image: LightboxImage) => void
-}
-
-interface ImageDismissDrag {
-  previewStyle: CSSProperties | undefined
-  handlers: {
-    onPointerDown: (event: ReactPointerEvent<HTMLButtonElement>) => void
-    onPointerMove: (event: ReactPointerEvent<HTMLButtonElement>) => void
-    onPointerUp: (event: ReactPointerEvent<HTMLButtonElement>) => void
-    onPointerCancel: (event: ReactPointerEvent<HTMLButtonElement>) => void
-    onClick: (event: ReactMouseEvent<HTMLButtonElement>) => void
-  }
-  finishSettle: () => void
-}
-
-function useImageDismissDrag({
-  active,
-  enabled,
-  onClose,
-}: {
-  active: boolean
-  enabled: boolean
-  onClose: () => void
-}): ImageDismissDrag {
-  const stateRef = useRef<DragState>(IDLE)
-  const [state, setState] = useState<DragState>(IDLE)
-  const suppressClickUntilRef = useRef(0)
-
-  const commit = useCallback((next: DragState): void => {
-    stateRef.current = next
-    setState(next)
-  }, [])
-
-  const finishSettle = useCallback((): void => {
-    const current = stateRef.current
-    if (current.phase !== 'settling') {
-      return
-    }
-    commit(IDLE)
-    if (current.action === 'cancel') {
-      suppressClickUntilRef.current = 0
-    }
-    if (current.action === 'close') {
-      onClose()
-    }
-  }, [commit, onClose])
-
-  useEffect(() => {
-    if ((!active || !enabled) && stateRef.current.phase !== 'idle') {
-      suppressClickUntilRef.current = 0
-      commit(IDLE)
-    }
-  }, [active, enabled, commit])
-
-  useEffect(() => {
-    if (state.phase !== 'settling') {
-      return
-    }
-    const timer = window.setTimeout(finishSettle, SETTLE_MS + 80)
-    return () => window.clearTimeout(timer)
-  }, [state, finishSettle])
-
-  const onPointerDown = useCallback(
-    (event: ReactPointerEvent<HTMLButtonElement>): void => {
-      if (!enabled || event.pointerType !== 'touch' || !event.isPrimary) {
-        return
-      }
-      if (stateRef.current.phase !== 'idle') {
-        return
-      }
-      commit({
-        phase: 'armed',
-        pointerId: event.pointerId,
-        startX: event.clientX,
-        startY: event.clientY,
-      })
-    },
-    [enabled, commit],
-  )
-
-  const onPointerMove = useCallback(
-    (event: ReactPointerEvent<HTMLButtonElement>): void => {
-      const current = stateRef.current
-      if (
-        (current.phase !== 'armed' && current.phase !== 'dragging') ||
-        current.pointerId !== event.pointerId
-      ) {
-        return
-      }
-
-      if (current.phase === 'armed') {
-        const deltaX = Math.abs(event.clientX - current.startX)
-        const deltaY = event.clientY - current.startY
-        if (deltaX > DRAG_DISARM_X_PX && deltaX > Math.abs(deltaY)) {
-          commit(IDLE)
-          return
-        }
-        if (deltaY < -DRAG_ACTIVATE_Y_PX) {
-          commit(IDLE)
-          return
-        }
-        if (deltaY < DRAG_ACTIVATE_Y_PX || deltaY <= deltaX) {
-          return
-        }
-
-        try {
-          event.currentTarget.setPointerCapture?.(event.pointerId)
-        } catch {
-          // Synthetic tests do not have a live pointer to capture.
-        }
-
-        const height = event.currentTarget.getBoundingClientRect().height || window.innerHeight
-        commit({
-          phase: 'dragging',
-          pointerId: event.pointerId,
-          startY: current.startY,
-          height,
-          deltaY,
-          velocity: 0,
-          sampleDeltaY: deltaY,
-          sampleTime: performance.now(),
-        })
-        return
-      }
-
-      const deltaY = Math.max(0, event.clientY - current.startY)
-      const now = performance.now()
-      const elapsed = now - current.sampleTime
-      if (elapsed < VELOCITY_WINDOW_MS) {
-        commit({ ...current, deltaY })
-        return
-      }
-      commit({
-        ...current,
-        deltaY,
-        velocity: (deltaY - current.sampleDeltaY) / elapsed,
-        sampleDeltaY: deltaY,
-        sampleTime: now,
-      })
-    },
-    [commit],
-  )
-
-  const release = useCallback(
-    (event: ReactPointerEvent<HTMLButtonElement>, interrupted: boolean): void => {
-      const current = stateRef.current
-      if (
-        (current.phase !== 'armed' && current.phase !== 'dragging') ||
-        current.pointerId !== event.pointerId
-      ) {
-        return
-      }
-      if (current.phase === 'armed') {
-        commit(IDLE)
-        return
-      }
-
-      const releaseDeltaY = Math.max(0, event.clientY - current.startY)
-      const now = performance.now()
-      const elapsed = now - current.sampleTime
-      const releaseVelocity =
-        elapsed >= VELOCITY_WINDOW_MS
-          ? (releaseDeltaY - current.sampleDeltaY) / elapsed
-          : current.velocity
-      const flicked =
-        releaseVelocity > DISMISS_VELOCITY_PX_PER_MS &&
-        releaseDeltaY > MIN_FLICK_DY_PX &&
-        elapsed <= VELOCITY_STALE_MS
-      const shouldClose =
-        !interrupted && (releaseDeltaY > current.height * DISMISS_FRACTION || flicked)
-      const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-      suppressClickUntilRef.current =
-        now + (reducedMotion ? CLICK_SUPPRESSION_MS : SETTLE_MS + 80)
-
-      if (reducedMotion) {
-        commit(IDLE)
-        if (shouldClose) {
-          onClose()
-        }
-        return
-      }
-
-      commit({ phase: 'settling', action: shouldClose ? 'close' : 'cancel', height: current.height })
-    },
-    [commit, onClose],
-  )
-
-  const onPointerUp = useCallback(
-    (event: ReactPointerEvent<HTMLButtonElement>): void => release(event, false),
-    [release],
-  )
-
-  const onPointerCancel = useCallback(
-    (event: ReactPointerEvent<HTMLButtonElement>): void => release(event, true),
-    [release],
-  )
-
-  const onClick = useCallback(
-    (event: ReactMouseEvent<HTMLButtonElement>): void => {
-      const settling = stateRef.current.phase === 'settling'
-      const suppressClick =
-        settling ||
-        (suppressClickUntilRef.current > 0 && performance.now() <= suppressClickUntilRef.current)
-      if (suppressClick) {
-        if (!settling) {
-          suppressClickUntilRef.current = 0
-        }
-        event.preventDefault()
-        event.stopPropagation()
-        return
-      }
-      onClose()
-    },
-    [onClose],
-  )
-
-  return {
-    previewStyle: previewStyleForState(state),
-    handlers: { onPointerDown, onPointerMove, onPointerUp, onPointerCancel, onClick },
-    finishSettle,
-  }
-}
-
-function dragProgress(deltaY: number, height: number): number {
-  return Math.min(1, deltaY / Math.max(height * 0.55, 1))
-}
-
-function previewStyleForState(state: DragState): CSSProperties | undefined {
-  if (state.phase === 'dragging') {
-    const progress = dragProgress(state.deltaY, state.height)
-    const scale = 1 - progress * 0.06
-    return {
-      opacity: 1 - progress * 0.12,
-      transform: `translate3d(0, ${state.deltaY}px, 0) scale(${scale})`,
-      transition: 'none',
-    }
-  }
-  if (state.phase === 'settling') {
-    const closing = state.action === 'close'
-    return {
-      opacity: closing ? 0 : 1,
-      transform: closing
-        ? `translate3d(0, ${state.height}px, 0) scale(0.94)`
-        : 'translate3d(0, 0, 0) scale(1)',
-      transition: `transform ${SETTLE_MS}ms ${SETTLE_EASING}, opacity ${SETTLE_MS}ms ${SETTLE_EASING}`,
-    }
-  }
-  return undefined
 }
 
 export function ImageLightbox({
@@ -328,9 +45,15 @@ export function ImageLightbox({
     image.openPath !== null && image.openImage !== null && onOpenImage !== undefined
 
   return (
-    <LightboxDialog open title="Image preview" onClose={onClose}>
+    <LightboxDialog open title="Image preview" immersive={mobileSurface} onClose={onClose}>
       {mobileSurface ? (
-        <div className="absolute top-[max(env(safe-area-inset-top),1rem)] left-[max(env(safe-area-inset-left),1rem)] z-10">
+        <div aria-hidden className="absolute inset-0 bg-black" style={dismissDrag.backdropStyle} />
+      ) : null}
+      {mobileSurface ? (
+        <div
+          className="absolute top-[max(env(safe-area-inset-top),1rem)] left-[max(env(safe-area-inset-left),1rem)] z-10"
+          style={dismissDrag.chromeStyle}
+        >
           <Button
             type="button"
             variant="ghost"
@@ -344,7 +67,10 @@ export function ImageLightbox({
         </div>
       ) : null}
       {canOpenImage ? (
-        <div className="absolute top-[max(env(safe-area-inset-top),1rem)] right-[max(env(safe-area-inset-right),1rem)] z-10">
+        <div
+          className="absolute top-[max(env(safe-area-inset-top),1rem)] right-[max(env(safe-area-inset-right),1rem)] z-10"
+          style={dismissDrag.chromeStyle}
+        >
           <Button
             type="button"
             variant="ghost"
@@ -367,7 +93,7 @@ export function ImageLightbox({
         aria-label="Close image preview"
         className={cn(
           'absolute inset-0 flex cursor-zoom-out items-center justify-center overflow-hidden bg-transparent',
-          mobileSurface ? 'touch-none bg-black p-0' : 'p-6',
+          mobileSurface ? 'touch-none p-0' : 'p-6',
         )}
         {...dismissDrag.handlers}
       >
@@ -377,7 +103,7 @@ export function ImageLightbox({
           draggable={false}
           className="h-full w-full select-none object-contain"
           onTransitionEnd={dismissDrag.finishSettle}
-          style={{ ...dismissDrag.previewStyle, viewTransitionName: image.transitionName }}
+          style={{ ...dismissDrag.imageStyle, viewTransitionName: image.transitionName }}
         />
       </button>
     </LightboxDialog>

--- a/apps/desktop/src/editor/lightbox-dialog.tsx
+++ b/apps/desktop/src/editor/lightbox-dialog.tsx
@@ -1,11 +1,17 @@
 import { type ReactElement, type ReactNode } from 'react'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
 
 interface LightboxDialogProps {
   open: boolean
   title: string
   children: ReactNode
   onClose: () => void
+  /**
+   * Strip the light backdrop wash so the lightbox owns its background —
+   * mobile drag-to-dismiss fades that background to reveal the note behind.
+   */
+  immersive?: boolean
 }
 
 /**
@@ -16,6 +22,7 @@ export function LightboxDialog({
   title,
   children,
   onClose,
+  immersive = false,
 }: LightboxDialogProps): ReactElement | null {
   if (!open) {
     return null
@@ -33,8 +40,14 @@ export function LightboxDialog({
       <DialogContent
         aria-describedby={undefined}
         showCloseButton={false}
-        overlayClassName="bg-white/80 backdrop-blur-0 supports-backdrop-filter:backdrop-blur-0"
-        className="fixed inset-0 top-0 left-0 z-50 flex h-dvh w-dvw max-w-none translate-x-0 translate-y-0 items-center justify-center overflow-hidden rounded-none bg-white/90 p-6 ring-0 outline-none sm:max-w-none"
+        overlayClassName={cn(
+          'bg-white/80 backdrop-blur-0 supports-backdrop-filter:backdrop-blur-0',
+          immersive && 'bg-transparent',
+        )}
+        className={cn(
+          'fixed inset-0 top-0 left-0 z-50 flex h-dvh w-dvw max-w-none translate-x-0 translate-y-0 items-center justify-center overflow-hidden rounded-none bg-white/90 p-6 ring-0 outline-none sm:max-w-none',
+          immersive && 'bg-transparent p-0',
+        )}
         onPointerDown={(event) => {
           if (event.target === event.currentTarget) {
             onClose()

--- a/apps/desktop/src/editor/lightbox-dialog.tsx
+++ b/apps/desktop/src/editor/lightbox-dialog.tsx
@@ -8,8 +8,8 @@ interface LightboxDialogProps {
   children: ReactNode
   onClose: () => void
   /**
-   * Strip the light backdrop wash so the lightbox owns its background —
-   * mobile drag-to-dismiss fades that background to reveal the note behind.
+   * Strip the dark scrim so the lightbox owns its background — mobile
+   * drag-to-dismiss fades that background to reveal the note behind.
    */
   immersive?: boolean
 }
@@ -40,13 +40,10 @@ export function LightboxDialog({
       <DialogContent
         aria-describedby={undefined}
         showCloseButton={false}
-        overlayClassName={cn(
-          'bg-white/80 backdrop-blur-0 supports-backdrop-filter:backdrop-blur-0',
-          immersive && 'bg-transparent',
-        )}
+        overlayClassName="bg-transparent backdrop-blur-0 supports-backdrop-filter:backdrop-blur-0"
         className={cn(
-          'fixed inset-0 top-0 left-0 z-50 flex h-dvh w-dvw max-w-none translate-x-0 translate-y-0 items-center justify-center overflow-hidden rounded-none bg-white/90 p-6 ring-0 outline-none sm:max-w-none',
-          immersive && 'bg-transparent p-0',
+          'fixed inset-0 top-0 left-0 z-50 flex h-dvh w-dvw max-w-none translate-x-0 translate-y-0 items-center justify-center overflow-hidden rounded-none ring-0 outline-none sm:max-w-none',
+          immersive ? 'bg-transparent p-0' : 'bg-black/80 p-6',
         )}
         onPointerDown={(event) => {
           if (event.target === event.currentTarget) {

--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -294,9 +294,8 @@ describe('NoteEditor image lightbox', () => {
     expect(close.parentElement?.className).toContain(
       'left-[max(env(safe-area-inset-left),1rem)]',
     )
-    expect(screen.getByRole('button', { name: 'Close image preview' }).className).toContain(
-      'bg-black',
-    )
+    const dialog = screen.getByRole('dialog', { name: 'Image preview' })
+    expect(dialog.querySelector('.bg-black')).not.toBeNull()
   })
 
   it('dismisses the mobile image lightbox with a downward drag', async () => {
@@ -321,7 +320,7 @@ describe('NoteEditor image lightbox', () => {
       clientX: 182,
       clientY: 180,
     })
-    expect(image?.style.transform).toContain('translate3d(0, 60px, 0)')
+    expect(image?.style.transform).toContain('translate3d(0px, 0px, 0)')
 
     firePointer(preview, 'pointermove', {
       pointerId: 1,
@@ -334,136 +333,9 @@ describe('NoteEditor image lightbox', () => {
       clientY: 360,
     })
 
-    expect(image?.style.transform).toContain(`translate3d(0, ${window.innerHeight}px, 0)`)
+    expect(image?.style.transform).toContain(`, ${window.innerHeight}px, 0)`)
     fireEvent.transitionEnd(image!)
     await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
-  })
-
-  it('uses the release position when the final mobile drag move is coalesced', async () => {
-    setPlatformSurface({ mobileApp: true })
-    renderEditor()
-
-    act(() => captured.props?.onImageClick?.(imageClick('assets/cat.png', 'Cat')))
-
-    const preview = await screen.findByRole('button', { name: 'Close image preview' })
-    const image = preview.querySelector('img')
-    expect(image).toBeInstanceOf(HTMLImageElement)
-
-    firePointer(preview, 'pointerdown', {
-      pointerId: 1,
-      isPrimary: true,
-      pointerType: 'touch',
-      clientX: 180,
-      clientY: 120,
-    })
-    firePointer(preview, 'pointermove', {
-      pointerId: 1,
-      clientX: 182,
-      clientY: 180,
-    })
-    firePointer(preview, 'pointerup', {
-      pointerId: 1,
-      clientX: 184,
-      clientY: 360,
-    })
-
-    expect(image?.style.transform).toContain(`translate3d(0, ${window.innerHeight}px, 0)`)
-    fireEvent.transitionEnd(image!)
-    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
-  })
-
-  it('snaps the mobile lightbox back after a short drag without tap-closing it', async () => {
-    setPlatformSurface({ mobileApp: true })
-    renderEditor()
-
-    act(() => captured.props?.onImageClick?.(imageClick('assets/cat.png', 'Cat')))
-
-    const preview = await screen.findByRole('button', { name: 'Close image preview' })
-    const image = preview.querySelector('img')
-    expect(image).toBeInstanceOf(HTMLImageElement)
-
-    firePointer(preview, 'pointerdown', {
-      pointerId: 1,
-      isPrimary: true,
-      pointerType: 'touch',
-      clientX: 180,
-      clientY: 120,
-    })
-    firePointer(preview, 'pointermove', {
-      pointerId: 1,
-      clientX: 182,
-      clientY: 150,
-    })
-    firePointer(preview, 'pointerup', {
-      pointerId: 1,
-      clientX: 182,
-      clientY: 150,
-    })
-
-    expect(image?.style.transform).toBe('translate3d(0, 0, 0) scale(1)')
-    fireEvent.click(preview)
-    expect(screen.getByRole('dialog', { name: 'Image preview' })).toBeInTheDocument()
-    fireEvent.click(preview)
-    expect(screen.getByRole('dialog', { name: 'Image preview' })).toBeInTheDocument()
-
-    fireEvent.transitionEnd(image!)
-    fireEvent.click(preview)
-    expect(screen.queryByRole('dialog')).toBeNull()
-  })
-
-  it('clears mobile drag click suppression when reduced motion skips the snap animation', async () => {
-    const originalMatchMedia = window.matchMedia
-    Object.defineProperty(window, 'matchMedia', {
-      configurable: true,
-      writable: true,
-      value: vi.fn((query: string): MediaQueryList => ({
-        matches: query === '(prefers-reduced-motion: reduce)',
-        media: query,
-        onchange: null,
-        addListener: vi.fn(),
-        removeListener: vi.fn(),
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-        dispatchEvent: vi.fn(),
-      })),
-    })
-
-    setPlatformSurface({ mobileApp: true })
-    renderEditor()
-
-    act(() => captured.props?.onImageClick?.(imageClick('assets/cat.png', 'Cat')))
-
-    const preview = await screen.findByRole('button', { name: 'Close image preview' })
-    try {
-      firePointer(preview, 'pointerdown', {
-        pointerId: 1,
-        isPrimary: true,
-        pointerType: 'touch',
-        clientX: 180,
-        clientY: 120,
-      })
-      firePointer(preview, 'pointermove', {
-        pointerId: 1,
-        clientX: 182,
-        clientY: 150,
-      })
-      firePointer(preview, 'pointerup', {
-        pointerId: 1,
-        clientX: 182,
-        clientY: 150,
-      })
-
-      fireEvent.click(preview)
-      expect(screen.getByRole('dialog', { name: 'Image preview' })).toBeInTheDocument()
-      fireEvent.click(preview)
-      expect(screen.queryByRole('dialog')).toBeNull()
-    } finally {
-      Object.defineProperty(window, 'matchMedia', {
-        configurable: true,
-        writable: true,
-        value: originalMatchMedia,
-      })
-    }
   })
 
   it('uses the opener captured when the lightbox opens', async () => {

--- a/apps/desktop/src/editor/use-image-dismiss-drag.ts
+++ b/apps/desktop/src/editor/use-image-dismiss-drag.ts
@@ -1,0 +1,403 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+} from 'react'
+
+const DRAG_ACTIVATE_PX = 8
+const DRAG_DISARM_X_PX = 18
+const DISMISS_FRACTION = 0.22
+const DISMISS_VELOCITY_PX_PER_MS = 0.45
+const MIN_FLICK_DY_PX = 40
+const VELOCITY_WINDOW_MS = 30
+const VELOCITY_STALE_MS = 120
+const SNAP_BACK_MS = 300
+const DISMISS_MS = 260
+const DISMISS_MIN_MS = 140
+const SETTLE_SLACK_MS = 80
+const CLICK_SUPPRESSION_MS = 500
+const UPWARD_RUBBER_BAND_PX = 48
+// Full visual effect (backdrop gone, image at min scale) at half the viewport.
+const PROGRESS_TRAVEL_FRACTION = 0.5
+const BACKDROP_FADE = 0.85
+const CHROME_FADE_RATE = 2
+const DRAG_SHRINK = 0.08
+// Slight overshoot so the snap-back reads as a spring, not a linear return.
+const SNAP_BACK_EASING = 'cubic-bezier(0.3, 1.35, 0.45, 1)'
+const DISMISS_EASING = 'cubic-bezier(0.3, 0.7, 0.4, 1)'
+
+type DragState =
+  | { phase: 'idle' }
+  | { phase: 'armed'; pointerId: number; startX: number; startY: number }
+  | {
+      phase: 'dragging'
+      pointerId: number
+      originX: number
+      originY: number
+      height: number
+      deltaX: number
+      /** Raw vertical travel from the rebased origin; negative when above it. */
+      deltaY: number
+      velocity: number
+      sampleDeltaY: number
+      sampleTime: number
+    }
+  | {
+      phase: 'settling'
+      action: 'close' | 'cancel'
+      deltaX: number
+      deltaY: number
+      height: number
+      durationMs: number
+    }
+
+const IDLE: DragState = { phase: 'idle' }
+
+/** Styles and handlers driving the mobile drag-to-dismiss gesture. */
+export interface ImageDismissDrag {
+  /** Transform applied to the dragged image, or undefined at rest. */
+  imageStyle: CSSProperties | undefined
+  /** Fade applied to the lightbox backdrop as the drag progresses. */
+  backdropStyle: CSSProperties | undefined
+  /** Fade applied to the corner chrome (close/open buttons) during a drag. */
+  chromeStyle: CSSProperties | undefined
+  handlers: {
+    onPointerDown: (event: ReactPointerEvent<HTMLButtonElement>) => void
+    onPointerMove: (event: ReactPointerEvent<HTMLButtonElement>) => void
+    onPointerUp: (event: ReactPointerEvent<HTMLButtonElement>) => void
+    onPointerCancel: (event: ReactPointerEvent<HTMLButtonElement>) => void
+    onClick: (event: ReactMouseEvent<HTMLButtonElement>) => void
+  }
+  /** Completes a settle animation; wire to the image's `onTransitionEnd`. */
+  finishSettle: () => void
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+function dragProgress(deltaY: number, height: number): number {
+  return clamp(Math.max(0, deltaY) / Math.max(height * PROGRESS_TRAVEL_FRACTION, 1), 0, 1)
+}
+
+/** Asymptotic resistance for travel above the origin, like an iOS scroll edge. */
+function rubberBandOffsetY(deltaY: number): number {
+  if (deltaY >= 0) {
+    return deltaY
+  }
+  const overshoot = -deltaY
+  return -((overshoot * UPWARD_RUBBER_BAND_PX) / (overshoot + UPWARD_RUBBER_BAND_PX))
+}
+
+/** Continue the drag vector so the image exits along the finger's line. */
+function projectDismissX(deltaX: number, deltaY: number, height: number): number {
+  const factor = height / Math.max(deltaY, height * 0.15)
+  return clamp(deltaX * factor, -height / 2, height / 2)
+}
+
+function dismissDurationMs(deltaY: number, height: number, velocity: number): number {
+  const remaining = Math.max(0, height - deltaY)
+  const floorVelocity = remaining / DISMISS_MS
+  return clamp(remaining / Math.max(velocity, floorVelocity), DISMISS_MIN_MS, DISMISS_MS)
+}
+
+function imageStyleForState(state: DragState): CSSProperties | undefined {
+  if (state.phase === 'dragging') {
+    const progress = dragProgress(state.deltaY, state.height)
+    const offsetY = rubberBandOffsetY(state.deltaY)
+    return {
+      transform: `translate3d(${state.deltaX}px, ${offsetY}px, 0) scale(${1 - progress * DRAG_SHRINK})`,
+      transition: 'none',
+      willChange: 'transform',
+    }
+  }
+  if (state.phase === 'settling') {
+    const closing = state.action === 'close'
+    return {
+      transform: closing
+        ? `translate3d(${projectDismissX(state.deltaX, state.deltaY, state.height)}px, ${state.height}px, 0) scale(0.9)`
+        : 'translate3d(0, 0, 0) scale(1)',
+      transition: `transform ${state.durationMs}ms ${closing ? DISMISS_EASING : SNAP_BACK_EASING}`,
+      willChange: 'transform',
+    }
+  }
+  return undefined
+}
+
+function backdropStyleForState(state: DragState): CSSProperties | undefined {
+  if (state.phase === 'dragging') {
+    return {
+      opacity: 1 - dragProgress(state.deltaY, state.height) * BACKDROP_FADE,
+      transition: 'none',
+    }
+  }
+  if (state.phase === 'settling') {
+    const closing = state.action === 'close'
+    return {
+      opacity: closing ? 0 : 1,
+      transition: `opacity ${state.durationMs}ms ${closing ? DISMISS_EASING : SNAP_BACK_EASING}`,
+    }
+  }
+  return undefined
+}
+
+function chromeStyleForState(state: DragState): CSSProperties | undefined {
+  if (state.phase === 'dragging') {
+    return {
+      opacity: clamp(1 - dragProgress(state.deltaY, state.height) * CHROME_FADE_RATE, 0, 1),
+      pointerEvents: 'none',
+      transition: 'none',
+    }
+  }
+  if (state.phase === 'settling') {
+    const closing = state.action === 'close'
+    return {
+      opacity: closing ? 0 : 1,
+      pointerEvents: 'none',
+      transition: `opacity ${state.durationMs}ms ${closing ? DISMISS_EASING : SNAP_BACK_EASING}`,
+    }
+  }
+  return undefined
+}
+
+/**
+ * Touch drag-to-dismiss for the mobile image lightbox. A predominantly
+ * vertical downward drag detaches the image so it follows the finger on both
+ * axes (upward travel rubber-bands) while the backdrop and chrome fade with
+ * progress. Releasing past a distance threshold, or flicking, slides the
+ * image out along the drag vector at a velocity-matched speed and then calls
+ * `onClose`; shorter drags spring back. A plain tap still closes via `onClick`.
+ */
+export function useImageDismissDrag({
+  active,
+  enabled,
+  onClose,
+}: {
+  active: boolean
+  enabled: boolean
+  onClose: () => void
+}): ImageDismissDrag {
+  const stateRef = useRef<DragState>(IDLE)
+  const [state, setState] = useState<DragState>(IDLE)
+  const suppressClickUntilRef = useRef(0)
+
+  const commit = useCallback((next: DragState): void => {
+    stateRef.current = next
+    setState(next)
+  }, [])
+
+  const suppressUpcomingClick = useCallback((): void => {
+    suppressClickUntilRef.current = performance.now() + CLICK_SUPPRESSION_MS
+  }, [])
+
+  const finishSettle = useCallback((): void => {
+    const current = stateRef.current
+    if (current.phase !== 'settling') {
+      return
+    }
+    commit(IDLE)
+    if (current.action === 'cancel') {
+      suppressClickUntilRef.current = 0
+    }
+    if (current.action === 'close') {
+      onClose()
+    }
+  }, [commit, onClose])
+
+  useEffect(() => {
+    if ((!active || !enabled) && stateRef.current.phase !== 'idle') {
+      suppressClickUntilRef.current = 0
+      commit(IDLE)
+    }
+  }, [active, enabled, commit])
+
+  useEffect(() => {
+    if (state.phase !== 'settling') {
+      return
+    }
+    const timer = window.setTimeout(finishSettle, state.durationMs + SETTLE_SLACK_MS)
+    return () => window.clearTimeout(timer)
+  }, [state, finishSettle])
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>): void => {
+      if (!enabled || event.pointerType !== 'touch' || !event.isPrimary) {
+        return
+      }
+      if (stateRef.current.phase !== 'idle') {
+        return
+      }
+      commit({
+        phase: 'armed',
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+      })
+    },
+    [enabled, commit],
+  )
+
+  const onPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>): void => {
+      const current = stateRef.current
+      if (
+        (current.phase !== 'armed' && current.phase !== 'dragging') ||
+        current.pointerId !== event.pointerId
+      ) {
+        return
+      }
+
+      if (current.phase === 'armed') {
+        const deltaX = Math.abs(event.clientX - current.startX)
+        const deltaY = event.clientY - current.startY
+        if (deltaX > DRAG_DISARM_X_PX && deltaX > Math.abs(deltaY)) {
+          suppressUpcomingClick()
+          commit(IDLE)
+          return
+        }
+        if (deltaY < -DRAG_ACTIVATE_PX) {
+          suppressUpcomingClick()
+          commit(IDLE)
+          return
+        }
+        if (deltaY < DRAG_ACTIVATE_PX || deltaY <= deltaX) {
+          return
+        }
+
+        try {
+          event.currentTarget.setPointerCapture?.(event.pointerId)
+        } catch {
+          // Synthetic tests do not have a live pointer to capture.
+        }
+
+        const height = event.currentTarget.getBoundingClientRect().height || window.innerHeight
+        // Rebase on the activation point so the image picks up from rest
+        // instead of jumping by the activation distance.
+        commit({
+          phase: 'dragging',
+          pointerId: event.pointerId,
+          originX: event.clientX,
+          originY: event.clientY,
+          height,
+          deltaX: 0,
+          deltaY: 0,
+          velocity: 0,
+          sampleDeltaY: 0,
+          sampleTime: performance.now(),
+        })
+        return
+      }
+
+      const deltaX = event.clientX - current.originX
+      const deltaY = event.clientY - current.originY
+      const now = performance.now()
+      const elapsed = now - current.sampleTime
+      if (elapsed < VELOCITY_WINDOW_MS) {
+        commit({ ...current, deltaX, deltaY })
+        return
+      }
+      commit({
+        ...current,
+        deltaX,
+        deltaY,
+        velocity: (deltaY - current.sampleDeltaY) / elapsed,
+        sampleDeltaY: deltaY,
+        sampleTime: now,
+      })
+    },
+    [commit, suppressUpcomingClick],
+  )
+
+  const release = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>, interrupted: boolean): void => {
+      const current = stateRef.current
+      if (
+        (current.phase !== 'armed' && current.phase !== 'dragging') ||
+        current.pointerId !== event.pointerId
+      ) {
+        return
+      }
+      if (current.phase === 'armed') {
+        commit(IDLE)
+        return
+      }
+
+      const releaseDeltaX = event.clientX - current.originX
+      const releaseDeltaY = Math.max(0, event.clientY - current.originY)
+      const now = performance.now()
+      const elapsed = now - current.sampleTime
+      const releaseVelocity =
+        elapsed >= VELOCITY_WINDOW_MS
+          ? (releaseDeltaY - current.sampleDeltaY) / elapsed
+          : current.velocity
+      const flicked =
+        releaseVelocity > DISMISS_VELOCITY_PX_PER_MS &&
+        releaseDeltaY > MIN_FLICK_DY_PX &&
+        elapsed <= VELOCITY_STALE_MS
+      const shouldClose =
+        !interrupted && (releaseDeltaY > current.height * DISMISS_FRACTION || flicked)
+      suppressUpcomingClick()
+
+      if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        commit(IDLE)
+        if (shouldClose) {
+          onClose()
+        }
+        return
+      }
+
+      commit({
+        phase: 'settling',
+        action: shouldClose ? 'close' : 'cancel',
+        deltaX: releaseDeltaX,
+        deltaY: releaseDeltaY,
+        height: current.height,
+        durationMs: shouldClose
+          ? dismissDurationMs(releaseDeltaY, current.height, releaseVelocity)
+          : SNAP_BACK_MS,
+      })
+    },
+    [commit, onClose, suppressUpcomingClick],
+  )
+
+  const onPointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>): void => release(event, false),
+    [release],
+  )
+
+  const onPointerCancel = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>): void => release(event, true),
+    [release],
+  )
+
+  const onClick = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement>): void => {
+      const settling = stateRef.current.phase === 'settling'
+      const suppressClick =
+        settling ||
+        (suppressClickUntilRef.current > 0 && performance.now() <= suppressClickUntilRef.current)
+      if (suppressClick) {
+        if (!settling) {
+          suppressClickUntilRef.current = 0
+        }
+        event.preventDefault()
+        event.stopPropagation()
+        return
+      }
+      onClose()
+    },
+    [onClose],
+  )
+
+  return {
+    imageStyle: imageStyleForState(state),
+    backdropStyle: backdropStyleForState(state),
+    chromeStyle: chromeStyleForState(state),
+    handlers: { onPointerDown, onPointerMove, onPointerUp, onPointerCancel, onClick },
+    finishSettle,
+  }
+}


### PR DESCRIPTION
## Problem

The mobile lightbox's drag-to-dismiss (added in #589) works, but it doesn't feel like a native photo viewer:

- The image only moves vertically — a finger dragging diagonally sees the image slide straight down while the finger drifts away from it.
- The gesture activates after 8px of travel and then jumps the image by that full activation distance in one frame.
- The black backdrop stays fully opaque for the whole drag, so there's no sense of "peeling away" the preview; iOS Photos/Telegram fade the background to reveal the content behind.
- Dragging above the start point dead-stops at 0 instead of resisting like a scroll edge.
- The dismiss animation runs at a fixed 220ms regardless of how hard you fling, and the snap-back uses the same curve with no spring.
- A disarmed gesture (horizontal wiggle) still fell through to tap-to-close.

The desktop lightbox also had two defects, fixed here in a follow-up commit:

- It hardcoded a white wash (`bg-white/80` overlay + `bg-white/90` content), so in dark mode opening an image flashed a bright white full screen.
- The image was `h-full w-full object-contain`, so a small screenshot or icon upscaled to viewport size and went blurry.

## Before → After

| Interaction | Before | After |
|---|---|---|
| Drag direction | Y only, clamped ≥ 0 | Follows the finger on both axes; upward travel rubber-bands asymptotically (max ~48px) |
| Activation | Image jumps by the 8px activation distance | Origin rebases at activation, image picks up from rest (UIKit pan-gesture semantics) |
| Backdrop | Opaque black throughout | Fades with drag progress, revealing the note behind (dialog wash is transparent on mobile) |
| Corner chrome (Close / Open) | Static during drag | Fades out quickly as the drag progresses, ignores pointer events mid-gesture |
| Dismiss animation | Fixed 220ms, straight down | Velocity-matched duration (140–260ms), slides out along the drag vector |
| Snap-back | Same ease as dismiss | 300ms spring curve with slight overshoot |
| Horizontal wiggle | Closed the lightbox via the trailing click | Suppressed one-shot; a deliberate second tap still closes |
| Desktop surface | White wash in both themes | Always-dark `bg-black/80` scrim (Quick Look-style); Open button becomes the same translucent white pill as mobile |
| Small images | Upscaled to fill the viewport, blurry | Render at natural size, capped to the viewport (`max-h-full max-w-full`) |

## Changes

1. **`use-image-dismiss-drag.ts` (new)** — the drag state machine (`idle → armed → dragging → settling`) extracted from `image-lightbox.tsx` into its own hook, per the one-responsibility file convention. It now exposes three style channels: `imageStyle` (transform), `backdropStyle` (opacity), and `chromeStyle` (opacity + `pointerEvents`), plus the pointer/click handlers and `finishSettle`. Dismissal thresholds (22% of height or a >0.45px/ms flick) are unchanged from #589.
2. **`image-lightbox.tsx`** — now purely presentational. On mobile it renders its own `bg-black` backdrop layer behind the image (previously the black was painted on the tap-target button, so it couldn't fade independently) and wires the chrome containers to `chromeStyle`.
3. **`lightbox-dialog.tsx`** — new `immersive` prop that strips the white overlay wash and content padding so the lightbox owns its background. Without this, fading the black layer revealed a white `bg-white/80` overlay instead of the note. `ImageLightbox` is the only consumer.
4. **Desktop scrim + image sizing** — the non-immersive `LightboxDialog` scrim is now `bg-black/80` in both themes (the Radix overlay is transparent; the content layer carries the scrim), and the lightbox `img` uses `max-h-full max-w-full` instead of `h-full w-full object-contain` on both surfaces, so images never upscale past natural size.
5. **Click suppression** simplified to a one-shot 500ms window consumed by the next click, set on drag release *and* on disarm-by-movement (the new wiggle fix). The settling-phase suppression and reduced-motion instant path keep their existing semantics.

## Tests

- **`image-lightbox.test.tsx` (new)** — component-level coverage of the gesture: rebase-at-activation + two-axis follow, backdrop/chrome fade values, distance dismiss (with coalesced release position), velocity flick dismiss (mocked `performance.now`), spring-back with tap suppression, upward rubber-band, interrupted-drag (`pointercancel`) snap-back, horizontal-wiggle suppression, reduced-motion instant path, plain tap-to-close, and the desktop path (drags ignored, click closes, dark scrim class, natural-size cap).
- **`note-editor.test.tsx`** — the four drag-mechanics tests moved to the component suite; one integration test remains pinning the full wire-up (drag → settle → `transitionEnd` → dialog unmounts). The mobile chrome test now asserts the backdrop layer instead of `bg-black` on the button.

## Verification

- `pnpm vitest run src/editor/image-lightbox.test.tsx src/editor/note-editor.test.tsx` — 43 tests pass
- `pnpm typecheck` — clean
- `pnpm lint` — clean

Not run: a manual device pass on iOS. The gesture values (rubber-band distance, fade rates, spring curve) were chosen against iOS-Photos behavior but should be validated by feel on hardware.

## Risk / Rollout

- Gesture changes are mobile-surface only (`isMobileSurface()`); the desktop changes are visual (scrim color, image sizing, Open-button style). The view-transition open/close paths are untouched.
- The immersive dialog makes the note visible behind the image during the drag. On dismiss the slide-out completes before `onClose` runs the existing close path, same as before.
- A manual TestFlight/device pass is owed to tune the feel constants if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
