### PR TITLE
test: cover partial multi-word title search

### DIFF
--- a/apps/cli/tests/cli.rs
+++ b/apps/cli/tests/cli.rs
@@ -322,6 +322,24 @@ fn search_matches_latin_title_terms_at_word_starts_only() {
     );
 }
 
+/// Multi-term Latin title recall accepts a prefix of each word, even though
+/// FTS5 itself cannot match the partial `Mac` token against `MacCaw`.
+#[test]
+fn search_finds_a_multi_term_partial_latin_title() {
+    let fixture = graph();
+    fixture.write_note(
+        "notes/tim-maccaw.md",
+        "# Tim MacCaw\nan otherwise unrelated body\n",
+    );
+    fixture.build_index();
+
+    let text = stdout(&reflect(&fixture, &["search", "Tim Mac"]));
+    assert!(
+        text.contains("notes/tim-maccaw.md"),
+        "expected the partial title match:\n{text}"
+    );
+}
+
 /// The V1-style exact-title boost (`filtered-search.ts`): a note whose title
 /// *is* the query ranks ahead of a louder lexical (bm25) match whose title only
 /// contains the query among other words — exact title is promoted before bm25.

--- a/apps/desktop/src/dev/dev-index-db.test.ts
+++ b/apps/desktop/src/dev/dev-index-db.test.ts
@@ -7,6 +7,11 @@ import {
   type IndexedNote,
 } from '@reflect/core'
 import { createDevIndexDb, type DevIndexDb } from '@/dev/dev-index-db'
+import {
+  buildAllNotesSearch,
+  EMPTY_ALL_NOTES_FILTERS,
+  searchPlanFor,
+} from '@/mobile/search-filters/filter-state'
 
 function sampleNote(overrides: Partial<IndexedNote> = {}): IndexedNote {
   return {
@@ -228,6 +233,27 @@ describe('createDevIndexDb', () => {
       'notes/car-log.md',
       'notes/car-wash.md',
       'notes/garage.md',
+    ])
+  })
+
+  it('finds a partial multi-term title through the mobile All search plan', async () => {
+    const db = await openDb()
+    db.applyNote(
+      sampleNote({
+        path: 'notes/tim-maccaw.md',
+        id: '01hv3xq7c2dm8k4t9w5e6r1n97',
+        title: 'Tim MacCaw',
+        titleKey: 'tim maccaw',
+        text: 'An otherwise unrelated body.',
+        preview: 'An otherwise unrelated body.',
+        tags: [],
+      }),
+    )
+    installQueryBridge(db)
+
+    const parsed = buildAllNotesSearch('Tim Mac', EMPTY_ALL_NOTES_FILTERS, null)
+    await expect(searchWithFilters(parsed, searchPlanFor(parsed))).resolves.toMatchObject([
+      { path: 'notes/tim-maccaw.md', title: 'Tim MacCaw', snippet: null },
     ])
   })
 


### PR DESCRIPTION
## Problem

The iOS All tab uses the ranked search query directly, while desktop can also surface title matches through its separate suggestion query. A query such as `Tim Mac` historically missed `Tim MacCaw` because FTS5 does not match the partial token `Mac` against `MacCaw`.

The current `next` title-recall implementation already fixes that behavior, but its coverage only exercised multi-term non-Latin substrings and a single Latin prefix. The exact iOS failure shape was not pinned.

## Changes

1. Exercise `Tim Mac` through `buildAllNotesSearch` and `searchPlanFor`, then run the compiled query against the real migrated SQLite/FTS5 database.
2. Assert the result is title-only (`snippet: null`), proving title recall supplied it rather than an unrelated body hit.
3. Add the same multi-term Latin-prefix fixture to the independent Rust CLI search suite so the mirrored query remains in parity.

## Verification

- `pnpm check`
- `pnpm --filter @reflect/core test --run src/indexing/search-query.test.ts src/indexing/filtered-search.test.ts`
- `pnpm --filter @reflect/desktop test --run src/dev/dev-index-db.test.ts src/mobile/search-filters/filter-state.test.ts`
- `cargo fmt --all -- --check`
- `cargo test -p reflect-cli search_finds_a_multi_term_partial_latin_title`

All commands passed locally.

## Risk / Rollout

Test-only change. There is no runtime behavior, schema, migration, or rollout impact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code, schema, or migration impact.
> 
> **Overview**
> Adds regression coverage for queries like **`Tim Mac`** finding **`Tim MacCaw`** when FTS5 cannot match the partial token `Mac` against `MacCaw`.
> 
> The desktop dev index test runs that query through the **mobile All tab search path** (`buildAllNotesSearch` + `searchPlanFor` → `searchWithFilters`) against a real migrated SQLite/FTS fixture and expects a **title-only hit** (`snippet: null`). A matching **Rust CLI** integration test keeps the mirrored `reflect search` behavior in parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84d21e25116c32952b464dc31c6ea4e5ba298b0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming multi-term searches match titles when each query term matches a word prefix.
  * Added integration coverage for mobile “All notes” searches in the development index.
  * Verified matching results and expected snippet behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->