### PR TITLE
feat(capture): attach Apple link previews to URL-only captures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,3 +183,25 @@ jobs:
 
       - name: Test
         run: cargo test --workspace
+
+  apple-rust:
+    name: check Apple Rust bindings
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-on-failure: true
+
+      - name: Stage desktop sidecars
+        run: node apps/desktop/scripts/build-sidecar.mjs
+
+      - name: Check desktop library
+        run: cargo check -p reflect-open --lib

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3824,6 +3824,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-link-presentation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e373111112c275f52dbe3e3e183d4f96afd2307912efa9c89e52ce0ddda07c4"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-osa-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4806,6 +4817,7 @@ dependencies = [
  "objc2-contacts",
  "objc2-event-kit",
  "objc2-foundation",
+ "objc2-link-presentation",
  "objc2-ui-kit",
  "ort",
  "percent-encoding",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -128,6 +128,12 @@ dispatch2 = "0.3.1"
 objc2 = "0.6.4"
 objc2-foundation = "0.3.2"
 objc2-contacts = "0.3.2"
+objc2-link-presentation = { version = "0.3.2", default-features = false, features = [
+  "std",
+  "LPLinkMetadata",
+  "LPMetadataProvider",
+  "block2",
+] }
 block2 = "0.6.2"
 
 # Finite-length execution assertions around iOS persistence. UIKit's begin/end

--- a/apps/desktop/src-tauri/gen/apple/project.yml
+++ b/apps/desktop/src-tauri/gen/apple/project.yml
@@ -177,6 +177,7 @@ targets:
       - sdk: libiconv.tbd
       # objc2-contacts' link directive doesn't reach xcodebuild either.
       - sdk: Contacts.framework
+      - sdk: LinkPresentation.framework
       - sdk: CoreGraphics.framework
       - sdk: Metal.framework
       - sdk: MetalKit.framework

--- a/apps/desktop/src-tauri/gen/apple/reflect-open.xcodeproj/project.pbxproj
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		93F2A1181D6BC7832338EE9C /* ShareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93EF89A222208D739ABC00B8 /* ShareView.swift */; };
 		9611839F9E9EC688FCDFCC91 /* RecordingWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A26DB86321DA75DFE1CD4B41 /* RecordingWidgetBundle.swift */; };
 		961AA49623F0DDC7AB09B777 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39269153EFAD0C2FEFBE6696 /* UIKit.framework */; };
+		99EC4B1E2F71936A7C4EFCE4 /* LinkPresentation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A941ADD800B6F9E26D1C47C /* LinkPresentation.framework */; };
 		9C05940F9725363AAB9131D3 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C94374B175075AF3AA7DE586 /* Security.framework */; };
 		9D7F5A94048CECBFC3D89BBA /* libapp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F28F8A628D32337E04C0CBC0 /* libapp.a */; };
 		A2E5A9558E714E679520EA9E /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E66BC7105426B91F03659B53 /* MetalKit.framework */; };
@@ -100,6 +101,7 @@
 		44C3B8C21F2D38187423AB2F /* libiconv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libiconv.tbd; path = usr/lib/libiconv.tbd; sourceTree = SDKROOT; };
 		48F8214D2C537DF115410CC0 /* resolve.rs */ = {isa = PBXFileReference; path = resolve.rs; sourceTree = "<group>"; };
 		491E4F680A58FFBD620237F9 /* commit.rs */ = {isa = PBXFileReference; path = commit.rs; sourceTree = "<group>"; };
+		4A941ADD800B6F9E26D1C47C /* LinkPresentation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LinkPresentation.framework; path = System/Library/Frameworks/LinkPresentation.framework; sourceTree = SDKROOT; };
 		4B8413C8F746CEEC50B61694 /* import_assets.rs */ = {isa = PBXFileReference; path = import_assets.rs; sourceTree = "<group>"; };
 		4EE64B671C831953394179E2 /* watcher.rs */ = {isa = PBXFileReference; path = watcher.rs; sourceTree = "<group>"; };
 		51006DE1482D28D9562253A1 /* ShareExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -155,6 +157,7 @@
 		E1940DEB1B975598A69CA93F /* frontmatter.rs */ = {isa = PBXFileReference; path = frontmatter.rs; sourceTree = "<group>"; };
 		E66BC7105426B91F03659B53 /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
 		E8031FEC080EBAF422BEE44C /* markers.rs */ = {isa = PBXFileReference; path = markers.rs; sourceTree = "<group>"; };
+		E833A01F2799F6788CDCE53F /* link_preview.rs */ = {isa = PBXFileReference; path = link_preview.rs; sourceTree = "<group>"; };
 		EC45808CD3D13DD431212EAE /* watch.rs */ = {isa = PBXFileReference; path = watch.rs; sourceTree = "<group>"; };
 		F28F8A628D32337E04C0CBC0 /* libapp.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libapp.a; sourceTree = "<group>"; };
 		F3173A0D7E498896FAC5A43E /* watcher_mobile.rs */ = {isa = PBXFileReference; path = watcher_mobile.rs; sourceTree = "<group>"; };
@@ -170,6 +173,7 @@
 				319EDF8F46AB05DFBA9D674F /* libz.tbd in Frameworks */,
 				E9E7B6C59015E7301EE63308 /* libiconv.tbd in Frameworks */,
 				C4FAE42D7B978D8330E5D6DC /* Contacts.framework in Frameworks */,
+				99EC4B1E2F71936A7C4EFCE4 /* LinkPresentation.framework in Frameworks */,
 				74275EAEFEA922B7D8A2C78F /* CoreGraphics.framework in Frameworks */,
 				266B3807E809464C8FC14146 /* Metal.framework in Frameworks */,
 				A2E5A9558E714E679520EA9E /* MetalKit.framework in Frameworks */,
@@ -291,6 +295,7 @@
 				08B3817A23175E584BA6FD8D /* error.rs */,
 				152767D3A95549268E140D0F /* graph_gitignore.rs */,
 				560C7C23BE58D7EA845F1170 /* lib.rs */,
+				E833A01F2799F6788CDCE53F /* link_preview.rs */,
 				37EF719F509C3A532C0E0114 /* main.rs */,
 				B667667E9C6C141128493B00 /* quit.rs */,
 				8C04E40F02C9B4AE9A24A9A4 /* recents.rs */,
@@ -375,6 +380,7 @@
 				F28F8A628D32337E04C0CBC0 /* libapp.a */,
 				44C3B8C21F2D38187423AB2F /* libiconv.tbd */,
 				80E05926405BFDA2A3BC70BC /* libz.tbd */,
+				4A941ADD800B6F9E26D1C47C /* LinkPresentation.framework */,
 				FDC9BB81FAB5AF8D65160799 /* Metal.framework */,
 				E66BC7105426B91F03659B53 /* MetalKit.framework */,
 				68D1FDE7F099CA5F909105EB /* QuartzCore.framework */,

--- a/apps/desktop/src-tauri/ios.project.yml
+++ b/apps/desktop/src-tauri/ios.project.yml
@@ -177,6 +177,7 @@ targets:
       - sdk: libiconv.tbd
       # objc2-contacts' link directive doesn't reach xcodebuild either.
       - sdk: Contacts.framework
+      - sdk: LinkPresentation.framework
       - sdk: CoreGraphics.framework
       - sdk: Metal.framework
       - sdk: MetalKit.framework

--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -7,7 +7,7 @@
 //! this module only moves bytes.
 
 use std::fs;
-use std::io::Write;
+use std::io::{Cursor, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -426,10 +426,23 @@ pub fn capture_shared_inbox_relay(generation: u64, state: State<GraphState>) -> 
 
 // ---- screenshot promote ---------------------------------------------------------
 
+const CAPTURE_IMAGE_MAX_DIMENSION: u32 = 8192;
+const CAPTURE_IMAGE_MAX_ALLOC: u64 = 128 * 1024 * 1024;
+const CAPTURE_IMAGE_LONG_EDGE: u32 = 1600;
+
 /// Decode, downscale to `max_dim` on the long edge, re-encode as JPEG. Pure —
 /// the unit tests exercise this without Tauri state.
 fn downscale_jpeg(bytes: &[u8], max_dim: u32) -> AppResult<Vec<u8>> {
-    let decoded = image::load_from_memory(bytes)
+    let mut reader = image::ImageReader::new(Cursor::new(bytes))
+        .with_guessed_format()
+        .map_err(|err| AppError::parse(format!("screenshot format is invalid: {err}")))?;
+    let mut limits = image::Limits::default();
+    limits.max_image_width = Some(CAPTURE_IMAGE_MAX_DIMENSION);
+    limits.max_image_height = Some(CAPTURE_IMAGE_MAX_DIMENSION);
+    limits.max_alloc = Some(CAPTURE_IMAGE_MAX_ALLOC);
+    reader.limits(limits);
+    let decoded = reader
+        .decode()
         .map_err(|err| AppError::parse(format!("screenshot does not decode: {err}")))?;
     let resized = if decoded.width() > max_dim || decoded.height() > max_dim {
         decoded.resize(max_dim, max_dim, image::imageops::FilterType::CatmullRom)
@@ -443,6 +456,20 @@ fn downscale_jpeg(bytes: &[u8], max_dim: u32) -> AppResult<Vec<u8>> {
         .write_with_encoder(encoder)
         .map_err(|err| AppError::io(format!("screenshot re-encode failed: {err}")))?;
     Ok(out)
+}
+
+fn persist_asset(root: &Path, asset_path: &str, bytes: &[u8]) -> AppResult<()> {
+    let target = crate::fs::resolve_in_graph(root, asset_path)?;
+    let parent = target
+        .parent()
+        .ok_or_else(|| AppError::io("asset path has no parent"))?;
+    fs::create_dir_all(parent)?;
+    let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
+    tmp.write_all(bytes)?;
+    tmp.flush()?;
+    tmp.persist(&target)
+        .map_err(|err| AppError::io(err.to_string()))?;
+    Ok(())
 }
 
 /// Copy a spooled screenshot into the graph as a downscaled JPEG asset. Copy,
@@ -459,20 +486,30 @@ pub fn capture_screenshot_promote(
     let root = root_for_generation(&state, generation)?;
     let bytes = fs::read(inbox_file(&root, &spool_name)?)?;
     let jpeg = downscale_jpeg(&bytes, max_dim)?;
-    let target = crate::fs::resolve_in_graph(&root, &asset_path)?;
-    if let Some(parent) = target.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    let mut tmp = tempfile::NamedTempFile::new_in(
-        target
-            .parent()
-            .ok_or_else(|| AppError::io("asset path has no parent"))?,
-    )?;
-    tmp.write_all(&jpeg)?;
-    tmp.flush()?;
-    tmp.persist(&target)
-        .map_err(|err| AppError::io(err.to_string()))?;
-    Ok(())
+    persist_asset(&root, &asset_path, &jpeg)
+}
+
+/// Ask the platform link-preview service for one representative image and
+/// persist it as the capture's normalized JPEG asset.
+#[tauri::command]
+pub async fn capture_link_preview(
+    app: tauri::AppHandle,
+    url: String,
+    asset_path: String,
+    generation: u64,
+    state: State<'_, GraphState>,
+) -> AppResult<bool> {
+    let Some(bytes) = crate::link_preview::fetch(&app, &url).await? else {
+        return Ok(false);
+    };
+    let jpeg = tauri::async_runtime::spawn_blocking(move || {
+        downscale_jpeg(&bytes, CAPTURE_IMAGE_LONG_EDGE)
+    })
+    .await
+    .map_err(|err| AppError::io(format!("link preview task failed: {err}")))??;
+    let root = root_for_generation(&state, generation)?;
+    persist_asset(&root, &asset_path, &jpeg)?;
+    Ok(true)
 }
 
 // ---- meta fetch -----------------------------------------------------------------
@@ -833,6 +870,21 @@ mod tests {
     fn downscale_rejects_non_images() {
         assert!(matches!(
             downscale_jpeg(b"not an image", 1600),
+            Err(AppError::Parse { .. })
+        ));
+    }
+
+    #[test]
+    fn downscale_rejects_images_over_the_dimension_limit() {
+        let too_wide =
+            image::DynamicImage::new_rgb8(CAPTURE_IMAGE_MAX_DIMENSION.saturating_add(1), 1);
+        let mut png = Vec::new();
+        too_wide
+            .write_to(&mut std::io::Cursor::new(&mut png), image::ImageFormat::Png)
+            .unwrap();
+
+        assert!(matches!(
+            downscale_jpeg(&png, CAPTURE_IMAGE_LONG_EDGE),
             Err(AppError::Parse { .. })
         ));
     }

--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -438,7 +438,7 @@ const CAPTURE_IMAGE_LONG_EDGE: u32 = 1600;
 fn downscale_jpeg(bytes: &[u8], max_dim: u32) -> AppResult<Vec<u8>> {
     let mut reader = image::ImageReader::new(Cursor::new(bytes))
         .with_guessed_format()
-        .map_err(|err| AppError::parse(format!("screenshot format is invalid: {err}")))?;
+        .map_err(|err| AppError::parse(format!("image format is invalid: {err}")))?;
     let mut limits = image::Limits::default();
     limits.max_image_width = Some(CAPTURE_IMAGE_MAX_DIMENSION);
     limits.max_image_height = Some(CAPTURE_IMAGE_MAX_DIMENSION);
@@ -446,7 +446,7 @@ fn downscale_jpeg(bytes: &[u8], max_dim: u32) -> AppResult<Vec<u8>> {
     reader.limits(limits);
     let decoded = reader
         .decode()
-        .map_err(|err| AppError::parse(format!("screenshot does not decode: {err}")))?;
+        .map_err(|err| AppError::parse(format!("image does not decode: {err}")))?;
     let resized = if decoded.width() > max_dim || decoded.height() > max_dim {
         decoded.resize(max_dim, max_dim, image::imageops::FilterType::CatmullRom)
     } else {
@@ -455,9 +455,9 @@ fn downscale_jpeg(bytes: &[u8], max_dim: u32) -> AppResult<Vec<u8>> {
     let mut out = Vec::new();
     let encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut out, 80);
     resized
-        .into_rgb8() // JPEG carries no alpha; screenshots are opaque
+        .into_rgb8() // JPEG carries no alpha
         .write_with_encoder(encoder)
-        .map_err(|err| AppError::io(format!("screenshot re-encode failed: {err}")))?;
+        .map_err(|err| AppError::io(format!("image re-encode failed: {err}")))?;
     Ok(out)
 }
 
@@ -493,26 +493,21 @@ pub fn capture_screenshot_promote(
 }
 
 /// Ask the platform link-preview service for one representative image and
-/// persist it as the capture's normalized JPEG asset.
+/// return a normalized JPEG for the policy layer to persist after its
+/// post-request privacy check.
 #[tauri::command]
-pub async fn capture_link_preview(
-    app: tauri::AppHandle,
-    url: String,
-    asset_path: String,
-    generation: u64,
-    state: State<'_, GraphState>,
-) -> AppResult<bool> {
+pub async fn capture_link_preview(app: tauri::AppHandle, url: String) -> AppResult<Option<String>> {
+    use base64::Engine;
+
     let Some(bytes) = crate::link_preview::fetch(&app, &url).await? else {
-        return Ok(false);
+        return Ok(None);
     };
     let jpeg = tauri::async_runtime::spawn_blocking(move || {
         downscale_jpeg(&bytes, CAPTURE_IMAGE_LONG_EDGE)
     })
     .await
     .map_err(|err| AppError::io(format!("link preview task failed: {err}")))??;
-    let root = root_for_generation(&state, generation)?;
-    persist_asset(&root, &asset_path, &jpeg)?;
-    Ok(true)
+    Ok(Some(base64::engine::general_purpose::STANDARD.encode(jpeg)))
 }
 
 // ---- meta fetch -----------------------------------------------------------------

--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -426,8 +426,11 @@ pub fn capture_shared_inbox_relay(generation: u64, state: State<GraphState>) -> 
 
 // ---- screenshot promote ---------------------------------------------------------
 
+// Maximum decoded image width or height, in pixels.
 const CAPTURE_IMAGE_MAX_DIMENSION: u32 = 8192;
+// Maximum memory the image decoder may allocate, in bytes.
 const CAPTURE_IMAGE_MAX_ALLOC: u64 = 128 * 1024 * 1024;
+// Long-edge target for persisted capture JPEGs, in pixels.
 const CAPTURE_IMAGE_LONG_EDGE: u32 = 1600;
 
 /// Decode, downscale to `max_dim` on the long edge, re-encode as JPEG. Pure —

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -26,6 +26,7 @@ mod fs;
 mod git;
 mod graph_gitignore;
 mod icloud;
+mod link_preview;
 mod menu;
 mod quit;
 mod recents;
@@ -321,6 +322,7 @@ pub fn run() {
             capture::capture_inbox_reject,
             capture::capture_shared_inbox_relay,
             capture::capture_screenshot_promote,
+            capture::capture_link_preview,
             capture::capture_meta_fetch,
             git::git_status,
             git::git_setup,

--- a/apps/desktop/src-tauri/src/link_preview.rs
+++ b/apps/desktop/src-tauri/src/link_preview.rs
@@ -1,0 +1,141 @@
+//! Apple LinkPresentation preview-image capability.
+//!
+//! Apple platforms ask the system for one representative image. Other
+//! platforms return no image and never perform a network request.
+
+use crate::error::AppResult;
+
+pub(crate) async fn fetch<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    url: &str,
+) -> AppResult<Option<Vec<u8>>> {
+    platform::fetch(app, url).await
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+mod platform {
+    use std::sync::{mpsc, Arc};
+    use std::time::Duration;
+
+    use block2::RcBlock;
+    use dispatch2::MainThreadBound;
+    use objc2::rc::Retained;
+    use objc2::MainThreadMarker;
+    use objc2_foundation::{NSData, NSError, NSString, NSURL};
+    use objc2_link_presentation::{LPLinkMetadata, LPMetadataProvider};
+
+    use crate::error::{AppError, AppResult};
+
+    const PROVIDER_TIMEOUT_SECONDS: f64 = 15.0;
+    const RECEIVER_TIMEOUT: Duration = Duration::from_secs(20);
+    const MAX_PROVIDER_BYTES: usize = 16 * 1024 * 1024;
+    const IMAGE_TYPE_IDENTIFIER: &str = "public.image";
+
+    type PreviewResult = Result<Option<Vec<u8>>, String>;
+    type Provider = Arc<MainThreadBound<Retained<LPMetadataProvider>>>;
+
+    pub async fn fetch<R: tauri::Runtime>(
+        app: &tauri::AppHandle<R>,
+        url: &str,
+    ) -> AppResult<Option<Vec<u8>>> {
+        if !url.starts_with("https://") && !url.starts_with("http://") {
+            return Err(AppError::parse("link preview requires an http(s) URL"));
+        }
+
+        let (sender, receiver) = mpsc::sync_channel::<PreviewResult>(1);
+        let url = url.to_owned();
+        app.run_on_main_thread(move || {
+            let start_sender = sender.clone();
+            if let Err(message) = start(&url, start_sender) {
+                let _ = sender.send(Err(message));
+            }
+        })
+        .map_err(|error| AppError::io(format!("could not schedule link preview: {error}")))?;
+
+        let received =
+            tauri::async_runtime::spawn_blocking(move || receiver.recv_timeout(RECEIVER_TIMEOUT))
+                .await
+                .map_err(|error| AppError::io(format!("link preview task failed: {error}")))?;
+
+        received
+            .map_err(|_| AppError::Network {
+                message: "LinkPresentation did not finish".into(),
+            })?
+            .map_err(|message| AppError::Network { message })
+    }
+
+    fn start(url: &str, sender: mpsc::SyncSender<PreviewResult>) -> Result<(), String> {
+        let mtm = MainThreadMarker::new()
+            .ok_or_else(|| "LinkPresentation was not started on the main thread".to_string())?;
+        let url = NSURL::URLWithString(&NSString::from_str(url))
+            .ok_or_else(|| "LinkPresentation rejected the URL".to_string())?;
+        let provider: Provider = Arc::new(MainThreadBound::new(
+            unsafe { LPMetadataProvider::new() },
+            mtm,
+        ));
+        unsafe {
+            provider.get(mtm).setTimeout(PROVIDER_TIMEOUT_SECONDS);
+            provider.get(mtm).setShouldFetchSubresources(true);
+        }
+
+        let provider_lifetime = Arc::clone(&provider);
+        let handler = RcBlock::new(move |metadata: *mut LPLinkMetadata, error: *mut NSError| {
+            let _provider_lifetime = &provider_lifetime;
+            let Some(metadata) = (unsafe { metadata.as_ref() }) else {
+                let _ = sender.send(Err(error_message(
+                    error,
+                    "LinkPresentation returned no metadata",
+                )));
+                return;
+            };
+            let Some(image_provider) = (unsafe { metadata.imageProvider() }) else {
+                let _ = sender.send(Ok(None));
+                return;
+            };
+
+            let data_sender = sender.clone();
+            let data_handler = RcBlock::new(move |data: *mut NSData, error: *mut NSError| {
+                let result = match unsafe { data.as_ref() } {
+                    Some(data) if data.len() <= MAX_PROVIDER_BYTES => Ok(Some(data.to_vec())),
+                    Some(_) => Err("LinkPresentation image is too large".into()),
+                    None => Err(error_message(
+                        error,
+                        "LinkPresentation returned no image data",
+                    )),
+                };
+                let _ = data_sender.send(result);
+            });
+            unsafe {
+                image_provider.loadDataRepresentationForTypeIdentifier_completionHandler(
+                    &NSString::from_str(IMAGE_TYPE_IDENTIFIER),
+                    &data_handler,
+                );
+            }
+        });
+
+        unsafe {
+            provider
+                .get(mtm)
+                .startFetchingMetadataForURL_completionHandler(&url, &handler);
+        }
+        Ok(())
+    }
+
+    fn error_message(error: *mut NSError, fallback: &str) -> String {
+        unsafe { error.as_ref() }
+            .map(|error| error.localizedDescription().to_string())
+            .unwrap_or_else(|| fallback.to_string())
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+mod platform {
+    use crate::error::AppResult;
+
+    pub async fn fetch<R: tauri::Runtime>(
+        _app: &tauri::AppHandle<R>,
+        _url: &str,
+    ) -> AppResult<Option<Vec<u8>>> {
+        Ok(None)
+    }
+}

--- a/docs/contributing/mobile-simulator.md
+++ b/docs/contributing/mobile-simulator.md
@@ -39,6 +39,23 @@ lines from `spike_mobile.rs`:
 [plan19-spike] PASS: libgit2 init+commit
 ```
 
+## Link preview capture
+
+To verify URL-only share captures:
+
+1. Share a web page from Safari to Reflect without a screenshot.
+2. Open Reflect and wait for capture enrichment to finish.
+3. Open the generated capture note and confirm it contains a `## Screenshot`
+   section whose asset is a JPEG under `assets/`.
+4. Repeat with a page that has no representative image and confirm enrichment
+   still completes without a screenshot.
+5. Mark either the capture note or its daily note `private: true` before
+   enrichment and confirm no preview is attached.
+
+The preview comes from Apple's LinkPresentation framework. It is expected to
+vary by website and OS release, so automated tests cover lifecycle and privacy
+behavior while this simulator check covers the system integration.
+
 ## The software keyboard
 
 The simulator hides the software keyboard whenever "Connect Hardware

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -74,8 +74,14 @@ disk at call time), and it is covered by tests.
   held in the browser's local extension storage and retried automatically until it
   spools — it is never sent anywhere else in the meantime.
 - Once a capture lands in your graph, the desktop app's rules above apply unchanged:
-  any BYOK AI enrichment of it honors `private: true`, and no content leaves the device
-  except through the calls listed here.
+  enrichment may request the captured URL directly to read page metadata. On macOS and
+  iOS, Reflect also asks Apple's LinkPresentation framework for one representative
+  image when the capture has no screenshot. These requests go to the captured website
+  and any redirects or subresources selected by the operating system, never through a
+  Reflect server. The app re-reads the capture and daily note before and after each
+  request; `private: true` prevents the request or discards its result. A successful
+  image is downscaled and stored as a local JPEG in the graph. Any BYOK AI enrichment
+  then follows the provider rules above.
 
 ## Apple Contacts (off by default)
 
@@ -142,5 +148,6 @@ API keys and tokens live in the **OS keychain only** — never in markdown, neve
 | Key validation | The provider | No | — (only when adding a key) |
 | Update check | GitHub Releases | No | On in packaged builds |
 | Browser capture | Nowhere (local host on disk) | — (stays on your machine) | — (only when you capture) |
+| Capture metadata and preview | The captured website, via Reflect and Apple LinkPresentation | URL only; private captures are blocked | No (after an explicit capture) |
 | Contacts lookup | Nowhere (on-device OS store) | — (stays on your machine) | Yes (opt-in) |
 | Exception diagnostics | Sentry | No — free-form messages and context are redacted | No (official releases) |

--- a/packages/core/src/actions/capture-drain.test.ts
+++ b/packages/core/src/actions/capture-drain.test.ts
@@ -25,6 +25,7 @@ vi.mock('../graph/commands', () => ({
   captureInboxRead: vi.fn(),
   captureInboxReject: vi.fn(),
   captureInboxRemove: vi.fn(),
+  captureLinkPreview: vi.fn(),
   listFiles: vi.fn(),
   promoteCaptureScreenshot: vi.fn(),
   readAsset: vi.fn(),

--- a/packages/core/src/actions/capture-drain.test.ts
+++ b/packages/core/src/actions/capture-drain.test.ts
@@ -30,6 +30,7 @@ vi.mock('../graph/commands', () => ({
   promoteCaptureScreenshot: vi.fn(),
   readAsset: vi.fn(),
   readNote: vi.fn(),
+  writeAsset: vi.fn(),
   writeNote: vi.fn(),
 }))
 vi.mock('./meta-scrape', () => ({

--- a/packages/core/src/actions/capture-enrichment-write.ts
+++ b/packages/core/src/actions/capture-enrichment-write.ts
@@ -38,6 +38,7 @@ interface PersistCaptureEnrichmentInput {
   toTitle: string
   status: Exclude<CaptureStatus, 'skipped'>
   provider: AiProviderConfig | null
+  screenshot?: string | undefined
   generation: number
 }
 
@@ -184,6 +185,7 @@ export async function persistCaptureEnrichment(
       captureHash,
       captureProvider: input.provider?.provider,
       captureModel: input.provider?.model,
+      ...(input.screenshot === undefined ? {} : { captureScreenshot: input.screenshot }),
       captureDailyFromTitle: titleChanged ? input.fromTitle : undefined,
       captureFinalizeStatus: titleChanged ? input.status : undefined,
     }),

--- a/packages/core/src/actions/capture-enrichment.test.ts
+++ b/packages/core/src/actions/capture-enrichment.test.ts
@@ -11,6 +11,7 @@ import {
   files,
   getSecretMock,
   IDENTITY,
+  linkPreviewMock,
   NO_PROVIDERS,
   readAssetMock,
   reconcile,
@@ -28,6 +29,7 @@ vi.mock('../graph/commands', () => ({
   captureInboxRead: vi.fn(),
   captureInboxReject: vi.fn(),
   captureInboxRemove: vi.fn(),
+  captureLinkPreview: vi.fn(),
   listFiles: vi.fn(),
   promoteCaptureScreenshot: vi.fn(),
   readAsset: vi.fn(),
@@ -60,6 +62,101 @@ describe('reconcileCaptureEnrichment', () => {
     expect(outcome.stopped).toBeNull()
     writeNoteMock.mockClear()
   }
+
+  it('attaches an Apple link preview to a URL-only capture', async () => {
+    addSpool(envelope({ source: 'ios-share', title: '' }), { screenshot: false })
+    expect((await drain()).stopped).toBeNull()
+    writeNoteMock.mockClear()
+    linkPreviewMock.mockResolvedValue(true)
+    scrapeMock.mockResolvedValue({
+      title: 'An article from metadata',
+      description: 'A scraped description.',
+      siteName: null,
+    })
+
+    const outcome = await reconcile({ providers: NO_PROVIDERS })
+
+    expect(outcome).toEqual({ pending: 1, enriched: 1, skipped: 0, stopped: null })
+    expect(linkPreviewMock).toHaveBeenCalledWith(CAPTURE_URL, IDENTITY.assetPath, 3)
+    const note = files.get(IDENTITY.notePath) ?? ''
+    expect(note).toContain(`captureScreenshot: ${IDENTITY.assetPath}`)
+    expect(note).toContain(`![An article from metadata](${IDENTITY.assetPath})`)
+    expect(note).toContain('captureStatus: done')
+  })
+
+  it('sends a newly attached link preview to the configured AI provider', async () => {
+    addSpool(envelope({ source: 'ios-share' }), { screenshot: false })
+    expect((await drain()).stopped).toBeNull()
+    writeNoteMock.mockClear()
+    linkPreviewMock.mockResolvedValue(true)
+
+    const outcome = await reconcile()
+
+    expect(outcome.enriched).toBe(1)
+    expect(readAssetMock).toHaveBeenCalledWith(IDENTITY.assetPath, 3)
+    expect(describeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ screenshotBase64: btoa('jpeg-bytes') }),
+    )
+  })
+
+  it('does not request a link preview when the capture already has a screenshot', async () => {
+    await drainOne()
+
+    await reconcile()
+
+    expect(linkPreviewMock).not.toHaveBeenCalled()
+  })
+
+  it('continues metadata enrichment when the link preview request fails', async () => {
+    addSpool(envelope({ source: 'ios-share' }), { screenshot: false })
+    expect((await drain()).stopped).toBeNull()
+    writeNoteMock.mockClear()
+    linkPreviewMock.mockRejectedValue(new ReflectError('network', 'preview unavailable'))
+
+    const outcome = await reconcile({ providers: NO_PROVIDERS })
+
+    expect(outcome.enriched).toBe(1)
+    const note = files.get(IDENTITY.notePath) ?? ''
+    expect(note).toContain('captureStatus: done')
+    expect(note).not.toContain('captureScreenshot')
+    expect(note).not.toContain('## Screenshot')
+  })
+
+  it('does not retry a link preview after the metadata checkpoint', async () => {
+    addSpool(envelope({ source: 'ios-share' }), { screenshot: false })
+    expect((await drain()).stopped).toBeNull()
+    writeNoteMock.mockClear()
+    linkPreviewMock.mockResolvedValue(true)
+    getSecretMock.mockResolvedValue(null)
+
+    const waiting = await reconcile()
+
+    expect(waiting.stopped?.reason).toBe('config')
+    expect(files.get(IDENTITY.notePath)).toContain('captureMetadataStatus: done')
+    expect(linkPreviewMock).toHaveBeenCalledTimes(1)
+
+    getSecretMock.mockResolvedValue('sk-live-key')
+    const retry = await reconcile()
+
+    expect(retry.enriched).toBe(1)
+    expect(linkPreviewMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips a capture made private while its link preview is loading', async () => {
+    addSpool(envelope({ source: 'ios-share' }), { screenshot: false })
+    expect((await drain()).stopped).toBeNull()
+    writeNoteMock.mockClear()
+    linkPreviewMock.mockImplementation(async () => {
+      files.set(DAILY, `---\nprivate: true\n---\n\n${files.get(DAILY) ?? ''}`)
+      return true
+    })
+
+    const outcome = await reconcile()
+
+    expect(outcome).toEqual({ pending: 1, enriched: 0, skipped: 1, stopped: null })
+    expect(files.get(IDENTITY.notePath)).toContain('captureStatus: skipped')
+    expect(describeMock).not.toHaveBeenCalled()
+  })
 
   it('patches the AI description into the metadata bullets with provenance', async () => {
     const contentText = [

--- a/packages/core/src/actions/capture-enrichment.test.ts
+++ b/packages/core/src/actions/capture-enrichment.test.ts
@@ -17,6 +17,7 @@ import {
   reconcile,
   scrapeMock,
   wireCaptureMocks,
+  writeAssetMock,
   writeNoteMock,
 } from './capture-harness'
 import { captureIdentity } from './capture'
@@ -34,6 +35,7 @@ vi.mock('../graph/commands', () => ({
   promoteCaptureScreenshot: vi.fn(),
   readAsset: vi.fn(),
   readNote: vi.fn(),
+  writeAsset: vi.fn(),
   writeNote: vi.fn(),
 }))
 vi.mock('./meta-scrape', () => ({
@@ -67,7 +69,7 @@ describe('reconcileCaptureEnrichment', () => {
     addSpool(envelope({ source: 'ios-share', title: '' }), { screenshot: false })
     expect((await drain()).stopped).toBeNull()
     writeNoteMock.mockClear()
-    linkPreviewMock.mockResolvedValue(true)
+    linkPreviewMock.mockResolvedValue(btoa('preview-jpeg'))
     scrapeMock.mockResolvedValue({
       title: 'An article from metadata',
       description: 'A scraped description.',
@@ -77,7 +79,12 @@ describe('reconcileCaptureEnrichment', () => {
     const outcome = await reconcile({ providers: NO_PROVIDERS })
 
     expect(outcome).toEqual({ pending: 1, enriched: 1, skipped: 0, stopped: null })
-    expect(linkPreviewMock).toHaveBeenCalledWith(CAPTURE_URL, IDENTITY.assetPath, 3)
+    expect(linkPreviewMock).toHaveBeenCalledWith(CAPTURE_URL)
+    expect(writeAssetMock).toHaveBeenCalledWith(
+      IDENTITY.assetPath,
+      btoa('preview-jpeg'),
+      3,
+    )
     const note = files.get(IDENTITY.notePath) ?? ''
     expect(note).toContain(`captureScreenshot: ${IDENTITY.assetPath}`)
     expect(note).toContain(`![An article from metadata](${IDENTITY.assetPath})`)
@@ -88,7 +95,7 @@ describe('reconcileCaptureEnrichment', () => {
     addSpool(envelope({ source: 'ios-share' }), { screenshot: false })
     expect((await drain()).stopped).toBeNull()
     writeNoteMock.mockClear()
-    linkPreviewMock.mockResolvedValue(true)
+    linkPreviewMock.mockResolvedValue(btoa('preview-jpeg'))
 
     const outcome = await reconcile()
 
@@ -105,6 +112,28 @@ describe('reconcileCaptureEnrichment', () => {
     await reconcile()
 
     expect(linkPreviewMock).not.toHaveBeenCalled()
+  })
+
+  it('treats an empty screenshot stamp as missing', async () => {
+    addSpool(envelope({ source: 'ios-share' }), { screenshot: false })
+    expect((await drain()).stopped).toBeNull()
+    const source = files.get(IDENTITY.notePath) ?? ''
+    files.set(
+      IDENTITY.notePath,
+      source.replace('captureStatus: pending\n', "captureStatus: pending\ncaptureScreenshot: ''\n"),
+    )
+    writeNoteMock.mockClear()
+    linkPreviewMock.mockResolvedValue(btoa('preview-jpeg'))
+
+    const outcome = await reconcile({ providers: NO_PROVIDERS })
+
+    expect(outcome.enriched).toBe(1)
+    expect(linkPreviewMock).toHaveBeenCalledWith(CAPTURE_URL)
+    expect(writeAssetMock).toHaveBeenCalledWith(
+      IDENTITY.assetPath,
+      btoa('preview-jpeg'),
+      3,
+    )
   })
 
   it('continues metadata enrichment when the link preview request fails', async () => {
@@ -126,7 +155,7 @@ describe('reconcileCaptureEnrichment', () => {
     addSpool(envelope({ source: 'ios-share' }), { screenshot: false })
     expect((await drain()).stopped).toBeNull()
     writeNoteMock.mockClear()
-    linkPreviewMock.mockResolvedValue(true)
+    linkPreviewMock.mockResolvedValue(btoa('preview-jpeg'))
     getSecretMock.mockResolvedValue(null)
 
     const waiting = await reconcile()
@@ -148,13 +177,14 @@ describe('reconcileCaptureEnrichment', () => {
     writeNoteMock.mockClear()
     linkPreviewMock.mockImplementation(async () => {
       files.set(DAILY, `---\nprivate: true\n---\n\n${files.get(DAILY) ?? ''}`)
-      return true
+      return btoa('preview-jpeg')
     })
 
     const outcome = await reconcile()
 
     expect(outcome).toEqual({ pending: 1, enriched: 0, skipped: 1, stopped: null })
     expect(files.get(IDENTITY.notePath)).toContain('captureStatus: skipped')
+    expect(writeAssetMock).not.toHaveBeenCalled()
     expect(describeMock).not.toHaveBeenCalled()
   })
 

--- a/packages/core/src/actions/capture-enrichment.ts
+++ b/packages/core/src/actions/capture-enrichment.ts
@@ -7,7 +7,14 @@ import {
 import { defaultAiProvider, type AiProvidersState } from '../ai/provider-config'
 import { aiKeySecretName } from '../ai/secrets'
 import { errorMessage, isAppError, toAppError } from '../errors'
-import { captureLinkPreview, listFiles, readAsset, readNote, writeNote } from '../graph/commands'
+import {
+  captureLinkPreview,
+  listFiles,
+  readAsset,
+  readNote,
+  writeAsset,
+  writeNote,
+} from '../graph/commands'
 import { dailyPath } from '../graph/paths'
 import { hashContent } from '../indexing/hash'
 import { parseFrontmatter, splitFrontmatter, upsertFrontmatter } from '../markdown/frontmatter'
@@ -149,18 +156,12 @@ async function readCaptureScreenshot(
   }
 }
 
-async function fetchLinkPreviewScreenshot(
-  meta: CaptureNoteMeta,
-  identity: CaptureIdentity,
-  generation: number,
-): Promise<string | null> {
-  if (meta.captureScreenshot !== undefined) {
+async function fetchLinkPreviewImage(meta: CaptureNoteMeta): Promise<string | null> {
+  if (meta.captureScreenshot) {
     return null
   }
   try {
-    return (await captureLinkPreview(meta.captureUrl, identity.assetPath, generation))
-      ? identity.assetPath
-      : null
+    return await captureLinkPreview(meta.captureUrl)
   } catch {
     return null
   }
@@ -341,9 +342,26 @@ export async function reconcileCaptureEnrichment(
       if (snapshot === null) {
         continue
       }
-      const previewScreenshot = metadataComplete
+      const previewImage = metadataComplete
         ? null
-        : await fetchLinkPreviewScreenshot(snapshot.meta, identity, input.generation)
+        : await fetchLinkPreviewImage(snapshot.meta)
+      if (stale()) {
+        return outcome({ reason: 'stale', message: 'the graph session ended mid-pass' })
+      }
+      snapshot = await currentCapture(identity)
+      if (snapshot === null) {
+        continue
+      }
+      let previewScreenshot: string | null = null
+      if (previewImage !== null) {
+        try {
+          await writeAsset(identity.assetPath, previewImage, input.generation)
+          previewScreenshot = identity.assetPath
+        } catch {
+          // A preview is optional; metadata enrichment still completes when
+          // the local asset cannot be persisted.
+        }
+      }
       if (stale()) {
         return outcome({ reason: 'stale', message: 'the graph session ended mid-pass' })
       }

--- a/packages/core/src/actions/capture-enrichment.ts
+++ b/packages/core/src/actions/capture-enrichment.ts
@@ -7,7 +7,7 @@ import {
 import { defaultAiProvider, type AiProvidersState } from '../ai/provider-config'
 import { aiKeySecretName } from '../ai/secrets'
 import { errorMessage, isAppError, toAppError } from '../errors'
-import { listFiles, readAsset, readNote, writeNote } from '../graph/commands'
+import { captureLinkPreview, listFiles, readAsset, readNote, writeNote } from '../graph/commands'
 import { dailyPath } from '../graph/paths'
 import { hashContent } from '../indexing/hash'
 import { parseFrontmatter, splitFrontmatter, upsertFrontmatter } from '../markdown/frontmatter'
@@ -32,6 +32,7 @@ import {
   notePrivate,
   noteSource,
   withDescription,
+  withScreenshot,
   withTitle,
   type CaptureNoteMeta,
 } from './capture-note'
@@ -145,6 +146,23 @@ async function readCaptureScreenshot(
       throw cause
     }
     return undefined
+  }
+}
+
+async function fetchLinkPreviewScreenshot(
+  meta: CaptureNoteMeta,
+  identity: CaptureIdentity,
+  generation: number,
+): Promise<string | null> {
+  if (meta.captureScreenshot !== undefined) {
+    return null
+  }
+  try {
+    return (await captureLinkPreview(meta.captureUrl, identity.assetPath, generation))
+      ? identity.assetPath
+      : null
+  } catch {
+    return null
   }
 }
 
@@ -323,6 +341,16 @@ export async function reconcileCaptureEnrichment(
       if (snapshot === null) {
         continue
       }
+      const previewScreenshot = metadataComplete
+        ? null
+        : await fetchLinkPreviewScreenshot(snapshot.meta, identity, input.generation)
+      if (stale()) {
+        return outcome({ reason: 'stale', message: 'the graph session ended mid-pass' })
+      }
+      snapshot = await currentCapture(identity)
+      if (snapshot === null) {
+        continue
+      }
       const placeholderTitle = displayTitle({ title: '', url: snapshot.meta.captureUrl })
       const metadataTitle =
         snapshot.title === placeholderTitle && pageMeta?.title
@@ -339,6 +367,9 @@ export async function reconcileCaptureEnrichment(
       if (metadataTitle !== null) {
         metadataBody = withTitle(metadataBody, metadataTitle)
       }
+      if (previewScreenshot !== null) {
+        metadataBody = withScreenshot(metadataBody, metadataDisplayTitle, previewScreenshot)
+      }
 
       if (config === null) {
         const titleChanged = metadataDisplayTitle !== snapshot.title
@@ -354,6 +385,7 @@ export async function reconcileCaptureEnrichment(
           toTitle: metadataDisplayTitle,
           status: titleChanged ? 'pending' : 'done',
           provider: null,
+          screenshot: previewScreenshot ?? undefined,
           generation: input.generation,
         })
         if (captureHash === null) {
@@ -390,6 +422,7 @@ export async function reconcileCaptureEnrichment(
           toTitle: metadataDisplayTitle,
           status: 'pending',
           provider: null,
+          screenshot: previewScreenshot ?? undefined,
           generation: input.generation,
         })
         if (persistedHash === null) {

--- a/packages/core/src/actions/capture-harness.ts
+++ b/packages/core/src/actions/capture-harness.ts
@@ -6,6 +6,7 @@ import {
   captureInboxRead,
   captureInboxReject,
   captureInboxRemove,
+  captureLinkPreview,
   listFiles,
   promoteCaptureScreenshot,
   readAsset,
@@ -39,6 +40,7 @@ export const inboxListMock = vi.mocked(captureInboxList)
 export const inboxReadMock = vi.mocked(captureInboxRead)
 export const inboxRejectMock = vi.mocked(captureInboxReject)
 export const inboxRemoveMock = vi.mocked(captureInboxRemove)
+export const linkPreviewMock = vi.mocked(captureLinkPreview)
 export const listFilesMock = vi.mocked(listFiles)
 export const promoteMock = vi.mocked(promoteCaptureScreenshot)
 export const readAssetMock = vi.mocked(readAsset)
@@ -151,6 +153,7 @@ export function wireCaptureMocks(): void {
     [...files.keys()].map((path) => ({ path, size: 1, modifiedMs: 0 })),
   )
   readAssetMock.mockResolvedValue(btoa('jpeg-bytes'))
+  linkPreviewMock.mockResolvedValue(false)
   getSecretMock.mockResolvedValue('sk-live-key')
   scrapeMock.mockResolvedValue({ title: 'An article', description: null, siteName: null })
   describeMock.mockResolvedValue({ title: null, description: 'An AI description of the page.' })

--- a/packages/core/src/actions/capture-harness.ts
+++ b/packages/core/src/actions/capture-harness.ts
@@ -11,6 +11,7 @@ import {
   promoteCaptureScreenshot,
   readAsset,
   readNote,
+  writeAsset,
   writeNote,
 } from '../graph/commands'
 import { getSecret } from '../secrets/keychain'
@@ -45,6 +46,7 @@ export const listFilesMock = vi.mocked(listFiles)
 export const promoteMock = vi.mocked(promoteCaptureScreenshot)
 export const readAssetMock = vi.mocked(readAsset)
 export const readNoteMock = vi.mocked(readNote)
+export const writeAssetMock = vi.mocked(writeAsset)
 export const writeNoteMock = vi.mocked(writeNote)
 export const scrapeMock = vi.mocked(scrapePageMeta)
 export const describeMock = vi.mocked(describePage)
@@ -153,7 +155,10 @@ export function wireCaptureMocks(): void {
     [...files.keys()].map((path) => ({ path, size: 1, modifiedMs: 0 })),
   )
   readAssetMock.mockResolvedValue(btoa('jpeg-bytes'))
-  linkPreviewMock.mockResolvedValue(false)
+  writeAssetMock.mockImplementation(async (path, contentsBase64) => {
+    files.set(path, contentsBase64)
+  })
+  linkPreviewMock.mockResolvedValue(null)
   getSecretMock.mockResolvedValue('sk-live-key')
   scrapeMock.mockResolvedValue({ title: 'An article', description: null, siteName: null })
   describeMock.mockResolvedValue({ title: null, description: 'An AI description of the page.' })

--- a/packages/core/src/actions/capture-note.ts
+++ b/packages/core/src/actions/capture-note.ts
@@ -202,6 +202,12 @@ export function withTitle(body: string, title: string): string {
   )
 }
 
+/** Append a screenshot section backed by a graph-relative asset. */
+export function withScreenshot(body: string, title: string, assetPath: string): string {
+  const separator = body.endsWith('\n') ? '\n' : '\n\n'
+  return `${body}${separator}## Screenshot\n\n![${title}](${assetPath})\n`
+}
+
 /**
  * Rewrite a daily entry's wiki-link display text after its capture note was
  * retitled. Both writers (the drain's dedup refresh and the enrichment

--- a/packages/core/src/graph/commands.ts
+++ b/packages/core/src/graph/commands.ts
@@ -348,6 +348,18 @@ export async function promoteCaptureScreenshot(
 }
 
 /**
+ * Ask the native platform for one representative image for a captured URL.
+ * Returns `false` when the platform or page has no preview image.
+ */
+export async function captureLinkPreview(
+  url: string,
+  assetPath: string,
+  generation: number,
+): Promise<boolean> {
+  return call('capture_link_preview', { url, assetPath, generation }, z.boolean())
+}
+
+/**
  * Fetch a captured page's HTML for meta-tag scraping — the Rust side caps
  * scheme/timeout/size/redirects, so arbitrary capture URLs never widen the
  * webview's own HTTP capability. The privacy gate runs before any call here.

--- a/packages/core/src/graph/commands.ts
+++ b/packages/core/src/graph/commands.ts
@@ -349,14 +349,10 @@ export async function promoteCaptureScreenshot(
 
 /**
  * Ask the native platform for one representative image for a captured URL.
- * Returns `false` when the platform or page has no preview image.
+ * Returns a base64-encoded normalized JPEG, or `null` when unavailable.
  */
-export async function captureLinkPreview(
-  url: string,
-  assetPath: string,
-  generation: number,
-): Promise<boolean> {
-  return call('capture_link_preview', { url, assetPath, generation }, z.boolean())
+export async function captureLinkPreview(url: string): Promise<string | null> {
+  return call('capture_link_preview', { url }, z.string().nullable())
 }
 
 /**


### PR DESCRIPTION
This PR takes a different approach from #888.

#888 fetches Open Graph data in Rust. This means we need to handle DNS lookups, IP filtering, redirects, and SSRF protection ourselves. More custom networking code means more chances for bugs and security issues.

This PR uses Apple’s built-in [Link Presentation](https://developer.apple.com/documentation/linkpresentation) framework instead. The code is much simpler, and Apple handles the network requests and metadata parsing.

The downside is that it only works on Apple platforms, so we cannot reuse it on Android. I think this is a reasonable tradeoff.

---

**Before:**




https://github.com/user-attachments/assets/95be9ab4-23d4-4065-9b8b-60c85944712f




**After:**

https://github.com/user-attachments/assets/2a2ae349-a9ee-4df6-9a30-26c733980883


---

## What

- Add an Apple-only Rust capability backed by `LPMetadataProvider` to obtain one representative image for a captured URL.
- Normalize provider images to bounded 1600px JPEG assets and reuse the existing atomic asset persistence path.
- Attach the preview during capture metadata enrichment, persist it through the existing checkpoint transaction, and make it available to optional AI enrichment.
- Link `LinkPresentation.framework` in the iOS project and add a macOS CI compile check for the Apple Rust bindings.
- Document the network/privacy behavior and the iOS simulator verification flow.

## Why

iOS share-sheet captures normally contain only a URL and page metadata, so their capture notes lack the visual context that browser-extension screenshots provide. Apple LinkPresentation already implements the platform-native preview selection behavior on macOS and iOS, so this uses that single system path instead of maintaining a separate HTML image scraper and downloader.

## Behavior and safety

- Existing capture screenshots always win and skip LinkPresentation.
- Non-Apple platforms return no preview without making a network request.
- Preview failures degrade to metadata-only enrichment and are checkpointed without retries.
- The capture note and daily note privacy/edit guards run before and after the preview request.
- Provider bytes, decoded dimensions, decoder allocation, and output dimensions are bounded before persistence.

## Checks

- `pnpm check`
- `pnpm test --run packages/core/src/actions/capture-enrichment.test.ts packages/core/src/actions/capture-drain.test.ts`
- `cargo fmt --all -- --check`
- `cargo clippy -p reflect-open --lib -- -D warnings`
- `cargo test -p reflect-open --lib`
- `TAURI_ENV_PLATFORM=ios cargo check -p reflect-open --lib --target aarch64-apple-ios-sim`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic link-preview images for URL-only captures on Apple platforms.
  * Preview images are added to capture notes and can be used during optional AI enrichment.
* **Bug Fixes**
  * Improved image resizing and validation to prevent oversized or invalid image processing.
  * Private captures do not request or retain link previews.
* **Documentation**
  * Added guidance for testing link previews in the iOS simulator.
  * Clarified privacy behavior for capture metadata and previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->