### PR TITLE
feat: add Claude Sonnet 5 to AI chat

### DIFF
--- a/apps/desktop/src/components/settings/ai-providers-section.test.tsx
+++ b/apps/desktop/src/components/settings/ai-providers-section.test.tsx
@@ -147,7 +147,7 @@ describe('AiProvidersSection', () => {
     fireEvent.keyDown(dialog.getByRole('combobox', { name: 'Provider' }), { key: 'ArrowDown' })
     fireEvent.keyDown(await screen.findByRole('option', { name: 'Anthropic' }), { key: 'Enter' })
     fireEvent.click(dialog.getByRole('combobox', { name: 'Default model' }))
-    fireEvent.click(await screen.findByRole('option', { name: /Claude Sonnet 4\.6/ }))
+    fireEvent.click(await screen.findByRole('option', { name: /Claude Sonnet 5/ }))
     fireEvent.change(dialog.getByLabelText('API key'), {
       target: { value: 'sk-ant-test-wxyz1' },
     })
@@ -158,7 +158,7 @@ describe('AiProvidersSection', () => {
     const [added] = doc.aiProviders
     expect(added).toMatchObject({
       provider: 'anthropic',
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       keyHint: 'wxyz1',
     })
     // The first entry becomes the default automatically.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.87",
+    "@ai-sdk/anthropic": "^3.0.96",
     "@ai-sdk/google": "^3.0.84",
     "@ai-sdk/openai": "^3.0.84",
     "@lezer/common": "^1.5.2",

--- a/packages/core/src/ai/chat/model-options.test.ts
+++ b/packages/core/src/ai/chat/model-options.test.ts
@@ -23,6 +23,9 @@ describe('chatModelOptions', () => {
     expect(options.find((option) => option.modelId === 'claude-fable-5')?.label).toBe(
       'Claude Fable 5',
     )
+    expect(options.find((option) => option.modelId === 'claude-sonnet-5')?.label).toBe(
+      'Claude Sonnet 5',
+    )
   })
 
   it('keeps a custom configured model selectable, labeled by its raw id', () => {

--- a/packages/core/src/ai/language-model.test.ts
+++ b/packages/core/src/ai/language-model.test.ts
@@ -16,7 +16,7 @@ interface RecordedCall {
 const ANTHROPIC_CONFIG: AiProviderConfig = {
   id: 'cfg-anthropic',
   provider: 'anthropic',
-  model: 'claude-opus-4-8',
+  model: 'claude-sonnet-5',
   keyHint: 'wxyz1',
 }
 
@@ -126,7 +126,7 @@ describe('languageModel', () => {
     expect(calls[0]!.body).toContain('"model":"gpt-5.6-terra"')
   })
 
-  it('adds Anthropic direct-browser access to model calls', async () => {
+  it('routes Claude Sonnet 5 through Anthropic Messages with direct-browser access', async () => {
     const calls: RecordedCall[] = []
 
     await generateText({
@@ -137,6 +137,8 @@ describe('languageModel', () => {
 
     expect(calls).toHaveLength(1)
     expect(calls[0]!.url).toBe('https://api.anthropic.com/v1/messages')
+    expect(calls[0]!.body).toContain('"model":"claude-sonnet-5"')
+    expect(calls[0]!.body).toContain('"max_tokens":128000')
     expect(calls[0]!.headers.get(ANTHROPIC_DIRECT_BROWSER_ACCESS_HEADER)).toBe(
       ANTHROPIC_DIRECT_BROWSER_ACCESS_VALUE,
     )

--- a/packages/core/src/ai/provider-catalog.test.ts
+++ b/packages/core/src/ai/provider-catalog.test.ts
@@ -7,6 +7,14 @@ import {
 } from './provider-catalog'
 
 describe('AI_PROVIDERS', () => {
+  it('offers the current Claude lineup in capability order', () => {
+    expect(aiProvider('anthropic').models.slice(0, 3)).toEqual([
+      { id: 'claude-fable-5', label: 'Claude Fable 5', contextWindow: 1_000_000 },
+      { id: 'claude-opus-4-8', label: 'Claude Opus 4.8', contextWindow: 1_000_000 },
+      { id: 'claude-sonnet-5', label: 'Claude Sonnet 5', contextWindow: 1_000_000 },
+    ])
+  })
+
   it('offers the GPT-5.6 family in capability order', () => {
     expect(aiProvider('openai').models.slice(0, 3)).toEqual([
       { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', contextWindow: 1_000_000 },

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -58,6 +58,7 @@ export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
     models: [
       { id: 'claude-fable-5', label: 'Claude Fable 5', contextWindow: 1_000_000 },
       { id: 'claude-opus-4-8', label: 'Claude Opus 4.8', contextWindow: 1_000_000 },
+      { id: 'claude-sonnet-5', label: 'Claude Sonnet 5', contextWindow: 1_000_000 },
       { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6', contextWindow: 1_000_000 },
       { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5', contextWindow: 200_000 },
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,8 +245,8 @@ importers:
   packages/core:
     dependencies:
       '@ai-sdk/anthropic':
-        specifier: ^3.0.87
-        version: 3.0.87(zod@4.4.3)
+        specifier: ^3.0.96
+        version: 3.0.96(zod@4.4.3)
       '@ai-sdk/google':
         specifier: ^3.0.84
         version: 3.0.84(zod@4.4.3)
@@ -336,8 +336,8 @@ packages:
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
-  '@ai-sdk/anthropic@3.0.87':
-    resolution: {integrity: sha512-4v7uoMblNYZ3X7S5a+manSKKqKVmWXTkJOtZ8ymArHdQbhgzMd+um1qDee8MiJbDhk6wjy8T/F+D1pVhB/7HTQ==}
+  '@ai-sdk/anthropic@3.0.96':
+    resolution: {integrity: sha512-6VQzaXQdm5FkX6NWOyKzV5GB11C8IqkgsKZE91lg/bdwyvnQJLDwal2qkE0+fC8CCGeW5d+VV8Mw/+H+OcDC1A==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -6278,10 +6278,10 @@ snapshots:
 
   '@adobe/css-tools@4.5.0': {}
 
-  '@ai-sdk/anthropic@3.0.87(zod@4.4.3)':
+  '@ai-sdk/anthropic@3.0.96(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.11
-      '@ai-sdk/provider-utils': 4.0.31(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.38(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/gateway@3.0.136(zod@4.4.3)':


### PR DESCRIPTION
## Problem

Reflect already offers Claude Fable 5, but its curated Anthropic catalog stops at Claude Sonnet 4.6. Users cannot choose Sonnet 5 when adding an Anthropic provider or switching models in chat.

The installed Anthropic adapter also predates explicit Sonnet 5 support. It accepts the model string but treats it as unknown, falling back to a 4,096-token output limit and disabling native structured-output and strict-tool capabilities.

## Before -> After

| Surface | Before | After |
| --- | --- | --- |
| Anthropic provider setup | Fable 5, Opus 4.8, Sonnet 4.6, Haiku 4.5 | Adds Sonnet 5 while retaining every existing model |
| Desktop and mobile chat | No Sonnet 5 choice | Sonnet 5 appears from the shared catalog |
| Anthropic adapter | 3.0.87 unknown-model fallback | 3.0.96 recognizes Sonnet 5 with 128k output and current capabilities |

Claude Fable 5 remains the first/default Anthropic model.

## Changes

1. Add `claude-sonnet-5` to the shared Anthropic catalog with a conservative 1,000,000-token context floor.
2. Update `@ai-sdk/anthropic` to 3.0.96, which includes explicit Sonnet 5 support and its adaptive-thinking handling.
3. Cover the current Anthropic catalog order, Fable and Sonnet chat labels, Sonnet 5 provider persistence, and a real Messages API request with the SDK-recognized 128k output limit.

## Verification

- `pnpm --filter @reflect/core test src/ai/provider-catalog.test.ts src/ai/chat/model-options.test.ts src/ai/language-model.test.ts` — 3 files, 16 tests passed
- `pnpm --filter @reflect/desktop test src/components/settings/ai-providers-section.test.tsx src/mobile/add-ai-provider-drawer.test.tsx` — 2 files, 15 tests passed
- `pnpm check` — passed; only the existing max-lines warnings remain
- `pnpm build` — passed; expected local Sentry-token and bundle-size warnings only

## Risk / Rollout

No settings migration or data rewrite is required because model IDs are already persisted as arbitrary strings. Existing Anthropic configurations keep their selected model, and Fable 5 remains the default for newly added Anthropic providers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog and dependency bump only; no migrations, and persisted model IDs are unchanged for existing configs.
> 
> **Overview**
> Adds **Claude Sonnet 5** (`claude-sonnet-5`) to the shared Anthropic provider catalog (after Fable 5 and Opus 4.8), so desktop/mobile settings and chat model pickers can select and persist it. Existing models, including Sonnet 4.6, stay in the list; **Fable 5** remains the first/default Anthropic option.
> 
> Bumps **`@ai-sdk/anthropic`** from `^3.0.87` to `^3.0.96` so Sonnet 5 is recognized by the adapter (e.g. **128k** `max_tokens` on Messages API calls instead of unknown-model fallback). Tests cover catalog order, chat labels, provider-setup persistence, and Anthropic routing for Sonnet 5.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9282e18f714577574c9f9f719be3b99c4cf2ab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Sonnet 5 to the available Anthropic model options.
  * Added support for Claude Sonnet 5 with a 1,000,000-token context window.
  * Updated Anthropic model ordering and labels for clearer selection.

* **Tests**
  * Added coverage confirming Claude Sonnet 5 selection and request configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->