### PR TITLE
fix: align task source note links

### DIFF
--- a/apps/desktop/src/components/tasks/task-row.tsx
+++ b/apps/desktop/src/components/tasks/task-row.tsx
@@ -5,7 +5,7 @@ import {
   type MutableRefObject,
   type ReactElement,
 } from 'react'
-import { ArrowRight, Circle, CircleCheck } from 'lucide-react'
+import { Circle, CircleCheck } from 'lucide-react'
 import type { OpenTask } from '@reflect/core'
 import { formatDayLabel } from '@/lib/dates'
 import { taskKey } from '@/lib/tasks/task-identity'
@@ -59,8 +59,8 @@ interface TaskRowProps {
 /**
  * One task row in the Tasks view (V1 design): a circle checkbox that toggles
  * the task (the guarded write-back, Plan 18), the task content with inline date
- * and link chips ({@link TaskText}), the source-note date on the right, and an
- * arrow that opens the source note. Clicking the row body **selects** it (V1's
+ * and link chips ({@link TaskText}), and a source-note link on the right.
+ * Clicking the row body **selects** it (V1's
  * multi-select); a plain click selects exclusively, ⌘/Ctrl toggles, Shift
  * extends a range. Completing optimistically drops the row; an archived
  * (completed) row shows struck through. A checkbox click on any selected row in
@@ -182,7 +182,7 @@ export function TaskRow({
           <TaskText task={task} />
         </div>
       )}
-      {showSource && task.dailyDate !== null ? (
+      {showSource ? (
         <button
           type="button"
           disabled={editing}
@@ -190,27 +190,13 @@ export function TaskRow({
             event.stopPropagation()
             onOpen(task.notePath)
           }}
-          className="mt-0.5 shrink-0 whitespace-nowrap text-xs text-text-muted hover:underline focus-visible:underline focus-visible:outline-none"
+          className="flex h-6 shrink-0 items-center whitespace-nowrap text-xs text-text-muted transition-colors hover:text-accent focus-visible:text-accent focus-visible:outline-none"
         >
-          {formatDayLabel(task.dailyDate, settings.dateFormat)}
+          {task.dailyDate !== null
+            ? formatDayLabel(task.dailyDate, settings.dateFormat)
+            : task.noteTitle}
         </button>
       ) : null}
-      <button
-        type="button"
-        aria-label={`Open ${task.noteTitle}`}
-        // Hidden while editing: keep focus on the editor (Esc first to leave).
-        disabled={editing}
-        onClick={(event) => {
-          event.stopPropagation()
-          onOpen(task.notePath)
-        }}
-        className={cn(
-          'mt-0.5 shrink-0 text-text-muted/60 opacity-0 transition-opacity hover:text-text focus-visible:opacity-100 focus-visible:outline-none',
-          !editing && 'group-hover/task:opacity-100',
-        )}
-      >
-        <ArrowRight aria-hidden className="size-3.5" />
-      </button>
     </li>
   )
 }

--- a/apps/desktop/src/components/tasks/tasks-screen.test.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.test.tsx
@@ -359,14 +359,21 @@ describe('TasksScreen', () => {
     view.unmount()
   })
 
-  it('opens a task’s source note via the open arrow', async () => {
+  it('opens a task’s source note from its title without an arrow', async () => {
     getOpenTasks.mockResolvedValue([
-      task({ notePath: 'notes/p.md', dailyDate: null, text: 'project task', noteTitle: 'Project' }),
+      task({
+        notePath: 'notes/p.md',
+        dailyDate: null,
+        dueDate: '2026-06-10',
+        text: 'project task',
+        noteTitle: 'Project',
+      }),
     ])
     const view = renderScreen()
 
-    await view.findByText('project task')
-    await userEvent.click(view.getByRole('button', { name: 'Open Project' }))
+    const sourceLink = await view.findByRole('button', { name: 'Project' })
+    expect(sourceLink.querySelector('svg')).toBeNull()
+    await userEvent.click(sourceLink)
     expect(view.getByTestId('route').textContent).toContain('notes/p.md')
     view.unmount()
   })


### PR DESCRIPTION
## Problem

Task rows rendered the source-note label and navigation arrow as separate, independently offset controls. This left the source link visually misaligned, spaced the arrow away from its label, and used an underline hover treatment that did not match Reflect backlinks.

## Changes

- Vertically center the task source link in the row’s 24px text line.
- Remove the redundant navigation arrow.
- Use the backlink accent color on hover and keyboard focus without an underline.
- Show the note title as the source link for dated tasks from non-daily notes.
- Update task-screen coverage for arrow-free source navigation.

## Verification

- `pnpm --filter @reflect/desktop test --run src/components/tasks/tasks-screen.test.tsx` — 61 tests passed.
- `pnpm check` — passed (two existing max-lines warnings remain in unrelated files).
- Manual browser smoke test not run at the requester’s direction.

## Risk / Rollout

Low-risk presentation-only change. No migrations, feature flags, or rollout steps are required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes in Tasks list rows; navigation behavior is unchanged aside from label fallback and styling.
> 
> **Overview**
> Task rows now use a **single right-aligned source control** instead of a separate date/title label plus a hover-only arrow. Clicking it still opens the source note via `onOpen`.
> 
> The link is **vertically centered** on the row’s 24px line (`h-6 flex items-center`), uses **accent color on hover/focus** (no underline), and labels with the formatted **daily date when present**, otherwise **`noteTitle`**—so non-daily dated tasks still get a visible source affordance. The redundant `ArrowRight` control and its `lucide` import are removed.
> 
> `tasks-screen.test.tsx` is updated to assert navigation from the title button with no SVG icon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f8680ad6cdb422aed3b306216aef3db64c8f09c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->