### PR TITLE
Support OpenAI-compatible AI providers

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -18,10 +18,8 @@
     {
       "identifier": "http:default",
       "allow": [
-        { "url": "https://api.openai.com/*" },
-        { "url": "https://api.anthropic.com/*" },
-        { "url": "https://generativelanguage.googleapis.com/*" },
-        { "url": "https://openrouter.ai/*" },
+        { "url": "http://*/*" },
+        { "url": "https://*/*" },
         { "url": "https://github.com/login/device/code" },
         { "url": "https://github.com/login/oauth/access_token" },
         { "url": "https://api.github.com/*" }

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: reflect-asset: https:; font-src 'self' data:; frame-src 'self' https://platform.twitter.com https://platform.x.com https://syndication.twitter.com https://www.youtube-nocookie.com https://www.youtube.com; connect-src 'self' ipc: http://ipc.localhost https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://openrouter.ai https://github.com https://api.github.com"
+      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: reflect-asset: https:; font-src 'self' data:; frame-src 'self' https://platform.twitter.com https://platform.x.com https://syndication.twitter.com https://www.youtube-nocookie.com https://www.youtube.com; connect-src 'self' ipc: http: https:"
     }
   },
   "plugins": {

--- a/apps/desktop/src/components/chat/chat-screen.test.tsx
+++ b/apps/desktop/src/components/chat/chat-screen.test.tsx
@@ -30,7 +30,9 @@ import { RouterProvider, useRouter } from '@/routing/router'
 const streamChat = vi.hoisted(() =>
   vi.fn<(options: StreamChatOptions) => AsyncGenerator<ChatStreamEvent>>(),
 )
-const getSecret = vi.hoisted(() => vi.fn<(name: string) => Promise<string | null>>())
+const aiApiKeyForConfig = vi.hoisted(() =>
+  vi.fn<(config: AiProviderConfig) => Promise<string | null>>(),
+)
 const resolveWikiTarget = vi.hoisted(() =>
   vi.fn<(target: string) => Promise<{ kind: 'resolved'; ref: string } | { kind: 'unresolved'; text: string }>>(),
 )
@@ -42,7 +44,7 @@ const loadChatGraphContext = vi.hoisted(() =>
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   streamChat,
-  getSecret,
+  aiApiKeyForConfig,
   resolveWikiTarget,
   loadChatGraphContext,
 }))
@@ -136,7 +138,7 @@ beforeEach(() => {
   settingsState.defaultId = null
   settingsState.selection = null
   streamChat.mockReset()
-  getSecret.mockReset().mockResolvedValue('sk-test')
+  aiApiKeyForConfig.mockReset().mockResolvedValue('sk-test')
   loadChatGraphContext.mockReset().mockResolvedValue(GRAPH_CONTEXT)
   resolveWikiTarget.mockReset().mockImplementation(async (target) => ({
     kind: 'resolved',
@@ -236,7 +238,7 @@ describe('ChatScreen', () => {
     expect(probedRoute).toEqual({ kind: 'note', path: 'notes/atlas.md' })
 
     // The turn went out with the keychain key and the full derived history.
-    expect(getSecret).toHaveBeenCalledWith('ai-api-key:m1')
+    expect(aiApiKeyForConfig).toHaveBeenCalledWith(MODEL)
     const options = streamChat.mock.lastCall?.[0]
     expect(options?.config).toEqual(MODEL)
     expect(options?.messages.at(-1)).toEqual({ role: 'user', content: 'when does atlas ship?' })
@@ -467,7 +469,7 @@ describe('ChatScreen', () => {
 
   it('surfaces a missing keychain entry as an in-transcript error', async () => {
     configureModel()
-    getSecret.mockResolvedValueOnce(null)
+    aiApiKeyForConfig.mockResolvedValueOnce(null)
     const view = renderChat()
 
     await userEvent.type(view.getByLabelText('Chat message'), 'hi{Enter}')

--- a/apps/desktop/src/components/settings/add-ai-provider-dialog.tsx
+++ b/apps/desktop/src/components/settings/add-ai-provider-dialog.tsx
@@ -1,6 +1,14 @@
 import { useEffect, type ReactElement } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
-import { AI_PROVIDERS, aiProvider, aiProviderIdSchema, type AiProviderId } from '@reflect/core'
+import {
+  AI_PROVIDERS,
+  DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
+  aiProvider,
+  aiProviderIdSchema,
+  aiProviderRequiresApiKey,
+  isHttpBaseUrl,
+  type AiProviderId,
+} from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -31,6 +39,7 @@ interface AddAiProviderDialogProps {
 interface AddAiProviderForm {
   provider: AiProviderId
   model: string
+  baseUrl: string
   apiKey: string
   isDefault: boolean
 }
@@ -50,6 +59,7 @@ export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps
     defaultValues: {
       provider: AI_PROVIDERS[0].id,
       model: AI_PROVIDERS[0].models[0].id,
+      baseUrl: '',
       apiKey: '',
       isDefault: false,
     },
@@ -76,6 +86,8 @@ export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps
   const providerId = useWatch({ control, name: 'provider' })
   const selectedModel = useWatch({ control, name: 'model' })
   const provider = aiProvider(providerId)
+  const isOpenAICompatible = provider.id === 'openai-compatible'
+  const apiKeyRequired = aiProviderRequiresApiKey(provider.id)
 
   const submitForm = handleSubmit(async (values) => {
     await submit(values)
@@ -83,7 +95,7 @@ export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps
 
   return (
     <Dialog open onOpenChange={(isOpen) => { if (!isOpen) onClose() }}>
-      <DialogContent showCloseButton={false} className="max-w-sm">
+      <DialogContent showCloseButton={false} className="max-w-md">
         <DialogHeader>
           <DialogTitle>Add AI provider</DialogTitle>
           <DialogDescription>
@@ -104,6 +116,10 @@ export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps
                 const next = aiProvider(aiProviderIdSchema.parse(value))
                 setValue('provider', next.id)
                 setValue('model', next.models[0].id)
+                setValue(
+                  'baseUrl',
+                  next.id === 'openai-compatible' ? DEFAULT_OPENAI_COMPATIBLE_BASE_URL : '',
+                )
                 resetUnverified()
               }}
             >
@@ -122,23 +138,71 @@ export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps
 
           <div className="flex flex-col gap-1">
             <span className={FIELD_LABEL_CLASS}>Default model</span>
-            <ModelCombobox
-              value={selectedModel}
-              provider={provider.id}
-              models={provider.models}
-              onChange={(modelId) => setValue('model', modelId)}
-            />
+            {isOpenAICompatible ? (
+              <Input
+                aria-label="Default model"
+                autoComplete="off"
+                spellCheck={false}
+                {...register('model', {
+                  validate: (value) => value.trim().length > 0 || 'Enter a model id.',
+                  onChange: () => {
+                    resetUnverified()
+                  },
+                })}
+              />
+            ) : (
+              <ModelCombobox
+                value={selectedModel}
+                provider={provider.id}
+                models={provider.models}
+                onChange={(modelId) => {
+                  setValue('model', modelId)
+                  resetUnverified()
+                }}
+              />
+            )}
+            {formState.errors.model ? (
+              <span role="alert" className="text-xs text-red-600 dark:text-red-400">
+                {formState.errors.model.message}
+              </span>
+            ) : null}
           </div>
 
+          {isOpenAICompatible ? (
+            <label className="flex flex-col gap-1">
+              <span className={FIELD_LABEL_CLASS}>Endpoint base URL</span>
+              <Input
+                type="url"
+                placeholder={DEFAULT_OPENAI_COMPATIBLE_BASE_URL}
+                autoComplete="off"
+                spellCheck={false}
+                {...register('baseUrl', {
+                  validate: (value) => isHttpBaseUrl(value) || 'Enter an http(s) endpoint URL.',
+                  onChange: () => {
+                    resetUnverified()
+                  },
+                })}
+              />
+              {formState.errors.baseUrl ? (
+                <span role="alert" className="text-xs text-red-600 dark:text-red-400">
+                  {formState.errors.baseUrl.message}
+                </span>
+              ) : null}
+            </label>
+          ) : null}
+
           <label className="flex flex-col gap-1">
-            <span className={FIELD_LABEL_CLASS}>API key</span>
+            <span className={FIELD_LABEL_CLASS}>
+              {apiKeyRequired ? 'API key' : 'API key (optional)'}
+            </span>
             <Input
               type="password"
               placeholder={provider.keyPlaceholder}
               autoComplete="off"
               spellCheck={false}
               {...register('apiKey', {
-                validate: (value) => value.trim().length > 0 || 'Enter an API key.',
+                validate: (value) =>
+                  !apiKeyRequired || value.trim().length > 0 || 'Enter an API key.',
                 onChange: () => {
                   resetUnverified()
                 },

--- a/apps/desktop/src/components/settings/ai-provider-row.tsx
+++ b/apps/desktop/src/components/settings/ai-provider-row.tsx
@@ -1,6 +1,12 @@
 import type { ReactElement } from 'react'
 import { Trash2 } from 'lucide-react'
-import { aiModelLabel, aiProvider, errorMessage, type AiProviderConfig } from '@reflect/core'
+import {
+  aiModelLabel,
+  aiProvider,
+  aiProviderRequiresApiKey,
+  errorMessage,
+  type AiProviderConfig,
+} from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import { startOperation } from '@/lib/operations'
 
@@ -29,6 +35,7 @@ export function AiProviderRow({
   const providerLabel = aiProvider(config.provider).label
   const modelLabel = aiModelLabel(config.provider, config.model)
   const name = `${providerLabel} — ${modelLabel}`
+  const showKeyHint = aiProviderRequiresApiKey(config.provider) || config.keyHint !== ''
 
   const remove = (): void => {
     onRemove(config.id).catch((error: unknown) => {
@@ -41,8 +48,17 @@ export function AiProviderRow({
       <div className="min-w-0">
         <div className="truncate text-sm font-medium text-text">{name}</div>
         <p className="mt-0.5 text-xs text-text-muted">
-          API key <span className="font-mono">·····{config.keyHint}</span>
+          {showKeyHint ? (
+            <>
+              API key <span className="font-mono">·····{config.keyHint}</span>
+            </>
+          ) : (
+            'No API key'
+          )}
         </p>
+        {config.provider === 'openai-compatible' ? (
+          <p className="mt-0.5 truncate text-xs text-text-muted">{config.baseUrl}</p>
+        ) : null}
       </div>
       <div className="flex shrink-0 items-center gap-2">
         {isDefault ? (

--- a/apps/desktop/src/components/settings/ai-providers-section.test.tsx
+++ b/apps/desktop/src/components/settings/ai-providers-section.test.tsx
@@ -1,7 +1,12 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { setBridge, settingsSchema, type AiProviderConfig, type Settings } from '@reflect/core'
+import {
+  setBridge,
+  settingsSchema,
+  type HostedAiProviderConfig,
+  type Settings,
+} from '@reflect/core'
 import { SettingsProvider } from '@/providers/settings-provider'
 import { resetOperations } from '@/lib/operations'
 import { AiProvidersSection } from './ai-providers-section'
@@ -79,7 +84,7 @@ function lastSavedDoc(): Settings {
   return settingsSchema.parse(saved.at(-1))
 }
 
-function entry(overrides: Partial<AiProviderConfig>): AiProviderConfig {
+function entry(overrides: Partial<HostedAiProviderConfig>): HostedAiProviderConfig {
   return {
     id: 'id',
     provider: 'anthropic',
@@ -182,6 +187,42 @@ describe('AiProvidersSection', () => {
     fireEvent.keyDown(dialog.getByRole('combobox', { name: 'Provider' }), { key: 'ArrowDown' })
 
     expect(await screen.findByRole('option', { name: 'OpenRouter' })).toBeTruthy()
+    expect(await screen.findByRole('option', { name: 'OpenAI-compatible' })).toBeTruthy()
+  })
+
+  it('adds an OpenAI-compatible endpoint without storing an empty key', async () => {
+    renderSection()
+    await waitFor(() => expect(screen.getByText(/No AI providers configured/)).toBeTruthy())
+
+    const dialog = openDialog()
+    fireEvent.keyDown(dialog.getByRole('combobox', { name: 'Provider' }), { key: 'ArrowDown' })
+    fireEvent.keyDown(await screen.findByRole('option', { name: 'OpenAI-compatible' }), {
+      key: 'Enter',
+    })
+    fireEvent.change(dialog.getByLabelText('Endpoint base URL'), {
+      target: { value: 'http://localhost:1234/v1/' },
+    })
+    fireEvent.change(dialog.getByLabelText('Default model'), {
+      target: { value: 'llama-local' },
+    })
+    fireEvent.click(dialog.getByRole('button', { name: 'Add provider' }))
+
+    await waitFor(() => expect(saved).toHaveLength(1))
+    const doc = lastSavedDoc()
+    const [added] = doc.aiProviders
+    expect(added).toMatchObject({
+      provider: 'openai-compatible',
+      model: 'llama-local',
+      baseUrl: 'http://localhost:1234/v1',
+      keyHint: '',
+    })
+    expect(providerFetchMock).toHaveBeenCalledWith(
+      'http://localhost:1234/v1/models',
+      expect.objectContaining({ method: 'GET', headers: {} }),
+    )
+    expect(secrets.size).toBe(0)
+    expect(JSON.stringify(saved)).not.toContain('localhost:1234/v1/')
+    expect(screen.queryByRole('dialog')).toBeNull()
   })
 
   it('rejects a key the provider turns down, storing nothing', async () => {

--- a/apps/desktop/src/editor/ai-menu/use-editor-ai-menu.tsx
+++ b/apps/desktop/src/editor/ai-menu/use-editor-ai-menu.tsx
@@ -15,11 +15,10 @@ import type {
   SelectionMenuSearchHandler,
 } from '@meowdown/react'
 import {
-  aiKeySecretName,
+  aiApiKeyForConfig,
   chatModelOptions,
   cloudSafeSelection,
   filterAiPrompts,
-  getSecret,
   isPrivateNoteError,
   transformSelection,
   type AiPrompt,
@@ -176,7 +175,7 @@ export function useEditorAiMenu({
         throw cause
       }
 
-      const apiKey = await getSecret(aiKeySecretName(config.id)).catch(() => null)
+      const apiKey = await aiApiKeyForConfig(config)
       if (runRef.current !== run) return
       if (apiKey === null) {
         fail('No API key found for this provider — re-add it in Settings → AI providers.')

--- a/apps/desktop/src/hooks/use-add-ai-provider-submit.ts
+++ b/apps/desktop/src/hooks/use-add-ai-provider-submit.ts
@@ -1,5 +1,12 @@
 import { useCallback, useState } from 'react'
-import { aiProvider, errorMessage, validateApiKey } from '@reflect/core'
+import {
+  aiProvider,
+  aiProviderRequiresApiKey,
+  errorMessage,
+  isHttpBaseUrl,
+  normalizeOpenAICompatibleBaseUrl,
+  validateApiKey,
+} from '@reflect/core'
 import { providerFetch } from '@/lib/provider-fetch'
 import type { NewAiProvider } from '@/hooks/use-ai-providers'
 
@@ -47,11 +54,35 @@ export function useAddAiProviderSubmit({
     async (draft: NewAiProvider): Promise<void> => {
       setSubmitError(null)
       const apiKey = draft.apiKey.trim()
+      const requiresApiKey = aiProviderRequiresApiKey(draft.provider)
+      const provider = aiProvider(draft.provider)
+      const baseUrl =
+        draft.provider === 'openai-compatible'
+          ? normalizeOpenAICompatibleBaseUrl(draft.baseUrl ?? '')
+          : undefined
+      if (requiresApiKey && apiKey === '') {
+        setSubmitError('Enter an API key.')
+        return
+      }
+      if (
+        draft.provider === 'openai-compatible' &&
+        (baseUrl === undefined || !isHttpBaseUrl(baseUrl))
+      ) {
+        setSubmitError('Enter an http(s) endpoint URL.')
+        return
+      }
       try {
         if (!unverified) {
-          const validation = await validateApiKey(draft.provider, apiKey, providerFetch)
+          const validation = await validateApiKey(
+            { provider: draft.provider, apiKey, baseUrl },
+            providerFetch,
+          )
           if (validation === 'invalid') {
-            setSubmitError(`${aiProvider(draft.provider).label} rejected this API key.`)
+            setSubmitError(
+              draft.provider === 'openai-compatible' && apiKey === ''
+                ? `${provider.label} endpoint requires an API key.`
+                : `${provider.label} rejected this API key.`,
+            )
             return
           }
           if (validation === 'unreachable') {
@@ -59,7 +90,7 @@ export function useAddAiProviderSubmit({
             return
           }
         }
-        await onAdd({ ...draft, apiKey })
+        await onAdd({ ...draft, apiKey, baseUrl })
         onDone()
       } catch (error: unknown) {
         setSubmitError(errorMessage(error))

--- a/apps/desktop/src/hooks/use-ai-providers.ts
+++ b/apps/desktop/src/hooks/use-ai-providers.ts
@@ -1,9 +1,11 @@
 import { useCallback } from 'react'
 import {
   aiKeySecretName,
+  aiProviderRequiresApiKey,
   apiKeyHint,
   defaultAiProvider,
   deleteSecret,
+  normalizeOpenAICompatibleBaseUrl,
   setSecret,
   withAiProviderAdded,
   withAiProviderRemoved,
@@ -24,6 +26,7 @@ import { useSettings } from '@/providers/settings-provider'
 export interface NewAiProvider {
   provider: AiProviderId
   model: string
+  baseUrl?: string | undefined
   apiKey: string
   isDefault: boolean
 }
@@ -76,11 +79,29 @@ export function useAiProviders(): UseAiProvidersValue {
         throw error
       }
       const id = crypto.randomUUID()
-      await setSecret(aiKeySecretName(id), draft.apiKey)
+      const apiKey = draft.apiKey.trim()
+      if (apiKey !== '' || aiProviderRequiresApiKey(draft.provider)) {
+        await setSecret(aiKeySecretName(id), apiKey)
+      }
       updateSettingsWith((current) => {
+        const entry: AiProviderConfig =
+          draft.provider === 'openai-compatible'
+            ? {
+                id,
+                provider: draft.provider,
+                model: draft.model,
+                baseUrl: normalizeOpenAICompatibleBaseUrl(draft.baseUrl ?? ''),
+                keyHint: apiKeyHint(apiKey),
+              }
+            : {
+                id,
+                provider: draft.provider,
+                model: draft.model,
+                keyHint: apiKeyHint(apiKey),
+              }
         const next = withAiProviderAdded(
           { providers: current.aiProviders, defaultProviderId: current.defaultAiProviderId },
-          { id, provider: draft.provider, model: draft.model, keyHint: apiKeyHint(draft.apiKey) },
+          entry,
           draft.isDefault,
         )
         return { aiProviders: next.providers, defaultAiProviderId: next.defaultProviderId }

--- a/apps/desktop/src/lib/chat-model-groups.ts
+++ b/apps/desktop/src/lib/chat-model-groups.ts
@@ -9,6 +9,13 @@ export interface ModelOptionGroup {
   options: Array<{ option: ChatModelOption; value: string }>
 }
 
+function providerQualifier(provider: AiProviderConfig): string {
+  if (provider.provider === 'openai-compatible') {
+    return provider.baseUrl
+  }
+  return provider.keyHint === '' ? '' : `·····${provider.keyHint}`
+}
+
 /**
  * The flat option list regrouped per configured provider for rendering
  * (options arrive consecutively per entry). Values are list indexes — model
@@ -30,10 +37,11 @@ export function groupModelOptions(
     const providerLabel = aiProvider(option.provider).label
     const duplicated =
       providers.filter((provider) => provider.provider === option.provider).length > 1
-    const keyHint = providers.find((provider) => provider.id === option.configId)?.keyHint ?? ''
+    const configured = providers.find((provider) => provider.id === option.configId) ?? null
+    const qualifier = configured === null ? '' : providerQualifier(configured)
     groups.push({
       configId: option.configId,
-      label: duplicated && keyHint !== '' ? `${providerLabel} ·····${keyHint}` : providerLabel,
+      label: duplicated && qualifier !== '' ? `${providerLabel} · ${qualifier}` : providerLabel,
       options: [item],
     })
   })

--- a/apps/desktop/src/mobile/add-ai-provider-drawer.test.tsx
+++ b/apps/desktop/src/mobile/add-ai-provider-drawer.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
-import type { ApiKeyValidation } from '@reflect/core'
+import type { ApiKeyValidation, ApiKeyValidationInput } from '@reflect/core'
 
 /**
  * The mobile add-provider sheet over the shared submit flow: a verified key
@@ -11,7 +11,7 @@ import type { ApiKeyValidation } from '@reflect/core'
  */
 
 const validateApiKey = vi.hoisted(() =>
-  vi.fn<(provider: string, key: string, fetchFn?: typeof fetch) => Promise<ApiKeyValidation>>(),
+  vi.fn<(input: ApiKeyValidationInput, fetchFn?: typeof fetch) => Promise<ApiKeyValidation>>(),
 )
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
@@ -97,5 +97,39 @@ describe('AddAiProviderDrawer', () => {
     )
     // The unverified key was saved once, without a second validation probe.
     expect(validateApiKey).toHaveBeenCalledTimes(1)
+  })
+
+  it('submits an OpenAI-compatible endpoint without requiring an API key', async () => {
+    validateApiKey.mockResolvedValue('valid')
+    renderSheet()
+
+    fireEvent.keyDown(screen.getByRole('combobox', { name: 'Provider' }), { key: 'ArrowDown' })
+    fireEvent.keyDown(await screen.findByRole('option', { name: 'OpenAI-compatible' }), {
+      key: 'Enter',
+    })
+    fireEvent.change(screen.getByLabelText('Endpoint base URL'), {
+      target: { value: 'http://localhost:1234/v1' },
+    })
+    fireEvent.change(screen.getByLabelText('Default model'), { target: { value: 'llama-local' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add provider' }))
+
+    await waitFor(() =>
+      expect(validateApiKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'openai-compatible',
+          apiKey: '',
+          baseUrl: 'http://localhost:1234/v1',
+        }),
+        expect.any(Function),
+      ),
+    )
+    expect(onAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'openai-compatible',
+        apiKey: '',
+        baseUrl: 'http://localhost:1234/v1',
+        model: 'llama-local',
+      }),
+    )
   })
 })

--- a/apps/desktop/src/mobile/add-ai-provider-drawer.tsx
+++ b/apps/desktop/src/mobile/add-ai-provider-drawer.tsx
@@ -1,5 +1,12 @@
 import { useState, type ReactElement } from 'react'
-import { AI_PROVIDERS, aiProvider, aiProviderIdSchema, type AiProviderId } from '@reflect/core'
+import {
+  AI_PROVIDERS,
+  DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
+  aiProvider,
+  aiProviderIdSchema,
+  aiProviderRequiresApiKey,
+  type AiProviderId,
+} from '@reflect/core'
 import { InlineAlert } from '@/components/inline-alert'
 import { Button } from '@/components/ui/button'
 import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
@@ -27,10 +34,10 @@ const FIELD_LABEL_CLASS = 'text-xs font-medium text-text-secondary'
  * The mobile "Add AI provider" bottom sheet — desktop's dialog as a Drawer
  * (the {@link ConnectGithubDrawer} form idiom: labeled fields, shadcn
  * Selects) over the same {@link useAddAiProviderSubmit} flow: verify key →
- * inline rejection / save-anyway downgrade → persist. Models come from the
- * provider's curated list; custom model ids stay a desktop affordance. The
- * sheet body mounts per open cycle, so a dismissed half-typed key never
- * leaks into the next open.
+ * inline rejection / save-anyway downgrade → persist. Hosted providers use
+ * the curated model list; OpenAI-compatible endpoints expose free-form
+ * endpoint and model inputs. The sheet body mounts per open cycle, so a
+ * dismissed half-typed key never leaks into the next open.
  */
 export function AddAiProviderDrawer({
   open,
@@ -56,6 +63,7 @@ function AddAiProviderSheet({
 }): ReactElement {
   const [providerId, setProviderId] = useState<AiProviderId>(AI_PROVIDERS[0].id)
   const [model, setModel] = useState(AI_PROVIDERS[0].models[0].id)
+  const [baseUrl, setBaseUrl] = useState('')
   const [apiKey, setApiKey] = useState('')
   const [isDefault, setIsDefault] = useState(false)
   const [submitting, setSubmitting] = useState(false)
@@ -64,15 +72,23 @@ function AddAiProviderSheet({
     onDone: onClose,
   })
   const provider = aiProvider(providerId)
+  const isOpenAICompatible = provider.id === 'openai-compatible'
+  const apiKeyRequired = aiProviderRequiresApiKey(provider.id)
 
   const submitDraft = async (): Promise<void> => {
     setSubmitting(true)
     try {
-      await submit({ provider: providerId, model, apiKey, isDefault })
+      await submit({ provider: providerId, model, baseUrl, apiKey, isDefault })
     } finally {
       setSubmitting(false)
     }
   }
+
+  const submitDisabled =
+    submitting ||
+    model.trim() === '' ||
+    (apiKeyRequired && apiKey.trim() === '') ||
+    (isOpenAICompatible && baseUrl.trim() === '')
 
   return (
     <>
@@ -91,6 +107,7 @@ function AddAiProviderSheet({
               const next = aiProvider(aiProviderIdSchema.parse(value))
               setProviderId(next.id)
               setModel(next.models[0].id)
+              setBaseUrl(next.id === 'openai-compatible' ? DEFAULT_OPENAI_COMPATIBLE_BASE_URL : '')
               resetUnverified()
             }}
           >
@@ -109,22 +126,60 @@ function AddAiProviderSheet({
 
         <div className="flex flex-col gap-1">
           <span className={FIELD_LABEL_CLASS}>Default model</span>
-          <Select value={model} onValueChange={setModel}>
-            <SelectTrigger aria-label="Default model" className="w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {provider.models.map((candidate) => (
-                <SelectItem key={candidate.id} value={candidate.id}>
-                  {candidate.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          {isOpenAICompatible ? (
+            <Input
+              aria-label="Default model"
+              autoComplete="off"
+              spellCheck={false}
+              value={model}
+              onChange={(event) => {
+                setModel(event.target.value)
+                resetUnverified()
+              }}
+            />
+          ) : (
+            <Select
+              value={model}
+              onValueChange={(value) => {
+                setModel(value)
+                resetUnverified()
+              }}
+            >
+              <SelectTrigger aria-label="Default model" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {provider.models.map((candidate) => (
+                  <SelectItem key={candidate.id} value={candidate.id}>
+                    {candidate.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
         </div>
 
+        {isOpenAICompatible ? (
+          <label className="flex flex-col gap-1">
+            <span className={FIELD_LABEL_CLASS}>Endpoint base URL</span>
+            <Input
+              type="url"
+              placeholder={DEFAULT_OPENAI_COMPATIBLE_BASE_URL}
+              autoComplete="off"
+              spellCheck={false}
+              value={baseUrl}
+              onChange={(event) => {
+                setBaseUrl(event.target.value)
+                resetUnverified()
+              }}
+            />
+          </label>
+        ) : null}
+
         <label className="flex flex-col gap-1">
-          <span className={FIELD_LABEL_CLASS}>API key</span>
+          <span className={FIELD_LABEL_CLASS}>
+            {apiKeyRequired ? 'API key' : 'API key (optional)'}
+          </span>
           <Input
             type="password"
             placeholder={provider.keyPlaceholder}
@@ -154,7 +209,7 @@ function AddAiProviderSheet({
             Couldn’t reach {provider.label} to verify the key. Submit again to save it unverified.
           </InlineAlert>
         ) : null}
-        <Button disabled={apiKey.trim() === '' || submitting} onClick={() => void submitDraft()}>
+        <Button disabled={submitDisabled} onClick={() => void submitDraft()}>
           {unverified ? 'Save anyway' : 'Add provider'}
         </Button>
       </div>

--- a/apps/desktop/src/mobile/ai-provider-actions-drawer.tsx
+++ b/apps/desktop/src/mobile/ai-provider-actions-drawer.tsx
@@ -1,5 +1,10 @@
 import { useState, type ReactElement } from 'react'
-import { aiProvider, errorMessage, type AiProviderConfig } from '@reflect/core'
+import {
+  aiProvider,
+  aiProviderRequiresApiKey,
+  errorMessage,
+  type AiProviderConfig,
+} from '@reflect/core'
 import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
 import { SettingsActionRow, SettingsGroup } from '@/mobile/settings-list'
 
@@ -30,6 +35,12 @@ export function AiProviderActionsDrawer({
   onRemove,
 }: AiProviderActionsDrawerProps): ReactElement {
   const [removing, setRemoving] = useState(false)
+  const title =
+    provider === null
+      ? ''
+      : aiProviderRequiresApiKey(provider.provider) || provider.keyHint !== ''
+        ? `${aiProvider(provider.provider).label} ·····${provider.keyHint}`
+        : `${aiProvider(provider.provider).label} · No API key`
 
   // A failed removal (keychain write, settings store) keeps the sheet open —
   // closing would read as success — and logs; the row is still there to retry.
@@ -50,9 +61,7 @@ export function AiProviderActionsDrawer({
       <DrawerContent aria-label="Manage AI provider">
         {provider !== null ? (
           <>
-            <DrawerTitle className="px-4 pt-1">
-              {`${aiProvider(provider.provider).label} ·····${provider.keyHint}`}
-            </DrawerTitle>
+            <DrawerTitle className="px-4 pt-1">{title}</DrawerTitle>
             <div className="flex flex-col gap-6 px-4 pb-8 pt-4">
               <SettingsGroup>
                 <SettingsActionRow

--- a/apps/desktop/src/mobile/screens/chat.test.tsx
+++ b/apps/desktop/src/mobile/screens/chat.test.tsx
@@ -23,12 +23,14 @@ import { RouterProvider, useRouter } from '@/routing/router'
 const streamChat = vi.hoisted(() =>
   vi.fn<(options: StreamChatOptions) => AsyncGenerator<ChatStreamEvent>>(),
 )
-const getSecret = vi.hoisted(() => vi.fn<(name: string) => Promise<string | null>>())
+const aiApiKeyForConfig = vi.hoisted(() =>
+  vi.fn<(config: AiProviderConfig) => Promise<string | null>>(),
+)
 const loadChatGraphContext = vi.hoisted(() => vi.fn<(graphName: string) => Promise<null>>())
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   streamChat,
-  getSecret,
+  aiApiKeyForConfig,
   loadChatGraphContext,
 }))
 
@@ -83,7 +85,7 @@ beforeEach(() => {
   settingsState.models = []
   settingsState.defaultId = null
   streamChat.mockReset()
-  getSecret.mockReset().mockResolvedValue('sk-test')
+  aiApiKeyForConfig.mockReset().mockResolvedValue('sk-test')
   loadChatGraphContext.mockReset().mockResolvedValue(null)
 })
 

--- a/apps/desktop/src/mobile/screens/settings.tsx
+++ b/apps/desktop/src/mobile/screens/settings.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import {
   aiProvider,
+  aiProviderRequiresApiKey,
   errorMessage,
   hasBridge,
   listNotes,
@@ -36,6 +37,14 @@ const THEME_OPTIONS: readonly SegmentedOption<ThemePreference>[] = [
   { value: 'light', label: 'Light' },
   { value: 'dark', label: 'Dark' },
 ]
+
+function aiProviderValue(provider: AiProviderConfig, defaultProviderId: string | null): string {
+  const credential =
+    aiProviderRequiresApiKey(provider.provider) || provider.keyHint !== ''
+      ? `·····${provider.keyHint}`
+      : 'No API key'
+  return provider.id === defaultProviderId ? `${credential} · Default` : credential
+}
 
 const TEXT_SIZE_OPTIONS: readonly SegmentedOption<EditorTextSize>[] = [
   { value: 'small', label: 'Small' },
@@ -171,7 +180,7 @@ export function MobileSettings(): ReactElement {
               <SettingsNavRow
                 key={provider.id}
                 label={aiProvider(provider.provider).label}
-                value={`·····${provider.keyHint}${provider.id === defaultProvider?.id ? ' · Default' : ''}`}
+                value={aiProviderValue(provider, defaultProvider?.id ?? null)}
                 onPress={() => {
                   setManagedProvider(provider)
                   setManageOpen(true)

--- a/apps/desktop/src/providers/chat-provider.test.tsx
+++ b/apps/desktop/src/providers/chat-provider.test.tsx
@@ -25,6 +25,7 @@ import { ChatProvider, useChatSession } from '@/providers/chat-provider'
 
 const core = vi.hoisted(() => ({
   streamChat: vi.fn<(options: StreamChatOptions) => AsyncGenerator<ChatStreamEvent>>(),
+  aiApiKeyForConfig: vi.fn<(config: AiProviderConfig) => Promise<string | null>>(),
   getSecret: vi.fn<(name: string) => Promise<string | null>>(),
   hasBridge: vi.fn<() => boolean>(),
   loadChatGraphContext: vi.fn<(graphName: string) => Promise<null>>(),
@@ -126,6 +127,7 @@ beforeEach(() => {
   settingsState.selection = null
   settingsState.semanticSearchEnabled = false
   core.hasBridge.mockReturnValue(true)
+  core.aiApiKeyForConfig.mockResolvedValue('sk-test')
   core.getSecret.mockResolvedValue('sk-test')
   core.loadChatGraphContext.mockResolvedValue(null)
   core.listChatConversations.mockResolvedValue([])

--- a/apps/desktop/src/providers/chat-provider.tsx
+++ b/apps/desktop/src/providers/chat-provider.tsx
@@ -8,13 +8,12 @@ import {
   type ReactNode,
 } from 'react'
 import {
-  aiKeySecretName,
+  aiApiKeyForConfig,
   appendEvent,
   buildHistory,
   chatModelOptions,
   deleteChatConversation,
   errorMessage,
-  getSecret,
   hasBridge,
   listChatConversations,
   loadChatGraphContext,
@@ -280,7 +279,7 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
         // The graph overview degrades to null (prompt without the block)
         // rather than blocking the turn — a cold index shouldn't kill chat.
         const [apiKey, context] = await Promise.all([
-          getSecret(aiKeySecretName(config.id)),
+          aiApiKeyForConfig(config),
           loadChatGraphContext(graph.name).catch((cause: unknown) => {
             console.error('chat graph context failed:', errorMessage(cause))
             return null
@@ -459,4 +458,3 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
   )
   return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>
 }
-

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
     "@ai-sdk/anthropic": "^3.0.87",
     "@ai-sdk/google": "^3.0.84",
     "@ai-sdk/openai": "^3.0.75",
+    "@ai-sdk/openai-compatible": "^2.0.58",
     "@lezer/common": "^1.5.2",
     "@lezer/markdown": "^1.6.4",
     "@reflect/db": "workspace:*",

--- a/packages/core/src/actions/asset-description.ts
+++ b/packages/core/src/actions/asset-description.ts
@@ -1,13 +1,12 @@
 import { describeAsset, isAssetDescriptionRejected } from '../ai/describe-asset'
 import { defaultAiProvider, type AiProvidersState } from '../ai/provider-config'
-import { aiKeySecretName } from '../ai/secrets'
+import { aiApiKeyForConfig } from '../ai/secrets'
 import { base64ToBytes } from '../ai/transcribe'
 import { errorMessage, isAppError, toAppError } from '../errors'
 import { listDir, readAsset, readNote, writeNote } from '../graph/commands'
 import { ASSETS_DIR, descriptionPathFor } from '../graph/paths'
 import type { FileMeta } from '../graph/schemas'
 import { hashContent } from '../indexing/hash'
-import { getSecret } from '../secrets/keychain'
 import type { AiProviderConfig } from '../settings/schema'
 import type { ReconcileStop } from './audio-memo'
 import {
@@ -359,7 +358,7 @@ export async function reconcileAssetDescriptions(
   if (config === null) {
     return outcome(total, { reason: 'config', message: 'No AI provider is configured.' })
   }
-  const apiKey = await getSecret(aiKeySecretName(config.id)).catch(() => null)
+  const apiKey = await aiApiKeyForConfig(config)
   if (apiKey === null) {
     return outcome(total, {
       reason: 'config',

--- a/packages/core/src/actions/audio-memo.ts
+++ b/packages/core/src/actions/audio-memo.ts
@@ -4,7 +4,7 @@ import {
   type AiProvidersState,
   type TranscriptionConfig,
 } from '../ai/provider-config'
-import { aiKeySecretName } from '../ai/secrets'
+import { aiApiKeyForConfig, aiKeySecretName } from '../ai/secrets'
 import { generateAudioMemoTitle, pickAudioMemoTitleConfig } from '../ai/audio-memo-title'
 import {
   AUDIO_EXTENSION_BY_MIME,
@@ -433,7 +433,7 @@ export async function reconcileAudioMemos(
       ? null
       : titleConfig.id === config.id
         ? apiKey
-        : await getSecret(aiKeySecretName(titleConfig.id)).catch(() => null)
+        : await aiApiKeyForConfig(titleConfig)
   const titleCredentials =
     titleConfig !== null && titleApiKey !== null ? { config: titleConfig, apiKey: titleApiKey } : null
 

--- a/packages/core/src/actions/capture-enrichment.ts
+++ b/packages/core/src/actions/capture-enrichment.ts
@@ -1,13 +1,12 @@
 import { describePage, isDescriptionRejected, type PageEnrichment } from '../ai/describe-page'
 import { defaultAiProvider, type AiProvidersState } from '../ai/provider-config'
-import { aiKeySecretName } from '../ai/secrets'
+import { aiApiKeyForConfig } from '../ai/secrets'
 import { errorMessage, isAppError, toAppError } from '../errors'
 import { listFiles, readAsset, readNote, writeNote } from '../graph/commands'
 import { dailyPath } from '../graph/paths'
 import { hashContent } from '../indexing/hash'
 import { parseNote } from '../markdown/extract'
 import { parseFrontmatter, splitFrontmatter, upsertFrontmatter } from '../markdown/frontmatter'
-import { getSecret } from '../secrets/keychain'
 import type { AiProviderConfig } from '../settings/schema'
 import type { ReconcileStop } from './audio-memo'
 import { captureFromPath, type CaptureIdentity } from './capture-identity'
@@ -159,7 +158,7 @@ export async function reconcileCaptureEnrichment(
   const config = defaultAiProvider(input.providers)
   let apiKey: string | null = null
   if (config !== null) {
-    apiKey = await getSecret(aiKeySecretName(config.id)).catch(() => null)
+    apiKey = await aiApiKeyForConfig(config)
     if (apiKey === null) {
       return {
         pending: pending.length,

--- a/packages/core/src/ai/audio-memo-title.ts
+++ b/packages/core/src/ai/audio-memo-title.ts
@@ -21,7 +21,7 @@ const audioMemoTitleSchema = z.object({
 interface AudioMemoTitleCredentials {
   /** The provider entry whose provider selects the fixed small title model. */
   readonly config: AiProviderConfig
-  /** The BYOK API key, read from the OS keychain by the caller. */
+  /** The BYOK API key, or an empty string for no-key compatible endpoints. */
   readonly apiKey: string
 }
 
@@ -46,6 +46,8 @@ function audioMemoTitleConfig(config: AiProviderConfig): AiProviderConfig | null
       return { ...config, model: GOOGLE_AUDIO_MEMO_TITLE_MODEL }
     case 'openrouter':
       return null
+    case 'openai-compatible':
+      return config
   }
 }
 
@@ -53,7 +55,8 @@ function audioMemoTitleConfig(config: AiProviderConfig): AiProviderConfig | null
  * Pick the small-model provider for audio memo title generation. The user's
  * default provider wins when it has a fixed small title model; otherwise the
  * first supported configured provider is used. OpenRouter is skipped because
- * `openrouter/auto` is not a small-model guarantee.
+ * `openrouter/auto` is not a small-model guarantee; OpenAI-compatible entries
+ * use the model the user configured for that endpoint.
  */
 export function pickAudioMemoTitleConfig(state: AiProvidersState): AiProviderConfig | null {
   const preferred = state.providers.find((provider) => provider.id === state.defaultProviderId)

--- a/packages/core/src/ai/chat/model-options.test.ts
+++ b/packages/core/src/ai/chat/model-options.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import type { AiProviderConfig } from '../../settings/schema'
+import type { HostedAiProviderConfig } from '../../settings/schema'
 import { aiProvider } from '../provider-catalog'
 import { chatModelOptions, resolveChatModel } from './model-options'
 
-function config(overrides: Partial<AiProviderConfig>): AiProviderConfig {
+function config(overrides: Partial<HostedAiProviderConfig>): HostedAiProviderConfig {
   return {
     id: 'id',
     provider: 'anthropic',
@@ -35,6 +35,24 @@ describe('chatModelOptions', () => {
       label: 'claude-custom',
     })
     expect(options).toHaveLength(aiProvider('anthropic').models.length + 1)
+  })
+
+  it('keeps the configured OpenAI-compatible model selectable', () => {
+    const options = chatModelOptions([
+      {
+        id: 'local',
+        provider: 'openai-compatible',
+        model: 'llama-local',
+        baseUrl: 'http://localhost:1234/v1',
+        keyHint: '',
+      },
+    ])
+    expect(options.at(-1)).toEqual({
+      configId: 'local',
+      provider: 'openai-compatible',
+      modelId: 'llama-local',
+      label: 'llama-local',
+    })
   })
 
   it('groups options consecutively per configured entry', () => {

--- a/packages/core/src/ai/chat/stream-chat.ts
+++ b/packages/core/src/ai/chat/stream-chat.ts
@@ -36,7 +36,7 @@ export const MAX_STEPS = 12
 export interface StreamChatOptions {
   /** The provider entry to call, with `model` set to the model id to use. */
   config: AiProviderConfig
-  /** The BYOK API key, read from the OS keychain by the caller. */
+  /** The BYOK API key, or an empty string for no-key compatible endpoints. */
   apiKey: string
   /**
    * Transport for the provider call — the desktop passes its shell fetch

--- a/packages/core/src/ai/describe-asset.ts
+++ b/packages/core/src/ai/describe-asset.ts
@@ -22,7 +22,7 @@ export type AssetKind = 'image' | 'pdf' | 'svg'
 export interface DescribeAssetRequest {
   /** The provider entry to call (the app default). */
   config: AiProviderConfig
-  /** The BYOK API key, read from the OS keychain by the caller. */
+  /** The BYOK API key, or an empty string for no-key compatible endpoints. */
   apiKey: string
   /** Host transport (the Tauri HTTP plugin's fetch; tests pass a stub). */
   fetchFn?: typeof fetch | undefined

--- a/packages/core/src/ai/describe-page.ts
+++ b/packages/core/src/ai/describe-page.ts
@@ -26,7 +26,7 @@ const MAX_TITLE_CHARS = 100
 export interface DescribePageRequest {
   /** The provider entry to call (the app default). */
   config: AiProviderConfig
-  /** The BYOK API key, read from the OS keychain by the caller. */
+  /** The BYOK API key, or an empty string for no-key compatible endpoints. */
   apiKey: string
   /** Host transport (the Tauri HTTP plugin's fetch; tests pass a stub). */
   fetchFn?: typeof fetch | undefined

--- a/packages/core/src/ai/language-model.test.ts
+++ b/packages/core/src/ai/language-model.test.ts
@@ -26,6 +26,14 @@ const OPENROUTER_CONFIG: AiProviderConfig = {
   keyHint: 'wxyz1',
 }
 
+const OPENAI_COMPATIBLE_CONFIG: AiProviderConfig = {
+  id: 'cfg-local',
+  provider: 'openai-compatible',
+  model: 'llama-local',
+  baseUrl: 'http://localhost:1234/v1',
+  keyHint: '',
+}
+
 function recordingAnthropicFetch(calls: RecordedCall[]): typeof fetch {
   return async (input, init) => {
     calls.push({
@@ -74,6 +82,32 @@ function recordingOpenRouterFetch(calls: RecordedCall[]): typeof fetch {
   }
 }
 
+function recordingOpenAICompatibleFetch(calls: RecordedCall[]): typeof fetch {
+  return async (input, init) => {
+    calls.push({
+      url: String(input),
+      headers: new Headers(init?.headers),
+    })
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl_local',
+        object: 'chat.completion',
+        created: 0,
+        model: OPENAI_COMPATIBLE_CONFIG.model,
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'ok' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+}
+
 describe('languageModel', () => {
   it('adds Anthropic direct-browser access to model calls', async () => {
     const calls: RecordedCall[] = []
@@ -105,5 +139,19 @@ describe('languageModel', () => {
     expect(calls[0]!.headers.get('Authorization')).toBe('Bearer sk-or-v1-test')
     expect(calls[0]!.headers.get('HTTP-Referer')).toBe('https://reflect.app')
     expect(calls[0]!.headers.get('X-OpenRouter-Title')).toBe('Reflect')
+  })
+
+  it('routes custom OpenAI-compatible providers through their configured endpoint', async () => {
+    const calls: RecordedCall[] = []
+
+    await generateText({
+      model: languageModel(OPENAI_COMPATIBLE_CONFIG, '', recordingOpenAICompatibleFetch(calls)),
+      prompt: 'hello',
+      maxRetries: 0,
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.url).toBe('http://localhost:1234/v1/chat/completions')
+    expect(calls[0]!.headers.get('Authorization')).toBeNull()
   })
 })

--- a/packages/core/src/ai/language-model.ts
+++ b/packages/core/src/ai/language-model.ts
@@ -1,9 +1,11 @@
 import { createAnthropic } from '@ai-sdk/anthropic'
 import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import { createOpenAI } from '@ai-sdk/openai'
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import type { LanguageModel } from 'ai'
 import type { AiProviderConfig } from '../settings/schema'
 import { anthropicDirectBrowserAccessHeaders } from './anthropic-headers'
+import { OPENAI_COMPATIBLE_PROVIDER_ID } from './openai-compatible'
 import { OPENROUTER_BASE_URL, openRouterAttributionHeaders } from './openrouter'
 
 /**
@@ -36,5 +38,13 @@ export function languageModel(
         headers: openRouterAttributionHeaders(),
         name: 'openrouter',
       }).chat(config.model)
+    case 'openai-compatible':
+      return createOpenAICompatible({
+        name: OPENAI_COMPATIBLE_PROVIDER_ID,
+        baseURL: config.baseUrl,
+        fetch: fetchFn,
+        includeUsage: true,
+        ...(apiKey.trim() === '' ? {} : { apiKey }),
+      }).chatModel(config.model)
   }
 }

--- a/packages/core/src/ai/openai-compatible.ts
+++ b/packages/core/src/ai/openai-compatible.ts
@@ -1,0 +1,22 @@
+export const OPENAI_COMPATIBLE_PROVIDER_ID = 'openai-compatible'
+
+export const DEFAULT_OPENAI_COMPATIBLE_BASE_URL = 'http://localhost:1234/v1'
+
+export const DEFAULT_OPENAI_COMPATIBLE_MODEL = 'local-model'
+
+export function normalizeOpenAICompatibleBaseUrl(value: string): string {
+  return value.trim().replace(/\/+$/u, '')
+}
+
+export function isHttpBaseUrl(value: string): boolean {
+  try {
+    const url = new URL(normalizeOpenAICompatibleBaseUrl(value))
+    return (
+      (url.protocol === 'http:' || url.protocol === 'https:') &&
+      url.search === '' &&
+      url.hash === ''
+    )
+  } catch {
+    return false
+  }
+}

--- a/packages/core/src/ai/provider-catalog.test.ts
+++ b/packages/core/src/ai/provider-catalog.test.ts
@@ -14,6 +14,15 @@ describe('AI_PROVIDERS', () => {
       keyPlaceholder: 'sk-or-v1-…',
     })
   })
+
+  it('includes OpenAI-compatible endpoints with optional keys', () => {
+    expect(aiProvider('openai-compatible')).toMatchObject({
+      id: 'openai-compatible',
+      label: 'OpenAI-compatible',
+      apiKeyRequired: false,
+      keyPlaceholder: 'Optional API key',
+    })
+  })
 })
 
 describe('modelContextWindow', () => {

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -1,4 +1,5 @@
 import type { AiProviderId } from '../settings/schema'
+import { DEFAULT_OPENAI_COMPATIBLE_MODEL } from './openai-compatible'
 
 /** A compile-time guarantee that an array has at least one element. */
 type NonEmptyArray<ElementType> = [ElementType, ...ElementType[]]
@@ -30,6 +31,8 @@ export interface AiProviderInfo {
   id: AiProviderId
   /** Human-readable provider name shown in pickers. */
   label: string
+  /** Whether a non-empty key must be stored before this provider can be used. */
+  apiKeyRequired: boolean
   /** Placeholder illustrating the provider's API-key format. */
   keyPlaceholder: string
   /** Curated models, most capable first (the first is the picker default). */
@@ -40,6 +43,7 @@ export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
   {
     id: 'openai',
     label: 'OpenAI',
+    apiKeyRequired: true,
     keyPlaceholder: 'sk-…',
     models: [
       { id: 'gpt-5.5', label: 'GPT-5.5', contextWindow: 1_000_000 },
@@ -51,6 +55,7 @@ export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
   {
     id: 'anthropic',
     label: 'Anthropic',
+    apiKeyRequired: true,
     keyPlaceholder: 'sk-ant-…',
     models: [
       { id: 'claude-fable-5', label: 'Claude Fable 5', contextWindow: 1_000_000 },
@@ -62,6 +67,7 @@ export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
   {
     id: 'google',
     label: 'Google Gemini',
+    apiKeyRequired: true,
     keyPlaceholder: 'AIza…',
     models: [
       { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro', contextWindow: 1_000_000 },
@@ -73,6 +79,7 @@ export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
   {
     id: 'openrouter',
     label: 'OpenRouter',
+    apiKeyRequired: true,
     keyPlaceholder: 'sk-or-v1-…',
     models: [
       { id: 'openrouter/auto', label: 'Auto Router', contextWindow: 128_000 },
@@ -85,6 +92,15 @@ export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
       { id: 'openai/gpt-5.2', label: 'GPT-5.2', contextWindow: 400_000 },
     ],
   },
+  {
+    id: 'openai-compatible',
+    label: 'OpenAI-compatible',
+    apiKeyRequired: false,
+    keyPlaceholder: 'Optional API key',
+    models: [
+      { id: DEFAULT_OPENAI_COMPATIBLE_MODEL, label: 'Local model', contextWindow: 128_000 },
+    ],
+  },
 ]
 
 /** The catalog entry for `id` (every `AiProviderId` is in the catalog). */
@@ -94,6 +110,11 @@ export function aiProvider(id: AiProviderId): AiProviderInfo {
     throw new Error(`unknown AI provider: ${id}`)
   }
   return provider
+}
+
+/** Whether a configured provider must have a non-empty keychain secret. */
+export function aiProviderRequiresApiKey(id: AiProviderId): boolean {
+  return aiProvider(id).apiKeyRequired
 }
 
 /**

--- a/packages/core/src/ai/provider-config.test.ts
+++ b/packages/core/src/ai/provider-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { AiProviderConfig } from '../settings/schema'
+import type { AiProviderConfig, HostedAiProviderConfig } from '../settings/schema'
 import {
   apiKeyHint,
   defaultAiProvider,
@@ -9,7 +9,7 @@ import {
   type AiProvidersState,
 } from './provider-config'
 
-function config(overrides: Partial<AiProviderConfig>): AiProviderConfig {
+function config(overrides: Partial<HostedAiProviderConfig>): HostedAiProviderConfig {
   return {
     id: 'id',
     provider: 'openai',

--- a/packages/core/src/ai/secrets.test.ts
+++ b/packages/core/src/ai/secrets.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { HostedAiProviderConfig, OpenAiCompatibleProviderConfig } from '../settings/schema'
+
+const getSecret = vi.hoisted(() => vi.fn<(name: string) => Promise<string | null>>())
+
+vi.mock('../secrets/keychain', () => ({ getSecret }))
+
+const { aiApiKeyForConfig } = await import('./secrets')
+
+function hostedConfig(overrides: Partial<HostedAiProviderConfig>): HostedAiProviderConfig {
+  return {
+    id: 'cfg',
+    provider: 'openai',
+    model: 'gpt-5.4',
+    keyHint: '12345',
+    ...overrides,
+  }
+}
+
+function openAiCompatibleConfig(
+  overrides: Partial<OpenAiCompatibleProviderConfig>,
+): OpenAiCompatibleProviderConfig {
+  return {
+    id: 'cfg-local',
+    provider: 'openai-compatible',
+    model: 'llama-local',
+    baseUrl: 'http://localhost:1234/v1',
+    keyHint: '',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  getSecret.mockReset()
+})
+
+describe('aiApiKeyForConfig', () => {
+  it('returns stored keys for configured providers', async () => {
+    getSecret.mockResolvedValue('sk-live')
+    await expect(aiApiKeyForConfig(hostedConfig({}))).resolves.toBe('sk-live')
+  })
+
+  it('allows a no-key OpenAI-compatible endpoint', async () => {
+    getSecret.mockResolvedValue(null)
+    await expect(
+      aiApiKeyForConfig(openAiCompatibleConfig({ keyHint: '' })),
+    ).resolves.toBe('')
+  })
+
+  it('reports a missing key when an OpenAI-compatible entry was saved with one', async () => {
+    getSecret.mockResolvedValue(null)
+    await expect(
+      aiApiKeyForConfig(openAiCompatibleConfig({ keyHint: '12345' })),
+    ).resolves.toBeNull()
+  })
+})

--- a/packages/core/src/ai/secrets.ts
+++ b/packages/core/src/ai/secrets.ts
@@ -1,3 +1,7 @@
+import type { AiProviderConfig } from '../settings/schema'
+import { getSecret } from '../secrets/keychain'
+import { aiProviderRequiresApiKey } from './provider-catalog'
+
 /**
  * The AI domain's keychain policy: which entries hold BYOK provider keys.
  * The storage primitive itself lives in `secrets/keychain` (shared with the
@@ -10,4 +14,20 @@
  */
 export function aiKeySecretName(configId: string): string {
   return `ai-api-key:${configId}`
+}
+
+/**
+ * Read the key for `config`, returning an empty string for providers that can
+ * legitimately run without one (for example a local OpenAI-compatible server).
+ * `null` still means "this provider is misconfigured and cannot be called."
+ */
+export async function aiApiKeyForConfig(config: AiProviderConfig): Promise<string | null> {
+  const apiKey = await getSecret(aiKeySecretName(config.id)).catch(() => null)
+  if (apiKey !== null) {
+    return apiKey
+  }
+  if (!aiProviderRequiresApiKey(config.provider) && config.keyHint === '') {
+    return ''
+  }
+  return null
 }

--- a/packages/core/src/ai/transform-selection.ts
+++ b/packages/core/src/ai/transform-selection.ts
@@ -28,7 +28,7 @@ const TRANSFORM_SYSTEM_PROMPT = [
 export interface TransformSelectionOptions {
   /** The provider entry to call, with `model` set to the model id to use. */
   config: AiProviderConfig
-  /** The BYOK API key, read from the OS keychain by the caller. */
+  /** The BYOK API key, or an empty string for no-key compatible endpoints. */
   apiKey: string
   /**
    * Transport for the provider call — the desktop passes its shell fetch

--- a/packages/core/src/ai/validate-key.test.ts
+++ b/packages/core/src/ai/validate-key.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { validateApiKey } from './validate-key'
 
 function fetchReturning(status: number): typeof fetch {
@@ -20,10 +20,22 @@ describe('validateApiKey', () => {
       return new Response(null, { status: 200 })
     }
 
-    await validateApiKey('openai', 'sk-test', recordingFetch)
-    await validateApiKey('anthropic', 'sk-ant-test', recordingFetch)
-    await validateApiKey('google', 'AIza-test', recordingFetch)
-    await validateApiKey('openrouter', 'sk-or-v1-test', recordingFetch)
+    await validateApiKey({ provider: 'openai', apiKey: 'sk-test' }, recordingFetch)
+    await validateApiKey({ provider: 'anthropic', apiKey: 'sk-ant-test' }, recordingFetch)
+    await validateApiKey({ provider: 'google', apiKey: 'AIza-test' }, recordingFetch)
+    await validateApiKey({ provider: 'openrouter', apiKey: 'sk-or-v1-test' }, recordingFetch)
+    await validateApiKey(
+      {
+        provider: 'openai-compatible',
+        apiKey: 'local-secret',
+        baseUrl: 'http://localhost:1234/v1/',
+      },
+      recordingFetch,
+    )
+    await validateApiKey(
+      { provider: 'openai-compatible', apiKey: '', baseUrl: 'http://localhost:1234/v1' },
+      recordingFetch,
+    )
 
     expect(calls[0]!.url).toBe('https://api.openai.com/v1/models')
     expect(calls[0]!.headers['Authorization']).toBe('Bearer sk-test')
@@ -34,25 +46,60 @@ describe('validateApiKey', () => {
     expect(calls[2]!.headers['x-goog-api-key']).toBe('AIza-test')
     expect(calls[3]!.url).toBe('https://openrouter.ai/api/v1/key')
     expect(calls[3]!.headers['Authorization']).toBe('Bearer sk-or-v1-test')
+    expect(calls[4]!.url).toBe('http://localhost:1234/v1/models')
+    expect(calls[4]!.headers['Authorization']).toBe('Bearer local-secret')
+    expect(calls[5]!.url).toBe('http://localhost:1234/v1/models')
+    expect(calls[5]!.headers['Authorization']).toBeUndefined()
   })
 
   it('reads an ok response as valid', async () => {
-    expect(await validateApiKey('openai', 'sk-test', fetchReturning(200))).toBe('valid')
-  })
-
-  it('reads an auth rejection as invalid', async () => {
-    expect(await validateApiKey('openai', 'sk-test', fetchReturning(401))).toBe('invalid')
-    expect(await validateApiKey('anthropic', 'sk-test', fetchReturning(403))).toBe('invalid')
-    // Gemini reports malformed keys as 400.
-    expect(await validateApiKey('google', 'bad', fetchReturning(400))).toBe('invalid')
-    expect(await validateApiKey('openrouter', 'sk-or-v1-test', fetchReturning(401))).toBe(
-      'invalid',
+    expect(await validateApiKey({ provider: 'openai', apiKey: 'sk-test' }, fetchReturning(200))).toBe(
+      'valid',
     )
   })
 
+  it('reads an auth rejection as invalid', async () => {
+    expect(await validateApiKey({ provider: 'openai', apiKey: 'sk-test' }, fetchReturning(401))).toBe(
+      'invalid',
+    )
+    expect(
+      await validateApiKey({ provider: 'anthropic', apiKey: 'sk-test' }, fetchReturning(403)),
+    ).toBe('invalid')
+    // Gemini reports malformed keys as 400.
+    expect(await validateApiKey({ provider: 'google', apiKey: 'bad' }, fetchReturning(400))).toBe(
+      'invalid',
+    )
+    expect(
+      await validateApiKey({ provider: 'openrouter', apiKey: 'sk-or-v1-test' }, fetchReturning(401)),
+    ).toBe('invalid')
+    expect(
+      await validateApiKey(
+        { provider: 'openai-compatible', apiKey: '', baseUrl: 'http://localhost:1234/v1' },
+        fetchReturning(401),
+      ),
+    ).toBe('invalid')
+  })
+
   it('reads anything that is not an auth decision as unreachable', async () => {
-    expect(await validateApiKey('openai', 'sk-test', fetchReturning(500))).toBe('unreachable')
-    expect(await validateApiKey('openai', 'sk-test', fetchReturning(429))).toBe('unreachable')
-    expect(await validateApiKey('openai', 'sk-test', fetchThrowing)).toBe('unreachable')
+    expect(await validateApiKey({ provider: 'openai', apiKey: 'sk-test' }, fetchReturning(500))).toBe(
+      'unreachable',
+    )
+    expect(await validateApiKey({ provider: 'openai', apiKey: 'sk-test' }, fetchReturning(429))).toBe(
+      'unreachable',
+    )
+    expect(await validateApiKey({ provider: 'openai', apiKey: 'sk-test' }, fetchThrowing)).toBe(
+      'unreachable',
+    )
+  })
+
+  it('reads an invalid OpenAI-compatible base URL as invalid without fetching', async () => {
+    const fetchFn = vi.fn<typeof fetch>()
+    expect(
+      await validateApiKey(
+        { provider: 'openai-compatible', apiKey: '', baseUrl: 'file:///tmp/model.sock' },
+        fetchFn,
+      ),
+    ).toBe('invalid')
+    expect(fetchFn).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/ai/validate-key.ts
+++ b/packages/core/src/ai/validate-key.ts
@@ -1,5 +1,6 @@
-import type { AiProviderId } from '../settings/schema'
+import type { AiProviderId, HostedAiProviderId } from '../settings/schema'
 import { anthropicDirectBrowserAccessHeaders } from './anthropic-headers'
+import { isHttpBaseUrl, normalizeOpenAICompatibleBaseUrl } from './openai-compatible'
 import { OPENROUTER_BASE_URL } from './openrouter'
 
 /**
@@ -23,7 +24,13 @@ interface KeyProbe {
   invalidStatuses: number[]
 }
 
-const PROBES: Record<AiProviderId, KeyProbe> = {
+export interface ApiKeyValidationInput {
+  provider: AiProviderId
+  apiKey: string
+  baseUrl?: string | undefined
+}
+
+const PROBES: Record<HostedAiProviderId, KeyProbe> = {
   openai: {
     url: 'https://api.openai.com/v1/models',
     headers: (key) => ({ Authorization: `Bearer ${key}` }),
@@ -51,20 +58,41 @@ const PROBES: Record<AiProviderId, KeyProbe> = {
   },
 }
 
+function openAiCompatibleProbe(input: ApiKeyValidationInput): KeyProbe | null {
+  if (input.baseUrl === undefined || !isHttpBaseUrl(input.baseUrl)) {
+    return null
+  }
+  const baseUrl = normalizeOpenAICompatibleBaseUrl(input.baseUrl)
+  return {
+    url: `${baseUrl}/models`,
+    headers: (key) => (key.trim() === '' ? {} : { Authorization: `Bearer ${key}` }),
+    invalidStatuses: [401, 403],
+  }
+}
+
+function keyProbe(input: ApiKeyValidationInput): KeyProbe | null {
+  if (input.provider === 'openai-compatible') {
+    return openAiCompatibleProbe(input)
+  }
+  return PROBES[input.provider]
+}
+
 /**
- * Probe `provider` with `apiKey`. `fetchFn` lets hosts substitute a
+ * Probe `input.provider` with `input.apiKey`. `fetchFn` lets hosts substitute a
  * CORS-free transport (the desktop app passes the Tauri HTTP plugin's fetch;
  * `@reflect/core` itself stays platform-agnostic).
  */
 export async function validateApiKey(
-  provider: AiProviderId,
-  apiKey: string,
+  input: ApiKeyValidationInput,
   fetchFn: typeof fetch = fetch,
 ): Promise<ApiKeyValidation> {
-  const probe = PROBES[provider]
+  const probe = keyProbe(input)
+  if (probe === null) {
+    return 'invalid'
+  }
   let response: Response
   try {
-    response = await fetchFn(probe.url, { method: 'GET', headers: probe.headers(apiKey) })
+    response = await fetchFn(probe.url, { method: 'GET', headers: probe.headers(input.apiKey) })
   } catch {
     return 'unreachable'
   }

--- a/packages/core/src/exports/ai-actions.ts
+++ b/packages/core/src/exports/ai-actions.ts
@@ -2,12 +2,20 @@ export {
   AI_PROVIDERS,
   aiProvider,
   aiModelLabel,
+  aiProviderRequiresApiKey,
   DEFAULT_CONTEXT_WINDOW,
   modelContextWindow,
   type AiProviderInfo,
   type AiModelOption,
 } from '../ai/provider-catalog'
-export { aiKeySecretName } from '../ai/secrets'
+export { aiKeySecretName, aiApiKeyForConfig } from '../ai/secrets'
+export {
+  DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
+  DEFAULT_OPENAI_COMPATIBLE_MODEL,
+  isHttpBaseUrl,
+  normalizeOpenAICompatibleBaseUrl,
+  OPENAI_COMPATIBLE_PROVIDER_ID,
+} from '../ai/openai-compatible'
 export { setSecret, getSecret, deleteSecret } from '../secrets/keychain'
 export {
   KEY_HINT_LENGTH,
@@ -27,7 +35,11 @@ export {
   type ChatModelOption,
   type ChatModelSelection,
 } from '../ai/chat/model-options'
-export { validateApiKey, type ApiKeyValidation } from '../ai/validate-key'
+export {
+  validateApiKey,
+  type ApiKeyValidation,
+  type ApiKeyValidationInput,
+} from '../ai/validate-key'
 export {
   assertCloudAllowed,
   cloudSafeAssetDescription,

--- a/packages/core/src/exports/platform.ts
+++ b/packages/core/src/exports/platform.ts
@@ -155,6 +155,7 @@ export {
   graphColorsSchema,
   GRAPH_COLOR_IDS,
   aiProviderIdSchema,
+  openAiCompatibleBaseUrlSchema,
   aiProviderConfigSchema,
   aiProvidersSchema,
   defaultAiProviderIdSchema,
@@ -175,7 +176,10 @@ export {
   type GraphColor,
   type GraphColors,
   type AiProviderId,
+  type HostedAiProviderId,
   type AiProviderConfig,
+  type HostedAiProviderConfig,
+  type OpenAiCompatibleProviderConfig,
   type AiPrompt,
   type AiPromptMode,
 } from '../settings/schema'

--- a/packages/core/src/settings/schema.test.ts
+++ b/packages/core/src/settings/schema.test.ts
@@ -218,6 +218,19 @@ describe('settingsSchema', () => {
       expect(settingsSchema.parse({ aiProviders: [entry] }).aiProviders).toEqual([entry])
     })
 
+    it('accepts OpenAI-compatible entries with an http base URL', () => {
+      const entry = {
+        id: 'local',
+        provider: 'openai-compatible',
+        model: 'llama-local',
+        baseUrl: 'http://localhost:1234/v1/',
+        keyHint: '',
+      }
+      expect(settingsSchema.parse({ aiProviders: [entry] }).aiProviders).toEqual([
+        { ...entry, baseUrl: 'http://localhost:1234/v1' },
+      ])
+    })
+
     it('defaults the per-entry display fields', () => {
       const entry = { id: 'abc', provider: 'openai', model: 'gpt-5.1' }
       expect(settingsSchema.parse({ aiProviders: [entry] }).aiProviders).toEqual([
@@ -228,6 +241,30 @@ describe('settingsSchema', () => {
     it('drops a corrupt entry without losing the rest', () => {
       const parsed = settingsSchema.parse({
         aiProviders: [valid, { provider: 'aliens' }, 42],
+      })
+      expect(parsed.aiProviders).toEqual([valid])
+    })
+
+    it('drops OpenAI-compatible entries without a safe base URL', () => {
+      const parsed = settingsSchema.parse({
+        aiProviders: [
+          valid,
+          { id: 'local', provider: 'openai-compatible', model: 'llama-local', keyHint: '' },
+          {
+            id: 'socket',
+            provider: 'openai-compatible',
+            model: 'llama-local',
+            baseUrl: 'file:///tmp/model.sock',
+            keyHint: '',
+          },
+          {
+            id: 'query',
+            provider: 'openai-compatible',
+            model: 'llama-local',
+            baseUrl: 'http://localhost:1234/v1?token=abc',
+            keyHint: '',
+          },
+        ],
       })
       expect(parsed.aiProviders).toEqual([valid])
     })

--- a/packages/core/src/settings/schema.ts
+++ b/packages/core/src/settings/schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { isHttpBaseUrl, normalizeOpenAICompatibleBaseUrl } from '../ai/openai-compatible'
 
 /**
  * The user-settings schema — the policy half of the settings store. Rust
@@ -233,12 +234,30 @@ export const graphColorsSchema = z
   })
 
 /**
- * The cloud AI providers Reflect can call directly (BYOK — the user's own
- * keys, no Reflect-hosted proxy).
+ * The AI providers Reflect can call directly (BYOK — the user's own keys, no
+ * Reflect-hosted proxy). `openai-compatible` stores its user-supplied base URL
+ * per configured entry.
  */
-export const aiProviderIdSchema = z.enum(['openai', 'anthropic', 'google', 'openrouter'])
+export const aiProviderIdSchema = z.enum([
+  'openai',
+  'anthropic',
+  'google',
+  'openrouter',
+  'openai-compatible',
+])
 
 export type AiProviderId = z.infer<typeof aiProviderIdSchema>
+
+const hostedAiProviderIdSchema = z.enum(['openai', 'anthropic', 'google', 'openrouter'])
+
+export type HostedAiProviderId = z.infer<typeof hostedAiProviderIdSchema>
+
+export const openAiCompatibleBaseUrlSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .refine(isHttpBaseUrl)
+  .transform(normalizeOpenAICompatibleBaseUrl)
 
 /**
  * One configured AI provider: the provider, its default model id, and a key
@@ -247,13 +266,54 @@ export type AiProviderId = z.infer<typeof aiProviderIdSchema>
  * key's trailing characters so the settings UI can identify it. Which entry
  * is the app-wide default is a sibling scalar (`defaultAiProviderId`), not a
  * per-entry flag, so "at most one default" holds by construction.
+ * OpenAI-compatible entries additionally carry their API base URL, because it
+ * is user configuration rather than a fixed catalog endpoint.
  */
-export const aiProviderConfigSchema = z.object({
+const aiProviderConfigBaseSchema = z.object({
   id: z.string().min(1),
-  provider: aiProviderIdSchema,
   model: z.string().min(1),
   keyHint: z.string().catch(''),
 })
+
+const openAiProviderConfigSchema = aiProviderConfigBaseSchema.extend({
+  provider: z.literal('openai'),
+})
+
+const anthropicProviderConfigSchema = aiProviderConfigBaseSchema.extend({
+  provider: z.literal('anthropic'),
+})
+
+const googleProviderConfigSchema = aiProviderConfigBaseSchema.extend({
+  provider: z.literal('google'),
+})
+
+const openRouterProviderConfigSchema = aiProviderConfigBaseSchema.extend({
+  provider: z.literal('openrouter'),
+})
+
+const hostedAiProviderConfigSchema = z.union([
+  openAiProviderConfigSchema,
+  anthropicProviderConfigSchema,
+  googleProviderConfigSchema,
+  openRouterProviderConfigSchema,
+])
+
+export type HostedAiProviderConfig = z.infer<typeof hostedAiProviderConfigSchema>
+
+const openAiCompatibleProviderConfigSchema = aiProviderConfigBaseSchema.extend({
+  provider: z.literal('openai-compatible'),
+  baseUrl: openAiCompatibleBaseUrlSchema,
+})
+
+export type OpenAiCompatibleProviderConfig = z.infer<typeof openAiCompatibleProviderConfigSchema>
+
+export const aiProviderConfigSchema = z.discriminatedUnion('provider', [
+  openAiProviderConfigSchema,
+  anthropicProviderConfigSchema,
+  googleProviderConfigSchema,
+  openRouterProviderConfigSchema,
+  openAiCompatibleProviderConfigSchema,
+])
 
 export type AiProviderConfig = z.infer<typeof aiProviderConfigSchema>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,6 +247,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.75
         version: 3.0.75(zod@4.4.3)
+      '@ai-sdk/openai-compatible':
+        specifier: ^2.0.58
+        version: 2.0.58(zod@4.4.3)
       '@lezer/common':
         specifier: ^1.5.2
         version: 1.5.2
@@ -348,6 +351,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/openai-compatible@2.0.58':
+    resolution: {integrity: sha512-0SXA0xVt18F4ki7ttVshqaM0oLXSB475ACOU0/2RK3OZS3UYqrmKF+DJwYBYUZmqCq2nZ2vkNZEXpWP2wfGsrQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/openai@3.0.75':
     resolution: {integrity: sha512-xKW+ZSHOdsFIUR6H2uSVjQQmzuHG+onsBZQmsr1OagDK/G55Vhx7Msd/5itoIT/kfGIhOGtCY0DTxbP0RWT7hA==}
     engines: {node: '>=18'}
@@ -360,8 +369,18 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.37':
+    resolution: {integrity: sha512-VG4tpVXCuzm21U9xjg05BCMZnjZOazC72+MxBkLAa7hCKsnqNt542GYWUUqwmHSczJwgbSXN8UvaNgSerUaKdw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@3.0.11':
     resolution: {integrity: sha512-GKu3RxsfKGWjBiXmEdsKsGR9uVgJ56mzL1w7mLsn5k2TiNtpyS2IYQo3v1NJpK3oyv2OVavlK3g801VSe+gujg==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.13':
+    resolution: {integrity: sha512-ZPtVYt5QIJzOta1kdUiDuCx4HhFkvNPv/rvmZ2b1iXwybYjJsCnNYR4PAw4kW7rgVfDARvHXcU64efWuqNp6bw==}
     engines: {node: '>=18'}
 
   '@aklinker1/rollup-plugin-visualizer@5.12.0':
@@ -6084,6 +6103,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.31(zod@4.4.3)
       zod: 4.4.3
 
+  '@ai-sdk/openai-compatible@2.0.58(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.13
+      '@ai-sdk/provider-utils': 4.0.37(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/openai@3.0.75(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.11
@@ -6097,7 +6122,18 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
+  '@ai-sdk/provider-utils@4.0.37(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.13
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
   '@ai-sdk/provider@3.0.11':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.13':
     dependencies:
       json-schema: 0.4.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,3 +18,5 @@ minimumReleaseAgeExclude:
   - '@aria-ui/*'
   - prosemirror-flat-list
   - prosemirror-view
+  - '@ai-sdk/openai-compatible@2.0.58'
+  - '@ai-sdk/provider-utils@4.0.37'


### PR DESCRIPTION
## Problem

Reflect's AI settings only understood a fixed set of hosted providers. Users with OpenAI-compatible endpoints, such as LM Studio or a local Llama server, could type custom model ids for some providers but still had no way to configure the endpoint URL or run without an API key.

This PR intentionally keeps transcription provider selection scoped to the existing OpenAI/Gemini paths. OpenAI-compatible endpoints are added for chat, editor AI transforms, capture enrichment, asset descriptions, and audio memo title generation where the configured chat model can be used directly.

## Before -> After

| Area | Before | After |
| --- | --- | --- |
| Settings provider catalog | OpenAI, Anthropic, Gemini, OpenRouter only | Adds `OpenAI-compatible` with endpoint base URL and free-form model id |
| API keys | Every provider row required a non-empty key | OpenAI-compatible rows may be saved with no key; hosted providers still require one |
| Runtime model factory | Fixed AI SDK providers only | Uses `@ai-sdk/openai-compatible` for custom `baseUrl` + `model` |
| Transport permissions | Tauri/CSP allowed only known AI hosts | Allows user-configured http(s) provider endpoints, including localhost |

## Changes

1. Extends settings/provider data shape with an `openai-compatible` provider id and `baseUrl` on those rows, including schema validation and normalization for http(s) base URLs.
2. Adds `createOpenAICompatible` wiring in `languageModel`, with empty-key support only for rows saved without a key hint.
3. Updates desktop and mobile add-provider UI to show endpoint/model inputs for OpenAI-compatible providers and keep hosted providers on the curated model picker.
4. Routes chat/editor/background AI call sites through `aiApiKeyForConfig`, so no-key local endpoints can be used without weakening hosted-provider key handling.
5. Broadens the Tauri HTTP/CSP provider transport from fixed AI hosts to user-selected http(s) endpoints.
6. Adds targeted tests for schema parsing, validation probes, model construction, key resolution, settings UI, and chat test mocks.

## Verification

- `pnpm --filter @reflect/core exec vitest run src/ai/secrets.test.ts src/settings/schema.test.ts src/ai/validate-key.test.ts src/ai/language-model.test.ts src/ai/provider-catalog.test.ts src/ai/chat/model-options.test.ts` passed.
- `pnpm --filter @reflect/desktop exec vitest run src/components/settings/ai-providers-section.test.tsx src/mobile/add-ai-provider-drawer.test.tsx src/providers/chat-provider.test.tsx src/components/chat/chat-screen.test.tsx src/mobile/screens/chat.test.tsx` passed.
- `pnpm check` passed. It still emits the existing `packages/core/src/indexing/indexer.ts` max-lines warning.

## Risk / Rollout

No migration is required; existing provider rows parse unchanged. The main security tradeoff is intentional: arbitrary user-configured AI endpoints require broader http(s) access for the provider fetch path. Existing private-note gates, direct BYOK calls, and keychain-only credential storage remain in place.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broadening Tauri HTTP/CSP to arbitrary user http(s) endpoints increases outbound fetch surface; credential handling still uses keychain and existing private-note gates.
> 
> **Overview**
> Users can add **OpenAI-compatible** endpoints (e.g. LM Studio, local servers) with a configurable **base URL** and **free-form model id**, while hosted providers keep curated models and required keys.
> 
> **Core:** New `openai-compatible` provider in settings/schema (validated http(s) `baseUrl`), catalog flag `apiKeyRequired`, `@ai-sdk/openai-compatible` in `languageModel`, endpoint probes in `validateApiKey`, and **`aiApiKeyForConfig`** so no-key locals return `''` without weakening hosted key rules. Chat, editor transforms, capture/asset/audio title paths switch from raw `getSecret` to that helper.
> 
> **Desktop/mobile:** Add-provider flows gain endpoint + optional key UI; lists show base URL / “No API key”; model pickers disambiguate compatible entries by URL. **Tauri** HTTP allowlist and **CSP `connect-src`** widen from fixed AI hosts to general http(s) for user-chosen endpoints.
> 
> Transcription provider picking is unchanged (still OpenAI/Gemini only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65e62d13113746ba6cc7522d72aa51684d6583da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->