### PR TITLE
Fix iOS background file-lock terminations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4756,6 +4756,7 @@ dependencies = [
  "objc2-contacts",
  "objc2-event-kit",
  "objc2-foundation",
+ "objc2-ui-kit",
  "ort",
  "percent-encoding",
  "reflect-index-schema",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -119,6 +119,15 @@ objc2-foundation = "0.3.2"
 objc2-contacts = "0.3.2"
 block2 = "0.6.2"
 
+# Finite-length execution assertions around iOS persistence. UIKit's begin/end
+# methods keep file and SQLite locks from surviving process suspension.
+[target.'cfg(target_os = "ios")'.dependencies]
+objc2-ui-kit = { version = "0.3.2", default-features = false, features = [
+  "std",
+  "UIApplication",
+  "block2",
+] }
+
 # Desktop-only capabilities (Plan 19): auto-update (mobile updates go through
 # the app stores), window-state (no windows to restore on mobile), the file
 # watcher (nothing else writes the mobile sandbox; local writes notify

--- a/apps/desktop/src-tauri/src/background_task.rs
+++ b/apps/desktop/src-tauri/src/background_task.rs
@@ -1,0 +1,258 @@
+//! iOS finite-length background execution assertions.
+//!
+//! UIKit may suspend the process shortly after it enters the background. A
+//! suspension while SQLite or a file writer owns a lock is fatal (`0xdead10cc`),
+//! so native write commands can hold a [`ScopedBackgroundTask`] and the mobile
+//! frontend can bracket its whole background persistence flush through the two
+//! commands below. Each path has an isolated registry; within either registry,
+//! normal completion and UIKit's expiration callback race to remove the token,
+//! and only the winner ends the native assertion.
+
+#[cfg(any(target_os = "ios", test))]
+use std::collections::HashMap;
+#[cfg(any(target_os = "ios", test))]
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+#[cfg(any(target_os = "ios", test))]
+use std::sync::{Mutex, MutexGuard};
+
+use tauri::State;
+
+#[cfg(any(target_os = "ios", test))]
+type NativeIdentifier = usize;
+
+#[cfg(any(target_os = "ios", test))]
+#[derive(Default)]
+struct TaskRegistry {
+    next_token: AtomicU64,
+    tasks: Mutex<HashMap<String, Option<NativeIdentifier>>>,
+}
+
+#[cfg(not(any(target_os = "ios", test)))]
+#[derive(Default)]
+struct TaskRegistry;
+
+#[cfg(any(target_os = "ios", test))]
+impl TaskRegistry {
+    fn lock(&self) -> MutexGuard<'_, HashMap<String, Option<NativeIdentifier>>> {
+        self.tasks
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    /// Reserve a token before asking UIKit for an identifier. The temporary
+    /// `None` lets an unusually early expiration remove the reservation; the
+    /// begin path then notices and immediately ends the identifier it received.
+    fn reserve(&self) -> String {
+        let sequence = self.next_token.fetch_add(1, Ordering::Relaxed) + 1;
+        let token = format!("background-task-{sequence}");
+        self.lock().insert(token.clone(), None);
+        token
+    }
+
+    /// Attach UIKit's identifier unless expiration already consumed the token.
+    fn activate(&self, token: &str, identifier: NativeIdentifier) -> bool {
+        let mut tasks = self.lock();
+        let Some(slot) = tasks.get_mut(token) else {
+            return false;
+        };
+        *slot = Some(identifier);
+        true
+    }
+
+    /// Remove a token and return its identifier, if UIKit had assigned one.
+    fn take(&self, token: &str) -> Option<NativeIdentifier> {
+        self.lock().remove(token).flatten()
+    }
+
+    fn cancel(&self, token: &str) {
+        self.lock().remove(token);
+    }
+}
+
+/// Process-wide native background assertions. Frontend and scoped native tasks
+/// intentionally use separate registries: an IPC caller can never end a DB
+/// assertion by guessing its predictable process-local token.
+#[derive(Default)]
+pub struct BackgroundTaskState {
+    frontend: Arc<TaskRegistry>,
+    scoped: Arc<TaskRegistry>,
+}
+
+impl BackgroundTaskState {
+    fn begin_frontend(&self, name: &str) -> Option<String> {
+        platform::begin(Arc::clone(&self.frontend), name)
+    }
+
+    fn end_frontend(&self, token: &str) {
+        platform::end(&self.frontend, token);
+    }
+}
+
+/// RAII assertion for native operations that may own a file or SQLite lock.
+/// Expiration and `Drop` are idempotent through [`TaskRegistry::take`].
+///
+/// Current consumers are synchronous Tauri DB commands on iOS's main thread;
+/// UIKit also invokes expiration handlers on that thread, so expiration cannot
+/// end their assertion until the command returns and has released its SQLite
+/// lock. Do not use this guard for background-thread work without adding an
+/// expiration signal that cancels the operation before ending the assertion.
+pub(crate) struct ScopedBackgroundTask {
+    registry: Arc<TaskRegistry>,
+    token: Option<String>,
+}
+
+impl Drop for ScopedBackgroundTask {
+    fn drop(&mut self) {
+        if let Some(token) = self.token.take() {
+            platform::end(&self.registry, &token);
+        }
+    }
+}
+
+/// Acquire an iOS background assertion before entering a native critical
+/// section. Other platforms return an inert guard.
+pub(crate) fn scoped(state: &State<'_, BackgroundTaskState>, name: &str) -> ScopedBackgroundTask {
+    ScopedBackgroundTask {
+        registry: Arc::clone(&state.scoped),
+        token: platform::begin(Arc::clone(&state.scoped), name),
+    }
+}
+
+/// Begin a frontend-owned persistence assertion. Returns `None` when UIKit
+/// cannot grant background time, and on non-iOS platforms.
+#[tauri::command]
+pub fn background_task_begin(state: State<'_, BackgroundTaskState>) -> Option<String> {
+    state.begin_frontend("Reflect background persistence")
+}
+
+/// End a frontend-owned persistence assertion. Unknown and already-expired
+/// tokens are harmless, which makes cleanup safe to retry.
+#[tauri::command]
+pub fn background_task_end(token: String, state: State<'_, BackgroundTaskState>) {
+    state.end_frontend(&token);
+}
+
+#[cfg(target_os = "ios")]
+mod platform {
+    use std::sync::Arc;
+
+    use block2::RcBlock;
+    use objc2::rc::Retained;
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
+    use objc2_foundation::NSString;
+    use objc2_ui_kit::UIBackgroundTaskInvalid;
+
+    use super::{NativeIdentifier, TaskRegistry};
+
+    pub fn begin(registry: Arc<TaskRegistry>, name: &str) -> Option<String> {
+        let token = registry.reserve();
+        let expiration_registry = Arc::clone(&registry);
+        let expiration_token = token.clone();
+        let expiration_handler = RcBlock::new(move || {
+            end(&expiration_registry, &expiration_token);
+        });
+        let task_name = NSString::from_str(name);
+
+        // UIKit documents begin/end as `nonisolated`; objc2 conservatively
+        // marks the UIApplication class main-thread-only, so message the two
+        // thread-safe methods directly. This is also what lets a synchronous
+        // SQLite command acquire its assertion *before* taking a DB lock,
+        // instead of queueing the begin call behind that same command.
+        let application: Retained<AnyObject> =
+            unsafe { msg_send![class!(UIApplication), sharedApplication] };
+        let identifier: NativeIdentifier = unsafe {
+            msg_send![
+                &*application,
+                beginBackgroundTaskWithName: &*task_name,
+                expirationHandler: &*expiration_handler
+            ]
+        };
+
+        if identifier == unsafe { UIBackgroundTaskInvalid } {
+            registry.cancel(&token);
+            return None;
+        }
+
+        if registry.activate(&token, identifier) {
+            Some(token)
+        } else {
+            // Expiration won the race before `begin…` returned.
+            unsafe {
+                let _: () = msg_send![&*application, endBackgroundTask: identifier];
+            }
+            None
+        }
+    }
+
+    pub fn end(registry: &TaskRegistry, token: &str) {
+        let Some(identifier) = registry.take(token) else {
+            return;
+        };
+        let application: Retained<AnyObject> =
+            unsafe { msg_send![class!(UIApplication), sharedApplication] };
+        unsafe {
+            let _: () = msg_send![&*application, endBackgroundTask: identifier];
+        }
+    }
+}
+
+#[cfg(not(target_os = "ios"))]
+mod platform {
+    use std::sync::Arc;
+
+    use super::TaskRegistry;
+
+    pub fn begin(_registry: Arc<TaskRegistry>, _name: &str) -> Option<String> {
+        None
+    }
+
+    pub fn end(_registry: &TaskRegistry, _token: &str) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BackgroundTaskState, TaskRegistry};
+
+    #[test]
+    fn normal_completion_consumes_an_active_identifier_once() {
+        let registry = TaskRegistry::default();
+        let token = registry.reserve();
+        assert!(registry.activate(&token, 42));
+        assert_eq!(registry.take(&token), Some(42));
+        assert_eq!(registry.take(&token), None);
+    }
+
+    #[test]
+    fn expiration_before_activation_prevents_a_late_identifier_leak() {
+        let registry = TaskRegistry::default();
+        let token = registry.reserve();
+        assert_eq!(registry.take(&token), None);
+        assert!(!registry.activate(&token, 42));
+    }
+
+    #[test]
+    fn cancelled_or_unknown_tokens_are_idempotent() {
+        let registry = TaskRegistry::default();
+        let token = registry.reserve();
+        registry.cancel(&token);
+        registry.cancel(&token);
+        assert_eq!(registry.take("not-issued"), None);
+    }
+
+    #[test]
+    fn frontend_tokens_cannot_end_scoped_assertions() {
+        let state = BackgroundTaskState::default();
+        let frontend_token = state.frontend.reserve();
+        let scoped_token = state.scoped.reserve();
+        // The counters are deliberately predictable and collide; registry
+        // ownership, not token secrecy, is the security boundary.
+        assert_eq!(frontend_token, scoped_token);
+        assert!(state.frontend.activate(&frontend_token, 11));
+        assert!(state.scoped.activate(&scoped_token, 22));
+
+        assert_eq!(state.frontend.take(&frontend_token), Some(11));
+        assert_eq!(state.scoped.take(&scoped_token), Some(22));
+    }
+}

--- a/apps/desktop/src-tauri/src/db/mod.rs
+++ b/apps/desktop/src-tauri/src/db/mod.rs
@@ -26,6 +26,7 @@ use rusqlite::{params, Connection};
 use serde_json::{Map, Value};
 use tauri::State;
 
+use crate::background_task::{self, BackgroundTaskState};
 use crate::error::{AppError, AppResult};
 use crate::fs::GraphState;
 
@@ -105,7 +106,12 @@ fn emit_note_moved<R: tauri::Runtime>(app: &tauri::AppHandle<R>, from: &str, to:
 /// Returns the new generation, which write commands must echo back. The
 /// generation bump and connection rebind happen under one lock, atomically.
 #[tauri::command]
-pub fn index_open(graph: State<GraphState>, index: State<IndexState>) -> AppResult<u64> {
+pub fn index_open(
+    graph: State<GraphState>,
+    index: State<IndexState>,
+    background_tasks: State<BackgroundTaskState>,
+) -> AppResult<u64> {
+    let _background_task = background_task::scoped(&background_tasks, "Reflect index open");
     let root = graph
         .0
         .lock()
@@ -132,9 +138,11 @@ pub fn index_open(graph: State<GraphState>, index: State<IndexState>) -> AppResu
 /// Returns whether it committed, so callers only broadcast real writes.
 fn apply_in_txn(
     index: &State<IndexState>,
+    background_tasks: &State<BackgroundTaskState>,
     generation: u64,
     notes: &[IndexedNote],
 ) -> AppResult<bool> {
+    let _background_task = background_task::scoped(background_tasks, "Reflect index update");
     let mut state = lock_state(index)?;
     if state.generation != generation {
         return Ok(false);
@@ -155,8 +163,14 @@ pub fn index_apply<R: tauri::Runtime>(
     generation: u64,
     app: tauri::AppHandle<R>,
     index: State<IndexState>,
+    background_tasks: State<BackgroundTaskState>,
 ) -> AppResult<()> {
-    if apply_in_txn(&index, generation, std::slice::from_ref(&note))? {
+    if apply_in_txn(
+        &index,
+        &background_tasks,
+        generation,
+        std::slice::from_ref(&note),
+    )? {
         emit_index_written(&app);
     }
     Ok(())
@@ -169,8 +183,9 @@ pub fn index_apply_batch<R: tauri::Runtime>(
     generation: u64,
     app: tauri::AppHandle<R>,
     index: State<IndexState>,
+    background_tasks: State<BackgroundTaskState>,
 ) -> AppResult<()> {
-    if apply_in_txn(&index, generation, &notes)? {
+    if apply_in_txn(&index, &background_tasks, generation, &notes)? {
         emit_index_written(&app);
     }
     Ok(())
@@ -186,7 +201,9 @@ pub fn index_remove<R: tauri::Runtime>(
     generation: u64,
     app: tauri::AppHandle<R>,
     index: State<IndexState>,
+    background_tasks: State<BackgroundTaskState>,
 ) -> AppResult<()> {
+    let _background_task = background_task::scoped(&background_tasks, "Reflect index remove");
     {
         let mut state = lock_state(&index)?;
         if state.generation != generation {
@@ -234,7 +251,9 @@ pub fn note_move_indexed<R: tauri::Runtime>(
     app: tauri::AppHandle<R>,
     graph: State<GraphState>,
     index: State<IndexState>,
+    background_tasks: State<BackgroundTaskState>,
 ) -> AppResult<()> {
+    let _background_task = background_task::scoped(&background_tasks, "Reflect note move");
     let root = crate::fs::root_for_generation(&graph, generation)?;
     {
         let mut state = lock_state(&index)?;
@@ -283,7 +302,9 @@ pub fn index_move<R: tauri::Runtime>(
     generation: u64,
     app: tauri::AppHandle<R>,
     index: State<IndexState>,
+    background_tasks: State<BackgroundTaskState>,
 ) -> AppResult<()> {
+    let _background_task = background_task::scoped(&background_tasks, "Reflect index move");
     {
         let mut state = lock_state(&index)?;
         if state.generation != generation {
@@ -342,7 +363,9 @@ pub fn index_touch(
     entries: Vec<IndexTouch>,
     generation: u64,
     index: State<IndexState>,
+    background_tasks: State<BackgroundTaskState>,
 ) -> AppResult<()> {
+    let _background_task = background_task::scoped(&background_tasks, "Reflect index touch");
     let mut state = lock_state(&index)?;
     if state.generation != generation {
         return Ok(());
@@ -366,7 +389,9 @@ pub fn index_meta_set(
     value: String,
     generation: u64,
     index: State<IndexState>,
+    background_tasks: State<BackgroundTaskState>,
 ) -> AppResult<()> {
+    let _background_task = background_task::scoped(&background_tasks, "Reflect index metadata");
     let state = lock_state(&index)?;
     if state.generation != generation {
         return Ok(());
@@ -388,7 +413,9 @@ pub fn index_clear<R: tauri::Runtime>(
     generation: u64,
     app: tauri::AppHandle<R>,
     index: State<IndexState>,
+    background_tasks: State<BackgroundTaskState>,
 ) -> AppResult<()> {
+    let _background_task = background_task::scoped(&background_tasks, "Reflect index clear");
     {
         let state = lock_state(&index)?;
         if state.generation != generation {
@@ -412,7 +439,9 @@ pub fn chat_message_save(
     message: ChatMessageRow,
     generation: u64,
     index: State<IndexState>,
+    background_tasks: State<BackgroundTaskState>,
 ) -> AppResult<()> {
+    let _background_task = background_task::scoped(&background_tasks, "Reflect chat save");
     let mut state = lock_state(&index)?;
     if state.generation != generation {
         return Ok(());
@@ -430,7 +459,9 @@ pub fn chat_conversation_delete(
     id: String,
     generation: u64,
     index: State<IndexState>,
+    background_tasks: State<BackgroundTaskState>,
 ) -> AppResult<()> {
+    let _background_task = background_task::scoped(&background_tasks, "Reflect chat delete");
     let state = lock_state(&index)?;
     if state.generation != generation {
         return Ok(());
@@ -447,7 +478,9 @@ pub fn embed_apply(
     chunks: Vec<EmbeddedChunk>,
     generation: u64,
     index: State<IndexState>,
+    background_tasks: State<BackgroundTaskState>,
 ) -> AppResult<()> {
+    let _background_task = background_task::scoped(&background_tasks, "Reflect embeddings update");
     let mut state = lock_state(&index)?;
     if state.generation != generation {
         return Ok(());
@@ -461,7 +494,13 @@ pub fn embed_apply(
 
 /// Drop a deleted note's chunks + vectors (no-op if stale).
 #[tauri::command]
-pub fn embed_remove(path: String, generation: u64, index: State<IndexState>) -> AppResult<()> {
+pub fn embed_remove(
+    path: String,
+    generation: u64,
+    index: State<IndexState>,
+    background_tasks: State<BackgroundTaskState>,
+) -> AppResult<()> {
+    let _background_task = background_task::scoped(&background_tasks, "Reflect embeddings remove");
     let mut state = lock_state(&index)?;
     if state.generation != generation {
         return Ok(());

--- a/apps/desktop/src-tauri/src/db/tests.rs
+++ b/apps/desktop/src-tauri/src/db/tests.rs
@@ -828,6 +828,7 @@ fn session_adoption_reads_never_bump_generations() {
         .expect("mock app");
     app.manage(crate::fs::GraphState::default());
     app.manage(super::IndexState::default());
+    app.manage(crate::background_task::BackgroundTaskState::default());
 
     let graph_dir = tempfile::tempdir().expect("tempdir");
     {
@@ -841,7 +842,7 @@ fn session_adoption_reads_never_bump_generations() {
     // than opening one itself.
     assert_eq!(super::current_generation(&app.state()).unwrap(), None);
 
-    let opened = super::index_open(app.state(), app.state()).expect("open");
+    let opened = super::index_open(app.state(), app.state(), app.state()).expect("open");
     for _ in 0..2 {
         let info = crate::fs::current_graph_info(&app.state()).expect("graph info");
         assert_eq!(info.generation, 3);
@@ -867,6 +868,7 @@ fn stale_generation_writes_are_dropped_end_to_end() {
         .expect("mock app");
     app.manage(crate::fs::GraphState::default());
     app.manage(super::IndexState::default());
+    app.manage(crate::background_task::BackgroundTaskState::default());
 
     let graph_dir = tempfile::tempdir().expect("tempdir");
     {
@@ -886,24 +888,26 @@ fn stale_generation_writes_are_dropped_end_to_end() {
         rows[0]["n"].clone()
     };
 
-    let stale = super::index_open(app.state(), app.state()).expect("first open");
+    let stale = super::index_open(app.state(), app.state(), app.state()).expect("first open");
     super::index_apply(
         note("notes/a.md", "A", vec![]),
         stale,
         app.handle().clone(),
+        app.state(),
         app.state(),
     )
     .expect("apply");
     assert_eq!(count("after first apply"), Value::from(1));
 
     // Reopening (graph switch / reload) bumps the generation; the old one is stale.
-    let fresh = super::index_open(app.state(), app.state()).expect("reopen");
+    let fresh = super::index_open(app.state(), app.state(), app.state()).expect("reopen");
     assert_ne!(stale, fresh);
 
     super::index_apply(
         note("notes/b.md", "B", vec![]),
         stale,
         app.handle().clone(),
+        app.state(),
         app.state(),
     )
     .expect("stale apply returns Ok");
@@ -914,6 +918,7 @@ fn stale_generation_writes_are_dropped_end_to_end() {
         stale,
         app.handle().clone(),
         app.state(),
+        app.state(),
     )
     .expect("stale remove returns Ok");
     assert_eq!(count("after stale remove"), Value::from(1)); // also dropped
@@ -922,6 +927,7 @@ fn stale_generation_writes_are_dropped_end_to_end() {
         note("notes/b.md", "B", vec![]),
         fresh,
         app.handle().clone(),
+        app.state(),
         app.state(),
     )
     .expect("fresh apply");
@@ -937,13 +943,31 @@ fn stale_generation_writes_are_dropped_end_to_end() {
         )
         .unwrap_or_else(|err| panic!("{label}: {err:?}"))
     };
-    super::index_meta_set("k".to_string(), "stale".to_string(), stale, app.state())
-        .expect("stale meta set returns Ok");
+    super::index_meta_set(
+        "k".to_string(),
+        "stale".to_string(),
+        stale,
+        app.state(),
+        app.state(),
+    )
+    .expect("stale meta set returns Ok");
     assert!(meta("after stale meta set").is_empty());
-    super::index_meta_set("k".to_string(), "v1".to_string(), fresh, app.state())
-        .expect("fresh meta set");
-    super::index_meta_set("k".to_string(), "v2".to_string(), fresh, app.state())
-        .expect("meta upsert");
+    super::index_meta_set(
+        "k".to_string(),
+        "v1".to_string(),
+        fresh,
+        app.state(),
+        app.state(),
+    )
+    .expect("fresh meta set");
+    super::index_meta_set(
+        "k".to_string(),
+        "v2".to_string(),
+        fresh,
+        app.state(),
+        app.state(),
+    )
+    .expect("meta upsert");
     assert_eq!(meta("after meta upsert")[0]["value"], Value::from("v2"));
 }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@
 //! [`contacts`] (live Apple Contacts lookups),
 //! [`error`] (the shared error contract).
 
+mod background_task;
 mod calendar;
 mod capture;
 mod conflict;
@@ -186,6 +187,7 @@ pub fn run() {
             fs::asset_protocol::handle,
         )
         .manage(fs::GraphState::default())
+        .manage(background_task::BackgroundTaskState::default())
         .manage(fs::ImportCancel::default())
         .manage(fs::assets::AssetUploads::default())
         .manage(db::IndexState::default())
@@ -196,6 +198,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             app_version,
             app_platform,
+            background_task::background_task_begin,
+            background_task::background_task_end,
             icloud::storage::mobile_storage,
             icloud::storage::mobile_storage_local,
             icloud::storage::icloud_download_pending,

--- a/apps/desktop/src/dev/dev-bridge.test.ts
+++ b/apps/desktop/src/dev/dev-bridge.test.ts
@@ -67,3 +67,18 @@ describe('dev bridge index_reconcile_scan', () => {
     ])
   })
 })
+
+describe('dev bridge background task parity', () => {
+  it('reports native background assertions as unavailable and accepts cleanup', async () => {
+    const bridge = createDevBridge({
+      platform: 'ios',
+      files: createDevFileStore({}),
+      index: await createDevIndexDb(),
+    })
+
+    await expect(bridge.invoke('background_task_begin', {})).resolves.toBeNull()
+    await expect(
+      bridge.invoke('background_task_end', { token: 'already-expired' }),
+    ).resolves.toBeNull()
+  })
+})

--- a/apps/desktop/src/dev/dev-bridge.ts
+++ b/apps/desktop/src/dev/dev-bridge.ts
@@ -76,6 +76,10 @@ export function createDevBridge(backend: DevBridgeBackend): IpcBridge {
         return '0.0.0-dev'
       case 'app_platform':
         return platform
+      case 'background_task_begin':
+        // Browser previews are never suspended like an iOS process, so the
+        // native finite-length assertion is honestly unavailable.
+        return null
       case 'mobile_storage':
         // No iCloud in a plain browser — the dev harness exercises the
         // local-storage path (and, via `mobileOnboarded` above, skips
@@ -94,6 +98,7 @@ export function createDevBridge(backend: DevBridgeBackend): IpcBridge {
       case 'capture_host_register':
       case 'watch_start':
       case 'watch_stop':
+      case 'background_task_end':
       case 'quit_confirm':
       case 'toggle_devtools':
         return null

--- a/apps/desktop/src/lib/background-flush.test.ts
+++ b/apps/desktop/src/lib/background-flush.test.ts
@@ -11,9 +11,15 @@ import { installBackgroundFlush } from './background-flush'
  */
 
 const seams = vi.hoisted(() => ({
+  beginBackgroundTask: vi.fn<() => Promise<string | null>>(async () => 'background-task-1'),
+  endBackgroundTask: vi.fn<(token: string) => Promise<void>>(async () => {}),
   flushOpenDocuments: vi.fn<() => Promise<void>>(async () => {}),
   flushSettings: vi.fn<() => Promise<void>>(async () => {}),
   flushBackup: vi.fn<() => Promise<void>>(async () => {}),
+}))
+vi.mock('@reflect/core', () => ({
+  beginBackgroundTask: seams.beginBackgroundTask,
+  endBackgroundTask: seams.endBackgroundTask,
 }))
 vi.mock('@/editor/open-documents', () => ({ flushOpenDocuments: seams.flushOpenDocuments }))
 vi.mock('@/lib/settings-flush', () => ({ flushSettings: seams.flushSettings }))
@@ -24,9 +30,9 @@ let dispose: (() => void) | null = null
 
 /** Wait for chained `.then` callbacks to run. */
 async function settleMicrotasks(): Promise<void> {
-  await Promise.resolve()
-  await Promise.resolve()
-  await Promise.resolve()
+  for (let iteration = 0; iteration < 8; iteration += 1) {
+    await Promise.resolve()
+  }
 }
 
 beforeEach(() => {
@@ -35,6 +41,8 @@ beforeEach(() => {
     configurable: true,
     get: () => visibility,
   })
+  seams.beginBackgroundTask.mockClear().mockImplementation(async () => 'background-task-1')
+  seams.endBackgroundTask.mockClear().mockImplementation(async () => {})
   seams.flushOpenDocuments.mockClear().mockImplementation(async () => {})
   seams.flushSettings.mockClear().mockImplementation(async () => {})
   seams.flushBackup.mockClear().mockImplementation(async () => {})
@@ -50,16 +58,29 @@ function goHidden(): void {
   document.dispatchEvent(new Event('visibilitychange'))
 }
 
+function goVisible(): void {
+  visibility = 'visible'
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
 describe('installBackgroundFlush', () => {
-  it('flushes documents and settings, then commits, when the app hides', async () => {
+  it('protects documents, settings, and the commit with one balanced assertion', async () => {
     dispose = installBackgroundFlush()
 
     goHidden()
     await settleMicrotasks()
 
+    expect(seams.beginBackgroundTask).toHaveBeenCalledTimes(1)
     expect(seams.flushOpenDocuments).toHaveBeenCalledTimes(1)
     expect(seams.flushSettings).toHaveBeenCalledTimes(1)
     expect(seams.flushBackup).toHaveBeenCalledTimes(1)
+    expect(seams.endBackgroundTask).toHaveBeenCalledWith('background-task-1')
+    expect(seams.beginBackgroundTask.mock.invocationCallOrder[0]).toBeLessThan(
+      seams.flushOpenDocuments.mock.invocationCallOrder[0] ?? 0,
+    )
+    expect(seams.flushBackup.mock.invocationCallOrder[0]).toBeLessThan(
+      seams.endBackgroundTask.mock.invocationCallOrder[0] ?? 0,
+    )
   })
 
   it('commits only after the buffers have landed (the mid-debounce edit)', async () => {
@@ -92,6 +113,41 @@ describe('installBackgroundFlush', () => {
     await settleMicrotasks()
 
     expect(seams.flushBackup).toHaveBeenCalledTimes(1)
+    expect(seams.endBackgroundTask).toHaveBeenCalledTimes(1)
+  })
+
+  it('ends the assertion even when a flush step unexpectedly rejects', async () => {
+    seams.flushBackup.mockRejectedValueOnce(new Error('commit failed'))
+    dispose = installBackgroundFlush()
+
+    goHidden()
+    await settleMicrotasks()
+
+    expect(seams.endBackgroundTask).toHaveBeenCalledWith('background-task-1')
+  })
+
+  it('still flushes when native background time is unavailable', async () => {
+    seams.beginBackgroundTask.mockRejectedValueOnce(new Error('no native bridge'))
+    dispose = installBackgroundFlush()
+
+    goHidden()
+    await settleMicrotasks()
+
+    expect(seams.flushOpenDocuments).toHaveBeenCalledTimes(1)
+    expect(seams.flushBackup).toHaveBeenCalledTimes(1)
+    expect(seams.endBackgroundTask).not.toHaveBeenCalled()
+  })
+
+  it('does not end a task when the native shell returns no assertion', async () => {
+    seams.beginBackgroundTask.mockResolvedValueOnce(null)
+    dispose = installBackgroundFlush()
+
+    goHidden()
+    await settleMicrotasks()
+
+    expect(seams.flushOpenDocuments).toHaveBeenCalledTimes(1)
+    expect(seams.flushBackup).toHaveBeenCalledTimes(1)
+    expect(seams.endBackgroundTask).not.toHaveBeenCalled()
   })
 
   it('does nothing on becoming visible', async () => {
@@ -114,11 +170,7 @@ describe('installBackgroundFlush', () => {
     expect(seams.flushBackup).toHaveBeenCalledTimes(1)
   })
 
-  it('triggers during an in-flight chain never overlap it — and are never dropped', async () => {
-    // iOS fires visibilitychange AND pagehide on one backgrounding; two
-    // concurrent chains would race the same buffers and git index. But a
-    // trigger arriving mid-chain (quick foreground-edit-background) must
-    // still get a flush afterwards, or that edit dies with the process.
+  it('coalesces visibilitychange and pagehide from one background transition', async () => {
     let landBuffers: () => void = () => {}
     seams.flushOpenDocuments.mockImplementationOnce(
       () =>
@@ -138,10 +190,35 @@ describe('installBackgroundFlush', () => {
 
     landBuffers()
     await settleMicrotasks()
+    expect(seams.flushOpenDocuments).toHaveBeenCalledTimes(1)
+    expect(seams.flushBackup).toHaveBeenCalledTimes(1)
+    expect(seams.beginBackgroundTask).toHaveBeenCalledTimes(1)
+  })
+
+  it('queues one rerun for a genuine visible-to-hidden transition in flight', async () => {
+    let landBuffers: () => void = () => {}
+    seams.flushOpenDocuments.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          landBuffers = resolve
+        }),
+    )
+    dispose = installBackgroundFlush()
+
+    goHidden()
+    goVisible()
+    goHidden()
+    window.dispatchEvent(new Event('pagehide'))
+    window.dispatchEvent(new Event('pagehide'))
     await settleMicrotasks()
-    // The mid-chain triggers coalesced into exactly one trailing chain.
+    expect(seams.flushOpenDocuments).toHaveBeenCalledTimes(1)
+
+    landBuffers()
+    await settleMicrotasks()
+    await settleMicrotasks()
     expect(seams.flushOpenDocuments).toHaveBeenCalledTimes(2)
     expect(seams.flushBackup).toHaveBeenCalledTimes(2)
+    expect(seams.beginBackgroundTask).toHaveBeenCalledTimes(2)
   })
 
   it('stops listening after dispose', async () => {

--- a/apps/desktop/src/lib/background-flush.ts
+++ b/apps/desktop/src/lib/background-flush.ts
@@ -1,3 +1,4 @@
+import { beginBackgroundTask, endBackgroundTask, type BackgroundTaskToken } from '@reflect/core'
 import { flushOpenDocuments } from '@/editor/open-documents'
 import { flushBackup } from '@/lib/backup-flush'
 import { flushSettings } from '@/lib/settings-flush'
@@ -28,6 +29,35 @@ export function installBackgroundFlush(): () => void {
   // the process. The trailing chain is a cheap no-op when nothing changed.
   let inFlight: Promise<void> | null = null
   let rerun = false
+  let hidden = document.visibilityState === 'hidden'
+  let transition = hidden ? 1 : 0
+  let lastRequestedTransition = 0
+
+  const runProtectedFlush = async (): Promise<void> => {
+    // Acquire before issuing any write IPC. If iOS cannot grant more time (or
+    // browser/mobile dev has no native command), the flush remains best-effort.
+    let backgroundTask: BackgroundTaskToken | null = null
+    try {
+      backgroundTask = await beginBackgroundTask()
+    } catch {
+      // Native protection is unavailable; still land as much as possible.
+    }
+
+    try {
+      await Promise.allSettled([flushOpenDocuments(), flushSettings()])
+      await flushBackup()
+    } finally {
+      if (backgroundTask !== null) {
+        try {
+          await endBackgroundTask(backgroundTask)
+        } catch {
+          // UIKit's expiration callback also ends an outstanding assertion.
+          // Backgrounding cannot surface cleanup failures into the webview.
+        }
+      }
+    }
+  }
+
   const flush = (): void => {
     if (inFlight !== null) {
       rerun = true
@@ -35,9 +65,10 @@ export function installBackgroundFlush(): () => void {
     }
     // Buffers and settings land first so the commit captures them. Failures
     // are surfaced by the save pipeline / next launch's sync — backgrounding
-    // must never be blocked on them.
-    inFlight = Promise.allSettled([flushOpenDocuments(), flushSettings()])
-      .then(() => flushBackup())
+    // must never be blocked on them. The catch also guarantees cleanup errors
+    // cannot become an unhandled rejection from this fire-and-forget trigger.
+    inFlight = runProtectedFlush()
+      .catch(() => {})
       .finally(() => {
         inFlight = null
         if (rerun) {
@@ -46,15 +77,38 @@ export function installBackgroundFlush(): () => void {
         }
       })
   }
+
+  const flushTransition = (): void => {
+    if (lastRequestedTransition === transition) {
+      return
+    }
+    lastRequestedTransition = transition
+    flush()
+  }
   const onVisibilityChange = (): void => {
     if (document.visibilityState === 'hidden') {
-      flush()
+      if (!hidden) {
+        hidden = true
+        transition += 1
+      }
+      flushTransition()
+    } else {
+      hidden = false
     }
   }
+  const onPageHide = (): void => {
+    // Usually follows visibilitychange for the same transition. When it is
+    // the only signal (some teardown/reload paths), create its transition.
+    if (!hidden) {
+      hidden = true
+      transition += 1
+    }
+    flushTransition()
+  }
   document.addEventListener('visibilitychange', onVisibilityChange)
-  window.addEventListener('pagehide', flush)
+  window.addEventListener('pagehide', onPageHide)
   return () => {
     document.removeEventListener('visibilitychange', onVisibilityChange)
-    window.removeEventListener('pagehide', flush)
+    window.removeEventListener('pagehide', onPageHide)
   }
 }

--- a/apps/desktop/src/lib/backup-controller.test.ts
+++ b/apps/desktop/src/lib/backup-controller.test.ts
@@ -451,6 +451,53 @@ describe('createBackupController', () => {
     controller.dispose()
   })
 
+  it('defers mobile launch, online, and debounce cycles until foreground', async () => {
+    setPlatformSurface({ mobileApp: true })
+    const visibility = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+    const { calls } = fakeBridge()
+    const controller = createBackupController({ graph: GRAPH, indexGeneration: 1 })
+    try {
+      await controller.start()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      // Adoption may probe status/auth while hidden, but the launch cycle must
+      // not acquire the Git index or touch the network.
+      expect(calls).not.toContain('git_commit_all')
+      expect(calls).not.toContain('git_fetch')
+
+      visibility.mockReturnValue('visible')
+      document.dispatchEvent(new Event('visibilitychange'))
+      await vi.waitFor(() => {
+        expect(calls.filter((command) => command === 'git_commit_all')).toHaveLength(1)
+      })
+      expect(calls.filter((command) => command === 'git_fetch')).toHaveLength(1)
+
+      visibility.mockReturnValue('hidden')
+      vi.useFakeTimers()
+      emitFileChanges([{ path: 'notes/edited.md', kind: 'upsert', modifiedMs: 1 }])
+      window.dispatchEvent(new Event('online'))
+      await vi.advanceTimersByTimeAsync(10_000)
+
+      // Both the immediate online trigger and the edit's 10s mobile debounce
+      // are dropped while hidden.
+      expect(calls.filter((command) => command === 'git_commit_all')).toHaveLength(1)
+      expect(calls.filter((command) => command === 'git_fetch')).toHaveLength(1)
+
+      visibility.mockReturnValue('visible')
+      document.dispatchEvent(new Event('visibilitychange'))
+      await vi.runAllTimersAsync()
+      expect(calls.filter((command) => command === 'git_commit_all')).toHaveLength(2)
+      // Foreground replay is full, so it fetches rather than merely pushing
+      // the edit that arrived while hidden.
+      expect(calls.filter((command) => command === 'git_fetch')).toHaveLength(2)
+    } finally {
+      vi.useRealTimers()
+      controller.dispose()
+      visibility.mockRestore()
+      setPlatformSurface({ mobileApp: false })
+    }
+  })
+
   it('an edit backs up after 30s idle on desktop, 10s on mobile', async () => {
     const commitCount = (calls: string[]): number =>
       calls.filter((command) => command === 'git_commit_all').length
@@ -516,5 +563,29 @@ describe('createBackupController', () => {
     ])
     controller.dispose()
     unlisten()
+  })
+
+  it('defers a pulled note direct-index apply while the mobile app is hidden', async () => {
+    setPlatformSurface({ mobileApp: true })
+    const visibility = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+    try {
+      const { calls } = fakeBridge({
+        mergeOutcome: {
+          kind: 'merged',
+          conflictedPaths: [],
+          changedFiles: [{ path: 'notes/from-remote.md', kind: 'upsert', modifiedMs: 123 }],
+        },
+      })
+      const controller = createBackupController({ graph: GRAPH, indexGeneration: 1 })
+      await controller.start()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(calls).not.toContain('note_read')
+      expect(calls).not.toContain('index_apply_batch')
+      controller.dispose()
+    } finally {
+      visibility.mockRestore()
+      setPlatformSurface({ mobileApp: false })
+    }
   })
 })

--- a/apps/desktop/src/lib/backup-controller.ts
+++ b/apps/desktop/src/lib/backup-controller.ts
@@ -173,7 +173,13 @@ export function createBackupController(options: BackupControllerOptions): Backup
     emitFileChanges(changes)
     const indexable = changes.filter((change) => isNotePath(change.path))
     if (indexGeneration !== null && indexable.length > 0) {
-      void applyIndexChanges(indexable, indexGeneration).then((mutations) => {
+      void applyIndexChanges(
+        indexable,
+        indexGeneration,
+        undefined,
+        undefined,
+        () => !isMobileSurface() || document.visibilityState !== 'hidden',
+      ).then((mutations) => {
         if (mutations > 0) {
           throttledInvalidateIndexQueries()
         }
@@ -288,6 +294,13 @@ export function createBackupController(options: BackupControllerOptions): Backup
       const next = createSyncEngine({
         generation,
         ...(isMobileSurface() ? { idleMs: MOBILE_IDLE_MS } : {}),
+        // iOS can suspend us at any await. Do not begin a launch, online, or
+        // debounced Git cycle after the document is hidden; the existing
+        // visible/focus trigger below replays a full cycle on foreground.
+        // The background flusher's protected local commit bypasses this
+        // engine deliberately.
+        canStartCycle: () =>
+          !isMobileSurface() || document.visibilityState !== 'hidden',
         // The managed token is for github.com only — a generic host must
         // never receive it. Rust resolves generic credentials locally.
         getToken: repo === null ? async () => null : () => getGithubToken(providerFetch),

--- a/apps/desktop/src/lib/icloud-controller.test.ts
+++ b/apps/desktop/src/lib/icloud-controller.test.ts
@@ -198,6 +198,47 @@ describe('createIcloudController', () => {
     expect(scanCalls[1]?.ingestedPaths).toEqual(['notes/other.md'])
   })
 
+  it('defers mobile baseline, conflict, and ingest scans until foreground', async () => {
+    const visibility = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+    try {
+      const icloud = controller({ emit: true })
+      await icloud.start()
+      await settleScan()
+      expect(scanCalls).toHaveLength(0)
+
+      emitFileChanges([{ path: 'notes/external.md', kind: 'upsert', modifiedMs: 5 }])
+      listeners.get('icloud:conflicts')?.(['notes/conflicted.md'])
+      await settleScan(INGEST_SETTLE_MS)
+      expect(scanCalls).toHaveLength(0)
+
+      visibility.mockReturnValue('visible')
+      document.dispatchEvent(new Event('visibilitychange'))
+      await settleScan()
+
+      expect(scanCalls).toHaveLength(1)
+      expect(scanCalls[0]).toMatchObject({
+        recordBaseline: true,
+        ingestedPaths: ['notes/external.md'],
+      })
+    } finally {
+      visibility.mockRestore()
+    }
+  })
+
+  it('preserves desktop baseline scanning while the document is hidden', async () => {
+    const visibility = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+    try {
+      const icloud = controller({ emit: false })
+      await icloud.start()
+      await settleScan()
+
+      expect(scanCalls).toHaveLength(1)
+      expect(scanCalls[0]?.recordBaseline).toBe(true)
+    } finally {
+      visibility.mockRestore()
+    }
+  })
+
   it('a failed sweep re-queues its ingests and the adoption baseline', async () => {
     scanResults.push(new Error('container hiccup'))
     const icloud = controller()

--- a/apps/desktop/src/lib/icloud-controller.ts
+++ b/apps/desktop/src/lib/icloud-controller.ts
@@ -117,8 +117,12 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
   let queuedScan: 'prompt' | 'ingest' | null = null
   let lastScanEndedAt = 0
 
+  function scanSuspended(): boolean {
+    return emitFileChangesFromWatch && document.visibilityState === 'hidden'
+  }
+
   function scheduleScan(delayMs: number = SCAN_DEBOUNCE_MS): void {
-    if (disposed) {
+    if (disposed || scanSuspended()) {
       return
     }
     if (scanRunning) {
@@ -148,7 +152,7 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
   }
 
   async function runScan(): Promise<void> {
-    if (disposed) {
+    if (disposed || scanSuspended()) {
       return
     }
     if (scanRunning) {
@@ -221,7 +225,13 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
     }
     const indexable = changes.filter((change) => isNotePath(change.path))
     if (indexGeneration !== null && indexable.length > 0) {
-      void applyIndexChanges(indexable, indexGeneration).then((mutations) => {
+      void applyIndexChanges(
+        indexable,
+        indexGeneration,
+        undefined,
+        undefined,
+        () => !emitFileChangesFromWatch || document.visibilityState !== 'hidden',
+      ).then((mutations) => {
         if (mutations > 0) {
           throttledInvalidateIndexQueries()
         }

--- a/apps/desktop/src/providers/graph-index.test.ts
+++ b/apps/desktop/src/providers/graph-index.test.ts
@@ -227,6 +227,20 @@ describe('createGraphIndex', () => {
     expect(mockWatchStart).toHaveBeenCalledTimes(1)
   })
 
+  it('resume(null) clears suspension without starting work before graph open', async () => {
+    const index = createGraphIndex()
+    index.suspend()
+
+    index.resume(null, () => false)
+    await Promise.resolve()
+    expect(mockSync).not.toHaveBeenCalled()
+
+    index.sync(5, () => false)
+    await index.settled()
+    expect(mockSync).toHaveBeenCalledTimes(1)
+    expect(mockWatchStart).toHaveBeenCalledTimes(1)
+  })
+
   it('suspend() aborts bulk work, drops live work, and resume coalesces catch-up triggers', async () => {
     const unlisten = vi.fn()
     let canApply: (() => boolean) | undefined

--- a/apps/desktop/src/providers/graph-index.test.ts
+++ b/apps/desktop/src/providers/graph-index.test.ts
@@ -69,7 +69,7 @@ describe('createGraphIndex', () => {
       signal: expect.any(AbortSignal),
       onMoved,
     })
-    expect(mockSubscribe).toHaveBeenCalledWith(5, onApplied, onMoved)
+    expect(mockSubscribe).toHaveBeenCalledWith(5, onApplied, onMoved, expect.any(Function))
     // The initial reconcile is itself an index change: invalidate once there.
     expect(onApplied).toHaveBeenCalledTimes(1)
     expect(mockWatchStart).toHaveBeenCalledTimes(1)
@@ -207,6 +207,62 @@ describe('createGraphIndex', () => {
     await index.settled()
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(mockSync).not.toHaveBeenCalled()
+  })
+
+  it('defers an initial sync while suspended and replays it on resume', async () => {
+    let backgrounded = true
+    const index = createGraphIndex({ shouldSuspend: () => backgrounded })
+
+    index.sync(5, () => false)
+    await Promise.resolve()
+    expect(mockSync).not.toHaveBeenCalled()
+    expect(mockSubscribe).not.toHaveBeenCalled()
+
+    backgrounded = false
+    index.resume(5, () => false)
+    await vi.waitFor(() => expect(mockSync).toHaveBeenCalledTimes(1))
+    await index.settled()
+
+    expect(mockSubscribe).toHaveBeenCalledTimes(1)
+    expect(mockWatchStart).toHaveBeenCalledTimes(1)
+  })
+
+  it('suspend() aborts bulk work, drops live work, and resume coalesces catch-up triggers', async () => {
+    const unlisten = vi.fn()
+    let canApply: (() => boolean) | undefined
+    mockSubscribe.mockImplementation(async (_generation, _onApplied, _onMoved, guard) => {
+      canApply = guard
+      return unlisten
+    })
+    const index = createGraphIndex()
+    index.sync(5, () => false)
+    await index.settled()
+    expect(canApply?.()).toBe(true)
+
+    index.suspend()
+    expect(unlisten).toHaveBeenCalledTimes(1)
+    expect(canApply?.()).toBe(false)
+
+    const settles: Array<() => void> = []
+    mockSync.mockClear()
+    mockSync.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          settles.push(resolve)
+        }),
+    )
+    index.resume(5, () => false)
+    await vi.waitFor(() => expect(settles).toHaveLength(1))
+    index.refresh(5, () => false)
+    index.refresh(5, () => false)
+
+    settles[0]!()
+    await vi.waitFor(() => expect(settles).toHaveLength(2))
+    settles[1]!()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    // One foreground catch-up plus one coalesced queued rerun, not one pass
+    // for every simultaneous resume/iCloud trigger.
+    expect(mockSync).toHaveBeenCalledTimes(2)
   })
 
   it('stops reporting file progress once the pass is superseded', async () => {

--- a/apps/desktop/src/providers/graph-index.ts
+++ b/apps/desktop/src/providers/graph-index.ts
@@ -27,6 +27,17 @@ import {
  */
 export interface GraphIndex {
   /**
+   * Suspend index writes for a backgrounded mobile app: abort the bulk pass
+   * and drop the live subscription synchronously. A later {@link resume}
+   * reconciles the whole graph, so file events missed while suspended converge.
+   */
+  suspend: () => void
+  /**
+   * Resume after {@link suspend} and run one coalesced full sync for anything
+   * that changed while the live subscription was absent.
+   */
+  resume: (generation: number, isStale: () => boolean) => void
+  /**
    * Abort the in-flight reconcile (if any) and wait for the sync pass to fully
    * settle, so a stale pass can't keep running into the next graph's open.
    */
@@ -100,6 +111,12 @@ export interface GraphIndexOptions {
    * skip-everything pass never surfaces. Superseded passes stop reporting.
    */
   onFileProgress?: (done: number, total: number, worked: number) => void
+  /**
+   * Dynamic guard for platforms that must not start index work while the app
+   * is suspended. Checked at every lifecycle boundary in addition to the
+   * explicit {@link GraphIndex.suspend} transition.
+   */
+  shouldSuspend?: () => boolean
 }
 
 /**
@@ -108,13 +125,36 @@ export interface GraphIndexOptions {
  * keeps one instance (e.g. in a ref) across graph switches.
  */
 export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
-  const { onError, onProgress, onApplied, onMoved, onFileProgress } = options
+  const { onError, onProgress, onApplied, onMoved, onFileProgress, shouldSuspend } = options
   let abort: AbortController | null = null
   let done: Promise<void> = Promise.resolve()
+  let suspended = false
   // Boxed so the async sync pass can read/replace the active subscription without
   // TS narrowing the closure-captured binding (the same reason the provider
   // previously held this in a ref's `.current`).
   const live: { unlisten: (() => void) | null } = { unlisten: null }
+
+  function isSuspended(): boolean {
+    return suspended || shouldSuspend?.() === true
+  }
+
+  function suspend(): void {
+    suspended = true
+    abort?.abort()
+    live.unlisten?.()
+    live.unlisten = null
+    onProgress?.('idle')
+  }
+
+  function resume(generation: number, isStale: () => boolean): void {
+    suspended = false
+    if (!isStale()) {
+      // Events intentionally dropped while suspended are recovered by the
+      // full reconcile. `refresh` also folds a rapid resume/poll burst into a
+      // single queued rerun when a prior pass is still settling.
+      refresh(generation, isStale)
+    }
+  }
 
   async function stop(): Promise<void> {
     abort?.abort()
@@ -129,6 +169,7 @@ export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
     await stop()
     live.unlisten?.()
     live.unlisten = null
+    suspended = false
     onProgress?.('idle')
     await watchStop().catch(() => {})
   }
@@ -148,6 +189,10 @@ export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
     live.unlisten?.()
     live.unlisten = null
 
+    if (isSuspended()) {
+      return
+    }
+
     onProgress?.('reconciling')
     const controller = new AbortController()
     abort = controller
@@ -156,6 +201,9 @@ export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
       // later step threw) is torn down in `finally` so listeners can't leak.
       let pending: (() => void) | null = null
       try {
+        if (isSuspended()) {
+          return
+        }
         await syncIndex({
           generation,
           signal: controller.signal,
@@ -170,16 +218,21 @@ export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
               }
             : {}),
         })
-        if (isStale()) {
+        if (isStale() || isSuspended()) {
           return
         }
         onApplied?.()
-        pending = await subscribeIndexChanges(generation, onApplied, onMoved)
-        if (isStale()) {
+        pending = await subscribeIndexChanges(
+          generation,
+          onApplied,
+          onMoved,
+          () => !controller.signal.aborted && !isStale() && !isSuspended(),
+        )
+        if (isStale() || isSuspended()) {
           return
         }
         await watchStart()
-        if (isStale()) {
+        if (isStale() || isSuspended()) {
           return
         }
         live.unlisten?.()
@@ -201,6 +254,9 @@ export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
   let refreshQueued = false
 
   function refresh(generation: number, isStale: () => boolean): void {
+    if (isSuspended()) {
+      return
+    }
     if (refreshRunning) {
       refreshQueued = true
       return
@@ -213,7 +269,7 @@ export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
           // Settle (abort) any in-flight pass first so two passes never write
           // concurrently, then bail if a newer open superseded this graph.
           await stop()
-          if (isStale()) {
+          if (isStale() || isSuspended()) {
             return
           }
           sync(generation, isStale)
@@ -225,5 +281,5 @@ export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
     })()
   }
 
-  return { stop, settled, close, open, sync, refresh }
+  return { suspend, resume, stop, settled, close, open, sync, refresh }
 }

--- a/apps/desktop/src/providers/graph-index.ts
+++ b/apps/desktop/src/providers/graph-index.ts
@@ -34,9 +34,10 @@ export interface GraphIndex {
   suspend: () => void
   /**
    * Resume after {@link suspend} and run one coalesced full sync for anything
-   * that changed while the live subscription was absent.
+   * that changed while the live subscription was absent. A null generation
+   * clears suspension without starting work (foreground can precede graph open).
    */
-  resume: (generation: number, isStale: () => boolean) => void
+  resume: (generation: number | null, isStale: () => boolean) => void
   /**
    * Abort the in-flight reconcile (if any) and wait for the sync pass to fully
    * settle, so a stale pass can't keep running into the next graph's open.
@@ -146,9 +147,9 @@ export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
     onProgress?.('idle')
   }
 
-  function resume(generation: number, isStale: () => boolean): void {
+  function resume(generation: number | null, isStale: () => boolean): void {
     suspended = false
-    if (!isStale()) {
+    if (generation !== null && !isStale()) {
       // Events intentionally dropped while suspended are recovered by the
       // full reconcile. `refresh` also folds a rapid resume/poll burst into a
       // single queued rerun when a prior pass is still settling.

--- a/apps/desktop/src/providers/graph-provider.test.tsx
+++ b/apps/desktop/src/providers/graph-provider.test.tsx
@@ -419,6 +419,34 @@ describe('GraphProvider mobile onboarding (Plans 19/21)', () => {
     }
   })
 
+  it('clears suspension when mobile foregrounds before its index session opens', async () => {
+    const visibility = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+    try {
+      const { result } = renderHook(() => useGraph(), { wrapper: mobileWrapper })
+      await waitFor(() => expect(result.current.needsOnboarding).toBe(true))
+      expect(result.current.indexGeneration).toBeNull()
+
+      // The app foregrounds while onboarding still has no graph/index. This
+      // must clear the sticky suspension even though there is nothing to sync.
+      visibility.mockReturnValue('visible')
+      act(() => {
+        document.dispatchEvent(new Event('visibilitychange'))
+      })
+
+      await act(async () => {
+        const done = result.current.completeOnboarding('local')
+        await waitFor(() => expect(pendingOpens.has(MOBILE_ROOT)).toBe(true))
+        resolveOpen(MOBILE_ROOT)
+        await done
+      })
+
+      await waitFor(() => expect(invokeLog).toContain('index_clear'))
+      expect(result.current.status).toBe('ready')
+    } finally {
+      visibility.mockRestore()
+    }
+  })
+
   it('creates the default container graph and records kind + name on completeOnboarding(icloud)', async () => {
     const { result } = renderHook(() => useGraph(), { wrapper: mobileWrapper })
     await waitFor(() => expect(result.current.needsOnboarding).toBe(true))

--- a/apps/desktop/src/providers/graph-provider.test.tsx
+++ b/apps/desktop/src/providers/graph-provider.test.tsx
@@ -386,6 +386,39 @@ describe('GraphProvider mobile onboarding (Plans 19/21)', () => {
     expect(settingsStore['mobileStorage']).toBe('local')
   })
 
+  it('defers the first mobile index pass while hidden and replays it on foreground', async () => {
+    const visibility = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+    try {
+      const { result } = renderHook(() => useGraph(), { wrapper: mobileWrapper })
+      await waitFor(() => expect(result.current.needsOnboarding).toBe(true))
+
+      await act(async () => {
+        const done = result.current.completeOnboarding('local')
+        await waitFor(() => expect(pendingOpens.has(MOBILE_ROOT)).toBe(true))
+        resolveOpen(MOBILE_ROOT)
+        await done
+      })
+      await waitFor(() => expect(metaStore['welcomeSeeded']).toBe('true'))
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(invokeLog).not.toContain('index_clear')
+      expect(invokeLog).not.toContain('index_reconcile_scan')
+
+      visibility.mockReturnValue('visible')
+      act(() => {
+        document.dispatchEvent(new Event('visibilitychange'))
+      })
+
+      // Resume performs a full sync, which catches files and local events the
+      // intentionally absent live subscription could not observe while hidden.
+      await waitFor(() => expect(invokeLog).toContain('index_clear'))
+    } finally {
+      visibility.mockRestore()
+    }
+  })
+
   it('creates the default container graph and records kind + name on completeOnboarding(icloud)', async () => {
     const { result } = renderHook(() => useGraph(), { wrapper: mobileWrapper })
     await waitFor(() => expect(result.current.needsOnboarding).toBe(true))

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -184,13 +184,12 @@ export function GraphProvider({
         index.suspend()
         return
       }
-      if (indexGeneration !== null) {
-        const seq = openSeq.current
-        // The full pass recovers every event intentionally missed while the
-        // live subscription was absent; stacked resume/iCloud triggers fold
-        // into the lifecycle's single queued rerun.
-        index.resume(indexGeneration, () => seq !== openSeq.current)
-      }
+      const seq = openSeq.current
+      // A null generation still clears suspension: mobile can foreground
+      // before onboarding/open has produced an index session. With a session,
+      // the full pass recovers every event missed while hidden; stacked
+      // resume/iCloud triggers fold into the lifecycle's queued rerun.
+      index.resume(indexGeneration, () => seq !== openSeq.current)
     }
 
     if (document.visibilityState === 'hidden') {

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -2,6 +2,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -14,6 +15,7 @@ import {
   errorMessage,
   forgetRecent,
   hasBridge,
+  isMobilePlatform,
   createGraph,
   openGraph,
   recentGraphs,
@@ -161,8 +163,44 @@ export function GraphProvider({
       // External renames healed by id follow through to sessions and routes,
       // exactly as for an in-app rename (Plan 17).
       onMoved: followHealedMove,
+      // `visibilitychange` below performs the active teardown; this dynamic
+      // guard also closes the launch race where the first sync is scheduled
+      // after iOS has already hidden the webview.
+      shouldSuspend: () =>
+        isMobilePlatform(platform) && document.visibilityState === 'hidden',
     }),
   )
+
+  useEffect(() => {
+    if (!isMobilePlatform(platform) || !isMainWindow()) {
+      return
+    }
+
+    const index = indexRef.current
+    const onVisibilityChange = (): void => {
+      if (document.visibilityState === 'hidden') {
+        // Synchronous teardown prevents a locally emitted or metadata-watcher
+        // batch from entering the index queue after iOS begins suspension.
+        index.suspend()
+        return
+      }
+      if (indexGeneration !== null) {
+        const seq = openSeq.current
+        // The full pass recovers every event intentionally missed while the
+        // live subscription was absent; stacked resume/iCloud triggers fold
+        // into the lifecycle's single queued rerun.
+        index.resume(indexGeneration, () => seq !== openSeq.current)
+      }
+    }
+
+    if (document.visibilityState === 'hidden') {
+      index.suspend()
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [indexGeneration, platform])
 
   const loadRecents = useCallback(
     async (options?: { surfaceErrors?: boolean }): Promise<RecentGraph[]> => {

--- a/packages/core/src/app/background-task.ts
+++ b/packages/core/src/app/background-task.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod'
+import { call } from '../ipc/invoke'
+
+const backgroundTaskTokenSchema = z.string()
+
+/** Opaque handle for one finite-length native background execution assertion. */
+export type BackgroundTaskToken = z.infer<typeof backgroundTaskTokenSchema>
+
+/**
+ * Ask the native shell to keep a finite persistence pass running after iOS
+ * backgrounds the app. Returns `null` when no assertion is available; callers
+ * must still attempt their best-effort flush.
+ */
+export function beginBackgroundTask(): Promise<BackgroundTaskToken | null> {
+  return call('background_task_begin', {}, backgroundTaskTokenSchema.nullable())
+}
+
+/**
+ * Balance {@link beginBackgroundTask}. The shell treats expired or repeated
+ * tokens as no-ops, so cleanup is safe from a `finally` block.
+ */
+export async function endBackgroundTask(token: BackgroundTaskToken): Promise<void> {
+  await call('background_task_end', { token }, z.null())
+}

--- a/packages/core/src/exports/platform.ts
+++ b/packages/core/src/exports/platform.ts
@@ -22,6 +22,11 @@ export {
   type MobileStorageKind,
 } from '../ipc/commands'
 export { confirmQuit, subscribeQuitRequested } from '../app/quit'
+export {
+  beginBackgroundTask,
+  endBackgroundTask,
+  type BackgroundTaskToken,
+} from '../app/background-task'
 export { WINDOW_NAVIGATE_EVENT, subscribeWindowNavigate } from '../app/window-events'
 export { toggleDevtools } from '../app/devtools'
 export {

--- a/packages/core/src/indexing/indexer.ts
+++ b/packages/core/src/indexing/indexer.ts
@@ -302,9 +302,11 @@ export function createMtimeTouchBatch(generation: number): MtimeTouchBatch {
 /**
  * Full rebuild: wipe derived tables and re-index every markdown file. Used for
  * explicit repair / schema-bump triggers, not the hot graph-switch path (that's
- * {@link reconcileIndex}). Abort is checked **only before** the wipe — once we've
- * cleared, we run to completion so an interrupted rebuild can't leave the index
- * empty or half-populated.
+ * {@link reconcileIndex}). An aborted rebuild may leave a partial index after
+ * the wipe; that is intentional for mobile suspension. `index_clear` preserves
+ * metadata, so the next foreground sync either rebuilds again for an old stamp
+ * or reconciles the missing rows for a current stamp. Both converge without
+ * continuing to hold SQLite locks in the background.
  */
 export async function rebuildIndex(options: IndexPassOptions): Promise<void> {
   const { generation, onSkippedNote, onFileProgress } = options
@@ -312,15 +314,24 @@ export async function rebuildIndex(options: IndexPassOptions): Promise<void> {
     return // don't wipe the current index for an already-cancelled pass
   }
   await clearIndex(generation)
+  if (options.signal?.aborted) {
+    return
+  }
   const files = await listFiles()
   const batch = createIndexApplyBatch(generation, onSkippedNote)
   let done = 0
   let worked = 0
   for (const file of files) {
+    if (options.signal?.aborted) {
+      return
+    }
     done += 1
     if (done % INDEX_PASS_YIELD_EVERY === 0) {
       onFileProgress?.(done, files.length, worked)
       await yieldToEventLoop()
+      if (options.signal?.aborted) {
+        return
+      }
     }
     if (file.placeholder === true) {
       continue // evicted to iCloud — unreadable until re-download, indexed then
@@ -328,9 +339,22 @@ export async function rebuildIndex(options: IndexPassOptions): Promise<void> {
     worked += 1
     const content = await readNote(file.path)
     const fileHash = await hashContent(content)
-    await batch.add(await buildNoteProjection(file.path, content, { fileHash, mtime: file.modifiedMs }))
+    const projection = await buildNoteProjection(file.path, content, {
+      fileHash,
+      mtime: file.modifiedMs,
+    })
+    if (options.signal?.aborted) {
+      return
+    }
+    await batch.add(projection)
+  }
+  if (options.signal?.aborted) {
+    return
   }
   await batch.flush()
+  if (options.signal?.aborted) {
+    return
+  }
   onFileProgress?.(files.length, files.length, worked)
   // The rows now match the current projection — stamp it so `syncIndex` can
   // reconcile cheaply from here on. A superseded pass stamps into a stale
@@ -479,6 +503,9 @@ export async function reconcileIndex(options: IndexPassOptions): Promise<void> {
       // echo-time stamp, or a provider rewrote it), re-stamp it so the next
       // pass takes the read-free path — left alone it mismatches forever.
       if (stored.mtime !== candidate.modifiedMs) {
+        if (signal?.aborted) {
+          return
+        }
         await touches.add({ path: candidate.path, mtime: candidate.modifiedMs })
       }
       continue // unchanged
@@ -486,11 +513,22 @@ export async function reconcileIndex(options: IndexPassOptions): Promise<void> {
     if (signal?.aborted) {
       return // re-check after the awaits — don't write for a superseded pass
     }
-    await batch.add(
-      await buildNoteProjection(candidate.path, content, { fileHash, mtime: candidate.modifiedMs }),
-    )
+    const projection = await buildNoteProjection(candidate.path, content, {
+      fileHash,
+      mtime: candidate.modifiedMs,
+    })
+    if (signal?.aborted) {
+      return
+    }
+    await batch.add(projection)
+  }
+  if (signal?.aborted) {
+    return
   }
   await batch.flush()
+  if (signal?.aborted) {
+    return
+  }
   await touches.flush()
   onFileProgress?.(total, total, worked)
 

--- a/packages/core/src/indexing/live.test.ts
+++ b/packages/core/src/indexing/live.test.ts
@@ -161,6 +161,44 @@ describe('subscribeIndexChanges', () => {
     ])
   })
 
+  it('drops queued live writes when the lifecycle suspends and leaves replay to reconcile', async () => {
+    const order: string[] = []
+    let canApply = true
+    let releaseRead: () => void = () => {}
+    const { emitChanges } = fakeBridge(async (command, args) => {
+      if (command === 'note_read') {
+        order.push(`read:${String(args['path'])}`)
+        await new Promise<void>((resolve) => {
+          releaseRead = resolve
+        })
+        order.push(`read-finished:${String(args['path'])}`)
+      }
+      if (command === 'index_apply_batch') {
+        order.push('apply')
+      }
+      if (command === 'db_query') {
+        return []
+      }
+      return command === 'note_read' ? '# content' : null
+    })
+
+    await subscribeIndexChanges(1, undefined, undefined, () => canApply)
+    emitChanges([{ path: 'notes/started-visible.md', kind: 'upsert' }])
+    emitChanges([{ path: 'notes/queued.md', kind: 'upsert' }])
+    await vi.waitFor(() => expect(order).toContain('read:notes/started-visible.md'))
+
+    canApply = false
+    releaseRead()
+    await vi.waitFor(() => expect(order).toContain('read-finished:notes/started-visible.md'))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // The first batch had begun reading while visible, but did not start its
+    // SQLite write after suspension. The second never began at all; the
+    // foreground full reconcile is the durable replay path for both.
+    expect(order).not.toContain('apply')
+    expect(order).not.toContain('read:notes/queued.md')
+  })
+
   it('fires onApplied only after the batch has been written to the index', async () => {
     const order: string[] = []
     const { emitChanges } = fakeBridge(async (command, args) => {

--- a/packages/core/src/indexing/live.ts
+++ b/packages/core/src/indexing/live.ts
@@ -61,6 +61,7 @@ async function healBatchMoves(
   generation: number,
   onError: ApplyErrorHandler,
   onMoved?: MovedHandler,
+  canApply: () => boolean = () => true,
 ): Promise<{ handled: Set<string>; healed: number }> {
   const handled = new Set<string>()
   let healed = 0
@@ -80,8 +81,21 @@ async function healBatchMoves(
   )
   const mtimeByPath = new Map(arrivals.map((change) => [change.path, change.modifiedMs]))
   for (const move of moves) {
+    if (!canApply()) {
+      break
+    }
     try {
       await moveIndexedRows(move.from, move.to, generation)
+      if (!canApply()) {
+        // The move transaction began while foregrounded and has committed.
+        // Preserve its UI/session notification even though the projection
+        // refresh is deferred; foreground reconcile repairs that row.
+        handled.add(move.from)
+        handled.add(move.to)
+        healed += 1
+        onMoved?.(move.from, move.to)
+        break
+      }
       await indexNote(move.to, {
         generation,
         content: content.get(move.to),
@@ -127,13 +141,21 @@ async function prefetchFacts(paths: string[]): Promise<Map<string, IndexedFileFa
  * Returns how many index mutations the batch actually performed (applies,
  * removes, and healed moves). Zero means every change was already reflected
  * in the index — the caller can skip its cache invalidation.
+ *
+ * `canApply` is checked immediately before each SQLite write. A caller that
+ * suspends the lifecycle can therefore abandon the remaining batch; its next
+ * full reconcile is responsible for convergence.
  */
 export async function applyIndexChanges(
   changes: FileChange[],
   generation: number,
   onError: ApplyErrorHandler = logApplyError,
   onMoved?: MovedHandler,
+  canApply: () => boolean = () => true,
 ): Promise<number> {
+  if (!canApply()) {
+    return 0
+  }
   // The change stream carries more than notes (the watcher also reports
   // audio-memo recordings); only markdown notes reach the index.
   const notes = changes.filter((change) => isNotePath(change.path))
@@ -143,7 +165,7 @@ export async function applyIndexChanges(
   let handled: Set<string>
   let mutations = 0
   try {
-    const outcome = await healBatchMoves(notes, generation, onError, onMoved)
+    const outcome = await healBatchMoves(notes, generation, onError, onMoved, canApply)
     handled = outcome.handled
     mutations += outcome.healed
   } catch (error) {
@@ -172,9 +194,15 @@ export async function applyIndexChanges(
 
   let done = 0
   for (const change of notes) {
+    if (!canApply()) {
+      return mutations
+    }
     done += 1
     if (done % INDEX_PASS_YIELD_EVERY === 0) {
       await yieldToEventLoop()
+      if (!canApply()) {
+        return mutations
+      }
     }
     if (handled.has(change.path)) {
       continue
@@ -183,7 +211,13 @@ export async function applyIndexChanges(
       if (change.kind === 'remove') {
         // Flush first: a same-batch upsert(x) … remove(x) sequence must not
         // have the batched upsert land *after* the remove and resurrect it.
+        if (!canApply()) {
+          return mutations
+        }
         await batch.flush()
+        if (!canApply()) {
+          return mutations
+        }
         await removeFromIndex(change.path, generation)
         mutations += 1
         continue
@@ -194,26 +228,40 @@ export async function applyIndexChanges(
       }
       const content = await readNote(change.path)
       const fileHash = await hashContent(content)
+      if (!canApply()) {
+        return mutations
+      }
       if (facts?.fileHash === fileHash) {
         // Content unchanged; only the mtime moved. Re-stamp the row so the
         // next pass skips the read — a stored echo-time stamp never matches
         // and would cost this read on every reconcile and every batch.
         if (change.modifiedMs !== undefined && facts.mtime !== change.modifiedMs) {
+          if (!canApply()) {
+            return mutations
+          }
           await touches.add({ path: change.path, mtime: change.modifiedMs })
         }
         continue
       }
-      await batch.add(
-        await buildNoteProjection(change.path, content, {
-          fileHash,
-          mtime: change.modifiedMs ?? Date.now(),
-        }),
-      )
+      const projection = await buildNoteProjection(change.path, content, {
+        fileHash,
+        mtime: change.modifiedMs ?? Date.now(),
+      })
+      if (!canApply()) {
+        return mutations
+      }
+      await batch.add(projection)
     } catch (error) {
       onError(error, change)
     }
   }
+  if (!canApply()) {
+    return mutations
+  }
   await batch.flush()
+  if (!canApply()) {
+    return mutations + batch.applied()
+  }
   await touches.flush()
   // Re-stamps count as mutations: `updated_at` moved, so recency-ordered
   // queries may return different rows and the caller must invalidate.
@@ -237,24 +285,42 @@ export async function applyIndexChanges(
  * settled index, never racing a just-written private note's indexing. Batches
  * that touch neither notes nor assets (e.g. audio-memo recordings) are skipped
  * entirely, as before.
+ *
+ * `canApply` gates both event admission and execution from the serialized
+ * queue. Events dropped after suspension are intentionally recovered by the
+ * lifecycle's foreground reconcile.
  */
 export function subscribeIndexChanges(
   generation: number,
   onApplied?: (changes: FileChange[]) => void,
   onMoved?: MovedHandler,
+  canApply: () => boolean = () => true,
 ): Promise<Unlisten> {
   // Serialize batches so overlapping events for the same path can't reorder
   // (e.g. an upsert landing after a later remove, leaving a ghost row).
   let applyQueue: Promise<void> = Promise.resolve()
   return subscribeFileChanges((changes) => {
+    if (!canApply()) {
+      return
+    }
     const notes = changes.filter((change) => isNotePath(change.path))
     const touchesAssets = changes.some((change) => isAssetPath(change.path))
     if (notes.length === 0 && !touchesAssets) {
       return // e.g. a batch of audio-memo recordings — nothing the index tracks
     }
     applyQueue = applyQueue
-      .then(() => (notes.length > 0 ? applyIndexChanges(notes, generation, undefined, onMoved) : 0))
+      .then(() => {
+        if (!canApply()) {
+          return 0
+        }
+        return notes.length > 0
+          ? applyIndexChanges(notes, generation, undefined, onMoved, canApply)
+          : 0
+      })
       .then((mutations) => {
+        if (!canApply()) {
+          return
+        }
         if (notes.length > 0 && mutations > 0) {
           onApplied?.(notes)
         }

--- a/packages/core/src/indexing/pipeline.test.ts
+++ b/packages/core/src/indexing/pipeline.test.ts
@@ -251,6 +251,30 @@ describe('rebuildIndex', () => {
     await expect(rebuildIndex({ generation: 1 })).rejects.toThrow('single note refused')
     expect(mockInvoke.mock.calls.some(([command]) => command === 'index_meta_set')).toBe(false)
   })
+
+  it('stops before the next SQLite write when suspended after the rebuild wipe', async () => {
+    const controller = new AbortController()
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === 'list_files') {
+        return [{ path: 'notes/a.md', size: 1, modifiedMs: 1 }]
+      }
+      if (command === 'note_read') {
+        // Models iOS becoming hidden while filesystem work is in flight.
+        controller.abort()
+        return '# A\n'
+      }
+      return null
+    })
+
+    await rebuildIndex({ generation: 1, signal: controller.signal })
+
+    const commands = mockInvoke.mock.calls.map(([command]) => command)
+    expect(commands).toContain('index_clear') // began while foregrounded
+    expect(commands).not.toContain('index_apply_batch')
+    // No new projection stamp is written; foreground sync converges either by
+    // rebuilding an old projection or reconciling missing rows for a current one.
+    expect(commands).not.toContain('index_meta_set')
+  })
 })
 
 describe('syncIndex', () => {

--- a/packages/core/src/sync/engine.test.ts
+++ b/packages/core/src/sync/engine.test.ts
@@ -576,6 +576,40 @@ describe('createSyncEngine', () => {
     engine.stop()
   })
 
+  it('stops at the next command boundary when cycles become suppressed', async () => {
+    let canStartCycle = true
+    const fetchGate: { resolve: ((value: unknown) => void) | null } = { resolve: null }
+    const calls = fakeGit((command) => {
+      if (command === 'git_fetch') {
+        return new Promise((resolve) => {
+          fetchGate.resolve = resolve
+        })
+      }
+      return defaultResponses(command)
+    })
+    const statuses: SyncStatus[] = []
+    const engine = createSyncEngine({
+      generation: 1,
+      getToken: async () => 'tok',
+      onStatus: (status) => statuses.push(status),
+      canStartCycle: () => canStartCycle,
+    })
+
+    const syncing = engine.syncNow()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(commandsOf(calls)).toEqual(['git_commit_all', 'git_fetch'])
+
+    canStartCycle = false
+    fetchGate.resolve?.(DELTA)
+    await syncing
+
+    // Fetch began while allowed, but merge/push must not start after the
+    // lifecycle becomes hidden. Suppression is an idle pause, not an error.
+    expect(commandsOf(calls)).toEqual(['git_commit_all', 'git_fetch'])
+    expect(statuses.map((status) => status.state)).toEqual(['syncing', 'idle'])
+    engine.stop()
+  })
+
   it('stop() mid-cycle issues no further commands and emits no further status', async () => {
     const pushGate: { resolve: ((value: unknown) => void) | null } = { resolve: null }
     const calls = fakeGit((command) => {

--- a/packages/core/src/sync/engine.ts
+++ b/packages/core/src/sync/engine.ts
@@ -84,6 +84,14 @@ export interface SyncEngineOptions {
   /** Ceiling on deferral while the user keeps typing. */
   maxWaitMs?: number
   /**
+   * Checked before a new cycle and again after every awaited command boundary.
+   * Returning false at admission drops the trigger without issuing Git work;
+   * returning false mid-cycle lets the already-issued command finish but
+   * suppresses every subsequent command. The lifecycle owner must replay a
+   * full cycle when work is allowed again.
+   */
+  canStartCycle?: () => boolean
+  /**
    * Commit-only mode, for a graph with no remote (local history): every
    * cycle ends after the commit — no credential resolved, no fetch/merge,
    * no push. Edits still land in Git history and stay revertable.
@@ -116,6 +124,9 @@ const MAX_PUSH_ATTEMPTS = 3
 /** A push the remote refused for a non-divergence reason (e.g. push protection). */
 class PushRejectedError extends Error {}
 
+/** Internal control flow: the owner suspended cycles while one command was in flight. */
+class CycleSuppressedError extends Error {}
+
 /**
  * Build a sync engine for one graph session. The engine starts idle and does
  * nothing until `noteChanged()` (debounced commit→push) or `syncNow()` (full
@@ -144,13 +155,17 @@ export function createSyncEngine(options: SyncEngineOptions): SyncEngine {
   }
 
   /**
-   * Await one cycle step, then bail if the engine stopped meanwhile. An
-   * already-issued git command can't be recalled, but nothing further runs
-   * after `stop()`.
+   * Await one cycle step, preserve any result-side notification, then bail if
+   * the engine stopped or the owner suppressed further cycles meanwhile. An
+   * already-issued Git command cannot be recalled, but no later command starts.
    */
-  async function step<T>(promise: Promise<T>): Promise<T> {
+  async function step<T>(promise: Promise<T>, onResult?: (result: T) => void): Promise<T> {
     const result = await promise
     signal.throwIfAborted()
+    onResult?.(result)
+    if (options.canStartCycle?.() === false) {
+      throw new CycleSuppressedError()
+    }
     return result
   }
 
@@ -178,7 +193,7 @@ export function createSyncEngine(options: SyncEngineOptions): SyncEngine {
   }
 
   async function run(mode: 'push' | 'full'): Promise<void> {
-    if (signal.aborted) {
+    if (signal.aborted || options.canStartCycle?.() === false) {
       return
     }
     if (running !== null) {
@@ -201,7 +216,9 @@ export function createSyncEngine(options: SyncEngineOptions): SyncEngine {
         await cycle(mode)
         emit({ state: 'idle' })
       } catch (error) {
-        if (!signal.aborted) {
+        if (error instanceof CycleSuppressedError) {
+          emit({ state: 'idle' })
+        } else if (!signal.aborted) {
           emit(statusForError(error))
         }
       } finally {
@@ -262,11 +279,13 @@ export function createSyncEngine(options: SyncEngineOptions): SyncEngine {
 
   /** Merge the fetched remote and hand any changed files to the reindexer. */
   async function merge(): Promise<{ kind: string }> {
-    const outcome = await step(gitMergeRemote(options.generation)) // upToDate is a no-op
-    if (outcome.changedFiles.length > 0) {
-      options.onRemoteChanges?.(outcome.changedFiles)
-    }
-    return outcome
+    return step(gitMergeRemote(options.generation), (outcome) => {
+      // The command may already have rewritten files before suspension. Fan
+      // those changes out before the boundary gate stops subsequent Git work.
+      if (outcome.changedFiles.length > 0) {
+        options.onRemoteChanges?.(outcome.changedFiles)
+      }
+    }) // upToDate is a no-op
   }
 
   function syncNow(): Promise<void> {


### PR DESCRIPTION
## Problem

TestFlight beta.45 recorded an iOS `0xdead10cc` termination while the app was backgrounded inside `index_apply_batch`. The stack was in SQLite FTS work (`pread` -> FTS5 -> `remove_note`), which means iOS suspended Reflect while it still owned a database/file lock and RunningBoard killed the process.

The web lifecycle previously continued admitting index, Git, and iCloud work as the app became hidden. The existing background flush also had no UIKit finite-length execution assertion, and individual native persistence commands could enter a critical section without protection.

This PR addresses that crash family. It does not attempt to classify the two older metadata-only beta.30 reports, which did not contain crash stacks.

## Before -> After

| Situation | Before | After |
| --- | --- | --- |
| App becomes hidden during indexing | The active pass and queued file changes could continue writing SQLite | The active pass is aborted, live admission stops, and a foreground reconcile restores convergence |
| Git/iCloud work while hidden | New cycles/scans could start and continue across await boundaries | New work is suppressed; an in-flight native command may finish, then the cycle stops and foreground triggers replay it |
| Background persistence flush | Documents, settings, and backup writes were best-effort only | The complete flush is bracketed by a finite UIKit background assertion |
| Native SQLite mutation | A command could acquire a lock without native background time | Every index/chat/embedding write acquires an RAII-scoped assertion before taking the database lock |

## Changes

1. Add native iOS background-task ownership.
   - Introduce `BackgroundTaskState` with isolated frontend and scoped registries so an IPC token cannot end a database command's assertion.
   - Add idempotent, race-safe UIKit begin/end handling for normal completion and expiration.
   - Wrap index open/mutations, chat persistence, and embedding mutations with `ScopedBackgroundTask` before database lock acquisition.
   - Keep non-iOS and browser-preview behavior as explicit no-ops.

2. Protect the app-level background flush.
   - Acquire a background assertion before flushing open documents, settings, and backup state, and release it in `finally`.
   - Coalesce `visibilitychange` and `pagehide` for the same transition while preserving one queued rerun for a distinct later transition.

3. Suspend derived/background work while iOS is hidden.
   - Add `GraphIndex.suspend()` / `resume()` and abort checks throughout rebuild, reconcile, live-batch, move-healing, and touch paths.
   - Clear suspension on every foreground transition, including the launch/onboarding race before an index generation exists; reconciliation starts only when a generation is available.
   - Drop hidden-time file events intentionally, then run a full foreground reconcile so the SQLite projection converges from markdown source-of-truth.
   - Gate mobile Git cycles and iCloud conflict scans while hidden, including checks after awaited native command boundaries.
   - Preserve desktop behavior.

## Tests

- Background assertion registry ownership, activation/expiration races, repeated cleanup, dev-bridge parity, and protected flush ordering/coalescing.
- Index suspension during rebuild/reconcile/live queues, hidden initial-open behavior, foreground-before-open recovery, foreground replay, and stale-generation handling.
- Git cycle admission/mid-cycle suppression and mobile backup/iCloud lifecycle gating.

## Verification

All passed locally:

- `pnpm check`
- `pnpm --filter @reflect/desktop exec vitest run src/lib/background-flush.test.ts src/dev/dev-bridge.test.ts src/lib/backup-controller.test.ts src/lib/icloud-controller.test.ts src/providers/graph-index.test.ts src/providers/graph-provider.test.tsx` (89 tests)
- `pnpm --filter @reflect/core exec vitest run src/indexing/live.test.ts src/indexing/pipeline.test.ts src/sync/engine.test.ts` (68 tests)
- `cargo test -p reflect-open background_task` (4 tests)
- `cargo test -p reflect-open db::tests::stale_generation_writes_are_dropped_end_to_end`
- `cargo check -p reflect-open --target aarch64-apple-ios`
- `pnpm build`
- `cargo fmt --all -- --check`
- `git diff --check`

The desktop sidecars were staged first with `pnpm --filter @reflect/desktop sidecar` as required by the repository workflow.

## Risk / Rollout

- There is no data migration. Interrupted derived-index rebuilds may be partial, but metadata remains intact and the next foreground reconcile/rebuild converges from markdown.
- UIKit background time is finite. If it cannot be granted, the flush remains best-effort; expiration and normal cleanup are idempotent.
- Scoped assertions currently cover synchronous Tauri database commands on iOS's main thread. The code documents that they must not be reused for background-thread work without an expiration cancellation signal.
- Validate in the next TestFlight build by backgrounding during a large index reconcile and confirming there are no new `0xdead10cc` RunningBoard terminations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile/iOS background-task support to keep important background work running more reliably when the app is suspended.
  * Added visibility-aware pause/resume behavior for indexing and sync-related workflows on mobile.

* **Bug Fixes**
  * Reduced duplicate or competing background flushes when the app switches between hidden and visible states.
  * Improved recovery after suspension so pending work resumes cleanly when the app returns to the foreground.
  * Made background save and indexing operations more resilient to interruption and cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->