### PR TITLE
fix: find non-Latin title substrings in search

### DIFF
--- a/apps/cli/src/commands/output.rs
+++ b/apps/cli/src/commands/output.rs
@@ -59,7 +59,7 @@ pub struct HitJson {
     pub path: String,
     pub title: String,
     pub snippet: String,
-    /// bm25 rank (more negative = better match).
+    /// bm25 rank (more negative = better match); `0` for title-only substring hits.
     pub score: f64,
 }
 

--- a/apps/cli/src/keys.rs
+++ b/apps/cli/src/keys.rs
@@ -1,16 +1,52 @@
-//! Match-key folding — the Rust mirror of `packages/core/src/markdown/keys.ts`.
-//! Title/alias matching is insensitive to case and surrounding whitespace; this
-//! must produce the same keys the TS indexer wrote to `notes.title_key` /
-//! `aliases.alias_key`, or lookups silently miss.
+//! Match-key folding and script classification — the Rust mirror of
+//! `packages/core/src/markdown/keys.ts` and the script table in
+//! `packages/core/src/indexing/search-query.ts`. This must produce the same
+//! keys the TS indexer wrote to `notes.title_key` / `aliases.alias_key` and
+//! classify query terms the same way the app's search does, or lookups
+//! silently miss and CLI/app result orders drift.
 
 /// Trim surrounding whitespace and case-fold `value` to its match key.
 pub fn fold_key(value: &str) -> String {
     value.trim().to_lowercase()
 }
 
+/// Scripts written without spaces between words (Han, kana, Hangul, Thai, …).
+/// FTS5's `unicode61` tokenizer only segments at non-alphanumeric characters,
+/// so a title run in these scripts indexes as ONE token and a shorter query
+/// can never match it lexically — such terms need anywhere-in-the-title
+/// substring recall. Space-delimited scripts must NOT get it: `car` may find
+/// `Car log` but never `Oscar party`. Mirrors `UNSEGMENTED_SCRIPT_RANGES`
+/// (`packages/core/src/indexing/search-query.ts`); the two must move together.
+const UNSEGMENTED_SCRIPT_RANGES: &[(u32, u32)] = &[
+    (0x0e00, 0x0eff),   // Thai, Lao
+    (0x1000, 0x109f),   // Myanmar
+    (0x1100, 0x11ff),   // Hangul Jamo
+    (0x1780, 0x17ff),   // Khmer
+    (0x3005, 0x3007),   // Japanese iteration marks (々〆〇)
+    (0x3040, 0x30ff),   // Hiragana, Katakana
+    (0x3130, 0x318f),   // Hangul Compatibility Jamo
+    (0x31f0, 0x31ff),   // Katakana Phonetic Extensions
+    (0x3400, 0x4dbf),   // CJK Extension A
+    (0x4e00, 0x9fff),   // CJK Unified Ideographs
+    (0xac00, 0xd7af),   // Hangul Syllables
+    (0xf900, 0xfaff),   // CJK Compatibility Ideographs
+    (0xff66, 0xff9f),   // Halfwidth Katakana
+    (0x20000, 0x2fa1f), // CJK Extensions B–F, Compatibility Supplement
+];
+
+/// True when `value` contains a character from an unsegmented script.
+pub fn contains_unsegmented_script(value: &str) -> bool {
+    value.chars().any(|character| {
+        let code_point = character as u32;
+        UNSEGMENTED_SCRIPT_RANGES
+            .iter()
+            .any(|&(start, end)| (start..=end).contains(&code_point))
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::fold_key;
+    use super::{contains_unsegmented_script, fold_key};
 
     /// Parity with `foldKey` (`keys.ts`): trim + Unicode lowercase. JS
     /// `toLowerCase` and Rust `to_lowercase` agree on all common inputs; known
@@ -22,5 +58,23 @@ mod tests {
         assert_eq!(fold_key("Café"), "café");
         assert_eq!(fold_key("ALPHA"), "alpha");
         assert_eq!(fold_key(""), "");
+    }
+
+    /// Parity with `containsUnsegmentedScript` (`search-query.ts`): the same
+    /// inputs must classify the same way in the CLI and the app.
+    #[test]
+    fn classifies_scripts_like_the_ts_search() {
+        assert!(contains_unsegmented_script("東京"));
+        assert!(contains_unsegmented_script("とうきょう"));
+        assert!(contains_unsegmented_script("トウキョウ"));
+        assert!(contains_unsegmented_script("人々"));
+        assert!(contains_unsegmented_script("서울"));
+        assert!(contains_unsegmented_script("กรุงเทพ"));
+        assert!(contains_unsegmented_script("𠮷野")); // CJK Extension B
+        assert!(contains_unsegmented_script("東京trip")); // mixed runs count
+        assert!(!contains_unsegmented_script("tokyo"));
+        assert!(!contains_unsegmented_script("café"));
+        assert!(!contains_unsegmented_script("Москва"));
+        assert!(!contains_unsegmented_script(""));
     }
 }

--- a/apps/cli/src/search.rs
+++ b/apps/cli/src/search.rs
@@ -1,13 +1,14 @@
 //! Lexical search over the FTS index. The `MATCH` expression is built exactly
 //! like `buildFtsMatch` (`packages/core/src/indexing/search-query.ts`) and
-//! ranking matches the desktop's palette search (`filtered-search.ts`): an
-//! exact title match leads, then title-boosted bm25 with the same column
-//! weights, then pinned and recency as deterministic tiebreakers and `path`
-//! as the stable fallback — so the same query against the same index orders
-//! the same in the CLI and the app. The CLI adds its privacy filter
+//! ranking matches the desktop's palette search (`filtered-search.ts`): exact,
+//! prefix, and substring title matches lead, then title-boosted bm25 with the
+//! same column weights, pinned, recency, and `path`. Folded title substring
+//! recall complements FTS5's `unicode61` tokenizer, which cannot match part of
+//! an uninterrupted CJK title. The CLI adds its privacy filter
 //! (`notes.is_private = 0`) and FTS5 `snippet()`.
 
-use rusqlite::{params, Connection};
+use rusqlite::types::Value;
+use rusqlite::{params_from_iter, Connection};
 
 use crate::error::CliError;
 
@@ -33,7 +34,7 @@ pub struct SearchHit {
     pub title: String,
     /// FTS5 `snippet()` over the indexed plain-text body.
     pub snippet: String,
-    /// Title-boosted bm25 score (more negative = better match).
+    /// Title-boosted bm25 score (more negative = better); `0` for title-only substring hits.
     pub score: f64,
 }
 
@@ -42,10 +43,12 @@ pub struct SearchHit {
 const RANK_EXPR: &str = "bm25(search_fts, 0, 10.0, 1.0)";
 
 /// Ranked, private-excluded search mirroring the desktop palette ordering
-/// (`filtered-search.ts`): exact title match first (`title_key = ?2`), then
-/// title-boosted bm25, then pinned and recency tiebreakers, then `path`. The
-/// returned `score` is the bm25 component only — it doesn't capture the
-/// exact-title or tiebreak ordering. The caller re-checks each hit's file
+/// (`filtered-search.ts`): exact, prefix, and substring title matches first,
+/// then title-boosted bm25, pinned and recency tiebreakers, then `path`. A
+/// materialized CTE runs MATCH once because SQLite rejects it beneath a plain
+/// OR and otherwise flattens a derived FTS join into one scan per note. The
+/// LEFT JOIN admits title-substring-only rows. Their snippet is empty and score
+/// is `0`, since no FTS rank exists. The caller re-checks each hit's file
 /// frontmatter (the index row may lag a just-flagged note).
 pub fn search_index(
     conn: &Connection,
@@ -53,20 +56,53 @@ pub fn search_index(
     title_key: &str,
     limit: usize,
 ) -> Result<Vec<SearchHit>, CliError> {
+    let title_terms: Vec<&str> = title_key.split_whitespace().collect();
+    if title_terms.is_empty() {
+        return Ok(Vec::new());
+    }
+    let title_term_predicate = title_terms
+        .iter()
+        .enumerate()
+        .map(|(index, _)| format!("instr(notes.title_key, ?{}) > 0", index + 3))
+        .collect::<Vec<String>>()
+        .join(" AND ");
+    let limit_parameter = title_terms.len() + 3;
     let mut statement = conn.prepare(&format!(
-        "SELECT search_fts.path, search_fts.title,
-                snippet(search_fts, 2, '', '', '…', 12), {RANK_EXPR}
-         FROM search_fts
-         JOIN notes ON notes.path = search_fts.path
-         WHERE search_fts MATCH ?1 AND notes.is_private = 0 AND notes.kind != 'template'
-         ORDER BY CASE WHEN notes.title_key = ?2 THEN 0 ELSE 1 END,
-                  {RANK_EXPR},
+        "WITH lexical AS MATERIALIZED (
+           SELECT path, snippet(search_fts, 2, '', '', '…', 12) AS snippet,
+                  {RANK_EXPR} AS rank
+           FROM search_fts
+           WHERE search_fts MATCH ?1
+         )
+         SELECT notes.path, notes.title,
+                coalesce(lexical.snippet, ''), coalesce(lexical.rank, 0)
+         FROM notes
+         LEFT JOIN lexical ON lexical.path = notes.path
+         WHERE (lexical.path IS NOT NULL OR ({title_term_predicate}))
+           AND notes.is_private = 0 AND notes.kind != 'template'
+         ORDER BY CASE
+                    WHEN notes.title_key = ?2 THEN 0
+                    WHEN instr(notes.title_key, ?2) = 1 THEN 1
+                    WHEN {title_term_predicate} THEN 2
+                    ELSE 3
+                  END,
+                  coalesce(lexical.rank, 0),
                   notes.is_pinned DESC,
                   notes.mtime DESC,
                   notes.path ASC
-         LIMIT ?3",
+         LIMIT ?{limit_parameter}",
     ))?;
-    let rows = statement.query_map(params![match_expr, title_key, limit as i64], |row| {
+    let mut parameters = vec![
+        Value::Text(match_expr.to_owned()),
+        Value::Text(title_key.to_owned()),
+    ];
+    parameters.extend(
+        title_terms
+            .into_iter()
+            .map(|term| Value::Text(term.to_owned())),
+    );
+    parameters.push(Value::Integer(limit as i64));
+    let rows = statement.query_map(params_from_iter(parameters), |row| {
         Ok(SearchHit {
             path: row.get(0)?,
             title: row.get(1)?,

--- a/apps/cli/src/search.rs
+++ b/apps/cli/src/search.rs
@@ -1,16 +1,19 @@
 //! Lexical search over the FTS index. The `MATCH` expression is built exactly
 //! like `buildFtsMatch` (`packages/core/src/indexing/search-query.ts`) and
 //! ranking matches the desktop's palette search (`filtered-search.ts`): exact,
-//! prefix, and substring title matches lead, then title-boosted bm25 with the
-//! same column weights, pinned, recency, and `path`. Folded title substring
-//! recall complements FTS5's `unicode61` tokenizer, which cannot match part of
-//! an uninterrupted CJK title. The CLI adds its privacy filter
+//! prefix, and all-terms title matches lead, then title-boosted bm25 with the
+//! same column weights, pinned, recency, and `path`. Folded title recall
+//! matches each term at a title word start — except terms in unsegmented
+//! scripts, which match anywhere: FTS5's `unicode61` tokenizer cannot match
+//! part of an uninterrupted CJK title (`titleRecallNeedles` in
+//! `search-query.ts` is the TS twin). The CLI adds its privacy filter
 //! (`notes.is_private = 0`) and FTS5 `snippet()`.
 
 use rusqlite::types::Value;
 use rusqlite::{params_from_iter, Connection};
 
 use crate::error::CliError;
+use crate::keys::contains_unsegmented_script;
 
 /// Build an FTS5 `MATCH` expression from a free-text query, or `None` when
 /// there is nothing to search. Every whitespace-split term is double-quoted
@@ -34,8 +37,26 @@ pub struct SearchHit {
     pub title: String,
     /// FTS5 `snippet()` over the indexed plain-text body.
     pub snippet: String,
-    /// Title-boosted bm25 score (more negative = better); `0` for title-only substring hits.
+    /// Title-boosted bm25 score (more negative = better); `0` for title-only hits.
     pub score: f64,
+}
+
+/// The `instr` needles for title recall, one per folded query term — the twin
+/// of `titleRecallNeedles` (`search-query.ts`). Matched against
+/// `' ' || notes.title_key`: terms in space-delimited scripts carry a leading
+/// space so they only match at word starts (`car` finds `Car log`, not
+/// `Oscar party`), while unsegmented-script terms match anywhere.
+fn title_recall_needles(title_key: &str) -> Vec<String> {
+    title_key
+        .split_whitespace()
+        .map(|term| {
+            if contains_unsegmented_script(term) {
+                term.to_owned()
+            } else {
+                format!(" {term}")
+            }
+        })
+        .collect()
 }
 
 /// The palette search's bm25 column weights (`filtered-search.ts`): path
@@ -43,11 +64,11 @@ pub struct SearchHit {
 const RANK_EXPR: &str = "bm25(search_fts, 0, 10.0, 1.0)";
 
 /// Ranked, private-excluded search mirroring the desktop palette ordering
-/// (`filtered-search.ts`): exact, prefix, and substring title matches first,
+/// (`filtered-search.ts`): exact, prefix, and all-terms title matches first,
 /// then title-boosted bm25, pinned and recency tiebreakers, then `path`. A
 /// materialized CTE runs MATCH once because SQLite rejects it beneath a plain
 /// OR and otherwise flattens a derived FTS join into one scan per note. The
-/// LEFT JOIN admits title-substring-only rows. Their snippet is empty and score
+/// LEFT JOIN admits title-recall-only rows. Their snippet is empty and score
 /// is `0`, since no FTS rank exists. The caller re-checks each hit's file
 /// frontmatter (the index row may lag a just-flagged note).
 pub fn search_index(
@@ -56,17 +77,17 @@ pub fn search_index(
     title_key: &str,
     limit: usize,
 ) -> Result<Vec<SearchHit>, CliError> {
-    let title_terms: Vec<&str> = title_key.split_whitespace().collect();
-    if title_terms.is_empty() {
+    let needles = title_recall_needles(title_key);
+    if needles.is_empty() {
         return Ok(Vec::new());
     }
-    let title_term_predicate = title_terms
+    let title_term_predicate = needles
         .iter()
         .enumerate()
-        .map(|(index, _)| format!("instr(notes.title_key, ?{}) > 0", index + 3))
+        .map(|(index, _)| format!("instr(' ' || notes.title_key, ?{}) > 0", index + 3))
         .collect::<Vec<String>>()
         .join(" AND ");
-    let limit_parameter = title_terms.len() + 3;
+    let limit_parameter = needles.len() + 3;
     let mut statement = conn.prepare(&format!(
         "WITH lexical AS MATERIALIZED (
            SELECT path, snippet(search_fts, 2, '', '', '…', 12) AS snippet,
@@ -96,11 +117,7 @@ pub fn search_index(
         Value::Text(match_expr.to_owned()),
         Value::Text(title_key.to_owned()),
     ];
-    parameters.extend(
-        title_terms
-            .into_iter()
-            .map(|term| Value::Text(term.to_owned())),
-    );
+    parameters.extend(needles.into_iter().map(Value::Text));
     parameters.push(Value::Integer(limit as i64));
     let rows = statement.query_map(params_from_iter(parameters), |row| {
         Ok(SearchHit {
@@ -119,7 +136,17 @@ pub fn search_index(
 
 #[cfg(test)]
 mod tests {
-    use super::build_fts_match;
+    use super::{build_fts_match, title_recall_needles};
+
+    /// Parity with `titleRecallNeedles` (`search-query.ts`): space-delimited
+    /// terms anchor at word starts (leading space); unsegmented-script terms
+    /// match anywhere (no anchor).
+    #[test]
+    fn needles_match_the_ts_builder() {
+        assert_eq!(title_recall_needles("tokyo 東京"), vec![" tokyo", "東京"]);
+        assert_eq!(title_recall_needles("car"), vec![" car"]);
+        assert_eq!(title_recall_needles(""), Vec::<String>::new());
+    }
 
     /// Parity with `buildFtsMatch` (`search-query.test.ts`) — same inputs,
     /// same expressions, byte for byte.

--- a/apps/cli/tests/cli.rs
+++ b/apps/cli/tests/cli.rs
@@ -292,6 +292,36 @@ fn search_finds_a_short_japanese_term_inside_a_title() {
     assert!(!multi_term.contains("notes/body-hit.md"));
 }
 
+/// Title recall anchors space-delimited terms at word starts: `car` leads
+/// with the title-prefix note, still returns the body match, and never
+/// surfaces a mid-word title hit like `Oscar party plans`.
+#[test]
+fn search_matches_latin_title_terms_at_word_starts_only() {
+    let fixture = graph();
+    fixture.write_note(
+        "notes/car-log.md",
+        "# Car maintenance log\nan otherwise unrelated body\n",
+    );
+    fixture.write_note(
+        "notes/oscar.md",
+        "# Oscar party plans\nan otherwise unrelated body\n",
+    );
+    fixture.write_note("notes/garage.md", "# Garage\nthe car needs new brakes\n");
+    fixture.build_index();
+
+    let text = stdout(&reflect(&fixture, &["search", "car"]));
+    let title_pos = text.find("notes/car-log.md").unwrap();
+    let body_pos = text.find("notes/garage.md").unwrap();
+    assert!(
+        title_pos < body_pos,
+        "expected the title-prefix match before the body match:\n{text}"
+    );
+    assert!(
+        !text.contains("notes/oscar.md"),
+        "a mid-word title substring must not match:\n{text}"
+    );
+}
+
 /// The V1-style exact-title boost (`filtered-search.ts`): a note whose title
 /// *is* the query ranks ahead of a louder lexical (bm25) match whose title only
 /// contains the query among other words — exact title is promoted before bm25.

--- a/apps/cli/tests/cli.rs
+++ b/apps/cli/tests/cli.rs
@@ -263,6 +263,35 @@ fn search_boosts_title_matches_over_body_matches() {
     );
 }
 
+/// `unicode61` treats an uninterrupted Japanese title as one token. Search
+/// therefore supplements MATCH with folded title-substring recall, including
+/// common two-character queries that a trigram-only index would miss.
+#[test]
+fn search_finds_a_short_japanese_term_inside_a_title() {
+    let fixture = graph();
+    fixture.write_note(
+        "notes/title-hit.md",
+        "# 来週の東京旅行計画\nan otherwise unrelated body\n",
+    );
+    fixture.write_note(
+        "notes/body-hit.md",
+        "# 別のノート\nan otherwise unrelated 東京 body token\n",
+    );
+    fixture.build_index();
+
+    let text = stdout(&reflect(&fixture, &["search", "東京"]));
+    let title_pos = text.find("notes/title-hit.md").unwrap();
+    let body_pos = text.find("notes/body-hit.md").unwrap();
+    assert!(
+        title_pos < body_pos,
+        "expected the title substring match before the body match:\n{text}"
+    );
+
+    let multi_term = stdout(&reflect(&fixture, &["search", "東京 旅行"]));
+    assert!(multi_term.contains("notes/title-hit.md"));
+    assert!(!multi_term.contains("notes/body-hit.md"));
+}
+
 /// The V1-style exact-title boost (`filtered-search.ts`): a note whose title
 /// *is* the query ranks ahead of a louder lexical (bm25) match whose title only
 /// contains the query among other words — exact title is promoted before bm25.

--- a/apps/desktop/src/dev/dev-index-db.test.ts
+++ b/apps/desktop/src/dev/dev-index-db.test.ts
@@ -164,6 +164,73 @@ describe('createDevIndexDb', () => {
     expect(filtered.map((hit) => hit.path)).toEqual(['notes/body-hit.md'])
   })
 
+  it('matches Latin terms at title word starts only, never mid-word', async () => {
+    const db = await openDb()
+    db.applyNote(
+      sampleNote({
+        path: 'notes/car-log.md',
+        id: '01hv3xq7c2dm8k4t9w5e6r1n93',
+        title: 'Car maintenance log',
+        titleKey: 'car maintenance log',
+        isPinned: false,
+        text: 'An otherwise unrelated body.',
+        preview: 'An otherwise unrelated body.',
+        tags: [],
+        mtime: 100,
+      }),
+    )
+    db.applyNote(
+      sampleNote({
+        path: 'notes/car-wash.md',
+        id: '01hv3xq7c2dm8k4t9w5e6r1n94',
+        title: 'Weekend car wash',
+        titleKey: 'weekend car wash',
+        isPinned: false,
+        text: 'An otherwise unrelated body.',
+        preview: 'An otherwise unrelated body.',
+        tags: [],
+        mtime: 50,
+      }),
+    )
+    db.applyNote(
+      sampleNote({
+        path: 'notes/oscar.md',
+        id: '01hv3xq7c2dm8k4t9w5e6r1n95',
+        title: 'Oscar party plans',
+        titleKey: 'oscar party plans',
+        isPinned: false,
+        text: 'An otherwise unrelated body.',
+        preview: 'An otherwise unrelated body.',
+        tags: [],
+        mtime: 300,
+      }),
+    )
+    db.applyNote(
+      sampleNote({
+        path: 'notes/garage.md',
+        id: '01hv3xq7c2dm8k4t9w5e6r1n96',
+        title: 'Garage',
+        titleKey: 'garage',
+        isPinned: false,
+        text: 'The car needs new brakes.',
+        preview: 'The car needs new brakes.',
+        tags: [],
+        mtime: 200,
+      }),
+    )
+    installQueryBridge(db)
+
+    // Title-prefix (rank 1) leads, then the word-start title match (rank 2),
+    // then the FTS body hit (rank 3). `Oscar party plans` contains `car` only
+    // mid-word and must not surface at all.
+    const hits = await searchWithFilters(parseSearchQuery('car'))
+    expect(hits.map((hit) => hit.path)).toEqual([
+      'notes/car-log.md',
+      'notes/car-wash.md',
+      'notes/garage.md',
+    ])
+  })
+
   it('re-applying a note replaces its rows instead of duplicating them', async () => {
     const db = await openDb()
     db.applyNote(sampleNote())

--- a/apps/desktop/src/dev/dev-index-db.test.ts
+++ b/apps/desktop/src/dev/dev-index-db.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest'
-import type { IndexedNote } from '@reflect/core'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  parseSearchQuery,
+  searchNotes,
+  searchWithFilters,
+  setBridge,
+  type IndexedNote,
+} from '@reflect/core'
 import { createDevIndexDb, type DevIndexDb } from '@/dev/dev-index-db'
 
 function sampleNote(overrides: Partial<IndexedNote> = {}): IndexedNote {
@@ -53,6 +59,28 @@ async function openDb(): Promise<DevIndexDb> {
   return createDevIndexDb()
 }
 
+interface CapturedQuery {
+  readonly sql: string
+  readonly params: readonly unknown[]
+}
+
+function installQueryBridge(db: DevIndexDb, captured: CapturedQuery[] = []): void {
+  setBridge({
+    invoke: async (command, args) => {
+      if (command !== 'db_query') {
+        throw new Error(`Unexpected command: ${command}`)
+      }
+      const sql = String(args['sql'])
+      const params = (args['params'] as readonly unknown[]) ?? []
+      captured.push({ sql, params })
+      return db.query(sql, params)
+    },
+    listen: async () => () => {},
+  })
+}
+
+afterEach(() => setBridge(null))
+
 describe('createDevIndexDb', () => {
   it('applies the real migrations and answers db_query-style reads', async () => {
     const db = await openDb()
@@ -83,6 +111,57 @@ describe('createDevIndexDb', () => {
 
     const hits = db.query("SELECT path FROM search_fts WHERE search_fts MATCH 'sync'", [])
     expect(hits).toEqual([{ path: 'notes/sample.md' }])
+  })
+
+  it('finds a short Japanese term inside a title as well as a note body', async () => {
+    const db = await openDb()
+    db.applyNote(
+      sampleNote({
+        path: 'notes/tokyo-trip.md',
+        id: '01hv3xq7c2dm8k4t9w5e6r1n91',
+        title: '来週の東京旅行計画',
+        titleKey: '来週の東京旅行計画',
+        isPinned: false,
+        text: 'An otherwise unrelated body.',
+        preview: 'An otherwise unrelated body.',
+        mtime: 100,
+      }),
+    )
+    db.applyNote(
+      sampleNote({
+        path: 'notes/body-hit.md',
+        id: '01hv3xq7c2dm8k4t9w5e6r1n92',
+        title: '別のノート',
+        titleKey: '別のノート',
+        isPinned: true,
+        text: 'An otherwise unrelated 東京 body token.',
+        preview: 'An otherwise unrelated 東京 body token.',
+        mtime: 200,
+      }),
+    )
+    const captured: CapturedQuery[] = []
+    installQueryBridge(db, captured)
+
+    const hits = await searchWithFilters(parseSearchQuery('東京'))
+
+    expect(hits.map((hit) => hit.path)).toEqual([
+      'notes/tokyo-trip.md',
+      'notes/body-hit.md',
+    ])
+    expect(hits[0]!.snippet).toBeNull()
+    expect(hits[1]!.snippet).toContain('東京')
+    const plan = db.query(`EXPLAIN QUERY PLAN ${captured[0]!.sql}`, captured[0]!.params)
+    expect(plan.some((row) => String(row['detail']).includes('MATERIALIZE lexical'))).toBe(true)
+    await expect(searchNotes('東京')).resolves.toEqual([
+      { path: 'notes/tokyo-trip.md', title: '来週の東京旅行計画' },
+      { path: 'notes/body-hit.md', title: '別のノート' },
+    ])
+    await expect(searchWithFilters(parseSearchQuery('東京 旅行'))).resolves.toMatchObject([
+      { path: 'notes/tokyo-trip.md', title: '来週の東京旅行計画', snippet: null },
+    ])
+
+    const filtered = await searchWithFilters(parseSearchQuery('is:pinned 東京'))
+    expect(filtered.map((hit) => hit.path)).toEqual(['notes/body-hit.md'])
   })
 
   it('re-applying a note replaces its rows instead of duplicating them', async () => {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -80,10 +80,13 @@ this is how editors/scripts create them).
 ### `reflect search <query> [--limit N] [--json]`
 
 Search over note titles and bodies, ranked like the app: exact, prefix, and
-substring title matches lead, followed by title-boosted bm25 matches. Body
-matches include snippets. Terms are matched literally (FTS5 operators in the
-query have no special meaning); a title-substring-only JSON result has an empty
-snippet and score `0`. Requires the index: if `.reflect/index.sqlite` is missing
+per-term title matches lead, followed by title-boosted bm25 matches. Title
+terms match at word starts (`car` finds `Car log`, never `Oscar party`);
+terms in scripts written without spaces (Japanese, Chinese, Korean, Thai, …)
+match anywhere in the title, since FTS alone cannot see inside their
+uninterrupted title runs. Body matches include snippets. Terms are matched
+literally (FTS5 operators in the query have no special meaning); a title-only
+JSON result has an empty snippet and score `0`. Requires the index: if `.reflect/index.sqlite` is missing
 the exit code is `4` — open the graph in Reflect to build it; the CLI never runs
 the indexer. If files on disk diverge from the index (checked by mtime, then
 content hash), a staleness warning goes to stderr and `"stale": true` is set —

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,11 +79,13 @@ this is how editors/scripts create them).
 
 ### `reflect search <query> [--limit N] [--json]`
 
-Lexical search over the graph's FTS index, ranked with the same title-boosted
-bm25 weighting as the app's search, snippets included. Terms are matched
-literally (FTS5 operators in the query have no special meaning). Requires the
-index: if `.reflect/index.sqlite` is missing the exit code is `4` — open the
-graph in Reflect to build it; the CLI never runs the indexer. If files on disk diverge from the index (checked by mtime, then
+Search over note titles and bodies, ranked like the app: exact, prefix, and
+substring title matches lead, followed by title-boosted bm25 matches. Body
+matches include snippets. Terms are matched literally (FTS5 operators in the
+query have no special meaning); a title-substring-only JSON result has an empty
+snippet and score `0`. Requires the index: if `.reflect/index.sqlite` is missing
+the exit code is `4` — open the graph in Reflect to build it; the CLI never runs
+the indexer. If files on disk diverge from the index (checked by mtime, then
 content hash), a staleness warning goes to stderr and `"stale": true` is set —
 results still return.
 

--- a/packages/core/src/embeddings/retrieve.ts
+++ b/packages/core/src/embeddings/retrieve.ts
@@ -1,7 +1,7 @@
 import { sql } from 'kysely'
 import { db } from '../indexing/db'
 import { searchWithFilters } from '../indexing/filtered-search'
-import type { ParsedSearchQuery } from '../indexing/filter-query'
+import { literalSearchQuery } from '../indexing/filter-query'
 import { embedTexts } from './commands'
 
 /**
@@ -101,23 +101,10 @@ async function semanticHits(query: string, limit: number): Promise<RetrievalHit[
 }
 
 async function lexicalHits(query: string, limit: number): Promise<RetrievalHit[]> {
-  // Deliberately UNPARSED: retrieve() receives raw text (often from AI
-  // callers, Plan 10) where palette filter tokens like "is:daily" inside a
-  // sentence must stay literal search terms, not become constraints.
-  const plain: ParsedSearchQuery = {
-    text: query,
-    filters: {
-      tags: [],
-      dailyOnly: false,
-      pinnedOnly: false,
-      linksTo: null,
-      linkedFrom: null,
-      updatedAfterMs: null,
-      updatedBeforeMs: null,
-    },
-    filtered: false,
-  }
-  const hits = await searchWithFilters(plain, { limit })
+  // Literal on purpose: retrieve() receives raw text (often from AI callers,
+  // Plan 10) where palette filter tokens like "is:daily" inside a sentence
+  // must stay search terms, not become constraints.
+  const hits = await searchWithFilters(literalSearchQuery(query), { limit })
   if (hits.length === 0) {
     return []
   }

--- a/packages/core/src/indexing/filter-query.ts
+++ b/packages/core/src/indexing/filter-query.ts
@@ -65,6 +65,16 @@ const EMPTY_FILTERS: SearchFilters = {
   updatedBeforeMs: null,
 }
 
+/**
+ * Wrap raw text as a parsed query with no filters — deliberately UNPARSED.
+ * For callers whose input is literal text (AI retrieval, programmatic search)
+ * where palette tokens like `is:daily` inside a sentence must stay search
+ * terms, not become constraints.
+ */
+export function literalSearchQuery(text: string): ParsedSearchQuery {
+  return { text, filters: { ...EMPTY_FILTERS, tags: [] }, filtered: false }
+}
+
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 
 /**

--- a/packages/core/src/indexing/filtered-search.test.ts
+++ b/packages/core/src/indexing/filtered-search.test.ts
@@ -119,7 +119,7 @@ describe('searchWithFilters', () => {
     expect(args['params']).toEqual(['work', 'template', 1, startOfLocalDay('2026-01-01'), 12])
   })
 
-  it('promotes title substrings, then bm25, pinned and recency on text search', async () => {
+  it('promotes title matches, then bm25, pinned and recency on text search', async () => {
     mockInvoke.mockResolvedValueOnce([
       {
         path: 'notes/quokka.md',
@@ -151,19 +151,23 @@ describe('searchWithFilters', () => {
     const sql = String(args['sql']).toLowerCase()
     expect(sql).toContain('with "lexical" as materialized')
     expect(sql).toContain('search_fts match')
-    // Exact/prefix/substring title rank leads, then title-boosted bm25 and the
+    // Exact/prefix/all-terms title rank leads, then title-boosted bm25 and the
     // deterministic pinned/recency/path tiebreakers.
     expect(sql).toContain('when "filtered_notes"."title_key" =')
     expect(sql).toContain('instr("filtered_notes"."title_key"')
+    // Term needles probe a space-prefixed title key — word-start anchoring.
+    expect(sql).toContain(`instr(' ' || "filtered_notes"."title_key"`)
     expect(sql).toContain('bm25(search_fts, 0, 10.0, 1.0)')
     expect(sql).toContain('"filtered_notes"."is_pinned" desc')
     expect(sql).toContain('"filtered_notes"."mtime" desc')
     expect(sql).toContain('"filtered_notes"."path" asc')
 
     const params = args['params'] as unknown[]
-    // The folded exact-title key and the literal FTS match expression.
+    // The folded exact-title key, the literal FTS match expression, and the
+    // word-start-anchored recall needle.
     expect(params).toContain('quokka')
     expect(params).toContain('"quokka"')
+    expect(params).toContain(' quokka')
   })
 
   it('folds the exact-title key the way titles were indexed', async () => {

--- a/packages/core/src/indexing/filtered-search.test.ts
+++ b/packages/core/src/indexing/filtered-search.test.ts
@@ -119,7 +119,7 @@ describe('searchWithFilters', () => {
     expect(args['params']).toEqual(['work', 'template', 1, startOfLocalDay('2026-01-01'), 12])
   })
 
-  it('promotes exact title, then bm25, then pinned and recency on text search', async () => {
+  it('promotes title substrings, then bm25, pinned and recency on text search', async () => {
     mockInvoke.mockResolvedValueOnce([
       {
         path: 'notes/quokka.md',
@@ -149,14 +149,16 @@ describe('searchWithFilters', () => {
     const [command, args] = mockInvoke.mock.calls[0]!
     expect(command).toBe('db_query')
     const sql = String(args['sql']).toLowerCase()
+    expect(sql).toContain('with "lexical" as materialized')
     expect(sql).toContain('search_fts match')
-    // Exact-title rank leads, then title-boosted bm25, then the deterministic
-    // pinned/recency/path tiebreakers — in that order.
-    expect(sql).toContain('case when "notes"."title_key" =')
+    // Exact/prefix/substring title rank leads, then title-boosted bm25 and the
+    // deterministic pinned/recency/path tiebreakers.
+    expect(sql).toContain('when "filtered_notes"."title_key" =')
+    expect(sql).toContain('instr("filtered_notes"."title_key"')
     expect(sql).toContain('bm25(search_fts, 0, 10.0, 1.0)')
-    expect(sql).toContain('"notes"."is_pinned" desc')
-    expect(sql).toContain('"notes"."mtime" desc')
-    expect(sql).toContain('"notes"."path" asc')
+    expect(sql).toContain('"filtered_notes"."is_pinned" desc')
+    expect(sql).toContain('"filtered_notes"."mtime" desc')
+    expect(sql).toContain('"filtered_notes"."path" asc')
 
     const params = args['params'] as unknown[]
     // The folded exact-title key and the literal FTS match expression.

--- a/packages/core/src/indexing/filtered-search.ts
+++ b/packages/core/src/indexing/filtered-search.ts
@@ -1,22 +1,23 @@
 import { sql, type RawBuilder } from 'kysely'
-import { foldKey } from '../markdown'
 import { db } from './db'
 import type { ParsedSearchQuery } from './filter-query'
 import { resolveWikiTarget } from './queries'
 import { HIGHLIGHT_END, HIGHLIGHT_START } from './search'
-import { buildFtsMatch } from './search-query'
+import { buildFtsMatch, buildTitleMatchSql } from './search-query'
 
 /**
  * The one palette search (Plan 08): parsed filter tokens become composable
  * predicates on `notes` (EXISTS subqueries against `tags` and the `backlinks`
- * view), with free text constraining and ranking through FTS. Free-text
- * ranking promotes an exact title match (V1's strongest jump-to-note signal)
- * ahead of every body hit, then orders by title-boosted bm25, with pinned and
- * recency as deterministic tiebreakers. Filters may be empty — plain text
- * search is the degenerate case, so there is exactly one search path to keep
- * correct. Without text, results order by recency — a (possibly filtered)
- * recall feed. The mobile All tab reuses that recall feed as its filtered
- * list via {@link FilteredSearchOptions}.
+ * view), with free text constraining and ranking through FTS plus folded title
+ * substring recall. The latter is essential for scripts such as Japanese:
+ * FTS5's default `unicode61` tokenizer treats an uninterrupted title as one
+ * token, so a shorter title query cannot match it lexically. Free-text ranking
+ * promotes exact, prefix, then substring title matches ahead of body hits,
+ * followed by title-boosted bm25, pinned, and recency. Filters may be empty —
+ * plain text search is the degenerate case, so there is exactly one search
+ * path to keep correct. Without text, results order by recency — a (possibly
+ * filtered) recall feed. The mobile All tab reuses that recall feed as its
+ * filtered list via {@link FilteredSearchOptions}.
  */
 
 export interface FilteredSearchHit {
@@ -236,40 +237,62 @@ export async function searchWithFilters(
   if (filters.updatedBeforeMs !== null) {
     query = query.where('notes.mtime', '<', filters.updatedBeforeMs)
   }
-  if (limit !== null) {
-    query = query.limit(limit)
-  }
-
   if (match === null) {
     // No free text: a filtered recall feed, newest first.
     let recallQuery = query
     for (const order of recallOrder(options.pinnedFirst === true)) {
       recallQuery = recallQuery.orderBy(order)
     }
+    if (limit !== null) {
+      recallQuery = recallQuery.limit(limit)
+    }
     const rows = await recallQuery.execute()
     return rows.map((row) => ({ ...row, snippet: null, isPinned: row.isPinned !== 0 }))
   }
 
-  // Free text: constrain + rank + snippet through FTS. An exact title match
-  // leads (title-rank 0); within a rank class, title-boosted bm25 orders (same
-  // weights as the unfiltered palette search), then pinned and recency break
-  // ties, with `path` as the stable final fallback. The exact-title key is
-  // folded the same way titles were at index time, so it can never drift from
-  // the stored `notes.title_key`.
-  const titleKey = foldKey(parsed.text)
-  const rows = await query
-    .innerJoin('searchFts', 'searchFts.path', 'notes.path')
-    .select(
-      sql<string>`snippet(search_fts, 2, ${HIGHLIGHT_START}, ${HIGHLIGHT_END}, '…', 10)`.as(
-        'snippet',
-      ),
+  // SQLite rejects `MATCH ... OR title_key LIKE ...`, and flattening an FTS
+  // subquery under this notes-first join reruns MATCH for every note. An
+  // explicitly materialized CTE computes lexical hits once, while the outer
+  // join safely admits title-substring-only rows and preserves FTS snippets.
+  const lexicalDb = db.with(
+    (cte) => cte('lexical').materialized(),
+    (queryDb) =>
+      queryDb
+        .selectFrom('searchFts')
+        .select([
+          'searchFts.path',
+          sql<string>`snippet(search_fts, 2, ${HIGHLIGHT_START}, ${HIGHLIGHT_END}, '…', 10)`.as(
+            'snippet',
+          ),
+          sql<number>`bm25(search_fts, 0, 10.0, 1.0)`.as('rank'),
+        ])
+        .where(sql<boolean>`search_fts MATCH ${match}`),
+  )
+  const filteredNotes = query.select('notes.titleKey').as('filteredNotes')
+  const titleMatch = buildTitleMatchSql(sql.ref<string>('filteredNotes.titleKey'), parsed.text)
+  let rankedQuery = lexicalDb
+    .selectFrom(filteredNotes)
+    .leftJoin('lexical', 'lexical.path', 'filteredNotes.path')
+    .select([
+      'filteredNotes.path',
+      'filteredNotes.title',
+      'filteredNotes.dailyDate',
+      'filteredNotes.preview',
+      'filteredNotes.mtime',
+      'filteredNotes.isPinned',
+      'lexical.snippet',
+    ])
+    .where(
+      sql<boolean>`("lexical"."path" is not null or ${titleMatch.containsAllTerms})`,
     )
-    .where(sql<boolean>`search_fts MATCH ${match}`)
-    .orderBy(sql`case when "notes"."title_key" = ${titleKey} then 0 else 1 end`)
-    .orderBy(sql`bm25(search_fts, 0, 10.0, 1.0)`)
-    .orderBy('notes.isPinned', 'desc')
-    .orderBy('notes.mtime', 'desc')
-    .orderBy('notes.path', 'asc')
-    .execute()
+    .orderBy(titleMatch.rank)
+    .orderBy(sql`coalesce("lexical"."rank", 0)`)
+    .orderBy('filteredNotes.isPinned', 'desc')
+    .orderBy('filteredNotes.mtime', 'desc')
+    .orderBy('filteredNotes.path', 'asc')
+  if (limit !== null) {
+    rankedQuery = rankedQuery.limit(limit)
+  }
+  const rows = await rankedQuery.execute()
   return rows.map((row) => ({ ...row, isPinned: row.isPinned !== 0 }))
 }

--- a/packages/core/src/indexing/filtered-search.ts
+++ b/packages/core/src/indexing/filtered-search.ts
@@ -1,6 +1,7 @@
-import { sql, type RawBuilder } from 'kysely'
+import type { Database } from '@reflect/db'
+import { sql, type RawBuilder, type Selectable } from 'kysely'
 import { db } from './db'
-import type { ParsedSearchQuery } from './filter-query'
+import { literalSearchQuery, type ParsedSearchQuery } from './filter-query'
 import { resolveWikiTarget } from './queries'
 import { HIGHLIGHT_END, HIGHLIGHT_START } from './search'
 import { buildFtsMatch, buildTitleMatchSql } from './search-query'
@@ -8,16 +9,18 @@ import { buildFtsMatch, buildTitleMatchSql } from './search-query'
 /**
  * The one palette search (Plan 08): parsed filter tokens become composable
  * predicates on `notes` (EXISTS subqueries against `tags` and the `backlinks`
- * view), with free text constraining and ranking through FTS plus folded title
- * substring recall. The latter is essential for scripts such as Japanese:
+ * view), with free text constraining and ranking through FTS plus folded
+ * title recall. Title recall matches each query term at a title word start —
+ * except terms in unsegmented scripts such as Japanese, which match anywhere:
  * FTS5's default `unicode61` tokenizer treats an uninterrupted title as one
- * token, so a shorter title query cannot match it lexically. Free-text ranking
- * promotes exact, prefix, then substring title matches ahead of body hits,
- * followed by title-boosted bm25, pinned, and recency. Filters may be empty —
- * plain text search is the degenerate case, so there is exactly one search
- * path to keep correct. Without text, results order by recency — a (possibly
- * filtered) recall feed. The mobile All tab reuses that recall feed as its
- * filtered list via {@link FilteredSearchOptions}.
+ * token, so a shorter title query can never match it lexically
+ * (`buildTitleMatchSql`). Free-text ranking promotes exact, prefix, then
+ * all-terms title matches ahead of body hits, followed by title-boosted bm25,
+ * pinned, and recency. Filters may be empty — plain text search is the
+ * degenerate case, so there is exactly one search path to keep correct.
+ * Without text, results order by recency — a (possibly filtered) recall feed.
+ * The mobile All tab reuses that recall feed as its filtered list via
+ * {@link FilteredSearchOptions}.
  */
 
 export interface FilteredSearchHit {
@@ -253,7 +256,10 @@ export async function searchWithFilters(
   // SQLite rejects `MATCH ... OR title_key LIKE ...`, and flattening an FTS
   // subquery under this notes-first join reruns MATCH for every note. An
   // explicitly materialized CTE computes lexical hits once, while the outer
-  // join safely admits title-substring-only rows and preserves FTS snippets.
+  // join safely admits title-recall-only rows and preserves FTS snippets.
+  // The admission OR can't use an index, so the ranked path scans the
+  // (filtered) notes table once per query — `instr` over titles is cheap at
+  // graph scale, and the FTS pass stays a single MATCH.
   const lexicalDb = db.with(
     (cte) => cte('lexical').materialized(),
     (queryDb) =>
@@ -295,4 +301,21 @@ export async function searchWithFilters(
   }
   const rows = await rankedQuery.execute()
   return rows.map((row) => ({ ...row, isPinned: row.isPinned !== 0 }))
+}
+
+/** A lexical/title search result: the note's path and title. */
+export type SearchHit = Pick<Selectable<Database['notes']>, 'path' | 'title'>
+
+/**
+ * Plain-text search over title + body: {@link searchWithFilters} without
+ * filter parsing (tokens like `is:daily` stay literal search text), projected
+ * to path + title. Delegating keeps exactly one ranked search query to keep
+ * correct — recall and ordering can never drift from the palette's.
+ */
+export async function searchNotes(query: string, limit = 50): Promise<SearchHit[]> {
+  if (buildFtsMatch(query) === null) {
+    return [] // nothing to search — never fall through to the recall feed.
+  }
+  const hits = await searchWithFilters(literalSearchQuery(query), { limit })
+  return hits.map((hit) => ({ path: hit.path, title: hit.title }))
 }

--- a/packages/core/src/indexing/index.ts
+++ b/packages/core/src/indexing/index.ts
@@ -72,7 +72,6 @@ export {
   getOpenTasks,
   getCompletedTasks,
   getPinnedNotes,
-  searchNotes,
   suggestWikiTargets,
   suggestTags,
   getIndexedFileFacts,
@@ -88,7 +87,6 @@ export {
   type NoteRow,
   type OpenTask,
   type PinnedNote,
-  type SearchHit,
   type TagSuggestion,
 } from './queries'
 export { resolveNoteTarget } from './resolve-target'
@@ -140,9 +138,11 @@ export {
 export { extractSnippetTasks, type SnippetTask } from './snippet-tasks'
 export { parseSearchQuery, type ParsedSearchQuery, type SearchFilters } from './filter-query'
 export {
+  searchNotes,
   searchWithFilters,
   type FilteredSearchHit,
   type FilteredSearchOptions,
+  type SearchHit,
 } from './filtered-search'
 export {
   rewriteLinksForTitleChange,

--- a/packages/core/src/indexing/pipeline.test.ts
+++ b/packages/core/src/indexing/pipeline.test.ts
@@ -446,13 +446,15 @@ describe('Kysely → db_query bridge', () => {
     expect(mockInvoke.mock.calls.length).toBe(before)
   })
 
-  it('searchNotes ranks by exact title, bm25, pinned and recency', async () => {
+  it('searchNotes ranks title substrings, bm25, pinned and recency', async () => {
     await searchNotes('hello')
     const query = mockInvoke.mock.calls.find(([cmd]) => cmd === 'db_query')
     const sql = String((query![1] as { sql: string }).sql).toLowerCase()
     // Same ranked join/order contract as the palette's `searchWithFilters`.
-    expect(sql).toContain('inner join "notes"')
-    expect(sql).toContain('case when "notes"."title_key" =')
+    expect(sql).toContain('with "lexical" as materialized')
+    expect(sql).toContain('left join "lexical"')
+    expect(sql).toContain('when "notes"."title_key" =')
+    expect(sql).toContain('instr("notes"."title_key"')
     expect(sql).toContain('bm25(search_fts, 0, 10.0, 1.0)')
     expect(sql).toContain('"notes"."is_pinned" desc')
     expect(sql).toContain('"notes"."mtime" desc')

--- a/packages/core/src/indexing/pipeline.test.ts
+++ b/packages/core/src/indexing/pipeline.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { setBridge } from '../ipc/bridge'
-import { getBacklinks, resolveWikiTarget, searchNotes } from './queries'
+import { getBacklinks, resolveWikiTarget } from './queries'
+import { searchNotes } from './filtered-search'
 import { hashContent } from './hash'
 import { PROJECTION_VERSION } from './indexed-note'
 import {
@@ -446,19 +447,20 @@ describe('Kysely → db_query bridge', () => {
     expect(mockInvoke.mock.calls.length).toBe(before)
   })
 
-  it('searchNotes ranks title substrings, bm25, pinned and recency', async () => {
+  it('searchNotes runs the palette ranked query (title match, bm25, pinned, recency)', async () => {
     await searchNotes('hello')
     const query = mockInvoke.mock.calls.find(([cmd]) => cmd === 'db_query')
     const sql = String((query![1] as { sql: string }).sql).toLowerCase()
-    // Same ranked join/order contract as the palette's `searchWithFilters`.
+    // searchNotes delegates to `searchWithFilters`, so it emits the palette's
+    // ranked query verbatim — one search path, orderings can't drift.
     expect(sql).toContain('with "lexical" as materialized')
     expect(sql).toContain('left join "lexical"')
-    expect(sql).toContain('when "notes"."title_key" =')
-    expect(sql).toContain('instr("notes"."title_key"')
+    expect(sql).toContain('when "filtered_notes"."title_key" =')
+    expect(sql).toContain(`instr(' ' || "filtered_notes"."title_key"`)
     expect(sql).toContain('bm25(search_fts, 0, 10.0, 1.0)')
-    expect(sql).toContain('"notes"."is_pinned" desc')
-    expect(sql).toContain('"notes"."mtime" desc')
-    expect(sql).toContain('"notes"."path" asc')
+    expect(sql).toContain('"filtered_notes"."is_pinned" desc')
+    expect(sql).toContain('"filtered_notes"."mtime" desc')
+    expect(sql).toContain('"filtered_notes"."path" asc')
   })
 
   it('getBacklinks maps snake_case rows back to camelCase', async () => {

--- a/packages/core/src/indexing/queries.ts
+++ b/packages/core/src/indexing/queries.ts
@@ -2,14 +2,13 @@ import type { Database } from '@reflect/db'
 import { sql, type Selectable } from 'kysely'
 import {
   foldEmail,
-  foldKey,
   foldTag,
   resolveWikiLinkAsync,
   type Resolution,
 } from '../markdown'
 import { db } from './db'
 import { inClauseChunks } from './query-utils'
-import { buildFtsMatch } from './search-query'
+import { buildFtsMatch, buildTitleMatchSql } from './search-query'
 export {
   getBacklinks,
   getBacklinksWithContext,
@@ -247,32 +246,44 @@ export async function getIndexMeta(key: string): Promise<string | null> {
   return row?.value ?? null
 }
 
-/** A full-text search result: the note's path and title. */
-export type SearchHit = Pick<Selectable<Database['searchFts']>, 'path' | 'title'>
+/** A lexical/title-substring search result: the note's path and title. */
+export type SearchHit = Pick<Selectable<Database['notes']>, 'path' | 'title'>
 
 /**
- * Full-text search over title + body (FTS5 `MATCH`), ranked like the palette's
- * lexical search (`searchWithFilters` in `filtered-search.ts`): an exact title
- * match leads, then title-boosted bm25, then pinned and recency as
- * deterministic tiebreakers, with `path` as the stable final fallback. The
- * `notes` join supplies the title-rank/pinned/recency columns; the exact-title
- * key is folded the same way titles were at index time so it can't drift from
- * the stored `notes.title_key`.
+ * Search over title + body, ranked like the palette's lexical search
+ * (`searchWithFilters` in `filtered-search.ts`): exact, prefix, and substring
+ * title matches lead, then title-boosted bm25, pinned, and recency. Title
+ * substring recall complements FTS5's `unicode61` tokenizer, which cannot
+ * match part of an uninterrupted CJK title. The title key is folded the same
+ * way titles were at index time so it cannot drift from `notes.title_key`.
  */
 export async function searchNotes(query: string, limit = 50): Promise<SearchHit[]> {
   const match = buildFtsMatch(query)
   if (match === null) {
     return [] // nothing to search (FTS5 also errors on an empty MATCH).
   }
-  const titleKey = foldKey(query)
-  return db
-    .selectFrom('searchFts')
-    .innerJoin('notes', 'notes.path', 'searchFts.path')
+  const lexicalDb = db.with(
+    (cte) => cte('lexical').materialized(),
+    (queryDb) =>
+      queryDb
+        .selectFrom('searchFts')
+        .select([
+          'searchFts.path',
+          sql<number>`bm25(search_fts, 0, 10.0, 1.0)`.as('rank'),
+        ])
+        .where(sql<boolean>`search_fts MATCH ${match}`),
+  )
+  const titleMatch = buildTitleMatchSql(sql.ref<string>('notes.titleKey'), query)
+  return lexicalDb
+    .selectFrom('notes')
+    .leftJoin('lexical', 'lexical.path', 'notes.path')
     .where('notes.kind', '!=', 'template')
-    .select(['searchFts.path', 'searchFts.title'])
-    .where(sql<boolean>`search_fts MATCH ${match}`)
-    .orderBy(sql`case when "notes"."title_key" = ${titleKey} then 0 else 1 end`)
-    .orderBy(sql`bm25(search_fts, 0, 10.0, 1.0)`)
+    .select(['notes.path', 'notes.title'])
+    .where(
+      sql<boolean>`("lexical"."path" is not null or ${titleMatch.containsAllTerms})`,
+    )
+    .orderBy(titleMatch.rank)
+    .orderBy(sql`coalesce("lexical"."rank", 0)`)
     .orderBy('notes.isPinned', 'desc')
     .orderBy('notes.mtime', 'desc')
     .orderBy('notes.path', 'asc')

--- a/packages/core/src/indexing/queries.ts
+++ b/packages/core/src/indexing/queries.ts
@@ -1,5 +1,4 @@
-import type { Database } from '@reflect/db'
-import { sql, type Selectable } from 'kysely'
+import { sql } from 'kysely'
 import {
   foldEmail,
   foldTag,
@@ -8,7 +7,6 @@ import {
 } from '../markdown'
 import { db } from './db'
 import { inClauseChunks } from './query-utils'
-import { buildFtsMatch, buildTitleMatchSql } from './search-query'
 export {
   getBacklinks,
   getBacklinksWithContext,
@@ -244,51 +242,6 @@ export async function getIndexMeta(key: string): Promise<string | null> {
     .select('value')
     .executeTakeFirst()
   return row?.value ?? null
-}
-
-/** A lexical/title-substring search result: the note's path and title. */
-export type SearchHit = Pick<Selectable<Database['notes']>, 'path' | 'title'>
-
-/**
- * Search over title + body, ranked like the palette's lexical search
- * (`searchWithFilters` in `filtered-search.ts`): exact, prefix, and substring
- * title matches lead, then title-boosted bm25, pinned, and recency. Title
- * substring recall complements FTS5's `unicode61` tokenizer, which cannot
- * match part of an uninterrupted CJK title. The title key is folded the same
- * way titles were at index time so it cannot drift from `notes.title_key`.
- */
-export async function searchNotes(query: string, limit = 50): Promise<SearchHit[]> {
-  const match = buildFtsMatch(query)
-  if (match === null) {
-    return [] // nothing to search (FTS5 also errors on an empty MATCH).
-  }
-  const lexicalDb = db.with(
-    (cte) => cte('lexical').materialized(),
-    (queryDb) =>
-      queryDb
-        .selectFrom('searchFts')
-        .select([
-          'searchFts.path',
-          sql<number>`bm25(search_fts, 0, 10.0, 1.0)`.as('rank'),
-        ])
-        .where(sql<boolean>`search_fts MATCH ${match}`),
-  )
-  const titleMatch = buildTitleMatchSql(sql.ref<string>('notes.titleKey'), query)
-  return lexicalDb
-    .selectFrom('notes')
-    .leftJoin('lexical', 'lexical.path', 'notes.path')
-    .where('notes.kind', '!=', 'template')
-    .select(['notes.path', 'notes.title'])
-    .where(
-      sql<boolean>`("lexical"."path" is not null or ${titleMatch.containsAllTerms})`,
-    )
-    .orderBy(titleMatch.rank)
-    .orderBy(sql`coalesce("lexical"."rank", 0)`)
-    .orderBy('notes.isPinned', 'desc')
-    .orderBy('notes.mtime', 'desc')
-    .orderBy('notes.path', 'asc')
-    .limit(limit)
-    .execute()
 }
 
 /** What a pass knows about an indexed note without reading its file. */

--- a/packages/core/src/indexing/search-query.test.ts
+++ b/packages/core/src/indexing/search-query.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { buildFtsMatch } from './search-query'
+import {
+  buildFtsMatch,
+  containsUnsegmentedScript,
+  titleRecallNeedles,
+} from './search-query'
 
 describe('buildFtsMatch', () => {
   it('returns null for an empty or whitespace-only query', () => {
@@ -21,5 +25,45 @@ describe('buildFtsMatch', () => {
 
   it('collapses runs of whitespace between terms', () => {
     expect(buildFtsMatch('  alpha   beta ')).toBe('"alpha" "beta"')
+  })
+})
+
+describe('containsUnsegmentedScript', () => {
+  // The Rust CLI mirrors this classification (`apps/cli/src/keys.rs`) — the
+  // same inputs must classify the same way there.
+  it('detects scripts written without word separators', () => {
+    expect(containsUnsegmentedScript('東京')).toBe(true) // Han
+    expect(containsUnsegmentedScript('とうきょう')).toBe(true) // Hiragana
+    expect(containsUnsegmentedScript('トウキョウ')).toBe(true) // Katakana
+    expect(containsUnsegmentedScript('人々')).toBe(true) // iteration mark
+    expect(containsUnsegmentedScript('서울')).toBe(true) // Hangul
+    expect(containsUnsegmentedScript('กรุงเทพ')).toBe(true) // Thai
+    expect(containsUnsegmentedScript('𠮷野')).toBe(true) // CJK Extension B
+    expect(containsUnsegmentedScript('東京trip')).toBe(true) // mixed runs count
+  })
+
+  it('rejects space-delimited scripts', () => {
+    expect(containsUnsegmentedScript('tokyo')).toBe(false)
+    expect(containsUnsegmentedScript('café')).toBe(false)
+    expect(containsUnsegmentedScript('Москва')).toBe(false)
+    expect(containsUnsegmentedScript('')).toBe(false)
+  })
+})
+
+describe('titleRecallNeedles', () => {
+  it('anchors space-delimited terms at word starts and leaves unsegmented terms free', () => {
+    // The leading space pairs with `instr(' ' || title_key, needle)`: `car`
+    // may match `Car log` but never mid-word in `Oscar party`, while `東京`
+    // must match anywhere — `unicode61` gives its title run no word starts.
+    expect(titleRecallNeedles('Tokyo 東京')).toEqual([' tokyo', '東京'])
+    expect(titleRecallNeedles('car')).toEqual([' car'])
+  })
+
+  it('folds terms the way titles were folded at index time', () => {
+    expect(titleRecallNeedles('  QuOkKa   Habitat ')).toEqual([' quokka', ' habitat'])
+  })
+
+  it('returns no needles for a blank query', () => {
+    expect(titleRecallNeedles('   ')).toEqual([])
   })
 })

--- a/packages/core/src/indexing/search-query.ts
+++ b/packages/core/src/indexing/search-query.ts
@@ -30,28 +30,87 @@ export function buildFtsMatch(query: string): string | null {
   return terms.map((term) => `"${term.replace(/"/g, '""')}"`).join(' ')
 }
 
+/**
+ * Scripts written without spaces between words (Han, kana, Hangul, Thai, …).
+ * FTS5's `unicode61` tokenizer only segments at non-alphanumeric characters,
+ * so a title run in these scripts indexes as ONE token and a shorter query
+ * can never match it lexically — such terms need anywhere-in-the-title
+ * substring recall. Space-delimited scripts must NOT get it: `car` may find
+ * `Car log` but never `Oscar party`. The Rust CLI mirrors this table
+ * (`apps/cli/src/keys.rs`); the two must move together.
+ */
+const UNSEGMENTED_SCRIPT_RANGES: ReadonlyArray<readonly [number, number]> = [
+  [0x0e00, 0x0eff], // Thai, Lao
+  [0x1000, 0x109f], // Myanmar
+  [0x1100, 0x11ff], // Hangul Jamo
+  [0x1780, 0x17ff], // Khmer
+  [0x3005, 0x3007], // Japanese iteration marks (々〆〇)
+  [0x3040, 0x30ff], // Hiragana, Katakana
+  [0x3130, 0x318f], // Hangul Compatibility Jamo
+  [0x31f0, 0x31ff], // Katakana Phonetic Extensions
+  [0x3400, 0x4dbf], // CJK Extension A
+  [0x4e00, 0x9fff], // CJK Unified Ideographs
+  [0xac00, 0xd7af], // Hangul Syllables
+  [0xf900, 0xfaff], // CJK Compatibility Ideographs
+  [0xff66, 0xff9f], // Halfwidth Katakana
+  [0x20000, 0x2fa1f], // CJK Extensions B–F, Compatibility Supplement
+]
+
+/** True when `value` contains a character from an unsegmented script. */
+export function containsUnsegmentedScript(value: string): boolean {
+  for (const char of value) {
+    const codePoint = char.codePointAt(0) ?? 0
+    if (
+      UNSEGMENTED_SCRIPT_RANGES.some(
+        ([start, end]) => codePoint >= start && codePoint <= end,
+      )
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * The `instr` needles for title recall, one per query term, folded like
+ * `notes.title_key`. Matched with `instr(' ' || title_key, needle)`: terms in
+ * space-delimited scripts carry a leading space so they only match at word
+ * starts (`car` finds `Car log`, not `Oscar party`), while unsegmented-script
+ * terms match anywhere ({@link containsUnsegmentedScript}) — `unicode61`
+ * cannot segment those, so word starts don't exist to anchor on.
+ */
+export function titleRecallNeedles(query: string): string[] {
+  return splitSearchTerms(query)
+    .map(foldKey)
+    .map((term) => (containsUnsegmentedScript(term) ? term : ` ${term}`))
+}
+
 export interface TitleMatchSql {
-  /** True when every whitespace-delimited query term occurs in the folded title. */
+  /**
+   * True when every query term matches the folded title — at a word start for
+   * space-delimited scripts, anywhere for unsegmented ones.
+   */
   readonly containsAllTerms: RawBuilder<boolean>
-  /** Exact (0), whole-query prefix (1), term-substring (2), or non-title (3). */
+  /** Exact (0), whole-query prefix (1), all-terms title match (2), else 3. */
   readonly rank: RawBuilder<number>
 }
 
 /**
- * Build title-substring SQL against a stored, already-folded title-key column.
- * Every query term must occur, so `東京 旅行` matches `東京旅行計画` even though
- * `unicode61` sees the uninterrupted title as one token.
+ * Build title-recall SQL against a stored, already-folded title-key column.
+ * Every query term must match per {@link titleRecallNeedles}, so `東京 旅行`
+ * matches `東京旅行計画` even though `unicode61` sees the uninterrupted title
+ * as one token, while `car` never matches `Oscar party`.
  */
 export function buildTitleMatchSql(
   titleKeyColumn: RawBuilder<string>,
   query: string,
 ): TitleMatchSql {
-  const terms = splitSearchTerms(query).map(foldKey)
+  const needles = titleRecallNeedles(query)
   const containsAllTerms =
-    terms.length === 0
+    needles.length === 0
       ? sql<boolean>`0`
       : sql<boolean>`(${sql.join(
-          terms.map((term) => sql`instr(${titleKeyColumn}, ${term}) > 0`),
+          needles.map((needle) => sql`instr(' ' || ${titleKeyColumn}, ${needle}) > 0`),
           sql` and `,
         )})`
   const titleKey = foldKey(query)

--- a/packages/core/src/indexing/search-query.ts
+++ b/packages/core/src/indexing/search-query.ts
@@ -9,15 +9,59 @@
  * matched as a literal — the search is robust to whatever the user types.
  */
 
+import { sql, type RawBuilder } from 'kysely'
+import { foldKey } from '../markdown'
+
+/** Split a free-text query into the terms shared by FTS and title recall. */
+export function splitSearchTerms(query: string): string[] {
+  return query.trim().split(/\s+/).filter(Boolean)
+}
+
 /**
  * Build an FTS5 `MATCH` expression from a free-text query, or `null` when there
  * is nothing to search. FTS5 errors on an empty `MATCH`, so callers should treat
  * `null` as an empty result set rather than passing it to the database.
  */
 export function buildFtsMatch(query: string): string | null {
-  const terms = query.trim().split(/\s+/).filter(Boolean)
+  const terms = splitSearchTerms(query)
   if (terms.length === 0) {
     return null
   }
   return terms.map((term) => `"${term.replace(/"/g, '""')}"`).join(' ')
+}
+
+export interface TitleMatchSql {
+  /** True when every whitespace-delimited query term occurs in the folded title. */
+  readonly containsAllTerms: RawBuilder<boolean>
+  /** Exact (0), whole-query prefix (1), term-substring (2), or non-title (3). */
+  readonly rank: RawBuilder<number>
+}
+
+/**
+ * Build title-substring SQL against a stored, already-folded title-key column.
+ * Every query term must occur, so `東京 旅行` matches `東京旅行計画` even though
+ * `unicode61` sees the uninterrupted title as one token.
+ */
+export function buildTitleMatchSql(
+  titleKeyColumn: RawBuilder<string>,
+  query: string,
+): TitleMatchSql {
+  const terms = splitSearchTerms(query).map(foldKey)
+  const containsAllTerms =
+    terms.length === 0
+      ? sql<boolean>`0`
+      : sql<boolean>`(${sql.join(
+          terms.map((term) => sql`instr(${titleKeyColumn}, ${term}) > 0`),
+          sql` and `,
+        )})`
+  const titleKey = foldKey(query)
+  return {
+    containsAllTerms,
+    rank: sql<number>`case
+      when ${titleKeyColumn} = ${titleKey} then 0
+      when instr(${titleKeyColumn}, ${titleKey}) = 1 then 1
+      when ${containsAllTerms} then 2
+      else 3
+    end`,
+  }
 }


### PR DESCRIPTION
## Problem

Reflect writes note titles into `search_fts`, but FTS5's default `unicode61` tokenizer treats an uninterrupted CJK title as one token. A query such as `東京` therefore failed to find a note titled `来週の東京旅行計画`, even though the same query worked when `東京` appeared as a delimited body term.

The unfiltered desktop command palette could mask this through its separate title suggestions. Mobile All Notes, filtered searches, shared lexical retrieval, and `reflect search` relied on the FTS-only candidate set and missed the title.

## Before -> After

| Query | Before | After |
| --- | --- | --- |
| `東京` in `来週の東京旅行計画` only | No search hit | Title hit, ranked ahead of body-only hits |
| `東京 旅行` in the same uninterrupted title | No search hit | Hit when every query term matches the folded title |
| `meet` in title `Meeting notes` | No search hit (FTS matches whole tokens) | Title hit — terms match at title word starts |
| `car` vs. title `Oscar party plans` | No hit | Still no hit — mid-word title matches are never admitted |
| Delimited body term | FTS hit with snippet | Unchanged |

## Changes

1. Added shared title-recall SQL that folds query terms once and matches each term at a title **word start** — except terms containing unsegmented scripts (Han, kana, Hangul, Thai, …), which match anywhere in the title, since `unicode61` gives their title runs no word boundaries to anchor on. Ranking: exact title, whole-query prefix, all-terms title match, then body hits.
2. Combined those title candidates with FTS results in `searchWithFilters`, so filtered/mobile/AI search paths share the same behavior.
3. `searchNotes` now delegates to `searchWithFilters` through a new `literalSearchQuery` constructor (also adopted by `retrieve.ts`), leaving exactly one ranked search query to keep correct.
4. Materialized the lexical CTE before joining it to notes. This keeps FTS auxiliary functions under `MATCH` and prevents SQLite from flattening the join into one FTS scan per note.
5. Mirrored the needle prep, script table, and ranking in the Rust CLI (`contains_unsegmented_script` twins `containsUnsegmentedScript`, with parity unit tests on both sides). Title-only CLI hits use an empty snippet and score `0`, documented in `docs/cli.md`.
6. Added real SQLite-WASM and native CLI regressions for Japanese title searches, Latin word-start gating (`car` never matches `Oscar party plans`), filter containment, ranking tiers, and the materialized query plan.

## Tests

- The SQLite-WASM integration seeds a title-only Japanese match and a body-only match, checks title-first ordering, verifies pinned filters still apply, and asserts `EXPLAIN QUERY PLAN` contains `MATERIALIZE lexical`. A second integration pins the Latin tiers: title-prefix, then word-start title match, then body hit — and that a mid-word title (`Oscar`) never surfaces.
- The CLI integration covers `東京` and `東京 旅行` against an uninterrupted Japanese title, plus the same Latin word-start gating.
- Unit tests pin `containsUnsegmentedScript` / `titleRecallNeedles` and their Rust twins, materialization, needle anchoring, and deterministic ranking.

## Verification

- `pnpm check`
- `pnpm --filter @reflect/core test --run src/indexing/search-query.test.ts src/indexing/filtered-search.test.ts src/indexing/pipeline.test.ts src/indexing/queries.test.ts src/embeddings`
- `pnpm --filter @reflect/desktop test --run src/dev/dev-index-db.test.ts`
- `cargo test -p reflect-cli`
- `cargo clippy -p reflect-cli --all-targets`
- `cargo fmt --all -- --check`

All commands passed. Lint reports the existing max-file-length warnings in `graph-provider.tsx` and `indexer.ts`; neither file is changed here.

## Risk / Rollout

No schema migration, reindex, or backfill is required: the fix uses the existing folded `notes.title_key` projection at query time. The materialized CTE syntax and plan are exercised in both SQLite-WASM and bundled native SQLite tests. The ranked text path now scans the (filtered) notes table once per query to admit title-only hits — `instr` over titles is cheap at graph scale, and the FTS pass stays a single MATCH.
