### PR TITLE
fix(mobile): keep the daily double-tap's end-of-note caret in view

### DIFF
--- a/apps/desktop/src/mobile/day-slide.tsx
+++ b/apps/desktop/src/mobile/day-slide.tsx
@@ -57,7 +57,7 @@ export function DaySlide({
   const { settings } = useSettings()
   const containerRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
-  const { handleScroll, resetToTop } = useScrollRestore({
+  const { handleScroll, resetToTop, cancelRestore } = useScrollRestore({
     key: day,
     memory: scrollMemory,
     containerRef,
@@ -70,10 +70,17 @@ export function DaySlide({
   // full-height viewport; the keyboard then raises and shrinks the shell by
   // its height, dropping the note's end below the fold. The reveal holds the
   // container at its end while that settles (see use-caret-reveal.ts).
+  //
+  // A remount's scroll restore must die first: the double-tap's second
+  // arrival often lands while this slide (freshly remounted from another
+  // tab) is still chasing its saved offset, and the chase's next re-apply —
+  // delivered after the reveal's pin, on the same content growth — would
+  // yank the caret back out of view with nothing re-pinning it.
   const handleAutoFocused = useCallback(() => {
+    cancelRestore()
     revealEnd()
     onFocusConsumed()
-  }, [revealEnd, onFocusConsumed])
+  }, [cancelRestore, revealEnd, onFocusConsumed])
 
   const lastResetSeq = useRef(scrollResetSeq)
   useEffect(() => {

--- a/apps/desktop/src/mobile/screens/daily.tsx
+++ b/apps/desktop/src/mobile/screens/daily.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react'
+import { useCallback, useState, type ReactElement } from 'react'
 import { untitledNotePath } from '@reflect/core'
 import { Plus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useToday } from '@/lib/use-today'
 import { CalendarStrip } from '@/mobile/calendar-strip'
 import { DayCarousel } from '@/mobile/day-carousel'
+import { useDailyArrivals } from '@/mobile/use-daily-arrivals'
 import { useRouter } from '@/routing/router'
 
 /**
@@ -50,30 +51,15 @@ export function MobileDaily({ date }: { date: string }): ReactElement {
   )
 
   // An explicit re-arrival at the day already shown — the Daily tab tapped
-  // while on today (V1's double-tap-to-today lands here as two such
-  // arrivals) — re-anchors the surface: the selected slide scrolls
-  // to the top and the strip re-centers. The router bumps `arrivalSeq` for
-  // every navigate, but a swipe's own echo also changes `date`, so only
-  // date-preserving arrivals count.
-  const [resetSeq, setResetSeq] = useState(0)
-  const [focusDate, setFocusDate] = useState<string | null>(null)
-  const lastArrival = useRef({ seq: arrivalSeq, date })
-  useEffect(() => {
-    const last = lastArrival.current
-    lastArrival.current = { seq: arrivalSeq, date }
-    if (arrivalSeq !== last.seq && arrivalFocusEditor) {
-      setFocusDate(date)
-    } else if (arrivalSeq !== last.seq) {
-      setFocusDate(null)
-    }
-    if (arrivalSeq !== last.seq && date === last.date) {
-      setResetSeq((seq) => seq + 1)
-    }
-  }, [arrivalSeq, arrivalFocusEditor, date])
-
-  const consumeFocus = useCallback((): void => {
-    setFocusDate(null)
-  }, [])
+  // while on today (V1's double-tap-to-today lands here) — re-anchors the
+  // surface, and a capture arrival focuses the day's editor; the arrival
+  // bookkeeping (including a focus request racing this surface's remount)
+  // lives in use-daily-arrivals.ts.
+  const { resetSeq, focusDate, consumeFocus } = useDailyArrivals({
+    arrivalSeq,
+    arrivalFocusEditor,
+    date,
+  })
 
   return (
     <div className="flex h-full w-screen flex-col">

--- a/apps/desktop/src/mobile/use-caret-reveal.test.ts
+++ b/apps/desktop/src/mobile/use-caret-reveal.test.ts
@@ -125,6 +125,29 @@ describe('useCaretReveal', () => {
     expect(scrollable.element.scrollTop).toBe(800)
   })
 
+  it('re-pins when something scrolls the container away without a resize', () => {
+    const { scrollable, hook } = mountReveal({ scrollHeight: 900, maxScrollTop: 400 })
+
+    hook.result.current.revealEnd()
+    // iOS WebKit scrolls the container directly to reveal the newly focused
+    // editor — no size change, so the observer never fires. The user's own
+    // take-over always leads with a pointerdown, so a bare scroll is never
+    // the user's.
+    scrollable.element.scrollTop = 120
+    scrollable.element.dispatchEvent(new Event('scroll'))
+    expect(scrollable.element.scrollTop).toBe(400)
+  })
+
+  it('stops chasing scrolls once the reveal ends', () => {
+    const { scrollable, hook } = mountReveal({ scrollHeight: 900, maxScrollTop: 400 })
+
+    hook.result.current.revealEnd()
+    scrollable.element.dispatchEvent(new Event('pointerdown'))
+    scrollable.element.scrollTop = 120
+    scrollable.element.dispatchEvent(new Event('scroll'))
+    expect(scrollable.element.scrollTop).toBe(120)
+  })
+
   it('ends the reveal at the deadline — later resizes leave the user alone', () => {
     const { scrollable, hook } = mountReveal({ scrollHeight: 900, maxScrollTop: 400 })
 

--- a/apps/desktop/src/mobile/use-caret-reveal.ts
+++ b/apps/desktop/src/mobile/use-caret-reveal.ts
@@ -52,6 +52,9 @@ export function useCaretReveal({ containerRef, contentRef }: CaretRevealOptions)
     stopRef.current?.()
     let observer: ResizeObserver | null = null
     let deadline: ReturnType<typeof setTimeout> | null = null
+    const pin = (): void => {
+      container.scrollTop = container.scrollHeight
+    }
     const stop = (): void => {
       if (stopRef.current === stop) {
         stopRef.current = null
@@ -61,16 +64,20 @@ export function useCaretReveal({ containerRef, contentRef }: CaretRevealOptions)
       }
       observer?.disconnect()
       container.removeEventListener('pointerdown', stop)
+      container.removeEventListener('scroll', pin)
     }
     stopRef.current = stop
-    const pin = (): void => {
-      container.scrollTop = container.scrollHeight
-    }
     pin()
     observer = new ResizeObserver(pin)
     observer.observe(container)
     observer.observe(content)
     container.addEventListener('pointerdown', stop, { passive: true })
+    // Anything that scrolls the container away mid-reveal loses. Sizes are
+    // covered by the observer, but iOS WebKit may scroll the container
+    // directly to reveal the newly focused editor — no resize involved. The
+    // user's own take-over always leads with a pointerdown (which stops the
+    // reveal above), so a scroll arriving here is never the user's.
+    container.addEventListener('scroll', pin, { passive: true })
     deadline = setTimeout(stop, REVEAL_WINDOW_MS)
   }, [containerRef, contentRef])
 

--- a/apps/desktop/src/mobile/use-daily-arrivals.test.ts
+++ b/apps/desktop/src/mobile/use-daily-arrivals.test.ts
@@ -1,0 +1,76 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { useDailyArrivals, type DailyArrivalsOptions } from './use-daily-arrivals'
+
+/**
+ * The daily surface's arrival bookkeeping (extracted from MobileDaily). The
+ * contract: date-preserving re-arrivals re-anchor, capture arrivals focus,
+ * swipe echoes do neither — and a focus arrival that raced the surface's
+ * remount (the Daily-tab double-tap completing before the remounting screen
+ * first commits, the from-another-tab bug) must still be honored.
+ */
+
+function mountArrivals(initial: DailyArrivalsOptions) {
+  return renderHook((props: DailyArrivalsOptions) => useDailyArrivals(props), {
+    initialProps: initial,
+  })
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('useDailyArrivals', () => {
+  it('a plain mount neither focuses nor re-anchors', () => {
+    const hook = mountArrivals({ arrivalSeq: 3, arrivalFocusEditor: false, date: '2026-07-06' })
+    expect(hook.result.current.focusDate).toBeNull()
+    expect(hook.result.current.resetSeq).toBe(0)
+  })
+
+  it('honors a focus arrival that raced the mount', () => {
+    // Both double-tap navigations landed before the remounting surface first
+    // committed: the mount already sees the final seq with the focus flag up.
+    const hook = mountArrivals({ arrivalSeq: 3, arrivalFocusEditor: true, date: '2026-07-06' })
+    expect(hook.result.current.focusDate).toBe('2026-07-06')
+    expect(hook.result.current.resetSeq).toBe(0)
+  })
+
+  it('re-anchors on a date-preserving re-arrival', () => {
+    const hook = mountArrivals({ arrivalSeq: 1, arrivalFocusEditor: false, date: '2026-07-06' })
+    hook.rerender({ arrivalSeq: 2, arrivalFocusEditor: false, date: '2026-07-06' })
+    expect(hook.result.current.resetSeq).toBe(1)
+    expect(hook.result.current.focusDate).toBeNull()
+  })
+
+  it('focuses on a capture re-arrival (the double-tap while already shown)', () => {
+    const hook = mountArrivals({ arrivalSeq: 1, arrivalFocusEditor: false, date: '2026-07-06' })
+    hook.rerender({ arrivalSeq: 2, arrivalFocusEditor: true, date: '2026-07-06' })
+    expect(hook.result.current.focusDate).toBe('2026-07-06')
+    // The date-preserving arrival still bumps the reset — the slide skips the
+    // jump-to-top itself while a focus request is pending.
+    expect(hook.result.current.resetSeq).toBe(1)
+  })
+
+  it('ignores a swipe echo (the date moved with the seq)', () => {
+    const hook = mountArrivals({ arrivalSeq: 1, arrivalFocusEditor: false, date: '2026-07-06' })
+    hook.rerender({ arrivalSeq: 2, arrivalFocusEditor: false, date: '2026-07-07' })
+    expect(hook.result.current.resetSeq).toBe(0)
+    expect(hook.result.current.focusDate).toBeNull()
+  })
+
+  it('a later non-focus arrival clears a pending focus request', () => {
+    const hook = mountArrivals({ arrivalSeq: 1, arrivalFocusEditor: true, date: '2026-07-06' })
+    expect(hook.result.current.focusDate).toBe('2026-07-06')
+    hook.rerender({ arrivalSeq: 2, arrivalFocusEditor: false, date: '2026-07-07' })
+    expect(hook.result.current.focusDate).toBeNull()
+  })
+
+  it('consumeFocus clears the request without disturbing the reset seq', () => {
+    const hook = mountArrivals({ arrivalSeq: 1, arrivalFocusEditor: true, date: '2026-07-06' })
+    act(() => {
+      hook.result.current.consumeFocus()
+    })
+    expect(hook.result.current.focusDate).toBeNull()
+    expect(hook.result.current.resetSeq).toBe(0)
+  })
+})

--- a/apps/desktop/src/mobile/use-daily-arrivals.ts
+++ b/apps/desktop/src/mobile/use-daily-arrivals.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export interface DailyArrivalsOptions {
+  /** The router's navigation counter — bumped on every `navigate`. */
+  arrivalSeq: number
+  /** Whether the latest navigation asked the daily editor to focus. */
+  arrivalFocusEditor: boolean
+  /** The daily route's shown day (ISO date). */
+  date: string
+}
+
+export interface DailyArrivals {
+  /**
+   * Bumped on an explicit re-arrival at the day already shown (the Daily tab
+   * or title tapped while already there): the selected slide re-anchors to
+   * the top and the strip re-centers.
+   */
+  resetSeq: number
+  /** The day whose editor should focus with the caret at its end, if any. */
+  focusDate: string | null
+  /** Clear {@link focusDate} once the focus request has been applied. */
+  consumeFocus: () => void
+}
+
+/**
+ * Turns the router's arrival stream into the daily surface's two intents:
+ * re-anchor (a date-preserving re-arrival) and focus (a capture arrival —
+ * `navigate(..., { focusEditor: true })`, the Daily-tab double-tap). The
+ * router bumps `arrivalSeq` for every navigate, but a swipe's own echo also
+ * changes `date`, so only date-preserving arrivals re-anchor.
+ *
+ * The arrival that mounts the surface is special: it never re-anchors (there
+ * is no previously-shown day), but its focus request still counts — the
+ * double-tap's second navigate can land before the remounting surface (a tab
+ * switch unmounts it) first commits, so waiting for a *change* against a
+ * mount-seeded seq would silently swallow the capture gesture. The initial
+ * state reads the mounting arrival instead.
+ */
+export function useDailyArrivals({
+  arrivalSeq,
+  arrivalFocusEditor,
+  date,
+}: DailyArrivalsOptions): DailyArrivals {
+  const [resetSeq, setResetSeq] = useState(0)
+  // The mounting arrival seeds the state directly — it never re-anchors
+  // (there is no previously-shown day), but its focus request counts.
+  const [focusDate, setFocusDate] = useState<string | null>(arrivalFocusEditor ? date : null)
+  const lastArrival = useRef({ seq: arrivalSeq, date })
+  useEffect(() => {
+    const last = lastArrival.current
+    lastArrival.current = { seq: arrivalSeq, date }
+    if (arrivalSeq !== last.seq && arrivalFocusEditor) {
+      setFocusDate(date)
+    } else if (arrivalSeq !== last.seq) {
+      setFocusDate(null)
+    }
+    if (arrivalSeq !== last.seq && date === last.date) {
+      setResetSeq((seq) => seq + 1)
+    }
+  }, [arrivalSeq, arrivalFocusEditor, date])
+
+  const consumeFocus = useCallback((): void => {
+    setFocusDate(null)
+  }, [])
+
+  return { resetSeq, focusDate, consumeFocus }
+}

--- a/apps/desktop/src/mobile/use-scroll-restore.test.ts
+++ b/apps/desktop/src/mobile/use-scroll-restore.test.ts
@@ -200,6 +200,27 @@ describe('useScrollRestore', () => {
     expect(memory.get(KEY)).toBe(10)
   })
 
+  it('cancelRestore ends the chase without touching the scroll or the memory', () => {
+    const { memory, scrollable, hook } = mountRestore({ saved: 500, maxScrollTop: 100 })
+
+    // An end-of-note focus arrival (the double-tap) pins the container to its
+    // end; the chase must die in place — its next content-growth re-apply
+    // would yank the caret back to the stale offset.
+    hook.result.current.cancelRestore()
+    expect(scrollable.element.scrollTop).toBe(100)
+    expect(memory.get(KEY)).toBe(500)
+    expect(observer()?.disconnected).toBe(true)
+
+    scrollable.setMaxScrollTop(1000)
+    observer()?.resize()
+    expect(scrollable.element.scrollTop).toBe(100)
+
+    // Scrolling records normally afterwards (the reveal's pins included).
+    scrollable.element.scrollTop = 900
+    hook.result.current.handleScroll(scrollEventOn(scrollable.element))
+    expect(memory.get(KEY)).toBe(900)
+  })
+
   it('restores a reachable offset synchronously without arming the machinery', () => {
     const { scrollable } = mountRestore({ saved: 80, maxScrollTop: 100 })
 

--- a/apps/desktop/src/mobile/use-scroll-restore.ts
+++ b/apps/desktop/src/mobile/use-scroll-restore.ts
@@ -29,6 +29,14 @@ export interface ScrollRestore {
   handleScroll: (event: UIEvent<HTMLElement>) => void
   /** Cancel any in-flight restore, forget the saved offset, and jump to the top. */
   resetToTop: () => void
+  /**
+   * End an in-flight restore without touching the scroll position or the
+   * saved offset. An end-of-note focus arrival (the Daily-tab double-tap)
+   * must call this before pinning the container to its end — the chase would
+   * otherwise re-apply the stale offset on the next content growth and yank
+   * the caret back out of view.
+   */
+  cancelRestore: () => void
 }
 
 /**
@@ -110,5 +118,9 @@ export function useScrollRestore({
     }
   }, [key, memory, containerRef])
 
-  return { handleScroll, resetToTop }
+  const cancelRestore = useCallback(() => {
+    stopRestoringRef.current?.()
+  }, [])
+
+  return { handleScroll, resetToTop, cancelRestore }
 }


### PR DESCRIPTION
## Problem

On iOS, double-tapping the Daily tab focuses today's note with the caret at the end — but on long notes the scroll often stayed elsewhere (typically the top), leaving the caret hidden off-screen. Reproduced in the `?platform=ios` browser harness with a 120-line today note: double-tapping Daily from another tab left the view at the top with the editor **not even focused**.

Three cooperating causes, all wider on long notes (slower mount/document render widens every race window):

1. **The focus request was swallowed when it raced the surface's remount.** Switching tabs unmounts `MobileDaily`; the first tap remounts it and the second tap's `focusEditor` navigation can be processed before that remount first commits. The arrival effect seeded its `lastArrival` ref from the *current* `arrivalSeq`, so an arrival already reflected at mount looked like "no change" and the capture gesture died silently.
2. **The scroll-restore chase outlived the caret reveal.** When the day slide remounts with a saved offset (double-tap from a far-away day), `useScrollRestore` keeps re-applying the stale offset on every content growth for up to 2s. Its ResizeObserver callback delivers *after* the reveal's pin on the same growth, yanking the caret back out of view — and nothing re-pins, because the reveal only reacted to resizes.
3. **The reveal was blind to bare scrolls.** iOS WebKit can scroll the container directly to reveal a newly focused editor — no resize involved, so the reveal's ResizeObserver never fired.

## Changes

- `MobileDaily`'s arrival bookkeeping moves into a new tested hook, [use-daily-arrivals.ts](apps/desktop/src/mobile/use-daily-arrivals.ts), whose **initial state reads the mounting arrival** — a focus request that raced the remount is honored instead of swallowed. Re-arrival/re-anchor/swipe-echo semantics are unchanged and now pinned by tests.
- `useScrollRestore` gains `cancelRestore()` (end the chase in place, keep the memory), and `DaySlide` calls it when the end-of-note focus applies, before starting the reveal.
- `useCaretReveal` also re-pins on container `scroll` events during the reveal window. User take-over still wins: a real touch always leads with `pointerdown`, which ends the reveal before its scroll events arrive.

## Verification

- Reproduced pre-fix and verified post-fix in the mobile browser harness (long seeded today note, 375×812): double-tap from the All tab now ends focused, caret in the last node, container pinned to its end; double-tap while already on Daily (top and mid-scroll) unchanged-good; single tap from All still does not focus.
- `pnpm check` clean; all 38 mobile test files pass (281 tests), including new coverage: the mount-racing focus arrival, `cancelRestore`, and scroll-away re-pinning.

## Risk / rollout

- The scroll guard only acts inside the existing 1.5s reveal window after an explicit capture gesture; outside it nothing changes.
- WebKit's native focus-scroll behavior (cause 3) is defended against but not reproducible in the harness — an on-device pass of the double-tap from each tab and from a far-away day is still owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mobile-only scroll/focus coordination inside existing timed reveal/restore windows; behavior is covered by new tests with no auth or data changes.
> 
> **Overview**
> Fixes iOS **Daily tab double-tap** so the editor focuses with the caret at the end of long notes instead of leaving the view at a stale scroll position.
> 
> **`useDailyArrivals`** pulls router arrival handling out of `MobileDaily` and **seeds focus from the mounting arrival**, so a `focusEditor` navigation that completes before the tab remount commits is no longer treated as “no change.” Re-anchor vs swipe-echo behavior is unchanged.
> 
> **`useScrollRestore`** adds **`cancelRestore()`** to stop the remount offset chase without clearing memory; **`DaySlide`** calls it before **`revealEnd()`** when end-of-note autofocus fires so a late restore re-apply cannot pull the view away from the caret.
> 
> **`useCaretReveal`** also re-pins on container **`scroll`** during the reveal window (not only resize), covering WebKit scrolling the container when focus lands; user **`pointerdown`** still ends the reveal first.
> 
> New hook and scroll/reveal tests cover mount-racing focus, `cancelRestore`, and scroll-away re-pinning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 166f9f5a10dd8b78fc96f76ba5b9585e71432a4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->