### PR TITLE
fix: preserve numeric notation in formatted transcripts

### DIFF
--- a/packages/core/src/ai/audio-memo-format.test.ts
+++ b/packages/core/src/ai/audio-memo-format.test.ts
@@ -183,6 +183,18 @@ describe('formatAudioMemoTranscript', () => {
     expect(result.title).not.toBe('Changed number')
   })
 
+  it.each([
+    ['a Roman numeral to ASCII letters', 'Phase Ⅳ starts tomorrow', 'Phase IV starts tomorrow.'],
+    ['full-width digits to ASCII digits', 'Invite ５０ people', 'Invite 50 people.'],
+    ['accounting parentheses', 'The loss was ($50) today', 'The loss was $50 today.'],
+  ])('falls back when formatting changes %s', async (_case, transcript, body) => {
+    modelAnswering({ title: 'Changed notation', body })
+
+    const result = await request(transcript)
+    expect(result.body).toBe(transcript)
+    expect(result.title).not.toBe('Changed notation')
+  })
+
   it('does not call a model for an empty transcript', async () => {
     modelAnswering({ title: 'Ignored', body: 'Ignored' })
 

--- a/packages/core/src/ai/audio-memo-format.ts
+++ b/packages/core/src/ai/audio-memo-format.ts
@@ -10,7 +10,7 @@ import { languageModel } from './language-model'
 
 const FORMAT_TIMEOUT_MS = 60_000
 const NUMBER_SIGNATURE_PATTERN =
-  /(?:(?:[+\-−±~≈#]|\p{Sc})+\p{N}+|(?:[+\-−±~≈#]\p{Sc}|\p{Sc}[+\-−±~≈#]?)\s+\p{N}+|\p{N}+)(?:[.,:/\-\u066B\u066C]\p{N}+)*(?:\s*(?:\p{Sc}|[%‰‱°]))?/gu
+  /(?:(?:[+\-−±~≈#(]|\p{Sc})+\p{N}+|(?:[+\-−±~≈#(]\p{Sc}|\p{Sc}[+\-−±~≈#(]?)\s+\p{N}+|\p{N}+)(?:[.,:/\-\u066B\u066C]\p{N}+)*(?:\s*(?:\p{Sc}|[%‰‱°)]))?/gu
 
 const formattedAudioMemoSchema = z.object({
   title: z.string(),
@@ -30,11 +30,11 @@ const FORMAT_SYSTEM_PROMPT = [
 ].join(' ')
 
 function normalizedTranscriptContent(value: string): string {
-  return value.normalize('NFKC').toLowerCase().replace(/[^\p{L}\p{M}\p{N}]/gu, '')
+  return value.normalize('NFC').toLowerCase().replace(/[^\p{L}\p{M}\p{N}]/gu, '')
 }
 
 function numberSignatures(value: string): readonly string[] {
-  return (value.normalize('NFKC').match(NUMBER_SIGNATURE_PATTERN) ?? []).map((match) =>
+  return (value.normalize('NFC').match(NUMBER_SIGNATURE_PATTERN) ?? []).map((match) =>
     match.replace(/\s/gu, ''),
   )
 }


### PR DESCRIPTION
## Problem

The transcript integrity guard added in #873 used NFKC normalization and did not include accounting parentheses in numeric signatures. That could accept meaning-changing model output such as `Ⅳ` -> `IV`, full-width digits -> ASCII digits, or `($50)` -> `$50` instead of falling back to the raw transcript.

## Before -> After

| Before | After |
| --- | --- |
| Compatibility-normalized forms could compare equal | NFC preserves compatibility-distinct letters and digits |
| Accounting parentheses were ignored | Parentheses remain part of the ordered numeric signature |
| Meaning-changing output could be stored | Validation rejects it and stores the untouched provider transcript |

## Changes

1. Use NFC for lexical content and numeric signature comparison.
2. Include opening and closing accounting parentheses in numeric signatures.
3. Add regressions for Roman numerals, full-width digits, and accounting-negative currency.

## Tests

- Formatter suite: 16 passing, including all three new notation regressions.
- Focused core suites: 82 passing.

## Verification

- `pnpm --filter @reflect/core test --run src/ai/audio-memo-format.test.ts`
- `pnpm --filter @reflect/core test --run src/ai/audio-memo-format.test.ts src/ai/audio-memo-title.test.ts src/actions/audio-memo.test.ts src/settings/schema.test.ts`
- `pnpm check`
- `pnpm build`

## Risk / Rollout

This only makes validation stricter. If model output changes compatibility characters or accounting notation, Reflect safely stores the raw transcript instead. There is no migration, provider change, or retry behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation-only tightening in audio memo formatting; failures already fall back to the untouched transcript with no migration or auth changes.
> 
> **Overview**
> Tightens **audio memo transcript integrity** checks so model formatting cannot silently change numeric notation.
> 
> **Normalization** for lexical comparison and numeric signatures switches from **NFKC to NFC**, so compatibility forms (e.g. Roman numeral `Ⅳ` vs `IV`, full-width `５０` vs `50`) no longer compare equal when the model rewrites them.
> 
> The **numeric signature regex** now treats **accounting parentheses** (`($50)`) as part of the signature, so stripping parentheses on the formatted side fails validation.
> 
> When validation fails, behavior is unchanged: the **raw provider transcript** is kept instead of the model body. **Three regressions** cover Roman numerals, full-width digits, and accounting currency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaf39af8d2f3827834dbb4ec3b0a24a5ad1cfe82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->