### PR TITLE
fix: reduce battery drain from mobile scrolling and idle polling

### DIFF
--- a/apps/desktop/src/editor/editor-input-traits.tsx
+++ b/apps/desktop/src/editor/editor-input-traits.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { useEditor } from '@meowdown/react'
 import { isTouchEditorSurface } from '@/lib/platform-surface'
+import { whenEditorMounted } from './when-editor-mounted'
 
 /**
  * iOS text-input hygiene on the editing surface (Plan 19, decision 7 — a gate
@@ -27,26 +28,11 @@ export function EditorInputTraits(): null {
     if (!isTouchEditorSurface()) {
       return
     }
-    // ProseKit attaches the view via ref before effects run, so this applies
-    // immediately in practice — but the mount timing is ProseKit's, not ours,
-    // so a not-yet-mounted editor is retried per frame instead of skipped.
-    let frame: number | null = null
-    const apply = (): void => {
-      if (!editor.mounted) {
-        frame = requestAnimationFrame(apply)
-        return
-      }
-      frame = null
+    return whenEditorMounted(editor, () => {
       const dom = editor.view.dom
       dom.setAttribute('autocapitalize', 'sentences')
       dom.setAttribute('autocorrect', 'on')
-    }
-    apply()
-    return () => {
-      if (frame !== null) {
-        cancelAnimationFrame(frame)
-      }
-    }
+    })
   }, [editor])
 
   return null

--- a/apps/desktop/src/editor/formatting-toolbar-bridge.tsx
+++ b/apps/desktop/src/editor/formatting-toolbar-bridge.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { useEditor } from '@meowdown/react'
 import type { EditorExtension } from '@meowdown/core'
 import { isTouchEditorSurface } from '@/lib/platform-surface'
+import { whenEditorMounted } from './when-editor-mounted'
 import {
   clearFormattingToolbar,
   publishFormattingToolbar,
@@ -37,18 +38,11 @@ export function FormattingToolbarBridge(): null {
       return
     }
     const owner = Symbol('formatting-toolbar')
-    let frame: number | null = null
     let teardown: (() => void) | null = null
 
-    // Same mount dance as EditorInputTraits: ProseKit attaches the view via
-    // ref before effects run, so this attaches immediately in practice — but
-    // the timing is ProseKit's, so a not-yet-mounted editor retries per frame.
-    const attach = (): void => {
-      if (!editor.mounted) {
-        frame = requestAnimationFrame(attach)
-        return
-      }
-      frame = null
+    // Same mount dance as EditorInputTraits — see `whenEditorMounted` for
+    // why the wait is bounded.
+    const cancel = whenEditorMounted(editor, () => {
       const dom = editor.view.dom
 
       function readCapabilities(): FormattingToolbarCapabilities {
@@ -137,12 +131,9 @@ export function FormattingToolbarBridge(): null {
         }
         clearFormattingToolbar(owner)
       }
-    }
-    attach()
+    })
     return () => {
-      if (frame !== null) {
-        cancelAnimationFrame(frame)
-      }
+      cancel()
       teardown?.()
     }
   }, [editor])

--- a/apps/desktop/src/editor/when-editor-mounted.test.ts
+++ b/apps/desktop/src/editor/when-editor-mounted.test.ts
@@ -6,23 +6,35 @@ import { whenEditorMounted } from './when-editor-mounted'
  * queue the test drains one frame at a time, so the retry budget is exact
  * rather than timing-dependent.
  */
-function fakeFrames(): { step: () => boolean; canceled: () => number } {
-  const queue: FrameRequestCallback[] = []
+interface FakeFrames {
+  /** Run the oldest queued frame; `false` when nothing is scheduled. */
+  step: () => boolean
+  canceled: () => number
+}
+
+function fakeFrames(): FakeFrames {
+  const queue = new Map<number, FrameRequestCallback>()
   let nextHandle = 1
   let canceled = 0
   vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback): number => {
-    queue.push(callback)
-    return nextHandle++
+    const handle = nextHandle
+    nextHandle += 1
+    queue.set(handle, callback)
+    return handle
   })
-  vi.stubGlobal('cancelAnimationFrame', (): void => {
-    canceled += 1
+  vi.stubGlobal('cancelAnimationFrame', (handle: number): void => {
+    if (queue.delete(handle)) {
+      canceled += 1
+    }
   })
   return {
     step: () => {
-      const frame = queue.shift()
-      if (frame === undefined) {
+      const next = queue.entries().next()
+      if (next.done === true) {
         return false
       }
+      const [handle, frame] = next.value
+      queue.delete(handle)
       frame(0)
       return true
     },
@@ -83,6 +95,9 @@ describe('whenEditorMounted', () => {
     const cancel = whenEditorMounted({ mounted: false }, run)
     cancel()
     expect(frames.canceled()).toBe(1)
+    // The canceled frame is genuinely gone — nothing left to run.
+    expect(frames.step()).toBe(false)
+    expect(run).not.toHaveBeenCalled()
     // Canceling again (or after settling) stays a no-op.
     cancel()
     expect(frames.canceled()).toBe(1)

--- a/apps/desktop/src/editor/when-editor-mounted.test.ts
+++ b/apps/desktop/src/editor/when-editor-mounted.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { whenEditorMounted } from './when-editor-mounted'
+
+/**
+ * Frame scheduling is driven by hand: `requestAnimationFrame` pushes into a
+ * queue the test drains one frame at a time, so the retry budget is exact
+ * rather than timing-dependent.
+ */
+function fakeFrames(): { step: () => boolean; canceled: () => number } {
+  const queue: FrameRequestCallback[] = []
+  let nextHandle = 1
+  let canceled = 0
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback): number => {
+    queue.push(callback)
+    return nextHandle++
+  })
+  vi.stubGlobal('cancelAnimationFrame', (): void => {
+    canceled += 1
+  })
+  return {
+    step: () => {
+      const frame = queue.shift()
+      if (frame === undefined) {
+        return false
+      }
+      frame(0)
+      return true
+    },
+    canceled: () => canceled,
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('whenEditorMounted', () => {
+  it('runs synchronously when the editor is already mounted', () => {
+    fakeFrames()
+    const run = vi.fn()
+    whenEditorMounted({ mounted: true }, run)
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries per frame and runs once the editor mounts', () => {
+    const frames = fakeFrames()
+    const editor = { mounted: false }
+    const run = vi.fn()
+    whenEditorMounted(editor, run)
+    expect(run).not.toHaveBeenCalled()
+
+    frames.step()
+    expect(run).not.toHaveBeenCalled()
+
+    editor.mounted = true
+    frames.step()
+    expect(run).toHaveBeenCalledTimes(1)
+    // Nothing left scheduled once it has run.
+    expect(frames.step()).toBe(false)
+  })
+
+  it('gives up loudly after the frame budget instead of spinning forever', () => {
+    const frames = fakeFrames()
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const run = vi.fn()
+    whenEditorMounted({ mounted: false }, run)
+
+    let steps = 0
+    while (frames.step()) {
+      steps += 1
+      expect(steps).toBeLessThan(100) // the budget must terminate the loop
+    }
+
+    expect(steps).toBe(30)
+    expect(run).not.toHaveBeenCalled()
+    expect(error).toHaveBeenCalledOnce()
+  })
+
+  it('cancel stops the retry loop', () => {
+    const frames = fakeFrames()
+    const run = vi.fn()
+    const cancel = whenEditorMounted({ mounted: false }, run)
+    cancel()
+    expect(frames.canceled()).toBe(1)
+    // Canceling again (or after settling) stays a no-op.
+    cancel()
+    expect(frames.canceled()).toBe(1)
+  })
+})

--- a/apps/desktop/src/editor/when-editor-mounted.ts
+++ b/apps/desktop/src/editor/when-editor-mounted.ts
@@ -1,0 +1,42 @@
+/** How many animation frames to wait for ProseKit to attach the editor view
+ *  before giving up. In practice the view is attached via ref before effects
+ *  run, so the first synchronous check succeeds and no frame is ever
+ *  scheduled; half a second of misses means something is genuinely broken. */
+const MOUNT_RETRY_FRAMES = 30
+
+/**
+ * Run `run` once `editor.mounted` is true — synchronously when the view is
+ * already attached (the ordinary case: ProseKit attaches via ref before
+ * effects run), else retrying once per animation frame. The retry is bounded
+ * to {@link MOUNT_RETRY_FRAMES}: the mount timing is ProseKit's, not ours,
+ * and an editor that never mounts must log an error and stop rather than
+ * spin at display refresh rate for the component's lifetime.
+ *
+ * Returns a cancel function for effect cleanup; canceling after `run` has
+ * fired (or after the budget lapsed) is a no-op.
+ */
+export function whenEditorMounted(editor: { readonly mounted: boolean }, run: () => void): () => void {
+  let frame: number | null = null
+  let attempts = 0
+  const check = (): void => {
+    if (editor.mounted) {
+      frame = null
+      run()
+      return
+    }
+    attempts += 1
+    if (attempts > MOUNT_RETRY_FRAMES) {
+      frame = null
+      console.error(`editor view never mounted; gave up after ${attempts} frames`)
+      return
+    }
+    frame = requestAnimationFrame(check)
+  }
+  check()
+  return () => {
+    if (frame !== null) {
+      cancelAnimationFrame(frame)
+      frame = null
+    }
+  }
+}

--- a/apps/desktop/src/editor/when-editor-mounted.ts
+++ b/apps/desktop/src/editor/when-editor-mounted.ts
@@ -24,12 +24,12 @@ export function whenEditorMounted(editor: { readonly mounted: boolean }, run: ()
       run()
       return
     }
-    attempts += 1
-    if (attempts > MOUNT_RETRY_FRAMES) {
+    if (attempts === MOUNT_RETRY_FRAMES) {
       frame = null
-      console.error(`editor view never mounted; gave up after ${attempts} frames`)
+      console.error(`editor view never mounted; gave up after ${MOUNT_RETRY_FRAMES} frames`)
       return
     }
+    attempts += 1
     frame = requestAnimationFrame(check)
   }
   check()

--- a/apps/desktop/src/hooks/use-poll.test.tsx
+++ b/apps/desktop/src/hooks/use-poll.test.tsx
@@ -75,6 +75,21 @@ describe('usePoll', () => {
     expect(tick).toHaveBeenCalledTimes(1)
   })
 
+  it('a synchronously throwing tick keeps the loop alive', async () => {
+    let calls = 0
+    const tick = (): Promise<'continue' | 'stop'> => {
+      calls += 1
+      if (calls === 1) {
+        throw new Error('sync boom')
+      }
+      return Promise.resolve('continue')
+    }
+    await render(<Harness enabled intervalMs={20} tick={tick} />)
+    await vi.waitFor(() => {
+      expect(calls).toBeGreaterThanOrEqual(2)
+    })
+  })
+
   it("a tick's 'stop' ends the loop for good, across hide and show", async () => {
     const tick = vi.fn(async () => 'stop' as const)
     await render(<Harness enabled intervalMs={20} tick={tick} />)

--- a/apps/desktop/src/hooks/use-poll.test.tsx
+++ b/apps/desktop/src/hooks/use-poll.test.tsx
@@ -1,0 +1,90 @@
+import { render } from 'vitest-browser-react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { usePoll } from './use-poll'
+
+/**
+ * Visibility is simulated by overriding `document.visibilityState` and
+ * dispatching `visibilitychange` (the use-wake-to-today pattern). Timers are
+ * real: the polling contract is about ordering (paused while hidden, an
+ * immediate tick on return), which short real intervals pin down without
+ * fake-timer/microtask interleaving hazards.
+ */
+
+let visibility: DocumentVisibilityState = 'visible'
+
+function setVisibility(state: DocumentVisibilityState): void {
+  visibility = state
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
+beforeEach(() => {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => visibility,
+  })
+  visibility = 'visible'
+})
+
+interface HarnessProps {
+  enabled: boolean
+  intervalMs: number
+  tick: () => Promise<'continue' | 'stop'>
+}
+
+function Harness({ enabled, intervalMs, tick }: HarnessProps): null {
+  usePoll(enabled, intervalMs, tick)
+  return null
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+describe('usePoll', () => {
+  it('ticks repeatedly at the interval while visible', async () => {
+    const tick = vi.fn(async () => 'continue' as const)
+    await render(<Harness enabled intervalMs={20} tick={tick} />)
+    await vi.waitFor(() => {
+      expect(tick.mock.calls.length).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  it('pauses while hidden', async () => {
+    const tick = vi.fn(async () => 'continue' as const)
+    await render(<Harness enabled intervalMs={20} tick={tick} />)
+    await vi.waitFor(() => {
+      expect(tick).toHaveBeenCalled()
+    })
+
+    setVisibility('hidden')
+    const paused = tick.mock.calls.length
+    await wait(120)
+    expect(tick.mock.calls.length).toBe(paused)
+  })
+
+  it('resumes with an immediate tick on return to visible', async () => {
+    const tick = vi.fn(async () => 'continue' as const)
+    // An interval far longer than the test: any tick observed after the
+    // visibility flip must be the immediate resume tick, not the schedule.
+    await render(<Harness enabled intervalMs={60_000} tick={tick} />)
+    setVisibility('hidden')
+    await wait(20)
+    expect(tick).not.toHaveBeenCalled()
+
+    setVisibility('visible')
+    expect(tick).toHaveBeenCalledTimes(1)
+  })
+
+  it("a tick's 'stop' ends the loop for good, across hide and show", async () => {
+    const tick = vi.fn(async () => 'stop' as const)
+    await render(<Harness enabled intervalMs={20} tick={tick} />)
+    await vi.waitFor(() => {
+      expect(tick).toHaveBeenCalledTimes(1)
+    })
+
+    setVisibility('hidden')
+    setVisibility('visible')
+    await wait(120)
+    expect(tick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/hooks/use-poll.ts
+++ b/apps/desktop/src/hooks/use-poll.ts
@@ -48,7 +48,13 @@ export function usePoll(
 
     function runTick(): void {
       inFlight = true
-      void tickRef.current().then(settle, () => settle('continue'))
+      try {
+        void tickRef.current().then(settle, () => settle('continue'))
+      } catch {
+        // A synchronous throw must not strand `inFlight` — that would block
+        // the visibility resume forever. Same rule as a rejection.
+        settle('continue')
+      }
     }
 
     function schedule(): void {
@@ -57,6 +63,9 @@ export function usePoll(
       }
       timer = setTimeout(() => {
         timer = null
+        if (document.visibilityState === 'hidden') {
+          return // went hidden in the firing gap; the listener resumes us
+        }
         runTick()
       }, intervalMs)
     }

--- a/apps/desktop/src/hooks/use-poll.ts
+++ b/apps/desktop/src/hooks/use-poll.ts
@@ -7,6 +7,12 @@ import { useEffect, useRef } from 'react'
  * that throws keeps the loop alive: the network checks this exists for fail
  * transiently. Return 'stop' to end the loop. Disabling or unmounting
  * cancels future ticks but not one already in flight.
+ *
+ * Polling pauses while the document is hidden — a hidden poll can't show its
+ * result, and this hook's consumers exist for flows where the user leaves
+ * the app to do something (create a repo, grant access) — and resumes with
+ * an *immediate* tick on return to visible: the moment the user comes back
+ * is exactly when the polled condition is likeliest to have just become true.
  */
 export function usePoll(
   enabled: boolean,
@@ -24,29 +30,60 @@ export function usePoll(
       return
     }
     let cancelled = false
-    let timer: ReturnType<typeof setTimeout> | undefined
+    let stopped = false
+    let inFlight = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+
+    function settle(result: 'continue' | 'stop'): void {
+      inFlight = false
+      if (cancelled) {
+        return
+      }
+      if (result === 'stop') {
+        stopped = true
+        return
+      }
+      schedule()
+    }
+
+    function runTick(): void {
+      inFlight = true
+      void tickRef.current().then(settle, () => settle('continue'))
+    }
 
     function schedule(): void {
+      if (document.visibilityState === 'hidden') {
+        return // paused — the visibility listener resumes with an immediate tick
+      }
       timer = setTimeout(() => {
-        void tickRef.current().then(
-          (result) => {
-            if (!cancelled && result === 'continue') {
-              schedule()
-            }
-          },
-          () => {
-            if (!cancelled) {
-              schedule()
-            }
-          },
-        )
+        timer = null
+        runTick()
       }, intervalMs)
     }
 
+    function onVisibilityChange(): void {
+      if (document.visibilityState === 'hidden') {
+        if (timer !== null) {
+          clearTimeout(timer)
+          timer = null
+        }
+        return
+      }
+      // An in-flight tick reschedules itself when it settles, and a pending
+      // timer means the loop never paused — only a paused loop resumes here.
+      if (!stopped && !inFlight && timer === null) {
+        runTick()
+      }
+    }
+
+    document.addEventListener('visibilitychange', onVisibilityChange)
     schedule()
     return () => {
       cancelled = true
-      clearTimeout(timer)
+      if (timer !== null) {
+        clearTimeout(timer)
+      }
+      document.removeEventListener('visibilitychange', onVisibilityChange)
     }
   }, [enabled, intervalMs])
 }

--- a/apps/desktop/src/mobile/use-back-swipe.test.tsx
+++ b/apps/desktop/src/mobile/use-back-swipe.test.tsx
@@ -12,7 +12,11 @@ import { useBackSwipe } from './use-back-swipe'
  * settle transition to wait out).
  */
 
-function Harness({ enabled = true }: { enabled?: boolean }): ReactElement {
+interface HarnessProps {
+  readonly enabled?: boolean
+}
+
+function Harness({ enabled = true }: HarnessProps): ReactElement {
   const containerRef = useRef<HTMLDivElement>(null)
   const swipe = useBackSwipe({
     enabled,
@@ -54,15 +58,22 @@ function touchMove(node: Element): TouchEvent {
   return event
 }
 
-async function setup(enabled = true): Promise<{
-  node: HTMLElement
-  edgeX: number
-  edgeY: number
-  added: ReturnType<typeof vi.spyOn>
-  removed: ReturnType<typeof vi.spyOn>
-}> {
+/** A listener spy, structurally — `vi.spyOn`'s overloads defeat ReturnType. */
+interface ListenerSpy {
+  readonly mock: { readonly calls: readonly unknown[][] }
+}
+
+interface SwipeSetup {
+  readonly node: Element
+  readonly edgeX: number
+  readonly edgeY: number
+  readonly added: ListenerSpy
+  readonly removed: ListenerSpy
+}
+
+async function setup(enabled = true): Promise<SwipeSetup> {
   const screen = await render(<Harness enabled={enabled} />)
-  const node = screen.getByTestId('stack').element() as HTMLElement
+  const node = screen.getByTestId('stack').element()
   const rect = node.getBoundingClientRect()
   return {
     node,
@@ -73,8 +84,9 @@ async function setup(enabled = true): Promise<{
   }
 }
 
-const touchmoveCalls = (spy: { mock: { calls: unknown[][] } }): number =>
-  spy.mock.calls.filter((call) => call[0] === 'touchmove').length
+function touchmoveCalls(spy: ListenerSpy): number {
+  return spy.mock.calls.filter((listenerCall) => listenerCall[0] === 'touchmove').length
+}
 
 describe('useBackSwipe scroll blocker', () => {
   it('is not attached at idle, and idle touchmoves stay cancelable', async () => {

--- a/apps/desktop/src/mobile/use-back-swipe.test.tsx
+++ b/apps/desktop/src/mobile/use-back-swipe.test.tsx
@@ -1,0 +1,118 @@
+import { useRef, type ReactElement } from 'react'
+import { render } from 'vitest-browser-react'
+import { describe, expect, it, vi } from 'vitest'
+import { useBackSwipe } from './use-back-swipe'
+
+/**
+ * The scroll blocker's lifecycle: the non-passive `touchmove` listener must
+ * exist only while a touch owns the gesture (armed → dragging) — a
+ * permanently attached one would tax every scroll in the app — and it must
+ * cancel the page's scroll only in the dragging phase. Driven with real
+ * pointer/touch events; `reducedMotion` keeps release synchronous (no
+ * settle transition to wait out).
+ */
+
+function Harness({ enabled = true }: { enabled?: boolean }): ReactElement {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const swipe = useBackSwipe({
+    enabled,
+    reducedMotion: true,
+    onPop: () => {},
+    containerRef,
+  })
+  return (
+    <div
+      ref={containerRef}
+      data-testid="stack"
+      style={{ width: '400px', height: '400px' }}
+      {...swipe.handlers}
+    />
+  )
+}
+
+function pointer(
+  type: 'pointerdown' | 'pointermove' | 'pointerup',
+  node: Element,
+  clientX: number,
+  clientY: number,
+): void {
+  node.dispatchEvent(
+    new PointerEvent(type, {
+      bubbles: true,
+      pointerType: 'touch',
+      isPrimary: true,
+      pointerId: 1,
+      clientX,
+      clientY,
+    }),
+  )
+}
+
+function touchMove(node: Element): TouchEvent {
+  const event = new TouchEvent('touchmove', { bubbles: true, cancelable: true })
+  node.dispatchEvent(event)
+  return event
+}
+
+async function setup(enabled = true): Promise<{
+  node: HTMLElement
+  edgeX: number
+  edgeY: number
+  added: ReturnType<typeof vi.spyOn>
+  removed: ReturnType<typeof vi.spyOn>
+}> {
+  const screen = await render(<Harness enabled={enabled} />)
+  const node = screen.getByTestId('stack').element() as HTMLElement
+  const rect = node.getBoundingClientRect()
+  return {
+    node,
+    edgeX: rect.left + 10,
+    edgeY: rect.top + 100,
+    added: vi.spyOn(node, 'addEventListener'),
+    removed: vi.spyOn(node, 'removeEventListener'),
+  }
+}
+
+const touchmoveCalls = (spy: { mock: { calls: unknown[][] } }): number =>
+  spy.mock.calls.filter((call) => call[0] === 'touchmove').length
+
+describe('useBackSwipe scroll blocker', () => {
+  it('is not attached at idle, and idle touchmoves stay cancelable', async () => {
+    const { node, added } = await setup()
+    expect(touchMove(node).defaultPrevented).toBe(false)
+    expect(touchmoveCalls(added)).toBe(0)
+  })
+
+  it('attaches on arm, cancels scroll while dragging, detaches on release', async () => {
+    const { node, edgeX, edgeY, added, removed } = await setup()
+
+    pointer('pointerdown', node, edgeX, edgeY)
+    expect(touchmoveCalls(added)).toBe(1)
+    // Armed but not yet dragging: the page's scroll must survive.
+    expect(touchMove(node).defaultPrevented).toBe(false)
+
+    pointer('pointermove', node, edgeX + 20, edgeY)
+    expect(touchMove(node).defaultPrevented).toBe(true)
+
+    pointer('pointerup', node, edgeX + 20, edgeY)
+    expect(touchmoveCalls(removed)).toBe(1)
+    expect(touchMove(node).defaultPrevented).toBe(false)
+  })
+
+  it('detaches when a vertical scroll disarms the gesture', async () => {
+    const { node, edgeX, edgeY, added, removed } = await setup()
+
+    pointer('pointerdown', node, edgeX, edgeY)
+    expect(touchmoveCalls(added)).toBe(1)
+
+    pointer('pointermove', node, edgeX, edgeY + 40)
+    expect(touchmoveCalls(removed)).toBe(1)
+    expect(touchMove(node).defaultPrevented).toBe(false)
+  })
+
+  it('never attaches while disabled', async () => {
+    const { node, edgeX, edgeY, added } = await setup(false)
+    pointer('pointerdown', node, edgeX, edgeY)
+    expect(touchmoveCalls(added)).toBe(0)
+  })
+})

--- a/apps/desktop/src/mobile/use-back-swipe.ts
+++ b/apps/desktop/src/mobile/use-back-swipe.ts
@@ -50,6 +50,12 @@ export type BackSwipeState =
 
 const IDLE: BackSwipeState = { phase: 'idle' }
 
+/** The gesture-scoped scroll blocker: one native listener on one node. */
+interface ScrollBlocker {
+  readonly node: HTMLElement
+  readonly block: (event: TouchEvent) => void
+}
+
 export interface BackSwipeOptions {
   /** Arm the gesture only on stacked screens with no transition running. */
   enabled: boolean
@@ -103,7 +109,7 @@ export function useBackSwipe({ enabled, reducedMotion, onPop, containerRef }: Ba
   // (the `armed` transition), so the listener exists before the sequence's
   // first `touchmove` — where WebKit fixes its cancelability — and an effect
   // could be a frame too late.
-  const blockerRef = useRef<{ node: HTMLElement; block: (event: TouchEvent) => void } | null>(null)
+  const blockerRef = useRef<ScrollBlocker | null>(null)
 
   const detachBlocker = useCallback((): void => {
     const blocker = blockerRef.current

--- a/apps/desktop/src/mobile/use-back-swipe.ts
+++ b/apps/desktop/src/mobile/use-back-swipe.ts
@@ -57,7 +57,8 @@ export interface BackSwipeOptions {
   reducedMotion: boolean
   /** Commit the pop once the screen has settled offscreen. */
   onPop: () => void
-  /** The stack container — gets a non-passive scroll blocker while dragging. */
+  /** The stack container — gets a non-passive scroll blocker while a touch
+   *  owns the gesture (armed through dragging), never between gestures. */
   containerRef: RefObject<HTMLElement | null>
 }
 
@@ -93,10 +94,54 @@ export function useBackSwipe({ enabled, reducedMotion, onPop, containerRef }: Ba
   const stateRef = useRef<BackSwipeState>(IDLE)
   const [state, setState] = useState<BackSwipeState>(IDLE)
 
-  const commit = useCallback((next: BackSwipeState): void => {
-    stateRef.current = next
-    setState(next)
+  // The scroll blocker lives only while a touch owns the gesture. React
+  // registers touch listeners passively, so blocking the page's own vertical
+  // scroll mid-drag needs a native non-passive listener — but a permanently
+  // attached one forces WebKit to consult the main thread for every
+  // `touchmove` in the stack (i.e. every scroll in the app) just in case.
+  // Attach happens synchronously in `commit` inside the pointerdown dispatch
+  // (the `armed` transition), so the listener exists before the sequence's
+  // first `touchmove` — where WebKit fixes its cancelability — and an effect
+  // could be a frame too late.
+  const blockerRef = useRef<{ node: HTMLElement; block: (event: TouchEvent) => void } | null>(null)
+
+  const detachBlocker = useCallback((): void => {
+    const blocker = blockerRef.current
+    if (blocker !== null) {
+      blocker.node.removeEventListener('touchmove', blocker.block)
+      blockerRef.current = null
+    }
   }, [])
+
+  const attachBlocker = useCallback((): void => {
+    if (blockerRef.current !== null) {
+      return
+    }
+    const node = containerRef.current
+    if (!node) {
+      return
+    }
+    const block = (event: TouchEvent): void => {
+      if (stateRef.current.phase === 'dragging') {
+        event.preventDefault()
+      }
+    }
+    node.addEventListener('touchmove', block, { passive: false })
+    blockerRef.current = { node, block }
+  }, [containerRef])
+
+  const commit = useCallback(
+    (next: BackSwipeState): void => {
+      stateRef.current = next
+      if (next.phase === 'armed' || next.phase === 'dragging') {
+        attachBlocker()
+      } else {
+        detachBlocker()
+      }
+      setState(next)
+    },
+    [attachBlocker, detachBlocker],
+  )
 
   // Navigation elsewhere (or a transition starting) invalidates the gesture.
   // Adjusted during render — the derive-state pattern — so a disabled stack
@@ -248,21 +293,18 @@ export function useBackSwipe({ enabled, reducedMotion, onPop, containerRef }: Ba
     return () => clearTimeout(timer)
   }, [state, finishSettle])
 
-  // React registers touch listeners passively, so blocking the page's own
-  // vertical scroll while a drag owns the screen needs a native listener.
+  // The render-path reset above bypasses `commit`, so it cannot detach the
+  // blocker itself; idle never needs one. No cleanup here — this effect
+  // re-runs on every mid-drag commit, and a cleanup would strip the blocker
+  // out from under the live gesture.
   useEffect(() => {
-    const node = containerRef.current
-    if (!node) {
-      return
+    if (state.phase === 'idle') {
+      detachBlocker()
     }
-    const blockScroll = (event: TouchEvent): void => {
-      if (stateRef.current.phase === 'dragging') {
-        event.preventDefault()
-      }
-    }
-    node.addEventListener('touchmove', blockScroll, { passive: false })
-    return () => node.removeEventListener('touchmove', blockScroll)
-  }, [containerRef])
+  }, [state, detachBlocker])
+
+  // Unmount backstop: `detachBlocker` is stable, so this cleanup runs once.
+  useEffect(() => detachBlocker, [detachBlocker])
 
   return {
     state,


### PR DESCRIPTION
## Problem

A battery audit of the iOS app found three frontend costs that tax the device far beyond their usefulness:

1. **Every scroll in the app paid for the back-swipe gesture.** `useBackSwipe` attached a non-passive `touchmove` listener to the `mobile-stack` container for the entire session. A non-passive touch listener forces WebKit to consult the main thread before committing each scroll frame — defeating the compositor fast path for every scroll on every screen — even though the handler only acts during the ~300ms of an actual edge drag.
2. **Two unbounded rAF retry loops in the editor mount path.** `FormattingToolbarBridge` and `EditorInputTraits` both waited for ProseKit's view with `if (!editor.mounted) requestAnimationFrame(retry)` — no attempt cap, no deadline. With three carousel editors mounted, a mount stall means up to six loops spinning at display refresh rate for the components' lifetime.
3. **The GitHub connect wizard polled the network with no visibility gate.** `usePoll` fired a real GitHub API request every 3s for as long as the wizard step was open, even while hidden — and the flow's whole premise is that the user leaves for Safari to create the repo.

## Changes

- **`use-back-swipe.ts`** — the scroll blocker now attaches synchronously in `commit` when a touch arms the gesture and detaches when the gesture ends. Attaching inside the pointerdown dispatch (rather than an effect) guarantees the listener exists before the sequence's first `touchmove`, where WebKit fixes cancelability; handler semantics are unchanged (still cancels only while `dragging`). An idle-keyed effect covers the render-path reset that bypasses `commit`, and a stable-cleanup effect backstops unmount.
- **`when-editor-mounted.ts`** (new) — shared bounded mount-wait: synchronous when already mounted (the ordinary case), else retries per frame up to 30 frames, then `console.error`s and gives up. Both editor bridges now use it.
- **`use-poll.ts`** — pauses while `document.visibilityState === 'hidden'` and resumes with an *immediate* tick on return to visible, which also makes the wizard feel faster: the moment the user returns from creating the repo is when the poll is likeliest to succeed. `'stop'` results and non-overlap semantics are preserved.

## Testing

- New `use-back-swipe.test.tsx` drives real pointer/touch events in browser mode: no listener at idle, attach on arm, `preventDefault` only while dragging, detach on release/disarm, never attached while disabled.
- New `when-editor-mounted.test.ts` pins the contract: synchronous run when mounted, per-frame retry, exact 30-frame budget with a loud give-up, idempotent cancel.
- New `use-poll.test.tsx` covers: repeated ticks while visible, paused while hidden, immediate resume tick, and `'stop'` surviving hide/show.
- Existing `formatting-toolbar-bridge.test.tsx` and `connect-github-drawer.test.tsx` suites pass unchanged; `pnpm check` clean.

## Risk

The back-swipe change is the behavior-sensitive one: if the attach timing were wrong, drag-blocking would silently regress to "page scrolls under the swipe". The lifecycle test pins attach-at-arm (pointerdown time, before any `touchmove`), and the handler's phase gate is unchanged. The other two changes are strictly defensive; the only observable difference is the wizard connecting immediately on app return instead of up to 3s later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Back-swipe attach timing is behavior-sensitive (scroll blocking during edge drag); editor and poll changes are mostly defensive with a positive UX change on wizard return.
> 
> **Overview**
> Addresses an iOS battery audit by tightening three frontend paths that were doing work when idle or hidden.
> 
> **`useBackSwipe`** no longer keeps a non-passive `touchmove` listener on the stack for the whole session. The scroll blocker attaches synchronously when a gesture enters `armed`/`dragging` (via `commit` on pointerdown) and detaches when the gesture ends; `preventDefault` behavior is unchanged (only while `dragging`). Idle resets and unmount get explicit detach backstops.
> 
> **Editor mount waits** are centralized in new **`whenEditorMounted`**: run immediately if `editor.mounted`, else retry per animation frame up to **30** frames then `console.error` and stop. **`EditorInputTraits`** and **`FormattingToolbarBridge`** drop their duplicate unbounded rAF loops in favor of this helper.
> 
> **`usePoll`** now pauses while `document.visibilityState === 'hidden'` and fires an **immediate** tick when the document becomes visible again (e.g. GitHub connect wizard after Safari). Tick scheduling is refactored around `inFlight`/`stopped` so synchronous throws cannot strand the loop.
> 
> New tests cover scroll-blocker lifecycle, mount retry budget/cancel, and visibility-aware polling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7a913ea1b6b4c566024b37777ef00632048ee31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor mount coordination so formatting and iOS touch-surface input traits apply immediately after the editor is ready.
  * Polling now respects browser tab visibility, pausing while hidden and triggering an immediate tick when visible again.
  * Back-swipe handling now attaches scroll-blocking only during active gesture phases and reliably detaches afterward.
* **Tests**
  * Added deterministic coverage for editor-mount readiness, visibility-aware polling behavior, and back-swipe scroll-blocking semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->