### PR TITLE
docs: reference meowdown repo for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,16 @@ reflect-open/
 └── turbo.json, pnpm-workspace.yaml
 ```
 
+### Related repos
+
+- **Meowdown:** the local checkout lives at `~/repos/meowdown`. Meowdown is the
+  first-party hybrid/live-preview Markdown editor that Reflect uses through
+  `@meowdown/core` and `@meowdown/react`. When investigating editor behavior,
+  markdown round-tripping, keybindings, slash menus, wiki links, task checkboxes,
+  paste/drop handling, or mobile editor quirks, check that repo as well as this
+  one. If the root cause is in Meowdown, fix it there and open the PR against the
+  Meowdown project rather than papering over it in Reflect.
+
 **Design system**
 
 All UI work should follow the Reflect design system documented in [`design-system/readme.md`](design-system/readme.md). Key resources:


### PR DESCRIPTION
## Summary
- Add a Related repos note to AGENTS.md pointing agents to `~/repos/meowdown`
- Explain that Meowdown is Reflect’s first-party live-preview Markdown editor dependency
- Clarify that editor-rooted bugs may need investigation or fixes in Meowdown instead of Reflect

## Verification
- Reviewed AGENTS.md diff; documentation-only change, no tests run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `AGENTS.md` with no runtime, API, or security impact.
> 
> **Overview**
> Adds a **Related repos** subsection to `AGENTS.md` so agents know where Reflect’s Markdown editor lives outside this monorepo.
> 
> It documents the local Meowdown checkout at `~/repos/meowdown`, ties it to `@meowdown/core` and `@meowdown/react`, and lists editor-focused areas (round-tripping, keybindings, slash menu, wiki links, tasks, paste/drop, mobile) that may need fixes in Meowdown rather than workarounds in Reflect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 928e68c982d6b13421ac67a23451a773c3920fbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for handling editor-related issues, including markdown round-tripping, keybindings, and mobile editor behavior.
  * Clarified when to consult the related Meowdown editor project for fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->