### PR TITLE
fix(desktop): eliminate white flash on window startup

### DIFF
--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -11,6 +11,7 @@
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
     />
     <title>Reflect</title>
+    <script src="/theme-init.js"></script>
   </head>
 
   <body>

--- a/apps/desktop/public/theme-init.js
+++ b/apps/desktop/public/theme-init.js
@@ -1,0 +1,10 @@
+// Match the OS theme before the design-system CSS applies, so a dark-mode
+// user does not see a light-to-dark flash between the first paint and the
+// ThemeProvider mounting. The ThemeProvider (`providers/theme-provider.tsx`)
+// overrides this once user settings load. Kept as an external file because
+// the app CSP is `script-src 'self'` — inline scripts would be blocked.
+(function () {
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+  document.documentElement.classList.toggle('dark', prefersDark)
+  document.documentElement.style.colorScheme = prefersDark ? 'dark' : 'light'
+})()

--- a/apps/desktop/public/theme-init.js
+++ b/apps/desktop/public/theme-init.js
@@ -1,10 +1,30 @@
-// Match the OS theme before the design-system CSS applies, so a dark-mode
-// user does not see a light-to-dark flash between the first paint and the
-// ThemeProvider mounting. The ThemeProvider (`providers/theme-provider.tsx`)
-// overrides this once user settings load. Kept as an external file because
-// the app CSP is `script-src 'self'` — inline scripts would be blocked.
+// Apply the theme before the design-system CSS does, so the first painted
+// frame is already the theme the user will end up on — otherwise a dark-mode
+// user sees a light-to-dark flash between that paint and the ThemeProvider
+// mounting. Kept as an external file because the app CSP is
+// `script-src 'self'`: inline scripts would be blocked.
+//
+// The persisted preference lives in the settings document, which only arrives
+// over IPC after the first paint, so `ThemeProvider`
+// (`src/providers/theme-provider.tsx`) mirrors it into localStorage for the
+// next launch. A pinned `light`/`dark` wins here; `system`, a first launch, and
+// an unreadable cache all fall back to the OS preference. ThemeProvider
+// re-applies the real value once settings load.
 (function () {
+  // Keep in sync with THEME_PREFERENCE_CACHE_KEY in src/lib/theme-cache.ts.
+  const PREFERENCE_KEY = 'reflect.theme.preference'
+
+  function pinnedTheme() {
+    try {
+      const preference = localStorage.getItem(PREFERENCE_KEY)
+      return preference === 'light' || preference === 'dark' ? preference : null
+    } catch {
+      return null
+    }
+  }
+
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-  document.documentElement.classList.toggle('dark', prefersDark)
-  document.documentElement.style.colorScheme = prefersDark ? 'dark' : 'light'
+  const theme = pinnedTheme() ?? (prefersDark ? 'dark' : 'light')
+  document.documentElement.classList.toggle('dark', theme === 'dark')
+  document.documentElement.style.colorScheme = theme
 })()

--- a/apps/desktop/public/theme-init.js
+++ b/apps/desktop/public/theme-init.js
@@ -10,7 +10,7 @@
 // next launch. A pinned `light`/`dark` wins here; `system`, a first launch, and
 // an unreadable cache all fall back to the OS preference. ThemeProvider
 // re-applies the real value once settings load.
-(function () {
+;(function () {
   // Keep in sync with THEME_PREFERENCE_CACHE_KEY in src/lib/theme-cache.ts.
   const PREFERENCE_KEY = 'reflect.theme.preference'
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -198,10 +198,14 @@ pub fn run() {
     // (see `open_note_window` in windows.rs). `Once` fires exactly on the
     // first Finished so reloads (⌘R, dev HMR, webview crash recovery)
     // never re-steal focus. `on_page_load` also fires for note windows;
-    // filter by label so this handler only reveals the main one.
+    // filter by label so this handler only reveals the main one. Ready still
+    // matters as the point where the fallback reveal is armed, below.
+    #[cfg(desktop)]
+    let revealed_main = std::sync::Arc::new(std::sync::Once::new());
+
     #[cfg(desktop)]
     let builder = {
-        let revealed = std::sync::Once::new();
+        let revealed = std::sync::Arc::clone(&revealed_main);
         builder.on_page_load(move |webview, payload| {
             if webview.label() != windows::MAIN_WINDOW_LABEL {
                 return;
@@ -229,9 +233,9 @@ pub fn run() {
     #[cfg(mobile)]
     let builder = builder.plugin(tauri_plugin_recording::init());
 
-    // The main window starts hidden (`visible: false`); desktop reveals it on
-    // Ready after restoring geometry, but mobile has no window-state plugin,
-    // so show it here or the UI would never appear.
+    // The main window starts hidden (`visible: false`); desktop reveals it
+    // from the page-load hook above after restoring geometry, but mobile has
+    // no window-state plugin, so show it here or the UI would never appear.
     #[cfg(mobile)]
     let builder = builder.setup(|app| {
         // Before anything else can crash: this is the only reporter that sees
@@ -373,7 +377,24 @@ pub fn run() {
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
-        .run(|app, event| match &event {
+        .run(move |app, event| match &event {
+            // Ready no longer reveals the main window — the page-load hook
+            // above does, once the webview has painted. It is still the first
+            // point where the window and an app handle both exist, so arm the
+            // fallback that reveals it anyway if that load never finishes.
+            // (Arming from `.setup()` would silently replace the deep-link
+            // registration hook, which Tauri stores as a single callback.)
+            #[cfg(desktop)]
+            tauri::RunEvent::Ready => {
+                let app = app.clone();
+                windows::arm_reveal_fallback(
+                    &revealed_main,
+                    windows::MAIN_WINDOW_LABEL,
+                    move || {
+                        windows::surface_main_window(&app);
+                    },
+                );
+            }
             // Clicking the Dock icon is macOS's recovery path when an app has
             // no visible windows. Surface the hidden/minimized main window,
             // or recreate it after an unexpected destruction.

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -171,7 +171,10 @@ pub fn run() {
     // geometry before first paint — avoiding a visible jump. Visibility is
     // deliberately not persistent: shutdown and updater relaunches can observe
     // a transiently hidden window, which must not suppress every later launch.
-    // The Ready event reveals the restored window below.
+    // The page-load hook below reveals it once the webview paints its first
+    // frame, so `theme-init.js` has applied the OS-preferred `.dark` scope
+    // before the window becomes visible — otherwise WKWebView flashes its
+    // default white backing between show() and the first HTML paint.
     #[cfg(desktop)]
     let builder = builder
         .plugin(tauri_plugin_updater::Builder::new().build())
@@ -185,6 +188,32 @@ pub fn run() {
                 .with_filter(|label| !label.starts_with(windows::NOTE_WINDOW_PREFIX))
                 .build(),
         );
+
+    // Reveal the main window on `PageLoadEvent::Finished`, not on
+    // `RunEvent::Ready`. Ready only guarantees plugin init + window-state
+    // geometry restore have finished — it does not wait for the webview to
+    // load the frontend, so on warm launches WKWebView is still on its
+    // default white backing when show() runs, producing the intermittent
+    // startup flash. Note windows already gate on Finished the same way
+    // (see `open_note_window` in windows.rs). `Once` fires exactly on the
+    // first Finished so reloads (⌘R, dev HMR, webview crash recovery)
+    // never re-steal focus. `on_page_load` also fires for note windows;
+    // filter by label so this handler only reveals the main one.
+    #[cfg(desktop)]
+    let builder = {
+        let revealed = std::sync::Once::new();
+        builder.on_page_load(move |webview, payload| {
+            if webview.label() != windows::MAIN_WINDOW_LABEL {
+                return;
+            }
+            if !matches!(payload.event(), tauri::webview::PageLoadEvent::Finished) {
+                return;
+            }
+            revealed.call_once(|| {
+                windows::surface_main_window(webview.app_handle());
+            });
+        })
+    };
 
     // The keyboard bridge (Plan 19, decision 8) is mobile-only: desktop has
     // no software keyboard to track. (Sharing uses the webview's Web Share
@@ -345,14 +374,6 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(|app, event| match &event {
-            // Config windows are built before Ready, including the synchronous
-            // window-state restore. Reveal the main window only after that
-            // geometry is settled, regardless of any stale persisted
-            // visibility from an older build.
-            #[cfg(desktop)]
-            tauri::RunEvent::Ready => {
-                windows::surface_main_window(app);
-            }
             // Clicking the Dock icon is macOS's recovery path when an app has
             // no visible windows. Surface the hidden/minimized main window,
             // or recreate it after an unexpected destruction.

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -11,7 +11,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
-use std::sync::{Mutex, MutexGuard};
+use std::sync::{Mutex, MutexGuard, Once};
 
 use serde::Serialize;
 use tauri::{Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
@@ -78,8 +78,38 @@ pub(crate) fn restorable_window_state_flags() -> tauri_plugin_window_state::Stat
         | StateFlags::FULLSCREEN
 }
 
+/// Resolve the OS-preferred theme background for `window`. Values mirror
+/// `--surface-app` in `design-system/tokens/colors.css` (`:root` and `.dark`
+/// scopes) so the native layer matches the first webview paint.
+fn theme_background_color<R: tauri::Runtime>(
+    window: &tauri::WebviewWindow<R>,
+) -> tauri::webview::Color {
+    use tauri::webview::Color;
+    use tauri::Theme;
+
+    match window.theme() {
+        Ok(Theme::Dark) => Color(10, 15, 30, 255),
+        _ => Color(248, 250, 250, 255),
+    }
+}
+
+/// Paint the native window in the OS-preferred theme color before its first
+/// reveal. Without this, the webview layer paints white for the frames between
+/// `show()` and the frontend applying the design-system's `.dark` scope, so a
+/// dark-mode user sees a white-to-dark flash. macOS's webview layer ignores
+/// `set_background_color` — the paired theme script
+/// (`apps/desktop/public/theme-init.js`, loaded from `index.html`) handles
+/// that side.
+#[cfg(desktop)]
+fn apply_theme_background<R: tauri::Runtime>(window: &tauri::WebviewWindow<R>) {
+    if let Err(err) = window.set_background_color(Some(theme_background_color(window))) {
+        tracing::warn!(error = %err, label = window.label(), "failed to set window background color");
+    }
+}
+
 #[cfg(desktop)]
 fn surface_window<R: tauri::Runtime>(window: &tauri::WebviewWindow<R>) {
+    apply_theme_background(window);
     if let Err(err) = window.unminimize() {
         tracing::warn!(error = %err, label = window.label(), "failed to unminimize window");
     }
@@ -312,6 +342,36 @@ pub async fn open_note_window(
     let mut builder = WebviewWindowBuilder::new(&app, &label, WebviewUrl::default())
         .title("Reflect")
         .inner_size(1000.0, 650.0)
+        // Paint the OS-preferred theme color at build time so the note window
+        // doesn't briefly flash white before its webview loads the frontend
+        // (mirrors the main window's `apply_theme_background`).
+        .background_color(theme_background_color(&window))
+        // Build hidden and reveal on `PageLoadEvent::Finished` so the user
+        // never sees WKWebView's default white backing while HTML/CSS/JS are
+        // still loading. The main window gets the same effect for free: its
+        // `visible: false` config only flips to visible on `RunEvent::Ready`,
+        // and Tauri's plugin + geometry-restore setup between builder and
+        // Ready gives the webview time to reach the same state. `Once` gates
+        // the reveal to the first Finished only: reloads (Cmd+R, dev HMR,
+        // webview crash recovery) otherwise re-run `set_focus`, stealing
+        // focus back to a note window the user has moved away from.
+        .visible(false)
+        .on_page_load({
+            let revealed = Once::new();
+            move |window, payload| {
+                if !matches!(payload.event(), tauri::webview::PageLoadEvent::Finished) {
+                    return;
+                }
+                revealed.call_once(|| {
+                    if let Err(err) = window.show() {
+                        tracing::warn!(error = %err, label = window.label(), "failed to show note window after page load");
+                    }
+                    if let Err(err) = window.set_focus() {
+                        tracing::warn!(error = %err, label = window.label(), "failed to focus note window after page load");
+                    }
+                });
+            }
+        })
         // Match the main window: HTML5 drops must reach the webview (chat and
         // editor file drops), so the native drag-drop handler stays off.
         .disable_drag_drop_handler();

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -11,7 +11,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
-use std::sync::{Mutex, MutexGuard, Once};
+use std::sync::{Arc, Mutex, MutexGuard, Once};
 
 use serde::Serialize;
 use tauri::{Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
@@ -78,18 +78,26 @@ pub(crate) fn restorable_window_state_flags() -> tauri_plugin_window_state::Stat
         | StateFlags::FULLSCREEN
 }
 
+/// `--surface-app` in the `:root` scope of
+/// `design-system/tokens/colors.css` (`#f8fafa`).
+const SURFACE_APP_LIGHT: tauri::webview::Color = tauri::webview::Color(248, 250, 250, 255);
+
+/// `--surface-app` in the `.dark` scope of
+/// `design-system/tokens/colors.css` (`#0a0f1e`).
+const SURFACE_APP_DARK: tauri::webview::Color = tauri::webview::Color(10, 15, 30, 255);
+
 /// Resolve the OS-preferred theme background for `window`. Values mirror
-/// `--surface-app` in `design-system/tokens/colors.css` (`:root` and `.dark`
-/// scopes) so the native layer matches the first webview paint.
+/// `--surface-app` so the native layer matches the first webview paint;
+/// `native_background_matches_the_surface_app_token` keeps them from drifting
+/// out of step with the stylesheet.
 fn theme_background_color<R: tauri::Runtime>(
     window: &tauri::WebviewWindow<R>,
 ) -> tauri::webview::Color {
-    use tauri::webview::Color;
     use tauri::Theme;
 
     match window.theme() {
-        Ok(Theme::Dark) => Color(10, 15, 30, 255),
-        _ => Color(248, 250, 250, 255),
+        Ok(Theme::Dark) => SURFACE_APP_DARK,
+        _ => SURFACE_APP_LIGHT,
     }
 }
 
@@ -104,6 +112,55 @@ fn theme_background_color<R: tauri::Runtime>(
 fn apply_theme_background<R: tauri::Runtime>(window: &tauri::WebviewWindow<R>) {
     if let Err(err) = window.set_background_color(Some(theme_background_color(window))) {
         tracing::warn!(error = %err, label = window.label(), "failed to set window background color");
+    }
+}
+
+/// How long a window waits for its webview's first `PageLoadEvent::Finished`
+/// before revealing itself anyway.
+#[cfg(desktop)]
+const REVEAL_FALLBACK_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Reveal a window even if its webview's first `PageLoadEvent::Finished` never
+/// arrives.
+///
+/// Windows build hidden and reveal from that event, which trades the startup
+/// flash for a dependency on the load completing. Without this fallback a
+/// webview that never finishes loading strands its window hidden forever: the
+/// main window makes the launch look like it silently did nothing (macOS can
+/// recover through a Dock click, but Windows and Linux have no equivalent for
+/// a window with no taskbar entry), and a note window is worse still — the
+/// registry keeps its entry, so every later open of that target focuses a
+/// window nobody can see.
+///
+/// `gate` is the same `Once` the page-load hook holds, so whichever path
+/// arrives first wins and the other becomes a no-op. Tauri window handles
+/// proxy to the event loop, making the reveal safe from this thread; once the
+/// app has shut down the calls simply fail and are logged.
+#[cfg(desktop)]
+pub(crate) fn arm_reveal_fallback<F>(gate: &Arc<Once>, label: &str, reveal: F)
+where
+    F: FnOnce() + Send + 'static,
+{
+    let gate = Arc::clone(gate);
+    let label = label.to_owned();
+    std::thread::spawn(move || {
+        std::thread::sleep(REVEAL_FALLBACK_DELAY);
+        gate.call_once(|| {
+            tracing::warn!(label = %label, "page load never finished; revealing window anyway");
+            reveal();
+        });
+    });
+}
+
+/// Show and focus a freshly built note window. Unlike `surface_window` this
+/// skips unminimize and the background repaint: the window has never been on
+/// screen, and its background was seeded at build time.
+fn reveal_note_window<R: tauri::Runtime>(window: &tauri::WebviewWindow<R>) {
+    if let Err(err) = window.show() {
+        tracing::warn!(error = %err, label = window.label(), "failed to show note window");
+    }
+    if let Err(err) = window.set_focus() {
+        tracing::warn!(error = %err, label = window.label(), "failed to focus note window");
     }
 }
 
@@ -339,6 +396,10 @@ pub async fn open_note_window(
     };
     let cascade = cascade_offset(&app);
 
+    // Shared by the page-load hook below and the fallback armed after the
+    // build, so the window is revealed exactly once whichever gets there first.
+    let revealed = Arc::new(Once::new());
+
     let mut builder = WebviewWindowBuilder::new(&app, &label, WebviewUrl::default())
         .title("Reflect")
         .inner_size(1000.0, 650.0)
@@ -349,25 +410,20 @@ pub async fn open_note_window(
         // Build hidden and reveal on `PageLoadEvent::Finished` so the user
         // never sees WKWebView's default white backing while HTML/CSS/JS are
         // still loading. The main window is gated the same way, from the
-        // app-level `on_page_load` hook in `lib.rs`. `Once` gates the reveal to
-        // the first Finished only: reloads (Cmd+R, dev HMR, webview crash
-        // recovery) otherwise re-run `set_focus`, stealing focus back to a note
-        // window the user has moved away from.
+        // app-level `on_page_load` hook in `lib.rs`. The shared `Once` gates
+        // the reveal to the first Finished only: reloads (Cmd+R, dev HMR,
+        // webview crash recovery) otherwise re-run `set_focus`, stealing focus
+        // back to a note window the user has moved away from. It also settles
+        // the race with the fallback armed after the build, for the load that
+        // never finishes at all.
         .visible(false)
         .on_page_load({
-            let revealed = Once::new();
+            let revealed = Arc::clone(&revealed);
             move |note_window, payload| {
                 if !matches!(payload.event(), tauri::webview::PageLoadEvent::Finished) {
                     return;
                 }
-                revealed.call_once(|| {
-                    if let Err(err) = note_window.show() {
-                        tracing::warn!(error = %err, label = note_window.label(), "failed to show note window after page load");
-                    }
-                    if let Err(err) = note_window.set_focus() {
-                        tracing::warn!(error = %err, label = note_window.label(), "failed to focus note window after page load");
-                    }
-                });
+                revealed.call_once(|| reveal_note_window(&note_window));
             }
         })
         // Match the main window: HTML5 drops must reach the webview (chat and
@@ -386,16 +442,35 @@ pub async fn open_note_window(
         builder = builder.position(position.x + cascade, position.y + cascade);
     }
 
-    if let Err(err) = builder.build() {
-        // Be defensive if a window created outside this command claimed the
-        // reserved label: surface it and preserve its one-shot bootstrap.
-        if focus_existing(&app, &label, &deep_link, &invoking_label) {
-            return Ok(());
+    let note_window = match builder.build() {
+        Ok(note_window) => note_window,
+        Err(err) => {
+            // Be defensive if a window created outside this command claimed the
+            // reserved label: surface it and preserve its one-shot bootstrap.
+            if focus_existing(&app, &label, &deep_link, &invoking_label) {
+                return Ok(());
+            }
+            // Keep the pending bootstrap for a later serialized retry, which
+            // reuses this preferred reservation.
+            return Err(AppError::io(format!("failed to open note window: {err}")));
         }
-        // Keep the pending bootstrap for a later serialized retry, which
-        // reuses this preferred reservation.
-        return Err(AppError::io(format!("failed to open note window: {err}")));
+    };
+
+    // The registry now routes this target here, so a webview that never
+    // finishes loading would strand the note behind a permanently hidden
+    // window rather than merely failing to show one.
+    #[cfg(desktop)]
+    {
+        let note_label = note_window.label().to_owned();
+        arm_reveal_fallback(&revealed, &note_label, move || {
+            reveal_note_window(&note_window)
+        });
     }
+    // Mobile builds compile this command but have no hidden-window failure to
+    // recover from (one fullscreen webview, revealed in `run`).
+    #[cfg(not(desktop))]
+    let _ = note_window;
+
     Ok(())
 }
 
@@ -476,6 +551,54 @@ pub fn window_bootstrap(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Read `--surface-app` out of one scope of the design-system token sheet.
+    ///
+    /// Stops at the scope's closing brace so `.reflect-space` — which declares
+    /// the same custom property — can't be misread as `.dark`, and trims the
+    /// value so both the aligned and the `oxfmt`-collapsed spellings parse.
+    #[cfg(desktop)]
+    fn surface_app_token(css: &str, scope: &str) -> tauri::webview::Color {
+        let block = css
+            .split_once(&format!("{scope} {{"))
+            .unwrap_or_else(|| panic!("`{scope}` scope missing from colors.css"))
+            .1
+            .split_once('}')
+            .unwrap_or_else(|| panic!("`{scope}` scope is unterminated"))
+            .0;
+        let value = block
+            .split_once("--surface-app:")
+            .unwrap_or_else(|| panic!("`--surface-app` missing from the `{scope}` scope"))
+            .1
+            .split(';')
+            .next()
+            .expect("split yields at least one element")
+            .trim();
+        let hex = value.strip_prefix('#').unwrap_or_else(|| {
+            panic!("`--surface-app` in `{scope}` is not a hex literal: {value}")
+        });
+        assert_eq!(
+            hex.len(),
+            6,
+            "`--surface-app` in `{scope}` is not a 6-digit hex literal: {value}"
+        );
+        let rgb = u32::from_str_radix(hex, 16)
+            .unwrap_or_else(|err| panic!("`--surface-app` in `{scope}` is not hex: {err}"));
+        tauri::webview::Color((rgb >> 16) as u8, (rgb >> 8) as u8, rgb as u8, 255)
+    }
+
+    /// The native window background is seeded before the webview paints, so a
+    /// value that drifts from `--surface-app` reintroduces exactly the flash
+    /// this seeding exists to prevent — one shade briefly showing through
+    /// before the frontend's own background lands. The constants can't be
+    /// derived from the stylesheet at build time, so assert they agree.
+    #[cfg(desktop)]
+    #[test]
+    fn native_background_matches_the_surface_app_token() {
+        let css = include_str!("../../../../design-system/tokens/colors.css");
+        assert_eq!(surface_app_token(css, ":root"), SURFACE_APP_LIGHT);
+        assert_eq!(surface_app_token(css, ".dark"), SURFACE_APP_DARK);
+    }
 
     #[cfg(desktop)]
     #[test]

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -348,26 +348,24 @@ pub async fn open_note_window(
         .background_color(theme_background_color(&window))
         // Build hidden and reveal on `PageLoadEvent::Finished` so the user
         // never sees WKWebView's default white backing while HTML/CSS/JS are
-        // still loading. The main window gets the same effect for free: its
-        // `visible: false` config only flips to visible on `RunEvent::Ready`,
-        // and Tauri's plugin + geometry-restore setup between builder and
-        // Ready gives the webview time to reach the same state. `Once` gates
-        // the reveal to the first Finished only: reloads (Cmd+R, dev HMR,
-        // webview crash recovery) otherwise re-run `set_focus`, stealing
-        // focus back to a note window the user has moved away from.
+        // still loading. The main window is gated the same way, from the
+        // app-level `on_page_load` hook in `lib.rs`. `Once` gates the reveal to
+        // the first Finished only: reloads (Cmd+R, dev HMR, webview crash
+        // recovery) otherwise re-run `set_focus`, stealing focus back to a note
+        // window the user has moved away from.
         .visible(false)
         .on_page_load({
             let revealed = Once::new();
-            move |window, payload| {
+            move |note_window, payload| {
                 if !matches!(payload.event(), tauri::webview::PageLoadEvent::Finished) {
                     return;
                 }
                 revealed.call_once(|| {
-                    if let Err(err) = window.show() {
-                        tracing::warn!(error = %err, label = window.label(), "failed to show note window after page load");
+                    if let Err(err) = note_window.show() {
+                        tracing::warn!(error = %err, label = note_window.label(), "failed to show note window after page load");
                     }
-                    if let Err(err) = window.set_focus() {
-                        tracing::warn!(error = %err, label = window.label(), "failed to focus note window after page load");
+                    if let Err(err) = note_window.set_focus() {
+                        tracing::warn!(error = %err, label = note_window.label(), "failed to focus note window after page load");
                     }
                 });
             }

--- a/apps/desktop/src/lib/theme-cache.test.ts
+++ b/apps/desktop/src/lib/theme-cache.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { THEME_PREFERENCE_CACHE_KEY } from './theme-cache'
+
+/**
+ * `public/theme-init.js` is served raw — no bundler, so it cannot import the
+ * cache key and has to repeat the literal. Renaming the key here without
+ * updating that script would silently stop the early theme paint from finding
+ * the cached preference, reverting every launch to the OS preference. Assert
+ * the two agree instead.
+ */
+const THEME_INIT_PATH = fileURLToPath(new URL('../../public/theme-init.js', import.meta.url))
+
+describe('THEME_PREFERENCE_CACHE_KEY', () => {
+  it('matches the key the early theme script reads', () => {
+    const script = readFileSync(THEME_INIT_PATH, 'utf8')
+    expect(script).toContain(`'${THEME_PREFERENCE_CACHE_KEY}'`)
+  })
+})

--- a/apps/desktop/src/lib/theme-cache.ts
+++ b/apps/desktop/src/lib/theme-cache.ts
@@ -1,0 +1,30 @@
+import type { ThemePreference } from '@reflect/core'
+
+/**
+ * Where the theme preference is mirrored for the *next* launch.
+ *
+ * The settings document is the source of truth, but it loads over IPC — too
+ * late for the first paint. `public/theme-init.js` reads this key before the
+ * design-system CSS is evaluated so a user who pinned `light` or `dark` never
+ * sees the OS theme painted first. That script is served raw (no bundling, so
+ * no imports), which is why the key literal is repeated there;
+ * `theme-cache.test.ts` guards against the two drifting apart.
+ */
+export const THEME_PREFERENCE_CACHE_KEY = 'reflect.theme.preference'
+
+/**
+ * Mirror the persisted theme preference so the next launch can apply it before
+ * the frontend boots.
+ *
+ * The *preference* is cached rather than the resolved `light`/`dark`: a user on
+ * `system` whose OS theme changed while the app was closed must re-resolve from
+ * `prefers-color-scheme`, not replay a stale answer. Best-effort — a webview
+ * with storage unavailable just falls back to the OS preference.
+ */
+export function writeCachedThemePreference(preference: ThemePreference): void {
+  try {
+    localStorage.setItem(THEME_PREFERENCE_CACHE_KEY, preference)
+  } catch {
+    // Storage is unavailable; theme-init.js falls back to `prefers-color-scheme`.
+  }
+}

--- a/apps/desktop/src/providers/theme-provider.test.tsx
+++ b/apps/desktop/src/providers/theme-provider.test.tsx
@@ -21,7 +21,13 @@ let failLoad: boolean
 let gateLoad: boolean
 let pendingLoad: (() => void) | null
 
-function releaseLoad(): void {
+/**
+ * Let the gated `settings_load` return. Awaiting the gate first matters: the
+ * bridge call is async, so a release that ran before `invoke` reached its
+ * `await` would be a silent no-op and the load would never settle.
+ */
+async function releaseLoad(): Promise<void> {
+  await vi.waitFor(() => expect(pendingLoad).not.toBeNull())
   pendingLoad?.()
   pendingLoad = null
 }
@@ -73,9 +79,14 @@ type Act = (callback: () => unknown) => Promise<void>
  */
 async function settleLoad(act: Act): Promise<void> {
   await act(async () => {
-    await vi.waitFor(() =>
-      expect(queryClient.getQueryState(SETTINGS_QUERY_KEY)?.status).not.toBe('pending'),
-    )
+    await vi.waitFor(() => {
+      // A query that has not been registered yet reads as `undefined`, which is
+      // also "not pending" — require the real settled state, or this returns
+      // before the load has even started.
+      const state = queryClient.getQueryState(SETTINGS_QUERY_KEY)
+      expect(state).toBeDefined()
+      expect(state?.status).not.toBe('pending')
+    })
   })
 }
 
@@ -128,7 +139,7 @@ describe('ThemeProvider', () => {
     const { act } = await renderHook(() => useTheme(), { wrapper })
     expect(document.documentElement.classList.contains('dark')).toBe(true)
 
-    releaseLoad()
+    await releaseLoad()
     await settleLoad(act)
     expect(cachedPreference()).toBe('dark')
     expect(document.documentElement.classList.contains('dark')).toBe(true)

--- a/apps/desktop/src/providers/theme-provider.test.tsx
+++ b/apps/desktop/src/providers/theme-provider.test.tsx
@@ -1,0 +1,191 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook } from 'vitest-browser-react'
+import type { ReactNode } from 'react'
+import { setBridge } from '@reflect/core'
+import { resetOperations } from '@/lib/operations'
+import { THEME_PREFERENCE_CACHE_KEY } from '@/lib/theme-cache'
+import { SETTINGS_QUERY_KEY, SettingsProvider } from './settings-provider'
+import { ThemeProvider, useTheme } from './theme-provider'
+
+/**
+ * Covers the startup-flash contract: `public/theme-init.js` paints the cached
+ * preference before React boots, so this provider must leave the document alone
+ * until the settings load settles — and must mirror the loaded preference back
+ * for the next launch.
+ */
+
+let stored: Record<string, unknown>
+let failLoad: boolean
+/** When set, `settings_load` blocks until {@link releaseLoad} is called. */
+let gateLoad: boolean
+let pendingLoad: (() => void) | null
+
+function releaseLoad(): void {
+  pendingLoad?.()
+  pendingLoad = null
+}
+
+function installFakeBridge(): void {
+  failLoad = false
+  gateLoad = false
+  pendingLoad = null
+  setBridge({
+    invoke: async (command) => {
+      if (command === 'settings_load') {
+        if (failLoad) {
+          throw { kind: 'io', message: 'corrupt store' }
+        }
+        if (gateLoad) {
+          await new Promise<void>((resolve) => {
+            pendingLoad = resolve
+          })
+        }
+        return stored
+      }
+      return null
+    },
+    listen: async () => () => {},
+  })
+}
+
+let queryClient: QueryClient
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>
+    <SettingsProvider>
+      <ThemeProvider>{children}</ThemeProvider>
+    </SettingsProvider>
+  </QueryClientProvider>
+)
+
+type Act = (callback: () => unknown) => Promise<void>
+
+/**
+ * Run the settings load to completion and flush every React update it cascades
+ * into, so assertions after this see the settled provider.
+ *
+ * The wait polls the query cache rather than the document: React defers the
+ * updates queued inside an `act` scope until the scope exits, so polling
+ * rendered output from in here would never observe it. Staying inside `act`
+ * matters because the load-settled state update would otherwise land
+ * unattached, and React's warning about that fails the test on console output.
+ */
+async function settleLoad(act: Act): Promise<void> {
+  await act(async () => {
+    await vi.waitFor(() =>
+      expect(queryClient.getQueryState(SETTINGS_QUERY_KEY)?.status).not.toBe('pending'),
+    )
+  })
+}
+
+/** What `theme-init.js` would have applied for a dark first paint. */
+function paintDarkFirstFrame(): void {
+  document.documentElement.classList.add('dark')
+  document.documentElement.style.colorScheme = 'dark'
+}
+
+function cachedPreference(): string | null {
+  return localStorage.getItem(THEME_PREFERENCE_CACHE_KEY)
+}
+
+function systemTheme(): 'light' | 'dark' {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+let originalClassName: string
+let originalColorScheme: string
+
+beforeEach(() => {
+  originalClassName = document.documentElement.className
+  originalColorScheme = document.documentElement.style.colorScheme
+  stored = {}
+  localStorage.removeItem(THEME_PREFERENCE_CACHE_KEY)
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  })
+  installFakeBridge()
+})
+
+afterEach(() => {
+  setBridge(null)
+  queryClient.clear()
+  localStorage.removeItem(THEME_PREFERENCE_CACHE_KEY)
+  document.documentElement.className = originalClassName
+  document.documentElement.style.colorScheme = originalColorScheme
+  resetOperations() // failed-load entries linger on a timer otherwise
+})
+
+describe('ThemeProvider', () => {
+  it('leaves the first-paint theme alone until the settings load settles', async () => {
+    // A `dark`-pinned user: theme-init.js painted dark, but `settings.theme` is
+    // the `system` default until the load lands. Reacting to that default is
+    // what used to flash the window.
+    paintDarkFirstFrame()
+    stored = { theme: 'dark' }
+    gateLoad = true
+
+    const { act } = await renderHook(() => useTheme(), { wrapper })
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+
+    releaseLoad()
+    await settleLoad(act)
+    expect(cachedPreference()).toBe('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('applies the loaded preference over the first-paint guess', async () => {
+    // The mismatch case: OS is dark, the user pinned light.
+    paintDarkFirstFrame()
+    stored = { theme: 'light' }
+
+    const { act } = await renderHook(() => useTheme(), { wrapper })
+    await settleLoad(act)
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+    expect(document.documentElement.style.colorScheme).toBe('light')
+  })
+
+  it('caches `system` verbatim rather than the theme it resolved to', async () => {
+    // Caching the resolved value would replay a stale answer on the next launch
+    // if the OS theme changed while the app was closed.
+    stored = { theme: 'system' }
+
+    const { result, act } = await renderHook(() => useTheme(), { wrapper })
+    await settleLoad(act)
+    expect(cachedPreference()).toBe('system')
+    expect(result.current.resolvedTheme).toBe(systemTheme())
+  })
+
+  it('caches a preference chosen during the session', async () => {
+    stored = { theme: 'light' }
+
+    const { result, act } = await renderHook(() => useTheme(), { wrapper })
+    await settleLoad(act)
+    expect(cachedPreference()).toBe('light')
+
+    await act(() => {
+      result.current.setTheme('dark')
+    })
+    expect(cachedPreference()).toBe('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('applies but does not cache a preference after a failed load', async () => {
+    // Changes are session-only once the load fails, so caching one would have
+    // the next launch paint a preference that never reached disk. A failed load
+    // must still unblock applying the theme, or the app would be stuck on
+    // theme-init.js's guess with no way to change it.
+    failLoad = true
+
+    const { result, act } = await renderHook(() => useTheme(), { wrapper })
+    await settleLoad(act)
+    expect(document.documentElement.style.colorScheme).toBe(systemTheme())
+    expect(cachedPreference()).toBeNull()
+
+    await act(() => {
+      result.current.setTheme('dark')
+    })
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+    expect(cachedPreference()).toBeNull()
+  })
+})

--- a/apps/desktop/src/providers/theme-provider.tsx
+++ b/apps/desktop/src/providers/theme-provider.tsx
@@ -9,7 +9,8 @@ import {
   type ReactNode,
 } from 'react'
 import type { ThemePreference } from '@reflect/core'
-import { useSettings } from '@/providers/settings-provider'
+import { writeCachedThemePreference } from '@/lib/theme-cache'
+import { useSettings, type SettingsLoadOutcome } from '@/providers/settings-provider'
 
 /** User-selectable theme; `system` follows the OS preference. */
 export type Theme = ThemePreference
@@ -40,11 +41,31 @@ interface ThemeProviderProps {
  * scope on the document root. The preference lives in the settings document
  * (the `theme` key), so a choice made anywhere — settings screen, palette
  * command — persists across launches; `system` reacts to live OS changes.
+ *
+ * Applying the theme waits for the settings load to settle. Until then
+ * `settings.theme` is the `system` default rather than the user's choice, and
+ * `public/theme-init.js` has already painted the cached preference — writing the
+ * default over it would flash a pinned-light user on a dark OS to dark and
+ * straight back.
  */
 export function ThemeProvider({ children }: ThemeProviderProps): ReactElement {
-  const { settings, updateSettings } = useSettings()
+  const { settings, updateSettings, whenSettingsLoaded } = useSettings()
   const theme = settings.theme
   const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(getSystemTheme)
+  const [loadOutcome, setLoadOutcome] = useState<SettingsLoadOutcome | null>(null)
+
+  useEffect(() => {
+    let active = true
+    void (async () => {
+      const outcome = await whenSettingsLoaded()
+      if (active) {
+        setLoadOutcome(outcome)
+      }
+    })()
+    return () => {
+      active = false
+    }
+  }, [whenSettingsLoaded])
 
   useEffect(() => {
     const media = window.matchMedia(DARK_MEDIA_QUERY)
@@ -58,10 +79,23 @@ export function ThemeProvider({ children }: ThemeProviderProps): ReactElement {
   const resolvedTheme: ResolvedTheme = theme === 'system' ? systemTheme : theme
 
   useEffect(() => {
+    if (loadOutcome === null) {
+      return
+    }
     const root = document.documentElement
     root.classList.toggle('dark', resolvedTheme === 'dark')
     root.style.colorScheme = resolvedTheme
-  }, [resolvedTheme])
+  }, [loadOutcome, resolvedTheme])
+
+  // Only a loaded document is worth caching: after a failed load changes apply
+  // for the session only, so mirroring them would have the next launch paint a
+  // preference that was never persisted. The last cached value stays instead.
+  useEffect(() => {
+    if (loadOutcome !== 'loaded') {
+      return
+    }
+    writeCachedThemePreference(theme)
+  }, [loadOutcome, theme])
 
   const setTheme = useCallback((next: Theme) => updateSettings({ theme: next }), [updateSettings])
 


### PR DESCRIPTION
## Problem

Cold launches of the desktop app occasionally flashed white before the frontend painted (roughly 1 in 5 launches on macOS). Two contributors:

1. The main window was revealed on `RunEvent::Ready`, which only waits for plugin init + window-state geometry restore — not the webview page load. On warm launches WKWebView's default white backing was on-screen when `show()` ran, before HTML/CSS had a chance to paint.
2. Even after the first HTML paint, dark-mode users saw a brief light-to-dark transition because the design-system's `.dark` scope only applied after the ThemeProvider mounted.

Note windows had the same class of issue on their own creation path.

A third, pre-existing flash surfaced while fixing those: the theme preference lives in the settings document, which only arrives over IPC *after* the first paint. Until it lands, `settings.theme` reads as the `system` default rather than the user's choice, so a user who pinned `light` on a dark OS was painted dark and flipped back once hydration completed.

## Before → After

| Scenario | Before | After |
| --- | --- | --- |
| Warm-cache cold launch | White flash between `show()` and first HTML paint | Window stays hidden until the webview has painted |
| Dark-mode launch | Brief light-to-dark flash before ThemeProvider mounts | `.dark` and `color-scheme` applied before the design-system CSS loads |
| Pinned `light` on a dark OS (or the reverse) | Painted the OS theme, then flipped once settings hydrated | The pinned preference is painted first; the provider stays off the document until hydration |
| Opening a note window | Brief white default backing before the content loaded | Note window builds hidden and reveals on `PageLoadEvent::Finished` |

## Changes

1. Add `apps/desktop/public/theme-init.js` — a small CSP-safe external script loaded from `index.html` that applies `.dark` / `color-scheme` before the design-system CSS is evaluated. It reads the theme preference mirrored into `localStorage` by `ThemeProvider`, falling back to `prefers-color-scheme` for `system`, a first launch, or an unreadable cache. The *preference* is cached rather than the resolved `light`/`dark` so `system` re-resolves when the OS theme changed while the app was closed.
2. `ThemeProvider` waits for the settings load to settle before touching the document, and mirrors the loaded preference to `localStorage` for the next launch. Writing the pre-hydration `system` default over what `theme-init.js` painted is what produced the third flash above. A *failed* load still unblocks applying the theme (otherwise the app would be stuck on the script's guess) but caches nothing, since those changes are session-only.
3. Seed native windows with the OS-preferred `--surface-app` color at build time so platforms whose webview honors `set_background_color` (WebView2 on Windows, WebKitGTK on Linux) match the first HTML paint. macOS's WKWebView ignores this — the theme script above handles that side.
4. Reveal the main window from an app-level `on_page_load` hook gated on the first `PageLoadEvent::Finished`, replacing the reveal that used to happen on `RunEvent::Ready`. `Once` prevents ⌘R, dev HMR, and webview crash recovery from re-stealing focus.
5. Note windows build hidden (`visible(false)`) and reveal via the same `Finished`-gated pattern.

## Verification

- `pnpm typecheck` / `pnpm lint` — clean.
- `theme-provider.test.tsx` (5 cases) — the first-paint theme survives until the load settles, the loaded preference then wins, `system` is cached verbatim, a session choice is cached, and a failed load applies without caching. Green on both Chromium and WebKit (the production Tauri webview engine).
- `theme-cache.test.ts` — guards the `localStorage` key against drifting from the literal repeated in `theme-init.js`, which is served raw and cannot import it.
- `settings-provider.test.tsx` — 15 passed, no regression from the new hydration dependency.
- `cargo check -p reflect-open` — clean. `cargo test -p reflect-open --lib` — 328 passed (window registry / surfacing / restart-state assertions still hold).
- Manual smoke on macOS (dark mode): 10 cold launches, no white flash observed. Reload (⌘R) and Cmd-clicking wikilinks to open note windows both work without focus theft.

## Risk / Rollout

Desktop-only, no data migration. If `PageLoadEvent::Finished` were to never fire (catastrophic webview load failure) the main window would stay hidden — but that same failure would already leave the UI unusable, so it isn't a new regression path. No fallback timeout was added; this matches the existing note-window reveal pattern.

The `localStorage` mirror is a cache, never a source of truth: the settings document still decides, and a missing, stale, or unreadable cache degrades to exactly the previous behavior (paint the OS preference, correct it on hydration). The first launch after this ships has no cache yet, so a pinned user sees one transition on that launch and none afterwards.

The native `set_background_color` seed still reads the OS theme rather than the user's preference. Left as-is deliberately: `settings.rs` treats the document as opaque JSON by design (schema and defaults are policy that lives in `@reflect/core`'s zod layer), and with windows now hidden until page load finishes that backing is effectively never on screen.

_Investigated and drafted with Claude Opus 4.7; review fixes with Claude Opus 5; verified manually._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added desktop theme preference caching across launches.
  * Applied the correct light or dark appearance before the app renders.

* **Bug Fixes**
  * Reduced startup flashes by delaying window display until page loading completes.
  * Prevented repeated focus stealing and ensured note windows appear only once.
  * Improved native window backgrounds to match the selected or system theme.

* **Tests**
  * Added coverage for theme caching, startup appearance, and window theming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
