### PR TITLE
Fade mobile Today button

### DIFF
--- a/apps/desktop/src/mobile/calendar-strip.tsx
+++ b/apps/desktop/src/mobile/calendar-strip.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, Settings } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { addDaysIso } from '@/lib/dates'
 import { monthOf } from '@/lib/month-grid'
+import { cn } from '@/lib/utils'
 import { monthPickTarget, weekAtIndex, weekStartOf } from '@/mobile/calendar'
 import { hapticImpactLight } from '@/mobile/haptics'
 import { MonthPickerDrawer } from '@/mobile/month-picker-drawer'
@@ -56,6 +57,7 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
   const selectionWeekStart = weekStartOf(date, settings.weekStartDay)
   const headerDate =
     displayedWeekStart === selectionWeekStart ? date : addDaysIso(displayedWeekStart, 3)
+  const showingToday = date === today
 
   const jumpToToday = (): void => {
     hapticImpactLight()
@@ -126,11 +128,19 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
           </button>
         </h1>
         <div className="justify-self-end">
-          {date !== today && (
-            <Button variant="ghost" size="sm" onClick={jumpToToday}>
-              Today
-            </Button>
-          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-hidden={showingToday ? true : undefined}
+            tabIndex={showingToday ? -1 : undefined}
+            className={cn(
+              'transition-opacity duration-200 ease-out motion-reduce:transition-none',
+              showingToday ? 'pointer-events-none opacity-0' : 'opacity-100',
+            )}
+            onClick={jumpToToday}
+          >
+            Today
+          </Button>
         </div>
       </div>
       <div className="overflow-hidden" ref={emblaRef}>

--- a/apps/desktop/src/mobile/calendar-strip.tsx
+++ b/apps/desktop/src/mobile/calendar-strip.tsx
@@ -8,10 +8,18 @@ import { monthPickTarget, weekAtIndex, weekStartOf } from '@/mobile/calendar'
 import { hapticImpactLight } from '@/mobile/haptics'
 import { MonthPickerDrawer } from '@/mobile/month-picker-drawer'
 import { MonthTitle } from '@/mobile/month-title'
+import { usePrefersReducedMotion } from '@/mobile/use-reduced-motion'
 import { useWeekStrip } from '@/mobile/use-week-strip'
 import { WeekRow } from '@/mobile/week-row'
 import { useSettings } from '@/providers/settings-provider'
 import { useRouter } from '@/routing/router'
+
+const TODAY_BUTTON_FADE_MS = 200
+
+interface TodayButtonState {
+  readonly showingToday: boolean
+  readonly interactive: boolean
+}
 
 interface CalendarStripProps {
   /**
@@ -47,6 +55,7 @@ interface CalendarStripProps {
 export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStripProps): ReactElement {
   const { settings } = useSettings()
   const { navigate } = useRouter()
+  const prefersReducedMotion = usePrefersReducedMotion()
   const { emblaRef, weekWindow, displayedWeekStart, showWeekOf } = useWeekStrip(
     date,
     settings.weekStartDay,
@@ -59,6 +68,19 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
     displayedWeekStart === selectionWeekStart ? date : addDaysIso(displayedWeekStart, 3)
   const showingToday = date === today
   const todayButtonRef = useRef<HTMLButtonElement>(null)
+  const [todayButtonState, setTodayButtonState] = useState<TodayButtonState>(() => ({
+    showingToday,
+    interactive: !showingToday,
+  }))
+  let todayButtonInteractive = todayButtonState.interactive
+  if (todayButtonState.showingToday !== showingToday) {
+    todayButtonInteractive = !showingToday && prefersReducedMotion
+    setTodayButtonState({ showingToday, interactive: todayButtonInteractive })
+  } else if (!showingToday && prefersReducedMotion && !todayButtonInteractive) {
+    todayButtonInteractive = true
+    setTodayButtonState({ showingToday, interactive: true })
+  }
+  const todayButtonInert = showingToday || !todayButtonInteractive
 
   const jumpToToday = (event: MouseEvent<HTMLButtonElement>): void => {
     event.currentTarget.blur()
@@ -106,6 +128,18 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
     }
   }, [showingToday])
 
+  useEffect(() => {
+    if (showingToday || prefersReducedMotion || todayButtonInteractive) {
+      return
+    }
+    const timeout = window.setTimeout(() => {
+      setTodayButtonState((state) =>
+        state.showingToday ? state : { ...state, interactive: true },
+      )
+    }, TODAY_BUTTON_FADE_MS)
+    return () => window.clearTimeout(timeout)
+  }, [showingToday, prefersReducedMotion, todayButtonInteractive])
+
   return (
     <header
       className="shrink-0 border-b border-border px-2 pb-1"
@@ -142,13 +176,14 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
             variant="ghost"
             size="sm"
             disabled={showingToday}
-            aria-hidden={showingToday ? true : undefined}
-            tabIndex={showingToday ? -1 : undefined}
+            aria-hidden={todayButtonInert ? true : undefined}
+            tabIndex={todayButtonInert ? -1 : undefined}
             className={cn(
               'transition-opacity duration-200 ease-out disabled:opacity-0! motion-reduce:transition-none',
-              showingToday ? 'pointer-events-none opacity-0' : 'opacity-100',
+              todayButtonInert && 'pointer-events-none',
+              showingToday ? 'opacity-0' : 'opacity-100',
             )}
-            onClick={jumpToToday}
+            onClick={todayButtonInert ? undefined : jumpToToday}
           >
             Today
           </Button>

--- a/apps/desktop/src/mobile/calendar-strip.tsx
+++ b/apps/desktop/src/mobile/calendar-strip.tsx
@@ -141,13 +141,14 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
             ref={todayButtonRef}
             variant="ghost"
             size="sm"
+            disabled={showingToday}
             aria-hidden={showingToday ? true : undefined}
             tabIndex={showingToday ? -1 : undefined}
             className={cn(
-              'transition-opacity duration-200 ease-out motion-reduce:transition-none',
+              'transition-opacity duration-200 ease-out disabled:opacity-0! motion-reduce:transition-none',
               showingToday ? 'pointer-events-none opacity-0' : 'opacity-100',
             )}
-            onClick={showingToday ? undefined : jumpToToday}
+            onClick={jumpToToday}
           >
             Today
           </Button>

--- a/apps/desktop/src/mobile/calendar-strip.tsx
+++ b/apps/desktop/src/mobile/calendar-strip.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactElement } from 'react'
+import { useEffect, useRef, useState, type MouseEvent, type ReactElement } from 'react'
 import { ChevronDown, Settings } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { addDaysIso } from '@/lib/dates'
@@ -60,7 +60,8 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
   const showingToday = date === today
   const todayButtonRef = useRef<HTMLButtonElement>(null)
 
-  const jumpToToday = (): void => {
+  const jumpToToday = (event: MouseEvent<HTMLButtonElement>): void => {
+    event.currentTarget.blur()
     hapticImpactLight()
     onSelect(today)
     // Selecting today only moves the strip when `date` changes — re-center
@@ -111,7 +112,7 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
       style={{ paddingTop: 'env(safe-area-inset-top)' }}
     >
       {/* Three equal-flanked columns so the month sits at the screen's center
-          regardless of the gear (left) and the conditional Today button (right). */}
+          regardless of the gear (left) and the always-mounted Today slot (right). */}
       <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-1 px-1 py-1">
         <div className="justify-self-start">
           <Button

--- a/apps/desktop/src/mobile/calendar-strip.tsx
+++ b/apps/desktop/src/mobile/calendar-strip.tsx
@@ -58,6 +58,7 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
   const headerDate =
     displayedWeekStart === selectionWeekStart ? date : addDaysIso(displayedWeekStart, 3)
   const showingToday = date === today
+  const todayButtonRef = useRef<HTMLButtonElement>(null)
 
   const jumpToToday = (): void => {
     hapticImpactLight()
@@ -97,6 +98,13 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
     showWeekOf(date)
   }, [resetSeq, date, showWeekOf])
 
+  useEffect(() => {
+    const todayButton = todayButtonRef.current
+    if (showingToday && todayButton !== null && todayButton === document.activeElement) {
+      todayButton.blur()
+    }
+  }, [showingToday])
+
   return (
     <header
       className="shrink-0 border-b border-border px-2 pb-1"
@@ -129,6 +137,7 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
         </h1>
         <div className="justify-self-end">
           <Button
+            ref={todayButtonRef}
             variant="ghost"
             size="sm"
             aria-hidden={showingToday ? true : undefined}
@@ -137,7 +146,7 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
               'transition-opacity duration-200 ease-out motion-reduce:transition-none',
               showingToday ? 'pointer-events-none opacity-0' : 'opacity-100',
             )}
-            onClick={jumpToToday}
+            onClick={showingToday ? undefined : jumpToToday}
           >
             Today
           </Button>

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -326,7 +326,9 @@ describe('MobileShell', () => {
 
     await user.click(view.getByRole('button', { name: 'Today' }))
     expect(view.queryByRole('button', { name: 'Today' })).toBeNull()
-    expect(view.getByText('Today').closest('button')?.className).toContain('opacity-0')
+    const fadedTodayButton = view.getByText('Today').closest('button')
+    expect(fadedTodayButton?.className).toContain('opacity-0')
+    expect(document.activeElement).not.toBe(fadedTodayButton)
     expect(view.getByRole('button', { name: dayCellLabel(today) }).getAttribute('aria-current')).toBe(
       'date',
     )

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -315,18 +315,21 @@ describe('MobileShell', () => {
       throw new Error('missing mounted Today button')
     }
     expect(hiddenTodayButton.getAttribute('aria-hidden')).toBe('true')
+    expect(hiddenTodayButton.disabled).toBe(true)
     expect(hiddenTodayButton.className).toContain('opacity-0')
     await user.click(view.getByRole('button', { name: dayCellLabel(other) }))
     expect(view.getByRole('button', { name: dayCellLabel(other) }).getAttribute('aria-current')).toBe(
       'date',
     )
     const shownTodayButton = view.getByRole('button', { name: 'Today' })
+    expect((shownTodayButton as HTMLButtonElement).disabled).toBe(false)
     expect(shownTodayButton.className).toContain('transition-opacity')
     expect(shownTodayButton.className).toContain('opacity-100')
 
     await user.click(view.getByRole('button', { name: 'Today' }))
     expect(view.queryByRole('button', { name: 'Today' })).toBeNull()
     const fadedTodayButton = view.getByText('Today').closest('button')
+    expect(fadedTodayButton?.disabled).toBe(true)
     expect(fadedTodayButton?.className).toContain('opacity-0')
     expect(document.activeElement).not.toBe(fadedTodayButton)
     expect(view.getByRole('button', { name: dayCellLabel(today) }).getAttribute('aria-current')).toBe(

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -321,6 +321,12 @@ describe('MobileShell', () => {
     expect(view.getByRole('button', { name: dayCellLabel(other) }).getAttribute('aria-current')).toBe(
       'date',
     )
+    const fadingTodayButton = view.getByText('Today').closest('button')
+    expect(fadingTodayButton?.disabled).toBe(false)
+    expect(fadingTodayButton?.getAttribute('aria-hidden')).toBe('true')
+    expect(fadingTodayButton?.className).toContain('pointer-events-none')
+    expect(fadingTodayButton?.className).toContain('opacity-100')
+    await waitFor(() => expect(view.getByRole('button', { name: 'Today' })).toBeTruthy())
     const shownTodayButton = view.getByRole('button', { name: 'Today' })
     expect((shownTodayButton as HTMLButtonElement).disabled).toBe(false)
     expect(shownTodayButton.className).toContain('transition-opacity')
@@ -350,7 +356,7 @@ describe('MobileShell', () => {
       view.getByRole('button', { name: dayCellLabel(nextFortnight) }).getAttribute('aria-current'),
     ).toBe('date')
     expect(shownMonth(view)).toBe(monthLabel(monthOf(nextFortnight)))
-    expect(view.getByRole('button', { name: 'Today' })).toBeTruthy()
+    await waitFor(() => expect(view.getByRole('button', { name: 'Today' })).toBeTruthy())
   })
 
   it('jumps to a picked month from the month title’s picker sheet', async () => {
@@ -371,7 +377,7 @@ describe('MobileShell', () => {
     expect(
       view.getByRole('button', { name: dayCellLabel(firstDay) }).getAttribute('aria-current'),
     ).toBe('date')
-    expect(view.getByRole('button', { name: 'Today' })).toBeTruthy()
+    await waitFor(() => expect(view.getByRole('button', { name: 'Today' })).toBeTruthy())
   })
 
   it('keeps the selection when its own month is picked from the sheet', async () => {
@@ -398,6 +404,7 @@ describe('MobileShell', () => {
     await user.click(view.getByRole('button', { name: dayCellLabel(other) }))
     hapticImpactLight.mockClear()
 
+    await waitFor(() => expect(view.getByRole('button', { name: 'Today' })).toBeTruthy())
     await user.click(view.getByRole('button', { name: 'Today' }))
     expect(hapticImpactLight).toHaveBeenCalledTimes(1)
 

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -310,14 +310,23 @@ describe('MobileShell', () => {
     const view = mount({ kind: 'today' })
 
     expect(view.queryByRole('button', { name: 'Today' })).toBeNull()
+    const hiddenTodayButton = view.getByText('Today').closest('button')
+    if (hiddenTodayButton === null) {
+      throw new Error('missing mounted Today button')
+    }
+    expect(hiddenTodayButton.getAttribute('aria-hidden')).toBe('true')
+    expect(hiddenTodayButton.className).toContain('opacity-0')
     await user.click(view.getByRole('button', { name: dayCellLabel(other) }))
     expect(view.getByRole('button', { name: dayCellLabel(other) }).getAttribute('aria-current')).toBe(
       'date',
     )
-    expect(view.getByRole('button', { name: 'Today' })).toBeTruthy()
+    const shownTodayButton = view.getByRole('button', { name: 'Today' })
+    expect(shownTodayButton.className).toContain('transition-opacity')
+    expect(shownTodayButton.className).toContain('opacity-100')
 
     await user.click(view.getByRole('button', { name: 'Today' }))
     expect(view.queryByRole('button', { name: 'Today' })).toBeNull()
+    expect(view.getByText('Today').closest('button')?.className).toContain('opacity-0')
     expect(view.getByRole('button', { name: dayCellLabel(today) }).getAttribute('aria-current')).toBe(
       'date',
     )


### PR DESCRIPTION
## Problem

On the iOS daily surface, the top-right Today affordance appeared and disappeared by mounting or unmounting the button. That made the control pop in and out when the selected daily note moved away from or back to today.

## Before -> After

| Before | After |
| --- | --- |
| The Today button only rendered when the selected day was not today. | The button stays mounted in the header slot and fades between `opacity-0` and `opacity-100`. |
| Hidden state removed the control from the DOM. | Hidden state is disabled, non-interactive, removed from the accessibility tree, blurred if it had focus, and guarded against click activation. |
| Fade-in could otherwise expose an invisible hit target. | Fade-in starts visually right away but remains pointer/click/focus inert until the 200ms fade completes, with reduced-motion users made interactive immediately. |

## Changes

1. Updated `CalendarStrip` so the Today button has an opacity transition, respects reduced motion, and keeps the header layout stable.
2. Added hidden-state safety: `disabled`, `aria-hidden`, `tabIndex={-1}`, `pointer-events-none`, focus blur on hide, and no activation while hidden.
3. Added a short fade-in interactivity gate so the button cannot be tapped before it is visible.
4. Extended the mobile shell coverage to assert the hidden mounted state, fade-in inert state, visible fade classes, jump-to-today behavior, and focus handoff after hiding.

## Verification

- `pnpm --filter @reflect/desktop exec vitest run src/mobile/mobile-screen.test.tsx` passed.
- `pnpm check` passed. The existing `packages/core/src/indexing/indexer.ts` max-lines warning is still present.

## Risk / Rollout

Low risk: this is a localized presentation and interaction-safety change to the mobile daily header with no data, routing, or persistence changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized mobile header UI and interaction polish only; no routing, persistence, or data changes.
> 
> **Overview**
> The mobile daily header **Today** control no longer mounts and unmounts when the selected day is or isn’t today. It stays in the right header slot and **fades** between hidden (`opacity-0`) and visible (`opacity-100`) with a 200ms transition, keeping the month title centered.
> 
> While hidden or mid-fade, the button is **non-interactive**: `disabled`, `aria-hidden`, `tabIndex={-1}`, `pointer-events-none`, and clicks are stripped until the fade finishes (skipped when **prefers-reduced-motion** is on). Focus is blurred when hiding so the control doesn’t stay focused after jumping back to today.
> 
> **`mobile-screen.test.tsx`** now asserts the always-mounted hidden state, the fade/interaction gating, and uses `waitFor` where the button becomes discoverable by role after the delay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44dae0c559e4802667903668658dfbe79eb479d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->