### PR TITLE
Prevent Enter from sending during IME composition; add IME guard hook and tests

### DIFF
--- a/apps/desktop/src/components/chat/chat-input.tsx
+++ b/apps/desktop/src/components/chat/chat-input.tsx
@@ -22,6 +22,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { imageFilesFrom } from '@/lib/chat-attachments'
 import { groupModelOptions } from '@/lib/chat-model-groups'
 import { keybindingFor } from '@/lib/commands/app-commands'
+import { useImeCompositionGuard } from '@/hooks/use-ime-composition-guard'
 import { useChatSession } from '@/providers/chat-provider'
 import { ChatHistoryMenu } from './chat-history-menu'
 
@@ -37,6 +38,7 @@ const NEW_CHAT_BINDING = keybindingFor('chat.new')
  * conversations; "New chat" appears once there's a conversation to leave.
  */
 export function ChatInput(): ReactElement {
+  const ime = useImeCompositionGuard<HTMLTextAreaElement>()
   const {
     turns,
     status,
@@ -108,8 +110,10 @@ export function ChatInput(): ReactElement {
         <textarea
           value={draft}
           onChange={(event) => setDraft(event.target.value)}
+          onCompositionStart={ime.onCompositionStart}
+          onCompositionEnd={ime.onCompositionEnd}
           onKeyDown={(event) => {
-            if (event.key === 'Enter' && !event.shiftKey) {
+            if (event.key === 'Enter' && !event.shiftKey && !ime.isImeKeyEvent(event)) {
               event.preventDefault()
               submit()
             }
@@ -118,6 +122,7 @@ export function ChatInput(): ReactElement {
               stop()
             }
           }}
+          onKeyUp={ime.onKeyUp}
           onPaste={(event) => {
             const files = imageFilesFrom(event.clipboardData)
             if (files.length === 0) {

--- a/apps/desktop/src/components/chat/chat-screen.test.tsx
+++ b/apps/desktop/src/components/chat/chat-screen.test.tsx
@@ -254,6 +254,27 @@ describe('ChatScreen', () => {
     expect(options?.messages.at(-1)).toEqual({ role: 'user', content: 'when does atlas ship?' })
   })
 
+  it('does not send when Enter confirms an IME conversion', async () => {
+    configureModel()
+    scriptTurn([{ type: 'complete', messages: [{ role: 'assistant', content: '了解' }] }])
+    const view = await renderChat()
+    const input = view.getByLabelText('Chat message').element()
+
+    await userEvent.type(input, '日本語')
+    input.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))
+    input.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }))
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }))
+
+    expect(streamChat).not.toHaveBeenCalled()
+    expect(input).toHaveValue('日本語')
+
+    input.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter', bubbles: true }))
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }))
+
+    await expect.element(view.getByText('日本語')).toBeInTheDocument()
+    expect(streamChat).toHaveBeenCalledTimes(1)
+  })
+
   it('opens ⌘-clicked tool-result and read-note links in new windows', async () => {
     configureModel()
     scriptTurn([

--- a/apps/desktop/src/hooks/use-ime-composition-guard.ts
+++ b/apps/desktop/src/hooks/use-ime-composition-guard.ts
@@ -1,0 +1,67 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type CompositionEventHandler,
+  type KeyboardEvent,
+  type KeyboardEventHandler,
+} from 'react'
+
+const IME_PROCESS_KEY_CODE = 229
+
+interface ImeCompositionGuard<ElementType extends HTMLElement> {
+  readonly isImeKeyEvent: (event: KeyboardEvent<ElementType>) => boolean
+  readonly onCompositionStart: CompositionEventHandler<ElementType>
+  readonly onCompositionEnd: CompositionEventHandler<ElementType>
+  readonly onKeyUp: KeyboardEventHandler<ElementType>
+}
+
+/**
+ * Identifies keyboard events that belong to an IME composition, including
+ * WebKit's conversion-confirmation event emitted just after `compositionend`.
+ */
+export function useImeCompositionGuard<
+  ElementType extends HTMLElement,
+>(): ImeCompositionGuard<ElementType> {
+  const compositionJustEndedRef = useRef(false)
+  const resetTimerRef = useRef<number | null>(null)
+
+  const cancelReset = useCallback((): void => {
+    if (resetTimerRef.current !== null) {
+      window.clearTimeout(resetTimerRef.current)
+      resetTimerRef.current = null
+    }
+  }, [])
+
+  useEffect(() => cancelReset, [cancelReset])
+
+  const onCompositionStart = useCallback((): void => {
+    cancelReset()
+    compositionJustEndedRef.current = false
+  }, [cancelReset])
+
+  const onCompositionEnd = useCallback((): void => {
+    compositionJustEndedRef.current = true
+    resetTimerRef.current = window.setTimeout(() => {
+      compositionJustEndedRef.current = false
+      resetTimerRef.current = null
+    }, 0)
+  }, [])
+
+  const onKeyUp = useCallback((): void => {
+    compositionJustEndedRef.current = false
+  }, [])
+
+  const isImeKeyEvent = useCallback((event: KeyboardEvent<ElementType>): boolean => {
+    const nativeEvent = event.nativeEvent
+    return (
+      compositionJustEndedRef.current ||
+      nativeEvent.isComposing ||
+      nativeEvent.key === 'Process' ||
+      nativeEvent.keyCode === IME_PROCESS_KEY_CODE ||
+      nativeEvent.which === IME_PROCESS_KEY_CODE
+    )
+  }, [])
+
+  return { isImeKeyEvent, onCompositionStart, onCompositionEnd, onKeyUp }
+}


### PR DESCRIPTION
### Motivation
- Prevent accidental message sends when users confirm IME (input method editor) conversions with the Enter key, which should not submit the composer. 
- Provide a reusable guard to detect IME composition state and platform-specific IME key events. 
- Add a focused test to ensure IME-confirmation Enter presses do not trigger sending while normal Enter still sends.

### Description
- Introduce `useImeCompositionGuard` hook to track composition state and detect IME-related keyboard events. 
- Integrate the hook into the chat composer by wiring `onCompositionStart`, `onCompositionEnd`, and `onKeyUp` to the textarea and by checking `isImeKeyEvent` before treating Enter as a submit. 
- Add a unit test `does not send when Enter confirms an IME conversion` to `chat-screen.test.tsx` that verifies Enter during IME composition does not send and that a subsequent Enter does send.

### Testing
- Ran the chat component unit tests including `apps/desktop/src/components/chat/chat-screen.test.tsx` which contains the new IME test. 
- The new IME composition test `does not send when Enter confirms an IME conversion` passed. 
- All related existing chat tests passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65c5eb43b883338174dc9beaa2e000)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX fix in the chat textarea; normal Enter-to-send behavior is unchanged outside IME events.
> 
> **Overview**
> Stops the chat composer from sending when **Enter** is used to confirm an IME conversion instead of submitting the message.
> 
> Adds **`useImeCompositionGuard`**, which tracks composition lifecycle and treats IME-related keys (`isComposing`, `Process`, keyCode 229, and WebKit’s post-`compositionend` Enter) as non-submit. **`ChatInput`** wires the hook’s composition and key handlers and only calls submit on Enter when `!ime.isImeKeyEvent(event)`.
> 
> A **`chat-screen`** test simulates composition + Enter and asserts no send until a normal Enter afterward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16188107b6f199c897b5472c12a441634dfe75dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat input handling for IME-based languages, such as Japanese.
  * Pressing Enter to confirm an IME conversion no longer sends the message prematurely.
  * Chat messages now send correctly after composition is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->