### PR TITLE
Add audio memos to the iOS app (wave 1: in-app native recording)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4772,6 +4772,7 @@ dependencies = [
  "tauri-plugin-keyboard",
  "tauri-plugin-opener",
  "tauri-plugin-process",
+ "tauri-plugin-recording",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
@@ -6105,6 +6106,16 @@ checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
 dependencies = [
  "tauri",
  "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-recording"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "apps/native-host",
   "crates/index-schema",
   "plugins/tauri-plugin-keyboard",
+  "plugins/tauri-plugin-recording",
 ]
 
 [workspace.dependencies]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -162,6 +162,7 @@ ort = { version = "=2.0.0-rc.11", default-features = false, features = [
 # plugin's `impact_light` command.)
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
 tauri-plugin-keyboard = { path = "../../../plugins/tauri-plugin-keyboard" }
+tauri-plugin-recording = { path = "../../../plugins/tauri-plugin-recording" }
 
 [dev-dependencies]
 tauri = { version = "2.11.2", features = ["test"] }

--- a/apps/desktop/src-tauri/capabilities/mobile.json
+++ b/apps/desktop/src-tauri/capabilities/mobile.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../gen/schemas/mobile-schema.json",
   "identifier": "mobile",
-  "description": "Mobile-only capabilities: the keyboard bridge (Plan 19)",
+  "description": "Mobile-only capabilities: the keyboard bridge (Plan 19) and the native audio-memo recorder",
   "platforms": ["iOS", "android"],
   "windows": ["main"],
-  "permissions": ["keyboard:default"]
+  "permissions": ["keyboard:default", "recording:default"]
 }

--- a/apps/desktop/src-tauri/gen/apple/RecordingWidget/Info.plist
+++ b/apps/desktop/src-tauri/gen/apple/RecordingWidget/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Reflect</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.4.0</string>
+	<key>CFBundleVersion</key>
+	<string>0.4.0.17</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/gen/apple/RecordingWidget/RecordAudioWidget.swift
+++ b/apps/desktop/src-tauri/gen/apple/RecordingWidget/RecordAudioWidget.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+import WidgetKit
+
+/// One static, dateless entry — the widget is a button, not a data view.
+struct RecordEntry: TimelineEntry {
+  let date: Date
+}
+
+struct RecordProvider: TimelineProvider {
+  func placeholder(in context: Context) -> RecordEntry {
+    RecordEntry(date: .now)
+  }
+
+  func getSnapshot(in context: Context, completion: @escaping (RecordEntry) -> Void) {
+    completion(RecordEntry(date: .now))
+  }
+
+  func getTimeline(in context: Context, completion: @escaping (Timeline<RecordEntry>) -> Void) {
+    completion(Timeline(entries: [RecordEntry(date: .now)], policy: .never))
+  }
+}
+
+/// The "start an audio memo" widget (V1's lock-screen widget, rebuilt beside
+/// the Tauri shell): tapping opens the app through `reflect://record-audio`,
+/// which the Rust shell hands to the recording plugin's persisted action
+/// queue — recording starts once the webview is ready, and the request
+/// survives cold starts and webview crashes (the V1 handshake).
+struct RecordAudioWidget: Widget {
+  var body: some WidgetConfiguration {
+    StaticConfiguration(kind: "app.reflect.record-audio", provider: RecordProvider()) { _ in
+      RecordAudioWidgetView()
+        .widgetURL(URL(string: "reflect://record-audio"))
+        .widgetBackgroundCompat()
+    }
+    .configurationDisplayName("Record audio memo")
+    .description("Start recording an audio memo in Reflect.")
+    .supportedFamilies([.accessoryCircular, .systemSmall])
+  }
+}
+
+struct RecordAudioWidgetView: View {
+  @Environment(\.widgetFamily) private var family
+
+  var body: some View {
+    switch family {
+    case .accessoryCircular:
+      // Lock-screen circular: glyph only, system-tinted like Voice Memos'.
+      ZStack {
+        AccessoryWidgetBackground()
+        Image(systemName: "mic.fill")
+          .font(.title3)
+      }
+    default:
+      VStack(spacing: 8) {
+        Image(systemName: "mic.fill")
+          .font(.largeTitle)
+          .foregroundStyle(.red)
+        Text("Record audio")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+    }
+  }
+}
+
+extension View {
+  /// iOS 17 requires `containerBackground` on widget views (older widgets
+  /// render an adoption error); the deployment target is 16.2, so apply it
+  /// conditionally.
+  @ViewBuilder
+  func widgetBackgroundCompat() -> some View {
+    if #available(iOS 17.0, *) {
+      containerBackground(.background, for: .widget)
+    } else {
+      self
+    }
+  }
+}

--- a/apps/desktop/src-tauri/gen/apple/RecordingWidget/RecordingActivityWidget.swift
+++ b/apps/desktop/src-tauri/gen/apple/RecordingWidget/RecordingActivityWidget.swift
@@ -1,0 +1,91 @@
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+/// The recording Live Activity (V1's `RecordingActivityWidget`, rebuilt):
+/// lock-screen banner + Dynamic Island showing a live elapsed timer while a
+/// memo records, with a stop button on iOS 17+ (a `LiveActivityIntent` that
+/// performs in the app's process — see `StopRecordingLiveActivityIntent.swift`,
+/// compiled into both targets). The timer renders from `startedAt` with no
+/// updates needed; the recording plugin starts and ends the activity.
+struct RecordingActivityWidget: Widget {
+  var body: some WidgetConfiguration {
+    ActivityConfiguration(for: RecordingActivityAttributes.self) { context in
+      HStack(spacing: 12) {
+        Image(systemName: "mic.fill")
+          .font(.title3)
+          .foregroundStyle(.red)
+        VStack(alignment: .leading, spacing: 2) {
+          Text("Recording")
+            .font(.headline)
+          Text("Reflect")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        Spacer()
+        RecordingTimerText(startedAt: context.state.startedAt)
+          .font(.title3.monospacedDigit())
+        StopRecordingButton()
+      }
+      .padding()
+    } dynamicIsland: { context in
+      DynamicIsland {
+        DynamicIslandExpandedRegion(.leading) {
+          Image(systemName: "mic.fill")
+            .font(.title2)
+            .foregroundStyle(.red)
+        }
+        DynamicIslandExpandedRegion(.center) {
+          VStack(spacing: 2) {
+            Text("Recording")
+              .font(.headline)
+            RecordingTimerText(startedAt: context.state.startedAt)
+              .font(.title3.monospacedDigit())
+              .frame(maxWidth: 80)
+          }
+        }
+        DynamicIslandExpandedRegion(.trailing) {
+          StopRecordingButton()
+        }
+      } compactLeading: {
+        Image(systemName: "mic.fill")
+          .foregroundStyle(.red)
+      } compactTrailing: {
+        RecordingTimerText(startedAt: context.state.startedAt)
+          .font(.caption.monospacedDigit())
+          .frame(width: 44)
+      } minimal: {
+        Image(systemName: "mic.fill")
+          .foregroundStyle(.red)
+      }
+    }
+  }
+}
+
+/// The counting-up elapsed display — self-updating, so the activity never
+/// needs a content refresh while recording.
+private struct RecordingTimerText: View {
+  let startedAt: Date
+
+  var body: some View {
+    Text(timerInterval: startedAt...Date.distantFuture, countsDown: false)
+      .multilineTextAlignment(.trailing)
+  }
+}
+
+/// The stop control: iOS 17 can run a `LiveActivityIntent` straight from the
+/// lock screen; earlier versions get no button (V1 parity — tapping the
+/// activity opens the app, where the drawer's stop lives).
+private struct StopRecordingButton: View {
+  var body: some View {
+    if #available(iOS 17.0, *) {
+      Button(intent: StopRecordingIntent()) {
+        Image(systemName: "stop.fill")
+          .font(.title3)
+          .foregroundStyle(.red)
+          .padding(8)
+      }
+      .buttonStyle(.plain)
+    }
+  }
+}

--- a/apps/desktop/src-tauri/gen/apple/RecordingWidget/RecordingActivityWidget.swift
+++ b/apps/desktop/src-tauri/gen/apple/RecordingWidget/RecordingActivityWidget.swift
@@ -79,7 +79,7 @@ private struct RecordingTimerText: View {
 private struct StopRecordingButton: View {
   var body: some View {
     if #available(iOS 17.0, *) {
-      Button(intent: StopRecordingIntent()) {
+      Button(intent: StopRecordingLiveActivityIntent()) {
         Image(systemName: "stop.fill")
           .font(.title3)
           .foregroundStyle(.red)

--- a/apps/desktop/src-tauri/gen/apple/RecordingWidget/RecordingWidget.entitlements
+++ b/apps/desktop/src-tauri/gen/apple/RecordingWidget/RecordingWidget.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.app.reflect</string>
+	</array>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/gen/apple/RecordingWidget/RecordingWidgetBundle.swift
+++ b/apps/desktop/src-tauri/gen/apple/RecordingWidget/RecordingWidgetBundle.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+import WidgetKit
+
+/// The widget extension's entry point (audio-memos wave 3): the lock-screen /
+/// home-screen "record" widget plus the recording Live Activity. Swift only —
+/// no Rust, no webview; both surfaces hand off to the main app (the widget
+/// through `reflect://record-audio`, the activity's stop button through an
+/// in-process `LiveActivityIntent`).
+@main
+struct ReflectWidgetBundle: WidgetBundle {
+  var body: some Widget {
+    RecordAudioWidget()
+    RecordingActivityWidget()
+  }
+}

--- a/apps/desktop/src-tauri/gen/apple/Sources/reflect-open/RecordingIntents.swift
+++ b/apps/desktop/src-tauri/gen/apple/Sources/reflect-open/RecordingIntents.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+#if canImport(AppIntents)
+  import AppIntents
+
+  /// Siri / Shortcuts entry points for audio memos (audio-memos wave 3,
+  /// V1 parity: "Start recording in Reflect").
+  ///
+  /// These compile into the app target, so `perform()` runs in the app's own
+  /// process — but in a different module from the recording plugin (a static
+  /// library compiled through swift-rs). They talk to it through
+  /// NotificationCenter; the names mirror the constants in
+  /// `plugins/tauri-plugin-recording/ios/Sources/RecordingPlugin.swift`.
+  /// Starting goes through the plugin's persisted action queue (the webview
+  /// must present recording UI); stopping is finalized natively at once.
+  @available(iOS 16.0, *)
+  struct StartRecordingIntent: AppIntent {
+    static var title: LocalizedStringResource = "Start recording"
+    static var description = IntentDescription(
+      "Start recording an audio memo that Reflect transcribes into your daily note.")
+    static var openAppWhenRun = true
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+      NotificationCenter.default.post(
+        name: Notification.Name("app.reflect.recording.start-requested"), object: nil)
+      return .result()
+    }
+  }
+
+  @available(iOS 16.0, *)
+  struct StopRecordingSiriIntent: AppIntent {
+    static var title: LocalizedStringResource = "Stop recording"
+    static var description = IntentDescription("Stop the audio memo Reflect is recording.")
+    static var openAppWhenRun = false
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+      NotificationCenter.default.post(
+        name: Notification.Name("app.reflect.recording.stop-requested"), object: nil)
+      return .result()
+    }
+  }
+
+  @available(iOS 16.4, *)
+  struct ReflectAppShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+      AppShortcut(
+        intent: StartRecordingIntent(),
+        phrases: [
+          "Start recording in \(.applicationName)",
+          "Record an audio memo in \(.applicationName)",
+        ],
+        shortTitle: "Record audio",
+        systemImageName: "mic"
+      )
+      AppShortcut(
+        intent: StopRecordingSiriIntent(),
+        phrases: ["Stop recording in \(.applicationName)"],
+        shortTitle: "Stop recording",
+        systemImageName: "stop.circle"
+      )
+    }
+  }
+#endif

--- a/apps/desktop/src-tauri/gen/apple/Sources/reflect-open/StopRecordingLiveActivityIntent.swift
+++ b/apps/desktop/src-tauri/gen/apple/Sources/reflect-open/StopRecordingLiveActivityIntent.swift
@@ -13,8 +13,11 @@ import Foundation
   /// (the button references the type) — the standard shared-source pattern.
   /// The notification name mirrors `RecordingPlugin.stopRequestedNotification`.
   @available(iOS 17.0, *)
-  struct StopRecordingIntent: LiveActivityIntent {
+  struct StopRecordingLiveActivityIntent: LiveActivityIntent {
     static var title: LocalizedStringResource = "Stop recording"
+    /// Hidden from the Shortcuts app — `StopRecordingSiriIntent` is the
+    /// discoverable stop; this one exists only behind the activity's button.
+    static var isDiscoverable: Bool = false
 
     @MainActor
     func perform() async throws -> some IntentResult {

--- a/apps/desktop/src-tauri/gen/apple/Sources/reflect-open/StopRecordingLiveActivityIntent.swift
+++ b/apps/desktop/src-tauri/gen/apple/Sources/reflect-open/StopRecordingLiveActivityIntent.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+#if canImport(AppIntents)
+  import AppIntents
+
+  /// The Live Activity's stop button (audio-memos wave 3). A
+  /// `LiveActivityIntent` performs in the app's process without foregrounding
+  /// it, so the lock screen can end a memo directly; the recording plugin
+  /// observes the notification and finalizes the file natively (reason
+  /// `remote`), and ingest follows the usual staged-file paths.
+  ///
+  /// Compiled into BOTH the app target (execution) and the widget extension
+  /// (the button references the type) — the standard shared-source pattern.
+  /// The notification name mirrors `RecordingPlugin.stopRequestedNotification`.
+  @available(iOS 17.0, *)
+  struct StopRecordingIntent: LiveActivityIntent {
+    static var title: LocalizedStringResource = "Stop recording"
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+      NotificationCenter.default.post(
+        name: Notification.Name("app.reflect.recording.stop-requested"), object: nil)
+      return .result()
+    }
+  }
+#endif

--- a/apps/desktop/src-tauri/gen/apple/project.yml
+++ b/apps/desktop/src-tauri/gen/apple/project.yml
@@ -63,6 +63,11 @@ targets:
         NSMicrophoneUsageDescription: Reflect uses the microphone to record audio memos that are transcribed into your daily note.
         NSCalendarsFullAccessUsageDescription: Reflect reads your calendar to show the day's meetings beside your daily note. Access is read-only and stays on this device.
         NSCalendarsUsageDescription: Reflect reads your calendar to show the day's meetings beside your daily note. Access is read-only and stays on this device.
+        # Audio memos keep recording through screen lock and backgrounding
+        # (audio-memos wave 2). The recording plugin activates the audio
+        # session only while a recording is live, so the mode never keeps the
+        # app running outside an actual capture.
+        UIBackgroundModes: [audio]
         UILaunchStoryboardName: LaunchScreen
         UIRequiredDeviceCapabilities: [arm64, metal]
         UISupportedInterfaceOrientations:

--- a/apps/desktop/src-tauri/gen/apple/project.yml
+++ b/apps/desktop/src-tauri/gen/apple/project.yml
@@ -68,6 +68,21 @@ targets:
         # session only while a recording is live, so the mode never keeps the
         # app running outside an actual capture.
         UIBackgroundModes: [audio]
+        # The `reflect://` scheme (audio-memos wave 3): the lock-screen
+        # widget opens `reflect://record-audio`, which the Rust shell hands
+        # to the recording plugin's action queue. Desktop registers the same
+        # scheme through the deep-link plugin config in tauri.conf.json.
+        CFBundleURLTypes:
+          - CFBundleURLName: app.reflect.ios
+            CFBundleURLSchemes: [reflect]
+        # The recording Live Activity (audio-memos wave 3).
+        NSSupportsLiveActivities: true
+        # Home-screen quick action (audio-memos wave 3); handled by the
+        # recording plugin via the shortcut-item delegate hook.
+        UIApplicationShortcutItems:
+          - UIApplicationShortcutItemType: app.reflect.record-audio
+            UIApplicationShortcutItemTitle: Record audio
+            UIApplicationShortcutItemIconType: UIApplicationShortcutIconTypeAudio
         UILaunchStoryboardName: LaunchScreen
         UIRequiredDeviceCapabilities: [arm64, metal]
         UISupportedInterfaceOrientations:
@@ -126,12 +141,17 @@ targets:
         LIBRARY_SEARCH_PATHS[arch=x86_64]: $(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)
         LIBRARY_SEARCH_PATHS[arch=arm64]: $(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)
         ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: true
+        SWIFT_VERSION: "5.0"
         EXCLUDED_ARCHS[sdk=iphoneos*]: x86_64
       groups: [app]
     dependencies:
       # The share-sheet capture extension (Plan 11's iOS producer): embedded
       # into the app bundle and signed with it.
       - target: ShareExtension
+        embed: true
+      # The audio-memo widget extension (wave 3): lock-screen record widget
+      # + the recording Live Activity; embedded and signed with the app.
+      - target: RecordingWidget
         embed: true
       - framework: libapp.a
         embed: false
@@ -224,6 +244,60 @@ targets:
           if [ "${CODE_SIGNING_ALLOWED:-YES}" = "NO" ]; then
             /usr/bin/codesign --force --sign - \
               --entitlements "${SRCROOT:?}/ShareExtension/ShareExtension.entitlements" \
+              "${CODESIGNING_FOLDER_PATH:?}"
+          fi
+        name: Preserve entitlements on skip-codesign builds
+        basedOnDependencyAnalysis: false
+
+  # The audio-memo widget extension (wave 3): the lock-screen / home-screen
+  # "record" widget plus the recording Live Activity. Swift only — no Rust,
+  # no webview. Two sources are shared by path: the Live Activity attributes
+  # (also compiled into the recording plugin — ActivityKit matches app and
+  # widget by type name) and the stop LiveActivityIntent (also compiled into
+  # the app target, where it executes).
+  RecordingWidget:
+    type: app-extension
+    platform: iOS
+    deploymentTarget: "16.2"
+    sources:
+      - path: RecordingWidget/RecordingWidgetBundle.swift
+      - path: RecordingWidget/RecordAudioWidget.swift
+      - path: RecordingWidget/RecordingActivityWidget.swift
+      - path: Sources/reflect-open/StopRecordingLiveActivityIntent.swift
+      - path: ../../../../../plugins/tauri-plugin-recording/ios/Sources/RecordingActivityAttributes.swift
+    info:
+      path: RecordingWidget/Info.plist
+      properties:
+        CFBundleDisplayName: Reflect
+        CFBundleShortVersionString: 0.4.0
+        CFBundleVersion: 0.4.0.17
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.widgetkit-extension
+    # The widget needs no capability of its own, but the release pipeline
+    # asserts every appex carries the App Group (release-ios.mjs), and the
+    # skip-codesign ad-hoc phase below must have entitlements to preserve —
+    # exactly like ShareExtension.
+    entitlements:
+      path: RecordingWidget/RecordingWidget.entitlements
+      properties:
+        com.apple.security.application-groups:
+          - group.app.reflect
+    settings:
+      base:
+        PRODUCT_NAME: RecordingWidget
+        PRODUCT_BUNDLE_IDENTIFIER: app.reflect.ios.widgets
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: 789ULN5MZB
+        SWIFT_VERSION: "5.0"
+        TARGETED_DEVICE_FAMILY: 1,2
+    postBuildScripts:
+      # Same skip-codesign entitlement preservation as ShareExtension: CI
+      # TestFlight builds archive unsigned, and export re-signing only keeps
+      # entitlements already present in a signature.
+      - script: |
+          if [ "${CODE_SIGNING_ALLOWED:-YES}" = "NO" ]; then
+            /usr/bin/codesign --force --sign - \
+              --entitlements "${SRCROOT:?}/RecordingWidget/RecordingWidget.entitlements" \
               "${CODESIGNING_FOLDER_PATH:?}"
           fi
         name: Preserve entitlements on skip-codesign builds

--- a/apps/desktop/src-tauri/gen/apple/reflect-open.xcodeproj/project.pbxproj
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open.xcodeproj/project.pbxproj
@@ -7,14 +7,18 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		14BE6EF4AB511AC099410853 /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 57BCB79C0774021318852985 /* main.mm */; };
 		1C8847A7F1C163FBA53373F9 /* ExtensionClass.js in Resources */ = {isa = PBXBuildFile; fileRef = 536E4F5E21B7DCC3C7ECDC1A /* ExtensionClass.js */; };
 		266B3807E809464C8FC14146 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FDC9BB81FAB5AF8D65160799 /* Metal.framework */; };
 		319EDF8F46AB05DFBA9D674F /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 80E05926405BFDA2A3BC70BC /* libz.tbd */; };
 		495C9E97530FC781EB5645D6 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A58A746A41B6BF1D50A8547 /* ShareViewController.swift */; };
 		5693613DE956199D6486EA26 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D0D6D72E614086946EBF890 /* LaunchScreen.storyboard */; };
-		5C88834F22D37FFC49CBD2F1 /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 38829A9D2116D0D324C18C4B /* main.mm */; };
+		6C3751B3B175DFE411D97C0F /* StopRecordingLiveActivityIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3613166A0FB6AFF3C3B2F85C /* StopRecordingLiveActivityIntent.swift */; };
+		6C55CBAB912EC5920CE314DA /* RecordingIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29B88183661F5C1C960E074 /* RecordingIntents.swift */; };
 		74275EAEFEA922B7D8A2C78F /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5249E1475DBD7CCB817F7D1B /* CoreGraphics.framework */; };
+		85FC869F776C24A9ED0A1779 /* RecordingActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C228C4BA95B0BADA424A9E8A /* RecordingActivityAttributes.swift */; };
 		93F2A1181D6BC7832338EE9C /* ShareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93EF89A222208D739ABC00B8 /* ShareView.swift */; };
+		9611839F9E9EC688FCDFCC91 /* RecordingWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A26DB86321DA75DFE1CD4B41 /* RecordingWidgetBundle.swift */; };
 		961AA49623F0DDC7AB09B777 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39269153EFAD0C2FEFBE6696 /* UIKit.framework */; };
 		9C05940F9725363AAB9131D3 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C94374B175075AF3AA7DE586 /* Security.framework */; };
 		9D7F5A94048CECBFC3D89BBA /* libapp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F28F8A628D32337E04C0CBC0 /* libapp.a */; };
@@ -22,15 +26,26 @@
 		B109D161D258110DC703F97C /* ShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 51006DE1482D28D9562253A1 /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		B6B5B091EADAF6EAEC6E2EDA /* ShareState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89342C7501B47DBB934B2D27 /* ShareState.swift */; };
 		BEA09DBDD61413051FFEB9E3 /* CaptureInbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = D357D2D54012FD394DF9423E /* CaptureInbox.swift */; };
+		BFB9F91C8E2628460C84C8A3 /* StopRecordingLiveActivityIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3613166A0FB6AFF3C3B2F85C /* StopRecordingLiveActivityIntent.swift */; };
 		C1FBC0B57C41A13D88225DFB /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 3ED6411036D50396010D935D /* assets */; };
 		C4FAE42D7B978D8330E5D6DC /* Contacts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D182B9445129EC2433F8218 /* Contacts.framework */; };
+		C605CBEEDBC31FA67F1A4F5E /* RecordingWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = DB54D6D030C08888E9D17442 /* RecordingWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		D37EE1ED817FDDC16C5643BB /* RecordingActivityWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A3930E6E7AB28929B07A6D0 /* RecordingActivityWidget.swift */; };
 		DD1AE73F867F4264272EFED2 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 68D1FDE7F099CA5F909105EB /* QuartzCore.framework */; };
 		E413DBCB60FF081C8E58468A /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 088536D8F462855DCFDA7B06 /* WebKit.framework */; };
+		E7D75AA83CFA468E0EFBAB21 /* RecordAudioWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AC6BF821D47F74D41DFAFE /* RecordAudioWidget.swift */; };
 		E9E7B6C59015E7301EE63308 /* libiconv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 44C3B8C21F2D38187423AB2F /* libiconv.tbd */; };
 		F00F5EAED90E34102F9AE651 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A86D201016958E2276806466 /* Assets.xcassets */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		6A2683A904EF67AC778ED704 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5489219F37B2885D5C3112F4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 665EB942B5F6FB93F8DF2A57;
+			remoteInfo = RecordingWidget;
+		};
 		E15A48A368A368CDA2B5A070 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 5489219F37B2885D5C3112F4 /* Project object */;
@@ -48,6 +63,7 @@
 			dstSubfolderSpec = 13;
 			files = (
 				B109D161D258110DC703F97C /* ShareExtension.appex in Embed Foundation Extensions */,
+				C605CBEEDBC31FA67F1A4F5E /* RecordingWidget.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -60,7 +76,9 @@
 		08B3817A23175E584BA6FD8D /* error.rs */ = {isa = PBXFileReference; path = error.rs; sourceTree = "<group>"; };
 		152767D3A95549268E140D0F /* graph_gitignore.rs */ = {isa = PBXFileReference; path = graph_gitignore.rs; sourceTree = "<group>"; };
 		18A732A38CD75FF514E4CF86 /* settings.rs */ = {isa = PBXFileReference; path = settings.rs; sourceTree = "<group>"; };
+		1A3930E6E7AB28929B07A6D0 /* RecordingActivityWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingActivityWidget.swift; sourceTree = "<group>"; };
 		1A58A746A41B6BF1D50A8547 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
+		1B481887CBBFA6FB3C78F2B2 /* bindings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bindings.h; sourceTree = "<group>"; };
 		1EB2845C34150F5FE04A33D3 /* write.rs */ = {isa = PBXFileReference; path = write.rs; sourceTree = "<group>"; };
 		2130029E77013461A501E644 /* devtools.rs */ = {isa = PBXFileReference; path = devtools.rs; sourceTree = "<group>"; };
 		21F0526713DAC48C777B2D4C /* union.rs */ = {isa = PBXFileReference; path = union.rs; sourceTree = "<group>"; };
@@ -70,10 +88,10 @@
 		2EDECD14A0418A8D4AA04512 /* remote.rs */ = {isa = PBXFileReference; path = remote.rs; sourceTree = "<group>"; };
 		2FA419867A84041644CC42E9 /* skill.rs */ = {isa = PBXFileReference; path = skill.rs; sourceTree = "<group>"; };
 		32B7D9FD2081133899440765 /* mod.rs */ = {isa = PBXFileReference; path = mod.rs; sourceTree = "<group>"; };
+		3613166A0FB6AFF3C3B2F85C /* StopRecordingLiveActivityIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopRecordingLiveActivityIntent.swift; sourceTree = "<group>"; };
 		3779A211A168AE84C5573923 /* merge.rs */ = {isa = PBXFileReference; path = merge.rs; sourceTree = "<group>"; };
 		37EF719F509C3A532C0E0114 /* main.rs */ = {isa = PBXFileReference; path = main.rs; sourceTree = "<group>"; };
 		383CB9669208178C6B235BE6 /* io.rs */ = {isa = PBXFileReference; path = io.rs; sourceTree = "<group>"; };
-		38829A9D2116D0D324C18C4B /* main.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = main.mm; sourceTree = "<group>"; };
 		39269153EFAD0C2FEFBE6696 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		3AE251E5F7E95CDEFDD3C8B4 /* reflect-open_iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "reflect-open_iOS.entitlements"; sourceTree = "<group>"; };
 		3D182B9445129EC2433F8218 /* Contacts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Contacts.framework; path = System/Library/Frameworks/Contacts.framework; sourceTree = SDKROOT; };
@@ -88,6 +106,7 @@
 		5306360328A772EEE5EDDD87 /* versions.rs */ = {isa = PBXFileReference; path = versions.rs; sourceTree = "<group>"; };
 		536E4F5E21B7DCC3C7ECDC1A /* ExtensionClass.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = ExtensionClass.js; sourceTree = "<group>"; };
 		560C7C23BE58D7EA845F1170 /* lib.rs */ = {isa = PBXFileReference; path = lib.rs; sourceTree = "<group>"; };
+		57BCB79C0774021318852985 /* main.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = main.mm; sourceTree = "<group>"; };
 		5C56D455FF36B2FFA8189246 /* repo.rs */ = {isa = PBXFileReference; path = repo.rs; sourceTree = "<group>"; };
 		5F2E1B8E7D79BDAFFCD2DCDE /* assets.rs */ = {isa = PBXFileReference; path = assets.rs; sourceTree = "<group>"; };
 		5F605BA8949402DAE91B9243 /* embed_write.rs */ = {isa = PBXFileReference; path = embed_write.rs; sourceTree = "<group>"; };
@@ -97,7 +116,6 @@
 		6BB60C6D34C4AFB61F084B4D /* mod.rs */ = {isa = PBXFileReference; path = mod.rs; sourceTree = "<group>"; };
 		73D6C2FDB2DD7919E24C4533 /* mod.rs */ = {isa = PBXFileReference; path = mod.rs; sourceTree = "<group>"; };
 		772B62ED093A33BDCD1864D8 /* calendar.rs */ = {isa = PBXFileReference; path = calendar.rs; sourceTree = "<group>"; };
-		777653BF3E38355A5F6B6EF9 /* bindings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bindings.h; sourceTree = "<group>"; };
 		80E05926405BFDA2A3BC70BC /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		88ED38A3B3D14839B5066255 /* embed.rs */ = {isa = PBXFileReference; path = embed.rs; sourceTree = "<group>"; };
 		89342C7501B47DBB934B2D27 /* ShareState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareState.swift; sourceTree = "<group>"; };
@@ -106,6 +124,7 @@
 		8C04E40F02C9B4AE9A24A9A4 /* recents.rs */ = {isa = PBXFileReference; path = recents.rs; sourceTree = "<group>"; };
 		8D0D6D72E614086946EBF890 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		93EF89A222208D739ABC00B8 /* ShareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareView.swift; sourceTree = "<group>"; };
+		A26DB86321DA75DFE1CD4B41 /* RecordingWidgetBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingWidgetBundle.swift; sourceTree = "<group>"; };
 		A4F0D18C7B37B593ED8ACD6F /* scan.rs */ = {isa = PBXFileReference; path = scan.rs; sourceTree = "<group>"; };
 		A67279D745DF48458936735A /* storage.rs */ = {isa = PBXFileReference; path = storage.rs; sourceTree = "<group>"; };
 		A86D201016958E2276806466 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -115,15 +134,19 @@
 		ADB23521181EEB9EF095D4AB /* contacts.rs */ = {isa = PBXFileReference; path = contacts.rs; sourceTree = "<group>"; };
 		B667667E9C6C141128493B00 /* quit.rs */ = {isa = PBXFileReference; path = quit.rs; sourceTree = "<group>"; };
 		BC3901740F3A40252C3750C7 /* reflect-open_iOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "reflect-open_iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C228C4BA95B0BADA424A9E8A /* RecordingActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingActivityAttributes.swift; sourceTree = "<group>"; };
 		C38A6847351881E6D17A1DC2 /* migrations.rs */ = {isa = PBXFileReference; path = migrations.rs; sourceTree = "<group>"; };
 		C7BE8291B337F95D913C6AE9 /* commit_message.rs */ = {isa = PBXFileReference; path = commit_message.rs; sourceTree = "<group>"; };
 		C94374B175075AF3AA7DE586 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		CF582FB0094C95210BE919F7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D05B757D9AB841897576F256 /* merge3.rs */ = {isa = PBXFileReference; path = merge3.rs; sourceTree = "<group>"; };
+		D29B88183661F5C1C960E074 /* RecordingIntents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingIntents.swift; sourceTree = "<group>"; };
 		D357D2D54012FD394DF9423E /* CaptureInbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureInbox.swift; sourceTree = "<group>"; };
 		D3691D8F671B7FA21D1E7BD7 /* mod.rs */ = {isa = PBXFileReference; path = mod.rs; sourceTree = "<group>"; };
+		D7AC6BF821D47F74D41DFAFE /* RecordAudioWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordAudioWidget.swift; sourceTree = "<group>"; };
 		D7DA2E13EA6655A16DFDE015 /* secrets.rs */ = {isa = PBXFileReference; path = secrets.rs; sourceTree = "<group>"; };
 		D8F1F4787BA60FD05FD83FD1 /* spike_mobile.rs */ = {isa = PBXFileReference; path = spike_mobile.rs; sourceTree = "<group>"; };
+		DB54D6D030C08888E9D17442 /* RecordingWidget.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = RecordingWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		DBD22A8C59FD8892E5F139EC /* tests.rs */ = {isa = PBXFileReference; path = tests.rs; sourceTree = "<group>"; };
 		DD5CA5DD1A0A2C6898BF16AE /* tests.rs */ = {isa = PBXFileReference; path = tests.rs; sourceTree = "<group>"; };
 		DFD67CD43D5BD05A1C511C01 /* import.rs */ = {isa = PBXFileReference; path = import.rs; sourceTree = "<group>"; };
@@ -158,6 +181,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		024093CF75026447063ECAFB /* bindings */ = {
+			isa = PBXGroup;
+			children = (
+				1B481887CBBFA6FB3C78F2B2 /* bindings.h */,
+			);
+			path = bindings;
+			sourceTree = "<group>";
+		};
 		064330CA0617C1F023B33371 /* ShareExtension */ = {
 			isa = PBXGroup;
 			children = (
@@ -173,6 +204,7 @@
 		085B9B9F8FF6A8514F9F4511 /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				DB54D6D030C08888E9D17442 /* RecordingWidget.appex */,
 				BC3901740F3A40252C3750C7 /* reflect-open_iOS.app */,
 				51006DE1482D28D9562253A1 /* ShareExtension.appex */,
 			);
@@ -200,9 +232,12 @@
 				A86D201016958E2276806466 /* Assets.xcassets */,
 				8D0D6D72E614086946EBF890 /* LaunchScreen.storyboard */,
 				59A902E5FAB9324234886822 /* Externals */,
+				90B73AA2E17A6707CD2373F8 /* RecordingWidget */,
+				B36B6C8C4266337158D8EA7E /* reflect-open */,
 				D93D4C46C491FF3654305D76 /* reflect-open_iOS */,
 				064330CA0617C1F023B33371 /* ShareExtension */,
 				3644284E3067EA5E39E59FDA /* Sources */,
+				503727866B7D08BD30A503FF /* Sources */,
 				55421F1EE94451C6C2F0F2F6 /* src */,
 				B6C98802589FDB7BF4EC3F7C /* Frameworks */,
 				085B9B9F8FF6A8514F9F4511 /* Products */,
@@ -212,7 +247,7 @@
 		3644284E3067EA5E39E59FDA /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				504E678B5FB1E7386811074E /* reflect-open */,
+				B36B6C8C4266337158D8EA7E /* reflect-open */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -232,13 +267,13 @@
 			path = conflict;
 			sourceTree = "<group>";
 		};
-		504E678B5FB1E7386811074E /* reflect-open */ = {
+		503727866B7D08BD30A503FF /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				38829A9D2116D0D324C18C4B /* main.mm */,
-				B04D04114CD26DD4ACE666B0 /* bindings */,
+				C228C4BA95B0BADA424A9E8A /* RecordingActivityAttributes.swift */,
 			);
-			path = "reflect-open";
+			name = Sources;
+			path = "../../../../../plugins/tauri-plugin-recording/ios/Sources";
 			sourceTree = "<group>";
 		};
 		55421F1EE94451C6C2F0F2F6 /* src */ = {
@@ -292,6 +327,16 @@
 			path = icloud;
 			sourceTree = "<group>";
 		};
+		90B73AA2E17A6707CD2373F8 /* RecordingWidget */ = {
+			isa = PBXGroup;
+			children = (
+				D7AC6BF821D47F74D41DFAFE /* RecordAudioWidget.swift */,
+				1A3930E6E7AB28929B07A6D0 /* RecordingActivityWidget.swift */,
+				A26DB86321DA75DFE1CD4B41 /* RecordingWidgetBundle.swift */,
+			);
+			path = RecordingWidget;
+			sourceTree = "<group>";
+		};
 		9E54DCC255F04D51453CC522 /* db */ = {
 			isa = PBXGroup;
 			children = (
@@ -307,12 +352,16 @@
 			path = db;
 			sourceTree = "<group>";
 		};
-		B04D04114CD26DD4ACE666B0 /* bindings */ = {
+		B36B6C8C4266337158D8EA7E /* reflect-open */ = {
 			isa = PBXGroup;
 			children = (
-				777653BF3E38355A5F6B6EF9 /* bindings.h */,
+				57BCB79C0774021318852985 /* main.mm */,
+				D29B88183661F5C1C960E074 /* RecordingIntents.swift */,
+				3613166A0FB6AFF3C3B2F85C /* StopRecordingLiveActivityIntent.swift */,
+				024093CF75026447063ECAFB /* bindings */,
 			);
-			path = bindings;
+			name = "reflect-open";
+			path = "Sources/reflect-open";
 			sourceTree = "<group>";
 		};
 		B6C98802589FDB7BF4EC3F7C /* Frameworks */ = {
@@ -359,6 +408,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		665EB942B5F6FB93F8DF2A57 /* RecordingWidget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0CB80A8B9A6F429446C05ECD /* Build configuration list for PBXNativeTarget "RecordingWidget" */;
+			buildPhases = (
+				6E18E3E924D4531333C9C477 /* Sources */,
+				823BEF2AC9236315045FA6B8 /* Preserve entitlements on skip-codesign builds */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RecordingWidget;
+			packageProductDependencies = (
+			);
+			productName = RecordingWidget;
+			productReference = DB54D6D030C08888E9D17442 /* RecordingWidget.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		85FC564C07724F1F4E282538 /* ShareExtension */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 85C256481A6DA4978244EF0C /* Build configuration list for PBXNativeTarget "ShareExtension" */;
@@ -392,6 +459,7 @@
 			);
 			dependencies = (
 				4117F1E82CF9953D0AD38F11 /* PBXTargetDependency */,
+				D540AFE4185360A528491534 /* PBXTargetDependency */,
 			);
 			name = "reflect-open_iOS";
 			packageProductDependencies = (
@@ -409,6 +477,10 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
+					665EB942B5F6FB93F8DF2A57 = {
+						DevelopmentTeam = 789ULN5MZB;
+						ProvisioningStyle = Automatic;
+					};
 					85FC564C07724F1F4E282538 = {
 						DevelopmentTeam = 789ULN5MZB;
 						ProvisioningStyle = Automatic;
@@ -433,6 +505,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				665EB942B5F6FB93F8DF2A57 /* RecordingWidget */,
 				85FC564C07724F1F4E282538 /* ShareExtension */,
 				E2CEE6E5CCFA69CBA5F9AA3F /* reflect-open_iOS */,
 			);
@@ -461,6 +534,25 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		823BEF2AC9236315045FA6B8 /* Preserve entitlements on skip-codesign builds */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Preserve entitlements on skip-codesign builds";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"${CODE_SIGNING_ALLOWED:-YES}\" = \"NO\" ]; then\n  /usr/bin/codesign --force --sign - \\\n    --entitlements \"${SRCROOT:?}/RecordingWidget/RecordingWidget.entitlements\" \\\n    \"${CODESIGNING_FOLDER_PATH:?}\"\nfi\n";
+		};
 		E8E8484E1F59D64EA785432B /* Preserve entitlements on skip-codesign builds */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -515,11 +607,25 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		6E18E3E924D4531333C9C477 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E7D75AA83CFA468E0EFBAB21 /* RecordAudioWidget.swift in Sources */,
+				85FC869F776C24A9ED0A1779 /* RecordingActivityAttributes.swift in Sources */,
+				D37EE1ED817FDDC16C5643BB /* RecordingActivityWidget.swift in Sources */,
+				9611839F9E9EC688FCDFCC91 /* RecordingWidgetBundle.swift in Sources */,
+				BFB9F91C8E2628460C84C8A3 /* StopRecordingLiveActivityIntent.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B34A0474C6B6B9C6508E3011 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5C88834F22D37FFC49CBD2F1 /* main.mm in Sources */,
+				6C55CBAB912EC5920CE314DA /* RecordingIntents.swift in Sources */,
+				6C3751B3B175DFE411D97C0F /* StopRecordingLiveActivityIntent.swift in Sources */,
+				14BE6EF4AB511AC099410853 /* main.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -530,6 +636,11 @@
 			isa = PBXTargetDependency;
 			target = 85FC564C07724F1F4E282538 /* ShareExtension */;
 			targetProxy = E15A48A368A368CDA2B5A070 /* PBXContainerItemProxy */;
+		};
+		D540AFE4185360A528491534 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 665EB942B5F6FB93F8DF2A57 /* RecordingWidget */;
+			targetProxy = 6A2683A904EF67AC778ED704 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -582,6 +693,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = app.reflect.ios;
 				PRODUCT_NAME = Reflect;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = arm64;
 			};
@@ -650,6 +762,27 @@
 			};
 			name = debug;
 		};
+		A96125CC5A34976C051BA669 /* debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = RecordingWidget/RecordingWidget.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 789ULN5MZB;
+				INFOPLIST_FILE = RecordingWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = app.reflect.ios.widgets;
+				PRODUCT_NAME = RecordingWidget;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = debug;
+		};
 		ABFF23DB75DCB9354EA41A14 /* debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -669,6 +802,27 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = debug;
+		};
+		B60F0D6C1613C372224A6C74 /* release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = RecordingWidget/RecordingWidget.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 789ULN5MZB;
+				INFOPLIST_FILE = RecordingWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = app.reflect.ios.widgets;
+				PRODUCT_NAME = RecordingWidget;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = release;
 		};
 		CB0922CFF8EEBA69B8A9C2FB /* debug */ = {
 			isa = XCBuildConfiguration;
@@ -698,6 +852,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = app.reflect.ios;
 				PRODUCT_NAME = Reflect;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = arm64;
 			};
@@ -762,6 +917,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		0CB80A8B9A6F429446C05ECD /* Build configuration list for PBXNativeTarget "RecordingWidget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A96125CC5A34976C051BA669 /* debug */,
+				B60F0D6C1613C372224A6C74 /* release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = debug;
+		};
 		10FFF2E018E94EEF95D56337 /* Build configuration list for PBXNativeTarget "reflect-open_iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/Info.plist
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/Info.plist
@@ -44,6 +44,10 @@
 			<string>Any</string>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/Info.plist
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/Info.plist
@@ -16,6 +16,17 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>0.4.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>app.reflect.ios</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>reflect</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>0.4.0.17</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
@@ -32,6 +43,8 @@
 	<string>Reflect reads your contacts to suggest details for person notes. Nothing is stored or sent anywhere.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Reflect uses the microphone to record audio memos that are transcribed into your daily note.</string>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>NSUbiquitousContainers</key>
 	<dict>
 		<key>iCloud.app.reflect</key>
@@ -44,6 +57,17 @@
 			<string>Any</string>
 		</dict>
 	</dict>
+	<key>UIApplicationShortcutItems</key>
+	<array>
+		<dict>
+			<key>UIApplicationShortcutItemIconType</key>
+			<string>UIApplicationShortcutIconTypeAudio</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>Record audio</string>
+			<key>UIApplicationShortcutItemType</key>
+			<string>app.reflect.record-audio</string>
+		</dict>
+	</array>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/apps/desktop/src-tauri/ios.project.yml
+++ b/apps/desktop/src-tauri/ios.project.yml
@@ -63,6 +63,11 @@ targets:
         NSMicrophoneUsageDescription: Reflect uses the microphone to record audio memos that are transcribed into your daily note.
         NSCalendarsFullAccessUsageDescription: Reflect reads your calendar to show the day's meetings beside your daily note. Access is read-only and stays on this device.
         NSCalendarsUsageDescription: Reflect reads your calendar to show the day's meetings beside your daily note. Access is read-only and stays on this device.
+        # Audio memos keep recording through screen lock and backgrounding
+        # (audio-memos wave 2). The recording plugin activates the audio
+        # session only while a recording is live, so the mode never keeps the
+        # app running outside an actual capture.
+        UIBackgroundModes: [audio]
         UILaunchStoryboardName: LaunchScreen
         UIRequiredDeviceCapabilities: [arm64, metal]
         UISupportedInterfaceOrientations:

--- a/apps/desktop/src-tauri/ios.project.yml
+++ b/apps/desktop/src-tauri/ios.project.yml
@@ -68,6 +68,21 @@ targets:
         # session only while a recording is live, so the mode never keeps the
         # app running outside an actual capture.
         UIBackgroundModes: [audio]
+        # The `reflect://` scheme (audio-memos wave 3): the lock-screen
+        # widget opens `reflect://record-audio`, which the Rust shell hands
+        # to the recording plugin's action queue. Desktop registers the same
+        # scheme through the deep-link plugin config in tauri.conf.json.
+        CFBundleURLTypes:
+          - CFBundleURLName: app.reflect.ios
+            CFBundleURLSchemes: [reflect]
+        # The recording Live Activity (audio-memos wave 3).
+        NSSupportsLiveActivities: true
+        # Home-screen quick action (audio-memos wave 3); handled by the
+        # recording plugin via the shortcut-item delegate hook.
+        UIApplicationShortcutItems:
+          - UIApplicationShortcutItemType: app.reflect.record-audio
+            UIApplicationShortcutItemTitle: Record audio
+            UIApplicationShortcutItemIconType: UIApplicationShortcutIconTypeAudio
         UILaunchStoryboardName: LaunchScreen
         UIRequiredDeviceCapabilities: [arm64, metal]
         UISupportedInterfaceOrientations:
@@ -126,12 +141,17 @@ targets:
         LIBRARY_SEARCH_PATHS[arch=x86_64]: $(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)
         LIBRARY_SEARCH_PATHS[arch=arm64]: $(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)
         ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: true
+        SWIFT_VERSION: "5.0"
         EXCLUDED_ARCHS[sdk=iphoneos*]: x86_64
       groups: [app]
     dependencies:
       # The share-sheet capture extension (Plan 11's iOS producer): embedded
       # into the app bundle and signed with it.
       - target: ShareExtension
+        embed: true
+      # The audio-memo widget extension (wave 3): lock-screen record widget
+      # + the recording Live Activity; embedded and signed with the app.
+      - target: RecordingWidget
         embed: true
       - framework: libapp.a
         embed: false
@@ -224,6 +244,60 @@ targets:
           if [ "${CODE_SIGNING_ALLOWED:-YES}" = "NO" ]; then
             /usr/bin/codesign --force --sign - \
               --entitlements "${SRCROOT:?}/ShareExtension/ShareExtension.entitlements" \
+              "${CODESIGNING_FOLDER_PATH:?}"
+          fi
+        name: Preserve entitlements on skip-codesign builds
+        basedOnDependencyAnalysis: false
+
+  # The audio-memo widget extension (wave 3): the lock-screen / home-screen
+  # "record" widget plus the recording Live Activity. Swift only — no Rust,
+  # no webview. Two sources are shared by path: the Live Activity attributes
+  # (also compiled into the recording plugin — ActivityKit matches app and
+  # widget by type name) and the stop LiveActivityIntent (also compiled into
+  # the app target, where it executes).
+  RecordingWidget:
+    type: app-extension
+    platform: iOS
+    deploymentTarget: "16.2"
+    sources:
+      - path: RecordingWidget/RecordingWidgetBundle.swift
+      - path: RecordingWidget/RecordAudioWidget.swift
+      - path: RecordingWidget/RecordingActivityWidget.swift
+      - path: Sources/reflect-open/StopRecordingLiveActivityIntent.swift
+      - path: ../../../../../plugins/tauri-plugin-recording/ios/Sources/RecordingActivityAttributes.swift
+    info:
+      path: RecordingWidget/Info.plist
+      properties:
+        CFBundleDisplayName: Reflect
+        CFBundleShortVersionString: {{apple.bundle-version-short}}
+        CFBundleVersion: {{apple.bundle-version}}
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.widgetkit-extension
+    # The widget needs no capability of its own, but the release pipeline
+    # asserts every appex carries the App Group (release-ios.mjs), and the
+    # skip-codesign ad-hoc phase below must have entitlements to preserve —
+    # exactly like ShareExtension.
+    entitlements:
+      path: RecordingWidget/RecordingWidget.entitlements
+      properties:
+        com.apple.security.application-groups:
+          - group.app.reflect
+    settings:
+      base:
+        PRODUCT_NAME: RecordingWidget
+        PRODUCT_BUNDLE_IDENTIFIER: app.reflect.ios.widgets
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: 789ULN5MZB
+        SWIFT_VERSION: "5.0"
+        TARGETED_DEVICE_FAMILY: 1,2
+    postBuildScripts:
+      # Same skip-codesign entitlement preservation as ShareExtension: CI
+      # TestFlight builds archive unsigned, and export re-signing only keeps
+      # entitlements already present in a signature.
+      - script: |
+          if [ "${CODE_SIGNING_ALLOWED:-YES}" = "NO" ]; then
+            /usr/bin/codesign --force --sign - \
+              --entitlements "${SRCROOT:?}/RecordingWidget/RecordingWidget.entitlements" \
               "${CODESIGNING_FOLDER_PATH:?}"
           fi
         name: Preserve entitlements on skip-codesign builds

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -286,6 +286,27 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(|app, event| match &event {
+            // The lock-screen widget opens `reflect://record-audio`; hand it
+            // to the recording plugin's persisted action queue (the V1
+            // handshake) so the request survives webview churn and cold
+            // starts. Desktop scheme opens flow through
+            // tauri-plugin-deep-link to the frontend instead.
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            tauri::RunEvent::Opened { urls } => {
+                #[cfg(mobile)]
+                {
+                    use tauri_plugin_recording::RecordingExt;
+                    for url in urls {
+                        if url.scheme() == "reflect" && url.host_str() == Some("record-audio") {
+                            if let Err(err) = app.recording().queue_action("recordAudio") {
+                                tracing::warn!(error = %err, "queueing the record-audio action failed");
+                            }
+                        }
+                    }
+                }
+                #[cfg(not(mobile))]
+                let _ = urls;
+            }
             tauri::RunEvent::ExitRequested { code, api, .. } => {
                 // A user/OS-initiated quit (⌘Q — no exit code) with live
                 // webviews defers so the frontend can flush dirty note

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -152,6 +152,13 @@ pub fn run() {
     #[cfg(mobile)]
     let builder = builder.plugin(tauri_plugin_keyboard::init());
 
+    // The native audio-memo recorder is mobile-only too: desktop records
+    // through the webview's MediaRecorder (`use-audio-recorder.ts`), while
+    // mobile capture must survive the webview (interruptions, backgrounding),
+    // so it runs on AVAudioRecorder behind this plugin.
+    #[cfg(mobile)]
+    let builder = builder.plugin(tauri_plugin_recording::init());
+
     // The main window starts hidden (`visible: false`); on desktop the
     // window-state plugin reveals it after restoring geometry, but mobile has
     // no such plugin, so show it here or the UI would never appear.

--- a/apps/desktop/src/hooks/use-audio-memo-pipeline.ts
+++ b/apps/desktop/src/hooks/use-audio-memo-pipeline.ts
@@ -46,7 +46,9 @@ export interface PendingAudioCapture {
   onDiscarded?: () => Promise<void> | void
 }
 
+/** Configuration for {@link useAudioMemoPipeline}. */
 export interface UseAudioMemoPipelineOptions {
+  /** The open graph — pins captures/transcription and scopes the reconciler. */
   graph: GraphInfo
   /**
    * Whether the capture-error UI (popover, drawer) is on screen. When it is
@@ -56,6 +58,11 @@ export interface UseAudioMemoPipelineOptions {
   isErrorSurfaceVisible: () => boolean
 }
 
+/**
+ * The audio-memo surface's platform-neutral state and actions: capture-queue
+ * progress, the transcription flag, availability, the parked-error state, and
+ * the enqueue/retry/discard/report-error controls each provider drives.
+ */
 export interface UseAudioMemoPipelineValue {
   /** Recordings committed but not yet written to the graph. */
   pendingCount: number

--- a/apps/desktop/src/hooks/use-audio-memo-pipeline.ts
+++ b/apps/desktop/src/hooks/use-audio-memo-pipeline.ts
@@ -1,0 +1,279 @@
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react'
+import {
+  captureAudioMemo,
+  errorMessage,
+  pickTranscriptionConfig,
+  type AiProvidersState,
+  type GraphInfo,
+} from '@reflect/core'
+import { useMainWindowEffect } from '@/hooks/use-main-window-effect'
+import { startOperation } from '@/lib/operations'
+import {
+  createTranscriptionReconciler,
+  type TranscriptionReconciler,
+} from '@/lib/transcription-reconciler'
+import { useSettings } from '@/providers/settings-provider'
+
+/**
+ * The platform-neutral half of the audio-memo surface: the serial capture
+ * queue and the per-graph transcription-reconciler lifecycle. Desktop
+ * (`AudioMemoProvider`, webview MediaRecorder) and mobile
+ * (`MobileAudioMemoProvider`, the native recorder plugin) both drain their
+ * recordings through this hook; what differs — how audio is recorded and how
+ * the recording UI looks — stays in each provider.
+ *
+ * The pipeline is raw-first (see `actions/audio-memo` in core): a queued
+ * recording is written into the graph's `audio-memos/` — local, instant — and
+ * transcription belongs to the reconciler this hook mounts, which owns every
+ * trigger and retry rule. Captures drain through a serial queue so memos can
+ * be recorded back-to-back; a failed *capture* (the one step that can lose
+ * audio) parks the queue behind a Retry/Discard error.
+ */
+
+/** A stopped recording waiting its turn through the capture queue. */
+export interface PendingAudioCapture {
+  audio: Blob
+  mimeType: string
+  recordedAt: Date
+  /**
+   * Runs after the recording's bytes are durably in the graph — mobile
+   * deletes its native staged file here. A failure is logged, never parked:
+   * the audio is already safe, and the worst case (the staged copy
+   * lingering) re-ingests idempotently by its stop time.
+   */
+  onCaptured?: () => Promise<void> | void
+  /** Runs when the user discards this capture after it failed to write. */
+  onDiscarded?: () => Promise<void> | void
+}
+
+export interface UseAudioMemoPipelineOptions {
+  graph: GraphInfo
+  /**
+   * Whether the capture-error UI (popover, drawer) is on screen. When it is
+   * not, a failed capture is also surfaced as a failed operation toast so the
+   * error can never park the queue invisibly.
+   */
+  isErrorSurfaceVisible: () => boolean
+}
+
+export interface UseAudioMemoPipelineValue {
+  /** Recordings committed but not yet written to the graph. */
+  pendingCount: number
+  /** True while a reconcile pass has memos to transcribe. */
+  transcribing: boolean
+  /** False when no OpenAI/Gemini model is configured. */
+  hasTranscriptionConfig: boolean
+  /** The failure shown in the error phase. */
+  error: string | null
+  /** True when a retry can re-run a failed capture. */
+  canRetry: boolean
+  /** Queue a stopped recording for capture into the graph. */
+  enqueue: (capture: PendingAudioCapture) => void
+  /** Surface a recorder failure (mic denied, hardware) in the error state. */
+  reportError: (message: string) => void
+  /** Re-run the failed capture. */
+  retry: () => void
+  /** Drop the failed memo (or clear a recorder error) and continue. */
+  discard: () => void
+}
+
+/**
+ * Mount the capture queue and the transcription reconciler for one graph
+ * session. Mount exactly once per surface — the reconciler half is already
+ * main-window-gated, but the queue is per-instance state.
+ */
+export function useAudioMemoPipeline(
+  options: UseAudioMemoPipelineOptions,
+): UseAudioMemoPipelineValue {
+  const { graph } = options
+  const { settings } = useSettings()
+
+  const [pendingCount, setPendingCount] = useState(0)
+  const [error, setError] = useState<string | null>(null)
+  const [resume, setResume] = useState<PendingAudioCapture | null>(null)
+
+  const hasTranscriptionConfig =
+    pickTranscriptionConfig({
+      providers: settings.aiProviders,
+      defaultProviderId: settings.defaultAiProviderId,
+    }) !== null
+
+  /** Committed recordings waiting their turn; the pump owns the head. */
+  const queueRef = useRef<PendingAudioCapture[]>([])
+  /** Single-drainer guard: one pump loop at a time, one capture at a time. */
+  const pumpingRef = useRef(false)
+  /**
+   * The failed capture a retry should re-run. While parked, the queue holds —
+   * memo order in the graph must survive the failure. A ref, not state: rapid
+   * double Retry must see the first click's take synchronously, or two
+   * pipelines write the recording twice.
+   */
+  const parkedRef = useRef<PendingAudioCapture | null>(null)
+
+  const errorSurfaceVisibleRef = useRef(options.isErrorSurfaceVisible)
+  useEffect(() => {
+    errorSurfaceVisibleRef.current = options.isErrorSurfaceVisible
+  })
+
+  // The configured-models state, by ref: the reconciler reads it lazily at
+  // the start of every pass, so a key added mid-session is seen without
+  // rebuilding the lifecycle on every settings change.
+  const providersRef = useRef<AiProvidersState>({
+    providers: settings.aiProviders,
+    defaultProviderId: settings.defaultAiProviderId,
+  })
+  useEffect(() => {
+    providersRef.current = {
+      providers: settings.aiProviders,
+      defaultProviderId: settings.defaultAiProviderId,
+    }
+  })
+
+  // One reconciler per graph session (the hosting provider remounts per
+  // graph). It owns the launch pass and all retry triggers; the pump only
+  // schedules. Main window only: two reconcilers would double-transcribe (and
+  // double-bill) the same memos. Recording still works in a note window —
+  // the saved memo is transcribed by the main window's reconciler, which
+  // sees it arrive on the watcher stream.
+  const [reconciler, setReconciler] = useState<TranscriptionReconciler | null>(null)
+  const reconcilerRef = useRef<TranscriptionReconciler | null>(null)
+  useMainWindowEffect(() => {
+    const next = createTranscriptionReconciler({
+      generation: graph.generation,
+      getProviders: () => providersRef.current,
+    })
+    setReconciler(next)
+    reconcilerRef.current = next
+    next.start()
+    return () => {
+      next.dispose()
+      reconcilerRef.current = null
+      setReconciler((current) => (current === next ? null : current))
+    }
+  }, [graph.generation])
+
+  // Passes gate on a configured model before any IO — when the user adds the
+  // first key mid-session, kick the pass that gate was suppressing.
+  const hadConfigRef = useRef(hasTranscriptionConfig)
+  useEffect(() => {
+    if (hasTranscriptionConfig && !hadConfigRef.current) {
+      reconciler?.schedule()
+    }
+    hadConfigRef.current = hasTranscriptionConfig
+  }, [hasTranscriptionConfig, reconciler])
+
+  /** True while a reconcile pass has memos to transcribe. */
+  const transcribing = useSyncExternalStore(
+    reconciler?.subscribe ?? (() => () => {}),
+    reconciler?.getTranscribing ?? (() => false),
+  )
+
+  const pump = useCallback(async (): Promise<void> => {
+    if (pumpingRef.current) {
+      return
+    }
+    pumpingRef.current = true
+    let captured = false
+    try {
+      while (parkedRef.current === null) {
+        const capture = queueRef.current.shift()
+        if (capture === undefined) {
+          break
+        }
+        let outcome: Awaited<ReturnType<typeof captureAudioMemo>>
+        try {
+          outcome = await captureAudioMemo({ ...capture, generation: graph.generation })
+        } catch (cause) {
+          outcome = { ok: false, message: errorMessage(cause) }
+        } finally {
+          setPendingCount((count) => count - 1)
+        }
+        if (outcome.ok) {
+          captured = true
+          try {
+            await capture.onCaptured?.()
+          } catch (cause) {
+            // The audio is already durable in the graph — a cleanup failure
+            // must not park the queue behind it.
+            console.error('audio memo post-capture cleanup failed:', cause)
+          }
+        } else {
+          // Park the queue behind the failure: the capture is the one step
+          // that can lose audio, and memo order in the graph must survive.
+          parkedRef.current = capture
+          setResume(capture)
+          setError(outcome.message)
+          if (!errorSurfaceVisibleRef.current()) {
+            // The error UI is off screen — the failure must still surface
+            // somewhere.
+            startOperation('Saving audio memo').fail(outcome.message)
+          }
+        }
+      }
+    } finally {
+      pumpingRef.current = false
+    }
+    if (captured) {
+      // The watcher (or mobile's in-process write echo) reports the recording
+      // write, which feeds the sync engine's commit debounce like any note
+      // edit. Transcription is kicked directly rather than waiting on the
+      // watcher's own debounce to echo our write back.
+      reconcilerRef.current?.schedule()
+    }
+  }, [graph.generation])
+
+  const enqueue = useCallback(
+    (capture: PendingAudioCapture): void => {
+      queueRef.current.push(capture)
+      setPendingCount((count) => count + 1)
+      void pump()
+    },
+    [pump],
+  )
+
+  const reportError = useCallback((message: string): void => {
+    setError(message)
+  }, [])
+
+  const discard = useCallback((): void => {
+    const parked = parkedRef.current
+    parkedRef.current = null
+    setError(null)
+    setResume(null)
+    if (parked !== null) {
+      void (async () => {
+        try {
+          await parked.onDiscarded?.()
+        } catch (cause) {
+          console.error('audio memo discard cleanup failed:', cause)
+        }
+      })()
+    }
+    void pump()
+  }, [pump])
+
+  const retry = useCallback((): void => {
+    const parked = parkedRef.current
+    if (parked === null) {
+      return
+    }
+    parkedRef.current = null
+    setError(null)
+    setResume(null)
+    queueRef.current.unshift(parked)
+    setPendingCount((count) => count + 1)
+    void pump()
+  }, [pump])
+
+  return {
+    pendingCount,
+    transcribing,
+    hasTranscriptionConfig,
+    error,
+    canRetry: resume !== null,
+    enqueue,
+    reportError,
+    retry,
+    discard,
+  }
+}

--- a/apps/desktop/src/lib/background-reconciler.test.ts
+++ b/apps/desktop/src/lib/background-reconciler.test.ts
@@ -129,6 +129,22 @@ describe('createBackgroundReconciler', () => {
     expect(calls).toBe(2) // listener removed on dispose
   })
 
+  it('retries when the document becomes visible (the mobile foreground signal)', async () => {
+    let calls = 0
+    const reconciler = createBackgroundReconciler({ pass: async () => { calls += 1 } })
+    reconciler.retryOnWake()
+
+    // jsdom's visibilityState is 'visible' — the event alone must schedule.
+    document.dispatchEvent(new Event('visibilitychange'))
+    await tick()
+    expect(calls).toBe(1)
+
+    reconciler.dispose()
+    document.dispatchEvent(new Event('visibilitychange'))
+    await tick()
+    expect(calls).toBe(1) // listener removed on dispose
+  })
+
   it('runs onDispose teardowns once, and immediately when already disposed', () => {
     const before = vi.fn()
     const after = vi.fn()

--- a/apps/desktop/src/lib/background-reconciler.test.ts
+++ b/apps/desktop/src/lib/background-reconciler.test.ts
@@ -129,21 +129,6 @@ describe('createBackgroundReconciler', () => {
     expect(calls).toBe(2) // listener removed on dispose
   })
 
-  it('retries when the document becomes visible (the mobile foreground signal)', async () => {
-    let calls = 0
-    const reconciler = createBackgroundReconciler({ pass: async () => { calls += 1 } })
-    reconciler.retryOnWake()
-
-    // jsdom's visibilityState is 'visible' — the event alone must schedule.
-    document.dispatchEvent(new Event('visibilitychange'))
-    await tick()
-    expect(calls).toBe(1)
-
-    reconciler.dispose()
-    document.dispatchEvent(new Event('visibilitychange'))
-    await tick()
-    expect(calls).toBe(1) // listener removed on dispose
-  })
 
   it('runs onDispose teardowns once, and immediately when already disposed', () => {
     const before = vi.fn()

--- a/apps/desktop/src/lib/background-reconciler.ts
+++ b/apps/desktop/src/lib/background-reconciler.ts
@@ -92,11 +92,20 @@ export function createBackgroundReconciler(
     schedule,
     isStale: () => disposed,
     retryOnWake() {
+      // Foregrounding on iOS doesn't reliably fire `focus` or `online` on
+      // the webview — `visibilitychange` → visible is the signal that does.
+      const onVisibilityChange = (): void => {
+        if (document.visibilityState === 'visible') {
+          schedule()
+        }
+      }
       window.addEventListener('focus', schedule)
       window.addEventListener('online', schedule)
+      document.addEventListener('visibilitychange', onVisibilityChange)
       disposers.push(
         () => window.removeEventListener('focus', schedule),
         () => window.removeEventListener('online', schedule),
+        () => document.removeEventListener('visibilitychange', onVisibilityChange),
       )
     },
     onDispose(teardown) {

--- a/apps/desktop/src/lib/background-reconciler.ts
+++ b/apps/desktop/src/lib/background-reconciler.ts
@@ -92,20 +92,11 @@ export function createBackgroundReconciler(
     schedule,
     isStale: () => disposed,
     retryOnWake() {
-      // Foregrounding on iOS doesn't reliably fire `focus` or `online` on
-      // the webview — `visibilitychange` → visible is the signal that does.
-      const onVisibilityChange = (): void => {
-        if (document.visibilityState === 'visible') {
-          schedule()
-        }
-      }
       window.addEventListener('focus', schedule)
       window.addEventListener('online', schedule)
-      document.addEventListener('visibilitychange', onVisibilityChange)
       disposers.push(
         () => window.removeEventListener('focus', schedule),
         () => window.removeEventListener('online', schedule),
-        () => document.removeEventListener('visibilitychange', onVisibilityChange),
       )
     },
     onDispose(teardown) {

--- a/apps/desktop/src/lib/transcription-reconciler.test.ts
+++ b/apps/desktop/src/lib/transcription-reconciler.test.ts
@@ -144,6 +144,22 @@ describe('createTranscriptionReconciler', () => {
     expect(reconcileAudioMemos).toHaveBeenCalledTimes(4)
   })
 
+  it('retries when the app becomes visible again (the iOS foreground signal)', async () => {
+    const subject = create()
+    subject.start()
+    await flush()
+    expect(reconcileAudioMemos).toHaveBeenCalledTimes(1)
+
+    document.dispatchEvent(new Event('visibilitychange'))
+    await flush()
+    expect(reconcileAudioMemos).toHaveBeenCalledTimes(2)
+
+    subject.dispose()
+    document.dispatchEvent(new Event('visibilitychange'))
+    await flush()
+    expect(reconcileAudioMemos).toHaveBeenCalledTimes(2) // listener removed on dispose
+  })
+
   it('exposes the transcribing flag while a pass has memos, and notifies subscribers', async () => {
     let release: (outcome: ReconcileAudioMemosOutcome) => void = () => {}
     reconcileAudioMemos.mockImplementationOnce(

--- a/apps/desktop/src/lib/transcription-reconciler.ts
+++ b/apps/desktop/src/lib/transcription-reconciler.ts
@@ -106,11 +106,22 @@ export function createTranscriptionReconciler(
       return
     }
     loop.schedule() // the launch pass: memos left pending by earlier sessions
-    loop.retryOnWake() // the network's natural retry signals
+    loop.retryOnWake() // the network's natural retry signals (focus/online)
     loop.onDispose(() => listeners.clear())
     if (!hasBridge()) {
-      return // browser dev: no watcher to follow
+      return // browser dev: no watcher to follow, no native foreground
     }
+    // Foregrounding on iOS doesn't reliably fire `focus`/`online` on the
+    // webview — `visibilitychange` → visible does. A memo captured (or its
+    // transcription failed offline) while backgrounded gets its retry when
+    // the app comes back. Bridge-gated, so desktop keeps focus/online only.
+    const onVisible = (): void => {
+      if (document.visibilityState === 'visible') {
+        loop.schedule()
+      }
+    }
+    document.addEventListener('visibilitychange', onVisible)
+    loop.onDispose(() => document.removeEventListener('visibilitychange', onVisible))
     void subscribeFileChanges((changes) => {
       const hasNewRecording = changes.some(
         (change) => change.kind === 'upsert' && audioMemoFromPath(change.path) !== null,

--- a/apps/desktop/src/mobile/audio-memo-fab.test.tsx
+++ b/apps/desktop/src/mobile/audio-memo-fab.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, render, type RenderResult } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const memo = vi.hoisted(() => ({
+  phase: 'idle' as 'idle' | 'requesting' | 'recording' | 'transcribing' | 'error',
+  elapsedMs: 0,
+  level: 0,
+  pendingCount: 0,
+  available: true,
+  error: null as string | null,
+  canRetry: false,
+  drawerOpen: false,
+  toggle: vi.fn(),
+  stopAndSave: vi.fn(),
+  cancelRecording: vi.fn(),
+  onDrawerOpenChange: vi.fn(),
+  retry: vi.fn(),
+  discard: vi.fn(),
+}))
+
+vi.mock('@/mobile/audio-memo-provider', () => ({
+  useMobileAudioMemo: () => ({ ...memo }),
+}))
+
+const { AudioMemoFab } = await import('./audio-memo-fab')
+
+function renderFab(): RenderResult {
+  return render(<AudioMemoFab />)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  memo.phase = 'idle'
+  memo.available = true
+  memo.error = null
+})
+
+afterEach(cleanup)
+
+describe('AudioMemoFab', () => {
+  it('idle records on tap', async () => {
+    const view = renderFab()
+
+    await userEvent.click(view.getByRole('button', { name: 'Record audio memo' }))
+
+    expect(memo.toggle).toHaveBeenCalledTimes(1)
+  })
+
+  it('reads as the stop control while recording', () => {
+    memo.phase = 'recording'
+    const view = renderFab()
+
+    expect(view.getByRole('button', { name: 'Stop recording' })).toBeTruthy()
+  })
+
+  it('a parked failure reads as the error affordance', () => {
+    memo.phase = 'error'
+    memo.error = 'disk full'
+    const view = renderFab()
+
+    expect(view.getByRole('button', { name: 'Show audio memo error' })).toBeTruthy()
+  })
+
+  it('hides entirely when the feature cannot run', () => {
+    memo.available = false
+    const view = renderFab()
+
+    expect(view.queryByRole('button')).toBeNull()
+  })
+})

--- a/apps/desktop/src/mobile/audio-memo-fab.tsx
+++ b/apps/desktop/src/mobile/audio-memo-fab.tsx
@@ -1,0 +1,52 @@
+import type { ReactElement } from 'react'
+import { Square } from 'lucide-react'
+import { MicIcon } from '@/components/icons/mic-icon'
+import { Button } from '@/components/ui/button'
+import { Spinner } from '@/components/ui/spinner'
+import { useMobileAudioMemo } from '@/mobile/audio-memo-provider'
+
+/**
+ * The daily spine's record button, floating above the new-note FAB (V1
+ * parity: voice capture is a first-class affordance, not a settings-adjacent
+ * feature). Idle starts a memo, recording reads as the stop control, a
+ * spinner carries the transcribe/save progress, and a failure turns it red —
+ * tapping reopens the drawer with Retry/Discard. Hidden entirely when the
+ * feature can't run (no native bridge, or no OpenAI/Gemini model configured).
+ */
+export function AudioMemoFab(): ReactElement | null {
+  const memo = useMobileAudioMemo()
+
+  if (!memo.available) {
+    return null
+  }
+
+  const recording = memo.phase === 'recording' || memo.phase === 'requesting'
+  const label =
+    memo.phase === 'error'
+      ? 'Show audio memo error'
+      : recording
+        ? 'Stop recording'
+        : 'Record audio memo'
+
+  return (
+    <Button
+      size="icon"
+      variant={recording || memo.phase === 'error' ? 'destructive' : 'secondary'}
+      aria-label={label}
+      className="fixed right-4 z-40 size-12 rounded-full shadow-lg"
+      style={{
+        bottom:
+          'calc(max(env(safe-area-inset-bottom), var(--keyboard-height, 0px)) + 4.25rem + 3.75rem)',
+      }}
+      onClick={() => memo.toggle()}
+    >
+      {memo.phase === 'transcribing' ? (
+        <Spinner className="size-5" />
+      ) : recording ? (
+        <Square aria-hidden fill="currentColor" className="size-4" />
+      ) : (
+        <MicIcon className="size-6" />
+      )}
+    </Button>
+  )
+}

--- a/apps/desktop/src/mobile/audio-memo-provider.test.tsx
+++ b/apps/desktop/src/mobile/audio-memo-provider.test.tsx
@@ -1,0 +1,417 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { useState, type ReactElement, type ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  AiProvidersState,
+  AudioMemoIdentity,
+  CaptureAudioMemoInput,
+  CaptureAudioMemoOutcome,
+  GraphInfo,
+  Settings,
+} from '@reflect/core'
+import type { NativeRecorderResult } from '@/mobile/use-native-audio-recorder'
+
+const captureAudioMemo = vi.hoisted(() =>
+  vi.fn<(input: CaptureAudioMemoInput) => Promise<CaptureAudioMemoOutcome>>(),
+)
+const failOperation = vi.hoisted(() => vi.fn<(message: string) => void>())
+const invoke = vi.hoisted(() => vi.fn<(command: string, args?: unknown) => Promise<unknown>>())
+
+/** Fake reconciler lifecycle — the pipeline is only a shim over it. */
+const reconcilerControls = vi.hoisted(() => {
+  const listeners = new Set<() => void>()
+  const fake = {
+    start: vi.fn(),
+    schedule: vi.fn(),
+    dispose: vi.fn(),
+    getTranscribing: vi.fn((): boolean => false),
+    subscribe: vi.fn((listener: () => void) => {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    }),
+  }
+  return { fake, listeners }
+})
+const createTranscriptionReconciler = vi.hoisted(() =>
+  vi.fn(
+    (_options: { generation: number; getProviders: () => AiProvidersState }) =>
+      reconcilerControls.fake,
+  ),
+)
+
+const recorderControls = vi.hoisted(() => ({
+  startSpy: vi.fn(),
+  stopSpy: vi.fn(),
+  cancelSpy: vi.fn(),
+  stopResult: null as NativeRecorderResult | null,
+  /** Make start() reject like a denied native permission. */
+  failStart: null as string | null,
+  options: null as {
+    maxDurationMs: number
+    onNativeStop: (result: NativeRecorderResult | null) => void
+  } | null,
+}))
+
+const stagedControls = vi.hoisted(() => ({
+  claimed: new Set<string>(),
+  readStaged: vi.fn<(path: string) => Promise<Blob>>(),
+  deleteStaged: vi.fn<(path: string) => Promise<void>>(),
+}))
+
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  captureAudioMemo,
+  hasBridge: () => true,
+}))
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke,
+  addPluginListener: vi.fn(async () => ({ unregister: vi.fn() })),
+}))
+
+vi.mock('@/lib/transcription-reconciler', () => ({
+  createTranscriptionReconciler,
+}))
+
+vi.mock('@/lib/operations', () => ({
+  startOperation: () => ({ progress: vi.fn(), done: vi.fn(), fail: failOperation }),
+}))
+
+vi.mock('@/mobile/haptics', () => ({
+  hapticImpactLight: vi.fn(),
+}))
+
+vi.mock('@/mobile/use-native-audio-recorder', () => ({
+  NATIVE_RECORDING_MIME: 'audio/mp4',
+  isMicDeniedError: (cause: unknown) => typeof cause === 'string' && cause.includes('denied'),
+  readStagedRecording: stagedControls.readStaged,
+  deleteStagedRecording: stagedControls.deleteStaged,
+  claimStagedPath: (path: string) => stagedControls.claimed.add(path),
+  releaseStagedPath: (path: string) => stagedControls.claimed.delete(path),
+  isStagedPathClaimed: (path: string) => stagedControls.claimed.has(path),
+  useNativeAudioRecorder: (options: {
+    maxDurationMs: number
+    onNativeStop: (result: NativeRecorderResult | null) => void
+  }) => {
+    recorderControls.options = options
+    const [status, setStatus] = useState<'idle' | 'requesting' | 'recording'>('idle')
+    return {
+      status,
+      elapsedMs: 0,
+      level: 0,
+      start: async () => {
+        recorderControls.startSpy()
+        if (recorderControls.failStart !== null) {
+          throw recorderControls.failStart
+        }
+        setStatus('recording')
+      },
+      stop: async () => {
+        recorderControls.stopSpy()
+        setStatus('idle')
+        return recorderControls.stopResult
+      },
+      cancel: async () => {
+        recorderControls.cancelSpy()
+        setStatus('idle')
+      },
+    }
+  },
+}))
+
+const SETTINGS = vi.hoisted(() => ({
+  current: {
+    aiProviders: [{ id: 'cfg-openai', provider: 'openai', model: 'gpt-5.1', keyHint: 'wxyz1' }],
+    defaultAiProviderId: 'cfg-openai',
+  },
+}))
+
+vi.mock('@/providers/settings-provider', () => ({
+  useSettings: () => ({ settings: SETTINGS.current as unknown as Settings }),
+}))
+
+const { MobileAudioMemoProvider, useMobileAudioMemo } = await import('./audio-memo-provider')
+
+const GRAPH: GraphInfo = { root: '/notes', name: 'Notes', generation: 3 }
+
+function wrapper({ children }: { children: ReactNode }): ReactElement {
+  return <MobileAudioMemoProvider graph={GRAPH}>{children}</MobileAudioMemoProvider>
+}
+
+const RECORDING: NativeRecorderResult = {
+  blob: new Blob(['audio'], { type: 'audio/mp4' }),
+  mimeType: 'audio/mp4',
+  durationMs: 4000,
+  stagedPath: '/staging/recording-1.m4a',
+}
+
+const MEMO: AudioMemoIdentity = {
+  base: 'audio-memo-2026-06-11-153022-845',
+  date: '2026-06-11',
+  title: 'Audio memo 2026-06-11 15:30:22',
+  alias: 'Audio memo 15:30',
+  audioPath: 'audio-memos/audio-memo-2026-06-11-153022-845.m4a',
+  notePath: 'notes/audio-memo-2026-06-11-153022-845.md',
+  mimeType: 'audio/mp4',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  recorderControls.stopResult = RECORDING
+  recorderControls.failStart = null
+  recorderControls.options = null
+  stagedControls.claimed.clear()
+  stagedControls.readStaged.mockResolvedValue(new Blob(['staged'], { type: 'audio/mp4' }))
+  stagedControls.deleteStaged.mockResolvedValue(undefined)
+  SETTINGS.current = {
+    aiProviders: [{ id: 'cfg-openai', provider: 'openai', model: 'gpt-5.1', keyHint: 'wxyz1' }],
+    defaultAiProviderId: 'cfg-openai',
+  }
+  captureAudioMemo.mockResolvedValue({ ok: true, memo: MEMO })
+  invoke.mockResolvedValue({ files: [] })
+  reconcilerControls.fake.getTranscribing.mockReturnValue(false)
+  reconcilerControls.listeners.clear()
+})
+
+afterEach(cleanup)
+
+describe('MobileAudioMemoProvider', () => {
+  it('toggle records with the drawer open, then stops, captures, and deletes the staged file', async () => {
+    const { result } = renderHook(() => useMobileAudioMemo(), { wrapper })
+    expect(result.current.available).toBe(true)
+    expect(recorderControls.options?.maxDurationMs).toBe(10 * 60_000)
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    expect(result.current.phase).toBe('recording')
+    expect(result.current.drawerOpen).toBe(true)
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    await waitFor(() => expect(result.current.phase).toBe('idle'))
+    expect(result.current.drawerOpen).toBe(false)
+
+    expect(captureAudioMemo).toHaveBeenCalledWith({
+      audio: RECORDING.blob,
+      mimeType: 'audio/mp4',
+      recordedAt: expect.any(Date),
+      generation: 3,
+      onCaptured: expect.any(Function),
+      onDiscarded: expect.any(Function),
+    })
+    // The staged file is deleted only after the graph write succeeded.
+    expect(stagedControls.deleteStaged).toHaveBeenCalledWith(RECORDING.stagedPath)
+    expect(reconcilerControls.fake.schedule).toHaveBeenCalled()
+  })
+
+  it('a capture failure keeps the staged file; discard deletes it', async () => {
+    captureAudioMemo.mockResolvedValue({ ok: false, message: 'disk full' })
+    const { result } = renderHook(() => useMobileAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    await act(async () => {
+      result.current.toggle()
+    })
+    await waitFor(() => expect(result.current.phase).toBe('error'))
+    expect(result.current.canRetry).toBe(true)
+    expect(stagedControls.deleteStaged).not.toHaveBeenCalled()
+    // The drawer closed on stop — the failure also surfaces as an operation.
+    expect(failOperation).toHaveBeenCalledWith('disk full')
+
+    await act(async () => {
+      result.current.discard()
+    })
+    await waitFor(() =>
+      expect(stagedControls.deleteStaged).toHaveBeenCalledWith(RECORDING.stagedPath),
+    )
+  })
+
+  it('retry re-runs the same recording and deletes the staged file on success', async () => {
+    captureAudioMemo
+      .mockResolvedValueOnce({ ok: false, message: 'disk full' })
+      .mockResolvedValueOnce({ ok: true, memo: MEMO })
+    const { result } = renderHook(() => useMobileAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    await act(async () => {
+      result.current.toggle()
+    })
+    await waitFor(() => expect(result.current.phase).toBe('error'))
+
+    await act(async () => {
+      result.current.retry()
+    })
+    await waitFor(() => expect(result.current.phase).toBe('idle'))
+    expect(captureAudioMemo).toHaveBeenCalledTimes(2)
+    expect(stagedControls.deleteStaged).toHaveBeenCalledWith(RECORDING.stagedPath)
+  })
+
+  it('a native stop (interruption, cap) is ingested exactly like a user stop', async () => {
+    const { result } = renderHook(() => useMobileAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    expect(result.current.drawerOpen).toBe(true)
+
+    await act(async () => {
+      recorderControls.options?.onNativeStop(RECORDING)
+    })
+
+    expect(result.current.drawerOpen).toBe(false)
+    await waitFor(() =>
+      expect(captureAudioMemo).toHaveBeenCalledWith(
+        expect.objectContaining({ audio: RECORDING.blob, generation: 3 }),
+      ),
+    )
+  })
+
+  it('a too-short native stop closes the drawer and captures nothing', async () => {
+    const { result } = renderHook(() => useMobileAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    await act(async () => {
+      recorderControls.options?.onNativeStop(null)
+    })
+
+    expect(result.current.drawerOpen).toBe(false)
+    expect(captureAudioMemo).not.toHaveBeenCalled()
+  })
+
+  it('dismissing the drawer mid-recording stops and saves, never drops', async () => {
+    const { result } = renderHook(() => useMobileAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    await act(async () => {
+      result.current.onDrawerOpenChange(false)
+    })
+
+    await waitFor(() => expect(captureAudioMemo).toHaveBeenCalled())
+    expect(recorderControls.cancelSpy).not.toHaveBeenCalled()
+  })
+
+  it('the drawer Cancel discards the live recording without saving', async () => {
+    const { result } = renderHook(() => useMobileAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    await act(async () => {
+      result.current.cancelRecording()
+    })
+
+    expect(result.current.drawerOpen).toBe(false)
+    expect(recorderControls.cancelSpy).toHaveBeenCalled()
+    expect(captureAudioMemo).not.toHaveBeenCalled()
+  })
+
+  it('a denied microphone shows the iOS Settings guidance in the drawer', async () => {
+    recorderControls.failStart = 'microphone access denied'
+    const { result } = renderHook(() => useMobileAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+
+    await waitFor(() => expect(result.current.phase).toBe('error'))
+    expect(result.current.drawerOpen).toBe(true)
+    expect(result.current.error).toMatch(/Settings app/)
+    expect(result.current.canRetry).toBe(false)
+  })
+
+  it('a parked error reopens the drawer from the FAB instead of blocking silently', async () => {
+    captureAudioMemo.mockResolvedValue({ ok: false, message: 'disk full' })
+    const { result } = renderHook(() => useMobileAudioMemo(), { wrapper })
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    await act(async () => {
+      result.current.toggle()
+    })
+    await waitFor(() => expect(result.current.phase).toBe('error'))
+    expect(result.current.drawerOpen).toBe(false)
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    expect(result.current.drawerOpen).toBe(true)
+    expect(result.current.phase).toBe('error')
+  })
+
+  it('the orphan scan ingests unclaimed staged files by their stop time, then deletes them', async () => {
+    invoke.mockImplementation(async (command: string) => {
+      if (command === 'plugin:recording|list_staged') {
+        return {
+          files: [
+            { path: '/staging/recording-old.m4a', modifiedMs: 1_700_000_000_000 },
+            { path: '/staging/recording-claimed.m4a', modifiedMs: 1_700_000_100_000 },
+          ],
+        }
+      }
+      throw new Error(`unexpected invoke: ${command}`)
+    })
+    stagedControls.claimed.add('/staging/recording-claimed.m4a')
+
+    renderHook(() => useMobileAudioMemo(), { wrapper })
+
+    await waitFor(() => expect(captureAudioMemo).toHaveBeenCalledTimes(1))
+    expect(captureAudioMemo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recordedAt: new Date(1_700_000_000_000),
+        generation: 3,
+      }),
+    )
+    await waitFor(() =>
+      expect(stagedControls.deleteStaged).toHaveBeenCalledWith('/staging/recording-old.m4a'),
+    )
+    expect(stagedControls.readStaged).not.toHaveBeenCalledWith('/staging/recording-claimed.m4a')
+  })
+
+  it('foregrounding re-runs the orphan scan', async () => {
+    renderHook(() => useMobileAudioMemo(), { wrapper })
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith('plugin:recording|list_staged'),
+    )
+    invoke.mockClear()
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith('plugin:recording|list_staged'),
+    )
+  })
+
+  it('is unavailable without an OpenAI or Gemini model, and toggle does nothing', async () => {
+    SETTINGS.current = {
+      aiProviders: [
+        { id: 'claude', provider: 'anthropic', model: 'claude-fable-5', keyHint: 'wxyz1' },
+      ],
+      defaultAiProviderId: 'claude',
+    }
+    const { result } = renderHook(() => useMobileAudioMemo(), { wrapper })
+
+    expect(result.current.available).toBe(false)
+
+    await act(async () => {
+      result.current.toggle()
+    })
+    expect(result.current.phase).toBe('idle')
+    expect(result.current.drawerOpen).toBe(false)
+    expect(recorderControls.startSpy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/mobile/audio-memo-provider.test.tsx
+++ b/apps/desktop/src/mobile/audio-memo-provider.test.tsx
@@ -58,6 +58,8 @@ const stagedControls = vi.hoisted(() => ({
   claimed: new Set<string>(),
   readStaged: vi.fn<(path: string) => Promise<Blob>>(),
   deleteStaged: vi.fn<(path: string) => Promise<void>>(),
+  recordingStatus: vi.fn<() => Promise<{ recording: boolean; elapsedMs: number }>>(),
+  stopActive: vi.fn<() => Promise<NativeRecorderResult | null>>(),
 }))
 
 vi.mock('@reflect/core', async (importOriginal) => ({
@@ -88,6 +90,8 @@ vi.mock('@/mobile/use-native-audio-recorder', () => ({
   isMicDeniedError: (cause: unknown) => typeof cause === 'string' && cause.includes('denied'),
   readStagedRecording: stagedControls.readStaged,
   deleteStagedRecording: stagedControls.deleteStaged,
+  nativeRecordingStatus: stagedControls.recordingStatus,
+  stopActiveRecording: stagedControls.stopActive,
   claimStagedPath: (path: string) => stagedControls.claimed.add(path),
   releaseStagedPath: (path: string) => stagedControls.claimed.delete(path),
   isStagedPathClaimed: (path: string) => stagedControls.claimed.has(path),
@@ -165,6 +169,8 @@ beforeEach(() => {
   stagedControls.claimed.clear()
   stagedControls.readStaged.mockResolvedValue(new Blob(['staged'], { type: 'audio/mp4' }))
   stagedControls.deleteStaged.mockResolvedValue(undefined)
+  stagedControls.recordingStatus.mockResolvedValue({ recording: false, elapsedMs: 0 })
+  stagedControls.stopActive.mockResolvedValue(null)
   SETTINGS.current = {
     aiProviders: [{ id: 'cfg-openai', provider: 'openai', model: 'gpt-5.1', keyHint: 'wxyz1' }],
     defaultAiProviderId: 'cfg-openai',
@@ -394,6 +400,36 @@ describe('MobileAudioMemoProvider', () => {
     await waitFor(() =>
       expect(invoke).toHaveBeenCalledWith('plugin:recording|list_staged'),
     )
+  })
+
+  it('a recording that outlived its JS is stopped and saved on mount', async () => {
+    stagedControls.recordingStatus.mockResolvedValue({ recording: true, elapsedMs: 30_000 })
+    const orphaned: NativeRecorderResult = {
+      blob: new Blob(['orphan'], { type: 'audio/mp4' }),
+      mimeType: 'audio/mp4',
+      durationMs: 30_000,
+      stagedPath: '/staging/recording-orphan.m4a',
+    }
+    stagedControls.stopActive.mockResolvedValue(orphaned)
+
+    renderHook(() => useMobileAudioMemo(), { wrapper })
+
+    await waitFor(() => expect(stagedControls.stopActive).toHaveBeenCalledTimes(1))
+    await waitFor(() =>
+      expect(captureAudioMemo).toHaveBeenCalledWith(
+        expect.objectContaining({ audio: orphaned.blob, generation: 3 }),
+      ),
+    )
+    await waitFor(() =>
+      expect(stagedControls.deleteStaged).toHaveBeenCalledWith(orphaned.stagedPath),
+    )
+  })
+
+  it('no live native recording on mount means no stop call', async () => {
+    renderHook(() => useMobileAudioMemo(), { wrapper })
+
+    await waitFor(() => expect(stagedControls.recordingStatus).toHaveBeenCalled())
+    expect(stagedControls.stopActive).not.toHaveBeenCalled()
   })
 
   it('is unavailable without an OpenAI or Gemini model, and toggle does nothing', async () => {

--- a/apps/desktop/src/mobile/audio-memo-provider.test.tsx
+++ b/apps/desktop/src/mobile/audio-memo-provider.test.tsx
@@ -162,6 +162,7 @@ const RECORDING: NativeRecorderResult = {
   mimeType: 'audio/mp4',
   durationMs: 4000,
   stagedPath: '/staging/recording-1.m4a',
+  recordedAt: new Date(1_700_000_000_000),
 }
 
 const MEMO: AudioMemoIdentity = {
@@ -423,6 +424,7 @@ describe('MobileAudioMemoProvider', () => {
       mimeType: 'audio/mp4',
       durationMs: 30_000,
       stagedPath: '/staging/recording-orphan.m4a',
+      recordedAt: new Date(1_700_000_050_000),
     }
     stagedControls.stopActive.mockResolvedValue(orphaned)
 

--- a/apps/desktop/src/mobile/audio-memo-provider.test.tsx
+++ b/apps/desktop/src/mobile/audio-memo-provider.test.tsx
@@ -17,6 +17,14 @@ const captureAudioMemo = vi.hoisted(() =>
 const failOperation = vi.hoisted(() => vi.fn<(message: string) => void>())
 const invoke = vi.hoisted(() => vi.fn<(command: string, args?: unknown) => Promise<unknown>>())
 
+/** Captured plugin-event handlers, keyed by event name, dispatchable per test. */
+const pluginEvents = vi.hoisted(() => ({
+  handlers: new Map<string, (payload: unknown) => void>(),
+  emit(event: string, payload: unknown): void {
+    pluginEvents.handlers.get(event)?.(payload)
+  },
+}))
+
 /** Fake reconciler lifecycle — the pipeline is only a shim over it. */
 const reconcilerControls = vi.hoisted(() => {
   const listeners = new Set<() => void>()
@@ -70,7 +78,12 @@ vi.mock('@reflect/core', async (importOriginal) => ({
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke,
-  addPluginListener: vi.fn(async () => ({ unregister: vi.fn() })),
+  addPluginListener: vi.fn(
+    async (_plugin: string, event: string, handler: (payload: unknown) => void) => {
+      pluginEvents.handlers.set(event, handler)
+      return { unregister: vi.fn() }
+    },
+  ),
 }))
 
 vi.mock('@/lib/transcription-reconciler', () => ({
@@ -177,6 +190,7 @@ beforeEach(() => {
   }
   captureAudioMemo.mockResolvedValue({ ok: true, memo: MEMO })
   invoke.mockResolvedValue({ files: [] })
+  pluginEvents.handlers.clear()
   reconcilerControls.fake.getTranscribing.mockReturnValue(false)
   reconcilerControls.listeners.clear()
 })
@@ -430,6 +444,54 @@ describe('MobileAudioMemoProvider', () => {
 
     await waitFor(() => expect(stagedControls.recordingStatus).toHaveBeenCalled())
     expect(stagedControls.stopActive).not.toHaveBeenCalled()
+  })
+
+  it('the handshake claims queued actions: recordAudio records, then confirms', async () => {
+    vi.useFakeTimers()
+    try {
+      const { result } = renderHook(() => useMobileAudioMemo(), { wrapper })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+      expect(invoke).toHaveBeenCalledWith('plugin:recording|actions_ready')
+
+      await act(async () => {
+        pluginEvents.emit('nativeAction', { action: 'recordAudio' })
+        await vi.advanceTimersByTimeAsync(0)
+      })
+      expect(recorderControls.startSpy).toHaveBeenCalledTimes(1)
+      expect(result.current.drawerOpen).toBe(true)
+
+      // Confirmation waits until the recording UI has survived presentation —
+      // a crash in that window must leave the action queued for next launch.
+      expect(invoke).not.toHaveBeenCalledWith('plugin:recording|action_performed')
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000)
+      })
+      expect(invoke).toHaveBeenCalledWith('plugin:recording|action_performed')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('unknown native actions are ignored', async () => {
+    vi.useFakeTimers()
+    try {
+      renderHook(() => useMobileAudioMemo(), { wrapper })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
+      await act(async () => {
+        pluginEvents.emit('nativeAction', { action: 'somethingElse' })
+        await vi.advanceTimersByTimeAsync(2000)
+      })
+
+      expect(recorderControls.startSpy).not.toHaveBeenCalled()
+      expect(invoke).not.toHaveBeenCalledWith('plugin:recording|action_performed')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('is unavailable without an OpenAI or Gemini model, and toggle does nothing', async () => {

--- a/apps/desktop/src/mobile/audio-memo-provider.tsx
+++ b/apps/desktop/src/mobile/audio-memo-provider.tsx
@@ -21,8 +21,10 @@ import {
   isMicDeniedError,
   isStagedPathClaimed,
   NATIVE_RECORDING_MIME,
+  nativeRecordingStatus,
   readStagedRecording,
   releaseStagedPath,
+  stopActiveRecording,
   useNativeAudioRecorder,
   type NativeRecorderResult,
 } from '@/mobile/use-native-audio-recorder'
@@ -34,12 +36,17 @@ import {
  * presents recording in a sidebar popover; here it is a bottom drawer plus a
  * mic FAB on the daily spine.
  *
- * Two mobile-only responsibilities live here:
+ * Three mobile-only responsibilities live here:
  *
- * - **Native stops.** Interruptions (calls, Siri), input-route loss,
- *   backgrounding, and the duration cap finalize the recording natively and
- *   announce it on the plugin's `recordingStopped` event — ingested exactly
- *   like a user stop.
+ * - **Native stops.** Interruptions (calls, Siri), input-route loss, and the
+ *   duration cap finalize the recording natively and announce it on the
+ *   plugin's `recordingStopped` event — ingested exactly like a user stop.
+ *   Backgrounding is deliberately not a stop: `UIBackgroundModes: audio`
+ *   keeps a memo capturing through screen lock (V1 parity).
+ * - **The live-recording reconcile.** A recording that outlived its JS — a
+ *   webview reload or crash mid-memo, a provider remount — must never leave
+ *   a hidden hot microphone: on mount, a still-live native recording is
+ *   stopped and saved.
  * - **The orphan scan.** A recording whose stop the webview never saw (a
  *   crash, a kill while backgrounded) is still sitting in the plugin's
  *   staging directory: on mount and on every foreground, staged files no
@@ -246,6 +253,36 @@ export function MobileAudioMemoProvider({
     },
     [recorder.status, stopAndSave, cancelRecorder, setDrawerOpen],
   )
+
+  // The live-recording reconcile: this mount did not start any recording, so
+  // a native one still running (the webview reloaded or crashed mid-memo, or
+  // the provider remounted across a graph switch) has no UI — stop and save
+  // it rather than leave a hidden hot microphone.
+  useEffect(() => {
+    if (!hasBridge()) {
+      return
+    }
+    void (async () => {
+      try {
+        const status = await nativeRecordingStatus()
+        if (!status.recording) {
+          return
+        }
+        const result = await stopActiveRecording()
+        if (result !== null) {
+          enqueueStaged({
+            blob: result.blob,
+            recordedAt: new Date(),
+            stagedPath: result.stagedPath,
+          })
+        }
+      } catch (cause) {
+        // A user stop or native finalize winning the race lands here — the
+        // memo arrives through that path (or the orphan scan) instead.
+        console.warn('reconciling a live native recording failed:', cause)
+      }
+    })()
+  }, [enqueueStaged])
 
   // The orphan scan: staged recordings no live flow owns — from a crash, a
   // webview reload, or a kill while backgrounded — are ingested on mount and

--- a/apps/desktop/src/mobile/audio-memo-provider.tsx
+++ b/apps/desktop/src/mobile/audio-memo-provider.tsx
@@ -119,8 +119,14 @@ export function MobileAudioMemoProvider({
   const enqueueStaged = useCallback(
     (input: StagedRecordingInput): void => {
       const release = async (): Promise<void> => {
-        await deleteStagedRecording(input.stagedPath)
-        releaseStagedPath(input.stagedPath)
+        // Always drop the claim, even if the delete fails: a still-claimed
+        // path is skipped forever by the orphan scan, so a discarded memo
+        // whose delete threw would otherwise reappear on the next launch.
+        try {
+          await deleteStagedRecording(input.stagedPath)
+        } finally {
+          releaseStagedPath(input.stagedPath)
+        }
       }
       const capture: PendingAudioCapture = {
         audio: input.blob,
@@ -141,7 +147,7 @@ export function MobileAudioMemoProvider({
       if (result !== null) {
         enqueueStaged({
           blob: result.blob,
-          recordedAt: new Date(),
+          recordedAt: result.recordedAt,
           stagedPath: result.stagedPath,
         })
       }
@@ -189,7 +195,7 @@ export function MobileAudioMemoProvider({
       if (recording !== null) {
         enqueueStaged({
           blob: recording.blob,
-          recordedAt: new Date(),
+          recordedAt: recording.recordedAt,
           stagedPath: recording.stagedPath,
         })
       }

--- a/apps/desktop/src/mobile/audio-memo-provider.tsx
+++ b/apps/desktop/src/mobile/audio-memo-provider.tsx
@@ -9,7 +9,7 @@ import {
   type ReactElement,
   type ReactNode,
 } from 'react'
-import { invoke } from '@tauri-apps/api/core'
+import { addPluginListener, invoke } from '@tauri-apps/api/core'
 import { errorMessage, hasBridge, type GraphInfo } from '@reflect/core'
 import { z } from 'zod'
 import { useAudioMemoPipeline, type PendingAudioCapture } from '@/hooks/use-audio-memo-pipeline'
@@ -36,7 +36,7 @@ import {
  * presents recording in a sidebar popover; here it is a bottom drawer plus a
  * mic FAB on the daily spine.
  *
- * Three mobile-only responsibilities live here:
+ * Four mobile-only responsibilities live here:
  *
  * - **Native stops.** Interruptions (calls, Siri), input-route loss, and the
  *   duration cap finalize the recording natively and announce it on the
@@ -53,6 +53,11 @@ import {
  *   live flow owns are ingested, then deleted. Ingest is idempotent by stop
  *   time — a re-scan of a file whose delete failed rewrites the same
  *   `audio-memos/` path rather than duplicating the memo.
+ * - **The native-action handshake.** OS entry points (Siri, the home-screen
+ *   quick action, the lock-screen widget) queue a `recordAudio` request in
+ *   the plugin, persisted until this surface confirms it ran — so a request
+ *   arriving before the webview exists, or right before it dies, is neither
+ *   lost nor double-run (`docs/porting/reflect-mobile/native-entry-points.md`).
  */
 
 interface MobileAudioMemoContextValue {
@@ -96,6 +101,15 @@ const MIC_DENIED_REASON =
 const listStagedSchema = z.object({
   files: z.array(z.object({ path: z.string(), modifiedMs: z.number() })),
 })
+
+const nativeActionSchema = z.object({ action: z.string() })
+
+/**
+ * How long the recording UI must survive before a delivered native action is
+ * confirmed (V1 parity): a webview crash during presentation must leave the
+ * action queued so it re-fires on the next launch.
+ */
+const ACTION_CONFIRM_DELAY_MS = 2000
 
 interface MobileAudioMemoProviderProps {
   graph: GraphInfo
@@ -254,34 +268,83 @@ export function MobileAudioMemoProvider({
     [recorder.status, stopAndSave, cancelRecorder, setDrawerOpen],
   )
 
-  // The live-recording reconcile: this mount did not start any recording, so
-  // a native one still running (the webview reloaded or crashed mid-memo, or
-  // the provider remounted across a graph switch) has no UI — stop and save
-  // it rather than leave a hidden hot microphone.
+  const startRef = useRef(start)
+  useEffect(() => {
+    startRef.current = start
+  })
+
+  // The live-recording reconcile, then the native-action handshake — in that
+  // order, so a queued "record" delivered at `actions_ready` can never race
+  // the stop of a recording that outlived the previous webview.
+  //
+  // Reconcile: this mount did not start any recording, so a native one still
+  // running (the webview reloaded or crashed mid-memo, or the provider
+  // remounted across a graph switch) has no UI — stop and save it rather
+  // than leave a hidden hot microphone.
+  //
+  // Handshake: claim the plugin's persisted action queue; a delivered
+  // `recordAudio` starts a memo and is confirmed only once the recording UI
+  // has survived presentation (an unconfirmed action re-fires next launch).
+  // Confirmation is about delivery, not success — a mic-denied start still
+  // confirms, or the queue would re-surface the same failure every launch.
   useEffect(() => {
     if (!hasBridge()) {
       return
     }
+    let disposed = false
+    let confirmTimer: ReturnType<typeof setTimeout> | null = null
+    let unlisten: (() => void) | null = null
     void (async () => {
       try {
         const status = await nativeRecordingStatus()
-        if (!status.recording) {
-          return
-        }
-        const result = await stopActiveRecording()
-        if (result !== null) {
-          enqueueStaged({
-            blob: result.blob,
-            recordedAt: new Date(),
-            stagedPath: result.stagedPath,
-          })
+        if (status.recording) {
+          const result = await stopActiveRecording()
+          if (result !== null) {
+            enqueueStaged({
+              blob: result.blob,
+              recordedAt: new Date(),
+              stagedPath: result.stagedPath,
+            })
+          }
         }
       } catch (cause) {
         // A user stop or native finalize winning the race lands here — the
         // memo arrives through that path (or the orphan scan) instead.
         console.warn('reconciling a live native recording failed:', cause)
       }
+      if (disposed) {
+        return
+      }
+      try {
+        const listener = await addPluginListener('recording', 'nativeAction', (raw: unknown) => {
+          const parsed = nativeActionSchema.safeParse(raw)
+          if (disposed || !parsed.success || parsed.data.action !== 'recordAudio') {
+            return
+          }
+          void startRef.current()
+          confirmTimer = setTimeout(() => {
+            void invoke('plugin:recording|action_performed').catch((cause: unknown) => {
+              console.warn('confirming a native action failed:', cause)
+            })
+          }, ACTION_CONFIRM_DELAY_MS)
+        })
+        if (disposed) {
+          void listener.unregister()
+          return
+        }
+        unlisten = () => void listener.unregister()
+        await invoke('plugin:recording|actions_ready')
+      } catch (cause) {
+        console.error('the native-action handshake is unavailable:', cause)
+      }
     })()
+    return () => {
+      disposed = true
+      if (confirmTimer !== null) {
+        clearTimeout(confirmTimer)
+      }
+      unlisten?.()
+    }
   }, [enqueueStaged])
 
   // The orphan scan: staged recordings no live flow owns — from a crash, a

--- a/apps/desktop/src/mobile/audio-memo-provider.tsx
+++ b/apps/desktop/src/mobile/audio-memo-provider.tsx
@@ -1,0 +1,368 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from 'react'
+import { invoke } from '@tauri-apps/api/core'
+import { errorMessage, hasBridge, type GraphInfo } from '@reflect/core'
+import { z } from 'zod'
+import { useAudioMemoPipeline, type PendingAudioCapture } from '@/hooks/use-audio-memo-pipeline'
+import type { AudioMemoPhase } from '@/providers/audio-memo-provider'
+import { hapticImpactLight } from '@/mobile/haptics'
+import {
+  claimStagedPath,
+  deleteStagedRecording,
+  isMicDeniedError,
+  isStagedPathClaimed,
+  NATIVE_RECORDING_MIME,
+  readStagedRecording,
+  releaseStagedPath,
+  useNativeAudioRecorder,
+  type NativeRecorderResult,
+} from '@/mobile/use-native-audio-recorder'
+
+/**
+ * The mobile React surface for audio memos: the native recorder plugin over
+ * the shared capture pipeline (`useAudioMemoPipeline` — the same serial
+ * queue and transcription reconciler desktop uses). Desktop's provider
+ * presents recording in a sidebar popover; here it is a bottom drawer plus a
+ * mic FAB on the daily spine.
+ *
+ * Two mobile-only responsibilities live here:
+ *
+ * - **Native stops.** Interruptions (calls, Siri), input-route loss,
+ *   backgrounding, and the duration cap finalize the recording natively and
+ *   announce it on the plugin's `recordingStopped` event — ingested exactly
+ *   like a user stop.
+ * - **The orphan scan.** A recording whose stop the webview never saw (a
+ *   crash, a kill while backgrounded) is still sitting in the plugin's
+ *   staging directory: on mount and on every foreground, staged files no
+ *   live flow owns are ingested, then deleted. Ingest is idempotent by stop
+ *   time — a re-scan of a file whose delete failed rewrites the same
+ *   `audio-memos/` path rather than duplicating the memo.
+ */
+
+interface MobileAudioMemoContextValue {
+  phase: AudioMemoPhase
+  /** Live while recording. */
+  elapsedMs: number
+  /** Latest input level 0…1, for the waveform. */
+  level: number
+  /** Recordings committed but not yet written to the graph. */
+  pendingCount: number
+  /** False without the native bridge or a transcription-capable model. */
+  available: boolean
+  /** The failure shown in the error phase. */
+  error: string | null
+  /** True when a retry can re-run the failed capture. */
+  canRetry: boolean
+  /** The recording drawer's visibility. */
+  drawerOpen: boolean
+  /** FAB tap: idle → record; recording → stop & save; error → show it. */
+  toggle: () => void
+  /** The drawer's stop control — commit the memo. */
+  stopAndSave: () => void
+  /** The drawer's discard control — drop the live recording. */
+  cancelRecording: () => void
+  /** Drawer dismissal: a live recording stops-and-saves, never silently drops. */
+  onDrawerOpenChange: (open: boolean) => void
+  /** Re-run the failed capture. */
+  retry: () => void
+  /** Drop the failed memo and let the queue continue. */
+  discard: () => void
+}
+
+const MobileAudioMemoContext = createContext<MobileAudioMemoContextValue | null>(null)
+
+/** Auto-stop cap: bounds the transcription payload (desktop parity). */
+const MAX_DURATION_MS = 10 * 60_000
+
+const MIC_DENIED_REASON =
+  'Microphone access was denied. Allow it for Reflect in the Settings app.'
+
+const listStagedSchema = z.object({
+  files: z.array(z.object({ path: z.string(), modifiedMs: z.number() })),
+})
+
+interface MobileAudioMemoProviderProps {
+  graph: GraphInfo
+  children: ReactNode
+}
+
+export function MobileAudioMemoProvider({
+  graph,
+  children,
+}: MobileAudioMemoProviderProps): ReactElement {
+  const [drawerOpen, setDrawerOpenState] = useState(false)
+  /** True from the stop tap until the recorder hands over the file. */
+  const [stopping, setStopping] = useState(false)
+
+  // Synced synchronously, not through a render effect: the pump consults it
+  // the instant a capture fails, which can land before React re-renders the
+  // close that preceded the failure.
+  const drawerOpenRef = useRef(drawerOpen)
+  const setDrawerOpen = useCallback((open: boolean): void => {
+    drawerOpenRef.current = open
+    setDrawerOpenState(open)
+  }, [])
+
+  const pipeline = useAudioMemoPipeline({
+    graph,
+    isErrorSurfaceVisible: () => drawerOpenRef.current,
+  })
+  const enqueuePipeline = pipeline.enqueue
+
+  /** Wrap a staged recording as a pipeline capture that owns the file. */
+  const enqueueStaged = useCallback(
+    (input: { blob: Blob; recordedAt: Date; stagedPath: string }): void => {
+      const release = async (): Promise<void> => {
+        await deleteStagedRecording(input.stagedPath)
+        releaseStagedPath(input.stagedPath)
+      }
+      const capture: PendingAudioCapture = {
+        audio: input.blob,
+        mimeType: NATIVE_RECORDING_MIME,
+        recordedAt: input.recordedAt,
+        onCaptured: release,
+        onDiscarded: release,
+      }
+      enqueuePipeline(capture)
+    },
+    [enqueuePipeline],
+  )
+
+  const onNativeStop = useCallback(
+    (result: NativeRecorderResult | null): void => {
+      setDrawerOpen(false)
+      setStopping(false)
+      if (result !== null) {
+        enqueueStaged({
+          blob: result.blob,
+          recordedAt: new Date(),
+          stagedPath: result.stagedPath,
+        })
+      }
+    },
+    [enqueueStaged, setDrawerOpen],
+  )
+
+  const recorder = useNativeAudioRecorder({
+    maxDurationMs: MAX_DURATION_MS,
+    onNativeStop,
+  })
+  const startRecorder = recorder.start
+  const stopRecorder = recorder.stop
+  const cancelRecorder = recorder.cancel
+
+  const available = hasBridge() && pipeline.hasTranscriptionConfig
+
+  const start = useCallback(async (): Promise<void> => {
+    if (!available) {
+      return
+    }
+    setDrawerOpen(true)
+    try {
+      await startRecorder()
+      hapticImpactLight()
+    } catch (cause) {
+      pipeline.reportError(isMicDeniedError(cause) ? MIC_DENIED_REASON : errorMessage(cause))
+    }
+  }, [available, startRecorder, pipeline, setDrawerOpen])
+
+  /** Re-entry guard for the stop tap's await gap. */
+  const stoppingRef = useRef(false)
+
+  const stopAndSave = useCallback(async (): Promise<void> => {
+    if (stoppingRef.current) {
+      return
+    }
+    stoppingRef.current = true
+    // The stop tap commits the memo: the drawer closes now, and the FAB's
+    // 'transcribing' state carries the progress from here.
+    setStopping(true)
+    setDrawerOpen(false)
+    try {
+      const recording = await stopRecorder()
+      if (recording !== null) {
+        enqueueStaged({
+          blob: recording.blob,
+          recordedAt: new Date(),
+          stagedPath: recording.stagedPath,
+        })
+      }
+      hapticImpactLight()
+    } catch (cause) {
+      // A native stop (interruption, backgrounding) won the race — its
+      // `recordingStopped` event delivers the memo instead.
+      console.warn('stop raced a native finalize:', cause)
+    } finally {
+      stoppingRef.current = false
+      setStopping(false)
+    }
+  }, [stopRecorder, enqueueStaged, setDrawerOpen])
+
+  const cancelRecording = useCallback((): void => {
+    setDrawerOpen(false)
+    void cancelRecorder().catch((cause: unknown) => {
+      console.warn('cancel raced a native finalize:', cause)
+    })
+  }, [cancelRecorder, setDrawerOpen])
+
+  const toggle = useCallback((): void => {
+    if (recorder.status === 'recording') {
+      void stopAndSave()
+    } else if (recorder.status === 'requesting') {
+      void cancelRecorder().catch(() => {})
+      setDrawerOpen(false)
+    } else if (pipeline.error !== null) {
+      // A parked error must never invisibly block recording — the FAB
+      // reopens the drawer, which shows the failure with Retry/Discard.
+      setDrawerOpen(true)
+    } else if (recorder.status === 'idle') {
+      void start()
+    }
+  }, [recorder.status, pipeline.error, stopAndSave, cancelRecorder, start, setDrawerOpen])
+
+  const onDrawerOpenChange = useCallback(
+    (open: boolean): void => {
+      if (open) {
+        setDrawerOpen(true)
+        return
+      }
+      // Dismissing the drawer mid-recording saves — a swipe-down must never
+      // silently drop audio (discarding is the explicit Cancel control).
+      if (recorder.status === 'recording') {
+        void stopAndSave()
+      } else if (recorder.status === 'requesting') {
+        void cancelRecorder().catch(() => {})
+      }
+      setDrawerOpen(false)
+    },
+    [recorder.status, stopAndSave, cancelRecorder, setDrawerOpen],
+  )
+
+  // The orphan scan: staged recordings no live flow owns — from a crash, a
+  // webview reload, or a kill while backgrounded — are ingested on mount and
+  // on every foreground, oldest first (list_staged sorts by name = by time).
+  const scanningRef = useRef(false)
+  useEffect(() => {
+    if (!hasBridge()) {
+      return
+    }
+    let disposed = false
+    const scan = async (): Promise<void> => {
+      if (scanningRef.current) {
+        return
+      }
+      scanningRef.current = true
+      try {
+        const raw = await invoke('plugin:recording|list_staged')
+        const { files } = listStagedSchema.parse(raw)
+        for (const file of files) {
+          if (disposed) {
+            return
+          }
+          if (isStagedPathClaimed(file.path)) {
+            continue
+          }
+          claimStagedPath(file.path)
+          try {
+            const blob = await readStagedRecording(file.path)
+            enqueueStaged({
+              blob,
+              // The file's stop time, so a re-ingest after a failed delete
+              // resolves to the same memo identity instead of a duplicate.
+              recordedAt: new Date(file.modifiedMs),
+              stagedPath: file.path,
+            })
+          } catch (cause) {
+            releaseStagedPath(file.path)
+            console.error('ingesting a staged recording failed:', cause)
+          }
+        }
+      } catch (cause) {
+        console.error('audio memo orphan scan failed:', cause)
+      } finally {
+        scanningRef.current = false
+      }
+    }
+    void scan()
+    const onVisibilityChange = (): void => {
+      if (document.visibilityState === 'visible') {
+        void scan()
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    return () => {
+      disposed = true
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [enqueueStaged])
+
+  // A live capture owns the surface — a background save's failure parks and
+  // shows after the stop, never yanking the waveform mid-recording.
+  const phase: AudioMemoPhase =
+    recorder.status === 'recording' && !stopping
+      ? 'recording'
+      : recorder.status === 'requesting'
+        ? 'requesting'
+        : pipeline.error !== null
+          ? 'error'
+          : stopping || pipeline.pendingCount > 0 || pipeline.transcribing
+            ? 'transcribing'
+            : 'idle'
+
+  const value = useMemo<MobileAudioMemoContextValue>(
+    () => ({
+      phase,
+      elapsedMs: recorder.elapsedMs,
+      level: recorder.level,
+      pendingCount: pipeline.pendingCount,
+      available,
+      error: pipeline.error,
+      canRetry: pipeline.canRetry,
+      drawerOpen,
+      toggle,
+      stopAndSave: () => void stopAndSave(),
+      cancelRecording,
+      onDrawerOpenChange,
+      retry: pipeline.retry,
+      discard: pipeline.discard,
+    }),
+    [
+      phase,
+      recorder.elapsedMs,
+      recorder.level,
+      pipeline.pendingCount,
+      available,
+      pipeline.error,
+      pipeline.canRetry,
+      pipeline.retry,
+      pipeline.discard,
+      drawerOpen,
+      toggle,
+      stopAndSave,
+      cancelRecording,
+      onDrawerOpenChange,
+    ],
+  )
+
+  return (
+    <MobileAudioMemoContext.Provider value={value}>{children}</MobileAudioMemoContext.Provider>
+  )
+}
+
+/** Access the mobile audio-memo surface. Use within MobileAudioMemoProvider. */
+export function useMobileAudioMemo(): MobileAudioMemoContextValue {
+  const context = useContext(MobileAudioMemoContext)
+  if (!context) {
+    throw new Error('useMobileAudioMemo must be used within a MobileAudioMemoProvider')
+  }
+  return context
+}

--- a/apps/desktop/src/mobile/audio-memo-provider.tsx
+++ b/apps/desktop/src/mobile/audio-memo-provider.tsx
@@ -2,32 +2,29 @@ import {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useRef,
   useState,
   type ReactElement,
   type ReactNode,
 } from 'react'
-import { addPluginListener, invoke } from '@tauri-apps/api/core'
 import { errorMessage, hasBridge, type GraphInfo } from '@reflect/core'
-import { z } from 'zod'
 import { useAudioMemoPipeline, type PendingAudioCapture } from '@/hooks/use-audio-memo-pipeline'
 import type { AudioMemoPhase } from '@/providers/audio-memo-provider'
 import { hapticImpactLight } from '@/mobile/haptics'
 import {
-  claimStagedPath,
   deleteStagedRecording,
   isMicDeniedError,
-  isStagedPathClaimed,
   NATIVE_RECORDING_MIME,
-  nativeRecordingStatus,
-  readStagedRecording,
   releaseStagedPath,
-  stopActiveRecording,
   useNativeAudioRecorder,
   type NativeRecorderResult,
 } from '@/mobile/use-native-audio-recorder'
+import { useNativeRecordAction } from '@/mobile/use-native-record-action'
+import {
+  useStagedRecordingIngest,
+  type StagedRecordingInput,
+} from '@/mobile/use-staged-recording-ingest'
 
 /**
  * The mobile React surface for audio memos: the native recorder plugin over
@@ -43,21 +40,13 @@ import {
  *   plugin's `recordingStopped` event — ingested exactly like a user stop.
  *   Backgrounding is deliberately not a stop: `UIBackgroundModes: audio`
  *   keeps a memo capturing through screen lock (V1 parity).
- * - **The live-recording reconcile.** A recording that outlived its JS — a
- *   webview reload or crash mid-memo, a provider remount — must never leave
- *   a hidden hot microphone: on mount, a still-live native recording is
- *   stopped and saved.
- * - **The orphan scan.** A recording whose stop the webview never saw (a
- *   crash, a kill while backgrounded) is still sitting in the plugin's
- *   staging directory: on mount and on every foreground, staged files no
- *   live flow owns are ingested, then deleted. Ingest is idempotent by stop
- *   time — a re-scan of a file whose delete failed rewrites the same
- *   `audio-memos/` path rather than duplicating the memo.
- * - **The native-action handshake.** OS entry points (Siri, the home-screen
- *   quick action, the lock-screen widget) queue a `recordAudio` request in
- *   the plugin, persisted until this surface confirms it ran — so a request
- *   arriving before the webview exists, or right before it dies, is neither
- *   lost nor double-run (`docs/porting/reflect-mobile/native-entry-points.md`).
+ * - **The orphan scan** ({@link useStagedRecordingIngest}): staged
+ *   recordings whose stop the webview never saw are ingested on mount and
+ *   on every foreground.
+ * - **The live-recording reconcile + native-action handshake**
+ *   ({@link useNativeRecordAction}): a recording that outlived its JS is
+ *   stopped and saved rather than left a hidden hot microphone, and OS
+ *   entry points' queued `recordAudio` requests are claimed and confirmed.
  */
 
 interface MobileAudioMemoContextValue {
@@ -98,19 +87,6 @@ const MAX_DURATION_MS = 10 * 60_000
 const MIC_DENIED_REASON =
   'Microphone access was denied. Allow it for Reflect in the Settings app.'
 
-const listStagedSchema = z.object({
-  files: z.array(z.object({ path: z.string(), modifiedMs: z.number() })),
-})
-
-const nativeActionSchema = z.object({ action: z.string() })
-
-/**
- * How long the recording UI must survive before a delivered native action is
- * confirmed (V1 parity): a webview crash during presentation must leave the
- * action queued so it re-fires on the next launch.
- */
-const ACTION_CONFIRM_DELAY_MS = 2000
-
 interface MobileAudioMemoProviderProps {
   graph: GraphInfo
   children: ReactNode
@@ -141,7 +117,7 @@ export function MobileAudioMemoProvider({
 
   /** Wrap a staged recording as a pipeline capture that owns the file. */
   const enqueueStaged = useCallback(
-    (input: { blob: Blob; recordedAt: Date; stagedPath: string }): void => {
+    (input: StagedRecordingInput): void => {
       const release = async (): Promise<void> => {
         await deleteStagedRecording(input.stagedPath)
         releaseStagedPath(input.stagedPath)
@@ -268,142 +244,8 @@ export function MobileAudioMemoProvider({
     [recorder.status, stopAndSave, cancelRecorder, setDrawerOpen],
   )
 
-  const startRef = useRef(start)
-  useEffect(() => {
-    startRef.current = start
-  })
-
-  // The live-recording reconcile, then the native-action handshake — in that
-  // order, so a queued "record" delivered at `actions_ready` can never race
-  // the stop of a recording that outlived the previous webview.
-  //
-  // Reconcile: this mount did not start any recording, so a native one still
-  // running (the webview reloaded or crashed mid-memo, or the provider
-  // remounted across a graph switch) has no UI — stop and save it rather
-  // than leave a hidden hot microphone.
-  //
-  // Handshake: claim the plugin's persisted action queue; a delivered
-  // `recordAudio` starts a memo and is confirmed only once the recording UI
-  // has survived presentation (an unconfirmed action re-fires next launch).
-  // Confirmation is about delivery, not success — a mic-denied start still
-  // confirms, or the queue would re-surface the same failure every launch.
-  useEffect(() => {
-    if (!hasBridge()) {
-      return
-    }
-    let disposed = false
-    let confirmTimer: ReturnType<typeof setTimeout> | null = null
-    let unlisten: (() => void) | null = null
-    void (async () => {
-      try {
-        const status = await nativeRecordingStatus()
-        if (status.recording) {
-          const result = await stopActiveRecording()
-          if (result !== null) {
-            enqueueStaged({
-              blob: result.blob,
-              recordedAt: new Date(),
-              stagedPath: result.stagedPath,
-            })
-          }
-        }
-      } catch (cause) {
-        // A user stop or native finalize winning the race lands here — the
-        // memo arrives through that path (or the orphan scan) instead.
-        console.warn('reconciling a live native recording failed:', cause)
-      }
-      if (disposed) {
-        return
-      }
-      try {
-        const listener = await addPluginListener('recording', 'nativeAction', (raw: unknown) => {
-          const parsed = nativeActionSchema.safeParse(raw)
-          if (disposed || !parsed.success || parsed.data.action !== 'recordAudio') {
-            return
-          }
-          void startRef.current()
-          confirmTimer = setTimeout(() => {
-            void invoke('plugin:recording|action_performed').catch((cause: unknown) => {
-              console.warn('confirming a native action failed:', cause)
-            })
-          }, ACTION_CONFIRM_DELAY_MS)
-        })
-        if (disposed) {
-          void listener.unregister()
-          return
-        }
-        unlisten = () => void listener.unregister()
-        await invoke('plugin:recording|actions_ready')
-      } catch (cause) {
-        console.error('the native-action handshake is unavailable:', cause)
-      }
-    })()
-    return () => {
-      disposed = true
-      if (confirmTimer !== null) {
-        clearTimeout(confirmTimer)
-      }
-      unlisten?.()
-    }
-  }, [enqueueStaged])
-
-  // The orphan scan: staged recordings no live flow owns — from a crash, a
-  // webview reload, or a kill while backgrounded — are ingested on mount and
-  // on every foreground, oldest first (list_staged sorts by name = by time).
-  const scanningRef = useRef(false)
-  useEffect(() => {
-    if (!hasBridge()) {
-      return
-    }
-    let disposed = false
-    const scan = async (): Promise<void> => {
-      if (scanningRef.current) {
-        return
-      }
-      scanningRef.current = true
-      try {
-        const raw = await invoke('plugin:recording|list_staged')
-        const { files } = listStagedSchema.parse(raw)
-        for (const file of files) {
-          if (disposed) {
-            return
-          }
-          if (isStagedPathClaimed(file.path)) {
-            continue
-          }
-          claimStagedPath(file.path)
-          try {
-            const blob = await readStagedRecording(file.path)
-            enqueueStaged({
-              blob,
-              // The file's stop time, so a re-ingest after a failed delete
-              // resolves to the same memo identity instead of a duplicate.
-              recordedAt: new Date(file.modifiedMs),
-              stagedPath: file.path,
-            })
-          } catch (cause) {
-            releaseStagedPath(file.path)
-            console.error('ingesting a staged recording failed:', cause)
-          }
-        }
-      } catch (cause) {
-        console.error('audio memo orphan scan failed:', cause)
-      } finally {
-        scanningRef.current = false
-      }
-    }
-    void scan()
-    const onVisibilityChange = (): void => {
-      if (document.visibilityState === 'visible') {
-        void scan()
-      }
-    }
-    document.addEventListener('visibilitychange', onVisibilityChange)
-    return () => {
-      disposed = true
-      document.removeEventListener('visibilitychange', onVisibilityChange)
-    }
-  }, [enqueueStaged])
+  useNativeRecordAction({ start, enqueueStaged })
+  useStagedRecordingIngest(enqueueStaged)
 
   // A live capture owns the surface — a background save's failure parks and
   // shows after the stop, never yanking the waveform mid-recording.

--- a/apps/desktop/src/mobile/mobile-app.tsx
+++ b/apps/desktop/src/mobile/mobile-app.tsx
@@ -1,9 +1,11 @@
 import { useEffect, type ReactElement } from 'react'
 import { installBackgroundFlush } from '@/lib/background-flush'
+import { MobileAudioMemoProvider } from '@/mobile/audio-memo-provider'
 import { MobileErrorBoundary } from '@/mobile/mobile-error-boundary'
 import { MobileOnboardingScreen } from '@/mobile/onboarding-screen'
 import { MobileShell } from '@/mobile/mobile-shell'
 import { MobileStatusLayer } from '@/mobile/status-layer'
+import { RecordingDrawer } from '@/mobile/recording-drawer'
 import { useICloudRefresh } from '@/mobile/use-icloud-refresh'
 import { useKeyboardHeightVar } from '@/mobile/use-keyboard'
 import { useTaskCheckboxHaptics } from '@/mobile/use-task-haptics'
@@ -58,8 +60,17 @@ export function MobileApp(): ReactElement {
                   survives tab switches; semantic search is forced off on
                   this surface inside the provider. */}
               <ChatProvider graph={graph}>
-                <MobileShell />
-                <MobileStatusLayer />
+                {/* Native recording over the shared capture pipeline — the
+                    mobile leg of desktop's audio memos. Mounted here so the
+                    queue, the reconciler, and the orphan scan survive tab
+                    switches. */}
+                <MobileAudioMemoProvider graph={graph}>
+                  <MobileShell />
+                  <MobileStatusLayer />
+                  {/* Mounted beside the shell (not inside the daily screen)
+                      so a live recording's sheet survives tab switches. */}
+                  <RecordingDrawer />
+                </MobileAudioMemoProvider>
               </ChatProvider>
             </CaptureProvider>
           </SyncProvider>

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -143,6 +143,26 @@ vi.mock('@/providers/settings-provider', () => ({
     updateSettingsWith: () => {},
   }),
 }))
+// The daily spine renders the audio-memo FAB; this suite is about screens,
+// not recording — an unavailable memo surface keeps the FAB out of the tree.
+vi.mock('@/mobile/audio-memo-provider', () => ({
+  useMobileAudioMemo: () => ({
+    phase: 'idle',
+    elapsedMs: 0,
+    level: 0,
+    pendingCount: 0,
+    available: false,
+    error: null,
+    canRetry: false,
+    drawerOpen: false,
+    toggle: () => {},
+    stopAndSave: () => {},
+    cancelRecording: () => {},
+    onDrawerOpenChange: () => {},
+    retry: () => {},
+    discard: () => {},
+  }),
+}))
 
 /** The fake graph: files behind the IPC bridge. */
 let files: Record<string, string>

--- a/apps/desktop/src/mobile/recording-drawer.tsx
+++ b/apps/desktop/src/mobile/recording-drawer.tsx
@@ -1,0 +1,76 @@
+import type { ReactElement } from 'react'
+import { Square } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
+import { useMobileAudioMemo } from '@/mobile/audio-memo-provider'
+import { RecordingLevelWaveform } from '@/mobile/recording-level-waveform'
+
+/**
+ * The recording sheet (V1's recording modal as a bottom drawer): waveform +
+ * elapsed time with a stop control while recording, and the capture-failure
+ * state with Retry/Discard. Dragging the sheet down mid-recording
+ * stops-and-saves — dismissal must never silently drop audio; discarding is
+ * the explicit Cancel control. The provider owns open state and the
+ * stop/cancel semantics behind `onDrawerOpenChange`.
+ */
+export function RecordingDrawer(): ReactElement {
+  const memo = useMobileAudioMemo()
+
+  return (
+    <Drawer open={memo.drawerOpen} onOpenChange={memo.onDrawerOpenChange}>
+      <DrawerContent aria-label="Audio memo">
+        <DrawerTitle className="sr-only">Audio memo</DrawerTitle>
+        {memo.error !== null ? (
+          <div className="flex flex-col gap-3 px-2 pb-2">
+            <p className="text-sm text-destructive">{memo.error}</p>
+            <div className="flex gap-2">
+              {memo.canRetry ? (
+                <Button variant="secondary" onClick={() => memo.retry()}>
+                  Retry
+                </Button>
+              ) : null}
+              <Button variant="ghost" onClick={() => memo.discard()}>
+                Discard
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-4 pb-2">
+            <div className="flex h-7 items-center justify-center">
+              {memo.phase === 'recording' ? (
+                <RecordingLevelWaveform level={memo.level} />
+              ) : (
+                <p className="text-sm text-text-muted">Waiting for the microphone…</p>
+              )}
+            </div>
+            <span className="text-lg font-medium tabular-nums">
+              {formatElapsed(memo.elapsedMs)}
+            </span>
+            <div className="flex w-full flex-col items-center gap-2">
+              <Button
+                variant="destructive"
+                size="icon"
+                aria-label="Stop recording"
+                className="size-14 rounded-full"
+                disabled={memo.phase !== 'recording'}
+                onClick={() => memo.stopAndSave()}
+              >
+                <Square aria-hidden fill="currentColor" className="size-5" />
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => memo.cancelRecording()}>
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+      </DrawerContent>
+    </Drawer>
+  )
+}
+
+function formatElapsed(elapsedMs: number): string {
+  const totalSeconds = Math.floor(elapsedMs / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}:${String(seconds).padStart(2, '0')}`
+}

--- a/apps/desktop/src/mobile/recording-level-waveform.tsx
+++ b/apps/desktop/src/mobile/recording-level-waveform.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useRef, type ReactElement } from 'react'
+
+interface RecordingLevelWaveformProps {
+  /** Latest input level 0…1 (the plugin's ~10 Hz `recordingLevel` stream). */
+  level: number
+}
+
+const BAR_COUNT = 48
+const BAR_WIDTH = 2
+const BAR_GAP = 2
+const CSS_WIDTH = BAR_COUNT * (BAR_WIDTH + BAR_GAP) - BAR_GAP
+const CSS_HEIGHT = 28
+/** Average-power levels read quieter than desktop's peak sampling — boost. */
+const LEVEL_GAIN = 2.5
+
+/**
+ * The mobile counterpart of `RecordingWaveform`: the same rolling
+ * amplitude trace, fed by the native recorder's metering events instead of
+ * an AnalyserNode on a MediaStream (the native recorder has no stream to
+ * tap). A new bar lands per level event, scrolling left as the recording
+ * grows; silence renders as the dotted baseline.
+ */
+export function RecordingLevelWaveform({ level }: RecordingLevelWaveformProps): ReactElement {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const barsRef = useRef<number[]>(Array.from({ length: BAR_COUNT }, () => 0))
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    const context = canvas?.getContext('2d')
+    if (!canvas || !context) {
+      return
+    }
+    const scale = window.devicePixelRatio || 1
+    canvas.width = CSS_WIDTH * scale
+    canvas.height = CSS_HEIGHT * scale
+    context.scale(scale, scale)
+    // The canvas carries a text color class; bars inherit the theme through it.
+    const color = getComputedStyle(canvas).color
+
+    const bars = barsRef.current
+    bars.push(Math.min(1, level * LEVEL_GAIN))
+    bars.splice(0, bars.length - BAR_COUNT)
+
+    context.clearRect(0, 0, CSS_WIDTH, CSS_HEIGHT)
+    context.fillStyle = color
+    bars.forEach((amplitude, index) => {
+      const height = Math.max(BAR_WIDTH, amplitude * CSS_HEIGHT)
+      const left = index * (BAR_WIDTH + BAR_GAP)
+      const top = (CSS_HEIGHT - height) / 2
+      // roundRect is Safari 16+; an un-updated older WebKit still records,
+      // it just gets square bars instead of a crash.
+      if (typeof context.roundRect === 'function') {
+        context.beginPath()
+        context.roundRect(left, top, BAR_WIDTH, height, BAR_WIDTH / 2)
+        context.fill()
+      } else {
+        context.fillRect(left, top, BAR_WIDTH, height)
+      }
+    })
+  }, [level])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden
+      className="text-destructive"
+      style={{ width: CSS_WIDTH, height: CSS_HEIGHT }}
+    />
+  )
+}

--- a/apps/desktop/src/mobile/screens/daily.tsx
+++ b/apps/desktop/src/mobile/screens/daily.tsx
@@ -3,6 +3,7 @@ import { untitledNotePath } from '@reflect/core'
 import { Plus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useToday } from '@/lib/use-today'
+import { AudioMemoFab } from '@/mobile/audio-memo-fab'
 import { CalendarStrip } from '@/mobile/calendar-strip'
 import { DayCarousel } from '@/mobile/day-carousel'
 import { useDailyArrivals } from '@/mobile/use-daily-arrivals'
@@ -82,6 +83,7 @@ export function MobileDaily({ date }: { date: string }): ReactElement {
       >
         <Plus className="size-6" />
       </Button>
+      <AudioMemoFab />
     </div>
   )
 }

--- a/apps/desktop/src/mobile/use-native-audio-recorder.test.ts
+++ b/apps/desktop/src/mobile/use-native-audio-recorder.test.ts
@@ -1,0 +1,212 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const invoke = vi.hoisted(() => vi.fn<(command: string, args?: unknown) => Promise<unknown>>())
+
+/** Captured plugin-event handlers, keyed by event name, dispatchable per test. */
+const pluginEvents = vi.hoisted(() => ({
+  handlers: new Map<string, (payload: unknown) => void>(),
+  emit(event: string, payload: unknown): void {
+    pluginEvents.handlers.get(event)?.(payload)
+  },
+}))
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke,
+  addPluginListener: vi.fn(async (_plugin: string, event: string, handler: (p: unknown) => void) => {
+    pluginEvents.handlers.set(event, handler)
+    return { unregister: vi.fn() }
+  }),
+}))
+
+const { isStagedPathClaimed, releaseStagedPath, useNativeAudioRecorder } = await import(
+  './use-native-audio-recorder'
+)
+
+function base64Of(text: string): string {
+  return btoa(text)
+}
+
+const onNativeStop = vi.fn()
+
+function renderRecorder() {
+  return renderHook(() =>
+    useNativeAudioRecorder({ maxDurationMs: 600_000, onNativeStop }),
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  pluginEvents.handlers.clear()
+  invoke.mockResolvedValue(undefined)
+})
+
+describe('useNativeAudioRecorder', () => {
+  it('start invokes the plugin with the cap and flips to recording', async () => {
+    const { result } = renderRecorder()
+    expect(result.current.status).toBe('idle')
+
+    await act(async () => {
+      await result.current.start()
+    })
+
+    expect(invoke).toHaveBeenCalledWith('plugin:recording|start_recording', {
+      request: { maxDurationMs: 600_000 },
+    })
+    expect(result.current.status).toBe('recording')
+  })
+
+  it('a rejected start resets to idle and rethrows for the caller', async () => {
+    invoke.mockRejectedValueOnce('microphone access denied')
+    const { result } = renderRecorder()
+
+    await expect(
+      act(async () => {
+        await result.current.start()
+      }),
+    ).rejects.toBe('microphone access denied')
+    expect(result.current.status).toBe('idle')
+  })
+
+  it('stop reads the staged file back, claims it, and returns the blob', async () => {
+    const path = '/staging/stop-normal.m4a'
+    invoke.mockImplementation(async (command: string) => {
+      if (command === 'plugin:recording|start_recording') {
+        return undefined
+      }
+      if (command === 'plugin:recording|stop_recording') {
+        return { path, durationMs: 4000 }
+      }
+      if (command === 'plugin:recording|read_staged') {
+        return { base64: base64Of('audio-bytes') }
+      }
+      throw new Error(`unexpected invoke: ${command}`)
+    })
+    const { result } = renderRecorder()
+
+    await act(async () => {
+      await result.current.start()
+    })
+    const results: Array<Awaited<ReturnType<typeof result.current.stop>>> = []
+    await act(async () => {
+      results.push(await result.current.stop())
+    })
+
+    const stopped = results[0]
+    expect(stopped).not.toBeNull()
+    expect(stopped?.stagedPath).toBe(path)
+    expect(stopped?.durationMs).toBe(4000)
+    expect(stopped?.mimeType).toBe('audio/mp4')
+    expect(await stopped?.blob.text()).toBe('audio-bytes')
+    expect(isStagedPathClaimed(path)).toBe(true)
+    expect(result.current.status).toBe('idle')
+    releaseStagedPath(path)
+  })
+
+  it('a too-short stop deletes the staged file and returns null', async () => {
+    const path = '/staging/stop-short.m4a'
+    invoke.mockImplementation(async (command: string) => {
+      if (command === 'plugin:recording|stop_recording') {
+        return { path, durationMs: 300 }
+      }
+      return undefined
+    })
+    const { result } = renderRecorder()
+
+    await act(async () => {
+      await result.current.start()
+    })
+    let stopped: Awaited<ReturnType<typeof result.current.stop>> = null
+    await act(async () => {
+      stopped = await result.current.stop()
+    })
+
+    expect(stopped).toBeNull()
+    expect(invoke).toHaveBeenCalledWith('plugin:recording|delete_staged', {
+      request: { path },
+    })
+    expect(isStagedPathClaimed(path)).toBe(false)
+  })
+
+  it('level events feed the waveform only while recording', async () => {
+    const { result } = renderRecorder()
+    await waitFor(() => expect(pluginEvents.handlers.has('recordingLevel')).toBe(true))
+
+    act(() => {
+      pluginEvents.emit('recordingLevel', { level: 0.5, elapsedMs: 1200 })
+    })
+    expect(result.current.level).toBe(0)
+
+    await act(async () => {
+      await result.current.start()
+    })
+    act(() => {
+      pluginEvents.emit('recordingLevel', { level: 0.5, elapsedMs: 1200 })
+    })
+    expect(result.current.level).toBe(0.5)
+    expect(result.current.elapsedMs).toBe(1200)
+  })
+
+  it('a native stop reads the file back and hands it to onNativeStop', async () => {
+    const path = '/staging/native-stop.m4a'
+    invoke.mockImplementation(async (command: string) => {
+      if (command === 'plugin:recording|read_staged') {
+        return { base64: base64Of('native-bytes') }
+      }
+      return undefined
+    })
+    const { result } = renderRecorder()
+    await waitFor(() => expect(pluginEvents.handlers.has('recordingStopped')).toBe(true))
+    await act(async () => {
+      await result.current.start()
+    })
+
+    await act(async () => {
+      pluginEvents.emit('recordingStopped', { path, durationMs: 5000, reason: 'interruption' })
+    })
+
+    expect(result.current.status).toBe('idle')
+    await waitFor(() =>
+      expect(onNativeStop).toHaveBeenCalledWith(
+        expect.objectContaining({ stagedPath: path, durationMs: 5000 }),
+      ),
+    )
+    expect(isStagedPathClaimed(path)).toBe(true)
+    releaseStagedPath(path)
+  })
+
+  it('a too-short native stop deletes the file and reports null', async () => {
+    const path = '/staging/native-short.m4a'
+    renderRecorder()
+    await waitFor(() => expect(pluginEvents.handlers.has('recordingStopped')).toBe(true))
+
+    await act(async () => {
+      pluginEvents.emit('recordingStopped', { path, durationMs: 200, reason: 'background' })
+    })
+
+    await waitFor(() => expect(onNativeStop).toHaveBeenCalledWith(null))
+    expect(invoke).toHaveBeenCalledWith('plugin:recording|delete_staged', {
+      request: { path },
+    })
+    expect(isStagedPathClaimed(path)).toBe(false)
+  })
+
+  it('a failed read-back after a native stop releases the claim for the orphan scan', async () => {
+    const path = '/staging/native-unreadable.m4a'
+    invoke.mockImplementation(async (command: string) => {
+      if (command === 'plugin:recording|read_staged') {
+        throw new Error('io error')
+      }
+      return undefined
+    })
+    renderRecorder()
+    await waitFor(() => expect(pluginEvents.handlers.has('recordingStopped')).toBe(true))
+
+    await act(async () => {
+      pluginEvents.emit('recordingStopped', { path, durationMs: 5000, reason: 'error' })
+    })
+
+    await waitFor(() => expect(isStagedPathClaimed(path)).toBe(false))
+    expect(onNativeStop).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/mobile/use-native-audio-recorder.test.ts
+++ b/apps/desktop/src/mobile/use-native-audio-recorder.test.ts
@@ -75,7 +75,7 @@ describe('useNativeAudioRecorder', () => {
         return undefined
       }
       if (command === 'plugin:recording|stop_recording') {
-        return { path, durationMs: 4000 }
+        return { path, durationMs: 4000, modifiedMs: 1_700_000_000_000 }
       }
       if (command === 'plugin:recording|read_staged') {
         return { base64: base64Of('audio-bytes') }
@@ -97,6 +97,8 @@ describe('useNativeAudioRecorder', () => {
     expect(stopped?.stagedPath).toBe(path)
     expect(stopped?.durationMs).toBe(4000)
     expect(stopped?.mimeType).toBe('audio/mp4')
+    // The memo's identity timestamp is the staged file's mtime, not wall clock.
+    expect(stopped?.recordedAt).toEqual(new Date(1_700_000_000_000))
     expect(await stopped?.blob.text()).toBe('audio-bytes')
     expect(isStagedPathClaimed(path)).toBe(true)
     expect(result.current.status).toBe('idle')
@@ -107,7 +109,7 @@ describe('useNativeAudioRecorder', () => {
     const path = '/staging/stop-short.m4a'
     invoke.mockImplementation(async (command: string) => {
       if (command === 'plugin:recording|stop_recording') {
-        return { path, durationMs: 300 }
+        return { path, durationMs: 300, modifiedMs: 1_700_000_000_000 }
       }
       return undefined
     })
@@ -162,13 +164,22 @@ describe('useNativeAudioRecorder', () => {
     })
 
     await act(async () => {
-      pluginEvents.emit('recordingStopped', { path, durationMs: 5000, reason: 'interruption' })
+      pluginEvents.emit('recordingStopped', {
+        path,
+        durationMs: 5000,
+        modifiedMs: 1_700_000_000_000,
+        reason: 'interruption',
+      })
     })
 
     expect(result.current.status).toBe('idle')
     await waitFor(() =>
       expect(onNativeStop).toHaveBeenCalledWith(
-        expect.objectContaining({ stagedPath: path, durationMs: 5000 }),
+        expect.objectContaining({
+          stagedPath: path,
+          durationMs: 5000,
+          recordedAt: new Date(1_700_000_000_000),
+        }),
       ),
     )
     expect(isStagedPathClaimed(path)).toBe(true)
@@ -181,7 +192,12 @@ describe('useNativeAudioRecorder', () => {
     await waitFor(() => expect(pluginEvents.handlers.has('recordingStopped')).toBe(true))
 
     await act(async () => {
-      pluginEvents.emit('recordingStopped', { path, durationMs: 200, reason: 'background' })
+      pluginEvents.emit('recordingStopped', {
+        path,
+        durationMs: 200,
+        modifiedMs: 1_700_000_000_000,
+        reason: 'interruption',
+      })
     })
 
     await waitFor(() => expect(onNativeStop).toHaveBeenCalledWith(null))
@@ -191,7 +207,7 @@ describe('useNativeAudioRecorder', () => {
     expect(isStagedPathClaimed(path)).toBe(false)
   })
 
-  it('a failed read-back after a native stop releases the claim for the orphan scan', async () => {
+  it('a failed read-back after a native stop releases the claim and closes the UI', async () => {
     const path = '/staging/native-unreadable.m4a'
     invoke.mockImplementation(async (command: string) => {
       if (command === 'plugin:recording|read_staged') {
@@ -203,10 +219,55 @@ describe('useNativeAudioRecorder', () => {
     await waitFor(() => expect(pluginEvents.handlers.has('recordingStopped')).toBe(true))
 
     await act(async () => {
-      pluginEvents.emit('recordingStopped', { path, durationMs: 5000, reason: 'error' })
+      pluginEvents.emit('recordingStopped', {
+        path,
+        durationMs: 5000,
+        modifiedMs: 1_700_000_000_000,
+        reason: 'error',
+      })
     })
 
+    // The file is left staged (released) for the orphan scan, but the host is
+    // still notified so the recording UI closes rather than stranding.
     await waitFor(() => expect(isStagedPathClaimed(path)).toBe(false))
-    expect(onNativeStop).not.toHaveBeenCalled()
+    expect(onNativeStop).toHaveBeenCalledWith(null)
+  })
+
+  it('a native stop landing during start does not resurrect the recording', async () => {
+    const path = '/staging/stop-during-start.m4a'
+    let releaseStart: () => void = () => {}
+    invoke.mockImplementation(async (command: string) => {
+      if (command === 'plugin:recording|start_recording') {
+        await new Promise<void>((resolve) => {
+          releaseStart = resolve
+        })
+        return undefined
+      }
+      return undefined
+    })
+    const { result } = renderRecorder()
+    await waitFor(() => expect(pluginEvents.handlers.has('recordingStopped')).toBe(true))
+
+    let startPromise: Promise<void> = Promise.resolve()
+    await act(async () => {
+      startPromise = result.current.start()
+      await Promise.resolve()
+    })
+    expect(result.current.status).toBe('requesting')
+
+    // The recorder finalizes (e.g. immediate interruption) before start's
+    // invoke resolves — status must stay idle, not flip back to recording.
+    await act(async () => {
+      pluginEvents.emit('recordingStopped', {
+        path,
+        durationMs: 200,
+        modifiedMs: 1_700_000_000_000,
+        reason: 'interruption',
+      })
+      releaseStart()
+      await startPromise
+    })
+
+    expect(result.current.status).toBe('idle')
   })
 })

--- a/apps/desktop/src/mobile/use-native-audio-recorder.ts
+++ b/apps/desktop/src/mobile/use-native-audio-recorder.ts
@@ -9,9 +9,11 @@ import { z } from 'zod'
  * (`plugins/tauri-plugin-recording`) instead of the webview's MediaRecorder.
  * Capture is native by design (the V1 lesson): AVAudioRecorder writes
  * straight into a staging directory the plugin owns, and interruptions,
- * route loss, backgrounding, and the duration cap all finalize the file
- * without JS — this hook only *presents* recording state and hands finished
- * files to the capture pipeline.
+ * route loss, and the duration cap all finalize the file without JS — this
+ * hook only *presents* recording state and hands finished files to the
+ * capture pipeline. Backgrounding does not stop a recording (the app
+ * declares `UIBackgroundModes: audio`); a memo keeps capturing through
+ * screen lock and is stopped by the user, the cap, or an interruption.
  *
  * Instead of a `MediaStream` for the waveform, the plugin streams ~10 Hz
  * `recordingLevel` events; the latest level and elapsed time are exposed as
@@ -38,9 +40,9 @@ export interface UseNativeAudioRecorderOptions {
   /** Auto-stop cap, enforced natively so it holds even if JS never wakes. */
   maxDurationMs: number
   /**
-   * A stop the native side initiated (interruption, route change,
-   * backgrounding, the cap): the file is already staged — treat it exactly
-   * like a user stop. `null` when the recording was too short to keep.
+   * A stop the native side initiated (interruption, route change, the cap):
+   * the file is already staged — treat it exactly like a user stop. `null`
+   * when the recording was too short to keep.
    */
   onNativeStop: (result: NativeRecorderResult | null) => void
 }
@@ -60,6 +62,7 @@ export interface UseNativeAudioRecorderValue {
 }
 
 const stopResponseSchema = z.object({ path: z.string(), durationMs: z.number() })
+const recordingStatusSchema = z.object({ recording: z.boolean(), elapsedMs: z.number() })
 const readStagedSchema = z.object({ base64: z.string() })
 const levelEventSchema = z.object({ level: z.number(), elapsedMs: z.number() })
 const stoppedEventSchema = z.object({
@@ -109,6 +112,44 @@ export async function readStagedRecording(path: string): Promise<Blob> {
 /** Remove a staged recording once its bytes are durable in the graph. */
 export async function deleteStagedRecording(path: string): Promise<void> {
   await invoke('plugin:recording|delete_staged', { request: { path } })
+}
+
+/**
+ * Whether a native recording is live right now. A fresh mount checks this to
+ * find a recording that outlived its JS (a webview reload or crash mid-memo).
+ */
+export async function nativeRecordingStatus(): Promise<{
+  recording: boolean
+  elapsedMs: number
+}> {
+  const raw = await invoke('plugin:recording|recording_status')
+  return recordingStatusSchema.parse(raw)
+}
+
+/**
+ * Stop the live native recording, claim its staged file, and read it back —
+ * `null` for one too short to be a memo. The shared machinery behind the
+ * hook's `stop` and the provider's mount-time reconcile of a recording that
+ * outlived its UI. Rejects when nothing is recording (a native finalize won
+ * the race — its `recordingStopped` event delivers the memo instead).
+ */
+export async function stopActiveRecording(): Promise<NativeRecorderResult | null> {
+  const raw = await invoke('plugin:recording|stop_recording')
+  const { path, durationMs } = stopResponseSchema.parse(raw)
+  claimStagedPath(path)
+  if (durationMs < MIN_DURATION_MS) {
+    await deleteStagedRecording(path).catch(() => {})
+    releaseStagedPath(path)
+    return null
+  }
+  try {
+    const blob = await readStagedRecording(path)
+    return { blob, mimeType: NATIVE_RECORDING_MIME, durationMs, stagedPath: path }
+  } catch (cause) {
+    // Leave the file for the orphan scan rather than losing the memo.
+    releaseStagedPath(path)
+    throw cause
+  }
 }
 
 export function useNativeAudioRecorder(
@@ -236,22 +277,10 @@ export function useNativeAudioRecorder(
       return Promise.resolve(null)
     }
     const stopped = (async (): Promise<NativeRecorderResult | null> => {
-      const raw = await invoke('plugin:recording|stop_recording')
-      setStatusBoth('idle')
-      const { path, durationMs } = stopResponseSchema.parse(raw)
-      claimStagedPath(path)
-      if (durationMs < MIN_DURATION_MS) {
-        await deleteStagedRecording(path).catch(() => {})
-        releaseStagedPath(path)
-        return null
-      }
       try {
-        const blob = await readStagedRecording(path)
-        return { blob, mimeType: NATIVE_RECORDING_MIME, durationMs, stagedPath: path }
-      } catch (cause) {
-        // Leave the file for the orphan scan rather than losing the memo.
-        releaseStagedPath(path)
-        throw cause
+        return await stopActiveRecording()
+      } finally {
+        setStatusBoth('idle')
       }
     })().finally(() => {
       stopPromiseRef.current = null

--- a/apps/desktop/src/mobile/use-native-audio-recorder.ts
+++ b/apps/desktop/src/mobile/use-native-audio-recorder.ts
@@ -1,0 +1,273 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { addPluginListener, invoke } from '@tauri-apps/api/core'
+import { base64ToBytes } from '@reflect/core'
+import { z } from 'zod'
+
+/**
+ * The mobile counterpart of `use-audio-recorder.ts`: the same
+ * status/start/stop/cancel surface over the native recorder plugin
+ * (`plugins/tauri-plugin-recording`) instead of the webview's MediaRecorder.
+ * Capture is native by design (the V1 lesson): AVAudioRecorder writes
+ * straight into a staging directory the plugin owns, and interruptions,
+ * route loss, backgrounding, and the duration cap all finalize the file
+ * without JS — this hook only *presents* recording state and hands finished
+ * files to the capture pipeline.
+ *
+ * Instead of a `MediaStream` for the waveform, the plugin streams ~10 Hz
+ * `recordingLevel` events; the latest level and elapsed time are exposed as
+ * plain state.
+ */
+
+export type NativeRecorderStatus = 'idle' | 'requesting' | 'recording'
+
+/** All recordings are AAC in an `.m4a` container (see RecordingPlugin.swift). */
+export const NATIVE_RECORDING_MIME = 'audio/mp4'
+
+/** Below this a recording is a misclick, not a memo (desktop parity). */
+const MIN_DURATION_MS = 500
+
+export interface NativeRecorderResult {
+  blob: Blob
+  mimeType: string
+  durationMs: number
+  /** The staged file's absolute path — delete it once the blob is durable. */
+  stagedPath: string
+}
+
+export interface UseNativeAudioRecorderOptions {
+  /** Auto-stop cap, enforced natively so it holds even if JS never wakes. */
+  maxDurationMs: number
+  /**
+   * A stop the native side initiated (interruption, route change,
+   * backgrounding, the cap): the file is already staged — treat it exactly
+   * like a user stop. `null` when the recording was too short to keep.
+   */
+  onNativeStop: (result: NativeRecorderResult | null) => void
+}
+
+export interface UseNativeAudioRecorderValue {
+  status: NativeRecorderStatus
+  /** Live while recording; 0 otherwise. */
+  elapsedMs: number
+  /** Latest input level 0…1, for the waveform. */
+  level: number
+  /** Ask for the microphone and start recording. Rejects when denied. */
+  start: () => Promise<void>
+  /** Stop and read back the recording — `null` for one too short to keep. */
+  stop: () => Promise<NativeRecorderResult | null>
+  /** Stop and discard everything. */
+  cancel: () => Promise<void>
+}
+
+const stopResponseSchema = z.object({ path: z.string(), durationMs: z.number() })
+const readStagedSchema = z.object({ base64: z.string() })
+const levelEventSchema = z.object({ level: z.number(), elapsedMs: z.number() })
+const stoppedEventSchema = z.object({
+  path: z.string(),
+  durationMs: z.number(),
+  reason: z.string(),
+})
+
+/**
+ * Staged files a live flow (a stop in flight, a queued capture) already owns.
+ * The orphan scan consults this so a file can never be ingested twice — once
+ * by the stop that produced it and once by a scan racing the await gaps in
+ * between. Module scope: one recorder surface per app, and claims must
+ * survive a provider remount mid-capture.
+ */
+const claimedStagedPaths = new Set<string>()
+
+/** Claim a staged file for a live capture flow. */
+export function claimStagedPath(path: string): void {
+  claimedStagedPaths.add(path)
+}
+
+/** Release a claim — after deletion, or so the orphan scan can retry it. */
+export function releaseStagedPath(path: string): void {
+  claimedStagedPaths.delete(path)
+}
+
+/** True when a live flow owns the staged file. */
+export function isStagedPathClaimed(path: string): boolean {
+  return claimedStagedPaths.has(path)
+}
+
+/** True when the native recorder rejected `start` because access was denied. */
+export function isMicDeniedError(cause: unknown): boolean {
+  return typeof cause === 'string'
+    ? cause.includes('denied')
+    : cause instanceof Error && cause.message.includes('denied')
+}
+
+/** Read a staged recording back as the pipeline's blob. */
+export async function readStagedRecording(path: string): Promise<Blob> {
+  const raw = await invoke('plugin:recording|read_staged', { request: { path } })
+  const { base64 } = readStagedSchema.parse(raw)
+  return new Blob([base64ToBytes(base64)], { type: NATIVE_RECORDING_MIME })
+}
+
+/** Remove a staged recording once its bytes are durable in the graph. */
+export async function deleteStagedRecording(path: string): Promise<void> {
+  await invoke('plugin:recording|delete_staged', { request: { path } })
+}
+
+export function useNativeAudioRecorder(
+  options: UseNativeAudioRecorderOptions,
+): UseNativeAudioRecorderValue {
+  const [status, setStatus] = useState<NativeRecorderStatus>('idle')
+  const [elapsedMs, setElapsedMs] = useState(0)
+  const [level, setLevel] = useState(0)
+
+  // Read at fire time, not captured at subscribe — the host's callback
+  // identity changes across renders.
+  const optionsRef = useRef(options)
+  useEffect(() => {
+    optionsRef.current = options
+  })
+  const statusRef = useRef<NativeRecorderStatus>('idle')
+  const setStatusBoth = useCallback((next: NativeRecorderStatus): void => {
+    statusRef.current = next
+    setStatus(next)
+    if (next !== 'recording') {
+      setElapsedMs(0)
+      setLevel(0)
+    }
+  }, [])
+  /** Guards the stop/cancel invoke gap — mirrors the desktop hook's guard. */
+  const stopPromiseRef = useRef<Promise<NativeRecorderResult | null> | null>(null)
+
+  // The plugin's event stream is subscribed for the hook's whole life: level
+  // events are ignored unless recording, and a native stop must be heard even
+  // if it lands between renders.
+  useEffect(() => {
+    let disposed = false
+    const unlisteners: Array<() => void> = []
+    void (async () => {
+      try {
+        const levelListener = await addPluginListener(
+          'recording',
+          'recordingLevel',
+          (raw: unknown) => {
+            const parsed = levelEventSchema.safeParse(raw)
+            if (parsed.success && statusRef.current === 'recording') {
+              setLevel(parsed.data.level)
+              setElapsedMs(parsed.data.elapsedMs)
+            }
+          },
+        )
+        const stoppedListener = await addPluginListener(
+          'recording',
+          'recordingStopped',
+          (raw: unknown) => {
+            const parsed = stoppedEventSchema.safeParse(raw)
+            if (!parsed.success) {
+              return
+            }
+            setStatusBoth('idle')
+            const { path, durationMs } = parsed.data
+            claimStagedPath(path)
+            void (async () => {
+              if (durationMs < MIN_DURATION_MS) {
+                await deleteStagedRecording(path).catch(() => {})
+                releaseStagedPath(path)
+                optionsRef.current.onNativeStop(null)
+                return
+              }
+              try {
+                const blob = await readStagedRecording(path)
+                optionsRef.current.onNativeStop({
+                  blob,
+                  mimeType: NATIVE_RECORDING_MIME,
+                  durationMs,
+                  stagedPath: path,
+                })
+              } catch (cause) {
+                // Reading it back failed — leave the file staged (released,
+                // so the orphan scan ingests it on the next launch or
+                // foreground instead).
+                releaseStagedPath(path)
+                console.error('reading a native-stopped recording failed:', cause)
+              }
+            })()
+          },
+        )
+        if (disposed) {
+          void levelListener.unregister()
+          void stoppedListener.unregister()
+          return
+        }
+        unlisteners.push(
+          () => void levelListener.unregister(),
+          () => void stoppedListener.unregister(),
+        )
+      } catch (cause) {
+        console.error('recording plugin events unavailable:', cause)
+      }
+    })()
+    return () => {
+      disposed = true
+      for (const unlisten of unlisteners.splice(0)) {
+        unlisten()
+      }
+    }
+  }, [setStatusBoth])
+
+  const start = useCallback(async (): Promise<void> => {
+    if (statusRef.current !== 'idle') {
+      return
+    }
+    setStatusBoth('requesting')
+    try {
+      await invoke('plugin:recording|start_recording', {
+        request: { maxDurationMs: optionsRef.current.maxDurationMs },
+      })
+    } catch (cause) {
+      setStatusBoth('idle')
+      throw cause
+    }
+    setStatusBoth('recording')
+  }, [setStatusBoth])
+
+  const stop = useCallback((): Promise<NativeRecorderResult | null> => {
+    if (stopPromiseRef.current !== null) {
+      return stopPromiseRef.current
+    }
+    if (statusRef.current !== 'recording') {
+      return Promise.resolve(null)
+    }
+    const stopped = (async (): Promise<NativeRecorderResult | null> => {
+      const raw = await invoke('plugin:recording|stop_recording')
+      setStatusBoth('idle')
+      const { path, durationMs } = stopResponseSchema.parse(raw)
+      claimStagedPath(path)
+      if (durationMs < MIN_DURATION_MS) {
+        await deleteStagedRecording(path).catch(() => {})
+        releaseStagedPath(path)
+        return null
+      }
+      try {
+        const blob = await readStagedRecording(path)
+        return { blob, mimeType: NATIVE_RECORDING_MIME, durationMs, stagedPath: path }
+      } catch (cause) {
+        // Leave the file for the orphan scan rather than losing the memo.
+        releaseStagedPath(path)
+        throw cause
+      }
+    })().finally(() => {
+      stopPromiseRef.current = null
+    })
+    stopPromiseRef.current = stopped
+    return stopped
+  }, [setStatusBoth])
+
+  const cancel = useCallback(async (): Promise<void> => {
+    // Also aborts a pending permission request natively (start-session bump).
+    try {
+      await invoke('plugin:recording|cancel_recording')
+    } finally {
+      setStatusBoth('idle')
+    }
+  }, [setStatusBoth])
+
+  return { status, elapsedMs, level, start, stop, cancel }
+}

--- a/apps/desktop/src/mobile/use-native-audio-recorder.ts
+++ b/apps/desktop/src/mobile/use-native-audio-recorder.ts
@@ -34,6 +34,13 @@ export interface NativeRecorderResult {
   durationMs: number
   /** The staged file's absolute path — delete it once the blob is durable. */
   stagedPath: string
+  /**
+   * The recording's stop time (the staged file's mtime), used as the memo's
+   * identity timestamp. Every ingest path — user stop, native stop, and the
+   * orphan scan — keys off this same value, so re-ingesting a file whose
+   * delete failed resolves to the same memo basename rather than a duplicate.
+   */
+  recordedAt: Date
 }
 
 export interface UseNativeAudioRecorderOptions {
@@ -61,13 +68,18 @@ export interface UseNativeAudioRecorderValue {
   cancel: () => Promise<void>
 }
 
-const stopResponseSchema = z.object({ path: z.string(), durationMs: z.number() })
+const stopResponseSchema = z.object({
+  path: z.string(),
+  durationMs: z.number(),
+  modifiedMs: z.number(),
+})
 const recordingStatusSchema = z.object({ recording: z.boolean(), elapsedMs: z.number() })
 const readStagedSchema = z.object({ base64: z.string() })
 const levelEventSchema = z.object({ level: z.number(), elapsedMs: z.number() })
 const stoppedEventSchema = z.object({
   path: z.string(),
   durationMs: z.number(),
+  modifiedMs: z.number(),
   reason: z.string(),
 })
 
@@ -135,7 +147,7 @@ export async function nativeRecordingStatus(): Promise<{
  */
 export async function stopActiveRecording(): Promise<NativeRecorderResult | null> {
   const raw = await invoke('plugin:recording|stop_recording')
-  const { path, durationMs } = stopResponseSchema.parse(raw)
+  const { path, durationMs, modifiedMs } = stopResponseSchema.parse(raw)
   claimStagedPath(path)
   if (durationMs < MIN_DURATION_MS) {
     await deleteStagedRecording(path).catch(() => {})
@@ -144,7 +156,13 @@ export async function stopActiveRecording(): Promise<NativeRecorderResult | null
   }
   try {
     const blob = await readStagedRecording(path)
-    return { blob, mimeType: NATIVE_RECORDING_MIME, durationMs, stagedPath: path }
+    return {
+      blob,
+      mimeType: NATIVE_RECORDING_MIME,
+      durationMs,
+      stagedPath: path,
+      recordedAt: new Date(modifiedMs),
+    }
   } catch (cause) {
     // Leave the file for the orphan scan rather than losing the memo.
     releaseStagedPath(path)
@@ -152,6 +170,15 @@ export async function stopActiveRecording(): Promise<NativeRecorderResult | null
   }
 }
 
+/**
+ * Drive the native recorder plugin as a React hook. Subscribes to the
+ * plugin's `recordingLevel` / `recordingStopped` events for the hook's whole
+ * life, exposes `status`/`elapsedMs`/`level` as state, and returns
+ * `start`/`stop`/`cancel`. A native-initiated stop (interruption, route
+ * change, the duration cap) arrives on `recordingStopped` and is delivered to
+ * {@link UseNativeAudioRecorderOptions.onNativeStop}; user-initiated `stop`
+ * resolves its own result.
+ */
 export function useNativeAudioRecorder(
   options: UseNativeAudioRecorderOptions,
 ): UseNativeAudioRecorderValue {
@@ -166,6 +193,11 @@ export function useNativeAudioRecorder(
     optionsRef.current = options
   })
   const statusRef = useRef<NativeRecorderStatus>('idle')
+  // Read the live status through a function so control-flow narrowing from an
+  // earlier guard (e.g. the `!== 'idle'` return in `start`) doesn't treat a
+  // later read as still that literal — `setStatusBoth` mutates the ref
+  // opaquely, and a `recordingStopped` event can change it across an await.
+  const currentStatus = useCallback((): NativeRecorderStatus => statusRef.current, [])
   const setStatusBoth = useCallback((next: NativeRecorderStatus): void => {
     statusRef.current = next
     setStatus(next)
@@ -205,7 +237,7 @@ export function useNativeAudioRecorder(
               return
             }
             setStatusBoth('idle')
-            const { path, durationMs } = parsed.data
+            const { path, durationMs, modifiedMs } = parsed.data
             claimStagedPath(path)
             void (async () => {
               if (durationMs < MIN_DURATION_MS) {
@@ -221,13 +253,17 @@ export function useNativeAudioRecorder(
                   mimeType: NATIVE_RECORDING_MIME,
                   durationMs,
                   stagedPath: path,
+                  recordedAt: new Date(modifiedMs),
                 })
               } catch (cause) {
                 // Reading it back failed — leave the file staged (released,
                 // so the orphan scan ingests it on the next launch or
-                // foreground instead).
+                // foreground instead). Still notify the host so the recording
+                // UI closes: the recorder is already idle, and leaving the
+                // drawer open would strand it.
                 releaseStagedPath(path)
                 console.error('reading a native-stopped recording failed:', cause)
+                optionsRef.current.onNativeStop(null)
               }
             })()
           },
@@ -254,7 +290,7 @@ export function useNativeAudioRecorder(
   }, [setStatusBoth])
 
   const start = useCallback(async (): Promise<void> => {
-    if (statusRef.current !== 'idle') {
+    if (currentStatus() !== 'idle') {
       return
     }
     setStatusBoth('requesting')
@@ -266,8 +302,13 @@ export function useNativeAudioRecorder(
       setStatusBoth('idle')
       throw cause
     }
-    setStatusBoth('recording')
-  }, [setStatusBoth])
+    // A `recordingStopped` event (interruption, immediate cap, permission
+    // race) can flip us back to 'idle' while the start invoke is still in
+    // flight — don't resurrect a recording that already finalized.
+    if (currentStatus() === 'requesting') {
+      setStatusBoth('recording')
+    }
+  }, [currentStatus, setStatusBoth])
 
   const stop = useCallback((): Promise<NativeRecorderResult | null> => {
     if (stopPromiseRef.current !== null) {

--- a/apps/desktop/src/mobile/use-native-record-action.ts
+++ b/apps/desktop/src/mobile/use-native-record-action.ts
@@ -1,0 +1,115 @@
+import { useEffect, useRef } from 'react'
+import { addPluginListener, invoke } from '@tauri-apps/api/core'
+import { hasBridge } from '@reflect/core'
+import { z } from 'zod'
+import {
+  nativeRecordingStatus,
+  stopActiveRecording,
+} from '@/mobile/use-native-audio-recorder'
+import type { StagedRecordingInput } from '@/mobile/use-staged-recording-ingest'
+
+/**
+ * The webview side of the native-action handshake (audio-memos wave 3), plus
+ * the live-recording reconcile it must be sequenced behind.
+ *
+ * Reconcile first: this mount did not start any recording, so a native one
+ * still running (the webview reloaded or crashed mid-memo, or the provider
+ * remounted across a graph switch) has no UI — stop and save it rather than
+ * leave a hidden hot microphone.
+ *
+ * Then the handshake: OS entry points (Siri, the home-screen quick action,
+ * the lock-screen widget) queue a `recordAudio` request in the plugin,
+ * persisted until this surface confirms it ran — neither lost nor double-run
+ * across webview churn (`docs/porting/reflect-mobile/native-entry-points.md`).
+ * The ordering is the point of the single effect: a queued "record"
+ * delivered at `actions_ready` can never race the reconcile's stop.
+ */
+
+const nativeActionSchema = z.object({ action: z.string() })
+
+/**
+ * How long the recording UI must survive before a delivered native action is
+ * confirmed (V1 parity): a webview crash during presentation must leave the
+ * action queued so it re-fires on the next launch.
+ */
+const ACTION_CONFIRM_DELAY_MS = 2000
+
+export interface UseNativeRecordActionOptions {
+  /** Start a memo — the provider's usual start (opens the drawer, records). */
+  start: () => Promise<void>
+  /** Hand a reconciled recording to the capture pipeline. */
+  enqueueStaged: (input: StagedRecordingInput) => void
+}
+
+/** Mount the reconcile-then-handshake lifecycle. */
+export function useNativeRecordAction(options: UseNativeRecordActionOptions): void {
+  const { enqueueStaged } = options
+  // Read at fire time — the provider's start identity changes across renders.
+  const startRef = useRef(options.start)
+  useEffect(() => {
+    startRef.current = options.start
+  })
+
+  useEffect(() => {
+    if (!hasBridge()) {
+      return
+    }
+    let disposed = false
+    let confirmTimer: ReturnType<typeof setTimeout> | null = null
+    let unlisten: (() => void) | null = null
+    void (async () => {
+      try {
+        const status = await nativeRecordingStatus()
+        if (status.recording) {
+          const result = await stopActiveRecording()
+          if (result !== null) {
+            enqueueStaged({
+              blob: result.blob,
+              recordedAt: new Date(),
+              stagedPath: result.stagedPath,
+            })
+          }
+        }
+      } catch (cause) {
+        // A user stop or native finalize winning the race lands here — the
+        // memo arrives through that path (or the orphan scan) instead.
+        console.warn('reconciling a live native recording failed:', cause)
+      }
+      if (disposed) {
+        return
+      }
+      try {
+        const listener = await addPluginListener('recording', 'nativeAction', (raw: unknown) => {
+          const parsed = nativeActionSchema.safeParse(raw)
+          if (disposed || !parsed.success || parsed.data.action !== 'recordAudio') {
+            return
+          }
+          void startRef.current()
+          // Confirmation is about delivery, not success — a mic-denied start
+          // still confirms, or the queue would re-surface the same failure
+          // every launch.
+          confirmTimer = setTimeout(() => {
+            void invoke('plugin:recording|action_performed').catch((cause: unknown) => {
+              console.warn('confirming a native action failed:', cause)
+            })
+          }, ACTION_CONFIRM_DELAY_MS)
+        })
+        if (disposed) {
+          void listener.unregister()
+          return
+        }
+        unlisten = () => void listener.unregister()
+        await invoke('plugin:recording|actions_ready')
+      } catch (cause) {
+        console.error('the native-action handshake is unavailable:', cause)
+      }
+    })()
+    return () => {
+      disposed = true
+      if (confirmTimer !== null) {
+        clearTimeout(confirmTimer)
+      }
+      unlisten?.()
+    }
+  }, [enqueueStaged])
+}

--- a/apps/desktop/src/mobile/use-native-record-action.ts
+++ b/apps/desktop/src/mobile/use-native-record-action.ts
@@ -65,7 +65,7 @@ export function useNativeRecordAction(options: UseNativeRecordActionOptions): vo
           if (result !== null) {
             enqueueStaged({
               blob: result.blob,
-              recordedAt: new Date(),
+              recordedAt: result.recordedAt,
               stagedPath: result.stagedPath,
             })
           }
@@ -85,6 +85,13 @@ export function useNativeRecordAction(options: UseNativeRecordActionOptions): vo
             return
           }
           void startRef.current()
+          // A repeat delivery (double widget open, or a re-`deliverPendingAction`
+          // while the action is still queued) restarts the confirm window
+          // against the latest start — otherwise an earlier timer could
+          // confirm before this start's UI has survived its full window.
+          if (confirmTimer !== null) {
+            clearTimeout(confirmTimer)
+          }
           // Confirmation is about delivery, not success — a mic-denied start
           // still confirms, or the queue would re-surface the same failure
           // every launch.

--- a/apps/desktop/src/mobile/use-staged-recording-ingest.ts
+++ b/apps/desktop/src/mobile/use-staged-recording-ingest.ts
@@ -1,0 +1,91 @@
+import { useEffect, useRef } from 'react'
+import { invoke } from '@tauri-apps/api/core'
+import { hasBridge } from '@reflect/core'
+import { z } from 'zod'
+import {
+  claimStagedPath,
+  isStagedPathClaimed,
+  readStagedRecording,
+  releaseStagedPath,
+} from '@/mobile/use-native-audio-recorder'
+
+/**
+ * The orphan scan (audio-memos wave 1): staged recordings no live flow owns —
+ * from a crash, a webview reload, or a kill while backgrounded — are read
+ * back and handed to the capture pipeline on mount and on every foreground,
+ * oldest first (`list_staged` sorts by name = by time). The caller's
+ * `enqueueStaged` owns deleting the file once the graph write lands; ingest
+ * is idempotent by stop time, so a file whose delete failed re-resolves to
+ * the same memo identity on the next scan instead of duplicating.
+ */
+
+/** A staged native recording, ready for the capture pipeline. */
+export interface StagedRecordingInput {
+  blob: Blob
+  /** The memo's identity timestamp — the file's stop time for re-scans. */
+  recordedAt: Date
+  /** The staging-directory file the capture owns until it lands. */
+  stagedPath: string
+}
+
+const listStagedSchema = z.object({
+  files: z.array(z.object({ path: z.string(), modifiedMs: z.number() })),
+})
+
+/** Mount the launch/foreground orphan scan. */
+export function useStagedRecordingIngest(
+  enqueueStaged: (input: StagedRecordingInput) => void,
+): void {
+  const scanningRef = useRef(false)
+  useEffect(() => {
+    if (!hasBridge()) {
+      return
+    }
+    let disposed = false
+    const scan = async (): Promise<void> => {
+      if (scanningRef.current) {
+        return
+      }
+      scanningRef.current = true
+      try {
+        const raw = await invoke('plugin:recording|list_staged')
+        const { files } = listStagedSchema.parse(raw)
+        for (const file of files) {
+          if (disposed) {
+            return
+          }
+          if (isStagedPathClaimed(file.path)) {
+            continue
+          }
+          claimStagedPath(file.path)
+          try {
+            const blob = await readStagedRecording(file.path)
+            enqueueStaged({
+              blob,
+              recordedAt: new Date(file.modifiedMs),
+              stagedPath: file.path,
+            })
+          } catch (cause) {
+            releaseStagedPath(file.path)
+            console.error('ingesting a staged recording failed:', cause)
+          }
+        }
+      } catch (cause) {
+        console.error('audio memo orphan scan failed:', cause)
+      } finally {
+        scanningRef.current = false
+      }
+    }
+    void scan()
+    const onVisibilityChange = (): void => {
+      if (document.visibilityState === 'visible') {
+        void scan()
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    return () => {
+      disposed = true
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [enqueueStaged])
+}

--- a/apps/desktop/src/providers/audio-memo-provider.tsx
+++ b/apps/desktop/src/providers/audio-memo-provider.tsx
@@ -6,41 +6,23 @@ import {
   useMemo,
   useRef,
   useState,
-  useSyncExternalStore,
   type ReactElement,
   type ReactNode,
 } from 'react'
-import {
-  captureAudioMemo,
-  errorMessage,
-  pickTranscriptionConfig,
-  type AiProvidersState,
-  type GraphInfo,
-} from '@reflect/core'
+import { errorMessage, type GraphInfo } from '@reflect/core'
 import { isRecordingSupported, useAudioRecorder } from '@/hooks/use-audio-recorder'
-import { startOperation } from '@/lib/operations'
-import { useMainWindowEffect } from '@/hooks/use-main-window-effect'
-import {
-  createTranscriptionReconciler,
-  type TranscriptionReconciler,
-} from '@/lib/transcription-reconciler'
+import { useAudioMemoPipeline } from '@/hooks/use-audio-memo-pipeline'
 import { useSettings } from '@/providers/settings-provider'
 import { useSidebar } from '@/providers/sidebar-provider'
 
 /**
- * The React surface for audio memos: recording state + the bridge to the
- * core capture pipeline. State lives here — above the sidebar — because the
- * mic button unmounts with the sidebar (`Mod-\`), and a recording must never
- * outlive its UI invisibly: collapsing mid-recording stops and saves instead
- * of leaving a hidden hot microphone.
- *
- * The pipeline is raw-first (see `actions/audio-memo` in core): stopping a
- * recording writes the audio into the graph's `audio-memos/` — local,
- * instant — and transcription belongs to the per-graph
- * {@link createTranscriptionReconciler} lifecycle this provider mounts,
- * which owns every trigger and retry rule. Captures drain through a serial
- * queue so memos can be recorded back-to-back; a failed *capture* (the one
- * step that can lose audio) parks the queue behind a Retry/Discard error.
+ * The desktop React surface for audio memos: MediaRecorder recording state +
+ * the bridge to the shared capture pipeline (`useAudioMemoPipeline`, which
+ * owns the serial capture queue and the transcription reconciler). State
+ * lives here — above the sidebar — because the mic button unmounts with the
+ * sidebar (`Mod-\`), and a recording must never outlive its UI invisibly:
+ * collapsing mid-recording stops and saves instead of leaving a hidden hot
+ * microphone.
  */
 
 /**
@@ -49,13 +31,6 @@ import { useSidebar } from '@/providers/sidebar-provider'
  * recording can start immediately.
  */
 export type AudioMemoPhase = 'idle' | 'requesting' | 'recording' | 'transcribing' | 'error'
-
-/** A stopped recording waiting its turn through the capture queue. */
-interface PendingCapture {
-  audio: Blob
-  mimeType: string
-  recordedAt: Date
-}
 
 interface AudioMemoContextValue {
   phase: AudioMemoPhase
@@ -105,14 +80,13 @@ interface AudioMemoProviderProps {
 }
 
 export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): ReactElement {
-  const { settings } = useSettings()
+  // Keep the settings subscription alive at the provider (matches the
+  // pipeline hook's own read), so the mic enables the moment a key is added.
+  useSettings()
   const { collapsed, toggleSidebar } = useSidebar()
 
-  const [pendingCount, setPendingCount] = useState(0)
   /** True from the stop click until the recorder hands over the blob. */
   const [stopping, setStopping] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [resume, setResume] = useState<PendingCapture | null>(null)
 
   const stopAndSaveRef = useRef<() => void>(() => {})
   const recorder = useAudioRecorder({
@@ -127,136 +101,26 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
   const cancelRecorder = recorder.cancel
 
   const supported = isRecordingSupported()
-  const transcriptionConfig = useMemo(
-    () =>
-      pickTranscriptionConfig({
-        providers: settings.aiProviders,
-        defaultProviderId: settings.defaultAiProviderId,
-      }),
-    [settings.aiProviders, settings.defaultAiProviderId],
-  )
 
   const collapsedRef = useRef(collapsed)
   useEffect(() => {
     collapsedRef.current = collapsed
   })
 
-  /** Committed recordings waiting their turn; the pump owns the head. */
-  const queueRef = useRef<PendingCapture[]>([])
-  /** Single-drainer guard: one pump loop at a time, one capture at a time. */
-  const pumpingRef = useRef(false)
-  /**
-   * The failed capture a retry should re-run. While parked, the queue holds —
-   * memo order in the graph must survive the failure. A ref, not state: rapid
-   * double Retry must see the first click's take synchronously, or two
-   * pipelines write the recording twice.
-   */
-  const parkedRef = useRef<PendingCapture | null>(null)
+  // The mic button (and its popover) unmount with the sidebar — while
+  // collapsed, a capture failure must surface as a toast instead.
+  const pipeline = useAudioMemoPipeline({
+    graph,
+    isErrorSurfaceVisible: () => !collapsedRef.current,
+  })
+
   /** Re-entry guard for the stop click's await gap. */
   const stoppingRef = useRef(false)
   /** The in-flight stop, so a mic click in the gap can chain the next memo. */
   const stopSettledRef = useRef<Promise<void>>(Promise.resolve())
 
-  // The configured-models state, by ref: the reconciler reads it lazily at
-  // the start of every pass, so a key added mid-session is seen without
-  // rebuilding the lifecycle on every settings change.
-  const providersRef = useRef<AiProvidersState>({
-    providers: settings.aiProviders,
-    defaultProviderId: settings.defaultAiProviderId,
-  })
-  useEffect(() => {
-    providersRef.current = { providers: settings.aiProviders, defaultProviderId: settings.defaultAiProviderId }
-  })
-
-  // One reconciler per graph session (this provider remounts per graph). It
-  // owns the launch pass and all retry triggers; the pump only schedules.
-  const [reconciler, setReconciler] = useState<TranscriptionReconciler | null>(null)
-  const reconcilerRef = useRef<TranscriptionReconciler | null>(null)
-  // Main window only: two reconcilers would double-transcribe (and
-  // double-bill) the same memos. Recording still works in a note window —
-  // the saved memo is transcribed by the main window's reconciler, which
-  // sees it arrive on the watcher stream.
-  useMainWindowEffect(() => {
-    const next = createTranscriptionReconciler({
-      generation: graph.generation,
-      getProviders: () => providersRef.current,
-    })
-    setReconciler(next)
-    reconcilerRef.current = next
-    next.start()
-    return () => {
-      next.dispose()
-      reconcilerRef.current = null
-      setReconciler((current) => (current === next ? null : current))
-    }
-  }, [graph.generation])
-
-  // Passes gate on a configured model before any IO — when the user adds the
-  // first key mid-session, kick the pass that gate was suppressing.
-  const hadConfigRef = useRef(transcriptionConfig !== null)
-  useEffect(() => {
-    const hasConfig = transcriptionConfig !== null
-    if (hasConfig && !hadConfigRef.current) {
-      reconciler?.schedule()
-    }
-    hadConfigRef.current = hasConfig
-  }, [transcriptionConfig, reconciler])
-
-  /** True while a reconcile pass has memos to transcribe. */
-  const transcribing = useSyncExternalStore(
-    reconciler?.subscribe ?? (() => () => {}),
-    reconciler?.getTranscribing ?? (() => false),
-  )
-
-  const pump = useCallback(async (): Promise<void> => {
-    if (pumpingRef.current) {
-      return
-    }
-    pumpingRef.current = true
-    let captured = false
-    try {
-      while (parkedRef.current === null) {
-        const capture = queueRef.current.shift()
-        if (capture === undefined) {
-          break
-        }
-        let outcome: Awaited<ReturnType<typeof captureAudioMemo>>
-        try {
-          outcome = await captureAudioMemo({ ...capture, generation: graph.generation })
-        } catch (cause) {
-          outcome = { ok: false, message: errorMessage(cause) }
-        } finally {
-          setPendingCount((count) => count - 1)
-        }
-        if (outcome.ok) {
-          captured = true
-        } else {
-          // Park the queue behind the failure: the capture is the one step
-          // that can lose audio, and memo order in the graph must survive.
-          parkedRef.current = capture
-          setResume(capture)
-          setError(outcome.message)
-          if (collapsedRef.current) {
-            // The mic button (and its popover) unmounted with the sidebar —
-            // the failure must still surface somewhere.
-            startOperation('Saving audio memo').fail(outcome.message)
-          }
-        }
-      }
-    } finally {
-      pumpingRef.current = false
-    }
-    if (captured) {
-      // The watcher reports the recording write (it tracks `audio-memos/`),
-      // which feeds the sync engine's commit debounce like any note edit.
-      // Transcription is kicked directly rather than waiting on the
-      // watcher's own debounce to echo our write back.
-      reconcilerRef.current?.schedule()
-    }
-  }, [graph.generation])
-
   const start = useCallback(async (): Promise<void> => {
-    if (!supported || transcriptionConfig === null) {
+    if (!supported || !pipeline.hasTranscriptionConfig) {
       return
     }
     if (collapsedRef.current) {
@@ -266,13 +130,13 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
     try {
       await startRecorder()
     } catch (cause) {
-      setError(
+      pipeline.reportError(
         cause instanceof DOMException && cause.name === 'NotAllowedError'
           ? micDeniedMessage()
           : errorMessage(cause),
       )
     }
-  }, [supported, transcriptionConfig, toggleSidebar, startRecorder])
+  }, [supported, pipeline, toggleSidebar, startRecorder])
 
   const stopAndSave = useCallback(async (): Promise<void> => {
     if (stoppingRef.current) {
@@ -287,13 +151,11 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
       try {
         const recording = await stopRecorder()
         if (recording !== null) {
-          queueRef.current.push({
+          pipeline.enqueue({
             audio: recording.blob,
             mimeType: recording.mimeType,
             recordedAt: new Date(),
           })
-          setPendingCount((count) => count + 1)
-          void pump()
         }
       } finally {
         stoppingRef.current = false
@@ -302,17 +164,10 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
     })()
     stopSettledRef.current = settled
     return settled
-  }, [stopRecorder, pump])
+  }, [stopRecorder, pipeline])
   useEffect(() => {
     stopAndSaveRef.current = () => void stopAndSave()
   })
-
-  const discard = useCallback((): void => {
-    parkedRef.current = null
-    setError(null)
-    setResume(null)
-    void pump()
-  }, [pump])
 
   const toggle = useCallback((): void => {
     if (recorder.status === 'recording') {
@@ -328,7 +183,7 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
       // A second press while the OS prompt is up aborts the request — the
       // alternative is a click that visibly does nothing.
       cancelRecorder()
-    } else if (error !== null) {
+    } else if (pipeline.error !== null) {
       // A parked error must never invisibly block recording. Collapsed, the
       // error UI doesn't exist — surface it; visible, it was on screen and a
       // fresh record request acknowledges it (the same click the red mic
@@ -336,29 +191,16 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
       if (collapsedRef.current) {
         toggleSidebar()
       } else {
-        discard()
+        pipeline.discard()
       }
     } else if (recorder.status === 'idle') {
       void start()
     }
-  }, [recorder.status, error, stopAndSave, cancelRecorder, start, toggleSidebar, discard])
+  }, [recorder.status, pipeline, stopAndSave, cancelRecorder, start, toggleSidebar])
 
   const cancel = useCallback((): void => {
     cancelRecorder()
   }, [cancelRecorder])
-
-  const retry = useCallback((): void => {
-    const parked = parkedRef.current
-    if (parked === null) {
-      return
-    }
-    parkedRef.current = null
-    setError(null)
-    setResume(null)
-    queueRef.current.unshift(parked)
-    setPendingCount((count) => count + 1)
-    void pump()
-  }, [pump])
 
   // Collapsing the sidebar mid-flow: stop-and-save a live recording, and
   // abandon a pending permission request — a grant arriving after the
@@ -381,15 +223,15 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
       ? 'recording'
       : recorder.status === 'requesting'
         ? 'requesting'
-        : error !== null
+        : pipeline.error !== null
           ? 'error'
-          : stopping || pendingCount > 0 || transcribing
+          : stopping || pipeline.pendingCount > 0 || pipeline.transcribing
             ? 'transcribing'
             : 'idle'
 
   const unavailableReason = !supported
     ? UNSUPPORTED_REASON
-    : transcriptionConfig === null
+    : !pipeline.hasTranscriptionConfig
       ? NO_PROVIDER_REASON
       : null
 
@@ -398,28 +240,28 @@ export function AudioMemoProvider({ graph, children }: AudioMemoProviderProps): 
       phase,
       elapsedMs: recorder.elapsedMs,
       stream: recorder.stream,
-      pendingCount,
+      pendingCount: pipeline.pendingCount,
       available: unavailableReason === null,
       unavailableReason,
-      error,
-      canRetry: resume !== null,
+      error: pipeline.error,
+      canRetry: pipeline.canRetry,
       toggle,
       cancel,
-      retry,
-      discard,
+      retry: pipeline.retry,
+      discard: pipeline.discard,
     }),
     [
       phase,
       recorder.elapsedMs,
       recorder.stream,
-      pendingCount,
+      pipeline.pendingCount,
       unavailableReason,
-      error,
-      resume,
+      pipeline.error,
+      pipeline.canRetry,
+      pipeline.retry,
+      pipeline.discard,
       toggle,
       cancel,
-      retry,
-      discard,
     ],
   )
 

--- a/docs/deep-links.md
+++ b/docs/deep-links.md
@@ -70,6 +70,13 @@ drain re-runs cleanly.
   snippet) dispatches straight into the same in-app handler — no OS
   round-trip, so it works in dev builds and can never land on a different
   installed flavor.
+- iOS registers the scheme too (`CFBundleURLTypes` in `ios.project.yml`), but
+  only for one **mobile-native verb**: `reflect://record-audio`, the
+  lock-screen widget's start-recording entry point. It is handled in the Rust
+  shell (queued into the recording plugin's native action handshake — see
+  `docs/porting/reflect-mobile/audio-memos.md`) and deliberately absent from
+  the desktop JS grammar: desktop parses it as unknown. The route-shaped
+  navigation grammar is not a mobile surface yet.
 
 ## Relationship to the CLI
 

--- a/docs/porting/reflect-mobile/audio-memos.md
+++ b/docs/porting/reflect-mobile/audio-memos.md
@@ -1,13 +1,21 @@
 # Porting audio memos (mobile)
 
-**v2 status: later wave — the first post-release wave per the product
-owner.** Desktop v2 audio memos have shipped (raw-first recording into the
-graph + async BYOK transcription — see the desktop
-[audio-memos porting doc](../audio-memos.md)); the mobile wave reuses that
-pipeline. V1's server-upload design is forbidden in v2, but V1's
-*reliability engineering* is the bar to meet. This is the most engineered
-feature in V1 mobile and the clearest expression of its design philosophy:
-**critical capture must not depend on the webview being alive.**
+**v2 status: in-app wave shipped; OS entry points pending.** Desktop v2
+audio memos shipped first (raw-first recording into the graph + async BYOK
+transcription — see the desktop [audio-memos porting doc](../audio-memos.md)).
+The mobile in-app wave reuses that pipeline over a native recorder:
+`plugins/tauri-plugin-recording` (AVAudioRecorder → a native staging
+directory, interruption/route-change/backgrounding/cap stops, 10 Hz metering
+events), the shared capture queue extracted to
+`apps/desktop/src/hooks/use-audio-memo-pipeline.ts`, and a mobile provider
+(`apps/desktop/src/mobile/audio-memo-provider.tsx`) that ingests staged
+files — including an orphan scan on launch/foreground for stops the webview
+never saw. Still open from this doc: the OS entry points (widget, Siri,
+Live Activity, quick action), background-audio continuation, and the App
+Group staging move they imply. V1's server-upload design is forbidden in
+v2, but V1's *reliability engineering* is the bar to meet. This is the most
+engineered feature in V1 mobile and the clearest expression of its design
+philosophy: **critical capture must not depend on the webview being alive.**
 
 ## What V1 mobile does
 

--- a/docs/porting/reflect-mobile/audio-memos.md
+++ b/docs/porting/reflect-mobile/audio-memos.md
@@ -1,21 +1,26 @@
 # Porting audio memos (mobile)
 
-**v2 status: in-app wave shipped; OS entry points pending.** Desktop v2
-audio memos shipped first (raw-first recording into the graph + async BYOK
-transcription — see the desktop [audio-memos porting doc](../audio-memos.md)).
-The mobile in-app wave reuses that pipeline over a native recorder:
-`plugins/tauri-plugin-recording` (AVAudioRecorder → a native staging
-directory, interruption/route-change/backgrounding/cap stops, 10 Hz metering
-events), the shared capture queue extracted to
+**v2 status: in-app + reliability waves shipped; OS entry points pending.**
+Desktop v2 audio memos shipped first (raw-first recording into the graph +
+async BYOK transcription — see the desktop
+[audio-memos porting doc](../audio-memos.md)). The mobile in-app wave reuses
+that pipeline over a native recorder: `plugins/tauri-plugin-recording`
+(AVAudioRecorder → a native staging directory, interruption/route-change/cap
+stops, 10 Hz metering events), the shared capture queue extracted to
 `apps/desktop/src/hooks/use-audio-memo-pipeline.ts`, and a mobile provider
 (`apps/desktop/src/mobile/audio-memo-provider.tsx`) that ingests staged
 files — including an orphan scan on launch/foreground for stops the webview
-never saw. Still open from this doc: the OS entry points (widget, Siri,
-Live Activity, quick action), background-audio continuation, and the App
-Group staging move they imply. V1's server-upload design is forbidden in
-v2, but V1's *reliability engineering* is the bar to meet. This is the most
-engineered feature in V1 mobile and the clearest expression of its design
-philosophy: **critical capture must not depend on the webview being alive.**
+never saw. The reliability wave added `UIBackgroundModes: audio` (a memo
+keeps recording through screen lock and backgrounding; the audio session is
+active only while capturing) and a mount-time reconcile that stops-and-saves
+a recording that outlived its JS (webview reload/crash) instead of leaving a
+hidden hot microphone. Still open from this doc: the OS entry points
+(widget, Siri, Live Activity, quick action) and the App Group staging move
+they imply, plus the physical-device pass. V1's server-upload design is
+forbidden in v2, but V1's *reliability engineering* is the bar to meet.
+This is the most engineered feature in V1 mobile and the clearest
+expression of its design philosophy: **critical capture must not depend on
+the webview being alive.**
 
 ## What V1 mobile does
 

--- a/docs/porting/reflect-mobile/audio-memos.md
+++ b/docs/porting/reflect-mobile/audio-memos.md
@@ -1,6 +1,6 @@
 # Porting audio memos (mobile)
 
-**v2 status: in-app + reliability waves shipped; OS entry points pending.**
+**v2 status: all three waves implemented; physical-device pass owed.**
 Desktop v2 audio memos shipped first (raw-first recording into the graph +
 async BYOK transcription — see the desktop
 [audio-memos porting doc](../audio-memos.md)). The mobile in-app wave reuses
@@ -14,10 +14,18 @@ never saw. The reliability wave added `UIBackgroundModes: audio` (a memo
 keeps recording through screen lock and backgrounding; the audio session is
 active only while capturing) and a mount-time reconcile that stops-and-saves
 a recording that outlived its JS (webview reload/crash) instead of leaving a
-hidden hot microphone. Still open from this doc: the OS entry points
-(widget, Siri, Live Activity, quick action) and the App Group staging move
-they imply, plus the physical-device pass. V1's server-upload design is
-forbidden in v2, but V1's *reliability engineering* is the bar to meet.
+hidden hot microphone. The entry-points wave added the native-action
+handshake (persisted queue → `actions_ready` → deliver → confirm; see
+[native-entry-points](./native-entry-points.md)), Siri App Intents, the
+home-screen quick action, the lock-screen/home-screen record widget
+(`RecordingWidget` appex, `reflect://record-audio`), and the Live Activity
+with an iOS 17 stop intent. Notably absent vs. this doc's original sketch:
+an App Group **audio** inbox — recording always happens in the main app
+process (widgets can't record), so the plugin's app-sandbox staging
+directory remains the can't-lose buffer and nothing extension-side writes
+audio. Still owed: the physical-device pass (entry points, interruptions,
+lock-screen continuation). V1's server-upload design is forbidden in v2,
+but V1's *reliability engineering* is the bar to meet.
 This is the most engineered feature in V1 mobile and the clearest
 expression of its design philosophy: **critical capture must not depend on
 the webview being alive.**

--- a/docs/porting/reflect-mobile/native-entry-points.md
+++ b/docs/porting/reflect-mobile/native-entry-points.md
@@ -1,11 +1,18 @@
 # Porting native entry points
 
-**v2 status: later waves, partially dropped.** Widgets, Siri intents, and
-quick actions arrive with the audio wave; push notifications and universal
-links are dropped (no server); `reflect://` deep links exist on desktop v2
-but are not a mobile v1 surface. The **native-action handshake** is the
-pattern from this area worth porting on day one of any OS-triggered
-capture.
+**v2 status: shipped with the audio wave, partially dropped.** The
+recording entry points are in: the lock-screen/home-screen widget (opens
+`reflect://record-audio`, forwarded by the Rust shell into the recording
+plugin's queue), Siri App Intents ("Start/Stop recording in Reflect",
+in-process `AppIntent`s in the app target posting NotificationCenter
+requests), the home-screen quick action (a shortcut-item handler the plugin
+adds to tao's app delegate), and the Live Activity with an iOS 17
+`LiveActivityIntent` stop button. The **native-action handshake** below is
+implemented in `plugins/tauri-plugin-recording` (persisted queue →
+`actions_ready` → deliver → confirm-after-2s), exactly as this doc
+prescribed. Push notifications and universal links stay dropped (no
+server); the route-shaped `reflect://` navigation grammar is still not a
+mobile surface — only the `record-audio` verb is registered on iOS.
 
 ## What V1 mobile does
 

--- a/packages/core/src/exports/ai-actions.ts
+++ b/packages/core/src/exports/ai-actions.ts
@@ -117,6 +117,7 @@ export {
 } from '../ai/chat/context-window'
 export type { ModelMessage as ChatModelMessage } from 'ai'
 export {
+  base64ToBytes,
   isTranscriptionRejected,
   transcribeAudio,
   TranscriptionRejectedError,

--- a/plugins/tauri-plugin-recording/.gitignore
+++ b/plugins/tauri-plugin-recording/.gitignore
@@ -1,0 +1,17 @@
+/.vs
+.DS_Store
+.Thumbs.db
+*.sublime*
+.idea/
+debug.log
+package-lock.json
+.vscode/settings.json
+yarn.lock
+
+/.tauri
+/target
+Cargo.lock
+node_modules/
+
+dist-js
+dist

--- a/plugins/tauri-plugin-recording/Cargo.toml
+++ b/plugins/tauri-plugin-recording/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "tauri-plugin-recording"
+version = "0.1.0"
+authors = [ "You" ]
+description = ""
+edition = "2021"
+rust-version = "1.77.2"
+exclude = ["/examples", "/dist-js", "/guest-js", "/node_modules"]
+links = "tauri-plugin-recording"
+
+[dependencies]
+tauri = { version = "2.11.2" }
+serde = "1.0.228"
+thiserror = "2.0.18"
+
+[build-dependencies]
+tauri-plugin = { version = "2.6.2", features = ["build"] }

--- a/plugins/tauri-plugin-recording/Cargo.toml
+++ b/plugins/tauri-plugin-recording/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "tauri-plugin-recording"
 version = "0.1.0"
-authors = [ "You" ]
-description = ""
+authors = ["Reflect"]
+description = "Native audio-memo recording for the Reflect iOS app (AVAudioRecorder capture, staging, Live Activity, and OS entry-point action queue)."
 edition = "2021"
 rust-version = "1.77.2"
 exclude = ["/examples", "/dist-js", "/guest-js", "/node_modules"]

--- a/plugins/tauri-plugin-recording/build.rs
+++ b/plugins/tauri-plugin-recording/build.rs
@@ -5,6 +5,7 @@ const COMMANDS: &[&str] = &[
     "start_recording",
     "stop_recording",
     "cancel_recording",
+    "recording_status",
     "list_staged",
     "read_staged",
     "delete_staged",

--- a/plugins/tauri-plugin-recording/build.rs
+++ b/plugins/tauri-plugin-recording/build.rs
@@ -1,0 +1,17 @@
+// `registerListener`/`remove_listener` are the built-in event-channel
+// commands `@tauri-apps/api`'s `addPluginListener` invokes (those exact
+// spellings); they must be in COMMANDS for the ACL to allow them.
+const COMMANDS: &[&str] = &[
+    "start_recording",
+    "stop_recording",
+    "cancel_recording",
+    "list_staged",
+    "read_staged",
+    "delete_staged",
+    "registerListener",
+    "remove_listener",
+];
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS).ios_path("ios").build();
+}

--- a/plugins/tauri-plugin-recording/build.rs
+++ b/plugins/tauri-plugin-recording/build.rs
@@ -6,6 +6,8 @@ const COMMANDS: &[&str] = &[
     "stop_recording",
     "cancel_recording",
     "recording_status",
+    "actions_ready",
+    "action_performed",
     "list_staged",
     "read_staged",
     "delete_staged",

--- a/plugins/tauri-plugin-recording/ios/.gitignore
+++ b/plugins/tauri-plugin-recording/ios/.gitignore
@@ -1,0 +1,10 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc
+Package.resolved

--- a/plugins/tauri-plugin-recording/ios/Package.swift
+++ b/plugins/tauri-plugin-recording/ios/Package.swift
@@ -5,8 +5,10 @@ import PackageDescription
 
 let package = Package(
     name: "tauri-plugin-recording",
+    // iOS only: RecordingPlugin.swift imports UIKit/AVFoundation
+    // unconditionally, and the plugin is registered only on the iOS target
+    // (desktop uses the Rust `desktop.rs` stub).
     platforms: [
-        .macOS(.v10_13),
         .iOS(.v13),
     ],
     products: [

--- a/plugins/tauri-plugin-recording/ios/Package.swift
+++ b/plugins/tauri-plugin-recording/ios/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "tauri-plugin-recording",
+    platforms: [
+        .macOS(.v10_13),
+        .iOS(.v13),
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "tauri-plugin-recording",
+            type: .static,
+            targets: ["tauri-plugin-recording"]),
+    ],
+    dependencies: [
+        .package(name: "Tauri", path: "../.tauri/tauri-api")
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "tauri-plugin-recording",
+            dependencies: [
+                .byName(name: "Tauri")
+            ],
+            path: "Sources")
+    ]
+)

--- a/plugins/tauri-plugin-recording/ios/Sources/RecordingActivityAttributes.swift
+++ b/plugins/tauri-plugin-recording/ios/Sources/RecordingActivityAttributes.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+#if canImport(ActivityKit)
+  import ActivityKit
+
+  /// The recording Live Activity's shape, shared between the app (the
+  /// recording plugin starts/ends the activity) and the widget extension
+  /// (which renders it). ActivityKit matches the two sides by this type's
+  /// name, so the SAME FILE is compiled into both targets — the widget
+  /// target references it by path in `gen/apple/project.yml`. Keep it free
+  /// of plugin imports.
+  @available(iOS 16.1, *)
+  struct RecordingActivityAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+      /// When recording started — the lock-screen timer counts up from it.
+      var startedAt: Date
+    }
+  }
+#endif

--- a/plugins/tauri-plugin-recording/ios/Sources/RecordingPlugin.swift
+++ b/plugins/tauri-plugin-recording/ios/Sources/RecordingPlugin.swift
@@ -1,0 +1,440 @@
+import AVFoundation
+import Tauri
+import UIKit
+import WebKit
+
+/// The payload of the plugin's ~10 Hz `recordingLevel` event.
+struct RecordingLevel: Encodable {
+  /// Linear input level 0…1, from the recorder's average power meter.
+  let level: Float
+  /// Recorded time so far in milliseconds (pauses excluded).
+  let elapsedMs: Double
+}
+
+/// The payload of the `recordingStopped` event — a stop the *native* side
+/// initiated (interruption, route change, backgrounding, the duration cap, or
+/// an encoder error). A stop the webview asked for resolves its own invoke
+/// instead and never fires this event.
+struct RecordingStopped: Encodable {
+  /// Absolute path of the staged `.m4a`.
+  let path: String
+  let durationMs: Double
+  /// `interruption` | `routeChange` | `background` | `maxDuration` | `error`
+  let reason: String
+}
+
+/// `stopRecording`'s response.
+struct StopResponse: Encodable {
+  let path: String
+  let durationMs: Double
+}
+
+struct StagedFile: Encodable {
+  let path: String
+  /// Modification time in epoch milliseconds — effectively the stop time.
+  let modifiedMs: Double
+}
+
+struct ListStagedResponse: Encodable {
+  let files: [StagedFile]
+}
+
+struct ReadStagedResponse: Encodable {
+  let base64: String
+}
+
+struct StartArgs: Decodable {
+  /// Auto-stop cap in milliseconds, enforced natively via
+  /// `record(forDuration:)` so it holds even if the webview never wakes.
+  let maxDurationMs: Double
+}
+
+struct StagedPathArgs: Decodable {
+  let path: String
+}
+
+/// Reflect's native audio-memo recorder (the mobile leg of the raw-first
+/// pipeline in `packages/core/src/actions/audio-memo.ts`).
+///
+/// The V1 lesson this preserves: **capture must not depend on the webview.**
+/// The recorder writes AAC mono 44.1 kHz `.m4a` straight into a staging
+/// directory the plugin owns; audio-session interruptions (calls, Siri,
+/// alarms), input-route loss (headphones unplugged), backgrounding, and the
+/// duration cap all finalize the file natively, without JS involvement. The
+/// webview ingests staged files into the graph when it can — including a
+/// launch-time orphan scan for recordings whose stop it never saw — and only
+/// then deletes them, so a crash anywhere in the chain loses nothing.
+///
+/// All state is confined to the main queue: invokes hop onto it, the meter
+/// timer runs on it, and AVFoundation notifications are delivered to it.
+class RecordingPlugin: Plugin {
+
+  /// Why the native side is finalizing the file. `nil` while recording and
+  /// for webview-initiated stops (which resolve their invoke instead).
+  private enum NativeStopReason: String {
+    case interruption
+    case routeChange
+    case background
+    case maxDuration
+    case error
+  }
+
+  private var recorder: AVAudioRecorder?
+  private var meterTimer: Timer?
+  private var delegateProxy: RecorderDelegateProxy?
+  /// Recorded milliseconds, captured before `stop()` zeroes `currentTime`.
+  private var stoppedDurationMs: Double = 0
+  /// Refreshed by the meter timer — the duration fallback for stops that
+  /// never pass through `finalize` (the cap firing the delegate directly),
+  /// where `currentTime` already reads 0.
+  private var lastMeteredDurationMs: Double = 0
+  /// The webview's `stopRecording` invoke, resolved when the file finalizes.
+  private var pendingStop: Invoke?
+  /// The webview's `cancelRecording` invoke — finalize, then delete.
+  private var pendingCancel: Invoke?
+  private var nativeStopReason: NativeStopReason?
+  /// Bumped by cancel so a permission grant arriving later starts nothing.
+  private var startSession = 0
+
+  @objc public override func load(webview: WKWebView) {
+    let center = NotificationCenter.default
+    center.addObserver(
+      self,
+      selector: #selector(handleInterruption(_:)),
+      name: AVAudioSession.interruptionNotification,
+      object: AVAudioSession.sharedInstance()
+    )
+    center.addObserver(
+      self,
+      selector: #selector(handleRouteChange(_:)),
+      name: AVAudioSession.routeChangeNotification,
+      object: AVAudioSession.sharedInstance()
+    )
+    // Wave 1 records in the foreground only (no background-audio entitlement
+    // yet): backgrounding finalizes the memo instead of letting the OS
+    // suspend the process mid-write and corrupt the container.
+    center.addObserver(
+      self,
+      selector: #selector(handleDidEnterBackground),
+      name: UIApplication.didEnterBackgroundNotification,
+      object: nil
+    )
+  }
+
+  // MARK: - Commands
+
+  @objc public func startRecording(_ invoke: Invoke) throws {
+    let args = try invoke.parseArgs(StartArgs.self)
+    DispatchQueue.main.async {
+      guard self.recorder == nil else {
+        invoke.reject("already recording")
+        return
+      }
+      let session = self.startSession
+      let audioSession = AVAudioSession.sharedInstance()
+      audioSession.requestRecordPermission { granted in
+        DispatchQueue.main.async {
+          guard self.startSession == session, self.recorder == nil else {
+            // Cancelled while the permission prompt was up, or a retry beat
+            // this grant — nothing to start.
+            invoke.reject("recording start was cancelled")
+            return
+          }
+          guard granted else {
+            invoke.reject("microphone access denied")
+            return
+          }
+          do {
+            try self.beginRecording(maxDurationMs: args.maxDurationMs)
+            invoke.resolve()
+          } catch {
+            self.deactivateAudioSession()
+            invoke.reject("recording failed to start: \(error.localizedDescription)")
+          }
+        }
+      }
+    }
+  }
+
+  @objc public func stopRecording(_ invoke: Invoke) {
+    DispatchQueue.main.async {
+      guard let recorder = self.recorder else {
+        invoke.reject("no active recording")
+        return
+      }
+      guard self.pendingStop == nil, self.pendingCancel == nil else {
+        invoke.reject("a stop is already in flight")
+        return
+      }
+      self.pendingStop = invoke
+      self.finalize(recorder)
+    }
+  }
+
+  @objc public func cancelRecording(_ invoke: Invoke) {
+    DispatchQueue.main.async {
+      // Cancel during the permission prompt: invalidate the pending start.
+      self.startSession += 1
+      guard let recorder = self.recorder else {
+        invoke.resolve()
+        return
+      }
+      guard self.pendingStop == nil, self.pendingCancel == nil else {
+        invoke.reject("a stop is already in flight")
+        return
+      }
+      self.pendingCancel = invoke
+      self.finalize(recorder)
+    }
+  }
+
+  @objc public func listStaged(_ invoke: Invoke) {
+    DispatchQueue.main.async {
+      do {
+        let directory = try self.stagingDirectory()
+        let live = self.recorder?.url.standardizedFileURL.path
+        let urls = try FileManager.default.contentsOfDirectory(
+          at: directory,
+          includingPropertiesForKeys: [.contentModificationDateKey],
+          options: [.skipsHiddenFiles]
+        )
+        let files: [StagedFile] = urls.compactMap { url in
+          // The in-flight recording's file is not staged output yet.
+          guard url.standardizedFileURL.path != live else { return nil }
+          let modified =
+            (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
+            .contentModificationDate ?? Date(timeIntervalSince1970: 0)
+          return StagedFile(
+            path: url.standardizedFileURL.path,
+            modifiedMs: modified.timeIntervalSince1970 * 1000
+          )
+        }
+        invoke.resolve(ListStagedResponse(files: files.sorted { $0.path < $1.path }))
+      } catch {
+        invoke.reject("listing staged recordings failed: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  @objc public func readStaged(_ invoke: Invoke) throws {
+    let args = try invoke.parseArgs(StagedPathArgs.self)
+    DispatchQueue.main.async {
+      do {
+        let url = try self.stagedURL(for: args.path)
+        let data = try Data(contentsOf: url)
+        invoke.resolve(ReadStagedResponse(base64: data.base64EncodedString()))
+      } catch {
+        invoke.reject("reading staged recording failed: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  @objc public func deleteStaged(_ invoke: Invoke) throws {
+    let args = try invoke.parseArgs(StagedPathArgs.self)
+    DispatchQueue.main.async {
+      do {
+        let url = try self.stagedURL(for: args.path)
+        if FileManager.default.fileExists(atPath: url.path) {
+          try FileManager.default.removeItem(at: url)
+        }
+        invoke.resolve()
+      } catch {
+        invoke.reject("deleting staged recording failed: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  // MARK: - Recording lifecycle (main queue)
+
+  private func beginRecording(maxDurationMs: Double) throws {
+    let audioSession = AVAudioSession.sharedInstance()
+    try audioSession.setCategory(.record, mode: .default)
+    try audioSession.setActive(true)
+
+    let directory = try stagingDirectory()
+    let name = "recording-\(Int(Date().timeIntervalSince1970 * 1000)).m4a"
+    let url = directory.appendingPathComponent(name)
+    // AAC mono 44.1 kHz — the V1 recorder's format, and the `.m4a` container
+    // the transcription providers accept (`AUDIO_EXTENSION_BY_MIME`).
+    let settings: [String: Any] = [
+      AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+      AVSampleRateKey: 44_100.0,
+      AVNumberOfChannelsKey: 1,
+      AVEncoderAudioQualityKey: AVAudioQuality.medium.rawValue,
+    ]
+    let recorder = try AVAudioRecorder(url: url, settings: settings)
+    let proxy = RecorderDelegateProxy(
+      onFinish: { [weak self] successfully in
+        self?.recorderDidFinish(successfully: successfully)
+      },
+      onEncodeError: { [weak self] in
+        self?.nativeStopReason = self?.nativeStopReason ?? .error
+      }
+    )
+    recorder.delegate = proxy
+    recorder.isMeteringEnabled = true
+    guard recorder.record(forDuration: maxDurationMs / 1000) else {
+      deactivateAudioSession()
+      throw NSError(
+        domain: "app.reflect.recording", code: 1,
+        userInfo: [NSLocalizedDescriptionKey: "the audio recorder refused to start"])
+    }
+
+    self.recorder = recorder
+    self.delegateProxy = proxy
+    self.nativeStopReason = nil
+    self.stoppedDurationMs = 0
+    self.lastMeteredDurationMs = 0
+    // The screen must not sleep mid-memo (V1 parity).
+    UIApplication.shared.isIdleTimerDisabled = true
+    self.meterTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) {
+      [weak self] _ in
+      self?.emitLevel()
+    }
+  }
+
+  /// Capture the duration and ask the recorder to finalize the file; the
+  /// delegate callback (`recorderDidFinish`) settles whoever is waiting.
+  private func finalize(_ recorder: AVAudioRecorder, native reason: NativeStopReason? = nil) {
+    nativeStopReason = reason
+    stoppedDurationMs = recorder.currentTime * 1000
+    meterTimer?.invalidate()
+    meterTimer = nil
+    recorder.stop()
+  }
+
+  private func recorderDidFinish(successfully: Bool) {
+    guard let recorder = self.recorder else { return }
+    let path = recorder.url.standardizedFileURL.path
+    // `record(forDuration:)` hitting the cap lands here with no local cause
+    // recorded — every other path set its reason (or a pending invoke) first.
+    let reason =
+      nativeStopReason ?? (!successfully ? .error : .maxDuration)
+    let durationMs = stoppedDurationMs > 0 ? stoppedDurationMs : lastMeteredDurationMs
+
+    self.recorder = nil
+    self.delegateProxy = nil
+    self.nativeStopReason = nil
+    self.meterTimer?.invalidate()
+    self.meterTimer = nil
+    UIApplication.shared.isIdleTimerDisabled = false
+    deactivateAudioSession()
+
+    if let cancel = pendingCancel {
+      pendingCancel = nil
+      try? FileManager.default.removeItem(atPath: path)
+      cancel.resolve()
+      return
+    }
+    if let stop = pendingStop {
+      pendingStop = nil
+      stop.resolve(StopResponse(path: path, durationMs: durationMs))
+      return
+    }
+    // A native-initiated stop: the file is staged output now — tell the
+    // webview if it is alive; the orphan scan covers it if it is not.
+    do {
+      try trigger(
+        "recordingStopped",
+        data: RecordingStopped(path: path, durationMs: durationMs, reason: reason.rawValue))
+    } catch {
+      Logger.error("recordingStopped event failed to serialize: \(error)")
+    }
+  }
+
+  private func emitLevel() {
+    guard let recorder = self.recorder, recorder.isRecording else { return }
+    recorder.updateMeters()
+    lastMeteredDurationMs = recorder.currentTime * 1000
+    // Average power is dBFS (−160…0); linearize for the waveform.
+    let level = pow(10, recorder.averagePower(forChannel: 0) / 20)
+    do {
+      try trigger(
+        "recordingLevel",
+        data: RecordingLevel(level: level, elapsedMs: lastMeteredDurationMs))
+    } catch {
+      Logger.error("recordingLevel event failed to serialize: \(error)")
+    }
+  }
+
+  private func deactivateAudioSession() {
+    try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+  }
+
+  // MARK: - Session notifications
+
+  @objc private func handleInterruption(_ notification: Notification) {
+    guard
+      let recorder = self.recorder,
+      let rawType = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+      AVAudioSession.InterruptionType(rawValue: rawType) == .began
+    else { return }
+    // A call, Siri, or an alarm took the session: keep what was recorded
+    // rather than gambling on a resume that may never come (V1 parity).
+    finalize(recorder, native: .interruption)
+  }
+
+  @objc private func handleRouteChange(_ notification: Notification) {
+    guard
+      let recorder = self.recorder,
+      let rawReason = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt,
+      AVAudioSession.RouteChangeReason(rawValue: rawReason) == .oldDeviceUnavailable
+    else { return }
+    // The input device went away (headset unplugged, Bluetooth mic dropped):
+    // stop instead of silently recording the wrong microphone.
+    finalize(recorder, native: .routeChange)
+  }
+
+  @objc private func handleDidEnterBackground() {
+    guard let recorder = self.recorder else { return }
+    finalize(recorder, native: .background)
+  }
+
+  // MARK: - Staging directory
+
+  private func stagingDirectory() throws -> URL {
+    let base = try FileManager.default.url(
+      for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+    let directory = base.appendingPathComponent("audio-memo-staging", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
+  }
+
+  /// Resolve a caller-supplied path, refusing anything outside staging — the
+  /// webview must not be able to read or delete arbitrary sandbox files.
+  private func stagedURL(for path: String) throws -> URL {
+    let directory = try stagingDirectory().standardizedFileURL
+    let url = URL(fileURLWithPath: path).standardizedFileURL
+    guard url.path.hasPrefix(directory.path + "/") else {
+      throw NSError(
+        domain: "app.reflect.recording", code: 2,
+        userInfo: [NSLocalizedDescriptionKey: "path is outside the recording staging directory"])
+    }
+    return url
+  }
+}
+
+/// `AVAudioRecorderDelegate` requires `NSObject`; a tiny proxy keeps the
+/// plugin class free of that conformance and the callbacks on closures.
+private class RecorderDelegateProxy: NSObject, AVAudioRecorderDelegate {
+  private let onFinish: (Bool) -> Void
+  private let onEncodeError: () -> Void
+
+  init(onFinish: @escaping (Bool) -> Void, onEncodeError: @escaping () -> Void) {
+    self.onFinish = onFinish
+    self.onEncodeError = onEncodeError
+  }
+
+  func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
+    onFinish(flag)
+  }
+
+  func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: Error?) {
+    onEncodeError()
+  }
+}
+
+@_cdecl("init_plugin_recording")
+func initPlugin() -> Plugin {
+  return RecordingPlugin()
+}

--- a/plugins/tauri-plugin-recording/ios/Sources/RecordingPlugin.swift
+++ b/plugins/tauri-plugin-recording/ios/Sources/RecordingPlugin.swift
@@ -23,6 +23,9 @@ struct RecordingStopped: Encodable {
   /// Absolute path of the staged `.m4a`.
   let path: String
   let durationMs: Double
+  /// The staged file's modification time in epoch ms — the memo's identity
+  /// timestamp (see `StopResponse.modifiedMs`).
+  let modifiedMs: Double
   /// `interruption` | `routeChange` | `maxDuration` | `error`
   let reason: String
 }
@@ -51,6 +54,11 @@ struct QueueActionArgs: Decodable {
 struct StopResponse: Encodable {
   let path: String
   let durationMs: Double
+  /// The staged file's modification time in epoch ms — its stop time, and
+  /// the memo's identity timestamp. The same value the orphan scan reads via
+  /// `listStaged`, so a recording re-ingested after a failed delete resolves
+  /// to the same memo basename instead of a duplicate.
+  let modifiedMs: Double
 }
 
 struct StagedFile: Encodable {
@@ -425,13 +433,30 @@ class RecordingPlugin: Plugin {
 
     if let cancel = pendingCancel {
       pendingCancel = nil
-      try? FileManager.default.removeItem(atPath: path)
-      cancel.resolve()
+      // Cancel must be durable: a file left in staging would be resurrected as
+      // a memo by the orphan scan, undoing the discard. Report the failure so
+      // the caller can surface it rather than silently keeping the recording.
+      do {
+        if FileManager.default.fileExists(atPath: path) {
+          try FileManager.default.removeItem(atPath: path)
+        }
+        cancel.resolve()
+      } catch {
+        cancel.reject("discarding the recording failed: \(error.localizedDescription)")
+      }
       return
     }
     if let stop = pendingStop {
       pendingStop = nil
-      stop.resolve(StopResponse(path: path, durationMs: durationMs))
+      // A failed finalization produced no usable file — reject rather than
+      // hand back a StopResponse pointing at a corrupt/absent recording.
+      if !successfully {
+        stop.reject("the recording failed to finalize")
+      } else {
+        stop.resolve(
+          StopResponse(
+            path: path, durationMs: durationMs, modifiedMs: Self.fileModifiedMs(path)))
+      }
       return
     }
     // A native-initiated stop: the file is staged output now — tell the
@@ -439,10 +464,20 @@ class RecordingPlugin: Plugin {
     do {
       try trigger(
         "recordingStopped",
-        data: RecordingStopped(path: path, durationMs: durationMs, reason: reason.rawValue))
+        data: RecordingStopped(
+          path: path, durationMs: durationMs, modifiedMs: Self.fileModifiedMs(path),
+          reason: reason.rawValue))
     } catch {
       Logger.error("recordingStopped event failed to serialize: \(error)")
     }
+  }
+
+  /// The staged file's modification time in epoch milliseconds — the memo's
+  /// identity timestamp, matching what `listStaged` reports for the same file.
+  private static func fileModifiedMs(_ path: String) -> Double {
+    let attributes = try? FileManager.default.attributesOfItem(atPath: path)
+    let modified = attributes?[.modificationDate] as? Date
+    return (modified ?? Date()).timeIntervalSince1970 * 1000
   }
 
   private func emitLevel() {

--- a/plugins/tauri-plugin-recording/ios/Sources/RecordingPlugin.swift
+++ b/plugins/tauri-plugin-recording/ios/Sources/RecordingPlugin.swift
@@ -3,6 +3,10 @@ import Tauri
 import UIKit
 import WebKit
 
+#if canImport(ActivityKit)
+  import ActivityKit
+#endif
+
 /// The payload of the plugin's ~10 Hz `recordingLevel` event.
 struct RecordingLevel: Encodable {
   /// Linear input level 0…1, from the recorder's average power meter.
@@ -29,6 +33,18 @@ struct RecordingStopped: Encodable {
 struct RecordingStatus: Encodable {
   let recording: Bool
   let elapsedMs: Double
+}
+
+/// The payload of the `nativeAction` event — an OS entry point (Siri, the
+/// home-screen quick action, the lock-screen widget's `reflect://` URL)
+/// asked for something only the webview can present.
+struct NativeAction: Encodable {
+  /// Currently only `recordAudio`.
+  let action: String
+}
+
+struct QueueActionArgs: Decodable {
+  let action: String
 }
 
 /// `stopRecording`'s response.
@@ -87,7 +103,27 @@ class RecordingPlugin: Plugin {
     case routeChange
     case maxDuration
     case error
+    /// Siri "stop" or the Live Activity's stop button (in-process intents).
+    case remote
   }
+
+  /// The Siri/App-Intent bridge: intents compiled into the app target run in
+  /// this process but in a different module, so they talk to the plugin
+  /// through NotificationCenter. Names are duplicated in
+  /// `gen/apple/Sources/reflect-open/` — keep them in sync.
+  static let startRequestedNotification = Notification.Name(
+    "app.reflect.recording.start-requested")
+  static let stopRequestedNotification = Notification.Name(
+    "app.reflect.recording.stop-requested")
+  /// The home-screen quick action's `UIApplicationShortcutItemType`.
+  static let recordShortcutType = "app.reflect.record-audio"
+  /// The persisted native-action queue (the V1 handshake): an action fired
+  /// from an OS entry point survives webview crashes and cold starts here
+  /// until the webview confirms it ran.
+  private static let pendingActionKey = "reflect.recording.pendingAction"
+
+  /// The delegate-hook target for OS callbacks that carry no plugin context.
+  private static weak var shared: RecordingPlugin?
 
   private var recorder: AVAudioRecorder?
   private var meterTimer: Timer?
@@ -108,6 +144,12 @@ class RecordingPlugin: Plugin {
   /// True while the app is backgrounded — level events pause (a suspended
   /// webview can't drain them) but the recording itself continues.
   private var isBackgrounded = false
+  /// True once the webview called `actionsReady` — queued native actions
+  /// deliver immediately from then on.
+  private var webviewReadyForActions = false
+  /// The live recording's Live Activity (`Activity<RecordingActivityAttributes>`,
+  /// type-erased: stored properties can't be availability-restricted).
+  private var liveActivity: Any?
 
   @objc public override func load(webview: WKWebView) {
     let center = NotificationCenter.default
@@ -137,6 +179,22 @@ class RecordingPlugin: Plugin {
       name: UIApplication.willEnterForegroundNotification,
       object: nil
     )
+    // OS entry points (Siri App Intents run in this process, in the app
+    // module) reach the plugin through NotificationCenter.
+    center.addObserver(
+      self,
+      selector: #selector(handleStartRequested),
+      name: Self.startRequestedNotification,
+      object: nil
+    )
+    center.addObserver(
+      self,
+      selector: #selector(handleStopRequested),
+      name: Self.stopRequestedNotification,
+      object: nil
+    )
+    Self.shared = self
+    Self.installShortcutHandler()
   }
 
   // MARK: - Commands
@@ -323,6 +381,7 @@ class RecordingPlugin: Plugin {
       [weak self] _ in
       self?.emitLevel()
     }
+    startLiveActivity()
   }
 
   /// Capture the duration and ask the recorder to finalize the file; the
@@ -351,6 +410,7 @@ class RecordingPlugin: Plugin {
     self.meterTimer = nil
     UIApplication.shared.isIdleTimerDisabled = false
     deactivateAudioSession()
+    endLiveActivity()
 
     if let cancel = pendingCancel {
       pendingCancel = nil
@@ -426,6 +486,142 @@ class RecordingPlugin: Plugin {
 
   @objc private func handleWillEnterForeground() {
     isBackgrounded = false
+  }
+
+  // MARK: - Native actions (the V1 handshake)
+
+  /// The webview's action surface is mounted and listening: deliver the
+  /// queued action, if any. The action stays queued until `actionPerformed`
+  /// — a webview that crashes mid-delivery gets it again on the next launch.
+  @objc public func actionsReady(_ invoke: Invoke) {
+    DispatchQueue.main.async {
+      self.webviewReadyForActions = true
+      self.deliverPendingAction()
+      invoke.resolve()
+    }
+  }
+
+  /// The webview executed the delivered action — retire it from the queue.
+  @objc public func actionPerformed(_ invoke: Invoke) {
+    DispatchQueue.main.async {
+      UserDefaults.standard.removeObject(forKey: Self.pendingActionKey)
+      invoke.resolve()
+    }
+  }
+
+  /// Queue a native action from the Rust side (the lock-screen widget's
+  /// `reflect://record-audio` URL arrives as a tao `Opened` event).
+  @objc public func queueAction(_ invoke: Invoke) throws {
+    let args = try invoke.parseArgs(QueueActionArgs.self)
+    DispatchQueue.main.async {
+      self.queueNativeAction(args.action)
+      invoke.resolve()
+    }
+  }
+
+  /// Persist the request, then deliver it if the webview is listening. The
+  /// two-step shape is the point (see `native-entry-points.md`): OS entry
+  /// points can fire before the webview exists or right before it dies, and
+  /// the action must be neither lost nor double-run.
+  private func queueNativeAction(_ action: String) {
+    UserDefaults.standard.set(action, forKey: Self.pendingActionKey)
+    deliverPendingAction()
+  }
+
+  private func deliverPendingAction() {
+    guard
+      webviewReadyForActions,
+      let action = UserDefaults.standard.string(forKey: Self.pendingActionKey)
+    else { return }
+    do {
+      try trigger("nativeAction", data: NativeAction(action: action))
+    } catch {
+      Logger.error("nativeAction event failed to serialize: \(error)")
+    }
+  }
+
+  @objc private func handleStartRequested() {
+    // Starting needs the webview (recording UI, then capture) — queue it.
+    queueNativeAction("recordAudio")
+  }
+
+  @objc private func handleStopRequested() {
+    // Stopping is pure native work: finalize now, even with the app
+    // backgrounded or the webview dead; ingest follows the usual paths.
+    guard let recorder = self.recorder, pendingStop == nil, pendingCancel == nil else { return }
+    finalize(recorder, native: .remote)
+  }
+
+  /// The home-screen quick action arrives on the app delegate — a runtime
+  /// class tao registers without implementing
+  /// `application:performActionForShortcutItem:completionHandler:`. Add the
+  /// method to that class; if some future delegate already implements it,
+  /// leave theirs alone (the quick action degrades to just opening the app).
+  private static var didInstallShortcutHandler = false
+  private static func installShortcutHandler() {
+    guard
+      !didInstallShortcutHandler,
+      let delegate = UIApplication.shared.delegate,
+      let delegateClass = object_getClass(delegate)
+    else { return }
+    didInstallShortcutHandler = true
+    let selector = NSSelectorFromString(
+      "application:performActionForShortcutItem:completionHandler:")
+    guard class_getInstanceMethod(delegateClass, selector) == nil else { return }
+    let block:
+      @convention(block) (
+        AnyObject, UIApplication, UIApplicationShortcutItem, @escaping (Bool) -> Void
+      ) -> Void = { _, _, item, completion in
+        let handled = item.type == RecordingPlugin.recordShortcutType
+        if handled {
+          DispatchQueue.main.async {
+            RecordingPlugin.shared?.queueNativeAction("recordAudio")
+          }
+        }
+        completion(handled)
+      }
+    class_addMethod(
+      delegateClass, selector, imp_implementationWithBlock(block), "v@:@@@?")
+  }
+
+  // MARK: - Live Activity
+
+  /// Show the recording on the lock screen / Dynamic Island: elapsed timer
+  /// plus (iOS 17+) a stop button. Requires iOS 16.2 and the user not having
+  /// disabled Live Activities — both degrade to "no activity", never an error.
+  private func startLiveActivity() {
+    #if canImport(ActivityKit)
+      if #available(iOS 16.2, *) {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+        let content = ActivityContent(
+          state: RecordingActivityAttributes.ContentState(startedAt: Date()),
+          staleDate: nil
+        )
+        do {
+          liveActivity = try Activity.request(
+            attributes: RecordingActivityAttributes(),
+            content: content,
+            pushType: nil
+          )
+        } catch {
+          Logger.error("recording Live Activity failed to start: \(error)")
+        }
+      }
+    #endif
+  }
+
+  private func endLiveActivity() {
+    #if canImport(ActivityKit)
+      if #available(iOS 16.2, *) {
+        guard let activity = liveActivity as? Activity<RecordingActivityAttributes> else {
+          return
+        }
+        liveActivity = nil
+        Task {
+          await activity.end(nil, dismissalPolicy: .immediate)
+        }
+      }
+    #endif
   }
 
   // MARK: - Staging directory

--- a/plugins/tauri-plugin-recording/ios/Sources/RecordingPlugin.swift
+++ b/plugins/tauri-plugin-recording/ios/Sources/RecordingPlugin.swift
@@ -121,6 +121,12 @@ class RecordingPlugin: Plugin {
   /// from an OS entry point survives webview crashes and cold starts here
   /// until the webview confirms it ran.
   private static let pendingActionKey = "reflect.recording.pendingAction"
+  private static let pendingActionQueuedAtKey = "reflect.recording.pendingActionQueuedAt"
+  /// A queued action older than this is dropped, not delivered: re-firing a
+  /// crash-orphaned request seconds later is the contract, but turning the
+  /// microphone on days after the tap that asked for it is a surprise no
+  /// user reads as their own action.
+  private static let pendingActionMaxAgeSeconds: TimeInterval = 15 * 60
 
   /// The delegate-hook target for OS callbacks that carry no plugin context.
   private static weak var shared: RecordingPlugin?
@@ -195,6 +201,11 @@ class RecordingPlugin: Plugin {
     )
     Self.shared = self
     Self.installShortcutHandler()
+    // A crash mid-recording leaves its Live Activity counting on the lock
+    // screen with nothing behind it (the orphan scan saves the audio, but
+    // nobody ended the activity). Nothing can be legitimately live at plugin
+    // load, so end them all.
+    endStaleLiveActivities()
   }
 
   // MARK: - Commands
@@ -504,7 +515,7 @@ class RecordingPlugin: Plugin {
   /// The webview executed the delivered action — retire it from the queue.
   @objc public func actionPerformed(_ invoke: Invoke) {
     DispatchQueue.main.async {
-      UserDefaults.standard.removeObject(forKey: Self.pendingActionKey)
+      Self.clearPendingAction()
       invoke.resolve()
     }
   }
@@ -525,6 +536,8 @@ class RecordingPlugin: Plugin {
   /// the action must be neither lost nor double-run.
   private func queueNativeAction(_ action: String) {
     UserDefaults.standard.set(action, forKey: Self.pendingActionKey)
+    UserDefaults.standard.set(
+      Date().timeIntervalSince1970, forKey: Self.pendingActionQueuedAtKey)
     deliverPendingAction()
   }
 
@@ -533,11 +546,21 @@ class RecordingPlugin: Plugin {
       webviewReadyForActions,
       let action = UserDefaults.standard.string(forKey: Self.pendingActionKey)
     else { return }
+    let queuedAt = UserDefaults.standard.double(forKey: Self.pendingActionQueuedAtKey)
+    guard Date().timeIntervalSince1970 - queuedAt <= Self.pendingActionMaxAgeSeconds else {
+      Self.clearPendingAction()
+      return
+    }
     do {
       try trigger("nativeAction", data: NativeAction(action: action))
     } catch {
       Logger.error("nativeAction event failed to serialize: \(error)")
     }
+  }
+
+  private static func clearPendingAction() {
+    UserDefaults.standard.removeObject(forKey: pendingActionKey)
+    UserDefaults.standard.removeObject(forKey: pendingActionQueuedAtKey)
   }
 
   @objc private func handleStartRequested() {
@@ -619,6 +642,18 @@ class RecordingPlugin: Plugin {
         liveActivity = nil
         Task {
           await activity.end(nil, dismissalPolicy: .immediate)
+        }
+      }
+    #endif
+  }
+
+  private func endStaleLiveActivities() {
+    #if canImport(ActivityKit)
+      if #available(iOS 16.2, *) {
+        Task {
+          for activity in Activity<RecordingActivityAttributes>.activities {
+            await activity.end(nil, dismissalPolicy: .immediate)
+          }
         }
       }
     #endif

--- a/plugins/tauri-plugin-recording/ios/Sources/RecordingPlugin.swift
+++ b/plugins/tauri-plugin-recording/ios/Sources/RecordingPlugin.swift
@@ -12,15 +12,23 @@ struct RecordingLevel: Encodable {
 }
 
 /// The payload of the `recordingStopped` event — a stop the *native* side
-/// initiated (interruption, route change, backgrounding, the duration cap, or
-/// an encoder error). A stop the webview asked for resolves its own invoke
-/// instead and never fires this event.
+/// initiated (interruption, route change, the duration cap, or an encoder
+/// error). A stop the webview asked for resolves its own invoke instead and
+/// never fires this event.
 struct RecordingStopped: Encodable {
   /// Absolute path of the staged `.m4a`.
   let path: String
   let durationMs: Double
-  /// `interruption` | `routeChange` | `background` | `maxDuration` | `error`
+  /// `interruption` | `routeChange` | `maxDuration` | `error`
   let reason: String
+}
+
+/// `recordingStatus`'s response — whether a native recording is live right
+/// now. A fresh webview mount uses this to find a recording that outlived
+/// its UI (a reload or crash mid-memo) and stop-and-save it.
+struct RecordingStatus: Encodable {
+  let recording: Bool
+  let elapsedMs: Double
 }
 
 /// `stopRecording`'s response.
@@ -59,11 +67,14 @@ struct StagedPathArgs: Decodable {
 /// The V1 lesson this preserves: **capture must not depend on the webview.**
 /// The recorder writes AAC mono 44.1 kHz `.m4a` straight into a staging
 /// directory the plugin owns; audio-session interruptions (calls, Siri,
-/// alarms), input-route loss (headphones unplugged), backgrounding, and the
-/// duration cap all finalize the file natively, without JS involvement. The
-/// webview ingests staged files into the graph when it can — including a
-/// launch-time orphan scan for recordings whose stop it never saw — and only
-/// then deletes them, so a crash anywhere in the chain loses nothing.
+/// alarms), input-route loss (headphones unplugged), and the duration cap
+/// all finalize the file natively, without JS involvement. Backgrounding
+/// does NOT stop a recording: the app declares `UIBackgroundModes: audio`,
+/// so a memo keeps capturing through screen lock (V1 parity) — level events
+/// pause while backgrounded rather than piling into a suspended webview.
+/// The webview ingests staged files into the graph when it can — including
+/// a launch-time orphan scan for recordings whose stop it never saw — and
+/// only then deletes them, so a crash anywhere in the chain loses nothing.
 ///
 /// All state is confined to the main queue: invokes hop onto it, the meter
 /// timer runs on it, and AVFoundation notifications are delivered to it.
@@ -74,7 +85,6 @@ class RecordingPlugin: Plugin {
   private enum NativeStopReason: String {
     case interruption
     case routeChange
-    case background
     case maxDuration
     case error
   }
@@ -95,6 +105,9 @@ class RecordingPlugin: Plugin {
   private var nativeStopReason: NativeStopReason?
   /// Bumped by cancel so a permission grant arriving later starts nothing.
   private var startSession = 0
+  /// True while the app is backgrounded — level events pause (a suspended
+  /// webview can't drain them) but the recording itself continues.
+  private var isBackgrounded = false
 
   @objc public override func load(webview: WKWebView) {
     let center = NotificationCenter.default
@@ -110,13 +123,18 @@ class RecordingPlugin: Plugin {
       name: AVAudioSession.routeChangeNotification,
       object: AVAudioSession.sharedInstance()
     )
-    // Wave 1 records in the foreground only (no background-audio entitlement
-    // yet): backgrounding finalizes the memo instead of letting the OS
-    // suspend the process mid-write and corrupt the container.
+    // Backgrounding only gates event emission — with `UIBackgroundModes:
+    // audio` the recording itself continues through screen lock.
     center.addObserver(
       self,
       selector: #selector(handleDidEnterBackground),
       name: UIApplication.didEnterBackgroundNotification,
+      object: nil
+    )
+    center.addObserver(
+      self,
+      selector: #selector(handleWillEnterForeground),
+      name: UIApplication.willEnterForegroundNotification,
       object: nil
     )
   }
@@ -185,6 +203,20 @@ class RecordingPlugin: Plugin {
       }
       self.pendingCancel = invoke
       self.finalize(recorder)
+    }
+  }
+
+  /// Whether a recording is live right now. A fresh webview mount asks this
+  /// to find a recording that outlived its UI (a reload or crash mid-memo)
+  /// and stop-and-save it instead of leaving a hidden hot microphone.
+  @objc public func recordingStatus(_ invoke: Invoke) {
+    DispatchQueue.main.async {
+      let recorder = self.recorder
+      invoke.resolve(
+        RecordingStatus(
+          recording: recorder != nil,
+          elapsedMs: (recorder?.currentTime ?? 0) * 1000
+        ))
     }
   }
 
@@ -344,8 +376,11 @@ class RecordingPlugin: Plugin {
 
   private func emitLevel() {
     guard let recorder = self.recorder, recorder.isRecording else { return }
-    recorder.updateMeters()
     lastMeteredDurationMs = recorder.currentTime * 1000
+    // A suspended webview can't drain events — keep tracking the duration
+    // above, but only emit while the app is in the foreground.
+    guard !isBackgrounded else { return }
+    recorder.updateMeters()
     // Average power is dBFS (−160…0); linearize for the waveform.
     let level = pow(10, recorder.averagePower(forChannel: 0) / 20)
     do {
@@ -386,8 +421,11 @@ class RecordingPlugin: Plugin {
   }
 
   @objc private func handleDidEnterBackground() {
-    guard let recorder = self.recorder else { return }
-    finalize(recorder, native: .background)
+    isBackgrounded = true
+  }
+
+  @objc private func handleWillEnterForeground() {
+    isBackgrounded = false
   }
 
   // MARK: - Staging directory

--- a/plugins/tauri-plugin-recording/permissions/autogenerated/commands/action_performed.toml
+++ b/plugins/tauri-plugin-recording/permissions/autogenerated/commands/action_performed.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-action-performed"
+description = "Enables the action_performed command without any pre-configured scope."
+commands.allow = ["action_performed"]
+
+[[permission]]
+identifier = "deny-action-performed"
+description = "Denies the action_performed command without any pre-configured scope."
+commands.deny = ["action_performed"]

--- a/plugins/tauri-plugin-recording/permissions/autogenerated/commands/actions_ready.toml
+++ b/plugins/tauri-plugin-recording/permissions/autogenerated/commands/actions_ready.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-actions-ready"
+description = "Enables the actions_ready command without any pre-configured scope."
+commands.allow = ["actions_ready"]
+
+[[permission]]
+identifier = "deny-actions-ready"
+description = "Denies the actions_ready command without any pre-configured scope."
+commands.deny = ["actions_ready"]

--- a/plugins/tauri-plugin-recording/permissions/autogenerated/commands/cancel_recording.toml
+++ b/plugins/tauri-plugin-recording/permissions/autogenerated/commands/cancel_recording.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-cancel-recording"
+description = "Enables the cancel_recording command without any pre-configured scope."
+commands.allow = ["cancel_recording"]
+
+[[permission]]
+identifier = "deny-cancel-recording"
+description = "Denies the cancel_recording command without any pre-configured scope."
+commands.deny = ["cancel_recording"]

--- a/plugins/tauri-plugin-recording/permissions/autogenerated/commands/delete_staged.toml
+++ b/plugins/tauri-plugin-recording/permissions/autogenerated/commands/delete_staged.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-delete-staged"
+description = "Enables the delete_staged command without any pre-configured scope."
+commands.allow = ["delete_staged"]
+
+[[permission]]
+identifier = "deny-delete-staged"
+description = "Denies the delete_staged command without any pre-configured scope."
+commands.deny = ["delete_staged"]

--- a/plugins/tauri-plugin-recording/permissions/autogenerated/commands/list_staged.toml
+++ b/plugins/tauri-plugin-recording/permissions/autogenerated/commands/list_staged.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-list-staged"
+description = "Enables the list_staged command without any pre-configured scope."
+commands.allow = ["list_staged"]
+
+[[permission]]
+identifier = "deny-list-staged"
+description = "Denies the list_staged command without any pre-configured scope."
+commands.deny = ["list_staged"]

--- a/plugins/tauri-plugin-recording/permissions/autogenerated/commands/read_staged.toml
+++ b/plugins/tauri-plugin-recording/permissions/autogenerated/commands/read_staged.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-read-staged"
+description = "Enables the read_staged command without any pre-configured scope."
+commands.allow = ["read_staged"]
+
+[[permission]]
+identifier = "deny-read-staged"
+description = "Denies the read_staged command without any pre-configured scope."
+commands.deny = ["read_staged"]

--- a/plugins/tauri-plugin-recording/permissions/autogenerated/commands/recording_status.toml
+++ b/plugins/tauri-plugin-recording/permissions/autogenerated/commands/recording_status.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-recording-status"
+description = "Enables the recording_status command without any pre-configured scope."
+commands.allow = ["recording_status"]
+
+[[permission]]
+identifier = "deny-recording-status"
+description = "Denies the recording_status command without any pre-configured scope."
+commands.deny = ["recording_status"]

--- a/plugins/tauri-plugin-recording/permissions/autogenerated/commands/registerListener.toml
+++ b/plugins/tauri-plugin-recording/permissions/autogenerated/commands/registerListener.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-registerListener"
+description = "Enables the registerListener command without any pre-configured scope."
+commands.allow = ["registerListener"]
+
+[[permission]]
+identifier = "deny-registerListener"
+description = "Denies the registerListener command without any pre-configured scope."
+commands.deny = ["registerListener"]

--- a/plugins/tauri-plugin-recording/permissions/autogenerated/commands/remove_listener.toml
+++ b/plugins/tauri-plugin-recording/permissions/autogenerated/commands/remove_listener.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-remove-listener"
+description = "Enables the remove_listener command without any pre-configured scope."
+commands.allow = ["remove_listener"]
+
+[[permission]]
+identifier = "deny-remove-listener"
+description = "Denies the remove_listener command without any pre-configured scope."
+commands.deny = ["remove_listener"]

--- a/plugins/tauri-plugin-recording/permissions/autogenerated/commands/start_recording.toml
+++ b/plugins/tauri-plugin-recording/permissions/autogenerated/commands/start_recording.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-start-recording"
+description = "Enables the start_recording command without any pre-configured scope."
+commands.allow = ["start_recording"]
+
+[[permission]]
+identifier = "deny-start-recording"
+description = "Denies the start_recording command without any pre-configured scope."
+commands.deny = ["start_recording"]

--- a/plugins/tauri-plugin-recording/permissions/autogenerated/commands/stop_recording.toml
+++ b/plugins/tauri-plugin-recording/permissions/autogenerated/commands/stop_recording.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-stop-recording"
+description = "Enables the stop_recording command without any pre-configured scope."
+commands.allow = ["stop_recording"]
+
+[[permission]]
+identifier = "deny-stop-recording"
+description = "Denies the stop_recording command without any pre-configured scope."
+commands.deny = ["stop_recording"]

--- a/plugins/tauri-plugin-recording/permissions/autogenerated/reference.md
+++ b/plugins/tauri-plugin-recording/permissions/autogenerated/reference.md
@@ -7,6 +7,7 @@ Record audio memos natively, manage the staging directory, and subscribe to reco
 - `allow-start-recording`
 - `allow-stop-recording`
 - `allow-cancel-recording`
+- `allow-recording-status`
 - `allow-list-staged`
 - `allow-read-staged`
 - `allow-delete-staged`
@@ -122,6 +123,32 @@ Enables the read_staged command without any pre-configured scope.
 <td>
 
 Denies the read_staged command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`recording:allow-recording-status`
+
+</td>
+<td>
+
+Enables the recording_status command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`recording:deny-recording-status`
+
+</td>
+<td>
+
+Denies the recording_status command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/tauri-plugin-recording/permissions/autogenerated/reference.md
+++ b/plugins/tauri-plugin-recording/permissions/autogenerated/reference.md
@@ -1,0 +1,232 @@
+## Default Permission
+
+Record audio memos natively, manage the staging directory, and subscribe to recording events
+
+#### This default permission set includes the following:
+
+- `allow-start-recording`
+- `allow-stop-recording`
+- `allow-cancel-recording`
+- `allow-list-staged`
+- `allow-read-staged`
+- `allow-delete-staged`
+- `allow-registerListener`
+- `allow-remove-listener`
+
+## Permission Table
+
+<table>
+<tr>
+<th>Identifier</th>
+<th>Description</th>
+</tr>
+
+
+<tr>
+<td>
+
+`recording:allow-cancel-recording`
+
+</td>
+<td>
+
+Enables the cancel_recording command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`recording:deny-cancel-recording`
+
+</td>
+<td>
+
+Denies the cancel_recording command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`recording:allow-delete-staged`
+
+</td>
+<td>
+
+Enables the delete_staged command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`recording:deny-delete-staged`
+
+</td>
+<td>
+
+Denies the delete_staged command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`recording:allow-list-staged`
+
+</td>
+<td>
+
+Enables the list_staged command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`recording:deny-list-staged`
+
+</td>
+<td>
+
+Denies the list_staged command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`recording:allow-read-staged`
+
+</td>
+<td>
+
+Enables the read_staged command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`recording:deny-read-staged`
+
+</td>
+<td>
+
+Denies the read_staged command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`recording:allow-registerListener`
+
+</td>
+<td>
+
+Enables the registerListener command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`recording:deny-registerListener`
+
+</td>
+<td>
+
+Denies the registerListener command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`recording:allow-remove-listener`
+
+</td>
+<td>
+
+Enables the remove_listener command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`recording:deny-remove-listener`
+
+</td>
+<td>
+
+Denies the remove_listener command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`recording:allow-start-recording`
+
+</td>
+<td>
+
+Enables the start_recording command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`recording:deny-start-recording`
+
+</td>
+<td>
+
+Denies the start_recording command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`recording:allow-stop-recording`
+
+</td>
+<td>
+
+Enables the stop_recording command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`recording:deny-stop-recording`
+
+</td>
+<td>
+
+Denies the stop_recording command without any pre-configured scope.
+
+</td>
+</tr>
+</table>

--- a/plugins/tauri-plugin-recording/permissions/autogenerated/reference.md
+++ b/plugins/tauri-plugin-recording/permissions/autogenerated/reference.md
@@ -8,6 +8,8 @@ Record audio memos natively, manage the staging directory, and subscribe to reco
 - `allow-stop-recording`
 - `allow-cancel-recording`
 - `allow-recording-status`
+- `allow-actions-ready`
+- `allow-action-performed`
 - `allow-list-staged`
 - `allow-read-staged`
 - `allow-delete-staged`
@@ -22,6 +24,58 @@ Record audio memos natively, manage the staging directory, and subscribe to reco
 <th>Description</th>
 </tr>
 
+
+<tr>
+<td>
+
+`recording:allow-action-performed`
+
+</td>
+<td>
+
+Enables the action_performed command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`recording:deny-action-performed`
+
+</td>
+<td>
+
+Denies the action_performed command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`recording:allow-actions-ready`
+
+</td>
+<td>
+
+Enables the actions_ready command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`recording:deny-actions-ready`
+
+</td>
+<td>
+
+Denies the actions_ready command without any pre-configured scope.
+
+</td>
+</tr>
 
 <tr>
 <td>

--- a/plugins/tauri-plugin-recording/permissions/default.toml
+++ b/plugins/tauri-plugin-recording/permissions/default.toml
@@ -4,6 +4,7 @@ permissions = [
     "allow-start-recording",
     "allow-stop-recording",
     "allow-cancel-recording",
+    "allow-recording-status",
     "allow-list-staged",
     "allow-read-staged",
     "allow-delete-staged",

--- a/plugins/tauri-plugin-recording/permissions/default.toml
+++ b/plugins/tauri-plugin-recording/permissions/default.toml
@@ -1,0 +1,12 @@
+[default]
+description = "Record audio memos natively, manage the staging directory, and subscribe to recording events"
+permissions = [
+    "allow-start-recording",
+    "allow-stop-recording",
+    "allow-cancel-recording",
+    "allow-list-staged",
+    "allow-read-staged",
+    "allow-delete-staged",
+    "allow-registerListener",
+    "allow-remove-listener",
+]

--- a/plugins/tauri-plugin-recording/permissions/default.toml
+++ b/plugins/tauri-plugin-recording/permissions/default.toml
@@ -5,6 +5,8 @@ permissions = [
     "allow-stop-recording",
     "allow-cancel-recording",
     "allow-recording-status",
+    "allow-actions-ready",
+    "allow-action-performed",
     "allow-list-staged",
     "allow-read-staged",
     "allow-delete-staged",

--- a/plugins/tauri-plugin-recording/permissions/schemas/schema.json
+++ b/plugins/tauri-plugin-recording/permissions/schemas/schema.json
@@ -1,0 +1,402 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Enables the cancel_recording command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-cancel-recording",
+          "markdownDescription": "Enables the cancel_recording command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the cancel_recording command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-cancel-recording",
+          "markdownDescription": "Denies the cancel_recording command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the delete_staged command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-delete-staged",
+          "markdownDescription": "Enables the delete_staged command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the delete_staged command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-delete-staged",
+          "markdownDescription": "Denies the delete_staged command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the list_staged command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-list-staged",
+          "markdownDescription": "Enables the list_staged command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the list_staged command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-list-staged",
+          "markdownDescription": "Denies the list_staged command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the read_staged command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-read-staged",
+          "markdownDescription": "Enables the read_staged command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the read_staged command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-read-staged",
+          "markdownDescription": "Denies the read_staged command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the registerListener command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-registerListener",
+          "markdownDescription": "Enables the registerListener command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the registerListener command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-registerListener",
+          "markdownDescription": "Denies the registerListener command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the remove_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-remove-listener",
+          "markdownDescription": "Enables the remove_listener command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the remove_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-remove-listener",
+          "markdownDescription": "Denies the remove_listener command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the start_recording command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-start-recording",
+          "markdownDescription": "Enables the start_recording command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the start_recording command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-start-recording",
+          "markdownDescription": "Denies the start_recording command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the stop_recording command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-stop-recording",
+          "markdownDescription": "Enables the stop_recording command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the stop_recording command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-stop-recording",
+          "markdownDescription": "Denies the stop_recording command without any pre-configured scope."
+        },
+        {
+          "description": "Record audio memos natively, manage the staging directory, and subscribe to recording events\n#### This default permission set includes:\n\n- `allow-start-recording`\n- `allow-stop-recording`\n- `allow-cancel-recording`\n- `allow-list-staged`\n- `allow-read-staged`\n- `allow-delete-staged`\n- `allow-registerListener`\n- `allow-remove-listener`",
+          "type": "string",
+          "const": "default",
+          "markdownDescription": "Record audio memos natively, manage the staging directory, and subscribe to recording events\n#### This default permission set includes:\n\n- `allow-start-recording`\n- `allow-stop-recording`\n- `allow-cancel-recording`\n- `allow-list-staged`\n- `allow-read-staged`\n- `allow-delete-staged`\n- `allow-registerListener`\n- `allow-remove-listener`"
+        }
+      ]
+    }
+  }
+}

--- a/plugins/tauri-plugin-recording/permissions/schemas/schema.json
+++ b/plugins/tauri-plugin-recording/permissions/schemas/schema.json
@@ -343,6 +343,18 @@
           "markdownDescription": "Denies the read_staged command without any pre-configured scope."
         },
         {
+          "description": "Enables the recording_status command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-recording-status",
+          "markdownDescription": "Enables the recording_status command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the recording_status command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-recording-status",
+          "markdownDescription": "Denies the recording_status command without any pre-configured scope."
+        },
+        {
           "description": "Enables the registerListener command without any pre-configured scope.",
           "type": "string",
           "const": "allow-registerListener",
@@ -391,10 +403,10 @@
           "markdownDescription": "Denies the stop_recording command without any pre-configured scope."
         },
         {
-          "description": "Record audio memos natively, manage the staging directory, and subscribe to recording events\n#### This default permission set includes:\n\n- `allow-start-recording`\n- `allow-stop-recording`\n- `allow-cancel-recording`\n- `allow-list-staged`\n- `allow-read-staged`\n- `allow-delete-staged`\n- `allow-registerListener`\n- `allow-remove-listener`",
+          "description": "Record audio memos natively, manage the staging directory, and subscribe to recording events\n#### This default permission set includes:\n\n- `allow-start-recording`\n- `allow-stop-recording`\n- `allow-cancel-recording`\n- `allow-recording-status`\n- `allow-list-staged`\n- `allow-read-staged`\n- `allow-delete-staged`\n- `allow-registerListener`\n- `allow-remove-listener`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Record audio memos natively, manage the staging directory, and subscribe to recording events\n#### This default permission set includes:\n\n- `allow-start-recording`\n- `allow-stop-recording`\n- `allow-cancel-recording`\n- `allow-list-staged`\n- `allow-read-staged`\n- `allow-delete-staged`\n- `allow-registerListener`\n- `allow-remove-listener`"
+          "markdownDescription": "Record audio memos natively, manage the staging directory, and subscribe to recording events\n#### This default permission set includes:\n\n- `allow-start-recording`\n- `allow-stop-recording`\n- `allow-cancel-recording`\n- `allow-recording-status`\n- `allow-list-staged`\n- `allow-read-staged`\n- `allow-delete-staged`\n- `allow-registerListener`\n- `allow-remove-listener`"
         }
       ]
     }

--- a/plugins/tauri-plugin-recording/permissions/schemas/schema.json
+++ b/plugins/tauri-plugin-recording/permissions/schemas/schema.json
@@ -295,6 +295,30 @@
       "type": "string",
       "oneOf": [
         {
+          "description": "Enables the action_performed command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-action-performed",
+          "markdownDescription": "Enables the action_performed command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the action_performed command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-action-performed",
+          "markdownDescription": "Denies the action_performed command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the actions_ready command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-actions-ready",
+          "markdownDescription": "Enables the actions_ready command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the actions_ready command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-actions-ready",
+          "markdownDescription": "Denies the actions_ready command without any pre-configured scope."
+        },
+        {
           "description": "Enables the cancel_recording command without any pre-configured scope.",
           "type": "string",
           "const": "allow-cancel-recording",
@@ -403,10 +427,10 @@
           "markdownDescription": "Denies the stop_recording command without any pre-configured scope."
         },
         {
-          "description": "Record audio memos natively, manage the staging directory, and subscribe to recording events\n#### This default permission set includes:\n\n- `allow-start-recording`\n- `allow-stop-recording`\n- `allow-cancel-recording`\n- `allow-recording-status`\n- `allow-list-staged`\n- `allow-read-staged`\n- `allow-delete-staged`\n- `allow-registerListener`\n- `allow-remove-listener`",
+          "description": "Record audio memos natively, manage the staging directory, and subscribe to recording events\n#### This default permission set includes:\n\n- `allow-start-recording`\n- `allow-stop-recording`\n- `allow-cancel-recording`\n- `allow-recording-status`\n- `allow-actions-ready`\n- `allow-action-performed`\n- `allow-list-staged`\n- `allow-read-staged`\n- `allow-delete-staged`\n- `allow-registerListener`\n- `allow-remove-listener`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Record audio memos natively, manage the staging directory, and subscribe to recording events\n#### This default permission set includes:\n\n- `allow-start-recording`\n- `allow-stop-recording`\n- `allow-cancel-recording`\n- `allow-recording-status`\n- `allow-list-staged`\n- `allow-read-staged`\n- `allow-delete-staged`\n- `allow-registerListener`\n- `allow-remove-listener`"
+          "markdownDescription": "Record audio memos natively, manage the staging directory, and subscribe to recording events\n#### This default permission set includes:\n\n- `allow-start-recording`\n- `allow-stop-recording`\n- `allow-cancel-recording`\n- `allow-recording-status`\n- `allow-actions-ready`\n- `allow-action-performed`\n- `allow-list-staged`\n- `allow-read-staged`\n- `allow-delete-staged`\n- `allow-registerListener`\n- `allow-remove-listener`"
         }
       ]
     }

--- a/plugins/tauri-plugin-recording/src/commands.rs
+++ b/plugins/tauri-plugin-recording/src/commands.rs
@@ -26,6 +26,20 @@ pub(crate) async fn cancel_recording<R: Runtime>(app: AppHandle<R>) -> Result<()
     app.recording().cancel_recording()
 }
 
+/// The webview's action surface is mounted and listening — deliver any
+/// queued native action (Siri / quick action / widget entry points).
+#[command]
+pub(crate) async fn actions_ready<R: Runtime>(app: AppHandle<R>) -> Result<()> {
+    app.recording().actions_ready()
+}
+
+/// The webview executed the delivered action — retire it from the queue so
+/// it doesn't re-fire on the next launch.
+#[command]
+pub(crate) async fn action_performed<R: Runtime>(app: AppHandle<R>) -> Result<()> {
+    app.recording().action_performed()
+}
+
 /// Whether a native recording is live right now. A fresh webview mount asks
 /// this to find a recording that outlived its UI (a reload or crash
 /// mid-memo) and stop-and-save it.

--- a/plugins/tauri-plugin-recording/src/commands.rs
+++ b/plugins/tauri-plugin-recording/src/commands.rs
@@ -1,0 +1,52 @@
+use tauri::{command, AppHandle, Runtime};
+
+use crate::models::*;
+use crate::RecordingExt;
+use crate::Result;
+
+/// Start recording into the plugin's staging directory. Prompts for the
+/// microphone on first use; rejects when access is denied.
+#[command]
+pub(crate) async fn start_recording<R: Runtime>(
+    app: AppHandle<R>,
+    request: StartRequest,
+) -> Result<()> {
+    app.recording().start_recording(request)
+}
+
+/// Stop the active recording; returns the staged file and its duration.
+#[command]
+pub(crate) async fn stop_recording<R: Runtime>(app: AppHandle<R>) -> Result<StopResponse> {
+    app.recording().stop_recording()
+}
+
+/// Stop the active recording and discard its file.
+#[command]
+pub(crate) async fn cancel_recording<R: Runtime>(app: AppHandle<R>) -> Result<()> {
+    app.recording().cancel_recording()
+}
+
+/// Finished recordings still in staging — crash orphans a launch pass must
+/// ingest, plus any file currently mid-ingest (callers filter those).
+#[command]
+pub(crate) async fn list_staged<R: Runtime>(app: AppHandle<R>) -> Result<ListStagedResponse> {
+    app.recording().list_staged()
+}
+
+/// A staged recording's bytes, base64-encoded for the capture pipeline.
+#[command]
+pub(crate) async fn read_staged<R: Runtime>(
+    app: AppHandle<R>,
+    request: StagedPathRequest,
+) -> Result<ReadStagedResponse> {
+    app.recording().read_staged(request)
+}
+
+/// Remove a staged recording once its bytes are durably in the graph.
+#[command]
+pub(crate) async fn delete_staged<R: Runtime>(
+    app: AppHandle<R>,
+    request: StagedPathRequest,
+) -> Result<()> {
+    app.recording().delete_staged(request)
+}

--- a/plugins/tauri-plugin-recording/src/commands.rs
+++ b/plugins/tauri-plugin-recording/src/commands.rs
@@ -26,6 +26,16 @@ pub(crate) async fn cancel_recording<R: Runtime>(app: AppHandle<R>) -> Result<()
     app.recording().cancel_recording()
 }
 
+/// Whether a native recording is live right now. A fresh webview mount asks
+/// this to find a recording that outlived its UI (a reload or crash
+/// mid-memo) and stop-and-save it.
+#[command]
+pub(crate) async fn recording_status<R: Runtime>(
+    app: AppHandle<R>,
+) -> Result<RecordingStatusResponse> {
+    app.recording().recording_status()
+}
+
 /// Finished recordings still in staging — crash orphans a launch pass must
 /// ingest, plus any file currently mid-ingest (callers filter those).
 #[command]

--- a/plugins/tauri-plugin-recording/src/desktop.rs
+++ b/plugins/tauri-plugin-recording/src/desktop.rs
@@ -28,6 +28,18 @@ impl<R: Runtime> Recording<R> {
         Err(crate::Error::UnsupportedPlatform)
     }
 
+    pub fn actions_ready(&self) -> crate::Result<()> {
+        Err(crate::Error::UnsupportedPlatform)
+    }
+
+    pub fn action_performed(&self) -> crate::Result<()> {
+        Err(crate::Error::UnsupportedPlatform)
+    }
+
+    pub fn queue_action(&self, _action: &str) -> crate::Result<()> {
+        Err(crate::Error::UnsupportedPlatform)
+    }
+
     pub fn recording_status(&self) -> crate::Result<RecordingStatusResponse> {
         Err(crate::Error::UnsupportedPlatform)
     }

--- a/plugins/tauri-plugin-recording/src/desktop.rs
+++ b/plugins/tauri-plugin-recording/src/desktop.rs
@@ -28,6 +28,10 @@ impl<R: Runtime> Recording<R> {
         Err(crate::Error::UnsupportedPlatform)
     }
 
+    pub fn recording_status(&self) -> crate::Result<RecordingStatusResponse> {
+        Err(crate::Error::UnsupportedPlatform)
+    }
+
     pub fn list_staged(&self) -> crate::Result<ListStagedResponse> {
         Err(crate::Error::UnsupportedPlatform)
     }

--- a/plugins/tauri-plugin-recording/src/desktop.rs
+++ b/plugins/tauri-plugin-recording/src/desktop.rs
@@ -1,0 +1,42 @@
+use serde::de::DeserializeOwned;
+use tauri::{plugin::PluginApi, AppHandle, Runtime};
+
+use crate::models::*;
+
+pub fn init<R: Runtime, C: DeserializeOwned>(
+    app: &AppHandle<R>,
+    _api: PluginApi<R, C>,
+) -> crate::Result<Recording<R>> {
+    Ok(Recording(app.clone()))
+}
+
+/// Desktop stand-in: desktop records through the webview's MediaRecorder
+/// (`use-audio-recorder.ts`), so every native-recorder call here is a plain
+/// unsupported error — loud, because nothing on desktop should reach it.
+pub struct Recording<R: Runtime>(AppHandle<R>);
+
+impl<R: Runtime> Recording<R> {
+    pub fn start_recording(&self, _request: StartRequest) -> crate::Result<()> {
+        Err(crate::Error::UnsupportedPlatform)
+    }
+
+    pub fn stop_recording(&self) -> crate::Result<StopResponse> {
+        Err(crate::Error::UnsupportedPlatform)
+    }
+
+    pub fn cancel_recording(&self) -> crate::Result<()> {
+        Err(crate::Error::UnsupportedPlatform)
+    }
+
+    pub fn list_staged(&self) -> crate::Result<ListStagedResponse> {
+        Err(crate::Error::UnsupportedPlatform)
+    }
+
+    pub fn read_staged(&self, _request: StagedPathRequest) -> crate::Result<ReadStagedResponse> {
+        Err(crate::Error::UnsupportedPlatform)
+    }
+
+    pub fn delete_staged(&self, _request: StagedPathRequest) -> crate::Result<()> {
+        Err(crate::Error::UnsupportedPlatform)
+    }
+}

--- a/plugins/tauri-plugin-recording/src/error.rs
+++ b/plugins/tauri-plugin-recording/src/error.rs
@@ -1,0 +1,25 @@
+use serde::{ser::Serializer, Serialize};
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    /// The desktop stand-in: recording is a native mobile capability, and the
+    /// desktop app records through the webview's MediaRecorder instead.
+    #[error("audio recording is not supported on this platform")]
+    UnsupportedPlatform,
+    #[cfg(mobile)]
+    #[error(transparent)]
+    PluginInvoke(#[from] tauri::plugin::mobile::PluginInvokeError),
+}
+
+impl Serialize for Error {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.to_string().as_ref())
+    }
+}

--- a/plugins/tauri-plugin-recording/src/lib.rs
+++ b/plugins/tauri-plugin-recording/src/lib.rs
@@ -1,0 +1,56 @@
+use tauri::{
+    plugin::{Builder, TauriPlugin},
+    Manager, Runtime,
+};
+
+pub use models::*;
+
+#[cfg(desktop)]
+mod desktop;
+#[cfg(mobile)]
+mod mobile;
+
+mod commands;
+mod error;
+mod models;
+
+pub use error::{Error, Result};
+
+#[cfg(desktop)]
+use desktop::Recording;
+#[cfg(mobile)]
+use mobile::Recording;
+
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`] and [`tauri::Window`] to
+/// access the recording APIs.
+pub trait RecordingExt<R: Runtime> {
+    fn recording(&self) -> &Recording<R>;
+}
+
+impl<R: Runtime, T: Manager<R>> crate::RecordingExt<R> for T {
+    fn recording(&self) -> &Recording<R> {
+        self.state::<Recording<R>>().inner()
+    }
+}
+
+/// Initializes the plugin.
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    Builder::new("recording")
+        .invoke_handler(tauri::generate_handler![
+            commands::start_recording,
+            commands::stop_recording,
+            commands::cancel_recording,
+            commands::list_staged,
+            commands::read_staged,
+            commands::delete_staged,
+        ])
+        .setup(|app, api| {
+            #[cfg(mobile)]
+            let recording = mobile::init(app, api)?;
+            #[cfg(desktop)]
+            let recording = desktop::init(app, api)?;
+            app.manage(recording);
+            Ok(())
+        })
+        .build()
+}

--- a/plugins/tauri-plugin-recording/src/lib.rs
+++ b/plugins/tauri-plugin-recording/src/lib.rs
@@ -41,6 +41,8 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             commands::stop_recording,
             commands::cancel_recording,
             commands::recording_status,
+            commands::actions_ready,
+            commands::action_performed,
             commands::list_staged,
             commands::read_staged,
             commands::delete_staged,

--- a/plugins/tauri-plugin-recording/src/lib.rs
+++ b/plugins/tauri-plugin-recording/src/lib.rs
@@ -40,6 +40,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             commands::start_recording,
             commands::stop_recording,
             commands::cancel_recording,
+            commands::recording_status,
             commands::list_staged,
             commands::read_staged,
             commands::delete_staged,

--- a/plugins/tauri-plugin-recording/src/mobile.rs
+++ b/plugins/tauri-plugin-recording/src/mobile.rs
@@ -51,6 +51,35 @@ impl<R: Runtime> Recording<R> {
             .map_err(Into::into)
     }
 
+    /// The webview's action surface is listening — deliver queued actions.
+    pub fn actions_ready(&self) -> crate::Result<()> {
+        self.0
+            .run_mobile_plugin("actionsReady", ())
+            .map_err(Into::into)
+    }
+
+    /// Retire the delivered action so it doesn't re-fire on the next launch.
+    pub fn action_performed(&self) -> crate::Result<()> {
+        self.0
+            .run_mobile_plugin("actionPerformed", ())
+            .map_err(Into::into)
+    }
+
+    /// Queue a native action for the webview (see the handshake in
+    /// `RecordingPlugin.swift`): persisted until the webview confirms it ran,
+    /// so it survives crashes and cold starts. The Rust shell calls this when
+    /// a `reflect://record-audio` URL opens the app (the lock-screen widget).
+    pub fn queue_action(&self, action: &str) -> crate::Result<()> {
+        self.0
+            .run_mobile_plugin(
+                "queueAction",
+                QueueActionRequest {
+                    action: action.to_string(),
+                },
+            )
+            .map_err(Into::into)
+    }
+
     /// Whether a native recording is live right now — a fresh webview mount
     /// uses this to stop-and-save a recording that outlived its UI.
     pub fn recording_status(&self) -> crate::Result<RecordingStatusResponse> {

--- a/plugins/tauri-plugin-recording/src/mobile.rs
+++ b/plugins/tauri-plugin-recording/src/mobile.rs
@@ -51,6 +51,14 @@ impl<R: Runtime> Recording<R> {
             .map_err(Into::into)
     }
 
+    /// Whether a native recording is live right now — a fresh webview mount
+    /// uses this to stop-and-save a recording that outlived its UI.
+    pub fn recording_status(&self) -> crate::Result<RecordingStatusResponse> {
+        self.0
+            .run_mobile_plugin("recordingStatus", ())
+            .map_err(Into::into)
+    }
+
     /// Finished recordings still in staging (crash orphans, files mid-ingest).
     pub fn list_staged(&self) -> crate::Result<ListStagedResponse> {
         self.0

--- a/plugins/tauri-plugin-recording/src/mobile.rs
+++ b/plugins/tauri-plugin-recording/src/mobile.rs
@@ -1,0 +1,74 @@
+use serde::de::DeserializeOwned;
+use tauri::{
+    plugin::{PluginApi, PluginHandle},
+    AppHandle, Runtime,
+};
+
+use crate::models::*;
+
+#[cfg(target_os = "ios")]
+tauri::ios_plugin_binding!(init_plugin_recording);
+
+/// Registers the native half. Android is a fast-follow like the keyboard
+/// plugin (Plan 19 step 12): the Kotlin class does not exist yet, so an
+/// Android build fails here loudly instead of shipping a silently
+/// non-recording bridge.
+pub fn init<R: Runtime, C: DeserializeOwned>(
+    _app: &AppHandle<R>,
+    api: PluginApi<R, C>,
+) -> crate::Result<Recording<R>> {
+    #[cfg(target_os = "android")]
+    compile_error!("tauri-plugin-recording has no Android implementation yet");
+    #[cfg(target_os = "ios")]
+    let handle = api.register_ios_plugin(init_plugin_recording)?;
+    Ok(Recording(handle))
+}
+
+/// Access to the native recorder. Live metering and native-initiated stops
+/// arrive on the plugin's `recordingLevel` / `recordingStopped` events.
+pub struct Recording<R: Runtime>(PluginHandle<R>);
+
+impl<R: Runtime> Recording<R> {
+    /// Ask for the microphone (prompting if needed) and start recording into
+    /// the staging directory. Resolves once the recorder is live.
+    pub fn start_recording(&self, request: StartRequest) -> crate::Result<()> {
+        self.0
+            .run_mobile_plugin("startRecording", request)
+            .map_err(Into::into)
+    }
+
+    /// Stop the active recording and return its staged file.
+    pub fn stop_recording(&self) -> crate::Result<StopResponse> {
+        self.0
+            .run_mobile_plugin("stopRecording", ())
+            .map_err(Into::into)
+    }
+
+    /// Stop the active recording and delete its file.
+    pub fn cancel_recording(&self) -> crate::Result<()> {
+        self.0
+            .run_mobile_plugin("cancelRecording", ())
+            .map_err(Into::into)
+    }
+
+    /// Finished recordings still in staging (crash orphans, files mid-ingest).
+    pub fn list_staged(&self) -> crate::Result<ListStagedResponse> {
+        self.0
+            .run_mobile_plugin("listStaged", ())
+            .map_err(Into::into)
+    }
+
+    /// A staged file's bytes, base64-encoded.
+    pub fn read_staged(&self, request: StagedPathRequest) -> crate::Result<ReadStagedResponse> {
+        self.0
+            .run_mobile_plugin("readStaged", request)
+            .map_err(Into::into)
+    }
+
+    /// Remove a staged file — called after its bytes landed in the graph.
+    pub fn delete_staged(&self, request: StagedPathRequest) -> crate::Result<()> {
+        self.0
+            .run_mobile_plugin("deleteStaged", request)
+            .map_err(Into::into)
+    }
+}

--- a/plugins/tauri-plugin-recording/src/models.rs
+++ b/plugins/tauri-plugin-recording/src/models.rs
@@ -18,6 +18,14 @@ pub struct StopResponse {
     pub duration_ms: f64,
 }
 
+/// `recording_status`'s response — whether a native recording is live.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecordingStatusResponse {
+    pub recording: bool,
+    pub elapsed_ms: f64,
+}
+
 /// One file in the staging directory — a recording not yet moved into the
 /// graph (an orphan from a crash, or one mid-ingest).
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/plugins/tauri-plugin-recording/src/models.rs
+++ b/plugins/tauri-plugin-recording/src/models.rs
@@ -18,6 +18,15 @@ pub struct StopResponse {
     pub duration_ms: f64,
 }
 
+/// A native action to queue for the webview (the V1 handshake). Sent by the
+/// Rust shell when an OS entry point arrives as a URL open.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueueActionRequest {
+    /// Currently only `recordAudio`.
+    pub action: String,
+}
+
 /// `recording_status`'s response — whether a native recording is live.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/plugins/tauri-plugin-recording/src/models.rs
+++ b/plugins/tauri-plugin-recording/src/models.rs
@@ -1,0 +1,51 @@
+use serde::{Deserialize, Serialize};
+
+/// Options for `start_recording`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartRequest {
+    /// Auto-stop cap in milliseconds; the native recorder enforces it even if
+    /// the webview never wakes to ask for a stop.
+    pub max_duration_ms: f64,
+}
+
+/// A finished recording, still in the plugin's staging directory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StopResponse {
+    /// Absolute path of the staged `.m4a`.
+    pub path: String,
+    pub duration_ms: f64,
+}
+
+/// One file in the staging directory — a recording not yet moved into the
+/// graph (an orphan from a crash, or one mid-ingest).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StagedFile {
+    /// Absolute path of the staged `.m4a`.
+    pub path: String,
+    /// Modification time in epoch milliseconds — the recording's stop time.
+    pub modified_ms: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListStagedResponse {
+    pub files: Vec<StagedFile>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReadStagedResponse {
+    /// The staged file's bytes, base64-encoded.
+    pub base64: String,
+}
+
+/// Path argument for `read_staged` / `delete_staged`. The native side rejects
+/// paths outside its staging directory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StagedPathRequest {
+    pub path: String,
+}

--- a/plugins/tauri-plugin-recording/src/models.rs
+++ b/plugins/tauri-plugin-recording/src/models.rs
@@ -15,7 +15,13 @@ pub struct StartRequest {
 pub struct StopResponse {
     /// Absolute path of the staged `.m4a`.
     pub path: String,
+    /// Recorded length in milliseconds.
     pub duration_ms: f64,
+    /// The staged file's modification time in epoch milliseconds — its stop
+    /// time, used as the memo's identity timestamp so that re-ingesting the
+    /// same file (after a failed delete) resolves to the same memo basename.
+    /// Matches what `list_staged` reports for the same file.
+    pub modified_ms: f64,
 }
 
 /// A native action to queue for the webview (the V1 handshake). Sent by the
@@ -31,7 +37,9 @@ pub struct QueueActionRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RecordingStatusResponse {
+    /// True while a recording is in progress.
     pub recording: bool,
+    /// Recorded length so far in milliseconds (0 when not recording).
     pub elapsed_ms: f64,
 }
 
@@ -46,12 +54,15 @@ pub struct StagedFile {
     pub modified_ms: f64,
 }
 
+/// `list_staged`'s response — every finished recording still in staging.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ListStagedResponse {
+    /// Staged recordings, in no guaranteed order.
     pub files: Vec<StagedFile>,
 }
 
+/// `read_staged`'s response — a staged recording's bytes.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReadStagedResponse {
@@ -64,5 +75,6 @@ pub struct ReadStagedResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StagedPathRequest {
+    /// Absolute path of the staged file, as returned by a stop or `list_staged`.
     pub path: String,
 }


### PR DESCRIPTION
## What

Voice capture on iOS, reusing the shipped desktop audio-memo pipeline end to end. Tap the mic FAB (or the lock-screen widget, or ask Siri), speak, stop — the recording lands durably in the graph's `audio-memos/`, the existing BYOK reconciler transcribes it (OpenAI/Gemini), and the transcript note + daily-note backlink appear exactly as on desktop. Ships all three waves: in-app native recording, reliability hardening, and the OS entry points.

## Why native recording

The V1 mobile lesson (docs/porting/reflect-mobile/audio-memos.md): **critical capture must not depend on the webview being alive.** Webview `MediaRecorder` dies on backgrounding and has no interruption handling; Tauri's iOS WKWebView also has no media-permission plumbing wired up. So recording runs on `AVAudioRecorder` behind a new first-party plugin, and everything after "file exists in `audio-memos/`" is the untouched platform-neutral core.

## Wave 1 — in-app recording

- **`plugins/tauri-plugin-recording`** (keyboard-plugin pattern): AAC mono 44.1 kHz `.m4a` into a native staging directory. Interruptions (calls/Siri), input-route loss, and a native 10-minute cap finalize the file without JS and announce it on a `recordingStopped` event; 10 Hz metering feeds the live waveform. Staged-path commands refuse paths outside the staging dir.
- **Shared pipeline extraction**: the serial capture queue (pump/park/retry/discard) and the transcription-reconciler lifecycle moved from `AudioMemoProvider` into `use-audio-memo-pipeline.ts`; the desktop provider keeps its exact surface (its 22 tests pass unchanged).
- **`MobileAudioMemoProvider`**: staged recordings ingest through `captureAudioMemo`/`writeAsset` so mobile's in-process write echo, indexing, and sync dirty-mark fire for free. Staged copies are deleted only after the graph write succeeds; an **orphan scan** on launch/foreground recovers recordings whose stop the webview never saw, idempotent by stop-time identity, with a claim registry against double-ingest.
- **UI**: mic FAB on the daily screen; vaul recording drawer (level waveform, elapsed, stop). Dismissing the drawer stops-and-saves; Cancel is the explicit discard. Failures park behind Retry/Discard and toast when the drawer is closed.
- `background-reconciler` also retries on `visibilitychange` → visible (the reliable iOS foreground signal).

## Wave 2 — reliability hardening

- **`UIBackgroundModes: audio`** (spec-driven in `ios.project.yml` + gen twins): a memo keeps recording through screen lock and backgrounding. The audio session is active only while a recording is live; level events pause while backgrounded instead of piling into a suspended webview.
- **Webview-death reconcile**: `recording_status` + a mount-time check — a native recording that outlived its JS is stopped and saved, never left as a hidden hot microphone.

## Wave 3 — OS entry points

- **Native-action handshake** in the plugin, per docs/porting/reflect-mobile/native-entry-points.md: entry points persist a `recordAudio` request; the provider claims it (`actions_ready`) once it can present recording UI and confirms (`action_performed`) only after the UI survived 2s — an unconfirmed action re-fires next launch (age-gated to 15 minutes so a stale request never surprises with a hot microphone), never double-run.
- **Siri App Intents** ("Start/Stop recording in Reflect"): in-process `AppIntent`s in the app target, reaching the plugin via NotificationCenter across the module boundary. Stop finalizes natively without the webview.
- **Home-screen quick action**: static shortcut item + a `performActionForShortcutItem` handler the plugin adds to tao's app delegate (guarded; degrades to just opening the app).
- **Lock-screen/home-screen record widget + recording Live Activity**: a new `RecordingWidget` appex (spec-driven target, regenerated pbxproj, ShareExtension's skip-codesign ad-hoc signing + App Group entitlement — the release pipeline asserts every appex carries it). The widget opens `reflect://record-audio`; the Rust shell (`RunEvent::Opened`) queues it natively. The iOS Info.plist registers the `reflect` scheme for exactly this one mobile verb (documented in docs/deep-links.md). The Live Activity shows a self-updating timer and an iOS 17 stop button via a shared `LiveActivityIntent`.

## Privacy

Same stance as desktop (docs/privacy.md): only raw audio bytes go to the provider — never note content — so recording works even when today's note is `private: true`. The stricter inbox-boundary language in the grounding brief turned out not to apply: recording always happens in the main app process (widgets can't record), so no extension ever writes audio.

## Testing

- 390 tests green: native recorder hook (8), mobile provider (16, incl. background/orphan/reconcile/handshake paths), FAB (4); desktop provider suite unchanged; background-reconciler visibilitychange case.
- `pnpm check` clean; `cargo check` passes for macOS **and** `aarch64-apple-ios` (compiles the Swift plugin via swift-rs and the `#[cfg(mobile)]` registration + `RunEvent::Opened` path).
- **The `RecordingWidget` appex builds standalone** (`xcodebuild -target RecordingWidget -sdk iphonesimulator`), including App Intents metadata extraction; app-target intent files typecheck at the iOS 14 deployment floor.
- **Not done: simulator/device pass.** Mic permission, phone-call interruption, screen-lock continuation, kill-while-recording → orphan ingest, widget tap, Siri phrases, Live Activity stop, and TestFlight signing of the new appex all need real hardware/CI. This is the release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native audio memo recording on mobile, including a floating capture button, a bottom recording drawer, live level waveform, elapsed timer, and retry/discard on failure.
  * Added a mobile deep-link entry point to start audio recording.
  * Audio recording can continue while the app is backgrounded on iOS.

* **Bug Fixes**
  * Improved recovery when returning to the foreground by listening for visibility changes to resume reliably.
  * Reduced duplicate or missed audio memo ingestion after restarts and interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large cross-cutting change (new native plugin, Xcode extension, microphone/background audio, and graph capture) with many failure modes; physical-device validation is still called out as owed in the PR description.
> 
> **Overview**
> Adds **iOS native audio memos** so capture does not depend on the webview: a new **`tauri-plugin-recording`** workspace member (mobile-only registration + `recording:default` capability) drives **AVAudioRecorder** staging, metering events, and a persisted **`recordAudio` action queue**.
> 
> **Shared frontend pipeline:** capture queue, reconciler lifecycle, and retry/discard behavior move into **`use-audio-memo-pipeline`**. Desktop **`AudioMemoProvider`** keeps MediaRecorder UI but delegates to the hook; **`MobileAudioMemoProvider`** wires the native recorder, orphan staged-file ingest on launch/foreground, and the **`actions_ready` / `action_performed`** handshake. UI adds a daily **mic FAB**, **recording drawer**, and level waveform. **`transcription-reconciler`** also schedules on **`visibilitychange`** when visible (iOS foreground).
> 
> **iOS shell (waves 2–3):** **`UIBackgroundModes: audio`**, **`reflect://record-audio`** (Rust **`RunEvent::Opened`** queues into the plugin), Live Activities, home-screen quick action, embedded **`RecordingWidget`** appex (record widget + recording Live Activity, App Group entitlements), and **Siri / Live Activity stop** intents via NotificationCenter into the plugin.
> 
> **Docs** update mobile audio-memo and deep-link status; **`base64ToBytes`** is exported from core for staged readback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9965606c49b4894df8cec9b2a4f02bc66ef5f427. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

