### PR TITLE
fix: create backlinks from formatted selections

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,10 @@ settings:
   dedupePeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@meowdown/core': https://pkg.pr.new/prosekit/meowdown/@meowdown/core@e04a672
+  '@meowdown/react': https://pkg.pr.new/prosekit/meowdown/@meowdown/react@e04a672
+
 importers:
 
   .:
@@ -34,11 +38,11 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.7)
       '@meowdown/core':
-        specifier: ^0.44.1
-        version: 0.44.1(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.10)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.0)
+        specifier: https://pkg.pr.new/prosekit/meowdown/@meowdown/core@e04a672
+        version: https://pkg.pr.new/prosekit/meowdown/@meowdown/core@e04a672(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.10)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.0)
       '@meowdown/react':
-        specifier: ^0.44.1
-        version: 0.44.1(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.10)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.0)(react-dom@19.2.7)(react@19.2.7)
+        specifier: https://pkg.pr.new/prosekit/meowdown/@meowdown/react@e04a672
+        version: https://pkg.pr.new/prosekit/meowdown/@meowdown/react@e04a672(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.10)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.0)(react-dom@19.2.7)(react@19.2.7)
       '@reflect/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -1055,11 +1059,13 @@ packages:
   '@marijn/find-cluster-break@1.0.3':
     resolution: {integrity: sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==}
 
-  '@meowdown/core@0.44.1':
-    resolution: {integrity: sha512-78kFwyhYRpDLdpk/Asd28+gcp3yVm5sJNH211hR4a2fD9GffPjs0wT4oKbDezoXxwbwDRf9ZNC/flAHumY8jHQ==}
+  '@meowdown/core@https://pkg.pr.new/prosekit/meowdown/@meowdown/core@e04a672':
+    resolution: {integrity: sha512-3jR00sfnZzSWDjdUaIHE1WhjRvA6syVXlA7ZhqW/R5Ov6ruYDGmySKE3UJmZqKyv9DbVF5SDkwVmPsqd/0zV/g==, tarball: https://pkg.pr.new/prosekit/meowdown/@meowdown/core@e04a672}
+    version: 0.44.1
 
-  '@meowdown/react@0.44.1':
-    resolution: {integrity: sha512-8wC+8PAsaK1t5hP9bkHoci+xXF61MvprAG0ZoHKxRtwu/PWzEobmT+Z9mml7m780ok7zTy9We3hFeF7dyjUywg==}
+  '@meowdown/react@https://pkg.pr.new/prosekit/meowdown/@meowdown/react@e04a672':
+    resolution: {integrity: sha512-oFU3y3w8Cx7qyX4LqeTRfWZ8jaJoJ2PKpyRdOoyY/BDBUa7DI4Lei+eAoRIrWLXhgojNk5JqQKaL0Tdmgn3kHQ==, tarball: https://pkg.pr.new/prosekit/meowdown/@meowdown/react@e04a672}
+    version: 0.44.1
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
@@ -7173,7 +7179,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.3': {}
 
-  '@meowdown/core@0.44.1(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.10)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.0)':
+  '@meowdown/core@https://pkg.pr.new/prosekit/meowdown/@meowdown/core@e04a672(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.10)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.0)':
     dependencies:
       '@codemirror/language': 6.12.4
       '@codemirror/language-data': 6.5.2
@@ -7211,10 +7217,10 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@meowdown/react@0.44.1(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.10)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.0)(react-dom@19.2.7)(react@19.2.7)':
+  '@meowdown/react@https://pkg.pr.new/prosekit/meowdown/@meowdown/react@e04a672(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.10)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.0)(react-dom@19.2.7)(react@19.2.7)':
     dependencies:
       '@base-ui/react': 1.6.0(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7)(react@19.2.7)
-      '@meowdown/core': 0.44.1(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.10)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.0)
+      '@meowdown/core': https://pkg.pr.new/prosekit/meowdown/@meowdown/core@e04a672(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.10)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.0)
       '@ocavue/utils': 1.7.0
       '@prosekit/core': 0.13.0-beta.5(prosemirror-model@1.25.10)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosekit/pm': 0.1.19-beta.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,9 @@ minimumReleaseAgeExclude:
   - prosemirror-flat-list
   - prosemirror-view
 
-# overrides:
-#   '@meowdown/core': https://pkg.pr.new/prosekit/meowdown/@meowdown/core@623bc43
-#   '@meowdown/react': https://pkg.pr.new/prosekit/meowdown/@meowdown/react@623bc43
-# blockExoticSubdeps: false
+# Temporary snapshot of prosekit/meowdown#287; replace it with the released
+# package version after the upstream fix ships.
+overrides:
+  '@meowdown/core': https://pkg.pr.new/prosekit/meowdown/@meowdown/core@e04a672
+  '@meowdown/react': https://pkg.pr.new/prosekit/meowdown/@meowdown/react@e04a672
+blockExoticSubdeps: false


### PR DESCRIPTION
## Problem

Turning a formatted selection into a backlink used the selection's hidden Markdown delimiters as part of the note query. Selecting bold `Klara and the Sun`, for example, searched for `**Klara and the Sun**`; the existing note no longer matched, and the menu offered to create a duplicate with the formatting characters in its title.

The defect lives in Meowdown's selection-to-wikilink command. It is fixed and fully green upstream in [prosekit/meowdown#287](https://github.com/prosekit/meowdown/pull/287).

## Before -> After

| Action | Before | After |
| --- | --- | --- |
| Create a backlink from bold `Klara and the Sun` | Search/create `**Klara and the Sun**` | Resolve `Klara and the Sun` |
| Choose the existing note | Formatting markers leak into the query | Insert `[[Klara and the Sun]]` |

## Changes

1. Pin both `@meowdown/core` and `@meowdown/react` to the immutable `e04a672` snapshot produced by the upstream PR.
2. Regenerate the pnpm lockfile with the snapshot tarballs and integrity hashes.
3. Document the temporary pin so it is replaced with the released package version after the upstream fix ships.

## Tests

- The upstream command and React menu regressions cover formatted selection cleanup, finding an existing note, and inserting a clean wikilink.
- Reflect's editor wrapper, formatting-toolbar, autocomplete, autocomplete-entry, and roundtrip suites pass against the snapshot.
- Upstream CI is green across Chromium, Firefox, WebKit, macOS, Linux, and Windows.

## Verification

- `pnpm --filter @reflect/desktop test --run src/editor/note-editor.test.tsx src/editor/formatting-toolbar-bridge.test.tsx src/editor/use-editor-autocomplete.test.tsx src/editor/wiki-autocomplete-entries.test.ts src/editor/roundtrip.test.ts` — 64 tests passed.
- `pnpm check` — passed (two pre-existing max-lines warnings).
- `pnpm build` — passed (expected missing Sentry token and chunk-size warnings only).
- `pnpm install --frozen-lockfile` — passed.

## Risk / Rollout

The dependency is pinned to an immutable upstream commit rather than a mutable PR alias, so installs are reproducible. Once Meowdown publishes the fix, replace the snapshot overrides with the released `@meowdown/core` and `@meowdown/react` version. There are no data migrations or configuration changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change with no app or data migrations; main follow-up is reverting overrides after Meowdown ships the fix.
> 
> **Overview**
> **Pins `@meowdown/core` and `@meowdown/react`** to the immutable `e04a672` build from upstream [prosekit/meowdown#287](https://github.com/prosekit/meowdown/pull/287), which fixes creating wikilinks from **formatted** selections so Markdown delimiters (e.g. `**`) are stripped from the note query instead of leaking into search and new-note titles.
> 
> `pnpm-workspace.yaml` enables **pnpm `overrides`** (with `blockExoticSubdeps: false`) and a short comment that this pin should be removed once the fix is on a normal npm release. **`pnpm-lock.yaml`** is regenerated so installs resolve those tarball URLs and integrity hashes.
> 
> `apps/desktop/package.json` still declares `^0.44.1`; only the workspace overrides change what actually installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 282bf3cd33d7a8b83cbbc95e3c366a4ea439ad5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->