### PR TITLE
docs: remove stale next branch guidance

### DIFF
--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -1545,9 +1545,9 @@ function syncBetaFeed() {
  * apps/desktop/package.json). The normal flow fills the asset-less draft
  * release that release-please created when the Release PR merged; the manual
  * fallback creates the release itself. A version with a prerelease segment
- * (e.g. `0.2.0-beta.1`, the `next`-branch convention) publishes as a GitHub
- * pre-release. All preflight checks run before the build so a doomed publish
- * fails in seconds, not after notarization.
+ * (e.g. `0.2.0-beta.1`) publishes as a GitHub pre-release. All preflight checks
+ * run before the build so a doomed publish fails in seconds, not after
+ * notarization.
  */
 function ensurePublishableRelease({ flavorFlag }) {
   ensureGhReady()

--- a/apps/desktop/src-tauri/icons/README.md
+++ b/apps/desktop/src-tauri/icons/README.md
@@ -5,7 +5,7 @@ Three color sets, one per build flavor. Same gradient gem artwork, different hue
 | Dir           | Color        | Flavor        | productName  | modulate (B,S,H) |
 | ------------- | ------------ | ------------- | ------------ | ---------------- |
 | `icons/`      | blue/violet  | stable        | Reflect      | none (as shipped) |
-| `icons-beta/` | purple/violet | beta (`next`) | Reflect Beta | `104,100,120`    |
+| `icons-beta/` | purple/violet | beta          | Reflect Beta | `104,100,120`    |
 | `icons-dev/`  | green        | dev (local)   | Reflect Dev  | `92,100,231`     |
 
 `icons/` is the shipped app icon and the default set Tauri uses with no `--config`;

--- a/docs/plans/15-hardening-packaging-release.md
+++ b/docs/plans/15-hardening-packaging-release.md
@@ -99,8 +99,9 @@ the original release scope and are **in** scope for the privacy/signing review.
       purple/violet), Reflect Dev (`…​.dev`, green, no updates). Beta/dev icons are the stable
       artwork recolored via `magick -modulate`. `release:macos` derives the flavor from the
       version channel. See docs/macos-distribution.md → Build flavors.
-    - **Release automation (shipped):** versioning moved to release-please with one
-      channel per branch (`next` → beta Release PR, `master` → stable Release PR).
+    - **Release automation (shipped):** versioning moved to release-please, which
+      maintains beta and stable channels side by side on `master` (one Release PR
+      per channel).
       The app version lives only in `apps/desktop/package.json`; releases are created
       as drafts and undrafted after the assets upload; `release-bump.mjs` was removed.
       See docs/macos-distribution.md → Cutting a release.


### PR DESCRIPTION
## Problem

`master` is now the only long-lived branch, and the operational workflows and contributor guidance already reflect that. Three current-facing references still described `next` as the beta branch, which could mislead maintainers and agents about where to branch or how release channels are selected.

Historical references that accurately record the old branch model are intentionally unchanged.

## Changes

1. Update the hardening/release plan to describe beta and stable Release PRs as side-by-side channels on `master`.
2. Remove the obsolete `next`-branch label from the macOS prerelease documentation.
3. Describe the beta icon set as a build flavor without tying it to a branch.

## Verification

- `pnpm check` — passed; only the existing max-lines warnings were reported.
- `pnpm build` — passed; only the expected missing-Sentry-token and bundle-size warnings were reported.
- `node --check apps/desktop/scripts/release-macos.mjs` — passed.
- `git diff --check` — passed.
- Repository audit confirms the remaining branch-like `next` references are historical records in the V1 documentation, security audit, and generated changelog.

## Risk / Rollout

Documentation and comments only. No runtime behavior, workflow configuration, or release behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and documentation edits only; no code paths, CI, or release automation were modified.
> 
> **Overview**
> Aligns maintainer-facing docs with **`master` as the only long-lived branch** by dropping references that tied beta releases, prerelease examples, and beta icons to a **`next` branch**.
> 
> The hardening/release plan now says **release-please keeps beta and stable Release PRs in parallel on `master`** (one PR per channel), instead of mapping channels to separate branches. The macOS release script comment for prerelease versions (**e.g. `0.2.0-beta.1`**) no longer mentions the old **`next`-branch convention**. The icons README labels **`icons-beta/`** as the beta **build flavor** only, not a branch-specific set.
> 
> **No runtime, workflow, or release-script behavior changes**—wording only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d75815c0ac606b992c82310e36866d4c258adc2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the macOS publishing workflow, including preflight checks that run before builds to identify failures sooner.
  - Updated icon flavor terminology by removing the legacy “next” alias from beta documentation.
  - Documented the current release model: beta and stable channels are maintained side by side, with a separate release process for each channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->