### PR TITLE
feat: keep local Git history for graphs without a backup remote

### DIFF
--- a/apps/desktop/src/lib/backup-controller.test.ts
+++ b/apps/desktop/src/lib/backup-controller.test.ts
@@ -40,8 +40,10 @@ interface FakeOptions {
   failStatus?: boolean
   /** Scripted `git_merge_remote` outcome (defaults to up-to-date). */
   mergeOutcome?: unknown
-  /** The graph's origin (defaults to a GitHub HTTPS remote). */
-  remoteUrl?: string
+  /** The graph's origin (defaults to a GitHub HTTPS remote; null = none). */
+  remoteUrl?: string | null
+  /** Whether the graph already has a repository (defaults to true). */
+  initialized?: boolean
 }
 
 /** Bridge fake with a mutable repo status, recording every command. */
@@ -50,9 +52,12 @@ function fakeBridge(options: FakeOptions = {}) {
   const invocations: Array<{ command: string; args: Record<string, unknown> }> = []
   let auth = options.auth === undefined ? AUTH : options.auth
   const status = {
-    initialized: true,
+    initialized: options.initialized ?? true,
     branch: 'main',
-    remoteUrl: (options.remoteUrl ?? 'https://github.com/alex/notes.git') as string | null,
+    remoteUrl:
+      options.remoteUrl === undefined
+        ? ('https://github.com/alex/notes.git' as string | null)
+        : options.remoteUrl,
     ahead: 0,
     behind: 0,
     inProgress: false,
@@ -69,6 +74,7 @@ function fakeBridge(options: FakeOptions = {}) {
           }
           return status
         case 'git_setup':
+          status.initialized = true
           status.remoteUrl = typeof args['remoteUrl'] === 'string' ? args['remoteUrl'] : null
           return status
         case 'secret_get':
@@ -216,6 +222,65 @@ describe('createBackupController', () => {
 
     expect(calls).not.toContain('git_commit_all')
     expect(calls.filter((command) => command === 'git_status')).toHaveLength(1)
+  })
+
+  it('initializes local history on desktop when no backup is configured', async () => {
+    const { calls, invocations } = fakeBridge({ auth: null, initialized: false, remoteUrl: null })
+    const controller = createBackupController({ graph: GRAPH, indexGeneration: 1 })
+    await controller.start()
+
+    // The UI never learns about local history — the graph reads as disconnected.
+    expect(controller.getState()).toEqual({ phase: 'disconnected' })
+    const setup = invocations.find(({ command }) => command === 'git_setup')
+    expect(setup?.args).toMatchObject({ remoteUrl: null, branch: null, generation: 3 })
+    await vi.waitFor(() => {
+      expect(calls).toContain('git_commit_all') // first snapshot on launch
+    })
+    expect(calls).not.toContain('git_fetch')
+    expect(calls).not.toContain('git_push')
+    controller.dispose()
+  })
+
+  it('local history keeps committing on edits — still with no network', async () => {
+    // A repo without a remote (e.g. after disconnectGraph) needs no git_setup.
+    const commitCount = (calls: string[]): number =>
+      calls.filter((command) => command === 'git_commit_all').length
+    const { calls } = fakeBridge({ auth: null, remoteUrl: null })
+    const controller = createBackupController({ graph: GRAPH, indexGeneration: 1 })
+    await controller.start()
+    await vi.waitFor(() => {
+      expect(commitCount(calls)).toBe(1)
+    })
+    expect(calls).not.toContain('git_setup')
+
+    vi.useFakeTimers()
+    try {
+      emitFileChanges([{ path: 'notes/edited.md', kind: 'upsert', modifiedMs: 1 }])
+      await vi.advanceTimersByTimeAsync(30_000)
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(commitCount(calls)).toBe(2)
+    expect(calls).not.toContain('git_fetch')
+    expect(calls).not.toContain('git_push')
+    controller.dispose()
+  })
+
+  it('never starts local history on mobile', async () => {
+    setPlatformSurface({ mobileApp: true })
+    try {
+      const { calls } = fakeBridge({ auth: null, initialized: false, remoteUrl: null })
+      const controller = createBackupController({ graph: GRAPH, indexGeneration: 1 })
+      await controller.start()
+      await new Promise((resolve) => setTimeout(resolve, 20))
+
+      expect(controller.getState()).toEqual({ phase: 'disconnected' })
+      expect(calls).not.toContain('git_setup')
+      expect(calls).not.toContain('git_commit_all')
+      controller.dispose()
+    } finally {
+      setPlatformSurface({ mobileApp: false })
+    }
   })
 
   it('disconnectGraph drops the remote and lands on disconnected', async () => {

--- a/apps/desktop/src/lib/backup-controller.ts
+++ b/apps/desktop/src/lib/backup-controller.ts
@@ -38,6 +38,10 @@ import { throttledInvalidateIndexQueries } from '@/lib/query-client'
  * remotes (which additionally require the stored GitHub credential) and
  * `null` for hand-wired generic remotes (Plan 16: GitLab/Gitea/self-hosted
  * over SSH, or a bare path repo), whose credentials resolve locally in Rust.
+ *
+ * `disconnected` means no *backup*: on desktop such graphs still run the
+ * local-history commit loop (see `startLocalHistory`), which the UI never
+ * surfaces.
  */
 export type BackupState =
   | { phase: 'loading' }
@@ -177,6 +181,59 @@ export function createBackupController(options: BackupControllerOptions): Backup
     }
   }
 
+  /**
+   * Wire an engine into the watcher (which feeds its debounce) and the
+   * quit-time flusher. Returns false when teardown or a restart won the race
+   * against the subscribe — the engine is already stopped in that case.
+   */
+  async function adoptEngine(next: SyncEngine): Promise<boolean> {
+    engine = next
+    // Spooled capture envelopes (`.reflect/inbox/`) are git-ignored and
+    // drained within seconds — they must not tick the commit debounce. The
+    // drain's own note writes arrive as ordinary changes right after.
+    const subscription = await subscribeFileChanges((changes) => {
+      if (changes.some((change) => !isCaptureSpoolPath(change.path))) {
+        next.noteChanged()
+      }
+    })
+    if (disposed || engine !== next) {
+      subscription()
+      next.stop()
+      return false
+    }
+    unlisten = subscription
+    // Quit-time commit (local only — never a network push on the way out).
+    setBackupFlusher(async () => {
+      await gitCommitAll('Update notes', generation)
+    })
+    return true
+  }
+
+  /**
+   * Local history (desktop only): a graph with no remote still gets a
+   * repository and the debounced commit loop, so every edit lands in Git
+   * history and stays revertable — nothing is ever fetched or pushed, and
+   * the UI stays `disconnected`. Connecting a backup later adopts this
+   * repository, history included.
+   */
+  async function startLocalHistory(initialized: boolean): Promise<void> {
+    if (isMobileSurface()) {
+      return
+    }
+    if (!initialized) {
+      await gitSetup(null, null, generation)
+    }
+    const next = createSyncEngine({
+      generation,
+      localOnly: true,
+      getToken: async () => null,
+    })
+    if (!(await adoptEngine(next))) {
+      return
+    }
+    void next.syncNow() // first snapshot: commit whatever is already pending
+  }
+
   async function start(): Promise<void> {
     teardown()
     if (disposed) {
@@ -190,6 +247,7 @@ export function createBackupController(options: BackupControllerOptions): Backup
       }
       if (!status.initialized || status.remoteUrl === null) {
         setState({ phase: 'disconnected' })
+        await startLocalHistory(status.initialized)
         return
       }
       const remoteUrl = status.remoteUrl
@@ -236,24 +294,10 @@ export function createBackupController(options: BackupControllerOptions): Backup
         },
         onRemoteChanges,
       })
-      engine = next
       setState({ phase: 'connected', remoteUrl, repo, status: { state: 'idle' } })
-
-      // Spooled capture envelopes (`.reflect/inbox/`) are git-ignored and
-      // drained within seconds — they must not tick the commit debounce. The
-      // drain's own note writes arrive as ordinary changes right after.
-      const subscription = await subscribeFileChanges((changes) => {
-        if (changes.some((change) => !isCaptureSpoolPath(change.path))) {
-          next.noteChanged()
-        }
-      })
-      if (disposed || engine !== next) {
-        // Teardown (or a restart) won the race against the subscribe.
-        subscription()
-        next.stop()
+      if (!(await adoptEngine(next))) {
         return
       }
-      unlisten = subscription
 
       // Resume triggers: window focus (desktop refocus) and visibility →
       // visible (mobile app resume; desktop unminimize, which doesn't
@@ -283,10 +327,6 @@ export function createBackupController(options: BackupControllerOptions): Backup
         () => document.removeEventListener('visibilitychange', onVisibilityChange),
         () => window.removeEventListener('online', onOnline),
       )
-      // Quit-time commit (local only — never a network push on the way out).
-      setBackupFlusher(async () => {
-        await gitCommitAll('Update notes', generation)
-      })
 
       void next.syncNow() // launch pull: pick up other devices' changes
     } catch (error) {

--- a/apps/desktop/src/lib/backup-controller.ts
+++ b/apps/desktop/src/lib/backup-controller.ts
@@ -227,6 +227,13 @@ export function createBackupController(options: BackupControllerOptions): Backup
       generation,
       localOnly: true,
       getToken: async () => null,
+      onStatus: (engineStatus) => {
+        // No UI surfaces local history, so a failing commit loop (disk full,
+        // corrupted repo) must at least leave a trace for diagnosis.
+        if (engineStatus.state === 'error') {
+          console.error('local history commit failed:', engineStatus.message)
+        }
+      },
     })
     if (!(await adoptEngine(next))) {
       return

--- a/packages/core/src/sync/engine.test.ts
+++ b/packages/core/src/sync/engine.test.ts
@@ -463,6 +463,23 @@ describe('createSyncEngine', () => {
     engine.stop()
   })
 
+  it('localOnly commits and never touches the network — even for a full sync', async () => {
+    const calls = fakeGit(defaultResponses)
+    const engine = createSyncEngine({
+      generation: 1,
+      getToken: async () => null,
+      localOnly: true,
+      idleMs: 10,
+    })
+
+    engine.noteChanged()
+    await vi.runAllTimersAsync()
+    await engine.syncNow()
+
+    expect(commandsOf(calls)).toEqual(['git_commit_all', 'git_commit_all'])
+    engine.stop()
+  })
+
   it('stop() cancels pending work', async () => {
     const calls = fakeGit(defaultResponses)
     const engine = createSyncEngine({ generation: 1, getToken: async () => 'tok', idleMs: 10 })

--- a/packages/core/src/sync/engine.ts
+++ b/packages/core/src/sync/engine.ts
@@ -83,6 +83,12 @@ export interface SyncEngineOptions {
   idleMs?: number
   /** Ceiling on deferral while the user keeps typing. */
   maxWaitMs?: number
+  /**
+   * Commit-only mode, for a graph with no remote (local history): every
+   * cycle ends after the commit — no credential resolved, no fetch/merge,
+   * no push. Edits still land in Git history and stay revertable.
+   */
+  localOnly?: boolean
 }
 
 export interface SyncEngine {
@@ -211,10 +217,13 @@ export function createSyncEngine(options: SyncEngineOptions): SyncEngine {
   }
 
   async function cycle(mode: 'push' | 'full'): Promise<void> {
-    const token = await step(options.getToken())
+    const token = options.localOnly === true ? null : await step(options.getToken())
     const commit = await step(gitCommitAll('Update notes', options.generation))
     if (commit.skippedLargeFiles.length > 0) {
       options.onLargeFilesSkipped?.(commit.skippedLargeFiles)
+    }
+    if (options.localOnly === true) {
+      return // the commit is the whole cycle — the repo has no remote
     }
     if (mode === 'push') {
       // The debounce path often fires for changes that are already committed


### PR DESCRIPTION
## Problem

A graph without Git backup has no history at all: nothing records edits, and a mangled or deleted note is simply gone. All the pieces already exist for backup-connected graphs — the repo init/adopt primitive, the debounced commit loop, the quit-time flush — they just never run without a remote.

## Change

Desktop graphs with no backup configured now build local Git history automatically:

- **`packages/core/src/sync/engine.ts`** — new `localOnly` option on the sync engine: every cycle ends after the commit step. No credential is resolved, no fetch/merge, no push. Debounce cadence (30s idle / 5m ceiling), single-flight, and `stop()` semantics are unchanged and shared.
- **`apps/desktop/src/lib/backup-controller.ts`** — when the probe finds no repo or no remote (and the surface is desktop), the controller initializes the repository via the existing `git_setup` (which also writes the graph `.gitignore` defaults and marks `.git` local-only so iCloud/Dropbox never replicate it), then runs a `localOnly` engine fed by the same watcher subscription, plus the quit-time commit flush. The shared engine wiring is extracted into `adoptEngine()` rather than duplicated. An initial `syncNow()` snapshots whatever is already pending.

The UI is deliberately untouched: `BackupState` stays `disconnected`, so settings and the graph footer render exactly as before. Connecting a backup later adopts the repository as-is — the accumulated history comes along and is pushed to the remote.

Mobile keeps its current behavior (no repo without backup); this is desktop-only.

## Behavior notes

- A graph whose backup was disconnected (`git_disconnect` drops `origin` but keeps the repo) now keeps committing locally instead of freezing history — consistent with the disconnect docstring ("history stays").
- A graph with a GitHub remote but a missing credential does *not* run local history; that state is an auth problem the user is prompted to fix, and the sync engine takes over once reconnected.
- Deleted note content now persists in `.git` on disk for every desktop graph, not just backup-opted ones, and connecting a backup later pushes that full history. Accepted for this iteration to keep the change minimal.

## Testing

- `pnpm test --run src/sync/engine.test.ts` (packages/core) — 22 passed, including the new `localOnly` never-touches-network case.
- `pnpm test --run src/lib/backup-controller.test.ts` (apps/desktop) — 20 passed, including: local-history init when no backup is configured, continued debounced commits with no `git_fetch`/`git_push`, no `git_setup` re-run for an existing remoteless repo, and no local history on mobile.
- `pnpm check` (typecheck + oxlint + eslint) — clean.
- Not manually verified in a running Tauri app yet.

## Risk / rollout

No Rust changes and no schema changes. The new code path only engages where nothing ran before (disconnected graphs on desktop); connected-graph behavior is a pure refactor covered by the existing controller tests. Disk growth from history is bounded by the existing 95 MB large-file guardrail, which now applies to local commits too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New desktop lifecycle writes `.git` history for every disconnected graph (disk growth, large-file guardrail now applies locally); connected sync is a refactor only, with no Rust or schema changes.
> 
> **Overview**
> Desktop graphs with **no backup remote** (or no repo yet) now get a **commit-only** sync path while **`BackupState` stays `disconnected`**—settings and footer unchanged.
> 
> **`packages/core`:** `createSyncEngine` gains **`localOnly`**: each cycle runs **`git_commit_all` only** (no token, fetch, merge, or push), including on **`syncNow`**.
> 
> **`backup-controller`:** When the probe finds no repo or no `origin`, desktop calls **`startLocalHistory`** (`git_setup` if needed, then a `localOnly` engine). Shared watcher subscription, quit-time flush, and teardown race handling move into **`adoptEngine`**, reused by the connected path. **Mobile** skips local history; **GitHub remote without stored credential** still stops before any engine (auth fix path, not local history).
> 
> Tests cover engine `localOnly`, init + debounced commits without network, mobile no-op, and test fakes for `initialized` / `remoteUrl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20aeff81a45c3d8a8fd08a42c16f034698f48a2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a local-only history mode on desktop when no remote backup is configured.
  * Local changes are now saved automatically even without network sync, while keeping the app disconnected.
* **Bug Fixes**
  * Improved behavior when switching between backup states so local history continues reliably.
  * On mobile, local history setup remains disabled as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->