### PR TITLE
chore: use fix semantic commit type for meowdown updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,9 @@
       "minimumReleaseAge": "0 days",
       "prPriority": 100,
       "dependencyDashboardApproval": false,
-      "draftPR": false
+      "draftPR": false,
+      "semanticCommitType": "fix",
+      "semanticCommitScope": null
     }
   ]
 }


### PR DESCRIPTION
Renovate PRs for the meowdown group currently get titles like `chore(deps): update meowdown to ^0.43.0`. Since meowdown bumps ship editor fixes to users, they should appear in the changelog as patch releases.

This sets `semanticCommitType: fix` and `semanticCommitScope: null` on the existing meowdown package rule, so those PRs are now titled `fix: update meowdown to ^0.43.0`. Other dependency updates keep the default `chore(deps):` prefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency commits to use standardized “fix” commit messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->