### PR TITLE
Keep the daily double-tap caret in view on long iOS notes

### DIFF
--- a/apps/desktop/src/components/route-content.test.tsx
+++ b/apps/desktop/src/components/route-content.test.tsx
@@ -43,6 +43,7 @@ vi.mock('@/editor/note-editor', async () => {
           insertMarkdown: () => {},
           focus: () => editorProbe.focusCalls.push('focus'),
           setSelection: () => {},
+          scrollIntoView: () => {},
           getSelectedText: () => '',
           openSelectionMenu: () => {},
           startPendingReplacement: () => false,

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -78,6 +78,13 @@ export interface NoteEditorHandle {
    * previous day / the start of the next day).
    */
   setSelection(position: 'start' | 'end'): void
+  /**
+   * Scroll the caret (the current selection) into view if it sits outside
+   * the visible area — a no-op while it is visible. Layout that settles
+   * after focus (the iOS keyboard raise, images sizing in) can push the
+   * caret off screen; this re-reveals it without touching the selection.
+   */
+  scrollIntoView(): void
   /** The current selection's text (blocks separated by blank lines). */
   getSelectedText(): string
   /** Open the selection AI menu (no-op on an empty selection). */
@@ -258,6 +265,7 @@ export function NoteEditor({
       insertMarkdown: (markdown) => innerRef.current?.insertMarkdown(markdown),
       focus: () => innerRef.current?.focus(),
       setSelection: (position) => innerRef.current?.setSelection(position),
+      scrollIntoView: () => innerRef.current?.scrollIntoView(),
       getSelectedText: () => innerRef.current?.getSelectedText() ?? '',
       openSelectionMenu: () => innerRef.current?.openSelectionMenu(),
       startPendingReplacement: (options) =>

--- a/apps/desktop/src/editor/use-note-document.test.tsx
+++ b/apps/desktop/src/editor/use-note-document.test.tsx
@@ -34,6 +34,7 @@ function fakeEditor(): NoteEditorHandle & { applied: string[] } {
     insertMarkdown: () => {},
     focus: () => {},
     setSelection: () => {},
+    scrollIntoView: () => {},
     getSelectedText: () => '',
     openSelectionMenu: () => {},
     startPendingReplacement: () => false,

--- a/apps/desktop/src/editor/use-template-slash-items.test.ts
+++ b/apps/desktop/src/editor/use-template-slash-items.test.ts
@@ -33,6 +33,7 @@ function fakeEditor(): NoteEditorHandle & { inserted: string[] } {
     },
     focus: () => {},
     setSelection: () => {},
+    scrollIntoView: () => {},
     getSelectedText: () => '',
     openSelectionMenu: () => {},
     startPendingReplacement: () => false,

--- a/apps/desktop/src/lib/attach-files.test.ts
+++ b/apps/desktop/src/lib/attach-files.test.ts
@@ -41,6 +41,7 @@ function editorHandle(): NoteEditorHandle & {
     insertMarkdown: vi.fn<(markdown: string) => void>(),
     focus: () => {},
     setSelection: () => {},
+    scrollIntoView: () => {},
     getSelectedText: () => '',
     openSelectionMenu: () => {},
     startPendingReplacement: () => false,

--- a/apps/desktop/src/mobile/day-slide.tsx
+++ b/apps/desktop/src/mobile/day-slide.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, type ReactElement } from 'react'
 import { dailyPath } from '@reflect/core'
 import { NotePane } from '@/components/note-pane'
+import { noteEditorHandleFor } from '@/editor/editor-handle-registry'
 import { formatDayLabel } from '@/lib/dates'
 import { cn } from '@/lib/utils'
 import { IncomingBacklinks } from '@/mobile/incoming-backlinks'
@@ -64,12 +65,24 @@ export function DaySlide({
     contentRef,
   })
 
-  const { revealEnd, cancelReveal } = useCaretReveal({ containerRef, contentRef })
+  // The day's editor registers under its note path as it mounts — before the
+  // autofocus that starts a reveal — so the lookup only misses after the
+  // editor unmounted, when there is no caret left to reveal.
+  const scrollCaretIntoView = useCallback(() => {
+    noteEditorHandleFor(dailyPath(day))?.scrollIntoView()
+  }, [day])
+
+  const { revealEnd, cancelReveal } = useCaretReveal({
+    containerRef,
+    contentRef,
+    scrollCaretIntoView,
+  })
 
   // The end-of-note autofocus scrolls the caret into view against the
   // full-height viewport; the keyboard then raises and shrinks the shell by
-  // its height, dropping the note's end below the fold. The reveal holds the
-  // container at its end while that settles (see use-caret-reveal.ts).
+  // its height — and a long note keeps growing as images size in — dropping
+  // the caret below the fold. The reveal keeps scrolling it back into view
+  // while that settles (see use-caret-reveal.ts).
   //
   // A remount's scroll restore must die first: the double-tap's second
   // arrival often lands while this slide (freshly remounted from another

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -77,6 +77,7 @@ vi.mock('@/editor/note-editor', async () => {
           setSelection: (position: 'start' | 'end') => {
             editorProbe.selectionCalls.push(position)
           },
+          scrollIntoView: () => {},
           getSelectedText: () => '',
           openSelectionMenu: () => {},
           startPendingReplacement: () => false,

--- a/apps/desktop/src/mobile/screens/tasks.test.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.test.tsx
@@ -100,6 +100,7 @@ vi.mock('@/editor/note-editor', async () => {
             editorProbe.focusCalls += 1
           },
           setSelection: () => {},
+          scrollIntoView: () => {},
           getSelectedText: () => '',
           openSelectionMenu: () => {},
           startPendingReplacement: () => false,

--- a/apps/desktop/src/mobile/use-caret-reveal.test.ts
+++ b/apps/desktop/src/mobile/use-caret-reveal.test.ts
@@ -4,11 +4,12 @@ import { REVEAL_WINDOW_MS, useCaretReveal } from './use-caret-reveal'
 
 /**
  * The end-of-note reveal in isolation (extracted from DaySlide). jsdom has no
- * layout, so the container is faked with a controllable scroll range and a
- * hand-fired ResizeObserver — the same harness as use-scroll-restore. The
- * contract under test: the double-tap's caret lands at the note's end before
- * the iOS keyboard reports its height, so the reveal must re-pin the
- * container to its end as it shrinks, then get out of the user's way.
+ * layout, so the caret scroll is a recording spy and the ResizeObserver is
+ * hand-fired — the same harness as use-scroll-restore. The contract under
+ * test: the double-tap's caret lands at the note's end before the iOS
+ * keyboard reports its height (and before a long note's images size in), so
+ * the reveal must keep asking the editor to scroll the caret back into view
+ * as the layout churns, then get out of the user's way.
  */
 
 class FakeResizeObserver {
@@ -48,44 +49,17 @@ function observer(): FakeResizeObserver | undefined {
   return FakeResizeObserver.instances[0]
 }
 
-interface FakeScrollable {
-  element: HTMLDivElement
-  /** Change the scrollable range, as a keyboard raise (shrink) would. */
-  setScrollRange: (options: { scrollHeight: number; maxScrollTop: number }) => void
-}
-
-function createScrollable(scrollHeight: number, maxScrollTop: number): FakeScrollable {
-  const element = document.createElement('div')
-  let height = scrollHeight
-  let max = maxScrollTop
-  let top = 0
-  Object.defineProperty(element, 'scrollHeight', {
-    get: () => height,
-  })
-  Object.defineProperty(element, 'scrollTop', {
-    get: () => top,
-    set: (value: number) => {
-      top = Math.min(Math.max(value, 0), max)
-    },
-  })
-  return {
-    element,
-    setScrollRange: (options) => {
-      height = options.scrollHeight
-      max = options.maxScrollTop
-      top = Math.min(top, max)
-    },
-  }
-}
-
-function mountReveal(options: { scrollHeight: number; maxScrollTop: number }) {
-  const scrollable = createScrollable(options.scrollHeight, options.maxScrollTop)
+function mountReveal() {
+  const container = document.createElement('div')
   const content = document.createElement('div')
-  scrollable.element.appendChild(content)
-  const containerRef = { current: scrollable.element }
+  container.appendChild(content)
+  const containerRef = { current: container }
   const contentRef = { current: content }
-  const hook = renderHook(() => useCaretReveal({ containerRef, contentRef }))
-  return { scrollable, content, hook }
+  const scrollCaretIntoView = vi.fn()
+  const hook = renderHook(() =>
+    useCaretReveal({ containerRef, contentRef, scrollCaretIntoView }),
+  )
+  return { container, content, scrollCaretIntoView, hook }
 }
 
 beforeEach(() => {
@@ -101,81 +75,84 @@ afterEach(() => {
 })
 
 describe('useCaretReveal', () => {
-  it('pins the container to its end immediately and re-pins as it shrinks', () => {
-    const { scrollable, content, hook } = mountReveal({ scrollHeight: 900, maxScrollTop: 400 })
+  it('reveals the caret immediately and re-reveals as the layout changes', () => {
+    const { container, content, scrollCaretIntoView, hook } = mountReveal()
 
     hook.result.current.revealEnd()
-    expect(scrollable.element.scrollTop).toBe(400)
-    expect(observer()?.observed).toContain(scrollable.element)
+    expect(scrollCaretIntoView).toHaveBeenCalledTimes(1)
+    expect(observer()?.observed).toContain(container)
     expect(observer()?.observed).toContain(content)
 
     // The keyboard raises: the shell (and the container) shrink by its
-    // height, so the reachable range grows and the end drops out of view.
-    scrollable.setScrollRange({ scrollHeight: 900, maxScrollTop: 716 })
+    // height, dropping an end-of-note caret under the keyboard. Late content
+    // growth (images sizing in) fires the same observer.
     observer()?.resize()
-    expect(scrollable.element.scrollTop).toBe(716)
+    expect(scrollCaretIntoView).toHaveBeenCalledTimes(2)
   })
 
-  it('re-pins on late content growth (images sizing in)', () => {
-    const { scrollable, hook } = mountReveal({ scrollHeight: 900, maxScrollTop: 400 })
-
-    hook.result.current.revealEnd()
-    scrollable.setScrollRange({ scrollHeight: 1300, maxScrollTop: 800 })
-    observer()?.resize()
-    expect(scrollable.element.scrollTop).toBe(800)
-  })
-
-  it('re-pins when something scrolls the container away without a resize', () => {
-    const { scrollable, hook } = mountReveal({ scrollHeight: 900, maxScrollTop: 400 })
+  it('re-reveals when something scrolls the container without a resize', () => {
+    const { container, scrollCaretIntoView, hook } = mountReveal()
 
     hook.result.current.revealEnd()
     // iOS WebKit scrolls the container directly to reveal the newly focused
     // editor — no size change, so the observer never fires. The user's own
     // take-over always leads with a pointerdown, so a bare scroll is never
     // the user's.
-    scrollable.element.scrollTop = 120
-    scrollable.element.dispatchEvent(new Event('scroll'))
-    expect(scrollable.element.scrollTop).toBe(400)
+    container.dispatchEvent(new Event('scroll'))
+    expect(scrollCaretIntoView).toHaveBeenCalledTimes(2)
   })
 
   it('stops chasing scrolls once the reveal ends', () => {
-    const { scrollable, hook } = mountReveal({ scrollHeight: 900, maxScrollTop: 400 })
+    const { container, scrollCaretIntoView, hook } = mountReveal()
 
     hook.result.current.revealEnd()
-    scrollable.element.dispatchEvent(new Event('pointerdown'))
-    scrollable.element.scrollTop = 120
-    scrollable.element.dispatchEvent(new Event('scroll'))
-    expect(scrollable.element.scrollTop).toBe(120)
+    container.dispatchEvent(new Event('pointerdown'))
+    container.dispatchEvent(new Event('scroll'))
+    expect(scrollCaretIntoView).toHaveBeenCalledTimes(1)
   })
 
-  it('ends the reveal at the deadline — later resizes leave the user alone', () => {
-    const { scrollable, hook } = mountReveal({ scrollHeight: 900, maxScrollTop: 400 })
+  it('ends the reveal after a quiet window — later churn leaves the user alone', () => {
+    const { scrollCaretIntoView, hook } = mountReveal()
 
     hook.result.current.revealEnd()
     vi.advanceTimersByTime(REVEAL_WINDOW_MS)
     expect(observer()?.disconnected).toBe(true)
 
-    scrollable.element.scrollTop = 100
-    scrollable.setScrollRange({ scrollHeight: 900, maxScrollTop: 716 })
     observer()?.resize()
-    expect(scrollable.element.scrollTop).toBe(100)
+    expect(scrollCaretIntoView).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-arms the quiet window on each disturbance, covering churn past one window', () => {
+    const { scrollCaretIntoView, hook } = mountReveal()
+
+    hook.result.current.revealEnd()
+    // A long note's images keep sizing in: each growth lands inside the
+    // current window and re-arms it, so the reveal outlives a single fixed
+    // window while the layout is still moving.
+    vi.advanceTimersByTime(REVEAL_WINDOW_MS - 100)
+    observer()?.resize()
+    vi.advanceTimersByTime(REVEAL_WINDOW_MS - 100)
+    expect(observer()?.disconnected).toBe(false)
+    observer()?.resize()
+    expect(scrollCaretIntoView).toHaveBeenCalledTimes(3)
+
+    vi.advanceTimersByTime(REVEAL_WINDOW_MS)
+    expect(observer()?.disconnected).toBe(true)
   })
 
   it('hands control to the user on pointerdown', () => {
-    const { scrollable, hook } = mountReveal({ scrollHeight: 900, maxScrollTop: 400 })
+    const { container, scrollCaretIntoView, hook } = mountReveal()
 
     hook.result.current.revealEnd()
-    scrollable.element.dispatchEvent(new Event('pointerdown'))
+    container.dispatchEvent(new Event('pointerdown'))
     expect(observer()?.disconnected).toBe(true)
 
-    scrollable.element.scrollTop = 100
-    scrollable.setScrollRange({ scrollHeight: 900, maxScrollTop: 716 })
     observer()?.resize()
-    expect(scrollable.element.scrollTop).toBe(100)
+    expect(scrollCaretIntoView).toHaveBeenCalledTimes(1)
   })
 
-  it('restarts the window when called again, replacing the old reveal', () => {
-    const { scrollable, hook } = mountReveal({ scrollHeight: 900, maxScrollTop: 400 })
+  it('restarts the reveal when called again, replacing the old one', () => {
+    const { scrollCaretIntoView, hook } = mountReveal()
 
     hook.result.current.revealEnd()
     const first = observer()
@@ -183,40 +160,33 @@ describe('useCaretReveal', () => {
     expect(first?.disconnected).toBe(true)
     expect(FakeResizeObserver.instances).toHaveLength(2)
 
-    scrollable.setScrollRange({ scrollHeight: 900, maxScrollTop: 716 })
     FakeResizeObserver.instances[1]?.resize()
-    expect(scrollable.element.scrollTop).toBe(716)
+    expect(scrollCaretIntoView).toHaveBeenCalledTimes(3)
   })
 
   it('cancelReveal ends an active reveal without touching the scroll position', () => {
-    const { scrollable, hook } = mountReveal({ scrollHeight: 900, maxScrollTop: 400 })
+    const { scrollCaretIntoView, hook } = mountReveal()
 
     hook.result.current.revealEnd()
-    expect(scrollable.element.scrollTop).toBe(400)
+    expect(scrollCaretIntoView).toHaveBeenCalledTimes(1)
     hook.result.current.cancelReveal()
     expect(observer()?.disconnected).toBe(true)
-    expect(scrollable.element.scrollTop).toBe(400)
 
-    // An explicit jump-to-top after the cancel must stick: no late re-pin
+    // An explicit jump-to-top after the cancel must stick: no late re-reveal
     // when the keyboard dismisses or content grows, and no live deadline.
-    scrollable.element.scrollTop = 0
-    scrollable.setScrollRange({ scrollHeight: 900, maxScrollTop: 716 })
     observer()?.resize()
-    expect(scrollable.element.scrollTop).toBe(0)
     vi.advanceTimersByTime(REVEAL_WINDOW_MS)
-    expect(scrollable.element.scrollTop).toBe(0)
+    expect(scrollCaretIntoView).toHaveBeenCalledTimes(1)
   })
 
   it('stops the reveal on unmount', () => {
-    const { scrollable, hook } = mountReveal({ scrollHeight: 900, maxScrollTop: 400 })
+    const { scrollCaretIntoView, hook } = mountReveal()
 
     hook.result.current.revealEnd()
     hook.unmount()
     expect(observer()?.disconnected).toBe(true)
 
-    scrollable.element.scrollTop = 100
-    scrollable.setScrollRange({ scrollHeight: 900, maxScrollTop: 716 })
     observer()?.resize()
-    expect(scrollable.element.scrollTop).toBe(100)
+    expect(scrollCaretIntoView).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/mobile/use-caret-reveal.ts
+++ b/apps/desktop/src/mobile/use-caret-reveal.ts
@@ -1,44 +1,58 @@
 import { useCallback, useEffect, useRef, type RefObject } from 'react'
 
-/** How long a reveal keeps re-pinning the container to its end. The iOS
- *  keyboard raise (and the shell shrinking by its height) settles well within
- *  a second; past this the user's scrolling owns the position. */
+/** How long a reveal outlives the *last* layout disturbance before handing
+ *  the scroll back to the user. The iOS keyboard raise (and the shell
+ *  shrinking by its height) settles well within a second; each container
+ *  resize, content growth, or stray scroll re-arms the window, so churn
+ *  that outlasts one window (a long note's images sizing in late) is still
+ *  covered. */
 export const REVEAL_WINDOW_MS = 1500
 
 export interface CaretRevealOptions {
-  /** The scroll container to hold at its end while the reveal is active. */
+  /** The scroll container whose disturbances re-reveal the caret. */
   containerRef: RefObject<HTMLElement | null>
-  /** The container's content, observed so late growth re-pins too. */
+  /** The container's content, observed so late growth re-reveals too. */
   contentRef: RefObject<HTMLElement | null>
+  /**
+   * Scroll the editor caret into view if it left the visible area — a no-op
+   * while it is visible ({@link NoteEditorHandle.scrollIntoView} semantics).
+   */
+  scrollCaretIntoView: () => void
 }
 
 export interface CaretReveal {
   /**
-   * Scroll the container to its end now and keep it there while the layout
+   * Scroll the caret into view now and keep re-revealing it while the layout
    * settles. The reveal ends when the user touches the container
-   * (pointerdown), {@link REVEAL_WINDOW_MS} passes, or the component
-   * unmounts; calling it again restarts the window.
+   * (pointerdown), the layout goes quiet for {@link REVEAL_WINDOW_MS}, or
+   * the component unmounts; calling it again restarts the reveal.
    */
   revealEnd: () => void
   /**
    * End an active reveal without touching the scroll position. An explicit
    * re-anchor (the slide's jump-to-top) must call this first — a live reveal
-   * would otherwise re-pin to the end on the next resize and undo it.
+   * would otherwise re-reveal the caret on the next resize and undo it.
    */
   cancelReveal: () => void
 }
 
 /**
- * Keeps an end-of-note caret visible through the iOS keyboard raise. The
- * editor's own scroll-into-view runs at focus time — against the full-height
- * viewport — but the keyboard reports its height only once it animates up,
- * and the shell then shrinks by that height (Plan 19, decision 8), dropping
- * the note's end below the fold again with nothing re-scrolling. A reveal
- * pins the container to its end and re-pins on every container resize (the
- * keyboard raise, a rotation) or content growth (images sizing in) until the
- * window closes or the user takes over.
+ * Keeps an end-of-note caret visible through the iOS keyboard raise and late
+ * layout growth. The editor's own scroll-into-view runs once at focus time —
+ * against the full-height viewport — but the keyboard reports its height only
+ * once it animates up, and the shell then shrinks by that height (Plan 19,
+ * decision 8); a long note also keeps growing after focus as images and file
+ * pills size in. Both push the caret out of the viewport with nothing
+ * re-scrolling. A reveal asks the editor to scroll the caret back into view
+ * on every container resize (the keyboard raise, a rotation), content growth,
+ * or stray scroll, each of which re-arms the quiet window, until the window
+ * closes or the user takes over.
  */
-export function useCaretReveal({ containerRef, contentRef }: CaretRevealOptions): CaretReveal {
+export function useCaretReveal({
+  containerRef,
+  contentRef,
+  scrollCaretIntoView,
+}: CaretRevealOptions): CaretReveal {
   const stopRef = useRef<(() => void) | null>(null)
 
   useEffect(() => () => stopRef.current?.(), [])
@@ -52,9 +66,6 @@ export function useCaretReveal({ containerRef, contentRef }: CaretRevealOptions)
     stopRef.current?.()
     let observer: ResizeObserver | null = null
     let deadline: ReturnType<typeof setTimeout> | null = null
-    const pin = (): void => {
-      container.scrollTop = container.scrollHeight
-    }
     const stop = (): void => {
       if (stopRef.current === stop) {
         stopRef.current = null
@@ -64,22 +75,28 @@ export function useCaretReveal({ containerRef, contentRef }: CaretRevealOptions)
       }
       observer?.disconnect()
       container.removeEventListener('pointerdown', stop)
-      container.removeEventListener('scroll', pin)
+      container.removeEventListener('scroll', reveal)
+    }
+    const reveal = (): void => {
+      if (deadline !== null) {
+        clearTimeout(deadline)
+      }
+      deadline = setTimeout(stop, REVEAL_WINDOW_MS)
+      scrollCaretIntoView()
     }
     stopRef.current = stop
-    pin()
-    observer = new ResizeObserver(pin)
+    reveal()
+    observer = new ResizeObserver(reveal)
     observer.observe(container)
     observer.observe(content)
     container.addEventListener('pointerdown', stop, { passive: true })
-    // Anything that scrolls the container away mid-reveal loses. Sizes are
+    // Anything that scrolls the caret out of view mid-reveal loses. Sizes are
     // covered by the observer, but iOS WebKit may scroll the container
     // directly to reveal the newly focused editor — no resize involved. The
     // user's own take-over always leads with a pointerdown (which stops the
     // reveal above), so a scroll arriving here is never the user's.
-    container.addEventListener('scroll', pin, { passive: true })
-    deadline = setTimeout(stop, REVEAL_WINDOW_MS)
-  }, [containerRef, contentRef])
+    container.addEventListener('scroll', reveal, { passive: true })
+  }, [containerRef, contentRef, scrollCaretIntoView])
 
   const cancelReveal = useCallback(() => {
     stopRef.current?.()


### PR DESCRIPTION
## Problem

Double-tapping the Daily tab on iOS focuses today's note with the caret at its end (the capture gesture from #585). On long notes the caret sometimes ends up below the fold with nothing scrolling it back, because the reveal that was supposed to hold it visible had two gaps:

- **It was caret-blind.** It pinned the scroll container to its *own* end (`scrollTop = scrollHeight`), a proxy that diverges from the caret by the height of whatever renders below the editor (the backlinks section, bottom padding).
- **It died on a fixed 1500ms timer.** Layout that settles later — images and file pills sizing in on a long note, a slow keyboard raise on older devices — pushed the caret out of the viewport after the window closed, with no mechanism left to bring it back.

## Change

- `NoteEditorHandle` gains `scrollIntoView()`, delegating to meowdown's selection-aware editor scroll (ProseMirror `tr.scrollIntoView()` — a no-op while the caret is visible, minimal scroll when it isn't).
- `useCaretReveal` now reveals the **caret** instead of the container end: every container resize (keyboard raise, rotation), content growth (images sizing in), or stray non-user scroll asks the editor to scroll the caret back into view.
- The reveal window is now a **quiet window**: each disturbance re-arms the 1500ms deadline, so churn that outlasts one fixed window is still covered. The reveal still ends on the user's first touch (`pointerdown`), on `cancelReveal` (the jump-to-top re-anchor), or on unmount — unchanged.
- `DaySlide` resolves the day's editor through the handle registry at reveal time.

Because the pin is now if-needed rather than a forced scroll-to-max, the longer effective window is strictly gentler than the old behavior: while the caret is visible the reveal does nothing.

## Testing

- `use-caret-reveal` unit tests rewritten to the caret-anchored contract (reveal on start/resize/growth/stray scroll, quiet-window re-arm, pointerdown/cancel/unmount teardown) — 9 passing.
- Verified end-to-end in the browser mobile harness (`?platform=ios`) with an 80-line seeded daily note: double-tap lands the caret in view (caret-anchored scroll, not pinned past it to the container end); content growth above the caret — including growth past the old fixed window — keeps it visible; a scroll event mid-reveal is corrected back to the caret; scrolls after pointerdown or after the quiet window stick.
- `pnpm check` clean; all 116 tests across the touched suites pass.
- **Owed:** an on-device pass (real keyboard raise + real scroll events), consistent with the other mobile daily work.

## Risk

Low. The reveal's lifecycle and every consumer are unchanged apart from the pin target; the only visible difference on short notes is that the scroll stops once the caret is visible instead of overshooting to the container's absolute end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is mobile daily autofocus/reveal and a new optional editor handle method; lifecycle and consumers aside from scroll targeting are unchanged.
> 
> **Overview**
> Fixes the iOS Daily double-tap capture gesture so the caret stays on screen on **long daily notes** when the keyboard rises and content keeps growing.
> 
> **`NoteEditorHandle`** adds **`scrollIntoView()`**, delegated to meowdown’s selection-aware scroll (no-op when the caret is already visible).
> 
> **`useCaretReveal`** no longer pins the day slide scroll container to `scrollTop = scrollHeight`. It repeatedly calls **`scrollCaretIntoView`** on resize, content growth, and stray scrolls so the **editor caret** is revealed—not the container bottom (which diverged from the caret because of backlinks and padding). The 1500ms window is now a **quiet window**: each disturbance resets the timer so late image/file layout churn is still covered. Teardown on pointerdown, `cancelReveal`, and unmount is unchanged.
> 
> **`DaySlide`** wires reveal through **`noteEditorHandleFor(dailyPath(day))?.scrollIntoView()`**. Test mocks and **`use-caret-reveal`** tests were updated for the new contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0b0ce415c673473cffc6652d3a56fec1ffd965c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->