### PR TITLE
fix: capture iOS audio memos from Bluetooth headsets

### DIFF
--- a/plugins/tauri-plugin-recording/ios/Sources/RecordingPlugin.swift
+++ b/plugins/tauri-plugin-recording/ios/Sources/RecordingPlugin.swift
@@ -357,7 +357,7 @@ class RecordingPlugin: Plugin {
 
   private func beginRecording(maxDurationMs: Double) throws {
     let audioSession = AVAudioSession.sharedInstance()
-    try audioSession.setCategory(.record, mode: .default)
+    try audioSession.setCategory(.record, mode: .default, options: [.allowBluetoothHFP])
     try audioSession.setActive(true)
 
     let directory = try stagingDirectory()


### PR DESCRIPTION
## Problem

The V2 iOS recorder starts an input-only `AVAudioSession` without enabling Bluetooth HFP. That excludes AirPods and other Bluetooth headset microphones from the available input routes, so audio memos fall back to the phone microphone. The V1 recorder enabled Bluetooth input; that option was lost in the port.

## Before -> After

| | Behavior |
| --- | --- |
| Before | Bluetooth headset microphones are not eligible; iOS records through the built-in microphone. |
| After | Bluetooth HFP microphones are eligible for the system-selected recording route. |

## Change

Keep the recorder's `.record` category and enable `.allowBluetoothHFP` before activating the session. This preserves the input-only session semantics and existing disconnect handling without forcing a preferred device or changing output routing.

## Verification

- `pnpm check`
- `pnpm --filter @reflect/desktop exec vitest run src/mobile/use-native-audio-recorder.test.ts src/mobile/audio-memo-provider.test.tsx` (25 tests passed)
- `cargo test -p tauri-plugin-recording` (passes; the crate has no Rust tests and does not exercise Swift)
- `pnpm --filter @reflect/desktop exec tauri ios build --debug --target aarch64-sim --ci --no-sign --config src-tauri/tauri.ios.dev.conf.json`

## Risk / Rollout

The simulator build verifies native integration but cannot emulate accessory microphone routing. Physical-device QA should confirm AirPods/Bluetooth input, built-in-mic fallback, and headset disconnect behavior. Wired and USB-C headset routing remains under iOS's existing automatic input selection and is intentionally unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line audio-session option change in the recording plugin; no auth or data-path changes, though physical-device QA is needed to confirm routing and disconnect behavior.
> 
> **Overview**
> Restores **Bluetooth headset microphone** support for V2 iOS audio memos by passing **`.allowBluetoothHFP`** when configuring the input-only `AVAudioSession` in `beginRecording`.
> 
> Without this option, iOS does not treat AirPods and similar HFP inputs as eligible routes, so capture stayed on the built-in mic. Category (`.record`), mode, staging, and existing **route-change / disconnect** finalization are unchanged—only session options expand so the system can pick a Bluetooth input when appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f0d60b194088fe6873c0bb737d5d0923dd0b39d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recording support for Bluetooth HFP audio devices on iOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->