### PR TITLE
Release v0.4.0-beta.46

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4737,7 +4737,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.4.0-beta.45"
+version = "0.4.0-beta.46"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.4.0-beta.45"
+version = "0.4.0-beta.46"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.4.0-beta.45",
+  "version": "0.4.0-beta.46",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.4.0-beta.46.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version alignment with no logic or dependency changes beyond the lockfile package version field.
> 
> **Overview**
> **Release-only version bump** for the desktop app: `reflect-open` and the bundled **Reflect** product version move from `0.4.0-beta.45` to **`0.4.0-beta.46`**.
> 
> Updates are limited to **`apps/desktop/src-tauri/Cargo.toml`**, **`tauri.conf.json`**, and the corresponding **`reflect-open`** entry in **`Cargo.lock`**. No application code, dependencies, or feature changes are included in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca6668f7259a1df9e5d0091893a870c869dfc576. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the desktop app version to `0.4.0-beta.46` in the app package and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->