### PR TITLE
Fix task source-note date navigation

### DIFF
--- a/apps/desktop/src/components/tasks/task-row.tsx
+++ b/apps/desktop/src/components/tasks/task-row.tsx
@@ -183,9 +183,17 @@ export function TaskRow({
         </div>
       )}
       {showSource && task.dailyDate !== null ? (
-        <span className="mt-0.5 shrink-0 whitespace-nowrap text-xs text-text-muted">
+        <button
+          type="button"
+          disabled={editing}
+          onClick={(event) => {
+            event.stopPropagation()
+            onOpen(task.notePath)
+          }}
+          className="mt-0.5 shrink-0 whitespace-nowrap text-xs text-text-muted hover:underline focus-visible:underline focus-visible:outline-none"
+        >
           {formatDayLabel(task.dailyDate, settings.dateFormat)}
-        </span>
+        </button>
       ) : null}
       <button
         type="button"

--- a/apps/desktop/src/components/tasks/tasks-screen.test.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.test.tsx
@@ -336,6 +336,28 @@ describe('TasksScreen', () => {
     view.unmount()
   })
 
+  it('opens a task’s source note from its date without editing the task', async () => {
+    getOpenTasks.mockResolvedValue([
+      task({
+        notePath: 'daily/2026-06-09.md',
+        dailyDate: '2026-06-09',
+        text: 'daily task',
+        noteTitle: '2026-06-09',
+      }),
+    ])
+    const view = renderScreen()
+
+    await userEvent.click(
+      await view.findByRole('button', { name: 'Tue, June 9th, 2026' }),
+    )
+
+    expect(view.getByTestId('route').textContent).toBe(
+      '{"kind":"daily","date":"2026-06-09"}',
+    )
+    expect(view.queryByTestId('task-editor')).toBeNull()
+    view.unmount()
+  })
+
   it('renders unfocused task content through the markdown preview', async () => {
     getOpenTasks.mockResolvedValue([
       task({


### PR DESCRIPTION
## Problem

The source-note date shown at the right of task rows was rendered as passive text inside the row-wide selection target. Clicking the date therefore selected the task and opened inline editing instead of navigating to the source note.

## Changes

- Render the source-note date as an explicit navigation button.
- Stop the date click from bubbling into task-row selection.
- Keep source-note navigation disabled while the row is already being edited, matching the existing arrow behavior.
- Add a regression test that verifies the daily-note route opens and the task editor stays closed.

## Verification

- `pnpm --filter @reflect/desktop test --run src/components/tasks/tasks-screen.test.tsx` — 59 tests passed.
- `pnpm check` — typecheck and lint passed (with the existing max-lines warning in `packages/core/src/indexing/indexer.ts`).

## Risk / Rollout

Low-risk interaction-only change. No data, schema, or migration changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only interaction fix in the Tasks list; no persistence, routing schema, or backend changes.
> 
> **Overview**
> Clicking the **source-note date** on a task row no longer falls through to row selection and inline edit. The date is now a **button** that calls the same `onOpen` path as the arrow, with `stopPropagation` so the row-wide click handler does not run.
> 
> While a row is in **edit mode**, the date control is **disabled**, consistent with the open-arrow behavior. Styling adds hover/focus underline so it reads as navigation.
> 
> A **regression test** clicks the formatted daily date and asserts the router opens the daily note (`kind: daily`) and the task editor stays closed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11a41a26a46f818c217570fb072153ceacffb394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->