### PR TITLE
fix: show the installed app version in About

### DIFF
--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -492,14 +492,17 @@ fn classify_fetch_error(err: reqwest::Error) -> AppError {
 /// can reach arbitrary hosts is this bounded, HTML-only primitive, and the
 /// privacy gate in `@reflect/core` runs before it is ever called.
 #[tauri::command]
-pub async fn capture_meta_fetch(url: String) -> AppResult<String> {
+pub async fn capture_meta_fetch<R: tauri::Runtime>(
+    url: String,
+    app: tauri::AppHandle<R>,
+) -> AppResult<String> {
     if !url.starts_with("https://") && !url.starts_with("http://") {
         return Err(AppError::parse(format!("not an http(s) url: {url}")));
     }
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::limited(5))
         .timeout(META_FETCH_TIMEOUT)
-        .user_agent(concat!("Reflect/", env!("CARGO_PKG_VERSION")))
+        .user_agent(crate::app_user_agent(&app))
         .build()
         .map_err(|err| AppError::io(err.to_string()))?;
     let response = client

--- a/apps/desktop/src-tauri/src/fs/import.rs
+++ b/apps/desktop/src-tauri/src/fs/import.rs
@@ -154,16 +154,19 @@ impl PreparedImport {
     /// Download every remote attachment into the graph's staging directory.
     /// Transient failures abort (nothing has been written to the graph yet);
     /// permanent 4xx failures come back as [`DownloadOutcome::Gone`].
+    /// `user_agent` identifies the configured application version.
     /// `cancelled` stops the workers between fetches; `on_progress` receives
     /// `(completed, total)` after each download settles.
     pub async fn download_assets(
         &self,
+        user_agent: &str,
         cancelled: Arc<AtomicBool>,
         on_progress: Arc<dyn Fn(usize, usize) + Send + Sync>,
     ) -> AppResult<HashMap<String, DownloadOutcome>> {
         import_assets::download_remote_assets(
             &self.staging,
             self.urls.clone(),
+            user_agent,
             cancelled,
             on_progress,
         )
@@ -1501,8 +1504,11 @@ mod tests {
         prefix: &str,
     ) -> AppResult<ImportSummary> {
         let prepared = prepare_zip_import_from(root, zip_path, &[prefix])?;
-        let downloads =
-            tauri::async_runtime::block_on(prepared.download_assets(no_cancel(), no_progress()))?;
+        let downloads = tauri::async_runtime::block_on(prepared.download_assets(
+            "Reflect/test",
+            no_cancel(),
+            no_progress(),
+        ))?;
         finalize_import(root, prepared, downloads, |_, _| {})
     }
 
@@ -1585,9 +1591,12 @@ mod tests {
         let Some(before) = open_fd_count() else {
             return;
         };
-        let downloads =
-            tauri::async_runtime::block_on(prepared.download_assets(no_cancel(), no_progress()))
-                .unwrap();
+        let downloads = tauri::async_runtime::block_on(prepared.download_assets(
+            "Reflect/test",
+            no_cancel(),
+            no_progress(),
+        ))
+        .unwrap();
         let Some(after) = open_fd_count() else {
             return;
         };
@@ -1695,6 +1704,7 @@ mod tests {
         let record = Arc::clone(&seen);
 
         tauri::async_runtime::block_on(prepared.download_assets(
+            "Reflect/test",
             no_cancel(),
             Arc::new(move |done, total| record.lock().unwrap().push((done, total))),
         ))
@@ -1718,8 +1728,11 @@ mod tests {
         let prepared = prepare_zip_import_from(root.path(), &zip_path, &[&base]).unwrap();
         let cancelled = Arc::new(AtomicBool::new(true));
 
-        let result =
-            tauri::async_runtime::block_on(prepared.download_assets(cancelled, no_progress()));
+        let result = tauri::async_runtime::block_on(prepared.download_assets(
+            "Reflect/test",
+            cancelled,
+            no_progress(),
+        ));
 
         match result.err() {
             Some(AppError::Io { message }) => assert!(message.contains("cancelled")),

--- a/apps/desktop/src-tauri/src/fs/import_assets.rs
+++ b/apps/desktop/src-tauri/src/fs/import_assets.rs
@@ -174,6 +174,7 @@ pub(super) fn rewrite_asset_paths(
 pub(super) async fn download_remote_assets(
     staging: &Path,
     urls: Vec<String>,
+    user_agent: &str,
     cancelled: Arc<AtomicBool>,
     on_progress: Arc<dyn Fn(usize, usize) + Send + Sync>,
 ) -> AppResult<HashMap<String, DownloadOutcome>> {
@@ -185,7 +186,7 @@ pub(super) async fn download_remote_assets(
         .redirect(reqwest::redirect::Policy::limited(5))
         .connect_timeout(CONNECT_TIMEOUT)
         .read_timeout(READ_TIMEOUT)
-        .user_agent(concat!("Reflect/", env!("CARGO_PKG_VERSION")))
+        .user_agent(user_agent)
         .build()
         .map_err(|err| AppError::io(err.to_string()))?;
 

--- a/apps/desktop/src-tauri/src/fs/mod.rs
+++ b/apps/desktop/src-tauri/src/fs/mod.rs
@@ -243,8 +243,10 @@ pub async fn graph_import_reflect_v1_zip(
         emit_import_progress(&app, "downloading", 0, prepared.remote_asset_count());
     }
     let download_app = app.clone();
+    let user_agent = crate::app_user_agent(&app);
     let downloads = prepared
         .download_assets(
+            &user_agent,
             cancel.flag(),
             std::sync::Arc::new(move |done, total| {
                 emit_import_progress(&download_app, "downloading", done, total);

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -53,13 +53,35 @@ mod spike_mobile;
 
 use tauri::{Emitter, Manager};
 
-/// Returns the desktop application version from Cargo metadata.
+/// Returns the application version from Tauri's resolved package metadata.
 ///
 /// The canonical round-trip example for the IPC boundary: the frontend reaches
 /// it only through `@reflect/core`'s typed, zod-validated `getAppVersion`.
 #[tauri::command]
-fn app_version() -> String {
-    env!("CARGO_PKG_VERSION").to_string()
+fn app_version<R: tauri::Runtime>(app: tauri::AppHandle<R>) -> String {
+    app.package_info().version.to_string()
+}
+
+/// Builds the HTTP User-Agent from the same resolved version shown in the UI.
+pub(crate) fn app_user_agent<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> String {
+    format!("Reflect/{}", app.package_info().version)
+}
+
+#[cfg(test)]
+mod app_metadata_tests {
+    use super::{app_user_agent, app_version};
+
+    #[test]
+    fn app_metadata_uses_tauri_package_info() {
+        let mut context = tauri::test::mock_context(tauri::test::noop_assets());
+        context.package_info_mut().version = "7.8.9-beta.4".parse().expect("valid version");
+        let app = tauri::test::mock_builder()
+            .build(context)
+            .expect("mock app");
+
+        assert_eq!(app_version(app.handle().clone()), "7.8.9-beta.4");
+        assert_eq!(app_user_agent(app.handle()), "Reflect/7.8.9-beta.4");
+    }
 }
 
 /// Which UI family this build serves. The frontend's root gate (Plan 19)


### PR DESCRIPTION
## Problem

The release-please migration made `apps/desktop/package.json` the canonical app version and intentionally froze the private Rust crate at `0.0.0`. The updater already reads Tauri's resolved package metadata, but Reflect's custom `app_version` command still returned `CARGO_PKG_VERSION`.

As a result, released builds could correctly report that they were up to date while About and mobile settings displayed `v0.0.0`. The same stale Cargo value also appeared in the User-Agent for capture metadata fetches and Reflect V1 asset downloads.

## Before -> After

| Surface | Before | After |
| --- | --- | --- |
| About / mobile settings | Frozen Rust crate version (`0.0.0`) | Tauri package version resolved from `apps/desktop/package.json` |
| Capture and import User-Agent | `Reflect/0.0.0` | `Reflect/<installed app version>` |

## Changes

1. Read the UI version from `AppHandle::package_info()` so it matches the updater and packaged app metadata.
2. Build outbound Reflect User-Agents from that same resolved package version and pass it into the capture/import HTTP clients.
3. Add a mock-Tauri regression test using a prerelease version, which prevents a return to Cargo metadata without coupling the test to the current release number.

## Tests

- The app metadata test verifies both the UI version and User-Agent preserve a configured prerelease version.
- All 16 capture tests pass.
- All 30 Reflect V1 import tests pass.

## Verification

- `pnpm --filter @reflect/desktop sidecar`
- `cargo fmt --all -- --check`
- `cargo test -p reflect-open app_metadata_uses_tauri_package_info`
- `cargo test -p reflect-open capture::tests`
- `cargo test -p reflect-open fs::import::tests`
- `pnpm check`
- `pnpm build`

All commands passed. The production build emitted only the existing Sentry-auth and chunk-size warnings; lint emitted only the existing max-file-length warnings.

## Risk / Rollout

No migrations or persisted data changes. The corrected value will appear once users install a build containing this fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and HTTP client metadata only; no auth, persistence, or graph write semantics change beyond using the correct version string.
> 
> **Overview**
> Released builds could show **v0.0.0** in About/mobile settings and send **`Reflect/0.0.0`** on outbound HTTP because `app_version` and several clients still read the frozen Rust crate version (`CARGO_PKG_VERSION`) instead of the packaged app version from `apps/desktop/package.json`.
> 
> **`app_version`** now takes `AppHandle` and returns `app.package_info().version`, aligned with the updater. A shared **`app_user_agent`** helper formats `Reflect/<that version>` for **`capture_meta_fetch`** and the V1 import download path (`graph_import_reflect_v1_zip` → `download_remote_assets`). Import tests pass a fixed `"Reflect/test"` user agent.
> 
> A mock-Tauri test pins a prerelease version and asserts both the IPC version string and User-Agent, so regressions back to Cargo metadata are caught without tying tests to the current release number.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99d48d499611a6738396a38efac1814ba35e537b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->