### PR TITLE
fix: backlink audio memos and links from daily notes

### DIFF
--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -360,7 +360,7 @@ html:root {
 /* The leading H1 is the document title: the regular-note subject, matching
    the daily date subject. H2 and H3 step down the type scale so a section
    heading reads as subordinate to the title, not a second one: auto-appended
-   sections (`## Links`, `## Audio memos`) land at H2, one size below the
+   sections (`## [[Links]]`, `## [[Audio memos]]`) land at H2, one size below the
    subject; H3 sits at body size, carried by weight rather than scale. */
 .reflect-editor h1 { @apply text-note-subject; } /* text-xl, 20px */
 .reflect-editor h2 { font-size: var(--text-lg, 1.125rem); } /* 18px */

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -18,9 +18,10 @@ Install the published extension from the
 popup → `chrome.storage` queue → background `sendNativeMessage` →
 `reflect-capture-host` (Tauri sidecar, registered by the desktop app on every
 launch) → capture inbox → desktop drain (`@reflect/core` `actions/capture`):
-raw note + daily `## Links` entry now, meta-scrape + BYOK AI title +
-description async. The extension stores no keys and makes no AI or network calls; its
-only honest status is **queued** — it cannot observe the desktop drain.
+raw note + daily `## [[Links]]` entry now (resolving or creating that category
+note), meta-scrape + BYOK AI title + description async. The extension stores no
+keys and makes no AI or network calls; its only honest status is **queued** — it
+cannot observe the desktop drain.
 
 ## Develop
 

--- a/docs/plans/11-link-capture.md
+++ b/docs/plans/11-link-capture.md
@@ -162,7 +162,8 @@ Every capture lands in two phases so saving never waits on the network or AI:
      provider/model used in provenance.
 
 6. **Write path (desktop-owned, executed inside drain step 3 above).** Default shape:
-   - append a `[[Links]]` entry to **today's daily note** (Plan 06 append-under-heading);
+   - append the capture under `## [[Links]]` in **today's daily note**, resolving the
+     existing `Links` category note (including aliases/renames) or creating it safely;
    - create a **dedicated markdown note** when the capture has enough phase-1 content
      to be worth preserving (selection/highlights present, or a screenshot) — the
      description arrives later in phase 2 and is patched into the dedicated note then,
@@ -208,9 +209,10 @@ Every capture lands in two phases so saving never waits on the network or AI:
 
 ## Acceptance criteria
 
-- With the extension installed, capturing a page appends a `[[Links]]` entry to today's
-  daily note with the screenshot already saved under `assets/` (phase 1, synchronous),
-  then asynchronously gains an AI description + scraped meta tags (phase 2).
+- With the extension installed, capturing a page appends under `## [[Links]]` in today's
+  daily note, with the category note and screenshot under `assets/` already saved
+  (phase 1, synchronous), then asynchronously gains an AI description + scraped meta
+  tags (phase 2).
 - **Capturing with the desktop app closed** queues the capture; it lands (raw, then
   enriched) on next app launch (test-asserted).
 - With no AI connection enabled, captures still get the raw entry + scraped meta tags;

--- a/docs/porting/audio-memos.md
+++ b/docs/porting/audio-memos.md
@@ -24,8 +24,10 @@ touches a Reflect server, because there isn't one.
 - **Transcription.** Runs against the user's own OpenAI or Gemini key
   (chosen by `pickTranscriptionConfig` in `@reflect/core`; keys in the OS
   keychain via `apps/desktop/src-tauri/src/secrets.rs`). The reconciler
-  (`apps/desktop/src/lib/transcription-reconciler.ts`) writes the transcript
-  into the daily note and retries pending memos in the background.
+  (`apps/desktop/src/lib/transcription-reconciler.ts`) writes a dedicated
+  transcript note, resolves or creates the `Audio memos` category note, and
+  backlinks both from the daily note under `## [[Audio memos]]`. Pending memos
+  retry in the background.
 - **No key configured.** The mic button is disabled with a tooltip pointing
   at Settings — there is no metered fallback tier to fall back to.
 

--- a/packages/core/src/actions/audio-memo.test.ts
+++ b/packages/core/src/actions/audio-memo.test.ts
@@ -25,6 +25,7 @@ import { getSecret } from '../secrets/keychain'
 const generateAudioMemoTitleMock = vi.hoisted(() =>
   vi.fn<(request: GenerateAudioMemoTitleRequest) => Promise<string>>(),
 )
+const ensureBacklinkTargetMock = vi.hoisted(() => vi.fn())
 
 vi.mock('../graph/commands', () => ({
   listDir: vi.fn(),
@@ -41,6 +42,9 @@ vi.mock('../ai/transcribe', async (importOriginal) => ({
 vi.mock('../ai/audio-memo-title', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../ai/audio-memo-title')>()),
   generateAudioMemoTitle: generateAudioMemoTitleMock,
+}))
+vi.mock('./backlink-target', () => ({
+  ensureBacklinkTarget: ensureBacklinkTargetMock,
 }))
 vi.mock('../secrets/keychain', () => ({
   getSecret: vi.fn(),
@@ -90,6 +94,7 @@ beforeEach(() => {
   getSecretMock.mockResolvedValue('sk-live-key')
   transcribeMock.mockResolvedValue('memo transcript')
   generateAudioMemoTitleMock.mockResolvedValue('Memo Transcript')
+  ensureBacklinkTargetMock.mockResolvedValue('Audio memos')
 })
 
 describe('audioMemoIdentity', () => {
@@ -204,10 +209,11 @@ describe('reconcileAudioMemos', () => {
       ],
       [
         'daily/2026-06-11.md',
-        'morning thoughts\n\n## Audio memos\n\n- [[audio-memo-2026-06-11-153022-845|Memo Transcript]]\n',
+        'morning thoughts\n\n## [[Audio memos]]\n\n- [[audio-memo-2026-06-11-153022-845|Memo Transcript]]\n',
         3,
       ],
     ])
+    expect(ensureBacklinkTargetMock).toHaveBeenCalledWith('Audio memos', 3)
     expect(generateAudioMemoTitleMock).toHaveBeenCalledWith({
       credentials: {
         config: { ...PROVIDERS.providers[0], model: 'gpt-5.4-nano' },
@@ -269,6 +275,7 @@ describe('reconcileAudioMemos', () => {
       expect.stringContaining('second transcript'),
       3,
     )
+    expect(ensureBacklinkTargetMock).toHaveBeenCalledTimes(1)
   })
 
   it('a failed note write stops before the backlink — the transcript is never tombstoned away', async () => {
@@ -297,9 +304,70 @@ describe('reconcileAudioMemos', () => {
 
     expect(writeNoteMock).toHaveBeenCalledWith(
       'daily/2026-06-11.md',
-      '## Audio memos\n\n- [[audio-memo-2026-06-11-153022-845|Memo Transcript]]\n',
+      '## [[Audio memos]]\n\n- [[audio-memo-2026-06-11-153022-845|Memo Transcript]]\n',
       3,
     )
+  })
+
+  it('upgrades the legacy plain memo heading without creating a second section', async () => {
+    listDirMock.mockResolvedValue([fileMeta(MEMO.audioPath)])
+    readNoteMock.mockResolvedValue(
+      '## Audio memos\n\n- [[audio-memo-2026-06-10-090000-000|Yesterday]]\n',
+    )
+
+    await reconcile()
+
+    expect(writeNoteMock).toHaveBeenCalledWith(
+      'daily/2026-06-11.md',
+      '## [[Audio memos]]\n\n- [[audio-memo-2026-06-10-090000-000|Yesterday]]\n\n- [[audio-memo-2026-06-11-153022-845|Memo Transcript]]\n',
+      3,
+    )
+  })
+
+  it('uses the current title when the Audio memos note was renamed', async () => {
+    listDirMock.mockResolvedValue([fileMeta(MEMO.audioPath)])
+    ensureBacklinkTargetMock.mockResolvedValue('Voice notes')
+
+    await reconcile()
+
+    expect(writeNoteMock).toHaveBeenCalledWith(
+      'daily/2026-06-11.md',
+      expect.stringContaining('## [[Voice notes]]'),
+      3,
+    )
+  })
+
+  it('stops before writing the transcript when the category note cannot be ensured', async () => {
+    listDirMock.mockResolvedValue([fileMeta(MEMO.audioPath)])
+    ensureBacklinkTargetMock.mockRejectedValue({ kind: 'io', message: 'disk full' })
+
+    const outcome = await reconcile()
+
+    expect(outcome).toEqual({
+      pending: 1,
+      transcribed: 0,
+      rejected: 0,
+      stopped: { reason: 'io', message: 'disk full' },
+    })
+    expect(writeNoteMock).not.toHaveBeenCalled()
+    expect(transcribeMock).not.toHaveBeenCalled()
+  })
+
+  it('does not finalize a memo while its category backlink is ambiguous', async () => {
+    listDirMock.mockResolvedValue([fileMeta(MEMO.audioPath)])
+    ensureBacklinkTargetMock.mockRejectedValue({
+      kind: 'unknown',
+      message: 'The [[Audio memos]] backlink matches multiple notes',
+    })
+
+    const outcome = await reconcile()
+
+    expect(outcome).toMatchObject({
+      transcribed: 0,
+      stopped: { reason: 'unknown', message: expect.stringContaining('matches multiple notes') },
+    })
+    expect(transcribeMock).not.toHaveBeenCalled()
+    expect(writeNoteMock).not.toHaveBeenCalled()
   })
 
   it('a daily-note backlink without the note is a tombstone — deletion stays deleted', async () => {
@@ -475,10 +543,11 @@ describe('reconcileAudioMemos', () => {
   it('the abort gate stops between memos', async () => {
     const earlier = audioMemoIdentity(new Date(2026, 5, 10, 9, 0, 0, 0), 'audio/mp4')
     listDirMock.mockResolvedValue([fileMeta(earlier.audioPath), fileMeta(MEMO.audioPath)])
-    // The gate is consulted three times per memo (loop top, post-read,
-    // post-transcribe): let the first memo through, stop the second.
+    // The first memo checks at loop start, after category resolution, after
+    // the asset read, and after transcription; stop at the next loop start.
     const isStale = vi
       .fn()
+      .mockReturnValueOnce(false)
       .mockReturnValueOnce(false)
       .mockReturnValueOnce(false)
       .mockReturnValueOnce(false)
@@ -509,6 +578,26 @@ describe('reconcileAudioMemos', () => {
       transcribed: 0,
       stopped: { reason: 'stale' },
     })
+    expect(writeNoteMock).not.toHaveBeenCalled()
+  })
+
+  it('a graph switch during category resolution stops before reading the recording', async () => {
+    listDirMock.mockResolvedValue([fileMeta(MEMO.audioPath)])
+    let closed = false
+    ensureBacklinkTargetMock.mockImplementation(async () => {
+      closed = true
+      return 'Audio memos'
+    })
+
+    const outcome = await reconcile({ isStale: () => closed })
+
+    expect(outcome).toMatchObject({
+      pending: 1,
+      transcribed: 0,
+      stopped: { reason: 'stale' },
+    })
+    expect(readAssetMock).not.toHaveBeenCalled()
+    expect(transcribeMock).not.toHaveBeenCalled()
     expect(writeNoteMock).not.toHaveBeenCalled()
   })
 

--- a/packages/core/src/actions/audio-memo.ts
+++ b/packages/core/src/actions/audio-memo.ts
@@ -17,9 +17,10 @@ import {
 } from '../ai/transcribe'
 import { listDir, listFiles, readAsset, readNote, writeAsset, writeNote } from '../graph/commands'
 import { AUDIO_MEMOS_DIR, audioMemoPath, dailyPath, notePath } from '../graph/paths'
-import { appendUnderHeading, wikiLinkSafe } from '../markdown/edit'
+import { appendUnderBacklinkedHeading, wikiLinkSafe } from '../markdown/edit'
 import { getSecret } from '../secrets/keychain'
 import type { AiProviderConfig } from '../settings/schema'
+import { ensureBacklinkTarget } from './backlink-target'
 
 /**
  * Capture actions for audio memos (the first of the `actions/` capture
@@ -32,9 +33,10 @@ import type { AiProviderConfig } from '../settings/schema'
  *    network. The sync engine commits it like any other change.
  * 2. **Reconcile** ({@link reconcileAudioMemos}): a memo's transcription is a
  *    note with the **same basename** (`notes/<base>.md`). Any memo without
- *    one is transcribed (BYOK provider), named from that transcript, its
- *    transcription note written, and a backlink appended to its day's daily
- *    note — note first, because it carries the transcript: a failure between
+ *    one resolves or creates the `Audio memos` category note, is transcribed
+ *    (BYOK provider), named from that transcript, written to its transcription
+ *    note, and backlinked from its day's daily note — transcript note first,
+ *    because it carries the result: a failure between
  *    the two writes leaves an unlinked note, never a tombstoned memo whose
  *    transcript was dropped. A
  *    failed pass (offline, bad key) leaves the memo pending; the next
@@ -306,21 +308,17 @@ async function memoNoteBody(input: {
   }
 }
 
-/** Where the memo's daily-note backlink lands (`appendUnderHeading` creates
- * it), mirroring link capture's `## Links` so both append paths read the same. */
-const MEMOS_HEADING = 'Audio memos'
-
+/** The category note every audio-memo section backlinks. */
+const MEMOS_NOTE_TITLE = 'Audio memos'
 /**
- * Append the memo's wikilink to its day's daily note, once — under an
- * `## Audio memos` section, creating the heading and the file as needed
- * (capture must never depend on the note already existing). The write goes
- * straight to disk: the watcher reindexes it, and an open editor session
- * reconciles it like any external change (clean buffers reload in place;
- * dirty ones park a conflict rather than being clobbered).
+ * Append the memo's wikilink once under `## [[Audio memos]]`, creating the
+ * heading and daily file as needed. The watcher reindexes the direct write;
+ * open dirty editors park a conflict instead of being clobbered.
  */
 async function ensureDailyBacklink(
   memo: AudioMemoIdentity,
   title: string,
+  memosNoteTitle: string,
   generation: number,
 ): Promise<void> {
   const source = await dailyNoteSource(memo.date, generation)
@@ -329,7 +327,8 @@ async function ensureDailyBacklink(
   }
   const displayTitle = wikiLinkSafe(title) || memo.title
   const link = `- [[${memo.base}|${displayTitle}]]`
-  await writeNote(dailyPath(memo.date), appendUnderHeading(source, MEMOS_HEADING, link), generation)
+  const updated = appendUnderBacklinkedHeading(source, memosNoteTitle, link, [MEMOS_NOTE_TITLE])
+  await writeNote(dailyPath(memo.date), updated, generation)
 }
 
 /**
@@ -380,9 +379,10 @@ export interface ReconcileAudioMemosOutcome {
 }
 
 /**
- * Transcribe every pending memo: read the recording back, transcribe, write
- * the transcription note, then append the daily-note backlink. The note is
- * written **first** — it carries the transcript, so a failure between the
+ * Transcribe every pending memo: ensure the category target, read the
+ * recording, transcribe, write the transcription note, then append the daily
+ * backlink. The transcript note is written **first** — it carries the result,
+ * so a failure between the
  * two writes leaves an unlinked note (recoverable from All Notes), never a
  * backlink-tombstoned memo whose transcript was dropped. A recording the
  * provider refuses gets a failure note (tombstoning it) and the pass moves
@@ -443,6 +443,7 @@ export async function reconcileAudioMemos(
 
   let transcribed = 0
   let rejected = 0
+  let memosNoteTitle: string | null = null
   // The gate is consulted again after every slow await (the asset read, the
   // provider call), not just per memo: a graph switch mid-transcription must
   // not bill another provider call or touch any note. Reads and writes are
@@ -460,6 +461,8 @@ export async function reconcileAudioMemos(
       return stalled()
     }
     try {
+      memosNoteTitle ??= await ensureBacklinkTarget(MEMOS_NOTE_TITLE, input.generation)
+      if (stale()) return stalled()
       const audio = new Blob([base64ToBytes(await readAsset(memo.audioPath, input.generation))], {
         type: memo.mimeType,
       })
@@ -478,7 +481,7 @@ export async function reconcileAudioMemos(
         return stalled()
       }
       await writeNote(memo.notePath, transcriptionNote(memo, note.title, note.body), input.generation)
-      await ensureDailyBacklink(memo, note.title, input.generation)
+      await ensureDailyBacklink(memo, note.title, memosNoteTitle, input.generation)
       if (note.rejected) {
         rejected += 1
       } else {

--- a/packages/core/src/actions/backlink-target.test.ts
+++ b/packages/core/src/actions/backlink-target.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { readNote } from '../graph/commands'
+import { resolveOrCreateNoteWithTitle } from '../graph/create-note'
+import { ensureBacklinkTarget } from './backlink-target'
+
+vi.mock('../graph/commands', () => ({ readNote: vi.fn() }))
+vi.mock('../graph/create-note', () => ({ resolveOrCreateNoteWithTitle: vi.fn() }))
+
+const readNoteMock = vi.mocked(readNote)
+const resolveOrCreateMock = vi.mocked(resolveOrCreateNoteWithTitle)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  resolveOrCreateMock.mockResolvedValue({ kind: 'resolved', path: 'notes/links.md' })
+  readNoteMock.mockResolvedValue('# Links\n')
+})
+
+describe('ensureBacklinkTarget', () => {
+  it('returns the existing note title so renamed categories keep one section', async () => {
+    resolveOrCreateMock.mockResolvedValue({ kind: 'resolved', path: 'notes/bookmarks.md' })
+    readNoteMock.mockResolvedValue('# Bookmarks\n')
+
+    await expect(ensureBacklinkTarget('Links', 3)).resolves.toBe('Bookmarks')
+    expect(readNoteMock).toHaveBeenCalledWith('notes/bookmarks.md', 3)
+  })
+
+  it('returns the canonical title of a newly created target', async () => {
+    resolveOrCreateMock.mockResolvedValue({ kind: 'created', path: 'notes/links.md' })
+
+    await expect(ensureBacklinkTarget('Links', 3)).resolves.toBe('Links')
+  })
+
+  it('keeps the resolvable alias when the current title is unsafe in wiki syntax', async () => {
+    resolveOrCreateMock.mockResolvedValue({ kind: 'resolved', path: 'notes/saved-links.md' })
+    readNoteMock.mockResolvedValue('# Saved | Links\n')
+
+    await expect(ensureBacklinkTarget('Links', 3)).resolves.toBe('Links')
+  })
+
+  it('refuses an ambiguous target instead of creating a terminal unresolved backlink', async () => {
+    resolveOrCreateMock.mockResolvedValue({
+      kind: 'ambiguous',
+      paths: ['notes/links-2.md', 'notes/links.md'],
+    })
+
+    await expect(ensureBacklinkTarget('Links', 3)).rejects.toMatchObject({
+      kind: 'unknown',
+      message: expect.stringContaining('matches multiple notes'),
+    })
+    expect(readNoteMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/actions/backlink-target.ts
+++ b/packages/core/src/actions/backlink-target.ts
@@ -1,0 +1,25 @@
+import { ReflectError } from '../errors'
+import { readNote } from '../graph/commands'
+import { resolveOrCreateNoteWithTitle } from '../graph/create-note'
+import { wikiLinkSafe } from '../markdown/edit'
+import { parseNote } from '../markdown/extract'
+
+/**
+ * Resolve the note targeted by an automatic backlink, or create it safely.
+ * Ambiguity is not success: callers cannot make a durable category link until
+ * the index or synced files identify one target unambiguously. Returns the
+ * a link-safe current title so renames keep one section; an unsafe title falls
+ * back to the requested spelling that just resolved as its alias.
+ */
+export async function ensureBacklinkTarget(title: string, generation: number): Promise<string> {
+  const outcome = await resolveOrCreateNoteWithTitle(title, generation)
+  if (outcome.kind === 'ambiguous') {
+    throw new ReflectError(
+      'unknown',
+      `The [[${title}]] backlink matches multiple notes: ${outcome.paths.join(', ')}`,
+    )
+  }
+  const source = await readNote(outcome.path, generation)
+  const currentTitle = parseNote({ path: outcome.path, source }).title
+  return wikiLinkSafe(currentTitle) === currentTitle ? currentTitle : title
+}

--- a/packages/core/src/actions/capture-drain.test.ts
+++ b/packages/core/src/actions/capture-drain.test.ts
@@ -18,6 +18,8 @@ import {
 } from './capture-harness'
 import type { TextCaptureEnvelope } from './capture-envelope'
 
+const ensureBacklinkTargetMock = vi.hoisted(() => vi.fn())
+
 vi.mock('../graph/commands', () => ({
   captureInboxList: vi.fn(),
   captureInboxRead: vi.fn(),
@@ -39,9 +41,13 @@ vi.mock('../ai/describe-page', async (importOriginal) => ({
 vi.mock('../secrets/keychain', () => ({
   getSecret: vi.fn(),
 }))
+vi.mock('./backlink-target', () => ({
+  ensureBacklinkTarget: ensureBacklinkTargetMock,
+}))
 
 beforeEach(() => {
   wireCaptureMocks()
+  ensureBacklinkTargetMock.mockResolvedValue('Links')
 })
 
 describe('drainCaptureInbox', () => {
@@ -70,8 +76,9 @@ describe('drainCaptureInbox', () => {
     expect(note).toContain(`## Screenshot\n\n![An article](${IDENTITY.assetPath})`)
 
     const daily = files.get(DAILY)
-    expect(daily).toContain('## Links')
+    expect(daily).toContain('## [[Links]]')
     expect(daily).toContain('- [[capture-2026-06-11-153022-845-7c9e|An article]]')
+    expect(ensureBacklinkTargetMock).toHaveBeenCalledWith('Links', 3)
     expect(spool.size).toBe(0)
   })
 
@@ -137,16 +144,111 @@ describe('drainCaptureInbox', () => {
     expect(spool.size).toBe(0)
   })
 
-  it('appends to the existing Links section without duplicating it', async () => {
+  it('upgrades the existing plain Links section without duplicating it', async () => {
     files.set(DAILY, '# plans\n\n## Links\n\n[[capture-2026-06-11-090000-000-0000|Old]]\n')
     addSpool(envelope())
 
     await drain()
 
     const daily = files.get(DAILY) ?? ''
-    expect(daily.match(/## Links/g)).toHaveLength(1)
+    expect(daily.match(/## \[\[Links\]\]/g)).toHaveLength(1)
+    expect(daily).not.toContain('## Links\n')
     expect(daily).toContain('[[capture-2026-06-11-090000-000-0000|Old]]')
     expect(daily).toContain('- [[capture-2026-06-11-153022-845-7c9e|An article]]')
+  })
+
+  it('reuses an existing linked Links section for same-day dedup', async () => {
+    addSpool(
+      envelope({
+        id: '00000000-0000-4000-8000-000000000001',
+        capturedAt: new Date(2026, 5, 11, 9, 30, 0, 0).toISOString(),
+      }),
+    )
+    await drain()
+
+    addSpool(envelope())
+    const outcome = await drain()
+
+    expect(outcome.deduped).toBe(1)
+    const daily = files.get(DAILY) ?? ''
+    expect(daily.match(/## \[\[Links\]\]/g)).toHaveLength(1)
+    expect(daily.match(/capture-2026-06-11-093000-000-0000/g)).toHaveLength(1)
+  })
+
+  it('upgrades a legacy heading even when a same-day recapture is deduplicated', async () => {
+    addSpool(
+      envelope({
+        id: '00000000-0000-4000-8000-000000000001',
+        capturedAt: new Date(2026, 5, 11, 9, 30, 0, 0).toISOString(),
+      }),
+    )
+    await drain()
+    files.set(DAILY, (files.get(DAILY) ?? '').replace('## [[Links]]', '## Links'))
+
+    addSpool(envelope())
+    const outcome = await drain()
+
+    expect(outcome.deduped).toBe(1)
+    expect(files.get(DAILY)).toContain('## [[Links]]')
+    expect(files.get(DAILY)).not.toContain('## Links\n')
+  })
+
+  it('deduplicates across every matching Links section', async () => {
+    addSpool(
+      envelope({
+        id: '00000000-0000-4000-8000-000000000001',
+        capturedAt: new Date(2026, 5, 11, 9, 30, 0, 0).toISOString(),
+      }),
+    )
+    await drain()
+    files.set(DAILY, `## Links\n\n- [[Old]]\n\n${files.get(DAILY) ?? ''}`)
+
+    addSpool(envelope())
+    const outcome = await drain()
+
+    expect(outcome.deduped).toBe(1)
+    expect(files.has(IDENTITY.notePath)).toBe(false)
+  })
+
+  it('keeps the spool retryable when the Links note cannot be ensured', async () => {
+    addSpool(envelope())
+    ensureBacklinkTargetMock.mockRejectedValue({ kind: 'io', message: 'disk full' })
+
+    const outcome = await drain()
+
+    expect(outcome.stopped).toEqual({ reason: 'io', message: 'disk full' })
+    expect(files.size).toBe(0)
+    expect(spool.size).toBe(2)
+  })
+
+  it('uses the current title when the Links note was renamed', async () => {
+    ensureBacklinkTargetMock.mockResolvedValue('Bookmarks')
+    addSpool(envelope())
+
+    await drain()
+
+    expect(files.get(DAILY)).toContain('## [[Bookmarks]]')
+    expect(files.get(DAILY)).not.toContain('## [[Links]]')
+    expect(ensureBacklinkTargetMock).toHaveBeenCalledWith('Links', 3)
+  })
+
+  it('deduplicates captures under a renamed Links heading', async () => {
+    addSpool(
+      envelope({
+        id: '00000000-0000-4000-8000-000000000001',
+        capturedAt: new Date(2026, 5, 11, 9, 30, 0, 0).toISOString(),
+      }),
+    )
+    await drain()
+    files.set(DAILY, (files.get(DAILY) ?? '').replace('[[Links]]', '[[Bookmarks]]'))
+    ensureBacklinkTargetMock.mockResolvedValue('Bookmarks')
+
+    addSpool(envelope())
+    const outcome = await drain()
+
+    expect(outcome.deduped).toBe(1)
+    expect(files.has(IDENTITY.notePath)).toBe(false)
+    expect(files.get(DAILY)).toContain('## [[Bookmarks]]')
   })
 
   it('saves a private-day capture raw, marked skipped', async () => {

--- a/packages/core/src/actions/capture-drain.ts
+++ b/packages/core/src/actions/capture-drain.ts
@@ -10,10 +10,16 @@ import {
 } from '../graph/commands'
 import { dailyPath, notePath } from '../graph/paths'
 import { hashContent } from '../indexing/hash'
-import { appendBlock, appendUnderHeading } from '../markdown/edit'
+import {
+  appendBlock,
+  appendUnderBacklinkedHeading,
+  headingMatchesBacklinkedTitle,
+  upgradeSectionHeadingBacklink,
+} from '../markdown/edit'
 import { parseNote } from '../markdown/extract'
 import { parseFrontmatter, splitFrontmatter } from '../markdown/frontmatter'
 import type { ReconcileStop } from './audio-memo'
+import { ensureBacklinkTarget } from './backlink-target'
 import {
   captureFromPath,
   captureIdentity,
@@ -36,8 +42,8 @@ import {
   type CaptureStatus,
 } from './capture-note'
 
-/** Where the daily-note entry lands (`appendUnderHeading` creates it). */
-const LINKS_HEADING = 'Links'
+/** The category note every captured-link section backlinks. */
+const LINKS_NOTE_TITLE = 'Links'
 
 /** Long-edge cap for promoted screenshots (the Rust side re-encodes JPEG). */
 const SCREENSHOT_MAX_DIM = 1600
@@ -75,20 +81,31 @@ interface SameDayCapture {
 
 async function findSameDayCapture(
   dailySource: string,
+  sectionTitles: readonly string[],
   url: string,
   selectionHash: string | undefined,
   generation: number,
 ): Promise<SameDayCapture | null> {
   const { headings, wikiLinks } = parseNote({ path: '', source: dailySource })
-  const links = headings.find((heading) => heading.text.toLowerCase() === LINKS_HEADING.toLowerCase())
-  if (!links) {
+  const linkSections = headings.filter(
+    (heading) =>
+      heading.level === 2 &&
+      sectionTitles.some((title) =>
+        headingMatchesBacklinkedTitle(dailySource, heading, wikiLinks, title),
+      ),
+  )
+  if (linkSections.length === 0) {
     return null
   }
-  const sectionEnd =
-    headings.find((heading) => heading.from > links.from && heading.level <= links.level)?.from ??
-    dailySource.length
+  const ranges = linkSections.map((section) => ({
+    from: section.to,
+    to:
+      headings.find(
+        (heading) => heading.from > section.from && heading.level <= section.level,
+      )?.from ?? dailySource.length,
+  }))
   const targets = wikiLinks
-    .filter((link) => link.from >= links.to && link.from < sectionEnd)
+    .filter((link) => ranges.some((range) => link.from >= range.from && link.from < range.to))
     .map((link) => link.target)
   for (const target of targets) {
     const identity = captureFromPath(notePath(target))
@@ -171,11 +188,13 @@ export async function drainCaptureInbox(
       }
       const fresh = captureIdentity(new Date(envelope.capturedAt), envelope.id)
       const daily = dailyPath(fresh.date)
+      const linksNoteTitle = await ensureBacklinkTarget(LINKS_NOTE_TITLE, input.generation)
       const dailySource = await noteSource(daily, input.generation)
       const selection = envelope.selection?.trim()
       const selectionHash = selection ? await hashContent(selection) : undefined
       const existing = await findSameDayCapture(
         dailySource,
+        [linksNoteTitle, LINKS_NOTE_TITLE],
         envelope.url,
         selectionHash,
         input.generation,
@@ -217,11 +236,13 @@ export async function drainCaptureInbox(
         // daily's link text in step.
         updatedDaily = retitleDailyEntry(updatedDaily, identity.base, existing.title, freshTitle)
       }
+      updatedDaily = upgradeSectionHeadingBacklink(updatedDaily, linksNoteTitle, [LINKS_NOTE_TITLE])
       if (!updatedDaily.includes(`[[${identity.base}`)) {
-        updatedDaily = appendUnderHeading(
+        updatedDaily = appendUnderBacklinkedHeading(
           updatedDaily,
-          LINKS_HEADING,
+          linksNoteTitle,
           `- [[${identity.base}|${freshTitle}]]`,
+          [LINKS_NOTE_TITLE],
         )
       }
       if (updatedDaily !== dailySource) {

--- a/packages/core/src/actions/capture-enrichment.test.ts
+++ b/packages/core/src/actions/capture-enrichment.test.ts
@@ -20,6 +20,8 @@ import {
 } from './capture-harness'
 import type { CaptureEnvelope } from './capture-envelope'
 
+const ensureBacklinkTargetMock = vi.hoisted(() => vi.fn())
+
 vi.mock('../graph/commands', () => ({
   captureInboxList: vi.fn(),
   captureInboxRead: vi.fn(),
@@ -41,9 +43,13 @@ vi.mock('../ai/describe-page', async (importOriginal) => ({
 vi.mock('../secrets/keychain', () => ({
   getSecret: vi.fn(),
 }))
+vi.mock('./backlink-target', () => ({
+  ensureBacklinkTarget: ensureBacklinkTargetMock,
+}))
 
 beforeEach(() => {
   wireCaptureMocks()
+  ensureBacklinkTargetMock.mockResolvedValue('Links')
 })
 
 describe('reconcileCaptureEnrichment', () => {

--- a/packages/core/src/markdown/edit.test.ts
+++ b/packages/core/src/markdown/edit.test.ts
@@ -4,6 +4,7 @@ import {
   appendBlock,
   appendTaskLine,
   appendTaskToContext,
+  appendUnderBacklinkedHeading,
   appendUnderHeading,
   clearTaskDueDate,
   editTaskLine,
@@ -57,6 +58,49 @@ describe('appendUnderHeading', () => {
 
   it('matches the heading case-insensitively', () => {
     expect(appendUnderHeading(doc, 'a', '- new')).toBe('# A\n\nalpha\n\n- new\n\n# B\n\nbeta')
+  })
+})
+
+describe('appendUnderBacklinkedHeading', () => {
+  it('creates a linked H2 section when the category is missing', () => {
+    expect(appendUnderBacklinkedHeading('morning notes\n', 'Links', '- [[Article]]')).toBe(
+      'morning notes\n\n## [[Links]]\n\n- [[Article]]\n',
+    )
+  })
+
+  it('appends to an existing linked section without duplicating it', () => {
+    const source = '## [[Links]]\n\n- [[Old]]\n\n## Other\n\ntext\n'
+    expect(appendUnderBacklinkedHeading(source, 'Links', '- [[New]]')).toBe(
+      '## [[Links]]\n\n- [[Old]]\n\n- [[New]]\n\n## Other\n\ntext\n',
+    )
+  })
+
+  it('matches a linked target case-insensitively and preserves its alias', () => {
+    const source = '## [[LINKS|Saved links]]\n\n- [[Old]]\n'
+    expect(appendUnderBacklinkedHeading(source, 'Links', '- [[New]]')).toBe(
+      '## [[LINKS|Saved links]]\n\n- [[Old]]\n\n- [[New]]\n',
+    )
+  })
+
+  it('upgrades a legacy plain section in place and preserves its content', () => {
+    const source = 'intro\n\n## links\n\n- [[Old]]\n\n## Other\n\ntext\n'
+    expect(appendUnderBacklinkedHeading(source, 'Links', '- [[New]]')).toBe(
+      'intro\n\n## [[Links]]\n\n- [[Old]]\n\n- [[New]]\n\n## Other\n\ntext\n',
+    )
+  })
+
+  it('does not mistake escaped literal brackets for a linked heading', () => {
+    const source = '## \\[[Links]]\n\nliteral brackets\n'
+    expect(appendUnderBacklinkedHeading(source, 'Links', '- [[New]]')).toBe(
+      '## \\[[Links]]\n\nliteral brackets\n\n## [[Links]]\n\n- [[New]]\n',
+    )
+  })
+
+  it('preserves a user-authored plain heading at another level', () => {
+    const source = '# Links\n\ntitle-like content\n'
+    expect(appendUnderBacklinkedHeading(source, 'Links', '- [[New]]')).toBe(
+      '# Links\n\ntitle-like content\n\n## [[Links]]\n\n- [[New]]\n',
+    )
   })
 })
 

--- a/packages/core/src/markdown/edit.ts
+++ b/packages/core/src/markdown/edit.ts
@@ -2,10 +2,11 @@ import type { SyntaxNode } from '@lezer/common'
 import { parseNote } from './extract'
 import { splitFrontmatter } from './frontmatter'
 import { parseBody } from './grammar'
+import { foldKey } from './keys'
 import { normalizeWikiTarget } from './resolve'
 import { scanInlineWikiLinks } from './scan'
 import { parseTaskMarker } from './task-marker'
-import type { Heading, TaskMarker } from './model'
+import type { Heading, TaskMarker, WikiLink } from './model'
 
 /**
  * Source-level edit helpers (Plan 03). These splice the original string by node
@@ -348,14 +349,140 @@ export function appendUnderHeading(source: string, heading: string, block: strin
   const target = headings.find((candidate) => candidate.text.toLowerCase() === headingKey)
 
   if (!target) {
-    const base = source.replace(/\s*$/, '')
-    const prefix = base.length > 0 ? `${base}\n\n` : ''
-    return `${prefix}## ${heading.trim()}\n\n${block}\n`
+    return appendHeadingSection(source, heading, block)
   }
 
+  return appendAtHeading(source, headings, target, block)
+}
+
+function appendHeadingSection(source: string, heading: string, block: string): string {
+  const base = source.replace(/\s*$/, '')
+  const prefix = base.length > 0 ? `${base}\n\n` : ''
+  return `${prefix}## ${heading.trim()}\n\n${block}\n`
+}
+
+function appendAtHeading(
+  source: string,
+  headings: Heading[],
+  target: Heading,
+  block: string,
+): string {
   const sectionEnd = nextSectionStart(headings, target, source.length)
   const head = source.slice(0, sectionEnd).replace(/\s*$/, '')
   const tail = source.slice(sectionEnd)
   const inserted = `${head}\n\n${block}`
   return tail ? `${inserted}\n\n${tail}` : `${inserted}\n`
+}
+
+/** The target when a heading consists entirely of one parsed wiki link. */
+function linkedHeadingTarget(
+  source: string,
+  heading: Heading,
+  wikiLinks: readonly WikiLink[],
+): string | null {
+  const raw = source.slice(heading.from, heading.to)
+  const firstLine = raw.slice(0, raw.indexOf('\n') === -1 ? raw.length : raw.indexOf('\n'))
+  const content = firstLine
+    .replace(/^[ \t]{0,3}#{1,6}[ \t]+/, '')
+    .replace(/[ \t]+#+[ \t]*$/, '')
+    .trim()
+  const match = /^\[\[\s*([^\]|\r\n]+?)\s*(?:\|[^\]\r\n]*)?\]\]$/.exec(content)
+  const textTarget = match?.[1]?.trim()
+  if (textTarget === undefined || textTarget === '') {
+    return null
+  }
+  const parsedLink = wikiLinks.find(
+    (link) =>
+      link.from >= heading.from &&
+      link.to <= heading.to &&
+      foldKey(link.target) === foldKey(textTarget),
+  )
+  return parsedLink?.target ?? null
+}
+
+/**
+ * Whether `heading` names `title` either as a linked heading (`## [[Links]]`)
+ * or as the legacy plain form (`## Links`). A linked heading's target, rather
+ * than its display alias, identifies the section.
+ */
+export function headingMatchesBacklinkedTitle(
+  source: string,
+  heading: Heading,
+  wikiLinks: readonly WikiLink[],
+  title: string,
+): boolean {
+  return foldKey(linkedHeadingTarget(source, heading, wikiLinks) ?? heading.text) === foldKey(title)
+}
+
+function matchingBacklinkedHeading(
+  source: string,
+  headings: readonly Heading[],
+  wikiLinks: readonly WikiLink[],
+  titles: readonly string[],
+): Heading | undefined {
+  const matches = headings.filter((heading) =>
+    heading.level === 2 &&
+    titles.some((title) => headingMatchesBacklinkedTitle(source, heading, wikiLinks, title)),
+  )
+  return (
+    matches.find((heading) => linkedHeadingTarget(source, heading, wikiLinks) !== null) ?? matches[0]
+  )
+}
+
+/**
+ * Add the missing wiki link to an existing legacy `## Title` section heading.
+ * Missing or already-linked sections are byte-identical no-ops.
+ */
+export function upgradeSectionHeadingBacklink(
+  source: string,
+  title: string,
+  matchingTitles: readonly string[] = [],
+): string {
+  const safeTitle = wikiLinkSafe(title)
+  if (safeTitle === '') {
+    throw new Error('a backlinked heading needs a title')
+  }
+  const { headings, wikiLinks } = parseNote({ path: '', source })
+  const target = matchingBacklinkedHeading(source, headings, wikiLinks, [safeTitle, ...matchingTitles])
+  if (target === undefined || linkedHeadingTarget(source, target, wikiLinks) !== null) {
+    return source
+  }
+  return (
+    source.slice(0, target.from) +
+    `${'#'.repeat(target.level)} [[${safeTitle}]]` +
+    source.slice(target.to)
+  )
+}
+
+/**
+ * Append `block` under a section whose heading is itself a wiki link. New
+ * sections are emitted as `## [[Title]]`; an existing linked heading is reused,
+ * including an aliased display spelling. The old app-generated `## Title` form
+ * is upgraded in place so the next automatic append adds the missing backlink
+ * without splitting one category across duplicate sections.
+ */
+export function appendUnderBacklinkedHeading(
+  source: string,
+  title: string,
+  block: string,
+  matchingTitles: readonly string[] = [],
+): string {
+  const safeTitle = wikiLinkSafe(title)
+  if (safeTitle === '') {
+    throw new Error('a backlinked heading needs a title')
+  }
+  const linkedHeading = `[[${safeTitle}]]`
+  const upgraded = upgradeSectionHeadingBacklink(source, safeTitle, matchingTitles)
+  const { headings, wikiLinks } = parseNote({ path: '', source: upgraded })
+  const target = matchingBacklinkedHeading(
+    upgraded,
+    headings,
+    wikiLinks,
+    [safeTitle, ...matchingTitles],
+  )
+
+  if (target === undefined) {
+    return appendHeadingSection(upgraded, linkedHeading, block)
+  }
+  return appendAtHeading(upgraded, headings, target, block)
 }


### PR DESCRIPTION
## Problem

Audio memos and captured links currently collect under plain `## Audio memos` and `## Links` headings in daily notes. Those headings look like categories but create no graph backlink, and the corresponding category note is never resolved or created.

That leaves automatic capture outside the note graph's organizing model. It also means simply changing the emitted heading text would be unsafe: existing plain sections could be duplicated, same-day link dedup could miss older entries, and a renamed category note could split future captures into a second section.

## Before -> After

| Flow | Before | After |
| --- | --- | --- |
| Audio memo | `## Audio memos` with a transcript-note child link | `## [[Audio memos]]`, with the category note safely resolved or created |
| Link capture | `## Links` with a capture-note child link | `## [[Links]]`, with the category note safely resolved or created |
| Existing generated section | Remains a plain heading | Upgraded in place on the next relevant append or deduplicated recapture |
| Renamed category note | Could produce a second canonical section | Reuses the note's current link-safe title (or its canonical alias when needed) |

## Changes

1. **Resolve the backlink target before capture becomes terminal.**
   - `ensureBacklinkTarget` uses the existing race-safe `resolveOrCreateNoteWithTitle` path.
   - Ambiguous disk/index matches stop without creating another note.
   - The resolved note's current title keeps renamed categories together; unsafe wiki-link titles fall back to the canonical alias that just resolved.

2. **Add linked-section markdown editing.**
   - New sections are emitted as H2 wiki-link headings.
   - Existing app-generated plain H2 headings are upgraded without moving their contents.
   - Linked headings are matched from parsed wiki-link spans and raw source, so escaped literals and user-authored non-H2 headings are not rewritten.

3. **Keep both pipelines retry-safe.**
   - Audio memos resolve the category before reading or sending recording bytes, avoiding repeated provider billing when a local note prerequisite fails.
   - Link capture resolves the category before writing the raw capture, so a failed/ambiguous prerequisite leaves the spool untouched.
   - Same-day capture dedup scans all legacy and linked category sections, including renamed headings, and upgrades a legacy heading even on a deduplicated recapture.

4. **Update implementation docs** for the extension, link-capture plan, audio-memo port, and linked H2 styling examples.

## Tests

Coverage includes:

- fresh linked sections for both capture flows;
- legacy plain-heading upgrades without duplicate sections;
- linked, legacy, duplicated, aliased, renamed, escaped-literal, and non-H2 heading cases;
- same-day link dedup across every matching section;
- category resolution, creation, ambiguity, unsafe renamed titles, retry ordering, and graph-switch staleness;
- one category resolution per multi-memo reconcile pass.

## Verification

- `pnpm --filter @reflect/core test` — 93 files / 1,277 tests passed.
- `pnpm check` — repository typecheck and lint passed. The command reports only the two pre-existing max-lines warnings in `graph-provider.tsx` and `indexer.ts`.
- `git diff --check` — passed.

## Risk / Rollout

No bulk migration runs. Existing daily notes change only when a new memo/link is appended or a same-day capture is reconciled. All category-note work remains local and generation-pinned; privacy and outbound-AI gates are unchanged. A temporarily ambiguous or unreadable target remains retryable rather than minting a duplicate category note.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core daily-note write paths for link capture and audio memos, including dedup and legacy heading upgrades, but behavior stays generation-pinned and failures remain retryable without duplicate category notes.
> 
> **Overview**
> Automatic capture no longer uses plain `## Links` / `## Audio memos` headings. **Link capture** and **audio-memo reconciliation** now resolve or create the category note first, then append under **`## [[Links]]`** / **`## [[Audio memos]]`** so daily sections tie into the graph.
> 
> A shared **`ensureBacklinkTarget`** helper wraps `resolveOrCreateNoteWithTitle`, rejects ambiguous matches, and returns a link-safe title (including after renames). Markdown editing gains **`appendUnderBacklinkedHeading`**, heading matching/upgrades for legacy plain H2s, and dedup that scans every matching section—including renamed headings.
> 
> **Retry safety:** link drain leaves the spool intact if category resolution fails; audio reconcile resolves the category before reading audio or calling the transcription provider. Docs and editor styling comments are updated for the linked heading shape.
> 
> No bulk migration—existing dailies upgrade in place on the next append or same-day dedup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8563c8e39c0502844ff43b2a5eb591b1a1476ca5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

