### PR TITLE
feat(desktop): open calendar days and selected notes in new windows

### DIFF
--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -1,4 +1,4 @@
-//! Secondary note windows (⌘-click a note link → its own window, Plan 06).
+//! Secondary note windows (modifier-click or command → its own window, Plan 06).
 //!
 //! The shell owns *creation* only: one window per deep-link target, deduped
 //! by a content-addressed label, plus the one-shot bootstrap a secondary

--- a/apps/desktop/src/components/context-sidebar/daily-context-sidebar.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/daily-context-sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -124,6 +124,29 @@ describe('DailyContextSidebar calendar', () => {
     fireEvent.click(day, { metaKey: true })
 
     await waitFor(() => expect(view.getByTestId('route').textContent).toContain('2026-06-18'))
+    view.unmount()
+  })
+
+  it('does not let a stale failed window open overwrite newer day navigation', async () => {
+    let finishOpen: ((opened: boolean) => void) | null = null
+    openRouteInNewWindow.mockReturnValue(
+      new Promise((resolve) => {
+        finishOpen = resolve
+      }),
+    )
+    const view = renderSidebar('2026-06-09')
+    const firstDay = view.getByRole('button', { name: formatDayLabel('2026-06-18', 'mdy') })
+    const newerDay = view.getByRole('button', { name: formatDayLabel('2026-06-19', 'mdy') })
+
+    fireEvent.click(firstDay, { metaKey: true })
+    fireEvent.click(newerDay)
+    expect(view.getByTestId('route').textContent).toContain('2026-06-19')
+
+    await act(async () => {
+      finishOpen?.(false)
+    })
+
+    expect(view.getByTestId('route').textContent).toContain('2026-06-19')
     view.unmount()
   })
 

--- a/apps/desktop/src/components/context-sidebar/daily-context-sidebar.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/daily-context-sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -14,12 +14,17 @@ const dailyDatesInRange = vi.hoisted(() => vi.fn())
 const relatedNotes = vi.hoisted(() => vi.fn())
 const readNote = vi.hoisted(() => vi.fn())
 const useNoteRow = vi.hoisted(() => vi.fn<(path: string) => NoteRow | null>(() => null))
+const openRouteInNewWindow = vi.hoisted(() => vi.fn<() => Promise<boolean>>())
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   hasBridge: () => true,
   dailyDatesInRange,
   readNote,
   relatedNotes,
+}))
+vi.mock('@/lib/windows/open-in-new-window', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/windows/open-in-new-window')>()),
+  openRouteInNewWindow,
 }))
 vi.mock('@/hooks/use-note-row', () => ({ useNoteRow }))
 vi.mock('@/providers/graph-provider', () => ({
@@ -70,6 +75,7 @@ beforeEach(() => {
   readNote.mockReset().mockResolvedValue('- daily entry\n')
   relatedNotes.mockReset().mockResolvedValue([])
   useNoteRow.mockReset().mockReturnValue(null)
+  openRouteInNewWindow.mockReset().mockResolvedValue(true)
 })
 
 afterEach(cleanup)
@@ -94,6 +100,30 @@ describe('DailyContextSidebar calendar', () => {
 
     await userEvent.click(view.getByRole('button', { name: formatDayLabel('2026-06-18', 'mdy') }))
     expect(view.getByTestId('route').textContent).toContain('2026-06-18')
+    view.unmount()
+  })
+
+  it('opens a day in a new window on ⌘-click without moving the current window', async () => {
+    const view = renderSidebar('2026-06-09')
+    const day = view.getByRole('button', { name: formatDayLabel('2026-06-18', 'mdy') })
+
+    fireEvent.click(day, { metaKey: true })
+
+    await waitFor(() =>
+      expect(openRouteInNewWindow).toHaveBeenCalledWith({ kind: 'daily', date: '2026-06-18' }),
+    )
+    expect(view.getByTestId('route').textContent).toBe(JSON.stringify({ kind: 'today' }))
+    view.unmount()
+  })
+
+  it('falls back to in-window day navigation when a new window cannot open', async () => {
+    openRouteInNewWindow.mockResolvedValue(false)
+    const view = renderSidebar('2026-06-09')
+    const day = view.getByRole('button', { name: formatDayLabel('2026-06-18', 'mdy') })
+
+    fireEvent.click(day, { metaKey: true })
+
+    await waitFor(() => expect(view.getByTestId('route').textContent).toContain('2026-06-18'))
     view.unmount()
   })
 

--- a/apps/desktop/src/components/context-sidebar/day-calendar.tsx
+++ b/apps/desktop/src/components/context-sidebar/day-calendar.tsx
@@ -1,4 +1,11 @@
-import { useMemo, useState, type ReactElement } from 'react'
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent,
+  type ReactElement,
+} from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { dailyDatesInRange, hasBridge, type WeekStartDay } from '@reflect/core'
 import { CalendarIcon } from '@/components/icons/calendar-icon'
@@ -17,6 +24,7 @@ import {
 } from '@/lib/month-grid'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { cn } from '@/lib/utils'
+import { isNewWindowClick, openRouteInNewWindow } from '@/lib/windows/open-in-new-window'
 import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
 import { useRouter } from '@/routing/router'
@@ -44,8 +52,9 @@ const HEADER_BUTTON_CLASS =
  * on a grey one), and days that already have a daily note carry a dot marker
  * revealed while the pointer is over the calendar (an indexed `dailyDate`
  * row — daily files exist only once written, so a row means real content).
- * Clicking a day navigates to it; the month view follows the selected day,
- * and the calendar glyph between the month arrows jumps back to today.
+ * Clicking a day navigates to it; modifier-clicking opens that daily note in
+ * a secondary window. The month view follows the selected day, and the
+ * calendar glyph between the month arrows jumps back to today.
  */
 export function DayCalendar({ selectedDate, today }: DayCalendarProps): ReactElement {
   const { navigate } = useRouter()
@@ -54,6 +63,30 @@ export function DayCalendar({ selectedDate, today }: DayCalendarProps): ReactEle
   const weekStartsOn = toWeekStartsOn(settings.weekStartDay)
 
   const [month, setMonth] = useState(() => monthOf(selectedDate))
+  // A failed native open falls back after an await. If the calendar has
+  // disappeared meanwhile, that late fallback must not pull the user back to
+  // a day they already left.
+  const unmountedRef = useRef(false)
+  useEffect(() => {
+    unmountedRef.current = false
+    return () => {
+      unmountedRef.current = true
+    }
+  }, [])
+
+  function openDate(date: string, event: MouseEvent<HTMLButtonElement>): void {
+    const route = { kind: 'daily', date } as const
+    if (isNewWindowClick(event)) {
+      void openRouteInNewWindow(route).then((opened) => {
+        if (!opened && !unmountedRef.current) {
+          navigate(route)
+        }
+      })
+      return
+    }
+    navigate(route)
+  }
+
   // Render-time state adjustment (not an effect): navigating to another day
   // re-anchors the visible month before the stale grid can paint.
   const [lastSelected, setLastSelected] = useState(selectedDate)
@@ -138,7 +171,7 @@ export function DayCalendar({ selectedDate, today }: DayCalendarProps): ReactEle
                     aria-label={formatDayLabel(cell.date, settings.dateFormat)}
                     aria-current={isToday ? 'date' : undefined}
                     aria-pressed={isSelected}
-                    onClick={() => navigate({ kind: 'daily', date: cell.date })}
+                    onClick={(event) => openDate(cell.date, event)}
                     className={cn(
                       'relative cursor-default py-1.5 text-xs',
                       // Today stays fully visible even as an adjacent-month

--- a/apps/desktop/src/components/context-sidebar/day-calendar.tsx
+++ b/apps/desktop/src/components/context-sidebar/day-calendar.tsx
@@ -57,28 +57,41 @@ const HEADER_BUTTON_CLASS =
  * calendar glyph between the month arrows jumps back to today.
  */
 export function DayCalendar({ selectedDate, today }: DayCalendarProps): ReactElement {
-  const { navigate } = useRouter()
+  const { navigate, arrivalSeq, entryId } = useRouter()
   const { graph } = useGraph()
   const { settings } = useSettings()
   const weekStartsOn = toWeekStartsOn(settings.weekStartDay)
 
   const [month, setMonth] = useState(() => monthOf(selectedDate))
-  // A failed native open falls back after an await. If the calendar has
-  // disappeared meanwhile, that late fallback must not pull the user back to
-  // a day they already left.
+  // A failed native open falls back after an await. Only the latest unchanged
+  // navigation intent may do that; otherwise a late failure could pull the
+  // user back to a day they already left.
   const unmountedRef = useRef(false)
+  const latestOpenRequestRef = useRef(0)
+  const navigationStateRef = useRef({ arrivalSeq, entryId, selectedDate })
   useEffect(() => {
     unmountedRef.current = false
     return () => {
       unmountedRef.current = true
     }
   }, [])
+  useEffect(() => {
+    navigationStateRef.current = { arrivalSeq, entryId, selectedDate }
+  }, [arrivalSeq, entryId, selectedDate])
 
   function openDate(date: string, event: MouseEvent<HTMLButtonElement>): void {
     const route = { kind: 'daily', date } as const
+    const request = ++latestOpenRequestRef.current
     if (isNewWindowClick(event)) {
+      const navigationState = navigationStateRef.current
       void openRouteInNewWindow(route).then((opened) => {
-        if (!opened && !unmountedRef.current) {
+        const currentNavigationState = navigationStateRef.current
+        const isLatestIntent = latestOpenRequestRef.current === request
+        const navigationIsUnchanged =
+          currentNavigationState.arrivalSeq === navigationState.arrivalSeq &&
+          currentNavigationState.entryId === navigationState.entryId &&
+          currentNavigationState.selectedDate === navigationState.selectedDate
+        if (!opened && !unmountedRef.current && isLatestIntent && navigationIsUnchanged) {
           navigate(route)
         }
       })

--- a/apps/desktop/src/components/note-window-content.tsx
+++ b/apps/desktop/src/components/note-window-content.tsx
@@ -9,10 +9,9 @@ import { useSettings } from '@/providers/settings-provider'
 import { useRouter } from '@/routing/router'
 
 /**
- * A secondary note window's whole surface (⌘-click → new window): the routed
- * view, full-bleed — no workspace sidebar, no context panel, no palette or
- * dialogs. A note window is an editing surface; every other affordance lives
- * in the main window.
+ * A secondary note window's whole surface: the routed view, full-bleed — no
+ * workspace sidebar, context panel, palette, or dialogs. A note window is an
+ * editing surface; every other affordance lives in the main window.
  *
  * Daily targets render as a **single note pane**, not the daily stream: this
  * window shows the one note that was ⌘-clicked, so a daily source is treated

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -20,6 +20,7 @@ const getNote = vi.hoisted(() => vi.fn<() => Promise<NoteRow | undefined>>(async
 const getPinnedNotes = vi.hoisted(() => vi.fn<() => Promise<PinnedNote[]>>(async () => []))
 const hasBridge = vi.hoisted(() => vi.fn(() => true))
 const toggleDevtools = vi.hoisted(() => vi.fn(async () => undefined))
+const openRouteInNewWindow = vi.hoisted(() => vi.fn<() => Promise<boolean>>())
 const operationFail = vi.hoisted(() => vi.fn())
 const startOperation = vi.hoisted(() =>
   vi.fn(() => ({ progress: vi.fn(), done: vi.fn(), fail: operationFail })),
@@ -31,6 +32,7 @@ vi.mock('@/lib/semantic', async (importOriginal) => ({
 vi.mock('@/lib/note-pin', () => ({ toggleNotePinned }))
 vi.mock('@/lib/note-private', () => ({ toggleNotePrivate }))
 vi.mock('@/lib/note-deep-link', () => ({ runCopyDeepLink }))
+vi.mock('@/lib/windows/open-in-new-window', () => ({ openRouteInNewWindow }))
 vi.mock('@/lib/operations', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/operations')>()),
   startOperation,
@@ -123,6 +125,10 @@ describe('keybindingFor', () => {
 
   it('note.copyDeepLink keeps the V1 copy-link shortcut', () => {
     expect(keybindingFor('note.copyDeepLink')).toBe('Alt-Mod-l')
+  })
+
+  it('note.openInNewWindow uses the system-level open-window shortcut', () => {
+    expect(keybindingFor('note.openInNewWindow')).toBe('Mod-Shift-o')
   })
 
   it('graph switch commands use macOS command-number bindings', () => {
@@ -224,6 +230,29 @@ describe('app commands', () => {
     })
     await command('note.new').run(context)
     expect(clearScrollState).not.toHaveBeenCalled()
+  })
+
+  it('note.openInNewWindow opens the selected note, including the focused daily note', async () => {
+    openRouteInNewWindow.mockReset().mockResolvedValue(true)
+    const { context } = fakeContext({ route: () => ({ kind: 'note', path: 'notes/a.md' }) })
+    await command('note.openInNewWindow').run(context)
+    expect(openRouteInNewWindow).toHaveBeenLastCalledWith({
+      kind: 'note',
+      path: 'notes/a.md',
+    })
+
+    const { context: focusedDaily } = fakeContext({
+      notePath: () => 'daily/2026-06-18.md',
+    })
+    await command('note.openInNewWindow').run(focusedDaily)
+    expect(openRouteInNewWindow).toHaveBeenLastCalledWith({ kind: 'daily', date: '2026-06-18' })
+  })
+
+  it('note.openInNewWindow is inert on a screen with no selected note', async () => {
+    openRouteInNewWindow.mockReset().mockResolvedValue(true)
+    const { context } = fakeContext({ route: () => ({ kind: 'settings' }) })
+    await command('note.openInNewWindow').run(context)
+    expect(openRouteInNewWindow).not.toHaveBeenCalled()
   })
 
   it('note.random navigates to the picked note and no-ops on an empty graph', async () => {

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -14,7 +14,8 @@ import { toggleNotePinned } from '@/lib/note-pin'
 import { toggleNotePrivate } from '@/lib/note-private'
 import { startOperation } from '@/lib/operations'
 import { rebuildIndexVisibly } from '@/lib/rebuild-index'
-import { type Route } from '@/routing/route'
+import { openRouteInNewWindow } from '@/lib/windows/open-in-new-window'
+import { routeForPath, type Route } from '@/routing/route'
 import { registerCommands } from './registry'
 import type { AppCommand, CommandContext } from './types'
 
@@ -93,6 +94,22 @@ const APP_COMMANDS: AppCommand[] = [
     keywords: ['create'],
     keybinding: 'Mod-n',
     run: openNewNote,
+  },
+  {
+    id: 'note.openInNewWindow',
+    title: 'Open note in new window',
+    keywords: ['window', 'duplicate', 'pop out'],
+    keybinding: 'Mod-Shift-o',
+    // `notePath` follows the focused day inside the daily stream. Converting
+    // that path back to a route also canonicalizes Today to a dated daily
+    // link, so every way of opening the day dedupes to the same window.
+    run: async (context) => {
+      const path = context.notePath()
+      if (path === null) {
+        return
+      }
+      await openRouteInNewWindow(routeForPath(path))
+    },
   },
   {
     id: 'chat.open',

--- a/apps/desktop/src/lib/native-menu/menu.test.ts
+++ b/apps/desktop/src/lib/native-menu/menu.test.ts
@@ -1,6 +1,39 @@
-import { describe, expect, it } from 'vitest'
-import { APP_COMMANDS, keybindingFor } from '@/lib/commands/app-commands'
-import { appMenuLayout } from './menu'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const isTauri = vi.hoisted(() => vi.fn(() => true))
+const isMainWindow = vi.hoisted(() => vi.fn(() => true))
+const setAsAppMenu = vi.hoisted(() => vi.fn(async () => null))
+const setAsWindowsMenuForNSApp = vi.hoisted(() => vi.fn(async () => {}))
+const setAsHelpMenuForNSApp = vi.hoisted(() => vi.fn(async () => {}))
+const submenuNew = vi.hoisted(() =>
+  vi.fn(async () => ({ setAsWindowsMenuForNSApp, setAsHelpMenuForNSApp })),
+)
+const menuNew = vi.hoisted(() => vi.fn(async () => ({ setAsAppMenu })))
+
+vi.mock('@tauri-apps/api/core', () => ({ isTauri }))
+vi.mock('@tauri-apps/api/menu', () => ({
+  Menu: { new: menuNew },
+  Submenu: { new: submenuNew },
+}))
+vi.mock('@/lib/windows/window-role', () => ({ isMainWindow }))
+
+const { APP_COMMANDS, keybindingFor } = await import('@/lib/commands/app-commands')
+const { appMenuLayout, installNativeMenu } = await import('./menu')
+
+beforeEach(() => {
+  vi.stubGlobal('navigator', { userAgent: 'Macintosh', maxTouchPoints: 0 })
+  isTauri.mockReset().mockReturnValue(true)
+  isMainWindow.mockReset().mockReturnValue(true)
+  submenuNew.mockClear()
+  menuNew.mockClear()
+  setAsAppMenu.mockClear()
+  setAsWindowsMenuForNSApp.mockClear()
+  setAsHelpMenuForNSApp.mockClear()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 function referencedCommandIds(): string[] {
   return appMenuLayout().flatMap((submenu) =>
@@ -41,5 +74,27 @@ describe('appMenuLayout', () => {
   it('lists each command at most once across the whole menu', () => {
     const referenced = referencedCommandIds()
     expect(new Set(referenced).size).toBe(referenced.length)
+  })
+
+  it('exposes the selected note’s new-window shortcut in the native Window menu', () => {
+    const windowMenu = appMenuLayout().find((submenu) => submenu.text === 'Window')
+    expect(windowMenu?.entries).toContainEqual({
+      kind: 'command',
+      commandId: 'note.openInNewWindow',
+      text: undefined,
+    })
+    expect(keybindingFor('note.openInNewWindow')).toBe('Mod-Shift-o')
+  })
+})
+
+describe('installNativeMenu', () => {
+  it('leaves the main window’s app-wide menu intact when a note window boots', async () => {
+    isMainWindow.mockReturnValue(false)
+
+    await installNativeMenu()
+
+    expect(isMainWindow).toHaveBeenCalledTimes(1)
+    expect(submenuNew).not.toHaveBeenCalled()
+    expect(menuNew).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/lib/native-menu/menu.ts
+++ b/apps/desktop/src/lib/native-menu/menu.ts
@@ -6,6 +6,7 @@ import {
   type PredefinedMenuItemOptions,
 } from '@tauri-apps/api/menu'
 import { APP_COMMANDS } from '@/lib/commands/app-commands'
+import { isMainWindow } from '@/lib/windows/window-role'
 import { bindingToAccelerator } from './accelerator'
 import { dispatchMenuCommand } from './dispatch'
 
@@ -112,6 +113,8 @@ export function appMenuLayout(): AppSubmenuLayout[] {
       text: 'Window',
       nsAppRole: 'windows',
       entries: [
+        command('note.openInNewWindow'),
+        separator(),
         predefined('Minimize'),
         predefined('Maximize', 'Zoom'),
         separator(),
@@ -172,7 +175,10 @@ function isMacosDesktop(): boolean {
  * so a focused webview never double-fires a command.
  */
 export async function installNativeMenu(): Promise<void> {
-  if (!isMacosDesktop()) {
+  // Menu actions use channels owned by the webview that created them. A note
+  // window has no command dispatcher, so it must not replace the app-wide
+  // menu installed by the main workspace with an inert copy.
+  if (!isMacosDesktop() || !isMainWindow()) {
     return
   }
   const layouts = appMenuLayout()

--- a/apps/desktop/src/lib/windows/open-in-new-window.ts
+++ b/apps/desktop/src/lib/windows/open-in-new-window.ts
@@ -5,11 +5,11 @@ import { isMobileSurface } from '@/lib/platform-surface'
 import type { Route } from '@/routing/route'
 
 /**
- * ⌘-click → open the target in a secondary note window (Plan 06). The
- * helpers resolve a route or an in-note `reflect://` link to the shell's
- * `open_note_window` command; callers fall back to in-window navigation
- * whenever a helper answers false, so the modifier can never make a link do
- * nothing.
+ * Open a target in a secondary note window (Plan 06). Modifier-click callers
+ * and the selected-note command resolve a route or an in-note `reflect://`
+ * link to the shell's `open_note_window` command. Modifier-click callers fall
+ * back to in-window navigation whenever a helper answers false, so the
+ * modifier can never make a link do nothing.
  */
 
 /** The modifier shape shared by native and React synthetic mouse events. */
@@ -35,8 +35,8 @@ export function isNewWindowClick(event: NewWindowClickEvent | undefined): boolea
 /**
  * Open `route` in a secondary note window. False — never a throw — when this
  * surface can't (no shell, mobile, a route the deep-link grammar doesn't
- * name, or a failed command): the caller then navigates in place, so a
- * modifier click degrades to a plain one instead of doing nothing.
+ * name, or a failed command). Modifier-click callers then navigate in place,
+ * so the gesture degrades to a plain click instead of doing nothing.
  */
 export async function openRouteInNewWindow(route: Route): Promise<boolean> {
   if (!hasBridge() || isMobileSurface()) {

--- a/apps/desktop/src/lib/windows/window-role.ts
+++ b/apps/desktop/src/lib/windows/window-role.ts
@@ -4,7 +4,7 @@ import { hasBridge } from '@reflect/core'
 /**
  * Which window this webview is: the main window (the config-declared `main`
  * label — also what plain-browser dev and mobile report) or a secondary
- * `note-*` window opened by ⌘-clicking a note link.
+ * `note-*` window opened by a modifier click or command.
  *
  * Secondary windows *adopt* the main window's graph session and run none of
  * the app-wide singletons — the index writer, sync/backup, the capture

--- a/apps/desktop/src/routing/app-shortcuts.test.tsx
+++ b/apps/desktop/src/routing/app-shortcuts.test.tsx
@@ -12,6 +12,9 @@ import { RouterProvider, useRouter } from './router'
 
 const newChat = vi.hoisted(() => vi.fn())
 const openRecent = vi.hoisted(() => vi.fn())
+const openRouteInNewWindow = vi.hoisted(() => vi.fn(async () => true))
+
+vi.mock('@/lib/windows/open-in-new-window', () => ({ openRouteInNewWindow }))
 
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({
@@ -45,6 +48,7 @@ registerAppCommands() // production does this in main.tsx
 afterEach(() => {
   cleanup()
   openRecent.mockClear()
+  openRouteInNewWindow.mockClear()
 })
 
 function shortcutsHook() {
@@ -95,6 +99,7 @@ describe('app shortcuts', () => {
       'Mod-Shift-a',
       'Mod-n',
       'Mod-Shift-n',
+      'Mod-Shift-o',
       'Mod-[',
       'Mod-]',
       'Mod-k',
@@ -135,6 +140,17 @@ describe('app shortcuts', () => {
     act(() => press('['))
     expect(result.current.router.route).toEqual({ kind: 'today' })
     expect(result.current.router.savedScroll()).toBeNull()
+  })
+
+  it('⌘⇧O opens the current note in a new window', () => {
+    const { result } = shortcutsHook()
+    act(() => press('n'))
+    const opened = result.current.router.route
+
+    act(() => press('o', { shiftKey: true }))
+
+    expect(openRouteInNewWindow).toHaveBeenCalledWith(opened)
+    expect(result.current.router.route).toEqual(opened)
   })
 
   it('⌘[ and ⌘] still traverse when the focused editor consumes the keydown', () => {

--- a/docs/multi-window.md
+++ b/docs/multi-window.md
@@ -48,15 +48,20 @@ under every window at once.
 
 ## Opening a window
 
-1. A modifier click (`isNewWindowClick` — **mouse events only**: meowdown
-   also fires link handlers for Mod-Enter keyboard follows, whose modifier
-   is held by definition) resolves the target as usual, then calls
-   `openRouteInNewWindow` / `openDeepLinkInNewWindow`
-   (`src/lib/windows/open-in-new-window.ts`). Routes serialize through the
-   existing deep-link grammar (`deepLinkForRoute`); capture links (`append`,
-   `task`) are writes, not places, and never window-ify. Any declined or
-   failed open falls back to in-window navigation, so the modifier can never
-   make a link do nothing.
+1. A new-window intent comes from modifier-clicking a note link on any note
+   surface, modifier-clicking a calendar day in the main workspace, or running
+   the main workspace's `note.openInNewWindow` command with
+   Cmd/Ctrl+Shift+O. `isNewWindowClick` applies to **mouse events only**:
+   meowdown also fires link handlers for Mod-Enter keyboard follows, whose
+   modifier is held by definition. The command targets
+   `CommandContext.notePath()`, which follows the focused day inside the daily
+   stream as well as ordinary note routes, and is also exposed in the native
+   Window menu. All three paths call `openRouteInNewWindow` /
+   `openDeepLinkInNewWindow` (`src/lib/windows/open-in-new-window.ts`). Routes
+   serialize through the existing deep-link grammar (`deepLinkForRoute`);
+   capture links (`append`, `task`) are writes, not places, and never
+   window-ify. Any declined or failed modifier-click open falls back to
+   in-window navigation, so the modifier can never make a click do nothing.
 2. `open_note_window` (`src-tauri/src/windows.rs`) refuses without an open
    graph or while a quit is in flight, dedupes by label (see
    [Focus & re-navigation](#focus--re-navigation)), stores the deep link in
@@ -160,6 +165,10 @@ can contend; the writer connection carries a 5s `busy_timeout`
   eventual alternative if that usage ever matters.
 - The same note open in two windows converges through the existing
   external-change reconciliation, the same path an iCloud edit takes.
+- The native macOS application menu is installed by the main window only.
+  Menu action channels belong to the webview that creates them; letting a
+  chrome-free note window replace the app-wide menu would leave command items
+  with no `useAppShortcuts` dispatcher.
 - A note window's settings screen shows sync as loading (its controller is
   deliberately inert).
 - **Settings are effectively main-window-owned.** Note windows mount no


### PR DESCRIPTION
## Problem

Secondary note windows already existed for note links, but two high-frequency paths could not use them:

- Clicking a day in the calendar always navigated the current workspace, even with Command held.
- There was no keyboard or native-menu command for opening the note currently selected in the main workspace. In the Daily stream, that matters because the selected note can be a focused day different from the routed day.

The native macOS application menu also initialized in every webview. Since menu actions are channel-bound to the webview that creates them, opening a chrome-free note window could replace the main window's working command menu with an inert copy.

## Before -> After

| Surface | Before | After |
| --- | --- | --- |
| Calendar day | Always navigates in place | Command-click opens that daily note in a secondary window |
| Selected note | No new-window command | `Cmd+Shift+O` opens the selected/focused note in a secondary window |
| Native Window menu | No note-window action | “Open note in new window” uses the same registered command and accelerator |
| Note-window boot | Could replace the app-wide menu with inert action channels | Leaves the main-owned native menu intact |

## Changes

1. **Calendar modifier-click**
   - `DayCalendar` now routes Command-click (and Ctrl-click off macOS) through the existing `openRouteInNewWindow` helper.
   - A declined or failed native open falls back to normal in-window navigation.
   - The async fallback is guarded by component lifetime, router arrival/entry state, selected date, and request order. A late failure cannot overwrite a newer day choice or navigation.

2. **Selected-note command**
   - Adds `note.openInNewWindow` with `Mod-Shift-o` to the central app command registry.
   - Targets `CommandContext.notePath()`, so Daily uses the focused stream day rather than only the routed date.
   - Converts the path with `routeForPath`, preserving daily-note presentation and deduping every route to the same window target.
   - The registry automatically exposes the command in the command palette and shortcut sheet; the native Window menu uses the same command and accelerator.

3. **Native menu ownership**
   - Only the main webview installs the app-wide macOS menu, preventing secondary note windows (which intentionally mount no command dispatcher) from replacing its action channels.

4. **Coverage and architecture docs**
   - Adds calendar open/fallback/stale-request cases, command routing/no-op cases, keyboard dispatch, native-menu layout, and note-window menu-ownership coverage.
   - Updates the multi-window architecture and nearby comments for all supported opening paths.

## Tests

- Command-clicking a calendar day opens the exact daily route without moving the current window.
- A failed calendar window open falls back to in-window daily navigation only when its request is still current.
- A deferred failed open cannot overwrite a newer plain-click day navigation.
- `note.openInNewWindow` canonicalizes ordinary and focused-daily paths and no-ops when no note is selected.
- `Cmd+Shift+O` dispatches through the app shortcut registry.
- The native Window menu references the command, and secondary webviews do not reinstall the app-wide menu.

## Verification

- `pnpm --filter @reflect/desktop test --run src/components/context-sidebar/daily-context-sidebar.test.tsx src/lib/commands/app-commands.test.ts src/routing/app-shortcuts.test.tsx src/lib/native-menu/menu.test.ts src/lib/windows/open-in-new-window.test.ts` — 5 files, 83 tests passed.
- `pnpm check` — passed; only the two pre-existing `max-lines` warnings remain.
- `cargo fmt --check` — passed.
- `git diff --check` — passed.

## Risk / Rollout

Low. This reuses the existing deep-link-based, deduped note-window creation path and changes no persisted data, schema, permissions, or release configuration. Native Tauri window creation and the macOS menu accelerator were not manually smoke-tested in a bundled app; unit coverage pins the routing, command, stale-fallback, and menu-ownership seams.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reuses the existing `openRouteInNewWindow` / Tauri dedupe path with no persistence or auth changes; main risk is untested bundled macOS menu/window smoke behavior.
> 
> **Overview**
> Extends secondary note windows beyond link modifier-clicks: **calendar days** and the **currently selected note** can open in their own window without leaving the main workspace.
> 
> **Day calendar:** Command/Ctrl-click on a day calls `openRouteInNewWindow` instead of in-place navigation; if the native open fails, it falls back to normal navigation, guarded so an unmounted calendar cannot navigate late.
> 
> **`note.openInNewWindow` (`Mod-Shift-o`):** Resolves the target via `CommandContext.notePath()` (including the focused day in the daily stream), converts with `routeForPath`, and reuses the existing deep-link deduped window path. Wired into the palette, shortcut sheet, and native **Window** menu.
> 
> **Native menu:** `installNativeMenu` runs only when `isMainWindow()` is true so note windows do not replace the app menu with channel-bound items that have no dispatcher.
> 
> Docs and comments are updated to describe all three opening paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f695d519eae415d515a1d8b369b3c88e2e81e8d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
