### PR TITLE
fix: find draft GitHub releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,6 +43,11 @@ jobs:
           echo "config=.github/release-please/config.${channel}.json" >> "$GITHUB_OUTPUT"
           echo "manifest=.github/release-please/manifest.${channel}.json" >> "$GITHUB_OUTPUT"
 
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
       # A stable promotion is a deliberately narrow path: it must be the merge
       # commit of the managed promotion PR. Squash/rebase would leave next and
       # master with unrelated histories, so reject it before touching releases.
@@ -217,7 +222,8 @@ jobs:
             exit 1
           fi
 
-          if release_details="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${expected_tag}" 2>/dev/null)"; then
+          release_details="$(bash apps/desktop/scripts/find-github-release.sh "$expected_tag")"
+          if [ "$release_details" != "null" ]; then
             if ! jq -e \
               --arg commit "$stable_commit" \
               --arg tag "$expected_tag" \
@@ -279,12 +285,6 @@ jobs:
       # The action's release-as input is not forwarded in manifest mode. Use
       # the lockfile-pinned matching CLI for the fresh promotion PR so a beta's
       # stable base (including a major version) is exact.
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        if: steps.promotion_state.outputs.phase == 'fresh'
-        with:
-          ref: ${{ github.sha }}
-          persist-credentials: false
-
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         if: steps.promotion_state.outputs.phase == 'fresh'
 
@@ -571,52 +571,57 @@ jobs:
             elif [ "$FIRST_RELEASE_CREATED" = "true" ]; then
               release_created=true
               tag_name="$FIRST_TAG_NAME"
-            elif [ -n "$stable_commit" ] && \
-              release_details="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${expected_tag}" 2>/dev/null)"; then
-              if ! jq -e \
-                --arg commit "$stable_commit" \
-                --arg tag "$expected_tag" \
-                '.tag_name == $tag and
-                  .target_commitish == $commit and
-                  .prerelease == false and
-                  ((.draft == true and .published_at == null) or
-                   (.draft == false and .published_at != null))' \
-                <<< "$release_details" > /dev/null; then
-                echo "::error::existing ${expected_tag} release does not match generated stable commit ${stable_commit}"
-                exit 1
-              fi
-              tag_details="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${expected_tag}")"
-              if ! jq -e \
-                --arg commit "$stable_commit" \
-                '.object.type == "commit" and .object.sha == $commit' \
-                <<< "$tag_details" > /dev/null; then
-                echo "::error::existing ${expected_tag} tag does not point to generated stable commit ${stable_commit}"
-                exit 1
-              fi
-
-              if [ "$(jq -r '.draft' <<< "$release_details")" = "true" ]; then
-                release_created=true
-                tag_name="$expected_tag"
-                echo "Recovering draft ${expected_tag} created by an earlier promotion attempt."
-              else
-                release_available=true
-                tag_name="$expected_tag"
-                echo "The promoted ${expected_tag} release is already published; release delivery remains complete."
-              fi
             else
-              if [ "$STABLE_RELEASE_PR_MERGED" = "true" ]; then
-                echo "::error::the second release-please run did not create the promoted stable release"
-                exit 1
+              release_details=null
+              if [ -n "$stable_commit" ]; then
+                release_details="$(bash apps/desktop/scripts/find-github-release.sh "$expected_tag")"
               fi
-              if [ "$PROMOTION_PHASE" = "fresh" ]; then
-                echo "::error::release-please did not create a stable Release PR for the promotion"
-                exit 1
+              if [ "$release_details" != "null" ]; then
+                if ! jq -e \
+                  --arg commit "$stable_commit" \
+                  --arg tag "$expected_tag" \
+                  '.tag_name == $tag and
+                    .target_commitish == $commit and
+                    .prerelease == false and
+                    ((.draft == true and .published_at == null) or
+                     (.draft == false and .published_at != null))' \
+                  <<< "$release_details" > /dev/null; then
+                  echo "::error::existing ${expected_tag} release does not match generated stable commit ${stable_commit}"
+                  exit 1
+                fi
+                tag_details="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${expected_tag}")"
+                if ! jq -e \
+                  --arg commit "$stable_commit" \
+                  '.object.type == "commit" and .object.sha == $commit' \
+                  <<< "$tag_details" > /dev/null; then
+                  echo "::error::existing ${expected_tag} tag does not point to generated stable commit ${stable_commit}"
+                  exit 1
+                fi
+
+                if [ "$(jq -r '.draft' <<< "$release_details")" = "true" ]; then
+                  release_created=true
+                  tag_name="$expected_tag"
+                  echo "Recovering draft ${expected_tag} created by an earlier promotion attempt."
+                else
+                  release_available=true
+                  tag_name="$expected_tag"
+                  echo "The promoted ${expected_tag} release is already published; release delivery remains complete."
+                fi
+              else
+                if [ "$STABLE_RELEASE_PR_MERGED" = "true" ]; then
+                  echo "::error::the second release-please run did not create the promoted stable release"
+                  exit 1
+                fi
+                if [ "$PROMOTION_PHASE" = "fresh" ]; then
+                  echo "::error::release-please did not create a stable Release PR for the promotion"
+                  exit 1
+                fi
+                if [ "$PROMOTION_PHASE" = "resume" ]; then
+                  echo "::error::release-please did not create the stable release while resuming the promotion"
+                  exit 1
+                fi
+                echo "The promotion is already complete; no release work remains."
               fi
-              if [ "$PROMOTION_PHASE" = "resume" ]; then
-                echo "::error::release-please did not create the stable release while resuming the promotion"
-                exit 1
-              fi
-              echo "The promotion is already complete; no release work remains."
             fi
           elif [ "$FIRST_RELEASE_CREATED" = "true" ]; then
             if [ -z "$FIRST_TAG_NAME" ]; then
@@ -645,7 +650,11 @@ jobs:
               echo "::error::promoted release has no verified stable commit"
               exit 1
             fi
-            release_details="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag_name}")"
+            release_details="$(bash apps/desktop/scripts/find-github-release.sh "$tag_name")"
+            if [ "$release_details" = "null" ]; then
+              echo "::error::promoted draft ${tag_name} does not exist"
+              exit 1
+            fi
             if ! jq -e \
               --arg commit "$stable_commit" \
               --arg tag "$tag_name" \
@@ -679,7 +688,11 @@ jobs:
               exit 1
             fi
             release_commit="$(jq -r '.object.sha' <<< "$tag_details")"
-            release_details="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag_name}")"
+            release_details="$(bash apps/desktop/scripts/find-github-release.sh "$tag_name")"
+            if [ "$release_details" = "null" ]; then
+              echo "::error::GitHub release ${tag_name} does not exist"
+              exit 1
+            fi
             if ! jq -e \
               --arg commit "$release_commit" \
               --arg tag "$tag_name" \

--- a/apps/desktop/scripts/find-github-release.sh
+++ b/apps/desktop/scripts/find-github-release.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "find-github-release: error: expected one release tag" >&2
+  exit 1
+fi
+
+repository="${GITHUB_REPOSITORY:-}"
+tag="$1"
+
+if [[ ! "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  echo "find-github-release: error: GITHUB_REPOSITORY must be an owner/repository name" >&2
+  exit 1
+fi
+if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+  echo "find-github-release: error: invalid release tag ${tag}" >&2
+  exit 1
+fi
+
+# GitHub's releases/tags/<tag> endpoint does not return draft releases. List
+# every page and select the exact tag so release-please drafts are visible.
+matches="$(
+  gh api --paginate "repos/${repository}/releases?per_page=100" |
+    jq -cs --arg tag "$tag" '
+      if all(.[]; type == "array") then
+        [.[][] | select(type == "object" and .tag_name == $tag)]
+      else
+        error("GitHub releases response contained a non-array page")
+      end
+    '
+)"
+match_count="$(jq 'length' <<< "$matches")"
+
+if [ "$match_count" -eq 0 ]; then
+  echo null
+elif [ "$match_count" -eq 1 ]; then
+  jq -c '.[0]' <<< "$matches"
+else
+  echo "find-github-release: error: multiple releases use tag ${tag}" >&2
+  exit 1
+fi

--- a/apps/desktop/scripts/find-github-release.test.mjs
+++ b/apps/desktop/scripts/find-github-release.test.mjs
@@ -1,0 +1,117 @@
+import { spawnSync } from 'node:child_process'
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { expect, test } from 'vitest'
+
+const scriptPath = join(dirname(fileURLToPath(import.meta.url)), 'find-github-release.sh')
+
+function runLookup({ output, repository = 'team-reflect/reflect-open', status = 0, tag = 'v0.6.0-beta.14' }) {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'find-github-release-'))
+  const mockGhPath = join(temporaryDirectory, 'gh')
+  const argsPath = join(temporaryDirectory, 'args.txt')
+  writeFileSync(
+    mockGhPath,
+    `#!/usr/bin/env bash
+printf '%s\n' "$*" > "$MOCK_GH_ARGS_PATH"
+if [ "$MOCK_GH_STATUS" -ne 0 ]; then
+  echo 'mock gh failure' >&2
+  exit "$MOCK_GH_STATUS"
+fi
+printf '%s' "$MOCK_GH_OUTPUT"
+`,
+  )
+  chmodSync(mockGhPath, 0o755)
+
+  try {
+    const result = spawnSync('bash', [scriptPath, tag], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        GITHUB_REPOSITORY: repository,
+        MOCK_GH_ARGS_PATH: argsPath,
+        MOCK_GH_OUTPUT: output,
+        MOCK_GH_STATUS: String(status),
+        PATH: `${temporaryDirectory}:${process.env.PATH ?? ''}`,
+      },
+    })
+    return {
+      args: existsSync(argsPath) ? readFileSync(argsPath, 'utf8').trim() : '',
+      exitCode: result.status,
+      stderr: result.stderr,
+      stdout: result.stdout,
+    }
+  } finally {
+    rmSync(temporaryDirectory, { force: true, recursive: true })
+  }
+}
+
+test('finds a draft release by exact tag', () => {
+  const draft = {
+    draft: true,
+    prerelease: true,
+    published_at: null,
+    tag_name: 'v0.6.0-beta.14',
+    target_commitish: 'a'.repeat(40),
+  }
+  const result = runLookup({
+    output: JSON.stringify([{ tag_name: 'v0.6.0-beta.13' }, draft]),
+  })
+
+  expect(result.exitCode).toBe(0)
+  expect(JSON.parse(result.stdout)).toEqual(draft)
+  expect(result.args).toBe(
+    'api --paginate repos/team-reflect/reflect-open/releases?per_page=100',
+  )
+})
+
+test('finds a published release on a later page', () => {
+  const published = {
+    draft: false,
+    prerelease: false,
+    published_at: '2026-07-13T20:00:00Z',
+    tag_name: 'v0.6.0',
+    target_commitish: 'b'.repeat(40),
+  }
+  const result = runLookup({
+    output: `${JSON.stringify([{ tag_name: 'v0.5.0' }])}\n${JSON.stringify([published])}`,
+    tag: 'v0.6.0',
+  })
+
+  expect(result.exitCode).toBe(0)
+  expect(JSON.parse(result.stdout)).toEqual(published)
+})
+
+test('prints null when no release matches', () => {
+  const result = runLookup({ output: JSON.stringify([{ tag_name: 'v0.5.0' }]) })
+
+  expect(result.exitCode).toBe(0)
+  expect(result.stdout).toBe('null\n')
+})
+
+test('fails closed when multiple releases use the tag', () => {
+  const release = { tag_name: 'v0.6.0-beta.14' }
+  const result = runLookup({ output: `${JSON.stringify([release])}\n${JSON.stringify([release])}` })
+
+  expect(result.exitCode).toBe(1)
+  expect(result.stderr).toContain('multiple releases use tag v0.6.0-beta.14')
+})
+
+test('propagates GitHub API failures instead of reporting an absent release', () => {
+  const result = runLookup({ output: '', status: 2 })
+
+  expect(result.exitCode).not.toBe(0)
+  expect(result.stderr).toContain('mock gh failure')
+  expect(result.stdout).not.toBe('null\n')
+})
+
+test('rejects invalid repository and tag inputs before calling GitHub', () => {
+  const invalidRepository = runLookup({ output: '[]', repository: 'not-a-repository' })
+  const invalidTag = runLookup({ output: '[]', tag: 'latest' })
+
+  expect(invalidRepository.exitCode).toBe(1)
+  expect(invalidRepository.stderr).toContain('GITHUB_REPOSITORY must be an owner/repository name')
+  expect(invalidTag.exitCode).toBe(1)
+  expect(invalidTag.stderr).toContain('invalid release tag latest')
+})


### PR DESCRIPTION
## Problem

Release Please creates a draft GitHub release before the delivery jobs run, but GitHub’s releases-by-tag endpoint returns 404 for draft releases. After [beta.14 merged](https://github.com/team-reflect/reflect-open/pull/774), the [release workflow](https://github.com/team-reflect/reflect-open/actions/runs/29285529370) failed while collecting outputs, so macOS, TestFlight, and stable promotion were skipped.

## Before → After

| | Before | After |
|---|---|---|
| Draft lookup | GET /releases/tags/:tag returned 404 | Paginated release-list lookup finds the exact tag, including drafts |
| API failures | Could be mistaken for an absent optional release | Fail closed and preserve the API error |
| Validation | Inline lookups differed by path | Shared lookup keeps tag, target commit, draft, and prerelease validation intact |

## Changes

- add a small exact-tag GitHub release lookup that supports drafts and pagination
- use it in all draft-capable beta and stable release paths
- check out the triggering SHA before release-state inspection so the helper is available consistently
- cover draft, published, paginated, missing, duplicate, invalid-input, and API-failure cases

## Verification

- 72 targeted release tests
- actionlint .github/workflows/*.yml
- shellcheck apps/desktop/scripts/find-github-release.sh
- pnpm check
- pnpm build
- live lookup against draft beta.14, published beta.13, and a missing tag

## Rollout

After merge, Release Please should open beta.15. We can then merge that release PR and observe the normal macOS → TestFlight → next-to-master promotion flow. The incomplete beta.14 draft and tag are intentionally left untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release-please promotion and publish gate on master/next; behavior is narrowly scoped but a mistake could block or mis-classify releases.
> 
> **Overview**
> Fixes release-please failing after a beta merge when Release Please has already created a **draft** GitHub release. The workflow no longer uses `GET /releases/tags/:tag` (404 for drafts) and instead resolves releases through a shared **`find-github-release.sh`** helper that paginates the releases list and matches the exact tag.
> 
> **`release-please.yml`** checks out the triggering SHA up front so that helper is on disk before promotion/resume logic runs, and every draft-capable lookup path now calls the script with explicit **`null`** handling when no release exists. Existing jq checks on tag, `target_commitish`, draft/prerelease state, and promotion error paths are unchanged in intent.
> 
> Adds **Vitest** coverage for draft vs published, pagination, missing tag, duplicate tags, input validation, and API failure propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ebd80cc7eda1c1223ee4bc8bdafa0a80f5967af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release promotion and recovery checks to reliably detect existing, missing, or ambiguous releases.
  * Added clearer failure handling when release information cannot be found or validated.

* **Tests**
  * Added coverage for draft and published releases, paginated lookups, missing or duplicate tags, API failures, and invalid release inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->