### PR TITLE
Add task breadcrumbs

### DIFF
--- a/apps/desktop/src-tauri/src/db/tests.rs
+++ b/apps/desktop/src-tauri/src/db/tests.rs
@@ -2,6 +2,7 @@
 //! together against a migrated in-memory database, the same shape the commands
 //! compose at runtime.
 
+use reflect_index_schema::LATEST_SCHEMA_VERSION;
 use rusqlite::Connection;
 use serde_json::Value;
 
@@ -68,6 +69,7 @@ fn task(marker_offset: i64, text: &str, checked: bool) -> IndexedTask {
         marker_offset,
         text: text.to_string(),
         raw: format!("[{}] {text}", if checked { "x" } else { " " }),
+        breadcrumbs: vec![],
         checked,
         due_date: None,
     }
@@ -81,7 +83,7 @@ fn migrations_are_valid_and_idempotent() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 16); // applied migrations (0001 through 0016)
+    assert_eq!(version, LATEST_SCHEMA_VERSION as i64);
     migrate(&mut conn).expect("re-running to_latest is a no-op");
 }
 
@@ -594,13 +596,14 @@ fn apply_note_inserts_tasks_and_replace_clears_them() {
 
     let rows = run_query(
         &conn,
-        "SELECT marker_offset, text, checked, due_date FROM tasks WHERE note_path = 'notes/a.md' ORDER BY marker_offset",
+        "SELECT marker_offset, text, breadcrumbs, checked, due_date FROM tasks WHERE note_path = 'notes/a.md' ORDER BY marker_offset",
         &[],
     )
     .unwrap();
     assert_eq!(rows.len(), 2);
     assert_eq!(rows[0]["marker_offset"], Value::from(4));
     assert_eq!(rows[0]["text"], Value::from("buy milk"));
+    assert_eq!(rows[0]["breadcrumbs"], Value::from("[]"));
     assert_eq!(rows[0]["checked"], Value::from(0));
     assert_eq!(rows[0]["due_date"], Value::from("2026-07-01"));
     assert_eq!(rows[1]["checked"], Value::from(1));
@@ -610,6 +613,27 @@ fn apply_note_inserts_tasks_and_replace_clears_them() {
     apply_note(&conn, &note("notes/a.md", "A", vec![])).unwrap();
     let after = run_query(&conn, "SELECT count(*) AS n FROM tasks", &[]).unwrap();
     assert_eq!(after[0]["n"], Value::from(0));
+}
+
+#[test]
+fn apply_note_serializes_task_breadcrumbs() {
+    let conn = migrated();
+    let mut seeded = note("notes/a.md", "A", vec![]);
+    let mut with_context = task(4, "ship it", false);
+    with_context.breadcrumbs = vec!["Project".to_string(), "Phase one".to_string()];
+    seeded.tasks = vec![with_context];
+    apply_note(&conn, &seeded).unwrap();
+
+    let rows = run_query(
+        &conn,
+        "SELECT breadcrumbs FROM tasks WHERE note_path = 'notes/a.md'",
+        &[],
+    )
+    .unwrap();
+    assert_eq!(
+        rows[0]["breadcrumbs"],
+        Value::from("[\"Project\",\"Phase one\"]")
+    );
 }
 
 #[test]
@@ -801,7 +825,7 @@ fn open_index_at_creates_migrates_and_reopens() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 16);
+    assert_eq!(version, LATEST_SCHEMA_VERSION as i64);
     let journal: String = conn
         .query_row("PRAGMA journal_mode", [], |row| row.get(0))
         .unwrap();

--- a/apps/desktop/src-tauri/src/db/write.rs
+++ b/apps/desktop/src-tauri/src/db/write.rs
@@ -89,6 +89,9 @@ pub(super) struct IndexedEmail {
 pub(super) struct IndexedTask {
     pub(super) marker_offset: i64,
     pub(super) text: String,
+    /// Parent outline/list item text, top-down, displayed in the Tasks view.
+    #[serde(default)]
+    pub(super) breadcrumbs: Vec<String>,
     pub(super) raw: String,
     pub(super) checked: bool,
     /// Explicit due date (first `[[YYYY-MM-DD]]` in the item), or None.
@@ -178,13 +181,17 @@ pub(super) fn apply_note(conn: &Connection, note: &IndexedNote) -> AppResult<()>
     }
     {
         let mut stmt = conn.prepare_cached(
-            "INSERT INTO tasks(note_path, marker_offset, text, raw, checked, due_date) VALUES(?1, ?2, ?3, ?4, ?5, ?6)",
+            "INSERT INTO tasks(note_path, marker_offset, text, breadcrumbs, raw, checked, due_date) VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7)",
         )?;
         for task in &note.tasks {
+            let breadcrumbs = serde_json::to_string(&task.breadcrumbs).map_err(|err| {
+                crate::error::AppError::io(format!("serialize task breadcrumbs: {err}"))
+            })?;
             stmt.execute(params![
                 note.path,
                 task.marker_offset,
                 task.text,
+                breadcrumbs,
                 task.raw,
                 i64::from(task.checked),
                 task.due_date

--- a/apps/desktop/src/components/tasks/task-breadcrumbs.tsx
+++ b/apps/desktop/src/components/tasks/task-breadcrumbs.tsx
@@ -1,0 +1,27 @@
+import type { ReactElement } from 'react'
+import { ChevronRight } from 'lucide-react'
+import { visibleTaskBreadcrumbs } from '@/lib/tasks/task-breadcrumbs'
+
+interface TaskBreadcrumbsProps {
+  breadcrumbs: readonly string[]
+}
+
+export function TaskBreadcrumbs({ breadcrumbs }: TaskBreadcrumbsProps): ReactElement | null {
+  const visible = visibleTaskBreadcrumbs(breadcrumbs)
+  if (visible.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="mb-1 flex min-w-0 items-center gap-1 text-xs leading-5 text-text-muted/80">
+      {visible.map((part, index) => (
+        <span key={`${part}-${index}`} className="flex min-w-0 items-center gap-1">
+          {index > 0 ? (
+            <ChevronRight aria-hidden className="size-3 shrink-0 text-text-muted/55" />
+          ) : null}
+          <span className="truncate">{part}</span>
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/apps/desktop/src/components/tasks/task-breadcrumbs.tsx
+++ b/apps/desktop/src/components/tasks/task-breadcrumbs.tsx
@@ -1,19 +1,29 @@
 import type { ReactElement } from 'react'
 import { ChevronRight } from 'lucide-react'
 import { visibleTaskBreadcrumbs } from '@/lib/tasks/task-breadcrumbs'
+import { cn } from '@/lib/utils'
 
 interface TaskBreadcrumbsProps {
   breadcrumbs: readonly string[]
+  className?: string
 }
 
-export function TaskBreadcrumbs({ breadcrumbs }: TaskBreadcrumbsProps): ReactElement | null {
+export function TaskBreadcrumbs({
+  breadcrumbs,
+  className,
+}: TaskBreadcrumbsProps): ReactElement | null {
   const visible = visibleTaskBreadcrumbs(breadcrumbs)
   if (visible.length === 0) {
     return null
   }
 
   return (
-    <div className="mb-1 flex min-w-0 items-center gap-1 text-xs leading-5 text-text-muted/80">
+    <div
+      className={cn(
+        'mb-1 flex min-w-0 items-center gap-1 text-xs leading-5 text-text-muted/80',
+        className,
+      )}
+    >
       {visible.map((part, index) => (
         <span key={`${part}-${index}`} className="flex min-w-0 items-center gap-1">
           {index > 0 ? (

--- a/apps/desktop/src/components/tasks/task-row.tsx
+++ b/apps/desktop/src/components/tasks/task-row.tsx
@@ -8,6 +8,7 @@ import {
 import { ArrowRight, Circle, CircleCheck } from 'lucide-react'
 import type { OpenTask } from '@reflect/core'
 import { formatDayLabel } from '@/lib/dates'
+import { visibleTaskBreadcrumbs } from '@/lib/tasks/task-breadcrumbs'
 import { taskKey } from '@/lib/tasks/task-identity'
 import { useTaskCheckboxToggle } from '@/lib/tasks/use-task-checkbox-toggle'
 import { cn } from '@/lib/utils'
@@ -95,6 +96,7 @@ export function TaskRow({
   const checkboxPending = isPending || taskActionPending
   const done = task.checked
   const label = task.text || 'Empty task'
+  const breadcrumbs = visibleTaskBreadcrumbs(task.breadcrumbs)
   const selectFromKeyboard = (event: KeyboardEvent<HTMLDivElement>): void => {
     if (event.key !== 'Enter' && event.key !== ' ') {
       return
@@ -114,98 +116,117 @@ export function TaskRow({
     onSelect(event)
   }
 
+  const checkboxButton = (
+    <button
+      type="button"
+      data-task-row
+      aria-label={task.checked ? `Reopen: ${label}` : `Complete: ${label}`}
+      disabled={checkboxPending}
+      onClick={(event) => {
+        event.stopPropagation()
+        if (editing) {
+          checkboxToggleControllerRef.current?.()
+          return
+        }
+        if (togglesSelection) {
+          onSelectionCheckboxToggle()
+          return
+        }
+        toggle()
+      }}
+      // h-6 matches the text/editor's leading-6 line so the circle centers on
+      // the first line (items-start keeps it there when a task wraps).
+      className="flex h-6 shrink-0 items-center text-text-muted transition-colors hover:text-text focus-visible:text-text focus-visible:outline-none disabled:cursor-default"
+    >
+      {done ? (
+        <CircleCheck aria-hidden className="size-[18px] text-accent" strokeWidth={2} />
+      ) : (
+        <Circle aria-hidden className="size-[18px]" strokeWidth={2} />
+      )}
+    </button>
+  )
+  const sourceDate =
+    showSource && task.dailyDate !== null ? (
+      <span className="mt-0.5 shrink-0 whitespace-nowrap text-xs text-text-muted">
+        {formatDayLabel(task.dailyDate, settings.dateFormat)}
+      </span>
+    ) : null
+  const openButton = (
+    <button
+      type="button"
+      aria-label={`Open ${task.noteTitle}`}
+      // Hidden while editing: keep focus on the editor (Esc first to leave).
+      disabled={editing}
+      onClick={(event) => {
+        event.stopPropagation()
+        onOpen(task.notePath)
+      }}
+      className={cn(
+        'mt-0.5 shrink-0 text-text-muted/60 opacity-0 transition-opacity hover:text-text focus-visible:opacity-100 focus-visible:outline-none',
+        !editing && 'group-hover/task:opacity-100',
+      )}
+    >
+      <ArrowRight aria-hidden className="size-3.5" />
+    </button>
+  )
+
   return (
     <li
       data-task-key={taskKey(task)}
       onClick={selectFromRow}
       className={cn(
-        'group/task flex min-h-10 items-start gap-3 border-b border-border bg-surface px-4 py-2 transition-colors duration-100 lg:px-12',
+        'group/task min-h-10 border-b border-border bg-surface px-4 py-2 transition-colors duration-100 lg:px-12',
+        editing && 'flex items-start gap-3',
         !editing && 'cursor-pointer',
         selected
           ? 'bg-accent-soft ring-1 ring-inset ring-accent/20 dark:ring-accent/10'
           : 'hover:bg-surface-hover dark:bg-surface dark:hover:bg-surface-hover',
       )}
     >
-      <button
-        type="button"
-        data-task-row
-        aria-label={task.checked ? `Reopen: ${label}` : `Complete: ${label}`}
-        disabled={checkboxPending}
-        onClick={(event) => {
-          event.stopPropagation()
-          if (editing) {
-            checkboxToggleControllerRef.current?.()
-            return
-          }
-          if (togglesSelection) {
-            onSelectionCheckboxToggle()
-            return
-          }
-          toggle()
-        }}
-        // h-6 matches the text/editor's leading-6 line so the circle centers on
-        // the first line (items-start keeps it there when a task wraps).
-        className="flex h-6 shrink-0 items-center text-text-muted transition-colors hover:text-text focus-visible:text-text focus-visible:outline-none disabled:cursor-default"
-      >
-        {done ? (
-          <CircleCheck aria-hidden className="size-[18px] text-accent" strokeWidth={2} />
-        ) : (
-          <Circle aria-hidden className="size-[18px]" strokeWidth={2} />
-        )}
-      </button>
       {editing ? (
-        <TaskEditor
-          task={task}
-          onCommit={onEditCommit}
-          onContinue={onEditContinue}
-          onDelete={onEditDelete}
-          onDeleteEmpty={onEditDeleteEmpty}
-          onCancel={onEditCancel}
-          onComplete={onEditComplete}
-          onCheckboxToggle={onEditCheckboxToggle}
-          onConvertToBullet={onEditConvertToBullet}
-          onFlush={onEditFlush}
-          onNavigate={onEditNavigate}
-          checkboxToggleControllerRef={checkboxToggleControllerRef}
-          convertControllerRef={convertControllerRef}
-        />
+        <>
+          {checkboxButton}
+          <TaskEditor
+            task={task}
+            onCommit={onEditCommit}
+            onContinue={onEditContinue}
+            onDelete={onEditDelete}
+            onDeleteEmpty={onEditDeleteEmpty}
+            onCancel={onEditCancel}
+            onComplete={onEditComplete}
+            onCheckboxToggle={onEditCheckboxToggle}
+            onConvertToBullet={onEditConvertToBullet}
+            onFlush={onEditFlush}
+            onNavigate={onEditNavigate}
+            checkboxToggleControllerRef={checkboxToggleControllerRef}
+            convertControllerRef={convertControllerRef}
+          />
+          {sourceDate}
+          {openButton}
+        </>
       ) : (
-        <div
-          role="button"
-          tabIndex={0}
-          aria-pressed={selected}
-          onKeyDown={selectFromKeyboard}
-          className={cn(
-            'min-w-0 flex-1 break-words text-left text-sm leading-6 text-text focus-visible:outline-none',
-          )}
-        >
-          <TaskBreadcrumbs breadcrumbs={task.breadcrumbs} />
-          <div className={cn(task.checked && 'text-text-muted line-through')}>
-            <TaskText task={task} />
+        <div className="min-w-0 flex-1">
+          <TaskBreadcrumbs breadcrumbs={breadcrumbs} />
+          <div className="flex min-w-0 items-start gap-3">
+            {checkboxButton}
+            <div
+              role="button"
+              tabIndex={0}
+              aria-pressed={selected}
+              onKeyDown={selectFromKeyboard}
+              className={cn(
+                'min-w-0 flex-1 break-words text-left text-sm leading-6 text-text focus-visible:outline-none',
+              )}
+            >
+              <div className={cn(task.checked && 'text-text-muted line-through')}>
+                <TaskText task={task} />
+              </div>
+            </div>
+            {sourceDate}
+            {openButton}
           </div>
         </div>
       )}
-      {showSource && task.dailyDate !== null ? (
-        <span className="mt-0.5 shrink-0 whitespace-nowrap text-xs text-text-muted">
-          {formatDayLabel(task.dailyDate, settings.dateFormat)}
-        </span>
-      ) : null}
-      <button
-        type="button"
-        aria-label={`Open ${task.noteTitle}`}
-        // Hidden while editing: keep focus on the editor (Esc first to leave).
-        disabled={editing}
-        onClick={(event) => {
-          event.stopPropagation()
-          onOpen(task.notePath)
-        }}
-        className={cn(
-          'mt-0.5 shrink-0 text-text-muted/60 opacity-0 transition-opacity hover:text-text focus-visible:opacity-100 focus-visible:outline-none',
-          !editing && 'group-hover/task:opacity-100',
-        )}
-      >
-        <ArrowRight aria-hidden className="size-3.5" />
-      </button>
     </li>
   )
 }

--- a/apps/desktop/src/components/tasks/task-row.tsx
+++ b/apps/desktop/src/components/tasks/task-row.tsx
@@ -12,6 +12,7 @@ import { taskKey } from '@/lib/tasks/task-identity'
 import { useTaskCheckboxToggle } from '@/lib/tasks/use-task-checkbox-toggle'
 import { cn } from '@/lib/utils'
 import { useSettings } from '@/providers/settings-provider'
+import { TaskBreadcrumbs } from './task-breadcrumbs'
 import { TaskEditor, type TaskNavigate } from './task-editor'
 import { TaskText } from './task-text'
 
@@ -176,10 +177,12 @@ export function TaskRow({
           onKeyDown={selectFromKeyboard}
           className={cn(
             'min-w-0 flex-1 break-words text-left text-sm leading-6 text-text focus-visible:outline-none',
-            task.checked && 'text-text-muted line-through',
           )}
         >
-          <TaskText task={task} />
+          <TaskBreadcrumbs breadcrumbs={task.breadcrumbs} />
+          <div className={cn(task.checked && 'text-text-muted line-through')}>
+            <TaskText task={task} />
+          </div>
         </div>
       )}
       {showSource && task.dailyDate !== null ? (

--- a/apps/desktop/src/components/tasks/tasks-screen.test.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.test.tsx
@@ -188,6 +188,7 @@ function task(overrides: Partial<OpenTask> = {}): OpenTask {
     raw: `[ ] ${text}`,
     checked: false,
     text,
+    breadcrumbs: [],
     noteTitle: 'N',
     dueDate: null,
     dailyDate: null,

--- a/apps/desktop/src/dev/dev-index-db.test.ts
+++ b/apps/desktop/src/dev/dev-index-db.test.ts
@@ -35,7 +35,16 @@ function sampleNote(overrides: Partial<IndexedNote> = {}): IndexedNote {
     aliases: [],
     emails: [{ email: 'Sample@Example.com', emailKey: 'sample@example.com' }],
     assets: [],
-    tasks: [{ markerOffset: 40, text: 'Do the thing', raw: '- [ ] Do the thing', checked: false, dueDate: null }],
+    tasks: [
+      {
+        markerOffset: 40,
+        text: 'Do the thing',
+        breadcrumbs: ['Project'],
+        raw: '- [ ] Do the thing',
+        checked: false,
+        dueDate: null,
+      },
+    ],
     ...overrides,
   }
 }
@@ -64,8 +73,8 @@ describe('createDevIndexDb', () => {
     const tags = db.query('SELECT tag FROM tags WHERE note_path = ?', ['notes/sample.md'])
     expect(tags).toEqual([{ tag: 'book' }])
 
-    const tasks = db.query('SELECT text, checked FROM tasks', [])
-    expect(tasks).toEqual([{ text: 'Do the thing', checked: 0 }])
+    const tasks = db.query('SELECT text, breadcrumbs, checked FROM tasks', [])
+    expect(tasks).toEqual([{ text: 'Do the thing', breadcrumbs: '["Project"]', checked: 0 }])
 
     const emails = db.query('SELECT email, email_key FROM note_emails', [])
     expect(emails).toEqual([

--- a/apps/desktop/src/dev/dev-index-db.ts
+++ b/apps/desktop/src/dev/dev-index-db.ts
@@ -168,8 +168,16 @@ export async function createDevIndexDb(): Promise<DevIndexDb> {
       for (const task of note.tasks) {
         run(
           db,
-          'INSERT INTO tasks(note_path, marker_offset, text, raw, checked, due_date) VALUES(?, ?, ?, ?, ?, ?)',
-          [note.path, task.markerOffset, task.text, task.raw, task.checked, task.dueDate],
+          'INSERT INTO tasks(note_path, marker_offset, text, breadcrumbs, raw, checked, due_date) VALUES(?, ?, ?, ?, ?, ?, ?)',
+          [
+            note.path,
+            task.markerOffset,
+            task.text,
+            JSON.stringify(task.breadcrumbs),
+            task.raw,
+            task.checked,
+            task.dueDate,
+          ],
         )
       }
       const searchBody = note.assetText === '' ? note.text : `${note.text}\n${note.assetText}`

--- a/apps/desktop/src/lib/tasks/recently-completed.test.ts
+++ b/apps/desktop/src/lib/tasks/recently-completed.test.ts
@@ -18,6 +18,7 @@ function task(over: Partial<OpenTask> = {}): OpenTask {
     raw: '[ ] do it',
     checked: false,
     text: 'do it',
+    breadcrumbs: [],
     noteTitle: 'N',
     dueDate: null,
     dailyDate: null,

--- a/apps/desktop/src/lib/tasks/task-breadcrumbs.test.ts
+++ b/apps/desktop/src/lib/tasks/task-breadcrumbs.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { visibleTaskBreadcrumbs } from './task-breadcrumbs'
+
+describe('visibleTaskBreadcrumbs', () => {
+  it('trims empty breadcrumb entries', () => {
+    expect(visibleTaskBreadcrumbs(['', ' Project ', '  '])).toEqual(['Project'])
+  })
+
+  it('hides common single task headings', () => {
+    expect(visibleTaskBreadcrumbs(['Tasks'])).toEqual([])
+    expect(visibleTaskBreadcrumbs(['to-do'])).toEqual([])
+  })
+
+  it('keeps multi-part breadcrumbs even when one part is common', () => {
+    expect(visibleTaskBreadcrumbs(['Tasks', 'Project'])).toEqual(['Tasks', 'Project'])
+  })
+})

--- a/apps/desktop/src/lib/tasks/task-breadcrumbs.ts
+++ b/apps/desktop/src/lib/tasks/task-breadcrumbs.ts
@@ -1,0 +1,13 @@
+const PUNCTUATION_RE = /[\p{P}\p{S}]/gu
+
+function normalizedBreadcrumb(text: string): string {
+  return text.replace(/\s+/g, '').replace(PUNCTUATION_RE, '')
+}
+
+export function visibleTaskBreadcrumbs(breadcrumbs: readonly string[]): string[] {
+  const visible = breadcrumbs.map((text) => text.trim()).filter((text) => text.length > 0)
+  if (visible.length !== 1) {
+    return visible
+  }
+  return /^(?:task|todo)s?$/i.test(normalizedBreadcrumb(visible[0]!)) ? [] : visible
+}

--- a/apps/desktop/src/lib/tasks/task-cache.test.ts
+++ b/apps/desktop/src/lib/tasks/task-cache.test.ts
@@ -17,6 +17,7 @@ function task(overrides: Partial<OpenTask> = {}): OpenTask {
     raw: `[ ] ${text}`,
     checked: false,
     text,
+    breadcrumbs: [],
     noteTitle: 'N',
     dueDate: null,
     dailyDate: null,

--- a/apps/desktop/src/lib/tasks/task-insert-target.ts
+++ b/apps/desktop/src/lib/tasks/task-insert-target.ts
@@ -20,6 +20,7 @@ export function insertedTaskRow(target: InsertTaskTarget, markerOffset: number):
     raw: '[ ] ',
     checked: false,
     text: '',
+    breadcrumbs: [],
     noteTitle: target.noteTitle,
     dueDate: null,
     dailyDate: target.dailyDate,

--- a/apps/desktop/src/lib/tasks/task-navigation.test.ts
+++ b/apps/desktop/src/lib/tasks/task-navigation.test.ts
@@ -10,6 +10,7 @@ function task(over: Partial<OpenTask> = {}): OpenTask {
     raw: '[ ] x',
     checked: false,
     text: 'x',
+    breadcrumbs: [],
     noteTitle: 'N',
     dueDate: null,
     dailyDate: null,

--- a/apps/desktop/src/lib/tasks/task-visibility.test.ts
+++ b/apps/desktop/src/lib/tasks/task-visibility.test.ts
@@ -22,6 +22,7 @@ function task(overrides: Partial<OpenTask> = {}): OpenTask {
     raw: `[ ] ${text}`,
     checked: false,
     text,
+    breadcrumbs: [],
     noteTitle: 'N',
     dueDate: null,
     dailyDate: null,
@@ -123,6 +124,22 @@ describe('composeVisibleTaskGroups', () => {
     })
     const rows = groups.flatMap((group) => group.tasks)
     expect(rows.map((row) => row.text)).toEqual(['buy milk'])
+  })
+
+  it('filters by breadcrumb context', () => {
+    const groups = composeVisibleTaskGroups({
+      open: [
+        task({ text: 'ship', markerOffset: 0, breadcrumbs: ['StartupToolbox', 'Reflections'] }),
+        task({ text: 'buy milk', markerOffset: 10, breadcrumbs: ['Personal'] }),
+      ],
+      completed: undefined,
+      recentlyCompleted: [],
+      filters: ALL_ON,
+      needle: 'startup',
+      today: TODAY,
+    })
+    const rows = groups.flatMap((group) => group.tasks)
+    expect(rows.map((row) => row.text)).toEqual(['ship'])
   })
 })
 

--- a/apps/desktop/src/lib/tasks/task-visibility.ts
+++ b/apps/desktop/src/lib/tasks/task-visibility.ts
@@ -32,6 +32,13 @@ export interface TaskListSources {
   readonly today: string
 }
 
+function taskMatchesNeedle(task: OpenTask, needle: string): boolean {
+  return (
+    task.text.toLowerCase().includes(needle) ||
+    task.breadcrumbs.some((breadcrumb) => breadcrumb.toLowerCase().includes(needle))
+  )
+}
+
 /**
  * The Tasks list every surface renders (Plan 18): open rows merged with the
  * struck "completed" rows, searched, grouped ({@link groupTasks}) and narrowed to
@@ -71,6 +78,6 @@ export function composeVisibleTaskGroups({
     : recentlyCompleted
   const completedKeys = new Set(completedRows.map(taskKey))
   const all = [...open.filter((task) => !completedKeys.has(taskKey(task))), ...completedRows]
-  const matched = needle ? all.filter((task) => task.text.toLowerCase().includes(needle)) : all
+  const matched = needle ? all.filter((task) => taskMatchesNeedle(task, needle)) : all
   return visibleGroups(groupTasks(matched, today), filters)
 }

--- a/apps/desktop/src/lib/tasks/use-task-keyboard.test.ts
+++ b/apps/desktop/src/lib/tasks/use-task-keyboard.test.ts
@@ -13,6 +13,7 @@ function task(over: Partial<OpenTask> = {}): OpenTask {
     raw: '[ ] do it',
     checked: false,
     text: 'do it',
+    breadcrumbs: [],
     noteTitle: 'N',
     dueDate: null,
     dailyDate: null,

--- a/apps/desktop/src/mobile/screens/tasks.test.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.test.tsx
@@ -182,6 +182,7 @@ function task(overrides: Partial<OpenTask> = {}): OpenTask {
     raw: `[ ] ${text}`,
     checked: false,
     text,
+    breadcrumbs: [],
     noteTitle: 'N',
     dueDate: null,
     dailyDate: null,

--- a/apps/desktop/src/mobile/task-row.tsx
+++ b/apps/desktop/src/mobile/task-row.tsx
@@ -4,6 +4,7 @@ import type { OpenTask } from '@reflect/core'
 import { TaskBreadcrumbs } from '@/components/tasks/task-breadcrumbs'
 import { TaskText } from '@/components/tasks/task-text'
 import { formatShortDate } from '@/lib/dates'
+import { visibleTaskBreadcrumbs } from '@/lib/tasks/task-breadcrumbs'
 import { taskKey } from '@/lib/tasks/task-identity'
 import { useTaskCheckboxToggle } from '@/lib/tasks/use-task-checkbox-toggle'
 import { cn } from '@/lib/utils'
@@ -32,12 +33,20 @@ export function MobileTaskRow({ task, showSource, onEdit }: MobileTaskRowProps):
   const { toggle, isPending } = useTaskCheckboxToggle(task)
   const label = task.text || 'Empty task'
   const edit = (): void => onEdit(task)
+  const breadcrumbs = visibleTaskBreadcrumbs(task.breadcrumbs)
+  const hasBreadcrumbs = breadcrumbs.length > 0
 
   return (
     <li
       data-task-key={taskKey(task)}
-      className="flex min-h-12 items-start border-b border-border bg-surface"
+      className="grid min-h-12 grid-cols-[auto,minmax(0,1fr)] border-b border-border bg-surface"
     >
+      {hasBreadcrumbs ? (
+        <TaskBreadcrumbs
+          breadcrumbs={breadcrumbs}
+          className="col-start-2 mb-0 min-w-0 pr-4 pt-3"
+        />
+      ) : null}
       <button
         type="button"
         aria-label={task.checked ? `Reopen: ${label}` : `Complete: ${label}`}
@@ -48,7 +57,12 @@ export function MobileTaskRow({ task, showSource, onEdit }: MobileTaskRowProps):
         }}
         // A generous touch target around the small glyph; self-stretch keeps
         // the circle vertically centered in the row as task text wraps.
-        className="flex shrink-0 self-stretch items-center pl-4 pr-3 text-text-muted disabled:opacity-50"
+        className={cn(
+          'col-start-1 flex shrink-0 pl-4 pr-3 text-text-muted disabled:opacity-50',
+          hasBreadcrumbs
+            ? 'row-start-2 items-start pb-3 pt-0.5'
+            : 'row-start-1 self-stretch items-center',
+        )}
       >
         {task.checked ? (
           <CircleCheck aria-hidden className="size-5 text-accent" strokeWidth={2} />
@@ -71,10 +85,12 @@ export function MobileTaskRow({ task, showSource, onEdit }: MobileTaskRowProps):
             edit()
           }
         }}
-        className="flex min-w-0 flex-1 cursor-pointer items-start gap-3 py-3 pr-4 text-left focus-visible:outline-none"
+        className={cn(
+          'col-start-2 flex min-w-0 cursor-pointer items-start gap-3 pr-4 text-left focus-visible:outline-none',
+          hasBreadcrumbs ? 'row-start-2 pb-3' : 'row-start-1 py-3',
+        )}
       >
         <div className="min-w-0 flex-1 break-words text-sm leading-6 text-text">
-          <TaskBreadcrumbs breadcrumbs={task.breadcrumbs} />
           <div className={cn(task.checked && 'text-text-muted line-through')}>
             <TaskText task={task} />
           </div>

--- a/apps/desktop/src/mobile/task-row.tsx
+++ b/apps/desktop/src/mobile/task-row.tsx
@@ -1,6 +1,7 @@
 import { type ReactElement } from 'react'
 import { Circle, CircleCheck } from 'lucide-react'
 import type { OpenTask } from '@reflect/core'
+import { TaskBreadcrumbs } from '@/components/tasks/task-breadcrumbs'
 import { TaskText } from '@/components/tasks/task-text'
 import { formatShortDate } from '@/lib/dates'
 import { taskKey } from '@/lib/tasks/task-identity'
@@ -72,14 +73,12 @@ export function MobileTaskRow({ task, showSource, onEdit }: MobileTaskRowProps):
         }}
         className="flex min-w-0 flex-1 cursor-pointer items-start gap-3 py-3 pr-4 text-left focus-visible:outline-none"
       >
-        <span
-          className={cn(
-            'min-w-0 flex-1 break-words text-sm leading-6 text-text',
-            task.checked && 'text-text-muted line-through',
-          )}
-        >
-          <TaskText task={task} />
-        </span>
+        <div className="min-w-0 flex-1 break-words text-sm leading-6 text-text">
+          <TaskBreadcrumbs breadcrumbs={task.breadcrumbs} />
+          <div className={cn(task.checked && 'text-text-muted line-through')}>
+            <TaskText task={task} />
+          </div>
+        </div>
         {showSource && task.dailyDate !== null ? (
           // The compact date, not desktop's long day label — a phone row can't
           // spare "Mon, June 1st, 2026" (V1 mobile's small gray source label).

--- a/apps/desktop/src/mobile/use-task-sheet-finalizer.test.ts
+++ b/apps/desktop/src/mobile/use-task-sheet-finalizer.test.ts
@@ -21,6 +21,7 @@ function task(overrides: Partial<OpenTask> = {}): OpenTask {
     raw: `[ ] ${text}`,
     checked: false,
     text,
+    breadcrumbs: [],
     noteTitle: 'N',
     dueDate: null,
     dailyDate: null,

--- a/crates/index-schema/migrations/0017_task_breadcrumbs.sql
+++ b/crates/index-schema/migrations/0017_task_breadcrumbs.sql
@@ -1,0 +1,4 @@
+-- Parent outline/list item text for a task, encoded as a JSON string array.
+-- Rebuildable projection data: the TS projection version bump reindexes notes
+-- so existing rows get their real breadcrumbs instead of this empty default.
+ALTER TABLE tasks ADD COLUMN breadcrumbs TEXT NOT NULL DEFAULT '[]';

--- a/crates/index-schema/src/lib.rs
+++ b/crates/index-schema/src/lib.rs
@@ -23,7 +23,7 @@ pub const INDEX_FILE: &str = "index.sqlite";
 /// `user_version` after every migration has run. Read-only consumers compare
 /// this against `PRAGMA user_version` to detect an index written by a newer
 /// (or older) app than they were built for.
-pub const LATEST_SCHEMA_VERSION: usize = 16;
+pub const LATEST_SCHEMA_VERSION: usize = 17;
 
 /// The `index_meta` key holding the TS-owned projection version (the rows'
 /// derivation version, distinct from the schema version above).
@@ -59,6 +59,7 @@ mod schema {
             M::up(include_str!("../migrations/0014_note_kind.sql")),
             M::up(include_str!("../migrations/0015_note_kind_invariant.sql")),
             M::up(include_str!("../migrations/0016_note_emails.sql")),
+            M::up(include_str!("../migrations/0017_task_breadcrumbs.sql")),
         ])
     });
 

--- a/packages/core/src/indexing/group-tasks.test.ts
+++ b/packages/core/src/indexing/group-tasks.test.ts
@@ -14,6 +14,7 @@ function task(overrides: Partial<OpenTask> = {}): OpenTask {
     raw: '[ ] do it',
     checked: false,
     text: 'do it',
+    breadcrumbs: [],
     noteTitle: 'N',
     dueDate: null,
     dailyDate: null,

--- a/packages/core/src/indexing/indexed-note.test.ts
+++ b/packages/core/src/indexing/indexed-note.test.ts
@@ -3,8 +3,8 @@ import { gistBodyHash, parseNote } from '../markdown'
 import { buildIndexedNote, indexedNoteSchema, PROJECTION_VERSION } from './indexed-note'
 
 describe('buildIndexedNote', () => {
-  it('carries the projection version that backfills the derived subject-alias rows', () => {
-    expect(PROJECTION_VERSION).toBe(14)
+  it('carries the projection version that backfills task breadcrumbs', () => {
+    expect(PROJECTION_VERSION).toBe(15)
   })
 
   it('flattens a parsed note into the index payload', () => {
@@ -219,8 +219,22 @@ describe('buildIndexedNote', () => {
       source,
     })
     expect(indexed.tasks).toEqual([
-      { markerOffset: source.indexOf('[ ]'), text: 'buy milk', raw: '[ ] buy milk', checked: false, dueDate: null },
-      { markerOffset: source.indexOf('[x] call'), text: 'call mum', raw: '[x] call mum', checked: true, dueDate: null },
+      {
+        markerOffset: source.indexOf('[ ]'),
+        text: 'buy milk',
+        breadcrumbs: [],
+        raw: '[ ] buy milk',
+        checked: false,
+        dueDate: null,
+      },
+      {
+        markerOffset: source.indexOf('[x] call'),
+        text: 'call mum',
+        breadcrumbs: [],
+        raw: '[x] call mum',
+        checked: true,
+        dueDate: null,
+      },
     ])
   })
 

--- a/packages/core/src/indexing/indexed-note.ts
+++ b/packages/core/src/indexing/indexed-note.ts
@@ -63,8 +63,10 @@ import { previewSnippet } from './snippet'
  * 14 — v1 subject aliases (`//` segments of the title) folded into the
  * `aliases` projection: existing v1-style titles carry no derived alias rows
  * until reprojected, so the bump backfills them.
+ * 15 — task parent outline/list breadcrumbs: existing task rows carry empty
+ * breadcrumbs until reprojected.
  */
-export const PROJECTION_VERSION = 14
+export const PROJECTION_VERSION = 15
 
 export const indexedLinkSchema = z.object({
   kind: z.enum(['wiki', 'md']),
@@ -104,6 +106,8 @@ export const indexedTaskSchema = z.object({
   markerOffset: z.number(),
   /** Display/search text of the task's marker line, markdown stripped. */
   text: z.string(),
+  /** Parent outline/list item text, top-down, displayed in the Tasks view. */
+  breadcrumbs: z.array(z.string()),
   /** The marker line verbatim — the surgical write-back's staleness guard. */
   raw: z.string(),
   checked: z.boolean(),
@@ -237,6 +241,7 @@ export function buildIndexedNote(
     tasks: parsed.tasks.map((task) => ({
       markerOffset: task.markerOffset,
       text: task.text,
+      breadcrumbs: task.breadcrumbs,
       raw: task.raw,
       checked: task.checked,
       dueDate: task.dueDate,

--- a/packages/core/src/indexing/queries-tasks.ts
+++ b/packages/core/src/indexing/queries-tasks.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod'
 import type { TaskMarker } from '../markdown'
 import { db } from './db'
 
@@ -11,6 +12,8 @@ export interface OpenTask extends TaskMarker {
   checked: boolean
   /** Display text, markdown stripped. */
   text: string
+  /** Parent outline/list item text, top-down, displayed above the task row. */
+  breadcrumbs: string[]
   noteTitle: string
   /** The task's explicit `[[YYYY-MM-DD]]` due date, or null. */
   dueDate: string | null
@@ -22,6 +25,8 @@ export interface OpenTask extends TaskMarker {
   updatedAt: number
 }
 
+const taskBreadcrumbsSchema = z.array(z.string())
+
 function taskRowsQuery() {
   return db
     .selectFrom('tasks')
@@ -32,6 +37,7 @@ function taskRowsQuery() {
       'tasks.markerOffset',
       'tasks.raw',
       'tasks.text',
+      'tasks.breadcrumbs',
       'tasks.checked',
       'tasks.dueDate',
       'notes.title as noteTitle',
@@ -45,8 +51,10 @@ function taskRowsQuery() {
 function toTaskRow(row: {
   checked: number
   isPinned: number
-}): { checked: boolean; isPinned: boolean } {
-  return { ...row, checked: row.checked !== 0, isPinned: row.isPinned !== 0 }
+  breadcrumbs: string
+}): { checked: boolean; isPinned: boolean; breadcrumbs: string[] } {
+  const breadcrumbs = taskBreadcrumbsSchema.parse(JSON.parse(row.breadcrumbs))
+  return { ...row, checked: row.checked !== 0, isPinned: row.isPinned !== 0, breadcrumbs }
 }
 
 /**

--- a/packages/core/src/indexing/queries.test.ts
+++ b/packages/core/src/indexing/queries.test.ts
@@ -377,6 +377,42 @@ describe('suggestWikiTargets', () => {
 })
 
 describe('getOpenTasks', () => {
+  it('parses task breadcrumbs and normalizes boolean note context', async () => {
+    mockInvoke.mockResolvedValue([
+      {
+        note_path: 'notes/project.md',
+        marker_offset: 12,
+        raw: '[ ] ship it',
+        text: 'ship it',
+        breadcrumbs: '["StartupToolbox","Reflections"]',
+        checked: 0,
+        due_date: null,
+        note_title: 'Project',
+        daily_date: null,
+        is_pinned: 1,
+        pinned_order: 2,
+        updated_at: 123,
+      },
+    ])
+
+    await expect(getOpenTasks()).resolves.toEqual([
+      {
+        notePath: 'notes/project.md',
+        markerOffset: 12,
+        raw: '[ ] ship it',
+        text: 'ship it',
+        breadcrumbs: ['StartupToolbox', 'Reflections'],
+        checked: false,
+        dueDate: null,
+        noteTitle: 'Project',
+        dailyDate: null,
+        isPinned: true,
+        pinnedOrder: 2,
+        updatedAt: 123,
+      },
+    ])
+  })
+
   it('never surfaces template checkboxes — boilerplate, not real tasks', async () => {
     mockInvoke.mockResolvedValue([])
 

--- a/packages/core/src/markdown/extract.test.ts
+++ b/packages/core/src/markdown/extract.test.ts
@@ -261,4 +261,12 @@ describe('parseNote — tasks', () => {
     const note = parse('+ [ ] no date here\n+ [ ] dated [[2026-07-01]]\n')
     expect(note.tasks.map((task) => task.dueDate)).toEqual([null, '2026-07-01'])
   })
+
+  it('does not borrow a due-date link from a nested child task', () => {
+    const note = parse('+ [ ] parent\n  + [ ] child [[2026-07-01]]\n')
+    expect(note.tasks.map((task) => ({ text: task.text, dueDate: task.dueDate }))).toEqual([
+      { text: 'parent', dueDate: null },
+      { text: 'child 2026-07-01', dueDate: '2026-07-01' },
+    ])
+  })
 })

--- a/packages/core/src/markdown/extract.test.ts
+++ b/packages/core/src/markdown/extract.test.ts
@@ -146,15 +146,36 @@ describe('parseNote — tasks', () => {
   it('extracts open and checked round task checkboxes with text, raw, marker offset', () => {
     const note = parse('+ [ ] buy milk\n+ [x] call mum\n')
     expect(note.tasks).toEqual([
-      { text: 'buy milk', raw: '[ ] buy milk', checked: false, markerOffset: 2, dueDate: null },
-      { text: 'call mum', raw: '[x] call mum', checked: true, markerOffset: 17, dueDate: null },
+      {
+        text: 'buy milk',
+        breadcrumbs: [],
+        raw: '[ ] buy milk',
+        checked: false,
+        markerOffset: 2,
+        dueDate: null,
+      },
+      {
+        text: 'call mum',
+        breadcrumbs: [],
+        raw: '[x] call mum',
+        checked: true,
+        markerOffset: 17,
+        dueDate: null,
+      },
     ])
   })
 
   it('treats an uppercase [X] marker as checked', () => {
     const note = parse('+ [X] done\n')
     expect(note.tasks).toEqual([
-      { text: 'done', raw: '[X] done', checked: true, markerOffset: 2, dueDate: null },
+      {
+        text: 'done',
+        breadcrumbs: [],
+        raw: '[X] done',
+        checked: true,
+        markerOffset: 2,
+        dueDate: null,
+      },
     ])
   })
 
@@ -184,10 +205,35 @@ describe('parseNote — tasks', () => {
     ])
   })
 
+  it('captures parent outline items as task breadcrumbs', () => {
+    const note = parse('+ Project [[Alpha]]\n  + **Phase one**\n    + [ ] ship it\n')
+    expect(note.tasks).toEqual([
+      expect.objectContaining({
+        text: 'ship it',
+        breadcrumbs: ['Project Alpha', 'Phase one'],
+      }),
+    ])
+  })
+
+  it('uses parent task rows as breadcrumbs for nested subtasks', () => {
+    const note = parse('+ [ ] parent task\n  + [x] child task\n')
+    expect(note.tasks.map((task) => ({ text: task.text, breadcrumbs: task.breadcrumbs }))).toEqual([
+      { text: 'parent task', breadcrumbs: [] },
+      { text: 'child task', breadcrumbs: ['parent task'] },
+    ])
+  })
+
   it('ignores checkboxes inside fenced code', () => {
     const note = parse('+ [ ] real\n\n```\n+ [ ] not a task\n```\n')
     expect(note.tasks).toEqual([
-      { text: 'real', raw: '[ ] real', checked: false, markerOffset: 2, dueDate: null },
+      {
+        text: 'real',
+        breadcrumbs: [],
+        raw: '[ ] real',
+        checked: false,
+        markerOffset: 2,
+        dueDate: null,
+      },
     ])
   })
 

--- a/packages/core/src/markdown/extract.ts
+++ b/packages/core/src/markdown/extract.ts
@@ -194,7 +194,7 @@ function lineEndAfter(body: string, from: number): number {
   return newline === -1 ? body.length : newline
 }
 
-function listItemText(
+function listItemBreadcrumbLabel(
   body: string,
   item: SyntaxNode,
   cuts: Span[],
@@ -217,13 +217,17 @@ function taskBreadcrumbs(
   cuts: Span[],
   literalRanges: Span[],
 ): string[] {
-  const breadcrumbs: string[] = []
   const ownItem = taskNode.parent
-  let ancestor = ownItem?.parent
+  if (ownItem?.name !== 'ListItem') {
+    return []
+  }
+
+  const breadcrumbs: string[] = []
+  let ancestor = ownItem.parent
 
   while (ancestor !== null && ancestor !== undefined) {
-    if (ancestor.name === 'ListItem' && ancestor !== ownItem) {
-      const text = listItemText(body, ancestor, cuts, literalRanges)
+    if (ancestor.name === 'ListItem') {
+      const text = listItemBreadcrumbLabel(body, ancestor, cuts, literalRanges)
       if (text !== null) {
         breadcrumbs.push(text)
       }

--- a/packages/core/src/markdown/extract.ts
+++ b/packages/core/src/markdown/extract.ts
@@ -1,3 +1,4 @@
+import type { SyntaxNode } from '@lezer/common'
 import { dateFromDailyPath, isDaily } from '../graph/paths'
 import { parseFrontmatter, splitFrontmatter } from './frontmatter'
 import { parseBody } from './grammar'
@@ -188,6 +189,51 @@ function hasRoundTaskListMarker(body: string, markerStart: number): boolean {
   return /^[\t ]*\+[\t ]+$/.test(body.slice(lineStart, markerStart))
 }
 
+function lineEndAfter(body: string, from: number): number {
+  const newline = body.indexOf('\n', from)
+  return newline === -1 ? body.length : newline
+}
+
+function listItemText(
+  body: string,
+  item: SyntaxNode,
+  cuts: Span[],
+  literalRanges: Span[],
+): string | null {
+  const lineEnd = lineEndAfter(body, item.from)
+  const firstLine = body.slice(item.from, lineEnd)
+  const marker = /^[\t ]*(?:[-+*]|\d+[.)])[\t ]+/.exec(firstLine)
+  if (marker === null) {
+    return null
+  }
+  const textStart = item.from + marker[0].length
+  const text = plainTextOfRange(body, textStart, lineEnd, cuts, literalRanges)
+  return text === '' ? null : text
+}
+
+function taskBreadcrumbs(
+  body: string,
+  taskNode: SyntaxNode,
+  cuts: Span[],
+  literalRanges: Span[],
+): string[] {
+  const breadcrumbs: string[] = []
+  const ownItem = taskNode.parent
+  let ancestor = ownItem?.parent
+
+  while (ancestor !== null && ancestor !== undefined) {
+    if (ancestor.name === 'ListItem' && ancestor !== ownItem) {
+      const text = listItemText(body, ancestor, cuts, literalRanges)
+      if (text !== null) {
+        breadcrumbs.push(text)
+      }
+    }
+    ancestor = ancestor.parent
+  }
+
+  return breadcrumbs.reverse()
+}
+
 /**
  * Resolve a `Task` Lezer node (the marker starts at `from`) into a
  * {@link ParsedTask}, or `null` when the marker shape isn't Reflect's task
@@ -196,13 +242,13 @@ function hasRoundTaskListMarker(body: string, markerStart: number): boolean {
  */
 function readTask(
   body: string,
-  range: Span,
+  taskNode: SyntaxNode,
   bodyOffset: number,
   cuts: Span[],
   literalRanges: Span[],
   wikiLinks: WikiLink[],
 ): ParsedTask | null {
-  const { from, to } = range
+  const { from, to } = taskNode
   if (!hasRoundTaskListMarker(body, from)) {
     return null
   }
@@ -210,11 +256,11 @@ function readTask(
   if (marker === null) {
     return null
   }
-  const newline = body.indexOf('\n', from)
-  const lineEnd = newline === -1 ? body.length : newline
+  const lineEnd = lineEndAfter(body, from)
   const markerOffset = from + bodyOffset
   return {
     text: plainTextOfRange(body, from, lineEnd, cuts, literalRanges),
+    breadcrumbs: taskBreadcrumbs(body, taskNode, cuts, literalRanges),
     raw: body.slice(from, lineEnd),
     checked: marker.checked,
     markerOffset,
@@ -313,7 +359,7 @@ export function parseNote(input: { path: string; source: string }): ParsedNote {
   const cuts: Span[] = [] // body coords — syntax to drop from plain text
   const tagExcluded: Span[] = [] // body coords — regions that don't yield tags
   const literalPlainText: Span[] = [] // body coords — regions that render backslashes literally
-  const taskRanges: Span[] = [] // body coords — `Task` node spans, resolved after the walk
+  const taskNodes: SyntaxNode[] = [] // body coords — `Task` nodes, resolved after the walk
 
   tree.iterate({
     enter: (node) => {
@@ -327,7 +373,7 @@ export function parseNote(input: { path: string; source: string }): ParsedNote {
         // needs to strip its text — and the `[[date]]` due-date link inside it —
         // aren't collected until their own `enter`. The node span bounds the
         // due-date search to this task.
-        taskRanges.push({ from, to })
+        taskNodes.push(node.node)
       }
       if (isTagExcludedNode(name)) {
         tagExcluded.push({ from, to })
@@ -369,8 +415,8 @@ export function parseNote(input: { path: string; source: string }): ParsedNote {
   collectTags(body, tagExcluded, tags)
 
   const tasks: ParsedTask[] = []
-  for (const range of taskRanges) {
-    const task = readTask(body, range, bodyOffset, cuts, literalPlainText, wikiLinks)
+  for (const taskNode of taskNodes) {
+    const task = readTask(body, taskNode, bodyOffset, cuts, literalPlainText, wikiLinks)
     if (task) {
       tasks.push(task)
     }

--- a/packages/core/src/markdown/model.ts
+++ b/packages/core/src/markdown/model.ts
@@ -187,6 +187,8 @@ export interface TaskMarker {
 export interface ParsedTask extends TaskMarker {
   /** Inline text of the item's marker line, markdown stripped, for display + search. */
   text: string
+  /** Parent outline/list item text, top-down, for the Tasks view breadcrumb. */
+  breadcrumbs: string[]
   /** `[x]`/`[X]` → true, `[ ]` → false. */
   checked: boolean
   /**
@@ -202,8 +204,9 @@ export interface ParsedTask extends TaskMarker {
 /** Version of the extraction contract; bump on breaking shape changes.
  * 1 — Plan 03 baseline · 2 — `tasks: ParsedTask[]` (with `dueDate`) added (Plan 18) ·
  * 3 — tasks limited to round Meowdown `+ [ ]` / `+ [x]` syntax; square checklist
- * checkboxes are excluded. */
-export const PARSED_NOTE_VERSION = 3
+ * checkboxes are excluded.
+ * 4 — task rows carry parent outline/list breadcrumbs. */
+export const PARSED_NOTE_VERSION = 4
 
 /** The full parse of one note — the stable contract downstream plans depend on. */
 export interface ParsedNote {

--- a/packages/db/src/schema.gen.ts
+++ b/packages/db/src/schema.gen.ts
@@ -122,6 +122,7 @@ export interface Tags {
 }
 
 export interface Tasks {
+  breadcrumbs: Generated<string>;
   checked: number;
   dueDate: string | null;
   markerOffset: number;


### PR DESCRIPTION
## Problem

Reflect V1's Tasks view showed the parent outline context above task rows, for example `StartupToolbox -> Reflections on a Movement`, so tasks made sense even when aggregated away from their source note. `reflect-open` only projected task text/raw/dates into SQLite, so the Tasks view lost that context and task search could not match parent outline labels.

## Before -> After

| Before | After |
| --- | --- |
| Task rows only showed the checkbox text plus date/source affordances. | Desktop and mobile rows show useful parent outline breadcrumbs above the task text. |
| Breadcrumb context was not part of the task projection. | `ParsedTask`, `IndexedTask`, SQLite `tasks`, and `OpenTask` carry `breadcrumbs`. |
| Search only matched `task.text`. | Search also matches breadcrumb context. |
| Adding breadcrumbs risked shifting the checkbox/date/open affordances. | Rows keep checkbox, task text, source date, and open affordance aligned on the task line while breadcrumbs sit as context. |

## Changes

1. Extract task breadcrumbs in `parseNote` by walking parent `ListItem` ancestors for round Meowdown task rows, preserving rendered plain text for links/emphasis.
2. Add `tasks.breadcrumbs` with migration `0017_task_breadcrumbs.sql`, bump schema/projection versions, regenerate Kysely schema, and serialize the breadcrumb array through the Rust and dev SQLite write paths.
3. Read breadcrumbs back through Zod validation in `getOpenTasks` / `getCompletedTasks` and include them in optimistic task rows.
4. Render breadcrumbs in desktop and mobile task rows with the V1 hiding rule for single generic `Tasks` / `Todo` breadcrumbs, while keeping row controls aligned with the task text.
5. Extend task filtering so breadcrumb text participates in search.
6. Tighten the extraction helper names/guards around task breadcrumb traversal so the Lezer `Task -> ListItem` assumption is explicit.

## Tests

- Parser tests cover nested parent outline items and parent task rows as breadcrumbs.
- Parser tests also cover nested child due-date links so parent task due dates stay scoped to the parent task row.
- Projection and Rust DB tests cover payload shape, migration versioning, and serialized breadcrumb storage.
- Query-boundary tests cover parsing JSON breadcrumbs and normalizing SQLite boolean fields.
- Desktop/mobile task tests cover the updated `OpenTask` shape, breadcrumb rendering, and breadcrumb search behavior.

## Verification

- `pnpm --filter @reflect/core test -- src/markdown/extract.test.ts src/indexing/indexed-note.test.ts src/indexing/group-tasks.test.ts` (passed; package ran 90 files / 1193 tests)
- `pnpm --filter @reflect/desktop test -- src/lib/tasks/task-breadcrumbs.test.ts src/components/tasks/tasks-screen.test.tsx src/dev/dev-index-db.test.ts src/mobile/screens/tasks.test.tsx` (passed; package ran 206 files / 1788 tests)
- `pnpm --filter @reflect/core test -- src/indexing/queries.test.ts src/indexing/indexed-note.test.ts src/markdown/extract.test.ts` (passed; package ran 90 files / 1193 tests)
- `pnpm --filter @reflect/desktop test -- src/lib/tasks/task-visibility.test.ts src/lib/tasks/task-breadcrumbs.test.ts` (passed; package ran 206 files / 1789 tests)
- `pnpm --filter @reflect/core test -- src/indexing/queries.test.ts` (passed; package ran 90 files / 1194 tests)
- `pnpm --filter @reflect/desktop test -- src/components/tasks/tasks-screen.test.tsx src/mobile/screens/tasks.test.tsx src/lib/tasks/task-breadcrumbs.test.ts src/lib/tasks/task-visibility.test.ts` (passed; package ran 206 files / 1789 tests)
- `pnpm --filter @reflect/core test -- src/markdown/extract.test.ts` (passed; package ran 90 files / 1195 tests)
- `pnpm --filter @reflect/desktop sidecar` (passed)
- `cargo test -p reflect-open db::tests` (passed; 50 tests)
- `pnpm check` (passed; existing `packages/core/src/indexing/indexer.ts` max-lines warning still appears)
- `git diff --check` (passed)

## Risk / Rollout

This adds a rebuildable projection column only. Existing indexes get `[]` from the schema migration and then receive real breadcrumbs after the projection-version bump triggers reindexing. Chat tables and non-rebuildable data are untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rebuildable projection column with a safe default and version-bump reindex; no auth or durable non-projection data changes.
> 
> **Overview**
> Restores V1-style **parent outline context** on aggregated task rows by threading `breadcrumbs` from markdown parse through the index into the Tasks view.
> 
> **Indexing:** `parseNote` walks parent `ListItem` ancestors for round `+ [ ]` tasks and records plain-text breadcrumb labels. `IndexedTask` / `OpenTask` gain `breadcrumbs`; migration `0017_task_breadcrumbs.sql` adds `tasks.breadcrumbs` (JSON, default `[]`); schema and **projection version** bumps trigger reindexing for real values. Rust and dev SQLite writers serialize the array; `getOpenTasks` parses it with Zod.
> 
> **UI:** Desktop and mobile rows render chevron-separated breadcrumbs above task text (strikethrough applies to text only). `visibleTaskBreadcrumbs` hides lone generic headings like “Tasks” / “Todo”. Task search also matches breadcrumb text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1f43a20646b68b9270117c564ce592329a3090f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks can now display breadcrumb context in both desktop and mobile views.
  * Breadcrumbs are extracted from nested task structure and included in task data throughout the app.
* **Bug Fixes**
  * Search and task grouping now match on breadcrumb text as well as task text.
  * Empty or generic breadcrumb labels are hidden for cleaner task lists.
* **Chores**
  * Updated schema and projection versions to support the new task data format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->