### PR TITLE
feat(desktop): open calendar days in new windows

### DIFF
--- a/apps/desktop/src/components/context-sidebar/daily-context-sidebar.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/daily-context-sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -14,12 +14,17 @@ const dailyDatesInRange = vi.hoisted(() => vi.fn())
 const relatedNotes = vi.hoisted(() => vi.fn())
 const readNote = vi.hoisted(() => vi.fn())
 const useNoteRow = vi.hoisted(() => vi.fn<(path: string) => NoteRow | null>(() => null))
+const openRouteInNewWindow = vi.hoisted(() => vi.fn<() => Promise<boolean>>())
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   hasBridge: () => true,
   dailyDatesInRange,
   readNote,
   relatedNotes,
+}))
+vi.mock('@/lib/windows/open-in-new-window', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/windows/open-in-new-window')>()),
+  openRouteInNewWindow,
 }))
 vi.mock('@/hooks/use-note-row', () => ({ useNoteRow }))
 vi.mock('@/providers/graph-provider', () => ({
@@ -70,6 +75,7 @@ beforeEach(() => {
   readNote.mockReset().mockResolvedValue('- daily entry\n')
   relatedNotes.mockReset().mockResolvedValue([])
   useNoteRow.mockReset().mockReturnValue(null)
+  openRouteInNewWindow.mockReset().mockResolvedValue(true)
 })
 
 afterEach(cleanup)
@@ -94,6 +100,53 @@ describe('DailyContextSidebar calendar', () => {
 
     await userEvent.click(view.getByRole('button', { name: formatDayLabel('2026-06-18', 'mdy') }))
     expect(view.getByTestId('route').textContent).toContain('2026-06-18')
+    view.unmount()
+  })
+
+  it('opens a day in a new window on ⌘-click without moving the current window', async () => {
+    const view = renderSidebar('2026-06-09')
+    const day = view.getByRole('button', { name: formatDayLabel('2026-06-18', 'mdy') })
+
+    fireEvent.click(day, { metaKey: true })
+
+    await waitFor(() =>
+      expect(openRouteInNewWindow).toHaveBeenCalledWith({ kind: 'daily', date: '2026-06-18' }),
+    )
+    expect(view.getByTestId('route').textContent).toBe(JSON.stringify({ kind: 'today' }))
+    view.unmount()
+  })
+
+  it('falls back to in-window day navigation when a new window cannot open', async () => {
+    openRouteInNewWindow.mockResolvedValue(false)
+    const view = renderSidebar('2026-06-09')
+    const day = view.getByRole('button', { name: formatDayLabel('2026-06-18', 'mdy') })
+
+    fireEvent.click(day, { metaKey: true })
+
+    await waitFor(() => expect(view.getByTestId('route').textContent).toContain('2026-06-18'))
+    view.unmount()
+  })
+
+  it('does not let a stale failed window open overwrite newer day navigation', async () => {
+    let finishOpen: ((opened: boolean) => void) | null = null
+    openRouteInNewWindow.mockReturnValue(
+      new Promise((resolve) => {
+        finishOpen = resolve
+      }),
+    )
+    const view = renderSidebar('2026-06-09')
+    const firstDay = view.getByRole('button', { name: formatDayLabel('2026-06-18', 'mdy') })
+    const newerDay = view.getByRole('button', { name: formatDayLabel('2026-06-19', 'mdy') })
+
+    fireEvent.click(firstDay, { metaKey: true })
+    fireEvent.click(newerDay)
+    expect(view.getByTestId('route').textContent).toContain('2026-06-19')
+
+    await act(async () => {
+      finishOpen?.(false)
+    })
+
+    expect(view.getByTestId('route').textContent).toContain('2026-06-19')
     view.unmount()
   })
 

--- a/apps/desktop/src/components/context-sidebar/day-calendar.tsx
+++ b/apps/desktop/src/components/context-sidebar/day-calendar.tsx
@@ -1,4 +1,11 @@
-import { useMemo, useState, type ReactElement } from 'react'
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent,
+  type ReactElement,
+} from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { dailyDatesInRange, hasBridge, type WeekStartDay } from '@reflect/core'
 import { CalendarIcon } from '@/components/icons/calendar-icon'
@@ -17,6 +24,7 @@ import {
 } from '@/lib/month-grid'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { cn } from '@/lib/utils'
+import { isNewWindowClick, openRouteInNewWindow } from '@/lib/windows/open-in-new-window'
 import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
 import { useRouter } from '@/routing/router'
@@ -44,16 +52,54 @@ const HEADER_BUTTON_CLASS =
  * on a grey one), and days that already have a daily note carry a dot marker
  * revealed while the pointer is over the calendar (an indexed `dailyDate`
  * row — daily files exist only once written, so a row means real content).
- * Clicking a day navigates to it; the month view follows the selected day,
- * and the calendar glyph between the month arrows jumps back to today.
+ * Clicking a day navigates to it; modifier-clicking opens that daily note in
+ * a secondary window. The month view follows the selected day, and the
+ * calendar glyph between the month arrows jumps back to today.
  */
 export function DayCalendar({ selectedDate, today }: DayCalendarProps): ReactElement {
-  const { navigate } = useRouter()
+  const { navigate, arrivalSeq, entryId } = useRouter()
   const { graph } = useGraph()
   const { settings } = useSettings()
   const weekStartsOn = toWeekStartsOn(settings.weekStartDay)
 
   const [month, setMonth] = useState(() => monthOf(selectedDate))
+  // A failed native open falls back after an await. Only the latest unchanged
+  // navigation intent may do that; otherwise a late failure could pull the
+  // user back to a day they already left.
+  const unmountedRef = useRef(false)
+  const latestOpenRequestRef = useRef(0)
+  const navigationStateRef = useRef({ arrivalSeq, entryId, selectedDate })
+  useEffect(() => {
+    unmountedRef.current = false
+    return () => {
+      unmountedRef.current = true
+    }
+  }, [])
+  useEffect(() => {
+    navigationStateRef.current = { arrivalSeq, entryId, selectedDate }
+  }, [arrivalSeq, entryId, selectedDate])
+
+  function openDate(date: string, event: MouseEvent<HTMLButtonElement>): void {
+    const route = { kind: 'daily', date } as const
+    const request = ++latestOpenRequestRef.current
+    if (isNewWindowClick(event)) {
+      const navigationState = navigationStateRef.current
+      void openRouteInNewWindow(route).then((opened) => {
+        const currentNavigationState = navigationStateRef.current
+        const isLatestIntent = latestOpenRequestRef.current === request
+        const navigationIsUnchanged =
+          currentNavigationState.arrivalSeq === navigationState.arrivalSeq &&
+          currentNavigationState.entryId === navigationState.entryId &&
+          currentNavigationState.selectedDate === navigationState.selectedDate
+        if (!opened && !unmountedRef.current && isLatestIntent && navigationIsUnchanged) {
+          navigate(route)
+        }
+      })
+      return
+    }
+    navigate(route)
+  }
+
   // Render-time state adjustment (not an effect): navigating to another day
   // re-anchors the visible month before the stale grid can paint.
   const [lastSelected, setLastSelected] = useState(selectedDate)
@@ -138,7 +184,7 @@ export function DayCalendar({ selectedDate, today }: DayCalendarProps): ReactEle
                     aria-label={formatDayLabel(cell.date, settings.dateFormat)}
                     aria-current={isToday ? 'date' : undefined}
                     aria-pressed={isSelected}
-                    onClick={() => navigate({ kind: 'daily', date: cell.date })}
+                    onClick={(event) => openDate(cell.date, event)}
                     className={cn(
                       'relative cursor-default py-1.5 text-xs',
                       // Today stays fully visible even as an adjacent-month

--- a/docs/multi-window.md
+++ b/docs/multi-window.md
@@ -48,9 +48,8 @@ under every window at once.
 
 ## Opening a window
 
-1. A modifier click on a note link or calendar day (`isNewWindowClick` —
-   **mouse events only**: meowdown also fires link handlers for Mod-Enter
-   keyboard follows, whose modifier
+1. A modifier click (`isNewWindowClick` — **mouse events only**: meowdown
+   also fires link handlers for Mod-Enter keyboard follows, whose modifier
    is held by definition) resolves the target as usual, then calls
    `openRouteInNewWindow` / `openDeepLinkInNewWindow`
    (`src/lib/windows/open-in-new-window.ts`). Routes serialize through the

--- a/docs/multi-window.md
+++ b/docs/multi-window.md
@@ -48,8 +48,9 @@ under every window at once.
 
 ## Opening a window
 
-1. A modifier click (`isNewWindowClick` — **mouse events only**: meowdown
-   also fires link handlers for Mod-Enter keyboard follows, whose modifier
+1. A modifier click on a note link or calendar day (`isNewWindowClick` —
+   **mouse events only**: meowdown also fires link handlers for Mod-Enter
+   keyboard follows, whose modifier
    is held by definition) resolves the target as usual, then calls
    `openRouteInNewWindow` / `openDeepLinkInNewWindow`
    (`src/lib/windows/open-in-new-window.ts`). Routes serialize through the


### PR DESCRIPTION
## Problem

The calendar could navigate to a daily note only in the current workspace. Holding Command while clicking a day behaved exactly like a plain click, so the calendar could not participate in Reflect's existing secondary note-window flow.

## Before -> After

| Gesture | Before | After |
| --- | --- | --- |
| Click a calendar day | Navigate in the current workspace | Unchanged |
| Command-click a calendar day | Navigate in the current workspace | Open that daily note in a secondary window |

## Changes

1. `DayCalendar` recognizes modifier clicks with the existing `isNewWindowClick` helper and sends the dated daily route through `openRouteInNewWindow`.
2. If the native window open is unavailable or fails, the gesture falls back to ordinary in-window navigation.
3. The async fallback is guarded by component lifetime, request order, router arrival/entry state, and the selected date. A late failure cannot overwrite a newer day choice or navigation.

## Tests

- Command-click opens the exact daily route without moving the current window.
- A failed window open falls back to in-window daily navigation.
- A deferred failed open cannot overwrite a newer plain-click day navigation.
- Existing calendar navigation, month paging, markers, and sidebar behavior remain covered.

## Verification

- `pnpm --filter @reflect/desktop test --run src/components/context-sidebar/daily-context-sidebar.test.tsx` — 1 file, 14 tests passed.
- `pnpm check` — passed; only the two pre-existing `max-lines` warnings remain.
- `git diff --check` — passed.

## Risk / Rollout

Low. This reuses the existing deep-link-based, deduped note-window creation path and changes no persisted data, schema, permissions, or release configuration. Native Tauri window creation was not manually smoke-tested in a bundled app; unit coverage pins both the success and fallback paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reuses existing note-window opening with no persistence or auth changes; risk is limited to calendar navigation edge cases covered by unit tests.
> 
> **Overview**
> **Command-click on a sidebar calendar day** now opens that daily note in a secondary window via the same `openRouteInNewWindow` path as note links; a normal click still navigates in the current workspace.
> 
> `DayCalendar` routes day clicks through `openDate`, which uses `isNewWindowClick` and only falls back to `navigate` when the native open fails. That async fallback is gated on mount state, the latest open request, and unchanged router arrival/entry/selected date so a late failure cannot override a newer day choice.
> 
> Tests cover successful ⌘-click without moving the current route, failed-open fallback, and the stale-failure race. **multi-window.md** documents calendar days as a modifier-click source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6c6775625f01d7db8160f74ff3825e677ef6add. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
