### PR TITLE
fix: reduce mobile week-row note dot to 50% opacity

### DIFF
--- a/apps/desktop/src/mobile/week-row.tsx
+++ b/apps/desktop/src/mobile/week-row.tsx
@@ -94,7 +94,7 @@ function WeekRowComponent({
               className={cn(
                 'size-1 rounded-full',
                 hasDailyNote
-                  ? 'bg-text-muted'
+                  ? 'bg-text-muted opacity-50'
                   : !selected && isToday
                     ? 'bg-primary'
                     : 'bg-transparent',


### PR DESCRIPTION
## Summary
- Sets the daily-note marker dot in the mobile week strip (`week-row.tsx`) to 50% opacity, so it reads as a softer marker relative to the today indicator dot.

## Test plan
- [ ] Visual check in the mobile week strip with a mix of days that have/don't have daily notes and today's dot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic CSS-only change in mobile week-row UI with no logic or data impact.
> 
> **Overview**
> **Visual tweak** for the mobile calendar week strip: days with a daily note now show their marker dot at **50% opacity** (`opacity-50` on top of `bg-text-muted`), so the note indicator reads softer and stays visually distinct from the **today** primary dot when today is not selected.
> 
> No behavior, accessibility labels, or test IDs change—only the note-dot styling when `hasDailyNote` is true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 553e4169f3e67048e8fbad189170059a43bd5638. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced the visual prominence of daily-note indicator dots for a subtler appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->