### PR TITLE
fix(audio-memo): let the App Review demo key pass API key validation

### DIFF
--- a/packages/core/src/actions/audio-memo.test.ts
+++ b/packages/core/src/actions/audio-memo.test.ts
@@ -10,7 +10,7 @@ import {
   type ReconcileAudioMemosInput,
   type ReconcileStop,
 } from './audio-memo'
-import { APP_REVIEW_STUB_KEY } from './audio-memo-review-stub'
+import { APP_REVIEW_STUB_KEY } from '../ai/audio-memo-review-stub'
 import {
   listDir,
   listFiles,

--- a/packages/core/src/actions/audio-memo.ts
+++ b/packages/core/src/actions/audio-memo.ts
@@ -6,7 +6,7 @@ import {
 } from '../ai/provider-config'
 import { aiKeySecretName } from '../ai/secrets'
 import { generateAudioMemoTitle, pickAudioMemoTitleConfig } from '../ai/audio-memo-title'
-import { APP_REVIEW_STUB_KEY, stubTranscriptBody } from './audio-memo-review-stub'
+import { APP_REVIEW_STUB_KEY, stubTranscriptBody } from '../ai/audio-memo-review-stub'
 import {
   AUDIO_EXTENSION_BY_MIME,
   base64ToBytes,

--- a/packages/core/src/ai/audio-memo-review-stub.ts
+++ b/packages/core/src/ai/audio-memo-review-stub.ts
@@ -1,10 +1,12 @@
 /**
  * The App Review demo key. App Store reviewers have no BYOK key, so this
  * sentinel (shared with Apple in the App Review notes; not a secret) makes
- * transcription produce a canned local transcript instead of calling any
- * provider. Only `memoNoteBody` in `actions/audio-memo` consults it: capture
- * and note plumbing run exactly as in production, and the network is never
- * touched.
+ * the app behave as if a real key was entered while never touching the
+ * network. Exactly two places consult it: `validateApiKey` accepts it without
+ * probing the provider (a real probe would 401 and block saving it), and
+ * `memoNoteBody` in `actions/audio-memo` returns a canned local transcript
+ * instead of calling any provider. Capture and note plumbing run exactly as
+ * in production.
  */
 export const APP_REVIEW_STUB_KEY = 'sk-demo-app-review'
 

--- a/packages/core/src/ai/audio-memo-review-stub.ts
+++ b/packages/core/src/ai/audio-memo-review-stub.ts
@@ -8,7 +8,7 @@
  * instead of calling any provider. Capture and note plumbing run exactly as
  * in production.
  */
-export const APP_REVIEW_STUB_KEY = 'sk-demo-app-review'
+export const APP_REVIEW_STUB_KEY = 'sk-demo'
 
 export function stubTranscriptBody(): string {
   return (

--- a/packages/core/src/ai/validate-key.test.ts
+++ b/packages/core/src/ai/validate-key.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { APP_REVIEW_STUB_KEY } from './audio-memo-review-stub'
 import { validateApiKey } from './validate-key'
 
 function fetchReturning(status: number): typeof fetch {
@@ -38,6 +39,10 @@ describe('validateApiKey', () => {
 
   it('reads an ok response as valid', async () => {
     expect(await validateApiKey('openai', 'sk-test', fetchReturning(200))).toBe('valid')
+  })
+
+  it('accepts the App Review demo key without probing the provider', async () => {
+    expect(await validateApiKey('openai', APP_REVIEW_STUB_KEY, fetchThrowing)).toBe('valid')
   })
 
   it('reads an auth rejection as invalid', async () => {

--- a/packages/core/src/ai/validate-key.ts
+++ b/packages/core/src/ai/validate-key.ts
@@ -1,5 +1,6 @@
 import type { AiProviderId } from '../settings/schema'
 import { anthropicDirectBrowserAccessHeaders } from './anthropic-headers'
+import { APP_REVIEW_STUB_KEY } from './audio-memo-review-stub'
 import { OPENROUTER_BASE_URL } from './openrouter'
 
 /**
@@ -61,6 +62,12 @@ export async function validateApiKey(
   apiKey: string,
   fetchFn: typeof fetch = fetch,
 ): Promise<ApiKeyValidation> {
+  // Providers know nothing about the App Review demo key, so a probe would
+  // reject it; accept it here so it can be saved and reach the canned
+  // transcription path.
+  if (apiKey === APP_REVIEW_STUB_KEY) {
+    return 'valid'
+  }
   const probe = PROBES[provider]
   let response: Response
   try {


### PR DESCRIPTION
The App Review demo key failed the live `validateApiKey` probe (the provider 401s it) so it could never be saved; `validateApiKey` now accepts it without a probe, and the key is shortened to `sk-demo` for easier typing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for a demo API key that is accepted immediately without contacting an external AI provider.
  - Demo audio memo processing now provides a canned transcript explaining that audio remains on the device and no AI service was contacted.
- **Bug Fixes**
  - Improved demo-mode behavior by preventing unnecessary network validation requests.
- **Tests**
  - Added coverage confirming the demo key validates successfully without network access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->