### PR TITLE
Clarify iOS onboarding around iCloud sync

### DIFF
--- a/apps/desktop/src/mobile/onboarding-icloud-header.tsx
+++ b/apps/desktop/src/mobile/onboarding-icloud-header.tsx
@@ -1,0 +1,27 @@
+import { type ReactElement } from 'react'
+import { Cloud } from 'lucide-react'
+
+interface OnboardingIcloudHeaderProps {
+  description: string
+}
+
+export function OnboardingIcloudHeader({
+  description,
+}: OnboardingIcloudHeaderProps): ReactElement {
+  return (
+    <div className="flex items-start gap-3">
+      <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+        <Cloud aria-hidden className="size-4" strokeWidth={1.75} />
+      </div>
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-semibold">iCloud sync</h2>
+          <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary">
+            Recommended
+          </span>
+        </div>
+        <p className="text-xs text-text-muted">{description}</p>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/mobile/onboarding-icloud-section.tsx
+++ b/apps/desktop/src/mobile/onboarding-icloud-section.tsx
@@ -5,6 +5,8 @@ import { Input } from '@/components/ui/input'
 import { Spinner } from '@/components/ui/spinner'
 import { cleanGraphName, graphNameFromRoot, graphRootForName, isGraphNameTaken } from '@/lib/graph-names'
 
+const DEFAULT_ICLOUD_NOTES_NAME = 'Notes'
+
 interface OnboardingIcloudSectionProps {
   /** The container is still resolving — render the pending row, not the form. */
   pending: boolean
@@ -34,12 +36,16 @@ export function OnboardingIcloudSection(props: OnboardingIcloudSectionProps): Re
   const [typedName, setTypedName] = useState<string | null>(null)
   const nameId = useId()
 
-  // "Notes" pre-fills only a fresh container. Next to an existing list the
-  // row starts empty — a prefilled default would collide with the usual
-  // first graph ("Notes") and paint the screen invalid before any input.
-  const name = typedName ?? (graphs.length > 0 ? '' : 'Notes')
+  const name = typedName ?? ''
   const cleanName = cleanGraphName(name)
   const nameTaken = cleanName !== null && isGraphNameTaken(cleanName, graphs)
+
+  function createDefault(): void {
+    if (documentsRoot === null) {
+      return
+    }
+    onCreate(graphRootForName(documentsRoot, DEFAULT_ICLOUD_NOTES_NAME))
+  }
 
   function create(): void {
     if (documentsRoot === null || cleanName === null || nameTaken) {
@@ -49,22 +55,22 @@ export function OnboardingIcloudSection(props: OnboardingIcloudSectionProps): Re
   }
 
   return (
-    <section className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-4">
+    <section className="flex flex-col gap-4 rounded-lg border border-primary/20 bg-surface p-4">
       <div className="flex items-start gap-3">
         <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
           <Cloud aria-hidden className="size-4" strokeWidth={1.75} />
         </div>
         <div className="min-w-0 flex-1 space-y-1">
           <div className="flex items-center gap-2">
-            <h2 className="text-sm font-semibold">iCloud Drive</h2>
-            <span className="rounded-full bg-secondary px-2 py-0.5 text-[11px] font-medium text-secondary-foreground">
+            <h2 className="text-sm font-semibold">iCloud sync</h2>
+            <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary">
               Recommended
             </span>
           </div>
           <p className="text-xs text-text-muted">
             {graphs.length > 0
-              ? 'Open an existing graph from iCloud Drive.'
-              : 'Syncs with Reflect on your other devices.'}
+              ? 'We found notes in iCloud Drive. Continue with one, or start fresh.'
+              : 'Recommended for most people. Your notes sync through iCloud Drive and stay available offline.'}
           </p>
         </div>
       </div>
@@ -72,7 +78,7 @@ export function OnboardingIcloudSection(props: OnboardingIcloudSectionProps): Re
       {pending ? (
         <div className="flex items-center gap-2 text-xs text-text-muted">
           <Spinner />
-          Looking for your notes…
+          Checking iCloud Drive…
         </div>
       ) : (
         <>
@@ -83,7 +89,7 @@ export function OnboardingIcloudSection(props: OnboardingIcloudSectionProps): Re
                   <Button
                     type="button"
                     variant="outline"
-                    className="w-full justify-start"
+                    className="w-full justify-start text-left"
                     onClick={() => onOpen(root)}
                     disabled={busy}
                   >
@@ -92,52 +98,70 @@ export function OnboardingIcloudSection(props: OnboardingIcloudSectionProps): Re
                     ) : (
                       <FolderOpen aria-hidden strokeWidth={1.75} />
                     )}
-                    <span className="truncate">{graphNameFromRoot(root, root)}</span>
+                    <span className="truncate">Continue with {graphNameFromRoot(root, root)}</span>
                   </Button>
                 </li>
               ))}
             </ul>
-          ) : null}
+          ) : (
+            <Button
+              type="button"
+              className="w-full justify-start text-left"
+              onClick={createDefault}
+              disabled={busy || documentsRoot === null}
+            >
+              {pendingChoice === 'icloud-create' ? (
+                <Spinner />
+              ) : (
+                <Cloud aria-hidden strokeWidth={1.75} />
+              )}
+              {pendingChoice === 'icloud-create' ? 'Setting up…' : 'Continue with iCloud'}
+            </Button>
+          )}
 
-          <div className="space-y-2">
-            {graphs.length > 0 ? <MobileDivider>or create new graph</MobileDivider> : null}
-            <div className="flex flex-col gap-1.5">
-              <label htmlFor={nameId} className="text-xs font-medium text-text-secondary">
-                Name
-              </label>
-              <div className="flex gap-2">
-                <Input
-                  id={nameId}
-                  value={name}
-                  placeholder={graphs.length > 0 ? 'New name' : undefined}
-                  enterKeyHint="go"
-                  onChange={(event) => setTypedName(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (event.key === 'Enter') {
-                      create()
-                    }
-                  }}
-                  aria-invalid={nameTaken}
-                  disabled={busy}
-                />
-                <Button
-                  type="button"
-                  className="shrink-0"
-                  onClick={create}
-                  disabled={busy || cleanName === null || nameTaken}
-                >
-                  {pendingChoice === 'icloud-create' ? (
-                    <Spinner />
-                  ) : (
-                    <Plus aria-hidden strokeWidth={1.75} />
-                  )}
-                  {pendingChoice === 'icloud-create' ? 'Setting up…' : 'Create'}
-                </Button>
+          {graphs.length > 0 ? (
+            <div className="space-y-2">
+              <MobileDivider>Start fresh</MobileDivider>
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor={nameId} className="text-xs font-medium text-text-secondary">
+                  Name
+                </label>
+                <div className="flex gap-2">
+                  <Input
+                    id={nameId}
+                    value={name}
+                    placeholder="Personal notes"
+                    enterKeyHint="go"
+                    onChange={(event) => setTypedName(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') {
+                        create()
+                      }
+                    }}
+                    aria-invalid={nameTaken}
+                    disabled={busy}
+                  />
+                  <Button
+                    type="button"
+                    className="shrink-0"
+                    onClick={create}
+                    disabled={busy || cleanName === null || nameTaken}
+                  >
+                    {pendingChoice === 'icloud-create' ? (
+                      <Spinner />
+                    ) : (
+                      <Plus aria-hidden strokeWidth={1.75} />
+                    )}
+                    {pendingChoice === 'icloud-create' ? 'Setting up…' : 'Create in iCloud'}
+                  </Button>
+                </div>
               </div>
+              {nameTaken ? (
+                <p className="text-xs text-destructive">
+                  That name already exists in iCloud Drive.
+                </p>
+              ) : null}
             </div>
-          </div>
-          {nameTaken ? (
-            <p className="text-xs text-destructive">That name already exists in iCloud Drive.</p>
           ) : null}
         </>
       )}

--- a/apps/desktop/src/mobile/onboarding-icloud-section.tsx
+++ b/apps/desktop/src/mobile/onboarding-icloud-section.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Spinner } from '@/components/ui/spinner'
 import { cleanGraphName, graphNameFromRoot, graphRootForName, isGraphNameTaken } from '@/lib/graph-names'
+import { OnboardingIcloudHeader } from '@/mobile/onboarding-icloud-header'
 
 const DEFAULT_ICLOUD_NOTES_NAME = 'Notes'
 
@@ -54,26 +55,14 @@ export function OnboardingIcloudSection(props: OnboardingIcloudSectionProps): Re
     onCreate(graphRootForName(documentsRoot, cleanName))
   }
 
+  const description =
+    graphs.length > 0
+      ? 'We found notes in iCloud Drive. Continue with one, or start fresh.'
+      : 'Recommended for most people. Your notes sync through iCloud Drive and stay available offline.'
+
   return (
     <section className="flex flex-col gap-4 rounded-lg border border-primary/20 bg-surface p-4">
-      <div className="flex items-start gap-3">
-        <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-          <Cloud aria-hidden className="size-4" strokeWidth={1.75} />
-        </div>
-        <div className="min-w-0 flex-1 space-y-1">
-          <div className="flex items-center gap-2">
-            <h2 className="text-sm font-semibold">iCloud sync</h2>
-            <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary">
-              Recommended
-            </span>
-          </div>
-          <p className="text-xs text-text-muted">
-            {graphs.length > 0
-              ? 'We found notes in iCloud Drive. Continue with one, or start fresh.'
-              : 'Recommended for most people. Your notes sync through iCloud Drive and stay available offline.'}
-          </p>
-        </div>
-      </div>
+      <OnboardingIcloudHeader description={description} />
 
       {pending ? (
         <div className="flex items-center gap-2 text-xs text-text-muted">

--- a/apps/desktop/src/mobile/onboarding-icloud-section.tsx
+++ b/apps/desktop/src/mobile/onboarding-icloud-section.tsx
@@ -1,5 +1,5 @@
 import { useId, useState, type ReactElement } from 'react'
-import { Cloud, FolderOpen, Plus } from 'lucide-react'
+import { Cloud, FolderOpen } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Spinner } from '@/components/ui/spinner'
@@ -37,16 +37,12 @@ export function OnboardingIcloudSection(props: OnboardingIcloudSectionProps): Re
   const [typedName, setTypedName] = useState<string | null>(null)
   const nameId = useId()
 
-  const name = typedName ?? ''
+  // Fresh iCloud setup still needs a user-editable graph name; keep the
+  // friendly default, but only leave the field blank when creating alongside
+  // existing iCloud notes where "Notes" would usually collide.
+  const name = typedName ?? (graphs.length > 0 ? '' : DEFAULT_ICLOUD_NOTES_NAME)
   const cleanName = cleanGraphName(name)
   const nameTaken = cleanName !== null && isGraphNameTaken(cleanName, graphs)
-
-  function createDefault(): void {
-    if (documentsRoot === null) {
-      return
-    }
-    onCreate(graphRootForName(documentsRoot, DEFAULT_ICLOUD_NOTES_NAME))
-  }
 
   function create(): void {
     if (documentsRoot === null || cleanName === null || nameTaken) {
@@ -92,66 +88,48 @@ export function OnboardingIcloudSection(props: OnboardingIcloudSectionProps): Re
                 </li>
               ))}
             </ul>
-          ) : (
+          ) : null}
+
+          <div className="space-y-2">
+            {graphs.length > 0 ? <MobileDivider>Start fresh</MobileDivider> : null}
+            <div className="flex flex-col gap-1.5">
+              <label htmlFor={nameId} className="text-xs font-medium text-text-secondary">
+                Name
+              </label>
+              <Input
+                id={nameId}
+                value={name}
+                placeholder={graphs.length > 0 ? 'Personal notes' : undefined}
+                enterKeyHint="go"
+                onChange={(event) => setTypedName(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    create()
+                  }
+                }}
+                aria-invalid={nameTaken}
+                disabled={busy}
+              />
+            </div>
+            {nameTaken ? (
+              <p className="text-xs text-destructive">
+                That name already exists in iCloud Drive.
+              </p>
+            ) : null}
             <Button
               type="button"
               className="w-full justify-start text-left"
-              onClick={createDefault}
-              disabled={busy || documentsRoot === null}
+              onClick={create}
+              disabled={busy || cleanName === null || nameTaken || documentsRoot === null}
             >
               {pendingChoice === 'icloud-create' ? (
                 <Spinner />
               ) : (
                 <Cloud aria-hidden strokeWidth={1.75} />
               )}
-              {pendingChoice === 'icloud-create' ? 'Setting up…' : 'Continue with iCloud'}
+              {pendingChoice === 'icloud-create' ? 'Setting up…' : 'Start with iCloud'}
             </Button>
-          )}
-
-          {graphs.length > 0 ? (
-            <div className="space-y-2">
-              <MobileDivider>Start fresh</MobileDivider>
-              <div className="flex flex-col gap-1.5">
-                <label htmlFor={nameId} className="text-xs font-medium text-text-secondary">
-                  Name
-                </label>
-                <div className="flex gap-2">
-                  <Input
-                    id={nameId}
-                    value={name}
-                    placeholder="Personal notes"
-                    enterKeyHint="go"
-                    onChange={(event) => setTypedName(event.target.value)}
-                    onKeyDown={(event) => {
-                      if (event.key === 'Enter') {
-                        create()
-                      }
-                    }}
-                    aria-invalid={nameTaken}
-                    disabled={busy}
-                  />
-                  <Button
-                    type="button"
-                    className="shrink-0"
-                    onClick={create}
-                    disabled={busy || cleanName === null || nameTaken}
-                  >
-                    {pendingChoice === 'icloud-create' ? (
-                      <Spinner />
-                    ) : (
-                      <Plus aria-hidden strokeWidth={1.75} />
-                    )}
-                    {pendingChoice === 'icloud-create' ? 'Setting up…' : 'Create in iCloud'}
-                  </Button>
-                </div>
-              </div>
-              {nameTaken ? (
-                <p className="text-xs text-destructive">
-                  That name already exists in iCloud Drive.
-                </p>
-              ) : null}
-            </div>
-          ) : null}
+          </div>
         </>
       )}
     </section>

--- a/apps/desktop/src/mobile/onboarding-icloud-section.tsx
+++ b/apps/desktop/src/mobile/onboarding-icloud-section.tsx
@@ -94,7 +94,7 @@ export function OnboardingIcloudSection(props: OnboardingIcloudSectionProps): Re
             {graphs.length > 0 ? <MobileDivider>Start fresh</MobileDivider> : null}
             <div className="flex flex-col gap-1.5">
               <label htmlFor={nameId} className="text-xs font-medium text-text-secondary">
-                Name
+                Graph name
               </label>
               <Input
                 id={nameId}
@@ -127,7 +127,7 @@ export function OnboardingIcloudSection(props: OnboardingIcloudSectionProps): Re
               ) : (
                 <Cloud aria-hidden strokeWidth={1.75} />
               )}
-              {pendingChoice === 'icloud-create' ? 'Setting up…' : 'Start with iCloud'}
+              {pendingChoice === 'icloud-create' ? 'Setting up…' : 'Setup graph'}
             </Button>
           </div>
         </>

--- a/apps/desktop/src/mobile/onboarding-screen.test.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.test.tsx
@@ -33,16 +33,16 @@ afterEach(() => {
 })
 
 describe('MobileOnboardingScreen', () => {
-  it('leads with iCloud sync and creates the default iCloud notes', async () => {
+  it('leads with iCloud sync and creates the named iCloud notes', async () => {
     render(<MobileOnboardingScreen />)
 
     expect(screen.getByRole('heading', { name: 'iCloud sync' })).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Continue with iCloud' })).toBeTruthy()
-    expect(screen.queryByLabelText('Name')).toBeNull()
-    fireEvent.click(screen.getByRole('button', { name: 'Continue with iCloud' }))
+    expect(screen.getByLabelText('Name')).toHaveProperty('value', 'Notes')
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Journal' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Start with iCloud' }))
 
     await waitFor(() =>
-      expect(completeOnboarding).toHaveBeenCalledWith('icloud', '/iCloud/Documents/Notes'),
+      expect(completeOnboarding).toHaveBeenCalledWith('icloud', '/iCloud/Documents/Journal'),
     )
   })
 
@@ -58,7 +58,7 @@ describe('MobileOnboardingScreen', () => {
     expect(screen.getByText('Start fresh')).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Continue with Notes' })).toBeTruthy()
     expect(
-      (screen.getByRole('button', { name: 'Create in iCloud' }) as HTMLButtonElement).disabled,
+      (screen.getByRole('button', { name: 'Start with iCloud' }) as HTMLButtonElement).disabled,
     ).toBe(true)
     fireEvent.click(screen.getByRole('button', { name: 'Continue with Work' }))
 
@@ -76,24 +76,21 @@ describe('MobileOnboardingScreen', () => {
     render(<MobileOnboardingScreen />)
 
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Journal' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Create in iCloud' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Start with iCloud' }))
 
     await waitFor(() =>
       expect(completeOnboarding).toHaveBeenCalledWith('icloud', '/iCloud/Documents/Journal'),
     )
   })
 
-  it('chooses a folder on this device without cloning', async () => {
+  it('keeps the on-device choice as a quiet secondary path', async () => {
     render(<MobileOnboardingScreen />)
 
     expect(screen.queryByText(/Your notes are plain markdown files/i)).toBeNull()
-    expect(screen.getByRole('heading', { name: 'This device only' })).toBeTruthy()
     expect(
-      screen.getByText(
-        'Notes stay on this device and won’t sync through iCloud. You can add GitHub sync later from Settings.',
-      ),
+      screen.getByText('No iCloud sync. You can add GitHub later from Settings.'),
     ).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: 'Keep notes on this device' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Use this device only' }))
 
     await waitFor(() => expect(completeOnboarding).toHaveBeenCalledWith('local'))
   })
@@ -108,10 +105,10 @@ describe('MobileOnboardingScreen', () => {
 
     expect(screen.getByRole('heading', { name: 'iCloud sync' })).toBeTruthy()
     expect(screen.getByText('Checking iCloud Drive…')).toBeTruthy()
-    expect(screen.queryByRole('button', { name: 'Continue with iCloud' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Start with iCloud' })).toBeNull()
     expect(screen.queryByText(/Sign in to iCloud/)).toBeNull()
     // The on-device path stays live — its root is already known.
-    const local = screen.getByRole('button', { name: 'Keep notes on this device' })
+    const local = screen.getByRole('button', { name: 'Use this device only' })
     expect((local as HTMLButtonElement).disabled).toBe(false)
   })
 
@@ -126,8 +123,7 @@ describe('MobileOnboardingScreen', () => {
     expect(
       screen.getByText('Sign in to iCloud on this device, then reopen Reflect.'),
     ).toBeTruthy()
-    expect(screen.getByRole('heading', { name: 'This device only' })).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Keep notes on this device' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Use this device only' })).toBeTruthy()
   })
 
   it('does not offer repository setup from the first-run picker', () => {

--- a/apps/desktop/src/mobile/onboarding-screen.test.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.test.tsx
@@ -37,9 +37,9 @@ describe('MobileOnboardingScreen', () => {
     render(<MobileOnboardingScreen />)
 
     expect(screen.getByRole('heading', { name: 'iCloud sync' })).toBeTruthy()
-    expect(screen.getByLabelText('Name')).toHaveProperty('value', 'Notes')
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Journal' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Start with iCloud' }))
+    expect(screen.getByLabelText('Graph name')).toHaveProperty('value', 'Notes')
+    fireEvent.change(screen.getByLabelText('Graph name'), { target: { value: 'Journal' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Setup graph' }))
 
     await waitFor(() =>
       expect(completeOnboarding).toHaveBeenCalledWith('icloud', '/iCloud/Documents/Journal'),
@@ -58,7 +58,7 @@ describe('MobileOnboardingScreen', () => {
     expect(screen.getByText('Start fresh')).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Continue with Notes' })).toBeTruthy()
     expect(
-      (screen.getByRole('button', { name: 'Start with iCloud' }) as HTMLButtonElement).disabled,
+      (screen.getByRole('button', { name: 'Setup graph' }) as HTMLButtonElement).disabled,
     ).toBe(true)
     fireEvent.click(screen.getByRole('button', { name: 'Continue with Work' }))
 
@@ -75,8 +75,8 @@ describe('MobileOnboardingScreen', () => {
     })
     render(<MobileOnboardingScreen />)
 
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Journal' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Start with iCloud' }))
+    fireEvent.change(screen.getByLabelText('Graph name'), { target: { value: 'Journal' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Setup graph' }))
 
     await waitFor(() =>
       expect(completeOnboarding).toHaveBeenCalledWith('icloud', '/iCloud/Documents/Journal'),
@@ -87,10 +87,8 @@ describe('MobileOnboardingScreen', () => {
     render(<MobileOnboardingScreen />)
 
     expect(screen.queryByText(/Your notes are plain markdown files/i)).toBeNull()
-    expect(
-      screen.getByText('No iCloud sync. You can add GitHub later from Settings.'),
-    ).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: 'Use this device only' }))
+    expect(screen.queryByText('No iCloud sync. You can add GitHub later from Settings.')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Or, use this device only' }))
 
     await waitFor(() => expect(completeOnboarding).toHaveBeenCalledWith('local'))
   })
@@ -105,10 +103,10 @@ describe('MobileOnboardingScreen', () => {
 
     expect(screen.getByRole('heading', { name: 'iCloud sync' })).toBeTruthy()
     expect(screen.getByText('Checking iCloud Drive…')).toBeTruthy()
-    expect(screen.queryByRole('button', { name: 'Start with iCloud' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Setup graph' })).toBeNull()
     expect(screen.queryByText(/Sign in to iCloud/)).toBeNull()
     // The on-device path stays live — its root is already known.
-    const local = screen.getByRole('button', { name: 'Use this device only' })
+    const local = screen.getByRole('button', { name: 'Or, use this device only' })
     expect((local as HTMLButtonElement).disabled).toBe(false)
   })
 
@@ -123,7 +121,7 @@ describe('MobileOnboardingScreen', () => {
     expect(
       screen.getByText('Sign in to iCloud on this device, then reopen Reflect.'),
     ).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Use this device only' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Or, use this device only' })).toBeTruthy()
   })
 
   it('does not offer repository setup from the first-run picker', () => {
@@ -134,10 +132,9 @@ describe('MobileOnboardingScreen', () => {
     expect(screen.queryByRole('button', { name: 'Download & open' })).toBeNull()
   })
 
-  it('does not expose graph or folder language in the primary first-run path', () => {
+  it('does not expose folder language in the primary first-run path', () => {
     render(<MobileOnboardingScreen />)
 
-    expect(screen.queryByText(/graph/i)).toBeNull()
     expect(screen.queryByText(/folder/i)).toBeNull()
   })
 })

--- a/apps/desktop/src/mobile/onboarding-screen.test.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.test.tsx
@@ -33,11 +33,13 @@ afterEach(() => {
 })
 
 describe('MobileOnboardingScreen', () => {
-  it('leads with iCloud Drive and creates the named container graph', async () => {
+  it('leads with iCloud sync and creates the default iCloud notes', async () => {
     render(<MobileOnboardingScreen />)
 
-    expect(screen.getByRole('heading', { name: 'iCloud Drive' })).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+    expect(screen.getByRole('heading', { name: 'iCloud sync' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Continue with iCloud' })).toBeTruthy()
+    expect(screen.queryByLabelText('Name')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Continue with iCloud' }))
 
     await waitFor(() =>
       expect(completeOnboarding).toHaveBeenCalledWith('icloud', '/iCloud/Documents/Notes'),
@@ -52,13 +54,13 @@ describe('MobileOnboardingScreen', () => {
     })
     render(<MobileOnboardingScreen />)
 
-    expect(screen.getByText('Open an existing graph from iCloud Drive.')).toBeTruthy()
-    expect(screen.getByText('or create new graph')).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Notes' })).toBeTruthy()
-    expect((screen.getByRole('button', { name: 'Create' }) as HTMLButtonElement).disabled).toBe(
-      true,
-    )
-    fireEvent.click(screen.getByRole('button', { name: 'Work' }))
+    expect(screen.getByText('We found notes in iCloud Drive. Continue with one, or start fresh.')).toBeTruthy()
+    expect(screen.getByText('Start fresh')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Continue with Notes' })).toBeTruthy()
+    expect(
+      (screen.getByRole('button', { name: 'Create in iCloud' }) as HTMLButtonElement).disabled,
+    ).toBe(true)
+    fireEvent.click(screen.getByRole('button', { name: 'Continue with Work' }))
 
     await waitFor(() =>
       expect(completeOnboarding).toHaveBeenCalledWith('icloud', '/iCloud/Documents/Work'),
@@ -74,7 +76,7 @@ describe('MobileOnboardingScreen', () => {
     render(<MobileOnboardingScreen />)
 
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Journal' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Create in iCloud' }))
 
     await waitFor(() =>
       expect(completeOnboarding).toHaveBeenCalledWith('icloud', '/iCloud/Documents/Journal'),
@@ -85,11 +87,13 @@ describe('MobileOnboardingScreen', () => {
     render(<MobileOnboardingScreen />)
 
     expect(screen.queryByText(/Your notes are plain markdown files/i)).toBeNull()
-    expect(screen.getByRole('heading', { name: 'This device' })).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'This device only' })).toBeTruthy()
     expect(
-      screen.getByText('Stored locally in Reflect on this device. Sync with GitHub later from Settings.'),
+      screen.getByText(
+        'Notes stay on this device and won’t sync through iCloud. You can add GitHub sync later from Settings.',
+      ),
     ).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: 'Choose a folder on this device' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Keep notes on this device' }))
 
     await waitFor(() => expect(completeOnboarding).toHaveBeenCalledWith('local'))
   })
@@ -102,25 +106,28 @@ describe('MobileOnboardingScreen', () => {
     setStorage({ localRoot: '/Documents', icloudDocumentsRoot: null, icloudGraphRoots: [] })
     render(<MobileOnboardingScreen />)
 
-    expect(screen.getByRole('heading', { name: 'iCloud Drive' })).toBeTruthy()
-    expect(screen.getByText('Looking for your notes…')).toBeTruthy()
-    expect(screen.queryByRole('button', { name: 'Create' })).toBeNull()
+    expect(screen.getByRole('heading', { name: 'iCloud sync' })).toBeTruthy()
+    expect(screen.getByText('Checking iCloud Drive…')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Continue with iCloud' })).toBeNull()
     expect(screen.queryByText(/Sign in to iCloud/)).toBeNull()
     // The on-device path stays live — its root is already known.
-    const local = screen.getByRole('button', { name: 'Choose a folder on this device' })
+    const local = screen.getByRole('button', { name: 'Keep notes on this device' })
     expect((local as HTMLButtonElement).disabled).toBe(false)
   })
 
-  it('hides the iCloud action and explains why when iCloud is unavailable', () => {
+  it('keeps the iCloud recommendation visible when iCloud is unavailable', () => {
     setStorage({ localRoot: '/Documents', icloudDocumentsRoot: null, icloudGraphRoots: [] })
     render(<MobileOnboardingScreen />)
 
-    expect(screen.queryByRole('heading', { name: 'iCloud Drive' })).toBeNull()
+    expect(screen.getByRole('heading', { name: 'iCloud sync' })).toBeTruthy()
     expect(
-      screen.getByText('Sign in to iCloud on this device to sync notes with iCloud Drive.'),
+      screen.getByText('Turn on iCloud Drive to keep your notes synced between devices.'),
     ).toBeTruthy()
-    expect(screen.getByRole('heading', { name: 'This device' })).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Choose a folder on this device' })).toBeTruthy()
+    expect(
+      screen.getByText('Sign in to iCloud on this device, then reopen Reflect.'),
+    ).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'This device only' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Keep notes on this device' })).toBeTruthy()
   })
 
   it('does not offer repository setup from the first-run picker', () => {
@@ -129,5 +136,12 @@ describe('MobileOnboardingScreen', () => {
     expect(screen.queryByRole('button', { name: /github/i })).toBeNull()
     expect(screen.queryByText(/backup repository/i)).toBeNull()
     expect(screen.queryByRole('button', { name: 'Download & open' })).toBeNull()
+  })
+
+  it('does not expose graph or folder language in the primary first-run path', () => {
+    render(<MobileOnboardingScreen />)
+
+    expect(screen.queryByText(/graph/i)).toBeNull()
+    expect(screen.queryByText(/folder/i)).toBeNull()
   })
 })

--- a/apps/desktop/src/mobile/onboarding-screen.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactElement } from 'react'
-import { HardDrive } from 'lucide-react'
+import { Cloud, HardDrive } from 'lucide-react'
 import { InlineAlert } from '@/components/inline-alert'
 import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
@@ -17,13 +17,12 @@ type PendingChoice = string | 'icloud-create' | 'local' | null
  * where their notes live, gated by the `mobileOnboarded` setting in
  * {@link GraphProvider}.
  *
- * iCloud Drive leads (Plan 21): it is the primary way a graph syncs between
- * iPhone and Mac, so the hero block ({@link OnboardingIcloudSection}) lists
- * every graph already in the app's iCloud container plus a create row.
- * **Choose a folder on this device** opens the app-sandbox root instead (and is
- * promoted to the only storage card when iCloud is unavailable). Every
- * path ends in `completeOnboarding(kind, root)`, which opens the chosen root
- * and records the flag + storage kind + graph name.
+ * iCloud Drive leads (Plan 21): it is the primary way notes sync between
+ * iPhone and Mac, so the hero block ({@link OnboardingIcloudSection}) either
+ * continues with iCloud or lists existing note sets in the app's iCloud
+ * container. **Keep notes on this device** opens the app-sandbox root instead.
+ * Every path ends in `completeOnboarding(kind, root)`, which opens the chosen
+ * root and records the flag + storage kind + graph name.
  *
  * The screen renders before the iCloud container has resolved (the boot no
  * longer waits on it — see `useMobileGraphBoot`): while
@@ -56,12 +55,22 @@ export function MobileOnboardingScreen(): ReactElement {
         paddingBottom: 'max(env(safe-area-inset-bottom), 1rem)',
       }}
     >
-      <div className="my-auto flex w-full flex-col gap-6">
-        <div className="text-center">
-          <h1 className="text-xl font-semibold tracking-tight">Welcome to Reflect</h1>
-        </div>
+      <div className="mx-auto flex w-full max-w-md flex-col gap-7 py-6">
+        <header className="flex flex-col gap-4 pt-2">
+          <div className="flex size-11 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            <Cloud aria-hidden className="size-5" strokeWidth={1.75} />
+          </div>
+          <div className="space-y-2">
+            <h1 className="text-[28px] font-semibold leading-tight tracking-tight">
+              Start with iCloud sync
+            </h1>
+            <p className="text-sm leading-6 text-text-secondary">
+              Keep your notes up to date across iPhone, iPad, and Mac with iCloud Drive.
+            </p>
+          </div>
+        </header>
 
-        <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-4">
           {icloudReady || icloudPending ? (
             <OnboardingIcloudSection
               pending={icloudPending}
@@ -74,7 +83,9 @@ export function MobileOnboardingScreen(): ReactElement {
                 runChoice('icloud-create', () => completeOnboarding('icloud', root))
               }
             />
-          ) : null}
+          ) : (
+            <IcloudUnavailableSection />
+          )}
 
           <section className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-4">
             <div className="flex items-start gap-3">
@@ -82,14 +93,15 @@ export function MobileOnboardingScreen(): ReactElement {
                 <HardDrive aria-hidden className="size-4" strokeWidth={1.75} />
               </div>
               <div className="min-w-0 flex-1 space-y-1">
-                <h2 className="text-sm font-semibold">This device</h2>
+                <h2 className="text-sm font-semibold">This device only</h2>
                 <p className="text-xs text-text-muted">
-                  Stored locally in Reflect on this device. Sync with GitHub later from Settings.
+                  Notes stay on this device and won’t sync through iCloud. You can add GitHub
+                  sync later from Settings.
                 </p>
               </div>
             </div>
             <Button
-              variant={icloudReady || icloudPending ? 'outline' : 'default'}
+              variant="outline"
               className="w-full justify-start text-left"
               onClick={() => runChoice('local', () => completeOnboarding('local'))}
               disabled={action.pending || mobileStorageInfo === null}
@@ -99,18 +111,39 @@ export function MobileOnboardingScreen(): ReactElement {
               ) : (
                 <HardDrive aria-hidden strokeWidth={1.75} />
               )}
-              {pendingChoice === 'local' ? 'Setting up…' : 'Choose a folder on this device'}
+              {pendingChoice === 'local' ? 'Setting up…' : 'Keep notes on this device'}
             </Button>
           </section>
-          {!icloudReady && !icloudPending ? (
-            <p className="text-center text-xs text-text-muted">
-              Sign in to iCloud on this device to sync notes with iCloud Drive.
-            </p>
-          ) : null}
         </div>
 
         {action.error !== null ? <InlineAlert tone="error">{action.error}</InlineAlert> : null}
       </div>
     </div>
+  )
+}
+
+function IcloudUnavailableSection(): ReactElement {
+  return (
+    <section className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-4">
+      <div className="flex items-start gap-3">
+        <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+          <Cloud aria-hidden className="size-4" strokeWidth={1.75} />
+        </div>
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex items-center gap-2">
+            <h2 className="text-sm font-semibold">iCloud sync</h2>
+            <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary">
+              Recommended
+            </span>
+          </div>
+          <p className="text-xs text-text-muted">
+            Turn on iCloud Drive to keep your notes synced between devices.
+          </p>
+        </div>
+      </div>
+      <p className="rounded-lg bg-muted/60 px-3 py-2 text-xs leading-5 text-text-muted">
+        Sign in to iCloud on this device, then reopen Reflect.
+      </p>
+    </section>
   )
 }

--- a/apps/desktop/src/mobile/onboarding-screen.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.tsx
@@ -101,11 +101,8 @@ export function MobileOnboardingScreen(): ReactElement {
               ) : (
                 <HardDrive aria-hidden strokeWidth={1.75} />
               )}
-              {pendingChoice === 'local' ? 'Setting up…' : 'Use this device only'}
+              {pendingChoice === 'local' ? 'Setting up…' : 'Or, use this device only'}
             </Button>
-            <p className="text-xs leading-5 text-text-muted">
-              No iCloud sync. You can add GitHub later from Settings.
-            </p>
           </div>
         </div>
 

--- a/apps/desktop/src/mobile/onboarding-screen.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.tsx
@@ -88,22 +88,11 @@ export function MobileOnboardingScreen(): ReactElement {
             <IcloudUnavailableSection />
           )}
 
-          <section className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-4">
-            <div className="flex items-start gap-3">
-              <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-text-secondary">
-                <HardDrive aria-hidden className="size-4" strokeWidth={1.75} />
-              </div>
-              <div className="min-w-0 flex-1 space-y-1">
-                <h2 className="text-sm font-semibold">This device only</h2>
-                <p className="text-xs text-text-muted">
-                  Notes stay on this device and won’t sync through iCloud. You can add GitHub
-                  sync later from Settings.
-                </p>
-              </div>
-            </div>
+          <div className="flex flex-col items-center gap-1 px-4 text-center">
             <Button
-              variant="outline"
-              className="w-full justify-start text-left"
+              variant="ghost"
+              size="sm"
+              className="text-text-secondary"
               onClick={() => runChoice('local', () => completeOnboarding('local'))}
               disabled={action.pending || mobileStorageInfo === null}
             >
@@ -112,9 +101,12 @@ export function MobileOnboardingScreen(): ReactElement {
               ) : (
                 <HardDrive aria-hidden strokeWidth={1.75} />
               )}
-              {pendingChoice === 'local' ? 'Setting up…' : 'Keep notes on this device'}
+              {pendingChoice === 'local' ? 'Setting up…' : 'Use this device only'}
             </Button>
-          </section>
+            <p className="text-xs leading-5 text-text-muted">
+              No iCloud sync. You can add GitHub later from Settings.
+            </p>
+          </div>
         </div>
 
         {action.error !== null ? <InlineAlert tone="error">{action.error}</InlineAlert> : null}

--- a/apps/desktop/src/mobile/onboarding-screen.tsx
+++ b/apps/desktop/src/mobile/onboarding-screen.tsx
@@ -4,6 +4,7 @@ import { InlineAlert } from '@/components/inline-alert'
 import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
 import { useAsyncAction } from '@/hooks/use-async-action'
+import { OnboardingIcloudHeader } from '@/mobile/onboarding-icloud-header'
 import { OnboardingIcloudSection } from '@/mobile/onboarding-icloud-section'
 import { useGraph } from '@/providers/graph-provider'
 
@@ -125,22 +126,7 @@ export function MobileOnboardingScreen(): ReactElement {
 function IcloudUnavailableSection(): ReactElement {
   return (
     <section className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-4">
-      <div className="flex items-start gap-3">
-        <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-          <Cloud aria-hidden className="size-4" strokeWidth={1.75} />
-        </div>
-        <div className="min-w-0 flex-1 space-y-1">
-          <div className="flex items-center gap-2">
-            <h2 className="text-sm font-semibold">iCloud sync</h2>
-            <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary">
-              Recommended
-            </span>
-          </div>
-          <p className="text-xs text-text-muted">
-            Turn on iCloud Drive to keep your notes synced between devices.
-          </p>
-        </div>
-      </div>
+      <OnboardingIcloudHeader description="Turn on iCloud Drive to keep your notes synced between devices." />
       <p className="rounded-lg bg-muted/60 px-3 py-2 text-xs leading-5 text-text-muted">
         Sign in to iCloud on this device, then reopen Reflect.
       </p>


### PR DESCRIPTION
## Problem

The iOS first-run screen exposed Reflect’s storage model too directly. It asked people to choose between iCloud Drive and a graph/folder on this device, which made the default path feel like an implementation detail instead of the normal way to start.

This PR keeps iCloud sync as the golden path, restores naming on that path, and makes the local-only path a quieter fallback for people who intentionally do not want iCloud.

## Before -> After

| Before | After |
| --- | --- |
| Fresh iCloud setup was framed around creating/opening a graph. | Fresh iCloud setup is framed around iCloud sync, with an editable `Graph name` field defaulted to `Notes` and a primary `Setup graph` action. |
| Existing iCloud choices were described as graphs. | Existing iCloud choices read as notes found in iCloud, with `Continue with …` buttons and a separate `Start fresh` graph-name field. |
| Local startup competed as a full `This device` card with `Choose a folder on this device`. | Local startup is a subdued ghost option: `Or, use this device only`. |
| If iCloud was unavailable, the iCloud option disappeared and a small note explained sign-in. | The iCloud recommendation stays visible with a clear sign-in/reopen instruction, while local-only remains available. |

## Changes

1. Reworked `MobileOnboardingScreen` around a benefit-led `Start with iCloud sync` header and a quieter local-only escape hatch.
2. Updated `OnboardingIcloudSection` so fresh iCloud installs keep an editable `Graph name` field, default to `Notes`, and create the named iCloud location through the existing `completeOnboarding` flow.
3. Preserved existing iCloud note selection while keeping the new-note path available under `Start fresh`.
4. Shared the iCloud card header between ready and unavailable states to avoid copy/style drift.
5. Updated onboarding tests to cover the iCloud-first copy, editable naming, existing iCloud notes, local-only fallback, pending iCloud lookup, unavailable iCloud, and the absence of visible folder language on the primary first-run path.

## Verification

- `pnpm --filter @reflect/desktop test src/mobile/onboarding-screen.test.tsx` (passed)
- `pnpm check` (passed; emitted the existing `packages/core/src/indexing/indexer.ts` max-lines warning)
- `git diff --check` (passed)
- Captured a phone-sized browser screenshot of the fresh iCloud-ready state from a temporary Vite harness.

## Risk / Rollout

Low risk: this changes first-run mobile copy/layout and preserves the same `completeOnboarding(kind, root)` storage behavior. No migrations or data-shape changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and copy-only changes on mobile onboarding; `completeOnboarding` paths and storage roots are unchanged.
> 
> **Overview**
> Reframes the mobile first-run screen so **iCloud sync** is the clear default, with benefit-led copy instead of graph/folder terminology on the primary path.
> 
> **Screen layout:** Adds a **Start with iCloud sync** hero and a shared `OnboardingIcloudHeader` (used when iCloud is ready, pending, or unavailable). When iCloud cannot be used, the recommendation card stays visible with sign-in/reopen guidance instead of hiding the iCloud option. Local-only startup moves to a subdued ghost action (**Or, use this device only**).
> 
> **iCloud card:** Updates messaging and controls—**Continue with …** for existing iCloud note sets, **Start fresh** + **Graph name** (default **Notes** on empty containers), and a full-width **Setup graph** action—while still calling the same `completeOnboarding('icloud', root)` flow. Pending state copy becomes **Checking iCloud Drive…**.
> 
> Tests are updated for the new copy, controls, unavailable iCloud behavior, and absence of folder language on the primary path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5028e5ccf62e550d2f28dab73b89480be8f5f28f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->