### PR TITLE
feat(desktop): open the selected note in a new window

### DIFF
--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -1,4 +1,4 @@
-//! Secondary note windows (⌘-click a note link → its own window, Plan 06).
+//! Secondary note windows (modifier-click or command → its own window, Plan 06).
 //!
 //! The shell owns *creation* only: one window per deep-link target, deduped
 //! by a content-addressed label, plus the one-shot bootstrap a secondary
@@ -32,10 +32,10 @@ pub const MAIN_WINDOW_LABEL: &str = "main";
 /// and hash labels would otherwise accrete in the state file forever).
 pub const NOTE_WINDOW_PREFIX: &str = "note-";
 
-/// Event delivered to an existing note window when its target is ⌘-clicked
-/// again: the window may have navigated elsewhere since it opened, so a
-/// focus alone could surface the wrong note — the payload (the deep link)
-/// re-navigates it to the clicked target.
+/// Event delivered when an already-open target is requested again: the window
+/// may have navigated elsewhere since it opened, so a focus alone could
+/// surface the wrong note — the payload (the deep link) re-navigates it to the
+/// requested target.
 const WINDOW_NAVIGATE_EVENT: &str = "window:navigate";
 
 /// Window properties that survive a desktop restart.
@@ -119,8 +119,8 @@ fn lock_init<'a>(
 }
 
 /// The label for a note window addressing `deep_link` — content-addressed so
-/// ⌘-clicking the same target focuses the existing window instead of piling
-/// up duplicates. Stable within a process run, which is all dedupe needs.
+/// reopening the same target focuses the existing window instead of piling up
+/// duplicates. Stable within a process run, which is all dedupe needs.
 fn note_window_label(deep_link: &str) -> String {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     deep_link.hash(&mut hasher);
@@ -129,8 +129,8 @@ fn note_window_label(deep_link: &str) -> String {
 
 /// Surface an already-open window for this target, when one exists: show,
 /// focus, and deliver the link ([`WINDOW_NAVIGATE_EVENT`]) so a window that
-/// has navigated away comes back to the note that was clicked. All
-/// best-effort — a focus that fails must not fail the click.
+/// has navigated away comes back to the note that was requested. All
+/// best-effort — a focus that fails must not fail the open request.
 fn focus_existing(app: &tauri::AppHandle, label: &str, deep_link: &str) -> bool {
     let Some(existing) = app.get_webview_window(label) else {
         return false;
@@ -176,7 +176,7 @@ pub async fn open_note_window(
     }
     // Mid-quit, a new webview would never join the flush handshake's pending
     // set — the armed windows' confirms would exit underneath it. Refuse
-    // (best-effort: the ⌘-click site degrades to in-window navigation).
+    // (best-effort: modifier-click callers degrade to in-window navigation).
     if quit.armed() {
         return Err(AppError::io("the app is quitting"));
     }

--- a/apps/desktop/src/components/note-window-content.tsx
+++ b/apps/desktop/src/components/note-window-content.tsx
@@ -9,15 +9,14 @@ import { useSettings } from '@/providers/settings-provider'
 import { useRouter } from '@/routing/router'
 
 /**
- * A secondary note window's whole surface (⌘-click → new window): the routed
- * view, full-bleed — no workspace sidebar, no context panel, no palette or
- * dialogs. A note window is an editing surface; every other affordance lives
- * in the main window.
+ * A secondary note window's whole surface: the routed view, full-bleed — no
+ * workspace sidebar, context panel, palette, or dialogs. A note window is an
+ * editing surface; every other affordance lives in the main window.
  *
  * Daily targets render as a **single note pane**, not the daily stream: this
- * window shows the one note that was ⌘-clicked, so a daily source is treated
- * like any other note (`lazy` covers a not-yet-created day, same as the
- * stream's placeholder behavior).
+ * window shows the one requested note, so a daily source is treated like any
+ * other note (`lazy` covers a not-yet-created day, same as the stream's
+ * placeholder behavior).
  */
 export function NoteWindowContent(): ReactElement {
   const { route } = useRouter()

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -20,6 +20,7 @@ const getNote = vi.hoisted(() => vi.fn<() => Promise<NoteRow | undefined>>(async
 const getPinnedNotes = vi.hoisted(() => vi.fn<() => Promise<PinnedNote[]>>(async () => []))
 const hasBridge = vi.hoisted(() => vi.fn(() => true))
 const toggleDevtools = vi.hoisted(() => vi.fn(async () => undefined))
+const openRouteInNewWindow = vi.hoisted(() => vi.fn<() => Promise<boolean>>())
 const operationFail = vi.hoisted(() => vi.fn())
 const startOperation = vi.hoisted(() =>
   vi.fn(() => ({ progress: vi.fn(), done: vi.fn(), fail: operationFail })),
@@ -31,6 +32,7 @@ vi.mock('@/lib/semantic', async (importOriginal) => ({
 vi.mock('@/lib/note-pin', () => ({ toggleNotePinned }))
 vi.mock('@/lib/note-private', () => ({ toggleNotePrivate }))
 vi.mock('@/lib/note-deep-link', () => ({ runCopyDeepLink }))
+vi.mock('@/lib/windows/open-in-new-window', () => ({ openRouteInNewWindow }))
 vi.mock('@/lib/operations', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/operations')>()),
   startOperation,
@@ -123,6 +125,10 @@ describe('keybindingFor', () => {
 
   it('note.copyDeepLink keeps the V1 copy-link shortcut', () => {
     expect(keybindingFor('note.copyDeepLink')).toBe('Alt-Mod-l')
+  })
+
+  it('note.openInNewWindow uses the system-level open-window shortcut', () => {
+    expect(keybindingFor('note.openInNewWindow')).toBe('Mod-Shift-o')
   })
 
   it('graph switch commands use macOS command-number bindings', () => {
@@ -224,6 +230,29 @@ describe('app commands', () => {
     })
     await command('note.new').run(context)
     expect(clearScrollState).not.toHaveBeenCalled()
+  })
+
+  it('note.openInNewWindow opens the selected note, including the focused daily note', async () => {
+    openRouteInNewWindow.mockReset().mockResolvedValue(true)
+    const { context } = fakeContext({ route: () => ({ kind: 'note', path: 'notes/a.md' }) })
+    await command('note.openInNewWindow').run(context)
+    expect(openRouteInNewWindow).toHaveBeenLastCalledWith({
+      kind: 'note',
+      path: 'notes/a.md',
+    })
+
+    const { context: focusedDaily } = fakeContext({
+      notePath: () => 'daily/2026-06-18.md',
+    })
+    await command('note.openInNewWindow').run(focusedDaily)
+    expect(openRouteInNewWindow).toHaveBeenLastCalledWith({ kind: 'daily', date: '2026-06-18' })
+  })
+
+  it('note.openInNewWindow is inert on a screen with no selected note', async () => {
+    openRouteInNewWindow.mockReset().mockResolvedValue(true)
+    const { context } = fakeContext({ route: () => ({ kind: 'settings' }) })
+    await command('note.openInNewWindow').run(context)
+    expect(openRouteInNewWindow).not.toHaveBeenCalled()
   })
 
   it('note.random navigates to the picked note and no-ops on an empty graph', async () => {

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -14,7 +14,8 @@ import { toggleNotePinned } from '@/lib/note-pin'
 import { toggleNotePrivate } from '@/lib/note-private'
 import { startOperation } from '@/lib/operations'
 import { rebuildIndexVisibly } from '@/lib/rebuild-index'
-import { type Route } from '@/routing/route'
+import { openRouteInNewWindow } from '@/lib/windows/open-in-new-window'
+import { routeForPath, type Route } from '@/routing/route'
 import { registerCommands } from './registry'
 import type { AppCommand, CommandContext } from './types'
 
@@ -93,6 +94,22 @@ const APP_COMMANDS: AppCommand[] = [
     keywords: ['create'],
     keybinding: 'Mod-n',
     run: openNewNote,
+  },
+  {
+    id: 'note.openInNewWindow',
+    title: 'Open note in new window',
+    keywords: ['window', 'duplicate', 'pop out'],
+    keybinding: 'Mod-Shift-o',
+    // `notePath` follows the focused day inside the daily stream. Converting
+    // that path back to a route also canonicalizes Today to a dated daily
+    // link, so every way of opening the day dedupes to the same window.
+    run: async (context) => {
+      const path = context.notePath()
+      if (path === null) {
+        return
+      }
+      await openRouteInNewWindow(routeForPath(path))
+    },
   },
   {
     id: 'chat.open',

--- a/apps/desktop/src/lib/native-menu/menu.test.ts
+++ b/apps/desktop/src/lib/native-menu/menu.test.ts
@@ -1,6 +1,39 @@
-import { describe, expect, it } from 'vitest'
-import { APP_COMMANDS, keybindingFor } from '@/lib/commands/app-commands'
-import { appMenuLayout } from './menu'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const isTauri = vi.hoisted(() => vi.fn(() => true))
+const isMainWindow = vi.hoisted(() => vi.fn(() => true))
+const setAsAppMenu = vi.hoisted(() => vi.fn(async () => null))
+const setAsWindowsMenuForNSApp = vi.hoisted(() => vi.fn(async () => {}))
+const setAsHelpMenuForNSApp = vi.hoisted(() => vi.fn(async () => {}))
+const submenuNew = vi.hoisted(() =>
+  vi.fn(async () => ({ setAsWindowsMenuForNSApp, setAsHelpMenuForNSApp })),
+)
+const menuNew = vi.hoisted(() => vi.fn(async () => ({ setAsAppMenu })))
+
+vi.mock('@tauri-apps/api/core', () => ({ isTauri }))
+vi.mock('@tauri-apps/api/menu', () => ({
+  Menu: { new: menuNew },
+  Submenu: { new: submenuNew },
+}))
+vi.mock('@/lib/windows/window-role', () => ({ isMainWindow }))
+
+const { APP_COMMANDS, keybindingFor } = await import('@/lib/commands/app-commands')
+const { appMenuLayout, installNativeMenu } = await import('./menu')
+
+beforeEach(() => {
+  vi.stubGlobal('navigator', { userAgent: 'Macintosh', maxTouchPoints: 0 })
+  isTauri.mockReset().mockReturnValue(true)
+  isMainWindow.mockReset().mockReturnValue(true)
+  submenuNew.mockClear()
+  menuNew.mockClear()
+  setAsAppMenu.mockClear()
+  setAsWindowsMenuForNSApp.mockClear()
+  setAsHelpMenuForNSApp.mockClear()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 function referencedCommandIds(): string[] {
   return appMenuLayout().flatMap((submenu) =>
@@ -41,5 +74,27 @@ describe('appMenuLayout', () => {
   it('lists each command at most once across the whole menu', () => {
     const referenced = referencedCommandIds()
     expect(new Set(referenced).size).toBe(referenced.length)
+  })
+
+  it('exposes the selected note’s new-window shortcut in the native Window menu', () => {
+    const windowMenu = appMenuLayout().find((submenu) => submenu.text === 'Window')
+    expect(windowMenu?.entries).toContainEqual({
+      kind: 'command',
+      commandId: 'note.openInNewWindow',
+      text: undefined,
+    })
+    expect(keybindingFor('note.openInNewWindow')).toBe('Mod-Shift-o')
+  })
+})
+
+describe('installNativeMenu', () => {
+  it('leaves the main window’s app-wide menu intact when a note window boots', async () => {
+    isMainWindow.mockReturnValue(false)
+
+    await installNativeMenu()
+
+    expect(isMainWindow).toHaveBeenCalledTimes(1)
+    expect(submenuNew).not.toHaveBeenCalled()
+    expect(menuNew).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/lib/native-menu/menu.ts
+++ b/apps/desktop/src/lib/native-menu/menu.ts
@@ -6,6 +6,7 @@ import {
   type PredefinedMenuItemOptions,
 } from '@tauri-apps/api/menu'
 import { APP_COMMANDS } from '@/lib/commands/app-commands'
+import { isMainWindow } from '@/lib/windows/window-role'
 import { bindingToAccelerator } from './accelerator'
 import { dispatchMenuCommand } from './dispatch'
 
@@ -112,6 +113,8 @@ export function appMenuLayout(): AppSubmenuLayout[] {
       text: 'Window',
       nsAppRole: 'windows',
       entries: [
+        command('note.openInNewWindow'),
+        separator(),
         predefined('Minimize'),
         predefined('Maximize', 'Zoom'),
         separator(),
@@ -172,7 +175,10 @@ function isMacosDesktop(): boolean {
  * so a focused webview never double-fires a command.
  */
 export async function installNativeMenu(): Promise<void> {
-  if (!isMacosDesktop()) {
+  // Menu actions use channels owned by the webview that created them. A note
+  // window has no command dispatcher, so it must not replace the app-wide
+  // menu installed by the main workspace with an inert copy.
+  if (!isMacosDesktop() || !isMainWindow()) {
     return
   }
   const layouts = appMenuLayout()

--- a/apps/desktop/src/lib/windows/open-in-new-window.ts
+++ b/apps/desktop/src/lib/windows/open-in-new-window.ts
@@ -5,11 +5,11 @@ import { isMobileSurface } from '@/lib/platform-surface'
 import type { Route } from '@/routing/route'
 
 /**
- * ⌘-click → open the target in a secondary note window (Plan 06). The
- * helpers resolve a route or an in-note `reflect://` link to the shell's
- * `open_note_window` command; callers fall back to in-window navigation
- * whenever a helper answers false, so the modifier can never make a link do
- * nothing.
+ * Open a target in a secondary note window (Plan 06). Modifier-click callers
+ * and the selected-note command resolve a route or an in-note `reflect://`
+ * link to the shell's `open_note_window` command. Modifier-click callers fall
+ * back to in-window navigation whenever a helper answers false, so the
+ * modifier can never make a link do nothing.
  */
 
 /** The modifier shape shared by native and React synthetic mouse events. */
@@ -35,8 +35,8 @@ export function isNewWindowClick(event: NewWindowClickEvent | undefined): boolea
 /**
  * Open `route` in a secondary note window. False — never a throw — when this
  * surface can't (no shell, mobile, a route the deep-link grammar doesn't
- * name, or a failed command): the caller then navigates in place, so a
- * modifier click degrades to a plain one instead of doing nothing.
+ * name, or a failed command). Modifier-click callers then navigate in place,
+ * so the gesture degrades to a plain click instead of doing nothing.
  */
 export async function openRouteInNewWindow(route: Route): Promise<boolean> {
   if (!hasBridge() || isMobileSurface()) {

--- a/apps/desktop/src/lib/windows/window-role.ts
+++ b/apps/desktop/src/lib/windows/window-role.ts
@@ -4,7 +4,7 @@ import { hasBridge } from '@reflect/core'
 /**
  * Which window this webview is: the main window (the config-declared `main`
  * label — also what plain-browser dev and mobile report) or a secondary
- * `note-*` window opened by ⌘-clicking a note link.
+ * `note-*` window opened by a modifier click or command.
  *
  * Secondary windows *adopt* the main window's graph session and run none of
  * the app-wide singletons — the index writer, sync/backup, the capture

--- a/apps/desktop/src/routing/app-shortcuts.test.tsx
+++ b/apps/desktop/src/routing/app-shortcuts.test.tsx
@@ -12,6 +12,9 @@ import { RouterProvider, useRouter } from './router'
 
 const newChat = vi.hoisted(() => vi.fn())
 const openRecent = vi.hoisted(() => vi.fn())
+const openRouteInNewWindow = vi.hoisted(() => vi.fn(async () => true))
+
+vi.mock('@/lib/windows/open-in-new-window', () => ({ openRouteInNewWindow }))
 
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({
@@ -45,6 +48,7 @@ registerAppCommands() // production does this in main.tsx
 afterEach(() => {
   cleanup()
   openRecent.mockClear()
+  openRouteInNewWindow.mockClear()
 })
 
 function shortcutsHook() {
@@ -95,6 +99,7 @@ describe('app shortcuts', () => {
       'Mod-Shift-a',
       'Mod-n',
       'Mod-Shift-n',
+      'Mod-Shift-o',
       'Mod-[',
       'Mod-]',
       'Mod-k',
@@ -135,6 +140,17 @@ describe('app shortcuts', () => {
     act(() => press('['))
     expect(result.current.router.route).toEqual({ kind: 'today' })
     expect(result.current.router.savedScroll()).toBeNull()
+  })
+
+  it('⌘⇧O opens the current note in a new window', () => {
+    const { result } = shortcutsHook()
+    act(() => press('n'))
+    const opened = result.current.router.route
+
+    act(() => press('o', { shiftKey: true }))
+
+    expect(openRouteInNewWindow).toHaveBeenCalledWith(opened)
+    expect(result.current.router.route).toEqual(opened)
   })
 
   it('⌘[ and ⌘] still traverse when the focused editor consumes the keydown', () => {

--- a/docs/multi-window.md
+++ b/docs/multi-window.md
@@ -1,10 +1,10 @@
 # Multiple windows & cross-window communication
 
-⌘-click a note link — an editor `[[wiki link]]`, a backlink title or snippet,
-an in-note `reflect://` link — and the note opens in its own chrome-free
-window: just the editor with its backlinks, no sidebar, palette, or context
-panel. This document describes how those windows relate to the main window
-and to each other.
+Modifier-click a note link — an editor `[[wiki link]]`, a backlink title or
+snippet, an in-note `reflect://` link — or run the selected-note command, and
+the note opens in its own chrome-free window: just the editor with its
+backlinks, no sidebar, palette, or context panel. This document describes how
+those windows relate to the main window and to each other.
 
 Two ideas carry the whole design:
 
@@ -24,7 +24,7 @@ Two ideas carry the whole design:
 
 The webview's Tauri label decides the role: `main` is the config-declared
 window; note windows get content-addressed `note-<hash(deep link)>` labels
-(so re-⌘-clicking a target finds its window). The frontend reads the role
+(so reopening a target finds its window). The frontend reads the role
 via `isMainWindow()` (`src/lib/windows/window-role.ts`), which treats
 bridge-less environments — browser dev, jsdom, the `?platform=ios` harness —
 as main: they are all single-window.
@@ -47,6 +47,11 @@ opening a graph from a note window would re-root the shared `GraphState`
 under every window at once.
 
 ## Opening a window
+
+The main workspace also exposes `note.openInNewWindow` at Cmd/Ctrl+Shift+O.
+It targets `CommandContext.notePath()`, so the focused day in the daily stream
+and an ordinary routed note both open through the same mechanism described
+below. The command is also exposed in the native Window menu.
 
 1. A modifier click (`isNewWindowClick` — **mouse events only**: meowdown
    also fires link handlers for Mod-Enter keyboard follows, whose modifier
@@ -95,7 +100,7 @@ asymmetry is what each broadcast below exists to bridge.
 | `index:changed` | file watcher (`watcher.rs`) | every window | Open editors reconcile external changes; the main window's indexer applies the batch. Pre-dates multi-window; note windows get editor freshness from it for free. |
 | `index:written` | index write commands after a **committed** write (`db/mod.rs`) | note windows only | Refetch index-backed queries (backlinks, lists). The main window invalidates in-process via its indexer and must not subscribe — it would refetch twice. |
 | `note:moved` | `note_move_indexed` / `index_move` after rows commit | **every** window (`desktop-root.tsx`) | Retarget open sessions + router history after a rename. Renames can originate in any window (a title edit), and a window left behind would resurrect the dead path on its next save. The origin window's in-process handling makes the echo idempotent. |
-| `window:navigate` | `open_note_window` on a dedupe hit (targeted `emit_to`) | that note window | Re-⌘-clicking a target focuses its window *and* re-navigates it there — it may have browsed elsewhere since opening. |
+| `window:navigate` | `open_note_window` on a dedupe hit (targeted `emit_to`) | that note window | Reopening a target focuses its window *and* re-navigates it there — it may have browsed elsewhere since opening. |
 | `app:quit-requested` | the run loop on a deferred ⌘Q (`lib.rs`) | every window | Each window flushes its own dirty buffers, then confirms. |
 
 The write path that ties it together: a note window saves via the ordinary
@@ -160,6 +165,10 @@ can contend; the writer connection carries a 5s `busy_timeout`
   eventual alternative if that usage ever matters.
 - The same note open in two windows converges through the existing
   external-change reconciliation, the same path an iCloud edit takes.
+- The native macOS application menu is installed by the main window only.
+  Menu action channels belong to the webview that creates them; letting a
+  chrome-free note window replace the app-wide menu would leave command items
+  with no `useAppShortcuts` dispatcher.
 - A note window's settings screen shows sync as loading (its controller is
   deliberately inert).
 - **Settings are effectively main-window-owned.** Note windows mount no


### PR DESCRIPTION
## Problem

Reflect's secondary note-window flow was available only through modifier-clicking links. There was no keyboard or native-menu command for opening the note currently selected in the main workspace. This was especially limiting in the Daily stream, where the selected note can be the focused day rather than the routed day.

The native macOS application menu also initialized in every webview. Menu actions are channel-bound to the webview that creates them, so opening a chrome-free note window could replace the main window's working command menu with an inert copy.

## Before -> After

| Surface | Before | After |
| --- | --- | --- |
| Selected note | No new-window command | `Cmd+Shift+O` opens it in a secondary window |
| Command palette / shortcut sheet | No selected-note window action | Lists “Open note in new window” with the same binding |
| Native Window menu | No note-window action | Exposes the registered command and accelerator |
| Note-window boot | Could replace the app-wide menu with inert action channels | Leaves the main-owned native menu intact |

## Changes

1. Adds `note.openInNewWindow` with `Mod-Shift-o` to the central app command registry.
2. Targets `CommandContext.notePath()`, so Daily uses the focused stream day while ordinary note routes use their path.
3. Converts the path with `routeForPath`, preserving daily-note presentation and deduping every route to the same window target.
4. Adds the command to the native Window menu; the registry automatically supplies the command palette and shortcut sheet.
5. Restricts app-wide native-menu installation to the main webview. Secondary note windows intentionally mount no command dispatcher and therefore cannot replace the menu's working action channels.
6. Updates multi-window architecture comments and docs to describe command-based opening and target reopening as well as modifier-clicks.

## Tests

- The command binding is registered as `Mod-Shift-o`.
- Ordinary and focused-daily note paths open as their canonical routes.
- Screens with no selected note are inert.
- `Cmd+Shift+O` dispatches through the app shortcut registry without changing the current route.
- The native Window menu references the command.
- Secondary webviews do not reinstall the app-wide native menu.

## Verification

- `pnpm --filter @reflect/desktop test --run src/lib/commands/app-commands.test.ts src/lib/native-menu/menu.test.ts src/routing/app-shortcuts.test.tsx` — 3 files, 59 tests passed.
- `pnpm check` — passed; only the two pre-existing `max-lines` warnings remain.
- `cargo fmt --check` — passed.
- `git diff --check` — passed.

## Risk / Rollout

Low. This reuses the existing deep-link-based, deduped note-window creation path and changes no persisted data, schema, permissions, or release configuration. The command is intentionally scoped to the main workspace's selected note; secondary note windows remain chrome-free editing surfaces. The macOS menu accelerator was not manually smoke-tested in a bundled app; unit coverage pins command routing and menu ownership.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reuses the existing note-window deep-link path with no persistence or auth changes; the main behavioral fix is skipping native menu install on secondary webviews.
> 
> **Overview**
> Adds **`note.openInNewWindow`** (`Mod-Shift-o`) so the main workspace can open the **currently selected note** in a secondary window—not only via modifier-click on links. The handler uses `CommandContext.notePath()` (including the **focused day** in the daily stream), converts with `routeForPath`, and reuses the existing **`openRouteInNewWindow`** / deduped `open_note_window` path.
> 
> The command is wired into the **native Window menu** and covered by command, shortcut, and menu tests.
> 
> **`installNativeMenu`** now runs only on the **main** webview so chrome-free note windows do not replace the app-wide menu with inert action channels. Comments and **`docs/multi-window.md`** are updated to describe command-based opening alongside modifier-click.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b030aee6c6ea3bad95651b90978785428ee7f03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut (Cmd+Shift+O / Ctrl+Shift+O) to open the current note in a new window.

* **Documentation**
  * Updated multi-window documentation to clarify platform-agnostic opening methods and explain native menu behavior across windows.

* **Tests**
  * Expanded test coverage for the new note window command and keyboard shortcut functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->