### PR TITLE
fix: show tagged daily notes in all notes

### DIFF
--- a/apps/desktop/src/components/all-notes/all-notes-screen.test.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.test.tsx
@@ -550,6 +550,23 @@ describe('AllNotesScreen — selection and bulk trash', () => {
     view.unmount()
   })
 
+  it('does not offer bulk trash for a tagged daily note', async () => {
+    const view = renderScreen()
+    await view.findByText('Health Stacked')
+
+    fireEvent.click(view.getByRole('button', { name: /Custom/ }))
+    fireEvent.click(view.getByRole('option', { name: /#travel/ }))
+    await view.findByText('June 9, 2026')
+
+    fireEvent.click(view.getByText('Daily travel notes.'))
+    expect(view.queryByRole('button', { name: /Trash \(/ })).toBeNull()
+
+    fireEvent.keyDown(view.getByLabelText('All notes'), { key: 'Backspace', metaKey: true })
+    expect(view.queryByText('Trash 1 note?')).toBeNull()
+    expect(mockInvoke.mock.calls.some(([command]) => command === 'note_delete')).toBe(false)
+    view.unmount()
+  })
+
   it('does not open a note when Return activates a focused header button', async () => {
     const view = renderScreen()
     await view.findByText('Health Stacked')

--- a/apps/desktop/src/components/all-notes/all-notes-screen.test.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.test.tsx
@@ -555,7 +555,7 @@ describe('AllNotesScreen — selection and bulk trash', () => {
     await view.findByText('Health Stacked')
 
     fireEvent.click(view.getByRole('button', { name: /Custom/ }))
-    fireEvent.click(view.getByRole('option', { name: /#travel/ }))
+    fireEvent.click(await view.findByRole('option', { name: /#travel/ }))
     await view.findByText('June 9, 2026')
 
     fireEvent.click(view.getByText('Daily travel notes.'))

--- a/apps/desktop/src/components/all-notes/all-notes-screen.test.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.test.tsx
@@ -70,9 +70,16 @@ const noteRows = [
     preview: 'Dandelion chocolate.',
   },
 ]
+const taggedDailyRow = {
+  path: 'daily/2026-06-09.md',
+  title: 'June 9, 2026',
+  mtime: TOKYO_MTIME,
+  preview: 'Daily travel notes.',
+}
 const tagRows = [
   { note_path: 'notes/health.md', tag: 'link' },
   { note_path: 'notes/tokyo.md', tag: 'link' },
+  { note_path: 'daily/2026-06-09.md', tag: 'travel' },
 ]
 const facetRows = [
   { tag: 'book', count: 3 },
@@ -101,7 +108,7 @@ beforeEach(() => {
       // A tag-filtered list starts from the folded tag key — only `travel`
       // has matches in this fixture.
       if (sql.includes('from "tags"')) {
-        return params.includes('travel') ? [noteRows[1]] : []
+        return params.includes('travel') ? [taggedDailyRow] : []
       }
       return noteRows
     }
@@ -364,12 +371,15 @@ describe('AllNotesScreen', () => {
     fireEvent.click(view.getByRole('option', { name: /#travel/ }))
 
     expect(probedRoute(view)).toEqual({ kind: 'allNotes', tag: 'travel' })
-    await view.findByText('Tokyo Gâteau')
+    await view.findByText('June 9, 2026')
+    expect(view.getByText('Daily travel notes.')).toBeDefined()
     expect(view.queryByText('Health Stacked')).toBeNull()
     // The trigger adopts the active custom tag.
     await waitFor(() =>
       expect(view.getByRole('button', { name: /#travel/, expanded: false })).toBeDefined(),
     )
+    fireEvent.click(view.getByRole('button', { name: 'June 9, 2026' }))
+    expect(probedRoute(view)).toEqual({ kind: 'daily', date: '2026-06-09' })
     view.unmount()
   })
 

--- a/apps/desktop/src/components/all-notes/all-notes-screen.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { hasBridge, listNotes, listNoteTags } from '@reflect/core'
+import { hasBridge, isDaily, listNotes, listNoteTags } from '@reflect/core'
 import { Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useNoteLinkNavigation } from '@/hooks/use-note-link-navigation'
@@ -82,16 +82,21 @@ export function AllNotesScreen({ tag }: AllNotesScreenProps): ReactElement {
 
   // The bulk-trash confirm: the screen owns whether it's open and which paths it
   // acts on (snapshotted at open time, since the delete prunes the live
-  // selection); the dialog owns the delete and its error.
+  // selection); the dialog owns the delete and its error. Daily rows remain
+  // selectable for keyboard navigation, but are never valid trash targets.
   const [confirmingTrash, setConfirmingTrash] = useState(false)
   const [pendingPaths, setPendingPaths] = useState<readonly string[]>([])
+  const trashableSelectedPaths = useMemo(
+    () => [...selection.selected].filter((path) => !isDaily(path)),
+    [selection.selected],
+  )
   const openTrashConfirm = useCallback(() => {
-    if (selection.selectedCount === 0) {
+    if (trashableSelectedPaths.length === 0) {
       return
     }
-    setPendingPaths([...selection.selected])
+    setPendingPaths(trashableSelectedPaths)
     setConfirmingTrash(true)
-  }, [selection])
+  }, [trashableSelectedPaths])
 
   // The table owns the virtualizer; the bridge lets the keyboard nav pull an
   // off-screen (unmounted) row into view through the virtualizer's scrollToIndex.
@@ -122,11 +127,11 @@ export function AllNotesScreen({ tag }: AllNotesScreenProps): ReactElement {
       <header className="flex flex-none flex-wrap items-center justify-between gap-3 border-b border-border py-4 pl-12 pr-7">
         <h1 className="text-[15px] font-semibold text-text">Notes</h1>
         <div className="flex flex-wrap items-center gap-3">
-          {selection.selectedCount > 0 ? (
+          {trashableSelectedPaths.length > 0 ? (
             <Button
               type="button"
               variant="outline"
-              aria-label={`Trash (${selection.selectedCount})`}
+              aria-label={`Trash (${trashableSelectedPaths.length})`}
               onClick={openTrashConfirm}
               className="text-text-secondary hover:text-destructive"
             >
@@ -136,7 +141,7 @@ export function AllNotesScreen({ tag }: AllNotesScreenProps): ReactElement {
                 aria-hidden
                 className="flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive/10 px-1 text-[10px] font-semibold leading-none tabular-nums text-destructive"
               >
-                {selection.selectedCount}
+                {trashableSelectedPaths.length}
               </span>
             </Button>
           ) : null}

--- a/apps/desktop/src/components/all-notes/all-notes-screen.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.tsx
@@ -27,7 +27,8 @@ interface AllNotesScreenProps {
  * The All Notes screen (a routed view, like settings): every non-daily note,
  * newest first, filterable by tag. The active tag lives on the route so
  * back/forward and "open a note, come back" keep the filter. Daily notes are
- * deliberately absent — the stream is their home.
+ * deliberately absent from the unfiltered view, but appear when they match the
+ * active tag.
  *
  * Rows are multi-selectable (V1 parity): click to select (⌘ toggle, Shift
  * range), the indicator gutter toggles, the subject or a double-click opens.

--- a/apps/desktop/src/lib/notes/use-note-trash.ts
+++ b/apps/desktop/src/lib/notes/use-note-trash.ts
@@ -33,8 +33,8 @@ export interface NoteTrash {
  *   prunes only vanished rows — so the user can retry it without re-selecting.
  * - **{@link deleteOpenNote}, not raw `deleteNote`.** It discards any open
  *   editor session for the note after the file is gone, so a teardown flush
- *   can't recreate the file. It also guards daily notes (which All Notes never
- *   lists, so this is only defense in depth).
+ *   can't recreate the file. It also guards daily notes as defense in depth;
+ *   All Notes filters them out of the selected trash targets before calling.
  * - **Per-note failures don't strand the rest.** Deletes run sequentially and a
  *   failure is recorded, not rethrown mid-batch, so the remaining notes still
  *   trash; the toast reports the count couldn't-trash via the last error.

--- a/packages/core/src/indexing/note-list.test.ts
+++ b/packages/core/src/indexing/note-list.test.ts
@@ -94,7 +94,7 @@ describe('listNotes', () => {
     expect(tagArgs['params']).toEqual(['note'])
   })
 
-  it('narrows both queries to one tag via tag-first joins on the stored folded tag_key', async () => {
+  it('narrows both queries to one tag and includes tagged daily notes', async () => {
     mockInvoke
       .mockResolvedValueOnce([
         {
@@ -105,10 +105,21 @@ describe('listNotes', () => {
           is_pinned: 0,
           pinned_order: null,
         },
+        {
+          path: 'daily/2026-06-09.md',
+          title: 'June 9, 2026',
+          mtime: 1500,
+          preview: 'Read a book.',
+          is_pinned: 0,
+          pinned_order: null,
+        },
       ])
-      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ note_path: 'daily/2026-06-09.md', tag: 'Book' }])
 
-    await listNotes({ tag: 'Book' })
+    const entries = await listNotes({ tag: 'Book' })
+
+    expect(entries.map((entry) => entry.path)).toEqual(['notes/health.md', 'daily/2026-06-09.md'])
+    expect(entries[1]?.tags).toEqual(['Book'])
 
     expect(mockInvoke).toHaveBeenCalledTimes(2)
     const [, listArgs] = mockInvoke.mock.calls[0]!
@@ -118,7 +129,7 @@ describe('listNotes', () => {
     expect(listSql).toContain('"tags"."tag_key"')
     expect(listSql).not.toContain('exists')
     expect(listSql).not.toContain('lower(')
-    expect(listArgs['params']).toEqual(['book', 'note'])
+    expect(listArgs['params']).toEqual(['book', 'note', 'daily'])
 
     const [, tagArgs] = mockInvoke.mock.calls[1]!
     const tagSql = String(tagArgs['sql'])
@@ -126,7 +137,7 @@ describe('listNotes', () => {
     expect(tagSql).toContain('"filter_tags"."tag_key"')
     expect(tagSql).not.toContain('exists')
     expect(tagSql).not.toContain('lower(')
-    expect(tagArgs['params']).toEqual(['book', 'note'])
+    expect(tagArgs['params']).toEqual(['book', 'note', 'daily'])
   })
 
   it('skips the tag fetch entirely when no notes match', async () => {

--- a/packages/core/src/indexing/note-list.ts
+++ b/packages/core/src/indexing/note-list.ts
@@ -5,9 +5,9 @@ import { recallOrder } from './filtered-search'
 
 /**
  * The All Notes list: every regular note, pinned first then newest, optionally
- * narrowed to one tag. Daily notes are excluded by design — the stream is
- * their home — and templates are boilerplate, not graph content;
- * `kind = 'note'` expresses both (mirroring the original app's `isDaily = 0`).
+ * narrowed to one tag. The unfiltered list excludes daily notes — the stream is
+ * their home — but a tag filter includes tagged daily notes alongside regular
+ * notes. Templates remain boilerplate, not graph content.
  * Uncapped: the screen virtualizes, the row
  * snippet is the stored `preview` column (derived once at index time), and
  * neither query carries a per-row parameter, so list size has no SQL ceiling.
@@ -33,8 +33,10 @@ export interface NoteListOptions {
 }
 
 /**
- * Non-daily notes for the All Notes screen: pinned first (explicit pin order,
- * then unordered pins), then most recently edited — V1's list order.
+ * Notes for the All Notes screen: unfiltered lists include non-daily notes only;
+ * tag-filtered lists include both regular and daily notes carrying the tag.
+ * Pinned notes appear first (explicit pin order, then unordered pins), then most
+ * recently edited — V1's list order.
  */
 export async function listNotes(options: NoteListOptions = {}): Promise<NoteListEntry[]> {
   const tag = options.tag ?? null
@@ -56,7 +58,7 @@ export async function listNotes(options: NoteListOptions = {}): Promise<NoteList
           .selectFrom('tags')
           .innerJoin('notes', 'notes.path', 'tags.notePath')
           .where('tags.tagKey', '=', foldTag(tag))
-          .where('notes.kind', '=', 'note')
+          .where('notes.kind', 'in', ['note', 'daily'])
           .select([
             'notes.path',
             'notes.title',
@@ -94,7 +96,7 @@ export async function listNotes(options: NoteListOptions = {}): Promise<NoteList
           .innerJoin('notes', 'notes.path', 'tags.notePath')
           .innerJoin('tags as filterTags', 'filterTags.notePath', 'notes.path')
           .where('filterTags.tagKey', '=', foldTag(tag))
-          .where('notes.kind', '=', 'note')
+          .where('notes.kind', 'in', ['note', 'daily'])
           .select(['tags.notePath', 'tags.tag'])
           .distinct()
           .orderBy('tags.tagKey')


### PR DESCRIPTION
## Problem

The All Notes screen intentionally omits daily notes in its unfiltered view, but tag filters should search the whole note graph. Tagged journal entries were therefore missing even when they carried the active tag.

Including those daily rows also exposed a deletion mismatch: All Notes selection offered bulk Trash for every visible row, while `deleteOpenNote` intentionally rejects `daily/*` paths. A selected daily note could enter the confirmation flow only to fail with “Daily notes cannot be deleted.”

## Before → After

| Behavior | Before | After |
| --- | --- | --- |
| Unfiltered All Notes | Regular notes only | Unchanged |
| Tag-filtered All Notes | Matching regular notes only | Matching regular and daily notes |
| Opening a tagged daily row | Not available | Opens the corresponding daily route |
| Trash with a daily-only selection | Confirmed, then failed | Trash is not offered and ⌘⌫ does not open the confirmation |
| Trash with regular-note selections | Sent notes to the system Trash | Unchanged |

## Changes

1. Expand the tag-filtered `listNotes` query and its tag-hydration join to accept both `note` and `daily` rows while leaving the unfiltered predicate unchanged.
2. Exercise the All Notes UI with a tagged daily fixture and verify that opening it navigates to `daily/:date`.
3. Derive bulk-trash targets from selected non-daily paths. Daily rows remain selectable for keyboard navigation, but they never reach the confirmation dialog or `deleteOpenNote`.
4. Update the All Notes and trash-hook documentation to describe the new boundary.

## Tests

- Core note-list coverage verifies that tag-filtered SQL includes both kinds and hydrates tags for daily results.
- All Notes screen coverage verifies tagged daily rendering and daily-route navigation.
- Bulk-trash coverage verifies that a selected tagged daily note exposes no Trash action, ⌘⌫ opens no confirmation, and no `note_delete` request is sent.
- Existing selection, successful bulk-trash, failure, partial-failure, and double-submit scenarios continue to pass.

## Verification

- `pnpm --filter @reflect/core exec vitest run src/indexing/note-list.test.ts` — 6 tests passed.
- `pnpm --filter @reflect/desktop exec vitest run src/components/all-notes/all-notes-screen.test.tsx` — 25 tests passed.
- `pnpm check` — typecheck and lint passed; lint reported only the two pre-existing max-file-length warnings.

## Risk / Rollout

Low risk and no migration or rollout step. The query change is limited to tag-filtered All Notes, and the deletion guard narrows an action that is already forbidden for daily notes.

------

[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e211e526483339ae699bc3f41ae48)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to tag-filtered listing and UI guards around an already-forbidden daily delete path; unfiltered All Notes behavior is unchanged.
> 
> **Overview**
> Tag-filtered **All Notes** now includes **daily** journal entries that carry the active tag, while the unfiltered list still shows only regular notes. Core `listNotes` widens the tag-filtered SQL (list + tag hydration) from `kind = 'note'` to `kind in ('note', 'daily')`.
> 
> On the desktop **All Notes** screen, bulk **Trash** and ⌘⌫ confirmation use only selected paths where `isDaily` is false—daily rows stay selectable for navigation but never open the delete flow or call `note_delete`. Tests cover tagged daily display, navigation to the daily route, and the trash guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c7812886d72a7fe44e8c9cba514880d69a49a61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tag-filtered All Notes now includes matching daily notes alongside regular notes.
  * Selecting a tagged daily note opens the corresponding daily note view.

* **Bug Fixes**
  * Daily notes now correctly show their tags in tag-filtered All Notes.
  * Daily notes are no longer available as bulk Trash targets, and the Trash confirmation reflects only trashable selections.

* **Tests**
  * Updated and added coverage to ensure tagged daily notes navigate correctly and can’t trigger bulk delete via keyboard actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->