### PR TITLE
fix: keep backlink context expanded when the source item is collapsed

### DIFF
--- a/packages/core/src/indexing/block-context.test.ts
+++ b/packages/core/src/indexing/block-context.test.ts
@@ -115,6 +115,25 @@ describe('blockContextAt', () => {
     )
   })
 
+  // Repro for https://github.com/team-reflect/reflect-open/issues/832
+  // A `+` bullet marker means the item is collapsed (see meowdown's
+  // md-to-pm.ts: collapsed = kind === 'bullet' && marker === '+'). The parent
+  // line is sliced from source verbatim, so its collapsed marker rides along
+  // into the snippet text. BacklinkSnippet renders that text through the same
+  // MarkdownView used for live notes, which folds anything starting with `+`
+  // — hiding the very child branch this function just went out of its way to
+  // include, even though the returned string still contains it.
+  it('does not carry the parent line collapsed marker into the context', () => {
+    const content = [
+      '+ parent line',
+      '  - mention of [[Target]]',
+      '',
+    ].join('\n')
+    expect(blockContextAt(content, posOf(content, '[[Target]]'))).toBe(
+      '- parent line\n  - mention of [[Target]]',
+    )
+  })
+
   it('keeps sibling branches that mention the same target', () => {
     const content = [
       '- parent line',

--- a/packages/core/src/indexing/block-context.ts
+++ b/packages/core/src/indexing/block-context.ts
@@ -231,6 +231,33 @@ function containsPos(node: SyntaxNode, pos: number): boolean {
 }
 
 /**
+ * Does `item`'s own marker mean meowdown renders it collapsed? A bullet
+ * item's `+` marker means collapsed (`-`/`*` mean expanded); task items keep
+ * `+` for a circle checkbox instead, so this only matches a bare `ListMark`,
+ * never a `TaskMarker` (see meowdown's md-to-pm.ts: `collapsed = !isTask &&
+ * kind === 'bullet' && marker === '+'`).
+ */
+function isCollapsedListItem(body: string, item: SyntaxNode): boolean {
+  const marker = item.firstChild
+  return marker != null && marker.name === 'ListMark' && body.slice(marker.from, marker.to) === '+'
+}
+
+/**
+ * A backlink context must never hide the structure it exists to show: normalize
+ * a collapsed `+` marker to `-` on the context's first line only — display-only,
+ * so {@link ContextLines.sourceLines} still matches the source for write-back.
+ * Without this, a folded item's own children render hidden in the panel even
+ * though this module already went out of its way to include them in the
+ * returned text. See https://github.com/team-reflect/reflect-open/issues/832.
+ */
+function withExpandedMarker(body: string, item: SyntaxNode, context: ContextLines): ContextLines {
+  if (isCollapsedListItem(body, item) && context.lines.length > 0) {
+    context.lines[0] = `-${context.lines[0]!.slice(1)}`
+  }
+  return context
+}
+
+/**
  * Context for a mention inside a list item, per old Reflect's rules: a
  * top-level item yields its whole subtree; a nested item yields the parent
  * item's own line plus the branches under it that mention the same target
@@ -245,16 +272,18 @@ function listItemContext(
   const parentItem = selfOrAncestor(item.parent, (node) => node.name === 'ListItem')
   const lead = parentItem ? leadTextblock(parentItem) : null
   if (!parentItem || !lead) {
-    return dedentedBlockAt(body, item.from, item.to)
+    return withExpandedMarker(body, item, dedentedBlockAt(body, item.from, item.to))
   }
 
   const indent = body.slice(lineStartAt(body, parentItem.from), parentItem.from)
-  const pieces: ContextLines[] = [dedentedBlockAt(body, parentItem.from, lead.to)]
+  const pieces: ContextLines[] = [
+    withExpandedMarker(body, parentItem, dedentedBlockAt(body, parentItem.from, lead.to)),
+  ]
   for (let child = lead.nextSibling; child; child = child.nextSibling) {
     const branches = isListName(child.name) ? child.getChildren('ListItem') : [child]
     for (const branch of branches) {
       if (branchMentions(body, branch, targetKeys) || containsPos(branch, bodyPos)) {
-        pieces.push(dedentedSlice(body, branch.from, branch.to, indent))
+        pieces.push(withExpandedMarker(body, branch, dedentedSlice(body, branch.from, branch.to, indent)))
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes #832.

Reflect encodes a list item's fold state directly in its bullet marker:
a bullet item starting with `+` is collapsed, `-`/`*` are expanded (see
`@meowdown/core`'s `md-to-pm.ts`: `collapsed = !isTask && kind === 'bullet'
&& marker === '+'`).

`block-context.ts` builds the incoming-backlinks panel's context by slicing
the relevant lines straight from the note's source. When the item carrying
the context (or its parent, for a nested mention) is folded in the source
note, its `+` marker rides along verbatim into the returned snippet text.
`BacklinkSnippet` renders that text through the same `MarkdownView` used for
live notes, which correctly folds anything starting with `+` — hiding the
very child branch this module already went out of its way to include, even
though the returned string does contain it.

## Fix

Added `isCollapsedListItem` + `withExpandedMarker` in `block-context.ts`.
Before returning a context whose leading line belongs to a list item, if
that item's own marker is a collapsed bullet, its first display line is
normalized from `+` to `-`. This only touches the display line
(`ContextLines.lines`) — the tracked `sourceLines` used for write-back
(e.g. clicking a task checkbox in a snippet) still match the real source,
so nothing about the source note itself is touched.

Scope note: this normalizes the outermost item's own marker in each
returned context (matching the reported case and the attached test). It
does not recursively normalize a `+` on some deeper descendant folded
inside the same snippet — happy to extend it if that's wanted too.

## Test plan

- Added a regression test in `block-context.test.ts` reproducing the exact
  issue: a collapsed parent (`+ parent line`) whose nested child mentions
  the target now returns `- parent line\n  - mention of [[Target]]` instead
  of leaking the `+`.
- `pnpm --filter @reflect/core test` — 1320 tests, all passing except 2
  pre-existing failures unrelated to this change (`fts5` SQLite module
  missing in this environment; confirmed present on unmodified `master`
  too).
- `tsc --noEmit` — clean.
- `oxlint` on the changed files — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Backlink context now displays collapsed `+` list markers as standard `-` bullets.
  * Preserved indentation and surrounding parent and child content in nested list contexts.
  * Improved consistency for direct and nested list-item backlink snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->