### PR TITLE
fix: keep note history when a graph's GitHub backup is signed out

### DIFF
--- a/apps/desktop/src/lib/backup-controller.test.tsx
+++ b/apps/desktop/src/lib/backup-controller.test.tsx
@@ -41,7 +41,11 @@ interface FakeOptions {
   failIndexApply?: boolean
   /** Hold the listen promise until `release()` (the teardown-race window). */
   gateListen?: boolean
+  /** Make the watcher subscription throw (the unusable-watcher path). */
+  failListen?: boolean
   failStatus?: boolean
+  /** Make the keychain read throw (locked keychain, stale ACL after re-signing). */
+  failSecretGet?: boolean
   /** Scripted `git_merge_remote` outcome (defaults to up-to-date). */
   mergeOutcome?: unknown
   /** Per-call merge outcomes for retry/convergence tests. */
@@ -90,6 +94,9 @@ function fakeBridge(options: FakeOptions = {}) {
           status.remoteUrl = typeof args['remoteUrl'] === 'string' ? args['remoteUrl'] : null
           return status
         case 'secret_get':
+          if (options.failSecretGet === true) {
+            throw { kind: 'io', message: 'keychain unavailable' }
+          }
           return auth
         case 'secret_delete':
           auth = null
@@ -131,6 +138,9 @@ function fakeBridge(options: FakeOptions = {}) {
       }
     },
     listen: async () => {
+      if (options.failListen === true) {
+        throw { kind: 'io', message: 'watcher unavailable' }
+      }
       if (options.gateListen === true) {
         await new Promise<void>((resolve) => {
           releaseListen = resolve
@@ -146,6 +156,10 @@ function fakeBridge(options: FakeOptions = {}) {
     releaseListen: () => releaseListen?.(),
     releaseIndexApply: () => releaseIndexApply?.(),
   }
+}
+
+function commitCount(calls: string[]): number {
+  return calls.filter((command) => command === 'git_commit_all').length
 }
 
 function trackStates(controller: ReturnType<typeof createBackupController>): BackupState[] {
@@ -176,8 +190,6 @@ describe('createBackupController', () => {
   })
 
   it('keeps committing on edits after the GitHub credential is gone', async () => {
-    const commitCount = (calls: string[]): number =>
-      calls.filter((command) => command === 'git_commit_all').length
     const { calls } = fakeBridge({ auth: null })
     const controller = createBackupController({ graph: GRAPH, indexGeneration: 1 })
     await controller.start()
@@ -256,15 +268,55 @@ describe('createBackupController', () => {
       expect(state.status.message).toContain('git remote set-url')
     }
 
-    // No *sync* engine: local history still commits, but focus events buy no
-    // network work — the remote stays unadopted until the user fixes the URL.
+    // No *sync* engine: the launch snapshot is local history's only commit,
+    // and focus buys nothing further, because the resume triggers belong to
+    // the sync engine that never started. The remote stays unadopted, and
+    // nothing on this path may touch the network.
+    await vi.waitFor(() => {
+      expect(commitCount(calls)).toBe(1)
+    })
     window.dispatchEvent(new Event('focus'))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(commitCount(calls)).toBe(1)
+    expect(calls).not.toContain('git_fetch')
+    expect(calls).not.toContain('git_push')
+    controller.dispose()
+  })
+
+  it('keeps the SSH suggestion when local history cannot start', async () => {
+    // Local history is best effort: a watcher that won't come up must not cost
+    // the user the one instruction they have for fixing the remote.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    fakeBridge({ remoteUrl: 'https://gitlab.com/alex/notes.git', failListen: true })
+    const controller = createBackupController({ graph: GRAPH, indexGeneration: 1 })
+    await controller.start()
+
+    expect(controller.getState()).toMatchObject({
+      phase: 'connected',
+      repo: null,
+      status: { state: 'error', errorKind: 'rejected' },
+    })
+    controller.dispose()
+    errorSpy.mockRestore()
+  })
+
+  it('keeps local history when the keychain itself cannot be read', async () => {
+    // A keychain read that throws is the same user-visible situation as a
+    // missing credential, so it must not fail the whole start into the
+    // engine-less catch and take the graph's history with it.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { calls } = fakeBridge({ failSecretGet: true })
+    const controller = createBackupController({ graph: GRAPH, indexGeneration: 1 })
+    await controller.start()
+
+    expect(controller.getState()).toEqual({ phase: 'disconnected' })
     await vi.waitFor(() => {
       expect(calls).toContain('git_commit_all')
     })
     expect(calls).not.toContain('git_fetch')
     expect(calls).not.toContain('git_push')
     controller.dispose()
+    errorSpy.mockRestore()
   })
 
   it('runs the launch pull when fully connected — and skips the idle push', async () => {
@@ -317,8 +369,6 @@ describe('createBackupController', () => {
 
   it('local history keeps committing on edits — still with no network', async () => {
     // A repo without a remote (e.g. after disconnectGraph) needs no git_setup.
-    const commitCount = (calls: string[]): number =>
-      calls.filter((command) => command === 'git_commit_all').length
     const { calls } = fakeBridge({ auth: null, remoteUrl: null })
     const controller = createBackupController({ graph: GRAPH, indexGeneration: 1 })
     await controller.start()
@@ -573,9 +623,6 @@ describe('createBackupController', () => {
   })
 
   it('an edit backs up after 30s idle on desktop, 10s on mobile', async () => {
-    const commitCount = (calls: string[]): number =>
-      calls.filter((command) => command === 'git_commit_all').length
-
     async function debouncedCommitDelay(mobile: boolean): Promise<number> {
       setPlatformSurface({ mobileApp: mobile })
       const { calls } = fakeBridge()

--- a/apps/desktop/src/lib/backup-controller.test.tsx
+++ b/apps/desktop/src/lib/backup-controller.test.tsx
@@ -155,13 +155,45 @@ function trackStates(controller: ReturnType<typeof createBackupController>): Bac
 }
 
 describe('createBackupController', () => {
-  it('reports disconnected when no credential is stored', async () => {
+  it('reports disconnected when no credential is stored — but keeps local history', async () => {
+    // Signing out of GitHub (or a lapsed credential) stops the *backup*, not
+    // the note history: the graph already has a repo, so the commit-only loop
+    // takes over. Losing history here is a silent downgrade the user never
+    // asked for.
     const { calls } = fakeBridge({ auth: null })
     const controller = createBackupController({ graph: GRAPH, indexGeneration: 1 })
     await controller.start()
 
     expect(controller.getState()).toEqual({ phase: 'disconnected' })
-    expect(calls).not.toContain('git_commit_all')
+    await vi.waitFor(() => {
+      expect(calls).toContain('git_commit_all')
+    })
+    // The repo is already initialized, and nothing may touch the network.
+    expect(calls).not.toContain('git_setup')
+    expect(calls).not.toContain('git_fetch')
+    expect(calls).not.toContain('git_push')
+    controller.dispose()
+  })
+
+  it('keeps committing on edits after the GitHub credential is gone', async () => {
+    const commitCount = (calls: string[]): number =>
+      calls.filter((command) => command === 'git_commit_all').length
+    const { calls } = fakeBridge({ auth: null })
+    const controller = createBackupController({ graph: GRAPH, indexGeneration: 1 })
+    await controller.start()
+    await vi.waitFor(() => {
+      expect(commitCount(calls)).toBe(1)
+    })
+
+    vi.useFakeTimers()
+    try {
+      emitFileChanges([{ path: 'notes/edited.md', kind: 'upsert', modifiedMs: 1 }])
+      await vi.advanceTimersByTimeAsync(30_000)
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(commitCount(calls)).toBe(2)
+    expect(calls).not.toContain('git_push')
     controller.dispose()
   })
 
@@ -224,11 +256,14 @@ describe('createBackupController', () => {
       expect(state.status.message).toContain('git remote set-url')
     }
 
-    // No engine: no git work now, and focus events stay inert.
+    // No *sync* engine: local history still commits, but focus events buy no
+    // network work — the remote stays unadopted until the user fixes the URL.
     window.dispatchEvent(new Event('focus'))
-    await new Promise((resolve) => setTimeout(resolve, 0))
-    expect(calls).not.toContain('git_commit_all')
+    await vi.waitFor(() => {
+      expect(calls).toContain('git_commit_all')
+    })
     expect(calls).not.toContain('git_fetch')
+    expect(calls).not.toContain('git_push')
     controller.dispose()
   })
 

--- a/apps/desktop/src/lib/backup-controller.ts
+++ b/apps/desktop/src/lib/backup-controller.ts
@@ -238,11 +238,16 @@ export function createBackupController(options: BackupControllerOptions): Backup
   }
 
   /**
-   * Local history (desktop only): a graph with no remote still gets a
-   * repository and the debounced commit loop, so every edit lands in Git
-   * history and stays revertable — nothing is ever fetched or pushed, and
-   * the UI stays `disconnected`. Connecting a backup later adopts this
-   * repository, history included.
+   * Local history (desktop only): a graph the sync engine can't run for still
+   * gets a repository and the debounced commit loop, so every edit lands in
+   * Git history and stays revertable — nothing is ever fetched or pushed.
+   * Connecting a backup later adopts this repository, history included.
+   *
+   * This covers *every* desktop path that ends without a syncing engine, not
+   * just "no remote": a graph whose `origin` is a GitHub repo the machine is
+   * no longer signed in to, and one whose remote we refuse to adopt, both
+   * keep committing locally. Otherwise a signed-out remote silently downgrades
+   * the graph to no history at all — worse than never having connected one.
    */
   async function startLocalHistory(initialized: boolean): Promise<void> {
     if (isMobileSurface()) {
@@ -292,6 +297,7 @@ export function createBackupController(options: BackupControllerOptions): Backup
         // Generic remotes adopt without it — their credentials live with the
         // user's own git tooling (ssh agent), not in our keychain.
         setState({ phase: 'disconnected' })
+        await startLocalHistory(status.initialized)
         return
       }
       if (repo === null && /^https?:\/\//i.test(remoteUrl)) {
@@ -311,6 +317,7 @@ export function createBackupController(options: BackupControllerOptions): Backup
               'HTTPS isn’t supported for this host yet — switch the remote to its SSH form: git remote set-url origin git@<host>:<owner>/<repo>.git',
           },
         })
+        await startLocalHistory(status.initialized)
         return
       }
       const next = createSyncEngine({

--- a/apps/desktop/src/lib/backup-controller.ts
+++ b/apps/desktop/src/lib/backup-controller.ts
@@ -243,35 +243,52 @@ export function createBackupController(options: BackupControllerOptions): Backup
    * Git history and stays revertable — nothing is ever fetched or pushed.
    * Connecting a backup later adopts this repository, history included.
    *
-   * This covers *every* desktop path that ends without a syncing engine, not
+   * This runs on the desktop paths that end without a syncing engine, not
    * just "no remote": a graph whose `origin` is a GitHub repo the machine is
    * no longer signed in to, and one whose remote we refuse to adopt, both
    * keep committing locally. Otherwise a signed-out remote silently downgrades
    * the graph to no history at all — worse than never having connected one.
+   * The one no-engine path it deliberately skips is a failed `gitStatus`,
+   * which leaves the repo state unknown: `gitSetup` there could initialize a
+   * repository on a broken graph. A failed *credential* read is not that case,
+   * so `start()` degrades it to the signed-out path above instead.
+   *
+   * Starting it is best effort. It must never take down the state the caller
+   * just published: the SSH-only `rejected` message is the user's only
+   * instruction for fixing that remote, and losing it to a watcher that
+   * happened not to come up would be the worse trade.
    */
   async function startLocalHistory(initialized: boolean): Promise<void> {
     if (isMobileSurface()) {
       return
     }
-    if (!initialized) {
-      await gitSetup(null, null, generation)
+    try {
+      if (!initialized) {
+        await gitSetup(null, null, generation)
+      }
+      const next = createSyncEngine({
+        generation,
+        localOnly: true,
+        getToken: async () => null,
+        onStatus: (engineStatus) => {
+          // No UI surfaces local history, so a failing commit loop (disk full,
+          // corrupted repo) must at least leave a trace for diagnosis.
+          if (engineStatus.state === 'error') {
+            console.error('local history commit failed:', engineStatus.message)
+          }
+        },
+      })
+      if (!(await adoptEngine(next))) {
+        return
+      }
+      void next.syncNow() // first snapshot: commit whatever is already pending
+    } catch (error) {
+      // `adoptEngine` assigns the engine before its first await, so a
+      // half-built lifecycle takes the same teardown as every other failure.
+      // No zombie engine keeps timers alive behind the caller's state.
+      teardown()
+      console.error('local history failed to start:', errorMessage(error))
     }
-    const next = createSyncEngine({
-      generation,
-      localOnly: true,
-      getToken: async () => null,
-      onStatus: (engineStatus) => {
-        // No UI surfaces local history, so a failing commit loop (disk full,
-        // corrupted repo) must at least leave a trace for diagnosis.
-        if (engineStatus.state === 'error') {
-          console.error('local history commit failed:', engineStatus.message)
-        }
-      },
-    })
-    if (!(await adoptEngine(next))) {
-      return
-    }
-    void next.syncNow() // first snapshot: commit whatever is already pending
   }
 
   async function start(): Promise<void> {
@@ -281,7 +298,17 @@ export function createBackupController(options: BackupControllerOptions): Backup
     }
     setState({ phase: 'loading' })
     try {
-      const [status, auth] = await Promise.all([gitStatus(generation), loadGithubAuth()])
+      const [status, auth] = await Promise.all([
+        gitStatus(generation),
+        // A keychain the app can't read is indistinguishable from a signed-out
+        // one as far as backup is concerned, and must not cost the graph its
+        // history: degrade to the signed-out path below rather than failing
+        // the whole start into the engine-less catch.
+        loadGithubAuth().catch((error: unknown) => {
+          console.error('reading the GitHub credential failed:', errorMessage(error))
+          return null
+        }),
+      ])
       if (disposed) {
         return
       }


### PR DESCRIPTION
## Problem

Reported by a beta user (7beta16): note history stopped being recorded. Their graph's `.git` was frozen at the last day they were signed in — HEAD weeks stale, `daily/`, `notes/`, `assets/` and `audio-memos/` all piling up as untracked. A manual `git add . && git commit` to clear the working tree changed nothing; the next edit still wasn't committed.

The cause is in `createBackupController.start()`. It only started the commit-only local-history engine for graphs with **no remote at all**:

```ts
if (!status.initialized || status.remoteUrl === null) {
  setState({ phase: 'disconnected' })
  await startLocalHistory(status.initialized)   // ← commit loop runs
  return
}
const repo = parseGithubRemote(remoteUrl)
if (repo !== null && auth === null) {
  setState({ phase: 'disconnected' })
  return                                        // ← nothing runs at all
}
```

Their graph has an `origin` pointing at a GitHub repo, but the machine is no longer signed in, so `auth === null` and it took the second return. No engine means no `subscribeFileChanges` subscription (so `noteChanged()` never fires), no launch `syncNow()`, and no `setBackupFlusher` — so even the quit-time commit is dead. The clean working tree after their manual commit is what rules out repo state as the cause and pins it on the engine never starting.

The old test asserted this as intended (`expect(calls).not.toContain('git_commit_all')`), so it wasn't an accident — it's a gap between "not backing up" and "no history at all". The second is much worse, and the user has no way to see it: the UI reads `disconnected` either way.

## Changes

`startLocalHistory` now runs on **every** desktop path that ends without a syncing engine, not just the no-remote one:

- **GitHub remote, no stored credential** — signed out, or the credential lapsed.
- **Generic HTTPS remote we refuse to adopt** — the Plan 16 SSH-only guard. The `rejected` error state still stands (that guard's whole point is failing at adoption rather than at first push); the graph just keeps its history while the user fixes the URL.

Both stay strictly local: `localOnly: true`, no token resolved, no fetch, no push. The UI still reports `disconnected` for the signed-out case, since there genuinely is no backup. Connecting a backup later adopts the repository with its history intact, exactly as it already does for a never-connected graph.

## Testing

`apps/desktop/src/lib/backup-controller.test.tsx` — 27/27 pass (browser project). Verified the three new/updated tests **fail** against the unpatched controller, so they're not vacuous:

- `reports disconnected when no credential is stored — but keeps local history` (rewritten; previously asserted the bug)
- `keeps committing on edits after the GitHub credential is gone` (new — covers the debounce path, not just the launch snapshot)
- `refuses a generic HTTPS remote at adoption with the SSH suggestion` (updated: local commits yes, network no)

`pnpm typecheck` and `eslint` clean on `apps/desktop`. No Rust touched.

## Notes / limits

- **Not fixed here:** the `catch` block at the end of `start()` also lands on `disconnected` with no engine. Left alone deliberately — if `gitStatus` itself threw, the repo state is unknown and calling `gitSetup` there could initialize a repo on a broken graph. Worth a separate look.
- **No retroactive history.** Affected users' existing untracked backlog lands as one large "Update N notes" snapshot on first launch after upgrading; history is granular from there.
- Mobile is unchanged — `startLocalHistory` still returns early on `isMobileSurface()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes backup startup paths for graphs with remotes but no working sync; scope is limited to enabling existing local-only history and is covered by updated controller tests.
> 
> **Overview**
> **Fixes silent loss of note history** when a graph still has a remote but the app cannot run the sync engine—most notably a **GitHub `origin` with no stored credential** (signed out or lapsed), and the existing **rejected generic HTTPS remote** path.
> 
> `createBackupController.start()` now calls **`startLocalHistory`** on those exit paths (same **local-only** engine as no-remote graphs: debounced `git_commit_all`, quit flusher, **no fetch/push**). UI stays **`disconnected`** for signed-out GitHub; HTTPS rejection still shows the SSH **`rejected`** error, but edits keep landing in git history instead of freezing HEAD.
> 
> Tests were flipped from asserting **no** commits to expecting **local commits only**, including a debounced second commit after file changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fd6951f60ca9a810bb0f13172188d148ddfa05a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Local note history now continues saving when GitHub authentication fails to load or credentials are missing.
  * When GitHub is unavailable, the controller cleanly reports a disconnected/error state while still initializing and committing local history.
  * Remote sync actions remain inactive after credential loss or rejected remote adoption, including during window focus.
  * Local history continues to commit on subsequent edits even if the connection state changes.
* **Tests**
  * Expanded coverage for additional failure modes and tightened expectations around “no credentials / no sync engine” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->