### PR TITLE
fix: let the Mac close button hide the app

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "core:window:allow-start-dragging",
     "core:window:allow-destroy",
+    "core:window:allow-hide",
     "core:window:allow-set-title",
     "opener:default",
     {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -84,6 +84,24 @@ mod app_metadata_tests {
     }
 }
 
+#[cfg(test)]
+mod capability_tests {
+    #[test]
+    fn desktop_capability_allows_main_window_hide() {
+        let capability: serde_json::Value = serde_json::from_str(include_str!(
+            "../capabilities/default.json"
+        ))
+        .expect("valid default capability");
+        let permissions = capability["permissions"]
+            .as_array()
+            .expect("capability permissions");
+
+        assert!(permissions
+            .iter()
+            .any(|permission| permission.as_str() == Some("core:window:allow-hide")));
+    }
+}
+
 /// Which UI family this build serves. The frontend's root gate (Plan 19)
 /// switches between the desktop and mobile surface trees on this answer.
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -88,10 +88,9 @@ mod app_metadata_tests {
 mod capability_tests {
     #[test]
     fn desktop_capability_allows_main_window_hide() {
-        let capability: serde_json::Value = serde_json::from_str(include_str!(
-            "../capabilities/default.json"
-        ))
-        .expect("valid default capability");
+        let capability: serde_json::Value =
+            serde_json::from_str(include_str!("../capabilities/default.json"))
+                .expect("valid default capability");
         let permissions = capability["permissions"]
             .as_array()
             .expect("capability permissions");


### PR DESCRIPTION
## Problem

PR #808 changed the macOS main-window close path to prevent destruction, flush pending work, and call `window.hide()`. The deployed Tauri capability did not grant the `hide` command, so close prevention succeeded but the hide IPC call was rejected. The red close button and Command-W therefore appeared to do nothing.

## Changes

- Grant `core:window:allow-hide` in the shared desktop window capability so the existing macOS main-window close handler can complete.
- Add a native regression test that pins the permission required by that handler.

The capability also covers secondary note-window labels because the existing desktop capability is shared, but only the guarded macOS main-window path invokes `hide()`.

## Verification

- `cargo test -p reflect-open capability_tests::desktop_capability_allows_main_window_hide` — passed.
- `pnpm --filter @reflect/desktop test src/lib/quit-flush.test.ts` — passed (3 tests).
- `pnpm check` — passed; reported only the existing max-lines warnings in `graph-provider.tsx` and `indexer.ts`.
- `git diff --check` — passed.

## Risk / Rollout

Low, configuration-only runtime change plus a regression test. A new desktop build/deploy is required because Tauri capabilities are bundled into the native app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only capability grant and a regression test; requires a new desktop build for the permission to take effect at runtime.
> 
> **Overview**
> Grants **`core:window:allow-hide`** on the shared desktop capability (`main` and `note-*` windows) so the existing macOS main-window close path can finish after it prevents destroy and flushes work.
> 
> Without this permission, the frontend’s **`hide()`** IPC call from the close handler was rejected, so the red close button and Command-W looked like they did nothing.
> 
> Adds a native **`capability_tests`** regression that loads `default.json` and asserts that permission is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c10637a4e7d0b0c918a18e5f1510a1ebb2c4992. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for hiding the desktop application window.

* **Tests**
  * Added coverage to verify the window-hiding permission is correctly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->