### PR TITLE
fix: retry rate-limited link previews and clean up share-sheet titles

### DIFF
--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -492,6 +492,22 @@ fn classify_fetch_error(err: reqwest::Error) -> AppError {
     }
 }
 
+/// Map a meta-fetch response status to its error: `None` for success,
+/// retryable `Network` for server errors and rate limiting (sites like
+/// Instagram answer `429` to bursts and recover — the enrichment pass keeps
+/// the capture pending and tries again later), permanent `io` for everything
+/// else.
+fn classify_fetch_status(url: &str, status: reqwest::StatusCode) -> Option<AppError> {
+    if status.is_success() {
+        return None;
+    }
+    let message = format!("{url} answered {status}");
+    if status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        return Some(AppError::Network { message });
+    }
+    Some(AppError::io(message))
+}
+
 /// Fetch a captured page's HTML for meta-tag scraping, hard-capped (timeout,
 /// byte cap, redirect limit, http(s) only). Lives here rather than widening
 /// the webview's HTTP-plugin capability to every URL — the only thing that
@@ -518,14 +534,8 @@ pub async fn capture_meta_fetch<R: tauri::Runtime>(
         .await
         .map_err(classify_fetch_error)?;
 
-    let status = response.status();
-    if status.is_server_error() {
-        return Err(AppError::Network {
-            message: format!("{url} answered {status}"),
-        });
-    }
-    if !status.is_success() {
-        return Err(AppError::io(format!("{url} answered {status}")));
+    if let Some(err) = classify_fetch_status(&url, response.status()) {
+        return Err(err);
     }
     let content_type = response
         .headers()
@@ -554,6 +564,29 @@ pub async fn capture_meta_fetch<R: tauri::Runtime>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn meta_fetch_statuses_classify_rate_limits_as_retryable() {
+        use reqwest::StatusCode;
+        let url = "https://www.instagram.com/reel/example/";
+        assert!(classify_fetch_status(url, StatusCode::OK).is_none());
+        assert!(matches!(
+            classify_fetch_status(url, StatusCode::TOO_MANY_REQUESTS),
+            Some(AppError::Network { .. })
+        ));
+        assert!(matches!(
+            classify_fetch_status(url, StatusCode::BAD_GATEWAY),
+            Some(AppError::Network { .. })
+        ));
+        assert!(matches!(
+            classify_fetch_status(url, StatusCode::NOT_FOUND),
+            Some(AppError::Io { .. })
+        ));
+        assert!(matches!(
+            classify_fetch_status(url, StatusCode::FORBIDDEN),
+            Some(AppError::Io { .. })
+        ));
+    }
 
     #[test]
     fn manifest_pins_name_path_and_origins() {

--- a/packages/core/src/actions/capture-enrichment.test.ts
+++ b/packages/core/src/actions/capture-enrichment.test.ts
@@ -18,6 +18,7 @@ import {
   wireCaptureMocks,
   writeNoteMock,
 } from './capture-harness'
+import { captureIdentity } from './capture'
 import type { CaptureEnvelope } from './capture-envelope'
 
 const ensureBacklinkTargetMock = vi.hoisted(() => vi.fn())
@@ -181,6 +182,27 @@ describe('reconcileCaptureEnrichment', () => {
     )
     expect(daily).not.toContain('|example.com]]')
     expect(describeMock).not.toHaveBeenCalled()
+  })
+
+  it('clips a runaway scraped title at a word boundary', async () => {
+    addSpool(envelope({ source: 'ios-share', title: '' }), { screenshot: false })
+    expect((await drain()).stopped).toBeNull()
+    writeNoteMock.mockClear()
+    scrapeMock.mockResolvedValue({
+      title: `${'lengthy '.repeat(20)}tail`,
+      description: 'A scraped description.',
+      siteName: 'Instagram',
+    })
+
+    const outcome = await reconcile({ providers: NO_PROVIDERS })
+
+    expect(outcome.enriched).toBe(1)
+    const note = files.get(IDENTITY.notePath) ?? ''
+    const heading = note.split('\n').find((line) => line.startsWith('# '))
+    expect(heading).toBeDefined()
+    expect(heading!.length).toBeLessThanOrEqual('# '.length + 100)
+    expect(heading).not.toContain('tail')
+    expect(files.get(DAILY)).toContain(`|${heading!.slice('# '.length)}]]`)
   })
 
   it('keeps a supplied capture title when scraped metadata differs', async () => {
@@ -434,7 +456,7 @@ describe('reconcileCaptureEnrichment', () => {
     expect(describeMock).not.toHaveBeenCalled()
   })
 
-  it('a transient scrape failure stops the pass; the next pass retries', async () => {
+  it('a transient scrape failure leaves the capture pending; the next pass retries', async () => {
     await drainOne()
     scrapeMock.mockRejectedValueOnce(new ReflectError('network', 'offline'))
 
@@ -444,6 +466,92 @@ describe('reconcileCaptureEnrichment', () => {
 
     const second = await reconcile()
     expect(second.enriched).toBe(1)
+  })
+
+  it('a rate-limited page leaves its capture pending without starving the queue', async () => {
+    const laterAt = new Date(2026, 5, 11, 16, 0, 0, 0)
+    const laterId = '9d0f7780-8536-4a1e-a55c-f18fd2a01bf8'
+    const laterIdentity = captureIdentity(laterAt, laterId)
+    addSpool(
+      envelope({ source: 'ios-share', url: 'https://www.instagram.com/reel/example/', title: '' }),
+      { screenshot: false },
+    )
+    addSpool(
+      envelope({ id: laterId, capturedAt: laterAt.toISOString(), title: 'An article' }),
+      { screenshot: false },
+    )
+    expect((await drain()).stopped).toBeNull()
+    writeNoteMock.mockClear()
+    scrapeMock.mockImplementation(async (url) => {
+      if (url.includes('instagram')) {
+        throw new ReflectError('network', 'https://www.instagram.com answered 429')
+      }
+      return { title: 'An article', description: 'A scraped description.', siteName: null }
+    })
+
+    const outcome = await reconcile({ providers: NO_PROVIDERS })
+
+    expect(outcome).toEqual({
+      pending: 2,
+      enriched: 1,
+      skipped: 0,
+      stopped: expect.objectContaining({ reason: 'network' }),
+    })
+    expect(files.get(IDENTITY.notePath)).toContain('captureStatus: pending')
+    expect(files.get(laterIdentity.notePath)).toContain('captureStatus: done')
+    expect(files.get(laterIdentity.notePath)).toContain('- Description: A scraped description.')
+
+    scrapeMock.mockResolvedValue({
+      title: 'First Chair on Instagram',
+      description: 'An Instagram reel about furniture and decor.',
+      siteName: 'Instagram',
+    })
+    const retry = await reconcile({ providers: NO_PROVIDERS })
+
+    expect(retry).toEqual({ pending: 1, enriched: 1, skipped: 0, stopped: null })
+    expect(files.get(IDENTITY.notePath)).toContain('# First Chair on Instagram')
+    expect(files.get(IDENTITY.notePath)).toContain('captureStatus: done')
+  })
+
+  it('a rate-limited provider leaves its capture pending without starving the queue', async () => {
+    const laterAt = new Date(2026, 5, 11, 16, 0, 0, 0)
+    const laterId = '9d0f7780-8536-4a1e-a55c-f18fd2a01bf8'
+    const laterIdentity = captureIdentity(laterAt, laterId)
+    addSpool(envelope({ url: 'https://example.com/first', title: 'The first article' }), {
+      screenshot: false,
+    })
+    addSpool(
+      envelope({
+        id: laterId,
+        capturedAt: laterAt.toISOString(),
+        url: 'https://example.com/second',
+        title: 'The second article',
+      }),
+      { screenshot: false },
+    )
+    expect((await drain()).stopped).toBeNull()
+    writeNoteMock.mockClear()
+    describeMock.mockImplementation(async (request) => {
+      if (request.url.endsWith('/first')) {
+        throw new ReflectError('network', 'the provider is unavailable (429)')
+      }
+      return { title: null, description: 'An AI description of the page.' }
+    })
+
+    const outcome = await reconcile()
+
+    expect(outcome).toEqual({
+      pending: 2,
+      enriched: 1,
+      skipped: 0,
+      stopped: expect.objectContaining({ reason: 'network' }),
+    })
+    expect(files.get(IDENTITY.notePath)).toContain('captureStatus: pending')
+    expect(files.get(IDENTITY.notePath)).toContain('captureMetadataStatus: done')
+    expect(files.get(laterIdentity.notePath)).toContain('captureStatus: done')
+    expect(files.get(laterIdentity.notePath)).toContain(
+      '- Description: An AI description of the page.',
+    )
   })
 
   it('a permanent scrape failure enriches without meta tags', async () => {

--- a/packages/core/src/actions/capture-enrichment.test.ts
+++ b/packages/core/src/actions/capture-enrichment.test.ts
@@ -535,6 +535,9 @@ describe('reconcileCaptureEnrichment', () => {
 
     const outcome = await reconcile()
 
+    expect(scrapeMock).toHaveBeenCalledTimes(2)
+    expect(scrapeMock).toHaveBeenNthCalledWith(1, expect.stringContaining('instagram'))
+    expect(scrapeMock.mock.calls[1]?.[0]).not.toContain('instagram')
     expect(outcome.stopped).toEqual({ reason: 'io', message: 'keychain is unavailable' })
     expect(outcome.pending).toBe(2)
     expect(describeMock).not.toHaveBeenCalled()

--- a/packages/core/src/actions/capture-enrichment.test.ts
+++ b/packages/core/src/actions/capture-enrichment.test.ts
@@ -513,6 +513,33 @@ describe('reconcileCaptureEnrichment', () => {
     expect(files.get(IDENTITY.notePath)).toContain('captureStatus: done')
   })
 
+  it('a keychain failure outranks a transient stop — the toast is never masked', async () => {
+    const laterAt = new Date(2026, 5, 11, 16, 0, 0, 0)
+    const laterId = '9d0f7780-8536-4a1e-a55c-f18fd2a01bf8'
+    addSpool(envelope({ url: 'https://www.instagram.com/reel/example/', title: '' }), {
+      screenshot: false,
+    })
+    addSpool(
+      envelope({ id: laterId, capturedAt: laterAt.toISOString(), title: 'An article' }),
+      { screenshot: false },
+    )
+    expect((await drain()).stopped).toBeNull()
+    writeNoteMock.mockClear()
+    scrapeMock.mockImplementation(async (url) => {
+      if (url.includes('instagram')) {
+        throw new ReflectError('network', 'https://www.instagram.com answered 429')
+      }
+      return { title: 'An article', description: 'A scraped description.', siteName: null }
+    })
+    getSecretMock.mockRejectedValue(new ReflectError('io', 'keychain is unavailable'))
+
+    const outcome = await reconcile()
+
+    expect(outcome.stopped).toEqual({ reason: 'io', message: 'keychain is unavailable' })
+    expect(outcome.pending).toBe(2)
+    expect(describeMock).not.toHaveBeenCalled()
+  })
+
   it('a rate-limited provider leaves its capture pending without starving the queue', async () => {
     const laterAt = new Date(2026, 5, 11, 16, 0, 0, 0)
     const laterId = '9d0f7780-8536-4a1e-a55c-f18fd2a01bf8'

--- a/packages/core/src/actions/capture-enrichment.ts
+++ b/packages/core/src/actions/capture-enrichment.ts
@@ -1,4 +1,9 @@
-import { describePage, isDescriptionRejected, type PageEnrichment } from '../ai/describe-page'
+import {
+  describePage,
+  isDescriptionRejected,
+  normalizedPageTitle,
+  type PageEnrichment,
+} from '../ai/describe-page'
 import { defaultAiProvider, type AiProvidersState } from '../ai/provider-config'
 import { aiKeySecretName } from '../ai/secrets'
 import { errorMessage, isAppError, toAppError } from '../errors'
@@ -190,6 +195,7 @@ export async function reconcileCaptureEnrichment(
   let enriched = 0
   let skipped = 0
   let waitingForKey = false
+  let transientStop: ReconcileStop | null = null
   const stale = (): boolean => input.isStale?.() === true
   const outcome = (stopped: ReconcileStop | null): ReconcileCaptureEnrichmentOutcome => ({
     pending: pending.length,
@@ -303,8 +309,9 @@ export async function reconcileCaptureEnrichment(
           if (kind === 'network' || kind === 'auth') {
             throw cause
           }
-          // Invalid URLs, non-HTML responses, and non-success statuses are
+          // Invalid URLs, non-HTML responses, and non-retryable statuses are
           // permanent for this capture; checkpoint the no-metadata result.
+          // (Rate limits and server errors arrive as `network` and retry.)
           pageMeta = null
         }
       }
@@ -319,7 +326,7 @@ export async function reconcileCaptureEnrichment(
       const placeholderTitle = displayTitle({ title: '', url: snapshot.meta.captureUrl })
       const metadataTitle =
         snapshot.title === placeholderTitle && pageMeta?.title
-          ? displayTitle({ title: pageMeta.title, url: snapshot.meta.captureUrl })
+          ? normalizedPageTitle(pageMeta.title)
           : null
       const metadataDisplayTitle = metadataTitle ?? snapshot.title
       const metadataDescription = hasDescription(snapshot.body)
@@ -455,10 +462,20 @@ export async function reconcileCaptureEnrichment(
       }
       enriched += 1
     } catch (cause) {
-      return outcome({ reason: toAppError(cause).kind, message: errorMessage(cause) })
+      const error = toAppError(cause)
+      // A transient failure — offline, a rate-limited page, an unavailable
+      // provider — leaves this capture pending for the next pass, but must
+      // not starve the captures queued behind it. Anything else (auth, an
+      // unexpected write failure) affects every capture alike, so it aborts
+      // the pass.
+      if (error.kind === 'network') {
+        transientStop ??= { reason: error.kind, message: errorMessage(cause) }
+        continue
+      }
+      return outcome({ reason: error.kind, message: errorMessage(cause) })
     }
   }
   // `waitingForKey` is only ever set when a provider is configured without a
   // usable key, which is exactly when `providerStop` was populated above.
-  return outcome(waitingForKey ? providerStop : null)
+  return outcome(transientStop ?? (waitingForKey ? providerStop : null))
 }

--- a/packages/core/src/actions/capture-enrichment.ts
+++ b/packages/core/src/actions/capture-enrichment.ts
@@ -476,6 +476,8 @@ export async function reconcileCaptureEnrichment(
     }
   }
   // `waitingForKey` is only ever set when a provider is configured without a
-  // usable key, which is exactly when `providerStop` was populated above.
-  return outcome(transientStop ?? (waitingForKey ? providerStop : null))
+  // usable key, which is exactly when `providerStop` was populated above. It
+  // outranks a transient stop: a keychain failure is persistent and surfaced
+  // to the user, and a silent network stop must not mask it.
+  return outcome((waitingForKey ? providerStop : null) ?? transientStop)
 }

--- a/packages/core/src/ai/describe-page.test.ts
+++ b/packages/core/src/ai/describe-page.test.ts
@@ -120,6 +120,16 @@ describe('describePage', () => {
     expect(parts.map((part) => part.type)).toEqual(['text'])
   })
 
+  it('tells the model to rebuild share-sheet boilerplate titles from the page', async () => {
+    const calls = modelAnsweringObject('A title', 'A description.')
+
+    await request()
+
+    const text = userText(calls)
+    expect(text).toContain('share sheets often supply boilerplate')
+    expect(text).toContain('build the title from the meta title, page text, or screenshot')
+  })
+
   it('sanitizes the returned title for wiki-link display', async () => {
     modelAnsweringObject(' An [article] | Site\nName ', 'A description.')
 

--- a/packages/core/src/ai/describe-page.ts
+++ b/packages/core/src/ai/describe-page.ts
@@ -128,13 +128,19 @@ function describePrompt(request: DescribePageRequest): string {
   }
   lines.push(
     'Ground both fields in the extracted page text when present, and the screenshot when one is attached.',
-    "title: the page's own title cleaned up for display — drop the site name, separators, and SEO clutter; keep the page's language and its plain wording. Never invent an editorial retitle; when the captured title is already clean, return it unchanged.",
+    "title: the page's own title cleaned up for display — drop the site name, separators, and SEO clutter; keep the page's language and its plain wording. The captured title may not describe the page at all: share sheets often supply boilerplate (\"See this Instagram post by @user\"), a bare domain, or message text — in that case build the title from the meta title, page text, or screenshot instead of keeping it. Never invent an editorial retitle; when the captured title already describes the page cleanly, return it unchanged.",
     'description: one or two plain sentences describing the page — no preamble, no markdown.',
   )
   return lines.join('\n')
 }
 
-function normalizedTitle(candidate: string): string | null {
+/**
+ * Sanitize a candidate display title — from the model or from scraped meta
+ * tags — for use as a capture note's H1 and wiki-link display text: wiki-link
+ * safe and clipped at a word boundary, or `null` when nothing displayable
+ * survives (the caller keeps the current title).
+ */
+export function normalizedPageTitle(candidate: string): string | null {
   const safe = clipAtWordBoundary(wikiLinkSafe(candidate), MAX_TITLE_CHARS)
   return safe === '' ? null : safe
 }
@@ -165,7 +171,7 @@ export async function describePage(request: DescribePageRequest): Promise<PageEn
       maxRetries: 0,
     })
     return {
-      title: normalizedTitle(result.object.title),
+      title: normalizedPageTitle(result.object.title),
       description: result.object.description.trim(),
     }
   } catch (cause) {


### PR DESCRIPTION
## Problem

Links shared through the iOS share sheet were landing unenriched despite #872 and #877. Two Instagram shares showed the failure modes:

1. **Shared from the Instagram app** → the note kept the `www.instagram.com` placeholder title and never got a description.
2. **Shared from instagram.com in the browser** → the note kept Instagram's share-sheet text (`See this Instagram post by @rosebanklandscaping`) as its title forever.

Digging in:

- Instagram *does* serve full OpenGraph tags (`og:title` with the author + caption, `og:description`) to the app's plain `Reflect/x.y` user agent — verified against the real reel URL, with the OG tags well inside the fetch's 512KB cap and parsed correctly by the production `parsePageMeta` on the real bytes. The metadata pipeline is sound.
- But Instagram answers **429** to bursts, and `capture_meta_fetch` classified any non-5xx failure as permanent `io`. The enrichment pass then checkpointed "no metadata" forever — the capture ends `done` with the placeholder title and nothing else. That matches failure mode 1.
- Worse, a *transient* scrape failure threw out of the per-capture loop and **aborted the entire pass**, so one rate-limited URL starved every capture queued behind it (they're processed oldest-first, so the starvation is sticky across retries).
- For failure mode 2, the share-sheet path (`navigator.share` → plain-text sibling) supplies *message text*, not a page title, but the AI prompt instructed the model to keep captured titles that look clean — and share boilerplate looks clean. The metadata leg deliberately only retitles host-placeholder titles (a real page title from Safari must not be clobbered by a login-wall's `og:title`), so the AI leg is the right place to fix this.

## Changes

- **`capture.rs`**: `capture_meta_fetch` now classifies **429** (alongside 5xx) as a retryable `network` error, via a new pure `classify_fetch_status` helper with tests. Rate-limited pages stay `pending` and retry on the next pass instead of being permanently stamped metadata-less.
- **`capture-enrichment.ts`**: a transient (`network`) scrape or provider failure now leaves *that capture* pending and continues the pass; the first transient stop is still reported in the outcome (so the background reconciler's retry-on-wake semantics are unchanged), and a persistent provider/keychain stop outranks it so the surfaced toast is never masked by a silent network stop. Auth and unexpected write failures still abort the pass, since they affect every capture alike.
- **`capture-enrichment.ts`**: scraped metadata titles are clipped at the same 100-char word boundary as AI titles (`normalizedPageTitle`, now exported from `describe-page`). Instagram's `og:title` embeds the whole caption; previously it would become a runaway H1 and daily-link text.
- **`capture.rs`**: the meta fetch now presents as a normal browser navigation — a pinned Safari UA plus the Accept-Language/Sec-Fetch/Upgrade-Insecure-Requests header set a typed-URL navigation sends — instead of the bare `Reflect/x.y` UA. Fingerprinting CDNs treat a bare app UA and missing browser headers as a bot signal on stricter edges (cellular CGNAT, datacenter IPs). Verified against the real reel URL: identical OG metadata, and 200s under a 12-request burst. The unused `AppHandle` parameter is dropped.
- **`describe-page.ts`**: the prompt now tells the model that captured titles can be share-sheet boilerplate ("See this Instagram post by @user"), a bare domain, or message text, and to rebuild the title from the meta title / page text / screenshot in that case — while still keeping genuinely clean captured titles unchanged.

## Testing

- `pnpm vitest run` for `capture-enrichment.test.ts`, `capture-drain.test.ts`, `describe-page.test.ts`, `meta-scrape.test.ts` — 94 tests pass, including new coverage: rate-limited page/provider leaves its capture pending without starving the queue (plus retry convergence), runaway scraped titles clipped at a word boundary, prompt carries the boilerplate guidance.
- `cargo test -p reflect-open capture::` — 17 pass, including the new status-classification test (200/429/502/404/403).
- Verified against the real reel URL: fetched with the app UA, capped at 512KB, parsed with the production `parsePageMeta` under jsdom — extracts the expected `og:title`/`og:description`/`og:site_name`.
- `pnpm typecheck` and `pnpm lint` clean (two pre-existing max-lines warnings untouched).

## Risk / rollout

- Offline behavior changes shape: instead of aborting at the first capture, an offline pass now attempts (and quickly fails) a fetch per pending capture before stopping with the same silent `network` stop. Connect failures are near-instant; only a captive-portal-style hang would make this slow, bounded by the pending count × 15s fetch timeout.
- Already-`done` captures are not retroactively re-enriched — the fix applies to new shares (re-share to recover an existing bad note).
- On-device iOS share pass still owed; the pipeline itself is exercised end-to-end by the drain→enrich harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retry and queue-fairness behavior for all pending captures and arbitrary-host meta-fetch; offline passes may attempt a fetch per pending item before stopping, though behavior is covered by new tests.
> 
> **Overview**
> Fixes iOS share captures that stayed unenriched when sites (e.g. Instagram) returned **429** or when one bad URL blocked the whole enrichment pass.
> 
> **Desktop meta-fetch** (`capture_meta_fetch`): HTTP **429** is classified like 5xx as a retryable `network` error via `classify_fetch_status`, so rate-limited pages stay **pending** instead of being checkpointed as permanently metadata-less.
> 
> **Enrichment pass** (`reconcileCaptureEnrichment`): Transient **`network`** failures (offline scrape, rate-limited page, provider 429) leave the affected capture **pending**, record the first stop in `transientStop`, and **continue** other captures. Auth and non-network aborts still end the pass. Keychain/config stops still **outrank** a transient network stop so user-facing errors are not hidden.
> 
> **Titles**: Scraped `og:title` for host-placeholder retitles goes through exported **`normalizedPageTitle`** (wiki-safe, 100-char word boundary). The **describe-page** prompt tells the model to replace share-sheet boilerplate (bare domain, “See this Instagram post…”) using meta title, page text, or screenshot when the captured title does not describe the page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 527b67ec8aac5bafcfbd95a72b6aa8a5bfd199ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved capture enrichment with more reliable, boilerplate-resistant page titles and updated title normalization.

* **Bug Fixes**
  * More resilient retry behavior: transient network/rate-limit failures no longer block other queued captures.
  * Failed captures remain `pending` and are retried on the next reconcile pass.
  * Rate limits and server errors are treated as retryable network failures; keychain/config failures now correctly take precedence.
  * Excessively long generated titles are shortened at word boundaries, and backlink headings use the clipped title.

* **Tests**
  * Expanded describe-page and capture-enrichment test coverage for retry, queue fairness, and title clipping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
