### PR TITLE
fix(mobile): dismiss the keyboard on return in the Tasks search too

### DIFF
--- a/apps/desktop/src/mobile/screens/all-notes.tsx
+++ b/apps/desktop/src/mobile/screens/all-notes.tsx
@@ -11,7 +11,6 @@ import {
   type NoteTagFacet,
 } from '@reflect/core'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
 import { Spinner } from '@/components/ui/spinner'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { FilterBar } from '@/mobile/search-filters/filter-bar'
@@ -22,6 +21,7 @@ import {
   type AllNotesFilters,
 } from '@/mobile/search-filters/filter-state'
 import { NoteRowList, type NoteRowModel } from '@/mobile/note-row-list'
+import { SearchInput } from '@/mobile/search-input'
 import { useArrivalFocus } from '@/mobile/use-arrival-focus'
 import { useGraph } from '@/providers/graph-provider'
 import { routeForPath } from '@/routing/route'
@@ -140,22 +140,12 @@ export function MobileAllNotes({
               <ChevronLeft />
             </Button>
           )}
-          <Input
+          <SearchInput
             ref={searchInputRef}
-            type="search"
-            inputMode="search"
             placeholder="Search anything…"
             aria-label="Search notes"
             value={query}
             onChange={(event) => onQueryChange(event.target.value)}
-            onKeyDown={(event) => {
-              // Results filter live, so the keyboard's search key has nothing
-              // to submit — it dismisses the keyboard to reveal the list.
-              if (event.key === 'Enter') {
-                event.currentTarget.blur()
-              }
-            }}
-            className="text-base"
           />
         </div>
         {pending !== null ? (

--- a/apps/desktop/src/mobile/screens/tasks.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.tsx
@@ -8,7 +8,6 @@ import {
   type OpenTask,
 } from '@reflect/core'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
 import { Spinner } from '@/components/ui/spinner'
 import { useRecentlyCompleted } from '@/lib/tasks/recently-completed'
 import { taskKey } from '@/lib/tasks/task-identity'
@@ -20,6 +19,7 @@ import { completedTasksQueryKey, tasksQueryKey } from '@/lib/tasks/tasks-query'
 import { useTaskActions } from '@/lib/tasks/use-task-actions'
 import { useToday } from '@/lib/use-today'
 import { hapticImpactLight } from '@/mobile/haptics'
+import { SearchInput } from '@/mobile/search-input'
 import { MobileTaskEditSheet } from '@/mobile/task-edit-sheet'
 import { TaskFiltersDrawer } from '@/mobile/task-filters-drawer'
 import { MobileTaskGroup } from '@/mobile/task-group'
@@ -133,14 +133,11 @@ export function MobileTasks(): ReactElement {
       style={{ paddingTop: 'env(safe-area-inset-top)' }}
     >
       <header className="flex shrink-0 items-center gap-1 border-b border-border px-4 pb-2 pt-1">
-        <Input
-          type="search"
-          inputMode="search"
+        <SearchInput
           placeholder="Search tasks…"
           aria-label="Search tasks"
           value={query}
           onChange={(event) => setQuery(event.target.value)}
-          className="text-base"
         />
         {recentlyCompleted.length > 0 ? (
           <Button

--- a/apps/desktop/src/mobile/search-input.test.tsx
+++ b/apps/desktop/src/mobile/search-input.test.tsx
@@ -1,0 +1,39 @@
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SearchInput } from './search-input'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('SearchInput', () => {
+  it('blurs the field on the return key (dismissing the iOS keyboard)', () => {
+    const { getByLabelText } = render(<SearchInput aria-label="Search" />)
+    const input = getByLabelText('Search') as HTMLInputElement
+    input.focus()
+    expect(document.activeElement).toBe(input)
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(document.activeElement).not.toBe(input)
+  })
+
+  it('leaves the field focused for other keys', () => {
+    const { getByLabelText } = render(<SearchInput aria-label="Search" />)
+    const input = getByLabelText('Search') as HTMLInputElement
+    input.focus()
+    fireEvent.keyDown(input, { key: 'a' })
+    expect(document.activeElement).toBe(input)
+  })
+
+  it('runs a caller-supplied onKeyDown after dismissing', () => {
+    const onKeyDown = vi.fn()
+    const { getByLabelText } = render(<SearchInput aria-label="Search" onKeyDown={onKeyDown} />)
+    const input = getByLabelText('Search')
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onKeyDown).toHaveBeenCalledTimes(1)
+  })
+
+  it('is a search-typed input', () => {
+    const { getByLabelText } = render(<SearchInput aria-label="Search" />)
+    expect(getByLabelText('Search').getAttribute('type')).toBe('search')
+  })
+})

--- a/apps/desktop/src/mobile/search-input.tsx
+++ b/apps/desktop/src/mobile/search-input.tsx
@@ -1,0 +1,30 @@
+import { type ComponentProps, type ReactElement } from 'react'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+
+type SearchInputProps = Omit<ComponentProps<'input'>, 'type' | 'inputMode'>
+
+/**
+ * The mobile screens' search field (the All and Tasks tabs): a search-typed
+ * {@link Input} that dismisses the software keyboard on the return key. These
+ * lists filter live as you type, so the keyboard's return key ("Search", the
+ * blue key on iOS) has nothing to submit — blurring the field lowers the
+ * keyboard and hands the whole screen back to the results. A caller's own
+ * `onKeyDown` still runs after.
+ */
+export function SearchInput({ className, onKeyDown, ...props }: SearchInputProps): ReactElement {
+  return (
+    <Input
+      type="search"
+      inputMode="search"
+      className={cn('text-base', className)}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter') {
+          event.currentTarget.blur()
+        }
+        onKeyDown?.(event)
+      }}
+      {...props}
+    />
+  )
+}


### PR DESCRIPTION
## Problem

Follow-up to #627. That PR made the All-tab search dismiss the keyboard on the return key, but the **Tasks** tab has its own separate search field that still did nothing on return — so on a real device, focusing the Tasks search and pressing the blue return key left the keyboard up, covering the list. (The reported screenshot was the Tasks tab, not All.)

The return-key handling and the search-field config (`type="search"`, `inputMode="search"`, `text-base`) were also duplicated between the two screens, so the two searches could drift.

## Before → After

| Return key on the iOS keyboard | Before | After |
| --- | --- | --- |
| All tab search | Dismisses the keyboard (#627) | Dismisses the keyboard |
| Tasks tab search | Nothing | Dismisses the keyboard |

## Changes

1. **`search-input.tsx`** (new) — a shared `SearchInput` that bundles the mobile search-field config and blurs the field on the return key (these lists filter live, so the return key has nothing to submit — blurring lowers the keyboard and hands the screen back). A caller's own `onKeyDown` still runs after.
2. **`screens/all-notes.tsx`** — the inline `Input` + return-key handler from #627 collapses onto `SearchInput`; it keeps its `ref` (for the double-tap `useArrivalFocus`), which forwards straight through.
3. **`screens/tasks.tsx`** — its plain `Input` becomes a `SearchInput`, which is the actual fix: the Tasks search now dismisses the keyboard identically to All.

## Tests

- `search-input.test.tsx` — the return key blurs the field, other keys don't, a caller-supplied `onKeyDown` still runs, and the field is search-typed.
- Existing `all-notes.test.ts` and `tasks.test.ts` continue to pass against the refactor.

## Verification

- `pnpm check` (typecheck + lint) — clean (the one `max-lines` warning is pre-existing in `packages/core/src/indexing/indexer.ts`, untouched here).
- `pnpm --filter @reflect/desktop test --run` on `search-input`, `all-notes`, and `tasks` — 40 passing.
- Live in the browser mobile harness (`?platform=ios`, 375×812): the return key blurs the focused field on **both** the All and Tasks searches.

## Risk / Rollout

Mobile-only, no data or schema changes. As with #627, the blur-to-dismiss behavior was verified in the browser harness, not on a physical device — worth confirming the return key lowers the keyboard on device, since that's where the original report came from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mobile-only UI refactor with no data or API changes; behavior is localized to search field keyboard dismissal.
> 
> **Overview**
> **Follow-up to #627:** the Tasks tab search now dismisses the software keyboard when the user presses return, matching All notes—live-filtered lists have nothing to submit, so **Enter** blurs the field instead of leaving the keyboard up over the list.
> 
> A new **`SearchInput`** wraps the shared mobile search setup (`type="search"`, `inputMode="search"`, `text-base`) and centralizes the Enter-to-blur behavior; optional **`onKeyDown`** still runs afterward. **All notes** drops its inline handler in favor of **`SearchInput`** (keeping **`ref`** for arrival focus); **Tasks** swaps a plain **`Input`** for **`SearchInput`**.
> 
> **`search-input.test.tsx`** covers blur on Enter, focus on other keys, chained **`onKeyDown`**, and search input type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b9baff50125ccfd2aa8c4cbcc13fa3c87a31cd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated mobile search field with improved search-specific behavior and consistent styling.
  * Updated mobile notes and tasks screens to use the new search field.

* **Bug Fixes**
  * Pressing Enter now dismisses the mobile keyboard in search fields while still allowing other key interactions.

* **Tests**
  * Added coverage for keyboard behavior and search input configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->