### PR TITLE
fix: allow changing AI provider default models

### DIFF
--- a/apps/desktop/src/components/settings/ai-provider-row.tsx
+++ b/apps/desktop/src/components/settings/ai-provider-row.tsx
@@ -3,6 +3,7 @@ import { Trash2 } from 'lucide-react'
 import { aiModelLabel, aiProvider, errorMessage, type AiProviderConfig } from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import { startOperation } from '@/lib/operations'
+import { ModelCombobox } from './model-combobox'
 
 interface AiProviderRowProps {
   config: AiProviderConfig
@@ -10,6 +11,8 @@ interface AiProviderRowProps {
   isDefault: boolean
   /** Make this entry the app-wide default. */
   onMakeDefault: (id: string) => void
+  /** Change the default model used by this provider entry. */
+  onSetDefaultModel: (id: string, model: string) => void
   /** Remove the entry and its keychain secret; rejects on failure. */
   onRemove: (id: string) => Promise<void>
 }
@@ -24,9 +27,11 @@ export function AiProviderRow({
   config,
   isDefault,
   onMakeDefault,
+  onSetDefaultModel,
   onRemove,
 }: AiProviderRowProps): ReactElement {
-  const providerLabel = aiProvider(config.provider).label
+  const provider = aiProvider(config.provider)
+  const providerLabel = provider.label
   const modelLabel = aiModelLabel(config.provider, config.model)
   const name = `${providerLabel} — ${modelLabel}`
 
@@ -37,13 +42,20 @@ export function AiProviderRow({
   }
 
   return (
-    <div className="flex items-center justify-between gap-4 px-4 py-3">
+    <div className="grid grid-cols-[minmax(0,1fr)_12rem_auto] items-center gap-3 px-4 py-3">
       <div className="min-w-0">
-        <div className="truncate text-sm font-medium text-text">{name}</div>
+        <div className="truncate text-sm font-medium text-text">{providerLabel}</div>
         <p className="mt-0.5 text-xs text-text-muted">
           API key <span className="font-mono">·····{config.keyHint}</span>
         </p>
       </div>
+      <ModelCombobox
+        value={config.model}
+        provider={config.provider}
+        models={provider.models}
+        onChange={(model) => onSetDefaultModel(config.id, model)}
+        ariaLabel={`Default model for ${providerLabel}`}
+      />
       <div className="flex shrink-0 items-center gap-2">
         {isDefault ? (
           <span className="rounded-full bg-accent-soft px-2 py-0.5 text-[11px] font-medium text-accent-soft-text">

--- a/apps/desktop/src/components/settings/ai-providers-section.test.tsx
+++ b/apps/desktop/src/components/settings/ai-providers-section.test.tsx
@@ -127,10 +127,14 @@ describe('AiProvidersSection', () => {
     stored = twoStoredModels()
     renderSection()
 
-    await waitFor(() =>
-      expect(screen.getByText('Anthropic — Claude Opus 4.8')).toBeTruthy(),
+    await waitFor(() => expect(screen.getByText('Anthropic')).toBeTruthy())
+    expect(screen.getByText('OpenAI')).toBeTruthy()
+    expect(screen.getByRole('combobox', { name: 'Default model for Anthropic' }).textContent).toMatch(
+      /Claude Opus 4\.8/,
     )
-    expect(screen.getByText('OpenAI — GPT-5.5')).toBeTruthy()
+    expect(screen.getByRole('combobox', { name: 'Default model for OpenAI' }).textContent).toMatch(
+      /GPT-5\.5/,
+    )
     expect(screen.getByText(/wxyz1/)).toBeTruthy()
     expect(screen.getByText(/abcd2/)).toBeTruthy()
     expect(screen.getByText('Default')).toBeTruthy()
@@ -256,9 +260,7 @@ describe('AiProvidersSection', () => {
     stored = twoStoredModels()
     secrets.set('ai-api-key:a', 'sk-a')
     renderSection()
-    await waitFor(() =>
-      expect(screen.getByText('Anthropic — Claude Opus 4.8')).toBeTruthy(),
-    )
+    await waitFor(() => expect(screen.getByText('Anthropic')).toBeTruthy())
 
     fireEvent.click(
       screen.getByRole('button', { name: 'Remove Anthropic — Claude Opus 4.8' }),
@@ -278,9 +280,7 @@ describe('AiProvidersSection', () => {
     secrets.set('ai-api-key:a', 'sk-a')
     secrets.set('ai-api-key:b', 'sk-b')
     renderSection()
-    await waitFor(() =>
-      expect(screen.getByText('Anthropic — Claude Opus 4.8')).toBeTruthy(),
-    )
+    await waitFor(() => expect(screen.getByText('Anthropic')).toBeTruthy())
 
     // Both removes fire in the same tick; each suspends on its keychain
     // delete, so each settings update applies after the other's snapshot
@@ -308,6 +308,24 @@ describe('AiProvidersSection', () => {
 
     await waitFor(() => expect(lastSavedDoc().defaultAiProviderId).toBe('b'))
     expect(lastSavedDoc().aiProviders).toHaveLength(2)
+  })
+
+  it('changes a configured provider default model without replacing its key', async () => {
+    stored = twoStoredModels()
+    secrets.set('ai-api-key:b', 'sk-openai-secret')
+    renderSection()
+
+    fireEvent.click(
+      await screen.findByRole('combobox', { name: 'Default model for OpenAI' }),
+    )
+    fireEvent.click(await screen.findByRole('option', { name: /GPT-5\.4 mini/ }))
+
+    await waitFor(() => {
+      expect(lastSavedDoc().aiProviders).toContainEqual(
+        entry({ id: 'b', provider: 'openai', model: 'gpt-5.4-mini', keyHint: 'abcd2' }),
+      )
+    })
+    expect(secrets.get('ai-api-key:b')).toBe('sk-openai-secret')
   })
 
   it('traps Tab inside the dialog', async () => {

--- a/apps/desktop/src/components/settings/ai-providers-section.tsx
+++ b/apps/desktop/src/components/settings/ai-providers-section.tsx
@@ -13,7 +13,14 @@ import { SettingsSection } from './section'
  * which is the app-wide default and only the key's trailing characters.
  */
 export function AiProvidersSection(): ReactElement {
-  const { providers, defaultProvider, addProvider, removeProvider, makeDefault } = useAiProviders()
+  const {
+    providers,
+    defaultProvider,
+    addProvider,
+    removeProvider,
+    makeDefault,
+    setDefaultModel,
+  } = useAiProviders()
   const [adding, setAdding] = useState(false)
 
   return (
@@ -30,6 +37,7 @@ export function AiProvidersSection(): ReactElement {
             config={config}
             isDefault={config.id === defaultProvider?.id}
             onMakeDefault={makeDefault}
+            onSetDefaultModel={setDefaultModel}
             onRemove={removeProvider}
           />
         ))

--- a/apps/desktop/src/components/settings/model-combobox.tsx
+++ b/apps/desktop/src/components/settings/model-combobox.tsx
@@ -39,6 +39,8 @@ interface ModelComboboxProps {
   models: AiModelOption[]
   /** Called with the new model id — either a catalog id or a custom string. */
   onChange: (modelId: string) => void
+  /** Accessible name for the trigger when multiple model pickers are visible. */
+  ariaLabel?: string
 }
 
 /**
@@ -51,6 +53,7 @@ export function ModelCombobox({
   provider,
   models,
   onChange,
+  ariaLabel = 'Default model',
 }: ModelComboboxProps): ReactElement {
   const [open, setOpen] = useState(false)
   const [inputValue, setInputValue] = useState('')
@@ -92,7 +95,7 @@ export function ModelCombobox({
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          aria-label="Default model"
+          aria-label={ariaLabel}
           className="w-full justify-between font-normal"
         >
           <span className="truncate">{aiModelLabel(provider, value)}</span>

--- a/apps/desktop/src/hooks/use-ai-providers.ts
+++ b/apps/desktop/src/hooks/use-ai-providers.ts
@@ -44,6 +44,8 @@ interface UseAiProvidersValue {
   removeProvider: (id: string) => Promise<void>
   /** Make the entry with `id` the app-wide default. */
   makeDefault: (id: string) => void
+  /** Change the default model used by the configured provider entry. */
+  setDefaultModel: (id: string, model: string) => void
 }
 
 export function useAiProviders(): UseAiProvidersValue {
@@ -116,5 +118,27 @@ export function useAiProviders(): UseAiProvidersValue {
     [updateSettingsWith],
   )
 
-  return { providers, defaultProvider, addProvider, removeProvider, makeDefault }
+  const setDefaultModel = useCallback(
+    (id: string, model: string): void => {
+      const normalizedModel = model.trim()
+      if (normalizedModel === '') {
+        return
+      }
+      updateSettingsWith((current) => ({
+        aiProviders: current.aiProviders.map((provider) =>
+          provider.id === id ? { ...provider, model: normalizedModel } : provider,
+        ),
+      }))
+    },
+    [updateSettingsWith],
+  )
+
+  return {
+    providers,
+    defaultProvider,
+    addProvider,
+    removeProvider,
+    makeDefault,
+    setDefaultModel,
+  }
 }

--- a/apps/desktop/src/mobile/ai-provider-actions-drawer.test.tsx
+++ b/apps/desktop/src/mobile/ai-provider-actions-drawer.test.tsx
@@ -23,11 +23,13 @@ const PROVIDER: AiProviderConfig = {
 }
 
 const onMakeDefault = vi.fn<(id: string) => void>()
+const onSetDefaultModel = vi.fn<(id: string, model: string) => void>()
 const onRemove = vi.fn<(id: string) => Promise<void>>()
 const onOpenChange = vi.fn<(open: boolean) => void>()
 
 beforeEach(() => {
   onMakeDefault.mockReset()
+  onSetDefaultModel.mockReset()
   onRemove.mockReset().mockResolvedValue(undefined)
   onOpenChange.mockReset()
 })
@@ -40,6 +42,7 @@ function renderSheet(isDefault = false) {
       open
       onOpenChange={onOpenChange}
       onMakeDefault={onMakeDefault}
+      onSetDefaultModel={onSetDefaultModel}
       onRemove={onRemove}
     />,
   )
@@ -61,6 +64,15 @@ describe('AiProviderActionsDrawer', () => {
     expect(
       (screen.getByRole('button', { name: 'Default provider' }) as HTMLButtonElement).disabled,
     ).toBe(true)
+  })
+
+  it('changes the provider default model and closes', () => {
+    renderSheet()
+
+    fireEvent.click(screen.getByRole('button', { name: 'GPT-5.4 mini' }))
+
+    expect(onSetDefaultModel).toHaveBeenCalledWith('p1', 'gpt-5.4-mini')
+    expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 
   it('removes the provider and closes once the removal lands', async () => {

--- a/apps/desktop/src/mobile/ai-provider-actions-drawer.tsx
+++ b/apps/desktop/src/mobile/ai-provider-actions-drawer.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactElement } from 'react'
-import { aiProvider, errorMessage, type AiProviderConfig } from '@reflect/core'
+import { aiModelLabel, aiProvider, errorMessage, type AiProviderConfig } from '@reflect/core'
 import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
-import { SettingsActionRow, SettingsGroup } from '@/mobile/settings-list'
+import { SettingsActionRow, SettingsGroup, SettingsSelectRow } from '@/mobile/settings-list'
 
 interface AiProviderActionsDrawerProps {
   /** The provider the sheet manages; null renders nothing (exit animation). */
@@ -11,6 +11,7 @@ interface AiProviderActionsDrawerProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   onMakeDefault: (id: string) => void
+  onSetDefaultModel: (id: string, model: string) => void
   /** Delete the key from the keychain, then drop the settings entry. */
   onRemove: (id: string) => Promise<void>
 }
@@ -27,9 +28,23 @@ export function AiProviderActionsDrawer({
   open,
   onOpenChange,
   onMakeDefault,
+  onSetDefaultModel,
   onRemove,
 }: AiProviderActionsDrawerProps): ReactElement {
   const [removing, setRemoving] = useState(false)
+  const providerInfo = provider === null ? null : aiProvider(provider.provider)
+  const models =
+    provider === null || providerInfo === null
+      ? []
+      : providerInfo.models.some((model) => model.id === provider.model)
+        ? providerInfo.models
+        : [
+            {
+              id: provider.model,
+              label: aiModelLabel(provider.provider, provider.model),
+            },
+            ...providerInfo.models,
+          ]
 
   // A failed removal (keychain write, settings store) keeps the sheet open —
   // closing would read as success — and logs; the row is still there to retry.
@@ -48,12 +63,25 @@ export function AiProviderActionsDrawer({
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
       <DrawerContent aria-label="Manage AI provider">
-        {provider !== null ? (
+        {provider !== null && providerInfo !== null ? (
           <>
             <DrawerTitle className="px-4 pt-1">
-              {`${aiProvider(provider.provider).label} ·····${provider.keyHint}`}
+              {`${providerInfo.label} ·····${provider.keyHint}`}
             </DrawerTitle>
             <div className="flex flex-col gap-6 px-4 pb-8 pt-4">
+              <SettingsGroup header="Default model">
+                {models.map((model) => (
+                  <SettingsSelectRow
+                    key={model.id}
+                    label={model.label}
+                    selected={model.id === provider.model}
+                    onPress={() => {
+                      onSetDefaultModel(provider.id, model.id)
+                      onOpenChange(false)
+                    }}
+                  />
+                ))}
+              </SettingsGroup>
               <SettingsGroup>
                 <SettingsActionRow
                   label={isDefault ? 'Default provider' : 'Use as default'}

--- a/apps/desktop/src/mobile/screens/settings.tsx
+++ b/apps/desktop/src/mobile/screens/settings.tsx
@@ -65,7 +65,14 @@ export function MobileSettings(): ReactElement {
   const status = useMobileSyncStatus()
   const [disconnecting, setDisconnecting] = useState(false)
   const [connectOpen, setConnectOpen] = useState(false)
-  const { providers, defaultProvider, addProvider, removeProvider, makeDefault } = useAiProviders()
+  const {
+    providers,
+    defaultProvider,
+    addProvider,
+    removeProvider,
+    makeDefault,
+    setDefaultModel,
+  } = useAiProviders()
   const [addProviderOpen, setAddProviderOpen] = useState(false)
   // The managed provider sticks around after close so the exit animation has
   // content; `manageOpen` alone drives visibility (the edit-sheet pattern).
@@ -233,6 +240,7 @@ export function MobileSettings(): ReactElement {
         open={manageOpen}
         onOpenChange={setManageOpen}
         onMakeDefault={makeDefault}
+        onSetDefaultModel={setDefaultModel}
         onRemove={removeProvider}
       />
     </div>


### PR DESCRIPTION
## Problem

The AI provider settings only exposed a model choice while adding a provider. Once saved, users could make the provider the app default or remove it, but changing its configured default model required deleting the entry and re-entering its API key.

## Before -> After

| Before | After |
| --- | --- |
| Default model was fixed after provider creation | Default model can be changed in place from provider settings |
| Changing models required removing and re-adding the API key | The existing provider entry and keychain credential are preserved |
| Mobile provider actions only supported make-default and remove | Mobile provider actions include a curated default-model picker |

## Changes

1. Add `setDefaultModel` to `useAiProviders`, using the functional settings updater so concurrent provider edits compose against the latest document. The update only replaces the matching entry model and does not touch the keychain.
2. Reuse `ModelCombobox` in each desktop provider row, including custom model IDs, with provider-specific accessible labels.
3. Add a default-model selection group to the mobile provider management drawer. Existing custom selections remain visible even though mobile continues to offer curated models for new choices.
4. Add integration coverage for persisted model changes and key preservation, plus mobile drawer wiring coverage.

## Tests

- Desktop settings changes a saved provider model and preserves its stored key.
- Mobile provider actions select a different default model and close the drawer.
- Existing add, remove, concurrent remove, default-provider, and keychain failure scenarios remain covered.

## Verification

- `pnpm --filter @reflect/desktop test --run src/components/settings/ai-providers-section.test.tsx src/mobile/ai-provider-actions-drawer.test.tsx` — 18 tests passed.
- `pnpm check` — typecheck and lint passed (two pre-existing max-file-length warnings outside this change).
- `pnpm build` — production desktop and extension builds passed.

## Risk / Rollout

Low risk. This uses the existing `model` field in the settings schema, requires no migration, and never reads or rewrites the provider API key.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings-only updates to the existing `model` field with no keychain or schema migration; behavior is covered by integration tests.
> 
> **Overview**
> Users can **change the default model** on an existing AI provider entry without deleting it and re-entering the API key.
> 
> **Desktop:** Each provider row now shows the provider name and a **`ModelCombobox`** wired to new **`setDefaultModel`** from `useAiProviders`, which updates only the persisted `model` on that entry (functional settings updater; keychain untouched). The combobox accepts an **`ariaLabel`** so multiple rows stay distinguishable.
> 
> **Mobile:** The provider management drawer adds a **Default model** group (curated list; custom model ids stay visible if not in the catalog). Selection calls the same **`setDefaultModel`** and closes the sheet.
> 
> Tests cover persisted model changes with key preservation and updated list assertions for the new row layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b1b1d894753a0322bead3b257227e1dcea06e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->