### PR TITLE
fix: focus daily notes from their date heading

### DIFF
--- a/apps/desktop/src/components/daily-stream.focus.test.tsx
+++ b/apps/desktop/src/components/daily-stream.focus.test.tsx
@@ -1,7 +1,8 @@
 import { act, fireEvent, render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useEffect } from 'react'
-import { todayIso } from '@/lib/dates'
+import { formatDayLabel, todayIso } from '@/lib/dates'
 import { RouterProvider, useRouter, type NavigateOptions } from '@/routing/router'
 import type { Route } from '@/routing/route'
 import { installVirtuaTestEnv } from '@/test-utils/virtua-jsdom'
@@ -12,8 +13,9 @@ import { DailyStream, ESTIMATED_DAY_HEIGHT } from './daily-stream'
  * target day, and only a capture arrival — `navigate(..., { focusEditor:
  * true })`, i.e. ⌘D or the sidebar's Daily notes row — asks for the caret at
  * the *end* of the day's content (append semantics, mobile double-tap
- * parity). NotePane is replaced by a probe that just reports the focus props
- * it was handed; the real mount-and-focus mechanics live in NotePane.
+ * parity). NotePane is replaced by a probe that reports the focus props it was
+ * handed and mirrors its register-then-autofocus ordering without mounting a
+ * real editor.
  *
  * Each test navigates *before* the target row exists and only then lets
  * virtua render it, mirroring the real sequence (the arrival's imperative
@@ -21,24 +23,78 @@ import { DailyStream, ESTIMATED_DAY_HEIGHT } from './daily-stream'
  * focus assignment as it mounts).
  */
 
-vi.mock('@/components/note-pane', () => ({
-  NotePane: ({
-    dailyDate,
-    autoFocus = false,
-    autoFocusSelection = 'start',
-  }: {
-    dailyDate?: string
-    autoFocus?: boolean
-    autoFocusSelection?: 'start' | 'end'
-  }) => (
-    <div
-      data-testid="pane-probe"
-      data-date={dailyDate}
-      data-autofocus={String(autoFocus)}
-      data-selection={autoFocusSelection}
-    />
-  ),
+const editorProbe = vi.hoisted(() => ({
+  calls: [] as Array<'focus' | 'start' | 'end'>,
+  deferRegistration: false,
+  pendingRegistrations: new Map<string, () => void>(),
 }))
+
+vi.mock('@/components/note-pane', async () => {
+  const { useEffect } = await import('react')
+  return {
+    NotePane: ({
+      dailyDate,
+      autoFocus = false,
+      autoFocusSelection = 'start',
+      registerHandle,
+    }: {
+      dailyDate?: string
+      autoFocus?: boolean
+      autoFocusSelection?: 'start' | 'end'
+      registerHandle?: (
+        date: string,
+        handle: {
+          focus: () => void
+          setSelection: (position: 'start' | 'end') => void
+        } | null,
+      ) => void
+    }) => {
+      useEffect(() => {
+        if (dailyDate === undefined || registerHandle === undefined) {
+          return
+        }
+        const handle = {
+          focus: () => editorProbe.calls.push('focus'),
+          setSelection: (position: 'start' | 'end') => editorProbe.calls.push(position),
+        }
+        let registered = false
+        const register = (): void => {
+          registered = true
+          registerHandle(dailyDate, handle)
+          // Mirror NotePane's real callback order: stream registration first,
+          // then the autofocus props captured while the document was loading.
+          if (autoFocus) {
+            handle.focus()
+            if (autoFocusSelection === 'end') {
+              handle.setSelection('end')
+            }
+          }
+        }
+        if (editorProbe.deferRegistration) {
+          editorProbe.pendingRegistrations.set(dailyDate, register)
+        } else {
+          register()
+        }
+        return () => {
+          if (editorProbe.pendingRegistrations.get(dailyDate) === register) {
+            editorProbe.pendingRegistrations.delete(dailyDate)
+          }
+          if (registered) {
+            registerHandle(dailyDate, null)
+          }
+        }
+      }, [dailyDate, autoFocus, autoFocusSelection, registerHandle])
+      return (
+        <div
+          data-testid="pane-probe"
+          data-date={dailyDate}
+          data-autofocus={String(autoFocus)}
+          data-selection={autoFocusSelection}
+        />
+      )
+    },
+  }
+})
 vi.mock('@/providers/settings-provider', () => ({
   useSettings: () => ({
     settings: { dateFormat: 'mdy' },
@@ -67,6 +123,9 @@ Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
 
 beforeEach(() => {
   scrollTop = 0
+  editorProbe.calls.length = 0
+  editorProbe.deferRegistration = false
+  editorProbe.pendingRegistrations.clear()
 })
 
 type Navigate = (route: Route, options?: NavigateOptions) => void
@@ -138,6 +197,43 @@ describe('DailyStream arrival focus', () => {
     const pane = paneFor(today)
     expect(pane?.getAttribute('data-autofocus')).toBe('true')
     expect(pane?.getAttribute('data-selection')).toBe('start')
+    view.unmount()
+  })
+})
+
+describe('DailyStream date focus', () => {
+  it('focuses the daily editor with its caret at the start when the date is clicked', async () => {
+    const user = userEvent.setup()
+    const today = todayIso()
+    const { view, anchored } = renderStream()
+    await anchored(today)
+    editorProbe.calls.length = 0
+
+    await user.click(view.getByRole('button', { name: formatDayLabel(today, 'mdy') }))
+
+    expect(editorProbe.calls).toEqual(['focus', 'start'])
+    view.unmount()
+  })
+
+  it('overrides a stale capture autofocus when the lazy editor registers', async () => {
+    const user = userEvent.setup()
+    const today = todayIso()
+    editorProbe.deferRegistration = true
+    const { view, navigate, anchored, paneFor } = renderStream()
+
+    act(() => navigate({ kind: 'today' }, { focusEditor: true }))
+    await anchored(today)
+    expect(paneFor(today)?.getAttribute('data-selection')).toBe('end')
+
+    await user.click(view.getByRole('button', { name: formatDayLabel(today, 'mdy') }))
+    expect(editorProbe.calls).toEqual([])
+    expect(paneFor(today)?.getAttribute('data-autofocus')).toBe('false')
+
+    const register = editorProbe.pendingRegistrations.get(today)
+    expect(register).toBeDefined()
+    act(() => register?.())
+
+    expect(editorProbe.calls).toEqual(['focus', 'start'])
     view.unmount()
   })
 })

--- a/apps/desktop/src/components/daily-stream.tsx
+++ b/apps/desktop/src/components/daily-stream.tsx
@@ -83,6 +83,9 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
   // render time), so a virtualizer re-render before the lazy load completes
   // can't drop the focus.
   const focusPending = useRef<{ date: string; selection: 'start' | 'end' } | null>(null)
+  const focusArrivalKey = `${entryId}:${arrivalSeq}`
+  const [cancelledFocusArrivalKey, setCancelledFocusArrivalKey] = useState<string | null>(null)
+  const focusArrivalCancelled = cancelledFocusArrivalKey === focusArrivalKey
   const consumeFocus = useCallback(() => {
     focusPending.current = null
   }, [])
@@ -106,6 +109,28 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
     // meowdown's setSelection also scrolls the caret into view.
     handle.setSelection(position)
   }, [])
+
+  const focusDayAtStart = useCallback(
+    (date: string) => {
+      // Date activation is an explicit focus target, including from the
+      // keyboard, so it supersedes any arrival or boundary focus still queued.
+      focusPending.current = null
+      pendingFocusRef.current = null
+      // The target NotePane may already have rendered the old arrival intent
+      // while its document was loading. Re-render that captured autofocus off
+      // so it cannot override this newer start selection when the editor mounts.
+      setCancelledFocusArrivalKey(focusArrivalKey)
+      const handle = dayHandlesRef.current.get(date)
+      if (handle !== undefined) {
+        focusDay(handle, 'start')
+        return
+      }
+      // The date chrome renders before its lazy editor may be ready. Keep the
+      // request until the pane registers instead of dropping an early click.
+      pendingFocusRef.current = { date, position: 'start' }
+    },
+    [focusArrivalKey, focusDay],
+  )
 
   const registerHandle = useCallback(
     (date: string, handle: NoteEditorHandle | null) => {
@@ -208,7 +233,9 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
           const isPast = date < today
           const pendingFocus = focusPending.current
           const focusSelection =
-            pendingFocus !== null && pendingFocus.date === date ? pendingFocus.selection : null
+            !focusArrivalCancelled && pendingFocus !== null && pendingFocus.date === date
+              ? pendingFocus.selection
+              : null
           const autoFocus = focusSelection !== null
           return (
             <section
@@ -221,10 +248,18 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
             >
               {/* V1 renders the date as the note's H1-sized subject, with
                   today's tinted brand (its `highlightSubject`). */}
-              <h2
-                className={cn('reflect-daily-subject mb-3', CONTENT_GUTTER, isToday && 'text-accent')}
-              >
-                {formatDayLabel(date, settings.dateFormat)}
+              <h2 className="mb-3">
+                <button
+                  type="button"
+                  className={cn(
+                    'reflect-daily-subject block w-full cursor-text text-left focus-visible:underline focus-visible:outline-none',
+                    CONTENT_GUTTER,
+                    isToday && 'text-accent',
+                  )}
+                  onClick={() => focusDayAtStart(date)}
+                >
+                  {formatDayLabel(date, settings.dateFormat)}
+                </button>
               </h2>
               <NotePane
                 path={dailyPath(date)}


### PR DESCRIPTION
## Problem

The date above each editor in the desktop daily stream was inert. Clicking it did not focus that day or move the caret to the beginning, even though the date acts as the daily note subject.

A click made while the lazy editor was still loading also needs to supersede any capture arrival that was waiting to put the caret at the end.

## Before → After

| Before | After |
| --- | --- |
| The date was a plain heading with no interaction. | Activating the date focuses its daily editor and places the caret at the document start. |
| An early click could be lost while the editor loaded. | The focus request is queued until the day handle registers and overrides stale arrival autofocus. |

## Changes

1. Render each desktop daily-stream date as a native, text-styled button.
2. Reuse the registered `NoteEditorHandle` to focus the editor and select the document start, with a pending request for lazy editors.
3. Invalidate the current arrival autofocus when the date is activated so an older append-to-end intent cannot win after loading.
4. Extend the daily focus harness to cover both mounted editors and the delayed capture-autofocus race.

## Verification

- `pnpm --filter @reflect/desktop exec vitest run src/components/daily-stream.focus.test.tsx src/components/daily-stream.test.tsx src/components/route-content.test.tsx` — 20 tests passed.
- `pnpm check` — typecheck and lint passed; only the existing max-file-length warnings remain.
- `pnpm build` — production build passed; expected local Sentry-token and bundle-size warnings remain.

## Risk / Rollout

Low-risk desktop interaction change with no data, schema, sync, or migration impact. Mobile day headings and secondary note-window headings are intentionally unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop-only focus/UI behavior in the daily stream; no data, sync, or auth changes.
> 
> **Overview**
> Makes each daily-stream **date heading** an interactive control that focuses that day’s editor and places the caret at the **start** of the note.
> 
> The heading is now a text-styled **button** wired to `focusDayAtStart`, which uses the registered editor handle when mounted or queues focus via the existing `pendingFocusRef` path when the lazy `NotePane` is still loading. Clicking the date also **clears** queued arrival/boundary focus and sets `cancelledFocusArrivalKey` so a pending capture arrival (⌘D / append-at-end) cannot win once the user explicitly chose the date.
> 
> Focus tests gain a richer `NotePane` probe (register-then-autofocus ordering, deferrable registration) plus cases for date click and the stale capture-autofocus race.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f45c0585975438943d876b445d5d3066b087cd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->