### PR TITLE
feat: show daily note markers in iOS calendar

### DIFF
--- a/apps/desktop/src/mobile/calendar-strip.tsx
+++ b/apps/desktop/src/mobile/calendar-strip.tsx
@@ -8,6 +8,7 @@ import { monthPickTarget, weekAtIndex, weekStartOf } from '@/mobile/calendar'
 import { hapticImpactLight } from '@/mobile/haptics'
 import { MonthPickerDrawer } from '@/mobile/month-picker-drawer'
 import { MonthTitle } from '@/mobile/month-title'
+import { useDailyNoteDates } from '@/mobile/use-daily-note-dates'
 import { useWeekStrip } from '@/mobile/use-week-strip'
 import { WeekRow } from '@/mobile/week-row'
 import { useSettings } from '@/providers/settings-provider'
@@ -50,6 +51,10 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
   const { emblaRef, weekWindow, displayedWeekStart, showWeekOf } = useWeekStrip(
     date,
     settings.weekStartDay,
+  )
+  const dailyNoteDates = useDailyNoteDates(
+    weekWindow.start,
+    addDaysIso(weekAtIndex(weekWindow, weekWindow.count - 1), 6),
   )
 
   // Header month: the selection's own month while its week is on screen;
@@ -157,6 +162,7 @@ export function CalendarStrip({ date, today, resetSeq, onSelect }: CalendarStrip
                 weekStart={weekStart}
                 selectedDay={contains(date) ? date : null}
                 todayDay={contains(today) ? today : null}
+                dailyNoteDates={dailyNoteDates}
                 onSelect={onSelect}
               />
             )

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -15,7 +15,7 @@ import { addDaysIso, formatDayLabel, parseIsoDate, todayIso } from '@/lib/dates'
 import { monthLabel, monthOf } from '@/lib/month-grid'
 import { fireEvent } from '@/test-utils/fire-event'
 import '@/test-utils/locator'
-import { weekOf } from './calendar'
+import { createWeekWindow, weekOf } from './calendar'
 import { MobileShell } from './mobile-shell'
 import { publishKeyboardHeight } from './use-keyboard'
 
@@ -88,6 +88,7 @@ vi.mock('@/mobile/haptics', () => ({
 }))
 
 const indexFns = vi.hoisted(() => ({
+  dailyDatesInRange: vi.fn(async () => [] as string[]),
   getBacklinksWithContext: vi.fn(async () => ({
     contexts: [],
     nextCursor: null,
@@ -97,6 +98,7 @@ const indexFns = vi.hoisted(() => ({
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   hasBridge: () => true,
+  dailyDatesInRange: indexFns.dailyDatesInRange,
   getBacklinksWithContext: indexFns.getBacklinksWithContext,
 }))
 // Vaul's drag/animation is verified on-device. This passthrough
@@ -173,6 +175,7 @@ beforeEach(async () => {
   editorProbe.selectionCalls = []
   mockInvoke.mockReset()
   hapticImpactLight.mockClear()
+  indexFns.dailyDatesInRange.mockReset().mockResolvedValue([])
   mockInvoke.mockImplementation(async (command, args) => {
     if (command === 'note_read') {
       const content = files[(args as { path: string }).path]
@@ -360,6 +363,32 @@ describe('MobileShell', () => {
         .element()
         .getAttribute('aria-current'),
     ).toBe('date')
+  })
+
+  it('marks dates backed by daily notes across the pageable strip window', async () => {
+    const today = todayIso()
+    const week = weekOf(today, 'monday')
+    const notedDay = week.find((day) => day !== today) ?? week[0]!
+    const emptyDay = week.find((day) => day !== today && day !== notedDay) ?? week[1]!
+    indexFns.dailyDatesInRange.mockResolvedValue([notedDay])
+
+    const view = await mount({ kind: 'today' })
+
+    await expect.element(view.getByTestId(`note-dot-${notedDay}`)).toBeVisible()
+    await expect.element(view.getByTestId(`note-dot-${emptyDay}`)).not.toBeInTheDocument()
+    await expect
+      .element(
+        view.getByRole('button', {
+          name: `${dayCellLabel(notedDay)}, has daily note`,
+        }),
+      )
+      .toBeVisible()
+
+    const weekWindow = createWeekWindow(today, 'monday')
+    expect(indexFns.dailyDatesInRange).toHaveBeenCalledWith(
+      weekWindow.start,
+      addDaysIso(weekWindow.start, weekWindow.count * 7 - 1),
+    )
   })
 
   it('selects a day in another week straight from the pageable strip', async () => {

--- a/apps/desktop/src/mobile/use-daily-note-dates.test.tsx
+++ b/apps/desktop/src/mobile/use-daily-note-dates.test.tsx
@@ -1,0 +1,62 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, renderHook } from 'vitest-browser-react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import { useDailyNoteDates } from './use-daily-note-dates'
+
+const dailyDatesInRange = vi.hoisted(() =>
+  vi.fn<(start: string, end: string) => Promise<string[]>>(),
+)
+
+vi.mock('@reflect/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@reflect/core')>()),
+  dailyDatesInRange,
+  hasBridge: () => true,
+}))
+
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({ graph: { root: '/g' } }),
+}))
+
+beforeEach(() => dailyDatesInRange.mockReset())
+afterEach(async () => cleanup())
+
+describe('useDailyNoteDates', () => {
+  it('keeps previous markers while a new range loads', async () => {
+    let resolveNextRange: (dates: string[]) => void = () => {}
+    dailyDatesInRange
+      .mockResolvedValueOnce(['2026-07-14'])
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveNextRange = resolve
+          }),
+      )
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = ({ children }: { children: ReactNode }): ReactNode => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    const hook = await renderHook(
+      (
+        { start, end }: { start: string; end: string } = {
+          start: '2026-01-12',
+          end: '2027-01-17',
+        },
+      ) => useDailyNoteDates(start, end),
+      {
+        initialProps: { start: '2026-01-12', end: '2027-01-17' },
+        wrapper,
+      },
+    )
+
+    await vi.waitFor(() => expect(hook.result.current.has('2026-07-14')).toBe(true))
+
+    await hook.rerender({ start: '2026-06-29', end: '2027-07-04' })
+    await vi.waitFor(() => expect(dailyDatesInRange).toHaveBeenCalledTimes(2))
+    expect(hook.result.current.has('2026-07-14')).toBe(true)
+
+    await hook.act(() => resolveNextRange(['2027-01-05']))
+    await vi.waitFor(() => expect(hook.result.current.has('2027-01-05')).toBe(true))
+    expect(hook.result.current.has('2026-07-14')).toBe(false)
+  })
+})

--- a/apps/desktop/src/mobile/use-daily-note-dates.ts
+++ b/apps/desktop/src/mobile/use-daily-note-dates.ts
@@ -1,0 +1,18 @@
+import { useMemo } from 'react'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { dailyDatesInRange, hasBridge } from '@reflect/core'
+import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
+import { useGraph } from '@/providers/graph-provider'
+
+/** Indexed daily-note dates in an inclusive range, ready for calendar lookup. */
+export function useDailyNoteDates(start: string, end: string): ReadonlySet<string> {
+  const { graph } = useGraph()
+  const { data } = useQuery({
+    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'dailyDates', start, end],
+    queryFn: () => dailyDatesInRange(start, end),
+    enabled: hasBridge() && graph !== null,
+    placeholderData: keepPreviousData,
+  })
+
+  return useMemo(() => new Set(data ?? []), [data])
+}

--- a/apps/desktop/src/mobile/week-row.test.tsx
+++ b/apps/desktop/src/mobile/week-row.test.tsx
@@ -1,0 +1,41 @@
+import { cleanup, render } from 'vitest-browser-react'
+import { page, userEvent } from 'vitest/browser'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import '@/test-utils/locator'
+import { WeekRow } from './week-row'
+
+const hapticImpactLight = vi.hoisted(() => vi.fn())
+
+vi.mock('@/mobile/haptics', () => ({ hapticImpactLight }))
+
+afterEach(async () => {
+  await cleanup()
+  hapticImpactLight.mockReset()
+})
+
+describe('WeekRow', () => {
+  it('keeps a daily note marked when the date is both selected and today', async () => {
+    const onSelect = vi.fn()
+    await render(
+      <WeekRow
+        weekStart="2026-07-13"
+        selectedDay="2026-07-16"
+        todayDay="2026-07-16"
+        dailyNoteDates={new Set(['2026-07-13', '2026-07-16'])}
+        onSelect={onSelect}
+      />,
+    )
+
+    const selected = page.getByRole('button', {
+      name: 'Thursday, July 16th, has daily note',
+    })
+    await expect.element(selected).toHaveAttribute('aria-current', 'date')
+    await expect.element(page.getByTestId('note-dot-2026-07-16')).toBeVisible()
+    await expect.element(page.getByTestId('note-dot-2026-07-13')).toBeVisible()
+    await expect.element(page.getByTestId('note-dot-2026-07-14')).not.toBeInTheDocument()
+
+    await userEvent.click(selected)
+    expect(hapticImpactLight).toHaveBeenCalledOnce()
+    expect(onSelect).toHaveBeenCalledWith('2026-07-16')
+  })
+})

--- a/apps/desktop/src/mobile/week-row.tsx
+++ b/apps/desktop/src/mobile/week-row.tsx
@@ -11,6 +11,8 @@ interface WeekRowProps {
   selectedDay: string | null
   /** Today when it falls in this week, else `null`. */
   todayDay: string | null
+  /** Dates backed by an indexed daily note. */
+  dailyNoteDates: ReadonlySet<string>
   /** Select a day — drives the carousel and the route. */
   onSelect: (date: string) => void
 }
@@ -27,6 +29,7 @@ function WeekRowComponent({
   weekStart,
   selectedDay,
   todayDay,
+  dailyNoteDates,
   onSelect,
 }: WeekRowProps): ReactElement {
   const days = Array.from({ length: 7 }, (_, index) => addDaysIso(weekStart, index))
@@ -57,11 +60,12 @@ function WeekRowComponent({
       {days.map((day) => {
         const selected = day === selectedDay
         const isToday = day === todayDay
+        const hasDailyNote = dailyNoteDates.has(day)
         return (
           <button
             key={day}
             type="button"
-            aria-label={format(parseIsoDate(day), 'EEEE, MMMM do')}
+            aria-label={`${format(parseIsoDate(day), 'EEEE, MMMM do')}${hasDailyNote ? ', has daily note' : ''}`}
             aria-current={selected ? 'date' : undefined}
             onClick={() => {
               hapticImpactLight()
@@ -82,13 +86,18 @@ function WeekRowComponent({
             >
               {format(parseIsoDate(day), 'd')}
             </span>
-            {/* Today dot (V1) — a fixed-height slot so cells stay aligned;
-                shown only when today isn't the selected (circled) day. */}
+            {/* A daily note takes the strip's marker slot. Otherwise it keeps
+                V1's Today dot when today is not selected. */}
             <span
               aria-hidden
+              data-testid={hasDailyNote ? `note-dot-${day}` : undefined}
               className={cn(
                 'size-1 rounded-full',
-                !selected && isToday ? 'bg-primary' : 'bg-transparent',
+                hasDailyNote
+                  ? 'bg-surface-inverse/50 dark:bg-white/50'
+                  : !selected && isToday
+                    ? 'bg-primary'
+                    : 'bg-transparent',
               )}
             />
           </button>


### PR DESCRIPTION
Replaces https://github.com/team-reflect/reflect-open/pull/849 

**Before**:


<img width="250"  alt="IMG_3259" src="https://github.com/user-attachments/assets/bffad31d-cba3-461d-b426-7cf37cd22ecc" />

**After**:


<img width="250"  alt="IMG_3260" src="https://github.com/user-attachments/assets/704c62cb-430e-4f71-8954-997a85c033c4" />





## Problem

The iOS calendar strip shows the selected date and today, but it does not indicate which neighboring dates already have a daily note. Finding a previous entry within the visible week requires opening dates one by one, even though the desktop calendar already exposes this information.

## Changes


- Query `dailyDatesInRange` once for the calendar strip's full 53-week window through the existing index-scoped TanStack Query cache.
- Keep the previous range visible while a recentered window loads, so markers on overlapping dates do not blink.
- Reuse the fixed marker slot in each day cell for a persistent 4px daily-note marker, with daily notes taking precedence over the existing Today dot.
- Add `, has daily note` to the accessible name while keeping the visual marker hidden from assistive technology.
- Cover the inclusive query bounds, marker presence, accessible label, selected/today overlap, navigation, haptics, and range-transition continuity in Browser Mode tests.

## Impact

Users can scan the week and jump directly to dates with existing daily notes. The feature performs one local indexed SQLite range query and adds no schema, migration, routing, native command, permission, or network changes.

## Verification




- `pnpm test --run apps/desktop/src/mobile/use-daily-note-dates.test.tsx apps/desktop/src/mobile/week-row.test.tsx apps/desktop/src/mobile/mobile-screen.test.tsx` (Chromium): 31 passed
- `REFLECT_TEST_BROWSER=webkit pnpm test --run apps/desktop/src/mobile/use-daily-note-dates.test.tsx apps/desktop/src/mobile/week-row.test.tsx apps/desktop/src/mobile/mobile-screen.test.tsx`: 31 passed
- `pnpm check`: passed with the repository's existing max-lines warnings
- `pnpm build`: passed with the expected Sentry token and chunk-size warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Calendar dates with daily notes now display a note indicator.
  - Date accessibility labels identify when a daily note is available.
  - Note indicators remain accurate as users navigate between calendar weeks.

- **Bug Fixes**
  - Improved handling of note indicators while calendar date data is loading.
  - Preserved previously displayed note information during date-range updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->