### PR TITLE
fix: keep Return-created tasks in their groups

### DIFF
--- a/apps/desktop/src/components/tasks/tasks-screen.test.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.test.tsx
@@ -802,7 +802,13 @@ describe('TasksScreen', () => {
   it('Enter in a grouped task keeps the new row in that breadcrumb context', async () => {
     continueTaskInContext.mockResolvedValue({
       created: { markerOffset: 40, raw: '[ ] ' },
-      offsetChanges: [],
+      offsetChanges: [
+        {
+          from: 40,
+          fromRaw: '[ ] later',
+          marker: { markerOffset: 56, raw: '[ ] later' },
+        },
+      ],
     })
     getOpenTasks.mockResolvedValue([
       task({
@@ -839,11 +845,43 @@ describe('TasksScreen', () => {
     )
     expect(insertTask).not.toHaveBeenCalled()
     await view.findByTestId('task-editor')
+    expect(view.getByText('later')).toBeDefined()
 
     await userEvent.click(
       view.getByRole('button', { name: 'StartupToolbox → Reflections' }),
     )
     expect(view.getByRole('button', { name: 'Convert to bullet 2' })).toBeDefined()
+    view.unmount()
+  })
+
+  it('preserves a grouped task draft when contextual insertion is refused', async () => {
+    continueTaskInContext.mockRejectedValue(new Error('This note is open.'))
+    editTask.mockResolvedValue(undefined)
+    getOpenTasks.mockResolvedValue([
+      task({
+        notePath: 'notes/a.md',
+        markerOffset: 2,
+        raw: '[ ] first',
+        text: 'first',
+        noteTitle: 'A',
+        breadcrumbs: ['Project'],
+      }),
+    ])
+    const view = renderScreen()
+
+    await userEvent.click(await view.findByRole('button', { name: 'first' }))
+    await userEvent.click(view.getByRole('button', { name: 'continue-edit' }))
+
+    await waitFor(() =>
+      expect(editTask).toHaveBeenCalledWith(
+        expect.objectContaining({ notePath: 'notes/a.md', raw: '[ ] first' }),
+        'edited content',
+        1,
+      ),
+    )
+    expect(insertTask).not.toHaveBeenCalled()
+    expect(await view.findByRole('button', { name: 'edited content' })).toBeDefined()
+    expect(fail).toHaveBeenCalledWith('This note is open.')
     view.unmount()
   })
 

--- a/apps/desktop/src/components/tasks/tasks-screen.test.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.test.tsx
@@ -55,12 +55,14 @@ const toggleTask = vi.hoisted(() => vi.fn())
 const deleteTask = vi.hoisted(() => vi.fn())
 const editTask = vi.hoisted(() => vi.fn())
 const insertTask = vi.hoisted(() => vi.fn())
+const continueTaskInContext = vi.hoisted(() => vi.fn())
 const convertTaskToBullet = vi.hoisted(() => vi.fn())
 vi.mock('@/lib/note-task', () => ({
   toggleTask,
   deleteTask,
   editTask,
   insertTask,
+  continueTaskInContext,
   convertTaskToBullet,
 }))
 
@@ -207,6 +209,11 @@ beforeEach(() => {
   editTask.mockReset()
   insertTask.mockReset()
   insertTask.mockResolvedValue(0)
+  continueTaskInContext.mockReset()
+  continueTaskInContext.mockResolvedValue({
+    created: { markerOffset: 0, raw: '[ ] ' },
+    offsetChanges: [],
+  })
   convertTaskToBullet.mockReset()
   convertTaskToBullet.mockResolvedValue(undefined)
   startOperation.mockClear()
@@ -789,6 +796,81 @@ describe('TasksScreen', () => {
     // Persists this row's edit, then appends the next task in the same note.
     await waitFor(() => expect(editTask).toHaveBeenCalled())
     await waitFor(() => expect(insertTask).toHaveBeenCalledWith('notes/a.md', 1))
+    view.unmount()
+  })
+
+  it('Enter in a grouped task keeps the new row in that breadcrumb context', async () => {
+    continueTaskInContext.mockResolvedValue({
+      created: { markerOffset: 40, raw: '[ ] ' },
+      offsetChanges: [],
+    })
+    getOpenTasks.mockResolvedValue([
+      task({
+        notePath: 'notes/a.md',
+        markerOffset: 2,
+        raw: '[ ] first',
+        text: 'first',
+        noteTitle: 'A',
+        breadcrumbs: ['StartupToolbox', 'Reflections'],
+      }),
+      task({
+        notePath: 'notes/a.md',
+        markerOffset: 40,
+        raw: '[ ] later',
+        text: 'later',
+        noteTitle: 'A',
+        breadcrumbs: ['StartupToolbox', 'Later'],
+      }),
+    ])
+    const view = renderScreen()
+
+    await userEvent.click(await view.findByRole('button', { name: 'first' }))
+    await userEvent.click(view.getByRole('button', { name: 'continue-edit' }))
+
+    await waitFor(() =>
+      expect(continueTaskInContext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          notePath: 'notes/a.md',
+          breadcrumbs: ['StartupToolbox', 'Reflections'],
+        }),
+        'edited content',
+        1,
+      ),
+    )
+    expect(insertTask).not.toHaveBeenCalled()
+    await view.findByTestId('task-editor')
+
+    await userEvent.click(
+      view.getByRole('button', { name: 'StartupToolbox → Reflections' }),
+    )
+    expect(view.getByRole('button', { name: 'Convert to bullet 2' })).toBeDefined()
+    view.unmount()
+  })
+
+  it('Enter continues a scheduled grouped task despite its aggregate date bucket', async () => {
+    getOpenTasks.mockResolvedValue([
+      task({
+        notePath: 'notes/a.md',
+        markerOffset: 2,
+        raw: '[ ] scheduled',
+        text: 'scheduled',
+        noteTitle: 'A',
+        breadcrumbs: ['Project'],
+        dueDate: '2026-07-01',
+      }),
+    ])
+    const view = renderScreen()
+
+    await userEvent.click(await view.findByRole('button', { name: 'scheduled' }))
+    await userEvent.click(view.getByRole('button', { name: 'continue-unchanged' }))
+
+    await waitFor(() =>
+      expect(continueTaskInContext).toHaveBeenCalledWith(
+        expect.objectContaining({ notePath: 'notes/a.md', breadcrumbs: ['Project'] }),
+        null,
+        1,
+      ),
+    )
     view.unmount()
   })
 

--- a/apps/desktop/src/lib/note-task.test.ts
+++ b/apps/desktop/src/lib/note-task.test.ts
@@ -1,7 +1,8 @@
-import { TaskStaleError } from '@reflect/core'
+import { parseNote, TaskStaleError } from '@reflect/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   convertTaskToBullet,
+  continueTaskInContext,
   deleteTask,
   editTask,
   insertTask,
@@ -221,5 +222,110 @@ describe('insertTask', () => {
 
     await expect(insertTask('notes/a.md', 7)).resolves.toBe('# Notes\n\nbody\n+ '.length)
     expect(writeNote).toHaveBeenCalledWith('notes/a.md', '# Notes\n\nbody\n+ [ ] \n', 7)
+  })
+})
+
+describe('continueTaskInContext', () => {
+  it('saves an edited task and adds the next row to the same nested context', async () => {
+    const source = [
+      '+ StartupToolbox',
+      '  + Reflections',
+      '    + [ ] first',
+      '  + Later',
+      '    + [ ] third',
+      '',
+    ].join('\n')
+    const anchor = parseNote({ path: 'notes/a.md', source }).tasks[0]!
+    openSession.mockReturnValue(null)
+    readNote.mockResolvedValue(source)
+    writeNote.mockResolvedValue(undefined)
+
+    const result = await continueTaskInContext(
+      { notePath: 'notes/a.md', markerOffset: anchor.markerOffset, raw: anchor.raw },
+      'edited first',
+      7,
+    )
+
+    const written = [
+      '+ StartupToolbox',
+      '  + Reflections',
+      '    + [ ] edited first',
+      '    + [ ] ',
+      '  + Later',
+      '    + [ ] third',
+      '',
+    ].join('\n')
+    expect(writeNote).toHaveBeenCalledWith('notes/a.md', written, 7)
+    const writtenTasks = parseNote({ path: 'notes/a.md', source: written }).tasks
+    const created = writtenTasks.find(
+      (task) => task.markerOffset === result.created.markerOffset,
+    )
+    expect(created?.breadcrumbs).toEqual(['StartupToolbox', 'Reflections'])
+    expect(result.offsetChanges[1]?.marker?.markerOffset).toBe(writtenTasks[2]?.markerOffset)
+  })
+
+  it('replaces a cleared row with one empty task at the end of its context', async () => {
+    const source = '+ Group\n  + [ ] old\n  + [ ] peer\n'
+    const anchor = parseNote({ path: 'notes/a.md', source }).tasks[0]!
+    openSession.mockReturnValue(null)
+    readNote.mockResolvedValue(source)
+    writeNote.mockResolvedValue(undefined)
+
+    const result = await continueTaskInContext(
+      { notePath: 'notes/a.md', markerOffset: anchor.markerOffset, raw: anchor.raw },
+      '',
+      7,
+    )
+
+    const written = '+ Group\n  + [ ] peer\n  + [ ] \n'
+    expect(writeNote).toHaveBeenCalledWith('notes/a.md', written, 7)
+    const tasks = parseNote({ path: 'notes/a.md', source: written }).tasks
+    expect(tasks.map((task) => task.text)).toEqual(['peer', ''])
+    expect(tasks[1]?.markerOffset).toBe(result.created.markerOffset)
+    expect(tasks[1]?.breadcrumbs).toEqual(['Group'])
+    expect(result.offsetChanges[0]?.marker).toBeNull()
+  })
+
+  it('uses the relocated anchor when an empty task moved before insertion', async () => {
+    const indexedSource = '+ Group\n  + [ ] \n'
+    const anchor = parseNote({ path: 'notes/a.md', source: indexedSource }).tasks[0]!
+    const source = `Intro\n\n${indexedSource}`
+    openSession.mockReturnValue(null)
+    readNote.mockResolvedValue(source)
+    writeNote.mockResolvedValue(undefined)
+
+    await expect(
+      continueTaskInContext(
+        { notePath: 'notes/a.md', markerOffset: anchor.markerOffset, raw: anchor.raw },
+        'filled',
+        7,
+      ),
+    ).resolves.toEqual(expect.objectContaining({ created: expect.any(Object) }))
+    expect(writeNote).toHaveBeenCalledWith(
+      'notes/a.md',
+      'Intro\n\n+ Group\n  + [ ] filled\n  + [ ] \n',
+      7,
+    )
+  })
+
+  it('returns the persisted CRLF raw marker for the optimistic row', async () => {
+    const source = '+ Group\r\n  + [ ] first\r\n'
+    const anchor = parseNote({ path: 'notes/a.md', source }).tasks[0]!
+    openSession.mockReturnValue(null)
+    readNote.mockResolvedValue(source)
+    writeNote.mockResolvedValue(undefined)
+
+    const result = await continueTaskInContext(
+      { notePath: 'notes/a.md', markerOffset: anchor.markerOffset, raw: anchor.raw },
+      'edited',
+      7,
+    )
+
+    expect(writeNote).toHaveBeenCalledWith(
+      'notes/a.md',
+      '+ Group\r\n  + [ ] edited\r\n  + [ ] \r\n',
+      7,
+    )
+    expect(result.created.raw).toBe('[ ] \r')
   })
 })

--- a/apps/desktop/src/lib/note-task.ts
+++ b/apps/desktop/src/lib/note-task.ts
@@ -1,7 +1,9 @@
 import {
+  appendTaskToContext,
   appendTaskLine,
   editTaskLine,
   isAppError,
+  parseNote,
   readNote,
   removeTaskLine,
   taskLineToBullet,
@@ -15,6 +17,22 @@ import { openSession } from '@/editor/open-documents'
 /** The marker coordinates ({@link TaskMarker}) plus the note they live in. */
 export interface TaskRef extends TaskMarker {
   notePath: string
+}
+
+export interface TaskMarkerOffsetChange {
+  /** Marker offset before the contextual write. */
+  readonly from: number
+  /** Exact pre-write marker line, used to relocate a stale indexed offset safely. */
+  readonly fromRaw: string
+  /** Marker after the write, or null when the original task was removed. */
+  readonly marker: TaskMarker | null
+}
+
+export interface ContinuedTaskInContext {
+  /** The newly inserted empty task's exact persisted marker identity. */
+  readonly created: TaskMarker
+  /** Relocations for pre-existing task markers shifted by the atomic write. */
+  readonly offsetChanges: readonly TaskMarkerOffsetChange[]
 }
 
 /**
@@ -146,6 +164,80 @@ export function convertTaskToBullet(task: TaskRef, generation: number): Promise<
     (owner, marker) => owner.commitTaskToBullet(marker),
     (source, marker) => taskLineToBullet(source, marker),
   )
+}
+
+/**
+ * Continue entry from a grouped task by atomically resolving the current draft
+ * and adding a new empty task to the same parent-list context. Changed content
+ * replaces the anchor line; cleared content removes it. The returned marker
+ * identities reflect the final source so the Tasks view can immediately address
+ * the new row and relocate shifted cached rows before reindexing catches up.
+ */
+export function continueTaskInContext(
+  task: TaskRef,
+  content: string | null,
+  generation: number,
+): Promise<ContinuedTaskInContext> {
+  return serializeByPath(task.notePath, async () => {
+    if (openSession(task.notePath) !== null) {
+      throw new NoteBusyError('This note is open — add the task in the note itself.')
+    }
+    const source = await readNote(task.notePath)
+    const originalTasks = parseNote({ path: task.notePath, source }).tasks
+    const marker: TaskMarker = { markerOffset: task.markerOffset, raw: task.raw }
+    const inserted = appendTaskToContext(source, marker)
+    const resolvedMarker: TaskMarker = { markerOffset: inserted.anchorOffset, raw: task.raw }
+    const insertionLength = inserted.source.length - source.length
+    let nextSource = inserted.source
+    let markerOffset = inserted.markerOffset
+    let anchorDelta = 0
+
+    if (content === '') {
+      const withoutAnchor = removeTaskLine(nextSource, resolvedMarker)
+      anchorDelta = withoutAnchor.length - nextSource.length
+      markerOffset += anchorDelta
+      nextSource = withoutAnchor
+    } else if (content !== null) {
+      const withEditedAnchor = editTaskLine(nextSource, resolvedMarker, content)
+      anchorDelta = withEditedAnchor.length - nextSource.length
+      markerOffset += anchorDelta
+      nextSource = withEditedAnchor
+    }
+
+    const finalTasksByOffset = new Map(
+      parseNote({ path: task.notePath, source: nextSource }).tasks.map((row) => [
+        row.markerOffset,
+        row,
+      ]),
+    )
+    const offsetChanges = originalTasks.map<TaskMarkerOffsetChange>((original) => {
+      if (content === '' && original.markerOffset === inserted.anchorOffset) {
+        return { from: original.markerOffset, fromRaw: original.raw, marker: null }
+      }
+      const shiftedOffset =
+        original.markerOffset +
+        (original.markerOffset >= inserted.insertionOffset ? insertionLength : 0) +
+        (original.markerOffset > inserted.anchorOffset ? anchorDelta : 0)
+      const shifted = finalTasksByOffset.get(shiftedOffset)
+      if (shifted === undefined) {
+        throw new Error(`contextual task relocation failed at offset ${original.markerOffset}`)
+      }
+      return {
+        from: original.markerOffset,
+        fromRaw: original.raw,
+        marker: { markerOffset: shifted.markerOffset, raw: shifted.raw },
+      }
+    })
+    const created = finalTasksByOffset.get(markerOffset)
+    if (created === undefined) {
+      throw new Error(`contextual task insertion failed at offset ${markerOffset}`)
+    }
+    await writeNote(task.notePath, nextSource, generation)
+    return {
+      created: { markerOffset: created.markerOffset, raw: created.raw },
+      offsetChanges,
+    }
+  })
 }
 
 /**

--- a/apps/desktop/src/lib/tasks/recently-completed.test.ts
+++ b/apps/desktop/src/lib/tasks/recently-completed.test.ts
@@ -2,12 +2,14 @@ import { act, cleanup, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { type OpenTask } from '@reflect/core'
 import { makeOpenTask as task } from './open-task-fixture'
+import { taskKey } from './task-identity'
 import {
   archiveRecentlyCompleted,
   forgetRecentlyCompleted,
   hasRecentlyCompleted,
   markRecentlyCompleted,
   reconcileRecentlyCompleted,
+  relocateRecentlyCompleted,
   resetRecentlyCompleted,
   useRecentlyCompleted,
 } from './recently-completed'
@@ -52,6 +54,68 @@ describe('recently-completed', () => {
 
     act(() => archiveRecentlyCompleted('/g'))
     expect(result.current).toEqual([])
+  })
+
+  it('relocates struck rows shifted by a contextual insertion', () => {
+    const { result } = renderHook(() => useRecentlyCompleted('/g', undefined))
+    act(() =>
+      markRecentlyCompleted('/g', [
+        task({ notePath: 'a.md', markerOffset: 40, raw: '[ ] done' }),
+        task({ notePath: 'b.md', markerOffset: 40, raw: '[ ] other' }),
+      ]),
+    )
+
+    act(() =>
+      relocateRecentlyCompleted('/g', 'a.md', [
+        { from: 40, fromRaw: '[x] done', marker: { markerOffset: 56, raw: '[x] done' } },
+      ]),
+    )
+
+    expect(result.current.map((row) => taskKey(row))).toEqual(['a.md:56', 'b.md:40'])
+    expect(result.current[0]?.raw).toBe('[x] done')
+  })
+
+  it('relocates a stale struck offset by a unique raw marker match', () => {
+    const { result } = renderHook(() => useRecentlyCompleted('/g', undefined))
+    act(() =>
+      markRecentlyCompleted('/g', [
+        task({ notePath: 'a.md', markerOffset: 12, raw: '[ ] done' }),
+      ]),
+    )
+
+    act(() =>
+      relocateRecentlyCompleted('/g', 'a.md', [
+        { from: 20, fromRaw: '[x] done', marker: { markerOffset: 36, raw: '[x] done' } },
+      ]),
+    )
+
+    expect(result.current.map((row) => taskKey(row))).toEqual(['a.md:36'])
+  })
+
+  it('does not guess when a stale raw marker is ambiguous', () => {
+    const { result } = renderHook(() => useRecentlyCompleted('/g', undefined))
+    act(() =>
+      markRecentlyCompleted('/g', [
+        task({ notePath: 'a.md', markerOffset: 12, raw: '[ ] duplicate' }),
+      ]),
+    )
+
+    act(() =>
+      relocateRecentlyCompleted('/g', 'a.md', [
+        {
+          from: 20,
+          fromRaw: '[x] duplicate',
+          marker: { markerOffset: 36, raw: '[x] duplicate' },
+        },
+        {
+          from: 40,
+          fromRaw: '[x] duplicate',
+          marker: { markerOffset: 56, raw: '[x] duplicate' },
+        },
+      ]),
+    )
+
+    expect(result.current.map((row) => taskKey(row))).toEqual(['a.md:12'])
   })
 
   it('drops a struck copy when the index reports the task open again with a newer updatedAt', () => {

--- a/apps/desktop/src/lib/tasks/recently-completed.test.ts
+++ b/apps/desktop/src/lib/tasks/recently-completed.test.ts
@@ -92,6 +92,34 @@ describe('recently-completed', () => {
     expect(result.current.map((row) => taskKey(row))).toEqual(['a.md:36'])
   })
 
+  it('refreshes an edited struck row from its relocated persisted marker', () => {
+    const { result } = renderHook(() => useRecentlyCompleted('/g', undefined))
+    act(() =>
+      markRecentlyCompleted('/g', [
+        task({ notePath: 'a.md', markerOffset: 20, raw: '[ ] old', text: 'old' }),
+      ]),
+    )
+
+    act(() =>
+      relocateRecentlyCompleted('/g', 'a.md', [
+        {
+          from: 20,
+          fromRaw: '[x] old',
+          marker: {
+            markerOffset: 20,
+            raw: '[x] edited [[2026-07-01]]',
+          },
+        },
+      ]),
+    )
+
+    expect(result.current[0]).toMatchObject({
+      raw: '[x] edited [[2026-07-01]]',
+      text: 'edited 2026-07-01',
+      dueDate: '2026-07-01',
+    })
+  })
+
   it('does not guess when a stale raw marker is ambiguous', () => {
     const { result } = renderHook(() => useRecentlyCompleted('/g', undefined))
     act(() =>

--- a/apps/desktop/src/lib/tasks/recently-completed.ts
+++ b/apps/desktop/src/lib/tasks/recently-completed.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react'
 import { type OpenTask } from '@reflect/core'
 import { type TaskMarkerOffsetChange } from '@/lib/note-task'
-import { withCheckedMarker } from '@/lib/tasks/task-cache'
+import { withCheckedMarker, withRelocatedTaskMarkers } from '@/lib/tasks/task-cache'
 import { taskKey } from '@/lib/tasks/task-identity'
 
 /**
@@ -95,25 +95,10 @@ export function relocateRecentlyCompleted(
   if (root !== graphRoot || changes.length === 0) {
     return
   }
-  let changed = false
-  const next = tasks.flatMap((task) => {
-    if (task.notePath !== notePath) {
-      return [task]
-    }
-    const exact = changes.find(
-      (change) => change.from === task.markerOffset && change.fromRaw === task.raw,
-    )
-    const rawMatches = exact === undefined
-      ? changes.filter((change) => change.fromRaw === task.raw)
-      : []
-    const change = exact ?? (rawMatches.length === 1 ? rawMatches[0] : undefined)
-    if (change === undefined) {
-      return [task]
-    }
-    changed = true
-    return change.marker === null ? [] : [{ ...task, ...change.marker }]
-  })
-  if (changed) {
+  const next = withRelocatedTaskMarkers(tasks, notePath, changes, {
+    matchUniqueRaw: true,
+  }) ?? tasks
+  if (next !== tasks) {
     tasks = next
     emit()
   }

--- a/apps/desktop/src/lib/tasks/recently-completed.ts
+++ b/apps/desktop/src/lib/tasks/recently-completed.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react'
 import { type OpenTask } from '@reflect/core'
+import { type TaskMarkerOffsetChange } from '@/lib/note-task'
 import { withCheckedMarker } from '@/lib/tasks/task-cache'
 import { taskKey } from '@/lib/tasks/task-identity'
 
@@ -79,6 +80,43 @@ export function forgetRecentlyCompleted(root: string | null, keys: readonly stri
 /** Whether a task is currently being kept visible by the session's struck set. */
 export function hasRecentlyCompleted(root: string | null, key: string): boolean {
   return root === graphRoot && tasks.some((task) => taskKey(task) === key)
+}
+
+/**
+ * Apply a contextual note write's marker relocations to the session's struck
+ * rows. Unlike the query caches, this singleton is not rebuilt by an open-task
+ * refetch, so shifted completed rows must be re-keyed explicitly.
+ */
+export function relocateRecentlyCompleted(
+  root: string | null,
+  notePath: string,
+  changes: readonly TaskMarkerOffsetChange[],
+): void {
+  if (root !== graphRoot || changes.length === 0) {
+    return
+  }
+  let changed = false
+  const next = tasks.flatMap((task) => {
+    if (task.notePath !== notePath) {
+      return [task]
+    }
+    const exact = changes.find(
+      (change) => change.from === task.markerOffset && change.fromRaw === task.raw,
+    )
+    const rawMatches = exact === undefined
+      ? changes.filter((change) => change.fromRaw === task.raw)
+      : []
+    const change = exact ?? (rawMatches.length === 1 ? rawMatches[0] : undefined)
+    if (change === undefined) {
+      return [task]
+    }
+    changed = true
+    return change.marker === null ? [] : [{ ...task, ...change.marker }]
+  })
+  if (changed) {
+    tasks = next
+    emit()
+  }
 }
 
 /**

--- a/apps/desktop/src/lib/tasks/task-cache.test.ts
+++ b/apps/desktop/src/lib/tasks/task-cache.test.ts
@@ -6,6 +6,7 @@ import {
   taskRawWithContent,
   withCheckedMarker,
   withEditedTask,
+  withRelocatedTaskMarkers,
   withoutTasks,
 } from './task-cache'
 
@@ -20,6 +21,62 @@ describe('withoutTasks', () => {
 
   it('leaves an undefined (not-loaded) list untouched', () => {
     expect(withoutTasks(undefined, [a])).toBeUndefined()
+  })
+})
+
+describe('withRelocatedTaskMarkers', () => {
+  it('moves and removes same-note rows while preserving unrelated rows', () => {
+    const moved = task({ notePath: 'a.md', markerOffset: 20, raw: '[ ] moved' })
+    const removed = task({ notePath: 'a.md', markerOffset: 40, raw: '[ ] removed' })
+    const unrelated = task({ notePath: 'b.md', markerOffset: 20, raw: '[ ] other' })
+
+    expect(
+      withRelocatedTaskMarkers([moved, removed, unrelated], 'a.md', [
+        {
+          from: 20,
+          fromRaw: '[ ] moved',
+          marker: { markerOffset: 36, raw: '[ ] moved' },
+        },
+        { from: 40, fromRaw: '[ ] removed', marker: null },
+      ]),
+    ).toEqual([{ ...moved, markerOffset: 36 }, unrelated])
+  })
+
+  it('returns the same list when every matched marker is unchanged', () => {
+    const rows = [task({ notePath: 'a.md', markerOffset: 20, raw: '[ ] same' })]
+    expect(
+      withRelocatedTaskMarkers(rows, 'a.md', [
+        {
+          from: 20,
+          fromRaw: '[ ] same',
+          marker: { markerOffset: 20, raw: '[ ] same' },
+        },
+      ]),
+    ).toBe(rows)
+  })
+
+  it('does not mistake an optimistically edited anchor for another source row', () => {
+    const editedAnchor = task({
+      notePath: 'a.md',
+      markerOffset: 2,
+      raw: '[ ] duplicate',
+    })
+    const rows = [editedAnchor]
+
+    expect(
+      withRelocatedTaskMarkers(rows, 'a.md', [
+        {
+          from: 2,
+          fromRaw: '[ ] original',
+          marker: { markerOffset: 2, raw: '[ ] duplicate' },
+        },
+        {
+          from: 40,
+          fromRaw: '[ ] duplicate',
+          marker: { markerOffset: 56, raw: '[ ] duplicate' },
+        },
+      ]),
+    ).toBe(rows)
   })
 })
 

--- a/apps/desktop/src/lib/tasks/task-cache.test.ts
+++ b/apps/desktop/src/lib/tasks/task-cache.test.ts
@@ -73,6 +73,10 @@ describe('taskRawWithContent', () => {
     expect(taskRawWithContent(task({ checked: true, raw: '[X] old' }), 'edited')).toBe('[X] edited')
   })
 
+  it('preserves a CRLF raw line’s carriage return', () => {
+    expect(taskRawWithContent(task({ raw: '[ ] old\r' }), 'edited')).toBe('[ ] edited\r')
+  })
+
   it('clears to a bare marker when content is empty', () => {
     expect(taskRawWithContent(task({ raw: '[ ] old' }), '')).toBe('[ ]')
   })

--- a/apps/desktop/src/lib/tasks/task-cache.ts
+++ b/apps/desktop/src/lib/tasks/task-cache.ts
@@ -1,4 +1,5 @@
 import { parseNote, type OpenTask } from '@reflect/core'
+import { type TaskMarkerOffsetChange } from '@/lib/note-task'
 import { sameTask, taskKey } from '@/lib/tasks/task-identity'
 
 /**
@@ -18,6 +19,98 @@ export function withoutTasks(
   tasks: OpenTask[],
 ): OpenTask[] | undefined {
   return rows?.filter((row) => !tasks.some((task) => sameTask(row, task)))
+}
+
+function markerChangeForTask(
+  task: OpenTask,
+  changes: readonly TaskMarkerOffsetChange[],
+  matchUniqueRaw: boolean,
+): TaskMarkerOffsetChange | undefined {
+  const exact = changes.find(
+    (change) => change.from === task.markerOffset && change.fromRaw === task.raw,
+  )
+  if (exact !== undefined) {
+    return exact
+  }
+  if (!matchUniqueRaw) {
+    return undefined
+  }
+  const rawMatches = changes.filter((change) => change.fromRaw === task.raw)
+  return rawMatches.length === 1 ? rawMatches[0] : undefined
+}
+
+interface TaskMarkerRelocationOptions {
+  /** Relocate a stale offset when its raw marker has exactly one source match. */
+  readonly matchUniqueRaw?: boolean
+}
+
+interface TaskLineProjection {
+  readonly text: string
+  readonly dueDate: string | null
+}
+
+function taskLineProjection(raw: string): TaskLineProjection {
+  const projected = parseNote({ path: '', source: `+ ${raw}` }).tasks[0]
+  return {
+    text: projected?.text ?? '',
+    dueDate: projected?.dueDate ?? null,
+  }
+}
+
+/**
+ * Re-key cached rows after a contextual note write shifts marker offsets. Exact
+ * offset + raw identity is the default. A caller holding a stale shadow row can
+ * opt into unique-raw matching; query caches must not because their optimistic
+ * anchor edit may now share another task's original raw.
+ */
+export function withRelocatedTaskMarkers(
+  rows: OpenTask[] | undefined,
+  notePath: string,
+  changes: readonly TaskMarkerOffsetChange[],
+  options?: TaskMarkerRelocationOptions,
+): OpenTask[] | undefined
+export function withRelocatedTaskMarkers(
+  rows: readonly OpenTask[],
+  notePath: string,
+  changes: readonly TaskMarkerOffsetChange[],
+  options?: TaskMarkerRelocationOptions,
+): readonly OpenTask[]
+export function withRelocatedTaskMarkers(
+  rows: readonly OpenTask[] | undefined,
+  notePath: string,
+  changes: readonly TaskMarkerOffsetChange[],
+  options: TaskMarkerRelocationOptions = {},
+): readonly OpenTask[] | undefined {
+  if (rows === undefined || changes.length === 0) {
+    return rows
+  }
+  let changed = false
+  const relocated = rows.flatMap((task) => {
+    if (task.notePath !== notePath) {
+      return [task]
+    }
+    const change = markerChangeForTask(task, changes, options.matchUniqueRaw === true)
+    if (change === undefined) {
+      return [task]
+    }
+    const { marker } = change
+    if (marker === null) {
+      changed = true
+      return []
+    }
+    if (marker.markerOffset === task.markerOffset && marker.raw === task.raw) {
+      return [task]
+    }
+    changed = true
+    return [
+      {
+        ...task,
+        ...marker,
+        ...(marker.raw === task.raw ? {} : taskLineProjection(marker.raw)),
+      },
+    ]
+  })
+  return changed ? relocated : rows
 }
 
 /**
@@ -79,7 +172,7 @@ export function taskRawWithContent(task: OpenTask, content: string): string {
  * reindex will store, not the raw markdown the editor produced.
  */
 function plainTextOfTaskLine(raw: string): string {
-  return parseNote({ path: '', source: `+ ${raw}` }).tasks[0]?.text ?? ''
+  return taskLineProjection(raw).text
 }
 
 /**

--- a/apps/desktop/src/lib/tasks/task-cache.ts
+++ b/apps/desktop/src/lib/tasks/task-cache.ts
@@ -61,14 +61,15 @@ export function asOpen(rows: OpenTask[] | undefined, tasks: OpenTask[]): OpenTas
 /**
  * The `raw` line a task would have after an inline edit: the indexed line's exact
  * marker kept, the content after it replaced. The marker is taken verbatim from
- * `raw` (not rebuilt from `checked`), so GitHub's `[X]` survives — otherwise the
- * cached `raw` wouldn't match disk and a follow-up edit/delete's staleness guard
- * would fail until the reindex. Empty content clears to a bare marker, matching
- * the disk edit ({@link editTaskLine}).
+ * `raw` (not rebuilt from `checked`), so GitHub's `[X]` survives; a CRLF raw line
+ * likewise keeps its trailing carriage return. Otherwise a follow-up edit/delete
+ * would fail the staleness guard until reindexing. Empty content clears to a bare
+ * marker, matching the disk edit ({@link editTaskLine}).
  */
 export function taskRawWithContent(task: OpenTask, content: string): string {
   const marker = task.raw.slice(0, 3) // `[ ]` / `[x]` / `[X]` — raw always begins with it
-  return content === '' ? marker : `${marker} ${content}`
+  const carriageReturn = task.raw.endsWith('\r') ? '\r' : ''
+  return content === '' ? `${marker}${carriageReturn}` : `${marker} ${content}${carriageReturn}`
 }
 
 /**

--- a/apps/desktop/src/lib/tasks/task-insert-target.ts
+++ b/apps/desktop/src/lib/tasks/task-insert-target.ts
@@ -13,14 +13,19 @@ export interface InsertTaskTarget {
 }
 
 /** Build the optimistic open row for a just-written empty task. */
-export function insertedTaskRow(target: InsertTaskTarget, markerOffset: number): OpenTask {
+export function insertedTaskRow(
+  target: InsertTaskTarget,
+  markerOffset: number,
+  breadcrumbs: readonly string[] = [],
+  raw = '[ ] ',
+): OpenTask {
   return {
     notePath: target.notePath,
     markerOffset,
-    raw: '[ ] ',
+    raw,
     checked: false,
     text: '',
-    breadcrumbs: [],
+    breadcrumbs,
     noteTitle: target.noteTitle,
     dueDate: null,
     dailyDate: target.dailyDate,

--- a/apps/desktop/src/lib/tasks/use-task-actions.ts
+++ b/apps/desktop/src/lib/tasks/use-task-actions.ts
@@ -368,6 +368,18 @@ export function useTaskActions(): TaskActions {
     },
   })
 
+  async function persistTaskDraft(task: OpenTask, content: string | null): Promise<boolean> {
+    try {
+      if (content === '') {
+        await deleteMutation.mutateAsync([task])
+      } else if (content !== null) {
+        await editMutation.mutateAsync({ task, content })
+      }
+      return true
+    } catch {
+      return false
+    }
+  }
   return {
     isPending:
       completeMutation.isPending ||
@@ -435,19 +447,22 @@ export function useTaskActions(): TaskActions {
         return null
       }
       if (task.breadcrumbs.length > 0) {
-        return contextInsert.insert(task, content)
+        try {
+          const created = await contextInsert.insert(task, content)
+          if (created !== null) {
+            return created
+          }
+        } catch {
+          // Failure already surfaced; fall through to preserve the draft.
+        }
+        await persistTaskDraft(task, content)
+        return null
       }
       // Resolve the current row first and *await* it, so the append reads the
       // settled source — the new offset can't drift when the line above resized.
       // Emptied content (the row was cleared) deletes that row rather than leaving
       // a bare `+ [ ]` ghost; a real change persists; null (unchanged) is left be.
-      try {
-        if (content === '') {
-          await deleteMutation.mutateAsync([task])
-        } else if (content !== null) {
-          await editMutation.mutateAsync({ task, content })
-        }
-      } catch {
+      if (!(await persistTaskDraft(task, content))) {
         return null // the edit/delete rollback already surfaced the failure
       }
       let markerOffset: number

--- a/apps/desktop/src/lib/tasks/use-task-actions.ts
+++ b/apps/desktop/src/lib/tasks/use-task-actions.ts
@@ -1,6 +1,12 @@
 import { useMutation } from '@tanstack/react-query'
 import { type OpenTask } from '@reflect/core'
-import { convertTaskToBullet, deleteTask, editTask, insertTask, toggleTask } from '@/lib/note-task'
+import {
+  convertTaskToBullet,
+  deleteTask,
+  editTask,
+  insertTask,
+  toggleTask,
+} from '@/lib/note-task'
 import { editAndToggleError, isEditAndToggleError } from '@/lib/tasks/edit-and-toggle-error'
 import {
   archiveRecentlyCompleted,
@@ -20,6 +26,7 @@ import { taskKey } from '@/lib/tasks/task-identity'
 import { insertedTaskRow, type InsertTaskTarget } from '@/lib/tasks/task-insert-target'
 import { useTaskCheckboxAction } from '@/lib/tasks/use-task-checkbox-action'
 import { useTaskCacheWriter } from '@/lib/tasks/use-task-cache'
+import { useTaskContextInsert } from '@/lib/tasks/use-task-context-insert'
 import { useGraph } from '@/providers/graph-provider'
 
 /**
@@ -58,8 +65,8 @@ export interface TaskActions {
   /**
    * Enter while editing (V1 continuous entry): persist the current row's edit
    * (when `content` isn't null), then add the next task in `target` and return it
-   * to select. The edit is **awaited before** the insert reads the note, so the
-   * new task's marker offset reflects the post-edit source and can't drift.
+   * to select. A task with breadcrumb context is continued structurally inside
+   * that context; other tasks retain the V1 bucket-target behavior.
    */
   insertAfter: (
     task: OpenTask,
@@ -102,6 +109,7 @@ export function useTaskActions(): TaskActions {
   const root = graph?.root ?? null
   const cache = useTaskCacheWriter()
   const checkboxAction = useTaskCheckboxAction()
+  const contextInsert = useTaskContextInsert()
 
   const completeMutation = useMutation({
     mutationFn: async (tasks: OpenTask[]) => {
@@ -369,6 +377,7 @@ export function useTaskActions(): TaskActions {
       editAndToggleMutation.isPending ||
       checkboxAction.isPending ||
       insertMutation.isPending ||
+      contextInsert.isPending ||
       scheduleMutation.isPending ||
       convertMutation.isPending ||
       editAndConvertMutation.isPending,
@@ -424,6 +433,9 @@ export function useTaskActions(): TaskActions {
     insertAfter: async (task, content, target) => {
       if (graph?.generation === undefined) {
         return null
+      }
+      if (task.breadcrumbs.length > 0) {
+        return contextInsert.insert(task, content)
       }
       // Resolve the current row first and *await* it, so the append reads the
       // settled source — the new offset can't drift when the line above resized.

--- a/apps/desktop/src/lib/tasks/use-task-cache.ts
+++ b/apps/desktop/src/lib/tasks/use-task-cache.ts
@@ -1,6 +1,8 @@
 import { useQueryClient } from '@tanstack/react-query'
 import { errorMessage, type OpenTask } from '@reflect/core'
+import { type TaskMarkerOffsetChange } from '@/lib/note-task'
 import { startOperation } from '@/lib/operations'
+import { withRelocatedTaskMarkers } from '@/lib/tasks/task-cache'
 import { sameTask } from '@/lib/tasks/task-identity'
 import { completedTasksQueryKey, tasksQueryKey } from '@/lib/tasks/tasks-query'
 import { useGraph } from '@/providers/graph-provider'
@@ -21,10 +23,12 @@ export interface TaskCacheWriter {
   patch: (open: TaskListPatch, completed: TaskListPatch) => void
   /**
    * Upsert one optimistic open row (Return-to-add) and remove the same identity
-   * from completed. A contextual insert shifts later source offsets, so its real
-   * marker can temporarily collide with a stale cached row until reindexing.
+   * from completed. Contextual callers relocate shifted source rows first so the
+   * new marker cannot collide with an existing cache identity.
    */
   addOpen: (task: OpenTask) => void
+  /** Re-key existing rows shifted by a contextual write, in both task caches. */
+  relocate: (notePath: string, changes: readonly TaskMarkerOffsetChange[]) => void
   /** Restore both lists from a snapshot and surface the failure once (single-write undo). */
   rollback: (captured: TaskCacheSnapshot | undefined, label: string, cause: unknown) => void
   /**
@@ -76,6 +80,13 @@ export function useTaskCacheWriter(): TaskCacheWriter {
     )
   }
 
+  const relocate = (notePath: string, changes: readonly TaskMarkerOffsetChange[]): void => {
+    patch(
+      (rows) => withRelocatedTaskMarkers(rows, notePath, changes),
+      (rows) => withRelocatedTaskMarkers(rows, notePath, changes),
+    )
+  }
+
   const rollback = (
     captured: TaskCacheSnapshot | undefined,
     label: string,
@@ -96,5 +107,5 @@ export function useTaskCacheWriter(): TaskCacheWriter {
     startOperation(label).fail(errorMessage(cause))
   }
 
-  return { snapshot, patch, addOpen, rollback, reconcile }
+  return { snapshot, patch, addOpen, relocate, rollback, reconcile }
 }

--- a/apps/desktop/src/lib/tasks/use-task-cache.ts
+++ b/apps/desktop/src/lib/tasks/use-task-cache.ts
@@ -20,8 +20,9 @@ export interface TaskCacheWriter {
   /** Optimistically rewrite the open and completed lists at once. */
   patch: (open: TaskListPatch, completed: TaskListPatch) => void
   /**
-   * Append one optimistic open row (Return-to-add): idempotent by task identity,
-   * so a reindex refetch that already added the real row can't double-list it.
+   * Upsert one optimistic open row (Return-to-add) and remove the same identity
+   * from completed. A contextual insert shifts later source offsets, so its real
+   * marker can temporarily collide with a stale cached row until reindexing.
    */
   addOpen: (task: OpenTask) => void
   /** Restore both lists from a snapshot and surface the failure once (single-write undo). */
@@ -69,10 +70,10 @@ export function useTaskCacheWriter(): TaskCacheWriter {
   }
 
   const addOpen = (task: OpenTask): void => {
-    queryClient.setQueryData<OpenTask[]>(openKey, (rows) => {
-      const list = rows ?? []
-      return list.some((row) => sameTask(row, task)) ? list : [...list, task]
-    })
+    patch(
+      (rows) => [...(rows ?? []).filter((row) => !sameTask(row, task)), task],
+      (rows) => rows?.filter((row) => !sameTask(row, task)),
+    )
   }
 
   const rollback = (

--- a/apps/desktop/src/lib/tasks/use-task-context-insert.ts
+++ b/apps/desktop/src/lib/tasks/use-task-context-insert.ts
@@ -15,7 +15,10 @@ interface ContextInsertInput {
 }
 
 export interface TaskContextInsert {
-  /** Resolve the current draft, add an empty row in the same context, and return it. */
+  /**
+   * Resolve the current draft, add an empty row in the same context, and return it.
+   * A failed write rejects after its optimistic cache update has been rolled back.
+   */
   readonly insert: (task: OpenTask, content: string | null) => Promise<OpenTask | null>
   /** Whether a contextual insert already has a disk write in flight. */
   readonly isPending: boolean
@@ -53,12 +56,12 @@ export function useTaskContextInsert(): TaskContextInsert {
         return null
       }
       const { generation, root } = graph
-      let result: ContinuedTaskInContext
-      try {
-        result = await mutation.mutateAsync({ task, content, generation })
-      } catch {
-        return null
-      }
+      const result: ContinuedTaskInContext = await mutation.mutateAsync({
+        task,
+        content,
+        generation,
+      })
+      cache.relocate(task.notePath, result.offsetChanges)
       relocateRecentlyCompleted(root, task.notePath, result.offsetChanges)
       const created = insertedTaskRow(
         insertTargetForTask(task),

--- a/apps/desktop/src/lib/tasks/use-task-context-insert.ts
+++ b/apps/desktop/src/lib/tasks/use-task-context-insert.ts
@@ -1,0 +1,73 @@
+import { useMutation } from '@tanstack/react-query'
+import { type OpenTask } from '@reflect/core'
+import { continueTaskInContext, type ContinuedTaskInContext } from '@/lib/note-task'
+import { relocateRecentlyCompleted } from '@/lib/tasks/recently-completed'
+import { withEditedTask, withoutTasks } from '@/lib/tasks/task-cache'
+import { insertedTaskRow } from '@/lib/tasks/task-insert-target'
+import { insertTargetForTask } from '@/lib/tasks/task-navigation'
+import { useTaskCacheWriter } from '@/lib/tasks/use-task-cache'
+import { useGraph } from '@/providers/graph-provider'
+
+interface ContextInsertInput {
+  readonly task: OpenTask
+  readonly content: string | null
+  readonly generation: number
+}
+
+export interface TaskContextInsert {
+  /** Resolve the current draft, add an empty row in the same context, and return it. */
+  readonly insert: (task: OpenTask, content: string | null) => Promise<OpenTask | null>
+  /** Whether a contextual insert already has a disk write in flight. */
+  readonly isPending: boolean
+}
+
+/**
+ * Context-preserving continuous entry for grouped Tasks rows. The disk transform
+ * and optimistic cache update stay atomic from the caller's perspective, including
+ * replacing a cleared row and displacing a stale offset collision until reindexing.
+ */
+export function useTaskContextInsert(): TaskContextInsert {
+  const { graph } = useGraph()
+  const cache = useTaskCacheWriter()
+  const mutation = useMutation({
+    mutationFn: ({ task, content, generation }: ContextInsertInput) =>
+      continueTaskInContext(task, content, generation),
+    onMutate: async ({ task, content }: ContextInsertInput) => {
+      const snapshot = await cache.snapshot()
+      const patch = (rows: OpenTask[] | undefined): OpenTask[] | undefined => {
+        if (content === '') {
+          return withoutTasks(rows, [task])
+        }
+        return content === null ? rows : withEditedTask(rows, task, content)
+      }
+      cache.patch(patch, patch)
+      return snapshot
+    },
+    onError: (cause, _variables, context) => cache.rollback(context, 'Adding task', cause),
+  })
+
+  return {
+    isPending: mutation.isPending,
+    insert: async (task, content) => {
+      if (graph === null || mutation.isPending) {
+        return null
+      }
+      const { generation, root } = graph
+      let result: ContinuedTaskInContext
+      try {
+        result = await mutation.mutateAsync({ task, content, generation })
+      } catch {
+        return null
+      }
+      relocateRecentlyCompleted(root, task.notePath, result.offsetChanges)
+      const created = insertedTaskRow(
+        insertTargetForTask(task),
+        result.created.markerOffset,
+        task.breadcrumbs,
+        result.created.raw,
+      )
+      cache.addOpen(created)
+      return created
+    },
+  }
+}

--- a/apps/desktop/src/lib/tasks/use-task-keyboard.test.ts
+++ b/apps/desktop/src/lib/tasks/use-task-keyboard.test.ts
@@ -350,12 +350,12 @@ describe('useTaskKeyboard', () => {
     })
   })
 
-  it('Return continues a grouped active row inside its task context', () => {
+  it('Return continues a grouped Current row inside its task context', () => {
     const grouped = task({
       notePath: 'notes/a.md',
       noteTitle: 'A',
       breadcrumbs: ['Project', 'Phase one'],
-      dueDate: '2026-07-01',
+      dueDate: '2026-06-15',
     })
     const insert = vi.fn().mockResolvedValue(null)
     const insertAfter = vi.fn().mockResolvedValue(null)

--- a/apps/desktop/src/lib/tasks/use-task-keyboard.test.ts
+++ b/apps/desktop/src/lib/tasks/use-task-keyboard.test.ts
@@ -350,6 +350,37 @@ describe('useTaskKeyboard', () => {
     })
   })
 
+  it('Return continues a grouped active row inside its task context', () => {
+    const grouped = task({
+      notePath: 'notes/a.md',
+      noteTitle: 'A',
+      breadcrumbs: ['Project', 'Phase one'],
+      dueDate: '2026-07-01',
+    })
+    const insert = vi.fn().mockResolvedValue(null)
+    const insertAfter = vi.fn().mockResolvedValue(null)
+    const selection = makeSelection({
+      selected: new Set(['grouped']),
+      selectedCount: 1,
+      activeKey: () => 'grouped',
+    })
+    mount({
+      selection,
+      actions: makeActions({ insert, insertAfter }),
+      tasksByKey: new Map([['grouped', grouped]]),
+    })
+
+    press(root, 'Enter')
+    expect(insertAfter).toHaveBeenCalledWith(grouped, null, {
+      notePath: 'notes/a.md',
+      noteTitle: 'A',
+      dailyDate: null,
+      isPinned: false,
+      pinnedOrder: null,
+    })
+    expect(insert).not.toHaveBeenCalled()
+  })
+
   it('Return falls to today’s daily when the pivot is no longer selected', () => {
     const deselected = task({ notePath: 'notes/a.md', noteTitle: 'A' })
     const insert = vi.fn().mockResolvedValue(null)

--- a/apps/desktop/src/lib/tasks/use-task-keyboard.ts
+++ b/apps/desktop/src/lib/tasks/use-task-keyboard.ts
@@ -3,10 +3,10 @@ import { type OpenTask } from '@reflect/core'
 import { taskKey } from '@/lib/tasks/task-identity'
 import {
   insertTargetForBucket,
+  insertTargetForTask,
   previousTaskKey,
   todaysDailyTarget,
 } from '@/lib/tasks/task-navigation'
-import { type InsertTaskTarget } from '@/lib/tasks/task-insert-target'
 import { type TaskActions } from '@/lib/tasks/use-task-actions'
 import { type TaskSelection } from '@/lib/tasks/use-task-selection'
 
@@ -118,18 +118,16 @@ export function useTaskKeyboard({
         return
       }
       const inSearch = target instanceof HTMLInputElement
-      // The note a Return-inserted task lands in (V1 group-based): the active row's
-      // group — Current → today's daily, a note → that note, Overdue/Upcoming refuse
-      // (`null`) — else, with nothing selected, today's daily. The pivot must still be
-      // *selected*: `activeKey()` keeps pointing at the last-touched row even after a
-      // ⌘-click deselects it (or all of them), so an unselected pivot falls to today.
-      const insertTarget = (): InsertTaskTarget | null => {
+      // Resolve the active row that Return pivots from. Breadcrumb context takes
+      // precedence and can always be continued structurally; otherwise the bucket
+      // decides whether insertion is available (Current/note yes, aggregate
+      // Overdue/Upcoming no). The pivot must still be selected: `activeKey()` keeps
+      // pointing at the last touched row after deselection, which falls back to today.
+      const activeTask = (): OpenTask | undefined => {
         const activeKey = selection.activeKey()
-        const active =
-          activeKey !== null && selection.selected.has(activeKey)
-            ? tasksByKey.get(activeKey)
-            : undefined
-        return active !== undefined ? insertTargetForBucket(active, today) : todaysDailyTarget(today)
+        return activeKey !== null && selection.selected.has(activeKey)
+          ? tasksByKey.get(activeKey)
+          : undefined
       }
       const selectExclusively = (key: string): void => {
         selection.clickSelect(key, { metaKey: false, ctrlKey: false, shiftKey: false })
@@ -164,9 +162,19 @@ export function useTaskKeyboard({
         // Skip while a write is in flight so a held/rapid Return can't append several
         // empty rows before the first insert's editor takes focus.
         event.preventDefault()
-        const target = insertTarget()
-        if (target !== null && !actions.isPending) {
-          void actions.insert(target).then((created) => {
+        const active = activeTask()
+        const taskTarget =
+          active === undefined
+            ? todaysDailyTarget(today)
+            : active.breadcrumbs.length > 0
+              ? insertTargetForTask(active)
+              : insertTargetForBucket(active, today)
+        if (taskTarget !== null && !actions.isPending) {
+          const insertion =
+            active !== undefined && active.breadcrumbs.length > 0
+              ? actions.insertAfter(active, null, taskTarget)
+              : actions.insert(taskTarget)
+          void insertion.then((created) => {
             if (created !== null) {
               selectExclusively(taskKey(created))
             }

--- a/apps/desktop/src/lib/tasks/use-task-row-handlers.ts
+++ b/apps/desktop/src/lib/tasks/use-task-row-handlers.ts
@@ -1,7 +1,11 @@
 import { useCallback } from 'react'
 import { type OpenTask } from '@reflect/core'
 import { type TaskNavigate } from '@/components/tasks/task-editor'
-import { insertTargetForBucket, previousTaskKey } from '@/lib/tasks/task-navigation'
+import {
+  insertTargetForBucket,
+  insertTargetForTask,
+  previousTaskKey,
+} from '@/lib/tasks/task-navigation'
 import { taskKey } from '@/lib/tasks/task-identity'
 import { type TaskActions } from '@/lib/tasks/use-task-actions'
 import { type TaskSelection } from '@/lib/tasks/use-task-selection'
@@ -61,12 +65,16 @@ export function useTaskRowHandlers({
         selection.clear()
       },
       onEditContinue: (content) => {
-        // Enter: persist this row, add the next task into its group (V1 — Current
-        // → today's daily, a note → that note), and select it so its editor opens.
-        const target = insertTargetForBucket(task, today)
+        // Enter: persist this row, add the next task into its breadcrumb context
+        // when it has one (otherwise use V1's Current/note bucket target), and
+        // select the new row so its editor opens.
+        const target =
+          task.breadcrumbs.length > 0
+            ? insertTargetForTask(task)
+            : insertTargetForBucket(task, today)
         if (target === null) {
-          // Overdue/Upcoming aggregate many notes — V1 can't add there. Persist the
-          // edit (or delete an emptied row) and exit, never stranding the editor.
+          // An ungrouped Overdue/Upcoming bucket spans many notes, so V1 can't add
+          // there. Persist the edit (or delete an emptied row) and exit cleanly.
           if (content === '') {
             actions.remove([task])
           } else if (content !== null) {

--- a/apps/desktop/src/mobile/screens/tasks.test.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.test.tsx
@@ -133,12 +133,14 @@ const toggleTask = vi.hoisted(() => vi.fn())
 const deleteTask = vi.hoisted(() => vi.fn())
 const editTask = vi.hoisted(() => vi.fn())
 const insertTask = vi.hoisted(() => vi.fn())
+const continueTaskInContext = vi.hoisted(() => vi.fn())
 const convertTaskToBullet = vi.hoisted(() => vi.fn())
 vi.mock('@/lib/note-task', () => ({
   toggleTask,
   deleteTask,
   editTask,
   insertTask,
+  continueTaskInContext,
   convertTaskToBullet,
 }))
 
@@ -209,6 +211,11 @@ beforeEach(() => {
   editTask.mockReset()
   insertTask.mockReset()
   insertTask.mockResolvedValue(0)
+  continueTaskInContext.mockReset()
+  continueTaskInContext.mockResolvedValue({
+    created: { markerOffset: 0, raw: '[ ] ' },
+    offsetChanges: [],
+  })
   convertTaskToBullet.mockReset()
   convertTaskToBullet.mockResolvedValue(undefined)
   startOperation.mockClear()

--- a/packages/core/src/exports/sync-markdown-indexing.ts
+++ b/packages/core/src/exports/sync-markdown-indexing.ts
@@ -58,6 +58,7 @@ export {
   appendBlock,
   appendUnderHeading,
   appendTaskLine,
+  appendTaskToContext,
   wikiLinkSafe,
   editTaskLine,
   removeTaskLine,

--- a/packages/core/src/markdown/edit.test.ts
+++ b/packages/core/src/markdown/edit.test.ts
@@ -3,6 +3,7 @@ import { parseNote } from './extract'
 import {
   appendBlock,
   appendTaskLine,
+  appendTaskToContext,
   appendUnderHeading,
   clearTaskDueDate,
   editTaskLine,
@@ -179,6 +180,11 @@ describe('editTaskLine', () => {
     expect(editTaskLine(source, indexedTask(source), 'really done')).toBe('+ [x] really done\n')
   })
 
+  it('preserves a CRLF line ending', () => {
+    const source = '+ [ ] old\r\n'
+    expect(editTaskLine(source, indexedTask(source), 'edited')).toBe('+ [ ] edited\r\n')
+  })
+
   it('keeps the indentation and bullet style of a nested item', () => {
     const source = '  + [ ] nested task\n'
     expect(editTaskLine(source, indexedTask(source), 'edited')).toBe('  + [ ] edited\n')
@@ -250,6 +256,69 @@ describe('appendTaskLine', () => {
     const tasks = parseNote({ path: 'n.md', source }).tasks
     expect(tasks).toHaveLength(1)
     expect(tasks[0]!.markerOffset).toBe(markerOffset)
+  })
+})
+
+describe('appendTaskToContext', () => {
+  it('adds a sibling at the end of a nested task context', () => {
+    const source = [
+      '+ StartupToolbox',
+      '  + Reflections',
+      '    + [ ] first',
+      '  + Later',
+      '    + [ ] third',
+      '',
+    ].join('\n')
+    const anchor = parseNote({ path: 'notes/n.md', source }).tasks[0]!
+    const inserted = appendTaskToContext(source, anchor)
+
+    expect(inserted.source).toBe([
+      '+ StartupToolbox',
+      '  + Reflections',
+      '    + [ ] first',
+      '    + [ ] ',
+      '  + Later',
+      '    + [ ] third',
+      '',
+    ].join('\n'))
+    const created = parseNote({ path: 'notes/n.md', source: inserted.source }).tasks.find(
+      (task) => task.markerOffset === inserted.markerOffset,
+    )
+    expect(created?.breadcrumbs).toEqual(['StartupToolbox', 'Reflections'])
+  })
+
+  it('appends after the selected context subtree without reparenting its children', () => {
+    const source = [
+      '+ Group',
+      '  + [ ] parent',
+      '    + [ ] child',
+      '  + [ ] peer',
+      '+ Other',
+      '',
+    ].join('\n')
+    const tasks = parseNote({ path: 'notes/n.md', source }).tasks
+    const inserted = appendTaskToContext(source, tasks[0]!)
+    const nextTasks = parseNote({ path: 'notes/n.md', source: inserted.source }).tasks
+
+    expect(nextTasks.map((task) => ({ text: task.text, breadcrumbs: task.breadcrumbs }))).toEqual([
+      { text: 'parent', breadcrumbs: ['Group'] },
+      { text: 'child', breadcrumbs: ['Group', 'parent'] },
+      { text: 'peer', breadcrumbs: ['Group'] },
+      { text: '', breadcrumbs: ['Group'] },
+    ])
+  })
+
+  it('refuses a task that is no longer nested under a parent list item', () => {
+    const source = '+ [ ] top-level\n'
+    const task = parseNote({ path: 'notes/n.md', source }).tasks[0]!
+    expect(() => appendTaskToContext(source, task)).toThrow(TaskStaleError)
+  })
+
+  it('preserves CRLF line endings around the inserted task', () => {
+    const source = '+ Group\r\n  + [ ] first\r\n'
+    const task = parseNote({ path: 'notes/n.md', source }).tasks[0]!
+    const inserted = appendTaskToContext(source, task)
+    expect(inserted.source).toBe('+ Group\r\n  + [ ] first\r\n  + [ ] \r\n')
   })
 })
 

--- a/packages/core/src/markdown/edit.ts
+++ b/packages/core/src/markdown/edit.ts
@@ -1,4 +1,7 @@
+import type { SyntaxNode } from '@lezer/common'
 import { parseNote } from './extract'
+import { splitFrontmatter } from './frontmatter'
+import { parseBody } from './grammar'
 import { normalizeWikiTarget } from './resolve'
 import { scanInlineWikiLinks } from './scan'
 import { parseTaskMarker } from './task-marker'
@@ -96,8 +99,9 @@ export function editTaskLine(source: string, task: TaskMarker, content: string):
   }
   const newline = source.indexOf('\n', offset)
   const lineEnd = newline === -1 ? source.length : newline
+  const contentEnd = lineEnd > offset && source[lineEnd - 1] === '\r' ? lineEnd - 1 : lineEnd
   const rewritten = text.length > 0 ? `${marker} ${text}` : marker
-  return source.slice(0, offset) + rewritten + source.slice(lineEnd)
+  return source.slice(0, offset) + rewritten + source.slice(contentEnd)
 }
 
 /**
@@ -128,6 +132,80 @@ export function appendTaskLine(source: string): { source: string; markerOffset: 
   const base = source.replace(/\s*$/, '')
   const prefix = base.length > 0 ? `${base}\n+ ` : '+ '
   return { source: `${prefix}[ ] \n`, markerOffset: prefix.length }
+}
+
+function taskNodeAt(body: string, markerOffset: number): SyntaxNode | null {
+  let node: SyntaxNode | null = parseBody(body).resolve(markerOffset, 1)
+  while (node !== null && node.name !== 'Task') {
+    node = node.parent
+  }
+  return node
+}
+
+function nearestParentListItem(taskNode: SyntaxNode): SyntaxNode | null {
+  const ownItem = taskNode.parent
+  if (ownItem?.name !== 'ListItem') {
+    return null
+  }
+  for (let ancestor = ownItem.parent; ancestor !== null; ancestor = ancestor.parent) {
+    if (ancestor.name === 'ListItem') {
+      return ancestor
+    }
+  }
+  return null
+}
+
+function insertionLineEnding(source: string, insertionOffset: number): '\r\n' | '\n' {
+  if (source.startsWith('\r\n', insertionOffset)) {
+    return '\r\n'
+  }
+  if (source[insertionOffset] === '\n') {
+    return '\n'
+  }
+  const previousNewline = source.lastIndexOf('\n', insertionOffset - 1)
+  return previousNewline > 0 && source[previousNewline - 1] === '\r' ? '\r\n' : '\n'
+}
+
+/**
+ * Add an empty task to the end of `task`'s nearest parent-list context. The new
+ * line reuses the task's exact indentation and round-list prefix, so parsing it
+ * yields the same ancestor breadcrumbs. The indexed marker is relocated through
+ * the normal stale guard first; a task that no longer has a parent context is
+ * refused rather than silently appended at the note root.
+ */
+export function appendTaskToContext(
+  source: string,
+  task: TaskMarker,
+): {
+  source: string
+  markerOffset: number
+  anchorOffset: number
+  insertionOffset: number
+} {
+  const locatedOffset = locateTaskMarker(source, task.markerOffset, task.raw)
+  const { body, bodyOffset } = splitFrontmatter(source)
+  const taskNode = taskNodeAt(body, locatedOffset - bodyOffset)
+  const contextItem = taskNode === null ? null : nearestParentListItem(taskNode)
+  if (contextItem === null) {
+    throw new TaskStaleError('task no longer has a parent list context')
+  }
+
+  const contextEnd = bodyOffset + contextItem.to
+  // Lezer's CRLF ranges end between `\r` and `\n`; splice before the pair so
+  // the inserted line cannot inherit a lone LF at either boundary.
+  const insertionOffset =
+    source[contextEnd - 1] === '\r' && source[contextEnd] === '\n' ? contextEnd - 1 : contextEnd
+  const lineStart = source.lastIndexOf('\n', locatedOffset - 1) + 1
+  const linePrefix = source.slice(lineStart, locatedOffset)
+  const lineEnding = insertionLineEnding(source, insertionOffset)
+  const trailingLineEnding = insertionOffset === source.length ? lineEnding : ''
+  const inserted = `${lineEnding}${linePrefix}[ ] ${trailingLineEnding}`
+  return {
+    source: source.slice(0, insertionOffset) + inserted + source.slice(insertionOffset),
+    markerOffset: insertionOffset + lineEnding.length + linePrefix.length,
+    anchorOffset: locatedOffset,
+    insertionOffset,
+  }
 }
 
 /**

--- a/packages/core/src/markdown/index.ts
+++ b/packages/core/src/markdown/index.ts
@@ -40,6 +40,7 @@ export {
   appendBlock,
   appendUnderHeading,
   appendTaskLine,
+  appendTaskToContext,
   wikiLinkSafe,
   editTaskLine,
   removeTaskLine,


### PR DESCRIPTION
## Problem

Pressing Return from a task with breadcrumb context used the generic end-of-note append path. The persisted Markdown task landed at the note root, while the optimistic row also hard-coded empty breadcrumbs, so the new task appeared ungrouped immediately and remained ungrouped after reindexing.

Scheduled grouped tasks had a second failure mode: the aggregate Overdue or Upcoming bucket rejected Return before the structural context could be considered. A refused contextual write could also roll back an inline edit and close the editor before that draft reached the session-aware edit path.

## Before -> After

| Scenario | Before | After |
| --- | --- | --- |
| Return in a breadcrumb-grouped task | Appends a root-level task | Adds an empty sibling at the end of the same parent-list context |
| Return in a scheduled grouped task | Refuses insertion for aggregate date buckets | Continues the breadcrumb context in the source note |
| Contextual insertion is refused after editing | The rolled-back draft can be lost when the editor closes | Saves the draft through the existing session-aware edit/delete path and does not append at the root |
| Immediate editing before reindex | Shifted cache identities can hide a sibling row; recently completed text can stay stale | Re-keys open, completed, and session rows and refreshes persisted marker metadata |
| Header Add or Return with no selection | Appends using the existing bucket target | Unchanged |

## Changes

1. Added `appendTaskToContext`, a guarded Markdown splice that relocates the indexed anchor, finds its nearest parent `ListItem`, preserves indentation and line endings, and appends after that context subtree.
2. Added an atomic grouped-task continuation path that resolves edited, unchanged, and cleared drafts in the same write and returns exact marker relocations for shifted tasks.
3. Made breadcrumb context take precedence over aggregate date-bucket gating for both Current and scheduled grouped tasks, while retaining the existing generic targets for ungrouped creation.
4. Applied exact marker relocations to the open and completed query caches before inserting the new optimistic row. Session-scoped recently completed rows retain their guarded unique-raw fallback and now refresh text and due-date metadata from changed persisted markers.
5. Preserved inline drafts when contextual continuation errors or declines because another write is pending by awaiting the existing session-aware edit/delete mutation before closing the editor. A failed contextual insert never falls back to an ungrouped root append.
6. Added regressions for nested groups, child subtrees, Current and scheduled groups, cleared tasks, refused insertion, stale and duplicate offsets, displaced cache rows, checked-row metadata, LF and CRLF notes, and optimistic selection.

## Verification

- `pnpm --filter @reflect/core test --run src/markdown/edit.test.ts src/indexing/group-tasks.test.ts` — 79 tests passed.
- `pnpm --filter @reflect/desktop test --run src/lib/note-task.test.ts src/lib/tasks src/components/tasks/tasks-screen.test.tsx src/mobile/screens/tasks.test.tsx src/mobile/use-task-sheet-finalizer.test.ts src/mobile/use-task-haptics.test.ts` — 230 tests passed across 13 files.
- `pnpm check` — typecheck and lint passed; only the two existing max-lines warnings remain.
- `pnpm build` — desktop and extension production builds passed; expected local Sentry-token and bundle-size warnings only.

## Risk / Rollout

No migration or data-format change. The new path only applies when the source task has breadcrumb context; generic task creation remains unchanged. Structural writes reuse the existing stale-task refusal and decline ambiguous raw relocation rather than risking the wrong Markdown row. If contextual insertion is unavailable, the current draft is preserved but no task is appended outside its group.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes markdown splice and task marker identity in the Tasks continuous-entry path; scope is limited to breadcrumb-grouped tasks and reuses existing stale-task refusal and ambiguous-relocation guards.
> 
> **Overview**
> **Grouped tasks** no longer use end-of-note `insertTask` when you press Return or Enter to continue entry. Tasks with **breadcrumb context** go through **`continueTaskInContext`**, which resolves the current draft and appends an empty sibling under the same parent list in one disk write.
> 
> Core adds **`appendTaskToContext`** (nested splice with indentation and LF/CRLF line endings). Desktop returns **marker relocations** so open/completed caches and the session **recently-completed** set re-key shifted rows before reindexing; optimistic rows carry **persisted breadcrumbs and raw markers**.
> 
> **Breadcrumb context overrides** aggregate Overdue/Upcoming bucket gating for Return on scheduled grouped tasks. If contextual insertion fails (e.g. note open), the draft is still saved and the user sees the error. Ungrouped Return-to-add and header **+ Add** behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88a067b74d095976f5da3ece0fb9ab7d711031ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->