### PR TITLE
Fade iOS image lightbox drag dismiss

### DIFF
--- a/apps/desktop/src/editor/image-lightbox.test.tsx
+++ b/apps/desktop/src/editor/image-lightbox.test.tsx
@@ -185,7 +185,7 @@ describe('ImageLightbox mobile drag-to-dismiss', () => {
   })
 
   it('springs back after a short drag and suppresses the trailing tap', () => {
-    const { preview, image, backdrop, onClose } = renderMobileLightbox()
+    const { preview, image, backdrop, closeChrome, onClose } = renderMobileLightbox()
 
     touchDown(preview, 100, 100)
     firePointer(preview, 'pointermove', { pointerId: 1, clientX: 102, clientY: 130 })
@@ -195,6 +195,7 @@ describe('ImageLightbox mobile drag-to-dismiss', () => {
     expect(image.style.transform).toBe('translate3d(0, 0, 0) scale(1)')
     expect(backdrop!.style.opacity).toBe('1')
 
+    fireEvent.transitionEnd(closeChrome)
     fireEvent.click(preview)
     fireEvent.click(preview)
     expect(onClose).not.toHaveBeenCalled()

--- a/apps/desktop/src/editor/image-lightbox.test.tsx
+++ b/apps/desktop/src/editor/image-lightbox.test.tsx
@@ -35,6 +35,7 @@ interface RenderedLightbox {
   onClose: ReturnType<typeof vi.fn>
   preview: HTMLElement
   image: HTMLImageElement
+  lightboxLayer: HTMLElement
   backdrop: HTMLElement | null
   closeChrome: HTMLElement
 }
@@ -50,6 +51,10 @@ function renderMobileLightbox(): RenderedLightbox {
   if (!(image instanceof HTMLImageElement)) {
     throw new Error('lightbox image missing')
   }
+  const lightboxLayer = preview.parentElement
+  if (!(lightboxLayer instanceof HTMLElement)) {
+    throw new Error('lightbox layer missing')
+  }
   const closeChrome = screen.getByRole('button', { name: 'Close' }).parentElement
   if (!(closeChrome instanceof HTMLElement)) {
     throw new Error('close chrome missing')
@@ -58,6 +63,7 @@ function renderMobileLightbox(): RenderedLightbox {
     onClose,
     preview,
     image,
+    lightboxLayer,
     backdrop: dialog.querySelector('.bg-black'),
     closeChrome,
   }
@@ -118,42 +124,47 @@ describe('ImageLightbox mobile drag-to-dismiss', () => {
     expect(closeChrome.style.pointerEvents).toBe('none')
   })
 
-  it('dismisses past the distance threshold, sliding out along the drag vector', () => {
-    const { preview, image, backdrop, onClose } = renderMobileLightbox()
+  it('dismisses past the distance threshold by fading the lightbox layer', () => {
+    const { preview, image, lightboxLayer, backdrop, onClose } = renderMobileLightbox()
 
     touchDown(preview, 180, 120)
     firePointer(preview, 'pointermove', { pointerId: 1, clientX: 182, clientY: 180 })
     firePointer(preview, 'pointermove', { pointerId: 1, clientX: 190, clientY: 260 })
     firePointer(preview, 'pointerup', { pointerId: 1, clientX: 190, clientY: 320 })
 
-    expect(image.style.transform).toContain(`, ${window.innerHeight}px, 0) scale(0.9)`)
-    expect(backdrop!.style.opacity).toBe('0')
+    expect(image.style.transform).toContain('translate3d(8px, 140px, 0)')
+    expect(image.style.transform).not.toContain(`${window.innerHeight}px`)
+    expect(lightboxLayer.style.opacity).toBe('0')
+    expect(lightboxLayer.style.transition).toContain('opacity 180ms')
+    expect(backdrop!.style.opacity).not.toBe('0')
     expect(onClose).not.toHaveBeenCalled()
     onClose.mockImplementation(() => {
       expect(image.style.transform).toBe('')
     })
 
-    fireEvent.transitionEnd(image)
+    fireEvent.transitionEnd(lightboxLayer)
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
   it('dismisses horizontally past the distance threshold', () => {
-    const { preview, image, onClose } = renderMobileLightbox()
+    const { preview, image, lightboxLayer, onClose } = renderMobileLightbox()
 
     touchDown(preview, 100, 100)
     firePointer(preview, 'pointermove', { pointerId: 1, clientX: 120, clientY: 100 })
     firePointer(preview, 'pointermove', { pointerId: 1, clientX: 340, clientY: 104 })
     firePointer(preview, 'pointerup', { pointerId: 1, clientX: 340, clientY: 104 })
 
-    expect(image.style.transform).toContain(`translate3d(${window.innerWidth}px, `)
+    expect(image.style.transform).toContain('translate3d(220px, 4px, 0)')
+    expect(image.style.transform).not.toContain(`${window.innerWidth}px`)
+    expect(lightboxLayer.style.opacity).toBe('0')
     expect(onClose).not.toHaveBeenCalled()
 
-    fireEvent.transitionEnd(image)
+    fireEvent.transitionEnd(lightboxLayer)
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
   it('dismisses a fast flick before the distance threshold', () => {
-    const { preview, image, onClose } = renderMobileLightbox()
+    const { preview, image, lightboxLayer, onClose } = renderMobileLightbox()
     const nowSpy = vi.spyOn(performance, 'now')
 
     nowSpy.mockReturnValue(1_000)
@@ -167,8 +178,9 @@ describe('ImageLightbox mobile drag-to-dismiss', () => {
     firePointer(preview, 'pointerup', { pointerId: 1, clientX: 100, clientY: 180 })
     nowSpy.mockRestore()
 
-    expect(image.style.transform).toContain(`, ${window.innerHeight}px, 0)`)
-    fireEvent.transitionEnd(image)
+    expect(image.style.transform).toContain('translate3d(0px, 60px, 0)')
+    expect(lightboxLayer.style.opacity).toBe('0')
+    fireEvent.transitionEnd(lightboxLayer)
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
@@ -193,7 +205,7 @@ describe('ImageLightbox mobile drag-to-dismiss', () => {
   })
 
   it('dismisses upward past the distance threshold', () => {
-    const { preview, image, onClose } = renderMobileLightbox()
+    const { preview, image, lightboxLayer, onClose } = renderMobileLightbox()
 
     touchDown(preview, 100, 100)
     firePointer(preview, 'pointermove', { pointerId: 1, clientX: 100, clientY: 80 })
@@ -202,8 +214,9 @@ describe('ImageLightbox mobile drag-to-dismiss', () => {
     expect(image.style.transform).toContain('translate3d(0px, -200px, 0)')
 
     firePointer(preview, 'pointerup', { pointerId: 1, clientX: 100, clientY: -120 })
-    expect(image.style.transform).toContain(`, -${window.innerHeight}px, 0)`)
-    fireEvent.transitionEnd(image)
+    expect(image.style.transform).toContain('translate3d(0px, -200px, 0)')
+    expect(lightboxLayer.style.opacity).toBe('0')
+    fireEvent.transitionEnd(lightboxLayer)
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 

--- a/apps/desktop/src/editor/image-lightbox.tsx
+++ b/apps/desktop/src/editor/image-lightbox.tsx
@@ -49,7 +49,11 @@ export function ImageLightbox({
         <div
           className="absolute inset-0"
           style={dismissDrag.lightboxStyle}
-          onTransitionEnd={dismissDrag.finishSettle}
+          onTransitionEnd={(event) => {
+            if (event.target === event.currentTarget) {
+              dismissDrag.finishSettle()
+            }
+          }}
         >
           <div
             aria-hidden

--- a/apps/desktop/src/editor/image-lightbox.tsx
+++ b/apps/desktop/src/editor/image-lightbox.tsx
@@ -5,7 +5,6 @@ import { LightboxDialog } from '@/editor/lightbox-dialog'
 import { useImageDismissDrag } from '@/editor/use-image-dismiss-drag'
 import { type LightboxTransitionItem } from '@/editor/use-lightbox-transition'
 import { isMobileSurface } from '@/lib/platform-surface'
-import { cn } from '@/lib/utils'
 
 export const IMAGE_LIGHTBOX_TRANSITION_NAME = 'reflect-image-lightbox'
 
@@ -47,60 +46,97 @@ export function ImageLightbox({
   return (
     <LightboxDialog open title="Image preview" immersive={mobileSurface} onClose={onClose}>
       {mobileSurface ? (
-        <div aria-hidden className="absolute inset-0 bg-black" style={dismissDrag.backdropStyle} />
-      ) : null}
-      {mobileSurface ? (
         <div
-          className="absolute top-[max(env(safe-area-inset-top),1rem)] left-[max(env(safe-area-inset-left),1rem)] z-10"
-          style={dismissDrag.chromeStyle}
-        >
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-lg"
-            aria-label="Close"
-            className="rounded-full bg-white/15 text-white shadow-sm backdrop-blur-xl hover:bg-white/25 active:bg-white/20"
-            onClick={onClose}
-          >
-            <XIcon />
-          </Button>
-        </div>
-      ) : null}
-      {canOpenImage ? (
-        <div
-          className="absolute top-[max(env(safe-area-inset-top),1rem)] right-[max(env(safe-area-inset-right),1rem)] z-10"
-          style={dismissDrag.chromeStyle}
-        >
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-9 rounded-full bg-white/15 px-3 text-white shadow-sm backdrop-blur-xl hover:bg-white/25 active:bg-white/20"
-            onClick={() => onOpenImage(image)}
-          >
-            <ExternalLinkIcon data-icon="inline-start" />
-            Open
-          </Button>
-        </div>
-      ) : null}
-      <button
-        type="button"
-        aria-label="Close image preview"
-        className={cn(
-          'absolute inset-0 flex cursor-zoom-out items-center justify-center overflow-hidden bg-transparent',
-          mobileSurface ? 'touch-none p-0' : 'p-6',
-        )}
-        {...dismissDrag.handlers}
-      >
-        <img
-          src={image.src}
-          alt={image.alt}
-          draggable={false}
-          className="max-h-full max-w-full select-none"
+          className="absolute inset-0"
+          style={dismissDrag.lightboxStyle}
           onTransitionEnd={dismissDrag.finishSettle}
-          style={{ ...dismissDrag.imageStyle, viewTransitionName: image.transitionName }}
-        />
-      </button>
+        >
+          <div
+            aria-hidden
+            className="absolute inset-0 bg-black"
+            style={dismissDrag.backdropStyle}
+          />
+          <div
+            className="absolute top-[max(env(safe-area-inset-top),1rem)] left-[max(env(safe-area-inset-left),1rem)] z-10"
+            style={dismissDrag.chromeStyle}
+          >
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-lg"
+              aria-label="Close"
+              className="rounded-full bg-white/15 text-white shadow-sm backdrop-blur-xl hover:bg-white/25 active:bg-white/20"
+              onClick={onClose}
+            >
+              <XIcon />
+            </Button>
+          </div>
+          {canOpenImage ? (
+            <div
+              className="absolute top-[max(env(safe-area-inset-top),1rem)] right-[max(env(safe-area-inset-right),1rem)] z-10"
+              style={dismissDrag.chromeStyle}
+            >
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-9 rounded-full bg-white/15 px-3 text-white shadow-sm backdrop-blur-xl hover:bg-white/25 active:bg-white/20"
+                onClick={() => onOpenImage(image)}
+              >
+                <ExternalLinkIcon data-icon="inline-start" />
+                Open
+              </Button>
+            </div>
+          ) : null}
+          <button
+            type="button"
+            aria-label="Close image preview"
+            className="absolute inset-0 flex touch-none cursor-zoom-out items-center justify-center overflow-hidden bg-transparent p-0"
+            {...dismissDrag.handlers}
+          >
+            <img
+              src={image.src}
+              alt={image.alt}
+              draggable={false}
+              className="max-h-full max-w-full select-none"
+              onTransitionEnd={dismissDrag.finishSettle}
+              style={{ ...dismissDrag.imageStyle, viewTransitionName: image.transitionName }}
+            />
+          </button>
+        </div>
+      ) : (
+        <>
+          {canOpenImage ? (
+            <div className="absolute top-[max(env(safe-area-inset-top),1rem)] right-[max(env(safe-area-inset-right),1rem)] z-10">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-9 rounded-full bg-white/15 px-3 text-white shadow-sm backdrop-blur-xl hover:bg-white/25 active:bg-white/20"
+                onClick={() => onOpenImage(image)}
+              >
+                <ExternalLinkIcon data-icon="inline-start" />
+                Open
+              </Button>
+            </div>
+          ) : null}
+          <button
+            type="button"
+            aria-label="Close image preview"
+            className="absolute inset-0 flex cursor-zoom-out items-center justify-center overflow-hidden bg-transparent p-6"
+            {...dismissDrag.handlers}
+          >
+            <img
+              src={image.src}
+              alt={image.alt}
+              draggable={false}
+              className="max-h-full max-w-full select-none"
+              onTransitionEnd={dismissDrag.finishSettle}
+              style={{ ...dismissDrag.imageStyle, viewTransitionName: image.transitionName }}
+            />
+          </button>
+        </>
+      )}
     </LightboxDialog>
   )
 }

--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -306,7 +306,9 @@ describe('NoteEditor image lightbox', () => {
 
     const preview = await screen.findByRole('button', { name: 'Close image preview' })
     const image = preview.querySelector('img')
+    const lightboxLayer = preview.parentElement
     expect(image).toBeInstanceOf(HTMLImageElement)
+    expect(lightboxLayer).toBeInstanceOf(HTMLElement)
 
     firePointer(preview, 'pointerdown', {
       pointerId: 1,
@@ -333,8 +335,9 @@ describe('NoteEditor image lightbox', () => {
       clientY: 360,
     })
 
-    expect(image?.style.transform).toContain(`, ${window.innerHeight}px, 0)`)
-    fireEvent.transitionEnd(image!)
+    expect(image?.style.transform).toContain('translate3d(2px, 180px, 0)')
+    expect(lightboxLayer?.style.opacity).toBe('0')
+    fireEvent.transitionEnd(lightboxLayer!)
     await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
   })
 

--- a/apps/desktop/src/editor/use-image-dismiss-drag.ts
+++ b/apps/desktop/src/editor/use-image-dismiss-drag.ts
@@ -16,8 +16,7 @@ const MIN_FLICK_DISTANCE_PX = 40
 const VELOCITY_WINDOW_MS = 30
 const VELOCITY_STALE_MS = 120
 const SNAP_BACK_MS = 300
-const DISMISS_MS = 260
-const DISMISS_MIN_MS = 140
+const DISMISS_FADE_MS = 180
 const SETTLE_SLACK_MS = 80
 const CLICK_SUPPRESSION_MS = 500
 // Full visual effect (backdrop gone, image at min scale) at half the viewport.
@@ -37,7 +36,6 @@ type DragState =
       pointerId: number
       originX: number
       originY: number
-      width: number
       height: number
       deltaX: number
       deltaY: number
@@ -50,7 +48,6 @@ type DragState =
       action: 'close' | 'cancel'
       deltaX: number
       deltaY: number
-      width: number
       height: number
       durationMs: number
     }
@@ -59,6 +56,8 @@ const IDLE: DragState = { phase: 'idle' }
 
 /** Styles and handlers driving the mobile drag-to-dismiss gesture. */
 export interface ImageDismissDrag {
+  /** Fade applied to the whole mobile lightbox while a drag-close settles. */
+  lightboxStyle: CSSProperties | undefined
   /** Transform applied to the dragged image, or undefined at rest. */
   imageStyle: CSSProperties | undefined
   /** Fade applied to the lightbox backdrop as the drag progresses. */
@@ -72,7 +71,7 @@ export interface ImageDismissDrag {
     onPointerCancel: (event: ReactPointerEvent<HTMLButtonElement>) => void
     onClick: (event: ReactMouseEvent<HTMLButtonElement>) => void
   }
-  /** Completes a settle animation; wire to the image's `onTransitionEnd`. */
+  /** Completes a settle animation; wire to transition-end events for settling elements. */
   finishSettle: () => void
 }
 
@@ -92,36 +91,35 @@ function dragProgress(deltaX: number, deltaY: number, height: number): number {
   )
 }
 
-/** Continue the drag vector so the image exits along the finger's line. */
-function projectDismissOffset(
-  deltaX: number,
-  deltaY: number,
-  width: number,
-  height: number,
-): { x: number; y: number } {
-  const absX = Math.abs(deltaX)
-  const absY = Math.abs(deltaY)
-  if (absX === 0 && absY === 0) {
-    return { x: 0, y: height }
-  }
-  const factor = absX >= absY ? width / Math.max(absX, 1) : height / Math.max(absY, 1)
-  return {
-    x: deltaX * factor,
-    y: deltaY * factor,
-  }
+function imageTransformForDrag(deltaX: number, deltaY: number, height: number): string {
+  const progress = dragProgress(deltaX, deltaY, height)
+  return `translate3d(${deltaX}px, ${deltaY}px, 0) scale(${1 - progress * DRAG_SHRINK})`
 }
 
-function dismissDurationMs(distance: number, height: number, velocity: number): number {
-  const remaining = Math.max(0, height - distance)
-  const floorVelocity = remaining / DISMISS_MS
-  return clamp(remaining / Math.max(velocity, floorVelocity), DISMISS_MIN_MS, DISMISS_MS)
+function backdropOpacityForDrag(deltaX: number, deltaY: number, height: number): number {
+  return 1 - dragProgress(deltaX, deltaY, height) * BACKDROP_FADE
+}
+
+function chromeOpacityForDrag(deltaX: number, deltaY: number, height: number): number {
+  return clamp(1 - dragProgress(deltaX, deltaY, height) * CHROME_FADE_RATE, 0, 1)
+}
+
+function lightboxStyleForState(state: DragState): CSSProperties | undefined {
+  if (state.phase === 'settling' && state.action === 'close') {
+    return {
+      opacity: 0,
+      pointerEvents: 'none',
+      transition: `opacity ${state.durationMs}ms ${DISMISS_EASING}`,
+      willChange: 'opacity',
+    }
+  }
+  return undefined
 }
 
 function imageStyleForState(state: DragState): CSSProperties | undefined {
   if (state.phase === 'dragging') {
-    const progress = dragProgress(state.deltaX, state.deltaY, state.height)
     return {
-      transform: `translate3d(${state.deltaX}px, ${state.deltaY}px, 0) scale(${1 - progress * DRAG_SHRINK})`,
+      transform: imageTransformForDrag(state.deltaX, state.deltaY, state.height),
       transition: 'none',
       willChange: 'transform',
     }
@@ -129,10 +127,9 @@ function imageStyleForState(state: DragState): CSSProperties | undefined {
   if (state.phase === 'settling') {
     const closing = state.action === 'close'
     if (closing) {
-      const offset = projectDismissOffset(state.deltaX, state.deltaY, state.width, state.height)
       return {
-        transform: `translate3d(${offset.x}px, ${offset.y}px, 0) scale(0.9)`,
-        transition: `transform ${state.durationMs}ms ${DISMISS_EASING}`,
+        transform: imageTransformForDrag(state.deltaX, state.deltaY, state.height),
+        transition: 'none',
         willChange: 'transform',
       }
     }
@@ -148,15 +145,21 @@ function imageStyleForState(state: DragState): CSSProperties | undefined {
 function backdropStyleForState(state: DragState): CSSProperties | undefined {
   if (state.phase === 'dragging') {
     return {
-      opacity: 1 - dragProgress(state.deltaX, state.deltaY, state.height) * BACKDROP_FADE,
+      opacity: backdropOpacityForDrag(state.deltaX, state.deltaY, state.height),
       transition: 'none',
     }
   }
   if (state.phase === 'settling') {
     const closing = state.action === 'close'
+    if (closing) {
+      return {
+        opacity: backdropOpacityForDrag(state.deltaX, state.deltaY, state.height),
+        transition: 'none',
+      }
+    }
     return {
-      opacity: closing ? 0 : 1,
-      transition: `opacity ${state.durationMs}ms ${closing ? DISMISS_EASING : SNAP_BACK_EASING}`,
+      opacity: 1,
+      transition: `opacity ${state.durationMs}ms ${SNAP_BACK_EASING}`,
     }
   }
   return undefined
@@ -165,21 +168,24 @@ function backdropStyleForState(state: DragState): CSSProperties | undefined {
 function chromeStyleForState(state: DragState): CSSProperties | undefined {
   if (state.phase === 'dragging') {
     return {
-      opacity: clamp(
-        1 - dragProgress(state.deltaX, state.deltaY, state.height) * CHROME_FADE_RATE,
-        0,
-        1,
-      ),
+      opacity: chromeOpacityForDrag(state.deltaX, state.deltaY, state.height),
       pointerEvents: 'none',
       transition: 'none',
     }
   }
   if (state.phase === 'settling') {
     const closing = state.action === 'close'
+    if (closing) {
+      return {
+        opacity: chromeOpacityForDrag(state.deltaX, state.deltaY, state.height),
+        pointerEvents: 'none',
+        transition: 'none',
+      }
+    }
     return {
-      opacity: closing ? 0 : 1,
+      opacity: 1,
       pointerEvents: 'none',
-      transition: `opacity ${state.durationMs}ms ${closing ? DISMISS_EASING : SNAP_BACK_EASING}`,
+      transition: `opacity ${state.durationMs}ms ${SNAP_BACK_EASING}`,
     }
   }
   return undefined
@@ -189,9 +195,8 @@ function chromeStyleForState(state: DragState): CSSProperties | undefined {
  * Touch drag-to-dismiss for the mobile image lightbox. A touch drag detaches
  * the image so it follows the finger in any direction while the backdrop and
  * chrome fade with distance. Releasing past a distance threshold, or flicking,
- * slides the image out along the drag vector at a velocity-matched speed and
- * then calls `onClose`; shorter drags spring back. A plain tap still closes via
- * `onClick`.
+ * fades the lightbox out and then calls `onClose`; shorter drags spring back.
+ * A plain tap still closes via `onClick`.
  */
 export function useImageDismissDrag({
   active,
@@ -287,9 +292,7 @@ export function useImageDismissDrag({
           // Synthetic tests do not have a live pointer to capture.
         }
 
-        const rect = event.currentTarget.getBoundingClientRect()
-        const width = rect.width || window.innerWidth
-        const height = rect.height || window.innerHeight
+        const height = event.currentTarget.getBoundingClientRect().height || window.innerHeight
         // Rebase on the activation point so the image picks up from rest
         // instead of jumping by the activation distance.
         commit({
@@ -297,7 +300,6 @@ export function useImageDismissDrag({
           pointerId: event.pointerId,
           originX: event.clientX,
           originY: event.clientY,
-          width,
           height,
           deltaX: 0,
           deltaY: 0,
@@ -373,11 +375,8 @@ export function useImageDismissDrag({
         action: shouldClose ? 'close' : 'cancel',
         deltaX: releaseDeltaX,
         deltaY: releaseDeltaY,
-        width: current.width,
         height: current.height,
-        durationMs: shouldClose
-          ? dismissDurationMs(releaseDistance, current.height, releaseVelocity)
-          : SNAP_BACK_MS,
+        durationMs: shouldClose ? DISMISS_FADE_MS : SNAP_BACK_MS,
       })
     },
     [commit, onClose, suppressUpcomingClick],
@@ -413,6 +412,7 @@ export function useImageDismissDrag({
   )
 
   return {
+    lightboxStyle: lightboxStyleForState(state),
     imageStyle: imageStyleForState(state),
     backdropStyle: backdropStyleForState(state),
     chromeStyle: chromeStyleForState(state),


### PR DESCRIPTION
## Problem

The iOS image lightbox drag-close release was doing a projected image exit: after the user released a drag, the image continued flying offscreen along the drag vector with a velocity-matched duration while the rest of the lightbox faded separately. That made the close animation smarter than it needed to be for this gesture.

## Before -> After

| Before | After |
| --- | --- |
| Drag-close release projected the image to the viewport edge. | Drag-close release keeps the image at the released drag pose. |
| Backdrop/chrome faded as separate close animations. | The mobile lightbox layer fades out as one unit. |
| Exit duration was derived from remaining projected travel. | Drag-close fade uses a fixed short 180ms duration. |

## Changes

1. Removed the drag-vector projection and velocity-matched close duration from `useImageDismissDrag`.
2. Added a `lightboxStyle` close-fade style so the mobile lightbox backdrop, chrome, and image fade together.
3. Split the mobile lightbox markup into a single fadeable layer while preserving the desktop opener button path.
4. Guarded the mobile layer transition-end handler so bubbled child transitions cannot finish snap-back early.
5. Updated the lightbox and note-editor tests to assert the new fade close behavior and the snap-back transition guard.

## Verification

- `pnpm --filter @reflect/desktop exec vitest run src/editor/image-lightbox.test.tsx src/editor/note-editor.test.tsx` passed: 44 tests.
- `pnpm check` passed. It still reports the existing non-failing `max-lines` warning in `packages/core/src/indexing/indexer.ts`.

## Risk / Rollout

Low risk. This only changes the mobile image lightbox drag-dismiss animation and related tests; no data, sync, privacy, or migration behavior changes.