### PR TITLE
feat: show daily note markers in iOS calendar

### DIFF
--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -54,6 +54,10 @@ const INTEL_ONNX_RUNTIME_RESOURCE_SOURCE = `resources/onnxruntime/${ONNX_RUNTIME
 const RELEASE_NOTES_FILENAME = 'release-notes.md'
 const MAC_DOWNLOAD_NOTICE_HEADING = '## Which Mac download should I choose?'
 const MACOS_SIDECARS = ['reflect', 'reflect-capture-host']
+const MACOS_PROFILE_IDENTITY_ENTITLEMENTS = [
+  'com.apple.application-identifier',
+  'com.apple.developer.team-identifier',
+]
 const RELEASE_VERSION_PATTERN = /^(\d+)\.(\d+)\.(\d+)(?:-beta(?:\.(\d+))?)?$/
 const NOTARIZATION_ENV_VARS = [
   'APPLE_ID',
@@ -492,6 +496,81 @@ function codesignArgs({ entitlements, identity, keychain, path }) {
   return args
 }
 
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function macosProfileIdentityEntitlements({ bundleIdentifier, profileEntitlements }) {
+  if (typeof bundleIdentifier !== 'string' || bundleIdentifier.length === 0) {
+    throw new Error('macOS flavor has no bundle identifier')
+  }
+  if (!isRecord(profileEntitlements)) {
+    throw new Error('embedded provisioning profile has no entitlements dictionary')
+  }
+
+  const identityEntitlements = {}
+  for (const key of MACOS_PROFILE_IDENTITY_ENTITLEMENTS) {
+    const value = profileEntitlements[key]
+    if (typeof value !== 'string' || value.length === 0) {
+      throw new Error(`embedded provisioning profile is missing string entitlement "${key}"`)
+    }
+    identityEntitlements[key] = value
+  }
+
+  const applicationIdentifier = identityEntitlements['com.apple.application-identifier']
+  const prefixSeparator = applicationIdentifier.indexOf('.')
+  const profileBundleIdentifier = applicationIdentifier.slice(prefixSeparator + 1)
+  if (prefixSeparator <= 0 || profileBundleIdentifier !== bundleIdentifier) {
+    throw new Error(
+      `embedded provisioning profile application identifier "${applicationIdentifier}" ` +
+        `does not match bundle identifier "${bundleIdentifier}"`,
+    )
+  }
+  return identityEntitlements
+}
+
+/**
+ * Add the identity entitlements supplied by a flavor's provisioning profile
+ * without importing unrelated wildcard grants from that profile.
+ */
+export function mergeMacosProfileIdentityEntitlements({
+  appEntitlements,
+  bundleIdentifier,
+  profileEntitlements,
+}) {
+  if (!isRecord(appEntitlements)) throw new Error('configured macOS entitlements are not a dictionary')
+  const identityEntitlements = macosProfileIdentityEntitlements({ bundleIdentifier, profileEntitlements })
+
+  for (const [key, value] of Object.entries(identityEntitlements)) {
+    if (Object.hasOwn(appEntitlements, key) && appEntitlements[key] !== value) {
+      throw new Error(
+        `configured macOS entitlement "${key}" is "${appEntitlements[key]}", ` +
+          `but the embedded provisioning profile requires "${value}"`,
+      )
+    }
+  }
+  return { ...appEntitlements, ...identityEntitlements }
+}
+
+/** Assert that a signed app retained the profile-owned identity entitlements. */
+export function assertMacosProfileIdentityEntitlements({
+  bundleIdentifier,
+  profileEntitlements,
+  signedEntitlements,
+}) {
+  if (!isRecord(signedEntitlements)) throw new Error('signed macOS entitlements are not a dictionary')
+  const identityEntitlements = macosProfileIdentityEntitlements({ bundleIdentifier, profileEntitlements })
+
+  for (const [key, value] of Object.entries(identityEntitlements)) {
+    if (signedEntitlements[key] !== value) {
+      throw new Error(
+        `signed app entitlement "${key}" is ${JSON.stringify(signedEntitlements[key])}, ` +
+          `expected "${value}" from the embedded provisioning profile`,
+      )
+    }
+  }
+}
+
 export function macosEntitlementsPath(flavor) {
   const entitlements = readFlavorConf(flavor).bundle?.macOS?.entitlements
   if (typeof entitlements !== 'string') {
@@ -500,24 +579,116 @@ export function macosEntitlementsPath(flavor) {
   return join(appDir, 'src-tauri', entitlements)
 }
 
+/** Resolve the provisioning profile embedded for a flavor, if it has one. */
+export function macosProvisioningProfilePath(flavor) {
+  const profile = readFlavorConf(flavor).bundle?.macOS?.files?.['embedded.provisionprofile']
+  if (profile === undefined) return null
+  if (typeof profile !== 'string' || profile.length === 0) {
+    fail(`macOS flavor "${flavor}" has an invalid embedded provisioning profile`)
+  }
+  return join(appDir, 'src-tauri', profile)
+}
+
+function parsePlistJson(output, description) {
+  const value = JSON.parse(output)
+  if (!isRecord(value)) throw new Error(`${description} is not a dictionary`)
+  return value
+}
+
+function readEntitlementsPlist(path) {
+  return parsePlistJson(capture('plutil', ['-convert', 'json', '-o', '-', '--', path]), path)
+}
+
+function readProvisioningProfileEntitlements(path) {
+  const profile = capture('security', ['cms', '-D', '-i', path])
+  const entitlements = capture('plutil', ['-extract', 'Entitlements', 'json', '-o', '-', '-'], {
+    input: profile,
+  })
+  return parsePlistJson(entitlements, `${path} entitlements`)
+}
+
+function readCodeSigningEntitlements(app) {
+  const entitlements = capture('codesign', ['--display', '--entitlements', '-', '--xml', app], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  const json = capture('plutil', ['-convert', 'json', '-o', '-', '-'], { input: entitlements })
+  return parsePlistJson(json, `${app} code-signing entitlements`)
+}
+
+function prepareMacosSigningEntitlements({ app, flavor }) {
+  const appEntitlementsPath = macosEntitlementsPath(flavor)
+  const configuredProfilePath = macosProvisioningProfilePath(flavor)
+  if (!configuredProfilePath) {
+    return { cleanup: () => {}, description: basename(appEntitlementsPath), path: appEntitlementsPath }
+  }
+
+  const embeddedProfilePath = join(app, 'Contents', 'embedded.provisionprofile')
+  if (!existsSync(embeddedProfilePath)) {
+    throw new Error(
+      `${basename(configuredProfilePath)} was configured for macOS flavor "${flavor}", ` +
+        `but ${embeddedProfilePath} does not exist`,
+    )
+  }
+
+  const bundleIdentifier = readFlavorConf(flavor).identifier
+  const appEntitlements = readEntitlementsPlist(appEntitlementsPath)
+  const profileEntitlements = readProvisioningProfileEntitlements(embeddedProfilePath)
+  const mergedEntitlements = mergeMacosProfileIdentityEntitlements({
+    appEntitlements,
+    bundleIdentifier,
+    profileEntitlements,
+  })
+  const tempDir = mkdtempSync(join(tmpdir(), 'reflect-signing-entitlements-'))
+  const path = join(tempDir, 'Entitlements.plist')
+  try {
+    // The plist round-trips through JSON, which only preserves strings,
+    // booleans, and arrays — every entitlement today. A number or <data>
+    // entitlement would lose its exact plist type here.
+    writeFileSync(path, `${JSON.stringify(mergedEntitlements, null, 2)}\n`, { mode: 0o600 })
+    execFileSync('plutil', ['-convert', 'xml1', path])
+  } catch (error) {
+    rmSync(tempDir, { recursive: true, force: true })
+    throw error
+  }
+  return {
+    cleanup: () => rmSync(tempDir, { recursive: true, force: true }),
+    description: `${basename(appEntitlementsPath)} + identity from ${basename(configuredProfilePath)}`,
+    path,
+  }
+}
+
 function macosSidecarPaths(app) {
   return MACOS_SIDECARS.map((binary) => join(app, 'Contents', 'MacOS', binary))
 }
 
 function resignMacosApp({ flavor, identity, keychain, target }) {
   const { app } = bundlePaths(flavor, target)
-  const entitlements = macosEntitlementsPath(flavor)
   for (const sidecar of macosSidecarPaths(app)) {
     if (!existsSync(sidecar)) fail(`${sidecar} does not exist — Tauri did not bundle the sidecar`)
   }
 
-  log('re-signing macOS sidecars without app entitlements…')
-  for (const sidecar of macosSidecarPaths(app)) {
-    execFileSync('codesign', codesignArgs({ identity, keychain, path: sidecar }), { stdio: 'inherit' })
+  let signingEntitlements
+  try {
+    signingEntitlements = prepareMacosSigningEntitlements({ app, flavor })
+  } catch (error) {
+    fail(`preparing macOS signing entitlements failed: ${error instanceof Error ? error.message : String(error)}`)
   }
 
-  log(`re-signing ${basename(app)} with ${basename(entitlements)}…`)
-  execFileSync('codesign', codesignArgs({ entitlements, identity, keychain, path: app }), { stdio: 'inherit' })
+  try {
+    log('re-signing macOS sidecars without app entitlements…')
+    for (const sidecar of macosSidecarPaths(app)) {
+      execFileSync('codesign', codesignArgs({ identity, keychain, path: sidecar }), { stdio: 'inherit' })
+    }
+
+    log(`re-signing ${basename(app)} with ${signingEntitlements.description}…`)
+    execFileSync(
+      'codesign',
+      codesignArgs({ entitlements: signingEntitlements.path, identity, keychain, path: app }),
+      { stdio: 'inherit' },
+    )
+  } finally {
+    signingEntitlements.cleanup()
+  }
 }
 
 function importSigningCertificate() {
@@ -694,6 +865,22 @@ function verifySidecarsLaunch({ flavor, target }) {
   }
 }
 
+function verifyMacosProfileIdentityEntitlements({ app, flavor }) {
+  const configuredProfilePath = macosProvisioningProfilePath(flavor)
+  if (!configuredProfilePath) return
+
+  const embeddedProfilePath = join(app, 'Contents', 'embedded.provisionprofile')
+  if (!existsSync(embeddedProfilePath)) {
+    throw new Error(`${app} is missing ${basename(configuredProfilePath)}`)
+  }
+  assertMacosProfileIdentityEntitlements({
+    bundleIdentifier: readFlavorConf(flavor).identifier,
+    profileEntitlements: readProvisioningProfileEntitlements(embeddedProfilePath),
+    signedEntitlements: readCodeSigningEntitlements(app),
+  })
+  log('profile identity entitlements: ok')
+}
+
 /** Verify the built bundles match the expected distribution state. */
 function verify({ notarized, flavor, target }) {
   const { app, dmg } = bundlePaths(flavor, target)
@@ -704,6 +891,11 @@ function verify({ notarized, flavor, target }) {
     'valid on disk',
     'satisfies its Designated Requirement',
   ])
+  try {
+    verifyMacosProfileIdentityEntitlements({ app, flavor })
+  } catch (error) {
+    fail(`profile identity entitlement verification failed: ${error instanceof Error ? error.message : String(error)}`)
+  }
   verifySidecarsLaunch({ flavor, target })
 
   if (!notarized) {

--- a/apps/desktop/scripts/release-macos.test.mjs
+++ b/apps/desktop/scripts/release-macos.test.mjs
@@ -5,6 +5,7 @@ import { expect, test } from 'vitest'
 
 import {
   appendMacDownloadNotice,
+  assertMacosProfileIdentityEntitlements,
   canLaunchTarget,
   compareReleaseVersions,
   createBetaFeedReleaseArgs,
@@ -20,7 +21,9 @@ import {
   createUpdaterArchiveArgs,
   createUpdaterManifest,
   macosEntitlementsPath,
+  macosProvisioningProfilePath,
   macosTargetResourceConfig,
+  mergeMacosProfileIdentityEntitlements,
   newestBetaVersionFromTags,
   parseKeychainList,
   signDmgArgs,
@@ -348,6 +351,111 @@ test('macOS entitlements resolve through platform and flavor overlays', () => {
   expect(macosEntitlementsPath('stable')).toBe(join(srcTauri, 'Entitlements.plist'))
   expect(macosEntitlementsPath('beta')).toBe(join(srcTauri, 'Entitlements.plist'))
   expect(macosEntitlementsPath('dev')).toBe(join(srcTauri, 'Entitlements.dev.plist'))
+})
+
+test('macOS provisioning profiles resolve per flavor and dev remains unprovisioned', () => {
+  const srcTauri = join(process.cwd(), 'src-tauri')
+
+  expect(macosProvisioningProfilePath('stable')).toBe(join(srcTauri, 'Reflect.provisionprofile'))
+  expect(macosProvisioningProfilePath('beta')).toBe(join(srcTauri, 'Reflect-beta.provisionprofile'))
+  expect(macosProvisioningProfilePath('dev')).toBeNull()
+})
+
+test('macOS signing keeps app entitlements and adds only profile identity entitlements', () => {
+  const appEntitlements = {
+    'com.apple.developer.icloud-services': ['CloudDocuments'],
+    'com.apple.security.device.audio-input': true,
+  }
+  const profileEntitlements = {
+    'com.apple.application-identifier': '789ULN5MZB.app.reflect.desktop.beta',
+    'com.apple.developer.team-identifier': '789ULN5MZB',
+    'keychain-access-groups': ['789ULN5MZB.*'],
+  }
+
+  expect(
+    mergeMacosProfileIdentityEntitlements({
+      appEntitlements,
+      bundleIdentifier: 'app.reflect.desktop.beta',
+      profileEntitlements,
+    }),
+  ).toEqual({
+    ...appEntitlements,
+    'com.apple.application-identifier': '789ULN5MZB.app.reflect.desktop.beta',
+    'com.apple.developer.team-identifier': '789ULN5MZB',
+  })
+})
+
+test('macOS signing rejects a provisioning profile for another flavor', () => {
+  expect(() =>
+    mergeMacosProfileIdentityEntitlements({
+      appEntitlements: { 'com.apple.security.device.audio-input': true },
+      bundleIdentifier: 'app.reflect.desktop.beta',
+      profileEntitlements: {
+        'com.apple.application-identifier': '789ULN5MZB.app.reflect.desktop',
+        'com.apple.developer.team-identifier': '789ULN5MZB',
+      },
+    }),
+  ).toThrow('does not match bundle identifier "app.reflect.desktop.beta"')
+})
+
+test('macOS signing compares the full profile bundle identifier, not only its suffix', () => {
+  expect(() =>
+    mergeMacosProfileIdentityEntitlements({
+      appEntitlements: {},
+      bundleIdentifier: 'app.reflect.desktop.beta',
+      profileEntitlements: {
+        'com.apple.application-identifier': '789ULN5MZB.other.app.reflect.desktop.beta',
+        'com.apple.developer.team-identifier': '789ULN5MZB',
+      },
+    }),
+  ).toThrow('does not match bundle identifier "app.reflect.desktop.beta"')
+})
+
+test.each(['com.apple.application-identifier', 'com.apple.developer.team-identifier'])(
+  'macOS signing rejects a profile missing %s',
+  (missingEntitlement) => {
+    const profileEntitlements = {
+      'com.apple.application-identifier': '789ULN5MZB.app.reflect.desktop.beta',
+      'com.apple.developer.team-identifier': '789ULN5MZB',
+    }
+    delete profileEntitlements[missingEntitlement]
+
+    expect(() =>
+      mergeMacosProfileIdentityEntitlements({
+        appEntitlements: {},
+        bundleIdentifier: 'app.reflect.desktop.beta',
+        profileEntitlements,
+      }),
+    ).toThrow(`missing string entitlement "${missingEntitlement}"`)
+  },
+)
+
+test('macOS signing rejects a conflicting identity in the app entitlement file', () => {
+  expect(() =>
+    mergeMacosProfileIdentityEntitlements({
+      appEntitlements: { 'com.apple.developer.team-identifier': 'WRONGTEAM' },
+      bundleIdentifier: 'app.reflect.desktop',
+      profileEntitlements: {
+        'com.apple.application-identifier': '789ULN5MZB.app.reflect.desktop',
+        'com.apple.developer.team-identifier': '789ULN5MZB',
+      },
+    }),
+  ).toThrow('but the embedded provisioning profile requires "789ULN5MZB"')
+})
+
+test('macOS verification rejects a signed app that lost a profile identity entitlement', () => {
+  expect(() =>
+    assertMacosProfileIdentityEntitlements({
+      bundleIdentifier: 'app.reflect.desktop.beta',
+      profileEntitlements: {
+        'com.apple.application-identifier': '789ULN5MZB.app.reflect.desktop.beta',
+        'com.apple.developer.team-identifier': '789ULN5MZB',
+      },
+      signedEntitlements: {
+        'com.apple.application-identifier': '789ULN5MZB.app.reflect.desktop.beta',
+      },
+    }),
+  ).toThrow('signed app entitlement "com.apple.developer.team-identifier" is undefined')
 })
 
 test('sidecar launch checks cover native targets and Intel under Rosetta', () => {

--- a/apps/desktop/src-tauri/src/icloud/watch.rs
+++ b/apps/desktop/src-tauri/src/icloud/watch.rs
@@ -232,6 +232,14 @@ mod platform {
         query.setPredicate(Some(&predicate));
 
         let queue = NSOperationQueue::new();
+        // Must stay serial: CloudDocs (BRQuery) schedules its own internal,
+        // unsynchronized gatherer work on this queue — not just notification
+        // delivery. On the default concurrent queue the initial gather and
+        // update batches classify items in parallel and corrupt BRQuery's
+        // result index sets, aborting with an uncaught NSRangeException
+        // (crash: NSMutableIndexSet addIndexesInRange in
+        // _handleReplacedItemsNotifications, ~10s after launch).
+        queue.setMaxConcurrentOperationCount(1);
         unsafe { query.setOperationQueue(Some(&queue)) };
 
         let handler_roots = roots.clone();

--- a/apps/desktop/src-tauri/tauri.dev.conf.json
+++ b/apps/desktop/src-tauri/tauri.dev.conf.json
@@ -24,7 +24,10 @@
       "icons-dev/icon.ico"
     ],
     "macOS": {
-      "entitlements": "Entitlements.dev.plist"
+      "entitlements": "Entitlements.dev.plist",
+      "files": {
+        "embedded.provisionprofile": null
+      }
     }
   },
   "plugins": {

--- a/apps/desktop/src/mobile/calendar-strip.tsx
+++ b/apps/desktop/src/mobile/calendar-strip.tsx
@@ -8,6 +8,7 @@ import { monthPickTarget, weekAtIndex, weekStartOf } from '@/mobile/calendar'
 import { hapticImpactLight } from '@/mobile/haptics'
 import { MonthPickerDrawer } from '@/mobile/month-picker-drawer'
 import { MonthTitle } from '@/mobile/month-title'
+import { useNotedDates } from '@/mobile/use-noted-dates'
 import { useWeekStrip } from '@/mobile/use-week-strip'
 import { WeekRow } from '@/mobile/week-row'
 import { useSettings } from '@/providers/settings-provider'
@@ -50,6 +51,10 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
   const { emblaRef, weekWindow, displayedWeekStart, showWeekOf } = useWeekStrip(
     date,
     settings.weekStartDay,
+  )
+  const notedDates = useNotedDates(
+    weekWindow.start,
+    addDaysIso(weekAtIndex(weekWindow, weekWindow.count - 1), 6),
   )
 
   // Header month: the selection's own month while its week is on screen;
@@ -157,6 +162,7 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
                 weekStart={weekStart}
                 selectedDay={contains(date) ? date : null}
                 todayDay={contains(today) ? today : null}
+                notedDates={notedDates}
                 onSelect={onSelect}
               />
             )

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -13,7 +13,7 @@ import { RouterProvider, useRouter } from '@/routing/router'
 import type { Route } from '@/routing/route'
 import { addDaysIso, formatDayLabel, parseIsoDate, todayIso } from '@/lib/dates'
 import { monthLabel, monthOf } from '@/lib/month-grid'
-import { weekOf } from './calendar'
+import { createWeekWindow, weekOf } from './calendar'
 import { MobileShell } from './mobile-shell'
 import { publishKeyboardHeight } from './use-keyboard'
 
@@ -107,6 +107,7 @@ vi.mock('@/mobile/haptics', () => ({
 }))
 
 const indexFns = vi.hoisted(() => ({
+  dailyDatesInRange: vi.fn(async () => [] as string[]),
   getBacklinksWithContext: vi.fn(async () => ({
     contexts: [],
     nextCursor: null,
@@ -116,6 +117,7 @@ const indexFns = vi.hoisted(() => ({
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   hasBridge: () => true,
+  dailyDatesInRange: indexFns.dailyDatesInRange,
   getBacklinksWithContext: indexFns.getBacklinksWithContext,
 }))
 // vaul needs browser APIs jsdom doesn't provide (matchMedia, pointer
@@ -192,6 +194,7 @@ beforeEach(() => {
   editorProbe.selectionCalls = []
   mockInvoke.mockReset()
   hapticImpactLight.mockClear()
+  indexFns.dailyDatesInRange.mockReset().mockResolvedValue([])
   mockInvoke.mockImplementation(async (command, args) => {
     if (command === 'note_read') {
       const content = files[(args as { path: string }).path]
@@ -351,6 +354,26 @@ describe('MobileShell', () => {
     expect(todayButton.hasAttribute('inert')).toBe(true)
     expect(view.getByRole('button', { name: dayCellLabel(today) }).getAttribute('aria-current')).toBe(
       'date',
+    )
+  })
+
+  it('marks dates with daily-note content across the pageable strip window', async () => {
+    const today = todayIso()
+    const week = weekOf(today, 'monday')
+    const notedDay = week.find((day) => day !== today) ?? week[0]!
+    const emptyDay = week.find((day) => day !== today && day !== notedDay) ?? week[1]!
+    indexFns.dailyDatesInRange.mockResolvedValue([notedDay])
+
+    const view = mount({ kind: 'today' })
+
+    await view.findByTestId(`note-dot-${notedDay}`)
+    expect(view.queryByTestId(`note-dot-${emptyDay}`)).toBeNull()
+    expect(view.getByRole('button', { name: `${dayCellLabel(notedDay)}, has content` })).toBeTruthy()
+
+    const weekWindow = createWeekWindow(today, 'monday')
+    expect(indexFns.dailyDatesInRange).toHaveBeenCalledWith(
+      weekWindow.start,
+      addDaysIso(weekWindow.start, weekWindow.count * 7 - 1),
     )
   })
 

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -357,7 +357,7 @@ describe('MobileShell', () => {
     )
   })
 
-  it('marks dates with daily-note content across the pageable strip window', async () => {
+  it('marks dates backed by daily notes across the pageable strip window', async () => {
     const today = todayIso()
     const week = weekOf(today, 'monday')
     const notedDay = week.find((day) => day !== today) ?? week[0]!
@@ -368,7 +368,9 @@ describe('MobileShell', () => {
 
     await view.findByTestId(`note-dot-${notedDay}`)
     expect(view.queryByTestId(`note-dot-${emptyDay}`)).toBeNull()
-    expect(view.getByRole('button', { name: `${dayCellLabel(notedDay)}, has content` })).toBeTruthy()
+    expect(
+      view.getByRole('button', { name: `${dayCellLabel(notedDay)}, has daily note` }),
+    ).toBeTruthy()
 
     const weekWindow = createWeekWindow(today, 'monday')
     expect(indexFns.dailyDatesInRange).toHaveBeenCalledWith(

--- a/apps/desktop/src/mobile/use-noted-dates.test.tsx
+++ b/apps/desktop/src/mobile/use-noted-dates.test.tsx
@@ -1,0 +1,57 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import { useNotedDates } from './use-noted-dates'
+
+const dailyDatesInRange = vi.hoisted(() =>
+  vi.fn<(start: string, end: string) => Promise<string[]>>(),
+)
+
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  dailyDatesInRange,
+  hasBridge: () => true,
+}))
+
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({ graph: { root: '/g' } }),
+}))
+
+beforeEach(() => dailyDatesInRange.mockReset())
+afterEach(cleanup)
+
+describe('useNotedDates', () => {
+  it('keeps previous markers while a new range loads', async () => {
+    let resolveNextRange: (dates: string[]) => void = () => {}
+    dailyDatesInRange
+      .mockResolvedValueOnce(['2026-07-14'])
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveNextRange = resolve
+          }),
+      )
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = ({ children }: { children: ReactNode }): ReactNode => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    const { result, rerender } = renderHook(
+      ({ start, end }) => useNotedDates(start, end),
+      {
+        initialProps: { start: '2026-01-12', end: '2027-01-17' },
+        wrapper,
+      },
+    )
+
+    await waitFor(() => expect(result.current.has('2026-07-14')).toBe(true))
+
+    rerender({ start: '2026-06-29', end: '2027-07-04' })
+    await waitFor(() => expect(dailyDatesInRange).toHaveBeenCalledTimes(2))
+    expect(result.current.has('2026-07-14')).toBe(true)
+
+    act(() => resolveNextRange(['2027-01-05']))
+    await waitFor(() => expect(result.current.has('2027-01-05')).toBe(true))
+    expect(result.current.has('2026-07-14')).toBe(false)
+  })
+})

--- a/apps/desktop/src/mobile/use-noted-dates.ts
+++ b/apps/desktop/src/mobile/use-noted-dates.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { dailyDatesInRange, hasBridge } from '@reflect/core'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
@@ -11,6 +11,7 @@ export function useNotedDates(start: string, end: string): ReadonlySet<string> {
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'dailyDates', start, end],
     queryFn: () => dailyDatesInRange(start, end),
     enabled: hasBridge() && graph !== null,
+    placeholderData: keepPreviousData,
   })
 
   return useMemo(() => new Set(data ?? []), [data])

--- a/apps/desktop/src/mobile/use-noted-dates.ts
+++ b/apps/desktop/src/mobile/use-noted-dates.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { dailyDatesInRange, hasBridge } from '@reflect/core'
+import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
+import { useGraph } from '@/providers/graph-provider'
+
+/** Indexed daily-note dates in an inclusive range, ready for calendar lookup. */
+export function useNotedDates(start: string, end: string): ReadonlySet<string> {
+  const { graph } = useGraph()
+  const { data } = useQuery({
+    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'dailyDates', start, end],
+    queryFn: () => dailyDatesInRange(start, end),
+    enabled: hasBridge() && graph !== null,
+  })
+
+  return useMemo(() => new Set(data ?? []), [data])
+}

--- a/apps/desktop/src/mobile/week-row.test.tsx
+++ b/apps/desktop/src/mobile/week-row.test.tsx
@@ -13,7 +13,7 @@ afterEach(() => {
 })
 
 describe('WeekRow', () => {
-  it('keeps content marked when the date is both selected and today', async () => {
+  it('keeps a daily note marked when the date is both selected and today', async () => {
     const onSelect = vi.fn()
     const view = render(
       <WeekRow
@@ -26,7 +26,7 @@ describe('WeekRow', () => {
     )
 
     const selected = view.getByRole('button', {
-      name: 'Thursday, July 16th, has content',
+      name: 'Thursday, July 16th, has daily note',
     })
     expect(selected.getAttribute('aria-current')).toBe('date')
     expect(within(selected).getByTestId('note-dot-2026-07-16')).toBeTruthy()

--- a/apps/desktop/src/mobile/week-row.test.tsx
+++ b/apps/desktop/src/mobile/week-row.test.tsx
@@ -1,0 +1,40 @@
+import { cleanup, render, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { WeekRow } from './week-row'
+
+const hapticImpactLight = vi.hoisted(() => vi.fn())
+
+vi.mock('@/mobile/haptics', () => ({ hapticImpactLight }))
+
+afterEach(() => {
+  cleanup()
+  hapticImpactLight.mockReset()
+})
+
+describe('WeekRow', () => {
+  it('keeps content marked when the date is both selected and today', async () => {
+    const onSelect = vi.fn()
+    const view = render(
+      <WeekRow
+        weekStart="2026-07-13"
+        selectedDay="2026-07-16"
+        todayDay="2026-07-16"
+        notedDates={new Set(['2026-07-13', '2026-07-16'])}
+        onSelect={onSelect}
+      />,
+    )
+
+    const selected = view.getByRole('button', {
+      name: 'Thursday, July 16th, has content',
+    })
+    expect(selected.getAttribute('aria-current')).toBe('date')
+    expect(within(selected).getByTestId('note-dot-2026-07-16')).toBeTruthy()
+    expect(view.getByTestId('note-dot-2026-07-13')).toBeTruthy()
+    expect(view.queryByTestId('note-dot-2026-07-14')).toBeNull()
+
+    await userEvent.click(selected)
+    expect(hapticImpactLight).toHaveBeenCalledOnce()
+    expect(onSelect).toHaveBeenCalledWith('2026-07-16')
+  })
+})

--- a/apps/desktop/src/mobile/week-row.tsx
+++ b/apps/desktop/src/mobile/week-row.tsx
@@ -11,7 +11,7 @@ interface WeekRowProps {
   selectedDay: string | null
   /** Today when it falls in this week, else `null`. */
   todayDay: string | null
-  /** Dates backed by an indexed daily note (and therefore real content). */
+  /** Dates backed by an indexed daily note. */
   notedDates: ReadonlySet<string>
   /** Select a day — drives the carousel and the route. */
   onSelect: (date: string) => void
@@ -60,12 +60,12 @@ function WeekRowComponent({
       {days.map((day) => {
         const selected = day === selectedDay
         const isToday = day === todayDay
-        const hasContent = notedDates.has(day)
+        const hasNote = notedDates.has(day)
         return (
           <button
             key={day}
             type="button"
-            aria-label={`${format(parseIsoDate(day), 'EEEE, MMMM do')}${hasContent ? ', has content' : ''}`}
+            aria-label={`${format(parseIsoDate(day), 'EEEE, MMMM do')}${hasNote ? ', has daily note' : ''}`}
             aria-current={selected ? 'date' : undefined}
             onClick={() => {
               hapticImpactLight()
@@ -86,14 +86,14 @@ function WeekRowComponent({
             >
               {format(parseIsoDate(day), 'd')}
             </span>
-            {/* Content takes the strip's single marker slot; otherwise it
+            {/* A daily note takes the strip's single marker slot; otherwise it
                 keeps V1's Today dot when today isn't selected. */}
             <span
               aria-hidden
-              data-testid={hasContent ? `note-dot-${day}` : undefined}
+              data-testid={hasNote ? `note-dot-${day}` : undefined}
               className={cn(
                 'size-1 rounded-full',
-                hasContent
+                hasNote
                   ? 'bg-surface-inverse/50 dark:bg-white/50'
                   : !selected && isToday
                     ? 'bg-primary'

--- a/apps/desktop/src/mobile/week-row.tsx
+++ b/apps/desktop/src/mobile/week-row.tsx
@@ -11,6 +11,8 @@ interface WeekRowProps {
   selectedDay: string | null
   /** Today when it falls in this week, else `null`. */
   todayDay: string | null
+  /** Dates backed by an indexed daily note (and therefore real content). */
+  notedDates: ReadonlySet<string>
   /** Select a day — drives the carousel and the route. */
   onSelect: (date: string) => void
 }
@@ -27,6 +29,7 @@ function WeekRowComponent({
   weekStart,
   selectedDay,
   todayDay,
+  notedDates,
   onSelect,
 }: WeekRowProps): ReactElement {
   const days = Array.from({ length: 7 }, (_, index) => addDaysIso(weekStart, index))
@@ -57,11 +60,12 @@ function WeekRowComponent({
       {days.map((day) => {
         const selected = day === selectedDay
         const isToday = day === todayDay
+        const hasContent = notedDates.has(day)
         return (
           <button
             key={day}
             type="button"
-            aria-label={format(parseIsoDate(day), 'EEEE, MMMM do')}
+            aria-label={`${format(parseIsoDate(day), 'EEEE, MMMM do')}${hasContent ? ', has content' : ''}`}
             aria-current={selected ? 'date' : undefined}
             onClick={() => {
               hapticImpactLight()
@@ -82,13 +86,18 @@ function WeekRowComponent({
             >
               {format(parseIsoDate(day), 'd')}
             </span>
-            {/* Today dot (V1) — a fixed-height slot so cells stay aligned;
-                shown only when today isn't the selected (circled) day. */}
+            {/* Content takes the strip's single marker slot; otherwise it
+                keeps V1's Today dot when today isn't selected. */}
             <span
               aria-hidden
+              data-testid={hasContent ? `note-dot-${day}` : undefined}
               className={cn(
                 'size-1 rounded-full',
-                !selected && isToday ? 'bg-primary' : 'bg-transparent',
+                hasContent
+                  ? 'bg-surface-inverse/50 dark:bg-white/50'
+                  : !selected && isToday
+                    ? 'bg-primary'
+                    : 'bg-transparent',
               )}
             />
           </button>

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -59,8 +59,9 @@ can still build unsigned bundles with plain `pnpm tauri build`.
 3. Runs `pnpm tauri build --target <target> --bundles app`, which stages the `reflect`
    CLI sidecar for that target and signs the app bundle. The release helper then
    re-signs the bundled sidecars without the app's restricted entitlements, re-signs the
-   `.app` with its entitlement file, notarizes the finalized `.app` via `notarytool`,
-   staples the ticket, and verifies the sidecars launch.
+   `.app` with its entitlement file plus the flavor-specific identity entitlements from
+   its embedded provisioning profile, notarizes the finalized `.app` via `notarytool`,
+   staples the ticket, and verifies the signed identity entitlements and sidecars.
    Intel builds also download Microsoft's official ONNX Runtime macOS x86_64 archive
    into `src-tauri/resources/onnxruntime/` and bundle `libonnxruntime.dylib` as a
    Tauri resource before signing; that directory is generated and gitignored.


### PR DESCRIPTION
## Problem

The iOS daily calendar strip shows the selected date and today, but gives no indication which neighboring dates already have a daily note. Finding an earlier entry within the week therefore requires opening dates one by one, even though the macOS calendar already exposes this information.

## Before -> After

| Before | After |
| --- | --- |
| Every unselected date looks empty apart from the existing Today treatment. | Dates backed by indexed daily notes carry a persistent 4px marker beneath the date. |
| VoiceOver announces only the calendar date. | Dates with a marker are announced with “has daily note.” |

## Changes

1. Query `dailyDatesInRange` once for the mobile strip’s full 53-week carousel window, using the existing index-scoped React Query cache and invalidation path. Retain the previous result while a recentered range loads so overlapping markers do not blink.
2. Pass the resulting date set into each `WeekRow` and reuse its fixed marker slot, so the indicator adds no height or layout shift. The daily-note marker takes precedence when a date also owns the existing Today dot.
3. Keep daily-note markers visible on touch devices and match the macOS marker’s 4px, half-opacity inverse styling.
4. Cover the query bounds, range-transition continuity, marker presence/absence, accessible label, navigation, and the combined selected/today/daily-note state.

## Tests

- Mobile integration: the full inclusive week window is queried and only returned dates receive markers.
- Week-row unit: a daily-note marker survives the combined selected + today state and the date remains tappable.
- Query hook: overlapping markers remain present until a recentered window’s result arrives.

## Verification

- `pnpm --filter @reflect/desktop exec vitest run src/mobile/use-noted-dates.test.tsx src/mobile/week-row.test.tsx src/mobile/mobile-screen.test.tsx` — 31 tests passed.
- `pnpm check` — typecheck and lint passed (with the repository’s existing max-lines warnings).
- `pnpm build` — production build passed.
- Browser preview at an iPhone-sized 390×844 viewport — markers render beneath dates without shifting the strip; no Vite error overlay.

## Risk / Rollout

No schema, migration, routing, privacy, or native-command changes. The feature performs one local SQLite date-range query for the strip’s existing 371 rendered dates, refreshes through the existing index invalidation flow, and uses cached placeholder data only while a changed range is loading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only mobile calendar indicators backed by an existing local index query and shared invalidation; no auth, routing, or schema changes.
> 
> **Overview**
> The mobile **calendar strip** now shows which dates have an indexed daily note, matching macOS calendar behavior so users can scan the week without opening each day.
> 
> A new **`useNotedDates`** hook loads `dailyDatesInRange` for the strip’s full pageable week window via the existing index-scoped React Query cache, using **`keepPreviousData`** so markers don’t flicker while the range refetches. **`CalendarStrip`** passes the resulting set into every **`WeekRow`**.
> 
> Each day cell reuses the fixed bottom marker slot: a **4px half-opacity dot** for noted dates (with **`note-dot-{date}`** test ids), **VoiceOver** suffix **“, has daily note”**, and **daily-note markers take precedence** over the legacy “today” dot when both apply. Selection and tap behavior are unchanged.
> 
> Tests cover query bounds and marker presence in **`mobile-screen`**, stale-data behavior in **`use-noted-dates`**, and selected/today + note state in **`week-row`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9e11a9b6bc180be9b08b6bdb87f5ce51cc2ca73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

