### PR TITLE
feat: add an App Review demo key for audio memo and mobile key-setup guidance

### DIFF
--- a/apps/desktop/src/mobile/audio-memo-fab.tsx
+++ b/apps/desktop/src/mobile/audio-memo-fab.tsx
@@ -11,7 +11,9 @@ import { useMobileAudioMemo } from '@/mobile/audio-memo-provider'
  * feature). Idle starts a memo, recording reads as the stop control, a
  * spinner carries the transcribe/save progress, and a failure turns it red —
  * tapping reopens the drawer with Retry/Discard. Hidden entirely when the
- * feature can't run (no native bridge, or no OpenAI/Gemini model configured).
+ * feature can't run (no native bridge). A missing OpenAI/Gemini model never
+ * hides it: the feature must stay discoverable, so the tap opens the
+ * drawer's key-setup guidance instead of recording.
  */
 export function AudioMemoFab(): ReactElement | null {
   const memo = useMobileAudioMemo()

--- a/apps/desktop/src/mobile/audio-memo-provider.test.tsx
+++ b/apps/desktop/src/mobile/audio-memo-provider.test.tsx
@@ -496,7 +496,7 @@ describe('MobileAudioMemoProvider', () => {
     }
   })
 
-  it('is unavailable without an OpenAI or Gemini model, and toggle does nothing', async () => {
+  it('without an OpenAI or Gemini model, toggle opens the drawer for key setup, never the mic', async () => {
     SETTINGS.current = {
       aiProviders: [
         { id: 'claude', provider: 'anthropic', model: 'claude-fable-5', keyHint: 'wxyz1' },
@@ -505,13 +505,16 @@ describe('MobileAudioMemoProvider', () => {
     }
     const { result } = renderHook(() => useMobileAudioMemo(), { wrapper })
 
-    expect(result.current.available).toBe(false)
+    // The FAB stays visible (available) so the feature is discoverable; only
+    // the recording itself waits for a key.
+    expect(result.current.available).toBe(true)
+    expect(result.current.hasTranscriptionConfig).toBe(false)
 
     await act(async () => {
       result.current.toggle()
     })
+    expect(result.current.drawerOpen).toBe(true)
     expect(result.current.phase).toBe('idle')
-    expect(result.current.drawerOpen).toBe(false)
     expect(recorderControls.startSpy).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/mobile/audio-memo-provider.tsx
+++ b/apps/desktop/src/mobile/audio-memo-provider.tsx
@@ -57,15 +57,17 @@ interface MobileAudioMemoContextValue {
   level: number
   /** Recordings committed but not yet written to the graph. */
   pendingCount: number
-  /** False without the native bridge or a transcription-capable model. */
+  /** False without the native bridge. */
   available: boolean
+  /** False when no OpenAI/Gemini model is configured; the drawer then guides key setup. */
+  hasTranscriptionConfig: boolean
   /** The failure shown in the error phase. */
   error: string | null
   /** True when a retry can re-run the failed capture. */
   canRetry: boolean
   /** The recording drawer's visibility. */
   drawerOpen: boolean
-  /** FAB tap: idle → record; recording → stop & save; error → show it. */
+  /** FAB tap: idle → record (or key setup); recording → stop & save; error → show it. */
   toggle: () => void
   /** The drawer's stop control — commit the memo. */
   stopAndSave: () => void
@@ -163,13 +165,19 @@ export function MobileAudioMemoProvider({
   const stopRecorder = recorder.stop
   const cancelRecorder = recorder.cancel
 
-  const available = hasBridge() && pipeline.hasTranscriptionConfig
+  const available = hasBridge()
 
   const start = useCallback(async (): Promise<void> => {
     if (!available) {
       return
     }
     setDrawerOpen(true)
+    // Recording never starts without a transcription key: the drawer opens on
+    // its key-setup guidance instead. OS entry points (Siri, the widget, the
+    // quick action) funnel through here too, so they surface the same guidance.
+    if (!pipeline.hasTranscriptionConfig) {
+      return
+    }
     try {
       await startRecorder()
       hapticImpactLight()
@@ -273,6 +281,7 @@ export function MobileAudioMemoProvider({
       level: recorder.level,
       pendingCount: pipeline.pendingCount,
       available,
+      hasTranscriptionConfig: pipeline.hasTranscriptionConfig,
       error: pipeline.error,
       canRetry: pipeline.canRetry,
       drawerOpen,
@@ -289,6 +298,7 @@ export function MobileAudioMemoProvider({
       recorder.level,
       pipeline.pendingCount,
       available,
+      pipeline.hasTranscriptionConfig,
       pipeline.error,
       pipeline.canRetry,
       pipeline.retry,

--- a/apps/desktop/src/mobile/recording-drawer.test.tsx
+++ b/apps/desktop/src/mobile/recording-drawer.test.tsx
@@ -9,6 +9,7 @@ const memo = vi.hoisted(() => ({
   level: 0.4,
   pendingCount: 0,
   available: true,
+  hasTranscriptionConfig: true,
   error: null as string | null,
   canRetry: false,
   drawerOpen: true,
@@ -31,12 +32,19 @@ vi.mock('@/mobile/audio-memo-provider', () => ({
   useMobileAudioMemo: () => ({ ...memo }),
 }))
 
+const navigate = vi.hoisted(() => vi.fn())
+
+vi.mock('@/routing/router', () => ({
+  useRouter: () => ({ navigate }),
+}))
+
 const { RecordingDrawer } = await import('./recording-drawer')
 
 beforeEach(() => {
   vi.useRealTimers()
   vi.clearAllMocks()
   memo.phase = 'recording'
+  memo.hasTranscriptionConfig = true
   memo.error = null
   memo.drawerOpen = true
 })
@@ -83,5 +91,18 @@ describe('RecordingDrawer', () => {
     await user.click(view.getByRole('button', { name: 'Stop recording' }))
 
     expect(memo.stopAndSave).toHaveBeenCalledOnce()
+  })
+
+  it('without a transcription model, guides key setup instead of recording', async () => {
+    memo.hasTranscriptionConfig = false
+    const user = userEvent.setup()
+    const view = render(<RecordingDrawer />)
+
+    expect(view.getByText(/OpenAI or Gemini API key/)).not.toBeNull()
+    expect(view.queryByRole('button', { name: 'Stop recording' })).toBeNull()
+
+    await user.click(view.getByRole('button', { name: 'Open Settings' }))
+    expect(navigate).toHaveBeenCalledWith({ kind: 'settings' })
+    expect(memo.onDrawerOpenChange).toHaveBeenCalledWith(false)
   })
 })

--- a/apps/desktop/src/mobile/recording-drawer.tsx
+++ b/apps/desktop/src/mobile/recording-drawer.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
 import { useMobileAudioMemo } from '@/mobile/audio-memo-provider'
 import { RecordingLevelWaveform } from '@/mobile/recording-level-waveform'
+import { useRouter } from '@/routing/router'
 
 /**
  * The recording sheet (V1's recording modal as a bottom drawer): waveform +
@@ -12,6 +13,10 @@ import { RecordingLevelWaveform } from '@/mobile/recording-level-waveform'
  * stops-and-saves — dismissal must never silently drop audio; discarding is
  * explicit and requires a second tap. The provider owns open state and the
  * stop/discard semantics behind `onDrawerOpenChange`.
+ *
+ * Without an OpenAI/Gemini model the sheet shows key-setup guidance instead
+ * of recording controls: the mic FAB stays discoverable, but recording never
+ * starts until transcription has a key to run on.
  */
 export function RecordingDrawer(): ReactElement {
   const memo = useMobileAudioMemo()
@@ -34,6 +39,8 @@ export function RecordingDrawer(): ReactElement {
               </Button>
             </div>
           </div>
+        ) : !memo.hasTranscriptionConfig ? (
+          <KeySetupControls memo={memo} />
         ) : (
           <LiveRecordingControls key={memo.drawerOpen ? 'open' : 'closed'} memo={memo} />
         )}
@@ -46,6 +53,27 @@ type MobileAudioMemo = ReturnType<typeof useMobileAudioMemo>
 
 interface LiveRecordingControlsProps {
   memo: MobileAudioMemo
+}
+
+function KeySetupControls({ memo }: LiveRecordingControlsProps): ReactElement {
+  const { navigate } = useRouter()
+
+  return (
+    <div className="flex flex-col items-center gap-4 px-4 pb-2 text-center">
+      <p className="text-sm text-text-muted">
+        Audio memos are transcribed into your notes with your own OpenAI or Gemini API key. Add
+        one in Settings to start recording.
+      </p>
+      <Button
+        onClick={() => {
+          memo.onDrawerOpenChange(false)
+          navigate({ kind: 'settings' })
+        }}
+      >
+        Open Settings
+      </Button>
+    </div>
+  )
 }
 
 function LiveRecordingControls({ memo }: LiveRecordingControlsProps): ReactElement {

--- a/packages/core/src/actions/audio-memo-review-stub.ts
+++ b/packages/core/src/actions/audio-memo-review-stub.ts
@@ -1,0 +1,17 @@
+/**
+ * The App Review demo key. App Store reviewers have no BYOK key, so this
+ * sentinel (shared with Apple in the App Review notes; not a secret) makes
+ * transcription produce a canned local transcript instead of calling any
+ * provider. Only `memoNoteBody` in `actions/audio-memo` consults it: capture
+ * and note plumbing run exactly as in production, and the network is never
+ * touched.
+ */
+export const APP_REVIEW_STUB_KEY = 'sk-demo-app-review'
+
+export function stubTranscriptBody(): string {
+  return (
+    "This is a demo transcription produced by Reflect's App Review demo key. " +
+    'No audio left the device and no AI provider was called.\n\n' +
+    `Demo transcript generated at ${new Date().toLocaleString()}.`
+  )
+}

--- a/packages/core/src/actions/audio-memo.test.ts
+++ b/packages/core/src/actions/audio-memo.test.ts
@@ -10,6 +10,7 @@ import {
   type ReconcileAudioMemosInput,
   type ReconcileStop,
 } from './audio-memo'
+import { APP_REVIEW_STUB_KEY } from './audio-memo-review-stub'
 import {
   listDir,
   listFiles,
@@ -420,6 +421,29 @@ describe('reconcileAudioMemos', () => {
     expect(writeNoteMock).toHaveBeenCalledWith(
       'daily/2026-06-11.md',
       expect.stringContaining('- [[audio-memo-2026-06-11-153022-845|Audio memo 2026-06-11 15:30:22]]'),
+      3,
+    )
+  })
+
+  it('the App Review demo key writes a canned transcript without any provider call', async () => {
+    listDirMock.mockResolvedValue([fileMeta(MEMO.audioPath)])
+    getSecretMock.mockResolvedValue(APP_REVIEW_STUB_KEY)
+
+    const outcome = await reconcile()
+
+    expect(outcome).toEqual({ pending: 1, transcribed: 1, rejected: 0, stopped: null })
+    expect(transcribeMock).not.toHaveBeenCalled()
+    expect(generateAudioMemoTitleMock).not.toHaveBeenCalled()
+    expect(writeNoteMock).toHaveBeenCalledWith(
+      MEMO.notePath,
+      expect.stringContaining('demo transcription'),
+      3,
+    )
+    expect(writeNoteMock).toHaveBeenCalledWith(
+      'daily/2026-06-11.md',
+      expect.stringContaining(
+        '- [[audio-memo-2026-06-11-153022-845|Audio memo 2026-06-11 15:30:22]]',
+      ),
       3,
     )
   })

--- a/packages/core/src/actions/audio-memo.ts
+++ b/packages/core/src/actions/audio-memo.ts
@@ -6,6 +6,7 @@ import {
 } from '../ai/provider-config'
 import { aiKeySecretName } from '../ai/secrets'
 import { generateAudioMemoTitle, pickAudioMemoTitleConfig } from '../ai/audio-memo-title'
+import { APP_REVIEW_STUB_KEY, stubTranscriptBody } from './audio-memo-review-stub'
 import {
   AUDIO_EXTENSION_BY_MIME,
   base64ToBytes,
@@ -265,6 +266,9 @@ async function memoNoteBody(input: {
   titleCredentials: { config: AiProviderConfig; apiKey: string } | null
   fetchFn?: typeof fetch | undefined
 }): Promise<{ body: string; title: string; rejected: boolean }> {
+  if (input.apiKey === APP_REVIEW_STUB_KEY) {
+    return { body: stubTranscriptBody(), title: input.memo.title, rejected: false }
+  }
   try {
     const text = await transcribeAudio({
       provider: input.config.provider,


### PR DESCRIPTION
The mobile record button now shows without a configured OpenAI/Gemini model and opens key-setup guidance instead of recording (recording itself still requires a key), and the hardcoded `sk-demo-app-review` key produces a canned local transcript so App Store reviewers can exercise the flow without a real key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio memo controls remain discoverable even when transcription isn’t configured.
  * Selecting the control now opens setup guidance instead of attempting to record.
  * Added a direct option to open Settings and configure transcription.
  * Added an App Review demonstration flow that provides a sample transcript without sending audio to an AI provider.

* **Bug Fixes**
  * Prevented recording from starting when required transcription setup is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->