### PR TITLE
fix: polish the backlink hover preview card design

### DIFF
--- a/apps/desktop/src/components/wiki-link-hover-preview.tsx
+++ b/apps/desktop/src/components/wiki-link-hover-preview.tsx
@@ -1,7 +1,8 @@
-import type { ReactElement } from 'react'
+import { useLayoutEffect, useState, type ReactElement } from 'react'
 import { dateFromDailyPath, type DateFormat } from '@reflect/core'
 import { MarkdownPreview } from '@/editor/markdown-preview'
 import { formatDayLabel } from '@/lib/dates'
+import { cn } from '@/lib/utils'
 
 interface WikiLinkHoverPreviewProps {
   path: string
@@ -12,9 +13,45 @@ interface WikiLinkHoverPreviewProps {
 }
 
 /**
+ * Whether the clamped preview box is taller than its content allows, so the
+ * bottom clip is real. Observed rather than computed once — image loads and
+ * font swaps change the content height after mount. The element lives in
+ * state (not a ref) so the observer attaches on mount and re-attaches if the
+ * node is replaced.
+ */
+function useOverflowing(): {
+  setRoot: (root: HTMLDivElement | null) => void
+  overflowing: boolean
+} {
+  const [root, setRoot] = useState<HTMLDivElement | null>(null)
+  const [overflowing, setOverflowing] = useState(false)
+
+  useLayoutEffect(() => {
+    if (root === null || typeof ResizeObserver === 'undefined') {
+      return
+    }
+    const update = (): void => {
+      setOverflowing(root.scrollHeight > root.clientHeight + 1)
+    }
+    update()
+    const observer = new ResizeObserver(update)
+    observer.observe(root)
+    for (const child of root.children) {
+      observer.observe(child)
+    }
+    return () => observer.disconnect()
+  }, [root])
+
+  return { setRoot, overflowing }
+}
+
+/**
  * Reflect's passive body for Meowdown's wiki-link hover card. Meowdown owns
  * the card chrome, sizing, and lifecycle; this renders only the content, from
- * a snapshot read at hover time.
+ * a snapshot read at hover time. The `reflect-hover-preview` class re-scales
+ * the editor type ramp to the card's compact size (styles/index.css), and a
+ * body taller than the card fades out at the bottom edge instead of clipping
+ * mid-line.
  */
 export function WikiLinkHoverPreview({
   path,
@@ -24,24 +61,32 @@ export function WikiLinkHoverPreview({
 }: WikiLinkHoverPreviewProps): ReactElement {
   const dailyDate = dateFromDailyPath(path)
   const empty = markdown.trim().length === 0
+  const { setRoot, overflowing } = useOverflowing()
 
   return (
-    <div className="p-3 text-xs text-popover-foreground" data-testid="wiki-link-hover-preview">
-      {dailyDate !== null ? (
-        <div className="reflect-daily-subject mb-2 text-base">
-          {formatDayLabel(dailyDate, dateFormat)}
-        </div>
-      ) : null}
-      {empty ? (
-        <p className="text-text-muted">Empty note</p>
-      ) : (
-        <MarkdownPreview
-          content={markdown}
-          resolveImageUrl={resolveImageUrl}
-          interactive={false}
-          className="text-xs leading-relaxed"
-        />
+    <div
+      ref={setRoot}
+      className={cn(
+        'reflect-hover-preview max-h-48 overflow-hidden px-3.5 py-3 text-xs text-popover-foreground',
+        overflowing && 'reflect-hover-preview-overflowing',
       )}
+      data-testid="wiki-link-hover-preview"
+    >
+      <div>
+        {dailyDate !== null ? (
+          <div className="reflect-daily-subject mb-1">{formatDayLabel(dailyDate, dateFormat)}</div>
+        ) : null}
+        {empty ? (
+          <p className="text-text-muted italic">Empty note</p>
+        ) : (
+          <MarkdownPreview
+            content={markdown}
+            resolveImageUrl={resolveImageUrl}
+            interactive={false}
+            className="text-xs leading-relaxed"
+          />
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -435,7 +435,9 @@ export function NoteEditor({
         <EditorInputTraits />
         <FormattingToolbarBridge />
         {renderWikilinkHoverCard !== undefined ? (
-          <WikilinkHoverCard>{renderWikilinkHoverCard}</WikilinkHoverCard>
+          <WikilinkHoverCard className="reflect-hover-card">
+            {renderWikilinkHoverCard}
+          </WikilinkHoverCard>
         ) : null}
         {children}
       </MeowdownEditor>

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -388,6 +388,55 @@ html:root {
   letter-spacing: var(--tracking-snug, -0.01em);
 }
 
+/* Chrome for meowdown's wiki-link hover card (its `className`, passed from
+   note-editor.tsx). Reflect popovers outline with `ring-foreground/10` —
+   stronger than the `--border` hairline meowdown defaults to, which vanishes
+   against the dark canvas — and float on the same DS shadow. Unlayered plain
+   CSS on purpose: the card's CSS-module defaults are unlayered too, so
+   layered Tailwind utilities could not override them. */
+.reflect-hover-card {
+  border-color: color-mix(in oklab, var(--foreground) 10%, transparent);
+  box-shadow: var(--shadow-md);
+}
+
+/* The wiki-link hover card's compact body (wiki-link-hover-preview.tsx).
+   Meowdown's card is a 20 × 12rem glimpse; the editor's display sizes (20px
+   H1, rem-sized checkboxes) overwhelm its 12px body text, so the type ramp
+   re-scales here: the subject one step above body, section headings at body
+   size carried by weight — the same hierarchy, compressed. Unlayered, so
+   these win over meowdown's `@layer meowdown` theme rules. */
+.reflect-hover-preview .reflect-editor h1,
+.reflect-hover-preview .reflect-daily-subject {
+  font-size: var(--text-sm, 0.875rem);
+}
+.reflect-hover-preview .reflect-editor h2,
+.reflect-hover-preview .reflect-editor h3 {
+  font-size: var(--text-xs, 0.75rem);
+}
+.reflect-hover-preview .reflect-editor h1,
+.reflect-hover-preview .reflect-editor h2,
+.reflect-hover-preview .reflect-editor h3 {
+  margin: 1em 0 0.35em;
+}
+.reflect-hover-preview .reflect-editor h1:first-child {
+  margin-top: 0;
+}
+.reflect-hover-preview .reflect-editor input[type='checkbox'] {
+  width: 0.75rem;
+  height: 0.75rem;
+}
+.reflect-hover-preview .reflect-editor img {
+  max-height: 7rem;
+  width: auto;
+  border-radius: var(--radius-sm, 0.25rem);
+}
+/* A body taller than the card fades out at the clipped edge instead of
+   slicing a line of text in half. Applied only while actually overflowing,
+   so a short note keeps its last line at full strength. */
+.reflect-hover-preview-overflowing {
+  mask-image: linear-gradient(to bottom, black calc(100% - 2.5rem), transparent);
+}
+
 /* NotePane's loading placeholder: hold the editor's reserved space silently,
    revealing the hint text only when a load is genuinely slow. Local note
    reads resolve in milliseconds, and "Loading note…" flashing on every


### PR DESCRIPTION
## Problem

The backlink hover preview shipped in #768 with Meowdown's default card chrome around an unadapted note body, and the result read as broken:

- The body renders at `text-xs` (12px), but `.reflect-editor`'s type ramp uses fixed display sizes — a 20px H1, 18px H2, rem-sized task checkboxes — so a previewed note showed a giant title and oversized controls crammed against tiny prose in a 20×12rem card.
- A note taller than the card was hard-clipped by the popup's `overflow: clip`, slicing the last visible line of text in half with no signal that content continues.
- In dark mode the card is `--surface` (#0b1020) on a `--surface-app` (#0a0f1e) canvas with a `--border` hairline at 6% white — the popup was nearly invisible.

Scope: content styling and card chrome only. Resolution, reads, privacy boundaries, and Meowdown's hover lifecycle are untouched.

## Before → After

| | Before | After |
| --- | --- | --- |
| Note title in card | 20px editor H1 | 14px, same 650 weight — one step above body |
| Section headings | 18px/16px | body size, carried by weight |
| Checkboxes | 0.95rem editor size | 0.75rem, scaled to the 12px line |
| Overflowing note | text sliced mid-line at the card edge | fades out over the last 2.5rem, only when actually overflowing |
| Dark-mode chrome | 6%-white hairline, invisible against the canvas | the app's popover `ring-foreground/10` convention + DS `--shadow-md` |
| Empty note | plain muted text | italic muted, matching the palette preview's `Empty` |

## Changes

1. **`wiki-link-hover-preview.tsx`** — the body root now carries a `reflect-hover-preview` class, clamps itself to the card's 12rem, and tracks real overflow with a `ResizeObserver` (`useOverflowing`): image loads and font swaps re-evaluate, and a short note keeps its last line at full strength while an overflowing one gets the bottom fade. Guarded for jsdom (no `ResizeObserver`), defaulting to no fade.
2. **`styles/index.css`** — a compact type ramp scoped under `.reflect-hover-preview`, unlayered so it wins over Meowdown's `@layer meowdown` theme rules: h1/daily-subject at `--text-sm`, h2/h3 at body size, tightened heading margins, 0.75rem checkboxes, images bounded to 7rem. Plus `.reflect-hover-card` chrome (ring-equivalent border color via `color-mix`, `--shadow-md`) — plain CSS on purpose, because the card's CSS-module defaults are unlayered and layered Tailwind utilities cannot override them.
3. **`note-editor.tsx`** — passes `className="reflect-hover-card"` to Meowdown's `WikilinkHoverCard` (the prop shipped in meowdown 0.46).

## Tests

Existing suites pin the behavior that matters here and still pass: `use-wiki-link-hover-preview.test.tsx` (passive body, frontmatter stripped, raster-only images, daily subject + `Empty note`) and `note-editor.test.tsx` (hover card wiring). The fade is visual and jsdom has no layout, so it's verified in-browser rather than unit-tested.

## Verification

- `pnpm vitest run src/editor/use-wiki-link-hover-preview.test.tsx src/editor/note-editor.test.tsx` — 42 passed.
- `pnpm check` — typecheck + lint clean (two pre-existing `max-lines` warnings in unrelated files).
- Drove the real `NoteEditor` + `WikilinkHoverCard` + preview body in a browser dev scaffold (temporary, not committed) and eyeballed light + dark: rich note with headings/tasks/quote, daily note, empty note, one-liner, and the overflow fade.

## Risk / Rollout

CSS + one prop; no data or IPC changes. The compact ramp is scoped under `.reflect-hover-preview`, so other `reflect-editor` surfaces (palette preview, backlink snippets, task rows) are unaffected. `color-mix` is long-supported in the shipped WebKit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS and one Meowdown `className`; no data, IPC, or hover-resolution behavior changes.
> 
> **Overview**
> Polishes the **wiki-link hover preview** so the compact card reads like other Reflect popovers and the note body fits the glimpse size.
> 
> **`WikiLinkHoverPreview`** clamps the body with `max-h-48`, adds `reflect-hover-preview` styling hooks, and uses a **`ResizeObserver`-based `useOverflowing` hook** so overflow is re-checked after images/fonts load; when content is taller than the box, **`reflect-hover-preview-overflowing`** applies a bottom fade instead of cutting text mid-line. Daily subject and empty-state copy are tweaked (spacing, italic empty label).
> 
> **`note-editor.tsx`** passes **`className="reflect-hover-card"`** to Meowdown’s `WikilinkHoverCard` for Reflect chrome.
> 
> **`index.css`** adds unlayered **`.reflect-hover-card`** (popover-like border via `color-mix`, `--shadow-md`) and **`.reflect-hover-preview`** rules that compress the editor type ramp (headings, checkboxes, image max-height) under the card’s 12px body text, scoped so other `reflect-editor` surfaces stay unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b7f2e2bbd2308c19b6ae901cbc0c8c4a040a379. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->