### PR TITLE
feat: add backlink hover previews

### DIFF
--- a/apps/desktop/src-tauri/src/fs/asset_protocol.rs
+++ b/apps/desktop/src-tauri/src/fs/asset_protocol.rs
@@ -16,6 +16,9 @@
 //! commands — a request racing a graph switch is refused, never resolved
 //! against the new graph. The path must live under `assets/` and passes the
 //! shared symlink-aware traversal guard before any IO.
+//! Passive previews append `?reflect-preview=raster`; those responses are
+//! served only when byte sniffing identifies PNG, JPEG, GIF, or WebP content,
+//! so an SVG renamed with a raster extension cannot load subresources there.
 
 use std::borrow::Cow;
 
@@ -28,6 +31,7 @@ use super::GraphState;
 /// The scheme name, shared with the `lib.rs` registration. The frontend and
 /// the CSP `img-src` grant in `tauri.conf.json` spell it out literally.
 pub(crate) const SCHEME: &str = "reflect-asset";
+const PREVIEW_RASTER_QUERY: &str = "reflect-preview=raster";
 
 /// Protocol entry point (`register_asynchronous_uri_scheme_protocol`). Runs
 /// on the webview's calling thread — on WebKit, the app's main thread — so it
@@ -42,31 +46,53 @@ pub(crate) fn handle<R: Runtime>(
     let request_path = percent_encoding::percent_decode(&request.uri().path().as_bytes()[1..])
         .decode_utf8_lossy()
         .into_owned();
+    let preview_raster_only = requests_preview_raster(request.uri().query());
     let method_allowed = request.method() == tauri::http::Method::GET;
     tauri::async_runtime::spawn_blocking(move || {
         if !method_allowed {
             responder.respond(status_response(StatusCode::METHOD_NOT_ALLOWED));
             return;
         }
-        responder.respond(response_for(&app, &request_path));
+        responder.respond(response_for(&app, &request_path, preview_raster_only));
     });
 }
 
 fn response_for<R: Runtime>(
     app: &AppHandle<R>,
     request_path: &str,
+    preview_raster_only: bool,
 ) -> Response<Cow<'static, [u8]>> {
     match serve(app, request_path) {
-        Ok((mime, bytes)) => Response::builder()
-            .header(header::CONTENT_TYPE, mime)
-            .header(header::CONTENT_LENGTH, bytes.len())
-            .body(Cow::Owned(bytes))
-            .unwrap_or_else(|_| status_response(StatusCode::INTERNAL_SERVER_ERROR)),
+        Ok((mime, bytes)) => {
+            if preview_raster_only && !is_preview_safe_raster_mime(&mime) {
+                return status_response(StatusCode::UNSUPPORTED_MEDIA_TYPE);
+            }
+            Response::builder()
+                .header(header::CONTENT_TYPE, mime)
+                .header(header::CONTENT_LENGTH, bytes.len())
+                .body(Cow::Owned(bytes))
+                .unwrap_or_else(|_| status_response(StatusCode::INTERNAL_SERVER_ERROR))
+        }
         Err(status) => {
             tracing::warn!(path = request_path, %status, "asset protocol refused a request");
             status_response(status)
         }
     }
+}
+
+fn requests_preview_raster(query: Option<&str>) -> bool {
+    query.is_some_and(|query| {
+        query
+            .split('&')
+            .any(|parameter| parameter == PREVIEW_RASTER_QUERY)
+    })
+}
+
+fn is_preview_safe_raster_mime(mime: &str) -> bool {
+    matches!(
+        mime,
+        "image/png" | "image/jpeg" | "image/gif" | "image/webp"
+    )
 }
 
 fn status_response(status: StatusCode) -> Response<Cow<'static, [u8]>> {
@@ -154,5 +180,28 @@ mod tests {
             parse_request_path("3/assets/").unwrap_err(),
             StatusCode::FORBIDDEN,
         );
+    }
+
+    #[test]
+    fn recognizes_only_the_explicit_preview_raster_query() {
+        assert!(requests_preview_raster(Some("reflect-preview=raster")));
+        assert!(requests_preview_raster(Some(
+            "cache=1&reflect-preview=raster"
+        )));
+        assert!(!requests_preview_raster(None));
+        assert!(!requests_preview_raster(Some("reflect-preview=svg")));
+    }
+
+    #[test]
+    fn preview_raster_filter_uses_sniffed_content_not_the_filename() {
+        let disguised_svg = br#"<svg xmlns="http://www.w3.org/2000/svg"></svg>"#;
+        let svg_mime = MimeType::parse(disguised_svg, "assets/disguised.png");
+        assert_ne!(svg_mime, "image/png");
+        assert!(!is_preview_safe_raster_mime(&svg_mime));
+
+        let png_signature = b"\x89PNG\r\n\x1a\n";
+        let png_mime = MimeType::parse(png_signature, "assets/image.bin");
+        assert_eq!(png_mime, "image/png");
+        assert!(is_preview_safe_raster_mime(&png_mime));
     }
 }

--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -23,6 +23,8 @@ import { useNoteDocument } from '@/editor/use-note-document'
 import { useTagNavigation } from '@/editor/use-tag-navigation'
 import { useTemplateSlashItems } from '@/editor/use-template-slash-items'
 import { useWikiLinkNavigation } from '@/editor/use-wiki-link-navigation'
+import { useWikiLinkHoverPreview } from '@/editor/use-wiki-link-hover-preview'
+import { isTouchEditorSurface } from '@/lib/platform-surface'
 import { cn } from '@/lib/utils'
 import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
@@ -157,6 +159,13 @@ export function NotePaneComponent({
     resolveFileInfo,
     saveError,
   } = useAssetPersistence(generation, path)
+  const renderWikilinkHoverCard = useWikiLinkHoverPreview({
+    generation,
+    graphKey: graph?.root ?? null,
+    dateFormat: settings.dateFormat,
+    resolveImageUrl,
+    resolveAssetOpenPath,
+  })
   const onWikiLinkClick = useWikiLinkNavigation(generation)
   const onTagClick = useTagNavigation()
   const { onWikilinkSearch, onTagSearch } = useEditorAutocomplete()
@@ -340,6 +349,9 @@ export function NotePaneComponent({
         resolveFileLink={resolveAssetFileLink}
         resolveFileInfo={resolveFileInfo}
         onWikiLinkClick={onWikiLinkClick}
+        {...(generation !== null && !isTouchEditorSurface()
+          ? { renderWikilinkHoverCard }
+          : {})}
         onTagClick={onTagClick}
         onWikilinkSearch={onWikilinkSearch}
         onTagSearch={onTagSearch}

--- a/apps/desktop/src/components/route-content.test.tsx
+++ b/apps/desktop/src/components/route-content.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactElement } from 'react'
 import { setBridge } from '@reflect/core'
 import { PaletteProvider, usePalette } from '@/components/command-palette/palette-provider'
@@ -8,6 +8,7 @@ import { flushOpenDocuments } from '@/editor/open-documents'
 import type { NoteEditorHandle } from '@/editor/note-editor'
 import { RouterProvider } from '@/routing/router'
 import type { Route } from '@/routing/route'
+import { setPlatformSurface } from '@/lib/platform-surface'
 import { RouteContent } from './route-content'
 
 /**
@@ -21,6 +22,7 @@ import { RouteContent } from './route-content'
 const editorProbe = vi.hoisted(() => ({
   onChange: null as ((markdown: string) => void) | null,
   focusCalls: [] as string[],
+  hoverRenderer: null as boolean | null,
 }))
 
 vi.mock('@/editor/note-editor', async () => {
@@ -30,11 +32,14 @@ vi.mock('@/editor/note-editor', async () => {
       initialContent,
       onChange,
       handleRef,
+      renderWikilinkHoverCard,
     }: {
       initialContent: string
       onChange: (markdown: string) => void
       handleRef?: (handle: NoteEditorHandle | null) => void
+      renderWikilinkHoverCard?: unknown
     }) => {
+      editorProbe.hoverRenderer = renderWikilinkHoverCard !== undefined
       const markdownRef = useRef(initialContent)
       editorProbe.onChange = (markdown) => {
         markdownRef.current = markdown
@@ -129,6 +134,7 @@ beforeEach(() => {
   writes = []
   editorProbe.onChange = null
   editorProbe.focusCalls.length = 0
+  editorProbe.hoverRenderer = null
   mockInvoke.mockReset()
   mockInvoke.mockImplementation(async (command, args) => {
     if (command === 'note_read') {
@@ -149,6 +155,10 @@ beforeEach(() => {
     }
     return null
   })
+})
+
+afterEach(() => {
+  setPlatformSurface({ touchEditor: false, mobileApp: false })
 })
 
 function PaletteProbe(): ReactElement {
@@ -190,9 +200,20 @@ describe('RouteContent', () => {
     await view.findByLabelText('Editing notes/exist.md')
     expect(view.queryByTestId('daily-stream')).toBeNull()
     expect(view.getByTestId('fake-editor').textContent).toContain('# Hello')
+    expect(editorProbe.hoverRenderer).toBe(true)
 
     // The navigated-to note takes focus on mount.
     await waitFor(() => expect(editorProbe.focusCalls).toContain('focus'))
+    view.unmount()
+  })
+
+  it('omits the wiki-link hover renderer on a touch editor surface', async () => {
+    setPlatformSurface({ touchEditor: true })
+    files['notes/exist.md'] = '# Hello\n'
+    const view = renderRoute({ kind: 'note', path: 'notes/exist.md' })
+
+    await view.findByLabelText('Editing notes/exist.md')
+    expect(editorProbe.hoverRenderer).toBe(false)
     view.unmount()
   })
 

--- a/apps/desktop/src/components/wiki-link-hover-preview.tsx
+++ b/apps/desktop/src/components/wiki-link-hover-preview.tsx
@@ -1,0 +1,47 @@
+import type { ReactElement } from 'react'
+import { dateFromDailyPath, type DateFormat } from '@reflect/core'
+import { MarkdownPreview } from '@/editor/markdown-preview'
+import { formatDayLabel } from '@/lib/dates'
+
+interface WikiLinkHoverPreviewProps {
+  path: string
+  /** The note body with frontmatter already stripped. */
+  markdown: string
+  dateFormat: DateFormat
+  resolveImageUrl: (src: string) => string | null
+}
+
+/**
+ * Reflect's passive body for Meowdown's wiki-link hover card. Meowdown owns
+ * the card chrome, sizing, and lifecycle; this renders only the content, from
+ * a snapshot read at hover time.
+ */
+export function WikiLinkHoverPreview({
+  path,
+  markdown,
+  dateFormat,
+  resolveImageUrl,
+}: WikiLinkHoverPreviewProps): ReactElement {
+  const dailyDate = dateFromDailyPath(path)
+  const empty = markdown.trim().length === 0
+
+  return (
+    <div className="p-3 text-xs text-popover-foreground" data-testid="wiki-link-hover-preview">
+      {dailyDate !== null ? (
+        <div className="reflect-daily-subject mb-2 text-base">
+          {formatDayLabel(dailyDate, dateFormat)}
+        </div>
+      ) : null}
+      {empty ? (
+        <p className="text-text-muted">Empty note</p>
+      ) : (
+        <MarkdownPreview
+          content={markdown}
+          resolveImageUrl={resolveImageUrl}
+          interactive={false}
+          className="text-xs leading-relaxed"
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/editor/markdown-preview.tsx
+++ b/apps/desktop/src/editor/markdown-preview.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react'
+import { useCallback, useEffect, useRef, type ReactElement } from 'react'
 import { MarkdownView } from '@meowdown/react'
 import { useOpenExternalLink } from '@/editor/open-external-link'
 import { cn } from '@/lib/utils'
@@ -25,6 +25,12 @@ interface MarkdownPreviewProps {
    * originating click so handlers can honor ⌘-click (open in new window).
    */
   onWikiLinkClick?: (target: string, event?: MouseEvent | KeyboardEvent) => void
+  /**
+   * Whether rendered links, images, and task checkboxes can be activated
+   * (default true). A passive preview renders no anchors, focusable controls,
+   * or remote embeds.
+   */
+  interactive?: boolean
   /** Extra classes for the rendered root. */
   className?: string
 }
@@ -33,6 +39,7 @@ export function MarkdownPreview({
   content,
   resolveImageUrl,
   onWikiLinkClick,
+  interactive = true,
   className,
 }: MarkdownPreviewProps): ReactElement {
   const openExternalLink = useOpenExternalLink()
@@ -46,11 +53,11 @@ export function MarkdownPreview({
     navigateRef.current = onWikiLinkClick
   })
 
-  // Whether wiki links navigate at all is fixed by the first render: hosts
-  // either always pass the handler (chat) or never do (palette preview). An
-  // inert preview omits the handler so a chip click is a no-op rather than a
-  // dead navigation.
-  const [navigates] = useState(() => onWikiLinkClick != null)
+  // Hosts either always pass the handler (chat) or never do (palette
+  // preview), and a passive preview forces links inert either way. An inert
+  // preview omits the handler so a chip click is a no-op rather than a dead
+  // navigation.
+  const navigates = interactive && onWikiLinkClick != null
 
   const resolveImageUrlStable = useCallback(
     (src: string) => resolveRef.current?.(src) ?? undefined,
@@ -66,8 +73,9 @@ export function MarkdownPreview({
     <MarkdownView
       markdown={content}
       markMode="hide"
+      interactive={interactive}
       resolveImageUrl={resolveImageUrlStable}
-      onLinkClick={openExternalLink}
+      {...(interactive ? { onLinkClick: openExternalLink } : {})}
       {...(navigates ? { onWikilinkClick: onWikilinkClickStable } : {})}
       className={cn('reflect-editor', className)}
     />

--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -28,7 +28,10 @@ interface CapturedEditorProps {
   onFileClick?: (payload: { href: string; name: string; event: MouseEvent | KeyboardEvent }) => void
 }
 
-const captured = vi.hoisted(() => ({ props: null as CapturedEditorProps | null }))
+const captured = vi.hoisted(() => ({
+  props: null as CapturedEditorProps | null,
+  hoverRenderer: null as unknown,
+}))
 
 /** The stub editor `useEditor` hands `EditorInputTraits` (see the mock below). */
 const editorStub = vi.hoisted(() => ({
@@ -55,6 +58,10 @@ vi.mock('@/lib/windows/open-in-new-window', async (importOriginal) => ({
 // `useEditor` backs `EditorInputTraits` (mounted inside the editor).
 vi.mock('@meowdown/react', () => ({
   useEditor: () => editorStub,
+  WikilinkHoverCard: ({ children }: { children: unknown }) => {
+    captured.hoverRenderer = children
+    return <div data-testid="wikilink-hover-card" />
+  },
   MeowdownEditor: (props: CapturedEditorProps) => {
     captured.props = props
     return (
@@ -124,6 +131,7 @@ function firePointer(element: Element, type: string, init: Record<string, unknow
 
 beforeEach(() => {
   captured.props = null
+  captured.hoverRenderer = null
   Object.defineProperty(window, 'matchMedia', {
     configurable: true,
     writable: true,
@@ -161,6 +169,21 @@ describe('NoteEditor markdown syntax mode', () => {
   it('passes an explicit markdown syntax mode to meowdown', () => {
     render(<NoteEditor initialContent="" markMode="show" />)
     expect(captured.props?.mode).toBe('show')
+  })
+})
+
+describe('NoteEditor wiki-link hover card', () => {
+  it('does not mount the optional card without a host renderer', () => {
+    render(<NoteEditor initialContent="" />)
+    expect(screen.queryByTestId('wikilink-hover-card')).toBeNull()
+  })
+
+  it('mounts the card with the host renderer as its body resolver', () => {
+    const renderer = async (): Promise<ReactNode> => null
+    render(<NoteEditor initialContent="" renderWikilinkHoverCard={renderer} />)
+
+    expect(screen.getByTestId('wikilink-hover-card')).toBeInTheDocument()
+    expect(captured.hoverRenderer).toBe(renderer)
   })
 })
 

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -17,9 +17,11 @@ import {
   type FileLinkResolver,
   type MarkMode,
   type StartPendingReplacementOptions,
+  type WikilinkHoverHit,
 } from '@meowdown/core'
 import {
   MeowdownEditor,
+  WikilinkHoverCard,
   type EditorHandle,
   type PendingReplacementResolveHandler,
   type SelectionMenuSearchHandler,
@@ -40,6 +42,8 @@ import { useLightboxTransition } from '@/editor/use-lightbox-transition'
 import { isDeepLinkUrl } from '@/lib/deep-links/parse'
 import { useFollowDeepLink } from '@/lib/deep-links/use-follow-deep-link'
 import { cn } from '@/lib/utils'
+
+type WikilinkHoverRenderer = (hit: WikilinkHoverHit) => ReactNode | Promise<ReactNode>
 
 /**
  * Reflect's note editor: a thin wrapper over `@meowdown/react`'s
@@ -152,6 +156,13 @@ interface NoteEditorProps {
    * modifiers, e.g. ⌘-click opens the target in a new window.
    */
   onWikiLinkClick?: (target: string, event?: MouseEvent | KeyboardEvent) => void
+  /**
+   * Resolve the passive body of Meowdown's editor-scoped wiki-link hover
+   * card. Resolving `null` (missing, ambiguous, or unavailable targets)
+   * renders no card. Must be a stable function: a new identity re-runs the
+   * resolution for the currently hovered link.
+   */
+  renderWikilinkHoverCard?: WikilinkHoverRenderer
   /** Click on an inline `#tag`. The tag name arrives without the leading `#`. */
   onTagClick?: (tag: string) => void
   /** Search notes for the `[[` autocomplete menu. */
@@ -207,6 +218,7 @@ export function NoteEditor({
   resolveFileLink,
   resolveFileInfo,
   onWikiLinkClick,
+  renderWikilinkHoverCard,
   onTagClick,
   onWikilinkSearch,
   onTagSearch,
@@ -422,6 +434,9 @@ export function NoteEditor({
       >
         <EditorInputTraits />
         <FormattingToolbarBridge />
+        {renderWikilinkHoverCard !== undefined ? (
+          <WikilinkHoverCard>{renderWikilinkHoverCard}</WikilinkHoverCard>
+        ) : null}
         {children}
       </MeowdownEditor>
       <ImageLightbox

--- a/apps/desktop/src/editor/use-editor-autocomplete.test.tsx
+++ b/apps/desktop/src/editor/use-editor-autocomplete.test.tsx
@@ -58,6 +58,27 @@ describe('useEditorAutocomplete', () => {
     )
   })
 
+  it('reports an unavailable background create distinctly from ambiguity', async () => {
+    resolveOrCreateNoteWithTitle.mockResolvedValue({
+      kind: 'unavailable',
+      paths: ['notes/business-ideas.md'],
+    })
+    const { result } = renderHook(() => useEditorAutocomplete())
+    const items = await result.current.onWikilinkSearch('Business ideas')
+
+    act(() => {
+      items[0]!.onSelect?.()
+    })
+
+    await waitFor(() =>
+      expect(resolveOrCreateNoteWithTitle).toHaveBeenCalledWith('Business ideas', 7),
+    )
+    expect(startOperation).toHaveBeenCalledWith('Creating note')
+    expect(operationFail).toHaveBeenCalledWith(
+      'Couldn’t create “Business ideas” while a potentially matching note is unavailable. Try again when it is available on this device.',
+    )
+  })
+
   it('surfaces a failed background create instead of silently doing nothing', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     resolveOrCreateNoteWithTitle.mockRejectedValue(new Error('graph changed'))

--- a/apps/desktop/src/editor/use-editor-autocomplete.ts
+++ b/apps/desktop/src/editor/use-editor-autocomplete.ts
@@ -55,13 +55,17 @@ export function useEditorAutocomplete(): EditorAutocomplete {
 
   // The `[[` autocomplete's create row: re-resolve and inspect the title's
   // on-disk slug family before creating. The menu inserts the link text either
-  // way; an ambiguous or failed create simply leaves it unresolved.
+  // way; an ambiguous, unavailable, or failed create leaves it unresolved.
   const resolveOrCreateFromAutocomplete = useCallback(
     async (title: string) => {
       if (generation !== null) {
         const outcome = await resolveOrCreateNoteWithTitle(title, generation)
         if (outcome.kind === 'ambiguous') {
           reportAmbiguousNoteTitle('Creating note', title)
+        } else if (outcome.kind === 'unavailable') {
+          startOperation('Creating note').fail(
+            `Couldn’t create “${title}” while a potentially matching note is unavailable. Try again when it is available on this device.`,
+          )
         }
       }
     },

--- a/apps/desktop/src/editor/use-wiki-link-hover-preview.test.tsx
+++ b/apps/desktop/src/editor/use-wiki-link-hover-preview.test.tsx
@@ -1,0 +1,149 @@
+import { render, renderHook, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import type { WikilinkHoverHit } from '@meowdown/core'
+import { useWikiLinkHoverPreview } from './use-wiki-link-hover-preview'
+
+const mocks = vi.hoisted(() => ({
+  resolveExistingWikiTarget: vi.fn(),
+  readExistingNoteSource: vi.fn(),
+  markdownPreview: vi.fn(),
+}))
+
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  resolveExistingWikiTarget: mocks.resolveExistingWikiTarget,
+}))
+
+vi.mock('@/lib/read-existing-note-source', () => ({
+  readExistingNoteSource: mocks.readExistingNoteSource,
+}))
+
+interface MarkdownPreviewProps {
+  content: string
+  interactive: boolean
+  resolveImageUrl: (src: string) => string | null
+}
+
+vi.mock('@/editor/markdown-preview', () => ({
+  MarkdownPreview: (props: MarkdownPreviewProps) => {
+    mocks.markdownPreview(props)
+    return <div data-testid="markdown-preview">{props.content}</div>
+  },
+}))
+
+function hoverHit(target: string): WikilinkHoverHit {
+  return { target, from: 0, to: 0, element: document.createElement('span') }
+}
+
+function setupRenderer(
+  overrides: Partial<Parameters<typeof useWikiLinkHoverPreview>[0]> = {},
+): (hit: WikilinkHoverHit) => Promise<ReactNode> {
+  const { result } = renderHook(() =>
+    useWikiLinkHoverPreview({
+      generation: 7,
+      graphKey: '/graph',
+      dateFormat: 'mdy',
+      resolveImageUrl: (source) => `reflect-asset://${source}`,
+      resolveAssetOpenPath: (source) =>
+        source.startsWith('assets/') && !source.includes('..') ? source : null,
+      ...overrides,
+    }),
+  )
+  return result.current
+}
+
+describe('useWikiLinkHoverPreview', () => {
+  beforeEach(() => {
+    mocks.resolveExistingWikiTarget.mockReset()
+    mocks.readExistingNoteSource.mockReset()
+    mocks.markdownPreview.mockReset()
+  })
+
+  it('resolves null without touching the graph when no graph session is open', async () => {
+    const renderBody = setupRenderer({ generation: null, graphKey: null })
+
+    await expect(renderBody(hoverHit('Alpha'))).resolves.toBeNull()
+    expect(mocks.resolveExistingWikiTarget).not.toHaveBeenCalled()
+  })
+
+  it('resolves null for missing, ambiguous, and unavailable targets without reading', async () => {
+    for (const resolution of [
+      { kind: 'missing' },
+      { kind: 'ambiguous', paths: ['notes/a.md', 'notes/b.md'] },
+      { kind: 'unavailable', paths: ['notes/a.md'] },
+    ]) {
+      mocks.resolveExistingWikiTarget.mockResolvedValueOnce(resolution)
+      const renderBody = setupRenderer()
+      await expect(renderBody(hoverHit('Target'))).resolves.toBeNull()
+    }
+    expect(mocks.readExistingNoteSource).not.toHaveBeenCalled()
+  })
+
+  it('resolves null instead of rejecting when resolution or the read fails', async () => {
+    const renderBody = setupRenderer()
+
+    mocks.resolveExistingWikiTarget.mockRejectedValueOnce(new Error('index gone'))
+    await expect(renderBody(hoverHit('Alpha'))).resolves.toBeNull()
+
+    mocks.resolveExistingWikiTarget.mockResolvedValueOnce({
+      kind: 'resolved',
+      path: 'notes/alpha.md',
+    })
+    mocks.readExistingNoteSource.mockRejectedValueOnce({ kind: 'notFound', message: 'gone' })
+    await expect(renderBody(hoverHit('Alpha'))).resolves.toBeNull()
+  })
+
+  it('renders a passive frontmatter-free body for a resolved target', async () => {
+    mocks.resolveExistingWikiTarget.mockResolvedValue({
+      kind: 'resolved',
+      path: 'notes/alpha.md',
+    })
+    mocks.readExistingNoteSource.mockResolvedValue('---\nprivate: true\n---\n# Alpha\n\nBody')
+    const renderBody = setupRenderer()
+
+    render(<>{await renderBody(hoverHit('Alpha'))}</>)
+
+    expect(screen.getByTestId('markdown-preview').textContent).toBe('# Alpha\n\nBody')
+    expect(mocks.markdownPreview.mock.calls.at(-1)?.[0]).toMatchObject({
+      content: '# Alpha\n\nBody',
+      interactive: false,
+    })
+    expect(mocks.resolveExistingWikiTarget).toHaveBeenCalledWith('Alpha', 7)
+    expect(mocks.readExistingNoteSource).toHaveBeenCalledWith('notes/alpha.md', 7)
+  })
+
+  it('serves only local sniffable raster images to the preview', async () => {
+    mocks.resolveExistingWikiTarget.mockResolvedValue({
+      kind: 'resolved',
+      path: 'notes/alpha.md',
+    })
+    mocks.readExistingNoteSource.mockResolvedValue('# Alpha')
+    const renderBody = setupRenderer()
+
+    render(<>{await renderBody(hoverHit('Alpha'))}</>)
+
+    const props = mocks.markdownPreview.mock.calls.at(-1)?.[0] as MarkdownPreviewProps
+    expect(props.resolveImageUrl('https://example.com/cat.png')).toBeNull()
+    expect(props.resolveImageUrl('assets/../secret.png')).toBeNull()
+    expect(props.resolveImageUrl('assets/vector.svg')).toBeNull()
+    expect(props.resolveImageUrl('assets/cat.png')).toBe(
+      'reflect-asset://assets/cat.png?reflect-preview=raster',
+    )
+  })
+
+  it('shows a formatted subject and Empty note for an empty daily note', async () => {
+    mocks.resolveExistingWikiTarget.mockResolvedValue({
+      kind: 'resolved',
+      path: 'daily/2026-06-09.md',
+    })
+    mocks.readExistingNoteSource.mockResolvedValue('---\nid: day\n---\n\n')
+    const renderBody = setupRenderer()
+
+    render(<>{await renderBody(hoverHit('2026-06-09'))}</>)
+
+    expect(screen.getByText('Tue, June 9th, 2026')).not.toBeNull()
+    expect(screen.getByText('Empty note')).not.toBeNull()
+    expect(mocks.markdownPreview).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/editor/use-wiki-link-hover-preview.tsx
+++ b/apps/desktop/src/editor/use-wiki-link-hover-preview.tsx
@@ -1,0 +1,80 @@
+import { useCallback, type ReactNode } from 'react'
+import type { WikilinkHoverHit } from '@meowdown/core'
+import { resolveExistingWikiTarget, splitFrontmatter, type DateFormat } from '@reflect/core'
+import { WikiLinkHoverPreview } from '@/components/wiki-link-hover-preview'
+import { readExistingNoteSource } from '@/lib/read-existing-note-source'
+
+interface WikiLinkHoverPreviewOptions {
+  generation: number | null
+  graphKey: string | null
+  dateFormat: DateFormat
+  resolveImageUrl: (src: string) => string | null
+  resolveAssetOpenPath: (src: string) => string | null
+}
+
+function isSvgAsset(path: string): boolean {
+  return path.toLowerCase().endsWith('.svg')
+}
+
+function previewRasterUrl(url: string): string {
+  const separator = url.includes('?') ? '&' : '?'
+  return `${url}${separator}reflect-preview=raster`
+}
+
+/**
+ * Build the async body resolver for Meowdown's editor-scoped wiki-link hover
+ * card. The whole preview is decided inside the returned promise: an existing
+ * target resolves to a passive snapshot body; missing, ambiguous, unavailable,
+ * and failed targets resolve to `null`, which renders no card. Failures are
+ * swallowed into `null` rather than rejected: transient read errors (an iCloud
+ * eviction, a graph switch) are expected and should not log as errors.
+ */
+export function useWikiLinkHoverPreview({
+  generation,
+  graphKey,
+  dateFormat,
+  resolveImageUrl,
+  resolveAssetOpenPath,
+}: WikiLinkHoverPreviewOptions): (hit: WikilinkHoverHit) => Promise<ReactNode> {
+  const resolvePreviewImageUrl = useCallback(
+    (source: string): string | null => {
+      const assetPath = resolveAssetOpenPath(source)
+      // SVG can contain external subresource references. The filename check
+      // avoids an unnecessary request; the query also makes the asset protocol
+      // enforce a sniffed raster MIME allowlist, so renamed SVG bytes cannot
+      // bypass the passive card's no-network boundary.
+      if (assetPath === null || isSvgAsset(assetPath)) {
+        return null
+      }
+      const url = resolveImageUrl(assetPath)
+      return url === null ? null : previewRasterUrl(url)
+    },
+    [resolveAssetOpenPath, resolveImageUrl],
+  )
+
+  return useCallback(
+    async ({ target }: WikilinkHoverHit): Promise<ReactNode> => {
+      if (generation === null || graphKey === null) {
+        return null
+      }
+      try {
+        const resolution = await resolveExistingWikiTarget(target, generation)
+        if (resolution.kind !== 'resolved') {
+          return null
+        }
+        const source = await readExistingNoteSource(resolution.path, generation)
+        return (
+          <WikiLinkHoverPreview
+            path={resolution.path}
+            markdown={splitFrontmatter(source).body}
+            dateFormat={dateFormat}
+            resolveImageUrl={resolvePreviewImageUrl}
+          />
+        )
+      } catch {
+        return null
+      }
+    },
+    [dateFormat, generation, graphKey, resolvePreviewImageUrl],
+  )
+}

--- a/apps/desktop/src/editor/use-wiki-link-navigation.test.tsx
+++ b/apps/desktop/src/editor/use-wiki-link-navigation.test.tsx
@@ -5,6 +5,7 @@ import { RouterProvider, useRouter } from '@/routing/router'
 import { useWikiLinkNavigation } from './use-wiki-link-navigation'
 
 const resolveWikiTarget = vi.hoisted(() => vi.fn())
+const resolveExistingWikiTarget = vi.hoisted(() => vi.fn())
 const resolveOrCreateNoteWithTitle = vi.hoisted(() => vi.fn())
 const openRouteInNewWindow = vi.hoisted(() => vi.fn<() => Promise<boolean>>())
 const operationFail = vi.hoisted(() => vi.fn())
@@ -12,6 +13,7 @@ const startOperation = vi.hoisted(() => vi.fn(() => ({ fail: operationFail })))
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   resolveWikiTarget,
+  resolveExistingWikiTarget,
   resolveOrCreateNoteWithTitle,
 }))
 vi.mock('@/lib/windows/open-in-new-window', async (importOriginal) => ({
@@ -53,6 +55,7 @@ function currentRoute(view: ReturnType<typeof renderHost>): string {
 
 beforeEach(() => {
   resolveWikiTarget.mockReset()
+  resolveExistingWikiTarget.mockReset()
   resolveOrCreateNoteWithTitle.mockReset()
   openRouteInNewWindow.mockReset()
   openRouteInNewWindow.mockResolvedValue(true)
@@ -89,24 +92,74 @@ describe('useWikiLinkNavigation', () => {
   })
 
   it('treats an unresolved ISO date as a daily target, without a focus intent', async () => {
-    resolveWikiTarget.mockResolvedValue({ kind: 'unresolved', text: '2026-06-09' })
+    resolveExistingWikiTarget.mockResolvedValue({ kind: 'missing' })
     const view = renderHost()
     lastHandler?.('2026-06-09')
     await waitFor(() => expect(currentRoute(view)).toContain('"daily"'))
     expect(currentRoute(view)).toContain('2026-06-09')
     expect(view.getByTestId('route').getAttribute('data-focus')).toBe('false')
     expect(resolveOrCreateNoteWithTitle).not.toHaveBeenCalled()
+    expect(resolveExistingWikiTarget).toHaveBeenCalledWith('2026-06-09', 1)
+    expect(resolveWikiTarget).not.toHaveBeenCalled()
     view.unmount()
   })
 
   it('preserves an existing regular note titled as an ISO date', async () => {
-    resolveWikiTarget.mockResolvedValue({ kind: 'resolved', ref: 'notes/2026-06-09.md' })
+    resolveExistingWikiTarget.mockResolvedValue({
+      kind: 'resolved',
+      path: 'notes/2026-06-09.md',
+    })
     const view = renderHost()
 
     lastHandler?.('2026-06-09')
 
     await waitFor(() => expect(currentRoute(view)).toContain('"note"'))
     expect(currentRoute(view)).toContain('notes/2026-06-09.md')
+    view.unmount()
+  })
+
+  it('retains read-only index resolution for ISO dates without a graph generation', async () => {
+    resolveWikiTarget.mockResolvedValue({ kind: 'resolved', ref: 'notes/2026-06-09.md' })
+    const view = renderHost(null)
+
+    lastHandler?.('2026-06-09')
+
+    await waitFor(() => expect(currentRoute(view)).toContain('notes/2026-06-09.md'))
+    expect(resolveWikiTarget).toHaveBeenCalledWith('2026-06-09')
+    expect(resolveExistingWikiTarget).not.toHaveBeenCalled()
+    view.unmount()
+  })
+
+  it('does not choose between ambiguous ISO-date targets', async () => {
+    resolveExistingWikiTarget.mockResolvedValue({
+      kind: 'ambiguous',
+      paths: ['daily/2026-06-09.md', 'daily/2026-06-09-2.md'],
+    })
+    const view = renderHost()
+
+    lastHandler?.('2026-06-09')
+
+    await waitFor(() => expect(operationFail).toHaveBeenCalled())
+    expect(currentRoute(view)).toContain('"today"')
+    expect(resolveOrCreateNoteWithTitle).not.toHaveBeenCalled()
+    view.unmount()
+  })
+
+  it('does not turn an unavailable ISO-date target into a lazy daily route', async () => {
+    resolveExistingWikiTarget.mockResolvedValue({
+      kind: 'unavailable',
+      paths: ['daily/2026-06-09.md'],
+    })
+    const view = renderHost()
+
+    lastHandler?.('2026-06-09')
+
+    await waitFor(() =>
+      expect(operationFail).toHaveBeenCalledWith(
+        expect.stringContaining('currently unavailable'),
+      ),
+    )
+    expect(currentRoute(view)).toContain('"today"')
     view.unmount()
   })
 
@@ -200,6 +253,25 @@ describe('useWikiLinkNavigation', () => {
     expect(operationFail).toHaveBeenCalledWith(
       'Couldn’t safely choose one note matching “Business ideas”. Rename conflicting notes or wait for unavailable notes to become available, then try again.',
     )
+    view.unmount()
+  })
+
+  it('does not navigate or create when a matching title is unavailable', async () => {
+    resolveOrCreateNoteWithTitle.mockResolvedValue({
+      kind: 'unavailable',
+      paths: ['notes/business-ideas.md'],
+    })
+    const view = renderHost(7)
+
+    lastHandler?.('Business ideas')
+
+    await waitFor(() =>
+      expect(operationFail).toHaveBeenCalledWith(
+        expect.stringContaining('currently unavailable'),
+      ),
+    )
+    expect(currentRoute(view)).toContain('"today"')
+    expect(resolveWikiTarget).not.toHaveBeenCalled()
     view.unmount()
   })
 

--- a/apps/desktop/src/editor/use-wiki-link-navigation.ts
+++ b/apps/desktop/src/editor/use-wiki-link-navigation.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import {
   errorMessage,
   normalizeWikiTarget,
+  resolveExistingWikiTarget,
   resolveOrCreateNoteWithTitle,
   resolveWikiTarget,
 } from '@reflect/core'
@@ -10,6 +11,12 @@ import { useNoteLinkNavigation } from '@/hooks/use-note-link-navigation'
 import { startOperation } from '@/lib/operations'
 import { useLinkIntentGuard } from '@/lib/windows/use-link-intent-guard'
 import { routeForPath, type NoteRoute } from '@/routing/route'
+
+function reportUnavailableNoteTitle(title: string): void {
+  startOperation('Opening link').fail(
+    `Couldn’t open “${title}” because a matching note is currently unavailable. Try again when it is available on this device.`,
+  )
+}
 
 /**
  * Navigation for a clicked `[[wiki link]]`. Calendar-valid ISO dates preserve
@@ -55,15 +62,32 @@ export function useWikiLinkNavigation(
             return
           }
           if (normalized.date !== undefined) {
-            const resolution = await resolveWikiTarget(normalized.raw)
+            if (generation === null) {
+              const resolution = await resolveWikiTarget(normalized.raw)
+              if (isStale()) {
+                return
+              }
+              open(
+                resolution.kind === 'resolved'
+                  ? routeForPath(resolution.ref)
+                  : { kind: 'daily', date: normalized.date },
+              )
+              return
+            }
+
+            const resolution = await resolveExistingWikiTarget(normalized.raw, generation)
             if (isStale()) {
               return
             }
-            open(
-              resolution.kind === 'resolved'
-                ? routeForPath(resolution.ref)
-                : { kind: 'daily', date: normalized.date },
-            )
+            if (resolution.kind === 'resolved') {
+              open(routeForPath(resolution.path))
+            } else if (resolution.kind === 'missing') {
+              open({ kind: 'daily', date: normalized.date })
+            } else if (resolution.kind === 'ambiguous') {
+              reportAmbiguousNoteTitle('Opening link', normalized.raw)
+            } else {
+              reportUnavailableNoteTitle(normalized.raw)
+            }
             return
           }
           if (generation !== null) {
@@ -73,6 +97,8 @@ export function useWikiLinkNavigation(
             }
             if (outcome.kind === 'ambiguous') {
               reportAmbiguousNoteTitle('Opening link', normalized.raw)
+            } else if (outcome.kind === 'unavailable') {
+              reportUnavailableNoteTitle(normalized.raw)
             } else {
               open(routeForPath(outcome.path))
             }

--- a/apps/desktop/src/lib/read-existing-note-source.test.ts
+++ b/apps/desktop/src/lib/read-existing-note-source.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { readNote } from '@reflect/core'
+import { openSession } from '@/editor/open-documents'
+import { readExistingNoteSource } from './read-existing-note-source'
+
+vi.mock('@reflect/core', () => ({
+  readNote: vi.fn(),
+}))
+
+vi.mock('@/editor/open-documents', () => ({
+  openSession: vi.fn(),
+}))
+
+const readNoteMock = vi.mocked(readNote)
+const openSessionMock = vi.mocked(openSession)
+
+describe('readExistingNoteSource', () => {
+  beforeEach(() => {
+    readNoteMock.mockReset()
+    openSessionMock.mockReset().mockReturnValue(null)
+  })
+
+  it('reads the live buffer of an open, ready session', async () => {
+    openSessionMock.mockReturnValue({ liveContent: () => '# Live' } as never)
+    readNoteMock.mockResolvedValue('# On disk')
+
+    await expect(readExistingNoteSource('notes/a.md', 7)).resolves.toBe('# Live')
+    expect(readNoteMock).toHaveBeenCalledWith('notes/a.md', 7)
+  })
+
+  it('preserves an authoritative empty live buffer', async () => {
+    openSessionMock.mockReturnValue({ liveContent: () => '' } as never)
+    readNoteMock.mockResolvedValue('# On disk')
+
+    await expect(readExistingNoteSource('notes/a.md', 7)).resolves.toBe('')
+    expect(readNoteMock).toHaveBeenCalledWith('notes/a.md', 7)
+  })
+
+  it('refuses a stale live buffer when its generation-pinned file is gone', async () => {
+    openSessionMock.mockReturnValue({ liveContent: () => '# Stale' } as never)
+    readNoteMock.mockRejectedValue({ kind: 'notFound', message: 'removed' })
+
+    await expect(readExistingNoteSource('notes/a.md', 7)).rejects.toMatchObject({
+      kind: 'notFound',
+    })
+  })
+
+  it('falls back to a generation-pinned disk read while the session is loading', async () => {
+    openSessionMock.mockReturnValue({ liveContent: () => null } as never)
+    readNoteMock.mockResolvedValue('# On disk')
+
+    await expect(readExistingNoteSource('notes/a.md', 7)).resolves.toBe('# On disk')
+    expect(readNoteMock).toHaveBeenCalledWith('notes/a.md', 7)
+  })
+})

--- a/apps/desktop/src/lib/read-existing-note-source.ts
+++ b/apps/desktop/src/lib/read-existing-note-source.ts
@@ -1,0 +1,29 @@
+import { readNote } from '@reflect/core'
+import { openSession } from '@/editor/open-documents'
+
+/**
+ * Read an existing note without disturbing its editor session.
+ *
+ * An open session's live buffer is newer than disk and can be read without
+ * reconciling pending native input (unlike `NoteEditorHandle.getMarkdown`). A
+ * closed note falls back to a generation-pinned read so a graph switch cannot
+ * return content from the newly active graph.
+ */
+export async function readExistingNoteSource(
+  path: string,
+  generation: number,
+): Promise<string> {
+  const session = openSession(path)
+  if (session !== null) {
+    const liveContent = session.liveContent()
+    if (liveContent !== null) {
+      // The index and open-document registry can briefly outlive an external
+      // delete or iCloud eviction. Prove the generation-pinned file is still
+      // locally readable before publishing a live buffer; the already-mounted
+      // watcher guards changes that race this read.
+      await readNote(path, generation)
+      return liveContent
+    }
+  }
+  return readNote(path, generation)
+}

--- a/docs/contributing/editor-architecture.md
+++ b/docs/contributing/editor-architecture.md
@@ -13,6 +13,7 @@ NotePane / DailyStream / MobileNote     components — composition only
   │    └─ createNoteSession()           pure document state machine (note-session.ts)
   │         └─ readNote / writeNote     @reflect/core typed commands
   ├─ useWikiLinkNavigation()            [[link]] click → route / create
+  ├─ useWikiLinkHoverPreview()          [[link]] hover → passive local preview
   ├─ useImagePersistence()              paste/drop → assets/ write
   └─ <NoteEditor>                       meowdown + our extensions (note-editor.tsx)
 ```
@@ -136,6 +137,8 @@ editor work must survive pane teardown. The pieces to understand are:
 | `wiki-links.ts` | `[[…]]` chips as view decorations over literal text |
 | `wiki-autocomplete.tsx` / `-entries.ts` | `[[` popover; pure row assembly |
 | `use-wiki-link-navigation.ts` | chip click → resolve → navigate or create |
+| `use-wiki-link-hover-preview.tsx` | desktop chip hover → side-effect-free local preview renderer |
+| `read-existing-note-source.ts` | live open-session content, else generation-pinned disk read |
 | `images.ts` / `use-image-persistence.ts` | image widgets; paste/drop → `assets/` |
 | `keymap.ts` | central shortcut registry (rejects duplicate bindings) |
 

--- a/docs/porting/README.md
+++ b/docs/porting/README.md
@@ -41,7 +41,7 @@ designs simply don't survive the move:
 | Doc                                                                 | v1 feature               | v2 status                                        |
 | ------------------------------------------------------------------- | ------------------------ | ------------------------------------------------ |
 | [Note aliases](./note-aliases.md)                                   | `//` title aliases       | **Ported** (frontmatter `aliases`) — mapping doc |
-| [Backlink hover previews](./backlink-hover-previews.md)             | Wiki-link preview        | Planned — Meowdown hover UI + local loader       |
+| [Backlink hover previews](./backlink-hover-previews.md)             | Wiki-link preview        | **Ported** (passive local desktop card)          |
 | [Audio memos](./audio-memos.md)                                     | Voice notes + transcript | **Ported** (BYOK transcription) — mapping doc    |
 | [AI menu and prompts](./ai-menu-and-prompts.md)                     | Selection AI + prompts   | Planned — needs meowdown + app work              |
 | [Note templates](./note-templates.md)                               | Per-graph templates      | Planned — markdown files in the graph            |

--- a/docs/porting/backlink-hover-previews.md
+++ b/docs/porting/backlink-hover-previews.md
@@ -1,9 +1,9 @@
 # Porting backlink hover previews
 
-**Status: planned.** Reflect v1 showed a compact preview when the pointer
-rested on an inline backlink. V2 already has local note resolution, reads, and
-read-only markdown rendering, but Meowdown does not yet expose the wiki-link
-hover UI needed to join them.
+**Status: ported.** Resting the pointer on a wiki link in a primary desktop
+note pane now opens a compact, passive preview of the existing local target.
+Meowdown owns the editor hover lifecycle and overlay; Reflect owns
+side-effect-free resolution, generation-pinned reads, and local-only content.
 
 This is separate from both the `[[` autocomplete menu documented in
 [Reflect v1: Backlink Menu & Date Generator](../reflect-v1-backlink-menu.md)
@@ -86,7 +86,7 @@ being edited. Preserve that value while adopting v2's boundaries:
 Do not add a mobile long-press as part of this work. A touch preview gesture
 would need its own interaction design.
 
-## Recommended v2 shape
+## Implemented v2 shape
 
 The split follows [Editor architecture](../contributing/editor-architecture.md),
 [Plan 05](../plans/05-markdown-editor.md), and the porting convention that
@@ -196,16 +196,28 @@ changing the guarantees in [Privacy](../privacy.md).
   optimize later with a markdown-aware preview projection if needed, never by
   cutting raw markdown mid-token.
 
-## UX decisions to make before implementation
+## Implementation decisions
 
-- **Timing:** v1 opened immediately; Meowdown's Markdown-link menu currently
-  uses a 400ms open delay and 300ms close grace. Choose deliberately and test
-  rapid pointer travel.
-- **Interactivity:** the v1 book markup contained a real external anchor, but
-  leaving the source link initiated dismissal with no close grace. Decide
-  whether a later v2 card can be entered or scrolled; keep the first port
-  passive.
-- **Viewport:** v1 clipped at `350 × 200px`. Preserve that compact baseline or
-  choose a tokenized max size and fade.
-- **Unavailable state:** decide whether missing, ambiguous, empty, and failed
-  targets show nothing or a small explicit state. None may trigger creation.
+- **Timing:** a target-aware 300ms dwell avoids flashes while the pointer
+  crosses prose. Reflect resolves the body asynchronously, so the card opens
+  once both the dwell and the local read have finished. Moving to another
+  wiki link switches without a new dwell and keeps the previous body until
+  the next one is ready; leaving closes after a 200ms grace.
+- **Interactivity:** the card is pointer-transparent and inert. Its links,
+  checkboxes, images, and embeds cannot navigate, mutate content, take focus,
+  or trigger remote loads.
+- **Viewport:** Meowdown owns the card chrome and its compact clipped
+  surface (`320 × 192px` with an 8px collision margin); Reflect renders only
+  the content inside it.
+- **Unavailable state:** missing, ambiguous, locally unavailable, deleted, and
+  failed targets resolve the body to nothing, so no card ever opens for them.
+  A successfully read note with an empty body shows `Empty note`; daily notes
+  keep their separately formatted date heading.
+- **Freshness:** the body is a snapshot read when the hover begins. Deleting
+  or rewriting the hovered link inside the editor closes the card through
+  Meowdown's transaction-aware hover tracking; external file changes during
+  the few seconds a card is open are not tracked.
+- **Resolution:** the shared existing-target resolver has a distinct
+  `unavailable` outcome in addition to resolved / ambiguous / missing. This
+  prevents hover or navigation from treating a placeholder or transient read
+  failure as permission to create a duplicate note.

--- a/packages/core/src/actions/backlink-target.test.ts
+++ b/packages/core/src/actions/backlink-target.test.ts
@@ -73,6 +73,16 @@ describe('ensureBacklinkTarget', () => {
     expect(readNoteMock).toHaveBeenCalledWith('notes/links-2.md', 3)
   })
 
+  it('keeps the requested spelling when a matching note is unavailable', async () => {
+    resolveOrCreateMock.mockResolvedValue({
+      kind: 'unavailable',
+      paths: ['notes/links.md'],
+    })
+
+    await expect(ensureBacklinkTarget('Links', 3)).resolves.toBe('Links')
+    expect(readNoteMock).not.toHaveBeenCalled()
+  })
+
   it('rejects an impossible ambiguous result without any target paths', async () => {
     resolveOrCreateMock.mockResolvedValue({ kind: 'ambiguous', paths: [] })
 

--- a/packages/core/src/actions/backlink-target.ts
+++ b/packages/core/src/actions/backlink-target.ts
@@ -8,12 +8,17 @@ import { parseNote } from '../markdown/extract'
  * Resolve the note targeted by an automatic backlink, or create it safely.
  * Existing duplicates use the same sorted-first winner as read-only wiki-link
  * resolution. That ambiguity must not block durable capture, and no new note
- * is created in that case. Returns a link-safe current title so renames keep
- * one section; an unsafe title falls back to the requested spelling that just
- * resolved as its alias.
+ * is created in that case. An unavailable match (an iCloud placeholder or a
+ * failed read) must not block capture either: the requested spelling is kept
+ * unchanged and resolves once the note is readable on this device. Returns a
+ * link-safe current title so renames keep one section; an unsafe title falls
+ * back to the requested spelling that just resolved as its alias.
  */
 export async function ensureBacklinkTarget(title: string, generation: number): Promise<string> {
   const outcome = await resolveOrCreateNoteWithTitle(title, generation)
+  if (outcome.kind === 'unavailable') {
+    return title
+  }
   const path =
     outcome.kind === 'ambiguous' ? [...outcome.paths].sort().at(0) : outcome.path
   if (path === undefined) {

--- a/packages/core/src/exports/platform.ts
+++ b/packages/core/src/exports/platform.ts
@@ -145,6 +145,10 @@ export {
   type ResolveOrCreateNoteResult,
 } from '../graph/create-note'
 export {
+  resolveExistingWikiTarget,
+  type ExistingWikiTargetResolution,
+} from '../graph/resolve-existing-wiki-target'
+export {
   settingsSchema,
   editorMarkdownSyntaxSchema,
   editorSpellCheckSchema,

--- a/packages/core/src/graph/create-note.test.ts
+++ b/packages/core/src/graph/create-note.test.ts
@@ -188,6 +188,22 @@ describe('resolveOrCreateNoteWithTitle', () => {
     ).toBe(false)
   })
 
+  it('reuses an unindexed daily file instead of creating a regular date-titled note', async () => {
+    const invoke = bindBridge({
+      files: { 'daily/2026-06-09.md': 'Daily contents\n' },
+    })
+
+    await expect(resolveOrCreateNoteWithTitle('2026-06-09', 7)).resolves.toEqual({
+      kind: 'resolved',
+      path: 'daily/2026-06-09.md',
+    })
+    expect(invoke).toHaveBeenCalledWith('note_read', {
+      path: 'daily/2026-06-09.md',
+      generation: 7,
+    })
+    expect(invoke.mock.calls.some(([command]) => command === 'note_create')).toBe(false)
+  })
+
   it('refuses multiple indexed notes claiming the same exact title', async () => {
     const invoke = bindBridge({
       query: (sql, params) =>
@@ -342,7 +358,7 @@ describe('resolveOrCreateNoteWithTitle', () => {
     expect(invoke.mock.calls.some(([command]) => command === 'note_create')).toBe(false)
   })
 
-  it('blocks creation when the fallback is ambiguous or unreadable', async () => {
+  it('reports an unavailable slug-family member instead of mislabeling it ambiguous', async () => {
     const invoke = bindBridge({
       files: {
         'notes/business-ideas.md': '# 🧠 Business ideas\n',
@@ -352,12 +368,8 @@ describe('resolveOrCreateNoteWithTitle', () => {
     })
 
     await expect(resolveOrCreateNoteWithTitle('Business ideas', 7)).resolves.toEqual({
-      kind: 'ambiguous',
-      paths: [
-        'notes/business-ideas-2.md',
-        'notes/business-ideas-3.md',
-        'notes/business-ideas.md',
-      ],
+      kind: 'unavailable',
+      paths: ['notes/business-ideas-3.md'],
     })
     expect(invoke.mock.calls.some(([command]) => command === 'note_create')).toBe(false)
   })
@@ -378,8 +390,8 @@ describe('resolveOrCreateNoteWithTitle', () => {
     })
 
     await expect(resolveOrCreateNoteWithTitle('Business ideas', 7)).resolves.toEqual({
-      kind: 'ambiguous',
-      paths: ['notes/business-ideas-2.md', 'notes/business-ideas.md'],
+      kind: 'unavailable',
+      paths: ['notes/business-ideas-2.md'],
     })
     expect(invoke.mock.calls.some(([command]) => command === 'note_create')).toBe(false)
   })

--- a/packages/core/src/graph/create-note.ts
+++ b/packages/core/src/graph/create-note.ts
@@ -1,12 +1,12 @@
 import { ulid } from 'ulidx'
-import { findExactWikiTargetMatches } from '../indexing/queries'
-import { foldFallbackTitleKey, foldKey } from '../markdown/keys'
-import { parseNote } from '../markdown/extract'
 import { upsertFrontmatter } from '../markdown/frontmatter'
 import { slugForTitle } from '../markdown/slug'
-import { subjectAliases } from '../markdown/subject-aliases'
-import { createNoteIfAbsent, listFiles, readNote } from './commands'
-import { notePath, NOTES_DIR } from './paths'
+import { createNoteIfAbsent } from './commands'
+import { notePath } from './paths'
+import {
+  resolveExistingWikiTarget,
+  type ExistingWikiTargetResolution,
+} from './resolve-existing-wiki-target'
 
 /**
  * Note identity at creation (`docs/readable-filenames.md`): regular notes get
@@ -89,8 +89,9 @@ export type ResolveOrCreateNoteResult =
   | { readonly kind: 'resolved'; readonly path: string }
   | { readonly kind: 'created'; readonly path: string }
   | { readonly kind: 'ambiguous'; readonly paths: readonly string[] }
+  | { readonly kind: 'unavailable'; readonly paths: readonly string[] }
 
-type ExistingTitleResolution = Exclude<ResolveOrCreateNoteResult, { kind: 'created' }>
+type ExistingTitleResolution = Exclude<ExistingWikiTargetResolution, { kind: 'missing' }>
 
 /**
  * Claim the first free path in `slug`'s collision family (`slug.md`, then
@@ -130,192 +131,30 @@ async function claimNotePathForSlug(
   throw new Error(`no available note path for slug "${slug}" after ${MAX_CREATE_ATTEMPTS} attempts`)
 }
 
-interface DiskTitleMatch {
-  exactTitlePaths: string[]
-  exactAliasPaths: string[]
-  fallbackTitlePaths: string[]
-  fallbackAliasPaths: string[]
-  unreadablePaths: string[]
-}
-
-/**
- * Does `path` belong to the collision family for `slug` (`slug.md`,
- * `slug-2.md`, ...)? Limiting the fallback scan to this family keeps the
- * second-chance lookup cheap and avoids turning link navigation into a fuzzy
- * graph-wide title search.
- */
-function isSlugFamilyPath(path: string, slug: string): boolean {
-  // Derived from the same contract `notePath` builds with, so a directory
-  // rename can't silently turn the disk guard into an always-empty scan.
-  const prefix = `${NOTES_DIR}/`
-  const suffix = '.md'
-  if (!path.startsWith(prefix) || !path.endsWith(suffix)) {
-    return false
-  }
-  const stem = path.slice(prefix.length, -suffix.length)
-  if (stem === slug) {
-    return true
-  }
-  if (!stem.startsWith(`${slug}-`)) {
-    return false
-  }
-  return /^\d+$/.test(stem.slice(slug.length + 1))
-}
-
-/**
- * Inspect the title-derived filename family directly on disk. The index can
- * briefly lag a sync checkout; disk is therefore the final authority before a
- * missing-link click is allowed to mint a suffixed note.
- */
-async function matchTitleOnDisk(title: string, generation: number): Promise<DiskTitleMatch> {
-  const slug = slugForTitle(title)
-  const candidates = (await listFiles(generation))
-    .filter((file) => isSlugFamilyPath(file.path, slug))
-    .sort((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0))
-  const targetKey = foldKey(title)
-  const fallbackKey = foldFallbackTitleKey(title)
-  const exactTitlePaths: string[] = []
-  const exactAliasPaths: string[] = []
-  const fallbackTitlePaths: string[] = []
-  const fallbackAliasPaths: string[] = []
-  const unreadablePaths: string[] = []
-
-  for (const candidate of candidates) {
-    if (candidate.placeholder === true) {
-      unreadablePaths.push(candidate.path)
-      continue
-    }
-    let source: string
-    try {
-      source = await readNote(candidate.path, generation)
-    } catch {
-      // A disappearing or temporarily unreadable collision cannot be proven
-      // distinct. Blocking creation is safer than silently minting `-2`.
-      unreadablePaths.push(candidate.path)
-      continue
-    }
-    const parsed = parseNote({ path: candidate.path, source })
-    const aliases = [...parsed.frontmatter.aliases, ...subjectAliases(parsed.title)]
-    if (foldKey(parsed.title) === targetKey) {
-      exactTitlePaths.push(candidate.path)
-      continue
-    }
-    if (aliases.some((alias) => foldKey(alias) === targetKey)) {
-      exactAliasPaths.push(candidate.path)
-      continue
-    }
-    if (fallbackKey !== '' && foldFallbackTitleKey(parsed.title) === fallbackKey) {
-      fallbackTitlePaths.push(candidate.path)
-      continue
-    }
-    if (
-      fallbackKey !== '' &&
-      aliases.some((alias) => foldFallbackTitleKey(alias) === fallbackKey)
-    ) {
-      fallbackAliasPaths.push(candidate.path)
-    }
-  }
-
-  return {
-    exactTitlePaths,
-    exactAliasPaths,
-    fallbackTitlePaths,
-    fallbackAliasPaths,
-    unreadablePaths,
-  }
-}
-
-function resolutionForPaths(paths: readonly string[]): ExistingTitleResolution | null {
-  if (paths.length === 1) {
-    return { kind: 'resolved', path: paths[0]! }
-  }
-  if (paths.length > 1) {
-    return { kind: 'ambiguous', paths: [...paths].sort() }
-  }
-  return null
-}
-
-async function indexedTargetResolution(
-  title: string,
-): Promise<ExistingTitleResolution | null> {
-  const match = await findExactWikiTargetMatches(title)
-  return resolutionForPaths(match.paths)
-}
-
-function diskTitleResolution(disk: DiskTitleMatch): ExistingTitleResolution | null {
-  // An unreadable candidate could claim any higher-precedence spelling. Do
-  // not choose a readable sibling until the whole collision family is known.
-  if (disk.unreadablePaths.length > 0) {
-    return {
-      kind: 'ambiguous',
-      paths: [
-        ...new Set([
-          ...disk.exactTitlePaths,
-          ...disk.exactAliasPaths,
-          ...disk.fallbackTitlePaths,
-          ...disk.fallbackAliasPaths,
-          ...disk.unreadablePaths,
-        ]),
-      ].sort(),
-    }
-  }
-
-  // Mirror indexed wiki resolution: an exact title outranks an exact alias.
-  // Only after both exact tiers miss do the conservative fallback tiers run,
-  // again preferring a title to an alias.
-  for (const paths of [
-    disk.exactTitlePaths,
-    disk.exactAliasPaths,
-    disk.fallbackTitlePaths,
-    disk.fallbackAliasPaths,
-  ]) {
-    const resolution = resolutionForPaths(paths)
-    if (resolution !== null) {
-      return resolution
-    }
-  }
-  return null
-}
-
 /**
  * Resolve a wiki-link title while guarding its title-derived creation path
  * against a stale per-device index.
  *
- * A unique exact index match wins; multiple indexed claims are ambiguous. On
- * a miss, the title's on-disk slug family is parsed with the same precedence
- * (title before alias), then the conservative leading-emoji fallback. A tier is
- * accepted only when exactly one file claims it; multiple or unreadable
- * candidates are ambiguous and no file is written. The index is queried once
- * more immediately before creation. The native path claim is atomic and
- * no-clobber; if it loses to a concurrent sync checkout or creator, the winner
- * is resolved before trying a suffix.
+ * Delegates the read-only decision to {@link resolveExistingWikiTarget}, so
+ * date/title/alias precedence, ambiguity, unavailable files, the bounded disk
+ * fallback, and the final index race check have one implementation. Only a
+ * genuine `missing` result reaches the atomic no-clobber claim. If that claim
+ * loses to a concurrent sync checkout or creator, the winner is resolved
+ * before any suffix is tried.
  */
 export async function resolveOrCreateNoteWithTitle(
   title: string,
   generation: number,
 ): Promise<ResolveOrCreateNoteResult> {
-  const indexed = await indexedTargetResolution(title)
-  if (indexed !== null) {
-    return indexed
-  }
-
-  const diskResolution = diskTitleResolution(await matchTitleOnDisk(title, generation))
-  if (diskResolution !== null) {
-    return diskResolution
-  }
-
-  const reResolved = await indexedTargetResolution(title)
-  if (reResolved !== null) {
-    return reResolved
+  const existing = await resolveExistingWikiTarget(title, generation)
+  if (existing.kind !== 'missing') {
+    return existing
   }
 
   // On a lost claim, re-resolve both projections before considering a
   // suffix: the winner may be the note this link meant.
   return claimNotePathForSlug(slugForTitle(title), newNoteSource(title), generation, async () => {
-    const collisionIndex = await indexedTargetResolution(title)
-    if (collisionIndex !== null) {
-      return collisionIndex
-    }
-    return diskTitleResolution(await matchTitleOnDisk(title, generation))
+    const collisionResolution = await resolveExistingWikiTarget(title, generation)
+    return collisionResolution.kind === 'missing' ? null : collisionResolution
   })
 }

--- a/packages/core/src/graph/resolve-existing-wiki-target.test.ts
+++ b/packages/core/src/graph/resolve-existing-wiki-target.test.ts
@@ -1,0 +1,336 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { setBridge } from '../ipc/bridge'
+import { resolveExistingWikiTarget } from './resolve-existing-wiki-target'
+
+interface BridgeBehavior {
+  readonly files?: Record<string, string>
+  readonly placeholders?: readonly string[]
+  readonly readErrors?: readonly string[]
+  readonly query?: (sql: string, params: readonly unknown[]) => Array<Record<string, unknown>>
+  readonly read?: (path: string) => Promise<string>
+}
+
+function bindBridge({
+  files = {},
+  placeholders = [],
+  readErrors = [],
+  query,
+  read,
+}: BridgeBehavior = {}): ReturnType<typeof vi.fn> {
+  const invoke = vi.fn(async (command: string, args?: Record<string, unknown>) => {
+    if (command === 'db_query') {
+      const params = args?.['params']
+      return query?.(
+        String(args?.['sql'] ?? ''),
+        Array.isArray(params) ? params : [],
+      ) ?? []
+    }
+    if (command === 'list_files') {
+      return [
+        ...Object.entries(files).map(([path, source]) => ({
+          path,
+          size: source.length,
+          modifiedMs: 1,
+        })),
+        ...placeholders.map((path) => ({
+          path,
+          size: 0,
+          modifiedMs: 1,
+          placeholder: true,
+        })),
+        ...readErrors.map((path) => ({ path, size: 1, modifiedMs: 1 })),
+      ]
+    }
+    if (command === 'note_read') {
+      const path = String(args?.['path'])
+      if (read !== undefined) {
+        return await read(path)
+      }
+      if (readErrors.includes(path)) {
+        throw { kind: 'io', message: `${path} is unavailable` }
+      }
+      const source = files[path]
+      if (source === undefined) {
+        throw { kind: 'notFound', message: `${path} not found` }
+      }
+      return source
+    }
+    return null
+  })
+  setBridge({ invoke, listen: async () => () => {} })
+  return invoke
+}
+
+function expectNoWrites(invoke: ReturnType<typeof vi.fn>): void {
+  expect(
+    invoke.mock.calls.some(([command]) =>
+      ['note_create', 'note_write', 'note_delete', 'index_apply_batch'].includes(String(command)),
+    ),
+  ).toBe(false)
+}
+
+afterEach(() => {
+  setBridge(null)
+})
+
+describe('resolveExistingWikiTarget', () => {
+  it('returns missing for a blank target without touching the graph', async () => {
+    const invoke = bindBridge()
+
+    await expect(resolveExistingWikiTarget('   ', 7)).resolves.toEqual({ kind: 'missing' })
+    expect(invoke).not.toHaveBeenCalled()
+  })
+
+  it('preserves ambiguity in the winning indexed tier', async () => {
+    const invoke = bindBridge({
+      query: (sql) =>
+        sql.includes('from "aliases"')
+          ? [
+              { note_path: 'notes/second.md' },
+              { note_path: 'notes/first.md' },
+            ]
+          : [],
+    })
+
+    await expect(resolveExistingWikiTarget('Project', 7)).resolves.toEqual({
+      kind: 'ambiguous',
+      paths: ['notes/first.md', 'notes/second.md'],
+    })
+    expectNoWrites(invoke)
+  })
+
+  it('resolves one indexed title without probing disk', async () => {
+    const invoke = bindBridge({
+      query: (sql) =>
+        sql.includes('"title_key" = ?') ? [{ path: 'notes/project.md' }] : [],
+    })
+
+    await expect(resolveExistingWikiTarget('Project', 7)).resolves.toEqual({
+      kind: 'resolved',
+      path: 'notes/project.md',
+    })
+    expect(invoke.mock.calls.some(([command]) => command === 'note_read')).toBe(false)
+    expect(invoke.mock.calls.some(([command]) => command === 'list_files')).toBe(false)
+    expectNoWrites(invoke)
+  })
+
+  it('resolves one indexed alias after the title tier misses', async () => {
+    const invoke = bindBridge({
+      query: (sql) =>
+        sql.includes('from "aliases"') ? [{ note_path: 'notes/project.md' }] : [],
+    })
+
+    await expect(resolveExistingWikiTarget('Initiative', 7)).resolves.toEqual({
+      kind: 'resolved',
+      path: 'notes/project.md',
+    })
+    expect(invoke.mock.calls.some(([command]) => command === 'note_read')).toBe(false)
+    expect(invoke.mock.calls.some(([command]) => command === 'list_files')).toBe(false)
+    expectNoWrites(invoke)
+  })
+
+  it('accepts an indexed daily before probing disk or lower index tiers', async () => {
+    const invoke = bindBridge({
+      query: (sql) =>
+        sql.includes('"daily_date" = ?') ? [{ path: 'daily/2026-06-09.md' }] : [],
+    })
+
+    await expect(resolveExistingWikiTarget('2026-06-09', 7)).resolves.toEqual({
+      kind: 'resolved',
+      path: 'daily/2026-06-09.md',
+    })
+    expect(invoke.mock.calls.some(([command]) => command === 'note_read')).toBe(false)
+    expect(invoke.mock.calls.some(([command]) => command === 'list_files')).toBe(false)
+    expectNoWrites(invoke)
+  })
+
+  it('lets an index-lagging daily file outrank an indexed regular date title', async () => {
+    const invoke = bindBridge({
+      files: { 'daily/2026-06-09.md': 'Daily contents\n' },
+      query: (sql) =>
+        sql.includes('"title_key" = ?') ? [{ path: 'notes/date-title.md' }] : [],
+    })
+
+    await expect(resolveExistingWikiTarget('2026-06-09', 17)).resolves.toEqual({
+      kind: 'resolved',
+      path: 'daily/2026-06-09.md',
+    })
+    expect(invoke).toHaveBeenCalledWith('note_read', {
+      path: 'daily/2026-06-09.md',
+      generation: 17,
+    })
+    expectNoWrites(invoke)
+  })
+
+  it('accepts an indexed regular date title only after the daily path is missing', async () => {
+    const invoke = bindBridge({
+      query: (sql) =>
+        sql.includes('"title_key" = ?') ? [{ path: 'notes/date-title.md' }] : [],
+    })
+
+    await expect(resolveExistingWikiTarget('2026-06-09', 7)).resolves.toEqual({
+      kind: 'resolved',
+      path: 'notes/date-title.md',
+    })
+    expect(invoke).toHaveBeenCalledWith('note_read', {
+      path: 'daily/2026-06-09.md',
+      generation: 7,
+    })
+    expectNoWrites(invoke)
+  })
+
+  it('reports an unreadable daily file as unavailable instead of accepting a lower tier', async () => {
+    const invoke = bindBridge({
+      query: (sql) =>
+        sql.includes('"title_key" = ?') ? [{ path: 'notes/date-title.md' }] : [],
+      read: async () => {
+        throw { kind: 'io', message: 'evicted' }
+      },
+    })
+
+    await expect(resolveExistingWikiTarget('2026-06-09', 7)).resolves.toEqual({
+      kind: 'unavailable',
+      paths: ['daily/2026-06-09.md'],
+    })
+    expectNoWrites(invoke)
+  })
+
+  it('reports an evicted daily placeholder as unavailable instead of missing', async () => {
+    const invoke = bindBridge({
+      placeholders: ['daily/2026-06-09.md'],
+      query: (sql) =>
+        sql.includes('"title_key" = ?') ? [{ path: 'notes/date-title.md' }] : [],
+    })
+
+    await expect(resolveExistingWikiTarget('2026-06-09', 7)).resolves.toEqual({
+      kind: 'unavailable',
+      paths: ['daily/2026-06-09.md'],
+    })
+    expect(invoke).toHaveBeenCalledWith('list_files', { generation: 7 })
+    expectNoWrites(invoke)
+  })
+
+  it('resolves an index-lagging note from the bounded slug-family scan', async () => {
+    const invoke = bindBridge({
+      files: {
+        'notes/business-ideas.md': '# Business ideas\n',
+        'notes/unrelated.md': '# Unrelated\n',
+      },
+    })
+
+    await expect(resolveExistingWikiTarget('Business ideas', 23)).resolves.toEqual({
+      kind: 'resolved',
+      path: 'notes/business-ideas.md',
+    })
+    expect(invoke).toHaveBeenCalledWith('list_files', { generation: 23 })
+    expect(invoke).toHaveBeenCalledWith('note_read', {
+      path: 'notes/business-ideas.md',
+      generation: 23,
+    })
+    expect(invoke).not.toHaveBeenCalledWith('note_read', {
+      path: 'notes/unrelated.md',
+      generation: 23,
+    })
+    expectNoWrites(invoke)
+  })
+
+  it.each([
+    {
+      label: 'iCloud placeholder',
+      behavior: { placeholders: ['notes/business-ideas.md'] },
+    },
+    {
+      label: 'read failure',
+      behavior: { readErrors: ['notes/business-ideas.md'] },
+    },
+  ])('reports a slug-family $label as unavailable', async ({ behavior }) => {
+    const invoke = bindBridge(behavior)
+
+    await expect(resolveExistingWikiTarget('Business ideas', 7)).resolves.toEqual({
+      kind: 'unavailable',
+      paths: ['notes/business-ideas.md'],
+    })
+    expectNoWrites(invoke)
+  })
+
+  it('keeps a listed-then-deleted slug-family candidate unavailable', async () => {
+    const invoke = bindBridge({
+      readErrors: ['notes/business-ideas.md'],
+      read: async () => {
+        throw { kind: 'notFound', message: 'vanished after listing' }
+      },
+    })
+
+    await expect(resolveExistingWikiTarget('Business ideas', 7)).resolves.toEqual({
+      kind: 'unavailable',
+      paths: ['notes/business-ideas.md'],
+    })
+    expectNoWrites(invoke)
+  })
+
+  it('does not globally scan for an unindexed alias outside the target slug family', async () => {
+    const invoke = bindBridge({
+      files: {
+        'notes/incubator.md': '---\naliases: [Business ideas]\n---\n# Incubator\n',
+      },
+    })
+
+    await expect(resolveExistingWikiTarget('Business ideas', 7)).resolves.toEqual({
+      kind: 'missing',
+    })
+    expect(invoke.mock.calls.some(([command]) => command === 'note_read')).toBe(false)
+    expectNoWrites(invoke)
+  })
+
+  it('rechecks the index after a disk miss to close the indexing race', async () => {
+    let titleLookups = 0
+    const invoke = bindBridge({
+      query: (sql) => {
+        if (!sql.includes('"title_key" = ?')) {
+          return []
+        }
+        titleLookups += 1
+        return titleLookups === 2 ? [{ path: 'notes/newly-indexed.md' }] : []
+      },
+    })
+
+    await expect(resolveExistingWikiTarget('Newly indexed', 7)).resolves.toEqual({
+      kind: 'resolved',
+      path: 'notes/newly-indexed.md',
+    })
+    expect(titleLookups).toBe(2)
+    expectNoWrites(invoke)
+  })
+
+  it('repeats the daily-path probe after a disk miss', async () => {
+    let dailyReads = 0
+    const invoke = bindBridge({
+      read: async (path) => {
+        if (path !== 'daily/2026-06-09.md') {
+          throw { kind: 'notFound', message: 'missing' }
+        }
+        dailyReads += 1
+        if (dailyReads === 1) {
+          throw { kind: 'notFound', message: 'not synced yet' }
+        }
+        return 'Arrived during resolution\n'
+      },
+    })
+
+    await expect(resolveExistingWikiTarget('2026-06-09', 7)).resolves.toEqual({
+      kind: 'resolved',
+      path: 'daily/2026-06-09.md',
+    })
+    expect(dailyReads).toBe(2)
+    expectNoWrites(invoke)
+  })
+
+  it('returns missing after both index checks and the disk fallback miss without writing', async () => {
+    const invoke = bindBridge()
+
+    await expect(resolveExistingWikiTarget('Absent', 7)).resolves.toEqual({ kind: 'missing' })
+    expect(invoke.mock.calls.filter(([command]) => command === 'db_query').length).toBeGreaterThan(1)
+    expect(invoke).toHaveBeenCalledWith('list_files', { generation: 7 })
+    expectNoWrites(invoke)
+  })
+})

--- a/packages/core/src/graph/resolve-existing-wiki-target.ts
+++ b/packages/core/src/graph/resolve-existing-wiki-target.ts
@@ -1,0 +1,240 @@
+import { isAppError } from '../errors'
+import {
+  findExactWikiTargetMatches,
+  type ExactWikiTargetMatch,
+} from '../indexing/queries'
+import { foldFallbackTitleKey, foldKey } from '../markdown/keys'
+import { parseNote } from '../markdown/extract'
+import { normalizeWikiTarget } from '../markdown/resolve'
+import { slugForTitle } from '../markdown/slug'
+import { subjectAliases } from '../markdown/subject-aliases'
+import { listFiles, readNote } from './commands'
+import { dailyPath, NOTES_DIR } from './paths'
+
+/** The side-effect-free outcome of resolving one existing wiki-link target. */
+export type ExistingWikiTargetResolution =
+  | { readonly kind: 'resolved'; readonly path: string }
+  | { readonly kind: 'ambiguous'; readonly paths: readonly string[] }
+  | { readonly kind: 'unavailable'; readonly paths: readonly string[] }
+  | { readonly kind: 'missing' }
+
+type ExistingMatchResolution = Exclude<ExistingWikiTargetResolution, { kind: 'missing' }>
+
+interface DiskTitleMatch {
+  readonly exactTitlePaths: readonly string[]
+  readonly exactAliasPaths: readonly string[]
+  readonly fallbackTitlePaths: readonly string[]
+  readonly fallbackAliasPaths: readonly string[]
+  readonly unavailablePaths: readonly string[]
+}
+
+type ListNoteFiles = () => ReturnType<typeof listFiles>
+
+function resolutionForPaths(paths: readonly string[]): ExistingMatchResolution | null {
+  if (paths.length === 1) {
+    return { kind: 'resolved', path: paths[0]! }
+  }
+  if (paths.length > 1) {
+    return { kind: 'ambiguous', paths: [...paths].sort() }
+  }
+  return null
+}
+
+/** Does `path` belong to `slug.md`, `slug-2.md`, ... under `notes/`? */
+function isSlugFamilyPath(path: string, slug: string): boolean {
+  const prefix = `${NOTES_DIR}/`
+  const suffix = '.md'
+  if (!path.startsWith(prefix) || !path.endsWith(suffix)) {
+    return false
+  }
+  const stem = path.slice(prefix.length, -suffix.length)
+  if (stem === slug) {
+    return true
+  }
+  if (!stem.startsWith(`${slug}-`)) {
+    return false
+  }
+  return /^\d+$/.test(stem.slice(slug.length + 1))
+}
+
+/**
+ * Inspect only the target's title-derived filename family. This deliberately
+ * is not a graph-wide alias scan: link resolution must remain bounded even
+ * when the index is rebuilding.
+ */
+async function matchTitleOnDisk(
+  title: string,
+  generation: number,
+  listNoteFiles: ListNoteFiles,
+): Promise<DiskTitleMatch> {
+  const slug = slugForTitle(title)
+  const candidates = (await listNoteFiles())
+    .filter((file) => isSlugFamilyPath(file.path, slug))
+    .sort((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0))
+  const targetKey = foldKey(title)
+  const fallbackKey = foldFallbackTitleKey(title)
+  const exactTitlePaths: string[] = []
+  const exactAliasPaths: string[] = []
+  const fallbackTitlePaths: string[] = []
+  const fallbackAliasPaths: string[] = []
+  const unavailablePaths: string[] = []
+
+  for (const candidate of candidates) {
+    if (candidate.placeholder === true) {
+      unavailablePaths.push(candidate.path)
+      continue
+    }
+    let source: string
+    try {
+      source = await readNote(candidate.path, generation)
+    } catch {
+      // A candidate that vanishes after listing is not proven absent: sync
+      // may restore it before an atomic claim. Preserve the creation guard.
+      unavailablePaths.push(candidate.path)
+      continue
+    }
+    const parsed = parseNote({ path: candidate.path, source })
+    const aliases = [...parsed.frontmatter.aliases, ...subjectAliases(parsed.title)]
+    if (foldKey(parsed.title) === targetKey) {
+      exactTitlePaths.push(candidate.path)
+      continue
+    }
+    if (aliases.some((alias) => foldKey(alias) === targetKey)) {
+      exactAliasPaths.push(candidate.path)
+      continue
+    }
+    if (fallbackKey !== '' && foldFallbackTitleKey(parsed.title) === fallbackKey) {
+      fallbackTitlePaths.push(candidate.path)
+      continue
+    }
+    if (
+      fallbackKey !== '' &&
+      aliases.some((alias) => foldFallbackTitleKey(alias) === fallbackKey)
+    ) {
+      fallbackAliasPaths.push(candidate.path)
+    }
+  }
+
+  return {
+    exactTitlePaths,
+    exactAliasPaths,
+    fallbackTitlePaths,
+    fallbackAliasPaths,
+    unavailablePaths,
+  }
+}
+
+function diskTitleResolution(disk: DiskTitleMatch): ExistingMatchResolution | null {
+  // An unavailable family member might claim any precedence tier, so no
+  // readable sibling is safe to choose until every candidate can be read.
+  if (disk.unavailablePaths.length > 0) {
+    return { kind: 'unavailable', paths: [...disk.unavailablePaths].sort() }
+  }
+
+  for (const paths of [
+    disk.exactTitlePaths,
+    disk.exactAliasPaths,
+    disk.fallbackTitlePaths,
+    disk.fallbackAliasPaths,
+  ]) {
+    const resolution = resolutionForPaths(paths)
+    if (resolution !== null) {
+      return resolution
+    }
+  }
+  return null
+}
+
+async function dailyFileResolution(
+  date: string,
+  generation: number,
+  listNoteFiles: ListNoteFiles,
+): Promise<ExistingMatchResolution | null> {
+  const path = dailyPath(date)
+  try {
+    await readNote(path, generation)
+    return { kind: 'resolved', path }
+  } catch (cause) {
+    if (isAppError(cause) && cause.kind === 'notFound') {
+      // An iCloud-evicted daily exists only as `.date.md.icloud`, so reading
+      // its logical path reports notFound. The generation-pinned listing maps
+      // that stub back to `path` with `placeholder: true`; it is unavailable,
+      // not permission to enter the lazy-create path.
+      const listed = (await listNoteFiles()).some((file) => file.path === path)
+      return listed ? { kind: 'unavailable', paths: [path] } : null
+    }
+    return { kind: 'unavailable', paths: [path] }
+  }
+}
+
+/**
+ * Apply index precedence while letting an index-lagging daily file outrank an
+ * indexed regular title or alias with the same ISO date spelling.
+ */
+async function indexedResolution(
+  match: ExactWikiTargetMatch,
+  date: string | undefined,
+  generation: number,
+  listNoteFiles: ListNoteFiles,
+): Promise<ExistingMatchResolution | null> {
+  if (match.kind === 'date') {
+    return resolutionForPaths(match.paths)
+  }
+  if (date !== undefined) {
+    const daily = await dailyFileResolution(date, generation, listNoteFiles)
+    if (daily !== null) {
+      return daily
+    }
+  }
+  return match.kind === 'missing' ? null : resolutionForPaths(match.paths)
+}
+
+/**
+ * Resolve an existing wiki target without creating or modifying anything.
+ *
+ * The index supplies date/title/alias precedence and preserves ambiguity. A
+ * generation-pinned disk probe fills two intentional index-lag gaps: a daily
+ * file is checked before a lower indexed tier, and an index miss scans only
+ * the regular note's slug family. A final index lookup closes the common race
+ * where indexing completes during the disk scan. An alias stored outside its
+ * title's slug family therefore remains missing until the index sees it.
+ */
+export async function resolveExistingWikiTarget(
+  target: string,
+  generation: number,
+): Promise<ExistingWikiTargetResolution> {
+  const normalized = normalizeWikiTarget(target)
+  if (normalized.key === '') {
+    return { kind: 'missing' }
+  }
+  let listedFiles: ReturnType<typeof listFiles> | null = null
+  function listNoteFiles(): ReturnType<typeof listFiles> {
+    listedFiles ??= listFiles(generation)
+    return listedFiles
+  }
+
+  const indexed = await indexedResolution(
+    await findExactWikiTargetMatches(normalized.raw),
+    normalized.date,
+    generation,
+    listNoteFiles,
+  )
+  if (indexed !== null) {
+    return indexed
+  }
+
+  const disk = diskTitleResolution(
+    await matchTitleOnDisk(normalized.raw, generation, listNoteFiles),
+  )
+  if (disk !== null) {
+    return disk
+  }
+
+  const reResolved = await indexedResolution(
+    await findExactWikiTargetMatches(normalized.raw),
+    normalized.date,
+    generation,
+    listNoteFiles,
+  )
+  return reResolved ?? { kind: 'missing' }
+}


### PR DESCRIPTION
Resting the pointer on a wiki link in a desktop note pane now shows a passive, local-only preview of the existing target, built on meowdown 0.46's async `WikilinkHoverCard` and a new side-effect-free `resolveExistingWikiTarget` resolver whose `unavailable` outcome also stops navigation, autocomplete, and capture from minting duplicate notes for iCloud placeholders or transient read failures.

Supersedes #756.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added desktop hover previews for wiki links, including note content, daily-note dates, empty-note messaging, and safe local images.
  * Hover previews are passive and unavailable on touch editor surfaces.
* **Bug Fixes**
  * Improved wiki-link resolution to distinguish missing, ambiguous, and temporarily unavailable notes.
  * Prevented duplicate note creation when an existing note cannot currently be read.
  * Improved handling of daily-note links and index synchronization.
  * Restricted preview image requests to supported raster formats for safer rendering.
* **Documentation**
  * Updated editor architecture and porting documentation to reflect hover preview support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->