### PR TITLE
fix: sort numbered graph-switch shortcuts alphabetically

### DIFF
--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { EmbedStatus, NoteRow, PinnedNote } from '@reflect/core'
+import type { EmbedStatus, NoteRow, PinnedNote, RecentGraph } from '@reflect/core'
 import { notePathForRoute, type Route } from '@/routing/route'
 import type { NavigateOptions } from '@/routing/router'
 import { resetOperations } from '@/lib/operations'
@@ -49,7 +49,7 @@ vi.mock('@reflect/core', async (importOriginal) => ({
 }))
 
 // Importing registers the commands (module side effect, like production).
-const { APP_COMMANDS, keybindingFor } = await import('./app-commands')
+const { APP_COMMANDS, keybindingFor, reconcileStableGraphOrder } = await import('./app-commands')
 
 function command(id: string) {
   const found = APP_COMMANDS.find((entry) => entry.id === id)
@@ -102,6 +102,32 @@ function noteRow(isPrivate: boolean): NoteRow {
     gistStale: false,
   }
 }
+
+function recentGraph(root: string, openedMs: number): RecentGraph {
+  return { root, name: root, openedMs }
+}
+
+describe('reconcileStableGraphOrder', () => {
+  it('keeps graph positions fixed when opening a graph reorders recents', () => {
+    const graphA = recentGraph('/graphs/a', 2)
+    const graphB = recentGraph('/graphs/b', 1)
+    const initialOrder = reconcileStableGraphOrder([], [graphA, graphB])
+
+    expect(initialOrder).toEqual(['/graphs/a', '/graphs/b'])
+    expect(reconcileStableGraphOrder(initialOrder, [graphB, graphA])).toEqual(initialOrder)
+  })
+
+  it('drops forgotten graphs and appends newly seen graphs without reshuffling survivors', () => {
+    const previousOrder = ['/graphs/a', '/graphs/b']
+    const graphB = recentGraph('/graphs/b', 2)
+    const graphC = recentGraph('/graphs/c', 1)
+
+    expect(reconcileStableGraphOrder(previousOrder, [graphC, graphB])).toEqual([
+      '/graphs/b',
+      '/graphs/c',
+    ])
+  })
+})
 
 describe('keybindingFor', () => {
   it('returns the binding UI hints derive from', () => {

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -49,7 +49,7 @@ vi.mock('@reflect/core', async (importOriginal) => ({
 }))
 
 // Importing registers the commands (module side effect, like production).
-const { APP_COMMANDS, keybindingFor, reconcileStableGraphOrder } = await import('./app-commands')
+const { APP_COMMANDS, keybindingFor, sortGraphsByName } = await import('./app-commands')
 
 function command(id: string) {
   const found = APP_COMMANDS.find((entry) => entry.id === id)
@@ -103,29 +103,23 @@ function noteRow(isPrivate: boolean): NoteRow {
   }
 }
 
-function recentGraph(root: string, openedMs: number): RecentGraph {
-  return { root, name: root, openedMs }
+function recentGraph(root: string, openedMs: number, name: string = root): RecentGraph {
+  return { root, name, openedMs }
 }
 
-describe('reconcileStableGraphOrder', () => {
-  it('keeps graph positions fixed when opening a graph reorders recents', () => {
-    const graphA = recentGraph('/graphs/a', 2)
-    const graphB = recentGraph('/graphs/b', 1)
-    const initialOrder = reconcileStableGraphOrder([], [graphA, graphB])
+describe('sortGraphsByName', () => {
+  it('orders graphs alphabetically by name, ignoring the recents (most-recently-used) order', () => {
+    const banana = recentGraph('/graphs/2', 2, 'Banana')
+    const apple = recentGraph('/graphs/1', 1, 'Apple')
 
-    expect(initialOrder).toEqual(['/graphs/a', '/graphs/b'])
-    expect(reconcileStableGraphOrder(initialOrder, [graphB, graphA])).toEqual(initialOrder)
+    expect(sortGraphsByName([banana, apple])).toEqual(['/graphs/1', '/graphs/2'])
   })
 
-  it('drops forgotten graphs and appends newly seen graphs without reshuffling survivors', () => {
-    const previousOrder = ['/graphs/a', '/graphs/b']
-    const graphB = recentGraph('/graphs/b', 2)
-    const graphC = recentGraph('/graphs/c', 1)
+  it('sorts case-insensitively and breaks ties by root path', () => {
+    const lower = recentGraph('/graphs/z', 1, 'alpha')
+    const upper = recentGraph('/graphs/a', 2, 'Alpha')
 
-    expect(reconcileStableGraphOrder(previousOrder, [graphC, graphB])).toEqual([
-      '/graphs/b',
-      '/graphs/c',
-    ])
+    expect(sortGraphsByName([lower, upper])).toEqual(['/graphs/a', '/graphs/z'])
   })
 })
 

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -6,6 +6,7 @@ import {
   randomNotePath,
   toggleDevtools,
   untitledNotePath,
+  type RecentGraph,
 } from '@reflect/core'
 import { attachFilesToNote } from '@/lib/attach-files'
 import { runCopyDeepLink } from '@/lib/note-deep-link'
@@ -47,6 +48,35 @@ function openNewNote(context: CommandContext): void {
     context.clearScrollState()
   }
   context.navigate(newNoteRoute())
+}
+
+/**
+ * Keep numbered graph slots in first-seen order while the persisted recents
+ * list reshuffles by most-recently-used. Forgotten graphs leave the order and
+ * newly discovered graphs append without moving the remaining slots.
+ */
+export function reconcileStableGraphOrder(
+  currentOrder: readonly string[],
+  recents: readonly RecentGraph[],
+): string[] {
+  const availableRoots = new Set(recents.map((recent) => recent.root))
+  const nextOrder: string[] = []
+  const orderedRoots = new Set<string>()
+
+  for (const root of currentOrder) {
+    if (availableRoots.has(root) && !orderedRoots.has(root)) {
+      nextOrder.push(root)
+      orderedRoots.add(root)
+    }
+  }
+  for (const recent of recents) {
+    if (!orderedRoots.has(recent.root)) {
+      nextOrder.push(recent.root)
+      orderedRoots.add(recent.root)
+    }
+  }
+
+  return nextOrder
 }
 
 const GRAPH_SWITCH_COMMANDS: AppCommand[] = Array.from({ length: 9 }, (_, index) => {

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -51,32 +51,19 @@ function openNewNote(context: CommandContext): void {
 }
 
 /**
- * Keep numbered graph slots in first-seen order while the persisted recents
- * list reshuffles by most-recently-used. Forgotten graphs leave the order and
- * newly discovered graphs append without moving the remaining slots.
+ * Order the numbered graph slots (Cmd+1..9) alphabetically by graph name so a
+ * given number maps to a predictable graph instead of following the persisted
+ * recents list, which reshuffles by most-recently-used. Case-insensitive, with
+ * the root path as a stable tiebreak.
  */
-export function reconcileStableGraphOrder(
-  currentOrder: readonly string[],
-  recents: readonly RecentGraph[],
-): string[] {
-  const availableRoots = new Set(recents.map((recent) => recent.root))
-  const nextOrder: string[] = []
-  const orderedRoots = new Set<string>()
-
-  for (const root of currentOrder) {
-    if (availableRoots.has(root) && !orderedRoots.has(root)) {
-      nextOrder.push(root)
-      orderedRoots.add(root)
-    }
-  }
-  for (const recent of recents) {
-    if (!orderedRoots.has(recent.root)) {
-      nextOrder.push(recent.root)
-      orderedRoots.add(recent.root)
-    }
-  }
-
-  return nextOrder
+export function sortGraphsByName(recents: readonly RecentGraph[]): string[] {
+  return [...recents]
+    .sort(
+      (a, b) =>
+        a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }) ||
+        a.root.localeCompare(b.root),
+    )
+    .map((recent) => recent.root)
 }
 
 const GRAPH_SWITCH_COMMANDS: AppCommand[] = Array.from({ length: 9 }, (_, index) => {

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef } from 'react'
 import { dailyPath } from '@reflect/core'
 import { usePalette } from '@/components/command-palette/palette-provider'
 import { registerKeymap } from '@/editor/keymap'
-import { APP_COMMANDS } from '@/lib/commands/app-commands'
+import { APP_COMMANDS, reconcileStableGraphOrder } from '@/lib/commands/app-commands'
 import { runCommand } from '@/lib/commands/registry'
 import { todayIso } from '@/lib/dates'
 import { setMenuCommandDispatch } from '@/lib/native-menu/dispatch'
@@ -189,7 +189,7 @@ export function useAppShortcuts(): CommandContext {
   // that created the context (palette open across an index rebuild, etc.).
   const generationRef = useRef<number | null>(graph?.generation ?? null)
   const graphRootRef = useRef<string | null>(graph?.root ?? null)
-  const recentsRef = useRef(recents)
+  const graphOrderRef = useRef<string[]>([])
   const openRecentRef = useRef(openRecent)
   const routeRef = useRef(route)
   const focusedDailyDateRef = useRef(focusedDailyDate)
@@ -199,7 +199,7 @@ export function useAppShortcuts(): CommandContext {
     templatesOpenRef.current = templatePickerOpen || templateCreateOpen
     generationRef.current = graph?.generation ?? null
     graphRootRef.current = graph?.root ?? null
-    recentsRef.current = recents
+    graphOrderRef.current = reconcileStableGraphOrder(graphOrderRef.current, recents)
     openRecentRef.current = openRecent
     routeRef.current = route
     focusedDailyDateRef.current = focusedDailyDate
@@ -225,11 +225,11 @@ export function useAppShortcuts(): CommandContext {
       toggleSidebar,
       newChat,
       switchGraph: (index) => {
-        const recent = recentsRef.current[index]
-        if (recent === undefined || recent.root === graphRootRef.current) {
+        const root = graphOrderRef.current[index]
+        if (root === undefined || root === graphRootRef.current) {
           return
         }
-        void openRecentRef.current(recent.root)
+        void openRecentRef.current(root)
       },
       toggleAudioMemo,
       generation: () => generationRef.current,

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef } from 'react'
 import { dailyPath } from '@reflect/core'
 import { usePalette } from '@/components/command-palette/palette-provider'
 import { registerKeymap } from '@/editor/keymap'
-import { APP_COMMANDS, reconcileStableGraphOrder } from '@/lib/commands/app-commands'
+import { APP_COMMANDS, sortGraphsByName } from '@/lib/commands/app-commands'
 import { runCommand } from '@/lib/commands/registry'
 import { todayIso } from '@/lib/dates'
 import { setMenuCommandDispatch } from '@/lib/native-menu/dispatch'
@@ -199,7 +199,7 @@ export function useAppShortcuts(): CommandContext {
     templatesOpenRef.current = templatePickerOpen || templateCreateOpen
     generationRef.current = graph?.generation ?? null
     graphRootRef.current = graph?.root ?? null
-    graphOrderRef.current = reconcileStableGraphOrder(graphOrderRef.current, recents)
+    graphOrderRef.current = sortGraphsByName(recents)
     openRecentRef.current = openRecent
     routeRef.current = route
     focusedDailyDateRef.current = focusedDailyDate


### PR DESCRIPTION
## Summary
Command+1 through Command+9 now switch to graphs sorted alphabetically by graph name instead of following the most-recently-used ordering, so a given number maps to a predictable graph.

## Why this matters
#816 reported that Command+1 / Command+2 graph switching behaved unpredictably. The shortcuts indexed into the graph list in MRU order, so every switch reordered the list and the number-to-graph mapping changed on each use. Pressing Command+2 twice could land on two different graphs.

## What changed
- Numbered graph slots are now ordered alphabetically by graph name (case-insensitive, root path as tiebreak) via `sortGraphsByName` in `app-commands.ts`, applied in `app-shortcuts.ts`.
- Active-graph and out-of-range selections remain no-ops.
- Regression coverage for the alphabetical ordering (`app-commands.test.ts`).

## Testing
Targeted Vitest for the changed command module: 36 passed. Typecheck + oxlint clean.

## Note
There is a separate, pre-existing collision between the Meta+digit graph shortcuts and the Meowdown heading shortcuts. That is out of scope for this fix and left unchanged; happy to file or address it separately if useful.

Closes #816