### PR TITLE
Preserve sensitive text in asset OCR

### DIFF
--- a/packages/core/src/ai/describe-asset.test.ts
+++ b/packages/core/src/ai/describe-asset.test.ts
@@ -94,6 +94,19 @@ describe('describeAsset', () => {
     expect(text).toContain('image')
   })
 
+  it('instructs OCR to preserve visible sensitive text without redaction', async () => {
+    const calls = modelAnswering('A driving license.\n\n## Text\nDLN D1234567')
+
+    await request({ filename: 'license.png' })
+
+    const text = partsOf(calls).find((part) => part.type === 'text')?.text ?? ''
+    expect(text).toContain('Transcribe visible text exactly as shown.')
+    expect(text).toContain('Do not redact')
+    expect(text).toContain('driving license')
+    expect(text).toContain("driver's license numbers")
+    expect(text).toContain('If a character is unreadable, use [?]')
+  })
+
   it('sends a PDF as a file part with its media type', async () => {
     const calls = modelAnswering('A report.')
 

--- a/packages/core/src/ai/describe-asset.ts
+++ b/packages/core/src/ai/describe-asset.ts
@@ -93,6 +93,7 @@ function describePrompt(kind: AssetKind, filename: string): string {
     'Write Markdown:',
     '- Start with one or two plain sentences describing what it shows.',
     '- If it contains readable text, add a "## Text" section transcribing that text (OCR), preserving meaningful structure such as headings, lists, and tables.',
+    '- Transcribe visible text exactly as shown. Do not redact, mask, omit, summarize, or replace sensitive-looking fields such as driving license or driver\'s license numbers, IDs, account numbers, addresses, phone numbers, dates of birth, or signatures. If a character is unreadable, use [?] rather than guessing.',
     'Answer with the Markdown only — no preamble, and do not wrap the whole answer in a code fence.',
   ].join('\n')
 }


### PR DESCRIPTION
## Problem

Asset OCR descriptions are meant to make the user's local assets searchable. The current prompt asked for OCR transcription but did not explicitly tell the model to preserve sensitive-looking document fields, so providers could return masked text for items like driving license numbers even though Reflect stores the generated sidecar locally and only sends eligible assets through the existing user-approved provider path.

This PR does not relax the asset privacy gate: assets referenced by `private: true` notes are still skipped before their bytes are read or sent.

## Before -> After

| Before | After |
| --- | --- |
| OCR prompt allowed models to redact or mask sensitive-looking visible text. | OCR prompt explicitly asks for exact visible transcription and says not to redact, mask, omit, summarize, or replace sensitive-looking fields. |
| No regression test covered non-redaction wording. | `describeAsset` now has a prompt test for preserving visible sensitive text. |

## Changes

1. Updates `describePrompt` in `packages/core/src/ai/describe-asset.ts` to tell the model to preserve visible OCR text exactly, including IDs, license numbers, addresses, phone numbers, dates of birth, signatures, and other sensitive-looking fields.
2. Adds a `describeAsset` regression test that verifies the prompt carries the no-redaction instruction.

## Verification

- `pnpm --filter @reflect/core test -- src/ai/describe-asset.test.ts` passed. This package-filtered run reported 89 test files and 1170 tests passing.
- `pnpm check` passed. It emitted the existing non-failing `max-lines` warning in `packages/core/src/indexing/indexer.ts`.

## Risk / Rollout

Low-risk prompt-only behavior change. Providers can still apply their own safety behavior, but Reflect no longer requests or implies redaction. No migrations, storage format changes, or privacy-gate changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change with no privacy-gate or storage changes; providers may still apply their own safety policies.
> 
> **Overview**
> Asset **OCR sidecars** are meant to make local images/PDFs searchable; the multimodal prompt now **explicitly requires verbatim transcription** instead of leaving room for models to mask sensitive-looking fields.
> 
> `describePrompt` adds a bullet telling the model to transcribe visible text exactly, **not** to redact/mask/omit/summarize IDs, license numbers, addresses, phone numbers, DOB, signatures, etc., and to use `[?]` for unreadable characters. A **`describeAsset` unit test** asserts those instructions appear in the prompt sent to the provider.
> 
> The asset **privacy gate** (`private: true` notes, BYOK path) is unchanged—only what Reflect *asks* the model to return in local description Markdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9026a116fd92164300773f97b453965536232d64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text extraction from images so visible details are transcribed more accurately, including sensitive-looking fields that should not be hidden or summarized.
  * Unreadable characters are now marked clearly instead of being guessed.

* **Tests**
  * Added coverage to ensure image descriptions follow the updated transcription rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->