### PR TITLE
feat(mobile): add AI provider consent block

### DIFF
--- a/apps/desktop/src/mobile/add-ai-provider-drawer.test.tsx
+++ b/apps/desktop/src/mobile/add-ai-provider-drawer.test.tsx
@@ -18,6 +18,7 @@ vi.mock('@reflect/core', async (importOriginal) => ({
   validateApiKey,
 }))
 vi.mock('@/lib/provider-fetch', () => ({ providerFetch: vi.fn() }))
+vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn(() => Promise.resolve()) }))
 
 // vaul needs browser APIs jsdom doesn't provide; passthrough so the sheet
 // content renders inline.
@@ -48,8 +49,13 @@ function renderSheet() {
   render(<AddAiProviderDrawer open onOpenChange={onOpenChange} onAdd={onAdd} />)
 }
 
+function consentCheckbox() {
+  return screen.getByRole('checkbox', { name: /I understand this data will be sent/ })
+}
+
 async function typeKeyAndSubmit(key: string, submitLabel = 'Add provider') {
   fireEvent.change(screen.getByLabelText('API key'), { target: { value: key } })
+  fireEvent.click(consentCheckbox())
   fireEvent.click(screen.getByRole('button', { name: submitLabel }))
 }
 
@@ -97,5 +103,38 @@ describe('AddAiProviderDrawer', () => {
     )
     // The unverified key was saved once, without a second validation probe.
     expect(validateApiKey).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the submit disabled until the data-sharing consent is checked', () => {
+    renderSheet()
+
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'sk-key' } })
+    expect(screen.getByRole('button', { name: 'Add provider' })).toHaveProperty('disabled', true)
+
+    fireEvent.click(consentCheckbox())
+    expect(screen.getByRole('button', { name: 'Add provider' })).toHaveProperty('disabled', false)
+  })
+
+  it('resets consent when the provider changes', async () => {
+    renderSheet()
+
+    fireEvent.click(consentCheckbox())
+    expect(consentCheckbox()).toHaveProperty('checked', true)
+
+    fireEvent.keyDown(screen.getByRole('combobox', { name: 'Provider' }), { key: 'ArrowDown' })
+    fireEvent.keyDown(await screen.findByRole('option', { name: 'Anthropic' }), { key: 'Enter' })
+
+    expect(consentCheckbox()).toHaveProperty('checked', false)
+  })
+
+  it('mentions audio only for transcription-capable providers', async () => {
+    renderSheet()
+
+    expect(screen.getByText(/audio memos send the recording/)).toBeDefined()
+
+    fireEvent.keyDown(screen.getByRole('combobox', { name: 'Provider' }), { key: 'ArrowDown' })
+    fireEvent.keyDown(await screen.findByRole('option', { name: 'Anthropic' }), { key: 'Enter' })
+
+    expect(screen.queryByText(/audio memos send the recording/)).toBeNull()
   })
 })

--- a/apps/desktop/src/mobile/add-ai-provider-drawer.tsx
+++ b/apps/desktop/src/mobile/add-ai-provider-drawer.tsx
@@ -12,6 +12,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { useAddAiProviderSubmit } from '@/hooks/use-add-ai-provider-submit'
+import { AiProviderConsent } from '@/mobile/ai-provider-consent'
 import type { NewAiProvider } from '@/hooks/use-ai-providers'
 
 interface AddAiProviderDrawerProps {
@@ -58,6 +59,7 @@ function AddAiProviderSheet({
   const [model, setModel] = useState(AI_PROVIDERS[0].models[0].id)
   const [apiKey, setApiKey] = useState('')
   const [isDefault, setIsDefault] = useState(false)
+  const [consented, setConsented] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const { submitError, unverified, resetUnverified, submit } = useAddAiProviderSubmit({
     onAdd,
@@ -91,6 +93,7 @@ function AddAiProviderSheet({
               const next = aiProvider(aiProviderIdSchema.parse(value))
               setProviderId(next.id)
               setModel(next.models[0].id)
+              setConsented(false)
               resetUnverified()
             }}
           >
@@ -138,6 +141,12 @@ function AddAiProviderSheet({
           />
         </label>
 
+        <AiProviderConsent
+          provider={provider}
+          consented={consented}
+          onConsentedChange={setConsented}
+        />
+
         <label className="flex items-center gap-2 py-1">
           <input
             type="checkbox"
@@ -154,7 +163,10 @@ function AddAiProviderSheet({
             Couldn’t reach {provider.label} to verify the key. Submit again to save it unverified.
           </InlineAlert>
         ) : null}
-        <Button disabled={apiKey.trim() === '' || submitting} onClick={() => void submitDraft()}>
+        <Button
+          disabled={apiKey.trim() === '' || !consented || submitting}
+          onClick={() => void submitDraft()}
+        >
           {unverified ? 'Save anyway' : 'Add provider'}
         </Button>
       </div>

--- a/apps/desktop/src/mobile/ai-provider-consent.test.tsx
+++ b/apps/desktop/src/mobile/ai-provider-consent.test.tsx
@@ -1,0 +1,38 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { aiProvider } from '@reflect/core'
+import { AiProviderConsent } from './ai-provider-consent'
+
+const openUrl = vi.hoisted(() => vi.fn(() => Promise.resolve()))
+vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl }))
+
+afterEach(cleanup)
+
+describe('AiProviderConsent', () => {
+  it('opens the privacy policy in the system browser', () => {
+    render(
+      <AiProviderConsent
+        provider={aiProvider('openai')}
+        consented={false}
+        onConsentedChange={() => {}}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Privacy policy' }))
+    expect(openUrl).toHaveBeenCalledWith('https://reflect.app/privacy')
+  })
+
+  it('reports checkbox changes to the owner', () => {
+    const onConsentedChange = vi.fn()
+    render(
+      <AiProviderConsent
+        provider={aiProvider('openai')}
+        consented={false}
+        onConsentedChange={onConsentedChange}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /I understand this data will be sent/ }))
+    expect(onConsentedChange).toHaveBeenCalledWith(true)
+  })
+})

--- a/apps/desktop/src/mobile/ai-provider-consent.tsx
+++ b/apps/desktop/src/mobile/ai-provider-consent.tsx
@@ -30,8 +30,8 @@ export function AiProviderConsent({
         When you use AI features, Reflect sends data directly to {provider.label} using this
         key: AI chat sends your messages and the notes the assistant reads
         {sendsAudio ? ', and audio memos send the recording audio for transcription' : ''}.
-        Nothing passes through a Reflect server, and notes marked{' '}
-        <code>private: true</code> are never sent.{' '}
+        Nothing passes through a Reflect server, and notes you mark as private are never
+        sent.{' '}
         <button
           type="button"
           className="underline"

--- a/apps/desktop/src/mobile/ai-provider-consent.tsx
+++ b/apps/desktop/src/mobile/ai-provider-consent.tsx
@@ -1,0 +1,58 @@
+import type { ReactElement } from 'react'
+import { openUrl } from '@tauri-apps/plugin-opener'
+import { TRANSCRIPTION_PROVIDERS, type AiProviderInfo } from '@reflect/core'
+
+export const PRIVACY_POLICY_URL = 'https://reflect.app/privacy'
+
+const TRANSCRIBING_PROVIDER_IDS: readonly string[] = TRANSCRIPTION_PROVIDERS
+
+interface AiProviderConsentProps {
+  provider: AiProviderInfo
+  consented: boolean
+  onConsentedChange: (value: boolean) => void
+}
+
+/**
+ * The pre-save disclosure and consent block (App Review 5.1.1(i)/5.1.2(i),
+ * https://developer.apple.com/app-store/review/guidelines/#data-use-and-sharing):
+ * states what data leaves the device and which provider receives it, and
+ * collects the explicit agreement that gates the submit button.
+ */
+export function AiProviderConsent({
+  provider,
+  consented,
+  onConsentedChange,
+}: AiProviderConsentProps): ReactElement {
+  const sendsAudio = TRANSCRIBING_PROVIDER_IDS.includes(provider.id)
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-sm text-text-muted">
+        When you use AI features, Reflect sends data directly to {provider.label} using this
+        key: AI chat sends your messages and the notes the assistant reads
+        {sendsAudio ? ', and audio memos send the recording audio for transcription' : ''}.
+        Nothing passes through a Reflect server, and notes marked{' '}
+        <code>private: true</code> are never sent.{' '}
+        <button
+          type="button"
+          className="underline"
+          onClick={() => {
+            void openUrl(PRIVACY_POLICY_URL).catch(() => {})
+          }}
+        >
+          Privacy policy
+        </button>
+      </p>
+      <label className="flex items-center gap-2 py-1">
+        <input
+          type="checkbox"
+          className="accent-accent"
+          checked={consented}
+          onChange={(event) => onConsentedChange(event.target.checked)}
+        />
+        <span className="text-sm text-text">
+          I understand this data will be sent to {provider.label}
+        </span>
+      </label>
+    </div>
+  )
+}

--- a/apps/desktop/src/mobile/recording-drawer.test.tsx
+++ b/apps/desktop/src/mobile/recording-drawer.test.tsx
@@ -98,7 +98,7 @@ describe('RecordingDrawer', () => {
     const user = userEvent.setup()
     const view = render(<RecordingDrawer />)
 
-    expect(view.getByText(/OpenAI or Gemini API key/)).not.toBeNull()
+    expect(view.getByText(/send the recording to OpenAI or Google Gemini/)).not.toBeNull()
     expect(view.queryByRole('button', { name: 'Stop recording' })).toBeNull()
 
     await user.click(view.getByRole('button', { name: 'Open Settings' }))

--- a/apps/desktop/src/mobile/recording-drawer.tsx
+++ b/apps/desktop/src/mobile/recording-drawer.tsx
@@ -61,8 +61,8 @@ function KeySetupControls({ memo }: LiveRecordingControlsProps): ReactElement {
   return (
     <div className="flex flex-col items-center gap-4 px-4 pb-2 text-center">
       <p className="text-sm text-text-muted">
-        Audio memos are transcribed into your notes with your own OpenAI or Gemini API key. Add
-        one in Settings to start recording.
+        Audio memos send the recording to OpenAI or Google Gemini for transcription into your
+        notes, using your own API key. Add one in Settings to start recording.
       </p>
       <Button
         onClick={() => {

--- a/apps/desktop/src/mobile/screens/settings.test.tsx
+++ b/apps/desktop/src/mobile/screens/settings.test.tsx
@@ -32,6 +32,9 @@ vi.mock('@/providers/graph-provider', () => ({
 }))
 vi.mock('@/hooks/use-app-version', () => ({ useAppVersion: () => '1.2.3-beta.4' }))
 
+const openUrl = vi.hoisted(() => vi.fn(() => Promise.resolve()))
+vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl }))
+
 const settingsState = vi.hoisted(() => ({ current: {} as Settings }))
 const updateSettings = vi.hoisted(() => vi.fn())
 vi.mock('@/providers/settings-provider', () => ({
@@ -118,6 +121,15 @@ describe('MobileSettings', () => {
     await user.click(graphRow)
 
     expect(navigate).toHaveBeenCalledWith({ kind: 'graphs' })
+  })
+
+  it('opens the privacy policy from the About group', async () => {
+    const user = userEvent.setup()
+    mount()
+
+    await user.click(screen.getByRole('button', { name: 'Privacy Policy' }))
+
+    expect(openUrl).toHaveBeenCalledWith('https://reflect.app/privacy')
   })
 
   it('writes appearance choices to the settings document', async () => {

--- a/apps/desktop/src/mobile/screens/settings.tsx
+++ b/apps/desktop/src/mobile/screens/settings.tsx
@@ -10,12 +10,14 @@ import {
   type EditorTextSize,
   type ThemePreference,
 } from '@reflect/core'
+import { openUrl } from '@tauri-apps/plugin-opener'
 import { useAiProviders } from '@/hooks/use-ai-providers'
 import { useAppVersion } from '@/hooks/use-app-version'
 import { marketingVersion } from '@/lib/marketing-version'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { AddAiProviderDrawer } from '@/mobile/add-ai-provider-drawer'
 import { AiProviderActionsDrawer } from '@/mobile/ai-provider-actions-drawer'
+import { PRIVACY_POLICY_URL } from '@/mobile/ai-provider-consent'
 import { ChatSystemPromptDrawer } from '@/mobile/chat-system-prompt-drawer'
 import { ConnectGithubDrawer } from '@/mobile/connect-github-drawer'
 import { MobileScreenHeader } from '@/mobile/screen-header'
@@ -255,6 +257,12 @@ export function MobileSettings(): ReactElement {
             <SettingsValueRow
               label="Version"
               value={version === null ? '…' : marketingVersion(version)}
+            />
+            <SettingsActionRow
+              label="Privacy Policy"
+              onPress={() => {
+                void openUrl(PRIVACY_POLICY_URL).catch(() => {})
+              }}
             />
           </SettingsGroup>
         </div>


### PR DESCRIPTION
Before an API key can be saved on iOS, the add-provider sheet now discloses what data goes to the selected provider and requires an explicit consent checkbox; the recording drawer says the audio is sent for transcription, and Settings > About gains a Privacy Policy link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a consent step when configuring an AI provider, including details about data sharing.
  - API key submission remains unavailable until consent is granted.
  - Consent resets when switching providers.
  - Added Privacy Policy links in AI provider setup and Settings.
- **Bug Fixes**
  - Clarified audio memo guidance, including when recordings are sent for transcription.
  - Provider-specific messaging now identifies when audio data is transmitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->