### PR TITLE
Document graph Git history in bundled agent skill

### DIFF
--- a/apps/desktop/src-tauri/skills/graph-skill.md
+++ b/apps/desktop/src-tauri/skills/graph-skill.md
@@ -26,6 +26,23 @@ Always target the graph explicitly so calls stay deterministic:
 
 or export `REFLECT_GRAPH="{{GRAPH_ROOT}}"` for a sequence of calls.
 
+## Git history
+
+On desktop, every graph is also a Git repository at its root. Reflect
+initializes or adopts that repo when the graph opens; even graphs with no
+backup remote keep local history through a commit-only sync loop. There may be
+no `origin`, but `.git` history is available.
+
+Use the CLI for current note lookup, privacy filtering, and path resolution.
+Use Git only when the user asks for history, diffs, recovery, or past states:
+
+    git -C "{{GRAPH_ROOT}}" log --oneline -- <graph-relative-path>
+    git -C "{{GRAPH_ROOT}}" diff <rev> -- <graph-relative-path>
+    git -C "{{GRAPH_ROOT}}" show <rev>:<graph-relative-path>
+
+Do not use Git history to bypass privacy. If a note is private, avoid reading
+or exposing its current or historical content unless the user explicitly asks.
+
 ## Commands
 
     reflect today              # print today's daily note

--- a/apps/desktop/src-tauri/src/skill.rs
+++ b/apps/desktop/src-tauri/src/skill.rs
@@ -349,6 +349,7 @@ mod tests {
         assert!(context
             .managed_content
             .contains("/Applications/Reflect.app/Contents/MacOS/reflect"));
+        assert!(context.managed_content.contains("git -C \"/graphs/Personal\""));
         assert!(!context.managed_content.contains("{{"));
     }
 

--- a/apps/desktop/src-tauri/src/skill.rs
+++ b/apps/desktop/src-tauri/src/skill.rs
@@ -349,7 +349,9 @@ mod tests {
         assert!(context
             .managed_content
             .contains("/Applications/Reflect.app/Contents/MacOS/reflect"));
-        assert!(context.managed_content.contains("git -C \"/graphs/Personal\""));
+        assert!(context
+            .managed_content
+            .contains("git -C \"/graphs/Personal\""));
         assert!(!context.managed_content.contains("{{"));
     }
 


### PR DESCRIPTION
## Problem
The bundled Reflect graph skill tells agents how to use `reflect` for current notes, but it omits the desktop local-history path. Desktop graphs are initialized or adopted as Git repositories, and local-only graphs are committed by the desktop backup controller, so agents can answer history, diff, recovery, and past-state requests through Git.

## Before -> After
| Before | After |
| --- | --- |
| Agents saw CLI commands for current-note lookup only. | Agents are told desktop graph roots are Git repos and get `git -C "{{GRAPH_ROOT}}"` examples for log, diff, and show. |
| Privacy guidance covered direct file reads. | Git-history access carries an explicit “do not bypass privacy” caveat. |

## Changes
1. Adds a `Git history` section to `apps/desktop/src-tauri/skills/graph-skill.md`.
2. Extends the rendered-skill test to assert the managed skill includes the graph-root-specific `git -C` guidance.

## Verification
- `pnpm --filter @reflect/desktop sidecar`
- `cargo test -p reflect-open skill::tests`
- `pnpm check`

## Risk / Rollout
No data migrations or runtime behavior changes. Existing managed skill installs will become stale and can be refreshed from Settings > Agents.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only template and test changes; no runtime or data behavior. Installed skills may show as stale until refreshed from Settings.
> 
> **Overview**
> The bundled **graph skill** template (`graph-skill.md`) now tells agents that desktop graph roots are Git repos (including local-only commit history) and when to use **`git -C "{{GRAPH_ROOT}}"`** for `log`, `diff`, and `show` versus the `reflect` CLI for current notes.
> 
> It also adds an explicit rule that **Git history must not bypass privacy** for private notes.
> 
> The **`render_bakes_in_the_graph_and_cli`** test now checks that rendered managed skill content includes the graph-root-specific `git -C` example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c210cc2071fd5a2d4b4b8e4108ce3c551e22aab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Git history” section to the skill guide, explaining how graph history is stored and when to use Git commands for history-related requests.
  * Clarified that Git history must not be used to expose protected content unless explicitly requested.

* **Tests**
  * Updated coverage to verify the generated skill content includes the expected Git command example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->