### PR TITLE
Focus mobile tab inputs on double tap

### DIFF
--- a/apps/desktop/src/mobile/chat-composer.tsx
+++ b/apps/desktop/src/mobile/chat-composer.tsx
@@ -10,7 +10,9 @@ import {
 } from '@/components/ui/attachment'
 import { Button } from '@/components/ui/button'
 import { ChatModelDrawer } from '@/mobile/chat-model-drawer'
+import { useArrivalFocus } from '@/mobile/use-arrival-focus'
 import { useChatSession } from '@/providers/chat-provider'
+import { useRouter } from '@/routing/router'
 
 /**
  * The mobile chat composer (Plan 23): a plain textarea bound to the
@@ -22,6 +24,7 @@ import { useChatSession } from '@/providers/chat-provider'
  * empty and the composer lands on the keyboard's top edge (contract 6).
  */
 export function MobileChatComposer(): ReactElement {
+  const { arrivalSeq, arrivalFocusEditor } = useRouter()
   const {
     status,
     activeModel,
@@ -34,9 +37,12 @@ export function MobileChatComposer(): ReactElement {
     stop,
   } = useChatSession()
   const [modelOpen, setModelOpen] = useState(false)
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   const streaming = status === 'streaming'
   const empty = draft.trim() === '' && attachments.length === 0
+
+  useArrivalFocus({ arrivalSeq, arrivalFocusEditor, target: textareaRef })
 
   const submit = (): void => {
     if (streaming || empty) {
@@ -73,6 +79,7 @@ export function MobileChatComposer(): ReactElement {
         </AttachmentGroup>
       ) : null}
       <textarea
+        ref={textareaRef}
         value={draft}
         onChange={(event) => setDraft(event.target.value)}
         placeholder="Ask about your notes…"

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -553,6 +553,34 @@ describe('MobileShell', () => {
     expect((await view.findByText('No tasks to show')).textContent).toBe('No tasks to show')
   })
 
+  it('double-tapping Tasks selects the task search filter', async () => {
+    const user = userEvent.setup()
+    let fakeNow = 1_000
+    const now = vi.spyOn(Date, 'now').mockImplementation(() => fakeNow)
+    const view = mount({ kind: 'today' })
+    let box: HTMLInputElement | null = null
+
+    try {
+      fireEvent.click(view.getByRole('button', { name: 'Tasks' }))
+      box = (await view.findByRole('searchbox', { name: 'Search tasks' })) as HTMLInputElement
+      await user.type(box, 'milk')
+
+      fakeNow = 2_000
+      fireEvent.click(view.getByRole('button', { name: 'Tasks' }))
+      fakeNow = 2_100
+      fireEvent.click(view.getByRole('button', { name: 'Tasks' }))
+    } finally {
+      now.mockRestore()
+    }
+
+    if (box === null) {
+      throw new Error('task search box did not render')
+    }
+    await waitFor(() => expect(document.activeElement).toBe(box))
+    expect(box.selectionStart).toBe(0)
+    expect(box.selectionEnd).toBe(box.value.length)
+  })
+
   it('hides the tab bar while the software keyboard is up (V1: the keyboard covered it)', () => {
     const view = mount({ kind: 'today' })
     expect(view.getByRole('navigation', { name: 'Sections' })).toBeTruthy()

--- a/apps/desktop/src/mobile/mobile-shell.tsx
+++ b/apps/desktop/src/mobile/mobile-shell.tsx
@@ -31,9 +31,10 @@ export function MobileShell(): ReactElement {
   const [allFilters, setAllFilters] = useState<AllNotesFilters>(EMPTY_ALL_NOTES_FILTERS)
   const [lastTab, setLastTab] = useState<MobileTab>('daily')
   const [lastDailyRoute, setLastDailyRoute] = useState<DailyRoute>({ kind: 'today' })
-  // A tab double-tap is a capture gesture (Daily focuses today's editor, All
-  // its search input); a pending tap expires if the route leaves the tab's
-  // root between taps — that second tap is a return, not a double-tap.
+  // A tab double-tap is a capture gesture (Daily focuses today's editor; list
+  // and chat tabs focus their primary inputs); a pending tap expires if the
+  // route leaves the tab's root between taps — that second tap is a return,
+  // not a double-tap.
   const isDoubleTap = useDoubleTap<MobileTab>(tabRootFor(route))
   const keyboardVisible = useKeyboardVisible()
   // V1's wake-to-today: foregrounding on a new calendar date lands on today.
@@ -71,8 +72,13 @@ export function MobileShell(): ReactElement {
       return
     }
 
-    if (next !== 'daily') {
-      navigate(next === 'tasks' ? { kind: 'tasks' } : { kind: 'chat' })
+    if (next === 'tasks') {
+      navigate({ kind: 'tasks' }, doubleTap ? { focusEditor: true } : undefined)
+      return
+    }
+
+    if (next === 'chat') {
+      navigate({ kind: 'chat' }, doubleTap ? { focusEditor: true } : undefined)
       return
     }
 

--- a/apps/desktop/src/mobile/screens/chat.test.tsx
+++ b/apps/desktop/src/mobile/screens/chat.test.tsx
@@ -107,12 +107,22 @@ function RouteProbe(): null {
   return null
 }
 
+function FocusChatProbe(): ReactElement {
+  const { navigate } = useRouter()
+  return (
+    <button type="button" onClick={() => navigate({ kind: 'chat' }, { focusEditor: true })}>
+      focus chat input
+    </button>
+  )
+}
+
 /** The screen inside the real provider stack, unmountable like a tab switch. */
 function Harness({ showScreen }: { showScreen: boolean }): ReactElement {
   return (
     <QueryClientProvider client={new QueryClient()}>
       <RouterProvider>
         <RouteProbe />
+        <FocusChatProbe />
         <ChatProvider graph={{ root: '/graphs/test', name: 'test-graph', generation: 1 }}>
           {showScreen ? <MobileChat /> : null}
         </ChatProvider>
@@ -174,5 +184,15 @@ describe('MobileChat', () => {
       'half-typed follow-up',
     )
     expect(screen.getByText('sent question')).toBeDefined()
+  })
+
+  it('focuses the composer when a chat tab capture arrival requests it', async () => {
+    configureModel()
+    render(<Harness showScreen />)
+
+    const composer = screen.getByLabelText('Chat message')
+    fireEvent.click(screen.getByRole('button', { name: 'focus chat input' }))
+
+    await waitFor(() => expect(document.activeElement).toBe(composer))
   })
 })

--- a/apps/desktop/src/mobile/screens/tasks.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.tsx
@@ -1,4 +1,4 @@
-import { useDeferredValue, useMemo, useState, type ReactElement } from 'react'
+import { useDeferredValue, useMemo, useRef, useState, type ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Archive, CircleCheck, Plus, SlidersHorizontal } from 'lucide-react'
 import {
@@ -23,6 +23,7 @@ import { SearchInput } from '@/mobile/search-input'
 import { MobileTaskEditSheet } from '@/mobile/task-edit-sheet'
 import { TaskFiltersDrawer } from '@/mobile/task-filters-drawer'
 import { MobileTaskGroup } from '@/mobile/task-group'
+import { useArrivalFocus } from '@/mobile/use-arrival-focus'
 import { useGraph } from '@/providers/graph-provider'
 import { routeForPath } from '@/routing/route'
 import { useRouter } from '@/routing/router'
@@ -42,10 +43,11 @@ import { useRouter } from '@/routing/router'
  */
 export function MobileTasks(): ReactElement {
   const { graph } = useGraph()
-  const { navigate } = useRouter()
+  const { navigate, arrivalSeq, arrivalFocusEditor } = useRouter()
   const today = useToday()
   const { filters, toggle } = useTaskFilters()
   const [query, setQuery] = useState('')
+  const searchInputRef = useRef<HTMLInputElement>(null)
   const [filtersOpen, setFiltersOpen] = useState(false)
   // The sheet's task sticks around after close so the exit animation has
   // content; `sheetOpen` alone drives visibility.
@@ -55,6 +57,15 @@ export function MobileTasks(): ReactElement {
   // (keyboard up) — set per visit: true for "+"-added tasks, false for row taps.
   const [autoFocusEditor, setAutoFocusEditor] = useState(false)
   const enabled = hasBridge() && graph !== null
+
+  // The Tasks-tab double-tap lands in the tab's capture surface: its live
+  // search filter, selected so a replacement query can start immediately.
+  useArrivalFocus({
+    arrivalSeq,
+    arrivalFocusEditor,
+    target: searchInputRef,
+    selectText: true,
+  })
 
   const { data: open, isError: openFailed } = useQuery({
     queryKey: tasksQueryKey(graph?.root),
@@ -134,6 +145,7 @@ export function MobileTasks(): ReactElement {
     >
       <header className="flex shrink-0 items-center gap-1 border-b border-border px-4 pb-2 pt-1">
         <SearchInput
+          ref={searchInputRef}
           placeholder="Search tasks…"
           aria-label="Search tasks"
           value={query}

--- a/apps/desktop/src/mobile/use-arrival-focus.ts
+++ b/apps/desktop/src/mobile/use-arrival-focus.ts
@@ -7,13 +7,15 @@ export interface ArrivalFocusOptions {
   arrivalFocusEditor: boolean
   /** The element a focus arrival should focus. */
   target: RefObject<HTMLElement | null>
+  /** Select existing text after focusing text controls. */
+  selectText?: boolean
 }
 
 /**
  * Focus `target` on capture arrivals (`navigate(..., { focusEditor: true })`
- * — the All-tab double-tap landing on the search input). Mirrors
+ * — e.g. tab double-taps landing on search/composer inputs). Mirrors
  * `useDailyArrivals`' bookkeeping: each arrival is consumed once, and the
- * arrival that mounts the screen still counts — the double-tap's second
+ * arrival that mounts the screen still counts — a double-tap's second
  * navigate can land before the remounting screen first commits, so waiting
  * for a seq *change* would silently swallow the gesture.
  */
@@ -21,13 +23,21 @@ export function useArrivalFocus({
   arrivalSeq,
   arrivalFocusEditor,
   target,
+  selectText = false,
 }: ArrivalFocusOptions): void {
   const seenSeq = useRef<number | null>(null)
   useEffect(() => {
     const newArrival = seenSeq.current !== arrivalSeq
     seenSeq.current = arrivalSeq
     if (newArrival && arrivalFocusEditor) {
-      target.current?.focus()
+      const element = target.current
+      element?.focus()
+      if (
+        selectText &&
+        (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement)
+      ) {
+        element.select()
+      }
     }
-  }, [arrivalSeq, arrivalFocusEditor, target])
+  }, [arrivalSeq, arrivalFocusEditor, selectText, target])
 }

--- a/apps/desktop/src/routing/router.tsx
+++ b/apps/desktop/src/routing/router.tsx
@@ -42,10 +42,10 @@ interface RouterValue {
   /**
    * True when the latest arrival asked the destination to focus its primary
    * input (`navigate(route, { focusEditor: true })`). Only explicit capture
-   * gestures request it — the mobile Daily- and All-tab double-taps,
-   * desktop's ⌘D and sidebar Daily notes row — while note navigations (wiki
-   * links, backlinks, back/forward) stay calm so the keyboard never rises
-   * mid-arrival.
+   * gestures request it — the mobile Daily-, All-, Tasks-, and Chat-tab
+   * double-taps, desktop's ⌘D and sidebar Daily notes row — while note
+   * navigations (wiki links, backlinks, back/forward) stay calm so the
+   * keyboard never rises mid-arrival.
    * One-shot by construction: the next navigate overwrites it and history
    * moves clear it, so it can never leak onto a later, unrelated arrival.
    */
@@ -91,9 +91,9 @@ export interface NavigateOptions {
    * {@link RouterValue.arrivalFocusEditor}. Consumed by the daily surfaces —
    * the mobile Daily-tab double-tap and desktop's stream (⌘D, the sidebar's
    * Daily notes row), which land the caret at the end of the day's content
-   * (append-style capture) — and by the mobile All tab, whose double-tap
-   * focuses the search input; desktop's note route autofocuses every arrival
-   * and ignores it.
+   * (append-style capture) — and by the mobile All, Tasks, and Chat tabs,
+   * whose double-taps focus their primary inputs; desktop's note route
+   * autofocuses every arrival and ignores it.
    */
   focusEditor?: boolean
 }


### PR DESCRIPTION
## Problem
The iOS tab bar already treats Daily and All double taps as capture gestures, but Tasks and Chat only re-navigated to their root screens. That left quick capture paths missing: a user had to tap into the Tasks search field manually, and Chat did not return focus to the composer.

## Before -> After
| Gesture | Before | After |
| --- | --- | --- |
| Double tap Tasks | Stays on Tasks | Focuses and selects Search tasks |
| Double tap Chat | Stays on Chat | Focuses Chat message composer |

## Changes
1. Extend `MobileShell` so Tasks and Chat double taps pass `{ focusEditor: true }` on their root navigation.
2. Let `MobileTasks` consume focus arrivals by focusing/selecting its search field.
3. Let `MobileChatComposer` consume focus arrivals by focusing the composer textarea.
4. Add optional `selectText` support to `useArrivalFocus` and update router comments.
5. Add regression coverage for Tasks tab double tap and Chat composer focus arrivals.

## Verification
- `pnpm --filter @reflect/desktop test -- src/mobile/mobile-screen.test.tsx src/mobile/screens/chat.test.tsx` passed. Vitest reported 203 files / 1776 tests because the workspace config expanded the run.
- `pnpm check` passed. Existing unrelated warning: `packages/core/src/indexing/indexer.ts` exceeds max-lines by 3 lines.

## Risk / Rollout
No migrations or data changes. Behavior is limited to mobile tab double-tap focus handling; the same one-shot focus flag already powers Daily and All capture gestures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mobile-only tab gesture UX reusing the established one-shot `focusEditor` path; no data, auth, or API changes.
> 
> **Overview**
> **Tasks** and **Chat** tab double-taps now behave like **Daily** and **All** capture gestures: `MobileShell` passes `{ focusEditor: true }` when a double-tap navigates to those tabs’ root routes.
> 
> **Tasks** focuses and **selects all text** in the task search field via `useArrivalFocus` with `selectText: true`. **Chat** focuses the composer textarea the same way (without selecting). `useArrivalFocus` gains optional `selectText` for input/textarea controls; router docs note all four mobile tab double-taps.
> 
> Regression tests cover Tasks double-tap search selection and Chat composer focus on capture arrival.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d79dc99814ca8285d18f4cf32d2aa80a13ce3c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile tab double-taps now refocus the main input for Chat and Tasks, making it faster to jump back into typing.
  * When arriving on Tasks, the search field is automatically focused and its current text is selected for quick replacement.

* **Bug Fixes**
  * Improved focus behavior so returning to Chat or Tasks reliably places the cursor in the expected input.
  * Added coverage for double-tap and focus flows to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->