### PR TITLE
ci: upload to TestFlight when a release is published

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -67,6 +67,17 @@ jobs:
       tag: ${{ needs.release-please.outputs.tag_name }}
     secrets: inherit
 
+  # Every release also ships to TestFlight. iOS needs no version bump of its
+  # own: the marketing version follows apps/desktop/package.json with the
+  # prerelease suffix stripped, so beta and stable builds stack under the same
+  # version, told apart by the UTC-timestamp build number.
+  publish-testflight:
+    name: Upload to TestFlight
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/testflight.yml
+    secrets: inherit
+
   # After a stable release, open a single PR that merges master back into next
   # and advances the beta manifest. A human merges it with a merge commit —
   # never squash, or the two branches diverge for good. This job does not wait

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -16,9 +16,26 @@ on:
         required: true
         type: boolean
         default: true
+  # Called by release-please.yml so every published release also ships to
+  # TestFlight. workflow_call has no choice type; release-ios.mjs validates
+  # the export method.
+  workflow_call:
+    inputs:
+      export_method:
+        description: Xcode export method for the IPA (app-store-connect or release-testing).
+        required: false
+        type: string
+        default: app-store-connect
+      wait_for_processing:
+        description: Wait for App Store Connect processing before finishing.
+        required: false
+        type: boolean
+        default: true
 
 # TestFlight uploads should be serialized so build numbers and App Store
-# Connect processing don't race each other.
+# Connect processing don't race each other. This also holds when the workflow
+# is called from release-please.yml; keep the group name hardcoded, since a
+# `github.workflow` group would resolve to the caller's name there.
 concurrency:
   group: testflight
   cancel-in-progress: false


### PR DESCRIPTION
Chain a `publish-testflight` job off release-please so merging a Release PR also uploads that release commit to TestFlight; manual `workflow_dispatch` stays as the retry path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic TestFlight publishing when a release is created.
  * TestFlight builds now support configurable export methods and processing waits.
  * Release builds use the marketing version and UTC timestamp-based build numbers to distinguish beta and stable releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->