### PR TITLE
fix(ios): preserve the ShareExtension App Group entitlement in CI TestFlight builds

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -91,3 +91,13 @@ jobs:
         run: |
           pnpm release:ios preflight --build-number="$BUILD_NUMBER"
           pnpm release:ios testflight --build-number="$BUILD_NUMBER" --export-method="$EXPORT_METHOD" $WAIT_FLAG
+
+      # The exported IPA, kept for post-hoc signing/entitlements inspection —
+      # TestFlight builds cannot be downloaded back from App Store Connect.
+      - name: Upload IPA artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: reflect-ios-ipa
+          path: apps/desktop/src-tauri/gen/apple/build/arm64/*.ipa
+          if-no-files-found: ignore

--- a/apps/desktop/scripts/release-ios.mjs
+++ b/apps/desktop/scripts/release-ios.mjs
@@ -24,6 +24,7 @@ const IOS_BUNDLE_IDENTIFIER = 'app.reflect.ios'
 const OLD_CAPACITOR_BUNDLE_IDENTIFIER = 'app.reflect.ReflectMobile'
 const NON_EXEMPT_ENCRYPTION_KEY = 'ITSAppUsesNonExemptEncryption'
 const KEYCHAIN_SERVICE = 'reflect-notary'
+const SHARE_EXTENSION_APP_GROUP = 'group.app.reflect'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const appDir = join(here, '..')
@@ -126,6 +127,16 @@ export function findIpaInfoPlistPath(listing) {
 /** Return true when an Info.plist raw value represents boolean false. */
 export function isFalsePlistValue(value) {
   return ['false', 'no', '0'].includes(value.trim().toLowerCase())
+}
+
+/** Find every app-extension bundle path inside an IPA's unzip listing. */
+export function findIpaAppexPaths(listing) {
+  const paths = new Set()
+  for (const line of listing.split('\n')) {
+    const match = line.trim().match(/^(Payload\/[^/]+\.app\/PlugIns\/[^/]+\.appex)\//)
+    if (match) paths.add(match[1])
+  }
+  return [...paths].sort()
 }
 
 function ensureMacos() {
@@ -346,9 +357,50 @@ function assertIpaExportCompliance(ipa) {
   log(`${NON_EXEMPT_ENCRYPTION_KEY}: false`)
 }
 
+/**
+ * The share extension is useless without its App Group entitlement: the
+ * container lookup returns nil and every share fails with "Couldn't save",
+ * while the build itself installs and launches normally. The entitlement
+ * comes from the export re-signing step (not the committed .entitlements
+ * file), so verify what was actually signed before letting an IPA upload.
+ */
+function assertIpaAppexEntitlements(ipa) {
+  const appexPaths = findIpaAppexPaths(capture('unzip', ['-Z1', ipa]))
+  if (appexPaths.length === 0) {
+    fail(
+      'IPA contains no app extensions — expected the ShareExtension appex.\n' +
+        '  Check that ios.project.yml still embeds ShareExtension.',
+    )
+  }
+  const tempDir = mkdtempSync(join(tmpdir(), 'reflect-ios-appex-'))
+  try {
+    execFileSync('unzip', ['-q', ipa, 'Payload/*', '-d', tempDir])
+    for (const appexPath of appexPaths) {
+      let entitlements
+      try {
+        entitlements = capture('codesign', ['-d', '--entitlements', ':-', join(tempDir, appexPath)])
+      } catch (error) {
+        fail(`cannot read code-signing entitlements of ${basename(appexPath)}: ${error.message}`)
+      }
+      if (!entitlements.includes(SHARE_EXTENSION_APP_GROUP)) {
+        fail(
+          `${basename(appexPath)} is signed without the ${SHARE_EXTENSION_APP_GROUP} App Group entitlement.\n` +
+            '  Shares from this build would fail with "Couldn\'t save" — the extension\n' +
+            '  cannot reach the shared capture inbox. Check the export re-signing step\n' +
+            '  against gen/apple/ShareExtension/ShareExtension.entitlements.',
+        )
+      }
+      log(`${basename(appexPath)} entitlements include ${SHARE_EXTENSION_APP_GROUP}`)
+    }
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true })
+  }
+}
+
 function assertIpaAppStoreMetadata(ipa) {
   assertIpaBundleIdentifier(ipa)
   assertIpaExportCompliance(ipa)
+  assertIpaAppexEntitlements(ipa)
 }
 
 function ensureReleaseTools() {

--- a/apps/desktop/scripts/release-ios.test.mjs
+++ b/apps/desktop/scripts/release-ios.test.mjs
@@ -10,6 +10,7 @@ import {
   createTimestampBuildNumber,
   createTauriIosBuildEnv,
   createTauriIosBuildArgs,
+  findIpaAppexPaths,
   findIpaInfoPlistPath,
   isFalsePlistValue,
   normalizeApiKeyContent,
@@ -194,6 +195,26 @@ test('IPA Info.plist lookup rejects ambiguous payloads', () => {
       ['Payload/Reflect.app/Info.plist', 'Payload/Other.app/Info.plist'].join('\n'),
     ),
   ).toThrow('expected exactly one app Info.plist')
+})
+
+test('IPA appex lookup finds each embedded extension bundle once', () => {
+  expect(
+    findIpaAppexPaths(
+      [
+        'Payload/',
+        'Payload/Reflect.app/',
+        'Payload/Reflect.app/Info.plist',
+        'Payload/Reflect.app/PlugIns/ShareExtension.appex/',
+        'Payload/Reflect.app/PlugIns/ShareExtension.appex/Info.plist',
+        'Payload/Reflect.app/PlugIns/ShareExtension.appex/ShareExtension',
+        'Symbols/Reflect.symbols',
+      ].join('\n'),
+    ),
+  ).toEqual(['Payload/Reflect.app/PlugIns/ShareExtension.appex'])
+})
+
+test('IPA appex lookup returns empty for an IPA without extensions', () => {
+  expect(findIpaAppexPaths(['Payload/Reflect.app/', 'Payload/Reflect.app/Info.plist'].join('\n'))).toEqual([])
 })
 
 test('Info.plist export-compliance false values are normalized', () => {

--- a/apps/desktop/src-tauri/gen/apple/ShareExtension/ShareExtension.entitlements
+++ b/apps/desktop/src-tauri/gen/apple/ShareExtension/ShareExtension.entitlements
@@ -2,9 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- The extension's only capability: the App Group container it spools
-	     capture envelopes into. It must match the main app's entry — the app
-	     reads the same container to relay envelopes into the graph. -->
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.app.reflect</string>

--- a/apps/desktop/src-tauri/gen/apple/project.yml
+++ b/apps/desktop/src-tauri/gen/apple/project.yml
@@ -57,6 +57,12 @@ targets:
         # Apple Contacts integration: read-only CNContactStore lookups for
         # person notes; the string is shown on the iOS permission prompt.
         NSContactsUsageDescription: Reflect reads your contacts to suggest details for person notes. Nothing is stored or sent anywhere.
+        # Mirrored from src-tauri/Info.plist (which merges at build) so that
+        # xcodegen regens keep them in the committed generated Info.plist
+        # instead of silently dropping them.
+        NSMicrophoneUsageDescription: Reflect uses the microphone to record audio memos that are transcribed into your daily note.
+        NSCalendarsFullAccessUsageDescription: Reflect reads your calendar to show the day's meetings beside your daily note. Access is read-only and stays on this device.
+        NSCalendarsUsageDescription: Reflect reads your calendar to show the day's meetings beside your daily note. Access is read-only and stays on this device.
         UILaunchStoryboardName: LaunchScreen
         UIRequiredDeviceCapabilities: [arm64, metal]
         UISupportedInterfaceOrientations:
@@ -82,11 +88,27 @@ targets:
         # version lives in one place and never drifts. Do not hardcode a literal.
         CFBundleShortVersionString: 0.4.0
         CFBundleVersion: 0.4.0.17
-    # CAUTION: `tauri ios init` rewrites BOTH committed .entitlements files
-    # to empty dicts — after a regen, restore the iCloud + App Group entries
-    # before committing (see docs/porting/reflect-mobile/share-extension.md).
+    # Entitlement contents live HERE, not in the .entitlements files: xcodegen
+    # (and `tauri ios init`, which runs it) rewrites those files from these
+    # properties on every regen — with no properties they were wiped to empty
+    # dicts (see docs/porting/reflect-mobile/share-extension.md).
+    #
+    # iCloud Drive document storage (Plan 21). CloudDocuments only: the graph
+    # is plain markdown in the app's container; there is no CloudKit database.
+    # The App Group is shared with ShareExtension: the share sheet spools
+    # capture envelopes into the container's inbox/, and the app relays them
+    # into the graph's .reflect/inbox/ on launch/foreground (Plan 11).
     entitlements:
       path: reflect-open_iOS/reflect-open_iOS.entitlements
+      properties:
+        com.apple.developer.icloud-container-identifiers:
+          - iCloud.app.reflect
+        com.apple.developer.icloud-services:
+          - CloudDocuments
+        com.apple.developer.ubiquity-container-identifiers:
+          - iCloud.app.reflect
+        com.apple.security.application-groups:
+          - group.app.reflect
     scheme:
       environmentVariables:
         RUST_BACKTRACE: full
@@ -167,8 +189,15 @@ targets:
               NSExtensionActivationSupportsWebPageWithMaxCount: 1
               NSExtensionActivationSupportsWebURLWithMaxCount: 1
             NSExtensionJavaScriptPreprocessingFile: ExtensionClass
+    # The extension's only capability: the App Group container it spools
+    # capture envelopes into. Must match the main app's entry — the app reads
+    # the same container to relay envelopes into the graph. Contents declared
+    # here so xcodegen regens rewrite the .entitlements file correctly.
     entitlements:
       path: ShareExtension/ShareExtension.entitlements
+      properties:
+        com.apple.security.application-groups:
+          - group.app.reflect
     settings:
       base:
         PRODUCT_NAME: ShareExtension
@@ -177,3 +206,20 @@ targets:
         DEVELOPMENT_TEAM: 789ULN5MZB
         SWIFT_VERSION: "5.0"
         TARGETED_DEVICE_FAMILY: 1,2
+    postBuildScripts:
+      # Tauri's App Store Connect API-key flow (CI TestFlight builds) archives
+      # with code signing disabled, then dummy-signs only the app binary before
+      # export. Xcode's export re-signing preserves only entitlements already
+      # present in a signature, so an unsigned appex ships without the App
+      # Group entitlement — the container lookup returns nil and every share
+      # fails with "Couldn't save" (tauri-cli mobile/ios/build.rs). Ad-hoc
+      # signing the extension with its entitlements here keeps them through
+      # export; properly signed builds never enter the branch.
+      - script: |
+          if [ "${CODE_SIGNING_ALLOWED:-YES}" = "NO" ]; then
+            /usr/bin/codesign --force --sign - \
+              --entitlements "${SRCROOT:?}/ShareExtension/ShareExtension.entitlements" \
+              "${CODESIGNING_FOLDER_PATH:?}"
+          fi
+        name: Preserve entitlements on skip-codesign builds
+        basedOnDependencyAnalysis: false

--- a/apps/desktop/src-tauri/gen/apple/reflect-open.xcodeproj/project.pbxproj
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		28AF2C553C3E42F07C4AF0DD /* shadow.rs */ = {isa = PBXFileReference; path = shadow.rs; sourceTree = "<group>"; };
 		28B078410B4B4507A763E297 /* ladder.rs */ = {isa = PBXFileReference; path = ladder.rs; sourceTree = "<group>"; };
 		2EDECD14A0418A8D4AA04512 /* remote.rs */ = {isa = PBXFileReference; path = remote.rs; sourceTree = "<group>"; };
+		2FA419867A84041644CC42E9 /* skill.rs */ = {isa = PBXFileReference; path = skill.rs; sourceTree = "<group>"; };
 		32B7D9FD2081133899440765 /* mod.rs */ = {isa = PBXFileReference; path = mod.rs; sourceTree = "<group>"; };
 		3779A211A168AE84C5573923 /* merge.rs */ = {isa = PBXFileReference; path = merge.rs; sourceTree = "<group>"; };
 		37EF719F509C3A532C0E0114 /* main.rs */ = {isa = PBXFileReference; path = main.rs; sourceTree = "<group>"; };
@@ -80,6 +81,7 @@
 		44C3B8C21F2D38187423AB2F /* libiconv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libiconv.tbd; path = usr/lib/libiconv.tbd; sourceTree = SDKROOT; };
 		48F8214D2C537DF115410CC0 /* resolve.rs */ = {isa = PBXFileReference; path = resolve.rs; sourceTree = "<group>"; };
 		491E4F680A58FFBD620237F9 /* commit.rs */ = {isa = PBXFileReference; path = commit.rs; sourceTree = "<group>"; };
+		4B8413C8F746CEEC50B61694 /* import_assets.rs */ = {isa = PBXFileReference; path = import_assets.rs; sourceTree = "<group>"; };
 		4EE64B671C831953394179E2 /* watcher.rs */ = {isa = PBXFileReference; path = watcher.rs; sourceTree = "<group>"; };
 		51006DE1482D28D9562253A1 /* ShareExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		5249E1475DBD7CCB817F7D1B /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -89,6 +91,7 @@
 		5C56D455FF36B2FFA8189246 /* repo.rs */ = {isa = PBXFileReference; path = repo.rs; sourceTree = "<group>"; };
 		5F2E1B8E7D79BDAFFCD2DCDE /* assets.rs */ = {isa = PBXFileReference; path = assets.rs; sourceTree = "<group>"; };
 		5F605BA8949402DAE91B9243 /* embed_write.rs */ = {isa = PBXFileReference; path = embed_write.rs; sourceTree = "<group>"; };
+		6572C3F24F414FF11A16F640 /* asset_protocol.rs */ = {isa = PBXFileReference; path = asset_protocol.rs; sourceTree = "<group>"; };
 		65C0E213C54BBE2152AA5DF2 /* chat_write.rs */ = {isa = PBXFileReference; path = chat_write.rs; sourceTree = "<group>"; };
 		68D1FDE7F099CA5F909105EB /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		6BB60C6D34C4AFB61F084B4D /* mod.rs */ = {isa = PBXFileReference; path = mod.rs; sourceTree = "<group>"; };
@@ -103,10 +106,12 @@
 		8C04E40F02C9B4AE9A24A9A4 /* recents.rs */ = {isa = PBXFileReference; path = recents.rs; sourceTree = "<group>"; };
 		8D0D6D72E614086946EBF890 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		93EF89A222208D739ABC00B8 /* ShareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareView.swift; sourceTree = "<group>"; };
+		A4F0D18C7B37B593ED8ACD6F /* scan.rs */ = {isa = PBXFileReference; path = scan.rs; sourceTree = "<group>"; };
 		A67279D745DF48458936735A /* storage.rs */ = {isa = PBXFileReference; path = storage.rs; sourceTree = "<group>"; };
 		A86D201016958E2276806466 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A8921CA643078550A7A02536 /* embed_mobile.rs */ = {isa = PBXFileReference; path = embed_mobile.rs; sourceTree = "<group>"; };
 		AABA262BFCEDA2C43E343A31 /* sweep.rs */ = {isa = PBXFileReference; path = sweep.rs; sourceTree = "<group>"; };
+		ACE1CDF45CDBB8D7B2446E36 /* windows.rs */ = {isa = PBXFileReference; path = windows.rs; sourceTree = "<group>"; };
 		ADB23521181EEB9EF095D4AB /* contacts.rs */ = {isa = PBXFileReference; path = contacts.rs; sourceTree = "<group>"; };
 		B667667E9C6C141128493B00 /* quit.rs */ = {isa = PBXFileReference; path = quit.rs; sourceTree = "<group>"; };
 		BC3901740F3A40252C3750C7 /* reflect-open_iOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "reflect-open_iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -121,6 +126,7 @@
 		D8F1F4787BA60FD05FD83FD1 /* spike_mobile.rs */ = {isa = PBXFileReference; path = spike_mobile.rs; sourceTree = "<group>"; };
 		DBD22A8C59FD8892E5F139EC /* tests.rs */ = {isa = PBXFileReference; path = tests.rs; sourceTree = "<group>"; };
 		DD5CA5DD1A0A2C6898BF16AE /* tests.rs */ = {isa = PBXFileReference; path = tests.rs; sourceTree = "<group>"; };
+		DFD67CD43D5BD05A1C511C01 /* import.rs */ = {isa = PBXFileReference; path = import.rs; sourceTree = "<group>"; };
 		E1940DEB1B975598A69CA93F /* frontmatter.rs */ = {isa = PBXFileReference; path = frontmatter.rs; sourceTree = "<group>"; };
 		E66BC7105426B91F03659B53 /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
 		E8031FEC080EBAF422BEE44C /* markers.rs */ = {isa = PBXFileReference; path = markers.rs; sourceTree = "<group>"; };
@@ -252,9 +258,11 @@
 				8C04E40F02C9B4AE9A24A9A4 /* recents.rs */,
 				D7DA2E13EA6655A16DFDE015 /* secrets.rs */,
 				18A732A38CD75FF514E4CF86 /* settings.rs */,
+				2FA419867A84041644CC42E9 /* skill.rs */,
 				D8F1F4787BA60FD05FD83FD1 /* spike_mobile.rs */,
 				F3173A0D7E498896FAC5A43E /* watcher_mobile.rs */,
 				4EE64B671C831953394179E2 /* watcher.rs */,
+				ACE1CDF45CDBB8D7B2446E36 /* windows.rs */,
 				3F54925F5E584B8E6578AFAD /* conflict */,
 				9E54DCC255F04D51453CC522 /* db */,
 				C0FD50680AFE75D524EF47A4 /* fs */,
@@ -292,6 +300,7 @@
 				C38A6847351881E6D17A1DC2 /* migrations.rs */,
 				73D6C2FDB2DD7919E24C4533 /* mod.rs */,
 				89B314CA06450414E4537033 /* query.rs */,
+				A4F0D18C7B37B593ED8ACD6F /* scan.rs */,
 				DD5CA5DD1A0A2C6898BF16AE /* tests.rs */,
 				1EB2845C34150F5FE04A33D3 /* write.rs */,
 			);
@@ -327,7 +336,10 @@
 		C0FD50680AFE75D524EF47A4 /* fs */ = {
 			isa = PBXGroup;
 			children = (
+				6572C3F24F414FF11A16F640 /* asset_protocol.rs */,
 				5F2E1B8E7D79BDAFFCD2DCDE /* assets.rs */,
+				4B8413C8F746CEEC50B61694 /* import_assets.rs */,
+				DFD67CD43D5BD05A1C511C01 /* import.rs */,
 				383CB9669208178C6B235BE6 /* io.rs */,
 				D3691D8F671B7FA21D1E7BD7 /* mod.rs */,
 				48F8214D2C537DF115410CC0 /* resolve.rs */,
@@ -353,6 +365,7 @@
 			buildPhases = (
 				6C4170AF0104E2BB23FF2992 /* Sources */,
 				D66D7A4411695309647B6A04 /* Resources */,
+				E8E8484E1F59D64EA785432B /* Preserve entitlements on skip-codesign builds */,
 			);
 			buildRules = (
 			);
@@ -448,6 +461,25 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		E8E8484E1F59D64EA785432B /* Preserve entitlements on skip-codesign builds */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Preserve entitlements on skip-codesign builds";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"${CODE_SIGNING_ALLOWED:-YES}\" = \"NO\" ]; then\n  /usr/bin/codesign --force --sign - \\\n    --entitlements \"${SRCROOT:?}/ShareExtension/ShareExtension.entitlements\" \\\n    \"${CODESIGNING_FOLDER_PATH:?}\"\nfi\n";
+		};
 		F27159B8EA2BAA999947A4AF /* Build Rust Code */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -533,7 +565,7 @@
 				CODE_SIGN_ENTITLEMENTS = "reflect-open_iOS/reflect-open_iOS.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "789ULN5MZB";
+				DEVELOPMENT_TEAM = 789ULN5MZB;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -548,7 +580,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = app.reflect.ios;
-				PRODUCT_NAME = "Reflect";
+				PRODUCT_NAME = Reflect;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = arm64;
@@ -649,7 +681,7 @@
 				CODE_SIGN_ENTITLEMENTS = "reflect-open_iOS/reflect-open_iOS.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "789ULN5MZB";
+				DEVELOPMENT_TEAM = 789ULN5MZB;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -664,7 +696,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = app.reflect.ios;
-				PRODUCT_NAME = "Reflect";
+				PRODUCT_NAME = Reflect;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = arm64;

--- a/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/Info.plist
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/Info.plist
@@ -24,8 +24,14 @@
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
 	<true/>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>Reflect reads your calendar to show the day's meetings beside your daily note. Access is read-only and stays on this device.</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>Reflect reads your calendar to show the day's meetings beside your daily note. Access is read-only and stays on this device.</string>
 	<key>NSContactsUsageDescription</key>
 	<string>Reflect reads your contacts to suggest details for person notes. Nothing is stored or sent anywhere.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Reflect uses the microphone to record audio memos that are transcribed into your daily note.</string>
 	<key>NSUbiquitousContainers</key>
 	<dict>
 		<key>iCloud.app.reflect</key>
@@ -60,11 +66,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>Reflect uses the microphone to record audio memos that are transcribed into your daily note.</string>
-	<key>NSCalendarsFullAccessUsageDescription</key>
-	<string>Reflect reads your calendar to show the day&apos;s meetings beside your daily note. Access is read-only and stays on this device.</string>
-	<key>NSCalendarsUsageDescription</key>
-	<string>Reflect reads your calendar to show the day&apos;s meetings beside your daily note. Access is read-only and stays on this device.</string>
 </dict>
 </plist>

--- a/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/reflect-open_iOS.entitlements
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/reflect-open_iOS.entitlements
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- iCloud Drive document storage (Plan 21). CloudDocuments only: the
-	     graph is plain markdown files in the app's container; there is no
-	     CloudKit database. Xcode's automatic signing registers the container
-	     against the App ID on the first entitled build. -->
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
 		<string>iCloud.app.reflect</string>
@@ -18,9 +14,6 @@
 	<array>
 		<string>iCloud.app.reflect</string>
 	</array>
-	<!-- Shared with the ShareExtension target: the share sheet spools capture
-	     envelopes into this container's inbox/, and the app relays them into
-	     the graph's .reflect/inbox/ on launch/foreground (Plan 11). -->
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.app.reflect</string>

--- a/apps/desktop/src-tauri/ios.project.yml
+++ b/apps/desktop/src-tauri/ios.project.yml
@@ -57,6 +57,12 @@ targets:
         # Apple Contacts integration: read-only CNContactStore lookups for
         # person notes; the string is shown on the iOS permission prompt.
         NSContactsUsageDescription: Reflect reads your contacts to suggest details for person notes. Nothing is stored or sent anywhere.
+        # Mirrored from src-tauri/Info.plist (which merges at build) so that
+        # xcodegen regens keep them in the committed generated Info.plist
+        # instead of silently dropping them.
+        NSMicrophoneUsageDescription: Reflect uses the microphone to record audio memos that are transcribed into your daily note.
+        NSCalendarsFullAccessUsageDescription: Reflect reads your calendar to show the day's meetings beside your daily note. Access is read-only and stays on this device.
+        NSCalendarsUsageDescription: Reflect reads your calendar to show the day's meetings beside your daily note. Access is read-only and stays on this device.
         UILaunchStoryboardName: LaunchScreen
         UIRequiredDeviceCapabilities: [arm64, metal]
         UISupportedInterfaceOrientations:
@@ -82,11 +88,27 @@ targets:
         # version lives in one place and never drifts. Do not hardcode a literal.
         CFBundleShortVersionString: {{apple.bundle-version-short}}
         CFBundleVersion: {{apple.bundle-version}}
-    # CAUTION: `tauri ios init` rewrites BOTH committed .entitlements files
-    # to empty dicts — after a regen, restore the iCloud + App Group entries
-    # before committing (see docs/porting/reflect-mobile/share-extension.md).
+    # Entitlement contents live HERE, not in the .entitlements files: xcodegen
+    # (and `tauri ios init`, which runs it) rewrites those files from these
+    # properties on every regen — with no properties they were wiped to empty
+    # dicts (see docs/porting/reflect-mobile/share-extension.md).
+    #
+    # iCloud Drive document storage (Plan 21). CloudDocuments only: the graph
+    # is plain markdown in the app's container; there is no CloudKit database.
+    # The App Group is shared with ShareExtension: the share sheet spools
+    # capture envelopes into the container's inbox/, and the app relays them
+    # into the graph's .reflect/inbox/ on launch/foreground (Plan 11).
     entitlements:
       path: reflect-open_iOS/reflect-open_iOS.entitlements
+      properties:
+        com.apple.developer.icloud-container-identifiers:
+          - iCloud.app.reflect
+        com.apple.developer.icloud-services:
+          - CloudDocuments
+        com.apple.developer.ubiquity-container-identifiers:
+          - iCloud.app.reflect
+        com.apple.security.application-groups:
+          - group.app.reflect
     scheme:
       environmentVariables:
         RUST_BACKTRACE: full
@@ -167,8 +189,15 @@ targets:
               NSExtensionActivationSupportsWebPageWithMaxCount: 1
               NSExtensionActivationSupportsWebURLWithMaxCount: 1
             NSExtensionJavaScriptPreprocessingFile: ExtensionClass
+    # The extension's only capability: the App Group container it spools
+    # capture envelopes into. Must match the main app's entry — the app reads
+    # the same container to relay envelopes into the graph. Contents declared
+    # here so xcodegen regens rewrite the .entitlements file correctly.
     entitlements:
       path: ShareExtension/ShareExtension.entitlements
+      properties:
+        com.apple.security.application-groups:
+          - group.app.reflect
     settings:
       base:
         PRODUCT_NAME: ShareExtension
@@ -177,3 +206,20 @@ targets:
         DEVELOPMENT_TEAM: 789ULN5MZB
         SWIFT_VERSION: "5.0"
         TARGETED_DEVICE_FAMILY: 1,2
+    postBuildScripts:
+      # Tauri's App Store Connect API-key flow (CI TestFlight builds) archives
+      # with code signing disabled, then dummy-signs only the app binary before
+      # export. Xcode's export re-signing preserves only entitlements already
+      # present in a signature, so an unsigned appex ships without the App
+      # Group entitlement — the container lookup returns nil and every share
+      # fails with "Couldn't save" (tauri-cli mobile/ios/build.rs). Ad-hoc
+      # signing the extension with its entitlements here keeps them through
+      # export; properly signed builds never enter the branch.
+      - script: |
+          if [ "${CODE_SIGNING_ALLOWED:-YES}" = "NO" ]; then
+            /usr/bin/codesign --force --sign - \
+              --entitlements "${SRCROOT:?}/ShareExtension/ShareExtension.entitlements" \
+              "${CODESIGNING_FOLDER_PATH:?}"
+          fi
+        name: Preserve entitlements on skip-codesign builds
+        basedOnDependencyAnalysis: false

--- a/docs/porting/reflect-mobile/share-extension.md
+++ b/docs/porting/reflect-mobile/share-extension.md
@@ -13,9 +13,9 @@ and the meta description in-page (`ExtensionClass.js` →
 `metaDescription`), so an offline save still reads complete; enrichment
 replaces the description later when online. Non-URL text saves as a
 daily-note bullet (`kind: append`, `source: ios-share`). Remaining
-release-gate work: a device pass, and confirming automatic signing
-provisions the new `app.reflect.ios.share` App ID + App Group for
-TestFlight.
+release-gate work: a device pass on a TestFlight build (earlier TestFlight
+builds failed every share because CI's export dropped the appex App Group
+entitlement — see the CI-signing note under Resolved decisions).
 
 ## What V1 mobile does
 
@@ -96,5 +96,18 @@ There is no API to POST to — the design inverts from *send to server* to
 - **Ingest is foreground-only** (v1 posture, like sync): graph open, window
   focus/online, and `visibilitychange` → visible all schedule the
   relay+drain pass; no background refresh task.
-- **Regen caution**: `tauri ios init` rewrites both `.entitlements` files to
-  empty dicts — restore the iCloud + App Group entries before committing.
+- **Entitlements are spec-driven**: the entitlement contents live in
+  `ios.project.yml`/`gen/apple/project.yml` (`entitlements.properties`), and
+  xcodegen writes the `.entitlements` files from them — regens (including
+  `tauri ios init`) are idempotent instead of wiping the files to empty
+  dicts, which is what they used to do.
+- **CI signing must preserve the App Group.** Tauri's App Store Connect
+  API-key flow (the TestFlight workflow) archives with signing disabled and
+  dummy-signs only the app binary before export; `xcodebuild -exportArchive`
+  preserves only entitlements already present in a signature, so the appex
+  used to ship without the App Group — the container lookup returned nil
+  and every share failed with "Couldn't save" (local builds were fine
+  because Xcode signs during archive). A post-build phase on the
+  ShareExtension target ad-hoc signs the appex with its entitlements when
+  `CODE_SIGNING_ALLOWED=NO`, and `release-ios.mjs` refuses to accept or
+  upload an IPA whose appex lacks `group.app.reflect`.


### PR DESCRIPTION
## Problem

Sharing a page to Reflect from Safari or Chrome on a TestFlight install fails every time: the share sheet opens, then shows "Couldn't save". The same build works from a locally-built IPA, and debug simulator builds work too — only CI-built TestFlight IPAs are broken.

Root cause: Tauri's App Store Connect API-key flow (what CI uses) archives with `CODE_SIGNING_ALLOWED=NO`, then dummy-signs **only the app binary** so its entitlements survive export (`tauri-cli` `mobile/ios/build.rs`). `xcodebuild -exportArchive` preserves only entitlements it finds in an existing signature, so the unsigned `ShareExtension.appex` is re-signed with **no App Group entitlement**. At runtime `containerURL(forSecurityApplicationGroupIdentifier:)` returns nil, the spool throws `containerUnavailable`, and every share fails. Local builds are unaffected because without the API-key env vars Xcode signs the appex (entitlements included) during archive.

Verified end to end:
- Simulator: an entitlement-stripped release appex reproduces "Couldn't save" exactly; the same appex ad-hoc signed *with* entitlements saves fine.
- Local replay of CI: exporting an unsigned device archive (`tauri ios build --archive-only --no-sign --ci`) drops the App Group from the appex; pre-signing the appex preserves it through export with the full correct entitlement set.
- Real CI: run [28820291156](https://github.com/team-reflect/reflect-open/actions/runs/28820291156) (this branch, before the fix commit) fails the new assertion with `ShareExtension.appex is signed without the group.app.reflect App Group entitlement`.

## Before → After

| | Before | After |
|---|---|---|
| Share to Reflect on a TestFlight build | "Couldn't save", capture lost | Saves; envelope reaches the App Group inbox |
| CI builds a broken appex | Uploads to TestFlight silently | `release-ios` fails loudly before upload |
| TestFlight IPA bytes | Not retrievable after upload | Kept as a workflow artifact |
| `xcodegen`/`tauri ios init` regen | Wipes both `.entitlements` files + drops Info.plist usage strings | Idempotent — contents are spec-driven |

## Changes

1. **`ios.project.yml` / `gen/apple/project.yml` / `project.pbxproj`** — a post-build phase on the ShareExtension target ("Preserve entitlements on skip-codesign builds") ad-hoc signs the appex with its entitlements when `CODE_SIGNING_ALLOWED=NO`. This mirrors what Tauri already does for the app binary; export then re-signs both with real certs and the App Group intact. Properly signed builds never enter the branch.
2. **Spec-driven entitlements** — entitlement contents now live under `entitlements.properties` in the project spec (and the mic/calendar usage descriptions under `info.properties`), so regenerating the project rewrites `reflect-open_iOS.entitlements` / `ShareExtension.entitlements` / `Info.plist` correctly instead of clobbering them — retiring the long-standing "restore entitlements by hand after `tauri ios init`" foot-gun.
3. **`release-ios.mjs`** — `assertIpaAppexEntitlements` reads the signed entitlements of every embedded appex (`codesign -d --entitlements`) and refuses to accept or upload an IPA missing `group.app.reflect`; runs both post-build and pre-upload. `findIpaAppexPaths` is exported and unit-tested.
4. **`testflight.yml`** — uploads the exported IPA as a workflow artifact (`if: always()`), since TestFlight builds can't be downloaded back for inspection.
5. **`docs/porting/reflect-mobile/share-extension.md`** — records the CI-signing pitfall and the new invariants.

## Tests

- `apps/desktop/scripts/release-ios.test.mjs` — appex path discovery in an IPA listing (single extension found once; IPAs without extensions return empty).
- Manual matrix (simulator, iPhone Air / iOS 26.5): debug appex ✅, unsigned release appex ❌ (`containerUnavailable`, reproduces the field failure), ad-hoc+entitlements release appex ✅ (envelope written to the App Group inbox).
- Export-preservation A/B on a real unsigned device archive: patched appex keeps the App Group through `-exportArchive`; unpatched control loses it (byte-for-byte the broken TestFlight entitlement set).

## Verification

- `pnpm check` — clean.
- `pnpm test --run scripts/release-ios.test.mjs` — 15 passed.
- `xcodebuild -target ShareExtension -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO` on the regenerated project — build succeeds and the phase leaves the appex ad-hoc signed with `group.app.reflect`.
- CI on this branch: [28820291156](https://github.com/team-reflect/reflect-open/actions/runs/28820291156) fails the assertion pre-fix (bug proven on the real pipeline); [28821066001](https://github.com/team-reflect/reflect-open/actions/runs/28821066001) is the post-fix TestFlight run — expected to pass the assertion and upload a working build (in progress at PR time).

## Risk / Rollout

- The signing phase is a no-op for every normally-signed build (local dev, `tauri ios dev`, local TestFlight builds); it only touches skip-codesign builds.
- If Apple's export ever stops preserving ad-hoc-carried entitlements, the new assertion fails the build loudly instead of shipping another broken extension.
- A device pass on the next TestFlight build is still owed (share from Safari + Chrome on iPhone) — the fix is proven at the entitlement level; the on-phone confirmation closes the loop.
- Upstream: this is a Tauri bug (`tauri-cli` dummy-signs only the app binary, never embedded appexes) — worth filing so the workaround can eventually be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches iOS code signing, entitlements, and the TestFlight release gate; mistakes could break share capture or block uploads, but changes are scoped with pre-upload assertions and a no-op for normally signed builds.
> 
> **Overview**
> Fixes **TestFlight shares failing with "Couldn't save"** by keeping `group.app.reflect` on `ShareExtension.appex` through Tauri's CI export path, where signing is skipped and export only carried entitlements already on a signature (the main app was dummy-signed; the extension was not).
> 
> A **ShareExtension post-build phase** ad-hoc signs the appex with `ShareExtension.entitlements` when `CODE_SIGNING_ALLOWED=NO`; normal local/Xcode-signed builds skip that branch. **`ios.project.yml` / `gen/apple/project.yml`** now declare entitlements and mic/calendar usage strings under `entitlements.properties` and `info.properties` so xcodegen/`tauri ios init` regens no longer wipe `.entitlements` or drop those plist keys.
> 
> **`release-ios.mjs`** adds `findIpaAppexPaths` and `assertIpaAppexEntitlements` (via `codesign -d --entitlements`) inside `assertIpaAppStoreMetadata`, blocking build/upload/validate if the appex lacks the App Group. The **TestFlight workflow** uploads the exported IPA as an artifact (`if: always()`). Porting docs record the CI-signing pitfall and spec-driven entitlements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff9300db4bea128f1c4efa0bf9e43ffc852c9744. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->