### PR TITLE
fix: keep Apple Silicon releases Xcode-compatible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
       matrix:
         include:
           - name: Apple Silicon
-            runner: macos-latest
+            runner: macos-26
             target: aarch64-apple-darwin
           - name: Intel
             runner: macos-15-intel
@@ -140,6 +140,21 @@ jobs:
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Scope the Rust cache to Xcode
+        run: |
+          set -euo pipefail
+
+          clang="$(xcrun --find clang)"
+          resource_dir="$("$clang" --print-resource-dir)"
+          runtime="$resource_dir/lib/darwin/libclang_rt.osx.a"
+          if [ ! -f "$runtime" ]; then
+            echo "::error::missing clang runtime at ${runtime}"
+            exit 1
+          fi
+          compiler_hash="$("$clang" --version | shasum -a 256 | cut -d ' ' -f 1)"
+          echo "CC=$clang" >> "$GITHUB_ENV"
+          echo "RUST_CACHE_XCODE=$compiler_hash" >> "$GITHUB_ENV"
 
       - name: Cache cargo build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/apps/desktop/scripts/release-workflow.test.mjs
+++ b/apps/desktop/scripts/release-workflow.test.mjs
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { expect, test } from 'vitest'
+
+const scriptsDirectory = dirname(fileURLToPath(import.meta.url))
+const workflowPath = join(scriptsDirectory, '..', '..', '..', '.github', 'workflows', 'release.yml')
+const workflow = readFileSync(workflowPath, 'utf8')
+
+test('Apple Silicon releases pin the runner and isolate Xcode build caches', () => {
+  const appleSiliconMatrix = workflow.match(
+    /- name: Apple Silicon\n\s+runner: [^\n]+\n\s+target: aarch64-apple-darwin/,
+  )?.[0]
+  expect(appleSiliconMatrix).toContain('runner: macos-26')
+
+  const cacheScopeStart = workflow.indexOf('- name: Scope the Rust cache to Xcode')
+  const cargoCacheStart = workflow.indexOf('- name: Cache cargo build')
+  expect(cacheScopeStart).toBeGreaterThan(-1)
+  expect(cargoCacheStart).toBeGreaterThan(cacheScopeStart)
+
+  const cacheScope = workflow.slice(cacheScopeStart, cargoCacheStart)
+  expect(cacheScope).toContain('xcrun --find clang')
+  expect(cacheScope).toContain('libclang_rt.osx.a')
+  expect(cacheScope).toContain('CC=$clang')
+  expect(cacheScope).toContain('RUST_CACHE_XCODE=$compiler_hash')
+})


### PR DESCRIPTION
## Problem

[Beta.15](https://github.com/team-reflect/reflect-open/actions/runs/29288260611) restored a Rust target cache created on macOS 26 / Xcode 26.5 into a macOS 15 runner. The cached ort-sys metadata retained an absolute Xcode 26.5 Clang runtime path, so the Apple Silicon link failed with libclang_rt.osx not found. Beta.10 failed the same way; beta.11–13 succeeded whenever macos-latest resolved to macOS 26.

GitHub is migrating the moving macos-latest alias between these images, so rerunning is nondeterministic.

## Before → After

| | Before | After |
|---|---|---|
| ARM runner | Moving macos-latest alias | Explicit macos-26 ARM64 image |
| Rust target cache | Shared across Xcode installations | Scoped by selected Clang path and compiler version |
| Failure timing | Link failed after the full build | Missing Clang runtime fails before cache restore/build |

## Changes

- pin Apple Silicon release builds to the official macos-26 runner label
- resolve and validate the active Clang runtime before restoring Rust targets
- expose CC and a compiler-version hash so the pinned rust-cache action isolates Xcode-specific artifacts
- add a workflow regression test; its app path also ensures Release Please includes this fix in beta.16

## Verification

- 73 release tests
- actionlint .github/workflows/release.yml
- pnpm check
- pnpm build
- local Clang runtime probe
- independent diff review: no findings

## Rollout

After merge, Release Please should open beta.16. Merging that generated PR will exercise the pinned ARM image and fresh Xcode-scoped cache before the stable promotion PR is opened.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/release workflow and test-only changes; no application runtime or signing logic is modified.
> 
> **Overview**
> **Apple Silicon macOS release builds** no longer use the moving `macos-latest` label; they run on **`macos-26`** so the image matches the Xcode toolchain that produced prior caches.
> 
> Before **`Cache cargo build`**, a new step resolves Clang via `xcrun`, verifies **`libclang_rt.osx.a`** exists (failing fast if not), sets **`CC`** to that compiler, and exports **`RUST_CACHE_XCODE`** from the compiler version hash so restored Rust target artifacts stay tied to the active Xcode install instead of stale absolute paths from another runner image.
> 
> A **Vitest** regression in `release-workflow.test.mjs` asserts the pinned runner, step order, and cache-scoping shell snippets in `release.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61a054af057b4c8f472274a9ca17d89ec451c87f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Apple Silicon release builds to use the latest macOS runner for improved build compatibility.
  * Scoped Rust build caching to the active Xcode/Clang toolchain to help prevent stale or incompatible cached builds.

* **Tests**
  * Added automated checks to verify the Apple Silicon runner and compiler-specific cache configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->