### PR TITLE
fix: keep macOS installer links current

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,8 @@ jobs:
     name: Publish release
     needs: macos
     runs-on: ubuntu-latest
+    outputs:
+      prerelease: ${{ steps.channel.outputs.prerelease }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -190,6 +192,16 @@ jobs:
           # checkouts, and credentials stay for gh/git release preflights.
           persist-credentials: true
           fetch-depth: 0
+
+      - name: Determine release channel
+        id: channel
+        run: |
+          version="$(jq -r .version apps/desktop/package.json)"
+          if [[ "$version" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Download release artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -204,4 +216,22 @@ jobs:
           # Pass the boolean flag through an env variable so the shell never
           # interpolates ${{ }} expressions directly into the run command.
           DRAFT_FLAG: ${{ inputs.draft && '--draft' || '' }}
-        run: node apps/desktop/scripts/release-macos.mjs publish --from-artifacts="$RUNNER_TEMP/release-artifacts" $DRAFT_FLAG
+        run: node apps/desktop/scripts/release-macos.mjs publish --defer-beta-feed --from-artifacts="$RUNNER_TEMP/release-artifacts" $DRAFT_FLAG
+
+  sync-beta-feed:
+    name: Sync beta downloads and updater feed
+    needs: publish
+    if: needs.publish.outputs.prerelease == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: true
+          fetch-depth: 0
+
+      # This is separate from publish so a transient moving-asset failure can
+      # be retried without rebuilding or touching the immutable tagged release.
+      - name: Sync beta downloads and updater feed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node apps/desktop/scripts/release-macos.mjs sync-beta-feed

--- a/README.md
+++ b/README.md
@@ -40,9 +40,12 @@ another git remote are connected directly by the user.
 
 ## Install
 
-1. **Install the Mac app.** Download the latest macOS DMG from
-   [Releases](https://github.com/team-reflect/reflect-open/releases/latest).
-   The app is signed, notarized, and auto-updated from GitHub Releases.
+1. **Install the Mac app.** Download the latest release for your Mac:
+   - **Stable 0.5.0:** [Apple silicon (M-series)](https://github.com/team-reflect/reflect-open/releases/download/v0.5.0/Reflect_0.5.0_aarch64.dmg) · [Intel](https://github.com/team-reflect/reflect-open/releases/download/v0.5.0/Reflect_0.5.0_x86_64.dmg)
+   - **Beta 0.6.0-beta.13:** [Apple silicon (M-series)](https://github.com/team-reflect/reflect-open/releases/download/v0.6.0-beta.13/Reflect.Beta_0.6.0-beta.13_aarch64.dmg) · [Intel](https://github.com/team-reflect/reflect-open/releases/download/v0.6.0-beta.13/Reflect.Beta_0.6.0-beta.13_x86_64.dmg)
+
+   Each build is signed, notarized, and auto-updated from GitHub Releases. You
+   can also [view all releases](https://github.com/team-reflect/reflect-open/releases).
 2. **Install the iOS beta.** Join
    [TestFlight](https://testflight.apple.com/join/j2eEz43d). The iOS app uses
    the same plain-file graph and sync options as the Mac app.

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ another git remote are connected directly by the user.
 ## Install
 
 1. **Install the Mac app.** Download the latest release for your Mac:
-   - **Stable 0.5.0:** [Apple silicon (M-series)](https://github.com/team-reflect/reflect-open/releases/download/v0.5.0/Reflect_0.5.0_aarch64.dmg) · [Intel](https://github.com/team-reflect/reflect-open/releases/download/v0.5.0/Reflect_0.5.0_x86_64.dmg)
-   - **Beta 0.6.0-beta.13:** [Apple silicon (M-series)](https://github.com/team-reflect/reflect-open/releases/download/v0.6.0-beta.13/Reflect.Beta_0.6.0-beta.13_aarch64.dmg) · [Intel](https://github.com/team-reflect/reflect-open/releases/download/v0.6.0-beta.13/Reflect.Beta_0.6.0-beta.13_x86_64.dmg)
+   - **Stable:** [Apple silicon (M-series)](https://github.com/team-reflect/reflect-open/releases/latest/download/Reflect_aarch64.dmg) · [Intel](https://github.com/team-reflect/reflect-open/releases/latest/download/Reflect_x86_64.dmg)
+   - **Beta:** [Apple silicon (M-series)](https://github.com/team-reflect/reflect-open/releases/download/updater-beta/Reflect.Beta_aarch64.dmg) · [Intel](https://github.com/team-reflect/reflect-open/releases/download/updater-beta/Reflect.Beta_x86_64.dmg)
 
    Each build is signed, notarized, and auto-updated from GitHub Releases. You
    can also [view all releases](https://github.com/team-reflect/reflect-open/releases).

--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -54,6 +54,7 @@ const INTEL_ONNX_RUNTIME_RESOURCE_SOURCE = `resources/onnxruntime/${ONNX_RUNTIME
 const RELEASE_NOTES_FILENAME = 'release-notes.md'
 const MAC_DOWNLOAD_NOTICE_HEADING = '## Which Mac download should I choose?'
 const MACOS_SIDECARS = ['reflect', 'reflect-capture-host']
+const RELEASE_VERSION_PATTERN = /^(\d+)\.(\d+)\.(\d+)(?:-beta(?:\.(\d+))?)?$/
 const NOTARIZATION_ENV_VARS = [
   'APPLE_ID',
   'APPLE_PASSWORD',
@@ -735,10 +736,10 @@ function printArtifacts(flavor, target) {
 /** Build the uploaded file name for a target-specific release artifact. */
 function releaseAssetName({ productName, version, target, type }) {
   const { arch } = releaseTargetConfig(target)
+  if (type === 'dmg') return `${githubAssetName(productName)}_${arch}.dmg`
+
   const prefix = `${productName}_${version}_${arch}`
   switch (type) {
-    case 'dmg':
-      return `${prefix}.dmg`
     case 'updaterArchive':
       return `${prefix}.app.tar.gz`
     case 'updaterSignature':
@@ -1036,11 +1037,11 @@ export function createGenerateReleaseNotesArgs({ commit, tag }) {
 }
 
 /** Create the release-note footer that maps Mac CPU families to the right DMG. */
-export function createMacDownloadNotice({ productName, version }) {
+export function createMacDownloadNotice({ productName }) {
   const appleSiliconDmg = githubAssetName(
-    releaseAssetName({ productName, version, target: APPLE_SILICON_MAC_TARGET, type: 'dmg' }),
+    releaseAssetName({ productName, target: APPLE_SILICON_MAC_TARGET, type: 'dmg' }),
   )
-  const intelDmg = githubAssetName(releaseAssetName({ productName, version, target: INTEL_MAC_TARGET, type: 'dmg' }))
+  const intelDmg = githubAssetName(releaseAssetName({ productName, target: INTEL_MAC_TARGET, type: 'dmg' }))
 
   return [
     MAC_DOWNLOAD_NOTICE_HEADING,
@@ -1053,11 +1054,11 @@ export function createMacDownloadNotice({ productName, version }) {
 }
 
 /** Append Reflect's Mac download guidance after GitHub's generated notes. */
-export function appendMacDownloadNotice({ body, productName, version }) {
+export function appendMacDownloadNotice({ body, productName }) {
   const trimmedBody = body.trimEnd()
   if (trimmedBody.includes(MAC_DOWNLOAD_NOTICE_HEADING)) return `${trimmedBody}\n`
 
-  const notice = createMacDownloadNotice({ productName, version })
+  const notice = createMacDownloadNotice({ productName })
   return `${trimmedBody ? `${trimmedBody}\n\n` : ''}${notice}\n`
 }
 
@@ -1084,11 +1085,11 @@ function generateReleaseNotesBody({ commit, tag }) {
 }
 
 /** Write generated release notes plus Reflect's Mac download footer to disk. */
-function writeReleaseNotes({ commit, outputDir, productName, tag, version }) {
+function writeReleaseNotes({ commit, outputDir, productName, tag }) {
   log('generating GitHub release notes…')
   const body = generateReleaseNotesBody({ commit, tag })
   const releaseNotesPath = join(outputDir, RELEASE_NOTES_FILENAME)
-  writeFileSync(releaseNotesPath, appendMacDownloadNotice({ body, productName, version }))
+  writeFileSync(releaseNotesPath, appendMacDownloadNotice({ body, productName }))
   return releaseNotesPath
 }
 
@@ -1137,52 +1138,204 @@ export function createFinalizeReleaseArgs({ keepDraft, notesPath, prerelease, pr
   return args
 }
 
-/** Build the `gh release create` arguments for the moving beta updater feed. */
-export function createBetaFeedReleaseArgs({ commit, manifestPath }) {
+/** Build the `gh release create` arguments for the moving beta download and updater feed. */
+export function createBetaFeedReleaseArgs({ assets, commit }) {
   return [
     'release',
     'create',
     BETA_UPDATER_FEED_TAG,
-    manifestPath,
+    ...assets,
     '--title',
-    'Reflect beta updater feed',
+    'Latest Reflect Beta downloads',
     '--target',
     commit,
     '--prerelease',
     '--latest=false',
     '--notes',
-    'Moving updater feed for beta builds. Do not install this release directly.',
+    'Moving downloads and updater feed for the latest Reflect Beta release. Choose a DMG for a fresh install; installed beta apps use latest.json.',
   ]
 }
 
-/** Build the `gh release upload` arguments that replace the beta feed manifest. */
-export function uploadBetaFeedArgs({ manifestPath }) {
-  return ['release', 'upload', BETA_UPDATER_FEED_TAG, manifestPath, '--clobber']
+/** Build ordered uploads so installer failures leave the working updater manifest untouched. */
+export function createBetaFeedUploadSteps({ dmgPaths, manifestPath }) {
+  return [
+    {
+      label: 'downloads',
+      args: ['release', 'upload', BETA_UPDATER_FEED_TAG, ...dmgPaths, '--clobber'],
+    },
+    {
+      label: 'updater feed',
+      args: ['release', 'upload', BETA_UPDATER_FEED_TAG, manifestPath, '--clobber'],
+    },
+  ]
 }
 
-function updateBetaFeed({ commit, manifestPath }) {
+/** Build the `gh release download` arguments used to recover moving assets from a tagged release. */
+export function createReleaseDownloadArgs({ assetNames, outputDir, tag }) {
+  return [
+    'release',
+    'download',
+    tag,
+    '--dir',
+    outputDir,
+    ...assetNames.flatMap((assetName) => ['--pattern', assetName]),
+  ]
+}
+
+function parseReleaseVersion(version) {
+  const match = RELEASE_VERSION_PATTERN.exec(version)
+  if (!match) throw new Error(`unsupported release version: ${version}`)
+
+  const [, major, minor, patch, betaNumber] = match
+  return {
+    core: [major, minor, patch].map(Number),
+    prerelease: version.includes('-beta') ? Number(betaNumber ?? 0) : null,
+  }
+}
+
+/** Compare Reflect stable/beta versions, returning negative, zero, or positive. */
+export function compareReleaseVersions(left, right) {
+  const leftVersion = parseReleaseVersion(left)
+  const rightVersion = parseReleaseVersion(right)
+
+  for (let index = 0; index < leftVersion.core.length; index += 1) {
+    const difference = leftVersion.core[index] - rightVersion.core[index]
+    if (difference !== 0) return Math.sign(difference)
+  }
+
+  if (leftVersion.prerelease === null && rightVersion.prerelease === null) return 0
+  if (leftVersion.prerelease === null) return 1
+  if (rightVersion.prerelease === null) return -1
+  return Math.sign(leftVersion.prerelease - rightVersion.prerelease)
+}
+
+/** Select the highest Reflect beta version from GitHub release tag names. */
+export function newestBetaVersionFromTags(tags) {
+  const versions = tags
+    .map((tag) => tag.trim())
+    .map((tag) => (tag.startsWith('v') ? tag.slice(1) : ''))
+    .filter((version) => version.includes('-beta') && RELEASE_VERSION_PATTERN.test(version))
+  if (versions.length === 0) throw new Error('GitHub did not return any published beta releases')
+
+  return versions.reduce((newest, version) =>
+    compareReleaseVersions(version, newest) > 0 ? version : newest,
+  )
+}
+
+function findNewestPublishedBetaVersion() {
+  const result = spawnSync(
+    'gh',
+    [
+      'api',
+      '--paginate',
+      'repos/{owner}/{repo}/releases',
+      '--jq',
+      '.[] | select(.prerelease == true and .draft == false) | .tag_name',
+    ],
+    { encoding: 'utf8' },
+  )
+  if (result.status !== 0) {
+    fail(`could not list published beta releases:\n${`${result.stdout ?? ''}${result.stderr ?? ''}`.trim()}`)
+  }
+
+  try {
+    return newestBetaVersionFromTags((result.stdout ?? '').split('\n'))
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    fail(message)
+  }
+}
+
+function updateBetaFeed({ commit, dmgPaths, manifestPath }) {
   const existing = run('gh', ['release', 'view', BETA_UPDATER_FEED_TAG])
   if (existing.status === 0) {
-    log(`updating ${BETA_UPDATER_FEED_TAG} updater feed…`)
-    const upload = spawnSync('gh', uploadBetaFeedArgs({ manifestPath }), {
-      encoding: 'utf8',
-      stdio: ['inherit', 'pipe', 'inherit'],
-    })
-    if (upload.status !== 0) {
-      fail(`updating the beta updater feed failed${upload.stdout ? `\n${upload.stdout.trim()}` : ''}`)
+    for (const step of createBetaFeedUploadSteps({ dmgPaths, manifestPath })) {
+      log(`updating ${BETA_UPDATER_FEED_TAG} ${step.label}…`)
+      const upload = spawnSync('gh', step.args, {
+        encoding: 'utf8',
+        stdio: ['inherit', 'pipe', 'inherit'],
+      })
+      if (upload.status !== 0) {
+        fail(`updating the beta ${step.label} failed${upload.stdout ? `\n${upload.stdout.trim()}` : ''}`)
+      }
     }
     return
   }
   if (!/release not found/i.test(existing.output)) {
     fail(`could not check GitHub for the ${BETA_UPDATER_FEED_TAG} updater feed:\n${existing.output.trim()}`)
   }
-  log(`creating ${BETA_UPDATER_FEED_TAG} updater feed…`)
-  const create = spawnSync('gh', createBetaFeedReleaseArgs({ commit, manifestPath }), {
+  log(`creating ${BETA_UPDATER_FEED_TAG} downloads and updater feed…`)
+  const create = spawnSync('gh', createBetaFeedReleaseArgs({ assets: [...dmgPaths, manifestPath], commit }), {
     encoding: 'utf8',
     stdio: ['inherit', 'pipe', 'inherit'],
   })
   if (create.status !== 0) {
-    fail(`creating the beta updater feed failed${create.stdout ? `\n${create.stdout.trim()}` : ''}`)
+    fail(`creating the beta downloads failed${create.stdout ? `\n${create.stdout.trim()}` : ''}`)
+  }
+}
+
+function downloadReleaseAssets({ assetNames, outputDir, tag }) {
+  mkdirSync(outputDir, { recursive: true })
+  const download = spawnSync('gh', createReleaseDownloadArgs({ assetNames, outputDir, tag }), {
+    encoding: 'utf8',
+    stdio: ['inherit', 'pipe', 'inherit'],
+  })
+  if (download.status !== 0) {
+    fail(`downloading release assets from ${tag} failed${download.stdout ? `\n${download.stdout.trim()}` : ''}`)
+  }
+
+  const paths = assetNames.map((assetName) => join(outputDir, assetName))
+  for (const path of paths) {
+    if (!existsSync(path)) fail(`release download did not produce ${path}`)
+  }
+  return paths
+}
+
+/** Refresh the moving beta assets from an already-published immutable release. */
+function syncBetaFeed() {
+  ensureGhReady()
+  const commit = ensurePublishableCommit()
+  const { version } = readTauriConf()
+  if (!version.includes('-')) fail(`version ${version} is stable — there is no beta feed to sync`)
+
+  const flavor = resolveFlavor({ version, forPublish: true })
+  const { productName } = readFlavorConf(flavor)
+  const tag = `v${version}`
+  const release = findReleaseByTag(tag)
+  if (!release) fail(`release ${tag} does not exist`)
+  ensureReleaseTargetsCommit(release, tag, commit)
+  if (release.draft) {
+    log(`release ${tag} is still a draft — ${BETA_UPDATER_FEED_TAG} remains unchanged`)
+    return
+  }
+  if (!release.prerelease) fail(`release ${tag} is not marked as a pre-release`)
+
+  const dmgNames = DEFAULT_PUBLISH_TARGETS.map((target) =>
+    releaseAssetName({ productName, target, type: 'dmg' }),
+  )
+  const assetNames = [...dmgNames, 'latest.json']
+  const publishedAssetNames = new Set((release.assets ?? []).map((asset) => asset.name))
+  const missingAsset = assetNames.find((assetName) => !publishedAssetNames.has(assetName))
+  if (missingAsset) fail(`release ${tag} does not contain ${missingAsset}`)
+
+  const newestPublishedVersion = findNewestPublishedBetaVersion()
+  if (compareReleaseVersions(version, newestPublishedVersion) < 0) {
+    log(`${newestPublishedVersion} is already published; skipping older ${version}`)
+    return
+  }
+  log(`syncing ${BETA_UPDATER_FEED_TAG} to the newest published beta, ${version}`)
+
+  const tempDir = mkdtempSync(join(tmpdir(), 'reflect-beta-feed-'))
+  try {
+    const sourceDir = join(tempDir, 'source')
+    downloadReleaseAssets({ assetNames, outputDir: sourceDir, tag })
+    updateBetaFeed({
+      commit,
+      dmgPaths: dmgNames.map((dmgName) => join(sourceDir, dmgName)),
+      manifestPath: join(sourceDir, 'latest.json'),
+    })
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true })
   }
 }
 
@@ -1247,7 +1400,7 @@ function publishIntoExistingRelease({ assets, draft, prerelease, productName, re
  * created by release-please when one exists (the Release PR flow), otherwise
  * as a brand-new release (the manual workflow_dispatch fallback).
  */
-function publish({ draft, flavorFlag, fromArtifacts }) {
+function publish({ deferBetaFeed, draft, flavorFlag, fromArtifacts }) {
   const { commit, flavor, productName, release, tag, version } = ensurePublishableRelease({ flavorFlag })
   const artifactDir = fromArtifacts ?? mkdtempSync(join(tmpdir(), 'reflect-release-assets-'))
 
@@ -1277,7 +1430,7 @@ function publish({ draft, flavorFlag, fromArtifacts }) {
     // release-please already wrote the changelog into the release body; keep
     // it and append the Mac download chooser.
     const releaseNotesPath = join(artifactDir, RELEASE_NOTES_FILENAME)
-    writeFileSync(releaseNotesPath, appendMacDownloadNotice({ body: release.body ?? '', productName, version }))
+    writeFileSync(releaseNotesPath, appendMacDownloadNotice({ body: release.body ?? '', productName }))
     publishIntoExistingRelease({ assets, draft, prerelease, productName, release, releaseNotesPath, tag, version })
   } else {
     const releaseNotesPath = writeReleaseNotes({
@@ -1285,7 +1438,6 @@ function publish({ draft, flavorFlag, fromArtifacts }) {
       outputDir: artifactDir,
       productName,
       tag,
-      version,
     })
     log(`creating GitHub ${prerelease ? 'pre-release' : 'release'} ${tag} from commit ${commit.slice(0, 7)}…`)
     const releaseArgs = createReleaseArgs({
@@ -1303,10 +1455,10 @@ function publish({ draft, flavorFlag, fromArtifacts }) {
     log(`${draft ? 'draft release created' : 'release published'}: ${result.stdout.trim()}`)
   }
 
-  if (prerelease && !draft) {
-    updateBetaFeed({ commit, manifestPath })
+  if (prerelease && !deferBetaFeed) {
+    syncBetaFeed()
   } else if (prerelease) {
-    log(`draft pre-release — ${BETA_UPDATER_FEED_TAG} feed not updated`)
+    log(`moving beta assets deferred to the downstream ${BETA_UPDATER_FEED_TAG} sync job`)
   }
 }
 
@@ -1385,6 +1537,7 @@ const USAGE = `Usage: pnpm release:macos [command] [flags]
 Commands:
   build          Signed + notarized release build, then verify (default)
   preflight      Check that the current commit can publish before CI spends macOS minutes
+  sync-beta-feed Refresh moving beta downloads/feed from the published tagged release
   setup          Store the notarization Apple ID + app-specific password in the keychain
   setup-updater  Generate the auto-update signing keypair (keychain + pubkey to commit)
   verify         Re-run signing/Gatekeeper checks on already-built bundles
@@ -1393,6 +1546,8 @@ Commands:
 Flags:
   --no-notarize   Skip notarization (signed-only build/verify)
   --draft         Create the GitHub release as a draft (publish only)
+  --defer-beta-feed
+                  Leave moving beta assets to a separate sync-beta-feed command (publish only)
   --target=<name> Build or verify one target: aarch64-apple-darwin | x86_64-apple-darwin
   --artifact-dir=<path>
                   Export release assets and metadata after build (build only)
@@ -1416,7 +1571,7 @@ async function main() {
   const fromArtifacts = flags.find((flag) => flag.startsWith('--from-artifacts='))?.slice('--from-artifacts='.length)
   const unknownFlag = flags.find(
     (flag) =>
-      !['--no-notarize', '--draft', '--help'].includes(flag) &&
+      !['--no-notarize', '--draft', '--defer-beta-feed', '--help'].includes(flag) &&
       !flag.startsWith('--flavor=') &&
       !flag.startsWith('--target=') &&
       !flag.startsWith('--artifact-dir=') &&
@@ -1430,6 +1585,7 @@ async function main() {
   if (targetFlag && !['build', 'verify'].includes(command)) fail('--target only applies to build and verify')
   if (artifactDir && command !== 'build') fail('--artifact-dir only applies to build')
   if (fromArtifacts && command !== 'publish') fail('--from-artifacts only applies to publish')
+  if (flags.includes('--defer-beta-feed') && command !== 'publish') fail('--defer-beta-feed only applies to publish')
   if (flags.includes('--help')) {
     console.log(USAGE)
     return
@@ -1458,6 +1614,8 @@ async function main() {
       return setup()
     case 'setup-updater':
       return setupUpdater()
+    case 'sync-beta-feed':
+      return syncBetaFeed()
     case 'verify': {
       const flavor = resolveFlavor({ flavorFlag, version, forPublish: false })
       const target = targetFlag ?? hostTarget()
@@ -1465,7 +1623,12 @@ async function main() {
       return printArtifacts(flavor, target)
     }
     case 'publish':
-      return publish({ draft: flags.includes('--draft'), flavorFlag, fromArtifacts })
+      return publish({
+        deferBetaFeed: flags.includes('--defer-beta-feed'),
+        draft: flags.includes('--draft'),
+        flavorFlag,
+        fromArtifacts,
+      })
     default:
       fail(`unknown command "${command}"\n\n${USAGE}`)
   }

--- a/apps/desktop/scripts/release-macos.test.mjs
+++ b/apps/desktop/scripts/release-macos.test.mjs
@@ -6,21 +6,24 @@ import { expect, test } from 'vitest'
 import {
   appendMacDownloadNotice,
   canLaunchTarget,
+  compareReleaseVersions,
   createBetaFeedReleaseArgs,
+  createBetaFeedUploadSteps,
   createDmgArgs,
   createExistingReleaseUploadArgs,
   createFinalizeReleaseArgs,
   createGenerateReleaseNotesArgs,
   createMacDownloadNotice,
+  createReleaseDownloadArgs,
   createReleaseArgs,
   createTauriBuildArgs,
   createUpdaterArchiveArgs,
   createUpdaterManifest,
   macosEntitlementsPath,
   macosTargetResourceConfig,
+  newestBetaVersionFromTags,
   parseKeychainList,
   signDmgArgs,
-  uploadBetaFeedArgs,
 } from './release-macos.mjs'
 
 const baseInput = {
@@ -159,10 +162,10 @@ test('generated release notes API targets the release tag and commit', () => {
 })
 
 test('Mac download notice points each processor at the matching DMG', () => {
-  const notice = createMacDownloadNotice({ productName: 'Reflect Beta', version: '0.4.0-beta.8' })
+  const notice = createMacDownloadNotice({ productName: 'Reflect Beta' })
 
-  expect(notice).toContain('`Reflect.Beta_0.4.0-beta.8_aarch64.dmg`')
-  expect(notice).toContain('`Reflect.Beta_0.4.0-beta.8_x86_64.dmg`')
+  expect(notice).toContain('`Reflect.Beta_aarch64.dmg`')
+  expect(notice).toContain('`Reflect.Beta_x86_64.dmg`')
   expect(notice).toContain('Apple Silicon (M-series Macs)')
   expect(notice).toContain('Apple menu -> About This Mac')
 })
@@ -171,7 +174,6 @@ test('Mac download notice is appended after generated release notes', () => {
   const notes = appendMacDownloadNotice({
     body: "## What's Changed\n\n- Fixed sync\n\n**Full Changelog**: v0.3.6...v0.3.7\n",
     productName: 'Reflect',
-    version: '0.3.7',
   })
 
   expect(notes).toBe(
@@ -179,47 +181,120 @@ test('Mac download notice is appended after generated release notes', () => {
       '- Fixed sync\n\n' +
       '**Full Changelog**: v0.3.6...v0.3.7\n\n' +
       '## Which Mac download should I choose?\n\n' +
-      '- **Apple Silicon (M-series Macs):** download `Reflect_0.3.7_aarch64.dmg`.\n' +
-      '- **Intel Macs:** download `Reflect_0.3.7_x86_64.dmg`.\n\n' +
+      '- **Apple Silicon (M-series Macs):** download `Reflect_aarch64.dmg`.\n' +
+      '- **Intel Macs:** download `Reflect_x86_64.dmg`.\n\n' +
       'To check your Mac, open **Apple menu -> About This Mac**. If it shows **Chip** with M1, M2, M3, M4, or newer, choose Apple Silicon. If it shows **Processor** with Intel, choose Intel.\n',
   )
 })
 
 test('Mac download notice is not duplicated when release notes are regenerated', () => {
   const notes = appendMacDownloadNotice({
-    body: createMacDownloadNotice({ productName: 'Reflect', version: '0.3.7' }),
+    body: createMacDownloadNotice({ productName: 'Reflect' }),
     productName: 'Reflect',
-    version: '0.3.7',
   })
 
   expect(notes.match(/Which Mac download should I choose/g)).toHaveLength(1)
 })
 
-test('beta feed release is a non-latest prerelease pointer', () => {
-  expect(createBetaFeedReleaseArgs({ commit: 'abc123', manifestPath: 'latest.json' })).toEqual([
+test('beta feed release carries the latest downloads without becoming the latest stable release', () => {
+  expect(
+    createBetaFeedReleaseArgs({
+      assets: ['Reflect.Beta_aarch64.dmg', 'Reflect.Beta_x86_64.dmg', 'latest.json'],
+      commit: 'abc123',
+    }),
+  ).toEqual([
     'release',
     'create',
     'updater-beta',
+    'Reflect.Beta_aarch64.dmg',
+    'Reflect.Beta_x86_64.dmg',
     'latest.json',
     '--title',
-    'Reflect beta updater feed',
+    'Latest Reflect Beta downloads',
     '--target',
     'abc123',
     '--prerelease',
     '--latest=false',
     '--notes',
-    'Moving updater feed for beta builds. Do not install this release directly.',
+    'Moving downloads and updater feed for the latest Reflect Beta release. Choose a DMG for a fresh install; installed beta apps use latest.json.',
   ])
 })
 
-test('beta feed upload replaces the moving manifest', () => {
-  expect(uploadBetaFeedArgs({ manifestPath: 'latest.json' })).toEqual([
-    'release',
-    'upload',
-    'updater-beta',
-    'latest.json',
-    '--clobber',
+test('beta feed replaces downloads before the updater manifest', () => {
+  expect(
+    createBetaFeedUploadSteps({
+      dmgPaths: ['Reflect.Beta_aarch64.dmg', 'Reflect.Beta_x86_64.dmg'],
+      manifestPath: 'latest.json',
+    }),
+  ).toEqual([
+    {
+      label: 'downloads',
+      args: [
+        'release',
+        'upload',
+        'updater-beta',
+        'Reflect.Beta_aarch64.dmg',
+        'Reflect.Beta_x86_64.dmg',
+        '--clobber',
+      ],
+    },
+    {
+      label: 'updater feed',
+      args: ['release', 'upload', 'updater-beta', 'latest.json', '--clobber'],
+    },
   ])
+})
+
+test('beta feed recovery downloads exact assets from the tagged release', () => {
+  expect(
+    createReleaseDownloadArgs({
+      assetNames: ['Reflect.Beta_aarch64.dmg', 'Reflect.Beta_x86_64.dmg', 'latest.json'],
+      outputDir: '/tmp/release-assets',
+      tag: 'v0.6.0-beta.14',
+    }),
+  ).toEqual([
+    'release',
+    'download',
+    'v0.6.0-beta.14',
+    '--dir',
+    '/tmp/release-assets',
+    '--pattern',
+    'Reflect.Beta_aarch64.dmg',
+    '--pattern',
+    'Reflect.Beta_x86_64.dmg',
+    '--pattern',
+    'latest.json',
+  ])
+})
+
+test('beta feed version comparison prevents rollback while allowing recovery', () => {
+  expect(compareReleaseVersions('0.6.0-beta.13', '0.6.0-beta.14')).toBe(-1)
+  expect(compareReleaseVersions('0.6.0-beta.14', '0.6.0-beta.14')).toBe(0)
+  expect(compareReleaseVersions('0.6.0-beta.15', '0.6.0-beta.14')).toBe(1)
+})
+
+test('beta feed version comparison handles release-please beta boundaries', () => {
+  expect(compareReleaseVersions('0.6.0-beta', '0.5.0-beta.99')).toBe(1)
+  expect(compareReleaseVersions('0.6.0-beta.1', '0.6.0-beta')).toBe(1)
+  expect(compareReleaseVersions('0.6.0', '0.6.0-beta.99')).toBe(1)
+})
+
+test('beta feed version comparison rejects unsupported versions', () => {
+  expect(() => compareReleaseVersions('0.6.0-rc.1', '0.6.0-beta.14')).toThrow('unsupported release version')
+})
+
+test('beta feed selects the newest immutable published beta tag', () => {
+  expect(
+    newestBetaVersionFromTags([
+      'updater-beta',
+      'v0.5.0',
+      'v0.5.0-beta.99',
+      'v0.6.0-beta.9',
+      'v0.6.0-beta.14',
+      '',
+    ]),
+  ).toBe('0.6.0-beta.14')
+  expect(() => newestBetaVersionFromTags(['updater-beta', 'v0.5.0'])).toThrow('published beta releases')
 })
 
 test('release builds ask Tauri for the app bundle only', () => {

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -89,12 +89,17 @@ pnpm release:macos --target=x86_64-apple-darwin  # build + notarize + verify for
 pnpm release:macos setup           # store Apple ID + app-specific password in the keychain
 pnpm release:macos verify          # re-run all checks on already-built bundles
 pnpm release:macos publish         # build + notarize + verify, then create a GitHub release
+pnpm release:macos sync-beta-feed  # retry moving beta downloads/feed from the tagged release
 pnpm release:macos publish --draft # same, but leave the release as a draft for review
 pnpm release:macos --no-notarize   # signed-only build (runs locally; Gatekeeper rejects it elsewhere)
 ```
 
 CI uses `build --target=<triple> --artifact-dir=<dir>` for each architecture, then
-`publish --from-artifacts=<dir>` after downloading both artifact sets.
+`publish --defer-beta-feed --from-artifacts=<dir>` after downloading both artifact
+sets. A separate `sync-beta-feed` job refreshes moving beta downloads after the tagged
+release is published, so that final step can be retried without rebuilding or
+republishing. Local `publish` runs the same sync before returning unless explicitly
+deferred.
 
 ## Cutting a release (Release PRs)
 
@@ -197,6 +202,10 @@ release-please created when the Release PR merged, or — when no release exists
 creating one itself. The release carries two notarized DMGs, two
 updater archives (one per architecture, each with its `.sig`), and a single
 `latest.json` manifest with both `darwin-aarch64` and `darwin-x86_64` platform entries.
+Published DMGs use fixed names (`Reflect_aarch64.dmg` and `Reflect_x86_64.dmg`
+for stable) because the release tag already identifies the version. That keeps
+`releases/latest/download/<asset>` stable across releases. Updater archives remain
+versioned because each manifest points at an immutable release payload.
 Stable installs poll `releases/latest/download/latest.json`; beta installs poll
 `releases/download/updater-beta/latest.json`, a moving feed release that points at the
 newest published beta. Publish requires the updater key and always attaches the
@@ -227,10 +236,16 @@ Development happens on `next` (the repo default branch); `master` only advances 
 turns that suffix into a GitHub **pre-release** automatically. `releases/latest` ignores
 pre-releases, so stable installs never see a beta.
 
-Beta builds use the dedicated `updater-beta` feed instead. Every non-draft beta publish
-uploads the beta's `latest.json` to that fixed release with `--clobber`; the manifest
-still points at the immutable versioned release artifacts for the actual download. Draft
-beta releases do not update the feed.
+Beta builds use the dedicated `updater-beta` release instead. Every non-draft beta
+publish replaces its `latest.json`, `Reflect.Beta_aarch64.dmg`, and
+`Reflect.Beta_x86_64.dmg` assets with `--clobber`. The fixed DMG names give the README
+permanent fresh-install links, while the manifest still points installed apps at the
+immutable versioned updater archives. Draft beta releases do not update the moving
+assets. The DMGs are replaced before `latest.json`; if that downstream job fails, rerun
+only **Sync beta downloads and updater feed** to recover from the tagged release. The
+sync compares its source with the immutable published beta releases: same-version
+retries repair partial uploads, while a retry for an older release becomes a no-op
+rather than rolling the channel back.
 
 The channel is picked by the version string alone: a `-beta.N` prerelease publishes to
 the beta feed, a plain version to the stable feed. The beta and dev flavor overlays pin
@@ -301,8 +316,11 @@ Each build job runs the same DMG notarization, Gatekeeper checks, and updater ar
 signing as a local release, then uploads its artifacts to the workflow. A final publish
 job downloads both sets, writes the combined `latest.json`, and fills the release-please
 draft release: it keeps the changelog body, appends the Mac download chooser that maps
-Apple Silicon to `_aarch64.dmg` and Intel to `_x86_64.dmg`, and undrafts the release as
-its last step. The workflow normally runs via `workflow_call` from
+Apple Silicon to `Reflect_aarch64.dmg` and Intel to `Reflect_x86_64.dmg` (with
+`Reflect.Beta` names for beta releases), and undrafts the release as its last step. The
+downstream beta-sync job then downloads the canonical DMGs and manifest from that
+tagged release before refreshing `updater-beta`. The workflow normally runs via
+`workflow_call` from
 `.github/workflows/release-please.yml` when a Release PR merges. The manual fallback is
 **Actions → Release → Run workflow** (tick *draft* to review the release before
 publishing) on a branch whose `apps/desktop/package.json` version was already bumped by


### PR DESCRIPTION
## Problem

Direct Mac installer links would go stale whenever a new release shipped: stable DMGs used versioned filenames, and beta releases do not participate in GitHub's `releases/latest` route.

## Changes

- Point the README at evergreen stable and beta installer URLs for Apple silicon and Intel Macs.
- Publish fixed DMG asset names while keeping updater archives versioned and immutable.
- Carry beta DMGs alongside `latest.json` on the moving `updater-beta` release.
- Split beta-feed synchronization into a retryable downstream job, update installers before the manifest, and prevent stale workflow reruns from rolling the channel backward.
- Document the release behavior and add focused tests for naming, recovery, and version ordering.
- Seed the four current aliases from stable `v0.5.0` and beta `v0.6.0-beta.13`, preserving and verifying their SHA-256 digests.

The release pipeline does not publish app ZIP assets—the GitHub-generated ZIP is source code—so these links target the signed, notarized DMG installers.

## Verification

- `pnpm --filter @reflect/desktop exec vitest run scripts/release-macos.test.mjs` (30 tests)
- `pnpm check`
- `pnpm build`
- `node apps/desktop/scripts/release-macos.mjs --help`
- Parsed `.github/workflows/release.yml` as YAML
- Confirmed all four evergreen URLs follow redirects and return HTTP 200
- Confirmed seeded aliases match their source release assets by GitHub SHA-256 digest

## Risk / Rollout

The current aliases are already live, so the README links work immediately. After merge, future stable releases retain the same `releases/latest` URLs, while beta publishes refresh `updater-beta` in a separate retryable job. The guard uses immutable published beta releases as its source of truth, so same-version retries repair partial uploads and older retries are no-ops.

The normal stable path promotes `next` to `master`, so it includes this publisher. If an emergency stable hotfix is cut from `master` before promotion, seed the two fixed aliases on that release or backport this publisher first.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or security behavior changes, though pinned version URLs will need manual updates when new releases ship.
> 
> **Overview**
> **Mac install** no longer points only at the generic latest release page. The README now lists **direct signed DMG downloads** for the current **stable (0.5.0)** and **beta (0.6.0-beta.13)** builds, with separate links for **Apple silicon** and **Intel** in each channel.
> 
> It still states builds are signed, notarized, and auto-updated, and adds a link to **view all releases** for notes and older builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09456ad174c046da6d74859db34958c13f5e2a42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
