### PR TITLE
fix(desktop): remove phantom blank line under wrapped wikilink chips on iOS

### DIFF
--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -549,6 +549,18 @@ html:root {
   border-radius: var(--radius-sm, 4px);
   padding: 0.05em 0.15em;
   cursor: pointer;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+
+/* A wrapping chip must flow like text, not sit in meowdown's `inline-block`
+   atom box: when the block fills the full line, the zero-width wikilink
+   source span after it no longer fits, and iOS WebKit wraps it onto an empty
+   full-strut line — a phantom blank line under every wrapped link. Inline
+   flow keeps the source glued to the last label fragment; the clone above
+   keeps chip corners on every fragment. */
+.reflect-editor .md-wikilink-view-preview {
+  display: inline;
 }
 
 /* Tags render via meowdown's `.md-tag` (an accent pill, our purple); the task


### PR DESCRIPTION
## Problem

On iOS, wiki-link chips that wrap onto a second line get a phantom blank line rendered underneath them. Captured links in the daily note's `## Links` section (long page titles that almost always wrap on a phone) showed a gap of a full extra line below each entry.

## Cause

meowdown renders the wikilink mark view as an `inline-block` atom preview (`.md-atom-view-preview`), followed by the hidden zero-width source span (`[[target|alias]]`, kept in the box tree at `font-size: 0` for caret placement). When the chip label wraps, the inline-block's outer width becomes the full line width. The zero-width source span after it then no longer fits on that line, and iOS WebKit wraps it onto a line of its own — an empty line box that still gets the paragraph's full strut height (~1 line-height of blank space).

Whether it triggers depends on the exact wrap width of the label's longest fragment, which is why some wrapped chips showed the gap and others didn't, and why desktop browsers happened not to reproduce it.

## Change

Reflect's editor CSS (unlayered, so it wins over meowdown's layered rules) now lets the wikilink preview flow `inline` instead of `inline-block`, so the label text wraps like ordinary text and the trailing source span stays glued to the last fragment. `box-decoration-break: clone` on the label keeps the chip background's rounded corners and padding on every wrapped fragment.

Scoped to `.md-wikilink-view-preview` only — image atom previews keep meowdown's `inline-block`.

## Verification

- Reproduced on the iOS simulator (`pnpm tauri ios dev`) with capture-style wrapped links: a 2-line chip measured 69px (3 line-heights) before the fix, 46px (exactly 2) after; the visible phantom gap is gone.
- Playwright WebKit + Chromium against the `?platform=ios` browser harness: wrapped items are exactly 2 line-heights, chip background and cloned corners render per fragment, mid-sentence chips unchanged.
- Interaction smoke test: tapping a wrapped chip still navigates to the linked note; placing the caret after a chip and typing works, including the mark-mode source reveal.
- `pnpm check` passes.

## Risk

Low: a 2-property CSS override on the wikilink chip only. The subtle behavior change is that a long chip can now start mid-line and wrap like text instead of dropping to a new line as a block — which matches V1's chip rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Unlayered CSS overrides on wikilink chip presentation only; no auth, data, or API changes.
> 
> **Overview**
> Fixes an **iOS WebKit layout bug** where wrapped wiki-link chips showed an extra blank line under the label (notably in daily note `## Links` with long titles).
> 
> Editor CSS now forces **`.md-wikilink-view-preview`** to `display: inline` so the hidden `[[…]]` source span stays on the same line as the last label fragment instead of wrapping alone. **`box-decoration-break: clone`** on **`.md-wikilink-view-label`** keeps chip padding and rounded corners on each wrapped fragment. Scoped to wikilink previews only; image atom previews stay `inline-block`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c7084b39c91051af01e11d04d3bea2539b1e0d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->