### PR TITLE
fix: clicking a daily note's date heading focuses the note

### DIFF
--- a/apps/desktop/src/components/daily-stream.focus.test.tsx
+++ b/apps/desktop/src/components/daily-stream.focus.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useEffect } from 'react'
 import { todayIso } from '@/lib/dates'
+import { createDayWindow, neighborDate } from '@/lib/day-window'
 import { RouterProvider, useRouter, type NavigateOptions } from '@/routing/router'
 import type { Route } from '@/routing/route'
 import { installVirtuaTestEnv } from '@/test-utils/virtua-jsdom'
@@ -21,23 +22,63 @@ import { DailyStream, ESTIMATED_DAY_HEIGHT } from './daily-stream'
  * focus assignment as it mounts).
  */
 
+/**
+ * Focus/selection calls the probe's registered handles receive, as
+ * `"<method>:<date>[:<arg>]"` — hoisted so the NotePane mock factory can
+ * reach it.
+ */
+const focusLog = vi.hoisted(() => ({ calls: [] as string[] }))
+
 vi.mock('@/components/note-pane', () => ({
   NotePane: ({
     dailyDate,
     autoFocus = false,
     autoFocusSelection = 'start',
+    registerHandle,
   }: {
     dailyDate?: string
     autoFocus?: boolean
     autoFocusSelection?: 'start' | 'end'
-  }) => (
-    <div
-      data-testid="pane-probe"
-      data-date={dailyDate}
-      data-autofocus={String(autoFocus)}
-      data-selection={autoFocusSelection}
-    />
-  ),
+    registerHandle?: (
+      date: string,
+      handle: import('@/editor/note-editor').NoteEditorHandle | null,
+    ) => void
+  }) => {
+    // Register a recording handle like the real pane's mounted editor would,
+    // so the stream's imperative focus paths (heading click, cross-day arrow
+    // navigation) are observable.
+    useEffect(() => {
+      if (dailyDate === undefined || registerHandle === undefined) {
+        return
+      }
+      registerHandle(dailyDate, {
+        getMarkdown: () => '',
+        setMarkdown: () => {},
+        insertMarkdown: () => {},
+        focus: () => {
+          focusLog.calls.push(`focus:${dailyDate}`)
+        },
+        setSelection: (position: 'start' | 'end') => {
+          focusLog.calls.push(`setSelection:${dailyDate}:${position}`)
+        },
+        getSelectedText: () => '',
+        openSelectionMenu: () => {},
+        startPendingReplacement: () => false,
+        appendPendingReplacementText: () => {},
+        acceptPendingReplacement: () => {},
+        discardPendingReplacement: () => {},
+      })
+      return () => registerHandle(dailyDate, null)
+    }, [dailyDate, registerHandle])
+    return (
+      <div
+        data-testid="pane-probe"
+        data-date={dailyDate}
+        data-autofocus={String(autoFocus)}
+        data-selection={autoFocusSelection}
+      />
+    )
+  },
 }))
 vi.mock('@/providers/settings-provider', () => ({
   useSettings: () => ({
@@ -67,6 +108,7 @@ Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
 
 beforeEach(() => {
   scrollTop = 0
+  focusLog.calls.length = 0
 })
 
 type Navigate = (route: Route, options?: NavigateOptions) => void
@@ -122,6 +164,46 @@ describe('DailyStream arrival focus', () => {
     const pane = paneFor(today)
     expect(pane?.getAttribute('data-autofocus')).toBe('true')
     expect(pane?.getAttribute('data-selection')).toBe('end')
+    view.unmount()
+  })
+
+  it('clicking a day’s date heading focuses that day’s note at its start', async () => {
+    const today = todayIso()
+    const yesterday = neighborDate(createDayWindow(today), today, -1)
+    expect(yesterday).not.toBeNull()
+    const { view, anchored, paneFor } = renderStream()
+    await anchored(today)
+    await waitFor(() => expect(paneFor(yesterday!)).not.toBeNull())
+    focusLog.calls.length = 0
+
+    const heading = paneFor(yesterday!)?.closest('section')?.querySelector('h2')
+    expect(heading).not.toBeNull()
+    fireEvent.click(heading!)
+
+    expect(focusLog.calls).toEqual([
+      `focus:${yesterday}`,
+      `setSelection:${yesterday}:start`,
+    ])
+    view.unmount()
+  })
+
+  it('a drag-selection over the date text does not steal focus on click', async () => {
+    const today = todayIso()
+    const { view, anchored, paneFor } = renderStream()
+    await anchored(today)
+    focusLog.calls.length = 0
+
+    const heading = paneFor(today)?.closest('section')?.querySelector('h2')
+    expect(heading).not.toBeNull()
+    const range = document.createRange()
+    range.selectNodeContents(heading!)
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    fireEvent.click(heading!)
+
+    expect(focusLog.calls).toEqual([])
+    selection?.removeAllRanges()
     view.unmount()
   })
 

--- a/apps/desktop/src/components/daily-stream.focus.test.tsx
+++ b/apps/desktop/src/components/daily-stream.focus.test.tsx
@@ -187,7 +187,10 @@ describe('DailyStream arrival focus', () => {
     view.unmount()
   })
 
-  it('a drag-selection over the date text does not steal focus on click', async () => {
+  it('a heading click focuses even while a selection stands elsewhere', async () => {
+    // The heading is unselectable chrome (`user-select: none`), so mousedown
+    // on it leaves an editor selection uncollapsed — the click must still
+    // focus rather than treating the stale selection as a copy gesture.
     const today = todayIso()
     const { view, anchored, paneFor } = renderStream()
     await anchored(today)
@@ -202,7 +205,7 @@ describe('DailyStream arrival focus', () => {
     selection?.addRange(range)
     fireEvent.click(heading!)
 
-    expect(focusLog.calls).toEqual([])
+    expect(focusLog.calls).toEqual([`focus:${today}`, `setSelection:${today}:start`])
     selection?.removeAllRanges()
     view.unmount()
   })

--- a/apps/desktop/src/components/daily-stream.tsx
+++ b/apps/desktop/src/components/daily-stream.tsx
@@ -130,12 +130,10 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
   // area via the full-width content gutter.
   const handleSubjectClick = useCallback(
     (date: string) => {
-      // A drag-select across the date text is a copy gesture, not a focus
-      // request — stealing the caret would dissolve the selection.
-      const selection = window.getSelection()
-      if (selection !== null && !selection.isCollapsed) {
-        return
-      }
+      // No selection guard: the heading is unselectable chrome (the global
+      // `user-select: none`), so there is no copy gesture to protect — and
+      // mousedown on unselectable chrome leaves an editor selection standing,
+      // so gating on `getSelection()` would swallow exactly these clicks.
       const mounted = dayHandlesRef.current.get(date)
       if (mounted) {
         focusDay(mounted, 'start')

--- a/apps/desktop/src/components/daily-stream.tsx
+++ b/apps/desktop/src/components/daily-stream.tsx
@@ -123,6 +123,32 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
     [focusDay],
   )
 
+  // The date heading is stream chrome outside the editor, so a click on it
+  // would otherwise land nowhere; make it focus that day's note at the top.
+  // The listener lives on the H2 itself rather than section-level hit-testing:
+  // every other part of the row already belongs to the editor's click-to-focus
+  // area via the full-width content gutter.
+  const handleSubjectClick = useCallback(
+    (date: string) => {
+      // A drag-select across the date text is a copy gesture, not a focus
+      // request — stealing the caret would dissolve the selection.
+      const selection = window.getSelection()
+      if (selection !== null && !selection.isCollapsed) {
+        return
+      }
+      const mounted = dayHandlesRef.current.get(date)
+      if (mounted) {
+        focusDay(mounted, 'start')
+        return
+      }
+      // The row is on screen but its lazy editor hasn't mounted yet: queue the
+      // focus for `registerHandle`. Set after the container's pointerdown
+      // clear (click fires on pointerup), so the slot survives to the mount.
+      pendingFocusRef.current = { date, position: 'start' }
+    },
+    [focusDay],
+  )
+
   const handleExitBoundary = useCallback(
     (date: string, direction: 'up' | 'down'): boolean => {
       const target = neighborDate(dayWindow, date, direction === 'up' ? -1 : 1)
@@ -223,6 +249,7 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
                   today's tinted brand (its `highlightSubject`). */}
               <h2
                 className={cn('reflect-daily-subject mb-3', CONTENT_GUTTER, isToday && 'text-accent')}
+                onClick={() => handleSubjectClick(date)}
               >
                 {formatDayLabel(date, settings.dateFormat)}
               </h2>


### PR DESCRIPTION
## Problem

In the daily stream, clicking a day's date heading did nothing. The heading is stream chrome rendered outside the editor, so unlike the rest of a day's row — where the full-width content gutter makes any click land in the editor — a click on the date silently fell through. The natural expectation is that clicking a day's date puts you in that day's note, at the top.

## Before -> After

| Action | Before | After |
| --- | --- | --- |
| Click a day's date heading | Nothing happens | That day's editor is focused with the caret at the note's start |
| Click the heading while text is selected in an editor | Nothing happens | Focus moves to the day's note start (the selection was going to be replaced by any focus move anyway) |

## Changes

1. **`daily-stream.tsx`** — a new `handleSubjectClick` wired to each row's `<h2>`. The listener is on the heading itself rather than section-level hit-testing: every other part of the row already belongs to the editor's click-to-focus area via the `reflect-content-gutter`, so the heading was the only dead zone. The handler reuses the stream's existing imperative-focus machinery:
   - If the day's editor handle is registered (`dayHandlesRef`), it focuses immediately via `focusDay(handle, 'start')` — the same path cross-day arrow navigation uses.
   - If the row's lazy editor hasn't mounted yet, the request is queued in `pendingFocusRef` and applied by `registerHandle` on mount. The queue survives because the container's `onPointerDownCapture` clear runs at pointerdown, while `click` fires after pointerup.
   - Deliberately **no** `getSelection()` guard: the heading is unselectable chrome (the app's global `user-select: none`), so there is no date-text copy gesture to protect — and since mousedown on unselectable chrome leaves an editor selection standing, such a guard would swallow exactly these clicks.

## Tests

`daily-stream.focus.test.tsx`:
- The `NotePane` probe mock now registers a recording `NoteEditorHandle` (mirroring the `mobile-screen.test.tsx` fake), making the stream's imperative focus paths observable.
- New: clicking a neighboring day's heading focuses **that** day at `start` (not the routed day).
- New: a heading click still focuses while a non-collapsed selection stands elsewhere in the document (pins the no-selection-guard decision).

## Verification

- `pnpm test --run src/components/daily-stream.focus.test.tsx src/components/daily-stream.test.tsx` — 9 passed.
- `pnpm check` (typecheck + lint) — clean; only the two pre-existing `max-lines` warnings.
- Not exercised in the running app; behavior is pinned by the unit tests above.

## Risk / Rollout

Desktop daily stream only (the mobile daily surface has its own tree and is untouched). No data or persistence changes; worst case is an unwanted focus move on heading clicks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
