### PR TITLE
fix(desktop): soften the sidebar resize handle hover

### DIFF
--- a/apps/desktop/src/components/sidebar-resize-handle.tsx
+++ b/apps/desktop/src/components/sidebar-resize-handle.tsx
@@ -17,11 +17,16 @@ interface SidebarResizeHandleProps {
 
 /**
  * The draggable divider on a sidebar's inner edge: an 8px invisible hit strip
- * whose 2px edge line tints on hover (after a short delay, so mousing past
- * doesn't flash), while dragging, and on keyboard focus — at rest the aside's
- * hairline border stays the only chrome. A focusable `separator` controlling
- * its aside: arrow keys nudge the divider, Home/End jump the rail to its
- * minimum/maximum width, and double-click resets to the default.
+ * whose 2px edge line fades in on a lingered hover, while dragging, and on
+ * keyboard focus — at rest the aside's hairline border stays the only chrome.
+ * The states follow the design system's restraint rules: hover is a quiet
+ * grey wash (border-strong at 60% — dark mode lands on V1's exact .03 hover
+ * opacity) revealed only after the slow-motion delay, so mouse traffic past
+ * the edge never flickers; the cursor alone signals the affordance
+ * immediately. Indigo is reserved for the active states — dragging and
+ * keyboard focus — which appear without delay. A focusable `separator`
+ * controlling its aside: arrow keys nudge the divider, Home/End jump the rail
+ * to its minimum/maximum width, and double-click resets to the default.
  */
 export function SidebarResizeHandle({ panel }: SidebarResizeHandleProps): ReactElement {
   const { width, range, dragging, handlers } = useSidebarResize(panel)
@@ -41,10 +46,11 @@ export function SidebarResizeHandle({ panel }: SidebarResizeHandleProps): ReactE
         // outline-hidden (not -none) keeps the forced-colors fallback outline
         // for high-contrast users, whom the tinted edge line cannot reach.
         'absolute inset-y-0 z-10 w-2 cursor-col-resize touch-none outline-hidden',
-        'after:absolute after:inset-y-0 after:w-0.5 after:transition-colors after:duration-100',
-        'hover:after:bg-border-strong hover:after:delay-150 focus-visible:after:bg-accent/40',
+        'after:absolute after:inset-y-0 after:w-0.5 after:bg-border-strong after:opacity-0 after:transition-opacity after:duration-150',
+        'hover:after:opacity-60 hover:after:delay-300',
+        'focus-visible:after:bg-accent focus-visible:after:opacity-40 focus-visible:after:delay-0',
         panel === 'workspace' ? 'right-0 after:right-0' : 'left-0 after:left-0',
-        dragging && 'after:bg-accent/60 hover:after:bg-accent/60',
+        dragging && 'after:bg-accent after:opacity-60 hover:after:delay-0',
       )}
     />
   )


### PR DESCRIPTION
## Problem

The resize handles from #751 reveal their 2px edge line on hover using `--border-strong` at full strength — the *input outline* color, noticeably darker than the design system's hover language. DS hover states are quiet translucent washes (dark mode pins them at V1's `.03` opacity), and the app's stated rule is restraint: hairlines do the structural work, and nothing should flicker as the mouse passes.

## Change

One file, styling only ([sidebar-resize-handle.tsx](apps/desktop/src/components/sidebar-resize-handle.tsx)): the edge line becomes an opacity fade instead of a color pop.

| State | Before | After |
|---|---|---|
| Hover | `border-strong` at 100%, 150ms delay | `border-strong` at **60%** (light ≈9% ink; dark lands on V1's exact `.03` hover opacity), revealed after the DS slow-motion delay (300ms) so mouse traffic past the edge stays silent — the `col-resize` cursor alone signals the affordance immediately |
| Keyboard focus | `accent/40` | unchanged intensity, now explicit zero delay |
| Dragging | `accent/60` | unchanged intensity, immediate |

Fade uses `transition-opacity` at the DS base duration (150ms); indigo stays reserved for the active states, per "indigo is the only saturated accent."

## Verification

- `pnpm check` and the 17 handle tests pass (behavioral tests — no class assertions to update).
- Not eyeballed in the running app; worth a hover/drag glance in both themes when someone has it open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-component Tailwind styling only; resize behavior and tests are unchanged.
> 
> **Overview**
> **Softens sidebar resize handle visuals** so hover matches the design system’s quiet hover language instead of flashing full-strength `border-strong`.
> 
> The 2px edge line now **fades via opacity** (`border-strong` at 60% on hover) with a **300ms delay** and **150ms opacity transition**, so quick mouse passes don’t flicker; **`col-resize` still signals the affordance immediately**. **Focus and drag** keep similar indigo emphasis but use explicit **`accent` + opacity** (40% focus, 60% drag) with **no delay** on those active states. Component JSDoc is updated to document the restraint rules. **No behavior or a11y API changes** — styling only in `sidebar-resize-handle.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4865dc8a424723f1156e4f5bce04aa5e5e9b2432. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the sidebar divider’s visual feedback during hover, keyboard focus, and dragging.
  * Updated opacity transitions to provide smoother interaction states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->