### PR TITLE
fix: add Paste and Match Style (⌘⇧V) to the macOS Edit menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +762,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "color_quant"
@@ -1385,6 +1415,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,6 +1587,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1676,6 +1718,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1957,6 +2005,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3641,6 +3699,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -4019,6 +4078,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "osakit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4118,6 +4187,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "phf"
@@ -4767,6 +4847,7 @@ dependencies = [
  "sha2 0.11.0",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-http",
@@ -5981,6 +6062,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-deep-link"
 version = "2.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6792,6 +6888,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7203,6 +7310,76 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.13.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]
@@ -7900,6 +8077,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7969,6 +8164,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xattr"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -71,6 +71,9 @@ zip = { version = "4.6.1", default-features = false, features = ["deflate-flate2
 
 [target.'cfg(target_os = "macos")'.dependencies]
 xattr = "1.6.1"
+# Backs the Edit > "Paste and Match Style" menu handler's pasteboard read
+# (`src/menu.rs`); the webview never calls it, so it needs no capability.
+tauri-plugin-clipboard-manager = "2.3.2"
 # Apple Calendar read-only bridge (`src/calendar.rs`): EventKit through the
 # objc2 bindings, trimmed to the classes the module touches. objc2-app-kit is
 # only here for EKCalendar's NSColor → hex conversion.

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@
 //! [`skill`] (per-graph agent-skill install under `~/.agents/skills/`),
 //! [`calendar`] (read-only Apple Calendar access),
 //! [`contacts`] (live Apple Contacts lookups),
+//! [`menu`] (the macOS app menu, incl. Paste and Match Style),
 //! [`error`] (the shared error contract).
 
 mod background_task;
@@ -25,6 +26,8 @@ mod fs;
 mod git;
 mod graph_gitignore;
 mod icloud;
+#[cfg(target_os = "macos")]
+mod menu;
 mod quit;
 mod recents;
 mod secrets;
@@ -141,6 +144,17 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_http::init());
+
+    // The app menu is macOS-only (like Tauri's own default menu): the default
+    // set plus Edit > "Paste and Match Style", whose ⌘⇧V key equivalent is the
+    // only way WKWebView users get paste-without-formatting (menu.rs). The
+    // clipboard plugin backs its click handler's pasteboard read; the webview
+    // never talks to it, so no capability grant is needed.
+    #[cfg(target_os = "macos")]
+    let builder = builder
+        .plugin(tauri_plugin_clipboard_manager::init())
+        .menu(menu::build)
+        .on_menu_event(menu::on_menu_event);
 
     // Deep links (`reflect://`) are desktop-only for now: the scheme is
     // registered at bundle time (`plugins.deep-link` in tauri.conf.json) and

--- a/apps/desktop/src-tauri/src/menu.rs
+++ b/apps/desktop/src-tauri/src/menu.rs
@@ -1,0 +1,104 @@
+//! The macOS app menu: Tauri's default menu plus Edit > "Paste and Match
+//! Style" (⌘⇧V).
+//!
+//! WKWebView only performs the editing shortcuts that an app-menu key
+//! equivalent routes to it, and Tauri's default menu carries no
+//! paste-without-formatting item — so ⌘⇧V reached the webview as a bare
+//! keydown with no paste behind it and did nothing (the old Electron app bound
+//! the same accelerator to `pasteAndMatchStyle:`). There is no predefined
+//! Tauri item for it either, and the webview cannot read the pasteboard
+//! reliably itself (WebKit gates `navigator.clipboard`), so the click handler
+//! reads the pasteboard here and hands the plain text to the focused window,
+//! where the focused editor pastes it without formatting
+//! (`paste-and-match-style-bridge.tsx`).
+
+use tauri::menu::{Menu, MenuEvent, MenuItem, MenuItemKind, Submenu};
+use tauri::{AppHandle, Emitter, Manager};
+use tauri_plugin_clipboard_manager::ClipboardExt;
+
+/// Menu id of the "Paste and Match Style" item, matched in [`on_menu_event`].
+const PASTE_AND_MATCH_STYLE_ID: &str = "paste-and-match-style";
+
+/// Event carrying the pasteboard's plain text to the focused window. Consumed
+/// by `subscribePasteAndMatchStyle` (`@reflect/core`).
+const PASTE_AND_MATCH_STYLE_EVENT: &str = "menu:paste-and-match-style";
+
+/// Builds the app menu: Tauri's default with "Paste and Match Style" inserted
+/// after Edit > Paste. The default menu gives its Edit submenu no stable id,
+/// so it is matched by its (unlocalized) title; if an upstream change ever
+/// renames it, the app degrades to the stock menu rather than failing launch.
+pub fn build(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
+    let menu = Menu::default(app)?;
+
+    let Some(edit) = find_edit_submenu(&menu)? else {
+        tracing::warn!("no Edit submenu in the default menu; ⌘⇧V paste unavailable");
+        return Ok(menu);
+    };
+
+    let item = MenuItem::with_id(
+        app,
+        PASTE_AND_MATCH_STYLE_ID,
+        "Paste and Match Style",
+        true,
+        Some("CmdOrCtrl+Shift+V"),
+    )?;
+    match paste_item_position(&edit)? {
+        Some(position) => edit.insert(&item, position + 1)?,
+        None => edit.append(&item)?,
+    }
+
+    Ok(menu)
+}
+
+fn find_edit_submenu(menu: &Menu<tauri::Wry>) -> tauri::Result<Option<Submenu<tauri::Wry>>> {
+    for kind in menu.items()? {
+        if let MenuItemKind::Submenu(submenu) = kind {
+            if submenu.text()? == "Edit" {
+                return Ok(Some(submenu));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Index of the predefined Paste item inside the Edit submenu, so the new
+/// item lands directly under it like in every native Edit menu.
+fn paste_item_position(edit: &Submenu<tauri::Wry>) -> tauri::Result<Option<usize>> {
+    for (position, kind) in edit.items()?.iter().enumerate() {
+        if let MenuItemKind::Predefined(item) = kind {
+            if item.text()? == "Paste" {
+                return Ok(Some(position));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Routes "Paste and Match Style" clicks (menu or ⌘⇧V): read the pasteboard's
+/// plain text and target the focused window's webview with it. An empty or
+/// non-text pasteboard is a silent no-op, exactly like the native item in
+/// other apps.
+pub fn on_menu_event(app: &AppHandle, event: MenuEvent) {
+    if event.id().as_ref() != PASTE_AND_MATCH_STYLE_ID {
+        return;
+    }
+    let text = match app.clipboard().read_text() {
+        Ok(text) if !text.is_empty() => text,
+        Ok(_) => return,
+        Err(error) => {
+            tracing::debug!(%error, "pasteboard has no readable text");
+            return;
+        }
+    };
+    let Some(label) = app
+        .webview_windows()
+        .into_iter()
+        .find(|(_, window)| window.is_focused().unwrap_or(false))
+        .map(|(label, _)| label)
+    else {
+        return;
+    };
+    if let Err(error) = app.emit_to(&label, PASTE_AND_MATCH_STYLE_EVENT, text) {
+        tracing::warn!(%error, "forwarding Paste and Match Style failed");
+    }
+}

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -31,6 +31,7 @@ import {
 } from '@meowdown/react'
 import { EditorInputTraits } from '@/editor/editor-input-traits'
 import { FormattingToolbarBridge } from '@/editor/formatting-toolbar-bridge'
+import { PasteAndMatchStyleBridge } from '@/editor/paste-and-match-style-bridge'
 import {
   IMAGE_LIGHTBOX_TRANSITION_NAME,
   ImageLightbox,
@@ -434,6 +435,7 @@ export function NoteEditor({
       >
         <EditorInputTraits />
         <FormattingToolbarBridge />
+        <PasteAndMatchStyleBridge />
         {renderWikilinkHoverCard !== undefined ? (
           <WikilinkHoverCard className="reflect-hover-card">
             {renderWikilinkHoverCard}

--- a/apps/desktop/src/editor/paste-and-match-style-bridge.test.tsx
+++ b/apps/desktop/src/editor/paste-and-match-style-bridge.test.tsx
@@ -1,0 +1,96 @@
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setBridge, PASTE_AND_MATCH_STYLE_EVENT } from '@reflect/core'
+import { PasteAndMatchStyleBridge } from './paste-and-match-style-bridge'
+
+/** The stub ProseKit editor `useEditor` hands the bridge (see the mock below). */
+const editorStub = vi.hoisted(() => ({
+  mounted: true,
+  focused: true,
+  view: { pasteText: vi.fn() },
+}))
+
+vi.mock('@meowdown/react', () => ({
+  useEditor: () => editorStub,
+}))
+
+/** Handlers the fake bridge captured, keyed by event name. */
+let listeners: Map<string, (payload: unknown) => void>
+
+beforeEach(() => {
+  listeners = new Map()
+  editorStub.mounted = true
+  editorStub.focused = true
+  editorStub.view.pasteText.mockClear()
+  setBridge({
+    invoke: async () => null,
+    listen: async (event, handler) => {
+      listeners.set(event, handler)
+      return () => {
+        listeners.delete(event)
+      }
+    },
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  setBridge(null)
+})
+
+async function emitPasteAndMatchStyle(payload: unknown): Promise<void> {
+  await waitFor(() => {
+    expect(listeners.has(PASTE_AND_MATCH_STYLE_EVENT)).toBe(true)
+  })
+  listeners.get(PASTE_AND_MATCH_STYLE_EVENT)?.(payload)
+}
+
+describe('PasteAndMatchStyleBridge', () => {
+  it('pastes the shell-forwarded text into the focused editor as plain text', async () => {
+    render(<PasteAndMatchStyleBridge />)
+
+    await emitPasteAndMatchStyle('plain **text**')
+
+    expect(editorStub.view.pasteText).toHaveBeenCalledExactlyOnceWith('plain **text**')
+  })
+
+  it('ignores the event while this editor is not focused', async () => {
+    editorStub.focused = false
+    render(<PasteAndMatchStyleBridge />)
+
+    await emitPasteAndMatchStyle('plain text')
+
+    expect(editorStub.view.pasteText).not.toHaveBeenCalled()
+  })
+
+  it('ignores a malformed payload', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(<PasteAndMatchStyleBridge />)
+
+    await emitPasteAndMatchStyle({ nested: 'object' })
+
+    expect(editorStub.view.pasteText).not.toHaveBeenCalled()
+    expect(consoleError).toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+
+  it('unsubscribes on unmount', async () => {
+    const { unmount } = render(<PasteAndMatchStyleBridge />)
+    await waitFor(() => {
+      expect(listeners.has(PASTE_AND_MATCH_STYLE_EVENT)).toBe(true)
+    })
+
+    unmount()
+
+    await waitFor(() => {
+      expect(listeners.has(PASTE_AND_MATCH_STYLE_EVENT)).toBe(false)
+    })
+  })
+
+  it('does nothing without a native shell bridge', () => {
+    setBridge(null)
+    render(<PasteAndMatchStyleBridge />)
+
+    expect(listeners.size).toBe(0)
+  })
+})

--- a/apps/desktop/src/editor/paste-and-match-style-bridge.tsx
+++ b/apps/desktop/src/editor/paste-and-match-style-bridge.tsx
@@ -1,0 +1,36 @@
+import { useEffect } from 'react'
+import { useEditor } from '@meowdown/react'
+import type { EditorExtension } from '@meowdown/core'
+import { hasBridge, subscribePasteAndMatchStyle } from '@reflect/core'
+import { trackSubscriptions } from '@/lib/subscriptions'
+
+/**
+ * Runs the shell menu's Edit > "Paste and Match Style" (⌘⇧V) in this editor
+ * while it holds focus. The accelerator is an app-menu key equivalent, so the
+ * webview never sees the keystroke; the Rust handler reads the pasteboard and
+ * targets the focused window with the plain text (`menu.rs`), and the focused
+ * editor feeds it through `view.pasteText` — ProseMirror's plain-text paste
+ * path, the same one a browser Shift-paste takes. Mounted inside the editor's
+ * ProseKit context like `EditorInputTraits`; a no-op without a native shell.
+ */
+export function PasteAndMatchStyleBridge(): null {
+  const editor = useEditor<EditorExtension>()
+
+  useEffect(() => {
+    if (!hasBridge()) {
+      return
+    }
+    const tracker = trackSubscriptions()
+    void tracker.add(
+      subscribePasteAndMatchStyle((text) => {
+        if (!editor.mounted || !editor.focused) {
+          return
+        }
+        editor.view.pasteText(text)
+      }),
+    )
+    return () => tracker.disposeAll()
+  }, [editor])
+
+  return null
+}

--- a/packages/core/src/app/window-events.ts
+++ b/packages/core/src/app/window-events.ts
@@ -24,3 +24,23 @@ export function subscribeWindowNavigate(handler: (url: string) => void): Promise
     }
   })
 }
+
+/**
+ * Delivered to the focused window when Edit > "Paste and Match Style" (⌘⇧V)
+ * is invoked. The accelerator is an app-menu key equivalent, so the webview
+ * never sees the keystroke — the shell reads the pasteboard itself and hands
+ * the plain text over; the focused editor pastes it without formatting.
+ */
+export const PASTE_AND_MATCH_STYLE_EVENT = 'menu:paste-and-match-style'
+
+/** Subscribe to the shell menu's plain-text paste requests. */
+export function subscribePasteAndMatchStyle(handler: (text: string) => void): Promise<Unlisten> {
+  return getBridge().listen(PASTE_AND_MATCH_STYLE_EVENT, (payload) => {
+    const parsed = z.string().safeParse(payload)
+    if (parsed.success) {
+      handler(parsed.data)
+    } else {
+      console.error('invalid menu:paste-and-match-style payload:', parsed.error)
+    }
+  })
+}

--- a/packages/core/src/exports/platform.ts
+++ b/packages/core/src/exports/platform.ts
@@ -27,7 +27,12 @@ export {
   endBackgroundTask,
   type BackgroundTaskToken,
 } from '../app/background-task'
-export { WINDOW_NAVIGATE_EVENT, subscribeWindowNavigate } from '../app/window-events'
+export {
+  WINDOW_NAVIGATE_EVENT,
+  PASTE_AND_MATCH_STYLE_EVENT,
+  subscribeWindowNavigate,
+  subscribePasteAndMatchStyle,
+} from '../app/window-events'
 export { toggleDevtools } from '../app/devtools'
 export {
   agentSkillStatus,


### PR DESCRIPTION
## Problem

⌘⇧V (paste without formatting) does nothing in the mac app. The app uses Tauri's default macOS menu, which has no "Paste and Match Style" item — and WKWebView only performs editing shortcuts that an app-menu key equivalent routes to it, so the keystroke reaches the webview as a bare keydown with no paste behind it. The old Electron app bound the same accelerator to `pasteAndMatchStyle:` (reflect-electron `src/menu.ts`), which is why this worked in traditional Reflect.

## Changes

**Rust (`src-tauri`)**
- New `menu.rs` (macOS-only): builds Tauri's default menu and inserts "Paste and Match Style" (`CmdOrCtrl+Shift+V`) directly under Edit > Paste. The default Edit submenu has no stable id, so it's matched by title with a warn-and-degrade fallback to the stock menu.
- The click handler reads the pasteboard via `tauri-plugin-clipboard-manager` (registered macOS-only, used Rust-side only — no webview capability grant) and `emit_to`s the focused window with the text (`menu:paste-and-match-style`).

**Frontend**
- `@reflect/core`: `PASTE_AND_MATCH_STYLE_EVENT` + `subscribePasteAndMatchStyle` in `app/window-events.ts` (zod-validated payload, same shape as `subscribeWindowNavigate`).
- New `PasteAndMatchStyleBridge`, mounted inside every `NoteEditor`'s ProseKit context (like `EditorInputTraits`): the focused editor runs the text through `view.pasteText` — ProseMirror's plain-text paste path, the exact one a browser Shift-paste takes. Covers note panes, the daily stream, and the task editor; a no-op without a native shell.

## Why not `editor.commands.pastePlainText`

meowdown [PR #342](https://github.com/prosekit/meowdown/pull/342) adds a `pastePlainText` command plus an in-editor ⌘⇧V clipboard-read fallback, but it isn't released yet (and this repo pins `@meowdown/*` 0.46). `view.pasteText` is the same code path that command wraps and exists in every meowdown version, so this fix doesn't need the bump. When meowdown is next bumped past 0.55.1, its in-editor fallback also becomes a second layer of coverage.

## Testing

- New `paste-and-match-style-bridge.test.tsx`: pastes on the event, ignores it when unfocused, rejects malformed payloads, unsubscribes on unmount, no-ops without a bridge.
- `pnpm check` (typecheck + lint) green; desktop editor tests green; `cargo check`, `cargo clippy`, and `cargo test -p reflect-open` green.
- Not yet verified in a built app bundle — reviewers should confirm in `pnpm tauri:dev`: ⌘⇧V pastes clipboard text without formatting, plain ⌘V still pastes with formatting, and the Edit menu shows the item under Paste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> macOS-only menu/clipboard wiring with graceful fallback if the Edit submenu is missing; no auth or data-model changes, and clipboard is read only on explicit user menu/shortcut.
> 
> **Overview**
> Restores **paste without formatting** on macOS by wiring ⌘⇧V through the native app menu instead of relying on WKWebView, which never received a menu key equivalent for that shortcut.
> 
> On **Rust (macOS only)**, the shell registers `tauri-plugin-clipboard-manager`, builds Tauri’s default menu with a new **Edit → Paste and Match Style** item (`CmdOrCtrl+Shift+V`) under Paste, reads plain text from the pasteboard on activation, and `emit_to`s the focused window on `menu:paste-and-match-style`. Clipboard access stays in the shell (no webview capability).
> 
> **`@reflect/core`** adds `PASTE_AND_MATCH_STYLE_EVENT` and zod-validated `subscribePasteAndMatchStyle`. **`PasteAndMatchStyleBridge`** listens in each `NoteEditor` and calls `view.pasteText` only when that editor is focused; tests cover focus, bad payloads, unsubscribe, and no bridge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46e5b76582426d32e3b3f1039b20eb75ac9aec8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->