### PR TITLE
fix: save captures with duplicate category notes

### DIFF
--- a/packages/core/src/actions/audio-memo.test.ts
+++ b/packages/core/src/actions/audio-memo.test.ts
@@ -353,23 +353,6 @@ describe('reconcileAudioMemos', () => {
     expect(transcribeMock).not.toHaveBeenCalled()
   })
 
-  it('does not finalize a memo while its category backlink is ambiguous', async () => {
-    listDirMock.mockResolvedValue([fileMeta(MEMO.audioPath)])
-    ensureBacklinkTargetMock.mockRejectedValue({
-      kind: 'unknown',
-      message: 'The [[Audio memos]] backlink matches multiple notes',
-    })
-
-    const outcome = await reconcile()
-
-    expect(outcome).toMatchObject({
-      transcribed: 0,
-      stopped: { reason: 'unknown', message: expect.stringContaining('matches multiple notes') },
-    })
-    expect(transcribeMock).not.toHaveBeenCalled()
-    expect(writeNoteMock).not.toHaveBeenCalled()
-  })
-
   it('a daily-note backlink without the note is a tombstone — deletion stays deleted', async () => {
     listDirMock.mockResolvedValue([fileMeta(MEMO.audioPath)])
     readNoteMock.mockResolvedValue(

--- a/packages/core/src/actions/backlink-target.test.ts
+++ b/packages/core/src/actions/backlink-target.test.ts
@@ -37,15 +37,48 @@ describe('ensureBacklinkTarget', () => {
     await expect(ensureBacklinkTarget('Links', 3)).resolves.toBe('Links')
   })
 
-  it('refuses an ambiguous target instead of creating a terminal unresolved backlink', async () => {
+  it('uses the read-only wiki-link winner when duplicate targets already exist', async () => {
     resolveOrCreateMock.mockResolvedValue({
       kind: 'ambiguous',
-      paths: ['notes/links-2.md', 'notes/links.md'],
+      paths: ['notes/links.md', 'notes/links-2.md'],
     })
+
+    await expect(ensureBacklinkTarget('Links', 3)).resolves.toBe('Links')
+    expect(readNoteMock).toHaveBeenCalledWith('notes/links-2.md', 3)
+  })
+
+  it('links directly to the selected duplicate when its current title is unique', async () => {
+    resolveOrCreateMock.mockResolvedValue({
+      kind: 'ambiguous',
+      paths: ['notes/saved-links.md', 'notes/bookmarks.md'],
+    })
+    readNoteMock.mockResolvedValue('# Bookmarks\n')
+
+    await expect(ensureBacklinkTarget('Links', 3)).resolves.toBe('Bookmarks')
+    expect(readNoteMock).toHaveBeenCalledWith('notes/bookmarks.md', 3)
+  })
+
+  it('keeps a duplicate target retryable when the selected winner cannot be read', async () => {
+    resolveOrCreateMock.mockResolvedValue({
+      kind: 'ambiguous',
+      paths: ['notes/links.md', 'notes/links-2.md'],
+    })
+    readNoteMock.mockRejectedValue({ kind: 'io', message: 'not downloaded' })
+
+    await expect(ensureBacklinkTarget('Links', 3)).rejects.toMatchObject({
+      kind: 'io',
+      message: 'not downloaded',
+    })
+    expect(readNoteMock).toHaveBeenCalledTimes(1)
+    expect(readNoteMock).toHaveBeenCalledWith('notes/links-2.md', 3)
+  })
+
+  it('rejects an impossible ambiguous result without any target paths', async () => {
+    resolveOrCreateMock.mockResolvedValue({ kind: 'ambiguous', paths: [] })
 
     await expect(ensureBacklinkTarget('Links', 3)).rejects.toMatchObject({
       kind: 'unknown',
-      message: expect.stringContaining('matches multiple notes'),
+      message: expect.stringContaining('could not be resolved'),
     })
     expect(readNoteMock).not.toHaveBeenCalled()
   })

--- a/packages/core/src/actions/backlink-target.ts
+++ b/packages/core/src/actions/backlink-target.ts
@@ -6,20 +6,23 @@ import { parseNote } from '../markdown/extract'
 
 /**
  * Resolve the note targeted by an automatic backlink, or create it safely.
- * Ambiguity is not success: callers cannot make a durable category link until
- * the index or synced files identify one target unambiguously. Returns the
- * a link-safe current title so renames keep one section; an unsafe title falls
- * back to the requested spelling that just resolved as its alias.
+ * Existing duplicates use the same sorted-first winner as read-only wiki-link
+ * resolution. That ambiguity must not block durable capture, and no new note
+ * is created in that case. Returns a link-safe current title so renames keep
+ * one section; an unsafe title falls back to the requested spelling that just
+ * resolved as its alias.
  */
 export async function ensureBacklinkTarget(title: string, generation: number): Promise<string> {
   const outcome = await resolveOrCreateNoteWithTitle(title, generation)
-  if (outcome.kind === 'ambiguous') {
+  const path =
+    outcome.kind === 'ambiguous' ? [...outcome.paths].sort().at(0) : outcome.path
+  if (path === undefined) {
     throw new ReflectError(
       'unknown',
-      `The [[${title}]] backlink matches multiple notes: ${outcome.paths.join(', ')}`,
+      `The [[${title}]] backlink target could not be resolved.`,
     )
   }
-  const source = await readNote(outcome.path, generation)
-  const currentTitle = parseNote({ path: outcome.path, source }).title
+  const source = await readNote(path, generation)
+  const currentTitle = parseNote({ path, source }).title
   return wikiLinkSafe(currentTitle) === currentTitle ? currentTitle : title
 }


### PR DESCRIPTION
## Problem

The linked daily-section change resolves or creates the `Links` or `Audio memos` category note before writing a capture. That reused the conservative note-creation resolver, which correctly refuses to create another note when several existing notes claim the same title.

Imported graphs can already contain those duplicates. In the reported graph, `notes/links.md` and `notes/links-2.md` are both empty `# Links` notes. Their ambiguity stopped link capture before the capture note or daily note was written, leaving the item queued with `The [[Links]] backlink matches multiple notes`.

The create guard is still necessary, but an automatic backlink does not need to create or mutate either existing category note.

## Before -> After

| Scenario | Before | After |
| --- | --- | --- |
| Duplicate existing category titles | Raw capture stops before any graph write | Existing target is selected deterministically and capture saves |
| Missing category note | Safely creates one note | Unchanged |
| Selected target cannot be read | Spool remains retryable | Unchanged |
| Interactive navigation to exact duplicates | Reports ambiguity | Unchanged; this PR does not merge user notes |

## Changes

1. **Make backlink resolution tolerant of existing duplicates.**
   - `ensureBacklinkTarget` keeps using `resolveOrCreateNoteWithTitle`, so a missing target is still created through the race-safe path.
   - An ambiguous existing result now selects the first sorted path, matching read-only wiki-link resolution, and reads its current title.
   - No third category note is created.

2. **Preserve retry and rename behavior.**
   - A selected iCloud placeholder or read failure still aborts and leaves capture work queued.
   - A selected alias target uses its current link-safe title, keeping future entries under the renamed section when possible.

3. **Update regression coverage.**
   - Exact duplicate `Links` notes no longer reject capture prerequisites.
   - Unsorted candidates select the deterministic winner.
   - Distinct current titles, selected-target read failures, and the impossible empty ambiguity case are covered.
   - The obsolete audio-memo test that modeled ambiguity as an automatic hard failure is removed; general category I/O failure coverage remains.

## Tests

- Duplicate existing category notes select the deterministic target without creating another note.
- Ambiguous aliases use the selected note current title.
- An unreadable selected target remains retryable and does not fall through to another candidate.
- Link-capture drain and audio-memo reconciliation suites remain green.

## Verification

- `pnpm --filter @reflect/core test --run src/actions/backlink-target.test.ts src/actions/capture-drain.test.ts src/actions/audio-memo.test.ts` — 3 files / 74 tests passed.
- `pnpm check` — typecheck and lint passed; only the two existing max-lines warnings remain.
- `git diff --check` — passed.

## Risk / Rollout

There is no migration and no graph data is changed. Existing duplicate notes remain intact. Exact duplicate-title links can still require disambiguation when opened; this change only prevents that pre-existing data condition from blocking durable capture. The queued capture in affected graphs will retry normally after the fixed app runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared capture prerequisite logic for category backlinks; wrong duplicate selection could route daily sections to an unintended note, but behavior is deterministic and does not mutate or merge duplicate notes.
> 
> **Overview**
> **Automatic capture no longer fails** when category notes like `Links` or `Audio memos` already exist as duplicates with the same title. Previously `ensureBacklinkTarget` treated an ambiguous resolver result as a hard error and blocked link capture and audio-memo reconciliation before any graph write.
> 
> **`ensureBacklinkTarget` now picks a deterministic target** when duplicates already exist: it takes the first path after sorting (same rule as read-only wiki-link resolution), reads that note for its current title, and does not create another category note. Missing targets still go through the existing create path; unreadable winners still surface I/O errors so work stays retryable. Only the empty-path ambiguity case still throws.
> 
> Tests cover the new duplicate behavior (sorted winner, distinct titles, read failures) and drop the audio-memo case that expected ambiguity to stop reconciliation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3a4afb7121ac8f8f38ed42a84da50e704dad178. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved backlink handling when multiple notes match the same target.
  - The system now deterministically selects an appropriate matching note instead of failing immediately.
  - Backlinks use the selected note’s current title, helping preserve valid wiki-link formatting.
  - Clearer errors are provided when no matching path can be resolved.
  - Underlying read failures remain visible so the operation can be retried.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->