### PR TITLE
fix: prevent macOS iCloud launch crashes

### DIFF
--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -54,6 +54,10 @@ const INTEL_ONNX_RUNTIME_RESOURCE_SOURCE = `resources/onnxruntime/${ONNX_RUNTIME
 const RELEASE_NOTES_FILENAME = 'release-notes.md'
 const MAC_DOWNLOAD_NOTICE_HEADING = '## Which Mac download should I choose?'
 const MACOS_SIDECARS = ['reflect', 'reflect-capture-host']
+const MACOS_PROFILE_IDENTITY_ENTITLEMENTS = [
+  'com.apple.application-identifier',
+  'com.apple.developer.team-identifier',
+]
 const RELEASE_VERSION_PATTERN = /^(\d+)\.(\d+)\.(\d+)(?:-beta(?:\.(\d+))?)?$/
 const NOTARIZATION_ENV_VARS = [
   'APPLE_ID',
@@ -492,6 +496,81 @@ function codesignArgs({ entitlements, identity, keychain, path }) {
   return args
 }
 
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function macosProfileIdentityEntitlements({ bundleIdentifier, profileEntitlements }) {
+  if (typeof bundleIdentifier !== 'string' || bundleIdentifier.length === 0) {
+    throw new Error('macOS flavor has no bundle identifier')
+  }
+  if (!isRecord(profileEntitlements)) {
+    throw new Error('embedded provisioning profile has no entitlements dictionary')
+  }
+
+  const identityEntitlements = {}
+  for (const key of MACOS_PROFILE_IDENTITY_ENTITLEMENTS) {
+    const value = profileEntitlements[key]
+    if (typeof value !== 'string' || value.length === 0) {
+      throw new Error(`embedded provisioning profile is missing string entitlement "${key}"`)
+    }
+    identityEntitlements[key] = value
+  }
+
+  const applicationIdentifier = identityEntitlements['com.apple.application-identifier']
+  const prefixSeparator = applicationIdentifier.indexOf('.')
+  const profileBundleIdentifier = applicationIdentifier.slice(prefixSeparator + 1)
+  if (prefixSeparator <= 0 || profileBundleIdentifier !== bundleIdentifier) {
+    throw new Error(
+      `embedded provisioning profile application identifier "${applicationIdentifier}" ` +
+        `does not match bundle identifier "${bundleIdentifier}"`,
+    )
+  }
+  return identityEntitlements
+}
+
+/**
+ * Add the identity entitlements supplied by a flavor's provisioning profile
+ * without importing unrelated wildcard grants from that profile.
+ */
+export function mergeMacosProfileIdentityEntitlements({
+  appEntitlements,
+  bundleIdentifier,
+  profileEntitlements,
+}) {
+  if (!isRecord(appEntitlements)) throw new Error('configured macOS entitlements are not a dictionary')
+  const identityEntitlements = macosProfileIdentityEntitlements({ bundleIdentifier, profileEntitlements })
+
+  for (const [key, value] of Object.entries(identityEntitlements)) {
+    if (Object.hasOwn(appEntitlements, key) && appEntitlements[key] !== value) {
+      throw new Error(
+        `configured macOS entitlement "${key}" is "${appEntitlements[key]}", ` +
+          `but the embedded provisioning profile requires "${value}"`,
+      )
+    }
+  }
+  return { ...appEntitlements, ...identityEntitlements }
+}
+
+/** Assert that a signed app retained the profile-owned identity entitlements. */
+export function assertMacosProfileIdentityEntitlements({
+  bundleIdentifier,
+  profileEntitlements,
+  signedEntitlements,
+}) {
+  if (!isRecord(signedEntitlements)) throw new Error('signed macOS entitlements are not a dictionary')
+  const identityEntitlements = macosProfileIdentityEntitlements({ bundleIdentifier, profileEntitlements })
+
+  for (const [key, value] of Object.entries(identityEntitlements)) {
+    if (signedEntitlements[key] !== value) {
+      throw new Error(
+        `signed app entitlement "${key}" is ${JSON.stringify(signedEntitlements[key])}, ` +
+          `expected "${value}" from the embedded provisioning profile`,
+      )
+    }
+  }
+}
+
 export function macosEntitlementsPath(flavor) {
   const entitlements = readFlavorConf(flavor).bundle?.macOS?.entitlements
   if (typeof entitlements !== 'string') {
@@ -500,24 +579,116 @@ export function macosEntitlementsPath(flavor) {
   return join(appDir, 'src-tauri', entitlements)
 }
 
+/** Resolve the provisioning profile embedded for a flavor, if it has one. */
+export function macosProvisioningProfilePath(flavor) {
+  const profile = readFlavorConf(flavor).bundle?.macOS?.files?.['embedded.provisionprofile']
+  if (profile === undefined) return null
+  if (typeof profile !== 'string' || profile.length === 0) {
+    fail(`macOS flavor "${flavor}" has an invalid embedded provisioning profile`)
+  }
+  return join(appDir, 'src-tauri', profile)
+}
+
+function parsePlistJson(output, description) {
+  const value = JSON.parse(output)
+  if (!isRecord(value)) throw new Error(`${description} is not a dictionary`)
+  return value
+}
+
+function readEntitlementsPlist(path) {
+  return parsePlistJson(capture('plutil', ['-convert', 'json', '-o', '-', '--', path]), path)
+}
+
+function readProvisioningProfileEntitlements(path) {
+  const profile = capture('security', ['cms', '-D', '-i', path])
+  const entitlements = capture('plutil', ['-extract', 'Entitlements', 'json', '-o', '-', '-'], {
+    input: profile,
+  })
+  return parsePlistJson(entitlements, `${path} entitlements`)
+}
+
+function readCodeSigningEntitlements(app) {
+  const entitlements = capture('codesign', ['--display', '--entitlements', '-', '--xml', app], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  const json = capture('plutil', ['-convert', 'json', '-o', '-', '-'], { input: entitlements })
+  return parsePlistJson(json, `${app} code-signing entitlements`)
+}
+
+function prepareMacosSigningEntitlements({ app, flavor }) {
+  const appEntitlementsPath = macosEntitlementsPath(flavor)
+  const configuredProfilePath = macosProvisioningProfilePath(flavor)
+  if (!configuredProfilePath) {
+    return { cleanup: () => {}, description: basename(appEntitlementsPath), path: appEntitlementsPath }
+  }
+
+  const embeddedProfilePath = join(app, 'Contents', 'embedded.provisionprofile')
+  if (!existsSync(embeddedProfilePath)) {
+    throw new Error(
+      `${basename(configuredProfilePath)} was configured for macOS flavor "${flavor}", ` +
+        `but ${embeddedProfilePath} does not exist`,
+    )
+  }
+
+  const bundleIdentifier = readFlavorConf(flavor).identifier
+  const appEntitlements = readEntitlementsPlist(appEntitlementsPath)
+  const profileEntitlements = readProvisioningProfileEntitlements(embeddedProfilePath)
+  const mergedEntitlements = mergeMacosProfileIdentityEntitlements({
+    appEntitlements,
+    bundleIdentifier,
+    profileEntitlements,
+  })
+  const tempDir = mkdtempSync(join(tmpdir(), 'reflect-signing-entitlements-'))
+  const path = join(tempDir, 'Entitlements.plist')
+  try {
+    // The plist round-trips through JSON, which only preserves strings,
+    // booleans, and arrays — every entitlement today. A number or <data>
+    // entitlement would lose its exact plist type here.
+    writeFileSync(path, `${JSON.stringify(mergedEntitlements, null, 2)}\n`, { mode: 0o600 })
+    execFileSync('plutil', ['-convert', 'xml1', path])
+  } catch (error) {
+    rmSync(tempDir, { recursive: true, force: true })
+    throw error
+  }
+  return {
+    cleanup: () => rmSync(tempDir, { recursive: true, force: true }),
+    description: `${basename(appEntitlementsPath)} + identity from ${basename(configuredProfilePath)}`,
+    path,
+  }
+}
+
 function macosSidecarPaths(app) {
   return MACOS_SIDECARS.map((binary) => join(app, 'Contents', 'MacOS', binary))
 }
 
 function resignMacosApp({ flavor, identity, keychain, target }) {
   const { app } = bundlePaths(flavor, target)
-  const entitlements = macosEntitlementsPath(flavor)
   for (const sidecar of macosSidecarPaths(app)) {
     if (!existsSync(sidecar)) fail(`${sidecar} does not exist — Tauri did not bundle the sidecar`)
   }
 
-  log('re-signing macOS sidecars without app entitlements…')
-  for (const sidecar of macosSidecarPaths(app)) {
-    execFileSync('codesign', codesignArgs({ identity, keychain, path: sidecar }), { stdio: 'inherit' })
+  let signingEntitlements
+  try {
+    signingEntitlements = prepareMacosSigningEntitlements({ app, flavor })
+  } catch (error) {
+    fail(`preparing macOS signing entitlements failed: ${error instanceof Error ? error.message : String(error)}`)
   }
 
-  log(`re-signing ${basename(app)} with ${basename(entitlements)}…`)
-  execFileSync('codesign', codesignArgs({ entitlements, identity, keychain, path: app }), { stdio: 'inherit' })
+  try {
+    log('re-signing macOS sidecars without app entitlements…')
+    for (const sidecar of macosSidecarPaths(app)) {
+      execFileSync('codesign', codesignArgs({ identity, keychain, path: sidecar }), { stdio: 'inherit' })
+    }
+
+    log(`re-signing ${basename(app)} with ${signingEntitlements.description}…`)
+    execFileSync(
+      'codesign',
+      codesignArgs({ entitlements: signingEntitlements.path, identity, keychain, path: app }),
+      { stdio: 'inherit' },
+    )
+  } finally {
+    signingEntitlements.cleanup()
+  }
 }
 
 function importSigningCertificate() {
@@ -694,6 +865,22 @@ function verifySidecarsLaunch({ flavor, target }) {
   }
 }
 
+function verifyMacosProfileIdentityEntitlements({ app, flavor }) {
+  const configuredProfilePath = macosProvisioningProfilePath(flavor)
+  if (!configuredProfilePath) return
+
+  const embeddedProfilePath = join(app, 'Contents', 'embedded.provisionprofile')
+  if (!existsSync(embeddedProfilePath)) {
+    throw new Error(`${app} is missing ${basename(configuredProfilePath)}`)
+  }
+  assertMacosProfileIdentityEntitlements({
+    bundleIdentifier: readFlavorConf(flavor).identifier,
+    profileEntitlements: readProvisioningProfileEntitlements(embeddedProfilePath),
+    signedEntitlements: readCodeSigningEntitlements(app),
+  })
+  log('profile identity entitlements: ok')
+}
+
 /** Verify the built bundles match the expected distribution state. */
 function verify({ notarized, flavor, target }) {
   const { app, dmg } = bundlePaths(flavor, target)
@@ -704,6 +891,11 @@ function verify({ notarized, flavor, target }) {
     'valid on disk',
     'satisfies its Designated Requirement',
   ])
+  try {
+    verifyMacosProfileIdentityEntitlements({ app, flavor })
+  } catch (error) {
+    fail(`profile identity entitlement verification failed: ${error instanceof Error ? error.message : String(error)}`)
+  }
   verifySidecarsLaunch({ flavor, target })
 
   if (!notarized) {

--- a/apps/desktop/scripts/release-macos.test.mjs
+++ b/apps/desktop/scripts/release-macos.test.mjs
@@ -5,6 +5,7 @@ import { expect, test } from 'vitest'
 
 import {
   appendMacDownloadNotice,
+  assertMacosProfileIdentityEntitlements,
   canLaunchTarget,
   compareReleaseVersions,
   createBetaFeedReleaseArgs,
@@ -20,7 +21,9 @@ import {
   createUpdaterArchiveArgs,
   createUpdaterManifest,
   macosEntitlementsPath,
+  macosProvisioningProfilePath,
   macosTargetResourceConfig,
+  mergeMacosProfileIdentityEntitlements,
   newestBetaVersionFromTags,
   parseKeychainList,
   signDmgArgs,
@@ -348,6 +351,111 @@ test('macOS entitlements resolve through platform and flavor overlays', () => {
   expect(macosEntitlementsPath('stable')).toBe(join(srcTauri, 'Entitlements.plist'))
   expect(macosEntitlementsPath('beta')).toBe(join(srcTauri, 'Entitlements.plist'))
   expect(macosEntitlementsPath('dev')).toBe(join(srcTauri, 'Entitlements.dev.plist'))
+})
+
+test('macOS provisioning profiles resolve per flavor and dev remains unprovisioned', () => {
+  const srcTauri = join(process.cwd(), 'src-tauri')
+
+  expect(macosProvisioningProfilePath('stable')).toBe(join(srcTauri, 'Reflect.provisionprofile'))
+  expect(macosProvisioningProfilePath('beta')).toBe(join(srcTauri, 'Reflect-beta.provisionprofile'))
+  expect(macosProvisioningProfilePath('dev')).toBeNull()
+})
+
+test('macOS signing keeps app entitlements and adds only profile identity entitlements', () => {
+  const appEntitlements = {
+    'com.apple.developer.icloud-services': ['CloudDocuments'],
+    'com.apple.security.device.audio-input': true,
+  }
+  const profileEntitlements = {
+    'com.apple.application-identifier': '789ULN5MZB.app.reflect.desktop.beta',
+    'com.apple.developer.team-identifier': '789ULN5MZB',
+    'keychain-access-groups': ['789ULN5MZB.*'],
+  }
+
+  expect(
+    mergeMacosProfileIdentityEntitlements({
+      appEntitlements,
+      bundleIdentifier: 'app.reflect.desktop.beta',
+      profileEntitlements,
+    }),
+  ).toEqual({
+    ...appEntitlements,
+    'com.apple.application-identifier': '789ULN5MZB.app.reflect.desktop.beta',
+    'com.apple.developer.team-identifier': '789ULN5MZB',
+  })
+})
+
+test('macOS signing rejects a provisioning profile for another flavor', () => {
+  expect(() =>
+    mergeMacosProfileIdentityEntitlements({
+      appEntitlements: { 'com.apple.security.device.audio-input': true },
+      bundleIdentifier: 'app.reflect.desktop.beta',
+      profileEntitlements: {
+        'com.apple.application-identifier': '789ULN5MZB.app.reflect.desktop',
+        'com.apple.developer.team-identifier': '789ULN5MZB',
+      },
+    }),
+  ).toThrow('does not match bundle identifier "app.reflect.desktop.beta"')
+})
+
+test('macOS signing compares the full profile bundle identifier, not only its suffix', () => {
+  expect(() =>
+    mergeMacosProfileIdentityEntitlements({
+      appEntitlements: {},
+      bundleIdentifier: 'app.reflect.desktop.beta',
+      profileEntitlements: {
+        'com.apple.application-identifier': '789ULN5MZB.other.app.reflect.desktop.beta',
+        'com.apple.developer.team-identifier': '789ULN5MZB',
+      },
+    }),
+  ).toThrow('does not match bundle identifier "app.reflect.desktop.beta"')
+})
+
+test.each(['com.apple.application-identifier', 'com.apple.developer.team-identifier'])(
+  'macOS signing rejects a profile missing %s',
+  (missingEntitlement) => {
+    const profileEntitlements = {
+      'com.apple.application-identifier': '789ULN5MZB.app.reflect.desktop.beta',
+      'com.apple.developer.team-identifier': '789ULN5MZB',
+    }
+    delete profileEntitlements[missingEntitlement]
+
+    expect(() =>
+      mergeMacosProfileIdentityEntitlements({
+        appEntitlements: {},
+        bundleIdentifier: 'app.reflect.desktop.beta',
+        profileEntitlements,
+      }),
+    ).toThrow(`missing string entitlement "${missingEntitlement}"`)
+  },
+)
+
+test('macOS signing rejects a conflicting identity in the app entitlement file', () => {
+  expect(() =>
+    mergeMacosProfileIdentityEntitlements({
+      appEntitlements: { 'com.apple.developer.team-identifier': 'WRONGTEAM' },
+      bundleIdentifier: 'app.reflect.desktop',
+      profileEntitlements: {
+        'com.apple.application-identifier': '789ULN5MZB.app.reflect.desktop',
+        'com.apple.developer.team-identifier': '789ULN5MZB',
+      },
+    }),
+  ).toThrow('but the embedded provisioning profile requires "789ULN5MZB"')
+})
+
+test('macOS verification rejects a signed app that lost a profile identity entitlement', () => {
+  expect(() =>
+    assertMacosProfileIdentityEntitlements({
+      bundleIdentifier: 'app.reflect.desktop.beta',
+      profileEntitlements: {
+        'com.apple.application-identifier': '789ULN5MZB.app.reflect.desktop.beta',
+        'com.apple.developer.team-identifier': '789ULN5MZB',
+      },
+      signedEntitlements: {
+        'com.apple.application-identifier': '789ULN5MZB.app.reflect.desktop.beta',
+      },
+    }),
+  ).toThrow('signed app entitlement "com.apple.developer.team-identifier" is undefined')
 })
 
 test('sidecar launch checks cover native targets and Intel under Rosetta', () => {

--- a/apps/desktop/src-tauri/src/icloud/watch.rs
+++ b/apps/desktop/src-tauri/src/icloud/watch.rs
@@ -232,6 +232,14 @@ mod platform {
         query.setPredicate(Some(&predicate));
 
         let queue = NSOperationQueue::new();
+        // Must stay serial: CloudDocs (BRQuery) schedules its own internal,
+        // unsynchronized gatherer work on this queue — not just notification
+        // delivery. On the default concurrent queue the initial gather and
+        // update batches classify items in parallel and corrupt BRQuery's
+        // result index sets, aborting with an uncaught NSRangeException
+        // (crash: NSMutableIndexSet addIndexesInRange in
+        // _handleReplacedItemsNotifications, ~10s after launch).
+        queue.setMaxConcurrentOperationCount(1);
         unsafe { query.setOperationQueue(Some(&queue)) };
 
         let handler_roots = roots.clone();

--- a/apps/desktop/src-tauri/tauri.dev.conf.json
+++ b/apps/desktop/src-tauri/tauri.dev.conf.json
@@ -24,7 +24,10 @@
       "icons-dev/icon.ico"
     ],
     "macOS": {
-      "entitlements": "Entitlements.dev.plist"
+      "entitlements": "Entitlements.dev.plist",
+      "files": {
+        "embedded.provisionprofile": null
+      }
     }
   },
   "plugins": {

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -59,8 +59,9 @@ can still build unsigned bundles with plain `pnpm tauri build`.
 3. Runs `pnpm tauri build --target <target> --bundles app`, which stages the `reflect`
    CLI sidecar for that target and signs the app bundle. The release helper then
    re-signs the bundled sidecars without the app's restricted entitlements, re-signs the
-   `.app` with its entitlement file, notarizes the finalized `.app` via `notarytool`,
-   staples the ticket, and verifies the sidecars launch.
+   `.app` with its entitlement file plus the flavor-specific identity entitlements from
+   its embedded provisioning profile, notarizes the finalized `.app` via `notarytool`,
+   staples the ticket, and verifies the signed identity entitlements and sidecars.
    Intel builds also download Microsoft's official ONNX Runtime macOS x86_64 archive
    into `src-tauri/resources/onnxruntime/` and bundle `libonnxruntime.dylib` as a
    Tauri resource before signing; that directory is generated and gitignored.


### PR DESCRIPTION
## Problem

Reflect Beta 0.7.0-beta.3 aborts (`SIGABRT`, uncaught `NSRangeException`) roughly ten seconds after launch while an iCloud-backed graph is open.

The crash report pins the cause: the iCloud watcher hands `NSMetadataQuery` a default **concurrent** `NSOperationQueue`, and CloudDocs (`BRQuery`) schedules its own internal, unsynchronized gatherer work on that client queue — not just notification delivery. The report shows three operations from the same queue executing simultaneously (the initial gather's `_classifyItems:` racing an update batch's `_classifyItems:` and `_handleReplacedItemsNotifications:`), corrupting BRQuery's result index sets until `-[NSMutableIndexSet addIndexesInRange:]` throws. The launch+10s timing is exactly the window where the initial gather overlaps the first batched update rounds. Serializing the queue closes the race.

While investigating, we also found a **separate, latent signing defect**: the macOS release helper re-signs the app with only the committed entitlement plist, which drops `com.apple.application-identifier` and `com.apple.developer.team-identifier` — identity entitlements Apple requires for Developer ID apps using iCloud, sourced from the embedded provisioning profile. The crash report shows CloudDocs was in fact accepting the broken-signature beta (the query was live when it crashed), so this is not what caused the abort — but the installed beta's signature is verifiably missing the identity entitlements, and this PR fixes and guards that too. The dev flavor also inherited the stable provisioning profile through Tauri's config merge, despite intentionally disabling iCloud entitlements.

## Before -> After

| Surface | Before | After |
| --- | --- | --- |
| iCloud metadata watch | Default concurrent operation queue | Explicitly serial queue before query startup |
| Stable/beta re-signing | Static app entitlements only | Static entitlements plus the matching embedded profile's app/team identity |
| Dev bundle | Inherited stable provisioning profile | No provisioning profile |
| Release verification | Generic code-signature validity | Also compares signed identity entitlements with the actual embedded profile |

## Changes

1. **The crash fix:** set the iCloud metadata query's `NSOperationQueue.maxConcurrentOperationCount` to `1`, serializing CloudDocs query processing and notification delivery on the queue it demonstrably shares.
2. Decode the provisioning profile embedded in each built stable/beta app, validate that its application identifier exactly matches the resolved flavor bundle ID, and merge only the profile-owned application/team identifiers into the configured entitlement plist.
3. Reject missing, conflicting, or wrong-flavor profile identity values before re-signing. Wildcard grants such as keychain access groups are deliberately not copied.
4. Verify the finalized signature retained both identity values from the actual embedded profile.
5. Remove the stable profile from the dev overlay using Tauri's merge-patch deletion semantics and document the release behavior.

## Tests

- Added release-script coverage for stable/beta/dev profile resolution, selective identity merging, exact bundle-ID matching, missing/conflicting identities, and final-signature validation.
- The existing iCloud watcher tests are pure-Rust snapshot/diff tests — they confirm the serial-queue change compiles but do **not** exercise the Objective-C queue or the concurrency itself. A manual soak is owed before calling the crash fixed: open an iCloud graph with a few thousand notes on a fresh machine so the initial gather overlaps update rounds (the exact window this crash lived in) and confirm no abort.

## Verification

- `pnpm --filter @reflect/desktop test --run scripts/release-macos.test.mjs` — 38 tests passed.
- `pnpm check` — typecheck, Oxlint, and ESLint passed (two pre-existing max-lines warnings).
- `pnpm --filter @reflect/desktop sidecar` — required desktop sidecars staged successfully.
- `cargo test -p reflect-open --lib icloud::watch` — 7 tests passed.
- `cargo fmt --package reflect-open -- --check` — passed.
- `git diff --check` — passed.
- Decoded both committed Developer ID profiles through the production `security cms` / `plutil` path and verified their stable/beta identities.
- Confirmed the new verifier rejects the currently installed broken beta signature.
- Signed and verified a temporary beta app with the local Developer ID certificate; the repaired application/team entitlements survived code signing.

## Risk / Rollout

There is no data migration or markdown change. The native behavior change only serializes metadata-query work on the queue CloudDocs already schedules onto; the cost is that gather-round enumeration now blocks update delivery briefly, which the existing 2-second batching interval already dominates. The signing change affects the next stable/beta artifacts; the release verifier now fails the build if a profile and flavor diverge or if code signing drops either identity entitlement.

## Note

This relands #842, which was merged into `next` after that branch was retired — the fix never reached `master`. This is a clean cherry-pick of the squash commit (`3d0eae96`) onto `master`; the release-script tests (38), `icloud::watch` tests (7), and `cargo fmt --check` were re-run green on the `master` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes native iCloud threading and the macOS release codesign path; mistakes could affect iCloud stability or block/ship broken beta/stable builds, but logic is guarded by new tests and pre-sign checks.
> 
> **Overview**
> Fixes a **~10s post-launch crash** when an iCloud-backed graph is open by forcing the `NSMetadataQuery` delivery queue to **serial** (`maxConcurrentOperationCount = 1`), so CloudDocs gather/update work cannot run concurrently on the client queue and corrupt BRQuery index sets.
> 
> **macOS release signing** now reads each stable/beta app’s **embedded provisioning profile**, validates its application identifier against the flavor bundle ID, merges only **`com.apple.application-identifier`** and **`com.apple.developer.team-identifier`** into the entitlement plist used for re-signing (not wildcard profile grants), and **fails verify** if the signed app dropped those values. **Reflect Dev** explicitly clears `embedded.provisionprofile` so it no longer inherits the stable profile.
> 
> Adds **release-script unit tests** for profile resolution, merge/reject rules, and post-sign checks; **docs** describe the updated re-sign/verify flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65f11773944e824eeb1838a2d79a182cbd87906a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS signing and verification to ensure app entitlements match the embedded provisioning profile.
  * Prevented signing mismatches that could cause release verification or installation failures.
  * Improved iCloud file monitoring stability by preventing concurrent index updates that could cause crashes.

* **Documentation**
  * Updated macOS distribution guidance to reflect the latest signing, notarization, and verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->