### PR TITLE
refactor: land the orphaned PR #696 review follow-ups (shared claim loop, NOTES_DIR, test gaps)

### DIFF
--- a/apps/desktop/src/editor/use-editor-autocomplete.test.tsx
+++ b/apps/desktop/src/editor/use-editor-autocomplete.test.tsx
@@ -72,4 +72,23 @@ describe('useEditorAutocomplete', () => {
     expect(startOperation).toHaveBeenCalledWith('Creating note')
     consoleError.mockRestore()
   })
+
+  it('creates in the background without user-facing feedback on the happy path', async () => {
+    resolveOrCreateNoteWithTitle.mockResolvedValue({
+      kind: 'created',
+      path: 'notes/business-ideas.md',
+    })
+    const { result } = renderHook(() => useEditorAutocomplete())
+    const items = await result.current.onWikilinkSearch('Business ideas')
+
+    act(() => {
+      items[0]!.onSelect?.()
+    })
+
+    await waitFor(() =>
+      expect(resolveOrCreateNoteWithTitle).toHaveBeenCalledWith('Business ideas', 7),
+    )
+    expect(startOperation).not.toHaveBeenCalled()
+    expect(operationFail).not.toHaveBeenCalled()
+  })
 })

--- a/packages/core/src/graph/commands.test.ts
+++ b/packages/core/src/graph/commands.test.ts
@@ -37,6 +37,26 @@ describe('graph commands', () => {
     }
   })
 
+  it('propagates a note-create rejection without echoing a local write', async () => {
+    // The failure side of the generation pin: a stale-generation bridge
+    // rejection reaches the caller, and nothing pretends a file was written.
+    const invoke = vi.fn(async () => {
+      throw { kind: 'io', message: 'the graph changed since this command was issued; dropping it' }
+    })
+    setBridge({ invoke, listen: async () => () => {} })
+    const ownWrites: string[] = []
+    const unlisten = subscribeOwnWrites((path) => ownWrites.push(path))
+
+    try {
+      await expect(
+        createNoteIfAbsent('notes/business-ideas.md', '# Business ideas\n', 6),
+      ).rejects.toMatchObject({ kind: 'io' })
+      expect(ownWrites).toEqual([])
+    } finally {
+      unlisten()
+    }
+  })
+
   it('returns a note-create collision without echoing a local write', async () => {
     const invoke = vi.fn(async () => ({ kind: 'collision' }))
     setBridge({ invoke, listen: async () => () => {} })

--- a/packages/core/src/graph/create-note.ts
+++ b/packages/core/src/graph/create-note.ts
@@ -6,7 +6,7 @@ import { upsertFrontmatter } from '../markdown/frontmatter'
 import { slugForTitle } from '../markdown/slug'
 import { subjectAliases } from '../markdown/subject-aliases'
 import { createNoteIfAbsent, listFiles, readNote } from './commands'
-import { notePath } from './paths'
+import { notePath, NOTES_DIR } from './paths'
 
 /**
  * Note identity at creation (`docs/readable-filenames.md`): regular notes get
@@ -77,16 +77,8 @@ export async function createNoteWithTitle(
   generation: number,
   body?: string,
 ): Promise<string> {
-  const slug = slugForTitle(title)
-  const source = newNoteSource(title, body)
-  for (let ordinal = 1; ordinal <= MAX_CREATE_ATTEMPTS; ordinal += 1) {
-    const path = notePath(ordinal === 1 ? slug : `${slug}-${ordinal}`)
-    const outcome = await createNoteIfAbsent(path, source, generation)
-    if (outcome.kind === 'created') {
-      return path
-    }
-  }
-  throw new Error(`no available note path for slug "${slug}" after ${MAX_CREATE_ATTEMPTS} attempts`)
+  const claimed = await claimNotePathForSlug(slugForTitle(title), newNoteSource(title, body), generation)
+  return claimed.path
 }
 
 /** Far beyond any real graph's same-slug population; fail loud instead of spinning. */
@@ -99,6 +91,44 @@ export type ResolveOrCreateNoteResult =
   | { readonly kind: 'ambiguous'; readonly paths: readonly string[] }
 
 type ExistingTitleResolution = Exclude<ResolveOrCreateNoteResult, { kind: 'created' }>
+
+/**
+ * Claim the first free path in `slug`'s collision family (`slug.md`, then
+ * `slug-2.md`, …) through the atomic no-clobber create — the one ordinal
+ * convention both create entry points share. `onCollision` runs after each
+ * lost claim; a non-null result short-circuits instead of trying the next
+ * suffix (`resolveOrCreateNoteWithTitle` re-resolves the winner there).
+ */
+async function claimNotePathForSlug(
+  slug: string,
+  source: string,
+  generation: number,
+): Promise<{ kind: 'created'; path: string }>
+async function claimNotePathForSlug(
+  slug: string,
+  source: string,
+  generation: number,
+  onCollision: () => Promise<ExistingTitleResolution | null>,
+): Promise<ResolveOrCreateNoteResult>
+async function claimNotePathForSlug(
+  slug: string,
+  source: string,
+  generation: number,
+  onCollision?: () => Promise<ExistingTitleResolution | null>,
+): Promise<ResolveOrCreateNoteResult> {
+  for (let ordinal = 1; ordinal <= MAX_CREATE_ATTEMPTS; ordinal += 1) {
+    const path = notePath(ordinal === 1 ? slug : `${slug}-${ordinal}`)
+    const outcome = await createNoteIfAbsent(path, source, generation)
+    if (outcome.kind === 'created') {
+      return { kind: 'created', path }
+    }
+    const resolution = (await onCollision?.()) ?? null
+    if (resolution !== null) {
+      return resolution
+    }
+  }
+  throw new Error(`no available note path for slug "${slug}" after ${MAX_CREATE_ATTEMPTS} attempts`)
+}
 
 interface DiskTitleMatch {
   exactTitlePaths: string[]
@@ -115,7 +145,9 @@ interface DiskTitleMatch {
  * graph-wide title search.
  */
 function isSlugFamilyPath(path: string, slug: string): boolean {
-  const prefix = 'notes/'
+  // Derived from the same contract `notePath` builds with, so a directory
+  // rename can't silently turn the disk guard into an always-empty scan.
+  const prefix = `${NOTES_DIR}/`
   const suffix = '.md'
   if (!path.startsWith(prefix) || !path.endsWith(suffix)) {
     return false
@@ -277,25 +309,13 @@ export async function resolveOrCreateNoteWithTitle(
     return reResolved
   }
 
-  const slug = slugForTitle(title)
-  const source = newNoteSource(title)
-  for (let ordinal = 1; ordinal <= MAX_CREATE_ATTEMPTS; ordinal += 1) {
-    const path = notePath(ordinal === 1 ? slug : `${slug}-${ordinal}`)
-    const outcome = await createNoteIfAbsent(path, source, generation)
-    if (outcome.kind === 'created') {
-      return { kind: 'created', path }
-    }
-
-    // The claim lost after our checks. Re-resolve both projections before
-    // considering a suffix: the winner may be the note this link meant.
+  // On a lost claim, re-resolve both projections before considering a
+  // suffix: the winner may be the note this link meant.
+  return claimNotePathForSlug(slugForTitle(title), newNoteSource(title), generation, async () => {
     const collisionIndex = await indexedTargetResolution(title)
     if (collisionIndex !== null) {
       return collisionIndex
     }
-    const collisionDisk = diskTitleResolution(await matchTitleOnDisk(title, generation))
-    if (collisionDisk !== null) {
-      return collisionDisk
-    }
-  }
-  throw new Error(`no available note path for slug "${slug}" after ${MAX_CREATE_ATTEMPTS} attempts`)
+    return diskTitleResolution(await matchTitleOnDisk(title, generation))
+  })
 }


### PR DESCRIPTION
## Problem

Commit `f317c434` ("Address review nitpicks: shared claim loop, NOTES_DIR, test gaps") was pushed to `codex/fix-cross-device-wikilink-duplicates` two minutes **after** PR #696 merged, so it never landed on `next` — even though a comment on #696 says all four CodeRabbit nitpicks were addressed in it. Verified none of it arrived via later PRs (`claimNotePathForSlug` has no hits on `next`, and neither test exists).

## Changes

This cherry-picks `f317c434` onto `next`, adapted to the hardening from #744:

- **Shared claim loop:** extract `claimNotePathForSlug` so both create entry points (`createNoteWithTitle`, `resolveOrCreateNoteWithTitle`) share one ordinal convention (`slug.md`, `slug-2.md`, …). The resolve path keeps its collision re-resolution via an `onCollision` hook rather than a lossy identical-loop merge.
- **`NOTES_DIR` over a literal:** `isSlugFamilyPath` derives its prefix from `NOTES_DIR`, so a directory rename can't silently turn the disk guard into an always-empty scan.
- **Test gaps:** cover the stale-generation rejection path for `createNoteIfAbsent` (rejection propagates, no own-write echo) and the autocomplete happy path (background create produces no user-facing feedback).

### Conflict resolution vs. #744

- The `onCollision` hook now calls #744's `indexedTargetResolution` (which already returns a resolution object) instead of the pre-#744 `indexedPathForTitle` + manual wrapping.
- The happy-path autocomplete test is appended after #744's failure-surface test, which had changed the surrounding context.

No behavior change intended; the refactor preserves the exact claim/re-resolve sequence #744 shipped.

## Testing

- `pnpm check` (typecheck + lint) passes.
- `packages/core` graph suite: 52 tests pass, including the new stale-generation rejection test.
- `apps/desktop` `use-editor-autocomplete.test.tsx`: 3 tests pass, including the new happy-path test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor intended to preserve existing claim/re-resolve behavior; changes are localized to note creation and test coverage.
> 
> **Overview**
> Cherry-picks follow-up work that never landed on `next`: **deduplicates** the slug ordinal claim loop (`slug.md`, `slug-2.md`, …) into **`claimNotePathForSlug`**, used by both **`createNoteWithTitle`** and **`resolveOrCreateNoteWithTitle`**. The resolve path keeps its post-collision re-resolution via an optional **`onCollision`** hook instead of duplicating the loop.
> 
> **`isSlugFamilyPath`** now builds its path prefix from **`NOTES_DIR`** instead of a hardcoded `notes/`, so a notes-directory rename does not break the disk fallback scan.
> 
> Adds tests: **`createNoteIfAbsent`** stale-generation rejection propagates with **no** own-write echo, and editor autocomplete **happy-path** create runs in the background without **`startOperation`** / failure UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7732339f696c096ea670b63f0cf47a16646aa112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->