### PR TITLE
fix(mobile): keep Today taps on the current day

### DIFF
--- a/apps/desktop/src/mobile/day-carousel.tsx
+++ b/apps/desktop/src/mobile/day-carousel.tsx
@@ -6,10 +6,12 @@ import { useDayCarousel } from '@/mobile/use-day-carousel'
 interface DayCarouselProps {
   /** The selected day (from the route). Drives the carousel position. */
   date: string
+  /** Identity of the route arrival that owns the selected day. */
+  navigationKey: string
   /** Today's live ISO date — tints today's date heading, as on desktop. */
   today: string
   /**
-   * Bumped on an explicit re-arrival at the shown day (Daily tab / title tap
+   * Bumped on an explicit re-arrival at the shown day (Daily tab / Today tap
    * while already there): the selected slide re-anchors to the top.
    */
   scrollResetSeq: number
@@ -22,9 +24,10 @@ interface DayCarouselProps {
   /**
    * A swipe's destination day, announced at pointer-up while the snap
    * animation still plays — for chrome (the calendar strip and its month
-   * title) that should move with the gesture, ahead of the route.
+   * title) that should move with the gesture, ahead of the route. The key
+   * identifies the source arrival so the receiver can reject stale updates.
    */
-  onTarget: (date: string) => void
+  onTarget: (date: string, navigationKey: string) => void
 }
 
 /** Slides within this many of the selection mount an editor; the rest are
@@ -41,6 +44,7 @@ const MOUNT_RADIUS = 1
  */
 export function DayCarousel({
   date,
+  navigationKey,
   today,
   scrollResetSeq,
   focusDate,
@@ -48,7 +52,12 @@ export function DayCarousel({
   onSelect,
   onTarget,
 }: DayCarouselProps): ReactElement {
-  const { emblaRef, dayWindow, selectedIndex } = useDayCarousel(date, onSelect, onTarget)
+  const { emblaRef, dayWindow, selectedIndex } = useDayCarousel(
+    date,
+    navigationKey,
+    onSelect,
+    onTarget,
+  )
   // One mutable map for the carousel's life; the identity never changes, so
   // holding it in state (read during render) rather than a ref is safe.
   const [scrollMemory] = useState(() => new Map<string, number>())

--- a/apps/desktop/src/mobile/screens/daily.tsx
+++ b/apps/desktop/src/mobile/screens/daily.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, type ReactElement } from 'react'
+import { useCallback, type ReactElement } from 'react'
 import { untitledNotePath } from '@reflect/core'
 import { Plus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -7,12 +7,8 @@ import { AudioMemoFab } from '@/mobile/audio-memo-fab'
 import { CalendarStrip } from '@/mobile/calendar-strip'
 import { DayCarousel } from '@/mobile/day-carousel'
 import { useDailyArrivals } from '@/mobile/use-daily-arrivals'
+import { useSwipeTarget } from '@/mobile/use-swipe-target'
 import { useRouter } from '@/routing/router'
-
-interface SwipeTargetState {
-  readonly navigationKey: string
-  readonly date: string | null
-}
 
 /**
  * The mobile spine (Plan 19, V1 parity): a month header + week calendar strip
@@ -34,35 +30,21 @@ export function MobileDaily({ date }: { date: string }): ReactElement {
   // tap on the highlighted today cell to a frozen `daily` date). Selecting
   // today routes to the live `today` route, keeping the spine rolling over.
   const today = useToday()
+  // The identity of the current router arrival. Every navigate bumps
+  // `arrivalSeq` (history moves change `entryId`), so any arrival — including
+  // a date-preserving Today tap — mints a new key, which supersedes the swipe
+  // state scoped to the old one.
+  const navigationKey = `${entryId}:${arrivalSeq}:${date}`
   // The day a swipe is heading toward, announced at pointer-up — the strip
   // (and its rolling month title) follows it while the carousel's snap
   // animation plays, instead of waiting for the settle-time route change.
-  // Tag it with the router arrival that created it: a delayed transition from
-  // an older swipe must not overwrite a newer Today/strip/history arrival.
-  const navigationKey = `${entryId}:${arrivalSeq}:${date}`
-  const [swipeTarget, setSwipeTarget] = useState<SwipeTargetState>(() => ({
-    navigationKey,
-    date: null,
-  }))
-  // Any route move or same-route re-arrival supersedes the transient target.
-  // Reconcile during render so stale transition state never reaches a frame.
-  if (swipeTarget.navigationKey !== navigationKey) {
-    setSwipeTarget({ navigationKey, date: null })
-  }
+  const { targetDate, followSwipeTarget } = useSwipeTarget(navigationKey)
   const select = useCallback(
     (day: string): void => {
-      setSwipeTarget((current) =>
-        current.date === null ? current : { ...current, date: null },
-      )
       navigate(day === today ? { kind: 'today' } : { kind: 'daily', date: day })
     },
     [navigate, today],
   )
-  const followSwipeTarget = useCallback((day: string, sourceNavigationKey: string): void => {
-    setSwipeTarget((current) =>
-      current.navigationKey === sourceNavigationKey ? { ...current, date: day } : current,
-    )
-  }, [])
 
   // An explicit re-arrival at the day already shown — the Daily tab tapped
   // while on today (V1's double-tap-to-today lands here) — re-anchors the
@@ -74,8 +56,6 @@ export function MobileDaily({ date }: { date: string }): ReactElement {
     arrivalFocusEditor,
     date,
   })
-  const targetDate =
-    swipeTarget.navigationKey === navigationKey ? swipeTarget.date : null
 
   return (
     <div className="flex h-full w-screen flex-col">

--- a/apps/desktop/src/mobile/screens/daily.tsx
+++ b/apps/desktop/src/mobile/screens/daily.tsx
@@ -9,6 +9,11 @@ import { DayCarousel } from '@/mobile/day-carousel'
 import { useDailyArrivals } from '@/mobile/use-daily-arrivals'
 import { useRouter } from '@/routing/router'
 
+interface SwipeTargetState {
+  readonly navigationKey: string
+  readonly date: string | null
+}
+
 /**
  * The mobile spine (Plan 19, V1 parity): a month header + week calendar strip
  * over a swipeable day carousel of daily notes. The strip and the carousel
@@ -22,7 +27,7 @@ import { useRouter } from '@/routing/router'
  * day change scrolls the carousel rather than remounting it.
  */
 export function MobileDaily({ date }: { date: string }): ReactElement {
-  const { navigate, arrivalSeq, arrivalFocusEditor } = useRouter()
+  const { navigate, entryId, arrivalSeq, arrivalFocusEditor } = useRouter()
   // One live `today` for the whole surface: the strip marks today's cell and
   // the `select` below decide "is this today?" from the *same* value, so they
   // can't disagree across the midnight rollover (which would otherwise route a
@@ -32,24 +37,32 @@ export function MobileDaily({ date }: { date: string }): ReactElement {
   // The day a swipe is heading toward, announced at pointer-up — the strip
   // (and its rolling month title) follows it while the carousel's snap
   // animation plays, instead of waiting for the settle-time route change.
-  const [targetDate, setTargetDate] = useState<string | null>(null)
-  // Any route move — the swipe's own settle, a strip tap, a date link, back —
-  // supersedes the override: the route is the truth again. Cleared on the
-  // `date` change itself (the render-phase previous-value pattern) rather
-  // than in `select`, because navigations from elsewhere (a daily backlink,
-  // history) never pass through `select`.
-  const [lastDate, setLastDate] = useState(date)
-  if (date !== lastDate) {
-    setLastDate(date)
-    setTargetDate(null)
+  // Tag it with the router arrival that created it: a delayed transition from
+  // an older swipe must not overwrite a newer Today/strip/history arrival.
+  const navigationKey = `${entryId}:${arrivalSeq}:${date}`
+  const [swipeTarget, setSwipeTarget] = useState<SwipeTargetState>(() => ({
+    navigationKey,
+    date: null,
+  }))
+  // Any route move or same-route re-arrival supersedes the transient target.
+  // Reconcile during render so stale transition state never reaches a frame.
+  if (swipeTarget.navigationKey !== navigationKey) {
+    setSwipeTarget({ navigationKey, date: null })
   }
   const select = useCallback(
     (day: string): void => {
-      setTargetDate(null)
+      setSwipeTarget((current) =>
+        current.date === null ? current : { ...current, date: null },
+      )
       navigate(day === today ? { kind: 'today' } : { kind: 'daily', date: day })
     },
     [navigate, today],
   )
+  const followSwipeTarget = useCallback((day: string, sourceNavigationKey: string): void => {
+    setSwipeTarget((current) =>
+      current.navigationKey === sourceNavigationKey ? { ...current, date: day } : current,
+    )
+  }, [])
 
   // An explicit re-arrival at the day already shown — the Daily tab tapped
   // while on today (V1's double-tap-to-today lands here) — re-anchors the
@@ -61,6 +74,8 @@ export function MobileDaily({ date }: { date: string }): ReactElement {
     arrivalFocusEditor,
     date,
   })
+  const targetDate =
+    swipeTarget.navigationKey === navigationKey ? swipeTarget.date : null
 
   return (
     <div className="flex h-full w-screen flex-col">
@@ -69,10 +84,11 @@ export function MobileDaily({ date }: { date: string }): ReactElement {
         date={date}
         today={today}
         scrollResetSeq={resetSeq}
+        navigationKey={navigationKey}
         focusDate={focusDate}
         onFocusConsumed={consumeFocus}
         onSelect={select}
-        onTarget={setTargetDate}
+        onTarget={followSwipeTarget}
       />
       <Button
         size="icon"

--- a/apps/desktop/src/mobile/use-day-carousel.test.ts
+++ b/apps/desktop/src/mobile/use-day-carousel.test.ts
@@ -37,8 +37,18 @@ const embla = vi.hoisted(() => {
       handlers.get(event)?.delete(handler)
       return api
     },
-    scrollTo: vi.fn((index: number) => {
+    scrollTo: vi.fn((index: number, jump?: boolean) => {
+      const changed = selected !== index
+      // Embla 8.6's instant path renders (and can emit `settle`) before it
+      // updates the selected index and emits `select`. Model that re-entrancy:
+      // a Today sync must ignore the old arrival's settle callback.
+      if (changed && jump === true) {
+        emit('settle')
+      }
       selected = index
+      if (changed) {
+        emit('select')
+      }
     }),
     reInit: vi.fn((options?: { startIndex?: number }) => {
       if (options?.startIndex !== undefined) {
@@ -66,6 +76,10 @@ const embla = vi.hoisted(() => {
       emit('select')
       emit('settle')
     },
+    /** Fire settle at the carousel's current target. */
+    settle(): void {
+      emit('settle')
+    },
     reset(): void {
       handlers.clear()
       selected = 0
@@ -90,6 +104,7 @@ const base: ReconcileInput = {
   lastWindowStart: '2025-06-11',
   date: '2026-06-12',
   reported: '2026-06-01',
+  forceScroll: false,
 }
 
 describe('reconcileCarousel', () => {
@@ -103,6 +118,17 @@ describe('reconcileCarousel', () => {
     expect(reconcileCarousel({ ...base, date: '2026-06-01', reported: '2026-06-01' })).toEqual({
       action: 'none',
     })
+  })
+
+  it('forces a same-date arrival to cancel an in-flight swipe', () => {
+    expect(
+      reconcileCarousel({
+        ...base,
+        date: '2026-06-01',
+        reported: '2026-06-01',
+        forceScroll: true,
+      }),
+    ).toEqual({ action: 'scroll', index: 10 })
   })
 
   it('does nothing when the date is outside the window (a re-anchor is pending)', () => {
@@ -160,6 +186,7 @@ describe('useDayCarousel', () => {
   /** The anchor day sits at {@link CAROUSEL_RADIUS} — the window's center. */
   const DATE = '2026-06-12'
   const CENTER = CAROUSEL_RADIUS
+  const NAVIGATION_KEY = `0:0:${DATE}`
   const initialWindow = createDayWindow(DATE, {
     past: CAROUSEL_RADIUS,
     future: CAROUSEL_RADIUS,
@@ -168,9 +195,12 @@ describe('useDayCarousel', () => {
   function mountCarousel() {
     const onSelect = vi.fn()
     const onTarget = vi.fn()
-    const hook = renderHook(({ date }) => useDayCarousel(date, onSelect, onTarget), {
-      initialProps: { date: DATE },
-    })
+    const hook = renderHook(
+      ({ date, navigationKey }) => useDayCarousel(date, navigationKey, onSelect, onTarget),
+      {
+        initialProps: { date: DATE, navigationKey: NAVIGATION_KEY },
+      },
+    )
     return { ...hook, onSelect, onTarget }
   }
 
@@ -191,7 +221,7 @@ describe('useDayCarousel', () => {
 
     // The strip (and its month title) follow this while the snap animates;
     // the route only moves at settle.
-    expect(onTarget).toHaveBeenCalledExactlyOnceWith('2026-06-13')
+    expect(onTarget).toHaveBeenCalledExactlyOnceWith('2026-06-13', NAVIGATION_KEY)
     expect(onSelect).not.toHaveBeenCalled()
   })
 
@@ -208,7 +238,7 @@ describe('useDayCarousel', () => {
     const { rerender } = mountCarousel()
     act(() => embla.settleAt(CENTER + 1))
 
-    rerender({ date: '2026-06-13' })
+    rerender({ date: '2026-06-13', navigationKey: '1:1:2026-06-13' })
 
     expect(embla.api.scrollTo).not.toHaveBeenCalled()
     expect(embla.api.reInit).not.toHaveBeenCalled()
@@ -217,11 +247,36 @@ describe('useDayCarousel', () => {
   it('scrolls to an external in-window selection without reporting it back', () => {
     const { result, rerender, onSelect } = mountCarousel()
 
-    rerender({ date: '2026-06-20' })
+    rerender({ date: '2026-06-20', navigationKey: '1:1:2026-06-20' })
 
     expect(embla.api.scrollTo).toHaveBeenCalledExactlyOnceWith(CENTER + 8, true)
     expect(result.current.selectedIndex).toBe(CENTER + 8)
     expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('cancels a pending swipe when Today re-arrives at the unchanged route date', () => {
+    const { result, rerender, onSelect, onTarget } = mountCarousel()
+
+    // Pointer-up has aimed away from Today, but the route is still Today until
+    // Embla settles. This is the window in which the fading Today button can
+    // be tapped.
+    act(() => embla.selectAt(CENTER + 1))
+    expect(result.current.selectedIndex).toBe(CENTER + 1)
+
+    // The Today tap is a date-preserving router arrival. It must still issue
+    // an instant horizontal sync, superseding the pending snap.
+    rerender({ date: DATE, navigationKey: `0:1:${DATE}` })
+    expect(embla.api.scrollTo).toHaveBeenCalledExactlyOnceWith(CENTER, true)
+    expect(result.current.selectedIndex).toBe(CENTER)
+    // The instant jump emitted stale settle/select events through the old
+    // listener, but neither may publish another target or route selection.
+    expect(onTarget).toHaveBeenCalledTimes(1)
+    expect(onSelect).not.toHaveBeenCalled()
+
+    act(() => embla.settle())
+    expect(onSelect).not.toHaveBeenCalled()
+    expect(onTarget).toHaveBeenCalledTimes(1)
+    expect(result.current.selectedIndex).toBe(CENTER)
   })
 
   it('re-centers the window when a swipe settles near an edge', () => {

--- a/apps/desktop/src/mobile/use-day-carousel.ts
+++ b/apps/desktop/src/mobile/use-day-carousel.ts
@@ -116,6 +116,22 @@ interface CarouselSelectionState {
   readonly index: number
 }
 
+/**
+ * State updater adopting the arrival's `navigationKey` and `index`, bailing
+ * out (returning the current state) when both already match — the state is an
+ * object, so an unconditional set would re-render the whole slide belt even
+ * when nothing changed.
+ */
+function adoptSelection(
+  navigationKey: string,
+  index: number,
+): (current: CarouselSelectionState) => CarouselSelectionState {
+  return (current) =>
+    current.navigationKey === navigationKey && current.index === index
+      ? current
+      : { navigationKey, index }
+}
+
 interface CarouselNavigationState {
   readonly navigationKey: string
   readonly date: string
@@ -154,15 +170,14 @@ export function useDayCarousel(
     watchDrag: dragAllowedWithKeyboardClosed,
   }))
   const [emblaRef, emblaApi] = useEmblaCarousel(emblaOptions)
-  const initialIndex = indexWithin(dayWindow, date)
+  const routeIndex = indexWithin(dayWindow, date)
   const [selection, setSelection] = useState<CarouselSelectionState>(() => ({
     navigationKey,
-    index: initialIndex,
+    index: routeIndex,
   }))
   // A newer router arrival is authoritative over transition-priority swipe
   // state. Carry its identity in the state itself so an older queued updater
   // cannot restore the old mount radius after navigation has won.
-  const routeIndex = indexWithin(dayWindow, date)
   const selectedIndex =
     selection.navigationKey === navigationKey || routeIndex === -1
       ? selection.index
@@ -227,7 +242,7 @@ export function useDayCarousel(
         return
       }
       const index = api.selectedScrollSnap()
-      setSelection({ navigationKey, index })
+      setSelection(adoptSelection(navigationKey, index))
       const day = dateAtIndex(dayWindow, index)
       if (day !== reportedRef.current) {
         reportedRef.current = day
@@ -322,7 +337,7 @@ export function useDayCarousel(
     } else {
       emblaApi.scrollTo(sync.index, true)
     }
-    setSelection({ navigationKey, index: sync.index })
+    setSelection(adoptSelection(navigationKey, sync.index))
   }, [emblaApi, date, dayWindow, navigationKey])
 
   return { emblaRef, dayWindow, selectedIndex }

--- a/apps/desktop/src/mobile/use-day-carousel.ts
+++ b/apps/desktop/src/mobile/use-day-carousel.ts
@@ -69,6 +69,8 @@ export interface ReconcileInput {
   date: string
   /** The day last reported back through `onSelect` — the echo guard. */
   reported: string
+  /** A date-preserving arrival must still cancel any in-flight swipe. */
+  forceScroll: boolean
 }
 
 /**
@@ -81,7 +83,8 @@ export interface ReconcileInput {
  *   animation the user may have restarted.
  * - `reinit` when the window was re-anchored (its start moved): Embla must
  *   reinitialize onto the rebuilt slide set at the target index.
- * - `scroll` for an ordinary in-window jump (calendar tap, Today, near link).
+ * - `scroll` for an ordinary in-window jump (calendar tap, Today, near link),
+ *   or a forced same-date arrival that must cancel an in-flight swipe.
  */
 export function reconcileCarousel(input: ReconcileInput): CarouselSync {
   if (input.index === -1) {
@@ -89,6 +92,9 @@ export function reconcileCarousel(input: ReconcileInput): CarouselSync {
   }
   if (input.windowStart !== input.lastWindowStart) {
     return { action: 'reinit', index: input.index }
+  }
+  if (input.forceScroll) {
+    return { action: 'scroll', index: input.index }
   }
   if (input.date === input.reported) {
     return { action: 'none' }
@@ -103,6 +109,16 @@ export interface DayCarousel {
   dayWindow: DayWindow
   /** The centered slide's index — the view mounts editors around it. */
   selectedIndex: number
+}
+
+interface CarouselSelectionState {
+  readonly navigationKey: string
+  readonly index: number
+}
+
+interface CarouselNavigationState {
+  readonly navigationKey: string
+  readonly date: string
 }
 
 /**
@@ -121,8 +137,9 @@ export interface DayCarousel {
  */
 export function useDayCarousel(
   date: string,
+  navigationKey: string,
   onSelect: (date: string) => void,
-  onTarget: (date: string) => void,
+  onTarget: (date: string, navigationKey: string) => void,
 ): DayCarousel {
   const [dayWindow, setDayWindow] = useState<DayWindow>(() => createDayWindow(date, CAROUSEL_WINDOW))
   // Frozen at mount: `embla-carousel-react` reinitializes whenever the options
@@ -137,13 +154,36 @@ export function useDayCarousel(
     watchDrag: dragAllowedWithKeyboardClosed,
   }))
   const [emblaRef, emblaApi] = useEmblaCarousel(emblaOptions)
-  const [selectedIndex, setSelectedIndex] = useState(() => indexWithin(dayWindow, date))
+  const initialIndex = indexWithin(dayWindow, date)
+  const [selection, setSelection] = useState<CarouselSelectionState>(() => ({
+    navigationKey,
+    index: initialIndex,
+  }))
+  // A newer router arrival is authoritative over transition-priority swipe
+  // state. Carry its identity in the state itself so an older queued updater
+  // cannot restore the old mount radius after navigation has won.
+  const routeIndex = indexWithin(dayWindow, date)
+  const selectedIndex =
+    selection.navigationKey === navigationKey || routeIndex === -1
+      ? selection.index
+      : routeIndex
+  if (selection.navigationKey !== navigationKey) {
+    setSelection({ navigationKey, index: selectedIndex })
+  }
   // The day we last reported via onSelect — so the route echo it produces
   // doesn't trigger a redundant (animation-cancelling) scrollTo.
   const reportedRef = useRef(date)
   // The window start we last reconciled against — a change means a re-anchor,
   // so Embla must reinitialize rather than scroll.
   const windowStartRef = useRef(dayWindow.start)
+  const reconciledNavigationRef = useRef<CarouselNavigationState>({ navigationKey, date })
+  // Event listeners are replaced in a passive effect. This layout-updated
+  // identity lets the old listener ignore a synchronous `scrollTo`/`reInit`
+  // event from a newer navigation commit.
+  const latestNavigationKeyRef = useRef(navigationKey)
+  useLayoutEffect(() => {
+    latestNavigationKeyRef.current = navigationKey
+  }, [navigationKey])
 
   // The swipe's target is known at pointer-up (`select`), and two light
   // things follow it from there. The slide window: the mount radius tracks
@@ -155,13 +195,18 @@ export function useDayCarousel(
   // first ones.
   const onEmblaSelect = useCallback(
     (api: NonNullable<typeof emblaApi>) => {
+      if (navigationKey !== latestNavigationKeyRef.current) {
+        return
+      }
       const index = api.selectedScrollSnap()
       startTransition(() => {
-        setSelectedIndex(index)
-        onTarget(dateAtIndex(dayWindow, index))
+        setSelection((current) =>
+          current.navigationKey === navigationKey ? { ...current, index } : current,
+        )
+        onTarget(dateAtIndex(dayWindow, index), navigationKey)
       })
     },
-    [dayWindow, onTarget],
+    [dayWindow, navigationKey, onTarget],
   )
 
   // The swipe's heavy consequence — reporting the day, which the parent turns
@@ -178,8 +223,11 @@ export function useDayCarousel(
   // onto the slide the user is already looking at.
   const onEmblaSettle = useCallback(
     (api: NonNullable<typeof emblaApi>) => {
+      if (navigationKey !== latestNavigationKeyRef.current) {
+        return
+      }
       const index = api.selectedScrollSnap()
-      setSelectedIndex(index)
+      setSelection({ navigationKey, index })
       const day = dateAtIndex(dayWindow, index)
       if (day !== reportedRef.current) {
         reportedRef.current = day
@@ -189,7 +237,7 @@ export function useDayCarousel(
         setDayWindow(createDayWindow(day, CAROUSEL_WINDOW))
       }
     },
-    [dayWindow, onSelect],
+    [dayWindow, navigationKey, onSelect],
   )
 
   useEffect(() => {
@@ -252,12 +300,17 @@ export function useDayCarousel(
     if (!emblaApi) {
       return
     }
+    const previousNavigation = reconciledNavigationRef.current
+    const forceScroll =
+      previousNavigation.navigationKey !== navigationKey && previousNavigation.date === date
+    reconciledNavigationRef.current = { navigationKey, date }
     const sync = reconcileCarousel({
       index: indexWithin(dayWindow, date),
       windowStart: dayWindow.start,
       lastWindowStart: windowStartRef.current,
       date,
       reported: reportedRef.current,
+      forceScroll,
     })
     if (sync.action === 'none') {
       return
@@ -269,8 +322,8 @@ export function useDayCarousel(
     } else {
       emblaApi.scrollTo(sync.index, true)
     }
-    setSelectedIndex(sync.index)
-  }, [emblaApi, date, dayWindow])
+    setSelection({ navigationKey, index: sync.index })
+  }, [emblaApi, date, dayWindow, navigationKey])
 
   return { emblaRef, dayWindow, selectedIndex }
 }

--- a/apps/desktop/src/mobile/use-swipe-target.test.ts
+++ b/apps/desktop/src/mobile/use-swipe-target.test.ts
@@ -1,0 +1,68 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { useSwipeTarget } from './use-swipe-target'
+
+/**
+ * The strip's optimistic swipe target (extracted from MobileDaily). The
+ * contract: a pointer-up target from the current arrival is followed, any new
+ * router arrival clears it, and an update tagged with a superseded arrival —
+ * a transition applying after a newer Today/strip/history navigation — must
+ * not restore it.
+ */
+
+const ARRIVAL = '0:1:2026-07-06'
+const NEXT_ARRIVAL = '0:2:2026-07-06'
+
+function mountSwipeTarget(navigationKey: string) {
+  return renderHook((props: { navigationKey: string }) => useSwipeTarget(props.navigationKey), {
+    initialProps: { navigationKey },
+  })
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('useSwipeTarget', () => {
+  it('starts with no target', () => {
+    const hook = mountSwipeTarget(ARRIVAL)
+    expect(hook.result.current.targetDate).toBeNull()
+  })
+
+  it('follows a target announced by the current arrival', () => {
+    const hook = mountSwipeTarget(ARRIVAL)
+    act(() => hook.result.current.followSwipeTarget('2026-07-07', ARRIVAL))
+    expect(hook.result.current.targetDate).toBe('2026-07-07')
+  })
+
+  it('clears the target on any new arrival', () => {
+    const hook = mountSwipeTarget(ARRIVAL)
+    act(() => hook.result.current.followSwipeTarget('2026-07-07', ARRIVAL))
+
+    // A date-preserving Today tap: only the arrival identity moves.
+    hook.rerender({ navigationKey: NEXT_ARRIVAL })
+
+    expect(hook.result.current.targetDate).toBeNull()
+  })
+
+  it('rejects a target from a superseded arrival', () => {
+    const hook = mountSwipeTarget(ARRIVAL)
+    hook.rerender({ navigationKey: NEXT_ARRIVAL })
+
+    // The old swipe's deferred pointer-up work lands after Today has won.
+    act(() => hook.result.current.followSwipeTarget('2026-07-07', ARRIVAL))
+
+    expect(hook.result.current.targetDate).toBeNull()
+  })
+
+  it('keeps following the arrival that owns the gesture', () => {
+    const hook = mountSwipeTarget(ARRIVAL)
+    act(() => hook.result.current.followSwipeTarget('2026-07-07', ARRIVAL))
+    hook.rerender({ navigationKey: NEXT_ARRIVAL })
+
+    // A fresh swipe under the new arrival is followed again.
+    act(() => hook.result.current.followSwipeTarget('2026-07-05', NEXT_ARRIVAL))
+
+    expect(hook.result.current.targetDate).toBe('2026-07-05')
+  })
+})

--- a/apps/desktop/src/mobile/use-swipe-target.ts
+++ b/apps/desktop/src/mobile/use-swipe-target.ts
@@ -1,0 +1,44 @@
+import { useCallback, useState } from 'react'
+
+interface SwipeTargetState {
+  readonly navigationKey: string
+  readonly date: string | null
+}
+
+export interface SwipeTarget {
+  /** The day an in-flight swipe is heading toward, or `null` when settled. */
+  targetDate: string | null
+  /**
+   * Follow a swipe's pointer-up target. Tagged with the arrival that produced
+   * it: an update from a superseded arrival (a transition applying after a
+   * newer Today/strip/history navigation) is ignored.
+   */
+  followSwipeTarget: (date: string, sourceNavigationKey: string) => void
+}
+
+/**
+ * The calendar strip's optimistic day: a swipe's destination announced at
+ * pointer-up, followed while the snap animation plays instead of waiting for
+ * the settle-time route change (extracted from MobileDaily).
+ *
+ * The target is scoped to the router arrival that created it. Any new arrival
+ * — the swipe's own settle, a Today tap, a strip tap, history — changes
+ * `navigationKey` and clears the target during render, so stale transition
+ * state never reaches a frame; a stale `followSwipeTarget` from the old
+ * arrival cannot restore it.
+ */
+export function useSwipeTarget(navigationKey: string): SwipeTarget {
+  const [swipeTarget, setSwipeTarget] = useState<SwipeTargetState>(() => ({
+    navigationKey,
+    date: null,
+  }))
+  if (swipeTarget.navigationKey !== navigationKey) {
+    setSwipeTarget({ navigationKey, date: null })
+  }
+  const followSwipeTarget = useCallback((date: string, sourceNavigationKey: string): void => {
+    setSwipeTarget((current) =>
+      current.navigationKey === sourceNavigationKey ? { ...current, date } : current,
+    )
+  }, [])
+  return { targetDate: swipeTarget.date, followSwipeTarget }
+}


### PR DESCRIPTION
## Problem

The iOS daily carousel publishes its swipe destination at pointer-up so the calendar strip can follow the gesture before the route changes. That made the fading Today button interactive while the app was still semantically on Today.

If Today was tapped before the swipe settled, the tap became a same-route arrival. The carousel did not horizontally resync because the date prop was unchanged, so the older swipe could settle afterward and navigate to the other day. Delayed transition work could also restore stale calendar chrome.

## Before -> After

| Before | After |
| --- | --- |
| Tapping Today during an in-flight swipe could still land on the swipe destination. | The Today arrival immediately cancels the pending horizontal snap and remains on Today. |
| Optimistic swipe state could outlive the route arrival that created it. | Swipe state is scoped to its router arrival and stale updates are ignored. |
| The test fake skipped Embla instant-jump event re-entrancy. | Regression coverage models the real settle-before-select ordering. |

## Changes

1. Give each mobile daily arrival an identity derived from the router entry, arrival sequence, and resolved date.
2. Tag optimistic carousel selection and calendar-strip target state with that identity so a newer Today, strip, history, or date-link arrival is authoritative.
3. Force a layout-time carousel sync for same-date arrivals, while invalidating the old Embla listener before the instant jump. This handles Embla 8.6 emitting a stale settle event before updating the selected index.
4. Add regression coverage for select -> Today -> re-entrant instant jump -> later settle, while retaining the ordinary swipe, route echo, external selection, and window re-centering assertions.

## Tests

- The Today regression test aims the carousel away from Today, delivers a same-date arrival before settle, and verifies the route, chrome target, and selected slide remain on Today through both synchronous and later settle events.
- Existing mobile screen coverage verifies settled calendar selection and Today behavior end to end.

## Verification

- `pnpm --filter @reflect/desktop test --run src/mobile/use-day-carousel.test.ts src/mobile/mobile-screen.test.tsx` — 44 tests passed.
- `pnpm check` — passed. Existing max-lines warnings remain in `graph-provider.tsx` and `indexer.ts`.
- `pnpm build` — passed. Existing missing-Sentry-token and large-chunk warnings remain.

## Risk / Rollout

Localized to mobile daily navigation state; there are no data, persistence, migration, or native-shell changes. Today remains immediately interactive during its fade-in, but now acts as a reliable cancellation gesture for an in-flight day swipe.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mobile daily navigation and Embla event ordering; localized to the daily surface with regression tests, but gesture/route sync bugs are user-visible.
> 
> **Overview**
> Fixes a race where **tapping Today while a day swipe was still snapping** could leave the app on the swipe destination because same-date arrivals skipped carousel resync and stale Embla/transition work could still win.
> 
> **Router arrival identity** (`entryId:arrivalSeq:date`) now scopes optimistic swipe state. Carousel selection and calendar-strip targets are tagged with that key; newer arrivals (Today, strip, history) supersede in-flight gestures, and `onTarget` callbacks from an old arrival are ignored.
> 
> **`useDayCarousel`** adds `forceScroll` when the navigation key changes but `date` does not, forcing an instant horizontal sync to cancel a pending snap. Embla listeners check the latest key so re-entrant `settle`/`select` from Embla 8.6 instant jumps do not publish stale routes or chrome.
> 
> **`useSwipeTarget`** replaces inline `targetDate` state in `MobileDaily`, clearing the strip’s optimistic day on any new arrival and rejecting late updates from superseded keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1337c4f5bc61f75076d7c7ce5516c5d17c91410. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved day carousel synchronization during navigation and swipe interactions.
  * Prevented stale swipe updates from older navigation states from affecting the current date.
  * Ensured canceled swipes and “Today” navigation settle on the correct day without duplicate updates.
  * Improved handling of same-date navigation arrivals that require the carousel to scroll.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->