### PR TITLE
fix: fetch link previews like a normal browser request

### DIFF
--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -487,8 +487,10 @@ const META_FETCH_TIMEOUT: Duration = Duration::from_secs(15);
 /// user agents with login walls or challenges a normal browser request never
 /// sees. Safari's platform token is frozen upstream, so the string stays
 /// plausible without tracking macOS releases.
-const META_FETCH_USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
-     AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15";
+const META_FETCH_USER_AGENT: &str = concat!(
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ",
+    "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15"
+);
 
 fn classify_fetch_error(err: reqwest::Error) -> AppError {
     if err.is_timeout() || err.is_connect() || err.is_request() {

--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -482,6 +482,14 @@ pub fn capture_screenshot_promote(
 const META_FETCH_MAX_BYTES: usize = 512 * 1024;
 const META_FETCH_TIMEOUT: Duration = Duration::from_secs(15);
 
+/// The meta fetch presents as a mainstream browser navigation: sites that
+/// gate on client fingerprint (Instagram among them) can answer bare app
+/// user agents with login walls or challenges a normal browser request never
+/// sees. Safari's platform token is frozen upstream, so the string stays
+/// plausible without tracking macOS releases.
+const META_FETCH_USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
+     AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15";
+
 fn classify_fetch_error(err: reqwest::Error) -> AppError {
     if err.is_timeout() || err.is_connect() || err.is_request() {
         AppError::Network {
@@ -514,22 +522,30 @@ fn classify_fetch_status(url: &str, status: reqwest::StatusCode) -> Option<AppEr
 /// can reach arbitrary hosts is this bounded, HTML-only primitive, and the
 /// privacy gate in `@reflect/core` runs before it is ever called.
 #[tauri::command]
-pub async fn capture_meta_fetch<R: tauri::Runtime>(
-    url: String,
-    app: tauri::AppHandle<R>,
-) -> AppResult<String> {
+pub async fn capture_meta_fetch(url: String) -> AppResult<String> {
     if !url.starts_with("https://") && !url.starts_with("http://") {
         return Err(AppError::parse(format!("not an http(s) url: {url}")));
     }
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::limited(5))
         .timeout(META_FETCH_TIMEOUT)
-        .user_agent(crate::app_user_agent(&app))
+        .user_agent(META_FETCH_USER_AGENT)
         .build()
         .map_err(|err| AppError::io(err.to_string()))?;
     let response = client
         .get(&url)
-        .header("Accept", "text/html,application/xhtml+xml")
+        // The full header set a browser sends on a typed-URL navigation —
+        // absent Sec-Fetch/Accept-Language headers are themselves a bot
+        // signal to fingerprinting CDNs.
+        .header(
+            "Accept",
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        )
+        .header("Accept-Language", "en-US,en;q=0.9")
+        .header("Sec-Fetch-Dest", "document")
+        .header("Sec-Fetch-Mode", "navigate")
+        .header("Sec-Fetch-Site", "none")
+        .header("Upgrade-Insecure-Requests", "1")
         .send()
         .await
         .map_err(classify_fetch_error)?;


### PR DESCRIPTION
## Problem

Follow-up to #884 (this commit was pushed to that branch moments after it merged, so it lands separately). #884 diagnosed the Instagram enrichment failures as rate limiting plus queue starvation — from a residential IP, Instagram serves identical OpenGraph metadata to the app's `Reflect/x.y` UA, a Safari UA, and a crawler UA, with 200s even under a 12-request burst. But that doesn't rule out client fingerprinting on stricter network edges (cellular CGNAT, datacenter IPs), where a bare app user agent — and the *absence* of the `Sec-Fetch-*`/`Accept-Language` headers every real browser sends — is itself a bot signal that can earn login walls or challenge pages a normal browser request never sees.

## Changes

- `capture_meta_fetch` now presents as a mainstream browser navigation: a pinned Safari UA (`META_FETCH_USER_AGENT` — Safari's platform token is frozen upstream, so the string stays plausible without tracking macOS releases) plus the exact header set of a typed-URL navigation (`Accept`, `Accept-Language`, `Sec-Fetch-Dest/Mode/Site`, `Upgrade-Insecure-Requests`).
- The now-unused `AppHandle` parameter is dropped; `app_user_agent` remains for its other consumer (`fs/mod.rs`).

## Testing

- Verified the exact production header set against the real Instagram reel URL: 200, identical OG metadata to the previous UA.
- `cargo fmt` / `cargo clippy -p reflect-open --no-deps` clean; `cargo test -p reflect-open capture::` — 17 pass.

## Risk

- Sites that vary content by `Accept-Language` will now see `en-US` preference; OG metadata is rarely localized that way, and the previous request sent no language header at all.
- The scrape remains the hard-capped, HTML-only primitive — only the request identity changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to bounded HTML meta scraping; main behavioral shift is sites may see `en-US` language preference where none was sent before.
> 
> **Overview**
> **`capture_meta_fetch`** no longer identifies as `Reflect/<version>` or takes **`AppHandle`**. It uses a fixed **`META_FETCH_USER_AGENT`** (Safari on macOS) and sends the same headers as a typed URL navigation—**`Accept`**, **`Accept-Language`**, **`Sec-Fetch-*`**, **`Upgrade-Insecure-Requests`**—so fingerprinting-heavy sites are less likely to return login walls instead of Open Graph HTML.
> 
> Fetch limits (timeout, byte cap, redirects, http(s)-only) are unchanged; **`app_user_agent`** is still used elsewhere (e.g. zip import downloads).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b4bd12fcb9c5271fd2dbb91fef2445bf0887857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->