### PR TITLE
fix: retry failed release maintenance

### DIFF
--- a/.github/workflows/retry-release-please.yml
+++ b/.github/workflows/retry-release-please.yml
@@ -1,6 +1,9 @@
 name: Retry Release PR
 
 on:
+  # zizmor: ignore[dangerous-triggers]
+  # Release PR only runs on protected-branch pushes, and this workflow never
+  # checks out or executes content from the triggering run.
   workflow_run:
     workflows: [Release PR]
     types: [completed]

--- a/.github/workflows/retry-release-please.yml
+++ b/.github/workflows/retry-release-please.yml
@@ -1,0 +1,86 @@
+name: Retry Release PR
+
+on:
+  workflow_run:
+    workflows: [Release PR]
+    types: [completed]
+
+permissions:
+  actions: write
+
+concurrency:
+  group: retry-release-pr-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  retry-maintenance:
+    name: Retry failed release maintenance
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt < 3
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Find the failed maintenance job
+        id: maintenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+
+          jobs="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/attempts/${RUN_ATTEMPT}/jobs?per_page=100"
+          )"
+          matches="$(
+            jq -c \
+              '[.jobs[] | select(
+                .name == "Maintain the Release PR" and
+                .conclusion == "failure"
+              )]' <<< "$jobs"
+          )"
+          match_count="$(jq 'length' <<< "$matches")"
+
+          if [ "$match_count" -eq 0 ]; then
+            echo "Release PR maintenance succeeded; no automatic retry is needed."
+            echo "retry=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$match_count" -ne 1 ]; then
+            echo "::error::expected one failed Release PR maintenance job, found ${match_count}"
+            exit 1
+          fi
+
+          echo "retry=true" >> "$GITHUB_OUTPUT"
+          echo "job_id=$(jq -r '.[0].id' <<< "$matches")" >> "$GITHUB_OUTPUT"
+
+      - name: Back off before retrying
+        if: steps.maintenance.outputs.retry == 'true'
+        env:
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+        run: |
+          delay_seconds=$((RUN_ATTEMPT * 30))
+          echo "Retrying release maintenance in ${delay_seconds} seconds."
+          sleep "$delay_seconds"
+
+      - name: Rerun the maintenance job
+        if: steps.maintenance.outputs.retry == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          JOB_ID: ${{ steps.maintenance.outputs.job_id }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+
+          current_run="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}")"
+          current_attempt="$(jq -r '.run_attempt' <<< "$current_run")"
+          current_status="$(jq -r '.status' <<< "$current_run")"
+          if [ "$current_attempt" != "$RUN_ATTEMPT" ] || [ "$current_status" != "completed" ]; then
+            echo "Release PR run ${RUN_ID} already advanced; skipping the stale retry."
+            exit 0
+          fi
+
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/actions/jobs/${JOB_ID}/rerun"

--- a/apps/desktop/scripts/release-please-workflow.test.mjs
+++ b/apps/desktop/scripts/release-please-workflow.test.mjs
@@ -14,6 +14,16 @@ const workflowPath = join(
   'release-please.yml',
 )
 const workflow = readFileSync(workflowPath, 'utf8')
+const retryWorkflowPath = join(
+  scriptsDirectory,
+  '..',
+  '..',
+  '..',
+  '.github',
+  'workflows',
+  'retry-release-please.yml',
+)
+const retryWorkflow = readFileSync(retryWorkflowPath, 'utf8')
 
 test('new releases wait for draft visibility before delivery', () => {
   const resultStepStart = workflow.indexOf('- name: Collect release-please outputs')
@@ -67,4 +77,29 @@ test('a beta retry only recovers release state for its immutable commit', () => 
   expect(resultStep).not.toContain(
     'if [ "$BRANCH_NAME" = "next" ] && [ "$release_commit" != "$GITHUB_SHA" ]; then',
   )
+})
+
+test('failed release maintenance gets two bounded automatic retries', () => {
+  expect(retryWorkflow).toContain('workflow_run:')
+  expect(retryWorkflow).toContain('workflows: [Release PR]')
+  expect(retryWorkflow).toContain('types: [completed]')
+  expect(retryWorkflow).toContain('actions: write')
+  expect(retryWorkflow).toContain(
+    "github.event.workflow_run.conclusion == 'failure' &&\n      github.event.workflow_run.run_attempt < 3",
+  )
+  expect(retryWorkflow).toContain(
+    'actions/runs/${RUN_ID}/attempts/${RUN_ATTEMPT}/jobs?per_page=100',
+  )
+  expect(retryWorkflow).toContain('.name == "Maintain the Release PR"')
+  expect(retryWorkflow).toContain('.conclusion == "failure"')
+  expect(retryWorkflow).toContain(
+    'current_attempt="$(jq -r \'.run_attempt\' <<< "$current_run")"',
+  )
+  expect(retryWorkflow).toContain(
+    '[ "$current_attempt" != "$RUN_ATTEMPT" ] || [ "$current_status" != "completed" ]',
+  )
+  expect(retryWorkflow).toContain(
+    'gh api --method POST "repos/${GITHUB_REPOSITORY}/actions/jobs/${JOB_ID}/rerun"',
+  )
+  expect(retryWorkflow).not.toContain('rerun-failed-jobs')
 })

--- a/apps/desktop/scripts/release-please-workflow.test.mjs
+++ b/apps/desktop/scripts/release-please-workflow.test.mjs
@@ -81,6 +81,7 @@ test('a beta retry only recovers release state for its immutable commit', () => 
 
 test('failed release maintenance gets two bounded automatic retries', () => {
   expect(retryWorkflow).toContain('workflow_run:')
+  expect(retryWorkflow).toContain('# zizmor: ignore[dangerous-triggers]')
   expect(retryWorkflow).toContain('workflows: [Release PR]')
   expect(retryWorkflow).toContain('types: [completed]')
   expect(retryWorkflow).toContain('actions: write')

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -113,6 +113,13 @@ channel changelog (`apps/desktop/CHANGELOG.beta.md` on `next`,
 `apps/desktop/CHANGELOG.md` on `master`) from the conventional-commit PR titles landed
 since the last release.
 
+If the Release PR workflow's maintenance job fails, a watchdog waits briefly and
+reruns that job automatically. It makes at most two attempts beyond the original run;
+GitHub also reruns the dependent release jobs so a partially completed release can
+resume through the workflow's existing recovery checks. After three failed attempts,
+inspect the latest logs and rerun the failed job manually rather than opening or
+editing release state by hand.
+
 **Merging the Release PR is the technical release boundary.** release-please then
 creates a draft GitHub release (with its `v<version>` tag — `force-tag-creation`, so
 later release-please runs can always anchor on the previous release) and hands the tag


### PR DESCRIPTION
## Problem

A transient GitHub API connection failure can stop Release Please after it discovers the existing Release PR but before it updates that PR. The release workflow already knows how to recover partial beta and stable release state on a later run attempt, but that recovery currently depends on a maintainer noticing the failure and rerunning it manually.

The result is a stale, still-mergeable Release PR whose changelog can omit commits already present on `next`.

## Before → After

| Scenario | Before | After |
| --- | --- | --- |
| Release maintenance fails | Release PR stays stale until a new push or manual rerun | The failed maintenance job is retried automatically |
| Failure persists | No bounded automatic recovery | Two retries are attempted, then the run remains failed for investigation |
| A maintainer reruns during backoff | N/A | The watchdog detects the advanced run and skips its stale retry |

## Changes

1. Add a `workflow_run` watchdog for the `Release PR` workflow.
   - Inspect the exact failed run attempt.
   - Retry only the failed `Maintain the Release PR` job and its dependent jobs.
   - Grant only `actions: write`.
   - Back off between attempts and cap the workflow at three total attempts.
2. Recheck the live run attempt and status immediately before rerunning so a concurrent manual recovery cannot exceed the retry bound.
3. Extend the release workflow regression test and document the automatic/manual recovery behavior.

## Tests

The workflow regression test covers the trigger, permission, attempt cap, attempt-scoped job lookup, exact maintenance-job filter, stale-attempt guard, POST rerun endpoint, and avoidance of a broad failed-jobs rerun.

## Verification

- `actionlint .github/workflows/*.yml`
- `pnpm --filter @reflect/desktop test --run scripts/release-please-workflow.test.mjs` — 4 tests passed
- `pnpm check` — passed; only the two existing max-lines warnings remain
- Validated the attempt-scoped job query against failed run `29337470982`; it selected exactly `Maintain the Release PR`

## Risk / Rollout

The watchdog becomes active after this workflow file lands on the default `next` branch. It does not check out or execute code from the triggering workflow and has no contents or secrets access. Retries are bounded; after attempt three, maintainers still use GitHub's normal manual rerun path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only automation with minimal `actions: write` scope, no checkout of triggering workflow content, and bounded retries; does not change release or app code paths.
> 
> **Overview**
> Adds a **`workflow_run` watchdog** (`.github/workflows/retry-release-please.yml`) that runs when the **Release PR** workflow finishes. On failure and while `run_attempt < 3`, it locates the failed **Maintain the Release PR** job for that attempt, waits (`run_attempt * 30` seconds), verifies the run is still on the same completed attempt (so a manual rerun is not doubled), then **POST-reruns that job only**—not a broad `rerun-failed-jobs`. Permissions are limited to **`actions: write`**; the workflow does not check out repo code.
> 
> **Tests** assert trigger, cap, job filter, stale-run guard, and rerun API in `release-please-workflow.test.mjs`. **`docs/macos-distribution.md`** documents the two automatic retries and manual recovery after three failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e563474a337858a428e06f4d137f463e3d789fdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Retry Release PR” GitHub Actions workflow that automatically retries the failed release maintenance job (up to two additional attempts) with safeguards against stale or duplicate reruns.
  * Enables release workflows to continue by rerunning dependent release jobs after maintenance recovery.

* **Documentation**
  * Updated macOS release guidance with the new recovery behavior, including when to switch to manual reruns after repeated failures.

* **Tests**
  * Expanded coverage to verify failure-based retry triggers, retry limits, and the job rerun behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->