### PR TITLE
fix(mobile): show task context grouping

### DIFF
--- a/apps/desktop/src/components/tasks/task-breadcrumbs.tsx
+++ b/apps/desktop/src/components/tasks/task-breadcrumbs.tsx
@@ -6,6 +6,7 @@ interface TaskBreadcrumbsProps {
   breadcrumbs: readonly string[]
   /** Select every task row sharing this outline context; omit on read-only surfaces. */
   onSelect?: () => void
+  /** Additional classes applied to the wrapper list item. */
   className?: string
 }
 

--- a/apps/desktop/src/components/tasks/task-breadcrumbs.tsx
+++ b/apps/desktop/src/components/tasks/task-breadcrumbs.tsx
@@ -1,16 +1,19 @@
 import type { ReactElement } from 'react'
+import { cn } from '@/lib/utils'
 
 interface TaskBreadcrumbsProps {
   /** The context's display labels ({@link TaskContext.visibleBreadcrumbs}); empty renders nothing. */
   breadcrumbs: readonly string[]
-  /** Select every task row sharing this outline context. */
-  onSelect: () => void
+  /** Select every task row sharing this outline context; omit on read-only surfaces. */
+  onSelect?: () => void
+  className?: string
 }
 
 /** One V1-style outline-context row above the consecutive tasks it labels. */
 export function TaskBreadcrumbs({
   breadcrumbs,
   onSelect,
+  className,
 }: TaskBreadcrumbsProps): ReactElement | null {
   if (breadcrumbs.length === 0) {
     return null
@@ -18,15 +21,24 @@ export function TaskBreadcrumbs({
   const label = breadcrumbs.join(' → ')
 
   return (
-    <li className="min-w-0 px-4 pt-1.5 lg:px-12">
-      <button
-        type="button"
-        title={label}
-        onClick={onSelect}
-        className="block max-w-full truncate text-left text-xs leading-5 text-text-muted transition-colors hover:text-text focus-visible:text-text focus-visible:outline-none"
-      >
-        {label}
-      </button>
+    <li className={cn('min-w-0 px-4 pt-1.5 lg:px-12', className)}>
+      {onSelect === undefined ? (
+        <span
+          title={label}
+          className="block max-w-full truncate text-left text-xs leading-5 text-text-muted"
+        >
+          {label}
+        </span>
+      ) : (
+        <button
+          type="button"
+          title={label}
+          onClick={onSelect}
+          className="block max-w-full truncate text-left text-xs leading-5 text-text-muted transition-colors hover:text-text focus-visible:text-text focus-visible:outline-none"
+        >
+          {label}
+        </button>
+      )}
     </li>
   )
 }

--- a/apps/desktop/src/mobile/screens/tasks.test.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.test.tsx
@@ -252,6 +252,32 @@ describe('MobileTasks', () => {
     view.unmount()
   })
 
+  it('renders one read-only breadcrumb per consecutive task context', async () => {
+    getOpenTasks.mockResolvedValue([
+      task({ markerOffset: 2, text: 'first', breadcrumbs: ['Project', 'Release'] }),
+      task({ markerOffset: 20, text: 'second', breadcrumbs: ['Project', 'Release'] }),
+      task({ markerOffset: 40, text: 'third', breadcrumbs: ['Project', 'Later'] }),
+      task({ markerOffset: 60, text: 'fourth', breadcrumbs: ['Project', 'Release'] }),
+    ])
+    const view = renderScreen()
+
+    expect(await view.findAllByText('Project → Release')).toHaveLength(2)
+    expect(view.getAllByText('Project → Later')).toHaveLength(1)
+    expect(view.queryByRole('button', { name: 'Project → Release' })).toBeNull()
+    view.unmount()
+  })
+
+  it('hides a lone generic task breadcrumb', async () => {
+    getOpenTasks.mockResolvedValue([
+      task({ markerOffset: 2, text: 'project task', breadcrumbs: ['Tasks:'] }),
+    ])
+    const view = renderScreen()
+
+    await view.findByText('project task')
+    expect(view.queryByText('Tasks:')).toBeNull()
+    view.unmount()
+  })
+
   it('toggles a task from its checkbox and keeps it struck until archived', async () => {
     getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
     const user = userEvent.setup()

--- a/apps/desktop/src/mobile/task-group.tsx
+++ b/apps/desktop/src/mobile/task-group.tsx
@@ -1,6 +1,7 @@
-import { type ReactElement } from 'react'
+import { Fragment, type ReactElement } from 'react'
 import { Plus } from 'lucide-react'
-import type { OpenTask, TaskGroup } from '@reflect/core'
+import { groupTaskContexts, type OpenTask, type TaskGroup } from '@reflect/core'
+import { TaskBreadcrumbs } from '@/components/tasks/task-breadcrumbs'
 import { addTargetForGroup, taskGroupHeaderStyle } from '@/lib/tasks/task-group-presentation'
 import { taskKey } from '@/lib/tasks/task-identity'
 import type { InsertTaskTarget } from '@/lib/tasks/task-insert-target'
@@ -25,7 +26,8 @@ interface MobileTaskGroupProps {
  * bucket (Current/Overdue/Upcoming) or a note — with a task count (V1 mobile
  * showed counts on its groups) over the rows. A note group's header opens the
  * note; Current and note groups grow a "+" that adds a task there and opens
- * its quick-edit sheet.
+ * its quick-edit sheet. Consecutive tasks sharing an outline context render
+ * under the same read-only breadcrumb row, matching desktop's grouping.
  */
 export function MobileTaskGroup({
   group,
@@ -38,6 +40,7 @@ export function MobileTaskGroup({
   const { notePath } = group
   const { icon, colorClass } = taskGroupHeaderStyle(group)
   const addTarget = addTargetForGroup(group, today)
+  const contexts = groupTaskContexts(group.tasks)
 
   return (
     <section>
@@ -76,8 +79,21 @@ export function MobileTaskGroup({
         ) : null}
       </div>
       <ul className="flex flex-col">
-        {group.tasks.map((task) => (
-          <MobileTaskRow key={taskKey(task)} task={task} showSource={showSource} onEdit={onEdit} />
+        {contexts.map((context) => (
+          <Fragment key={taskKey(context.tasks[0]!)}>
+            <TaskBreadcrumbs
+              breadcrumbs={context.visibleBreadcrumbs}
+              className="px-4 pb-1 pt-3"
+            />
+            {context.tasks.map((task) => (
+              <MobileTaskRow
+                key={taskKey(task)}
+                task={task}
+                showSource={showSource}
+                onEdit={onEdit}
+              />
+            ))}
+          </Fragment>
         ))}
       </ul>
     </section>

--- a/docs/plans/18-tasks.md
+++ b/docs/plans/18-tasks.md
@@ -71,8 +71,9 @@ markers in markdown, AI task extraction (later, over this projection), CLI
   derived projection data: `tasks.breadcrumbs` holds one JSON string array written
   and read only through `encodeTaskBreadcrumbs`/`decodeTaskBreadcrumbs` (mirrored by
   `write.rs`). Task search matches task text, note title, and breadcrumb labels.
-  Clicking a desktop breadcrumb selects exactly the rows it labels; mobile shares the
-  data and search but intentionally renders no context row.
+  Both desktop and mobile render the same context runs. Clicking a desktop breadcrumb
+  selects exactly the rows it labels; mobile renders the breadcrumb as a read-only
+  grouping label because its Tasks tab has no multi-select mode.
 - **Write-back is surgical and guarded.** Toggling from the Tasks view replaces
   exactly the three-character marker (`[ ]` ↔ `[x]`) at the indexed position **only
   if** the surrounding item text still matches what the index recorded. On mismatch


### PR DESCRIPTION
## Problem

The mobile Tasks tab already shared desktop's top-level Current / Overdue / Upcoming / note buckets, but it rendered every task row flat inside those buckets. Tasks nested under outline parents therefore lost the `Parent → Child` context rows shown on desktop.

| Before | After |
| --- | --- |
| Mobile rendered tasks without their outline context | Mobile renders one context label above each consecutive run, matching desktop |
| Repeated adjacent contexts had no visual grouping | Adjacent matching contexts share one label; a later repeated context gets its own label |

## Changes

1. Reuse `groupTaskContexts` in `MobileTaskGroup`, including the shared visible-breadcrumb rules.
2. Let `TaskBreadcrumbs` render a read-only label when no desktop selection callback is supplied; desktop's clickable multi-select behavior is unchanged.
3. Cover consecutive grouping, split contexts, read-only mobile semantics, and generic `Tasks` label suppression.
4. Update the Tasks plan to document parity between desktop and mobile.

## Verification

- `pnpm --filter @reflect/desktop exec vitest run src/mobile/screens/tasks.test.tsx` — 33 tests passed.
- `pnpm --filter @reflect/core exec vitest run src/indexing/group-tasks.test.ts` — 16 tests passed.
- Broader desktop Vitest run — 217 files / 1,956 tests passed.
- `pnpm check` — typecheck and lint passed (the two existing max-file-length warnings remain).
- Mobile browser preview at 390×844 — verified grouped context labels, unchanged task counts, and no render error overlay.

## Risk / Rollout

Presentation-only change with no data migration or rollout step. It reuses the same grouping and generic-label suppression code as desktop; the intentional mobile difference is that context labels remain read-only because mobile has no multi-select mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only UI reuse of existing grouping helpers; no data, write-back, or auth changes.
> 
> **Overview**
> Mobile task lists now show **outline context labels** (`Parent → Child`) above consecutive runs of tasks, matching desktop grouping instead of a flat list inside each bucket.
> 
> `MobileTaskGroup` uses shared **`groupTaskContexts`** and **`TaskBreadcrumbs`**. **`TaskBreadcrumbs`** gains optional **`onSelect`** (desktop multi-select unchanged) and **`className`**; without **`onSelect`**, the label is a **read-only** `<span>` instead of a button.
> 
> Tests cover consecutive/split contexts, read-only semantics, and hiding lone generic **`Tasks:`** labels. The Tasks plan doc notes desktop/mobile parity on context rows, with mobile labels non-clickable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab32829ee56e99626800087285a41154102cd977. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile task lists now group tasks by context and display read-only breadcrumb labels.
  * Breadcrumbs support read-only display and customizable styling.
* **Bug Fixes**
  * Hidden generic “Tasks” labels when they are the only breadcrumb shown.
* **Documentation**
  * Updated task breadcrumb behavior to reflect consistent desktop and mobile experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->