### PR TITLE
feat(chat): let AI chat read asset descriptions via read_assets

### DIFF
--- a/apps/desktop/src/components/chat/chat-screen.test.tsx
+++ b/apps/desktop/src/components/chat/chat-screen.test.tsx
@@ -392,6 +392,39 @@ describe('ChatScreen', () => {
     expect(probedRoute).toEqual({ kind: 'daily', date: '2026-06-10' })
   })
 
+  it('renders an attachment chip: filenames, with per-asset refusals inline', async () => {
+    configureModel()
+    scriptTurn([
+      {
+        type: 'tool-call',
+        call: {
+          tool: 'assets',
+          toolCallId: 'tool-1',
+          paths: ['assets/chart.png', 'assets/scan.pdf'],
+        },
+      },
+      {
+        type: 'tool-result',
+        result: {
+          tool: 'assets',
+          toolCallId: 'tool-1',
+          assets: [
+            { path: 'assets/chart.png', error: null },
+            { path: 'assets/scan.pdf', error: 'This asset cannot be read by AI.' },
+          ],
+        },
+      },
+      { type: 'complete', messages: [{ role: 'assistant', content: 'Done.' }] },
+    ])
+    const view = renderChat()
+
+    await userEvent.type(view.getByLabelText('Chat message'), 'what does the chart show?{Enter}')
+
+    // Entries are labeled by filename; a refused asset keeps its refusal inline.
+    await view.findByText('chart.png')
+    await view.findByText(/scan\.pdf — This asset cannot be read by AI\./)
+  })
+
   it('renders streaming text as plain text until the turn settles', async () => {
     configureModel()
     streamChat.mockImplementation(() =>

--- a/apps/desktop/src/components/chat/chat-tool-chip.tsx
+++ b/apps/desktop/src/components/chat/chat-tool-chip.tsx
@@ -1,5 +1,5 @@
 import { Fragment, type ReactElement, type ReactNode } from 'react'
-import { CalendarDays, FileText, History, Search } from 'lucide-react'
+import { CalendarDays, FileText, History, Paperclip, Search } from 'lucide-react'
 import { isTagName, isToolPending, type AssistantPart, type NoteHitSummary } from '@reflect/core'
 import { Marker, MarkerContent, MarkerIcon } from '@/components/ui/marker'
 import { Spinner } from '@/components/ui/spinner'
@@ -13,6 +13,11 @@ interface ChatToolChipProps {
 /** ` · 3 notes` — the settled count suffix of a listing chip. */
 function countSuffix(count: number, noun: string): string {
   return ` · ${count} ${noun}${count === 1 ? '' : 's'}`
+}
+
+/** An asset chip labels entries by filename — the path adds only noise. */
+function assetName(path: string): string {
+  return path.split('/').pop() ?? path
 }
 
 interface ChipFrameProps {
@@ -120,6 +125,35 @@ export function ChatToolChip({ part }: ChatToolChipProps): ReactElement {
         Listed daily notes {call.start} – {call.end}
         {result !== null ? countSuffix(result.days.length, 'day') : ''}
         {result !== null ? <NoteLinks notes={result.days} onOpen={openNote} /> : null}
+      </ChipFrame>
+    )
+  }
+
+  // read_assets: one chip for the whole batch of attachment descriptions.
+  // Assets have no note route, so entries stay plain text with per-asset
+  // refusals inline.
+  if (call.tool === 'assets') {
+    const result = part.result?.tool === 'assets' ? part.result : null
+    if (part.error !== null) {
+      return (
+        <ChipFrame pending={false} icon={<Paperclip aria-hidden className="size-3.5" />}>
+          {call.paths.map(assetName).join(', ')} — {part.error}
+        </ChipFrame>
+      )
+    }
+    const assets = result?.assets ?? call.paths.map((path) => ({ path, error: null }))
+    return (
+      <ChipFrame pending={pending} icon={<Paperclip aria-hidden className="size-3.5" />}>
+        Read{' '}
+        {assets.map((asset, index) => (
+          <Fragment key={`${asset.path}-${index}`}>
+            {index > 0 ? ', ' : ''}
+            <span>
+              {assetName(asset.path)}
+              {asset.error !== null ? ` — ${asset.error}` : ''}
+            </span>
+          </Fragment>
+        ))}
       </ChipFrame>
     )
   }

--- a/docs/plans/20-asset-descriptions.md
+++ b/docs/plans/20-asset-descriptions.md
@@ -397,6 +397,9 @@ note(s) that reference that asset, as ordinary hits.
   alone** — so descriptions are locally searchable but never widen the All-Notes
   preview or what is sent to a provider (those read the note body / live
   markdown). That falls out of enriching only the FTS column.
+  > **Addendum (PR #630):** AI chat can now read description text explicitly via
+  > the `read_assets` tool (`ai/chat/read-assets.ts`), behind its own live
+  > privacy verdict. Note text and previews are still never widened.
 - `PROJECTION_VERSION` 8 → 9, so existing graphs rebuild and fold descriptions.
 
 **Async re-index seam.** Descriptions are written *after* a note is indexed and

--- a/packages/core/src/actions/asset-description-helpers.ts
+++ b/packages/core/src/actions/asset-description-helpers.ts
@@ -130,6 +130,20 @@ export type AssetVerdict = 'send' | 'skip-unreferenced' | 'skip-private'
  */
 export async function classifyAsset(assetPath: string, generation: number): Promise<AssetVerdict> {
   const candidates = await assetReferencingNotePaths(assetPath)
+  return classifyAssetFromNotes(assetPath, candidates, (notePath) => readNote(notePath, generation))
+}
+
+/**
+ * The verdict core of {@link classifyAsset}, over an explicit candidate list
+ * and note reader. The chat tools reuse it with unpinned reads and an
+ * injectable candidate query; the description pass wraps it with
+ * generation-pinned reads.
+ */
+export async function classifyAssetFromNotes(
+  assetPath: string,
+  candidates: readonly string[],
+  readSource: (notePath: string) => Promise<string>,
+): Promise<AssetVerdict> {
   if (candidates.length === 0) {
     return 'skip-unreferenced'
   }
@@ -137,7 +151,7 @@ export async function classifyAsset(assetPath: string, generation: number): Prom
   for (const notePath of candidates) {
     let source: string
     try {
-      source = await readNote(notePath, generation)
+      source = await readSource(notePath)
     } catch (cause) {
       if (isAppError(cause) && cause.kind === 'notFound') {
         continue

--- a/packages/core/src/actions/asset-description-helpers.ts
+++ b/packages/core/src/actions/asset-description-helpers.ts
@@ -1,10 +1,6 @@
 import { z } from 'zod'
 import { type AssetKind } from '../ai/describe-asset'
-import { isAppError } from '../errors'
-import { readNote } from '../graph/commands'
 import { ASSETS_DIR, DESCRIPTION_SUFFIX } from '../graph/paths'
-import { assetReferencingNotePaths } from '../indexing/asset-refs'
-import { parseNote } from '../markdown/extract'
 import { parseFrontmatter, splitFrontmatter, upsertFrontmatter } from '../markdown/frontmatter'
 
 /** The eligible asset type and how it enters a provider request. */
@@ -118,54 +114,3 @@ export function base64ByteLength(base64: string): number {
   return Math.floor((length * 3) / 4) - padding
 }
 
-/** Outcome of the privacy gate for one asset. */
-export type AssetVerdict = 'send' | 'skip-unreferenced' | 'skip-private'
-
-/**
- * Decide whether an asset may be sent: referenced by ≥1 non-private note and by
- * **0** private notes (unreferenced → skip). Candidate notes come from the
- * index, but the verdict is made from each candidate's **live** markdown — the
- * private flag and a re-confirmation that the body still references the asset.
- * Fails closed: an unreadable candidate blocks the asset.
- */
-export async function classifyAsset(assetPath: string, generation: number): Promise<AssetVerdict> {
-  const candidates = await assetReferencingNotePaths(assetPath)
-  return classifyAssetFromNotes(assetPath, candidates, (notePath) => readNote(notePath, generation))
-}
-
-/**
- * The verdict core of {@link classifyAsset}, over an explicit candidate list
- * and note reader. The chat tools reuse it with unpinned reads and an
- * injectable candidate query; the description pass wraps it with
- * generation-pinned reads.
- */
-export async function classifyAssetFromNotes(
-  assetPath: string,
-  candidates: readonly string[],
-  readSource: (notePath: string) => Promise<string>,
-): Promise<AssetVerdict> {
-  if (candidates.length === 0) {
-    return 'skip-unreferenced'
-  }
-  let publicRefs = 0
-  for (const notePath of candidates) {
-    let source: string
-    try {
-      source = await readSource(notePath)
-    } catch (cause) {
-      if (isAppError(cause) && cause.kind === 'notFound') {
-        continue
-      }
-      return 'skip-private'
-    }
-    const parsed = parseNote({ path: notePath, source })
-    if (!parsed.assets.some((ref) => ref.path === assetPath)) {
-      continue
-    }
-    if (parsed.frontmatter.private) {
-      return 'skip-private'
-    }
-    publicRefs += 1
-  }
-  return publicRefs > 0 ? 'send' : 'skip-unreferenced'
-}

--- a/packages/core/src/actions/asset-description.ts
+++ b/packages/core/src/actions/asset-description.ts
@@ -24,6 +24,7 @@ export {
   base64ByteLength,
   buildDescriptionSource,
   classifyAsset,
+  classifyAssetFromNotes,
   isEligibleAssetPath,
   readManagedDescription,
   type AssetDescriptionMeta,

--- a/packages/core/src/actions/asset-description.ts
+++ b/packages/core/src/actions/asset-description.ts
@@ -14,24 +14,22 @@ import {
   assetTypeFor,
   base64ByteLength,
   buildDescriptionSource,
-  classifyAsset,
   isEligibleAssetPath,
   readManagedDescription,
   type ManagedDescription,
 } from './asset-description-helpers'
+import { classifyAsset } from './asset-privacy'
 export {
   assetTypeFor,
   base64ByteLength,
   buildDescriptionSource,
-  classifyAsset,
-  classifyAssetFromNotes,
   isEligibleAssetPath,
   readManagedDescription,
   type AssetDescriptionMeta,
   type AssetType,
-  type AssetVerdict,
   type ManagedDescription,
 } from './asset-description-helpers'
+export { classifyAsset, classifyAssetFromNotes, type AssetVerdict } from './asset-privacy'
 
 /**
  * Asset descriptions (Plan 20). For each eligible image/PDF under `assets/`

--- a/packages/core/src/actions/asset-privacy.ts
+++ b/packages/core/src/actions/asset-privacy.ts
@@ -1,0 +1,68 @@
+import { isAppError } from '../errors'
+import { readNote } from '../graph/commands'
+import { assetReferencingNotePaths } from '../indexing/asset-refs'
+import { parseNote } from '../markdown/extract'
+
+/**
+ * The asset privacy verdict both asset-description consumers share: the
+ * generation pass (`reconcileAssetDescriptions`) decides whether an asset's
+ * bytes may be sent to a provider, and the chat read_assets tool decides
+ * whether its stored description may be — the sidecar on disk can predate a
+ * note turning private, so the read path re-runs the same verdict live.
+ *
+ * The contract: sendable only when the asset is referenced by ≥1 non-private
+ * note and by **0** private notes. Candidates come from the index, but the
+ * verdict is made from each candidate's live markdown, failing closed.
+ */
+
+/** Outcome of the privacy gate for one asset. */
+export type AssetVerdict = 'send' | 'skip-unreferenced' | 'skip-private'
+
+/**
+ * Decide whether an asset may be sent: referenced by ≥1 non-private note and by
+ * **0** private notes (unreferenced → skip). Candidate notes come from the
+ * index, but the verdict is made from each candidate's **live** markdown — the
+ * private flag and a re-confirmation that the body still references the asset.
+ * Fails closed: an unreadable candidate blocks the asset.
+ */
+export async function classifyAsset(assetPath: string, generation: number): Promise<AssetVerdict> {
+  const candidates = await assetReferencingNotePaths(assetPath)
+  return classifyAssetFromNotes(assetPath, candidates, (notePath) => readNote(notePath, generation))
+}
+
+/**
+ * The verdict core of {@link classifyAsset}, over an explicit candidate list
+ * and note reader. The chat tools reuse it with unpinned reads and an
+ * injectable candidate query; the description pass wraps it with
+ * generation-pinned reads.
+ */
+export async function classifyAssetFromNotes(
+  assetPath: string,
+  candidates: readonly string[],
+  readSource: (notePath: string) => Promise<string>,
+): Promise<AssetVerdict> {
+  if (candidates.length === 0) {
+    return 'skip-unreferenced'
+  }
+  let publicRefs = 0
+  for (const notePath of candidates) {
+    let source: string
+    try {
+      source = await readSource(notePath)
+    } catch (cause) {
+      if (isAppError(cause) && cause.kind === 'notFound') {
+        continue
+      }
+      return 'skip-private'
+    }
+    const parsed = parseNote({ path: notePath, source })
+    if (!parsed.assets.some((ref) => ref.path === assetPath)) {
+      continue
+    }
+    if (parsed.frontmatter.private) {
+      return 'skip-private'
+    }
+    publicRefs += 1
+  }
+  return publicRefs > 0 ? 'send' : 'skip-unreferenced'
+}

--- a/packages/core/src/ai/chat/read-assets.ts
+++ b/packages/core/src/ai/chat/read-assets.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { classifyAssetFromNotes } from '../../actions/asset-description-helpers'
+import { classifyAssetFromNotes } from '../../actions/asset-privacy'
 import { isAppError } from '../../errors'
 import { descriptionPathFor, isAssetPath } from '../../graph/paths'
 import { splitFrontmatter } from '../../markdown/frontmatter'

--- a/packages/core/src/ai/chat/read-assets.ts
+++ b/packages/core/src/ai/chat/read-assets.ts
@@ -78,7 +78,9 @@ export interface ReadAssetDeps {
  * (`./`-prefixes, percent-escapes). Existence is checked next — a missing
  * sidecar reveals nothing — then the live privacy verdict over the
  * referencing notes (the sidecar on disk can predate a note turning private)
- * gates the mint, failing closed.
+ * gates the mint, failing closed. Once a sidecar exists, the verdict outranks
+ * everything else about it — even an empty body answers "unavailable", not
+ * "no description", when the asset is blocked.
  */
 export function buildReadOneAsset(deps: ReadAssetDeps) {
   return async function readOneAsset(path: string): Promise<ReadAssetResult> {
@@ -96,22 +98,23 @@ export function buildReadOneAsset(deps: ReadAssetDeps) {
       throw cause
     }
     const body = splitFrontmatter(source).body.trim()
-    if (body === '') {
-      return { ok: false, path, error: NO_ASSET_DESCRIPTION_ERROR }
-    }
     const candidates = await deps.assetReferencingNotePathsFn(canonical)
     const verdict = await classifyAssetFromNotes(canonical, candidates, deps.readNoteFn)
     const truncated = body.length > MAX_ASSET_DESCRIPTION_CHARS
     try {
-      return {
-        ok: true,
-        asset: cloudSafeAssetDescription({
-          path: canonical,
-          isPrivate: verdict !== 'send',
-          description: truncated ? body.slice(0, MAX_ASSET_DESCRIPTION_CHARS) : body,
-          truncated,
-        }),
+      const asset = cloudSafeAssetDescription({
+        path: canonical,
+        isPrivate: verdict !== 'send',
+        description: truncated ? body.slice(0, MAX_ASSET_DESCRIPTION_CHARS) : body,
+        truncated,
+      })
+      if (body === '') {
+        // An existing-but-empty sidecar reads as "no description" — but only
+        // for a sendable asset; a blocked one threw above, so the two miss
+        // messages stay consistent with the privacy contract.
+        return { ok: false, path, error: NO_ASSET_DESCRIPTION_ERROR }
       }
+      return { ok: true, asset }
     } catch (cause) {
       if (isPrivateNoteError(cause)) {
         return { ok: false, path, error: ASSET_UNAVAILABLE_ERROR }

--- a/packages/core/src/ai/chat/read-assets.ts
+++ b/packages/core/src/ai/chat/read-assets.ts
@@ -1,0 +1,117 @@
+import { z } from 'zod'
+import { classifyAssetFromNotes } from '../../actions/asset-description-helpers'
+import { isAppError } from '../../errors'
+import { descriptionPathFor, isAssetPath } from '../../graph/paths'
+import { splitFrontmatter } from '../../markdown/frontmatter'
+import {
+  cloudSafeAssetDescription,
+  isPrivateNoteError,
+  type CloudAssetDescription,
+  type CloudSafe,
+} from '../checkers'
+
+/**
+ * The read_assets tool's executor (Plan 20 meets Plan 10): resolve an
+ * `assets/…` path to its stored description sidecar (`<asset>.reflect.md`)
+ * and gate it for the provider. The tool registration, name, and transcript
+ * unions stay in `./tools` — this module only knows how to read one asset.
+ */
+
+/** Cap on assets one read_assets call returns, mirroring `MAX_READ_NOTES`. */
+export const MAX_READ_ASSETS = 10
+
+/**
+ * Cap on one asset's returned description text — the same bound the indexer
+ * puts on a note's folded asset text (`MAX_ASSET_TEXT_CHARS`), so the tool
+ * never returns wildly more than search could have matched on.
+ */
+export const MAX_ASSET_DESCRIPTION_CHARS = 8_000
+
+/** read_assets miss — the sidecar description file doesn't exist (yet). */
+export const NO_ASSET_DESCRIPTION_ERROR =
+  'No description exists for this asset yet — descriptions are generated in the background.'
+
+/**
+ * read_assets refusal for a blocked asset. Deliberately unspecific: naming the
+ * private reference would itself reveal that a private note exists, so the
+ * private and unreferenced verdicts share one message.
+ */
+export const ASSET_UNAVAILABLE_ERROR = 'This asset cannot be read by AI.'
+
+/** read_assets refusal for a path that is not an `assets/` attachment. */
+export const NOT_AN_ASSET_ERROR =
+  'Not an asset path — pass assets/… paths exactly as they appear in note markdown.'
+
+/** One asset in a {@link ReadAssetsOutput}: its stored description, or a structured miss/refusal. */
+export type ReadAssetResult =
+  | { ok: true; asset: CloudSafe<CloudAssetDescription> }
+  | { ok: false; path: string; error: string }
+
+/** The read_assets output: one {@link ReadAssetResult} per requested path, in order. */
+export interface ReadAssetsOutput {
+  assets: ReadAssetResult[]
+}
+
+export const readAssetsInput = z.object({
+  paths: z
+    .array(z.string().min(1))
+    .min(1)
+    .max(MAX_READ_ASSETS)
+    .describe(
+      'Graph-relative asset paths as they appear in note markdown, e.g. ' +
+        `["assets/photo.png"]. Pass every attachment you need in one call, up to ${MAX_READ_ASSETS}.`,
+    ),
+})
+
+/** The effects {@link buildReadOneAsset} needs, already defaulted by the caller. */
+export interface ReadAssetDeps {
+  readNoteFn: (path: string) => Promise<string>
+  assetReferencingNotePathsFn: (assetPath: string) => Promise<string[]>
+}
+
+/**
+ * Build the per-asset reader for read_assets: the sidecar body (frontmatter
+ * stripped, capped), or a structured per-asset miss/refusal. Existence is
+ * checked first — a missing sidecar reveals nothing — then the live privacy
+ * verdict over the referencing notes (the sidecar on disk can predate a note
+ * turning private) gates the mint, failing closed.
+ */
+export function buildReadOneAsset(deps: ReadAssetDeps) {
+  return async function readOneAsset(path: string): Promise<ReadAssetResult> {
+    if (!isAssetPath(path)) {
+      return { ok: false, path, error: NOT_AN_ASSET_ERROR }
+    }
+    let source: string
+    try {
+      source = await deps.readNoteFn(descriptionPathFor(path))
+    } catch (cause) {
+      if (isAppError(cause) && cause.kind === 'notFound') {
+        return { ok: false, path, error: NO_ASSET_DESCRIPTION_ERROR }
+      }
+      throw cause
+    }
+    const body = splitFrontmatter(source).body.trim()
+    if (body === '') {
+      return { ok: false, path, error: NO_ASSET_DESCRIPTION_ERROR }
+    }
+    const candidates = await deps.assetReferencingNotePathsFn(path)
+    const verdict = await classifyAssetFromNotes(path, candidates, deps.readNoteFn)
+    const truncated = body.length > MAX_ASSET_DESCRIPTION_CHARS
+    try {
+      return {
+        ok: true,
+        asset: cloudSafeAssetDescription({
+          path,
+          isPrivate: verdict !== 'send',
+          description: truncated ? body.slice(0, MAX_ASSET_DESCRIPTION_CHARS) : body,
+          truncated,
+        }),
+      }
+    } catch (cause) {
+      if (isPrivateNoteError(cause)) {
+        return { ok: false, path, error: ASSET_UNAVAILABLE_ERROR }
+      }
+      throw cause
+    }
+  }
+}

--- a/packages/core/src/ai/chat/read-assets.ts
+++ b/packages/core/src/ai/chat/read-assets.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { classifyAssetFromNotes } from '../../actions/asset-privacy'
 import { isAppError } from '../../errors'
 import { descriptionPathFor, isAssetPath } from '../../graph/paths'
+import { canonicalAssetPath } from '../../markdown/extract'
 import { splitFrontmatter } from '../../markdown/frontmatter'
 import {
   cloudSafeAssetDescription,
@@ -71,19 +72,23 @@ export interface ReadAssetDeps {
 
 /**
  * Build the per-asset reader for read_assets: the sidecar body (frontmatter
- * stripped, capped), or a structured per-asset miss/refusal. Existence is
- * checked first — a missing sidecar reveals nothing — then the live privacy
- * verdict over the referencing notes (the sidecar on disk can predate a note
- * turning private) gates the mint, failing closed.
+ * stripped, capped), or a structured per-asset miss/refusal. The model copies
+ * paths verbatim from note markdown, so the href is first collapsed to the
+ * canonical `assets/…` form the sidecar, index, and privacy gate all key off
+ * (`./`-prefixes, percent-escapes). Existence is checked next — a missing
+ * sidecar reveals nothing — then the live privacy verdict over the
+ * referencing notes (the sidecar on disk can predate a note turning private)
+ * gates the mint, failing closed.
  */
 export function buildReadOneAsset(deps: ReadAssetDeps) {
   return async function readOneAsset(path: string): Promise<ReadAssetResult> {
-    if (!isAssetPath(path)) {
+    const canonical = canonicalAssetPath(path)
+    if (canonical === null || !isAssetPath(canonical)) {
       return { ok: false, path, error: NOT_AN_ASSET_ERROR }
     }
     let source: string
     try {
-      source = await deps.readNoteFn(descriptionPathFor(path))
+      source = await deps.readNoteFn(descriptionPathFor(canonical))
     } catch (cause) {
       if (isAppError(cause) && cause.kind === 'notFound') {
         return { ok: false, path, error: NO_ASSET_DESCRIPTION_ERROR }
@@ -94,14 +99,14 @@ export function buildReadOneAsset(deps: ReadAssetDeps) {
     if (body === '') {
       return { ok: false, path, error: NO_ASSET_DESCRIPTION_ERROR }
     }
-    const candidates = await deps.assetReferencingNotePathsFn(path)
-    const verdict = await classifyAssetFromNotes(path, candidates, deps.readNoteFn)
+    const candidates = await deps.assetReferencingNotePathsFn(canonical)
+    const verdict = await classifyAssetFromNotes(canonical, candidates, deps.readNoteFn)
     const truncated = body.length > MAX_ASSET_DESCRIPTION_CHARS
     try {
       return {
         ok: true,
         asset: cloudSafeAssetDescription({
-          path,
+          path: canonical,
           isPrivate: verdict !== 'send',
           description: truncated ? body.slice(0, MAX_ASSET_DESCRIPTION_CHARS) : body,
           truncated,

--- a/packages/core/src/ai/chat/read-notes.ts
+++ b/packages/core/src/ai/chat/read-notes.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod'
+import { isAppError } from '../../errors'
+import { parseNote } from '../../markdown/extract'
+import { splitFrontmatter } from '../../markdown/frontmatter'
+import {
+  cloudSafeNoteContent,
+  isPrivateNoteError,
+  type CloudNoteContent,
+  type CloudSafe,
+} from '../checkers'
+
+/**
+ * The read_notes tool's executor (Plan 10): resolve a graph-relative note
+ * path to its body and gate it for the provider. The tool registration,
+ * name, and transcript unions stay in `./tools` — this module only knows how
+ * to read one note.
+ */
+
+/** Cap on returned note content so one huge note can't flood the context. */
+export const MAX_NOTE_CONTENT_CHARS = 24_000
+
+/**
+ * Cap on notes one read_notes call returns. Each note is itself capped at
+ * {@link MAX_NOTE_CONTENT_CHARS}, so this bounds a single batch read to roughly
+ * the per-turn token reserve — past it the model splits the read across calls.
+ */
+export const MAX_READ_NOTES = 10
+
+/** One note in a {@link ReadNotesOutput}: its content, or a structured refusal/miss. */
+export type ReadNoteResult =
+  | { ok: true; note: CloudSafe<CloudNoteContent> }
+  | { ok: false; path: string; error: string }
+
+/** The read_notes output: one {@link ReadNoteResult} per requested path, in order. */
+export interface ReadNotesOutput {
+  notes: ReadNoteResult[]
+}
+
+export const readNotesInput = z.object({
+  paths: z
+    .array(z.string().min(1))
+    .min(1)
+    .max(MAX_READ_NOTES)
+    .describe(
+      'Graph-relative note paths to read, e.g. ["notes/abc.md"] (from search_notes ' +
+        `results). Pass every note you need in one call, up to ${MAX_READ_NOTES}.`,
+    ),
+})
+
+/** The effects {@link buildReadOneNote} needs, already defaulted by the caller. */
+export interface ReadNoteDeps {
+  readNoteFn: (path: string) => Promise<string>
+}
+
+/**
+ * Build the per-note reader for read_notes: the body (frontmatter stripped,
+ * capped), or a structured per-note miss/refusal so one bad path never fails
+ * the batch. Content is minted CloudSafe only after the live private re-check.
+ */
+export function buildReadOneNote(deps: ReadNoteDeps) {
+  return async function readOneNote(path: string): Promise<ReadNoteResult> {
+    let source: string
+    try {
+      source = await deps.readNoteFn(path)
+    } catch (cause) {
+      if (isAppError(cause) && cause.kind === 'notFound') {
+        return { ok: false, path, error: 'No note exists at this path.' }
+      }
+      throw cause
+    }
+    const parsed = parseNote({ path, source })
+    const { body } = splitFrontmatter(source)
+    const truncated = body.length > MAX_NOTE_CONTENT_CHARS
+    try {
+      return {
+        ok: true,
+        note: cloudSafeNoteContent({
+          path,
+          isPrivate: parsed.frontmatter.private,
+          title: parsed.title,
+          content: truncated ? body.slice(0, MAX_NOTE_CONTENT_CHARS) : body,
+          truncated,
+        }),
+      }
+    } catch (cause) {
+      if (isPrivateNoteError(cause)) {
+        return { ok: false, path, error: 'This note is marked private and cannot be read by AI.' }
+      }
+      throw cause
+    }
+  }
+}

--- a/packages/core/src/ai/chat/system-prompt.test.ts
+++ b/packages/core/src/ai/chat/system-prompt.test.ts
@@ -42,6 +42,16 @@ describe('chatSystemPrompt', () => {
     expect(prompt).toContain('limited number of tool rounds')
   })
 
+  it('points attachment links at read_assets', () => {
+    const prompt = chatSystemPrompt({
+      today: '2026-06-12',
+      context: null,
+      semanticSearchEnabled: true,
+    })
+    expect(prompt).toContain('pass asset paths to read_assets')
+    expect(prompt).toContain('may mention your query only inside an attachment')
+  })
+
   it('describes lexical search when semantic search is disabled', () => {
     const prompt = chatSystemPrompt({
       today: '2026-06-12',

--- a/packages/core/src/ai/chat/system-prompt.ts
+++ b/packages/core/src/ai/chat/system-prompt.ts
@@ -36,6 +36,7 @@ export function chatSystemPrompt({
     'Grounding rules:',
     '- When a question could be answered by the user’s notes, look them up before answering: search_notes finds notes by topic or keyword, list_daily_notes finds daily notes in a date range (questions like “yesterday” or “last week”), and list_recent_notes shows what was edited lately. Call read_notes when you need notes’ full content.',
     searchNotesGuidance(semanticSearchEnabled),
+    '- Notes embed images and PDFs as markdown links under assets/, e.g. ![sketch](assets/sketch.png). The link alone tells you nothing about the file — pass asset paths to read_assets to get each attachment’s stored description and text transcription. Search also matches attachment text, so a matching note may mention your query only inside an attachment.',
     '- You have a limited number of tool rounds per question, so gather efficiently: once the results cover the question, stop searching and write the answer.',
     '- For “what have I written or worked on lately?”, call list_recent_notes with no tag — pass a tag only when the user names one. Tool inputs are plain values; there is no wildcard or operator syntax (never pass “*”).',
     '- Ground answers in what the tools return. If the notes don’t cover something, say so plainly instead of guessing.',

--- a/packages/core/src/ai/chat/tools.test.ts
+++ b/packages/core/src/ai/chat/tools.test.ts
@@ -357,6 +357,29 @@ describe('read_assets', () => {
     expect(output.asset.truncated).toBe(false)
   })
 
+  it('canonicalizes markdown-spelled paths to the indexed assets/… form', async () => {
+    const spacedSidecar = 'assets/chart one.png.reflect.md'
+    const tools = assetTools(
+      {
+        [SIDECAR]: `---\nreflectAsset: true\n---\n${DESCRIPTION_BODY}\n`,
+        [spacedSidecar]: `---\nreflectAsset: true\n---\n${DESCRIPTION_BODY}\n`,
+        'notes/deck.md': '# Deck\n\n![a](./assets/chart.png)\n\n![b](assets/chart%20one.png)\n',
+      },
+      ['notes/deck.md'],
+    )
+    for (const [spelled, canonical] of [
+      ['./assets/chart.png', ASSET],
+      ['assets/chart%20one.png', 'assets/chart one.png'],
+    ] as const) {
+      const output = await runReadAsset(tools, spelled)
+      if (!output.ok) {
+        expect.unreachable(`expected a successful read for ${spelled}`)
+      }
+      expect(output.asset.path).toBe(canonical)
+      expect(output.asset.description).toBe(DESCRIPTION_BODY)
+    }
+  })
+
   it('reads several assets in one call, isolating a per-asset miss', async () => {
     const tools = assetTools(
       {

--- a/packages/core/src/ai/chat/tools.test.ts
+++ b/packages/core/src/ai/chat/tools.test.ts
@@ -475,6 +475,18 @@ describe('read_assets', () => {
     expect(output.error).toBe(NO_ASSET_DESCRIPTION_ERROR)
   })
 
+  it('answers unavailable, not no-description, for a blocked asset with an empty sidecar', async () => {
+    const tools = assetTools(
+      { [SIDECAR]: '---\nreflectAsset: true\n---\n\n', [PRIVATE_PATH]: PRIVATE_REF },
+      [PRIVATE_PATH],
+    )
+    const output = await runReadAsset(tools, ASSET)
+    if (output.ok) {
+      expect.unreachable('expected a refusal')
+    }
+    expect(output.error).toBe(ASSET_UNAVAILABLE_ERROR)
+  })
+
   it('caps an oversized description and flags the cut', async () => {
     const tools = assetTools(
       {

--- a/packages/core/src/ai/chat/tools.test.ts
+++ b/packages/core/src/ai/chat/tools.test.ts
@@ -5,20 +5,24 @@ import type { DailyNoteRow, DailyNotesRange } from '../../indexing/queries'
 import type { RecentNoteRow, RecentNotesOptions } from '../../indexing/note-list'
 import {
   ASSET_UNAVAILABLE_ERROR,
-  buildNoteTools,
-  INVALID_TAG_ERROR,
   MAX_ASSET_DESCRIPTION_CHARS,
-  MAX_DAILY_NOTE_DAYS,
-  MAX_NOTE_CONTENT_CHARS,
   NO_ASSET_DESCRIPTION_ERROR,
   NOT_AN_ASSET_ERROR,
+  type ReadAssetResult,
+  type ReadAssetsOutput,
+} from './read-assets'
+import {
+  MAX_NOTE_CONTENT_CHARS,
+  type ReadNoteResult,
+  type ReadNotesOutput,
+} from './read-notes'
+import {
+  buildNoteTools,
+  INVALID_TAG_ERROR,
+  MAX_DAILY_NOTE_DAYS,
   type ListDailyNotesOutput,
   type ListRecentNotesOutput,
   type NoteTools,
-  type ReadAssetResult,
-  type ReadAssetsOutput,
-  type ReadNoteResult,
-  type ReadNotesOutput,
   type SearchNotesOutput,
 } from './tools'
 

--- a/packages/core/src/ai/chat/tools.test.ts
+++ b/packages/core/src/ai/chat/tools.test.ts
@@ -4,13 +4,19 @@ import type { RetrievalHit, RetrieveOptions } from '../../embeddings/retrieve'
 import type { DailyNoteRow, DailyNotesRange } from '../../indexing/queries'
 import type { RecentNoteRow, RecentNotesOptions } from '../../indexing/note-list'
 import {
+  ASSET_UNAVAILABLE_ERROR,
   buildNoteTools,
   INVALID_TAG_ERROR,
+  MAX_ASSET_DESCRIPTION_CHARS,
   MAX_DAILY_NOTE_DAYS,
   MAX_NOTE_CONTENT_CHARS,
+  NO_ASSET_DESCRIPTION_ERROR,
+  NOT_AN_ASSET_ERROR,
   type ListDailyNotesOutput,
   type ListRecentNotesOutput,
   type NoteTools,
+  type ReadAssetResult,
+  type ReadAssetsOutput,
   type ReadNoteResult,
   type ReadNotesOutput,
   type SearchNotesOutput,
@@ -102,6 +108,28 @@ async function runRead(tools: NoteTools, path: string): Promise<ReadNoteResult> 
     throw new Error('read_notes returned no notes')
   }
   return note
+}
+
+/** Execute `read_assets` directly, asserting a non-streaming output. */
+async function runReadAssets(tools: NoteTools, paths: string[]): Promise<ReadAssetsOutput> {
+  const execute = tools.read_assets.execute
+  if (!execute) {
+    throw new Error('read_assets has no execute')
+  }
+  const output = await execute({ paths }, CALL)
+  if (isAsyncIterable(output)) {
+    throw new Error('unexpected streaming tool output')
+  }
+  return output
+}
+
+/** Read a single asset via `read_assets`, returning its lone result. */
+async function runReadAsset(tools: NoteTools, path: string): Promise<ReadAssetResult> {
+  const [asset] = (await runReadAssets(tools, [path])).assets
+  if (asset === undefined) {
+    throw new Error('read_assets returned no assets')
+  }
+  return asset
 }
 
 /** Execute `list_recent_notes` directly, asserting a non-streaming output. */
@@ -284,6 +312,156 @@ describe('read_notes', () => {
     }
     expect(output.note.content.length).toBe(MAX_NOTE_CONTENT_CHARS)
     expect(output.note.truncated).toBe(true)
+  })
+})
+
+describe('read_assets', () => {
+  const ASSET = 'assets/chart.png'
+  const SIDECAR = 'assets/chart.png.reflect.md'
+  const DESCRIPTION_BODY = 'sentinel-description-01jxq3'
+  const PUBLIC_REF = '# Board deck\n\n![chart](assets/chart.png)\n'
+  const PRIVATE_REF = `---\nprivate: true\n---\n# Diary\n\n![chart](assets/chart.png)\n`
+
+  /** Tools over an in-memory file map + a fixed referencing-notes answer. */
+  function assetTools(files: Record<string, string>, refs: string[]): NoteTools {
+    return buildNoteTools({
+      readNoteFn: async (path) => {
+        const source = files[path]
+        if (source === undefined) {
+          throw { kind: 'notFound', message: 'no such file' }
+        }
+        return source
+      },
+      assetReferencingNotePathsFn: async () => refs,
+    })
+  }
+
+  it('returns the sidecar body without frontmatter for a public-referenced asset', async () => {
+    const tools = assetTools(
+      {
+        [SIDECAR]: `---\nreflectAsset: true\nsource: ${ASSET}\n---\nA bar chart.\n\nOCR: ${DESCRIPTION_BODY}\n`,
+        'notes/deck.md': PUBLIC_REF,
+      },
+      ['notes/deck.md'],
+    )
+    const output = await runReadAsset(tools, ASSET)
+    if (!output.ok) {
+      expect.unreachable('expected a successful read')
+    }
+    expect(output.asset.path).toBe(ASSET)
+    expect(output.asset.description).toBe(`A bar chart.\n\nOCR: ${DESCRIPTION_BODY}`)
+    expect(output.asset.truncated).toBe(false)
+  })
+
+  it('reads several assets in one call, isolating a per-asset miss', async () => {
+    const tools = assetTools(
+      {
+        [SIDECAR]: `---\nreflectAsset: true\n---\n${DESCRIPTION_BODY}\n`,
+        'notes/deck.md': PUBLIC_REF,
+      },
+      ['notes/deck.md'],
+    )
+    const output = await runReadAssets(tools, [ASSET, 'assets/undescribed.pdf'])
+    expect(output.assets.map((asset) => asset.ok)).toEqual([true, false])
+    expect(output.assets[1]).toMatchObject({
+      ok: false,
+      path: 'assets/undescribed.pdf',
+      error: NO_ASSET_DESCRIPTION_ERROR,
+    })
+  })
+
+  it('refuses when any referencing note is private — live, and without the description', async () => {
+    const tools = assetTools(
+      {
+        [SIDECAR]: `---\nreflectAsset: true\n---\n${DESCRIPTION_BODY}\n`,
+        'notes/deck.md': PUBLIC_REF,
+        [PRIVATE_PATH]: PRIVATE_REF,
+      },
+      ['notes/deck.md', PRIVATE_PATH],
+    )
+    const output = await runReadAsset(tools, ASSET)
+    if (output.ok) {
+      expect.unreachable('expected a refusal')
+    }
+    expect(output.error).toBe(ASSET_UNAVAILABLE_ERROR)
+    expect(JSON.stringify(output)).not.toContain(DESCRIPTION_BODY)
+  })
+
+  it('refuses an asset no note references, with the same unspecific message', async () => {
+    const tools = assetTools(
+      { [SIDECAR]: `---\nreflectAsset: true\n---\n${DESCRIPTION_BODY}\n` },
+      [],
+    )
+    const output = await runReadAsset(tools, ASSET)
+    if (output.ok) {
+      expect.unreachable('expected a refusal')
+    }
+    expect(output.error).toBe(ASSET_UNAVAILABLE_ERROR)
+    expect(JSON.stringify(output)).not.toContain(DESCRIPTION_BODY)
+  })
+
+  it('fails closed when a referencing note cannot be read', async () => {
+    const tools = buildNoteTools({
+      readNoteFn: async (path) => {
+        if (path === SIDECAR) {
+          return `---\nreflectAsset: true\n---\n${DESCRIPTION_BODY}\n`
+        }
+        throw { kind: 'io', message: 'disk error' }
+      },
+      assetReferencingNotePathsFn: async () => ['notes/deck.md'],
+    })
+    const output = await runReadAsset(tools, ASSET)
+    if (output.ok) {
+      expect.unreachable('expected a refusal')
+    }
+    expect(output.error).toBe(ASSET_UNAVAILABLE_ERROR)
+  })
+
+  it('rejects a non-asset path without touching the filesystem', async () => {
+    const reads: string[] = []
+    const tools = buildNoteTools({
+      readNoteFn: async (path) => {
+        reads.push(path)
+        throw { kind: 'notFound', message: 'no such file' }
+      },
+      assetReferencingNotePathsFn: async () => [],
+    })
+    for (const path of ['notes/secret.md', 'assets/chart.png.reflect.md']) {
+      const output = await runReadAsset(tools, path)
+      if (output.ok) {
+        expect.unreachable('expected a refusal')
+      }
+      expect(output.error).toBe(NOT_AN_ASSET_ERROR)
+    }
+    expect(reads).toEqual([])
+  })
+
+  it('treats an empty sidecar body as no description', async () => {
+    const tools = assetTools(
+      { [SIDECAR]: '---\nreflectAsset: true\n---\n\n', 'notes/deck.md': PUBLIC_REF },
+      ['notes/deck.md'],
+    )
+    const output = await runReadAsset(tools, ASSET)
+    if (output.ok) {
+      expect.unreachable('expected a miss')
+    }
+    expect(output.error).toBe(NO_ASSET_DESCRIPTION_ERROR)
+  })
+
+  it('caps an oversized description and flags the cut', async () => {
+    const tools = assetTools(
+      {
+        [SIDECAR]: 'x'.repeat(MAX_ASSET_DESCRIPTION_CHARS + 10),
+        'notes/deck.md': PUBLIC_REF,
+      },
+      ['notes/deck.md'],
+    )
+    const output = await runReadAsset(tools, ASSET)
+    if (!output.ok) {
+      expect.unreachable('expected a successful read')
+    }
+    expect(output.asset.description.length).toBe(MAX_ASSET_DESCRIPTION_CHARS)
+    expect(output.asset.truncated).toBe(true)
   })
 })
 

--- a/packages/core/src/ai/chat/tools.ts
+++ b/packages/core/src/ai/chat/tools.ts
@@ -1,43 +1,31 @@
 import { tool, type TypedToolCall, type TypedToolResult } from 'ai'
 import { z } from 'zod'
-import { isAppError } from '../../errors'
 import { readNote } from '../../graph/commands'
 import { retrieve, type RetrievalHit, type RetrieveOptions } from '../../embeddings/retrieve'
 import { assetReferencingNotePaths } from '../../indexing/asset-refs'
 import { listDailyNotes, type DailyNoteRow, type DailyNotesRange } from '../../indexing/queries'
 import { listRecentNotes, type RecentNoteRow, type RecentNotesOptions } from '../../indexing/note-list'
 import { parseFrontmatter, splitFrontmatter } from '../../markdown/frontmatter'
-import { isTagName, parseNote } from '../../markdown/extract'
+import { isTagName } from '../../markdown/extract'
 import { buildReadOneAsset, readAssetsInput, type ReadAssetsOutput } from './read-assets'
+import { buildReadOneNote, readNotesInput, type ReadNotesOutput } from './read-notes'
 import {
-  cloudSafeNoteContent,
   cloudSafeNoteListings,
   cloudSafeSearchHits,
-  isPrivateNoteError,
-  type CloudNoteContent,
   type CloudNoteListing,
   type CloudSafe,
   type CloudSearchHit,
   type CloudSendable,
 } from '../checkers'
 
-export {
-  ASSET_UNAVAILABLE_ERROR,
-  MAX_ASSET_DESCRIPTION_CHARS,
-  MAX_READ_ASSETS,
-  NO_ASSET_DESCRIPTION_ERROR,
-  NOT_AN_ASSET_ERROR,
-  type ReadAssetResult,
-  type ReadAssetsOutput,
-} from './read-assets'
-
 /**
  * The read-only note tools the chat model can call (Plan 10, first wave),
  * and — deliberately in the same module — everything else that knows their
  * names: the {@link NoteToolCall}/{@link NoteToolResult} unions the engine
  * streams and the UI renders, and the mappers from SDK stream parts onto
- * them. Adding a tool means extending this file and the chip that renders
- * it; nothing else switches on tool names.
+ * them. Adding a tool means registering it here (batch executors live in
+ * sibling `read-*.ts` modules) and extending the chip that renders it;
+ * nothing else switches on tool names.
  *
  * Note content enters tool outputs only as {@link CloudSafe} values, minted
  * by the privacy gate in `../checkers` — search drops private hits entirely,
@@ -54,16 +42,6 @@ const MAX_RECENT_LIMIT = 20
 
 /** Most days one daily-range call returns; past it the model narrows the range. */
 export const MAX_DAILY_NOTE_DAYS = 31
-
-/** Cap on returned note content so one huge note can't flood the context. */
-export const MAX_NOTE_CONTENT_CHARS = 24_000
-
-/**
- * Cap on notes one read_notes call returns. Each note is itself capped at
- * {@link MAX_NOTE_CONTENT_CHARS}, so this bounds a single batch read to roughly
- * the per-turn token reserve — past it the model splits the read across calls.
- */
-export const MAX_READ_NOTES = 10
 
 /** Injectable effects so tests can drive the tools without a live bridge. */
 export interface NoteToolDeps {
@@ -84,16 +62,6 @@ export interface BuildNoteToolsOptions extends NoteToolDeps {
 
 export interface SearchNotesOutput {
   hits: CloudSafe<CloudSearchHit>[]
-}
-
-/** One note in a {@link ReadNotesOutput}: its content, or a structured refusal/miss. */
-export type ReadNoteResult =
-  | { ok: true; note: CloudSafe<CloudNoteContent> }
-  | { ok: false; path: string; error: string }
-
-/** The read_notes output: one {@link ReadNoteResult} per requested path, in order. */
-export interface ReadNotesOutput {
-  notes: ReadNoteResult[]
 }
 
 /**
@@ -125,17 +93,6 @@ const searchNotesInput = z.object({
     .max(MAX_SEARCH_LIMIT)
     .optional()
     .describe(`How many notes to return (default ${DEFAULT_SEARCH_LIMIT})`),
-})
-
-const readNotesInput = z.object({
-  paths: z
-    .array(z.string().min(1))
-    .min(1)
-    .max(MAX_READ_NOTES)
-    .describe(
-      'Graph-relative note paths to read, e.g. ["notes/abc.md"] (from search_notes ' +
-        `results). Pass every note you need in one call, up to ${MAX_READ_NOTES}.`,
-    ),
 })
 
 const listRecentNotesInput = z.object({
@@ -203,40 +160,7 @@ export function buildNoteTools(options: BuildNoteToolsOptions = {}) {
     }
   }
 
-  // Read one note for read_notes: its body (frontmatter stripped, capped), or
-  // a structured per-note miss/refusal so one bad path never fails the batch.
-  // Content is minted CloudSafe only after the live private re-check.
-  const readOneNote = async (path: string): Promise<ReadNoteResult> => {
-    let source: string
-    try {
-      source = await readNoteFn(path)
-    } catch (cause) {
-      if (isAppError(cause) && cause.kind === 'notFound') {
-        return { ok: false, path, error: 'No note exists at this path.' }
-      }
-      throw cause
-    }
-    const parsed = parseNote({ path, source })
-    const { body } = splitFrontmatter(source)
-    const truncated = body.length > MAX_NOTE_CONTENT_CHARS
-    try {
-      return {
-        ok: true,
-        note: cloudSafeNoteContent({
-          path,
-          isPrivate: parsed.frontmatter.private,
-          title: parsed.title,
-          content: truncated ? body.slice(0, MAX_NOTE_CONTENT_CHARS) : body,
-          truncated,
-        }),
-      }
-    } catch (cause) {
-      if (isPrivateNoteError(cause)) {
-        return { ok: false, path, error: 'This note is marked private and cannot be read by AI.' }
-      }
-      throw cause
-    }
-  }
+  const readOneNote = buildReadOneNote({ readNoteFn })
 
   const readOneAsset = buildReadOneAsset({
     readNoteFn,

--- a/packages/core/src/ai/chat/tools.ts
+++ b/packages/core/src/ai/chat/tools.ts
@@ -3,10 +3,12 @@ import { z } from 'zod'
 import { isAppError } from '../../errors'
 import { readNote } from '../../graph/commands'
 import { retrieve, type RetrievalHit, type RetrieveOptions } from '../../embeddings/retrieve'
+import { assetReferencingNotePaths } from '../../indexing/asset-refs'
 import { listDailyNotes, type DailyNoteRow, type DailyNotesRange } from '../../indexing/queries'
 import { listRecentNotes, type RecentNoteRow, type RecentNotesOptions } from '../../indexing/note-list'
 import { parseFrontmatter, splitFrontmatter } from '../../markdown/frontmatter'
 import { isTagName, parseNote } from '../../markdown/extract'
+import { buildReadOneAsset, readAssetsInput, type ReadAssetsOutput } from './read-assets'
 import {
   cloudSafeNoteContent,
   cloudSafeNoteListings,
@@ -18,6 +20,16 @@ import {
   type CloudSearchHit,
   type CloudSendable,
 } from '../checkers'
+
+export {
+  ASSET_UNAVAILABLE_ERROR,
+  MAX_ASSET_DESCRIPTION_CHARS,
+  MAX_READ_ASSETS,
+  NO_ASSET_DESCRIPTION_ERROR,
+  NOT_AN_ASSET_ERROR,
+  type ReadAssetResult,
+  type ReadAssetsOutput,
+} from './read-assets'
 
 /**
  * The read-only note tools the chat model can call (Plan 10, first wave),
@@ -59,6 +71,7 @@ export interface NoteToolDeps {
   readNoteFn?: (path: string) => Promise<string>
   listRecentNotesFn?: (options: RecentNotesOptions) => Promise<RecentNoteRow[]>
   listDailyNotesFn?: (range: DailyNotesRange) => Promise<DailyNoteRow[]>
+  assetReferencingNotePathsFn?: (assetPath: string) => Promise<string[]>
 }
 
 export interface BuildNoteToolsOptions extends NoteToolDeps {
@@ -173,6 +186,7 @@ export function buildNoteTools(options: BuildNoteToolsOptions = {}) {
   const readNoteFn = options.readNoteFn ?? readNote
   const listRecentNotesFn = options.listRecentNotesFn ?? listRecentNotes
   const listDailyNotesFn = options.listDailyNotesFn ?? listDailyNotes
+  const assetRefsFn = options.assetReferencingNotePathsFn ?? assetReferencingNotePaths
   const searchMode: RetrieveOptions['mode'] =
     options.semanticSearchEnabled === false ? 'lexical' : 'hybrid'
 
@@ -223,6 +237,11 @@ export function buildNoteTools(options: BuildNoteToolsOptions = {}) {
       throw cause
     }
   }
+
+  const readOneAsset = buildReadOneAsset({
+    readNoteFn,
+    assetReferencingNotePathsFn: assetRefsFn,
+  })
 
   return {
     search_notes: tool({
@@ -288,6 +307,19 @@ export function buildNoteTools(options: BuildNoteToolsOptions = {}) {
         return { notes: await Promise.all(paths.map(readOneNote)) }
       },
     }),
+
+    read_assets: tool({
+      description:
+        'Read the stored text description and OCR transcription of image or PDF ' +
+        'attachments that notes embed as assets/… markdown links, e.g. ' +
+        '![sketch](assets/sketch.png). Returns descriptive text about each file, not ' +
+        'the file itself. Pass every attachment you need in a single call. ' +
+        'Attachments of private notes cannot be read.',
+      inputSchema: readAssetsInput,
+      execute: async ({ paths }): Promise<ReadAssetsOutput> => {
+        return { assets: await Promise.all(paths.map(readOneAsset)) }
+      },
+    }),
   }
 }
 
@@ -315,10 +347,18 @@ export interface ReadNoteSummary {
   error: string | null
 }
 
+/** One asset's outcome in a read_assets call, for the tool-activity UI. */
+export interface ReadAssetSummary {
+  path: string
+  /** The per-asset refusal/miss text, or `null` when the read succeeded. */
+  error: string | null
+}
+
 /** One tool invocation, as the transcript sees it. */
 export type NoteToolCall =
   | { tool: 'search'; toolCallId: string; query: string }
   | { tool: 'read'; toolCallId: string; paths: string[] }
+  | { tool: 'assets'; toolCallId: string; paths: string[] }
   | { tool: 'recents'; toolCallId: string; tag: string | null }
   | { tool: 'dailies'; toolCallId: string; start: string; end: string }
 
@@ -326,6 +366,7 @@ export type NoteToolCall =
 export type NoteToolResult =
   | { tool: 'search'; toolCallId: string; query: string; hits: NoteHitSummary[] }
   | { tool: 'read'; toolCallId: string; notes: ReadNoteSummary[] }
+  | { tool: 'assets'; toolCallId: string; assets: ReadAssetSummary[] }
   | {
       tool: 'recents'
       toolCallId: string
@@ -345,6 +386,8 @@ export function noteToolCall(part: TypedToolCall<NoteTools>): NoteToolCall | nul
       return { tool: 'search', toolCallId: part.toolCallId, query: part.input.query }
     case 'read_notes':
       return { tool: 'read', toolCallId: part.toolCallId, paths: part.input.paths }
+    case 'read_assets':
+      return { tool: 'assets', toolCallId: part.toolCallId, paths: part.input.paths }
     case 'list_recent_notes':
       return { tool: 'recents', toolCallId: part.toolCallId, tag: part.input.tag ?? null }
     case 'list_daily_notes':
@@ -383,6 +426,16 @@ export function noteToolResult(part: TypedToolResult<NoteTools>): NoteToolResult
           entry.ok
             ? { path: entry.note.path, title: entry.note.title, error: null }
             : { path: entry.path, title: null, error: entry.error },
+        ),
+      }
+    case 'read_assets':
+      return {
+        tool: 'assets',
+        toolCallId: part.toolCallId,
+        assets: part.output.assets.map((entry) =>
+          entry.ok
+            ? { path: entry.asset.path, error: null }
+            : { path: entry.path, error: entry.error },
         ),
       }
     case 'list_recent_notes': {

--- a/packages/core/src/ai/checkers.test.ts
+++ b/packages/core/src/ai/checkers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { RetrievalHit } from '../embeddings/retrieve'
 import {
   assertCloudAllowed,
+  cloudSafeAssetDescription,
   cloudSafeNoteContent,
   cloudSafeSearchHits,
   cloudSafeSelection,
@@ -121,6 +122,34 @@ describe('cloudSafeNoteContent', () => {
         isPrivate: true,
         title: PRIVATE_TITLE,
         content: PRIVATE_BODY,
+        truncated: false,
+      }),
+    ).toThrow(PrivateNoteError)
+  })
+})
+
+describe('cloudSafeAssetDescription', () => {
+  it('mints a description for a sendable asset', () => {
+    expect(
+      cloudSafeAssetDescription({
+        path: 'assets/chart.png',
+        isPrivate: false,
+        description: 'A bar chart of Q4 revenue.',
+        truncated: false,
+      }),
+    ).toEqual({
+      path: 'assets/chart.png',
+      description: 'A bar chart of Q4 revenue.',
+      truncated: false,
+    })
+  })
+
+  it('refuses to mint a blocked asset before any description escapes', () => {
+    expect(() =>
+      cloudSafeAssetDescription({
+        path: 'assets/secret.png',
+        isPrivate: true,
+        description: PRIVATE_BODY,
         truncated: false,
       }),
     ).toThrow(PrivateNoteError)

--- a/packages/core/src/ai/checkers.ts
+++ b/packages/core/src/ai/checkers.ts
@@ -190,6 +190,35 @@ export function cloudSafeNoteContent(
   })
 }
 
+/** One asset's stored description as an external service may see it. */
+export interface CloudAssetDescription {
+  /** Graph-relative asset path, e.g. `assets/photo.png`. */
+  path: string
+  /** The description file's markdown body (frontmatter stripped, capped). */
+  description: string
+  truncated: boolean
+}
+
+/**
+ * Gate one asset's stored description (Plan 20's `<asset>.reflect.md`) for an
+ * outbound payload. Callers pass the asset's **live** privacy verdict as
+ * `isPrivate` — sendable only when the asset is referenced by ≥1 public note
+ * and 0 private notes, decided from each referencing note's markdown at call
+ * time (`classifyAssetFromNotes`), because the sidecar on disk can predate a
+ * note turning private. A blocked asset throws {@link PrivateNoteError}
+ * before any description text is minted.
+ */
+export function cloudSafeAssetDescription(
+  asset: CloudSendable & Omit<CloudAssetDescription, 'path'>,
+): CloudSafe<CloudAssetDescription> {
+  assertCloudAllowed(asset)
+  return mint({
+    path: asset.path,
+    description: asset.description,
+    truncated: asset.truncated,
+  })
+}
+
 /**
  * Gate a text selection (the AI menu's editor selection) for an outbound
  * payload. The selection is note content, so the same contract as

--- a/packages/core/src/exports/ai-actions.ts
+++ b/packages/core/src/exports/ai-actions.ts
@@ -30,6 +30,7 @@ export {
 export { validateApiKey, type ApiKeyValidation } from '../ai/validate-key'
 export {
   assertCloudAllowed,
+  cloudSafeAssetDescription,
   cloudSafeGraphContext,
   cloudSafeNoteContent,
   cloudSafeNoteListings,
@@ -37,6 +38,7 @@ export {
   cloudSafeSelection,
   isPrivateNoteError,
   PrivateNoteError,
+  type CloudAssetDescription,
   type CloudGraphContext,
   type CloudNoteContent,
   type CloudNoteListing,
@@ -46,8 +48,10 @@ export {
 } from '../ai/checkers'
 export {
   buildNoteTools,
+  MAX_ASSET_DESCRIPTION_CHARS,
   MAX_DAILY_NOTE_DAYS,
   MAX_NOTE_CONTENT_CHARS,
+  MAX_READ_ASSETS,
   MAX_READ_NOTES,
   type ListDailyNotesOutput,
   type ListRecentNotesOutput,
@@ -56,6 +60,9 @@ export {
   type NoteToolDeps,
   type NoteToolResult,
   type NoteTools,
+  type ReadAssetResult,
+  type ReadAssetsOutput,
+  type ReadAssetSummary,
   type ReadNoteResult,
   type ReadNoteSummary,
   type ReadNotesOutput,

--- a/packages/core/src/exports/ai-actions.ts
+++ b/packages/core/src/exports/ai-actions.ts
@@ -48,11 +48,7 @@ export {
 } from '../ai/checkers'
 export {
   buildNoteTools,
-  MAX_ASSET_DESCRIPTION_CHARS,
   MAX_DAILY_NOTE_DAYS,
-  MAX_NOTE_CONTENT_CHARS,
-  MAX_READ_ASSETS,
-  MAX_READ_NOTES,
   type ListDailyNotesOutput,
   type ListRecentNotesOutput,
   type NoteHitSummary,
@@ -60,14 +56,22 @@ export {
   type NoteToolDeps,
   type NoteToolResult,
   type NoteTools,
-  type ReadAssetResult,
-  type ReadAssetsOutput,
   type ReadAssetSummary,
-  type ReadNoteResult,
   type ReadNoteSummary,
-  type ReadNotesOutput,
   type SearchNotesOutput,
 } from '../ai/chat/tools'
+export {
+  MAX_NOTE_CONTENT_CHARS,
+  MAX_READ_NOTES,
+  type ReadNoteResult,
+  type ReadNotesOutput,
+} from '../ai/chat/read-notes'
+export {
+  MAX_ASSET_DESCRIPTION_CHARS,
+  MAX_READ_ASSETS,
+  type ReadAssetResult,
+  type ReadAssetsOutput,
+} from '../ai/chat/read-assets'
 export { chatSystemPrompt, type SystemPromptInput } from '../ai/chat/system-prompt'
 export {
   loadChatGraphContext,

--- a/packages/core/src/indexing/asset-description-text.ts
+++ b/packages/core/src/indexing/asset-description-text.ts
@@ -10,7 +10,9 @@ import { splitFrontmatter } from '../markdown/frontmatter'
  * so a query matching a description surfaces the note — transparently, as an
  * ordinary hit. The same bodies feed the note's embedding chunks (the semantic
  * leg), so lexical and semantic retrieval see the same asset text. It never
- * enters the All-Notes preview or the AI-readable note *content*.
+ * enters the All-Notes preview or the note *content* AI reads — chat reaches
+ * description text solely through the read_assets tool
+ * (`ai/chat/read-assets.ts`), behind its own live privacy gate.
  */
 
 /** Cap on folded description text per note (chars) — bounds the FTS document. */

--- a/packages/core/src/indexing/indexed-note.ts
+++ b/packages/core/src/indexing/indexed-note.ts
@@ -139,8 +139,9 @@ export const indexedNoteSchema = z.object({
   text: z.string(),
   /**
    * Description text of the note's referenced assets (Plan 20), folded into the
-   * FTS `body` only — not the preview or AI-reachable text. Empty when the note
-   * has no described assets.
+   * FTS `body` only — not the preview or the note text AI reads (chat reaches
+   * descriptions solely via the read_assets tool and its live privacy gate).
+   * Empty when the note has no described assets.
    */
   assetText: z.string(),
   /** The All Notes row snippet, derived once here rather than per query. */

--- a/packages/core/src/markdown/extract.ts
+++ b/packages/core/src/markdown/extract.ts
@@ -138,6 +138,18 @@ function decodeAssetPath(href: string): string {
   return segments.join('/')
 }
 
+/**
+ * The canonical on-disk path for an asset href, or `null` when the href is
+ * not an asset link at all. The public entry point for callers holding an
+ * href copied from raw markdown — e.g. the chat read_assets tool, whose
+ * model-supplied paths are the verbatim link targets from note bodies —
+ * applying the same {@link decodeAssetPath} rule the index projection uses,
+ * so every spelling resolves to the indexed key.
+ */
+export function canonicalAssetPath(href: string): string | null {
+  return isAssetHref(href) ? decodeAssetPath(href) : null
+}
+
 function stringField(frontmatter: Frontmatter, key: string): string | undefined {
   const value = (frontmatter as Record<string, unknown>)[key]
   return typeof value === 'string' ? value : undefined
@@ -339,8 +351,9 @@ export function parseNote(input: { path: string; source: string }): ParsedNote {
       if (name === 'Link' || name === 'Image') {
         const link = readLink(body, from, to, bodyOffset)
         if (link) {
-          if (isAssetHref(link.href)) {
-            assets.push({ path: decodeAssetPath(link.href), from: link.from, to: link.to })
+          const assetPath = canonicalAssetPath(link.href)
+          if (assetPath !== null) {
+            assets.push({ path: assetPath, from: link.from, to: link.to })
           } else {
             links.push(link)
           }


### PR DESCRIPTION
## Problem

Asset descriptions (Plan 20) are searchable but invisible to AI chat. Each described image/PDF gets a `<asset>.reflect.md` sidecar whose body is folded into the note's FTS document, so `search_notes` can surface a note *because of* its attachment's OCR text — but when the model then calls `read_notes`, it receives only the bare `![…](assets/…)` link. The model ends up holding a snippet quoting text that appears nowhere in the note it just read, and it has no way to learn what any attachment contains.

This PR closes the loop for chat. The semantic (embedding) search leg landed separately in #632; this branch is rebased on it, and the shared indexing doc comments reflect both.

## Before → After

| | Before | After |
|---|---|---|
| Model sees `![chart](assets/chart.png)` in a note | A dead string | Can call `read_assets` with the path and get the stored description + OCR |
| Search hit matched via attachment text | Unexplainable to the model | System prompt tells it a match "may mention your query only inside an attachment" and points at `read_assets` |
| Chat UI | — | A paperclip chip: `Read chart.png, scan.pdf`, with per-asset refusals inline |

## Changes

1. **`read_assets` tool** (new `packages/core/src/ai/chat/read-assets.ts`, registered in `tools.ts`). Batch tool mirroring `read_notes`: up to 10 asset paths per call, one structured result per path (body with frontmatter stripped, capped at 8 000 chars — the same bound the indexer puts on folded asset text). Misses and refusals are per-asset, so one bad path never fails the batch. Model-supplied paths are collapsed to the canonical `assets/…` form via the exported `canonicalAssetPath` (the same rule `parseNote` applies), so `./`-prefixed or percent-encoded spellings copied from raw markdown still resolve. Model-supplied paths are collapsed to the canonical `assets/…` form via the exported `canonicalAssetPath` (the same rule `parseNote` applies), so `./`-prefixed or percent-encoded spellings copied from raw markdown still resolve.
2. **Live privacy gate** (`checkers.ts` `cloudSafeAssetDescription`, new `actions/asset-privacy.ts`). The description-generation pass already refuses assets referenced by any private note, but a sidecar on disk can predate a note turning private. The tool therefore re-runs the same verdict at read time — candidates from the index, each candidate's frontmatter and asset reference re-read from disk, failing closed — before the `CloudSafe` mint. The verdict (`classifyAsset`/`classifyAssetFromNotes`/`AssetVerdict`) now lives in its own `asset-privacy.ts` module since it's shared contract between the generation pass and the chat read path.
3. **Deliberately unspecific refusal.** A blocked asset answers `This asset cannot be read by AI.` for both the private and unreferenced verdicts — naming the private reference would itself reveal that a private note exists. A missing sidecar gets a distinct "no description yet" miss, which reveals nothing.
4. **Tool-module shape.** Per-item executors live in sibling `read-notes.ts`/`read-assets.ts` modules; `tools.ts` is registration + tool names + transcript unions + mappers only (its documented contract). `read_notes` behavior is unchanged — its executor just moved.
5. **Honest invariant comments.** `asset-description-text.ts`, `indexed-note.ts`, and a Plan 20 addendum previously said asset text is "never AI-reachable"; they now say what's true post-PR: note text and previews are never widened, and chat reaches descriptions only through the gated tool.
6. **System prompt** gains one grounding bullet explaining `assets/…` links, `read_assets`, and why a search hit may only match inside an attachment.
7. **Tool chip** (`chat-tool-chip.tsx`): paperclip icon, entries labeled by filename, per-asset refusals inline. Assets have no note route, so entries stay plain text.

## Tests

- `tools.test.ts`: sidecar body returned without frontmatter; per-asset miss isolation in a batch; live private-reference refusal (payload asserted to not contain the description sentinel); unreferenced refusal with the same unspecific message; fail-closed on an unreadable referencing note; non-asset paths rejected without touching the filesystem; empty sidecar treated as no description; oversize cap + `truncated` flag.
- `checkers.test.ts`: `cloudSafeAssetDescription` mints a sendable asset, throws `PrivateNoteError` before a blocked description escapes.
- `system-prompt.test.ts`: prompt points attachment links at `read_assets`.
- `chat-screen.test.tsx`: attachment chip renders filenames with a per-asset refusal inline.

## Verification

- `pnpm --filter @reflect/core test --run src/ai/chat/ src/ai/checkers.test.ts src/actions/` — 281 tests pass (re-run after the refactor commit).
- `pnpm --filter @reflect/desktop test --run src/components/chat/chat-screen.test.tsx` — 19 tests pass.
- `pnpm check` — typecheck + lint clean.
- Pre-existing, unrelated failure on `next`: `src/ai/language-model.test.ts` expects `https://api.anthropic.com/v1/messages`, gets `…/messages` (fails identically on a clean tree).

## Risk / Rollout

No schema, migration, or settings changes; the tool is additive and read-only. Privacy exposure is the main risk surface: description text leaves the device only through the new `CloudSafe` mint, behind the same referenced-by-public-notes-only verdict the generation pass uses, re-checked live per call. Not yet exercised against a live provider in the app — worth a manual chat pass with a described asset before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New outbound path for description text is gated like generation, but it re-checks privacy at read time and could still leak sidecar content if the verdict logic regresses; additive and read-only otherwise.
> 
> **Overview**
> Adds **`read_assets`** so chat can fetch stored description/OCR text from `assets/…` sidecars (`<asset>.reflect.md`) instead of only seeing bare markdown links after `read_notes`. The tool batches up to 10 paths per call, canonicalizes hrefs via **`canonicalAssetPath`**, and returns per-asset hits or refusals without failing the whole batch.
> 
> **Privacy** moves shared **`classifyAsset` / `classifyAssetFromNotes`** into **`asset-privacy.ts`**; the read path re-runs the same live verdict (public referrers only, fail closed) before **`cloudSafeAssetDescription`** mints outbound text. Blocked assets share one unspecific refusal so private-note existence is not leaked.
> 
> **Structure:** `read_notes` and `read_assets` executors live in sibling modules; **`tools.ts`** registers tools and transcript unions. The system prompt and a **paperclip** chat chip (filenames, inline per-asset errors) document and surface the new flow. Docs/comments now state note bodies/previews are not widened—descriptions reach the provider only through this gated tool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdb09ba5d61b3c437dd67f88e31f0ed09433de3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->