### PR TITLE
Add React Sentry diagnostics

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -29,6 +29,7 @@
     "@reflect/db": "workspace:*",
     "@reflect/design-system": "workspace:*",
     "@reflect/utils": "workspace:*",
+    "@sentry/react": "^10.64.0",
     "@shadcn/react": "^0.1.0",
     "@tanstack/react-query": "^5.101.1",
     "@tauri-apps/api": "^2.11.1",
@@ -57,6 +58,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
+    "@sentry/vite-plugin": "^5.3.0",
     "@sqlite.org/sqlite-wasm": "3.53.0-build1",
     "@tailwindcss/vite": "^4.3.1",
     "@tauri-apps/cli": "^2.11.3",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: reflect-asset: https:; font-src 'self' data:; frame-src 'self' https://platform.twitter.com https://platform.x.com https://syndication.twitter.com https://www.youtube-nocookie.com https://www.youtube.com; connect-src 'self' ipc: http://ipc.localhost https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://openrouter.ai https://github.com https://api.github.com https://o463484.ingest.us.sentry.io"
+      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: reflect-asset: https:; font-src 'self' data:; frame-src 'self' https://platform.twitter.com https://platform.x.com https://syndication.twitter.com https://www.youtube-nocookie.com https://www.youtube.com; connect-src 'self' ipc: http://ipc.localhost https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://openrouter.ai https://github.com https://api.github.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://*.ingest.de.sentry.io https://*.ingest.eu.sentry.io"
     }
   },
   "plugins": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: reflect-asset: https:; font-src 'self' data:; frame-src 'self' https://platform.twitter.com https://platform.x.com https://syndication.twitter.com https://www.youtube-nocookie.com https://www.youtube.com; connect-src 'self' ipc: http://ipc.localhost https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://openrouter.ai https://github.com https://api.github.com"
+      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: reflect-asset: https:; font-src 'self' data:; frame-src 'self' https://platform.twitter.com https://platform.x.com https://syndication.twitter.com https://www.youtube-nocookie.com https://www.youtube.com; connect-src 'self' ipc: http://ipc.localhost https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://openrouter.ai https://github.com https://api.github.com https://o463484.ingest.us.sentry.io"
     }
   },
   "plugins": {

--- a/apps/desktop/src/lib/sentry-privacy.test.ts
+++ b/apps/desktop/src/lib/sentry-privacy.test.ts
@@ -36,6 +36,8 @@ describe('Sentry privacy scrubber', () => {
                 {
                   filename: 'assets/index.js',
                   function: 'renderEditor',
+                  module: 'Users.alex.reflect-open.editor',
+                  abs_path: '/Users/alex/notes/secret-note/assets/index.js',
                   lineno: 10,
                   colno: 4,
                   context_line: 'const note = "secret note text"',
@@ -67,7 +69,10 @@ describe('Sentry privacy scrubber', () => {
     expect(scrubbed.sdkProcessingMetadata).toBeUndefined()
     expect(scrubbed.exception?.values?.[0]?.type).toBeUndefined()
     expect(scrubbed.exception?.values?.[0]?.value).toBeUndefined()
-    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.filename).toBe('assets/index.js')
+    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.filename).toBeUndefined()
+    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.abs_path).toBeUndefined()
+    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.module).toBeUndefined()
+    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.function).toBe('renderEditor')
     expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.context_line).toBeUndefined()
     expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.pre_context).toBeUndefined()
     expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.post_context).toBeUndefined()

--- a/apps/desktop/src/lib/sentry-privacy.test.ts
+++ b/apps/desktop/src/lib/sentry-privacy.test.ts
@@ -65,7 +65,7 @@ describe('Sentry privacy scrubber', () => {
     expect(scrubbed.server_name).toBeUndefined()
     expect(scrubbed.contexts).toBeUndefined()
     expect(scrubbed.sdkProcessingMetadata).toBeUndefined()
-    expect(scrubbed.exception?.values?.[0]?.type).toBe('Error')
+    expect(scrubbed.exception?.values?.[0]?.type).toBeUndefined()
     expect(scrubbed.exception?.values?.[0]?.value).toBeUndefined()
     expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.filename).toBe('assets/index.js')
     expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.context_line).toBeUndefined()

--- a/apps/desktop/src/lib/sentry-privacy.test.ts
+++ b/apps/desktop/src/lib/sentry-privacy.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { dropSentryBreadcrumb, scrubSentryEventForPrivacy } from './sentry-privacy'
+
+describe('Sentry privacy scrubber', () => {
+  it('drops free-form event fields that could contain note content', () => {
+    const scrubbed = scrubSentryEventForPrivacy({
+      type: undefined,
+      message: 'secret note text',
+      logentry: { message: 'secret note text' },
+      release: 'reflect@1.0.0',
+      environment: 'production',
+      request: { url: 'tauri://localhost/notes/secret-note?body=secret' },
+      breadcrumbs: [{ message: 'secret note text', category: 'console' }],
+      extra: { markdown: 'secret note text' },
+      user: { email: 'person@example.com' },
+      transaction: 'notes/secret-note',
+      tags: { note: 'secret-note' },
+      fingerprint: ['secret-note'],
+      server_name: 'Alexs-MacBook',
+      contexts: {
+        app: { app_name: 'Reflect' },
+        device: { model: 'Mac' },
+        os: { name: 'macOS' },
+        culture: { locale: 'en-GB' },
+        trace: { span_id: '0123456789abcdef', trace_id: '0123456789abcdef0123456789abcdef' },
+        note: { markdown: 'secret note text' },
+      },
+      sdkProcessingMetadata: { note: 'secret note text' },
+      exception: {
+        values: [
+          {
+            type: 'Error',
+            value: 'secret note text',
+            stacktrace: {
+              frames: [
+                {
+                  filename: 'assets/index.js',
+                  function: 'renderEditor',
+                  lineno: 10,
+                  colno: 4,
+                  context_line: 'const note = "secret note text"',
+                  pre_context: ['secret note text'],
+                  post_context: ['secret note text'],
+                  vars: { note: 'secret note text' },
+                  module_metadata: { note: 'secret note text' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    })
+
+    expect(scrubbed.release).toBe('reflect@1.0.0')
+    expect(scrubbed.environment).toBe('production')
+    expect(scrubbed.message).toBeUndefined()
+    expect(scrubbed.logentry).toBeUndefined()
+    expect(scrubbed.request).toBeUndefined()
+    expect(scrubbed.breadcrumbs).toBeUndefined()
+    expect(scrubbed.extra).toBeUndefined()
+    expect(scrubbed.user).toBeUndefined()
+    expect(scrubbed.transaction).toBeUndefined()
+    expect(scrubbed.tags).toBeUndefined()
+    expect(scrubbed.fingerprint).toBeUndefined()
+    expect(scrubbed.server_name).toBeUndefined()
+    expect(scrubbed.contexts).toBeUndefined()
+    expect(scrubbed.sdkProcessingMetadata).toBeUndefined()
+    expect(scrubbed.exception?.values?.[0]?.type).toBe('Error')
+    expect(scrubbed.exception?.values?.[0]?.value).toBeUndefined()
+    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.filename).toBe('assets/index.js')
+    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.context_line).toBeUndefined()
+    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.pre_context).toBeUndefined()
+    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.post_context).toBeUndefined()
+    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.vars).toBeUndefined()
+    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.module_metadata).toBeUndefined()
+  })
+
+  it('drops every breadcrumb before it can be attached to an event', () => {
+    expect(dropSentryBreadcrumb({ message: 'secret note text', category: 'console' })).toBeNull()
+  })
+})

--- a/apps/desktop/src/lib/sentry-privacy.test.ts
+++ b/apps/desktop/src/lib/sentry-privacy.test.ts
@@ -26,6 +26,20 @@ describe('Sentry privacy scrubber', () => {
         note: { markdown: 'secret note text' },
       },
       sdkProcessingMetadata: { note: 'secret note text' },
+      debug_meta: {
+        images: [
+          {
+            type: 'sourcemap',
+            code_file: 'tauri://localhost/assets/index.js?note=secret-note#selection',
+            debug_id: '11111111-1111-4111-8111-111111111111',
+          },
+          {
+            type: 'sourcemap',
+            code_file: 'notes/secret-note.md',
+            debug_id: '22222222-2222-4222-8222-222222222222',
+          },
+        ],
+      },
       exception: {
         values: [
           {
@@ -34,7 +48,7 @@ describe('Sentry privacy scrubber', () => {
             stacktrace: {
               frames: [
                 {
-                  filename: 'assets/index.js',
+                  filename: 'assets/index.js?note=secret-note#selection',
                   function: 'renderEditor',
                   module: 'Users.alex.reflect-open.editor',
                   abs_path: '/Users/alex/notes/secret-note/assets/index.js',
@@ -69,8 +83,8 @@ describe('Sentry privacy scrubber', () => {
     expect(scrubbed.sdkProcessingMetadata).toBeUndefined()
     expect(scrubbed.exception?.values?.[0]?.type).toBeUndefined()
     expect(scrubbed.exception?.values?.[0]?.value).toBeUndefined()
-    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.filename).toBeUndefined()
-    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.abs_path).toBeUndefined()
+    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.filename).toBe('assets/index.js')
+    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.abs_path).toBe('app:///assets/index.js')
     expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.module).toBeUndefined()
     expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.function).toBe('renderEditor')
     expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.context_line).toBeUndefined()
@@ -78,6 +92,69 @@ describe('Sentry privacy scrubber', () => {
     expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.post_context).toBeUndefined()
     expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.vars).toBeUndefined()
     expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.module_metadata).toBeUndefined()
+    expect(scrubbed.debug_meta?.images).toEqual([
+      {
+        type: 'sourcemap',
+        code_file: 'tauri://localhost/assets/index.js',
+        debug_id: '11111111-1111-4111-8111-111111111111',
+      },
+    ])
+  })
+
+  it('keeps Sentry source map asset paths while removing URL payloads', () => {
+    const scrubbed = scrubSentryEventForPrivacy({
+      type: undefined,
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  filename: 'tauri://localhost/assets/index-abc123.js?note=secret#text',
+                  abs_path: 'http://localhost:1420/assets/index-abc123.js?note=secret#text',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    })
+
+    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.filename).toBe(
+      'tauri://localhost/assets/index-abc123.js',
+    )
+    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.abs_path).toBe(
+      'http://localhost:1420/assets/index-abc123.js',
+    )
+  })
+
+  it('drops unknown stack frame paths instead of guessing whether they are safe', () => {
+    const scrubbed = scrubSentryEventForPrivacy({
+      type: undefined,
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  filename: 'notes/secret-note.md',
+                  abs_path: 'reflect://graph/notes/secret-note.md',
+                },
+                {
+                  filename: 'app:///notes/secret-note.md',
+                  abs_path: 'http://localhost:1420/notes/secret-note.md',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    })
+
+    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.filename).toBeUndefined()
+    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.abs_path).toBeUndefined()
+    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[1]?.filename).toBeUndefined()
+    expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[1]?.abs_path).toBeUndefined()
   })
 
   it('drops every breadcrumb before it can be attached to an event', () => {

--- a/apps/desktop/src/lib/sentry-privacy.test.ts
+++ b/apps/desktop/src/lib/sentry-privacy.test.ts
@@ -45,6 +45,12 @@ describe('Sentry privacy scrubber', () => {
           {
             type: 'Error',
             value: 'secret note text',
+            module: 'notes.secret-note',
+            mechanism: {
+              type: 'react',
+              handled: true,
+              data: { componentStack: 'secret note text' },
+            },
             stacktrace: {
               frames: [
                 {
@@ -83,6 +89,8 @@ describe('Sentry privacy scrubber', () => {
     expect(scrubbed.sdkProcessingMetadata).toBeUndefined()
     expect(scrubbed.exception?.values?.[0]?.type).toBeUndefined()
     expect(scrubbed.exception?.values?.[0]?.value).toBeUndefined()
+    expect(scrubbed.exception?.values?.[0]?.module).toBeUndefined()
+    expect(scrubbed.exception?.values?.[0]?.mechanism).toBeUndefined()
     expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.filename).toBe('assets/index.js')
     expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.abs_path).toBe('app:///assets/index.js')
     expect(scrubbed.exception?.values?.[0]?.stacktrace?.frames?.[0]?.module).toBeUndefined()

--- a/apps/desktop/src/lib/sentry-privacy.ts
+++ b/apps/desktop/src/lib/sentry-privacy.ts
@@ -1,0 +1,56 @@
+import type { init } from '@sentry/react'
+
+type SentryInitOptions = NonNullable<Parameters<typeof init>[0]>
+type BeforeSend = NonNullable<SentryInitOptions['beforeSend']>
+type SentryErrorEvent = Parameters<BeforeSend>[0]
+type SentryException = NonNullable<NonNullable<SentryErrorEvent['exception']>['values']>[number]
+
+export const dropSentryBreadcrumb: NonNullable<SentryInitOptions['beforeBreadcrumb']> = () => null
+
+export function scrubSentryEventForPrivacy(event: SentryErrorEvent): SentryErrorEvent {
+  const scrubbed: SentryErrorEvent = { ...event }
+
+  delete scrubbed.message
+  delete scrubbed.logentry
+  delete scrubbed.request
+  delete scrubbed.breadcrumbs
+  delete scrubbed.extra
+  delete scrubbed.user
+  delete scrubbed.transaction
+  delete scrubbed.tags
+  delete scrubbed.fingerprint
+  delete scrubbed.server_name
+  delete scrubbed.spans
+  delete scrubbed.measurements
+  delete scrubbed.threads
+  delete scrubbed.contexts
+  delete scrubbed.sdkProcessingMetadata
+
+  if (scrubbed.exception?.values) {
+    scrubbed.exception = {
+      values: scrubbed.exception.values.map(scrubException),
+    }
+  }
+
+  return scrubbed
+}
+
+function scrubException(exception: SentryException): SentryException {
+  const scrubbed = { ...exception }
+  delete scrubbed.value
+  if (scrubbed.stacktrace?.frames) {
+    scrubbed.stacktrace = {
+      ...scrubbed.stacktrace,
+      frames: scrubbed.stacktrace.frames.map((frame) => {
+        const scrubbedFrame = { ...frame }
+        delete scrubbedFrame.context_line
+        delete scrubbedFrame.pre_context
+        delete scrubbedFrame.post_context
+        delete scrubbedFrame.vars
+        delete scrubbedFrame.module_metadata
+        return scrubbedFrame
+      }),
+    }
+  }
+  return scrubbed
+}

--- a/apps/desktop/src/lib/sentry-privacy.ts
+++ b/apps/desktop/src/lib/sentry-privacy.ts
@@ -32,7 +32,8 @@ export const dropSentryBreadcrumb: NonNullable<SentryInitOptions['beforeBreadcru
  *
  * This keeps release/environment metadata and sanitized stack-frame structure, while stripping
  * messages, breadcrumbs, request data, user data, custom contexts, tags, transaction names,
- * exception type/value text, frame source snippets, frame locals, and local filesystem paths.
+ * exception type/value/mechanism text, frame source snippets, frame locals, and local filesystem
+ * paths.
  */
 export function scrubSentryEventForPrivacy(event: SentryErrorEvent): SentryErrorEvent {
   const scrubbed: SentryErrorEvent = { ...event }
@@ -75,6 +76,8 @@ function scrubException(exception: SentryException): SentryException {
   const scrubbed = { ...exception }
   delete scrubbed.type
   delete scrubbed.value
+  delete scrubbed.mechanism
+  delete scrubbed.module
   if (scrubbed.stacktrace?.frames) {
     scrubbed.stacktrace = {
       ...scrubbed.stacktrace,

--- a/apps/desktop/src/lib/sentry-privacy.ts
+++ b/apps/desktop/src/lib/sentry-privacy.ts
@@ -5,8 +5,16 @@ type BeforeSend = NonNullable<SentryInitOptions['beforeSend']>
 type SentryErrorEvent = Parameters<BeforeSend>[0]
 type SentryException = NonNullable<NonNullable<SentryErrorEvent['exception']>['values']>[number]
 
+/** Sentry beforeBreadcrumb hook that drops all breadcrumbs before note text can enter an event. */
 export const dropSentryBreadcrumb: NonNullable<SentryInitOptions['beforeBreadcrumb']> = () => null
 
+/**
+ * Sentry beforeSend hook that removes free-form event fields before an error leaves the app.
+ *
+ * This keeps release/environment metadata and sanitized stack-frame structure, while stripping
+ * messages, breadcrumbs, request data, user data, custom contexts, tags, transaction names,
+ * exception type/value text, frame source snippets, frame locals, and frame paths.
+ */
 export function scrubSentryEventForPrivacy(event: SentryErrorEvent): SentryErrorEvent {
   const scrubbed: SentryErrorEvent = { ...event }
 
@@ -44,6 +52,9 @@ function scrubException(exception: SentryException): SentryException {
       ...scrubbed.stacktrace,
       frames: scrubbed.stacktrace.frames.map((frame) => {
         const scrubbedFrame = { ...frame }
+        delete scrubbedFrame.filename
+        delete scrubbedFrame.abs_path
+        delete scrubbedFrame.module
         delete scrubbedFrame.context_line
         delete scrubbedFrame.pre_context
         delete scrubbedFrame.post_context

--- a/apps/desktop/src/lib/sentry-privacy.ts
+++ b/apps/desktop/src/lib/sentry-privacy.ts
@@ -4,6 +4,25 @@ type SentryInitOptions = NonNullable<Parameters<typeof init>[0]>
 type BeforeSend = NonNullable<SentryInitOptions['beforeSend']>
 type SentryErrorEvent = Parameters<BeforeSend>[0]
 type SentryException = NonNullable<NonNullable<SentryErrorEvent['exception']>['values']>[number]
+type SentryFrame = NonNullable<NonNullable<SentryException['stacktrace']>['frames']>[number]
+type SentryDebugImage = NonNullable<NonNullable<SentryErrorEvent['debug_meta']>['images']>[number]
+
+const LOCAL_PATH_PATTERNS = [
+  /^file:\/\//i,
+  /^\/(?:Users|home|private|var|tmp)\//i,
+  /^[A-Z]:[\\/]/i,
+  /[\\/]Reflect[\\/]/,
+  /[\\.]reflect[\\/]/,
+]
+
+const APP_ASSET_PATH_PATTERNS = [
+  /^app:\/\/\/assets\//i,
+  /^tauri:\/\/[^/]*\/assets\//i,
+  /^https?:\/\/(?:localhost|127\.0\.0\.1|tauri\.localhost)(?::\d+)?\/assets\//i,
+  /^\/?assets\//i,
+]
+
+const LOCAL_ASSET_PATTERN = /(?:^|[\\/])assets[\\/](?<assetPath>[^?#]+)$/i
 
 /** Sentry beforeBreadcrumb hook that drops all breadcrumbs before note text can enter an event. */
 export const dropSentryBreadcrumb: NonNullable<SentryInitOptions['beforeBreadcrumb']> = () => null
@@ -13,7 +32,7 @@ export const dropSentryBreadcrumb: NonNullable<SentryInitOptions['beforeBreadcru
  *
  * This keeps release/environment metadata and sanitized stack-frame structure, while stripping
  * messages, breadcrumbs, request data, user data, custom contexts, tags, transaction names,
- * exception type/value text, frame source snippets, frame locals, and frame paths.
+ * exception type/value text, frame source snippets, frame locals, and local filesystem paths.
  */
 export function scrubSentryEventForPrivacy(event: SentryErrorEvent): SentryErrorEvent {
   const scrubbed: SentryErrorEvent = { ...event }
@@ -40,6 +59,15 @@ export function scrubSentryEventForPrivacy(event: SentryErrorEvent): SentryError
     }
   }
 
+  if (scrubbed.debug_meta?.images) {
+    const images = scrubbed.debug_meta.images.map(scrubDebugImage).filter(isSentryDebugImage)
+    if (images.length > 0) {
+      scrubbed.debug_meta = { ...scrubbed.debug_meta, images }
+    } else {
+      delete scrubbed.debug_meta
+    }
+  }
+
   return scrubbed
 }
 
@@ -50,19 +78,67 @@ function scrubException(exception: SentryException): SentryException {
   if (scrubbed.stacktrace?.frames) {
     scrubbed.stacktrace = {
       ...scrubbed.stacktrace,
-      frames: scrubbed.stacktrace.frames.map((frame) => {
-        const scrubbedFrame = { ...frame }
-        delete scrubbedFrame.filename
-        delete scrubbedFrame.abs_path
-        delete scrubbedFrame.module
-        delete scrubbedFrame.context_line
-        delete scrubbedFrame.pre_context
-        delete scrubbedFrame.post_context
-        delete scrubbedFrame.vars
-        delete scrubbedFrame.module_metadata
-        return scrubbedFrame
-      }),
+      frames: scrubbed.stacktrace.frames.map(scrubStackFrame),
     }
   }
   return scrubbed
+}
+
+function scrubDebugImage(image: SentryDebugImage): SentryDebugImage | undefined {
+  if (!('code_file' in image) || !image.code_file) {
+    return image
+  }
+
+  const codeFile = normalizeStackFramePath(image.code_file)
+  return codeFile ? { ...image, code_file: codeFile } : undefined
+}
+
+function isSentryDebugImage(image: SentryDebugImage | undefined): image is SentryDebugImage {
+  return image !== undefined
+}
+
+function scrubStackFrame(frame: SentryFrame): SentryFrame {
+  const scrubbed = { ...frame }
+  applyNormalizedStackFramePath(scrubbed, 'filename')
+  applyNormalizedStackFramePath(scrubbed, 'abs_path')
+  delete scrubbed.module
+  delete scrubbed.context_line
+  delete scrubbed.pre_context
+  delete scrubbed.post_context
+  delete scrubbed.vars
+  delete scrubbed.module_metadata
+  return scrubbed
+}
+
+function applyNormalizedStackFramePath(frame: SentryFrame, field: 'filename' | 'abs_path'): void {
+  const normalizedPath = normalizeStackFramePath(frame[field])
+  if (normalizedPath) {
+    frame[field] = normalizedPath
+    return
+  }
+
+  delete frame[field]
+}
+
+function normalizeStackFramePath(path: string | undefined): string | undefined {
+  if (!path) {
+    return undefined
+  }
+
+  const strippedPath = stripQueryAndHash(path)
+  if (APP_ASSET_PATH_PATTERNS.some((pattern) => pattern.test(strippedPath))) {
+    return strippedPath
+  }
+
+  if (LOCAL_PATH_PATTERNS.some((pattern) => pattern.test(strippedPath))) {
+    const assetPath = LOCAL_ASSET_PATTERN.exec(strippedPath)?.groups?.['assetPath']
+    return assetPath ? `app:///assets/${assetPath.replaceAll('\\', '/')}` : undefined
+  }
+
+  return undefined
+}
+
+function stripQueryAndHash(path: string): string {
+  const queryIndex = path.search(/[?#]/)
+  return queryIndex === -1 ? path : path.slice(0, queryIndex)
 }

--- a/apps/desktop/src/lib/sentry-privacy.ts
+++ b/apps/desktop/src/lib/sentry-privacy.ts
@@ -37,6 +37,7 @@ export function scrubSentryEventForPrivacy(event: SentryErrorEvent): SentryError
 
 function scrubException(exception: SentryException): SentryException {
   const scrubbed = { ...exception }
+  delete scrubbed.type
   delete scrubbed.value
   if (scrubbed.stacktrace?.frames) {
     scrubbed.stacktrace = {

--- a/apps/desktop/src/lib/sentry.ts
+++ b/apps/desktop/src/lib/sentry.ts
@@ -3,12 +3,14 @@ import { init } from '@sentry/react'
 const DEFAULT_DSN =
   'https://91e35d9c7b2d0a1898bc9574c6a6f3f2@o463484.ingest.us.sentry.io/4511705649971200'
 
-const enabled =
-  import.meta.env.VITE_SENTRY_ENABLED === 'true' ||
-  (import.meta.env.PROD && import.meta.env.VITE_SENTRY_ENABLED !== 'false')
+const dsn =
+  import.meta.env.VITE_SENTRY_DSN ||
+  (import.meta.env.VITE_SENTRY_ENABLED === 'true' ? DEFAULT_DSN : '')
+
+const enabled = dsn.length > 0 && import.meta.env.VITE_SENTRY_ENABLED !== 'false'
 
 init({
-  dsn: import.meta.env.VITE_SENTRY_DSN || DEFAULT_DSN,
+  dsn,
   enabled,
   environment: import.meta.env.MODE,
   release: import.meta.env.VITE_SENTRY_RELEASE || undefined,

--- a/apps/desktop/src/lib/sentry.ts
+++ b/apps/desktop/src/lib/sentry.ts
@@ -1,4 +1,5 @@
 import { init } from '@sentry/react'
+import { dropSentryBreadcrumb, scrubSentryEventForPrivacy } from '@/lib/sentry-privacy'
 
 const DEFAULT_DSN =
   'https://91e35d9c7b2d0a1898bc9574c6a6f3f2@o463484.ingest.us.sentry.io/4511705649971200'
@@ -15,6 +16,8 @@ init({
   environment: import.meta.env.MODE,
   release: import.meta.env.VITE_SENTRY_RELEASE || undefined,
   debug: import.meta.env.DEV && import.meta.env.VITE_SENTRY_DEBUG === 'true',
+  maxBreadcrumbs: 0,
+  enableLogs: false,
   dataCollection: {
     userInfo: false,
     cookies: false,
@@ -22,5 +25,11 @@ init({
     httpBodies: [],
     queryParams: false,
     genAI: { inputs: false, outputs: false },
+    stackFrameVariables: false,
+    frameContextLines: 0,
   },
+  beforeBreadcrumb: dropSentryBreadcrumb,
+  beforeSend: scrubSentryEventForPrivacy,
+  beforeSendLog: () => null,
+  beforeSendTransaction: () => null,
 })

--- a/apps/desktop/src/lib/sentry.ts
+++ b/apps/desktop/src/lib/sentry.ts
@@ -1,0 +1,24 @@
+import { init } from '@sentry/react'
+
+const DEFAULT_DSN =
+  'https://91e35d9c7b2d0a1898bc9574c6a6f3f2@o463484.ingest.us.sentry.io/4511705649971200'
+
+const enabled =
+  import.meta.env.VITE_SENTRY_ENABLED === 'true' ||
+  (import.meta.env.PROD && import.meta.env.VITE_SENTRY_ENABLED !== 'false')
+
+init({
+  dsn: import.meta.env.VITE_SENTRY_DSN || DEFAULT_DSN,
+  enabled,
+  environment: import.meta.env.MODE,
+  release: import.meta.env.VITE_SENTRY_RELEASE || undefined,
+  debug: import.meta.env.DEV && import.meta.env.VITE_SENTRY_DEBUG === 'true',
+  dataCollection: {
+    userInfo: false,
+    cookies: false,
+    httpHeaders: { request: false, response: false },
+    httpBodies: [],
+    queryParams: false,
+    genAI: { inputs: false, outputs: false },
+  },
+})

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1,5 +1,7 @@
+import '@/lib/sentry'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { reactErrorHandler } from '@sentry/react'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { queryClient } from '@/lib/query-client'
 import { registerAppCommands } from '@/lib/commands/app-commands'
@@ -10,6 +12,16 @@ import { EditorTextSizeEffect } from '@/providers/editor-text-size'
 import { SettingsProvider } from '@/providers/settings-provider'
 import { ThemeProvider } from '@/providers/theme-provider'
 import '@/styles/index.css'
+
+interface ReactRootErrorInfo {
+  readonly componentStack?: string | undefined
+}
+
+const sentryReactErrorHandler = reactErrorHandler()
+
+function handleReactRootError(error: unknown, info: ReactRootErrorInfo): void {
+  sentryReactErrorHandler(error, { componentStack: info.componentStack ?? null })
+}
 
 installTauriBridge()
 // Start the platform resolve + surface-chunk fetch (and, on mobile, the
@@ -29,7 +41,11 @@ if (!rootElement) {
 // Platform-neutral providers only — everything desktop- or mobile-specific
 // (update checks, drag region, graph bootstrap mode) lives inside the lazy
 // trees behind the PlatformRoot gate (Plan 19).
-createRoot(rootElement).render(
+createRoot(rootElement, {
+  onUncaughtError: handleReactRootError,
+  onCaughtError: handleReactRootError,
+  onRecoverableError: handleReactRootError,
+}).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <SettingsProvider>

--- a/apps/desktop/src/vite-env.d.ts
+++ b/apps/desktop/src/vite-env.d.ts
@@ -1,6 +1,11 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  readonly VITE_SENTRY_DEBUG?: string
+  readonly VITE_SENTRY_DSN?: string
+  readonly VITE_SENTRY_ENABLED?: string
+  readonly VITE_SENTRY_RELEASE?: string
+
   /**
    * Build-target platform injected by the Tauri CLI (`darwin`, `windows`,
    * `linux`, `ios`, `android`). Absent in plain Vite builds and tests.

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -10,69 +10,74 @@ const host = process.env.TAURI_DEV_HOST
 const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN
 // @ts-expect-error process is a Node.js global available in the Vite config context
 const sentryRelease = process.env.SENTRY_RELEASE ?? process.env.VITE_SENTRY_RELEASE ?? process.env.GITHUB_SHA
-// @ts-expect-error process is a Node.js global available in the Vite config context
-const sentryEnabled = process.env.VITE_SENTRY_ENABLED ?? (sentryAuthToken ? 'true' : '')
 
 // https://vite.dev/config/
-export default defineConfig(async () => ({
-  plugins: [
-    reactWithCompiler(),
-    tailwindcss(),
-    sentryAuthToken
-      ? sentryVitePlugin({
-          org: 'reflect-64',
-          project: 'reflect-open',
-          authToken: sentryAuthToken,
-          telemetry: false,
-          ...(sentryRelease ? { release: { name: sentryRelease } } : {}),
-        })
-      : null,
-  ],
+export default defineConfig(async ({ command, mode }) => {
+  // @ts-expect-error process is a Node.js global available in the Vite config context
+  const sentryEnabled =
+    process.env.VITE_SENTRY_ENABLED ??
+    (sentryAuthToken && command === 'build' && mode === 'production' ? 'true' : '')
 
-  // If the target is below Safari 17.5, Lightning CSS downlevels `light-dark()` to a broken polyfill.
-  build: { cssTarget: 'safari17.5', sourcemap: true },
+  return {
+    plugins: [
+      reactWithCompiler(),
+      tailwindcss(),
+      sentryAuthToken && command === 'build'
+        ? sentryVitePlugin({
+            org: 'reflect-64',
+            project: 'reflect-open',
+            authToken: sentryAuthToken,
+            telemetry: false,
+            ...(sentryRelease ? { release: { name: sentryRelease } } : {}),
+          })
+        : null,
+    ],
 
-  define: {
-    'import.meta.env.VITE_SENTRY_ENABLED': JSON.stringify(sentryEnabled),
-    'import.meta.env.VITE_SENTRY_RELEASE': JSON.stringify(sentryRelease ?? ''),
-  },
+    // If the target is below Safari 17.5, Lightning CSS downlevels `light-dark()` to a broken polyfill.
+    build: { cssTarget: 'safari17.5', sourcemap: true },
 
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    define: {
+      'import.meta.env.VITE_SENTRY_ENABLED': JSON.stringify(sentryEnabled),
+      'import.meta.env.VITE_SENTRY_RELEASE': JSON.stringify(sentryRelease ?? ''),
     },
-  },
 
-  // Expose the Tauri CLI's build-time TAURI_ENV_* vars (e.g. the target
-  // platform, which gates desktop-only surfaces like the updater).
-  envPrefix: ['VITE_', 'TAURI_ENV_'],
-
-  // The dev bridge's SQLite (dev-only, behind `?platform=ios`) locates its
-  // .wasm relative to its own module URL; esbuild pre-bundling would relocate
-  // the module into .vite/deps and break that lookup.
-  optimizeDeps: {
-    exclude: ['@sqlite.org/sqlite-wasm'],
-  },
-
-  // Vite options tailored for Tauri development, applied in `tauri dev`/`tauri build`.
-  //
-  // 1. prevent Vite from obscuring Rust errors
-  clearScreen: false,
-  // 2. Tauri expects a fixed port; fail if it is not available
-  server: {
-    port: 1420,
-    strictPort: true,
-    host: host || false,
-    hmr: host
-      ? {
-          protocol: 'ws',
-          host,
-          port: 1421,
-        }
-      : undefined,
-    watch: {
-      // 3. tell Vite to ignore watching `src-tauri`
-      ignored: ['**/src-tauri/**'],
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+      },
     },
-  },
-}))
+
+    // Expose the Tauri CLI's build-time TAURI_ENV_* vars (e.g. the target
+    // platform, which gates desktop-only surfaces like the updater).
+    envPrefix: ['VITE_', 'TAURI_ENV_'],
+
+    // The dev bridge's SQLite (dev-only, behind `?platform=ios`) locates its
+    // .wasm relative to its own module URL; esbuild pre-bundling would relocate
+    // the module into .vite/deps and break that lookup.
+    optimizeDeps: {
+      exclude: ['@sqlite.org/sqlite-wasm'],
+    },
+
+    // Vite options tailored for Tauri development, applied in `tauri dev`/`tauri build`.
+    //
+    // 1. prevent Vite from obscuring Rust errors
+    clearScreen: false,
+    // 2. Tauri expects a fixed port; fail if it is not available
+    server: {
+      port: 1420,
+      strictPort: true,
+      host: host || false,
+      hmr: host
+        ? {
+            protocol: 'ws',
+            host,
+            port: 1421,
+          }
+        : undefined,
+      watch: {
+        // 3. tell Vite to ignore watching `src-tauri`
+        ignored: ['**/src-tauri/**'],
+      },
+    },
+  }
+})

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -10,6 +10,8 @@ const host = process.env.TAURI_DEV_HOST
 const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN
 // @ts-expect-error process is a Node.js global available in the Vite config context
 const sentryRelease = process.env.SENTRY_RELEASE ?? process.env.VITE_SENTRY_RELEASE ?? process.env.GITHUB_SHA
+// @ts-expect-error process is a Node.js global available in the Vite config context
+const sentryEnabled = process.env.VITE_SENTRY_ENABLED ?? (sentryAuthToken ? 'true' : '')
 
 // https://vite.dev/config/
 export default defineConfig(async () => ({
@@ -31,6 +33,7 @@ export default defineConfig(async () => ({
   build: { cssTarget: 'safari17.5', sourcemap: true },
 
   define: {
+    'import.meta.env.VITE_SENTRY_ENABLED': JSON.stringify(sentryEnabled),
     'import.meta.env.VITE_SENTRY_RELEASE': JSON.stringify(sentryRelease ?? ''),
   },
 

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,17 +1,38 @@
 import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
+import { sentryVitePlugin } from '@sentry/vite-plugin'
 import tailwindcss from '@tailwindcss/vite'
 import { reactWithCompiler } from './react-compiler-plugin'
 
 // @ts-expect-error process is a Node.js global available in the Vite config context
 const host = process.env.TAURI_DEV_HOST
+// @ts-expect-error process is a Node.js global available in the Vite config context
+const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN
+// @ts-expect-error process is a Node.js global available in the Vite config context
+const sentryRelease = process.env.SENTRY_RELEASE ?? process.env.VITE_SENTRY_RELEASE ?? process.env.GITHUB_SHA
 
 // https://vite.dev/config/
 export default defineConfig(async () => ({
-  plugins: [reactWithCompiler(), tailwindcss()],
+  plugins: [
+    reactWithCompiler(),
+    tailwindcss(),
+    sentryAuthToken
+      ? sentryVitePlugin({
+          org: 'reflect-64',
+          project: 'reflect-open',
+          authToken: sentryAuthToken,
+          telemetry: false,
+          ...(sentryRelease ? { release: { name: sentryRelease } } : {}),
+        })
+      : null,
+  ],
 
   // If the target is below Safari 17.5, Lightning CSS downlevels `light-dark()` to a broken polyfill.
-  build: { cssTarget: 'safari17.5' },
+  build: { cssTarget: 'safari17.5', sourcemap: true },
+
+  define: {
+    'import.meta.env.VITE_SENTRY_RELEASE': JSON.stringify(sentryRelease ?? ''),
+  },
 
   resolve: {
     alias: {

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -75,10 +75,10 @@ disk at call time), and it is covered by tests.
   source-map debug IDs, release, environment, and SDK metadata. Before an event leaves
   the app, Reflect strips free-form event messages, breadcrumbs, request data, custom
   extras, user data, tags, transaction names, exception messages, event contexts,
-  stack-frame variables, source context lines, and local filesystem paths. App bundle
-  URLs in stack frames and source-map metadata are kept only after query strings and
-  fragments are removed, so source maps can still make stack traces readable. It also
-  disables Sentry user identity
+  exception mechanism data, stack-frame variables, source context lines, and local
+  filesystem paths. App bundle URLs in stack frames and source-map metadata are kept
+  only after query strings and fragments are removed, so source maps can still make
+  stack traces readable. It also disables Sentry user identity
   collection, cookies, query params, HTTP header and body capture, and generative-AI
   input/output capture. Session Replay is not enabled.
 - **When:** automatically in official production builds when the React app throws,

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -71,8 +71,8 @@ disk at call time), and it is covered by tests.
 ## Error diagnostics
 
 - **Where:** Sentry (`o463484.ingest.us.sentry.io`).
-- **What:** JavaScript error reports from the packaged app: stack traces, exception
-  type, release, environment, and SDK metadata. Before an event leaves the app,
+- **What:** JavaScript error reports from the packaged app: stack traces, release,
+  environment, and SDK metadata. Before an event leaves the app,
   Reflect strips free-form event messages, breadcrumbs, request data, custom extras,
   user data, tags, transaction names, exception messages, event contexts, stack-frame
   variables, and source context lines. It also disables Sentry user identity

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -76,9 +76,9 @@ disk at call time), and it is covered by tests.
   breadcrumbs that help explain how the app reached the failure. Reflect disables
   Sentry user identity collection, cookies, query params, HTTP header and body
   capture, and generative-AI input/output capture. Session Replay is not enabled.
-- **When:** automatically in production builds when the React app throws, catches, or
-  recovers from an error. Development builds send diagnostics only when explicitly
-  enabled for that build.
+- **When:** automatically in official production builds when the React app throws,
+  catches, or recovers from an error. Development builds and third-party source builds
+  send diagnostics only when explicitly configured for that build.
 
 ## Apple Contacts (off by default)
 
@@ -122,7 +122,7 @@ API keys and tokens live in the **OS keychain only** — never in markdown, neve
 | Model download | Hugging Face | No | Yes (opt-in) |
 | Backup | Your git repository | Yes — including private notes | Yes (needs connecting) |
 | Key validation | The provider | No | — (only when adding a key) |
-| Error diagnostics | Sentry | Not intentionally — error metadata only | No (packaged builds) |
+| Error diagnostics | Sentry | Not intentionally — error metadata only | Official builds: no; source builds: yes |
 | Update check | GitHub Releases | No | On in packaged builds |
 | Browser capture | Nowhere (local host on disk) | — (stays on your machine) | — (only when you capture) |
 | Contacts lookup | Nowhere (on-device OS store) | — (stays on your machine) | Yes (opt-in) |

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -71,11 +71,13 @@ disk at call time), and it is covered by tests.
 ## Error diagnostics
 
 - **Where:** Sentry (`o463484.ingest.us.sentry.io`).
-- **What:** JavaScript error reports from the packaged app: stack traces, release and
-  environment tags, React component stacks, browser/WebView metadata, and recent
-  breadcrumbs that help explain how the app reached the failure. Reflect disables
-  Sentry user identity collection, cookies, query params, HTTP header and body
-  capture, and generative-AI input/output capture. Session Replay is not enabled.
+- **What:** JavaScript error reports from the packaged app: stack traces, exception
+  type, release, environment, and SDK metadata. Before an event leaves the app,
+  Reflect strips free-form event messages, breadcrumbs, request data, custom extras,
+  user data, tags, transaction names, exception messages, event contexts, stack-frame
+  variables, and source context lines. It also disables Sentry user identity
+  collection, cookies, query params, HTTP header and body capture, and generative-AI
+  input/output capture. Session Replay is not enabled.
 - **When:** automatically in official production builds when the React app throws,
   catches, or recovers from an error. Development builds and third-party source builds
   send diagnostics only when explicitly configured for that build.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -2,8 +2,8 @@
 
 Reflect is local-first: your notes are markdown files in a folder you chose, the search
 index is SQLite in `.reflect/` beside them, and **no Reflect-hosted server exists in any
-path** — there is no telemetry, no analytics, and no account. Every network call the app
-can make is listed here, with what it carries.
+path**. There is no Reflect account, and every network call the app can make is listed
+here, with what it carries.
 
 The one hard rule sits above all of it: **a note with `private: true` frontmatter never
 has its content sent to any external service.** This is enforced in code at every AI
@@ -68,6 +68,18 @@ disk at call time), and it is covered by tests.
   any BYOK AI enrichment of it honors `private: true`, and no content leaves the device
   except through the calls listed here.
 
+## Error diagnostics
+
+- **Where:** Sentry (`o463484.ingest.us.sentry.io`).
+- **What:** JavaScript error reports from the packaged app: stack traces, release and
+  environment tags, React component stacks, browser/WebView metadata, and recent
+  breadcrumbs that help explain how the app reached the failure. Reflect disables
+  Sentry user identity collection, cookies, query params, HTTP header and body
+  capture, and generative-AI input/output capture. Session Replay is not enabled.
+- **When:** automatically in production builds when the React app throws, catches, or
+  recovers from an error. Development builds send diagnostics only when explicitly
+  enabled for that build.
+
 ## Apple Contacts (off by default)
 
 - **Where:** nowhere on the network. Enabling the Contacts integration reads the
@@ -110,6 +122,7 @@ API keys and tokens live in the **OS keychain only** — never in markdown, neve
 | Model download | Hugging Face | No | Yes (opt-in) |
 | Backup | Your git repository | Yes — including private notes | Yes (needs connecting) |
 | Key validation | The provider | No | — (only when adding a key) |
+| Error diagnostics | Sentry | Not intentionally — error metadata only | No (packaged builds) |
 | Update check | GitHub Releases | No | On in packaged builds |
 | Browser capture | Nowhere (local host on disk) | — (stays on your machine) | — (only when you capture) |
 | Contacts lookup | Nowhere (on-device OS store) | — (stays on your machine) | Yes (opt-in) |

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -71,8 +71,8 @@ disk at call time), and it is covered by tests.
 ## Error diagnostics
 
 - **Where:** Sentry (`o463484.ingest.us.sentry.io`).
-- **What:** JavaScript error reports from the packaged app: stack traces, release,
-  environment, and SDK metadata. Before an event leaves the app,
+- **What:** JavaScript error reports from the packaged app: sanitized stack frames,
+  release, environment, and SDK metadata. Before an event leaves the app,
   Reflect strips free-form event messages, breadcrumbs, request data, custom extras,
   user data, tags, transaction names, exception messages, event contexts, stack-frame
   variables, and source context lines. It also disables Sentry user identity

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -72,10 +72,13 @@ disk at call time), and it is covered by tests.
 
 - **Where:** Sentry (`o463484.ingest.us.sentry.io`).
 - **What:** JavaScript error reports from the packaged app: sanitized stack frames,
-  release, environment, and SDK metadata. Before an event leaves the app,
-  Reflect strips free-form event messages, breadcrumbs, request data, custom extras,
-  user data, tags, transaction names, exception messages, event contexts, stack-frame
-  variables, and source context lines. It also disables Sentry user identity
+  source-map debug IDs, release, environment, and SDK metadata. Before an event leaves
+  the app, Reflect strips free-form event messages, breadcrumbs, request data, custom
+  extras, user data, tags, transaction names, exception messages, event contexts,
+  stack-frame variables, source context lines, and local filesystem paths. App bundle
+  URLs in stack frames and source-map metadata are kept only after query strings and
+  fragments are removed, so source maps can still make stack traces readable. It also
+  disables Sentry user identity
   collection, cookies, query params, HTTP header and body capture, and generative-AI
   input/output capture. Session Replay is not enabled.
 - **When:** automatically in official production builds when the React app throws,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@reflect/utils':
         specifier: workspace:*
         version: link:../../packages/utils
+      '@sentry/react':
+        specifier: ^10.64.0
+        version: 10.64.0(react@19.2.7)
       '@shadcn/react':
         specifier: ^0.1.0
         version: 0.1.0(@types/react@19.2.17)(react@19.2.7)
@@ -130,6 +133,9 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
     devDependencies:
+      '@sentry/vite-plugin':
+        specifier: ^5.3.0
+        version: 5.3.0(rollup@4.61.1)
       '@sqlite.org/sqlite-wasm':
         specifier: 3.53.0-build1
         version: 3.53.0-build1
@@ -2226,6 +2232,113 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
+  '@sentry/babel-plugin-component-annotate@5.3.0':
+    resolution: {integrity: sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==}
+    engines: {node: '>= 18'}
+
+  '@sentry/browser-utils@10.64.0':
+    resolution: {integrity: sha512-qXvUpsZdE0+6SovhDZvjN4JkqQEpzeYsrOF5g63wMsqJWWv2vW/pQZIlJs0F6C0t4q5AHZL4fl5rNkvpVqFdKA==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.64.0':
+    resolution: {integrity: sha512-CHZ7+79evh8knBtVHjW/XqV3mRaWs2TdjX7i55zpFe9vcNngQHV++0ss8ird/xfMY1mfCDtbyAN+Z6XY2o5aJA==}
+    engines: {node: '>=18'}
+
+  '@sentry/bundler-plugin-core@5.3.0':
+    resolution: {integrity: sha512-L5T60sWdAI3qWwdg3Ptwek/0TY59PERrxyqp4XMUkroayQvGd9r5dIW9Q1kSeXX9iJ442nXbFZKAOyCKV4Z13Q==}
+    engines: {node: '>= 18'}
+
+  '@sentry/cli-darwin@2.58.6':
+    resolution: {integrity: sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    resolution: {integrity: sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.6':
+    resolution: {integrity: sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.6':
+    resolution: {integrity: sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.6':
+    resolution: {integrity: sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    resolution: {integrity: sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.6':
+    resolution: {integrity: sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.6':
+    resolution: {integrity: sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.6':
+    resolution: {integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
+  '@sentry/conventions@0.15.1':
+    resolution: {integrity: sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==}
+    engines: {node: '>=14'}
+
+  '@sentry/core@10.64.0':
+    resolution: {integrity: sha512-HjojJcXD1l2qZ1AXje2s0XY/nYsaUt00wsM1HMBImA8vAClyPisFE/CC0/UD6pEvsGFhVgi8Dcxo7EN41uyeFw==}
+    engines: {node: '>=18'}
+
+  '@sentry/feedback@10.64.0':
+    resolution: {integrity: sha512-YrmKwRoAto+nwo26DoAhnpNmhkrVkuQFIAXqlTD8ipERjhcSNUYJAkAB+nH4w1KIgm9QQZE1sTq3iNQdPl1XMQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/react@10.64.0':
+    resolution: {integrity: sha512-oShEKcosBKdm0kgan8suFb6Jj8poccEyDz2qiflonq/5/hUDyzdVeKfFzf0b1MmdjWSn9k3hfrLNFfPNCuEt7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/replay-canvas@10.64.0':
+    resolution: {integrity: sha512-EioBwcnnhtPiXzTZJTbZKaMEg3qNM5YZlX1VanoXomPATqfJD62cb/M27zhgiWXXJ7e8/NGVHvwNDYGrqsN39g==}
+    engines: {node: '>=18'}
+
+  '@sentry/replay@10.64.0':
+    resolution: {integrity: sha512-q8nke2GDSwEiu1zYoctDDvnSNTjHWoVAKo2JXTleD0nwOO6IlAgUYmsm3qEQiSW7BVla9W1TRbW6ChFAUXYZbw==}
+    engines: {node: '>=18'}
+
+  '@sentry/rollup-plugin@5.3.0':
+    resolution: {integrity: sha512-hgPGPYdQJ/G1cGYOxAb7d4z3V+/k/E5/P/5TFPEEBLuIbFFk+JG0CISUDJdzXJjO382Lb99PBJuXGbueBmO79w==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      rollup: '>=3.2.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@sentry/vite-plugin@5.3.0':
+    resolution: {integrity: sha512-qcoSzo4n2MulVQ70UUPLq6dTleb2a2HwL2wuwvAgWhPChrYTuk6A6mDg6aQb9fairPAwFPiU9PzOANpoDJcz1A==}
+    engines: {node: '>= 18'}
+
   '@shadcn/react@0.1.0':
     resolution: {integrity: sha512-6i67TEnqValsZY7e4exJ4rkHo2OdHXmDH152YulwSpuEUnTQYumHkXzFsaje7HB7GbMTWuI9x1Jn6sSduCYdeA==}
     peerDependencies:
@@ -2774,6 +2887,10 @@ packages:
   adm-zip@0.5.17:
     resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
     engines: {node: '>=12.0'}
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -3730,6 +3847,10 @@ packages:
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
     engines: {node: '>=18'}
@@ -3833,6 +3954,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -4538,6 +4663,10 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -4583,6 +4712,15 @@ packages:
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
@@ -4757,6 +4895,10 @@ packages:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
 
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
@@ -4834,6 +4976,10 @@ packages:
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
 
   promise-toolbox@0.21.0:
     resolution: {integrity: sha512-NV8aTmpwrZv+Iys54sSFOBx3tuVaOBvvrft5PNppnxy9xpU/akHbaWIril22AB22zaPgrgwKdD0KsrM0ptUtpg==}
@@ -4961,6 +5107,9 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   publish-browser-extension@4.0.5:
     resolution: {integrity: sha512-EePAn3VIHJS/jqCuvs1NgPgoecCT8+RsES76hbgYe2Ze1dyvB0tX60C1PCrV8Z8fv56mW3E59s9Gd/GwWiw7dw==}
@@ -5523,6 +5672,9 @@ packages:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
@@ -5907,6 +6059,9 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -5921,6 +6076,9 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   when-exit@2.1.5:
     resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
@@ -8171,6 +8329,122 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
+  '@sentry/babel-plugin-component-annotate@5.3.0': {}
+
+  '@sentry/browser-utils@10.64.0':
+    dependencies:
+      '@sentry/core': 10.64.0
+
+  '@sentry/browser@10.64.0':
+    dependencies:
+      '@sentry/browser-utils': 10.64.0
+      '@sentry/core': 10.64.0
+      '@sentry/feedback': 10.64.0
+      '@sentry/replay': 10.64.0
+      '@sentry/replay-canvas': 10.64.0
+
+  '@sentry/bundler-plugin-core@5.3.0':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@sentry/babel-plugin-component-annotate': 5.3.0
+      '@sentry/cli': 2.58.6
+      dotenv: 16.6.1
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.21
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/cli-darwin@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli@2.58.6':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.6
+      '@sentry/cli-linux-arm': 2.58.6
+      '@sentry/cli-linux-arm64': 2.58.6
+      '@sentry/cli-linux-i686': 2.58.6
+      '@sentry/cli-linux-x64': 2.58.6
+      '@sentry/cli-win32-arm64': 2.58.6
+      '@sentry/cli-win32-i686': 2.58.6
+      '@sentry/cli-win32-x64': 2.58.6
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/conventions@0.15.1': {}
+
+  '@sentry/core@10.64.0':
+    dependencies:
+      '@sentry/conventions': 0.15.1
+
+  '@sentry/feedback@10.64.0':
+    dependencies:
+      '@sentry/core': 10.64.0
+
+  '@sentry/react@10.64.0(react@19.2.7)':
+    dependencies:
+      '@sentry/browser': 10.64.0
+      '@sentry/core': 10.64.0
+      react: 19.2.7
+
+  '@sentry/replay-canvas@10.64.0':
+    dependencies:
+      '@sentry/core': 10.64.0
+      '@sentry/replay': 10.64.0
+
+  '@sentry/replay@10.64.0':
+    dependencies:
+      '@sentry/browser-utils': 10.64.0
+      '@sentry/core': 10.64.0
+
+  '@sentry/rollup-plugin@5.3.0(rollup@4.61.1)':
+    dependencies:
+      '@sentry/bundler-plugin-core': 5.3.0
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.61.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/vite-plugin@5.3.0(rollup@4.61.1)':
+    dependencies:
+      '@sentry/bundler-plugin-core': 5.3.0
+      '@sentry/rollup-plugin': 5.3.0(rollup@4.61.1)
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
   '@shadcn/react@0.1.0(@types/react@19.2.17)(react@19.2.7)':
     optionalDependencies:
       '@types/react': 19.2.17
@@ -8709,6 +8983,12 @@ snapshots:
   acorn@8.16.0: {}
 
   adm-zip@0.5.17: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   agent-base@7.1.4: {}
 
@@ -9679,6 +9959,12 @@ snapshots:
 
   glob-to-regexp@0.4.1: {}
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   global-directory@4.0.1:
     dependencies:
       ini: 4.1.1
@@ -9842,6 +10128,13 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -10617,6 +10910,8 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@7.1.3: {}
+
   mkdirp-classic@0.5.3: {}
 
   mlly@1.8.2:
@@ -10656,6 +10951,10 @@ snapshots:
   node-domexception@1.0.0: {}
 
   node-fetch-native@1.6.7: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-fetch@3.3.2:
     dependencies:
@@ -10857,6 +11156,11 @@ snapshots:
 
   path-key@4.0.0: {}
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.1
+      minipass: 7.1.3
+
   path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
@@ -10948,6 +11252,8 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   process-warning@5.0.0: {}
+
+  progress@2.0.3: {}
 
   promise-toolbox@0.21.0:
     dependencies:
@@ -11096,6 +11402,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@1.1.0: {}
 
   publish-browser-extension@4.0.5:
     dependencies:
@@ -11820,6 +12128,8 @@ snapshots:
     dependencies:
       tldts: 7.4.2
 
+  tr46@0.0.3: {}
+
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
@@ -12184,6 +12494,8 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@8.0.1: {}
 
   webpack-virtual-modules@0.6.2: {}
@@ -12197,6 +12509,11 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   when-exit@2.1.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - design-system
 
 allowBuilds:
+  '@sentry/cli': true
   better-sqlite3: true
   esbuild: true
   spawn-sync: true


### PR DESCRIPTION
## Problem

The Tauri iOS and desktop app can already rely on native crash reporting for process-level failures, but React/WebView errors were effectively invisible in production. We need useful JavaScript diagnostics without letting note content, note titles, local graph paths, request data, or user identifiers leave the device by accident.

This PR is intentionally React-first. It does not add the native Sentry SDK because Apple crash logs already cover the higher-value native crash path for now.

## Before -> After

| Area | Before | After |
| --- | --- | --- |
| React errors | Render/caught/recoverable errors stayed local or appeared only as minified production stacks | React 19 root error hooks report to Sentry in configured production builds |
| Privacy | No Sentry path existed, but no diagnostics existed either | Client-side Sentry config disables PII-prone collection and `beforeSend` strips free-form fields before upload |
| Source maps | No upload path for readable production JS stacks | Vite can upload source maps to `reflect-64/reflect-open` when `SENTRY_AUTH_TOKEN` is present, while emitted `.map` files stay in the open-source build |
| Source builds | A custom production build could accidentally inherit official telemetry if enabled too broadly | Third-party/source builds stay opt-in unless `VITE_SENTRY_ENABLED=true` or `VITE_SENTRY_DSN` is set |

## Changes

1. Add `@sentry/react` initialization in `apps/desktop/src/lib/sentry.ts`, imported first from `main.tsx`.
2. Wire React 19 `createRoot` error hooks through Sentry, with a small adapter for the current React/Sentry `componentStack` type mismatch under `exactOptionalPropertyTypes`.
3. Configure privacy-first Sentry collection: disable user identity, cookies, query params, HTTP headers/bodies, stack-frame variables, source context lines, logs, breadcrumbs, transactions, and generative-AI inputs/outputs.
4. Add `scrubSentryEventForPrivacy`, a `beforeSend` scrubber that removes free-form event messages, request data, custom extras, user data, tags, transaction names, exception messages, exception mechanism/module data, event contexts, SDK processing metadata, frame source snippets, frame locals, and unsafe paths before an event leaves the app.
5. Preserve source-map usefulness without preserving sensitive paths: bundle asset URLs in stack frames and `debug_meta.images[].code_file` are kept only after query strings/fragments are removed; local filesystem asset paths are normalized to `app:///assets/...`; unknown or note-looking paths are dropped.
6. Add focused scrubber tests with fake note text in risky Sentry fields, including breadcrumbs, request URLs, extras, contexts, exception mechanisms, stack frame snippets, local paths, unknown paths, and source-map debug metadata.
7. Add `@sentry/vite-plugin`, gated on `SENTRY_AUTH_TOKEN`, for source-map upload to `reflect-64/reflect-open`; keep emitted `.map` files because Reflect is open source and release devtools are intentional.
8. Allow Sentry SaaS ingest origins in the Tauri CSP, including the deeper `ingest.*.sentry.io` host patterns used by regional DSNs, and approve `@sentry/cli` in pnpm build-script policy.
9. Update `docs/privacy.md` to document the new Sentry diagnostics network path, client-side scrubbing, source-map debug IDs, exception mechanism stripping, and build opt-in behavior.

## Tests

- `apps/desktop/src/lib/sentry-privacy.test.ts` verifies that note-like content is stripped from risky Sentry event fields.
- The same test covers breadcrumb dropping, exception type/value/mechanism/module removal, source context/local variable removal, safe bundle asset path normalization, unsafe path dropping, and `debug_meta` code-file normalization.

## Verification

- `pnpm --filter @reflect/desktop test --run src/lib/sentry-privacy.test.ts` passed.
- `pnpm --filter @reflect/desktop typecheck` passed.
- `pnpm check` passed. It still reports the existing `packages/core/src/indexing/indexer.ts` max-lines warning.
- `pnpm --filter @reflect/desktop build` passed and emitted source maps. Vite still reports the existing large-chunk warnings.
- `git diff --check` passed.

## Risk / Rollout

- Release CI needs `SENTRY_AUTH_TOKEN` for source-map uploads; in official builds, that also enables the default Reflect Sentry DSN unless `VITE_SENTRY_ENABLED=false` is set.
- `SENTRY_RELEASE` or `VITE_SENTRY_RELEASE` can be set to align runtime events with uploaded artifacts; otherwise the Vite plugin release name falls back to `GITHUB_SHA`.
- Development builds and third-party/source production builds do not send to Reflect Sentry unless explicitly configured with `VITE_SENTRY_ENABLED=true` or `VITE_SENTRY_DSN`.
- The CSP allowlist covers Sentry SaaS ingest domains for custom DSNs; self-hosted Sentry still requires downstream source builders to adjust their own CSP.
- Sentry Session Replay is not enabled in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Sentry-based error diagnostics for the desktop app, with React error handling and privacy-scrubbed reports.
  * Enabled build-time release tracking and production source maps when configured.
* **Documentation**
  * Updated privacy documentation with an “Error diagnostics” section covering what’s collected and sending conditions.
* **Bug Fixes**
  * Improved routing of uncaught, caught, and recoverable UI errors into the diagnostics pipeline.
* **Tests**
  * Added automated tests to verify privacy scrubbing behavior.
* **Chores**
  * Updated the desktop app security policy to permit required error-reporting traffic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new third-party egress path for error metadata; mitigations are strong but official production builds may report by default when CI sets `SENTRY_AUTH_TOKEN`, so rollout and opt-out env vars matter.
> 
> **Overview**
> Adds **Sentry-based JavaScript error reporting** for the desktop React app so production WebView failures are visible without relying on native crash logs alone.
> 
> **Runtime:** `@sentry/react` initializes from `main.tsx` (imported first). React 19 root `onUncaughtError` / `onCaughtError` / `onRecoverableError` route through Sentry’s `reactErrorHandler`. Collection is locked down (no user info, cookies, HTTP bodies/headers, breadcrumbs, transactions, replay, or gen-AI capture), with `beforeSend` / `beforeBreadcrumb` hooks that strip messages, requests, extras, contexts, exception text, frame snippets/locals, and unsafe paths while keeping normalized bundle asset URLs for source maps.
> 
> **Build & policy:** Vite enables production source maps and optionally uploads them via `@sentry/vite-plugin` when `SENTRY_AUTH_TOKEN` is set; `VITE_SENTRY_ENABLED` / release names are injected at build time. Tauri CSP allows Sentry ingest hosts; `docs/privacy.md` documents the new outbound path and scrubbing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2403a3fa954ef3e0cf6f9c64b4494d281431c47d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
