### PR TITLE
Import Reflect V1 CDN assets

### DIFF
--- a/apps/desktop/src-tauri/src/fs/import.rs
+++ b/apps/desktop/src-tauri/src/fs/import.rs
@@ -4,8 +4,8 @@
 //! `daily/`, `notes/`, optional `assets/`, plus ignorable local metadata. The
 //! import path is therefore a bounded archive extraction into the active graph,
 //! not a content migration — with one addition: attachments the notes link
-//! straight to Firebase Storage are downloaded into `assets/` and the links
-//! rewritten (see [`super::import_assets`]).
+//! straight to Firebase Storage or Reflect's CDN are downloaded into `assets/`
+//! and the links rewritten (see [`super::import_assets`]).
 //!
 //! The flow is three phases so nothing lands in the graph until everything is
 //! in hand: [`prepare_zip_import`] (read + validate, no writes), the async
@@ -147,7 +147,7 @@ pub struct PreparedImport {
     /// Unique remote-asset URLs across all notes, in first-seen order (which
     /// also fixes collision-suffix assignment).
     urls: Vec<String>,
-    prefix: String,
+    asset_prefixes: Vec<String>,
 }
 
 impl PreparedImport {
@@ -179,15 +179,15 @@ impl PreparedImport {
 /// Read and validate a user-selected Reflect V1 export zip against `root`,
 /// without writing anything.
 pub(super) fn prepare_zip_import(root: &Path, zip_path: &Path) -> AppResult<PreparedImport> {
-    prepare_zip_import_from(root, zip_path, import_assets::V1_ASSET_URL_PREFIX)
+    prepare_zip_import_from(root, zip_path, &import_assets::V1_ASSET_URL_PREFIXES)
 }
 
-/// [`prepare_zip_import`] with the remote-asset URL prefix injectable, so
+/// [`prepare_zip_import`] with remote-asset URL prefixes injectable, so
 /// tests can point it at a local server.
 fn prepare_zip_import_from(
     root: &Path,
     zip_path: &Path,
-    prefix: &str,
+    asset_prefixes: &[&str],
 ) -> AppResult<PreparedImport> {
     let entries = dedupe_entries(read_zip_entries(zip_path)?)?;
     ensure_has_notes(&entries)?;
@@ -200,7 +200,7 @@ fn prepare_zip_import_from(
         let Ok(text) = std::str::from_utf8(&entry.bytes) else {
             continue;
         };
-        for span in import_assets::scan_remote_spans(text, prefix) {
+        for span in import_assets::scan_remote_spans(text, asset_prefixes.iter().copied()) {
             if seen.insert(span.url.clone()) {
                 urls.push(span.url);
             }
@@ -210,8 +210,15 @@ fn prepare_zip_import_from(
         entries,
         staging: super::assets::staging_dir(root)?,
         urls,
-        prefix: prefix.to_string(),
+        asset_prefixes: owned_asset_prefixes(asset_prefixes),
     })
+}
+
+fn owned_asset_prefixes(asset_prefixes: &[&str]) -> Vec<String> {
+    asset_prefixes
+        .iter()
+        .map(|asset_prefix| (*asset_prefix).to_string())
+        .collect()
 }
 
 /// Two distinct URLs can serve the same attachment (V1 stored one upload per
@@ -261,7 +268,7 @@ pub(super) fn finalize_import(
     let PreparedImport {
         mut entries,
         urls,
-        prefix,
+        asset_prefixes,
         ..
     } = prepared;
 
@@ -360,7 +367,11 @@ pub(super) fn finalize_import(
             // Zip-borne `assets/…` links first: the remote rewrite splices in
             // downloaded assets' final names, which must not be re-mapped.
             let rewritten = import_assets::rewrite_asset_paths(text, &path_replacements);
-            let rewritten = import_assets::rewrite_markdown(&rewritten, &prefix, &url_replacements);
+            let rewritten = import_assets::rewrite_markdown(
+                &rewritten,
+                asset_prefixes.iter().map(String::as_str),
+                &url_replacements,
+            );
             if rewritten != text {
                 entry.bytes = rewritten.into_bytes();
             }
@@ -831,7 +842,7 @@ mod tests {
             entries,
             staging: super::super::assets::staging_dir(root)?,
             urls: Vec::new(),
-            prefix: import_assets::V1_ASSET_URL_PREFIX.to_string(),
+            asset_prefixes: owned_asset_prefixes(&import_assets::V1_ASSET_URL_PREFIXES),
         };
         finalize_import(root, prepared, HashMap::new(), |_, _| {})
     }
@@ -1493,7 +1504,18 @@ mod tests {
         zip_path: &Path,
         prefix: &str,
     ) -> AppResult<ImportSummary> {
-        let prepared = prepare_zip_import_from(root, zip_path, prefix)?;
+        let prepared = prepare_zip_import_from(root, zip_path, &[prefix])?;
+        let downloads =
+            tauri::async_runtime::block_on(prepared.download_assets(no_cancel(), no_progress()))?;
+        finalize_import(root, prepared, downloads, |_, _| {})
+    }
+
+    fn import_zip_downloading_from_prefixes(
+        root: &Path,
+        zip_path: &Path,
+        asset_prefixes: &[&str],
+    ) -> AppResult<ImportSummary> {
+        let prepared = prepare_zip_import_from(root, zip_path, asset_prefixes)?;
         let downloads =
             tauri::async_runtime::block_on(prepared.download_assets(no_cancel(), no_progress()))?;
         finalize_import(root, prepared, downloads, |_, _| {})
@@ -1562,6 +1584,93 @@ mod tests {
     }
 
     #[test]
+    fn prepares_firebase_and_reflect_cdn_asset_urls() {
+        let root = tempdir().unwrap();
+        let zip_path = root.path().join("export.zip");
+        let markdown = "![](https://firebasestorage.googleapis.com/o/a?alt=media\\&token=t)\n![](https://reflect-assets.app/v1/users/user-id/document-id/asset-id?key=k)\n";
+        write_zip(&zip_path, &[("daily/2026-07-04.md", markdown)]);
+
+        let prepared = prepare_zip_import(root.path(), &zip_path).unwrap();
+
+        assert_eq!(prepared.remote_asset_count(), 2);
+    }
+
+    #[test]
+    fn downloads_reflect_cdn_assets_and_rewrites_links() {
+        let root = tempdir().unwrap();
+        let base = serve(
+            vec![(
+                "/v1/users/user-id/document-id/asset-id?key=k",
+                "200 OK",
+                "Content-Type: image/png\r\n",
+                b"cdn image bytes",
+            )],
+            1,
+        );
+        let cdn_prefix = format!("{base}v1/users/");
+        let zip_path = root.path().join("export.zip");
+        let markdown = format!("![]({cdn_prefix}user-id/document-id/asset-id?key=k)\n");
+        write_zip(&zip_path, &[("daily/2026-07-04.md", markdown.as_str())]);
+
+        let summary =
+            import_zip_downloading_from_prefixes(root.path(), &zip_path, &[cdn_prefix.as_str()])
+                .unwrap();
+
+        assert_eq!(summary.downloaded_assets, 1);
+        assert!(summary
+            .changed_paths
+            .contains(&"assets/asset-id.png".to_string()));
+        assert_eq!(
+            fs::read(root.path().join("assets/asset-id.png")).unwrap(),
+            b"cdn image bytes"
+        );
+        let note = fs::read_to_string(root.path().join("daily/2026-07-04.md")).unwrap();
+        assert_eq!(note, "![](assets/asset-id.png)\n");
+    }
+
+    #[test]
+    fn downloads_assets_from_multiple_remote_prefixes() {
+        let root = tempdir().unwrap();
+        let base = serve(
+            vec![
+                (
+                    "/firebase/photo?alt=media&token=t",
+                    "200 OK",
+                    "Content-Type: image/webp\r\n",
+                    b"firebase image bytes",
+                ),
+                (
+                    "/v1/users/user-id/document-id/cdn-photo?key=k",
+                    "200 OK",
+                    "Content-Type: image/jpeg\r\n",
+                    b"cdn jpg bytes",
+                ),
+            ],
+            2,
+        );
+        let firebase_prefix = format!("{base}firebase/");
+        let cdn_prefix = format!("{base}v1/users/");
+        let zip_path = root.path().join("export.zip");
+        let markdown = format!(
+            "![]({firebase_prefix}photo?alt=media\\&token=t)\n![]({cdn_prefix}user-id/document-id/cdn-photo?key=k)\n"
+        );
+        write_zip(&zip_path, &[("daily/2026-07-04.md", markdown.as_str())]);
+
+        let summary = import_zip_downloading_from_prefixes(
+            root.path(),
+            &zip_path,
+            &[firebase_prefix.as_str(), cdn_prefix.as_str()],
+        )
+        .unwrap();
+
+        assert_eq!(summary.downloaded_assets, 2);
+        assert!(root.path().join("assets/photo.webp").exists());
+        assert!(root.path().join("assets/cdn-photo.jpg").exists());
+        let note = fs::read_to_string(root.path().join("daily/2026-07-04.md")).unwrap();
+        assert_eq!(note, "![](assets/photo.webp)\n![](assets/cdn-photo.jpg)\n");
+    }
+
+    #[test]
     #[cfg(unix)]
     fn downloaded_assets_do_not_hold_file_descriptors_until_finalize() {
         const ASSET_COUNT: usize = 80;
@@ -1574,7 +1683,7 @@ mod tests {
             .collect::<String>();
         write_zip(&zip_path, &[("daily/2026-07-04.md", markdown.as_str())]);
 
-        let prepared = prepare_zip_import_from(root.path(), &zip_path, &base).unwrap();
+        let prepared = prepare_zip_import_from(root.path(), &zip_path, &[base.as_str()]).unwrap();
         let Some(before) = open_fd_count() else {
             return;
         };
@@ -1683,7 +1792,7 @@ mod tests {
             .map(|index| format!("![]({base}asset-{index}?alt=media\\&token={index})\n"))
             .collect::<String>();
         write_zip(&zip_path, &[("daily/2026-07-04.md", markdown.as_str())]);
-        let prepared = prepare_zip_import_from(root.path(), &zip_path, &base).unwrap();
+        let prepared = prepare_zip_import_from(root.path(), &zip_path, &[base.as_str()]).unwrap();
         let seen = Arc::new(Mutex::new(Vec::new()));
         let record = Arc::clone(&seen);
 
@@ -1708,7 +1817,7 @@ mod tests {
         let zip_path = root.path().join("export.zip");
         let markdown = format!("![]({base}photo?alt=media\\&token=t)\n");
         write_zip(&zip_path, &[("daily/2026-07-04.md", markdown.as_str())]);
-        let prepared = prepare_zip_import_from(root.path(), &zip_path, &base).unwrap();
+        let prepared = prepare_zip_import_from(root.path(), &zip_path, &[base.as_str()]).unwrap();
         let cancelled = Arc::new(AtomicBool::new(true));
 
         let result =
@@ -1734,7 +1843,7 @@ mod tests {
             entries: dedupe_entries(entries).unwrap(),
             staging: super::super::assets::staging_dir(root.path()).unwrap(),
             urls: Vec::new(),
-            prefix: import_assets::V1_ASSET_URL_PREFIX.to_string(),
+            asset_prefixes: owned_asset_prefixes(&import_assets::V1_ASSET_URL_PREFIXES),
         };
         let mut seen = Vec::new();
 

--- a/apps/desktop/src-tauri/src/fs/import_assets.rs
+++ b/apps/desktop/src-tauri/src/fs/import_assets.rs
@@ -1,6 +1,6 @@
 //! Remote-asset localization for the Reflect V1 import.
 //!
-//! V1 notes link attachments straight at Firebase Storage download URLs. An
+//! V1 notes link attachments straight at Firebase Storage or Reflect's CDN. An
 //! import must not leave a graph depending on Reflect V1's infrastructure, so
 //! every such URL is downloaded into the graph's `assets/` directory and the
 //! markdown link is rewritten to the relative `assets/…` path.
@@ -20,9 +20,12 @@ use std::time::Duration;
 
 use crate::error::{AppError, AppResult};
 
-/// Only asset links on Reflect V1's storage host are localized; every other
+/// Only asset links on Reflect V1's storage hosts are localized; every other
 /// URL in the export is an ordinary link and imports untouched.
-pub(super) const V1_ASSET_URL_PREFIX: &str = "https://firebasestorage.googleapis.com/";
+pub(super) const V1_ASSET_URL_PREFIXES: [&str; 2] = [
+    "https://firebasestorage.googleapis.com/",
+    "https://reflect-assets.app/v1/users/",
+];
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 /// Per-read stall timeout. There is deliberately no whole-request timeout so
@@ -57,13 +60,29 @@ pub(super) struct FetchedAsset {
     pub desired_name: String,
 }
 
-/// Find every remote-asset URL in `markdown` that starts with `prefix`.
+/// Find every remote-asset URL in `markdown` that starts with one of
+/// `prefixes`.
 ///
 /// V1 exports escape URL punctuation the CommonMark way (`?alt=media\&token=`),
 /// so the span keeps the escaped bytes (for splicing) while `url` holds the
 /// unescaped form (for fetching). A span ends at whitespace or any character
 /// that terminates a markdown link destination.
-pub(super) fn scan_remote_spans(markdown: &str, prefix: &str) -> Vec<RemoteSpan> {
+pub(super) fn scan_remote_spans<'a>(
+    markdown: &str,
+    prefixes: impl IntoIterator<Item = &'a str>,
+) -> Vec<RemoteSpan> {
+    let mut spans = Vec::new();
+    for prefix in prefixes {
+        if prefix.is_empty() {
+            continue;
+        }
+        spans.extend(scan_remote_spans_for_prefix(markdown, prefix));
+    }
+    spans.sort_by_key(|span| (span.start, span.end));
+    spans
+}
+
+fn scan_remote_spans_for_prefix(markdown: &str, prefix: &str) -> Vec<RemoteSpan> {
     let mut spans = Vec::new();
     let mut from = 0;
     while let Some(found) = markdown[from..].find(prefix) {
@@ -108,13 +127,13 @@ pub(super) fn scan_remote_spans(markdown: &str, prefix: &str) -> Vec<RemoteSpan>
 /// Replace the remote spans of `markdown` whose URL has a localized path in
 /// `replacements` (URL → `assets/…`). URLs without a replacement (permanent
 /// download failures) keep their remote form.
-pub(super) fn rewrite_markdown(
+pub(super) fn rewrite_markdown<'a>(
     markdown: &str,
-    prefix: &str,
+    prefixes: impl IntoIterator<Item = &'a str>,
     replacements: &HashMap<String, String>,
 ) -> String {
     let mut result = markdown.to_string();
-    for span in scan_remote_spans(markdown, prefix).into_iter().rev() {
+    for span in scan_remote_spans(markdown, prefixes).into_iter().rev() {
         if let Some(local) = replacements.get(&span.url) {
             result.replace_range(span.start..span.end, local);
         }
@@ -135,7 +154,7 @@ pub(super) fn rewrite_asset_paths(
         return markdown.to_string();
     }
     let mut result = markdown.to_string();
-    for span in scan_remote_spans(markdown, "assets/").into_iter().rev() {
+    for span in scan_remote_spans(markdown, ["assets/"]).into_iter().rev() {
         let opens_destination = markdown[..span.start]
             .chars()
             .next_back()
@@ -571,12 +590,13 @@ mod tests {
     use std::fs;
     use tempfile::tempdir;
 
-    const PREFIX: &str = "https://firebasestorage.googleapis.com/";
+    const FIREBASE_PREFIX: &str = "https://firebasestorage.googleapis.com/";
+    const REFLECT_CDN_PREFIX: &str = "https://reflect-assets.app/v1/users/";
 
     #[test]
     fn scan_finds_escaped_urls_in_link_destinations() {
         let markdown = "![](https://firebasestorage.googleapis.com/v0/b/x/o/a?alt=media\\&token=t)\nplain text\n[memo.m4a](https://firebasestorage.googleapis.com/v0/b/x/o/b?alt=media\\&token=u)";
-        let spans = scan_remote_spans(markdown, PREFIX);
+        let spans = scan_remote_spans(markdown, [FIREBASE_PREFIX]);
         assert_eq!(spans.len(), 2);
         assert_eq!(
             spans[0].url,
@@ -595,17 +615,34 @@ mod tests {
     #[test]
     fn scan_ignores_other_hosts() {
         let markdown = "[a](https://example.com/file.png)";
-        assert!(scan_remote_spans(markdown, PREFIX).is_empty());
+        assert!(scan_remote_spans(markdown, [FIREBASE_PREFIX]).is_empty());
     }
 
     #[test]
     fn scan_stops_at_terminators() {
         let markdown = "see https://firebasestorage.googleapis.com/v0/o/a?alt=media end";
-        let spans = scan_remote_spans(markdown, PREFIX);
+        let spans = scan_remote_spans(markdown, [FIREBASE_PREFIX]);
         assert_eq!(spans.len(), 1);
         assert_eq!(
             spans[0].url,
             "https://firebasestorage.googleapis.com/v0/o/a?alt=media"
+        );
+    }
+
+    #[test]
+    fn scan_finds_reflect_assets_cdn_urls() {
+        let markdown = "![](https://reflect-assets.app/v1/users/u/8d964adcdd324599b74cb4efc81aa62d/5ff0f164-fe07-4436-9f9f-234ee49805a0?key=k\\&download=1)\n[clip](https://reflect-assets.app/v1/users/u/0a19dc2e-40e8-4271-8697-616bf11a3edd?key=k)";
+
+        let spans = scan_remote_spans(markdown, [REFLECT_CDN_PREFIX]);
+
+        assert_eq!(spans.len(), 2);
+        assert_eq!(
+            spans[0].url,
+            "https://reflect-assets.app/v1/users/u/8d964adcdd324599b74cb4efc81aa62d/5ff0f164-fe07-4436-9f9f-234ee49805a0?key=k&download=1"
+        );
+        assert_eq!(
+            spans[1].url,
+            "https://reflect-assets.app/v1/users/u/0a19dc2e-40e8-4271-8697-616bf11a3edd?key=k"
         );
     }
 
@@ -617,8 +654,32 @@ mod tests {
             "assets/photo.webp".to_string(),
         )]);
         assert_eq!(
-            rewrite_markdown(markdown, PREFIX, &replacements),
+            rewrite_markdown(markdown, [FIREBASE_PREFIX], &replacements),
             "![](assets/photo.webp) and [f](https://firebasestorage.googleapis.com/o/b?alt=media\\&token=u)"
+        );
+    }
+
+    #[test]
+    fn rewrite_replaces_all_v1_asset_prefixes() {
+        let markdown = "![](https://firebasestorage.googleapis.com/o/a?alt=media\\&token=t) and ![](https://reflect-assets.app/v1/users/u/asset?key=k)";
+        let replacements = HashMap::from([
+            (
+                "https://firebasestorage.googleapis.com/o/a?alt=media&token=t".to_string(),
+                "assets/photo.webp".to_string(),
+            ),
+            (
+                "https://reflect-assets.app/v1/users/u/asset?key=k".to_string(),
+                "assets/cdn-photo.webp".to_string(),
+            ),
+        ]);
+
+        assert_eq!(
+            rewrite_markdown(
+                markdown,
+                V1_ASSET_URL_PREFIXES.iter().copied(),
+                &replacements
+            ),
+            "![](assets/photo.webp) and ![](assets/cdn-photo.webp)"
         );
     }
 
@@ -655,6 +716,22 @@ mod tests {
                 "https://firebasestorage.googleapis.com/v0/b/x/o/users%2Fabc%2Fd8fbbe?alt=media"
             ),
             Some("d8fbbe".to_string())
+        );
+    }
+
+    #[test]
+    fn object_id_uses_the_final_reflect_assets_cdn_segment() {
+        assert_eq!(
+            url_object_id(
+                "https://reflect-assets.app/v1/users/u/8d964adcdd324599b74cb4efc81aa62d/5ff0f164-fe07-4436-9f9f-234ee49805a0?key=k"
+            ),
+            Some("5ff0f164-fe07-4436-9f9f-234ee49805a0".to_string())
+        );
+        assert_eq!(
+            url_object_id(
+                "https://reflect-assets.app/v1/users/u/0a19dc2e-40e8-4271-8697-616bf11a3edd?key=k"
+            ),
+            Some("0a19dc2e-40e8-4271-8697-616bf11a3edd".to_string())
         );
     }
 


### PR DESCRIPTION
## Problem

Reflect V1 imports localized assets referenced through Firebase Storage URLs, but V1 exports can also contain signed `https://reflect-assets.app/v1/users/...` CDN links. Those CDN assets were not counted during prepare, downloaded during import, or rewritten to local `assets/...` paths, so imported notes could continue depending on V1 infrastructure.

The provided sample export contains 31 unique `reflect-assets.app/v1/users/...` links alongside 140 unique Firebase links, so both URL families need to be handled by the same localization path.

## Before -> After

| Case | Before | After |
| --- | --- | --- |
| Firebase Storage asset URL | Downloaded and rewritten to `assets/...` | Unchanged |
| `reflect-assets.app/v1/users/...` asset URL | Left as a remote URL in imported notes | Downloaded, named from the final CDN path segment plus `Content-Type`, and rewritten to `assets/...` |
| Mixed exports | Only Firebase links contributed to the download total | Firebase and CDN links contribute to the download total and progress |

## Changes

1. Replaced the single V1 asset URL prefix with `V1_ASSET_URL_PREFIXES`, covering Firebase Storage and `reflect-assets.app/v1/users/`.
2. Updated `scan_remote_spans` and `rewrite_markdown` to operate over trusted prefix iterators while preserving existing markdown escape handling.
3. Carried the prefix set through `PreparedImport` so final note rewriting uses the same hosts that prepare counted.
4. Added Rust coverage for CDN scanning, mixed-prefix rewriting, CDN object-id filename fallback, default prepare counting, CDN download/rewrite, and mixed Firebase/CDN imports.

## Verification

- `pnpm --filter @reflect/desktop sidecar` passed.
- `cargo fmt --check --package reflect-open` passed.
- `cargo test -p reflect-open fs::import` passed: 45 import tests.
- `pnpm check` passed. It replayed an existing unrelated `max-lines` warning in `packages/core/src/indexing/indexer.ts`.
- Counted the provided export locally without printing signed URLs: 31 unique `reflect-assets.app/v1/users/...` links and 140 unique Firebase links.

## Risk / Rollout

No migrations or data-shape changes. The change expands the set of V1 asset hosts eligible for localization during import; permanent 4xx responses still keep the original remote link and are counted as failed asset downloads, matching the existing Firebase behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the desktop import pipeline (network fetches and graph writes), but only expands which V1 hosts are localized with the same download/rewrite rules as Firebase.
> 
> **Overview**
> **V1 zip import** now treats signed `https://reflect-assets.app/v1/users/...` links like Firebase Storage URLs: they are counted during prepare, downloaded into `assets/`, and rewritten to local paths so notes do not keep depending on V1 infrastructure.
> 
> The single host prefix is replaced with **`V1_ASSET_URL_PREFIXES`** (Firebase + Reflect CDN). **`scan_remote_spans`** and **`rewrite_markdown`** scan and rewrite across all trusted prefixes; **`PreparedImport`** carries that same set through finalize so prepare and rewrite stay aligned. CDN filenames still fall back to the **last URL path segment** (plus `Content-Type`) via existing naming logic.
> 
> New integration tests cover CDN-only and mixed Firebase/CDN exports; Firebase behavior and permanent 4xx “keep remote link” handling are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9665110fec72f465577a99c1fa7f5972d6a7483d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->