### PR TITLE
fix: hide the editor block handle on iOS

### DIFF
--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -13,6 +13,7 @@ interface CapturedEditorProps {
   mode?: 'hide' | 'focus' | 'show' | 'source'
   editorClassName?: string
   spellCheck?: boolean
+  blockHandle?: boolean
   timeFormat?: '12' | '24'
   children?: ReactNode
   resolveImageUrl?: (src: string) => string | undefined
@@ -191,6 +192,17 @@ describe('NoteEditor touch-surface input hygiene', () => {
     setPlatformSurface({ touchEditor: true })
     render(<NoteEditor initialContent="" spellCheck={true} />)
     expect(captured.props?.spellCheck).toBe(false)
+  })
+
+  it('passes the block handle through on desktop', () => {
+    render(<NoteEditor initialContent="" blockHandle={true} />)
+    expect(captured.props?.blockHandle).toBe(true)
+  })
+
+  it('pins the block handle off on the touch surface', () => {
+    setPlatformSurface({ touchEditor: true })
+    render(<NoteEditor initialContent="" blockHandle={true} />)
+    expect(captured.props?.blockHandle).toBe(false)
   })
 
   it('sets explicit input traits on the contenteditable on the touch surface', () => {

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -122,7 +122,8 @@ interface NoteEditorProps {
    * Whether to show meowdown's per-block gutter handle: a grip to drag-reorder
    * blocks and a "+" to insert a paragraph below. Off by default. The main note
    * editor opts in; one-line surfaces like the inline task editor leave it off so
-   * no stray grip appears beside them.
+   * no stray grip appears beside them. Always off on the touch surface, which
+   * has no hover to reveal the grip.
    */
   blockHandle?: boolean
   /** Resolve an image `![…](…)` source to a displayable URL; unresolved images are skipped. */
@@ -406,7 +407,11 @@ export function NoteEditor({
         // `12`/`24` here at the boundary, like `markModeFromSyntax`.
         timeFormat={timeFormat === '24h' ? '24' : '12'}
         bulletAfterHeading={bulletAfterHeading}
-        blockHandle={blockHandle}
+        // Pinned off on the touch surface regardless of the caller: the grip is
+        // revealed on hover and drag-reorders blocks with a pointer, neither of
+        // which a touch webview can express. Turning it off also drops the drop
+        // indicator, which meowdown gates on the same prop.
+        blockHandle={isTouchEditorSurface() ? false : blockHandle}
         editorClassName={cn('reflect-editor', className)}
         {...(titlePlaceholder !== undefined ? { placeholder: titlePlaceholder } : {})}
         onDocChange={handleDocChange}


### PR DESCRIPTION
The block-handle grip is revealed on hover and drag-reorders blocks with a pointer, so `NoteEditor` now pins `blockHandle` off on the touch surface instead of letting `NotePane` render it on iOS.

See the screenshot below.  Notice the block handle before the text "1234" are gone. 


**Before**:


<img width="2532" height="1170" alt="IMG_3200" src="https://github.com/user-attachments/assets/a360b888-9b3d-4b3a-be54-5c43217a8b3e" />
<img width="450"  alt="IMG_3199" src="https://github.com/user-attachments/assets/556b0dfa-c4e4-4a5a-abe0-c0bc57f8b4e3" />


**After**:


<img width="2532" height="1170" alt="IMG_3202" src="https://github.com/user-attachments/assets/8e48f3b8-4180-4d6d-8dfa-f27dddb5d910" />
<img width="450"  alt="IMG_3201" src="https://github.com/user-attachments/assets/ccd62673-c046-4fb1-b36a-67a7305ff1f6" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor behavior on touch devices so block-handle interactions stay disabled where hover and drag-based reordering aren’t available.
  * On desktop, block-handle settings continue to be passed through as expected.
  * Added test coverage to verify the editor handles this behavior consistently across desktop and touch surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->