### PR TITLE
fix: accept Anthropic API keys from orgs that disallow browser CORS requests

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -60,7 +60,9 @@ git2 = { version = "0.21.0", default-features = false, features = [
   "vendored-libgit2",
   "vendored-openssl",
 ] }
-tauri-plugin-http = "2.5.9"
+# unsafe-headers lets provider-fetch.ts pass an explicit empty Origin, which
+# the plugin treats as "send no Origin header" (see providerFetch's doc).
+tauri-plugin-http = { version = "2.5.9", features = ["unsafe-headers"] }
 # Link capture (Plan 11): screenshot downscale + the bounded meta-scrape fetch.
 # reqwest 0.12 rides the exact version tauri-plugin-http already compiles.
 image = { version = "0.25.10", default-features = false, features = ["jpeg", "png"] }

--- a/apps/desktop/src/lib/provider-fetch.test.ts
+++ b/apps/desktop/src/lib/provider-fetch.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { setBridge } from '@reflect/core'
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
+import { providerFetch } from './provider-fetch'
+
+vi.mock('@tauri-apps/plugin-http', () => ({ fetch: vi.fn() }))
+const httpFetch = vi.mocked(tauriFetch)
+
+afterEach(() => {
+  setBridge(null)
+  httpFetch.mockReset()
+  vi.unstubAllGlobals()
+})
+
+function installBridge(): void {
+  setBridge({ invoke: async () => null, listen: async () => () => {} })
+}
+
+describe('providerFetch', () => {
+  it('sends an explicit empty Origin so the plugin drops the header', async () => {
+    installBridge()
+    httpFetch.mockResolvedValue(new Response(null, { status: 200 }))
+
+    await providerFetch('https://api.anthropic.com/v1/models', {
+      headers: { 'x-api-key': 'sk-ant-test' },
+    })
+
+    const [, init] = httpFetch.mock.calls[0]!
+    const headers = new Headers(init?.headers)
+    expect(headers.get('Origin')).toBe('')
+    expect(headers.get('x-api-key')).toBe('sk-ant-test')
+  })
+
+  it('leaves a caller-set Origin alone', async () => {
+    installBridge()
+    httpFetch.mockResolvedValue(new Response(null, { status: 200 }))
+
+    await providerFetch('https://api.anthropic.com/v1/models', {
+      headers: { Origin: 'https://reflect.example' },
+    })
+
+    const [, init] = httpFetch.mock.calls[0]!
+    expect(new Headers(init?.headers).get('Origin')).toBe('https://reflect.example')
+  })
+
+  it('falls back to the global fetch (untouched init) without a bridge', async () => {
+    const globalFetch = vi.fn(async () => new Response(null, { status: 200 }))
+    vi.stubGlobal('fetch', globalFetch)
+
+    await providerFetch('https://api.anthropic.com/v1/models', undefined)
+
+    expect(globalFetch).toHaveBeenCalledWith('https://api.anthropic.com/v1/models', undefined)
+    expect(httpFetch).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/provider-fetch.ts
+++ b/apps/desktop/src/lib/provider-fetch.ts
@@ -8,7 +8,25 @@ import { hasBridge } from '@reflect/core'
  * headers and would be unreachable from the webview otherwise). The allowed
  * hosts are scoped in `src-tauri/capabilities/default.json`. In plain-browser
  * dev there is no shell, so this falls back to the global fetch.
+ *
+ * The plugin stamps the webview's `Origin` (`tauri://localhost`) on every
+ * request, which makes providers treat the app as a web page: Anthropic
+ * answers any Origin-bearing request with a blanket 401 for organizations
+ * with custom data-retention settings — the
+ * `anthropic-dangerous-direct-browser-access` opt-in cannot override that
+ * org policy, so keys from such orgs looked "rejected" on entry. These are
+ * app → API calls, not page scripts, so send no Origin at all: an explicit
+ * empty `Origin` tells the plugin to drop the header entirely (its
+ * `unsafe-headers` feature, enabled in `src-tauri/Cargo.toml`, makes the
+ * empty value an explicit removal).
  */
 export function providerFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
-  return hasBridge() ? tauriFetch(input, init) : fetch(input, init)
+  if (!hasBridge()) {
+    return fetch(input, init)
+  }
+  const headers = new Headers(init?.headers)
+  if (!headers.has('Origin')) {
+    headers.set('Origin', '')
+  }
+  return tauriFetch(input, { ...init, headers })
 }


### PR DESCRIPTION
## Summary

- send an explicit empty `Origin` header on `providerFetch` calls so the Tauri HTTP plugin omits the header entirely (its `unsafe-headers` feature turns an empty `Origin` into an explicit removal)
- enable the plugin's `unsafe-headers` feature in `src-tauri/Cargo.toml`
- add a regression test for the header behavior on both transports

## The problem

`tauri-plugin-http` unconditionally stamps the webview's `Origin` (`tauri://localhost`) on every outgoing request. Anthropic treats any Origin-bearing request as a browser CORS request, and for organizations with custom data-retention settings it rejects **all** CORS requests with a 401:

```
{"type":"error","error":{"type":"authentication_error","message":"CORS requests
are not allowed for this Organization because of custom retention settings. ..."}}
```

The `anthropic-dangerous-direct-browser-access: true` header the app already sends cannot override that org-level policy. The result: a perfectly valid key from such an org fails the add-provider probe (`GET /v1/models` → 401) and surfaces as "Anthropic rejected this API key." — and even if saved unverified, every chat/describe call hits the same 401. Reproducible with curl by adding any `Origin` header (any value, any scheme) to an otherwise-working request.

## The fix

These are app → API calls, not page scripts, so no Origin should be sent at all — matching how server-side SDKs call the same APIs. The plugin supports exactly this: with the `unsafe-headers` feature enabled, a caller-supplied `Origin` suppresses the webview-origin stamping, and an *empty* `Origin` value removes the header entirely (the plugin's own escape hatch, commented "Some services do not like Origin header").

`providerFetch` now sets `Origin: ''` (unless a caller set one) on the Tauri transport. The plain-browser dev fallback is untouched — real browsers control Origin themselves. GitHub sync/gist/device-flow traffic also rides `providerFetch`; the GitHub API ignores the Origin header on token-authenticated calls, so it is unaffected.

## Testing

- Verified against the live Anthropic API: the validation probe with a retention-locked org key returns 401 with any `Origin` header present and 200 with the header absent.
- Added `provider-fetch.test.ts` covering the empty-Origin injection, caller-set Origin passthrough, and the no-bridge fallback.
- Local `pnpm test`/`typecheck`/`lint` couldn't run on my machine (corporate registry quarantines the brand-new `@meowdown@0.55.0` tarballs for 48h) — relying on CI here; happy to follow up on anything it flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop network requests by preventing unintended `Origin` headers when none are provided.
  * Preserved explicitly supplied `Origin` headers.
  * Maintained standard browser fetch behavior when the desktop bridge is unavailable.

* **Tests**
  * Added coverage for header handling and fallback request behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->