### PR TITLE
chore: update AI sdk to v7

### DIFF
--- a/apps/desktop/src/components/chat/chat-screen.test.tsx
+++ b/apps/desktop/src/components/chat/chat-screen.test.tsx
@@ -607,7 +607,7 @@ describe('ChatScreen', () => {
     expect(streamChat.mock.lastCall?.[0]?.messages.at(-1)).toEqual({
       role: 'user',
       content: [
-        { type: 'image', image: 'data:image/png;base64,iVBORw==', mediaType: 'image/png' },
+        { type: 'file', data: 'data:image/png;base64,iVBORw==', mediaType: 'image/png' },
       ],
     })
     // The queue cleared; the photo now lives in the transcript bubble.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,20 +13,20 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.96",
-    "@ai-sdk/google": "^3.0.84",
-    "@ai-sdk/openai": "^3.0.84",
+    "@ai-sdk/anthropic": "^4.0.20",
+    "@ai-sdk/google": "^4.0.24",
+    "@ai-sdk/openai": "^4.0.20",
     "@meowdown/markdown": "^0.58.3",
     "@reflect/db": "workspace:*",
     "@reflect/utils": "workspace:*",
-    "ai": "^6.0.211",
+    "ai": "^7.0.37",
     "kysely": "^0.28.17",
     "ulidx": "^2.4.1",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@ai-sdk/provider": "^3.0.11",
+    "@ai-sdk/provider": "^4.0.3",
     "jsdom": "^29.1.1",
     "sqlite-vec": "^0.1.9",
     "typescript": "~6.0.3",

--- a/packages/core/src/ai/audio-memo-format.ts
+++ b/packages/core/src/ai/audio-memo-format.ts
@@ -99,7 +99,7 @@ export async function formatAudioMemoTranscript(
         request.fetchFn ?? fetch,
       ),
       output: Output.object({ schema: formattedAudioMemoSchema }),
-      system: FORMAT_SYSTEM_PROMPT,
+      instructions: FORMAT_SYSTEM_PROMPT,
       prompt: `Transcript JSON string:\n${JSON.stringify(request.transcript)}`,
       abortSignal: AbortSignal.timeout(FORMAT_TIMEOUT_MS),
       maxRetries: 0,

--- a/packages/core/src/ai/chat/context-window.test.ts
+++ b/packages/core/src/ai/chat/context-window.test.ts
@@ -50,7 +50,7 @@ describe('estimateTokens', () => {
     const photo: ModelMessage = {
       role: 'user',
       content: [
-        { type: 'image', image: `data:image/png;base64,${'a'.repeat(400_000)}`, mediaType: 'image/png' },
+        { type: 'file', data: `data:image/png;base64,${'a'.repeat(400_000)}`, mediaType: 'image/png' },
       ],
     }
     expect(estimateTokens(photo)).toBe(1_604)

--- a/packages/core/src/ai/chat/context-window.ts
+++ b/packages/core/src/ai/chat/context-window.ts
@@ -21,7 +21,7 @@ const CHARS_PER_TOKEN = 4
 
 /**
  * Flat per-image estimate. Providers downscale and bill far below the data
- * URL's size, so estimating from `image.length` would wildly overshoot
+ * URL's size, so estimating from `data.length` would wildly overshoot
  * (a 1 MB photo is ~340k chars of base64 but ~1.6k tokens).
  */
 const IMAGE_TOKENS = 1_600
@@ -78,8 +78,10 @@ function partTokens(part: ContentPart): number {
     case 'text':
     case 'reasoning':
       return textTokens(part.text)
-    case 'image':
-      return IMAGE_TOKENS
+    case 'file':
+      // Attachments arrive as image file parts; anything else falls through
+      // to its JSON size like the other parts.
+      return part.mediaType.startsWith('image') ? IMAGE_TOKENS : textTokens(JSON.stringify(part))
     default:
       // Tool calls, tool results, files: the JSON encoding is what travels.
       return textTokens(JSON.stringify(part))

--- a/packages/core/src/ai/chat/stream-chat.test.ts
+++ b/packages/core/src/ai/chat/stream-chat.test.ts
@@ -297,10 +297,10 @@ describe('streamChatTurn', () => {
 
   it('keeps every completed step when cut short after multiple tool rounds', async () => {
     // Pins the SDK semantic the engine relies on: each onStepFinish's
-    // `response.messages` is *cumulative* across steps, so assigning (not
-    // appending) yields the full paired history. If an `ai` upgrade ever
-    // makes it per-step, this starts failing instead of silently dropping
-    // earlier rounds.
+    // `response.messages` holds *only that step's* messages, so appending
+    // (not assigning) yields the full paired history. If an `ai` upgrade ever
+    // makes it cumulative again, this starts failing instead of silently
+    // duplicating earlier rounds.
     const model = new MockLanguageModelV3({
       doStream: sequence([
         toolCallTurn('atlas', 'call-1'),

--- a/packages/core/src/ai/chat/stream-chat.test.ts
+++ b/packages/core/src/ai/chat/stream-chat.test.ts
@@ -296,7 +296,7 @@ describe('streamChatTurn', () => {
   })
 
   it('keeps every completed step when cut short after multiple tool rounds', async () => {
-    // Pins the SDK semantic the engine relies on: each onStepFinish's
+    // Pins the SDK semantic the engine relies on: each onStepEnd's
     // `response.messages` holds *only that step's* messages, so appending
     // (not assigning) yields the full paired history. If an `ai` upgrade ever
     // makes it cumulative again, this starts failing instead of silently

--- a/packages/core/src/ai/chat/stream-chat.ts
+++ b/packages/core/src/ai/chat/stream-chat.ts
@@ -1,4 +1,4 @@
-import { stepCountIs, streamText, type LanguageModel, type ModelMessage } from 'ai'
+import { isStepCount, streamText, type LanguageModel, type ModelMessage } from 'ai'
 import { errorMessage } from '../../errors'
 import { languageModel } from '../language-model'
 import { modelContextWindow } from '../provider-catalog'
@@ -147,7 +147,7 @@ export async function* streamChatTurn(
   try {
     const result = streamText({
       model,
-      system: chatSystemPrompt({
+      instructions: chatSystemPrompt({
         today: options.today,
         context: options.context,
         semanticSearchEnabled: options.semanticSearchEnabled,
@@ -155,7 +155,7 @@ export async function* streamChatTurn(
       }),
       messages: options.messages,
       tools,
-      stopWhen: stepCountIs(MAX_STEPS),
+      stopWhen: isStepCount(MAX_STEPS),
       // On the final permitted step, disable tools so the model must answer
       // from what it has already gathered. Without this a turn still calling
       // tools when the ceiling fires ends on a tool result with no reply — the
@@ -166,19 +166,19 @@ export async function* streamChatTurn(
       ...(options.signal !== undefined ? { abortSignal: options.signal } : {}),
       // `step.response.messages` holds only the messages that step created,
       // so the running history is accumulated here rather than assigned.
-      onStepFinish: (step) => {
+      onStepEnd: (step) => {
         stepMessages = [...stepMessages, ...step.response.messages]
       },
     })
 
-    for await (const part of result.fullStream) {
+    for await (const part of result.stream) {
       switch (part.type) {
         case 'text-delta':
           pendingText += part.text
           yield { type: 'text-delta', text: part.text }
           break
         case 'finish-step':
-          // onStepFinish has already folded this step's text into
+          // onStepEnd has already folded this step's text into
           // stepMessages; only unfinished-step text may count as partial.
           pendingText = ''
           break

--- a/packages/core/src/ai/chat/stream-chat.ts
+++ b/packages/core/src/ai/chat/stream-chat.ts
@@ -164,8 +164,10 @@ export async function* streamChatTurn(
       prepareStep: ({ stepNumber }) =>
         stepNumber >= MAX_STEPS - 1 ? { toolChoice: 'none' } : {},
       ...(options.signal !== undefined ? { abortSignal: options.signal } : {}),
+      // `step.response.messages` holds only the messages that step created,
+      // so the running history is accumulated here rather than assigned.
       onStepFinish: (step) => {
-        stepMessages = [...step.response.messages]
+        stepMessages = [...stepMessages, ...step.response.messages]
       },
     })
 
@@ -208,8 +210,7 @@ export async function* streamChatTurn(
       }
     }
 
-    const response = await result.response
-    yield { type: 'complete', messages: response.messages }
+    yield { type: 'complete', messages: await result.responseMessages }
   } catch (cause) {
     // Belt and braces: most failures surface as `error` parts above, but a
     // synchronous throw (bad config, aborted before first byte) lands here.

--- a/packages/core/src/ai/chat/tools.test.ts
+++ b/packages/core/src/ai/chat/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { ToolCallOptions } from 'ai'
+import type { ToolExecutionOptions } from 'ai'
 import type { RetrievalHit, RetrieveOptions } from '../../embeddings/retrieve'
 import type { DailyNoteRow, DailyNotesRange } from '../../indexing/queries'
 import type { RecentNoteRow, RecentNotesOptions } from '../../indexing/note-list'
@@ -26,7 +26,11 @@ import {
   type SearchNotesOutput,
 } from './tools'
 
-const CALL: ToolCallOptions = { toolCallId: 'call-1', messages: [] }
+const CALL: ToolExecutionOptions<Record<string, unknown>> = {
+  toolCallId: 'call-1',
+  messages: [],
+  context: {},
+}
 
 // Sentinels that cannot collide with prompt copy or fixture prose, so the
 // not-in-payload assertions below can never pass vacuously.

--- a/packages/core/src/ai/chat/transcript.test.ts
+++ b/packages/core/src/ai/chat/transcript.test.ts
@@ -230,7 +230,7 @@ describe('buildHistory', () => {
     expect(buildHistory(turns)).toEqual([
       {
         role: 'user',
-        content: [{ type: 'image', image: photo.dataUrl, mediaType: 'image/png' }],
+        content: [{ type: 'file', data: photo.dataUrl, mediaType: 'image/png' }],
       },
       { role: 'assistant', content: 'A cat.' },
     ])
@@ -253,7 +253,7 @@ describe('userMessage', () => {
     expect(userMessage('what is this?', [photo])).toEqual({
       role: 'user',
       content: [
-        { type: 'image', image: photo.dataUrl, mediaType: 'image/png' },
+        { type: 'file', data: photo.dataUrl, mediaType: 'image/png' },
         { type: 'text', text: 'what is this?' },
       ],
     })
@@ -262,7 +262,7 @@ describe('userMessage', () => {
   it('omits the text part for a photo-only message', () => {
     expect(userMessage('', [photo])).toEqual({
       role: 'user',
-      content: [{ type: 'image', image: photo.dataUrl, mediaType: 'image/png' }],
+      content: [{ type: 'file', data: photo.dataUrl, mediaType: 'image/png' }],
     })
   })
 })

--- a/packages/core/src/ai/chat/transcript.ts
+++ b/packages/core/src/ai/chat/transcript.ts
@@ -135,7 +135,7 @@ function settleTools(
 
 /**
  * The model-facing user message for one turn: plain text when nothing is
- * attached, otherwise image parts (the data URL is the payload) followed by
+ * attached, otherwise image file parts (the data URL is the payload) followed by
  * the text — which may be absent entirely for a photo-only message.
  */
 export function userMessage(
@@ -149,8 +149,8 @@ export function userMessage(
     role: 'user',
     content: [
       ...attachments.map((attachment) => ({
-        type: 'image' as const,
-        image: attachment.dataUrl,
+        type: 'file' as const,
+        data: attachment.dataUrl,
         mediaType: attachment.mediaType,
       })),
       ...(text === '' ? [] : [{ type: 'text' as const, text }]),

--- a/packages/core/src/ai/describe-asset.ts
+++ b/packages/core/src/ai/describe-asset.ts
@@ -26,7 +26,7 @@ export interface DescribeAssetRequest {
   apiKey: string
   /** Host transport (the Tauri HTTP plugin's fetch; tests pass a stub). */
   fetchFn?: typeof fetch | undefined
-  /** How `data` is carried: image input, file input, or SVG source text. */
+  /** How `data` is carried: image or PDF file input, or SVG source text. */
   kind: AssetKind
   /** IANA media type (e.g. `image/png`, `application/pdf`, `image/svg+xml`). */
   mediaType: string
@@ -108,7 +108,7 @@ function describePrompt(kind: AssetKind, filename: string): string {
 export async function describeAsset(request: DescribeAssetRequest): Promise<string> {
   const content: UserContent = [{ type: 'text', text: describePrompt(request.kind, request.filename) }]
   if (request.kind === 'image') {
-    content.push({ type: 'image', image: request.data, mediaType: request.mediaType })
+    content.push({ type: 'file', data: request.data, mediaType: request.mediaType })
   } else if (request.kind === 'pdf') {
     content.push({
       type: 'file',

--- a/packages/core/src/ai/describe-page.ts
+++ b/packages/core/src/ai/describe-page.ts
@@ -155,8 +155,8 @@ export async function describePage(request: DescribePageRequest): Promise<PageEn
   const content: UserContent = [{ type: 'text', text: describePrompt(request) }]
   if (request.screenshotBase64) {
     content.push({
-      type: 'image',
-      image: request.screenshotBase64,
+      type: 'file',
+      data: request.screenshotBase64,
       mediaType: 'image/jpeg',
     })
   }

--- a/packages/core/src/ai/language-model.ts
+++ b/packages/core/src/ai/language-model.ts
@@ -1,5 +1,5 @@
 import { createAnthropic } from '@ai-sdk/anthropic'
-import { createGoogleGenerativeAI } from '@ai-sdk/google'
+import { createGoogle } from '@ai-sdk/google'
 import { createOpenAI } from '@ai-sdk/openai'
 import type { LanguageModel } from 'ai'
 import type { AiProviderConfig } from '../settings/schema'
@@ -27,7 +27,7 @@ export function languageModel(
         headers: anthropicDirectBrowserAccessHeaders(),
       })(config.model)
     case 'google':
-      return createGoogleGenerativeAI({ apiKey, fetch: fetchFn })(config.model)
+      return createGoogle({ apiKey, fetch: fetchFn })(config.model)
     case 'openrouter':
       return createOpenAI({
         apiKey,

--- a/packages/core/src/ai/transform-selection.ts
+++ b/packages/core/src/ai/transform-selection.ts
@@ -85,12 +85,12 @@ export async function* streamTransformTurn(
   try {
     const result = streamText({
       model,
-      system: TRANSFORM_SYSTEM_PROMPT,
+      instructions: TRANSFORM_SYSTEM_PROMPT,
       prompt: options.prompt,
       ...(options.signal !== undefined ? { abortSignal: options.signal } : {}),
     })
 
-    for await (const part of result.fullStream) {
+    for await (const part of result.stream) {
       switch (part.type) {
         case 'text-delta':
           text += part.text

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,14 +248,14 @@ importers:
   packages/core:
     dependencies:
       '@ai-sdk/anthropic':
-        specifier: ^3.0.96
-        version: 3.0.100(zod@4.4.3)
+        specifier: ^4.0.20
+        version: 4.0.20(zod@4.4.3)
       '@ai-sdk/google':
-        specifier: ^3.0.84
-        version: 3.0.99(zod@4.4.3)
+        specifier: ^4.0.24
+        version: 4.0.24(zod@4.4.3)
       '@ai-sdk/openai':
-        specifier: ^3.0.84
-        version: 3.0.87(zod@4.4.3)
+        specifier: ^4.0.20
+        version: 4.0.20(zod@4.4.3)
       '@meowdown/markdown':
         specifier: ^0.58.3
         version: 0.58.3
@@ -266,8 +266,8 @@ importers:
         specifier: workspace:*
         version: link:../utils
       ai:
-        specifier: ^6.0.211
-        version: 6.0.234(zod@4.4.3)
+        specifier: ^7.0.37
+        version: 7.0.37(zod@4.4.3)
       kysely:
         specifier: ^0.28.17
         version: 0.28.17
@@ -282,8 +282,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@ai-sdk/provider':
-        specifier: ^3.0.11
-        version: 3.0.14
+        specifier: ^4.0.3
+        version: 4.0.3
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -336,39 +336,39 @@ packages:
   '@1natsu/wait-element@4.2.0':
     resolution: {integrity: sha512-Om0Q+WE9mNrpY4AwMTvkFiYHv8VM7TML3PvOqXy+w6kAjLjKhGYHYX+305+a6J8RVpds9s7IF2Z5aOPYwULFNw==}
 
-  '@ai-sdk/anthropic@3.0.100':
-    resolution: {integrity: sha512-/o2a3zVPdwRGSHYgssZ6Xec0vdhlgzMpm/T6JmifApVc5j6JmMChtV+sZ3omUqCFmHxfPzHvvNumplDFh3zrmw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/anthropic@4.0.20':
+    resolution: {integrity: sha512-5QdZt6AkWIKIKuwRSjAQIBhN0JSSvthaIcAJKTHP7HPCvWMcNJFF6rz0uKfUlpI3h7nVbY+1Cy5dNl5zjzJ6qA==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.156':
-    resolution: {integrity: sha512-OeOfIlbp8DwlqBHDe3IbfAF6zRdKQg041UYaTz5gRFUwthZQXLCH5HK8JE0XCfhQFg92cGsQucOuXld+VFOhXQ==}
-    engines: {node: '>=18'}
+  '@ai-sdk/gateway@4.0.28':
+    resolution: {integrity: sha512-ee9TsNO3mkgHDWmTmJ8Fvltr6PFh52zhrV2+FaKJY3F3iu7kWZi5tCRJCR1HVhhlpj6lHniUb28nLQdPHkA/1Q==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/google@3.0.99':
-    resolution: {integrity: sha512-mZnXQRMIlQKCUa3gPD+MaFmONzXppeIzBP+XcPhEkwcw2bQZucZsHMXW8nGqaJ/tOIbZdYG8UmtnIRqrrxpzOA==}
-    engines: {node: '>=18'}
+  '@ai-sdk/google@4.0.24':
+    resolution: {integrity: sha512-W+kTGb/RRe2SEYwbKcKYM3N2EQryS2Iqjgou6wPsyP/2BwBU7Q23CF6/YWE8k7xtseDLcSY59jsR2MDpY4azRg==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@3.0.87':
-    resolution: {integrity: sha512-fg0Lyr99bX2ApS0+cgKlndOK3l53nNF6JtlQcPsMVp0/tgzAMZSXQ+H5GAy0pdJjevmmwMY5rQaq3L6wE+cSvA==}
-    engines: {node: '>=18'}
+  '@ai-sdk/openai@4.0.20':
+    resolution: {integrity: sha512-/Hu+btLIO2zuYqCp//vBBAGdM/BeN4gds+NWrlv7Y9WrcTXwnEEwh6P3QZIWh2Tt1I1lswuDIpAJ4t/c/rws3Q==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.40':
-    resolution: {integrity: sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider-utils@5.0.12':
+    resolution: {integrity: sha512-bbhlOgHeYwrIGheLkM6fhS8hVger8uFPmcOLg+kxc9EFh7y30XYorWhthlYAgpadO3SJhFZrIcEknN7qEqEVvA==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@3.0.14':
-    resolution: {integrity: sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider@4.0.3':
+    resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
+    engines: {node: '>=22'}
 
   '@aklinker1/rollup-plugin-visualizer@5.12.0':
     resolution: {integrity: sha512-X24LvEGw6UFmy0lpGJDmXsMyBD58XmX1bbwsaMLhNoM+UMQfQ3b2RtC+nz4b/NoRK5r6QJSKJHBNVeUdwqybaQ==}
@@ -2672,6 +2672,9 @@ packages:
   '@webext-core/match-patterns@1.1.0':
     resolution: {integrity: sha512-vebVVbcOyva4jyvljIzRJwjFi/OKMLr96LIIxiPeXfA38gE4Z3+H6Y9DwRmn7pWErJGNNHU6XOhOb5ZwicGs7Q==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   '@wxt-dev/browser@0.1.43':
     resolution: {integrity: sha512-RMB0zgfe7uuiTp18s9taLeKXoOCLBV418797dnEggiMWmM1JDJekiLtlvrNc6QeZg+amDBy2/KKYuQB2kh/K9A==}
 
@@ -2728,9 +2731,9 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
-  ai@6.0.234:
-    resolution: {integrity: sha512-6/7Go3Z6j/rpMgTS8wWm38/pcDfvhSmQvNLvElwYezmjYKr5hNDMa4bGlnBtQcYNzbc1dLpWdbYNLJaas3AFPw==}
-    engines: {node: '>=18'}
+  ai@7.0.37:
+    resolution: {integrity: sha512-stF+SEQJgKY3Qfe3FwNzqUrehHviOp2l7LemoI8YMOa0Zk5PxKsRNgUk3cHXz0RAue9RRyCAis2fz6LSCP6EKw==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -6236,39 +6239,40 @@ snapshots:
       defu: 6.1.7
       many-keys-map: 3.0.3
 
-  '@ai-sdk/anthropic@3.0.100(zod@4.4.3)':
+  '@ai-sdk/anthropic@4.0.20(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/gateway@3.0.156(zod@4.4.3)':
+  '@ai-sdk/gateway@4.0.28(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/google@3.0.99(zod@4.4.3)':
+  '@ai-sdk/google@4.0.24(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/openai@3.0.87(zod@4.4.3)':
+  '@ai-sdk/openai@4.0.20(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.40(zod@4.4.3)':
+  '@ai-sdk/provider-utils@5.0.12(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider': 4.0.3
       '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
-  '@ai-sdk/provider@3.0.14':
+  '@ai-sdk/provider@4.0.3':
     dependencies:
       json-schema: 0.4.0
 
@@ -7274,7 +7278,8 @@ snapshots:
 
   '@ocavue/utils@1.7.0': {}
 
-  '@opentelemetry/api@1.9.1': {}
+  '@opentelemetry/api@1.9.1':
+    optional: true
 
   '@oxc-project/types@0.139.0': {}
 
@@ -8857,6 +8862,8 @@ snapshots:
 
   '@webext-core/match-patterns@1.1.0': {}
 
+  '@workflow/serde@4.1.0': {}
+
   '@wxt-dev/browser@0.1.43':
     dependencies:
       '@types/filesystem': 0.0.36
@@ -8925,12 +8932,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ai@6.0.234(zod@4.4.3):
+  ai@7.0.37(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.156(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
-      '@opentelemetry/api': 1.9.1
+      '@ai-sdk/gateway': 4.0.28(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
       zod: 4.4.3
 
   ajv-formats@2.1.1(ajv@8.20.0):


### PR DESCRIPTION
Updates `ai` to v7 and `@ai-sdk/*` to v4, migrating every renamed and deprecated API, including the v7 change that makes `step.response.messages` per-step rather than cumulative (the chat engine now accumulates it, so a tool-using turn keeps its full history).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved handling of image and file attachments in chat messages, including image-only messages.
  * Enhanced token estimation for image and non-image files to support more accurate context management.
  * Improved multi-step chat streaming so completed tool and message steps are retained reliably.
  * Updated image and PDF inputs used for asset and page descriptions.
  * Refined AI provider compatibility and audio transcript formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->