### PR TITLE
fix: rename GitHub backup to GitHub sync in settings

### DIFF
--- a/apps/desktop/src/components/settings/backup-section.test.tsx
+++ b/apps/desktop/src/components/settings/backup-section.test.tsx
@@ -49,7 +49,7 @@ describe('BackupSettingsField', () => {
     })
 
     expect(await screen.findByText('Backup', { selector: 'legend' })).toBeTruthy()
-    expect(screen.queryByText('GitHub backup')).toBeNull()
+    expect(screen.queryByText('GitHub sync')).toBeNull()
     expect(screen.getByText('git@gitlab.com:alex/notes.git')).toBeTruthy()
     // The actionable message, not a GitHub reconnect that can't help.
     expect(screen.getByText(/ssh-add/)).toBeTruthy()
@@ -67,7 +67,7 @@ describe('BackupSettingsField', () => {
       status: AUTH_ERROR,
     })
 
-    expect(await screen.findByText('GitHub backup')).toBeTruthy()
+    expect(await screen.findByText('GitHub sync')).toBeTruthy()
     expect(screen.getByText('alex/notes')).toBeTruthy()
     expect(screen.getByText(/reconnect GitHub/)).toBeTruthy()
     expect(screen.getByText('GitHub account')).toBeTruthy()

--- a/apps/desktop/src/components/settings/backup-section.tsx
+++ b/apps/desktop/src/components/settings/backup-section.tsx
@@ -47,7 +47,7 @@ function githubRepoBrowserUrl(repo: NonNullable<Extract<BackupState, { phase: 'c
 }
 
 /**
- * Settings → Sync → Backup: connect a GitHub repository, see the current
+ * Settings → Sync → GitHub sync: connect a GitHub repository, see the current
  * backup state in product language, back up on demand, and disconnect.
  * Conflicted notes ("needs review") surface here with a count; each conflicted
  * note also shows its own banner when opened.
@@ -124,7 +124,7 @@ export function BackupSettingsField(): ReactElement {
   return (
     <>
       <SettingsField
-        legend={genericRemote ? 'Backup' : 'GitHub backup'}
+        legend={genericRemote ? 'Backup' : 'GitHub sync'}
         description={
           genericRemote
             ? 'This graph backs up to its own git remote. Edits back up automatically a few moments after you stop typing.'

--- a/apps/desktop/src/components/settings/icloud-section.tsx
+++ b/apps/desktop/src/components/settings/icloud-section.tsx
@@ -138,7 +138,7 @@ export function IcloudSettingsField(): ReactElement | null {
           // graph regardless; the original folder keeping its backup is the
           // recovery copy working as intended. Tell the user, don't block.
           setError(
-            `The graph moved to iCloud, but GitHub backup could not be disconnected from the original folder: ${errorMessage(caught)}`,
+            `The graph moved to iCloud, but GitHub sync could not be disconnected from the original folder: ${errorMessage(caught)}`,
           )
         }
       }
@@ -203,7 +203,7 @@ export function IcloudSettingsField(): ReactElement | null {
                     Your notes are copied into iCloud Drive and the graph reopens there. The
                     current folder stays on disk, untouched, as a recovery copy.
                     {backupConnected
-                      ? ' GitHub backup is disconnected from the recovery copy; you can reconnect backup after the iCloud graph opens.'
+                      ? ' GitHub sync is disconnected from the recovery copy; you can reconnect GitHub sync after the iCloud graph opens.'
                       : ''}
                   </DialogDescription>
                 </DialogHeader>

--- a/apps/desktop/src/components/settings/sync-section.test.tsx
+++ b/apps/desktop/src/components/settings/sync-section.test.tsx
@@ -97,17 +97,17 @@ afterEach(() => {
 })
 
 describe('SyncSection', () => {
-  it('combines iCloud Drive and GitHub backup under Sync for local graphs', async () => {
+  it('combines iCloud Drive and GitHub sync under Sync for local graphs', async () => {
     renderSection()
 
     const section = screen.getByRole('region', { name: 'Sync' })
     expect(within(section).getByText('iCloud Drive', { selector: 'legend' })).toBeTruthy()
     expect(await within(section).findByText('1 graph in iCloud Drive.')).toBeTruthy()
-    expect(within(section).getByText('GitHub backup', { selector: 'legend' })).toBeTruthy()
+    expect(within(section).getByText('GitHub sync', { selector: 'legend' })).toBeTruthy()
     expect(within(section).getByRole('button', { name: /connect github/i })).toBeTruthy()
   })
 
-  it('keeps GitHub backup visible when the graph syncs through iCloud', async () => {
+  it('keeps GitHub sync visible when the graph syncs through iCloud', async () => {
     graph.current = {
       root: '/Users/alex/Library/Mobile Documents/iCloud~app/Documents/Notes',
       name: 'Notes',
@@ -120,7 +120,7 @@ describe('SyncSection', () => {
     expect(within(section).getByText('iCloud Drive', { selector: 'legend' })).toBeTruthy()
     expect(await within(section).findByText('All note files are downloaded.')).toBeTruthy()
     expect(within(section).getByText('No notes need review.')).toBeTruthy()
-    expect(within(section).getByText('GitHub backup', { selector: 'legend' })).toBeTruthy()
+    expect(within(section).getByText('GitHub sync', { selector: 'legend' })).toBeTruthy()
     expect(within(section).getByRole('button', { name: /connect github/i })).toBeTruthy()
   })
 
@@ -144,7 +144,7 @@ describe('SyncSection', () => {
     expect(within(section).getByRole('button', { name: /A.*notes\/a\.md/ })).toBeTruthy()
   })
 
-  it('opens the conflicted note listed under GitHub backup', async () => {
+  it('opens the conflicted note listed under GitHub sync', async () => {
     core.conflictedNotes = [{ path: 'notes/conflicted.md', title: 'Conflicted note' }]
     sync.backup = {
       phase: 'connected',
@@ -205,6 +205,6 @@ describe('SyncSection', () => {
 
     const section = screen.getByRole('region', { name: 'Sync' })
     expect(within(section).queryByText('iCloud Drive', { selector: 'legend' })).toBeNull()
-    expect(within(section).getByText('GitHub backup', { selector: 'legend' })).toBeTruthy()
+    expect(within(section).getByText('GitHub sync', { selector: 'legend' })).toBeTruthy()
   })
 })

--- a/apps/desktop/src/components/settings/sync-section.tsx
+++ b/apps/desktop/src/components/settings/sync-section.tsx
@@ -6,7 +6,7 @@ import { SettingsSection } from './section'
 /**
  * Settings → Sync: iCloud Drive and Git remote sync live together here. Keep
  * both controls visible so an iCloud-hosted graph can still manage its GitHub
- * backup.
+ * sync.
  */
 export function SyncSection(): ReactElement {
   return (


### PR DESCRIPTION
## Problem

Settings presents the GitHub integration as “GitHub backup,” while it lives alongside other sync providers under Sync. That terminology is inconsistent with the product surface.

## Before → After

| Surface | Before | After |
| --- | --- | --- |
| GitHub Settings field | GitHub backup | GitHub sync |
| iCloud migration messages | GitHub backup | GitHub sync |

Generic non-GitHub remotes continue to use the host-neutral “Backup” label.

## Changes

- Rename the GitHub field legend and Settings-only migration messages to “GitHub sync.”
- Update Settings component tests to assert the new terminology.

## Verification

- `pnpm check` — passed
- `pnpm --filter @reflect/desktop test src/components/settings/backup-section.test.tsx src/components/settings/sync-section.test.tsx` — 15 tests passed

## Risk / Rollout

Low risk: this is a copy-only change with no sync behavior, data, or migration changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change in desktop settings strings and tests; no sync, auth, or migration logic is modified.
> 
> **Overview**
> Aligns Settings **Sync** copy so the GitHub integration is labeled **GitHub sync** instead of **GitHub backup**, matching how it sits next to iCloud and other sync options.
> 
> The `BackupSettingsField` legend for GitHub remotes becomes **GitHub sync**; non-GitHub git remotes still use the neutral **Backup** label. iCloud “move graph” error and confirmation text now say **GitHub sync** when describing disconnect/reconnect. Related comments and Settings tests (`backup-section`, `sync-section`) are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff139cb001190c91563670bbfca2fe732dbdf87a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Renamed GitHub-related “backup” labels and messages to “GitHub sync” throughout Sync and iCloud settings.
  * Updated confirmation and error messaging to use consistent sync terminology.
* **Tests**
  * Updated settings tests to verify the new “GitHub sync” wording and preserve existing reconnect, visibility, and navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->