### PR TITLE
Fix ISO dates wrapping in All Notes

### DIFF
--- a/apps/desktop/src/components/all-notes/all-notes-row.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-row.tsx
@@ -10,7 +10,7 @@ import { useSettings } from '@/providers/settings-provider'
  * The selection indicator is positioned beside the row, outside the column flow.
  */
 export const ALL_NOTES_GRID =
-  'grid grid-cols-[minmax(0,15rem)_minmax(0,1fr)_minmax(0,8rem)_5rem] items-center gap-4 pl-12 pr-7'
+  'grid grid-cols-[minmax(0,15rem)_minmax(0,1fr)_minmax(0,8rem)_6rem] items-center gap-4 pl-12 pr-7'
 
 interface AllNotesRowProps {
   note: NoteListEntry
@@ -90,7 +90,7 @@ export const AllNotesRow = memo(function AllNotesRow({ note, selected, onSelect,
       <span className="truncate text-right text-[13px] text-text-secondary">
         {note.tags.map((tag) => `#${tag}`).join(' ')}
       </span>
-      <span className="text-right text-[13px] tabular-nums text-text-secondary">
+      <span className="whitespace-nowrap text-right text-[13px] tabular-nums text-text-secondary">
         {note.mtime > 0 ? formatRecencyLabel(note.mtime, settings) : '—'}
       </span>
     </div>

--- a/apps/desktop/src/components/all-notes/all-notes-screen.test.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.test.tsx
@@ -15,6 +15,10 @@ import { AllNotesScreen } from './all-notes-screen'
  * query, and navigation through the real router.
  */
 
+const settingsState = vi.hoisted((): { dateFormat: 'mdy' | 'dmy' | 'iso' } => ({
+  dateFormat: 'mdy',
+}))
+
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({
     graph: { root: '/g', name: 'g', generation: 1 },
@@ -27,7 +31,7 @@ vi.mock('@/providers/settings-provider', () => ({
       editorMarkdownSyntax: 'hide',
       theme: 'system',
       timeFormat: '12h',
-      dateFormat: 'mdy',
+      dateFormat: settingsState.dateFormat,
       allNotesFilterTags: ['book', 'person'],
     },
     updateSettings: () => {},
@@ -76,6 +80,7 @@ setBridge({ invoke: mockInvoke, listen: async () => () => {} })
 
 beforeEach(() => {
   resetOperations()
+  settingsState.dateFormat = 'mdy'
   mockInvoke.mockReset()
   mockInvoke.mockImplementation(async (command, args) => {
     if (command !== 'db_query') {
@@ -162,6 +167,18 @@ describe('AllNotesScreen', () => {
     expect(view.getAllByText('#link')).toHaveLength(2)
     expect(view.getByText('1/15/2020')).toBeDefined()
     expect(view.getByText('1/10/2020')).toBeDefined()
+    view.unmount()
+  })
+
+  it('keeps ISO updated dates on one line', async () => {
+    settingsState.dateFormat = 'iso'
+    const view = renderScreen()
+
+    const updated = await view.findByText('2020-01-15')
+    expect(updated.className).toContain('whitespace-nowrap')
+    expect(updated.parentElement?.className ?? '').toContain(
+      'grid-cols-[minmax(0,15rem)_minmax(0,1fr)_minmax(0,8rem)_6rem]',
+    )
     view.unmount()
   })
 


### PR DESCRIPTION
## Problem

When the date format preference is set to ISO, the All Notes `Updated` column can wrap dates like `2020-01-15` onto two lines because the column was narrow and the cell allowed normal hyphen wrapping. That makes the fixed-height table row look broken even though the underlying date formatting is correct.

## Before -> After

| Before | After |
| --- | --- |
| ISO `Updated` labels could break across two lines at hyphens. | ISO `Updated` labels render as a single non-wrapping tabular date. |

## Changes

1. Widen the shared All Notes table `Updated` column from `5rem` to `6rem`, keeping the header and rows aligned through `ALL_NOTES_GRID`.
2. Add `whitespace-nowrap` to the row's `Updated` cell so ISO dates do not split at hyphens.
3. Make the All Notes screen test settings mock date-format-aware and add an ISO regression assertion for the non-wrapping date cell and updated grid width.

## Verification

- `pnpm --filter @reflect/desktop test src/components/all-notes/all-notes-screen.test.tsx` passed.
- `pnpm check` passed. Oxlint still reports the existing `packages/core/src/indexing/indexer.ts` max-lines warning.

## Risk / Rollout

Low-risk desktop UI layout change. No data migration, persistence change, or external integration impact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop-only CSS grid and typography tweaks in the All Notes table; no data, API, or persistence changes.
> 
> **Overview**
> Fixes **All Notes** rows breaking when **Updated** is shown in ISO format (`2020-01-15`), where hyphens could wrap across lines inside the fixed-height row.
> 
> The shared `ALL_NOTES_GRID` template widens the **Updated** column from `5rem` to `6rem` (header and rows stay aligned). The row’s **Updated** cell adds `whitespace-nowrap` so ISO labels stay on one line.
> 
> Tests make the settings mock respect `dateFormat` and add an ISO regression that asserts the non-wrapping class and the `6rem` grid column.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48244eb03f2c28a2882bfb40624510bf8a166bc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->