### PR TITLE
fix: enrich URL-only mobile link captures

### DIFF
--- a/packages/core/src/actions/capture-enrichment.test.ts
+++ b/packages/core/src/actions/capture-enrichment.test.ts
@@ -154,6 +154,48 @@ describe('reconcileCaptureEnrichment', () => {
     expect(getSecretMock).not.toHaveBeenCalled()
   })
 
+  it('retitles a URL-only iOS share from scraped metadata without AI', async () => {
+    addSpool(envelope({ source: 'ios-share', title: '' }), { screenshot: false })
+    expect((await drain()).stopped).toBeNull()
+    writeNoteMock.mockClear()
+    scrapeMock.mockResolvedValue({
+      title: 'An article from its metadata',
+      description: 'A scraped description.',
+      siteName: 'Example',
+    })
+
+    const outcome = await reconcile({ providers: NO_PROVIDERS })
+
+    expect(outcome).toEqual({ pending: 1, enriched: 1, skipped: 0, stopped: null })
+    const note = files.get(IDENTITY.notePath) ?? ''
+    expect(note).toContain('# An article from its metadata')
+    expect(note).toContain('- Description: A scraped description.')
+    expect(note).toContain('captureStatus: done')
+    expect(note).not.toContain('captureProvider')
+    const daily = files.get(DAILY) ?? ''
+    expect(daily).toContain(
+      '- [[capture-2026-06-11-153022-845-7c9e|An article from its metadata]]',
+    )
+    expect(daily).not.toContain('|example.com]]')
+    expect(describeMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps a supplied capture title when scraped metadata differs', async () => {
+    await drainOne({ source: 'ios-share', title: 'The title supplied by the app' })
+    scrapeMock.mockResolvedValue({
+      title: 'A different metadata title',
+      description: 'A scraped description.',
+      siteName: 'Example',
+    })
+
+    const outcome = await reconcile({ providers: NO_PROVIDERS })
+
+    expect(outcome.enriched).toBe(1)
+    expect(files.get(IDENTITY.notePath)).toContain('# The title supplied by the app')
+    expect(files.get(DAILY)).toContain('|The title supplied by the app]]')
+    expect(files.get(DAILY)).not.toContain('|A different metadata title]]')
+  })
+
   it('stops on a configured provider whose key is missing from the keychain', async () => {
     await drainOne()
     getSecretMock.mockResolvedValue(null)

--- a/packages/core/src/actions/capture-enrichment.test.ts
+++ b/packages/core/src/actions/capture-enrichment.test.ts
@@ -154,8 +154,11 @@ describe('reconcileCaptureEnrichment', () => {
     expect(getSecretMock).not.toHaveBeenCalled()
   })
 
-  it('retitles a URL-only iOS share from scraped metadata without AI', async () => {
-    addSpool(envelope({ source: 'ios-share', title: '' }), { screenshot: false })
+  it.each([
+    ['an empty title', ''],
+    ['a host-equivalent title', 'example.com'],
+  ])('retitles a URL-only iOS share with %s from scraped metadata', async (_label, title) => {
+    addSpool(envelope({ source: 'ios-share', title }), { screenshot: false })
     expect((await drain()).stopped).toBeNull()
     writeNoteMock.mockClear()
     scrapeMock.mockResolvedValue({

--- a/packages/core/src/actions/capture-enrichment.ts
+++ b/packages/core/src/actions/capture-enrichment.ts
@@ -14,6 +14,7 @@ import { captureFromPath, type CaptureIdentity } from './capture-identity'
 import {
   captureNoteMeta,
   capturePageTextFromBody,
+  displayTitle,
   hasDescription,
   metadataValue,
   notePrivate,
@@ -132,8 +133,8 @@ async function generateEnrichment(input: GenerateEnrichmentInput): Promise<PageE
 }
 
 /**
- * Enrich every pending capture: scrape the page's meta tags, generate the AI
- * description and cleaned-up display title when a provider is configured
+ * Enrich every pending capture: scrape the page's description and display
+ * title, optionally replace them with AI output when a provider is configured
  * (retitling the note's H1 and the daily entry's link text), and stamp
  * `captureStatus: done`. Never throws.
  */
@@ -254,6 +255,12 @@ export async function reconcileCaptureEnrichment(
         }
       }
       const aiTitle = generated?.title ?? null
+      const placeholderTitle = displayTitle({ title: '', url: meta.captureUrl })
+      const metadataTitle =
+        title === placeholderTitle && pageMeta?.title
+          ? displayTitle({ title: pageMeta.title, url: meta.captureUrl })
+          : null
+      const enrichedTitle = aiTitle ?? metadataTitle
       const description = generated?.description ?? null
 
       const usedAiDescription = description !== null && metadataValue(description) !== ''
@@ -264,8 +271,8 @@ export async function reconcileCaptureEnrichment(
           ? null
           : pageMeta?.description ?? null
       let newBody = text !== null ? withDescription(split.body, text) : split.body
-      if (aiTitle !== null) {
-        newBody = withTitle(newBody, aiTitle)
+      if (enrichedTitle !== null) {
+        newBody = withTitle(newBody, enrichedTitle)
       }
       const reassembled = source.slice(0, split.bodyOffset) + newBody
       await writeNote(
@@ -278,11 +285,11 @@ export async function reconcileCaptureEnrichment(
         }),
         input.generation,
       )
-      if (aiTitle !== null && aiTitle !== title) {
-        // Re-read the daily: the provider call above is slow, and the
-        // pre-call snapshot would silently drop anything written meanwhile.
+      if (enrichedTitle !== null && enrichedTitle !== title) {
+        // Re-read the daily: the network work above is slow, and the pre-call
+        // snapshot would silently drop anything written meanwhile.
         const freshDaily = await noteSource(dailyPath(identity.date), input.generation)
-        const retitled = retitleDailyEntry(freshDaily, identity.base, title, aiTitle)
+        const retitled = retitleDailyEntry(freshDaily, identity.base, title, enrichedTitle)
         if (retitled !== freshDaily) {
           await writeNote(dailyPath(identity.date), retitled, input.generation)
         }

--- a/packages/core/src/actions/capture-note.ts
+++ b/packages/core/src/actions/capture-note.ts
@@ -39,7 +39,7 @@ const PAGE_TEXT_START = '<!-- reflect-capture-page-text:start -->'
 const PAGE_TEXT_END = '<!-- reflect-capture-page-text:end -->'
 
 /** The capture's display title: the page title, else the URL's host. */
-export function displayTitle(envelope: CaptureEnvelope): string {
+export function displayTitle(envelope: Pick<CaptureEnvelope, 'title' | 'url'>): string {
   const title = wikiLinkSafe(envelope.title)
   return title !== '' ? title : urlHost(envelope.url)
 }


### PR DESCRIPTION
## Problem

Many iOS apps share only a URL, without a page title. The raw capture correctly falls back to the URL hostname, but the later metadata pass discarded the scraped page title unless an AI provider also returned a title. As a result, enrichment could finish with `captureStatus: done` while the capture note and Daily link still displayed a hostname such as `example.com`.

## Before -> After

| Scenario | Before | After |
| --- | --- | --- |
| URL-only mobile share | Hostname remained after metadata enrichment | Scraped page title replaces the hostname placeholder |
| Share with a meaningful supplied title | Preserved | Still preserved unless AI explicitly retitles it |
| Metadata-only enrichment | Description added without AI provenance | Title and description can be added without AI provenance |

## Changes

1. Reuse `displayTitle` for scraped titles so untrusted metadata receives the same wiki-link sanitation as capture-time titles.
2. Apply the scraped title only when the current title is the URL hostname — the placeholder semantics used for URL-only captures. AI-generated titles still take precedence.
3. Add regression coverage for the real iOS URL-only envelope shape and for preserving a valid title when scraped metadata differs.

## Tests

- URL-only `ios-share` envelopes with an empty or host-equivalent title, no screenshot, and no AI provider retitle both the capture note and Daily entry from scraped metadata.
- Metadata-only enrichment adds the description, completes the capture, and does not stamp AI provider provenance.
- A meaningful non-host title supplied by the sharing app remains unchanged when metadata has a different title.

## Verification

- `pnpm --filter @reflect/core test` — 97 files, 1,368 tests passed against current `master`.
- `pnpm check` — typecheck and lint passed; only the existing max-lines warnings were reported.
- `pnpm build` — desktop and extension production builds passed; only expected missing-Sentry-token and chunk-size warnings were reported.
- `git diff --check` — passed.

## Risk / Rollout

No migration or data-shape change. The fallback is limited to untouched captures whose current title equals the URL hostname. A host-equivalent supplied title deliberately receives the same enrichment because it is indistinguishable from, and no more informative than, the synthesized placeholder; meaningful non-host titles remain authoritative. The existing body-hash and Daily-link guards continue to protect user edits. Already completed hostname-only captures are not backfilled; new or still-pending captures use the corrected behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is scoped to captures whose title equals the URL host placeholder; meaningful supplied titles and existing hash/edit guards are unchanged, with no migration.
> 
> **Overview**
> **URL-only iOS link shares** could finish enrichment with `captureStatus: done` while the note H1 and Daily wiki-link text still showed the URL hostname (e.g. `example.com`), because retitling only ran when an AI provider returned a title.
> 
> Capture enrichment now applies a **scraped page title** when the note’s current title matches the hostname placeholder (`displayTitle` with an empty title for that URL). Scraped titles go through the same `displayTitle` / wiki-link sanitization as capture-time titles. **AI-generated titles still win** over metadata. Note H1, screenshot alt, and Daily link text update for metadata-only retitles the same way as for AI retitles, without stamping AI provenance.
> 
> `displayTitle` is widened to `Pick<CaptureEnvelope, 'title' | 'url'>` so enrichment can reuse it for scraped titles. Regression tests cover empty/host-equivalent iOS share titles and preserving a meaningful app-supplied title when metadata differs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dcd7384ebc6f3695f4d6e6b3680e0d1591f28a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shared-link capture titles by using scraped page titles when the original title is empty or only reflects the website address.
  - Added scraped page descriptions to enriched captures where available.
  - Preserved titles entered by users instead of replacing them with scraped metadata.
  - Updated daily capture links to match the final note title.
  - Captures enriched without configured providers now correctly complete with a finished status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->