### PR TITLE
Fix pinned sidebar title wikilinks

### DIFF
--- a/apps/desktop/src/components/sidebar/sidebar-pinned.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar-pinned.tsx
@@ -13,6 +13,7 @@ import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { usePinnedNotes } from '@/hooks/use-pinned-notes'
 import { useReorderPinnedNotes } from '@/hooks/use-reorder-pinned-notes'
 import { formatDayLabel } from '@/lib/dates'
+import { displayNoteTitle } from '@/lib/note-title-display'
 import { useSettings } from '@/providers/settings-provider'
 import { routeForPath, routesEqual } from '@/routing/route'
 import { useRouter } from '@/routing/router'
@@ -86,7 +87,7 @@ export function SidebarPinned(): ReactElement | null {
               overlay
               label={
                 activeNote.dailyDate === null
-                  ? activeNote.title
+                  ? displayNoteTitle(activeNote.title)
                   : formatDayLabel(activeNote.dailyDate, settings.dateFormat)
               }
             />

--- a/apps/desktop/src/components/sidebar/sidebar-sortable-pinned-row.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar-sortable-pinned-row.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/lib/notes/pinned-notes-cache'
 import { formatDayLabel } from '@/lib/dates'
 import { openNativeContextMenu } from '@/lib/native-menu/context-menu'
+import { displayNoteTitle } from '@/lib/note-title-display'
 import { unpinNote } from '@/lib/note-pin'
 import { startOperation } from '@/lib/operations'
 import { useGraph } from '@/providers/graph-provider'
@@ -32,7 +33,9 @@ export const SidebarSortablePinnedRow = memo(function SidebarSortablePinnedRow({
   const target = routeForPath(note.path)
   const active = routesEqual(route, target)
   const label =
-    note.dailyDate !== null ? formatDayLabel(note.dailyDate, settings.dateFormat) : note.title
+    note.dailyDate !== null
+      ? formatDayLabel(note.dailyDate, settings.dateFormat)
+      : displayNoteTitle(note.title)
   const {
     isDragging,
     listeners,

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -271,6 +271,18 @@ describe('Sidebar', () => {
     await waitFor(() => expect(roadmap.getAttribute('aria-current')).toBe('page'))
   })
 
+  it('renders wiki links in pinned note titles as display text', async () => {
+    getPinnedNotes.mockResolvedValue([
+      { path: 'notes/meeting.md', title: 'Meeting with [[Ada Lovelace|Ada]]', dailyDate: null },
+    ])
+    const { view } = renderSidebar()
+
+    const pinnedSection = await view.findByRole('region', { name: /pinned notes/i })
+    expect(pinnedSection.textContent).toContain('Meeting with Ada')
+    expect(pinnedSection.textContent).not.toContain('[[Ada Lovelace|Ada]]')
+    expect(view.getByRole('button', { name: 'Meeting with Ada' })).toBeTruthy()
+  })
+
   it('All notes is inactive while the active note is pinned', async () => {
     getPinnedNotes.mockResolvedValue([
       { path: 'notes/roadmap.md', title: 'Roadmap', dailyDate: null },

--- a/apps/desktop/src/lib/note-title-display.ts
+++ b/apps/desktop/src/lib/note-title-display.ts
@@ -1,0 +1,16 @@
+import { scanInlineSegments } from '@reflect/core'
+
+export function displayNoteTitle(title: string): string {
+  return scanInlineSegments(title)
+    .map((segment) => {
+      switch (segment.kind) {
+        case 'text':
+          return segment.text
+        case 'wikiLink':
+          return segment.alias ?? segment.target
+        case 'link':
+          return segment.text
+      }
+    })
+    .join('')
+}


### PR DESCRIPTION
## Problem
Pinned notes whose title includes a wiki link render the raw markdown source in the sidebar, e.g. `Meeting with [[Ada Lovelace|Ada]]`, while the editor displays the link text.

## Before -> After
| Before | After |
| --- | --- |
| Pinned sidebar rows showed `[[...]]` wiki-link syntax in note titles. | Pinned rows and drag previews render wiki links as their visible text, including aliases. |

## Changes
1. Added `displayNoteTitle`, which reuses `scanInlineSegments` from `@reflect/core` to turn title inline links into display text.
2. Applied that helper to pinned sidebar rows and the drag overlay label.
3. Added a sidebar regression test for an aliased wiki link in a pinned note title.

## Verification
- `pnpm --filter @reflect/desktop exec vitest run src/components/sidebar/sidebar.test.tsx` passed.
- `pnpm check` passed. Existing lint warning remains: `packages/core/src/indexing/indexer.ts` exceeds the max-lines rule.

## Risk / Rollout
Low risk; this is UI-only title formatting for the pinned sidebar and does not change indexed note identity, title keys, or rename behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only title formatting in the pinned sidebar; no changes to indexing, identity, or pin behavior.
> 
> **Overview**
> Pinned sidebar rows and drag previews no longer show raw `[[...]]` wiki-link syntax in note titles. They now use a new **`displayNoteTitle`** helper that walks title text via **`scanInlineSegments`** from `@reflect/core`, showing alias or target for wiki links (and link text for markdown links) like the editor.
> 
> Daily pinned notes still use **`formatDayLabel`**; only non-daily titles go through the formatter. A sidebar test covers an aliased wiki link in a pinned title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a465e20fb2d9a26bebfb99dc69e0c3dbf99ac07f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->