### PR TITLE
ci: build Intel releases on macos-26-intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
             runner: macos-26
             target: aarch64-apple-darwin
           - name: Intel
-            runner: macos-15-intel
+            runner: macos-26-intel
             target: x86_64-apple-darwin
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -113,6 +113,17 @@ function capture(command, args, options = {}) {
   return execFileSync(command, args, { encoding: 'utf8', ...options })
 }
 
+/** Format an error for fail(), keeping any stdout/stderr captured by execFileSync. */
+export function describeError(error) {
+  if (!(error instanceof Error)) return String(error)
+  const parts = [error.message]
+  for (const stream of ['stdout', 'stderr']) {
+    const text = typeof error[stream] === 'string' ? error[stream].trim() : ''
+    if (text) parts.push(`${stream}:\n${text}`)
+  }
+  return parts.join('\n')
+}
+
 /** Run a command and return { status, output } with stdout+stderr combined. */
 function run(command, args) {
   const result = spawnSync(command, args, { encoding: 'utf8' })
@@ -671,7 +682,7 @@ function resignMacosApp({ flavor, identity, keychain, target }) {
   try {
     signingEntitlements = prepareMacosSigningEntitlements({ app, flavor })
   } catch (error) {
-    fail(`preparing macOS signing entitlements failed: ${error instanceof Error ? error.message : String(error)}`)
+    fail(`preparing macOS signing entitlements failed: ${describeError(error)}`)
   }
 
   try {
@@ -894,7 +905,7 @@ function verify({ notarized, flavor, target }) {
   try {
     verifyMacosProfileIdentityEntitlements({ app, flavor })
   } catch (error) {
-    fail(`profile identity entitlement verification failed: ${error instanceof Error ? error.message : String(error)}`)
+    fail(`profile identity entitlement verification failed: ${describeError(error)}`)
   }
   verifySidecarsLaunch({ flavor, target })
 
@@ -1266,8 +1277,7 @@ function generateReleaseNotesBody({ commit, tag }) {
   try {
     generated = JSON.parse(result.stdout)
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    fail(`GitHub release notes response was not JSON: ${message}`)
+    fail(`GitHub release notes response was not JSON: ${describeError(error)}`)
   }
 
   if (!generated || typeof generated !== 'object' || typeof generated.body !== 'string') {
@@ -1433,8 +1443,7 @@ function findNewestPublishedBetaVersion() {
   try {
     return newestBetaVersionFromTags((result.stdout ?? '').split('\n'))
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    fail(message)
+    fail(describeError(error))
   }
 }
 

--- a/apps/desktop/scripts/release-macos.test.mjs
+++ b/apps/desktop/scripts/release-macos.test.mjs
@@ -20,6 +20,7 @@ import {
   createTauriBuildArgs,
   createUpdaterArchiveArgs,
   createUpdaterManifest,
+  describeError,
   macosEntitlementsPath,
   macosProvisioningProfilePath,
   macosTargetResourceConfig,
@@ -565,4 +566,19 @@ test('macOS keychain list output is parsed as paths', () => {
     "/Library/Keychains/System.keychain"
 `),
   ).toEqual(['/Users/runner/Library/Keychains/login.keychain-db', '/Library/Keychains/System.keychain'])
+})
+
+test('described errors keep the stdout and stderr captured by execFileSync', () => {
+  const error = new Error('Command failed: plutil -extract Entitlements json -o - -')
+  error.stdout = '<stdin>: Could not extract value\n'
+  error.stderr = ''
+
+  expect(describeError(error)).toBe(
+    'Command failed: plutil -extract Entitlements json -o - -\nstdout:\n<stdin>: Could not extract value',
+  )
+})
+
+test('described errors without captured output stay a plain message', () => {
+  expect(describeError(new Error('boom'))).toBe('boom')
+  expect(describeError('not an error')).toBe('not an error')
 })

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -322,8 +322,8 @@ Stable installs are unaffected (same identifier and the shipped icon).
 `.github/workflows/release.yml` first runs the publish preflights, then builds two
 signed/notarized macOS artifacts in parallel:
 
-- Apple Silicon: `macos-latest`, `--target=aarch64-apple-darwin`
-- Intel: `macos-15-intel`, `--target=x86_64-apple-darwin`
+- Apple Silicon: `macos-26`, `--target=aarch64-apple-darwin`
+- Intel: `macos-26-intel`, `--target=x86_64-apple-darwin`
 
 Each build job runs the same DMG notarization, Gatekeeper checks, and updater artifact
 signing as a local release, then uploads its artifacts to the workflow. A final publish


### PR DESCRIPTION
Moves the Intel release job from macos-15-intel to macos-26-intel (macOS 15 broke the entitlements merge added in #842, while the same step passes on the macos-26 Apple Silicon job), and makes `release-macos.mjs` failures include the stdout/stderr captured from the failing command so the next environment quirk is not a silent one-liner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS release error messages by preserving captured command output, making failures easier to diagnose.

- **Documentation**
  - Updated macOS CI release instructions to reflect the latest Apple Silicon and Intel build environments.

- **Chores**
  - Updated the Intel macOS release build configuration to use the latest runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->