### PR TITLE
fix: reuse person notes by contact email

### DIFF
--- a/apps/desktop/src/components/context-sidebar/attendee-combobox.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/attendee-combobox.test.tsx
@@ -74,8 +74,13 @@ describe('AttendeeCombobox', () => {
     await expect.element(input).toHaveValue('')
   })
 
-  it('a picked contact carries its invite email for the note pre-fill', async () => {
-    contactLinkSuggestions.mockResolvedValue([contact('Grace Hopper', 'grace@example.com')])
+  it('a picked contact carries all emails for identity resolution', async () => {
+    contactLinkSuggestions.mockResolvedValue([
+      {
+        ...contact('Grace Hopper', 'grace@example.com'),
+        emails: ['grace@example.com', 'grace@work.example'],
+      },
+    ])
     const input = await renderCombobox()
 
     await input.fill('gra')
@@ -83,7 +88,10 @@ describe('AttendeeCombobox', () => {
     await expect.element(page.getByText('grace@example.com')).toBeInTheDocument()
     await userEvent.keyboard('{Enter}')
 
-    expect(onAdd).toHaveBeenCalledWith({ name: 'Grace Hopper', email: 'grace@example.com' })
+    expect(onAdd).toHaveBeenCalledWith({
+      name: 'Grace Hopper',
+      emails: ['grace@example.com', 'grace@work.example'],
+    })
   })
 
   it('Enter with no suggestions adds the typed name verbatim', async () => {
@@ -96,7 +104,21 @@ describe('AttendeeCombobox', () => {
     await expect.element(input).toHaveValue('')
   })
 
-  it('Enter during a pending refetch adds the typed text, not a stale row', async () => {
+  it('blur does not bypass an exact Contact row', async () => {
+    contactLinkSuggestions.mockResolvedValue([
+      contact('Grace Hopper', 'grace@example.com'),
+    ])
+    const input = await renderCombobox()
+
+    await input.fill('Grace Hopper')
+    await expect.element(page.getByText('grace@example.com')).toBeInTheDocument()
+    await userEvent.tab()
+
+    expect(onAdd).not.toHaveBeenCalled()
+    await expect.element(input).toHaveValue('Grace Hopper')
+  })
+
+  it('Enter during a pending refetch does not add stale or identity-less text', async () => {
     suggestWikiTargets.mockResolvedValue([noteSuggestion('Ada Lovelace')])
     const input = await renderCombobox()
 
@@ -110,7 +132,8 @@ describe('AttendeeCombobox', () => {
     await input.fill('Adam Smith')
     await userEvent.keyboard('{Enter}')
 
-    expect(onAdd).toHaveBeenCalledWith({ name: 'Adam Smith' })
+    expect(onAdd).not.toHaveBeenCalled()
+    await expect.element(input).toHaveValue('Adam Smith')
   })
 
   it('offers an Add row for a name that matches nothing exactly', async () => {

--- a/apps/desktop/src/components/context-sidebar/attendee-combobox.tsx
+++ b/apps/desktop/src/components/context-sidebar/attendee-combobox.tsx
@@ -98,7 +98,14 @@ export function AttendeeCombobox({ attendees, onAdd }: AttendeeComboboxProps): R
       return buildAutocompleteEntries(
         searchTerm,
         suggestions.filter((suggestion) => suggestion.date === null),
-        { offerCreate: true, contacts },
+        {
+          offerCreate: true,
+          contacts: contacts.map((contact) => ({
+            contact,
+            target: contact.fullName,
+            ownerPath: null,
+          })),
+        },
       )
     },
     enabled: hasBridge() && graph !== null && searchTerm !== '',

--- a/apps/desktop/src/components/context-sidebar/attendee-combobox.tsx
+++ b/apps/desktop/src/components/context-sidebar/attendee-combobox.tsx
@@ -48,10 +48,10 @@ function entryName(entry: AutocompleteEntry): string {
 }
 
 function entryAttendee(entry: AutocompleteEntry): MeetingAttendee {
-  // A contact's invite email rides along so the submit-time contacts lookup
-  // can pre-fill the person note, exactly like calendar-sourced attendees.
+  // Every Contact email rides along so submit-time ownership cannot give the
+  // primary address special treatment.
   return entry.kind === 'contact'
-    ? { name: entry.contact.fullName, email: entry.contact.emails[0] }
+    ? { name: entry.contact.fullName, emails: entry.contact.emails }
     : { name: entryName(entry) }
 }
 
@@ -81,7 +81,7 @@ export function AttendeeCombobox({ attendees, onAdd }: AttendeeComboboxProps): R
   const deferredQuery = useDeferredValue(query)
   const searchTerm = deferredQuery.trim()
 
-  const { data: fetched, isPlaceholderData } = useQuery({
+  const { data: fetched, isFetching, isPlaceholderData } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'attendee-suggestions', searchTerm, contactsInMenu],
     queryFn: async () => {
       const [suggestions, contacts] = await Promise.all([
@@ -121,9 +121,17 @@ export function AttendeeCombobox({ attendees, onAdd }: AttendeeComboboxProps): R
   const open = !dismissed && query.trim() !== '' && entries.length > 0
   // The list lags the input twice over (the deferred value, then the fetch —
   // keepPreviousData shows the prior query's rows meanwhile). Enter may only
-  // take the highlighted row when the rows answer exactly what's typed;
-  // anything staler falls back to the typed text, like blur always does.
-  const entriesMatchInput = !isPlaceholderData && searchTerm === query.trim()
+  // take the highlighted row or add typed text only when the rows answer
+  // exactly what is typed. Pending results must not discard Contact emails.
+  const entriesMatchInput =
+    !isFetching && !isPlaceholderData && searchTerm === query.trim()
+  const exactContact = entriesMatchInput
+    ? entries.find(
+        (entry) =>
+          entry.kind === 'contact' &&
+          foldKey(entry.contact.fullName) === foldKey(query),
+      )
+    : undefined
 
   const select = (entry: AutocompleteEntry): void => {
     onAdd(entryAttendee(entry))
@@ -133,7 +141,7 @@ export function AttendeeCombobox({ attendees, onAdd }: AttendeeComboboxProps): R
 
   const addTyped = (): void => {
     const name = query.trim()
-    if (name === '') {
+    if (name === '' || !entriesMatchInput || exactContact !== undefined) {
       return
     }
     onAdd({ name })
@@ -151,8 +159,9 @@ export function AttendeeCombobox({ attendees, onAdd }: AttendeeComboboxProps): R
         open && entriesMatchInput
           ? entries.find((candidate) => entryKey(candidate) === highlighted)
           : undefined
-      if (entry !== undefined) {
-        select(entry)
+      const selected = entry ?? exactContact
+      if (selected !== undefined) {
+        select(selected)
       } else {
         addTyped()
       }

--- a/apps/desktop/src/components/context-sidebar/daily-events-section.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/daily-events-section.test.tsx
@@ -227,7 +227,7 @@ describe('DailyEventsSection', () => {
     await vi.waitFor(() =>
       expect(addMeetingToDaily).toHaveBeenCalledWith(
         expect.objectContaining({
-          attendees: [{ name: 'Ada Lovelace', email: 'ada@example.com' }],
+          attendees: [{ name: 'Ada Lovelace', emails: ['ada@example.com'] }],
           lookupContacts: true,
         }),
       ),
@@ -236,7 +236,7 @@ describe('DailyEventsSection', () => {
 
   it('upgrades a prefilled chip to the note that owns its invite email', async () => {
     resolveMeetingAttendees.mockResolvedValueOnce([
-      { name: 'Ada Lovelace', email: 'ada@example.com' },
+      { name: 'Ada Lovelace', emails: ['ada@example.com'] },
     ])
     events = [
       eventAt(9, {
@@ -262,7 +262,7 @@ describe('DailyEventsSection', () => {
     await vi.waitFor(() =>
       expect(addMeetingToDaily).toHaveBeenCalledWith(
         expect.objectContaining({
-          attendees: [{ name: 'Ada Lovelace', email: 'ada@example.com' }],
+          attendees: [{ name: 'Ada Lovelace', emails: ['ada@example.com'] }],
         }),
       ),
     )

--- a/apps/desktop/src/editor/use-editor-autocomplete.test.tsx
+++ b/apps/desktop/src/editor/use-editor-autocomplete.test.tsx
@@ -3,9 +3,13 @@ import { renderHook } from 'vitest-browser-react'
 import { useEditorAutocomplete } from './use-editor-autocomplete'
 
 const resolveOrCreateNoteWithTitle = vi.hoisted(() => vi.fn())
+const ensurePersonNote = vi.hoisted(() => vi.fn())
+const contactLinkSuggestions = vi.hoisted(() => vi.fn())
+const resolvePersonContact = vi.hoisted(() => vi.fn())
 const suggestWikiLinkTargets = vi.hoisted(() => vi.fn())
 const operationFail = vi.hoisted(() => vi.fn())
 const startOperation = vi.hoisted(() => vi.fn(() => ({ fail: operationFail })))
+const settingsState = vi.hoisted(() => ({ contactsEnabled: false }))
 
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
@@ -13,7 +17,10 @@ vi.mock('@reflect/core', async (importOriginal) => ({
   suggestWikiTargets: async () => [],
   suggestWikiLinkTargets,
   suggestTags: async () => [],
+  contactLinkSuggestions,
+  ensurePersonNote,
   resolveOrCreateNoteWithTitle,
+  resolvePersonContact,
 }))
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({ graph: { generation: 7 } }),
@@ -21,19 +28,23 @@ vi.mock('@/providers/graph-provider', () => ({
 vi.mock('@/providers/settings-provider', () => ({
   useSettings: () => ({
     settings: {
-      contactsEnabled: false,
+      ...settingsState,
       dateFormat: 'MMM d, yyyy',
       weekStartDay: 1,
     },
   }),
 }))
 vi.mock('@/hooks/use-contacts-authorization', () => ({
-  useContactsAuthorization: () => null,
+  useContactsAuthorization: () => 'authorized',
 }))
 vi.mock('@/lib/operations', () => ({ startOperation }))
 
 beforeEach(() => {
   resolveOrCreateNoteWithTitle.mockReset()
+  ensurePersonNote.mockReset()
+  contactLinkSuggestions.mockReset().mockResolvedValue([])
+  resolvePersonContact.mockReset()
+  settingsState.contactsEnabled = false
   suggestWikiLinkTargets.mockReset()
   suggestWikiLinkTargets.mockResolvedValue({
     suggestions: [],
@@ -130,5 +141,105 @@ describe('useEditorAutocomplete', () => {
     )
     expect(startOperation).not.toHaveBeenCalled()
     expect(operationFail).not.toHaveBeenCalled()
+  })
+
+  it('uses an existing email owner as the Contact row target', async () => {
+    settingsState.contactsEnabled = true
+    const contact = {
+      fullName: 'Ada Lovelace',
+      givenName: 'Ada',
+      familyName: 'Lovelace',
+      emails: ['ada@example.com'],
+      phones: [],
+    }
+    contactLinkSuggestions.mockResolvedValue([contact])
+    resolvePersonContact.mockResolvedValue({
+      kind: 'existing',
+      contact,
+      emails: ['ada@example.com'],
+      path: 'notes/augusta.md',
+      title: 'Augusta Ada King',
+      insertText: 'Augusta Ada King',
+    })
+    ensurePersonNote.mockResolvedValue({
+      kind: 'existing',
+      emails: ['ada@example.com'],
+      path: 'notes/augusta.md',
+      title: 'Augusta Ada King',
+      insertText: 'Augusta Ada King',
+    })
+    const { result, act } = await renderHook(() => useEditorAutocomplete())
+
+    const items = await result.current.onWikilinkSearch('Ada')
+    expect(items).toMatchObject([
+      {
+        target: 'Augusta Ada King',
+        label: 'Ada Lovelace',
+        detail: 'ada@example.com',
+      },
+      { target: 'Ada', label: 'Create “Ada”' },
+    ])
+
+    await act(() => {
+      items[0]!.onSelect?.()
+    })
+    await vi.waitFor(() =>
+      expect(ensurePersonNote).toHaveBeenCalledWith({
+        title: 'Ada Lovelace',
+        emails: ['ada@example.com'],
+        body: '- Type: #person\n- Email: ada@example.com',
+        generation: 7,
+      }),
+    )
+  })
+
+  it('hides an exact blocked Contact and its Create fallback', async () => {
+    settingsState.contactsEnabled = true
+    const contact = {
+      fullName: 'Ada Lovelace',
+      givenName: 'Ada',
+      familyName: 'Lovelace',
+      emails: ['ada@example.com'],
+      phones: [],
+    }
+    contactLinkSuggestions.mockResolvedValue([contact])
+    resolvePersonContact.mockResolvedValue({
+      kind: 'blocked',
+      contact,
+      reason: 'identity-conflict',
+    })
+    const { result } = await renderHook(() => useEditorAutocomplete())
+
+    await expect(
+      result.current.onWikilinkSearch('Ada Lovelace'),
+    ).resolves.toEqual([])
+  })
+
+  it('reports a failed Contact creation through the operation UI', async () => {
+    settingsState.contactsEnabled = true
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const contact = {
+      fullName: 'Ada Lovelace',
+      givenName: 'Ada',
+      familyName: 'Lovelace',
+      emails: ['ada@example.com'],
+      phones: [],
+    }
+    contactLinkSuggestions.mockResolvedValue([contact])
+    resolvePersonContact.mockResolvedValue({
+      kind: 'new',
+      contact,
+      insertText: 'Ada Lovelace',
+    })
+    ensurePersonNote.mockRejectedValue(new Error('graph changed'))
+    const { result, act } = await renderHook(() => useEditorAutocomplete())
+    const items = await result.current.onWikilinkSearch('Ada Lovelace')
+
+    await act(() => {
+      items[0]!.onSelect?.()
+    })
+
+    await vi.waitFor(() => expect(operationFail).toHaveBeenCalledWith('graph changed'))
+    consoleError.mockRestore()
   })
 })

--- a/apps/desktop/src/editor/use-editor-autocomplete.ts
+++ b/apps/desktop/src/editor/use-editor-autocomplete.ts
@@ -7,11 +7,14 @@ import {
 } from '@meowdown/react'
 import {
   contactLinkSuggestions,
+  contactDetailsMarkdown,
   displayNoteTitle,
+  ensurePersonNote,
   errorMessage,
   hasBridge,
   isContactsReadable,
   resolveOrCreateNoteWithTitle,
+  resolvePersonContact,
   suggestTags,
   suggestWikiLinkTargets,
 } from '@reflect/core'
@@ -19,7 +22,6 @@ import { reportAmbiguousNoteTitle } from '@/editor/ambiguous-note-feedback'
 import { buildAutocompleteEntries } from '@/editor/wiki-autocomplete-entries'
 import { useContactsAuthorization } from '@/hooks/use-contacts-authorization'
 import { formatDayLabel, todayIso } from '@/lib/dates'
-import { createPersonNoteFromContact } from '@/lib/note-contact'
 import { startOperation } from '@/lib/operations'
 import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
@@ -83,20 +85,37 @@ export function useEditorAutocomplete(): EditorAutocomplete {
         dateFormat: settings.dateFormat,
         weekStartDay: settings.weekStartDay,
       }
-      const [wikiLinks, contacts] = await Promise.all([
+      const [wikiLinks, contactResolutions] = await Promise.all([
         suggestWikiLinkTargets(query, 8, dateContext),
         // A contacts hiccup (permission revoked mid-session, store error)
         // must cost only its own rows, never the note suggestions.
         contactsInMenu
-          ? contactLinkSuggestions(query).catch((error: unknown) => {
-              console.error('contact link suggestions failed:', error)
-              return []
-            })
+          ? contactLinkSuggestions(query)
+              .then((contacts) =>
+                Promise.all(contacts.map((contact) => resolvePersonContact(contact))),
+              )
+              .catch((error: unknown) => {
+                console.error('contact link suggestions failed:', error)
+                return []
+              })
           : Promise.resolve([]),
       ])
+      const contacts = contactResolutions.flatMap((resolution) =>
+        resolution.kind === 'blocked'
+          ? []
+          : [{
+              contact: resolution.contact,
+              target: resolution.insertText,
+              ownerPath: resolution.kind === 'existing' ? resolution.path : null,
+            }],
+      )
+      const blockedContactNames = contactResolutions.flatMap((resolution) =>
+        resolution.kind === 'blocked' ? [resolution.contact.fullName] : [],
+      )
       return buildAutocompleteEntries(query, wikiLinks.suggestions, {
         offerCreate: true,
         contacts,
+        blockedContactNames,
         requireSerializableWikiText: true,
         queryReadsAsDate: wikiLinks.queryReadsAsDate,
         claimedTargetKeys: wikiLinks.claimedTargetKeys,
@@ -118,18 +137,30 @@ export function useEditorAutocomplete(): EditorAutocomplete {
         if (entry.kind === 'contact') {
           const { contact } = entry
           return {
-            target: contact.fullName,
+            target: entry.target,
             label: contact.fullName,
             detail: contact.emails[0] ?? contact.phones[0] ?? 'Contact',
-            // Like the create row: the menu inserts the link text; the person
-            // note is born in the background, prefilled from the contact.
             onSelect: () => {
               if (generation !== null) {
-                void createPersonNoteFromContact(contact, generation).catch(
-                  (error: unknown) => {
+                void ensurePersonNote({
+                  title: contact.fullName,
+                  emails: contact.emails,
+                  body: contactDetailsMarkdown(contact),
+                  generation,
+                })
+                  .then((outcome) => {
+                    if (outcome.kind === 'ambiguous') {
+                      reportAmbiguousNoteTitle('Creating note', contact.fullName)
+                    } else if (outcome.kind === 'unavailable') {
+                      startOperation('Creating note').fail(
+                        `Couldn’t create “${contact.fullName}” while a potentially matching note is unavailable. Try again when it is available on this device.`,
+                      )
+                    }
+                  })
+                  .catch((error: unknown) => {
                     console.error('create-person-note failed:', error)
-                  },
-                )
+                    startOperation('Creating note').fail(errorMessage(error))
+                  })
               }
             },
           }

--- a/apps/desktop/src/editor/wiki-autocomplete-entries.test.ts
+++ b/apps/desktop/src/editor/wiki-autocomplete-entries.test.ts
@@ -27,6 +27,11 @@ function contact(overrides: Partial<ContactMatch>): ContactMatch {
   }
 }
 
+function contactCandidate(overrides: Partial<ContactMatch> = {}) {
+  const value = contact(overrides)
+  return { contact: value, target: value.fullName, ownerPath: null }
+}
+
 describe('buildAutocompleteEntries', () => {
   it('offers create when nothing matches the typed text exactly', () => {
     const entries = buildAutocompleteEntries('New Idea', [
@@ -96,7 +101,7 @@ describe('buildAutocompleteEntries', () => {
       expect(
         buildAutocompleteEntries(unsafeName, [], {
           offerCreate: true,
-          contacts: [contact({ fullName: unsafeName })],
+          contacts: [contactCandidate({ fullName: unsafeName })],
           requireSerializableWikiText: true,
         }),
       ).toEqual([])
@@ -141,7 +146,7 @@ describe('buildAutocompleteEntries', () => {
     expect(
       buildAutocompleteEntries('Ada Lovelace', [], {
         offerCreate: true,
-        contacts: [contact({})],
+        contacts: [contactCandidate()],
         claimedTargetKeys: ['ada lovelace'],
       }),
     ).toEqual([])
@@ -153,7 +158,7 @@ describe('buildAutocompleteEntries', () => {
     // bare `Ideas` would be refused by the writable resolver's fallback guard.
     const entries = buildAutocompleteEntries('Ideas', [], {
       offerCreate: true,
-      contacts: [contact({ fullName: 'Ideas' })],
+      contacts: [contactCandidate({ fullName: 'Ideas' })],
       claimedTargetKeys: ['🧠 ideas'],
     })
     expect(entries).toEqual([])
@@ -162,7 +167,7 @@ describe('buildAutocompleteEntries', () => {
   it('drops a claimed contact found by a partial query', () => {
     const entries = buildAutocompleteEntries('Road', [], {
       offerCreate: true,
-      contacts: [contact({ fullName: 'Roadmap' })],
+      contacts: [contactCandidate({ fullName: 'Roadmap' })],
       claimedTargetKeys: ['roadmap'],
     })
     expect(entries).toEqual([{ kind: 'create', title: 'Road' }])
@@ -172,10 +177,17 @@ describe('buildAutocompleteEntries', () => {
     const ada = contact({})
     const entries = buildAutocompleteEntries('Ada Lovelace', [], {
       offerCreate: true,
-      contacts: [ada],
+      contacts: [{ contact: ada, target: ada.fullName, ownerPath: null }],
       claimedTargetKeys: ['roadmap'],
     })
-    expect(entries).toEqual([{ kind: 'contact', contact: ada }])
+    expect(entries).toEqual([
+      {
+        kind: 'contact',
+        contact: ada,
+        target: 'Ada Lovelace',
+        ownerPath: null,
+      },
+    ])
   })
 
   it('never offers create from unsettled (in-flight) suggestions', () => {
@@ -200,17 +212,72 @@ describe('buildAutocompleteEntries', () => {
     const entries = buildAutocompleteEntries(
       'Ada L',
       [suggestion({ target: 'Ada Lovelace Notes', title: 'Ada Lovelace Notes' })],
-      { offerCreate: true, contacts: [ada] },
+      {
+        offerCreate: true,
+        contacts: [{ contact: ada, target: ada.fullName, ownerPath: null }],
+      },
     )
     expect(entries.map((entry) => entry.kind)).toEqual(['suggestion', 'contact', 'create'])
-    expect(entries[1]).toEqual({ kind: 'contact', contact: ada })
+    expect(entries[1]).toEqual({
+      kind: 'contact',
+      contact: ada,
+      target: 'Ada Lovelace',
+      ownerPath: null,
+    })
   })
 
   it('drops a contact whose name already resolves to a suggestion', () => {
     const entries = buildAutocompleteEntries(
       'ada',
       [suggestion({ target: 'Ada Lovelace', title: 'Ada Lovelace' })],
-      { offerCreate: true, contacts: [contact({})] },
+      { offerCreate: true, contacts: [contactCandidate()] },
+    )
+    expect(entries.filter((entry) => entry.kind === 'contact')).toEqual([])
+  })
+
+  it('keeps an email-owned Contact when its name resolves to another note', () => {
+    const ada = contact({})
+    const entries = buildAutocompleteEntries(
+      'ada',
+      [suggestion({ target: 'Ada Lovelace', title: 'Ada Lovelace' })],
+      {
+        offerCreate: true,
+        contacts: [{
+          contact: ada,
+          target: 'Augusta Ada King',
+          ownerPath: 'notes/augusta.md',
+        }],
+      },
+    )
+    expect(entries.filter((entry) => entry.kind === 'contact')).toEqual([
+      {
+        kind: 'contact',
+        contact: ada,
+        target: 'Augusta Ada King',
+        ownerPath: 'notes/augusta.md',
+      },
+    ])
+  })
+
+  it('drops an email-owned Contact when its owner already has a note row', () => {
+    const ada = contact({})
+    const entries = buildAutocompleteEntries(
+      'ada',
+      [
+        suggestion({
+          target: 'Augusta Ada King',
+          title: 'Augusta Ada King',
+          path: 'notes/augusta.md',
+        }),
+      ],
+      {
+        offerCreate: true,
+        contacts: [{
+          contact: ada,
+          target: 'Augusta Ada King',
+          ownerPath: 'notes/augusta.md',
+        }],
+      },
     )
     expect(entries.filter((entry) => entry.kind === 'contact')).toEqual([])
   })
@@ -219,7 +286,7 @@ describe('buildAutocompleteEntries', () => {
     const entries = buildAutocompleteEntries(
       'ada',
       [suggestion({ target: 'People/Ada', title: 'People/Ada', alias: 'Ada Lovelace' })],
-      { offerCreate: true, contacts: [contact({})] },
+      { offerCreate: true, contacts: [contactCandidate()] },
     )
     expect(entries.filter((entry) => entry.kind === 'contact')).toEqual([])
   })
@@ -228,7 +295,7 @@ describe('buildAutocompleteEntries', () => {
     const entries = buildAutocompleteEntries(
       'Ada Lovelace',
       [suggestion({ target: '🧠 Ada Lovelace', title: '🧠 Ada Lovelace' })],
-      { offerCreate: true, contacts: [contact({})] },
+      { offerCreate: true, contacts: [contactCandidate()] },
     )
     expect(entries.map((entry) => entry.kind)).toEqual(['suggestion'])
   })
@@ -238,9 +305,18 @@ describe('buildAutocompleteEntries', () => {
     // beside it would just be the worse duplicate.
     const entries = buildAutocompleteEntries('ada lovelace', [], {
       offerCreate: true,
-      contacts: [contact({})],
+      contacts: [contactCandidate()],
     })
     expect(entries.map((entry) => entry.kind)).toEqual(['contact'])
+  })
+
+  it('suppresses Create for an exact blocked Contact without hiding note rows', () => {
+    const note = suggestion({ target: 'Ada Notes', title: 'Ada Notes' })
+    const entries = buildAutocompleteEntries('Ada Lovelace', [note], {
+      offerCreate: true,
+      blockedContactNames: ['Ada Lovelace'],
+    })
+    expect(entries).toEqual([{ kind: 'suggestion', suggestion: note }])
   })
 })
 

--- a/apps/desktop/src/editor/wiki-autocomplete-entries.ts
+++ b/apps/desktop/src/editor/wiki-autocomplete-entries.ts
@@ -17,8 +17,21 @@ import {
 
 export type AutocompleteEntry<Suggestion extends WikiSuggestion = WikiSuggestion> =
   | { kind: 'suggestion'; suggestion: Suggestion }
-  | { kind: 'contact'; contact: ContactMatch }
+  | {
+      kind: 'contact'
+      contact: ContactMatch
+      target: string
+      ownerPath: string | null
+    }
   | { kind: 'create'; title: string }
+
+export interface ContactEntryCandidate {
+  readonly contact: ContactMatch
+  /** Validated text inserted by a wikilink consumer, or the attendee name. */
+  readonly target: string
+  /** Existing owner path, or null for a Contact that would create a note. */
+  readonly ownerPath: string | null
+}
 
 export interface EntryOptions {
   /**
@@ -32,7 +45,9 @@ export interface EntryOptions {
    * A contact whose name would resolve to an existing suggestion is dropped —
    * the note row already covers it, exactly v1's dedup.
    */
-  contacts?: readonly ContactMatch[]
+  contacts?: readonly ContactEntryCandidate[]
+  /** Exact Contact names whose identity is blocked and must not offer Create. */
+  blockedContactNames?: readonly string[]
   /**
    * Drop raw Create/contact text that cannot be embedded in `[[…]]` without
    * changing what Markdown parses. False for non-markdown consumers such as
@@ -73,10 +88,14 @@ export function buildAutocompleteEntries<Suggestion extends WikiSuggestion>(
   // ambiguous or unsafe still collides with the writable resolver's fallback
   // matching, so it must keep suppressing Create and contact rows.
   const resolvable = new Set<string>()
+  const suggestionPaths = new Set<string>()
   const fallbackResolvable = new Set(
     [...claimedTargetKeys].map(foldFallbackTitleKey),
   )
   for (const suggestion of suggestions) {
+    if (suggestion.path !== null) {
+      suggestionPaths.add(suggestion.path)
+    }
     resolvable.add(foldKey(suggestion.target))
     fallbackResolvable.add(foldFallbackTitleKey(suggestion.target))
     if (suggestion.alias !== null) {
@@ -84,7 +103,11 @@ export function buildAutocompleteEntries<Suggestion extends WikiSuggestion>(
       fallbackResolvable.add(foldFallbackTitleKey(suggestion.alias))
     }
   }
-  const contacts = (options.contacts ?? []).filter((contact) => {
+  const contacts = (options.contacts ?? []).filter((candidate) => {
+    const { contact } = candidate
+    if (candidate.ownerPath !== null) {
+      return !suggestionPaths.has(candidate.ownerPath)
+    }
     if (
       claimedTargetKeys.has(foldKey(contact.fullName)) ||
       resolvable.has(foldKey(contact.fullName)) ||
@@ -94,10 +117,15 @@ export function buildAutocompleteEntries<Suggestion extends WikiSuggestion>(
     }
     return (
       !options.requireSerializableWikiText ||
-      serializeWikiSuggestionAddress(contact.fullName, null) !== null
+      serializeWikiSuggestionAddress(candidate.target, null) !== null
     )
   })
-  entries.push(...contacts.map((contact) => ({ kind: 'contact' as const, contact })))
+  entries.push(
+    ...contacts.map((candidate) => ({
+      kind: 'contact' as const,
+      ...candidate,
+    })),
+  )
 
   if (title === '' || !options.offerCreate) {
     return entries
@@ -114,7 +142,9 @@ export function buildAutocompleteEntries<Suggestion extends WikiSuggestion>(
     suggestions.some((suggestion) => suggestion.generated !== undefined)
   // A contact row for the exact typed name IS the create action (prefilled) —
   // a bare Create row beside it would just be the worse duplicate.
-  const contactCoversQuery = contacts.some((contact) => foldKey(contact.fullName) === key)
+  const contactCoversQuery =
+    contacts.some(({ contact }) => foldKey(contact.fullName) === key) ||
+    (options.blockedContactNames ?? []).some((name) => foldKey(name) === key)
   const canSerializeCreate =
     !options.requireSerializableWikiText ||
     serializeWikiSuggestionAddress(title, null) !== null

--- a/apps/desktop/src/lib/note-contact.test.ts
+++ b/apps/desktop/src/lib/note-contact.test.ts
@@ -4,22 +4,16 @@ import type { NoteSession } from '@/editor/note-session'
 
 const readNote = vi.hoisted(() => vi.fn<(path: string) => Promise<string>>())
 const writeNote = vi.hoisted(() => vi.fn(async () => {}))
-const noteExists = vi.hoisted(() => vi.fn(async () => false))
 const openSession = vi.hoisted(() => vi.fn<(path: string) => NoteSession | null>(() => null))
-const createNoteWithTitle = vi.hoisted(() => vi.fn(async () => 'notes/created.md'))
 
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   readNote,
   writeNote,
-  noteExists,
-  createNoteWithTitle,
 }))
 vi.mock('@/editor/open-documents', () => ({ openSession }))
 
-const { addContactToNote, createPersonNoteFromContact, ignoreContactSuggestion } = await import(
-  './note-contact'
-)
+const { addContactToNote, ignoreContactSuggestion } = await import('./note-contact')
 
 const ADA: ContactMatch = {
   fullName: 'Ada Lovelace',
@@ -34,9 +28,6 @@ const ADA_BLOCK = '- Type: #person\n- Email: ada@example.com\n- Phone: +1 555 01
 beforeEach(() => {
   readNote.mockReset()
   writeNote.mockClear()
-  noteExists.mockReset()
-  noteExists.mockResolvedValue(false)
-  createNoteWithTitle.mockClear()
   openSession.mockReset()
   openSession.mockReturnValue(null)
 })
@@ -140,23 +131,6 @@ describe('addContactToNote', () => {
     await addContactToNote('notes/Ada Lovelace.md', bare, 3)
 
     expect(writeNote).not.toHaveBeenCalled()
-  })
-})
-
-describe('createPersonNoteFromContact', () => {
-  it('creates the person note prefilled with the details block', async () => {
-    await createPersonNoteFromContact(ADA, 3)
-
-    expect(createNoteWithTitle).toHaveBeenCalledWith('Ada Lovelace', 3, ADA_BLOCK)
-  })
-
-  it('skips creation when the slug path already exists (index-lag backstop)', async () => {
-    noteExists.mockResolvedValue(true)
-
-    await createPersonNoteFromContact(ADA, 3)
-
-    expect(noteExists).toHaveBeenCalledWith('notes/ada-lovelace.md')
-    expect(createNoteWithTitle).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/lib/note-contact.ts
+++ b/apps/desktop/src/lib/note-contact.ts
@@ -2,13 +2,9 @@ import {
   appendContactDetails,
   contactDetailsMarkdown,
   contactNamesEqual,
-  createNoteWithTitle,
   matchContactForTitle,
-  noteExists,
   noteHasContactDetails,
-  notePath,
   parseNote,
-  slugForTitle,
   splitFrontmatter,
   writeNote,
   type ContactMatch,
@@ -81,24 +77,6 @@ export async function addContactToNote(
   // Reuse the validated snapshot — with no session, `source` came from disk.
   // A second read here would reopen the window between the check and the write.
   await writeNote(path, appendContactDetails(source, contact), generation)
-}
-
-/**
- * Create a person note from a `[[` link-menu contact row (v1's backlink-menu
- * behavior): titled with the contact's name and prefilled with the same
- * details block Add writes. The row only appears when no suggestion resolves
- * to the name, so the note shouldn't exist — the direct existence check
- * backstops index lag, ensuring a race never mints an `ada-lovelace-2.md`
- * beside the real person note.
- */
-export async function createPersonNoteFromContact(
-  contact: ContactMatch,
-  generation: number,
-): Promise<void> {
-  if (await noteExists(notePath(slugForTitle(contact.fullName)))) {
-    return
-  }
-  await createNoteWithTitle(contact.fullName, generation, contactDetailsMarkdown(contact))
 }
 
 /**

--- a/docs/porting/calendar-meetings-integration.md
+++ b/docs/porting/calendar-meetings-integration.md
@@ -68,7 +68,10 @@ is added to [docs/privacy.md](../privacy.md)'s inventory.
    [contacts integration](./contacts-integration.md) on, a fresh person note
    is pre-filled from the Apple Contacts entry matching the attendee's
    invite email. After that, they are ordinary notes; nothing about them
-   stays tied to the calendar.
+   stays tied to the calendar. Existing `#person` notes are reused by explicit
+   email ownership even when their title differs from the calendar name.
+   Conflicting or unaddressable owners are written as plain attendee text and
+   do not create another person note.
 
 ### Architecture
 

--- a/docs/porting/contacts-integration.md
+++ b/docs/porting/contacts-integration.md
@@ -10,9 +10,10 @@ Settings → System integrations switch with the permission flow, the
 suggested-contact card, contacts in the `[[` link menu, and the
 meeting-attendee half: the
 [calendar flow](./calendar-meetings-integration.md)'s add-meeting action
-resolves each attendee's invite email through `resolveAttendeeContact`
-(gated on the integration being enabled and readable) and pre-fills the
-person notes it creates; on a miss the note is created bare, as v1 did.
+resolves every attendee email against explicit `Email` fields on `#person`
+notes. A unique owner is reused. Conflicting or unaddressable owners stay
+plain text and never create a duplicate. On a miss, Apple Contacts can still
+provide the display name and details for the new person note.
 
 Decisions taken at implementation time:
 
@@ -33,11 +34,16 @@ Decisions taken at implementation time:
   `ignoredContactNames`), so a retitled note stays eligible for its own
   suggestion and the state travels with the note through sync and export.
 - **Contacts join the `[[` link menu, like v1's backlink menu.** Word-prefix
-  matches (min two typed characters, capped, deduped against notes the link
-  would resolve to) appear after note suggestions; selecting one inserts the
-  link and creates the person note prefilled with the same details block Add
-  writes. A contact row for the exact typed name replaces the bare Create
-  row.
+  matches appear after note suggestions. All of a Contact's emails resolve as
+  one identity: a unique `#person` owner supplies the verified wikilink
+  address, a miss creates a prefilled person note, and several owners block
+  the Contact row rather than choosing one. An exact blocked Contact also
+  suppresses its duplicate-creating Create fallback; ordinary note
+  suggestions remain available.
+- **Email ownership is explicit and conservative.** Only `Email` fields on
+  `#person` notes count, including legacy V1 nested `Email` / `Emails` lists.
+  Values are canonicalized for matching, and primary email order does not
+  break conflicts.
 - **No `mailto:`/`tel:` links.** v1's rich editor hid link URLs; v2 notes are
   markdown the user owns, where the syntax would double every value — and the
   editor's link opener is scoped to `https`. Plain values keep the files
@@ -70,10 +76,10 @@ macOS.
    contacts permission prompt; denial shows an inline pointer to System
    Settings.
 2. **Meeting attendees become person notes.** When a meeting is added from
-   the [calendar flow](./calendar-meetings-integration.md), each attendee
-   email is looked up in Apple Contacts. On a match, the created person note
-   is pre-filled (name, email, phone); on a miss, a person note is still
-   created from the attendee email, as in v1.
+   the [calendar flow](./calendar-meetings-integration.md), all known attendee
+   emails first resolve against existing `#person` notes. On a miss, Apple
+   Contacts can pre-fill the created note with name, email, and phone. The
+   invite email is still written when Contacts is unavailable.
 3. **Suggested contact.** On a note whose title matches a contact's name, a
    card offers the contact's details (photo, primary email, phone) with
    **Add** — writes the fields into the note as plain markdown — and

--- a/packages/core/src/actions/add-meeting.test.ts
+++ b/packages/core/src/actions/add-meeting.test.ts
@@ -1,11 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ensurePersonNote } from '../contacts/person'
 import { noteExists, readNote, writeNote } from '../graph/commands'
 import { createNoteWithTitle } from '../graph/create-note'
-import { noteTitleOwningEmail, resolveWikiTarget } from '../indexing/queries'
+import { resolveWikiTarget } from '../indexing/queries'
 import { setBridge } from '../ipc/bridge'
 import { resolved, unresolved } from '../markdown/resolve'
-import { addMeetingToDaily, meetingLine, type AddMeetingInput } from './add-meeting'
+import {
+  addMeetingToDaily,
+  meetingLine,
+  type AddMeetingInput,
+  type MeetingAttendee,
+} from './add-meeting'
+import { resolveMeetingAttendeeTargets } from './resolve-attendees'
 
+vi.mock('../contacts/person', () => ({
+  ensurePersonNote: vi.fn(),
+}))
 vi.mock('../graph/commands', () => ({
   noteExists: vi.fn(),
   readNote: vi.fn(),
@@ -15,21 +25,22 @@ vi.mock('../graph/create-note', () => ({
   createNoteWithTitle: vi.fn(),
 }))
 vi.mock('../indexing/queries', () => ({
-  noteTitleOwningEmail: vi.fn(),
   resolveWikiTarget: vi.fn(),
 }))
+vi.mock('./resolve-attendees', () => ({
+  resolveMeetingAttendeeTargets: vi.fn(),
+}))
 
+const ensurePersonMock = vi.mocked(ensurePersonNote)
 const noteExistsMock = vi.mocked(noteExists)
 const readNoteMock = vi.mocked(readNote)
 const writeNoteMock = vi.mocked(writeNote)
 const createNoteMock = vi.mocked(createNoteWithTitle)
-const resolveMock = vi.mocked(resolveWikiTarget)
-const owningNoteMock = vi.mocked(noteTitleOwningEmail)
+const resolveWikiTargetMock = vi.mocked(resolveWikiTarget)
+const resolveAttendeesMock = vi.mocked(resolveMeetingAttendeeTargets)
 
 const DAILY = 'daily/2026-07-01.md'
 const GENERATION = 3
-
-const notFound = () => ({ kind: 'notFound', message: 'missing' })
 
 function input(overrides: Partial<AddMeetingInput> = {}): AddMeetingInput {
   return {
@@ -42,234 +53,273 @@ function input(overrides: Partial<AddMeetingInput> = {}): AddMeetingInput {
   }
 }
 
+function newTargets(attendees: readonly MeetingAttendee[]) {
+  return attendees.map((attendee) => ({
+    kind: 'new' as const,
+    attendee,
+    insertText: attendee.name,
+  }))
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
-  readNoteMock.mockRejectedValue(notFound())
+  readNoteMock.mockRejectedValue({ kind: 'notFound', message: 'missing' })
   noteExistsMock.mockResolvedValue(false)
   createNoteMock.mockImplementation(async (title: string) => `notes/${title.toLowerCase()}.md`)
-  resolveMock.mockImplementation(async (target) => unresolved(target))
-  owningNoteMock.mockResolvedValue(null)
+  resolveWikiTargetMock.mockImplementation(async (target) => unresolved(target))
+  resolveAttendeesMock.mockImplementation(async (attendees) => newTargets(attendees))
+  ensurePersonMock.mockImplementation(async ({ title }) => ({
+    kind: 'created',
+    path: `notes/${title.toLowerCase()}.md`,
+  }))
 })
 
 describe('meetingLine', () => {
-  it('renders the v1 shape: time, met with, for', () => {
+  it('renders linked and plain attendees', () => {
     expect(
       meetingLine({
         title: 'Standup',
-        attendees: ['Ada Lovelace', 'Grace Hopper'],
+        attendees: [
+          { kind: 'linked', insertText: 'Ada Lovelace' },
+          { kind: 'plain', text: 'Shared inbox' },
+        ],
         backlinkMeeting: true,
         startTime: '9:00am',
       }),
-    ).toBe('- 9:00am met with [[Ada Lovelace]], [[Grace Hopper]] for [[Standup]]')
+    ).toBe('- 9:00am met with [[Ada Lovelace]], Shared inbox for [[Standup]]')
   })
 
-  it('shortens for attendee-less events and capitalizes without a time', () => {
-    expect(
-      meetingLine({ title: 'Standup', attendees: [], backlinkMeeting: true, startTime: '9:00am' }),
-    ).toBe('- 9:00am [[Standup]]')
-    expect(
-      meetingLine({ title: 'Standup', attendees: ['Ada Lovelace'], backlinkMeeting: true }),
-    ).toBe('- Met with [[Ada Lovelace]] for [[Standup]]')
-  })
-
-  it('writes the meeting name as plain text when not backlinked', () => {
+  it('shortens attendee-less events and supports a plain meeting title', () => {
     expect(
       meetingLine({
         title: 'Standup',
-        attendees: ['Ada Lovelace'],
-        backlinkMeeting: false,
+        attendees: [],
+        backlinkMeeting: true,
         startTime: '9:00am',
       }),
-    ).toBe('- 9:00am met with [[Ada Lovelace]] for Standup')
+    ).toBe('- 9:00am [[Standup]]')
+    expect(
+      meetingLine({
+        title: 'Standup',
+        attendees: [{ kind: 'linked', insertText: 'Ada Lovelace' }],
+        backlinkMeeting: false,
+      }),
+    ).toBe('- Met with [[Ada Lovelace]] for Standup')
   })
 })
 
 describe('addMeetingToDaily', () => {
-  it('appends the meeting under ## Meetings, creating the section on a fresh daily', async () => {
+  it('writes the daily line before creating missing notes', async () => {
+    const calls: string[] = []
+    writeNoteMock.mockImplementation(async () => {
+      calls.push('daily')
+    })
+    ensurePersonMock.mockImplementation(async () => {
+      calls.push('person')
+      return { kind: 'created', path: 'notes/ada.md' }
+    })
+
     const outcome = await addMeetingToDaily(
-      input({ attendees: [{ name: 'Ada Lovelace' }], startTime: '9:00am' }),
+      input({
+        attendees: [{
+          name: 'Ada Lovelace',
+          emails: ['ada@example.com'],
+        }],
+        backlinkMeeting: false,
+        startTime: '9:00am',
+      }),
     )
-    expect(outcome.appended).toBe(true)
+
+    expect(calls).toEqual(['daily', 'person'])
     expect(writeNoteMock).toHaveBeenCalledWith(
       DAILY,
-      '## Meetings\n\n- 9:00am met with [[Ada Lovelace]] for [[Standup]]\n',
+      '## Meetings\n\n- 9:00am met with [[Ada Lovelace]] for Standup\n',
       GENERATION,
     )
+    expect(ensurePersonMock).toHaveBeenCalledWith({
+      title: 'Ada Lovelace',
+      emails: ['ada@example.com'],
+      body: '- Type: #person\n- Email: ada@example.com',
+      generation: GENERATION,
+    })
+    expect(outcome).toEqual({
+      appended: true,
+      createdNotes: ['Ada Lovelace'],
+    })
   })
 
-  it('appends to an existing Meetings section of a non-empty daily', async () => {
-    readNoteMock.mockResolvedValue('Some notes\n\n## Meetings\n\n- [[Kickoff]]\n\n## Later\n\nx\n')
-    await addMeetingToDaily(input())
-    const written = writeNoteMock.mock.calls[0]?.[1]
-    expect(written).toContain('## Meetings\n\n- [[Kickoff]]\n\n- [[Standup]]')
-    expect(written).toContain('## Later')
-  })
+  it('is a full no-op when the meeting is already linked that day', async () => {
+    readNoteMock.mockResolvedValue(
+      '## Meetings\n\n- 9:00am met with [[Ada Lovelace]] for [[Standup]]\n',
+    )
 
-  it('is idempotent: a day that already links the meeting is a full no-op', async () => {
-    readNoteMock.mockResolvedValue('## Meetings\n\n- 9:00am met with [[Ada Lovelace]] for [[Standup]]\n')
-    const outcome = await addMeetingToDaily(input({ attendees: [{ name: 'Carol' }] }))
-    expect(outcome).toEqual({ appended: false, createdNotes: [] })
+    await expect(
+      addMeetingToDaily(input({ attendees: [{ name: 'Carol' }] })),
+    ).resolves.toEqual({ appended: false, createdNotes: [] })
     expect(writeNoteMock).not.toHaveBeenCalled()
-    // No invisible side effects either — a re-add must not mint notes the
-    // daily line never gained.
-    expect(createNoteMock).not.toHaveBeenCalled()
+    expect(resolveAttendeesMock).not.toHaveBeenCalled()
+    expect(ensurePersonMock).not.toHaveBeenCalled()
   })
 
-  it('treats case-different and aliased Meetings links as already linked', async () => {
+  it('recognizes an aliased meeting link in the Meetings section', async () => {
     readNoteMock.mockResolvedValue('## Meetings\n\n- [[STANDUP|Daily sync]]\n')
-    const outcome = await addMeetingToDaily(input())
-    expect(outcome.appended).toBe(false)
-    expect(writeNoteMock).not.toHaveBeenCalled()
+
+    await expect(addMeetingToDaily(input())).resolves.toEqual({
+      appended: false,
+      createdNotes: [],
+    })
   })
 
-  it('matches a link whose alias (not target) carries the meeting name', async () => {
-    readNoteMock.mockResolvedValue('## Meetings\n\n- [[Standup|Daily sync]]\n')
-    const outcome = await addMeetingToDaily(input({ title: 'Daily sync' }))
-    expect(outcome.appended).toBe(false)
-    expect(writeNoteMock).not.toHaveBeenCalled()
-  })
-
-  it('still appends when the title is only linked outside the Meetings section', async () => {
-    readNoteMock.mockResolvedValue('Prep notes for [[Standup]] tomorrow.\n')
-    const outcome = await addMeetingToDaily(input())
-    expect(outcome.appended).toBe(true)
-    const written = writeNoteMock.mock.calls[0]?.[1]
-    expect(written).toContain('## Meetings\n\n- [[Standup]]')
-  })
-
-  it('an un-backlinked meeting always appends, like v1 (plain text has no link to match)', async () => {
-    readNoteMock.mockResolvedValue('## Meetings\n\n- [[Standup]]\n')
-    const outcome = await addMeetingToDaily(input({ backlinkMeeting: false }))
-    expect(outcome.appended).toBe(true)
-    const written = writeNoteMock.mock.calls[0]?.[1]
-    expect(written).toContain('- [[Standup]]\n\n- Standup')
-  })
-
-  it('creates the meeting note (typed #meeting) only when backlinked and missing', async () => {
-    await addMeetingToDaily(input({ backlinkMeeting: false }))
-    expect(createNoteMock).not.toHaveBeenCalled()
-
+  it('creates a missing backlinked meeting note only', async () => {
     await addMeetingToDaily(input())
-    expect(createNoteMock).toHaveBeenCalledWith('Standup', GENERATION, '- Type: #meeting')
+    expect(createNoteMock).toHaveBeenCalledWith(
+      'Standup',
+      GENERATION,
+      '- Type: #meeting',
+    )
 
     createNoteMock.mockClear()
-    resolveMock.mockResolvedValue(resolved('notes/standup.md'))
+    resolveWikiTargetMock.mockResolvedValue(resolved('notes/standup.md'))
     await addMeetingToDaily(input())
     expect(createNoteMock).not.toHaveBeenCalled()
   })
 
-  it('creates person notes for missing attendees, typed #person', async () => {
-    resolveMock.mockImplementation(async (target) =>
-      target === 'Grace Hopper' || target === 'Standup'
-        ? resolved(`notes/${target.toLowerCase()}.md`)
-        : unresolved(target),
-    )
-    const outcome = await addMeetingToDaily(
-      input({ attendees: [{ name: 'Ada Lovelace' }, { name: 'Grace Hopper' }] }),
-    )
-    expect(createNoteMock).toHaveBeenCalledTimes(1)
-    expect(createNoteMock).toHaveBeenCalledWith('Ada Lovelace', GENERATION, '- Type: #person')
-    expect(outcome.createdNotes).toEqual(['Ada Lovelace'])
-  })
-
-  it('skips creation when the slug path already exists (index lag backstop)', async () => {
-    noteExistsMock.mockImplementation(async (path) => path === 'notes/ada-lovelace.md')
-    await addMeetingToDaily(input({ attendees: [{ name: 'Ada Lovelace' }], backlinkMeeting: false }))
-    expect(createNoteMock).not.toHaveBeenCalled()
-  })
-
-  it('sanitizes link-corrupting characters and deduplicates attendees', async () => {
+  it('deduplicates attendee display names and removes the meeting itself', async () => {
     await addMeetingToDaily(
       input({
-        title: '  Stand|up [v2]  ',
         attendees: [
           { name: 'Ada Lovelace' },
           { name: 'ada lovelace' },
           { name: '' },
-          { name: 'Stand up v2' },
+          { name: 'Standup' },
         ],
+        backlinkMeeting: false,
       }),
     )
-    // `Stand up v2` also names the meeting itself, so it drops out of the
-    // attendee links rather than duplicating the meeting link.
+
     expect(writeNoteMock).toHaveBeenCalledWith(
       DAILY,
-      '## Meetings\n\n- Met with [[Ada Lovelace]] for [[Stand up v2]]\n',
+      '## Meetings\n\n- Met with [[Ada Lovelace]] for Standup\n',
       GENERATION,
     )
+    expect(ensurePersonMock).toHaveBeenCalledTimes(1)
   })
 
-  it('does not create a person note for an attendee named like the meeting', async () => {
-    resolveMock.mockImplementation(async (target) =>
-      target === 'Standup' ? resolved('notes/standup.md') : unresolved(target),
-    )
-    await addMeetingToDaily(input({ attendees: [{ name: 'Standup' }] }))
-    expect(createNoteMock).not.toHaveBeenCalled()
-  })
-
-  it('rejects an empty meeting name', async () => {
-    await expect(addMeetingToDaily(input({ title: '  [|]  ' }))).rejects.toThrow(
-      'a meeting needs a name',
-    )
+  it('rejects an empty meeting name before writing', async () => {
+    await expect(
+      addMeetingToDaily(input({ title: '  [|]  ' })),
+    ).rejects.toThrow('a meeting needs a name')
     expect(writeNoteMock).not.toHaveBeenCalled()
   })
 })
 
-describe('addMeetingToDaily attendee resolution', () => {
-  it('links the note owning the invite email instead of minting a duplicate', async () => {
-    owningNoteMock.mockImplementation(async (email) =>
-      email === 'jane@corp.com' ? 'Jane Doe' : null,
-    )
-    resolveMock.mockImplementation(async (target) =>
-      target === 'Jane Doe' ? resolved('notes/jane-doe.md') : unresolved(target),
-    )
+describe('attendee identity outcomes', () => {
+  it('reuses an existing owner and does not create', async () => {
+    resolveAttendeesMock.mockResolvedValue([
+      {
+        kind: 'existing',
+        attendee: {
+          name: 'Jane Doe',
+          emails: ['jane@corp.com'],
+        },
+        insertText: 'Jane Doe',
+      },
+    ])
+
     const outcome = await addMeetingToDaily(
       input({
-        attendees: [{ name: 'jane@corp.com', email: 'jane@corp.com' }],
+        attendees: [{
+          name: 'jane@corp.com',
+          emails: ['jane@corp.com'],
+        }],
         backlinkMeeting: false,
       }),
     )
+
     expect(writeNoteMock).toHaveBeenCalledWith(
       DAILY,
       '## Meetings\n\n- Met with [[Jane Doe]] for Standup\n',
       GENERATION,
     )
-    expect(createNoteMock).not.toHaveBeenCalled()
+    expect(ensurePersonMock).not.toHaveBeenCalled()
     expect(outcome.createdNotes).toEqual([])
   })
 
-  it('collapses two spellings of one person once their emails resolve to the same note', async () => {
-    owningNoteMock.mockResolvedValue('Jane Doe')
-    resolveMock.mockImplementation(async (target) =>
-      target === 'Jane Doe' ? resolved('notes/jane-doe.md') : unresolved(target),
-    )
-    await addMeetingToDaily(
+  it.each(['identity conflict', 'unaddressable owner'])(
+    'writes a %s as plain text without creating',
+    async () => {
+      resolveAttendeesMock.mockResolvedValue([
+        {
+          kind: 'plain',
+          attendee: {
+            name: 'Jane Doe',
+            emails: ['jane@corp.com'],
+          },
+        },
+      ])
+
+      await addMeetingToDaily(
+        input({
+          attendees: [{
+            name: 'Jane Doe',
+            emails: ['jane@corp.com'],
+          }],
+          backlinkMeeting: false,
+        }),
+      )
+
+      expect(writeNoteMock).toHaveBeenCalledWith(
+        DAILY,
+        '## Meetings\n\n- Met with Jane Doe for Standup\n',
+        GENERATION,
+      )
+      expect(ensurePersonMock).not.toHaveBeenCalled()
+    },
+  )
+
+  it('fails before writing when identity resolution fails', async () => {
+    resolveAttendeesMock.mockRejectedValue(new Error('index unavailable'))
+
+    await expect(
+      addMeetingToDaily(
+        input({
+          attendees: [{
+            name: 'Jane',
+            emails: ['jane@corp.com'],
+          }],
+        }),
+      ),
+    ).rejects.toThrow('index unavailable')
+    expect(writeNoteMock).not.toHaveBeenCalled()
+  })
+
+  it('accepts a race that blocks creation after the daily write', async () => {
+    ensurePersonMock.mockResolvedValue({
+      kind: 'blocked',
+      emails: ['ada@example.com'],
+      reason: 'identity-conflict',
+    })
+
+    const outcome = await addMeetingToDaily(
       input({
-        attendees: [
-          { name: 'jane@corp.com', email: 'jane@corp.com' },
-          { name: 'Doe, Jane', email: 'jane.doe@home.example' },
-        ],
+        attendees: [{
+          name: 'Ada Lovelace',
+          emails: ['ada@example.com'],
+        }],
         backlinkMeeting: false,
       }),
     )
-    expect(writeNoteMock).toHaveBeenCalledWith(
-      DAILY,
-      '## Meetings\n\n- Met with [[Jane Doe]] for Standup\n',
-      GENERATION,
-    )
-  })
 
-  it('resolution errors fail the call loudly rather than writing a duplicate-prone line', async () => {
-    owningNoteMock.mockRejectedValue(new Error('index unavailable'))
-    await expect(
-      addMeetingToDaily(input({ attendees: [{ name: 'Jane', email: 'jane@corp.com' }] })),
-    ).rejects.toThrow('index unavailable')
-    expect(createNoteMock).not.toHaveBeenCalled()
+    expect(writeNoteMock).toHaveBeenCalled()
+    expect(outcome.createdNotes).toEqual([])
   })
 })
 
-describe('addMeetingToDaily contact pre-fill', () => {
-  const ADA = { name: 'Ada Lovelace', email: 'ada@example.com' }
+describe('Contact prefill', () => {
+  const ADA = {
+    name: 'Ada Lovelace',
+    emails: ['ada@example.com'],
+  }
 
   function installContactsBridge(contacts: unknown[]): ReturnType<typeof vi.fn> {
     const invoke = vi.fn(async () => contacts)
@@ -281,84 +331,45 @@ describe('addMeetingToDaily contact pre-fill', () => {
     setBridge(null)
   })
 
-  it('pre-fills a created person note from the matching contact', async () => {
+  it('uses Contact details as the new note body', async () => {
     const invoke = installContactsBridge([
       {
         fullName: 'Ada Lovelace',
         givenName: 'Ada',
         familyName: 'Lovelace',
-        emails: ['ada@example.com'],
+        emails: ['ada@example.com', 'ada@work.example'],
         phones: ['+1 555-0100'],
       },
     ])
-    await addMeetingToDaily(input({ attendees: [ADA], lookupContacts: true }))
-    expect(invoke).toHaveBeenCalledWith('contacts_lookup_by_email', { email: 'ada@example.com' })
-    expect(createNoteMock).toHaveBeenCalledWith(
-      'Ada Lovelace',
-      GENERATION,
-      '- Type: #person\n- Email: ada@example.com\n- Phone: +1 555-0100',
+
+    await addMeetingToDaily(
+      input({ attendees: [ADA], lookupContacts: true }),
     )
+
+    expect(invoke).toHaveBeenCalledWith(
+      'contacts_lookup_by_email',
+      { email: 'ada@example.com' },
+    )
+    expect(ensurePersonMock).toHaveBeenCalledWith({
+      title: 'Ada Lovelace',
+      emails: ['ada@example.com'],
+      body:
+        '- Type: #person\n- Email: ada@example.com\n- Phone: +1 555-0100',
+      generation: GENERATION,
+    })
   })
 
-  it('names and pre-fills the created note from the contact when the calendar only knew the address', async () => {
-    installContactsBridge([
-      {
-        fullName: 'Ada Lovelace',
-        givenName: 'Ada',
-        familyName: 'Lovelace',
+  it('persists attendee emails without touching Contacts when the gate is off', async () => {
+    const invoke = installContactsBridge([])
+
+    await addMeetingToDaily(input({ attendees: [ADA] }))
+
+    expect(invoke).not.toHaveBeenCalled()
+    expect(ensurePersonMock).toHaveBeenCalledWith(
+      expect.objectContaining({
         emails: ['ada@example.com'],
-        phones: [],
-      },
-    ])
-    const outcome = await addMeetingToDaily(
-      input({
-        attendees: [{ name: 'ada@example.com', email: 'ada@example.com' }],
-        lookupContacts: true,
+        body: '- Type: #person\n- Email: ada@example.com',
       }),
     )
-    expect(writeNoteMock).toHaveBeenCalledWith(
-      DAILY,
-      expect.stringContaining('[[Ada Lovelace]]'),
-      GENERATION,
-    )
-    expect(createNoteMock).toHaveBeenCalledWith(
-      'Ada Lovelace',
-      GENERATION,
-      '- Type: #person\n- Email: ada@example.com',
-    )
-    expect(outcome.createdNotes).toContain('Ada Lovelace')
-  })
-
-  it('creates the bare typed note on a lookup miss, as v1 did', async () => {
-    installContactsBridge([])
-    await addMeetingToDaily(input({ attendees: [ADA], lookupContacts: true }))
-    expect(createNoteMock).toHaveBeenCalledWith('Ada Lovelace', GENERATION, '- Type: #person')
-  })
-
-  it('never touches the bridge while the contacts gate is off', async () => {
-    const invoke = installContactsBridge([])
-    await addMeetingToDaily(input({ attendees: [ADA] }))
-    expect(invoke).not.toHaveBeenCalled()
-    expect(createNoteMock).toHaveBeenCalledWith('Ada Lovelace', GENERATION, '- Type: #person')
-  })
-
-  it('skips the lookup for attendees without an invite email', async () => {
-    const invoke = installContactsBridge([])
-    await addMeetingToDaily(
-      input({ attendees: [{ name: 'Grace Hopper' }], lookupContacts: true }),
-    )
-    expect(invoke).not.toHaveBeenCalled()
-    expect(createNoteMock).toHaveBeenCalledWith('Grace Hopper', GENERATION, '- Type: #person')
-  })
-
-  it('does not look up attendees whose note already exists', async () => {
-    const invoke = installContactsBridge([])
-    resolveMock.mockImplementation(async (target) =>
-      target === 'Ada Lovelace' ? resolved('notes/ada-lovelace.md') : unresolved(target),
-    )
-    await addMeetingToDaily(input({ attendees: [ADA], lookupContacts: true }))
-    expect(invoke).not.toHaveBeenCalled()
-    expect(createNoteMock).toHaveBeenCalledTimes(1)
-    expect(createNoteMock).toHaveBeenCalledWith('Standup', GENERATION, '- Type: #meeting')
   })
 })

--- a/packages/core/src/actions/add-meeting.ts
+++ b/packages/core/src/actions/add-meeting.ts
@@ -1,4 +1,5 @@
 import { contactDetailsMarkdown } from '../contacts/markdown'
+import { ensurePersonNote } from '../contacts/person'
 import { resolveAttendeeContact } from '../contacts/resolve'
 import { isAppError } from '../errors'
 import { noteExists, readNote, writeNote } from '../graph/commands'
@@ -6,10 +7,14 @@ import { createNoteWithTitle } from '../graph/create-note'
 import { dailyPath, notePath } from '../graph/paths'
 import { resolveWikiTarget } from '../indexing/queries'
 import { appendUnderHeading, wikiLinkSafe } from '../markdown/edit'
+import { canonicalEmails } from '../markdown/email-fields'
 import { parseNote } from '../markdown/extract'
 import { foldKey } from '../markdown/keys'
 import { slugForTitle } from '../markdown/slug'
-import { resolveMeetingAttendees } from './resolve-attendees'
+import {
+  resolveMeetingAttendeeTargets,
+  type ResolvedMeetingAttendee,
+} from './resolve-attendees'
 
 /**
  * "Add to daily note" for a calendar event — the write half of the calendar
@@ -23,15 +28,11 @@ import { resolveMeetingAttendees } from './resolve-attendees'
  * With "Create backlinked note" off, the meeting name is plain text (as in
  * v1), not a link — only attendees get `[[Person]]` links and notes.
  *
- * Attendees resolve by invite email first ({@link resolveMeetingAttendees}):
- * a `#person`-tagged note owning the address via a `- Email:` bullet supplies
- * the link name, so a person keeps one note however the calendar spelled
- * them. With the
- * contacts integration on (docs/porting/contacts-integration.md), a fresh
- * person note is named and pre-filled from the Apple Contacts entry matching
- * the attendee's invite email. After that, they are ordinary notes; nothing
- * stays tied to the calendar, and no event metadata is persisted beyond this
- * markdown.
+ * Attendees resolve by all known emails first
+ * ({@link resolveMeetingAttendeeTargets}). A unique `#person` owner supplies
+ * the verified link address. A conflict stays plain text. With Contacts on, a
+ * missing attendee collects the Contact's other emails before that decision
+ * and can use its phone details when the note is created.
  *
  * Wiki links resolve by title, so "one note per meeting title" holds by
  * construction: a recurring "Standup" links the same `[[Standup]]` note from
@@ -50,12 +51,10 @@ export const MEETINGS_HEADING = 'Meetings'
 const MEETING_NOTE_BODY = '- Type: #meeting'
 const PERSON_NOTE_BODY = '- Type: #person'
 
-/** One attendee entering the flow: the display name that becomes the
- * `[[Person]]` link, plus the invite email (when the calendar knew it) that
- * the contacts lookup resolves by. */
+/** One attendee entering the flow: a display name and every known email. */
 export interface MeetingAttendee {
   name: string
-  email?: string | undefined
+  emails?: readonly string[] | undefined
 }
 
 export interface AddMeetingInput {
@@ -74,9 +73,8 @@ export interface AddMeetingInput {
   /**
    * The contacts gate, computed by the caller at submit time
    * (`settings.contactsEnabled && isContactsReadable(authorization)`). On,
-   * a missing person note is pre-filled from the Apple Contacts entry
-   * matching the attendee's invite email; off — or on a lookup miss — the
-   * note is created bare, as v1 did.
+   * a missing person note can include phone details from the Apple Contacts
+   * entry matching an attendee email. Known emails are written either way.
    */
   lookupContacts?: boolean
   /**
@@ -114,8 +112,7 @@ async function noteSource(path: string, generation: number): Promise<string> {
 /**
  * Does a note this title resolves to already exist? The index answers by
  * title/alias; the slug-path check backstops it for notes written moments ago
- * that the watcher → index pipeline hasn't caught up with (adding two
- * meetings that share an attendee back-to-back must not mint `alice-2`).
+ * that the watcher → index pipeline has not caught up with.
  */
 async function titleHasNote(title: string): Promise<boolean> {
   const resolution = await resolveWikiTarget(title)
@@ -160,39 +157,51 @@ function meetingAlreadyLinked(source: string, title: string): boolean {
 }
 
 /** Attendees with sanitized names, case-insensitively name-deduplicated, order kept. */
-function normalizeAttendees(attendees: MeetingAttendee[]): MeetingAttendee[] {
+function normalizeAttendees(
+  attendees: readonly ResolvedMeetingAttendee[],
+): ResolvedMeetingAttendee[] {
   const seen = new Set<string>()
-  const normalized: MeetingAttendee[] = []
-  for (const attendee of attendees) {
-    const name = wikiLinkSafe(attendee.name)
+  const normalized: ResolvedMeetingAttendee[] = []
+  for (const resolved of attendees) {
+    const name = wikiLinkSafe(resolved.attendee.name)
     const key = name.toLowerCase()
     if (name === '' || seen.has(key)) {
       continue
     }
     seen.add(key)
-    normalized.push(attendee.email === undefined ? { name } : { name, email: attendee.email })
+    const emails = canonicalEmails(resolved.attendee.emails ?? [])
+    const attendee = emails.length === 0 ? { name } : { name, emails }
+    normalized.push({ ...resolved, attendee })
   }
   return normalized
 }
 
 /**
- * The body a fresh person note is born with. On the contacts path — gate on
- * and an invite email known — a matched contact's details block (typed
- * `- Type: #person` by {@link contactDetailsMarkdown}); in every other case
- * (gate off, no email, lookup miss, or a contact with nothing to write),
- * v1's bare typing line.
+ * The body a fresh person note is born with. Every resolved email is written.
+ * When Contacts is readable, phone details from the same Contact are included
+ * without adding emails that ownership resolution did not already inspect.
  */
 async function personNoteBody(attendee: MeetingAttendee, lookupContacts: boolean): Promise<string> {
-  if (!lookupContacts || attendee.email === undefined) {
-    return PERSON_NOTE_BODY
+  const emails = canonicalEmails(attendee.emails ?? [])
+  if (lookupContacts && emails[0] !== undefined) {
+    const contact = await resolveAttendeeContact(emails[0])
+    if (contact !== null) {
+      const details = contactDetailsMarkdown({ ...contact, emails })
+      if (details !== '') {
+        return details
+      }
+    }
   }
-  const contact = await resolveAttendeeContact(attendee.email)
-  if (contact === null) {
-    return PERSON_NOTE_BODY
-  }
-  const details = contactDetailsMarkdown(contact)
-  return details === '' ? PERSON_NOTE_BODY : details
+  return [
+    PERSON_NOTE_BODY,
+    ...emails.map((email) => `- Email: ${email}`),
+  ].join('\n')
 }
+
+/** One attendee fragment ready for daily-note Markdown serialization. */
+export type MeetingLineAttendee =
+  | { readonly kind: 'linked'; readonly insertText: string }
+  | { readonly kind: 'plain'; readonly text: string }
 
 /**
  * The daily-note bullet, in v1's `generateMeetingListItem` shape:
@@ -202,7 +211,7 @@ async function personNoteBody(attendee: MeetingAttendee, lookupContacts: boolean
  */
 export function meetingLine(input: {
   title: string
-  attendees: string[]
+  attendees: readonly MeetingLineAttendee[]
   backlinkMeeting: boolean
   startTime?: string | undefined
 }): string {
@@ -212,7 +221,15 @@ export function meetingLine(input: {
   }
   if (input.attendees.length > 0) {
     parts.push(input.startTime ? 'met with ' : 'Met with ')
-    parts.push(input.attendees.map((name) => `[[${name}]]`).join(', '))
+    parts.push(
+      input.attendees
+        .map((attendee) =>
+          attendee.kind === 'linked'
+            ? `[[${attendee.insertText}]]`
+            : attendee.text,
+        )
+        .join(', '),
+    )
     parts.push(' for ')
   }
   parts.push(input.backlinkMeeting ? `[[${input.title}]]` : input.title)
@@ -248,11 +265,17 @@ export async function addMeetingToDaily(input: AddMeetingInput): Promise<AddMeet
   // attendee spelled like the meeting itself (a shared mailbox, a 1:1 named
   // after the person) would just duplicate the link — drop it.
   const attendees = normalizeAttendees(
-    await resolveMeetingAttendees(input.attendees, lookupContacts),
-  ).filter((attendee) => attendee.name.toLowerCase() !== title.toLowerCase())
+    await resolveMeetingAttendeeTargets(input.attendees, lookupContacts),
+  ).filter(
+    ({ attendee }) => attendee.name.toLowerCase() !== title.toLowerCase(),
+  )
   const line = meetingLine({
     title,
-    attendees: attendees.map((attendee) => attendee.name),
+    attendees: attendees.map((resolved) =>
+      resolved.kind === 'plain'
+        ? { kind: 'plain', text: resolved.attendee.name }
+        : { kind: 'linked', insertText: resolved.insertText },
+    ),
     backlinkMeeting: input.backlinkMeeting,
     startTime: input.startTime,
   })
@@ -263,13 +286,21 @@ export async function addMeetingToDaily(input: AddMeetingInput): Promise<AddMeet
     await createNoteWithTitle(title, input.generation, MEETING_NOTE_BODY)
     createdNotes.push(title)
   }
-  for (const attendee of attendees) {
-    if (await titleHasNote(attendee.name)) {
+  for (const resolved of attendees) {
+    if (resolved.kind !== 'new') {
       continue
     }
+    const { attendee } = resolved
     const body = await personNoteBody(attendee, lookupContacts)
-    await createNoteWithTitle(attendee.name, input.generation, body)
-    createdNotes.push(attendee.name)
+    const outcome = await ensurePersonNote({
+      title: attendee.name,
+      emails: attendee.emails ?? [],
+      body,
+      generation: input.generation,
+    })
+    if (outcome.kind === 'created') {
+      createdNotes.push(attendee.name)
+    }
   }
 
   return { appended: true, createdNotes }

--- a/packages/core/src/actions/resolve-attendees.test.ts
+++ b/packages/core/src/actions/resolve-attendees.test.ts
@@ -1,103 +1,222 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { resolvePerson } from '../contacts/person'
 import { resolveAttendeeContact } from '../contacts/resolve'
-import { noteTitleOwningEmail } from '../indexing/queries'
-import { resolveMeetingAttendees } from './resolve-attendees'
+import {
+  resolveMeetingAttendees,
+  resolveMeetingAttendeeTargets,
+} from './resolve-attendees'
 
-vi.mock('../indexing/queries', () => ({
-  noteTitleOwningEmail: vi.fn(),
+vi.mock('../contacts/person', () => ({
+  resolvePerson: vi.fn(),
 }))
 vi.mock('../contacts/resolve', () => ({
   resolveAttendeeContact: vi.fn(),
 }))
 
-const owningNoteMock = vi.mocked(noteTitleOwningEmail)
+const resolvePersonMock = vi.mocked(resolvePerson)
 const contactMock = vi.mocked(resolveAttendeeContact)
-
-function contact(fullName: string): Awaited<ReturnType<typeof resolveAttendeeContact>> {
-  return { fullName, givenName: '', familyName: '', emails: [], phones: [] }
-}
 
 beforeEach(() => {
   vi.clearAllMocks()
-  owningNoteMock.mockResolvedValue(null)
+  resolvePersonMock.mockImplementation(async (emails) => ({
+    kind: 'missing',
+    emails: [...emails],
+  }))
   contactMock.mockResolvedValue(null)
 })
 
 describe('resolveMeetingAttendees', () => {
-  it('renames an attendee to the note that owns their invite email', async () => {
-    owningNoteMock.mockResolvedValue('Jane Doe')
-    const resolved = await resolveMeetingAttendees(
-      [{ name: 'jane@corp.com', email: 'jane@corp.com' }],
-      false,
-    )
-    expect(resolved).toEqual([{ name: 'Jane Doe', email: 'jane@corp.com' }])
-  })
+  it('renames an attendee to its unique email owner', async () => {
+    resolvePersonMock.mockResolvedValue({
+      kind: 'existing',
+      emails: ['jane@corp.com'],
+      path: 'notes/jane.md',
+      title: 'Jane Doe',
+      insertText: 'Jane Doe',
+    })
 
-  it('the graph outranks Apple Contacts — a note owner wins even with the gate on', async () => {
-    owningNoteMock.mockResolvedValue('Jane Doe')
-    contactMock.mockResolvedValue(contact('Jane A. Doe'))
-    const resolved = await resolveMeetingAttendees(
-      [{ name: 'jane@corp.com', email: 'jane@corp.com' }],
-      true,
-    )
-    expect(resolved).toEqual([{ name: 'Jane Doe', email: 'jane@corp.com' }])
+    await expect(
+      resolveMeetingAttendees(
+        [{ name: 'jane@corp.com', emails: ['jane@corp.com'] }],
+        false,
+      ),
+    ).resolves.toEqual([
+      { name: 'Jane Doe', emails: ['jane@corp.com'] },
+    ])
     expect(contactMock).not.toHaveBeenCalled()
   })
 
-  it('names an email-only attendee from Apple Contacts when no note owns the address', async () => {
-    contactMock.mockResolvedValue(contact('Jane Doe'))
-    const resolved = await resolveMeetingAttendees(
-      [{ name: 'Jane@Corp.com', email: 'jane@corp.com' }],
-      true,
-    )
-    expect(resolved).toEqual([{ name: 'Jane Doe', email: 'jane@corp.com' }])
+  it('uses all Contact emails when a bare address resolves through Contacts', async () => {
+    contactMock.mockResolvedValue({
+      fullName: 'Jane Doe',
+      givenName: 'Jane',
+      familyName: 'Doe',
+      emails: ['jane@corp.com', 'jane@home.example'],
+      phones: [],
+    })
+
+    await expect(
+      resolveMeetingAttendees(
+        [{ name: 'Jane@Corp.com', emails: ['jane@corp.com'] }],
+        true,
+      ),
+    ).resolves.toEqual([
+      {
+        name: 'Jane Doe',
+        emails: ['jane@corp.com', 'jane@home.example'],
+      },
+    ])
+    expect(resolvePersonMock).toHaveBeenLastCalledWith([
+      'jane@corp.com',
+      'jane@home.example',
+    ])
   })
 
-  it('leaves a calendar-named attendee alone — contacts only fill in for a bare address', async () => {
-    contactMock.mockResolvedValue(contact('Jane Doe'))
-    const resolved = await resolveMeetingAttendees(
-      [{ name: 'Doe, Jane', email: 'jane@corp.com' }],
-      true,
-    )
-    expect(resolved).toEqual([{ name: 'Doe, Jane', email: 'jane@corp.com' }])
+  it('keeps a calendar display name while collecting all Contact emails', async () => {
+    contactMock.mockResolvedValue({
+      fullName: 'Jane Doe',
+      givenName: 'Jane',
+      familyName: 'Doe',
+      emails: ['jane@corp.com', 'jane@home.example'],
+      phones: [],
+    })
+
+    await expect(
+      resolveMeetingAttendees(
+        [{ name: 'Doe, Jane', emails: ['jane@corp.com'] }],
+        true,
+      ),
+    ).resolves.toEqual([
+      {
+        name: 'Doe, Jane',
+        emails: ['jane@corp.com', 'jane@home.example'],
+      },
+    ])
+    expect(resolvePersonMock).toHaveBeenLastCalledWith([
+      'jane@corp.com',
+      'jane@home.example',
+    ])
+  })
+
+  it('keeps a conflicted Contact selectable under its original name', async () => {
+    resolvePersonMock.mockResolvedValue({
+      kind: 'blocked',
+      emails: ['jane@corp.com', 'jane@home.example'],
+      reason: 'identity-conflict',
+    })
+
+    await expect(
+      resolveMeetingAttendees(
+        [{
+          name: 'Jane Doe',
+          emails: ['jane@corp.com', 'jane@home.example'],
+        }],
+        true,
+      ),
+    ).resolves.toEqual([
+      {
+        name: 'Jane Doe',
+        emails: ['jane@corp.com', 'jane@home.example'],
+      },
+    ])
     expect(contactMock).not.toHaveBeenCalled()
   })
 
-  it('never reaches Contacts while the gate is off', async () => {
-    const resolved = await resolveMeetingAttendees(
-      [{ name: 'jane@corp.com', email: 'jane@corp.com' }],
-      false,
-    )
-    expect(resolved).toEqual([{ name: 'jane@corp.com', email: 'jane@corp.com' }])
-    expect(contactMock).not.toHaveBeenCalled()
+  it('blocks when a Contact lookup adds an email owned by another person note', async () => {
+    contactMock.mockResolvedValue({
+      fullName: 'Jane Doe',
+      givenName: 'Jane',
+      familyName: 'Doe',
+      emails: ['jane@corp.com', 'jane@home.example'],
+      phones: [],
+    })
+    resolvePersonMock
+      .mockResolvedValueOnce({
+        kind: 'missing',
+        emails: ['jane@corp.com'],
+      })
+      .mockResolvedValueOnce({
+        kind: 'blocked',
+        emails: ['jane@corp.com', 'jane@home.example'],
+        reason: 'identity-conflict',
+      })
+
+    await expect(
+      resolveMeetingAttendeeTargets(
+        [{ name: 'jane@corp.com', emails: ['jane@corp.com'] }],
+        true,
+      ),
+    ).resolves.toEqual([
+      {
+        kind: 'plain',
+        attendee: {
+          name: 'Jane Doe',
+          emails: ['jane@corp.com', 'jane@home.example'],
+        },
+      },
+    ])
+  })
+})
+
+describe('resolveMeetingAttendeeTargets', () => {
+  it('links unique owners with their verified address', async () => {
+    resolvePersonMock.mockResolvedValue({
+      kind: 'existing',
+      emails: ['jane@corp.com'],
+      path: 'notes/jane.md',
+      title: 'Jane Doe',
+      insertText: 'Jane|Jane Doe',
+    })
+
+    await expect(
+      resolveMeetingAttendeeTargets(
+        [{ name: 'jane@corp.com', emails: ['jane@corp.com'] }],
+        false,
+      ),
+    ).resolves.toEqual([
+      {
+        kind: 'existing',
+        attendee: { name: 'Jane Doe', emails: ['jane@corp.com'] },
+        insertText: 'Jane|Jane Doe',
+      },
+    ])
   })
 
-  it('passes attendees without an email straight through, no lookups', async () => {
-    const resolved = await resolveMeetingAttendees([{ name: 'Grace Hopper' }], true)
-    expect(resolved).toEqual([{ name: 'Grace Hopper' }])
-    expect(owningNoteMock).not.toHaveBeenCalled()
-    expect(contactMock).not.toHaveBeenCalled()
-  })
+  it.each(['identity-conflict', 'unaddressable-owner'] as const)(
+    'writes %s identities as plain text',
+    async (reason) => {
+      resolvePersonMock.mockResolvedValue({
+        kind: 'blocked',
+        emails: ['jane@corp.com'],
+        reason,
+      })
 
-  it('skips an owner whose title cannot be wiki-linked verbatim', async () => {
-    // `[[Jane [Doe]]]` would corrupt the link, and the sanitized form would
-    // miss the owner in the index — so the rename must not happen at all.
-    owningNoteMock.mockResolvedValue('Jane [Doe]')
-    contactMock.mockResolvedValue(contact('Jane Doe'))
-    const resolved = await resolveMeetingAttendees(
-      [{ name: 'jane@corp.com', email: 'jane@corp.com' }],
-      true,
-    )
-    expect(resolved).toEqual([{ name: 'Jane Doe', email: 'jane@corp.com' }])
-  })
+      await expect(
+        resolveMeetingAttendeeTargets(
+          [{ name: 'Jane Doe', emails: ['jane@corp.com'] }],
+          false,
+        ),
+      ).resolves.toEqual([
+        {
+          kind: 'plain',
+          attendee: { name: 'Jane Doe', emails: ['jane@corp.com'] },
+        },
+      ])
+    },
+  )
 
-  it('falls through on a nameless contact or blank-titled owner', async () => {
-    owningNoteMock.mockResolvedValue('   ')
-    contactMock.mockResolvedValue(contact('  '))
-    const resolved = await resolveMeetingAttendees(
-      [{ name: 'jane@corp.com', email: 'jane@corp.com' }],
-      true,
-    )
-    expect(resolved).toEqual([{ name: 'jane@corp.com', email: 'jane@corp.com' }])
+  it('returns a safe new target when no email owner exists', async () => {
+    await expect(
+      resolveMeetingAttendeeTargets(
+        [{ name: 'Jane Doe', emails: ['JANE@corp.com'] }],
+        false,
+      ),
+    ).resolves.toEqual([
+      {
+        kind: 'new',
+        attendee: { name: 'Jane Doe', emails: ['jane@corp.com'] },
+        insertText: 'Jane Doe',
+      },
+    ])
   })
 })

--- a/packages/core/src/actions/resolve-attendees.ts
+++ b/packages/core/src/actions/resolve-attendees.ts
@@ -1,63 +1,128 @@
+import {
+  resolvePerson,
+  type PersonResolution,
+} from '../contacts/person'
 import { resolveAttendeeContact } from '../contacts/resolve'
-import { noteTitleOwningEmail } from '../indexing/queries'
+import { serializeWikiSuggestionAddress } from '../indexing/suggest'
+import { canonicalEmail, canonicalEmails } from '../markdown/email-fields'
 import { wikiLinkSafe } from '../markdown/edit'
-import { foldEmail } from '../markdown/email-fields'
 import type { MeetingAttendee } from './add-meeting'
 
+/** An attendee classified for linked or plain-text meeting serialization. */
+export type ResolvedMeetingAttendee =
+  | {
+      readonly kind: 'existing'
+      readonly attendee: MeetingAttendee
+      readonly insertText: string
+    }
+  | {
+      readonly kind: 'new'
+      readonly attendee: MeetingAttendee
+      readonly insertText: string
+    }
+  | {
+      readonly kind: 'plain'
+      readonly attendee: MeetingAttendee
+    }
+
+function normalizedAttendee(
+  attendee: MeetingAttendee,
+  emails: readonly string[],
+): MeetingAttendee {
+  return emails.length === 0
+    ? { name: attendee.name }
+    : { name: attendee.name, emails }
+}
+
+function targetFromPerson(
+  attendee: MeetingAttendee,
+  resolution: PersonResolution,
+): ResolvedMeetingAttendee {
+  if (resolution.kind === 'existing') {
+    return {
+      kind: 'existing',
+      attendee: {
+        name: resolution.title,
+        emails: resolution.emails,
+      },
+      insertText: resolution.insertText,
+    }
+  }
+  if (resolution.kind === 'blocked') {
+    return {
+      kind: 'plain',
+      attendee: normalizedAttendee(attendee, resolution.emails),
+    }
+  }
+  const name = wikiLinkSafe(attendee.name)
+  const insertText = serializeWikiSuggestionAddress(name, null)
+  if (insertText === null) {
+    return {
+      kind: 'plain',
+      attendee: normalizedAttendee(attendee, resolution.emails),
+    }
+  }
+  return {
+    kind: 'new',
+    attendee:
+      resolution.emails.length === 0
+        ? { name }
+        : { name, emails: resolution.emails },
+    insertText,
+  }
+}
+
+async function resolveMeetingAttendee(
+  attendee: MeetingAttendee,
+  lookupContacts: boolean,
+): Promise<ResolvedMeetingAttendee> {
+  const emails = canonicalEmails(attendee.emails ?? [])
+  let resolution = await resolvePerson(emails)
+  if (resolution.kind !== 'missing') {
+    return targetFromPerson(attendee, resolution)
+  }
+
+  const nameEmail = canonicalEmail(attendee.name)
+  if (lookupContacts && emails[0] !== undefined) {
+    const contact = await resolveAttendeeContact(emails[0])
+    if (contact !== null) {
+      const contactAttendee = {
+        name:
+          emails.includes(nameEmail) && contact.fullName.trim() !== ''
+            ? contact.fullName.trim()
+            : attendee.name,
+        emails: canonicalEmails([...emails, ...contact.emails]),
+      }
+      resolution = await resolvePerson(contactAttendee.emails)
+      return targetFromPerson(contactAttendee, resolution)
+    }
+  }
+  return targetFromPerson(normalizedAttendee(attendee, emails), resolution)
+}
+
 /**
- * Canonicalize meeting attendees against what the graph already knows, so
- * one person keeps one note no matter how the calendar spelled them.
- *
- * Calendars are unreliable about names: EventKit reports many participants
- * by bare address (no display name), and the ones it does name can differ
- * from the note title ("Doe, Jane" vs "Jane Doe"). Matching by name alone
- * therefore mints duplicate person notes. The invite email is the stable
- * identity, so each attendee that carries one resolves in order:
- *
- * 1. **The graph.** A `#person`-tagged note owning the address via a
- *    `- Email:` contact-field bullet (the `note_emails` projection) wins
- *    outright — the attendee is renamed to that note's title, so the
- *    `[[Person]]` link lands on the existing note.
- * 2. **Apple Contacts** (gate on), only when the attendee's name *is* the
- *    address — the calendar knew no better. The contact's full name becomes
- *    the attendee, so the note the flow then creates (pre-filled with the
- *    contact's details, including this email) is born under the person's
- *    real name — and step 1 finds it next time.
- * 3. Otherwise the attendee passes through unchanged, and the flow behaves
- *    as v1 did: title match or a fresh note.
- *
- * Both the add-meeting dialog (prefilling chips) and `addMeetingToDaily`
- * (authoritatively, at write time) run this, so what the user sees is what
- * gets linked — and a quick submit can't skip the resolution.
+ * Resolve attendees for meeting serialization. Every Contact email participates
+ * in ownership; conflicts and unaddressable owners become plain text.
+ */
+export async function resolveMeetingAttendeeTargets(
+  attendees: readonly MeetingAttendee[],
+  lookupContacts: boolean,
+): Promise<ResolvedMeetingAttendee[]> {
+  return Promise.all(
+    attendees.map((attendee) =>
+      resolveMeetingAttendee(attendee, lookupContacts),
+    ),
+  )
+}
+
+/**
+ * Resolve the editable attendee chips. Existing owners use their note title;
+ * blocked identities remain selectable under the original display name.
  */
 export async function resolveMeetingAttendees(
   attendees: readonly MeetingAttendee[],
   lookupContacts: boolean,
 ): Promise<MeetingAttendee[]> {
-  return Promise.all(attendees.map((attendee) => resolveAttendee(attendee, lookupContacts)))
-}
-
-async function resolveAttendee(
-  attendee: MeetingAttendee,
-  lookupContacts: boolean,
-): Promise<MeetingAttendee> {
-  if (attendee.email === undefined || foldEmail(attendee.email) === '') {
-    return attendee
-  }
-  const ownerTitle = await noteTitleOwningEmail(attendee.email)
-  // The rename must be lossless: `[[…]]` has no escaping, so a title that
-  // wikiLinkSafe would alter (brackets, pipes, doubled spaces) can't be
-  // linked verbatim — the sanitized form would miss the owner in the index
-  // and mint the very duplicate this resolution exists to prevent. Such an
-  // owner falls through to the later steps instead.
-  if (ownerTitle !== null && ownerTitle !== '' && wikiLinkSafe(ownerTitle) === ownerTitle) {
-    return { name: ownerTitle, email: attendee.email }
-  }
-  if (lookupContacts && foldEmail(attendee.name) === foldEmail(attendee.email)) {
-    const contact = await resolveAttendeeContact(attendee.email)
-    if (contact !== null && contact.fullName.trim() !== '') {
-      return { name: contact.fullName.trim(), email: attendee.email }
-    }
-  }
-  return attendee
+  const resolved = await resolveMeetingAttendeeTargets(attendees, lookupContacts)
+  return resolved.map(({ attendee }) => attendee)
 }

--- a/packages/core/src/calendar/events.test.ts
+++ b/packages/core/src/calendar/events.test.ts
@@ -118,7 +118,7 @@ describe('defaultAttendees', () => {
       }),
     )
     expect(attendees).toEqual([
-      { name: 'Ada Lovelace', email: 'ada@example.com' },
+      { name: 'Ada Lovelace', emails: ['ada@example.com'] },
       { name: 'Grace Hopper' },
     ])
   })

--- a/packages/core/src/calendar/events.ts
+++ b/packages/core/src/calendar/events.ts
@@ -78,7 +78,9 @@ export function defaultAttendees(event: CalendarEvent): MeetingAttendee[] {
       continue
     }
     seen.add(key)
-    attendees.push(attendee.email === null ? { name } : { name, email: attendee.email })
+    attendees.push(
+      attendee.email === null ? { name } : { name, emails: [attendee.email] },
+    )
   }
   return attendees
 }

--- a/packages/core/src/contacts/markdown.test.ts
+++ b/packages/core/src/contacts/markdown.test.ts
@@ -32,11 +32,13 @@ describe('contactDetailsMarkdown', () => {
     )
   })
 
-  it('dedupes values case-insensitively, keeping first casing and order', () => {
+  it('canonicalizes and deduplicates emails in order', () => {
     const details = contactDetailsMarkdown(
-      contact({ emails: ['Ada@Example.com', 'ada@example.com', 'ada@work.com'] }),
+      contact({
+        emails: ['Ada Lovelace <Ada@Example.com>', 'ada@example.com', 'ada@work.com'],
+      }),
     )
-    expect(details).toBe('- Type: #person\n- Email: Ada@Example.com\n- Email: ada@work.com')
+    expect(details).toBe('- Type: #person\n- Email: ada@example.com\n- Email: ada@work.com')
   })
 
   it('omits the typing line when the target body already carries a Type bullet', () => {

--- a/packages/core/src/contacts/markdown.ts
+++ b/packages/core/src/contacts/markdown.ts
@@ -1,4 +1,5 @@
 import { appendBlock } from '../markdown/edit'
+import { canonicalEmails } from '../markdown/email-fields'
 import { splitFrontmatter } from '../markdown/frontmatter'
 import type { ContactMatch } from './commands'
 
@@ -46,7 +47,7 @@ const TYPE_LINE_PATTERN = /^[ \t]*[-+*][ \t]+type:/im
  * stack a second line.
  */
 export function contactDetailsMarkdown(contact: ContactMatch, existingBody = ''): string {
-  const emails = uniqueValues(contact.emails)
+  const emails = canonicalEmails(contact.emails)
   const phones = uniqueValues(contact.phones)
   if (emails.length === 0 && phones.length === 0) {
     return ''

--- a/packages/core/src/contacts/person.test.ts
+++ b/packages/core/src/contacts/person.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resolveOrCreateNoteWithTitle } from '../graph/create-note'
+import { setBridge } from '../ipc/bridge'
+import { getWikiAddressForPath } from '../indexing/queries-suggestions'
+import { ensurePersonNote, resolvePerson } from './person'
+
+vi.mock('../graph/create-note', () => ({
+  resolveOrCreateNoteWithTitle: vi.fn(),
+}))
+vi.mock('../indexing/queries-suggestions', () => ({
+  getWikiAddressForPath: vi.fn(),
+}))
+
+const mockInvoke = vi.fn<(command: string, args: Record<string, unknown>) => Promise<unknown>>()
+const getAddressMock = vi.mocked(getWikiAddressForPath)
+const resolveOrCreateMock = vi.mocked(resolveOrCreateNoteWithTitle)
+
+function address(path = 'notes/ada.md') {
+  return {
+    target: 'Ada Lovelace',
+    path,
+    title: 'Ada Lovelace',
+    alias: null,
+    date: null,
+    insertText: 'Ada Lovelace',
+  }
+}
+
+beforeEach(() => {
+  mockInvoke.mockReset()
+  getAddressMock.mockReset()
+  resolveOrCreateMock.mockReset()
+  setBridge({ invoke: mockInvoke, listen: async () => () => {} })
+})
+
+afterEach(() => {
+  setBridge(null)
+})
+
+describe('resolvePerson', () => {
+  it('returns missing without querying for blank identities', async () => {
+    await expect(resolvePerson([' ', 'mailto: '])).resolves.toEqual({
+      kind: 'missing',
+      emails: [],
+    })
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it('queries all canonical emails and reuses one owner', async () => {
+    mockInvoke.mockResolvedValue([
+      { path: 'notes/ada.md', title: 'Ada Lovelace' },
+    ])
+    getAddressMock.mockResolvedValue(address())
+
+    await expect(
+      resolvePerson([
+        'Ada <ADA@example.com>',
+        'ada@example.com',
+        'work@example.com',
+      ]),
+    ).resolves.toEqual({
+      kind: 'existing',
+      emails: ['ada@example.com', 'work@example.com'],
+      path: 'notes/ada.md',
+      title: 'Ada Lovelace',
+      insertText: 'Ada Lovelace',
+    })
+
+    const [, args] = mockInvoke.mock.calls[0]!
+    expect(String(args['sql'])).toContain('note_emails')
+    expect(String(args['sql'])).toContain('tags')
+    expect(String(args['sql'])).not.toContain('limit')
+    expect(args['params']).toEqual([
+      'ada@example.com',
+      'work@example.com',
+      'person',
+      'note',
+    ])
+  })
+
+  it('deduplicates one owner found through several emails', async () => {
+    mockInvoke.mockResolvedValue([
+      { path: 'notes/ada.md', title: 'Ada Lovelace' },
+      { path: 'notes/ada.md', title: 'Ada Lovelace' },
+    ])
+    getAddressMock.mockResolvedValue(address())
+
+    await expect(
+      resolvePerson(['ada@example.com', 'work@example.com']),
+    ).resolves.toMatchObject({
+      kind: 'existing',
+      path: 'notes/ada.md',
+    })
+  })
+
+  it('blocks when the email union has several owners', async () => {
+    mockInvoke.mockResolvedValue([
+      { path: 'notes/ada.md', title: 'Ada' },
+      { path: 'notes/augusta.md', title: 'Augusta' },
+    ])
+
+    await expect(
+      resolvePerson(['ada@example.com', 'work@example.com']),
+    ).resolves.toEqual({
+      kind: 'blocked',
+      emails: ['ada@example.com', 'work@example.com'],
+      reason: 'identity-conflict',
+    })
+    expect(getAddressMock).not.toHaveBeenCalled()
+  })
+
+  it('blocks a unique owner without a safe wiki address', async () => {
+    mockInvoke.mockResolvedValue([
+      { path: 'notes/ada.md', title: 'Ada Lovelace' },
+    ])
+    getAddressMock.mockResolvedValue(null)
+
+    await expect(resolvePerson(['ada@example.com'])).resolves.toEqual({
+      kind: 'blocked',
+      emails: ['ada@example.com'],
+      reason: 'unaddressable-owner',
+    })
+  })
+})
+
+describe('ensurePersonNote', () => {
+  it('does not create when an owner already exists', async () => {
+    mockInvoke.mockResolvedValue([
+      { path: 'notes/ada.md', title: 'Ada Lovelace' },
+    ])
+    getAddressMock.mockResolvedValue(address())
+
+    await expect(
+      ensurePersonNote({
+        title: 'Ada',
+        emails: ['ada@example.com'],
+        generation: 7,
+      }),
+    ).resolves.toMatchObject({ kind: 'existing', path: 'notes/ada.md' })
+    expect(resolveOrCreateMock).not.toHaveBeenCalled()
+  })
+
+  it('does not create a conflicted identity', async () => {
+    mockInvoke.mockResolvedValue([
+      { path: 'notes/ada.md', title: 'Ada' },
+      { path: 'notes/augusta.md', title: 'Augusta' },
+    ])
+
+    await expect(
+      ensurePersonNote({
+        title: 'Ada',
+        emails: ['ada@example.com'],
+        generation: 7,
+      }),
+    ).resolves.toMatchObject({ kind: 'blocked' })
+    expect(resolveOrCreateMock).not.toHaveBeenCalled()
+  })
+
+  it('creates a missing identity with its initial body', async () => {
+    mockInvoke.mockResolvedValue([])
+    resolveOrCreateMock.mockResolvedValue({
+      kind: 'created',
+      path: 'notes/ada.md',
+    })
+
+    await expect(
+      ensurePersonNote({
+        title: 'Ada',
+        emails: ['ada@example.com'],
+        body: '- Type: #person\n- Email: ada@example.com',
+        generation: 7,
+      }),
+    ).resolves.toEqual({ kind: 'created', path: 'notes/ada.md' })
+    expect(resolveOrCreateMock).toHaveBeenCalledWith(
+      'Ada',
+      7,
+      '- Type: #person\n- Email: ada@example.com',
+    )
+  })
+})

--- a/packages/core/src/contacts/person.test.ts
+++ b/packages/core/src/contacts/person.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { resolveOrCreateNoteWithTitle } from '../graph/create-note'
 import { setBridge } from '../ipc/bridge'
 import { getWikiAddressForPath } from '../indexing/queries-suggestions'
-import { ensurePersonNote, resolvePerson } from './person'
+import type { ContactMatch } from './commands'
+import {
+  ensurePersonNote,
+  resolvePerson,
+  resolvePersonContact,
+} from './person'
 
 vi.mock('../graph/create-note', () => ({
   resolveOrCreateNoteWithTitle: vi.fn(),
@@ -23,6 +28,17 @@ function address(path = 'notes/ada.md') {
     alias: null,
     date: null,
     insertText: 'Ada Lovelace',
+  }
+}
+
+function contact(overrides: Partial<ContactMatch> = {}): ContactMatch {
+  return {
+    fullName: 'Ada Lovelace',
+    givenName: 'Ada',
+    familyName: 'Lovelace',
+    emails: ['ada@example.com'],
+    phones: [],
+    ...overrides,
   }
 }
 
@@ -176,5 +192,51 @@ describe('ensurePersonNote', () => {
       7,
       '- Type: #person\n- Email: ada@example.com',
     )
+  })
+})
+
+describe('resolvePersonContact', () => {
+  it('uses an existing email owner target even when its title differs', async () => {
+    mockInvoke.mockResolvedValue([
+      { path: 'notes/augusta.md', title: 'Augusta Ada King' },
+    ])
+    getAddressMock.mockResolvedValue({
+      ...address('notes/augusta.md'),
+      target: 'Augusta Ada King',
+      title: 'Augusta Ada King',
+      insertText: 'Augusta Ada King',
+    })
+    const ada = contact()
+
+    await expect(resolvePersonContact(ada)).resolves.toEqual({
+      kind: 'existing',
+      contact: ada,
+      emails: ['ada@example.com'],
+      path: 'notes/augusta.md',
+      title: 'Augusta Ada King',
+      insertText: 'Augusta Ada King',
+    })
+  })
+
+  it('returns a serializable new target for an unowned contact', async () => {
+    mockInvoke.mockResolvedValue([])
+    const ada = contact()
+
+    await expect(resolvePersonContact(ada)).resolves.toEqual({
+      kind: 'new',
+      contact: ada,
+      insertText: 'Ada Lovelace',
+    })
+  })
+
+  it('blocks an unsafe new contact name', async () => {
+    mockInvoke.mockResolvedValue([])
+    const ada = contact({ fullName: 'Ada | Augusta' })
+
+    await expect(resolvePersonContact(ada)).resolves.toEqual({
+      kind: 'blocked',
+      contact: ada,
+      reason: 'unaddressable-contact',
+    })
   })
 })

--- a/packages/core/src/contacts/person.ts
+++ b/packages/core/src/contacts/person.ts
@@ -59,7 +59,6 @@ export type PersonContactResolution =
 
 interface PersonOwnerRow {
   readonly path: string
-  readonly title: string
 }
 
 async function personOwners(emails: readonly string[]): Promise<PersonOwnerRow[]> {
@@ -72,7 +71,7 @@ async function personOwners(emails: readonly string[]): Promise<PersonOwnerRow[]
       .where('noteEmails.emailKey', 'in', chunk)
       .where('tags.tagKey', '=', PERSON_TAG_KEY)
       .where('notes.kind', '=', 'note')
-      .select(['notes.path as path', 'notes.title as title'])
+      .select('notes.path as path')
       .distinct()
       .orderBy('notes.path')
       .execute()

--- a/packages/core/src/contacts/person.ts
+++ b/packages/core/src/contacts/person.ts
@@ -2,7 +2,9 @@ import { resolveOrCreateNoteWithTitle, type ResolveOrCreateNoteResult } from '..
 import { db } from '../indexing/db'
 import { getWikiAddressForPath } from '../indexing/queries-suggestions'
 import { inClauseChunks } from '../indexing/query-utils'
+import { serializeWikiSuggestionAddress } from '../indexing/suggest'
 import { canonicalEmails } from '../markdown/email-fields'
+import type { ContactMatch } from './commands'
 
 const PERSON_TAG_KEY = 'person'
 
@@ -30,6 +32,30 @@ export type PersonResolution =
   | MissingPersonResolution
   | ExistingPersonResolution
   | BlockedPersonResolution
+
+export interface NewPersonContactResolution {
+  readonly kind: 'new'
+  readonly contact: ContactMatch
+  readonly insertText: string
+}
+
+export interface ExistingPersonContactResolution extends ExistingPersonResolution {
+  readonly contact: ContactMatch
+}
+
+export interface BlockedPersonContactResolution {
+  readonly kind: 'blocked'
+  readonly contact: ContactMatch
+  readonly reason:
+    | BlockedPersonResolution['reason']
+    | 'unaddressable-contact'
+}
+
+/** A Contact row ready for a wikilink surface, or a reason to hide it. */
+export type PersonContactResolution =
+  | NewPersonContactResolution
+  | ExistingPersonContactResolution
+  | BlockedPersonContactResolution
 
 interface PersonOwnerRow {
   readonly path: string
@@ -91,6 +117,28 @@ export async function resolvePerson(
     title: address.title,
     insertText: address.insertText,
   }
+}
+
+/**
+ * Resolve one Apple Contact into a selectable new/existing wikilink target.
+ * Unsafe new names and unsafe or conflicting owners remain blocked identities,
+ * so callers cannot fall through to duplicate creation.
+ */
+export async function resolvePersonContact(
+  contact: ContactMatch,
+): Promise<PersonContactResolution> {
+  const resolution = await resolvePerson(contact.emails)
+  if (resolution.kind === 'existing') {
+    return { ...resolution, contact }
+  }
+  if (resolution.kind === 'blocked') {
+    return { kind: 'blocked', contact, reason: resolution.reason }
+  }
+  const insertText = serializeWikiSuggestionAddress(contact.fullName, null)
+  if (insertText === null) {
+    return { kind: 'blocked', contact, reason: 'unaddressable-contact' }
+  }
+  return { kind: 'new', contact, insertText }
 }
 
 export interface EnsurePersonNoteInput {

--- a/packages/core/src/contacts/person.ts
+++ b/packages/core/src/contacts/person.ts
@@ -1,0 +1,125 @@
+import { resolveOrCreateNoteWithTitle, type ResolveOrCreateNoteResult } from '../graph/create-note'
+import { db } from '../indexing/db'
+import { getWikiAddressForPath } from '../indexing/queries-suggestions'
+import { inClauseChunks } from '../indexing/query-utils'
+import { canonicalEmails } from '../markdown/email-fields'
+
+const PERSON_TAG_KEY = 'person'
+
+export interface MissingPersonResolution {
+  readonly kind: 'missing'
+  readonly emails: readonly string[]
+}
+
+export interface ExistingPersonResolution {
+  readonly kind: 'existing'
+  readonly emails: readonly string[]
+  readonly path: string
+  readonly title: string
+  readonly insertText: string
+}
+
+export interface BlockedPersonResolution {
+  readonly kind: 'blocked'
+  readonly emails: readonly string[]
+  readonly reason: 'identity-conflict' | 'unaddressable-owner'
+}
+
+/** The graph's answer for a set of email identities. */
+export type PersonResolution =
+  | MissingPersonResolution
+  | ExistingPersonResolution
+  | BlockedPersonResolution
+
+interface PersonOwnerRow {
+  readonly path: string
+  readonly title: string
+}
+
+async function personOwners(emails: readonly string[]): Promise<PersonOwnerRow[]> {
+  const owners = new Map<string, PersonOwnerRow>()
+  for (const chunk of inClauseChunks(emails)) {
+    const rows = await db
+      .selectFrom('noteEmails')
+      .innerJoin('notes', 'notes.path', 'noteEmails.notePath')
+      .innerJoin('tags', 'tags.notePath', 'notes.path')
+      .where('noteEmails.emailKey', 'in', chunk)
+      .where('tags.tagKey', '=', PERSON_TAG_KEY)
+      .where('notes.kind', '=', 'note')
+      .select(['notes.path as path', 'notes.title as title'])
+      .distinct()
+      .orderBy('notes.path')
+      .execute()
+    for (const row of rows) {
+      owners.set(row.path, row)
+    }
+  }
+  return [...owners.values()].sort((left, right) => left.path.localeCompare(right.path))
+}
+
+/**
+ * Resolve all supplied emails as one person identity. Primary-email order has
+ * no ownership priority: zero unique owner paths is missing, one is reusable,
+ * and more than one is a conflict.
+ */
+export async function resolvePerson(
+  values: readonly string[],
+): Promise<PersonResolution> {
+  const emails = canonicalEmails(values)
+  if (emails.length === 0) {
+    return { kind: 'missing', emails }
+  }
+  const owners = await personOwners(emails)
+  if (owners.length === 0) {
+    return { kind: 'missing', emails }
+  }
+  if (owners.length > 1) {
+    return { kind: 'blocked', emails, reason: 'identity-conflict' }
+  }
+  const owner = owners[0]
+  if (owner === undefined) {
+    return { kind: 'missing', emails }
+  }
+  const address = await getWikiAddressForPath(owner.path)
+  if (address === null) {
+    return { kind: 'blocked', emails, reason: 'unaddressable-owner' }
+  }
+  return {
+    kind: 'existing',
+    emails,
+    path: owner.path,
+    title: address.title,
+    insertText: address.insertText,
+  }
+}
+
+export interface EnsurePersonNoteInput {
+  readonly title: string
+  readonly emails: readonly string[]
+  readonly generation: number
+  readonly body?: string
+}
+
+export type EnsurePersonNoteResult =
+  | ExistingPersonResolution
+  | BlockedPersonResolution
+  | ResolveOrCreateNoteResult
+
+/**
+ * Recheck email ownership immediately before creating a person note. Existing
+ * and blocked identities never create; only a current ownership miss reaches
+ * the ordinary title resolver and atomic path claim.
+ */
+export async function ensurePersonNote(
+  input: EnsurePersonNoteInput,
+): Promise<EnsurePersonNoteResult> {
+  const resolution = await resolvePerson(input.emails)
+  if (resolution.kind !== 'missing') {
+    return resolution
+  }
+  return resolveOrCreateNoteWithTitle(
+    input.title,
+    input.generation,
+    input.body,
+  )
+}

--- a/packages/core/src/exports/ai-actions.ts
+++ b/packages/core/src/exports/ai-actions.ts
@@ -200,9 +200,14 @@ export {
   MEETINGS_HEADING,
   type AddMeetingInput,
   type AddMeetingOutcome,
+  type MeetingLineAttendee,
   type MeetingAttendee,
 } from '../actions/add-meeting'
-export { resolveMeetingAttendees } from '../actions/resolve-attendees'
+export {
+  resolveMeetingAttendees,
+  resolveMeetingAttendeeTargets,
+  type ResolvedMeetingAttendee,
+} from '../actions/resolve-attendees'
 export {
   describePage,
   isDescriptionRejected,

--- a/packages/core/src/exports/platform.ts
+++ b/packages/core/src/exports/platform.ts
@@ -245,3 +245,13 @@ export {
   noteHasContactDetails,
 } from '../contacts/markdown'
 export { pickContactForEmail, resolveAttendeeContact } from '../contacts/resolve'
+export {
+  ensurePersonNote,
+  resolvePerson,
+  type BlockedPersonResolution,
+  type EnsurePersonNoteInput,
+  type EnsurePersonNoteResult,
+  type ExistingPersonResolution,
+  type MissingPersonResolution,
+  type PersonResolution,
+} from '../contacts/person'

--- a/packages/core/src/exports/platform.ts
+++ b/packages/core/src/exports/platform.ts
@@ -248,10 +248,15 @@ export { pickContactForEmail, resolveAttendeeContact } from '../contacts/resolve
 export {
   ensurePersonNote,
   resolvePerson,
+  resolvePersonContact,
   type BlockedPersonResolution,
+  type BlockedPersonContactResolution,
   type EnsurePersonNoteInput,
   type EnsurePersonNoteResult,
   type ExistingPersonResolution,
+  type ExistingPersonContactResolution,
   type MissingPersonResolution,
+  type NewPersonContactResolution,
+  type PersonContactResolution,
   type PersonResolution,
 } from '../contacts/person'

--- a/packages/core/src/graph/create-note.test.ts
+++ b/packages/core/src/graph/create-note.test.ts
@@ -452,6 +452,21 @@ describe('resolveOrCreateNoteWithTitle', () => {
     })
     expect(invoke.mock.calls.filter(([command]) => command === 'note_create')).toHaveLength(1)
   })
+
+  it('uses the optional body only when creating a missing note', async () => {
+    const invoke = bindBridge()
+
+    await expect(
+      resolveOrCreateNoteWithTitle('Ada Lovelace', 7, '- Type: #person'),
+    ).resolves.toMatchObject({
+      kind: 'created',
+      path: 'notes/ada-lovelace.md',
+    })
+    const write = invoke.mock.calls.find(([command]) => command === 'note_create')
+    expect(write?.[1]?.['contents']).toMatch(
+      /^---\nid: [0-9a-z]{26}\n---\n# Ada Lovelace\n\n- Type: #person\n$/,
+    )
+  })
 })
 
 describe('untitledNoteSeed', () => {

--- a/packages/core/src/graph/create-note.ts
+++ b/packages/core/src/graph/create-note.ts
@@ -140,11 +140,13 @@ async function claimNotePathForSlug(
  * fallback, and the final index race check have one implementation. Only a
  * genuine `missing` result reaches the atomic no-clobber claim. If that claim
  * loses to a concurrent sync checkout or creator, the winner is resolved
- * before any suffix is tried.
+ * before any suffix is tried. `body` seeds only a genuinely new note; an
+ * existing title or alias is left untouched.
  */
 export async function resolveOrCreateNoteWithTitle(
   title: string,
   generation: number,
+  body?: string,
 ): Promise<ResolveOrCreateNoteResult> {
   const existing = await resolveExistingWikiTarget(title, generation)
   if (existing.kind !== 'missing') {
@@ -153,7 +155,7 @@ export async function resolveOrCreateNoteWithTitle(
 
   // On a lost claim, re-resolve both projections before considering a
   // suffix: the winner may be the note this link meant.
-  return claimNotePathForSlug(slugForTitle(title), newNoteSource(title), generation, async () => {
+  return claimNotePathForSlug(slugForTitle(title), newNoteSource(title, body), generation, async () => {
     const collisionResolution = await resolveExistingWikiTarget(title, generation)
     return collisionResolution.kind === 'missing' ? null : collisionResolution
   })

--- a/packages/core/src/indexing/index.ts
+++ b/packages/core/src/indexing/index.ts
@@ -75,6 +75,7 @@ export {
   getOpenTasks,
   getCompletedTasks,
   getPinnedNotes,
+  getWikiAddressForPath,
   suggestWikiTargets,
   suggestWikiLinkTargets,
   suggestTags,

--- a/packages/core/src/indexing/indexed-note.test.ts
+++ b/packages/core/src/indexing/indexed-note.test.ts
@@ -3,8 +3,8 @@ import { gistBodyHash, parseNote } from '../markdown'
 import { buildIndexedNote, indexedNoteSchema, PROJECTION_VERSION } from './indexed-note'
 
 describe('buildIndexedNote', () => {
-  it('carries the projection version that backfills linkable rich-title aliases', () => {
-    expect(PROJECTION_VERSION).toBe(16)
+  it('carries the projection version that backfills legacy contact emails', () => {
+    expect(PROJECTION_VERSION).toBe(17)
   })
 
   it('flattens a parsed note into the index payload', () => {
@@ -94,6 +94,26 @@ describe('buildIndexedNote', () => {
       source,
     })
     expect(indexed.emails).toEqual([{ email: 'ada@example.com', emailKey: 'ada@example.com' }])
+  })
+
+  it('projects legacy nested email fields', () => {
+    const source = [
+      '# Ada',
+      '',
+      '- Type: #person',
+      '- Emails',
+      '  - <Ada@Example.com>',
+      '  - [work@example.com](mailto:work@example.com)',
+    ].join('\n')
+    const indexed = buildIndexedNote(parseNote({ path: 'notes/ada.md', source }), {
+      fileHash: 'h',
+      mtime: 0,
+      source,
+    })
+    expect(indexed.emails).toEqual([
+      { email: 'Ada@Example.com', emailKey: 'ada@example.com' },
+      { email: 'work@example.com', emailKey: 'work@example.com' },
+    ])
   })
 
   it('derives the list preview and folded tag keys at index time', () => {

--- a/packages/core/src/indexing/indexed-note.ts
+++ b/packages/core/src/indexing/indexed-note.ts
@@ -71,8 +71,10 @@ import { serializeWikiSuggestionAddress } from './suggest'
  * derived linkable aliases for rich titles and rich frontmatter aliases:
  * existing notes must reproject for both the recovery-semantics convergence
  * and the backfilled alias rows.
+ * 17 - legacy nested `Email` / `Emails` contact fields and canonical email
+ * identities: unchanged V1 person notes need their `note_emails` rows rebuilt.
  */
-export const PROJECTION_VERSION = 16
+export const PROJECTION_VERSION = 17
 
 export const indexedLinkSchema = z.object({
   kind: z.enum(['wiki', 'md']),

--- a/packages/core/src/indexing/queries-suggestions.ts
+++ b/packages/core/src/indexing/queries-suggestions.ts
@@ -100,6 +100,37 @@ export async function suggestWikiLinkTargets(
   )
 }
 
+/**
+ * Return a verified wiki-link suggestion for one indexed note path. This is
+ * the path-first counterpart to text search: it uses the same canonical title,
+ * `note_keys` winner checks, rich-title address, and alias rescue.
+ */
+export async function getWikiAddressForPath(
+  path: string,
+): Promise<WikiLinkSuggestion | null> {
+  const note = await db
+    .selectFrom('notes')
+    .where('path', '=', path)
+    .where('kind', '!=', 'template')
+    .select(['path', 'title', 'titleKey', 'dailyDate', 'mtime'])
+    .executeTakeFirst()
+  if (note === undefined) {
+    return null
+  }
+  const candidate = rankWikiSuggestions('', [note], [], 1)[0]
+  if (candidate === undefined) {
+    return null
+  }
+  const result = await verifyWikiSuggestionAddresses(
+    [candidate],
+    [note.titleKey],
+    1,
+    '',
+    false,
+  )
+  return result.suggestions[0] ?? null
+}
+
 async function queryWikiTargetCandidates(
   query: string,
   dateGen?: DateSuggestionContext,

--- a/packages/core/src/indexing/queries.test.ts
+++ b/packages/core/src/indexing/queries.test.ts
@@ -8,6 +8,7 @@ import {
   getNoteIdsByPath,
   getOpenTasks,
   getPinnedNotes,
+  getWikiAddressForPath,
   listDailyNotes,
   noteTitleOwningEmail,
   resolveWikiTarget,
@@ -77,6 +78,74 @@ describe('noteTitleOwningEmail', () => {
   it('short-circuits a blank address before touching the bridge', async () => {
     await expect(noteTitleOwningEmail('   ')).resolves.toBeNull()
     expect(mockInvoke).not.toHaveBeenCalled()
+  })
+})
+
+describe('getWikiAddressForPath', () => {
+  it('uses the note_keys winner for the canonical title address', async () => {
+    mockInvoke
+      .mockResolvedValueOnce([
+        {
+          path: 'notes/ada.md',
+          title: 'Ada Lovelace',
+          title_key: 'ada lovelace',
+          daily_date: null,
+          mtime: 1,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          key: 'ada lovelace',
+          note_path: 'notes/ada.md',
+          daily_date: null,
+          claim_count: 1,
+        },
+      ])
+
+    await expect(getWikiAddressForPath('notes/ada.md')).resolves.toMatchObject({
+      path: 'notes/ada.md',
+      title: 'Ada Lovelace',
+      insertText: 'Ada Lovelace',
+    })
+  })
+
+  it('rescues an ambiguous title with a unique alias', async () => {
+    mockInvoke
+      .mockResolvedValueOnce([
+        {
+          path: 'notes/ada.md',
+          title: 'Ada Lovelace',
+          title_key: 'ada lovelace',
+          daily_date: null,
+          mtime: 1,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          key: 'ada lovelace',
+          note_path: 'notes/ada.md',
+          daily_date: null,
+          claim_count: 2,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          note_path: 'notes/ada.md',
+          alias: 'Augusta Ada King',
+          claim_count: 1,
+        },
+      ])
+
+    await expect(getWikiAddressForPath('notes/ada.md')).resolves.toMatchObject({
+      path: 'notes/ada.md',
+      alias: 'Augusta Ada King',
+      insertText: 'Augusta Ada King',
+    })
+  })
+
+  it('returns null when the path is absent', async () => {
+    mockInvoke.mockResolvedValue([])
+    await expect(getWikiAddressForPath('notes/missing.md')).resolves.toBeNull()
   })
 })
 

--- a/packages/core/src/indexing/queries.test.ts
+++ b/packages/core/src/indexing/queries.test.ts
@@ -10,7 +10,6 @@ import {
   getPinnedNotes,
   getWikiAddressForPath,
   listDailyNotes,
-  noteTitleOwningEmail,
   resolveWikiTarget,
   suggestWikiTargets,
 } from './queries'
@@ -50,34 +49,6 @@ describe('dailyDatesInRange', () => {
   it('returns an empty list when no daily notes exist in the range', async () => {
     mockInvoke.mockResolvedValue([])
     await expect(dailyDatesInRange('2025-01-01', '2025-01-31')).resolves.toEqual([])
-  })
-})
-
-describe('noteTitleOwningEmail', () => {
-  it('joins note_emails to #person-tagged regular notes by folded key, first path wins', async () => {
-    mockInvoke.mockResolvedValue([{ title: 'Jane Doe' }])
-
-    await expect(noteTitleOwningEmail('  Jane@Corp.com ')).resolves.toBe('Jane Doe')
-
-    const [command, args] = mockInvoke.mock.calls[0]!
-    expect(command).toBe('db_query')
-    const sql = String(args['sql'])
-    expect(sql).toContain('note_emails')
-    expect(sql).toContain('email_key')
-    expect(sql).toContain('tag_key')
-    expect(sql).toContain('kind')
-    expect(sql).toContain('order by')
-    expect(args['params']).toEqual(['jane@corp.com', 'person', 'note'])
-  })
-
-  it('answers null for an unowned address without guessing', async () => {
-    mockInvoke.mockResolvedValue([])
-    await expect(noteTitleOwningEmail('nobody@corp.com')).resolves.toBeNull()
-  })
-
-  it('short-circuits a blank address before touching the bridge', async () => {
-    await expect(noteTitleOwningEmail('   ')).resolves.toBeNull()
-    expect(mockInvoke).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/core/src/indexing/queries.ts
+++ b/packages/core/src/indexing/queries.ts
@@ -1,6 +1,5 @@
 import { sql } from 'kysely'
 import {
-  foldEmail,
   foldTag,
   normalizeWikiTarget,
   resolved,
@@ -314,36 +313,6 @@ export async function getNoteIdsByPath(paths: string[]): Promise<Map<string, str
     }
   }
   return ids
-}
-
-/** The folded tag key marking person notes (`- Type: #person`, v1's typing). */
-const PERSON_TAG_KEY = 'person'
-
-/**
- * The title of the note that owns `email` through a `- Email:` contact-field
- * bullet (the `note_emails` projection), or null. Only `#person`-tagged
- * regular notes qualify: a daily note, template, or non-person note quoting
- * an address must never become a `[[Person]]` link target — the projection
- * records every field bullet, and this query is where the ownership policy
- * lives. Several notes claiming one address resolve to the first path
- * alphabetically, the resolver's rule everywhere else.
- */
-export async function noteTitleOwningEmail(email: string): Promise<string | null> {
-  const key = foldEmail(email)
-  if (key === '') {
-    return null
-  }
-  const owner = await db
-    .selectFrom('noteEmails')
-    .innerJoin('notes', 'notes.path', 'noteEmails.notePath')
-    .innerJoin('tags', 'tags.notePath', 'notes.path')
-    .where('noteEmails.emailKey', '=', key)
-    .where('tags.tagKey', '=', PERSON_TAG_KEY)
-    .where('notes.kind', '=', 'note')
-    .select('notes.title as title')
-    .orderBy('notes.path')
-    .executeTakeFirst()
-  return owner?.title ?? null
 }
 
 /** Exact indexed date/title/alias candidates, preserving ambiguity within the winning tier. */

--- a/packages/core/src/indexing/queries.ts
+++ b/packages/core/src/indexing/queries.ts
@@ -20,6 +20,7 @@ export {
 } from './queries-backlinks'
 export { getCompletedTasks, getOpenTasks, type OpenTask } from './queries-tasks'
 export {
+  getWikiAddressForPath,
   suggestTags,
   suggestWikiLinkTargets,
   suggestWikiTargets,

--- a/packages/core/src/markdown/email-fields.test.ts
+++ b/packages/core/src/markdown/email-fields.test.ts
@@ -1,9 +1,39 @@
 import { describe, expect, it } from 'vitest'
-import { extractEmailFields, foldEmail } from './email-fields'
+import {
+  canonicalEmail,
+  canonicalEmails,
+  extractEmailFields,
+  foldEmail,
+} from './email-fields'
 
 describe('foldEmail', () => {
   it('trims and lowercases', () => {
     expect(foldEmail('  Ada@Example.COM ')).toBe('ada@example.com')
+  })
+
+  it('treats envelopes, display names, and mailto values as one identity', () => {
+    expect(canonicalEmail('<Ada@Example.COM>')).toBe('ada@example.com')
+    expect(canonicalEmail('Ada Lovelace <Ada@Example.COM>')).toBe('ada@example.com')
+    expect(canonicalEmail('<mailto:Ada@Example.COM>')).toBe('ada@example.com')
+  })
+
+  it('preserves provider-significant dots and plus tags', () => {
+    expect(canonicalEmail('<ada.lovelace+notes@example.com>')).toBe(
+      'ada.lovelace+notes@example.com',
+    )
+  })
+})
+
+describe('canonicalEmails', () => {
+  it('canonicalizes, removes blanks, and deduplicates in order', () => {
+    expect(
+      canonicalEmails([
+        ' Ada@Example.com ',
+        '<ada@example.com>',
+        '',
+        'ada@work.example',
+      ]),
+    ).toEqual(['ada@example.com', 'ada@work.example'])
   })
 })
 
@@ -31,6 +61,73 @@ describe('extractEmailFields', () => {
       'a@x.com',
       'B@Y.com',
     ])
+  })
+
+  it('reads V1 addresses nested under an empty Email field', () => {
+    const body = [
+      '- Type: #person',
+      '- Email:',
+      '  - <Ada@Example.com>',
+      '  - <ada@work.example>',
+      '- Phone:',
+      '  - [555-1234](tel:555-1234)',
+    ].join('\n')
+
+    expect(extractEmailFields(body)).toEqual([
+      'Ada@Example.com',
+      'ada@work.example',
+    ])
+  })
+
+  it('reads pre-2023 V1 Emails fields and nested mailto links', () => {
+    const body = [
+      '- Emails',
+      '  - [Ada@Example.com](mailto:ada@example.com)',
+      '  - <ada@work.example>',
+    ].join('\n')
+
+    expect(extractEmailFields(body)).toEqual([
+      'Ada@Example.com',
+      'ada@work.example',
+    ])
+  })
+
+  it('handles an indented legacy field and tab-indented child', () => {
+    expect(extractEmailFields('  * EMAIL:\n\t+ <ada@example.com>')).toEqual([
+      'ada@example.com',
+    ])
+  })
+
+  it('ends a legacy field at a sibling and ignores unrelated nested addresses', () => {
+    const body = [
+      '- Email:',
+      '  - owner@example.com',
+      '- Notes:',
+      '  - unrelated@example.com',
+    ].join('\n')
+
+    expect(extractEmailFields(body)).toEqual(['owner@example.com'])
+  })
+
+  it('does not extend a populated inline field into nested list items', () => {
+    const body = [
+      '- Email: owner@example.com',
+      '  - unrelated@example.com',
+    ].join('\n')
+
+    expect(extractEmailFields(body)).toEqual(['owner@example.com'])
+  })
+
+  it('ignores indented prose under a legacy Email field', () => {
+    expect(
+      extractEmailFields('- Email:\n  Reach Ada at unrelated@example.com'),
+    ).toEqual([])
+  })
+
+  it('deduplicates bare and angle-wrapped field values', () => {
+    expect(
+      extractEmailFields('- Email: <Ada@Example.com>\n- Email: ada@example.com'),
+    ).toEqual(['Ada@Example.com'])
   })
 
   it('unwraps a mailto link, collapsing the text/href pair', () => {

--- a/packages/core/src/markdown/email-fields.ts
+++ b/packages/core/src/markdown/email-fields.ts
@@ -1,9 +1,8 @@
 /**
- * Contact-field emails — the `- Email: ada@example.com` bullet shape of v1's
- * person template, written today by the contacts integration
- * (`contactDetailsMarkdown`) and the meeting flow's person-note pre-fill.
- * The indexer projects these into `note_emails` so an invite email can find
- * the person note that owns it (attendee resolution in the calendar flow).
+ * Contact-field emails — the canonical `- Email: ada@example.com` V2 shape,
+ * plus V1's `- Email:` / nested-value shape. The indexer projects these into
+ * `note_emails` so an invite email can find the person note that owns it
+ * (attendee resolution in the calendar flow).
  *
  * Ownership is deliberately narrow: only an explicit `Email:` field bullet
  * counts. A bare address in prose — a daily note quoting an email, a meeting
@@ -11,8 +10,17 @@
  * the address.
  */
 
-/** An `Email:` field bullet (any list marker, any case), capturing its value. */
-const EMAIL_FIELD_PATTERN = /^[ \t]*[-+*][ \t]+email:(.*)$/gim
+/**
+ * An `Email:` field bullet (or pre-2023 V1 `Emails`), capturing indentation
+ * and an optional inline value. A missing colon is accepted only when the
+ * label occupies the whole list item.
+ */
+const EMAIL_FIELD_PATTERN = /^([ \t]*)[-+*][ \t]+emails?[ \t]*(?::[ \t]*(.*))?$/i
+
+/** A nested unordered-list item, capturing indentation and value. */
+const LIST_ITEM_PATTERN = /^([ \t]*)[-+*][ \t]+(.*)$/
+const LEADING_WHITESPACE_PATTERN = /^[ \t]*/
+const MARKDOWN_TAB_WIDTH = 4
 
 /**
  * An address inside a field value (tolerates `mailto:` links and commas —
@@ -20,33 +28,91 @@ const EMAIL_FIELD_PATTERN = /^[ \t]*[-+*][ \t]+email:(.*)$/gim
  */
 const EMAIL_PATTERN = /[^\s@<>(),;:[\]]+@[^\s@<>(),;:[\]]+\.[^\s@<>(),;:[\]]+/g
 
-/** Normalize an email for matching: trimmed, lowercased. */
-export function foldEmail(email: string): string {
-  return email.trim().toLowerCase()
+/**
+ * Normalize an email identity for matching. Provider-specific transformations
+ * such as removing dots or `+tags` are deliberately not applied.
+ */
+export function canonicalEmail(email: string): string {
+  const trimmed = email.trim()
+  const wrapped = trimmed.match(/^(?:[^<>]*)<\s*([^<>]+)\s*>$/)
+  const address = (wrapped?.[1] ?? trimmed).replace(/^mailto:/i, '').trim()
+  return address.toLowerCase()
+}
+
+/** The established indexing name for {@link canonicalEmail}. */
+export const foldEmail = canonicalEmail
+
+/** Canonicalize, remove blanks, and deduplicate email identities in order. */
+export function canonicalEmails(values: readonly string[]): string[] {
+  const seen = new Set<string>()
+  const emails: string[] = []
+  for (const value of values) {
+    const email = canonicalEmail(value)
+    if (email === '' || seen.has(email)) {
+      continue
+    }
+    seen.add(email)
+    emails.push(email)
+  }
+  return emails
+}
+
+function indentationWidth(whitespace: string): number {
+  let width = 0
+  for (const character of whitespace) {
+    if (character === '\t') {
+      width += MARKDOWN_TAB_WIDTH - (width % MARKDOWN_TAB_WIDTH)
+    } else {
+      width += 1
+    }
+  }
+  return width
+}
+
+function appendEmails(value: string, seen: Set<string>, emails: string[]): void {
+  for (const match of value.matchAll(EMAIL_PATTERN)) {
+    const email = match[0].replace(/\.+$/, '')
+    const key = canonicalEmail(email)
+    if (seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    emails.push(email)
+  }
 }
 
 /**
- * Every email a note body owns via `- Email:` field bullets, in document
- * order, case-insensitively deduplicated (first casing kept). One bullet may
- * carry several addresses (comma-separated, or a `mailto:` link whose text
- * repeats the address — the dedup collapses that pair). Run this on the
- * body, frontmatter split off.
+ * Every email a note body owns via a contact field, in document order and
+ * case-insensitively deduplicated (first casing kept). V2 writes the value on
+ * the `- Email:` line. V1 wrote an empty parent followed by nested address
+ * bullets. Run this on the body, frontmatter split off.
  */
 export function extractEmailFields(body: string): string[] {
   const seen = new Set<string>()
   const emails: string[] = []
-  for (const field of body.matchAll(EMAIL_FIELD_PATTERN)) {
-    const value = field[1] ?? ''
-    for (const match of value.matchAll(EMAIL_PATTERN)) {
-      // The field value is free-form prose; a sentence-final dot glued to an
-      // address is punctuation, not domain.
-      const email = match[0].replace(/\.+$/, '')
-      const key = foldEmail(email)
-      if (seen.has(key)) {
-        continue
-      }
-      seen.add(key)
-      emails.push(email)
+  let legacyParentIndent: number | null = null
+
+  for (const line of body.split(/\r?\n/)) {
+    const field = line.match(EMAIL_FIELD_PATTERN)
+    if (field !== null) {
+      const inlineValue = field[2] ?? ''
+      appendEmails(inlineValue, seen, emails)
+      legacyParentIndent = inlineValue.trim() === '' ? indentationWidth(field[1] ?? '') : null
+      continue
+    }
+
+    if (legacyParentIndent === null || line.trim() === '') {
+      continue
+    }
+
+    const item = line.match(LIST_ITEM_PATTERN)
+    const whitespace = item?.[1] ?? line.match(LEADING_WHITESPACE_PATTERN)?.[0] ?? ''
+    if (indentationWidth(whitespace) <= legacyParentIndent) {
+      legacyParentIndent = null
+      continue
+    }
+    if (item !== null) {
+      appendEmails(item[2] ?? '', seen, emails)
     }
   }
   return emails

--- a/packages/core/src/markdown/index.ts
+++ b/packages/core/src/markdown/index.ts
@@ -64,7 +64,12 @@ export {
   type ConflictSegment,
   type ConflictSide,
 } from './conflict-markers'
-export { extractEmailFields, foldEmail } from './email-fields'
+export {
+  canonicalEmail,
+  canonicalEmails,
+  extractEmailFields,
+  foldEmail,
+} from './email-fields'
 export { foldFallbackTitleKey, foldKey, foldTag } from './keys'
 export { gistBodyHash, gistFilename } from './gist'
 export { slugForTitle } from './slug'


### PR DESCRIPTION
Closes https://github.com/team-reflect/reflect-open/pull/794 

Closes https://github.com/prosekit/meowdown/pull/309

## Summary

- canonicalize Contact emails and index legacy nested `Email` / `Emails` fields, with projection version 17 rebuilding unchanged notes
- resolve every Contact email to zero, one, or multiple `#person` note owners through one shared core resolver
- reuse the current `note_keys` winner and alias-rescue rules to produce safe wikilink addresses
- reuse unique owners in wikilink autocomplete and meetings, while blocking duplicate creation for conflicts and unaddressable owners
- preserve all Contact emails in meeting attendees and write blocked attendees as plain text

## Why

Contact names, calendar labels, and person note titles can differ. The previous flows primarily created or reused notes by display name, so the same person could receive a second note even when an existing `#person` note already claimed their email. The old single-email query also silently selected one path when identity was already conflicted.

This change treats explicit email fields on `#person` notes as the stable identity. Primary email order has no ownership privilege: all owner paths are unioned, one owner is reused, and multiple owners are blocked without guessing.

## User impact

Selecting a Contact or adding a meeting attendee now reuses the existing email-owned person note even when its title differs. Conflicting or unaddressable identities do not create another person note. Autocomplete hides only the blocked Contact row, while meeting attendees remain selectable and are written as plain text.

Selection-time creation still uses the existing background operation feedback. A very small search-to-selection race may leave an unresolved wikilink, but creation rechecks ownership and avoids a known duplicate. No Meowdown changes or editor-range correction machinery are included.

## Validation

- `pnpm check`
- `pnpm build`
- 225 focused Vitest tests across email parsing, projection, person resolution, wikilink autocomplete, meeting resolution, and attendee UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved contact and attendee matching using all associated email addresses.
  * Meeting attendees now link to existing person notes when ownership is clear, while conflicts safely remain plain text.
  * Contact suggestions in link autocomplete now provide more accurate selections and avoid duplicate creation.
  * Newly created person notes can include contact email and phone details.

* **Bug Fixes**
  * Prevented incorrect attendee additions during refetches or input blur.
  * Improved recognition of legacy and formatted email fields.

* **Documentation**
  * Clarified calendar and contacts integration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->