### PR TITLE
Fix V1 import Unicode path aliases

### DIFF
--- a/apps/desktop/src-tauri/src/fs/import.rs
+++ b/apps/desktop/src-tauri/src/fs/import.rs
@@ -22,8 +22,11 @@ use serde::Serialize;
 use crate::error::{AppError, AppResult};
 
 use super::import_assets::{self, DownloadOutcome};
-use super::io::{atomic_write_bytes, file_occupied};
+use super::io::{atomic_write_bytes, eviction_placeholder, file_occupied};
 use super::resolve::resolve;
+
+/// Collision probes before giving up, matching the note-path probe cap.
+const MAX_IMPORT_PATH_PROBES: u32 = 1000;
 
 /// Summary returned to the settings UI after an import completes.
 #[derive(Debug, PartialEq, Eq, Serialize)]
@@ -147,7 +150,7 @@ pub(super) fn finalize_import(
         mut entries,
         urls,
         prefix,
-        ..
+        staging,
     } = prepared;
 
     let assets_dir = root.join("assets");
@@ -194,6 +197,8 @@ pub(super) fn finalize_import(
             }
         }
     }
+
+    plan_import_paths(root, &staging, &mut entries)?;
 
     let collisions = entries
         .iter()
@@ -247,6 +252,145 @@ pub(super) fn finalize_import(
         failed_asset_downloads,
         changed_paths,
     })
+}
+
+fn plan_import_paths(root: &Path, staging: &Path, entries: &mut [ImportEntry]) -> AppResult<()> {
+    let scratch = tempfile::TempDir::new_in(staging)?;
+    for entry in entries {
+        plan_import_path(root, scratch.path(), entry)?;
+    }
+    Ok(())
+}
+
+fn plan_import_path(root: &Path, scratch: &Path, entry: &mut ImportEntry) -> AppResult<()> {
+    match exact_collision(root, &entry.relative, &entry.bytes)? {
+        ExactCollision::SameBytes => return Ok(()),
+        ExactCollision::DifferentBytes => {
+            return Err(AppError::io(format!(
+                "import would overwrite existing files: {}",
+                entry.relative
+            )))
+        }
+        ExactCollision::Free => {}
+    }
+
+    if !is_suffixable_note_markdown(&entry.relative) {
+        if filesystem_occupied(root, &entry.relative)?
+            || planned_path_occupied(scratch, &entry.relative)
+        {
+            return Err(AppError::io(format!(
+                "import would overwrite existing files: {}",
+                entry.relative
+            )));
+        }
+        mark_planned_path(scratch, &entry.relative)?;
+        return Ok(());
+    }
+
+    let original = entry.relative.clone();
+    for attempt in 1..=MAX_IMPORT_PATH_PROBES {
+        let candidate = suffixed_relative_path(&original, attempt);
+        match exact_collision(root, &candidate, &entry.bytes)? {
+            ExactCollision::SameBytes => {
+                entry.relative = candidate;
+                return Ok(());
+            }
+            ExactCollision::DifferentBytes => continue,
+            ExactCollision::Free => {}
+        }
+        if filesystem_occupied(root, &candidate)? || planned_path_occupied(scratch, &candidate) {
+            continue;
+        }
+        mark_planned_path(scratch, &candidate)?;
+        entry.relative = candidate;
+        return Ok(());
+    }
+
+    Err(AppError::io(format!(
+        "no free import path after {MAX_IMPORT_PATH_PROBES} probes for {original}"
+    )))
+}
+
+enum ExactCollision {
+    Free,
+    SameBytes,
+    DifferentBytes,
+}
+
+fn exact_collision(root: &Path, relative: &str, bytes: &[u8]) -> AppResult<ExactCollision> {
+    let target = resolve(root, relative)?;
+    if !exact_path_occupied(&target)? {
+        return Ok(ExactCollision::Free);
+    }
+    if target.is_file() && fs::read(&target)? == bytes {
+        return Ok(ExactCollision::SameBytes);
+    }
+    Ok(ExactCollision::DifferentBytes)
+}
+
+fn exact_path_occupied(path: &Path) -> AppResult<bool> {
+    if exact_path_exists(path)? {
+        return Ok(true);
+    }
+    match eviction_placeholder(path) {
+        Some(placeholder) => exact_path_exists(&placeholder),
+        None => Ok(false),
+    }
+}
+
+fn exact_path_exists(path: &Path) -> AppResult<bool> {
+    let Some(parent) = path.parent() else {
+        return Ok(false);
+    };
+    if !parent.is_dir() {
+        return Ok(false);
+    }
+    let Some(name) = path.file_name() else {
+        return Ok(false);
+    };
+    for entry in fs::read_dir(parent)? {
+        if entry?.file_name() == name {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn filesystem_occupied(root: &Path, relative: &str) -> AppResult<bool> {
+    let target = resolve(root, relative)?;
+    Ok(target.exists() || file_occupied(&target))
+}
+
+fn planned_path_occupied(scratch: &Path, relative: &str) -> bool {
+    scratch.join(relative).exists()
+}
+
+fn mark_planned_path(scratch: &Path, relative: &str) -> AppResult<()> {
+    let path = scratch.join(relative);
+    let parent = path
+        .parent()
+        .ok_or_else(|| AppError::io(format!("no parent directory for {relative}")))?;
+    fs::create_dir_all(parent)?;
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)?;
+    Ok(())
+}
+
+fn suffixed_relative_path(relative: &str, attempt: u32) -> String {
+    if attempt == 1 {
+        return relative.to_string();
+    }
+    let slash = relative.rfind('/').map_or(0, |index| index + 1);
+    let dot = relative[slash..]
+        .rfind('.')
+        .map(|index| slash + index)
+        .filter(|index| *index > slash);
+    match dot {
+        Some(dot) => format!("{}-{}{}", &relative[..dot], attempt, &relative[dot..]),
+        None => format!("{relative}-{attempt}"),
+    }
 }
 
 fn dedupe_entries(entries: Vec<ImportEntry>) -> AppResult<Vec<ImportEntry>> {
@@ -415,6 +559,17 @@ fn is_note_markdown(relative: &str) -> bool {
             .is_some_and(|extension| extension.eq_ignore_ascii_case("md"))
 }
 
+fn is_suffixable_note_markdown(relative: &str) -> bool {
+    relative
+        .split('/')
+        .next()
+        .is_some_and(|first| first == "notes")
+        && Path::new(relative)
+            .extension()
+            .and_then(|value| value.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("md"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -466,6 +621,15 @@ mod tests {
             writer.write_all(contents.as_bytes()).unwrap();
         }
         writer.finish().unwrap();
+    }
+
+    fn filesystem_aliases_sharp_s(root: &Path) -> bool {
+        let dir = root.join("casefold-probe");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("füsse.md"), "probe").unwrap();
+        let aliases = dir.join("füße.md").exists();
+        fs::remove_dir_all(&dir).unwrap();
+        aliases
     }
 
     /// Serve canned HTTP responses on a local port: each entry is
@@ -638,6 +802,65 @@ mod tests {
         assert_eq!(
             fs::read_to_string(root.path().join("notes/a.md")).unwrap(),
             "# Mine\n"
+        );
+    }
+
+    #[test]
+    fn suffixes_existing_filesystem_alias_for_regular_notes() {
+        let root = tempdir().unwrap();
+        if !filesystem_aliases_sharp_s(root.path()) {
+            return;
+        }
+        fs::create_dir_all(root.path().join("notes")).unwrap();
+        fs::write(root.path().join("notes/füsse.md"), "# Swiss spelling\n").unwrap();
+
+        let summary = import_entries_into_graph(
+            root.path(),
+            entries(&[("notes/füße.md", "# German spelling\n")]),
+        )
+        .unwrap();
+
+        assert_eq!(summary.imported_files, 1);
+        assert_eq!(summary.skipped_files, 0);
+        assert_eq!(summary.changed_paths, vec!["notes/füße-2.md"]);
+        assert_eq!(
+            fs::read_to_string(root.path().join("notes/füsse.md")).unwrap(),
+            "# Swiss spelling\n"
+        );
+        assert_eq!(
+            fs::read_to_string(root.path().join("notes/füße-2.md")).unwrap(),
+            "# German spelling\n"
+        );
+    }
+
+    #[test]
+    fn suffixes_filesystem_aliases_within_the_import_batch() {
+        let root = tempdir().unwrap();
+        if !filesystem_aliases_sharp_s(root.path()) {
+            return;
+        }
+
+        let summary = import_entries_into_graph(
+            root.path(),
+            entries(&[
+                ("notes/füsse.md", "# Swiss spelling\n"),
+                ("notes/füße.md", "# German spelling\n"),
+            ]),
+        )
+        .unwrap();
+
+        assert_eq!(summary.imported_files, 2);
+        assert_eq!(
+            summary.changed_paths,
+            vec!["notes/füsse.md", "notes/füße-2.md"]
+        );
+        assert_eq!(
+            fs::read_to_string(root.path().join("notes/füsse.md")).unwrap(),
+            "# Swiss spelling\n"
+        );
+        assert_eq!(
+            fs::read_to_string(root.path().join("notes/füße-2.md")).unwrap(),
+            "# German spelling\n"
         );
     }
 


### PR DESCRIPTION
## Problem

Reflect V1 import uses the filesystem as the final overwrite guard. On macOS and iCloud-style volumes, Unicode/case-insensitive lookup can make distinct Reflect slugs share one filesystem slot: `notes/füsse.md` can occupy `notes/füße.md`. That made imports of legitimate Swiss/German spelling variants fail with `import would overwrite existing files`, even though Reflect treats the note titles as distinct.

The same failure can happen inside one import batch: the first spelling writes successfully, then the second spelling collides with it at the filesystem layer.

## Before -> After

| Before | After |
| --- | --- |
| `füsse.md` and `füße.md` could trip the overwrite guard on Unicode/case-insensitive volumes. | Regular imported notes that only collide through filesystem aliasing get the normal `-2`, `-3`, ... suffix. |
| Exact same-path overwrites stayed blocked. | Exact same-path overwrites still stay blocked, and identical exact files are still skipped. |
| Batch-internal aliases could fail after a partial write. | Import paths are planned before graph writes, using a scratch directory to catch aliases among incoming files. |

## Changes

1. Add `plan_import_paths` before any graph write in `finalize_import`.
2. Distinguish exact path occupancy from filesystem-alias occupancy by checking the parent directory for the exact filename and exact iCloud placeholder.
3. For regular note markdown under `notes/`, probe suffixed paths when the intended path is occupied only by filesystem aliasing or by an earlier planned import path.
4. Keep non-note alias collisions as hard errors so imported asset paths are not silently renamed without rewriting references.
5. Add regression coverage for importing `füße.md` into a graph that already has `füsse.md`, plus importing both spellings in the same batch.

## Verification

- `pnpm --filter @reflect/desktop sidecar`
- `cargo test -p reflect-open fs::import::tests`
- `pnpm check`

## Risk / Rollout

No data migration or UI change. The behavior only affects Reflect V1 imports. Exact path conflicts are still conservative hard errors; only regular-note filesystem aliases receive suffixes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes import write semantics and filesystem collision logic for Reflect V1 only; wrong alias/suffix handling could misplace notes, but scope is limited to import and exact-path overwrites stay blocked.
> 
> **Overview**
> Reflect V1 import now **plans destination paths before any graph write**, so Unicode/case-insensitive volume aliasing (e.g. `notes/füsse.md` vs `notes/füße.md`) no longer fails with overwrite errors when Reflect treats the titles as distinct.
> 
> **`plan_import_paths`** runs in `finalize_import` after asset rewrite: it uses a staging scratch directory to reserve paths within the batch and distinguishes **exact** filename occupancy (parent `read_dir` + iCloud eviction placeholders via `eviction_placeholder`) from broader **`filesystem_occupied`** / `file_occupied` checks. For **`notes/*.md` only**, alias-only conflicts probe suffixed paths (`-2`, `-3`, … up to 1000) and update `entry.relative` before the existing collision pass; exact same-path different bytes and non-note alias collisions remain hard errors. Identical bytes at an exact path are still skipped.
> 
> Adds regression tests (gated on a filesystem sharp-s probe) for importing into an existing alias and for two aliasing spellings in one batch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de3a0a083da59707b08a898e94c92c1168b2027a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->