### PR TITLE
feat: show backlinks on daily notes that have no file yet

### DIFF
--- a/packages/core/src/indexing/queries-backlinks.test.ts
+++ b/packages/core/src/indexing/queries-backlinks.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setBridge } from '../ipc/bridge'
+import { getBacklinks, getBacklinksWithContext } from './queries-backlinks'
+
+const mockInvoke = vi.fn<(command: string, args: Record<string, unknown>) => Promise<unknown>>()
+
+beforeEach(() => {
+  mockInvoke.mockReset()
+  setBridge({ invoke: mockInvoke, listen: async () => () => {} })
+})
+
+afterEach(() => {
+  setBridge(null)
+})
+
+/** The bridge calls made so far, as `[sql, params]` pairs. */
+function queries(): Array<[string, unknown[]]> {
+  return mockInvoke.mock.calls.map(([command, args]) => {
+    expect(command).toBe('db_query')
+    return [String(args['sql']), args['params'] as unknown[]]
+  })
+}
+
+describe('getBacklinks', () => {
+  it('resolves a daily with no file yet through its path-derived date key', async () => {
+    // note_keys has nothing for the absent daily; the links query still runs.
+    mockInvoke.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      {
+        source_path: 'daily/2026-07-16.md',
+        target_raw: '2026-07-29',
+        alias: null,
+        pos_from: 10,
+        pos_to: 24,
+      },
+    ])
+
+    const backlinks = await getBacklinks('daily/2026-07-29.md')
+
+    const [keysQuery, linksQuery] = queries()
+    expect(keysQuery?.[0]).toContain('"note_keys"')
+    expect(keysQuery?.[1]).toEqual(['daily/2026-07-29.md'])
+    expect(linksQuery?.[0]).toContain('from "links"')
+    expect(linksQuery?.[0]).toContain('"links"."target_key" in')
+    // Template sources never surface as backlinks (the view's guarantee, kept).
+    expect(linksQuery?.[0]).toContain('"notes"."kind" !=')
+    expect(linksQuery?.[1]).toEqual(['wiki', '2026-07-29', 'template'])
+    expect(backlinks).toEqual([
+      {
+        sourcePath: 'daily/2026-07-16.md',
+        targetRaw: '2026-07-29',
+        alias: null,
+        posFrom: 10,
+        posTo: 24,
+      },
+    ])
+  })
+
+  it('combines note_keys spellings with the daily date key', async () => {
+    mockInvoke
+      .mockResolvedValueOnce([{ key: '2026-07-29' }, { key: 'release day' }])
+      .mockResolvedValueOnce([])
+
+    await getBacklinks('daily/2026-07-29.md')
+
+    const [, linksQuery] = queries()
+    expect(linksQuery?.[1]).toEqual(['wiki', '2026-07-29', 'release day', 'template'])
+  })
+
+  it('returns empty without a links query when nothing resolves to the path', async () => {
+    mockInvoke.mockResolvedValueOnce([])
+
+    await expect(getBacklinks('notes/does-not-exist.md')).resolves.toEqual([])
+    expect(mockInvoke).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('getBacklinksWithContext', () => {
+  it('rejects a non-positive page limit', async () => {
+    await expect(
+      getBacklinksWithContext('daily/2026-07-29.md', { limit: 0, cursor: null }),
+    ).rejects.toThrow(RangeError)
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it('short-circuits to an empty page when nothing resolves to the path', async () => {
+    mockInvoke.mockResolvedValueOnce([])
+
+    await expect(
+      getBacklinksWithContext('notes/does-not-exist.md', { limit: 10, cursor: null }),
+    ).resolves.toEqual({ contexts: [], nextCursor: null, indexedLinkCount: 0 })
+    expect(mockInvoke).toHaveBeenCalledTimes(1)
+  })
+
+  it('pages an absent daily through the links table, not the backlinks view', async () => {
+    mockInvoke
+      // note_keys: the daily has no file, so no rows.
+      .mockResolvedValueOnce([])
+      // source page query and count query (Promise.all order).
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ count: 0 }])
+
+    const page = await getBacklinksWithContext('daily/2026-07-29.md', {
+      limit: 10,
+      cursor: null,
+    })
+
+    expect(page).toEqual({ contexts: [], nextCursor: null, indexedLinkCount: 0 })
+    const linkQueries = queries().slice(1)
+    expect(linkQueries).toHaveLength(2)
+    for (const [sqlText, params] of linkQueries) {
+      expect(sqlText).toContain('from "links"')
+      expect(sqlText).not.toContain('"backlinks"')
+      expect(params).toContain('2026-07-29')
+    }
+  })
+})

--- a/packages/core/src/indexing/queries-backlinks.ts
+++ b/packages/core/src/indexing/queries-backlinks.ts
@@ -1,6 +1,7 @@
 import type { Database } from '@reflect/db'
 import { sql, type Selectable } from 'kysely'
 import { readNote } from '../graph/commands'
+import { dateFromDailyPath } from '../graph/paths'
 import { blockContextLinesAt, prepareBlockContext, type BlockContextSource } from './block-context'
 import { db } from './db'
 import { extractSnippetTasks, type SnippetTask } from './snippet-tasks'
@@ -10,13 +11,56 @@ export type Backlink = Pick<
   'sourcePath' | 'targetRaw' | 'alias' | 'posFrom' | 'posTo'
 >
 
-/** Notes that link to `path` (resolved at query time via the `backlinks` view). */
-export function getBacklinks(path: string): Promise<Backlink[]> {
+/**
+ * Every index key that resolves to `path`: its `note_keys` rows (title,
+ * aliases, daily date) plus, for a daily path, the date derived from the path
+ * itself. The derived date is what lets links to a daily that has no file yet
+ * (a future date carrying reminders) resolve — the `backlinks` view can't
+ * serve those, because its `note_keys` join requires an indexed target note.
+ */
+async function targetKeysFor(path: string): Promise<string[]> {
+  const keys = new Set(
+    (await db.selectFrom('noteKeys').where('notePath', '=', path).select('key').execute())
+      .map((row) => row.key)
+      .filter((key): key is string => typeof key === 'string'),
+  )
+  const dailyDate = dateFromDailyPath(path)
+  if (dailyDate !== null) {
+    keys.add(dailyDate)
+  }
+  return [...keys]
+}
+
+/**
+ * Inbound wiki links whose target resolves to one of `targetKeys`, with the
+ * source note joined for recency/title. Semantically the `backlinks` view
+ * (wiki links only, template sources excluded) rebuilt over `links` directly,
+ * so a target that is not an indexed note yet still finds its inbound links.
+ */
+function inboundLinks(targetKeys: string[]) {
   return db
-    .selectFrom('backlinks')
-    .where('targetPath', '=', path)
-    .select(['sourcePath', 'targetRaw', 'alias', 'posFrom', 'posTo'])
-    .orderBy('sourcePath')
+    .selectFrom('links')
+    .innerJoin('notes', 'notes.path', 'links.sourcePath')
+    .where('links.kind', '=', 'wiki')
+    .where('links.targetKey', 'in', targetKeys)
+    .where('notes.kind', '!=', 'template')
+}
+
+/** Notes that link to `path` (resolved at query time against the link keys). */
+export async function getBacklinks(path: string): Promise<Backlink[]> {
+  const targetKeys = await targetKeysFor(path)
+  if (targetKeys.length === 0) {
+    return []
+  }
+  return inboundLinks(targetKeys)
+    .select([
+      'links.sourcePath',
+      'links.targetRaw',
+      'links.alias',
+      'links.posFrom',
+      'links.posTo',
+    ])
+    .orderBy('links.sourcePath')
     .execute()
 }
 
@@ -81,7 +125,7 @@ function afterSource(cursor: BacklinkSourceCursor) {
   return sql<boolean>`(
     ${sourceRecency} < ${cursor.recencyMs}
     or (${sourceRecency} = ${cursor.recencyMs}
-      and "backlinks"."source_path" > ${cursor.sourcePath})
+      and "links"."source_path" > ${cursor.sourcePath})
   )`
 }
 
@@ -89,7 +133,7 @@ function throughSource(cursor: BacklinkSourceCursor) {
   return sql<boolean>`(
     ${sourceRecency} > ${cursor.recencyMs}
     or (${sourceRecency} = ${cursor.recencyMs}
-      and "backlinks"."source_path" <= ${cursor.sourcePath})
+      and "links"."source_path" <= ${cursor.sourcePath})
   )`
 }
 
@@ -103,6 +147,10 @@ function throughSource(cursor: BacklinkSourceCursor) {
  * complete source notes rather than raw links: `limit` sources are selected by
  * recency/path keyset, then every matching position in those sources is
  * processed. Consequently `contexts.length` may be greater than `limit`.
+ *
+ * Resolution runs over the link keys rather than the `backlinks` view, so a
+ * daily note that has no file yet (a future date) still lists the notes that
+ * already point at it.
  */
 export async function getBacklinksWithContext(
   path: string,
@@ -112,12 +160,14 @@ export async function getBacklinksWithContext(
     throw new RangeError('backlink page limit must be a positive safe integer')
   }
 
-  let sourceQuery = db
-    .selectFrom('backlinks')
-    .innerJoin('notes', 'notes.path', 'backlinks.sourcePath')
-    .where('targetPath', '=', path)
+  const targetKeyList = await targetKeysFor(path)
+  if (targetKeyList.length === 0) {
+    return { contexts: [], nextCursor: null, indexedLinkCount: 0 }
+  }
+
+  let sourceQuery = inboundLinks(targetKeyList)
     .select([
-      'backlinks.sourcePath',
+      'links.sourcePath',
       'notes.title as sourceTitle',
       sourceRecency.as('recencyMs'),
     ])
@@ -132,13 +182,10 @@ export async function getBacklinksWithContext(
   const [candidateSources, countRow] = await Promise.all([
     sourceQuery
       .orderBy(sourceRecency, 'desc')
-      .orderBy('backlinks.sourcePath')
+      .orderBy('links.sourcePath')
       .limit(candidateLimit)
       .execute(),
-    db
-      .selectFrom('backlinks')
-      .innerJoin('notes', 'notes.path', 'backlinks.sourcePath')
-      .where('targetPath', '=', path)
+    inboundLinks(targetKeyList)
       .select(sql<number>`count(*)`.as('count'))
       .executeTakeFirst(),
   ])
@@ -158,23 +205,20 @@ export async function getBacklinksWithContext(
   // source path. This keeps arbitrarily large safe limits below SQLite's bound
   // parameter ceiling; the selected-path guard below also closes the tiny race
   // where an index write lands between the source and context queries.
-  let contextRowQuery = db
-    .selectFrom('backlinks')
-    .innerJoin('notes', 'notes.path', 'backlinks.sourcePath')
-    .where('targetPath', '=', path)
+  let contextRowQuery = inboundLinks(targetKeyList)
     .where(throughSource({
       recencyMs: lastSource.recencyMs,
       sourcePath: lastSource.sourcePath,
     }))
-    .select(['backlinks.sourcePath', 'backlinks.posFrom'])
+    .select(['links.sourcePath', 'links.posFrom'])
     .$narrowType<{ sourcePath: string; posFrom: number }>()
   if (options.cursor !== null) {
     contextRowQuery = contextRowQuery.where(afterSource(options.cursor))
   }
   const rows = await contextRowQuery
     .orderBy(sourceRecency, 'desc')
-    .orderBy('backlinks.sourcePath')
-    .orderBy('backlinks.posFrom')
+    .orderBy('links.sourcePath')
+    .orderBy('links.posFrom')
     .execute()
 
   const selectedSourcePaths = new Set(pageSources.map((source) => source.sourcePath))
@@ -194,11 +238,7 @@ export async function getBacklinksWithContext(
   // Every spelling that resolves to the target (title, aliases, daily date),
   // so sibling branches co-group under any of them — old Reflect compared
   // resolved note ids, not link text.
-  const targetKeys = new Set(
-    (await db.selectFrom('noteKeys').where('notePath', '=', path).select('key').execute())
-      .map((row) => row.key)
-      .filter((key): key is string => typeof key === 'string'),
-  )
+  const targetKeys = new Set(targetKeyList)
 
   // One read *and one parse* per distinct source: a well-linked source
   // contributes many rows, and context extraction walks the parsed body.


### PR DESCRIPTION
## Problem

Linking a future date (e.g. `[[2026-07-29]]` as a reminder) stores the link in the index immediately, but when that day arrives the daily note's backlinks panel is empty until something is typed. Daily notes are created lazily on the first keystroke, and backlink resolution goes through the `backlinks` view, whose `note_keys` join requires an indexed target note — so a daily that exists only as a link target has no rows to serve. Past dates appear to work only because those files already exist.

## Change

`getBacklinks` / `getBacklinksWithContext` now resolve over the `links` table with the target's full key set — its `note_keys` rows plus, for a daily path, the date derived from the path itself (`dateFromDailyPath`). The view's semantics are preserved (wiki links only, template sources excluded, alias/title spellings still co-group), and the same key set feeds the block-context highlighter, replacing the second `note_keys` query.

A future daily now lists its inbound links the moment the date is opened, before any keystroke creates the file.

## Testing

- New `queries-backlinks.test.ts`: absent-daily resolution through the path-derived date key, note_keys + date key merging, template-source exclusion, empty-key short circuit, page-limit guard, and links-table (not view) query shape.
- `pnpm check` clean; verified in a real graph (link from one daily to a not-yet-created future daily shows up in the panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLgoFLw2b4xv1cLudoyPLT