### PR TITLE
ci: automate stable promotion releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,6 +28,7 @@ jobs:
     # whether any release exists.
     outputs:
       release_created: ${{ steps.result.outputs.release_created }}
+      release_available: ${{ steps.result.outputs.release_available }}
       tag_name: ${{ steps.result.outputs.tag_name }}
       release_commit: ${{ steps.result.outputs.release_commit }}
     steps:
@@ -558,6 +559,7 @@ jobs:
           set -euo pipefail
 
           release_created=false
+          release_available=false
           tag_name=""
           release_commit=""
           if [ "$IS_PROMOTION" = "true" ]; then
@@ -597,7 +599,9 @@ jobs:
                 tag_name="$expected_tag"
                 echo "Recovering draft ${expected_tag} created by an earlier promotion attempt."
               else
-                echo "The promoted ${expected_tag} release is already published; no release work remains."
+                release_available=true
+                tag_name="$expected_tag"
+                echo "The promoted ${expected_tag} release is already published; release delivery remains complete."
               fi
             else
               if [ "$STABLE_RELEASE_PR_MERGED" = "true" ]; then
@@ -623,12 +627,15 @@ jobs:
             tag_name="$FIRST_TAG_NAME"
           fi
 
-          if [ "$release_created" = "true" ] && [ -z "$tag_name" ]; then
-            echo "::error::release-please reported a release without a tag"
+          if [ "$release_created" = "true" ]; then
+            release_available=true
+          fi
+          if [ "$release_available" = "true" ] && [ -z "$tag_name" ]; then
+            echo "::error::verified release is missing its tag"
             exit 1
           fi
           if [ "$IS_PROMOTION" = "true" ] && \
-            [ "$release_created" = "true" ] && \
+            [ "$release_available" = "true" ] && \
             [ "$tag_name" != "v${EXPECTED_STABLE_VERSION}" ]; then
             echo "::error::promoted release tag ${tag_name} does not match v${EXPECTED_STABLE_VERSION}"
             exit 1
@@ -661,7 +668,7 @@ jobs:
             fi
           fi
 
-          if [ "$release_created" = "true" ]; then
+          if [ "$release_available" = "true" ]; then
             if [[ ! "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
               echo "::error::release-please returned invalid tag ${tag_name}"
               exit 1
@@ -689,6 +696,7 @@ jobs:
 
           {
             echo "release_created=$release_created"
+            echo "release_available=$release_available"
             echo "tag_name=$tag_name"
             echo "release_commit=$release_commit"
           } >> "$GITHUB_OUTPUT"
@@ -752,14 +760,16 @@ jobs:
         run: node apps/desktop/scripts/release-promotion.mjs "$TAG" "$RELEASE_COMMIT"
 
   # After a stable release, open a single PR that merges master back into next
-  # and advances the beta manifest. A human merges it with a merge commit —
-  # never squash, or the two branches diverge for good. This job does not wait
-  # for publish-release: the code is already on master, and a failed build is
-  # retried via workflow_dispatch.
+  # and advances the beta manifest. `release_available` also stays true when a
+  # promotion rerun verifies an already-published release, so this idempotent
+  # job can recover after an earlier back-merge failure. A human merges it with
+  # a merge commit — never squash, or the two branches diverge for good. This
+  # job does not wait for publish-release: the code is already on master, and a
+  # failed build is retried via workflow_dispatch.
   post-stable:
     name: Open the back-merge PR
     needs: release-please
-    if: github.ref_name == 'master' && needs.release-please.outputs.release_created == 'true'
+    if: github.ref_name == 'master' && needs.release-please.outputs.release_available == 'true'
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,9 +2,10 @@ name: Release PR
 
 # One release-please channel per branch: pushes to `next` maintain the beta
 # Release PR (v0.5.0-beta.N), pushes to `master` the stable one (v0.5.0).
-# Merging a Release PR makes release-please create a draft GitHub release;
-# the publish-release job then chains into release.yml, which uploads the
-# signed artifacts and undrafts it. Everything runs on GITHUB_TOKEN — no PAT.
+# Merging a beta Release PR publishes it, then opens the stable promotion PR.
+# A merge-commit promotion is the single stable approval: this workflow creates
+# and squash-merges the generated stable Release PR, runs release-please again
+# to create its tag, then publishes it. Everything runs on GITHUB_TOKEN — no PAT.
 
 on:
   push:
@@ -26,8 +27,9 @@ jobs:
     # outputs without a path prefix; the global `releases_created` reports
     # whether any release exists.
     outputs:
-      release_created: ${{ steps.release.outputs.releases_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
+      release_created: ${{ steps.result.outputs.release_created }}
+      tag_name: ${{ steps.result.outputs.tag_name }}
+      release_commit: ${{ steps.result.outputs.release_commit }}
     steps:
       - name: Pick the channel config for this branch
         id: channel
@@ -40,19 +42,666 @@ jobs:
           echo "config=.github/release-please/config.${channel}.json" >> "$GITHUB_OUTPUT"
           echo "manifest=.github/release-please/manifest.${channel}.json" >> "$GITHUB_OUTPUT"
 
+      # A stable promotion is a deliberately narrow path: it must be the merge
+      # commit of the managed promotion PR. Squash/rebase would leave next and
+      # master with unrelated histories, so reject it before touching releases.
+      - name: Detect a stable promotion merge
+        if: github.ref_name == 'master'
+        id: promotion
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          pulls="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls")"
+          matches="$(
+            jq -c \
+              --arg repository "$GITHUB_REPOSITORY" \
+              --arg sha "$GITHUB_SHA" \
+              '[.[] | select(
+                .base.repo.full_name == $repository and
+                .base.ref == "master" and
+                .head.repo.full_name == $repository and
+                .head.ref == "release-promotion/latest-beta" and
+                .merged_at != null and
+                .merge_commit_sha == $sha
+              )]' <<< "$pulls"
+          )"
+          match_count="$(jq 'length' <<< "$matches")"
+
+          if [ "$match_count" -eq 0 ]; then
+            echo "is_promotion=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$match_count" -ne 1 ]; then
+            echo "::error::expected one promotion PR for ${GITHUB_SHA}, found ${match_count}"
+            exit 1
+          fi
+
+          promotion_number="$(jq -r '.[0].number' <<< "$matches")"
+          promotion_title="$(jq -r '.[0].title' <<< "$matches")"
+          promotion_head="$(jq -r '.[0].head.sha' <<< "$matches")"
+          commit_details="$(gh api "repos/${GITHUB_REPOSITORY}/git/commits/${GITHUB_SHA}")"
+          parent_count="$(jq '.parents | length' <<< "$commit_details")"
+          if [ "$parent_count" -ne 2 ]; then
+            echo "::error::promotion PR #${promotion_number} was not merged with a merge commit (${parent_count} parent(s)); do not squash or rebase promotion PRs"
+            exit 1
+          fi
+          first_parent="$(jq -r '.parents[0].sha' <<< "$commit_details")"
+          second_parent="$(jq -r '.parents[1].sha' <<< "$commit_details")"
+          if [ "$second_parent" != "$promotion_head" ]; then
+            echo "::error::promotion merge second parent ${second_parent} does not match approved head ${promotion_head}"
+            exit 1
+          fi
+
+          promotion_head_details="$(gh api "repos/${GITHUB_REPOSITORY}/git/commits/${promotion_head}")"
+          merge_tree="$(jq -r '.tree.sha' <<< "$commit_details")"
+          promotion_tree="$(jq -r '.tree.sha' <<< "$promotion_head_details")"
+          if [ "$merge_tree" != "$promotion_tree" ]; then
+            echo "::error::promotion merge tree differs from the published beta snapshot; publish a new beta after back-merging master"
+            exit 1
+          fi
+          comparison="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${first_parent}...${promotion_head}")"
+          comparison_status="$(jq -r '.status' <<< "$comparison")"
+          if [ "$comparison_status" != "ahead" ] && [ "$comparison_status" != "identical" ]; then
+            echo "::error::promotion base ${first_parent} is not an ancestor of published beta ${promotion_head}"
+            exit 1
+          fi
+
+          if [[ "$promotion_title" =~ ^chore:\ promote\ (v([0-9]+)\.([0-9]+)\.([0-9]+)-beta(\.[0-9]+)?)\ to\ stable\ ([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            beta_tag="${BASH_REMATCH[1]}"
+            beta_stable="${BASH_REMATCH[2]}.${BASH_REMATCH[3]}.${BASH_REMATCH[4]}"
+            title_stable="${BASH_REMATCH[6]}"
+          else
+            echo "::error::promotion PR #${promotion_number} has an invalid title: ${promotion_title}"
+            exit 1
+          fi
+          if [ "$beta_stable" != "$title_stable" ]; then
+            echo "::error::promotion PR #${promotion_number} mismatches beta ${beta_tag} and stable ${title_stable}"
+            exit 1
+          fi
+
+          release_details="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${beta_tag}")"
+          if ! jq -e \
+            --arg head "$promotion_head" \
+            --arg tag "$beta_tag" \
+            '.tag_name == $tag and
+              .target_commitish == $head and
+              .draft == false and
+              .prerelease == true' \
+            <<< "$release_details" > /dev/null; then
+            echo "::error::promotion PR #${promotion_number} is not pinned to published beta ${beta_tag}"
+            exit 1
+          fi
+          tag_details="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${beta_tag}")"
+          if ! jq -e \
+            --arg head "$promotion_head" \
+            '.object.type == "commit" and .object.sha == $head' \
+            <<< "$tag_details" > /dev/null; then
+            echo "::error::published beta tag ${beta_tag} does not point to approved head ${promotion_head}"
+            exit 1
+          fi
+
+          echo "is_promotion=true" >> "$GITHUB_OUTPUT"
+          echo "stable_version=$title_stable" >> "$GITHUB_OUTPUT"
+
+      # A rerun can arrive after the generated stable Release PR or its draft
+      # release already exists. Classify that exact state before invoking
+      # release-please, and reject an unrelated advance of master.
+      - name: Prepare the stable promotion
+        if: steps.promotion.outputs.is_promotion == 'true'
+        id: promotion_state
+        env:
+          EXPECTED_STABLE_VERSION: ${{ steps.promotion.outputs.stable_version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          expected_head="release-please--branches--master--components--reflect-open"
+          expected_title="chore(master): release ${EXPECTED_STABLE_VERSION}"
+          expected_tag="v${EXPECTED_STABLE_VERSION}"
+          owner="${GITHUB_REPOSITORY%%/*}"
+          master_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/master" --jq '.object.sha')"
+
+          if [ "$master_sha" = "$GITHUB_SHA" ]; then
+            {
+              echo "phase=fresh"
+              echo "stable_commit="
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          closed_pulls="$({
+            gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls" \
+              -f state=closed \
+              -f base=master \
+              -f head="${owner}:${expected_head}" \
+              -f per_page=100
+          })"
+          stable_pr_number=""
+          stable_commit=""
+          while IFS=$'\t' read -r candidate_number candidate_commit; do
+            if [ -z "$candidate_number" ] || [ -z "$candidate_commit" ]; then
+              continue
+            fi
+            candidate_details="$(gh api "repos/${GITHUB_REPOSITORY}/git/commits/${candidate_commit}")"
+            candidate_parent_count="$(jq '.parents | length' <<< "$candidate_details")"
+            candidate_parent="$(jq -r '.parents[0].sha // empty' <<< "$candidate_details")"
+            if [ "$candidate_parent_count" -eq 1 ] && [ "$candidate_parent" = "$GITHUB_SHA" ]; then
+              if [ -n "$stable_pr_number" ]; then
+                echo "::error::multiple generated stable Release PRs descend from promotion ${GITHUB_SHA}"
+                exit 1
+              fi
+              stable_pr_number="$candidate_number"
+              stable_commit="$candidate_commit"
+            fi
+          done < <(
+            jq -r \
+              --arg repository "$GITHUB_REPOSITORY" \
+              --arg head "$expected_head" \
+              --arg title "$expected_title" \
+              '.[] | select(
+                .merged_at != null and
+                .title == $title and
+                .base.repo.full_name == $repository and
+                .base.ref == "master" and
+                .head.repo.full_name == $repository and
+                .head.ref == $head and
+                .user.login == "github-actions[bot]"
+              ) | [.number, .merge_commit_sha] | @tsv' <<< "$closed_pulls"
+          )
+
+          if [ -z "$stable_commit" ]; then
+            echo "::error::master advanced from approved promotion ${GITHUB_SHA} to unrelated commit ${master_sha}"
+            exit 1
+          fi
+
+          if release_details="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${expected_tag}" 2>/dev/null)"; then
+            if ! jq -e \
+              --arg commit "$stable_commit" \
+              --arg tag "$expected_tag" \
+              '.tag_name == $tag and
+                .target_commitish == $commit and
+                .prerelease == false and
+                ((.draft == true and .published_at == null) or
+                 (.draft == false and .published_at != null))' \
+              <<< "$release_details" > /dev/null; then
+              echo "::error::existing ${expected_tag} release does not match generated stable commit ${stable_commit}"
+              exit 1
+            fi
+            tag_details="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${expected_tag}")"
+            if ! jq -e \
+              --arg commit "$stable_commit" \
+              '.object.type == "commit" and .object.sha == $commit' \
+              <<< "$tag_details" > /dev/null; then
+              echo "::error::existing ${expected_tag} tag does not point to generated stable commit ${stable_commit}"
+              exit 1
+            fi
+
+            if [ "$(jq -r '.draft' <<< "$release_details")" = "true" ]; then
+              phase=recover-draft
+            else
+              phase=complete
+            fi
+            {
+              echo "phase=$phase"
+              echo "stable_commit=$stable_commit"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$master_sha" != "$stable_commit" ]; then
+            echo "::error::cannot safely create ${expected_tag}: master advanced beyond generated stable commit ${stable_commit}"
+            exit 1
+          fi
+
+          {
+            echo "phase=resume"
+            echo "stable_commit=$stable_commit"
+          } >> "$GITHUB_OUTPUT"
+
+      # A queued master run must never let release-please inspect commits that
+      # arrived after its event. The newest push gets its own queued run.
+      - name: Guard the stable branch snapshot
+        if: github.ref_name == 'master' && steps.promotion.outputs.is_promotion != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          master_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/master" --jq '.object.sha')"
+          if [ "$master_sha" != "$GITHUB_SHA" ]; then
+            echo "::error::master advanced from event ${GITHUB_SHA} to ${master_sha}; the newer push will maintain the stable release state"
+            exit 1
+          fi
+
+      # The action's release-as input is not forwarded in manifest mode. Use
+      # the lockfile-pinned matching CLI for the fresh promotion PR so a beta's
+      # stable base (including a major version) is exact.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        if: steps.promotion_state.outputs.phase == 'fresh'
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        if: steps.promotion_state.outputs.phase == 'fresh'
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        if: steps.promotion_state.outputs.phase == 'fresh'
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install the pinned release CLI
+        if: steps.promotion_state.outputs.phase == 'fresh'
+        run: pnpm install --frozen-lockfile --ignore-scripts --filter @reflect/monorepo
+
+      - name: Create the exact stable Release PR
+        if: steps.promotion_state.outputs.phase == 'fresh'
+        id: promotion_release_pr
+        env:
+          EXPECTED_STABLE_VERSION: ${{ steps.promotion.outputs.stable_version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          pnpm exec release-please release-pr \
+            --token "$GH_TOKEN" \
+            --repo-url "$GITHUB_REPOSITORY" \
+            --target-branch master \
+            --config-file .github/release-please/config.stable.json \
+            --manifest-file .github/release-please/manifest.stable.json \
+            --release-as "$EXPECTED_STABLE_VERSION"
+
+          expected_head="release-please--branches--master--components--reflect-open"
+          expected_title="chore(master): release ${EXPECTED_STABLE_VERSION}"
+          owner="${GITHUB_REPOSITORY%%/*}"
+          open_pulls="$(
+            gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls" \
+              -f state=open \
+              -f base=master \
+              -f head="${owner}:${expected_head}" \
+              -f per_page=100
+          )"
+          matches="$(
+            jq -c \
+              --arg repository "$GITHUB_REPOSITORY" \
+              --arg head "$expected_head" \
+              --arg title "$expected_title" \
+              '[.[] | select(
+                .title == $title and
+                .base.repo.full_name == $repository and
+                .base.ref == "master" and
+                .head.repo.full_name == $repository and
+                .head.ref == $head and
+                .user.login == "github-actions[bot]" and
+                any(.labels[]?; .name == "autorelease: pending")
+              )]' <<< "$open_pulls"
+          )"
+          if [ "$(jq 'length' <<< "$matches")" -ne 1 ]; then
+            echo "::error::release-please did not leave exactly one generated ${expected_title} PR"
+            exit 1
+          fi
+
+          number="$(jq -r '.[0].number' <<< "$matches")"
+          pr="$(
+            jq -cn \
+              --argjson number "$number" \
+              --arg head "$expected_head" \
+              --arg title "$expected_title" \
+              '{number: $number, headBranchName: $head, baseBranchName: "master", title: $title}'
+          )"
+          {
+            echo "prs_created=true"
+            echo "pr<<RELEASE_PR_JSON"
+            echo "$pr"
+            echo "RELEASE_PR_JSON"
+          } >> "$GITHUB_OUTPUT"
+
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
-        id: release
+        if: steps.promotion.outputs.is_promotion != 'true' || steps.promotion_state.outputs.phase == 'resume'
+        id: release_first
         with:
           target-branch: ${{ github.ref_name }}
           config-file: ${{ steps.channel.outputs.config }}
           manifest-file: ${{ steps.channel.outputs.manifest }}
 
-      # The output names above are load-bearing for the jobs below; dump the
-      # full map so a skipped downstream job is diagnosable from the run log.
+      - name: Validate the first promotion pass
+        if: steps.promotion.outputs.is_promotion == 'true' && steps.release_first.outputs.releases_created == 'true'
+        env:
+          EXPECTED_STABLE_VERSION: ${{ steps.promotion.outputs.stable_version }}
+          FIRST_TAG_NAME: ${{ steps.release_first.outputs.tag_name }}
+          PROMOTION_PHASE: ${{ steps.promotion_state.outputs.phase }}
+        run: |
+          set -euo pipefail
+
+          if [ "$FIRST_TAG_NAME" != "v${EXPECTED_STABLE_VERSION}" ]; then
+            echo "::error::release-please created unrelated ${FIRST_TAG_NAME} while preparing v${EXPECTED_STABLE_VERSION}"
+            exit 1
+          fi
+          if [ "$PROMOTION_PHASE" = "fresh" ]; then
+            echo "::error::release-please unexpectedly created the stable tag before merging its generated Release PR"
+            exit 1
+          fi
+
+      # A human approved the exact promotion head. release-please has now made
+      # the stable version/changelog PR; only merge the PR it returned, after
+      # verifying its live identity and pinning the merge to its current SHA.
+      - name: Squash-merge the generated stable Release PR
+        if: steps.promotion_state.outputs.phase == 'fresh' && steps.promotion_release_pr.outputs.prs_created == 'true'
+        id: stable_release_pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_STABLE_VERSION: ${{ steps.promotion.outputs.stable_version }}
+          RELEASE_PR: ${{ steps.promotion_release_pr.outputs.pr }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$RELEASE_PR" ]; then
+            echo "::error::release-please did not return a stable Release PR"
+            exit 1
+          fi
+
+          number="$(jq -er '.number | select(type == "number")' <<< "$RELEASE_PR")"
+          action_head="$(jq -er '.headBranchName' <<< "$RELEASE_PR")"
+          action_base="$(jq -er '.baseBranchName' <<< "$RELEASE_PR")"
+          action_title="$(jq -er '.title' <<< "$RELEASE_PR")"
+          expected_head="release-please--branches--master--components--reflect-open"
+          expected_title="chore(master): release ${EXPECTED_STABLE_VERSION}"
+          if [ "$action_head" != "$expected_head" ] || \
+            [ "$action_base" != "master" ] || \
+            [ "$action_title" != "$expected_title" ]; then
+            echo "::error::release-please returned unexpected PR #${number}: ${action_title} (${action_head} -> ${action_base})"
+            exit 1
+          fi
+
+          details="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${number}")"
+          if ! jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg base_sha "$GITHUB_SHA" \
+            --arg head "$expected_head" \
+            --arg title "$expected_title" \
+            --argjson number "$number" \
+            '.number == $number and
+              .state == "open" and
+              .title == $title and
+              .base.repo.full_name == $repository and
+              .base.ref == "master" and
+              .base.sha == $base_sha and
+              .head.repo.full_name == $repository and
+              .head.ref == $head and
+              .user.login == "github-actions[bot]" and
+              any(.labels[]?; .name == "autorelease: pending")' \
+            <<< "$details" > /dev/null; then
+            echo "::error::refusing to merge PR #${number}: it is not the generated stable Release PR"
+            exit 1
+          fi
+
+          head_sha="$(jq -er '.head.sha' <<< "$details")"
+          master_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/master" --jq '.object.sha')"
+          if [ "$master_sha" != "$GITHUB_SHA" ]; then
+            echo "::error::master advanced from approved promotion ${GITHUB_SHA} before the generated Release PR could merge"
+            exit 1
+          fi
+
+          expected_files="$(printf '%s\n' \
+            '.github/release-please/manifest.stable.json' \
+            'apps/desktop/CHANGELOG.md' \
+            'apps/desktop/package.json')"
+          actual_files="$(
+            gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${number}/files" --jq '.[].filename' |
+              LC_ALL=C sort
+          )"
+          if [ "$actual_files" != "$expected_files" ]; then
+            echo "::error::generated stable Release PR #${number} changed unexpected files"
+            diff -u <(printf '%s\n' "$expected_files") <(printf '%s\n' "$actual_files") || true
+            exit 1
+          fi
+
+          temporary_directory="$(mktemp -d)"
+          trap 'rm -rf "$temporary_directory"' EXIT
+          for ref in "$GITHUB_SHA" "$head_sha"; do
+            gh api "repos/${GITHUB_REPOSITORY}/contents/apps/desktop/package.json?ref=${ref}" \
+              --jq '.content' | base64 --decode > "$temporary_directory/package-${ref}.json"
+            gh api "repos/${GITHUB_REPOSITORY}/contents/.github/release-please/manifest.stable.json?ref=${ref}" \
+              --jq '.content' | base64 --decode > "$temporary_directory/manifest-${ref}.json"
+          done
+          gh api "repos/${GITHUB_REPOSITORY}/contents/apps/desktop/CHANGELOG.md?ref=${head_sha}" \
+            --jq '.content' | base64 --decode > "$temporary_directory/changelog.md"
+
+          if ! jq -e --arg version "$EXPECTED_STABLE_VERSION" '.version == $version' \
+            "$temporary_directory/package-${head_sha}.json" > /dev/null; then
+            echo "::error::generated stable Release PR has the wrong package version"
+            exit 1
+          fi
+          jq -S 'del(.version)' "$temporary_directory/package-${GITHUB_SHA}.json" > "$temporary_directory/package-base.json"
+          jq -S 'del(.version)' "$temporary_directory/package-${head_sha}.json" > "$temporary_directory/package-head.json"
+          if ! cmp -s "$temporary_directory/package-base.json" "$temporary_directory/package-head.json"; then
+            echo "::error::generated stable Release PR changed package.json fields other than version"
+            exit 1
+          fi
+
+          if ! jq -e --arg version "$EXPECTED_STABLE_VERSION" '."." == $version' \
+            "$temporary_directory/manifest-${head_sha}.json" > /dev/null; then
+            echo "::error::generated stable Release PR has the wrong stable manifest version"
+            exit 1
+          fi
+          jq -S 'del(.".")' "$temporary_directory/manifest-${GITHUB_SHA}.json" > "$temporary_directory/manifest-base.json"
+          jq -S 'del(.".")' "$temporary_directory/manifest-${head_sha}.json" > "$temporary_directory/manifest-head.json"
+          if ! cmp -s "$temporary_directory/manifest-base.json" "$temporary_directory/manifest-head.json"; then
+            echo "::error::generated stable Release PR changed unexpected stable manifest fields"
+            exit 1
+          fi
+          if ! grep -Fq "## [${EXPECTED_STABLE_VERSION}]" "$temporary_directory/changelog.md"; then
+            echo "::error::generated stable changelog does not contain ${EXPECTED_STABLE_VERSION}"
+            exit 1
+          fi
+
+          gh pr merge "$number" \
+            --repo "$GITHUB_REPOSITORY" \
+            --squash \
+            --match-head-commit "$head_sha"
+
+          merged_pr="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${number}")"
+          merged_sha="$(jq -r '.merge_commit_sha // empty' <<< "$merged_pr")"
+          if [ "$(jq -r '.merged' <<< "$merged_pr")" != "true" ] || [ -z "$merged_sha" ]; then
+            echo "::error::generated stable Release PR #${number} was not merged"
+            exit 1
+          fi
+          merged_details="$(gh api "repos/${GITHUB_REPOSITORY}/git/commits/${merged_sha}")"
+          parent_count="$(jq '.parents | length' <<< "$merged_details")"
+          parent_sha="$(jq -r '.parents[0].sha // empty' <<< "$merged_details")"
+          if [ "$parent_count" -ne 1 ] || [ "$parent_sha" != "$GITHUB_SHA" ]; then
+            # A base-branch race can occur in the narrow interval inside
+            # GitHub's merge operation. Quarantine the merged PR before this
+            # job releases its concurrency lock so no queued master run can
+            # tag the unapproved result.
+            gh api --method DELETE \
+              "repos/${GITHUB_REPOSITORY}/issues/${number}/labels/autorelease%3A%20pending" > /dev/null
+            jq -n '{labels: ["autorelease: tagged"]}' |
+              gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${number}/labels" --input - > /dev/null
+            echo "::error::generated stable Release PR did not merge directly onto approved promotion ${GITHUB_SHA}"
+            exit 1
+          fi
+          echo "merged=true" >> "$GITHUB_OUTPUT"
+          echo "stable_commit=$merged_sha" >> "$GITHUB_OUTPUT"
+
+      # A GITHUB_TOKEN merge does not start another workflow. Run the action a
+      # second time against the now-updated master so it creates the tag and
+      # draft release in this same job.
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        if: steps.stable_release_pr.outputs.merged == 'true'
+        id: release_second
+        with:
+          target-branch: master
+          config-file: ${{ steps.channel.outputs.config }}
+          manifest-file: ${{ steps.channel.outputs.manifest }}
+
+      # The first action owns normal beta/stable releases. The second owns the
+      # single-approval promotion path; normalize them for downstream jobs.
+      - name: Collect release-please outputs
+        id: result
+        env:
+          FIRST_RELEASE_CREATED: ${{ steps.release_first.outputs.releases_created }}
+          FIRST_TAG_NAME: ${{ steps.release_first.outputs.tag_name }}
+          EXPECTED_STABLE_VERSION: ${{ steps.promotion.outputs.stable_version }}
+          GH_TOKEN: ${{ github.token }}
+          IS_PROMOTION: ${{ steps.promotion.outputs.is_promotion }}
+          PREPARED_STABLE_COMMIT: ${{ steps.promotion_state.outputs.stable_commit }}
+          PROMOTION_PHASE: ${{ steps.promotion_state.outputs.phase }}
+          MERGED_STABLE_COMMIT: ${{ steps.stable_release_pr.outputs.stable_commit }}
+          STABLE_RELEASE_PR_MERGED: ${{ steps.stable_release_pr.outputs.merged }}
+          SECOND_RELEASE_CREATED: ${{ steps.release_second.outputs.releases_created }}
+          SECOND_TAG_NAME: ${{ steps.release_second.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+
+          release_created=false
+          tag_name=""
+          release_commit=""
+          if [ "$IS_PROMOTION" = "true" ]; then
+            expected_tag="v${EXPECTED_STABLE_VERSION}"
+            stable_commit="${MERGED_STABLE_COMMIT:-$PREPARED_STABLE_COMMIT}"
+            if [ "$SECOND_RELEASE_CREATED" = "true" ]; then
+              release_created=true
+              tag_name="$SECOND_TAG_NAME"
+            elif [ "$FIRST_RELEASE_CREATED" = "true" ]; then
+              release_created=true
+              tag_name="$FIRST_TAG_NAME"
+            elif [ -n "$stable_commit" ] && \
+              release_details="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${expected_tag}" 2>/dev/null)"; then
+              if ! jq -e \
+                --arg commit "$stable_commit" \
+                --arg tag "$expected_tag" \
+                '.tag_name == $tag and
+                  .target_commitish == $commit and
+                  .prerelease == false and
+                  ((.draft == true and .published_at == null) or
+                   (.draft == false and .published_at != null))' \
+                <<< "$release_details" > /dev/null; then
+                echo "::error::existing ${expected_tag} release does not match generated stable commit ${stable_commit}"
+                exit 1
+              fi
+              tag_details="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${expected_tag}")"
+              if ! jq -e \
+                --arg commit "$stable_commit" \
+                '.object.type == "commit" and .object.sha == $commit' \
+                <<< "$tag_details" > /dev/null; then
+                echo "::error::existing ${expected_tag} tag does not point to generated stable commit ${stable_commit}"
+                exit 1
+              fi
+
+              if [ "$(jq -r '.draft' <<< "$release_details")" = "true" ]; then
+                release_created=true
+                tag_name="$expected_tag"
+                echo "Recovering draft ${expected_tag} created by an earlier promotion attempt."
+              else
+                echo "The promoted ${expected_tag} release is already published; no release work remains."
+              fi
+            else
+              if [ "$STABLE_RELEASE_PR_MERGED" = "true" ]; then
+                echo "::error::the second release-please run did not create the promoted stable release"
+                exit 1
+              fi
+              if [ "$PROMOTION_PHASE" = "fresh" ]; then
+                echo "::error::release-please did not create a stable Release PR for the promotion"
+                exit 1
+              fi
+              if [ "$PROMOTION_PHASE" = "resume" ]; then
+                echo "::error::release-please did not create the stable release while resuming the promotion"
+                exit 1
+              fi
+              echo "The promotion is already complete; no release work remains."
+            fi
+          elif [ "$FIRST_RELEASE_CREATED" = "true" ]; then
+            if [ -z "$FIRST_TAG_NAME" ]; then
+              echo "::error::release-please reported a release without a tag"
+              exit 1
+            fi
+            release_created=true
+            tag_name="$FIRST_TAG_NAME"
+          fi
+
+          if [ "$release_created" = "true" ] && [ -z "$tag_name" ]; then
+            echo "::error::release-please reported a release without a tag"
+            exit 1
+          fi
+          if [ "$IS_PROMOTION" = "true" ] && \
+            [ "$release_created" = "true" ] && \
+            [ "$tag_name" != "v${EXPECTED_STABLE_VERSION}" ]; then
+            echo "::error::promoted release tag ${tag_name} does not match v${EXPECTED_STABLE_VERSION}"
+            exit 1
+          fi
+          if [ "$IS_PROMOTION" = "true" ] && [ "$release_created" = "true" ]; then
+            if [ -z "$stable_commit" ]; then
+              echo "::error::promoted release has no verified stable commit"
+              exit 1
+            fi
+            release_details="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag_name}")"
+            if ! jq -e \
+              --arg commit "$stable_commit" \
+              --arg tag "$tag_name" \
+              '.tag_name == $tag and
+                .target_commitish == $commit and
+                .draft == true and
+                .published_at == null and
+                .prerelease == false' \
+              <<< "$release_details" > /dev/null; then
+              echo "::error::promoted draft ${tag_name} is not pinned to generated stable commit ${stable_commit}"
+              exit 1
+            fi
+            tag_details="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag_name}")"
+            if ! jq -e \
+              --arg commit "$stable_commit" \
+              '.object.type == "commit" and .object.sha == $commit' \
+              <<< "$tag_details" > /dev/null; then
+              echo "::error::promoted tag ${tag_name} does not point to generated stable commit ${stable_commit}"
+              exit 1
+            fi
+          fi
+
+          if [ "$release_created" = "true" ]; then
+            if [[ ! "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+              echo "::error::release-please returned invalid tag ${tag_name}"
+              exit 1
+            fi
+            tag_details="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag_name}")"
+            if ! jq -e '.object.type == "commit"' <<< "$tag_details" > /dev/null; then
+              echo "::error::release tag ${tag_name} is not a lightweight commit tag"
+              exit 1
+            fi
+            release_commit="$(jq -r '.object.sha' <<< "$tag_details")"
+            release_details="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag_name}")"
+            if ! jq -e \
+              --arg commit "$release_commit" \
+              --arg tag "$tag_name" \
+              '.tag_name == $tag and .target_commitish == $commit' \
+              <<< "$release_details" > /dev/null; then
+              echo "::error::GitHub release ${tag_name} is not pinned to tag commit ${release_commit}"
+              exit 1
+            fi
+            if [ "$IS_PROMOTION" = "true" ] && [ "$release_commit" != "$stable_commit" ]; then
+              echo "::error::promoted release commit ${release_commit} does not match generated stable commit ${stable_commit}"
+              exit 1
+            fi
+          fi
+
+          {
+            echo "release_created=$release_created"
+            echo "tag_name=$tag_name"
+            echo "release_commit=$release_commit"
+          } >> "$GITHUB_OUTPUT"
+
+      # These output names are load-bearing for downstream jobs. Dump both maps
+      # so a skipped publish is diagnosable from the run log.
       - name: Print release-please outputs
         env:
-          RELEASE_PLEASE_OUTPUTS: ${{ toJSON(steps.release.outputs) }}
-        run: echo "$RELEASE_PLEASE_OUTPUTS"
+          FIRST_RELEASE_PLEASE_OUTPUTS: ${{ toJSON(steps.release_first.outputs) }}
+          SECOND_RELEASE_PLEASE_OUTPUTS: ${{ toJSON(steps.release_second.outputs) }}
+        run: |
+          echo "$FIRST_RELEASE_PLEASE_OUTPUTS"
+          echo "$SECOND_RELEASE_PLEASE_OUTPUTS"
 
   # Merging the Release PR makes release-please create a draft release and
   # output its tag. Chain straight into the build/sign/publish pipeline; tags
@@ -65,6 +714,7 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
+      commit: ${{ needs.release-please.outputs.release_commit }}
     secrets: inherit
 
   # Every release also ships to TestFlight. iOS needs no version bump of its
@@ -76,7 +726,30 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     uses: ./.github/workflows/testflight.yml
+    with:
+      commit: ${{ needs.release-please.outputs.release_commit }}
     secrets: inherit
+
+  # Publishing a beta makes it eligible for stable promotion. Wait for both
+  # delivery channels before moving the managed promotion branch or opening its
+  # PR, so the single approval always points at a beta that actually shipped.
+  promote-stable:
+    name: Open the stable promotion PR
+    needs: [release-please, publish-release, publish-testflight]
+    if: github.ref_name == 'next' && needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_COMMIT: ${{ needs.release-please.outputs.release_commit }}
+      TAG: ${{ needs.release-please.outputs.tag_name }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.release-please.outputs.release_commit }}
+
+      - name: Open or update the stable promotion PR
+        run: node apps/desktop/scripts/release-promotion.mjs "$TAG" "$RELEASE_COMMIT"
 
   # After a stable release, open a single PR that merges master back into next
   # and advances the beta manifest. A human merges it with a merge commit —
@@ -90,17 +763,29 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
+      RELEASE_COMMIT: ${{ needs.release-please.outputs.release_commit }}
       TAG: ${{ needs.release-please.outputs.tag_name }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          ref: ${{ needs.release-please.outputs.release_commit }}
 
       - name: Open the back-merge PR into next
         run: |
+          set -euo pipefail
+
           version="${TAG#v}"
           branch="post-stable-${TAG}"
-          git switch -c "$branch" origin/master
+          title="chore: merge master back into next"
+          body="Back-merge after the ${TAG} stable release. Merge with a merge commit, not squash."
+          tag_ref="refs/tags/${TAG}"
+          tag_commit="$(git rev-parse "${tag_ref}^{commit}")"
+          if [ "$tag_commit" != "$RELEASE_COMMIT" ]; then
+            echo "::error::${TAG} moved from verified release commit ${RELEASE_COMMIT} to ${tag_commit}"
+            exit 1
+          fi
+          git switch -c "$branch" "$RELEASE_COMMIT"
 
           # Advance the beta manifest only when it is behind the just-released
           # stable version; never move it backwards once next has entered a
@@ -117,6 +802,7 @@ jobs:
           current="$(git show "origin/next:$manifest" | jq -r '."."')"
           base="${current%%-*}"
           lower="$(printf '%s\n%s\n' "$base" "$version" | sort -t . -k 1,1n -k 2,2n -k 3,3n | head -1)"
+          manifest_advanced=false
           if { [ "$base" != "$version" ] && [ "$lower" = "$base" ]; } ||
             { [ "$base" = "$version" ] && [ "$current" != "$base" ]; }; then
             jq --arg v "$version" '."." = $v' "$manifest" > "$manifest.tmp"
@@ -125,9 +811,71 @@ jobs:
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add "$manifest"
             git commit -m "chore: open the next beta cycle"
+            manifest_advanced=true
           fi
 
-          git push origin "$branch"
-          gh pr create --base next --head "$branch" \
-            --title "chore: merge master back into next" \
-            --body "Back-merge after the ${TAG} stable release. Merge with a merge commit, not squash."
+          desired_manifest="$(git show "HEAD:$manifest")"
+          next_manifest="$(git show "origin/next:$manifest")"
+          if git merge-base --is-ancestor "$RELEASE_COMMIT" origin/next && \
+            { [ "$manifest_advanced" = "false" ] || [ "$desired_manifest" = "$next_manifest" ]; }; then
+            echo "${TAG} and its beta-manifest advance are already present on next."
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --heads origin "refs/heads/${branch}" > /dev/null 2>&1; then
+            git fetch --no-tags origin "+refs/heads/${branch}:refs/remotes/origin/${branch}"
+            remote_commit="$(git rev-parse "origin/${branch}^{commit}")"
+            if [ "$remote_commit" != "$tag_commit" ]; then
+              read -r -a remote_line <<< "$(git rev-list --parents -n 1 "$remote_commit")"
+              remote_subject="$(git show -s --format=%s "$remote_commit")"
+              remote_files="$(git diff --name-only "$tag_commit" "$remote_commit")"
+              remote_version="$(git show "${remote_commit}:${manifest}" | jq -r '."."')"
+              if [ "${#remote_line[@]}" -ne 2 ] || \
+                [ "${remote_line[1]}" != "$tag_commit" ] || \
+                [ "$remote_subject" != "chore: open the next beta cycle" ] || \
+                [ "$remote_files" != "$manifest" ] || \
+                [ "$remote_version" != "$version" ]; then
+                echo "::error::existing ${branch} has unexpected history"
+                exit 1
+              fi
+            fi
+            if [ "$remote_commit" = "$tag_commit" ] && [ "$manifest_advanced" = "true" ]; then
+              git push origin "HEAD:refs/heads/${branch}"
+            else
+              git reset --hard "origin/${branch}"
+            fi
+          else
+            git push origin "HEAD:refs/heads/${branch}"
+          fi
+
+          owner="${GITHUB_REPOSITORY%%/*}"
+          open_pulls="$(
+            gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls" \
+              -f state=open \
+              -f base=next \
+              -f head="${owner}:${branch}" \
+              -f per_page=100
+          )"
+          matches="$(
+            jq -c \
+              --arg repository "$GITHUB_REPOSITORY" \
+              --arg branch "$branch" \
+              '[.[] | select(
+                .base.repo.full_name == $repository and
+                .base.ref == "next" and
+                .head.repo.full_name == $repository and
+                .head.ref == $branch
+              )]' <<< "$open_pulls"
+          )"
+          match_count="$(jq 'length' <<< "$matches")"
+          if [ "$match_count" -gt 1 ]; then
+            echo "::error::found multiple open ${TAG} back-merge PRs"
+            exit 1
+          fi
+          if [ "$match_count" -eq 1 ]; then
+            number="$(jq -r '.[0].number' <<< "$matches")"
+            gh pr edit "$number" --repo "$GITHUB_REPOSITORY" --title "$title" --body "$body"
+          else
+            gh pr create --repo "$GITHUB_REPOSITORY" --base next --head "$branch" \
+              --title "$title" --body "$body"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ on:
         description: The release tag (v<version>) created by release-please
         type: string
         required: true
+      commit:
+        description: Immutable commit targeted by the release tag
+        type: string
+        required: true
   # Manual fallback and retry path: run on a branch (or commit) whose version
   # was already bumped by a merged PR; the tag is derived from
   # apps/desktop/package.json.
@@ -38,9 +42,12 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # Reusable workflows inherit the caller SHA, which may be newer or
+          # older than the release. Build the verified immutable tag commit.
+          ref: ${{ inputs.commit || github.sha }}
           # Unlike CI, credentials stay: the publish preflights run
           # `git ls-remote` against origin. Full history so the
-          # HEAD-is-on-an-origin-branch check also passes on tag checkouts.
+          # HEAD-is-on-an-origin-branch check also passes on release commits.
           persist-credentials: true
           fetch-depth: 0
 
@@ -87,6 +94,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ inputs.commit || github.sha }}
           persist-credentials: false
 
       # Without the certificate, signing only fails at codesign time — after
@@ -188,8 +196,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # Full history so the HEAD-is-on-an-origin-branch check passes on tag
-          # checkouts, and credentials stay for gh/git release preflights.
+          ref: ${{ inputs.commit || github.sha }}
+          # Full history so the HEAD-is-on-an-origin-branch check passes on the
+          # release commit, and credentials stay for gh/git release preflights.
           persist-credentials: true
           fetch-depth: 0
 
@@ -216,7 +225,12 @@ jobs:
           # Pass the boolean flag through an env variable so the shell never
           # interpolates ${{ }} expressions directly into the run command.
           DRAFT_FLAG: ${{ inputs.draft && '--draft' || '' }}
-        run: node apps/desktop/scripts/release-macos.mjs publish --defer-beta-feed --from-artifacts="$RUNNER_TEMP/release-artifacts" $DRAFT_FLAG
+        run: |
+          args=(publish --defer-beta-feed --from-artifacts="$RUNNER_TEMP/release-artifacts")
+          if [ -n "$DRAFT_FLAG" ]; then
+            args+=("$DRAFT_FLAG")
+          fi
+          node apps/desktop/scripts/release-macos.mjs "${args[@]}"
 
   sync-beta-feed:
     name: Sync beta downloads and updater feed
@@ -226,6 +240,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ inputs.commit || github.sha }}
           persist-credentials: true
           fetch-depth: 0
 

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -21,6 +21,10 @@ on:
   # the export method.
   workflow_call:
     inputs:
+      commit:
+        description: Immutable commit targeted by the release tag.
+        required: true
+        type: string
       export_method:
         description: Xcode export method for the IPA (app-store-connect or release-testing).
         required: false
@@ -53,6 +57,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # Reusable workflows inherit the caller SHA, which may not be the
+          # release snapshot. Always build the verified immutable tag commit.
+          ref: ${{ inputs.commit || github.sha }}
           persist-credentials: false
 
       - name: Verify TestFlight secrets are configured
@@ -111,7 +118,11 @@ jobs:
           WAIT_FLAG: ${{ inputs.wait_for_processing && '--wait' || '' }}
         run: |
           pnpm release:ios preflight --build-number="$BUILD_NUMBER"
-          pnpm release:ios testflight --build-number="$BUILD_NUMBER" --export-method="$EXPORT_METHOD" $WAIT_FLAG
+          args=(testflight --build-number="$BUILD_NUMBER" --export-method="$EXPORT_METHOD")
+          if [ -n "$WAIT_FLAG" ]; then
+            args+=("$WAIT_FLAG")
+          fi
+          pnpm release:ios "${args[@]}"
 
       # The exported IPA, kept for post-hoc signing/entitlements inspection —
       # TestFlight builds cannot be downloaded back from App Store Connect.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,9 @@ commit message and, for `feat`/`fix`, the user-facing changelog entry.
 - `docs:` / `chore:` / `ci:` / `test:` / `refactor:` / `build:` — no release,
   no changelog entry.
 - Reflect is an app, not a library: `feat!:` and `BREAKING CHANGE:` footers are
-  not used (CI rejects `!`). Going 1.0 someday is a product decision, made by
-  editing the release manifests, not by commit markers.
+  not used (CI rejects `!`). Going 1.0 someday is a product decision: open the
+  1.0 beta cycle through the beta release manifest, then the stable promotion
+  carries `1.0.0-beta.N` to `1.0.0` automatically.
 - Write the title as user-visible behavior (`fix: keep the daily caret in view
   on long iOS notes`), not implementation detail.
 - The changelog is scoped to `apps/desktop/`: a change that should appear in it

--- a/apps/desktop/scripts/release-promotion.mjs
+++ b/apps/desktop/scripts/release-promotion.mjs
@@ -1,0 +1,363 @@
+// Maintain the rolling pull request that promotes the latest published beta
+// snapshot from `next` to `master`.
+//
+// Usage:
+//   node apps/desktop/scripts/release-promotion.mjs v0.6.0-beta.14 <commit-sha>
+
+// The branch always points directly at a beta tag commit. It is only created
+// or fast-forwarded, so an older or unrelated workflow run cannot replace a
+// newer promotion candidate.
+
+import { execFileSync, spawnSync } from 'node:child_process'
+import { pathToFileURL } from 'node:url'
+
+/** Rolling bot branch whose tip is the latest promotable beta tag commit. */
+export const PROMOTION_BRANCH = 'release-promotion/latest-beta'
+/** Stable branch targeted by the rolling promotion pull request. */
+export const PROMOTION_BASE_BRANCH = 'master'
+const DEVELOPMENT_BRANCH = 'next'
+const GITHUB_REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/i
+
+const BETA_TAG_PATTERN =
+  /^v(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)-beta(?:\.(?<prerelease>0|[1-9]\d*))?$/
+
+function log(message) {
+  console.log(`release-promotion: ${message}`)
+}
+
+function commandOutput(result) {
+  return `${result.stdout ?? ''}${result.stderr ?? ''}`.trim()
+}
+
+function capture(command, args) {
+  return execFileSync(command, args, { encoding: 'utf8' }).trim()
+}
+
+function run(command, args) {
+  execFileSync(command, args, { stdio: 'inherit' })
+}
+
+/** Parse and validate a release-please beta tag. */
+export function validateBetaTag(tag) {
+  const match = BETA_TAG_PATTERN.exec(tag)
+  if (!match?.groups) {
+    throw new Error(`expected a beta tag like v0.6.0-beta or v0.6.0-beta.14, received "${tag}"`)
+  }
+
+  const stableVersion = `${match.groups.major}.${match.groups.minor}.${match.groups.patch}`
+  return {
+    tag,
+    version: tag.slice(1),
+    stableVersion,
+  }
+}
+
+/** Validate an immutable Git commit supplied by the release workflow. */
+export function validateCommitSha(commit) {
+  if (!COMMIT_SHA_PATTERN.test(commit)) {
+    throw new Error(`expected a 40-character release commit SHA, received "${commit}"`)
+  }
+  return commit.toLowerCase()
+}
+
+/**
+ * Decide how a rolling branch may move without ever rewinding or switching to
+ * unrelated history.
+ */
+export function decideBranchUpdate({
+  currentCommit,
+  targetCommit,
+  currentIsAncestorOfTarget = false,
+  targetIsAncestorOfCurrent = false,
+}) {
+  if (!currentCommit) return 'create'
+  if (currentCommit === targetCommit) return 'unchanged'
+  if (currentIsAncestorOfTarget && !targetIsAncestorOfCurrent) return 'fast-forward'
+  if (targetIsAncestorOfCurrent && !currentIsAncestorOfTarget) {
+    return 'stale'
+  }
+  if (currentIsAncestorOfTarget && targetIsAncestorOfCurrent) {
+    throw new Error(`inconsistent ancestry reported for ${currentCommit} and ${targetCommit}`)
+  }
+  throw new Error(
+    `refusing to move ${PROMOTION_BRANCH} from ${currentCommit} to divergent commit ${targetCommit}`,
+  )
+}
+
+/** Build the stable-promotion PR fields shown to the releaser. */
+export function createPromotionPrMetadata(betaTag) {
+  const { stableVersion } = validateBetaTag(betaTag)
+  return {
+    base: PROMOTION_BASE_BRANCH,
+    head: PROMOTION_BRANCH,
+    title: `chore: promote ${betaTag} to stable ${stableVersion}`,
+    body: [
+      `Promotes the exact published beta snapshot \`${betaTag}\` from \`${DEVELOPMENT_BRANCH}\` to \`${PROMOTION_BASE_BRANCH}\`.`,
+      '',
+      'Merging this PR is the single human approval for the stable release. The release workflow will finalize the stable version and changelog, then publish the desktop and TestFlight builds.',
+      '',
+      '**Merge with “Create a merge commit”. Do not squash or rebase this PR.** A merge commit preserves the development history shared by the release branches.',
+    ].join('\n'),
+  }
+}
+
+/** Validate the owner/name repository identifier supplied by GitHub Actions. */
+export function validateGitHubRepository(repository) {
+  if (!GITHUB_REPOSITORY_PATTERN.test(repository)) {
+    throw new Error(`expected GITHUB_REPOSITORY to contain owner/name, received "${repository}"`)
+  }
+  return repository
+}
+
+/** Build `gh pr create` arguments for the rolling promotion PR. */
+export function createPromotionPrCreateArgs(metadata, repository) {
+  return [
+    'pr',
+    'create',
+    '--repo',
+    validateGitHubRepository(repository),
+    '--base',
+    metadata.base,
+    '--head',
+    metadata.head,
+    '--title',
+    metadata.title,
+    '--body',
+    metadata.body,
+  ]
+}
+
+/** Build `gh pr edit` arguments for an existing rolling promotion PR. */
+export function createPromotionPrEditArgs({ metadata, number, repository }) {
+  return [
+    'pr',
+    'edit',
+    String(number),
+    '--repo',
+    validateGitHubRepository(repository),
+    '--title',
+    metadata.title,
+    '--body',
+    metadata.body,
+  ]
+}
+
+/** Build `gh pr list` arguments including the repository-identity fields. */
+export function createPromotionPrListArgs(repository) {
+  return [
+    'pr',
+    'list',
+    '--repo',
+    validateGitHubRepository(repository),
+    '--state',
+    'open',
+    '--base',
+    PROMOTION_BASE_BRANCH,
+    '--head',
+    PROMOTION_BRANCH,
+    '--json',
+    'number,baseRefName,headRefName,headRepository,isCrossRepository',
+    '--limit',
+    '10',
+  ]
+}
+
+function isAncestor(ancestor, descendant) {
+  const result = spawnSync('git', ['merge-base', '--is-ancestor', ancestor, descendant], {
+    encoding: 'utf8',
+  })
+  if (result.status === 0) return true
+  if (result.status === 1) return false
+  throw new Error(
+    `git merge-base failed for ${ancestor} and ${descendant}${commandOutput(result) ? `: ${commandOutput(result)}` : ''}`,
+  )
+}
+
+function remoteBranchCommit(branch) {
+  const result = spawnSync(
+    'git',
+    ['ls-remote', '--exit-code', '--heads', 'origin', `refs/heads/${branch}`],
+    { encoding: 'utf8' },
+  )
+  if (result.status === 2) return null
+  if (result.status !== 0) {
+    throw new Error(
+      `could not read origin/${branch}${commandOutput(result) ? `: ${commandOutput(result)}` : ''}`,
+    )
+  }
+
+  const commit = result.stdout.trim().split(/\s+/)[0]
+  if (!/^[0-9a-f]{40}$/i.test(commit)) {
+    throw new Error(`origin/${branch} returned an invalid commit: ${result.stdout.trim()}`)
+  }
+  return commit
+}
+
+function fetchReleaseRefs(betaTag) {
+  run('git', [
+    'fetch',
+    '--no-tags',
+    'origin',
+    `+refs/heads/${DEVELOPMENT_BRANCH}:refs/remotes/origin/${DEVELOPMENT_BRANCH}`,
+    `+refs/heads/${PROMOTION_BASE_BRANCH}:refs/remotes/origin/${PROMOTION_BASE_BRANCH}`,
+  ])
+  run('git', ['fetch', '--force', 'origin', `refs/tags/${betaTag}:refs/tags/${betaTag}`])
+}
+
+function fetchPromotionBranch() {
+  run('git', [
+    'fetch',
+    '--no-tags',
+    'origin',
+    `+refs/heads/${PROMOTION_BRANCH}:refs/remotes/origin/${PROMOTION_BRANCH}`,
+  ])
+}
+
+/** Parse `gh pr list` output and retain only this repository's managed PR. */
+export function parseManagedPromotionPrNumbers(output, repository) {
+  const expectedRepository = validateGitHubRepository(repository).toLowerCase()
+  let pullRequests
+  try {
+    pullRequests = JSON.parse(output)
+  } catch {
+    throw new Error('gh returned invalid JSON while listing promotion PRs')
+  }
+  if (!Array.isArray(pullRequests)) {
+    throw new Error('gh returned a non-array while listing promotion PRs')
+  }
+
+  return pullRequests.flatMap((pullRequest, index) => {
+    if (
+      !pullRequest ||
+      typeof pullRequest !== 'object' ||
+      !Number.isSafeInteger(pullRequest.number) ||
+      pullRequest.number <= 0 ||
+      typeof pullRequest.baseRefName !== 'string' ||
+      typeof pullRequest.headRefName !== 'string' ||
+      typeof pullRequest.isCrossRepository !== 'boolean' ||
+      (pullRequest.headRepository !== null &&
+        (typeof pullRequest.headRepository !== 'object' ||
+          typeof pullRequest.headRepository.nameWithOwner !== 'string'))
+    ) {
+      throw new Error(`gh returned an invalid promotion PR at index ${index}`)
+    }
+
+    const headRepository = pullRequest.headRepository?.nameWithOwner.toLowerCase()
+    const isManaged =
+      !pullRequest.isCrossRepository &&
+      headRepository === expectedRepository &&
+      pullRequest.baseRefName === PROMOTION_BASE_BRANCH &&
+      pullRequest.headRefName === PROMOTION_BRANCH
+    return isManaged ? [pullRequest.number] : []
+  })
+}
+
+function openPromotionPrNumbers(repository) {
+  const output = capture('gh', createPromotionPrListArgs(repository))
+  return parseManagedPromotionPrNumbers(output, repository)
+}
+
+function updatePromotionPr(number, metadata, repository) {
+  run('gh', createPromotionPrEditArgs({ metadata, number, repository }))
+  log(`updated promotion PR #${number} for ${metadata.title}`)
+}
+
+function createOrUpdatePromotionPr(metadata, repository) {
+  const existing = openPromotionPrNumbers(repository)
+  if (existing.length > 1) {
+    throw new Error(`found multiple open promotion PRs: ${existing.map((number) => `#${number}`).join(', ')}`)
+  }
+  if (existing.length === 1) {
+    updatePromotionPr(existing[0], metadata, repository)
+    return
+  }
+
+  const create = spawnSync('gh', createPromotionPrCreateArgs(metadata, repository), {
+    encoding: 'utf8',
+  })
+  if (create.status === 0) {
+    log(`opened promotion PR${create.stdout.trim() ? `: ${create.stdout.trim()}` : ''}`)
+    return
+  }
+
+  // Another release workflow may have created the same rolling PR after the
+  // initial lookup. GitHub rejects the duplicate; discover and update the
+  // winning PR so both runs remain idempotent.
+  const concurrent = openPromotionPrNumbers(repository)
+  if (concurrent.length === 1) {
+    updatePromotionPr(concurrent[0], metadata, repository)
+    return
+  }
+  throw new Error(
+    `could not create the promotion PR${commandOutput(create) ? `: ${commandOutput(create)}` : ''}`,
+  )
+}
+
+function updatePromotionBranch(betaTag, expectedCommit) {
+  fetchReleaseRefs(betaTag)
+
+  const betaCommit = capture('git', ['rev-parse', `${betaTag}^{commit}`])
+  if (betaCommit !== expectedCommit) {
+    throw new Error(`${betaTag} moved from verified release commit ${expectedCommit} to ${betaCommit}`)
+  }
+  if (!isAncestor(betaCommit, `origin/${DEVELOPMENT_BRANCH}`)) {
+    throw new Error(`${betaTag} (${betaCommit}) is not on origin/${DEVELOPMENT_BRANCH}`)
+  }
+  if (isAncestor(betaCommit, `origin/${PROMOTION_BASE_BRANCH}`)) {
+    log(`${betaTag} (${betaCommit}) is already contained in origin/${PROMOTION_BASE_BRANCH}`)
+    return 'already-promoted'
+  }
+  if (!isAncestor(`origin/${PROMOTION_BASE_BRANCH}`, betaCommit)) {
+    throw new Error(`origin/${PROMOTION_BASE_BRANCH} is not an ancestor of ${betaTag} (${betaCommit})`)
+  }
+
+  const currentCommit = remoteBranchCommit(PROMOTION_BRANCH)
+  if (currentCommit) fetchPromotionBranch()
+  const decision = decideBranchUpdate({
+    currentCommit,
+    targetCommit: betaCommit,
+    currentIsAncestorOfTarget: currentCommit ? isAncestor(currentCommit, betaCommit) : false,
+    targetIsAncestorOfCurrent: currentCommit ? isAncestor(betaCommit, currentCommit) : false,
+  })
+
+  if (decision === 'stale') {
+    log(`ignored stale promotion candidate ${betaTag} (${betaCommit}); ${PROMOTION_BRANCH} is newer`)
+    return decision
+  }
+  if (decision !== 'unchanged') {
+    run('git', ['push', 'origin', `${betaCommit}:refs/heads/${PROMOTION_BRANCH}`])
+  }
+  log(`${decision === 'unchanged' ? 'kept' : decision === 'create' ? 'created' : 'fast-forwarded'} ${PROMOTION_BRANCH} at ${betaTag} (${betaCommit})`)
+  return decision
+}
+
+function main() {
+  const args = process.argv.slice(2)
+  if (args.length !== 2 || args[0] === '--help') {
+    const usage =
+      'Usage: node apps/desktop/scripts/release-promotion.mjs <vX.Y.Z-beta[.N]> <commit-sha>'
+    if (args[0] === '--help') {
+      console.log(usage)
+      return
+    }
+    throw new Error(usage)
+  }
+
+  const betaTag = args[0]
+  validateBetaTag(betaTag)
+  const expectedCommit = validateCommitSha(args[1])
+  const decision = updatePromotionBranch(betaTag, expectedCommit)
+  if (decision === 'stale' || decision === 'already-promoted') return
+  const repository = validateGitHubRepository(process.env.GITHUB_REPOSITORY ?? '')
+  createOrUpdatePromotionPr(createPromotionPrMetadata(betaTag), repository)
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main()
+  } catch (error) {
+    console.error(`release-promotion: error: ${error instanceof Error ? error.message : String(error)}`)
+    process.exitCode = 1
+  }
+}

--- a/apps/desktop/scripts/release-promotion.test.mjs
+++ b/apps/desktop/scripts/release-promotion.test.mjs
@@ -1,0 +1,201 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  PROMOTION_BASE_BRANCH,
+  PROMOTION_BRANCH,
+  createPromotionPrCreateArgs,
+  createPromotionPrEditArgs,
+  createPromotionPrListArgs,
+  createPromotionPrMetadata,
+  decideBranchUpdate,
+  parseManagedPromotionPrNumbers,
+  validateBetaTag,
+  validateCommitSha,
+  validateGitHubRepository,
+} from './release-promotion.mjs'
+
+const repository = 'team-reflect/reflect-open'
+
+describe('beta tag validation', () => {
+  test.each([
+    ['v0.6.0-beta', '0.6.0-beta', '0.6.0'],
+    ['v0.6.0-beta.14', '0.6.0-beta.14', '0.6.0'],
+    ['v1.0.0-beta.0', '1.0.0-beta.0', '1.0.0'],
+  ])('accepts %s', (tag, version, stableVersion) => {
+    expect(validateBetaTag(tag)).toEqual({ tag, version, stableVersion })
+  })
+
+  test.each([
+    '0.6.0-beta.14',
+    'v0.6.0',
+    'v0.6.0-alpha.1',
+    'v0.6.0-beta.01',
+    'v01.6.0-beta.1',
+    'v0.6-beta.1',
+    'v0.6.0-beta.1-extra',
+  ])('rejects %s', (tag) => {
+    expect(() => validateBetaTag(tag)).toThrow('expected a beta tag')
+  })
+})
+
+test('release commit validation requires an immutable full SHA', () => {
+  expect(validateCommitSha('A'.repeat(40))).toBe('a'.repeat(40))
+  expect(() => validateCommitSha('abc123')).toThrow('40-character release commit SHA')
+})
+
+describe('promotion branch updates', () => {
+  test('creates a missing branch', () => {
+    expect(
+      decideBranchUpdate({
+        currentCommit: null,
+        targetCommit: 'bbbb',
+      }),
+    ).toBe('create')
+  })
+
+  test('keeps a branch already pinned to the beta commit', () => {
+    expect(
+      decideBranchUpdate({
+        currentCommit: 'bbbb',
+        targetCommit: 'bbbb',
+        currentIsAncestorOfTarget: true,
+        targetIsAncestorOfCurrent: true,
+      }),
+    ).toBe('unchanged')
+  })
+
+  test('fast-forwards an older promotion commit', () => {
+    expect(
+      decideBranchUpdate({
+        currentCommit: 'aaaa',
+        targetCommit: 'bbbb',
+        currentIsAncestorOfTarget: true,
+        targetIsAncestorOfCurrent: false,
+      }),
+    ).toBe('fast-forward')
+  })
+
+  test('refuses to roll the promotion branch backward', () => {
+    expect(
+      decideBranchUpdate({
+        currentCommit: 'bbbb',
+        targetCommit: 'aaaa',
+        currentIsAncestorOfTarget: false,
+        targetIsAncestorOfCurrent: true,
+      }),
+    ).toBe('stale')
+  })
+
+  test('refuses to replace the promotion branch with divergent history', () => {
+    expect(() =>
+      decideBranchUpdate({
+        currentCommit: 'aaaa',
+        targetCommit: 'bbbb',
+        currentIsAncestorOfTarget: false,
+        targetIsAncestorOfCurrent: false,
+      }),
+    ).toThrow('divergent')
+  })
+})
+
+test('promotion PR metadata makes the stable release contract explicit', () => {
+  const metadata = createPromotionPrMetadata('v0.6.0-beta.14')
+
+  expect(metadata).toEqual({
+    base: PROMOTION_BASE_BRANCH,
+    head: PROMOTION_BRANCH,
+    title: 'chore: promote v0.6.0-beta.14 to stable 0.6.0',
+    body: expect.stringContaining('single human approval'),
+  })
+  expect(metadata.body).toContain('Create a merge commit')
+  expect(metadata.body).toContain('Do not squash or rebase')
+  expect(metadata.body).toContain('`v0.6.0-beta.14`')
+})
+
+test('promotion PR arguments pin the base and rolling head branches', () => {
+  const metadata = createPromotionPrMetadata('v1.0.0-beta')
+
+  expect(createPromotionPrCreateArgs(metadata, repository)).toEqual([
+    'pr',
+    'create',
+    '--repo',
+    repository,
+    '--base',
+    'master',
+    '--head',
+    'release-promotion/latest-beta',
+    '--title',
+    metadata.title,
+    '--body',
+    metadata.body,
+  ])
+  expect(createPromotionPrEditArgs({ metadata, number: 123, repository })).toEqual([
+    'pr',
+    'edit',
+    '123',
+    '--repo',
+    repository,
+    '--title',
+    metadata.title,
+    '--body',
+    metadata.body,
+  ])
+  expect(createPromotionPrListArgs(repository)).toEqual([
+    'pr',
+    'list',
+    '--repo',
+    repository,
+    '--state',
+    'open',
+    '--base',
+    'master',
+    '--head',
+    'release-promotion/latest-beta',
+    '--json',
+    'number,baseRefName,headRefName,headRepository,isCrossRepository',
+    '--limit',
+    '10',
+  ])
+})
+
+describe('managed promotion PR discovery', () => {
+  test('keeps the same-repository PR and ignores a fork with the same branch name', () => {
+    const output = JSON.stringify([
+      {
+        number: 123,
+        baseRefName: PROMOTION_BASE_BRANCH,
+        headRefName: PROMOTION_BRANCH,
+        headRepository: { nameWithOwner: repository },
+        isCrossRepository: false,
+      },
+      {
+        number: 456,
+        baseRefName: PROMOTION_BASE_BRANCH,
+        headRefName: PROMOTION_BRANCH,
+        headRepository: { nameWithOwner: 'untrusted/reflect-open' },
+        isCrossRepository: true,
+      },
+    ])
+
+    expect(parseManagedPromotionPrNumbers(output, repository)).toEqual([123])
+  })
+
+  test('ignores same-named branches whose repository identity does not match', () => {
+    const output = JSON.stringify([
+      {
+        number: 456,
+        baseRefName: PROMOTION_BASE_BRANCH,
+        headRefName: PROMOTION_BRANCH,
+        headRepository: { nameWithOwner: 'untrusted/reflect-open' },
+        isCrossRepository: false,
+      },
+    ])
+
+    expect(parseManagedPromotionPrNumbers(output, repository)).toEqual([])
+  })
+
+  test('rejects malformed GitHub output and repository identifiers', () => {
+    expect(() => parseManagedPromotionPrNumbers('{', repository)).toThrow('invalid JSON')
+    expect(() => validateGitHubRepository('reflect-open')).toThrow('owner/name')
+  })
+})

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -113,23 +113,30 @@ channel changelog (`apps/desktop/CHANGELOG.beta.md` on `next`,
 `apps/desktop/CHANGELOG.md` on `master`) from the conventional-commit PR titles landed
 since the last release.
 
-**Merging the Release PR is the release.** release-please then creates a draft GitHub
-release (with its `v<version>` tag — `force-tag-creation`, so later release-please
-runs can always anchor on the previous release) and hands the tag name to the Release
-workflow, which builds, signs, notarizes, uploads the assets, and undrafts the
-release. Nothing is visible to users (and `releases/latest` does not move) until
-every asset is in place.
+**Merging the Release PR is the technical release boundary.** release-please then
+creates a draft GitHub release (with its `v<version>` tag — `force-tag-creation`, so
+later release-please runs can always anchor on the previous release) and hands the tag
+name to the Release workflow, which builds, signs, notarizes, uploads the assets, and
+undrafts the release. Humans merge beta Release PRs and Release PRs for stable
+hotfixes. In the normal stable-promotion path, the workflow mechanically merges the
+stable Release PR after a human approves the promotion PR. Nothing is visible to users
+(and `releases/latest` does not move) until every asset is in place. The caller resolves
+the release tag to its immutable commit once; macOS, TestFlight, promotion, feed sync,
+and back-merge jobs all check out that SHA rather than resolving a tag name independently.
 
 Merge methods matter:
 
-- **Release PRs: squash** (the default).
-- **Promote and back-merge PRs: "Create a merge commit"** — squashing one collapses a
+- **Release PRs: squash** (the default, including the mechanically merged stable one).
+- **Promotion and back-merge PRs: "Create a merge commit"** — squashing one collapses a
   whole branch's history into a single non-conventional commit, blinding the other
   channel's version calculation and changelog, and the two branches' histories diverge
   for good.
 
-Bot-created PRs (the Release PR and the post-stable back-merge PR) do not run CI
-automatically; use the run-checks button on the PR before merging.
+PRs created with `GITHUB_TOKEN` do not start `pull_request` workflows, so checks do not
+appear automatically on the bot-created Release, promotion, and post-stable back-merge
+PRs. Use the run-checks button before a human merge. The stable Release PR in the normal
+promotion path is not a second review point: it contains generated release metadata for
+the already-approved snapshot and the workflow squash-merges it mechanically.
 
 ### Beta (the everyday release, on `next`)
 
@@ -139,25 +146,51 @@ automatically; use the run-checks button on the PR before merging.
    new commits land, so polish last), and **merge it**.
 3. Everything else is automatic, ending with the `updater-beta` feed refresh. Installed
    Reflect Beta apps pick up the update.
+4. Only after the GitHub/macOS release and TestFlight upload both succeed, the workflow
+   creates or advances the open promotion PR. Its head is a bot-owned snapshot pinned
+   to that beta tag, not the moving `next` branch. Commits that land on `next` after the
+   tag are therefore excluded until a newer beta publishes successfully. A failed beta
+   leaves the promotion PR at the last fully published beta; rerun the failed publishing
+   job to advance it.
 
 ### Stable
 
-1. **Promote**: open a PR with base `master`, compare `next`, titled
-   `chore: promote next to master`, and merge it with a **merge commit**. In the normal
-   cycle it merges clean; if a hotfix shipped since the last back-merge, the only
-   conflict is the `version` line in `apps/desktop/package.json` — take either side,
-   the next Release PR rewrites it from the manifest.
-2. **Merge the stable Release PR** (`chore: release X.Y.Z`) that appears on `master`.
-3. **Merge the post-stable PR** (`chore: merge master back into next`), which the
-   workflow opens automatically: it back-merges master and advances the beta manifest
-   so the next beta cycle starts above the released version. **Merge commit, not
-   squash.**
+1. Review the bot-maintained promotion PR (`chore: promote vX.Y.Z-beta.N to stable
+   X.Y.Z`). It targets `master` from the exact commit tagged by the latest fully
+   published beta, so its diff cannot acquire newer, unshipped work from `next` while it
+   waits for review. Newer successful betas advance the same open PR.
+2. Run its checks, then merge it with a **merge commit**. This is the sole human release
+   approval. The automation only advances the promotion PR when `master` is already an
+   ancestor of the published beta snapshot, so this merge stays conflict-free. If a
+   hotfix shipped, merge its post-stable back-merge into `next` before publishing the
+   next beta; otherwise promotion stops instead of offering a conflicted snapshot.
+3. The workflow waits for release-please to create the stable Release PR on `master`,
+   pins its version to the stable base of the approved beta tag, then squash-merges that
+   generated PR mechanically. Its merge creates the stable tag and draft release and
+   starts the macOS/GitHub and TestFlight publishing workflows; there is no second
+   human approval. The explicit version pin means a major beta such as
+   `v1.0.0-beta.4` promotes directly to `v1.0.0` rather than relying on conventional
+   commits to infer the major bump.
+4. After the stable release is healthy, merge the post-stable PR
+   (`chore: merge master back into next`) with a **merge commit**. The workflow opens it
+   automatically to back-merge `master` and advance the beta manifest so the next beta
+   cycle starts above the released version.
+
+If stable Release PR creation or its mechanical merge fails after the promotion merge,
+rerun the failed Release PR workflow rather than opening or merging another promotion.
+If macOS publishing or TestFlight fails after the stable Release PR merged, the stable
+tag and GitHub release record already exist (the release may still be a draft): rerun
+**Actions → Release** or **Actions → TestFlight** on the stable commit as appropriate.
+Leave the post-stable back-merge PR unmerged until both publishing paths are healthy.
 
 ### Hotfix (directly on `master`)
 
 1. Branch from `master`, fix, PR back to `master` with a `fix:` title.
-2. Merge the stable Release PR (`chore: release X.Y.Z`) that appears on `master`.
-3. Merge the auto-opened post-stable back-merge PR into `next`.
+2. Merge the stable Release PR (`chore: release X.Y.Z`) that appears on `master`
+   manually. A direct hotfix has no approved promotion snapshot, so the workflow does
+   not auto-merge its Release PR.
+3. After publishing succeeds, merge the auto-opened post-stable back-merge PR into
+   `next` with a merge commit.
 
 ### Release automation files
 
@@ -178,11 +211,13 @@ file both channels write is `apps/desktop/package.json` (`version`); on a merge
 conflict, take either side — the next Release PR rewrites it. Do not hand-edit the
 changelogs or manifests outside the flows above.
 
-All version interventions go through the manifest files. **Never use `Release-As:`
-commit footers**: they stay in `next`'s history and leak into `master`'s version
-calculation at the next promote. The first beta of a new cycle is tagged without a
-number (`v0.6.0-beta`, then `-beta.1`, `-beta.2`, …) — a release-please naming quirk,
-not a bug.
+All human version interventions go through the manifest files. **Never use
+`Release-As:` commit footers**: they stay in `next`'s history and leak into `master`'s
+version calculation at the next promote. The promotion workflow does supply an
+ephemeral `release-as` CLI override derived from the approved beta tag; it does not
+enter Git history and guarantees that `vX.Y.Z-beta.N` becomes stable `vX.Y.Z`. The
+first beta of a new cycle is tagged without a number (`v0.6.0-beta`, then `-beta.1`,
+`-beta.2`, …) — a release-please naming quirk, not a bug.
 
 ### Manual fallback (no Release PR)
 
@@ -253,7 +288,7 @@ their own feeds, and `release-macos.mjs` pins the stable feed into stable builds
 build time, so releases are branch-independent.
 
 Cutting a beta is the normal Release PR flow on `next`; a stable release is the
-promote + Release PR flow on `master` (see
+single-approval promotion flow into `master` (see
 [Cutting a release](#cutting-a-release-release-prs) above).
 
 ## Build flavors (Reflect / Reflect Beta / Reflect Dev)

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -211,7 +211,8 @@ file both channels write is `apps/desktop/package.json` (`version`); on a merge
 conflict, take either side — the next Release PR rewrites it. Do not hand-edit the
 changelogs or manifests outside the flows above.
 
-All human version interventions go through the manifest files. **Never use
+In normal release-please flows, human version interventions go through the manifest
+files; the no-Release-PR fallback below is the explicit exception. **Never use
 `Release-As:` commit footers**: they stay in `next`'s history and leak into `master`'s
 version calculation at the next promote. The promotion workflow does supply an
 ephemeral `release-as` CLI override derived from the approved beta tag; it does not
@@ -221,7 +222,8 @@ first beta of a new cycle is tagged without a number (`v0.6.0-beta`, then `-beta
 
 ### Manual fallback (no Release PR)
 
-Merge a PR that sets `version` in `apps/desktop/package.json`, then run
+For this exceptional recovery path, merge a PR that sets `version` in
+`apps/desktop/package.json`, then run
 **Actions → Release → Run workflow** on that branch. The workflow derives the tag from
 the version, and publish creates the release (and its tag) itself via
 `gh release create`. Afterwards, sync that channel's manifest file with a follow-up PR

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@types/node": "^24.0.0",
     "oxlint": "^1.71.0",
+    "release-please": "17.6.0",
     "turbo": "^2.10.0",
     "typescript": "~6.0.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       oxlint:
         specifier: ^1.71.0
         version: 1.71.0
+      release-please:
+        specifier: 17.6.0
+        version: 17.6.0
       turbo:
         specifier: ^2.10.0
         version: 2.10.0
@@ -666,6 +669,9 @@ packages:
   '@codemirror/view@6.43.5':
     resolution: {integrity: sha512-7uT/vUgH6dfXWn3WqOe23KneILMvGy5wQjNMEcRXLKzziJ9NOktpW6tGoyQpwVkBgE5Gj6hKkCcsddbnkaWrOQ==}
 
+  '@conventional-commits/parser@0.4.1':
+    resolution: {integrity: sha512-H2ZmUVt6q+KBccXfMBhbBF14NlANeqHTXL4qCL6QGbMzrc4HDXyzWuxPxPNbz71f/5UkR5DrycP5VO9u7crahg==}
+
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
     engines: {node: '>=20.19.0'}
@@ -966,6 +972,10 @@ packages:
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
+  '@google-automations/git-file-utils@3.0.1':
+    resolution: {integrity: sha512-vlQZ8DlBcippB5zTY0M5Rib8tKT4yQ7oBKbs6kcWAzp70oyillKinXLZwlIgNTmfzzZx1J6cez3M0EmrpXFRcw==}
+    engines: {node: '>= 20'}
+
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
@@ -992,6 +1002,9 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@iarna/toml@3.0.0':
+    resolution: {integrity: sha512-td6ZUkz2oS3VeleBcN+m//Q6HlCFCPrnI0FZhrt/h4XqLEdOyYp2u21nd8MdsR+WJy5r9PTDaHTDDfhf4H4l6Q==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1007,6 +1020,18 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jsep-plugin/assignment@1.3.0':
+    resolution: {integrity: sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
+  '@jsep-plugin/regex@1.0.4':
+    resolution: {integrity: sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
 
   '@lezer/common@1.5.2':
     resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
@@ -1124,6 +1149,58 @@ packages:
 
   '@ocavue/utils@1.7.0':
     resolution: {integrity: sha512-yEk9ATNBjTZTtuVFMB/MAIF6zJBvJ2+lVNQvK2+O+ggEBGTgx2tp27d4FPgmD5bRsNHHP3D0SleQia/bvIeV8w==}
+
+  '@octokit/auth-token@4.0.0':
+    resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/core@5.2.2':
+    resolution: {integrity: sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==}
+    engines: {node: '>= 18'}
+
+  '@octokit/endpoint@9.0.6':
+    resolution: {integrity: sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/graphql@7.1.1':
+    resolution: {integrity: sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==}
+    engines: {node: '>= 18'}
+
+  '@octokit/openapi-types@24.2.0':
+    resolution: {integrity: sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==}
+
+  '@octokit/plugin-paginate-rest@11.4.4-cjs.2':
+    resolution: {integrity: sha512-2dK6z8fhs8lla5PaOTgqfCGBxgAv/le+EhPs27KklPhm1bKObpu6lXzwfUEQ16ajXzqNrKMujsFyo9K2eaoISw==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '5'
+
+  '@octokit/plugin-request-log@4.0.1':
+    resolution: {integrity: sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '5'
+
+  '@octokit/plugin-rest-endpoint-methods@13.3.2-cjs.1':
+    resolution: {integrity: sha512-VUjIjOOvF2oELQmiFpWA1aOPdawpyaCUqcEBc/UOUnj3Xp6DJGrJ1+bjUIIDzdHjnFNO6q57ODMfdEZnoBkCwQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': ^5
+
+  '@octokit/request-error@5.1.1':
+    resolution: {integrity: sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==}
+    engines: {node: '>= 18'}
+
+  '@octokit/request@8.4.1':
+    resolution: {integrity: sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/rest@20.1.2':
+    resolution: {integrity: sha512-GmYiltypkHHtihFwPRxlaorG5R9VAHuk/vbszVoRTGXnAsY60wYLkh/E2XiFmdZmqrisw+9FaazS1i5SbdWYgA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/types@13.10.0':
+    resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
 
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
@@ -2712,11 +2789,20 @@ packages:
   '@types/minimatch@3.0.5':
     resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
 
+  '@types/minimist@1.2.5':
+    resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
+
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@24.13.2':
     resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
+
+  '@types/normalize-package-data@2.4.4':
+    resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/npm-package-arg@6.1.4':
+    resolution: {integrity: sha512-vDgdbMy2QXHnAruzlv68pUtXCjmqUk3WrBAsRboRovsOmxbfn/WiYCjmecyKjGztnMps5dWp4Uq2prp+Ilo17Q==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -2726,6 +2812,9 @@ packages:
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
@@ -2734,6 +2823,12 @@ packages:
 
   '@types/webextension-polyfill@0.12.5':
     resolution: {integrity: sha512-uKSAv6LgcVdINmxXMKBuVIcg/2m5JZugoZO8x20g7j2bXJkPIl/lVGQcDlbV+aXAiTyXT2RA5U5mI4IGCDMQeg==}
+
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@16.0.11':
+    resolution: {integrity: sha512-sbtvk8wDN+JvEdabmZExoW/HNr1cB7D/j4LT08rMiuikfA7m/JNJg7ATQcgzs34zHnoScDkY0ZRSl29Fkmk36g==}
 
   '@typescript-eslint/eslint-plugin@8.62.0':
     resolution: {integrity: sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==}
@@ -2867,6 +2962,10 @@ packages:
   '@wxt-dev/storage@1.2.8':
     resolution: {integrity: sha512-GWCFKgF5+d7eslOxUDFC70ypA9njupmJb1nQM8uZoX0J3sWT2BO5xJLzb1sYahWAfID9p2BMtnUBN1lkWxPsbQ==}
 
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+    engines: {node: '>=10.0.0'}
+
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
@@ -2984,9 +3083,16 @@ packages:
     resolution: {integrity: sha512-Q6VPTLMsmXZ47ENG3V+wQyZS1ZxXMxFyYzA+Z/GMrJ6yIutAIEf9wTyroTzmGjNfox9/h3GdGBCVh43GVFx4Uw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  array-ify@1.0.0:
+    resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
+
   array-union@3.0.1:
     resolution: {integrity: sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==}
     engines: {node: '>=12'}
+
+  arrify@1.0.1:
+    resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
+    engines: {node: '>=0.10.0'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -2998,6 +3104,9 @@ packages:
 
   async-mutex@0.5.0:
     resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -3029,6 +3138,9 @@ packages:
     resolution: {integrity: sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  before-after-hook@2.2.3:
+    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
 
   better-sqlite3@12.11.1:
     resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
@@ -3114,6 +3226,14 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  camelcase-keys@6.2.2:
+    resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
+    engines: {node: '>=8'}
+
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
   camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
@@ -3183,6 +3303,9 @@ packages:
     resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
     engines: {node: '>=20'}
 
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -3199,6 +3322,11 @@ packages:
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
+
+  code-suggester@5.0.1:
+    resolution: {integrity: sha512-8qJiiSCfkbPNWvjEFzdG1UW3axL+Bs0ldV1/TdlBKmF9I/a/WooSQZQCi9M44HoXbVTQesn/IQr6+nIWNnVIWA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -3233,6 +3361,9 @@ packages:
   commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
+
+  compare-func@2.0.0:
+    resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -3269,6 +3400,19 @@ packages:
   content-type@2.0.0:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
     engines: {node: '>=18'}
+
+  conventional-changelog-conventionalcommits@6.1.0:
+    resolution: {integrity: sha512-3cS3GEtR78zTfMzk0AizXKKIdN4OvSh7ibNz6/DPbhWWQu7LqE/8+/GqSodV+sywUR2gpJAdP/1JFf4XtN7Zpw==}
+    engines: {node: '>=14'}
+
+  conventional-changelog-writer@6.0.1:
+    resolution: {integrity: sha512-359t9aHorPw+U+nHzUXHS5ZnPBOizRxfQsWT5ZDHBfvfxQOAik+yfuhKXG66CN5LEWPpMNnIMHUTCKeYNprvHQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  conventional-commits-filter@3.0.0:
+    resolution: {integrity: sha512-1ymej8b5LouPx9Ox0Dw/qAO2dVdfpRFq28e5Y0jJEU8ZrLdy0vOSkkIInwmxErFGhg6SALro60ZrwYFVTUDo4Q==}
+    engines: {node: '>=14'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -3340,6 +3484,9 @@ packages:
   date-fns@4.4.0:
     resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
+  dateformat@3.0.3:
+    resolution: {integrity: sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==}
+
   debounce@1.2.1:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
 
@@ -3360,6 +3507,14 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decamelize-keys@1.1.1:
+    resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
+    engines: {node: '>=0.10.0'}
+
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -3417,12 +3572,19 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  deprecation@2.3.1:
+    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
+
+  detect-indent@6.1.0:
+    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -3456,6 +3618,10 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dot-prop@5.3.0:
+    resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
+    engines: {node: '>=8'}
 
   dot-prop@9.0.0:
     resolution: {integrity: sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==}
@@ -3587,6 +3753,10 @@ packages:
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -3735,6 +3905,10 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  figures@3.2.0:
+    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
+    engines: {node: '>=8'}
+
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
@@ -3757,6 +3931,10 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -3800,6 +3978,9 @@ packages:
   fs-extra@11.3.5:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -3877,6 +4058,10 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
     engines: {node: '>=18'}
@@ -3896,6 +4081,15 @@ packages:
 
   growly@1.3.0:
     resolution: {integrity: sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==}
+
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
+  hard-rejection@2.1.0:
+    resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
+    engines: {node: '>=6'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -3951,6 +4145,10 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
@@ -3963,6 +4161,13 @@ packages:
 
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+
+  hosted-git-info@2.8.9:
+    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
+
+  hosted-git-info@4.1.0:
+    resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
+    engines: {node: '>=10'}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -3980,6 +4185,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
 
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -4030,6 +4239,10 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -4058,6 +4271,10 @@ packages:
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
 
   is-docker@2.2.1:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
@@ -4115,6 +4332,10 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-obj@2.0.0:
+    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
+    engines: {node: '>=8'}
+
   is-obj@3.0.0:
     resolution: {integrity: sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==}
     engines: {node: '>=12'}
@@ -4122,6 +4343,10 @@ packages:
   is-path-inside@4.0.0:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
     engines: {node: '>=12'}
+
+  is-plain-obj@1.1.0:
+    resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
+    engines: {node: '>=0.10.0'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -4216,6 +4441,10 @@ packages:
       canvas:
         optional: true
 
+  jsep@1.4.0:
+    resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
+    engines: {node: '>= 10.16.0'}
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -4246,6 +4475,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -4253,6 +4485,11 @@ packages:
 
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
+  jsonpath-plus@10.4.0:
+    resolution: {integrity: sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
@@ -4273,6 +4510,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -4440,6 +4681,10 @@ packages:
     resolution: {integrity: sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==}
     engines: {node: '>=14'}
 
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -4452,6 +4697,9 @@ packages:
 
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.ismatch@4.4.0:
+    resolution: {integrity: sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==}
 
   lodash.isnumber@3.0.3:
     resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
@@ -4486,6 +4734,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
   lucide-react@1.23.0:
     resolution: {integrity: sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==}
     peerDependencies:
@@ -4507,6 +4759,14 @@ packages:
   many-keys-map@3.0.3:
     resolution: {integrity: sha512-1DiZmDHPXMBgMRjeUtHy1q1VYmeJscHxhIAexX9z/zjRMP80+0ETuPfssi8z+kMY4DwUgsKuHqpjxgmeA9gBNA==}
     engines: {node: '>=18'}
+
+  map-obj@1.0.1:
+    resolution: {integrity: sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==}
+    engines: {node: '>=0.10.0'}
+
+  map-obj@4.3.0:
+    resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
+    engines: {node: '>=8'}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -4563,6 +4823,10 @@ packages:
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
+
+  meow@8.1.2:
+    resolution: {integrity: sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==}
+    engines: {node: '>=10'}
 
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
@@ -4694,6 +4958,10 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minimist-options@4.1.0:
+    resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
+    engines: {node: '>= 6'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -4706,6 +4974,10 @@ packages:
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  modify-values@1.0.1:
+    resolution: {integrity: sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==}
+    engines: {node: '>=0.10.0'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -4736,6 +5008,9 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
   node-abi@3.92.0:
     resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
     engines: {node: '>=10'}
@@ -4765,12 +5040,22 @@ packages:
     resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
     engines: {node: '>= 6.13.0'}
 
+  node-html-parser@6.1.13:
+    resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
+
   node-notifier@10.0.1:
     resolution: {integrity: sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==}
 
   node-releases@2.0.50:
     resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
     engines: {node: '>=18'}
+
+  normalize-package-data@2.5.0:
+    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
+
+  normalize-package-data@3.0.3:
+    resolution: {integrity: sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==}
+    engines: {node: '>=10'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -4875,13 +5160,25 @@ packages:
       vite-plus:
         optional: true
 
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
 
   package-json@10.0.1:
     resolution: {integrity: sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==}
@@ -4893,6 +5190,12 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-diff@0.11.1:
+    resolution: {integrity: sha512-Oq4j8LAOPOcssanQkIjxosjATBIEJhCxMCxPhMu+Ci4wdNmAEdx0O+a7gzbR2PyKXgKPvRLIN5g224+dJAsKHA==}
+
+  parse-github-repo-url@1.4.1:
+    resolution: {integrity: sha512-bSWyzBKqcSL4RrncTpGsEKoJ7H8a4L3++ifTAbTFeMHyq2wRV+42DGmQcHIrJIvdcacjIOxEuKH/w4tthF17gg==}
 
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
@@ -4923,6 +5226,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -4930,6 +5237,9 @@ packages:
   path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
@@ -5178,6 +5488,10 @@ packages:
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
+  quick-lru@4.0.1:
+    resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
+    engines: {node: '>=8'}
+
   radix-ui@1.6.0:
     resolution: {integrity: sha512-EUEC70O03EgxWMP5aoqfBZ6iLC5bczFagGy7zhSYRt8o5DP7IWNiP3ywetse3L9b8843ExB0OGWZvgbYVJuNeg==}
     peerDependencies:
@@ -5257,6 +5571,14 @@ packages:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
+  read-pkg-up@7.0.1:
+    resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
+    engines: {node: '>=8'}
+
+  read-pkg@5.2.0:
+    resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
+    engines: {node: '>=8'}
+
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
@@ -5306,6 +5628,11 @@ packages:
   rehype-remark@10.0.1:
     resolution: {integrity: sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==}
 
+  release-please@17.6.0:
+    resolution: {integrity: sha512-ItzkkEBeEbKsCrx7N1QlADrCahoONA4WPlsOinSnXTkqUBIWlHC6+S28VJ9PaHy7ZPSJwSQsRuDjI0/HL5G6hw==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
 
@@ -5330,9 +5657,18 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -5391,6 +5727,10 @@ packages:
 
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
+
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -5516,6 +5856,18 @@ packages:
 
   spawn-sync@1.0.15:
     resolution: {integrity: sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==}
+
+  spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
@@ -5643,6 +5995,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -5728,6 +6084,10 @@ packages:
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
+  trim-newlines@3.0.1:
+    resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
+    engines: {node: '>=8'}
+
   trim-trailing-lines@2.1.0:
     resolution: {integrity: sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==}
 
@@ -5768,6 +6128,18 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-fest@0.18.1:
+    resolution: {integrity: sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==}
+    engines: {node: '>=10'}
+
+  type-fest@0.6.0:
+    resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
+    engines: {node: '>=8'}
+
+  type-fest@0.8.1:
+    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
+    engines: {node: '>=8'}
+
   type-fest@3.13.1:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
     engines: {node: '>=14.16'}
@@ -5794,6 +6166,11 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  typescript@4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -5801,6 +6178,11 @@ packages:
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
 
   uhyphen@0.2.0:
     resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
@@ -5838,6 +6220,9 @@ packages:
   unist-util-find-after@5.0.0:
     resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
 
+  unist-util-is@4.1.0:
+    resolution: {integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==}
+
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
@@ -5847,11 +6232,20 @@ packages:
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
 
+  unist-util-visit-parents@3.1.1:
+    resolution: {integrity: sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==}
+
   unist-util-visit-parents@6.0.2:
     resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
 
+  unist-util-visit@2.0.3:
+    resolution: {integrity: sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==}
+
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  universal-user-agent@6.0.1:
+    resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -5914,6 +6308,9 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
+
+  validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
   validate-npm-package-name@7.0.2:
     resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
@@ -6166,6 +6563,9 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
+
   wrap-ansi@10.0.0:
     resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
     engines: {node: '>=20'}
@@ -6214,6 +6614,10 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  xpath@0.0.34:
+    resolution: {integrity: sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==}
+    engines: {node: '>=0.6.0'}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -6221,14 +6625,25 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yargs@16.2.2:
+    resolution: {integrity: sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==}
+    engines: {node: '>=10'}
 
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
@@ -6830,6 +7245,11 @@ snapshots:
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
 
+  '@conventional-commits/parser@0.4.1':
+    dependencies:
+      unist-util-visit: 2.0.3
+      unist-util-visit-parents: 3.1.1
+
   '@csstools/color-helpers@6.0.2': {}
 
   '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0)(@csstools/css-tokenizer@4.0.0)':
@@ -7058,6 +7478,13 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
+  '@google-automations/git-file-utils@3.0.1':
+    dependencies:
+      '@octokit/rest': 20.1.2
+      '@octokit/types': 13.10.0
+      js-yaml: 4.2.0
+      minimatch: 10.2.5
+
   '@hono/node-server@1.19.14(hono@4.12.25)':
     dependencies:
       hono: 4.12.25
@@ -7078,6 +7505,8 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@iarna/toml@3.0.0': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -7096,6 +7525,14 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jsep-plugin/assignment@1.3.0(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
+  '@jsep-plugin/regex@1.0.4(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
 
   '@lezer/common@1.5.2': {}
 
@@ -7321,6 +7758,69 @@ snapshots:
       fastq: 1.20.1
 
   '@ocavue/utils@1.7.0': {}
+
+  '@octokit/auth-token@4.0.0': {}
+
+  '@octokit/core@5.2.2':
+    dependencies:
+      '@octokit/auth-token': 4.0.0
+      '@octokit/graphql': 7.1.1
+      '@octokit/request': 8.4.1
+      '@octokit/request-error': 5.1.1
+      '@octokit/types': 13.10.0
+      before-after-hook: 2.2.3
+      universal-user-agent: 6.0.1
+
+  '@octokit/endpoint@9.0.6':
+    dependencies:
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/graphql@7.1.1':
+    dependencies:
+      '@octokit/request': 8.4.1
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/openapi-types@24.2.0': {}
+
+  '@octokit/plugin-paginate-rest@11.4.4-cjs.2(@octokit/core@5.2.2)':
+    dependencies:
+      '@octokit/core': 5.2.2
+      '@octokit/types': 13.10.0
+
+  '@octokit/plugin-request-log@4.0.1(@octokit/core@5.2.2)':
+    dependencies:
+      '@octokit/core': 5.2.2
+
+  '@octokit/plugin-rest-endpoint-methods@13.3.2-cjs.1(@octokit/core@5.2.2)':
+    dependencies:
+      '@octokit/core': 5.2.2
+      '@octokit/types': 13.10.0
+
+  '@octokit/request-error@5.1.1':
+    dependencies:
+      '@octokit/types': 13.10.0
+      deprecation: 2.3.1
+      once: 1.4.0
+
+  '@octokit/request@8.4.1':
+    dependencies:
+      '@octokit/endpoint': 9.0.6
+      '@octokit/request-error': 5.1.1
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/rest@20.1.2':
+    dependencies:
+      '@octokit/core': 5.2.2
+      '@octokit/plugin-paginate-rest': 11.4.4-cjs.2(@octokit/core@5.2.2)
+      '@octokit/plugin-request-log': 4.0.1(@octokit/core@5.2.2)
+      '@octokit/plugin-rest-endpoint-methods': 13.3.2-cjs.1(@octokit/core@5.2.2)
+
+  '@octokit/types@13.10.0':
+    dependencies:
+      '@octokit/openapi-types': 24.2.0
 
   '@opentelemetry/api@1.9.1': {}
 
@@ -8814,11 +9314,17 @@ snapshots:
 
   '@types/minimatch@3.0.5': {}
 
+  '@types/minimist@1.2.5': {}
+
   '@types/ms@2.1.0': {}
 
   '@types/node@24.13.2':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/normalize-package-data@2.4.4': {}
+
+  '@types/npm-package-arg@6.1.4': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
@@ -8828,11 +9334,19 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/unist@2.0.11': {}
+
   '@types/unist@3.0.3': {}
 
   '@types/validate-npm-package-name@4.0.2': {}
 
   '@types/webextension-polyfill@0.12.5': {}
+
+  '@types/yargs-parser@21.0.3': {}
+
+  '@types/yargs@16.0.11':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
 
   '@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0)(eslint@10.5.0)(typescript@6.0.3)':
     dependencies:
@@ -9013,6 +9527,8 @@ snapshots:
       async-mutex: 0.5.0
       dequal: 2.0.3
 
+  '@xmldom/xmldom@0.8.13': {}
+
   '@xmldom/xmldom@0.9.10':
     optional: true
 
@@ -9122,7 +9638,11 @@ snapshots:
 
   array-differ@4.0.0: {}
 
+  array-ify@1.0.0: {}
+
   array-union@3.0.1: {}
+
+  arrify@1.0.1: {}
 
   assertion-error@2.0.1: {}
 
@@ -9133,6 +9653,10 @@ snapshots:
   async-mutex@0.5.0:
     dependencies:
       tslib: 2.8.1
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
 
   async@3.2.6: {}
 
@@ -9156,6 +9680,8 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.42: {}
+
+  before-after-hook@2.2.3: {}
 
   better-sqlite3@12.11.1:
     dependencies:
@@ -9272,6 +9798,14 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase-keys@6.2.2:
+    dependencies:
+      camelcase: 5.3.1
+      map-obj: 4.3.0
+      quick-lru: 4.0.1
+
+  camelcase@5.3.1: {}
+
   camelcase@8.0.0: {}
 
   caniuse-lite@1.0.30001802: {}
@@ -9329,6 +9863,12 @@ snapshots:
       slice-ansi: 8.0.0
       string-width: 8.2.1
 
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -9351,6 +9891,16 @@ snapshots:
 
   code-block-writer@13.0.3: {}
 
+  code-suggester@5.0.1:
+    dependencies:
+      '@octokit/rest': 20.1.2
+      '@types/yargs': 16.0.11
+      async-retry: 1.3.3
+      diff: 8.0.4
+      glob: 7.2.3
+      parse-diff: 0.11.1
+      yargs: 16.2.2
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -9372,6 +9922,11 @@ snapshots:
   commander@8.3.0: {}
 
   commander@9.5.0: {}
+
+  compare-func@2.0.0:
+    dependencies:
+      array-ify: 1.0.0
+      dot-prop: 5.3.0
 
   concat-map@0.0.1: {}
 
@@ -9405,6 +9960,25 @@ snapshots:
   content-type@1.0.5: {}
 
   content-type@2.0.0: {}
+
+  conventional-changelog-conventionalcommits@6.1.0:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-changelog-writer@6.0.1:
+    dependencies:
+      conventional-commits-filter: 3.0.0
+      dateformat: 3.0.3
+      handlebars: 4.7.9
+      json-stringify-safe: 5.0.1
+      meow: 8.1.2
+      semver: 7.8.3
+      split: 1.0.1
+
+  conventional-commits-filter@3.0.0:
+    dependencies:
+      lodash.ismatch: 4.4.0
+      modify-values: 1.0.1
 
   convert-source-map@2.0.0: {}
 
@@ -9470,6 +10044,8 @@ snapshots:
 
   date-fns@4.4.0: {}
 
+  dateformat@3.0.3: {}
+
   debounce@1.2.1: {}
 
   debug@4.3.7:
@@ -9479,6 +10055,13 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decamelize-keys@1.1.1:
+    dependencies:
+      decamelize: 1.2.0
+      map-obj: 1.0.1
+
+  decamelize@1.2.0: {}
 
   decimal.js@10.6.0: {}
 
@@ -9524,9 +10107,13 @@ snapshots:
 
   depd@2.0.0: {}
 
+  deprecation@2.3.1: {}
+
   dequal@2.0.3: {}
 
   destr@2.0.5: {}
+
+  detect-indent@6.1.0: {}
 
   detect-libc@2.1.2: {}
 
@@ -9559,6 +10146,10 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  dot-prop@5.3.0:
+    dependencies:
+      is-obj: 2.0.0
 
   dot-prop@9.0.0:
     dependencies:
@@ -9689,6 +10280,8 @@ snapshots:
   escape-goat@4.0.0: {}
 
   escape-html@1.0.3: {}
+
+  escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -9891,6 +10484,10 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
+  figures@3.2.0:
+    dependencies:
+      escape-string-regexp: 1.0.5
+
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -9917,6 +10514,11 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
 
   find-up@5.0.0:
     dependencies:
@@ -9957,6 +10559,8 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
+
+  fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -10031,6 +10635,15 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
   global-directory@4.0.1:
     dependencies:
       ini: 4.1.1
@@ -10044,6 +10657,17 @@ snapshots:
   graceful-readlink@1.0.1: {}
 
   growly@1.3.0: {}
+
+  handlebars@4.7.9:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
+  hard-rejection@2.1.0: {}
 
   has-flag@4.0.0: {}
 
@@ -10160,6 +10784,8 @@ snapshots:
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
 
+  he@1.2.0: {}
+
   hermes-estree@0.25.1: {}
 
   hermes-parser@0.25.1:
@@ -10169,6 +10795,12 @@ snapshots:
   hono@4.12.25: {}
 
   hookable@6.1.1: {}
+
+  hosted-git-info@2.8.9: {}
+
+  hosted-git-info@4.1.0:
+    dependencies:
+      lru-cache: 6.0.0
 
   html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
@@ -10194,6 +10826,13 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@5.0.1:
     dependencies:
@@ -10236,6 +10875,11 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
@@ -10253,6 +10897,10 @@ snapshots:
       is-relative: 0.1.3
 
   is-arrayish@0.2.1: {}
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
 
   is-docker@2.2.1: {}
 
@@ -10289,9 +10937,13 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-obj@2.0.0: {}
+
   is-obj@3.0.0: {}
 
   is-path-inside@4.0.0: {}
+
+  is-plain-obj@1.1.0: {}
 
   is-plain-obj@4.1.0: {}
 
@@ -10373,6 +11025,8 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  jsep@1.4.0: {}
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -10391,6 +11045,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stringify-safe@5.0.1: {}
+
   json5@2.2.3: {}
 
   jsonfile@6.2.1:
@@ -10398,6 +11054,12 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jsonpath-plus@10.4.0:
+    dependencies:
+      '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
+      '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)
+      jsep: 1.4.0
 
   jsonwebtoken@9.0.3:
     dependencies:
@@ -10437,6 +11099,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
 
@@ -10560,6 +11224,10 @@ snapshots:
       pkg-types: 2.3.1
       quansync: 0.2.11
 
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -10569,6 +11237,8 @@ snapshots:
   lodash.isboolean@3.0.3: {}
 
   lodash.isinteger@4.0.4: {}
+
+  lodash.ismatch@4.4.0: {}
 
   lodash.isnumber@3.0.3: {}
 
@@ -10601,6 +11271,10 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
+
   lucide-react@1.23.0(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -10620,6 +11294,10 @@ snapshots:
   make-error@1.3.6: {}
 
   many-keys-map@3.0.3: {}
+
+  map-obj@1.0.1: {}
+
+  map-obj@4.3.0: {}
 
   markdown-table@3.0.4: {}
 
@@ -10749,6 +11427,20 @@ snapshots:
   mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
+
+  meow@8.1.2:
+    dependencies:
+      '@types/minimist': 1.2.5
+      camelcase-keys: 6.2.2
+      decamelize-keys: 1.1.1
+      hard-rejection: 2.1.0
+      minimist-options: 4.1.0
+      normalize-package-data: 3.0.3
+      read-pkg-up: 7.0.1
+      redent: 3.0.0
+      trim-newlines: 3.0.1
+      type-fest: 0.18.1
+      yargs-parser: 20.2.9
 
   merge-descriptors@2.0.0: {}
 
@@ -10974,6 +11666,12 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.15
 
+  minimist-options@4.1.0:
+    dependencies:
+      arrify: 1.0.1
+      is-plain-obj: 1.1.0
+      kind-of: 6.0.3
+
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
@@ -10986,6 +11684,8 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.4
+
+  modify-values@1.0.1: {}
 
   ms@2.1.3: {}
 
@@ -11010,6 +11710,8 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  neo-async@2.6.2: {}
+
   node-abi@3.92.0:
     dependencies:
       semver: 7.8.3
@@ -11030,6 +11732,11 @@ snapshots:
 
   node-forge@1.4.0: {}
 
+  node-html-parser@6.1.13:
+    dependencies:
+      css-select: 5.2.2
+      he: 1.2.0
+
   node-notifier@10.0.1:
     dependencies:
       growly: 1.3.0
@@ -11040,6 +11747,20 @@ snapshots:
       which: 2.0.2
 
   node-releases@2.0.50: {}
+
+  normalize-package-data@2.5.0:
+    dependencies:
+      hosted-git-info: 2.8.9
+      resolve: 1.22.12
+      semver: 5.7.2
+      validate-npm-package-license: 3.0.4
+
+  normalize-package-data@3.0.3:
+    dependencies:
+      hosted-git-info: 4.1.0
+      is-core-module: 2.16.2
+      semver: 7.8.3
+      validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
 
@@ -11166,13 +11887,23 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.71.0
       '@oxlint/binding-win32-x64-msvc': 1.71.0
 
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-try@2.2.0: {}
 
   package-json@10.0.1:
     dependencies:
@@ -11186,6 +11917,10 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-diff@0.11.1: {}
+
+  parse-github-repo-url@1.4.1: {}
 
   parse-json@5.2.0:
     dependencies:
@@ -11218,9 +11953,13 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-is-absolute@1.0.1: {}
+
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
+
+  path-parse@1.0.7: {}
 
   path-scurry@2.0.2:
     dependencies:
@@ -11504,6 +12243,8 @@ snapshots:
 
   quick-format-unescaped@4.0.4: {}
 
+  quick-lru@4.0.1: {}
+
   radix-ui@1.6.0(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7):
     dependencies:
       '@radix-ui/primitive': 1.1.4
@@ -11630,6 +12371,19 @@ snapshots:
 
   react@19.2.7: {}
 
+  read-pkg-up@7.0.1:
+    dependencies:
+      find-up: 4.1.0
+      read-pkg: 5.2.0
+      type-fest: 0.8.1
+
+  read-pkg@5.2.0:
+    dependencies:
+      '@types/normalize-package-data': 2.4.4
+      normalize-package-data: 2.5.0
+      parse-json: 5.2.0
+      type-fest: 0.6.0
+
   readable-stream@2.3.8:
     dependencies:
       core-util-is: 1.0.3
@@ -11700,6 +12454,42 @@ snapshots:
       unified: 11.0.5
       vfile: 6.0.3
 
+  release-please@17.6.0:
+    dependencies:
+      '@conventional-commits/parser': 0.4.1
+      '@google-automations/git-file-utils': 3.0.1
+      '@iarna/toml': 3.0.0
+      '@octokit/graphql': 7.1.1
+      '@octokit/request': 8.4.1
+      '@octokit/request-error': 5.1.1
+      '@octokit/rest': 20.1.2
+      '@types/npm-package-arg': 6.1.4
+      '@xmldom/xmldom': 0.8.13
+      chalk: 4.1.2
+      code-suggester: 5.0.1
+      conventional-changelog-conventionalcommits: 6.1.0
+      conventional-changelog-writer: 6.0.1
+      conventional-commits-filter: 3.0.0
+      detect-indent: 6.1.0
+      diff: 8.0.4
+      figures: 3.2.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      js-yaml: 4.2.0
+      jsonpath-plus: 10.4.0
+      node-html-parser: 6.1.13
+      parse-github-repo-url: 1.4.1
+      semver: 7.8.3
+      type-fest: 3.13.1
+      typescript: 4.9.5
+      unist-util-visit: 2.0.3
+      unist-util-visit-parents: 3.1.1
+      xpath: 0.0.34
+      yaml: 2.9.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - supports-color
+
   remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -11734,10 +12524,19 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
+
+  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
@@ -11830,6 +12629,8 @@ snapshots:
   scheduler@0.27.0: {}
 
   scule@1.3.0: {}
+
+  semver@5.7.2: {}
 
   semver@6.3.1: {}
 
@@ -12016,6 +12817,20 @@ snapshots:
       concat-stream: 1.6.2
       os-shim: 0.1.3
 
+  spdx-correct@3.2.0:
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.23
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@3.0.1:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
+
   split2@4.2.0: {}
 
   split@1.0.1:
@@ -12129,6 +12944,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-preserve-symlinks-flag@1.0.0: {}
+
   symbol-tree@3.2.4: {}
 
   tagged-tag@1.0.0: {}
@@ -12202,6 +13019,8 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
+  trim-newlines@3.0.1: {}
+
   trim-trailing-lines@2.1.0: {}
 
   trough@2.2.0: {}
@@ -12247,6 +13066,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-fest@0.18.1: {}
+
+  type-fest@0.6.0: {}
+
+  type-fest@0.8.1: {}
+
   type-fest@3.13.1: {}
 
   type-fest@4.41.0: {}
@@ -12274,9 +13099,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  typescript@4.9.5: {}
+
   typescript@6.0.3: {}
 
   ufo@1.6.4: {}
+
+  uglify-js@3.19.3:
+    optional: true
 
   uhyphen@0.2.0: {}
 
@@ -12324,6 +13154,8 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
 
+  unist-util-is@4.1.0: {}
+
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
@@ -12336,16 +13168,29 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  unist-util-visit-parents@3.1.1:
+    dependencies:
+      '@types/unist': 2.0.11
+      unist-util-is: 4.1.0
+
   unist-util-visit-parents@6.0.2:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
+
+  unist-util-visit@2.0.3:
+    dependencies:
+      '@types/unist': 2.0.11
+      unist-util-is: 4.1.0
+      unist-util-visit-parents: 3.1.1
 
   unist-util-visit@5.1.0:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  universal-user-agent@6.0.1: {}
 
   universalify@2.0.1: {}
 
@@ -12407,6 +13252,11 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@8.3.2: {}
+
+  validate-npm-package-license@3.0.4:
+    dependencies:
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
 
   validate-npm-package-name@7.0.2: {}
 
@@ -12611,6 +13461,8 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wordwrap@1.0.0: {}
+
   wrap-ansi@10.0.0:
     dependencies:
       ansi-styles: 6.2.3
@@ -12714,13 +13566,29 @@ snapshots:
 
   xmlchars@2.2.0: {}
 
+  xpath@0.0.34: {}
+
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
 
+  yallist@4.0.0: {}
+
   yaml@2.9.0: {}
 
+  yargs-parser@20.2.9: {}
+
   yargs-parser@21.1.1: {}
+
+  yargs@16.2.2:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   yargs@17.7.2:
     dependencies:


### PR DESCRIPTION
## Problem

Beta releases already have a maintained release-please PR and automatic macOS/GitHub + TestFlight delivery, but graduating a published beta to stable is still a multi-step manual sequence: open a `next` → `master` PR, merge it, wait for a second stable Release PR, merge that too, and then deploy. The moving `next` branch also makes it easy for a promotion review to drift beyond the beta that was actually tested and shipped.

Major graduation is especially fragile: conventional commits cannot intentionally express the product decision that `1.0.0-beta.N` must become exactly `1.0.0`.

## Before → After

| | Before | After |
| --- | --- | --- |
| Promotion candidate | Human opens a PR from moving `next` | One bot-maintained PR points at the latest fully published beta commit |
| Stable approval | Merge promotion PR, then merge stable Release PR | Merge the promotion PR once; generated release metadata merges mechanically |
| Stable version | Inferred again from conventional commits | Pinned to the stable base of the approved beta tag |
| Build source | Reusable workflows may inherit the caller SHA or resolve a tag independently | Every delivery path checks out one verified immutable release commit |
| Hotfixes | Manual stable Release PR | Unchanged; direct `master` hotfix releases stay manual |

## Changes

1. **Maintain an exact beta promotion snapshot**
   - Adds `release-promotion.mjs`, which creates or safely advances `release-promotion/latest-beta` only after both beta delivery workflows succeed.
   - Reuses one open PR, rejects divergent/rewound branch updates, ignores same-named fork PRs, and verifies the beta tag still resolves to the release commit.

2. **Make the promotion merge the single stable approval**
   - Recognizes only a merge-commit promotion whose second parent, tree, ancestry, tag, and published prerelease record all match the approved beta.
   - Uses the lockfile-pinned release-please 17.6.0 CLI to create the stable Release PR with an exact `release-as` value, including major releases such as `1.0.0-beta.4` → `1.0.0`.
   - Allow-lists and validates the generated manifest, changelog, and package-version changes before squash-merging that metadata PR and creating the stable draft/tag in the same workflow.

3. **Harden races and retries**
   - Serializes branch release maintenance, rejects stale `master` events, quarantines a generated Release PR if its base changes inside GitHub’s merge operation, and resumes safely before/after the metadata merge or draft creation.
   - Makes the post-stable back-merge idempotent and keeps direct stable hotfix Release PRs human-controlled.

4. **Pin every delivery job to the released commit**
   - Resolves the lightweight tag once, verifies it against the GitHub release target, and passes that SHA to macOS, TestFlight, beta-feed sync, promotion, and back-merge checkouts.
   - Updates the distribution and contribution guides with the single-approval flow and major-version behavior.

## Tests

- `release-promotion.test.mjs` covers beta/commit validation, forward-only branch movement, exact PR metadata, explicit repository scoping, and fork/cross-repository collisions.
- Existing macOS and iOS release-helper suites continue to cover signing/publishing and TestFlight behavior.
- A release-please dry run with `--release-as 1.0.0` produced `chore(next): release 1.0.0` and the expected manifest/changelog/version updates.

## Verification

- `pnpm --filter @reflect/desktop exec vitest run scripts/release-promotion.test.mjs scripts/release-macos.test.mjs scripts/release-ios.test.mjs` — 66 tests passed
- `actionlint .github/workflows/*.yml` — passed
- `pnpm check` — passed (two pre-existing max-lines warnings)
- `pnpm build` — passed (expected local Sentry-token and chunk-size warnings)
- `git diff --check` — passed
- `pnpm install --frozen-lockfile --ignore-scripts --filter @reflect/monorepo` — passed; pinned CLI reports 17.6.0

## Risk / Rollout

This changes release control flow, so the workflow fails closed whenever GitHub state does not match the reviewed beta snapshot. Merging this PR does not ship stable by itself: it activates on `next`, and the promotion PR appears only after a subsequent beta finishes both delivery channels. Stable deployment starts only when that promotion PR is merge-committed. Leaving or closing the promotion PR remains a safe stop mechanism.

A direct hotfix on `master` still requires its stable Release PR to be merged manually. Failed stable metadata/tag creation can be rerun from the original promotion workflow; failed macOS or TestFlight delivery can use the existing manual retry workflows against the stable commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to release control flow, branch history, and automated merges on `master`; mistakes could ship wrong versions or block releases, though the workflow is designed to fail closed on state mismatches.
> 
> **Overview**
> **Stable promotion** no longer relies on a hand-opened `next` → `master` PR plus a second manual stable Release PR. After macOS and TestFlight both succeed for a beta, a new job runs `release-promotion.mjs` to maintain `release-promotion/latest-beta` at the published beta commit and open/update one promotion PR. Merging that PR with a **merge commit** is the only human approval; `release-please.yml` then validates the merge against the beta tag, creates the stable Release PR with a pinned `release-as` (via lockfile `release-please` 17.6.0), squash-merges it mechanically, and runs release-please again to tag and draft the stable release.
> 
> **Delivery** reusable workflows (`release.yml`, `testflight.yml`) gain a required `commit` input so macOS, TestFlight, beta-feed sync, promotion, and post-stable back-merge all checkout the same immutable SHA resolved once from the tag, not the caller event SHA.
> 
> **Resilience** includes promotion detection, stale-`master` guards, idempotent promotion/back-merge PR handling, and `release_available` so post-stable jobs can recover when a release is already published.
> 
> Docs (`macos-distribution.md`, `CONTRIBUTING.md`) describe the single-approval flow and major-version promotion (`v1.0.0-beta.N` → `v1.0.0`). Direct `master` hotfixes still merge stable Release PRs manually.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 338f2d54059fd0e0e81c954a12f2a0d551e0cb48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a managed beta-to-stable promotion process with automated validation and controlled stable release preparation.
  - Release builds, macOS packages, and TestFlight uploads now use the verified release commit.

- **Bug Fixes**
  - Improved safeguards against incorrect, outdated, divergent, or prematurely tagged releases.
  - Added safer handling for optional release and upload settings.

- **Documentation**
  - Clarified beta, stable, hotfix, promotion, rerun, and back-merge procedures.
  - Updated contribution guidance for release markers and version promotion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->