### PR TITLE
fix: harden cross-device title resolution

### DIFF
--- a/apps/desktop/src-tauri/src/fs/io.rs
+++ b/apps/desktop/src-tauri/src/fs/io.rs
@@ -450,6 +450,55 @@ mod tests {
     }
 
     #[test]
+    fn atomic_create_allows_exactly_one_concurrent_claim() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        let dir = tempdir().unwrap();
+        bootstrap(dir.path()).unwrap();
+        let root = Arc::new(dir.path().to_path_buf());
+        let barrier = Arc::new(Barrier::new(2));
+
+        let claim = |contents: &'static str| {
+            let root = Arc::clone(&root);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                let target = root.join("notes/business-ideas.md");
+                barrier.wait();
+                (contents, atomic_create(&root, &target, contents).unwrap())
+            })
+        };
+        let first = claim("# First\n");
+        let second = claim("# Second\n");
+        let outcomes = [first.join().unwrap(), second.join().unwrap()];
+
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|(_, outcome)| matches!(outcome, AtomicCreateOutcome::Created(_)))
+                .count(),
+            1
+        );
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|(_, outcome)| matches!(outcome, AtomicCreateOutcome::Collision))
+                .count(),
+            1
+        );
+        let winner = outcomes
+            .iter()
+            .find_map(|(contents, outcome)| {
+                matches!(outcome, AtomicCreateOutcome::Created(_)).then_some(*contents)
+            })
+            .unwrap();
+        assert_eq!(
+            fs::read_to_string(root.join("notes/business-ideas.md")).unwrap(),
+            winner
+        );
+    }
+
+    #[test]
     fn atomic_create_treats_an_eviction_placeholder_as_a_collision() {
         let dir = tempdir().unwrap();
         bootstrap(dir.path()).unwrap();

--- a/apps/desktop/src/components/backlinks-panel.test.tsx
+++ b/apps/desktop/src/components/backlinks-panel.test.tsx
@@ -7,12 +7,12 @@ import { RouterProvider, useRouter } from '@/routing/router'
 import { BacklinksPanel } from './backlinks-panel'
 
 const getBacklinksWithContext = vi.hoisted(() => vi.fn())
-const resolveWikiTarget = vi.hoisted(() => vi.fn())
+const resolveOrCreateNoteWithTitle = vi.hoisted(() => vi.fn())
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   hasBridge: () => true,
   getBacklinksWithContext,
-  resolveWikiTarget,
+  resolveOrCreateNoteWithTitle,
 }))
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({ graph: { root: '/g', name: 'g', generation: 1 } }),
@@ -42,7 +42,7 @@ function renderPanel(path: string) {
 beforeEach(() => {
   window.sessionStorage.clear()
   getBacklinksWithContext.mockReset()
-  resolveWikiTarget.mockReset()
+  resolveOrCreateNoteWithTitle.mockReset()
 })
 
 describe('BacklinksPanel', () => {
@@ -87,7 +87,10 @@ describe('BacklinksPanel', () => {
         tasks: [],
       },
     ])
-    resolveWikiTarget.mockResolvedValue({ kind: 'resolved', ref: 'notes/roadmap.md' })
+    resolveOrCreateNoteWithTitle.mockResolvedValue({
+      kind: 'resolved',
+      path: 'notes/roadmap.md',
+    })
     const view = renderPanel('notes/source.md')
 
     // The [[Roadmap]] source renders as a chip whose label is the bare target,

--- a/apps/desktop/src/editor/ambiguous-note-feedback.ts
+++ b/apps/desktop/src/editor/ambiguous-note-feedback.ts
@@ -2,12 +2,12 @@ import { startOperation } from '@/lib/operations'
 
 /**
  * The one user-visible refusal for an `ambiguous` title resolution
- * (`resolveOrCreateNoteWithTitle`): several notes claim the title's fallback
- * key, so neither navigation nor creation can safely pick one. Autocomplete
- * is the disambiguator — its rows carry the distinct titles.
+ * (`resolveOrCreateNoteWithTitle`): several notes may claim the title's exact
+ * or fallback key, or an unavailable collision prevents proving uniqueness.
+ * Neither navigation nor creation may guess in those states.
  */
 export function reportAmbiguousNoteTitle(operationLabel: string, title: string): void {
   startOperation(operationLabel).fail(
-    `Couldn’t safely choose one note matching “${title}”. Choose the intended note from autocomplete.`,
+    `Couldn’t safely choose one note matching “${title}”. Rename conflicting notes or wait for unavailable notes to become available, then try again.`,
   )
 }

--- a/apps/desktop/src/editor/document-binding.ts
+++ b/apps/desktop/src/editor/document-binding.ts
@@ -82,10 +82,10 @@ export function createDocumentBinding(): DocumentBinding {
     // rename tracker via onContent('saved'); settle after it so a just-edited
     // title still renames on the way out.
     const settled = target.flush()
-    // `flush()` synchronously asks the live editor to reconcile native input;
-    // Meowdown reports a resulting document change through onDocChange. Keep
-    // the target discoverable for that callback, then release ownership before
-    // any asynchronous write settles or a replacement session binds.
+    // `flush()` may synchronously report reconciled editor input through the
+    // change callback. Keep the target discoverable for that re-entry, then
+    // release ownership before any asynchronous write settles or a replacement
+    // session binds.
     if (session === target) {
       session = null
       coordinator = null

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -58,7 +58,11 @@ import { cn } from '@/lib/utils'
 
 /** Imperative surface for note switching, reload, and save flushes. */
 export interface NoteEditorHandle {
-  /** Serialize the current, settled document to Markdown. */
+  /**
+   * Reconcile pending native input, then serialize the current document to
+   * Markdown. If reconciliation changes the document, `onChange` may run
+   * synchronously before this method returns.
+   */
   getMarkdown(): string
   /** Replace the document (note switch / external reload). */
   setMarkdown(markdown: string): void

--- a/apps/desktop/src/editor/note-session-state.ts
+++ b/apps/desktop/src/editor/note-session-state.ts
@@ -7,7 +7,7 @@ const DEFAULT_SAVE_DEBOUNCE_MS = 800
 
 /** Create the document session for one note. See note-session.ts for semantics. */
 export function createNoteSession(options: NoteSessionOptions): NoteSession {
-  const { io, classify, onSnapshot, applyContent, onContent, reconcileEditorInput } = options
+  const { io, classify, onSnapshot, applyContent, onContent, reconcilePendingEditorInput } = options
   /** Mutable: a rename retargets the session in place (Plan 17). */
   let path = options.path
   const createIfMissing = options.createIfMissing ?? false
@@ -142,7 +142,7 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
   }
 
   function flush(): Promise<void> {
-    reconcileEditorInput?.()
+    reconcilePendingEditorInput?.()
     cancelScheduledSave()
     save()
     // save() extended the chain synchronously (or left it settled when there

--- a/apps/desktop/src/editor/note-session-types.ts
+++ b/apps/desktop/src/editor/note-session-types.ts
@@ -79,12 +79,13 @@ export interface NoteSessionOptions {
    */
   applyContent: (markdown: string) => void
   /**
-   * Ask the live editor to reconcile native input immediately before
-   * persistence. Meowdown synchronously emits `onDocChange` only when that
-   * reconciliation changes the document, which updates the session buffer
-   * without treating a normalized but unchanged snapshot as a user edit.
+   * Ask the live editor to reconcile pending native input immediately before
+   * persistence. When reconciliation changes the document, the implementation
+   * must deliver that change to {@link NoteSession.editorChanged} synchronously
+   * before returning. A normalized but unchanged snapshot must not be emitted
+   * as an edit.
    */
-  reconcileEditorInput?: () => void
+  reconcilePendingEditorInput?: () => void
   /**
    * Treat a missing file as an empty note on load instead of an error; the
    * file is then created by the first save — Plan 06's lazy daily-note

--- a/apps/desktop/src/editor/note-session.test.ts
+++ b/apps/desktop/src/editor/note-session.test.ts
@@ -35,7 +35,7 @@ function harness(options?: {
   disk?: string | null
   createIfMissing?: boolean
   missingSeed?: string
-  reconcileEditorInput?: () => void
+  reconcilePendingEditorInput?: () => void
 }): Harness {
   const snapshots: NoteSessionSnapshot[] = []
   const writes: Array<{ path: string; contents: string }> = []
@@ -68,9 +68,9 @@ function harness(options?: {
     applyContent: (markdown) => {
       applied.push(markdown)
     },
-    ...(options?.reconcileEditorInput === undefined
+    ...(options?.reconcilePendingEditorInput === undefined
       ? {}
-      : { reconcileEditorInput: options.reconcileEditorInput }),
+      : { reconcilePendingEditorInput: options.reconcilePendingEditorInput }),
     onContent: (content, origin) => {
       contents.push({ content, origin })
     },
@@ -135,10 +135,10 @@ describe('createNoteSession', () => {
 
   it('reconciles pending editor input before a flush snapshots the buffer', async () => {
     let target: ReturnType<typeof createNoteSession> | null = null
-    const reconcileEditorInput = vi.fn(() => {
+    const reconcilePendingEditorInput = vi.fn(() => {
       target?.editorChanged('# 🧠 Business ideas\n')
     })
-    const { session, writes } = harness({ reconcileEditorInput })
+    const { session, writes } = harness({ reconcilePendingEditorInput })
     target = session
     session.load()
     await settled()
@@ -146,7 +146,7 @@ describe('createNoteSession', () => {
     session.editorChanged('# Business ideas\n')
     await session.flush()
 
-    expect(reconcileEditorInput).toHaveBeenCalledOnce()
+    expect(reconcilePendingEditorInput).toHaveBeenCalledOnce()
     expect(writes).toEqual([
       { path: 'notes/a.md', contents: '# 🧠 Business ideas\n' },
     ])

--- a/apps/desktop/src/editor/use-editor-autocomplete.test.tsx
+++ b/apps/desktop/src/editor/use-editor-autocomplete.test.tsx
@@ -54,7 +54,22 @@ describe('useEditorAutocomplete', () => {
     )
     expect(startOperation).toHaveBeenCalledWith('Creating note')
     expect(operationFail).toHaveBeenCalledWith(
-      'Couldn’t safely choose one note matching “Business ideas”. Choose the intended note from autocomplete.',
+      'Couldn’t safely choose one note matching “Business ideas”. Rename conflicting notes or wait for unavailable notes to become available, then try again.',
     )
+  })
+
+  it('surfaces a failed background create instead of silently doing nothing', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    resolveOrCreateNoteWithTitle.mockRejectedValue(new Error('graph changed'))
+    const { result } = renderHook(() => useEditorAutocomplete())
+    const items = await result.current.onWikilinkSearch('Business ideas')
+
+    act(() => {
+      items[0]!.onSelect?.()
+    })
+
+    await waitFor(() => expect(operationFail).toHaveBeenCalledWith('graph changed'))
+    expect(startOperation).toHaveBeenCalledWith('Creating note')
+    consoleError.mockRestore()
   })
 })

--- a/apps/desktop/src/editor/use-editor-autocomplete.ts
+++ b/apps/desktop/src/editor/use-editor-autocomplete.ts
@@ -7,6 +7,7 @@ import {
 } from '@meowdown/react'
 import {
   contactLinkSuggestions,
+  errorMessage,
   hasBridge,
   isContactsReadable,
   resolveOrCreateNoteWithTitle,
@@ -18,6 +19,7 @@ import { buildAutocompleteEntries } from '@/editor/wiki-autocomplete-entries'
 import { useContactsAuthorization } from '@/hooks/use-contacts-authorization'
 import { formatDayLabel, todayIso } from '@/lib/dates'
 import { createPersonNoteFromContact } from '@/lib/note-contact'
+import { startOperation } from '@/lib/operations'
 import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
 
@@ -99,6 +101,7 @@ export function useEditorAutocomplete(): EditorAutocomplete {
             onSelect: () => {
               void resolveOrCreateFromAutocomplete(entry.title).catch((error: unknown) => {
                 console.error('create-from-autocomplete failed:', error)
+                startOperation('Creating note').fail(errorMessage(error))
               })
             },
           }

--- a/apps/desktop/src/editor/use-note-document.test.tsx
+++ b/apps/desktop/src/editor/use-note-document.test.tsx
@@ -899,7 +899,7 @@ describe('useNoteDocument', () => {
       })
       act(() => hook.result.current.bindEditor(editor))
 
-      // Changing an IO option recreates the session without unmounting the
+      // Changing a session option recreates the session without unmounting the
       // editor. The outgoing session must remain discoverable while Meowdown
       // synchronously reports reconciled native input from getMarkdown().
       hook.rerender({ createIfMissing: true })

--- a/apps/desktop/src/editor/use-note-document.ts
+++ b/apps/desktop/src/editor/use-note-document.ts
@@ -134,7 +134,7 @@ export function useNoteDocument(
             setSnapshot(next)
           },
           applyContent: (markdown) => editorRef.current?.setMarkdown(markdown),
-          reconcileEditorInput: () => {
+          reconcilePendingEditorInput: () => {
             // Meowdown 0.43.1 synchronously emits onDocChange only when this
             // reconciliation changes the document. Discarding the always-
             // returned snapshot avoids dirtying files whose serialization is

--- a/apps/desktop/src/editor/use-wiki-link-navigation.test.tsx
+++ b/apps/desktop/src/editor/use-wiki-link-navigation.test.tsx
@@ -61,16 +61,23 @@ beforeEach(() => {
 
 describe('useWikiLinkNavigation', () => {
   it('navigates to the resolved note', async () => {
-    resolveWikiTarget.mockResolvedValue({ kind: 'resolved', ref: 'notes/target.md' })
+    resolveOrCreateNoteWithTitle.mockResolvedValue({
+      kind: 'resolved',
+      path: 'notes/target.md',
+    })
     const view = renderHost()
     lastHandler?.('Target')
     await waitFor(() => expect(currentRoute(view)).toContain('notes/target.md'))
-    expect(resolveOrCreateNoteWithTitle).not.toHaveBeenCalled()
+    expect(resolveOrCreateNoteWithTitle).toHaveBeenCalledWith('Target', 1)
+    expect(resolveWikiTarget).not.toHaveBeenCalled()
     view.unmount()
   })
 
   it('arrives at a resolved note without a focus intent (no keyboard on navigation)', async () => {
-    resolveWikiTarget.mockResolvedValue({ kind: 'resolved', ref: 'notes/target.md' })
+    resolveOrCreateNoteWithTitle.mockResolvedValue({
+      kind: 'resolved',
+      path: 'notes/target.md',
+    })
     const view = renderHost()
     lastHandler?.('Target')
     await waitFor(() => expect(currentRoute(view)).toContain('notes/target.md'))
@@ -89,8 +96,32 @@ describe('useWikiLinkNavigation', () => {
     view.unmount()
   })
 
+  it('preserves an existing regular note titled as an ISO date', async () => {
+    resolveWikiTarget.mockResolvedValue({ kind: 'resolved', ref: 'notes/2026-06-09.md' })
+    const view = renderHost()
+
+    lastHandler?.('2026-06-09')
+
+    await waitFor(() => expect(currentRoute(view)).toContain('"note"'))
+    expect(currentRoute(view)).toContain('notes/2026-06-09.md')
+    view.unmount()
+  })
+
+  it('routes a resolved daily alias through the daily view', async () => {
+    resolveOrCreateNoteWithTitle.mockResolvedValue({
+      kind: 'resolved',
+      path: 'daily/2026-06-09.md',
+    })
+    const view = renderHost()
+
+    lastHandler?.('Project log')
+
+    await waitFor(() => expect(currentRoute(view)).toContain('"daily"'))
+    expect(currentRoute(view)).toContain('2026-06-09')
+    view.unmount()
+  })
+
   it('creates and opens an unresolved title, without a focus intent', async () => {
-    resolveWikiTarget.mockResolvedValue({ kind: 'unresolved', text: 'Brand New' })
     resolveOrCreateNoteWithTitle.mockResolvedValue({
       kind: 'created',
       path: 'notes/created.md',
@@ -114,17 +145,20 @@ describe('useWikiLinkNavigation', () => {
   })
 
   it('ignores an unresolved empty target', async () => {
-    resolveWikiTarget.mockResolvedValue({ kind: 'unresolved', text: '   ' })
     const view = renderHost()
     lastHandler?.('   ')
-    await waitFor(() => expect(resolveWikiTarget).toHaveBeenCalled())
+    await new Promise((tick) => setTimeout(tick, 0))
+    expect(resolveWikiTarget).not.toHaveBeenCalled()
     expect(resolveOrCreateNoteWithTitle).not.toHaveBeenCalled()
     expect(currentRoute(view)).toContain('"today"')
     view.unmount()
   })
 
   it('⌘-click opens the resolved note in a new window instead of navigating', async () => {
-    resolveWikiTarget.mockResolvedValue({ kind: 'resolved', ref: 'notes/target.md' })
+    resolveOrCreateNoteWithTitle.mockResolvedValue({
+      kind: 'resolved',
+      path: 'notes/target.md',
+    })
     const view = renderHost()
     lastHandler?.('Target', new MouseEvent('click', { metaKey: true }))
     await waitFor(() =>
@@ -135,7 +169,6 @@ describe('useWikiLinkNavigation', () => {
   })
 
   it('⌘-click on an unresolved title still creates, then opens the new window', async () => {
-    resolveWikiTarget.mockResolvedValue({ kind: 'unresolved', text: 'Brand New' })
     resolveOrCreateNoteWithTitle.mockResolvedValue({
       kind: 'created',
       path: 'notes/created.md',
@@ -150,8 +183,7 @@ describe('useWikiLinkNavigation', () => {
     view.unmount()
   })
 
-  it('does not navigate when the on-disk fallback is ambiguous', async () => {
-    resolveWikiTarget.mockResolvedValue({ kind: 'unresolved', text: 'Business ideas' })
+  it('does not navigate when indexed or on-disk title resolution is ambiguous', async () => {
     resolveOrCreateNoteWithTitle.mockResolvedValue({
       kind: 'ambiguous',
       paths: ['notes/business-ideas.md', 'notes/business-ideas-2.md'],
@@ -160,15 +192,33 @@ describe('useWikiLinkNavigation', () => {
     lastHandler?.('Business ideas')
     await waitFor(() => expect(resolveOrCreateNoteWithTitle).toHaveBeenCalled())
     expect(currentRoute(view)).toContain('"today"')
+    expect(resolveWikiTarget).not.toHaveBeenCalled()
     expect(startOperation).toHaveBeenCalledWith('Opening link')
     expect(operationFail).toHaveBeenCalledWith(
-      'Couldn’t safely choose one note matching “Business ideas”. Choose the intended note from autocomplete.',
+      'Couldn’t safely choose one note matching “Business ideas”. Rename conflicting notes or wait for unavailable notes to become available, then try again.',
     )
     view.unmount()
   })
 
+  it('surfaces a resolution failure instead of silently doing nothing', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    resolveOrCreateNoteWithTitle.mockRejectedValue(new Error('index unavailable'))
+    const view = renderHost()
+
+    lastHandler?.('Business ideas')
+
+    await waitFor(() => expect(operationFail).toHaveBeenCalledWith('index unavailable'))
+    expect(startOperation).toHaveBeenCalledWith('Opening link')
+    expect(currentRoute(view)).toContain('"today"')
+    consoleError.mockRestore()
+    view.unmount()
+  })
+
   it('a declined new-window open falls back to in-window navigation', async () => {
-    resolveWikiTarget.mockResolvedValue({ kind: 'resolved', ref: 'notes/target.md' })
+    resolveOrCreateNoteWithTitle.mockResolvedValue({
+      kind: 'resolved',
+      path: 'notes/target.md',
+    })
     openRouteInNewWindow.mockResolvedValue(false)
     const view = renderHost()
     lastHandler?.('Target', new MouseEvent('click', { metaKey: true }))
@@ -177,7 +227,10 @@ describe('useWikiLinkNavigation', () => {
   })
 
   it('a Mod-Enter keyboard follow stays in-window despite the held modifier', async () => {
-    resolveWikiTarget.mockResolvedValue({ kind: 'resolved', ref: 'notes/target.md' })
+    resolveOrCreateNoteWithTitle.mockResolvedValue({
+      kind: 'resolved',
+      path: 'notes/target.md',
+    })
     const view = renderHost()
     lastHandler?.('Target', new KeyboardEvent('keydown', { metaKey: true }))
     await waitFor(() => expect(currentRoute(view)).toContain('notes/target.md'))
@@ -186,8 +239,8 @@ describe('useWikiLinkNavigation', () => {
   })
 
   it('drops a resolution that lands after the host unmounts', async () => {
-    let resolve: (value: { kind: 'resolved'; ref: string }) => void = () => {}
-    resolveWikiTarget.mockReturnValue(
+    let resolve: (value: { kind: 'resolved'; path: string }) => void = () => {}
+    resolveOrCreateNoteWithTitle.mockReturnValue(
       new Promise((promiseResolve) => {
         resolve = promiseResolve
       }),
@@ -206,7 +259,7 @@ describe('useWikiLinkNavigation', () => {
         <RouteProbe key="probe" />
       </RouterProvider>,
     )
-    resolve({ kind: 'resolved', ref: 'notes/target.md' })
+    resolve({ kind: 'resolved', path: 'notes/target.md' })
     await new Promise((tick) => setTimeout(tick, 0))
     expect(view.getByTestId('route').textContent).toContain('"today"')
     view.unmount()

--- a/apps/desktop/src/editor/use-wiki-link-navigation.ts
+++ b/apps/desktop/src/editor/use-wiki-link-navigation.ts
@@ -1,19 +1,24 @@
 import { useCallback, useEffect, useRef } from 'react'
-import { resolveOrCreateNoteWithTitle, resolveWikiTarget } from '@reflect/core'
+import {
+  errorMessage,
+  normalizeWikiTarget,
+  resolveOrCreateNoteWithTitle,
+  resolveWikiTarget,
+} from '@reflect/core'
 import { reportAmbiguousNoteTitle } from '@/editor/ambiguous-note-feedback'
-import { isIsoDate } from '@/lib/dates'
+import { startOperation } from '@/lib/operations'
 import { isNewWindowClick, openRouteInNewWindow } from '@/lib/windows/open-in-new-window'
 import { routeForPath, type Route } from '@/routing/route'
 import { useRouter } from '@/routing/router'
 
 /**
- * Navigation for a clicked `[[wiki link]]`: resolve via the index, then open
- * the target. An unresolved ISO date is still a valid daily target (created
- * lazily on first write). An unresolved non-empty title is rechecked against
- * the index and its on-disk slug family before it can be created and opened —
- * Plan 07's create-from-unresolved with a guard for a lagging device index and
- * title/path mismatch. With no graph generation available, unresolved titles
- * are a no-op (nothing can be written).
+ * Navigation for a clicked `[[wiki link]]`. Calendar-valid ISO dates preserve
+ * ordinary resolution precedence, then open their lazy daily route on a miss.
+ * Every other writable title goes through the ambiguity-preserving index +
+ * disk resolver before it opens or creates, so an indexed duplicate cannot
+ * bypass the same guard used for an index miss. With no graph generation
+ * available, existing titles still use the read-only index resolver and
+ * unresolved titles are a no-op.
  *
  * A ⌘-click (the originating `event`, when the caller passes it) opens the
  * resolved target in a secondary note window instead — falling back to
@@ -62,31 +67,48 @@ export function useWikiLinkNavigation(
       }
       void (async () => {
         try {
-          const resolution = await resolveWikiTarget(target)
-          if (unmountedRef.current) {
+          const normalized = normalizeWikiTarget(target)
+          if (normalized.raw === '') {
             return
           }
-          if (resolution.kind === 'resolved') {
-            const route = routeForPath(resolution.ref)
-            // Deliberately no focus request: on mobile, focusing mid-arrival
-            // raises the keyboard through the stack animation. Desktop
-            // autofocuses note arrivals on its own.
-            await open(route)
-          } else if (isIsoDate(resolution.text)) {
-            await open({ kind: 'daily', date: resolution.text })
-          } else if (generation !== null && resolution.text.trim() !== '') {
-            const outcome = await resolveOrCreateNoteWithTitle(resolution.text, generation)
+          if (normalized.date !== undefined) {
+            const resolution = await resolveWikiTarget(normalized.raw)
+            if (unmountedRef.current) {
+              return
+            }
+            await open(
+              resolution.kind === 'resolved'
+                ? routeForPath(resolution.ref)
+                : { kind: 'daily', date: normalized.date },
+            )
+            return
+          }
+          if (generation !== null) {
+            const outcome = await resolveOrCreateNoteWithTitle(normalized.raw, generation)
             if (unmountedRef.current) {
               return
             }
             if (outcome.kind === 'ambiguous') {
-              reportAmbiguousNoteTitle('Opening link', resolution.text)
+              reportAmbiguousNoteTitle('Opening link', normalized.raw)
             } else {
-              await open({ kind: 'note', path: outcome.path })
+              await open(routeForPath(outcome.path))
             }
+            return
+          }
+
+          const resolution = await resolveWikiTarget(normalized.raw)
+          if (unmountedRef.current) {
+            return
+          }
+          if (resolution.kind === 'resolved') {
+            // Deliberately no focus request: on mobile, focusing mid-arrival
+            // raises the keyboard through the stack animation. Desktop
+            // autofocuses note arrivals on its own.
+            await open(routeForPath(resolution.ref))
           }
         } catch (err) {
           console.error('wiki-link resolution failed:', err)
+          startOperation('Opening link').fail(errorMessage(err))
         }
       })()
     },

--- a/apps/desktop/src/lib/backup-controller.test.ts
+++ b/apps/desktop/src/lib/backup-controller.test.ts
@@ -44,6 +44,10 @@ interface FakeOptions {
   failStatus?: boolean
   /** Scripted `git_merge_remote` outcome (defaults to up-to-date). */
   mergeOutcome?: unknown
+  /** Per-call merge outcomes for retry/convergence tests. */
+  mergeOutcomes?: unknown[]
+  /** Per-call push outcomes for retry/convergence tests. */
+  pushOutcomes?: unknown[]
   /** The graph's origin (defaults to a GitHub HTTPS remote; null = none). */
   remoteUrl?: string | null
   /** Whether the graph already has a repository (defaults to true). */
@@ -68,6 +72,9 @@ function fakeBridge(options: FakeOptions = {}) {
   }
   let releaseListen: (() => void) | null = null
   let releaseIndexApply: (() => void) | null = null
+  let indexApplyCount = 0
+  const mergeOutcomes = [...(options.mergeOutcomes ?? [])]
+  const pushOutcomes = [...(options.pushOutcomes ?? [])]
   setBridge({
     invoke: async (command, args) => {
       calls.push(command)
@@ -92,18 +99,25 @@ function fakeBridge(options: FakeOptions = {}) {
         case 'git_fetch':
           return { ahead: 0, behind: 0 }
         case 'git_merge_remote':
-          return options.mergeOutcome ?? UP_TO_DATE
+          return mergeOutcomes.shift() ?? options.mergeOutcome ?? UP_TO_DATE
         case 'git_push':
-          return { pushed: true, nonFastForward: false, rejectionMessage: null }
+          return (
+            pushOutcomes.shift() ?? {
+              pushed: true,
+              nonFastForward: false,
+              rejectionMessage: null,
+            }
+          )
         case 'db_query':
           return []
         case 'note_read':
           return '# Remote note\n'
         case 'index_apply_batch':
+          indexApplyCount += 1
           if (options.failIndexApply === true) {
             throw { kind: 'io', message: 'index write failed' }
           }
-          if (options.gateIndexApply === true) {
+          if (options.gateIndexApply === true && indexApplyCount === 1) {
             await new Promise<void>((resolve) => {
               releaseIndexApply = resolve
             })
@@ -588,6 +602,102 @@ describe('createBackupController', () => {
     ])
     controller.dispose()
     unlisten()
+  })
+
+  it('fans retry-merge batches immediately while serializing direct indexing', async () => {
+    const firstChange: FileChange = {
+      path: 'notes/from-remote-1.md',
+      kind: 'upsert',
+      modifiedMs: 123,
+    }
+    const secondChange: FileChange = {
+      path: 'notes/from-remote-2.md',
+      kind: 'upsert',
+      modifiedMs: 456,
+    }
+    const { calls, releaseIndexApply } = fakeBridge({
+      gateIndexApply: true,
+      mergeOutcomes: [
+        { kind: 'merged', conflictedPaths: [], changedFiles: [firstChange] },
+        { kind: 'merged', conflictedPaths: [], changedFiles: [secondChange] },
+      ],
+      pushOutcomes: [
+        { pushed: false, nonFastForward: true, rejectionMessage: 'fetch first' },
+        { pushed: true, nonFastForward: false, rejectionMessage: null },
+      ],
+    })
+    const batches: FileChange[][] = []
+    const unlisten = await subscribeFileChanges((changes) => batches.push(changes))
+    const controller = createBackupController({ graph: GRAPH, indexGeneration: 1 })
+    await controller.start()
+
+    try {
+      await vi.waitFor(() => {
+        expect(calls.filter((command) => command === 'git_push')).toHaveLength(2)
+        expect(batches).toEqual([[firstChange], [secondChange]])
+      })
+      // The second callback already fanned out synchronously, but its direct
+      // index write is queued behind the first gated batch.
+      expect(calls.filter((command) => command === 'index_apply_batch')).toHaveLength(1)
+      expect(controller.getState()).toMatchObject({
+        phase: 'connected',
+        status: { state: 'syncing' },
+      })
+
+      releaseIndexApply()
+      await vi.waitFor(() => {
+        expect(calls.filter((command) => command === 'index_apply_batch')).toHaveLength(2)
+        expect(controller.getState()).toMatchObject({
+          phase: 'connected',
+          status: { state: 'idle' },
+        })
+      })
+    } finally {
+      controller.dispose()
+      unlisten()
+    }
+  })
+
+  it('does not start queued direct indexing after controller teardown', async () => {
+    const { calls, releaseIndexApply } = fakeBridge({
+      gateIndexApply: true,
+      mergeOutcomes: [
+        {
+          kind: 'merged',
+          conflictedPaths: [],
+          changedFiles: [
+            { path: 'notes/from-remote-1.md', kind: 'upsert', modifiedMs: 123 },
+          ],
+        },
+        {
+          kind: 'merged',
+          conflictedPaths: [],
+          changedFiles: [
+            { path: 'notes/from-remote-2.md', kind: 'upsert', modifiedMs: 456 },
+          ],
+        },
+      ],
+      pushOutcomes: [
+        { pushed: false, nonFastForward: true, rejectionMessage: 'fetch first' },
+        { pushed: true, nonFastForward: false, rejectionMessage: null },
+      ],
+    })
+    const controller = createBackupController({ graph: GRAPH, indexGeneration: 1 })
+    await controller.start()
+
+    await vi.waitFor(() => {
+      expect(calls.filter((command) => command === 'git_push')).toHaveLength(2)
+      expect(calls.filter((command) => command === 'index_apply_batch')).toHaveLength(1)
+    })
+
+    controller.dispose()
+    releaseIndexApply()
+    // The first, already-running apply can finish. The second task then reaches
+    // the controller-owned tail, observes the teardown epoch, and must exit
+    // before touching the index bridge.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(calls.filter((command) => command === 'index_apply_batch')).toHaveLength(1)
   })
 
   it('keeps launch sync active until pulled notes finish direct indexing', async () => {

--- a/apps/desktop/src/lib/backup-controller.ts
+++ b/apps/desktop/src/lib/backup-controller.ts
@@ -136,6 +136,10 @@ export function createBackupController(options: BackupControllerOptions): Backup
   let engine: SyncEngine | null = null
   let unlisten: Unlisten | null = null
   const domDisposers: Array<() => void> = []
+  /** Serializes direct index writes without delaying synchronous file-change fanout. */
+  let remoteIndexTail: Promise<void> = Promise.resolve()
+  /** Invalidates index work that was queued before a controller teardown/restart. */
+  let remoteIndexEpoch = 0
 
   function setState(next: BackupState): void {
     if (disposed) {
@@ -149,6 +153,7 @@ export function createBackupController(options: BackupControllerOptions): Backup
 
   /** The single teardown path — every exit (failure, dispose, restart) takes it. */
   function teardown(): void {
+    remoteIndexEpoch += 1
     engine?.stop()
     engine = null
     unlisten?.()
@@ -159,10 +164,13 @@ export function createBackupController(options: BackupControllerOptions): Backup
     setBackupFlusher(null)
   }
 
-  async function onRemoteChanges(changes: ChangedFile[]): Promise<void> {
+  function onRemoteChanges(changes: ChangedFile[]): void | Promise<void> {
     if (changes.length === 0) {
       return
     }
+    // Capture before fanout: a synchronous subscriber can tear down/restart
+    // the controller, and work from this old merge must remain invalidated.
+    const notificationEpoch = remoteIndexEpoch
     // Pull-applied writes must not depend on the file watcher being up (the
     // launch pull can land before watch start), so consumers are notified
     // directly. The whole batch goes to the local file-changes channel —
@@ -173,12 +181,13 @@ export function createBackupController(options: BackupControllerOptions): Backup
     emitFileChanges(changes)
     const indexable = changes.filter((change) => isNotePath(change.path))
     if (indexGeneration !== null && indexable.length > 0) {
-      // Awaited so sync only reports idle once pulled notes are indexed —
-      // but a failure here must not fail the cycle: the index is a
-      // rebuildable projection (the reconcile scan heals it), while the
-      // cycle's remaining work pushes the user's markdown. Markdown backup
-      // never waits on projection health.
-      try {
+      const task = remoteIndexTail.then(async () => {
+        // Teardown stops the engine and invalidates work that has not begun.
+        // A landed merge was already fanned out synchronously above; the next
+        // watcher/reconcile pass can rebuild this disposable projection.
+        if (disposed || notificationEpoch !== remoteIndexEpoch) {
+          return
+        }
         const mutations = await applyIndexChanges(
           indexable,
           indexGeneration,
@@ -189,9 +198,14 @@ export function createBackupController(options: BackupControllerOptions): Backup
         if (mutations > 0) {
           throttledInvalidateIndexQueries()
         }
-      } catch (cause) {
+      })
+      // Direct index writes remain ordered across retry merges. Their handled
+      // promise is what the engine joins before idle; failure is logged but
+      // never prevents the already-concurrent Git push of Markdown truth.
+      remoteIndexTail = task.catch((cause) => {
         console.error('pulled-note direct index apply failed:', cause)
-      }
+      })
+      return remoteIndexTail
     }
   }
 

--- a/apps/desktop/src/mobile/screens/tasks.test.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.test.tsx
@@ -21,14 +21,14 @@ import { MobileTasks } from './tasks'
 
 const getOpenTasks = vi.hoisted(() => vi.fn())
 const getCompletedTasks = vi.hoisted(() => vi.fn())
-const resolveWikiTarget = vi.hoisted(() => vi.fn())
+const resolveOrCreateNoteWithTitle = vi.hoisted(() => vi.fn())
 const hapticImpactLight = vi.hoisted(() => vi.fn())
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   hasBridge: () => true,
   getOpenTasks,
   getCompletedTasks,
-  resolveWikiTarget,
+  resolveOrCreateNoteWithTitle,
 }))
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({ graph: { root: '/g', name: 'g', generation: 1 } }),
@@ -213,8 +213,11 @@ beforeEach(() => {
   convertTaskToBullet.mockResolvedValue(undefined)
   startOperation.mockClear()
   fail.mockReset()
-  resolveWikiTarget.mockReset()
-  resolveWikiTarget.mockResolvedValue({ kind: 'resolved', ref: 'notes/other.md' })
+  resolveOrCreateNoteWithTitle.mockReset()
+  resolveOrCreateNoteWithTitle.mockResolvedValue({
+    kind: 'resolved',
+    path: 'notes/other.md',
+  })
   hapticImpactLight.mockClear()
   editorProbe.focusCalls = 0
   resetRecentlyCompleted()

--- a/packages/core/src/graph/create-note.test.ts
+++ b/packages/core/src/graph/create-note.test.ts
@@ -19,6 +19,8 @@ interface BridgeBehavior {
   files?: Record<string, string>
   /** Evicted files whose title cannot currently be inspected. */
   placeholders?: string[]
+  /** Listed files whose contents fail to read. */
+  readErrors?: string[]
   /** Optional exact control over an index query's result rows. */
   query?: (sql: string, params: unknown[]) => Array<Record<string, unknown>>
   /** Override an atomic create attempt (for collision-race tests). */
@@ -33,10 +35,12 @@ function bindBridge({
   occupied = [],
   files = {},
   placeholders = [],
+  readErrors = [],
   query,
   create,
 }: BridgeBehavior = {}): ReturnType<typeof vi.fn> {
-  const taken = new Set([...occupied, ...Object.keys(files), ...placeholders])
+  const taken = new Set([...occupied, ...Object.keys(files), ...placeholders, ...readErrors])
+  const unreadable = new Set(readErrors)
   const invoke = vi.fn(async (command: string, args?: Record<string, unknown>) => {
     if (command === 'db_query') {
       const sql = String(args?.['sql'] ?? '')
@@ -61,10 +65,14 @@ function bindBridge({
           modifiedMs: 1,
           placeholder: true,
         })),
+        ...readErrors.map((path) => ({ path, size: 1, modifiedMs: 1 })),
       ]
     }
     if (command === 'note_read') {
       const path = String(args?.['path'])
+      if (unreadable.has(path)) {
+        throw { kind: 'io', message: `${path} is temporarily unreadable` }
+      }
       const source = files[path]
       if (source === undefined) {
         throw { kind: 'notFound', message: `${path} not found` }
@@ -155,6 +163,92 @@ describe('resolveOrCreateNoteWithTitle', () => {
     expect(invoke.mock.calls.some(([command]) => command === 'note_create')).toBe(false)
   })
 
+  it('preserves indexed daily-date precedence over a regular title', async () => {
+    const invoke = bindBridge({
+      query: (sql) => {
+        if (sql.includes('"daily_date" = ?')) {
+          return [{ path: 'daily/2026-06-09.md' }]
+        }
+        if (sql.includes('"title_key" = ?')) {
+          return [{ path: 'notes/date-title.md' }]
+        }
+        return []
+      },
+    })
+
+    await expect(resolveOrCreateNoteWithTitle('2026-06-09', 7)).resolves.toEqual({
+      kind: 'resolved',
+      path: 'daily/2026-06-09.md',
+    })
+    expect(
+      invoke.mock.calls.some(
+        ([command, args]) =>
+          command === 'db_query' && String(args?.['sql']).includes('"title_key" = ?'),
+      ),
+    ).toBe(false)
+  })
+
+  it('refuses multiple indexed notes claiming the same exact title', async () => {
+    const invoke = bindBridge({
+      query: (sql, params) =>
+        sql.includes('"title_key" = ?') && params[0] === 'business ideas'
+          ? [{ path: 'notes/business-ideas-2.md' }, { path: 'notes/business-ideas.md' }]
+          : [],
+    })
+
+    await expect(resolveOrCreateNoteWithTitle('Business ideas', 7)).resolves.toEqual({
+      kind: 'ambiguous',
+      paths: ['notes/business-ideas-2.md', 'notes/business-ideas.md'],
+    })
+    expect(invoke.mock.calls.some(([command]) => command === 'list_files')).toBe(false)
+    expect(invoke.mock.calls.some(([command]) => command === 'note_create')).toBe(false)
+  })
+
+  it('prefers indexed title matches over aliases', async () => {
+    const titleInvoke = bindBridge({
+      query: (sql) => {
+        if (sql.includes('"title_key" = ?')) {
+          return [{ path: 'notes/titled.md' }]
+        }
+        if (sql.includes('from "aliases"')) {
+          return [
+            { note_path: 'notes/alias-a.md' },
+            { note_path: 'notes/alias-b.md' },
+          ]
+        }
+        return []
+      },
+    })
+
+    await expect(resolveOrCreateNoteWithTitle('Business ideas', 7)).resolves.toEqual({
+      kind: 'resolved',
+      path: 'notes/titled.md',
+    })
+    expect(
+      titleInvoke.mock.calls.some(
+        ([command, args]) =>
+          command === 'db_query' && String(args?.['sql']).includes('from "aliases"'),
+      ),
+    ).toBe(false)
+  })
+
+  it('refuses multiple indexed notes claiming the same exact alias', async () => {
+    const aliasInvoke = bindBridge({
+      query: (sql) =>
+        sql.includes('from "aliases"')
+          ? [
+              { note_path: 'notes/alias-b.md' },
+              { note_path: 'notes/alias-a.md' },
+            ]
+          : [],
+    })
+    await expect(resolveOrCreateNoteWithTitle('Business ideas', 7)).resolves.toEqual({
+      kind: 'ambiguous',
+      paths: ['notes/alias-a.md', 'notes/alias-b.md'],
+    })
+    expect(aliasInvoke.mock.calls.some(([command]) => command === 'note_create')).toBe(false)
+  })
+
   it('reuses an exact title or alias from the on-disk slug family', async () => {
     const invoke = bindBridge({
       files: {
@@ -170,10 +264,42 @@ describe('resolveOrCreateNoteWithTitle', () => {
     expect(invoke.mock.calls.some(([command]) => command === 'note_create')).toBe(false)
   })
 
+  it('prefers an exact on-disk title over an exact alias', async () => {
+    const invoke = bindBridge({
+      files: {
+        'notes/business-ideas.md': '# Business ideas\n',
+        'notes/business-ideas-2.md':
+          '---\naliases: [Business ideas]\n---\n# Incubator\n',
+      },
+    })
+
+    await expect(resolveOrCreateNoteWithTitle('Business ideas', 7)).resolves.toEqual({
+      kind: 'resolved',
+      path: 'notes/business-ideas.md',
+    })
+    expect(invoke.mock.calls.some(([command]) => command === 'note_create')).toBe(false)
+  })
+
   it('reuses exactly one leading-emoji fallback match', async () => {
     const invoke = bindBridge({
       files: {
         'notes/business-ideas.md': '# 🧠Business ideas\n',
+      },
+    })
+
+    await expect(resolveOrCreateNoteWithTitle('Business ideas', 7)).resolves.toEqual({
+      kind: 'resolved',
+      path: 'notes/business-ideas.md',
+    })
+    expect(invoke.mock.calls.some(([command]) => command === 'note_create')).toBe(false)
+  })
+
+  it('prefers an on-disk fallback title over a fallback alias', async () => {
+    const invoke = bindBridge({
+      files: {
+        'notes/business-ideas.md': '# 🧠 Business ideas\n',
+        'notes/business-ideas-2.md':
+          '---\naliases: ["💡 Business ideas"]\n---\n# Incubator\n',
       },
     })
 
@@ -232,6 +358,28 @@ describe('resolveOrCreateNoteWithTitle', () => {
         'notes/business-ideas-3.md',
         'notes/business-ideas.md',
       ],
+    })
+    expect(invoke.mock.calls.some(([command]) => command === 'note_create')).toBe(false)
+  })
+
+  it.each([
+    {
+      label: 'eviction placeholder',
+      unavailable: { placeholders: ['notes/business-ideas-2.md'] },
+    },
+    {
+      label: 'read failure',
+      unavailable: { readErrors: ['notes/business-ideas-2.md'] },
+    },
+  ])('refuses an exact disk match beside an unreadable $label', async ({ unavailable }) => {
+    const invoke = bindBridge({
+      files: { 'notes/business-ideas.md': '# Business ideas\n' },
+      ...unavailable,
+    })
+
+    await expect(resolveOrCreateNoteWithTitle('Business ideas', 7)).resolves.toEqual({
+      kind: 'ambiguous',
+      paths: ['notes/business-ideas-2.md', 'notes/business-ideas.md'],
     })
     expect(invoke.mock.calls.some(([command]) => command === 'note_create')).toBe(false)
   })

--- a/packages/core/src/graph/create-note.ts
+++ b/packages/core/src/graph/create-note.ts
@@ -1,5 +1,5 @@
 import { ulid } from 'ulidx'
-import { resolveWikiTarget } from '../indexing/queries'
+import { findExactWikiTargetMatches } from '../indexing/queries'
 import { foldFallbackTitleKey, foldKey } from '../markdown/keys'
 import { parseNote } from '../markdown/extract'
 import { upsertFrontmatter } from '../markdown/frontmatter'
@@ -101,8 +101,10 @@ export type ResolveOrCreateNoteResult =
 type ExistingTitleResolution = Exclude<ResolveOrCreateNoteResult, { kind: 'created' }>
 
 interface DiskTitleMatch {
-  exactPaths: string[]
-  fallbackPaths: string[]
+  exactTitlePaths: string[]
+  exactAliasPaths: string[]
+  fallbackTitlePaths: string[]
+  fallbackAliasPaths: string[]
   unreadablePaths: string[]
 }
 
@@ -140,8 +142,10 @@ async function matchTitleOnDisk(title: string, generation: number): Promise<Disk
     .sort((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0))
   const targetKey = foldKey(title)
   const fallbackKey = foldFallbackTitleKey(title)
-  const exactPaths: string[] = []
-  const fallbackPaths: string[] = []
+  const exactTitlePaths: string[] = []
+  const exactAliasPaths: string[] = []
+  const fallbackTitlePaths: string[] = []
+  const fallbackAliasPaths: string[] = []
   const unreadablePaths: string[] = []
 
   for (const candidate of candidates) {
@@ -159,50 +163,84 @@ async function matchTitleOnDisk(title: string, generation: number): Promise<Disk
       continue
     }
     const parsed = parseNote({ path: candidate.path, source })
-    const spellings = [
-      parsed.title,
-      ...parsed.frontmatter.aliases,
-      ...subjectAliases(parsed.title),
-    ]
-    if (spellings.some((spelling) => foldKey(spelling) === targetKey)) {
-      exactPaths.push(candidate.path)
+    const aliases = [...parsed.frontmatter.aliases, ...subjectAliases(parsed.title)]
+    if (foldKey(parsed.title) === targetKey) {
+      exactTitlePaths.push(candidate.path)
+      continue
+    }
+    if (aliases.some((alias) => foldKey(alias) === targetKey)) {
+      exactAliasPaths.push(candidate.path)
+      continue
+    }
+    if (fallbackKey !== '' && foldFallbackTitleKey(parsed.title) === fallbackKey) {
+      fallbackTitlePaths.push(candidate.path)
       continue
     }
     if (
       fallbackKey !== '' &&
-      spellings.some((spelling) => foldFallbackTitleKey(spelling) === fallbackKey)
+      aliases.some((alias) => foldFallbackTitleKey(alias) === fallbackKey)
     ) {
-      fallbackPaths.push(candidate.path)
+      fallbackAliasPaths.push(candidate.path)
     }
   }
 
-  return { exactPaths, fallbackPaths, unreadablePaths }
+  return {
+    exactTitlePaths,
+    exactAliasPaths,
+    fallbackTitlePaths,
+    fallbackAliasPaths,
+    unreadablePaths,
+  }
 }
 
-async function indexedPathForTitle(title: string): Promise<string | null> {
-  const resolution = await resolveWikiTarget(title)
-  return resolution.kind === 'resolved' ? resolution.ref : null
+function resolutionForPaths(paths: readonly string[]): ExistingTitleResolution | null {
+  if (paths.length === 1) {
+    return { kind: 'resolved', path: paths[0]! }
+  }
+  if (paths.length > 1) {
+    return { kind: 'ambiguous', paths: [...paths].sort() }
+  }
+  return null
+}
+
+async function indexedTargetResolution(
+  title: string,
+): Promise<ExistingTitleResolution | null> {
+  const match = await findExactWikiTargetMatches(title)
+  return resolutionForPaths(match.paths)
 }
 
 function diskTitleResolution(disk: DiskTitleMatch): ExistingTitleResolution | null {
-  if (disk.exactPaths.length === 1) {
-    return { kind: 'resolved', path: disk.exactPaths[0]! }
-  }
-  // Several files claiming the identical title/alias (the historic duplicate
-  // bug's own output) is a guess too: sorted-first would even prefer the
-  // `-2.md` dupe over the original (`-` sorts before `.`). Refuse, same as an
-  // ambiguous fallback.
-  if (disk.exactPaths.length > 1) {
-    return { kind: 'ambiguous', paths: [...disk.exactPaths].sort() }
-  }
-  if (disk.unreadablePaths.length > 0 || disk.fallbackPaths.length > 1) {
+  // An unreadable candidate could claim any higher-precedence spelling. Do
+  // not choose a readable sibling until the whole collision family is known.
+  if (disk.unreadablePaths.length > 0) {
     return {
       kind: 'ambiguous',
-      paths: [...disk.fallbackPaths, ...disk.unreadablePaths].sort(),
+      paths: [
+        ...new Set([
+          ...disk.exactTitlePaths,
+          ...disk.exactAliasPaths,
+          ...disk.fallbackTitlePaths,
+          ...disk.fallbackAliasPaths,
+          ...disk.unreadablePaths,
+        ]),
+      ].sort(),
     }
   }
-  if (disk.fallbackPaths.length === 1) {
-    return { kind: 'resolved', path: disk.fallbackPaths[0]! }
+
+  // Mirror indexed wiki resolution: an exact title outranks an exact alias.
+  // Only after both exact tiers miss do the conservative fallback tiers run,
+  // again preferring a title to an alias.
+  for (const paths of [
+    disk.exactTitlePaths,
+    disk.exactAliasPaths,
+    disk.fallbackTitlePaths,
+    disk.fallbackAliasPaths,
+  ]) {
+    const resolution = resolutionForPaths(paths)
+    if (resolution !== null) {
+      return resolution
+    }
   }
   return null
 }
@@ -211,21 +249,22 @@ function diskTitleResolution(disk: DiskTitleMatch): ExistingTitleResolution | nu
  * Resolve a wiki-link title while guarding its title-derived creation path
  * against a stale per-device index.
  *
- * Exact index resolution always wins. On a miss, the title's on-disk slug
- * family is parsed for exact title/alias matches and then for the conservative
- * leading-emoji fallback. Either tier is accepted only when exactly one file
- * claims it; multiple (or unreadable) candidates are ambiguous and no file is
- * written. The index is queried once more immediately before creation. The
- * native path claim is atomic and no-clobber; if it loses to a concurrent sync
- * checkout or creator, the winner is resolved before trying a suffix.
+ * A unique exact index match wins; multiple indexed claims are ambiguous. On
+ * a miss, the title's on-disk slug family is parsed with the same precedence
+ * (title before alias), then the conservative leading-emoji fallback. A tier is
+ * accepted only when exactly one file claims it; multiple or unreadable
+ * candidates are ambiguous and no file is written. The index is queried once
+ * more immediately before creation. The native path claim is atomic and
+ * no-clobber; if it loses to a concurrent sync checkout or creator, the winner
+ * is resolved before trying a suffix.
  */
 export async function resolveOrCreateNoteWithTitle(
   title: string,
   generation: number,
 ): Promise<ResolveOrCreateNoteResult> {
-  const indexed = await indexedPathForTitle(title)
+  const indexed = await indexedTargetResolution(title)
   if (indexed !== null) {
-    return { kind: 'resolved', path: indexed }
+    return indexed
   }
 
   const diskResolution = diskTitleResolution(await matchTitleOnDisk(title, generation))
@@ -233,9 +272,9 @@ export async function resolveOrCreateNoteWithTitle(
     return diskResolution
   }
 
-  const reResolved = await indexedPathForTitle(title)
+  const reResolved = await indexedTargetResolution(title)
   if (reResolved !== null) {
-    return { kind: 'resolved', path: reResolved }
+    return reResolved
   }
 
   const slug = slugForTitle(title)
@@ -249,9 +288,9 @@ export async function resolveOrCreateNoteWithTitle(
 
     // The claim lost after our checks. Re-resolve both projections before
     // considering a suffix: the winner may be the note this link meant.
-    const collisionIndex = await indexedPathForTitle(title)
+    const collisionIndex = await indexedTargetResolution(title)
     if (collisionIndex !== null) {
-      return { kind: 'resolved', path: collisionIndex }
+      return collisionIndex
     }
     const collisionDisk = diskTitleResolution(await matchTitleOnDisk(title, generation))
     if (collisionDisk !== null) {

--- a/packages/core/src/indexing/queries.test.ts
+++ b/packages/core/src/indexing/queries.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setBridge } from '../ipc/bridge'
 import {
   dailyDatesInRange,
+  findExactWikiTargetMatches,
   getBacklinksWithContext,
   getDuplicateNoteIds,
   getNoteIdsByPath,
@@ -75,6 +76,67 @@ describe('noteTitleOwningEmail', () => {
   it('short-circuits a blank address before touching the bridge', async () => {
     await expect(noteTitleOwningEmail('   ')).resolves.toBeNull()
     expect(mockInvoke).not.toHaveBeenCalled()
+  })
+})
+
+describe('findExactWikiTargetMatches', () => {
+  it('returns every exact title in path order without querying aliases', async () => {
+    mockInvoke.mockResolvedValue([
+      { path: 'notes/business-ideas-2.md' },
+      { path: 'notes/business-ideas.md' },
+    ])
+
+    await expect(findExactWikiTargetMatches('Business ideas')).resolves.toEqual({
+      kind: 'title',
+      paths: ['notes/business-ideas-2.md', 'notes/business-ideas.md'],
+    })
+
+    expect(mockInvoke).toHaveBeenCalledTimes(1)
+    const [, args] = mockInvoke.mock.calls[0]!
+    const sql = String(args['sql'])
+    expect(sql).toContain('title_key')
+    expect(sql).toContain('distinct')
+    expect(sql).toContain('order by "path"')
+    expect(sql).toContain('"kind" != ?')
+    expect(args['params']).toEqual(['business ideas', 'template'])
+  })
+
+  it('queries exact aliases only after titles miss', async () => {
+    mockInvoke
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { note_path: 'notes/alias-a.md' },
+        { note_path: 'notes/alias-b.md' },
+      ])
+
+    await expect(findExactWikiTargetMatches('Business ideas')).resolves.toEqual({
+      kind: 'alias',
+      paths: ['notes/alias-a.md', 'notes/alias-b.md'],
+    })
+
+    expect(mockInvoke).toHaveBeenCalledTimes(2)
+    const [, args] = mockInvoke.mock.calls[1]!
+    const sql = String(args['sql'])
+    expect(sql).toContain('from "aliases"')
+    expect(sql).toContain('inner join "notes"')
+    expect(sql).toContain('distinct')
+    expect(sql).toContain('order by "note_path"')
+    expect(sql).toContain('"notes"."kind" != ?')
+    expect(args['params']).toEqual(['business ideas', 'template'])
+  })
+
+  it('preserves daily-date precedence before titles and aliases', async () => {
+    mockInvoke.mockResolvedValue([{ path: 'daily/2026-06-09.md' }])
+
+    await expect(findExactWikiTargetMatches('2026-06-09')).resolves.toEqual({
+      kind: 'date',
+      paths: ['daily/2026-06-09.md'],
+    })
+
+    expect(mockInvoke).toHaveBeenCalledTimes(1)
+    const [, args] = mockInvoke.mock.calls[0]!
+    expect(String(args['sql'])).toContain('daily_date')
+    expect(args['params']).toEqual(['2026-06-09', 'template'])
   })
 })
 

--- a/packages/core/src/indexing/queries.ts
+++ b/packages/core/src/indexing/queries.ts
@@ -2,6 +2,7 @@ import { sql } from 'kysely'
 import {
   foldEmail,
   foldTag,
+  normalizeWikiTarget,
   resolveWikiLinkAsync,
   type Resolution,
 } from '../markdown'
@@ -336,6 +337,69 @@ export async function noteTitleOwningEmail(email: string): Promise<string | null
     .orderBy('notes.path')
     .executeTakeFirst()
   return owner?.title ?? null
+}
+
+/** Exact indexed date/title/alias candidates, preserving ambiguity within the winning tier. */
+export type ExactWikiTargetMatch =
+  | { readonly kind: 'date'; readonly paths: readonly string[] }
+  | { readonly kind: 'title'; readonly paths: readonly string[] }
+  | { readonly kind: 'alias'; readonly paths: readonly string[] }
+  | { readonly kind: 'missing'; readonly paths: readonly [] }
+
+/**
+ * Find every indexed path that exactly claims `target`, with ordinary wiki
+ * resolution precedence: calendar date, then title, then alias. Unlike
+ * {@link resolveWikiTarget}, this does not collapse a tier to its first path;
+ * callers that may create on a miss need to distinguish one existing note
+ * from several notes claiming the same spelling.
+ */
+export async function findExactWikiTargetMatches(
+  target: string,
+): Promise<ExactWikiTargetMatch> {
+  const normalized = normalizeWikiTarget(target)
+  if (normalized.key === '') {
+    return { kind: 'missing', paths: [] }
+  }
+
+  if (normalized.date !== undefined) {
+    const dateRows = await db
+      .selectFrom('notes')
+      .where('dailyDate', '=', normalized.date)
+      .where('kind', '!=', 'template')
+      .select('path')
+      .distinct()
+      .orderBy('path')
+      .execute()
+    if (dateRows.length > 0) {
+      return { kind: 'date', paths: dateRows.map((row) => row.path) }
+    }
+  }
+
+  const titleRows = await db
+    .selectFrom('notes')
+    .where('titleKey', '=', normalized.key)
+    .where('kind', '!=', 'template')
+    .select('path')
+    .distinct()
+    .orderBy('path')
+    .execute()
+  if (titleRows.length > 0) {
+    return { kind: 'title', paths: titleRows.map((row) => row.path) }
+  }
+
+  const aliasRows = await db
+    .selectFrom('aliases')
+    .innerJoin('notes', 'notes.path', 'aliases.notePath')
+    .where('aliasKey', '=', normalized.key)
+    .where('notes.kind', '!=', 'template')
+    .select('notePath')
+    .distinct()
+    .orderBy('notePath')
+    .execute()
+  if (aliasRows.length > 0) {
+    return { kind: 'alias', paths: aliasRows.map((row) => row.notePath) }
+  }
+  return { kind: 'missing', paths: [] }
 }
 
 /**

--- a/packages/core/src/sync/engine.test.ts
+++ b/packages/core/src/sync/engine.test.ts
@@ -329,23 +329,16 @@ describe('createSyncEngine', () => {
     engine.stop()
   })
 
-  it('waits for async remote-change handling before reporting idle', async () => {
-    const calls = fakeGit((command) => {
-      if (command === 'git_commit_all') {
-        return CLEAN_COMMIT
-      }
-      if (command === 'git_fetch') {
-        return { ahead: 0, behind: 1 }
-      }
-      if (command === 'git_merge_remote') {
-        return {
-          kind: 'fastForward',
-          conflictedPaths: [],
-          changedFiles: [{ path: 'notes/from-remote.md', kind: 'upsert' }],
-        }
-      }
-      return defaultResponses(command)
-    })
+  it('continues through push while remote-change handling runs, then waits before idle', async () => {
+    const calls = fakeGit((command) =>
+      command === 'git_merge_remote'
+        ? {
+            kind: 'merged',
+            conflictedPaths: [],
+            changedFiles: [{ path: 'notes/from-remote.md', kind: 'upsert' }],
+          }
+        : defaultResponses(command),
+    )
     const remoteChangesGate: { resolve: (() => void) | null } = { resolve: null }
     const statuses: SyncStatus[] = []
     const engine = createSyncEngine({
@@ -361,10 +354,78 @@ describe('createSyncEngine', () => {
     const syncing = engine.syncNow()
     await vi.advanceTimersByTimeAsync(0)
 
-    expect(commandsOf(calls)).toEqual(['git_commit_all', 'git_fetch', 'git_merge_remote'])
+    // The projection is still gated, but the merge's Markdown has already
+    // continued through the durable Git push. Only the idle boundary waits.
+    expect(commandsOf(calls)).toEqual([
+      'git_commit_all',
+      'git_fetch',
+      'git_merge_remote',
+      'git_push',
+    ])
     expect(statuses.map((status) => status.state)).toEqual(['syncing'])
 
     remoteChangesGate.resolve?.()
+    await syncing
+
+    expect(statuses.map((status) => status.state)).toEqual(['syncing', 'idle'])
+    engine.stop()
+  })
+
+  it('starts every remote-change callback immediately while repeated Git convergence continues', async () => {
+    let mergeCount = 0
+    let pushCount = 0
+    const calls = fakeGit((command) => {
+      if (command === 'git_merge_remote') {
+        mergeCount += 1
+        return {
+          kind: 'merged',
+          conflictedPaths: [],
+          changedFiles: [
+            { path: `notes/remote-${mergeCount}.md`, kind: 'upsert' },
+          ],
+        }
+      }
+      if (command === 'git_push') {
+        pushCount += 1
+        return pushCount === 1 ? NON_FAST_FORWARD : PUSHED
+      }
+      return defaultResponses(command)
+    })
+    const firstBatchGate: { resolve: (() => void) | null } = { resolve: null }
+    const started: string[] = []
+    const statuses: SyncStatus[] = []
+    const engine = createSyncEngine({
+      generation: 1,
+      getToken: async () => 'tok',
+      onStatus: (status) => statuses.push(status),
+      onRemoteChanges: (changes) => {
+        started.push(changes[0]!.path)
+        if (started.length === 1) {
+          return new Promise<void>((resolve) => {
+            firstBatchGate.resolve = resolve
+          })
+        }
+      },
+    })
+
+    const syncing = engine.syncNow()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(commandsOf(calls)).toEqual([
+      'git_commit_all',
+      'git_fetch',
+      'git_merge_remote',
+      'git_push',
+      'git_fetch',
+      'git_merge_remote',
+      'git_push',
+    ])
+    // Both merges notify synchronously even though the first returned task is
+    // still gated. Their async work can overlap; only idle waits for both.
+    expect(started).toEqual(['notes/remote-1.md', 'notes/remote-2.md'])
+    expect(statuses.map((status) => status.state)).toEqual(['syncing'])
+
+    firstBatchGate.resolve?.()
     await syncing
 
     expect(statuses.map((status) => status.state)).toEqual(['syncing', 'idle'])
@@ -397,28 +458,45 @@ describe('createSyncEngine', () => {
 
     const syncing = engine.syncNow()
     await vi.advanceTimersByTimeAsync(0)
-    expect(commandsOf(calls)).toEqual(['git_commit_all', 'git_fetch', 'git_merge_remote'])
+    expect(commandsOf(calls)).toEqual([
+      'git_commit_all',
+      'git_fetch',
+      'git_merge_remote',
+      'git_push',
+    ])
 
     canStartCycle = false
     expect(statuses.map((status) => status.state)).toEqual(['syncing'])
     remoteChangesGate.resolve?.()
     await syncing
 
-    expect(commandsOf(calls)).toEqual(['git_commit_all', 'git_fetch', 'git_merge_remote'])
+    expect(commandsOf(calls)).toEqual([
+      'git_commit_all',
+      'git_fetch',
+      'git_merge_remote',
+      'git_push',
+    ])
     expect(statuses.map((status) => status.state)).toEqual(['syncing', 'idle'])
     engine.stop()
   })
 
-  it('surfaces an async remote-change failure and stops before push', async () => {
-    const calls = fakeGit((command) =>
-      command === 'git_merge_remote'
-        ? {
-            kind: 'merged',
-            conflictedPaths: [],
-            changedFiles: [{ path: 'notes/from-remote.md', kind: 'upsert' }],
-          }
-        : defaultResponses(command),
-    )
+  it('surfaces an async remote-change failure only after the push finishes', async () => {
+    const pushGate: { resolve: ((value: unknown) => void) | null } = { resolve: null }
+    const calls = fakeGit((command) => {
+      if (command === 'git_merge_remote') {
+        return {
+          kind: 'merged',
+          conflictedPaths: [],
+          changedFiles: [{ path: 'notes/from-remote.md', kind: 'upsert' }],
+        }
+      }
+      if (command === 'git_push') {
+        return new Promise((resolve) => {
+          pushGate.resolve = resolve
+        })
+      }
+      return defaultResponses(command)
+    })
     const statuses: SyncStatus[] = []
     const engine = createSyncEngine({
       generation: 1,
@@ -429,9 +507,22 @@ describe('createSyncEngine', () => {
       },
     })
 
-    await engine.syncNow()
+    const syncing = engine.syncNow()
+    await vi.advanceTimersByTimeAsync(0)
 
-    expect(commandsOf(calls)).toEqual(['git_commit_all', 'git_fetch', 'git_merge_remote'])
+    // The projection has already rejected, but that failure must not strand
+    // the merged Markdown before its required push.
+    expect(commandsOf(calls)).toEqual([
+      'git_commit_all',
+      'git_fetch',
+      'git_merge_remote',
+      'git_push',
+    ])
+    expect(statuses.map((status) => status.state)).toEqual(['syncing'])
+
+    pushGate.resolve?.(PUSHED)
+    await syncing
+
     expect(statuses.at(-1)).toMatchObject({
       state: 'error',
       errorKind: 'other',
@@ -440,7 +531,43 @@ describe('createSyncEngine', () => {
     engine.stop()
   })
 
-  it('stop during async remote-change handling emits nothing further', async () => {
+  it('stop while merge is in flight never starts its remote-change callback', async () => {
+    const mergeGate: { resolve: ((value: unknown) => void) | null } = { resolve: null }
+    const calls = fakeGit((command) => {
+      if (command === 'git_merge_remote') {
+        return new Promise((resolve) => {
+          mergeGate.resolve = resolve
+        })
+      }
+      return defaultResponses(command)
+    })
+    const remoteChanges = vi.fn()
+    const statuses: SyncStatus[] = []
+    const engine = createSyncEngine({
+      generation: 1,
+      getToken: async () => 'tok',
+      onStatus: (status) => statuses.push(status),
+      onRemoteChanges: remoteChanges,
+    })
+
+    const syncing = engine.syncNow()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(commandsOf(calls)).toEqual(['git_commit_all', 'git_fetch', 'git_merge_remote'])
+
+    engine.stop()
+    mergeGate.resolve?.({
+      kind: 'merged',
+      conflictedPaths: [],
+      changedFiles: [{ path: 'notes/from-remote.md', kind: 'upsert' }],
+    })
+    await syncing
+
+    expect(commandsOf(calls)).toEqual(['git_commit_all', 'git_fetch', 'git_merge_remote'])
+    expect(remoteChanges).not.toHaveBeenCalled()
+    expect(statuses.map((status) => status.state)).toEqual(['syncing'])
+  })
+
+  it('stop after a remote-change task starts emits no later status or Git work', async () => {
     const calls = fakeGit((command) =>
       command === 'git_merge_remote'
         ? {
@@ -464,11 +591,43 @@ describe('createSyncEngine', () => {
 
     const syncing = engine.syncNow()
     await vi.advanceTimersByTimeAsync(0)
-    expect(commandsOf(calls)).toEqual(['git_commit_all', 'git_fetch', 'git_merge_remote'])
+    const commandsBeforeStop = commandsOf(calls)
+    expect(commandsBeforeStop).toEqual([
+      'git_commit_all',
+      'git_fetch',
+      'git_merge_remote',
+      'git_push',
+    ])
+    expect(statuses.map((status) => status.state)).toEqual(['syncing'])
 
     engine.stop()
     remoteChangesGate.resolve?.()
     await syncing
+
+    expect(commandsOf(calls)).toEqual(commandsBeforeStop)
+    expect(statuses.map((status) => status.state)).toEqual(['syncing'])
+  })
+
+  it('stop from a synchronous remote-change callback prevents the later push', async () => {
+    const calls = fakeGit((command) =>
+      command === 'git_merge_remote'
+        ? {
+            kind: 'merged',
+            conflictedPaths: [],
+            changedFiles: [{ path: 'notes/from-remote.md', kind: 'upsert' }],
+          }
+        : defaultResponses(command),
+    )
+    const statuses: SyncStatus[] = []
+    let engine: ReturnType<typeof createSyncEngine>
+    engine = createSyncEngine({
+      generation: 1,
+      getToken: async () => 'tok',
+      onStatus: (status) => statuses.push(status),
+      onRemoteChanges: () => engine.stop(),
+    })
+
+    await engine.syncNow()
 
     expect(commandsOf(calls)).toEqual(['git_commit_all', 'git_fetch', 'git_merge_remote'])
     expect(statuses.map((status) => status.state)).toEqual(['syncing'])

--- a/packages/core/src/sync/engine.ts
+++ b/packages/core/src/sync/engine.ts
@@ -74,10 +74,12 @@ export interface SyncEngineOptions {
   /**
    * Files a pull's merge changed on disk. The caller reindexes them directly:
    * pull-applied writes must reach the index even when the file watcher isn't
-   * up yet (the launch pull can race the watcher start). The cycle waits for
-   * async work here before proceeding or reporting idle, so consumers see a
-   * converged index when sync settles. A throw or rejection fails the cycle
-   * and surfaces as an `error` status.
+   * up yet (the launch pull can race the watcher start). Invoked synchronously
+   * at the merge boundary so immediate notifications cannot lag a later merge;
+   * any returned promise runs alongside required Git convergence and push. A
+   * successful cycle waits for every returned task before reporting idle. A
+   * throw or rejection surfaces as an `error` only after that Git work has had
+   * its chance to make the Markdown source of truth durable.
    */
   onRemoteChanges?: (changes: ChangedFile[]) => void | Promise<void>
   /** Quiet period after the last edit before a backup commit. */
@@ -156,29 +158,58 @@ export function createSyncEngine(options: SyncEngineOptions): SyncEngine {
   }
 
   /**
-   * Await one cycle step; while the engine is still alive, await any result-side
-   * notification, then bail if the engine stopped or the owner suppressed
-   * further cycles meanwhile. An already-issued Git command cannot be recalled,
-   * but no later command starts.
+   * Await one cycle step, preserve any result-side notification, then bail if
+   * the engine stopped or the owner suppressed further cycles meanwhile. An
+   * already-issued Git command cannot be recalled, but no later command starts.
    */
-  async function step<T>(
-    promise: Promise<T>,
-    onResult?: (result: T) => void | Promise<void>,
-  ): Promise<T> {
+  async function step<T>(promise: Promise<T>, onResult?: (result: T) => void): Promise<T> {
     const result = await promise
     signal.throwIfAborted()
-    const resultNotification = onResult?.(result)
-    if (resultNotification !== undefined) {
-      await resultNotification
-    }
-    // An async result observer can outlive the engine just like a Git command.
-    // Re-check before the caller is allowed to issue its next command or emit
-    // idle; stop() remains terminal even when it lands during reindexing.
+    onResult?.(result)
+    // A synchronous result notification can itself tear down the owner (for
+    // example, a file-change subscriber closing the graph). Preserve stop's
+    // command boundary before the caller is allowed to issue later Git work.
     signal.throwIfAborted()
     if (options.canStartCycle?.() === false) {
       throw new CycleSuppressedError()
     }
     return result
+  }
+
+  /** Start one merge notification now, without making later Git commands wait. */
+  function startRemoteChanges(changes: ChangedFile[]): Promise<void> {
+    let task: Promise<void>
+    try {
+      task = Promise.resolve(options.onRemoteChanges?.(changes))
+    } catch (error) {
+      task = Promise.reject(error)
+    }
+    // Attach a handler immediately: a synchronous throw or fast rejection can
+    // happen well before the successful cycle joins this task at its idle
+    // boundary, and must never become an unhandled rejection in between.
+    void task.catch(() => {})
+    return task
+  }
+
+  /** Join this cycle's observer tasks and rethrow the first error. */
+  async function settleRemoteChanges(
+    tasks: readonly Promise<void>[],
+    checkSuppression = true,
+  ): Promise<void> {
+    if (tasks.length === 0) {
+      return
+    }
+    const outcomes = await Promise.allSettled(tasks)
+    signal.throwIfAborted()
+    const failed = outcomes.find(
+      (outcome): outcome is PromiseRejectedResult => outcome.status === 'rejected',
+    )
+    if (failed !== undefined) {
+      throw failed.reason
+    }
+    if (checkSuppression && options.canStartCycle?.() === false) {
+      throw new CycleSuppressedError()
+    }
   }
 
   function schedule(delayMs: number): void {
@@ -216,6 +247,7 @@ export function createSyncEngine(options: SyncEngineOptions): SyncEngine {
       return running
     }
     running = (async () => {
+      const remoteChangeTasks: Promise<void>[] = []
       // This cycle commits everything dirty so far — a pending debounce pass
       // (e.g. queued before a launch/focus/manual sync) would only duplicate it.
       if (timer !== null) {
@@ -225,11 +257,24 @@ export function createSyncEngine(options: SyncEngineOptions): SyncEngine {
       deadline = null
       emit({ state: 'syncing' })
       try {
-        await cycle(mode)
+        await cycle(mode, (changes) => {
+          remoteChangeTasks.push(startRemoteChanges(changes))
+        })
+        await settleRemoteChanges(remoteChangeTasks)
         emit({ state: 'idle' })
       } catch (error) {
         if (error instanceof CycleSuppressedError) {
-          emit({ state: 'idle' })
+          // A merge can land and queue its changed files just before the owner
+          // suppresses later Git commands. Preserve the old boundary: finish
+          // that notification before the suppressed cycle settles to idle.
+          try {
+            await settleRemoteChanges(remoteChangeTasks, false)
+            emit({ state: 'idle' })
+          } catch (notificationError) {
+            if (!signal.aborted) {
+              emit(statusForError(notificationError))
+            }
+          }
         } else if (!signal.aborted) {
           emit(statusForError(error))
         }
@@ -245,7 +290,10 @@ export function createSyncEngine(options: SyncEngineOptions): SyncEngine {
     return running
   }
 
-  async function cycle(mode: 'push' | 'full'): Promise<void> {
+  async function cycle(
+    mode: 'push' | 'full',
+    remoteChanges: (changes: ChangedFile[]) => void,
+  ): Promise<void> {
     const token = options.localOnly === true ? null : await step(options.getToken())
     const commit = await step(gitCommitAll('Update notes', options.generation))
     if (commit.skippedLargeFiles.length > 0) {
@@ -265,7 +313,7 @@ export function createSyncEngine(options: SyncEngineOptions): SyncEngine {
     } else {
       // Launch/focus: pick up other devices' changes even with nothing to push.
       const delta = await step(gitFetch(token, options.generation))
-      const merged = await merge()
+      const merged = await merge(remoteChanges)
       const localOnly = commit.committed || delta.ahead > 0
       if (!localOnly && (merged.kind === 'upToDate' || merged.kind === 'fastForward')) {
         return // pulled cleanly and have nothing of our own — no push needed
@@ -282,20 +330,20 @@ export function createSyncEngine(options: SyncEngineOptions): SyncEngine {
       // The normal two-device race: another device pushed first. Converge and
       // retry — a conflicted merge still commits (markers in the note).
       await step(gitFetch(token, options.generation))
-      await merge()
+      await merge(remoteChanges)
     }
     throw new PushRejectedError(
       'the backup repo kept changing while syncing; will retry on the next edit',
     )
   }
 
-  /** Merge the fetched remote and hand any changed files to the reindexer. */
-  async function merge(): Promise<{ kind: string }> {
+  /** Merge fetched changes and start any changed-file notification. */
+  async function merge(remoteChanges: (changes: ChangedFile[]) => void): Promise<{ kind: string }> {
     return step(gitMergeRemote(options.generation), (outcome) => {
       // The command may already have rewritten files before suspension. Fan
       // those changes out before the boundary gate stops subsequent Git work.
       if (outcome.changedFiles.length > 0) {
-        return options.onRemoteChanges?.(outcome.changedFiles)
+        remoteChanges(outcome.changedFiles)
       }
     }) // upToDate is a no-op
   }


### PR DESCRIPTION
## Follow-up to #696

This is the post-merge hardening found by the requested implementation reflection on #696. It contains only new changes based on the merged `next` branch.

## Problem

The original fix closed the reported emoji-title loss and duplicate-create path, but the reflection found several remaining consistency gaps:

- an already-indexed duplicate exact title could bypass the safe resolver because ordinary wiki resolution selected the first path;
- one readable disk match could win even when an unreadable sibling might claim the same title;
- direct indexing ran before Git push and serialized whole merge callbacks, so slow projection work could delay durable backup and later file-change fanout;
- teardown could leave queued old-graph index work, and ambiguous/general resolution failures were not always explained accurately to the user.

## Changes

1. Preserve ambiguity consistently
   - Added an exact indexed candidate query that keeps ordinary date → title → alias precedence but returns every path in the winning tier.
   - `resolveOrCreateNoteWithTitle` now refuses multiple indexed title/alias claims instead of selecting the alphabetically first path.
   - Disk resolution uses the same title-before-alias tiers for exact and emoji/whitespace fallback matches, and any unreadable collision-family file blocks a guess.
   - Writable wiki-link navigation goes through the ambiguity-preserving resolver even when the index is current; date semantics and daily-route routing remain unchanged.

2. Keep Markdown backup independent from projection latency
   - Every landed merge fans file changes out synchronously.
   - Returned indexing work runs alongside required Git convergence/push, while successful sync still waits for it before reporting idle.
   - The backup controller serializes only direct index writes and invalidates queued work on teardown/restart, preventing old-graph projection work from starting later.

3. Make failures and editor contracts explicit
   - Ambiguous or unavailable matches produce neutral, visible guidance; ordinary resolver/create failures now surface instead of remaining console-only.
   - Renamed the session hook to `reconcilePendingEditorInput` and documented that settled `getMarkdown()` may synchronously deliver `onChange` before returning.

4. Pin the atomic claim as an actual race
   - Added a concurrent Rust regression proving two simultaneous `atomic_create` callers produce exactly one winner and one collision, with winner bytes preserved.

## Verification

- `pnpm check` (passes; only the existing max-lines warnings in `graph-provider.tsx` and `indexer.ts`)
- `pnpm --filter @reflect/core test` — 1,251 passed
- `pnpm --filter @reflect/desktop exec vitest run --maxWorkers=4` — 1,852 passed
- `pnpm --filter @reflect/desktop exec vitest run src/mobile/mobile-screen.test.tsx` — 28 passed
- `cargo fmt --check`
- `cargo test -p reflect-open atomic_create` — 3 passed

## Risk / Rollout

- No schema migration or data backfill is required.
- Exact duplicate titles that previously navigated to the first indexed path now refuse to guess and ask the user to resolve the conflict.
- Git push no longer waits on direct indexing; the UI remains `syncing` until the projection barrier settles, preserving the successful-cycle pre-idle guarantee.
- Leading-emoji fallback matching remains confined to guarded navigation/create behavior; normalized backlink attribution and legacy aliases on unrelated filenames remain follow-up data-model work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes navigation/create behavior for duplicate exact titles (no more first-path guess) and reorders sync so push proceeds before index apply while idle still waits; edge cases around teardown and overlapping merge callbacks are newly exercised in tests.
> 
> **Overview**
> Hardens wiki-link **title resolution** and **backup/sync** so ambiguous or unavailable matches never silently pick a note, and Git push is not blocked by index projection work.
> 
> **Title resolution:** Adds `findExactWikiTargetMatches` (date → title → alias, all paths in the winning tier). `resolveOrCreateNoteWithTitle` uses it instead of first-path `resolveWikiTarget`, refuses multiple indexed claims, and aligns on-disk matching with title-before-alias tiers plus blocking when any slug-family file is unreadable (iCloud placeholder or read error). Writable wiki navigation and backlinks/autocomplete/mobile tasks route through `resolveOrCreateNoteWithTitle`; ambiguous and failed resolves surface via `reportAmbiguousNoteTitle` / `startOperation` instead of console-only behavior. ISO dates still prefer an indexed note over lazy daily routing when one exists.
> 
> **Sync:** Merge file-change fanout stays synchronous; direct `index_apply_batch` work is queued on a serialized tail while Git fetch/merge/push continues. Successful cycles still wait for those tasks before idle; teardown bumps an epoch so queued index work does not run after dispose. Session hook renamed to `reconcilePendingEditorInput` with documented synchronous `onChange` from `getMarkdown()`.
> 
> **Tests:** Concurrent Rust `atomic_create` race; expanded core/create-note and sync-engine/backup-controller coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2e4c4677128db0c6162d47cdb220439553f3647. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->