### PR TITLE
fix: enrich shared links before AI finishes

### DIFF
--- a/packages/core/src/actions/capture-enrichment-write.ts
+++ b/packages/core/src/actions/capture-enrichment-write.ts
@@ -16,11 +16,17 @@ import {
 } from './capture-note'
 
 export interface PendingCaptureSnapshot {
+  /** Full source, including frontmatter, used to preserve unrelated keys. */
   source: string
+  /** Markdown body whose hash guards against concurrent edits. */
   body: string
+  /** Body start within `source`; the prefix is retained when replacing `body`. */
   bodyOffset: number
+  /** Current note title used to keep the Daily alias in sync. */
   title: string
+  /** Parsed hard privacy gate for every external enrichment call. */
   isPrivate: boolean
+  /** Validated capture lifecycle and transaction frontmatter. */
   meta: CaptureNoteMeta
 }
 

--- a/packages/core/src/actions/capture-enrichment-write.ts
+++ b/packages/core/src/actions/capture-enrichment-write.ts
@@ -1,0 +1,190 @@
+import { isAppError } from '../errors'
+import { readNote, writeNote } from '../graph/commands'
+import { dailyPath } from '../graph/paths'
+import { hashContent } from '../indexing/hash'
+import { parseNote } from '../markdown/extract'
+import { parseFrontmatter, splitFrontmatter, upsertFrontmatter } from '../markdown/frontmatter'
+import type { AiProviderConfig } from '../settings/schema'
+import type { CaptureIdentity } from './capture-identity'
+import {
+  captureNoteMeta,
+  notePrivate,
+  noteSource,
+  retitleDailyEntry,
+  type CaptureNoteMeta,
+  type CaptureStatus,
+} from './capture-note'
+
+export interface PendingCaptureSnapshot {
+  source: string
+  body: string
+  bodyOffset: number
+  title: string
+  isPrivate: boolean
+  meta: CaptureNoteMeta
+}
+
+interface PersistCaptureEnrichmentInput {
+  identity: CaptureIdentity
+  expectedHash: string
+  body: string
+  fromTitle: string
+  toTitle: string
+  status: Exclude<CaptureStatus, 'skipped'>
+  provider: AiProviderConfig | null
+  generation: number
+}
+
+interface CaptureWriteTransaction {
+  fromTitle: string
+  status: Exclude<CaptureStatus, 'skipped'>
+}
+
+/** Read the current pending form of a capture, or `null` if it moved on. */
+export async function readPendingCaptureSnapshot(
+  identity: CaptureIdentity,
+  generation: number,
+): Promise<PendingCaptureSnapshot | null> {
+  let source: string
+  try {
+    source = await readNote(identity.notePath, generation)
+  } catch (cause) {
+    if (isAppError(cause) && cause.kind === 'notFound') {
+      return null
+    }
+    throw cause
+  }
+  const split = splitFrontmatter(source)
+  const frontmatter = parseFrontmatter(split.raw).data
+  const meta = captureNoteMeta(frontmatter)
+  if (meta === null || meta.captureStatus !== 'pending') {
+    return null
+  }
+  return {
+    source,
+    body: split.body,
+    bodyOffset: split.bodyOffset,
+    title: parseNote({ path: identity.notePath, source }).title,
+    isPrivate: frontmatter.private,
+    meta,
+  }
+}
+
+function captureWriteTransaction(meta: CaptureNoteMeta): CaptureWriteTransaction | null {
+  if (meta.captureDailyFromTitle === undefined || meta.captureFinalizeStatus === undefined) {
+    return null
+  }
+  return {
+    fromTitle: meta.captureDailyFromTitle,
+    status: meta.captureFinalizeStatus,
+  }
+}
+
+/** Whether a prior pass left a recoverable note/Daily retitle to finish. */
+export function hasCaptureWriteTransaction(meta: CaptureNoteMeta): boolean {
+  return captureWriteTransaction(meta) !== null
+}
+
+/**
+ * Finish the Daily half of a prepared capture retitle, then commit the capture
+ * status. The prepared note keeps enough state for this to resume after either
+ * write fails without re-scraping or guessing whether Daily text was user-made.
+ */
+export async function finishCaptureWrite(
+  identity: CaptureIdentity,
+  generation: number,
+): Promise<Exclude<CaptureStatus, 'skipped'> | null> {
+  let snapshot = await readPendingCaptureSnapshot(identity, generation)
+  if (snapshot === null) {
+    return null
+  }
+  const transaction = captureWriteTransaction(snapshot.meta)
+  if (transaction === null) {
+    return null
+  }
+  const expectedHash = snapshot.meta.captureHash
+  const dailyNotePath = dailyPath(identity.date)
+  let dailySource = await noteSource(dailyNotePath, generation)
+  if (
+    snapshot.isPrivate ||
+    notePrivate(dailySource) ||
+    (await hashContent(snapshot.body)) !== expectedHash
+  ) {
+    return null
+  }
+  const retitled = retitleDailyEntry(
+    dailySource,
+    identity.base,
+    transaction.fromTitle,
+    snapshot.title,
+  )
+  if (retitled !== dailySource) {
+    await writeNote(dailyNotePath, retitled, generation)
+  }
+
+  snapshot = await readPendingCaptureSnapshot(identity, generation)
+  dailySource = await noteSource(dailyNotePath, generation)
+  const currentTransaction = snapshot === null ? null : captureWriteTransaction(snapshot.meta)
+  if (
+    snapshot === null ||
+    currentTransaction === null ||
+    currentTransaction.fromTitle !== transaction.fromTitle ||
+    currentTransaction.status !== transaction.status ||
+    snapshot.isPrivate ||
+    notePrivate(dailySource) ||
+    (await hashContent(snapshot.body)) !== expectedHash
+  ) {
+    return null
+  }
+  await writeNote(
+    identity.notePath,
+    upsertFrontmatter(snapshot.source, {
+      captureStatus: transaction.status,
+      captureDailyFromTitle: undefined,
+      captureFinalizeStatus: undefined,
+    }),
+    generation,
+  )
+  return transaction.status
+}
+
+/**
+ * Persist a metadata or AI checkpoint. Title changes are prepared in the note
+ * first and committed only after the Daily alias is updated, making the
+ * two-file change recoverable on the next pass.
+ */
+export async function persistCaptureEnrichment(
+  input: PersistCaptureEnrichmentInput,
+): Promise<string | null> {
+  const captureHash = await hashContent(input.body)
+  const snapshot = await readPendingCaptureSnapshot(input.identity, input.generation)
+  const dailySource = await noteSource(dailyPath(input.identity.date), input.generation)
+  if (
+    snapshot === null ||
+    snapshot.title !== input.fromTitle ||
+    snapshot.isPrivate ||
+    notePrivate(dailySource) ||
+    (await hashContent(snapshot.body)) !== input.expectedHash
+  ) {
+    return null
+  }
+  const reassembled = snapshot.source.slice(0, snapshot.bodyOffset) + input.body
+  const titleChanged = input.toTitle !== input.fromTitle
+  await writeNote(
+    input.identity.notePath,
+    upsertFrontmatter(reassembled, {
+      captureStatus: titleChanged ? 'pending' : input.status,
+      captureMetadataStatus: 'done',
+      captureHash,
+      captureProvider: input.provider?.provider,
+      captureModel: input.provider?.model,
+      captureDailyFromTitle: titleChanged ? input.fromTitle : undefined,
+      captureFinalizeStatus: titleChanged ? input.status : undefined,
+    }),
+    input.generation,
+  )
+  if (titleChanged && (await finishCaptureWrite(input.identity, input.generation)) === null) {
+    return null
+  }
+  return captureHash
+}

--- a/packages/core/src/actions/capture-enrichment.test.ts
+++ b/packages/core/src/actions/capture-enrichment.test.ts
@@ -623,7 +623,7 @@ describe('reconcileCaptureEnrichment', () => {
     expect(files.get(IDENTITY.notePath)).toContain('# A title from metadata')
     expect(files.get(IDENTITY.notePath)).toContain('captureStatus: pending')
     expect(files.get(IDENTITY.notePath)).toContain('captureDailyFromTitle: example.com')
-    expect(files.get(IDENTITY.notePath)).toContain('captureFinalizeStatus: done')
+    expect(files.get(IDENTITY.notePath)).toContain('captureFinalizeStatus: pending')
 
     scrapeMock.mockResolvedValue({
       title: 'A different title on retry',
@@ -641,6 +641,65 @@ describe('reconcileCaptureEnrichment', () => {
     expect(files.get(IDENTITY.notePath)).not.toContain('captureDailyFromTitle')
     expect(files.get(IDENTITY.notePath)).not.toContain('captureFinalizeStatus')
     expect(scrapeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs newly configured AI after resuming a metadata-only daily retitle', async () => {
+    await drainOne({ source: 'ios-share', title: '' })
+    scrapeMock.mockResolvedValue({
+      title: 'A title from metadata',
+      description: 'A scraped description.',
+      siteName: null,
+    })
+    writeNoteMock
+      .mockImplementationOnce(async (path, contents) => {
+        files.set(path, contents)
+      })
+      .mockRejectedValueOnce(new ReflectError('io', 'disk full'))
+
+    const first = await reconcile({ providers: NO_PROVIDERS })
+
+    expect(first.stopped?.reason).toBe('io')
+    expect(files.get(IDENTITY.notePath)).toContain('captureFinalizeStatus: pending')
+
+    scrapeMock.mockClear()
+    getSecretMock.mockResolvedValue(null)
+    const waiting = await reconcile()
+
+    expect(waiting).toEqual({
+      pending: 1,
+      enriched: 0,
+      skipped: 0,
+      stopped: expect.objectContaining({ reason: 'config' }),
+    })
+    expect(scrapeMock).not.toHaveBeenCalled()
+    expect(describeMock).not.toHaveBeenCalled()
+    expect(files.get(DAILY)).toContain('|A title from metadata]]')
+    expect(files.get(IDENTITY.notePath)).toContain('captureStatus: pending')
+    expect(files.get(IDENTITY.notePath)).not.toContain('captureFinalizeStatus')
+
+    getSecretMock.mockResolvedValue('sk-live-key')
+    describeMock.mockResolvedValue({
+      title: 'A title from AI',
+      description: 'An AI description.',
+    })
+    const retry = await reconcile()
+
+    expect(retry).toEqual({ pending: 1, enriched: 1, skipped: 0, stopped: null })
+    expect(scrapeMock).not.toHaveBeenCalled()
+    expect(describeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'A title from metadata',
+        metaTitle: 'A title from metadata',
+        metaDescription: 'A scraped description.',
+      }),
+    )
+    const note = files.get(IDENTITY.notePath) ?? ''
+    expect(note).toContain('# A title from AI')
+    expect(note).toContain('- Description: An AI description.')
+    expect(note).toContain('captureStatus: done')
+    expect(note).toContain('captureProvider: openai')
+    expect(note).not.toContain('captureFinalizeStatus')
+    expect(files.get(DAILY)).toContain('|A title from AI]]')
   })
 
   it('preserves privacy set while a metadata retitle writes the daily backlink', async () => {

--- a/packages/core/src/actions/capture-enrichment.test.ts
+++ b/packages/core/src/actions/capture-enrichment.test.ts
@@ -199,15 +199,105 @@ describe('reconcileCaptureEnrichment', () => {
     expect(files.get(DAILY)).not.toContain('|A different metadata title]]')
   })
 
-  it('stops on a configured provider whose key is missing from the keychain', async () => {
-    await drainOne()
+  it('persists scraped metadata before waiting for AI enrichment', async () => {
+    await drainOne({ source: 'ios-share', title: '' })
+    scrapeMock.mockResolvedValue({
+      title: 'A title available immediately',
+      description: 'A description available immediately.',
+      siteName: null,
+    })
+    let finishProvider: (() => void) | undefined
+    describeMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishProvider = () =>
+            resolve({ title: 'A title from AI', description: 'A description from AI.' })
+        }),
+    )
+
+    const running = reconcile()
+
+    await vi.waitFor(() => {
+      const pendingNote = files.get(IDENTITY.notePath) ?? ''
+      expect(pendingNote).toContain('# A title available immediately')
+      expect(pendingNote).toContain('- Description: A description available immediately.')
+      expect(pendingNote).toContain(`![A title available immediately](${IDENTITY.assetPath})`)
+      expect(pendingNote).toContain('captureStatus: pending')
+      expect(files.get(DAILY)).toContain('|A title available immediately]]')
+      expect(describeMock).toHaveBeenCalledTimes(1)
+    })
+
+    if (finishProvider === undefined) {
+      throw new Error('provider did not start')
+    }
+    finishProvider()
+    expect(await running).toEqual({ pending: 1, enriched: 1, skipped: 0, stopped: null })
+    const enrichedNote = files.get(IDENTITY.notePath) ?? ''
+    expect(enrichedNote).toContain('# A title from AI')
+    expect(enrichedNote).toContain('- Description: A description from AI.')
+    expect(enrichedNote).toContain('captureStatus: done')
+    expect(files.get(DAILY)).toContain('|A title from AI]]')
+  })
+
+  it('applies scraped metadata while waiting for a configured provider key', async () => {
+    addSpool(
+      envelope({
+        source: 'ios-share',
+        url: 'https://www.instagram.com/reel/example/',
+        title: '',
+      }),
+      { screenshot: false },
+    )
+    expect((await drain()).stopped).toBeNull()
+    writeNoteMock.mockClear()
+    scrapeMock.mockResolvedValue({
+      title: 'First Chair on Instagram',
+      description: 'An Instagram reel about furniture and decor.',
+      siteName: 'Instagram',
+    })
     getSecretMock.mockResolvedValue(null)
 
     const outcome = await reconcile()
 
     expect(outcome.stopped?.reason).toBe('config')
-    expect(files.get(IDENTITY.notePath)).toContain('captureStatus: pending')
+    const pendingNote = files.get(IDENTITY.notePath) ?? ''
+    expect(pendingNote).toContain('# First Chair on Instagram')
+    expect(pendingNote).toContain('- Description: An Instagram reel about furniture and decor.')
+    expect(pendingNote).toContain('captureStatus: pending')
+    expect(pendingNote).toContain('captureMetadataStatus: done')
+    expect(pendingNote).not.toContain('captureProvider')
+    expect(files.get(DAILY)).toContain('|First Chair on Instagram]]')
+    expect(describeMock).not.toHaveBeenCalled()
+
+    scrapeMock.mockClear()
+    const stillWaiting = await reconcile()
+
+    expect(stillWaiting).toEqual({
+      pending: 1,
+      enriched: 0,
+      skipped: 0,
+      stopped: expect.objectContaining({ reason: 'config' }),
+    })
     expect(scrapeMock).not.toHaveBeenCalled()
+    expect(describeMock).not.toHaveBeenCalled()
+
+    getSecretMock.mockResolvedValue('sk-live-key')
+    const retry = await reconcile()
+
+    expect(retry).toEqual({ pending: 1, enriched: 1, skipped: 0, stopped: null })
+    const enrichedNote = files.get(IDENTITY.notePath) ?? ''
+    expect(enrichedNote).toContain('# First Chair on Instagram')
+    expect(enrichedNote).toContain('- Description: An AI description of the page.')
+    expect(enrichedNote).toContain('captureStatus: done')
+    expect(enrichedNote).toContain('captureProvider: openai')
+    expect(scrapeMock).toHaveBeenCalledTimes(1)
+    expect(describeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'First Chair on Instagram',
+        metaTitle: 'First Chair on Instagram',
+        metaDescription: 'An Instagram reel about furniture and decor.',
+      }),
+    )
   })
 
   it('skips an edited capture instead of clobbering it — zero outbound', async () => {
@@ -241,12 +331,86 @@ describe('reconcileCaptureEnrichment', () => {
   it('skips when the capture note itself was marked private — zero outbound', async () => {
     await drainOne()
     const source = files.get(IDENTITY.notePath) ?? ''
-    files.set(IDENTITY.notePath, source.replace('---\n', '---\nprivate: true\n', ))
+    files.set(IDENTITY.notePath, source.replace('---\n', '---\nprivate: true\n'))
 
     const outcome = await reconcile()
 
     expect(outcome.skipped).toBe(1)
     expect(scrapeMock).not.toHaveBeenCalled()
+    expect(describeMock).not.toHaveBeenCalled()
+  })
+
+  it('preserves capture edits made while metadata is being fetched', async () => {
+    await drainOne({ source: 'ios-share', title: '' })
+    scrapeMock.mockImplementation(async () => {
+      const source = files.get(IDENTITY.notePath) ?? ''
+      files.set(IDENTITY.notePath, source.replace('# example.com', '# My edited title'))
+      return {
+        title: 'A scraped title',
+        description: 'A scraped description.',
+        siteName: null,
+      }
+    })
+
+    const outcome = await reconcile({ providers: NO_PROVIDERS })
+
+    expect(outcome).toEqual({ pending: 1, enriched: 0, skipped: 1, stopped: null })
+    const note = files.get(IDENTITY.notePath) ?? ''
+    expect(note).toContain('# My edited title')
+    expect(note).not.toContain('A scraped description.')
+    expect(note).toContain('captureStatus: skipped')
+    expect(describeMock).not.toHaveBeenCalled()
+  })
+
+  it('does not send capture content to AI when the day becomes private during metadata fetch', async () => {
+    await drainOne()
+    scrapeMock.mockImplementation(async () => {
+      files.set(DAILY, `---\nprivate: true\n---\n\n${files.get(DAILY) ?? ''}`)
+      return {
+        title: 'An article',
+        description: 'A scraped description.',
+        siteName: null,
+      }
+    })
+
+    const outcome = await reconcile()
+
+    expect(outcome).toEqual({ pending: 1, enriched: 0, skipped: 1, stopped: null })
+    expect(files.get(IDENTITY.notePath)).toContain('captureStatus: skipped')
+    expect(describeMock).not.toHaveBeenCalled()
+    expect(readAssetMock).not.toHaveBeenCalled()
+  })
+
+  it('does not send capture content to AI when the day becomes private while loading its screenshot', async () => {
+    await drainOne()
+    readAssetMock.mockImplementation(async () => {
+      files.set(DAILY, `---\nprivate: true\n---\n\n${files.get(DAILY) ?? ''}`)
+      return btoa('jpeg-bytes')
+    })
+
+    const outcome = await reconcile()
+
+    expect(outcome).toEqual({ pending: 1, enriched: 0, skipped: 1, stopped: null })
+    expect(files.get(IDENTITY.notePath)).toContain('captureStatus: skipped')
+    expect(readAssetMock).toHaveBeenCalledTimes(1)
+    expect(describeMock).not.toHaveBeenCalled()
+  })
+
+  it('does not resurrect a capture deleted during metadata fetch', async () => {
+    await drainOne()
+    scrapeMock.mockImplementation(async () => {
+      files.delete(IDENTITY.notePath)
+      return {
+        title: 'An article',
+        description: 'A scraped description.',
+        siteName: null,
+      }
+    })
+
+    const outcome = await reconcile()
+
+    expect(outcome).toEqual({ pending: 1, enriched: 0, skipped: 0, stopped: null })
+    expect(files.has(IDENTITY.notePath)).toBe(false)
     expect(describeMock).not.toHaveBeenCalled()
   })
 
@@ -275,10 +439,10 @@ describe('reconcileCaptureEnrichment', () => {
     expect(files.get(IDENTITY.notePath)).toContain('- Description: An AI description of the page.')
   })
 
-  it('a provider refusal falls back to the scraped description, done without AI provenance', async () => {
-    await drainOne()
+  it('a provider refusal falls back to scraped metadata, done without AI provenance', async () => {
+    await drainOne({ source: 'ios-share', title: '' })
     scrapeMock.mockResolvedValue({
-      title: 'An article',
+      title: 'A title from metadata',
       description: 'A scraped description.',
       siteName: null,
     })
@@ -288,9 +452,11 @@ describe('reconcileCaptureEnrichment', () => {
 
     expect(outcome.enriched).toBe(1)
     const note = files.get(IDENTITY.notePath) ?? ''
+    expect(note).toContain('# A title from metadata')
     expect(note).toContain('- Description: A scraped description.')
     expect(note).toContain('captureStatus: done')
     expect(note).not.toContain('captureProvider')
+    expect(files.get(DAILY)).toContain('|A title from metadata]]')
   })
 
   it('a provider refusal without scraped description does not stamp AI provenance', async () => {
@@ -321,13 +487,23 @@ describe('reconcileCaptureEnrichment', () => {
   })
 
   it('an auth failure from the provider stops the pass', async () => {
-    await drainOne()
+    await drainOne({ source: 'ios-share', title: '' })
+    scrapeMock.mockResolvedValue({
+      title: 'A title available without AI',
+      description: 'A description available without AI.',
+      siteName: null,
+    })
     describeMock.mockRejectedValue(new ReflectError('auth', 'key rejected'))
 
     const outcome = await reconcile()
 
     expect(outcome.stopped?.reason).toBe('auth')
-    expect(files.get(IDENTITY.notePath)).toContain('captureStatus: pending')
+    const note = files.get(IDENTITY.notePath) ?? ''
+    expect(note).toContain('# A title available without AI')
+    expect(note).toContain('- Description: A description available without AI.')
+    expect(note).toContain('captureStatus: pending')
+    expect(note).not.toContain('captureProvider')
+    expect(files.get(DAILY)).toContain('|A title available without AI]]')
   })
 
   it('retitles the note H1, screenshot alt, and daily link text from the AI title', async () => {
@@ -388,6 +564,98 @@ describe('reconcileCaptureEnrichment', () => {
     const daily = files.get(DAILY) ?? ''
     expect(daily).toContain('- jotted down mid-enrichment')
     expect(daily).toContain('|A Cleaned Up Article]]')
+  })
+
+  it('resumes the exact metadata checkpoint when its daily write fails', async () => {
+    await drainOne({ source: 'ios-share', title: '' })
+    scrapeMock.mockResolvedValue({
+      title: 'A title from metadata',
+      description: 'A scraped description.',
+      siteName: null,
+    })
+    writeNoteMock
+      .mockImplementationOnce(async (path, contents) => {
+        files.set(path, contents)
+      })
+      .mockRejectedValueOnce({ kind: 'io', message: 'disk full' })
+
+    const first = await reconcile({ providers: NO_PROVIDERS })
+
+    expect(first.stopped?.reason).toBe('io')
+    expect(files.get(DAILY)).toContain('|example.com]]')
+    expect(files.get(IDENTITY.notePath)).toContain('# A title from metadata')
+    expect(files.get(IDENTITY.notePath)).toContain('captureStatus: pending')
+    expect(files.get(IDENTITY.notePath)).toContain('captureDailyFromTitle: example.com')
+    expect(files.get(IDENTITY.notePath)).toContain('captureFinalizeStatus: done')
+
+    scrapeMock.mockResolvedValue({
+      title: 'A different title on retry',
+      description: 'A different description on retry.',
+      siteName: null,
+    })
+
+    const retry = await reconcile({ providers: NO_PROVIDERS })
+
+    expect(retry).toEqual({ pending: 1, enriched: 1, skipped: 0, stopped: null })
+    expect(files.get(DAILY)).toContain('|A title from metadata]]')
+    expect(files.get(IDENTITY.notePath)).toContain('# A title from metadata')
+    expect(files.get(IDENTITY.notePath)).not.toContain('A different title on retry')
+    expect(files.get(IDENTITY.notePath)).toContain('captureStatus: done')
+    expect(files.get(IDENTITY.notePath)).not.toContain('captureDailyFromTitle')
+    expect(files.get(IDENTITY.notePath)).not.toContain('captureFinalizeStatus')
+    expect(scrapeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves privacy set while a metadata retitle writes the daily backlink', async () => {
+    await drainOne({ source: 'ios-share', title: '' })
+    scrapeMock.mockResolvedValue({
+      title: 'A title from metadata',
+      description: 'A scraped description.',
+      siteName: null,
+    })
+    writeNoteMock
+      .mockImplementationOnce(async (path, contents) => {
+        files.set(path, contents)
+      })
+      .mockImplementationOnce(async (path, contents) => {
+        files.set(path, contents)
+        const prepared = files.get(IDENTITY.notePath) ?? ''
+        files.set(IDENTITY.notePath, prepared.replace('---\n', '---\nprivate: true\n'))
+      })
+
+    const outcome = await reconcile({ providers: NO_PROVIDERS })
+
+    expect(outcome).toEqual({ pending: 1, enriched: 0, skipped: 1, stopped: null })
+    const note = files.get(IDENTITY.notePath) ?? ''
+    expect(note).toContain('private: true')
+    expect(note).toContain('# A title from metadata')
+    expect(note).toContain('captureStatus: skipped')
+    expect(note).not.toContain('captureDailyFromTitle')
+    expect(note).not.toContain('captureFinalizeStatus')
+    expect(describeMock).not.toHaveBeenCalled()
+  })
+
+  it('does not overwrite capture edits made after metadata enrichment', async () => {
+    await drainOne({ source: 'ios-share', title: '' })
+    scrapeMock.mockResolvedValue({
+      title: 'A scraped title',
+      description: 'A scraped description.',
+      siteName: null,
+    })
+    describeMock.mockImplementation(async () => {
+      const staged = files.get(IDENTITY.notePath) ?? ''
+      files.set(IDENTITY.notePath, staged.replace('# A scraped title', '# My edited title'))
+      return { title: 'An AI title', description: 'An AI description.' }
+    })
+
+    const outcome = await reconcile()
+
+    expect(outcome).toEqual({ pending: 1, enriched: 0, skipped: 1, stopped: null })
+    const note = files.get(IDENTITY.notePath) ?? ''
+    expect(note).toContain('# My edited title')
+    expect(note).toContain('- Description: A scraped description.')
+    expect(note).not.toContain('An AI description.')
+    expect(note).toContain('captureStatus: skipped')
   })
 
   it('leaves a user-edited daily link text alone while still retitling the note', async () => {

--- a/packages/core/src/actions/capture-enrichment.test.ts
+++ b/packages/core/src/actions/capture-enrichment.test.ts
@@ -300,6 +300,26 @@ describe('reconcileCaptureEnrichment', () => {
     )
   })
 
+  it('applies scraped metadata while preserving a keychain failure', async () => {
+    await drainOne({ source: 'ios-share', title: '' })
+    scrapeMock.mockResolvedValue({
+      title: 'A title available without the keychain',
+      description: 'A description available without the keychain.',
+      siteName: null,
+    })
+    getSecretMock.mockRejectedValue(new ReflectError('io', 'keychain is unavailable'))
+
+    const outcome = await reconcile()
+
+    expect(outcome.stopped).toEqual({ reason: 'io', message: 'keychain is unavailable' })
+    const note = files.get(IDENTITY.notePath) ?? ''
+    expect(note).toContain('# A title available without the keychain')
+    expect(note).toContain('- Description: A description available without the keychain.')
+    expect(note).toContain('captureStatus: pending')
+    expect(note).toContain('captureMetadataStatus: done')
+    expect(describeMock).not.toHaveBeenCalled()
+  })
+
   it('skips an edited capture instead of clobbering it — zero outbound', async () => {
     await drainOne()
     const source = files.get(IDENTITY.notePath) ?? ''

--- a/packages/core/src/actions/capture-enrichment.test.ts
+++ b/packages/core/src/actions/capture-enrichment.test.ts
@@ -290,7 +290,7 @@ describe('reconcileCaptureEnrichment', () => {
     expect(enrichedNote).toContain('- Description: An AI description of the page.')
     expect(enrichedNote).toContain('captureStatus: done')
     expect(enrichedNote).toContain('captureProvider: openai')
-    expect(scrapeMock).toHaveBeenCalledTimes(1)
+    expect(scrapeMock).not.toHaveBeenCalled()
     expect(describeMock).toHaveBeenCalledWith(
       expect.objectContaining({
         title: 'First Chair on Instagram',
@@ -504,6 +504,23 @@ describe('reconcileCaptureEnrichment', () => {
     expect(note).toContain('captureStatus: pending')
     expect(note).not.toContain('captureProvider')
     expect(files.get(DAILY)).toContain('|A title available without AI]]')
+
+    scrapeMock.mockClear()
+    scrapeMock.mockRejectedValue(new ReflectError('network', 'offline'))
+    describeMock.mockResolvedValue({ title: null, description: 'A description from the retry.' })
+    const retry = await reconcile()
+
+    expect(retry).toEqual({ pending: 1, enriched: 1, skipped: 0, stopped: null })
+    expect(scrapeMock).not.toHaveBeenCalled()
+    expect(describeMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        title: 'A title available without AI',
+        metaTitle: 'A title available without AI',
+        metaDescription: 'A description available without AI.',
+      }),
+    )
+    expect(files.get(IDENTITY.notePath)).toContain('- Description: A description from the retry.')
+    expect(files.get(IDENTITY.notePath)).toContain('captureStatus: done')
   })
 
   it('retitles the note H1, screenshot alt, and daily link text from the AI title', async () => {

--- a/packages/core/src/actions/capture-enrichment.ts
+++ b/packages/core/src/actions/capture-enrichment.ts
@@ -286,6 +286,10 @@ export async function reconcileCaptureEnrichment(
 
       let pageMeta: PageMeta | null = null
       if (metadataComplete) {
+        // Deliberately lossy resume: the checkpoint keeps only what the note
+        // shows, so a retried AI call sees the current H1 as the meta title
+        // and loses `siteName` — close enough that persisting the raw scrape
+        // isn't worth another frontmatter field.
         pageMeta = {
           title: snapshot.title,
           description: captureDescriptionFromBody(snapshot.body) ?? null,
@@ -331,6 +335,10 @@ export async function reconcileCaptureEnrichment(
 
       if (config === null) {
         const titleChanged = metadataDisplayTitle !== snapshot.title
+        // Two persists on purpose: the retitle commits as `pending` first so
+        // an interrupted Daily write resumes as `pending`, letting a provider
+        // configured between passes still run AI on this capture. Only after
+        // the retitle fully lands does the second persist stamp `done`.
         const captureHash = await persistCaptureEnrichment({
           identity,
           expectedHash: snapshot.meta.captureHash,
@@ -450,5 +458,7 @@ export async function reconcileCaptureEnrichment(
       return outcome({ reason: toAppError(cause).kind, message: errorMessage(cause) })
     }
   }
+  // `waitingForKey` is only ever set when a provider is configured without a
+  // usable key, which is exactly when `providerStop` was populated above.
   return outcome(waitingForKey ? providerStop : null)
 }

--- a/packages/core/src/actions/capture-enrichment.ts
+++ b/packages/core/src/actions/capture-enrichment.ts
@@ -18,6 +18,7 @@ import {
 } from './capture-enrichment-write'
 import { captureFromPath, type CaptureIdentity } from './capture-identity'
 import {
+  captureDescriptionFromBody,
   captureNoteMeta,
   capturePageTextFromBody,
   displayTitle,
@@ -254,7 +255,8 @@ export async function reconcileCaptureEnrichment(
           continue
         }
       }
-      if (snapshot.meta.captureMetadataStatus === 'done' && apiKey === null) {
+      const metadataComplete = snapshot.meta.captureMetadataStatus === 'done'
+      if (metadataComplete && apiKey === null) {
         if (config !== null) {
           waitingForKey = true
           continue
@@ -278,14 +280,22 @@ export async function reconcileCaptureEnrichment(
       }
 
       let pageMeta: PageMeta | null = null
-      try {
-        pageMeta = await scrapePageMeta(snapshot.meta.captureUrl)
-      } catch (cause) {
-        const kind = toAppError(cause).kind
-        if (kind === 'network' || kind === 'auth') {
-          throw cause
+      if (metadataComplete) {
+        pageMeta = {
+          title: snapshot.title,
+          description: captureDescriptionFromBody(snapshot.body) ?? null,
+          siteName: null,
         }
-        pageMeta = null
+      } else {
+        try {
+          pageMeta = await scrapePageMeta(snapshot.meta.captureUrl)
+        } catch (cause) {
+          const kind = toAppError(cause).kind
+          if (kind === 'network' || kind === 'auth') {
+            throw cause
+          }
+          pageMeta = null
+        }
       }
       if (stale()) {
         return outcome({ reason: 'stale', message: 'the graph session ended mid-pass' })
@@ -331,19 +341,23 @@ export async function reconcileCaptureEnrichment(
         continue
       }
 
-      const metadataHash = await persistCaptureEnrichment({
-        identity,
-        expectedHash: snapshot.meta.captureHash,
-        body: metadataBody,
-        fromTitle: snapshot.title,
-        toTitle: metadataDisplayTitle,
-        status: 'pending',
-        provider: null,
-        generation: input.generation,
-      })
-      if (metadataHash === null) {
-        await skipPending(identity)
-        continue
+      let metadataHash = snapshot.meta.captureHash
+      if (!metadataComplete) {
+        const persistedHash = await persistCaptureEnrichment({
+          identity,
+          expectedHash: snapshot.meta.captureHash,
+          body: metadataBody,
+          fromTitle: snapshot.title,
+          toTitle: metadataDisplayTitle,
+          status: 'pending',
+          provider: null,
+          generation: input.generation,
+        })
+        if (persistedHash === null) {
+          await skipPending(identity)
+          continue
+        }
+        metadataHash = persistedHash
       }
       if (stale()) {
         return outcome({ reason: 'stale', message: 'the graph session ended mid-pass' })

--- a/packages/core/src/actions/capture-enrichment.ts
+++ b/packages/core/src/actions/capture-enrichment.ts
@@ -5,11 +5,17 @@ import { errorMessage, isAppError, toAppError } from '../errors'
 import { listFiles, readAsset, readNote, writeNote } from '../graph/commands'
 import { dailyPath } from '../graph/paths'
 import { hashContent } from '../indexing/hash'
-import { parseNote } from '../markdown/extract'
 import { parseFrontmatter, splitFrontmatter, upsertFrontmatter } from '../markdown/frontmatter'
 import { getSecret } from '../secrets/keychain'
 import type { AiProviderConfig } from '../settings/schema'
 import type { ReconcileStop } from './audio-memo'
+import {
+  finishCaptureWrite,
+  hasCaptureWriteTransaction,
+  persistCaptureEnrichment,
+  readPendingCaptureSnapshot,
+  type PendingCaptureSnapshot,
+} from './capture-enrichment-write'
 import { captureFromPath, type CaptureIdentity } from './capture-identity'
 import {
   captureNoteMeta,
@@ -19,11 +25,9 @@ import {
   metadataValue,
   notePrivate,
   noteSource,
-  retitleDailyEntry,
   withDescription,
   withTitle,
   type CaptureNoteMeta,
-  type CaptureStatus,
 } from './capture-note'
 import { scrapePageMeta, type PageMeta } from './meta-scrape'
 
@@ -91,26 +95,15 @@ interface GenerateEnrichmentInput {
   scraped: PageMeta | null
   /** The raw drain-written body (page text is extracted from it). */
   body: string
-  generation: number
+  screenshotBase64?: string | undefined
 }
 
 /**
- * The AI leg of one capture's enrichment: read the screenshot asset, make the
- * one-shot provider call, and treat a provider refusal as "no enrichment"
- * (`null`) — the scraped meta is the fallback. Transient failures (`auth`,
- * `network`) propagate for the pass to retry later.
+ * The AI leg of one capture's enrichment: make the one-shot provider call and
+ * treat a provider refusal as "no enrichment" (`null`) — the scraped meta is
+ * the fallback. Transient failures (`auth`, `network`) propagate for retry.
  */
 async function generateEnrichment(input: GenerateEnrichmentInput): Promise<PageEnrichment | null> {
-  let screenshotBase64: string | undefined
-  if (input.meta.captureScreenshot) {
-    try {
-      screenshotBase64 = await readAsset(input.meta.captureScreenshot, input.generation)
-    } catch (cause) {
-      if (!isAppError(cause) || cause.kind !== 'notFound') {
-        throw cause
-      }
-    }
-  }
   try {
     return await describePage({
       config: input.config,
@@ -122,7 +115,7 @@ async function generateEnrichment(input: GenerateEnrichmentInput): Promise<PageE
       siteName: input.scraped?.siteName ?? undefined,
       metaDescription: input.scraped?.description ?? undefined,
       contentText: capturePageTextFromBody(input.body),
-      screenshotBase64,
+      screenshotBase64: input.screenshotBase64,
     })
   } catch (cause) {
     if (!isDescriptionRejected(cause)) {
@@ -132,11 +125,29 @@ async function generateEnrichment(input: GenerateEnrichmentInput): Promise<PageE
   }
 }
 
+async function readCaptureScreenshot(
+  meta: CaptureNoteMeta,
+  generation: number,
+): Promise<string | undefined> {
+  if (!meta.captureScreenshot) {
+    return undefined
+  }
+  try {
+    return await readAsset(meta.captureScreenshot, generation)
+  } catch (cause) {
+    if (!isAppError(cause) || cause.kind !== 'notFound') {
+      throw cause
+    }
+    return undefined
+  }
+}
+
 /**
  * Enrich every pending capture: scrape the page's description and display
- * title, optionally replace them with AI output when a provider is configured
- * (retitling the note's H1 and the daily entry's link text), and stamp
- * `captureStatus: done`. Never throws.
+ * title and persist those before the optional AI call. A provider failure
+ * therefore leaves a useful capture pending for retry instead of hiding the
+ * metadata work; a completed/no-provider pass stamps `captureStatus: done`.
+ * Never throws.
  */
 export async function reconcileCaptureEnrichment(
   input: ReconcileCaptureEnrichmentInput,
@@ -159,23 +170,20 @@ export async function reconcileCaptureEnrichment(
 
   const config = defaultAiProvider(input.providers)
   let apiKey: string | null = null
+  let missingKeyStop: ReconcileStop | null = null
   if (config !== null) {
     apiKey = await getSecret(aiKeySecretName(config.id)).catch(() => null)
     if (apiKey === null) {
-      return {
-        pending: pending.length,
-        enriched: 0,
-        skipped: 0,
-        stopped: {
-          reason: 'config',
-          message: `The API key for the configured ${config.provider} model is missing from the keychain.`,
-        },
+      missingKeyStop = {
+        reason: 'config',
+        message: `The API key for the configured ${config.provider} model is missing from the keychain.`,
       }
     }
   }
 
   let enriched = 0
   let skipped = 0
+  let waitingForKey = false
   const stale = (): boolean => input.isStale?.() === true
   const outcome = (stopped: ReconcileStop | null): ReconcileCaptureEnrichmentOutcome => ({
     pending: pending.length,
@@ -186,10 +194,40 @@ export async function reconcileCaptureEnrichment(
   const markSkipped = async (source: string, identity: CaptureIdentity): Promise<void> => {
     await writeNote(
       identity.notePath,
-      upsertFrontmatter(source, { captureStatus: 'skipped' }),
+      upsertFrontmatter(source, {
+        captureStatus: 'skipped',
+        captureDailyFromTitle: undefined,
+        captureFinalizeStatus: undefined,
+      }),
       input.generation,
     )
     skipped += 1
+  }
+  const skipPending = async (identity: CaptureIdentity): Promise<void> => {
+    const snapshot = await readPendingCaptureSnapshot(identity, input.generation)
+    if (snapshot !== null) {
+      await markSkipped(snapshot.source, identity)
+    }
+  }
+  const currentCapture = async (
+    identity: CaptureIdentity,
+    expectedHash?: string,
+  ): Promise<PendingCaptureSnapshot | null> => {
+    const snapshot = await readPendingCaptureSnapshot(identity, input.generation)
+    if (snapshot === null) {
+      return null
+    }
+    const dailySource = await noteSource(dailyPath(identity.date), input.generation)
+    const bodyHash = await hashContent(snapshot.body)
+    if (
+      snapshot.isPrivate ||
+      notePrivate(dailySource) ||
+      bodyHash !== (expectedHash ?? snapshot.meta.captureHash)
+    ) {
+      await markSkipped(snapshot.source, identity)
+      return null
+    }
+    return snapshot
   }
 
   for (const identity of pending) {
@@ -197,35 +235,51 @@ export async function reconcileCaptureEnrichment(
       return outcome({ reason: 'stale', message: 'the graph session ended mid-pass' })
     }
     try {
-      let source: string
-      try {
-        source = await readNote(identity.notePath, input.generation)
-      } catch (cause) {
-        if (isAppError(cause) && cause.kind === 'notFound') {
+      let snapshot = await currentCapture(identity)
+      if (snapshot === null) {
+        continue
+      }
+      if (hasCaptureWriteTransaction(snapshot.meta)) {
+        const finalized = await finishCaptureWrite(identity, input.generation)
+        if (finalized === null) {
+          await skipPending(identity)
           continue
         }
-        throw cause
+        if (finalized === 'done') {
+          enriched += 1
+          continue
+        }
+        snapshot = await currentCapture(identity)
+        if (snapshot === null) {
+          continue
+        }
       }
-      const split = splitFrontmatter(source)
-      const frontmatter = parseFrontmatter(split.raw).data
-      const meta = captureNoteMeta(frontmatter)
-      if (meta === null || meta.captureStatus !== 'pending') {
-        continue
-      }
-
-      const dailySource = await noteSource(dailyPath(identity.date), input.generation)
-      if (frontmatter.private || notePrivate(dailySource)) {
-        await markSkipped(source, identity)
-        continue
-      }
-      if ((await hashContent(split.body)) !== meta.captureHash) {
-        await markSkipped(source, identity)
+      if (snapshot.meta.captureMetadataStatus === 'done' && apiKey === null) {
+        if (config !== null) {
+          waitingForKey = true
+          continue
+        }
+        const captureHash = await persistCaptureEnrichment({
+          identity,
+          expectedHash: snapshot.meta.captureHash,
+          body: snapshot.body,
+          fromTitle: snapshot.title,
+          toTitle: snapshot.title,
+          status: 'done',
+          provider: null,
+          generation: input.generation,
+        })
+        if (captureHash === null) {
+          await skipPending(identity)
+          continue
+        }
+        enriched += 1
         continue
       }
 
       let pageMeta: PageMeta | null = null
       try {
-        pageMeta = await scrapePageMeta(meta.captureUrl)
+        pageMeta = await scrapePageMeta(snapshot.meta.captureUrl)
       } catch (cause) {
         const kind = toAppError(cause).kind
         if (kind === 'network' || kind === 'auth') {
@@ -237,67 +291,126 @@ export async function reconcileCaptureEnrichment(
         return outcome({ reason: 'stale', message: 'the graph session ended mid-pass' })
       }
 
-      const title = parseNote({ path: identity.notePath, source }).title
-      let generated: PageEnrichment | null = null
-      if (config !== null && apiKey !== null) {
-        generated = await generateEnrichment({
-          config,
-          apiKey,
-          fetchFn: input.fetchFn,
-          meta,
-          title,
-          scraped: pageMeta,
-          body: split.body,
+      snapshot = await currentCapture(identity)
+      if (snapshot === null) {
+        continue
+      }
+      const placeholderTitle = displayTitle({ title: '', url: snapshot.meta.captureUrl })
+      const metadataTitle =
+        snapshot.title === placeholderTitle && pageMeta?.title
+          ? displayTitle({ title: pageMeta.title, url: snapshot.meta.captureUrl })
+          : null
+      const metadataDisplayTitle = metadataTitle ?? snapshot.title
+      const metadataDescription = hasDescription(snapshot.body)
+        ? null
+        : pageMeta?.description ?? null
+      let metadataBody =
+        metadataDescription !== null
+          ? withDescription(snapshot.body, metadataDescription)
+          : snapshot.body
+      if (metadataTitle !== null) {
+        metadataBody = withTitle(metadataBody, metadataTitle)
+      }
+
+      if (config === null) {
+        const captureHash = await persistCaptureEnrichment({
+          identity,
+          expectedHash: snapshot.meta.captureHash,
+          body: metadataBody,
+          fromTitle: snapshot.title,
+          toTitle: metadataDisplayTitle,
+          status: 'done',
+          provider: null,
           generation: input.generation,
         })
-        if (stale()) {
-          return outcome({ reason: 'stale', message: 'the graph session ended mid-pass' })
+        if (captureHash === null) {
+          await skipPending(identity)
+          continue
         }
+        enriched += 1
+        continue
+      }
+
+      const metadataHash = await persistCaptureEnrichment({
+        identity,
+        expectedHash: snapshot.meta.captureHash,
+        body: metadataBody,
+        fromTitle: snapshot.title,
+        toTitle: metadataDisplayTitle,
+        status: 'pending',
+        provider: null,
+        generation: input.generation,
+      })
+      if (metadataHash === null) {
+        await skipPending(identity)
+        continue
+      }
+      if (stale()) {
+        return outcome({ reason: 'stale', message: 'the graph session ended mid-pass' })
+      }
+      if (apiKey === null) {
+        waitingForKey = true
+        continue
+      }
+
+      snapshot = await currentCapture(identity, metadataHash)
+      if (snapshot === null) {
+        continue
+      }
+      const screenshotBase64 = await readCaptureScreenshot(snapshot.meta, input.generation)
+      if (stale()) {
+        return outcome({ reason: 'stale', message: 'the graph session ended mid-pass' })
+      }
+      snapshot = await currentCapture(identity, metadataHash)
+      if (snapshot === null) {
+        continue
+      }
+      const generated: PageEnrichment | null = await generateEnrichment({
+        config,
+        apiKey,
+        fetchFn: input.fetchFn,
+        meta: snapshot.meta,
+        title: snapshot.title,
+        scraped: pageMeta,
+        body: snapshot.body,
+        screenshotBase64,
+      })
+      if (stale()) {
+        return outcome({ reason: 'stale', message: 'the graph session ended mid-pass' })
+      }
+
+      snapshot = await currentCapture(identity, metadataHash)
+      if (snapshot === null) {
+        continue
       }
       const aiTitle = generated?.title ?? null
-      const placeholderTitle = displayTitle({ title: '', url: meta.captureUrl })
-      const metadataTitle =
-        title === placeholderTitle && pageMeta?.title
-          ? displayTitle({ title: pageMeta.title, url: meta.captureUrl })
-          : null
-      const enrichedTitle = aiTitle ?? metadataTitle
+      const enrichedTitle = aiTitle ?? snapshot.title
       const description = generated?.description ?? null
 
       const usedAiDescription = description !== null && metadataValue(description) !== ''
-      const usedAi = (usedAiDescription || aiTitle !== null) && config !== null
-      const text = usedAiDescription
-        ? description
-        : hasDescription(split.body)
-          ? null
-          : pageMeta?.description ?? null
-      let newBody = text !== null ? withDescription(split.body, text) : split.body
-      if (enrichedTitle !== null) {
-        newBody = withTitle(newBody, enrichedTitle)
+      const usedAi = usedAiDescription || aiTitle !== null
+      let newBody = usedAiDescription ? withDescription(snapshot.body, description) : snapshot.body
+      if (aiTitle !== null) {
+        newBody = withTitle(newBody, aiTitle)
       }
-      const reassembled = source.slice(0, split.bodyOffset) + newBody
-      await writeNote(
-        identity.notePath,
-        upsertFrontmatter(reassembled, {
-          captureStatus: 'done' satisfies CaptureStatus,
-          captureHash: await hashContent(newBody),
-          captureProvider: usedAi ? config.provider : undefined,
-          captureModel: usedAi ? config.model : undefined,
-        }),
-        input.generation,
-      )
-      if (enrichedTitle !== null && enrichedTitle !== title) {
-        // Re-read the daily: the network work above is slow, and the pre-call
-        // snapshot would silently drop anything written meanwhile.
-        const freshDaily = await noteSource(dailyPath(identity.date), input.generation)
-        const retitled = retitleDailyEntry(freshDaily, identity.base, title, enrichedTitle)
-        if (retitled !== freshDaily) {
-          await writeNote(dailyPath(identity.date), retitled, input.generation)
-        }
+      const captureHash = await persistCaptureEnrichment({
+        identity,
+        expectedHash: metadataHash,
+        body: newBody,
+        fromTitle: snapshot.title,
+        toTitle: enrichedTitle,
+        status: 'done',
+        provider: usedAi ? config : null,
+        generation: input.generation,
+      })
+      if (captureHash === null) {
+        await skipPending(identity)
+        continue
       }
       enriched += 1
     } catch (cause) {
       return outcome({ reason: toAppError(cause).kind, message: errorMessage(cause) })
     }
   }
-  return outcome(null)
+  return outcome(waitingForKey ? missingKeyStop : null)
 }

--- a/packages/core/src/actions/capture-enrichment.ts
+++ b/packages/core/src/actions/capture-enrichment.ts
@@ -171,11 +171,16 @@ export async function reconcileCaptureEnrichment(
 
   const config = defaultAiProvider(input.providers)
   let apiKey: string | null = null
-  let missingKeyStop: ReconcileStop | null = null
+  let providerStop: ReconcileStop | null = null
   if (config !== null) {
-    apiKey = await getSecret(aiKeySecretName(config.id)).catch(() => null)
-    if (apiKey === null) {
-      missingKeyStop = {
+    try {
+      apiKey = await getSecret(aiKeySecretName(config.id))
+    } catch (cause) {
+      const error = toAppError(cause)
+      providerStop = { reason: error.kind, message: error.message }
+    }
+    if (apiKey === null && providerStop === null) {
+      providerStop = {
         reason: 'config',
         message: `The API key for the configured ${config.provider} model is missing from the keychain.`,
       }
@@ -294,6 +299,8 @@ export async function reconcileCaptureEnrichment(
           if (kind === 'network' || kind === 'auth') {
             throw cause
           }
+          // Invalid URLs, non-HTML responses, and non-success statuses are
+          // permanent for this capture; checkpoint the no-metadata result.
           pageMeta = null
         }
       }
@@ -426,5 +433,5 @@ export async function reconcileCaptureEnrichment(
       return outcome({ reason: toAppError(cause).kind, message: errorMessage(cause) })
     }
   }
-  return outcome(waitingForKey ? missingKeyStop : null)
+  return outcome(waitingForKey ? providerStop : null)
 }

--- a/packages/core/src/actions/capture-enrichment.ts
+++ b/packages/core/src/actions/capture-enrichment.ts
@@ -330,19 +330,36 @@ export async function reconcileCaptureEnrichment(
       }
 
       if (config === null) {
+        const titleChanged = metadataDisplayTitle !== snapshot.title
         const captureHash = await persistCaptureEnrichment({
           identity,
           expectedHash: snapshot.meta.captureHash,
           body: metadataBody,
           fromTitle: snapshot.title,
           toTitle: metadataDisplayTitle,
-          status: 'done',
+          status: titleChanged ? 'pending' : 'done',
           provider: null,
           generation: input.generation,
         })
         if (captureHash === null) {
           await skipPending(identity)
           continue
+        }
+        if (titleChanged) {
+          const finalizedHash = await persistCaptureEnrichment({
+            identity,
+            expectedHash: captureHash,
+            body: metadataBody,
+            fromTitle: metadataDisplayTitle,
+            toTitle: metadataDisplayTitle,
+            status: 'done',
+            provider: null,
+            generation: input.generation,
+          })
+          if (finalizedHash === null) {
+            await skipPending(identity)
+            continue
+          }
         }
         enriched += 1
         continue

--- a/packages/core/src/actions/capture-note.ts
+++ b/packages/core/src/actions/capture-note.ts
@@ -141,13 +141,26 @@ export function metadataValue(text: string): string {
   return text.replace(/\s+/g, ' ').trim()
 }
 
+const DESCRIPTION_PREFIX = '- Description: '
+
 function descriptionLineIndex(metadataLines: readonly string[]): number {
-  return metadataLines.findIndex((candidate) => candidate.startsWith('- Description: '))
+  return metadataLines.findIndex((candidate) => candidate.startsWith(DESCRIPTION_PREFIX))
 }
 
 /** Does the raw body already carry a description metadata bullet? */
 export function hasDescription(body: string): boolean {
   return descriptionLineIndex(body.slice(0, firstSectionStart(body)).split('\n')) !== -1
+}
+
+/** The capture's persisted metadata description, when present. */
+export function captureDescriptionFromBody(body: string): string | undefined {
+  const metadataLines = body.slice(0, firstSectionStart(body)).split('\n')
+  const descriptionLine = descriptionLineIndex(metadataLines)
+  if (descriptionLine === -1) {
+    return undefined
+  }
+  const description = metadataValue(metadataLines[descriptionLine]!.slice(DESCRIPTION_PREFIX.length))
+  return description === '' ? undefined : description
 }
 
 /**
@@ -209,7 +222,7 @@ export function retitleDailyEntry(
  * raw body has a `- Type: #link` anchor.
  */
 export function withDescription(body: string, description: string): string {
-  const line = `- Description: ${metadataValue(description)}`
+  const line = `${DESCRIPTION_PREFIX}${metadataValue(description)}`
   const metadataEnd = firstSectionStart(body)
   const metadataLines = body.slice(0, metadataEnd).split('\n')
   const descriptionLine = descriptionLineIndex(metadataLines)

--- a/packages/core/src/actions/capture-note.ts
+++ b/packages/core/src/actions/capture-note.ts
@@ -8,7 +8,14 @@ import type { Frontmatter } from '../markdown/model'
 import type { CaptureIdentity } from './capture-identity'
 import type { CaptureEnvelope } from './capture-envelope'
 
-/** Enrichment lifecycle of a capture note, in its frontmatter. */
+/**
+ * Enrichment lifecycle of a capture note, in its frontmatter. `skipped` means
+ * enrichment stopped touching the note — an edit, a privacy flip, or a
+ * deletion race won. Any checkpoint persisted before the skip, including AI
+ * content and its `captureProvider`/`captureModel` provenance, stays exactly
+ * as written: the stamps describe who authored the persisted text, not
+ * whether the capture finished.
+ */
 export type CaptureStatus = 'pending' | 'done' | 'skipped'
 
 const captureNoteMetaSchema = z.object({

--- a/packages/core/src/actions/capture-note.ts
+++ b/packages/core/src/actions/capture-note.ts
@@ -14,8 +14,11 @@ export type CaptureStatus = 'pending' | 'done' | 'skipped'
 const captureNoteMetaSchema = z.object({
   captureUrl: z.string(),
   captureStatus: z.enum(['pending', 'done', 'skipped']),
+  /** The metadata attempt completed, including a permanently unsuitable page. */
   captureMetadataStatus: z.literal('done').optional(),
+  /** Prior Daily alias; paired with `captureFinalizeStatus` during a retitle. */
   captureDailyFromTitle: z.string().optional(),
+  /** Status to commit after the paired Daily alias update succeeds. */
   captureFinalizeStatus: z.enum(['pending', 'done']).optional(),
   captureHash: z.string(),
   captureSelectionHash: z.string().optional(),

--- a/packages/core/src/actions/capture-note.ts
+++ b/packages/core/src/actions/capture-note.ts
@@ -14,6 +14,9 @@ export type CaptureStatus = 'pending' | 'done' | 'skipped'
 const captureNoteMetaSchema = z.object({
   captureUrl: z.string(),
   captureStatus: z.enum(['pending', 'done', 'skipped']),
+  captureMetadataStatus: z.literal('done').optional(),
+  captureDailyFromTitle: z.string().optional(),
+  captureFinalizeStatus: z.enum(['pending', 'done']).optional(),
   captureHash: z.string(),
   captureSelectionHash: z.string().optional(),
   captureScreenshot: z.string().optional(),

--- a/packages/core/src/actions/meta-scrape.test.ts
+++ b/packages/core/src/actions/meta-scrape.test.ts
@@ -20,6 +20,22 @@ describe('parsePageMeta', () => {
     })
   })
 
+  it('parses the OpenGraph shape returned for an Instagram reel', () => {
+    const meta = parsePageMeta(`
+      <html><head>
+        <meta property="og:title" content="First Chair on Instagram: &quot;A walnut lounge chair&quot;">
+        <meta property="og:description" content="Furniture &amp; decor from an independent studio.">
+        <meta property="og:site_name" content="Instagram">
+      </head><body></body></html>
+    `)
+
+    expect(meta).toEqual({
+      title: 'First Chair on Instagram: "A walnut lounge chair"',
+      description: 'Furniture & decor from an independent studio.',
+      siteName: 'Instagram',
+    })
+  })
+
   it('falls back to <title> and the meta description', () => {
     const meta = parsePageMeta(
       '<html><head><title>Doc title</title><meta name="description" content="Plain"></head></html>',


### PR DESCRIPTION
## Problem

URL-only shares from iOS can stay as raw hostname notes even when the destination page exposes useful OpenGraph metadata. The enrichment pass looked up the optional AI key before scraping and did not persist scraped metadata until after the AI request completed. A missing key, provider error, or slow request therefore left captures such as an Instagram Reel displayed only as www.instagram.com.

This PR fixes pending captures. It intentionally does not backfill captures that were already marked done by an older build.

## Before -> After

| Situation | Before | After |
| --- | --- | --- |
| AI request is slow | Hostname remains visible until AI finishes | Scraped title and description appear immediately |
| Configured AI key is missing | Enrichment stops before scraping | Metadata is saved; AI remains pending for retry |
| Provider fails or refuses | Capture remains a raw hostname | Scraped metadata remains visible and retryable/finalized as appropriate |
| Note changes while work is in flight | A stale write could overwrite the change | The capture is re-read, privacy-checked, and skipped without clobbering user data |

## Changes

1. Persist page metadata as a durable checkpoint before optional AI enrichment, including title, description, screenshot alt text, and the Daily backlink alias.
2. Treat saved metadata as authoritative on AI retries, so missing keys, provider failures, or later page-fetch errors do not trigger another scrape or hide the checkpoint.
3. Make capture-note and Daily retitles recoverable across partial write failures. A prepared pending note records the prior Daily title and intended final status, then resumes that exact checkpoint on the next pass. Provider configuration is re-evaluated after a metadata-only resume, so newly configured AI still runs.
4. Re-read capture and Daily state after slow scrape, screenshot, provider, and cross-file write steps so edits, deletion, and private notes are preserved and private content is not sent to AI.
5. Add an Instagram-shaped OpenGraph fixture and regression coverage for missing keys, provider failures, deferred AI, concurrent edits/privacy/deletion, and interrupted writes.

## Tests

- URL-only iOS and Instagram shares receive the scraped title and description before AI completes.
- Missing-key and provider-error retries reuse the metadata checkpoint without another page fetch, while keychain failures remain visible as their original error.
- Provider refusal/auth failures preserve metadata without false AI provenance.
- Edits, deletion, and privacy changes during scrape, screenshot loading, AI, and Daily retitling are not overwritten.
- A failed Daily write resumes the exact first checkpoint without re-scraping, including when a provider and key are configured between retries.

## Verification

- pnpm --filter @reflect/core test — 98 files, 1,398 tests passed
- pnpm check — typecheck and lint passed; only the two existing max-lines warnings remain
- pnpm build — production desktop and extension builds passed; only existing Sentry-token and chunk-size warnings remain
- git diff --check — passed

## Risk / Rollout

This adds optional internal capture frontmatter fields. There is no migration: old notes continue to parse, and existing pending captures self-heal during the next enrichment pass. The transaction fields exist only while a note/Daily retitle is unfinished and are cleared after completion or skip. Captures already marked done by older versions are not automatically revisited.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches capture enrichment, note/Daily writes, privacy gates, and optional AI calls; behavior is heavily tested but the reconcile loop and new frontmatter transaction fields add complexity for in-flight edge cases.
> 
> **Overview**
> URL-only shares (e.g. Instagram reels) no longer stay as raw hostnames while AI or keychain work is pending. **Scraped OpenGraph title, description, H1, screenshot alt, and Daily backlink are written as a durable checkpoint before any provider call**, and AI retries reuse that checkpoint without re-scraping.
> 
> The reconcile pass **no longer aborts the whole pass on a missing API key**—it scrapes and saves metadata, leaves the capture `pending`, and reports `config` only when AI is still blocked. Keychain I/O errors surface as `stopped` while metadata remains visible.
> 
> **Two-file retitles** (capture note + Daily alias) are recoverable via new frontmatter (`captureMetadataStatus`, `captureDailyFromTitle`, `captureFinalizeStatus`) and a dedicated `capture-enrichment-write` module (`persistCaptureEnrichment`, `finishCaptureWrite`). After slow scrape, screenshot load, or AI, captures are **re-read** with hash and privacy checks so user edits, deletion, or `private` notes are skipped instead of overwritten or sent to AI.
> 
> Adds `captureDescriptionFromBody` for resume, an Instagram OpenGraph parse fixture, and broad regression tests for deferred AI, missing keys, interrupted Daily writes, and in-flight edits/privacy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09c16515923f09c75d77fb26f8e7774e011f07ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capture enrichment now stamps scraped title/description immediately and then continues AI enrichment when available, improving responsiveness and safe resumptions.
  * Added more granular capture status tracking for metadata completion and dependent daily backlink retitling.
* **Bug Fixes**
  * Prevents overwriting user edits, preserves privacy changes made during processing, and avoids resurrecting deleted captures.
  * Improved handling for missing config, auth failures, and provider refusals—stopping or completing appropriately while keeping the capture state consistent.
  * More resilient checkpointing when daily updates encounter I/O errors.
* **Tests**
  * Expanded coverage for OpenGraph parsing (Instagram reel) and added enrichment/resume regression cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->