### PR TITLE
Confirm iOS audio memo discard

### DIFF
--- a/apps/desktop/src/mobile/recording-drawer.test.tsx
+++ b/apps/desktop/src/mobile/recording-drawer.test.tsx
@@ -1,0 +1,87 @@
+import type { ReactNode } from 'react'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const memo = vi.hoisted(() => ({
+  phase: 'recording' as 'idle' | 'requesting' | 'recording' | 'transcribing' | 'error',
+  elapsedMs: 65_000,
+  level: 0.4,
+  pendingCount: 0,
+  available: true,
+  error: null as string | null,
+  canRetry: false,
+  drawerOpen: true,
+  toggle: vi.fn(),
+  stopAndSave: vi.fn(),
+  cancelRecording: vi.fn(),
+  onDrawerOpenChange: vi.fn(),
+  retry: vi.fn(),
+  discard: vi.fn(),
+}))
+
+vi.mock('@/components/ui/drawer', () => ({
+  Drawer: ({ open, children }: { open?: boolean; children?: ReactNode }) =>
+    open ? <div data-testid="drawer">{children}</div> : null,
+  DrawerContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DrawerTitle: ({ children }: { children?: ReactNode }) => <h2>{children}</h2>,
+}))
+
+vi.mock('@/mobile/audio-memo-provider', () => ({
+  useMobileAudioMemo: () => ({ ...memo }),
+}))
+
+const { RecordingDrawer } = await import('./recording-drawer')
+
+beforeEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+  memo.phase = 'recording'
+  memo.error = null
+  memo.drawerOpen = true
+})
+
+afterEach(cleanup)
+afterEach(() => vi.useRealTimers())
+
+describe('RecordingDrawer', () => {
+  it('requires a second tap before discarding a live recording', async () => {
+    const user = userEvent.setup()
+    const view = render(<RecordingDrawer />)
+
+    await user.click(view.getByRole('button', { name: 'Discard recording' }))
+
+    expect(memo.cancelRecording).not.toHaveBeenCalled()
+    expect(
+      view.getByRole('button', { name: 'Confirm discard recording' }).textContent,
+    ).toContain('Tap again to discard')
+
+    await user.click(view.getByRole('button', { name: 'Confirm discard recording' }))
+
+    expect(memo.cancelRecording).toHaveBeenCalledOnce()
+  })
+
+  it('lets the discard confirmation lapse back to a single safe tap', async () => {
+    vi.useFakeTimers()
+    const view = render(<RecordingDrawer />)
+
+    fireEvent.click(view.getByRole('button', { name: 'Discard recording' }))
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+
+    fireEvent.click(view.getByRole('button', { name: 'Discard recording' }))
+
+    expect(memo.cancelRecording).not.toHaveBeenCalled()
+    expect(view.getByRole('button', { name: 'Confirm discard recording' })).toBeTruthy()
+  })
+
+  it('stops and saves from the primary control without confirmation', async () => {
+    const user = userEvent.setup()
+    const view = render(<RecordingDrawer />)
+
+    await user.click(view.getByRole('button', { name: 'Stop recording' }))
+
+    expect(memo.stopAndSave).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/mobile/recording-drawer.tsx
+++ b/apps/desktop/src/mobile/recording-drawer.tsx
@@ -1,5 +1,5 @@
-import type { ReactElement } from 'react'
-import { Square } from 'lucide-react'
+import { useEffect, useRef, useState, type ReactElement } from 'react'
+import { Square, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
 import { useMobileAudioMemo } from '@/mobile/audio-memo-provider'
@@ -10,8 +10,8 @@ import { RecordingLevelWaveform } from '@/mobile/recording-level-waveform'
  * elapsed time with a stop control while recording, and the capture-failure
  * state with Retry/Discard. Dragging the sheet down mid-recording
  * stops-and-saves — dismissal must never silently drop audio; discarding is
- * the explicit Cancel control. The provider owns open state and the
- * stop/cancel semantics behind `onDrawerOpenChange`.
+ * explicit and requires a second tap. The provider owns open state and the
+ * stop/discard semantics behind `onDrawerOpenChange`.
  */
 export function RecordingDrawer(): ReactElement {
   const memo = useMobileAudioMemo()
@@ -35,36 +35,86 @@ export function RecordingDrawer(): ReactElement {
             </div>
           </div>
         ) : (
-          <div className="flex flex-col items-center gap-4 pb-2">
-            <div className="flex h-7 items-center justify-center">
-              {memo.phase === 'recording' ? (
-                <RecordingLevelWaveform level={memo.level} />
-              ) : (
-                <p className="text-sm text-text-muted">Waiting for the microphone…</p>
-              )}
-            </div>
-            <span className="text-lg font-medium tabular-nums">
-              {formatElapsed(memo.elapsedMs)}
-            </span>
-            <div className="flex w-full flex-col items-center gap-2">
-              <Button
-                variant="destructive"
-                size="icon"
-                aria-label="Stop recording"
-                className="size-14 rounded-full"
-                disabled={memo.phase !== 'recording'}
-                onClick={() => memo.stopAndSave()}
-              >
-                <Square aria-hidden fill="currentColor" className="size-5" />
-              </Button>
-              <Button variant="ghost" size="sm" onClick={() => memo.cancelRecording()}>
-                Cancel
-              </Button>
-            </div>
-          </div>
+          <LiveRecordingControls key={memo.drawerOpen ? 'open' : 'closed'} memo={memo} />
         )}
       </DrawerContent>
     </Drawer>
+  )
+}
+
+type MobileAudioMemo = ReturnType<typeof useMobileAudioMemo>
+
+interface LiveRecordingControlsProps {
+  memo: MobileAudioMemo
+}
+
+function LiveRecordingControls({ memo }: LiveRecordingControlsProps): ReactElement {
+  const [discardArmed, setDiscardArmed] = useState(false)
+  const discardResetTimer = useRef<number | null>(null)
+
+  const clearDiscardReset = (): void => {
+    if (discardResetTimer.current !== null) {
+      window.clearTimeout(discardResetTimer.current)
+      discardResetTimer.current = null
+    }
+  }
+
+  useEffect(
+    () => () => {
+      if (discardResetTimer.current !== null) {
+        window.clearTimeout(discardResetTimer.current)
+      }
+    },
+    [],
+  )
+
+  const confirmDiscard = (): void => {
+    if (!discardArmed) {
+      setDiscardArmed(true)
+      clearDiscardReset()
+      discardResetTimer.current = window.setTimeout(() => {
+        setDiscardArmed(false)
+        discardResetTimer.current = null
+      }, 3000)
+      return
+    }
+    clearDiscardReset()
+    memo.cancelRecording()
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-4 pb-2">
+      <div className="flex h-7 items-center justify-center">
+        {memo.phase === 'recording' ? (
+          <RecordingLevelWaveform level={memo.level} />
+        ) : (
+          <p className="text-sm text-text-muted">Waiting for the microphone…</p>
+        )}
+      </div>
+      <span className="text-lg font-medium tabular-nums">{formatElapsed(memo.elapsedMs)}</span>
+      <div className="flex w-full flex-col items-center gap-3">
+        <Button
+          variant="destructive"
+          size="icon"
+          aria-label="Stop recording"
+          className="size-14 rounded-full"
+          disabled={memo.phase !== 'recording'}
+          onClick={() => memo.stopAndSave()}
+        >
+          <Square aria-hidden fill="currentColor" className="size-5" />
+        </Button>
+        <Button
+          variant={discardArmed ? 'destructive' : 'ghost'}
+          size="sm"
+          className={discardArmed ? undefined : 'text-text-muted'}
+          aria-label={discardArmed ? 'Confirm discard recording' : 'Discard recording'}
+          onClick={confirmDiscard}
+        >
+          <Trash2 aria-hidden className="size-3.5" />
+          {discardArmed ? 'Tap again to discard' : 'Discard'}
+        </Button>
+      </div>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Problem

The iOS audio memo drawer had a one-tap `Cancel` button directly under the stop control. That made it easy to accidentally discard a live recording, and the label was ambiguous: it looked like it might dismiss the sheet, but it actually dropped the memo.

## Before -> After

| Before | After |
| --- | --- |
| `Cancel` immediately discarded the live recording. | `Discard` arms the action; a second tap on `Tap again to discard` is required before `cancelRecording()` runs. |
| The destructive action stayed hot indefinitely after a tap. | The armed state lapses after 3 seconds, returning the button to the safe first-tap state. |
| Stop/save stayed primary. | Stop/save still commits immediately with no extra confirmation. |

## Changes

1. Split the live recording controls in `RecordingDrawer` into a small private component so discard confirmation state resets with each drawer session.
2. Replace the direct `Cancel` call with an inline two-tap discard affordance using explicit destructive copy on the confirmation tap.
3. Add `recording-drawer.test.tsx` coverage for the first-tap arm, second-tap discard, timeout reset, and unchanged primary stop/save path.

## Verification

- `pnpm --filter @reflect/desktop exec vitest run src/mobile/recording-drawer.test.tsx` passed.
- `pnpm --filter @reflect/desktop exec vitest run src/mobile/audio-memo-provider.test.tsx` passed.
- `pnpm check` passed. It still prints the existing `packages/core/src/indexing/indexer.ts` max-lines warning.

## Risk / Rollout

No data migrations or native plugin changes. The recording lifecycle remains owned by the existing mobile audio memo provider; this only adds a two-tap confirmation gate before the existing discard callback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change in the mobile recording drawer; recording lifecycle and provider APIs are unchanged aside from gating discard behind confirmation.
> 
> **Overview**
> **Live recording discard** no longer fires on a single tap. The drawer replaces the ambiguous **Cancel** control with a **Discard** button (trash icon, muted styling) that must be tapped twice: the first tap arms confirmation (“Tap again to discard”, destructive styling), and only the second tap calls the existing `cancelRecording()` path. Armed state auto-resets after **3 seconds**.
> 
> Recording UI is split into **`LiveRecordingControls`**, keyed off drawer open/closed so confirmation state does not leak across sessions. **Stop recording** still calls `stopAndSave()` immediately with no extra step; error-state Retry/Discard is unchanged.
> 
> Adds **`recording-drawer.test.tsx`** for the two-tap flow, timeout re-arm behavior, and unchanged stop/save.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63e4e66b4e94d837ad1415e25de0503756ea1b4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->