### PR TITLE
docs: troubleshoot new-appex bundle ID registration for TestFlight CI

### DIFF
--- a/docs/ios-testflight.md
+++ b/docs/ios-testflight.md
@@ -145,6 +145,24 @@ workflow.
   bundle id exists for signing, but no App Store Connect app record exists yet.
   Create a new iOS app in App Store Connect for `app.reflect.ios`; do not reuse
   the old Capacitor app record (`app.reflect.ReflectMobile`).
+- **`Automatic signing cannot register bundle identifier "app.reflect.ios.<ext>"`**
+  (with **`No profiles for 'app.reflect.ios.<ext>' were found`**): a NEW app
+  extension target (ShareExtension, RecordingWidget, …) is shipping for the
+  first time and its bundle identifier does not exist on the developer portal
+  yet. The CI App Store Connect key can create provisioning profiles for
+  *existing* identifiers but cannot *register* new ones. Register it once from
+  a machine whose Xcode is signed into the team — a signed build of just that
+  target auto-registers the identifier and its capabilities (App Group
+  included):
+
+  ```bash
+  cd apps/desktop/src-tauri/gen/apple
+  xcodebuild -project reflect-open.xcodeproj -target <NewExtension> \
+    -sdk iphoneos -configuration release -allowProvisioningUpdates build
+  ```
+
+  Then rerun the TestFlight workflow. (Registering the identifier by hand in
+  the developer portal — with its App Groups capability — works too.)
 - **Duplicate build number**: rerun the GitHub Action so it stamps a fresh
   timestamp. For local debugging commands, pass a larger `--build-number`.
   TestFlight build numbers are per marketing version; `0.4.0` build `123` can


### PR DESCRIPTION
## What

Adds a Troubleshooting entry to `docs/ios-testflight.md` for a CI TestFlight failure hit while shipping audio memos wave 3.

## Why

The `RecordingWidget` appex (new in #642) failed its first CI TestFlight upload with:

```
error: exportArchive Automatic signing cannot register bundle identifier "app.reflect.ios.widgets".
error: exportArchive No profiles for 'app.reflect.ios.widgets' were found
```

Root cause: the archive itself built fine (all three targets compiled and linked), but `xcodebuild -exportArchive` with cloud automatic signing failed because the CI App Store Connect API key can provision *existing* bundle identifiers but cannot *register new ones* on the developer portal. `app.reflect.ios` and `app.reflect.ios.share` already existed there from earlier local Xcode builds; the widget's identifier never had a local signed build to register it.

Fix (already applied out-of-band): one local signed build of just the new target with `-allowProvisioningUpdates`, using a team-signed-in Xcode session, auto-registered the identifier and its capabilities (App Group included). The TestFlight rerun after that [succeeded](https://github.com/team-reflect/reflect-open/actions/runs/28902928623).

This PR only documents the failure mode and the fix so the next new extension target (a future widget/intents appex) doesn't require re-discovering this.

## Testing

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, signing, or CI behavior changes.
> 
> **Overview**
> Adds a **Troubleshooting** entry in `docs/ios-testflight.md` for CI `exportArchive` failures when a **new app extension** (e.g. `ShareExtension`, `RecordingWidget`) ships with a bundle ID like `app.reflect.ios.<ext>` that is not yet on the Apple Developer portal.
> 
> The doc explains that the App Store Connect API key used in CI can provision **existing** identifiers but cannot **register** new ones, and gives a one-time fix: a local team-signed `xcodebuild` of just the new target with `-allowProvisioningUpdates`, plus an optional manual portal registration note, then rerun TestFlight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de36771ca4eeca64621afeda22177a9cf1f7e9ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added TestFlight troubleshooting guidance for iOS extension signing issues.
  * Included steps for handling first-time bundle identifier registration problems and a manual provisioning command.
  * Added instructions to rerun the workflow after provisioning is completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
