### PR TITLE
ci: build Intel releases on `macos-26`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,9 +88,6 @@ jobs:
           - name: Apple Silicon
             runner: macos-26
             target: aarch64-apple-darwin
-          # Cross-compiled on the Apple Silicon runner; the sidecar launch
-          # checks run the x86_64 binaries under Rosetta 2, which GitHub's
-          # arm64 macOS images preinstall.
           - name: Intel
             runner: macos-26
             target: x86_64-apple-darwin
@@ -165,7 +162,7 @@ jobs:
           # Both matrix legs run on the same runner image, so rust-cache's
           # default key (OS, rustc, Cargo.lock, job id) would collide across
           # legs and they would clobber each other's caches.
-          key: ${{ matrix.target }}
+          key: ${{ matrix.runner }}-${{ matrix.target }}
           # A failed notarization still compiled everything; keep the cache.
           cache-on-failure: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,9 +159,6 @@ jobs:
       - name: Cache cargo build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          # Both matrix legs run on the same runner image, so rust-cache's
-          # default key (OS, rustc, Cargo.lock, job id) would collide across
-          # legs and they would clobber each other's caches.
           key: ${{ matrix.runner }}-${{ matrix.target }}
           # A failed notarization still compiled everything; keep the cache.
           cache-on-failure: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,11 @@ jobs:
           - name: Apple Silicon
             runner: macos-26
             target: aarch64-apple-darwin
+          # Cross-compiled on the Apple Silicon runner; the sidecar launch
+          # checks run the x86_64 binaries under Rosetta 2, which GitHub's
+          # arm64 macOS images preinstall.
           - name: Intel
-            runner: macos-26-intel
+            runner: macos-26
             target: x86_64-apple-darwin
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -159,6 +162,10 @@ jobs:
       - name: Cache cargo build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
+          # Both matrix legs run on the same runner image, so rust-cache's
+          # default key (OS, rustc, Cargo.lock, job id) would collide across
+          # legs and they would clobber each other's caches.
+          key: ${{ matrix.target }}
           # A failed notarization still compiled everything; keep the cache.
           cache-on-failure: true
 

--- a/apps/desktop/scripts/release-workflow.test.mjs
+++ b/apps/desktop/scripts/release-workflow.test.mjs
@@ -24,17 +24,3 @@ test('Apple Silicon releases pin the runner and isolate Xcode build caches', () 
   expect(cacheScope).toContain('CC=$clang')
   expect(cacheScope).toContain('RUST_CACHE_XCODE=$compiler_hash')
 })
-
-test('Intel releases cross-compile on the Apple Silicon runner with a per-target cache', () => {
-  const intelMatrix = workflow.match(
-    /- name: Intel\n\s+runner: [^\n]+\n\s+target: x86_64-apple-darwin/,
-  )?.[0]
-  expect(intelMatrix).toContain('runner: macos-26')
-
-  // Both legs run on the same runner image, so the cargo cache must be keyed
-  // by target or the legs clobber each other's caches.
-  const cargoCacheStart = workflow.indexOf('- name: Cache cargo build')
-  const cargoCacheEnd = workflow.indexOf('- name: ', cargoCacheStart + 1)
-  const cargoCache = workflow.slice(cargoCacheStart, cargoCacheEnd)
-  expect(cargoCache).toContain('key: ${{ matrix.target }}')
-})

--- a/apps/desktop/scripts/release-workflow.test.mjs
+++ b/apps/desktop/scripts/release-workflow.test.mjs
@@ -24,3 +24,17 @@ test('Apple Silicon releases pin the runner and isolate Xcode build caches', () 
   expect(cacheScope).toContain('CC=$clang')
   expect(cacheScope).toContain('RUST_CACHE_XCODE=$compiler_hash')
 })
+
+test('Intel releases cross-compile on the Apple Silicon runner with a per-target cache', () => {
+  const intelMatrix = workflow.match(
+    /- name: Intel\n\s+runner: [^\n]+\n\s+target: x86_64-apple-darwin/,
+  )?.[0]
+  expect(intelMatrix).toContain('runner: macos-26')
+
+  // Both legs run on the same runner image, so the cargo cache must be keyed
+  // by target or the legs clobber each other's caches.
+  const cargoCacheStart = workflow.indexOf('- name: Cache cargo build')
+  const cargoCacheEnd = workflow.indexOf('- name: ', cargoCacheStart + 1)
+  const cargoCache = workflow.slice(cargoCacheStart, cargoCacheEnd)
+  expect(cargoCache).toContain('key: ${{ matrix.target }}')
+})

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -323,7 +323,8 @@ Stable installs are unaffected (same identifier and the shipped icon).
 signed/notarized macOS artifacts in parallel:
 
 - Apple Silicon: `macos-26`, `--target=aarch64-apple-darwin`
-- Intel: `macos-26-intel`, `--target=x86_64-apple-darwin`
+- Intel: `macos-26`, `--target=x86_64-apple-darwin` (cross-compiled; the sidecar
+  launch checks run under Rosetta 2, preinstalled on GitHub's arm64 images)
 
 Each build job runs the same DMG notarization, Gatekeeper checks, and updater artifact
 signing as a local release, then uploads its artifacts to the workflow. A final publish

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -323,8 +323,7 @@ Stable installs are unaffected (same identifier and the shipped icon).
 signed/notarized macOS artifacts in parallel:
 
 - Apple Silicon: `macos-26`, `--target=aarch64-apple-darwin`
-- Intel: `macos-26`, `--target=x86_64-apple-darwin` (cross-compiled; the sidecar
-  launch checks run under Rosetta 2, preinstalled on GitHub's arm64 images)
+- Intel: `macos-26`, `--target=x86_64-apple-darwin`
 
 Each build job runs the same DMG notarization, Gatekeeper checks, and updater artifact
 signing as a local release, then uploads its artifacts to the workflow. A final publish


### PR DESCRIPTION
Cross-compile the Intel release on the `macos-26` Apple Silicon runner (Rosetta 2 runs the sidecar launch checks) and key the cargo cache by target so the two matrix legs stop sharing a cache key.

This should speed up our CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the macOS release build configuration to support Intel builds on the current runner environment.
  * Improved build-cache separation for different macOS runner and target combinations, helping produce more consistent release builds.

* **Documentation**
  * Updated macOS distribution instructions to reflect the current Intel build runner configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->