### PR TITLE
test: cover AI menu shortcut in help modal

### DIFF
--- a/apps/desktop/src/components/shortcuts-dialog.test.tsx
+++ b/apps/desktop/src/components/shortcuts-dialog.test.tsx
@@ -1,10 +1,19 @@
 import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ShortcutsDialog } from './shortcuts-dialog'
 import { ShortcutsProvider, useShortcuts } from '@/providers/shortcuts-provider'
 
+const isApplePlatform = vi.hoisted(() => vi.fn(() => false))
+vi.mock('@/lib/keybindings', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/keybindings')>()),
+  isApplePlatform,
+}))
+
 afterEach(cleanup) // `globals: false` disables testing-library's automatic cleanup
+beforeEach(() => {
+  isApplePlatform.mockReturnValue(false)
+})
 
 function OpenButton() {
   const { openShortcuts } = useShortcuts()
@@ -40,6 +49,19 @@ describe('ShortcutsDialog', () => {
     expect(screen.getByText('Bold')).toBeTruthy()
     // The cheat-sheet lists itself; a user who forgot ⌘/ can re-learn it here.
     expect(screen.getByText('Keyboard shortcuts', { selector: 'li *' })).toBeTruthy()
+  })
+
+  it('lists the AI menu shortcut with the Apple command chord', async () => {
+    isApplePlatform.mockReturnValue(true)
+    renderDialog()
+    await userEvent.click(screen.getByRole('button', { name: 'open' }))
+
+    const row = screen.getByText('Open the AI menu on the selection').closest('li')
+
+    if (row === null) {
+      throw new Error('AI menu shortcut row was not rendered')
+    }
+    expect([...row.querySelectorAll('kbd')].map((keycap) => keycap.textContent)).toEqual(['⌘', '⇧', 'J'])
   })
 
   it('keeps the sheet within the viewport and scrolls the shortcut rows', async () => {


### PR DESCRIPTION
## Problem

The shortcuts helper modal should continue to show the editor AI menu shortcut (`⌘⇧J`) alongside the rest of the registry-backed shortcuts.

## Changes

- Mock Apple shortcut rendering in `ShortcutsDialog` tests.
- Assert the modal includes the AI menu row and renders the `⌘`, `⇧`, `J` keycaps.

## Verification

- `pnpm --filter @reflect/desktop test --run src/components/shortcuts-dialog.test.tsx`
- `pnpm check`

## Risk

Low. Test-only coverage for existing registry-backed modal behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code or runtime behavior impact.
> 
> **Overview**
> Adds **test-only** coverage in `shortcuts-dialog.test.tsx` so the keyboard shortcuts modal still shows the editor **“Open the AI menu on the selection”** row with the correct **Apple** keycaps.
> 
> The suite now **mocks** `isApplePlatform` from `@/lib/keybindings` (default `false` in `beforeEach`, `true` in the new case) and asserts the row’s `<kbd>` elements render as **`⌘`, `⇧`, `J`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04929cdf3d9480badefbea1412165b7f8390d983. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->