### PR TITLE
Fix image lightbox gestures and transitions

### DIFF
--- a/apps/desktop/src/editor/image-lightbox.test.tsx
+++ b/apps/desktop/src/editor/image-lightbox.test.tsx
@@ -112,7 +112,7 @@ describe('ImageLightbox mobile drag-to-dismiss', () => {
     firePointer(preview, 'pointermove', { pointerId: 1, clientX: 182, clientY: 180 })
     firePointer(preview, 'pointermove', { pointerId: 1, clientX: 190, clientY: 260 })
 
-    const progress = 80 / (window.innerHeight * 0.5)
+    const progress = Math.hypot(8, 80) / (window.innerHeight * 0.5)
     expect(Number.parseFloat(backdrop!.style.opacity)).toBeCloseTo(1 - progress * 0.85, 5)
     expect(Number.parseFloat(closeChrome.style.opacity)).toBeCloseTo(1 - progress * 2, 5)
     expect(closeChrome.style.pointerEvents).toBe('none')
@@ -128,6 +128,21 @@ describe('ImageLightbox mobile drag-to-dismiss', () => {
 
     expect(image.style.transform).toContain(`, ${window.innerHeight}px, 0) scale(0.9)`)
     expect(backdrop!.style.opacity).toBe('0')
+    expect(onClose).not.toHaveBeenCalled()
+
+    fireEvent.transitionEnd(image)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('dismisses horizontally past the distance threshold', () => {
+    const { preview, image, onClose } = renderMobileLightbox()
+
+    touchDown(preview, 100, 100)
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 120, clientY: 100 })
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 340, clientY: 104 })
+    firePointer(preview, 'pointerup', { pointerId: 1, clientX: 340, clientY: 104 })
+
+    expect(image.style.transform).toContain(`translate3d(${window.innerWidth}px, `)
     expect(onClose).not.toHaveBeenCalled()
 
     fireEvent.transitionEnd(image)
@@ -174,22 +189,19 @@ describe('ImageLightbox mobile drag-to-dismiss', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
-  it('rubber-bands upward travel and never dismisses upward', () => {
+  it('dismisses upward past the distance threshold', () => {
     const { preview, image, onClose } = renderMobileLightbox()
 
     touchDown(preview, 100, 100)
-    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 100, clientY: 120 })
-    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 100, clientY: 60 })
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 100, clientY: 80 })
+    firePointer(preview, 'pointermove', { pointerId: 1, clientX: 100, clientY: -120 })
 
-    const match = /translate3d\(0px, (-[\d.]+)px, 0\)/.exec(image.style.transform)
-    const offsetY = Number.parseFloat(match?.[1] ?? 'NaN')
-    expect(offsetY).toBeGreaterThan(-48)
-    expect(offsetY).toBeLessThan(-20)
+    expect(image.style.transform).toContain('translate3d(0px, -200px, 0)')
 
-    firePointer(preview, 'pointerup', { pointerId: 1, clientX: 100, clientY: 60 })
-    expect(image.style.transform).toBe('translate3d(0, 0, 0) scale(1)')
+    firePointer(preview, 'pointerup', { pointerId: 1, clientX: 100, clientY: -120 })
+    expect(image.style.transform).toContain(`, -${window.innerHeight}px, 0)`)
     fireEvent.transitionEnd(image)
-    expect(onClose).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 
   it('snaps back without closing when the drag is interrupted', () => {
@@ -205,16 +217,22 @@ describe('ImageLightbox mobile drag-to-dismiss', () => {
     expect(onClose).not.toHaveBeenCalled()
   })
 
-  it('does not treat a horizontal wiggle as a tap-to-close', () => {
-    const { preview, onClose } = renderMobileLightbox()
+  it('springs back after a short horizontal drag and suppresses the trailing tap', () => {
+    const { preview, image, onClose } = renderMobileLightbox()
 
     touchDown(preview, 100, 100)
     firePointer(preview, 'pointermove', { pointerId: 1, clientX: 140, clientY: 102 })
     firePointer(preview, 'pointerup', { pointerId: 1, clientX: 140, clientY: 102 })
 
+    expect(image.style.transform).toBe('translate3d(0, 0, 0) scale(1)')
+
     fireEvent.click(preview)
     expect(onClose).not.toHaveBeenCalled()
 
+    fireEvent.click(preview)
+    expect(onClose).not.toHaveBeenCalled()
+
+    fireEvent.transitionEnd(image)
     fireEvent.click(preview)
     expect(onClose).toHaveBeenCalledTimes(1)
   })

--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -58,7 +58,7 @@ vi.mock('@meowdown/react', () => ({
     captured.props = props
     return (
       <div className={props.editorClassName}>
-        <span className="md-image-preview md-image-preview-img">
+        <span className="md-image-view-preview">
           <img
             src={props.resolveImageUrl?.('assets/cat.png') ?? ''}
             alt="Cat"

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -353,11 +353,13 @@ export function NoteEditor({
       if (displayUrl === null) {
         return
       }
-      // The clicked target is the `<img>` or its `.md-image-preview` wrapper;
+      // The clicked target is the `<img>` or its meowdown image wrapper;
       // the source element drives the View Transition zoom.
       const sourceImage =
         event.target instanceof HTMLElement
-          ? event.target.closest('.md-image-preview')?.querySelector('img') ?? null
+          ? event.target
+              .closest('.md-image-view-preview, .md-image-preview')
+              ?.querySelector('img') ?? null
           : null
       openLightbox(sourceImage, {
         src: displayUrl,

--- a/apps/desktop/src/editor/use-image-dismiss-drag.ts
+++ b/apps/desktop/src/editor/use-image-dismiss-drag.ts
@@ -9,10 +9,9 @@ import {
 } from 'react'
 
 const DRAG_ACTIVATE_PX = 8
-const DRAG_DISARM_X_PX = 18
 const DISMISS_FRACTION = 0.22
 const DISMISS_VELOCITY_PX_PER_MS = 0.45
-const MIN_FLICK_DY_PX = 40
+const MIN_FLICK_DISTANCE_PX = 40
 const VELOCITY_WINDOW_MS = 30
 const VELOCITY_STALE_MS = 120
 const SNAP_BACK_MS = 300
@@ -20,7 +19,6 @@ const DISMISS_MS = 260
 const DISMISS_MIN_MS = 140
 const SETTLE_SLACK_MS = 80
 const CLICK_SUPPRESSION_MS = 500
-const UPWARD_RUBBER_BAND_PX = 48
 // Full visual effect (backdrop gone, image at min scale) at half the viewport.
 const PROGRESS_TRAVEL_FRACTION = 0.5
 const BACKDROP_FADE = 0.85
@@ -38,12 +36,12 @@ type DragState =
       pointerId: number
       originX: number
       originY: number
+      width: number
       height: number
       deltaX: number
-      /** Raw vertical travel from the rebased origin; negative when above it. */
       deltaY: number
       velocity: number
-      sampleDeltaY: number
+      sampleDistance: number
       sampleTime: number
     }
   | {
@@ -51,6 +49,7 @@ type DragState =
       action: 'close' | 'cancel'
       deltaX: number
       deltaY: number
+      width: number
       height: number
       durationMs: number
     }
@@ -80,48 +79,65 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value))
 }
 
-function dragProgress(deltaY: number, height: number): number {
-  return clamp(Math.max(0, deltaY) / Math.max(height * PROGRESS_TRAVEL_FRACTION, 1), 0, 1)
+function dragDistance(deltaX: number, deltaY: number): number {
+  return Math.hypot(deltaX, deltaY)
 }
 
-/** Asymptotic resistance for travel above the origin, like an iOS scroll edge. */
-function rubberBandOffsetY(deltaY: number): number {
-  if (deltaY >= 0) {
-    return deltaY
-  }
-  const overshoot = -deltaY
-  return -((overshoot * UPWARD_RUBBER_BAND_PX) / (overshoot + UPWARD_RUBBER_BAND_PX))
+function dragProgress(deltaX: number, deltaY: number, height: number): number {
+  return clamp(
+    dragDistance(deltaX, deltaY) / Math.max(height * PROGRESS_TRAVEL_FRACTION, 1),
+    0,
+    1,
+  )
 }
 
 /** Continue the drag vector so the image exits along the finger's line. */
-function projectDismissX(deltaX: number, deltaY: number, height: number): number {
-  const factor = height / Math.max(deltaY, height * 0.15)
-  return clamp(deltaX * factor, -height / 2, height / 2)
+function projectDismissOffset(
+  deltaX: number,
+  deltaY: number,
+  width: number,
+  height: number,
+): { x: number; y: number } {
+  const absX = Math.abs(deltaX)
+  const absY = Math.abs(deltaY)
+  if (absX === 0 && absY === 0) {
+    return { x: 0, y: height }
+  }
+  const factor = absX >= absY ? width / Math.max(absX, 1) : height / Math.max(absY, 1)
+  return {
+    x: deltaX * factor,
+    y: deltaY * factor,
+  }
 }
 
-function dismissDurationMs(deltaY: number, height: number, velocity: number): number {
-  const remaining = Math.max(0, height - deltaY)
+function dismissDurationMs(distance: number, height: number, velocity: number): number {
+  const remaining = Math.max(0, height - distance)
   const floorVelocity = remaining / DISMISS_MS
   return clamp(remaining / Math.max(velocity, floorVelocity), DISMISS_MIN_MS, DISMISS_MS)
 }
 
 function imageStyleForState(state: DragState): CSSProperties | undefined {
   if (state.phase === 'dragging') {
-    const progress = dragProgress(state.deltaY, state.height)
-    const offsetY = rubberBandOffsetY(state.deltaY)
+    const progress = dragProgress(state.deltaX, state.deltaY, state.height)
     return {
-      transform: `translate3d(${state.deltaX}px, ${offsetY}px, 0) scale(${1 - progress * DRAG_SHRINK})`,
+      transform: `translate3d(${state.deltaX}px, ${state.deltaY}px, 0) scale(${1 - progress * DRAG_SHRINK})`,
       transition: 'none',
       willChange: 'transform',
     }
   }
   if (state.phase === 'settling') {
     const closing = state.action === 'close'
+    if (closing) {
+      const offset = projectDismissOffset(state.deltaX, state.deltaY, state.width, state.height)
+      return {
+        transform: `translate3d(${offset.x}px, ${offset.y}px, 0) scale(0.9)`,
+        transition: `transform ${state.durationMs}ms ${DISMISS_EASING}`,
+        willChange: 'transform',
+      }
+    }
     return {
-      transform: closing
-        ? `translate3d(${projectDismissX(state.deltaX, state.deltaY, state.height)}px, ${state.height}px, 0) scale(0.9)`
-        : 'translate3d(0, 0, 0) scale(1)',
-      transition: `transform ${state.durationMs}ms ${closing ? DISMISS_EASING : SNAP_BACK_EASING}`,
+      transform: 'translate3d(0, 0, 0) scale(1)',
+      transition: `transform ${state.durationMs}ms ${SNAP_BACK_EASING}`,
       willChange: 'transform',
     }
   }
@@ -131,7 +147,7 @@ function imageStyleForState(state: DragState): CSSProperties | undefined {
 function backdropStyleForState(state: DragState): CSSProperties | undefined {
   if (state.phase === 'dragging') {
     return {
-      opacity: 1 - dragProgress(state.deltaY, state.height) * BACKDROP_FADE,
+      opacity: 1 - dragProgress(state.deltaX, state.deltaY, state.height) * BACKDROP_FADE,
       transition: 'none',
     }
   }
@@ -148,7 +164,11 @@ function backdropStyleForState(state: DragState): CSSProperties | undefined {
 function chromeStyleForState(state: DragState): CSSProperties | undefined {
   if (state.phase === 'dragging') {
     return {
-      opacity: clamp(1 - dragProgress(state.deltaY, state.height) * CHROME_FADE_RATE, 0, 1),
+      opacity: clamp(
+        1 - dragProgress(state.deltaX, state.deltaY, state.height) * CHROME_FADE_RATE,
+        0,
+        1,
+      ),
       pointerEvents: 'none',
       transition: 'none',
     }
@@ -165,12 +185,12 @@ function chromeStyleForState(state: DragState): CSSProperties | undefined {
 }
 
 /**
- * Touch drag-to-dismiss for the mobile image lightbox. A predominantly
- * vertical downward drag detaches the image so it follows the finger on both
- * axes (upward travel rubber-bands) while the backdrop and chrome fade with
- * progress. Releasing past a distance threshold, or flicking, slides the
- * image out along the drag vector at a velocity-matched speed and then calls
- * `onClose`; shorter drags spring back. A plain tap still closes via `onClick`.
+ * Touch drag-to-dismiss for the mobile image lightbox. A touch drag detaches
+ * the image so it follows the finger in any direction while the backdrop and
+ * chrome fade with distance. Releasing past a distance threshold, or flicking,
+ * slides the image out along the drag vector at a velocity-matched speed and
+ * then calls `onClose`; shorter drags spring back. A plain tap still closes via
+ * `onClick`.
  */
 export function useImageDismissDrag({
   active,
@@ -252,19 +272,9 @@ export function useImageDismissDrag({
       }
 
       if (current.phase === 'armed') {
-        const deltaX = Math.abs(event.clientX - current.startX)
-        const deltaY = event.clientY - current.startY
-        if (deltaX > DRAG_DISARM_X_PX && deltaX > Math.abs(deltaY)) {
-          suppressUpcomingClick()
-          commit(IDLE)
-          return
-        }
-        if (deltaY < -DRAG_ACTIVATE_PX) {
-          suppressUpcomingClick()
-          commit(IDLE)
-          return
-        }
-        if (deltaY < DRAG_ACTIVATE_PX || deltaY <= deltaX) {
+        const travelX = event.clientX - current.startX
+        const travelY = event.clientY - current.startY
+        if (dragDistance(travelX, travelY) < DRAG_ACTIVATE_PX) {
           return
         }
 
@@ -274,7 +284,9 @@ export function useImageDismissDrag({
           // Synthetic tests do not have a live pointer to capture.
         }
 
-        const height = event.currentTarget.getBoundingClientRect().height || window.innerHeight
+        const rect = event.currentTarget.getBoundingClientRect()
+        const width = rect.width || window.innerWidth
+        const height = rect.height || window.innerHeight
         // Rebase on the activation point so the image picks up from rest
         // instead of jumping by the activation distance.
         commit({
@@ -282,11 +294,12 @@ export function useImageDismissDrag({
           pointerId: event.pointerId,
           originX: event.clientX,
           originY: event.clientY,
+          width,
           height,
           deltaX: 0,
           deltaY: 0,
           velocity: 0,
-          sampleDeltaY: 0,
+          sampleDistance: 0,
           sampleTime: performance.now(),
         })
         return
@@ -294,6 +307,7 @@ export function useImageDismissDrag({
 
       const deltaX = event.clientX - current.originX
       const deltaY = event.clientY - current.originY
+      const distance = dragDistance(deltaX, deltaY)
       const now = performance.now()
       const elapsed = now - current.sampleTime
       if (elapsed < VELOCITY_WINDOW_MS) {
@@ -304,12 +318,12 @@ export function useImageDismissDrag({
         ...current,
         deltaX,
         deltaY,
-        velocity: (deltaY - current.sampleDeltaY) / elapsed,
-        sampleDeltaY: deltaY,
+        velocity: (distance - current.sampleDistance) / elapsed,
+        sampleDistance: distance,
         sampleTime: now,
       })
     },
-    [commit, suppressUpcomingClick],
+    [commit],
   )
 
   const release = useCallback(
@@ -327,19 +341,20 @@ export function useImageDismissDrag({
       }
 
       const releaseDeltaX = event.clientX - current.originX
-      const releaseDeltaY = Math.max(0, event.clientY - current.originY)
+      const releaseDeltaY = event.clientY - current.originY
+      const releaseDistance = dragDistance(releaseDeltaX, releaseDeltaY)
       const now = performance.now()
       const elapsed = now - current.sampleTime
       const releaseVelocity =
         elapsed >= VELOCITY_WINDOW_MS
-          ? (releaseDeltaY - current.sampleDeltaY) / elapsed
+          ? (releaseDistance - current.sampleDistance) / elapsed
           : current.velocity
       const flicked =
         releaseVelocity > DISMISS_VELOCITY_PX_PER_MS &&
-        releaseDeltaY > MIN_FLICK_DY_PX &&
+        releaseDistance > MIN_FLICK_DISTANCE_PX &&
         elapsed <= VELOCITY_STALE_MS
       const shouldClose =
-        !interrupted && (releaseDeltaY > current.height * DISMISS_FRACTION || flicked)
+        !interrupted && (releaseDistance > current.height * DISMISS_FRACTION || flicked)
       suppressUpcomingClick()
 
       if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
@@ -355,9 +370,10 @@ export function useImageDismissDrag({
         action: shouldClose ? 'close' : 'cancel',
         deltaX: releaseDeltaX,
         deltaY: releaseDeltaY,
+        width: current.width,
         height: current.height,
         durationMs: shouldClose
-          ? dismissDurationMs(releaseDeltaY, current.height, releaseVelocity)
+          ? dismissDurationMs(releaseDistance, current.height, releaseVelocity)
           : SNAP_BACK_MS,
       })
     },


### PR DESCRIPTION
## Problem

The image lightbox had two native-feel regressions:

- On mobile, drag-to-dismiss only worked on a downward vertical axis. Horizontal or upward drags were either ignored, disarmed, or rubber-banded even though the preview itself already visually followed the finger.
- On desktop, clicking an inline editor image could open the lightbox without the shared-element zoom animation because the source image lookup still targeted meowdown's older `.md-image-preview` wrapper class.

## Before -> After

| Surface | Before | After |
| --- | --- | --- |
| Mobile lightbox drag | Only downward distance and velocity could dismiss. | Drag distance, velocity, backdrop fade, chrome fade, and exit projection use the full drag vector. |
| Desktop image open | The lightbox could open instantly when the clicked image source element was not found. | The source lookup recognizes current `.md-image-view-preview` markup, keeping a fallback for the older class. |

## Changes

1. Updated `useImageDismissDrag` to track drag distance with `Math.hypot`, activate on movement in any direction, and project close animations along the release vector.
2. Kept short drags springing back and suppressing synthetic trailing clicks, including horizontal drags.
3. Updated `NoteEditor` image source lookup to match `.md-image-view-preview, .md-image-preview` so the View Transitions API receives the clicked `<img>` again.
4. Adjusted editor/lightbox tests to cover horizontal dismissal, upward dismissal, vector-based fade progress, and the current meowdown image wrapper class.

## Verification

- `pnpm --filter @reflect/desktop exec vitest run src/editor/image-lightbox.test.tsx src/editor/note-editor.test.tsx` passed: 2 files, 44 tests.
- `pnpm check` passed: workspace typecheck plus oxlint and desktop ESLint.

## Risk / Rollout

No migrations or data changes. The interaction change is limited to the image lightbox: mobile touch drag semantics become less axis-locked, while desktop restores the existing native View Transition behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only gesture and DOM selector changes in the image lightbox/editor path; no auth, data, or API impact.
> 
> **Overview**
> Fixes mobile image lightbox drag-to-dismiss and desktop open animation regressions.
> 
> **Mobile:** `useImageDismissDrag` no longer limits dismissal to downward drags. Progress, velocity, backdrop/chrome fade, and exit animation use **2D distance** (`Math.hypot`) and **vector projection** so horizontal and upward swipes can dismiss; upward rubber-banding and horizontal “disarm” behavior are removed. Short drags still snap back with click suppression.
> 
> **Desktop:** `NoteEditor` resolves the View Transition source image via `.md-image-view-preview` (with fallback to `.md-image-preview`) so inline clicks pass the correct `<img>` again.
> 
> Tests updated for vector-based fade, horizontal/upward dismiss, and the new wrapper class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55207afd77b1d1c228b7bb304bb0fb28e15db512. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->