### PR TITLE
Release v0.4.0-beta.42

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4737,7 +4737,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.4.0-beta.41"
+version = "0.4.0-beta.42"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.4.0-beta.41"
+version = "0.4.0-beta.42"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.4.0-beta.41",
+  "version": "0.4.0-beta.42",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.4.0-beta.42.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version-only release bump with no code or dependency changes beyond the lockfile package version string.
> 
> **Overview**
> **Release version bump** for the desktop Tauri app (`reflect-open`) from `0.4.0-beta.41` to **`0.4.0-beta.42`**.
> 
> The change is limited to **`apps/desktop/src-tauri/Cargo.toml`**, **`apps/desktop/src-tauri/tauri.conf.json`**, and the matching **`reflect-open`** entry in **`Cargo.lock`**. No application logic, dependencies, or feature changes are included in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eef9c83a54bdbd230d8ccc74a60c5c053f85531a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->