### PR TITLE
fix: show tagged daily notes in all notes

### DIFF
--- a/apps/desktop/src/components/all-notes/all-notes-screen.test.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.test.tsx
@@ -70,9 +70,16 @@ const noteRows = [
     preview: 'Dandelion chocolate.',
   },
 ]
+const taggedDailyRow = {
+  path: 'daily/2026-06-09.md',
+  title: 'June 9, 2026',
+  mtime: TOKYO_MTIME,
+  preview: 'Daily travel notes.',
+}
 const tagRows = [
   { note_path: 'notes/health.md', tag: 'link' },
   { note_path: 'notes/tokyo.md', tag: 'link' },
+  { note_path: 'daily/2026-06-09.md', tag: 'travel' },
 ]
 const facetRows = [
   { tag: 'book', count: 3 },
@@ -101,7 +108,7 @@ beforeEach(() => {
       // A tag-filtered list starts from the folded tag key — only `travel`
       // has matches in this fixture.
       if (sql.includes('from "tags"')) {
-        return params.includes('travel') ? [noteRows[1]] : []
+        return params.includes('travel') ? [taggedDailyRow] : []
       }
       return noteRows
     }
@@ -364,12 +371,15 @@ describe('AllNotesScreen', () => {
     fireEvent.click(view.getByRole('option', { name: /#travel/ }))
 
     expect(probedRoute(view)).toEqual({ kind: 'allNotes', tag: 'travel' })
-    await view.findByText('Tokyo Gâteau')
+    await view.findByText('June 9, 2026')
+    expect(view.getByText('Daily travel notes.')).toBeDefined()
     expect(view.queryByText('Health Stacked')).toBeNull()
     // The trigger adopts the active custom tag.
     await waitFor(() =>
       expect(view.getByRole('button', { name: /#travel/, expanded: false })).toBeDefined(),
     )
+    fireEvent.click(view.getByRole('button', { name: 'June 9, 2026' }))
+    expect(probedRoute(view)).toEqual({ kind: 'daily', date: '2026-06-09' })
     view.unmount()
   })
 

--- a/apps/desktop/src/components/all-notes/all-notes-screen.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.tsx
@@ -27,7 +27,8 @@ interface AllNotesScreenProps {
  * The All Notes screen (a routed view, like settings): every non-daily note,
  * newest first, filterable by tag. The active tag lives on the route so
  * back/forward and "open a note, come back" keep the filter. Daily notes are
- * deliberately absent — the stream is their home.
+ * deliberately absent from the unfiltered view, but appear when they match the
+ * active tag.
  *
  * Rows are multi-selectable (V1 parity): click to select (⌘ toggle, Shift
  * range), the indicator gutter toggles, the subject or a double-click opens.

--- a/packages/core/src/indexing/note-list.test.ts
+++ b/packages/core/src/indexing/note-list.test.ts
@@ -94,7 +94,7 @@ describe('listNotes', () => {
     expect(tagArgs['params']).toEqual(['note'])
   })
 
-  it('narrows both queries to one tag via tag-first joins on the stored folded tag_key', async () => {
+  it('narrows both queries to one tag and includes tagged daily notes', async () => {
     mockInvoke
       .mockResolvedValueOnce([
         {
@@ -105,10 +105,21 @@ describe('listNotes', () => {
           is_pinned: 0,
           pinned_order: null,
         },
+        {
+          path: 'daily/2026-06-09.md',
+          title: 'June 9, 2026',
+          mtime: 1500,
+          preview: 'Read a book.',
+          is_pinned: 0,
+          pinned_order: null,
+        },
       ])
-      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ note_path: 'daily/2026-06-09.md', tag: 'Book' }])
 
-    await listNotes({ tag: 'Book' })
+    const entries = await listNotes({ tag: 'Book' })
+
+    expect(entries.map((entry) => entry.path)).toEqual(['notes/health.md', 'daily/2026-06-09.md'])
+    expect(entries[1]?.tags).toEqual(['Book'])
 
     expect(mockInvoke).toHaveBeenCalledTimes(2)
     const [, listArgs] = mockInvoke.mock.calls[0]!
@@ -118,7 +129,7 @@ describe('listNotes', () => {
     expect(listSql).toContain('"tags"."tag_key"')
     expect(listSql).not.toContain('exists')
     expect(listSql).not.toContain('lower(')
-    expect(listArgs['params']).toEqual(['book', 'note'])
+    expect(listArgs['params']).toEqual(['book', 'note', 'daily'])
 
     const [, tagArgs] = mockInvoke.mock.calls[1]!
     const tagSql = String(tagArgs['sql'])
@@ -126,7 +137,7 @@ describe('listNotes', () => {
     expect(tagSql).toContain('"filter_tags"."tag_key"')
     expect(tagSql).not.toContain('exists')
     expect(tagSql).not.toContain('lower(')
-    expect(tagArgs['params']).toEqual(['book', 'note'])
+    expect(tagArgs['params']).toEqual(['book', 'note', 'daily'])
   })
 
   it('skips the tag fetch entirely when no notes match', async () => {

--- a/packages/core/src/indexing/note-list.ts
+++ b/packages/core/src/indexing/note-list.ts
@@ -5,9 +5,9 @@ import { recallOrder } from './filtered-search'
 
 /**
  * The All Notes list: every regular note, pinned first then newest, optionally
- * narrowed to one tag. Daily notes are excluded by design — the stream is
- * their home — and templates are boilerplate, not graph content;
- * `kind = 'note'` expresses both (mirroring the original app's `isDaily = 0`).
+ * narrowed to one tag. The unfiltered list excludes daily notes — the stream is
+ * their home — but a tag filter includes tagged daily notes alongside regular
+ * notes. Templates remain boilerplate, not graph content.
  * Uncapped: the screen virtualizes, the row
  * snippet is the stored `preview` column (derived once at index time), and
  * neither query carries a per-row parameter, so list size has no SQL ceiling.
@@ -33,8 +33,10 @@ export interface NoteListOptions {
 }
 
 /**
- * Non-daily notes for the All Notes screen: pinned first (explicit pin order,
- * then unordered pins), then most recently edited — V1's list order.
+ * Notes for the All Notes screen: unfiltered lists include non-daily notes only;
+ * tag-filtered lists include both regular and daily notes carrying the tag.
+ * Pinned notes appear first (explicit pin order, then unordered pins), then most
+ * recently edited — V1's list order.
  */
 export async function listNotes(options: NoteListOptions = {}): Promise<NoteListEntry[]> {
   const tag = options.tag ?? null
@@ -56,7 +58,7 @@ export async function listNotes(options: NoteListOptions = {}): Promise<NoteList
           .selectFrom('tags')
           .innerJoin('notes', 'notes.path', 'tags.notePath')
           .where('tags.tagKey', '=', foldTag(tag))
-          .where('notes.kind', '=', 'note')
+          .where('notes.kind', 'in', ['note', 'daily'])
           .select([
             'notes.path',
             'notes.title',
@@ -94,7 +96,7 @@ export async function listNotes(options: NoteListOptions = {}): Promise<NoteList
           .innerJoin('notes', 'notes.path', 'tags.notePath')
           .innerJoin('tags as filterTags', 'filterTags.notePath', 'notes.path')
           .where('filterTags.tagKey', '=', foldTag(tag))
-          .where('notes.kind', '=', 'note')
+          .where('notes.kind', 'in', ['note', 'daily'])
           .select(['tags.notePath', 'tags.tag'])
           .distinct()
           .orderBy('tags.tagKey')


### PR DESCRIPTION
### Motivation
- The All Notes list intentionally omits daily notes in the unfiltered view, but when the user filters by a tag the list should include daily notes that carry that tag so tagged journal entries appear alongside regular notes. 

### Description
- Updated `listNotes` to include both `note` and `daily` rows when a `tag` is supplied by changing the SQL predicate to `notes.kind IN ('note','daily')` for the tag-filtered query. 
- Applied the same `in` predicate to the tag-fetch join so tag labels are populated for both regular and daily results. 
- Touched comments in `packages/core/src/indexing/note-list.ts` and clarified All Notes docstring in `apps/desktop/src/components/all-notes/all-notes-screen.tsx`. 
- Added/adjusted tests to cover the new behavior in `packages/core/src/indexing/note-list.test.ts` and `apps/desktop/src/components/all-notes/all-notes-screen.test.tsx`, including asserting a tagged daily row renders and opens via the daily route. 

### Testing
- Ran the core unit test that targets the change with `vitest` (`packages/core/src/indexing/note-list.test.ts`) and it passed. 
- Ran the desktop unit test that targets the All Notes UI (`apps/desktop/src/components/all-notes/all-notes-screen.test.tsx`) and it passed. 
- Ran `pnpm check` (typecheck + lint); typecheck passed and lint produced only existing warnings (file length), no new errors. 
- Note: a broad package-level test run initially surfaced an unrelated, environment-dependent failing test in the core AI suite; this was pre-existing and the targeted tests for this change passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e211e526483339ae699bc3f41ae48)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to tag-filtered list SQL and documentation; unfiltered behavior and facet counts are untouched.
> 
> **Overview**
> **Tag-filtered All Notes** now surfaces **daily journal entries** that carry the active tag, alongside regular notes. The **unfiltered** list is unchanged: it still shows only non-daily notes.
> 
> In **`listNotes`**, when a `tag` is set, both the main list query and the tag-label join use `notes.kind IN ('note', 'daily')` instead of restricting to `note` only. Comments on the All Notes screen describe this split behavior.
> 
> Tests assert SQL parameters include both kinds, that a tagged daily row appears under **#travel**, and that opening it navigates to the **daily** route for that date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2193e75a34087b2c2118f88096ac351852f115f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tag-filtered All Notes views now include matching daily notes.
  * Selecting a tagged daily note opens it directly on its daily-note page.

* **Bug Fixes**
  * Corrected tag results and metadata so tagged daily notes appear consistently in filtered lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->