### PR TITLE
Import Reflect V1 asset CDN links

### DIFF
--- a/apps/desktop/src-tauri/src/fs/import.rs
+++ b/apps/desktop/src-tauri/src/fs/import.rs
@@ -4,8 +4,8 @@
 //! `daily/`, `notes/`, optional `assets/`, plus ignorable local metadata. The
 //! import path is therefore a bounded archive extraction into the active graph,
 //! not a content migration — with one addition: attachments the notes link
-//! straight to Firebase Storage are downloaded into `assets/` and the links
-//! rewritten (see [`super::import_assets`]).
+//! straight to Reflect V1's storage hosts are downloaded into `assets/` and
+//! the links rewritten (see [`super::import_assets`]).
 //!
 //! The flow is three phases so nothing lands in the graph until everything is
 //! in hand: [`prepare_zip_import`] (read + validate, no writes), the async
@@ -147,7 +147,7 @@ pub struct PreparedImport {
     /// Unique remote-asset URLs across all notes, in first-seen order (which
     /// also fixes collision-suffix assignment).
     urls: Vec<String>,
-    prefix: String,
+    prefixes: Vec<String>,
 }
 
 impl PreparedImport {
@@ -179,15 +179,15 @@ impl PreparedImport {
 /// Read and validate a user-selected Reflect V1 export zip against `root`,
 /// without writing anything.
 pub(super) fn prepare_zip_import(root: &Path, zip_path: &Path) -> AppResult<PreparedImport> {
-    prepare_zip_import_from(root, zip_path, import_assets::V1_ASSET_URL_PREFIX)
+    prepare_zip_import_from(root, zip_path, import_assets::V1_ASSET_URL_PREFIXES)
 }
 
-/// [`prepare_zip_import`] with the remote-asset URL prefix injectable, so
+/// [`prepare_zip_import`] with the remote-asset URL prefixes injectable, so
 /// tests can point it at a local server.
 fn prepare_zip_import_from(
     root: &Path,
     zip_path: &Path,
-    prefix: &str,
+    prefixes: &[&str],
 ) -> AppResult<PreparedImport> {
     let entries = dedupe_entries(read_zip_entries(zip_path)?)?;
     ensure_has_notes(&entries)?;
@@ -200,7 +200,7 @@ fn prepare_zip_import_from(
         let Ok(text) = std::str::from_utf8(&entry.bytes) else {
             continue;
         };
-        for span in import_assets::scan_remote_spans(text, prefix) {
+        for span in import_assets::scan_remote_spans(text, prefixes) {
             if seen.insert(span.url.clone()) {
                 urls.push(span.url);
             }
@@ -210,7 +210,10 @@ fn prepare_zip_import_from(
         entries,
         staging: super::assets::staging_dir(root)?,
         urls,
-        prefix: prefix.to_string(),
+        prefixes: prefixes
+            .iter()
+            .map(|prefix| (*prefix).to_string())
+            .collect(),
     })
 }
 
@@ -261,7 +264,7 @@ pub(super) fn finalize_import(
     let PreparedImport {
         mut entries,
         urls,
-        prefix,
+        prefixes,
         ..
     } = prepared;
 
@@ -360,7 +363,8 @@ pub(super) fn finalize_import(
             // Zip-borne `assets/…` links first: the remote rewrite splices in
             // downloaded assets' final names, which must not be re-mapped.
             let rewritten = import_assets::rewrite_asset_paths(text, &path_replacements);
-            let rewritten = import_assets::rewrite_markdown(&rewritten, &prefix, &url_replacements);
+            let rewritten =
+                import_assets::rewrite_markdown(&rewritten, &prefixes, &url_replacements);
             if rewritten != text {
                 entry.bytes = rewritten.into_bytes();
             }
@@ -831,7 +835,10 @@ mod tests {
             entries,
             staging: super::super::assets::staging_dir(root)?,
             urls: Vec::new(),
-            prefix: import_assets::V1_ASSET_URL_PREFIX.to_string(),
+            prefixes: import_assets::V1_ASSET_URL_PREFIXES
+                .iter()
+                .map(|prefix| (*prefix).to_string())
+                .collect(),
         };
         finalize_import(root, prepared, HashMap::new(), |_, _| {})
     }
@@ -1493,10 +1500,29 @@ mod tests {
         zip_path: &Path,
         prefix: &str,
     ) -> AppResult<ImportSummary> {
-        let prepared = prepare_zip_import_from(root, zip_path, prefix)?;
+        let prepared = prepare_zip_import_from(root, zip_path, &[prefix])?;
         let downloads =
             tauri::async_runtime::block_on(prepared.download_assets(no_cancel(), no_progress()))?;
         finalize_import(root, prepared, downloads, |_, _| {})
+    }
+
+    #[test]
+    fn recognizes_both_v1_asset_url_families() {
+        let root = tempdir().unwrap();
+        let zip_path = root.path().join("export.zip");
+        let firebase =
+            "https://firebasestorage.googleapis.com/v0/b/reflect/o/users%2Fu%2Fa?alt=media&token=t";
+        let asset_cdn = "https://reflect-assets.app/v1/users/u/graph/a?key=k";
+        let markdown = format!("![]({firebase})\n\n[attachment]({asset_cdn})\n");
+        write_zip(&zip_path, &[("daily/2026-07-04.md", markdown.as_str())]);
+
+        let prepared = prepare_zip_import(root.path(), &zip_path).unwrap();
+
+        assert_eq!(prepared.remote_asset_count(), 2);
+        assert_eq!(
+            prepared.urls,
+            vec![firebase.to_string(), asset_cdn.to_string()]
+        );
     }
 
     #[test]
@@ -1574,7 +1600,7 @@ mod tests {
             .collect::<String>();
         write_zip(&zip_path, &[("daily/2026-07-04.md", markdown.as_str())]);
 
-        let prepared = prepare_zip_import_from(root.path(), &zip_path, &base).unwrap();
+        let prepared = prepare_zip_import_from(root.path(), &zip_path, &[base.as_str()]).unwrap();
         let Some(before) = open_fd_count() else {
             return;
         };
@@ -1683,7 +1709,7 @@ mod tests {
             .map(|index| format!("![]({base}asset-{index}?alt=media\\&token={index})\n"))
             .collect::<String>();
         write_zip(&zip_path, &[("daily/2026-07-04.md", markdown.as_str())]);
-        let prepared = prepare_zip_import_from(root.path(), &zip_path, &base).unwrap();
+        let prepared = prepare_zip_import_from(root.path(), &zip_path, &[base.as_str()]).unwrap();
         let seen = Arc::new(Mutex::new(Vec::new()));
         let record = Arc::clone(&seen);
 
@@ -1708,7 +1734,7 @@ mod tests {
         let zip_path = root.path().join("export.zip");
         let markdown = format!("![]({base}photo?alt=media\\&token=t)\n");
         write_zip(&zip_path, &[("daily/2026-07-04.md", markdown.as_str())]);
-        let prepared = prepare_zip_import_from(root.path(), &zip_path, &base).unwrap();
+        let prepared = prepare_zip_import_from(root.path(), &zip_path, &[base.as_str()]).unwrap();
         let cancelled = Arc::new(AtomicBool::new(true));
 
         let result =
@@ -1734,7 +1760,10 @@ mod tests {
             entries: dedupe_entries(entries).unwrap(),
             staging: super::super::assets::staging_dir(root.path()).unwrap(),
             urls: Vec::new(),
-            prefix: import_assets::V1_ASSET_URL_PREFIX.to_string(),
+            prefixes: import_assets::V1_ASSET_URL_PREFIXES
+                .iter()
+                .map(|prefix| (*prefix).to_string())
+                .collect(),
         };
         let mut seen = Vec::new();
 

--- a/apps/desktop/src-tauri/src/fs/import_assets.rs
+++ b/apps/desktop/src-tauri/src/fs/import_assets.rs
@@ -1,9 +1,10 @@
 //! Remote-asset localization for the Reflect V1 import.
 //!
-//! V1 notes link attachments straight at Firebase Storage download URLs. An
-//! import must not leave a graph depending on Reflect V1's infrastructure, so
-//! every such URL is downloaded into the graph's `assets/` directory and the
-//! markdown link is rewritten to the relative `assets/…` path.
+//! V1 notes link attachments straight at Firebase Storage and Reflect's asset
+//! CDN. An import must not leave a graph depending on Reflect V1's
+//! infrastructure, so every such URL is downloaded into the graph's `assets/`
+//! directory and the markdown link is rewritten to the relative `assets/…`
+//! path.
 //!
 //! Download failures split by permanence: a 4xx means the asset is gone (or
 //! the token was revoked) and no retry will help, so the note keeps its remote
@@ -20,9 +21,12 @@ use std::time::Duration;
 
 use crate::error::{AppError, AppResult};
 
-/// Only asset links on Reflect V1's storage host are localized; every other
+/// Only asset links on Reflect V1's storage hosts are localized; every other
 /// URL in the export is an ordinary link and imports untouched.
-pub(super) const V1_ASSET_URL_PREFIX: &str = "https://firebasestorage.googleapis.com/";
+pub(super) const V1_ASSET_URL_PREFIXES: &[&str] = &[
+    "https://firebasestorage.googleapis.com/",
+    "https://reflect-assets.app/v1/users/",
+];
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 /// Per-read stall timeout. There is deliberately no whole-request timeout so
@@ -57,13 +61,24 @@ pub(super) struct FetchedAsset {
     pub desired_name: String,
 }
 
-/// Find every remote-asset URL in `markdown` that starts with `prefix`.
+/// Find every remote-asset URL in `markdown` that starts with one of
+/// `prefixes`.
 ///
 /// V1 exports escape URL punctuation the CommonMark way (`?alt=media\&token=`),
 /// so the span keeps the escaped bytes (for splicing) while `url` holds the
 /// unescaped form (for fetching). A span ends at whitespace or any character
 /// that terminates a markdown link destination.
-pub(super) fn scan_remote_spans(markdown: &str, prefix: &str) -> Vec<RemoteSpan> {
+pub(super) fn scan_remote_spans<P: AsRef<str>>(markdown: &str, prefixes: &[P]) -> Vec<RemoteSpan> {
+    let mut spans = prefixes
+        .iter()
+        .flat_map(|prefix| scan_remote_spans_for_prefix(markdown, prefix.as_ref()))
+        .collect::<Vec<_>>();
+    spans.sort_unstable_by_key(|span| (span.start, span.end));
+    spans.dedup_by(|left, right| left.start == right.start && left.end == right.end);
+    spans
+}
+
+fn scan_remote_spans_for_prefix(markdown: &str, prefix: &str) -> Vec<RemoteSpan> {
     let mut spans = Vec::new();
     let mut from = 0;
     while let Some(found) = markdown[from..].find(prefix) {
@@ -108,13 +123,13 @@ pub(super) fn scan_remote_spans(markdown: &str, prefix: &str) -> Vec<RemoteSpan>
 /// Replace the remote spans of `markdown` whose URL has a localized path in
 /// `replacements` (URL → `assets/…`). URLs without a replacement (permanent
 /// download failures) keep their remote form.
-pub(super) fn rewrite_markdown(
+pub(super) fn rewrite_markdown<P: AsRef<str>>(
     markdown: &str,
-    prefix: &str,
+    prefixes: &[P],
     replacements: &HashMap<String, String>,
 ) -> String {
     let mut result = markdown.to_string();
-    for span in scan_remote_spans(markdown, prefix).into_iter().rev() {
+    for span in scan_remote_spans(markdown, prefixes).into_iter().rev() {
         if let Some(local) = replacements.get(&span.url) {
             result.replace_range(span.start..span.end, local);
         }
@@ -135,7 +150,7 @@ pub(super) fn rewrite_asset_paths(
         return markdown.to_string();
     }
     let mut result = markdown.to_string();
-    for span in scan_remote_spans(markdown, "assets/").into_iter().rev() {
+    for span in scan_remote_spans(markdown, &["assets/"]).into_iter().rev() {
         let opens_destination = markdown[..span.start]
             .chars()
             .next_back()
@@ -576,7 +591,7 @@ mod tests {
     #[test]
     fn scan_finds_escaped_urls_in_link_destinations() {
         let markdown = "![](https://firebasestorage.googleapis.com/v0/b/x/o/a?alt=media\\&token=t)\nplain text\n[memo.m4a](https://firebasestorage.googleapis.com/v0/b/x/o/b?alt=media\\&token=u)";
-        let spans = scan_remote_spans(markdown, PREFIX);
+        let spans = scan_remote_spans(markdown, &[PREFIX]);
         assert_eq!(spans.len(), 2);
         assert_eq!(
             spans[0].url,
@@ -595,13 +610,26 @@ mod tests {
     #[test]
     fn scan_ignores_other_hosts() {
         let markdown = "[a](https://example.com/file.png)";
-        assert!(scan_remote_spans(markdown, PREFIX).is_empty());
+        assert!(scan_remote_spans(markdown, &[PREFIX]).is_empty());
+    }
+
+    #[test]
+    fn scan_finds_both_v1_asset_url_families() {
+        let markdown = "![](https://firebasestorage.googleapis.com/v0/b/x/o/a?alt=media\\&token=t)\n![](https://reflect-assets.app/v1/users/user/graph/asset?key=k)";
+
+        let spans = scan_remote_spans(markdown, V1_ASSET_URL_PREFIXES);
+
+        assert_eq!(spans.len(), 2);
+        assert_eq!(
+            spans[1].url,
+            "https://reflect-assets.app/v1/users/user/graph/asset?key=k"
+        );
     }
 
     #[test]
     fn scan_stops_at_terminators() {
         let markdown = "see https://firebasestorage.googleapis.com/v0/o/a?alt=media end";
-        let spans = scan_remote_spans(markdown, PREFIX);
+        let spans = scan_remote_spans(markdown, &[PREFIX]);
         assert_eq!(spans.len(), 1);
         assert_eq!(
             spans[0].url,
@@ -617,7 +645,7 @@ mod tests {
             "assets/photo.webp".to_string(),
         )]);
         assert_eq!(
-            rewrite_markdown(markdown, PREFIX, &replacements),
+            rewrite_markdown(markdown, &[PREFIX], &replacements),
             "![](assets/photo.webp) and [f](https://firebasestorage.googleapis.com/o/b?alt=media\\&token=u)"
         );
     }


### PR DESCRIPTION
## Problem

Reflect V1 exports can reference remote attachments through two Reflect-owned URL families: Firebase Storage download URLs and `reflect-assets.app/v1/users/...` CDN URLs. The importer only recognized Firebase URLs, so CDN-backed attachments remained remote and were not copied into the V2 graph's `assets/` directory.

The supplied V1 export contains both forms (142 Firebase URLs and 31 asset-CDN URLs), so a single import needs to discover and localize them together.

## Before -> After

| URL family | Before | After |
| --- | --- | --- |
| Firebase Storage | Downloaded and rewritten to `assets/...` | Unchanged |
| Reflect asset CDN | Left as a remote URL | Downloaded and rewritten to `assets/...` |
| Unrelated web URLs | Left untouched | Unchanged |

## Changes

1. Replace the single V1 asset prefix with an allowlist containing both Reflect-owned storage URL families.
2. Generalize remote-span scanning and markdown rewriting to handle multiple prefixes while preserving note order, URL deduplication, deterministic collision naming, and the existing failure policy.
3. Add regression coverage for mixed-host scanning and for the production import configuration recognizing both URL families.

## Tests

- Mixed Firebase/CDN notes discover both attachments in first-seen order.
- Existing download, rewrite, deduplication, collision, cancellation, progress, and failure behavior continues to pass.

## Verification

- `cargo test -p reflect-open fs::import` — 41 passed, 0 failed.
- `pnpm check` — typecheck and lint passed; lint reported the existing `packages/core/src/indexing/indexer.ts` max-lines warning.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.

## Risk / Rollout

No migration or backfill runs automatically. The change only expands the existing V1 import allowlist to another Reflect-owned HTTPS prefix; download staging, transient/permanent failure handling, and graph writes use the existing path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to V1 zip import asset localization; only adds another Reflect-owned HTTPS prefix to the existing allowlist without changing auth, sync, or graph write semantics.
> 
> **Overview**
> V1 import now treats **`reflect-assets.app/v1/users/…`** links like Firebase Storage URLs: they are discovered, downloaded into `assets/`, and rewritten to local paths. Exports that mix both families are handled in one pass with the same deduplication, collision naming, and download failure behavior as before.
> 
> The single URL prefix constant becomes an allowlist (`V1_ASSET_URL_PREFIXES`). **`scan_remote_spans`** and **`rewrite_markdown`** take multiple prefixes, merge results, and dedupe overlapping spans. **`PreparedImport`** stores `prefixes` instead of one `prefix` through prepare/finalize.
> 
> Regression tests cover mixed-host scanning and production prep discovering both URL types in first-seen order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9de23b9b90507ff6327c1880d6431d1ebaa9623d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->