### PR TITLE
feat: add GPT-5.6 models to AI chat

### DIFF
--- a/apps/desktop/src/components/chat/chat-screen.test.tsx
+++ b/apps/desktop/src/components/chat/chat-screen.test.tsx
@@ -345,7 +345,16 @@ describe('ChatScreen', () => {
     expect(await screen.findByText('OpenAI')).toBeDefined()
     const labels = screen.getAllByRole('option').map((option) => option.textContent)
     // The full curated catalog plus the entry's custom configured model.
-    expect(labels).toEqual(['GPT-5.5', 'GPT-5.4', 'GPT-5.4 mini', 'GPT-5.4 nano', 'gpt-5.1'])
+    expect(labels).toEqual([
+      'GPT-5.6 Sol',
+      'GPT-5.6 Terra',
+      'GPT-5.6 Luna',
+      'GPT-5.5',
+      'GPT-5.4',
+      'GPT-5.4 mini',
+      'GPT-5.4 nano',
+      'gpt-5.1',
+    ])
   })
 
   it('routes the turn to the picked catalog model', async () => {
@@ -357,23 +366,23 @@ describe('ChatScreen', () => {
     const view = renderChat()
 
     fireEvent.keyDown(view.getByRole('combobox', { name: 'Model' }), { key: 'ArrowDown' })
-    fireEvent.keyDown(await screen.findByRole('option', { name: 'GPT-5.5' }), { key: 'Enter' })
+    fireEvent.keyDown(await screen.findByRole('option', { name: 'GPT-5.6 Terra' }), { key: 'Enter' })
 
     await userEvent.type(view.getByLabelText('Chat message'), 'hi{Enter}')
 
     await waitFor(() => expect(streamChat).toHaveBeenCalledTimes(1))
     // Same entry (id → keychain key), with the picked model applied.
-    expect(streamChat.mock.lastCall?.[0].config).toEqual({ ...MODEL, model: 'gpt-5.5' })
+    expect(streamChat.mock.lastCall?.[0].config).toEqual({ ...MODEL, model: 'gpt-5.6-terra' })
   })
 
   it('starts the picker on the model persisted from the last session', async () => {
     configureModel()
-    settingsState.selection = { configId: 'm1', modelId: 'gpt-5.5' }
+    settingsState.selection = { configId: 'm1', modelId: 'gpt-5.6-luna' }
     const view = renderChat()
 
     fireEvent.keyDown(view.getByRole('combobox', { name: 'Model' }), { key: 'ArrowDown' })
 
-    const picked = await screen.findByRole('option', { name: 'GPT-5.5' })
+    const picked = await screen.findByRole('option', { name: 'GPT-5.6 Luna' })
     expect(picked.getAttribute('aria-selected')).toBe('true')
   })
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.87",
     "@ai-sdk/google": "^3.0.84",
-    "@ai-sdk/openai": "^3.0.75",
+    "@ai-sdk/openai": "^3.0.84",
     "@lezer/common": "^1.5.2",
     "@lezer/markdown": "^1.6.4",
     "@reflect/db": "workspace:*",

--- a/packages/core/src/ai/language-model.test.ts
+++ b/packages/core/src/ai/language-model.test.ts
@@ -10,12 +10,20 @@ import { languageModel } from './language-model'
 interface RecordedCall {
   readonly url: string
   readonly headers: Headers
+  readonly body: string | null
 }
 
 const ANTHROPIC_CONFIG: AiProviderConfig = {
   id: 'cfg-anthropic',
   provider: 'anthropic',
   model: 'claude-opus-4-8',
+  keyHint: 'wxyz1',
+}
+
+const OPENAI_CONFIG: AiProviderConfig = {
+  id: 'cfg-openai',
+  provider: 'openai',
+  model: 'gpt-5.6-terra',
   keyHint: 'wxyz1',
 }
 
@@ -31,6 +39,7 @@ function recordingAnthropicFetch(calls: RecordedCall[]): typeof fetch {
     calls.push({
       url: String(input),
       headers: new Headers(init?.headers),
+      body: typeof init?.body === 'string' ? init.body : null,
     })
     return new Response(
       JSON.stringify({
@@ -48,11 +57,38 @@ function recordingAnthropicFetch(calls: RecordedCall[]): typeof fetch {
   }
 }
 
+function recordingOpenAiFetch(calls: RecordedCall[]): typeof fetch {
+  return async (input, init) => {
+    calls.push({
+      url: String(input),
+      headers: new Headers(init?.headers),
+      body: typeof init?.body === 'string' ? init.body : null,
+    })
+    return new Response(
+      JSON.stringify({
+        id: 'resp_123',
+        created_at: 0,
+        model: OPENAI_CONFIG.model,
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            id: 'msg_123',
+            content: [{ type: 'output_text', text: 'ok', annotations: [] }],
+          },
+        ],
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+}
+
 function recordingOpenRouterFetch(calls: RecordedCall[]): typeof fetch {
   return async (input, init) => {
     calls.push({
       url: String(input),
       headers: new Headers(init?.headers),
+      body: typeof init?.body === 'string' ? init.body : null,
     })
     return new Response(
       JSON.stringify({
@@ -75,6 +111,21 @@ function recordingOpenRouterFetch(calls: RecordedCall[]): typeof fetch {
 }
 
 describe('languageModel', () => {
+  it('routes a GPT-5.6 model through OpenAI Responses', async () => {
+    const calls: RecordedCall[] = []
+
+    await generateText({
+      model: languageModel(OPENAI_CONFIG, 'sk-test', recordingOpenAiFetch(calls)),
+      prompt: 'hello',
+      maxRetries: 0,
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.url).toBe('https://api.openai.com/v1/responses')
+    expect(calls[0]!.headers.get('Authorization')).toBe('Bearer sk-test')
+    expect(calls[0]!.body).toContain('"model":"gpt-5.6-terra"')
+  })
+
   it('adds Anthropic direct-browser access to model calls', async () => {
     const calls: RecordedCall[] = []
 

--- a/packages/core/src/ai/provider-catalog.test.ts
+++ b/packages/core/src/ai/provider-catalog.test.ts
@@ -7,6 +7,14 @@ import {
 } from './provider-catalog'
 
 describe('AI_PROVIDERS', () => {
+  it('offers the GPT-5.6 family in capability order', () => {
+    expect(aiProvider('openai').models.slice(0, 3)).toEqual([
+      { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', contextWindow: 1_000_000 },
+      { id: 'gpt-5.6-terra', label: 'GPT-5.6 Terra', contextWindow: 1_000_000 },
+      { id: 'gpt-5.6-luna', label: 'GPT-5.6 Luna', contextWindow: 1_000_000 },
+    ])
+  })
+
   it('includes OpenRouter in the settings catalog', () => {
     expect(aiProvider('openrouter')).toMatchObject({
       id: 'openrouter',

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -42,6 +42,9 @@ export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
     label: 'OpenAI',
     keyPlaceholder: 'sk-…',
     models: [
+      { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', contextWindow: 1_000_000 },
+      { id: 'gpt-5.6-terra', label: 'GPT-5.6 Terra', contextWindow: 1_000_000 },
+      { id: 'gpt-5.6-luna', label: 'GPT-5.6 Luna', contextWindow: 1_000_000 },
       { id: 'gpt-5.5', label: 'GPT-5.5', contextWindow: 1_000_000 },
       { id: 'gpt-5.4', label: 'GPT-5.4', contextWindow: 1_000_000 },
       { id: 'gpt-5.4-mini', label: 'GPT-5.4 mini', contextWindow: 400_000 },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,8 +251,8 @@ importers:
         specifier: ^3.0.84
         version: 3.0.84(zod@4.4.3)
       '@ai-sdk/openai':
-        specifier: ^3.0.75
-        version: 3.0.75(zod@4.4.3)
+        specifier: ^3.0.84
+        version: 3.0.84(zod@4.4.3)
       '@lezer/common':
         specifier: ^1.5.2
         version: 1.5.2
@@ -354,8 +354,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@3.0.75':
-    resolution: {integrity: sha512-xKW+ZSHOdsFIUR6H2uSVjQQmzuHG+onsBZQmsr1OagDK/G55Vhx7Msd/5itoIT/kfGIhOGtCY0DTxbP0RWT7hA==}
+  '@ai-sdk/openai@3.0.84':
+    resolution: {integrity: sha512-cmgbeJL0bbY0yTJH4/AdmP5E7MjWRL9G8UdhIi0JlV/So03o82ORJofW8OzwCZPTORVQblFbpZXYGDcUd9NdUQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -366,8 +366,18 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.38':
+    resolution: {integrity: sha512-/HHGmtKllqjg1OLc023v9w9kK3laW7Z6TzfZukYQWCsGBbzB9p60zTvvpXFVcs44NZBVXL3viOa1HRKUbeee8g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@3.0.11':
     resolution: {integrity: sha512-GKu3RxsfKGWjBiXmEdsKsGR9uVgJ56mzL1w7mLsn5k2TiNtpyS2IYQo3v1NJpK3oyv2OVavlK3g801VSe+gujg==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.14':
+    resolution: {integrity: sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==}
     engines: {node: '>=18'}
 
   '@aklinker1/rollup-plugin-visualizer@5.12.0':
@@ -6287,10 +6297,10 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.31(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/openai@3.0.75(zod@4.4.3)':
+  '@ai-sdk/openai@3.0.84(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.11
-      '@ai-sdk/provider-utils': 4.0.31(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.38(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@4.0.31(zod@4.4.3)':
@@ -6300,7 +6310,18 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
+  '@ai-sdk/provider-utils@4.0.38(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
   '@ai-sdk/provider@3.0.11':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.14':
     dependencies:
       json-schema: 0.4.0
 


### PR DESCRIPTION
## Problem

The curated OpenAI catalog in Reflect stops at GPT-5.5, so users cannot choose the GPT-5.6 family when adding an OpenAI provider or switching models in chat. The installed OpenAI adapter also predates the upstream GPT-5.6 model metadata.

## Before -> After

| Surface | Before | After |
| --- | --- | --- |
| OpenAI provider setup | GPT-5.5 is the newest default | GPT-5.6 Sol is the default, with Terra and Luna available |
| Desktop and mobile chat | No GPT-5.6 choices | Sol, Terra, and Luna appear first in capability order |
| OpenAI adapter | 3.0.75 generic unknown-model handling | 3.0.84 explicit GPT-5.6 IDs and capabilities |

Existing configured model IDs remain unchanged.

## Changes

1. Add `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` to the shared OpenAI catalog. Each uses a conservative 1,000,000-token context floor against the documented 1,050,000-token window.
2. Update `@ai-sdk/openai` to 3.0.84, which explicitly supports the GPT-5.6 family.
3. Cover catalog order, picker visibility, selected and persisted chat routing, and a real adapter request to `/v1/responses`.

## Verification

- `pnpm --filter @reflect/core test src/ai/provider-catalog.test.ts src/ai/chat/model-options.test.ts src/ai/language-model.test.ts` — 3 files, 15 tests passed
- `pnpm --filter @reflect/desktop test src/components/chat/chat-screen.test.tsx src/components/settings/ai-providers-section.test.tsx src/mobile/add-ai-provider-drawer.test.tsx` — 3 files, 36 tests passed
- `pnpm check` — passed; only the existing max-lines warnings remain
- `pnpm build` — passed; expected local Sentry-token and bundle-size warnings only

## Risk / Rollout

No settings migration or data rewrite is required because model IDs are already persisted as arbitrary strings. Existing provider configurations keep their current model; only newly added OpenAI providers default to GPT-5.6 Sol.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog and dependency bump only; no migrations or changes to auth or persisted provider configs beyond new picker defaults.
> 
> **Overview**
> Adds **GPT-5.6 Sol, Terra, and Luna** to the shared OpenAI curated catalog ahead of GPT-5.5, so new providers default to Sol and chat/settings pickers list the family first (1M-token context floor each).
> 
> Bumps **`@ai-sdk/openai`** from 3.0.75 to 3.0.84 (lockfile included). Tests now assert catalog order, desktop model-picker labels/routing for `gpt-5.6-terra` / `gpt-5.6-luna`, and that `languageModel` sends GPT-5.6 through **`/v1/responses`** with the expected model id in the body.
> 
> Existing saved model IDs are untouched; only the offered defaults and picker ordering change for OpenAI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f89b1df5b54f69b89047d3ea6ea6e1adc6f7e71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPT-5.6 Sol, Terra, and Luna models to the OpenAI model catalog.
  * Added support for routing GPT-5.6 requests through the OpenAI Responses API.
  * GPT-5.6 models now support a 1,000,000-token context window.

* **Bug Fixes**
  * Updated model selection and persistence behavior to recognize the new GPT-5.6 options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

