### PR TITLE
Add macOS graph switch shortcuts

### DIFF
--- a/apps/desktop/src/components/command-palette/command-palette.test.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.test.tsx
@@ -90,6 +90,7 @@ function renderPalette(query: string, context?: Partial<CommandContext>) {
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
     newChat: vi.fn(),
+    switchGraph: vi.fn(),
     toggleAudioMemo: vi.fn(),
     generation: () => 1,
     openPalette: vi.fn(),

--- a/apps/desktop/src/components/sidebar/graph-footer.tsx
+++ b/apps/desktop/src/components/sidebar/graph-footer.tsx
@@ -31,6 +31,7 @@ const MENU_ITEM_CLASS = 'gap-2 px-2 py-1.5 text-[13px] text-text-secondary'
 const SETTINGS_BINDING = keybindingFor('settings.open')
 
 function graphSwitchBindingFor(index: number): string | null {
+  // Recent rows are zero-based; `graph.switchN` commands and keycaps are one-based.
   return keybindingFor(`graph.switch${index + 1}`)
 }
 

--- a/apps/desktop/src/components/sidebar/graph-footer.tsx
+++ b/apps/desktop/src/components/sidebar/graph-footer.tsx
@@ -30,6 +30,10 @@ import { useRouter } from '@/routing/router'
 const MENU_ITEM_CLASS = 'gap-2 px-2 py-1.5 text-[13px] text-text-secondary'
 const SETTINGS_BINDING = keybindingFor('settings.open')
 
+function graphSwitchBindingFor(index: number): string | null {
+  return keybindingFor(`graph.switch${index + 1}`)
+}
+
 /**
  * The quiet backup indicator: nothing when backed up (or not set up), a
  * pulsing accent dot while backing up, amber when offline with queued
@@ -111,8 +115,9 @@ export function GraphFooter({ graph, context }: GraphFooterProps): ReactElement 
           <TooltipContent>{graph.root}</TooltipContent>
         </Tooltip>
         <DropdownMenuContent aria-label="Switch graph" side="top" sideOffset={6}>
-          {recents.map((recent) => {
+          {recents.map((recent, index) => {
             const current = recent.root === graph.root
+            const binding = graphSwitchBindingFor(index)
             return (
               <Tooltip key={recent.root} delayDuration={700}>
                 <TooltipTrigger asChild>
@@ -128,6 +133,8 @@ export function GraphFooter({ graph, context }: GraphFooterProps): ReactElement 
                     <span className="min-w-0 flex-1 truncate">{recent.name}</span>
                     {current ? (
                       <Check aria-hidden className="size-3.5 shrink-0 text-accent" />
+                    ) : binding !== null ? (
+                      <ShortcutKeys binding={binding} className="text-[10px]" />
                     ) : null}
                   </DropdownMenuItem>
                 </TooltipTrigger>

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -365,7 +365,9 @@ describe('Sidebar', () => {
     const { view } = renderSidebar()
 
     await userEvent.click(view.getByRole('button', { name: /Notes/ }))
-    await userEvent.click(view.getByRole('menuitem', { name: 'Work' }))
+    const work = view.getByRole('menuitem', { name: 'Work' })
+    expect([...work.querySelectorAll('kbd')].map((keycap) => keycap.textContent)).toContain('2')
+    await userEvent.click(work)
     expect(openRecent).toHaveBeenCalledWith('/work')
 
     await userEvent.click(view.getByRole('button', { name: /Notes/ }))

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -135,6 +135,7 @@ function renderSidebar(overrides?: Partial<CommandContext>, initialRoute?: Route
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
     newChat: vi.fn(),
+    switchGraph: vi.fn(),
     toggleAudioMemo: vi.fn(),
     generation: () => 1,
     openPalette,

--- a/apps/desktop/src/lib/attach-files.test.ts
+++ b/apps/desktop/src/lib/attach-files.test.ts
@@ -21,6 +21,7 @@ function contextFor(notePath: string | null, generation: number | null): Command
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
     newChat: vi.fn(),
+    switchGraph: vi.fn(),
     toggleAudioMemo: vi.fn(),
     generation: () => generation,
     openPalette: vi.fn(),

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -76,6 +76,7 @@ function fakeContext(overrides?: Partial<CommandContext>) {
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
     newChat: vi.fn(),
+    switchGraph: vi.fn(),
     toggleAudioMemo: vi.fn(),
     generation: () => 7,
     openPalette: vi.fn(),
@@ -122,6 +123,11 @@ describe('keybindingFor', () => {
 
   it('note.copyDeepLink keeps the V1 copy-link shortcut', () => {
     expect(keybindingFor('note.copyDeepLink')).toBe('Alt-Mod-l')
+  })
+
+  it('graph switch commands use macOS command-number bindings', () => {
+    expect(keybindingFor('graph.switch1')).toBe('Meta-1')
+    expect(keybindingFor('graph.switch9')).toBe('Meta-9')
   })
 })
 
@@ -186,6 +192,17 @@ describe('app commands', () => {
     const { context: outsideChat } = fakeContext()
     await command('chat.new').run(outsideChat)
     expect(outsideChat.newChat).not.toHaveBeenCalled()
+  })
+
+  it('graph switch commands select their recent graph position', async () => {
+    const switchGraph = vi.fn()
+    const { context } = fakeContext({ switchGraph })
+
+    await command('graph.switch1').run(context)
+    await command('graph.switch9').run(context)
+
+    expect(switchGraph).toHaveBeenNthCalledWith(1, 0)
+    expect(switchGraph).toHaveBeenNthCalledWith(2, 8)
   })
 
   it('note.new clears daily scroll and navigates to a fresh lazy ULID note path', async () => {

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -48,7 +48,19 @@ function openNewNote(context: CommandContext): void {
   context.navigate(newNoteRoute())
 }
 
+const GRAPH_SWITCH_COMMANDS: AppCommand[] = Array.from({ length: 9 }, (_, index) => {
+  const position = index + 1
+  return {
+    id: `graph.switch${position}`,
+    title: `Switch to graph ${position}`,
+    keywords: ['graph', 'workspace', 'switch', 'recent'],
+    keybinding: `Meta-${position}`,
+    run: (context) => context.switchGraph(index),
+  }
+})
+
 const APP_COMMANDS: AppCommand[] = [
+  ...GRAPH_SWITCH_COMMANDS,
   {
     id: 'nav.today',
     title: 'Go to today',

--- a/apps/desktop/src/lib/commands/registry.test.ts
+++ b/apps/desktop/src/lib/commands/registry.test.ts
@@ -17,6 +17,7 @@ function fakeContext(overrides?: Partial<CommandContext>): CommandContext {
     toggleTheme: vi.fn(),
     toggleSidebar: vi.fn(),
     newChat: vi.fn(),
+    switchGraph: vi.fn(),
     toggleAudioMemo: vi.fn(),
     generation: () => 1,
     openPalette: vi.fn(),

--- a/apps/desktop/src/lib/commands/types.ts
+++ b/apps/desktop/src/lib/commands/types.ts
@@ -28,6 +28,8 @@ export interface CommandContext {
   toggleSidebar: () => void
   /** Start a fresh chat conversation. */
   newChat: () => void
+  /** Switch to a recent graph by zero-based position in the graph switcher. */
+  switchGraph: (index: number) => void
   /** Start an audio memo, or stop-and-save the one recording. */
   toggleAudioMemo: () => void
   /**

--- a/apps/desktop/src/routing/app-shortcuts.test.tsx
+++ b/apps/desktop/src/routing/app-shortcuts.test.tsx
@@ -246,6 +246,22 @@ describe('app shortcuts', () => {
     expect(openRecent).toHaveBeenCalledWith('/work')
   })
 
+  it('strips Shift from physical digit fallback on layouts where digits require Shift', () => {
+    shortcutsHook()
+
+    act(() => press('2', { code: 'Digit2', shiftKey: true }))
+
+    expect(openRecent).toHaveBeenCalledWith('/work')
+  })
+
+  it('does not turn produced symbols with Shift into graph number shortcuts', () => {
+    shortcutsHook()
+
+    act(() => press('@', { code: 'Digit2', shiftKey: true }))
+
+    expect(openRecent).not.toHaveBeenCalled()
+  })
+
   it('keeps graph switching on the Meta key, not Ctrl-number', () => {
     shortcutsHook()
 

--- a/apps/desktop/src/routing/app-shortcuts.test.tsx
+++ b/apps/desktop/src/routing/app-shortcuts.test.tsx
@@ -11,9 +11,18 @@ import { useAppShortcuts } from './app-shortcuts'
 import { RouterProvider, useRouter } from './router'
 
 const newChat = vi.hoisted(() => vi.fn())
+const openRecent = vi.hoisted(() => vi.fn())
 
 vi.mock('@/providers/graph-provider', () => ({
-  useGraph: () => ({ graph: { root: '/g', name: 'g', generation: 1 } }),
+  useGraph: () => ({
+    graph: { root: '/g', name: 'g', generation: 1 },
+    recents: [
+      { root: '/g', name: 'g', openedMs: 3 },
+      { root: '/work', name: 'Work', openedMs: 2 },
+      { root: '/side', name: 'Side', openedMs: 1 },
+    ],
+    openRecent,
+  }),
 }))
 vi.mock('@/providers/theme-provider', () => ({
   useTheme: () => ({ theme: 'light', resolvedTheme: 'light', setTheme: vi.fn() }),
@@ -33,7 +42,10 @@ vi.mock('@/providers/chat-provider', () => ({
 
 registerAppCommands() // production does this in main.tsx
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  openRecent.mockClear()
+})
 
 function shortcutsHook() {
   return renderHook(
@@ -87,6 +99,8 @@ describe('app shortcuts', () => {
       'Mod-]',
       'Mod-k',
       'Alt-Mod-l',
+      'Meta-1',
+      'Meta-9',
     ]) {
       expect(bindings.get(key)).toBe('app')
     }
@@ -209,6 +223,27 @@ describe('app shortcuts', () => {
     act(() => press('n', { shiftKey: true }))
     expect(result.current.router.route).toEqual({ kind: 'today' })
     expect(newChat).not.toHaveBeenCalled()
+  })
+
+  it('⌘number switches to the matching recent graph', () => {
+    shortcutsHook()
+
+    act(() => press('1'))
+    expect(openRecent).not.toHaveBeenCalled() // first row is already open
+
+    act(() => press('2'))
+    expect(openRecent).toHaveBeenCalledWith('/work')
+
+    act(() => press('9'))
+    expect(openRecent).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps graph switching on the Meta key, not Ctrl-number', () => {
+    shortcutsHook()
+
+    act(() => press('2', { metaKey: false, ctrlKey: true }))
+
+    expect(openRecent).not.toHaveBeenCalled()
   })
 
   it('matches uppercase keys (caps lock) and ignores auto-repeat', () => {

--- a/apps/desktop/src/routing/app-shortcuts.test.tsx
+++ b/apps/desktop/src/routing/app-shortcuts.test.tsx
@@ -238,6 +238,14 @@ describe('app shortcuts', () => {
     expect(openRecent).toHaveBeenCalledTimes(1)
   })
 
+  it('matches graph number shortcuts by physical digit key on symbol-producing layouts', () => {
+    shortcutsHook()
+
+    act(() => press('@', { code: 'Digit2' }))
+
+    expect(openRecent).toHaveBeenCalledWith('/work')
+  })
+
   it('keeps graph switching on the Meta key, not Ctrl-number', () => {
     shortcutsHook()
 

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -69,7 +69,16 @@ function physicalDigitKeyFor(event: KeyboardEvent): string | null {
     return null
   }
   const match = /^Digit([0-9])$/.exec(event.code)
-  return match?.[1] ?? null
+  if (match === null) {
+    return null
+  }
+  const digit = match[1]!
+  // Some layouts type number-row digits with Shift. Treat that as the same
+  // graph-switch shortcut, but don't make US-style Cmd+Shift+@ mean Cmd+2.
+  if (event.shiftKey && event.key !== digit) {
+    return null
+  }
+  return digit
 }
 
 function idForKeyDown(event: KeyboardEvent): string | null {
@@ -79,11 +88,21 @@ function idForKeyDown(event: KeyboardEvent): string | null {
   // Alt participates in the lookup rather than being rejected, so `Alt-Mod-l`
   // can bind while an alt chord still never fires a plain `Mod-` command.
   const alt = event.altKey ? 'Alt-' : ''
-  const shift = event.shiftKey ? 'Shift-' : ''
-  const bindingKeys = [bindingKeyFor(event), physicalDigitKeyFor(event)].filter(
-    (key, index, keys): key is string => key !== null && keys.indexOf(key) === index,
+  const producedKey = bindingKeyFor(event)
+  const physicalDigitKey = physicalDigitKeyFor(event)
+  const bindingKeys = [
+    { key: producedKey, shift: event.shiftKey },
+    physicalDigitKey === null ? null : { key: physicalDigitKey, shift: false },
+  ].filter(
+    (lookup, index, lookups): lookup is { key: string; shift: boolean } =>
+      lookup !== null &&
+      lookups.findIndex(
+        (candidate) =>
+          candidate !== null && candidate.key === lookup.key && candidate.shift === lookup.shift,
+      ) === index,
   )
-  for (const key of bindingKeys) {
+  for (const { key, shift: shifted } of bindingKeys) {
+    const shift = shifted ? 'Shift-' : ''
     const candidates = [
       event.metaKey ? `${alt}Meta-${shift}${key}` : null,
       event.ctrlKey ? `${alt}Ctrl-${shift}${key}` : null,

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -45,10 +45,6 @@ const CODE_TO_BINDING_KEY: Record<string, string> = {
   BracketRight: ']',
 }
 
-function isModKey(event: KeyboardEvent): boolean {
-  return event.metaKey || event.ctrlKey
-}
-
 function bindingKeyFor(event: KeyboardEvent): string {
   if (!event.altKey && event.key.length === 1) {
     return event.key.toLowerCase()
@@ -69,14 +65,26 @@ function bindingKeyFor(event: KeyboardEvent): string {
 }
 
 function idForKeyDown(event: KeyboardEvent): string | null {
-  if (!isModKey(event) || event.repeat) {
+  if ((!event.metaKey && !event.ctrlKey) || event.repeat) {
     return null // held keys must not spam navigations (e.g. a stack of new notes)
   }
   // Alt participates in the lookup rather than being rejected, so `Alt-Mod-l`
   // can bind while an alt chord still never fires a plain `Mod-` command.
   const alt = event.altKey ? 'Alt-' : ''
   const shift = event.shiftKey ? 'Shift-' : ''
-  return BINDING_TO_ID.get(`${alt}Mod-${shift}${bindingKeyFor(event)}`) ?? null
+  const key = bindingKeyFor(event)
+  const candidates = [
+    event.metaKey ? `${alt}Meta-${shift}${key}` : null,
+    event.ctrlKey ? `${alt}Ctrl-${shift}${key}` : null,
+    `${alt}Mod-${shift}${key}`,
+  ].filter((candidate): candidate is string => candidate !== null)
+  for (const candidate of candidates) {
+    const id = BINDING_TO_ID.get(candidate)
+    if (id !== undefined) {
+      return id
+    }
+  }
+  return null
 }
 
 /**
@@ -90,7 +98,7 @@ export function useAppShortcuts(): CommandContext {
   const { route, navigate, back, forward, clearScrollState } = useRouter()
   const focusedDailyDate = useFocusedDailyDate()
   const { resolvedTheme, setTheme } = useTheme()
-  const { graph } = useGraph()
+  const { graph, recents, openRecent } = useGraph()
   const { openPalette, open: paletteOpen } = usePalette()
   const { openShortcuts, closeShortcuts, open: shortcutsOpen } = useShortcuts()
   const {
@@ -118,6 +126,9 @@ export function useAppShortcuts(): CommandContext {
   // Read at run time, not captured: a command can fire long after the render
   // that created the context (palette open across an index rebuild, etc.).
   const generationRef = useRef<number | null>(graph?.generation ?? null)
+  const graphRootRef = useRef<string | null>(graph?.root ?? null)
+  const recentsRef = useRef(recents)
+  const openRecentRef = useRef(openRecent)
   const routeRef = useRef(route)
   const focusedDailyDateRef = useRef(focusedDailyDate)
   useEffect(() => {
@@ -125,6 +136,9 @@ export function useAppShortcuts(): CommandContext {
     shortcutsOpenRef.current = shortcutsOpen
     templatesOpenRef.current = templatePickerOpen || templateCreateOpen
     generationRef.current = graph?.generation ?? null
+    graphRootRef.current = graph?.root ?? null
+    recentsRef.current = recents
+    openRecentRef.current = openRecent
     routeRef.current = route
     focusedDailyDateRef.current = focusedDailyDate
   })
@@ -148,6 +162,13 @@ export function useAppShortcuts(): CommandContext {
       toggleTheme: () => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark'),
       toggleSidebar,
       newChat,
+      switchGraph: (index) => {
+        const recent = recentsRef.current[index]
+        if (recent === undefined || recent.root === graphRootRef.current) {
+          return
+        }
+        void openRecentRef.current(recent.root)
+      },
       toggleAudioMemo,
       generation: () => generationRef.current,
       openPalette,

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -64,6 +64,14 @@ function bindingKeyFor(event: KeyboardEvent): string {
   return event.key.toLowerCase()
 }
 
+function physicalDigitKeyFor(event: KeyboardEvent): string | null {
+  if (event.altKey) {
+    return null
+  }
+  const match = /^Digit([0-9])$/.exec(event.code)
+  return match?.[1] ?? null
+}
+
 function idForKeyDown(event: KeyboardEvent): string | null {
   if ((!event.metaKey && !event.ctrlKey) || event.repeat) {
     return null // held keys must not spam navigations (e.g. a stack of new notes)
@@ -72,16 +80,20 @@ function idForKeyDown(event: KeyboardEvent): string | null {
   // can bind while an alt chord still never fires a plain `Mod-` command.
   const alt = event.altKey ? 'Alt-' : ''
   const shift = event.shiftKey ? 'Shift-' : ''
-  const key = bindingKeyFor(event)
-  const candidates = [
-    event.metaKey ? `${alt}Meta-${shift}${key}` : null,
-    event.ctrlKey ? `${alt}Ctrl-${shift}${key}` : null,
-    `${alt}Mod-${shift}${key}`,
-  ].filter((candidate): candidate is string => candidate !== null)
-  for (const candidate of candidates) {
-    const id = BINDING_TO_ID.get(candidate)
-    if (id !== undefined) {
-      return id
+  const bindingKeys = [bindingKeyFor(event), physicalDigitKeyFor(event)].filter(
+    (key, index, keys): key is string => key !== null && keys.indexOf(key) === index,
+  )
+  for (const key of bindingKeys) {
+    const candidates = [
+      event.metaKey ? `${alt}Meta-${shift}${key}` : null,
+      event.ctrlKey ? `${alt}Ctrl-${shift}${key}` : null,
+      `${alt}Mod-${shift}${key}`,
+    ].filter((candidate): candidate is string => candidate !== null)
+    for (const candidate of candidates) {
+      const id = BINDING_TO_ID.get(candidate)
+      if (id !== undefined) {
+        return id
+      }
     }
   }
   return null

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -45,6 +45,11 @@ const CODE_TO_BINDING_KEY: Record<string, string> = {
   BracketRight: ']',
 }
 
+interface BindingKeyLookup {
+  key: string
+  shift: boolean
+}
+
 function bindingKeyFor(event: KeyboardEvent): string {
   if (!event.altKey && event.key.length === 1) {
     return event.key.toLowerCase()
@@ -81,34 +86,45 @@ function physicalDigitKeyFor(event: KeyboardEvent): string | null {
   return digit
 }
 
+function addBindingLookup(lookups: BindingKeyLookup[], lookup: BindingKeyLookup): void {
+  if (lookups.some((existing) => existing.key === lookup.key && existing.shift === lookup.shift)) {
+    return
+  }
+  lookups.push(lookup)
+}
+
+function bindingLookupsFor(event: KeyboardEvent): BindingKeyLookup[] {
+  const lookups: BindingKeyLookup[] = []
+  addBindingLookup(lookups, { key: bindingKeyFor(event), shift: event.shiftKey })
+
+  const digit = physicalDigitKeyFor(event)
+  if (digit !== null) {
+    addBindingLookup(lookups, { key: digit, shift: false })
+  }
+
+  return lookups
+}
+
+function modifierPrefixesFor(event: KeyboardEvent): string[] {
+  const alt = event.altKey ? 'Alt-' : ''
+  return [
+    event.metaKey ? `${alt}Meta-` : null,
+    event.ctrlKey ? `${alt}Ctrl-` : null,
+    `${alt}Mod-`,
+  ].filter((prefix): prefix is string => prefix !== null)
+}
+
 function idForKeyDown(event: KeyboardEvent): string | null {
   if ((!event.metaKey && !event.ctrlKey) || event.repeat) {
     return null // held keys must not spam navigations (e.g. a stack of new notes)
   }
-  // Alt participates in the lookup rather than being rejected, so `Alt-Mod-l`
-  // can bind while an alt chord still never fires a plain `Mod-` command.
-  const alt = event.altKey ? 'Alt-' : ''
-  const producedKey = bindingKeyFor(event)
-  const physicalDigitKey = physicalDigitKeyFor(event)
-  const bindingKeys = [
-    { key: producedKey, shift: event.shiftKey },
-    physicalDigitKey === null ? null : { key: physicalDigitKey, shift: false },
-  ].filter(
-    (lookup, index, lookups): lookup is { key: string; shift: boolean } =>
-      lookup !== null &&
-      lookups.findIndex(
-        (candidate) =>
-          candidate !== null && candidate.key === lookup.key && candidate.shift === lookup.shift,
-      ) === index,
-  )
-  for (const { key, shift: shifted } of bindingKeys) {
+  for (const { key, shift: shifted } of bindingLookupsFor(event)) {
     const shift = shifted ? 'Shift-' : ''
-    const candidates = [
-      event.metaKey ? `${alt}Meta-${shift}${key}` : null,
-      event.ctrlKey ? `${alt}Ctrl-${shift}${key}` : null,
-      `${alt}Mod-${shift}${key}`,
-    ].filter((candidate): candidate is string => candidate !== null)
-    for (const candidate of candidates) {
+    for (const prefix of modifierPrefixesFor(event)) {
+      // Alt participates in the lookup rather than being rejected, so
+      // `Alt-Mod-l` can bind while an alt chord still never fires a plain
+      // `Mod-` command.
+      const candidate = `${prefix}${shift}${key}`
       const id = BINDING_TO_ID.get(candidate)
       if (id !== undefined) {
         return id


### PR DESCRIPTION
## Problem
Switching between recent graphs was mouse-driven: users had to open the sidebar graph dropdown and pick a row. On macOS that left a gap for keyboard-native graph switching, even though the app already centralizes navigation shortcuts through the command registry.

## Before -> After
| Before | After |
| --- | --- |
| Recent graphs could be selected from the sidebar dropdown only. | `Command+1` through `Command+9` switch to the matching recent graph row. |
| The graph dropdown did not teach the number shortcuts. | Non-current graph rows now show their matching shortcut hint beside the graph name. |
| The shortcut matcher only resolved `Mod-` bindings. | It now resolves `Meta-` bindings first, so graph switching is Command-key specific and `Ctrl+number` stays inert. |
| Digit shortcuts depended only on the produced character. | Number-row graph shortcuts also fall back to the physical `DigitN` code, so layouts that produce symbols or require Shift for digits still switch graphs. |

## Changes
1. Added `graph.switch1` through `graph.switch9` app commands bound to `Meta-1` through `Meta-9`.
2. Extended `CommandContext` with `switchGraph(index)` and wired `useAppShortcuts` to use the existing serialized `openRecent` flow against the current recents list.
3. Refactored shortcut dispatch into named lookup helpers for produced keys, physical digit fallback, and modifier prefixes, preserving existing punctuation shortcuts like history brackets.
4. Added graph-switch shortcut hints to the sidebar graph switcher rows, deriving them from the command registry.
5. Updated command-context and sidebar test harnesses and added coverage for command bindings, recent-graph index selection, current-graph no-op behavior, missing-slot no-op behavior, `Ctrl+number` not switching graphs, symbol-producing keyboard layouts, Shift-required digit layouts, and graph-menu keycap rendering.

## Tests
- `pnpm --filter @reflect/desktop test --run src/lib/commands/app-commands.test.ts src/routing/app-shortcuts.test.tsx`
- `pnpm --filter @reflect/desktop test --run src/lib/commands/registry.test.ts src/lib/attach-files.test.ts src/components/command-palette/command-palette.test.tsx src/components/sidebar/sidebar.test.tsx`
- `pnpm --filter @reflect/desktop test --run src/routing/app-shortcuts.test.tsx`
- `pnpm --filter @reflect/desktop test --run src/routing/app-shortcuts.test.tsx src/components/sidebar/sidebar.test.tsx`

## Verification
- `pnpm check` passed. It reported an existing max-lines warning in `packages/core/src/indexing/indexer.ts`, outside this diff.

## Risk / Rollout
No migrations or data changes. The switch uses the existing `openRecent` graph-open path, so it inherits the current serialization and graph-session guards. The main behavioral risk is shortcut matching; the PR pins the modifier and keyboard-layout cases with focused tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global shortcut resolution for all app commands; wrong matching could fire unintended commands, though tests cover Meta-only gating and keyboard-layout edge cases.
> 
> **Overview**
> Adds **keyboard switching between recent graphs** on macOS: **⌘1–⌘9** map to the first nine rows in the recents list and call the existing **`openRecent`** flow (no-op when that graph is already open or the slot is empty).
> 
> Registers **`graph.switch1`–`graph.switch9`** in the command registry with **`Meta-N`** bindings and extends **`CommandContext`** with **`switchGraph(index)`**. The sidebar graph menu shows matching shortcut hints on non-current recent rows via **`keybindingFor`**.
> 
> **Shortcut dispatch** now tries **`Meta-`**, **`Ctrl-`**, and **`Mod-`** prefixes and adds a **physical `DigitN` fallback** so number-row shortcuts still work on symbol-producing or Shift-for-digit layouts, while **`Ctrl+number`** does not switch graphs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae68b971ba8e9feb64ac74617854e960449212aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “switch to recent graph” commands bound to ⌘+1 through ⌘+9.
  * Updated the graph switch dropdown to display the shortcut keys for each recent graph.
* **Bug Fixes**
  * Prevented graph switching from navigating when the target recent graph is already open.
  * Improved number-shortcut handling across keyboard layouts/modifier states, with physical digit awareness and correct ⌘ gating.
* **Tests**
  * Expanded/updated coverage for graph-switch command execution, keybinding mappings, and recent-graph shortcut routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
