### PR TITLE
fix: link conflict warnings to affected notes

### DIFF
--- a/apps/desktop/src/components/settings/backup-section.tsx
+++ b/apps/desktop/src/components/settings/backup-section.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 import { getConflictedNotes, getDuplicateNoteIds, hasBridge } from '@reflect/core'
 import { ExternalLink } from 'lucide-react'
 import { ConnectGithubDialog } from '@/components/settings/connect-github-dialog'
+import { ConflictedNoteLinks } from '@/components/settings/conflicted-note-links'
 import { SettingsField } from '@/components/settings/field'
 import { SyncForkNotice } from '@/components/settings/sync-fork-notice'
 import { Button } from '@/components/ui/button'
@@ -65,7 +66,8 @@ export function BackupSettingsField(): ReactElement {
     queryFn: () => getConflictedNotes(),
     enabled: hasBridge() && graph !== null,
   })
-  const conflictCount = conflicted.data?.length ?? 0
+  const conflictedNotes = conflicted.data ?? []
+  const conflictCount = conflictedNotes.length
 
   // A sync fork (Plan 17): two files claiming one frontmatter id — the same
   // note retitled differently on two devices. Surfaced for review beside the
@@ -149,12 +151,15 @@ export function BackupSettingsField(): ReactElement {
                 <span className="ml-2 text-xs text-text-muted">{statusLine(backup)}</span>
               </p>
               {conflictCount > 0 ? (
-                <p className="text-xs text-amber-700 dark:text-amber-300">
-                  {conflictCount === 1
-                    ? '1 note needs review'
-                    : `${conflictCount} notes need review`}{' '}
-                  — open it to keep the version you want.
-                </p>
+                <div className="text-xs text-amber-700 dark:text-amber-300">
+                  <p>
+                    {conflictCount === 1
+                      ? '1 note needs review'
+                      : `${conflictCount} notes need review`}{' '}
+                    — open {conflictCount === 1 ? 'it' : 'one'} to keep the version you want:
+                  </p>
+                  <ConflictedNoteLinks notes={conflictedNotes} />
+                </div>
               ) : null}
               <SyncForkNotice groups={forkGroups} />
               <div className="flex flex-wrap gap-2">

--- a/apps/desktop/src/components/settings/conflicted-note-links.tsx
+++ b/apps/desktop/src/components/settings/conflicted-note-links.tsx
@@ -1,0 +1,53 @@
+import type { ReactElement } from 'react'
+import type { ConflictedNote } from '@reflect/core'
+import { ChevronRight } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useRouter } from '@/routing/router'
+
+interface ConflictedNoteLinksProps {
+  readonly notes: readonly ConflictedNote[]
+}
+
+interface ConflictedNoteLinkProps {
+  readonly note: ConflictedNote
+}
+
+function ConflictedNoteLink({ note }: ConflictedNoteLinkProps): ReactElement {
+  const { navigate } = useRouter()
+
+  return (
+    <li>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-auto w-full max-w-sm justify-start whitespace-normal px-2 py-1 text-left text-xs text-current hover:bg-amber-500/10 hover:text-current"
+        onClick={() => navigate({ kind: 'note', path: note.path })}
+      >
+        <span className="min-w-0 flex-1">
+          <span className="block truncate font-medium">{note.title}</span>
+          <span className="block truncate text-[11px] opacity-75">{note.path}</span>
+        </span>
+        <ChevronRight
+          aria-hidden
+          className="size-3.5 shrink-0 opacity-60"
+          strokeWidth={1.75}
+        />
+      </Button>
+    </li>
+  )
+}
+
+/** Links from a sync warning directly to every note carrying conflict markers. */
+export function ConflictedNoteLinks({ notes }: ConflictedNoteLinksProps): ReactElement | null {
+  if (notes.length === 0) {
+    return null
+  }
+
+  return (
+    <ul className="mt-1 flex flex-col gap-0.5" aria-label="Notes that need review">
+      {notes.map((note) => (
+        <ConflictedNoteLink key={note.path} note={note} />
+      ))}
+    </ul>
+  )
+}

--- a/apps/desktop/src/components/settings/icloud-section.tsx
+++ b/apps/desktop/src/components/settings/icloud-section.tsx
@@ -9,6 +9,7 @@ import {
   icloudPendingCount,
   icloudStatus,
 } from '@reflect/core'
+import { ConflictedNoteLinks } from '@/components/settings/conflicted-note-links'
 import { SettingsField } from '@/components/settings/field'
 import { Button } from '@/components/ui/button'
 import {
@@ -176,9 +177,10 @@ export function IcloudSettingsField(): ReactElement | null {
             {pendingNotes.isPending ? <p>Checking downloaded notes...</p> : null}
             {pendingNotes.data !== undefined ? <p>{pendingNotesLine(pendingNotes.data)}</p> : null}
             {conflictCount !== undefined && forkCount !== undefined ? (
-              <p className={hasReviewIssues ? 'text-amber-700 dark:text-amber-300' : undefined}>
-                {reviewLine(conflictCount, forkCount)}
-              </p>
+              <div className={hasReviewIssues ? 'text-amber-700 dark:text-amber-300' : undefined}>
+                <p>{reviewLine(conflictCount, forkCount)}</p>
+                <ConflictedNoteLinks notes={conflicted.data ?? []} />
+              </div>
             ) : null}
           </div>
         ) : status?.available === true ? (

--- a/apps/desktop/src/components/settings/sync-section.test.tsx
+++ b/apps/desktop/src/components/settings/sync-section.test.tsx
@@ -1,8 +1,10 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, render, screen, within } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import type { ReactElement } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { GraphInfo } from '@reflect/core'
 import type { BackupState } from '@/lib/backup-controller'
+import { RouterProvider, useRouter } from '@/routing/router'
 import { SyncSection } from './sync-section'
 
 const core = vi.hoisted(() => ({
@@ -51,9 +53,17 @@ vi.mock('@/providers/sync-provider', () => ({ useSync: () => sync }))
 function renderSection(): void {
   render(
     <QueryClientProvider client={new QueryClient()}>
-      <SyncSection />
+      <RouterProvider initialRoute={{ kind: 'settings' }}>
+        <SyncSection />
+        <RouteProbe />
+      </RouterProvider>
     </QueryClientProvider>,
   )
+}
+
+function RouteProbe(): ReactElement {
+  const { route } = useRouter()
+  return <output data-testid="route">{route.kind === 'note' ? route.path : route.kind}</output>
 }
 
 beforeEach(() => {
@@ -124,6 +134,28 @@ describe('SyncSection', () => {
       await within(section).findByText('2 notes are still downloading from iCloud.'),
     ).toBeTruthy()
     expect(within(section).getByText('1 note needs review, 1 sync fork')).toBeTruthy()
+    expect(within(section).getByRole('button', { name: /A.*notes\/a\.md/ })).toBeTruthy()
+  })
+
+  it('opens the conflicted note listed under GitHub backup', async () => {
+    core.conflictedNotes = [{ path: 'notes/conflicted.md', title: 'Conflicted note' }]
+    sync.backup = {
+      phase: 'connected',
+      remoteUrl: 'https://github.com/alex/notes.git',
+      repo: { owner: 'alex', name: 'notes' },
+      status: { state: 'idle' },
+    }
+
+    renderSection()
+
+    const section = screen.getByRole('region', { name: 'Sync' })
+    const noteLink = await within(section).findByRole('button', {
+      name: /Conflicted note.*notes\/conflicted\.md/,
+    })
+
+    fireEvent.click(noteLink)
+
+    expect(screen.getByTestId('route').textContent).toBe('notes/conflicted.md')
   })
 
   it('keeps backup visible when the iCloud row is platform-hidden', () => {


### PR DESCRIPTION
## Problem

Sync settings report how many notes need conflict review, but discard the title and path data already returned by the index. The warning tells people to open the affected note without giving them a way to identify or navigate to it.

## Before → After

| Before | After |
| --- | --- |
| Settings shows only a conflict count and generic instruction. | Each warning lists the affected note titles and graph-relative paths. |
| People must search or inspect notes until they find the conflict. | Clicking a listed note opens it directly in the existing conflict-resolution view. |

## Changes

1. Add `ConflictedNoteLinks`, a keyboard-accessible settings list that routes each conflicted note through the app router.
2. Show the links under both Git backup and iCloud conflict summaries.
3. Extend Sync settings coverage to verify the iCloud list and direct navigation from the Git backup warning.

## Tests

- Conflicted iCloud notes render with their title and path.
- Clicking a conflicted note under Git backup navigates to its note route.
- Existing backup settings behavior remains covered.

## Verification

- `pnpm --filter @reflect/desktop test --run src/components/settings/sync-section.test.tsx src/components/settings/backup-section.test.tsx` — 14 tests passed.
- `pnpm check` — typecheck and lint passed (with the repository's existing max-lines warnings in `graph-provider.tsx` and `indexer.ts`).

## Risk / Rollout

Low-risk UI-only change. It uses conflict metadata already loaded by Settings and the existing note router; there are no schema, sync-engine, or data migration changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only reuse of existing `getConflictedNotes` data and in-app routing; no sync, schema, or persistence changes.
> 
> **Overview**
> Sync settings still show conflict counts, but **GitHub backup** and **iCloud** review warnings now list each conflicted note’s title and path and let you open it in one click.
> 
> A new **`ConflictedNoteLinks`** component renders an accessible list of ghost buttons that call `navigate({ kind: 'note', path })` via the app router. **Backup** keeps the existing count copy and appends the list under the amber warning; **iCloud** renders the same list under `reviewLine` whenever conflict metadata is loaded.
> 
> **`sync-section.test.tsx`** wraps the section in **`RouterProvider`**, asserts the iCloud conflict row shows title/path, and checks that clicking a conflict under connected GitHub backup updates the route to that note path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e27fd24051ba8b243f6bc75146cb9fb050f17b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->