### PR TITLE
docs: add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Changelog
+
+This changelog summarizes the public GitHub Releases in plain language. It skips most dependency updates, release-only bumps, and internal maintenance; see the linked GitHub release pages for the full technical history.
+
+## 0.4.0 Beta - July 6, 2026
+
+Latest beta: [v0.4.0-beta.35](https://github.com/team-reflect/reflect-open/releases/tag/v0.4.0-beta.35)
+
+This section covers the 0.4.0 beta line from [v0.4.0-beta.1](https://github.com/team-reflect/reflect-open/releases/tag/v0.4.0-beta.1) through [v0.4.0-beta.35](https://github.com/team-reflect/reflect-open/releases/tag/v0.4.0-beta.35).
+
+- Expanded the iOS app into a more complete companion, including Daily, All Notes, Tasks, Chat, Settings, graph switching, native-feeling navigation, haptics, and mobile editor polish.
+- Added iCloud Drive sync and broader GitHub sync support, with clearer sync settings, conflict handling, and local history for graphs that are not backed up remotely.
+- Added Calendar and Contacts integration so daily notes can show events, meeting notes can use attendees, and person notes can be pre-filled from contacts.
+- Added note templates, editor selection AI actions, OpenRouter support, deep links, file attachments, and richer link and file capture flows.
+- Improved migration and capture paths with Reflect V1 import work, Firebase attachment downloads, iOS share sheet link saving, and better handling for app links and media.
+- Continued everyday polish across desktop and mobile, including date display options, pinned note menus, task interactions, keyboard and caret behavior, backlinks, image lightboxes, and Mac download guidance.
+
+## 0.3.6 - June 26, 2026
+
+[GitHub release](https://github.com/team-reflect/reflect-open/releases/tag/v0.3.6)
+
+- Fixed the Intel Mac release so users on Intel macOS could run the app reliably.
+
+## 0.3.4 - June 26, 2026
+
+[GitHub release](https://github.com/team-reflect/reflect-open/releases/tag/v0.3.4)
+
+- Let users reorder pinned notes.
+- Improved keyboard movement between the editor and the surrounding note surface.
+- Prepared the Chrome extension for its Web Store identity.
+
+## 0.3.3 - June 25, 2026
+
+[GitHub release](https://github.com/team-reflect/reflect-open/releases/tag/v0.3.3)
+
+- Fixed Mac release signing so downloads install more reliably.
+
+## 0.3.0 - June 25, 2026
+
+[GitHub release](https://github.com/team-reflect/reflect-open/releases/tag/v0.3.0)
+
+- Clarified first-run setup, especially the choice between starting fresh and coming from Reflect V1.
+- Made note editing feel closer to Reflect V1, with familiar markers, text-size controls, better checklist spacing, and cleaner appended sections.
+- Improved day-to-day graph management with clearer backup access, a safer forget-graph flow, better backup messages, and a more reliable updater experience.
+- Improved tasks, notifications, tag navigation, and All Notes selection behavior.
+- Prepared the browser extension and app release channels for wider distribution.
+
+## 0.2.2 - June 24, 2026
+
+[GitHub release](https://github.com/team-reflect/reflect-open/releases/tag/v0.2.2)
+
+- Maintenance release for the app release process. No major user-facing changes were called out in the GitHub release notes.
+
+## 0.2.0 - June 23, 2026
+
+[GitHub release](https://github.com/team-reflect/reflect-open/releases/tag/v0.2.0)
+
+- Added a dedicated Tasks experience with inline editing, multi-select, keyboard shortcuts, checkbox polish, and smoother task navigation.
+- Improved All Notes with better tag filters, keyboard selection, bulk actions, and clearer filtered views.
+- Expanded capture and sharing with browser page capture, whole-page text capture, secret GitHub Gist publishing, unpublishing, and clearer published-link handling.
+- Improved the editor with tag autocomplete, date suggestions, markdown display options, image lightboxes, link opening, embeds, and more predictable note title sizing.
+- Made chat and search more useful with better retrieval, clickable note references, exact-title search ranking, and faster tag search.
+- Added user-facing polish around settings, private-note messaging, trash actions, graph colors, startup performance, and security.
+- Added the beta updater channel and separate app flavors for stable, beta, and development builds.
+
+## 0.1.0 - June 12, 2026
+
+[GitHub release](https://github.com/team-reflect/reflect-open/releases/tag/v0.1.0)
+
+- Initial Reflect V2 release.
+- Introduced markdown-backed daily notes and named notes, local graph folders, live indexing, wiki links, backlinks, All Notes, and the command palette.
+- Added local search and related-note discovery, including semantic search powered on the user's device.
+- Added settings for editor behavior, calendar and date preferences, spell check, privacy, keyboard shortcuts, and graph identity.
+- Added BYOK AI foundations, including model management, audio memos, image-aware chat, note-grounded chat, and persistent chat history.
+- Added GitHub backup and sync, the Reflect CLI, macOS app icons, signed and notarized Mac distribution, auto-update, onboarding, and the first privacy and accessibility hardening pass.


### PR DESCRIPTION
## Summary
- Add a root-level CHANGELOG.md based on the public GitHub Releases.
- Keep the entries high level and non technical, with a cumulative 0.4.0 beta section and stable release sections.
- Link each section back to the relevant GitHub release for full details.

## Verification
- pnpm check

## Risk
- Docs-only change; no app behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no application or runtime behavior changes.
> 
> **Overview**
> Adds a new root **`CHANGELOG.md`** that distills public GitHub Releases into plain-language, user-facing notes.
> 
> It opens with scope (skips routine dependency/maintenance noise; links to releases for detail), then walks versions from **0.1.0** through a cumulative **0.4.0 beta** section (**beta.1**–**beta.35**), with dated stable sections (**0.3.x**, **0.2.x**, etc.) each pointing at the matching release tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9692f25f9e1bdf999ff05a70fa044ea9e4bffbeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->