### PR TITLE
Release v0.4.0-beta.47

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4737,7 +4737,7 @@ dependencies = [
 
 [[package]]
 name = "reflect-open"
-version = "0.4.0-beta.46"
+version = "0.4.0-beta.47"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect-open"
-version = "0.4.0-beta.46"
+version = "0.4.0-beta.47"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reflect",
-  "version": "0.4.0-beta.46",
+  "version": "0.4.0-beta.47",
   "identifier": "app.reflect.desktop",
   "build": {
     "beforeDevCommand": "pnpm sidecar && pnpm dev",


### PR DESCRIPTION
Bumps Reflect to 0.4.0-beta.47.

The release bump script will merge this PR, pull the merged commit, and push the release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata changes with no runtime, security, or behavioral diffs.
> 
> **Overview**
> **Release bump** for Reflect desktop from `0.4.0-beta.46` to **`0.4.0-beta.47`**.
> 
> The version is updated in `apps/desktop/src-tauri/Cargo.toml`, `tauri.conf.json`, and the workspace `Cargo.lock` entry for `reflect-open`. There are **no application or dependency logic changes** in this PR—only the semver strings used for builds, bundles, and the auto-updater flow described in the release script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7e863b30ccde91abc09e4b5366432cfcce66c9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application to version 0.4.0-beta.47.
  * Included the latest associated platform improvements and compatibility updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->