### PR TITLE
fix: keep long AI prompts within the dialog

### DIFF
--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -1052,6 +1052,22 @@ describe('SettingsScreen', () => {
     await vi.waitFor(() => expect(saved.at(-1)).toMatchObject({ chatSystemPrompt: '' }))
   })
 
+  it('keeps long AI prompts scrollable within the viewport', async () => {
+    await renderScreen()
+    const section = page.getByRole('region', { name: 'AI prompts' })
+
+    await section.getByRole('button', { name: /add prompt/i }).click()
+    const dialog = page.getByRole('dialog', { name: /add prompt/i })
+    const promptBody = dialog.getByPlaceholder(/Translate the following/)
+
+    expect(dialog.element().className).toContain('max-h-[calc(100dvh-2rem)]')
+    expect(dialog.element().className).toContain('overflow-y-auto')
+    expect(promptBody.element().className).toContain('field-sizing-fixed')
+    expect(promptBody.element().className).toContain('max-h-[50dvh]')
+    expect(promptBody.element().className).toContain('resize-y')
+    expect(promptBody.element().className).toContain('overflow-y-auto')
+  })
+
   it('adding an AI prompt persists the full document', async () => {
     await renderScreen()
     const section = page.getByRole('region', { name: 'AI prompts' })

--- a/apps/desktop/src/components/settings/ai-prompt-dialog.tsx
+++ b/apps/desktop/src/components/settings/ai-prompt-dialog.tsx
@@ -70,7 +70,10 @@ export function AiPromptDialog({ prompt, onSave, onClose }: AiPromptDialogProps)
         if (!isOpen) onClose()
       }}
     >
-      <DialogContent showCloseButton={false} className="max-w-md">
+      <DialogContent
+        showCloseButton={false}
+        className="max-h-[calc(100dvh-2rem)] max-w-md overflow-y-auto"
+      >
         <DialogHeader>
           <DialogTitle>{prompt === null ? 'Add prompt' : 'Edit prompt'}</DialogTitle>
           <DialogDescription>
@@ -99,6 +102,7 @@ export function AiPromptDialog({ prompt, onSave, onClose }: AiPromptDialogProps)
             <Textarea
               {...register('body', { required: true })}
               aria-invalid={formState.errors.body !== undefined || undefined}
+              className="field-sizing-fixed h-40 max-h-[50dvh] resize-y overflow-y-auto"
               rows={5}
               placeholder={'Translate the following text to French.\n\n{{selectedText}}'}
             />


### PR DESCRIPTION
## Problem

The AI prompt textarea inherited content-based sizing from the shared textarea component. Pasting a long prompt therefore expanded the field and its centered dialog beyond the window, hiding the result selector and the `Add prompt` / `Save` action.

## Before -> After

| Before | After |
| --- | --- |
| Long prompt text expanded the dialog past the viewport. | The prompt body scrolls within a vertically resizable field. |
| Dialog actions could move off-screen with no usable way to reach them. | The dialog is capped to the viewport and can scroll as a fallback. |

## Changes

1. Give the prompt body a fixed initial height, vertical resize behavior, independent overflow scrolling, and a viewport-relative maximum height.
2. Cap the add/edit prompt dialog to the available viewport height.
3. Add a regression test that pins both overflow safeguards.

## Verification

- `pnpm --filter @reflect/desktop exec vitest run src/components/settings-screen.test.tsx` — 44 tests passed.
- `pnpm check` — typecheck and lint passed.
- `pnpm build` — production build passed.

## Risk / Rollout

Low-risk CSS-only behavior change scoped to the AI prompt dialog. No data, persistence, or prompt execution behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout change limited to the AI prompt dialog; no persistence or prompt execution logic is touched.
> 
> **Overview**
> Fixes the add/edit AI prompt dialog growing past the window when the prompt body is long (from the shared textarea’s content-based sizing), which could hide the result selector and submit actions.
> 
> **`AiPromptDialog`** now caps `DialogContent` with `max-h-[calc(100dvh-2rem)]` and `overflow-y-auto`, and styles the prompt `Textarea` with fixed field sizing, a `50dvh` max height, vertical resize, and its own scroll.
> 
> A **settings screen regression test** asserts those layout classes on the dialog and prompt field when opening Add prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb97f0ea0efa40a27d59ceeb7026761bd9fc416c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the AI prompt dialog layout for smaller screens and long prompts.
  * Added/strengthened vertical scrolling inside the dialog and the prompt text area so long content stays accessible within the viewport.
  * Added a unit test to verify the dialog and prompt area sizing/scroll behavior for long prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->