### PR TITLE
Fix iOS lock-screen record widget deadlocking the app on tap

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -294,14 +294,21 @@ pub fn run() {
             #[cfg(any(target_os = "macos", target_os = "ios"))]
             tauri::RunEvent::Opened { urls } => {
                 #[cfg(mobile)]
-                {
-                    use tauri_plugin_recording::RecordingExt;
-                    for url in urls {
-                        if url.scheme() == "reflect" && url.host_str() == Some("record-audio") {
+                for url in urls {
+                    if url.scheme() == "reflect" && url.host_str() == Some("record-audio") {
+                        // This callback runs on the main thread, and
+                        // `run_mobile_plugin` blocks its caller until the
+                        // Swift command resolves — which `queueAction` does
+                        // from the main queue. Calling it inline deadlocks
+                        // the main thread (the watchdog then kills the app),
+                        // so queue from a worker thread instead.
+                        let app = app.clone();
+                        tauri::async_runtime::spawn_blocking(move || {
+                            use tauri_plugin_recording::RecordingExt;
                             if let Err(err) = app.recording().queue_action("recordAudio") {
                                 tracing::warn!(error = %err, "queueing the record-audio action failed");
                             }
-                        }
+                        });
                     }
                 }
                 #[cfg(not(mobile))]


### PR DESCRIPTION
## Problem

Tapping the lock-screen record widget killed the iOS app instead of starting an audio memo, while the Action button entry point worked fine.

The two entry points take different paths into the same native-action handshake:

- **Action button** → in-process `StartRecordingIntent` → NotificationCenter → `queueNativeAction` (pure Swift, no Rust round-trip). Works.
- **Lock-screen widget** → opens `reflect://record-audio` → tao delivers `RunEvent::Opened` **on the main thread** → `app.recording().queue_action("recordAudio")`.

`queue_action` uses Tauri's `run_mobile_plugin`, which **blocks its calling thread** on a channel until the Swift command resolves. The Swift `queueAction` handler hops to `DispatchQueue.main.async` before resolving — but the main queue is the very thread sitting blocked in the channel recv. The resolve block can never run, the main thread deadlocks permanently, and the iOS watchdog kills the app. To the user: tap widget → app opens → dies.

The webview-initiated plugin commands (`startRecording`, `actionsReady`, …) never hit this because Tauri runs them off the main thread — only the `RunEvent::Opened` call site runs on main.

## Changes

One call site in `apps/desktop/src-tauri/src/lib.rs`: the `RunEvent::Opened` handler now clones the `AppHandle` and calls `queue_action` from `tauri::async_runtime::spawn_blocking` (the crate's existing pattern for blocking native work) instead of inline on the main thread. The Swift side resolves on the main queue as before; the worker thread receives it. No plugin/Swift changes.

## Tests

No new automated tests — the deadlock lives in the tao main-thread ↔ plugin dispatch interaction, which unit tests can't reach.

## Verification

- `cargo check -p reflect-open --target aarch64-apple-ios` and host `cargo check` / `cargo clippy` pass (two pre-existing iOS-target clippy warnings untouched).
- Simulator smoke (iPhone 17 Pro, `pnpm tauri ios dev`): fired `xcrun simctl openurl booted reflect://record-audio` at the running app — the sim log shows the URL delivered to `app.reflect.ios`, and the app stayed alive and responsive afterwards. Before the fix this exact delivery would freeze the main thread on the spot.
- Not verified end-to-end: I couldn't confirm the recording drawer visibly opening in the simulator run, and the real lock-screen widget tap needs a device. @maccman is confirming the full widget → recording flow manually on device.

## Risk / Rollout

- iOS-only; desktop `RunEvent::Opened` handling (deep-link plugin path) is untouched.
- The action queue semantics are unchanged — the request still persists in UserDefaults until the webview confirms, so ordering with `actionsReady` is preserved regardless of which thread queues it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single iOS-only call-site change with unchanged action-queue semantics; desktop `RunEvent::Opened` is untouched.
> 
> **Overview**
> Fixes an iOS crash when the lock-screen record widget opens `reflect://record-audio` by no longer calling the recording plugin’s `queue_action` on the main thread inside `RunEvent::Opened`.
> 
> That handler runs on the main thread, while `queue_action` blocks until Swift resolves on the main queue—so an inline call deadlocks and the watchdog kills the app. The URL is still matched the same way; **`queue_action("recordAudio")` now runs inside `tauri::async_runtime::spawn_blocking`** with a cloned `AppHandle`, matching other blocking native work in the shell. Desktop deep-link handling is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f959a1f09295371f2182894ad7d13c84040b1f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->