### PR TITLE
feat: attach page preview images to shared link captures

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -178,3 +178,6 @@ tauri-plugin-recording = { path = "../../../plugins/tauri-plugin-recording" }
 
 [dev-dependencies]
 tauri = { version = "2.11.2", features = ["test"] }
+# The capture fetch integration tests drive the async primitives against a
+# local server; the extra features are test-only (prod inherits tauri's).
+tokio = { version = "1.52.3", features = ["macros", "rt", "net", "io-util"] }

--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -524,6 +524,17 @@ fn classify_fetch_status(url: &str, status: reqwest::StatusCode) -> Option<AppEr
     Some(AppError::io(message))
 }
 
+/// What the meta fetch hands back: the capped HTML plus the URL that
+/// actually served it — redirects are followed, so relative references in
+/// the HTML (an `og:image` path) must resolve against `final_url`, not the
+/// URL the capture started from.
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MetaFetchResponse {
+    pub html: String,
+    pub final_url: String,
+}
+
 /// Fetch a captured page's HTML for meta-tag scraping, hard-capped (timeout,
 /// byte cap, redirect limit, http(s) only). Lives here rather than widening
 /// the webview's HTTP-plugin capability to every URL — the only thing that
@@ -536,7 +547,7 @@ fn classify_fetch_status(url: &str, status: reqwest::StatusCode) -> Option<AppEr
 /// URL comes from page content. The response is only ever parsed for text
 /// metadata. Revisit if scrape targets ever become content-controlled.
 #[tauri::command]
-pub async fn capture_meta_fetch(url: String) -> AppResult<String> {
+pub async fn capture_meta_fetch(url: String) -> AppResult<MetaFetchResponse> {
     if !url.starts_with("https://") && !url.starts_with("http://") {
         return Err(AppError::parse(format!("not an http(s) url: {url}")));
     }
@@ -579,6 +590,7 @@ pub async fn capture_meta_fetch(url: String) -> AppResult<String> {
         )));
     }
 
+    let final_url = response.url().to_string();
     let mut body: Vec<u8> = Vec::new();
     let mut response = response;
     while let Some(chunk) = response.chunk().await.map_err(classify_fetch_error)? {
@@ -588,7 +600,10 @@ pub async fn capture_meta_fetch(url: String) -> AppResult<String> {
             break;
         }
     }
-    Ok(String::from_utf8_lossy(&body).into_owned())
+    Ok(MetaFetchResponse {
+        html: String::from_utf8_lossy(&body).into_owned(),
+        final_url,
+    })
 }
 
 /// Cap on a fetched preview image's raw bytes. Unlike the HTML fetch, a
@@ -990,8 +1005,34 @@ mod tests {
 
         let fetched = capture_meta_fetch(format!("{base}/page")).await.unwrap();
 
-        assert_eq!(fetched.len(), META_FETCH_MAX_BYTES);
-        assert!(fetched.contains("<title>Big page</title>"));
+        assert_eq!(fetched.html.len(), META_FETCH_MAX_BYTES);
+        assert!(fetched.html.contains("<title>Big page</title>"));
+        assert_eq!(fetched.final_url, format!("{base}/page"));
+    }
+
+    #[tokio::test]
+    async fn meta_fetch_reports_the_redirected_final_url() {
+        let base = serve(vec![
+            (
+                "/moved",
+                response("301 Moved Permanently", &[("Location", "/final/page")], b""),
+            ),
+            (
+                "/final/page",
+                response(
+                    "200 OK",
+                    &[("Content-Type", "text/html")],
+                    b"<html><head><title>Landed</title></head></html>",
+                ),
+            ),
+        ])
+        .await;
+
+        let fetched = capture_meta_fetch(format!("{base}/moved")).await.unwrap();
+
+        // Relative references in the HTML must resolve against this URL.
+        assert_eq!(fetched.final_url, format!("{base}/final/page"));
+        assert!(fetched.html.contains("Landed"));
     }
 
     #[tokio::test]

--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -529,6 +529,12 @@ fn classify_fetch_status(url: &str, status: reqwest::StatusCode) -> Option<AppEr
 /// the webview's HTTP-plugin capability to every URL — the only thing that
 /// can reach arbitrary hosts is this bounded, HTML-only primitive, and the
 /// privacy gate in `@reflect/core` runs before it is ever called.
+///
+/// Deliberately *not* host-vetted the way `capture_image_fetch` is: the
+/// capture URL is one the user chose to share (user intent, possibly a
+/// private-network page they legitimately want captured), whereas the image
+/// URL comes from page content. The response is only ever parsed for text
+/// metadata. Revisit if scrape targets ever become content-controlled.
 #[tauri::command]
 pub async fn capture_meta_fetch(url: String) -> AppResult<String> {
     if !url.starts_with("https://") && !url.starts_with("http://") {
@@ -630,10 +636,11 @@ fn public_address(addr: &std::net::IpAddr) -> bool {
 }
 
 /// Resolve one redirect hop's host and refuse it unless every address is
-/// public ({@link public_address}); returns the vetted socket address so the
-/// caller can pin the connection to it (resolving again at connect time
-/// would reopen the DNS-rebinding window this check closes).
-async fn vetted_image_addr(target: &reqwest::Url) -> AppResult<std::net::SocketAddr> {
+/// public ([`public_address`]); returns the full vetted address list so the
+/// caller can pin the connection to it — all of it, keeping the resolver's
+/// v4/v6 fallback — because resolving again at connect time would reopen
+/// the DNS-rebinding window this check closes.
+async fn vetted_image_addrs(target: &reqwest::Url) -> AppResult<Vec<std::net::SocketAddr>> {
     let host = target
         .host_str()
         .ok_or_else(|| AppError::parse(format!("{target} has no host")))?;
@@ -658,7 +665,7 @@ async fn vetted_image_addr(target: &reqwest::Url) -> AppResult<std::net::SocketA
             )));
         }
     }
-    Ok(addrs[0])
+    Ok(addrs)
 }
 
 /// Fetch a captured page's own preview image (its `og:image`) and store it
@@ -688,13 +695,13 @@ pub async fn capture_image_fetch(
         if target.scheme() != "https" && target.scheme() != "http" {
             return Err(AppError::parse(format!("not an http(s) url: {target}")));
         }
-        let addr = vetted_image_addr(&target).await?;
+        let addrs = vetted_image_addrs(&target).await?;
         let host = target.host_str().unwrap_or_default().to_owned();
         // Redirects are followed manually (with the host re-vetted each hop)
-        // and the connection pinned to the vetted address.
+        // and the connection pinned to the vetted addresses.
         let client = reqwest::Client::builder()
             .redirect(reqwest::redirect::Policy::none())
-            .resolve(&host, addr)
+            .resolve_to_addrs(&host, &addrs)
             .timeout(META_FETCH_TIMEOUT)
             .user_agent(META_FETCH_USER_AGENT)
             .build()

--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -445,6 +445,25 @@ fn downscale_jpeg(bytes: &[u8], max_dim: u32) -> AppResult<Vec<u8>> {
     Ok(out)
 }
 
+/// Write asset bytes into the graph atomically: a same-directory temp file
+/// first, then a rename — readers never see a half-written asset.
+fn persist_asset(root: &std::path::Path, asset_path: &str, bytes: &[u8]) -> AppResult<()> {
+    let target = crate::fs::resolve_in_graph(root, asset_path)?;
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut tmp = tempfile::NamedTempFile::new_in(
+        target
+            .parent()
+            .ok_or_else(|| AppError::io("asset path has no parent"))?,
+    )?;
+    tmp.write_all(bytes)?;
+    tmp.flush()?;
+    tmp.persist(&target)
+        .map_err(|err| AppError::io(err.to_string()))?;
+    Ok(())
+}
+
 /// Copy a spooled screenshot into the graph as a downscaled JPEG asset. Copy,
 /// not move — the drain removes spool files only after the note is written,
 /// so a crash mid-drain re-runs cleanly.
@@ -459,20 +478,7 @@ pub fn capture_screenshot_promote(
     let root = root_for_generation(&state, generation)?;
     let bytes = fs::read(inbox_file(&root, &spool_name)?)?;
     let jpeg = downscale_jpeg(&bytes, max_dim)?;
-    let target = crate::fs::resolve_in_graph(&root, &asset_path)?;
-    if let Some(parent) = target.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    let mut tmp = tempfile::NamedTempFile::new_in(
-        target
-            .parent()
-            .ok_or_else(|| AppError::io("asset path has no parent"))?,
-    )?;
-    tmp.write_all(&jpeg)?;
-    tmp.flush()?;
-    tmp.persist(&target)
-        .map_err(|err| AppError::io(err.to_string()))?;
-    Ok(())
+    persist_asset(&root, &asset_path, &jpeg)
 }
 
 // ---- meta fetch -----------------------------------------------------------------
@@ -579,9 +585,96 @@ pub async fn capture_meta_fetch(url: String) -> AppResult<String> {
     Ok(String::from_utf8_lossy(&body).into_owned())
 }
 
+/// Cap on a fetched preview image's raw bytes. Unlike the HTML fetch, a
+/// truncated image is useless, so an oversized answer fails instead of
+/// being cut off; the downscale pass below bounds what lands in the graph.
+const IMAGE_FETCH_MAX_BYTES: usize = 8 * 1024 * 1024;
+
+/// Is this Content-Type an image? Parameters (`; charset=…`) don't matter;
+/// case doesn't either (the caller lowercases).
+fn image_content_type(content_type: &str) -> bool {
+    content_type.trim_start().starts_with("image/")
+}
+
+/// Fetch a captured page's own preview image (its `og:image`) and store it
+/// as the capture's screenshot asset. Same bounded shape as the meta fetch —
+/// http(s) only, timeout, redirect limit, byte cap, browser presentation —
+/// plus image-only content and the screenshot downscale/re-encode, so a
+/// hostile URL can neither widen the webview's HTTP capability nor land
+/// oversized or non-image bytes in the graph. The privacy gate in
+/// `@reflect/core` runs before it is ever called.
+#[tauri::command]
+pub async fn capture_image_fetch(
+    url: String,
+    asset_path: String,
+    max_dim: u32,
+    generation: u64,
+    state: State<'_, GraphState>,
+) -> AppResult<()> {
+    if !url.starts_with("https://") && !url.starts_with("http://") {
+        return Err(AppError::parse(format!("not an http(s) url: {url}")));
+    }
+    let root = root_for_generation(&state, generation)?;
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::limited(5))
+        .timeout(META_FETCH_TIMEOUT)
+        .user_agent(META_FETCH_USER_AGENT)
+        .build()
+        .map_err(|err| AppError::io(err.to_string()))?;
+    let response = client
+        .get(&url)
+        // What a browser sends when a page loads a cross-site image.
+        .header(
+            "Accept",
+            "image/avif,image/webp,image/png,image/*;q=0.8,*/*;q=0.5",
+        )
+        .header("Accept-Language", "en-US,en;q=0.9")
+        .header("Sec-Fetch-Dest", "image")
+        .header("Sec-Fetch-Mode", "no-cors")
+        .header("Sec-Fetch-Site", "cross-site")
+        .send()
+        .await
+        .map_err(classify_fetch_error)?;
+
+    if let Some(err) = classify_fetch_status(&url, response.status()) {
+        return Err(err);
+    }
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    if !image_content_type(&content_type) {
+        return Err(AppError::parse(format!(
+            "{url} is not an image ({content_type})"
+        )));
+    }
+
+    let mut bytes: Vec<u8> = Vec::new();
+    let mut response = response;
+    while let Some(chunk) = response.chunk().await.map_err(classify_fetch_error)? {
+        if bytes.len() + chunk.len() > IMAGE_FETCH_MAX_BYTES {
+            return Err(AppError::io(format!("{url} exceeds the preview image cap")));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    let jpeg = downscale_jpeg(&bytes, max_dim)?;
+    persist_asset(&root, &asset_path, &jpeg)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn image_content_types_gate_on_the_image_family() {
+        assert!(image_content_type("image/jpeg"));
+        assert!(image_content_type("image/webp; charset=binary"));
+        assert!(!image_content_type("text/html"));
+        assert!(!image_content_type("application/octet-stream"));
+        assert!(!image_content_type(""));
+    }
 
     #[test]
     fn meta_fetch_statuses_classify_rate_limits_as_retryable() {

--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -596,13 +596,80 @@ fn image_content_type(content_type: &str) -> bool {
     content_type.trim_start().starts_with("image/")
 }
 
+/// Is this an address the preview-image fetch may connect to? The image URL
+/// comes from page *content* — attacker-controlled, unlike the user-shared
+/// capture URL — so the fetch must never become a bridge onto localhost, the
+/// user's LAN, carrier-grade NAT space, or link-local metadata endpoints.
+fn public_address(addr: &std::net::IpAddr) -> bool {
+    match addr {
+        std::net::IpAddr::V4(v4) => {
+            let octets = v4.octets();
+            let cgnat = octets[0] == 100 && (octets[1] & 0xc0) == 64; // 100.64/10
+            !(v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_broadcast()
+                || v4.is_multicast()
+                || v4.is_unspecified()
+                || cgnat)
+        }
+        std::net::IpAddr::V6(v6) => {
+            if let Some(mapped) = v6.to_ipv4_mapped() {
+                return public_address(&std::net::IpAddr::V4(mapped));
+            }
+            let segments = v6.segments();
+            let unique_local = (segments[0] & 0xfe00) == 0xfc00; // fc00::/7
+            let link_local = (segments[0] & 0xffc0) == 0xfe80; // fe80::/10
+            !(v6.is_loopback()
+                || v6.is_unspecified()
+                || v6.is_multicast()
+                || unique_local
+                || link_local)
+        }
+    }
+}
+
+/// Resolve one redirect hop's host and refuse it unless every address is
+/// public ({@link public_address}); returns the vetted socket address so the
+/// caller can pin the connection to it (resolving again at connect time
+/// would reopen the DNS-rebinding window this check closes).
+async fn vetted_image_addr(target: &reqwest::Url) -> AppResult<std::net::SocketAddr> {
+    let host = target
+        .host_str()
+        .ok_or_else(|| AppError::parse(format!("{target} has no host")))?;
+    let port = target
+        .port_or_known_default()
+        .ok_or_else(|| AppError::parse(format!("{target} has no port")))?;
+    let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host((host, port))
+        .await
+        .map_err(|err| AppError::Network {
+            message: format!("{host} did not resolve: {err}"),
+        })?
+        .collect();
+    if addrs.is_empty() {
+        return Err(AppError::Network {
+            message: format!("{host} did not resolve"),
+        });
+    }
+    for addr in &addrs {
+        if !public_address(&addr.ip()) {
+            return Err(AppError::parse(format!(
+                "{host} resolves to a non-public address"
+            )));
+        }
+    }
+    Ok(addrs[0])
+}
+
 /// Fetch a captured page's own preview image (its `og:image`) and store it
 /// as the capture's screenshot asset. Same bounded shape as the meta fetch —
 /// http(s) only, timeout, redirect limit, byte cap, browser presentation —
-/// plus image-only content and the screenshot downscale/re-encode, so a
-/// hostile URL can neither widen the webview's HTTP capability nor land
-/// oversized or non-image bytes in the graph. The privacy gate in
-/// `@reflect/core` runs before it is ever called.
+/// plus image-only content, public-address-only hosts (checked per redirect
+/// hop, connections pinned to the vetted address), and the screenshot
+/// downscale/re-encode, so a hostile URL can neither widen the webview's
+/// HTTP capability, reach into the local network, nor land oversized or
+/// non-image bytes in the graph. The privacy gate in `@reflect/core` runs
+/// before it is ever called.
 #[tauri::command]
 pub async fn capture_image_fetch(
     url: String,
@@ -611,30 +678,57 @@ pub async fn capture_image_fetch(
     generation: u64,
     state: State<'_, GraphState>,
 ) -> AppResult<()> {
-    if !url.starts_with("https://") && !url.starts_with("http://") {
-        return Err(AppError::parse(format!("not an http(s) url: {url}")));
+    // Fail fast before any network work; the root is re-derived after it.
+    root_for_generation(&state, generation)?;
+
+    let mut target =
+        reqwest::Url::parse(&url).map_err(|err| AppError::parse(format!("{url}: {err}")))?;
+    let mut response: Option<reqwest::Response> = None;
+    for _hop in 0..=5 {
+        if target.scheme() != "https" && target.scheme() != "http" {
+            return Err(AppError::parse(format!("not an http(s) url: {target}")));
+        }
+        let addr = vetted_image_addr(&target).await?;
+        let host = target.host_str().unwrap_or_default().to_owned();
+        // Redirects are followed manually (with the host re-vetted each hop)
+        // and the connection pinned to the vetted address.
+        let client = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .resolve(&host, addr)
+            .timeout(META_FETCH_TIMEOUT)
+            .user_agent(META_FETCH_USER_AGENT)
+            .build()
+            .map_err(|err| AppError::io(err.to_string()))?;
+        let hop_response = client
+            .get(target.clone())
+            // What a browser sends when a page loads a cross-site image.
+            .header(
+                "Accept",
+                "image/avif,image/webp,image/png,image/*;q=0.8,*/*;q=0.5",
+            )
+            .header("Accept-Language", "en-US,en;q=0.9")
+            .header("Sec-Fetch-Dest", "image")
+            .header("Sec-Fetch-Mode", "no-cors")
+            .header("Sec-Fetch-Site", "cross-site")
+            .send()
+            .await
+            .map_err(classify_fetch_error)?;
+        if hop_response.status().is_redirection() {
+            let location = hop_response
+                .headers()
+                .get(reqwest::header::LOCATION)
+                .and_then(|value| value.to_str().ok())
+                .ok_or_else(|| AppError::io(format!("{target} redirected without a location")))?;
+            target = target
+                .join(location)
+                .map_err(|err| AppError::parse(format!("{target} redirected badly: {err}")))?;
+            continue;
+        }
+        response = Some(hop_response);
+        break;
     }
-    let root = root_for_generation(&state, generation)?;
-    let client = reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::limited(5))
-        .timeout(META_FETCH_TIMEOUT)
-        .user_agent(META_FETCH_USER_AGENT)
-        .build()
-        .map_err(|err| AppError::io(err.to_string()))?;
-    let response = client
-        .get(&url)
-        // What a browser sends when a page loads a cross-site image.
-        .header(
-            "Accept",
-            "image/avif,image/webp,image/png,image/*;q=0.8,*/*;q=0.5",
-        )
-        .header("Accept-Language", "en-US,en;q=0.9")
-        .header("Sec-Fetch-Dest", "image")
-        .header("Sec-Fetch-Mode", "no-cors")
-        .header("Sec-Fetch-Site", "cross-site")
-        .send()
-        .await
-        .map_err(classify_fetch_error)?;
+    let response =
+        response.ok_or_else(|| AppError::io(format!("{url} redirected too many times")))?;
 
     if let Some(err) = classify_fetch_status(&url, response.status()) {
         return Err(err);
@@ -660,12 +754,34 @@ pub async fn capture_image_fetch(
         bytes.extend_from_slice(&chunk);
     }
     let jpeg = downscale_jpeg(&bytes, max_dim)?;
+    // Re-pin the graph: a 15s fetch is long enough for a graph switch, and
+    // persisting into a stale root would resurrect files under it.
+    let root = root_for_generation(&state, generation)?;
     persist_asset(&root, &asset_path, &jpeg)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn public_addresses_exclude_every_local_network_family() {
+        use std::net::IpAddr;
+        let public = |candidate: &str| public_address(&candidate.parse::<IpAddr>().unwrap());
+        assert!(public("93.184.216.34"));
+        assert!(public("2606:2800:220:1:248:1893:25c8:1946"));
+        assert!(!public("127.0.0.1")); // loopback
+        assert!(!public("10.0.0.8")); // private
+        assert!(!public("172.16.4.1")); // private
+        assert!(!public("192.168.1.1")); // private
+        assert!(!public("169.254.169.254")); // link-local (cloud metadata)
+        assert!(!public("100.64.0.1")); // carrier-grade NAT
+        assert!(!public("0.0.0.0")); // unspecified
+        assert!(!public("::1")); // v6 loopback
+        assert!(!public("fd12:3456:789a::1")); // v6 unique-local
+        assert!(!public("fe80::1")); // v6 link-local
+        assert!(!public("::ffff:192.168.1.1")); // v4-mapped private
+    }
 
     #[test]
     fn image_content_types_gate_on_the_image_family() {

--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -635,12 +635,28 @@ fn public_address(addr: &std::net::IpAddr) -> bool {
     }
 }
 
+/// Which hosts the preview-image fetch may connect to. Production always
+/// runs [`HostPolicy::PublicOnly`]; the test-only variant lets integration
+/// tests point the fetch at a loopback server to exercise the redirect,
+/// content-type, and byte-cap mechanics.
+#[derive(Clone, Copy)]
+enum HostPolicy {
+    /// Every hop's host must resolve exclusively to public addresses.
+    PublicOnly,
+    /// Skip the public-address check (local test servers only).
+    #[cfg(test)]
+    AllowLocal,
+}
+
 /// Resolve one redirect hop's host and refuse it unless every address is
 /// public ([`public_address`]); returns the full vetted address list so the
 /// caller can pin the connection to it — all of it, keeping the resolver's
 /// v4/v6 fallback — because resolving again at connect time would reopen
 /// the DNS-rebinding window this check closes.
-async fn vetted_image_addrs(target: &reqwest::Url) -> AppResult<Vec<std::net::SocketAddr>> {
+async fn vetted_image_addrs(
+    target: &reqwest::Url,
+    hosts: HostPolicy,
+) -> AppResult<Vec<std::net::SocketAddr>> {
     let host = target
         .host_str()
         .ok_or_else(|| AppError::parse(format!("{target} has no host")))?;
@@ -658,6 +674,11 @@ async fn vetted_image_addrs(target: &reqwest::Url) -> AppResult<Vec<std::net::So
             message: format!("{host} did not resolve"),
         });
     }
+    match hosts {
+        #[cfg(test)]
+        HostPolicy::AllowLocal => return Ok(addrs),
+        HostPolicy::PublicOnly => {}
+    }
     for addr in &addrs {
         if !public_address(&addr.ip()) {
             return Err(AppError::parse(format!(
@@ -668,34 +689,20 @@ async fn vetted_image_addrs(target: &reqwest::Url) -> AppResult<Vec<std::net::So
     Ok(addrs)
 }
 
-/// Fetch a captured page's own preview image (its `og:image`) and store it
-/// as the capture's screenshot asset. Same bounded shape as the meta fetch —
-/// http(s) only, timeout, redirect limit, byte cap, browser presentation —
-/// plus image-only content, public-address-only hosts (checked per redirect
-/// hop, connections pinned to the vetted address), and the screenshot
-/// downscale/re-encode, so a hostile URL can neither widen the webview's
-/// HTTP capability, reach into the local network, nor land oversized or
-/// non-image bytes in the graph. The privacy gate in `@reflect/core` runs
-/// before it is ever called.
-#[tauri::command]
-pub async fn capture_image_fetch(
-    url: String,
-    asset_path: String,
-    max_dim: u32,
-    generation: u64,
-    state: State<'_, GraphState>,
-) -> AppResult<()> {
-    // Fail fast before any network work; the root is re-derived after it.
-    root_for_generation(&state, generation)?;
-
+/// The network half of the preview-image fetch: follow redirects manually
+/// (host-vetted per hop, connection pinned to the vetted addresses), require
+/// image content, cap the raw bytes, and downscale/re-encode to JPEG.
+/// Stateless so the integration tests can exercise it against a local
+/// server; the command below owns graph-root resolution and the write.
+async fn fetch_preview_image(url: &str, max_dim: u32, hosts: HostPolicy) -> AppResult<Vec<u8>> {
     let mut target =
-        reqwest::Url::parse(&url).map_err(|err| AppError::parse(format!("{url}: {err}")))?;
+        reqwest::Url::parse(url).map_err(|err| AppError::parse(format!("{url}: {err}")))?;
     let mut response: Option<reqwest::Response> = None;
     for _hop in 0..=5 {
         if target.scheme() != "https" && target.scheme() != "http" {
             return Err(AppError::parse(format!("not an http(s) url: {target}")));
         }
-        let addrs = vetted_image_addrs(&target).await?;
+        let addrs = vetted_image_addrs(&target, hosts).await?;
         let host = target.host_str().unwrap_or_default().to_owned();
         // Redirects are followed manually (with the host re-vetted each hop)
         // and the connection pinned to the vetted addresses.
@@ -737,7 +744,7 @@ pub async fn capture_image_fetch(
     let response =
         response.ok_or_else(|| AppError::io(format!("{url} redirected too many times")))?;
 
-    if let Some(err) = classify_fetch_status(&url, response.status()) {
+    if let Some(err) = classify_fetch_status(url, response.status()) {
         return Err(err);
     }
     let content_type = response
@@ -760,7 +767,29 @@ pub async fn capture_image_fetch(
         }
         bytes.extend_from_slice(&chunk);
     }
-    let jpeg = downscale_jpeg(&bytes, max_dim)?;
+    downscale_jpeg(&bytes, max_dim)
+}
+
+/// Fetch a captured page's own preview image (its `og:image`) and store it
+/// as the capture's screenshot asset. Same bounded shape as the meta fetch —
+/// http(s) only, timeout, redirect limit, byte cap, browser presentation —
+/// plus image-only content, public-address-only hosts (checked per redirect
+/// hop, connections pinned to the vetted address), and the screenshot
+/// downscale/re-encode, so a hostile URL can neither widen the webview's
+/// HTTP capability, reach into the local network, nor land oversized or
+/// non-image bytes in the graph. The privacy gate in `@reflect/core` runs
+/// before it is ever called.
+#[tauri::command]
+pub async fn capture_image_fetch(
+    url: String,
+    asset_path: String,
+    max_dim: u32,
+    generation: u64,
+    state: State<'_, GraphState>,
+) -> AppResult<()> {
+    // Fail fast before any network work; the root is re-derived after it.
+    root_for_generation(&state, generation)?;
+    let jpeg = fetch_preview_image(&url, max_dim, HostPolicy::PublicOnly).await?;
     // Re-pin the graph: a 15s fetch is long enough for a graph switch, and
     // persisting into a stale root would resurrect files under it.
     let root = root_for_generation(&state, generation)?;
@@ -770,6 +799,213 @@ pub async fn capture_image_fetch(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use std::sync::Arc;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    /// Serve canned HTTP/1.1 responses on 127.0.0.1: each connection's
+    /// request path is matched against `routes` and the canned bytes written
+    /// back verbatim. Returns the server's base URL.
+    async fn serve(routes: Vec<(&'static str, Vec<u8>)>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://127.0.0.1:{}", listener.local_addr().unwrap().port());
+        let routes = Arc::new(routes);
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let routes = routes.clone();
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 4096];
+                    let Ok(read) = stream.read(&mut buf).await else {
+                        return;
+                    };
+                    let head = String::from_utf8_lossy(&buf[..read]).into_owned();
+                    let path = head.split_whitespace().nth(1).unwrap_or("/").to_owned();
+                    let not_found = response("404 Not Found", &[], b"");
+                    let body = routes
+                        .iter()
+                        .find(|(route, _)| *route == path)
+                        .map(|(_, bytes)| bytes.as_slice())
+                        .unwrap_or(&not_found);
+                    let _ = stream.write_all(body).await;
+                    let _ = stream.shutdown().await;
+                });
+            }
+        });
+        base
+    }
+
+    /// One canned HTTP/1.1 response with correct framing.
+    fn response(status: &str, headers: &[(&str, &str)], body: &[u8]) -> Vec<u8> {
+        let mut head = format!("HTTP/1.1 {status}\r\n");
+        for (name, value) in headers {
+            head.push_str(&format!("{name}: {value}\r\n"));
+        }
+        head.push_str(&format!(
+            "Content-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        ));
+        let mut bytes = head.into_bytes();
+        bytes.extend_from_slice(body);
+        bytes
+    }
+
+    /// A tiny valid PNG for the happy-path fetch.
+    fn png_bytes() -> Vec<u8> {
+        let mut out = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::new_rgb8(4, 4)
+            .write_to(&mut out, image::ImageFormat::Png)
+            .unwrap();
+        out.into_inner()
+    }
+
+    fn error_message(result: AppResult<Vec<u8>>) -> String {
+        match result.unwrap_err() {
+            AppError::Io { message }
+            | AppError::Parse { message }
+            | AppError::Network { message } => message,
+            other => panic!("unexpected error kind: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn preview_fetch_follows_relative_redirects_to_the_image() {
+        let base = serve(vec![
+            (
+                "/start",
+                response("302 Found", &[("Location", "/hop/")], b""),
+            ),
+            // A relative Location must resolve against the current hop.
+            (
+                "/hop/",
+                response("302 Found", &[("Location", "cover.png")], b""),
+            ),
+            (
+                "/hop/cover.png",
+                response("200 OK", &[("Content-Type", "image/png")], &png_bytes()),
+            ),
+        ])
+        .await;
+
+        let jpeg = fetch_preview_image(&format!("{base}/start"), 64, HostPolicy::AllowLocal)
+            .await
+            .unwrap();
+
+        // Decoded and re-encoded: the stored asset is JPEG regardless of source.
+        assert_eq!(&jpeg[..2], &[0xff, 0xd8]);
+    }
+
+    #[tokio::test]
+    async fn preview_fetch_gives_up_after_five_redirects() {
+        let base = serve(vec![(
+            "/loop",
+            response("302 Found", &[("Location", "/loop")], b""),
+        )])
+        .await;
+
+        let message = error_message(
+            fetch_preview_image(&format!("{base}/loop"), 64, HostPolicy::AllowLocal).await,
+        );
+
+        assert!(message.contains("redirected too many times"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn preview_fetch_fails_on_a_redirect_without_a_location() {
+        let base = serve(vec![("/lost", response("302 Found", &[], b""))]).await;
+
+        let message = error_message(
+            fetch_preview_image(&format!("{base}/lost"), 64, HostPolicy::AllowLocal).await,
+        );
+
+        assert!(
+            message.contains("redirected without a location"),
+            "{message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn preview_fetch_refuses_non_image_content() {
+        let base = serve(vec![(
+            "/page",
+            response("200 OK", &[("Content-Type", "text/html")], b"<html></html>"),
+        )])
+        .await;
+
+        let message = error_message(
+            fetch_preview_image(&format!("{base}/page"), 64, HostPolicy::AllowLocal).await,
+        );
+
+        assert!(message.contains("is not an image"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn preview_fetch_refuses_oversized_images() {
+        let oversized = vec![0u8; IMAGE_FETCH_MAX_BYTES + 1];
+        let base = serve(vec![(
+            "/huge.png",
+            response("200 OK", &[("Content-Type", "image/png")], &oversized),
+        )])
+        .await;
+
+        let message = error_message(
+            fetch_preview_image(&format!("{base}/huge.png"), 64, HostPolicy::AllowLocal).await,
+        );
+
+        assert!(
+            message.contains("exceeds the preview image cap"),
+            "{message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn preview_fetch_refuses_local_hosts_in_production_policy() {
+        // The SSRF regression test: under the production policy the fetch
+        // must refuse loopback before a single byte is sent.
+        let base = serve(vec![(
+            "/cover.png",
+            response("200 OK", &[("Content-Type", "image/png")], &png_bytes()),
+        )])
+        .await;
+
+        let message = error_message(
+            fetch_preview_image(&format!("{base}/cover.png"), 64, HostPolicy::PublicOnly).await,
+        );
+
+        assert!(message.contains("non-public address"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn meta_fetch_truncates_at_the_byte_cap() {
+        let mut html = String::from("<html><head><title>Big page</title></head><body>");
+        html.push_str(&"x".repeat(600 * 1024));
+        let base = serve(vec![(
+            "/page",
+            response("200 OK", &[("Content-Type", "text/html")], html.as_bytes()),
+        )])
+        .await;
+
+        let fetched = capture_meta_fetch(format!("{base}/page")).await.unwrap();
+
+        assert_eq!(fetched.len(), META_FETCH_MAX_BYTES);
+        assert!(fetched.contains("<title>Big page</title>"));
+    }
+
+    #[tokio::test]
+    async fn meta_fetch_refuses_non_html_content() {
+        let base = serve(vec![(
+            "/cover.png",
+            response("200 OK", &[("Content-Type", "image/png")], &png_bytes()),
+        )])
+        .await;
+
+        let result = capture_meta_fetch(format!("{base}/cover.png")).await;
+
+        assert!(matches!(result, Err(AppError::Parse { .. })), "{result:?}");
+    }
 
     #[test]
     fn public_addresses_exclude_every_local_network_family() {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -315,6 +315,7 @@ pub fn run() {
             capture::capture_shared_inbox_relay,
             capture::capture_screenshot_promote,
             capture::capture_meta_fetch,
+            capture::capture_image_fetch,
             git::git_status,
             git::git_setup,
             git::git_disconnect,

--- a/docs/contributing/mobile-simulator.md
+++ b/docs/contributing/mobile-simulator.md
@@ -54,3 +54,56 @@ merged `Info.plist` usage descriptions. Inspect those diffs before committing;
 when the generated output is intentionally refreshed, update the source
 template in `apps/desktop/src-tauri/ios.project.yml` or
 `apps/desktop/src-tauri/Info.plist` first.
+
+## Exercising share capture without the share sheet
+
+The share extension only writes an envelope into the App Group inbox — the
+main app relays, drains, and enriches it on the next foreground. Because the
+simulator's containers are plain directories on the host, you can spool that
+envelope yourself and exercise the whole pipeline (relay → drain → meta
+scrape → preview image → AI enrichment) deterministically, without driving
+the share sheet. This is how the enrichment fixes in #884/#886/#888 were
+debugged and verified.
+
+With the app running and a local graph created:
+
+```bash
+# 1. The dev App Group container (group id per ShareExtension/CaptureInbox.swift)
+GROUP=$(xcrun simctl get_app_container booted app.reflect.ios.dev groups \
+  | grep group.app.reflect.dev | awk '{print $2}')
+
+# 2. Spool a link-capture envelope, exactly as the extension would
+ID=$(uuidgen | tr 'A-Z' 'a-z')
+NOW=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+mkdir -p "$GROUP/inbox"
+printf '{"version":1,"id":"%s","url":"https://example.com/article","title":"","capturedAt":"%s","source":"ios-share"}' \
+  "$ID" "$NOW" > "$GROUP/inbox/$ID.json"
+
+# 3. Trigger the relay: background the app, then foreground it
+xcrun simctl launch booted com.apple.mobilesafari
+xcrun simctl launch booted app.reflect.ios.dev
+```
+
+The envelope shape is `captureEnvelopeSchema` in
+`packages/core/src/actions/capture-envelope.ts` (the id must be a lowercase
+8-4-4-4-12 uuid; `capturedAt` decides which daily note the link lands on).
+An empty `title` exercises the URL-only path most mobile apps produce;
+setting one exercises the share-sheet-supplied-title path.
+
+Results land in the graph, which is the app data container's `Documents/`:
+
+```bash
+DATA=$(xcrun simctl get_app_container booted app.reflect.ios.dev data)
+cat "$DATA"/Documents/notes/capture-*.md     # frontmatter shows captureStatus
+ls "$DATA"/Documents/assets/                 # fetched preview images
+cat "$DATA"/Documents/daily/$(date +%F).md   # the daily's Links entry
+```
+
+Two behaviors worth knowing while iterating:
+
+- Re-spooling the **same URL on the same day** dedups into the existing
+  capture note and resets it to `captureStatus: pending`, so enrichment runs
+  again — handy for re-testing without minting new notes.
+- `xcrun simctl openurl booted "reflect://note/<capture base name>"` opens
+  the note in the app for a visual check (approve the confirmation dialog in
+  the simulator).

--- a/docs/contributing/mobile-simulator.md
+++ b/docs/contributing/mobile-simulator.md
@@ -72,12 +72,15 @@ With the app running and a local graph created:
 GROUP=$(xcrun simctl get_app_container booted app.reflect.ios.dev groups \
   | grep group.app.reflect.dev | awk '{print $2}')
 
-# 2. Spool a link-capture envelope, exactly as the extension would
+# 2. Spool a link-capture envelope, exactly as the extension would:
+#    write a .tmp sibling, then rename — the relay only picks up committed
+#    .json files, so it can never see a half-written envelope
 ID=$(uuidgen | tr 'A-Z' 'a-z')
 NOW=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
 mkdir -p "$GROUP/inbox"
 printf '{"version":1,"id":"%s","url":"https://example.com/article","title":"","capturedAt":"%s","source":"ios-share"}' \
-  "$ID" "$NOW" > "$GROUP/inbox/$ID.json"
+  "$ID" "$NOW" > "$GROUP/inbox/$ID.json.tmp"
+mv "$GROUP/inbox/$ID.json.tmp" "$GROUP/inbox/$ID.json"
 
 # 3. Trigger the relay: background the app, then foreground it
 xcrun simctl launch booted com.apple.mobilesafari

--- a/packages/core/src/actions/capture-drain.test.ts
+++ b/packages/core/src/actions/capture-drain.test.ts
@@ -21,6 +21,7 @@ import type { TextCaptureEnvelope } from './capture-envelope'
 const ensureBacklinkTargetMock = vi.hoisted(() => vi.fn())
 
 vi.mock('../graph/commands', () => ({
+  captureImageFetch: vi.fn(),
   captureInboxList: vi.fn(),
   captureInboxRead: vi.fn(),
   captureInboxReject: vi.fn(),

--- a/packages/core/src/actions/capture-drain.ts
+++ b/packages/core/src/actions/capture-drain.ts
@@ -45,8 +45,11 @@ import {
 /** The category note every captured-link section backlinks. */
 const LINKS_NOTE_TITLE = 'Links'
 
-/** Long-edge cap for promoted screenshots (the Rust side re-encodes JPEG). */
-const SCREENSHOT_MAX_DIM = 1600
+/**
+ * Long-edge cap for capture screenshots (the Rust side re-encodes JPEG) —
+ * shared by the drain's spool promotion and enrichment's preview-image fetch.
+ */
+export const SCREENSHOT_MAX_DIM = 1600
 
 /** Spool `.jpg`s with no sibling `.json` older than this are host-crash debris. */
 const ORPHAN_SPOOL_MAX_AGE_MS = 60 * 60 * 1000

--- a/packages/core/src/actions/capture-enrichment-write.ts
+++ b/packages/core/src/actions/capture-enrichment-write.ts
@@ -39,6 +39,12 @@ interface PersistCaptureEnrichmentInput {
   status: Exclude<CaptureStatus, 'skipped'>
   provider: AiProviderConfig | null
   generation: number
+  /**
+   * Newly fetched preview-image asset to stamp as `captureScreenshot`.
+   * Omitted (`undefined`) leaves any existing stamp untouched — an
+   * `undefined` in the frontmatter patch would delete it.
+   */
+  screenshot?: string | undefined
 }
 
 interface CaptureWriteTransaction {
@@ -186,6 +192,7 @@ export async function persistCaptureEnrichment(
       captureModel: input.provider?.model,
       captureDailyFromTitle: titleChanged ? input.fromTitle : undefined,
       captureFinalizeStatus: titleChanged ? input.status : undefined,
+      ...(input.screenshot === undefined ? {} : { captureScreenshot: input.screenshot }),
     }),
     input.generation,
   )

--- a/packages/core/src/actions/capture-enrichment.test.ts
+++ b/packages/core/src/actions/capture-enrichment.test.ts
@@ -501,14 +501,16 @@ describe('reconcileCaptureEnrichment', () => {
   })
 
   it('does not send capture content to AI when the day becomes private during metadata fetch', async () => {
-    await drainOne()
+    addSpool(envelope({ source: 'ios-share', title: '' }), { screenshot: false })
+    expect((await drain()).stopped).toBeNull()
+    writeNoteMock.mockClear()
     scrapeMock.mockImplementation(async () => {
       files.set(DAILY, `---\nprivate: true\n---\n\n${files.get(DAILY) ?? ''}`)
       return {
         title: 'An article',
         description: 'A scraped description.',
         siteName: null,
-        image: null,
+        image: 'https://cdn.example.com/cover.jpg',
       }
     })
 
@@ -518,6 +520,8 @@ describe('reconcileCaptureEnrichment', () => {
     expect(files.get(IDENTITY.notePath)).toContain('captureStatus: skipped')
     expect(describeMock).not.toHaveBeenCalled()
     expect(readAssetMock).not.toHaveBeenCalled()
+    // Even the preview-image fetch stays behind the privacy gate.
+    expect(imageFetchMock).not.toHaveBeenCalled()
   })
 
   it('does not send capture content to AI when the day becomes private while loading its screenshot', async () => {

--- a/packages/core/src/actions/capture-enrichment.test.ts
+++ b/packages/core/src/actions/capture-enrichment.test.ts
@@ -11,6 +11,7 @@ import {
   files,
   getSecretMock,
   IDENTITY,
+  imageFetchMock,
   NO_PROVIDERS,
   readAssetMock,
   reconcile,
@@ -24,6 +25,7 @@ import type { CaptureEnvelope } from './capture-envelope'
 const ensureBacklinkTargetMock = vi.hoisted(() => vi.fn())
 
 vi.mock('../graph/commands', () => ({
+  captureImageFetch: vi.fn(),
   captureInboxList: vi.fn(),
   captureInboxRead: vi.fn(),
   captureInboxReject: vi.fn(),
@@ -79,6 +81,7 @@ describe('reconcileCaptureEnrichment', () => {
       title: 'An article',
       description: 'A scraped description.',
       siteName: 'Example',
+      image: null,
     })
 
     const outcome = await reconcile()
@@ -125,6 +128,7 @@ describe('reconcileCaptureEnrichment', () => {
       title: 'An article',
       description: 'A shorter scraped description.',
       siteName: null,
+      image: null,
     })
 
     const outcome = await reconcile({ providers: NO_PROVIDERS })
@@ -142,6 +146,7 @@ describe('reconcileCaptureEnrichment', () => {
       title: 'An article',
       description: 'A scraped description.',
       siteName: null,
+      image: null,
     })
 
     const outcome = await reconcile({ providers: NO_PROVIDERS })
@@ -166,6 +171,7 @@ describe('reconcileCaptureEnrichment', () => {
       title: 'An article from its metadata',
       description: 'A scraped description.',
       siteName: 'Example',
+      image: null,
     })
 
     const outcome = await reconcile({ providers: NO_PROVIDERS })
@@ -192,6 +198,7 @@ describe('reconcileCaptureEnrichment', () => {
       title: `${'lengthy '.repeat(20)}tail`,
       description: 'A scraped description.',
       siteName: 'Instagram',
+      image: null,
     })
 
     const outcome = await reconcile({ providers: NO_PROVIDERS })
@@ -205,12 +212,97 @@ describe('reconcileCaptureEnrichment', () => {
     expect(files.get(DAILY)).toContain(`|${heading!.slice('# '.length)}]]`)
   })
 
+  it('fetches the page preview image as the capture screenshot', async () => {
+    addSpool(envelope({ source: 'ios-share', title: '' }), { screenshot: false })
+    expect((await drain()).stopped).toBeNull()
+    writeNoteMock.mockClear()
+    scrapeMock.mockResolvedValue({
+      title: 'An article from its metadata',
+      description: 'A scraped description.',
+      siteName: null,
+      image: 'https://cdn.example.com/cover.jpg',
+    })
+
+    const outcome = await reconcile({ providers: NO_PROVIDERS })
+
+    expect(outcome).toEqual({ pending: 1, enriched: 1, skipped: 0, stopped: null })
+    expect(imageFetchMock).toHaveBeenCalledWith(
+      'https://cdn.example.com/cover.jpg',
+      IDENTITY.assetPath,
+      1600,
+      3,
+    )
+    const note = files.get(IDENTITY.notePath) ?? ''
+    expect(note).toContain(`captureScreenshot: ${IDENTITY.assetPath}`)
+    expect(note).toContain(`## Screenshot\n\n![An article from its metadata](${IDENTITY.assetPath})`)
+    expect(note).toContain('captureStatus: done')
+  })
+
+  it('feeds the fetched preview image to the AI call', async () => {
+    addSpool(envelope({ source: 'ios-share', title: '' }), { screenshot: false })
+    expect((await drain()).stopped).toBeNull()
+    writeNoteMock.mockClear()
+    scrapeMock.mockResolvedValue({
+      title: 'An article from its metadata',
+      description: 'A scraped description.',
+      siteName: null,
+      image: 'https://cdn.example.com/cover.jpg',
+    })
+
+    const outcome = await reconcile()
+
+    expect(outcome.enriched).toBe(1)
+    expect(describeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ screenshotBase64: btoa('jpeg-bytes') }),
+    )
+    expect(readAssetMock).toHaveBeenCalledWith(IDENTITY.assetPath, 3)
+  })
+
+  it('a preview image failure never blocks enrichment', async () => {
+    addSpool(envelope({ source: 'ios-share', title: '' }), { screenshot: false })
+    expect((await drain()).stopped).toBeNull()
+    writeNoteMock.mockClear()
+    scrapeMock.mockResolvedValue({
+      title: 'An article from its metadata',
+      description: 'A scraped description.',
+      siteName: null,
+      image: 'https://cdn.example.com/cover.jpg',
+    })
+    imageFetchMock.mockRejectedValue(new ReflectError('io', 'cover.jpg answered 404 Not Found'))
+
+    const outcome = await reconcile({ providers: NO_PROVIDERS })
+
+    expect(outcome).toEqual({ pending: 1, enriched: 1, skipped: 0, stopped: null })
+    const note = files.get(IDENTITY.notePath) ?? ''
+    expect(note).not.toContain('## Screenshot')
+    expect(note).not.toContain('captureScreenshot')
+    expect(note).toContain('- Description: A scraped description.')
+    expect(note).toContain('captureStatus: done')
+  })
+
+  it('never fetches a preview image over an extension screenshot', async () => {
+    await drainOne()
+    scrapeMock.mockResolvedValue({
+      title: 'An article',
+      description: 'A scraped description.',
+      siteName: null,
+      image: 'https://cdn.example.com/cover.jpg',
+    })
+
+    const outcome = await reconcile()
+
+    expect(outcome.enriched).toBe(1)
+    expect(imageFetchMock).not.toHaveBeenCalled()
+    expect(files.get(IDENTITY.notePath)).toContain(`captureScreenshot: ${IDENTITY.assetPath}`)
+  })
+
   it('keeps a supplied capture title when scraped metadata differs', async () => {
     await drainOne({ source: 'ios-share', title: 'The title supplied by the app' })
     scrapeMock.mockResolvedValue({
       title: 'A different metadata title',
       description: 'A scraped description.',
       siteName: 'Example',
+      image: null,
     })
 
     const outcome = await reconcile({ providers: NO_PROVIDERS })
@@ -227,6 +319,7 @@ describe('reconcileCaptureEnrichment', () => {
       title: 'A title available immediately',
       description: 'A description available immediately.',
       siteName: null,
+      image: null,
     })
     let finishProvider: (() => void) | undefined
     describeMock.mockImplementation(
@@ -276,6 +369,7 @@ describe('reconcileCaptureEnrichment', () => {
       title: 'First Chair on Instagram',
       description: 'An Instagram reel about furniture and decor.',
       siteName: 'Instagram',
+      image: null,
     })
     getSecretMock.mockResolvedValue(null)
 
@@ -328,6 +422,7 @@ describe('reconcileCaptureEnrichment', () => {
       title: 'A title available without the keychain',
       description: 'A description available without the keychain.',
       siteName: null,
+      image: null,
     })
     getSecretMock.mockRejectedValue(new ReflectError('io', 'keychain is unavailable'))
 
@@ -391,6 +486,7 @@ describe('reconcileCaptureEnrichment', () => {
         title: 'A scraped title',
         description: 'A scraped description.',
         siteName: null,
+        image: null,
       }
     })
 
@@ -412,6 +508,7 @@ describe('reconcileCaptureEnrichment', () => {
         title: 'An article',
         description: 'A scraped description.',
         siteName: null,
+        image: null,
       }
     })
 
@@ -446,6 +543,7 @@ describe('reconcileCaptureEnrichment', () => {
         title: 'An article',
         description: 'A scraped description.',
         siteName: null,
+        image: null,
       }
     })
 
@@ -486,7 +584,7 @@ describe('reconcileCaptureEnrichment', () => {
       if (url.includes('instagram')) {
         throw new ReflectError('network', 'https://www.instagram.com answered 429')
       }
-      return { title: 'An article', description: 'A scraped description.', siteName: null }
+      return { title: 'An article', description: 'A scraped description.', siteName: null, image: null }
     })
 
     const outcome = await reconcile({ providers: NO_PROVIDERS })
@@ -505,6 +603,7 @@ describe('reconcileCaptureEnrichment', () => {
       title: 'First Chair on Instagram',
       description: 'An Instagram reel about furniture and decor.',
       siteName: 'Instagram',
+      image: null,
     })
     const retry = await reconcile({ providers: NO_PROVIDERS })
 
@@ -529,7 +628,7 @@ describe('reconcileCaptureEnrichment', () => {
       if (url.includes('instagram')) {
         throw new ReflectError('network', 'https://www.instagram.com answered 429')
       }
-      return { title: 'An article', description: 'A scraped description.', siteName: null }
+      return { title: 'An article', description: 'A scraped description.', siteName: null, image: null }
     })
     getSecretMock.mockRejectedValue(new ReflectError('io', 'keychain is unavailable'))
 
@@ -603,6 +702,7 @@ describe('reconcileCaptureEnrichment', () => {
       title: 'A title from metadata',
       description: 'A scraped description.',
       siteName: null,
+      image: null,
     })
     describeMock.mockRejectedValue(new DescriptionRejectedError('image too large'))
 
@@ -619,7 +719,7 @@ describe('reconcileCaptureEnrichment', () => {
 
   it('a provider refusal without scraped description does not stamp AI provenance', async () => {
     await drainOne()
-    scrapeMock.mockResolvedValue({ title: 'An article', description: null, siteName: null })
+    scrapeMock.mockResolvedValue({ title: 'An article', description: null, siteName: null, image: null })
     describeMock.mockRejectedValue(new DescriptionRejectedError('image too large'))
 
     const outcome = await reconcile()
@@ -634,7 +734,7 @@ describe('reconcileCaptureEnrichment', () => {
 
   it('omits the description bullet when no description source exists', async () => {
     await drainOne()
-    scrapeMock.mockResolvedValue({ title: 'An article', description: null, siteName: null })
+    scrapeMock.mockResolvedValue({ title: 'An article', description: null, siteName: null, image: null })
 
     const outcome = await reconcile({ providers: NO_PROVIDERS })
 
@@ -650,6 +750,7 @@ describe('reconcileCaptureEnrichment', () => {
       title: 'A title available without AI',
       description: 'A description available without AI.',
       siteName: null,
+      image: null,
     })
     describeMock.mockRejectedValue(new ReflectError('auth', 'key rejected'))
 
@@ -747,6 +848,7 @@ describe('reconcileCaptureEnrichment', () => {
       title: 'A title from metadata',
       description: 'A scraped description.',
       siteName: null,
+      image: null,
     })
     writeNoteMock
       .mockImplementationOnce(async (path, contents) => {
@@ -767,6 +869,7 @@ describe('reconcileCaptureEnrichment', () => {
       title: 'A different title on retry',
       description: 'A different description on retry.',
       siteName: null,
+      image: null,
     })
 
     const retry = await reconcile({ providers: NO_PROVIDERS })
@@ -787,6 +890,7 @@ describe('reconcileCaptureEnrichment', () => {
       title: 'A title from metadata',
       description: 'A scraped description.',
       siteName: null,
+      image: null,
     })
     writeNoteMock
       .mockImplementationOnce(async (path, contents) => {
@@ -846,6 +950,7 @@ describe('reconcileCaptureEnrichment', () => {
       title: 'A title from metadata',
       description: 'A scraped description.',
       siteName: null,
+      image: null,
     })
     writeNoteMock
       .mockImplementationOnce(async (path, contents) => {
@@ -875,6 +980,7 @@ describe('reconcileCaptureEnrichment', () => {
       title: 'A scraped title',
       description: 'A scraped description.',
       siteName: null,
+      image: null,
     })
     describeMock.mockImplementation(async () => {
       const staged = files.get(IDENTITY.notePath) ?? ''
@@ -913,6 +1019,7 @@ describe('reconcileCaptureEnrichment', () => {
       title: 'An article',
       description: 'A scraped description.',
       siteName: null,
+      image: null,
     })
     describeMock.mockResolvedValue({ title: 'A Cleaned Up Article', description: '' })
 

--- a/packages/core/src/actions/capture-enrichment.ts
+++ b/packages/core/src/actions/capture-enrichment.ts
@@ -7,7 +7,7 @@ import {
 import { defaultAiProvider, type AiProvidersState } from '../ai/provider-config'
 import { aiKeySecretName } from '../ai/secrets'
 import { errorMessage, isAppError, toAppError } from '../errors'
-import { listFiles, readAsset, readNote, writeNote } from '../graph/commands'
+import { listFiles, readNote, writeNote } from '../graph/commands'
 import { dailyPath } from '../graph/paths'
 import { hashContent } from '../indexing/hash'
 import { parseFrontmatter, splitFrontmatter, upsertFrontmatter } from '../markdown/frontmatter'
@@ -32,9 +32,11 @@ import {
   notePrivate,
   noteSource,
   withDescription,
+  withScreenshot,
   withTitle,
   type CaptureNoteMeta,
 } from './capture-note'
+import { fetchPreviewScreenshot, readCaptureScreenshot } from './capture-screenshot'
 import { scrapePageMeta, type PageMeta } from './meta-scrape'
 
 /**
@@ -128,23 +130,6 @@ async function generateEnrichment(input: GenerateEnrichmentInput): Promise<PageE
       throw cause
     }
     return null
-  }
-}
-
-async function readCaptureScreenshot(
-  meta: CaptureNoteMeta,
-  generation: number,
-): Promise<string | undefined> {
-  if (!meta.captureScreenshot) {
-    return undefined
-  }
-  try {
-    return await readAsset(meta.captureScreenshot, generation)
-  } catch (cause) {
-    if (!isAppError(cause) || cause.kind !== 'notFound') {
-      throw cause
-    }
-    return undefined
   }
 }
 
@@ -300,6 +285,7 @@ export async function reconcileCaptureEnrichment(
           title: snapshot.title,
           description: captureDescriptionFromBody(snapshot.body) ?? null,
           siteName: null,
+          image: null,
         }
       } else {
         try {
@@ -315,6 +301,9 @@ export async function reconcileCaptureEnrichment(
           pageMeta = null
         }
       }
+      const fetchedScreenshot = metadataComplete
+        ? null
+        : await fetchPreviewScreenshot(pageMeta, snapshot.meta, identity, input.generation)
       if (stale()) {
         return outcome({ reason: 'stale', message: 'the graph session ended mid-pass' })
       }
@@ -339,6 +328,9 @@ export async function reconcileCaptureEnrichment(
       if (metadataTitle !== null) {
         metadataBody = withTitle(metadataBody, metadataTitle)
       }
+      if (fetchedScreenshot !== null) {
+        metadataBody = withScreenshot(metadataBody, metadataDisplayTitle, fetchedScreenshot)
+      }
 
       if (config === null) {
         const titleChanged = metadataDisplayTitle !== snapshot.title
@@ -355,6 +347,7 @@ export async function reconcileCaptureEnrichment(
           status: titleChanged ? 'pending' : 'done',
           provider: null,
           generation: input.generation,
+          screenshot: fetchedScreenshot ?? undefined,
         })
         if (captureHash === null) {
           await skipPending(identity)
@@ -391,6 +384,7 @@ export async function reconcileCaptureEnrichment(
           status: 'pending',
           provider: null,
           generation: input.generation,
+          screenshot: fetchedScreenshot ?? undefined,
         })
         if (persistedHash === null) {
           await skipPending(identity)

--- a/packages/core/src/actions/capture-enrichment.ts
+++ b/packages/core/src/actions/capture-enrichment.ts
@@ -301,9 +301,6 @@ export async function reconcileCaptureEnrichment(
           pageMeta = null
         }
       }
-      const fetchedScreenshot = metadataComplete
-        ? null
-        : await fetchPreviewScreenshot(pageMeta, snapshot.meta, identity, input.generation)
       if (stale()) {
         return outcome({ reason: 'stale', message: 'the graph session ended mid-pass' })
       }
@@ -312,6 +309,11 @@ export async function reconcileCaptureEnrichment(
       if (snapshot === null) {
         continue
       }
+      // After the privacy/edit re-check on purpose: a capture made private
+      // while the scrape ran must not trigger even this outbound fetch.
+      const fetchedScreenshot = metadataComplete
+        ? null
+        : await fetchPreviewScreenshot(pageMeta, snapshot.meta, identity, input.generation)
       const placeholderTitle = displayTitle({ title: '', url: snapshot.meta.captureUrl })
       const metadataTitle =
         snapshot.title === placeholderTitle && pageMeta?.title

--- a/packages/core/src/actions/capture-harness.ts
+++ b/packages/core/src/actions/capture-harness.ts
@@ -2,6 +2,7 @@ import { vi } from 'vitest'
 import { describePage } from '../ai/describe-page'
 import type { AiProvidersState } from '../ai/provider-config'
 import {
+  captureImageFetch,
   captureInboxList,
   captureInboxRead,
   captureInboxReject,
@@ -41,6 +42,7 @@ export const inboxRejectMock = vi.mocked(captureInboxReject)
 export const inboxRemoveMock = vi.mocked(captureInboxRemove)
 export const listFilesMock = vi.mocked(listFiles)
 export const promoteMock = vi.mocked(promoteCaptureScreenshot)
+export const imageFetchMock = vi.mocked(captureImageFetch)
 export const readAssetMock = vi.mocked(readAsset)
 export const readNoteMock = vi.mocked(readNote)
 export const writeNoteMock = vi.mocked(writeNote)
@@ -151,7 +153,13 @@ export function wireCaptureMocks(): void {
     [...files.keys()].map((path) => ({ path, size: 1, modifiedMs: 0 })),
   )
   readAssetMock.mockResolvedValue(btoa('jpeg-bytes'))
+  imageFetchMock.mockResolvedValue(undefined)
   getSecretMock.mockResolvedValue('sk-live-key')
-  scrapeMock.mockResolvedValue({ title: 'An article', description: null, siteName: null })
+  scrapeMock.mockResolvedValue({
+    title: 'An article',
+    description: null,
+    siteName: null,
+    image: null,
+  })
   describeMock.mockResolvedValue({ title: null, description: 'An AI description of the page.' })
 }

--- a/packages/core/src/actions/capture-note.ts
+++ b/packages/core/src/actions/capture-note.ts
@@ -203,6 +203,16 @@ export function withTitle(body: string, title: string): string {
 }
 
 /**
+ * Append the screenshot section for a fetched preview image — the exact
+ * shape the drain writes for spooled screenshots, so {@link withTitle} keeps
+ * the alt text in sync on later retitles. The caller has verified the
+ * capture carries no screenshot yet.
+ */
+export function withScreenshot(body: string, title: string, assetPath: string): string {
+  return `${body.trimEnd()}\n\n## Screenshot\n\n![${title}](${assetPath})\n`
+}
+
+/**
  * Rewrite a daily entry's wiki-link display text after its capture note was
  * retitled. Both writers (the drain's dedup refresh and the enrichment
  * retitle) keep the invariant "daily link text mirrors the note's H1", so the

--- a/packages/core/src/actions/capture-screenshot.ts
+++ b/packages/core/src/actions/capture-screenshot.ts
@@ -1,0 +1,54 @@
+import { isAppError } from '../errors'
+import { captureImageFetch, readAsset } from '../graph/commands'
+import { SCREENSHOT_MAX_DIM } from './capture-drain'
+import type { CaptureIdentity } from './capture-identity'
+import type { CaptureNoteMeta } from './capture-note'
+import type { PageMeta } from './meta-scrape'
+
+/**
+ * The capture's screenshot pixels for the AI call, base64 — `undefined` when
+ * the capture has none or the asset vanished (a race with a user delete is
+ * not an enrichment failure).
+ */
+export async function readCaptureScreenshot(
+  meta: CaptureNoteMeta,
+  generation: number,
+): Promise<string | undefined> {
+  if (!meta.captureScreenshot) {
+    return undefined
+  }
+  try {
+    return await readAsset(meta.captureScreenshot, generation)
+  } catch (cause) {
+    if (!isAppError(cause) || cause.kind !== 'notFound') {
+      throw cause
+    }
+    return undefined
+  }
+}
+
+/**
+ * Fetch the page's own preview image (its scraped `og:image`) into the graph
+ * as the capture's screenshot asset — the stand-in pixels for shares that
+ * carry none of their own (the iOS share sheet, unlike the Chrome extension,
+ * cannot screenshot the host app). Returns the asset path to stamp, or
+ * `null` when the capture already has a screenshot, the scrape produced no
+ * image, or the fetch failed — bonus context only, never a blocker, and the
+ * lossy metadata checkpoint deliberately does not retry it.
+ */
+export async function fetchPreviewScreenshot(
+  pageMeta: PageMeta | null,
+  meta: CaptureNoteMeta,
+  identity: CaptureIdentity,
+  generation: number,
+): Promise<string | null> {
+  if (meta.captureScreenshot !== undefined || !pageMeta?.image) {
+    return null
+  }
+  try {
+    await captureImageFetch(pageMeta.image, identity.assetPath, SCREENSHOT_MAX_DIM, generation)
+    return identity.assetPath
+  } catch {
+    return null
+  }
+}

--- a/packages/core/src/actions/meta-scrape.test.ts
+++ b/packages/core/src/actions/meta-scrape.test.ts
@@ -95,6 +95,17 @@ describe('parsePageMeta', () => {
     expect(meta.image).toBe(`https://example.com${longPath}`)
   })
 
+  it('falls back to twitter:image when og:image is blank or invalid', () => {
+    const meta = parsePageMeta(
+      `<html><head>
+        <meta property="og:image" content="   ">
+        <meta name="twitter:image" content="https://example.com/card.png">
+      </head></html>`,
+      BASE_URL,
+    )
+    expect(meta.image).toBe('https://example.com/card.png')
+  })
+
   it('falls back to twitter:image when og:image is absent', () => {
     const meta = parsePageMeta(
       '<html><head><meta name="twitter:image" content="https://example.com/card.png"></head></html>',

--- a/packages/core/src/actions/meta-scrape.test.ts
+++ b/packages/core/src/actions/meta-scrape.test.ts
@@ -2,9 +2,12 @@
 import { describe, expect, it } from 'vitest'
 import { parsePageMeta } from './meta-scrape'
 
+const BASE_URL = 'https://example.com/article'
+
 describe('parsePageMeta', () => {
   it('prefers OpenGraph tags over the document fallbacks', () => {
-    const meta = parsePageMeta(`
+    const meta = parsePageMeta(
+      `
       <html><head>
         <title>Doc title</title>
         <meta name="description" content="Plain description">
@@ -12,60 +15,99 @@ describe('parsePageMeta', () => {
         <meta property="og:description" content="OG description">
         <meta property="og:site_name" content="Example">
       </head><body></body></html>
-    `)
+    `,
+      BASE_URL,
+    )
     expect(meta).toEqual({
       title: 'OG title',
       description: 'OG description',
       siteName: 'Example',
+      image: null,
     })
   })
 
   it('parses the OpenGraph shape returned for an Instagram reel', () => {
-    const meta = parsePageMeta(`
+    const meta = parsePageMeta(
+      `
       <html><head>
         <meta property="og:title" content="First Chair on Instagram: &quot;A walnut lounge chair&quot;">
         <meta property="og:description" content="Furniture &amp; decor from an independent studio.">
         <meta property="og:site_name" content="Instagram">
+        <meta property="og:image" content="https://scontent.cdninstagram.com/v/cover.jpg?stp=dst-jpg_e35">
       </head><body></body></html>
-    `)
+    `,
+      'https://www.instagram.com/reel/example/',
+    )
 
     expect(meta).toEqual({
       title: 'First Chair on Instagram: "A walnut lounge chair"',
       description: 'Furniture & decor from an independent studio.',
       siteName: 'Instagram',
+      image: 'https://scontent.cdninstagram.com/v/cover.jpg?stp=dst-jpg_e35',
     })
   })
 
   it('falls back to <title> and the meta description', () => {
     const meta = parsePageMeta(
       '<html><head><title>Doc title</title><meta name="description" content="Plain"></head></html>',
+      BASE_URL,
     )
-    expect(meta).toEqual({ title: 'Doc title', description: 'Plain', siteName: null })
+    expect(meta).toEqual({ title: 'Doc title', description: 'Plain', siteName: null, image: null })
   })
 
   it('reads a page with no metadata as all nulls', () => {
-    expect(parsePageMeta('<p>hello</p>')).toEqual({
+    expect(parsePageMeta('<p>hello</p>', BASE_URL)).toEqual({
       title: null,
       description: null,
       siteName: null,
+      image: null,
     })
   })
 
   it('collapses whitespace and treats blank values as absent', () => {
-    const meta = parsePageMeta(`
+    const meta = parsePageMeta(
+      `
       <html><head>
         <title>  A
         wrapped   title </title>
         <meta name="description" content="   ">
       </head></html>
-    `)
-    expect(meta).toEqual({ title: 'A wrapped title', description: null, siteName: null })
+    `,
+      BASE_URL,
+    )
+    expect(meta).toEqual({ title: 'A wrapped title', description: null, siteName: null, image: null })
   })
 
   it('caps runaway values', () => {
     const meta = parsePageMeta(
       `<html><head><meta name="description" content="${'x'.repeat(2000)}"></head></html>`,
+      BASE_URL,
     )
     expect(meta.description).toHaveLength(500)
+  })
+
+  it('resolves a relative preview image against the page URL, uncapped', () => {
+    const longPath = `/covers/${'a'.repeat(600)}.jpg`
+    const meta = parsePageMeta(
+      `<html><head><meta property="og:image" content="${longPath}"></head></html>`,
+      BASE_URL,
+    )
+    expect(meta.image).toBe(`https://example.com${longPath}`)
+  })
+
+  it('falls back to twitter:image when og:image is absent', () => {
+    const meta = parsePageMeta(
+      '<html><head><meta name="twitter:image" content="https://example.com/card.png"></head></html>',
+      BASE_URL,
+    )
+    expect(meta.image).toBe('https://example.com/card.png')
+  })
+
+  it('refuses non-http(s) preview images', () => {
+    const meta = parsePageMeta(
+      '<html><head><meta property="og:image" content="data:image/png;base64,aGk="></head></html>',
+      BASE_URL,
+    )
+    expect(meta.image).toBeNull()
   })
 })

--- a/packages/core/src/actions/meta-scrape.ts
+++ b/packages/core/src/actions/meta-scrape.ts
@@ -72,11 +72,15 @@ export function parsePageMeta(html: string, baseUrl: string): PageMeta {
       metaContent(document, 'meta[property="og:description"]') ??
       metaContent(document, 'meta[name="description"]'),
     siteName: metaContent(document, 'meta[property="og:site_name"]'),
-    image: imageUrl(
-      document.querySelector('meta[property="og:image"]')?.getAttribute('content') ??
+    image:
+      imageUrl(
+        document.querySelector('meta[property="og:image"]')?.getAttribute('content'),
+        baseUrl,
+      ) ??
+      imageUrl(
         document.querySelector('meta[name="twitter:image"]')?.getAttribute('content'),
-      baseUrl,
-    ),
+        baseUrl,
+      ),
   }
 }
 

--- a/packages/core/src/actions/meta-scrape.ts
+++ b/packages/core/src/actions/meta-scrape.ts
@@ -90,5 +90,8 @@ export function parsePageMeta(html: string, baseUrl: string): PageMeta {
  * retry, `io`/`parse` for permanent ones it should write through without).
  */
 export async function scrapePageMeta(url: string): Promise<PageMeta> {
-  return parsePageMeta(await captureMetaFetch(url), url)
+  const fetched = await captureMetaFetch(url)
+  // Redirects were followed server-side: relative references in the HTML
+  // belong to the URL that served it, not the one the capture started from.
+  return parsePageMeta(fetched.html, fetched.finalUrl)
 }

--- a/packages/core/src/actions/meta-scrape.ts
+++ b/packages/core/src/actions/meta-scrape.ts
@@ -15,6 +15,12 @@ export interface PageMeta {
   description: string | null
   /** `og:site_name`. */
   siteName: string | null
+  /**
+   * The page's preview image (`og:image`, falling back to `twitter:image`),
+   * resolved to an absolute http(s) URL — the capture's screenshot stand-in
+   * for shares that carry no pixels of their own.
+   */
+  image: string | null
 }
 
 /** Caps how much of a meta value survives — these render inline in notes. */
@@ -32,8 +38,31 @@ function metaContent(document: Document, selector: string): string | null {
   return clean(document.querySelector(selector)?.getAttribute('content'))
 }
 
-/** Extract {@link PageMeta} from an HTML document's text. Never throws. */
-export function parsePageMeta(html: string): PageMeta {
+/**
+ * Resolve a scraped image reference to an absolute http(s) URL, or `null`
+ * when it is not one (a data: URI, a protocol we would refuse to fetch, an
+ * unparseable value). URLs are never truncated — a clipped URL is broken.
+ */
+function imageUrl(value: string | null | undefined, baseUrl: string): string | null {
+  const trimmed = value?.trim() ?? ''
+  if (trimmed === '') {
+    return null
+  }
+  try {
+    const resolved = new URL(trimmed, baseUrl)
+    return resolved.protocol === 'https:' || resolved.protocol === 'http:'
+      ? resolved.toString()
+      : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Extract {@link PageMeta} from an HTML document's text; `baseUrl` resolves
+ * relative image references. Never throws.
+ */
+export function parsePageMeta(html: string, baseUrl: string): PageMeta {
   const document = new DOMParser().parseFromString(html, 'text/html')
   return {
     title:
@@ -43,6 +72,11 @@ export function parsePageMeta(html: string): PageMeta {
       metaContent(document, 'meta[property="og:description"]') ??
       metaContent(document, 'meta[name="description"]'),
     siteName: metaContent(document, 'meta[property="og:site_name"]'),
+    image: imageUrl(
+      document.querySelector('meta[property="og:image"]')?.getAttribute('content') ??
+        document.querySelector('meta[name="twitter:image"]')?.getAttribute('content'),
+      baseUrl,
+    ),
   }
 }
 
@@ -52,5 +86,5 @@ export function parsePageMeta(html: string): PageMeta {
  * retry, `io`/`parse` for permanent ones it should write through without).
  */
 export async function scrapePageMeta(url: string): Promise<PageMeta> {
-  return parsePageMeta(await captureMetaFetch(url))
+  return parsePageMeta(await captureMetaFetch(url), url)
 }

--- a/packages/core/src/graph/commands.ts
+++ b/packages/core/src/graph/commands.ts
@@ -310,6 +310,21 @@ export async function captureMetaFetch(url: string): Promise<string> {
   return call('capture_meta_fetch', { url }, z.string())
 }
 
+/**
+ * Fetch a captured page's own preview image (its `og:image`) into the graph
+ * as the capture's screenshot asset. Same bounded fetch rules as
+ * {@link captureMetaFetch} — image content only, downscaled and re-encoded on
+ * the Rust side before it touches the graph.
+ */
+export async function captureImageFetch(
+  url: string,
+  assetPath: string,
+  maxDim: number,
+  generation: number,
+): Promise<void> {
+  await call('capture_image_fetch', { url, assetPath, maxDim, generation }, voidSchema)
+}
+
 /** The recently-opened graphs, newest first. */
 export async function recentGraphs(): Promise<RecentGraph[]> {
   return call('recent_graphs', {}, z.array(recentGraphSchema))

--- a/packages/core/src/graph/commands.ts
+++ b/packages/core/src/graph/commands.ts
@@ -301,13 +301,25 @@ export async function promoteCaptureScreenshot(
   await call('capture_screenshot_promote', { spoolName, assetPath, maxDim, generation }, voidSchema)
 }
 
+const metaFetchResponseSchema = z.object({
+  html: z.string(),
+  /**
+   * The URL that actually served the HTML after redirects — relative
+   * references in the page (an `og:image` path) resolve against this, not
+   * the URL the capture started from.
+   */
+  finalUrl: z.string(),
+})
+
+export type MetaFetchResponse = z.infer<typeof metaFetchResponseSchema>
+
 /**
  * Fetch a captured page's HTML for meta-tag scraping — the Rust side caps
  * scheme/timeout/size/redirects, so arbitrary capture URLs never widen the
  * webview's own HTTP capability. The privacy gate runs before any call here.
  */
-export async function captureMetaFetch(url: string): Promise<string> {
-  return call('capture_meta_fetch', { url }, z.string())
+export async function captureMetaFetch(url: string): Promise<MetaFetchResponse> {
+  return call('capture_meta_fetch', { url }, metaFetchResponseSchema)
 }
 
 /**


### PR DESCRIPTION
## Problem

Links shared through the iOS share sheet arrive with no pixels: extensions cannot screenshot the host app (there is no `captureVisibleTab` equivalent on iOS), so mobile captures miss both the visual context in the note and the multimodal half of the BYOK description call that Chrome-extension captures get. For the motivating Instagram case, the page's own `og:image` *is* the reel's cover frame — a plain, publicly fetchable JPEG.

## Changes

- **`meta-scrape.ts`**: `PageMeta` gains `image` — `og:image` with a `twitter:image` fallback, resolved against the page URL to an absolute http(s) URL (relative refs resolve; `data:`/other schemes refuse; URLs are never length-capped — a clipped URL is broken).
- **`capture.rs`**: new `capture_image_fetch` primitive — same bounded shape as the meta fetch (http(s) only, 15s timeout, 5 redirects, browser presentation with image-flavored `Accept`/`Sec-Fetch-*` headers) plus image-only content-type, an 8MB raw-byte cap (a truncated image is useless, so oversized fails instead of clipping), and the existing screenshot downscale/re-encode before the bytes touch the graph. The atomic asset write is factored into `persist_asset`, shared with `capture_screenshot_promote`.
- **`capture-screenshot.ts`** (new): `fetchPreviewScreenshot` — fetches the preview image as the capture's screenshot asset when the capture has none of its own; any failure returns `null` (bonus context, never a blocker, deliberately not retried by the lossy metadata checkpoint). `readCaptureScreenshot` moves here from `capture-enrichment.ts`.
- **`capture-enrichment.ts`**: the metadata leg stamps the fetched asset as `captureScreenshot` and appends the same `## Screenshot` section the drain writes for extension screenshots (`withScreenshot`, alt text tracked by `withTitle` on later retitles). The AI leg then picks it up through the existing `screenshotBase64` path — no `describePage` changes needed.
- `persistCaptureEnrichment` accepts an optional `screenshot` stamp; omitted leaves existing stamps untouched (an `undefined` in the frontmatter patch would delete them).
- Captures that already carry an extension screenshot never fetch a preview image.
- **Hardening (review follow-ups)**: the image URL is page-controlled, so redirects are followed manually (≤5 hops) with each hop's host resolved and required to be entirely public-address space (loopback, RFC1918, link-local/metadata, CGNAT, v6 ULA/link-local, v4-mapped all refused) and the connection pinned to the vetted address (no rebinding window); the graph generation is re-checked after the slow fetch before the asset persists; the fetch runs only after the post-scrape privacy/edit re-check; a blank `og:image` no longer masks a valid `twitter:image`.

## Testing

- New unit coverage: `parsePageMeta` image extraction (absolute/relative/twitter-fallback/non-http refusal, uncapped URLs); enrichment fetches + stamps + sections the preview image, feeds it to the AI call, survives image-fetch failure, and skips when an extension screenshot exists; Rust `image_content_type` gate. 264 `packages/core` action/AI tests pass; `cargo test -p reflect-open capture::` — 18 pass; typecheck + lint clean (no new max-lines warning — the screenshot helpers moved to their own module).
- **Integration tests against a local server** (fb343c8a): the preview fetch's network core is now a stateless `fetch_preview_image` with a test-only `HostPolicy::AllowLocal`, driven by a loopback HTTP server — relative-redirect chains, the five-hop limit, missing `Location`, non-image content, the 8MB cap, the meta fetch's 512KB truncation/HTML-only gate, plus the SSRF regression test that the production policy refuses local hosts before a byte is sent. `cargo test -p reflect-open capture::` — 27 pass.
- **Simulator-verified end-to-end**: injected a real share envelope for an Instagram reel into the dev App Group inbox; the foreground pass scraped, fetched the reel's `og:image` (re-encoded to a 360×640 JPEG asset), and produced a `done` note with title, description, `captureScreenshot` frontmatter, and the cover image rendering in the app's note view.

## Risk / rollout

- The image fetch adds one bounded request per new link capture (only when the scrape yields an image and the capture has no screenshot). Failures are swallowed by design; nothing new blocks or retries.
- Desktop URL-only captures (deep links) gain the same behavior; extension captures are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds attacker-controlled outbound HTTP with deliberate SSRF mitigations and non-blocking failure paths; touches capture enrichment and native graph writes, but extension screenshots and privacy gates limit blast radius.
> 
> **Overview**
> **Link captures without their own screenshot** (e.g. iOS share) can now get a cover image from scraped `og:image` / `twitter:image`, stored like extension screenshots and used for AI description.
> 
> **Rust (`capture.rs`)** adds `capture_image_fetch` with SSRF-style guards: public-only DNS per redirect hop, connection pinning, image content-type and 8MB cap, JPEG downscale, and graph generation re-checked after the fetch. Asset writes are shared via new `persist_asset`. **`capture_meta_fetch`** now returns `{ html, finalUrl }` so relative image URLs resolve after redirects.
> 
> **Core** extends meta scrape with `PageMeta.image`, wires `fetchPreviewScreenshot` in enrichment (non-blocking on failure; skipped if a screenshot already exists or privacy blocks outbound fetch), and stamps `captureScreenshot` plus a `## Screenshot` section through `persistCaptureEnrichment`.
> 
> **Tests & docs**: Rust loopback integration tests for redirects/limits/SSRF; enrichment and `parsePageMeta` unit tests; iOS simulator doc for manual share-inbox injection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 546a353a08aca9022fcb0aa54cea732c5c01b00d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically fetches preview images from a page’s Open Graph/Twitter metadata and saves them as downscaled JPEG screenshots when no screenshot exists.
  * Enriched capture notes now include a **Screenshot** section, using the preview image to improve AI descriptions.
* **Bug Fixes**
  * Preview-image fetching is safely constrained (size/type and safe network/address checks), follows redirects, and stays non-blocking on failure.
  * Existing screenshots always take precedence.
* **Tests**
  * Added coverage for URL resolution, redirect behavior/limits, validation rejections, byte caps, and screenshot enrichment integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

