### PR TITLE
feat: add clear actions to mobile search fields

### DIFF
--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -660,6 +660,7 @@ describe('MobileShell', () => {
   })
 
   it('renders a search entry as the All tab with the query seeded', async () => {
+    const user = userEvent.setup()
     const view = mount({ kind: 'search', query: 'meeting' })
 
     const box = view.getByRole('searchbox', { name: 'Search notes' })
@@ -667,6 +668,11 @@ describe('MobileShell', () => {
       expect((box as HTMLInputElement).value).toBe('meeting')
     })
     expect(view.getByRole('button', { name: 'All' }).getAttribute('aria-current')).toBe('page')
+
+    await user.click(view.getByRole('button', { name: 'Clear search' }))
+
+    expect((box as HTMLInputElement).value).toBe('')
+    expect(view.queryByRole('button', { name: 'Clear search' })).toBeNull()
   })
 
   it('back from a cold note entry lands on today', async () => {

--- a/apps/desktop/src/mobile/screens/all-notes.tsx
+++ b/apps/desktop/src/mobile/screens/all-notes.tsx
@@ -145,7 +145,7 @@ export function MobileAllNotes({
             placeholder="Search anything…"
             aria-label="Search notes"
             value={query}
-            onChange={(event) => onQueryChange(event.target.value)}
+            onValueChange={onQueryChange}
           />
         </div>
         {pending !== null ? (

--- a/apps/desktop/src/mobile/screens/tasks.test.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.test.tsx
@@ -725,10 +725,17 @@ describe('MobileTasks', () => {
     const view = renderScreen()
 
     await view.findByText('buy milk')
-    await user.type(view.getByRole('searchbox', { name: 'Search tasks' }), 'milk')
+    const search = view.getByRole('searchbox', { name: 'Search tasks' })
+    await user.type(search, 'milk')
 
     await waitFor(() => expect(view.queryByText('call mum')).toBeNull())
     view.getByText('buy milk')
+
+    await user.click(view.getByRole('button', { name: 'Clear search' }))
+
+    expect((search as HTMLInputElement).value).toBe('')
+    expect(document.activeElement).toBe(search)
+    await view.findByText('call mum')
     view.unmount()
   })
 

--- a/apps/desktop/src/mobile/screens/tasks.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.tsx
@@ -149,7 +149,7 @@ export function MobileTasks(): ReactElement {
           placeholder="Search tasks…"
           aria-label="Search tasks"
           value={query}
-          onChange={(event) => setQuery(event.target.value)}
+          onValueChange={setQuery}
         />
         {recentlyCompleted.length > 0 ? (
           <Button

--- a/apps/desktop/src/mobile/search-filters/note-picker-drawer.tsx
+++ b/apps/desktop/src/mobile/search-filters/note-picker-drawer.tsx
@@ -3,8 +3,8 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { hasBridge, parseSearchQuery, searchWithFilters } from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
-import { Input } from '@/components/ui/input'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
+import { SearchInput } from '@/mobile/search-input'
 import { useGraph } from '@/providers/graph-provider'
 import type { NoteFilterRef } from './filter-state'
 
@@ -63,14 +63,11 @@ export function NotePickerDrawer({
     <Drawer open={open} onOpenChange={setOpen}>
       <DrawerContent>
         <DrawerTitle>{title}</DrawerTitle>
-        <Input
-          type="search"
-          inputMode="search"
+        <SearchInput
           placeholder="Find a note…"
           aria-label="Find a note"
           value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          className="text-base"
+          onValueChange={setQuery}
         />
         <div className="min-h-0 flex-1 overflow-y-auto">
           {hits !== undefined && hits.length === 0 && (

--- a/apps/desktop/src/mobile/search-input.test.tsx
+++ b/apps/desktop/src/mobile/search-input.test.tsx
@@ -1,4 +1,6 @@
+import { useState, type ReactElement } from 'react'
 import { cleanup, fireEvent, render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { SearchInput } from './search-input'
 
@@ -8,7 +10,9 @@ afterEach(() => {
 
 describe('SearchInput', () => {
   it('blurs the field on the return key (dismissing the iOS keyboard)', () => {
-    const { getByLabelText } = render(<SearchInput aria-label="Search" />)
+    const { getByLabelText } = render(
+      <SearchInput aria-label="Search" value="" onValueChange={vi.fn()} />,
+    )
     const input = getByLabelText('Search') as HTMLInputElement
     input.focus()
     expect(document.activeElement).toBe(input)
@@ -17,7 +21,9 @@ describe('SearchInput', () => {
   })
 
   it('leaves the field focused for other keys', () => {
-    const { getByLabelText } = render(<SearchInput aria-label="Search" />)
+    const { getByLabelText } = render(
+      <SearchInput aria-label="Search" value="" onValueChange={vi.fn()} />,
+    )
     const input = getByLabelText('Search') as HTMLInputElement
     input.focus()
     fireEvent.keyDown(input, { key: 'a' })
@@ -26,14 +32,58 @@ describe('SearchInput', () => {
 
   it('runs a caller-supplied onKeyDown after dismissing', () => {
     const onKeyDown = vi.fn()
-    const { getByLabelText } = render(<SearchInput aria-label="Search" onKeyDown={onKeyDown} />)
+    const { getByLabelText } = render(
+      <SearchInput
+        aria-label="Search"
+        value=""
+        onValueChange={vi.fn()}
+        onKeyDown={onKeyDown}
+      />,
+    )
     const input = getByLabelText('Search')
     fireEvent.keyDown(input, { key: 'Enter' })
     expect(onKeyDown).toHaveBeenCalledTimes(1)
   })
 
   it('is a search-typed input', () => {
-    const { getByLabelText } = render(<SearchInput aria-label="Search" />)
+    const { getByLabelText } = render(
+      <SearchInput aria-label="Search" value="" onValueChange={vi.fn()} />,
+    )
     expect(getByLabelText('Search').getAttribute('type')).toBe('search')
   })
+
+  it('shows the clear action only while the search has text', async () => {
+    const user = userEvent.setup()
+    const { getByRole, queryByRole } = render(<SearchInputHarness />)
+
+    expect(queryByRole('button', { name: 'Clear search' })).toBeNull()
+    await user.type(getByRole('searchbox', { name: 'Search' }), 'notes')
+    expect(getByRole('button', { name: 'Clear search' })).toBeTruthy()
+
+    await user.click(getByRole('button', { name: 'Clear search' }))
+    expect((getByRole('searchbox', { name: 'Search' }) as HTMLInputElement).value).toBe('')
+    expect(queryByRole('button', { name: 'Clear search' })).toBeNull()
+  })
+
+  it('keeps the search field focused when the clear action is tapped', async () => {
+    const user = userEvent.setup()
+    const { getByRole } = render(<SearchInputHarness initialValue="notes" />)
+    const input = getByRole('searchbox', { name: 'Search' })
+    input.focus()
+
+    await user.click(getByRole('button', { name: 'Clear search' }))
+
+    expect(document.activeElement).toBe(input)
+  })
 })
+
+function SearchInputHarness({ initialValue = '' }: { initialValue?: string }): ReactElement {
+  const [value, setValue] = useState(initialValue)
+  return (
+    <SearchInput
+      aria-label="Search"
+      value={value}
+      onValueChange={setValue}
+    />
+  )
+}

--- a/apps/desktop/src/mobile/search-input.tsx
+++ b/apps/desktop/src/mobile/search-input.tsx
@@ -1,8 +1,16 @@
 import { type ComponentProps, type ReactElement } from 'react'
+import { CircleX } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
 
-type SearchInputProps = Omit<ComponentProps<'input'>, 'type' | 'inputMode'>
+type SearchInputProps = Omit<
+  ComponentProps<'input'>,
+  'type' | 'inputMode' | 'value' | 'defaultValue' | 'onChange'
+> & {
+  value: string
+  onValueChange: (value: string) => void
+}
 
 /**
  * The mobile screens' search field (the All and Tasks tabs): a search-typed
@@ -10,21 +18,53 @@ type SearchInputProps = Omit<ComponentProps<'input'>, 'type' | 'inputMode'>
  * lists filter live as you type, so the keyboard's return key ("Search", the
  * blue key on iOS) has nothing to submit — blurring the field lowers the
  * keyboard and hands the whole screen back to the results. A caller's own
- * `onKeyDown` still runs after.
+ * `onKeyDown` still runs after. Non-empty searches get a consistent clear
+ * action that does not steal focus from an active field.
  */
-export function SearchInput({ className, onKeyDown, ...props }: SearchInputProps): ReactElement {
+export function SearchInput({
+  className,
+  disabled,
+  onKeyDown,
+  onValueChange,
+  readOnly,
+  value,
+  ...props
+}: SearchInputProps): ReactElement {
   return (
-    <Input
-      type="search"
-      inputMode="search"
-      className={cn('text-base', className)}
-      onKeyDown={(event) => {
-        if (event.key === 'Enter') {
-          event.currentTarget.blur()
-        }
-        onKeyDown?.(event)
-      }}
-      {...props}
-    />
+    <div className="relative w-full min-w-0">
+      <Input
+        type="search"
+        inputMode="search"
+        className={cn(
+          'text-base [&::-webkit-search-cancel-button]:hidden',
+          value !== '' && 'pr-9',
+          className,
+        )}
+        disabled={disabled}
+        readOnly={readOnly}
+        value={value}
+        onChange={(event) => onValueChange(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            event.currentTarget.blur()
+          }
+          onKeyDown?.(event)
+        }}
+        {...props}
+      />
+      {value !== '' && !disabled && !readOnly ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="absolute inset-y-0 right-0 size-8 text-text-muted"
+          aria-label="Clear search"
+          onPointerDown={(event) => event.preventDefault()}
+          onClick={() => onValueChange('')}
+        >
+          <CircleX aria-hidden />
+        </Button>
+      ) : null}
+    </div>
   )
 }


### PR DESCRIPTION
## Problem

Mobile search fields keep their query until users manually delete it character by character. This is especially awkward on the Tasks and All Notes tabs, where clearing the filter is a common way to return to the full list.

## Before -> After

| Before | After |
| --- | --- |
| Non-empty mobile searches had no consistent clear affordance | A labeled clear icon appears inside every non-empty mobile search field |
| Clearing required editing the text manually | One tap empties the query and restores the unfiltered list |
| Browser-native search cancellation varied by WebKit surface | The shared control owns a consistent clear action and hides the duplicate native glyph |

## Changes

1. Make `SearchInput` an explicitly controlled mobile primitive with `value` / `onValueChange` and a conditional `Clear search` button.
2. Preserve an active input focus during pointer taps so clearing does not unnecessarily dismiss the mobile keyboard.
3. Use the shared search control in All Notes, Tasks, and the linked-note filter drawer.
4. Add component and screen-level coverage for visibility, clearing, focus retention, lifted All Notes state, and immediate Tasks list restoration.

## Verification

- `pnpm --filter @reflect/desktop test --run src/mobile/search-input.test.tsx src/mobile/screens/tasks.test.tsx src/mobile/mobile-screen.test.tsx` — 67 tests passed.
- `pnpm check` — typecheck and lint passed; only the existing max-lines warnings remain in `graph-provider.tsx` and `indexer.ts`.
- Browser-verified the iOS preview at a 390×844 viewport on both All Notes and Tasks: the icon rendered in-field, cleared the query, disappeared afterward, and restored the list.

## Risk / Rollout

Low-risk UI-only change. No persistence, schema, privacy, or rollout changes. The clear action resets only typed search text; All Notes badges and route filters remain intact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only search affordance and controlled-input API; no persistence, auth, or data-layer changes.
> 
> **Overview**
> Mobile search fields get a **one-tap clear** affordance instead of deleting text character by character.
> 
> **`SearchInput`** is now a controlled primitive (`value` / `onValueChange`) with an in-field **Clear search** button when the query is non-empty. The native WebKit cancel glyph is hidden; clearing uses `onPointerDown` + `preventDefault` so focus (and the software keyboard) stay on the field.
> 
> **All Notes**, **Tasks**, and the **note-picker drawer** wire through `onValueChange` and use the shared control (the drawer swaps raw `Input` for `SearchInput`). Tests cover clear visibility, emptying the query, focus retention, seeded All-tab search, and Tasks list restoration after clear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a641d8f96d2120f39a7b1a1d2a5cb2fd67a6a1d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a clear-search button to mobile search fields when text is entered.
  - Clearing a search resets the field, preserves focus, and refreshes previously filtered results.
  - Added consistent search behavior to note selection, notes, and tasks screens.
  - Search fields now use native search input behavior and support controlled query updates.

- **Bug Fixes**
  - Improved clearing and filtering interactions across mobile search experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->