### PR TITLE
feat: let agents manage Reflect notes through the CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4724,6 +4724,8 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
+ "ulid",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -6821,6 +6823,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand",
+ "web-time",
+]
+
+[[package]]
 name = "unic-char-property"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6872,6 +6884,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-normalization-alignments"

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "reflect-cli"
 version = "0.1.0"
-description = "Read/discovery CLI over a Reflect graph (Plan 14)"
+description = "Scriptable read and write access to a Reflect graph"
 edition = "2021"
 
 [[bin]]
@@ -18,7 +18,9 @@ jiff = "0.2.28"
 sha2 = { workspace = true }
 pulldown-cmark = "0.13.4"
 saphyr = "0.0.6"
+tempfile = { workspace = true }
+ulid = "1.2.1"
+unicode-normalization = "0.1.25"
 
 [dev-dependencies]
-tempfile = { workspace = true }
 reflect-index-schema = { path = "../../crates/index-schema" }

--- a/apps/cli/src/commands/append.rs
+++ b/apps/cli/src/commands/append.rs
@@ -1,0 +1,78 @@
+//! `reflect append <note>` — append a Markdown block atomically.
+
+use crate::commands::open_index_for_resolution;
+use crate::commands::output::{print_json, MutationJson};
+use crate::error::CliError;
+use crate::graph::Graph;
+use crate::mutation::{atomic_create, atomic_replace, payload};
+use crate::resolve::resolve_note;
+
+fn with_appended_block(source: &str, block: &str) -> String {
+    let block = block.trim_end_matches(['\r', '\n']);
+    if source.is_empty() {
+        return format!("{block}\n");
+    }
+    let mut next = source.trim_end_matches(['\r', '\n']).to_string();
+    next.push_str("\n\n");
+    next.push_str(block);
+    next.push('\n');
+    next
+}
+
+pub(crate) fn append_to_note(
+    graph: &Graph,
+    note_arg: &str,
+    block: String,
+    expected_hash: Option<&str>,
+) -> Result<(String, String), CliError> {
+    if block.trim().is_empty() {
+        return Err(CliError::runtime("appended content must not be empty"));
+    }
+    let index = open_index_for_resolution(&graph.root);
+    let resolved = resolve_note(note_arg, &graph.root, index.as_ref().map(|open| &open.conn))?;
+    let path = resolved.rel_path().to_string();
+    let absolute = graph.root.join(&path);
+    if !absolute.exists() {
+        if !path.starts_with("daily/") {
+            return Err(CliError::NotFound(format!("note does not exist: {path}")));
+        }
+        if expected_hash.is_some() {
+            return Err(CliError::Conflict(format!(
+                "cannot match --expect-hash because {path} does not exist"
+            )));
+        }
+        let source = with_appended_block("", &block);
+        let hash = atomic_create(&graph.root, &path, &source)?;
+        return Ok((path, hash));
+    }
+    let source = crate::mutation::read_for_mutation(&graph.root, &path, expected_hash)?;
+    let next = with_appended_block(&source, &block);
+    let hash = atomic_replace(&graph.root, &path, &next, expected_hash)?;
+    Ok((path, hash))
+}
+
+pub fn run(
+    graph: &Graph,
+    json: bool,
+    note_arg: &str,
+    text: Option<String>,
+    stdin: bool,
+    expected_hash: Option<&str>,
+) -> Result<(), CliError> {
+    let block = payload(text, stdin, "text")?;
+    let (path, hash) = append_to_note(graph, note_arg, block, expected_hash)?;
+    let output = MutationJson {
+        action: "append",
+        absolute_path: graph.root.join(&path).display().to_string(),
+        path,
+        hash,
+        previous_path: None,
+        trash_path: None,
+    };
+    if json {
+        print_json(&output)
+    } else {
+        println!("{}", output.path);
+        Ok(())
+    }
+}

--- a/apps/cli/src/commands/backlinks.rs
+++ b/apps/cli/src/commands/backlinks.rs
@@ -1,0 +1,68 @@
+//! `reflect backlinks <note>` — incoming wiki links from the read-only index.
+
+use rusqlite::params;
+
+use crate::commands::open_index_for_resolution;
+use crate::commands::open_index_required;
+use crate::commands::output::{print_json, BacklinkJson, BacklinksJson};
+use crate::error::CliError;
+use crate::graph::Graph;
+use crate::note_file::read_note;
+use crate::resolve::resolve_note;
+
+pub fn run(graph: &Graph, json: bool, note_arg: &str, limit: usize) -> Result<(), CliError> {
+    let resolution_index = open_index_for_resolution(&graph.root);
+    let resolved = resolve_note(
+        note_arg,
+        &graph.root,
+        resolution_index.as_ref().map(|open| &open.conn),
+    )?;
+    let target_path = resolved.rel_path().to_string();
+    if !graph.root.join(&target_path).is_file() {
+        return Err(CliError::NotFound(format!(
+            "note does not exist: {target_path}"
+        )));
+    }
+    read_note(&graph.root, &target_path)?;
+
+    let index = open_index_required(&graph.root)?;
+    let mut statement = index.conn.prepare(
+        "SELECT source_path, target_raw, alias, pos_from, pos_to
+         FROM backlinks WHERE target_path = ?1
+         ORDER BY source_path, pos_from LIMIT ?2",
+    )?;
+    let rows = statement.query_map(params![target_path, limit as i64], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, Option<String>>(2)?,
+            row.get::<_, i64>(3)?,
+            row.get::<_, i64>(4)?,
+        ))
+    })?;
+    let mut results = Vec::new();
+    for row in rows {
+        let (source_path, target_raw, alias, pos_from, pos_to) = row?;
+        let Ok(source) = read_note(&graph.root, &source_path) else {
+            continue;
+        };
+        results.push(BacklinkJson {
+            source_path,
+            source_title: source.meta.title,
+            target_raw,
+            alias,
+            pos_from,
+            pos_to,
+        });
+    }
+    if json {
+        return print_json(&BacklinksJson {
+            target_path,
+            results,
+        });
+    }
+    for backlink in results {
+        println!("{}\t{}", backlink.source_path, backlink.source_title);
+    }
+    Ok(())
+}

--- a/apps/cli/src/commands/create.rs
+++ b/apps/cli/src/commands/create.rs
@@ -1,0 +1,76 @@
+//! `reflect create <title>` — atomically create a regular note.
+
+use crate::commands::output::{print_json, MutationJson};
+use crate::error::CliError;
+use crate::graph::Graph;
+use crate::mutation::{atomic_create, payload};
+use crate::slug::slug_for_title;
+
+const MAX_ATTEMPTS: usize = 1000;
+
+fn source(title: &str, body: &str) -> String {
+    let id = ulid::Ulid::new().to_string().to_lowercase();
+    let body = body.trim();
+    if body.is_empty() {
+        format!("---\nid: {id}\n---\n# {title}\n")
+    } else {
+        format!("---\nid: {id}\n---\n# {title}\n\n{body}\n")
+    }
+}
+
+pub fn run(
+    graph: &Graph,
+    json: bool,
+    title: &str,
+    path: Option<&str>,
+    body: Option<String>,
+    stdin: bool,
+) -> Result<(), CliError> {
+    let title = title.trim();
+    if title.is_empty() || title.contains(['\r', '\n']) {
+        return Err(CliError::runtime("note title must be one non-empty line"));
+    }
+    let body = if body.is_some() || stdin {
+        payload(body, stdin, "body")?
+    } else {
+        String::new()
+    };
+    let source = source(title, &body);
+    let (path, hash) = if let Some(path) = path {
+        (path.to_string(), atomic_create(&graph.root, path, &source)?)
+    } else {
+        let slug = slug_for_title(title);
+        let mut created = None;
+        for ordinal in 1..=MAX_ATTEMPTS {
+            let suffix = if ordinal == 1 {
+                slug.clone()
+            } else {
+                format!("{slug}-{ordinal}")
+            };
+            let candidate = format!("notes/{suffix}.md");
+            match atomic_create(&graph.root, &candidate, &source) {
+                Ok(hash) => {
+                    created = Some((candidate, hash));
+                    break;
+                }
+                Err(CliError::Conflict(_)) => continue,
+                Err(error) => return Err(error),
+            }
+        }
+        created.ok_or_else(|| CliError::Conflict("could not claim a free note path".to_string()))?
+    };
+    let output = MutationJson {
+        action: "create",
+        absolute_path: graph.root.join(&path).display().to_string(),
+        path,
+        hash,
+        previous_path: None,
+        trash_path: None,
+    };
+    if json {
+        print_json(&output)
+    } else {
+        println!("{}", output.path);
+        Ok(())
+    }
+}

--- a/apps/cli/src/commands/delete.rs
+++ b/apps/cli/src/commands/delete.rs
@@ -1,0 +1,31 @@
+//! `reflect delete <note>` — recoverably move a public note to graph-local trash.
+
+use crate::commands::output::{print_json, MutationJson};
+use crate::commands::resolve_public_note;
+use crate::error::CliError;
+use crate::graph::Graph;
+use crate::mutation::trash_note;
+
+pub fn run(
+    graph: &Graph,
+    json: bool,
+    note_arg: &str,
+    expected_hash: Option<&str>,
+) -> Result<(), CliError> {
+    let path = resolve_public_note(graph, note_arg)?;
+    let (trash_path, hash) = trash_note(&graph.root, &path, expected_hash)?;
+    let output = MutationJson {
+        action: "delete",
+        absolute_path: graph.root.join(&trash_path).display().to_string(),
+        path: path.clone(),
+        hash,
+        previous_path: Some(path),
+        trash_path: Some(trash_path),
+    };
+    if json {
+        print_json(&output)
+    } else {
+        println!("{}", output.trash_path.as_deref().unwrap_or_default());
+        Ok(())
+    }
+}

--- a/apps/cli/src/commands/list.rs
+++ b/apps/cli/src/commands/list.rs
@@ -1,0 +1,75 @@
+//! `reflect list` — current public notes from disk, newest first.
+
+use clap::ValueEnum;
+
+use crate::commands::output::{print_json, ListJson, NoteSummaryJson};
+use crate::error::CliError;
+use crate::graph::Graph;
+use crate::hash::hash_content;
+use crate::note_file::{parse_note_meta, walk_notes};
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum Kind {
+    All,
+    Note,
+    Daily,
+    Template,
+}
+
+fn note_kind(path: &str) -> &'static str {
+    if path.starts_with("daily/") {
+        "daily"
+    } else if path.starts_with("templates/") {
+        "template"
+    } else {
+        "note"
+    }
+}
+
+pub fn run(graph: &Graph, json: bool, kind: Kind, limit: usize) -> Result<(), CliError> {
+    let mut disk_notes = walk_notes(&graph.root)?;
+    disk_notes.sort_by(|left, right| {
+        right
+            .mtime_ms
+            .cmp(&left.mtime_ms)
+            .then_with(|| left.rel_path.cmp(&right.rel_path))
+    });
+    let mut results = Vec::new();
+    for disk_note in disk_notes {
+        if results.len() >= limit {
+            break;
+        }
+        let found_kind = note_kind(&disk_note.rel_path);
+        let matches = match kind {
+            Kind::All => true,
+            Kind::Note => found_kind == "note",
+            Kind::Daily => found_kind == "daily",
+            Kind::Template => found_kind == "template",
+        };
+        if !matches {
+            continue;
+        }
+        let Ok(source) = std::fs::read_to_string(graph.root.join(&disk_note.rel_path)) else {
+            continue;
+        };
+        let meta = parse_note_meta(&disk_note.rel_path, &source);
+        if meta.private {
+            continue;
+        }
+        results.push(NoteSummaryJson {
+            absolute_path: graph.root.join(&disk_note.rel_path).display().to_string(),
+            path: disk_note.rel_path,
+            title: meta.title,
+            kind: found_kind.to_string(),
+            mtime: disk_note.mtime_ms,
+            hash: hash_content(&source),
+        });
+    }
+    if json {
+        return print_json(&ListJson { results });
+    }
+    for note in results {
+        println!("{}\t{}", note.path, note.title);
+    }
+    Ok(())
+}

--- a/apps/cli/src/commands/mod.rs
+++ b/apps/cli/src/commands/mod.rs
@@ -1,13 +1,24 @@
-//! The five commands. Shared rules live here: stdout carries only data,
-//! warnings go to stderr, and `show`/`path`/`open` degrade to a file scan
-//! when the index is missing or unusable (`search` is the one command that
-//! requires it).
+//! Reflect graph commands. Shared rules live here: stdout carries only data,
+//! warnings go to stderr, and note resolution degrades to a file scan when
+//! the index is missing or unusable. Relationship and projection commands
+//! require the read-only index.
 
+pub mod append;
+pub mod backlinks;
+pub mod create;
+pub mod delete;
+pub mod list;
+pub mod move_note;
 pub mod open;
 pub mod path;
+pub mod restore;
 pub mod search;
 pub mod show;
+pub mod tags;
+pub mod task;
+pub mod tasks;
 pub mod today;
+pub mod write;
 
 mod output;
 
@@ -15,6 +26,8 @@ use std::fmt::Display;
 use std::path::Path;
 
 use crate::index::{open_read_only, IndexOpen, OpenIndex};
+use crate::note_file::read_note;
+use crate::resolve::resolve_note;
 
 fn warn(message: impl Display) {
     eprintln!("reflect: warning: {message}");
@@ -36,4 +49,39 @@ fn open_index_for_resolution(root: &Path) -> Option<OpenIndex> {
             None
         }
     }
+}
+
+/// Open the read-only index for commands whose relationship/projection data
+/// cannot be reconstructed cheaply from individual markdown files.
+pub(crate) fn open_index_required(root: &Path) -> Result<OpenIndex, crate::error::CliError> {
+    match open_read_only(root) {
+        IndexOpen::Opened(open) => {
+            if open.newer_schema {
+                warn("the index schema is newer than this CLI — update Reflect");
+            }
+            Ok(open)
+        }
+        IndexOpen::Missing => Err(crate::error::CliError::NoIndex(
+            "no search index — open this graph in Reflect to build it".to_string(),
+        )),
+        IndexOpen::Unusable(message) => Err(crate::error::CliError::NoIndex(message)),
+    }
+}
+
+/// Resolve a note reference and enforce existence + live privacy before a
+/// command reads relationships or mutates the file.
+pub(crate) fn resolve_public_note(
+    graph: &crate::graph::Graph,
+    note_arg: &str,
+) -> Result<String, crate::error::CliError> {
+    let index = open_index_for_resolution(&graph.root);
+    let resolved = resolve_note(note_arg, &graph.root, index.as_ref().map(|open| &open.conn))?;
+    let path = resolved.rel_path().to_string();
+    if !graph.root.join(&path).is_file() {
+        return Err(crate::error::CliError::NotFound(format!(
+            "note does not exist: {path}"
+        )));
+    }
+    read_note(&graph.root, &path)?;
+    Ok(path)
 }

--- a/apps/cli/src/commands/move_note.rs
+++ b/apps/cli/src/commands/move_note.rs
@@ -1,0 +1,32 @@
+//! `reflect move <note> <destination>` — move a public note without rewriting content.
+
+use crate::commands::output::{print_json, MutationJson};
+use crate::commands::resolve_public_note;
+use crate::error::CliError;
+use crate::graph::Graph;
+use crate::mutation::move_note;
+
+pub fn run(
+    graph: &Graph,
+    json: bool,
+    note_arg: &str,
+    destination: &str,
+    expected_hash: Option<&str>,
+) -> Result<(), CliError> {
+    let from = resolve_public_note(graph, note_arg)?;
+    let hash = move_note(&graph.root, &from, destination, expected_hash)?;
+    let output = MutationJson {
+        action: "move",
+        absolute_path: graph.root.join(destination).display().to_string(),
+        path: destination.to_string(),
+        hash,
+        previous_path: Some(from),
+        trash_path: None,
+    };
+    if json {
+        print_json(&output)
+    } else {
+        println!("{}", output.path);
+        Ok(())
+    }
+}

--- a/apps/cli/src/commands/output.rs
+++ b/apps/cli/src/commands/output.rs
@@ -16,6 +16,8 @@ pub struct NoteJson<'a> {
     pub absolute_path: String,
     pub title: &'a str,
     pub content: &'a str,
+    /// SHA-256 of the full source; pass it to mutation commands as `--expect-hash`.
+    pub hash: String,
 }
 
 /// `path` / `today --path`: a resolved location (the file may not exist yet
@@ -61,6 +63,86 @@ pub struct HitJson {
     pub snippet: String,
     /// bm25 rank (more negative = better match); `0` for title-only substring hits.
     pub score: f64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NoteSummaryJson {
+    pub path: String,
+    pub absolute_path: String,
+    pub title: String,
+    pub kind: String,
+    pub mtime: u64,
+    pub hash: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListJson {
+    pub results: Vec<NoteSummaryJson>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BacklinkJson {
+    pub source_path: String,
+    pub source_title: String,
+    pub target_raw: String,
+    pub alias: Option<String>,
+    pub pos_from: i64,
+    pub pos_to: i64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BacklinksJson {
+    pub target_path: String,
+    pub results: Vec<BacklinkJson>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskJson {
+    pub note_path: String,
+    pub note_title: String,
+    pub marker_offset: i64,
+    pub text: String,
+    pub raw: String,
+    pub checked: bool,
+    pub due_date: Option<String>,
+    pub breadcrumbs: Vec<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TasksJson {
+    pub results: Vec<TaskJson>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TagJson {
+    pub tag: String,
+    pub count: usize,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TagsJson {
+    pub results: Vec<TagJson>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MutationJson {
+    pub action: &'static str,
+    pub path: String,
+    pub absolute_path: String,
+    pub hash: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trash_path: Option<String>,
 }
 
 pub fn print_json<T: Serialize>(value: &T) -> Result<(), CliError> {

--- a/apps/cli/src/commands/restore.rs
+++ b/apps/cli/src/commands/restore.rs
@@ -1,0 +1,24 @@
+//! `reflect restore <trash-path>` — restore a note from graph-local trash.
+
+use crate::commands::output::{print_json, MutationJson};
+use crate::error::CliError;
+use crate::graph::Graph;
+use crate::mutation::restore_note;
+
+pub fn run(graph: &Graph, json: bool, trash_path: &str, to: Option<&str>) -> Result<(), CliError> {
+    let (path, hash) = restore_note(&graph.root, trash_path, to)?;
+    let output = MutationJson {
+        action: "restore",
+        absolute_path: graph.root.join(&path).display().to_string(),
+        path,
+        hash,
+        previous_path: None,
+        trash_path: Some(trash_path.to_string()),
+    };
+    if json {
+        print_json(&output)
+    } else {
+        println!("{}", output.path);
+        Ok(())
+    }
+}

--- a/apps/cli/src/commands/show.rs
+++ b/apps/cli/src/commands/show.rs
@@ -6,6 +6,7 @@ use crate::commands::open_index_for_resolution;
 use crate::commands::output::{print_content, print_json, NoteJson};
 use crate::error::CliError;
 use crate::graph::Graph;
+use crate::hash::hash_content;
 use crate::note_file::read_note;
 use crate::paths::date_from_daily_path;
 use crate::resolve::{resolve_note, ResolvedNote};
@@ -31,6 +32,7 @@ pub fn run(graph: &Graph, json: bool, note_arg: &str) -> Result<(), CliError> {
             absolute_path: graph.root.join(rel_path).display().to_string(),
             title: &note.meta.title,
             content: &note.content,
+            hash: hash_content(&note.content),
         });
     }
     print_content(&note.content);

--- a/apps/cli/src/commands/tags.rs
+++ b/apps/cli/src/commands/tags.rs
@@ -1,0 +1,55 @@
+//! `reflect tags` — public-note tag facets from the read-only index.
+
+use std::collections::{BTreeMap, HashSet};
+
+use crate::commands::open_index_required;
+use crate::commands::output::{print_json, TagJson, TagsJson};
+use crate::error::CliError;
+use crate::graph::Graph;
+use crate::note_file::read_note;
+
+pub fn run(graph: &Graph, json: bool) -> Result<(), CliError> {
+    let index = open_index_required(&graph.root)?;
+    let mut statement = index.conn.prepare(
+        "SELECT tags.note_path, tags.tag, tags.tag_key
+         FROM tags JOIN notes ON notes.path = tags.note_path
+         WHERE notes.kind != 'template' AND notes.is_private = 0
+         ORDER BY tags.tag_key, tags.note_path",
+    )?;
+    let rows = statement.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+        ))
+    })?;
+    let mut public = HashSet::new();
+    let mut blocked = HashSet::new();
+    let mut facets: BTreeMap<String, (String, usize)> = BTreeMap::new();
+    for row in rows {
+        let (note_path, tag, tag_key) = row?;
+        if blocked.contains(&note_path) {
+            continue;
+        }
+        if !public.contains(&note_path) {
+            if read_note(&graph.root, &note_path).is_err() {
+                blocked.insert(note_path);
+                continue;
+            }
+            public.insert(note_path.clone());
+        }
+        let entry = facets.entry(tag_key).or_insert((tag, 0));
+        entry.1 += 1;
+    }
+    let results = facets
+        .into_values()
+        .map(|(tag, count)| TagJson { tag, count })
+        .collect::<Vec<_>>();
+    if json {
+        return print_json(&TagsJson { results });
+    }
+    for tag in results {
+        println!("{}\t{}", tag.tag, tag.count);
+    }
+    Ok(())
+}

--- a/apps/cli/src/commands/task.rs
+++ b/apps/cli/src/commands/task.rs
@@ -1,0 +1,44 @@
+//! `reflect task <text>` — append a round Reflect task to a note.
+
+use crate::commands::append::append_to_note;
+use crate::commands::output::{print_json, MutationJson};
+use crate::error::CliError;
+use crate::graph::Graph;
+use crate::paths::{parse_calendar_date, today_date};
+
+pub fn run(
+    graph: &Graph,
+    json: bool,
+    text: &str,
+    note: Option<&str>,
+    due: Option<&str>,
+    expected_hash: Option<&str>,
+) -> Result<(), CliError> {
+    let text = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if text.is_empty() {
+        return Err(CliError::runtime("task text must not be empty"));
+    }
+    if let Some(due) = due {
+        if parse_calendar_date(due).is_none() {
+            return Err(CliError::runtime(format!("invalid due date: {due}")));
+        }
+    }
+    let due_suffix = due.map(|date| format!(" [[{date}]]")).unwrap_or_default();
+    let block = format!("+ [ ] {text}{due_suffix}");
+    let default_note = today_date();
+    let (path, hash) = append_to_note(graph, note.unwrap_or(&default_note), block, expected_hash)?;
+    let output = MutationJson {
+        action: "task",
+        absolute_path: graph.root.join(&path).display().to_string(),
+        path,
+        hash,
+        previous_path: None,
+        trash_path: None,
+    };
+    if json {
+        print_json(&output)
+    } else {
+        println!("{}", output.path);
+        Ok(())
+    }
+}

--- a/apps/cli/src/commands/tasks.rs
+++ b/apps/cli/src/commands/tasks.rs
@@ -1,0 +1,84 @@
+//! `reflect tasks` — public-note task projection from the read-only index.
+
+use std::collections::HashSet;
+
+use clap::ValueEnum;
+
+use crate::commands::open_index_required;
+use crate::commands::output::{print_json, TaskJson, TasksJson};
+use crate::error::CliError;
+use crate::graph::Graph;
+use crate::note_file::read_note;
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum State {
+    Open,
+    Done,
+    All,
+}
+
+pub fn run(graph: &Graph, json: bool, state: State, limit: usize) -> Result<(), CliError> {
+    let index = open_index_required(&graph.root)?;
+    let checked_filter = match state {
+        State::Open => "AND tasks.checked = 0",
+        State::Done => "AND tasks.checked = 1",
+        State::All => "",
+    };
+    let sql = format!(
+        "SELECT tasks.note_path, notes.title, tasks.marker_offset, tasks.text,
+                tasks.raw, tasks.checked, tasks.due_date, tasks.breadcrumbs
+         FROM tasks JOIN notes ON notes.path = tasks.note_path
+         WHERE notes.kind != 'template' AND notes.is_private = 0 {checked_filter}
+         ORDER BY notes.updated_at DESC, tasks.note_path, tasks.marker_offset
+         LIMIT ?1"
+    );
+    let mut statement = index.conn.prepare(&sql)?;
+    let rows = statement.query_map([limit as i64], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, i64>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, String>(4)?,
+            row.get::<_, i64>(5)?,
+            row.get::<_, Option<String>>(6)?,
+            row.get::<_, String>(7)?,
+        ))
+    })?;
+    let mut public = HashSet::new();
+    let mut blocked = HashSet::new();
+    let mut results = Vec::new();
+    for row in rows {
+        let (note_path, note_title, marker_offset, text, raw, checked, due_date, breadcrumbs) =
+            row?;
+        if blocked.contains(&note_path) {
+            continue;
+        }
+        if !public.contains(&note_path) {
+            if read_note(&graph.root, &note_path).is_err() {
+                blocked.insert(note_path);
+                continue;
+            }
+            public.insert(note_path.clone());
+        }
+        let breadcrumbs = serde_json::from_str::<Vec<String>>(&breadcrumbs).unwrap_or_default();
+        results.push(TaskJson {
+            note_path,
+            note_title,
+            marker_offset,
+            text,
+            raw,
+            checked: checked != 0,
+            due_date,
+            breadcrumbs,
+        });
+    }
+    if json {
+        return print_json(&TasksJson { results });
+    }
+    for task in results {
+        let mark = if task.checked { "x" } else { " " };
+        println!("- [{mark}] {}\t{}", task.text, task.note_path);
+    }
+    Ok(())
+}

--- a/apps/cli/src/commands/today.rs
+++ b/apps/cli/src/commands/today.rs
@@ -4,6 +4,7 @@
 use crate::commands::output::{print_content, print_json, NoteJson, PathJson};
 use crate::error::CliError;
 use crate::graph::Graph;
+use crate::hash::hash_content;
 use crate::note_file::{ensure_not_private, read_note};
 use crate::paths::{daily_path, today_date};
 
@@ -41,6 +42,7 @@ pub fn run(graph: &Graph, json: bool, path_only: bool) -> Result<(), CliError> {
             absolute_path: absolute.display().to_string(),
             title: &note.meta.title,
             content: &note.content,
+            hash: hash_content(&note.content),
         });
     }
     print_content(&note.content);

--- a/apps/cli/src/commands/write.rs
+++ b/apps/cli/src/commands/write.rs
@@ -1,0 +1,34 @@
+//! `reflect write <note>` — replace a public note's full Markdown source.
+
+use crate::commands::output::{print_json, MutationJson};
+use crate::commands::resolve_public_note;
+use crate::error::CliError;
+use crate::graph::Graph;
+use crate::mutation::{atomic_replace, payload};
+
+pub fn run(
+    graph: &Graph,
+    json: bool,
+    note_arg: &str,
+    content: Option<String>,
+    stdin: bool,
+    expected_hash: Option<&str>,
+) -> Result<(), CliError> {
+    let path = resolve_public_note(graph, note_arg)?;
+    let content = payload(content, stdin, "content")?;
+    let hash = atomic_replace(&graph.root, &path, &content, expected_hash)?;
+    let output = MutationJson {
+        action: "write",
+        absolute_path: graph.root.join(&path).display().to_string(),
+        path,
+        hash,
+        previous_path: None,
+        trash_path: None,
+    };
+    if json {
+        print_json(&output)
+    } else {
+        println!("{}", output.path);
+        Ok(())
+    }
+}

--- a/apps/cli/src/error.rs
+++ b/apps/cli/src/error.rs
@@ -4,7 +4,7 @@
 use std::fmt;
 
 /// Exit codes: `0` ok · `1` runtime error · `2` usage (clap) · `3` not found
-/// or private · `4` index missing/unusable (`search` only).
+/// or private · `4` index missing/unusable · `5` write conflict.
 #[derive(Debug)]
 pub enum CliError {
     /// IO/SQL/graph-resolution failures (exit 1).
@@ -14,8 +14,10 @@ pub enum CliError {
     /// The note exists but carries `private: true` (exit 3 — indistinguishable
     /// from not-found by exit code; the stderr message says why).
     Private(String),
-    /// `search` needs the index and it is missing or unusable (exit 4).
+    /// An index-backed command needs the index and it is missing or unusable (exit 4).
     NoIndex(String),
+    /// A create collision or optimistic-concurrency mismatch (exit 5).
+    Conflict(String),
 }
 
 impl CliError {
@@ -28,6 +30,7 @@ impl CliError {
             CliError::Runtime(_) => 1,
             CliError::NotFound(_) | CliError::Private(_) => 3,
             CliError::NoIndex(_) => 4,
+            CliError::Conflict(_) => 5,
         }
     }
 }
@@ -38,7 +41,8 @@ impl fmt::Display for CliError {
             CliError::Runtime(message)
             | CliError::NotFound(message)
             | CliError::Private(message)
-            | CliError::NoIndex(message) => write!(formatter, "{message}"),
+            | CliError::NoIndex(message)
+            | CliError::Conflict(message) => write!(formatter, "{message}"),
         }
     }
 }

--- a/apps/cli/src/lib.rs
+++ b/apps/cli/src/lib.rs
@@ -1,17 +1,16 @@
-//! `reflect` — read/discovery CLI over a Reflect graph (Plan 14).
+//! `reflect` — scriptable access to a Reflect graph.
 //!
-//! Self-contained: reads the graph's markdown files directly and opens
-//! `.reflect/index.sqlite` strictly read-only — no Node runtime, no running
-//! desktop app, no IPC. The modules mirror the small read-side contract owned
-//! by `@reflect/core` (paths, fold keys, frontmatter, title derivation,
-//! hashing, FTS match syntax); each one names its TS counterpart and is
-//! parity-tested against the same expected values. Keep this surface frozen —
-//! the CLI must never grow its own parser or indexer beyond it.
+//! Self-contained: reads and atomically mutates the graph's markdown files
+//! directly and opens `.reflect/index.sqlite` strictly read-only — no Node
+//! runtime, running desktop app, or IPC required. The desktop watcher picks up
+//! mutations while the app is open; the next app open reconciles them
+//! otherwise. Read-side modules mirror the small contract owned by
+//! `@reflect/core` and are parity-tested against the same fixtures.
 //!
-//! Privacy contract: notes with `private: true` frontmatter are invisible
-//! through this CLI — excluded from `search`, refused by `show`/`today`/`path`
-//! — with no override flag. The resolved file's own frontmatter is checked,
-//! never just the index row, so a stale index can't leak a just-flagged note.
+//! Privacy contract: notes with `private: true` frontmatter are invisible and
+//! immutable through this CLI, with no override flag. The resolved file's own
+//! frontmatter is checked, never just the index row, so a stale index cannot
+//! leak or mutate a just-flagged note.
 
 pub mod commands;
 pub mod error;
@@ -20,7 +19,9 @@ pub mod graph;
 pub mod hash;
 pub mod index;
 pub mod keys;
+pub mod mutation;
 pub mod note_file;
 pub mod paths;
 pub mod resolve;
 pub mod search;
+pub mod slug;

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -9,12 +9,12 @@ use clap::{Parser, Subcommand};
 use reflect_cli::error::CliError;
 use reflect_cli::{commands, graph};
 
-/// Read and discover notes in a Reflect graph.
+/// Read and manage notes in a Reflect graph.
 ///
 /// The graph resolves from --graph, then $REFLECT_GRAPH, then the nearest
 /// ancestor of the current directory containing .reflect/. Notes marked
-/// `private: true` are never returned. Exit codes: 0 ok, 1 error, 2 usage,
-/// 3 not found or private, 4 search index missing.
+/// `private: true` are never returned or mutated. Exit codes: 0 ok, 1 error,
+/// 2 usage, 3 not found or private, 4 index missing, 5 write conflict.
 #[derive(Parser)]
 #[command(name = "reflect", version)]
 struct Cli {
@@ -46,6 +46,15 @@ enum Command {
         #[arg(long, default_value_t = 20)]
         limit: usize,
     },
+    /// List current public notes from disk, newest first
+    List {
+        /// Include all notes, regular notes, dailies, or templates
+        #[arg(long, value_enum, default_value = "all")]
+        kind: commands::list::Kind,
+        /// Maximum number of notes
+        #[arg(long, default_value_t = 100)]
+        limit: usize,
+    },
     /// Print a note, resolved by date, path, title, or alias
     Show {
         /// A YYYY-MM-DD date, graph-relative path, note title, or alias
@@ -64,6 +73,107 @@ enum Command {
         #[arg(long)]
         print: bool,
     },
+    /// List public notes that link to a note
+    Backlinks {
+        /// A date, graph-relative path, note title, or alias
+        note: String,
+        /// Maximum number of link rows
+        #[arg(long, default_value_t = 100)]
+        limit: usize,
+    },
+    /// List public-note tasks from the index
+    Tasks {
+        /// Open, completed, or all tasks
+        #[arg(long, value_enum, default_value = "open")]
+        state: commands::tasks::State,
+        /// Maximum number of task rows
+        #[arg(long, default_value_t = 200)]
+        limit: usize,
+    },
+    /// List public-note tag facets from the index
+    Tags,
+    /// Create a regular note with a title-derived path
+    Create {
+        /// H1 title for the new note
+        title: String,
+        /// Explicit graph-relative destination instead of a title slug
+        #[arg(long)]
+        path: Option<String>,
+        /// Markdown body below the generated H1
+        #[arg(long)]
+        body: Option<String>,
+        /// Read the Markdown body from stdin
+        #[arg(long)]
+        stdin: bool,
+    },
+    /// Append a Markdown block to a public note
+    Append {
+        /// A date, graph-relative path, note title, or alias
+        note: String,
+        /// Markdown block to append
+        #[arg(long)]
+        text: Option<String>,
+        /// Read the Markdown block from stdin
+        #[arg(long)]
+        stdin: bool,
+        /// Fail if the current source hash differs
+        #[arg(long)]
+        expect_hash: Option<String>,
+    },
+    /// Append a round Reflect task (today by default)
+    Task {
+        /// Plain task text
+        text: String,
+        /// Target note; defaults to today's daily note
+        #[arg(long)]
+        note: Option<String>,
+        /// Optional ISO due date, written as a daily wiki link
+        #[arg(long)]
+        due: Option<String>,
+        /// Fail if the current source hash differs
+        #[arg(long)]
+        expect_hash: Option<String>,
+    },
+    /// Replace a public note's full Markdown source
+    Write {
+        /// A date, graph-relative path, note title, or alias
+        note: String,
+        /// Complete Markdown source
+        #[arg(long)]
+        content: Option<String>,
+        /// Read complete Markdown source from stdin
+        #[arg(long)]
+        stdin: bool,
+        /// Fail if the current source hash differs
+        #[arg(long)]
+        expect_hash: Option<String>,
+    },
+    /// Move a public note to another graph-relative Markdown path
+    Move {
+        /// A date, graph-relative path, note title, or alias
+        note: String,
+        /// Destination under daily/, notes/, or templates/
+        destination: String,
+        /// Fail if the current source hash differs
+        #[arg(long)]
+        expect_hash: Option<String>,
+    },
+    /// Move a public note to recoverable graph-local trash
+    Delete {
+        /// A date, graph-relative path, note title, or alias
+        note: String,
+        /// Fail if the current source hash differs
+        #[arg(long)]
+        expect_hash: Option<String>,
+    },
+    /// Restore a note from a trash path returned by `delete`
+    Restore {
+        /// Path below `.reflect/trash/` returned by `delete`
+        trash_path: String,
+        /// Restore to a different graph-relative note path
+        #[arg(long)]
+        to: Option<String>,
+    },
 }
 
 fn run(cli: &Cli) -> Result<(), CliError> {
@@ -71,9 +181,78 @@ fn run(cli: &Cli) -> Result<(), CliError> {
     match &cli.command {
         Command::Today { path } => commands::today::run(&graph, cli.json, *path),
         Command::Search { query, limit } => commands::search::run(&graph, cli.json, query, *limit),
+        Command::List { kind, limit } => commands::list::run(&graph, cli.json, *kind, *limit),
         Command::Show { note } => commands::show::run(&graph, cli.json, note),
         Command::Path { note } => commands::path::run(&graph, cli.json, note),
         Command::Open { note, print } => commands::open::run(&graph, cli.json, note, *print),
+        Command::Backlinks { note, limit } => {
+            commands::backlinks::run(&graph, cli.json, note, *limit)
+        }
+        Command::Tasks { state, limit } => commands::tasks::run(&graph, cli.json, *state, *limit),
+        Command::Tags => commands::tags::run(&graph, cli.json),
+        Command::Create {
+            title,
+            path,
+            body,
+            stdin,
+        } => commands::create::run(
+            &graph,
+            cli.json,
+            title,
+            path.as_deref(),
+            body.clone(),
+            *stdin,
+        ),
+        Command::Append {
+            note,
+            text,
+            stdin,
+            expect_hash,
+        } => commands::append::run(
+            &graph,
+            cli.json,
+            note,
+            text.clone(),
+            *stdin,
+            expect_hash.as_deref(),
+        ),
+        Command::Task {
+            text,
+            note,
+            due,
+            expect_hash,
+        } => commands::task::run(
+            &graph,
+            cli.json,
+            text,
+            note.as_deref(),
+            due.as_deref(),
+            expect_hash.as_deref(),
+        ),
+        Command::Write {
+            note,
+            content,
+            stdin,
+            expect_hash,
+        } => commands::write::run(
+            &graph,
+            cli.json,
+            note,
+            content.clone(),
+            *stdin,
+            expect_hash.as_deref(),
+        ),
+        Command::Move {
+            note,
+            destination,
+            expect_hash,
+        } => commands::move_note::run(&graph, cli.json, note, destination, expect_hash.as_deref()),
+        Command::Delete { note, expect_hash } => {
+            commands::delete::run(&graph, cli.json, note, expect_hash.as_deref())
+        }
+        Command::Restore { trash_path, to } => {
+            commands::restore::run(&graph, cli.json, trash_path, to.as_deref())
+        }
     }
 }
 

--- a/apps/cli/src/mutation.rs
+++ b/apps/cli/src/mutation.rs
@@ -1,0 +1,378 @@
+//! Shared mutation primitives: graph-contained paths, optimistic hashes,
+//! atomic writes, recoverable deletion, and stdin payloads.
+
+use std::fs;
+use std::io::{self, Read, Write};
+use std::path::{Component, Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::error::CliError;
+use crate::hash::hash_content;
+use crate::note_file::parse_note_meta;
+use crate::paths::{parse_calendar_date, NOTE_DIRS};
+
+pub const REFLECT_DIR: &str = ".reflect";
+pub const TRASH_DIR: &str = ".reflect/trash";
+
+fn lexical_note_path(rel_path: &str) -> Result<PathBuf, CliError> {
+    let path = Path::new(rel_path);
+    let mut components = path.components();
+    let Some(Component::Normal(first)) = components.next() else {
+        return Err(CliError::runtime(format!(
+            "note path must be graph-relative: {rel_path}"
+        )));
+    };
+    let first = first.to_string_lossy();
+    if !NOTE_DIRS.contains(&first.as_ref()) {
+        return Err(CliError::runtime(format!(
+            "note path must be under daily/, notes/, or templates/: {rel_path}"
+        )));
+    }
+    for component in components {
+        if !matches!(component, Component::Normal(_)) {
+            return Err(CliError::runtime(format!(
+                "note path escapes the graph: {rel_path}"
+            )));
+        }
+    }
+    if path.extension().and_then(|extension| extension.to_str()) != Some("md") {
+        return Err(CliError::runtime(format!(
+            "note path must end in .md: {rel_path}"
+        )));
+    }
+    if first == "daily" {
+        let Some(date) = rel_path
+            .strip_prefix("daily/")
+            .and_then(|path| path.strip_suffix(".md"))
+        else {
+            return Err(CliError::runtime(format!("invalid daily path: {rel_path}")));
+        };
+        if date.contains('/') || parse_calendar_date(date).is_none() {
+            return Err(CliError::runtime(format!("invalid daily path: {rel_path}")));
+        }
+    }
+    Ok(path.to_path_buf())
+}
+
+fn existing_ancestor(path: &Path) -> PathBuf {
+    let mut current = path;
+    loop {
+        if current.exists() {
+            return current.to_path_buf();
+        }
+        match current.parent() {
+            Some(parent) if !parent.as_os_str().is_empty() => current = parent,
+            _ => return path.to_path_buf(),
+        }
+    }
+}
+
+/// Resolve a note path and reject symlink escapes out of the graph.
+pub fn resolve_note_path(root: &Path, rel_path: &str) -> Result<PathBuf, CliError> {
+    let rel = lexical_note_path(rel_path)?;
+    let target = root.join(&rel);
+    let canonical_root = root.canonicalize()?;
+    let anchor = existing_ancestor(&target).canonicalize()?;
+    if !anchor.starts_with(&canonical_root) {
+        return Err(CliError::runtime(format!(
+            "note path resolves outside the graph: {rel_path}"
+        )));
+    }
+    Ok(target)
+}
+
+/// Read an existing public note and optionally verify its expected hash.
+pub fn read_for_mutation(
+    root: &Path,
+    rel_path: &str,
+    expected_hash: Option<&str>,
+) -> Result<String, CliError> {
+    let path = resolve_note_path(root, rel_path)?;
+    let source = fs::read_to_string(&path).map_err(|error| {
+        if error.kind() == io::ErrorKind::NotFound {
+            CliError::NotFound(format!("note does not exist: {rel_path}"))
+        } else {
+            CliError::runtime(format!("could not read {rel_path}: {error}"))
+        }
+    })?;
+    if parse_note_meta(rel_path, &source).private {
+        return Err(CliError::Private(format!("note is private: {rel_path}")));
+    }
+    verify_hash(rel_path, &source, expected_hash)?;
+    Ok(source)
+}
+
+pub fn verify_hash(
+    rel_path: &str,
+    source: &str,
+    expected_hash: Option<&str>,
+) -> Result<(), CliError> {
+    let Some(expected_hash) = expected_hash else {
+        return Ok(());
+    };
+    let actual = hash_content(source);
+    if actual != expected_hash {
+        return Err(CliError::Conflict(format!(
+            "note changed since it was read: {rel_path} (expected {expected_hash}, found {actual})"
+        )));
+    }
+    Ok(())
+}
+
+fn stage(root: &Path, contents: &[u8]) -> Result<tempfile::NamedTempFile, CliError> {
+    let staging = root.join(REFLECT_DIR).join("tmp");
+    fs::create_dir_all(&staging)?;
+    let mut temp = tempfile::NamedTempFile::new_in(staging)?;
+    temp.write_all(contents)?;
+    temp.as_file().sync_all()?;
+    Ok(temp)
+}
+
+/// Atomically replace an existing note after re-checking the expected hash.
+pub fn atomic_replace(
+    root: &Path,
+    rel_path: &str,
+    contents: &str,
+    expected_hash: Option<&str>,
+) -> Result<String, CliError> {
+    let target = resolve_note_path(root, rel_path)?;
+    let current = read_for_mutation(root, rel_path, expected_hash)?;
+    let temp = stage(root, contents.as_bytes())?;
+    let latest = fs::read_to_string(&target)
+        .map_err(|error| CliError::runtime(format!("could not re-read {rel_path}: {error}")))?;
+    if latest != current {
+        return Err(CliError::Conflict(format!(
+            "note changed while it was being written: {rel_path}"
+        )));
+    }
+    temp.persist(&target)
+        .map_err(|error| CliError::runtime(error.error.to_string()))?;
+    Ok(hash_content(contents))
+}
+
+/// Atomically create a note without replacing an existing path.
+pub fn atomic_create(root: &Path, rel_path: &str, contents: &str) -> Result<String, CliError> {
+    let target = resolve_note_path(root, rel_path)?;
+    if target.exists() {
+        return Err(CliError::Conflict(format!(
+            "note already exists: {rel_path}"
+        )));
+    }
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let temp = stage(root, contents.as_bytes())?;
+    temp.persist_noclobber(&target).map_err(|error| {
+        if error.error.kind() == io::ErrorKind::AlreadyExists {
+            CliError::Conflict(format!("note already exists: {rel_path}"))
+        } else {
+            CliError::runtime(error.error.to_string())
+        }
+    })?;
+    Ok(hash_content(contents))
+}
+
+/// Read a payload from an option or stdin, requiring exactly one source.
+pub fn payload(value: Option<String>, stdin: bool, label: &str) -> Result<String, CliError> {
+    match (value, stdin) {
+        (Some(value), false) => Ok(value),
+        (None, true) => {
+            let mut input = String::new();
+            io::stdin().read_to_string(&mut input)?;
+            Ok(input)
+        }
+        (Some(_), true) => Err(CliError::runtime(format!(
+            "provide either --{label} or --stdin, not both"
+        ))),
+        (None, false) => Err(CliError::runtime(format!("provide --{label} or --stdin"))),
+    }
+}
+
+/// Move a public note to another valid graph-relative note path.
+pub fn move_note(
+    root: &Path,
+    from: &str,
+    to: &str,
+    expected_hash: Option<&str>,
+) -> Result<String, CliError> {
+    let source = read_for_mutation(root, from, expected_hash)?;
+    let from_abs = resolve_note_path(root, from)?;
+    let to_abs = resolve_note_path(root, to)?;
+    if to_abs.exists() {
+        return Err(CliError::Conflict(format!(
+            "destination already exists: {to}"
+        )));
+    }
+    if let Some(parent) = to_abs.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let latest = fs::read_to_string(&from_abs)
+        .map_err(|error| CliError::runtime(format!("could not re-read {from}: {error}")))?;
+    if latest != source {
+        return Err(CliError::Conflict(format!(
+            "note changed while it was being moved: {from}"
+        )));
+    }
+    fs::rename(from_abs, to_abs)?;
+    Ok(hash_content(&source))
+}
+
+fn timestamp_millis() -> Result<u128, CliError> {
+    Ok(SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| CliError::runtime(error.to_string()))?
+        .as_millis())
+}
+
+/// Move a public note into the graph-local recoverable trash.
+pub fn trash_note(
+    root: &Path,
+    rel_path: &str,
+    expected_hash: Option<&str>,
+) -> Result<(String, String), CliError> {
+    let source = read_for_mutation(root, rel_path, expected_hash)?;
+    let from = resolve_note_path(root, rel_path)?;
+    let millis = timestamp_millis()?;
+    let mut attempt = 0_u32;
+    let trash_rel = loop {
+        let bucket = if attempt == 0 {
+            millis.to_string()
+        } else {
+            format!("{millis}-{attempt}")
+        };
+        let candidate = format!("{TRASH_DIR}/{bucket}/{rel_path}");
+        if !root.join(&candidate).exists() {
+            break candidate;
+        }
+        attempt += 1;
+    };
+    let to = root.join(&trash_rel);
+    if let Some(parent) = to.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let latest = fs::read_to_string(&from)
+        .map_err(|error| CliError::runtime(format!("could not re-read {rel_path}: {error}")))?;
+    if latest != source {
+        return Err(CliError::Conflict(format!(
+            "note changed while it was being deleted: {rel_path}"
+        )));
+    }
+    fs::rename(from, to)?;
+    Ok((trash_rel, hash_content(&source)))
+}
+
+fn original_path_from_trash(trash_path: &str) -> Option<&str> {
+    let rest = trash_path.strip_prefix(&format!("{TRASH_DIR}/"))?;
+    let (_, original) = rest.split_once('/')?;
+    Some(original)
+}
+
+/// Restore a public note from graph-local trash, optionally to a new path.
+pub fn restore_note(
+    root: &Path,
+    trash_path: &str,
+    to: Option<&str>,
+) -> Result<(String, String), CliError> {
+    let original = original_path_from_trash(trash_path)
+        .ok_or_else(|| CliError::runtime(format!("invalid trash path: {trash_path}")))?;
+    let destination = to.unwrap_or(original);
+    let to_abs = resolve_note_path(root, destination)?;
+    let trash_abs = root.join(trash_path);
+    let canonical_root = root.canonicalize()?;
+    let canonical_trash = trash_abs.canonicalize().map_err(|error| {
+        if error.kind() == io::ErrorKind::NotFound {
+            CliError::NotFound(format!("trashed note does not exist: {trash_path}"))
+        } else {
+            CliError::runtime(error.to_string())
+        }
+    })?;
+    if !canonical_trash.starts_with(canonical_root.join(TRASH_DIR)) || !canonical_trash.is_file() {
+        return Err(CliError::runtime(format!(
+            "invalid trash path: {trash_path}"
+        )));
+    }
+    if to_abs.exists() {
+        return Err(CliError::Conflict(format!(
+            "restore destination already exists: {destination}"
+        )));
+    }
+    let source = fs::read_to_string(&canonical_trash)?;
+    if parse_note_meta(destination, &source).private {
+        return Err(CliError::Private(format!(
+            "trashed note is private: {trash_path}"
+        )));
+    }
+    if let Some(parent) = to_abs.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::rename(canonical_trash, to_abs)?;
+    Ok((destination.to_string(), hash_content(&source)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn graph() -> tempfile::TempDir {
+        let root = tempdir().unwrap();
+        for dir in [REFLECT_DIR, "daily", "notes", "templates"] {
+            fs::create_dir_all(root.path().join(dir)).unwrap();
+        }
+        root
+    }
+
+    #[test]
+    fn rejects_traversal_and_symlink_escapes() {
+        let root = graph();
+        assert!(resolve_note_path(root.path(), "../secret.md").is_err());
+        assert!(resolve_note_path(root.path(), "assets/a.md").is_err());
+        assert!(resolve_note_path(root.path(), "daily/2026-02-31.md").is_err());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::symlink;
+            let outside = tempdir().unwrap();
+            symlink(outside.path(), root.path().join("notes/escape")).unwrap();
+            assert!(resolve_note_path(root.path(), "notes/escape/a.md").is_err());
+        }
+    }
+
+    #[test]
+    fn atomic_write_checks_hash_and_private_state() {
+        let root = graph();
+        atomic_create(root.path(), "notes/a.md", "# A\n").unwrap();
+        let old_hash = hash_content("# A\n");
+        atomic_replace(root.path(), "notes/a.md", "# B\n", Some(&old_hash)).unwrap();
+        assert!(matches!(
+            atomic_replace(root.path(), "notes/a.md", "# C\n", Some(&old_hash)),
+            Err(CliError::Conflict(_))
+        ));
+
+        atomic_create(
+            root.path(),
+            "notes/private.md",
+            "---\nprivate: true\n---\nsecret\n",
+        )
+        .unwrap();
+        assert!(matches!(
+            atomic_replace(root.path(), "notes/private.md", "nope", None),
+            Err(CliError::Private(_))
+        ));
+    }
+
+    #[test]
+    fn delete_and_restore_are_recoverable() {
+        let root = graph();
+        atomic_create(root.path(), "notes/a.md", "# A\n").unwrap();
+        let (trash_path, _) = trash_note(root.path(), "notes/a.md", None).unwrap();
+        assert!(!root.path().join("notes/a.md").exists());
+        assert!(root.path().join(&trash_path).exists());
+        let (restored, _) = restore_note(root.path(), &trash_path, None).unwrap();
+        assert_eq!(restored, "notes/a.md");
+        assert_eq!(
+            fs::read_to_string(root.path().join(restored)).unwrap(),
+            "# A\n"
+        );
+    }
+}

--- a/apps/cli/src/slug.rs
+++ b/apps/cli/src/slug.rs
@@ -1,0 +1,78 @@
+//! Title-derived note filenames, mirroring `packages/core/src/markdown/slug.ts`.
+
+use unicode_normalization::UnicodeNormalization;
+
+const MAX_SLUG_CHARS: usize = 60;
+
+fn is_windows_reserved(value: &str) -> bool {
+    matches!(
+        value,
+        "con"
+            | "prn"
+            | "aux"
+            | "nul"
+            | "com1"
+            | "com2"
+            | "com3"
+            | "com4"
+            | "com5"
+            | "com6"
+            | "com7"
+            | "com8"
+            | "com9"
+            | "lpt1"
+            | "lpt2"
+            | "lpt3"
+            | "lpt4"
+            | "lpt5"
+            | "lpt6"
+            | "lpt7"
+            | "lpt8"
+            | "lpt9"
+    )
+}
+
+/// Derive a portable, lowercase filename slug from a note title.
+pub fn slug_for_title(title: &str) -> String {
+    let mut slug = String::new();
+    let mut separator = false;
+    for character in title.nfc().flat_map(char::to_lowercase) {
+        if character.is_alphanumeric() {
+            if separator && !slug.is_empty() {
+                slug.push('-');
+            }
+            separator = false;
+            slug.push(character);
+        } else if character.is_whitespace() || matches!(character, '-' | '_') {
+            separator = true;
+        }
+    }
+    slug = slug.chars().take(MAX_SLUG_CHARS).collect();
+    while slug.ends_with('-') {
+        slug.pop();
+    }
+    if slug.is_empty() {
+        return "untitled".to_string();
+    }
+    if is_windows_reserved(&slug) {
+        return format!("{slug}-note");
+    }
+    slug
+}
+
+#[cfg(test)]
+mod tests {
+    use super::slug_for_title;
+
+    #[test]
+    fn matches_the_core_slug_examples() {
+        assert_eq!(slug_for_title("Meeting Notes"), "meeting-notes");
+        assert_eq!(slug_for_title("Don't Panic!"), "dont-panic");
+        assert_eq!(slug_for_title("Q3 / Q4 Review"), "q3-q4-review");
+        assert_eq!(slug_for_title("path\\with\\slashes"), "pathwithslashes");
+        assert_eq!(slug_for_title("日本語ノート"), "日本語ノート");
+        assert_eq!(slug_for_title("🎉🎉🎉"), "untitled");
+        assert_eq!(slug_for_title("CON"), "con-note");
+        assert_eq!(slug_for_title(&"a".repeat(80)), "a".repeat(60));
+    }
+}

--- a/apps/cli/tests/cli.rs
+++ b/apps/cli/tests/cli.rs
@@ -664,3 +664,235 @@ fn open_json_shape() {
     assert_eq!(daily["path"], "daily/2026-01-02.md");
     assert_eq!(daily["url"], "reflect://daily/2026-01-02");
 }
+
+// ---- full graph management ----------------------------------------------------
+
+#[test]
+fn create_append_write_move_delete_and_restore_round_trip() {
+    let fixture = graph();
+
+    let created = json(&reflect(
+        &fixture,
+        &[
+            "create",
+            "Project Atlas",
+            "--body",
+            "Initial body",
+            "--json",
+        ],
+    ));
+    assert_eq!(created["action"], "create");
+    assert_eq!(created["path"], "notes/project-atlas.md");
+    let created_hash = created["hash"].as_str().unwrap();
+    let source = fs::read_to_string(fixture.root().join("notes/project-atlas.md")).unwrap();
+    assert!(source.contains("id:"));
+    assert!(source.contains("# Project Atlas\n\nInitial body\n"));
+
+    let appended = json(&reflect(
+        &fixture,
+        &[
+            "append",
+            "notes/project-atlas.md",
+            "--text",
+            "Second block",
+            "--expect-hash",
+            created_hash,
+            "--json",
+        ],
+    ));
+    assert_eq!(appended["action"], "append");
+    let appended_hash = appended["hash"].as_str().unwrap();
+    assert_ne!(created_hash, appended_hash);
+
+    let stale = reflect(
+        &fixture,
+        &[
+            "write",
+            "notes/project-atlas.md",
+            "--content",
+            "# Wrong\n",
+            "--expect-hash",
+            created_hash,
+        ],
+    );
+    assert_eq!(stale.status.code(), Some(5));
+    assert!(stderr(&stale).contains("changed since it was read"));
+
+    let written = json(&reflect(
+        &fixture,
+        &[
+            "write",
+            "notes/project-atlas.md",
+            "--content",
+            "# Project Atlas\n\nReplaced\n",
+            "--expect-hash",
+            appended_hash,
+            "--json",
+        ],
+    ));
+    let written_hash = written["hash"].as_str().unwrap();
+
+    let moved = json(&reflect(
+        &fixture,
+        &[
+            "move",
+            "notes/project-atlas.md",
+            "notes/archive/project-atlas.md",
+            "--expect-hash",
+            written_hash,
+            "--json",
+        ],
+    ));
+    assert_eq!(moved["path"], "notes/archive/project-atlas.md");
+    assert_eq!(moved["previousPath"], "notes/project-atlas.md");
+
+    let deleted = json(&reflect(
+        &fixture,
+        &[
+            "delete",
+            "notes/archive/project-atlas.md",
+            "--expect-hash",
+            written_hash,
+            "--json",
+        ],
+    ));
+    let trash_path = deleted["trashPath"].as_str().unwrap();
+    assert!(trash_path.starts_with(".reflect/trash/"));
+    assert!(!fixture
+        .root()
+        .join("notes/archive/project-atlas.md")
+        .exists());
+
+    let restored = json(&reflect(&fixture, &["restore", trash_path, "--json"]));
+    assert_eq!(restored["action"], "restore");
+    assert_eq!(restored["path"], "notes/archive/project-atlas.md");
+    assert!(fixture
+        .root()
+        .join("notes/archive/project-atlas.md")
+        .exists());
+}
+
+#[test]
+fn create_claims_collision_suffixes_and_rejects_path_traversal() {
+    let fixture = graph();
+    let first = json(&reflect(&fixture, &["create", "Same Title", "--json"]));
+    let second = json(&reflect(&fixture, &["create", "Same Title", "--json"]));
+    assert_eq!(first["path"], "notes/same-title.md");
+    assert_eq!(second["path"], "notes/same-title-2.md");
+
+    let escaped = reflect(&fixture, &["create", "Escape", "--path", "../escape.md"]);
+    assert_eq!(escaped.status.code(), Some(1));
+    assert!(!fixture.root().parent().unwrap().join("escape.md").exists());
+}
+
+#[test]
+fn task_creates_today_and_private_notes_remain_immutable() {
+    let fixture = graph();
+    let task = json(&reflect(
+        &fixture,
+        &["task", "Buy milk", "--due", "2026-07-20", "--json"],
+    ));
+    assert_eq!(task["action"], "task");
+    assert_eq!(task["path"], daily_path(&today_date()));
+    let daily = fs::read_to_string(fixture.root().join(daily_path(&today_date()))).unwrap();
+    assert_eq!(daily, "+ [ ] Buy milk [[2026-07-20]]\n");
+
+    fixture.write_note(
+        "notes/private.md",
+        "---\nprivate: true\n---\n# Private\nsecret\n",
+    );
+    for args in [
+        vec!["append", "notes/private.md", "--text", "nope"],
+        vec!["write", "notes/private.md", "--content", "nope"],
+        vec!["delete", "notes/private.md"],
+    ] {
+        let output = reflect(&fixture, &args);
+        assert_eq!(output.status.code(), Some(3), "args: {args:?}");
+    }
+    assert!(fixture.root().join("notes/private.md").exists());
+}
+
+#[test]
+fn list_is_live_and_excludes_private_notes() {
+    let fixture = graph();
+    fixture.write_note("notes/public.md", "# Public\n");
+    fixture.write_note("notes/private.md", "---\nprivate: true\n---\n# Private\n");
+    fixture.write_note("daily/2026-07-01.md", "daily\n");
+
+    let all = json(&reflect(&fixture, &["list", "--json"]));
+    let paths = all["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|row| row["path"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert!(paths.contains(&"notes/public.md"));
+    assert!(paths.contains(&"daily/2026-07-01.md"));
+    assert!(!paths.contains(&"notes/private.md"));
+
+    let notes = json(&reflect(&fixture, &["list", "--kind", "note", "--json"]));
+    assert_eq!(notes["results"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn backlinks_tasks_and_tags_drop_sources_made_private_after_indexing() {
+    let fixture = graph();
+    fixture.write_note("notes/target.md", "# Target\n");
+    let source = fixture.write_note(
+        "notes/source.md",
+        "# Source\n[[Target]] #Work\n+ [ ] Ship it\n",
+    );
+    fixture.build_index();
+    let conn = rusqlite::Connection::open(fixture.root().join(".reflect/index.sqlite")).unwrap();
+    conn.execute(
+        "INSERT INTO links(source_path, kind, target_raw, target_key, alias, pos_from, pos_to)
+         VALUES('notes/source.md', 'wiki', 'Target', 'target', NULL, 9, 19)",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO tags(note_path, tag, tag_key) VALUES('notes/source.md', 'Work', 'work')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO tasks(note_path, marker_offset, text, raw, checked, due_date, breadcrumbs)
+         VALUES('notes/source.md', 29, 'Ship it', '[ ] Ship it', 0, NULL, '[]')",
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    assert_eq!(
+        json(&reflect(&fixture, &["backlinks", "Target", "--json"]))["results"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        json(&reflect(&fixture, &["tasks", "--json"]))["results"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        json(&reflect(&fixture, &["tags", "--json"]))["results"][0]["tag"],
+        "Work"
+    );
+
+    fs::write(
+        source,
+        "---\nprivate: true\n---\n# Source\n[[Target]] #Work\n+ [ ] Ship it\n",
+    )
+    .unwrap();
+    for args in [
+        vec!["backlinks", "Target", "--json"],
+        vec!["tasks", "--json"],
+        vec!["tags", "--json"],
+    ] {
+        let value = json(&reflect(&fixture, &args));
+        assert!(value["results"].as_array().unwrap().is_empty(), "{args:?}");
+    }
+}

--- a/apps/desktop/src-tauri/skills/graph-skill.md
+++ b/apps/desktop/src-tauri/skills/graph-skill.md
@@ -1,6 +1,6 @@
 ---
 name: {{SKILL_NAME}}
-description: Read, search, and open notes in the user's "{{GRAPH_NAME}}" Reflect graph via the `reflect` CLI. Use when the user asks about their notes, daily notes, journal, or anything they may have written down in Reflect.
+description: Read, search, create, edit, move, delete, restore, and open notes and tasks in the user's "{{GRAPH_NAME}}" Reflect graph via the `reflect` CLI. Use whenever the user asks about their Reflect notes, daily notes, journal, tasks, backlinks, tags, note history, or requests any change to this graph.
 ---
 
 # Reflect graph: {{GRAPH_NAME}}
@@ -10,21 +10,25 @@ one graph (a folder of notes):
 
     {{GRAPH_ROOT}}
 
-Read it through the `reflect` CLI rather than scanning the files — the CLI
-resolves titles, aliases, and daily dates, searches the graph's ranked index,
-and enforces the privacy contract.
+Use the `reflect` CLI rather than scanning or editing files directly. It
+resolves titles, aliases, and daily dates, performs atomic writes, detects
+concurrent edits with hashes, and enforces the privacy contract.
 
 ## The CLI
 
-Use `reflect` from PATH when available; the app also bundles the binary at:
+Prefer the binary bundled with this Reflect build so every documented command
+is available:
 
     {{CLI_PATH}}
 
-Always target the graph explicitly so calls stay deterministic:
+Use `reflect` from PATH only when that bundled path is unavailable. Always
+target the graph explicitly so calls stay deterministic:
 
-    reflect --graph "{{GRAPH_ROOT}}" <command>
+    "{{CLI_PATH}}" --graph "{{GRAPH_ROOT}}" <command>
 
-or export `REFLECT_GRAPH="{{GRAPH_ROOT}}"` for a sequence of calls.
+or export `REFLECT_GRAPH="{{GRAPH_ROOT}}"` for a sequence of calls and invoke
+the same bundled binary. In the command reference below, `reflect` means this
+bundled binary with the graph targeted as above.
 
 ## Git history
 
@@ -33,24 +37,52 @@ initializes or adopts that repo when the graph opens; even graphs with no
 backup remote keep local history through a commit-only sync loop. There may be
 no `origin`, but `.git` history is available.
 
-Use the CLI for current note lookup, privacy filtering, and path resolution.
-Use Git only when the user asks for history, diffs, recovery, or past states:
+Use the CLI for current note lookup, privacy filtering, path resolution, and
+mutations. Use Git only when the user asks for history, diffs, recovery, or
+past states:
 
     git -C "{{GRAPH_ROOT}}" log --oneline -- <graph-relative-path>
     git -C "{{GRAPH_ROOT}}" diff <rev> -- <graph-relative-path>
     git -C "{{GRAPH_ROOT}}" show <rev>:<graph-relative-path>
 
-Do not use Git history to bypass privacy. If a note is private, avoid reading
-or exposing its current or historical content unless the user explicitly asks.
+Do not use Git history to bypass privacy. Never read or expose a private note's
+current or historical content through direct files, Git, or another tool.
 
-## Commands
+## Read commands
 
     reflect today              # print today's daily note
     reflect today --path       # its absolute path (works before the file exists)
     reflect search <query>     # ranked full-text search over the graph
+    reflect list               # recent public notes (`--kind`, `--limit`)
     reflect show <note>        # print a note by date, path, title, or alias
     reflect path <note>        # resolve a note to its absolute path
     reflect open <note>        # open the note in the Reflect app
+    reflect backlinks <note>   # public notes linking to this note
+    reflect tasks              # public tasks (`--state open|done|all`)
+    reflect tags               # public tag facets
+
+## Write commands
+
+    reflect create <title> [--body TEXT|--stdin] [--path notes/x.md]
+    reflect append <note> --text TEXT [--expect-hash HASH]
+    reflect append <note> --stdin [--expect-hash HASH]
+    reflect task <text> [--note NOTE] [--due YYYY-MM-DD] [--expect-hash HASH]
+    reflect write <note> --stdin [--expect-hash HASH]
+    reflect move <note> <destination> [--expect-hash HASH]
+    reflect delete <note> [--expect-hash HASH]
+    reflect restore <trash-path> [--to notes/x.md]
+
+For an existing note, first run `reflect show <note> --json`, preserve its
+complete `content`, and pass its `hash` as `--expect-hash`. Exit code 5 means
+the note changed; re-read it and reconcile instead of overwriting. Use stdin
+for multiline Markdown:
+
+    reflect show "Project X" --json
+    printf '%s' "$NEW_SOURCE" | reflect write "Project X" --stdin --expect-hash HASH
+
+`delete` is recoverable: keep the returned `.reflect/trash/...` path and pass
+it to `restore`. `move` changes the file path only; when a title/path change
+also requires wiki-link rewrites, update affected source notes explicitly.
 
 - Add `--json` to any command for stable machine-readable output — the field
   names and exit codes are the supported automation contract.
@@ -66,16 +98,18 @@ or exposing its current or historical content unless the user explicitly asks.
 | 1 | runtime error (no graph, IO failure) |
 | 2 | usage error |
 | 3 | note not found, or note is private |
-| 4 | search index missing — open the graph in Reflect once to build it |
+| 4 | index missing for an index-backed command — open the graph in Reflect once |
+| 5 | write conflict (hash mismatch or destination collision) |
 
 ## Rules
 
 1. **Respect privacy.** Notes with `private: true` frontmatter are invisible
    through the CLI by design — no content, no paths, no search hits. Never
-   work around this by reading graph files directly unless the user
-   explicitly asks for that.
-2. **The CLI never writes.** Notes are plain markdown under the graph root
-   (`daily/YYYY-MM-DD.md`, `notes/*.md`). To change a note, edit the file the
-   CLI resolves (`reflect path <note>`); the running app picks the edit up.
-3. **Prefer search over enumeration.** `reflect search` uses the app's own
+   work around this through direct files, Git history, or another tool.
+2. **Use guarded writes.** Prefer `--expect-hash` for every existing-note
+   mutation. Never retry a conflict with an unguarded overwrite; re-read first.
+3. **Respect destructive intent.** Create/append/edit when requested. Move,
+   delete, restore, or bulk-change only when the user asked for that outcome.
+   Never edit `.reflect/index.sqlite`; it is a rebuildable projection.
+4. **Prefer search over enumeration.** `reflect search` uses the app's own
    ranked index; don't grep the whole graph when a search will do.

--- a/apps/desktop/src/components/settings/agents-section.test.tsx
+++ b/apps/desktop/src/components/settings/agents-section.test.tsx
@@ -80,6 +80,9 @@ afterEach(() => {
 describe('AgentsSection', () => {
   it('installs the skill with the graph generation pinned', async () => {
     renderSection()
+    expect(
+      await screen.findByText(/read and manage “Personal” with the reflect CLI/),
+    ).toBeTruthy()
     fireEvent.click(await screen.findByRole('button', { name: 'Install skill' }))
 
     await waitFor(() => expect(screen.getByText('Installed')).toBeTruthy())

--- a/apps/desktop/src/components/settings/agents-section.tsx
+++ b/apps/desktop/src/components/settings/agents-section.tsx
@@ -18,9 +18,10 @@ import { useGraph } from '@/providers/graph-provider'
 /**
  * Settings → Agents: one-click install of a per-graph agent skill under
  * `~/.agents/skills/`. The skill is named after the graph and teaches coding
- * agents (Claude Code and friends) to read this graph through the bundled
- * `reflect` CLI. macOS desktop only, like the iCloud section — the navigator
- * hides the entry through the same gate (see use-visible-settings-sections).
+ * agents (Claude Code and friends) to read and manage this graph through the
+ * bundled `reflect` CLI. macOS desktop only, like the iCloud section — the
+ * navigator hides the entry through the same gate (see
+ * use-visible-settings-sections).
  */
 export function AgentsSection(): ReactElement | null {
   const { graph } = useGraph()
@@ -58,7 +59,7 @@ export function AgentsSection(): ReactElement | null {
     <SettingsSection id="agents">
       <SettingsField
         legend="Agent skill"
-        description={`Teach Claude Code and other agents to read “${graph.name}” with the reflect CLI.`}
+        description={`Teach Claude Code and other agents to read and manage “${graph.name}” with the reflect CLI.`}
       >
         {status !== undefined ? (
           <div className="mt-2 flex flex-col gap-2">

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,17 +1,29 @@
 # The `reflect` CLI
 
-A small, self-contained read/discovery CLI over a Reflect graph (Plan 14). It
-reads the graph's markdown files directly and opens `.reflect/index.sqlite`
-strictly read-only — no running desktop app required. It never writes: markdown
-edits are the write path, and the index is refreshed by the desktop app.
+A small, self-contained management CLI over a Reflect graph. It reads and
+atomically mutates the graph's markdown files directly, while opening
+`.reflect/index.sqlite` strictly read-only. No running desktop app is required.
+When the app is running its watcher indexes file changes; otherwise the next
+open reconciles them.
 
 ```
 reflect today              # print today's daily note
 reflect today --path       # its absolute path (works before the file exists)
 reflect search <query>     # ranked full-text search over the index
+reflect list               # list current public notes from disk
 reflect show <note>        # print a note by date, path, title, or alias
 reflect path <note>        # resolve a note to its absolute path
 reflect open <note>        # open a note in the app (reflect:// deep link)
+reflect backlinks <note>   # list incoming wiki links
+reflect tasks              # list indexed tasks
+reflect tags               # list indexed tag facets
+reflect create <title>     # create a note
+reflect append <note> ...  # append markdown
+reflect task <text>        # append a task to today's daily note
+reflect write <note> ...   # replace complete markdown source
+reflect move <note> <path> # move a note
+reflect delete <note>      # move a note to recoverable trash
+reflect restore <trash>    # restore a deleted note
 ```
 
 Built from `apps/cli` (`cargo build -p reflect-cli`); bundled with the desktop
@@ -33,12 +45,24 @@ the CLI stays deterministic for scripts and agents.
 
 ## Privacy
 
-Notes with `private: true` frontmatter are **invisible through the CLI** — no
-content, no paths, no search hits — and there is no flag that overrides this.
-`search` filters them out; `show`/`today`/`path` print nothing to stdout,
-explain on stderr, and exit `3`. The check reads the resolved file's own
-frontmatter (never just the index row), so a stale index can't leak a
-just-flagged note.
+Notes with `private: true` frontmatter are **invisible and immutable through
+the CLI** — no content, no paths, no search hits, no mutations — and there is
+no flag that overrides this. Every read and existing-note mutation checks the
+resolved file's current frontmatter, never just an index row, so a stale index
+cannot leak or mutate a just-flagged note.
+
+## Mutation safety
+
+- Existing-note commands accept `--expect-hash`. Obtain the SHA-256 hash from
+  `reflect show <note> --json`, then pass it to `append`, `task`, `write`,
+  `move`, or `delete`. A mismatch exits `5`; re-read and reconcile the note.
+- Writes stage under `.reflect/tmp/` and atomically replace or create the
+  markdown file. New destinations never overwrite an existing file.
+- Writable paths are restricted to `.md` files under `daily/`, `notes/`, or
+  `templates/`; path traversal and symlink escapes are rejected.
+- `delete` moves the source to `.reflect/trash/` and returns the restore path.
+- The CLI never writes `.reflect/index.sqlite`; it remains a rebuildable
+  projection owned by the desktop app.
 
 ## Output contract
 
@@ -53,7 +77,8 @@ just-flagged note.
 | 1 | runtime error (no graph, IO/SQL failure) |
 | 2 | usage error |
 | 3 | note not found, or note is private |
-| 4 | search index missing or unusable (`search` only) |
+| 4 | index missing or unusable for an index-backed command |
+| 5 | write conflict (hash mismatch or destination collision) |
 
 ## Commands
 
@@ -71,7 +96,8 @@ this is how editors/scripts create them).
   "path": "daily/2026-06-11.md",
   "absolutePath": "/…/graph/daily/2026-06-11.md",
   "title": "2026-06-11",
-  "content": "…"
+  "content": "…",
+  "hash": "e3b0c442…"
 }
 // reflect today --path --json adds "exists" and omits title/content:
 { "date": "…", "path": "…", "absolutePath": "…", "exists": false }
@@ -86,11 +112,11 @@ terms in scripts written without spaces (Japanese, Chinese, Korean, Thai, …)
 match anywhere in the title, since FTS alone cannot see inside their
 uninterrupted title runs. Body matches include snippets. Terms are matched
 literally (FTS5 operators in the query have no special meaning); a title-only
-JSON result has an empty snippet and score `0`. Requires the index: if `.reflect/index.sqlite` is missing
-the exit code is `4` — open the graph in Reflect to build it; the CLI never runs
-the indexer. If files on disk diverge from the index (checked by mtime, then
-content hash), a staleness warning goes to stderr and `"stale": true` is set —
-results still return.
+JSON result has an empty snippet and score `0`. Requires the index: if
+`.reflect/index.sqlite` is missing the exit code is `4` — open the graph in
+Reflect to build it; the CLI never runs the indexer. If files on disk diverge
+from the index (checked by mtime, then content hash), a staleness warning goes
+to stderr and `"stale": true` is set — results still return.
 
 ```jsonc
 // reflect search "meeting notes" --json
@@ -102,6 +128,12 @@ results still return.
   ]
 }
 ```
+
+### `reflect list [--kind all|note|daily|template] [--limit N] [--json]`
+
+Lists current public markdown files directly from disk, newest first. It does
+not require the index. JSON rows include `path`, `absolutePath`, `title`,
+`kind`, `mtime`, and `hash`.
 
 ### `reflect show <note> [--json]`
 
@@ -120,7 +152,7 @@ alphabetically and list the others on stderr.
 
 ```jsonc
 // reflect show "Project X" --json   ("date" is null for non-dailies)
-{ "date": null, "path": "notes/project-x.md", "absolutePath": "…", "title": "Project X", "content": "…" }
+{ "date": null, "path": "notes/project-x.md", "absolutePath": "…", "title": "Project X", "content": "…", "hash": "e3b0c442…" }
 ```
 
 ### `reflect path <note> [--json]`
@@ -141,7 +173,7 @@ opener the note's `reflect://` deep link ([docs/deep-links.md](deep-links.md)).
 The URL prefers the most durable address the note has: the date form for
 dailies (which need not exist yet — navigation creates them lazily), the
 frontmatter `id` form when the note carries one (it survives renames), else
-the graph-relative path form. The CLI never writes, so it does not mint ids —
+the graph-relative path form. The `open` command does not mint missing ids;
 "Copy deep link" in the app does that.
 
 The URL is always printed to stdout; `--print` skips launching the opener —
@@ -153,13 +185,68 @@ CLI surface, before their address leaks.
 { "path": "notes/project-x.md", "url": "reflect://note/01hzy3…", "launched": false }
 ```
 
+### `reflect backlinks <note> [--limit N] [--json]`
+
+Lists indexed incoming wiki links to a public note. The target and every
+source are rechecked from disk for privacy. Requires the index.
+
+### `reflect tasks [--state open|done|all] [--limit N] [--json]`
+
+Lists the indexed task projection from public, non-template notes. JSON rows
+include note path/title, marker offset, text, raw source, checked state, due
+date, and heading breadcrumbs. Requires the index.
+
+### `reflect tags [--json]`
+
+Lists indexed tag facets and public-note occurrence counts. Requires the
+index and rechecks source privacy from disk.
+
+### `reflect create <title> [--body TEXT|--stdin] [--path PATH] [--json]`
+
+Creates a note with generated ULID frontmatter and an H1 title. The default
+path is `notes/<title-slug>.md`; collisions claim `-2`, `-3`, and so on. An
+explicit path can target `notes/`, `daily/`, or `templates/` and never replaces
+an existing file.
+
+### `reflect append <note> (--text TEXT|--stdin) [--expect-hash HASH] [--json]`
+
+Appends a markdown block with one blank line of separation. A missing daily
+date is created lazily; other missing notes fail.
+
+### `reflect task <text> [--note NOTE] [--due YYYY-MM-DD] [--expect-hash HASH] [--json]`
+
+Appends Reflect's round task syntax (`+ [ ] text`) to today's daily note by
+default. `--note` selects another public note. `--due` appends a daily wiki
+link such as `[[2026-07-20]]`.
+
+### `reflect write <note> (--content TEXT|--stdin) [--expect-hash HASH] [--json]`
+
+Atomically replaces the note's complete markdown source. Use stdin for
+multiline content and guard the write with the hash returned by `show --json`.
+
+### `reflect move <note> <destination> [--expect-hash HASH] [--json]`
+
+Moves a public note to an unoccupied valid note path. It does not rewrite the
+note's title or inbound wiki links; callers must make those semantic edits
+explicitly when needed.
+
+### `reflect delete <note> [--expect-hash HASH] [--json]`
+
+Moves a public note into graph-local recoverable trash. Human output is the
+trash path. JSON includes the original `path`, `hash`, and `trashPath`.
+
+### `reflect restore <trash-path> [--to PATH] [--json]`
+
+Restores a deleted public note to its original path, or to `--to`. Existing
+destinations are never replaced. Private trashed content remains inaccessible.
+
 ## For agents
 
-The five commands plus `--json` are the supported automation surface (e.g.
-`~/.agents` discovery workflows). The JSON field names and exit codes above
-are stable; new fields may be added, existing ones won't change meaning.
-Reading a private note is not possible through this surface by design — don't
-work around it by reading graph files directly unless the user asked for that.
+These commands plus `--json` are the supported automation surface (for
+example, `~/.agents` discovery workflows). The JSON field names and exit codes
+above are stable; new fields may be added, existing ones will not change
+meaning. Reading or mutating a private note is impossible through this surface
+by design. Do not work around it by reading graph files directly.
 
 Settings → Agents installs a per-graph agent skill
 (`~/.agents/skills/reflect-<graph-slug>/SKILL.md`) that teaches coding agents
@@ -170,14 +257,13 @@ app can refresh its own installs without ever overwriting a hand-edited one
 
 ## Development notes
 
-- The CLI deliberately duplicates a thin read-side contract from
+- The CLI deliberately duplicates a thin graph contract from
   `@reflect/core` (path conventions, fold keys, frontmatter coercions, title
-  derivation, SHA-256 hashing, FTS match syntax). Each Rust module names its
-  TS counterpart, and the contract is pinned by the shared parity corpus in
-  [`fixtures/parity/`](../fixtures/parity/README.md): TS generates
-  `expected.json` from the real core pipeline, the Rust tests assert against
-  it, so neither side can change without the other following in the same PR.
-  Don't grow the surface.
+  and slug derivation, SHA-256 hashing, FTS match syntax). Read-side modules
+  name their TS counterpart, and the contract is pinned by the shared parity
+  corpus in [`fixtures/parity/`](../fixtures/parity/README.md): TS generates
+  `expected.json` from the real core pipeline, the Rust tests assert against it,
+  so neither side can change without the other following in the same PR.
 - The sidecar is staged by `apps/desktop/scripts/build-sidecar.mjs` into
   `apps/desktop/src-tauri/binaries/` (gitignored), which Tauri's
   `bundle.externalBin` (desktop platform overlay configs) picks up. tauri-build


### PR DESCRIPTION
## Summary
- expand the reflect CLI with note discovery, backlinks, tasks, tags, and full public-note mutations
- protect writes with source hashes, atomic staging, path containment, recoverable trash, and an immutable private-note boundary
- upgrade the generated graph skill, Agents settings copy, and CLI documentation

## Testing
- pnpm check
- cargo test -p reflect-cli
- cargo test -p reflect-open skill::tests
- pnpm --filter @reflect/desktop test src/components/settings/agents-section.test.tsx
- cargo fmt --all -- --check
- git diff --check
- skill-creator quick_validate.py on the installed managed skill
- isolated forward test of create, append, guarded write, delete, restore, and show
- signed Reflect Dev.app build and bundled CLI smoke test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI commands to create, append, edit, move, delete, restore, and manage notes and tasks.
  * Added commands for listing notes, backlinks, tasks, and tags.
  * Added JSON output with content hashes and mutation details.
  * Added safe filename generation and conflict detection for concurrent edits.
* **Bug Fixes**
  * Strengthened privacy protections and path validation, including traversal and symlink checks.
* **Documentation**
  * Expanded CLI and agent guidance for note management, automation, privacy, and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->