### PR TITLE
Add privacy-safe Sentry diagnostics for WebView errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,11 +87,12 @@ jobs:
           APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
         run: |
           missing=()
-          for name in APPLE_SIGNING_IDENTITY APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD SENTRY_DSN TAURI_SIGNING_PRIVATE_KEY; do
+          for name in APPLE_SIGNING_IDENTITY APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD SENTRY_AUTH_TOKEN SENTRY_DSN TAURI_SIGNING_PRIVATE_KEY; do
             [ -n "${!name}" ] || missing+=("$name")
           done
           if { [ -z "$APPLE_API_KEY" ] || [ -z "$APPLE_API_ISSUER" ] || [ -z "$APPLE_API_KEY_CONTENT" ]; } &&
@@ -150,6 +151,7 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,10 +87,11 @@ jobs:
           APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
         run: |
           missing=()
-          for name in APPLE_SIGNING_IDENTITY APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD TAURI_SIGNING_PRIVATE_KEY; do
+          for name in APPLE_SIGNING_IDENTITY APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD SENTRY_DSN TAURI_SIGNING_PRIVATE_KEY; do
             [ -n "${!name}" ] || missing+=("$name")
           done
           if { [ -z "$APPLE_API_KEY" ] || [ -z "$APPLE_API_ISSUER" ] || [ -z "$APPLE_API_KEY_CONTENT" ]; } &&
@@ -151,6 +152,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: pnpm release:macos build --target=${{ matrix.target }} --artifact-dir="$RUNNER_TEMP/release-artifacts"
 
       - name: Upload release artifacts

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -43,9 +43,10 @@ jobs:
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           missing=()
-          for name in APPLE_API_KEY APPLE_API_ISSUER APPLE_API_KEY_CONTENT; do
+          for name in APPLE_API_KEY APPLE_API_ISSUER APPLE_API_KEY_CONTENT SENTRY_DSN; do
             [ -n "${!name}" ] || missing+=("$name")
           done
           if [ "${#missing[@]}" -gt 0 ]; then
@@ -87,6 +88,7 @@ jobs:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
           EXPORT_METHOD: ${{ inputs.export_method }}
+          VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           WAIT_FLAG: ${{ inputs.wait_for_processing && '--wait' || '' }}
         run: |
           pnpm release:ios preflight --build-number="$BUILD_NUMBER"

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -43,10 +43,11 @@ jobs:
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           missing=()
-          for name in APPLE_API_KEY APPLE_API_ISSUER APPLE_API_KEY_CONTENT SENTRY_DSN; do
+          for name in APPLE_API_KEY APPLE_API_ISSUER APPLE_API_KEY_CONTENT SENTRY_AUTH_TOKEN SENTRY_DSN; do
             [ -n "${!name}" ] || missing+=("$name")
           done
           if [ "${#missing[@]}" -gt 0 ]; then
@@ -88,6 +89,7 @@ jobs:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
           EXPORT_METHOD: ${{ inputs.export_method }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           WAIT_FLAG: ${{ inputs.wait_for_processing && '--wait' || '' }}
         run: |

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -29,6 +29,7 @@
     "@reflect/db": "workspace:*",
     "@reflect/design-system": "workspace:*",
     "@reflect/utils": "workspace:*",
+    "@sentry/react": "^10.64.0",
     "@shadcn/react": "^0.1.0",
     "@tanstack/react-query": "^5.101.1",
     "@tauri-apps/api": "^2.11.1",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -58,6 +58,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
+    "@sentry/vite-plugin": "^5.3.0",
     "@sqlite.org/sqlite-wasm": "3.53.0-build1",
     "@tailwindcss/vite": "^4.3.1",
     "@tauri-apps/cli": "^2.11.3",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: reflect-asset: https:; font-src 'self' data:; frame-src 'self' https://platform.twitter.com https://platform.x.com https://syndication.twitter.com https://www.youtube-nocookie.com https://www.youtube.com; connect-src 'self' ipc: http://ipc.localhost https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://openrouter.ai https://github.com https://api.github.com"
+      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: reflect-asset: https:; font-src 'self' data:; frame-src 'self' https://platform.twitter.com https://platform.x.com https://syndication.twitter.com https://www.youtube-nocookie.com https://www.youtube.com; connect-src 'self' ipc: http://ipc.localhost https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://openrouter.ai https://github.com https://api.github.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://*.ingest.de.sentry.io"
     }
   },
   "plugins": {

--- a/apps/desktop/src/lib/exception-telemetry.test.ts
+++ b/apps/desktop/src/lib/exception-telemetry.test.ts
@@ -1,6 +1,33 @@
 import { describe, expect, it } from 'vitest'
 import type { ErrorEvent } from '@sentry/react'
-import { createExceptionTelemetryOptions, scrubExceptionEvent } from './exception-telemetry'
+import {
+  createExceptionTelemetryOptions,
+  parseExceptionTelemetryDsn,
+  scrubExceptionEvent,
+} from './exception-telemetry'
+
+describe('parseExceptionTelemetryDsn', () => {
+  it('accepts only the production Reflect Sentry project', () => {
+    expect(
+      parseExceptionTelemetryDsn(
+        ' https://0123456789abcdef0123456789abcdef@o463484.ingest.us.sentry.io/4511705649971200 ',
+      ),
+    ).toBe(
+      'https://0123456789abcdef0123456789abcdef@o463484.ingest.us.sentry.io/4511705649971200',
+    )
+    expect(
+      parseExceptionTelemetryDsn(
+        'https://0123456789abcdef0123456789abcdef@evil.example/4511705649971200',
+      ),
+    ).toBeNull()
+    expect(
+      parseExceptionTelemetryDsn(
+        'https://0123456789abcdef0123456789abcdef@o463484.ingest.us.sentry.io/123',
+      ),
+    ).toBeNull()
+    expect(parseExceptionTelemetryDsn(undefined)).toBeNull()
+  })
+})
 
 describe('scrubExceptionEvent', () => {
   it('rebuilds exceptions from an allow-list and removes user and request data', () => {
@@ -24,6 +51,20 @@ describe('scrubExceptionEvent', () => {
       tags: { graphId: 'graph-123' },
       modules: { privatePlugin: '1.0.0' },
       fingerprint: ['person@example.com'],
+      debug_meta: {
+        images: [
+          {
+            type: 'sourcemap',
+            code_file: 'file:///Users/alex/reflect/dist/assets/main-ABC123.js',
+            debug_id: '12345678-1234-1234-1234-123456789abc',
+          },
+          {
+            type: 'sourcemap',
+            code_file: '/Users/alex/Notes/Customers/Acme.md',
+            debug_id: 'person@example.com',
+          },
+        ],
+      },
       exception: {
         values: [
           {
@@ -74,13 +115,21 @@ describe('scrubExceptionEvent', () => {
               frames: [
                 {
                   filename: 'app:///main-ABC123.js',
-                  function: 'openDailyNote',
                   lineno: 42,
                   colno: 7,
                   in_app: true,
                 },
               ],
             },
+          },
+        ],
+      },
+      debug_meta: {
+        images: [
+          {
+            type: 'sourcemap',
+            code_file: 'app:///main-ABC123.js',
+            debug_id: '12345678-1234-1234-1234-123456789abc',
           },
         ],
       },
@@ -127,7 +176,6 @@ describe('scrubExceptionEvent', () => {
               frames: [
                 {
                   filename: 'app:///[redacted]',
-                  function: '[redacted]',
                 },
               ],
             },

--- a/apps/desktop/src/lib/exception-telemetry.test.ts
+++ b/apps/desktop/src/lib/exception-telemetry.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest'
+import type { ErrorEvent } from '@sentry/react'
+import { createExceptionTelemetryOptions, scrubExceptionEvent } from './exception-telemetry'
+
+describe('scrubExceptionEvent', () => {
+  it('rebuilds exceptions from an allow-list and removes user and request data', () => {
+    const event: ErrorEvent = {
+      type: undefined,
+      event_id: '0123456789abcdef0123456789abcdef',
+      timestamp: 1_725_000_000,
+      release: 'reflect@0.4.0-beta.45',
+      environment: 'production',
+      message: 'Could not open /Users/alex/Notes/Customers/Acme.md',
+      transaction: '/Users/alex/Notes',
+      user: { id: 'user-123', email: 'person@example.com', ip_address: '192.0.2.1' },
+      request: {
+        url: 'https://api.example.test/graphs/alex',
+        data: { note: 'A private note' },
+        headers: { authorization: 'Bearer secret' },
+      },
+      breadcrumbs: [{ message: 'Opened Acme', data: { path: '/Users/alex/Notes' } }],
+      contexts: { graph: { title: 'Customers' } },
+      extra: { noteContent: 'A private note' },
+      tags: { graphId: 'graph-123' },
+      modules: { privatePlugin: '1.0.0' },
+      fingerprint: ['person@example.com'],
+      exception: {
+        values: [
+          {
+            type: 'TypeError',
+            value: 'Customer “Acme” failed at /Users/alex/Notes/Customers/Acme.md',
+            mechanism: {
+              type: 'onerror',
+              handled: false,
+              data: { target: 'person@example.com' },
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename: 'file:///Users/alex/reflect/dist/assets/main-ABC123.js?graph=Customers',
+                  function: 'openDailyNote',
+                  lineno: 42,
+                  colno: 7,
+                  in_app: true,
+                  abs_path: '/Users/alex/reflect/dist/assets/main-ABC123.js',
+                  context_line: 'throw new Error(note.title)',
+                  pre_context: ['const title = note.title'],
+                  post_context: ['sendRequest(note.content)'],
+                  vars: { title: 'Acme' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }
+
+    expect(scrubExceptionEvent(event)).toEqual({
+      type: undefined,
+      event_id: '0123456789abcdef0123456789abcdef',
+      timestamp: 1_725_000_000,
+      release: 'reflect@0.4.0-beta.45',
+      environment: 'production',
+      level: 'error',
+      platform: 'javascript',
+      tags: { runtime: 'tauri-webview' },
+      exception: {
+        values: [
+          {
+            type: 'TypeError',
+            value: '[redacted]',
+            mechanism: { type: 'onerror', handled: false },
+            stacktrace: {
+              frames: [
+                {
+                  filename: 'app:///main-ABC123.js',
+                  function: 'openDailyNote',
+                  lineno: 42,
+                  colno: 7,
+                  in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    })
+  })
+
+  it('redacts untrusted types, function names, filenames, mechanisms, and release values', () => {
+    const event: ErrorEvent = {
+      type: undefined,
+      event_id: 'person@example.com',
+      release: 'reflect@0.4.0-/Users/alex',
+      environment: 'person@example.com',
+      exception: {
+        values: [
+          {
+            type: 'Customer Acme',
+            value: 'private note text',
+            mechanism: { type: 'custom-person@example.com' },
+            stacktrace: {
+              frames: [
+                {
+                  filename: '/Users/alex/Notes/Acme.md',
+                  function: 'Customer Acme',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }
+
+    expect(scrubExceptionEvent(event)).toEqual({
+      type: undefined,
+      level: 'error',
+      platform: 'javascript',
+      tags: { runtime: 'tauri-webview' },
+      exception: {
+        values: [
+          {
+            type: 'Error',
+            value: '[redacted]',
+            mechanism: { type: 'generic' },
+            stacktrace: {
+              frames: [
+                {
+                  filename: 'app:///[redacted]',
+                  function: '[redacted]',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    })
+  })
+
+  it('drops non-exception events', () => {
+    expect(scrubExceptionEvent({ type: undefined, message: 'note content' })).toBeNull()
+  })
+})
+
+describe('createExceptionTelemetryOptions', () => {
+  it('enables only exception integrations and disables ambient collection', () => {
+    const options = createExceptionTelemetryOptions(
+      'https://public@example.ingest.sentry.io/123',
+      'reflect@0.4.0-beta.45',
+    )
+
+    expect(options.defaultIntegrations).toBe(false)
+    expect(options.integrations).toEqual([
+      expect.objectContaining({ name: 'GlobalHandlers' }),
+      expect.objectContaining({ name: 'LinkedErrors' }),
+      expect.objectContaining({ name: 'Dedupe' }),
+    ])
+    expect(options.maxBreadcrumbs).toBe(0)
+    expect(options.tracesSampleRate).toBe(0)
+    expect(options.replaysSessionSampleRate).toBe(0)
+    expect(options.replaysOnErrorSampleRate).toBe(0)
+    expect(options.sendClientReports).toBe(false)
+    expect(options.sendDefaultPii).toBe(false)
+    expect(options.dataCollection).toEqual({
+      userInfo: false,
+      cookies: false,
+      httpHeaders: { request: false, response: false },
+      httpBodies: [],
+      queryParams: false,
+      genAI: { inputs: false, outputs: false },
+      stackFrameVariables: false,
+      frameContextLines: 0,
+    })
+  })
+})

--- a/apps/desktop/src/lib/exception-telemetry.ts
+++ b/apps/desktop/src/lib/exception-telemetry.ts
@@ -1,0 +1,213 @@
+import {
+  dedupeIntegration,
+  globalHandlersIntegration,
+  init,
+  linkedErrorsIntegration,
+  reactErrorHandler,
+} from '@sentry/react'
+import type { BrowserOptions, ErrorEvent, Exception, StackFrame } from '@sentry/react'
+import type { RootOptions } from 'react-dom/client'
+
+const REDACTED_VALUE = '[redacted]'
+const MAX_EXCEPTION_COUNT = 3
+const MAX_STACK_FRAME_COUNT = 50
+
+const SAFE_EXCEPTION_TYPES = new Set([
+  'AbortError',
+  'AggregateError',
+  'DOMException',
+  'Error',
+  'EvalError',
+  'NetworkError',
+  'NotAllowedError',
+  'NotFoundError',
+  'QuotaExceededError',
+  'RangeError',
+  'ReferenceError',
+  'SyntaxError',
+  'TypeError',
+  'URIError',
+])
+
+const SAFE_MECHANISM_TYPES = new Set([
+  'auto.function.react.error_handler',
+  'generic',
+  'onerror',
+  'onunhandledrejection',
+])
+
+const SAFE_FUNCTION_NAME = /^(?:async |new )?[A-Za-z_$][\w$]*(?:(?:\.|#)[A-Za-z_$][\w$]*)*$/
+const SAFE_SCRIPT_BASENAME = /^[A-Za-z0-9_.-]+\.(?:js|jsx|mjs|ts|tsx)$/
+const SAFE_RELEASE = /^reflect@\d+\.\d+\.\d+(?:-[a-z0-9.-]+)?$/
+const SAFE_EVENT_ID = /^[a-f0-9]{32}$/
+
+function scrubExceptionType(type: string | undefined): string {
+  if (type?.startsWith('React ErrorBoundary ')) {
+    const causeType = type.slice('React ErrorBoundary '.length)
+    return SAFE_EXCEPTION_TYPES.has(causeType) ? `ReactErrorBoundary<${causeType}>` : 'ReactErrorBoundary<Error>'
+  }
+  return type && SAFE_EXCEPTION_TYPES.has(type) ? type : 'Error'
+}
+
+function scrubFunctionName(functionName: string | undefined): string | undefined {
+  if (!functionName) {
+    return undefined
+  }
+  if (functionName === '<anonymous>' || functionName === 'global code') {
+    return functionName
+  }
+  return functionName.length <= 120 && SAFE_FUNCTION_NAME.test(functionName)
+    ? functionName
+    : REDACTED_VALUE
+}
+
+function scrubFilename(filename: string | undefined): string | undefined {
+  if (!filename) {
+    return undefined
+  }
+  const pathWithoutQuery = filename.split(/[?#]/, 1)[0]
+  const basename = pathWithoutQuery?.split(/[\\/]/).at(-1)
+  return basename && SAFE_SCRIPT_BASENAME.test(basename)
+    ? `app:///${basename}`
+    : `app:///${REDACTED_VALUE}`
+}
+
+function scrubStackFrame(frame: StackFrame): StackFrame {
+  const scrubbed: StackFrame = {}
+  const filename = scrubFilename(frame.filename)
+  const functionName = scrubFunctionName(frame.function)
+  if (filename) {
+    scrubbed.filename = filename
+  }
+  if (functionName) {
+    scrubbed.function = functionName
+  }
+  if (typeof frame.lineno === 'number' && Number.isFinite(frame.lineno)) {
+    scrubbed.lineno = frame.lineno
+  }
+  if (typeof frame.colno === 'number' && Number.isFinite(frame.colno)) {
+    scrubbed.colno = frame.colno
+  }
+  if (typeof frame.in_app === 'boolean') {
+    scrubbed.in_app = frame.in_app
+  }
+  return scrubbed
+}
+
+function scrubException(exception: Exception): Exception {
+  const scrubbed: Exception = {
+    type: scrubExceptionType(exception.type),
+    value: REDACTED_VALUE,
+  }
+  if (exception.mechanism) {
+    scrubbed.mechanism = {
+      type: SAFE_MECHANISM_TYPES.has(exception.mechanism.type)
+        ? exception.mechanism.type
+        : 'generic',
+      ...(typeof exception.mechanism.handled === 'boolean'
+        ? { handled: exception.mechanism.handled }
+        : {}),
+    }
+  }
+  if (exception.stacktrace?.frames) {
+    scrubbed.stacktrace = {
+      frames: exception.stacktrace.frames
+        .slice(-MAX_STACK_FRAME_COUNT)
+        .map(scrubStackFrame),
+    }
+  }
+  return scrubbed
+}
+
+/**
+ * Reduce a Sentry error event to the diagnostic allow-list. This deliberately
+ * constructs a new event rather than deleting known-sensitive fields so new
+ * SDK fields cannot begin leaving the device unnoticed after an upgrade.
+ */
+export function scrubExceptionEvent(event: ErrorEvent): ErrorEvent | null {
+  const exceptions = event.exception?.values
+  if (!exceptions?.length) {
+    return null
+  }
+
+  return {
+    type: undefined,
+    level: 'error',
+    platform: 'javascript',
+    tags: { runtime: 'tauri-webview' },
+    exception: {
+      values: exceptions.slice(-MAX_EXCEPTION_COUNT).map(scrubException),
+    },
+    ...(event.event_id && SAFE_EVENT_ID.test(event.event_id) ? { event_id: event.event_id } : {}),
+    ...(typeof event.timestamp === 'number' && Number.isFinite(event.timestamp)
+      ? { timestamp: event.timestamp }
+      : {}),
+    ...(event.release && SAFE_RELEASE.test(event.release) ? { release: event.release } : {}),
+    ...(event.environment === 'production' ? { environment: 'production' } : {}),
+  }
+}
+
+/** Build the exception-only Sentry configuration shared by desktop and iOS WebViews. */
+export function createExceptionTelemetryOptions(dsn: string, release: string): BrowserOptions {
+  return {
+    dsn,
+    release,
+    environment: 'production',
+    defaultIntegrations: false,
+    integrations: [
+      globalHandlersIntegration(),
+      linkedErrorsIntegration({ limit: 2 }),
+      dedupeIntegration(),
+    ],
+    sampleRate: 1,
+    tracesSampleRate: 0,
+    replaysSessionSampleRate: 0,
+    replaysOnErrorSampleRate: 0,
+    sendClientReports: false,
+    enableLogs: false,
+    sendDefaultPii: false,
+    dataCollection: {
+      userInfo: false,
+      cookies: false,
+      httpHeaders: { request: false, response: false },
+      httpBodies: [],
+      queryParams: false,
+      genAI: { inputs: false, outputs: false },
+      stackFrameVariables: false,
+      frameContextLines: 0,
+    },
+    maxBreadcrumbs: 0,
+    beforeBreadcrumb: () => null,
+    normalizeDepth: 1,
+    normalizeMaxBreadth: 10,
+    maxValueLength: 200,
+    enhanceFetchErrorMessages: false,
+    beforeSend: scrubExceptionEvent,
+    beforeSendTransaction: () => null,
+  }
+}
+
+/**
+ * Start production exception telemetry before app bootstrap and return the
+ * React 19 root handlers which capture render and recovery failures.
+ */
+export function initializeExceptionTelemetry(): RootOptions {
+  const dsn = import.meta.env.VITE_SENTRY_DSN?.trim()
+  if (!import.meta.env.PROD || !dsn) {
+    return {}
+  }
+
+  init(createExceptionTelemetryOptions(dsn, `reflect@${__REFLECT_VERSION__}`))
+  const adaptReactErrorHandler = (
+    handler: ReturnType<typeof reactErrorHandler>,
+  ): ((error: unknown, errorInfo: { componentStack?: string | undefined }) => void) => {
+    return (error, errorInfo): void => {
+      handler(error, { componentStack: errorInfo.componentStack ?? null })
+    }
+  }
+  return {
+    onCaughtError: adaptReactErrorHandler(reactErrorHandler(() => {})),
+    onRecoverableError: adaptReactErrorHandler(reactErrorHandler(() => {})),
+    onUncaughtError: adaptReactErrorHandler(reactErrorHandler()),
+  }
+}

--- a/apps/desktop/src/lib/exception-telemetry.ts
+++ b/apps/desktop/src/lib/exception-telemetry.ts
@@ -7,6 +7,7 @@ import {
 } from '@sentry/react'
 import type { BrowserOptions, ErrorEvent, Exception, StackFrame } from '@sentry/react'
 import type { RootOptions } from 'react-dom/client'
+import { z } from 'zod'
 
 const REDACTED_VALUE = '[redacted]'
 const MAX_EXCEPTION_COUNT = 3
@@ -36,10 +37,30 @@ const SAFE_MECHANISM_TYPES = new Set([
   'onunhandledrejection',
 ])
 
-const SAFE_FUNCTION_NAME = /^(?:async |new )?[A-Za-z_$][\w$]*(?:(?:\.|#)[A-Za-z_$][\w$]*)*$/
 const SAFE_SCRIPT_BASENAME = /^[A-Za-z0-9_.-]+\.(?:js|jsx|mjs|ts|tsx)$/
 const SAFE_RELEASE = /^reflect@\d+\.\d+\.\d+(?:-[a-z0-9.-]+)?$/
 const SAFE_EVENT_ID = /^[a-f0-9]{32}$/
+const SAFE_DEBUG_ID = /^(?:[a-f0-9]{32}|[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12})$/
+const SENTRY_DSN_SCHEMA = z
+  .url()
+  .transform((value) => new URL(value))
+  .refine(
+    (url) =>
+      url.protocol === 'https:' &&
+      url.hostname === 'o463484.ingest.us.sentry.io' &&
+      url.pathname === '/4511705649971200' &&
+      /^[a-f0-9]{32}$/.test(url.username) &&
+      !url.password &&
+      !url.search &&
+      !url.hash,
+  )
+  .transform((url) => url.toString())
+
+/** Accept only the production Reflect Sentry project DSN, while allowing public-key rotation. */
+export function parseExceptionTelemetryDsn(value: string | undefined): string | null {
+  const parsed = SENTRY_DSN_SCHEMA.safeParse(value?.trim())
+  return parsed.success ? parsed.data : null
+}
 
 function scrubExceptionType(type: string | undefined): string {
   if (type?.startsWith('React ErrorBoundary ')) {
@@ -47,18 +68,6 @@ function scrubExceptionType(type: string | undefined): string {
     return SAFE_EXCEPTION_TYPES.has(causeType) ? `ReactErrorBoundary<${causeType}>` : 'ReactErrorBoundary<Error>'
   }
   return type && SAFE_EXCEPTION_TYPES.has(type) ? type : 'Error'
-}
-
-function scrubFunctionName(functionName: string | undefined): string | undefined {
-  if (!functionName) {
-    return undefined
-  }
-  if (functionName === '<anonymous>' || functionName === 'global code') {
-    return functionName
-  }
-  return functionName.length <= 120 && SAFE_FUNCTION_NAME.test(functionName)
-    ? functionName
-    : REDACTED_VALUE
 }
 
 function scrubFilename(filename: string | undefined): string | undefined {
@@ -75,12 +84,8 @@ function scrubFilename(filename: string | undefined): string | undefined {
 function scrubStackFrame(frame: StackFrame): StackFrame {
   const scrubbed: StackFrame = {}
   const filename = scrubFilename(frame.filename)
-  const functionName = scrubFunctionName(frame.function)
   if (filename) {
     scrubbed.filename = filename
-  }
-  if (functionName) {
-    scrubbed.function = functionName
   }
   if (typeof frame.lineno === 'number' && Number.isFinite(frame.lineno)) {
     scrubbed.lineno = frame.lineno
@@ -92,6 +97,17 @@ function scrubStackFrame(frame: StackFrame): StackFrame {
     scrubbed.in_app = frame.in_app
   }
   return scrubbed
+}
+
+function scrubDebugMeta(debugMeta: ErrorEvent['debug_meta']): ErrorEvent['debug_meta'] {
+  const images = debugMeta?.images?.flatMap((image) => {
+    if (image.type !== 'sourcemap' || !SAFE_DEBUG_ID.test(image.debug_id)) {
+      return []
+    }
+    const codeFile = scrubFilename(image.code_file)
+    return codeFile ? [{ type: 'sourcemap' as const, code_file: codeFile, debug_id: image.debug_id }] : []
+  })
+  return images?.length ? { images } : undefined
 }
 
 function scrubException(exception: Exception): Exception {
@@ -130,6 +146,7 @@ export function scrubExceptionEvent(event: ErrorEvent): ErrorEvent | null {
     return null
   }
 
+  const debugMeta = scrubDebugMeta(event.debug_meta)
   return {
     type: undefined,
     level: 'error',
@@ -144,6 +161,7 @@ export function scrubExceptionEvent(event: ErrorEvent): ErrorEvent | null {
       : {}),
     ...(event.release && SAFE_RELEASE.test(event.release) ? { release: event.release } : {}),
     ...(event.environment === 'production' ? { environment: 'production' } : {}),
+    ...(debugMeta ? { debug_meta: debugMeta } : {}),
   }
 }
 
@@ -192,12 +210,16 @@ export function createExceptionTelemetryOptions(dsn: string, release: string): B
  * React 19 root handlers which capture render and recovery failures.
  */
 export function initializeExceptionTelemetry(): RootOptions {
-  const dsn = import.meta.env.VITE_SENTRY_DSN?.trim()
+  const dsn = parseExceptionTelemetryDsn(import.meta.env.VITE_SENTRY_DSN)
   if (!import.meta.env.PROD || !dsn) {
     return {}
   }
 
-  init(createExceptionTelemetryOptions(dsn, `reflect@${__REFLECT_VERSION__}`))
+  try {
+    init(createExceptionTelemetryOptions(dsn, `reflect@${__REFLECT_VERSION__}`))
+  } catch {
+    return {}
+  }
   const adaptReactErrorHandler = (
     handler: ReturnType<typeof reactErrorHandler>,
   ): ((error: unknown, errorInfo: { componentStack?: string | undefined }) => void) => {

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { queryClient } from '@/lib/query-client'
 import { registerAppCommands } from '@/lib/commands/app-commands'
+import { initializeExceptionTelemetry } from '@/lib/exception-telemetry'
 import { installNativeMenu } from '@/lib/native-menu/menu'
 import { installTauriBridge } from '@/lib/tauri-bridge'
 import { PlatformRoot, warmPlatformRoot } from '@/platform-root'
@@ -11,6 +12,7 @@ import { SettingsProvider } from '@/providers/settings-provider'
 import { ThemeProvider } from '@/providers/theme-provider'
 import '@/styles/index.css'
 
+const reactRootOptions = initializeExceptionTelemetry()
 installTauriBridge()
 // Start the platform resolve + surface-chunk fetch (and, on mobile, the
 // iCloud-container resolve) now, ahead of React's first render — the lazy
@@ -29,7 +31,7 @@ if (!rootElement) {
 // Platform-neutral providers only — everything desktop- or mobile-specific
 // (update checks, drag region, graph bootstrap mode) lives inside the lazy
 // trees behind the PlatformRoot gate (Plan 19).
-createRoot(rootElement).render(
+createRoot(rootElement, reactRootOptions).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <SettingsProvider>

--- a/apps/desktop/src/vite-env.d.ts
+++ b/apps/desktop/src/vite-env.d.ts
@@ -6,4 +6,9 @@ interface ImportMetaEnv {
    * `linux`, `ios`, `android`). Absent in plain Vite builds and tests.
    */
   readonly TAURI_ENV_PLATFORM?: string
+  /** Public Sentry project endpoint injected only into official release builds. */
+  readonly VITE_SENTRY_DSN?: string
 }
+
+/** App version injected from the canonical Tauri configuration by Vite. */
+declare const __REFLECT_VERSION__: string

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -2,6 +2,7 @@ import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
 import tailwindcss from '@tailwindcss/vite'
 import { reactWithCompiler } from './react-compiler-plugin'
+import tauriConfig from './src-tauri/tauri.conf.json'
 
 // @ts-expect-error process is a Node.js global available in the Vite config context
 const host = process.env.TAURI_DEV_HOST
@@ -9,6 +10,10 @@ const host = process.env.TAURI_DEV_HOST
 // https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [reactWithCompiler(), tailwindcss()],
+
+  define: {
+    __REFLECT_VERSION__: JSON.stringify(tauriConfig.version),
+  },
 
   // If the target is below Safari 17.5, Lightning CSS downlevels `light-dark()` to a broken polyfill.
   build: { cssTarget: 'safari17.5' },

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,4 +1,5 @@
 import { fileURLToPath } from 'node:url'
+import { sentryVitePlugin } from '@sentry/vite-plugin'
 import { defineConfig } from 'vite'
 import tailwindcss from '@tailwindcss/vite'
 import { reactWithCompiler } from './react-compiler-plugin'
@@ -9,14 +10,29 @@ const host = process.env.TAURI_DEV_HOST
 
 // https://vite.dev/config/
 export default defineConfig(async () => ({
-  plugins: [reactWithCompiler(), tailwindcss()],
+  plugins: [
+    reactWithCompiler(),
+    tailwindcss(),
+    sentryVitePlugin({
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+      org: 'reflect-64',
+      project: 'reflect-open',
+      telemetry: false,
+      release: {
+        name: `reflect@${tauriConfig.version}`,
+      },
+      sourcemaps: {
+        filesToDeleteAfterUpload: ['./dist/**/*.map'],
+      },
+    }),
+  ],
 
   define: {
     __REFLECT_VERSION__: JSON.stringify(tauriConfig.version),
   },
 
   // If the target is below Safari 17.5, Lightning CSS downlevels `light-dark()` to a broken polyfill.
-  build: { cssTarget: 'safari17.5' },
+  build: { cssTarget: 'safari17.5', sourcemap: 'hidden' },
 
   resolve: {
     alias: {

--- a/docs/ios-testflight.md
+++ b/docs/ios-testflight.md
@@ -60,7 +60,11 @@ for `pnpm release:ios testflight`.
    created by `pnpm release:macos setup`, passing the stored password to altool
    through `@env:APPLE_PASSWORD`.
 
-4. **A monotonically increasing build number.** TestFlight rejects duplicate
+4. **The exception telemetry DSN.** Set `VITE_SENTRY_DSN` for local TestFlight builds and
+   configure the same public Sentry DSN as the repository secret `SENTRY_DSN`. The
+   TestFlight workflow requires it before building.
+
+5. **A monotonically increasing build number.** TestFlight rejects duplicate
    `CFBundleVersion` values for the same marketing version. The GitHub Action
    always generates a UTC timestamp in `YYYYMMDDHHmm` format. Local `preflight`
    and `testflight` commands generate the same timestamp when `--build-number`

--- a/docs/ios-testflight.md
+++ b/docs/ios-testflight.md
@@ -60,9 +60,11 @@ for `pnpm release:ios testflight`.
    created by `pnpm release:macos setup`, passing the stored password to altool
    through `@env:APPLE_PASSWORD`.
 
-4. **The exception telemetry DSN.** Set `VITE_SENTRY_DSN` for local TestFlight builds and
-   configure the same public Sentry DSN as the repository secret `SENTRY_DSN`. The
-   TestFlight workflow requires it before building.
+4. **Sentry exception telemetry credentials.** Set the public `VITE_SENTRY_DSN` and the
+   private, build-only `SENTRY_AUTH_TOKEN` for local TestFlight builds. Configure them in
+   GitHub as the repository secrets `SENTRY_DSN` and `SENTRY_AUTH_TOKEN`; the TestFlight
+   workflow requires both before building. The token needs release/source-map upload
+   scope only and must never use the `VITE_` prefix or enter the app bundle.
 
 5. **A monotonically increasing build number.** TestFlight rejects duplicate
    `CFBundleVersion` values for the same marketing version. The GitHub Action

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -41,9 +41,12 @@ The helper lives at `apps/desktop/scripts/release-macos.mjs` and is exposed as
    reject anything not signed with it), so back it up; rotating it only reaches users via
    a release signed with the old key that ships the new pubkey.
 
-5. **The exception telemetry DSN.** Set `VITE_SENTRY_DSN` for local release builds and
-   configure the same public Sentry DSN as the repository secret `SENTRY_DSN`. Release CI
-   requires it so packaged builds cannot silently ship without JavaScript diagnostics.
+5. **Sentry exception telemetry credentials.** Set the public `VITE_SENTRY_DSN` and the
+   private, build-only `SENTRY_AUTH_TOKEN` for local release builds. Configure them in
+   GitHub as the repository secrets `SENTRY_DSN` and `SENTRY_AUTH_TOKEN`; release CI
+   requires both so packaged builds cannot silently ship without JavaScript diagnostics
+   or readable source-mapped stacks. The token needs release/source-map upload scope only
+   and must never use the `VITE_` prefix or enter an app bundle.
 
 Nothing signing-related is committed to the repo: contributors without the certificate
 can still build unsigned bundles with plain `pnpm tauri build`.

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -41,6 +41,10 @@ The helper lives at `apps/desktop/scripts/release-macos.mjs` and is exposed as
    reject anything not signed with it), so back it up; rotating it only reaches users via
    a release signed with the old key that ships the new pubkey.
 
+5. **The exception telemetry DSN.** Set `VITE_SENTRY_DSN` for local release builds and
+   configure the same public Sentry DSN as the repository secret `SENTRY_DSN`. Release CI
+   requires it so packaged builds cannot silently ship without JavaScript diagnostics.
+
 Nothing signing-related is committed to the repo: contributors without the certificate
 can still build unsigned bundles with plain `pnpm tauri build`.
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -2,8 +2,9 @@
 
 Reflect is local-first: your notes are markdown files in a folder you chose, the search
 index is SQLite in `.reflect/` beside them, and **no Reflect-hosted server exists in any
-path** — there is no telemetry, no analytics, and no account. Every network call the app
-can make is listed here, with what it carries.
+path** — there is no product analytics and no account. Official release builds send
+scrubbed JavaScript exception diagnostics to Sentry. Every network call the app can make
+is listed here, with what it carries.
 
 The one hard rule sits above all of it: **a note with `private: true` frontmatter never
 has its content sent to any external service.** This is enforced in code at every AI
@@ -84,6 +85,19 @@ disk at call time), and it is covered by tests.
   the meeting being added). Turning it off — in Settings or in the OS privacy pane —
   stops all reads immediately.
 
+## Exception diagnostics (on in official release builds)
+
+- **Where:** Sentry, for errors raised in the React/WebView layer. Native process crashes
+  remain covered by the operating system's crash reporting.
+- **What:** an allow-listed diagnostic containing the exception class, redacted exception
+  text, sanitized JavaScript stack locations, the app version, and whether React handled
+  the error. Stack filenames are reduced to bundle basenames. Request data, note content,
+  note titles, graph paths, local filesystem paths, breadcrumbs, console output, session
+  replay, tracing, IP addresses, and user identifiers are not collected.
+- **When:** only when an official desktop or iOS release raises an uncaught JavaScript
+  error, an unhandled promise rejection, or a caught/recoverable React error. Development
+  and self-built apps without the release DSN do not initialize Sentry.
+
 ## Housekeeping calls
 
 - **API key validation:** adding a provider key sends one cheap authenticated probe to
@@ -113,3 +127,4 @@ API keys and tokens live in the **OS keychain only** — never in markdown, neve
 | Update check | GitHub Releases | No | On in packaged builds |
 | Browser capture | Nowhere (local host on disk) | — (stays on your machine) | — (only when you capture) |
 | Contacts lookup | Nowhere (on-device OS store) | — (stays on your machine) | Yes (opt-in) |
+| Exception diagnostics | Sentry | No — messages and context are redacted | No (official releases) |

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -93,10 +93,16 @@ disk at call time), and it is covered by tests.
   text, sanitized JavaScript stack locations, the app version, and whether React handled
   the error. Stack filenames are reduced to bundle basenames. Request data, note content,
   note titles, graph paths, local filesystem paths, breadcrumbs, console output, session
-  replay, tracing, IP addresses, and user identifiers are not collected.
+  replay, tracing, and user identifiers are not collected. Sentry is also configured not
+  to store the transport IP address with events.
 - **When:** only when an official desktop or iOS release raises an uncaught JavaScript
   error, an unhandled promise rejection, or a caught/recoverable React error. Development
   and self-built apps without the release DSN do not initialize Sentry.
+- **Operational safeguards:** Sentry's server-side and default scrubbers are enabled, IP
+  address storage and server-side JavaScript source scraping are disabled, and explicit
+  sensitive-field rules cover notes, graph paths, requests, and user identifiers. Private
+  source maps are uploaded during official builds for readable stacks, then deleted from
+  the app bundle.
 
 ## Housekeeping calls
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@reflect/utils':
         specifier: workspace:*
         version: link:../../packages/utils
+      '@sentry/react':
+        specifier: ^10.64.0
+        version: 10.64.0(react@19.2.7)
       '@shadcn/react':
         specifier: ^0.1.0
         version: 0.1.0(@types/react@19.2.17)(react@19.2.7)
@@ -2225,6 +2228,40 @@ packages:
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@sentry/browser-utils@10.64.0':
+    resolution: {integrity: sha512-qXvUpsZdE0+6SovhDZvjN4JkqQEpzeYsrOF5g63wMsqJWWv2vW/pQZIlJs0F6C0t4q5AHZL4fl5rNkvpVqFdKA==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.64.0':
+    resolution: {integrity: sha512-CHZ7+79evh8knBtVHjW/XqV3mRaWs2TdjX7i55zpFe9vcNngQHV++0ss8ird/xfMY1mfCDtbyAN+Z6XY2o5aJA==}
+    engines: {node: '>=18'}
+
+  '@sentry/conventions@0.15.1':
+    resolution: {integrity: sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==}
+    engines: {node: '>=14'}
+
+  '@sentry/core@10.64.0':
+    resolution: {integrity: sha512-HjojJcXD1l2qZ1AXje2s0XY/nYsaUt00wsM1HMBImA8vAClyPisFE/CC0/UD6pEvsGFhVgi8Dcxo7EN41uyeFw==}
+    engines: {node: '>=18'}
+
+  '@sentry/feedback@10.64.0':
+    resolution: {integrity: sha512-YrmKwRoAto+nwo26DoAhnpNmhkrVkuQFIAXqlTD8ipERjhcSNUYJAkAB+nH4w1KIgm9QQZE1sTq3iNQdPl1XMQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/react@10.64.0':
+    resolution: {integrity: sha512-oShEKcosBKdm0kgan8suFb6Jj8poccEyDz2qiflonq/5/hUDyzdVeKfFzf0b1MmdjWSn9k3hfrLNFfPNCuEt7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/replay-canvas@10.64.0':
+    resolution: {integrity: sha512-EioBwcnnhtPiXzTZJTbZKaMEg3qNM5YZlX1VanoXomPATqfJD62cb/M27zhgiWXXJ7e8/NGVHvwNDYGrqsN39g==}
+    engines: {node: '>=18'}
+
+  '@sentry/replay@10.64.0':
+    resolution: {integrity: sha512-q8nke2GDSwEiu1zYoctDDvnSNTjHWoVAKo2JXTleD0nwOO6IlAgUYmsm3qEQiSW7BVla9W1TRbW6ChFAUXYZbw==}
+    engines: {node: '>=18'}
 
   '@shadcn/react@0.1.0':
     resolution: {integrity: sha512-6i67TEnqValsZY7e4exJ4rkHo2OdHXmDH152YulwSpuEUnTQYumHkXzFsaje7HB7GbMTWuI9x1Jn6sSduCYdeA==}
@@ -8170,6 +8207,44 @@ snapshots:
     optional: true
 
   '@sec-ant/readable-stream@0.4.1': {}
+
+  '@sentry/browser-utils@10.64.0':
+    dependencies:
+      '@sentry/core': 10.64.0
+
+  '@sentry/browser@10.64.0':
+    dependencies:
+      '@sentry/browser-utils': 10.64.0
+      '@sentry/core': 10.64.0
+      '@sentry/feedback': 10.64.0
+      '@sentry/replay': 10.64.0
+      '@sentry/replay-canvas': 10.64.0
+
+  '@sentry/conventions@0.15.1': {}
+
+  '@sentry/core@10.64.0':
+    dependencies:
+      '@sentry/conventions': 0.15.1
+
+  '@sentry/feedback@10.64.0':
+    dependencies:
+      '@sentry/core': 10.64.0
+
+  '@sentry/react@10.64.0(react@19.2.7)':
+    dependencies:
+      '@sentry/browser': 10.64.0
+      '@sentry/core': 10.64.0
+      react: 19.2.7
+
+  '@sentry/replay-canvas@10.64.0':
+    dependencies:
+      '@sentry/core': 10.64.0
+      '@sentry/replay': 10.64.0
+
+  '@sentry/replay@10.64.0':
+    dependencies:
+      '@sentry/browser-utils': 10.64.0
+      '@sentry/core': 10.64.0
 
   '@shadcn/react@0.1.0(@types/react@19.2.17)(react@19.2.7)':
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
     devDependencies:
+      '@sentry/vite-plugin':
+        specifier: ^5.3.0
+        version: 5.3.0(rollup@4.61.1)
       '@sqlite.org/sqlite-wasm':
         specifier: 3.53.0-build1
         version: 3.53.0-build1
@@ -2229,6 +2232,10 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
+  '@sentry/babel-plugin-component-annotate@5.3.0':
+    resolution: {integrity: sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==}
+    engines: {node: '>= 18'}
+
   '@sentry/browser-utils@10.64.0':
     resolution: {integrity: sha512-qXvUpsZdE0+6SovhDZvjN4JkqQEpzeYsrOF5g63wMsqJWWv2vW/pQZIlJs0F6C0t4q5AHZL4fl5rNkvpVqFdKA==}
     engines: {node: '>=18'}
@@ -2236,6 +2243,62 @@ packages:
   '@sentry/browser@10.64.0':
     resolution: {integrity: sha512-CHZ7+79evh8knBtVHjW/XqV3mRaWs2TdjX7i55zpFe9vcNngQHV++0ss8ird/xfMY1mfCDtbyAN+Z6XY2o5aJA==}
     engines: {node: '>=18'}
+
+  '@sentry/bundler-plugin-core@5.3.0':
+    resolution: {integrity: sha512-L5T60sWdAI3qWwdg3Ptwek/0TY59PERrxyqp4XMUkroayQvGd9r5dIW9Q1kSeXX9iJ442nXbFZKAOyCKV4Z13Q==}
+    engines: {node: '>= 18'}
+
+  '@sentry/cli-darwin@2.58.6':
+    resolution: {integrity: sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    resolution: {integrity: sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.6':
+    resolution: {integrity: sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.6':
+    resolution: {integrity: sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.6':
+    resolution: {integrity: sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    resolution: {integrity: sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.6':
+    resolution: {integrity: sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.6':
+    resolution: {integrity: sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.6':
+    resolution: {integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==}
+    engines: {node: '>= 10'}
+    hasBin: true
 
   '@sentry/conventions@0.15.1':
     resolution: {integrity: sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==}
@@ -2262,6 +2325,19 @@ packages:
   '@sentry/replay@10.64.0':
     resolution: {integrity: sha512-q8nke2GDSwEiu1zYoctDDvnSNTjHWoVAKo2JXTleD0nwOO6IlAgUYmsm3qEQiSW7BVla9W1TRbW6ChFAUXYZbw==}
     engines: {node: '>=18'}
+
+  '@sentry/rollup-plugin@5.3.0':
+    resolution: {integrity: sha512-hgPGPYdQJ/G1cGYOxAb7d4z3V+/k/E5/P/5TFPEEBLuIbFFk+JG0CISUDJdzXJjO382Lb99PBJuXGbueBmO79w==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      rollup: '>=3.2.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@sentry/vite-plugin@5.3.0':
+    resolution: {integrity: sha512-qcoSzo4n2MulVQ70UUPLq6dTleb2a2HwL2wuwvAgWhPChrYTuk6A6mDg6aQb9fairPAwFPiU9PzOANpoDJcz1A==}
+    engines: {node: '>= 18'}
 
   '@shadcn/react@0.1.0':
     resolution: {integrity: sha512-6i67TEnqValsZY7e4exJ4rkHo2OdHXmDH152YulwSpuEUnTQYumHkXzFsaje7HB7GbMTWuI9x1Jn6sSduCYdeA==}
@@ -2811,6 +2887,10 @@ packages:
   adm-zip@0.5.17:
     resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
     engines: {node: '>=12.0'}
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -3767,6 +3847,10 @@ packages:
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
     engines: {node: '>=18'}
@@ -3870,6 +3954,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -4575,6 +4663,10 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -4620,6 +4712,15 @@ packages:
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
@@ -4794,6 +4895,10 @@ packages:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
 
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
@@ -4871,6 +4976,10 @@ packages:
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
 
   promise-toolbox@0.21.0:
     resolution: {integrity: sha512-NV8aTmpwrZv+Iys54sSFOBx3tuVaOBvvrft5PNppnxy9xpU/akHbaWIril22AB22zaPgrgwKdD0KsrM0ptUtpg==}
@@ -4998,6 +5107,9 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   publish-browser-extension@4.0.5:
     resolution: {integrity: sha512-EePAn3VIHJS/jqCuvs1NgPgoecCT8+RsES76hbgYe2Ze1dyvB0tX60C1PCrV8Z8fv56mW3E59s9Gd/GwWiw7dw==}
@@ -5560,6 +5672,9 @@ packages:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
@@ -5944,6 +6059,9 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -5958,6 +6076,9 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   when-exit@2.1.5:
     resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
@@ -8208,6 +8329,8 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
+  '@sentry/babel-plugin-component-annotate@5.3.0': {}
+
   '@sentry/browser-utils@10.64.0':
     dependencies:
       '@sentry/core': 10.64.0
@@ -8219,6 +8342,63 @@ snapshots:
       '@sentry/feedback': 10.64.0
       '@sentry/replay': 10.64.0
       '@sentry/replay-canvas': 10.64.0
+
+  '@sentry/bundler-plugin-core@5.3.0':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@sentry/babel-plugin-component-annotate': 5.3.0
+      '@sentry/cli': 2.58.6
+      dotenv: 16.6.1
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.21
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/cli-darwin@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli@2.58.6':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.6
+      '@sentry/cli-linux-arm': 2.58.6
+      '@sentry/cli-linux-arm64': 2.58.6
+      '@sentry/cli-linux-i686': 2.58.6
+      '@sentry/cli-linux-x64': 2.58.6
+      '@sentry/cli-win32-arm64': 2.58.6
+      '@sentry/cli-win32-i686': 2.58.6
+      '@sentry/cli-win32-x64': 2.58.6
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   '@sentry/conventions@0.15.1': {}
 
@@ -8245,6 +8425,25 @@ snapshots:
     dependencies:
       '@sentry/browser-utils': 10.64.0
       '@sentry/core': 10.64.0
+
+  '@sentry/rollup-plugin@5.3.0(rollup@4.61.1)':
+    dependencies:
+      '@sentry/bundler-plugin-core': 5.3.0
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.61.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/vite-plugin@5.3.0(rollup@4.61.1)':
+    dependencies:
+      '@sentry/bundler-plugin-core': 5.3.0
+      '@sentry/rollup-plugin': 5.3.0(rollup@4.61.1)
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
 
   '@shadcn/react@0.1.0(@types/react@19.2.17)(react@19.2.7)':
     optionalDependencies:
@@ -8784,6 +8983,12 @@ snapshots:
   acorn@8.16.0: {}
 
   adm-zip@0.5.17: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   agent-base@7.1.4: {}
 
@@ -9754,6 +9959,12 @@ snapshots:
 
   glob-to-regexp@0.4.1: {}
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   global-directory@4.0.1:
     dependencies:
       ini: 4.1.1
@@ -9917,6 +10128,13 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -10692,6 +10910,8 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@7.1.3: {}
+
   mkdirp-classic@0.5.3: {}
 
   mlly@1.8.2:
@@ -10731,6 +10951,10 @@ snapshots:
   node-domexception@1.0.0: {}
 
   node-fetch-native@1.6.7: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-fetch@3.3.2:
     dependencies:
@@ -10932,6 +11156,11 @@ snapshots:
 
   path-key@4.0.0: {}
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.1
+      minipass: 7.1.3
+
   path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
@@ -11023,6 +11252,8 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   process-warning@5.0.0: {}
+
+  progress@2.0.3: {}
 
   promise-toolbox@0.21.0:
     dependencies:
@@ -11171,6 +11402,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@1.1.0: {}
 
   publish-browser-extension@4.0.5:
     dependencies:
@@ -11895,6 +12128,8 @@ snapshots:
     dependencies:
       tldts: 7.4.2
 
+  tr46@0.0.3: {}
+
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
@@ -12259,6 +12494,8 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@8.0.1: {}
 
   webpack-virtual-modules@0.6.2: {}
@@ -12272,6 +12509,11 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   when-exit@2.1.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - design-system
 
 allowBuilds:
+  '@sentry/cli': true
   better-sqlite3: true
   esbuild: true
   spawn-sync: true


### PR DESCRIPTION
## Problem

Native crash reporting covers process-level failures, but production exceptions in the shared React/WebView layer disappeared. Adding a browser telemetry SDK with ordinary defaults would be unsafe for a local-first notes app: exception messages, stack metadata, breadcrumbs, URLs, requests, and user context can all contain note content, titles, graph paths, or identifiers.

Readable diagnostics also require source maps, but those must be uploaded privately during the release build rather than bundled with the app or exposed by Sentry source scraping.

## Before -> After

| Surface | Before | After |
| --- | --- | --- |
| React/WebView failures | Invisible after release | Uncaught, recoverable, caught React, and unhandled rejection diagnostics reach Sentry |
| Event data | No JavaScript diagnostics | Exception class, redacted message, sanitized stack locations, handled state, app release, and a static runtime tag only |
| Ambient collection | N/A | Requests, breadcrumbs, sessions, tracing, replay, logs, PII, frame context, and local variables are disabled |
| Stack readability | Minified bundle locations | Debug-ID source maps are uploaded privately during official builds and deleted from `dist` afterward |
| Release configuration | No Sentry configuration | macOS and TestFlight require both the public DSN and the build-only source-map upload token |

## Changes

1. Add `@sentry/react` at the shared desktop/iOS bootstrap and attach the React 19 root error handlers before bridge initialization.
2. Add `scrubExceptionEvent`, which constructs a new allow-listed event. Messages are always `[redacted]`; filenames become bundle basenames; raw function names, request/user/note/graph/filesystem data, breadcrumbs, contexts, and session fields are omitted.
3. Preserve only validated source-map Debug IDs and matching sanitized bundle basenames so Sentry can symbolicate without receiving local paths. Invalid Debug IDs and non-source-map debug metadata are dropped.
4. Disable Sentry default integrations and explicitly opt into exception handlers, linked errors, and deduplication. Every ambient data-collection category remains disabled.
5. Validate the production DSN against the exact Reflect organization/project before initialization and fail closed if initialization itself throws.
6. Add `@sentry/vite-plugin`, hidden source maps, release naming, post-upload map deletion, and the required `@sentry/cli` build approval.
7. Require `SENTRY_AUTH_TOKEN` alongside `SENTRY_DSN` in macOS and TestFlight release workflows, while exposing only the public DSN to Vite client code.
8. Document exception telemetry, source-map handling, release credentials, and Sentry storage-side privacy controls.

## Tests

`exception-telemetry.test.ts` verifies that a deliberately sensitive event containing note text, titles, local graph paths, request bodies and headers, user identifiers, breadcrumbs, contexts, source lines, variables, and malicious Debug ID metadata is reduced to the exact safe schema. It also covers fail-closed DSN validation, untrusted exception metadata, invalid release/event identifiers, non-exception event drops, and the exception-only SDK configuration.

## Verification

- `pnpm --filter @reflect/desktop exec vitest run src/lib/exception-telemetry.test.ts` — 5 tests passed.
- `pnpm check` — passed; the existing 503-line warning in `packages/core/src/indexing/indexer.ts` remains unchanged.
- Production Vite build with the release upload token — passed; Sentry accepted a Debug-ID artifact bundle for `reflect@0.4.0-beta.45`, and no `.map` files remained in `dist`.
- Production Vite build without Sentry credentials — passed; source-map upload was skipped without breaking ordinary CI/self-builds.

## Risk / Rollout

- Repository secrets `SENTRY_DSN` and `SENTRY_AUTH_TOKEN` are configured. Release and TestFlight jobs fail before native compilation if either is absent.
- The auth token has release/source-map upload scope only, is available only at build time, and is not present in tracked files, built assets, or the local worktree. The DSN is a public ingestion endpoint embedded in release clients.
- The `reflect-open` Sentry project has server-side/default scrubbers and IP non-storage enabled, explicit sensitive fields for notes/paths/requests/users, and JavaScript source scraping disabled. Uploaded debug files inherit Admin-only access.
- The client sanitizer remains the primary privacy boundary and is an allow-list, so future SDK fields stay excluded until reviewed deliberately.
- No note schema, migration, user setting, or native crash-reporting behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New outbound network path and CI gate on `SENTRY_DSN`; privacy risk is mitigated by allow-list scrubbing and tests, but misconfiguration or sanitizer gaps could leak sensitive strings in exception metadata.
> 
> **Overview**
> Adds **exception-only Sentry** for production React/WebView failures on desktop and iOS, with an allow-list sanitizer so note paths, user data, and request context never leave the device.
> 
> `exception-telemetry` initializes `@sentry/react` only when `PROD` and `VITE_SENTRY_DSN` are set, disables default integrations and ambient collection (tracing, replay, breadcrumbs, PII), and rebuilds each event in `beforeSend` via `scrubExceptionEvent`—redacted messages, safe stack basenames, and no breadcrumbs or user fields. React 19 root error handlers are wired through `initializeExceptionTelemetry()` before bootstrap; Vite defines `__REFLECT_VERSION__` from `tauri.conf.json` for the Sentry release.
> 
> **Release plumbing:** macOS and TestFlight workflows require `SENTRY_DSN` and pass it as `VITE_SENTRY_DSN`; Tauri CSP `connect-src` adds Sentry ingest hosts. `docs/privacy.md` and distribution docs describe the new outbound call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc61fd32131ef0111cedc87d39e1b54583d2686e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
