### PR TITLE
fix(desktop): recover invisible main window

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -95,10 +95,7 @@ pub fn run() {
     // the running app natively; this is the Windows/Linux equivalent.
     #[cfg(desktop)]
     let builder = builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
-        if let Some(window) = app.get_webview_window(windows::MAIN_WINDOW_LABEL) {
-            let _ = window.show();
-            let _ = window.set_focus();
-        }
+        windows::surface_main_window(app);
     }));
 
     let builder = builder
@@ -131,8 +128,10 @@ pub fn run() {
     // Window-state restore is likewise meaningless on mobile (one fullscreen
     // webview, no window frames to remember). The main window starts hidden
     // (`visible: false` in tauri.conf.json) so this plugin can restore its
-    // geometry before first paint — avoiding a visible jump — and then reveal
-    // it; mobile shows the window itself in the setup hook below.
+    // geometry before first paint — avoiding a visible jump. Visibility is
+    // deliberately not persistent: shutdown and updater relaunches can observe
+    // a transiently hidden window, which must not suppress every later launch.
+    // The Ready event reveals the restored window below.
     #[cfg(desktop)]
     let builder = builder
         .plugin(tauri_plugin_updater::Builder::new().build())
@@ -142,6 +141,7 @@ pub fn run() {
             // fresh from their opener, and their content-hashed labels would
             // otherwise accrete in the state file forever.
             tauri_plugin_window_state::Builder::default()
+                .with_state_flags(windows::restorable_window_state_flags())
                 .with_filter(|label| !label.starts_with(windows::NOTE_WINDOW_PREFIX))
                 .build(),
         );
@@ -160,9 +160,9 @@ pub fn run() {
     #[cfg(mobile)]
     let builder = builder.plugin(tauri_plugin_recording::init());
 
-    // The main window starts hidden (`visible: false`); on desktop the
-    // window-state plugin reveals it after restoring geometry, but mobile has
-    // no such plugin, so show it here or the UI would never appear.
+    // The main window starts hidden (`visible: false`); desktop reveals it on
+    // Ready after restoring geometry, but mobile has no window-state plugin,
+    // so show it here or the UI would never appear.
     //
     // (Also runs the TEMPORARY Plan 19 spike-A capability probe — delete that
     // line with the spike, but keep the window show.)
@@ -292,6 +292,30 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(|app, event| match &event {
+            // Config windows are built before Ready, including the synchronous
+            // window-state restore. Reveal the main window only after that
+            // geometry is settled, regardless of any stale persisted
+            // visibility from an older build.
+            #[cfg(desktop)]
+            tauri::RunEvent::Ready => {
+                windows::surface_main_window(app);
+            }
+            // Clicking the Dock icon is macOS's recovery path when an app has
+            // no visible windows. Surface a hidden/minimized main window, or
+            // recreate it if the user previously closed it with ⌘W.
+            #[cfg(target_os = "macos")]
+            tauri::RunEvent::Reopen {
+                has_visible_windows,
+                ..
+            } => {
+                if !*has_visible_windows
+                    || app
+                        .get_webview_window(windows::MAIN_WINDOW_LABEL)
+                        .is_none()
+                {
+                    windows::reopen_main_window(app);
+                }
+            }
             // The lock-screen widget opens `reflect://record-audio`; hand it
             // to the recording plugin's persisted action queue (the V1
             // handshake) so the request survives webview churn and cold

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -38,6 +38,77 @@ pub const NOTE_WINDOW_PREFIX: &str = "note-";
 /// re-navigates it to the clicked target.
 const WINDOW_NAVIGATE_EVENT: &str = "window:navigate";
 
+/// Window properties that survive a desktop restart.
+///
+/// Visibility is intentionally absent. The main window starts hidden while
+/// geometry restores, and shutdown or updater relaunches can otherwise persist
+/// that temporary state and leave every subsequent launch hidden.
+#[cfg(desktop)]
+pub(crate) fn restorable_window_state_flags() -> tauri_plugin_window_state::StateFlags {
+    use tauri_plugin_window_state::StateFlags;
+
+    StateFlags::SIZE
+        | StateFlags::POSITION
+        | StateFlags::MAXIMIZED
+        | StateFlags::DECORATIONS
+        | StateFlags::FULLSCREEN
+}
+
+#[cfg(desktop)]
+fn surface_window<R: tauri::Runtime>(window: &tauri::WebviewWindow<R>) {
+    if let Err(err) = window.unminimize() {
+        tracing::warn!(error = %err, label = window.label(), "failed to unminimize window");
+    }
+    if let Err(err) = window.show() {
+        tracing::warn!(error = %err, label = window.label(), "failed to show window");
+    }
+    if let Err(err) = window.set_focus() {
+        tracing::warn!(error = %err, label = window.label(), "failed to focus window");
+    }
+}
+
+/// Show, unminimize, and focus the existing main window.
+///
+/// Returns whether the window exists, so macOS Dock reopen handling can create
+/// a replacement after the user has closed the original window.
+#[cfg(desktop)]
+pub(crate) fn surface_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool {
+    let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) else {
+        return false;
+    };
+    surface_window(&window);
+    true
+}
+
+/// Recover the main window when macOS asks an app with no visible windows to
+/// reopen (normally a Dock click).
+#[cfg(target_os = "macos")]
+pub(crate) fn reopen_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    if app.state::<QuitState>().armed() {
+        return;
+    }
+    if surface_main_window(app) {
+        return;
+    }
+
+    let Some(config) = app
+        .config()
+        .app
+        .windows
+        .iter()
+        .find(|config| config.label == MAIN_WINDOW_LABEL)
+        .cloned()
+    else {
+        tracing::warn!("cannot reopen main window because its config is missing");
+        return;
+    };
+
+    match WebviewWindowBuilder::from_config(app, &config).and_then(|builder| builder.build()) {
+        Ok(window) => surface_window(&window),
+        Err(err) => tracing::warn!(error = %err, "failed to recreate main window"),
+    }
+}
+
 fn lock_init<'a>(
     state: &'a State<'_, WindowInit>,
 ) -> AppResult<MutexGuard<'a, HashMap<String, String>>> {
@@ -226,6 +297,39 @@ pub fn window_bootstrap(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(desktop)]
+    #[test]
+    fn restart_state_restores_geometry_but_never_visibility() {
+        use tauri_plugin_window_state::StateFlags;
+
+        let flags = restorable_window_state_flags();
+        for geometry_flag in [
+            StateFlags::SIZE,
+            StateFlags::POSITION,
+            StateFlags::MAXIMIZED,
+            StateFlags::DECORATIONS,
+            StateFlags::FULLSCREEN,
+        ] {
+            assert!(flags.contains(geometry_flag));
+        }
+        assert!(!flags.contains(StateFlags::VISIBLE));
+    }
+
+    #[cfg(desktop)]
+    #[test]
+    fn surfacing_main_window_distinguishes_missing_and_existing_windows() {
+        let app = tauri::test::mock_builder()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("mock app");
+        assert!(!surface_main_window(app.handle()));
+
+        let _main = WebviewWindowBuilder::new(&app, MAIN_WINDOW_LABEL, WebviewUrl::default())
+            .visible(false)
+            .build()
+            .expect("main window");
+        assert!(surface_main_window(app.handle()));
+    }
 
     #[test]
     fn labels_are_stable_per_target_and_distinct_across_targets() {


### PR DESCRIPTION
## Problem

Reflect creates the desktop main window hidden so saved geometry can restore before first paint. The window-state plugin also persisted `VISIBLE`, so a stale `visible: false` value or a restore failure could leave every later launch hidden: the process and menu bar remained active, but no window appeared. Replacing the app bundle could not repair state stored under Application Support.

macOS had a second recovery gap: after the main window was destroyed with the red close button or Command-W, Dock activation emitted `RunEvent::Reopen`, but Reflect did not surface or recreate a window.

## Before -> After

| Scenario | Before | After |
| --- | --- | --- |
| Saved visibility is false | Launch remains invisible | Geometry restores, then Reflect explicitly shows the main window |
| Main window is minimized or hidden | A second launch may not recover it | Shared surfacing logic unminimizes, shows, and focuses it |
| Main window was closed on macOS | Dock icon leaves the app windowless | Dock reopen recreates the configured main window |

## Changes

1. Persist only size, position, maximized, decorations, and fullscreen state. Visibility is now an application-owned launch invariant.
2. Surface the main window on `RunEvent::Ready`, after the synchronous window-state restore, preserving the no-jump startup behavior.
3. Reuse the same surfacing helper for second-instance activation and macOS Dock reopen. Reopen recreates a missing main window from configuration and refuses to do so during the quit handshake.
4. Add regression coverage for the geometry-only state contract and missing versus existing main-window lookup.

## Verification

- `cargo fmt --check`
- `cargo test -p reflect-open windows::tests` — 3 passed
- `pnpm check`
- `cargo clippy -p reflect-open --tests -- -D warnings`
- `git diff --check`

A native macOS smoke test was intentionally not run because the machine was actively in use.

## Risk / Rollout

No data migration is required. Existing `.window-state.json` files may retain `visible: false`, but the field is ignored from this release onward. The next beta should verify a cold launch with seeded false visibility and Dock reopen after closing the main window.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes desktop window lifecycle and persisted state behavior across platforms, but scope is limited to visibility recovery with quit-handshake guards and no data migration.
> 
> **Overview**
> Fixes launches where the Reflect desktop process stayed alive but **no main window appeared**, caused by the window-state plugin persisting a transient `visible: false` from hidden startup or shutdown/updater relaunches.
> 
> **Window state** now restores only geometry (size, position, maximized, decorations, fullscreen)—not visibility. After synchronous restore on **`RunEvent::Ready`**, the shell explicitly **shows, unminimizes, and focuses** the main window via shared `surface_main_window` (also used for second-instance activation).
> 
> On **macOS**, **`RunEvent::Reopen`** (Dock click with no visible windows or after ⌘W closed the main window) surfaces an existing hidden/minimized window or **recreates** it from `tauri.conf` config, skipping recreation while the quit flush handshake is armed.
> 
> Adds unit tests for the geometry-only state flags and for surfacing when the main window is missing vs present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a84026273a7d58f1f654f5fa14bbfbbbf9db76fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->