### PR TITLE
feat: outline the current note's headings in the sidebar

### DIFF
--- a/apps/desktop/src/components/context-sidebar/note-context-sidebar.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-context-sidebar.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react'
 import { NoteActionsSection } from './note-actions-section'
+import { OutlineSection } from './outline-section'
 import { PublishedUrlSection } from './published-url-section'
 import { SimilarNotesSection } from './similar-notes-section'
 
@@ -19,6 +20,7 @@ export function NoteContextSidebar({ path }: NoteContextSidebarProps): ReactElem
     <div className="flex flex-col py-2 text-text">
       <div className="my-4 space-y-4 pb-4">
         <NoteActionsSection path={path} showTrash />
+        <OutlineSection path={path} />
         <PublishedUrlSection path={path} />
         <SimilarNotesSection path={path} />
       </div>

--- a/apps/desktop/src/components/context-sidebar/outline-section.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/outline-section.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { clearOutline, publishOutline } from '@/editor/note-outline-store'
+import { OutlineSection } from './outline-section'
+
+// jsdom doesn't implement scrollIntoView; the active row scrolls on mount.
+Element.prototype.scrollIntoView ??= () => {}
+
+const revealHeading = vi.fn(() => true)
+
+vi.mock('@/editor/editor-handle-registry', () => ({
+  noteEditorHandleFor: () => ({ revealHeading }),
+}))
+
+vi.mock('./use-active-heading', () => ({
+  useActiveHeading: () => 0,
+}))
+
+const NOTE = 'notes/a.md'
+
+afterEach(() => {
+  cleanup()
+  clearOutline(NOTE)
+  vi.clearAllMocks()
+})
+
+describe('OutlineSection', () => {
+  it('shows the placeholder when the note has no headings', () => {
+    render(<OutlineSection path={NOTE} />)
+    expect(screen.getByText('No headings')).toBeDefined()
+  })
+
+  it('renders one row per heading and navigates on click', async () => {
+    publishOutline(NOTE, [
+      { level: 1, text: 'Title', slug: 'title', from: 0, to: 1 },
+      { level: 2, text: 'Section', slug: 'section', from: 2, to: 3 },
+    ])
+    render(<OutlineSection path={NOTE} />)
+    expect(screen.getByRole('button', { name: 'Title' })).toBeDefined()
+    await userEvent.click(screen.getByRole('button', { name: 'Section' }))
+    expect(revealHeading).toHaveBeenCalledWith('Section')
+  })
+
+  it('marks the active row with aria-current', () => {
+    publishOutline(NOTE, [
+      { level: 1, text: 'Title', slug: 'title', from: 0, to: 1 },
+      { level: 2, text: 'Section', slug: 'section', from: 2, to: 3 },
+    ])
+    render(<OutlineSection path={NOTE} />)
+    expect(screen.getByRole('button', { name: 'Title' }).getAttribute('aria-current')).toBe('true')
+    expect(screen.getByRole('button', { name: 'Section' }).getAttribute('aria-current')).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/context-sidebar/outline-section.tsx
+++ b/apps/desktop/src/components/context-sidebar/outline-section.tsx
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useRef, type ReactElement } from 'react'
+import { useSyncExternalStore } from 'react'
+import { noteEditorHandleFor } from '@/editor/editor-handle-registry'
+import { getOutline, subscribeOutline } from '@/editor/note-outline-store'
+import { cn } from '@/lib/utils'
+import { SidebarSection } from './sidebar-section'
+import { useActiveHeading } from './use-active-heading'
+
+interface OutlineSectionProps {
+  /** Graph-relative path of the note whose headings to outline. */
+  path: string
+}
+
+// Indentation (in rem) per heading level below H1, capped so deep nesting
+// never pushes text off the narrow sidebar.
+const INDENT_REM = 0.75
+
+/**
+ * The note's heading outline as a context-sidebar section. Always rendered:
+ * an empty note shows a muted placeholder rather than vanishing. Headings come
+ * from the live {@link file://../../editor/note-outline-store.ts}; the active
+ * row tracks the viewport via {@link useActiveHeading}; a click drives
+ * meowdown's `revealHeading` through the editor handle registry.
+ */
+export function OutlineSection({ path }: OutlineSectionProps): ReactElement {
+  const headings = useSyncExternalStore(
+    useCallback((listener) => subscribeOutline(path, listener), [path]),
+    useCallback(() => getOutline(path), [path]),
+  )
+  const activeIndex = useActiveHeading(path, headings.length)
+  const activeRef = useRef<HTMLButtonElement | null>(null)
+
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ block: 'nearest' })
+  }, [activeIndex])
+
+  const onSelect = useCallback(
+    (text: string) => {
+      noteEditorHandleFor(path)?.revealHeading(text)
+    },
+    [path],
+  )
+
+  return (
+    <SidebarSection storageKey="outline" title="Outline">
+      {headings.length === 0 ? (
+        <p className="px-3 py-1 text-text-muted">No headings</p>
+      ) : (
+        <ul className="space-y-0.5">
+          {headings.map((heading, index) => {
+            const active = index === activeIndex
+            return (
+              <li key={`${index}-${heading.slug}`}>
+                <button
+                  type="button"
+                  ref={active ? activeRef : null}
+                  aria-current={active ? 'true' : undefined}
+                  onClick={() => {
+                    onSelect(heading.text)
+                  }}
+                  style={{ paddingLeft: `${(heading.level - 1) * INDENT_REM + 0.75}rem` }}
+                  className={cn(
+                    'flex w-full items-center truncate rounded-md py-1 pr-2 text-left leading-5 transition-colors duration-100',
+                    active
+                      ? 'bg-surface-hover text-text'
+                      : 'text-text-secondary hover:bg-surface-hover hover:text-text',
+                  )}
+                >
+                  <span className="truncate">{heading.text}</span>
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </SidebarSection>
+  )
+}

--- a/apps/desktop/src/components/context-sidebar/use-active-heading.test.ts
+++ b/apps/desktop/src/components/context-sidebar/use-active-heading.test.ts
@@ -127,6 +127,32 @@ describe('useActiveHeading', () => {
     expect(result.current).toBe(0)
   })
 
+  it('keeps the active index when only the heading count changes (same note)', () => {
+    // Editing a heading elsewhere in the same note changes headingCount but
+    // must not reset the reader's current position.
+    const root = mountPane('notes/a.md', [-100, -50, LINE - 1])
+    const { result, rerender } = renderHook(
+      ({ path, headingCount }: { path: string; headingCount: number }) =>
+        useActiveHeading(path, headingCount),
+      { initialProps: { path: 'notes/a.md', headingCount: 3 } },
+    )
+    act(() => {
+      flushRaf()
+    })
+    expect(result.current).toBe(2)
+
+    // A fourth heading appears further down; the reader hasn't scrolled, so the
+    // active index stays put rather than snapping back to 0.
+    const fourth = window.document.createElement('h4')
+    setTop(fourth, 800)
+    root.appendChild(fourth)
+    rerender({ path: 'notes/a.md', headingCount: 4 })
+    act(() => {
+      flushRaf()
+    })
+    expect(result.current).toBe(2)
+  })
+
   it('recovers when heading DOM is painted after the effect runs (no open-time race)', async () => {
     // Editor root exists but its headings have not been painted yet.
     const pane = window.document.createElement('div')

--- a/apps/desktop/src/components/context-sidebar/use-active-heading.test.ts
+++ b/apps/desktop/src/components/context-sidebar/use-active-heading.test.ts
@@ -1,0 +1,157 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useActiveHeading } from './use-active-heading'
+
+// The reference line is the scroll parent's top (0 in jsdom, no scroll parent)
+// plus this offset — kept in sync with ACTIVE_LINE_OFFSET in the hook.
+const LINE = 12
+
+let rafCallbacks: FrameRequestCallback[] = []
+
+function flushRaf(): void {
+  const callbacks = rafCallbacks
+  rafCallbacks = []
+  callbacks.forEach((callback) => {
+    callback(0)
+  })
+}
+
+function setTop(element: HTMLElement, top: number): void {
+  element.getBoundingClientRect = () =>
+    ({ top, bottom: top + 20, height: 20, width: 0, left: 0, right: 0, x: 0, y: top }) as DOMRect
+}
+
+/** Mount a pane + editor root with `tops.length` headings at the given tops. */
+function mountPane(path: string, tops: number[]): HTMLElement {
+  const pane = window.document.createElement('div')
+  pane.setAttribute('aria-label', `Editing ${path}`)
+  const root = window.document.createElement('div')
+  root.className = 'reflect-editor'
+  tops.forEach((top, index) => {
+    const heading = window.document.createElement(`h${(index % 6) + 1}`)
+    setTop(heading, top)
+    root.appendChild(heading)
+  })
+  pane.appendChild(root)
+  window.document.body.appendChild(pane)
+  return root
+}
+
+function scroll(): void {
+  window.document.dispatchEvent(new Event('scroll'))
+}
+
+beforeEach(() => {
+  rafCallbacks = []
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback): number => {
+    rafCallbacks.push(callback)
+    return rafCallbacks.length
+  })
+  vi.stubGlobal('cancelAnimationFrame', () => {})
+})
+
+afterEach(() => {
+  window.document.body.innerHTML = ''
+  vi.unstubAllGlobals()
+})
+
+describe('useActiveHeading', () => {
+  it('activates the last heading whose top has passed the reference line', () => {
+    mountPane('notes/a.md', [-100, LINE - 5, 400])
+    const { result } = renderHook(() => useActiveHeading('notes/a.md', 3))
+    act(() => {
+      flushRaf()
+    })
+    expect(result.current).toBe(1)
+
+    // scroll further: the third heading crosses the line too.
+    const headings = window.document.querySelectorAll<HTMLElement>('.reflect-editor h1, .reflect-editor h2, .reflect-editor h3')
+    setTop(headings[2]!, LINE - 2)
+    act(() => {
+      scroll()
+      flushRaf()
+    })
+    expect(result.current).toBe(2)
+
+    // scroll back to the very top: nothing has passed the line except the first.
+    setTop(headings[0]!, LINE - 1)
+    setTop(headings[1]!, 300)
+    setTop(headings[2]!, 700)
+    act(() => {
+      scroll()
+      flushRaf()
+    })
+    expect(result.current).toBe(0)
+  })
+
+  it('activates the final heading even with no content below it', () => {
+    // All four headings have scrolled above the line — the last one wins.
+    mountPane('notes/a.md', [-400, -300, -200, LINE - 3])
+    const { result } = renderHook(() => useActiveHeading('notes/a.md', 4))
+    act(() => {
+      flushRaf()
+    })
+    expect(result.current).toBe(3)
+  })
+
+  it('clamps the active index to the heading count', () => {
+    // Four DOM headings but the store only knows about two.
+    mountPane('notes/a.md', [-100, -90, -80, -70])
+    const { result } = renderHook(() => useActiveHeading('notes/a.md', 2))
+    act(() => {
+      flushRaf()
+    })
+    expect(result.current).toBe(1)
+  })
+
+  it('returns 0 and schedules nothing when there are no headings', () => {
+    const { result } = renderHook(() => useActiveHeading('notes/a.md', 0))
+    expect(result.current).toBe(0)
+    expect(rafCallbacks).toHaveLength(0)
+  })
+
+  it('resets the active index when the path changes', () => {
+    mountPane('notes/a.md', [-100, -50, LINE - 1])
+    const { result, rerender } = renderHook(
+      ({ path, headingCount }: { path: string; headingCount: number }) =>
+        useActiveHeading(path, headingCount),
+      { initialProps: { path: 'notes/a.md', headingCount: 3 } },
+    )
+    act(() => {
+      flushRaf()
+    })
+    expect(result.current).toBe(2)
+
+    mountPane('notes/b.md', [5, 400])
+    rerender({ path: 'notes/b.md', headingCount: 2 })
+    expect(result.current).toBe(0)
+  })
+
+  it('recovers when heading DOM is painted after the effect runs (no open-time race)', async () => {
+    // Editor root exists but its headings have not been painted yet.
+    const pane = window.document.createElement('div')
+    pane.setAttribute('aria-label', 'Editing notes/a.md')
+    const root = window.document.createElement('div')
+    root.className = 'reflect-editor'
+    pane.appendChild(root)
+    window.document.body.appendChild(pane)
+
+    const { result } = renderHook(() => useActiveHeading('notes/a.md', 2))
+    act(() => {
+      flushRaf()
+    })
+    expect(result.current).toBe(0)
+
+    // Headings appear later; the MutationObserver must re-compute.
+    await act(async () => {
+      const first = window.document.createElement('h1')
+      setTop(first, -100)
+      const second = window.document.createElement('h2')
+      setTop(second, LINE - 4)
+      root.append(first, second)
+      await Promise.resolve()
+      flushRaf()
+    })
+    expect(result.current).toBe(1)
+  })
+})

--- a/apps/desktop/src/components/context-sidebar/use-active-heading.ts
+++ b/apps/desktop/src/components/context-sidebar/use-active-heading.ts
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react'
+
+const HEADING_SELECTOR = 'h1, h2, h3, h4, h5, h6'
+// How far below the scroll container's top edge a heading must sit before the
+// section above it stops being "current". A small offset means a heading
+// becomes active as soon as its top scrolls up to the reading area's top.
+const ACTIVE_LINE_OFFSET = 12
+
+/** The nearest scrollable ancestor of `element`, or null for the viewport. */
+function findScrollParent(element: Element): HTMLElement | null {
+  let node = element.parentElement
+  while (node !== null) {
+    const overflowY = window.getComputedStyle(node).overflowY
+    if (
+      (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay') &&
+      node.scrollHeight > node.clientHeight
+    ) {
+      return node
+    }
+    node = node.parentElement
+  }
+  return null
+}
+
+/**
+ * The index (document order) of the heading whose section currently sits at the
+ * top of the reading area for the note rendered in the pane labelled
+ * `Editing <path>` — the last heading whose top has scrolled to (or past) the
+ * scroll container's top edge. Because it is position-based rather than a
+ * top-band detector, the final heading activates correctly even when there is
+ * no content below it to scroll further.
+ *
+ * Rows in the outline map to headings by this index, so duplicate heading text
+ * is never ambiguous. Returns 0 before any scroll, when the note has no
+ * headings, and while the editor's heading DOM has not yet been painted (it
+ * re-computes as soon as it is, via a MutationObserver — no open-time race).
+ */
+export function useActiveHeading(path: string, headingCount: number): number {
+  const [active, setActive] = useState(0)
+
+  const paneKey = `${path}:${headingCount}`
+  const [previousPaneKey, setPreviousPaneKey] = useState(paneKey)
+  if (previousPaneKey !== paneKey) {
+    setPreviousPaneKey(paneKey)
+    setActive(0)
+  }
+
+  useEffect(() => {
+    if (headingCount === 0) {
+      return
+    }
+    const pane = window.document.querySelector(`[aria-label="Editing ${path}"]`)
+    if (pane === null) {
+      return
+    }
+    const root = pane.querySelector('.reflect-editor')
+    if (root === null) {
+      return
+    }
+    const scrollParent = findScrollParent(root)
+
+    let frame = 0
+    const compute = (): void => {
+      frame = 0
+      const nodes = root.querySelectorAll<HTMLElement>(HEADING_SELECTOR)
+      if (nodes.length === 0) {
+        return
+      }
+      const line =
+        (scrollParent === null ? 0 : scrollParent.getBoundingClientRect().top) + ACTIVE_LINE_OFFSET
+      let next = 0
+      for (let index = 0; index < nodes.length; index += 1) {
+        if (nodes[index]!.getBoundingClientRect().top <= line) {
+          next = index
+        } else {
+          break
+        }
+      }
+      setActive(Math.min(next, headingCount - 1))
+    }
+    const schedule = (): void => {
+      if (frame === 0) {
+        frame = window.requestAnimationFrame(compute)
+      }
+    }
+
+    schedule()
+    // scroll does not bubble; the capture phase catches it from whichever
+    // container actually scrolls, so we never have to guess which one.
+    window.document.addEventListener('scroll', schedule, { capture: true, passive: true })
+    window.addEventListener('resize', schedule, { passive: true })
+    // Re-compute when the editor paints or edits its heading DOM: the open-time
+    // race fix, plus live tracking as headings are added/removed/reordered.
+    const mutations = new MutationObserver(schedule)
+    mutations.observe(root, { childList: true, subtree: true })
+
+    return () => {
+      if (frame !== 0) {
+        window.cancelAnimationFrame(frame)
+      }
+      window.document.removeEventListener('scroll', schedule, { capture: true })
+      window.removeEventListener('resize', schedule)
+      mutations.disconnect()
+    }
+  }, [path, headingCount])
+
+  return active
+}

--- a/apps/desktop/src/components/context-sidebar/use-active-heading.ts
+++ b/apps/desktop/src/components/context-sidebar/use-active-heading.ts
@@ -38,10 +38,13 @@ function findScrollParent(element: Element): HTMLElement | null {
 export function useActiveHeading(path: string, headingCount: number): number {
   const [active, setActive] = useState(0)
 
-  const paneKey = `${path}:${headingCount}`
-  const [previousPaneKey, setPreviousPaneKey] = useState(paneKey)
-  if (previousPaneKey !== paneKey) {
-    setPreviousPaneKey(paneKey)
+  // Reset only when the note itself changes. Keying on `headingCount` too would
+  // reset to 0 on every heading edit within the same note — the exact
+  // live-editing case this feature tracks — and the out-of-range case is
+  // already clamped by `Math.min(next, headingCount - 1)` in `compute`.
+  const [previousPath, setPreviousPath] = useState(path)
+  if (previousPath !== path) {
+    setPreviousPath(path)
     setActive(0)
   }
 

--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -254,11 +254,17 @@ export function NotePaneComponent({
   )
 
   useEffect(() => {
+    // Protected notes (sync conflicts land here) render raw, conflict-marked
+    // content instead of the editor, so parsing `editorSeed` would outline
+    // headings from both conflict sides rather than the note's real structure.
+    if (document.protected) {
+      return
+    }
     publishOutlineFromMarkdown(path, editorSeed)
     return () => {
       clearOutline(path)
     }
-  }, [path, editorSeed])
+  }, [path, editorSeed, document.protected])
 
   if (document.status === 'loading') {
     // `reflect-note-loading` keeps the hint invisible for the first beat:

--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useRef, useState, type ReactElement } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react'
 import type { ExitBoundaryHandler } from '@meowdown/core'
 import { detectConflictMarkers, isDaily, isTemplatePath, untitledNoteSeed } from '@reflect/core'
 import { BacklinksPanel } from '@/components/backlinks-panel'
@@ -17,6 +17,7 @@ import {
 } from '@/editor/editor-handle-registry'
 import { markModeFromSyntax } from '@/editor/mark-mode'
 import { NoteEditor, type NoteEditorHandle } from '@/editor/note-editor'
+import { clearOutline, publishOutlineFromMarkdown } from '@/editor/note-outline-store'
 import { resolveAssetFileLink, useAssetPersistence } from '@/editor/use-asset-persistence'
 import { useEditorAutocomplete } from '@/editor/use-editor-autocomplete'
 import { useNoteDocument } from '@/editor/use-note-document'
@@ -230,6 +231,35 @@ export function NotePaneComponent({
     }
   }, [dailyDate, onExitBoundary])
 
+  // A note that opens with an empty body starts on an empty bullet when the
+  // setting is on (old Reflect's every-note default). The seed only changes what
+  // the editor shows; persistence is untouched, so a not-yet-created daily
+  // placeholder stays uncreated until the user types — see `default-bullet.ts`.
+  // Computed here — before the loading/error/protected early returns below —
+  // so the outline-publish effect can depend on it while every hook call
+  // below stays unconditional; `document.initialContent` is always a string,
+  // even before the note finishes loading.
+  const editorSeed = editorBodyWithDefaultBullet(
+    document.initialContent,
+    settings.editorDefaultBullet,
+  )
+
+  const onDocumentEditorChange = document.onEditorChange
+  const onEditorChange = useCallback(
+    (markdown: string) => {
+      onDocumentEditorChange(markdown)
+      publishOutlineFromMarkdown(path, markdown)
+    },
+    [onDocumentEditorChange, path],
+  )
+
+  useEffect(() => {
+    publishOutlineFromMarkdown(path, editorSeed)
+    return () => {
+      clearOutline(path)
+    }
+  }, [path, editorSeed])
+
   if (document.status === 'loading') {
     // `reflect-note-loading` keeps the hint invisible for the first beat:
     // local reads resolve in milliseconds, and the text flashing on every
@@ -284,15 +314,6 @@ export function NotePaneComponent({
     )
   }
 
-  // A note that opens with an empty body starts on an empty bullet when the
-  // setting is on (old Reflect's every-note default). The seed only changes what
-  // the editor shows; persistence is untouched, so a not-yet-created daily
-  // placeholder stays uncreated until the user types — see `default-bullet.ts`.
-  const editorSeed = editorBodyWithDefaultBullet(
-    document.initialContent,
-    settings.editorDefaultBullet,
-  )
-
   return (
     <div className={cn('relative', className)} aria-label={`Editing ${path}`}>
       <div className={gutterClassName}>
@@ -332,7 +353,7 @@ export function NotePaneComponent({
         // for that would throw away the cursor mid-thought.
         key={document.sessionEpoch}
         initialContent={editorSeed}
-        onChange={document.onEditorChange}
+        onChange={onEditorChange}
         markMode={markModeFromSyntax(settings.editorMarkdownSyntax)}
         spellCheck={settings.editorSpellCheck}
         smoothCaretAnimation={settings.editorSmoothCaretAnimation}

--- a/apps/desktop/src/components/route-content.test.tsx
+++ b/apps/desktop/src/components/route-content.test.tsx
@@ -54,6 +54,7 @@ vi.mock('@/editor/note-editor', async () => {
           insertMarkdown: () => {},
           focus: () => editorProbe.focusCalls.push('focus'),
           setSelection: () => {},
+          revealHeading: () => false,
           getSelectedText: () => '',
           openSelectionMenu: () => {},
           startPendingReplacement: () => false,

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -85,6 +85,12 @@ export interface NoteEditorHandle {
    * previous day / the start of the next day).
    */
   setSelection(position: 'start' | 'end'): void
+  /**
+   * Move the caret to the first heading matching `fragment`
+   * (case-insensitive, whitespace-collapsed) and scroll it into view.
+   * Returns false when no heading matches. Drives the outline sidebar.
+   */
+  revealHeading(fragment: string): boolean
   /** The current selection's text (blocks separated by blank lines). */
   getSelectedText(): string
   /** Open the selection AI menu (no-op on an empty selection). */
@@ -278,6 +284,7 @@ export function NoteEditor({
       insertMarkdown: (markdown) => innerRef.current?.insertMarkdown(markdown),
       focus: () => innerRef.current?.focus(),
       setSelection: (position) => innerRef.current?.setSelection(position),
+      revealHeading: (fragment) => innerRef.current?.revealHeading(fragment) ?? false,
       getSelectedText: () => innerRef.current?.getSelectedText() ?? '',
       openSelectionMenu: () => innerRef.current?.openSelectionMenu(),
       startPendingReplacement: (options) =>

--- a/apps/desktop/src/editor/note-outline-store.test.ts
+++ b/apps/desktop/src/editor/note-outline-store.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearOutline,
+  getOutline,
+  publishOutline,
+  publishOutlineFromMarkdown,
+  subscribeOutline,
+} from './note-outline-store'
+
+const NOTE = 'notes/a.md'
+
+afterEach(() => {
+  clearOutline(NOTE)
+  clearOutline('notes/b.md')
+})
+
+describe('note-outline-store', () => {
+  it('returns a stable empty reference for an unknown path', () => {
+    expect(getOutline(NOTE)).toEqual([])
+    expect(getOutline(NOTE)).toBe(getOutline('notes/b.md'))
+  })
+
+  it('publishes headings and notifies subscribers', () => {
+    const listener = vi.fn()
+    const unsubscribe = subscribeOutline(NOTE, listener)
+    publishOutline(NOTE, [{ level: 1, text: 'A', slug: 'a', from: 0, to: 1 }])
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(getOutline(NOTE).map((heading) => heading.text)).toEqual(['A'])
+    unsubscribe()
+  })
+
+  it('keeps the same reference until the next publish', () => {
+    publishOutline(NOTE, [{ level: 1, text: 'A', slug: 'a', from: 0, to: 1 }])
+    const first = getOutline(NOTE)
+    expect(getOutline(NOTE)).toBe(first)
+    publishOutline(NOTE, [{ level: 2, text: 'B', slug: 'b', from: 2, to: 3 }])
+    expect(getOutline(NOTE)).not.toBe(first)
+  })
+
+  it('isolates paths and stops notifying after unsubscribe', () => {
+    const listener = vi.fn()
+    const unsubscribe = subscribeOutline(NOTE, listener)
+    publishOutline('notes/b.md', [])
+    expect(listener).not.toHaveBeenCalled()
+    unsubscribe()
+    publishOutline(NOTE, [])
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('parses markdown headings via publishOutlineFromMarkdown', () => {
+    publishOutlineFromMarkdown(NOTE, '# Title\n\n## Section one\n\ntext\n\n### Nested')
+    expect(getOutline(NOTE).map((heading) => [heading.level, heading.text])).toEqual([
+      [1, 'Title'],
+      [2, 'Section one'],
+      [3, 'Nested'],
+    ])
+  })
+})

--- a/apps/desktop/src/editor/note-outline-store.ts
+++ b/apps/desktop/src/editor/note-outline-store.ts
@@ -1,0 +1,64 @@
+import { parseNote, type Heading } from '@reflect/core'
+
+type Listener = () => void
+
+/**
+ * Live note outlines, keyed by graph-relative note path. The note pane
+ * (publisher) parses headings on edit and calls {@link publishOutline}; the
+ * context sidebar (subscriber) reads them through `useSyncExternalStore`.
+ * Module-level rather than a provider — the pane and the sidebar are siblings
+ * that never share a React parent below the workspace, the same shape as
+ * {@link file://./editor-handle-registry.ts}.
+ */
+const EMPTY: readonly Heading[] = Object.freeze([])
+const outlines = new Map<string, readonly Heading[]>()
+const listeners = new Map<string, Set<Listener>>()
+
+/** The current outline for a note path — a stable reference until the next publish. */
+export function getOutline(path: string): readonly Heading[] {
+  return outlines.get(path) ?? EMPTY
+}
+
+/** Subscribe to outline changes for a path; returns an unsubscribe function. */
+export function subscribeOutline(path: string, listener: Listener): () => void {
+  let set = listeners.get(path)
+  if (set === undefined) {
+    set = new Set<Listener>()
+    listeners.set(path, set)
+  }
+  set.add(listener)
+  return () => {
+    const current = listeners.get(path)
+    if (current === undefined) {
+      return
+    }
+    current.delete(listener)
+    if (current.size === 0) {
+      listeners.delete(path)
+    }
+  }
+}
+
+function emit(path: string): void {
+  listeners.get(path)?.forEach((listener) => {
+    listener()
+  })
+}
+
+/** Replace the outline for a path and notify its subscribers. */
+export function publishOutline(path: string, headings: readonly Heading[]): void {
+  outlines.set(path, headings)
+  emit(path)
+}
+
+/** Parse `markdown` for `path` and publish its headings. */
+export function publishOutlineFromMarkdown(path: string, markdown: string): void {
+  publishOutline(path, parseNote({ path, source: markdown }).headings)
+}
+
+/** Drop a path's outline (note unmount); notifies only if one existed. */
+export function clearOutline(path: string): void {
+  if (outlines.delete(path)) {
+    emit(path)
+  }
+}

--- a/apps/desktop/src/editor/reveal-heading.test.tsx
+++ b/apps/desktop/src/editor/reveal-heading.test.tsx
@@ -1,0 +1,39 @@
+import { createRef, useEffect, type Ref } from 'react'
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { EditorHandle } from '@meowdown/react'
+import { NoteEditor, type NoteEditorHandle } from './note-editor'
+
+/**
+ * `NoteEditorHandle.revealHeading` delegates to meowdown's first-class
+ * handle method; this only guards the pass-through.
+ */
+
+const revealHeading = vi.hoisted(() => vi.fn(() => true))
+
+vi.mock('@meowdown/react', () => ({
+  MeowdownEditor: ({ handleRef }: { handleRef?: Ref<Partial<EditorHandle>> }) => {
+    useEffect(() => {
+      if (typeof handleRef === 'function') {
+        handleRef({ revealHeading })
+      } else if (handleRef !== null && handleRef !== undefined) {
+        handleRef.current = { revealHeading }
+      }
+    })
+    return <div />
+  },
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('NoteEditorHandle.revealHeading', () => {
+  it('delegates to the meowdown handle and returns its result', () => {
+    const ref = createRef<NoteEditorHandle>()
+    render(<NoteEditor handleRef={ref} initialContent="# A" />)
+    expect(ref.current?.revealHeading('A')).toBe(true)
+    expect(revealHeading).toHaveBeenCalledWith('A')
+  })
+})

--- a/apps/desktop/src/editor/use-note-document.test.tsx
+++ b/apps/desktop/src/editor/use-note-document.test.tsx
@@ -34,6 +34,7 @@ function fakeEditor(): NoteEditorHandle & { applied: string[] } {
     insertMarkdown: () => {},
     focus: () => {},
     setSelection: () => {},
+    revealHeading: () => false,
     getSelectedText: () => '',
     openSelectionMenu: () => {},
     startPendingReplacement: () => false,

--- a/apps/desktop/src/editor/use-template-slash-items.test.ts
+++ b/apps/desktop/src/editor/use-template-slash-items.test.ts
@@ -33,6 +33,7 @@ function fakeEditor(): NoteEditorHandle & { inserted: string[] } {
     },
     focus: () => {},
     setSelection: () => {},
+    revealHeading: () => false,
     getSelectedText: () => '',
     openSelectionMenu: () => {},
     startPendingReplacement: () => false,

--- a/apps/desktop/src/lib/attach-files.test.ts
+++ b/apps/desktop/src/lib/attach-files.test.ts
@@ -42,6 +42,7 @@ function editorHandle(): NoteEditorHandle & {
     insertMarkdown: vi.fn<(markdown: string) => void>(),
     focus: () => {},
     setSelection: () => {},
+    revealHeading: () => false,
     getSelectedText: () => '',
     openSelectionMenu: () => {},
     startPendingReplacement: () => false,

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -80,6 +80,7 @@ vi.mock('@/editor/note-editor', async () => {
           setSelection: (position: 'start' | 'end') => {
             editorProbe.selectionCalls.push(position)
           },
+          revealHeading: () => false,
           getSelectedText: () => '',
           openSelectionMenu: () => {},
           startPendingReplacement: () => false,

--- a/apps/desktop/src/mobile/screens/tasks.test.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.test.tsx
@@ -101,6 +101,7 @@ vi.mock('@/editor/note-editor', async () => {
             editorProbe.focusCalls += 1
           },
           setSelection: () => {},
+          revealHeading: () => false,
           getSelectedText: () => '',
           openSelectionMenu: () => {},
           startPendingReplacement: () => false,


### PR DESCRIPTION
Closes #870.

Adds a collapsible **Outline** section to the note context sidebar — the intra-note navigation aid proposed in #870.

### What it does
- Lists the current note's headings, indented by level.
- Live-updates as you edit (add / remove / rename a heading).
- Click a heading to jump to it in the editor.
- Highlights the section you're currently reading as you scroll (scroll-spy), keeping the active row in view.
- Always shown; renders "No headings" when the note has none.

### Scope / alignment with the discussion
- **Note context sidebar only** — the daily stream is untouched.
- One collapsible section, styled like the existing "Similar notes" — no new chrome, nothing that competes with the editor.
- Reuses `parseNote(...).headings` and the editor's existing `revealHeading`; **`apps/desktop` only, no `packages/core` or Rust changes**.

### How it works
- A small per-path store (mirroring `editor-handle-registry`) carries the parsed headings from the note pane to the sidebar via `useSyncExternalStore`.
- Scroll-spy is position-based (the last heading whose top has passed the scroll container's top edge), recomputed on scroll / resize / editor DOM mutations, so it attaches as soon as headings paint and the final heading activates correctly.

### Checks
- `pnpm typecheck` and `pnpm lint` clean.
- Unit tests for the store, the `revealHeading` passthrough, the scroll-spy hook, and the outline section (colocated `*.test.ts(x)`).
- No Rust touched, so `cargo test` is not applicable.

### Notes
- Currently always-on (no setting) — happy to gate it behind an editor setting if you'd prefer opt-in.
- Daily notes opened on their own use the daily context sidebar, so they don't show the outline (kept out of scope per "don't interfere with the daily stream"). Can extend if wanted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an **Outline** section to the note sidebar, showing a list of document headings with indentation.
  - Highlights the heading currently in view while you scroll.
  - Clicking a heading moves the editor caret to the matching heading (and scrolls it into view).
  - The outline updates automatically as the note content changes, including initial loading.
  - Shows a **“No headings”** message when the outline is empty.
- **Tests**
  - Added/expanded suites covering outline rendering, navigation behavior, active-heading tracking, live outline store updates, and the editor’s reveal-heading API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->