### PR TITLE
Fade iOS Today button with a CSS transition

### DIFF
--- a/apps/desktop/src/mobile/calendar-strip.tsx
+++ b/apps/desktop/src/mobile/calendar-strip.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, Settings } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { addDaysIso } from '@/lib/dates'
 import { monthOf } from '@/lib/month-grid'
+import { cn } from '@/lib/utils'
 import { monthPickTarget, weekAtIndex, weekStartOf } from '@/mobile/calendar'
 import { hapticImpactLight } from '@/mobile/haptics'
 import { MonthPickerDrawer } from '@/mobile/month-picker-drawer'
@@ -56,6 +57,7 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
   const selectionWeekStart = weekStartOf(date, settings.weekStartDay)
   const headerDate =
     displayedWeekStart === selectionWeekStart ? date : addDaysIso(displayedWeekStart, 3)
+  const showToday = date !== today
 
   const jumpToToday = (): void => {
     hapticImpactLight()
@@ -101,7 +103,7 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
       style={{ paddingTop: 'env(safe-area-inset-top)' }}
     >
       {/* Three equal-flanked columns so the month sits at the screen's center
-          regardless of the gear (left) and the conditional Today button (right). */}
+          regardless of the gear (left) and the fading Today button (right). */}
       <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-1 px-1 py-1">
         <div className="justify-self-start">
           <Button
@@ -126,11 +128,19 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
           </button>
         </h1>
         <div className="justify-self-end">
-          {date !== today && (
-            <Button variant="ghost" size="sm" onClick={jumpToToday}>
-              Today
-            </Button>
-          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-hidden={!showToday || undefined}
+            inert={!showToday}
+            className={cn(
+              'transition-opacity duration-150 motion-reduce:transition-none',
+              showToday ? 'opacity-100' : 'pointer-events-none opacity-0',
+            )}
+            onClick={jumpToToday}
+          >
+            Today
+          </Button>
         </div>
       </div>
       <div className="overflow-hidden" ref={emblaRef}>

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -310,14 +310,23 @@ describe('MobileShell', () => {
     const view = mount({ kind: 'today' })
 
     expect(view.queryByRole('button', { name: 'Today' })).toBeNull()
+    const todayButton = view.getByText('Today')
+    expect(todayButton.classList.contains('opacity-0')).toBe(true)
+    expect(todayButton.hasAttribute('inert')).toBe(true)
+
     await user.click(view.getByRole('button', { name: dayCellLabel(other) }))
     expect(view.getByRole('button', { name: dayCellLabel(other) }).getAttribute('aria-current')).toBe(
       'date',
     )
-    expect(view.getByRole('button', { name: 'Today' })).toBeTruthy()
+    expect(
+      view.getByRole('button', { name: 'Today' }).classList.contains('opacity-100'),
+    ).toBe(true)
+    expect(todayButton.hasAttribute('inert')).toBe(false)
 
     await user.click(view.getByRole('button', { name: 'Today' }))
     expect(view.queryByRole('button', { name: 'Today' })).toBeNull()
+    expect(todayButton.classList.contains('opacity-0')).toBe(true)
+    expect(todayButton.hasAttribute('inert')).toBe(true)
     expect(view.getByRole('button', { name: dayCellLabel(today) }).getAttribute('aria-current')).toBe(
       'date',
     )


### PR DESCRIPTION
## Problem

The iOS daily header currently mounts and unmounts the Today button as the selected date moves away from or back to today. The control therefore pops in and out instead of fading.

## Before -> After

| Before | After |
| --- | --- |
| Today is conditionally mounted. | Today remains mounted and transitions between `opacity-0` and `opacity-100`. |
| The hidden control is absent from the DOM. | The hidden control is `inert`, `aria-hidden`, and ignores pointer input. |

## Changes

1. Keep the Today button mounted in `CalendarStrip` so both fade directions can transition.
2. Use the design system base duration: a 150ms opacity transition, collapsed for reduced-motion preferences.
3. Remove the hidden state from pointer, keyboard, and accessibility interaction with `pointer-events-none`, `inert`, and `aria-hidden`.
4. Extend the mobile shell test to cover mounted-hidden, visible, and hidden-again states.

## Comparison with #672

This is intentionally the smaller CSS-driven alternative: it adds no timers, effects, refs, or component state. The button becomes interactive as its 150ms fade-in begins; when fading out, it becomes inert immediately. PR #672 instead delays fade-in interactivity until its 200ms animation completes.

## Verification

- `pnpm --filter @reflect/desktop test --run src/mobile/mobile-screen.test.tsx` — 28 tests passed.
- `pnpm check` — passed; the existing max-lines warning in `packages/core/src/indexing/indexer.ts` remains.
- `pnpm build` — passed; existing large-chunk warnings remain.

## Risk / Rollout

Low risk and localized to the mobile daily header. There are no data, routing, or persistence changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized mobile header UI and test updates only; no routing, persistence, or auth changes.
> 
> **Overview**
> The mobile daily header **Today** control no longer mounts and unmounts when the selected day matches today. It stays in the layout and **fades** between visible and hidden with a **150ms** opacity transition (disabled under `motion-reduce`).
> 
> When hidden, the button is **`inert`**, **`aria-hidden`**, and **`pointer-events-none`** so it does not steal taps or focus while still reserving the right column for centered month title layout. **`showToday`** drives visibility from `date !== today`.
> 
> **`mobile-screen.test.tsx`** now asserts the mounted hidden state (`opacity-0`, `inert`) and the visible state after picking another day, instead of expecting the control to disappear from the accessibility tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3de1208dd4367eee0734fbe69f75aac03229adb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->