### PR TITLE
fix: allow linking notes whose titles contain wiki links

### DIFF
--- a/apps/cli/src/note_file.rs
+++ b/apps/cli/src/note_file.rs
@@ -442,5 +442,11 @@ mod tests {
             renamed.aliases,
             vec!["Meeting with [[Ada Lovelace|Ada]]", "Meeting with Ada"]
         );
+
+        let already_claimed = parse_note_meta(
+            "notes/meeting.md",
+            "---\naliases: ['Meeting with Ada']\n---\n# Meeting with [[Ada Lovelace|Ada]]\n",
+        );
+        assert_eq!(already_claimed.aliases, vec!["Meeting with Ada"]);
     }
 }

--- a/apps/cli/src/note_file.rs
+++ b/apps/cli/src/note_file.rs
@@ -48,6 +48,24 @@ fn basename(path: &str) -> &str {
     }
 }
 
+/// CommonMark backslash escapes, matching TS `unescapeMarkdownText`.
+fn unescape_markdown_text(text: &str) -> String {
+    let mut unescaped = String::new();
+    let mut characters = text.chars().peekable();
+    while let Some(character) = characters.next() {
+        if character == '\\'
+            && characters
+                .peek()
+                .is_some_and(|next| next.is_ascii_punctuation())
+        {
+            unescaped.push(characters.next().expect("peeked character exists"));
+        } else {
+            unescaped.push(character);
+        }
+    }
+    unescaped
+}
+
 /// The TS `cleanHeadingText`: setext headings keep their first line; ATX
 /// headings lose the leading hashes and any trailing closing hashes.
 fn clean_heading_text(raw: &str) -> String {
@@ -56,14 +74,14 @@ fn clean_heading_text(raw: &str) -> String {
         .map(|text| text.strip_suffix('\r').unwrap_or(text))
         .unwrap_or(raw);
     if let Some(newline_at) = raw.find('\n') {
-        return raw[..newline_at].trim().to_string();
+        return unescape_markdown_text(raw[..newline_at].trim());
     }
     let text = raw.trim_start();
     let text = text.trim_start_matches('#');
     let text = text.trim_start_matches([' ', '\t']);
     let text = text.trim_end_matches([' ', '\t']);
     let text = text.trim_end_matches('#');
-    text.trim().to_string()
+    unescape_markdown_text(text.trim())
 }
 
 /// First level-1 heading with non-empty text, cleaned like the TS extractor
@@ -132,6 +150,66 @@ fn subject_aliases(title: &str) -> Vec<String> {
     aliases
 }
 
+/// Mirrors TS `renderEmbeddedWikiLinks` (`markdown/note-title.ts`): this is
+/// source normalization, independent of Markdown context, so both runtimes
+/// derive the same fallback target from an indexed title string.
+fn render_embedded_wiki_links(title: &str) -> Option<String> {
+    let mut rendered = String::new();
+    let mut index = 0;
+    let mut replaced = false;
+    while index < title.len() {
+        let Some(open_offset) = title[index..].find("[[") else {
+            break;
+        };
+        let open = index + open_offset;
+        let Some(close_offset) = title[open + 2..].find("]]") else {
+            break;
+        };
+        let close = open + 2 + close_offset;
+        let inner = &title[open + 2..close];
+        if inner.contains('\r') || inner.contains('\n') {
+            rendered.push_str(&title[index..open + 2]);
+            index = open + 2;
+            continue;
+        }
+        let (target, alias) = inner
+            .split_once('|')
+            .map_or((inner.trim(), ""), |(target, alias)| {
+                (target.trim(), alias.trim())
+            });
+        if target.is_empty() {
+            rendered.push_str(&title[index..open + 2]);
+            index = open + 2;
+            continue;
+        }
+        rendered.push_str(&title[index..open]);
+        rendered.push_str(if alias.is_empty() { target } else { alias });
+        index = close + 2;
+        replaced = true;
+    }
+    if !replaced {
+        return None;
+    }
+    rendered.push_str(&title[index..]);
+    Some(rendered)
+}
+
+/// TS `wikiLinkTargetForTitle`: titles without embedded wiki source keep their
+/// exact identity; rich titles use the normalized, link-safe form.
+fn wiki_link_target_for_title(title: &str) -> String {
+    let Some(visible) = render_embedded_wiki_links(title) else {
+        return title.to_string();
+    };
+    let sanitized: String = visible
+        .chars()
+        .map(|character| match character {
+            '[' | ']' | '|' | '\r' | '\n' => ' ',
+            other => other,
+        })
+        .collect();
+    sanitized.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 /// The TS `deriveTitle` chain: frontmatter `title` → first H1 → daily date →
 /// filename.
 fn derive_title(rel_path: &str, frontmatter: &Frontmatter, body: &str) -> String {
@@ -151,8 +229,8 @@ fn derive_title(rel_path: &str, frontmatter: &Frontmatter, body: &str) -> String
 }
 
 /// Derive a note's metadata from its source, as the TS indexer would:
-/// `aliases:` frontmatter verbatim, then the v1 subject aliases derived from
-/// the title, skipping segments a frontmatter alias already claims (the TS
+/// `aliases:` frontmatter verbatim, then linkable rich title/alias forms,
+/// then v1 subject aliases, skipping values already claimed (the TS
 /// `noteAliases`, `indexed-note.ts`).
 pub fn parse_note_meta(rel_path: &str, source: &str) -> NoteMeta {
     let split = split_frontmatter(source);
@@ -161,6 +239,16 @@ pub fn parse_note_meta(rel_path: &str, source: &str) -> NoteMeta {
     let mut aliases = frontmatter.aliases;
     let mut claimed: std::collections::HashSet<String> =
         aliases.iter().map(|alias| fold_key(alias)).collect();
+    let rich_texts: Vec<String> = std::iter::once(title.clone())
+        .chain(aliases.iter().cloned())
+        .collect();
+    for rich_text in rich_texts {
+        let link_target = wiki_link_target_for_title(&rich_text);
+        let link_target_key = fold_key(&link_target);
+        if link_target_key != fold_key(&rich_text) && claimed.insert(link_target_key) {
+            aliases.push(link_target);
+        }
+    }
     for alias in subject_aliases(&title) {
         if claimed.insert(fold_key(&alias)) {
             aliases.push(alias);
@@ -329,5 +417,30 @@ mod tests {
             "---\naliases: [MUM]\n---\n# Charlotte MacCaw // Mum\n",
         );
         assert_eq!(meta.aliases, vec!["MUM", "Charlotte MacCaw"]);
+    }
+
+    #[test]
+    fn rich_titles_derive_the_same_linkable_alias_as_ts() {
+        assert_eq!(
+            wiki_link_target_for_title("Meeting with [[Ada Lovelace|Ada]]"),
+            "Meeting with Ada"
+        );
+        assert_eq!(wiki_link_target_for_title("Old  Title"), "Old  Title");
+        assert_eq!(
+            wiki_link_target_for_title("Code `[[Ada Lovelace|Ada]]`"),
+            "Code `Ada`"
+        );
+
+        let meta = parse_note_meta("notes/meeting.md", "# Meeting with [[Ada Lovelace|Ada]]\n");
+        assert_eq!(meta.aliases, vec!["Meeting with Ada"]);
+
+        let renamed = parse_note_meta(
+            "notes/meeting.md",
+            "---\naliases: ['Meeting with [[Ada Lovelace|Ada]]']\n---\n# Current Meeting\n",
+        );
+        assert_eq!(
+            renamed.aliases,
+            vec!["Meeting with [[Ada Lovelace|Ada]]", "Meeting with Ada"]
+        );
     }
 }

--- a/apps/desktop/src/dev/dev-index-db.test.ts
+++ b/apps/desktop/src/dev/dev-index-db.test.ts
@@ -1,18 +1,26 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import {
+  buildIndexedNote,
   parseHighlights,
+  parseNote,
   parseSearchQuery,
+  resolveWikiTarget,
   searchNotes,
   searchWithFilters,
   setBridge,
+  suggestWikiTargets,
   type IndexedNote,
 } from '@reflect/core'
+import { createDevBridge } from '@/dev/dev-bridge'
+import { createDevFileStore } from '@/dev/dev-file-store'
 import { createDevIndexDb, type DevIndexDb } from '@/dev/dev-index-db'
 import {
   buildAllNotesSearch,
   EMPTY_ALL_NOTES_FILTERS,
   searchPlanFor,
 } from '@/mobile/search-filters/filter-state'
+
+afterEach(() => setBridge(null))
 
 function sampleNote(overrides: Partial<IndexedNote> = {}): IndexedNote {
   return {
@@ -402,6 +410,37 @@ describe('createDevIndexDb', () => {
     db.applyNote(sampleNote({ isPinned: true, pinnedOrder: 1 }))
     const pinned = db.query('SELECT path FROM notes WHERE is_pinned = ?', [true])
     expect(pinned).toEqual([{ path: 'notes/sample.md' }])
+  })
+
+  it('suggests and resolves a note whose title contains a wiki link', async () => {
+    const source = '# Meeting with [[Ada Lovelace|Ada]]\n\nAgenda.'
+    const index = await openDb()
+    index.applyNote(
+      buildIndexedNote(parseNote({ path: 'notes/meeting.md', source }), {
+        fileHash: 'meeting-hash',
+        mtime: 1,
+        source,
+      }),
+    )
+    setBridge(
+      createDevBridge({
+        platform: 'ios',
+        files: createDevFileStore({ 'notes/meeting.md': source }),
+        index,
+      }),
+    )
+
+    const suggestions = await suggestWikiTargets('meeting with ada')
+
+    expect(suggestions[0]).toMatchObject({
+      path: 'notes/meeting.md',
+      title: 'Meeting with [[Ada Lovelace|Ada]]',
+      target: 'Meeting with Ada',
+    })
+    await expect(resolveWikiTarget(suggestions[0]!.target)).resolves.toEqual({
+      kind: 'resolved',
+      ref: 'notes/meeting.md',
+    })
   })
 
   it('chat writes mirror chat_write.rs: seq assignment, upsert-by-id, cascade delete', async () => {

--- a/apps/desktop/src/editor/use-editor-autocomplete.ts
+++ b/apps/desktop/src/editor/use-editor-autocomplete.ts
@@ -7,6 +7,7 @@ import {
 } from '@meowdown/react'
 import {
   contactLinkSuggestions,
+  displayNoteTitle,
   errorMessage,
   hasBridge,
   isContactsReadable,
@@ -130,15 +131,16 @@ export function useEditorAutocomplete(): EditorAutocomplete {
           }
         }
         const { target, title, alias, date, path, generated } = entry.suggestion
+        const displayedTitle = displayNoteTitle(title)
         // A generated date leads with its phrase ("Next Friday"), resolved day
         // as the detail; everything else keeps the title/alias/daily form.
         if (generated !== undefined && date !== null) {
           return { target, label: generated.phrase, detail: formatDayLabel(date, settings.dateFormat) }
         }
-        const label = date !== null ? formatDayLabel(date, settings.dateFormat) : title
+        const label = date !== null ? formatDayLabel(date, settings.dateFormat) : displayedTitle
         const detail =
           alias !== null
-            ? `${alias} → ${title}`
+            ? `${alias} → ${displayedTitle}`
             : date !== null
               ? path === null
                 ? `${date} · new`

--- a/apps/desktop/src/editor/wiki-autocomplete-entries.test.ts
+++ b/apps/desktop/src/editor/wiki-autocomplete-entries.test.ts
@@ -39,6 +39,14 @@ describe('buildAutocompleteEntries', () => {
     expect(entries.every((entry) => entry.kind === 'suggestion')).toBe(true)
   })
 
+  it('does not offer create when a rich title has a different link target', () => {
+    const entries = buildAutocompleteEntries('Meeting with [[Ada]]', [
+      suggestion({ target: 'Meeting with Ada', title: 'Meeting with [[Ada]]' }),
+    ])
+
+    expect(entries.every((entry) => entry.kind === 'suggestion')).toBe(true)
+  })
+
   it('does not offer create on an exact alias match', () => {
     const entries = buildAutocompleteEntries('meetco', [
       suggestion({ target: 'Acme Corp', title: 'Acme Corp', alias: 'meetco' }),

--- a/apps/desktop/src/editor/wiki-autocomplete-entries.ts
+++ b/apps/desktop/src/editor/wiki-autocomplete-entries.ts
@@ -52,6 +52,8 @@ export function buildAutocompleteEntries(
   for (const suggestion of suggestions) {
     resolvable.add(foldKey(suggestion.target))
     fallbackResolvable.add(foldFallbackTitleKey(suggestion.target))
+    resolvable.add(foldKey(suggestion.title))
+    fallbackResolvable.add(foldFallbackTitleKey(suggestion.title))
     if (suggestion.alias !== null) {
       resolvable.add(foldKey(suggestion.alias))
       fallbackResolvable.add(foldFallbackTitleKey(suggestion.alias))

--- a/apps/desktop/src/lib/note-title-display.ts
+++ b/apps/desktop/src/lib/note-title-display.ts
@@ -1,16 +1,1 @@
-import { scanInlineSegments } from '@reflect/core'
-
-export function displayNoteTitle(title: string): string {
-  return scanInlineSegments(title)
-    .map((segment) => {
-      switch (segment.kind) {
-        case 'text':
-          return segment.text
-        case 'wikiLink':
-          return segment.alias ?? segment.target
-        case 'link':
-          return segment.text
-      }
-    })
-    .join('')
-}
+export { displayNoteTitle } from '@reflect/core'

--- a/fixtures/parity/expected.json
+++ b/fixtures/parity/expected.json
@@ -145,6 +145,19 @@
       "private": false,
       "fileHash": "3cf0d98e4c2d173ba03df92f4b9183b11627f917dc97dc409b3fed7de916bce0"
     },
+    "notes/h1-escaped-wikilink.md": {
+      "id": null,
+      "title": "Meeting [[Ada Lovelace|Ada]]",
+      "titleKey": "meeting [[ada lovelace|ada]]",
+      "aliases": [
+        "Meeting Ada"
+      ],
+      "aliasKeys": [
+        "meeting ada"
+      ],
+      "private": false,
+      "fileHash": "e5737824bc97abbc20cbf82cfc89fe80ef50ebc147823bdc39246791153150d5"
+    },
     "notes/h1-in-code-fence.md": {
       "id": null,
       "title": "h1-in-code-fence",
@@ -158,8 +171,12 @@
       "id": null,
       "title": "The *Heading* [[Link]]",
       "titleKey": "the *heading* [[link]]",
-      "aliases": [],
-      "aliasKeys": [],
+      "aliases": [
+        "The *Heading* Link"
+      ],
+      "aliasKeys": [
+        "the *heading* link"
+      ],
       "private": false,
       "fileHash": "b6b9e67480f08bd54378318c1e8b39999cc4027cec24dcaf7b68a19afaf2c4a9"
     },

--- a/fixtures/parity/notes/h1-escaped-wikilink.md
+++ b/fixtures/parity/notes/h1-escaped-wikilink.md
@@ -1,0 +1,4 @@
+# Meeting \[[Ada Lovelace|Ada]]
+
+The escaped opener remains literal body syntax, but title derivation renders
+the CommonMark escape before deriving its linkable title alias.

--- a/packages/core/src/exports/sync-markdown-indexing.ts
+++ b/packages/core/src/exports/sync-markdown-indexing.ts
@@ -96,6 +96,8 @@ export {
   isTagName,
   hasAuthoredTitle,
   normalizeWikiTarget,
+  displayNoteTitle,
+  wikiLinkTargetForTitle,
   slugForTitle,
   type ConflictResolution,
   type Frontmatter,

--- a/packages/core/src/graph/resolve-existing-wiki-target.test.ts
+++ b/packages/core/src/graph/resolve-existing-wiki-target.test.ts
@@ -234,6 +234,24 @@ describe('resolveExistingWikiTarget', () => {
     expectNoWrites(invoke)
   })
 
+  it('uses a rich title’s linkable alias in the bounded slug-family scan', async () => {
+    const invoke = bindBridge({
+      files: {
+        'notes/meeting-with-ada.md': '# Meeting with [[Ada]]\n',
+      },
+    })
+
+    await expect(resolveExistingWikiTarget('Meeting with Ada', 23)).resolves.toEqual({
+      kind: 'resolved',
+      path: 'notes/meeting-with-ada.md',
+    })
+    expect(invoke).toHaveBeenCalledWith('note_read', {
+      path: 'notes/meeting-with-ada.md',
+      generation: 23,
+    })
+    expectNoWrites(invoke)
+  })
+
   it.each([
     {
       label: 'iCloud placeholder',

--- a/packages/core/src/graph/resolve-existing-wiki-target.ts
+++ b/packages/core/src/graph/resolve-existing-wiki-target.ts
@@ -1,4 +1,5 @@
 import { isAppError } from '../errors'
+import { projectNoteAliases } from '../indexing/indexed-note'
 import {
   findExactWikiTargetMatches,
   type ExactWikiTargetMatch,
@@ -7,7 +8,6 @@ import { foldFallbackTitleKey, foldKey } from '../markdown/keys'
 import { parseNote } from '../markdown/extract'
 import { normalizeWikiTarget } from '../markdown/resolve'
 import { slugForTitle } from '../markdown/slug'
-import { subjectAliases } from '../markdown/subject-aliases'
 import { listFiles, readNote } from './commands'
 import { dailyPath, NOTES_DIR } from './paths'
 
@@ -94,7 +94,7 @@ async function matchTitleOnDisk(
       continue
     }
     const parsed = parseNote({ path: candidate.path, source })
-    const aliases = [...parsed.frontmatter.aliases, ...subjectAliases(parsed.title)]
+    const aliases = projectNoteAliases(parsed).map((alias) => alias.alias)
     if (foldKey(parsed.title) === targetKey) {
       exactTitlePaths.push(candidate.path)
       continue

--- a/packages/core/src/indexing/indexed-note.test.ts
+++ b/packages/core/src/indexing/indexed-note.test.ts
@@ -3,8 +3,8 @@ import { gistBodyHash, parseNote } from '../markdown'
 import { buildIndexedNote, indexedNoteSchema, PROJECTION_VERSION } from './indexed-note'
 
 describe('buildIndexedNote', () => {
-  it('carries the projection version that backfills task breadcrumbs', () => {
-    expect(PROJECTION_VERSION).toBe(15)
+  it('carries the projection version that backfills linkable rich-title aliases', () => {
+    expect(PROJECTION_VERSION).toBe(16)
   })
 
   it('flattens a parsed note into the index payload', () => {
@@ -72,6 +72,53 @@ describe('buildIndexedNote', () => {
     expect(indexed.aliases).toEqual([
       { alias: 'MUM', aliasKey: 'mum' },
       { alias: 'Charlotte MacCaw', aliasKey: 'charlotte maccaw' },
+    ])
+  })
+
+  it('derives a resolvable visible alias for a title containing a wiki link', () => {
+    const source = '# Meeting with [[Ada Lovelace|Ada]]\n\nAgenda.'
+    const indexed = buildIndexedNote(parseNote({ path: 'notes/meeting.md', source }), {
+      fileHash: 'h',
+      mtime: 0,
+      source,
+    })
+
+    expect(indexed.title).toBe('Meeting with [[Ada Lovelace|Ada]]')
+    expect(indexed.aliases).toContainEqual({
+      alias: 'Meeting with Ada',
+      aliasKey: 'meeting with ada',
+    })
+  })
+
+  it('does not duplicate a rich title target already claimed by frontmatter', () => {
+    const source =
+      '---\naliases: [Meeting with Ada]\n---\n# Meeting with [[Ada Lovelace|Ada]]\n'
+    const indexed = buildIndexedNote(parseNote({ path: 'notes/meeting.md', source }), {
+      fileHash: 'h',
+      mtime: 0,
+      source,
+    })
+
+    expect(indexed.aliases).toEqual([
+      { alias: 'Meeting with Ada', aliasKey: 'meeting with ada' },
+    ])
+  })
+
+  it('derives a linkable form for a rich frontmatter alias', () => {
+    const source =
+      '---\naliases: ["Meeting with [[Ada Lovelace|Ada]]"]\n---\n# Current Meeting\n'
+    const indexed = buildIndexedNote(parseNote({ path: 'notes/meeting.md', source }), {
+      fileHash: 'h',
+      mtime: 0,
+      source,
+    })
+
+    expect(indexed.aliases).toEqual([
+      {
+        alias: 'Meeting with [[Ada Lovelace|Ada]]',
+        aliasKey: 'meeting with [[ada lovelace|ada]]',
+      },
+      { alias: 'Meeting with Ada', aliasKey: 'meeting with ada' },
     ])
   })
 

--- a/packages/core/src/indexing/indexed-note.ts
+++ b/packages/core/src/indexing/indexed-note.ts
@@ -12,6 +12,7 @@ import {
   pinnedOrder,
   splitFrontmatter,
   subjectAliases,
+  wikiLinkTargetForTitle,
   type ParsedNote,
 } from '../markdown'
 import { previewSnippet } from './snippet'
@@ -65,8 +66,12 @@ import { previewSnippet } from './snippet'
  * until reprojected, so the bump backfills them.
  * 15 — task parent outline/list breadcrumbs: existing task rows carry empty
  * breadcrumbs until reprojected.
+ * 16 — linkable rich-title/alias targets: source containing an inline wiki
+ * link cannot itself be nested inside `[[...]]`, so its linkable form is now
+ * a derived alias and existing notes must be reprojected before the picker can
+ * address them through it.
  */
-export const PROJECTION_VERSION = 15
+export const PROJECTION_VERSION = 16
 
 export const indexedLinkSchema = z.object({
   kind: z.enum(['wiki', 'md']),
@@ -177,17 +182,25 @@ export const indexedNoteSchema = z.object({
 export type IndexedNote = z.infer<typeof indexedNoteSchema>
 
 /**
- * The `aliases` projection: `aliases:` frontmatter verbatim, then the v1
- * subject aliases derived from the title (`Charlotte MacCaw // Mum`), skipping
- * segments a frontmatter alias already claims. The derived rows are index-only
- * compatibility — the file's frontmatter is never rewritten to hold them.
+ * The `aliases` projection: `aliases:` frontmatter verbatim, then linkable
+ * forms derived from rich title/alias source that cannot be nested in another
+ * wiki link, then the v1 subject aliases (`Charlotte MacCaw // Mum`). Derived
+ * rows are index-only — the file's frontmatter is never rewritten to hold them.
  */
-function noteAliases(parsed: ParsedNote): IndexedAlias[] {
+export function projectNoteAliases(parsed: ParsedNote): IndexedAlias[] {
   const aliases: IndexedAlias[] = parsed.frontmatter.aliases.map((alias) => ({
     alias,
     aliasKey: foldKey(alias),
   }))
   const claimed = new Set(aliases.map((row) => row.aliasKey))
+  for (const richText of [parsed.title, ...parsed.frontmatter.aliases]) {
+    const linkTarget = wikiLinkTargetForTitle(richText)
+    const linkTargetKey = foldKey(linkTarget)
+    if (linkTargetKey !== foldKey(richText) && !claimed.has(linkTargetKey)) {
+      claimed.add(linkTargetKey)
+      aliases.push({ alias: linkTarget, aliasKey: linkTargetKey })
+    }
+  }
   for (const alias of subjectAliases(parsed.title)) {
     const aliasKey = foldKey(alias)
     if (claimed.has(aliasKey)) {
@@ -250,7 +263,7 @@ export function buildIndexedNote(
     preview: previewSnippet(parsed.text, parsed.title),
     links: [...wikiLinks, ...mdLinks],
     tags: parsed.tags.map((tag) => ({ tag, tagKey: foldTag(tag) })),
-    aliases: noteAliases(parsed),
+    aliases: projectNoteAliases(parsed),
     emails: extractEmailFields(body).map((email) => ({ email, emailKey: foldEmail(email) })),
     assets: parsed.assets.map((asset) => asset.path),
     tasks: parsed.tasks.map((task) => ({

--- a/packages/core/src/indexing/rename.test.ts
+++ b/packages/core/src/indexing/rename.test.ts
@@ -116,6 +116,47 @@ describe('rewriteLinksForTitleChange', () => {
       [2, 2],
     ])
   })
+
+  it('rewrites links using the visible targets of rich titles', async () => {
+    const { io, writes } = fakeIo({
+      'notes/source.md': 'Discuss [[Meeting with Ada]] tomorrow.\n',
+    })
+    io.sources = async (targetKey) => {
+      expect(targetKey).toBe('meeting with ada')
+      return ['notes/source.md']
+    }
+    io.resolve = async (target) => {
+      expect(target).toBe('Meeting with Ada')
+      return unresolved(target)
+    }
+
+    const result = await rewriteLinksForTitleChange({
+      path: 'notes/target.md',
+      from: 'Meeting with [[Ada Lovelace|Ada]]',
+      to: 'Meeting with [[Grace Hopper|Grace]]',
+      io,
+    })
+
+    expect(result.rewritten).toEqual(['notes/source.md'])
+    expect(writes['notes/source.md']).toBe('Discuss [[Meeting with Grace]] tomorrow.\n')
+  })
+
+  it('preserves repeated whitespace in ordinary title rewrites', async () => {
+    const { io, writes } = fakeIo({ 'notes/source.md': '[[Old  Title]]\n' })
+    io.sources = async (targetKey) => {
+      expect(targetKey).toBe('old  title')
+      return ['notes/source.md']
+    }
+
+    await rewriteLinksForTitleChange({
+      path: 'notes/target.md',
+      from: 'Old  Title',
+      to: 'New  Title',
+      io,
+    })
+
+    expect(writes['notes/source.md']).toBe('[[New  Title]]\n')
+  })
 })
 
 describe('rewriteLinksForTitleChange write failures', () => {
@@ -169,5 +210,15 @@ describe('nextAliases', () => {
 
   it('adds the first alias to an empty list', () => {
     expect(nextAliases([], { from: 'Old', to: 'New', previousAutoAlias: null })).toEqual(['Old'])
+  })
+
+  it('preserves the raw rich old title for non-wiki resolution', () => {
+    expect(
+      nextAliases([], {
+        from: 'Meeting with [[Ada Lovelace|Ada]]',
+        to: 'Meeting with [[Grace Hopper|Grace]]',
+        previousAutoAlias: null,
+      }),
+    ).toEqual(['Meeting with [[Ada Lovelace|Ada]]'])
   })
 })

--- a/packages/core/src/indexing/rename.ts
+++ b/packages/core/src/indexing/rename.ts
@@ -1,5 +1,6 @@
 import { renameWikiLink } from '../markdown/edit'
 import { foldKey } from '../markdown/keys'
+import { wikiLinkTargetForTitle } from '../markdown/note-title'
 import type { Resolution } from '../markdown/resolve'
 
 /**
@@ -39,15 +40,19 @@ export interface TitleRenameRewriteResult {
 }
 
 /**
- * Rewrite `[[from]]` → `[[to]]` across every source that links to the renamed
- * note's old title. Serialized (ordering stays deterministic and progress
- * means something); a failing source is skipped, not fatal — the old-title
- * alias keeps its links resolving.
+ * Rewrite the old title's linkable target to the new title's linkable target
+ * across every source. Rich title Markdown cannot be nested inside `[[...]]`,
+ * so this deliberately uses the same visible-title mapping as autocomplete.
+ * Serialized (ordering stays deterministic and progress means something); a
+ * failing source is skipped, not fatal — the old-target alias keeps its links
+ * resolving.
  */
 export async function rewriteLinksForTitleChange(
   options: TitleRenameRewriteOptions,
 ): Promise<TitleRenameRewriteResult> {
   const { path, from, to, io, onProgress } = options
+  const fromTarget = wikiLinkTargetForTitle(from)
+  const toTarget = wikiLinkTargetForTitle(to)
 
   // Collision guard: if the old title now resolves to a *different* note (a
   // second note owns it as title or alias), the existing links still point
@@ -57,19 +62,19 @@ export async function rewriteLinksForTitleChange(
   // with the old title inside that sub-second window can be missed here —
   // resolution stays deterministic and the alias still lands, so nothing
   // breaks; the late-created note simply wins future resolutions.
-  const resolution = await io.resolve(from)
+  const resolution = await io.resolve(fromTarget)
   if (resolution.kind === 'resolved' && resolution.ref !== path) {
     return { rewritten: [], failed: [], collision: true }
   }
 
-  const sources = (await io.sources(foldKey(from))).filter((source) => source !== path)
+  const sources = (await io.sources(foldKey(fromTarget))).filter((source) => source !== path)
   const rewritten: string[] = []
   const failed: string[] = []
   let done = 0
   for (const source of sources) {
     try {
       const content = await io.read(source)
-      const next = renameWikiLink(content, from, to)
+      const next = renameWikiLink(content, fromTarget, toTarget)
       if (next !== content) {
         await io.write(source, next)
         rewritten.push(source)

--- a/packages/core/src/indexing/suggest.test.ts
+++ b/packages/core/src/indexing/suggest.test.ts
@@ -74,6 +74,29 @@ describe('rankWikiSuggestions', () => {
     expect(result[0]!.date).toBe('2026-06-09')
   })
 
+  it('targets a rich title through its linkable visible form', () => {
+    const richTitle = 'Meeting with [[Ada Lovelace|Ada]]'
+    const result = rankWikiSuggestions('meeting', [note(richTitle)], [], 8)
+
+    expect(result[0]).toMatchObject({
+      target: 'Meeting with Ada',
+      title: richTitle,
+      alias: null,
+    })
+  })
+
+  it('does not present the derived rich-title alias as an alternate name', () => {
+    const rich = note('Meeting with [[Ada Lovelace|Ada]]')
+    const result = rankWikiSuggestions(
+      'meeting with ada',
+      [],
+      [alias(rich, 'Meeting with Ada')],
+      8,
+    )
+
+    expect(result[0]).toMatchObject({ target: 'Meeting with Ada', alias: null })
+  })
+
   it('honours the limit after merging', () => {
     const titles = Array.from({ length: 10 }, (_, i) => note(`Note ${i}`, i))
     expect(rankWikiSuggestions('note', titles, [], 3)).toHaveLength(3)

--- a/packages/core/src/indexing/suggest.test.ts
+++ b/packages/core/src/indexing/suggest.test.ts
@@ -143,6 +143,18 @@ describe('mergeDateSuggestions', () => {
     expect(result.map((row) => row.target)).toEqual(['Today', '2020-01-01', 'Today Notes'])
   })
 
+  it('keeps an exact raw rich-title match above generated dates', () => {
+    const title = '3 days ago [[Trip]]'
+    const rankedRows = rankWikiSuggestions(title.toLowerCase(), [note(title)], [], 8)
+    const result = mergeDateSuggestions(
+      rankedRows,
+      [{ date: '2026-07-09', phrase: '3 days ago' }],
+      { key: title.toLowerCase(), limit: 8 },
+    )
+
+    expect(result.map((row) => row.target)).toEqual(['3 days ago Trip', '2026-07-09'])
+  })
+
   it('reuses an existing daily row (real path) and marks it generated once', () => {
     const existingDaily = ranked('2020-01-06', {
       target: '2020-01-06',

--- a/packages/core/src/indexing/suggest.ts
+++ b/packages/core/src/indexing/suggest.ts
@@ -189,6 +189,7 @@ export function mergeDateSuggestions(
   const rest = ranked.filter((suggestion) => !reused.has(suggestion))
   const exactIndex = rest.findIndex(
     (suggestion) =>
+      foldKey(suggestion.title) === options.key ||
       foldKey(suggestion.target) === options.key ||
       (suggestion.alias !== null && foldKey(suggestion.alias) === options.key),
   )

--- a/packages/core/src/indexing/suggest.ts
+++ b/packages/core/src/indexing/suggest.ts
@@ -7,6 +7,7 @@
  */
 
 import { foldKey } from '../markdown/keys'
+import { wikiLinkTargetForTitle } from '../markdown/note-title'
 import type { DateSuggestion } from './date-suggestions'
 
 /**
@@ -23,7 +24,7 @@ export interface GeneratedDate {
 
 /** A `[[` autocomplete candidate. */
 export interface WikiSuggestion {
-  /** What `[[…]]` should contain when chosen (the canonical title, or an ISO date). */
+  /** What `[[…]]` should contain when chosen (a linkable title target, or an ISO date). */
   target: string
   /** The note it resolves to — `null` for a daily whose file doesn't exist yet. */
   path: string | null
@@ -82,29 +83,37 @@ export function rankWikiSuggestions(
   limit: number,
 ): WikiSuggestion[] {
   const scored: Scored[] = [
-    ...titles.map((row) => ({
-      suggestion: {
-        target: row.dailyDate ?? row.title,
-        path: row.path,
-        title: row.title,
-        alias: null,
-        date: row.dailyDate,
-      },
-      // ×2 leaves room for the alias penalty between match ranks.
-      score: matchRank(key, row.titleKey) * 2,
-      mtime: row.mtime,
-    })),
-    ...aliases.map((row) => ({
-      suggestion: {
-        target: row.dailyDate ?? row.title,
-        path: row.path,
-        title: row.title,
-        alias: row.alias,
-        date: row.dailyDate,
-      },
-      score: matchRank(key, row.aliasKey) * 2 + 1,
-      mtime: row.mtime,
-    })),
+    ...titles.map((row) => {
+      const target = row.dailyDate ?? wikiLinkTargetForTitle(row.title)
+      return {
+        suggestion: {
+          target,
+          path: row.path,
+          title: row.title,
+          alias: null,
+          date: row.dailyDate,
+        },
+        // ×2 leaves room for the alias penalty between match ranks.
+        score: matchRank(key, row.titleKey) * 2,
+        mtime: row.mtime,
+      }
+    }),
+    ...aliases.map((row) => {
+      const target = row.dailyDate ?? wikiLinkTargetForTitle(row.title)
+      return {
+        suggestion: {
+          target,
+          path: row.path,
+          title: row.title,
+          // The derived linkable-title alias is an addressing detail, not a
+          // meaningful alternate name to repeat as "alias → same title".
+          alias: foldKey(row.alias) === foldKey(target) ? null : row.alias,
+          date: row.dailyDate,
+        },
+        score: matchRank(key, row.aliasKey) * 2 + 1,
+        mtime: row.mtime,
+      }
+    }),
   ]
 
   scored.sort(

--- a/packages/core/src/markdown/index.ts
+++ b/packages/core/src/markdown/index.ts
@@ -66,6 +66,7 @@ export {
 export { extractEmailFields, foldEmail } from './email-fields'
 export { foldFallbackTitleKey, foldKey, foldTag } from './keys'
 export { gistBodyHash, gistFilename } from './gist'
+export { displayNoteTitle, wikiLinkTargetForTitle } from './note-title'
 export { slugForTitle } from './slug'
 export { subjectAliases } from './subject-aliases'
 export {

--- a/packages/core/src/markdown/note-title.test.ts
+++ b/packages/core/src/markdown/note-title.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { displayNoteTitle, wikiLinkTargetForTitle } from './note-title'
+
+describe('displayNoteTitle', () => {
+  it('renders inline links as their visible text', () => {
+    expect(displayNoteTitle('Meeting with [[Ada Lovelace|Ada]] about [Notes](https://x.com)')).toBe(
+      'Meeting with Ada about Notes',
+    )
+  })
+})
+
+describe('wikiLinkTargetForTitle', () => {
+  it('keeps a plain title unchanged', () => {
+    expect(wikiLinkTargetForTitle('Project Atlas')).toBe('Project Atlas')
+  })
+
+  it('turns a rich title into valid visible wiki-link text', () => {
+    expect(wikiLinkTargetForTitle('Meeting with [[Ada Lovelace|Ada]]')).toBe('Meeting with Ada')
+  })
+
+  it('preserves titles without embedded wiki-link source byte-for-byte', () => {
+    expect(wikiLinkTargetForTitle('Project  Atlas')).toBe('Project  Atlas')
+    expect(wikiLinkTargetForTitle('[] |')).toBe('[] |')
+  })
+
+  it('normalizes embedded wiki-link source consistently across Markdown contexts', () => {
+    expect(wikiLinkTargetForTitle('Code `[[Ada Lovelace|Ada]]`')).toBe('Code `Ada`')
+    expect(wikiLinkTargetForTitle('<https://x.test/[[Ada Lovelace|Ada]]>')).toBe(
+      '<https://x.test/Ada>',
+    )
+  })
+})

--- a/packages/core/src/markdown/note-title.test.ts
+++ b/packages/core/src/markdown/note-title.test.ts
@@ -7,6 +7,10 @@ describe('displayNoteTitle', () => {
       'Meeting with Ada about Notes',
     )
   })
+
+  it('uses the target when a wiki link has no alias', () => {
+    expect(displayNoteTitle('Meeting with [[Ada Lovelace]]')).toBe('Meeting with Ada Lovelace')
+  })
 })
 
 describe('wikiLinkTargetForTitle', () => {
@@ -16,6 +20,12 @@ describe('wikiLinkTargetForTitle', () => {
 
   it('turns a rich title into valid visible wiki-link text', () => {
     expect(wikiLinkTargetForTitle('Meeting with [[Ada Lovelace|Ada]]')).toBe('Meeting with Ada')
+  })
+
+  it('uses the target when an embedded wiki link has no alias', () => {
+    expect(wikiLinkTargetForTitle('Meeting with [[Ada Lovelace]]')).toBe(
+      'Meeting with Ada Lovelace',
+    )
   })
 
   it('preserves titles without embedded wiki-link source byte-for-byte', () => {

--- a/packages/core/src/markdown/note-title.ts
+++ b/packages/core/src/markdown/note-title.ts
@@ -1,6 +1,8 @@
 import { wikiLinkSafe } from './edit'
 import { scanInlineSegments } from './scan'
 
+// Unlike displayNoteTitle, target derivation scans raw source so wiki links are
+// normalized even inside Markdown syntax such as code spans and autolinks.
 function renderEmbeddedWikiLinks(title: string): string | null {
   let rendered = ''
   let cursor = 0

--- a/packages/core/src/markdown/note-title.ts
+++ b/packages/core/src/markdown/note-title.ts
@@ -1,0 +1,70 @@
+import { wikiLinkSafe } from './edit'
+import { scanInlineSegments } from './scan'
+
+function renderEmbeddedWikiLinks(title: string): string | null {
+  let rendered = ''
+  let cursor = 0
+  let replaced = false
+  while (cursor < title.length) {
+    const open = title.indexOf('[[', cursor)
+    if (open === -1) {
+      break
+    }
+    const close = title.indexOf(']]', open + 2)
+    if (close === -1) {
+      break
+    }
+    const inner = title.slice(open + 2, close)
+    if (inner.includes('\n') || inner.includes('\r')) {
+      rendered += title.slice(cursor, open + 2)
+      cursor = open + 2
+      continue
+    }
+    const pipe = inner.indexOf('|')
+    const target = (pipe === -1 ? inner : inner.slice(0, pipe)).trim()
+    if (target === '') {
+      rendered += title.slice(cursor, open + 2)
+      cursor = open + 2
+      continue
+    }
+    const alias = pipe === -1 ? '' : inner.slice(pipe + 1).trim()
+    rendered += title.slice(cursor, open) + (alias || target)
+    cursor = close + 2
+    replaced = true
+  }
+  if (!replaced) {
+    return null
+  }
+  return rendered + title.slice(cursor)
+}
+
+/**
+ * Render a note title the way the editor presents its inline links: wiki links
+ * use their alias (or target), and Markdown links use their visible text.
+ * Other inline Markdown stays source-shaped so a plain title is unchanged.
+ */
+export function displayNoteTitle(title: string): string {
+  return scanInlineSegments(title)
+    .map((segment) => {
+      switch (segment.kind) {
+        case 'text':
+          return segment.text
+        case 'wikiLink':
+          return segment.alias ?? segment.target
+        case 'link':
+          return segment.text
+      }
+    })
+    .join('')
+}
+
+/**
+ * The valid wiki-link target for a title containing embedded `[[...]]` source.
+ * Nested wiki links have no escaping, so each embedded form is replaced by its
+ * alias (or target) and remaining delimiters are sanitized. Titles without an
+ * embedded form are returned byte-for-byte, preserving their existing identity.
+ */
+export function wikiLinkTargetForTitle(title: string): string {
+  const rendered = renderEmbeddedWikiLinks(title)
+  return rendered === null ? title : wikiLinkSafe(rendered)
+}


### PR DESCRIPTION
## Problem

The backlink picker used a note subject verbatim as the inserted wiki-link target. A subject such as `Meeting with [[Ada Lovelace|Ada]]` therefore produced nested syntax:

```md
[[Meeting with [[Ada Lovelace|Ada]]]]
```

Meowdown intentionally inserts picker targets literally, and wiki links have no nested-bracket escaping, so that link could not resolve to the selected note. Searching the visible subject text also missed the raw indexed title.

## Before -> After

| Before | After |
| --- | --- |
| Selecting a note with a wiki link in its subject inserted malformed nested syntax. | The picker inserts a valid visible target such as `[[Meeting with Ada]]`. |
| Rich subjects were searchable only through pieces of their raw Markdown title. | Their linkable form participates in alias search and resolution. |
| A later rich-title rename could strand the newly inserted target. | Rename rewrites use the same link-target derivation while preserving the raw old title as an alias. |

## Changes

1. Added shared `displayNoteTitle` and `wikiLinkTargetForTitle` helpers. Rich subjects retain their raw Markdown title for rendering and metadata, while embedded wiki-link source derives a valid insertion target.
2. Projected linkable forms for rich titles and frontmatter aliases into the existing aliases table, with `PROJECTION_VERSION` bumped to 16 so unchanged notes are backfilled.
3. Updated suggestion ranking and desktop picker mapping to insert the linkable target, display the rendered subject, and avoid a duplicate Create row for raw-title and emoji-fallback matches.
4. Applied the same target derivation to rename rewrites. Frontmatter still preserves the raw old title, and projection derives its linkable form for unresolved or external references.
5. Integrated with the shared `resolveExistingWikiTarget` resolver by reusing `projectNoteAliases` during its bounded slug-family disk fallback, preserving upstream date, ambiguity, template, and unavailable-index behavior.
6. Kept the index-free Rust CLI mirror aligned, including CommonMark heading escapes, and extended the TS/Rust parity corpus.

## Tests

- Rich-title target rendering, alias projection, suggestion ranking, exact/fallback match handling, and rename behavior.
- Real in-memory SQLite flow: project a rich-title note, search its visible subject, and resolve the returned target to the selected path.
- Shared resolver coverage for a rich-title note whose source slug differs from its derived link target.
- TS/Rust parity for escaped rich H1 titles and index-free CLI alias resolution.
- Existing navigation-intent, pinned-title rendering, search, and editor coverage.

## Verification

- `pnpm check`
- Focused Vitest suites: 105 tests passed across core and desktop.
- Full `pnpm test`: project suites passed except an unrelated mobile double-tap test exceeded its 5-second local timeout; the isolated test passed with a 15-second timeout in 5.43 seconds.
- `cargo test -p reflect-cli`
- `cargo fmt --all -- --check`

## Risk / Rollout

The projection version bump causes a one-time derived-index rebuild when an existing graph next opens; Markdown files are not migrated or rewritten. Existing title-before-alias precedence, ambiguity handling, and the shared resolver's bounded fallback behavior are preserved. No database schema migration or Markdown rewrite is required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core wiki resolution, alias projection, and rename rewrites across TS and Rust; PROJECTION_VERSION 16 triggers a one-time index reprojection on open, but markdown files are not rewritten.
> 
> **Overview**
> Fixes wiki-link picker and resolution when a note’s **title or alias contains `[[...]]` syntax**, which previously produced invalid nested `[[...]]` targets and weak search/resolution.
> 
> **Shared helpers** in `@reflect/core` (`displayNoteTitle`, `wikiLinkTargetForTitle`) derive a **link-safe insertion target** from rich title source while keeping the raw Markdown title for display and metadata. The Rust CLI mirror gains the same heading unescape and alias derivation; parity fixtures cover escaped H1 wikilinks.
> 
> **Indexing** projects those linkable forms as derived **aliases** (via exported `projectNoteAliases`), bumps **`PROJECTION_VERSION` to 16** for backfill, and wires the same alias set into **bounded disk fallback** in `resolveExistingWikiTarget`.
> 
> **Product behavior**: `[[` suggestions insert the linkable **target** (not the raw title); autocomplete labels use `displayNoteTitle`; create rows are suppressed when the raw title matches even if target differs; **title renames** rewrite links using linkable targets while `nextAliases` still stores the raw old title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 916cce5f89d0fc0e57c97b09d617403045020216. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved wiki-link suggestions and resolution for titles containing embedded links.
  * Added support for linkable aliases derived from rich note titles and frontmatter aliases.
  * Displayed readable titles in editor autocomplete suggestions.
  * Improved link rewriting when renaming notes with rich titles.

* **Bug Fixes**
  * Corrected Markdown escaping and title normalization for more consistent indexing and alias matching.
  * Prevented duplicate or unnecessary “Create” suggestions when an existing target matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->