### PR TITLE
fix: soften iOS calendar note markers

### DIFF
--- a/apps/desktop/src/mobile/week-row.tsx
+++ b/apps/desktop/src/mobile/week-row.tsx
@@ -94,7 +94,7 @@ function WeekRowComponent({
               className={cn(
                 'size-1 rounded-full',
                 hasDailyNote
-                  ? 'bg-surface-inverse/50 dark:bg-white/50'
+                  ? 'bg-text-muted'
                   : !selected && isToday
                     ? 'bg-primary'
                     : 'bg-transparent',


### PR DESCRIPTION
## Problem

The persistent daily-note dots added in #928 use the inverse surface color at 50% opacity. On the iOS calendar strip that makes them visually heavier than the weekday labels, especially in dark mode, so they compete with the selected date instead of acting as quiet metadata.

## Changes

- Render daily-note markers with the same muted-text token used by the weekday initials.
- Keep the existing 4px size, Today treatment, note lookup, and accessible labels unchanged.

## Verification

- pnpm test --run apps/desktop/src/mobile/week-row.test.tsx — 1 passed
- pnpm check — passed with existing max-lines warnings
- pnpm build — passed with expected Sentry token and chunk-size warnings
- Browser-checked the iOS preview at 390 × 844 in light and dark themes; marker and weekday colors resolve to the same computed value in each theme

## Risk / Rollout

CSS-only token change. No data, query, routing, or accessibility behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS class token swap in `week-row.tsx` with no logic, data, or accessibility changes.
> 
> **Overview**
> **Daily-note dots** on the mobile week calendar strip now use `bg-text-muted` instead of inverse-surface at 50% opacity, so they align visually with weekday initials and read as quiet metadata rather than competing with the selected date (especially in dark mode).
> 
> Size, today-dot behavior, note lookup, and accessible labels are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c828a8d6db97c996f647edbd1dbf3b9ab6782b8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the daily note indicator color for improved visual consistency across themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->