### PR TITLE
Release v0.4.0-beta.36

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4737,7 +4737,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.4.0-beta.35"
+version = "0.4.0-beta.36"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.4.0-beta.35"
+version = "0.4.0-beta.36"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.4.0-beta.35",
+  "version": "0.4.0-beta.36",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.4.0-beta.36.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version alignment only; no logic, security, or dependency changes in the diff.
> 
> **Overview**
> Bumps the desktop app release version from **0.4.0-beta.35** to **0.4.0-beta.36** in `apps/desktop/src-tauri/Cargo.toml`, `tauri.conf.json`, and the `reflect-open` entry in `Cargo.lock`. No application or dependency changes beyond the version string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6df20ff2be6414da3fa99aa778a56f513fca2f4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->