### PR TITLE
docs: add TestFlight invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Download the latest DMG from
 updates itself from GitHub Releases; update payloads are verified against a
 public key compiled into the app.
 
+Reflect for iPhone is available as a TestFlight beta. It is the mobile
+companion for the same plain-file graph: capture quick notes, read and edit
+your daily note, and keep everything in sync through the same iCloud or git
+setup you use on Mac. Join the
+[Reflect TestFlight](https://testflight.apple.com/join/j2eEz43d).
+
 Or [build from source](#building-from-source).
 
 ## Browser capture


### PR DESCRIPTION
## Summary
- Add the public Reflect TestFlight invite link to the README install section.
- Briefly describe the iPhone app as the TestFlight mobile companion for the same plain-file graph.

## Verification
- pnpm check

## Risk
- Documentation-only change; no runtime risk.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no runtime or build impact.
> 
> **Overview**
> The **Install** section now tells readers that **Reflect for iPhone** is on TestFlight as the mobile companion to the same plain-file graph (quick capture, daily note, iCloud/git sync with Mac), with a link to join **[Reflect TestFlight](https://testflight.apple.com/join/j2eEz43d)**. Mac DMG install text is unchanged; the new copy sits between that block and “build from source.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a6738d51e15fdad67ff2897f76ab154379a9b21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->