### PR TITLE
fix(editor): preserve tasks in cross-note drags

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -25,6 +25,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@meowdown/core": "^0.42.0",
     "@meowdown/react": "^0.42.0",
+    "@prosekit/pm": "^0.1.19-beta.2",
     "@reflect/core": "workspace:*",
     "@reflect/db": "workspace:*",
     "@reflect/design-system": "workspace:*",

--- a/apps/desktop/src/editor/block-drag-clipboard.test.tsx
+++ b/apps/desktop/src/editor/block-drag-clipboard.test.tsx
@@ -1,0 +1,140 @@
+import { createElement } from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { docToMarkdown, markdownToDoc } from '@meowdown/core'
+import { DOMParser, Fragment, Slice, type Schema } from '@prosekit/pm/model'
+import { BlockDragClipboard } from './block-drag-clipboard'
+
+interface DraggingStub {
+  readonly slice: Slice
+  readonly move: boolean
+  readonly node: object
+}
+
+const editor = vi.hoisted(() => ({
+  mounted: true,
+  view: {
+    dom: document.createElement('div'),
+    dragging: null as DraggingStub | null,
+    serializeForClipboard: vi.fn(),
+    state: { schema: null as Schema | null },
+  },
+}))
+
+vi.mock('@meowdown/react', () => ({
+  useEditor: () => editor,
+}))
+
+function renderBridge(): void {
+  render(
+    <div className="meowdown">
+      <div
+        ref={(element) => {
+          if (element !== null) {
+            editor.view.dom = element
+          }
+        }}
+      />
+      {createElement('prosekit-block-handle-draggable', {
+        'data-testid': 'block-handle',
+      })}
+      <div draggable data-testid="other-drag-source" />
+      <BlockDragClipboard />
+    </div>,
+  )
+}
+
+function dataTransfer(): DataTransfer {
+  const values = new Map<string, string>()
+  return {
+    clearData: vi.fn((type?: string) => {
+      if (type === undefined) {
+        values.clear()
+      } else {
+        values.delete(type)
+      }
+    }),
+    getData: vi.fn((type: string) => values.get(type) ?? ''),
+    setData: vi.fn((type: string, value: string) => values.set(type, value)),
+  } as unknown as DataTransfer
+}
+
+afterEach(() => {
+  cleanup()
+  editor.mounted = true
+  editor.view.dom = document.createElement('div')
+  editor.view.dragging = null
+  editor.view.state.schema = null
+  vi.clearAllMocks()
+})
+
+describe('BlockDragClipboard', () => {
+  it('serializes a handled round task as lossless ProseMirror clipboard data', () => {
+    const sourceDocument = markdownToDoc('+ [ ] Task')
+    const sourceTask = sourceDocument.firstChild
+    expect(sourceTask).not.toBeNull()
+    const sourceSlice = new Slice(Fragment.from(sourceTask), 0, 0)
+    const serializedSlice = new Slice(sourceSlice.content, 0, 0)
+    const selectedNode = { from: 3, to: 29 }
+    const container = document.createElement('div')
+    container.innerHTML =
+      '<ul data-pm-slice="0 0 []"><li data-list-kind="task"><p>Task</p></li></ul>'
+    editor.view.state.schema = sourceDocument.type.schema
+    editor.view.dragging = { slice: sourceSlice, move: true, node: selectedNode }
+    editor.view.serializeForClipboard.mockReturnValue({
+      dom: container,
+      text: '+ [ ] Task',
+      slice: serializedSlice,
+    })
+    const transfer = dataTransfer()
+
+    renderBridge()
+    fireEvent.dragStart(screen.getByTestId('block-handle'), { dataTransfer: transfer })
+
+    expect(editor.view.serializeForClipboard).toHaveBeenCalledWith(sourceSlice)
+    const html = transfer.getData('text/html')
+    const transferred = document.createElement('div')
+    transferred.innerHTML = html
+    expect(transferred.firstElementChild).toHaveAttribute('data-pm-slice', '0 0 []')
+    expect(transferred.firstElementChild).toHaveAttribute('data-list-kind', 'task')
+    expect(transferred.firstElementChild).toHaveAttribute('data-list-marker', '+')
+    expect(docToMarkdown(DOMParser.fromSchema(sourceDocument.type.schema).parse(transferred))).toBe(
+      '+ [ ] Task\n',
+    )
+    expect(transfer.getData('text/plain')).toBe('+ [ ] Task')
+    expect(editor.view.dragging).toEqual({
+      slice: serializedSlice,
+      move: true,
+      node: selectedNode,
+    })
+  })
+
+  it('does not rewrite unrelated drag payloads', () => {
+    editor.view.dragging = {
+      slice: Slice.empty,
+      move: true,
+      node: { from: 1, to: 2 },
+    }
+
+    renderBridge()
+    fireEvent.dragStart(screen.getByTestId('other-drag-source'), {
+      dataTransfer: dataTransfer(),
+    })
+
+    expect(editor.view.serializeForClipboard).not.toHaveBeenCalled()
+  })
+
+  it('clears the source slice when the handled drag ends', () => {
+    editor.view.dragging = {
+      slice: Slice.empty,
+      move: true,
+      node: { from: 1, to: 2 },
+    }
+
+    renderBridge()
+    fireEvent.dragEnd(screen.getByTestId('block-handle'))
+
+    expect(editor.view.dragging).toBeNull()
+  })
+})

--- a/apps/desktop/src/editor/block-drag-clipboard.test.tsx
+++ b/apps/desktop/src/editor/block-drag-clipboard.test.tsx
@@ -1,5 +1,5 @@
 import { createElement } from 'react'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { docToMarkdown, markdownToDoc } from '@meowdown/core'
@@ -26,8 +26,8 @@ vi.mock('@meowdown/react', () => ({
   useEditor: () => editor,
 }))
 
-function renderBridge(): void {
-  render(
+function renderBridge(): ReturnType<typeof render> {
+  return render(
     <div className="meowdown">
       <div
         ref={(element) => {
@@ -66,6 +66,7 @@ afterEach(() => {
   editor.view.dom = document.createElement('div')
   editor.view.dragging = null
   editor.view.state.schema = null
+  vi.restoreAllMocks()
   vi.clearAllMocks()
 })
 
@@ -111,18 +112,22 @@ describe('BlockDragClipboard', () => {
   })
 
   it('does not rewrite unrelated drag payloads', () => {
-    editor.view.dragging = {
+    const unrelatedDragging = {
       slice: Slice.empty,
       move: true,
       node: { from: 1, to: 2 },
     }
+    editor.view.dragging = unrelatedDragging
 
     renderBridge()
-    fireEvent.dragStart(screen.getByTestId('other-drag-source'), {
+    const otherSource = screen.getByTestId('other-drag-source')
+    fireEvent.dragStart(otherSource, {
       dataTransfer: dataTransfer(),
     })
+    fireEvent.dragEnd(otherSource)
 
     expect(editor.view.serializeForClipboard).not.toHaveBeenCalled()
+    expect(editor.view.dragging).toBe(unrelatedDragging)
   })
 
   it('clears the source slice when the handled drag ends', () => {
@@ -136,5 +141,49 @@ describe('BlockDragClipboard', () => {
     fireEvent.dragEnd(screen.getByTestId('block-handle'))
 
     expect(editor.view.dragging).toBeNull()
+  })
+
+  it('retries a delayed mount and removes its listeners on unmount', () => {
+    const retries: FrameRequestCallback[] = []
+    const requestFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        retries.push(callback)
+        return 1
+      })
+    editor.mounted = false
+
+    const rendered = renderBridge()
+    const handle = screen.getByTestId('block-handle')
+    const wrapper = handle.closest('.meowdown')
+    if (wrapper === null) {
+      throw new Error('Expected the test handle inside a Meowdown wrapper')
+    }
+    expect(requestFrame).toHaveBeenCalledOnce()
+
+    editor.mounted = true
+    const runRetry = retries[0]
+    if (runRetry === undefined) {
+      throw new Error('Expected the bridge to schedule a mount retry')
+    }
+    act(() => runRetry(0))
+    editor.view.dragging = {
+      slice: Slice.empty,
+      move: true,
+      node: { from: 1, to: 2 },
+    }
+    fireEvent.dragEnd(handle)
+    expect(editor.view.dragging).toBeNull()
+
+    const draggingAfterUnmount = {
+      slice: Slice.empty,
+      move: true,
+      node: { from: 2, to: 3 },
+    }
+    rendered.unmount()
+    editor.view.dragging = draggingAfterUnmount
+    wrapper.append(handle)
+    fireEvent.dragEnd(handle)
+    expect(editor.view.dragging).toBe(draggingAfterUnmount)
   })
 })

--- a/apps/desktop/src/editor/block-drag-clipboard.tsx
+++ b/apps/desktop/src/editor/block-drag-clipboard.tsx
@@ -1,0 +1,119 @@
+import { useEffect } from 'react'
+import { useEditor } from '@meowdown/react'
+import { DOMSerializer } from '@prosekit/pm/model'
+
+const BLOCK_HANDLE_SELECTOR = 'prosekit-block-handle-draggable'
+
+function isBlockHandleEvent(event: Event): boolean {
+  return (
+    event.target instanceof Element &&
+    event.target.closest(BLOCK_HANDLE_SELECTOR) !== null
+  )
+}
+
+/**
+ * Give block-handle drags a ProseMirror-native clipboard envelope. ProseKit's
+ * handle only supplies the rendered block HTML; that is enough
+ * inside one editor, where `view.dragging` carries the source slice, but a drop
+ * into another editor parses the HTML as foreign content. In the daily stream
+ * that turned task-list DOM into a literal `\[ ]` paragraph and detached task
+ * text. The serialized payload carries `data-pm-slice`, so another mounted note
+ * can reconstruct the original block without passing it through rich-HTML
+ * conversion. This only makes the transfer lossless; ProseMirror continues to
+ * treat drops between editor views as copies.
+ */
+export function BlockDragClipboard(): null {
+  const editor = useEditor()
+
+  useEffect(() => {
+    let frame: number | null = null
+    let removeListener: (() => void) | null = null
+
+    const attach = (): void => {
+      if (!editor.mounted) {
+        frame = requestAnimationFrame(attach)
+        return
+      }
+
+      frame = null
+      const view = editor.view
+      const wrapper = view.dom.closest('.meowdown')
+      if (wrapper === null) {
+        return
+      }
+
+      const handleDragStart = (event: Event): void => {
+        const dragEvent = event as DragEvent
+        if (dragEvent.dataTransfer === null) {
+          return
+        }
+        if (!isBlockHandleEvent(event)) {
+          return
+        }
+
+        // ProseKit's listener runs on the draggable handle before this bubbling
+        // listener, so it has already selected the block and populated
+        // `view.dragging` with the exact source slice.
+        const dragging = view.dragging
+        if (dragging === null) {
+          return
+        }
+
+        const serialized = view.serializeForClipboard(dragging.slice)
+        const sliceMetadata = serialized.dom
+          .querySelector('[data-pm-slice]')
+          ?.getAttribute('data-pm-slice')
+        if (sliceMetadata === null || sliceMetadata === undefined) {
+          return
+        }
+
+        // The flat-list clipboard serializer normalizes list markers, which
+        // would turn Reflect's round `+ [ ]` task into a plain `- [ ]`
+        // checklist. Serialize through the full Meowdown schema to retain its
+        // marker attributes, then reuse ProseMirror's own slice metadata.
+        const container = view.dom.ownerDocument.createElement('div')
+        container.append(
+          DOMSerializer.fromSchema(view.state.schema).serializeFragment(
+            serialized.slice.content,
+            { document: view.dom.ownerDocument },
+          ),
+        )
+        const firstElement = container.firstElementChild
+        if (firstElement === null) {
+          return
+        }
+        firstElement.setAttribute('data-pm-slice', sliceMetadata)
+
+        dragEvent.dataTransfer.setData('text/html', container.innerHTML)
+        dragEvent.dataTransfer.setData('text/plain', serialized.text)
+        view.dragging = { ...dragging, slice: serialized.slice }
+      }
+
+      const handleDragEnd = (event: Event): void => {
+        if (isBlockHandleEvent(event)) {
+          // The handle lives outside `view.dom`, so ProseMirror's own dragend
+          // handler never clears this source-view state after a cross-editor
+          // drop or a canceled drag.
+          view.dragging = null
+        }
+      }
+
+      wrapper.addEventListener('dragstart', handleDragStart)
+      wrapper.addEventListener('dragend', handleDragEnd)
+      removeListener = () => {
+        wrapper.removeEventListener('dragstart', handleDragStart)
+        wrapper.removeEventListener('dragend', handleDragEnd)
+      }
+    }
+
+    attach()
+    return () => {
+      if (frame !== null) {
+        cancelAnimationFrame(frame)
+      }
+      removeListener?.()
+    }
+  }, [editor])
+
+  return null
+}

--- a/apps/desktop/src/editor/block-drag-clipboard.tsx
+++ b/apps/desktop/src/editor/block-drag-clipboard.tsx
@@ -11,6 +11,10 @@ function isBlockHandleEvent(event: Event): boolean {
   )
 }
 
+function isDragEvent(event: Event): event is DragEvent {
+  return 'dataTransfer' in event
+}
+
 /**
  * Give block-handle drags a ProseMirror-native clipboard envelope. ProseKit's
  * handle only supplies the rendered block HTML; that is enough
@@ -43,10 +47,10 @@ export function BlockDragClipboard(): null {
       }
 
       const handleDragStart = (event: Event): void => {
-        const dragEvent = event as DragEvent
-        if (dragEvent.dataTransfer === null) {
+        if (!isDragEvent(event) || event.dataTransfer === null) {
           return
         }
+        const dataTransfer = event.dataTransfer
         if (!isBlockHandleEvent(event)) {
           return
         }
@@ -84,8 +88,8 @@ export function BlockDragClipboard(): null {
         }
         firstElement.setAttribute('data-pm-slice', sliceMetadata)
 
-        dragEvent.dataTransfer.setData('text/html', container.innerHTML)
-        dragEvent.dataTransfer.setData('text/plain', serialized.text)
+        dataTransfer.setData('text/html', container.innerHTML)
+        dataTransfer.setData('text/plain', serialized.text)
         view.dragging = { ...dragging, slice: serialized.slice }
       }
 

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -28,6 +28,7 @@ import {
   type WikilinkSearchHandler,
 } from '@meowdown/react'
 import { EditorInputTraits } from '@/editor/editor-input-traits'
+import { BlockDragClipboard } from '@/editor/block-drag-clipboard'
 import { FormattingToolbarBridge } from '@/editor/formatting-toolbar-bridge'
 import {
   IMAGE_LIGHTBOX_TRANSITION_NAME,
@@ -425,6 +426,7 @@ export function NoteEditor({
         onExitBoundary={handleExitBoundary}
       >
         <EditorInputTraits />
+        <BlockDragClipboard />
         <FormattingToolbarBridge />
         {children}
       </MeowdownEditor>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@meowdown/react':
         specifier: ^0.42.0
         version: 0.42.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.0)(react-dom@19.2.7)(react@19.2.7)
+      '@prosekit/pm':
+        specifier: ^0.1.19-beta.2
+        version: 0.1.19-beta.2
       '@reflect/core':
         specifier: workspace:*
         version: link:../../packages/core


### PR DESCRIPTION
## Problem

Each day in the daily stream owns a separate Meowdown/ProseMirror editor. ProseKit's six-dot block handle exports rendered block HTML, but not the `data-pm-slice` envelope that a different editor needs to recognize it as native content. Dropping a round task such as `+ [ ] Task` onto another day therefore ran the task DOM through Meowdown's foreign-HTML converter and produced a literal `\[ ]` paragraph followed by detached task text. The saved note no longer contained or indexed a task.

This change preserves the existing drag semantics: reordering inside one editor is still a move, while a drop between editor views is still a copy. It fixes the reported content corruption without adding cross-note source deletion.

## Before -> After

| Flow | Before | After |
| --- | --- | --- |
| Drag a round task to another daily note | Checkbox becomes `\[ ]`; task text becomes a separate paragraph | Exact task structure and `+` marker survive |
| Drag a block within one note | Reorders through ProseMirror's source slice | Unchanged |
| Drag files or other non-handle content | Existing handlers own the event | Unchanged |

## Changes

1. Add `BlockDragClipboard` inside the editor's ProseKit context. Its bubbling `dragstart` listener runs after ProseKit has selected the block, reuses ProseMirror's transformed slice metadata, and writes lossless HTML plus Markdown `text/plain` to the transfer.
2. Serialize the slice through the full Meowdown schema instead of the flat-list clipboard serializer. This retains Reflect-specific list attributes such as the round `+` marker; the normal native-list serializer would normalize it to a square `- [ ]` checklist.
3. Clear the source view's stale drag slice on `dragend`. The handle lives outside the contenteditable, so ProseMirror's own cleanup does not see cross-editor or canceled handle drags.
4. Add focused coverage using the real Meowdown schema. The tests reparse the transferred HTML, prove that `+ [ ] Task` survives exactly, isolate unrelated drags, and cover delayed mount plus listener cleanup.

## Verification

- `pnpm --filter @reflect/desktop test --run src/editor/block-drag-clipboard.test.tsx src/editor/note-editor.test.tsx` — 38 tests passed.
- `pnpm check` — typecheck and lint passed. The existing max-lines warnings in `graph-provider.tsx` and `indexer.ts` remain unchanged.

## Risk / Rollout

No migration or rollout step is required. The listener is scoped to ProseKit's block-handle custom element, and the regression covers the main isolation boundary. Cross-editor drops intentionally remain copies; implementing true cross-note moves would require destination acknowledgement before safely deleting the source.
