### PR TITLE
fix(mobile): show the Settings version without the prerelease tag

### DIFF
--- a/apps/desktop/src/lib/marketing-version.test.ts
+++ b/apps/desktop/src/lib/marketing-version.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { marketingVersion } from './marketing-version'
+
+describe('marketingVersion', () => {
+  it('strips the prerelease tag', () => {
+    expect(marketingVersion('0.6.0-beta.6')).toBe('0.6.0')
+  })
+
+  it('strips build metadata', () => {
+    expect(marketingVersion('0.6.0+20260711')).toBe('0.6.0')
+  })
+
+  it('keeps a stable version unchanged', () => {
+    expect(marketingVersion('0.6.0')).toBe('0.6.0')
+  })
+})

--- a/apps/desktop/src/lib/marketing-version.ts
+++ b/apps/desktop/src/lib/marketing-version.ts
@@ -1,0 +1,10 @@
+/**
+ * The version with any prerelease tag or build metadata stripped:
+ * `0.6.0-beta.6` becomes `0.6.0`. Matches how Tauri renders
+ * `CFBundleShortVersionString` (Apple allows only three numeric parts), so
+ * mobile Settings shows the same version as the App Store listing and a
+ * promoted TestFlight build never surfaces `-beta.N` to production users.
+ */
+export function marketingVersion(version: string): string {
+  return version.replace(/[-+].*$/, '')
+}

--- a/apps/desktop/src/mobile/screens/settings.test.tsx
+++ b/apps/desktop/src/mobile/screens/settings.test.tsx
@@ -30,7 +30,7 @@ vi.mock('@/providers/graph-provider', () => ({
     mobileStorageKind: graphState.mobileStorageKind,
   }),
 }))
-vi.mock('@/hooks/use-app-version', () => ({ useAppVersion: () => '1.2.3' }))
+vi.mock('@/hooks/use-app-version', () => ({ useAppVersion: () => '1.2.3-beta.4' }))
 
 const settingsState = vi.hoisted(() => ({ current: {} as Settings }))
 const updateSettings = vi.hoisted(() => vi.fn())

--- a/apps/desktop/src/mobile/screens/settings.tsx
+++ b/apps/desktop/src/mobile/screens/settings.tsx
@@ -11,6 +11,7 @@ import {
 } from '@reflect/core'
 import { useAiProviders } from '@/hooks/use-ai-providers'
 import { useAppVersion } from '@/hooks/use-app-version'
+import { marketingVersion } from '@/lib/marketing-version'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { AddAiProviderDrawer } from '@/mobile/add-ai-provider-drawer'
 import { AiProviderActionsDrawer } from '@/mobile/ai-provider-actions-drawer'
@@ -213,7 +214,10 @@ export function MobileSettings(): ReactElement {
               label="Notes"
               value={notes === undefined ? '…' : String(notes.length)}
             />
-            <SettingsValueRow label="Version" value={version ?? '…'} />
+            <SettingsValueRow
+              label="Version"
+              value={version === null ? '…' : marketingVersion(version)}
+            />
           </SettingsGroup>
         </div>
       </main>


### PR DESCRIPTION
Mobile Settings now strips the prerelease tag from the displayed app version, so a TestFlight build promoted to the App Store shows `0.6.0` instead of `0.6.0-beta.6`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the mobile Settings screen to show a simplified app version, removing prerelease and build metadata from displayed version numbers.
  * Version information remains unchanged for stable releases.
  * The existing placeholder continues to appear when the app version is unavailable.

* **Tests**
  * Added coverage for prerelease, build metadata, stable version, and updated mobile Settings display scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->