### PR TITLE
Release v0.4.0-beta.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4737,7 +4737,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.4.0-beta.33"
+version = "0.4.0-beta.34"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.4.0-beta.33"
+version = "0.4.0-beta.34"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.4.0-beta.33",
+  "version": "0.4.0-beta.34",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.4.0-beta.34.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version-only changes with no functional code or dependency updates.
> 
> **Overview**
> **Release version bump** from `0.4.0-beta.34` (replacing `0.4.0-beta.33`) across the desktop Tauri app so Cargo, the lockfile, and the bundled app metadata stay aligned.
> 
> Updates `apps/desktop/src-tauri/Cargo.toml`, `Cargo.lock` for `reflect-open`, and `apps/desktop/src-tauri/tauri.conf.json` `version` / `productName` packaging fields. No application logic or dependency changes beyond the version string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeca11579747c7b944a7018394bd3de67146e0f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->