### PR TITLE
fix: make sidebar toggling keyboard-first

### DIFF
--- a/apps/desktop/src/components/workspace-content.test.tsx
+++ b/apps/desktop/src/components/workspace-content.test.tsx
@@ -1,0 +1,86 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GraphInfo } from '@reflect/core'
+import type { ContextSidebarTarget } from '@/components/context-sidebar/sidebar-route'
+
+interface WorkspaceState {
+  collapsed: boolean
+  target: ContextSidebarTarget | null
+}
+
+const workspaceState = vi.hoisted<WorkspaceState>(() => ({
+  collapsed: false,
+  target: { kind: 'daily', date: '2026-07-11' },
+}))
+
+vi.mock('@/components/command-palette/command-palette', () => ({
+  CommandPalette: () => null,
+}))
+vi.mock('@/components/context-sidebar/daily-context-sidebar', () => ({
+  DailyContextSidebar: ({ date }: { date: string }) => (
+    <div data-testid="daily-context">{date}</div>
+  ),
+}))
+vi.mock('@/components/context-sidebar/note-context-sidebar', () => ({
+  NoteContextSidebar: ({ path }: { path: string }) => (
+    <div data-testid="note-context">{path}</div>
+  ),
+}))
+vi.mock('@/components/embeddings-sync', () => ({ EmbeddingsSync: () => null }))
+vi.mock('@/components/route-content', () => ({ RouteContent: () => <div>Route content</div> }))
+vi.mock('@/components/shortcuts-dialog', () => ({ ShortcutsDialog: () => null }))
+vi.mock('@/components/sidebar/sidebar', () => ({
+  Sidebar: () => <div data-testid="workspace-sidebar" />,
+}))
+vi.mock('@/components/templates/template-create-dialog', () => ({
+  TemplateCreateDialog: () => null,
+}))
+vi.mock('@/components/templates/template-picker', () => ({ TemplatePicker: () => null }))
+vi.mock('@/providers/focused-daily-provider', () => ({
+  useDailyContextTarget: () => workspaceState.target,
+}))
+vi.mock('@/providers/sidebar-provider', () => ({
+  useSidebar: () => ({ collapsed: workspaceState.collapsed, toggleSidebar: vi.fn() }),
+}))
+vi.mock('@/routing/app-shortcuts', () => ({ useAppShortcuts: () => ({}) }))
+
+const { WorkspaceContent } = await import('./workspace-content')
+
+const GRAPH: GraphInfo = { root: '/notes', name: 'Notes', generation: 1 }
+
+beforeEach(() => {
+  workspaceState.collapsed = false
+  workspaceState.target = { kind: 'daily', date: '2026-07-11' }
+})
+
+afterEach(cleanup)
+
+describe('WorkspaceContent', () => {
+  it('hides and restores the workspace and daily context sidebars together', () => {
+    const view = render(<WorkspaceContent graph={GRAPH} />)
+
+    expect(view.getByRole('complementary', { name: 'Workspace' })).toBeTruthy()
+    expect(view.getByRole('complementary', { name: 'Context' })).toBeTruthy()
+    expect(view.getByTestId('daily-context').textContent).toBe('2026-07-11')
+
+    workspaceState.collapsed = true
+    view.rerender(<WorkspaceContent graph={GRAPH} />)
+    expect(view.queryByRole('complementary', { name: 'Workspace' })).toBeNull()
+    expect(view.queryByRole('complementary', { name: 'Context' })).toBeNull()
+
+    workspaceState.collapsed = false
+    view.rerender(<WorkspaceContent graph={GRAPH} />)
+    expect(view.getByRole('complementary', { name: 'Workspace' })).toBeTruthy()
+    expect(view.getByRole('complementary', { name: 'Context' })).toBeTruthy()
+  })
+
+  it('applies the same collapsed state to ordinary note context', () => {
+    workspaceState.target = { kind: 'note', path: 'notes/project.md' }
+    const view = render(<WorkspaceContent graph={GRAPH} />)
+    expect(view.getByTestId('note-context').textContent).toBe('notes/project.md')
+
+    workspaceState.collapsed = true
+    view.rerender(<WorkspaceContent graph={GRAPH} />)
+    expect(view.queryByRole('complementary', { name: 'Context' })).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/workspace-content.tsx
+++ b/apps/desktop/src/components/workspace-content.tsx
@@ -33,9 +33,9 @@ function contextSidebarFor(target: ContextSidebarTarget | null): ReactElement | 
 
 /**
  * Everything inside the workspace's providers: the headerless shell — the
- * collapsible workspace sidebar beside the note pane, with the contextual
- * panel on the right for daily and note routes — plus the always-mounted
- * global surfaces (operations status, ⌘K palette, embeddings sync). Split
+ * collapsible workspace and contextual sidebars beside the note pane — plus
+ * the always-mounted global surfaces (operations status, ⌘K palette,
+ * embeddings sync). Split
  * from {@link GraphWorkspace} because these hooks need the providers it
  * mounts.
  */
@@ -51,7 +51,7 @@ export function WorkspaceContent({ graph }: WorkspaceContentProps): ReactElement
   return (
     <AppShell
       sidebar={collapsed ? undefined : <Sidebar graph={graph} context={commandContext} />}
-      context={contextSidebarFor(contextTarget)}
+      context={collapsed ? undefined : contextSidebarFor(contextTarget)}
     >
       <div className="relative flex h-full flex-col">
         <div className="min-h-0 flex-1">

--- a/apps/desktop/src/components/workspace-content.tsx
+++ b/apps/desktop/src/components/workspace-content.tsx
@@ -1,27 +1,19 @@
 import type { ReactElement } from 'react'
 import type { GraphInfo } from '@reflect/core'
-import { PanelLeft } from 'lucide-react'
 import { AppShell } from '@/components/app-shell'
 import { CommandPalette } from '@/components/command-palette/command-palette'
 import { DailyContextSidebar } from '@/components/context-sidebar/daily-context-sidebar'
 import { NoteContextSidebar } from '@/components/context-sidebar/note-context-sidebar'
 import { type ContextSidebarTarget } from '@/components/context-sidebar/sidebar-route'
 import { EmbeddingsSync } from '@/components/embeddings-sync'
-import { ShortcutKeys } from '@/components/shortcut-keys'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { RouteContent } from '@/components/route-content'
 import { ShortcutsDialog } from '@/components/shortcuts-dialog'
 import { Sidebar } from '@/components/sidebar/sidebar'
 import { TemplateCreateDialog } from '@/components/templates/template-create-dialog'
 import { TemplatePicker } from '@/components/templates/template-picker'
-import { keybindingFor } from '@/lib/commands/app-commands'
-import { cn } from '@/lib/utils'
-import { hasMacosTitleBarOverlay } from '@/lib/window-chrome'
 import { useDailyContextTarget } from '@/providers/focused-daily-provider'
 import { useSidebar } from '@/providers/sidebar-provider'
 import { useAppShortcuts } from '@/routing/app-shortcuts'
-
-const TOGGLE_SIDEBAR_BINDING = keybindingFor('sidebar.toggle')
 
 interface WorkspaceContentProps {
   graph: GraphInfo
@@ -62,30 +54,6 @@ export function WorkspaceContent({ graph }: WorkspaceContentProps): ReactElement
       context={contextSidebarFor(contextTarget)}
     >
       <div className="relative flex h-full flex-col">
-        {collapsed ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                aria-label="Show sidebar"
-                onClick={() => commandContext.toggleSidebar()}
-                className={cn(
-                  'absolute left-3 z-10 rounded-md p-1 text-text-muted transition-colors duration-100 hover:bg-surface-hover hover:text-text-secondary',
-                  // Clear the overlaid macOS title bar: the traffic lights float
-                  // exactly where this button otherwise sits.
-                  hasMacosTitleBarOverlay ? 'top-9' : 'top-2.5',
-                )}
-              >
-                <PanelLeft aria-hidden strokeWidth={1.75} className="size-4" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>
-              Show sidebar{' '}
-              {TOGGLE_SIDEBAR_BINDING && <ShortcutKeys binding={TOGGLE_SIDEBAR_BINDING} />}
-            </TooltipContent>
-          </Tooltip>
-        ) : null}
-
         <div className="min-h-0 flex-1">
           <RouteContent />
         </div>

--- a/apps/desktop/src/lib/commands/types.ts
+++ b/apps/desktop/src/lib/commands/types.ts
@@ -24,7 +24,7 @@ export interface CommandContext {
   /** Discard the current view's saved scroll offsets so it re-anchors when revisited. */
   clearScrollState: () => void
   toggleTheme: () => void
-  /** Collapse/expand the workspace sidebar. */
+  /** Collapse/expand the workspace and contextual sidebars. */
   toggleSidebar: () => void
   /** Start a fresh chat conversation. */
   newChat: () => void

--- a/apps/desktop/src/lib/native-menu/menu.test.ts
+++ b/apps/desktop/src/lib/native-menu/menu.test.ts
@@ -4,7 +4,7 @@ interface MenuItemOptionsForTest {
   readonly id?: string
   readonly text?: string
   readonly accelerator?: string
-  readonly action?: (id: string) => void
+  readonly action?: (commandId: string) => void
 }
 
 interface SubmenuOptionsForTest {

--- a/apps/desktop/src/lib/native-menu/menu.test.ts
+++ b/apps/desktop/src/lib/native-menu/menu.test.ts
@@ -1,12 +1,27 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+interface MenuItemOptionsForTest {
+  readonly id?: string
+  readonly text?: string
+  readonly accelerator?: string
+  readonly action?: (id: string) => void
+}
+
+interface SubmenuOptionsForTest {
+  readonly text: string
+  readonly items: readonly MenuItemOptionsForTest[]
+}
+
 const isTauri = vi.hoisted(() => vi.fn(() => true))
 const isMainWindow = vi.hoisted(() => vi.fn(() => true))
 const setAsAppMenu = vi.hoisted(() => vi.fn(async () => null))
 const setAsWindowsMenuForNSApp = vi.hoisted(() => vi.fn(async () => {}))
 const setAsHelpMenuForNSApp = vi.hoisted(() => vi.fn(async () => {}))
 const submenuNew = vi.hoisted(() =>
-  vi.fn(async () => ({ setAsWindowsMenuForNSApp, setAsHelpMenuForNSApp })),
+  vi.fn(async (_options: SubmenuOptionsForTest) => ({
+    setAsWindowsMenuForNSApp,
+    setAsHelpMenuForNSApp,
+  })),
 )
 const menuNew = vi.hoisted(() => vi.fn(async () => ({ setAsAppMenu })))
 
@@ -18,7 +33,8 @@ vi.mock('@tauri-apps/api/menu', () => ({
 vi.mock('@/lib/windows/window-role', () => ({ isMainWindow }))
 
 const { APP_COMMANDS, keybindingFor } = await import('@/lib/commands/app-commands')
-const { appMenuLayout, installNativeMenu } = await import('./menu')
+const { setMenuCommandDispatch } = await import('./dispatch')
+const { appMenuLayout, installNativeMenu, isNativeMenuInstalled } = await import('./menu')
 
 beforeEach(() => {
   vi.stubGlobal('navigator', { userAgent: 'Macintosh', maxTouchPoints: 0 })
@@ -32,6 +48,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  setMenuCommandDispatch(null)
   vi.unstubAllGlobals()
 })
 
@@ -88,6 +105,30 @@ describe('appMenuLayout', () => {
 })
 
 describe('installNativeMenu', () => {
+  it('installs sidebar.toggle as a native Command+\\ menu accelerator', async () => {
+    const dispatch = vi.fn()
+    setMenuCommandDispatch(dispatch)
+
+    await installNativeMenu()
+
+    const viewMenu = submenuNew.mock.calls
+      .map(([options]) => options)
+      .find((options) => options.text === 'View')
+    const sidebarToggle = viewMenu?.items.find((item) => item.id === 'sidebar.toggle')
+
+    expect(sidebarToggle).toMatchObject({
+      id: 'sidebar.toggle',
+      text: 'Toggle sidebar',
+      accelerator: 'CmdOrCtrl+\\',
+    })
+    expect(sidebarToggle?.action).toBeTypeOf('function')
+    sidebarToggle?.action?.('sidebar.toggle')
+    expect(dispatch).toHaveBeenCalledWith('sidebar.toggle')
+    expect(menuNew).toHaveBeenCalledTimes(1)
+    expect(setAsAppMenu).toHaveBeenCalledTimes(1)
+    expect(isNativeMenuInstalled()).toBe(true)
+  })
+
   it('leaves the main window’s app-wide menu intact when a note window boots', async () => {
     isMainWindow.mockReturnValue(false)
 

--- a/apps/desktop/src/lib/native-menu/menu.ts
+++ b/apps/desktop/src/lib/native-menu/menu.ts
@@ -38,6 +38,13 @@ export interface AppSubmenuLayout {
   entries: AppMenuEntry[]
 }
 
+let nativeMenuInstalled = false
+
+/** Whether this webview has successfully installed the native app menu. */
+export function isNativeMenuInstalled(): boolean {
+  return nativeMenuInstalled
+}
+
 function command(commandId: string, text?: string): AppMenuEntry {
   return { kind: 'command', commandId, text }
 }
@@ -170,9 +177,11 @@ function isMacosDesktop(): boolean {
  *
  * macOS-only for now: other desktop platforms would render an in-window
  * menubar we haven't designed for, and every shortcut already works there
- * through the keydown path. Keyboard equivalents the webview handles are
+ * through the keydown path. Most keyboard equivalents the webview handles are
  * consumed before the menu sees them (`useAppShortcuts` prevents the default),
- * so a focused webview never double-fires a command.
+ * so a focused webview never double-fires a command. The sidebar toggle is
+ * deliberately exempted there so its key equivalent belongs to this native
+ * macOS application menu.
  */
 export async function installNativeMenu(): Promise<void> {
   // Menu actions use channels owned by the webview that created them. A note
@@ -192,6 +201,7 @@ export async function installNativeMenu(): Promise<void> {
   )
   const menu = await Menu.new({ items: submenus })
   await menu.setAsAppMenu()
+  nativeMenuInstalled = true
   // NSApp roles must be assigned after setAsAppMenu: attaching the menu
   // clones each submenu's NSMenu, and muda resolves the role against the
   // instance inside the installed main menu — assigned earlier, the role

--- a/apps/desktop/src/providers/sidebar-provider.tsx
+++ b/apps/desktop/src/providers/sidebar-provider.tsx
@@ -9,10 +9,10 @@ import {
 } from 'react'
 
 /**
- * Sidebar visibility state, provided once per workspace so both the shell
- * (which renders or hides the sidebar) and the command registry (`⌘\` /
- * "Toggle sidebar") share one source of truth. Session-only by design —
- * a relaunch starts expanded.
+ * Side-panel visibility state, provided once per workspace so the shell
+ * (which renders or hides both sidebar regions) and the command registry
+ * (`⌘\` / "Toggle sidebar") share one source of truth. Session-only by
+ * design — a relaunch starts expanded.
  */
 
 interface SidebarContextValue {
@@ -35,7 +35,7 @@ export function SidebarProvider({ children }: { children: ReactNode }): ReactEle
   return <SidebarContext.Provider value={value}>{children}</SidebarContext.Provider>
 }
 
-/** Access sidebar visibility + the toggle. Use within a SidebarProvider. */
+/** Access side-panel visibility + the toggle. Use within a SidebarProvider. */
 export function useSidebar(): SidebarContextValue {
   const context = useContext(SidebarContext)
   if (!context) {

--- a/apps/desktop/src/routing/app-shortcuts.test.tsx
+++ b/apps/desktop/src/routing/app-shortcuts.test.tsx
@@ -1,20 +1,31 @@
 import { act, cleanup, renderHook } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
 import { PaletteProvider, usePalette } from '@/components/command-palette/palette-provider'
 import { listRegisteredBindings } from '@/editor/keymap'
 import { registerAppCommands } from '@/lib/commands/app-commands'
+import { dispatchMenuCommand } from '@/lib/native-menu/dispatch'
 import { NoteTemplatesProvider } from '@/providers/note-templates-provider'
 import { ShortcutsProvider, useShortcuts } from '@/providers/shortcuts-provider'
-import { SidebarProvider } from '@/providers/sidebar-provider'
+import { SidebarProvider, useSidebar } from '@/providers/sidebar-provider'
 import { useAppShortcuts } from './app-shortcuts'
 import { RouterProvider, useRouter } from './router'
 
 const newChat = vi.hoisted(() => vi.fn())
 const openRecent = vi.hoisted(() => vi.fn())
 const openRouteInNewWindow = vi.hoisted(() => vi.fn(async () => true))
+const platform = vi.hoisted(() => ({ isMacosDesktop: false }))
+const nativeMenu = vi.hoisted(() => ({ installed: false }))
 
 vi.mock('@/lib/windows/open-in-new-window', () => ({ openRouteInNewWindow }))
+vi.mock('@/lib/native-menu/menu', () => ({
+  isNativeMenuInstalled: () => nativeMenu.installed,
+}))
+vi.mock('@/lib/platform', () => ({
+  get isMacosDesktop() {
+    return platform.isMacosDesktop
+  },
+}))
 
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({
@@ -45,6 +56,11 @@ vi.mock('@/providers/chat-provider', () => ({
 
 registerAppCommands() // production does this in main.tsx
 
+beforeEach(() => {
+  platform.isMacosDesktop = false
+  nativeMenu.installed = false
+})
+
 afterEach(() => {
   cleanup()
   openRecent.mockClear()
@@ -55,7 +71,12 @@ function shortcutsHook() {
   return renderHook(
     () => {
       useAppShortcuts()
-      return { router: useRouter(), palette: usePalette(), shortcuts: useShortcuts() }
+      return {
+        router: useRouter(),
+        palette: usePalette(),
+        shortcuts: useShortcuts(),
+        sidebar: useSidebar(),
+      }
     },
     {
       wrapper: ({ children }: { children: ReactNode }) => (
@@ -103,6 +124,7 @@ describe('app shortcuts', () => {
       'Mod-[',
       'Mod-]',
       'Mod-k',
+      'Mod-\\',
       'Alt-Mod-l',
       'Meta-1',
       'Meta-9',
@@ -196,6 +218,53 @@ describe('app shortcuts', () => {
     expect(result.current.palette.open).toBe(false)
     act(() => press('k'))
     expect(result.current.palette.open).toBe(true)
+  })
+
+  it('⌘\\ toggles the sidebar in both directions', () => {
+    const { result } = shortcutsHook()
+    expect(result.current.sidebar.collapsed).toBe(false)
+
+    act(() => press('\\'))
+    expect(result.current.sidebar.collapsed).toBe(true)
+
+    act(() => press('\\'))
+    expect(result.current.sidebar.collapsed).toBe(false)
+  })
+
+  it('keeps the macOS webview fallback until the native menu is installed', () => {
+    platform.isMacosDesktop = true
+    const { result } = shortcutsHook()
+    const event = new KeyboardEvent('keydown', {
+      key: '\\',
+      metaKey: true,
+      cancelable: true,
+    })
+
+    act(() => {
+      window.dispatchEvent(event)
+    })
+    expect(event.defaultPrevented).toBe(true)
+    expect(result.current.sidebar.collapsed).toBe(true)
+  })
+
+  it('leaves ⌘\\ to the native macOS menu accelerator', () => {
+    platform.isMacosDesktop = true
+    nativeMenu.installed = true
+    const { result } = shortcutsHook()
+    const event = new KeyboardEvent('keydown', {
+      key: '\\',
+      metaKey: true,
+      cancelable: true,
+    })
+
+    act(() => {
+      window.dispatchEvent(event)
+    })
+    expect(event.defaultPrevented).toBe(false)
+    expect(result.current.sidebar.collapsed).toBe(false)
+
+    act(() => dispatchMenuCommand('sidebar.toggle'))
+    expect(result.current.sidebar.collapsed).toBe(true)
   })
 
   it('defers ⌘K to a focused editor that already handled it', () => {

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -141,8 +141,12 @@ function idForKeyDown(event: KeyboardEvent): string | null {
   return null
 }
 
-function isNativeMacosMenuCommand(id: string): boolean {
-  return isMacosDesktop && isNativeMenuInstalled() && NATIVE_MACOS_MENU_COMMAND_IDS.has(id)
+function isNativeMacosMenuCommand(commandId: string): boolean {
+  return (
+    isMacosDesktop &&
+    isNativeMenuInstalled() &&
+    NATIVE_MACOS_MENU_COMMAND_IDS.has(commandId)
+  )
 }
 
 /**

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -6,6 +6,8 @@ import { APP_COMMANDS } from '@/lib/commands/app-commands'
 import { runCommand } from '@/lib/commands/registry'
 import { todayIso } from '@/lib/dates'
 import { setMenuCommandDispatch } from '@/lib/native-menu/dispatch'
+import { isNativeMenuInstalled } from '@/lib/native-menu/menu'
+import { isMacosDesktop } from '@/lib/platform'
 import { retryFailedEmbeddings } from '@/lib/semantic'
 import type { CommandContext } from '@/lib/commands/types'
 import { useAudioMemo } from '@/providers/audio-memo-provider'
@@ -39,6 +41,11 @@ export const APP_BINDINGS = registerKeymap(
 
 const BINDING_TO_ID = new Map(BOUND_COMMANDS.map(({ binding, command }) => [binding, command.id]))
 const HISTORY_COMMAND_IDS = new Set(['history.back', 'history.forward'])
+
+// AppKit owns this key equivalent on macOS. Keep it in the registry for
+// display, collision detection, and the plain-browser/non-macOS fallback, but
+// do not consume its keydown in the webview before the native menu sees it.
+const NATIVE_MACOS_MENU_COMMAND_IDS = new Set(['sidebar.toggle'])
 
 const CODE_TO_BINDING_KEY: Record<string, string> = {
   BracketLeft: '[',
@@ -132,6 +139,10 @@ function idForKeyDown(event: KeyboardEvent): string | null {
     }
   }
   return null
+}
+
+function isNativeMacosMenuCommand(id: string): boolean {
+  return isMacosDesktop && isNativeMenuInstalled() && NATIVE_MACOS_MENU_COMMAND_IDS.has(id)
 }
 
 /**
@@ -272,7 +283,7 @@ export function useAppShortcuts(): CommandContext {
 
     function onHistoryKeyDownCapture(event: KeyboardEvent) {
       const id = idForKeyDown(event)
-      if (id === null || !HISTORY_COMMAND_IDS.has(id)) {
+      if (id === null || isNativeMacosMenuCommand(id) || !HISTORY_COMMAND_IDS.has(id)) {
         return
       }
       if (triggerCommand(id)) {
@@ -291,7 +302,7 @@ export function useAppShortcuts(): CommandContext {
         return
       }
       const id = idForKeyDown(event)
-      if (id === null) {
+      if (id === null || isNativeMacosMenuCommand(id)) {
         return
       }
       if (triggerCommand(id)) {


### PR DESCRIPTION
## Problem

After collapsing the workspace sidebar, Reflect displayed a floating `Show sidebar` control over the note pane. Sidebar chrome should stay out of the editor and be restored through Command+\ instead.

The shortcut also had two gaps: on daily and note routes it controlled only the left workspace sidebar, leaving the right contextual sidebar open; and on macOS the focused webview consumed the key equivalent before the native View menu could own it.

## Before -> After

| Surface | Before | After |
| --- | --- | --- |
| Collapsed chrome | Floating restore button over the note pane | No in-window restore control |
| Command+\ on daily/note routes | Toggles only the left workspace sidebar | Toggles both workspace and contextual sidebars |
| macOS shortcut routing | Webview handles the keydown first | Installed native application menu owns the accelerator |

## Changes

- Remove the collapsed-sidebar restore button and tooltip.
- Apply the shared sidebar visibility state to both AppShell side regions, including daily and ordinary-note context.
- Let the installed native macOS application menu own Command+\ without webview interception.
- Keep the webview handler as a browser/non-macOS fallback and while native menu installation is incomplete or failed.
- Add coverage for shell hide/restore behavior, native menu construction and dispatch, macOS ownership, installation fallback, and two-way toggling.

## Verification

- `pnpm check`
- `pnpm build`
- `pnpm --filter @reflect/desktop test --run src/components/workspace-content.test.tsx src/routing/app-shortcuts.test.tsx src/lib/native-menu/menu.test.ts src/lib/native-menu/accelerator.test.ts src/lib/commands/app-commands.test.ts src/lib/keybindings.test.ts` — 6 files, 75 tests passed

## Risk / Rollout

Low. There are no data or migration changes. Collapsing now unmounts both side regions, and restoring recreates the correct contextual panel from the still-active route/focused day. Non-macOS and plain-browser shortcuts retain the existing webview fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sidebar chrome and shortcut routing; no data, auth, or persistence changes. Non-macOS behavior unchanged aside from hiding the context panel when collapsed.
> 
> **Overview**
> Removes the floating **Show sidebar** control when panels are collapsed so toggling stays keyboard-first via **⌘\\**.
> 
> **Collapse** now hides both the workspace sidebar and the contextual (daily/note) panel together, driven by the same `collapsed` state.
> 
> On **macOS**, once the native app menu is installed, the webview no longer intercepts **⌘\\** for `sidebar.toggle`—AppKit’s View menu accelerator owns the key. The existing webview handler remains as a fallback before install completes, on non-macOS, and in the browser. `isNativeMenuInstalled()` tracks successful menu setup.
> 
> Adds tests for workspace shell visibility, native menu accelerator/dispatch, and macOS vs fallback shortcut behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 714865f5a4e32a56eb6b62882bcf67add03a3484. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native menu tracking for macOS desktop installations.
  * Added the `⌘\` sidebar shortcut to the central shortcut registry.

* **Bug Fixes**
  * Improved macOS shortcut handling to prevent duplicate actions between native menus and the app.
  * Removed the collapsed-sidebar “Show sidebar” button from the workspace view.

* **Tests**
  * Added coverage for native menu installation, sidebar shortcut behavior, and command dispatching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->