### PR TITLE
Release v0.4.0-beta.35

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4737,7 +4737,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.4.0-beta.34"
+version = "0.4.0-beta.35"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.4.0-beta.34"
+version = "0.4.0-beta.35"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.4.0-beta.34",
+  "version": "0.4.0-beta.35",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.4.0-beta.35.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-metadata-only change with no logic, security, or dependency updates.
> 
> **Overview**
> **Release version bump** from `0.4.0-beta.34` to `0.4.0-beta.35` with no application or dependency changes beyond aligning the version string.
> 
> Updates `apps/desktop/src-tauri/Cargo.toml` (`reflect-open` package version), `apps/desktop/src-tauri/tauri.conf.json` (`productName` / bundle version), and the matching `reflect-open` entry in `Cargo.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b93a9040efb52affc1d767feaa383228dc64a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->