### PR TITLE
fix: complete releases after GitHub visibility delays

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -544,6 +544,7 @@ jobs:
       - name: Collect release-please outputs
         id: result
         env:
+          BRANCH_NAME: ${{ github.ref_name }}
           FIRST_RELEASE_CREATED: ${{ steps.release_first.outputs.releases_created }}
           FIRST_TAG_NAME: ${{ steps.release_first.outputs.tag_name }}
           EXPECTED_STABLE_VERSION: ${{ steps.promotion.outputs.stable_version }}
@@ -555,11 +556,13 @@ jobs:
           STABLE_RELEASE_PR_MERGED: ${{ steps.stable_release_pr.outputs.merged }}
           SECOND_RELEASE_CREATED: ${{ steps.release_second.outputs.releases_created }}
           SECOND_TAG_NAME: ${{ steps.release_second.outputs.tag_name }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
 
           release_created=false
           release_available=false
+          recovered_beta_release=false
           tag_name=""
           release_commit=""
           if [ "$IS_PROMOTION" = "true" ]; then
@@ -574,7 +577,13 @@ jobs:
             else
               release_details=null
               if [ -n "$stable_commit" ]; then
-                release_details="$(bash apps/desktop/scripts/find-github-release.sh "$expected_tag")"
+                promotion_lookup_args=("$expected_tag")
+                if [ "$STABLE_RELEASE_PR_MERGED" = "true" ] || [ "$PROMOTION_PHASE" = "resume" ]; then
+                  promotion_lookup_args=(--wait-for-visible "$expected_tag")
+                fi
+                release_details="$(
+                  bash apps/desktop/scripts/find-github-release.sh "${promotion_lookup_args[@]}"
+                )"
               fi
               if [ "$release_details" != "null" ]; then
                 if ! jq -e \
@@ -630,6 +639,61 @@ jobs:
             fi
             release_created=true
             tag_name="$FIRST_TAG_NAME"
+          elif [ "$BRANCH_NAME" = "next" ] && [ "$RUN_ATTEMPT" -gt 1 ]; then
+            branch_details="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BRANCH_NAME}")"
+            branch_head="$(jq -r '.object.sha' <<< "$branch_details")"
+            if [ "$branch_head" != "$GITHUB_SHA" ]; then
+              echo "A newer next commit owns release state; not recovering ${GITHUB_SHA}."
+            else
+              current_version="$(jq -r '.version' apps/desktop/package.json)"
+              manifest_version="$(jq -r '."."' .github/release-please/manifest.beta.json)"
+              if [ "$current_version" != "$manifest_version" ]; then
+                echo "::error::beta package version ${current_version} does not match manifest ${manifest_version}"
+                exit 1
+              fi
+              if [[ "$current_version" == *-* ]]; then
+                expected_tag="v${current_version}"
+                release_details="$(
+                  bash apps/desktop/scripts/find-github-release.sh --wait-for-visible "$expected_tag"
+                )"
+                if [ "$release_details" != "null" ]; then
+                  tag_details="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${expected_tag}")"
+                  release_is_current="$(
+                    jq -r --arg commit "$GITHUB_SHA" '.target_commitish == $commit' <<< "$release_details"
+                  )"
+                  tag_is_current="$(
+                    jq -r --arg commit "$GITHUB_SHA" \
+                      '.object.type == "commit" and .object.sha == $commit' <<< "$tag_details"
+                  )"
+                  if [ "$release_is_current" != "$tag_is_current" ]; then
+                    echo "::error::${expected_tag} release and tag disagree about retry commit ${GITHUB_SHA}"
+                    exit 1
+                  fi
+                  if [ "$release_is_current" = "true" ]; then
+                    if jq -e \
+                      '.draft == true and .published_at == null and .prerelease == true' \
+                      <<< "$release_details" > /dev/null; then
+                      release_created=true
+                      recovered_beta_release=true
+                      tag_name="$expected_tag"
+                      echo "Recovering draft ${expected_tag} for release retry ${RUN_ATTEMPT}."
+                    elif jq -e \
+                      '.draft == false and .published_at != null and .prerelease == true' \
+                      <<< "$release_details" > /dev/null; then
+                      release_available=true
+                      recovered_beta_release=true
+                      tag_name="$expected_tag"
+                      echo "${expected_tag} is already published; no delivery recovery is needed."
+                    else
+                      echo "::error::${expected_tag} has invalid beta release state"
+                      exit 1
+                    fi
+                  else
+                    echo "${expected_tag} belongs to an older commit; not recovering it for ${GITHUB_SHA}."
+                  fi
+                fi
+              fi
+            fi
           fi
 
           if [ "$release_created" = "true" ]; then
@@ -650,7 +714,9 @@ jobs:
               echo "::error::promoted release has no verified stable commit"
               exit 1
             fi
-            release_details="$(bash apps/desktop/scripts/find-github-release.sh "$tag_name")"
+            release_details="$(
+              bash apps/desktop/scripts/find-github-release.sh --wait-for-visible "$tag_name"
+            )"
             if [ "$release_details" = "null" ]; then
               echo "::error::promoted draft ${tag_name} does not exist"
               exit 1
@@ -688,7 +754,13 @@ jobs:
               exit 1
             fi
             release_commit="$(jq -r '.object.sha' <<< "$tag_details")"
-            release_details="$(bash apps/desktop/scripts/find-github-release.sh "$tag_name")"
+            release_lookup_args=("$tag_name")
+            if [ "$release_created" = "true" ]; then
+              release_lookup_args=(--wait-for-visible "$tag_name")
+            fi
+            release_details="$(
+              bash apps/desktop/scripts/find-github-release.sh "${release_lookup_args[@]}"
+            )"
             if [ "$release_details" = "null" ]; then
               echo "::error::GitHub release ${tag_name} does not exist"
               exit 1
@@ -703,6 +775,10 @@ jobs:
             fi
             if [ "$IS_PROMOTION" = "true" ] && [ "$release_commit" != "$stable_commit" ]; then
               echo "::error::promoted release commit ${release_commit} does not match generated stable commit ${stable_commit}"
+              exit 1
+            fi
+            if [ "$recovered_beta_release" = "true" ] && [ "$release_commit" != "$GITHUB_SHA" ]; then
+              echo "::error::recovered beta release commit ${release_commit} does not match retry commit ${GITHUB_SHA}"
               exit 1
             fi
           fi
@@ -745,7 +821,9 @@ jobs:
   publish-testflight:
     name: Upload to TestFlight
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: >-
+      needs.release-please.outputs.release_created == 'true' ||
+      (github.ref_name == 'next' && needs.release-please.outputs.release_available == 'true')
     uses: ./.github/workflows/testflight.yml
     with:
       commit: ${{ needs.release-please.outputs.release_commit }}
@@ -757,7 +835,16 @@ jobs:
   promote-stable:
     name: Open the stable promotion PR
     needs: [release-please, publish-release, publish-testflight]
-    if: github.ref_name == 'next' && needs.release-please.outputs.release_created == 'true'
+    if: >-
+      always() &&
+      github.ref_name == 'next' &&
+      needs.release-please.result == 'success' &&
+      needs.release-please.outputs.release_available == 'true' &&
+      needs.publish-testflight.result == 'success' &&
+      ((needs.release-please.outputs.release_created == 'true' &&
+        needs.publish-release.result == 'success') ||
+       (needs.release-please.outputs.release_created == 'false' &&
+        needs.publish-release.result == 'skipped'))
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}

--- a/apps/desktop/scripts/find-github-release.sh
+++ b/apps/desktop/scripts/find-github-release.sh
@@ -2,8 +2,12 @@
 
 set -euo pipefail
 
-if [ "$#" -ne 1 ]; then
-  echo "find-github-release: error: expected one release tag" >&2
+wait_for_visible=false
+if [ "$#" -eq 2 ] && [ "$1" = "--wait-for-visible" ]; then
+  wait_for_visible=true
+  shift
+elif [ "$#" -ne 1 ]; then
+  echo "find-github-release: error: expected [--wait-for-visible] <release-tag>" >&2
   exit 1
 fi
 
@@ -19,25 +23,39 @@ if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
   exit 1
 fi
 
-# GitHub's releases/tags/<tag> endpoint does not return draft releases. List
-# every page and select the exact tag so release-please drafts are visible.
-matches="$(
-  gh api --paginate "repos/${repository}/releases?per_page=100" |
-    jq -cs --arg tag "$tag" '
-      if all(.[]; type == "array") then
-        [.[][] | select(type == "object" and .tag_name == $tag)]
-      else
-        error("GitHub releases response contained a non-array page")
-      end
-    '
-)"
-match_count="$(jq 'length' <<< "$matches")"
-
-if [ "$match_count" -eq 0 ]; then
-  echo null
-elif [ "$match_count" -eq 1 ]; then
-  jq -c '.[0]' <<< "$matches"
-else
-  echo "find-github-release: error: multiple releases use tag ${tag}" >&2
-  exit 1
+attempt_limit=1
+if [ "$wait_for_visible" = "true" ]; then
+  attempt_limit=6
 fi
+
+for ((attempt = 1; attempt <= attempt_limit; attempt += 1)); do
+  # GitHub's releases/tags/<tag> endpoint does not return draft releases. List
+  # every page and select the exact tag so release-please drafts are visible.
+  matches="$(
+    gh api --paginate "repos/${repository}/releases?per_page=100" |
+      jq -cs --arg tag "$tag" '
+        if all(.[]; type == "array") then
+          [.[][] | select(type == "object" and .tag_name == $tag)]
+        else
+          error("GitHub releases response contained a non-array page")
+        end
+      '
+  )"
+  match_count="$(jq 'length' <<< "$matches")"
+
+  if [ "$match_count" -eq 1 ]; then
+    jq -c '.[0]' <<< "$matches"
+    exit 0
+  fi
+  if [ "$match_count" -gt 1 ]; then
+    echo "find-github-release: error: multiple releases use tag ${tag}" >&2
+    exit 1
+  fi
+  if [ "$attempt" -eq "$attempt_limit" ]; then
+    echo null
+    exit 0
+  fi
+
+  echo "find-github-release: ${tag} is not visible yet; retrying" >&2
+  sleep 2
+done

--- a/apps/desktop/scripts/find-github-release.test.mjs
+++ b/apps/desktop/scripts/find-github-release.test.mjs
@@ -7,38 +7,85 @@ import { expect, test } from 'vitest'
 
 const scriptPath = join(dirname(fileURLToPath(import.meta.url)), 'find-github-release.sh')
 
-function runLookup({ output, repository = 'team-reflect/reflect-open', status = 0, tag = 'v0.6.0-beta.14' }) {
+function runLookup({
+  output = '[]',
+  outputs,
+  repository = 'team-reflect/reflect-open',
+  scriptArgs,
+  status = 0,
+  statuses,
+  tag = 'v0.6.0-beta.14',
+  waitForVisible = false,
+}) {
   const temporaryDirectory = mkdtempSync(join(tmpdir(), 'find-github-release-'))
   const mockGhPath = join(temporaryDirectory, 'gh')
+  const mockSleepPath = join(temporaryDirectory, 'sleep')
   const argsPath = join(temporaryDirectory, 'args.txt')
+  const countPath = join(temporaryDirectory, 'count.txt')
+  const sleepArgsPath = join(temporaryDirectory, 'sleep-args.txt')
+  const responseOutputs = outputs ?? [output]
+  const responseStatuses = statuses ?? responseOutputs.map((_, index) => (index === 0 ? status : 0))
   writeFileSync(
     mockGhPath,
     `#!/usr/bin/env bash
-printf '%s\n' "$*" > "$MOCK_GH_ARGS_PATH"
-if [ "$MOCK_GH_STATUS" -ne 0 ]; then
-  echo 'mock gh failure' >&2
-  exit "$MOCK_GH_STATUS"
+count=0
+if [ -f "$MOCK_GH_COUNT_PATH" ]; then
+  count="$(< "$MOCK_GH_COUNT_PATH")"
 fi
-printf '%s' "$MOCK_GH_OUTPUT"
+count="$((count + 1))"
+printf '%s\n' "$count" > "$MOCK_GH_COUNT_PATH"
+printf '%s\n' "$*" >> "$MOCK_GH_ARGS_PATH"
+response_index="$count"
+if [ "$response_index" -gt "$MOCK_GH_RESPONSE_COUNT" ]; then
+  response_index="$MOCK_GH_RESPONSE_COUNT"
+fi
+status_variable="MOCK_GH_STATUS_\${response_index}"
+output_variable="MOCK_GH_OUTPUT_\${response_index}"
+response_status="\${!status_variable}"
+if [ "$response_status" -ne 0 ]; then
+  echo 'mock gh failure' >&2
+  exit "$response_status"
+fi
+printf '%s' "\${!output_variable}"
+`,
+  )
+  writeFileSync(
+    mockSleepPath,
+    `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_SLEEP_ARGS_PATH"
 `,
   )
   chmodSync(mockGhPath, 0o755)
+  chmodSync(mockSleepPath, 0o755)
 
   try {
-    const result = spawnSync('bash', [scriptPath, tag], {
+    const mockResponses = Object.fromEntries(
+      responseOutputs.flatMap((responseOutput, index) => [
+        [`MOCK_GH_OUTPUT_${index + 1}`, responseOutput],
+        [`MOCK_GH_STATUS_${index + 1}`, String(responseStatuses[index] ?? 0)],
+      ]),
+    )
+    const lookupArgs = scriptArgs ?? (waitForVisible ? ['--wait-for-visible', tag] : [tag])
+    const result = spawnSync('bash', [scriptPath, ...lookupArgs], {
       encoding: 'utf8',
       env: {
         ...process.env,
         GITHUB_REPOSITORY: repository,
         MOCK_GH_ARGS_PATH: argsPath,
-        MOCK_GH_OUTPUT: output,
-        MOCK_GH_STATUS: String(status),
+        MOCK_GH_COUNT_PATH: countPath,
+        MOCK_GH_RESPONSE_COUNT: String(responseOutputs.length),
+        MOCK_SLEEP_ARGS_PATH: sleepArgsPath,
+        ...mockResponses,
         PATH: `${temporaryDirectory}:${process.env.PATH ?? ''}`,
       },
     })
+    const args = existsSync(argsPath) ? readFileSync(argsPath, 'utf8').trim() : ''
+    const sleepArgs = existsSync(sleepArgsPath) ? readFileSync(sleepArgsPath, 'utf8').trim() : ''
     return {
-      args: existsSync(argsPath) ? readFileSync(argsPath, 'utf8').trim() : '',
+      args,
       exitCode: result.status,
+      ghCallCount: args === '' ? 0 : args.split('\n').length,
+      sleepArgs,
       stderr: result.stderr,
       stdout: result.stdout,
     }
@@ -88,30 +135,80 @@ test('prints null when no release matches', () => {
 
   expect(result.exitCode).toBe(0)
   expect(result.stdout).toBe('null\n')
+  expect(result.ghCallCount).toBe(1)
+  expect(result.sleepArgs).toBe('')
+})
+
+test('waits for a newly created draft to become visible', () => {
+  const draft = { draft: true, tag_name: 'v0.6.0-beta.14' }
+  const result = runLookup({
+    outputs: ['[]', '[]', JSON.stringify([draft])],
+    waitForVisible: true,
+  })
+
+  expect(result.exitCode).toBe(0)
+  expect(JSON.parse(result.stdout)).toEqual(draft)
+  expect(result.ghCallCount).toBe(3)
+  expect(result.sleepArgs).toBe('2\n2')
+  expect(result.stderr).toContain('v0.6.0-beta.14 is not visible yet; retrying')
+})
+
+test('returns null after bounded visibility retries are exhausted', () => {
+  const result = runLookup({ output: '[]', waitForVisible: true })
+
+  expect(result.exitCode).toBe(0)
+  expect(result.stdout).toBe('null\n')
+  expect(result.ghCallCount).toBe(6)
+  expect(result.sleepArgs).toBe('2\n2\n2\n2\n2')
 })
 
 test('fails closed when multiple releases use the tag', () => {
   const release = { tag_name: 'v0.6.0-beta.14' }
-  const result = runLookup({ output: `${JSON.stringify([release])}\n${JSON.stringify([release])}` })
+  const result = runLookup({
+    output: `${JSON.stringify([release])}\n${JSON.stringify([release])}`,
+    waitForVisible: true,
+  })
 
   expect(result.exitCode).toBe(1)
   expect(result.stderr).toContain('multiple releases use tag v0.6.0-beta.14')
+  expect(result.ghCallCount).toBe(1)
+  expect(result.sleepArgs).toBe('')
 })
 
 test('propagates GitHub API failures instead of reporting an absent release', () => {
-  const result = runLookup({ output: '', status: 2 })
+  const result = runLookup({
+    outputs: ['[]', ''],
+    statuses: [0, 2],
+    waitForVisible: true,
+  })
 
   expect(result.exitCode).not.toBe(0)
   expect(result.stderr).toContain('mock gh failure')
   expect(result.stdout).not.toBe('null\n')
+  expect(result.ghCallCount).toBe(2)
+  expect(result.sleepArgs).toBe('2')
+})
+
+test('does not retry malformed GitHub responses', () => {
+  const result = runLookup({ output: '{}', waitForVisible: true })
+
+  expect(result.exitCode).not.toBe(0)
+  expect(result.ghCallCount).toBe(1)
+  expect(result.sleepArgs).toBe('')
 })
 
 test('rejects invalid repository and tag inputs before calling GitHub', () => {
   const invalidRepository = runLookup({ output: '[]', repository: 'not-a-repository' })
   const invalidTag = runLookup({ output: '[]', tag: 'latest' })
+  const invalidOption = runLookup({ output: '[]', scriptArgs: ['--eventually', 'v0.6.0'] })
 
   expect(invalidRepository.exitCode).toBe(1)
   expect(invalidRepository.stderr).toContain('GITHUB_REPOSITORY must be an owner/repository name')
   expect(invalidTag.exitCode).toBe(1)
   expect(invalidTag.stderr).toContain('invalid release tag latest')
+  expect(invalidOption.exitCode).toBe(1)
+  expect(invalidOption.stderr).toContain('expected [--wait-for-visible] <release-tag>')
+  expect(invalidRepository.ghCallCount).toBe(0)
+  expect(invalidTag.ghCallCount).toBe(0)
+  expect(invalidOption.ghCallCount).toBe(0)
 })

--- a/apps/desktop/scripts/release-please-workflow.test.mjs
+++ b/apps/desktop/scripts/release-please-workflow.test.mjs
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { expect, test } from 'vitest'
+
+const scriptsDirectory = dirname(fileURLToPath(import.meta.url))
+const workflowPath = join(
+  scriptsDirectory,
+  '..',
+  '..',
+  '..',
+  '.github',
+  'workflows',
+  'release-please.yml',
+)
+const workflow = readFileSync(workflowPath, 'utf8')
+
+test('new releases wait for draft visibility before delivery', () => {
+  const resultStepStart = workflow.indexOf('- name: Collect release-please outputs')
+  const resultStepEnd = workflow.indexOf('- name: Print release-please outputs')
+  const resultStep = workflow.slice(resultStepStart, resultStepEnd)
+
+  expect(resultStepStart).toBeGreaterThan(-1)
+  expect(resultStepEnd).toBeGreaterThan(resultStepStart)
+  expect(resultStep).toContain('if [ "$release_created" = "true" ]; then')
+  expect(resultStep).toContain('release_lookup_args=(--wait-for-visible "$tag_name")')
+  expect(resultStep).toContain(
+    'find-github-release.sh "${release_lookup_args[@]}"',
+  )
+})
+
+test('a published beta retry resumes TestFlight and promotion without rebuilding macOS', () => {
+  const publishReleaseStart = workflow.indexOf('  publish-release:')
+  const postStableStart = workflow.indexOf('  post-stable:')
+  const betaDeliveryJobs = workflow.slice(publishReleaseStart, postStableStart)
+
+  expect(publishReleaseStart).toBeGreaterThan(-1)
+  expect(postStableStart).toBeGreaterThan(publishReleaseStart)
+  expect(betaDeliveryJobs).toContain(
+    "(github.ref_name == 'next' && needs.release-please.outputs.release_available == 'true')",
+  )
+  expect(betaDeliveryJobs).toContain('always() &&')
+  expect(betaDeliveryJobs).toContain("needs.publish-testflight.result == 'success'")
+  expect(betaDeliveryJobs).toContain(
+    "needs.release-please.outputs.release_created == 'true' &&\n        needs.publish-release.result == 'success'",
+  )
+  expect(betaDeliveryJobs).toContain(
+    "needs.release-please.outputs.release_created == 'false' &&\n        needs.publish-release.result == 'skipped'",
+  )
+})
+
+test('a beta retry only recovers release state for its immutable commit', () => {
+  const resultStepStart = workflow.indexOf('- name: Collect release-please outputs')
+  const resultStepEnd = workflow.indexOf('- name: Print release-please outputs')
+  const resultStep = workflow.slice(resultStepStart, resultStepEnd)
+
+  expect(resultStep).toContain(
+    'elif [ "$BRANCH_NAME" = "next" ] && [ "$RUN_ATTEMPT" -gt 1 ]; then',
+  )
+  expect(resultStep).toContain('if [ "$branch_head" != "$GITHUB_SHA" ]; then')
+  expect(resultStep).toContain('.target_commitish == $commit')
+  expect(resultStep).toContain('.draft == true and .published_at == null and .prerelease == true')
+  expect(resultStep).toContain('recovered_beta_release=true')
+  expect(resultStep).toContain(
+    'if [ "$recovered_beta_release" = "true" ] && [ "$release_commit" != "$GITHUB_SHA" ]; then',
+  )
+  expect(resultStep).not.toContain(
+    'if [ "$BRANCH_NAME" = "next" ] && [ "$release_commit" != "$GITHUB_SHA" ]; then',
+  )
+})


### PR DESCRIPTION
## Problem

GitHub can briefly omit a newly-created draft release from the paginated releases endpoint. The beta.16 release run hit that consistency window after release-please had already created the tag and draft, so collection failed before builds and the stable promotion PR never opened. A full workflow rerun also had no safe way to resume that exact beta.

## Changes

- add an opt-in, bounded visibility retry to exact draft release lookup
- retry only zero-match responses while failing immediately on API, schema, or duplicate-tag errors
- recover beta reruns only when the live next head, release target, and lightweight tag all match the failed run commit
- let an already-published beta rerun TestFlight and promotion without rebuilding macOS
- cover visibility retries, recovery invariants, and downstream rerun gates with regression tests

## Verification

- 79 release-related tests
- actionlint .github/workflows/release-please.yml
- shellcheck and bash syntax validation
- pnpm check
- pnpm build
- live exact lookup of the beta.16 draft through both immediate and wait modes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches beta/stable release orchestration and promotion gates; recovery paths are heavily validated but a mistake could skip builds or advance promotion incorrectly.
> 
> **Overview**
> Addresses release workflow failures when GitHub’s paginated releases list briefly omits a new draft after release-please creates the tag.
> 
> **`find-github-release.sh`** gains optional `--wait-for-visible`: up to six lookups with 2s backoff on zero matches only; API errors, duplicate tags, and malformed responses still fail immediately.
> 
> **Collect release-please outputs** uses that wait mode when verifying fresh tags and in stable promotion resume paths. On **`next`** with **`run_attempt > 1`**, it can **recover** an existing beta draft or an already-published prerelease when the live branch head, package/manifest version, release `target_commitish`, and lightweight tag all match the rerun’s commit—otherwise it refuses to steal a newer or older release.
> 
> **Downstream jobs:** `publish-testflight` also runs when a beta is only `release_available` (not newly `release_created`). `promote-stable` uses `always()` and allows macOS `publish-release` to be **skipped** while TestFlight still succeeds, so a published-beta retry can reopen promotion without rebuilding macOS.
> 
> Regression tests cover visibility retries, workflow gate strings, and recovery invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2fcfe6f94df7cedbe2c6e9cbfa3e4418bfcc33a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->