### PR TITLE
fix(desktop): always scroll Daily notes to today

### DIFF
--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -161,18 +161,15 @@ function renderSidebar(overrides?: Partial<CommandContext>, initialRoute?: Route
 }
 
 describe('Sidebar', () => {
-  it('nav rows navigate, with Daily notes restoring its surface scroll', async () => {
-    const { view, navigate } = renderSidebar()
+  it('nav rows navigate, with Daily notes always re-anchoring to today', async () => {
+    const { view, navigate } = renderSidebar(undefined, { kind: 'settings' })
 
-    // The Daily row is a capture gesture: it asks for editor focus (the
-    // stream appends at today's end), while a genuine off-surface return
-    // still restores the stream's saved position instead.
+    // The Daily row shares the ⌘D capture command: omitting
+    // `restoreSurfaceScroll` makes even an off-surface return discard the
+    // stream's saved position and re-anchor on today.
     await userEvent.click(view.getByRole('button', { name: /daily notes/i }))
     await waitFor(() =>
-      expect(navigate).toHaveBeenCalledWith(
-        { kind: 'today' },
-        { restoreSurfaceScroll: true, focusEditor: true },
-      ),
+      expect(navigate).toHaveBeenCalledWith({ kind: 'today' }, { focusEditor: true }),
     )
 
     await userEvent.click(view.getByRole('button', { name: /settings/i }))

--- a/apps/desktop/src/components/sidebar/sidebar.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.tsx
@@ -31,10 +31,8 @@ interface SidebarProps {
  * Pinned shelf, and the graph switcher footer. Most nav rows run registered
  * commands so a binding and its behavior stay one definition; the Daily notes
  * row is a capture gesture like `Mod-D` — it asks the stream to focus today
- * with the caret at the end, ready to append — except when clicked from
- * another surface with a saved stream position, where the surface-scroll
- * restore wins and focus stays put. (Sidebar collapse stays on `Mod-\` via
- * the command registry.)
+ * with the caret at the end, ready to append. (Sidebar collapse stays on
+ * `Mod-\` via the command registry.)
  */
 export function Sidebar({ graph, context }: SidebarProps): ReactElement {
   const { route } = useRouter()
@@ -75,12 +73,7 @@ export function Sidebar({ graph, context }: SidebarProps): ReactElement {
             label="Daily notes"
             binding={keybindingFor('nav.today') ?? undefined}
             active={(route.kind === 'today' || route.kind === 'daily') && !hasActivePinnedNote}
-            onClick={() =>
-              context.navigate(
-                { kind: 'today' },
-                { restoreSurfaceScroll: true, focusEditor: true },
-              )
-            }
+            onClick={() => void runCommand('nav.today', context)}
           />
           <SidebarItem
             icon={


### PR DESCRIPTION
## Problem

Clicking **Daily notes** after leaving the daily stream restored its last saved scroll offset. That could return someone to an older day instead of taking them to today, despite the navigation label and shortcut semantics.

## Changes

- Route the desktop sidebar click through the existing `nav.today` command, matching `Mod-D` behavior.
- Re-anchor the daily stream on today while retaining append-style editor focus.
- Update the sidebar regression test to start off-surface and assert that `restoreSurfaceScroll` is not requested.

## Verification

- `pnpm --filter @reflect/desktop test --run src/components/sidebar/sidebar.test.tsx src/routing/router.test.tsx src/components/daily-stream.focus.test.tsx` (46 tests passed)
- `pnpm --filter @reflect/desktop test --run src/components/sidebar/sidebar.test.tsx` (19 tests passed)
- `pnpm check`

## Risk / Rollout

Low risk and limited to the desktop sidebar action. Mobile daily-tab scroll restoration is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop sidebar Daily notes click only; behavior aligns with the existing nav.today command and does not touch auth, sync, or mobile scroll restoration.
> 
> **Overview**
> **Daily notes** in the desktop sidebar no longer restores the daily stream’s saved scroll when you return from another surface (e.g. Settings). That path could leave you on an older day instead of today.
> 
> The Daily row now goes through **`runCommand('nav.today', context)`** like **⌘D**, instead of calling **`navigate`** with **`restoreSurfaceScroll: true`**. Navigation still uses **`focusEditor: true`** so the caret lands at the end of today for append-style editing. Sidebar comments and the regression test were updated to start off-surface and assert **`restoreSurfaceScroll`** is not requested.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c52887d283cc7d399bf040ea3f7393724cf8aa68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->