### PR TITLE
feat: add timestamp editor shortcut

### DIFF
--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -15,6 +15,7 @@ import {
   registerNoteEditorHandle,
   unregisterNoteEditorHandle,
 } from '@/editor/editor-handle-registry'
+import { EditorTimestampKeymap } from '@/editor/editor-timestamp-keymap'
 import { markModeFromSyntax } from '@/editor/mark-mode'
 import { NoteEditor, type NoteEditorHandle } from '@/editor/note-editor'
 import { resolveAssetFileLink, useAssetPersistence } from '@/editor/use-asset-persistence'
@@ -372,6 +373,7 @@ export function NotePaneComponent({
         onExitBoundary={handleExitBoundary}
       >
         <EditorAiKeymap onTrigger={aiMenu.openMenu} />
+        <EditorTimestampKeymap timeFormat={settings.timeFormat} />
       </NoteEditor>
 
       {showBacklinks ? (

--- a/apps/desktop/src/editor/editor-timestamp-keymap.test.tsx
+++ b/apps/desktop/src/editor/editor-timestamp-keymap.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TIMESTAMP_BINDING } from '@/editor/keymap'
+import { EditorTimestampKeymap } from './editor-timestamp-keymap'
+
+type TimestampHandler = () => boolean
+
+const harness = vi.hoisted(() => ({
+  handler: null as TimestampHandler | null,
+  insertText: vi.fn(() => true),
+}))
+
+vi.mock('@meowdown/react', () => ({
+  useEditor: () => ({ commands: { insertText: harness.insertText } }),
+  useKeymap: (keymap: Record<string, TimestampHandler>) => {
+    harness.handler = keymap[TIMESTAMP_BINDING] ?? null
+  },
+}))
+
+function pressTimestampShortcut(): boolean {
+  if (harness.handler === null) {
+    throw new Error('Timestamp keymap was not mounted')
+  }
+  return harness.handler()
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(2026, 6, 15, 11, 34))
+  harness.handler = null
+  harness.insertText.mockClear()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('EditorTimestampKeymap', () => {
+  it('inserts the current time with a trailing space in 12-hour format', () => {
+    render(<EditorTimestampKeymap timeFormat="12h" />)
+
+    expect(pressTimestampShortcut()).toBe(true)
+    expect(harness.insertText).toHaveBeenCalledWith({ text: '11:34am ' })
+  })
+
+  it('honors the 24-hour time preference', () => {
+    render(<EditorTimestampKeymap timeFormat="24h" />)
+
+    expect(pressTimestampShortcut()).toBe(true)
+    expect(harness.insertText).toHaveBeenCalledWith({ text: '11:34 ' })
+  })
+})

--- a/apps/desktop/src/editor/editor-timestamp-keymap.tsx
+++ b/apps/desktop/src/editor/editor-timestamp-keymap.tsx
@@ -1,0 +1,27 @@
+import { useMemo } from 'react'
+import { Priority, type EditorExtension } from '@meowdown/core'
+import { useEditor, useKeymap } from '@meowdown/react'
+import type { TimeFormat } from '@reflect/core'
+import { TIMESTAMP_BINDING } from '@/editor/keymap'
+import { formatTimeOfDay } from '@/lib/dates'
+
+interface EditorTimestampKeymapProps {
+  timeFormat: TimeFormat
+}
+
+/** Inserts the current time at the caret when the editor receives ⌘⇧T. */
+export function EditorTimestampKeymap({ timeFormat }: EditorTimestampKeymapProps): null {
+  const editor = useEditor<EditorExtension>()
+  const keymap = useMemo(
+    () => ({
+      [TIMESTAMP_BINDING]: () =>
+        editor.commands.insertText({
+          text: `${formatTimeOfDay(new Date(), timeFormat)} `,
+        }),
+    }),
+    [editor, timeFormat],
+  )
+
+  useKeymap(keymap, { priority: Priority.high })
+  return null
+}

--- a/apps/desktop/src/editor/keymap.ts
+++ b/apps/desktop/src/editor/keymap.ts
@@ -62,6 +62,9 @@ const EDITOR_BINDINGS = Object.fromEntries(
 /** The editor-scope binding that opens the AI menu on the current selection. */
 export const AI_MENU_BINDING = 'Mod-Shift-j'
 
+/** The editor-scope binding that inserts the current time at the caret. */
+export const TIMESTAMP_BINDING = 'Mod-Shift-t'
+
 /**
  * Reflect's own editor-scope bindings (bound via `useKeymap` inside the
  * editor, not by meowdown's engine). Declared here, next to meowdown's, so
@@ -70,6 +73,7 @@ export const AI_MENU_BINDING = 'Mod-Shift-j'
  */
 const REFLECT_EDITOR_BINDINGS: Record<string, string> = {
   [AI_MENU_BINDING]: 'Open the AI menu on the selection',
+  [TIMESTAMP_BINDING]: 'Insert the current time',
 }
 
 export const EDITOR_BINDING_DESCRIPTIONS: Record<string, string> = registerKeymap('editor', {


### PR DESCRIPTION
## Summary
- add an editor-scoped `Cmd+Shift+T` shortcut that inserts the current time at the caret
- honor the existing 12-hour or 24-hour time preference
- expose the binding in the central shortcut registry

## Verification
- `pnpm check`
- `pnpm --filter @reflect/desktop build`
- `pnpm --filter @reflect/desktop exec vitest run src/editor/editor-timestamp-keymap.test.tsx src/editor/keymap.test.ts src/components/shortcuts-dialog.test.tsx`
- autoreview: clean, no actionable findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcut (`Mod-Shift-T`) to insert the current time at the cursor in the note editor.
  * Time formatting follows the selected 12-hour or 24-hour preference.
  * Added the shortcut to the editor’s shortcuts reference.

* **Tests**
  * Added coverage for timestamp insertion and both supported time formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->