### PR TITLE
Import Reflect V1 asset CDN links

### DIFF
--- a/apps/desktop/src-tauri/src/fs/import.rs
+++ b/apps/desktop/src-tauri/src/fs/import.rs
@@ -4,8 +4,8 @@
 //! `daily/`, `notes/`, optional `assets/`, plus ignorable local metadata. The
 //! import path is therefore a bounded archive extraction into the active graph,
 //! not a content migration — with one addition: attachments the notes link
-//! straight to Firebase Storage are downloaded into `assets/` and the links
-//! rewritten (see [`super::import_assets`]).
+//! straight to Firebase Storage or Reflect's asset CDN are downloaded into
+//! `assets/` and the links rewritten (see [`super::import_assets`]).
 //!
 //! The flow is three phases so nothing lands in the graph until everything is
 //! in hand: [`prepare_zip_import`] (read + validate, no writes), the async
@@ -147,7 +147,7 @@ pub struct PreparedImport {
     /// Unique remote-asset URLs across all notes, in first-seen order (which
     /// also fixes collision-suffix assignment).
     urls: Vec<String>,
-    prefix: String,
+    prefixes: Vec<String>,
 }
 
 impl PreparedImport {
@@ -179,15 +179,15 @@ impl PreparedImport {
 /// Read and validate a user-selected Reflect V1 export zip against `root`,
 /// without writing anything.
 pub(super) fn prepare_zip_import(root: &Path, zip_path: &Path) -> AppResult<PreparedImport> {
-    prepare_zip_import_from(root, zip_path, import_assets::V1_ASSET_URL_PREFIX)
+    prepare_zip_import_from(root, zip_path, import_assets::V1_ASSET_URL_PREFIXES)
 }
 
-/// [`prepare_zip_import`] with the remote-asset URL prefix injectable, so
+/// [`prepare_zip_import`] with the remote-asset URL prefixes injectable, so
 /// tests can point it at a local server.
 fn prepare_zip_import_from(
     root: &Path,
     zip_path: &Path,
-    prefix: &str,
+    prefixes: &[&str],
 ) -> AppResult<PreparedImport> {
     let entries = dedupe_entries(read_zip_entries(zip_path)?)?;
     ensure_has_notes(&entries)?;
@@ -200,7 +200,7 @@ fn prepare_zip_import_from(
         let Ok(text) = std::str::from_utf8(&entry.bytes) else {
             continue;
         };
-        for span in import_assets::scan_remote_spans(text, prefix) {
+        for span in import_assets::scan_remote_spans(text, prefixes) {
             if seen.insert(span.url.clone()) {
                 urls.push(span.url);
             }
@@ -210,7 +210,10 @@ fn prepare_zip_import_from(
         entries,
         staging: super::assets::staging_dir(root)?,
         urls,
-        prefix: prefix.to_string(),
+        prefixes: prefixes
+            .iter()
+            .map(|prefix| (*prefix).to_string())
+            .collect(),
     })
 }
 
@@ -261,7 +264,7 @@ pub(super) fn finalize_import(
     let PreparedImport {
         mut entries,
         urls,
-        prefix,
+        prefixes,
         ..
     } = prepared;
 
@@ -360,7 +363,8 @@ pub(super) fn finalize_import(
             // Zip-borne `assets/…` links first: the remote rewrite splices in
             // downloaded assets' final names, which must not be re-mapped.
             let rewritten = import_assets::rewrite_asset_paths(text, &path_replacements);
-            let rewritten = import_assets::rewrite_markdown(&rewritten, &prefix, &url_replacements);
+            let rewritten =
+                import_assets::rewrite_markdown(&rewritten, &prefixes, &url_replacements);
             if rewritten != text {
                 entry.bytes = rewritten.into_bytes();
             }
@@ -831,7 +835,10 @@ mod tests {
             entries,
             staging: super::super::assets::staging_dir(root)?,
             urls: Vec::new(),
-            prefix: import_assets::V1_ASSET_URL_PREFIX.to_string(),
+            prefixes: import_assets::V1_ASSET_URL_PREFIXES
+                .iter()
+                .map(|prefix| (*prefix).to_string())
+                .collect(),
         };
         finalize_import(root, prepared, HashMap::new(), |_, _| {})
     }
@@ -1493,7 +1500,7 @@ mod tests {
         zip_path: &Path,
         prefix: &str,
     ) -> AppResult<ImportSummary> {
-        let prepared = prepare_zip_import_from(root, zip_path, prefix)?;
+        let prepared = prepare_zip_import_from(root, zip_path, &[prefix])?;
         let downloads =
             tauri::async_runtime::block_on(prepared.download_assets(no_cancel(), no_progress()))?;
         finalize_import(root, prepared, downloads, |_, _| {})
@@ -1574,7 +1581,7 @@ mod tests {
             .collect::<String>();
         write_zip(&zip_path, &[("daily/2026-07-04.md", markdown.as_str())]);
 
-        let prepared = prepare_zip_import_from(root.path(), &zip_path, &base).unwrap();
+        let prepared = prepare_zip_import_from(root.path(), &zip_path, &[&base]).unwrap();
         let Some(before) = open_fd_count() else {
             return;
         };
@@ -1683,7 +1690,7 @@ mod tests {
             .map(|index| format!("![]({base}asset-{index}?alt=media\\&token={index})\n"))
             .collect::<String>();
         write_zip(&zip_path, &[("daily/2026-07-04.md", markdown.as_str())]);
-        let prepared = prepare_zip_import_from(root.path(), &zip_path, &base).unwrap();
+        let prepared = prepare_zip_import_from(root.path(), &zip_path, &[&base]).unwrap();
         let seen = Arc::new(Mutex::new(Vec::new()));
         let record = Arc::clone(&seen);
 
@@ -1708,7 +1715,7 @@ mod tests {
         let zip_path = root.path().join("export.zip");
         let markdown = format!("![]({base}photo?alt=media\\&token=t)\n");
         write_zip(&zip_path, &[("daily/2026-07-04.md", markdown.as_str())]);
-        let prepared = prepare_zip_import_from(root.path(), &zip_path, &base).unwrap();
+        let prepared = prepare_zip_import_from(root.path(), &zip_path, &[&base]).unwrap();
         let cancelled = Arc::new(AtomicBool::new(true));
 
         let result =
@@ -1734,7 +1741,10 @@ mod tests {
             entries: dedupe_entries(entries).unwrap(),
             staging: super::super::assets::staging_dir(root.path()).unwrap(),
             urls: Vec::new(),
-            prefix: import_assets::V1_ASSET_URL_PREFIX.to_string(),
+            prefixes: import_assets::V1_ASSET_URL_PREFIXES
+                .iter()
+                .map(|prefix| (*prefix).to_string())
+                .collect(),
         };
         let mut seen = Vec::new();
 

--- a/apps/desktop/src-tauri/src/fs/import_assets.rs
+++ b/apps/desktop/src-tauri/src/fs/import_assets.rs
@@ -1,9 +1,10 @@
 //! Remote-asset localization for the Reflect V1 import.
 //!
-//! V1 notes link attachments straight at Firebase Storage download URLs. An
-//! import must not leave a graph depending on Reflect V1's infrastructure, so
-//! every such URL is downloaded into the graph's `assets/` directory and the
-//! markdown link is rewritten to the relative `assets/…` path.
+//! V1 notes link attachments straight at Firebase Storage and Reflect's asset
+//! CDN. An import must not leave a graph depending on Reflect V1's
+//! infrastructure, so every such URL is downloaded into the graph's `assets/`
+//! directory and the markdown link is rewritten to the relative `assets/…`
+//! path.
 //!
 //! Download failures split by permanence: a 4xx means the asset is gone (or
 //! the token was revoked) and no retry will help, so the note keeps its remote
@@ -20,9 +21,12 @@ use std::time::Duration;
 
 use crate::error::{AppError, AppResult};
 
-/// Only asset links on Reflect V1's storage host are localized; every other
+/// Only asset links on Reflect V1's storage hosts are localized; every other
 /// URL in the export is an ordinary link and imports untouched.
-pub(super) const V1_ASSET_URL_PREFIX: &str = "https://firebasestorage.googleapis.com/";
+pub(super) const V1_ASSET_URL_PREFIXES: &[&str] = &[
+    "https://firebasestorage.googleapis.com/",
+    "https://reflect-assets.app/v1/users/",
+];
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 /// Per-read stall timeout. There is deliberately no whole-request timeout so
@@ -57,17 +61,26 @@ pub(super) struct FetchedAsset {
     pub desired_name: String,
 }
 
-/// Find every remote-asset URL in `markdown` that starts with `prefix`.
+/// Find every remote-asset URL in `markdown` that starts with one of
+/// `prefixes`.
 ///
 /// V1 exports escape URL punctuation the CommonMark way (`?alt=media\&token=`),
 /// so the span keeps the escaped bytes (for splicing) while `url` holds the
 /// unescaped form (for fetching). A span ends at whitespace or any character
 /// that terminates a markdown link destination.
-pub(super) fn scan_remote_spans(markdown: &str, prefix: &str) -> Vec<RemoteSpan> {
+pub(super) fn scan_remote_spans<P: AsRef<str>>(markdown: &str, prefixes: &[P]) -> Vec<RemoteSpan> {
     let mut spans = Vec::new();
     let mut from = 0;
-    while let Some(found) = markdown[from..].find(prefix) {
-        let start = from + found;
+    while let Some((start, prefix)) = prefixes
+        .iter()
+        .filter_map(|candidate| {
+            let prefix = candidate.as_ref();
+            markdown[from..]
+                .find(prefix)
+                .map(|found| (from + found, prefix))
+        })
+        .min_by_key(|(start, _)| *start)
+    {
         let mut url = String::new();
         let mut cursor = start;
         let mut chars = markdown[start..].char_indices().peekable();
@@ -108,13 +121,13 @@ pub(super) fn scan_remote_spans(markdown: &str, prefix: &str) -> Vec<RemoteSpan>
 /// Replace the remote spans of `markdown` whose URL has a localized path in
 /// `replacements` (URL → `assets/…`). URLs without a replacement (permanent
 /// download failures) keep their remote form.
-pub(super) fn rewrite_markdown(
+pub(super) fn rewrite_markdown<P: AsRef<str>>(
     markdown: &str,
-    prefix: &str,
+    prefixes: &[P],
     replacements: &HashMap<String, String>,
 ) -> String {
     let mut result = markdown.to_string();
-    for span in scan_remote_spans(markdown, prefix).into_iter().rev() {
+    for span in scan_remote_spans(markdown, prefixes).into_iter().rev() {
         if let Some(local) = replacements.get(&span.url) {
             result.replace_range(span.start..span.end, local);
         }
@@ -135,7 +148,7 @@ pub(super) fn rewrite_asset_paths(
         return markdown.to_string();
     }
     let mut result = markdown.to_string();
-    for span in scan_remote_spans(markdown, "assets/").into_iter().rev() {
+    for span in scan_remote_spans(markdown, &["assets/"]).into_iter().rev() {
         let opens_destination = markdown[..span.start]
             .chars()
             .next_back()
@@ -571,12 +584,12 @@ mod tests {
     use std::fs;
     use tempfile::tempdir;
 
-    const PREFIX: &str = "https://firebasestorage.googleapis.com/";
+    const PREFIXES: &[&str] = &["https://firebasestorage.googleapis.com/"];
 
     #[test]
     fn scan_finds_escaped_urls_in_link_destinations() {
         let markdown = "![](https://firebasestorage.googleapis.com/v0/b/x/o/a?alt=media\\&token=t)\nplain text\n[memo.m4a](https://firebasestorage.googleapis.com/v0/b/x/o/b?alt=media\\&token=u)";
-        let spans = scan_remote_spans(markdown, PREFIX);
+        let spans = scan_remote_spans(markdown, PREFIXES);
         assert_eq!(spans.len(), 2);
         assert_eq!(
             spans[0].url,
@@ -595,13 +608,13 @@ mod tests {
     #[test]
     fn scan_ignores_other_hosts() {
         let markdown = "[a](https://example.com/file.png)";
-        assert!(scan_remote_spans(markdown, PREFIX).is_empty());
+        assert!(scan_remote_spans(markdown, PREFIXES).is_empty());
     }
 
     #[test]
     fn scan_stops_at_terminators() {
         let markdown = "see https://firebasestorage.googleapis.com/v0/o/a?alt=media end";
-        let spans = scan_remote_spans(markdown, PREFIX);
+        let spans = scan_remote_spans(markdown, PREFIXES);
         assert_eq!(spans.len(), 1);
         assert_eq!(
             spans[0].url,
@@ -617,8 +630,42 @@ mod tests {
             "assets/photo.webp".to_string(),
         )]);
         assert_eq!(
-            rewrite_markdown(markdown, PREFIX, &replacements),
+            rewrite_markdown(markdown, PREFIXES, &replacements),
             "![](assets/photo.webp) and [f](https://firebasestorage.googleapis.com/o/b?alt=media\\&token=u)"
+        );
+    }
+
+    #[test]
+    fn scan_and_rewrite_support_all_v1_asset_hosts_in_source_order() {
+        let reflect_user = "https://reflect-assets.app/v1/users/user/asset?key=k1";
+        let reflect_graph = "https://reflect-assets.app/v1/users/user/graph/asset?key=k2";
+        let firebase =
+            "https://firebasestorage.googleapis.com/v0/b/bucket/o/asset?alt=media&token=t";
+        let markdown = format!("![]({reflect_user})\n\n![]({firebase})\n\n![]({reflect_graph})\n");
+
+        let spans = scan_remote_spans(&markdown, V1_ASSET_URL_PREFIXES);
+
+        assert_eq!(
+            spans
+                .iter()
+                .map(|span| span.url.as_str())
+                .collect::<Vec<_>>(),
+            [reflect_user, firebase, reflect_graph]
+        );
+        let replacements = HashMap::from([
+            (
+                reflect_user.to_string(),
+                "assets/reflect-user.png".to_string(),
+            ),
+            (
+                reflect_graph.to_string(),
+                "assets/reflect-graph.png".to_string(),
+            ),
+            (firebase.to_string(), "assets/firebase.png".to_string()),
+        ]);
+        assert_eq!(
+            rewrite_markdown(&markdown, V1_ASSET_URL_PREFIXES, &replacements),
+            "![](assets/reflect-user.png)\n\n![](assets/firebase.png)\n\n![](assets/reflect-graph.png)\n"
         );
     }
 

--- a/apps/desktop/src-tauri/src/fs/mod.rs
+++ b/apps/desktop/src-tauri/src/fs/mod.rs
@@ -220,10 +220,11 @@ pub fn graph_create(path: String, state: State<GraphState>) -> AppResult<GraphIn
 /// directly under the current root; existing files are never replaced (and
 /// never fail the import — identical files skip, conflicting notes rename,
 /// conflicting daily notes merge). Attachments the notes link to on Firebase
-/// Storage are downloaded into `assets/` first and the links rewritten, so
-/// the imported graph doesn't depend on Reflect V1's infrastructure staying
-/// up. Progress is emitted as `import:progress` events, and
-/// [`graph_import_cancel`] aborts the run before anything lands in the graph.
+/// Storage or Reflect's asset CDN are downloaded into `assets/` first and the
+/// links rewritten, so the imported graph doesn't depend on Reflect V1's
+/// infrastructure staying up. Progress is emitted as `import:progress` events,
+/// and [`graph_import_cancel`] aborts the run before anything lands in the
+/// graph.
 #[tauri::command]
 pub async fn graph_import_reflect_v1_zip(
     path: String,

--- a/packages/core/src/graph/commands.ts
+++ b/packages/core/src/graph/commands.ts
@@ -64,9 +64,9 @@ export async function createGraph(path: string): Promise<GraphInfo> {
  * Reflect Open's graph-folder layout; Rust extracts safe entries under the
  * active graph root without ever replacing an existing file (identical files
  * skip, conflicting notes rename, conflicting daily notes merge). Attachments
- * the notes link to on Firebase Storage are downloaded into `assets/` and the
- * links rewritten, so the call can take a while on attachment-heavy graphs —
- * observe {@link subscribeImportProgress} and offer
+ * the notes link to on Firebase Storage or Reflect's asset CDN are downloaded
+ * into `assets/` and the links rewritten, so the call can take a while on
+ * attachment-heavy graphs — observe {@link subscribeImportProgress} and offer
  * {@link cancelReflectV1Import} while it runs.
  */
 export async function importReflectV1Zip(


### PR DESCRIPTION
## Problem

The Reflect V1 importer only recognizes Firebase Storage attachment URLs. Notes that reference `https://reflect-assets.app/v1/users/...` therefore retain remote links instead of downloading those assets into the local graph.

The supplied V1 export contains 31 CDN references across both known path shapes: `users/{uid}/{asset}` and `users/{uid}/{graph}/{asset}`.

## Before -> After

| | Before | After |
| --- | --- | --- |
| Firebase Storage links | Downloaded and rewritten to `assets/...` | Unchanged |
| Reflect asset CDN links | Left remote | Downloaded and rewritten to `assets/...` |
| Mixed origins in one note | Only Firebase links discovered | All supported links discovered in source order |

## Changes

1. Define both trusted V1 asset URL prefixes in the native import pipeline.
2. Generalize remote span discovery and Markdown rewriting to accept multiple prefixes while preserving first-seen source order for deterministic collision naming.
3. Carry the supported prefix set through preparation and finalization, while keeping the local-server injection used by download tests.
4. Document that V1 imports localize both Firebase Storage and Reflect asset CDN attachments.

## Tests

- Covers both Reflect CDN path shapes, mixed with a Firebase URL, and verifies source-order discovery plus rewriting.
- Exercises the full existing V1 import suite for downloads, rewrites, failures, deduplication, collisions, progress, cancellation, and re-import behavior.

## Verification

- `cargo test -p reflect-open fs::import` — 40 passed, 0 failed.
- `pnpm check` — typecheck and lint passed. Lint reports the existing unrelated max-lines warning in `packages/core/src/indexing/indexer.ts`.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.

## Risk / Rollout

No migration or backfill is required. The change only broadens the allowlisted V1 asset origins; all downloads retain the existing staging, retry, failure, collision, and atomic-write behavior. Re-running an import continues to reuse identical downloaded assets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only widens the trusted remote-asset host allowlist; download, failure handling, and graph writes follow the existing import path.
> 
> **Overview**
> Reflect V1 zip import now treats **`https://reflect-assets.app/v1/users/`** attachment links like Firebase Storage: they are discovered, downloaded into `assets/`, and rewritten to local paths instead of staying remote.
> 
> The native pipeline switches from a single URL prefix to **`V1_ASSET_URL_PREFIXES`**, and **`scan_remote_spans`** / **`rewrite_markdown`** accept multiple prefixes while still walking the note in **first-seen source order** (earliest match when several prefixes could apply). **`PreparedImport`** carries the full prefix set through prepare and finalize; tests still inject a custom prefix via a slice.
> 
> User-facing docs on **`graph_import_reflect_v1_zip`** and **`importReflectV1Zip`** mention both Firebase and the Reflect asset CDN.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc6602e6eefeb710e5d98e3981d4e85ef7631660. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Importing Reflect V1 exports now recognizes multiple remote asset URL formats, improving support for attachments from different hosted sources.
  * Asset links are rewritten more reliably during import, keeping downloaded files and markdown references aligned.

* **Documentation**
  * Updated import-related documentation to better describe how remote assets are downloaded and linked during import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->