### PR TITLE
feat: allow GitHub sign-out with no connected graph

### DIFF
--- a/apps/desktop/src/components/settings/backup-section.test.tsx
+++ b/apps/desktop/src/components/settings/backup-section.test.tsx
@@ -18,13 +18,16 @@ const sync = vi.hoisted(() => ({
   signOut: vi.fn(async () => {}),
   backUpNow: vi.fn(async () => {}),
 }))
+const github = vi.hoisted(() => ({ connected: false }))
 vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn(async () => {}) }))
 vi.mock('@/providers/sync-provider', () => ({ useSync: () => sync }))
 vi.mock('@/providers/graph-provider', () => ({ useGraph: () => ({ graph: null }) }))
+vi.mock('@/hooks/use-github-connected', () => ({ useGithubConnected: () => github.connected }))
 
 afterEach(async () => {
   await cleanup()
   vi.clearAllMocks()
+  github.connected = false
 })
 
 async function renderSection(backup: BackupState): Promise<void> {
@@ -228,5 +231,37 @@ describe('BackupSettingsField', () => {
     await expect
       .element(page.getByRole('heading', { name: 'Sign out of GitHub?' }))
       .not.toBeInTheDocument()
+  })
+
+  it('offers sign-out with no connected graph when signed in to GitHub', async () => {
+    github.connected = true
+    await renderSection({ phase: 'disconnected' })
+
+    await expect.element(page.getByRole('button', { name: /Connect GitHub/ })).toBeVisible()
+    await expect.element(page.getByText('GitHub account')).toBeVisible()
+    await expect.element(page.getByText(/Sign out to connect a different account/i)).toBeVisible()
+    await expect.element(page.getByRole('button', { name: /Sign out of GitHub/ })).toBeVisible()
+  })
+
+  it('hides sign-out with no connected graph when not signed in to GitHub', async () => {
+    github.connected = false
+    await renderSection({ phase: 'disconnected' })
+
+    await expect.element(page.getByRole('button', { name: /Connect GitHub/ })).toBeVisible()
+    await expect
+      .element(page.getByRole('button', { name: /Sign out of GitHub/ }))
+      .not.toBeInTheDocument()
+  })
+
+  it('signs out of GitHub from the disconnected state', async () => {
+    github.connected = true
+    await renderSection({ phase: 'disconnected' })
+
+    await userEvent.click(page.getByRole('button', { name: /Sign out of GitHub/ }))
+    await expect.element(page.getByRole('heading', { name: 'Sign out of GitHub?' })).toBeVisible()
+
+    await userEvent.click(page.getByRole('button', { name: 'Sign out' }))
+
+    await vi.waitFor(() => expect(sync.signOut).toHaveBeenCalledTimes(1))
   })
 })

--- a/apps/desktop/src/components/settings/backup-section.tsx
+++ b/apps/desktop/src/components/settings/backup-section.tsx
@@ -6,19 +6,11 @@ import { ExternalLink } from 'lucide-react'
 import { ConnectGithubDialog } from '@/components/settings/connect-github-dialog'
 import { ConflictedNoteLinks } from '@/components/settings/conflicted-note-links'
 import { SettingsField } from '@/components/settings/field'
+import { GithubSignOutRow } from '@/components/settings/github-sign-out-row'
 import { SyncForkNotice } from '@/components/settings/sync-fork-notice'
 import { Button } from '@/components/ui/button'
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog'
 import { useAsyncAction } from '@/hooks/use-async-action'
+import { useGithubConnected } from '@/hooks/use-github-connected'
 import { suggestRepoName } from '@/lib/github-repos'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
@@ -55,11 +47,10 @@ function githubRepoBrowserUrl(repo: NonNullable<Extract<BackupState, { phase: 'c
 export function BackupSettingsField(): ReactElement {
   const { backup, disconnectGraph, signOut, backUpNow } = useSync()
   const { graph } = useGraph()
+  const githubConnected = useGithubConnected()
   const [connectOpen, setConnectOpen] = useState(false)
-  const [signOutOpen, setSignOutOpen] = useState(false)
   const openRepoAttempt = useRef(0)
   const action = useAsyncAction()
-  const signOutAction = useAsyncAction()
 
   const conflicted = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, 'conflicted-notes', graph?.root],
@@ -107,20 +98,6 @@ export function BackupSettingsField(): ReactElement {
       })
   }
 
-  function setSignOutDialogOpen(open: boolean): void {
-    if (!open && signOutAction.pending) {
-      return
-    }
-    setSignOutOpen(open)
-  }
-
-  async function confirmSignOut(): Promise<void> {
-    await signOutAction.run(async () => {
-      await signOut()
-      setSignOutOpen(false)
-    })
-  }
-
   return (
     <>
       <SettingsField
@@ -137,11 +114,19 @@ export function BackupSettingsField(): ReactElement {
           ) : null}
 
           {backup.phase === 'disconnected' ? (
-            <div>
-              <Button size="sm" onClick={() => setConnectOpen(true)}>
-                Connect GitHub…
-              </Button>
-            </div>
+            <>
+              <div>
+                <Button size="sm" onClick={() => setConnectOpen(true)}>
+                  Connect GitHub…
+                </Button>
+              </div>
+              {githubConnected ? (
+                <GithubSignOutRow
+                  signOut={signOut}
+                  description="Signed in to GitHub. Sign out to connect a different account."
+                />
+              ) : null}
+            </>
           ) : null}
 
           {backup.phase === 'connected' ? (
@@ -187,54 +172,10 @@ export function BackupSettingsField(): ReactElement {
                 ) : null}
               </div>
               {backup.repo !== null ? (
-                <div className="mt-2 flex flex-col gap-2 border-t border-border/70 pt-3 sm:flex-row sm:items-center sm:justify-between">
-                  <div>
-                    <p className="text-xs font-medium text-text">GitHub account</p>
-                    <p className="text-xs text-text-muted">
-                      Sign out on this machine; connected graphs stop backing up.
-                    </p>
-                  </div>
-                  <Dialog open={signOutOpen} onOpenChange={setSignOutDialogOpen}>
-                    <DialogTrigger asChild>
-                      <Button
-                        variant="destructive"
-                        size="sm"
-                        title="Removes the GitHub token from this machine"
-                        disabled={signOutAction.pending}
-                      >
-                        Sign out of GitHub…
-                      </Button>
-                    </DialogTrigger>
-                    <DialogContent showCloseButton={!signOutAction.pending}>
-                      <DialogHeader>
-                        <DialogTitle>Sign out of GitHub?</DialogTitle>
-                        <DialogDescription>
-                          This removes the GitHub token from this machine. Every
-                          GitHub-backed graph will stop backing up until you sign in again.
-                        </DialogDescription>
-                      </DialogHeader>
-                      {signOutAction.error !== null ? (
-                        <p className="text-xs text-red-700 dark:text-red-300">
-                          {signOutAction.error}
-                        </p>
-                      ) : null}
-                      <DialogFooter>
-                        <DialogClose asChild>
-                          <Button variant="outline" disabled={signOutAction.pending}>
-                            Cancel
-                          </Button>
-                        </DialogClose>
-                        <Button
-                          variant="destructive"
-                          disabled={signOutAction.pending}
-                          onClick={() => void confirmSignOut()}
-                        >
-                          Sign out
-                        </Button>
-                      </DialogFooter>
-                    </DialogContent>
-                  </Dialog>
-                </div>
+                <GithubSignOutRow
+                  signOut={signOut}
+                  description="Sign out on this machine; connected graphs stop backing up."
+                />
               ) : null}
             </>
           ) : null}

--- a/apps/desktop/src/components/settings/github-sign-out-row.tsx
+++ b/apps/desktop/src/components/settings/github-sign-out-row.tsx
@@ -1,0 +1,93 @@
+import { useState, type ReactElement } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { useAsyncAction } from '@/hooks/use-async-action'
+
+interface GithubSignOutRowProps {
+  /** Remove the machine's GitHub credential (every connected graph stops syncing). */
+  signOut: () => Promise<void>
+  /** The one-line explanation shown beside the button, tuned to the caller. */
+  description: string
+}
+
+/**
+ * The machine-level "Sign out of GitHub" row: a destructive button behind a
+ * confirmation dialog, with a short explanation. GitHub sign-in is per machine,
+ * not per graph, so this is reused wherever the stored credential can be
+ * reached: beside a connected repo, and (with no connected graph) on its own,
+ * so the credential can still be cleared to switch to another account.
+ */
+export function GithubSignOutRow({ signOut, description }: GithubSignOutRowProps): ReactElement {
+  const [open, setOpen] = useState(false)
+  const action = useAsyncAction()
+
+  function setDialogOpen(next: boolean): void {
+    if (!next && action.pending) {
+      return
+    }
+    setOpen(next)
+  }
+
+  async function confirmSignOut(): Promise<void> {
+    await action.run(async () => {
+      await signOut()
+      setOpen(false)
+    })
+  }
+
+  return (
+    <div className="mt-2 flex flex-col gap-2 border-t border-border/70 pt-3 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <p className="text-xs font-medium text-text">GitHub account</p>
+        <p className="text-xs text-text-muted">{description}</p>
+      </div>
+      <Dialog open={open} onOpenChange={setDialogOpen}>
+        <DialogTrigger asChild>
+          <Button
+            variant="destructive"
+            size="sm"
+            title="Removes the GitHub token from this machine"
+            disabled={action.pending}
+          >
+            Sign out of GitHub…
+          </Button>
+        </DialogTrigger>
+        <DialogContent showCloseButton={!action.pending}>
+          <DialogHeader>
+            <DialogTitle>Sign out of GitHub?</DialogTitle>
+            <DialogDescription>
+              This removes the GitHub token from this machine. Every
+              GitHub-backed graph will stop backing up until you sign in again.
+            </DialogDescription>
+          </DialogHeader>
+          {action.error !== null ? (
+            <p className="text-xs text-red-700 dark:text-red-300">{action.error}</p>
+          ) : null}
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline" disabled={action.pending}>
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button
+              variant="destructive"
+              disabled={action.pending}
+              onClick={() => void confirmSignOut()}
+            >
+              Sign out
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}


### PR DESCRIPTION
Show the machine-level GitHub sign-out in Settings → Sync even when no graph is connected, so a signed-in user can clear the stored credential and switch to a different GitHub account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable GitHub sign-out control with confirmation, loading states, and error messaging.
  * Added GitHub sign-out options to backup settings when connected or disconnected from a backup graph.
  * Updated messaging to clarify GitHub connection and local disconnection actions.

* **Tests**
  * Added coverage for GitHub connection states, sign-out visibility, confirmation, and successful sign-out behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->