### PR TITLE
Release v0.4.0-beta.41

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4737,7 +4737,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.4.0-beta.40"
+version = "0.4.0-beta.41"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.4.0-beta.40"
+version = "0.4.0-beta.41"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.4.0-beta.40",
+  "version": "0.4.0-beta.41",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.4.0-beta.41.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version-only changes with no logic, security, or data-handling modifications.
> 
> **Overview**
> **Release version bump** from `0.4.0-beta.40` to **`0.4.0-beta.41`** with no functional code changes.
> 
> The same version string is updated in **`apps/desktop/src-tauri/Cargo.toml`** (`reflect-open`), **`apps/desktop/src-tauri/tauri.conf.json`** (bundle/updater metadata), and **`Cargo.lock`** for the `reflect-open` package entry so builds and auto-update artifacts stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21ea756f191bf38294c2b50ef86970b6328a0b77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->