### PR TITLE
Fold asset descriptions into semantic search embeddings

### DIFF
--- a/apps/desktop/src/components/embeddings-sync.test.tsx
+++ b/apps/desktop/src/components/embeddings-sync.test.tsx
@@ -1,18 +1,18 @@
 import { cleanup, render, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { FileChange } from '@reflect/core'
+import type { IndexAppliedListener } from '@reflect/core'
 import { EmbeddingsSync } from './embeddings-sync'
 
 const core = vi.hoisted(() => ({
   embedNote: vi.fn(async () => ({ written: 0 })),
   embedRemove: vi.fn(async () => {}),
-  subscribeFileChanges: vi.fn(),
+  subscribeIndexApplied: vi.fn(),
 }))
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   embedNote: core.embedNote,
   embedRemove: core.embedRemove,
-  subscribeFileChanges: core.subscribeFileChanges,
+  subscribeIndexApplied: core.subscribeIndexApplied,
 }))
 
 const semantic = vi.hoisted(() => ({
@@ -39,22 +39,20 @@ vi.mock('@/lib/use-embed-status', () => ({
   useEmbedStatus: () => ({ status: 'ready', model: 'all-MiniLM-L6-v2' }),
 }))
 
-let onFileChanges: ((changes: FileChange[]) => void) | null = null
+let onApplied: IndexAppliedListener | null = null
 const unlisten = vi.fn()
 
 beforeEach(() => {
   semanticSetting.enabled = true
-  onFileChanges = null
+  onApplied = null
   unlisten.mockClear()
   core.embedNote.mockClear()
   core.embedRemove.mockClear()
   semantic.backfillEmbeddingsVisibly.mockClear()
-  core.subscribeFileChanges
-    .mockReset()
-    .mockImplementation(async (handler: (changes: FileChange[]) => void) => {
-      onFileChanges = handler
-      return unlisten
-    })
+  core.subscribeIndexApplied.mockReset().mockImplementation((handler: IndexAppliedListener) => {
+    onApplied = handler
+    return unlisten
+  })
 })
 
 afterEach(cleanup)
@@ -65,12 +63,12 @@ function flushQueue(): Promise<void> {
 }
 
 describe('EmbeddingsSync', () => {
-  it('backfills and follows the watcher while enabled and ready', async () => {
+  it('backfills and follows applied index batches while enabled and ready', async () => {
     render(<EmbeddingsSync />)
     await waitFor(() => expect(semantic.backfillEmbeddingsVisibly).toHaveBeenCalled())
-    await waitFor(() => expect(onFileChanges).not.toBeNull())
+    await waitFor(() => expect(onApplied).not.toBeNull())
 
-    onFileChanges?.([{ kind: 'upsert', path: 'notes/a.md' }])
+    onApplied?.([{ kind: 'upsert', path: 'notes/a.md' }], 7)
     await waitFor(() =>
       expect(core.embedNote).toHaveBeenCalledWith({
         path: 'notes/a.md',
@@ -80,14 +78,26 @@ describe('EmbeddingsSync', () => {
     )
   })
 
-  it('never embeds audio-memo recordings riding the same stream', async () => {
+  it('ignores a delayed emit from a superseded index session', async () => {
     render(<EmbeddingsSync />)
-    await waitFor(() => expect(onFileChanges).not.toBeNull())
+    await waitFor(() => expect(onApplied).not.toBeNull())
 
-    onFileChanges?.([
-      { kind: 'upsert', path: 'audio-memos/audio-memo-2026-06-12-090000-000.m4a' },
-      { kind: 'remove', path: 'audio-memos/audio-memo-2026-06-12-091500-000.m4a' },
-    ])
+    onApplied?.([{ kind: 'upsert', path: 'notes/a.md' }], 6)
+    await flushQueue()
+    expect(core.embedNote).not.toHaveBeenCalled()
+  })
+
+  it('never embeds asset-file changes riding the same batches', async () => {
+    render(<EmbeddingsSync />)
+    await waitFor(() => expect(onApplied).not.toBeNull())
+
+    onApplied?.(
+      [
+        { kind: 'upsert', path: 'assets/photo.png' },
+        { kind: 'remove', path: 'assets/old.pdf' },
+      ],
+      7,
+    )
     await flushQueue()
     expect(core.embedNote).not.toHaveBeenCalled()
     expect(core.embedRemove).not.toHaveBeenCalled()
@@ -98,12 +108,12 @@ describe('EmbeddingsSync', () => {
     render(<EmbeddingsSync />)
     await flushQueue()
     expect(semantic.backfillEmbeddingsVisibly).not.toHaveBeenCalled()
-    expect(core.subscribeFileChanges).not.toHaveBeenCalled()
+    expect(core.subscribeIndexApplied).not.toHaveBeenCalled()
   })
 
-  it('pauses watcher work the moment semantic search is disabled', async () => {
+  it('pauses follow-up work the moment semantic search is disabled', async () => {
     const view = render(<EmbeddingsSync />)
-    await waitFor(() => expect(onFileChanges).not.toBeNull())
+    await waitFor(() => expect(onApplied).not.toBeNull())
 
     semanticSetting.enabled = false
     view.rerender(<EmbeddingsSync />)
@@ -111,7 +121,7 @@ describe('EmbeddingsSync', () => {
 
     // A batch still in flight when the teardown ran must be dropped, not
     // embedded behind the user's back.
-    onFileChanges?.([{ kind: 'upsert', path: 'notes/b.md' }])
+    onApplied?.([{ kind: 'upsert', path: 'notes/b.md' }], 7)
     await flushQueue()
     expect(core.embedNote).not.toHaveBeenCalled()
   })

--- a/apps/desktop/src/components/embeddings-sync.tsx
+++ b/apps/desktop/src/components/embeddings-sync.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { embedNote, embedRemove, isNotePath, subscribeFileChanges } from '@reflect/core'
+import { embedNote, embedRemove, isNotePath, subscribeIndexApplied } from '@reflect/core'
 import {
   backfillEmbeddingsVisibly,
   consumeLegacySemanticOptIn,
@@ -20,10 +20,19 @@ import { useSettings } from '@/providers/settings-provider'
  *   first download starts);
  * - run one incremental backfill per graph-open once `ready` (hash-skip makes
  *   this cheap when nothing changed);
- * - follow the watcher: changed notes re-embed, deleted notes drop vectors.
+ * - follow the index: changed notes re-embed, deleted notes drop vectors.
  *   Work is serialized on one queue so passes can't interleave.
  *
- * Backfill and watcher work need the runtime `ready` *and* the setting on:
+ * The follow trigger is `subscribeIndexApplied` — the post-apply signal — not
+ * the raw watcher stream, for two reasons. Ordering: `embed_apply` drops
+ * chunks for paths without a `notes` row, so embedding a brand-new note off
+ * the raw file event could race its index apply and lose the chunks until the
+ * next backfill; post-apply, the row is always there. Coverage: asset
+ * description writes re-index their referencing notes *outside* the watcher
+ * pipeline (`reindexNotesReferencing` emits the same signal), and those notes
+ * must re-embed for the description text to reach semantic search.
+ *
+ * Backfill and follow work need the runtime `ready` *and* the setting on:
  * disabling semantic search pauses embedding work immediately (the loaded
  * model just idles for the rest of the session), and re-enabling catches up
  * via the cheap hash-skip backfill.
@@ -61,16 +70,15 @@ export function EmbeddingsSync(): null {
     }
   }, [enabled, status.status])
 
-  // One backfill per (graph, model) once ready, then live watcher follow-up.
-  // `enabled` is part of the gate so a mid-session disable tears this down:
-  // pending queue items see `active` go false and skip, and the watcher
-  // unsubscribes.
+  // One backfill per (graph, model) once ready, then live post-apply
+  // follow-up. `enabled` is part of the gate so a mid-session disable tears
+  // this down: pending queue items see `active` go false and skip, and the
+  // subscription drops.
   useEffect(() => {
     if (!enabled || !ready || generation === null || root === null || modelId === null) {
       return
     }
     let active = true
-    let unlisten: (() => void) | null = null
 
     queue.current = queue.current
       .then(() => {
@@ -82,18 +90,18 @@ export function EmbeddingsSync(): null {
         )
       })
       .catch((cause) => {
-        // A rejection here must not poison the queue (later watcher items
+        // A rejection here must not poison the queue (later change items
         // chain off this promise) nor masquerade as a per-change failure.
         console.error('embedding backfill failed:', cause)
       })
 
-    void subscribeFileChanges((changes) => {
-      if (!active) {
-        return
+    const unlisten = subscribeIndexApplied((changes, appliedGeneration) => {
+      if (!active || appliedGeneration !== generation) {
+        return // torn down, or a delayed emit from a superseded index session
       }
       for (const change of changes) {
         if (!isNotePath(change.path)) {
-          continue // audio-memo recordings ride the same stream — never embedded
+          continue // asset-file changes ride the same batches — never embedded
         }
         queue.current = queue.current
           .then(() => {
@@ -108,17 +116,11 @@ export function EmbeddingsSync(): null {
             console.error(`embedding sync failed for ${change.path}:`, cause)
           })
       }
-    }).then((fn) => {
-      if (active) {
-        unlisten = fn
-      } else {
-        fn()
-      }
     })
 
     return () => {
       active = false
-      unlisten?.()
+      unlisten()
     }
   }, [enabled, ready, generation, root, modelId])
 

--- a/apps/desktop/src/lib/asset-describe-controller.ts
+++ b/apps/desktop/src/lib/asset-describe-controller.ts
@@ -103,7 +103,11 @@ export function createAssetDescribeController(
     }
     // Runs even on a stop — whatever was described is real. A re-index failure
     // must not crash the loop: the descriptions are written, so search catches
-    // up on the note's next re-index or a rebuild.
+    // up on the note's next re-index or a rebuild. The re-index emits the
+    // post-apply signal for the refreshed notes (the embedding sync re-embeds
+    // them off it); our own index-applied trigger hears that emit too and
+    // re-marks the notes' assets, which the next pass skips as up-to-date —
+    // one cheap extra cycle, no loop (a clean pass writes nothing new).
     if (outcome.describedAssetPaths.length > 0) {
       try {
         await reindexNotesReferencing(outcome.describedAssetPaths, options.generation)

--- a/docs/plans/20-asset-descriptions.md
+++ b/docs/plans/20-asset-descriptions.md
@@ -413,8 +413,11 @@ and enriching only `search_fts.body` keeps descriptions out of AI/cloud and the
 preview. (`descriptionPathFor`/`DESCRIPTION_SUFFIX` moved to `graph/paths.ts` so
 `indexing/` need not import `actions/`.)
 
-**Deferred:** semantic embedding of descriptions (Plan 09 is opt-in/off by
-default); attributed "matched in image: X" result UI (transparent chosen).
+**Deferred:** ~~semantic embedding of descriptions~~ (shipped later: description
+bodies chunk into the referencing note's embedding set, mirroring the FTS fold —
+see `embeddings/pipeline.ts`); attributed "matched in image: X" result UI
+(transparent chosen — though asset chunks carry the asset filename as their
+chunk heading).
 
 ## Conventions
 

--- a/packages/core/src/embeddings/chunk.test.ts
+++ b/packages/core/src/embeddings/chunk.test.ts
@@ -130,6 +130,21 @@ describe('chunkAssetDescriptions', () => {
     expect(total).toBe(MAX_ASSET_TEXT_CHARS)
   })
 
+  it('counts the body joiner against the cap, like the FTS join-then-slice', async () => {
+    // FTS keeps `first + '\n\n' + second` sliced to the cap, so a later body
+    // only gets what the cap leaves after the two joiner chars.
+    const chunks = await chunkAssetDescriptions(
+      [
+        { assetPath: 'assets/a.png', body: 'x'.repeat(MAX_ASSET_TEXT_CHARS - 6) },
+        { assetPath: 'assets/b.png', body: 'yyyyyyyy' },
+      ],
+      BASE,
+    )
+    const second = chunks.filter((chunk) => chunk.heading === 'b.png')
+    expect(second).toHaveLength(1)
+    expect(second[0]!.text).toBe('yyyy') // cap − body − joiner = 4 chars left
+  })
+
   it('returns nothing for no bodies', async () => {
     expect(await chunkAssetDescriptions([], BASE)).toEqual([])
   })

--- a/packages/core/src/embeddings/chunk.test.ts
+++ b/packages/core/src/embeddings/chunk.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { chunkNote } from './chunk'
+import { MAX_ASSET_TEXT_CHARS } from '../indexing/asset-description-text'
+import { chunkAssetDescriptions, chunkNote } from './chunk'
 
 const PATH = 'notes/a.md'
 
@@ -65,5 +66,71 @@ describe('chunkNote', () => {
     const last = chunks[chunks.length - 1]!
     expect(last.text.length).toBeGreaterThanOrEqual(200)
     expect(last.text.endsWith('Tiny tail.')).toBe(true)
+  })
+})
+
+describe('chunkAssetDescriptions', () => {
+  const BASE = 500 // as if the note source were 499 chars long
+
+  it('chunks each body under the asset filename with positions past the note', async () => {
+    const chunks = await chunkAssetDescriptions(
+      [
+        { assetPath: 'assets/graphs/q4.png', body: 'Quarterly revenue bar chart.' },
+        { assetPath: 'assets/scan.pdf', body: 'A signed lease agreement.' },
+      ],
+      BASE,
+    )
+    expect(chunks).toHaveLength(2)
+    expect(chunks[0]!.heading).toBe('q4.png')
+    expect(chunks[1]!.heading).toBe('scan.pdf')
+    expect(chunks[0]!.text).toBe('Quarterly revenue bar chart.')
+    expect(chunks[0]!.posFrom).toBe(BASE)
+    // The second body starts after the first, so positions stay ordered.
+    expect(chunks[1]!.posFrom).toBeGreaterThan(chunks[0]!.posTo)
+  })
+
+  it('hashes are stable across runs and change with the body', async () => {
+    const bodies = [{ assetPath: 'assets/a.png', body: 'A red bridge at dawn.' }]
+    const first = await chunkAssetDescriptions(bodies, BASE)
+    const again = await chunkAssetDescriptions(bodies, BASE)
+    expect(again[0]!.contentHash).toBe(first[0]!.contentHash)
+
+    const changed = await chunkAssetDescriptions(
+      [{ assetPath: 'assets/a.png', body: 'A snowy mountain pass.' }],
+      BASE,
+    )
+    expect(changed[0]!.contentHash).not.toBe(first[0]!.contentHash)
+  })
+
+  it('splits a long body into sentence-aligned chunks and merges the runt tail', async () => {
+    const sentence = 'The scanned page describes the quarterly figures in detail. '
+    const chunks = await chunkAssetDescriptions(
+      [{ assetPath: 'assets/report.pdf', body: `${sentence.repeat(40)}End.` }],
+      BASE,
+    )
+    expect(chunks.length).toBeGreaterThan(1)
+    for (const chunk of chunks) {
+      expect(chunk.heading).toBe('report.pdf')
+    }
+    const last = chunks[chunks.length - 1]!
+    expect(last.text.length).toBeGreaterThanOrEqual(200) // runt merged
+    expect(last.text.endsWith('End.')).toBe(true)
+  })
+
+  it('caps the combined description text, mirroring the FTS fold', async () => {
+    const chunks = await chunkAssetDescriptions(
+      [
+        { assetPath: 'assets/a.png', body: 'x'.repeat(MAX_ASSET_TEXT_CHARS) },
+        { assetPath: 'assets/b.png', body: 'never reached' },
+      ],
+      BASE,
+    )
+    expect(chunks.every((chunk) => chunk.heading === 'a.png')).toBe(true)
+    const total = chunks.reduce((sum, chunk) => sum + chunk.text.length, 0)
+    expect(total).toBe(MAX_ASSET_TEXT_CHARS)
+  })
+
+  it('returns nothing for no bodies', async () => {
+    expect(await chunkAssetDescriptions([], BASE)).toEqual([])
   })
 })

--- a/packages/core/src/embeddings/chunk.ts
+++ b/packages/core/src/embeddings/chunk.ts
@@ -184,6 +184,9 @@ export async function chunkAssetDescriptions(
   let offset = baseOffset
   let budget = MAX_ASSET_TEXT_CHARS
   for (const { assetPath, body } of bodies) {
+    if (chunks.length > 0) {
+      budget -= 2 // the joiner counts against the FTS fold's slice — mirror it
+    }
     if (budget <= 0) {
       break
     }

--- a/packages/core/src/embeddings/chunk.ts
+++ b/packages/core/src/embeddings/chunk.ts
@@ -1,5 +1,9 @@
 import { parseNote, splitFrontmatter } from '../markdown'
 import { hashContent } from '../indexing/hash'
+import {
+  MAX_ASSET_TEXT_CHARS,
+  type AssetDescriptionBody,
+} from '../indexing/asset-description-text'
 
 /**
  * Sentence-aware note chunking (Plan 09). Sections split on headings, then
@@ -45,9 +49,88 @@ interface Section {
   to: number
 }
 
-/** Chunk a note's source into embedding units. Pure; empty input → []. */
-export async function chunkNote(path: string, source: string): Promise<NoteChunk[]> {
-  const parsed = parseNote({ path, source })
+/**
+ * Accumulate one run of text into chunks: sentence spans gather toward
+ * {@link TARGET_CHARS}, offsets are `base`-relative into the enclosing
+ * document. No runt-tail merging here — each caller owns its own merge rule
+ * (the note merges only its final chunk, asset bodies merge per body).
+ */
+async function chunkRun(text: string, base: number, heading: string | null): Promise<NoteChunk[]> {
+  const chunks: NoteChunk[] = []
+  let chunkFrom = -1
+  let chunkTo = -1
+  const flush = async (): Promise<void> => {
+    if (chunkFrom === -1) {
+      return
+    }
+    const chunkText = text.slice(chunkFrom - base, chunkTo - base)
+    if (chunkText.trim() === '') {
+      chunkFrom = -1
+      return
+    }
+    chunks.push({
+      heading,
+      posFrom: chunkFrom,
+      posTo: chunkTo,
+      text: chunkText,
+      contentHash: await hashContent(chunkText),
+    })
+    chunkFrom = -1
+  }
+  for (const span of sentenceSpans(text, base)) {
+    if (chunkFrom === -1) {
+      chunkFrom = span.from
+    }
+    chunkTo = span.to
+    if (chunkTo - chunkFrom >= TARGET_CHARS) {
+      await flush()
+    }
+  }
+  await flush()
+  return chunks
+}
+
+/**
+ * Merge the final chunk into its predecessor when it is a runt (smaller than
+ * {@link MIN_CHARS}) under the same heading — a tail that reads better (and
+ * embeds better) merged. `sliceText` re-slices the merged span from the
+ * source the positions index into.
+ */
+async function mergeRuntTail(
+  chunks: NoteChunk[],
+  sliceText: (from: number, to: number) => string,
+): Promise<NoteChunk[]> {
+  if (chunks.length < 2) {
+    return chunks
+  }
+  const last = chunks[chunks.length - 1]!
+  const prev = chunks[chunks.length - 2]!
+  if (last.text.length >= MIN_CHARS || prev.heading !== last.heading) {
+    return chunks
+  }
+  const text = sliceText(prev.posFrom, last.posTo)
+  return [
+    ...chunks.slice(0, -2),
+    {
+      heading: prev.heading,
+      posFrom: prev.posFrom,
+      posTo: last.posTo,
+      text,
+      contentHash: await hashContent(text),
+    },
+  ]
+}
+
+/**
+ * Chunk a note's source into embedding units. Pure; empty input → [].
+ * Pass `parsed` when the caller already parsed the note (the embedding
+ * pipeline does, for the asset list) to avoid a second parse.
+ */
+export async function chunkNote(
+  path: string,
+  source: string,
+  parsed = parseNote({ path, source }),
+): Promise<NoteChunk[]> {
   const headings = parsed.headings
 
   // Sections: the run before the first heading, then one per heading (each
@@ -69,52 +152,50 @@ export async function chunkNote(path: string, source: string): Promise<NoteChunk
     if (text.trim() === '') {
       continue
     }
-    let chunkFrom = -1
-    let chunkTo = -1
-    const flush = async (): Promise<void> => {
-      if (chunkFrom === -1) {
-        return
-      }
-      const chunkText = source.slice(chunkFrom, chunkTo)
-      if (chunkText.trim() === '') {
-        chunkFrom = -1
-        return
-      }
-      chunks.push({
-        heading: section.heading,
-        posFrom: chunkFrom,
-        posTo: chunkTo,
-        text: chunkText,
-        contentHash: await hashContent(chunkText),
-      })
-      chunkFrom = -1
-    }
-    for (const span of sentenceSpans(text, section.from)) {
-      if (chunkFrom === -1) {
-        chunkFrom = span.from
-      }
-      chunkTo = span.to
-      if (chunkTo - chunkFrom >= TARGET_CHARS) {
-        await flush()
-      }
-    }
-    await flush()
+    chunks.push(...(await chunkRun(text, section.from, section.heading)))
   }
 
-  // A runt tail reads better (and embeds better) merged into its predecessor.
-  if (chunks.length >= 2) {
-    const last = chunks[chunks.length - 1]!
-    const prev = chunks[chunks.length - 2]!
-    if (last.text.length < MIN_CHARS && prev.heading === last.heading) {
-      const text = source.slice(prev.posFrom, last.posTo)
-      chunks.splice(chunks.length - 2, 2, {
-        heading: prev.heading,
-        posFrom: prev.posFrom,
-        posTo: last.posTo,
-        text,
-        contentHash: await hashContent(text),
-      })
+  // Only the note's final chunk merges — mid-note section tails keep their
+  // historical shape, so existing chunk hashes (and the re-embed skip) hold.
+  return mergeRuntTail(chunks, (from, to) => source.slice(from, to))
+}
+
+/** `assets/graphs/q4.png` → `q4.png` — the chunk heading for an asset body. */
+function assetBasename(assetPath: string): string {
+  return assetPath.split('/').pop() ?? assetPath
+}
+
+/**
+ * Chunk a note's asset-description bodies (Plan 20 → semantic leg) into
+ * embedding units attributed to the referencing note. Each body chunks like a
+ * section whose heading is the asset's filename — light provenance for
+ * snippets. Positions are synthetic: they start at `baseOffset` (past the end
+ * of the note source, which has exclusive claim to real offsets) and advance
+ * as if the bodies were appended to the note, so asset chunks order after
+ * note chunks everywhere positions sort (vector pairing, related-notes
+ * seeds). The combined text is capped at {@link MAX_ASSET_TEXT_CHARS},
+ * mirroring the FTS fold.
+ */
+export async function chunkAssetDescriptions(
+  bodies: readonly AssetDescriptionBody[],
+  baseOffset: number,
+): Promise<NoteChunk[]> {
+  const chunks: NoteChunk[] = []
+  let offset = baseOffset
+  let budget = MAX_ASSET_TEXT_CHARS
+  for (const { assetPath, body } of bodies) {
+    if (budget <= 0) {
+      break
     }
+    const text = body.slice(0, budget)
+    budget -= text.length
+    const heading = assetBasename(assetPath)
+    const bodyChunks = await mergeRuntTail(
+      await chunkRun(text, offset, heading),
+      (from, to) => text.slice(from - offset, to - offset),
+    )
+    chunks.push(...bodyChunks)
+    offset += text.length + 2 // as if joined by the FTS fold's blank line
   }
   return chunks
 }

--- a/packages/core/src/embeddings/pipeline.test.ts
+++ b/packages/core/src/embeddings/pipeline.test.ts
@@ -7,6 +7,9 @@ afterEach(() => {
 })
 
 interface AppliedChunk {
+  heading: string | null
+  posFrom: number
+  text: string
   contentHash: string
   vector: number[] | null
 }
@@ -14,16 +17,27 @@ interface AppliedChunk {
 /**
  * Bridge fake for the pipeline: a note on "disk", stored hash+model rows for
  * the db_query the diff makes, and capture of embed_texts / embed_apply.
+ * `descriptions` answers reads of `<asset>.reflect.md` sidecars; any other
+ * sidecar read gets the Rust layer's notFound.
  */
 function fakePipelineBridge(options: {
   content: string
   storedRows: Array<{ content_hash: string; model_id: string }>
+  descriptions?: Record<string, string>
 }) {
   const embedded: string[][] = []
   const applied: { path: string; chunks: AppliedChunk[] }[] = []
   setBridge({
     invoke: async (command, args) => {
       if (command === 'note_read') {
+        const path = (args as { path: string }).path
+        if (path.endsWith('.reflect.md')) {
+          const description = options.descriptions?.[path]
+          if (description === undefined) {
+            throw { kind: 'notFound', message: `no description at ${path}` }
+          }
+          return description
+        }
         return options.content
       }
       if (command === 'db_query') {
@@ -135,5 +149,73 @@ describe('embedNote', () => {
     const count = await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
     expect(count).toBe(0)
     expect(applied).toEqual([{ path: 'notes/a.md', chunks: [] }])
+  })
+
+  const IMAGE_NOTE = '# Trip\n\nSome notes about the day.\n\n![photo](assets/pic.png)\n'
+  const PIC_DESCRIPTION =
+    '---\nreflectAsset: true\nsource: assets/pic.png\n---\n\nA red bridge over a misty river at dawn.\n'
+
+  it('embeds asset description chunks after the note’s own chunks', async () => {
+    const { applied } = fakePipelineBridge({
+      content: IMAGE_NOTE,
+      storedRows: [],
+      descriptions: { 'assets/pic.png.reflect.md': PIC_DESCRIPTION },
+    })
+    const count = await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
+    expect(count).toBeGreaterThanOrEqual(2) // note chunk(s) + the asset chunk
+
+    const chunks = applied[0]!.chunks
+    const assetChunk = chunks[chunks.length - 1]!
+    expect(assetChunk.heading).toBe('pic.png')
+    expect(assetChunk.text).toContain('red bridge over a misty river')
+    expect(assetChunk.text).not.toContain('reflectAsset') // frontmatter stripped
+    // Synthetic positions live past the note source, so asset chunks order last.
+    expect(assetChunk.posFrom).toBeGreaterThan(IMAGE_NOTE.length)
+    expect(chunks.slice(0, -1).every((chunk) => chunk.posFrom < IMAGE_NOTE.length)).toBe(true)
+  })
+
+  it('a note without a description for its asset embeds only its own text', async () => {
+    const { applied } = fakePipelineBridge({ content: IMAGE_NOTE, storedRows: [] })
+    await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
+    expect(applied[0]!.chunks.every((chunk) => chunk.posFrom < IMAGE_NOTE.length)).toBe(true)
+  })
+
+  it('the hash-skip covers unchanged asset description chunks', async () => {
+    const descriptions = { 'assets/pic.png.reflect.md': PIC_DESCRIPTION }
+    const first = fakePipelineBridge({ content: IMAGE_NOTE, storedRows: [], descriptions })
+    await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
+    const storedRows = first.applied[0]!.chunks.map((chunk) => ({
+      content_hash: chunk.contentHash,
+      model_id: MODEL,
+    }))
+
+    const second = fakePipelineBridge({ content: IMAGE_NOTE, storedRows, descriptions })
+    const count = await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
+    expect(count).toBe(0)
+    expect(second.embedded).toHaveLength(0)
+  })
+
+  it('a rewritten description re-embeds only the asset chunk', async () => {
+    const first = fakePipelineBridge({
+      content: IMAGE_NOTE,
+      storedRows: [],
+      descriptions: { 'assets/pic.png.reflect.md': PIC_DESCRIPTION },
+    })
+    await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
+    const storedRows = first.applied[0]!.chunks.map((chunk) => ({
+      content_hash: chunk.contentHash,
+      model_id: MODEL,
+    }))
+
+    const second = fakePipelineBridge({
+      content: IMAGE_NOTE,
+      storedRows,
+      descriptions: {
+        'assets/pic.png.reflect.md': '---\nreflectAsset: true\n---\n\nNow a snowy mountain pass.\n',
+      },
+    })
+    const count = await embedNote({ path: 'notes/a.md', generation: 1, modelId: MODEL })
+    expect(count).toBe(1)
+    expect(second.embedded).toEqual([['Now a snowy mountain pass.']])
   })
 })

--- a/packages/core/src/embeddings/pipeline.ts
+++ b/packages/core/src/embeddings/pipeline.ts
@@ -1,7 +1,9 @@
 import { readNote } from '../graph/commands'
 import { isTemplatePath } from '../graph/paths'
+import { gatherAssetDescriptionBodies } from '../indexing/asset-description-text'
 import { db } from '../indexing/db'
-import { chunkNote } from './chunk'
+import { parseNote } from '../markdown'
+import { chunkAssetDescriptions, chunkNote } from './chunk'
 import { embedApply, embedRemove, embedTexts, type EmbedChunkPayload } from './commands'
 
 /**
@@ -9,6 +11,11 @@ import { embedApply, embedRemove, embedTexts, type EmbedChunkPayload } from './c
  * against the stored rows, embed only what changed, and apply as one
  * generation-pinned write. TS owns this orchestration (Rust supplies
  * `embed_texts` + the table writes), mirroring the indexing pipeline.
+ *
+ * A note's chunk set also carries its referenced assets' description bodies
+ * (Plan 20 → semantic leg), mirroring the FTS fold — so a meaning-level query
+ * about an image or PDF's contents surfaces the referencing note on the
+ * semantic side of hybrid retrieval, not just on keyword matches.
  */
 
 export interface EmbedNoteOptions {
@@ -38,7 +45,12 @@ export async function embedNote(options: EmbedNoteOptions): Promise<number> {
     }
   }
 
-  const chunks = await chunkNote(path, content)
+  const parsed = parseNote({ path, source: content })
+  const assetBodies = await gatherAssetDescriptionBodies(parsed.assets.map((asset) => asset.path))
+  const chunks = [
+    ...(await chunkNote(path, content, parsed)),
+    ...(await chunkAssetDescriptions(assetBodies, content.length + 1)),
+  ]
   if (chunks.length === 0) {
     await embedRemove(path, generation)
     return 0

--- a/packages/core/src/exports/sync-markdown-indexing.ts
+++ b/packages/core/src/exports/sync-markdown-indexing.ts
@@ -126,6 +126,7 @@ export {
   watchStop,
   subscribeIndexChanges,
   subscribeIndexApplied,
+  type IndexAppliedListener,
   subscribeIndexWritten,
   subscribeNoteMoved,
   subscribeFileChanges,

--- a/packages/core/src/indexing/asset-description-text.test.ts
+++ b/packages/core/src/indexing/asset-description-text.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { readNote } from '../graph/commands'
-import { gatherAssetDescriptionText, MAX_ASSET_TEXT_CHARS } from './asset-description-text'
+import {
+  gatherAssetDescriptionBodies,
+  gatherAssetDescriptionText,
+  MAX_ASSET_TEXT_CHARS,
+} from './asset-description-text'
 
 vi.mock('../graph/commands', () => ({
   readNote: vi.fn(),
@@ -70,5 +74,44 @@ describe('gatherAssetDescriptionText', () => {
   it('propagates a non-notFound read error', async () => {
     readNoteMock.mockRejectedValueOnce({ kind: 'io', message: 'disk error' })
     await expect(gatherAssetDescriptionText(['assets/a.png'])).rejects.toMatchObject({ kind: 'io' })
+  })
+})
+
+describe('gatherAssetDescriptionBodies', () => {
+  it('returns per-asset bodies attributed to their asset paths', async () => {
+    files.set('assets/a.png.reflect.md', '---\nreflectAsset: true\n---\n\nA flow diagram.\n')
+    files.set('assets/b.pdf.reflect.md', '---\nreflectAsset: true\n---\n\nQ4 revenue report.\n')
+
+    const bodies = await gatherAssetDescriptionBodies(['assets/a.png', 'assets/b.pdf'])
+
+    expect(bodies).toEqual([
+      { assetPath: 'assets/a.png', body: 'A flow diagram.' },
+      { assetPath: 'assets/b.pdf', body: 'Q4 revenue report.' },
+    ])
+  })
+
+  it('skips missing descriptions, empty bodies, and repeated assets', async () => {
+    files.set('assets/a.png.reflect.md', '---\nreflectAsset: true\n---\n\nDescribed.\n')
+    files.set('assets/empty.png.reflect.md', '---\nreflectAsset: true\n---\n\n  \n')
+
+    const bodies = await gatherAssetDescriptionBodies([
+      'assets/a.png',
+      'assets/a.png',
+      'assets/empty.png',
+      'assets/missing.pdf',
+    ])
+
+    expect(bodies).toEqual([{ assetPath: 'assets/a.png', body: 'Described.' }])
+    expect(readNoteMock).toHaveBeenCalledTimes(3) // the repeat never re-reads
+  })
+
+  it('stops accumulating once the combined length reaches the cap', async () => {
+    files.set('assets/a.png.reflect.md', 'x'.repeat(MAX_ASSET_TEXT_CHARS))
+    files.set('assets/b.png.reflect.md', 'never reached')
+
+    const bodies = await gatherAssetDescriptionBodies(['assets/a.png', 'assets/b.png'])
+
+    expect(bodies).toHaveLength(1)
+    expect(bodies[0]!.assetPath).toBe('assets/a.png')
   })
 })

--- a/packages/core/src/indexing/asset-description-text.ts
+++ b/packages/core/src/indexing/asset-description-text.ts
@@ -8,27 +8,41 @@ import { splitFrontmatter } from '../markdown/frontmatter'
  * integration). A note's referenced assets each may have a description file
  * (`<asset>.reflect.md`); their bodies are appended to the note's FTS document
  * so a query matching a description surfaces the note — transparently, as an
- * ordinary hit. The text goes into `search_fts.body` only, never the All-Notes
- * preview or AI-reachable note text.
+ * ordinary hit. The same bodies feed the note's embedding chunks (the semantic
+ * leg), so lexical and semantic retrieval see the same asset text. It never
+ * enters the All-Notes preview or the AI-readable note *content*.
  */
 
 /** Cap on folded description text per note (chars) — bounds the FTS document. */
 export const MAX_ASSET_TEXT_CHARS = 8_000
 
+/** One asset's description body, attributed to the asset it describes. */
+export interface AssetDescriptionBody {
+  /** Graph-relative asset path (`assets/x.png`), not the description path. */
+  assetPath: string
+  /** The description file's body, frontmatter stripped and trimmed. */
+  body: string
+}
+
 /**
- * The combined body text of a note's assets' description files, for folding
- * into its search index. Reads any `<asset>.reflect.md` that exists (managed or
- * user-authored — it is the user's content about the asset), strips frontmatter,
- * joins the bodies, and caps the total. Missing files are skipped. Reads are
- * unpinned, matching the indexer's own note reads (the *write* is
- * generation-pinned, so a graph switch drops the stale row regardless).
+ * The per-asset description bodies for a note's referenced assets. Reads any
+ * `<asset>.reflect.md` that exists (managed or user-authored — it is the
+ * user's content about the asset) and strips frontmatter. Missing files and
+ * empty bodies are skipped; a repeated asset contributes once. Accumulation
+ * stops once the combined length reaches {@link MAX_ASSET_TEXT_CHARS} (the
+ * body that crosses the cap is kept whole — consumers apply their own final
+ * cap). Reads are unpinned, matching the indexer's own note reads (the
+ * *write* is generation-pinned, so a graph switch drops the stale row
+ * regardless).
  */
-export async function gatherAssetDescriptionText(assetPaths: readonly string[]): Promise<string> {
+export async function gatherAssetDescriptionBodies(
+  assetPaths: readonly string[],
+): Promise<AssetDescriptionBody[]> {
   if (assetPaths.length === 0) {
-    return ''
+    return []
   }
   const seen = new Set<string>()
-  const bodies: string[] = []
+  const bodies: AssetDescriptionBody[] = []
   let total = 0
   for (const assetPath of assetPaths) {
     if (seen.has(assetPath)) {
@@ -48,11 +62,24 @@ export async function gatherAssetDescriptionText(assetPaths: readonly string[]):
     if (body === '') {
       continue
     }
-    bodies.push(body)
+    bodies.push({ assetPath, body })
     total += body.length
     if (total >= MAX_ASSET_TEXT_CHARS) {
       break
     }
   }
-  return bodies.join('\n\n').slice(0, MAX_ASSET_TEXT_CHARS)
+  return bodies
+}
+
+/**
+ * The combined body text of a note's assets' description files, for folding
+ * into its search index — {@link gatherAssetDescriptionBodies} joined and
+ * capped at {@link MAX_ASSET_TEXT_CHARS}.
+ */
+export async function gatherAssetDescriptionText(assetPaths: readonly string[]): Promise<string> {
+  const bodies = await gatherAssetDescriptionBodies(assetPaths)
+  return bodies
+    .map((entry) => entry.body)
+    .join('\n\n')
+    .slice(0, MAX_ASSET_TEXT_CHARS)
 }

--- a/packages/core/src/indexing/indexer.ts
+++ b/packages/core/src/indexing/indexer.ts
@@ -14,6 +14,7 @@ import {
 } from './commands'
 import { assetReferencingNotePaths } from './asset-refs'
 import { gatherAssetDescriptionText } from './asset-description-text'
+import { emitIndexApplied } from './index-applied'
 import { hashContent } from './hash'
 import { buildIndexedNote, PROJECTION_VERSION, type IndexedNote } from './indexed-note'
 import { detectExternalMoves } from './move-healing'
@@ -96,6 +97,13 @@ export async function buildNoteProjection(
  * this folds the new description text into their FTS documents. `indexNote` is
  * not hash-gated, so the unchanged note files re-index unconditionally. A note
  * removed since it referenced the asset is skipped. Pinned to `generation`.
+ *
+ * The re-applied notes broadcast through {@link emitIndexApplied} — the same
+ * post-apply signal the live indexer emits — because these writes bypass the
+ * watcher pipeline entirely (`.reflect.md` files are untracked by design).
+ * Without it, subscribers that follow the index (the embedding sync above
+ * all, which must re-embed the notes so the new description text reaches the
+ * semantic leg too) would never hear about description-driven changes.
  */
 export async function reindexNotesReferencing(
   assetPaths: readonly string[],
@@ -107,15 +115,23 @@ export async function reindexNotesReferencing(
       notePaths.add(notePath)
     }
   }
+  const applied: string[] = []
   for (const notePath of notePaths) {
     try {
       await indexNote(notePath, { generation })
+      applied.push(notePath)
     } catch (cause) {
       if (isAppError(cause) && cause.kind === 'notFound') {
         continue // the note was removed since it referenced the asset
       }
       throw cause
     }
+  }
+  if (applied.length > 0) {
+    emitIndexApplied(
+      applied.map((path) => ({ path, kind: 'upsert' as const })),
+      generation,
+    )
   }
 }
 

--- a/packages/core/src/indexing/indexer.ts
+++ b/packages/core/src/indexing/indexer.ts
@@ -116,22 +116,28 @@ export async function reindexNotesReferencing(
     }
   }
   const applied: string[] = []
-  for (const notePath of notePaths) {
-    try {
-      await indexNote(notePath, { generation })
-      applied.push(notePath)
-    } catch (cause) {
-      if (isAppError(cause) && cause.kind === 'notFound') {
-        continue // the note was removed since it referenced the asset
+  try {
+    for (const notePath of notePaths) {
+      try {
+        await indexNote(notePath, { generation })
+        applied.push(notePath)
+      } catch (cause) {
+        if (isAppError(cause) && cause.kind === 'notFound') {
+          continue // the note was removed since it referenced the asset
+        }
+        throw cause
       }
-      throw cause
     }
-  }
-  if (applied.length > 0) {
-    emitIndexApplied(
-      applied.map((path) => ({ path, kind: 'upsert' as const })),
-      generation,
-    )
+  } finally {
+    // Emit even when a later note's re-index threw: whatever was applied is
+    // real, and unnotified followers would serve stale vectors until the
+    // next backfill.
+    if (applied.length > 0) {
+      emitIndexApplied(
+        applied.map((path) => ({ path, kind: 'upsert' as const })),
+        generation,
+      )
+    }
   }
 }
 

--- a/packages/core/src/indexing/pipeline.test.ts
+++ b/packages/core/src/indexing/pipeline.test.ts
@@ -98,6 +98,35 @@ describe('reindexNotesReferencing', () => {
     expect(emitted).toEqual([[[{ path: 'notes/a.md', kind: 'upsert' }], 7]])
   })
 
+  it('still emits the applied prefix when a later note’s re-index throws', async () => {
+    mockInvoke.mockImplementation(async (command, args) => {
+      const sql = String(args['sql'] ?? '')
+      if (command === 'db_query' && sql.includes('from "assets"')) {
+        return [{ note_path: 'notes/a.md' }, { note_path: 'notes/b.md' }]
+      }
+      if (command === 'note_read') {
+        if ((args as { path: string }).path === 'notes/b.md') {
+          throw { kind: 'io', message: 'disk error' }
+        }
+        return '# Hello'
+      }
+      return null
+    })
+    const emitted: Array<readonly { path: string }[]> = []
+    const unsubscribe = subscribeIndexApplied((changes) => {
+      emitted.push(changes)
+    })
+    try {
+      await expect(reindexNotesReferencing(['assets/pic.png'], 7)).rejects.toMatchObject({
+        kind: 'io',
+      })
+    } finally {
+      unsubscribe()
+    }
+    // notes/a.md was applied before the failure — followers must hear it.
+    expect(emitted).toEqual([[{ path: 'notes/a.md', kind: 'upsert' }]])
+  })
+
   it('emits nothing when no note references the assets', async () => {
     mockInvoke.mockImplementation(async (command, args) => {
       const sql = String(args['sql'] ?? '')

--- a/packages/core/src/indexing/pipeline.test.ts
+++ b/packages/core/src/indexing/pipeline.test.ts
@@ -3,7 +3,15 @@ import { setBridge } from '../ipc/bridge'
 import { getBacklinks, resolveWikiTarget, searchNotes } from './queries'
 import { hashContent } from './hash'
 import { PROJECTION_VERSION } from './indexed-note'
-import { indexNote, rebuildIndex, reconcileIndex, syncIndex, PROJECTION_VERSION_KEY } from './indexer'
+import {
+  indexNote,
+  rebuildIndex,
+  reconcileIndex,
+  reindexNotesReferencing,
+  syncIndex,
+  PROJECTION_VERSION_KEY,
+} from './indexer'
+import { subscribeIndexApplied } from './index-applied'
 import { applyIndexChanges } from './live'
 
 // Install a fake bridge so both core's `call` and the Kysely runner resolve
@@ -39,6 +47,7 @@ beforeEach(() => {
         return null
       case 'db_query':
         if (sql.includes('index_meta')) return metaRows
+        if (sql.includes('from "assets"')) return [{ note_path: 'notes/a.md' }]
         if (sql.includes('search_fts')) return [{ path: 'notes/a.md', title: 'A' }]
         if (sql.includes('backlinks')) {
           return [{ source_path: 'notes/b.md', target_raw: 'A', alias: null, pos_from: 0, pos_to: 3 }]
@@ -65,6 +74,48 @@ describe('indexNote', () => {
     expect(args.note['mtime']).toBe(5)
     expect(args.note['fileHash']).toMatch(/^[0-9a-f]{64}$/)
     expect((args.note['links'] as { targetKey: string }[]).map((link) => link.targetKey)).toContain('world')
+  })
+})
+
+describe('reindexNotesReferencing', () => {
+  it('re-applies referencing notes and emits the post-apply signal', async () => {
+    const emitted: Array<[readonly { path: string; kind: string }[], number]> = []
+    const unsubscribe = subscribeIndexApplied((changes, generation) => {
+      emitted.push([changes, generation])
+    })
+    try {
+      await reindexNotesReferencing(['assets/pic.png'], 7)
+    } finally {
+      unsubscribe()
+    }
+
+    const apply = mockInvoke.mock.calls.find(([cmd]) => cmd === 'index_apply')
+    expect(apply).toBeDefined()
+    expect((apply![1] as { generation: number }).generation).toBe(7)
+
+    // These writes bypass the watcher pipeline, so the emit is the only way
+    // followers (the embedding sync) hear about the refreshed notes.
+    expect(emitted).toEqual([[[{ path: 'notes/a.md', kind: 'upsert' }], 7]])
+  })
+
+  it('emits nothing when no note references the assets', async () => {
+    mockInvoke.mockImplementation(async (command, args) => {
+      const sql = String(args['sql'] ?? '')
+      if (command === 'db_query' && sql.includes('from "assets"')) {
+        return []
+      }
+      return null
+    })
+    const emitted: unknown[] = []
+    const unsubscribe = subscribeIndexApplied((changes) => {
+      emitted.push(changes)
+    })
+    try {
+      await reindexNotesReferencing(['assets/pic.png'], 7)
+    } finally {
+      unsubscribe()
+    }
+    expect(emitted).toEqual([])
   })
 })
 


### PR DESCRIPTION
## Problem

Asset AI descriptions/OCR (`<asset>.reflect.md` sidecars, Plan 20) fed only the lexical index: `gatherAssetDescriptionText` folded sidecar bodies into `search_fts.body`, so "search by asset contents" worked for keyword matches but never on the semantic leg of hybrid retrieval. A meaning-level query about an image or PDF's contents ("that bar chart about quarterly revenue") would not surface the referencing note unless the words happened to match. Plan 20 explicitly deferred exactly this ("semantic embedding of descriptions").

There was a second, subtler gap: even if asset text had been embedded, nothing would re-embed when a sidecar is written *later* — `.reflect.md` files are deliberately untracked by the Rust watcher (loop prevention), and `reindexNotesReferencing` refreshed only FTS rows, invisibly to the embedding sync.

Privacy is unchanged by design: embeddings are computed locally, description *generation* already hard-blocks assets referenced by any private note, and retrieval already strips private content at the AI boundary (`excludePrivateContent`, `is_private = 0` in related-notes). Asset text already reached AI callers through lexical FTS snippets, so the semantic leg adds no new exposure surface.

## Before → After

| Scenario | Before | After |
|---|---|---|
| Semantic/hybrid query matching an image's description meaning | Note not found (lexical keyword match only) | Note surfaces via an asset chunk; snippet shows the description, chunk heading = asset filename |
| Description written after the note was embedded | Embeddings never learn about it | Referencing notes re-embed off the post-apply signal |
| Brand-new note embedded off the raw file event | Could race the index apply; `apply_chunks` silently dropped chunks (no `notes` row yet) until the next backfill | Embeds run post-apply, so the row always exists |

## Changes

1. **`packages/core/src/indexing/asset-description-text.ts`** — new `gatherAssetDescriptionBodies()` returns per-asset `{assetPath, body}` entries (same dedup/frontmatter-strip/cap accumulation); `gatherAssetDescriptionText` now composes it, producing byte-identical FTS output.
2. **`packages/core/src/embeddings/chunk.ts`** — the sentence-accumulation loop is extracted into `chunkRun`, and the runt-tail merge into `mergeRuntTail`; `chunkNote` keeps its exact historical output (only the final chunk merges), so stored chunk hashes — and the re-embed skip — hold across the update. New `chunkAssetDescriptions(bodies, baseOffset)` chunks each body under the asset's filename as heading, with synthetic positions past the end of the note source so asset chunks order last everywhere positions sort (vector pairing in `embed_write.rs`, related-notes seed cap), and the same `MAX_ASSET_TEXT_CHARS` budget as the FTS fold.
3. **`packages/core/src/embeddings/pipeline.ts`** — `embedNote` parses once, chunks the note, and appends the asset-description chunks. The existing per-note hash-skip covers them: unchanged descriptions cost no inference, a rewritten description re-embeds only its own chunk. Zero Rust changes — `apply_chunks` already refreshes metadata for hash-matched rows and drops stale ones.
4. **`packages/core/src/indexing/indexer.ts`** — `reindexNotesReferencing` now emits `emitIndexApplied` for the notes it re-applied (same generation its writes were gated on). These writes bypass the watcher pipeline entirely, so the emit is the only way index followers hear about description-driven changes.
5. **`apps/desktop/src/components/embeddings-sync.tsx`** — the follow trigger switches from the raw `subscribeFileChanges` stream to `subscribeIndexApplied` (generation-gated). This picks up both watcher batches (the live indexer emits post-apply) and description re-indexes, and fixes the new-note ordering race above. The describe controller hears the reindex emit too and re-marks the assets; the next pass hash-skips them as up-to-date — one cheap extra cycle, no loop (documented in `asset-describe-controller.ts`).
6. **`packages/core/src/exports/sync-markdown-indexing.ts`** — export `IndexAppliedListener`; **`docs/plans/20-asset-descriptions.md`** — the deferred item is marked shipped.

Deliberately duplicated per referencing note (an asset in N notes → N chunk copies), mirroring the FTS design: vectors are ~1.5 KB, descriptions cap at 8k chars/note, and all N notes genuinely contain the image so all should rank.

## Tests

- `embeddings/chunk.test.ts` — asset chunks carry the filename heading and post-note positions; stable/changing hashes; sentence split + runt-tail merge within a body; the 8k cap stops later bodies; existing `chunkNote` cases unchanged (pins the no-hash-churn refactor).
- `embeddings/pipeline.test.ts` — path-aware fake bridge with sidecars: asset chunks embed after note chunks; a missing description embeds nothing extra; the hash-skip covers unchanged descriptions; a rewritten description re-embeds only the asset chunk.
- `indexing/asset-description-text.test.ts` — per-asset bodies attribution, skip/dedup/cap semantics; existing combined-text cases untouched.
- `indexing/pipeline.test.ts` — `reindexNotesReferencing` re-applies referencing notes and emits the post-apply signal with the pinned generation; no emit when nothing referenced.
- `components/embeddings-sync.test.tsx` — follows applied batches, ignores a superseded index session's delayed emit, never embeds asset-file changes riding the same batches, teardown still drops in-flight batches.

Two Bugbot findings were fixed in follow-up commits, each with a regression test: the embedding budget now counts the `\n\n` body joiners like the FTS join-then-slice (`eea7a9b3`), and `reindexNotesReferencing` emits the post-apply signal in a `finally` so notes applied before a mid-pass failure still notify followers (`21289994`).

## Verification

- `pnpm check` — pass (typecheck + oxlint + eslint).
- `pnpm test --run src/embeddings src/indexing` in `packages/core` — 30 files, 310 tests pass.
- `pnpm test --run src/components src/lib` in `apps/desktop` — 110 files, 916 tests pass.
- Not run: a live end-to-end pass in the Tauri app (paste image → describe → semantic query).

## Risk / Rollout

- No schema or Rust changes; no migration. Existing embedded graphs pick up asset chunks lazily: the per-open backfill re-runs `embedNote` per note and the hash-skip embeds only the new asset chunks.
- The trigger switch means embeds now depend on the live indexer's post-apply emit rather than the raw watcher stream; on desktop every local write flows file → watcher → live apply → emit, and mobile's write echo feeds the same path, so coverage is equivalent (plus the description path that was previously missing).
- Pre-existing (not introduced here, flagged separately): the describe controller pins index writes and index-applied comparisons to `graph.generation` while those are index-generation-gated — if the two counters ever diverge, description re-indexing (and now re-embedding) silently drops. Also pre-existing: `reindexNotesReferencing` stamps referencing notes' `mtime` to "now", nudging recency sorts until the next reconcile re-stamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hybrid search behavior and moves embedding triggers from file events to index-applied signals; logic is well-tested but affects retrieval timing and ordering for semantic search.
> 
> **Overview**
> Asset AI description sidecars now feed **semantic** retrieval, not only lexical FTS: `embedNote` appends chunked description bodies (filename headings, same 8k cap and hash-skip as note chunks) so meaning-level queries can surface referencing notes.
> 
> **Embedding sync** no longer follows raw file watcher events—it subscribes to **`subscribeIndexApplied`** with index-generation checks. That avoids racing new notes before a `notes` row exists, picks up **`reindexNotesReferencing`** after descriptions are written (watcher bypasses `.reflect.md`), and ignores stale sessions and asset paths in the same batches.
> 
> Core plumbing: **`gatherAssetDescriptionBodies`** (FTS text unchanged via composition), **`chunkAssetDescriptions`**, and **`emitIndexApplied`** from description-driven re-indexes (including partial emit on failure). Docs mark Plan 20’s deferred semantic embedding as shipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2128999437c5ea9bfd8153dd4025a36f39396e2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
