### PR TITLE
Fix V1 import asset handle exhaustion

### DIFF
--- a/apps/desktop/src-tauri/src/fs/import.rs
+++ b/apps/desktop/src-tauri/src/fs/import.rs
@@ -114,7 +114,7 @@ fn planned_duplicate(
 ) -> AppResult<Option<String>> {
     for (prior, plan) in planned {
         if prior.desired_name == fetched.desired_name
-            && import_assets::same_file_bytes(prior.file.path(), fetched.file.path())?
+            && import_assets::same_file_bytes(prior.file.as_ref(), fetched.file.as_ref())?
         {
             return Ok(Some(plan.name.clone()));
         }
@@ -168,7 +168,7 @@ pub(super) fn finalize_import(
                 let plan = import_assets::plan_asset_name(
                     &assets_dir,
                     &fetched.desired_name,
-                    fetched.file.path(),
+                    fetched.file.as_ref(),
                     &taken,
                 )?;
                 taken.insert(plan.name.clone());
@@ -516,6 +516,46 @@ mod tests {
         base
     }
 
+    fn serve_generated_assets(expected_requests: usize) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let base = format!("http://{}/", listener.local_addr().unwrap());
+        std::thread::spawn(move || {
+            for _ in 0..expected_requests {
+                let Ok((stream, _)) = listener.accept() else {
+                    return;
+                };
+                let mut reader = BufReader::new(stream);
+                let mut request_line = String::new();
+                if reader.read_line(&mut request_line).is_err() {
+                    continue;
+                }
+                loop {
+                    let mut header = String::new();
+                    if reader.read_line(&mut header).is_err() || header.trim().is_empty() {
+                        break;
+                    }
+                }
+                let requested = request_line.split_whitespace().nth(1).unwrap_or("");
+                let body = requested.as_bytes();
+                let mut stream = reader.into_inner();
+                let _ = write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Type: image/png\r\nContent-Length: {}\r\n\r\n",
+                    body.len()
+                );
+                let _ = stream.write_all(body);
+            }
+        });
+        base
+    }
+
+    #[cfg(unix)]
+    fn open_fd_count() -> Option<usize> {
+        ["/proc/self/fd", "/dev/fd"]
+            .into_iter()
+            .find_map(|path| fs::read_dir(path).ok().map(|entries| entries.count()))
+    }
+
     #[test]
     fn imports_notes_into_the_open_graph() {
         let root = tempdir().unwrap();
@@ -759,6 +799,48 @@ mod tests {
         assert_eq!(
             note,
             "![](assets/trip-photo.webp)\n\n[memo.m4a](assets/memo.m4a)\n\n![](assets/9c2c28.png)\n"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn downloaded_assets_do_not_hold_file_descriptors_until_finalize() {
+        const ASSET_COUNT: usize = 80;
+
+        let root = tempdir().unwrap();
+        let base = serve_generated_assets(ASSET_COUNT);
+        let zip_path = root.path().join("export.zip");
+        let markdown = (0..ASSET_COUNT)
+            .map(|index| format!("![]({base}asset-{index}?alt=media\\&token={index})\n"))
+            .collect::<String>();
+        write_zip(&zip_path, &[("daily/2026-07-04.md", markdown.as_str())]);
+
+        let prepared = prepare_zip_import_from(root.path(), &zip_path, &base).unwrap();
+        let Some(before) = open_fd_count() else {
+            return;
+        };
+        let downloads = tauri::async_runtime::block_on(prepared.download_assets()).unwrap();
+        let Some(after) = open_fd_count() else {
+            return;
+        };
+
+        assert_eq!(downloads.len(), ASSET_COUNT);
+        assert!(
+            after.saturating_sub(before) < ASSET_COUNT / 4,
+            "asset downloads kept too many file descriptors open: before {before}, after {after}"
+        );
+
+        let summary = finalize_import(root.path(), prepared, downloads).unwrap();
+        assert_eq!(summary.imported_files, 1);
+        assert_eq!(summary.downloaded_assets, ASSET_COUNT);
+        assert_eq!(summary.failed_asset_downloads, 0);
+        assert_eq!(
+            summary
+                .changed_paths
+                .iter()
+                .filter(|path| path.starts_with("assets/"))
+                .count(),
+            ASSET_COUNT
         );
     }
 

--- a/apps/desktop/src-tauri/src/fs/import_assets.rs
+++ b/apps/desktop/src-tauri/src/fs/import_assets.rs
@@ -50,7 +50,7 @@ pub(super) enum DownloadOutcome {
 }
 
 pub(super) struct FetchedAsset {
-    pub file: tempfile::NamedTempFile,
+    pub file: tempfile::TempPath,
     /// Sanitized filename the asset would like under `assets/` (collision
     /// suffixes are decided later, against the live graph).
     pub desired_name: String,
@@ -231,7 +231,7 @@ async fn fetch_asset(
     }
     file.as_file().sync_all()?;
     Ok(DownloadOutcome::Fetched(FetchedAsset {
-        file,
+        file: file.into_temp_path(),
         desired_name,
     }))
 }


### PR DESCRIPTION
## Problem

Reflect V1 import downloads every remote attachment before writing anything into the graph. Each successful asset download was kept as an open `NamedTempFile` until finalization, so a large export could hold hundreds of staged files open at once. On macOS that can trip the process file descriptor limit and surface as `Too many open files (os error 24)` during import, matching the reported failure.

## Before -> After

| Before | After |
| --- | --- |
| Successful asset downloads stayed open until the full import finalized. | Successful asset downloads are synced, converted to cleanup-owned temp paths, and have their file handles closed immediately. |
| Large V1 imports could fail before any graph write with `os error 24`. | Large V1 imports can keep staged asset paths without consuming one descriptor per downloaded asset. |

## Changes

1. Change `FetchedAsset` to store `tempfile::TempPath` instead of `NamedTempFile`.
2. Convert staged downloads with `into_temp_path()` after writing and syncing, preserving drop cleanup plus `persist_noclobber()` finalization.
3. Update import finalization and duplicate detection to compare staged paths through `AsRef<Path>`.
4. Add a regression test that downloads 80 generated assets, holds the download outcomes before finalization, asserts descriptor growth stays bounded, and then finalizes the import.

## Verification

- `pnpm --filter @reflect/desktop sidecar`
- `cargo test -p reflect-open fs::import::tests::downloaded_assets_do_not_hold_file_descriptors_until_finalize`
- `cargo test -p reflect-open fs::import::tests`
- `cargo test -p reflect-open fs::import_assets::tests`
- `pnpm check`

## Risk / Rollout

No data migration or UI change. The main risk is temp-file lifecycle behavior, covered by existing import tests plus the new finalization check that persists closed temp paths into `assets/`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a8efdd340910201332647c246d8cbef6c5d20805. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->