### PR TITLE
fix: keep app running when closing Mac window

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -324,8 +324,8 @@ pub fn run() {
                 windows::surface_main_window(app);
             }
             // Clicking the Dock icon is macOS's recovery path when an app has
-            // no visible windows. Surface a hidden/minimized main window, or
-            // recreate it if the user previously closed it with ⌘W.
+            // no visible windows. Surface the hidden/minimized main window,
+            // or recreate it after an unexpected destruction.
             #[cfg(target_os = "macos")]
             tauri::RunEvent::Reopen {
                 has_visible_windows,

--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -14,8 +14,9 @@ export function App(): ReactElement {
   const { status, graph, error } = useGraph()
 
   // Quit-time persistence: flush dirty note buffers before the webview dies
-  // (window close, ⌘Q, reload) — unmount effects don't run on those paths.
-  // installQuitFlush returns its teardown, which the effect returns as cleanup.
+  // (secondary-window close, ⌘Q, reload) or the macOS main window hides.
+  // Unmount effects don't run on those paths. installQuitFlush returns its
+  // teardown, which the effect returns as cleanup.
   useEffect(() => {
     return installQuitFlush()
   }, [])

--- a/apps/desktop/src/lib/quit-flush.test.ts
+++ b/apps/desktop/src/lib/quit-flush.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface CloseRequestedEventForTest {
+  preventDefault: () => void
+}
+
+type CloseRequestedHandler = (event: CloseRequestedEventForTest) => Promise<void>
+
+const windowMock = vi.hoisted(() => ({
+  closeRequested: null as CloseRequestedHandler | null,
+  hide: vi.fn(async () => {}),
+  unlisten: vi.fn(),
+}))
+const platform = vi.hoisted(() => ({ isMacosDesktop: true }))
+const windowRole = vi.hoisted(() => ({ isMainWindow: true }))
+const core = vi.hoisted(() => ({
+  confirmQuit: vi.fn(async () => {}),
+  quitRequested: null as (() => void) | null,
+  unlisten: vi.fn(),
+}))
+const flushOpenDocuments = vi.hoisted(() => vi.fn(async () => {}))
+const flushSettings = vi.hoisted(() => vi.fn(async () => {}))
+const flushBackup = vi.hoisted(() => vi.fn(async () => {}))
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    hide: windowMock.hide,
+    onCloseRequested: async (handler: CloseRequestedHandler) => {
+      windowMock.closeRequested = handler
+      return windowMock.unlisten
+    },
+  }),
+}))
+
+vi.mock('@reflect/core', () => ({
+  confirmQuit: core.confirmQuit,
+  hasBridge: () => true,
+  subscribeQuitRequested: async (handler: () => void) => {
+    core.quitRequested = handler
+    return core.unlisten
+  },
+}))
+
+vi.mock('@/editor/open-documents', () => ({ flushOpenDocuments }))
+vi.mock('@/lib/backup-flush', () => ({ flushBackup }))
+vi.mock('@/lib/settings-flush', () => ({ flushSettings }))
+vi.mock('@/lib/platform', () => ({
+  get isMacosDesktop() {
+    return platform.isMacosDesktop
+  },
+}))
+vi.mock('@/lib/windows/window-role', () => ({
+  isMainWindow: () => windowRole.isMainWindow,
+}))
+
+const { installQuitFlush } = await import('./quit-flush')
+
+beforeEach(() => {
+  platform.isMacosDesktop = true
+  windowRole.isMainWindow = true
+  windowMock.closeRequested = null
+  core.quitRequested = null
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+interface CloseRequestForTest {
+  completed: Promise<void>
+  preventDefault: ReturnType<typeof vi.fn>
+}
+
+function closeCurrentWindow(): CloseRequestForTest {
+  const preventDefault = vi.fn()
+  const closeRequested = windowMock.closeRequested
+  expect(closeRequested).not.toBeNull()
+  const completed = closeRequested?.({ preventDefault }) ?? Promise.resolve()
+  return { completed, preventDefault }
+}
+
+describe('installQuitFlush', () => {
+  it('flushes and hides the macOS main window instead of destroying it', async () => {
+    const dispose = installQuitFlush()
+    const closeRequest = closeCurrentWindow()
+
+    expect(closeRequest.preventDefault).toHaveBeenCalledOnce()
+    await closeRequest.completed
+    expect(flushOpenDocuments).toHaveBeenCalledOnce()
+    expect(flushSettings).toHaveBeenCalledOnce()
+    expect(flushBackup).toHaveBeenCalledOnce()
+    expect(windowMock.hide).toHaveBeenCalledOnce()
+
+    dispose()
+  })
+
+  it('allows secondary windows to close normally', async () => {
+    windowRole.isMainWindow = false
+    const dispose = installQuitFlush()
+    const closeRequest = closeCurrentWindow()
+
+    expect(closeRequest.preventDefault).not.toHaveBeenCalled()
+    await closeRequest.completed
+    expect(flushOpenDocuments).toHaveBeenCalledOnce()
+    expect(flushBackup).toHaveBeenCalledOnce()
+    expect(windowMock.hide).not.toHaveBeenCalled()
+
+    dispose()
+  })
+
+  it('allows the main window to close normally outside macOS', async () => {
+    platform.isMacosDesktop = false
+    const dispose = installQuitFlush()
+    const closeRequest = closeCurrentWindow()
+
+    expect(closeRequest.preventDefault).not.toHaveBeenCalled()
+    await closeRequest.completed
+    expect(windowMock.hide).not.toHaveBeenCalled()
+
+    dispose()
+  })
+})

--- a/apps/desktop/src/lib/quit-flush.test.ts
+++ b/apps/desktop/src/lib/quit-flush.test.ts
@@ -80,7 +80,8 @@ function closeCurrentWindow(): CloseRequestForTest {
 }
 
 describe('installQuitFlush', () => {
-  it('flushes and hides the macOS main window instead of destroying it', async () => {
+  it('flushes and hides the macOS main window even when one flush rejects', async () => {
+    flushSettings.mockRejectedValueOnce(new Error('settings flush failed'))
     const dispose = installQuitFlush()
     const closeRequest = closeCurrentWindow()
 

--- a/apps/desktop/src/lib/quit-flush.ts
+++ b/apps/desktop/src/lib/quit-flush.ts
@@ -2,8 +2,10 @@ import { getCurrentWindow } from '@tauri-apps/api/window'
 import { confirmQuit, hasBridge, subscribeQuitRequested } from '@reflect/core'
 import { flushOpenDocuments } from '@/editor/open-documents'
 import { flushBackup } from '@/lib/backup-flush'
+import { isMacosDesktop } from '@/lib/platform'
 import { flushSettings } from '@/lib/settings-flush'
 import { trackSubscriptions } from '@/lib/subscriptions'
+import { isMainWindow } from '@/lib/windows/window-role'
 
 /**
  * Quit-time persistence: the webview never dies with dirty note buffers still
@@ -12,7 +14,9 @@ import { trackSubscriptions } from '@/lib/subscriptions'
  *
  * - **Window close** (red button, ⌘W): registering a JS `onCloseRequested`
  *   listener defers the close until the handler returns, so the flush is
- *   awaited before the window is destroyed.
+ *   awaited before the window is destroyed. On macOS the main window stays
+ *   alive and is hidden after flushing, preserving normal last-window close
+ *   behavior without terminating the app; secondary windows still close.
  * - **App quit** (⌘Q): never reaches close-requested — the Rust shell defers
  *   `ExitRequested` once and emits `app:quit-requested`; we flush, then
  *   `confirmQuit()` exits for real (even if a flush failed: its error is
@@ -33,13 +37,23 @@ export function installQuitFlush(): () => void {
   // A subscription can resolve after teardown (StrictMode's probe mount) —
   // the tracker disposes it on the spot.
   const subscriptions = trackSubscriptions()
+  const currentWindow = getCurrentWindow()
 
   // Note buffers land first, then the backup commit captures them (a local
   // git commit only — pushing on the way out could stall the quit).
   void subscriptions.add(
-    getCurrentWindow().onCloseRequested(async () => {
+    currentWindow.onCloseRequested(async (event) => {
+      const shouldHide = isMacosDesktop && isMainWindow()
+      if (shouldHide) {
+        // Prevent synchronously: waiting until after the flush lets AppKit
+        // destroy the last window (and Tauri then terminates the process).
+        event.preventDefault()
+      }
       await Promise.all([flushOpenDocuments(), flushSettings()])
       await flushBackup()
+      if (shouldHide) {
+        await currentWindow.hide()
+      }
     }),
   )
 

--- a/apps/desktop/src/lib/quit-flush.ts
+++ b/apps/desktop/src/lib/quit-flush.ts
@@ -49,7 +49,7 @@ export function installQuitFlush(): () => void {
         // destroy the last window (and Tauri then terminates the process).
         event.preventDefault()
       }
-      await Promise.all([flushOpenDocuments(), flushSettings()])
+      await Promise.allSettled([flushOpenDocuments(), flushSettings()])
       await flushBackup()
       if (shouldHide) {
         await currentWindow.hide()

--- a/docs/multi-window.md
+++ b/docs/multi-window.md
@@ -134,13 +134,17 @@ silently dropped the note window's initial link.
 
 - **Window close (⌘W / red button):** each webview's `onCloseRequested`
   flushes its own note buffers and settings; the backup commit hook is only
-  registered in main. Per-window JS state makes this correct with no
-  coordination.
-- **Closing the main window closes every note window.** Note windows adopt
-  main's graph session and would degrade silently without it — edits still
-  land on disk, but nothing indexes, syncs, or propagates renames. Rather
-  than run in that half-alive state, they close with their owner (via
-  `close()`, so each child's flush runs exactly like ⌘W — no data loss).
+  registered in main. On macOS the main window prevents destruction and hides
+  after flushing, so closing the last window leaves Reflect running like a
+  native Mac app. Note windows still close normally. Per-window JS state makes
+  both paths correct with no coordination.
+- **Destroying the main window closes every note window.** This is a fallback
+  for shell-driven teardown rather than the macOS user-close path (which hides
+  main). Note windows adopt main's graph session and would degrade silently
+  without it — edits still land on disk, but nothing indexes, syncs, or
+  propagates renames. Rather than run in that half-alive state, they close with
+  their owner (via `close()`, so each child's flush runs exactly like ⌘W — no
+  data loss).
 - **Switching or deleting the graph closes note windows first.** They
   adopted the outgoing session, so `GraphProvider` awaits
   `close_note_windows` **before** anything bumps the generations: each
@@ -170,9 +174,9 @@ can contend; the writer connection carries a 5s `busy_timeout`
 ## Deliberate v1 limits
 
 - Note windows are **same-graph only**; switching graphs lives in main.
-- Note windows close with the main window (above) — "promote a note window
-  to session owner", which would let one survive as a focus surface, is the
-  eventual alternative if that usage ever matters.
+- Note windows close if the main window is destroyed (above) — "promote a note
+  window to session owner", which would let one survive as a focus surface,
+  is the eventual alternative if that usage ever matters.
 - The same note open in two windows converges through the existing
   external-change reconciliation, the same path an iCloud edit takes.
 - The native macOS application menu is installed by the main window only.


### PR DESCRIPTION
## Problem

Closing Reflect's main macOS window with Command-W or the red close button destroys the final webview. Tauri then terminates the process, so Close Window behaves like Quit instead of the normal Mac last-window behavior.

The existing close hook already flushes note buffers, settings, and the local backup commit, and Command-Q has a separate coordinated quit handshake. The missing piece is keeping the macOS main window alive after its close flush.

## Before -> After

| Action | Before | After |
| --- | --- | --- |
| Close the main Mac window | Flushes, destroys the last webview, and exits Reflect | Flushes, hides the main window, and leaves Reflect running |
| Close a secondary note window | Flushes and closes | Unchanged |
| Command-Q | Flushes all windows through the quit handshake and exits | Unchanged |
| Close windows on other desktop platforms | Closes normally | Unchanged |

## Changes

1. Handle the macOS main window's `onCloseRequested` event in `installQuitFlush` by preventing destruction synchronously, completing the existing note/settings/backup flush, and then hiding the window.
2. Keep secondary windows and non-macOS windows on the ordinary close path.
3. Add focused regression coverage for all three close branches, including synchronous close prevention for the macOS main window.
4. Update the multi-window lifecycle documentation and nearby shell comments to describe hide-versus-destroy behavior accurately.

## Tests

- `quit-flush.test.ts` verifies the macOS main window is prevented, flushed, and hidden.
- It also verifies secondary note windows and non-macOS main windows are not prevented or hidden.

## Verification

- `pnpm --filter @reflect/desktop test src/lib/quit-flush.test.ts` — passed (3 tests).
- `pnpm check` — passed; reported only the existing max-lines warnings in `graph-provider.tsx` and `indexer.ts`.
- `git diff --check` — passed.

## Risk / Rollout

Low and macOS-scoped. No migrations or data-shape changes. The main window remains alive while hidden, preserving the services that secondary note windows depend on, and the explicit Command-Q exit path is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> macOS-scoped lifecycle change only; quit handshake and data flushes are preserved, with new regression tests for the close branches.
> 
> **Overview**
> Fixes **⌘W / red-button close on the macOS main window** so Reflect stays running like a typical Mac app instead of exiting when the last webview would be destroyed.
> 
> `installQuitFlush` now treats **macOS + main window** specially: it calls **`preventDefault()` immediately** on `onCloseRequested`, runs the existing **documents/settings/backup** flush (now via **`Promise.allSettled`** so one failed flush still continues), then **`hide()`** the window instead of letting Tauri tear it down. **Note windows** and **non-macOS** main windows keep the normal close path (no prevent/hide).
> 
> Adds **`quit-flush.test.ts`** for those three branches, including flush-then-hide when settings flush rejects. **`docs/multi-window.md`** and shell comments now separate **user close (hide main)** from **main window destruction** (still cascades note windows); **⌘Q** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38981843d68ab53c7b81bd360e0da9b1bd4a53b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * On macOS, closing the main window now prevents termination, flushes open documents, settings, and backups, and then hides the window (app continues running).
  * Closing secondary windows continues to flush open documents and backups without hiding or preventing the close by default.

* **Documentation**
  * Updated multi-window “Quit & close” guidance to clarify macOS main-window hide behavior vs per-window close flushing, and improved notes on main-window destruction handling.

* **Tests**
  * Added coverage for the quit/close flush behavior across main vs secondary windows and macOS vs non-macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->